### PR TITLE
test(files): restore cleanup fixture permissions

### DIFF
--- a/tests/test_file_browser_backend.py
+++ b/tests/test_file_browser_backend.py
@@ -898,7 +898,6 @@ def test_copy_cleanup_never_chmods_symlink_target(tmp_path, monkeypatch):
     locked = source / "locked"
     locked.mkdir(parents=True)
     (locked / "external-link").symlink_to(external)
-    locked.chmod(0o500)
     destination = tmp_path / "destination"
 
     def fail_publish(*_args, **_kwargs):
@@ -906,13 +905,17 @@ def test_copy_cleanup_never_chmods_symlink_target(tmp_path, monkeypatch):
 
     monkeypatch.setattr(fs, "_publish_staged_copy", fail_publish)
 
-    with pytest.raises(FileBrowserError) as exc:
-        fs.copy_path(str(source), str(destination))
+    locked.chmod(0o500)
+    try:
+        with pytest.raises(FileBrowserError) as exc:
+            fs.copy_path(str(source), str(destination))
 
-    assert exc.value.code == "fs_error"
-    assert external.stat().st_mode & 0o777 == 0o600
-    assert not destination.exists()
-    assert not list(tmp_path.glob(f"{fs._COPY_TEMP_PREFIX}*"))
+        assert exc.value.code == "fs_error"
+        assert external.stat().st_mode & 0o777 == 0o600
+        assert not destination.exists()
+        assert not list(tmp_path.glob(f"{fs._COPY_TEMP_PREFIX}*"))
+    finally:
+        locked.chmod(0o700)
 
 
 def test_copy_file_size_cap_rejects_before_staging(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

- restore the test-owned locked source directory in a `finally` block so pytest can remove its temporary tree
- retain the assertion that copy cleanup leaves the external symlink target at mode `0600`
- keep production copy behavior unchanged; the same-module permission sweep found no other unfinalized locked-directory fixture

## Capability and scope

- Capability: stable Files copy-cleanup security regression coverage
- Scenario IDs: none; no cataloged scenario is changed by this test-harness-only fix
- Production behavior: unchanged

## Evidence

- Unit: focused test passed twice against the same isolated `--basetemp`; the second run had no pytest cleanup warning and created no `garbage-*` directory
- Unit: `tests/test_file_browser_backend.py` passed (`120 passed`) in an isolated temp root
- Contract: the existing external-target mode assertion remains `0600`
- Scenario: not applicable; no runtime behavior changed
- Residual manual checks: none beyond GitHub CI for this test-only change

Closes #898
