### PR TITLE
fix(webui): parse modern tailscale whois Node payload for peer trust

### DIFF
--- a/tests/test_ui_remote_access_auth.py
+++ b/tests/test_ui_remote_access_auth.py
@@ -49,7 +49,11 @@ def _mock_tailscale_whois(
     *,
     addresses: list[str] | None = None,
     allowed_ips: list[str] | None = None,
+    payload_key: str = "Node",
 ) -> None:
+    """Stub ``_tailscale_whois`` with the modern ``Node`` payload shape by
+    default (host-CIDR address strings, as emitted by current ``tailscale
+    whois --json``); pass ``payload_key="Machine"`` for the legacy shape."""
     peer_address = ipaddress.ip_address(peer)
     prefix = peer_address.max_prefixlen
     monkeypatch.setattr(ui_server, "_TAILSCALE_PEER_CACHE", {})
@@ -57,8 +61,8 @@ def _mock_tailscale_whois(
         ui_server,
         "_tailscale_whois",
         lambda address: {
-            "Machine": {
-                "Addresses": addresses or [str(peer_address)],
+            payload_key: {
+                "Addresses": addresses or [f"{peer_address}/{prefix}"],
                 "AllowedIPs": allowed_ips or [f"{peer_address}/{prefix}"],
             }
         }
@@ -2703,6 +2707,65 @@ def test_setup_host_wildcard_rejects_tailscale_subnet_router_peer(monkeypatch, t
 
     assert response.status_code == 503
     assert response.get_json()["error"] == "remote_access_host_mismatch"
+
+
+def test_trusted_tailscale_peer_accepts_modern_node_whois_payload(monkeypatch):
+    """Current ``tailscale whois --json`` nests the peer under ``Node`` with
+    host-CIDR address strings; the top-level ``Machine`` object is gone."""
+    peer = ipaddress.ip_address("100.97.103.5")
+    monkeypatch.setattr(ui_server, "_TAILSCALE_PEER_CACHE", {})
+    monkeypatch.setattr(
+        ui_server,
+        "_tailscale_whois",
+        lambda address: {
+            "Node": {
+                "Name": "iphone.example.ts.net.",
+                "Machine": "mkey:0123456789abcdef",
+                "Addresses": ["100.97.103.5/32", "fd7a:115c:a1e0::5/128"],
+                "AllowedIPs": ["100.97.103.5/32", "fd7a:115c:a1e0::5/128"],
+            },
+            "UserProfile": {"LoginName": "user@example.com"},
+            "CapMap": {},
+        },
+    )
+
+    assert ui_server._is_trusted_tailscale_peer(peer) is True
+
+
+def test_trusted_tailscale_peer_accepts_legacy_machine_whois_payload(monkeypatch):
+    peer = ipaddress.ip_address("100.97.103.5")
+    _mock_tailscale_whois(
+        monkeypatch,
+        "100.97.103.5",
+        addresses=["100.97.103.5"],
+        payload_key="Machine",
+    )
+
+    assert ui_server._is_trusted_tailscale_peer(peer) is True
+
+
+def test_trusted_tailscale_peer_rejects_node_payload_with_subnet_route(monkeypatch):
+    peer = ipaddress.ip_address("100.97.103.5")
+    _mock_tailscale_whois(
+        monkeypatch,
+        "100.97.103.5",
+        allowed_ips=["100.97.103.5/32", "192.168.50.0/24"],
+    )
+
+    assert ui_server._is_trusted_tailscale_peer(peer) is False
+
+
+def test_trusted_tailscale_peer_ignores_non_host_address_entries(monkeypatch):
+    """Address entries that are not host CIDRs must not satisfy the peer
+    match, so a payload claiming a whole range cannot vouch for the peer."""
+    peer = ipaddress.ip_address("100.97.103.5")
+    _mock_tailscale_whois(
+        monkeypatch,
+        "100.97.103.5",
+        addresses=["100.97.103.0/24"],
+    )
+
+    assert ui_server._is_trusted_tailscale_peer(peer) is False
 
 
 def test_setup_host_wildcard_does_not_trust_unconfigured_tailscale_host(monkeypatch, tmp_path):

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -1136,14 +1136,23 @@ def _is_trusted_tailscale_peer(peer_address: ipaddress._BaseAddress) -> bool:
     payload = _tailscale_whois(peer_address)
     trusted = False
     if payload is not None:
-        machine = payload.get("Machine") or payload.get("machine") or {}
+        # Modern `tailscale whois --json` nests the peer record under "Node"
+        # (where "Machine" is just the machine-key string); older builds used a
+        # top-level "Machine" object. Accept a dict from either shape.
+        machine = payload.get("Machine") or payload.get("machine")
+        if not isinstance(machine, dict):
+            machine = payload.get("Node") or payload.get("node") or {}
         if isinstance(machine, dict):
             addresses = set()
             for raw_address in _json_list(machine, "Addresses", "addresses"):
+                # "Node" payloads list addresses as host CIDRs ("100.64.0.2/32");
+                # older "Machine" payloads used bare IPs.
                 try:
-                    addresses.add(ipaddress.ip_address(str(raw_address)))
+                    interface = ipaddress.ip_interface(str(raw_address))
                 except ValueError:
                     continue
+                if interface.network.prefixlen == interface.network.max_prefixlen:
+                    addresses.add(interface.ip)
             allowed_networks = []
             for raw_network in _json_list(machine, "AllowedIPs", "allowedIPs", "allowedIps"):
                 try:


### PR DESCRIPTION
## Capability

Direct Tailscale tailnet access to the Web UI (wildcard `setup_host` + Tailscale peer trust). Since Tailscale moved `tailscale whois --json` to the `Node` payload shape, every tailnet peer failed verification and direct access to `http://<tailscale-ip>:<port>` always returned `{"ok":false,"error":"remote_access_host_mismatch"}`.

## Root cause

`_is_trusted_tailscale_peer()` only reads a top-level `"Machine"` object from the whois payload, and parses `Addresses` entries with `ipaddress.ip_address()`:

- current Tailscale CLI (observed on 1.98.x) nests the peer record under a top-level `"Node"` key — `"Machine"` survives only as the machine-key *string* inside `Node`, so the lookup yields nothing;
- `Node.Addresses` entries are host CIDRs (`"100.64.0.2/32"`), which `ip_address()` rejects, so even a correct record produced an empty address set.

Both paths left `trusted = False` for every peer. The existing tests mocked `_tailscale_whois` with the legacy `Machine`/bare-IP shape, so the suite never exercised the real CLI format.

## Fix

- Fall back to the `"Node"` object when `"Machine"` is not a dict (both shapes stay accepted).
- Parse address entries as `ip_interface` and require a host prefix, so bare IPs and host CIDRs match while range entries (`"100.97.103.0/24"`) still cannot vouch for a peer.
- Security posture is unchanged: the AllowedIPs host-route gate (subnet routers / exit nodes rejected) still applies on top.

## Evidence

- **Unit**: new direct tests for `_is_trusted_tailscale_peer` — modern `Node` payload accepted, legacy `Machine` payload accepted, subnet-route `AllowedIPs` rejected, non-host `Addresses` entries ignored.
- **Contract**: `_mock_tailscale_whois` now defaults to the modern `Node`/host-CIDR shape, so all existing wildcard setup-host tests exercise the real CLI format; legacy shape remains covered explicitly.
- **Scenario**: no auth_setup catalog entry touched (no scenario IDs affected).
- **Manual**: reproduced and verified on macOS + Tailscale 1.98.x — before: `/health` via `http://100.x.y.z:5123` returned `remote_access_host_mismatch`; after: `{"status":"ok"}` and the UI loads, while localhost behavior is unchanged and `tailscale whois` for iOS/macOS peers passes the host-route gate.

`tests/test_ui_remote_access_auth.py` passes locally except three pre-existing environment-dependent failures also present on clean `master` (`test_docker_loopback_trust_does_not_bypass_ui_auth`, `test_docker_loopback_trust_accepts_runtime_default_gateway`, `test_remote_host_renews_cookie_past_half_ttl`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
