### PR TITLE
docs(design): update shared source location

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -248,7 +248,7 @@ Source-of-truth rule:
 - source lives in `ui/`; build with `cd ui && npm run build`; `ui/dist/` is served by `vibe/ui_server.py`
 - reuse `ui/src/components/ui/` primitives first (`Button`, `Badge`, `Card`, `Input`, `Popover`, `Dialog`, etc.); extend via variants/sizes/props before creating new primitives
 - follow the reuse ladder for UI and shared backend logic: inventory existing patterns -> reuse -> extend -> promote near-duplicates -> create a reusable unit only when needed; extract on the third repeat
-- `design.pen` is the visual source of truth; map spacing, type, radius, color, and shadow to exact tokens/classes, add missing tokens instead of hardcoding, and verify against the exported frame when visual fidelity matters
+- `../avibe-docs/design.pen` is the visual source of truth; map spacing, type, radius, color, and shadow to exact tokens/classes, add missing tokens instead of hardcoding, and verify against the exported frame when visual fidelity matters
 - installed `vibe` uses packaged UI assets, not raw repo `ui/dist/`; for packaged CLI/UI preview, build UI and reinstall from a normal wheel, not `uv tool install --force --editable .`
 - do not run editable installs against system Python, and do not restart local `vibe` for UI checks unless the user explicitly requests that local-service workflow
 

--- a/docs/plans/rebrand-avibe.md
+++ b/docs/plans/rebrand-avibe.md
@@ -246,8 +246,8 @@ Some references are likely mixed-purpose and need per-occurrence judgment:
 
 Scope: `vibe-remote` task worktree, `avibe-bot-backend`, and `avibe-docs`.
 Generated/build folders were excluded (`.git`, `node_modules`, `.next`, `dist`,
-`build`, `.venv`, `__pycache__`). The project-level `design.pen` and unrelated
-parallel worktrees were not counted in this text sweep.
+`build`, `.venv`, `__pycache__`). The shared `avibe-docs/design.pen` and
+unrelated parallel worktrees were not counted in this text sweep.
 
 Token totals:
 

--- a/docs/plans/vaults-design-alignment.md
+++ b/docs/plans/vaults-design-alignment.md
@@ -12,7 +12,7 @@ before merge.
 ## Source of truth
 
 `design.pen` (open via the `pencil` MCP tools, `filePath:
-/Users/cyh/vibe-remote-project/design.pen`). Exported reference PNGs are in
+/Users/cyh/vibe-remote-project/avibe-docs/design.pen`). Exported reference PNGs are in
 `/tmp/vault-design/`. For each surface, BOTH read the PNG and read the frame via
 `batch_get` (high `readDepth`, `resolveVariables: true`) to get exact copy,
 spacing, colors, radii. Map every value to a UI token/class; add a token if one

--- a/docs/plans/vaults-design-alignment.md
+++ b/docs/plans/vaults-design-alignment.md
@@ -11,8 +11,9 @@ before merge.
 
 ## Source of truth
 
-`design.pen` (open via the `pencil` MCP tools, `filePath:
-/Users/cyh/vibe-remote-project/avibe-docs/design.pen`). Exported reference PNGs are in
+`design.pen` lives at `../avibe-docs/design.pen` relative to this repository.
+Open it through the `pencil` MCP tools, resolving that checkout-relative path
+to an absolute `filePath` when required. Exported reference PNGs are in
 `/tmp/vault-design/`. For each surface, BOTH read the PNG and read the frame via
 `batch_get` (high `readDepth`, `resolveVariables: true`) to get exact copy,
 spacing, colors, radii. Map every value to a UI token/class; add a token if one

--- a/docs/plans/workbench-skills-page.md
+++ b/docs/plans/workbench-skills-page.md
@@ -2,7 +2,7 @@
 
 > **Branch**: `feature/workbench-skills` (from `origin/master` @ `88c8afe`)
 > **Status**: Design finalized 2026-05-30 — ready to build.
-> **Design source of truth**: `design.pen` (project root) — frames listed in §2. Read them via the `pencil` MCP tools, not text.
+> **Design source of truth**: `../avibe-docs/design.pen` — frames listed in §2. Read them via the `pencil` MCP tools, not text.
 > **Owner**: cyhhao
 > **Core principle**: extreme reuse + first-principles. Reuse a primitive → extend it → only then build new. Never re-roll a one-off variant inline. **Pixel-perfect 1:1 with the design is a hard requirement** (see §8).
 


### PR DESCRIPTION
## What changed

- Point Avibe contributor guidance and historical implementation plans at the shared design source in `avibe-docs/design.pen`.
- Remove the stale project-root absolute path so future visual verification opens the versioned file.

## Evidence

- Unit: not applicable; documentation-only path updates.
- Contract: exact-path reference sweep found no remaining old location in this branch.
- Scenario: not applicable; no runtime behavior changed.
- Residual manual: none after the AVIBE Docs source PR is merged.

## Dependencies

- Requires avibe-bot/avibe-docs#7 to land first.
