### PR TITLE
docs(portability): remove personal machine paths

### DIFF
--- a/assets/mascot/prompts/P1_initial_3candidates.md
+++ b/assets/mascot/prompts/P1_initial_3candidates.md
@@ -38,8 +38,8 @@
 
 ## 输出
 - 用 OpenAI 的 gpt-image-1 模型(images.generate API)生成
-- 保存到 /Users/cyh/vibe-remote-project/mascot/ 下,文件名分别是 cloud-tuanzi.png, mist-tuanzi.png, smoke-tuanzi.png
-- 完成后告诉我三张图的完整路径
+- 保存到仓库的 `assets/mascot/` 目录下,文件名分别是 cloud-tuanzi.png, mist-tuanzi.png, smoke-tuanzi.png
+- 完成后告诉我三张图的仓库相对路径
 
 如果 OPENAI_API_KEY 没有设置,请先检查环境(env | grep OPENAI 或 echo $OPENAI_API_KEY),并报告问题。如果 API key 可用就直接生成。
 

--- a/assets/mascot/prompts/P2_retry_builtin_imagegen.md
+++ b/assets/mascot/prompts/P2_retry_builtin_imagegen.md
@@ -37,8 +37,8 @@ Vibe Remote 是把 AI agent 接入 Slack/Discord/Telegram/飞书/微信的中间
 
 ## 输出
 为每张图都用一次内置 image_gen 工具调用。生成完成后,把三张图分别复制/移动到这三个路径(因为这是项目相关资产):
-- /Users/cyh/vibe-remote-project/mascot/cloud-tuanzi.png
-- /Users/cyh/vibe-remote-project/mascot/mist-tuanzi.png
-- /Users/cyh/vibe-remote-project/mascot/smoke-tuanzi.png
+- assets/mascot/cloud-tuanzi.png
+- assets/mascot/mist-tuanzi.png
+- assets/mascot/smoke-tuanzi.png
 
-最后告诉我三张图的最终路径。
+最后告诉我三张图的仓库相对路径。

--- a/assets/mascot/prompts/P4_full_9image_set.md
+++ b/assets/mascot/prompts/P4_full_9image_set.md
@@ -1,12 +1,12 @@
 # P4 — full 9-image set: 6 emojis + 2 logos + 1 dark
 # Codex session: 14:14:18 (rollout-2026-05-03T14-14-18-019dec79-3024-7c52-9fbb-c8eb22e8e00b.jsonl)
 
-基于参考图 /Users/cyh/vibe-remote-project/mascot/cloud-tuanzi.png(白色蓬松圆滚滚的棉花糖云团 + 一对黑色圆豆豆眼 + 内部柔和的淡彩色光晕,温和友好,治愈系扁平卡通风格),需要出一整套衍生素材。
+基于参考图 `assets/mascot/cloud-tuanzi.png`(白色蓬松圆滚滚的棉花糖云团 + 一对黑色圆豆豆眼 + 内部柔和的淡彩色光晕,温和友好,治愈系扁平卡通风格),需要出一整套衍生素材。
 
 ## 操作流程
 1. 先用 view_image 加载参考图
 2. 然后用内置 image_gen(不需要 OPENAI_API_KEY,**不要用 CLI fallback**)逐张生成下面 9 张图
-3. 每张完成后,把内置工具默认输出位置的最新文件 cp 到 /Users/cyh/vibe-remote-project/mascot/ 下,使用我指定的文件名
+3. 每张完成后,把内置工具默认输出位置的最新文件复制到仓库的 `assets/mascot/` 目录下,使用我指定的文件名
 
 ## 必须保持的'云团子'识别点(所有衍生图都要保留)
 - 白色蓬松圆滚滚的棉花糖云形状,边缘卷曲
@@ -68,4 +68,4 @@
 - 整体氛围: ' 夜晚的温柔'
 
 ## 总输出
-9 张图都保存到 /Users/cyh/vibe-remote-project/mascot/ 下,文件名按上面给的。每张完成都立即 cp 到目标位置。最后给我一个完整路径列表。
+9 张图都保存到仓库的 `assets/mascot/` 目录下,文件名按上面给的。每张完成都立即复制到目标位置。最后给我一个仓库相对路径列表。

--- a/assets/mascot/prompts/README.md
+++ b/assets/mascot/prompts/README.md
@@ -10,9 +10,9 @@
 调用方式（每次都是 stdin 喂 prompt，否则 codex exec 会卡）：
 
 ```bash
-cat /tmp/vibey_origin_prompts/p4_full_9image_set.md \
+cat assets/mascot/prompts/P4_full_9image_set.md \
   | codex exec --json \
       --dangerously-bypass-approvals-and-sandbox \
       --skip-git-repo-check \
-      --cd /Users/cyh/vibe-remote-project -
+      --cd . -
 ```

--- a/docs/opencode-poll-loop-refactor/NEXT_STEPS.md
+++ b/docs/opencode-poll-loop-refactor/NEXT_STEPS.md
@@ -27,7 +27,7 @@
 
 **How to test:**
 ```bash
-cd /Users/cyh/avibe
+# Run from the Avibe repository root.
 git checkout refactor/unify-opencode-poll-loop
 
 # Install in editable mode

--- a/docs/opencode-poll-loop-refactor/REFACTOR_PLAN.md
+++ b/docs/opencode-poll-loop-refactor/REFACTOR_PLAN.md
@@ -165,7 +165,7 @@ async def _process_question_answer(request, pending):
 QUESTION_WAIT_TIMEOUT_SECONDS = 30  # Change from 30*60
 
 # Start vibe in editable mode
-cd /Users/cyh/avibe
+# Run from the Avibe repository root.
 uv tool install --force --editable .
 vibe
 

--- a/docs/opencode-poll-loop-refactor/TESTING_GUIDE.md
+++ b/docs/opencode-poll-loop-refactor/TESTING_GUIDE.md
@@ -50,7 +50,7 @@ This guide covers testing the refactored OpenCode agent poll loop that unifies q
 ### 1. Install Editable Version
 
 ```bash
-cd /Users/cyh/avibe
+# Run from the Avibe repository root.
 git checkout refactor/unify-opencode-poll-loop
 
 # Install in editable mode so changes take effect immediately

--- a/docs/plans/agent-native-resume-session-list.md
+++ b/docs/plans/agent-native-resume-session-list.md
@@ -178,8 +178,8 @@ Directory encoding rule:
 
 - absolute path with `/` replaced by `-`
 - example:
-  - `/Users/cyh/avibe`
-  - `-Users-cyh-vibe-remote`
+  - `/Users/alice/avibe`
+  - `-Users-alice-avibe`
 
 #### Metadata source
 

--- a/docs/plans/agent-run-target-resolver.md
+++ b/docs/plans/agent-run-target-resolver.md
@@ -26,7 +26,7 @@ That leaves Avibe/Web UI contexts with no matching IM custom cwd. When there is
 no global default cwd, `get_cwd()` falls back to the Vibe Remote process cwd.
 If the service was launched from `/tmp/test`, a Workbench session can start its
 agent from `/tmp/test` even though the selected project is
-`/Users/cyh/vibe-remote-project`.
+`/workspace/avibe-project`.
 
 Some backends then bind their native session id back into the reserved
 `agent_sessions` row with `request.working_path`, which can persist the wrong

--- a/tests/test_claude_agent_sessions.py
+++ b/tests/test_claude_agent_sessions.py
@@ -2794,13 +2794,13 @@ class BindReservedWorkbenchSessionTests(unittest.TestCase):
         agent = _FakeBaseAgent(SimpleNamespace(bind_agent_session_by_id=bind_by_id))
         ctx = self._ctx("ses_workbench")
         ctx.platform_specific["agent_run_target"] = {
-            "workdir": "/Users/cyh/vibe-remote-project",
+            "workdir": "/Users/alice/vibe-remote-project",
         }
 
         ret = agent._bind_reserved_workbench_session(ctx, "native-123", working_path="/tmp/test")
 
         self.assertEqual(ret, "ses_workbench")
-        self.assertEqual(calls["workdir"], "/Users/cyh/vibe-remote-project")
+        self.assertEqual(calls["workdir"], "/Users/alice/vibe-remote-project")
 
     def test_routing_subagent_does_not_bind_native_to_reserved_row(self):
         agent = _FakeBaseAgent(SimpleNamespace(bind_agent_session_by_id=lambda *a, **k: "ses_wb"))

--- a/tests/test_native_session_providers.py
+++ b/tests/test_native_session_providers.py
@@ -22,13 +22,13 @@ def test_claude_provider_falls_back_to_history_jsonl(tmp_path: Path) -> None:
     history_path = tmp_path / "history.jsonl"
     projects_root.mkdir(parents=True, exist_ok=True)
 
-    working_path = "/Users/cyh/avibe"
+    working_path = "/Users/alice/avibe"
     history_path.write_text(
         "\n".join(
             [
-                '{"display":"old prompt","timestamp":1766078000000,"project":"/Users/cyh/avibe","sessionId":"sess_a"}',
-                '{"display":"latest prompt","timestamp":1766079000000,"project":"/Users/cyh/avibe","sessionId":"sess_a"}',
-                '{"display":"other project","timestamp":1766079100000,"project":"/Users/cyh/other","sessionId":"sess_b"}',
+                '{"display":"old prompt","timestamp":1766078000000,"project":"/Users/alice/avibe","sessionId":"sess_a"}',
+                '{"display":"latest prompt","timestamp":1766079000000,"project":"/Users/alice/avibe","sessionId":"sess_a"}',
+                '{"display":"other project","timestamp":1766079100000,"project":"/Users/alice/other","sessionId":"sess_b"}',
             ]
         ),
         encoding="utf-8",
@@ -45,7 +45,7 @@ def test_claude_provider_falls_back_to_history_jsonl(tmp_path: Path) -> None:
 
 
 def test_claude_project_path_encoding_handles_windows_paths() -> None:
-    assert encode_project_path("C:\\Users\\cyh\\vibe-remote") == "C--Users-cyh-vibe-remote"
+    assert encode_project_path("C:\\Users\\alice\\vibe-remote") == "C--Users-alice-vibe-remote"
 
 
 def test_claude_provider_scans_candidate_jsonl_when_history_has_results(tmp_path: Path) -> None:
@@ -53,9 +53,9 @@ def test_claude_provider_scans_candidate_jsonl_when_history_has_results(tmp_path
     history_path = tmp_path / "history.jsonl"
     projects_root.mkdir(parents=True, exist_ok=True)
 
-    working_path = "/Users/cyh/avibe"
+    working_path = "/Users/alice/avibe"
     history_path.write_text(
-        '{"display":"history prompt","timestamp":1766079000000,"project":"/Users/cyh/avibe","sessionId":"sess_history"}',
+        '{"display":"history prompt","timestamp":1766079000000,"project":"/Users/alice/avibe","sessionId":"sess_history"}',
         encoding="utf-8",
     )
 
@@ -64,7 +64,7 @@ def test_claude_provider_scans_candidate_jsonl_when_history_has_results(tmp_path
     (candidate_dir / "sess_sdk.jsonl").write_text(
         "\n".join(
             [
-                '{"type":"user","timestamp":"2026-03-27T09:59:00Z","cwd":"/Users/cyh/avibe","message":{"content":"sdk prompt"}}',
+                '{"type":"user","timestamp":"2026-03-27T09:59:00Z","cwd":"/Users/alice/avibe","message":{"content":"sdk prompt"}}',
                 '{"type":"assistant","timestamp":"2026-03-27T10:00:00Z","message":{"content":"sdk reply"}}',
             ]
         ),
@@ -84,13 +84,13 @@ def test_claude_provider_keeps_legacy_slash_only_project_dir(tmp_path: Path) -> 
     projects_root.mkdir(parents=True, exist_ok=True)
     history_path.write_text("", encoding="utf-8")
 
-    working_path = "/Users/cyh/my.repo"
+    working_path = "/Users/alice/my.repo"
     legacy_dir = projects_root / working_path.replace("/", "-")
     legacy_dir.mkdir(parents=True, exist_ok=True)
     (legacy_dir / "sess_legacy.jsonl").write_text(
         "\n".join(
             [
-                '{"type":"user","timestamp":"2026-03-27T09:59:00Z","cwd":"/Users/cyh/my.repo","message":{"content":"legacy prompt"}}',
+                '{"type":"user","timestamp":"2026-03-27T09:59:00Z","cwd":"/Users/alice/my.repo","message":{"content":"legacy prompt"}}',
                 '{"type":"assistant","timestamp":"2026-03-27T10:00:00Z","message":{"content":"legacy reply"}}',
             ]
         ),
@@ -110,7 +110,7 @@ def test_claude_provider_does_not_scan_unrelated_project_jsonl(tmp_path: Path, m
     projects_root.mkdir(parents=True, exist_ok=True)
     history_path.write_text("", encoding="utf-8")
 
-    working_path = "/Users/cyh/avibe"
+    working_path = "/Users/alice/avibe"
     candidate_dir = projects_root / encode_project_path(working_path)
     candidate_dir.mkdir(parents=True, exist_ok=True)
     target_jsonl = candidate_dir / "sess_target.jsonl"
@@ -119,7 +119,7 @@ def test_claude_provider_does_not_scan_unrelated_project_jsonl(tmp_path: Path, m
         encoding="utf-8",
     )
 
-    unrelated_dir = projects_root / "-Users-cyh-other"
+    unrelated_dir = projects_root / "-Users-alice-other"
     unrelated_dir.mkdir(parents=True, exist_ok=True)
     unrelated_jsonl = unrelated_dir / "sess_other.jsonl"
     unrelated_jsonl.write_text(
@@ -150,14 +150,14 @@ def test_claude_provider_uses_global_index_fallback_without_scanning_all_jsonl(t
     projects_root.mkdir(parents=True, exist_ok=True)
     history_path.write_text("", encoding="utf-8")
 
-    working_path = "/Users/cyh/avibe"
-    indexed_dir = projects_root / "-Users-cyh"
+    working_path = "/Users/alice/avibe"
+    indexed_dir = projects_root / "-Users-alice"
     indexed_dir.mkdir(parents=True, exist_ok=True)
     session_jsonl = indexed_dir / "sess_idx.jsonl"
     session_jsonl.write_text(
         "\n".join(
             [
-                '{"type":"user","timestamp":"2026-03-27T09:59:00Z","cwd":"/Users/cyh/avibe","message":{"content":"hello"}}',
+                '{"type":"user","timestamp":"2026-03-27T09:59:00Z","cwd":"/Users/alice/avibe","message":{"content":"hello"}}',
                 '{"type":"assistant","timestamp":"2026-03-27T10:00:00Z","message":{"content":"reply from indexed session"}}',
             ]
         ),
@@ -170,7 +170,7 @@ def test_claude_provider_uses_global_index_fallback_without_scanning_all_jsonl(t
                 "entries": [
                     {
                         "sessionId": "sess_idx",
-                        "projectPath": "/Users/cyh/avibe",
+                        "projectPath": "/Users/alice/avibe",
                         "created": "2026-03-27T09:59:00Z",
                         "modified": "2026-03-27T10:00:00Z",
                         "firstPrompt": "hello",

--- a/tests/test_resume_session.py
+++ b/tests/test_resume_session.py
@@ -115,7 +115,7 @@ class _StubController(Controller):
         return f"{getattr(context, 'platform', None) or 'test'}::{self._get_settings_key(context)}"
 
     def get_cwd(self, context: MessageContext) -> str:
-        return "/Users/cyh/avibe"
+        return "/Users/alice/avibe"
 
 
 class ResumeSessionTests(unittest.IsolatedAsyncioTestCase):
@@ -131,7 +131,7 @@ class ResumeSessionTests(unittest.IsolatedAsyncioTestCase):
                     agent="claude",
                     agent_prefix="cc",
                     native_session_id="sess_abc",
-                    working_path="/Users/cyh/avibe",
+                    working_path="/Users/alice/avibe",
                     created_at=None,
                     updated_at=None,
                     sort_ts=10.0,
@@ -286,7 +286,7 @@ class ResumeSessionTests(unittest.IsolatedAsyncioTestCase):
         codex_agent.prepare_resume_binding.assert_awaited_once_with(
             base_session_id="slack_169999.123",
             session_key="slack::C111",
-            working_path="/Users/cyh/avibe",
+            working_path="/Users/alice/avibe",
         )
 
     async def test_handle_resume_session_submission_prepares_claude_binding(self):
@@ -309,7 +309,7 @@ class ResumeSessionTests(unittest.IsolatedAsyncioTestCase):
         claude_agent.prepare_resume_binding.assert_awaited_once_with(
             base_session_id="slack_169999.123",
             session_key="slack::C111",
-            working_path="/Users/cyh/avibe",
+            working_path="/Users/alice/avibe",
         )
 
     async def test_handle_resume_session_submission_skips_resume_prepare_when_backend_has_no_hook(self):
@@ -474,7 +474,7 @@ class ResumeSessionTests(unittest.IsolatedAsyncioTestCase):
                     agent="codex",
                     agent_prefix="cx",
                     native_session_id="thread_123",
-                    working_path="/Users/cyh/avibe",
+                    working_path="/Users/alice/avibe",
                     created_at=None,
                     updated_at=None,
                     sort_ts=100.0,
@@ -501,7 +501,7 @@ class ResumeSessionTests(unittest.IsolatedAsyncioTestCase):
         trigger_id, sessions, channel_id, thread_id, host_ts = im_client.resume_calls[0]
         self.assertEqual((trigger_id, channel_id, thread_id, host_ts), ("TRIG", "CCHAN", "TS1", "TS1"))
         self.assertEqual([item.native_session_id for item in sessions], ["thread_123"])
-        self.assertEqual(ctrl.native_session_service.calls, [("/Users/cyh/avibe", 100)])
+        self.assertEqual(ctrl.native_session_service.calls, [("/Users/alice/avibe", 100)])
 
     async def test_handle_resume_in_existing_thread_is_rejected(self):
         # /resume is scope-level only: invoking it inside an existing thread must be
@@ -538,7 +538,7 @@ class ResumeSessionTests(unittest.IsolatedAsyncioTestCase):
                     agent="opencode",
                     agent_prefix="oc",
                     native_session_id="oc_disabled",
-                    working_path="/Users/cyh/avibe",
+                    working_path="/Users/alice/avibe",
                     created_at=None,
                     updated_at=None,
                     sort_ts=200.0,
@@ -549,7 +549,7 @@ class ResumeSessionTests(unittest.IsolatedAsyncioTestCase):
                     agent="codex",
                     agent_prefix="cx",
                     native_session_id="cx_enabled",
-                    working_path="/Users/cyh/avibe",
+                    working_path="/Users/alice/avibe",
                     created_at=None,
                     updated_at=None,
                     sort_ts=100.0,
@@ -608,7 +608,7 @@ class ResumeSessionTests(unittest.IsolatedAsyncioTestCase):
                     agent="codex",
                     agent_prefix="cx",
                     native_session_id="session_telegram_123",
-                    working_path="/Users/cyh/avibe",
+                    working_path="/Users/alice/avibe",
                     created_at=None,
                     updated_at=None,
                     sort_ts=100.0,
@@ -637,7 +637,7 @@ class ResumeSessionTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(trigger_id, ctx)
         self.assertEqual((channel_id, thread_id, host_ts), ("TGCHAN", "MSG1", "MSG1"))
         self.assertEqual([item.native_session_id for item in sessions], ["session_telegram_123"])
-        self.assertEqual(ctrl.native_session_service.calls, [("/Users/cyh/avibe", 25)])
+        self.assertEqual(ctrl.native_session_service.calls, [("/Users/alice/avibe", 25)])
 
     async def test_command_handlers_handle_resume_wechat_lists_recent_sessions(self):
         settings = _StubSettingsManager()
@@ -651,7 +651,7 @@ class ResumeSessionTests(unittest.IsolatedAsyncioTestCase):
                     agent="claude",
                     agent_prefix="cc",
                     native_session_id="claude-1",
-                    working_path="/Users/cyh/avibe",
+                    working_path="/Users/alice/avibe",
                     created_at=None,
                     updated_at=datetime(2026, 3, 27, 14, 32),
                     sort_ts=10.0,
@@ -662,7 +662,7 @@ class ResumeSessionTests(unittest.IsolatedAsyncioTestCase):
                     agent="codex",
                     agent_prefix="cx",
                     native_session_id="codex-1",
-                    working_path="/Users/cyh/avibe",
+                    working_path="/Users/alice/avibe",
                     created_at=None,
                     updated_at=datetime(2026, 3, 27, 14, 10),
                     sort_ts=9.0,
@@ -700,7 +700,7 @@ class ResumeSessionTests(unittest.IsolatedAsyncioTestCase):
                     agent="opencode",
                     agent_prefix="oc",
                     native_session_id="oc-1",
-                    working_path="/Users/cyh/avibe",
+                    working_path="/Users/alice/avibe",
                     created_at=None,
                     updated_at=None,
                     sort_ts=10.0,
@@ -711,7 +711,7 @@ class ResumeSessionTests(unittest.IsolatedAsyncioTestCase):
                     agent="claude",
                     agent_prefix="cc",
                     native_session_id="cc-2",
-                    working_path="/Users/cyh/avibe",
+                    working_path="/Users/alice/avibe",
                     created_at=None,
                     updated_at=None,
                     sort_ts=9.0,
@@ -781,7 +781,7 @@ class ResumeSessionTests(unittest.IsolatedAsyncioTestCase):
                     agent="opencode",
                     agent_prefix="oc",
                     native_session_id="oc_disabled",
-                    working_path="/Users/cyh/avibe",
+                    working_path="/Users/alice/avibe",
                     created_at=None,
                     updated_at=None,
                     sort_ts=200.0,
@@ -792,7 +792,7 @@ class ResumeSessionTests(unittest.IsolatedAsyncioTestCase):
                     agent="codex",
                     agent_prefix="cx",
                     native_session_id="cx_enabled",
-                    working_path="/Users/cyh/avibe",
+                    working_path="/Users/alice/avibe",
                     created_at=None,
                     updated_at=None,
                     sort_ts=100.0,

--- a/tests/test_telegram_bot.py
+++ b/tests/test_telegram_bot.py
@@ -934,7 +934,7 @@ def test_resume_menu_uses_short_callback_ids() -> None:
             agent="codex",
             agent_prefix="cx",
             native_session_id="session_abcdefghijklmnopqrstuvwxyz",
-            working_path="/Users/cyh/avibe",
+            working_path="/Users/alice/avibe",
             created_at=None,
             updated_at=None,
             sort_ts=100.0,


### PR DESCRIPTION
## Summary

- make internal documentation and asset-generation prompts portable across developer machines
- replace developer-specific path fixtures with clearly generic fixture users
- keep path-format examples only where the behavior under test requires an absolute path

## Evidence

- **Unit:** 157 focused tests passed across session discovery, resume flows, and Telegram resume handling
- **Contract:** Ruff passed for all changed test modules; tracked-file scan finds no `/Users/cyh` or `C:\\Users\\cyh` reference
- **Scenario:** No scenario catalog applies to documentation and fixture-only changes
- **Residual manual checks:** None

Companion cleanup for the encrypted design source is tracked separately in `avibe-docs`.
