### PR TITLE
fix(runtime): serialize migrations and delay upgrade reload

### DIFF
--- a/storage/migrations.py
+++ b/storage/migrations.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 import sqlite3
 import logging
+import threading
 from importlib import import_module
 from pathlib import Path
 from types import SimpleNamespace
@@ -17,6 +18,11 @@ from storage.db import create_sqlite_engine, sqlite_url
 
 
 logger = logging.getLogger(__name__)
+
+# Alembic's EnvironmentContext installs module-level proxies while an upgrade
+# runs. Concurrent store initialization can otherwise tear down another
+# thread's proxy and surface errors such as KeyError("config").
+_MIGRATION_LOCK = threading.RLock()
 
 INITIAL_REVISION = "20260501_0001"
 LATEST_SCHEMA_REVISION = "20260622_0023"
@@ -143,6 +149,20 @@ def run_migrations(
 ) -> None:
     target_db = (db_path or paths.get_sqlite_state_path()).expanduser().resolve()
     guard_source_checkout_default_state_migration(target_db)
+    with _MIGRATION_LOCK:
+        _run_migrations_locked(
+            target_db,
+            revision=revision,
+            prune_backups_after_upgrade=prune_backups_after_upgrade,
+        )
+
+
+def _run_migrations_locked(
+    target_db: Path,
+    *,
+    revision: str,
+    prune_backups_after_upgrade: bool,
+) -> None:
     cfg = alembic_config(target_db)
     backup_revisions = _migration_backup_revisions(target_db, cfg, revision)
     if backup_revisions is not None:

--- a/tests/test_sqlite_state_migration.py
+++ b/tests/test_sqlite_state_migration.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+from concurrent.futures import ThreadPoolExecutor
 import json
 import re
 import sqlite3
+import threading
 from pathlib import Path
 
 import pytest
@@ -131,6 +133,47 @@ def test_run_migrations_creates_initial_schema(tmp_path: Path) -> None:
         assert "deleted_at" in background_columns
         version = conn.execute("select version_num from alembic_version").fetchone()
         assert version == (HEAD_REVISION,)
+
+
+def test_run_migrations_serializes_alembic_context(monkeypatch, tmp_path: Path) -> None:
+    first_entered = threading.Event()
+    second_entered = threading.Event()
+    release_first = threading.Event()
+    calls: list[Path] = []
+
+    def fake_run_locked(
+        target_db: Path,
+        *,
+        revision: str,
+        prune_backups_after_upgrade: bool,
+    ) -> None:
+        assert revision == "head"
+        assert prune_backups_after_upgrade is True
+        calls.append(target_db)
+        if len(calls) == 1:
+            first_entered.set()
+            assert release_first.wait(2)
+        else:
+            second_entered.set()
+
+    monkeypatch.setattr(migrations, "_run_migrations_locked", fake_run_locked)
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        first = pool.submit(run_migrations, tmp_path / "first.sqlite")
+        assert first_entered.wait(2)
+        second = pool.submit(run_migrations, tmp_path / "second.sqlite")
+        try:
+            assert not second_entered.wait(0.1)
+        finally:
+            release_first.set()
+        first.result(timeout=2)
+        second.result(timeout=2)
+
+    assert second_entered.is_set()
+    assert calls == [
+        (tmp_path / "first.sqlite").resolve(),
+        (tmp_path / "second.sqlite").resolve(),
+    ]
 
 
 def test_run_migrations_blocks_source_checkout_default_user_state(monkeypatch, tmp_path: Path) -> None:

--- a/ui/src/components/VersionBadge.tsx
+++ b/ui/src/components/VersionBadge.tsx
@@ -7,6 +7,7 @@ import { ToggleSwitch } from './settings/SettingsPrimitives';
 import { Button } from './ui/button';
 import { badgeVariants } from './ui/badge';
 import { cn } from '@/lib/utils';
+import { scheduleUpgradeReload } from '../lib/upgradeReload';
 
 // Dev / regression builds carry long versions like
 // `3.0.1.dev33+g1df6865a1.d20260608`. Collapse to the release core
@@ -91,9 +92,9 @@ export const VersionBadge: React.FC<{ openUpward?: boolean }> = ({ openUpward = 
       if (result.ok) {
         if (result.restarting) {
           setRestarting(true);
-          setTimeout(() => {
+          scheduleUpgradeReload(() => {
             window.location.reload();
-          }, 4000);
+          });
         } else {
           setTimeout(() => checkVersion(), 1000);
         }

--- a/ui/src/lib/upgradeReload.test.ts
+++ b/ui/src/lib/upgradeReload.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  scheduleUpgradeReload,
+  UPGRADE_RELOAD_DELAY_MS,
+} from './upgradeReload';
+
+describe('scheduleUpgradeReload', () => {
+  it('waits 30 seconds after an upgrade requests a restart', async () => {
+    vi.useFakeTimers();
+    const reload = vi.fn();
+    try {
+      scheduleUpgradeReload(reload, (callback, delayMs) => setTimeout(callback, delayMs));
+
+      expect(UPGRADE_RELOAD_DELAY_MS).toBe(30_000);
+      await vi.advanceTimersByTimeAsync(29_999);
+      expect(reload).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(1);
+      expect(reload).toHaveBeenCalledOnce();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/ui/src/lib/upgradeReload.ts
+++ b/ui/src/lib/upgradeReload.ts
@@ -1,0 +1,10 @@
+export const UPGRADE_RELOAD_DELAY_MS = 30_000;
+
+type ReloadScheduler = (callback: () => void, delayMs: number) => unknown;
+
+export function scheduleUpgradeReload(
+  reload: () => void,
+  schedule: ReloadScheduler = (callback, delayMs) => window.setTimeout(callback, delayMs),
+): void {
+  schedule(reload, UPGRADE_RELOAD_DELAY_MS);
+}


### PR DESCRIPTION
## Summary

- serialize all in-process Alembic upgrades so parallel Web bootstrap requests cannot corrupt Alembic's module-level context and surface `KeyError("config")`
- wait 30 seconds after a successful self-update requests a restart before reloading the Web UI, avoiding the normal service startup window
- add focused concurrency and reload-timing regression coverage

## Capability and scenarios

Changed capabilities:

- SQLite schema bootstrap under concurrent Store initialization
- Web self-update restart handoff

Scenario catalog: N/A (no cataloged scenario IDs cover these runtime boundaries).

## Evidence

- Unit: focused SQLite migration serialization tests pass
- Unit: Vitest proves no reload at 29,999 ms and one reload at 30,000 ms
- Contract: four real concurrent `run_migrations` callers completed successfully; Ruff and changed-file ESLint pass
- Scenario: Playwright browser clock observed zero navigation before 30 seconds and one navigation at 30 seconds
- Build: `npm run build` passes
- Residual manual: a full self-update is intentionally deferred because it would mutate the local installed runtime; CI and the existing regression environment cover packaging/startup integration

## Known by design

- The 30-second delay is measured from the successful upgrade response that reports `restarting: true`.
- Migration execution is serialized process-wide, including different SQLite files, because Alembic's environment proxy is process-global.
