### PR TITLE
fix(ui): hide Show Tool Calls row until Show Agent Activity is on

### DIFF
--- a/ui/src/components/settings/SettingsMessagingPage.tsx
+++ b/ui/src/components/settings/SettingsMessagingPage.tsx
@@ -508,24 +508,31 @@ export const SettingsMessagingPage: React.FC = () => {
           }
         />
 
-        <SettingsRow
-          title={t('dashboard.showToolCalls')}
-          description={t('dashboard.showToolCallsHint')}
-          control={
-            <ToggleSwitch
-              // Default on: absent key reads as enabled (only an explicit false hides).
-              enabled={config.ui?.show_tool_calls !== false}
-              onClick={() => {
-                const next = config.ui?.show_tool_calls === false;
-                const nextConfig = {
-                  ...config,
-                  ui: { ...(config.ui || {}), show_tool_calls: next },
-                };
-                void persist(nextConfig, { ui: { show_tool_calls: next } });
-              }}
-            />
-          }
-        />
+        {/* Tool-call rows only surface inside the Activity panel, which renders
+            only when Show Agent Activity is on — so this child control has
+            nothing to affect while the parent is off. Display-only linkage: the
+            stored ``show_tool_calls`` value is left untouched, so re-enabling the
+            parent restores the user's prior choice. */}
+        {Boolean(config.ui?.show_agent_activity) && (
+          <SettingsRow
+            title={t('dashboard.showToolCalls')}
+            description={t('dashboard.showToolCallsHint')}
+            control={
+              <ToggleSwitch
+                // Default on: absent key reads as enabled (only an explicit false hides).
+                enabled={config.ui?.show_tool_calls !== false}
+                onClick={() => {
+                  const next = config.ui?.show_tool_calls === false;
+                  const nextConfig = {
+                    ...config,
+                    ui: { ...(config.ui || {}), show_tool_calls: next },
+                  };
+                  void persist(nextConfig, { ui: { show_tool_calls: next } });
+                }}
+              />
+            }
+          />
+        )}
       </SettingsPanel>
 
       <SettingsPanel


### PR DESCRIPTION
## Capability

Settings › Messaging › Display: the **Show Tool Calls** row is now only
**visible** when **Show Agent Activity** is enabled. The tool-call rows this
setting controls render only inside the Agent Activity panel, which itself
appears only when Show Agent Activity is on — so while the parent is off the
child toggle controlled something that could not appear anywhere, which is
confusing. The two settings are now linked as a pure display-visibility
relationship.

Follow-up refinement to #946 (P2 item B).

## Change

- Wrap the `showToolCalls` `SettingsRow` in
  `{Boolean(config.ui?.show_agent_activity) && ( … )}`, reusing the existing
  conditional-row pattern already in this file (`{slackSupportsLinkUnfurl && …}`).
- **No config writes** beyond what the toggles already do: the stored
  `config.ui.show_tool_calls` value is **not** reset/cleared when the parent
  turns off, so re-enabling the parent restores the user's previous choice.
- No i18n, backend, or config-schema changes. The eye/Tools pill inside the
  chat Activity panel (`AgentActivityGroup`) is untouched — panels only exist
  when the parent is on, so it is already consistent.

Single product file changed: `ui/src/components/settings/SettingsMessagingPage.tsx`.

## Evidence layers

- **Unit / contract / scenario:** none added. This is a 3-line display-only
  conditional; the settings page has no existing row-rendering test harness,
  and no scenario catalog covers Settings display toggles, so per the task
  brief a new harness is not warranted here.
- **Build gate:** `npm run build` (tsc + vite) green; `npm run validate:theme`
  green — both mirror the CI `build-linux-artifacts` UI gate.
- **Lint:** change is lint-neutral — `eslint` reports the identical
  `5 problems (4 errors, 1 warning)` on this file with and without the change;
  all are pre-existing in untouched code (`no-explicit-any` on the shared
  `config`/`persist` `any`, `set-state-in-effect`/`exhaustive-deps` in the
  font-size effect). CI does not run eslint.
- **Residual manual checks (deferred to the orchestrator's regression pass):**
  in the running UI, toggling Show Agent Activity **off** hides the Show Tool
  Calls row; toggling it back **on** shows the row again with its prior value
  intact (default-on when never explicitly set). jsdom / real-browser
  verification deferred to the integration pass.
