### PR TITLE
fix(claude): settle multiple activity outputs together

### DIFF
--- a/core/session_activities.py
+++ b/core/session_activities.py
@@ -96,6 +96,21 @@ class SessionActivity:
         )
 
 
+@dataclass(frozen=True)
+class _CompletedOutputEntry:
+    """One completion's stable position in a runtime output queue."""
+
+    sequence: int
+    queued_at: float
+    activity: SessionActivity
+
+
+@dataclass(frozen=True)
+class _ClaimedCompletedOutput:
+    entry: _CompletedOutputEntry
+    recovered: bool
+
+
 def activity_completion_output(
     activity: SessionActivity,
     *,
@@ -136,11 +151,12 @@ class SessionActivityRegistry:
         self._active: dict[tuple[str, str, str], SessionActivity] = {}
         self._connections: dict[tuple[str, str], tuple[str | None, str]] = {}
         self._completed_outputs: dict[
-            tuple[str, str], deque[tuple[float, SessionActivity]]
+            tuple[str, str], deque[_CompletedOutputEntry]
         ] = defaultdict(deque)
         self._claimed_completed_outputs: dict[
-            tuple[str, str, str], tuple[SessionActivity, bool]
+            tuple[str, str, str], _ClaimedCompletedOutput
         ] = {}
+        self._next_completed_output_sequence = 0
         self._recovered_output_ids: set[tuple[str, str, str]] = set()
         self._recovered_terminals: deque[SessionActivity] = deque()
         self._restore()
@@ -161,6 +177,17 @@ class SessionActivityRegistry:
     @classmethod
     def _activity_key(cls, activity: SessionActivity) -> tuple[str, str, str]:
         return cls._key(activity.backend, activity.runtime_key, activity.id)
+
+    def _new_completed_output_entry(
+        self,
+        activity: SessionActivity,
+    ) -> _CompletedOutputEntry:
+        self._next_completed_output_sequence += 1
+        return _CompletedOutputEntry(
+            sequence=self._next_completed_output_sequence,
+            queued_at=time.monotonic(),
+            activity=activity,
+        )
 
     @staticmethod
     def _activity_run_ids(activity: SessionActivity) -> set[str]:
@@ -269,7 +296,9 @@ class SessionActivityRegistry:
             )
             phase = record.get("phase")
             if phase == "awaiting_output":
-                self._completed_outputs[connection_key].append((time.monotonic(), activity))
+                self._completed_outputs[connection_key].append(
+                    self._new_completed_output_entry(activity)
+                )
                 self._recovered_output_ids.add(key)
                 continue
 
@@ -421,7 +450,7 @@ class SessionActivityRegistry:
                 self._persist_activity(completed, phase="awaiting_output")
                 self._active.pop(key, None)
                 self._completed_outputs[(str(backend), str(runtime_key))].append(
-                    (time.monotonic(), completed)
+                    self._new_completed_output_entry(completed)
                 )
             elif retain_terminal_snapshot:
                 self._persist_activity(completed, phase=TERMINAL_SNAPSHOT_PHASE)
@@ -468,36 +497,148 @@ class SessionActivityRegistry:
         max_age_seconds: float = 0,
         recovered_only: bool = False,
     ) -> SessionActivity | None:
+        claimed = self._claim_completed_outputs(
+            backend,
+            runtime_key,
+            max_age_seconds=max_age_seconds,
+            recovered_only=recovered_only,
+            limit=1,
+        )
+        return claimed[0] if claimed else None
+
+    def claim_completed_output_batch(
+        self,
+        backend: str,
+        runtime_key: str,
+        *,
+        turn_ids: set[str] | None = None,
+    ) -> list[SessionActivity]:
+        """Atomically claim one causal batch without disturbing other output.
+
+        Explicit ``turn_ids`` select every matching completion in FIFO order,
+        even when unrelated output is interleaved. Without them, the queue head
+        defines the batch; turn-less legacy completions remain single-item.
+        """
+
         key = (str(backend), str(runtime_key))
+        with self._lock:
+            queue = self._completed_outputs.get(key)
+            if not queue:
+                return []
+            identities = (
+                {str(turn_id or "").strip() for turn_id in turn_ids}
+                if turn_ids is not None
+                else None
+            )
+            if identities is not None:
+                identities.discard("")
+                if not identities:
+                    return []
+            else:
+                head_turn_id = str(queue[0].activity.turn_id or "").strip()
+                if not head_turn_id:
+                    return self._claim_completed_outputs(
+                        backend,
+                        runtime_key,
+                        limit=1,
+                    )
+                identities = {head_turn_id}
+            return self._claim_completed_outputs(
+                backend,
+                runtime_key,
+                turn_ids=identities,
+            )
+
+    def _claim_completed_outputs(
+        self,
+        backend: str,
+        runtime_key: str,
+        *,
+        turn_ids: set[str] | None = None,
+        max_age_seconds: float = 0,
+        recovered_only: bool = False,
+        limit: int | None = None,
+    ) -> list[SessionActivity]:
+        key = (str(backend), str(runtime_key))
+        identities = (
+            {str(turn_id or "").strip() for turn_id in turn_ids}
+            if turn_ids is not None
+            else None
+        )
+        if identities is not None:
+            identities.discard("")
+            if not identities:
+                return []
         now = time.monotonic()
         with self._lock:
             queue = self._completed_outputs.get(key)
             if not queue:
-                return None
-            candidates = len(queue)
-            while queue and candidates > 0:
-                candidates -= 1
-                completed_at, activity = queue.popleft()
+                return []
+            retained: deque[_CompletedOutputEntry] = deque()
+            claimed: list[SessionActivity] = []
+            while queue:
+                entry = queue.popleft()
+                if limit is not None and len(claimed) >= limit:
+                    retained.append(entry)
+                    retained.extend(queue)
+                    break
+                activity = entry.activity
                 activity_key = self._activity_key(activity)
                 is_recovered = activity_key in self._recovered_output_ids
                 if recovered_only and not is_recovered:
-                    queue.append((completed_at, activity))
+                    retained.append(entry)
                     continue
-                if max_age_seconds <= 0 or now - completed_at <= max_age_seconds:
-                    self._claimed_completed_outputs[activity_key] = (activity, is_recovered)
+                if max_age_seconds > 0 and now - entry.queued_at > max_age_seconds:
+                    try:
+                        self._delete_activity(activity)
+                    except Exception:
+                        retained.append(entry)
+                        retained.extend(queue)
+                        self._completed_outputs[key] = retained
+                        raise
                     self._recovered_output_ids.discard(activity_key)
-                    if not queue:
-                        self._completed_outputs.pop(key, None)
-                    return activity
-                try:
-                    self._delete_activity(activity)
-                except Exception:
-                    queue.appendleft((completed_at, activity))
-                    raise
+                    continue
+                turn_id = str(activity.turn_id or "").strip()
+                if identities is not None and turn_id not in identities:
+                    retained.append(entry)
+                    continue
+                self._claimed_completed_outputs[activity_key] = _ClaimedCompletedOutput(
+                    entry=entry,
+                    recovered=is_recovered,
+                )
                 self._recovered_output_ids.discard(activity_key)
-            if not queue:
+                claimed.append(activity)
+            if retained:
+                self._completed_outputs[key] = retained
+            else:
                 self._completed_outputs.pop(key, None)
-        return None
+            return claimed
+
+    def requeue_completed_outputs(
+        self,
+        activities: list[SessionActivity],
+    ) -> int:
+        """Restore a claimed batch to its original positions atomically."""
+
+        restored_by_runtime: dict[
+            tuple[str, str], list[_ClaimedCompletedOutput]
+        ] = defaultdict(list)
+        with self._lock:
+            for activity in activities:
+                activity_key = self._activity_key(activity)
+                claimed = self._claimed_completed_outputs.pop(activity_key, None)
+                if claimed is None:
+                    continue
+                key = (str(activity.backend), str(activity.runtime_key))
+                restored_by_runtime[key].append(claimed)
+                if claimed.recovered:
+                    self._recovered_output_ids.add(activity_key)
+            for key, restored in restored_by_runtime.items():
+                entries = list(self._completed_outputs.get(key) or ())
+                entries.extend(item.entry for item in restored)
+                entries.sort(key=lambda item: item.sequence)
+                self._completed_outputs[key] = deque(entries)
+        return sum(len(items) for items in restored_by_runtime.values())
 
     def requeue_completed_output(
         self,
@@ -506,22 +647,31 @@ class SessionActivityRegistry:
         front: bool = True,
         recovered: bool | None = None,
     ) -> bool:
-        """Restore a claimed completion when its causal output cannot be consumed yet."""
+        """Restore one claim, optionally promoting it for immediate retry."""
 
         key = (str(activity.backend), str(activity.runtime_key))
         activity_key = self._activity_key(activity)
-        item = (time.monotonic(), activity)
         with self._lock:
             claimed = self._claimed_completed_outputs.pop(activity_key, None)
             if claimed is None:
                 return False
             if recovered is None:
-                recovered = claimed[1]
+                recovered = claimed.recovered
             queue = self._completed_outputs[key]
             if front:
-                queue.appendleft(item)
+                lowest_sequence = min(
+                    (entry.sequence for entry in queue),
+                    default=claimed.entry.sequence + 1,
+                )
+                queue.appendleft(
+                    replace(
+                        claimed.entry,
+                        sequence=lowest_sequence - 1,
+                        queued_at=time.monotonic(),
+                    )
+                )
             else:
-                queue.append(item)
+                queue.append(self._new_completed_output_entry(activity))
             if recovered:
                 self._recovered_output_ids.add(activity_key)
         return True
@@ -534,7 +684,7 @@ class SessionActivityRegistry:
             claimed = self._claimed_completed_outputs.get(activity_key)
             if claimed is None:
                 return False
-            self._delete_activity(claimed[0])
+            self._delete_activity(claimed.entry.activity)
             self._claimed_completed_outputs.pop(activity_key, None)
             self._recovered_output_ids.discard(activity_key)
             callback = self._output_settled_callback
@@ -555,8 +705,8 @@ class SessionActivityRegistry:
         with self._lock:
             prefix = (str(backend), str(runtime_key))
             return bool(self._completed_outputs.get(prefix)) or any(
-                (item.backend, item.runtime_key) == prefix
-                for item, _recovered in self._claimed_completed_outputs.values()
+                (claimed.entry.activity.backend, claimed.entry.activity.runtime_key) == prefix
+                for claimed in self._claimed_completed_outputs.values()
             )
 
     def has_pending_run_output(self, run_id: str) -> bool:
@@ -565,11 +715,14 @@ class SessionActivityRegistry:
             return False
         with self._lock:
             pending = [
-                activity
+                entry.activity
                 for queue in self._completed_outputs.values()
-                for _created_at, activity in queue
+                for entry in queue
             ]
-            pending.extend(activity for activity, _recovered in self._claimed_completed_outputs.values())
+            pending.extend(
+                claimed.entry.activity
+                for claimed in self._claimed_completed_outputs.values()
+            )
             return any(identity in self._activity_run_ids(activity) for activity in pending)
 
     def recovered_output_runtimes(self) -> list[tuple[str, str]]:
@@ -577,10 +730,10 @@ class SessionActivityRegistry:
 
         with self._lock:
             runtimes = {
-                (activity.backend, activity.runtime_key)
+                (entry.activity.backend, entry.activity.runtime_key)
                 for queue in self._completed_outputs.values()
-                for _created_at, activity in queue
-                if self._activity_key(activity) in self._recovered_output_ids
+                for entry in queue
+                if self._activity_key(entry.activity) in self._recovered_output_ids
             }
         return sorted(runtimes)
 
@@ -648,15 +801,15 @@ class SessionActivityRegistry:
         now = _now_iso()
         with self._lock:
             pending_by_key = {
-                self._activity_key(activity): activity
+                self._activity_key(entry.activity): entry.activity
                 for key, queue in self._completed_outputs.items()
                 if key[0] == identity
-                for _completed_at, activity in queue
+                for entry in queue
             }
             pending_by_key.update(
                 {
-                    key: activity
-                    for key, (activity, _recovered) in self._claimed_completed_outputs.items()
+                    key: claimed.entry.activity
+                    for key, claimed in self._claimed_completed_outputs.items()
                     if key[0] == identity
                 }
             )
@@ -741,12 +894,12 @@ class SessionActivityRegistry:
             pending_output_count = sum(
                 1
                 for queue in self._completed_outputs.values()
-                for _created_at, activity in queue
-                if activity.session_id == session_id
+                for entry in queue
+                if entry.activity.session_id == session_id
             ) + sum(
                 1
-                for activity, _recovered in self._claimed_completed_outputs.values()
-                if activity.session_id == session_id
+                for claimed in self._claimed_completed_outputs.values()
+                if claimed.entry.activity.session_id == session_id
             )
         if "connected" in connection_states:
             connection = "connected"

--- a/docs/plans/full-duplex-sessions.md
+++ b/docs/plans/full-duplex-sessions.md
@@ -125,10 +125,11 @@ admission forever.
 Batch membership follows the Activity origin IDs already retained by the pending
 request plus that request's own `turn_id`, not queue adjacency. This lets a
 synthetic agent-initiated Turn settle both the completion that opened it and any
-Activity it completes itself. Batch selection may scan past unrelated completions,
-which are restored in their original FIFO order. Likewise, a failed delivery
-requeues the claimed batch without reversing it even though the registry's
-single-item requeue operation inserts at the queue front.
+Activity it completes itself. The shared Activity Registry owns this transaction:
+it atomically claims every matching completion without removing unrelated queue
+entries, records each claim's stable queue sequence, and restores a failed batch
+to those original positions. Backend adapters consume the selected batch but do
+not scan or rebuild the completion queue themselves.
 
 ## Claude mapping
 

--- a/docs/plans/full-duplex-sessions.md
+++ b/docs/plans/full-duplex-sessions.md
@@ -122,6 +122,14 @@ before handling its Result. A later completion must never overwrite and strand
 an earlier claim, because an unreachable claimed output would block native-query
 admission forever.
 
+Batch membership follows the Activity origin IDs already retained by the pending
+request plus that request's own `turn_id`, not queue adjacency. This lets a
+synthetic agent-initiated Turn settle both the completion that opened it and any
+Activity it completes itself. Batch selection may scan past unrelated completions,
+which are restored in their original FIFO order. Likewise, a failed delivery
+requeues the claimed batch without reversing it even though the registry's
+single-item requeue operation inserts at the queue front.
+
 ## Claude mapping
 
 Claude task frames map into the shared Activity registry:

--- a/docs/plans/full-duplex-sessions.md
+++ b/docs/plans/full-duplex-sessions.md
@@ -117,8 +117,10 @@ Several Claude Activities can complete inside one Turn before the backend emits
 its single final Result. The pending request retains all claimed completions as
 one delivery batch: the latest Activity supplies the visible Result provenance,
 and every retained completion is acknowledged only after that Result is durably
-delivered. A later completion must never overwrite and strand an earlier claim,
-because an unreachable claimed output would block native-query admission forever.
+delivered. The receiver drains every already-queued completion owned by that Turn
+before handling its Result. A later completion must never overwrite and strand
+an earlier claim, because an unreachable claimed output would block native-query
+admission forever.
 
 ## Claude mapping
 

--- a/docs/plans/full-duplex-sessions.md
+++ b/docs/plans/full-duplex-sessions.md
@@ -113,6 +113,13 @@ without acquiring lifecycle authority over whichever foreground Turn is current.
 Deferred terminal intent is excluded from generic restart requeueing, then
 reconciled against recovered Activity/output snapshots before normal Run drain.
 
+Several Claude Activities can complete inside one Turn before the backend emits
+its single final Result. The pending request retains all claimed completions as
+one delivery batch: the latest Activity supplies the visible Result provenance,
+and every retained completion is acknowledged only after that Result is durably
+delivered. A later completion must never overwrite and strand an earlier claim,
+because an unreachable claimed output would block native-query admission forever.
+
 ## Claude mapping
 
 Claude task frames map into the shared Activity registry:

--- a/modules/agents/base.py
+++ b/modules/agents/base.py
@@ -60,9 +60,11 @@ class AgentRequest:
     # Explicit output semantics for the Turn. Backend-initiated/multi-output
     # paths override this instead of relying on the visible Message role.
     output: Optional[MessageOutput] = field(default_factory=terminal_turn_output)
-    # Producer-owned lifecycle object retained until durable output delivery is
-    # acknowledged. The shared dispatcher sees only ``output`` provenance.
-    output_activity: Optional[Any] = None
+    # Producer-owned lifecycle objects retained until durable output delivery is
+    # acknowledged. Claude can complete several background tools before one
+    # Result; the latest supplies ``output`` provenance and the whole batch is
+    # settled after delivery. The shared dispatcher sees only ``output``.
+    output_activities: List[Any] = field(default_factory=list)
 
 
 @dataclass

--- a/modules/agents/claude_agent.py
+++ b/modules/agents/claude_agent.py
@@ -1379,6 +1379,38 @@ class ClaudeAgent(BaseAgent):
             completes_turn=True,
         )
 
+    def _attach_queued_same_turn_activities(
+        self,
+        registry,
+        composite_key: str,
+        request: AgentRequest,
+        first_activity: SessionActivity,
+    ) -> SessionActivity:
+        """Claim the complete queued batch owned by one pending Turn."""
+
+        pending_turn_id = str(
+            (
+                getattr(
+                    getattr(request, "context", None),
+                    "platform_specific",
+                    None,
+                )
+                or {}
+            ).get(AGENT_TURN_TOKEN)
+            or ""
+        ).strip()
+        latest = first_activity
+        self._attach_request_activity(request, first_activity)
+        while True:
+            candidate = registry.claim_completed_output(self.name, composite_key)
+            if candidate is None:
+                return latest
+            if not candidate.turn_id or candidate.turn_id != pending_turn_id:
+                registry.requeue_completed_output(candidate)
+                return latest
+            self._attach_request_activity(request, candidate)
+            latest = candidate
+
     def _clear_request_activities(self, request: AgentRequest | None) -> None:
         if request is None:
             return
@@ -1861,7 +1893,13 @@ class ClaudeAgent(BaseAgent):
             if same_turn:
                 matched_request = self._pop_pending_request(composite_key)
                 self._adopt_pending_turn_token(context, matched_request)
-                self._attach_request_activity(matched_request, activity)
+                activity = self._attach_queued_same_turn_activities(
+                    registry,
+                    composite_key,
+                    matched_request,
+                    activity,
+                )
+                result_text = str(activity.metadata.get("summary") or "").strip()
                 try:
                     await self._emit_activity_result(
                         context,
@@ -1993,7 +2031,12 @@ class ClaudeAgent(BaseAgent):
                 or ""
             ).strip()
             if completed_activity.turn_id and completed_activity.turn_id == pending_turn_id:
-                self._attach_request_activity(pending_request, completed_activity)
+                self._attach_queued_same_turn_activities(
+                    registry,
+                    composite_key,
+                    pending_request,
+                    completed_activity,
+                )
                 return None
             self._detached_activity_outputs[composite_key] = completed_activity
             logger.info(

--- a/modules/agents/claude_agent.py
+++ b/modules/agents/claude_agent.py
@@ -878,7 +878,8 @@ class ClaudeAgent(BaseAgent):
                         # so sending both would duplicate the content.
 
                         pending_request = self._pop_pending_request(composite_key)
-                        output_activity = getattr(pending_request, "output_activity", None)
+                        output_activities = self._request_activities(pending_request)
+                        output_activity = output_activities[-1] if output_activities else None
 
                         # The receiver is long-lived and reused across a session's
                         # turns, so ``context`` still carries the FIRST turn's
@@ -907,7 +908,7 @@ class ClaudeAgent(BaseAgent):
                                 )
                                 registry = self._activity_registry()
                                 if registry is not None:
-                                    registry.ack_completed_output(output_activity)
+                                    self._ack_request_activities(pending_request)
                             else:
                                 await self.emit_result_message(
                                     context,
@@ -920,9 +921,7 @@ class ClaudeAgent(BaseAgent):
                         except Exception:
                             emit_failed = True
                             if output_activity is not None:
-                                registry = self._activity_registry()
-                                if registry is not None:
-                                    registry.requeue_completed_output(output_activity)
+                                self._requeue_request_activity(pending_request)
                                 await self._settle_activity_turn_after_delivery_failure(
                                     context
                                 )
@@ -1359,14 +1358,49 @@ class ClaudeAgent(BaseAgent):
         service = getattr(self.controller, "agent_service", None)
         return getattr(service, "activities", None)
 
+    @staticmethod
+    def _request_activities(request: AgentRequest | None) -> list[SessionActivity]:
+        if request is None:
+            return []
+        return list(getattr(request, "output_activities", None) or [])
+
+    def _attach_request_activity(
+        self,
+        request: AgentRequest,
+        activity: SessionActivity,
+    ) -> None:
+        retained = list(getattr(request, "output_activities", None) or [])
+        if all(item is not activity for item in retained):
+            retained.append(activity)
+        request.output_activities = retained
+        request.output = self._activity_message_output(
+            activity,
+            detached=False,
+            completes_turn=True,
+        )
+
+    def _clear_request_activities(self, request: AgentRequest | None) -> None:
+        if request is None:
+            return
+        request.output_activities = []
+
+    def _ack_request_activities(self, request: AgentRequest | None) -> None:
+        activities = self._request_activities(request)
+        registry = self._activity_registry()
+        if registry is not None:
+            for activity in activities:
+                registry.ack_completed_output(activity)
+        self._clear_request_activities(request)
+
     def _requeue_request_activity(self, request: AgentRequest | None) -> None:
-        activity = getattr(request, "output_activity", None)
-        if activity is None or request is None:
+        activities = self._request_activities(request)
+        if not activities or request is None:
             return
         registry = self._activity_registry()
         if registry is not None:
-            registry.requeue_completed_output(activity)
-        request.output_activity = None
+            for activity in activities:
+                registry.requeue_completed_output(activity)
+        self._clear_request_activities(request)
         request.output = terminal_turn_output()
 
     def _activity_output_pending(self, composite_key: str) -> bool:
@@ -1827,6 +1861,7 @@ class ClaudeAgent(BaseAgent):
             if same_turn:
                 matched_request = self._pop_pending_request(composite_key)
                 self._adopt_pending_turn_token(context, matched_request)
+                self._attach_request_activity(matched_request, activity)
                 try:
                     await self._emit_activity_result(
                         context,
@@ -1836,9 +1871,9 @@ class ClaudeAgent(BaseAgent):
                         completes_turn=True,
                         request=matched_request,
                     )
-                    registry.ack_completed_output(activity)
+                    self._ack_request_activities(matched_request)
                 except Exception:
-                    registry.requeue_completed_output(activity)
+                    self._requeue_request_activity(matched_request)
                     await self._settle_activity_turn_after_delivery_failure(context)
                     raise
                 finally:
@@ -1958,12 +1993,7 @@ class ClaudeAgent(BaseAgent):
                 or ""
             ).strip()
             if completed_activity.turn_id and completed_activity.turn_id == pending_turn_id:
-                pending_request.output = self._activity_message_output(
-                    completed_activity,
-                    detached=False,
-                    completes_turn=True,
-                )
-                pending_request.output_activity = completed_activity
+                self._attach_request_activity(pending_request, completed_activity)
                 return None
             self._detached_activity_outputs[composite_key] = completed_activity
             logger.info(
@@ -2028,7 +2058,11 @@ class ClaudeAgent(BaseAgent):
                 if completed_activity is not None
                 else None
             ),
-            output_activity=completed_activity,
+            output_activities=(
+                [completed_activity]
+                if completed_activity is not None
+                else []
+            ),
         )
         self._pending_requests.setdefault(composite_key, []).append(request)
         logger.info(

--- a/modules/agents/claude_agent.py
+++ b/modules/agents/claude_agent.py
@@ -62,7 +62,7 @@ class ClaudeAgent(BaseAgent):
         # the list shape remains for defensive cleanup of older queued state.
         self._pending_reactions: dict[str, list[tuple[str, str]]] = {}
         self._pending_requests: dict[str, list[AgentRequest]] = {}
-        self._detached_activity_outputs: dict[str, SessionActivity] = {}
+        self._detached_activity_outputs: dict[str, list[SessionActivity]] = {}
         self._detached_assistant_text: dict[str, str] = {}
         self._detached_unsolicited_outputs: set[str] = set()
         self._detached_unsolicited_text: dict[str, str] = {}
@@ -806,8 +806,12 @@ class ClaudeAgent(BaseAgent):
 
                     if message_type == "result":
                         result_text = getattr(message, "result", None)
-                        detached_activity = self._detached_activity_outputs.pop(composite_key, None)
-                        if detached_activity is not None:
+                        detached_activities = self._detached_activity_outputs.pop(
+                            composite_key,
+                            None,
+                        )
+                        if detached_activities:
+                            detached_activity = detached_activities[-1]
                             if not result_text:
                                 result_text = self._detached_assistant_text.get(composite_key)
                             self._detached_assistant_text.pop(composite_key, None)
@@ -823,11 +827,15 @@ class ClaudeAgent(BaseAgent):
                                 )
                                 registry = self._activity_registry()
                                 if registry is not None:
-                                    registry.ack_completed_output(detached_activity)
+                                    for activity in detached_activities:
+                                        registry.ack_completed_output(activity)
                             except Exception:
                                 registry = self._activity_registry()
                                 if registry is not None:
-                                    registry.requeue_completed_output(detached_activity)
+                                    self._requeue_activities(
+                                        registry,
+                                        detached_activities,
+                                    )
                                 raise
                             # The detached Activity output has no authority over
                             # a newer pending request. Its Turn stays owned by its
@@ -1073,11 +1081,11 @@ class ClaudeAgent(BaseAgent):
         finally:
             self._suppressed_synthetic_results.discard(composite_key)
             self._suppressed_synthetic_error_text.pop(composite_key, None)
-            detached_activity = self._detached_activity_outputs.pop(composite_key, None)
-            if detached_activity is not None:
+            detached_activities = self._detached_activity_outputs.pop(composite_key, None)
+            if detached_activities:
                 registry = self._activity_registry()
                 if registry is not None:
-                    registry.requeue_completed_output(detached_activity)
+                    self._requeue_activities(registry, detached_activities)
                     self._schedule_completed_activity_flush(composite_key, context)
             self._detached_assistant_text.pop(composite_key, None)
             self._detached_unsolicited_outputs.discard(composite_key)
@@ -1379,37 +1387,67 @@ class ClaudeAgent(BaseAgent):
             completes_turn=True,
         )
 
-    def _attach_queued_same_turn_activities(
+    @staticmethod
+    def _requeue_activities(
+        registry,
+        activities: list[SessionActivity],
+    ) -> None:
+        """Restore a claimed batch without reversing its FIFO order."""
+
+        for activity in reversed(activities):
+            registry.requeue_completed_output(activity)
+
+    def _claim_activity_batch_for_turns(
         self,
         registry,
         composite_key: str,
-        request: AgentRequest,
-        first_activity: SessionActivity,
-    ) -> SessionActivity:
-        """Claim the complete queued batch owned by one pending Turn."""
+        turn_ids: set[str],
+        *,
+        claimed: list[SessionActivity] | None = None,
+    ) -> list[SessionActivity]:
+        """Claim one causal batch while preserving unrelated queue order."""
 
-        pending_turn_id = str(
-            (
-                getattr(
-                    getattr(request, "context", None),
-                    "platform_specific",
-                    None,
-                )
-                or {}
-            ).get(AGENT_TURN_TOKEN)
-            or ""
-        ).strip()
-        latest = first_activity
-        self._attach_request_activity(request, first_activity)
+        batch = list(claimed or [])
+        identities = {str(turn_id or "").strip() for turn_id in turn_ids}
+        identities.discard("")
+        if not identities:
+            return batch
+        skipped: list[SessionActivity] = []
         while True:
             candidate = registry.claim_completed_output(self.name, composite_key)
             if candidate is None:
-                return latest
-            if not candidate.turn_id or candidate.turn_id != pending_turn_id:
-                registry.requeue_completed_output(candidate)
-                return latest
-            self._attach_request_activity(request, candidate)
-            latest = candidate
+                break
+            if candidate.turn_id in identities:
+                batch.append(candidate)
+            else:
+                skipped.append(candidate)
+        self._requeue_activities(registry, skipped)
+        return batch
+
+    def _attach_request_activities(
+        self,
+        request: AgentRequest,
+        activities: list[SessionActivity],
+    ) -> None:
+        for activity in activities:
+            self._attach_request_activity(request, activity)
+
+    @staticmethod
+    def _request_activity_turn_ids(request: AgentRequest | None) -> set[str]:
+        activities = ClaudeAgent._request_activities(request)
+        turn_ids = {
+            str(activity.turn_id or "").strip()
+            for activity in activities
+        }
+        context = getattr(request, "context", None) if request is not None else None
+        request_turn_id = str(
+            ((getattr(context, "platform_specific", None) or {}).get(AGENT_TURN_TOKEN))
+            or ""
+        ).strip()
+        if request_turn_id:
+            turn_ids.add(request_turn_id)
+        turn_ids.discard("")
+        return turn_ids
 
     def _clear_request_activities(self, request: AgentRequest | None) -> None:
         if request is None:
@@ -1430,8 +1468,7 @@ class ClaudeAgent(BaseAgent):
             return
         registry = self._activity_registry()
         if registry is not None:
-            for activity in activities:
-                registry.requeue_completed_output(activity)
+            self._requeue_activities(registry, activities)
         self._clear_request_activities(request)
         request.output = terminal_turn_output()
 
@@ -1825,9 +1862,10 @@ class ClaudeAgent(BaseAgent):
         composite_key: str,
         context: MessageContext,
     ) -> None:
-        activity = self._detached_activity_outputs.pop(composite_key, None)
-        if activity is None:
+        activities = self._detached_activity_outputs.pop(composite_key, None)
+        if not activities:
             return
+        activity = activities[-1]
         text = self._detached_assistant_text.pop(composite_key, "").strip()
         if not text:
             text = str(activity.metadata.get("summary") or "").strip()
@@ -1841,11 +1879,12 @@ class ClaudeAgent(BaseAgent):
             )
             registry = self._activity_registry()
             if registry is not None:
-                registry.ack_completed_output(activity)
+                for item in activities:
+                    registry.ack_completed_output(item)
         except Exception:
             registry = self._activity_registry()
             if registry is not None:
-                registry.requeue_completed_output(activity)
+                self._requeue_activities(registry, activities)
             raise
         self._mark_session_idle_if_runtime_free(composite_key)
         self._signal_activity_output_settled(composite_key)
@@ -1861,44 +1900,30 @@ class ClaudeAgent(BaseAgent):
         if registry is None:
             return False
         while True:
-            activity = registry.claim_completed_output(self.name, composite_key)
-            if activity is None:
-                return False
             pending = self._pending_requests.get(composite_key) or []
             pending_request = pending[0] if pending else None
-            pending_turn_id = str(
-                (
-                    getattr(
-                        getattr(pending_request, "context", None),
-                        "platform_specific",
-                        None,
-                    )
-                    or {}
-                ).get(AGENT_TURN_TOKEN)
-                or ""
-            ).strip()
-            same_turn = bool(
-                pending_request is not None
-                and activity.turn_id
-                and activity.turn_id == pending_turn_id
-            )
-            if pending_request is not None and not same_turn:
-                # A timed summary flush cannot consume the only correlation for
-                # an Activity whose real assistant/result sequence may still be
-                # in flight. Leave it for the receiver so that later output is
-                # detached from, and cannot complete, this newer Turn.
-                registry.requeue_completed_output(activity)
-                return True
-            result_text = str(activity.metadata.get("summary") or "").strip()
-            if same_turn:
-                matched_request = self._pop_pending_request(composite_key)
-                self._adopt_pending_turn_token(context, matched_request)
-                activity = self._attach_queued_same_turn_activities(
+            if pending_request is not None:
+                pending_turn_ids = self._request_activity_turn_ids(pending_request)
+                activities = self._claim_activity_batch_for_turns(
                     registry,
                     composite_key,
-                    matched_request,
-                    activity,
+                    pending_turn_ids,
                 )
+                if not activities:
+                    candidate = registry.claim_completed_output(
+                        self.name,
+                        composite_key,
+                    )
+                    if candidate is None:
+                        return False
+                    registry.requeue_completed_output(candidate)
+                    return True
+
+                self._attach_request_activities(pending_request, activities)
+                matched_request = self._pop_pending_request(composite_key)
+                self._adopt_pending_turn_token(context, matched_request)
+                retained = self._request_activities(matched_request)
+                activity = retained[-1]
                 result_text = str(activity.metadata.get("summary") or "").strip()
                 try:
                     await self._emit_activity_result(
@@ -1926,6 +1951,17 @@ class ClaudeAgent(BaseAgent):
                     self._signal_activity_output_settled(composite_key)
                 continue
 
+            activity = registry.claim_completed_output(self.name, composite_key)
+            if activity is None:
+                return False
+            activities = self._claim_activity_batch_for_turns(
+                registry,
+                composite_key,
+                {str(activity.turn_id or "")},
+                claimed=[activity],
+            )
+            activity = activities[-1]
+            result_text = str(activity.metadata.get("summary") or "").strip()
             try:
                 await self._emit_activity_result(
                     context,
@@ -1934,9 +1970,10 @@ class ClaudeAgent(BaseAgent):
                     detached=True,
                     completes_turn=False,
                 )
-                registry.ack_completed_output(activity)
+                for item in activities:
+                    registry.ack_completed_output(item)
             except Exception:
-                registry.requeue_completed_output(activity)
+                self._requeue_activities(registry, activities)
                 raise
             self._mark_session_idle_if_runtime_free(composite_key)
             self._signal_activity_output_settled(composite_key)
@@ -2000,7 +2037,21 @@ class ClaudeAgent(BaseAgent):
         agent-initiated Turn and synthesize a pending ``AgentRequest`` so the
         existing result path retains its normal lifecycle behavior.
         """
-        if composite_key in self._detached_activity_outputs:
+        registry = self._activity_registry()
+        detached_activities = self._detached_activity_outputs.get(composite_key)
+        if detached_activities:
+            turn_ids = {
+                str(activity.turn_id or "").strip()
+                for activity in detached_activities
+            }
+            if registry is not None and any(turn_ids):
+                detached_activities.extend(
+                    self._claim_activity_batch_for_turns(
+                        registry,
+                        composite_key,
+                        turn_ids,
+                    )
+                )
             return "activity"
         if composite_key in self._detached_unsolicited_outputs:
             return "detached"
@@ -2011,45 +2062,77 @@ class ClaudeAgent(BaseAgent):
         # when the paired result is consumed or the receiver exits.
         if composite_key in self._suppressed_synthetic_results:
             return None
-        registry = self._activity_registry()
+        pending = self._pending_requests.get(composite_key) or []
+        if pending:
+            pending_request = pending[0]
+            retained = self._request_activities(pending_request)
+            retained_turn_ids = self._request_activity_turn_ids(pending_request)
+            if retained:
+                if registry is not None and retained_turn_ids:
+                    self._attach_request_activities(
+                        pending_request,
+                        self._claim_activity_batch_for_turns(
+                            registry,
+                            composite_key,
+                            retained_turn_ids,
+                        ),
+                    )
+                return None
+
+            completed_activity = (
+                registry.claim_completed_output(self.name, composite_key)
+                if registry is not None
+                else None
+            )
+            if completed_activity is None:
+                return None
+            pending_turn_ids = self._request_activity_turn_ids(pending_request)
+            if completed_activity.turn_id in pending_turn_ids:
+                activities = self._claim_activity_batch_for_turns(
+                    registry,
+                    composite_key,
+                    pending_turn_ids,
+                    claimed=[completed_activity],
+                )
+                self._attach_request_activities(
+                    pending_request,
+                    activities,
+                )
+                return None
+            activities = self._claim_activity_batch_for_turns(
+                registry,
+                composite_key,
+                {str(completed_activity.turn_id or "")},
+                claimed=[completed_activity],
+            )
+            self._detached_activity_outputs[composite_key] = activities
+            logger.info(
+                "Claude Activity batch %s output detached from the current user turn in %s",
+                ",".join(activity.id for activity in activities),
+                composite_key,
+            )
+            return "activity"
+
         completed_activity = (
             registry.claim_completed_output(self.name, composite_key)
             if registry is not None
             else None
         )
-        if completed_activity is not None and self._has_pending_requests(composite_key):
-            pending_request = self._pending_requests[composite_key][0]
-            pending_turn_id = str(
-                (
-                    getattr(
-                        getattr(pending_request, "context", None),
-                        "platform_specific",
-                        None,
-                    )
-                    or {}
-                ).get(AGENT_TURN_TOKEN)
-                or ""
-            ).strip()
-            if completed_activity.turn_id and completed_activity.turn_id == pending_turn_id:
-                self._attach_queued_same_turn_activities(
-                    registry,
-                    composite_key,
-                    pending_request,
-                    completed_activity,
-                )
-                return None
-            self._detached_activity_outputs[composite_key] = completed_activity
-            logger.info(
-                "Claude Activity %s output detached from the current user turn in %s",
-                completed_activity.id,
+        completed_activities = (
+            self._claim_activity_batch_for_turns(
+                registry,
                 composite_key,
+                {str(completed_activity.turn_id or "")},
+                claimed=[completed_activity],
             )
-            return "activity"
-        if self._has_pending_requests(composite_key):
-            return None
+            if registry is not None and completed_activity is not None
+            else []
+        )
         service = getattr(self.controller, "agent_service", None)
         begin = getattr(service, "begin_agent_initiated_turn", None)
         if not callable(begin):
+            if registry is not None:
+                self._requeue_activities(registry, completed_activities)
             return None
         payload = getattr(context, "platform_specific", None) or {}
         runtime_key = str(payload.get(AGENT_RUNTIME_TURN_KEY) or "").strip() or composite_key
@@ -2065,8 +2148,8 @@ class ClaudeAgent(BaseAgent):
                 "(a user turn holds or is queued on it)",
                 composite_key,
             )
-            if completed_activity is not None:
-                self._detached_activity_outputs[composite_key] = completed_activity
+            if completed_activities:
+                self._detached_activity_outputs[composite_key] = completed_activities
                 return "activity"
             if message_type in {"assistant", "result"}:
                 self._detached_unsolicited_outputs.add(composite_key)
@@ -2085,6 +2168,7 @@ class ClaudeAgent(BaseAgent):
         mark_active = getattr(self.session_handler, "mark_session_active", None)
         if callable(mark_active):
             mark_active(composite_key)
+        latest_activity = completed_activities[-1] if completed_activities else None
         request = AgentRequest(
             context=context,
             message="",
@@ -2094,18 +2178,14 @@ class ClaudeAgent(BaseAgent):
             session_key=session_key,
             output=(
                 self._activity_message_output(
-                    completed_activity,
+                    latest_activity,
                     detached=False,
                     completes_turn=True,
                 )
-                if completed_activity is not None
+                if latest_activity is not None
                 else None
             ),
-            output_activities=(
-                [completed_activity]
-                if completed_activity is not None
-                else []
-            ),
+            output_activities=completed_activities,
         )
         self._pending_requests.setdefault(composite_key, []).append(request)
         logger.info(

--- a/modules/agents/claude_agent.py
+++ b/modules/agents/claude_agent.py
@@ -1392,37 +1392,23 @@ class ClaudeAgent(BaseAgent):
         registry,
         activities: list[SessionActivity],
     ) -> None:
-        """Restore a claimed batch without reversing its FIFO order."""
+        """Restore a claimed batch to its Registry-owned queue positions."""
 
-        for activity in reversed(activities):
-            registry.requeue_completed_output(activity)
+        registry.requeue_completed_outputs(activities)
 
     def _claim_activity_batch_for_turns(
         self,
         registry,
         composite_key: str,
         turn_ids: set[str],
-        *,
-        claimed: list[SessionActivity] | None = None,
     ) -> list[SessionActivity]:
-        """Claim one causal batch while preserving unrelated queue order."""
+        """Claim one causal batch through the shared Registry transaction."""
 
-        batch = list(claimed or [])
-        identities = {str(turn_id or "").strip() for turn_id in turn_ids}
-        identities.discard("")
-        if not identities:
-            return batch
-        skipped: list[SessionActivity] = []
-        while True:
-            candidate = registry.claim_completed_output(self.name, composite_key)
-            if candidate is None:
-                break
-            if candidate.turn_id in identities:
-                batch.append(candidate)
-            else:
-                skipped.append(candidate)
-        self._requeue_activities(registry, skipped)
-        return batch
+        return registry.claim_completed_output_batch(
+            self.name,
+            composite_key,
+            turn_ids=turn_ids,
+        )
 
     def _attach_request_activities(
         self,
@@ -1910,14 +1896,7 @@ class ClaudeAgent(BaseAgent):
                     pending_turn_ids,
                 )
                 if not activities:
-                    candidate = registry.claim_completed_output(
-                        self.name,
-                        composite_key,
-                    )
-                    if candidate is None:
-                        return False
-                    registry.requeue_completed_output(candidate)
-                    return True
+                    return registry.has_completed_output(self.name, composite_key)
 
                 self._attach_request_activities(pending_request, activities)
                 matched_request = self._pop_pending_request(composite_key)
@@ -1951,15 +1930,12 @@ class ClaudeAgent(BaseAgent):
                     self._signal_activity_output_settled(composite_key)
                 continue
 
-            activity = registry.claim_completed_output(self.name, composite_key)
-            if activity is None:
-                return False
-            activities = self._claim_activity_batch_for_turns(
-                registry,
+            activities = registry.claim_completed_output_batch(
+                self.name,
                 composite_key,
-                {str(activity.turn_id or "")},
-                claimed=[activity],
             )
+            if not activities:
+                return False
             activity = activities[-1]
             result_text = str(activity.metadata.get("summary") or "").strip()
             try:
@@ -2079,32 +2055,29 @@ class ClaudeAgent(BaseAgent):
                     )
                 return None
 
-            completed_activity = (
-                registry.claim_completed_output(self.name, composite_key)
-                if registry is not None
-                else None
-            )
-            if completed_activity is None:
-                return None
             pending_turn_ids = self._request_activity_turn_ids(pending_request)
-            if completed_activity.turn_id in pending_turn_ids:
-                activities = self._claim_activity_batch_for_turns(
+            activities = (
+                self._claim_activity_batch_for_turns(
                     registry,
                     composite_key,
                     pending_turn_ids,
-                    claimed=[completed_activity],
                 )
+                if registry is not None
+                else []
+            )
+            if activities:
                 self._attach_request_activities(
                     pending_request,
                     activities,
                 )
                 return None
-            activities = self._claim_activity_batch_for_turns(
-                registry,
-                composite_key,
-                {str(completed_activity.turn_id or "")},
-                claimed=[completed_activity],
+            activities = (
+                registry.claim_completed_output_batch(self.name, composite_key)
+                if registry is not None
+                else []
             )
+            if not activities:
+                return None
             self._detached_activity_outputs[composite_key] = activities
             logger.info(
                 "Claude Activity batch %s output detached from the current user turn in %s",
@@ -2113,19 +2086,9 @@ class ClaudeAgent(BaseAgent):
             )
             return "activity"
 
-        completed_activity = (
-            registry.claim_completed_output(self.name, composite_key)
-            if registry is not None
-            else None
-        )
         completed_activities = (
-            self._claim_activity_batch_for_turns(
-                registry,
-                composite_key,
-                {str(completed_activity.turn_id or "")},
-                claimed=[completed_activity],
-            )
-            if registry is not None and completed_activity is not None
+            registry.claim_completed_output_batch(self.name, composite_key)
+            if registry is not None
             else []
         )
         service = getattr(self.controller, "agent_service", None)

--- a/tests/test_claude_agent_initiated_turn.py
+++ b/tests/test_claude_agent_initiated_turn.py
@@ -575,7 +575,7 @@ class ReceiverOpensAgentInitiatedTurnTests(unittest.IsolatedAsyncioTestCase):
         self.assertFalse(service.activities.has_completed_output("claude", composite_key))
         self.assertFalse(gate.lock.locked())
 
-    async def test_activity_batch_scan_preserves_interleaved_completion(self):
+    async def test_pending_activity_batch_scans_past_older_queue_head(self):
         agent, service = _build_agent()
         composite_key = "session-interleaved-batch:/tmp/work"
         context = SimpleNamespace(
@@ -593,8 +593,8 @@ class ReceiverOpensAgentInitiatedTurnTests(unittest.IsolatedAsyncioTestCase):
         agent._pending_requests[composite_key] = [pending_request]
 
         for activity_id, turn_id in (
-            ("task-current-a", "current-turn"),
             ("task-detached", "older-turn"),
+            ("task-current-a", "current-turn"),
             ("task-current-b", "current-turn"),
         ):
             service.activities.start(
@@ -1100,7 +1100,59 @@ class ReceiverOpensAgentInitiatedTurnTests(unittest.IsolatedAsyncioTestCase):
             self.assertIsNotNone(activity)
             service.activities.ack_completed_output(activity)
 
-    async def test_requeued_terminal_only_activity_flushes_after_pending_turn(self):
+    async def test_failed_pending_batch_restores_older_global_output_order(self):
+        agent, service = _build_agent()
+        composite_key = "session-global-requeue-order:/tmp/work"
+        pending_request = SimpleNamespace(
+            context=SimpleNamespace(
+                platform_specific={"turn_token": "current-turn"},
+            ),
+            output_activities=[],
+        )
+        agent._pending_requests[composite_key] = [pending_request]
+        context = SimpleNamespace(
+            platform_specific={"agent_session_id": "sess-global-requeue-order"},
+        )
+        for activity_id, turn_id in (
+            ("task-old", "older-turn"),
+            ("task-current-a", "current-turn"),
+            ("task-current-b", "current-turn"),
+        ):
+            service.activities.start(
+                backend="claude",
+                runtime_key=composite_key,
+                session_id="sess-global-requeue-order",
+                activity_id=activity_id,
+                kind="local_bash",
+                turn_id=turn_id,
+            )
+            service.activities.complete(
+                backend="claude",
+                runtime_key=composite_key,
+                activity_id=activity_id,
+                status="completed",
+                metadata={"summary": f"{activity_id} finished"},
+                expects_output=True,
+            )
+        agent.emit_result_message = AsyncMock(return_value=None)
+
+        with self.assertRaisesRegex(RuntimeError, "was not persisted or delivered"):
+            await agent._flush_completed_activity_outputs(composite_key, context)
+
+        restored = []
+        while activity := service.activities.claim_completed_output(
+            "claude",
+            composite_key,
+        ):
+            restored.append(activity)
+        self.assertEqual(
+            [activity.id for activity in restored],
+            ["task-old", "task-current-a", "task-current-b"],
+        )
+        for activity in restored:
+            service.activities.ack_completed_output(activity)
+
+    async def test_terminal_only_activity_waits_queued_until_pending_turn_finishes(self):
         agent, service = _build_agent()
         agent.ACTIVITY_OUTPUT_FLUSH_GRACE_SECONDS = 0
         composite_key = "session-retry-flush:/tmp/work"
@@ -1126,26 +1178,24 @@ class ReceiverOpensAgentInitiatedTurnTests(unittest.IsolatedAsyncioTestCase):
             metadata={"summary": "Background verification finished"},
             expects_output=True,
         )
-        requeued = asyncio.Event()
-        original_requeue = service.activities.requeue_completed_output
+        agent.emit_result_message = AsyncMock(return_value="message-id")
 
-        def _requeue(activity, *, front=True):
-            original_requeue(activity, front=front)
-            requeued.set()
+        should_retry = await agent._flush_completed_activity_outputs(
+            composite_key,
+            context,
+        )
 
-        service.activities.requeue_completed_output = _requeue
-        emitted = asyncio.Event()
-        async def _emit(*_args, **_kwargs):
-            emitted.set()
-            return "message-id"
-
-        agent.emit_result_message = AsyncMock(side_effect=_emit)
-
-        agent._schedule_completed_activity_flush(composite_key, context)
-        await asyncio.wait_for(requeued.wait(), timeout=1)
+        self.assertTrue(should_retry)
+        agent.emit_result_message.assert_not_awaited()
+        self.assertTrue(service.activities.has_completed_output("claude", composite_key))
         agent._pending_requests.pop(composite_key)
-        await asyncio.wait_for(emitted.wait(), timeout=1)
+        should_retry = await agent._flush_completed_activity_outputs(
+            composite_key,
+            context,
+        )
 
+        self.assertFalse(should_retry)
+        agent.emit_result_message.assert_awaited_once()
         self.assertFalse(service.activities.has_completed_output("claude", composite_key))
         self.assertFalse(agent._activity_output_pending(composite_key))
 

--- a/tests/test_claude_agent_initiated_turn.py
+++ b/tests/test_claude_agent_initiated_turn.py
@@ -433,6 +433,60 @@ class ReceiverOpensAgentInitiatedTurnTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(pending_request.output_activities, [])
         await asyncio.wait_for(agent._wait_for_activity_output(composite_key), timeout=1)
 
+    async def test_prequeued_same_turn_activities_are_drained_before_result(self):
+        agent, service = _build_agent()
+        composite_key = "session-prequeued-activities:/tmp/work"
+        context = SimpleNamespace(
+            user_id="U1",
+            channel_id="C1",
+            platform="avibe",
+            platform_specific={
+                "agent_session_id": "sess-prequeued-activities",
+                "turn_token": "origin-turn",
+            },
+        )
+        pending_request = SimpleNamespace(
+            context=SimpleNamespace(
+                platform_specific={"turn_token": "origin-turn"},
+            ),
+            output=None,
+            output_activities=[],
+        )
+        agent._pending_requests[composite_key] = [pending_request]
+        agent.emit_result_message = AsyncMock(return_value="message-id")
+
+        for activity_id in ("task-build", "task-rebuild"):
+            service.activities.start(
+                backend="claude",
+                runtime_key=composite_key,
+                session_id="sess-prequeued-activities",
+                activity_id=activity_id,
+                kind="local_bash",
+                turn_id="origin-turn",
+            )
+            service.activities.complete(
+                backend="claude",
+                runtime_key=composite_key,
+                activity_id=activity_id,
+                status="completed",
+                metadata={"summary": f"{activity_id} finished"},
+                expects_output=True,
+            )
+
+        await agent._receive_messages(
+            _one_result_client(),
+            "sess-prequeued-activities",
+            "/tmp/work",
+            context,
+            composite_key=composite_key,
+        )
+
+        output = agent.emit_result_message.await_args.kwargs["output"]
+        self.assertEqual(output.activity_id, "task-rebuild")
+        self.assertFalse(service.activities.has_completed_output("claude", composite_key))
+        self.assertEqual(pending_request.output_activities, [])
+        await asyncio.wait_for(agent._wait_for_activity_output(composite_key), timeout=1)
+
     async def test_terminal_only_task_event_keeps_current_turn_origin(self):
         agent, service = _build_agent()
         composite_key = "session-terminal-only:/tmp/work"
@@ -734,6 +788,51 @@ class ReceiverOpensAgentInitiatedTurnTests(unittest.IsolatedAsyncioTestCase):
         claimed = service.activities.claim_completed_output("claude", composite_key)
         self.assertIsNotNone(claimed)
         self.assertEqual(claimed.turn_id, "origin-turn")
+
+    async def test_timed_flush_drains_prequeued_same_turn_batch(self):
+        agent, service = _build_agent()
+        composite_key = "session-batched-flush:/tmp/work"
+        pending_request = SimpleNamespace(
+            context=SimpleNamespace(
+                platform_specific={"turn_token": "origin-turn"},
+            ),
+            output_activities=[],
+        )
+        agent._pending_requests[composite_key] = [pending_request]
+        context = SimpleNamespace(
+            platform_specific={"agent_session_id": "sess-batched-flush"},
+        )
+        agent.emit_result_message = AsyncMock(return_value="message-id")
+
+        for activity_id in ("task-build", "task-rebuild"):
+            service.activities.start(
+                backend="claude",
+                runtime_key=composite_key,
+                session_id="sess-batched-flush",
+                activity_id=activity_id,
+                kind="local_bash",
+                turn_id="origin-turn",
+            )
+            service.activities.complete(
+                backend="claude",
+                runtime_key=composite_key,
+                activity_id=activity_id,
+                status="completed",
+                metadata={"summary": f"{activity_id} finished"},
+                expects_output=True,
+            )
+
+        should_retry = await agent._flush_completed_activity_outputs(
+            composite_key,
+            context,
+        )
+
+        self.assertFalse(should_retry)
+        agent.emit_result_message.assert_awaited_once()
+        output = agent.emit_result_message.await_args.kwargs["output"]
+        self.assertEqual(output.activity_id, "task-rebuild")
+        self.assertFalse(service.activities.has_completed_output("claude", composite_key))
+        self.assertEqual(pending_request.output_activities, [])
 
     async def test_detached_activity_output_requeues_when_delivery_returns_none(self):
         agent, service = _build_agent()

--- a/tests/test_claude_agent_initiated_turn.py
+++ b/tests/test_claude_agent_initiated_turn.py
@@ -487,6 +487,151 @@ class ReceiverOpensAgentInitiatedTurnTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(pending_request.output_activities, [])
         await asyncio.wait_for(agent._wait_for_activity_output(composite_key), timeout=1)
 
+    async def test_agent_initiated_turn_retains_prequeued_activity_batch(self):
+        agent, service = _build_agent()
+        composite_key = "session-synthetic-batch:/tmp/work"
+        context = SimpleNamespace(
+            user_id="U1",
+            channel_id="C1",
+            platform="avibe",
+            platform_specific={
+                "agent_runtime_turn_key": composite_key,
+                "agent_runtime_turn_token": "OLD-TURN",
+                "turn_token": "origin-turn",
+                "agent_session_id": "sess-synthetic-batch",
+            },
+        )
+        for activity_id in ("task-build", "task-rebuild"):
+            service.activities.start(
+                backend="claude",
+                runtime_key=composite_key,
+                session_id="sess-synthetic-batch",
+                activity_id=activity_id,
+                kind="local_bash",
+                turn_id="origin-turn",
+            )
+            service.activities.complete(
+                backend="claude",
+                runtime_key=composite_key,
+                activity_id=activity_id,
+                status="completed",
+                metadata={"summary": f"{activity_id} finished"},
+                expects_output=True,
+            )
+
+        mode = await agent._maybe_begin_agent_initiated_turn(
+            context,
+            composite_key,
+            "sess-synthetic-batch",
+            "/tmp/work",
+            "session-key",
+            message_type="assistant",
+        )
+
+        self.assertIsNone(mode)
+        pending_request = agent._pending_requests[composite_key][0]
+        self.assertEqual(
+            [activity.id for activity in pending_request.output_activities],
+            ["task-build", "task-rebuild"],
+        )
+        gate = service._get_turn_gate(composite_key)
+        self.assertTrue(gate.lock.locked())
+
+        synthetic_turn = context.platform_specific["turn_token"]
+        self.assertNotEqual(synthetic_turn, "origin-turn")
+        service.activities.start(
+            backend="claude",
+            runtime_key=composite_key,
+            session_id="sess-synthetic-batch",
+            activity_id="task-followup",
+            kind="local_bash",
+            turn_id=synthetic_turn,
+        )
+        service.activities.complete(
+            backend="claude",
+            runtime_key=composite_key,
+            activity_id="task-followup",
+            status="completed",
+            metadata={"summary": "task-followup finished"},
+            expects_output=True,
+        )
+
+        async def _emit_result(ctx, *_args, **_kwargs):
+            service.release_runtime_turn(ctx)
+            return "message-id"
+
+        agent.emit_result_message = AsyncMock(side_effect=_emit_result)
+        await agent._receive_messages(
+            _one_result_client(),
+            "sess-synthetic-batch",
+            "/tmp/work",
+            context,
+            composite_key=composite_key,
+        )
+
+        output = agent.emit_result_message.await_args.kwargs["output"]
+        self.assertEqual(output.activity_id, "task-followup")
+        self.assertFalse(agent._has_pending_requests(composite_key))
+        self.assertFalse(service.activities.has_completed_output("claude", composite_key))
+        self.assertFalse(gate.lock.locked())
+
+    async def test_activity_batch_scan_preserves_interleaved_completion(self):
+        agent, service = _build_agent()
+        composite_key = "session-interleaved-batch:/tmp/work"
+        context = SimpleNamespace(
+            platform_specific={
+                "agent_session_id": "sess-interleaved-batch",
+                "turn_token": "current-turn",
+            },
+        )
+        pending_request = SimpleNamespace(
+            context=SimpleNamespace(
+                platform_specific={"turn_token": "current-turn"},
+            ),
+            output_activities=[],
+        )
+        agent._pending_requests[composite_key] = [pending_request]
+
+        for activity_id, turn_id in (
+            ("task-current-a", "current-turn"),
+            ("task-detached", "older-turn"),
+            ("task-current-b", "current-turn"),
+        ):
+            service.activities.start(
+                backend="claude",
+                runtime_key=composite_key,
+                session_id="sess-interleaved-batch",
+                activity_id=activity_id,
+                kind="local_bash",
+                turn_id=turn_id,
+            )
+            service.activities.complete(
+                backend="claude",
+                runtime_key=composite_key,
+                activity_id=activity_id,
+                status="completed",
+                expects_output=True,
+            )
+
+        await agent._maybe_begin_agent_initiated_turn(
+            context,
+            composite_key,
+            "sess-interleaved-batch",
+            "/tmp/work",
+            "session-key",
+            message_type="result",
+        )
+
+        self.assertEqual(
+            [activity.id for activity in pending_request.output_activities],
+            ["task-current-a", "task-current-b"],
+        )
+        detached = service.activities.claim_completed_output("claude", composite_key)
+        self.assertIsNotNone(detached)
+        self.assertEqual(detached.id, "task-detached")
+        service.activities.ack_completed_output(detached)
+        agent._ack_request_activities(pending_request)
+
     async def test_terminal_only_task_event_keeps_current_turn_origin(self):
         agent, service = _build_agent()
         composite_key = "session-terminal-only:/tmp/work"
@@ -858,7 +1003,7 @@ class ReceiverOpensAgentInitiatedTurnTests(unittest.IsolatedAsyncioTestCase):
         )
         activity = service.activities.claim_completed_output("claude", composite_key)
         self.assertIsNotNone(activity)
-        agent._detached_activity_outputs[composite_key] = activity
+        agent._detached_activity_outputs[composite_key] = [activity]
         agent._detached_assistant_text[composite_key] = "Full background result"
         agent.emit_result_message = AsyncMock(return_value=None)
 
@@ -908,6 +1053,52 @@ class ReceiverOpensAgentInitiatedTurnTests(unittest.IsolatedAsyncioTestCase):
         self.assertIsNotNone(
             service.activities.claim_completed_output("claude", composite_key)
         )
+
+    async def test_requeued_activity_batch_preserves_fifo_order(self):
+        agent, service = _build_agent()
+        composite_key = "session-requeued-batch-order:/tmp/work"
+        claimed = []
+        for activity_id in ("task-build", "task-rebuild"):
+            service.activities.start(
+                backend="claude",
+                runtime_key=composite_key,
+                session_id="sess-requeued-batch-order",
+                activity_id=activity_id,
+                kind="local_bash",
+                turn_id="origin-turn",
+            )
+            service.activities.complete(
+                backend="claude",
+                runtime_key=composite_key,
+                activity_id=activity_id,
+                status="completed",
+                expects_output=True,
+            )
+            activity = service.activities.claim_completed_output("claude", composite_key)
+            self.assertIsNotNone(activity)
+            claimed.append(activity)
+        request = SimpleNamespace(
+            output_activities=claimed,
+            output=agent._activity_message_output(
+                claimed[-1],
+                detached=False,
+                completes_turn=True,
+            ),
+        )
+
+        agent._requeue_request_activity(request)
+
+        retried = [
+            service.activities.claim_completed_output("claude", composite_key),
+            service.activities.claim_completed_output("claude", composite_key),
+        ]
+        self.assertEqual(
+            [activity.id for activity in retried if activity is not None],
+            ["task-build", "task-rebuild"],
+        )
+        for activity in retried:
+            self.assertIsNotNone(activity)
+            service.activities.ack_completed_output(activity)
 
     async def test_requeued_terminal_only_activity_flushes_after_pending_turn(self):
         agent, service = _build_agent()

--- a/tests/test_claude_agent_initiated_turn.py
+++ b/tests/test_claude_agent_initiated_turn.py
@@ -351,6 +351,88 @@ class ReceiverOpensAgentInitiatedTurnTests(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(service.activities.ack_completed_output(claimed))
         await asyncio.wait_for(waiter, timeout=1)
 
+    async def test_multiple_same_turn_activities_settle_as_one_delivery_batch(self):
+        agent, service = _build_agent()
+        composite_key = "session-multi-activity:/tmp/work"
+        context = SimpleNamespace(
+            user_id="U1",
+            channel_id="C1",
+            platform="avibe",
+            platform_specific={
+                "agent_session_id": "sess-multi-activity",
+                "turn_token": "origin-turn",
+            },
+        )
+        pending_request = SimpleNamespace(
+            context=SimpleNamespace(
+                platform_specific={"turn_token": "origin-turn"},
+            ),
+            output=None,
+            output_activities=[],
+        )
+        agent._pending_requests[composite_key] = [pending_request]
+        agent.emit_result_message = AsyncMock(return_value="message-id")
+
+        def _complete(activity_id: str, summary: str) -> None:
+            service.activities.start(
+                backend="claude",
+                runtime_key=composite_key,
+                session_id="sess-multi-activity",
+                activity_id=activity_id,
+                kind="local_bash",
+                turn_id="origin-turn",
+            )
+            service.activities.complete(
+                backend="claude",
+                runtime_key=composite_key,
+                activity_id=activity_id,
+                status="completed",
+                metadata={"summary": summary},
+                expects_output=True,
+            )
+
+        _complete("task-build", "Build finished")
+        await agent._maybe_begin_agent_initiated_turn(
+            context,
+            composite_key,
+            "sess-multi-activity",
+            "/tmp/work",
+            "session-key",
+            message_type="assistant",
+        )
+        self.assertEqual(
+            [activity.id for activity in pending_request.output_activities],
+            ["task-build"],
+        )
+
+        _complete("task-rebuild", "Rebuild finished")
+        await agent._maybe_begin_agent_initiated_turn(
+            context,
+            composite_key,
+            "sess-multi-activity",
+            "/tmp/work",
+            "session-key",
+            message_type="result",
+        )
+        self.assertEqual(
+            [activity.id for activity in pending_request.output_activities],
+            ["task-build", "task-rebuild"],
+        )
+
+        await agent._receive_messages(
+            _one_result_client(),
+            "sess-multi-activity",
+            "/tmp/work",
+            context,
+            composite_key=composite_key,
+        )
+
+        output = agent.emit_result_message.await_args.kwargs["output"]
+        self.assertEqual(output.activity_id, "task-rebuild")
+        self.assertFalse(service.activities.has_completed_output("claude", composite_key))
+        self.assertEqual(pending_request.output_activities, [])
+        await asyncio.wait_for(agent._wait_for_activity_output(composite_key), timeout=1)
+
     async def test_terminal_only_task_event_keeps_current_turn_origin(self):
         agent, service = _build_agent()
         composite_key = "session-terminal-only:/tmp/work"
@@ -709,7 +791,7 @@ class ReceiverOpensAgentInitiatedTurnTests(unittest.IsolatedAsyncioTestCase):
         activity = service.activities.claim_completed_output("claude", composite_key)
         self.assertIsNotNone(activity)
         request = SimpleNamespace(
-            output_activity=activity,
+            output_activities=[activity],
             output=agent._activity_message_output(
                 activity,
                 detached=False,
@@ -719,7 +801,7 @@ class ReceiverOpensAgentInitiatedTurnTests(unittest.IsolatedAsyncioTestCase):
 
         agent._requeue_request_activity(request)
 
-        self.assertIsNone(request.output_activity)
+        self.assertEqual(request.output_activities, [])
         restored = terminal_output_for(request)
         self.assertTrue(restored.completes_turn)
         self.assertTrue(restored.settles_run)
@@ -869,7 +951,7 @@ class ReceiverOpensAgentInitiatedTurnTests(unittest.IsolatedAsyncioTestCase):
         self.assertIsNotNone(activity)
         pending_request = SimpleNamespace(
             context=pending_context,
-            output_activity=activity,
+            output_activities=[activity],
         )
         agent._pending_requests[composite_key] = [pending_request]
         agent.emit_result_message = AsyncMock(

--- a/tests/test_session_activities.py
+++ b/tests/test_session_activities.py
@@ -62,6 +62,95 @@ def test_activity_lifecycle_keeps_state_axes_orthogonal():
     assert registry.has_completed_output("claude", "runtime-1") is False
 
 
+def test_activity_batch_claim_leaves_interleaved_output_in_place():
+    registry = SessionActivityRegistry()
+    for activity_id, turn_id in (
+        ("task-old", "older-turn"),
+        ("task-current-a", "current-turn"),
+        ("task-other", "other-turn"),
+        ("task-current-b", "current-turn"),
+    ):
+        registry.start(
+            backend="claude",
+            runtime_key="runtime-1",
+            session_id="ses-1",
+            activity_id=activity_id,
+            kind="background_task",
+            turn_id=turn_id,
+        )
+        registry.complete(
+            backend="claude",
+            runtime_key="runtime-1",
+            activity_id=activity_id,
+            status="completed",
+            expects_output=True,
+        )
+
+    claimed = registry.claim_completed_output_batch(
+        "claude",
+        "runtime-1",
+        turn_ids={"current-turn"},
+    )
+
+    assert [activity.id for activity in claimed] == [
+        "task-current-a",
+        "task-current-b",
+    ]
+    older = registry.claim_completed_output_batch("claude", "runtime-1")
+    other = registry.claim_completed_output_batch("claude", "runtime-1")
+    assert [activity.id for activity in older] == ["task-old"]
+    assert [activity.id for activity in other] == ["task-other"]
+    for activity in [*claimed, *older, *other]:
+        registry.ack_completed_output(activity)
+
+
+def test_activity_batch_requeue_restores_global_fifo_position():
+    registry = SessionActivityRegistry()
+
+    def _complete(activity_id: str, turn_id: str) -> None:
+        registry.start(
+            backend="claude",
+            runtime_key="runtime-1",
+            session_id="ses-1",
+            activity_id=activity_id,
+            kind="background_task",
+            turn_id=turn_id,
+        )
+        registry.complete(
+            backend="claude",
+            runtime_key="runtime-1",
+            activity_id=activity_id,
+            status="completed",
+            expects_output=True,
+        )
+
+    _complete("task-old", "older-turn")
+    _complete("task-current-a", "current-turn")
+    _complete("task-other", "other-turn")
+    _complete("task-current-b", "current-turn")
+    claimed = registry.claim_completed_output_batch(
+        "claude",
+        "runtime-1",
+        turn_ids={"current-turn"},
+    )
+    _complete("task-new", "newer-turn")
+
+    assert registry.requeue_completed_outputs(claimed) == 2
+
+    restored = []
+    while activity := registry.claim_completed_output("claude", "runtime-1"):
+        restored.append(activity)
+    assert [activity.id for activity in restored] == [
+        "task-old",
+        "task-current-a",
+        "task-other",
+        "task-current-b",
+        "task-new",
+    ]
+    for activity in restored:
+        registry.ack_completed_output(activity)
+
+
 def test_activity_output_native_id_is_stable_across_recovery_contexts():
     activity = SessionActivity(
         id="task-1",


### PR DESCRIPTION
## Summary

- retain every claimed Claude Activity on the pending Turn until its single final Result is durably delivered
- drain every already-queued completion owned by that Turn before handling its Result or timed summary flush
- make the shared Activity Registry atomically select batches by turn without dequeuing unrelated output
- retain each claim's stable queue position so delivery failures restore the complete global FIFO order
- use the latest Activity for visible Result provenance, then acknowledge or requeue the whole ordered batch together
- cover the production failure sequence where two background tools complete in one Turn and the earlier claim used to become unreachable

## Root cause

`AgentRequest` originally held only one `output_activity`. When another same-Turn Activity completed before Claude emitted its final Result, the newer claim overwrote the older claim. The durable Activity stayed in the registry's claimed set forever, so Claude native-query admission waited forever on output that no code could acknowledge or requeue.

The first batch fix still made the Claude adapter scan and rebuild the shared completion queue. That left ownership split across layers: an unrelated queue head could steal a pending Result, and a failed matched batch could overtake older skipped output. The Registry now owns batch membership and queue position as one atomic transaction; backend adapters only consume or restore the returned batch.

## Scenarios

- `MESSAGE-DELIVERY-003`: background Activity delivery cannot block a newer Turn indefinitely
- `MESSAGE-DELIVERY-004`: multiple outputs in one Turn retain one terminal delivery boundary

## Evidence

- unit: added sequential, prequeued, synthetic, older-head, interleaved, timed-flush, and global failed-requeue regressions; 59 focused Activity, receiver, and registry tests pass
- contract: 256 Claude session, AgentService, scheduler, and dispatcher tests pass
- scenario: the regressions reproduce both sequentially observed and already-queued completions, and prove native admission unblocks after batch settlement
- build/lint: UI package prerequisite build passes; Ruff passes on all changed Python files
- CI: all current-head checks pass for `2171335f`
- residual manual: no local Avibe service restart or state mutation was performed; runtime upgrade/recovery remains an integration step

## Known by design

- One final Claude Result remains one visible message. The latest same-Turn Activity supplies its stable output identity; earlier same-Turn Activities are acknowledged by that same durable delivery instead of producing duplicate summary bubbles.

## Dependencies

- None
