### PR TITLE
fix(workbench): compact Activity card height = min(content, 3-row cap)

### DIFF
--- a/docs/plans/chat-agent-activity-panel.md
+++ b/docs/plans/chat-agent-activity-panel.md
@@ -278,3 +278,16 @@ activity". The activity-streaming flag cache is reset on config save so the togg
 takes effect immediately. Presentation is `ActivityCard` / `ActivityChip` in
 `ui/src/components/workbench/AgentActivityGroup.tsx`; pure helpers + the live
 generation reducer + wire mapping in `ui/src/lib/agentActivity.ts`.
+
+**Compact running-card height (refined UX, design.pen State A updated).** The
+compact viewport height is **min(content, 3-row cap ≈ 110px)** — NOT a constant
+reserved height. Below the cap the body is exactly content-tall and grows downward
+as rows arrive (natural, like any new message at the transcript tail), so a 1–2 row
+turn shows no blank space above the content. Only once content reaches the cap does
+it become the constant-height viewport: clamped height, newest rows pinned to the
+bottom (`justify-end` + `overflow-hidden` clipping the top), older rows fading up
+(the top gradient renders ONLY at the cap). The cap is a CSS `max-height`; a small
+layout measurement (`offsetHeight >= cap`) gates the fade, so the height behavior
+itself is CSS-driven — not unit-testable under jsdom, which does no layout. Expanded
+mode is unchanged: `max-h-[40vh]` + internal scroll already fits content up to its
+cap. Tail auto-follow (the Transcript scroller) is untouched.

--- a/ui/src/components/workbench/AgentActivityGroup.tsx
+++ b/ui/src/components/workbench/AgentActivityGroup.tsx
@@ -158,12 +158,20 @@ export const ActivityCard: React.FC<{
   }, [rows.length, expanded, following]);
 
   // Measure whether the compact body has hit the cap (content clamped) — drives the
-  // top fade so it only appears once older rows are actually clipped.
+  // top fade so it only appears once older rows are actually clipped. A ResizeObserver
+  // ties the gate to ACTUAL layout, so it also tracks resizes that don't change
+  // ``rows.length``: a tool row expanding its stored call text, a late-loading image,
+  // or a width change reflowing an assistant markdown row.
   useLayoutEffect(() => {
     if (expanded) return;
     const el = compactBodyRef.current;
-    if (el) setCompactAtCap(el.offsetHeight >= COMPACT_CAP_PX);
-  }, [rows.length, expanded]);
+    if (!el) return;
+    const measure = () => setCompactAtCap(el.offsetHeight >= COMPACT_CAP_PX);
+    measure();
+    const observer = new ResizeObserver(measure);
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [expanded]);
 
   const elapsedMs = Math.max(0, nowMs - (startedAtMs ?? mountedAt));
   const mm = Math.floor(elapsedMs / 60000);

--- a/ui/src/components/workbench/AgentActivityGroup.tsx
+++ b/ui/src/components/workbench/AgentActivityGroup.tsx
@@ -1,4 +1,4 @@
-import { memo, useEffect, useRef, useState } from 'react';
+import { memo, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   AlertTriangle,
@@ -119,6 +119,11 @@ const ActivityRows: React.FC<{ rows: ActivityRow[] }> = ({ rows }) => (
 
 // ===== Running card (states A/B): compact fixed-height viewport that never grows,
 // or an expanded ~40vh internal scroller that auto-follows the tail. =====
+// Compact running-card viewport cap ≈ 3 rows. The body height is min(content, cap):
+// it grows downward from a single row (no reserved blank space) and only becomes a
+// constant-height, bottom-following, top-fading viewport once content reaches the cap.
+const COMPACT_CAP_PX = 110;
+
 export const ActivityCard: React.FC<{
   rows: ActivityRow[];
   startedAtMs: number | null;
@@ -132,6 +137,11 @@ export const ActivityCard: React.FC<{
   const [mountedAt] = useState(() => Date.now());
   const scrollRef = useRef<HTMLDivElement>(null);
   const [following, setFollowing] = useState(true);
+  // Compact body reached its cap → clamp to the cap + show the top "older rows
+  // fading up" gradient. Below the cap the body is exactly content-tall (no fade,
+  // no blank space).
+  const compactBodyRef = useRef<HTMLDivElement>(null);
+  const [compactAtCap, setCompactAtCap] = useState(false);
 
   // Tick the elapsed clock once a second while mounted (the card only mounts
   // while a live turn is running).
@@ -146,6 +156,14 @@ export const ActivityCard: React.FC<{
       scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
     }
   }, [rows.length, expanded, following]);
+
+  // Measure whether the compact body has hit the cap (content clamped) — drives the
+  // top fade so it only appears once older rows are actually clipped.
+  useLayoutEffect(() => {
+    if (expanded) return;
+    const el = compactBodyRef.current;
+    if (el) setCompactAtCap(el.offsetHeight >= COMPACT_CAP_PX);
+  }, [rows.length, expanded]);
 
   const elapsedMs = Math.max(0, nowMs - (startedAtMs ?? mountedAt));
   const mm = Math.floor(elapsedMs / 60000);
@@ -201,14 +219,21 @@ export const ActivityCard: React.FC<{
             )}
           </div>
         ) : (
-          // Compact: a fixed ~110px viewport, content pinned to the bottom so the
-          // newest rows show and older rows are clipped + faded upward. The box
-          // never grows → no transcript reflow.
-          <div className="relative h-[110px] overflow-hidden">
-            <div className="flex h-full flex-col justify-end px-1.5 py-1.5">
-              <ActivityRows rows={rows} />
-            </div>
-            <div className="pointer-events-none absolute inset-x-0 top-0 h-8 bg-gradient-to-b from-background to-transparent" />
+          // Compact: body height = min(content, cap). Below the cap it is exactly
+          // content-tall and grows downward as rows arrive (natural, like any new
+          // message at the transcript tail) — no reserved blank space. At the cap it
+          // clamps to a constant viewport with the newest rows pinned to the bottom
+          // (justify-end) and older rows clipped + faded up. ``overflow-hidden`` clips
+          // the top overflow; the tail auto-follow lives in the Transcript scroller.
+          <div
+            ref={compactBodyRef}
+            className="relative flex flex-col justify-end overflow-hidden px-1.5 py-1.5"
+            style={{ maxHeight: COMPACT_CAP_PX }}
+          >
+            <ActivityRows rows={rows} />
+            {compactAtCap && (
+              <div className="pointer-events-none absolute inset-x-0 top-0 h-8 bg-gradient-to-b from-background to-transparent" />
+            )}
           </div>
         )}
       </div>


### PR DESCRIPTION
## Capability

Frontend-only UX polish for the shipped Chat Agent Activity panel (#934): the
**compact running card** reserved the full ~3-row viewport from the first step
(fixed height + bottom-anchored content), so a 1–2 row turn showed **blank space
above the content** — which reads as a bug.

## Change

The compact body height is now **`min(content, 3-row cap ≈ 110px)`**:
- **Below the cap** — exactly content-tall; grows downward as rows arrive (natural,
  like any new message at the transcript tail). No reserved blank space above/below.
- **At the cap** — behaves exactly as before: constant height, newest rows pinned to
  the bottom (`justify-end` + `overflow-hidden` clipping the top), older rows fading
  up. The top fade gradient now renders **only at the cap** (a small
  `offsetHeight >= cap` layout measurement gates it), so a short card isn't dimmed.
- **Expanded mode unchanged** — already `max-h-[40vh]` + internal scroll (fit-content
  up to its cap); verified.
- **Tail auto-follow** (the Transcript scroller) is untouched.

Only `ui/src/components/workbench/AgentActivityGroup.tsx` (the `ActivityCard`).

## Evidence layers

- **Gates** — `npm run build` green; `vitest run` 308 green (unchanged);
  `AgentActivityGroup.tsx` eslint-clean.
- **Test note** — the height is a CSS `max-height` and the fade-gate reads
  `offsetHeight`; both depend on real layout, which **jsdom does not compute**, so
  there is nothing sensibly unit-testable here (per the change brief). The existing
  component/lib suite is kept green.
- **Residual manual (defer to real-browser acceptance):** 1-row / 2-row / 3-row+
  running card renders with no blank space, grows downward pre-cap, and at the cap
  shows the fixed viewport + top fade + bottom-follow.

design.pen State A caption + interaction rules updated (orchestrator-side) to
"compact height = min(content, 3-row cap), constant only at the cap"; as-built note
appended to `docs/plans/chat-agent-activity-panel.md`. Depends on #934/#935 (merged).
