### PR TITLE
fix(vaults): poll requests only when events disconnect

### DIFF
--- a/ui/src/components/workbench/VaultsPage.tsx
+++ b/ui/src/components/workbench/VaultsPage.tsx
@@ -21,8 +21,8 @@ import { VaultRequestSessionLink, vaultRequestSessionDisplay } from '../ui/vault
 import { VaultSecretDialog } from '../ui/vault-secret-dialog';
 import { VaultSettingsDialog } from '../ui/vault-settings-dialog';
 import { useProtectedVault } from '../../lib/useProtectedVault';
+import { useVaultRequestRefresh } from '../../lib/useVaultRequestRefresh';
 
-const PENDING_REQUEST_POLL_INTERVAL_MS = 5000;
 const PENDING_REQUEST_EXPIRY_GRACE_MS = 100;
 const MAX_BROWSER_TIMEOUT_MS = 2_147_483_647;
 
@@ -315,10 +315,10 @@ const RequestRow: React.FC<{ request: VaultRequest; onReview: (request: VaultReq
 };
 
 /**
- * Pending approvals strip for the hub: lists requests an agent is waiting on, polls for
- * new ones, and opens the full {@link VaultApprovalCard} in a dialog to approve or deny.
- * Best-effort — a requests fetch failure (e.g. an older backend without the route) must
- * not surface an error or blank the rest of the hub.
+ * Pending approvals strip for the hub: lists requests an agent is waiting on,
+ * follows Vault events with disconnected polling as a fallback, and opens the
+ * full {@link VaultApprovalCard} in a dialog to approve or deny. Best-effort —
+ * a requests fetch failure must not surface an error or blank the rest of the hub.
  */
 const PendingRequestsSection: React.FC<{
   onResolved: () => void;
@@ -334,8 +334,8 @@ const PendingRequestsSection: React.FC<{
 
   const load = useCallback(async () => {
     try {
-      // Best-effort with suppressed errors so an older backend without the route doesn't
-      // spam global toasts on every 5s poll.
+      // Best-effort with suppressed errors so an older backend without the route
+      // does not spam global toasts while fallback polling is active.
       const res = await api.getVaultRequests({ status: 'pending' }, { handleError: false });
       const pending = (res.requests ?? []).filter((r) => {
         const type = requestReviewType(r);
@@ -348,72 +348,7 @@ const PendingRequestsSection: React.FC<{
     }
   }, [api]);
 
-  useEffect(() => {
-    load();
-  }, [load]);
-
-  useEffect(() => {
-    return api.connectWorkbenchEvents({
-      onConnected: (data) => {
-        if (data.source === 'controller') {
-          load();
-        }
-      },
-      onEventBridgeStatus: ({ connected }) => {
-        if (connected) load();
-      },
-      onVaultsUpdated: () => load(),
-    });
-  }, [api, load]);
-
-  useEffect(() => {
-    // CLI-created requests can arrive without a browser bridge event, so keep
-    // a light fallback poll even when SSE is connected.
-    let timer: number | undefined;
-    let cancelled = false;
-    let inFlight = false;
-    let pendingWake = false;
-
-    const tick = async () => {
-      if (cancelled) return;
-      if (document.visibilityState !== 'visible') {
-        timer = window.setTimeout(tick, PENDING_REQUEST_POLL_INTERVAL_MS);
-        return;
-      }
-      if (inFlight) {
-        pendingWake = true;
-        return;
-      }
-      inFlight = true;
-      window.clearTimeout(timer);
-      try {
-        await load();
-      } finally {
-        inFlight = false;
-      }
-      if (cancelled) return;
-      if (pendingWake) {
-        pendingWake = false;
-        void tick();
-        return;
-      }
-      timer = window.setTimeout(tick, PENDING_REQUEST_POLL_INTERVAL_MS);
-    };
-
-    const refreshNow = () => {
-      if (document.visibilityState === 'visible') void tick();
-    };
-
-    void tick();
-    document.addEventListener('visibilitychange', refreshNow);
-    window.addEventListener('focus', refreshNow);
-    return () => {
-      cancelled = true;
-      window.clearTimeout(timer);
-      document.removeEventListener('visibilitychange', refreshNow);
-      window.removeEventListener('focus', refreshNow);
-    };
-  }, [load]);
+  useVaultRequestRefresh(load);
 
   useEffect(() => {
     const expiresAt = earliestRequestExpiry(requests);

--- a/ui/src/lib/usePendingVaultRequests.ts
+++ b/ui/src/lib/usePendingVaultRequests.ts
@@ -1,15 +1,14 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { useApi, type VaultRequest } from '@/context/ApiContext';
-
-const PENDING_REQUEST_POLL_INTERVAL_MS = 5000;
+import { useVaultRequestRefresh } from '@/lib/useVaultRequestRefresh';
 
 /**
- * Pending vault requests (access/sign/provision) for one chat session. Fed by the workbench SSE
- * (`vaults.updated`) plus a visibility-aware poll that runs even while SSE is connected — CLI/
- * agent-created requests can arrive without a browser bridge event (mirrors VaultsPage). A timer
- * also refreshes at the earliest visible `expires_at` (expiry emits no event). Lifted into a hook
- * so the in-scroll cards and the floating approval bar share one source.
+ * Pending vault requests (access/sign/provision) for one chat session. Fed by
+ * `vaults.updated`, with polling only when the controller event bridge is down.
+ * A timer also refreshes at the earliest visible `expires_at` because expiry
+ * emits no event. Lifted into a hook so the in-scroll cards and floating
+ * approval bar share one source.
  */
 export function usePendingVaultRequests(sessionId: string): { requests: VaultRequest[]; refresh: () => void } {
   const api = useApi();
@@ -55,62 +54,7 @@ export function usePendingVaultRequests(sessionId: string): { requests: VaultReq
     }
   }, [api, sessionId]);
 
-  useEffect(() => {
-    return api.connectWorkbenchEvents({
-      onConnected: (data) => {
-        if (data.source === 'controller') void load();
-      },
-      onEventBridgeStatus: ({ connected }) => {
-        if (connected) void load();
-      },
-      onVaultsUpdated: () => void load(),
-    });
-  }, [api, load]);
-
-  // Non-stacking recursive poll; also refreshes immediately on tab focus / visibility.
-  useEffect(() => {
-    let timer: number | undefined;
-    let cancelled = false;
-    let inFlight = false;
-    let pendingWake = false;
-    const tick = async () => {
-      if (cancelled) return;
-      if (document.visibilityState !== 'visible') {
-        timer = window.setTimeout(tick, PENDING_REQUEST_POLL_INTERVAL_MS);
-        return;
-      }
-      if (inFlight) {
-        pendingWake = true;
-        return;
-      }
-      inFlight = true;
-      window.clearTimeout(timer);
-      try {
-        await load();
-      } finally {
-        inFlight = false;
-      }
-      if (cancelled) return;
-      if (pendingWake) {
-        pendingWake = false;
-        void tick();
-        return;
-      }
-      timer = window.setTimeout(tick, PENDING_REQUEST_POLL_INTERVAL_MS);
-    };
-    const refreshNow = () => {
-      if (document.visibilityState === 'visible') void tick();
-    };
-    void tick();
-    document.addEventListener('visibilitychange', refreshNow);
-    window.addEventListener('focus', refreshNow);
-    return () => {
-      cancelled = true;
-      window.clearTimeout(timer);
-      document.removeEventListener('visibilitychange', refreshNow);
-      window.removeEventListener('focus', refreshNow);
-    };
-  }, [load]);
+  useVaultRequestRefresh(load);
 
   // Expiry has no SSE event → refresh at the earliest visible expires_at.
   useEffect(() => {

--- a/ui/src/lib/useVaultRequestRefresh.test.ts
+++ b/ui/src/lib/useVaultRequestRefresh.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'vitest';
+
+import { shouldPollVaultRequests } from './useVaultRequestRefresh';
+
+describe('Vault request refresh mode', () => {
+  it('polls only while the controller event bridge is unavailable', () => {
+    expect(shouldPollVaultRequests(false)).toBe(true);
+    expect(shouldPollVaultRequests(true)).toBe(false);
+  });
+});

--- a/ui/src/lib/useVaultRequestRefresh.ts
+++ b/ui/src/lib/useVaultRequestRefresh.ts
@@ -1,0 +1,79 @@
+import { useEffect, useState } from 'react';
+
+import { useApi } from '@/context/ApiContext';
+
+const FALLBACK_POLL_INTERVAL_MS = 5000;
+
+export function shouldPollVaultRequests(eventBridgeConnected: boolean): boolean {
+  return !eventBridgeConnected;
+}
+
+/**
+ * Refresh pending Vault requests from `vaults.updated` while the controller
+ * event bridge is healthy, with visibility-aware polling only as a degraded
+ * fallback. The immediate fallback tick also supplies the initial snapshot.
+ */
+export function useVaultRequestRefresh(refresh: () => void | Promise<void>): void {
+  const api = useApi();
+  const [eventBridgeConnected, setEventBridgeConnected] = useState(false);
+
+  useEffect(() => {
+    return api.connectWorkbenchEvents({
+      onEventBridgeStatus: ({ connected }) => {
+        setEventBridgeConnected(connected);
+        if (connected) void refresh();
+      },
+      onError: () => setEventBridgeConnected(false),
+      onVaultsUpdated: () => void refresh(),
+    });
+  }, [api, refresh]);
+
+  useEffect(() => {
+    if (!shouldPollVaultRequests(eventBridgeConnected)) return;
+
+    let timer: number | undefined;
+    let cancelled = false;
+    let inFlight = false;
+    let pendingWake = false;
+
+    const tick = async () => {
+      if (cancelled) return;
+      if (document.visibilityState !== 'visible') {
+        timer = window.setTimeout(tick, FALLBACK_POLL_INTERVAL_MS);
+        return;
+      }
+      if (inFlight) {
+        pendingWake = true;
+        return;
+      }
+      inFlight = true;
+      window.clearTimeout(timer);
+      try {
+        await refresh();
+      } finally {
+        inFlight = false;
+      }
+      if (cancelled) return;
+      if (pendingWake) {
+        pendingWake = false;
+        void tick();
+        return;
+      }
+      timer = window.setTimeout(tick, FALLBACK_POLL_INTERVAL_MS);
+    };
+
+    const refreshNow = () => {
+      if (document.visibilityState === 'visible') void tick();
+    };
+
+    void tick();
+    document.addEventListener('visibilitychange', refreshNow);
+    window.addEventListener('focus', refreshNow);
+    return () => {
+      cancelled = true;
+      window.clearTimeout(timer);
+      document.removeEventListener('visibilitychange', refreshNow);
+      window.removeEventListener('focus', refreshNow);
+    };
+  }, [eventBridgeConnected, refresh]);
+}


### PR DESCRIPTION
## Summary

- centralize pending Vault request refresh behavior for Chat and the Vaults hub
- consume `vaults.updated` while the controller event bridge is connected
- retain the visibility-aware 5-second poll only as a degraded fallback while the bridge is unavailable
- keep the existing one-shot expiry timers because request expiry does not emit an event

## Evidence

- Unit: full UI Vitest suite passed, 37 files / 269 tests
- Contract: focused refresh-mode test asserts polling is disabled while the controller event bridge is connected
- Scenario catalog: no existing Vault scenario IDs are affected
- Browser: mocked connected controller SSE held `/api/vault/requests` at 2 initial StrictMode requests for 11 seconds; disconnect resumed polling, reconnect refreshed once, then remained steady for another 6 seconds
- Build: `npm run build` passed
- Lint: the new shared hook and test pass focused ESLint; touched existing surfaces retain only their pre-existing React lint baseline findings

## Residual checks

- verify a real CLI-created access/sign/provision request appears immediately through `vaults.updated` in Chat and the Vaults hub
