### PR TITLE
fix(workbench): constrain ActivityStrip and recover realtime

### DIFF
--- a/ui/src/components/workbench/ChatPage.tsx
+++ b/ui/src/components/workbench/ChatPage.tsx
@@ -27,6 +27,7 @@ import {
 import { useFileDrop } from '../../lib/useFileDrop';
 import { quoteText } from '../../lib/quoteText';
 import { mergeById, insertMessageOrdered } from '../../lib/transcriptOrder';
+import type { WorkbenchEventConnectionState } from '../../lib/workbenchEventConnection';
 import { AgentRoutePicker } from './AgentRoutePicker';
 import { ShowPageShareControl } from './ShowPageShareControl';
 import { SelectionQuoteToolbar } from './SelectionQuoteToolbar';
@@ -321,6 +322,8 @@ export const ChatPage: React.FC = () => {
   const workingRef = useRef(working);
   workingRef.current = working;
   const [runtimeState, setRuntimeState] = useState<SessionRuntimeState>(emptyRuntimeState);
+  const [realtimeConnection, setRealtimeConnection] =
+    useState<WorkbenchEventConnectionState>('connected');
   // Global background-work banner toggle (spec req 2), persisted server-side.
   // Tri-state: null = not yet known → suppress the banner so a stored "off"
   // never flashes on first paint; resolves to the stored value (ON when absent),
@@ -1066,6 +1069,7 @@ export const ChatPage: React.FC = () => {
         void syncTurnState();
         void refreshSessionRowUntilNativeBound();
       },
+      onConnectionState: setRealtimeConnection,
       onError: () => {
         // Browser EventSource auto-reconnects; keep the page usable.
       },
@@ -1889,7 +1893,12 @@ export const ChatPage: React.FC = () => {
             ) : null
           }
         />
-        <ActivityStrip state={runtimeState} sessionId={sessionId ?? ''} enabled={bannerEnabled === true} />
+        <ActivityStrip
+          state={runtimeState}
+          sessionId={sessionId ?? ''}
+          enabled={bannerEnabled === true}
+          connection={realtimeConnection}
+        />
         <QueueStrip queue={queue} onRemove={removeQueued} onRecall={recallQueued} onSendNow={sendQueueNow} />
         {sessionId && pendingApprovals.length > 0 ? (
           <VaultApprovalFloat offscreen={offscreenApprovals} pending={pendingApprovals} onResolved={refreshVaultRequests} />
@@ -2073,7 +2082,8 @@ const ActivityStrip: React.FC<{
   state: SessionRuntimeState;
   sessionId: string;
   enabled: boolean;
-}> = ({ state, sessionId, enabled }) => {
+  connection: WorkbenchEventConnectionState;
+}> = ({ state, sessionId, enabled, connection }) => {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const [open, setOpen] = useState(false);
@@ -2091,7 +2101,7 @@ const ActivityStrip: React.FC<{
     : '';
   const connectionVisible =
     active.length > 0 &&
-    (state.connection === 'reconnecting' || state.connection === 'disconnected');
+    (connection === 'reconnecting' || connection === 'disconnected');
   const expandable = active.length > 0;
   const navigateTo = (path: string) => {
     setOpen(false);
@@ -2104,7 +2114,7 @@ const ActivityStrip: React.FC<{
       role="status"
       aria-live="polite"
       className={clsx(
-        'min-h-7 min-w-0 max-w-[420px] gap-2 px-3 py-1 text-[11px] font-normal shadow-sm shadow-mint/5',
+        'min-h-7 min-w-0 max-w-full gap-2 px-3 py-1 text-[11px] font-normal shadow-sm shadow-mint/5',
         expandable && 'cursor-pointer select-none',
       )}
       indicator={
@@ -2123,8 +2133,11 @@ const ActivityStrip: React.FC<{
             {firstLabel ? ` · ${firstLabel}` : ''}
           </span>
           {connectionVisible ? (
-            <span className="shrink-0 border-l border-border-strong pl-2 text-gold">
-              {t(`chat.activities.connection.${state.connection}`)}
+            <span
+              className="shrink-0 border-l border-border-strong pl-2 text-gold"
+              title={t(`chat.activities.connection.${connection}Title`)}
+            >
+              {t(`chat.activities.connection.${connection}`)}
             </span>
           ) : null}
           {expandable ? (
@@ -2147,7 +2160,7 @@ const ActivityStrip: React.FC<{
               <button
                 type="button"
                 aria-label={t('chat.activities.toggle')}
-                className="block max-w-full rounded-full outline-none focus-visible:ring-2 focus-visible:ring-mint/40"
+                className="block w-fit max-w-[min(420px,100%)] rounded-full outline-none focus-visible:ring-2 focus-visible:ring-mint/40"
               >
                 {pill}
               </button>

--- a/ui/src/components/workbench/ChatPage.tsx
+++ b/ui/src/components/workbench/ChatPage.tsx
@@ -27,7 +27,6 @@ import {
 import { useFileDrop } from '../../lib/useFileDrop';
 import { quoteText } from '../../lib/quoteText';
 import { mergeById, insertMessageOrdered } from '../../lib/transcriptOrder';
-import type { WorkbenchEventConnectionState } from '../../lib/workbenchEventConnection';
 import { AgentRoutePicker } from './AgentRoutePicker';
 import { ShowPageShareControl } from './ShowPageShareControl';
 import { SelectionQuoteToolbar } from './SelectionQuoteToolbar';
@@ -322,8 +321,7 @@ export const ChatPage: React.FC = () => {
   const workingRef = useRef(working);
   workingRef.current = working;
   const [runtimeState, setRuntimeState] = useState<SessionRuntimeState>(emptyRuntimeState);
-  const [realtimeConnection, setRealtimeConnection] =
-    useState<WorkbenchEventConnectionState>('connected');
+  const [eventStreamConnected, setEventStreamConnected] = useState(false);
   // Global background-work banner toggle (spec req 2), persisted server-side.
   // Tri-state: null = not yet known → suppress the banner so a stored "off"
   // never flashes on first paint; resolves to the stored value (ON when absent),
@@ -387,10 +385,6 @@ export const ChatPage: React.FC = () => {
     setLiveRows(next.rows);
     setLiveStartedAt(next.startedAt);
   }, []);
-  // Bumped on resume (tab visible again / network back) to force the transcript
-  // subscription effect to reopen a possibly-dead SSE stream — see the
-  // visibility effect below.
-  const [connectionEpoch, setConnectionEpoch] = useState(0);
   // Lifecycle guards for ``syncTurnState``'s clear-on-idle (Codex P2):
   //  - ``turnEpochRef`` bumps every time a turn STARTS (local send / send-now /
   //    observed ``turn.start``). syncTurnState captures it before its request and
@@ -1069,13 +1063,18 @@ export const ChatPage: React.FC = () => {
         void syncTurnState();
         void refreshSessionRowUntilNativeBound();
       },
-      onConnectionState: setRealtimeConnection,
-      onError: () => {
-        // Browser EventSource auto-reconnects; keep the page usable.
+      onConnectionState: (state) => {
+        const connected = state === 'connected';
+        setEventStreamConnected(connected);
+        if (!connected) void syncTurnState();
       },
-    }, { reconnect: connectionEpoch > 0 });
+      onError: () => {
+        // ApiContext owns the explicit retry loop; keep the page usable while
+        // the turn-state fallback below reconciles durable activity data.
+      },
+    });
     return disconnect;
-  }, [api, sessionId, appendMessage, reconcile, refreshQueue, syncTurnState, refreshSessionRowUntilNativeBound, markWorking, connectionEpoch, goBack, ingestActivityRow, scheduleActivityRefresh, dispatchLive]);
+  }, [api, sessionId, appendMessage, reconcile, refreshQueue, syncTurnState, refreshSessionRowUntilNativeBound, markWorking, goBack, ingestActivityRow, scheduleActivityRefresh, dispatchLive]);
 
   // Mobile tabs (the common case for IM users) get backgrounded mid-turn; the
   // SSE feed can be suspended without a clean reconnect, dropping the reply.
@@ -1083,32 +1082,21 @@ export const ChatPage: React.FC = () => {
   // catch up to durable storage.
   useEffect(() => {
     if (!sessionId) return;
-    const onVisible = () => {
+    const resync = () => {
       if (document.visibilityState !== 'visible') return;
       // A suspended tab can drop the reply AND the turn.end, so recover all
       // three: missed rows, the queue, and the working/Stop state (Codex P2).
       void reconcile();
       void refreshQueue();
       void syncTurnState();
-      // The immediate reconcile above only catches up to NOW; if the socket
-      // itself is dead (iOS can leave EventSource in a zombie OPEN state that
-      // never auto-reconnects), it would be the last update until the next
-      // resume. Reopen the stream so live events keep flowing while the page
-      // stays foregrounded — the reopen's onConnected re-runs reconcile
-      // (idempotent).
-      setConnectionEpoch((e) => e + 1);
     };
-    document.addEventListener('visibilitychange', onVisible);
-    // Network flaps (mobile handoff, sleep/wake) can kill the stream without a
-    // visibility change; reopen it on ``online`` too (only while foregrounded —
-    // a background resume is handled by visibilitychange).
-    const onOnline = () => {
-      if (document.visibilityState === 'visible') setConnectionEpoch((e) => e + 1);
-    };
-    window.addEventListener('online', onOnline);
+    document.addEventListener('visibilitychange', resync);
+    window.addEventListener('online', resync);
+    window.addEventListener('focus', resync);
     return () => {
-      document.removeEventListener('visibilitychange', onVisible);
-      window.removeEventListener('online', onOnline);
+      document.removeEventListener('visibilitychange', resync);
+      window.removeEventListener('online', resync);
+      window.removeEventListener('focus', resync);
     };
   }, [sessionId, reconcile, refreshQueue, syncTurnState]);
 
@@ -1130,13 +1118,14 @@ export const ChatPage: React.FC = () => {
       runtimeState.background_activities.length > 0 ||
       runtimeState.pending_activity_output_count > 0 ||
       runtimeState.connection === 'reconnecting';
-    if (!working && !hasBackgroundState) return;
+    const needsStreamFallback = !eventStreamConnected;
+    if (!working && !hasBackgroundState && !needsStreamFallback) return;
     const interval = window.setInterval(() => {
       if (document.visibilityState !== 'visible') return;
       void syncTurnState();
-    }, hasBackgroundState ? ACTIVITY_RECONCILE_INTERVAL_MS : WORKING_RECONCILE_INTERVAL_MS);
+    }, hasBackgroundState || needsStreamFallback ? ACTIVITY_RECONCILE_INTERVAL_MS : WORKING_RECONCILE_INTERVAL_MS);
     return () => window.clearInterval(interval);
-  }, [working, runtimeState.background_activities.length, runtimeState.pending_activity_output_count, runtimeState.connection, syncTurnState]);
+  }, [working, runtimeState.background_activities.length, runtimeState.pending_activity_output_count, runtimeState.connection, eventStreamConnected, syncTurnState]);
 
   const sendMessage = useCallback(
     async (
@@ -1897,7 +1886,6 @@ export const ChatPage: React.FC = () => {
           state={runtimeState}
           sessionId={sessionId ?? ''}
           enabled={bannerEnabled === true}
-          connection={realtimeConnection}
         />
         <QueueStrip queue={queue} onRemove={removeQueued} onRecall={recallQueued} onSendNow={sendQueueNow} />
         {sessionId && pendingApprovals.length > 0 ? (
@@ -2082,8 +2070,7 @@ const ActivityStrip: React.FC<{
   state: SessionRuntimeState;
   sessionId: string;
   enabled: boolean;
-  connection: WorkbenchEventConnectionState;
-}> = ({ state, sessionId, enabled, connection }) => {
+}> = ({ state, sessionId, enabled }) => {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const [open, setOpen] = useState(false);
@@ -2099,9 +2086,6 @@ const ActivityStrip: React.FC<{
   const firstLabel = first
     ? resolveActivityLabel(first, t(`chat.activities.kind.${activityKindI18nKey(first)}`))
     : '';
-  const connectionVisible =
-    active.length > 0 &&
-    (connection === 'reconnecting' || connection === 'disconnected');
   const expandable = active.length > 0;
   const navigateTo = (path: string) => {
     setOpen(false);
@@ -2132,14 +2116,6 @@ const ActivityStrip: React.FC<{
               : t('chat.activities.delivering', { count: pendingOutputs })}
             {firstLabel ? ` · ${firstLabel}` : ''}
           </span>
-          {connectionVisible ? (
-            <span
-              className="shrink-0 border-l border-border-strong pl-2 text-gold"
-              title={t(`chat.activities.connection.${connection}Title`)}
-            >
-              {t(`chat.activities.connection.${connection}`)}
-            </span>
-          ) : null}
           {expandable ? (
             <ChevronDown
               className={clsx('size-3.5 shrink-0 text-muted transition-transform', open && 'rotate-180')}

--- a/ui/src/components/workbench/ChatPage.tsx
+++ b/ui/src/components/workbench/ChatPage.tsx
@@ -778,11 +778,11 @@ export const ChatPage: React.FC = () => {
   // directions: sets Stop when a turn is live, and clears a stale Stop (a
   // ``turn.end`` we missed while the socket was down) when the controller reports
   // idle — guarded so it can't drop a turn that's genuinely starting.
-  const syncTurnState = useCallback(async () => {
+  const syncTurnState = useCallback(async (options?: { quiet?: boolean }) => {
     if (!sessionId) return;
     const epochAtRequest = turnEpochRef.current;
     try {
-      const res = await api.getTurnState(sessionId);
+      const res = await api.getTurnState(sessionId, { handleError: !options?.quiet });
       if (sessionId !== sessionIdRef.current) return;
       if (res.foreground === 'unknown') return;
       setRuntimeState(res);
@@ -1060,13 +1060,13 @@ export const ChatPage: React.FC = () => {
         // a native bind whose turn.end we missed.
         void reconcile();
         void refreshQueue();
-        void syncTurnState();
+        void syncTurnState({ quiet: true });
         void refreshSessionRowUntilNativeBound();
       },
       onConnectionState: (state) => {
         const connected = state === 'connected';
         setEventStreamConnected(connected);
-        if (!connected) void syncTurnState();
+        if (!connected) void syncTurnState({ quiet: true });
       },
       onError: () => {
         // ApiContext owns the explicit retry loop; keep the page usable while
@@ -1088,7 +1088,7 @@ export const ChatPage: React.FC = () => {
       // three: missed rows, the queue, and the working/Stop state (Codex P2).
       void reconcile();
       void refreshQueue();
-      void syncTurnState();
+      void syncTurnState({ quiet: true });
     };
     document.addEventListener('visibilitychange', resync);
     window.addEventListener('online', resync);
@@ -1122,7 +1122,7 @@ export const ChatPage: React.FC = () => {
     if (!working && !hasBackgroundState && !needsStreamFallback) return;
     const interval = window.setInterval(() => {
       if (document.visibilityState !== 'visible') return;
-      void syncTurnState();
+      void syncTurnState({ quiet: needsStreamFallback });
     }, hasBackgroundState || needsStreamFallback ? ACTIVITY_RECONCILE_INTERVAL_MS : WORKING_RECONCILE_INTERVAL_MS);
     return () => window.clearInterval(interval);
   }, [working, runtimeState.background_activities.length, runtimeState.pending_activity_output_count, runtimeState.connection, eventStreamConnected, syncTurnState]);

--- a/ui/src/context/ApiContext.tsx
+++ b/ui/src/context/ApiContext.tsx
@@ -4,6 +4,10 @@ import { useToast } from './ToastContext';
 import { apiFetch } from '../lib/apiFetch';
 import type { TurnActivityGroupWire } from '../lib/agentActivity';
 import type { VaultSessionPolicy } from '../lib/vaultSandboxPolicy';
+import {
+  eventSourceErrorConnectionState,
+  type WorkbenchEventConnectionState,
+} from '../lib/workbenchEventConnection';
 import type { DockDoc } from './DockContext';
 
 // The workbench Dock API response shape ({ ok, dock }); the Dock document type
@@ -914,6 +918,7 @@ export type WorkbenchEventEnvelope<T = unknown> = {
 
 export type WorkbenchEventHandlers = {
   onConnected?: (data: { sub_id: number; source?: 'browser' | 'controller' }) => void;
+  onConnectionState?: (state: WorkbenchEventConnectionState) => void;
   onEventBridgeStatus?: (data: { connected: boolean }) => void;
   onMessageNew?: (data: WorkbenchMessage) => void;
   onSessionActivity?: (data: { session_id: string; scope_id: string | null; event: string; title?: string | null }) => void;
@@ -1769,6 +1774,7 @@ export const ApiProvider: React.FC<{ children: React.ReactNode }> = ({ children 
   const eventHandlersRef = useRef(new Set<WorkbenchEventHandlers>());
   const eventConnectionRef = useRef<{ sub_id: number; source?: 'browser' | 'controller' } | null>(null);
   const eventBridgeConnectedRef = useRef(false);
+  const eventConnectionStateRef = useRef<WorkbenchEventConnectionState>('disconnected');
 
   const handleApiError = async (res: Response, path: string) => {
     let errorMessage = `Request failed: ${path} (${res.status})`;
@@ -1868,6 +1874,12 @@ export const ApiProvider: React.FC<{ children: React.ReactNode }> = ({ children 
     }
   };
 
+  const setWorkbenchEventConnectionState = (state: WorkbenchEventConnectionState) => {
+    if (eventConnectionStateRef.current === state) return;
+    eventConnectionStateRef.current = state;
+    dispatchToWorkbenchHandlers((handlers) => handlers.onConnectionState?.(state));
+  };
+
   const parseWorkbenchEnvelope = <T,>(raw: string): WorkbenchEventEnvelope<T> | null => {
     try {
       return JSON.parse(raw) as WorkbenchEventEnvelope<T>;
@@ -1892,7 +1904,13 @@ export const ApiProvider: React.FC<{ children: React.ReactNode }> = ({ children 
 
     const source = new EventSource('/api/events');
     eventSourceRef.current = source;
+    setWorkbenchEventConnectionState('reconnecting');
+    source.onopen = () => {
+      if (eventSourceRef.current !== source) return;
+      setWorkbenchEventConnectionState('connected');
+    };
     source.addEventListener('connected', (e: MessageEvent) => {
+      if (eventSourceRef.current !== source) return;
       try {
         const parsed = JSON.parse(e.data) as { sub_id?: number; type?: string; data?: unknown };
         const sourceKind = typeof parsed.sub_id === 'number' ? 'browser' : 'controller';
@@ -1902,6 +1920,7 @@ export const ApiProvider: React.FC<{ children: React.ReactNode }> = ({ children 
         };
         if (sourceKind === 'controller') {
           eventBridgeConnectedRef.current = true;
+          setWorkbenchEventConnectionState('connected');
           dispatchToWorkbenchHandlers((handlers) => handlers.onEventBridgeStatus?.({ connected: true }));
         }
       } catch (err) {
@@ -2038,17 +2057,21 @@ export const ApiProvider: React.FC<{ children: React.ReactNode }> = ({ children 
       });
     });
     source.addEventListener('workbench.events.bridge.status', (e: MessageEvent) => {
+      if (eventSourceRef.current !== source) return;
       const envelope = parseWorkbenchEnvelope<{ connected: boolean }>(e.data);
       if (!envelope) return;
       eventBridgeConnectedRef.current = envelope.data.connected;
+      setWorkbenchEventConnectionState(envelope.data.connected ? 'connected' : 'disconnected');
       dispatchToWorkbenchHandlers((handlers) => {
         handlers.onAny?.(envelope);
         handlers.onEventBridgeStatus?.(envelope.data);
       });
     });
     source.onerror = (err) => {
+      if (eventSourceRef.current !== source) return;
       eventConnectionRef.current = null;
       eventBridgeConnectedRef.current = false;
+      setWorkbenchEventConnectionState(eventSourceErrorConnectionState(source.readyState));
       dispatchToWorkbenchHandlers((handlers) => handlers.onEventBridgeStatus?.({ connected: false }));
       dispatchToWorkbenchHandlers((handlers) => handlers.onError?.(err));
     };
@@ -2716,6 +2739,11 @@ export const ApiProvider: React.FC<{ children: React.ReactNode }> = ({ children 
     connectWorkbenchEvents: (handlers, options) => {
       eventHandlersRef.current.add(handlers);
       ensureWorkbenchEventSource(options);
+      queueMicrotask(() => {
+        if (eventHandlersRef.current.has(handlers)) {
+          handlers.onConnectionState?.(eventConnectionStateRef.current);
+        }
+      });
       if (
         eventConnectionRef.current &&
         (eventConnectionRef.current.source !== 'controller' || eventBridgeConnectedRef.current)

--- a/ui/src/context/ApiContext.tsx
+++ b/ui/src/context/ApiContext.tsx
@@ -606,10 +606,10 @@ export type ApiContextType = {
   listSessionQueue: (sessionId: string, options?: { cache?: boolean }) => Promise<{ queued: WorkbenchMessage[] }>;
   removeQueuedMessage: (sessionId: string, messageId: string) => Promise<{ removed: boolean }>;
   sendQueuedNow: (sessionId: string, messageId: string) => Promise<{ ok: boolean; status?: string; code?: string; detail?: string }>;
-  getTurnState: (sessionId: string) => Promise<SessionRuntimeState>;
+  getTurnState: (sessionId: string, options?: { handleError?: boolean }) => Promise<SessionRuntimeState>;
   getSessionDraft: (sessionId: string) => Promise<{ text: string }>;
   setSessionDraft: (sessionId: string, text: string) => Promise<{ ok: boolean }>;
-  listInbox: (params?: { platform?: string; unreadOnly?: boolean; limit?: number; before?: string; cache?: boolean }) => Promise<InboxFeedResult>;
+  listInbox: (params?: { platform?: string; unreadOnly?: boolean; limit?: number; before?: string; cache?: boolean; handleError?: boolean }) => Promise<InboxFeedResult>;
   connectWorkbenchEvents: (handlers: WorkbenchEventHandlers) => () => void;
   listVibeAgents: (params?: { backend?: string; includeDisabled?: boolean }) => Promise<{ ok: boolean; agents: VibeAgentBrief[]; default_agent_name: string | null }>;
   getVibeAgent: (name: string) => Promise<{ ok: boolean; agent: VibeAgentFull; default_agent_name: string | null }>;
@@ -2587,7 +2587,7 @@ export const ApiProvider: React.FC<{ children: React.ReactNode }> = ({ children 
       );
       return { ok: res.ok, ...payloadJson };
     },
-    getTurnState: async (sessionId) => {
+    getTurnState: async (sessionId, options) => {
       const path = `/api/sessions/${encodeURIComponent(sessionId)}/turn-state`;
       const res = await apiFetch(path);
       if (res.status === 504) {
@@ -2603,6 +2603,9 @@ export const ApiProvider: React.FC<{ children: React.ReactNode }> = ({ children 
         };
       }
       if (!res.ok) {
+        if (options?.handleError === false) {
+          throw new ApiError(`Request failed: ${path} (${res.status})`, res.status, null);
+        }
         await handleApiError(res, path);
       }
       return res.json();
@@ -2624,7 +2627,8 @@ export const ApiProvider: React.FC<{ children: React.ReactNode }> = ({ children 
       if (params?.before) search.set('before', params.before);
       const qs = search.toString();
       const path = qs ? `/api/inbox?${qs}` : '/api/inbox';
-      return params?.cache === false ? getJson(path) : getCachedJson(path);
+      const options = { handleError: params?.handleError };
+      return params?.cache === false ? getJson(path, options) : getCachedJson(path, 1500, options);
     },
     listVibeAgents: (params) => {
       const search = new URLSearchParams();

--- a/ui/src/context/ApiContext.tsx
+++ b/ui/src/context/ApiContext.tsx
@@ -1,11 +1,11 @@
-import React, { createContext, useContext, useMemo, useRef } from 'react';
+import React, { createContext, useContext, useEffect, useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useToast } from './ToastContext';
 import { apiFetch } from '../lib/apiFetch';
 import type { TurnActivityGroupWire } from '../lib/agentActivity';
 import type { VaultSessionPolicy } from '../lib/vaultSandboxPolicy';
 import {
-  eventSourceErrorConnectionState,
+  WorkbenchEventReconnectLoop,
   type WorkbenchEventConnectionState,
 } from '../lib/workbenchEventConnection';
 import type { DockDoc } from './DockContext';
@@ -610,7 +610,7 @@ export type ApiContextType = {
   getSessionDraft: (sessionId: string) => Promise<{ text: string }>;
   setSessionDraft: (sessionId: string, text: string) => Promise<{ ok: boolean }>;
   listInbox: (params?: { platform?: string; unreadOnly?: boolean; limit?: number; before?: string; cache?: boolean }) => Promise<InboxFeedResult>;
-  connectWorkbenchEvents: (handlers: WorkbenchEventHandlers, options?: { reconnect?: boolean }) => () => void;
+  connectWorkbenchEvents: (handlers: WorkbenchEventHandlers) => () => void;
   listVibeAgents: (params?: { backend?: string; includeDisabled?: boolean }) => Promise<{ ok: boolean; agents: VibeAgentBrief[]; default_agent_name: string | null }>;
   getVibeAgent: (name: string) => Promise<{ ok: boolean; agent: VibeAgentFull; default_agent_name: string | null }>;
   createVibeAgent: (payload: VibeAgentCreatePayload) => Promise<{ ok: boolean; agent: VibeAgentFull }>;
@@ -1774,7 +1774,10 @@ export const ApiProvider: React.FC<{ children: React.ReactNode }> = ({ children 
   const eventHandlersRef = useRef(new Set<WorkbenchEventHandlers>());
   const eventConnectionRef = useRef<{ sub_id: number; source?: 'browser' | 'controller' } | null>(null);
   const eventBridgeConnectedRef = useRef(false);
-  const eventConnectionStateRef = useRef<WorkbenchEventConnectionState>('disconnected');
+  const eventConnectionStateRef = useRef<WorkbenchEventConnectionState>('reconnecting');
+  const eventReconnectLoopRef = useRef<WorkbenchEventReconnectLoop | null>(null);
+  const wakeWorkbenchEventsRef = useRef<() => void>(() => {});
+  const stopWorkbenchEventsRef = useRef<() => void>(() => {});
 
   const handleApiError = async (res: Response, path: string) => {
     let errorMessage = `Request failed: ${path} (${res.status})`;
@@ -1889,26 +1892,51 @@ export const ApiProvider: React.FC<{ children: React.ReactNode }> = ({ children 
     }
   };
 
-  const closeWorkbenchEventSource = () => {
-    eventSourceRef.current?.close();
+  const closeActiveWorkbenchEventSource = () => {
+    const source = eventSourceRef.current;
     eventSourceRef.current = null;
+    source?.close();
     eventConnectionRef.current = null;
     eventBridgeConnectedRef.current = false;
   };
 
-  const ensureWorkbenchEventSource = (options?: { reconnect?: boolean }) => {
-    if (options?.reconnect) {
-      closeWorkbenchEventSource();
-    }
-    if (eventSourceRef.current) return;
+  function reconnectWorkbenchEventSource(): void {
+    if (eventHandlersRef.current.size === 0) return;
+    closeActiveWorkbenchEventSource();
+    openWorkbenchEventSource();
+  }
 
-    const source = new EventSource('/api/events');
+  function getWorkbenchEventReconnectLoop(): WorkbenchEventReconnectLoop {
+    if (!eventReconnectLoopRef.current) {
+      eventReconnectLoopRef.current = new WorkbenchEventReconnectLoop({
+        reconnect: reconnectWorkbenchEventSource,
+        isVisible: () => document.visibilityState === 'visible',
+      });
+    }
+    return eventReconnectLoopRef.current;
+  }
+
+  function openWorkbenchEventSource(): void {
+    if (
+      eventSourceRef.current ||
+      eventHandlersRef.current.size === 0 ||
+      document.visibilityState !== 'visible'
+    ) return;
+
+    let source: EventSource;
+    try {
+      source = new EventSource('/api/events');
+    } catch (err) {
+      setWorkbenchEventConnectionState('reconnecting');
+      getWorkbenchEventReconnectLoop().failed();
+      const event = err instanceof Event ? err : new Event('error');
+      dispatchToWorkbenchHandlers((handlers) => handlers.onError?.(event));
+      return;
+    }
+
     eventSourceRef.current = source;
     setWorkbenchEventConnectionState('reconnecting');
-    source.onopen = () => {
-      if (eventSourceRef.current !== source) return;
-      setWorkbenchEventConnectionState('connected');
-    };
+    getWorkbenchEventReconnectLoop().attemptStarted();
     source.addEventListener('connected', (e: MessageEvent) => {
       if (eventSourceRef.current !== source) return;
       try {
@@ -1928,6 +1956,7 @@ export const ApiProvider: React.FC<{ children: React.ReactNode }> = ({ children 
         eventConnectionRef.current = null;
       }
       if (eventConnectionRef.current) {
+        getWorkbenchEventReconnectLoop().streamOpened();
         const connected = eventConnectionRef.current;
         dispatchToWorkbenchHandlers((handlers) => handlers.onConnected?.(connected));
       }
@@ -2060,8 +2089,9 @@ export const ApiProvider: React.FC<{ children: React.ReactNode }> = ({ children 
       if (eventSourceRef.current !== source) return;
       const envelope = parseWorkbenchEnvelope<{ connected: boolean }>(e.data);
       if (!envelope) return;
+      getWorkbenchEventReconnectLoop().streamOpened();
       eventBridgeConnectedRef.current = envelope.data.connected;
-      setWorkbenchEventConnectionState(envelope.data.connected ? 'connected' : 'disconnected');
+      setWorkbenchEventConnectionState(envelope.data.connected ? 'connected' : 'reconnecting');
       dispatchToWorkbenchHandlers((handlers) => {
         handlers.onAny?.(envelope);
         handlers.onEventBridgeStatus?.(envelope.data);
@@ -2069,13 +2099,48 @@ export const ApiProvider: React.FC<{ children: React.ReactNode }> = ({ children 
     });
     source.onerror = (err) => {
       if (eventSourceRef.current !== source) return;
-      eventConnectionRef.current = null;
-      eventBridgeConnectedRef.current = false;
-      setWorkbenchEventConnectionState(eventSourceErrorConnectionState(source.readyState));
+      closeActiveWorkbenchEventSource();
+      setWorkbenchEventConnectionState('reconnecting');
       dispatchToWorkbenchHandlers((handlers) => handlers.onEventBridgeStatus?.({ connected: false }));
       dispatchToWorkbenchHandlers((handlers) => handlers.onError?.(err));
+      getWorkbenchEventReconnectLoop().failed();
     };
+  }
+
+  const ensureWorkbenchEventSource = () => {
+    getWorkbenchEventReconnectLoop();
+    openWorkbenchEventSource();
   };
+
+  const stopWorkbenchEventSource = () => {
+    closeActiveWorkbenchEventSource();
+    eventReconnectLoopRef.current?.stop();
+    eventReconnectLoopRef.current = null;
+    setWorkbenchEventConnectionState('reconnecting');
+  };
+  stopWorkbenchEventsRef.current = stopWorkbenchEventSource;
+
+  const wakeWorkbenchEvents = () => {
+    if (eventHandlersRef.current.size === 0 || document.visibilityState !== 'visible') return;
+    setWorkbenchEventConnectionState('reconnecting');
+    getWorkbenchEventReconnectLoop().wake();
+  };
+  wakeWorkbenchEventsRef.current = wakeWorkbenchEvents;
+
+  useEffect(() => {
+    const wakeIfVisible = () => {
+      if (document.visibilityState === 'visible') wakeWorkbenchEventsRef.current();
+    };
+    document.addEventListener('visibilitychange', wakeIfVisible);
+    window.addEventListener('online', wakeIfVisible);
+    window.addEventListener('focus', wakeIfVisible);
+    return () => {
+      document.removeEventListener('visibilitychange', wakeIfVisible);
+      window.removeEventListener('online', wakeIfVisible);
+      window.removeEventListener('focus', wakeIfVisible);
+      stopWorkbenchEventsRef.current();
+    };
+  }, []);
 
   const requestJson = async (
     path: string,
@@ -2736,9 +2801,9 @@ export const ApiProvider: React.FC<{ children: React.ReactNode }> = ({ children 
       return getCachedJson(qs ? `/api/harness/runs?${qs}` : '/api/harness/runs');
     },
     getHarnessRun: (runId) => getCachedJson(`/api/harness/runs/${encodeURIComponent(runId)}`),
-    connectWorkbenchEvents: (handlers, options) => {
+    connectWorkbenchEvents: (handlers) => {
       eventHandlersRef.current.add(handlers);
-      ensureWorkbenchEventSource(options);
+      ensureWorkbenchEventSource();
       queueMicrotask(() => {
         if (eventHandlersRef.current.has(handlers)) {
           handlers.onConnectionState?.(eventConnectionStateRef.current);
@@ -2768,7 +2833,7 @@ export const ApiProvider: React.FC<{ children: React.ReactNode }> = ({ children 
       return () => {
         eventHandlersRef.current.delete(handlers);
         if (eventHandlersRef.current.size === 0) {
-          closeWorkbenchEventSource();
+          stopWorkbenchEventSource();
         }
       };
     },

--- a/ui/src/context/WorkbenchInboxContext.tsx
+++ b/ui/src/context/WorkbenchInboxContext.tsx
@@ -56,8 +56,8 @@ const appendPage = (prev: InboxSession[], page: InboxSession[]): InboxSession[] 
 
 /** Provider that owns the Inbox state shared across WorkbenchSidebar + InboxPage.
  *
- *  Connects to ``/api/events`` (reopening the stream on resume — see the resync
- *  effect) and updates the per-session feed in place: ``inbox.session.updated``
+ *  Connects to ``/api/events`` and updates the per-session feed in place:
+ *  ``inbox.session.updated``
  *  upserts + re-sorts a card (the realtime "bump to top"), ``inbox.unread.changed``
  *  refreshes the unread map after a mark-read elsewhere. Each (re)connect also
  *  does a full ``refresh()`` so events missed while the socket was down (the
@@ -79,10 +79,6 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
   const [nextCursor, setNextCursor] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [loadingMore, setLoadingMore] = useState(false);
-  // Bumped on resume (tab visible again / network back) to force the SSE
-  // connection effect to tear down the (possibly dead) stream and reopen it.
-  // See the resync effect below for why a frozen mobile PWA needs this.
-  const [connectionEpoch, setConnectionEpoch] = useState(0);
   // Mirror the cursor into a ref so ``loadMore`` can read the latest value
   // without re-creating its identity (and the context value) on every page.
   const cursorRef = useRef<string | null>(null);
@@ -92,9 +88,8 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
   const inboxSessionsRef = useRef<InboxSession[]>([]);
   inboxSessionsRef.current = inboxSessions;
   // Only the very first mount does the destructive first-page refresh; every
-  // later effect rerun — an ``api`` identity change (e.g. a locale switch, which
-  // ApiProvider documents as rebuilding the value) or a resume-driven
-  // connectionEpoch bump — reconciles the loaded window instead, so a non-resume
+  // later effect rerun — such as an ``api`` identity change after a locale switch
+  // — reconciles the loaded window instead, so a non-resume
   // rerun never collapses a multi-page feed back to page one.
   const initialFetched = useRef(false);
 
@@ -189,8 +184,7 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
 
   useEffect(() => {
     // First mount loads page one; every later rerun reconciles the loaded window
-    // instead — whether the rerun is a resume-driven connectionEpoch bump or just
-    // an ``api`` identity change (e.g. a locale switch rebuilding the value) — so
+    // instead when an ``api`` identity change rebuilds the value — so
     // a non-resume rerun never collapses a multi-page feed back to page one. The
     // broker fans events out live with no replay (sse_broker.py ``/api/events``),
     // so anything missed while the socket was down must be re-read; plain HTTP,
@@ -230,37 +224,32 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
         });
       },
       onError: (err) => {
-        // Browser EventSource auto-reconnects on transient drops; the
-        // visibility/online resync below covers what it can't — a frozen mobile
-        // tab whose socket died without ever firing a clean error. Keep this a
-        // log, not a crash, so the workbench stays usable.
+        // ApiContext owns the explicit reconnect loop. Keep this a log, not a
+        // crash, so the workbench stays usable during the HTTP fallback.
         console.debug('[inbox] sse error', err);
       },
-    }, { reconnect: connectionEpoch > 0 });
+    });
     return disconnect;
-  }, [api, refresh, reconcile, connectionEpoch, applyUnreadMap]);
+  }, [api, refresh, reconcile, applyUnreadMap]);
 
   // Recover after the OS suspended us. A backgrounded mobile PWA has its page
-  // frozen and its SSE socket dropped, and the broker never replays the gap; on
-  // iOS the stream frequently does NOT auto-reconnect (it can sit in a zombie
-  // OPEN state that never fires onerror), so neither the live handlers nor the
-  // refresh above re-fire on their own. Bump the connection epoch when the tab
-  // becomes visible again or the network returns: the effect above tears the
-  // dead stream down, reopens it, and re-reads the feed + unread map — so the
-  // inbox cards and sidebar dots catch up to messages that arrived while away.
-  // StatusContext (runtime status) and ChatPage (transcript) already resync on
-  // visibility; the inbox feed was the surface missing it.
+  // frozen and its SSE socket dropped, and the broker never replays the gap;
+  // iOS can leave EventSource in a zombie OPEN state without onerror. ApiContext
+  // reopens the shared stream on visibility, online, and focus; independently
+  // reconcile the durable feed here so missed events never gate data freshness.
   useEffect(() => {
     const resync = () => {
-      if (document.visibilityState === 'visible') setConnectionEpoch((e) => e + 1);
+      if (document.visibilityState === 'visible') void reconcile();
     };
     document.addEventListener('visibilitychange', resync);
     window.addEventListener('online', resync);
+    window.addEventListener('focus', resync);
     return () => {
       document.removeEventListener('visibilitychange', resync);
       window.removeEventListener('online', resync);
+      window.removeEventListener('focus', resync);
     };
-  }, []);
+  }, [reconcile]);
 
   const totalUnread = useMemo(
     () => Object.values(unreadBySession).reduce((sum, n) => sum + (n || 0), 0),

--- a/ui/src/context/WorkbenchInboxContext.tsx
+++ b/ui/src/context/WorkbenchInboxContext.tsx
@@ -155,7 +155,12 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
     const loadedIds = new Set(inboxSessionsRef.current.map((s) => s.session_id));
     const limit = Math.min(Math.max(loadedIds.size, PAGE_SIZE), 100);
     try {
-      const result = await api.listInbox({ platform: 'avibe', limit, cache: false });
+      const result = await api.listInbox({
+        platform: 'avibe',
+        limit,
+        cache: false,
+        handleError: false,
+      });
       setInboxSessions((prev) => {
         const incoming = new Map(result.sessions.map((s) => [s.session_id, s]));
         const merged = prev.map((s) => incoming.get(s.session_id) ?? s);

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -2363,8 +2363,10 @@
         "agentRun": "Agent run"
       },
       "connection": {
-        "reconnecting": "Reconnecting",
-        "disconnected": "Disconnected"
+        "reconnecting": "Reconnecting...",
+        "reconnectingTitle": "Live updates are reconnecting - background tasks are still running and updates will resume automatically.",
+        "disconnected": "Disconnected",
+        "disconnectedTitle": "Live updates are disconnected - background tasks are still running and will reconnect automatically when the network recovers."
       }
     },
     "agentActivity": {

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -2361,12 +2361,6 @@
         "taskOneShot": "One-time",
         "taskRecurring": "Recurring",
         "agentRun": "Agent run"
-      },
-      "connection": {
-        "reconnecting": "Reconnecting...",
-        "reconnectingTitle": "Live updates are reconnecting - background tasks are still running and updates will resume automatically.",
-        "disconnected": "Disconnected",
-        "disconnectedTitle": "Live updates are disconnected - background tasks are still running and will reconnect automatically when the network recovers."
       }
     },
     "agentActivity": {

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -2361,12 +2361,6 @@
         "taskOneShot": "一次性",
         "taskRecurring": "周期性",
         "agentRun": "Agent 运行"
-      },
-      "connection": {
-        "reconnecting": "重连中…",
-        "reconnectingTitle": "实时更新正在重连——后台任务仍在运行，连接恢复后将自动继续更新。",
-        "disconnected": "已断开",
-        "disconnectedTitle": "实时更新连接已断开——后台任务仍在运行，网络恢复后自动重连。"
       }
     },
     "agentActivity": {

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -2363,8 +2363,10 @@
         "agentRun": "Agent 运行"
       },
       "connection": {
-        "reconnecting": "重连中",
-        "disconnected": "已断开"
+        "reconnecting": "重连中…",
+        "reconnectingTitle": "实时更新正在重连——后台任务仍在运行，连接恢复后将自动继续更新。",
+        "disconnected": "已断开",
+        "disconnectedTitle": "实时更新连接已断开——后台任务仍在运行，网络恢复后自动重连。"
       }
     },
     "agentActivity": {

--- a/ui/src/lib/workbenchEventConnection.test.ts
+++ b/ui/src/lib/workbenchEventConnection.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+
+import { eventSourceErrorConnectionState } from './workbenchEventConnection';
+
+describe('eventSourceErrorConnectionState', () => {
+  it('keeps transient EventSource failures in the automatic retry state', () => {
+    expect(eventSourceErrorConnectionState(0)).toBe('reconnecting');
+  });
+
+  it('reserves disconnected for a stream that stopped retrying', () => {
+    expect(eventSourceErrorConnectionState(2)).toBe('disconnected');
+    expect(eventSourceErrorConnectionState(1)).toBe('disconnected');
+  });
+});

--- a/ui/src/lib/workbenchEventConnection.test.ts
+++ b/ui/src/lib/workbenchEventConnection.test.ts
@@ -1,14 +1,62 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { eventSourceErrorConnectionState } from './workbenchEventConnection';
+import {
+  WorkbenchEventReconnectLoop,
+  WORKBENCH_EVENT_OPEN_TIMEOUT_MS,
+} from './workbenchEventConnection';
 
-describe('eventSourceErrorConnectionState', () => {
-  it('keeps transient EventSource failures in the automatic retry state', () => {
-    expect(eventSourceErrorConnectionState(0)).toBe('reconnecting');
+describe('WorkbenchEventReconnectLoop', () => {
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
-  it('reserves disconnected for a stream that stopped retrying', () => {
-    expect(eventSourceErrorConnectionState(2)).toBe('disconnected');
-    expect(eventSourceErrorConnectionState(1)).toBe('disconnected');
+  it('retries terminal failures forever with bounded backoff and resets after recovery', () => {
+    vi.useFakeTimers();
+    const reconnect = vi.fn();
+    const loop = new WorkbenchEventReconnectLoop({ reconnect, isVisible: () => true });
+
+    for (const delayMs of [1_000, 2_000, 4_000, 8_000, 15_000, 15_000]) {
+      loop.failed();
+      vi.advanceTimersByTime(delayMs - 1);
+      expect(reconnect).toHaveBeenCalledTimes(0);
+      vi.advanceTimersByTime(1);
+      expect(reconnect).toHaveBeenCalledTimes(1);
+      reconnect.mockClear();
+    }
+
+    loop.streamOpened();
+    loop.failed();
+    vi.advanceTimersByTime(999);
+    expect(reconnect).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(1);
+    expect(reconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it('replaces a hung connection attempt and wakes immediately on foreground signals', () => {
+    vi.useFakeTimers();
+    let visible = true;
+    const reconnect = vi.fn();
+    const loop = new WorkbenchEventReconnectLoop({ reconnect, isVisible: () => visible });
+
+    loop.attemptStarted();
+    vi.advanceTimersByTime(WORKBENCH_EVENT_OPEN_TIMEOUT_MS - 1);
+    expect(reconnect).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(1);
+    expect(reconnect).toHaveBeenCalledTimes(1);
+
+    visible = false;
+    loop.failed();
+    vi.advanceTimersByTime(60_000);
+    expect(reconnect).toHaveBeenCalledTimes(1);
+
+    visible = true;
+    loop.wake();
+    expect(reconnect).toHaveBeenCalledTimes(2);
+
+    loop.stop();
+    loop.failed();
+    loop.wake();
+    vi.advanceTimersByTime(60_000);
+    expect(reconnect).toHaveBeenCalledTimes(2);
   });
 });

--- a/ui/src/lib/workbenchEventConnection.ts
+++ b/ui/src/lib/workbenchEventConnection.ts
@@ -1,0 +1,8 @@
+export type WorkbenchEventConnectionState = 'connected' | 'reconnecting' | 'disconnected';
+
+// EventSource keeps readyState=CONNECTING (0) while its built-in retry loop is
+// active. CLOSED (2), or any non-standard terminal value, means it has stopped
+// retrying and needs an external recovery signal such as visibility/online.
+export function eventSourceErrorConnectionState(readyState: number): WorkbenchEventConnectionState {
+  return readyState === 0 ? 'reconnecting' : 'disconnected';
+}

--- a/ui/src/lib/workbenchEventConnection.ts
+++ b/ui/src/lib/workbenchEventConnection.ts
@@ -1,8 +1,85 @@
-export type WorkbenchEventConnectionState = 'connected' | 'reconnecting' | 'disconnected';
+export type WorkbenchEventConnectionState = 'connected' | 'reconnecting';
 
-// EventSource keeps readyState=CONNECTING (0) while its built-in retry loop is
-// active. CLOSED (2), or any non-standard terminal value, means it has stopped
-// retrying and needs an external recovery signal such as visibility/online.
-export function eventSourceErrorConnectionState(readyState: number): WorkbenchEventConnectionState {
-  return readyState === 0 ? 'reconnecting' : 'disconnected';
+export const WORKBENCH_EVENT_RETRY_INITIAL_MS = 1_000;
+export const WORKBENCH_EVENT_RETRY_MAX_MS = 15_000;
+export const WORKBENCH_EVENT_OPEN_TIMEOUT_MS = 20_000;
+
+type TimerHandle = ReturnType<typeof setTimeout>;
+
+interface WorkbenchEventReconnectLoopOptions {
+  reconnect: () => void;
+  isVisible: () => boolean;
+}
+
+/** Owns the retry policy; EventSource wiring stays in ApiContext. */
+export class WorkbenchEventReconnectLoop {
+  private readonly reconnect: () => void;
+  private readonly isVisible: () => boolean;
+  private retryTimer: TimerHandle | null = null;
+  private openTimer: TimerHandle | null = null;
+  private retryAttempt = 0;
+  private stopped = false;
+
+  constructor(options: WorkbenchEventReconnectLoopOptions) {
+    this.reconnect = options.reconnect;
+    this.isVisible = options.isVisible;
+  }
+
+  attemptStarted(): void {
+    if (this.stopped) return;
+    this.clearOpenTimer();
+    this.openTimer = setTimeout(() => {
+      this.openTimer = null;
+      if (!this.stopped && this.isVisible()) this.reconnect();
+    }, WORKBENCH_EVENT_OPEN_TIMEOUT_MS);
+  }
+
+  streamOpened(): void {
+    if (this.stopped) return;
+    this.retryAttempt = 0;
+    this.clearRetryTimer();
+    this.clearOpenTimer();
+  }
+
+  failed(): void {
+    if (this.stopped) return;
+    this.clearOpenTimer();
+    if (this.retryTimer !== null || !this.isVisible()) return;
+    const delayMs = Math.min(
+      WORKBENCH_EVENT_RETRY_INITIAL_MS * (2 ** this.retryAttempt),
+      WORKBENCH_EVENT_RETRY_MAX_MS,
+    );
+    if (delayMs < WORKBENCH_EVENT_RETRY_MAX_MS) this.retryAttempt += 1;
+    this.retryTimer = setTimeout(() => {
+      this.retryTimer = null;
+      if (!this.stopped && this.isVisible()) this.reconnect();
+    }, delayMs);
+  }
+
+  wake(): void {
+    if (this.stopped || !this.isVisible()) return;
+    this.retryAttempt = 0;
+    this.clearRetryTimer();
+    this.clearOpenTimer();
+    this.reconnect();
+  }
+
+  stop(): void {
+    this.stopped = true;
+    this.retryAttempt = 0;
+    this.clearRetryTimer();
+    this.clearOpenTimer();
+  }
+
+  private clearRetryTimer(): void {
+    if (this.retryTimer === null) return;
+    clearTimeout(this.retryTimer);
+    this.retryTimer = null;
+  }
+
+  private clearOpenTimer(): void {
+    if (this.openTimer === null) return;
+    clearTimeout(this.openTimer);
+    this.openTimer = null;
+  }
 }


### PR DESCRIPTION
## Summary

- keep the ActivityStrip pill inside its parent at every viewport while retaining the 420px desktop cap
- truncate only the first activity label so the chevron stays visible; remove connection status from the strip and delete its unused locale keys
- explicitly recreate the shared `/api/events` EventSource after terminal errors or a hung handshake, retrying forever while the page is visible with 1/2/4/8/15-second bounded backoff
- reset recovery immediately on visibility-to-visible, online, and focus signals
- reconcile the session turn-state immediately when realtime drops and every 10 seconds while it remains down, so background-work data stays truthful before SSE recovers without surfacing retry-error toasts

## Failure audit

The foreground give-up was in the browser-to-UI-server layer. `ApiContext` previously handled `EventSource.onerror` by clearing connection refs only and relied entirely on native EventSource retry. A tunnel HTTP error can leave EventSource terminally closed, so no new source was scheduled while the page remained visible. The only forced reopen came from ChatPage/Inbox visibility or online epoch changes; there was no focus recovery, and a foreground failure received neither signal.

The ActivityStrip fallback also only polled when a foreground turn or already-known background activity existed. If SSE died while the strip was empty, a later background task could remain invisible indefinitely.

The fix keeps one shared source and one retry owner in `ApiContext`:

- every error closes the failed native source and schedules an explicit replacement
- a 20-second SSE handshake deadline replaces connections that return/open but never deliver data
- successful SSE handshake resets backoff; browser stream plus controller bridge health is the internal `connected` signal
- the existing UI-server-to-controller bridge already retries forever at 1-15 seconds and remains unchanged
- lifecycle wake signals cancel pending backoff and replace the source immediately
- durable turn-state reconciliation starts immediately on down transition, repeats every 10 seconds while down, and stops when realtime is healthy; recovery reads are best-effort and silent

Connection state is now internal recovery plumbing only. ActivityStrip never renders it.

## Evidence

- Unit: focused Vitest covers repeated terminal failures through the 15-second cap, reset after recovery, hung-handshake replacement, hidden-page pause, foreground wake, and stop cleanup (2 tests)
- Component/browser: isolated Chrome fixture terminates the first two EventSource instances, restores the third, and observes recovery without reload
- Contract: `npm run build` passed (TypeScript + Vite)
- Lint: new helper/test pass default ESLint; targeted lint passes on all touched files after suppressing only their unchanged legacy baseline rules (default baseline remains exactly 59 errors / 5 warnings before and after)
- Browser layout: Chrome at 390x844 reports document/pill width 390/358px, a 495px label truncated to 288px, and the 14px chevron fully visible; at 1440x900 the pill remains exactly 420px
- Scenario IDs: none (no matching catalog scenario)

## Screenshots

[Open the side-by-side browser proof](https://alex-app.avibe.bot/p/pr-947-activity-strip/).

### Mobile · 390x844

![ActivityStrip mobile viewport proof](https://alex-app.avibe.bot/p/pr-947-activity-strip/activity-strip-mobile-390.png)

### Desktop · 1440x900

![ActivityStrip desktop viewport proof](https://alex-app.avibe.bot/p/pr-947-activity-strip/activity-strip-desktop-1440.png)

## Scope / residual checks

- No changes to AgentActivityGroup, activity-card/transcript rendering, settings pages, StatusPill, or docs/plans; this is a focused bug fix
- No dependencies
- Real phone lock/background lifecycle and server-restart recovery remain for the orchestrator's regression pass

## Known-by-design ledger

- None
