### PR TITLE
fix(pwa): preserve back navigation after route restore

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -389,6 +389,8 @@ const DocumentTitle = () => {
 // launch; later in-app navigation to `/` must still reach the workbench canvas.
 const PwaRouteMemory = () => {
   const location = useLocation();
+  const navigate = useNavigate();
+  const restoreStartedRef = useRef(false);
   const [launch] = useState(() => {
     const iosStandalone = isIosDevice() && isStandalonePwa();
     return {
@@ -424,14 +426,26 @@ const PwaRouteMemory = () => {
 
   useEffect(() => {
     if (!launch.iosStandalone || launchRestorePath === undefined) return;
-    // Do not overwrite the remembered destination while <Navigate> is still
-    // replacing the manifest start URL (including StrictMode's second effect).
-    if (restoringLaunch) return;
+    // Do not overwrite the remembered destination before the one-shot restore
+    // starts. Once it has, returning to this root is real user navigation and
+    // must remember `/` instead of immediately restoring the old page again.
+    if (restoringLaunch && !restoreStartedRef.current) return;
 
     writeLastPwaPath(location.pathname);
   }, [launch.iosStandalone, launchRestorePath, location.pathname, restoringLaunch]);
 
-  return restorePath ? <Navigate to={restorePath} replace /> : null;
+  // Keep the manifest root underneath the restored page. Replacing that first
+  // entry strands a cold-launched PWA on the restored route: neither the chat
+  // back button nor iOS's edge-swipe has an in-app history entry to return to.
+  // The ref makes this one-shot even when the user later returns to the launch
+  // entry and while React StrictMode replays effects in development.
+  useEffect(() => {
+    if (!restorePath || restoreStartedRef.current) return;
+    restoreStartedRef.current = true;
+    navigate(restorePath);
+  }, [navigate, restorePath]);
+
+  return null;
 };
 
 function RouterRoot() {

--- a/ui/src/components/workbench/ChatPage.tsx
+++ b/ui/src/components/workbench/ChatPage.tsx
@@ -33,6 +33,7 @@ import { Markdown } from '../ui/markdown';
 import { VaultApprovalFloat, VaultChatRequests } from '../ui/vault-chat-requests';
 import { StatusPill } from '../visual';
 import { usePendingVaultRequests } from '../../lib/usePendingVaultRequests';
+import { hasInAppBackEntry } from '../../lib/navigationHistory';
 import { Composer, type ComposerAttachment, type ComposerHandle, type ComposerProps } from './Composer';
 import type { MentionReference } from '../../lib/mentions';
 import { QuickReplies } from './QuickReplies';
@@ -235,13 +236,13 @@ export const ChatPage: React.FC = () => {
   );
   const [offscreenApprovals, setOffscreenApprovals] = useState<VaultRequest[]>([]);
 
-  // Back returns to the page the user came from, not a hardcoded inbox.
-  // location.key === 'default' means /chat was the first history entry (deep
-  // link / refresh) with nothing to pop back to — fall back to the inbox then.
+  // Back returns to the page the user came from, not a hardcoded inbox. The
+  // history index is the source of truth: replaceState can assign a non-default
+  // location key without creating an entry that can actually be popped.
   const goBack = useCallback(() => {
-    if (location.key !== 'default') navigate(-1);
+    if (hasInAppBackEntry(window.history.state)) navigate(-1);
     else navigate('/inbox');
-  }, [location.key, navigate]);
+  }, [navigate]);
 
   const [agents, setAgents] = useState<VibeAgentBrief[]>([]);
   const [defaultAgentName, setDefaultAgentName] = useState<string | null>(null);

--- a/ui/src/lib/navigationHistory.test.ts
+++ b/ui/src/lib/navigationHistory.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+
+import { hasInAppBackEntry } from './navigationHistory';
+
+describe('browser navigation history', () => {
+  it('allows back navigation only when React Router has an earlier in-app entry', () => {
+    expect(hasInAppBackEntry({ idx: 1 })).toBe(true);
+    expect(hasInAppBackEntry({ idx: 0 })).toBe(false);
+    expect(hasInAppBackEntry({ idx: -1 })).toBe(false);
+  });
+
+  it('treats missing or malformed history state as a direct entry', () => {
+    expect(hasInAppBackEntry(null)).toBe(false);
+    expect(hasInAppBackEntry({})).toBe(false);
+    expect(hasInAppBackEntry({ idx: '1' })).toBe(false);
+  });
+});

--- a/ui/src/lib/navigationHistory.ts
+++ b/ui/src/lib/navigationHistory.ts
@@ -1,0 +1,6 @@
+export function hasInAppBackEntry(historyState: unknown): boolean {
+  if (!historyState || typeof historyState !== 'object') return false;
+
+  const index = (historyState as { idx?: unknown }).idx;
+  return typeof index === 'number' && Number.isFinite(index) && index > 0;
+}


### PR DESCRIPTION
## Summary

- push the remembered PWA page on top of the manifest root instead of replacing the only history entry
- make cold-launch restoration one-shot so returning to `/` does not immediately reopen the remembered page
- make the Chat back button inspect React Router's actual history index and fall back to Inbox for direct or legacy replaced entries

## Evidence

- Unit: full UI Vitest suite passed, 37 files / 270 tests
- Contract: navigation history tests cover poppable, root, negative, missing, and malformed history indexes
- Scenario catalog: no existing PWA navigation scenario IDs are affected
- Browser: iOS standalone emulation restored `/chat/session-123` at history index 1; browser back returned to `/` at index 0 and persisted `/`
- Build: `npm run build` passed
- Lint: new helper and tests pass focused ESLint; changed large components retain the existing repository lint baseline findings

## Residual checks

- verify cold-launch restore, header back, and edge-swipe on a real iOS Home Screen install
