### PR TITLE
fix(apps): resolve Show Page icons via Vite publicDir root-mapping (§7.1j)

### DIFF
--- a/core/show_pages.py
+++ b/core/show_pages.py
@@ -747,6 +747,23 @@ def _resolve_icon_candidate(page_dir: Path, relative: str) -> tuple[Path, str] |
     return candidate, content_type
 
 
+def _public_mapped_icon_relative(relative: str) -> str | None:
+    """The Vite publicDir root-mapping of a declared icon href, or None.
+
+    Vite serves ``public/*`` at the SITE ROOT, so a browser-valid relative href like
+    ``./icon.png`` (which the page resolves against the site root) can live on disk at
+    ``public/icon.png`` — while our resolution is against the workspace root, so the exact
+    on-disk path ``<ws>/icon.png`` misses. This returns the ``public/``-prefixed relative
+    to try AFTER the exact path. None when the path is already under ``public/`` (the
+    exact-path probe covers it — no ``public/public/…``). The result is a plain relative
+    that still flows through :func:`_resolve_icon_candidate`, so the realpath / whitelist /
+    size guards apply to the mapped path too (a hostile ``..`` href is already rejected by
+    :func:`_extract_icon_path`, and the realpath check re-guards the mapped candidate)."""
+    if relative.startswith("public/"):
+        return None
+    return f"public/{relative}"
+
+
 def resolve_show_page_icon(session_id: str) -> tuple[Path, str] | None:
     """The absolute path + Content-Type of a Show Page's own icon, or None.
 
@@ -756,8 +773,11 @@ def resolve_show_page_icon(session_id: str) -> tuple[Path, str] | None:
     the serving layer just streams the file. An explicit ``<link rel="icon">`` WINS;
     when the page declares none, it falls back to the workspace-conventional favicon
     files (root then ``public/``) so agent-built pages — which rarely add a link —
-    still get an icon (§7.1h). Returns None for any missing workspace / no icon /
-    policy rejection — the caller answers 404 and the frontend uses the letter avatar.
+    still get an icon (§7.1h). A declared href also honors Vite's **publicDir
+    root-mapping** (§7.1j): an exact ``<ws>/<path>`` miss falls back to
+    ``<ws>/public/<path>`` (Vite serves ``public/*`` at the site root) before the
+    conventions. Returns None for any missing workspace / no icon / policy rejection —
+    the caller answers 404 and the frontend uses the letter avatar.
     """
     page_dir = show_page_dir(session_id)
     link = _extract_icon_path(page_dir)
@@ -765,7 +785,19 @@ def resolve_show_page_icon(session_id: str) -> tuple[Path, str] | None:
     # explicit link that resolves to nothing (missing file / rejected) must not strand
     # the page icon-less when a conventional favicon exists — fall through to the
     # conventions after it, so coverage is maximized (Codex §7.1h).
-    relatives = (link, *_CONVENTIONAL_ICON_RELATIVES) if link else _CONVENTIONAL_ICON_RELATIVES
+    #
+    # For the declared link, probe the EXACT on-disk path first, then the Vite publicDir
+    # mapping (``public/<path>``): a fully-compliant ``./icon.png`` can live at
+    # ``public/icon.png`` because Vite serves ``public/*`` at the site root while we
+    # resolve against the workspace root on disk, so the exact path misses even though the
+    # browser loads it fine (owner-reported §7.1j). The mapped candidate still goes through
+    # _resolve_icon_candidate, so whitelist/size/traversal-realpath guards apply to it too.
+    if link:
+        mapped = _public_mapped_icon_relative(link)
+        link_candidates = (link, mapped) if mapped else (link,)
+        relatives = (*link_candidates, *_CONVENTIONAL_ICON_RELATIVES)
+    else:
+        relatives = _CONVENTIONAL_ICON_RELATIVES
     for relative in relatives:
         resolved = _resolve_icon_candidate(page_dir, relative)
         if resolved is not None:

--- a/docs/plans/dock-pinned-show-page-apps.md
+++ b/docs/plans/dock-pinned-show-page-apps.md
@@ -695,6 +695,18 @@ alongside §7.1h item 3), in `AppWindow.tsx` + `WindowManagerContext.tsx`:
   archived session with `session_archived` (the store's `is_archived` check is promoted to
   public), matching every other Show Page mutator's archived guard.
 
+**Amendment (owner-reported bug, 2026-07-16 — Vite publicDir root-mapping):** the icon
+resolver resolved a declared `<link rel=icon href="./icon.png">` only against `<ws>/icon.png`
+on disk, so a fully-compliant page whose icon lives at `public/icon.png` (Vite serves
+`public/*` at the SITE ROOT, so the browser loads `./icon.png` fine) was deemed unusable →
+letter avatar. Fix: when the declared href misses at the exact path, also try
+`<ws>/public/<path>` before falling through. Precedence: **exact path first, then the
+`public/` mapping**, then the conventional fallback (unchanged). The mapped candidate runs
+through the same `_resolve_icon_candidate` chokepoint, so the whitelist / 2 MiB cap /
+traversal-realpath guards apply to it too (a hostile `..` href is already rejected by the
+href policy before mapping), and `icon_version` hashes the resolved (mapped) file so it stays
+content-correct. The mapping is LINK-scoped — it is not a blanket scan of `public/`.
+
 ### 7.2 Becoming an app: the ladder (owner Q&A 2026-07-13)
 
 Pinning **is** installing — no separate ceremony. Two entrances, one action:

--- a/tests/test_show_pages.py
+++ b/tests/test_show_pages.py
@@ -1165,6 +1165,107 @@ def test_resolve_icon_none_without_link_or_conventional(monkeypatch, tmp_path):
     assert resolve_show_page_icon("sesnone") is None
 
 
+def test_resolve_icon_link_maps_to_vite_public_dir(monkeypatch, tmp_path):
+    # §7.1j: a fully-compliant `./icon.png` whose file lives at public/icon.png (Vite
+    # serves public/* at the SITE ROOT) must resolve — the exact <ws>/icon.png misses, so
+    # the resolver falls back to the publicDir mapping instead of the letter avatar.
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    from core.show_pages import resolve_show_page_icon
+
+    page_dir = ensure_show_page_dir("sespub")
+    (page_dir / "index.html").write_text(
+        '<link rel="icon" type="image/png" sizes="180x180" href="./icon.png">', encoding="utf-8"
+    )
+    (page_dir / "public").mkdir(parents=True, exist_ok=True)
+    (page_dir / "public" / "icon.png").write_bytes(b"PUBLIC-PNG")
+
+    resolved = resolve_show_page_icon("sespub")
+    assert resolved is not None
+    assert resolved[0] == (page_dir / "public" / "icon.png").resolve()
+    assert resolved[1] == "image/png"
+
+
+def test_resolve_icon_link_exact_path_wins_over_public_mapping(monkeypatch, tmp_path):
+    # Precedence: when the declared href exists at BOTH the exact on-disk path and the
+    # publicDir mapping, the exact path (root) wins (§7.1j).
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    from core.show_pages import resolve_show_page_icon
+
+    page_dir = ensure_show_page_dir("sesboth")
+    (page_dir / "index.html").write_text('<link rel="icon" href="./icon.png">', encoding="utf-8")
+    (page_dir / "icon.png").write_bytes(b"ROOT-PNG")
+    (page_dir / "public").mkdir(parents=True, exist_ok=True)
+    (page_dir / "public" / "icon.png").write_bytes(b"PUBLIC-PNG")
+
+    resolved = resolve_show_page_icon("sesboth")
+    assert resolved is not None
+    assert resolved[0] == (page_dir / "icon.png").resolve()  # exact/root wins over public/
+
+
+def test_resolve_icon_public_mapping_does_not_bypass_traversal(monkeypatch, tmp_path):
+    # The publicDir mapping must not open a traversal hole: a hostile `..` href is rejected
+    # by the href policy (so the mapping is never reached from it), and an outside file is
+    # never served — the mapping only ever prepends `public/` to an already-clean path.
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    from core.show_pages import resolve_show_page_icon
+
+    page_dir = ensure_show_page_dir("sestrav")
+    (tmp_path / "outside.png").write_bytes(b"OUTSIDE")
+    for href in ("./../outside.png", "./..%2foutside.png", r".\..\outside.png", "public/../../outside.png"):
+        (page_dir / "index.html").write_text(f'<link rel="icon" href="{href}">', encoding="utf-8")
+        assert resolve_show_page_icon("sestrav") is None, href
+
+
+def test_resolve_icon_conventional_order_unchanged_after_unusable_link(monkeypatch, tmp_path):
+    # (d) The publicDir mapping is LINK-scoped and runs before the conventions; it must not
+    # perturb the conventional order. An unusable link (no exact, no public mapping) falls
+    # through, and the conventions still resolve root-before-public.
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    from core.show_pages import resolve_show_page_icon
+
+    page_dir = ensure_show_page_dir("sesorder2")
+    (page_dir / "index.html").write_text('<link rel="icon" href="missing.svg">', encoding="utf-8")
+    (page_dir / "public").mkdir(parents=True, exist_ok=True)
+    (page_dir / "public" / "favicon.svg").write_bytes(b"PUB")
+    (page_dir / "favicon.svg").write_bytes(b"ROOT")
+
+    resolved = resolve_show_page_icon("sesorder2")
+    assert resolved is not None
+    assert resolved[0] == (page_dir / "favicon.svg").resolve()  # root convention still wins
+
+
+def test_resolve_icon_public_mapping_is_link_scoped(monkeypatch, tmp_path):
+    # The mapping only applies to a DECLARED link, not a blanket scan of public/: a
+    # non-conventionally-named file in public/ with NO link that points at it is not an
+    # icon (so it stays the letter avatar) — this keeps the fallback rules tight.
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    from core.show_pages import resolve_show_page_icon
+
+    page_dir = ensure_show_page_dir("seslinkscope")
+    (page_dir / "index.html").write_text("<title>no link</title>", encoding="utf-8")
+    (page_dir / "public").mkdir(parents=True, exist_ok=True)
+    (page_dir / "public" / "icon.png").write_bytes(b"UNREFERENCED")  # not a favicon name, no link
+    assert resolve_show_page_icon("seslinkscope") is None
+
+
+def test_icon_version_follows_public_mapped_file(monkeypatch, tmp_path):
+    # (e) icon_version hashes the RESOLVED (mapped) file's content, so overwriting
+    # public/icon.png changes the token — the content-versioned URL stays correct.
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    from core.show_pages import show_page_icon_version
+
+    page_dir = ensure_show_page_dir("sespubver")
+    (page_dir / "index.html").write_text('<link rel="icon" href="./icon.png">', encoding="utf-8")
+    (page_dir / "public").mkdir(parents=True, exist_ok=True)
+    (page_dir / "public" / "icon.png").write_bytes(b"V1")
+    v1 = show_page_icon_version("sespubver")
+    assert v1
+
+    (page_dir / "public" / "icon.png").write_bytes(b"V2-different-bytes")
+    v2 = show_page_icon_version("sespubver")
+    assert v2 and v2 != v1
+
+
 def test_read_show_page_icon_enforces_the_token(monkeypatch, tmp_path):
     # ?v= is a content assertion: the correct token yields the bytes; a wrong/empty
     # token is None (→ 404), so `immutable` caching is honest (URL ⇒ one content).


### PR DESCRIPTION
## Capability

Fix a real, owner-verified bug in the Show Page **icon resolver** (§7.1j amendment): it missed **Vite's publicDir root-mapping**.

**Repro** (live workspace `~/.avibe/show/ses2q9re7sjfr`): `index.html` declares `<link rel="icon" type="image/png" sizes="180x180" href="./icon.png">`, and the file exists at `public/icon.png`. Vite serves `public/*` at the **site root**, so the browser loads `./icon.png` fine — but our resolver resolved the href only against the workspace root on disk (`<ws>/icon.png`, missing) → deemed the declaration unusable → fell through → **letter avatar**. The declaration is fully compliant; the resolver lacked the publicDir mapping.

## Fix (`core/show_pages.py`)

When a declared `<link rel=icon>` href resolves inside the workspace but the file is **missing at `<ws>/<path>`**, also try **`<ws>/public/<path>`** before declaring the link unusable.

- **Precedence:** exact path first → then the `public/` mapping → then the conventional fallback (**unchanged**).
- All existing policy still applies **after** mapping: the mapped candidate runs through the same `_resolve_icon_candidate` chokepoint (same-workspace realpath guard, whitelist extension, 2 MiB cap) and the `_read_workspace_file_safely` read path. A hostile `..` href is already rejected by the href policy *before* mapping, and the realpath check re-guards the mapped candidate.
- `icon_version` hashes the **resolved (mapped)** file's content, so it stays content-correct (the versioned URL busts on a `public/icon.png` change).
- The mapping is **link-scoped** — it is not a blanket scan of `public/`.

## Evidence

- **Unit (pytest — `tests/test_show_pages.py`):**
  - (a) `href ./icon.png` + file only at `public/icon.png` → resolves + serves (`image/png`);
  - (b) file at **both** root and `public/` → **root wins**;
  - (c) mapped-path traversal (`./..%2f…`, backslash, `public/../..`) still rejected (outside file never served);
  - (d) conventional fallback order unchanged after an unusable link (root convention still beats `public/`);
  - link-scoped (an unreferenced `public/icon.png` with no link → letter avatar);
  - (e) `icon_version` follows the mapped file's content.
- Full `test_show_pages.py` green (119); `ruff` clean.
- Backend-only (resolver + tests + spec §7.1j note) — no UI change.

Off latest `origin/master`. Spec §7.1j amended in `docs/plans/dock-pinned-show-page-apps.md`.
