### PR TITLE
fix(ui): clarify background task labels

### DIFF
--- a/docs/plans/unified-background-work-banner.md
+++ b/docs/plans/unified-background-work-banner.md
@@ -1,6 +1,6 @@
 # Unified Background-Work Banner (P1) — spec
 
-Owner decision (2026-07-16 20:51): the workbench chat's "后台工作 · N" banner must present ONE
+Owner decision (2026-07-16 20:51): the workbench chat's background-task banner must present ONE
 unified concept of background work for a session, regardless of where the work runs. Harness
 items (watches, scheduled tasks, delegated agent runs) join the same banner that today only
 shows backend-reported Activities (e.g. Claude background tasks).
@@ -25,14 +25,18 @@ The banner's source of truth is a **union assembled at runtime-state build time*
 
 Each unified item carries: `kind` (`backend_activity` | `watch` | `task` | `agent_run`),
 `label` (watch name / task summary / target agent + short message head / activity description),
-`since` timestamp, and a stable id. The banner count = union size. No controls (pause/cancel)
-in this phase — the expanded list links to the Harness page (watches/tasks) or run detail.
+`since` timestamp, and a stable id. Task items also carry the durable `schedule_type` (`at` |
+`cron`) used for display classification. The banner count = union size. No controls
+(pause/cancel) in this phase — the expanded list links to the Harness page (watches/tasks) or
+run detail.
 
 ## UX
 
-- Banner line unchanged: `后台工作 · N` (existing `chat.activities.running` string).
+- Banner line: `后台任务 · N` (`chat.activities.running`).
 - Expanded list: one row per item — kind icon + label + relative time. Rows for harness items
   navigate to their Harness surface on click; backend-activity rows keep current behavior.
+- Chinese row kinds use `监听` for watches, `一次性` for `schedule_type=at`, and `周期性` for
+  `schedule_type=cron`. Classification must use `schedule_type`, never parse the task label.
 - Empty union → banner hidden (current behavior).
 - All new strings through i18n (en + zh).
 
@@ -50,7 +54,7 @@ in this phase — the expanded list links to the Harness page (watches/tasks) or
 
 1. **Popover opens UPWARD.** The banner sits at the bottom of the chat (above the composer);
    the expanded list anchors to the pill's TOP edge and grows upward. Never downward.
-2. **Harness-page toggle.** A switch on the Harness page ("后台工作横幅", default ON) hides the
+2. **Harness-page toggle.** A switch on the Harness page ("后台任务横幅", default ON) hides the
    banner entirely for users who don't want it. Global (not per-session), persisted server-side
    (same `state_meta` family as other workbench prefs — lane picks the exact key, declares it).
    When off, the banner never renders; the underlying data/API is unaffected.

--- a/storage/workbench_sessions_service.py
+++ b/storage/workbench_sessions_service.py
@@ -630,15 +630,17 @@ def _harness_banner_item(
     since: str,
     updated_at: str,
     backend: str = "",
+    schedule_type: str | None = None,
 ) -> dict[str, Any]:
     """Shape one harness row like a serialized background activity.
 
     The banner unions these with process-local backend activities
     (``core/session_activities.SessionActivity.to_dict``), so a harness item
     carries every key an existing ``background_activities`` consumer already
-    reads, plus the unified ``item_kind`` / ``label`` / ``since`` fields the
-    banner uses to render and route each row. Nothing here is written back into
-    the registry — the row is derived fresh on every runtime-state build.
+    reads, plus the unified ``item_kind`` / ``label`` / ``since`` /
+    ``schedule_type`` fields the banner uses to render and route each row.
+    Nothing here is written back into the registry — the row is derived fresh
+    on every runtime-state build.
     """
     return {
         "id": item_id,
@@ -657,10 +659,11 @@ def _harness_banner_item(
         "started_at": since,
         "updated_at": updated_at or since,
         "completed_at": None,
-        # Unified background-work banner fields (spec: kind / label / since).
+        # Unified background-work banner fields.
         "item_kind": item_kind,
         "label": label,
         "since": since,
+        "schedule_type": schedule_type,
     }
 
 
@@ -678,7 +681,7 @@ def derive_session_harness_activities(conn: Connection, session_id: str) -> list
       session dispatched and is waiting on).
 
     Each row is shaped like a serialized background activity plus the unified
-    ``item_kind`` / ``label`` / ``since`` fields (see ``_harness_banner_item``).
+    banner fields (see ``_harness_banner_item``).
     """
     session_id = str(session_id or "").strip()
     if not session_id:
@@ -696,6 +699,7 @@ def derive_session_harness_activities(conn: Connection, session_id: str) -> list
                 run_definitions.c.name,
                 run_definitions.c.prompt,
                 run_definitions.c.message,
+                run_definitions.c.schedule_type,
                 run_definitions.c.created_at,
                 run_definitions.c.updated_at,
             )
@@ -720,6 +724,11 @@ def derive_session_harness_activities(conn: Connection, session_id: str) -> list
         else:
             continue
         since = str(row["created_at"] or "")
+        schedule_type = (
+            str(row["schedule_type"] or "").strip() or None
+            if item_kind == "task"
+            else None
+        )
         items.append(
             _harness_banner_item(
                 item_id=f"{item_kind}:{row['id']}",
@@ -729,6 +738,7 @@ def derive_session_harness_activities(conn: Connection, session_id: str) -> list
                 label=label,
                 since=since,
                 updated_at=str(row["updated_at"] or since),
+                schedule_type=schedule_type,
             )
         )
 

--- a/tests/test_background_work_banner.py
+++ b/tests/test_background_work_banner.py
@@ -93,6 +93,7 @@ def test_each_harness_source_contributes_one_row(tmp_path: Path):
         definition_type="scheduled",
         name="nightly report",
         session_id="ses-1",
+        schedule_type="cron",
     )
     _insert_run(
         engine,
@@ -110,13 +111,44 @@ def test_each_harness_source_contributes_one_row(tmp_path: Path):
     assert set(by_kind) == {"watch", "task", "agent_run"}
     assert by_kind["watch"]["id"] == "watch:watch-1"
     assert by_kind["watch"]["label"] == "deploy watch"
+    assert by_kind["watch"]["schedule_type"] is None
     assert by_kind["task"]["id"] == "task:task-1"
     assert by_kind["task"]["label"] == "nightly report"
+    assert by_kind["task"]["schedule_type"] == "cron"
     assert by_kind["agent_run"]["id"] == "agent_run:run-1"
     assert by_kind["agent_run"]["label"] == "worker: audit the contract"
+    assert by_kind["agent_run"]["schedule_type"] is None
     # ``since`` and a stable id are present on every unified item.
     assert all(item["since"] == _NOW for item in items)
     assert all(item["id"] for item in items)
+
+
+def test_task_schedule_type_comes_from_the_durable_definition(tmp_path: Path):
+    engine, _ = _make_engine(tmp_path)
+    _insert_definition(
+        engine,
+        id="task-once",
+        definition_type="scheduled",
+        name="title says every day but is one-shot",
+        session_id="ses-1",
+        schedule_type="at",
+    )
+    _insert_definition(
+        engine,
+        id="task-recurring",
+        definition_type="scheduled",
+        name="title says one-off but is recurring",
+        session_id="ses-1",
+        schedule_type="cron",
+    )
+
+    with engine.connect() as conn:
+        items = derive_session_harness_activities(conn, "ses-1")
+
+    assert {item["id"]: item["schedule_type"] for item in items} == {
+        "task:task-once": "at",
+        "task:task-recurring": "cron",
+    }
 
 
 def test_task_label_falls_back_to_prompt_when_unnamed(tmp_path: Path):

--- a/ui/src/components/workbench/ChatPage.tsx
+++ b/ui/src/components/workbench/ChatPage.tsx
@@ -17,7 +17,13 @@ import { useIosKeyboardInset } from '../../lib/useIosKeyboardInset';
 import { isProxyMediaUrl } from '../../lib/mediaProxy';
 import { localPath, type ShowPageLinkInfo } from '../../lib/showPageLinks';
 import { formatLocalDateTime, formatRelativeTime } from '../../lib/relativeTime';
-import { activityItemKind, harnessNavPath, resolveActivityLabel, sortBackgroundActivities } from '../../lib/backgroundActivity';
+import {
+  activityItemKind,
+  activityKindI18nKey,
+  harnessNavPath,
+  resolveActivityLabel,
+  sortBackgroundActivities,
+} from '../../lib/backgroundActivity';
 import { useFileDrop } from '../../lib/useFileDrop';
 import { quoteText } from '../../lib/quoteText';
 import { mergeById, insertMessageOrdered } from '../../lib/transcriptOrder';
@@ -1985,14 +1991,6 @@ const ACTIVITY_ITEM_TINT: Record<SessionActivityItemKind, string> = {
   agent_run: 'bg-violet/15 text-violet',
 };
 
-// item_kind (snake_case wire value) -> chat.activities.kind.* i18n leaf.
-const ACTIVITY_ITEM_I18N: Record<SessionActivityItemKind, string> = {
-  backend_activity: 'backendActivity',
-  watch: 'watch',
-  task: 'task',
-  agent_run: 'agentRun',
-};
-
 // One expanded popover row: colored kind icon box + two-line label / subtitle.
 // Backend activities are display-only with a colored status word (no landing
 // page); harness rows navigate to their Harness surface on click.
@@ -2003,7 +2001,7 @@ const ActivityRow: React.FC<{
   const { t } = useTranslation();
   const kind = activityItemKind(item);
   const Icon = ACTIVITY_ITEM_ICON[kind];
-  const kindLabel = t(`chat.activities.kind.${ACTIVITY_ITEM_I18N[kind]}`);
+  const kindLabel = t(`chat.activities.kind.${activityKindI18nKey(item)}`);
   const label = resolveActivityLabel(item, kindLabel);
   const relative = formatRelativeTime(item.since ?? item.started_at, t);
   const isHarness = kind !== 'backend_activity';
@@ -2073,7 +2071,7 @@ const ActivityStrip: React.FC<{
 
   const first = active[0];
   const firstLabel = first
-    ? resolveActivityLabel(first, t(`chat.activities.kind.${ACTIVITY_ITEM_I18N[activityItemKind(first)]}`))
+    ? resolveActivityLabel(first, t(`chat.activities.kind.${activityKindI18nKey(first)}`))
     : '';
   const connectionVisible =
     active.length > 0 &&

--- a/ui/src/context/ApiContext.tsx
+++ b/ui/src/context/ApiContext.tsx
@@ -1031,8 +1031,9 @@ export type MessageSearchResult = {
 // process-local SessionActivityRegistry) and live-derived harness items
 // (watches / scheduled tasks / delegated agent runs) share this shape. The
 // legacy fields stay for backward compatibility; `item_kind` / `label` /
-// `since` are the unified fields the banner renders and routes on. `item_kind`
-// is optional so a pre-union payload degrades to a backend activity.
+// `since` / `schedule_type` are the unified fields the banner renders and
+// routes on. `item_kind` is optional so a pre-union payload degrades to a
+// backend activity.
 export type SessionActivityItemKind = 'backend_activity' | 'watch' | 'task' | 'agent_run';
 
 export type SessionActivityState = {
@@ -1048,6 +1049,7 @@ export type SessionActivityState = {
   item_kind?: SessionActivityItemKind;
   label?: string | null;
   since?: string;
+  schedule_type?: 'at' | 'cron' | null;
 };
 
 export type SessionRuntimeState = {

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -2148,8 +2148,8 @@
     },
     "filtered": "{{shown}}/{{total}}",
     "bannerToggle": {
-      "title": "Background-work banner",
-      "description": "Show in-progress background work at the bottom of chats."
+      "title": "Background task banner",
+      "description": "Show in-progress background tasks at the bottom of chats."
     },
     "sessionFilter": {
       "chip": "Only: this session {{id}}",
@@ -2344,9 +2344,9 @@
       "zoomOut": "Zoom out"
     },
     "activities": {
-      "running": "Background work · {{count}}",
+      "running": "Background tasks · {{count}}",
       "delivering": "Delivering background output · {{count}}",
-      "toggle": "Toggle background work",
+      "toggle": "Toggle background tasks",
       "manageInHarness": "Manage in Harness",
       "openHarness": "Open in Harness · {{kind}}",
       "status": {
@@ -2355,7 +2355,9 @@
       "kind": {
         "backendActivity": "Background task",
         "watch": "Watch",
-        "task": "Scheduled task",
+        "task": "Task",
+        "taskOneShot": "One-time",
+        "taskRecurring": "Recurring",
         "agentRun": "Agent run"
       },
       "connection": {

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -2148,8 +2148,8 @@
     },
     "filtered": "{{shown}}/{{total}}",
     "bannerToggle": {
-      "title": "后台工作横幅",
-      "description": "在会话底部显示进行中的后台工作。"
+      "title": "后台任务横幅",
+      "description": "在会话底部显示进行中的后台任务。"
     },
     "sessionFilter": {
       "chip": "仅看:本会话 {{id}}",
@@ -2344,9 +2344,9 @@
       "zoomOut": "缩小"
     },
     "activities": {
-      "running": "后台工作 · {{count}}",
+      "running": "后台任务 · {{count}}",
       "delivering": "正在投递后台输出 · {{count}}",
-      "toggle": "展开后台工作",
+      "toggle": "展开后台任务",
       "manageInHarness": "在 Harness 中管理",
       "openHarness": "在 Harness 中打开 · {{kind}}",
       "status": {
@@ -2354,8 +2354,10 @@
       },
       "kind": {
         "backendActivity": "后台任务",
-        "watch": "监视",
-        "task": "定时任务",
+        "watch": "监听",
+        "task": "任务",
+        "taskOneShot": "一次性",
+        "taskRecurring": "周期性",
         "agentRun": "Agent 运行"
       },
       "connection": {

--- a/ui/src/lib/backgroundActivity.test.ts
+++ b/ui/src/lib/backgroundActivity.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import type { SessionActivityState } from '../context/ApiContext';
 import {
   activityItemKind,
+  activityKindI18nKey,
   harnessItemNativeId,
   harnessNavPath,
   isHarnessActivity,
@@ -40,6 +41,22 @@ describe('activityItemKind', () => {
     expect(activityItemKind({ item_kind: undefined })).toBe('backend_activity');
     // An unexpected value still degrades to a backend activity row.
     expect(activityItemKind({ item_kind: 'mystery' as never })).toBe('backend_activity');
+  });
+});
+
+describe('activityKindI18nKey', () => {
+  it('classifies one-shot and recurring tasks from schedule_type', () => {
+    expect(activityKindI18nKey({ item_kind: 'task', schedule_type: 'at' })).toBe('taskOneShot');
+    expect(activityKindI18nKey({ item_kind: 'task', schedule_type: 'cron' })).toBe(
+      'taskRecurring',
+    );
+  });
+
+  it('does not infer recurrence from labels or other activity kinds', () => {
+    expect(activityKindI18nKey({ item_kind: 'task', schedule_type: null })).toBe('task');
+    expect(activityKindI18nKey({ item_kind: 'watch' })).toBe('watch');
+    expect(activityKindI18nKey({ item_kind: 'agent_run' })).toBe('agentRun');
+    expect(activityKindI18nKey({ item_kind: 'backend_activity' })).toBe('backendActivity');
   });
 });
 

--- a/ui/src/lib/backgroundActivity.ts
+++ b/ui/src/lib/backgroundActivity.ts
@@ -15,6 +15,22 @@ export function activityItemKind(
   return kind && HARNESS_ITEM_KINDS.includes(kind) ? kind : 'backend_activity';
 }
 
+// Task recurrence is an explicit durable field (`at` / `cron`). Keep this
+// mapping independent of task names so display text can never misclassify a
+// user-authored label that happens to mention scheduling words.
+export function activityKindI18nKey(
+  item: Pick<SessionActivityState, 'item_kind' | 'schedule_type'>,
+): string {
+  const kind = activityItemKind(item);
+  if (kind === 'task') {
+    if (item.schedule_type === 'at') return 'taskOneShot';
+    if (item.schedule_type === 'cron') return 'taskRecurring';
+  }
+  if (kind === 'backend_activity') return 'backendActivity';
+  if (kind === 'agent_run') return 'agentRun';
+  return kind;
+}
+
 // Harness rows (watch / task / delegated run) navigate to the Harness surface;
 // backend activities keep their current non-navigating behavior.
 export function isHarnessActivity(item: Pick<SessionActivityState, 'item_kind'>): boolean {


### PR DESCRIPTION
## Summary

- rename the chat banner from "Background work" / "后台工作" to "Background tasks" / "后台任务"
- rename the Chinese watch row kind from "监视" to "监听"
- label scheduled rows as "一次性" for durable `schedule_type=at` and "周期性" for `schedule_type=cron`
- carry the authoritative schedule type through the runtime-state banner payload instead of inferring recurrence from user-authored task names
- update the unified banner design contract to match the new product wording

## Evidence

- Unit: `tests/test_background_work_banner.py` (11 passed)
- Unit: `ui/src/lib/backgroundActivity.test.ts` (14 passed)
- Contract: local Incus runtime-state returned `at` and `cron` for two deliberately misleading task names
- Scenario: Playwright verified the Chinese pill and expanded rows on desktop and 390px mobile, including no horizontal overflow and absence of the retired labels
- Build/lint: UI production build, Ruff, JSON parsing, and `git diff --check` passed

Scenario catalog: no named scenario IDs exist for this banner; the existing five UX requirements remain unchanged apart from the wording and task-kind classification recorded in the design plan.

## Compatibility

Older or imported task rows without a known schedule type fall back to the neutral "任务" / "Task" label. Scheduling, execution, navigation, and task persistence are unchanged.
