### PR TITLE
fix(apps): dock tile radius/border polish + minimized-chip real icons (§7.1k)

### DIFF
--- a/docs/plans/dock-pinned-show-page-apps.md
+++ b/docs/plans/dock-pinned-show-page-apps.md
@@ -707,6 +707,34 @@ traversal-realpath guards apply to it too (a hostile `..` href is already reject
 href policy before mapping), and `icon_version` hashes the resolved (mapped) file so it stays
 content-correct. The mapping is LINK-scoped — it is not a blanket scan of `public/`.
 
+### 7.1k Dock visual polish — tile radius/borders + minimized-chip icons (owner 2026-07-16 15:56)
+
+Owner feedback on the live Dock (two items):
+
+1. **Tile radius + accent borders.** The Dock tile icon's rounding is too heavy — target
+   **12px** (`rounded-xl`) on the Dock tile box. And the per-session accent BORDERS
+   ("有的绿有的紫") read as noisy — **remove the accent border entirely** from
+   `ShowPageAvatarTile` (the 34% `color-mix` `borderColor` + the `border` class). This is
+   the shared chokepoint, so the border disappears everywhere it renders (Dock, App
+   Library rows, ⌘K results) — ONE consistent look, declared in the PR body. Letter
+   avatars keep their accent-tinted BACKGROUND fill (16% mix) and accent letter color —
+   only the border goes. **Radius is unified too (owner 16:04): 12px (`rounded-xl`) at
+   the shared chokepoint itself** — Dock tiles AND App Library rows AND ⌘K results all
+   render the same 12px, borderless tile; no per-surface radius overrides.
+2. **Minimized-window chips use the app's real icon.** The minimized thumbnail's body
+   currently renders the registry glyph (`def.icon`) for every window. New rule: **if the
+   app has an icon, show it; only fall back otherwise.** Concretely: for `showpage`
+   windows, render the page's own avatar content through the shared chokepoint
+   (`ShowPageAvatarContent`: favicon `<img>` when the page has one, else the letter
+   avatar with its accent — same identity as its Dock tile, sized to the chip); built-ins
+   keep their registry icon (that IS their icon). The letter-not-generic fallback choice
+   is deliberate (consistent with the Dock tile identity) — declare it in the PR body.
+
+Invariant reminder: Dock tile visual changes MUST NOT break the drag gesture — the
+press target must remain a filling non-interactive child (icon `<img
+draggable={false}>` without `pointer-events-none`, letter wrapped in a filling `<span>`);
+see the invariant comment in `showPageAvatarTile.tsx` (§7.1i forensics).
+
 ### 7.2 Becoming an app: the ladder (owner Q&A 2026-07-13)
 
 Pinning **is** installing — no separate ceremony. Two entrances, one action:

--- a/ui/src/apps/showPageAvatarTile.test.tsx
+++ b/ui/src/apps/showPageAvatarTile.test.tsx
@@ -1,7 +1,7 @@
 import { renderToStaticMarkup } from 'react-dom/server';
 import { describe, expect, it } from 'vitest';
 
-import { ShowPageAvatarContent } from './showPageAvatarTile';
+import { ShowPageAvatarContent, ShowPageAvatarTile } from './showPageAvatarTile';
 
 // Guards the Dock-drag invariant (§7.1h item 3): a Dock tile is a framer-motion
 // Reorder.Item whose drag pan starts ONLY when the press lands on a non-interactive
@@ -27,5 +27,26 @@ describe('ShowPageAvatarContent — Dock-drag press-target invariant', () => {
     // The #907 pointer-events-none is reverted: it pushed the press back to the
     // button and re-broke drag for icon tiles.
     expect(html).not.toContain('pointer-events-none');
+  });
+});
+
+// §7.1k item 1: the shared chokepoint is borderless — the per-session accent border
+// (the 34% color-mix borderColor + the `border` class) read as noisy across many
+// tiles, so it is gone everywhere ShowPageAvatarTile renders (App Library rows +
+// ⌘K results). The accent survives only as the 16% background tint + letter color,
+// and the tile keeps its 12px radius (`rounded-lg` = --radius-lg in this theme).
+describe('ShowPageAvatarTile — §7.1k borderless accent tile', () => {
+  it('renders no border, keeping the accent tint + letter color + 12px radius', () => {
+    const html = renderToStaticMarkup(<ShowPageAvatarTile sessionId="ses_border" title="Hello" />);
+    // No accent border anywhere: neither the `border` utility class nor a
+    // `border-color` inline style (which is how React serializes borderColor).
+    expect(html).not.toContain('border');
+    // The accent still shows as the background tint + letter color.
+    expect(html).toContain('background-color:');
+    expect(html).toContain('color:var(');
+    // 12px radius preserved (unified with the Dock tile).
+    expect(html).toContain('rounded-lg');
+    // The letter avatar still renders (no icon version supplied).
+    expect(html).toContain('>H</span>');
   });
 });

--- a/ui/src/apps/showPageAvatarTile.tsx
+++ b/ui/src/apps/showPageAvatarTile.tsx
@@ -72,13 +72,17 @@ export const ShowPageAvatarTile: React.FC<{
     <span
       aria-hidden
       className={clsx(
-        'flex size-9 shrink-0 items-center justify-center overflow-hidden rounded-lg border text-[14px] font-bold leading-none',
+        // §7.1k: borderless, 12px radius. `rounded-lg` is 12px in this theme
+        // (--radius-lg; NOT stock Tailwind's 8px — `rounded-xl` here is 16px), the
+        // owner's unified target across the Dock, App Library rows, and ⌘K results.
+        // The per-session accent BORDER is dropped (it read as noisy across many
+        // tiles); the accent survives only as the 16% background tint + letter color.
+        'flex size-9 shrink-0 items-center justify-center overflow-hidden rounded-lg text-[14px] font-bold leading-none',
         className,
       )}
       style={{
         color: `var(${accentVar})`,
         backgroundColor: `color-mix(in srgb, var(${accentVar}) 16%, transparent)`,
-        borderColor: `color-mix(in srgb, var(${accentVar}) 34%, transparent)`,
       }}
     >
       <ShowPageAvatarContent iconUrl={showPageIconUrl(sessionId, iconVersion)} letter={letter} />

--- a/ui/src/components/apps/AppWindow.tsx
+++ b/ui/src/components/apps/AppWindow.tsx
@@ -276,11 +276,13 @@ export const AppWindow: React.FC<{
           {showpageSid && showpageAvatar ? (
             <span
               aria-hidden
-              className="grid size-4 shrink-0 place-items-center overflow-hidden rounded-[4px] border text-[10px] font-bold leading-none"
+              // §7.1k sweep: borderless — the per-session accent border was the noise the
+              // owner flagged. Keep the 16% tint + accent letter color and the chip's own
+              // 4px radius (a small title-bar chip; the 12px tile unification is not for it).
+              className="grid size-4 shrink-0 place-items-center overflow-hidden rounded-[4px] text-[10px] font-bold leading-none"
               style={{
                 color: `var(${showpageAvatar.accentVar})`,
                 backgroundColor: `color-mix(in srgb, var(${showpageAvatar.accentVar}) 16%, transparent)`,
-                borderColor: `color-mix(in srgb, var(${showpageAvatar.accentVar}) 34%, transparent)`,
               }}
             >
               <ShowPageAvatarContent iconUrl={showPageIconUrl(showpageSid, iconVersion)} letter={showpageAvatar.letter} />

--- a/ui/src/components/apps/Dock.tsx
+++ b/ui/src/components/apps/Dock.tsx
@@ -47,11 +47,13 @@ export const Dock: React.FC = () => {
   // chips so a page reads identically wherever it appears (§7.1k item 2).
   const showpageIdentity = useMemo(
     () =>
-      (sessionId: string): { title: string; iconVersion: string | null } => {
+      (sessionId: string, fallbackTitle?: string): { title: string; iconVersion: string | null } => {
         const page = pageBySession.get(sessionId);
+        // live session title → pin snapshot → caller fallback (e.g. a minimized
+        // window's own title, so it survives an unloaded/failed inventory) → sid.
         const title = page
           ? page.title?.trim() || t('chat.untitled')
-          : pinBySession.get(sessionId)?.title_snapshot?.trim() || sessionId;
+          : pinBySession.get(sessionId)?.title_snapshot?.trim() || fallbackTitle?.trim() || sessionId;
         return { title, iconVersion: page?.icon_version ?? null };
       },
     [pageBySession, pinBySession, t],
@@ -229,11 +231,15 @@ export const Dock: React.FC = () => {
                         : {
                             // Pinned Show Page: the page's favicon or a letter avatar on a
                             // hashed accent tint (no icon pipeline). §7.1k: the per-session
-                            // accent BORDER is gone (it read as noisy across many pinned
-                            // tiles); the accent survives as the tint + letter color, and
-                            // focus deepens the tint (16%→28%) in place of the removed border.
+                            // accent RESTING border is gone (it read as noisy across many
+                            // pinned tiles); the accent survives as the 16% tint + letter
+                            // color. The FOCUSED tile shows an accent ring (box-shadow, not a
+                            // resting border) — visible even over an opaque favicon, where a
+                            // tint change would be hidden; only one tile is focused at a time,
+                            // so it is not the noisy multi-color resting look §7.1k removed.
                             color: `var(${avatar!.accentVar})`,
-                            backgroundColor: `color-mix(in srgb, var(${avatar!.accentVar}) ${active ? 28 : 16}%, transparent)`,
+                            backgroundColor: `color-mix(in srgb, var(${avatar!.accentVar}) 16%, transparent)`,
+                            boxShadow: active ? `0 0 0 2px var(${avatar!.accentVar})` : undefined,
                           }
                     }
                   >
@@ -302,7 +308,10 @@ export const Dock: React.FC = () => {
           // the typeof check narrows without a possibly-undefined property access.
           const rawSessionId = w.appId === 'showpage' ? w.params?.sessionId : undefined;
           const sessionId = typeof rawSessionId === 'string' && rawSessionId ? rawSessionId : null;
-          const identity = sessionId ? showpageIdentity(sessionId) : null;
+          // Pass w.title as the identity fallback so a persisted minimized window keeps
+          // its real title if the inventory hasn't loaded / failed (Codex P3); the
+          // live/pinned title still wins when available.
+          const identity = sessionId ? showpageIdentity(sessionId, w.title) : null;
           const avatar = sessionId && identity ? showPageAvatar(sessionId, identity.title) : null;
           const label = identity ? identity.title : (w.title ?? t(def.titleKey));
           return (

--- a/ui/src/components/apps/Dock.tsx
+++ b/ui/src/components/apps/Dock.tsx
@@ -41,20 +41,33 @@ export const Dock: React.FC = () => {
   const pinBySession = useMemo(() => new Map(pins.map((pin) => [pin.session_id, pin])), [pins]);
   const pageBySession = useMemo(() => new Map(pages.map((page) => [page.session_id, page])), [pages]);
 
-  const resolveItem = useMemo(() => {
-    return (id: string): ResidentItem | null => {
-      const sessionId = dockIdToSession(id);
-      if (sessionId !== null) {
+  // A Show Page's display identity from the live inventory: title prefers the live
+  // session title, then the pin snapshot, then the session id; icon_version is the
+  // has-icon signal + cache token. Shared by the resident tiles and the minimized
+  // chips so a page reads identically wherever it appears (§7.1k item 2).
+  const showpageIdentity = useMemo(
+    () =>
+      (sessionId: string): { title: string; iconVersion: string | null } => {
         const page = pageBySession.get(sessionId);
         const title = page
           ? page.title?.trim() || t('chat.untitled')
           : pinBySession.get(sessionId)?.title_snapshot?.trim() || sessionId;
-        return { kind: 'showpage', id, sessionId, title, iconVersion: page?.icon_version ?? null };
+        return { title, iconVersion: page?.icon_version ?? null };
+      },
+    [pageBySession, pinBySession, t],
+  );
+
+  const resolveItem = useMemo(() => {
+    return (id: string): ResidentItem | null => {
+      const sessionId = dockIdToSession(id);
+      if (sessionId !== null) {
+        const { title, iconVersion } = showpageIdentity(sessionId);
+        return { kind: 'showpage', id, sessionId, title, iconVersion };
       }
       const def = APP_REGISTRY[id as AppId];
       return def ? { kind: 'builtin', id, def } : null;
     };
-  }, [pageBySession, pinBySession, t]);
+  }, [showpageIdentity]);
 
   // Local, drag-mutable copy of the order; framer's Reorder updates it live, and
   // it re-syncs whenever the server order changes (load / pin / unpin elsewhere).
@@ -199,9 +212,14 @@ export const Dock: React.FC = () => {
                       setMenu({ x: e.clientX, y: e.clientY, item });
                     }}
                     className={clsx(
-                      'grid size-10 place-items-center overflow-hidden rounded-xl border text-[15px] font-bold leading-none transition',
+                      // §7.1k: 12px radius (rounded-lg = --radius-lg = 12px in this theme;
+                      // rounded-xl is 16px here) unified with the App Library / ⌘K tiles.
+                      // No shared `border` here: built-in tiles carry their own neutral
+                      // border (accent only when focused); pinned Show Page tiles are
+                      // borderless — the accent lives in the tint + letter color.
+                      'grid size-10 place-items-center overflow-hidden rounded-lg text-[15px] font-bold leading-none transition',
                       item.kind === 'builtin' &&
-                        (active ? 'border-2 bg-foreground/[0.07]' : 'border-border bg-foreground/[0.03] hover:bg-foreground/[0.07]'),
+                        (active ? 'border-2 bg-foreground/[0.07]' : 'border border-border bg-foreground/[0.03] hover:bg-foreground/[0.07]'),
                     )}
                     style={
                       item.kind === 'builtin'
@@ -209,14 +227,13 @@ export const Dock: React.FC = () => {
                           ? { borderColor: `var(${item.def.accent})` }
                           : undefined
                         : {
-                            // Pinned Show Page: a letter avatar on a hashed accent tint (no icon
-                            // pipeline). Border brightens to the full accent when focused.
+                            // Pinned Show Page: the page's favicon or a letter avatar on a
+                            // hashed accent tint (no icon pipeline). §7.1k: the per-session
+                            // accent BORDER is gone (it read as noisy across many pinned
+                            // tiles); the accent survives as the tint + letter color, and
+                            // focus deepens the tint (16%→28%) in place of the removed border.
                             color: `var(${avatar!.accentVar})`,
-                            backgroundColor: `color-mix(in srgb, var(${avatar!.accentVar}) 16%, transparent)`,
-                            borderWidth: active ? 2 : 1,
-                            borderColor: active
-                              ? `var(${avatar!.accentVar})`
-                              : `color-mix(in srgb, var(${avatar!.accentVar}) 34%, transparent)`,
+                            backgroundColor: `color-mix(in srgb, var(${avatar!.accentVar}) ${active ? 28 : 16}%, transparent)`,
                           }
                     }
                   >
@@ -278,7 +295,16 @@ export const Dock: React.FC = () => {
         {minimized.map((w) => {
           const def = APP_REGISTRY[w.appId];
           const Icon = def.icon;
-          const label = w.title ?? t(def.titleKey);
+          // A showpage window's chip mirrors its Dock tile: the page's OWN icon
+          // (favicon → letter avatar with its accent) and its live title. Every
+          // other app keeps its registry glyph — that IS its icon (§7.1k item 2).
+          // Resolve the sessionId param via a local first (the registry idiom) so
+          // the typeof check narrows without a possibly-undefined property access.
+          const rawSessionId = w.appId === 'showpage' ? w.params?.sessionId : undefined;
+          const sessionId = typeof rawSessionId === 'string' && rawSessionId ? rawSessionId : null;
+          const identity = sessionId ? showpageIdentity(sessionId) : null;
+          const avatar = sessionId && identity ? showPageAvatar(sessionId, identity.title) : null;
+          const label = identity ? identity.title : (w.title ?? t(def.titleKey));
           return (
             <button
               key={w.id}
@@ -296,7 +322,25 @@ export const Dock: React.FC = () => {
                   <span className="size-1 rounded-full" style={{ backgroundColor: '#28c840' }} />
                 </span>
                 <span className="grid flex-1 place-items-center">
-                  <Icon className="size-4" style={{ color: `var(${def.accent})` }} />
+                  {sessionId && avatar ? (
+                    // The page's favicon (else letter avatar on its accent tint) — the
+                    // same shared chokepoint the Dock tile uses, scaled to the chip body.
+                    <span
+                      aria-hidden
+                      className="grid size-5 place-items-center overflow-hidden rounded-md text-[11px] font-bold leading-none"
+                      style={{
+                        color: `var(${avatar.accentVar})`,
+                        backgroundColor: `color-mix(in srgb, var(${avatar.accentVar}) 16%, transparent)`,
+                      }}
+                    >
+                      <ShowPageAvatarContent
+                        iconUrl={showPageIconUrl(sessionId, identity!.iconVersion)}
+                        letter={avatar.letter}
+                      />
+                    </span>
+                  ) : (
+                    <Icon className="size-4" style={{ color: `var(${def.accent})` }} />
+                  )}
                 </span>
               </span>
               <span className="max-w-full truncate text-[10px] leading-tight text-muted">{label}</span>

--- a/ui/src/components/apps/MobileDockDrawer.tsx
+++ b/ui/src/components/apps/MobileDockDrawer.tsx
@@ -172,11 +172,19 @@ export const MobileDockDrawer: React.FC<{ open: boolean; onClose: () => void }> 
                   className="flex select-none flex-col items-center gap-1.5"
                 >
                   <span
-                    className="grid size-14 place-items-center overflow-hidden rounded-2xl border text-[20px] font-bold leading-none"
+                    className="grid size-14 place-items-center overflow-hidden rounded-2xl text-[20px] font-bold leading-none"
                     style={{
                       color: `var(${accentVar})`,
                       backgroundColor: `color-mix(in srgb, var(${accentVar}) ${item.kind === 'builtin' ? 14 : 16}%, transparent)`,
-                      borderColor: `color-mix(in srgb, var(${accentVar}) ${item.kind === 'builtin' ? 30 : 34}%, transparent)`,
+                      // §7.1k sweep: pinned Show Page tiles are borderless (the per-session
+                      // accent border was the owner's noise, matching the desktop Dock);
+                      // built-in tiles keep a subtle fixed-accent border. The tile keeps its
+                      // existing 20px radius (mobile tiles are larger than desktop's 40px, so
+                      // the 12px desktop-tile unification does not apply here).
+                      border:
+                        item.kind === 'builtin'
+                          ? `1px solid color-mix(in srgb, var(${accentVar}) 30%, transparent)`
+                          : undefined,
                     }}
                   >
                     {Icon ? (

--- a/ui/src/components/apps/ShowPageRoute.tsx
+++ b/ui/src/components/apps/ShowPageRoute.tsx
@@ -7,6 +7,7 @@ import { useApi } from '../../context/ApiContext';
 import { useDock } from '../../context/DockContext';
 import { useWindowManager } from '../../context/WindowManagerContext';
 import { showPageAvatar, showPagePrivatePath } from '../../apps/showPageAvatar';
+import { ShowPageAvatarContent } from '../../apps/showPageAvatarTile';
 
 // The `/apps/show/:sessionId` route — a pinned Show Page opened as an app on the
 // current surface. Desktop keeps windows (mirrors LibraryRoute): focus an
@@ -122,14 +123,18 @@ const MobileShowPage: React.FC<{ sessionId: string }> = ({ sessionId }) => {
         {avatar && (
           <span
             aria-hidden
-            className="grid size-7 shrink-0 place-items-center rounded-lg border text-[13px] font-bold leading-none"
+            // §7.1k sweep: borderless — the per-session accent border removed. Keep the 16%
+            // tint + accent letter color and the header's existing 12px radius. Routes the
+            // avatar through the shared ShowPageAvatarContent chokepoint (letter-only here:
+            // this header loads the session, not the icon inventory, so it has no favicon
+            // — §7.1f — but it now shares the one render path if that changes).
+            className="grid size-7 shrink-0 place-items-center overflow-hidden rounded-lg text-[13px] font-bold leading-none"
             style={{
               color: `var(${avatar.accentVar})`,
               backgroundColor: `color-mix(in srgb, var(${avatar.accentVar}) 16%, transparent)`,
-              borderColor: `color-mix(in srgb, var(${avatar.accentVar}) 34%, transparent)`,
             }}
           >
-            {avatar.letter}
+            <ShowPageAvatarContent iconUrl={null} letter={avatar.letter} />
           </span>
         )}
         <span className="min-w-0 flex-1 truncate text-[14px] font-semibold text-foreground">{label}</span>

--- a/ui/src/components/workbench/search/AppSearchResults.tsx
+++ b/ui/src/components/workbench/search/AppSearchResults.tsx
@@ -54,7 +54,9 @@ export const AppSearchResultSection: React.FC<AppSearchResultSectionProps> = ({
                   sessionId={result.sessionId}
                   title={result.title}
                   iconVersion={result.iconVersion}
-                  className="size-7 rounded-md"
+                  // §7.1k: size-only override — the radius stays the shared 12px
+                  // (rounded-lg) from the tile, no per-surface radius override.
+                  className="size-7"
                 />
               ) : (
                 <span


### PR DESCRIPTION
## Capability

Dock visual polish (§7.1k): calmer, consistent Show Page tiles and truthful minimized-window icons. Spec: `docs/plans/dock-pinned-show-page-apps.md` §7.1k (first commit).

### 1. Tile radius + accent borders
The per-session accent BORDERS on Show Page tiles ("有的绿有的紫") read as noisy, and the Dock tile rounding was too heavy.
- **Accent border removed** at the shared avatar chokepoint `ShowPageAvatarTile` (App Library rows + ⌘K) and the Dock resident tile. The accent survives only as the **16% background tint + accent letter color**.
- **Radius unified to 12px** across Dock / App Library / ⌘K — no per-surface overrides (owner 16:04). Built-in Dock tiles keep their own neutral/active border.

### 2. Minimized-window chips use the app's real icon
`showpage` windows render the page's own icon via the shared `ShowPageAvatarContent` (favicon `<img>`, else the letter avatar) — same identity + live title as the Dock tile; built-ins keep their registry glyph.

## 3. Accent-border sweep (§7.1k 统一处理 — round 3)
Owner ask: one look everywhere. Swept the per-session accent border off **every** remaining showpage-avatar surface (not just Dock/Library/⌘K). Each swept element **keeps its existing proportional radius** — these are small chips / headers / larger mobile tiles, and 12px on a ~16–28px chip reads as a circle (changes identity); the 12px unification is for desktop **tile-sized** surfaces (already covered above):

| Surface | Element | Radius kept | Change |
|---|---|---|---|
| `AppWindow.tsx` | title-bar chip (`size-4`) | `rounded-[4px]` | border removed; 16% tint + letter kept (already used `ShowPageAvatarContent`) |
| `ShowPageRoute.tsx` | mobile header avatar (`size-7`) | `rounded-lg` | border removed; **routed through `ShowPageAvatarContent`** (letter-only — no inventory/favicon here, §7.1f) |
| `MobileDockDrawer.tsx` | mobile-dock tile (`size-14`) | `rounded-2xl` | showpage tiles **borderless** (matching desktop); built-in tiles keep a subtle fixed-accent border |

**End-of-life grep** (`color-mix …34%` + `borderColor …accent` across `ui/src`): **swept 5 spots total** (chokepoint + Dock tile in the first commits; these 3 now) — **remaining showpage-avatar accent resting borders: none.** Intentionally kept (NOT the swept class): `Dock.tsx:229` built-in **active** focus border (fixed accent, focused tile only) and `MobileDockDrawer` built-in **resting** border (fixed per-app accent, not the per-session showpage noise).

## ⚠️ Radius class is `rounded-lg` (=12px here), NOT `rounded-xl`
This UI overrides the radius scale in `@theme` (`ui/src/index.css`): compiled `.rounded-lg{border-radius:12px}`, `.rounded-xl{border-radius:16px}`. The owner's **12px** target = `rounded-lg`; `rounded-xl` would be 16px (the "too-heavy" current value). Orchestrator-accepted.

## Evidence
- **Unit (vitest):** new `ShowPageAvatarTile` borderless test; full suite **258/258**.
- **Build:** `tsc -b && vite build` clean. **Lint:** `eslint` clean on changed files.
- **Review:** R1 → 3 P3 findings fixed (chip `w.title` fallback · ⌘K `rounded-md` override removed · favicon-visible focus ring) + threads resolved → R2 clean pass → R3 = this sweep.
- **Contract / scenario:** n/a (frontend-only; no backend, no scenario catalog).
- **Residual manual (PM live CDP on regression post-merge):** ① Dock tile drag works for icon & letter tiles (§7.1i — tile children/press target unchanged); ② minimized chip shows favicon/letter/registry per kind; ③ 12px + borderless across Dock/Library/⌘K, and borderless showpage avatars in the window title bar, mobile header, and mobile drawer; ④ focused showpage Dock tile ring visible over favicons.

## Known-by-design ledger
- Accent border removed at the shared chokepoint (Dock + Library + ⌘K) **and** swept off every other showpage-avatar surface (window title-bar, mobile header, mobile drawer) for one look everywhere; letter avatar (not a generic glyph) is the no-icon fallback.
- Radius is `rounded-lg` (12px), not `rounded-xl` (16px in this theme).
- Focused Dock showpage tile uses an accent **ring** (box-shadow) — visible over opaque favicons, only on the focused tile (not the noisy resting look).
- Swept elements keep their **existing** proportional radius (4px / 12px / 20px); the 12px unification is desktop-tile-scoped.
- `MobileDockDrawer` built-in tiles keep a 30% fixed-accent border (pre-existing mobile treatment, not the per-session showpage noise) — flag if you want mobile built-ins neutralized to match desktop's neutral border.
- Minimized-chip label uses the live session title for showpage windows, falling back to the window's own title (survives an unloaded/failed inventory) then the session id.

## Scope
`docs/plans/dock-pinned-show-page-apps.md`, `ui/src/apps/showPageAvatarTile.tsx` (+ `.test`), `ui/src/components/apps/Dock.tsx`, `ui/src/components/workbench/search/AppSearchResults.tsx` (⌘K radius, amendment-driven), `ui/src/components/apps/AppWindow.tsx`, `ui/src/components/apps/ShowPageRoute.tsx`, `ui/src/components/apps/MobileDockDrawer.tsx` (sweep; AppSearchResults + these 3 granted by the orchestrator). Lockfile untouched.
