### PR TITLE
docs(remote): use canonical backend repo name

### DIFF
--- a/docs/plans/vibe-cloud-remote-access.md
+++ b/docs/plans/vibe-cloud-remote-access.md
@@ -437,7 +437,7 @@ GET /oauth/jwks.json
 
 ### Phase 1: Planning and Backend Skeleton
 
-- Create `vibe-remote-backend` private repository.
+- Create the private `avibe-bot/avibe-backend` repository.
 - Add backend architecture plan.
 - Implement API skeleton, data models, config, and tests.
 - Implement OIDC discovery and JWKS endpoints.

--- a/docs/plans/workbench-chat-media-io.md
+++ b/docs/plans/workbench-chat-media-io.md
@@ -129,7 +129,7 @@ the right-side send/stop button.
 - Reuses 100% of `core/audio_asr.py` + Vibe Cloud device-secret auth.
 - Button gated on Vibe Cloud pairing (D3); disabled + hint otherwise.
 - **Backend (already deployed):** the ASR endpoint `POST /v1/audio/transcriptions`
-  is live on `vibe-remote-backend` `main` (PR #32, merged 2026-05-19; the
+  is live on `avibe-backend` `main` (PR #32, merged 2026-05-19; the
   DashScope/Qwen key lives server-side in Vercel Production). It authenticates
   with the paired device's `X-Vibe-Instance-Id` / `X-Vibe-Device-Secret` and
   requires the device tunnel to be running (else `409 tunnel_not_running`) —


### PR DESCRIPTION
## Summary

- update Avibe planning documents to use the canonical `avibe-bot/avibe-backend` repository identity
- preserve historical PR references while removing the stale backend repository name

## Evidence

- Unit: not applicable; documentation-only change
- Contract: cross-repository documentation now names the canonical backend repository
- Scenario: not applicable
- Residual manual checks: `git diff --check` and focused stale-name search
