### PR TITLE
test(memory-poc): synthetic corpus + predeclared expectations (Lane P2)

### DIFF
--- a/scripts/memory_poc/corpus/README.md
+++ b/scripts/memory_poc/corpus/README.md
@@ -1,0 +1,126 @@
+# Memory POC corpus (Lane P2)
+
+Synthetic fixture corpus and predeclared expectations for the EverOS phase-0
+POC. This directory is the measuring stick for the provider decision: its
+quality decides whether the POC verdict means anything.
+
+- `manifest.json` — corpus revision and counts (validates against
+  [`../CONTRACT.md`](../CONTRACT.md) → *corpus/manifest.json*).
+- `sessions.jsonl` — one message per line, ordered by `(session_key, seq)`.
+- `queries.jsonl` — predeclared positive / negative / temporal expectations.
+
+All three validate against the frozen CONTRACT exactly. Expectations were
+declared **before any run** and are never tuned to results.
+
+## 1. Principal and scenario (entirely synthetic)
+
+One synthetic principal — a solo developer building a personal side project,
+codename **Seagull** — talks to the agent across three sessions in the fixed
+`personal` project. No real names, employers, chat logs, or personal data
+appear; the only proper nouns are generic developer tooling (PostgreSQL,
+Fly.io, Stripe, …), which are not personal data. Text is Chinese-first with
+natural mixed English for tech terms and product names.
+
+| Session | `session_key` | Story beat | Day (offset) |
+|---|---|---|---|
+| Kickoff | `s1` | Initial tech/business choices, stable preferences, goals | day 0 |
+| Two-week review | `s2` | Corrections to early choices, episodic events, more prefs | day 14 |
+| Later session | `s3` | Cross-session facts, more corrections, buffered tail | day 21 |
+
+Two-plus `session_key`s for one principal exercise POC §5.3 (personal-pool
+coherence across sessions); `s3` is a natural "third session" for querying the
+global pool.
+
+## 2. How the fixtures stress the design (deep-dive §7)
+
+EverOS keeps **append-oriented history** (episodes/atomic facts retain dated
+evidence) but a **single rewritten profile snapshot**, and temporal correction
+is an LLM-guided convention, *not* an enforced temporal data model. The corpus
+is built to expose exactly that seam:
+
+- **Five temporal pairs.** Each *old* statement (`temporal-old`, in `s1`) and
+  its *correction* (`temporal-new`, in `s2`/`s3`) name the **same subject**
+  (database, deploy platform, state manager, pricing, payment scope) but the
+  correction **deliberately never repeats the old value token**. So the `forbid`
+  hint (old value) matches only the superseded statement and the `expect` hint
+  (new value) matches only the correction — a stale-outranks-correction failure
+  is mechanically detectable under substring matching. Corrections are clearly
+  dated later (day 14 / day 21 vs day 0).
+- **Retained history is respected.** Because superseded values legitimately
+  survive in episode history, the authoritative stale test is the `temporal`
+  **rank** comparison (correction must outrank superseded), not an absolute
+  `negative` forbid. Absolute `negative` forbids are therefore reserved for
+  values that never appear in the corpus at all (see §4).
+
+## 3. Matching-rule discipline (CONTRACT)
+
+Matching is NFC-normalized, case-insensitive substring match on returned item
+text. To keep every expectation decidable from fixture text alone:
+
+- **Positive queries are paraphrase/synonym-driven, not lexical echoes** of the
+  fixture (e.g. "每个月能赚到多少钱" → `MRR`; "内测什么时候开跑" → `2026-08-01`;
+  "带静态类型的语言" → `TypeScript`), so vector recall is genuinely tested.
+- **Every `expect.text_hint` is a distinctive noun phrase contained in the
+  referenced fixture message(s)** — a proper noun, exact date, or number that
+  any faithful distillation must preserve. A local checker confirms each
+  positive/temporal hint is a substring of its `seq_refs` text.
+- **Every `negative` forbid hint is verified absent from the entire corpus**, so
+  retained history can never turn a negative into a guaranteed failure.
+- **Every `temporal` forbid hint is verified present in a `temporal-old` message
+  and absent from its correction message**, guaranteeing the pair is decidable.
+
+## 4. Query inventory
+
+| Type | Count | Design |
+|---|---|---|
+| `positive` | 34 | ≥30 required. Paraphrase/synonym queries over preferences, goals, dates, episodic events, and current-state facts. |
+| `temporal` | 5 | `expect` = correction, `forbid` = superseded, same subject. DB, deploy, state manager, pricing, payment scope. |
+| `negative` | 11 | 8 unrelated-fact (pets, sports, city, OS, Django, Kubernetes, AWS, coffee — never in corpus) + 3 stale-assertion (current-marker + old value phrasings that only ever attach to the new value in the fixture, so they are decidably absent). |
+
+Temporal pairs (subject → old ⇒ new):
+
+| Subject | Old (`s1`) | New (`s2`/`s3`) | Temporal query |
+|---|---|---|---|
+| Database | MongoDB | PostgreSQL | q035 |
+| Deploy platform | Heroku | Fly.io | q036 |
+| State management | Redux | Zustand | q037 |
+| Pricing | free / donation (捐赠) | $5/month subscription | q038 |
+| Payment scope | Alipay + WeChat (支付宝/微信) | Stripe only | q039 |
+
+## 5. Coverage — POC §4 mandatory content
+
+| POC §4 requirement | Where satisfied |
+|---|---|
+| ≥30 predeclared zh / mixed positive queries | `queries.jsonl` q001–q034 (34 positive) |
+| Negative queries for unrelated facts | q040–q047 (8 unrelated-fact) |
+| Negative queries for stale assertions | q048–q050 (stale current-state, decidably absent) + `temporal` rank tests q035–q039 |
+| Temporal corrections (old choice replaced) | 5 pairs, `temporal-old`↔`temporal-new`; e.g. DB MongoDB⇒PostgreSQL (q035) |
+| Stable preferences | s1#7 TypeScript, s1#8 pnpm, s1#9 Neovim/LazyVim, s2#5 Conventional Commits, s2#6 dark mode, s2#11 ≤50-line functions, s3#2 2-space indent, s3#3 lo-fi |
+| Goals | s1#1 3-month MVP, s1#10 $1000 MRR, s2#7 i18n, s3#4 learn Rust |
+| Dates | s1#1 2026-09-30, s2#8 2026-08-01, s3#5 renew 3 月 15 日 |
+| Short episodic events | s1#11 scaffold, s1#12 hackathon, s2#1 OAuth bug, s2#9 first deploy, s2#10 slow-search feedback, s3#1 payment refactor |
+| ≥2 sessions for same principal | `s1`, `s2`, `s3` |
+| `buffered-tail` (buffered until explicit flush) | s3#8 (incomplete Pomodoro idea, session tail) |
+| `kill-case` (response-loss/kill experiment) | s2#10 |
+
+## 6. Coverage — POC §6 criteria that this corpus feeds
+
+| Criterion id (CONTRACT §report) | Corpus content that decides it |
+|---|---|
+| `temporal_all` | q035–q039: every correction's `expect` must outrank its `forbid`. Each pair names the same subject with non-overlapping value tokens so the assertion is mechanically checkable. |
+| `negatives_all` | q040–q050: no returned item may match any `forbid` hint. All hints verified absent from the corpus, so a pass reflects the provider, not the fixture. |
+| `positive_top8_rate` | q001–q034: ≥90% must return the expected item in top-8 each clean run. Paraphrase/synonym phrasing tests genuine recall rather than lexical echo. |
+
+## 7. Notes / caveats for P1 and the PM
+
+- `occurred_offset_ms` is monotonic across the file; day spacing (0 / 14 / 21)
+  makes corrections unambiguously later than the statements they supersede.
+- Stale-assertion negatives (q048–q050) are intentionally conservative: under
+  contiguous substring matching plus retained history, the robust stale signal
+  is the `temporal` rank test. The stale negatives add defense-in-depth by
+  forbidding "finality/current-marker + old value" phrasings that the fixture
+  only ever attaches to the *new* value.
+- A local checker (run during authoring) confirms: contract-shape, count
+  integrity vs `manifest.json`, tag-vocabulary, positive/temporal hints ⊆
+  referenced fixture, negative forbids ∉ corpus, and temporal forbids ∈ old ∧ ∉
+  correction. No expectation was adjusted to any run output.

--- a/scripts/memory_poc/corpus/README.md
+++ b/scripts/memory_poc/corpus/README.md
@@ -41,11 +41,17 @@ is built to expose exactly that seam:
 - **Five temporal pairs.** Each *old* statement (`temporal-old`, in `s1`) and
   its *correction* (`temporal-new`, in `s2`/`s3`) name the **same subject**
   (database, deploy platform, state manager, pricing, payment scope) but the
-  correction **deliberately never repeats the old value token**. So the `forbid`
-  hint (old value) matches only the superseded statement and the `expect` hint
-  (new value) matches only the correction — a stale-outranks-correction failure
-  is mechanically detectable under substring matching. Corrections are clearly
-  dated later (day 14 / day 21 vs day 0).
+  correction **deliberately never repeats the old value token**, and the old
+  value's forbidden token appears **only** in the superseded statement. So the
+  `forbid` hint (old value) matches only the superseded statement and the
+  `expect` hint (new value) matches only the correction — a
+  stale-outranks-correction failure is mechanically detectable under substring
+  matching. Two subtleties the checker enforces: the payment correction's new
+  token (`Stripe`) is kept out of the unrelated payment-refactor episode `s3#1`
+  so it cannot masquerade as the correction; and the pricing forbid token is
+  `捐赠` (donation), which occurs only in the superseded `s1#5` (the correction
+  drops both `免费` and `捐赠`), because `免费` is polluted across unrelated
+  deploy episodes. Corrections are clearly dated later (day 14 / day 21 vs day 0).
 - **Retained history is respected.** Because superseded values legitimately
   survive in episode history, the authoritative stale test is the `temporal`
   **rank** comparison (correction must outrank superseded), not an absolute
@@ -60,14 +66,22 @@ text. To keep every expectation decidable from fixture text alone:
 - **Positive queries are paraphrase/synonym-driven, not lexical echoes** of the
   fixture (e.g. "每个月能赚到多少钱" → `MRR`; "内测什么时候开跑" → `2026-08-01`;
   "带静态类型的语言" → `TypeScript`), so vector recall is genuinely tested.
-- **Every `expect.text_hint` is a distinctive noun phrase contained in the
-  referenced fixture message(s)** — a proper noun, exact date, or number that
-  any faithful distillation must preserve. A local checker confirms each
-  positive/temporal hint is a substring of its `seq_refs` text.
+- **Every `expect.text_hint` is a distinctive noun phrase that occurs *only* in
+  the referenced fixture message(s)** — a proper noun, exact date, or number that
+  any faithful distillation must preserve *and* that no other message shares. A
+  local checker confirms each positive/temporal hint appears in its `seq_refs`
+  text **and in no non-referenced message**, so a pass cannot come from an
+  unrelated memory (e.g. `Seagull` recurs in seven messages and is therefore
+  never used as an identifying hint; q001 hints on `三个月`, unique to `s1#1`).
+- **Hints avoid internal ASCII spaces** that NFC does not remove: dates and
+  counts hint on the space-free contiguous form (`3月15日`, `50行`) and the
+  indentation preference hints on `空格` rather than a fragile `2 个空格`, so a
+  faithful `3月15日`/`50行` prose distillation still matches.
 - **Every `negative` forbid hint is verified absent from the entire corpus**, so
   retained history can never turn a negative into a guaranteed failure.
-- **Every `temporal` forbid hint is verified present in a `temporal-old` message
-  and absent from its correction message**, guaranteeing the pair is decidable.
+- **Every `temporal` forbid hint is verified present only in a `temporal-old`
+  message and absent from its correction (and every non-old message)**,
+  guaranteeing the pair is decidable.
 
 ## 4. Query inventory
 
@@ -96,9 +110,9 @@ Temporal pairs (subject → old ⇒ new):
 | Negative queries for stale assertions | q048–q050 (stale current-state, decidably absent) + `temporal` rank tests q035–q039 |
 | Temporal corrections (old choice replaced) | 5 pairs, `temporal-old`↔`temporal-new`; e.g. DB MongoDB⇒PostgreSQL (q035) |
 | Stable preferences | s1#7 TypeScript, s1#8 pnpm, s1#9 Neovim/LazyVim, s2#5 Conventional Commits, s2#6 dark mode, s2#11 ≤50-line functions, s3#2 2-space indent, s3#3 lo-fi |
-| Goals | s1#1 3-month MVP, s1#10 $1000 MRR, s2#7 i18n, s3#4 learn Rust |
-| Dates | s1#1 2026-09-30, s2#8 2026-08-01, s3#5 renew 3 月 15 日 |
-| Short episodic events | s1#11 scaffold, s1#12 hackathon, s2#1 OAuth bug, s2#9 first deploy, s2#10 slow-search feedback, s3#1 payment refactor |
+| Goals | s1#1 3-month MVP (q001), s1#10 $1000 MRR, s2#7 i18n, s3#4 learn Rust |
+| Dates | s1#1 2026-09-30, s2#8 2026-08-01, s3#5 renew 3月15日 |
+| Short episodic events | s1#11 scaffold, s1#12 hackathon, s2#1 OAuth `state` bug, s2#9 first deploy, s2#10 slow-search feedback, s3#1 payment refactor |
 | ≥2 sessions for same principal | `s1`, `s2`, `s3` |
 | `buffered-tail` (buffered until explicit flush) | s3#8 (incomplete Pomodoro idea, session tail) |
 | `kill-case` (response-loss/kill experiment) | s2#10 |
@@ -120,7 +134,16 @@ Temporal pairs (subject → old ⇒ new):
   is the `temporal` rank test. The stale negatives add defense-in-depth by
   forbidding "finality/current-marker + old value" phrasings that the fixture
   only ever attaches to the *new* value.
+- All proper nouns are generic developer tooling; the only domain is the
+  synthetic reserved-TLD `seagull.example` (RFC 2606, cannot resolve to a real
+  asset). `Seagull` is a common word used as a personal-project codename, not a
+  real org/product; no real domain, product, org, or person is attributed to the
+  principal.
 - A local checker (run during authoring) confirms: contract-shape, count
-  integrity vs `manifest.json`, tag-vocabulary, positive/temporal hints ⊆
-  referenced fixture, negative forbids ∉ corpus, and temporal forbids ∈ old ∧ ∉
-  correction. No expectation was adjusted to any run output.
+  integrity vs `manifest.json`, tag-vocabulary, monotonic offsets, **each
+  positive/temporal hint occurs only in its referenced message(s)** (globally
+  identifying), negative forbids ∉ corpus, temporal forbids ∈ old-only ∧ ∉
+  correction ∧ ∉ any non-old message, and no `seagull.app` real domain. 0
+  errors / 0 warnings on content (the only heuristic warning is the `Fly.io`
+  `.io` token, a generic deploy platform). No expectation was adjusted to any
+  run output.

--- a/scripts/memory_poc/corpus/manifest.json
+++ b/scripts/memory_poc/corpus/manifest.json
@@ -1,0 +1,6 @@
+{
+  "corpus_revision": "2026-07-22.1",
+  "message_count": 31,
+  "query_count": 50,
+  "notes": "Synthetic Chinese-first personal-memory corpus for the EverOS phase-0 POC. One synthetic principal, project codename Seagull, three sessions (s1 kickoff / s2 two-week adjustments / s3 later). No real names, employers, chats, or personal data; product/tech names are generic tooling. Queries: 34 positive, 11 negative (8 unrelated-fact, 3 stale-assertion), 5 temporal. See corpus/README.md for the coverage table and expectation rationale. All expectations declared before any run."
+}

--- a/scripts/memory_poc/corpus/manifest.json
+++ b/scripts/memory_poc/corpus/manifest.json
@@ -1,5 +1,5 @@
 {
-  "corpus_revision": "2026-07-22.1",
+  "corpus_revision": "2026-07-22.2",
   "message_count": 31,
   "query_count": 50,
   "notes": "Synthetic Chinese-first personal-memory corpus for the EverOS phase-0 POC. One synthetic principal, project codename Seagull, three sessions (s1 kickoff / s2 two-week adjustments / s3 later). No real names, employers, chats, or personal data; product/tech names are generic tooling. Queries: 34 positive, 11 negative (8 unrelated-fact, 3 stale-assertion), 5 temporal. See corpus/README.md for the coverage table and expectation rationale. All expectations declared before any run."

--- a/scripts/memory_poc/corpus/queries.jsonl
+++ b/scripts/memory_poc/corpus/queries.jsonl
@@ -1,0 +1,50 @@
+{"query_id": "q001", "type": "positive", "query": "我这个 side project 的代号叫什么？", "expect": {"kind": "episode", "session_key": "s1", "seq_refs": [1], "text_hint": "Seagull"}, "forbid": []}
+{"query_id": "q002", "type": "positive", "query": "MVP 我给自己定的上线死线是哪一天？", "expect": {"kind": "episode", "session_key": "s1", "seq_refs": [1], "text_hint": "2026-09-30"}, "forbid": []}
+{"query_id": "q003", "type": "positive", "query": "我希望这个项目每个月能赚到多少钱？", "expect": {"kind": "episode", "session_key": "s1", "seq_refs": [10], "text_hint": "$1000"}, "forbid": []}
+{"query_id": "q004", "type": "positive", "query": "写代码我更偏向哪种带静态类型的语言？", "expect": {"kind": "episode", "session_key": "s1", "seq_refs": [7], "text_hint": "TypeScript"}, "forbid": []}
+{"query_id": "q005", "type": "positive", "query": "我平时装依赖用的是哪个包管理器？", "expect": {"kind": "episode", "session_key": "s1", "seq_refs": [8], "text_hint": "pnpm"}, "forbid": []}
+{"query_id": "q006", "type": "positive", "query": "我日常敲代码用的编辑器是哪个？", "expect": {"kind": "episode", "session_key": "s1", "seq_refs": [9], "text_hint": "Neovim"}, "forbid": []}
+{"query_id": "q007", "type": "positive", "query": "搭前端脚手架时用的构建打包工具是什么？", "expect": {"kind": "episode", "session_key": "s1", "seq_refs": [11], "text_hint": "Vite"}, "forbid": []}
+{"query_id": "q008", "type": "positive", "query": "项目前端的 UI 框架用的是啥？", "expect": {"kind": "episode", "session_key": "s1", "seq_refs": [11], "text_hint": "React"}, "forbid": []}
+{"query_id": "q009", "type": "positive", "query": "样式我用的是哪个 CSS 工具库？", "expect": {"kind": "episode", "session_key": "s1", "seq_refs": [11], "text_hint": "Tailwind"}, "forbid": []}
+{"query_id": "q010", "type": "positive", "query": "我提交代码时遵循的那套信息规范叫什么？", "expect": {"kind": "episode", "session_key": "s2", "seq_refs": [5], "text_hint": "Conventional Commits"}, "forbid": []}
+{"query_id": "q011", "type": "positive", "query": "界面配色我是喜欢亮色还是偏暗的那种？", "expect": {"kind": "episode", "session_key": "s2", "seq_refs": [6], "text_hint": "深色"}, "forbid": []}
+{"query_id": "q012", "type": "positive", "query": "接下来准备给项目加的多语言支持能力叫什么？", "expect": {"kind": "episode", "session_key": "s2", "seq_refs": [7], "text_hint": "i18n"}, "forbid": []}
+{"query_id": "q013", "type": "positive", "query": "内测大概安排在什么时候开跑？", "expect": {"kind": "episode", "session_key": "s2", "seq_refs": [8], "text_hint": "2026-08-01"}, "forbid": []}
+{"query_id": "q014", "type": "positive", "query": "上周三我搞定的那个登录问题跟什么协议有关？", "expect": {"kind": "episode", "session_key": "s2", "seq_refs": [1], "text_hint": "OAuth"}, "forbid": []}
+{"query_id": "q015", "type": "positive", "query": "有用户抱怨哪个功能在数据多的时候很慢？", "expect": {"kind": "episode", "session_key": "s2", "seq_refs": [10], "text_hint": "搜索功能"}, "forbid": []}
+{"query_id": "q016", "type": "positive", "query": "这个周末我动手重构的是哪个模块？", "expect": {"kind": "episode", "session_key": "s3", "seq_refs": [1], "text_hint": "payment"}, "forbid": []}
+{"query_id": "q017", "type": "positive", "query": "处理收款我接入的是哪家支付服务？", "expect": {"kind": "episode", "session_key": "s3", "seq_refs": [1, 7], "text_hint": "Stripe"}, "forbid": []}
+{"query_id": "q018", "type": "positive", "query": "代码缩进我习惯用几个空格？", "expect": {"kind": "episode", "session_key": "s3", "seq_refs": [2], "text_hint": "2 个空格"}, "forbid": []}
+{"query_id": "q019", "type": "positive", "query": "工作时我喜欢放哪种风格的背景音乐？", "expect": {"kind": "episode", "session_key": "s3", "seq_refs": [3], "text_hint": "lo-fi"}, "forbid": []}
+{"query_id": "q020", "type": "positive", "query": "我打算今年年底之前学哪门新的编程语言？", "expect": {"kind": "episode", "session_key": "s3", "seq_refs": [4], "text_hint": "Rust"}, "forbid": []}
+{"query_id": "q021", "type": "positive", "query": "我想用新语言重写项目里性能敏感的哪一块？", "expect": {"kind": "episode", "session_key": "s3", "seq_refs": [4], "text_hint": "搜索索引"}, "forbid": []}
+{"query_id": "q022", "type": "positive", "query": "项目上线用的域名地址是什么？", "expect": {"kind": "episode", "session_key": "s3", "seq_refs": [5], "text_hint": "seagull.app"}, "forbid": []}
+{"query_id": "q023", "type": "positive", "query": "域名每年在几月几号需要续费？", "expect": {"kind": "episode", "session_key": "s3", "seq_refs": [5], "text_hint": "3 月 15 日"}, "forbid": []}
+{"query_id": "q024", "type": "positive", "query": "我参加过什么线上比赛式的活动做过 demo？", "expect": {"kind": "episode", "session_key": "s1", "seq_refs": [12], "text_hint": "hackathon"}, "forbid": []}
+{"query_id": "q025", "type": "positive", "query": "第一次把服务正式发布那天我做了什么？", "expect": {"kind": "episode", "session_key": "s2", "seq_refs": [9], "text_hint": "部署上线"}, "forbid": []}
+{"query_id": "q026", "type": "positive", "query": "我审代码时对单个函数的长度有什么硬性要求？", "expect": {"kind": "episode", "session_key": "s2", "seq_refs": [11], "text_hint": "50 行"}, "forbid": []}
+{"query_id": "q027", "type": "positive", "query": "我的 Neovim 是基于哪个配置发行版搭的？", "expect": {"kind": "episode", "session_key": "s1", "seq_refs": [9], "text_hint": "LazyVim"}, "forbid": []}
+{"query_id": "q028", "type": "positive", "query": "我在考虑给项目加一个做时间管理的小功能，是什么？", "expect": {"kind": "episode", "session_key": "s3", "seq_refs": [8], "text_hint": "番茄钟"}, "forbid": []}
+{"query_id": "q029", "type": "positive", "query": "项目最后定下来的收费方案是怎样的？", "expect": {"kind": "episode", "session_key": "s3", "seq_refs": [6], "text_hint": "$5"}, "forbid": []}
+{"query_id": "q030", "type": "positive", "query": "现在生产环境里跑的那个关系型数据库是哪个？", "expect": {"kind": "episode", "session_key": "s2", "seq_refs": [2], "text_hint": "PostgreSQL"}, "forbid": []}
+{"query_id": "q031", "type": "positive", "query": "项目当前部署在哪个托管平台上？", "expect": {"kind": "episode", "session_key": "s2", "seq_refs": [3], "text_hint": "Fly.io"}, "forbid": []}
+{"query_id": "q032", "type": "positive", "query": "现在项目里用的状态管理库是哪一个？", "expect": {"kind": "episode", "session_key": "s2", "seq_refs": [4], "text_hint": "Zustand"}, "forbid": []}
+{"query_id": "q033", "type": "positive", "query": "我这个项目希望达到怎样的月度经常性收入目标？", "expect": {"kind": "episode", "session_key": "s1", "seq_refs": [10], "text_hint": "MRR"}, "forbid": []}
+{"query_id": "q034", "type": "positive", "query": "Google 登录那个偶发失败是因为哪个参数丢了？", "expect": {"kind": "episode", "session_key": "s2", "seq_refs": [1], "text_hint": "state"}, "forbid": []}
+{"query_id": "q035", "type": "temporal", "query": "我现在到底该用哪个数据库，是不是还停在 MongoDB？", "expect": {"kind": "episode", "session_key": "s2", "seq_refs": [2], "text_hint": "PostgreSQL"}, "forbid": [{"text_hint": "MongoDB"}]}
+{"query_id": "q036", "type": "temporal", "query": "Seagull 最后是部署在 Heroku 还是别的平台？", "expect": {"kind": "episode", "session_key": "s2", "seq_refs": [3], "text_hint": "Fly.io"}, "forbid": [{"text_hint": "Heroku"}]}
+{"query_id": "q037", "type": "temporal", "query": "项目现在的状态管理还是当初那个 Redux 吗？", "expect": {"kind": "episode", "session_key": "s2", "seq_refs": [4], "text_hint": "Zustand"}, "forbid": [{"text_hint": "Redux"}]}
+{"query_id": "q038", "type": "temporal", "query": "定价最后是收费还是当初说的捐赠模式？", "expect": {"kind": "episode", "session_key": "s3", "seq_refs": [6], "text_hint": "$5"}, "forbid": [{"text_hint": "捐赠"}]}
+{"query_id": "q039", "type": "temporal", "query": "第一版支付最终只接一家还是像最早说的支持支付宝？", "expect": {"kind": "episode", "session_key": "s3", "seq_refs": [7], "text_hint": "Stripe"}, "forbid": [{"text_hint": "支付宝"}]}
+{"query_id": "q040", "type": "negative", "query": "我养了什么宠物？", "forbid": [{"text_hint": "猫"}, {"text_hint": "狗"}]}
+{"query_id": "q041", "type": "negative", "query": "我平时最爱做的运动是什么？", "forbid": [{"text_hint": "篮球"}, {"text_hint": "跑步"}]}
+{"query_id": "q042", "type": "negative", "query": "我现在住在哪个城市？", "forbid": [{"text_hint": "北京"}, {"text_hint": "上海"}]}
+{"query_id": "q043", "type": "negative", "query": "我开发用的操作系统是不是 Windows？", "forbid": [{"text_hint": "Windows"}]}
+{"query_id": "q044", "type": "negative", "query": "项目后端框架用的是 Django 吗？", "forbid": [{"text_hint": "Django"}]}
+{"query_id": "q045", "type": "negative", "query": "项目是用 Kubernetes 编排部署的吗？", "forbid": [{"text_hint": "Kubernetes"}]}
+{"query_id": "q046", "type": "negative", "query": "我用的云服务商是 AWS 吗？", "forbid": [{"text_hint": "AWS"}]}
+{"query_id": "q047", "type": "negative", "query": "我每天喝几杯咖啡？", "forbid": [{"text_hint": "咖啡"}]}
+{"query_id": "q048", "type": "negative", "query": "数据库最后是不是敲定用 MongoDB 了？", "forbid": [{"text_hint": "最终定了 MongoDB"}, {"text_hint": "现在生产环境就是 MongoDB"}]}
+{"query_id": "q049", "type": "negative", "query": "部署平台最后是不是敲定留在 Heroku 了？", "forbid": [{"text_hint": "最终换成了 Heroku"}, {"text_hint": "现在 Seagull 就跑在 Heroku"}]}
+{"query_id": "q050", "type": "negative", "query": "定价最后是不是决定走免费捐赠那条路？", "forbid": [{"text_hint": "最终决定免费"}, {"text_hint": "改成了免费捐赠"}]}

--- a/scripts/memory_poc/corpus/queries.jsonl
+++ b/scripts/memory_poc/corpus/queries.jsonl
@@ -1,4 +1,4 @@
-{"query_id": "q001", "type": "positive", "query": "我这个 side project 的代号叫什么？", "expect": {"kind": "episode", "session_key": "s1", "seq_refs": [1], "text_hint": "Seagull"}, "forbid": []}
+{"query_id": "q001", "type": "positive", "query": "我一开始给项目定的目标是几个月内做出能用的 MVP？", "expect": {"kind": "episode", "session_key": "s1", "seq_refs": [1], "text_hint": "三个月"}, "forbid": []}
 {"query_id": "q002", "type": "positive", "query": "MVP 我给自己定的上线死线是哪一天？", "expect": {"kind": "episode", "session_key": "s1", "seq_refs": [1], "text_hint": "2026-09-30"}, "forbid": []}
 {"query_id": "q003", "type": "positive", "query": "我希望这个项目每个月能赚到多少钱？", "expect": {"kind": "episode", "session_key": "s1", "seq_refs": [10], "text_hint": "$1000"}, "forbid": []}
 {"query_id": "q004", "type": "positive", "query": "写代码我更偏向哪种带静态类型的语言？", "expect": {"kind": "episode", "session_key": "s1", "seq_refs": [7], "text_hint": "TypeScript"}, "forbid": []}
@@ -14,16 +14,16 @@
 {"query_id": "q014", "type": "positive", "query": "上周三我搞定的那个登录问题跟什么协议有关？", "expect": {"kind": "episode", "session_key": "s2", "seq_refs": [1], "text_hint": "OAuth"}, "forbid": []}
 {"query_id": "q015", "type": "positive", "query": "有用户抱怨哪个功能在数据多的时候很慢？", "expect": {"kind": "episode", "session_key": "s2", "seq_refs": [10], "text_hint": "搜索功能"}, "forbid": []}
 {"query_id": "q016", "type": "positive", "query": "这个周末我动手重构的是哪个模块？", "expect": {"kind": "episode", "session_key": "s3", "seq_refs": [1], "text_hint": "payment"}, "forbid": []}
-{"query_id": "q017", "type": "positive", "query": "处理收款我接入的是哪家支付服务？", "expect": {"kind": "episode", "session_key": "s3", "seq_refs": [1, 7], "text_hint": "Stripe"}, "forbid": []}
-{"query_id": "q018", "type": "positive", "query": "代码缩进我习惯用几个空格？", "expect": {"kind": "episode", "session_key": "s3", "seq_refs": [2], "text_hint": "2 个空格"}, "forbid": []}
+{"query_id": "q017", "type": "positive", "query": "处理收款我接入的是哪家支付服务？", "expect": {"kind": "episode", "session_key": "s3", "seq_refs": [7], "text_hint": "Stripe"}, "forbid": []}
+{"query_id": "q018", "type": "positive", "query": "代码缩进我习惯用几个空格？", "expect": {"kind": "episode", "session_key": "s3", "seq_refs": [2], "text_hint": "空格"}, "forbid": []}
 {"query_id": "q019", "type": "positive", "query": "工作时我喜欢放哪种风格的背景音乐？", "expect": {"kind": "episode", "session_key": "s3", "seq_refs": [3], "text_hint": "lo-fi"}, "forbid": []}
 {"query_id": "q020", "type": "positive", "query": "我打算今年年底之前学哪门新的编程语言？", "expect": {"kind": "episode", "session_key": "s3", "seq_refs": [4], "text_hint": "Rust"}, "forbid": []}
 {"query_id": "q021", "type": "positive", "query": "我想用新语言重写项目里性能敏感的哪一块？", "expect": {"kind": "episode", "session_key": "s3", "seq_refs": [4], "text_hint": "搜索索引"}, "forbid": []}
-{"query_id": "q022", "type": "positive", "query": "项目上线用的域名地址是什么？", "expect": {"kind": "episode", "session_key": "s3", "seq_refs": [5], "text_hint": "seagull.app"}, "forbid": []}
-{"query_id": "q023", "type": "positive", "query": "域名每年在几月几号需要续费？", "expect": {"kind": "episode", "session_key": "s3", "seq_refs": [5], "text_hint": "3 月 15 日"}, "forbid": []}
+{"query_id": "q022", "type": "positive", "query": "项目上线用的域名地址是什么？", "expect": {"kind": "episode", "session_key": "s3", "seq_refs": [5], "text_hint": "seagull.example"}, "forbid": []}
+{"query_id": "q023", "type": "positive", "query": "域名每年在几月几号需要续费？", "expect": {"kind": "episode", "session_key": "s3", "seq_refs": [5], "text_hint": "3月15日"}, "forbid": []}
 {"query_id": "q024", "type": "positive", "query": "我参加过什么线上比赛式的活动做过 demo？", "expect": {"kind": "episode", "session_key": "s1", "seq_refs": [12], "text_hint": "hackathon"}, "forbid": []}
 {"query_id": "q025", "type": "positive", "query": "第一次把服务正式发布那天我做了什么？", "expect": {"kind": "episode", "session_key": "s2", "seq_refs": [9], "text_hint": "部署上线"}, "forbid": []}
-{"query_id": "q026", "type": "positive", "query": "我审代码时对单个函数的长度有什么硬性要求？", "expect": {"kind": "episode", "session_key": "s2", "seq_refs": [11], "text_hint": "50 行"}, "forbid": []}
+{"query_id": "q026", "type": "positive", "query": "我审代码时对单个函数的长度有什么硬性要求？", "expect": {"kind": "episode", "session_key": "s2", "seq_refs": [11], "text_hint": "50行"}, "forbid": []}
 {"query_id": "q027", "type": "positive", "query": "我的 Neovim 是基于哪个配置发行版搭的？", "expect": {"kind": "episode", "session_key": "s1", "seq_refs": [9], "text_hint": "LazyVim"}, "forbid": []}
 {"query_id": "q028", "type": "positive", "query": "我在考虑给项目加一个做时间管理的小功能，是什么？", "expect": {"kind": "episode", "session_key": "s3", "seq_refs": [8], "text_hint": "番茄钟"}, "forbid": []}
 {"query_id": "q029", "type": "positive", "query": "项目最后定下来的收费方案是怎样的？", "expect": {"kind": "episode", "session_key": "s3", "seq_refs": [6], "text_hint": "$5"}, "forbid": []}
@@ -31,7 +31,7 @@
 {"query_id": "q031", "type": "positive", "query": "项目当前部署在哪个托管平台上？", "expect": {"kind": "episode", "session_key": "s2", "seq_refs": [3], "text_hint": "Fly.io"}, "forbid": []}
 {"query_id": "q032", "type": "positive", "query": "现在项目里用的状态管理库是哪一个？", "expect": {"kind": "episode", "session_key": "s2", "seq_refs": [4], "text_hint": "Zustand"}, "forbid": []}
 {"query_id": "q033", "type": "positive", "query": "我这个项目希望达到怎样的月度经常性收入目标？", "expect": {"kind": "episode", "session_key": "s1", "seq_refs": [10], "text_hint": "MRR"}, "forbid": []}
-{"query_id": "q034", "type": "positive", "query": "Google 登录那个偶发失败是因为哪个参数丢了？", "expect": {"kind": "episode", "session_key": "s2", "seq_refs": [1], "text_hint": "state"}, "forbid": []}
+{"query_id": "q034", "type": "positive", "query": "Google 登录那个偶发失败是因为丢了哪个 OAuth 回调参数？", "expect": {"kind": "episode", "session_key": "s2", "seq_refs": [1], "text_hint": "state 参数"}, "forbid": []}
 {"query_id": "q035", "type": "temporal", "query": "我现在到底该用哪个数据库，是不是还停在 MongoDB？", "expect": {"kind": "episode", "session_key": "s2", "seq_refs": [2], "text_hint": "PostgreSQL"}, "forbid": [{"text_hint": "MongoDB"}]}
 {"query_id": "q036", "type": "temporal", "query": "Seagull 最后是部署在 Heroku 还是别的平台？", "expect": {"kind": "episode", "session_key": "s2", "seq_refs": [3], "text_hint": "Fly.io"}, "forbid": [{"text_hint": "Heroku"}]}
 {"query_id": "q037", "type": "temporal", "query": "项目现在的状态管理还是当初那个 Redux 吗？", "expect": {"kind": "episode", "session_key": "s2", "seq_refs": [4], "text_hint": "Zustand"}, "forbid": [{"text_hint": "Redux"}]}

--- a/scripts/memory_poc/corpus/sessions.jsonl
+++ b/scripts/memory_poc/corpus/sessions.jsonl
@@ -2,7 +2,7 @@
 {"session_key": "s1", "seq": 2, "text": "后端数据库我打算先用 MongoDB，图它 schema 灵活、上手快。", "occurred_offset_ms": 60000, "tags": ["temporal-old"]}
 {"session_key": "s1", "seq": 3, "text": "部署平台先放在 Heroku 上，免费额度暂时够用。", "occurred_offset_ms": 120000, "tags": ["temporal-old"]}
 {"session_key": "s1", "seq": 4, "text": "前端状态管理我先上 Redux，自己之前比较熟。", "occurred_offset_ms": 180000, "tags": ["temporal-old"]}
-{"session_key": "s1", "seq": 5, "text": "商业模式我一开始想让 Seagull 完全免费，用捐赠模式养着。", "occurred_offset_ms": 240000, "tags": ["temporal-old"]}
+{"session_key": "s1", "seq": 5, "text": "商业模式我一开始想让 Seagull 完全免费，靠用户自愿捐赠来维持。", "occurred_offset_ms": 240000, "tags": ["temporal-old"]}
 {"session_key": "s1", "seq": 6, "text": "支付第一版我想同时支持支付宝和微信支付两种渠道。", "occurred_offset_ms": 300000, "tags": ["temporal-old"]}
 {"session_key": "s1", "seq": 7, "text": "写代码我强烈偏好 TypeScript，纯 JavaScript 基本不碰了，类型安全对我太重要。", "occurred_offset_ms": 360000, "tags": ["preference"]}
 {"session_key": "s1", "seq": 8, "text": "包管理我一直用 pnpm，不用 npm 也不用 yarn，磁盘占用小很多。", "occurred_offset_ms": 420000, "tags": ["preference"]}
@@ -20,12 +20,12 @@
 {"session_key": "s2", "seq": 8, "text": "Beta 内测我定在 2026-08-01 开始，先拉一小批朋友进来试用。", "occurred_offset_ms": 1210020000, "tags": ["date"]}
 {"session_key": "s2", "seq": 9, "text": "昨天第一次把服务正式部署上线，还特意发了条动态庆祝一下，虽然基本只有我自己看。", "occurred_offset_ms": 1210080000, "tags": ["episodic"]}
 {"session_key": "s2", "seq": 10, "text": "刚收到一个早期用户的反馈，说搜索功能在数据量一大的时候特别慢，得抽时间优化索引。", "occurred_offset_ms": 1210140000, "tags": ["episodic", "kill-case"]}
-{"session_key": "s2", "seq": 11, "text": "我 review 代码时特别在意单个函数不要超过 50 行，太长了就必须拆开。", "occurred_offset_ms": 1210200000, "tags": ["preference"]}
-{"session_key": "s3", "seq": 1, "text": "这周末我把整个 payment 模块重构了一遍，把 Stripe 的调用都收到一个 service 层里，测试好写多了。", "occurred_offset_ms": 1814400000, "tags": ["episodic"]}
+{"session_key": "s2", "seq": 11, "text": "我 review 代码时特别在意单个函数不要超过50行，太长了就必须拆开。", "occurred_offset_ms": 1210200000, "tags": ["preference"]}
+{"session_key": "s3", "seq": 1, "text": "这周末我把整个 payment 模块重构了一遍，把收款相关的调用都收敛到一个 service 层里，测试好写多了。", "occurred_offset_ms": 1814400000, "tags": ["episodic"]}
 {"session_key": "s3", "seq": 2, "text": "缩进我坚持用 2 个空格，不用 tab 也不用 4 空格，我自己的项目就这么定。", "occurred_offset_ms": 1814460000, "tags": ["preference"]}
 {"session_key": "s3", "seq": 3, "text": "工作的时候我喜欢放 lo-fi 音乐，太安静了反而静不下心。", "occurred_offset_ms": 1814520000, "tags": ["preference"]}
 {"session_key": "s3", "seq": 4, "text": "我计划年底之前认真学一下 Rust，想用它重写 Seagull 里性能敏感的搜索索引部分。", "occurred_offset_ms": 1814580000, "tags": ["goal"]}
-{"session_key": "s3", "seq": 5, "text": "域名 seagull.app 每年 3 月 15 日续费，我特意设了个提醒免得忘。", "occurred_offset_ms": 1814640000, "tags": ["date"]}
-{"session_key": "s3", "seq": 6, "text": "定价我想清楚了，不打算再走免费路线，改成每月 $5 的订阅制。", "occurred_offset_ms": 1814700000, "tags": ["temporal-new"]}
+{"session_key": "s3", "seq": 5, "text": "域名 seagull.example 每年3月15日续费，我特意设了个提醒免得忘。", "occurred_offset_ms": 1814640000, "tags": ["date"]}
+{"session_key": "s3", "seq": 6, "text": "定价我最后拍板了：不再走之前那种不收钱的路子，改成每月 $5 的订阅制。", "occurred_offset_ms": 1814700000, "tags": ["temporal-new"]}
 {"session_key": "s3", "seq": 7, "text": "支付这块也想清楚了，第一版只接 Stripe 一家，其它渠道都放到以后再说。", "occurred_offset_ms": 1814760000, "tags": ["temporal-new"]}
 {"session_key": "s3", "seq": 8, "text": "另外我在琢磨要不要给 Seagull 加一个番茄钟（Pomodoro）功能，细节还没定……", "occurred_offset_ms": 1814820000, "tags": ["buffered-tail"]}

--- a/scripts/memory_poc/corpus/sessions.jsonl
+++ b/scripts/memory_poc/corpus/sessions.jsonl
@@ -1,0 +1,31 @@
+{"session_key": "s1", "seq": 1, "text": "我最近开始做一个个人 side project，代号叫 Seagull，目标是三个月内做出一个能用的 MVP，最晚不能晚于 2026-09-30 上线。", "occurred_offset_ms": 0, "tags": ["goal", "date"]}
+{"session_key": "s1", "seq": 2, "text": "后端数据库我打算先用 MongoDB，图它 schema 灵活、上手快。", "occurred_offset_ms": 60000, "tags": ["temporal-old"]}
+{"session_key": "s1", "seq": 3, "text": "部署平台先放在 Heroku 上，免费额度暂时够用。", "occurred_offset_ms": 120000, "tags": ["temporal-old"]}
+{"session_key": "s1", "seq": 4, "text": "前端状态管理我先上 Redux，自己之前比较熟。", "occurred_offset_ms": 180000, "tags": ["temporal-old"]}
+{"session_key": "s1", "seq": 5, "text": "商业模式我一开始想让 Seagull 完全免费，用捐赠模式养着。", "occurred_offset_ms": 240000, "tags": ["temporal-old"]}
+{"session_key": "s1", "seq": 6, "text": "支付第一版我想同时支持支付宝和微信支付两种渠道。", "occurred_offset_ms": 300000, "tags": ["temporal-old"]}
+{"session_key": "s1", "seq": 7, "text": "写代码我强烈偏好 TypeScript，纯 JavaScript 基本不碰了，类型安全对我太重要。", "occurred_offset_ms": 360000, "tags": ["preference"]}
+{"session_key": "s1", "seq": 8, "text": "包管理我一直用 pnpm，不用 npm 也不用 yarn，磁盘占用小很多。", "occurred_offset_ms": 420000, "tags": ["preference"]}
+{"session_key": "s1", "seq": 9, "text": "编辑器我用 Neovim，配置基于 LazyVim，习惯了 vim 键位改不回去。", "occurred_offset_ms": 480000, "tags": ["preference"]}
+{"session_key": "s1", "seq": 10, "text": "我希望这个项目最终能做到每月 $1000 MRR，算是能养活自己的第一步。", "occurred_offset_ms": 540000, "tags": ["goal"]}
+{"session_key": "s1", "seq": 11, "text": "今天把脚手架搭好了，技术栈是 Vite + React + Tailwind，本地能跑起来还挺开心。", "occurred_offset_ms": 600000, "tags": ["episodic"]}
+{"session_key": "s1", "seq": 12, "text": "上个月我参加了一个线上 hackathon，用两天赶了个小 demo 出来，学到不少东西。", "occurred_offset_ms": 660000, "tags": ["episodic"]}
+{"session_key": "s2", "seq": 1, "text": "上周三我修掉了一个特别烦人的 bug，是 Google OAuth 登录回调偶尔丢掉 state 参数导致登录失败。", "occurred_offset_ms": 1209600000, "tags": ["episodic"]}
+{"session_key": "s2", "seq": 2, "text": "数据库最终定了 PostgreSQL，关系型查询和事务的需求太多，之前那个方案撑不住。现在生产环境就是 PostgreSQL。", "occurred_offset_ms": 1209660000, "tags": ["temporal-new"]}
+{"session_key": "s2", "seq": 3, "text": "部署平台最终换成了 Fly.io，之前那家的免费套餐取消了。现在 Seagull 就跑在 Fly.io 上。", "occurred_offset_ms": 1209720000, "tags": ["temporal-new"]}
+{"session_key": "s2", "seq": 4, "text": "状态管理最终收敛到 Zustand，样板代码少太多了，之前那一套已经全删掉。现在项目里只有 Zustand。", "occurred_offset_ms": 1209780000, "tags": ["temporal-new"]}
+{"session_key": "s2", "seq": 5, "text": "我写 commit 一直坚持 Conventional Commits 规范，feat/fix/docs 这种前缀，历史看着清爽。", "occurred_offset_ms": 1209840000, "tags": ["preference"]}
+{"session_key": "s2", "seq": 6, "text": "界面我只用深色主题（dark mode），白底看久了眼睛实在受不了。", "occurred_offset_ms": 1209900000, "tags": ["preference"]}
+{"session_key": "s2", "seq": 7, "text": "接下来一个大目标是给 Seagull 加 i18n，至少要支持中文和英文两种语言。", "occurred_offset_ms": 1209960000, "tags": ["goal"]}
+{"session_key": "s2", "seq": 8, "text": "Beta 内测我定在 2026-08-01 开始，先拉一小批朋友进来试用。", "occurred_offset_ms": 1210020000, "tags": ["date"]}
+{"session_key": "s2", "seq": 9, "text": "昨天第一次把服务正式部署上线，还特意发了条动态庆祝一下，虽然基本只有我自己看。", "occurred_offset_ms": 1210080000, "tags": ["episodic"]}
+{"session_key": "s2", "seq": 10, "text": "刚收到一个早期用户的反馈，说搜索功能在数据量一大的时候特别慢，得抽时间优化索引。", "occurred_offset_ms": 1210140000, "tags": ["episodic", "kill-case"]}
+{"session_key": "s2", "seq": 11, "text": "我 review 代码时特别在意单个函数不要超过 50 行，太长了就必须拆开。", "occurred_offset_ms": 1210200000, "tags": ["preference"]}
+{"session_key": "s3", "seq": 1, "text": "这周末我把整个 payment 模块重构了一遍，把 Stripe 的调用都收到一个 service 层里，测试好写多了。", "occurred_offset_ms": 1814400000, "tags": ["episodic"]}
+{"session_key": "s3", "seq": 2, "text": "缩进我坚持用 2 个空格，不用 tab 也不用 4 空格，我自己的项目就这么定。", "occurred_offset_ms": 1814460000, "tags": ["preference"]}
+{"session_key": "s3", "seq": 3, "text": "工作的时候我喜欢放 lo-fi 音乐，太安静了反而静不下心。", "occurred_offset_ms": 1814520000, "tags": ["preference"]}
+{"session_key": "s3", "seq": 4, "text": "我计划年底之前认真学一下 Rust，想用它重写 Seagull 里性能敏感的搜索索引部分。", "occurred_offset_ms": 1814580000, "tags": ["goal"]}
+{"session_key": "s3", "seq": 5, "text": "域名 seagull.app 每年 3 月 15 日续费，我特意设了个提醒免得忘。", "occurred_offset_ms": 1814640000, "tags": ["date"]}
+{"session_key": "s3", "seq": 6, "text": "定价我想清楚了，不打算再走免费路线，改成每月 $5 的订阅制。", "occurred_offset_ms": 1814700000, "tags": ["temporal-new"]}
+{"session_key": "s3", "seq": 7, "text": "支付这块也想清楚了，第一版只接 Stripe 一家，其它渠道都放到以后再说。", "occurred_offset_ms": 1814760000, "tags": ["temporal-new"]}
+{"session_key": "s3", "seq": 8, "text": "另外我在琢磨要不要给 Seagull 加一个番茄钟（Pomodoro）功能，细节还没定……", "occurred_offset_ms": 1814820000, "tags": ["buffered-tail"]}


### PR DESCRIPTION
## Capability

Adds the **Lane P2 fixture corpus** for the EverOS phase-0 Memory POC: the
synthetic Chinese-first corpus plus predeclared expectations that decide the
provider verdict. Scope is `scripts/memory_poc/corpus/**` only; the frozen
`scripts/memory_poc/CONTRACT.md` is untouched.

All three data files validate against CONTRACT v1 exactly.

## Contents

- `corpus/manifest.json` — revision `2026-07-22.1`, 31 messages, 50 queries.
- `corpus/sessions.jsonl` — 31 messages across 3 sessions (`s1`/`s2`/`s3`) for
  one synthetic principal (project codename *Seagull*). Covers stable
  preferences, goals, dates, short episodic events, **5 temporal-old→temporal-new
  correction pairs**, one `buffered-tail`, one `kill-case`.
- `corpus/queries.jsonl` — **34 positive** (paraphrase/synonym, zh + mixed EN),
  **11 negative** (8 unrelated-fact + 3 stale-assertion), **5 temporal**.
- `corpus/README.md` — design rationale + coverage tables mapping content to
  POC §4 bullets and to criteria ids `temporal_all`, `negatives_all`,
  `positive_top8_rate`.

## Affected scenarios / criteria

Feeds POC §6 criteria `temporal_all` (q035–q039), `negatives_all` (q040–q050),
`positive_top8_rate` (q001–q034); supports §5.2 quality/temporal and §5.3
cross-session personal-pool experiments.

## Evidence layers

- **Contract/decidability check (authoring-time):** a local checker confirms
  contract-shape, count integrity vs `manifest.json`, tag-vocabulary,
  positive/temporal hints ⊆ referenced fixture text, negative forbids ∉ corpus
  (no guaranteed-fail expectations), and temporal forbids ∈ superseded ∧ ∉
  correction. 0 errors / 0 warnings.
- **Residual manual:** none — corpus is data-only, exercised by Lane P1's runner.

## Guarantees

- Expectations declared **before any run**; never tuned to results.
- Entirely synthetic — no real names, employers, chats, or personal data.
- Temporal corrections name the same subject with non-overlapping value tokens,
  so stale-outranks-correction is mechanically detectable under substring match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)