### PR TITLE
fix(opencode): make provider probes actionable

### DIFF
--- a/core/agent_auth_service.py
+++ b/core/agent_auth_service.py
@@ -2339,15 +2339,30 @@ class AgentAuthService:
         if server is None:
             return {"ok": False, "error": "opencode_server_unavailable"}
 
-        # Resolve the model id: caller-supplied wins, followed by Avibe's
-        # effective Agent default for this provider, then OpenCode's catalog.
+        # Match normal OpenCode turns: caller override, the selected OpenCode
+        # agent's model, Avibe's V2 fallback, then the provider catalog.
         chosen_model = (model or "").strip()
         backend_config = self._resolve_backend_config("opencode")
+        default_provider = getattr(backend_config, "default_provider", None)
+        if not chosen_model:
+            try:
+                default_agent = server.get_default_agent_from_config()
+                runtime_agent_model = server.get_agent_model_from_config(default_agent)
+            except Exception:  # noqa: BLE001
+                runtime_agent_model = None
+            chosen_model = (
+                resolve_opencode_configured_default_model(
+                    runtime_agent_model,
+                    default_provider=default_provider,
+                    provider_id=provider_id,
+                )
+                or ""
+            )
         if not chosen_model and backend_config is not None:
             chosen_model = (
                 resolve_opencode_configured_default_model(
                     getattr(backend_config, "default_model", None),
-                    default_provider=getattr(backend_config, "default_provider", None),
+                    default_provider=default_provider,
                     provider_id=provider_id,
                 )
                 or ""

--- a/core/agent_auth_service.py
+++ b/core/agent_auth_service.py
@@ -31,7 +31,11 @@ from modules.agents.opencode.message_processor import (
     extract_opencode_response_text,
     is_empty_terminal_opencode_message,
 )
-from modules.agents.opencode.utils import resolve_opencode_model_id, resolve_opencode_reasoning_effort
+from modules.agents.opencode.utils import (
+    resolve_opencode_configured_default_model,
+    resolve_opencode_model_id,
+    resolve_opencode_reasoning_effort,
+)
 from modules.im import InlineButton, InlineKeyboard, MessageContext
 from core.resource_governance import governor_from_controller
 from core.message_output import MessageOutput, terminal_turn_output
@@ -2325,7 +2329,7 @@ class AgentAuthService:
 
         ``model`` is the model id (e.g. ``"gpt-4o-mini"``); we wrap it
         into the ``{providerID, modelID}`` shape OpenCode expects. When
-        ``None``, OpenCode uses the provider's configured default.
+        ``None``, the probe resolves Avibe's effective Agent default first.
         """
         provider_id = (provider_id or "").strip()
         if not provider_id:
@@ -2335,11 +2339,19 @@ class AgentAuthService:
         if server is None:
             return {"ok": False, "error": "opencode_server_unavailable"}
 
-        # Resolve the model id: caller-supplied wins; otherwise look up
-        # the provider's default from the live catalog so the probe
-        # doesn't fail with "model is required" on providers that don't
-        # carry a config-level default.
+        # Resolve the model id: caller-supplied wins, followed by Avibe's
+        # effective Agent default for this provider, then OpenCode's catalog.
         chosen_model = (model or "").strip()
+        backend_config = self._resolve_backend_config("opencode")
+        if not chosen_model and backend_config is not None:
+            chosen_model = (
+                resolve_opencode_configured_default_model(
+                    getattr(backend_config, "default_model", None),
+                    default_provider=getattr(backend_config, "default_provider", None),
+                    provider_id=provider_id,
+                )
+                or ""
+            )
         if not chosen_model:
             try:
                 catalog = await server.get_available_models(os.path.expanduser("~"))
@@ -2508,6 +2520,15 @@ class AgentAuthService:
                                 detail = await server.get_provider_api_diagnostic(provider_id, chosen_model)
                             except Exception:  # noqa: BLE001
                                 detail = None
+                        classified = _classify_test_failure("", detail or "")
+                        if classified != "cli_failed":
+                            return {
+                                "ok": False,
+                                "error": classified,
+                                "detail": (detail or "")[:600],
+                                "duration_ms": int((time.monotonic() - started) * 1000),
+                                "model": chosen_model,
+                            }
                         i18n_key = (
                             "error.opencodeProviderRuntimeError"
                             if detail
@@ -2528,12 +2549,51 @@ class AgentAuthService:
                             "model": chosen_model,
                         }
                     break
+                try:
+                    detail = await server.get_recent_session_error(
+                        session_id,
+                        since=prompt_started_at,
+                    )
+                except Exception:  # noqa: BLE001
+                    detail = None
+                if detail:
+                    classified = _classify_test_failure("", detail)
+                    if classified in {
+                        "invalid_credentials",
+                        "forbidden",
+                        "model_not_found",
+                    }:
+                        return {
+                            "ok": False,
+                            "error": classified,
+                            "detail": detail[:600],
+                            "duration_ms": int((time.monotonic() - started) * 1000),
+                            "model": chosen_model,
+                        }
                 await asyncio.sleep(poll_interval)
             else:
+                try:
+                    detail = await server.get_recent_session_error(
+                        session_id,
+                        since=prompt_started_at,
+                    )
+                except Exception:  # noqa: BLE001
+                    detail = None
+                if detail:
+                    classified = _classify_test_failure("", detail)
+                    if classified != "cli_failed":
+                        return {
+                            "ok": False,
+                            "error": classified,
+                            "detail": detail[:600],
+                            "duration_ms": int((time.monotonic() - started) * 1000),
+                            "model": chosen_model,
+                        }
                 return {
                     "ok": False,
                     "error": "timed_out",
                     "duration_ms": int((time.monotonic() - started) * 1000),
+                    "model": chosen_model,
                 }
 
             duration_ms = int((time.monotonic() - started) * 1000)

--- a/modules/agents/opencode/server.py
+++ b/modules/agents/opencode/server.py
@@ -580,17 +580,38 @@ class OpenCodeServerManager:
         code = str(cause.get("code") or error.get("code") or "").strip()
         url = cls._safe_url(error.get("url") or cause.get("path"))
 
+        response_payload: object = error.get("responseBody")
+        if isinstance(response_payload, str):
+            try:
+                response_payload = json.loads(response_payload)
+            except (TypeError, ValueError):
+                response_payload = None
+        response_error = (
+            response_payload.get("error")
+            if isinstance(response_payload, dict)
+            else None
+        )
+        if not isinstance(response_error, dict):
+            response_error = response_payload if isinstance(response_payload, dict) else {}
+        response_type = str(response_error.get("type") or "").strip()
+        status_code = str(error.get("statusCode") or "").strip()
+
         message = ""
         data = error.get("data")
         if isinstance(data, dict):
             message = str(data.get("message") or "").strip()
         if not message:
             message = str(error.get("message") or "").strip()
+        if not message:
+            message = str(response_error.get("message") or "").strip()
         message = cls._redact_diagnostic_text(message)
 
         details = name
-        if code:
-            details += f" ({code})"
+        qualifiers = [value for value in (code, response_type) if value]
+        if status_code:
+            qualifiers.append(f"HTTP {status_code}")
+        if qualifiers:
+            details += f" ({'; '.join(dict.fromkeys(qualifiers))})"
         if url:
             details += f" while calling {url}"
         if message and message not in details:

--- a/modules/agents/opencode/server.py
+++ b/modules/agents/opencode/server.py
@@ -593,6 +593,7 @@ class OpenCodeServerManager:
         )
         if not isinstance(response_error, dict):
             response_error = response_payload if isinstance(response_payload, dict) else {}
+        response_code = str(response_error.get("code") or "").strip()
         response_type = str(response_error.get("type") or "").strip()
         status_code = str(error.get("statusCode") or "").strip()
 
@@ -607,7 +608,7 @@ class OpenCodeServerManager:
         message = cls._redact_diagnostic_text(message)
 
         details = name
-        qualifiers = [value for value in (code, response_type) if value]
+        qualifiers = [value for value in (code, response_code, response_type) if value]
         if status_code:
             qualifiers.append(f"HTTP {status_code}")
         if qualifiers:

--- a/modules/agents/opencode/utils.py
+++ b/modules/agents/opencode/utils.py
@@ -122,6 +122,26 @@ def resolve_opencode_model_id(
     return model_id
 
 
+def resolve_opencode_configured_default_model(
+    default_model: str | None,
+    *,
+    default_provider: str | None,
+    provider_id: str | None,
+) -> str | None:
+    """Return the configured agent model when it belongs to ``provider_id``."""
+
+    model = (default_model or "").strip()
+    provider = (provider_id or "").strip()
+    configured_provider = (default_provider or "").strip()
+    if not model or not provider:
+        return None
+
+    model_provider, model_id = _parse_model_key(model)
+    if model_provider:
+        return model_id if model_provider == provider and model_id else None
+    return model if configured_provider == provider else None
+
+
 def _opencode_model_supports_variant(model_info: dict | None, variant: str | None) -> bool:
     if not isinstance(model_info, dict) or not isinstance(variant, str) or not variant.strip():
         return False

--- a/tests/test_opencode_default_provider_routing.py
+++ b/tests/test_opencode_default_provider_routing.py
@@ -14,7 +14,10 @@ import dataclasses
 
 from config.v2_config import OpenCodeConfig
 from modules.agents.opencode.agent import resolve_opencode_model_dict
-from modules.agents.opencode.utils import resolve_opencode_model_id
+from modules.agents.opencode.utils import (
+    resolve_opencode_configured_default_model,
+    resolve_opencode_model_id,
+)
 
 
 def test_opencode_config_default_provider_is_unset_by_default() -> None:
@@ -59,6 +62,47 @@ def test_prefixed_model_ignores_default_provider() -> None:
         "providerID": "openai",
         "modelID": "gpt-5",
     }
+
+
+def test_configured_default_model_matches_bare_model_to_default_provider() -> None:
+    assert (
+        resolve_opencode_configured_default_model(
+            "gpt-5.4",
+            default_provider="openai",
+            provider_id="openai",
+        )
+        == "gpt-5.4"
+    )
+
+
+def test_configured_default_model_matches_explicit_provider_prefix() -> None:
+    assert (
+        resolve_opencode_configured_default_model(
+            "openai/gpt-5.4",
+            default_provider="anthropic",
+            provider_id="openai",
+        )
+        == "gpt-5.4"
+    )
+
+
+def test_configured_default_model_rejects_other_provider() -> None:
+    assert (
+        resolve_opencode_configured_default_model(
+            "gpt-5.4",
+            default_provider="openai",
+            provider_id="anthropic",
+        )
+        is None
+    )
+    assert (
+        resolve_opencode_configured_default_model(
+            "openai/gpt-5.4",
+            default_provider="openai",
+            provider_id="anthropic",
+        )
+        is None
+    )
 
 
 def test_model_id_uses_catalog_casing_for_unique_match() -> None:

--- a/tests/test_opencode_server.py
+++ b/tests/test_opencode_server.py
@@ -1742,7 +1742,8 @@ class OpenCodeServerTests(unittest.IsolatedAsyncioTestCase):
                                     'Model "gpt-5.3-chat-latest" is not supported by '
                                     "any configured account in this group"
                                 ),
-                                "type": "model_not_found",
+                                "code": "model_not_found",
+                                "type": "invalid_request_error",
                             }
                         }
                     ),
@@ -1760,7 +1761,7 @@ class OpenCodeServerTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(
             summary,
-            "AI_APICallError (model_not_found; HTTP 404) while calling "
+            "AI_APICallError (model_not_found; invalid_request_error; HTTP 404) while calling "
             'https://relay.example/v1/responses: Model "gpt-5.3-chat-latest" is not '
             "supported by any configured account in this group",
         )

--- a/tests/test_opencode_server.py
+++ b/tests/test_opencode_server.py
@@ -1727,6 +1727,44 @@ class OpenCodeServerTests(unittest.IsolatedAsyncioTestCase):
         self.assertNotIn("sk-secret", summary or "")
         self.assertNotIn("sk-query-secret", summary or "")
 
+    def test_recent_session_error_extracts_typed_response_body(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            log_dir = Path(tmp_dir)
+            line_payload = {
+                "error": {
+                    "name": "AI_APICallError",
+                    "url": "https://relay.example/v1/responses",
+                    "statusCode": 404,
+                    "responseBody": json.dumps(
+                        {
+                            "error": {
+                                "message": (
+                                    'Model "gpt-5.3-chat-latest" is not supported by '
+                                    "any configured account in this group"
+                                ),
+                                "type": "model_not_found",
+                            }
+                        }
+                    ),
+                }
+            }
+            (log_dir / "2026-07-20T064420.log").write_text(
+                "ERROR 2026-07-20T06:48:14 +1ms service=llm "
+                f"session.id=ses_test error={SERVER_MODULE.json.dumps(line_payload)} stream error\n",
+                encoding="utf-8",
+            )
+            manager = OpenCodeServerManager(binary="opencode", port=4096)
+
+            with patch.object(manager, "_opencode_log_dirs", return_value=[log_dir]):
+                summary = manager._recent_session_error_sync("ses_test")
+
+        self.assertEqual(
+            summary,
+            "AI_APICallError (model_not_found; HTTP 404) while calling "
+            'https://relay.example/v1/responses: Model "gpt-5.3-chat-latest" is not '
+            "supported by any configured account in this group",
+        )
+
     def test_recent_session_error_reads_only_log_tail(self):
         with tempfile.TemporaryDirectory() as tmp_dir:
             log_dir = Path(tmp_dir)

--- a/tests/test_ui_api.py
+++ b/tests/test_ui_api.py
@@ -982,10 +982,16 @@ def test_opencode_provider_catalog_keeps_builtin_overrides_read_only(monkeypatch
 
 
 @pytest.mark.parametrize(
-    ("available_models", "configured_model"),
+    ("available_models", "configured_model", "runtime_model", "expected_model"),
     [
-        ({"gpt-5.3-chat-latest": {}, "gpt-5.4": {}}, "gpt-5.4"),
-        ({"gpt-5.3-chat-latest": {}}, "gpt-5.4-new"),
+        ({"gpt-5.3-chat-latest": {}, "gpt-5.4": {}}, "gpt-5.4", None, "gpt-5.4"),
+        ({"gpt-5.3-chat-latest": {}}, "gpt-5.4-new", None, "gpt-5.4-new"),
+        (
+            {"gpt-5.3-chat-latest": {}, "gpt-5.4": {}, "gpt-5.4-runtime": {}},
+            "gpt-5.4",
+            "openai/gpt-5.4-runtime",
+            "gpt-5.4-runtime",
+        ),
     ],
 )
 def test_opencode_provider_catalog_prefers_configured_agent_default_model(
@@ -993,6 +999,8 @@ def test_opencode_provider_catalog_prefers_configured_agent_default_model(
     tmp_path,
     available_models,
     configured_model,
+    runtime_model,
+    expected_model,
 ):
     class _FakeServer:
         async def get_providers(self):
@@ -1018,6 +1026,12 @@ def test_opencode_provider_catalog_prefers_configured_agent_default_model(
         async def close_http_session(self, *, loop=None):
             pass
 
+        def get_default_agent_from_config(self):
+            return "build"
+
+        def get_agent_model_from_config(self, agent_name):
+            return runtime_model if agent_name == "build" else None
+
     async def _fake_get_server():
         return _FakeServer()
 
@@ -1039,7 +1053,7 @@ def test_opencode_provider_catalog_prefers_configured_agent_default_model(
     result = asyncio.run(api.get_opencode_providers_async())
 
     provider = next(provider for provider in result["providers"] if provider["id"] == "openai")
-    assert provider["default_model"] == configured_model
+    assert provider["default_model"] == expected_model
 
 
 def test_opencode_provider_catalog_marks_keyless_custom_provider_configured(

--- a/tests/test_ui_api.py
+++ b/tests/test_ui_api.py
@@ -981,6 +981,58 @@ def test_opencode_provider_catalog_keeps_builtin_overrides_read_only(monkeypatch
     assert entry["user_managed"] is False
 
 
+def test_opencode_provider_catalog_prefers_configured_agent_default_model(monkeypatch, tmp_path):
+    class _FakeServer:
+        async def get_providers(self):
+            return {
+                "all": [{"id": "openai", "name": "OpenAI"}],
+                "connected": ["openai"],
+            }
+
+        async def get_provider_auth(self):
+            return {}
+
+        async def get_available_models(self, directory):
+            return {
+                "providers": [
+                    {
+                        "id": "openai",
+                        "models": {
+                            "gpt-5.3-chat-latest": {},
+                            "gpt-5.4": {},
+                        },
+                    }
+                ],
+                "default": {"openai": "gpt-5.3-chat-latest"},
+            }
+
+        async def close_http_session(self, *, loop=None):
+            pass
+
+    async def _fake_get_server():
+        return _FakeServer()
+
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+    monkeypatch.setattr(api, "_opencode_get_server", _fake_get_server)
+    monkeypatch.setattr(
+        api,
+        "load_config",
+        lambda: SimpleNamespace(
+            agents=SimpleNamespace(
+                opencode=SimpleNamespace(
+                    default_provider="openai",
+                    default_model="gpt-5.4",
+                )
+            )
+        ),
+    )
+
+    result = asyncio.run(api.get_opencode_providers_async())
+
+    provider = next(provider for provider in result["providers"] if provider["id"] == "openai")
+    assert provider["default_model"] == "gpt-5.4"
+
+
 def test_opencode_provider_catalog_marks_keyless_custom_provider_configured(
     monkeypatch, tmp_path
 ):

--- a/tests/test_ui_api.py
+++ b/tests/test_ui_api.py
@@ -981,7 +981,19 @@ def test_opencode_provider_catalog_keeps_builtin_overrides_read_only(monkeypatch
     assert entry["user_managed"] is False
 
 
-def test_opencode_provider_catalog_prefers_configured_agent_default_model(monkeypatch, tmp_path):
+@pytest.mark.parametrize(
+    ("available_models", "configured_model"),
+    [
+        ({"gpt-5.3-chat-latest": {}, "gpt-5.4": {}}, "gpt-5.4"),
+        ({"gpt-5.3-chat-latest": {}}, "gpt-5.4-new"),
+    ],
+)
+def test_opencode_provider_catalog_prefers_configured_agent_default_model(
+    monkeypatch,
+    tmp_path,
+    available_models,
+    configured_model,
+):
     class _FakeServer:
         async def get_providers(self):
             return {
@@ -997,10 +1009,7 @@ def test_opencode_provider_catalog_prefers_configured_agent_default_model(monkey
                 "providers": [
                     {
                         "id": "openai",
-                        "models": {
-                            "gpt-5.3-chat-latest": {},
-                            "gpt-5.4": {},
-                        },
+                        "models": available_models,
                     }
                 ],
                 "default": {"openai": "gpt-5.3-chat-latest"},
@@ -1021,7 +1030,7 @@ def test_opencode_provider_catalog_prefers_configured_agent_default_model(monkey
             agents=SimpleNamespace(
                 opencode=SimpleNamespace(
                     default_provider="openai",
-                    default_model="gpt-5.4",
+                    default_model=configured_model,
                 )
             )
         ),
@@ -1030,7 +1039,7 @@ def test_opencode_provider_catalog_prefers_configured_agent_default_model(monkey
     result = asyncio.run(api.get_opencode_providers_async())
 
     provider = next(provider for provider in result["providers"] if provider["id"] == "openai")
-    assert provider["default_model"] == "gpt-5.4"
+    assert provider["default_model"] == configured_model
 
 
 def test_opencode_provider_catalog_marks_keyless_custom_provider_configured(

--- a/tests/test_web_oauth_flow.py
+++ b/tests/test_web_oauth_flow.py
@@ -578,6 +578,7 @@ class _FakeOpencodeServer:
         self.active_calls: list[str] = []
         self.inactive_calls: list[str] = []
         self.message_sent = False
+        self.recent_error: str | None = None
 
     async def get_provider_auth(self):
         return self.auth_map
@@ -605,7 +606,7 @@ class _FakeOpencodeServer:
         self.abort_calls.append((session_id, directory))
 
     async def get_recent_session_error(self, session_id, since=None):
-        return None
+        return self.recent_error
 
     async def get_provider_api_diagnostic(self, provider_id, model_id):
         return None
@@ -776,6 +777,132 @@ def test_opencode_provider_test_returns_excerpt_from_non_text_part(
     assert fake.active_calls == ["sess_probe"]
     assert fake.abort_calls == [("sess_probe", os.path.expanduser("~"))]
     assert fake.inactive_calls == ["sess_probe"]
+
+
+def test_opencode_provider_test_prefers_configured_agent_default_model(
+    service: AgentAuthService, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    fake = _FakeOpencodeServer()
+    fake.catalog = {
+        "providers": [
+            {
+                "id": "openai",
+                "models": {
+                    "gpt-5.3-chat-latest": {},
+                    "gpt-5.4": {},
+                },
+            }
+        ],
+        "default": {"openai": "gpt-5.3-chat-latest"},
+    }
+    fake.messages = [
+        {
+            "info": {
+                "id": "msg_assistant",
+                "role": "assistant",
+                "time": {"completed": 123},
+                "finish": "stop",
+            },
+            "parts": [{"type": "text", "text": "OK"}],
+        }
+    ]
+    monkeypatch.setattr(service, "_opencode_server", AsyncMock(return_value=fake))
+    monkeypatch.setattr(
+        service,
+        "_resolve_backend_config",
+        lambda backend: SimpleNamespace(
+            default_provider="openai",
+            default_model="gpt-5.4",
+        )
+        if backend == "opencode"
+        else None,
+    )
+
+    result = _run(service.test_opencode_provider("openai"))
+
+    assert result["ok"] is True
+    assert result["model"] == "gpt-5.4"
+    assert fake.prompt_calls[-1]["model"] == {
+        "providerID": "openai",
+        "modelID": "gpt-5.4",
+    }
+
+
+def test_opencode_provider_test_surfaces_non_retryable_log_error_before_timeout(
+    service: AgentAuthService, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    fake = _FakeOpencodeServer()
+    fake.catalog = {
+        "providers": [
+            {
+                "id": "openai",
+                "models": {"gpt-5.3-chat-latest": {}},
+            }
+        ]
+    }
+    fake.recent_error = (
+        "AI_APICallError (model_not_found) while calling "
+        'https://relay.example/v1/responses: Model "gpt-5.3-chat-latest" is not supported'
+    )
+    monkeypatch.setattr(service, "_opencode_server", AsyncMock(return_value=fake))
+
+    result = _run(
+        service.test_opencode_provider(
+            "openai",
+            model="gpt-5.3-chat-latest",
+            timeout=0.1,
+        )
+    )
+
+    assert result["ok"] is False
+    assert result["error"] == "model_not_found"
+    assert result["model"] == "gpt-5.3-chat-latest"
+    assert "not supported" in result["detail"]
+    assert result["duration_ms"] < 100
+    assert fake.abort_calls == [("sess_probe", os.path.expanduser("~"))]
+    assert fake.inactive_calls == ["sess_probe"]
+
+
+def test_opencode_provider_test_classifies_log_error_for_empty_terminal(
+    service: AgentAuthService, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    fake = _FakeOpencodeServer()
+    fake.catalog = {
+        "providers": [
+            {
+                "id": "openai",
+                "models": {"gpt-5.3-chat-latest": {}},
+            }
+        ]
+    }
+    fake.messages = [
+        {
+            "info": {
+                "id": "msg_assistant",
+                "role": "assistant",
+                "time": {"completed": 123},
+                "finish": "unknown",
+            },
+            "parts": [],
+        }
+    ]
+    fake.recent_error = (
+        "AI_APICallError (model_not_found; HTTP 404): "
+        'Model "gpt-5.3-chat-latest" is not supported'
+    )
+    monkeypatch.setattr(service, "_opencode_server", AsyncMock(return_value=fake))
+
+    result = _run(
+        service.test_opencode_provider(
+            "openai",
+            model="gpt-5.3-chat-latest",
+        )
+    )
+
+    assert result["ok"] is False
+    assert result["error"] == "model_not_found"
+    assert result["model"] == "gpt-5.3-chat-latest"
+    assert "not supported" in result["detail"]
 
 
 def test_opencode_provider_test_fails_on_empty_terminal_message(

--- a/tests/test_web_oauth_flow.py
+++ b/tests/test_web_oauth_flow.py
@@ -579,6 +579,8 @@ class _FakeOpencodeServer:
         self.inactive_calls: list[str] = []
         self.message_sent = False
         self.recent_error: str | None = None
+        self.default_agent = "build"
+        self.agent_model: str | None = None
 
     async def get_provider_auth(self):
         return self.auth_map
@@ -610,6 +612,12 @@ class _FakeOpencodeServer:
 
     async def get_provider_api_diagnostic(self, provider_id, model_id):
         return None
+
+    def get_default_agent_from_config(self):
+        return self.default_agent
+
+    def get_agent_model_from_config(self, agent_name):
+        return self.agent_model if agent_name == self.default_agent else None
 
     async def start_provider_oauth(self, provider_id, *, method, prompt_answers):
         self.start_calls.append((provider_id, method, prompt_answers))
@@ -825,6 +833,57 @@ def test_opencode_provider_test_prefers_configured_agent_default_model(
     assert fake.prompt_calls[-1]["model"] == {
         "providerID": "openai",
         "modelID": "gpt-5.4",
+    }
+
+
+def test_opencode_provider_test_prefers_runtime_agent_model(
+    service: AgentAuthService, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    fake = _FakeOpencodeServer()
+    fake.agent_model = "openai/gpt-5.4-runtime"
+    fake.catalog = {
+        "providers": [
+            {
+                "id": "openai",
+                "models": {
+                    "gpt-5.3-chat-latest": {},
+                    "gpt-5.4": {},
+                    "gpt-5.4-runtime": {},
+                },
+            }
+        ],
+        "default": {"openai": "gpt-5.3-chat-latest"},
+    }
+    fake.messages = [
+        {
+            "info": {
+                "id": "msg_assistant",
+                "role": "assistant",
+                "time": {"completed": 123},
+                "finish": "stop",
+            },
+            "parts": [{"type": "text", "text": "OK"}],
+        }
+    ]
+    monkeypatch.setattr(service, "_opencode_server", AsyncMock(return_value=fake))
+    monkeypatch.setattr(
+        service,
+        "_resolve_backend_config",
+        lambda backend: SimpleNamespace(
+            default_provider="openai",
+            default_model="gpt-5.4",
+        )
+        if backend == "opencode"
+        else None,
+    )
+
+    result = _run(service.test_opencode_provider("openai"))
+
+    assert result["ok"] is True
+    assert result["model"] == "gpt-5.4-runtime"
+    assert fake.prompt_calls[-1]["model"] == {
+        "providerID": "openai",
+        "modelID": "gpt-5.4-runtime",
     }
 
 

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -9796,8 +9796,7 @@ async def _get_opencode_providers_async() -> dict:
                 pid,
                 preferred_model,
             )
-            if preferred_model in model_ids:
-                default_model = preferred_model
+            default_model = preferred_model
 
         out_providers.append(
             {

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -9603,12 +9603,16 @@ async def _get_opencode_providers_async() -> dict:
     # it became a no-op (no state change to persist), silently
     # blocking users from picking Anthropic explicitly.
     default_provider: str | None = None
+    configured_default_model: str | None = None
     try:
         config = load_config()
         cfg = getattr(getattr(config, "agents", None), "opencode", None)
         configured_default = getattr(cfg, "default_provider", None)
         if isinstance(configured_default, str) and configured_default.strip():
             default_provider = configured_default.strip()
+        raw_default_model = getattr(cfg, "default_model", None)
+        if isinstance(raw_default_model, str) and raw_default_model.strip():
+            configured_default_model = raw_default_model.strip()
     except Exception:
         pass
 
@@ -9701,6 +9705,11 @@ async def _get_opencode_providers_async() -> dict:
         api_key_mask_index[pid_key] = masked
         active_auth_type_index[pid_key] = "api"
 
+    from modules.agents.opencode.utils import (
+        resolve_opencode_configured_default_model,
+        resolve_opencode_model_id,
+    )
+
     out_providers = []
     for pid, entry in all_providers.items():
         if not isinstance(entry, dict):
@@ -9776,6 +9785,19 @@ async def _get_opencode_providers_async() -> dict:
             raw_default = defaults_block.get(pid)
             if isinstance(raw_default, str):
                 default_model = raw_default
+        preferred_model = resolve_opencode_configured_default_model(
+            configured_default_model,
+            default_provider=default_provider,
+            provider_id=pid,
+        )
+        if preferred_model:
+            preferred_model = resolve_opencode_model_id(
+                config_raw,
+                pid,
+                preferred_model,
+            )
+            if preferred_model in model_ids:
+                default_model = preferred_model
 
         out_providers.append(
             {

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -9595,6 +9595,12 @@ async def _get_opencode_providers_async() -> dict:
 
     auth_index = auth_raw if isinstance(auth_raw, dict) else {}
 
+    try:
+        default_agent = server.get_default_agent_from_config()
+        runtime_agent_model = server.get_agent_model_from_config(default_agent)
+    except Exception:  # noqa: BLE001
+        runtime_agent_model = None
+
     # Resolve the user-configured default provider. ``None`` means
     # the user has not picked one — the UI surfaces that as "no
     # default selected" so clicking a provider actually persists the
@@ -9786,10 +9792,16 @@ async def _get_opencode_providers_async() -> dict:
             if isinstance(raw_default, str):
                 default_model = raw_default
         preferred_model = resolve_opencode_configured_default_model(
-            configured_default_model,
+            runtime_agent_model,
             default_provider=default_provider,
             provider_id=pid,
         )
+        if not preferred_model:
+            preferred_model = resolve_opencode_configured_default_model(
+                configured_default_model,
+                default_provider=default_provider,
+                provider_id=pid,
+            )
         if preferred_model:
             preferred_model = resolve_opencode_model_id(
                 config_raw,


### PR DESCRIPTION
## Summary

- make OpenCode provider probes use the same default model precedence as real turns: OpenCode agent, Avibe V2 fallback, then provider catalog
- surface safe, typed upstream failures from the current OpenCode session log instead of waiting for the generic 60-second timeout
- keep response diagnostics limited to redacted error type, HTTP status, URL without query parameters, and message

## Why

The OpenAI provider catalog advertised `gpt-5.3-chat-latest` as its daemon default even though Avibe was configured to run `gpt-5.4`. The Settings probe therefore tested the wrong model. The upstream returned `model_not_found` with HTTP 404, but OpenCode completed an empty assistant message only when the probe was aborted, so Avibe reported a misleading timeout.

## Evidence

- Unit/contract: 233 focused tests pass across runtime-agent/V2/catalog model routing, provider API, OpenCode log parsing, and web probe behavior, including stale catalogs and standard error envelopes
- Static: Ruff and `git diff --check` pass
- Build: UI production build passes
- Scenario: isolated local Incus worktree environment reports OpenAI default `gpt-5.4`; an implicit probe succeeds with `gpt-5.4` in about 4.6 seconds
- Scenario: the known unsupported `gpt-5.3-chat-latest` returns typed `model_not_found`, HTTP 404 detail, and cleanup in about 1.6 seconds instead of timing out

## Residual checks

- No UI source changed; the existing provider test panel consumes the corrected provider catalog value.
- Retryable network, rate-limit, and server failures are still allowed to recover until the probe deadline; only deterministic credential, permission, and model failures short-circuit.
