### PR TITLE
feat(show): teach agents annotation workflows

### DIFF
--- a/core/show_session_events.py
+++ b/core/show_session_events.py
@@ -496,13 +496,35 @@ def _event_id(original_payload: dict[str, Any], event_payload: dict[str, Any]) -
     return _text_or_none(original_payload.get("id")) or _new_id("show_evt")
 
 
+def _format_transcript_header(
+    family: str,
+    *,
+    scope: Any,
+    action: str | None = None,
+    default_action: str | None = None,
+) -> str:
+    parts = [family]
+    if action and action != default_action:
+        parts.append(action)
+    normalized_scope = _text_or_none(scope) or DEFAULT_MARK_SCOPE
+    if normalized_scope != DEFAULT_MARK_SCOPE:
+        parts.append(f"scope={normalized_scope}")
+    return f"[{' '.join(parts)}]"
+
+
 def _format_transcript_text(event_type: str, payload: dict[str, Any], anchor: dict[str, Any]) -> str:
     if event_type == "system.annotation.control":
         return ""
     if event_type.startswith("assistant.mark."):
         action = event_type.split(".")[-1]
+        header = _format_transcript_header(
+            "agent-mark",
+            scope=payload.get("scope"),
+            action=action,
+            default_action="created",
+        )
         lines = [
-            f"[agent-mark:{payload.get('scope') or DEFAULT_MARK_SCOPE}:{action}] {payload.get('target')}",
+            f"{header} {payload.get('target')}",
             "",
             str(payload.get("body") or "").strip(),
         ]
@@ -517,13 +539,20 @@ def _format_transcript_text(event_type: str, payload: dict[str, Any], anchor: di
     if event_type == "human.intent.submitted":
         text = _text_or_none(payload.get("text") or payload.get("comment") or payload.get("value"))
         label = _text_or_none(payload.get("intent") or payload.get("component")) or "intent"
-        return f"[show-intent:{payload.get('scope') or DEFAULT_MARK_SCOPE}] {label}\n\n{text or _json_dumps(payload)}"
+        header = _format_transcript_header("show-intent", scope=payload.get("scope"))
+        return f"{header} {label}\n\n{text or _json_dumps(payload)}"
 
     if event_type in ANNOTATION_EVENT_TYPES:
         action = event_type.split(".")[-1]
         text = _text_or_none(payload.get("text") or payload.get("comment"))
         label = _text_or_none(payload.get("intent")) or "comment"
-        lines = [f"[show-annotation:{payload.get('scope') or DEFAULT_MARK_SCOPE}:{action}] {label}"]
+        header = _format_transcript_header(
+            "show-annotation",
+            scope=payload.get("scope"),
+            action=action,
+            default_action="created",
+        )
+        lines = [f"{header} {label}"]
         if text:
             lines.extend(["", text])
         primary_anchor = _normalize_annotation_primary_anchor(payload.get("primaryAnchor"))

--- a/core/system_prompt_injection.py
+++ b/core/system_prompt_injection.py
@@ -88,6 +88,11 @@ Change visibility:
 `vibe show update --visibility offline`
 
 For more usage details, run `vibe show --help` or a subcommand help such as `vibe show update --help`.
+
+### Show Page annotations & reverse marks
+- Users can annotate your Show Page; each annotation arrives as a chat message tagged [show-annotation] with its event id. Some messages end with a ready-to-run reply command — whether to reply on the page or respond by editing the page content is your call, per scenario.
+- After reworking a page area you may leave a short callout: `vibe show mark <selector-or-anchor> --message '...'` (same target replaces), or an `agent-note="..."` attribute on elements you author. Marks retire once read — leave at most 1-2 per turn.
+- Inspect/withdraw: `vibe show marks` / `vibe show unmark <id|target> ...`; toggle the user's annotation mode: `vibe show annotate --on|--off [--mode smart|screenshot]`.
 $avibe_cloud_guidance_section
 History contract:
 $show_git_agent_contract

--- a/tests/test_reply_enhancer_platform.py
+++ b/tests/test_reply_enhancer_platform.py
@@ -592,6 +592,27 @@ class ReplyEnhancerPlatformTests(unittest.IsolatedAsyncioTestCase):
         self.assertNotIn("`vibe show path --session-id sesk8m4q2p7x`", prompt)
         self.assertIn("export async function GET(request) { return Response.json({ ok: true }) }", prompt)
 
+    def test_show_pages_prompt_includes_annotation_capability_guidance(self):
+        context = MessageContext(
+            user_id="U1",
+            channel_id="C1",
+            platform="slack",
+            platform_specific={"agent_session_id": "sesk8m4q2p7x"},
+        )
+
+        with patch.object(paths, "get_user_preferences_path", return_value=Path("/tmp/user_preferences.md")):
+            prompt = build_system_prompt_injection(
+                include_quick_replies=False,
+                context=context,
+            )
+
+        guidance = """### Show Page annotations & reverse marks
+- Users can annotate your Show Page; each annotation arrives as a chat message tagged [show-annotation] with its event id. Some messages end with a ready-to-run reply command — whether to reply on the page or respond by editing the page content is your call, per scenario.
+- After reworking a page area you may leave a short callout: `vibe show mark <selector-or-anchor> --message '...'` (same target replaces), or an `agent-note="..."` attribute on elements you author. Marks retire once read — leave at most 1-2 per turn.
+- Inspect/withdraw: `vibe show marks` / `vibe show unmark <id|target> ...`; toggle the user's annotation mode: `vibe show annotate --on|--off [--mode smart|screenshot]`."""
+        self.assertIn(guidance, prompt)
+        self.assertNotIn("prefer replying on the page", prompt)
+
     def test_prompt_uses_fallback_platform_for_unannotated_context(self):
         context = MessageContext(
             user_id="U1",

--- a/tests/test_show_pages.py
+++ b/tests/test_show_pages.py
@@ -2172,7 +2172,7 @@ def test_show_mark_cli_records_event_and_message(monkeypatch, tmp_path, capsys):
     assert payload["ok"] is True
     assert payload["event"]["type"] == "assistant.mark.created"
     assert payload["event"]["message_id"]
-    assert payload["event"]["transcript_text"].startswith("[agent-mark:default:created] mark-default-summary")
+    assert payload["event"]["transcript_text"].startswith("[agent-mark] mark-default-summary")
 
     with engine.connect() as conn:
         assert conn.execute(select(show_session_events.c.id)).scalar_one() == payload["event"]["id"]
@@ -2262,7 +2262,7 @@ def test_show_mark_cli_posts_to_live_ui_when_running(monkeypatch, tmp_path, caps
                         "scope": "default",
                         "anchor": {},
                         "payload": {},
-                        "transcript_text": "[agent-mark:default] mark-default-summary\n\nReview this summary.",
+                        "transcript_text": "[agent-mark] mark-default-summary\n\nReview this summary.",
                         "message_id": "msg_live",
                         "message": {"id": "msg_live"},
                         "created_at": "now",
@@ -2834,7 +2834,7 @@ def test_show_event_cli_dispatch_flag_updates_annotation_payload(monkeypatch, tm
                         "scope": "default",
                         "anchor": {},
                         "payload": {"dispatch": True},
-                        "transcript_text": "[show-annotation:default:created] comment",
+                        "transcript_text": "[show-annotation] comment",
                         "message_id": "msg_live",
                         "message": {"id": "msg_live"},
                         "created_at": "now",

--- a/tests/test_show_pages.py
+++ b/tests/test_show_pages.py
@@ -1726,6 +1726,7 @@ def test_show_path_cli_json_creates_page(monkeypatch, tmp_path, capsys):
     assert payload["url_guidance"] is None
     assert "Do not send implementation details such as local paths to the user unless they ask for them." in payload["next_actions"]
     assert "Treat the Show Page as the primary collaboration surface; put meaningful updates there first." in payload["next_actions"]
+    assert "Annotations: users can mark up this page; see vibe show marks / reply / annotate." in payload["next_actions"]
     assert (
         "Use visual thinking: diagrams, timelines, maps, comparisons, dashboards, or small prototypes when they help."
         in payload["next_actions"]
@@ -1734,6 +1735,20 @@ def test_show_path_cli_json_creates_page(monkeypatch, tmp_path, capsys):
     assert captured["url"] == "http://127.0.0.1:5123/api/show/sessions/ses123/prewarm"
     assert captured["payload"] == {}
     assert captured["timeout"] == 3
+
+
+def test_show_path_cli_prints_annotation_capabilities(monkeypatch, tmp_path, capsys):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    paths.ensure_data_dirs()
+    _save_config()
+    monkeypatch.setattr(cli.runtime, "read_status", lambda: {})
+
+    args = cli.build_parser().parse_args(["show", "path", "--session-id", "ses123"])
+    assert cli.cmd_show_path(args) == 0
+
+    output = capsys.readouterr().out
+    assert "Use it:" in output
+    assert "- Annotations: users can mark up this page; see vibe show marks / reply / annotate." in output
 
 
 def test_show_path_cli_keeps_page_when_prewarm_fails(monkeypatch, tmp_path, capsys):

--- a/tests/test_show_session_events.py
+++ b/tests/test_show_session_events.py
@@ -711,9 +711,15 @@ def test_show_event_dispatch_streams_via_stream_dispatch(isolated_state, monkeyp
 
 @pytest.mark.parametrize(
     ("intent", "expects_guidance"),
-    [("question", True), ("change", False)],
+    [
+        ("question", True),
+        ("comment", True),
+        ("fix", False),
+        ("change", False),
+        ("approve", False),
+    ],
 )
-def test_annotation_dispatch_text_adds_event_id_and_question_guidance_only(monkeypatch, intent, expects_guidance):
+def test_annotation_dispatch_text_adds_event_id_and_optional_reply_guidance(monkeypatch, intent, expects_guidance):
     import asyncio
 
     from vibe import internal_client, ui_server
@@ -732,16 +738,19 @@ def test_annotation_dispatch_text_adds_event_id_and_question_guidance_only(monke
         "session_id": "ses_show",
         "scope_id": "scope1",
         "payload": {"intent": intent},
-        "transcript_text": "[show-annotation:default:created] question\n\nWhy?",
+        "transcript_text": f"[show-annotation:default:created] {intent}\n\nReview this.",
         "message_id": "m1",
     }
 
     asyncio.run(ui_server._run_show_event_dispatch(event))
 
-    assert event["transcript_text"] == "[show-annotation:default:created] question\n\nWhy?"
+    assert event["transcript_text"] == f"[show-annotation:default:created] {intent}\n\nReview this."
     assert "Show event id: show_evt_1a2b3c4d" in captured[0]["text"]
     guidance = (
-        "用户在页面上提出了疑问。请优先把回答放回页面上用户指的位置（chat 里保留一句简短结论即可）：\n"
-        "  vibe show reply show_evt_1a2b3c4d --message '<你的回答>'"
+        "如需在页面上原位回应，可执行：\n"
+        "  vibe show reply show_evt_1a2b3c4d --message '<你的回答>'\n"
+        "（也可以直接修改页面内容来响应，按场景选择。）"
     )
     assert (guidance in captured[0]["text"]) is expects_guidance
+    if expects_guidance:
+        assert captured[0]["text"].endswith(guidance)

--- a/tests/test_show_session_events.py
+++ b/tests/test_show_session_events.py
@@ -770,6 +770,7 @@ def test_show_event_dispatch_streams_via_stream_dispatch(isolated_state, monkeyp
     [
         ("question", True),
         ("comment", True),
+        (None, True),
         ("fix", False),
         ("change", False),
         ("approve", False),
@@ -788,19 +789,20 @@ def test_annotation_dispatch_text_adds_event_id_and_optional_reply_guidance(monk
             yield None
 
     monkeypatch.setattr(internal_client, "stream_dispatch", fake_stream_dispatch)
+    label = intent or "comment"
     event = {
         "id": "show_evt_1a2b3c4d",
         "type": "human.annotation.created",
         "session_id": "ses_show",
         "scope_id": "scope1",
-        "payload": {"intent": intent},
-        "transcript_text": f"[show-annotation] {intent}\n\nReview this.",
+        "payload": {"intent": intent} if intent is not None else {},
+        "transcript_text": f"[show-annotation] {label}\n\nReview this.",
         "message_id": "m1",
     }
 
     asyncio.run(ui_server._run_show_event_dispatch(event))
 
-    assert event["transcript_text"] == f"[show-annotation] {intent}\n\nReview this."
+    assert event["transcript_text"] == f"[show-annotation] {label}\n\nReview this."
     assert "Show event id: show_evt_1a2b3c4d" in captured[0]["text"]
     guidance = (
         "如需在页面上原位回应，可执行：\n"

--- a/tests/test_show_session_events.py
+++ b/tests/test_show_session_events.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import pytest
 from sqlalchemy import select
 
-from core.show_session_events import ShowSessionEventError, ShowSessionEventStore
+from core.show_session_events import ShowSessionEventError, ShowSessionEventStore, _format_transcript_text
 from storage.db import create_sqlite_engine
 from storage.importer import ensure_sqlite_state
 from storage.models import agent_sessions, messages, show_session_events
@@ -84,7 +84,7 @@ def test_show_event_store_records_assistant_mark_and_transcript_message(isolated
     assert event["scope"] == "default"
     assert event["message_id"]
     assert event["message"]["id"] == event["message_id"]
-    assert "[agent-mark:default:created] mark-default-summary" in event["transcript_text"]
+    assert "[agent-mark] mark-default-summary" in event["transcript_text"]
     assert "Anchor: [mark-default='summary']" in event["transcript_text"]
 
     with engine.connect() as conn:
@@ -133,7 +133,7 @@ def test_show_event_store_records_human_annotation_with_anchor_context(isolated_
     assert event["payload"]["status"] == "pending"
     assert event["payload"]["author"] == {"kind": "local"}
     assert event["message_id"]
-    assert "[show-annotation:default:created] question" in event["transcript_text"]
+    assert "[show-annotation] question" in event["transcript_text"]
     assert "Clarify this claim." in event["transcript_text"]
     assert "Quote: Quarterly summary" in event["transcript_text"]
 
@@ -580,7 +580,7 @@ def test_show_event_store_records_intent_dispatch_payload(isolated_state):
         store.close()
 
     assert event["payload"]["dispatch"] is True
-    assert "[show-intent:default] choose" in event["transcript_text"]
+    assert "[show-intent] choose" in event["transcript_text"]
     assert "Pick B." in event["transcript_text"]
 
 
@@ -604,6 +604,62 @@ def test_show_event_store_records_assistant_page_update(isolated_state):
     assert event["actor"] == "assistant"
     assert event["message_id"]
     assert "[show-page-updated] Updated the Show Page" in event["transcript_text"]
+
+
+@pytest.mark.parametrize(
+    ("event_type", "payload", "expected_header"),
+    [
+        (
+            "assistant.mark.created",
+            {"scope": "default", "target": "summary", "body": "Created."},
+            "[agent-mark] summary",
+        ),
+        (
+            "assistant.mark.resolved",
+            {"scope": "default", "target": "summary", "body": "Resolved."},
+            "[agent-mark resolved] summary",
+        ),
+        (
+            "assistant.mark.updated",
+            {"scope": "review", "target": "summary", "body": "Updated."},
+            "[agent-mark updated scope=review] summary",
+        ),
+        (
+            "human.intent.submitted",
+            {"scope": "default", "intent": "question", "text": "Why?"},
+            "[show-intent] question",
+        ),
+        (
+            "human.intent.submitted",
+            {"scope": "review", "intent": "question", "text": "Why?"},
+            "[show-intent scope=review] question",
+        ),
+        (
+            "human.annotation.created",
+            {"scope": "default", "intent": "question", "comment": "Why?"},
+            "[show-annotation] question",
+        ),
+        (
+            "human.annotation.resolved",
+            {"scope": "default", "intent": "comment", "comment": "Done."},
+            "[show-annotation resolved] comment",
+        ),
+        (
+            "human.annotation.created",
+            {"scope": "review", "intent": "question", "comment": "Why?"},
+            "[show-annotation scope=review] question",
+        ),
+        (
+            "human.annotation.resolved",
+            {"scope": "review", "intent": "comment", "comment": "Done."},
+            "[show-annotation resolved scope=review] comment",
+        ),
+    ],
+)
+def test_show_event_transcript_headers_only_render_deviations(event_type, payload, expected_header):
+    transcript = _format_transcript_text(event_type, payload, {})
+
+    assert transcript.splitlines()[0] == expected_header
 
 
 def test_show_event_store_rejects_unknown_session(isolated_state):
@@ -738,13 +794,13 @@ def test_annotation_dispatch_text_adds_event_id_and_optional_reply_guidance(monk
         "session_id": "ses_show",
         "scope_id": "scope1",
         "payload": {"intent": intent},
-        "transcript_text": f"[show-annotation:default:created] {intent}\n\nReview this.",
+        "transcript_text": f"[show-annotation] {intent}\n\nReview this.",
         "message_id": "m1",
     }
 
     asyncio.run(ui_server._run_show_event_dispatch(event))
 
-    assert event["transcript_text"] == f"[show-annotation:default:created] {intent}\n\nReview this."
+    assert event["transcript_text"] == f"[show-annotation] {intent}\n\nReview this."
     assert "Show event id: show_evt_1a2b3c4d" in captured[0]["text"]
     guidance = (
         "如需在页面上原位回应，可执行：\n"

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -10074,7 +10074,14 @@ def cmd_remote_stop(args):
     return 0 if result.get("ok") else 1
 
 
-def _show_page_result(page, *, message: str, previous_payload: dict | None = None, extra: dict | None = None) -> dict:
+def _show_page_result(
+    page,
+    *,
+    message: str,
+    previous_payload: dict | None = None,
+    extra: dict | None = None,
+    include_annotation_guidance: bool = False,
+) -> dict:
     from core.show_pages import show_page_payload
 
     payload = {
@@ -10086,11 +10093,14 @@ def _show_page_result(page, *, message: str, previous_payload: dict | None = Non
         payload.update(previous_payload)
     if extra:
         payload.update(extra)
-    payload["next_actions"] = _show_page_next_actions(payload)
+    payload["next_actions"] = _show_page_next_actions(
+        payload,
+        include_annotation_guidance=include_annotation_guidance,
+    )
     return payload
 
 
-def _show_page_next_actions(payload: dict) -> list[str]:
+def _show_page_next_actions(payload: dict, *, include_annotation_guidance: bool = False) -> list[str]:
     session_id = payload.get("session_id") or "<session-id>"
     visibility = payload.get("visibility")
     actions = [
@@ -10107,6 +10117,8 @@ def _show_page_next_actions(payload: dict) -> list[str]:
     actions.append("Treat the Show Page as the primary collaboration surface; put meaningful updates there first.")
     actions.append("Use visual thinking: diagrams, timelines, maps, comparisons, dashboards, or small prototypes when they help.")
     actions.append("To update the page later, edit src/App.tsx or api/*.ts; the private page hot-reloads when open.")
+    if include_annotation_guidance:
+        actions.append("Annotations: users can mark up this page; see vibe show marks / reply / annotate.")
     actions.append("For more options, run: vibe show --help")
     return actions
 
@@ -10269,6 +10281,7 @@ def cmd_show_path(args):
             page,
             message=f"Show Page workspace is ready at {page_dir}.",
             extra={"session_default_notice": session_default_notice} if session_default_notice else None,
+            include_annotation_guidance=True,
         )
         if getattr(args, "json", False):
             _print_json(payload)

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -8691,12 +8691,13 @@ def _show_event_dispatch_text(event_payload: dict[str, Any]) -> str:
         return transcript_text
     lines = [transcript_text, "", f"Show event id: {event_id}"]
     payload = event_payload.get("payload")
-    if isinstance(payload, dict) and payload.get("intent") == "question":
+    if isinstance(payload, dict) and payload.get("intent") in {"question", "comment"}:
         lines.extend(
             [
                 "",
-                "用户在页面上提出了疑问。请优先把回答放回页面上用户指的位置（chat 里保留一句简短结论即可）：",
+                "如需在页面上原位回应，可执行：",
                 f"  vibe show reply {event_id} --message '<你的回答>'",
+                "（也可以直接修改页面内容来响应，按场景选择。）",
             ]
         )
     return "\n".join(lines)

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -8691,7 +8691,10 @@ def _show_event_dispatch_text(event_payload: dict[str, Any]) -> str:
         return transcript_text
     lines = [transcript_text, "", f"Show event id: {event_id}"]
     payload = event_payload.get("payload")
-    if isinstance(payload, dict) and payload.get("intent") in {"question", "comment"}:
+    intent = "comment"
+    if isinstance(payload, dict):
+        intent = str(payload.get("intent") or "").strip() or "comment"
+    if intent in {"question", "comment"}:
         lines.extend(
             [
                 "",


### PR DESCRIPTION
## Capability

Adds concise annotation capability education for agents across the moments where it matters:

- the Show Pages system prompt explains incoming annotations, reverse marks, mark retirement, inspection/withdrawal, and annotation-mode controls
- annotation dispatch suggests an optional in-page reply for both `question` and `comment`, while preserving event-id-only dispatch for `fix`, `change`, and `approve`
- `vibe show path` surfaces annotation capabilities in its `Use it:` output
- annotation, intent, and agent-mark transcript headers omit default `created`/`default` values while spelling out non-default actions and scopes

## Known by design

- The system prompt deliberately does not prefer page replies over page edits. Scenario-specific timing guidance exists only in the annotation dispatch tail so agents do not over-generalize it.
- The dispatch suggestion remains the owner-approved Chinese operational copy, independent of UI locale. It is phrased as an option, never a restriction.
- Transcript headers retain intent tokens such as `question` and `comment`; only default action/scope metadata is suppressed.

## Scenarios

No repository scenario catalog covers this prompt/CLI surface. Focused tests cover the owner-approved system-prompt block, the dispatch matrix including omitted-intent comments, the three transcript-header families, transcript cleanliness, and `show path` capability discovery.

## Evidence

- Unit: exact system-prompt block, path next-action generation, and default/deviation transcript-header matrix
- Contract: no event or CLI contract changes; existing event IDs and commands are referenced as documented capabilities
- Scenario: `tests/test_reply_enhancer_platform.py` (35 passed), `tests/test_show_session_events.py` (41 passed), `tests/test_show_pages.py` (130 passed)
- Lint: Ruff passed on all touched Python files
- Residual manual: live agent consumption of the injected prompt and a real Show Page annotation round trip remain for the orchestrator integration pass

## Dependencies

No unmerged dependency. This follows merged PR #955 and does not change its event or CLI contracts.
