### PR TITLE
fix(chat): guard A9a source link against a missing source session

### DIFF
--- a/storage/messages_service.py
+++ b/storage/messages_service.py
@@ -156,8 +156,11 @@ def _attach_agent_run_provenance(
 
     for payload in payloads:
         source_id = source_by_exec.get(exec_by_msg.get(payload["id"], ""))
-        if source_id:
-            meta = meta_by_session.get(source_id) or {}
+        # Only attach when the source session still exists (is in meta_by_session);
+        # a stale/imported/deleted source would otherwise write source_session_id
+        # and produce a dead /chat/<missing id> link with only the fallback label.
+        if source_id in meta_by_session:
+            meta = meta_by_session[source_id]
             payload["source_session_id"] = source_id
             payload["source_session_title"] = meta.get("title")
             payload["source_session_agent_name"] = meta.get("agent_name")

--- a/tests/test_messages_service.py
+++ b/tests/test_messages_service.py
@@ -133,6 +133,27 @@ def test_agent_run_message_provenance_enrichment(isolated_state):
     assert "source_session_id" not in by_id["msg_task"]
 
 
+def test_agent_run_provenance_skips_missing_source_session(isolated_state):
+    # Dead-link guard: if the resolved source session no longer has an
+    # agent_sessions row (stale/imported/deleted), the enrichment must NOT attach
+    # source_session_id — a /chat/<missing id> link would only show the fallback.
+    engine = create_sqlite_engine()
+    with engine.begin() as conn:
+        scope_id = _seed_scope(conn)
+        _seed_session(conn, scope_id, "ses_target")
+        # source_actor points at a session that was never seeded (deleted/stale).
+        _insert_agent_run(conn, "execGhost", session_id="ses_target",
+                          source_kind="agent", source_actor="ses_ghost")
+        _insert_harness_msg(conn, scope_id, "ses_target", author_name="agent_run",
+                            native_message_id="agent_run:execGhost", msg_id="msg_ghost",
+                            created_at="2026-05-30T10:00:00Z")
+
+    with engine.connect() as conn:
+        result = messages_service.list_session_messages(conn, session_id="ses_target")
+    by_id = {m["id"]: m for m in result["messages"]}
+    assert "source_session_id" not in by_id["msg_ghost"]
+
+
 def test_mark_session_read_ties_break_on_id(isolated_state):
     """When ``until_message_id`` points at a message whose ``created_at``
     is shared by newer messages (second precision), only rows at-or-before


### PR DESCRIPTION
## Capability

Follow-up to #965 (Codex post-merge P2). A9a's chat source-session chip could deep-link to a **deleted/stale source session** — a dead `/chat/<missing id>` link.

## What shipped

`messages_service._attach_agent_run_provenance` resolves an agent-callback message's source session (agent → `source_actor`; callback → the parent run's `session_id`) and attaches `source_session_id` / `source_session_title` / `source_session_agent_name`. It attached the id **before** confirming the session still exists, so a stale/imported/deleted source produced a `/chat/<missing id>` chip with only the fallback label.

**Fix (read-side, 3 lines):** attach the source fields only when the resolved id is present in `meta_by_session` (i.e., the target session actually resolved). No schema/write-path change; behavior for real source sessions is unchanged.

## Evidence layers

- **Unit:** `tests/test_messages_service.py::test_agent_run_provenance_skips_missing_source_session` — an `agent_run` message whose `source_actor` was never seeded gets no `source_session_*`. The existing `test_agent_run_message_provenance_enrichment` (real agent + callback sources still attach) is unaffected.
- **Gates:** `python3 -m pytest tests/test_messages_service.py` = 33 ✓ · `ruff` clean.

Scope: `storage/messages_service.py` guard + one test only — no other changes. DO NOT MERGE — orchestrator merges.
