### PR TITLE
feat(model-hub): add per-turn backend injection

### DIFF
--- a/core/controller.py
+++ b/core/controller.py
@@ -225,6 +225,12 @@ class Controller:
 
         self.session_turns = SessionTurnManager(self)
 
+        # Model Hub owns per-turn supply selection. Backend adapters consume
+        # the resulting launch plan without persisting native CLI config.
+        from modules.agents.model_hub import ModelHubRuntimeRouter
+
+        self.model_hub_runtime = ModelHubRuntimeRouter()
+
         # Initialize core modules
         self._init_modules()
 

--- a/core/handlers/session_handler.py
+++ b/core/handlers/session_handler.py
@@ -890,7 +890,11 @@ class SessionHandler(BaseHandler):
 
         # Determine final model: explicit override > agent frontmatter > global default
         effective_model = explicit_model or agent_model or self.config.claude.default_model
-        from modules.agents.model_hub import build_claude_hub_env, launch_for_context
+        from modules.agents.model_hub import (
+            build_claude_hub_env,
+            claude_setting_sources_for_launch,
+            launch_for_context,
+        )
 
         model_hub_launch = launch_for_context(context)
         runtime_model = (
@@ -961,7 +965,7 @@ class SessionHandler(BaseHandler):
             "resume": stored_claude_session_id if stored_claude_session_id else None,
             "fork_session": bool(fork_session and stored_claude_session_id),
             "extra_args": extra_args,
-            "setting_sources": ["user", "project", "local"],  # Load all setting sources (user, project CLAUDE.md, local overrides)
+            "setting_sources": claude_setting_sources_for_launch(model_hub_launch),
             "sandbox": CLAUDE_REMOTE_SANDBOX,
             # Disable interactive-only Claude Code tools that remote IM sessions
             # cannot answer programmatically.

--- a/core/handlers/session_handler.py
+++ b/core/handlers/session_handler.py
@@ -113,6 +113,10 @@ class SessionHandler(BaseHandler):
         self.session_turn_started.pop(composite_key, None)
         self.claude_system_prompts.pop(composite_key, None)
 
+    async def _wait_for_claude_session_idle(self, composite_key: str) -> None:
+        while composite_key in self.active_sessions:
+            await asyncio.sleep(0.05)
+
     def bind_claude_runtime_session(
         self,
         client: ClaudeSDKClient,
@@ -179,6 +183,7 @@ class SessionHandler(BaseHandler):
             return None
         if getattr(client, "_vibe_model_hub_fingerprint", "direct") != model_hub_launch.fingerprint:
             logger.info("Recreating cached Claude SDK client because Model Hub channel changed")
+            await self._wait_for_claude_session_idle(composite_key)
             await self.cleanup_session(composite_key)
             return None
 
@@ -248,6 +253,7 @@ class SessionHandler(BaseHandler):
             return None
         if getattr(client, "_vibe_model_hub_fingerprint", "direct") != model_hub_launch.fingerprint:
             logger.info("Recreating cached Claude subagent SDK client because Model Hub channel changed")
+            await self._wait_for_claude_session_idle(composite_key)
             await self.cleanup_session(composite_key)
             return None
         self.ensure_agent_session_id(

--- a/core/handlers/session_handler.py
+++ b/core/handlers/session_handler.py
@@ -82,6 +82,15 @@ class SessionHandler(BaseHandler):
         controller.claude_system_prompts = self.claude_system_prompts
         controller.claude_session_creates = self.claude_session_creates
 
+    @staticmethod
+    def _cached_claude_subagent_model(
+        explicit_model: Optional[str],
+        model_hub_launch: "ModelHubLaunch",
+    ) -> Optional[str]:
+        if model_hub_launch.channel in {"native_cli", "hub"}:
+            return model_hub_launch.runtime_model
+        return explicit_model
+
     def touch_session_activity(self, composite_key: str) -> None:
         if composite_key:
             self.session_last_activity[composite_key] = time.monotonic()
@@ -724,7 +733,7 @@ class SessionHandler(BaseHandler):
         )
         bind_launch(context, model_hub_launch)
         runtime_model = model_hub_launch.runtime_model or launch_model
-        cached_subagent_model = runtime_model if model_hub_launch.channel == "hub" else explicit_model
+        cached_subagent_model = self._cached_claude_subagent_model(explicit_model, model_hub_launch)
 
         if not effective_agent:
             # Claude SDK model changes are control requests; only send one when

--- a/core/handlers/session_handler.py
+++ b/core/handlers/session_handler.py
@@ -6,7 +6,7 @@ import os
 import re
 import time
 from pathlib import Path
-from typing import Optional, Dict, Any, Tuple
+from typing import TYPE_CHECKING, Optional, Dict, Any, Tuple
 from uuid import uuid4
 from modules.im import MessageContext
 from modules.claude_sdk_compat import (
@@ -39,6 +39,9 @@ from vibe import backend_model_catalog
 from .base import BaseHandler
 
 logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    from modules.agents.model_hub import ModelHubLaunch
 
 CLAUDE_NO_CONVERSATION_RE = re.compile(r"No conversation found with session ID:\s*(\S+)")
 CLAUDE_REMOTE_DISALLOWED_TOOLS = ["AskUserQuestion", "EnterPlanMode", "ExitPlanMode"]
@@ -169,9 +172,14 @@ class SessionHandler(BaseHandler):
         stored_claude_session_id: Optional[str],
         current_model: Optional[str],
         agent_system_prompt: Optional[str],
+        model_hub_launch: "ModelHubLaunch",
     ) -> ClaudeSDKClient | None:
         client = self.claude_sessions.get(composite_key)
         if client is None:
+            return None
+        if getattr(client, "_vibe_model_hub_fingerprint", "direct") != model_hub_launch.fingerprint:
+            logger.info("Recreating cached Claude SDK client because Model Hub channel changed")
+            await self.cleanup_session(composite_key)
             return None
 
         next_system_prompt = self._build_claude_system_prompt(
@@ -232,10 +240,15 @@ class SessionHandler(BaseHandler):
         context: MessageContext,
         session_key: str,
         native_session_id: Optional[str],
-        explicit_model: Optional[str],
+        desired_model: Optional[str],
+        model_hub_launch: "ModelHubLaunch",
     ) -> ClaudeSDKClient | None:
         client = self.claude_sessions.get(composite_key)
         if client is None:
+            return None
+        if getattr(client, "_vibe_model_hub_fingerprint", "direct") != model_hub_launch.fingerprint:
+            logger.info("Recreating cached Claude subagent SDK client because Model Hub channel changed")
+            await self.cleanup_session(composite_key)
             return None
         self.ensure_agent_session_id(
             context,
@@ -259,16 +272,16 @@ class SessionHandler(BaseHandler):
             )
             await self.cleanup_session(composite_key)
             return None
-        if explicit_model:
+        if desired_model:
             try:
-                await self._set_claude_model_if_needed(client, explicit_model)
+                await self._set_claude_model_if_needed(client, desired_model)
             except Exception as e:
                 logger.warning(f"Failed to update model on cached Claude subagent session: {e}")
         logger.info(
             "Using Claude subagent session for %s at %s (model_override=%s)",
             base_session_id,
             working_path,
-            explicit_model,
+            desired_model,
         )
         self.bind_claude_runtime_session(
             client,
@@ -689,10 +702,28 @@ class SessionHandler(BaseHandler):
             explicit_model = subagent_model or session_target.get("model") or explicit_model
             explicit_effort = subagent_reasoning_effort or session_target.get("reasoning_effort") or explicit_effort
 
+        launch_model = explicit_model
+        if not launch_model and effective_agent:
+            launch_agent_data = self._load_agent_file(effective_agent, working_path)
+            configured_agent_model = launch_agent_data.get("model") if launch_agent_data else None
+            if configured_agent_model and configured_agent_model.lower() not in ("inherit", ""):
+                launch_model = configured_agent_model
+        launch_model = launch_model or self.config.claude.default_model
+        from modules.agents.model_hub import bind_launch, resolve_model_hub_launch
+
+        model_hub_launch = await resolve_model_hub_launch(
+            self.controller,
+            "claude",
+            launch_model or "",
+        )
+        bind_launch(context, model_hub_launch)
+        runtime_model = model_hub_launch.runtime_model or launch_model
+        cached_subagent_model = runtime_model if model_hub_launch.channel == "hub" else explicit_model
+
         if not effective_agent:
             # Claude SDK model changes are control requests; only send one when
             # the effective model actually changes.
-            current_model = explicit_model or self.config.claude.default_model
+            current_model = runtime_model
             client = await self._reuse_cached_claude_session_if_available(
                 composite_key=composite_key,
                 base_session_id=base_session_id,
@@ -702,6 +733,7 @@ class SessionHandler(BaseHandler):
                 stored_claude_session_id=stored_claude_session_id,
                 current_model=current_model,
                 agent_system_prompt=None,
+                model_hub_launch=model_hub_launch,
             )
             if client is not None:
                 return client
@@ -721,7 +753,8 @@ class SessionHandler(BaseHandler):
                 context=context,
                 session_key=session_key,
                 native_session_id=cached_session_id,
-                explicit_model=explicit_model,
+                desired_model=cached_subagent_model,
+                model_hub_launch=model_hub_launch,
             )
             if client is not None:
                 return client
@@ -744,7 +777,8 @@ class SessionHandler(BaseHandler):
                     context=context,
                     session_key=session_key,
                     native_session_id=stored_claude_session_id,
-                    explicit_model=explicit_model,
+                    desired_model=cached_subagent_model,
+                    model_hub_launch=model_hub_launch,
                 )
             else:
                 client = await self._reuse_cached_claude_session_if_available(
@@ -754,8 +788,9 @@ class SessionHandler(BaseHandler):
                     context=context,
                     session_key=session_key,
                     stored_claude_session_id=stored_claude_session_id,
-                    current_model=explicit_model or self.config.claude.default_model,
+                    current_model=runtime_model,
                     agent_system_prompt=None,
+                    model_hub_launch=model_hub_launch,
                 )
             if client is not None:
                 return client
@@ -840,6 +875,14 @@ class SessionHandler(BaseHandler):
 
         # Determine final model: explicit override > agent frontmatter > global default
         effective_model = explicit_model or agent_model or self.config.claude.default_model
+        from modules.agents.model_hub import build_claude_hub_env, launch_for_context
+
+        model_hub_launch = launch_for_context(context)
+        runtime_model = (
+            model_hub_launch.runtime_model
+            if model_hub_launch is not None and model_hub_launch.backend == "claude"
+            else effective_model
+        )
         from modules.agents.opencode.utils import normalize_claude_reasoning_effort
 
         effective_effort = normalize_claude_reasoning_effort(
@@ -862,8 +905,8 @@ class SessionHandler(BaseHandler):
 
         # Create extra_args for CLI passthrough (fallback for model)
         extra_args: Dict[str, str | None] = {}
-        if effective_model:
-            extra_args["model"] = effective_model
+        if runtime_model:
+            extra_args["model"] = runtime_model
 
         claude_stderr_lines: list[str] = []
 
@@ -882,6 +925,8 @@ class SessionHandler(BaseHandler):
         from core.git_runtime import prepend_vendored_git_to_path
 
         claude_env = build_claude_subprocess_env(getattr(self.config, "claude", None))
+        if model_hub_launch is not None:
+            claude_env = build_claude_hub_env(claude_env, model_hub_launch)
         claude_env.update(caller_env_for_platform_payload(getattr(context, "platform_specific", None)))
         prepend_vendored_git_to_path(
             claude_env,
@@ -946,6 +991,11 @@ class SessionHandler(BaseHandler):
         client = ClaudeSDKClient(options=options)
         setattr(client, "_vibe_caller_env", caller_env_for_platform_payload(getattr(context, "platform_specific", None)))
         setattr(client, "_vibe_git_path_state", git_path_state)
+        setattr(
+            client,
+            "_vibe_model_hub_fingerprint",
+            model_hub_launch.fingerprint if model_hub_launch is not None else "direct",
+        )
 
         # Log the actual options being used
         logger.info("ClaudeAgentOptions details:")

--- a/modules/agents/base.py
+++ b/modules/agents/base.py
@@ -163,7 +163,7 @@ class BaseAgent(ABC):
             mark_started(context)
 
     async def record_model_hub_native_failure(self, context: Any, diagnostic: str) -> bool:
-        """Persist native subscription cooldown state when a turn proves quota loss."""
+        """Persist source cooldown state when a terminal turn proves source loss."""
 
         router = getattr(self.controller, "model_hub_runtime", None)
         recorder = getattr(router, "record_native_failure", None)

--- a/modules/agents/base.py
+++ b/modules/agents/base.py
@@ -162,6 +162,19 @@ class BaseAgent(ABC):
         if callable(mark_started):
             mark_started(context)
 
+    async def record_model_hub_native_failure(self, context: Any, diagnostic: str) -> bool:
+        """Persist native subscription cooldown state when a turn proves quota loss."""
+
+        router = getattr(self.controller, "model_hub_runtime", None)
+        recorder = getattr(router, "record_native_failure", None)
+        if not callable(recorder):
+            return False
+        try:
+            return bool(await recorder(context, diagnostic))
+        except Exception:
+            logger.warning("Failed to record Model Hub native cooldown", exc_info=True)
+            return False
+
     def ensure_agent_session_id(
         self,
         request: AgentRequest,

--- a/modules/agents/claude_agent.py
+++ b/modules/agents/claude_agent.py
@@ -172,6 +172,7 @@ class ClaudeAgent(BaseAgent):
             raise
         except Exception as e:
             logger.error(f"Error processing Claude message: {e}", exc_info=True)
+            await self.record_model_hub_native_failure(context, str(e))
             # Clean up the specific reaction for this request (not FIFO)
             await self._remove_specific_pending_reaction(runtime_session_key, context, request)
             self._remove_pending_request(runtime_session_key, request)
@@ -1075,6 +1076,8 @@ class ClaudeAgent(BaseAgent):
             # the receiver is dead and won't process any more results.
             await self._clear_pending_reactions(composite_key, context)
             error_notify = self._format_error_notify(e)
+            failure_context = getattr(pending_request, "context", context)
+            await self.record_model_hub_native_failure(failure_context, str(e))
             handled = await self.controller.agent_auth_service.maybe_emit_auth_recovery_message(
                 context,
                 "claude",
@@ -1245,6 +1248,8 @@ class ClaudeAgent(BaseAgent):
             composite_key,
             diagnostic,
         )
+        failure_context = getattr(pending_request, "context", context)
+        await self.record_model_hub_native_failure(failure_context, diagnostic)
         handled_auth = await emit_backend_failure(
             self.controller,
             context,

--- a/modules/agents/codex/agent.py
+++ b/modules/agents/codex/agent.py
@@ -842,10 +842,21 @@ class CodexAgent(BaseAgent):
         active_turn = self._turn_registry.get_active_turn(request.base_session_id)
         if not thread_id or not active_turn:
             return
-        await transport.send_request(
-            "turn/interrupt",
-            {"threadId": thread_id, "turnId": active_turn},
-        )
+        try:
+            await transport.send_request(
+                "turn/interrupt",
+                {"threadId": thread_id, "turnId": active_turn},
+            )
+        except Exception:
+            # A dead/wedged transport cannot acknowledge the interrupt. Hide
+            # and release the old turn anyway so the runtime-change path can
+            # replace that transport instead of waiting on it forever.
+            logger.warning(
+                "Codex turn interrupt failed before Model Hub runtime change; "
+                "replacing stale transport for cwd=%s",
+                request.working_path,
+                exc_info=True,
+            )
         interrupted_request = self._event_handler.clear_pending(active_turn)
         if interrupted_request:
             await self._remove_ack_reaction(interrupted_request)

--- a/modules/agents/codex/agent.py
+++ b/modules/agents/codex/agent.py
@@ -167,60 +167,59 @@ class CodexAgent(BaseAgent):
         3. If a turn is active → interrupt it first
         4. Start a new turn with the user's message
         """
-        launch = None
-        try:
-            if getattr(self.controller, "model_hub_runtime", None) is not None:
-                from modules.agents.model_hub import bind_launch, resolve_model_hub_launch
-
-                _, requested_model, _, _ = self._resolve_codex_agent_settings(request)
-                launch = await resolve_model_hub_launch(
-                    self.controller,
-                    "codex",
-                    requested_model or "",
-                )
-                bind_launch(request.context, launch)
-                transport = await self._get_or_create_transport(request.working_path, launch)
-            else:
-                transport = await self._get_or_create_transport(request.working_path)
-        except FileNotFoundError:
-            await emit_backend_failure(
-                self.controller,
-                request.context,
-                self.name,
-                "Codex CLI not found",
-                display_text="❌ Codex CLI not found. Please install it or set CODEX_CLI_PATH.",
-                request=request,
-            )
-            await self._remove_ack_reaction(request)
-            self._event_handler._release_stream_turn(request.context)
-            return
-        except Exception as e:
-            logger.error("Failed to start Codex transport: %s", e, exc_info=True)
-            await self._record_model_hub_native_failure(request.context, str(e))
-            await emit_backend_failure(
-                self.controller,
-                request.context,
-                self.name,
-                str(e),
-                display_text=f"❌ Failed to start Codex CLI: {e}",
-                request=request,
-            )
-            await self._remove_ack_reaction(request)
-            self._event_handler._release_stream_turn(request.context)
-            return
-
-        # Track session_key and cwd for scoped invalidation
-        self._session_mgr.set_session_key(request.base_session_id, request.session_key)
-        self._session_mgr.set_cwd(request.base_session_id, request.working_path)
-        self._touch_transport_activity(request.working_path)
-
-        await self._delete_ack(request)
-
         # Serialize turn lifecycle per session
         if request.base_session_id not in self._session_locks:
             self._session_locks[request.base_session_id] = asyncio.Lock()
 
         async with self._session_locks[request.base_session_id]:
+            launch = None
+            try:
+                if getattr(self.controller, "model_hub_runtime", None) is not None:
+                    from modules.agents.model_hub import bind_launch, resolve_model_hub_launch
+
+                    _, requested_model, _, _ = self._resolve_codex_agent_settings(request)
+                    launch = await resolve_model_hub_launch(
+                        self.controller,
+                        "codex",
+                        requested_model or "",
+                    )
+                    bind_launch(request.context, launch)
+                    transport = await self._get_or_create_transport(request.working_path, launch)
+                else:
+                    transport = await self._get_or_create_transport(request.working_path)
+            except FileNotFoundError:
+                await emit_backend_failure(
+                    self.controller,
+                    request.context,
+                    self.name,
+                    "Codex CLI not found",
+                    display_text="❌ Codex CLI not found. Please install it or set CODEX_CLI_PATH.",
+                    request=request,
+                )
+                await self._remove_ack_reaction(request)
+                self._event_handler._release_stream_turn(request.context)
+                return
+            except Exception as e:
+                logger.error("Failed to start Codex transport: %s", e, exc_info=True)
+                await self._record_model_hub_native_failure(request.context, str(e))
+                await emit_backend_failure(
+                    self.controller,
+                    request.context,
+                    self.name,
+                    str(e),
+                    display_text=f"❌ Failed to start Codex CLI: {e}",
+                    request=request,
+                )
+                await self._remove_ack_reaction(request)
+                self._event_handler._release_stream_turn(request.context)
+                return
+
+            # Resolve after queued turns, then bind this session to the runtime.
+            self._session_mgr.set_session_key(request.base_session_id, request.session_key)
+            self._session_mgr.set_cwd(request.base_session_id, request.working_path)
+            self._touch_transport_activity(request.working_path)
+            await self._delete_ack(request)
+
             self._turn_registry.remember_request(request)
             try:
                 # Get or create thread (with resume support)
@@ -737,82 +736,93 @@ class CodexAgent(BaseAgent):
         if cwd not in self._transport_locks:
             self._transport_locks[cwd] = asyncio.Lock()
 
-        async with self._transport_locks[cwd]:
-            # Double-check after acquiring lock
-            existing = self._transports.get(cwd)
-            if existing and existing.is_initialized:
-                # Reuse only while the directory the app-server was spawned in
-                # is still the SAME directory (#561): after a delete (+ possible
-                # re-create) the cached process sits in a dead inode and every
-                # thread/start fails. Untracked legacy entries reuse as before.
-                spawned_ino = self._cwd_inodes().get(cwd)
-                stale_cwd = spawned_ino is not None and self._cwd_inode(cwd) != spawned_ino
-                desired_fingerprint = launch.fingerprint if launch is not None else "direct"
-                runtime_changed = getattr(existing, "runtime_fingerprint", "direct") != desired_fingerprint
-                if not stale_cwd and not runtime_changed:
-                    self._touch_transport_activity(cwd)
-                    return existing
-                if stale_cwd:
-                    logger.warning(
-                        "Codex transport cwd was replaced under the cached app-server; restarting transport for cwd=%s",
-                        cwd,
-                    )
+        while True:
+            wait_for_active_turns = False
+            async with self._transport_locks[cwd]:
+                # Double-check after acquiring lock
+                existing = self._transports.get(cwd)
+                if existing and existing.is_initialized:
+                    # Reuse only while the directory the app-server was spawned in
+                    # is still the SAME directory (#561): after a delete (+ possible
+                    # re-create) the cached process sits in a dead inode and every
+                    # thread/start fails. Untracked legacy entries reuse as before.
+                    spawned_ino = self._cwd_inodes().get(cwd)
+                    stale_cwd = spawned_ino is not None and self._cwd_inode(cwd) != spawned_ino
+                    desired_fingerprint = launch.fingerprint if launch is not None else "direct"
+                    runtime_changed = getattr(existing, "runtime_fingerprint", "direct") != desired_fingerprint
+                    if not stale_cwd and not runtime_changed:
+                        self._touch_transport_activity(cwd)
+                        return existing
+                    if runtime_changed and self._has_active_turns_for_cwd(cwd):
+                        wait_for_active_turns = True
+                    elif stale_cwd:
+                        logger.warning(
+                            "Codex transport cwd was replaced under the cached app-server; "
+                            "restarting transport for cwd=%s",
+                            cwd,
+                        )
+                    else:
+                        logger.info("Restarting Codex transport after Model Hub channel change for cwd=%s", cwd)
+
+                if wait_for_active_turns:
+                    pass
                 else:
-                    logger.info("Restarting Codex transport after Model Hub channel change for cwd=%s", cwd)
+                    # Stop stale transport if any
+                    if existing:
+                        await existing.stop()
+                        # The new app-server process won't know about threads/turns
+                        # from the old process. Invalidate only sessions bound to
+                        # this cwd so healthy sessions on other cwds are unaffected.
+                        affected = self._session_mgr.sessions_for_cwd(cwd)
+                        for bid in affected:
+                            self._session_mgr.invalidate_thread(bid)
+                            self._clear_thread_developer_instructions(bid)
+                            self._turn_registry.clear_session(bid)
+                        if affected:
+                            logger.info(
+                                "Invalidated %d stale Codex session(s) after transport restart for cwd=%s",
+                                len(affected),
+                                cwd,
+                            )
 
-            # Stop stale transport if any
-            if existing:
-                await existing.stop()
-                # The new app-server process won't know about threads/turns
-                # from the old process.  Invalidate only sessions bound to
-                # this cwd so healthy sessions on other cwds are unaffected.
-                affected = self._session_mgr.sessions_for_cwd(cwd)
-                for bid in affected:
-                    self._session_mgr.invalidate_thread(bid)
-                    self._clear_thread_developer_instructions(bid)
-                    self._turn_registry.clear_session(bid)
-                if affected:
-                    logger.info(
-                        "Invalidated %d stale Codex session(s) after transport restart for cwd=%s",
-                        len(affected),
-                        cwd,
+                    runtime_args: list[str] = []
+                    runtime_env: dict[str, str] | None = None
+                    runtime_fingerprint = "direct"
+                    if launch is not None:
+                        from modules.agents.model_hub import build_codex_hub_launch
+
+                        runtime_args, runtime_env = build_codex_hub_launch([], os.environ.copy(), launch)
+                        runtime_fingerprint = launch.fingerprint
+                    transport = CodexTransport(
+                        binary=self.codex_config.binary,
+                        cwd=cwd,
+                        extra_args=list(self.codex_config.extra_args),
+                        runtime_args=runtime_args,
+                        runtime_env=runtime_env,
+                        runtime_fingerprint=runtime_fingerprint,
                     )
 
-            runtime_args: list[str] = []
-            runtime_env: dict[str, str] | None = None
-            runtime_fingerprint = "direct"
-            if launch is not None:
-                from modules.agents.model_hub import build_codex_hub_launch
+                    # Wire up callbacks
+                    transport.on_notification(self._on_notification)
+                    # Bind the cwd so any server request (e.g. an auto-approval)
+                    # refreshes this transport's activity even without a turn id.
+                    transport.on_server_request(
+                        lambda req_id, method, params, _cwd=cwd: self._on_server_request(
+                            _cwd, req_id, method, params
+                        )
+                    )
 
-                runtime_args, runtime_env = build_codex_hub_launch([], os.environ.copy(), launch)
-                runtime_fingerprint = launch.fingerprint
-            transport = CodexTransport(
-                binary=self.codex_config.binary,
-                cwd=cwd,
-                extra_args=list(self.codex_config.extra_args),
-                runtime_args=runtime_args,
-                runtime_env=runtime_env,
-                runtime_fingerprint=runtime_fingerprint,
-            )
-
-            # Wire up callbacks
-            transport.on_notification(self._on_notification)
-            # Bind the cwd so any server request (e.g. an auto-approval) refreshes
-            # this transport's activity: a server request IS app-server liveness,
-            # and unlike notifications it isn't always tied to a resolvable
-            # turn/thread in params. Without this a turn that thinks silently and
-            # then asks for approval near the stuck-active cap could be wrongly
-            # force-evicted by the next sweep.
-            transport.on_server_request(
-                lambda req_id, method, params, _cwd=cwd: self._on_server_request(_cwd, req_id, method, params)
-            )
-
-            await transport.start()
-            governor_from_controller(self.controller).apply_to_pid(getattr(transport, "pid", None), label="codex app-server")
-            self._transports[cwd] = transport
-            self._cwd_inodes()[cwd] = self._cwd_inode(cwd)
-            self._touch_transport_activity(cwd)
-            return transport
+                    await transport.start()
+                    governor_from_controller(self.controller).apply_to_pid(
+                        getattr(transport, "pid", None),
+                        label="codex app-server",
+                    )
+                    self._transports[cwd] = transport
+                    self._cwd_inodes()[cwd] = self._cwd_inode(cwd)
+                    self._touch_transport_activity(cwd)
+                    return transport
+            if wait_for_active_turns:
+                await asyncio.sleep(0.05)
 
     # ------------------------------------------------------------------
     # Thread management

--- a/modules/agents/codex/agent.py
+++ b/modules/agents/codex/agent.py
@@ -42,6 +42,7 @@ if TYPE_CHECKING:
 
 _CODEX_MANAGED_PROVIDER_IDS = frozenset((MANAGED_PROVIDER_ID, *LEGACY_MANAGED_PROVIDER_IDS))
 _CODEX_MODEL_HUB_PROVIDER_ID = "avibe_model_hub"
+_CODEX_DEFAULT_PROVIDER_ID = "openai"
 CODEX_CALLER_ENV_DIR = "codex-caller-env"
 
 
@@ -184,6 +185,7 @@ class CodexAgent(BaseAgent):
                         requested_model or "",
                     )
                     bind_launch(request.context, launch)
+                    await self._interrupt_active_turn_before_runtime_change(request, launch)
                     transport = await self._get_or_create_transport(request.working_path, launch)
                 else:
                     transport = await self._get_or_create_transport(request.working_path)
@@ -824,6 +826,30 @@ class CodexAgent(BaseAgent):
             if wait_for_active_turns:
                 await asyncio.sleep(0.05)
 
+    async def _interrupt_active_turn_before_runtime_change(
+        self,
+        request: AgentRequest,
+        launch: "ModelHubLaunch",
+    ) -> None:
+        """Let a replacement prompt interrupt its own stale-runtime turn."""
+
+        transport = self._transports.get(request.working_path)
+        if transport is None or not transport.is_initialized:
+            return
+        if getattr(transport, "runtime_fingerprint", "direct") == launch.fingerprint:
+            return
+        thread_id = self._session_mgr.get_thread_id(request.base_session_id)
+        active_turn = self._turn_registry.get_active_turn(request.base_session_id)
+        if not thread_id or not active_turn:
+            return
+        await transport.send_request(
+            "turn/interrupt",
+            {"threadId": thread_id, "turnId": active_turn},
+        )
+        interrupted_request = self._event_handler.clear_pending(active_turn)
+        if interrupted_request:
+            await self._remove_ack_reaction(interrupted_request)
+
     # ------------------------------------------------------------------
     # Thread management
     # ------------------------------------------------------------------
@@ -1279,7 +1305,10 @@ class CodexAgent(BaseAgent):
         model_provider = config_obj.get("model_provider")
         if isinstance(model_provider, str) and model_provider.strip():
             return model_provider.strip()
-        return None
+        # Codex omits the built-in provider from config/read when no explicit
+        # model_provider is configured. Make that default concrete so a thread
+        # created under the ephemeral Hub provider can resume in Direct mode.
+        return _CODEX_DEFAULT_PROVIDER_ID
 
     def _build_thread_developer_instructions(self, request: AgentRequest) -> Optional[str]:
         """Build Codex thread-level developer instructions for start/resume.

--- a/modules/agents/codex/agent.py
+++ b/modules/agents/codex/agent.py
@@ -8,7 +8,7 @@ import os
 import shlex
 import time
 from pathlib import Path
-from typing import Any, Callable, Dict, Optional
+from typing import TYPE_CHECKING, Any, Callable, Dict, Optional
 
 from config import paths
 from config.v2_config import (
@@ -37,7 +37,11 @@ from vibe.message_identity import is_input_turn
 
 logger = logging.getLogger(__name__)
 
+if TYPE_CHECKING:
+    from modules.agents.model_hub import ModelHubLaunch
+
 _CODEX_MANAGED_PROVIDER_IDS = frozenset((MANAGED_PROVIDER_ID, *LEGACY_MANAGED_PROVIDER_IDS))
+_CODEX_MODEL_HUB_PROVIDER_ID = "avibe_model_hub"
 CODEX_CALLER_ENV_DIR = "codex-caller-env"
 
 
@@ -143,6 +147,17 @@ class CodexAgent(BaseAgent):
             return lambda: None
         return lambda: self._transport_alive(transport)
 
+    async def _record_model_hub_native_failure(self, context: Any, diagnostic: str) -> bool:
+        router = getattr(self.controller, "model_hub_runtime", None)
+        recorder = getattr(router, "record_native_failure", None)
+        if not callable(recorder):
+            return False
+        try:
+            return bool(await recorder(context, diagnostic))
+        except Exception:
+            logger.warning("Failed to record Model Hub native cooldown", exc_info=True)
+            return False
+
     async def handle_message(self, request: AgentRequest) -> None:
         """Process a user message by routing it through app-server.
 
@@ -152,8 +167,21 @@ class CodexAgent(BaseAgent):
         3. If a turn is active → interrupt it first
         4. Start a new turn with the user's message
         """
+        launch = None
         try:
-            transport = await self._get_or_create_transport(request.working_path)
+            if getattr(self.controller, "model_hub_runtime", None) is not None:
+                from modules.agents.model_hub import bind_launch, resolve_model_hub_launch
+
+                _, requested_model, _, _ = self._resolve_codex_agent_settings(request)
+                launch = await resolve_model_hub_launch(
+                    self.controller,
+                    "codex",
+                    requested_model or "",
+                )
+                bind_launch(request.context, launch)
+                transport = await self._get_or_create_transport(request.working_path, launch)
+            else:
+                transport = await self._get_or_create_transport(request.working_path)
         except FileNotFoundError:
             await emit_backend_failure(
                 self.controller,
@@ -168,6 +196,7 @@ class CodexAgent(BaseAgent):
             return
         except Exception as e:
             logger.error("Failed to start Codex transport: %s", e, exc_info=True)
+            await self._record_model_hub_native_failure(request.context, str(e))
             await emit_backend_failure(
                 self.controller,
                 request.context,
@@ -242,7 +271,10 @@ class CodexAgent(BaseAgent):
                     )
                     await self._drop_transport_after_failure(request.working_path, transport, request)
                     try:
-                        transport = await self._get_or_create_transport(request.working_path)
+                        if launch is None:
+                            transport = await self._get_or_create_transport(request.working_path)
+                        else:
+                            transport = await self._get_or_create_transport(request.working_path, launch)
                         self._touch_transport_activity(request.working_path)
                         thread_id = await self._start_or_resume_thread(transport, request)
                         await self._start_turn(transport, request, thread_id)
@@ -258,6 +290,7 @@ class CodexAgent(BaseAgent):
                 # fallbacks).
                 self._turn_registry.clear_pending_turn_start(request.base_session_id, request)
                 logger.error("Error in Codex handle_message: %s", e, exc_info=True)
+                await self._record_model_hub_native_failure(request.context, str(e))
                 error_text = f"❌ Codex error: {e}"
                 await emit_backend_failure(
                     self.controller,
@@ -694,7 +727,11 @@ class CodexAgent(BaseAgent):
         self._clear_thread_developer_instructions(request.base_session_id)
         self._turn_registry.clear_session(request.base_session_id)
 
-    async def _get_or_create_transport(self, cwd: str) -> CodexTransport:
+    async def _get_or_create_transport(
+        self,
+        cwd: str,
+        launch: "ModelHubLaunch | None" = None,
+    ) -> CodexTransport:
         """Return an initialized transport for the given working directory."""
         # Serialize creation per cwd
         if cwd not in self._transport_locks:
@@ -710,13 +747,18 @@ class CodexAgent(BaseAgent):
                 # thread/start fails. Untracked legacy entries reuse as before.
                 spawned_ino = self._cwd_inodes().get(cwd)
                 stale_cwd = spawned_ino is not None and self._cwd_inode(cwd) != spawned_ino
-                if not stale_cwd:
+                desired_fingerprint = launch.fingerprint if launch is not None else "direct"
+                runtime_changed = getattr(existing, "runtime_fingerprint", "direct") != desired_fingerprint
+                if not stale_cwd and not runtime_changed:
                     self._touch_transport_activity(cwd)
                     return existing
-                logger.warning(
-                    "Codex transport cwd was replaced under the cached app-server; restarting transport for cwd=%s",
-                    cwd,
-                )
+                if stale_cwd:
+                    logger.warning(
+                        "Codex transport cwd was replaced under the cached app-server; restarting transport for cwd=%s",
+                        cwd,
+                    )
+                else:
+                    logger.info("Restarting Codex transport after Model Hub channel change for cwd=%s", cwd)
 
             # Stop stale transport if any
             if existing:
@@ -736,10 +778,21 @@ class CodexAgent(BaseAgent):
                         cwd,
                     )
 
+            runtime_args: list[str] = []
+            runtime_env: dict[str, str] | None = None
+            runtime_fingerprint = "direct"
+            if launch is not None:
+                from modules.agents.model_hub import build_codex_hub_launch
+
+                runtime_args, runtime_env = build_codex_hub_launch([], os.environ.copy(), launch)
+                runtime_fingerprint = launch.fingerprint
             transport = CodexTransport(
                 binary=self.codex_config.binary,
                 cwd=cwd,
                 extra_args=list(self.codex_config.extra_args),
+                runtime_args=runtime_args,
+                runtime_env=runtime_env,
+                runtime_fingerprint=runtime_fingerprint,
             )
 
             # Wire up callbacks
@@ -1021,6 +1074,12 @@ class CodexAgent(BaseAgent):
                 logger.warning("Failed to load Codex subagent %s: %s", effective_agent, exc)
 
         effective_model = explicit_model or (agent_definition.model if agent_definition else None) or self.codex_config.default_model
+        if getattr(self.controller, "model_hub_runtime", None) is not None:
+            from modules.agents.model_hub import launch_for_context
+
+            launch = launch_for_context(getattr(request, "context", None))
+            if launch is not None and launch.backend == "codex":
+                effective_model = launch.runtime_model or effective_model
         effective_effort = explicit_effort or (agent_definition.reasoning_effort if agent_definition else None)
         developer_instructions = vibe_instructions or (agent_definition.developer_instructions if agent_definition else None)
 
@@ -1183,6 +1242,8 @@ class CodexAgent(BaseAgent):
 
     @staticmethod
     def _is_managed_provider_transition(stored_provider: str, current_provider: str) -> bool:
+        if _CODEX_MODEL_HUB_PROVIDER_ID in {stored_provider, current_provider}:
+            return True
         return {stored_provider, current_provider}.issubset(_CODEX_MANAGED_PROVIDER_IDS)
 
     async def _read_effective_model_provider(

--- a/modules/agents/codex/agent.py
+++ b/modules/agents/codex/agent.py
@@ -849,6 +849,12 @@ class CodexAgent(BaseAgent):
         interrupted_request = self._event_handler.clear_pending(active_turn)
         if interrupted_request:
             await self._remove_ack_reaction(interrupted_request)
+            # The app-server may be replaced before its interrupted completion
+            # notification arrives. Settle the old request now; release is
+            # token-guarded, so it cannot close the replacement turn.
+            release = getattr(self._event_handler, "_release_stream_turn", None)
+            if callable(release):
+                release(interrupted_request.context)
 
     # ------------------------------------------------------------------
     # Thread management

--- a/modules/agents/codex/event_handler.py
+++ b/modules/agents/codex/event_handler.py
@@ -157,6 +157,10 @@ class CodexEventHandler:
             if not error_msg:
                 error_obj = turn_obj.get("error", {}) if isinstance(turn_obj, dict) else {}
                 error_msg = self._extract_error_message(error_obj)
+            await self._record_model_hub_native_failure(
+                tracked_request.context,
+                error_msg or "Unknown error",
+            )
 
             if should_emit_terminal_error and not already_notified:
                 message = f"❌ Codex turn failed: {error_msg}"
@@ -311,6 +315,11 @@ class CodexEventHandler:
                     parse_mode="markdown",
                 )
 
+    async def _record_model_hub_native_failure(self, context: Any, diagnostic: str) -> None:
+        recorder = getattr(self._agent, "_record_model_hub_native_failure", None)
+        if recorder is not None:
+            await recorder(context, diagnostic)
+
     async def _on_error(self, params: dict[str, Any], request: AgentRequest) -> None:
         error = params.get("error", {})
         message = self._extract_error_message(error)
@@ -320,6 +329,8 @@ class CodexEventHandler:
         if will_retry:
             logger.info("Suppressing transient Codex error for turn %s: %s", turn_id or "<unknown>", message)
             return
+
+        await self._record_model_hub_native_failure(request.context, message)
 
         if turn_id:
             turn_state = self._agent._turn_registry.get_turn(turn_id)

--- a/modules/agents/codex/transport.py
+++ b/modules/agents/codex/transport.py
@@ -69,8 +69,8 @@ class CodexTransport:
 
         cmd = (
             [self._binary, "--dangerously-bypass-approvals-and-sandbox"]
-            + self._runtime_args
             + ["app-server"]
+            + self._runtime_args
             + self._extra_args
         )
         logger.info("Launching Codex app-server: %s (cwd=%s)", " ".join(cmd), self._cwd)

--- a/modules/agents/codex/transport.py
+++ b/modules/agents/codex/transport.py
@@ -30,10 +30,16 @@ class CodexTransport:
         binary: str,
         cwd: str,
         extra_args: list[str] | None = None,
+        runtime_args: list[str] | None = None,
+        runtime_env: dict[str, str] | None = None,
+        runtime_fingerprint: str = "direct",
     ) -> None:
         self._binary = binary
         self._cwd = cwd
         self._extra_args = extra_args or []
+        self._runtime_args = runtime_args or []
+        self._runtime_env = runtime_env
+        self.runtime_fingerprint = runtime_fingerprint
         self._process: Optional[Process] = None
         self._request_id: int = 0
         self._pending: dict[int | str, asyncio.Future[dict[str, Any]]] = {}
@@ -61,21 +67,28 @@ class CodexTransport:
             logger.warning("CodexTransport.start() called but process is already running")
             return
 
-        cmd = [self._binary, "--dangerously-bypass-approvals-and-sandbox", "app-server"] + self._extra_args
+        cmd = (
+            [self._binary, "--dangerously-bypass-approvals-and-sandbox"]
+            + self._runtime_args
+            + ["app-server"]
+            + self._extra_args
+        )
         logger.info("Launching Codex app-server: %s (cwd=%s)", " ".join(cmd), self._cwd)
 
         if not os.path.exists(self._cwd):
             os.makedirs(self._cwd, exist_ok=True)
 
-        self._process = await asyncio.create_subprocess_exec(
-            *cmd,
-            stdin=asyncio.subprocess.PIPE,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-            cwd=self._cwd,
-            limit=STREAM_BUFFER_LIMIT,
+        subprocess_kwargs: dict[str, Any] = {
+            "stdin": asyncio.subprocess.PIPE,
+            "stdout": asyncio.subprocess.PIPE,
+            "stderr": asyncio.subprocess.PIPE,
+            "cwd": self._cwd,
+            "limit": STREAM_BUFFER_LIMIT,
             **isolated_subprocess_kwargs(),
-        )
+        }
+        if self._runtime_env is not None:
+            subprocess_kwargs["env"] = self._runtime_env
+        self._process = await asyncio.create_subprocess_exec(*cmd, **subprocess_kwargs)
         identity = process_identity(self._process.pid)
         logger.info(
             "Codex app-server started (pid=%s pgid=%s sid=%s service_pgid=%s)",

--- a/modules/agents/model_hub.py
+++ b/modules/agents/model_hub.py
@@ -8,7 +8,7 @@ import json
 import os
 import re
 import tempfile
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable, Literal, Mapping, Optional, cast
 
@@ -72,6 +72,8 @@ class OpenCodeOverlay:
     content_hash: str
     content: bytes
     checked_identifiers: tuple[str, ...]
+    available_identifiers: tuple[str, ...]
+    launches: tuple[ModelHubLaunch, ...] = field(repr=False)
 
 
 def bind_launch(context: Any, launch: ModelHubLaunch) -> None:
@@ -153,6 +155,18 @@ async def resolve_model_hub_launch(
         target_model=requested_model,
         runtime_model=requested_model,
     )
+
+
+async def resolve_opencode_overlay_launch(
+    controller: Any,
+    requested_model: str,
+    overlay: OpenCodeOverlay | None,
+) -> ModelHubLaunch:
+    router = getattr(controller, "model_hub_runtime", None)
+    resolver = getattr(router, "resolve_opencode_overlay_launch", None)
+    if overlay is not None and callable(resolver):
+        return await resolver(overlay, requested_model)
+    return await resolve_model_hub_launch(controller, "opencode", requested_model)
 
 
 def build_claude_hub_env(
@@ -489,6 +503,24 @@ class ModelHubRuntimeRouter:
         self._emit_channel_switch(launch)
         return launch
 
+    async def resolve_opencode_overlay_launch(
+        self,
+        overlay: OpenCodeOverlay,
+        requested_model: str,
+    ) -> ModelHubLaunch:
+        """Activate the exact source snapshot used to build an overlay."""
+
+        launch = next(
+            (item for item in overlay.launches if item.requested_model == requested_model),
+            None,
+        )
+        if launch is None:
+            raise ModelHubError("mapping_target_unavailable", status=409)
+        config = self.service.store.load()
+        self._emit_source_switch(launch, config)
+        self._emit_channel_switch(launch)
+        return launch
+
     async def record_native_failure(self, context: Any, diagnostic: str) -> bool:
         """Record a terminal source failure for the next per-turn resolution.
 
@@ -541,9 +573,11 @@ class ModelHubRuntimeRouter:
 
         gateway_base_url, gateway_token = await self._gateway_credentials()
         providers: dict[str, dict[str, Any]] = {}
+        projected_identifiers: list[str] = []
         available_identifiers: list[str] = []
+        launches: list[ModelHubLaunch] = []
         sources_by_id = {source.id: source for source in config.sources}
-        for identifier in sorted(checked):
+        for identifier in dict.fromkeys(checked):
             try:
                 provider_id, model_id = parse_opencode_model_id(identifier)
             except ValueError:
@@ -553,7 +587,11 @@ class ModelHubRuntimeRouter:
                 model_id,
                 provider=provider_id,
             )
-            source = next((candidate for candidate in candidates if candidate.supply_channel == "hub"), None)
+            available_source = next(
+                (candidate for candidate in candidates if candidate.supply_channel == "hub"),
+                None,
+            )
+            source = available_source
             if source is None:
                 # Keep a cooling/error route's public identifier stable in the
                 # overlay. Per-turn resolution still rejects that requested
@@ -590,9 +628,23 @@ class ModelHubRuntimeRouter:
                 "id": f"{prefix}/{model_id}",
                 "name": model.display_name or model_id,
             }
-            available_identifiers.append(identifier)
+            projected_identifiers.append(identifier)
+            if available_source is not None:
+                available_identifiers.append(identifier)
+                launches.append(
+                    ModelHubLaunch(
+                        backend="opencode",
+                        channel="hub",
+                        requested_model=identifier,
+                        target_model=model_id,
+                        runtime_model=f"{prefix}/{model_id}",
+                        source_id=source.id,
+                        gateway_base_url=gateway_base_url,
+                        gateway_token=gateway_token,
+                    )
+                )
 
-        if not available_identifiers:
+        if not projected_identifiers:
             raise ModelHubError("mapping_target_unavailable", status=409)
 
         content = (
@@ -610,7 +662,9 @@ class ModelHubRuntimeRouter:
             path=self.overlay_path,
             content_hash=content_hash,
             content=content,
-            checked_identifiers=tuple(available_identifiers),
+            checked_identifiers=tuple(projected_identifiers),
+            available_identifiers=tuple(available_identifiers),
+            launches=tuple(launches),
         )
 
     def _secure_write_overlay(self, content: bytes) -> None:
@@ -643,7 +697,9 @@ def opencode_model_for_overlay(model: str | None, overlay: OpenCodeOverlay | Non
         return model
     candidate = str(model or "").strip()
     if not candidate:
-        return overlay.checked_identifiers[0]
+        if not overlay.available_identifiers:
+            raise ModelHubError("mapping_target_unavailable", status=409)
+        return overlay.available_identifiers[0]
     if candidate in overlay.checked_identifiers:
         return candidate
     matches = [identifier for identifier in overlay.checked_identifiers if identifier.endswith(f"/{candidate}")]

--- a/modules/agents/model_hub.py
+++ b/modules/agents/model_hub.py
@@ -1,0 +1,445 @@
+"""Per-turn Model Hub selection and backend runtime injection."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import os
+import re
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Literal, Optional, cast
+
+from config import paths
+from config.v2_config import ModelHubConfig
+from core.handlers.model_hub.classification import ResolutionDecision
+from core.handlers.model_hub.events import EventAgent, EventReason
+from core.handlers.model_hub.identifiers import parse_opencode_model_id
+from core.handlers.model_hub.service import ModelHubError, ModelHubService, create_default_service
+
+
+BackendName = Literal["claude", "codex", "opencode"]
+LaunchChannel = Literal["direct", "native_cli", "hub"]
+
+_CONTEXT_LAUNCH_ATTR = "_vibe_model_hub_launch"
+_CONTEXT_FAILURE_RECORDED_ATTR = "_vibe_model_hub_failure_recorded"
+_NATIVE_QUOTA_RE = re.compile(
+    r"(?:quota|usage|credit|billing).{0,32}(?:exhaust|exceed|limit|deplet|insufficient)|"
+    r"(?:exhaust|exceed|limit|deplet|insufficient).{0,32}(?:quota|usage|credit|billing)|"
+    r"(?:hit|reached).{0,24}(?:usage )?limit|limit.{0,24}reset",
+    re.IGNORECASE,
+)
+_NATIVE_RATE_RE = re.compile(r"(?:\b429\b|rate[_ -]?limit|too many requests)", re.IGNORECASE)
+
+
+@dataclass(frozen=True)
+class ModelHubLaunch:
+    backend: BackendName
+    channel: LaunchChannel
+    requested_model: str
+    target_model: str
+    runtime_model: str
+    source_id: Optional[str] = None
+    gateway_base_url: Optional[str] = None
+    gateway_token: Optional[str] = None
+
+    @property
+    def fingerprint(self) -> str:
+        if self.channel == "direct":
+            return "direct"
+        if self.channel == "native_cli":
+            return f"native_cli:{self.source_id or ''}"
+        token_hash = hashlib.sha256((self.gateway_token or "").encode()).hexdigest()
+        return ":".join(
+            (
+                self.channel,
+                self.gateway_base_url or "",
+                token_hash,
+            )
+        )
+
+
+@dataclass(frozen=True)
+class OpenCodeOverlay:
+    path: Path
+    content_hash: str
+    content: bytes
+    checked_identifiers: tuple[str, ...]
+
+
+def bind_launch(context: Any, launch: ModelHubLaunch) -> None:
+    try:
+        setattr(context, _CONTEXT_LAUNCH_ATTR, launch)
+        setattr(context, _CONTEXT_FAILURE_RECORDED_ATTR, False)
+    except (AttributeError, TypeError):
+        return
+
+
+def launch_for_context(context: Any) -> ModelHubLaunch | None:
+    value = getattr(context, _CONTEXT_LAUNCH_ATTR, None)
+    return value if isinstance(value, ModelHubLaunch) else None
+
+
+async def resolve_model_hub_launch(
+    controller: Any,
+    backend: BackendName,
+    requested_model: str,
+) -> ModelHubLaunch:
+    router = getattr(controller, "model_hub_runtime", None)
+    resolver = getattr(router, "resolve", None)
+    if callable(resolver):
+        return await resolver(backend, requested_model)
+    return ModelHubLaunch(
+        backend=backend,
+        channel="direct",
+        requested_model=requested_model,
+        target_model=requested_model,
+        runtime_model=requested_model,
+    )
+
+
+def build_claude_hub_env(
+    base_env: dict[str, str],
+    launch: ModelHubLaunch,
+) -> dict[str, str]:
+    """Return a hub-only Claude environment without inherited auth routing."""
+
+    if launch.channel != "hub" or not launch.gateway_base_url or not launch.gateway_token:
+        return dict(base_env)
+    result = dict(base_env)
+    for key in (
+        "ANTHROPIC_API_KEY",
+        "ANTHROPIC_AUTH_TOKEN",
+        "ANTHROPIC_BASE_URL",
+        "CLAUDE_CODE_OAUTH_TOKEN",
+    ):
+        result.pop(key, None)
+    result["ANTHROPIC_BASE_URL"] = launch.gateway_base_url
+    result["ANTHROPIC_AUTH_TOKEN"] = launch.gateway_token
+    return result
+
+
+def build_codex_hub_launch(
+    base_args: list[str],
+    base_env: dict[str, str],
+    launch: ModelHubLaunch,
+) -> tuple[list[str], dict[str, str] | None]:
+    """Return app-server global overrides and environment for a Hub turn."""
+
+    if launch.channel != "hub" or not launch.gateway_base_url or not launch.gateway_token:
+        return list(base_args), None
+    env = dict(base_env)
+    for key in ("OPENAI_API_KEY", "OPENAI_BASE_URL", "OPENAI_API_BASE", "CODEX_API_KEY"):
+        env.pop(key, None)
+    env["AVIBE_MODEL_HUB_TOKEN"] = launch.gateway_token
+    provider = "avibe_model_hub"
+    gateway_v1 = f"{launch.gateway_base_url.rstrip('/')}/v1"
+    overrides = [
+        "-c",
+        f'model_provider="{provider}"',
+        "-c",
+        f'model_providers.{provider}.name="Avibe Model Hub"',
+        "-c",
+        f'model_providers.{provider}.base_url="{gateway_v1}"',
+        "-c",
+        f'model_providers.{provider}.env_key="AVIBE_MODEL_HUB_TOKEN"',
+        "-c",
+        f'model_providers.{provider}.wire_api="responses"',
+        "-c",
+        f"model_providers.{provider}.requires_openai_auth=false",
+    ]
+    return overrides + list(base_args), env
+
+
+def _provider_package(protocol: str) -> str:
+    if protocol == "anthropic":
+        return "@ai-sdk/anthropic"
+    if protocol == "openai_responses":
+        return "@ai-sdk/openai"
+    return "@ai-sdk/openai-compatible"
+
+
+def _provider_base_url(gateway_base_url: str, protocol: str) -> str:
+    # All supported OpenCode SDK adapters expect their versioned API root.
+    return f"{gateway_base_url.rstrip('/')}/v1"
+
+
+def overlay_identifier_bytes(content: bytes) -> bytes:
+    """Canonical visible identifier projection used by MH-OVL-001."""
+
+    payload = json.loads(content)
+    identifiers = [
+        f"{provider_id}/{model_id}"
+        for provider_id, provider in sorted(payload.get("provider", {}).items())
+        for model_id in sorted(provider.get("models", {}))
+    ]
+    return json.dumps(identifiers, ensure_ascii=True, separators=(",", ":")).encode()
+
+
+class ModelHubRuntimeRouter:
+    """Select a supply channel once per turn and build ephemeral injections."""
+
+    def __init__(
+        self,
+        *,
+        service: ModelHubService | None = None,
+        overlay_path: Path | None = None,
+    ) -> None:
+        if service is None:
+            from vibe.model_hub_runtime import get_model_hub_engine_adapter
+
+            service = create_default_service(adapter=get_model_hub_engine_adapter())
+        self.service = service
+        self.overlay_path = overlay_path or paths.get_runtime_dir() / "model-hub" / "opencode-overlay.json"
+        self._last_launch: dict[BackendName, ModelHubLaunch] = {}
+        self._pending_switch_reason: dict[BackendName, EventReason] = {}
+
+    @staticmethod
+    def _target_model(config: ModelHubConfig, backend: BackendName, requested_model: str) -> str:
+        agent = config.agents[backend]
+        return next(
+            (
+                mapping.target_model_id
+                for mapping in agent.mappings
+                if mapping.enabled and mapping.builtin_id == requested_model
+            ),
+            requested_model,
+        )
+
+    async def _source_prefix(self, source_id: str) -> str:
+        adapter = self.service.adapter
+        getter = getattr(adapter, "source_prefix", None)
+        if callable(getter):
+            value = getter(source_id)
+            if asyncio.iscoroutine(value):
+                value = await value
+            if isinstance(value, str) and value:
+                return value
+        state_store = getattr(adapter, "state_store", None)
+        state_getter = getattr(state_store, "get_source", None)
+        if callable(state_getter):
+            record = await asyncio.to_thread(state_getter, source_id)
+            prefix = getattr(record, "prefix", None)
+            if isinstance(prefix, str) and prefix:
+                return prefix
+        raise ModelHubError("engine_down", status=503)
+
+    async def _gateway_credentials(self) -> tuple[str, str]:
+        await self.service._ensure_engine_synced()
+        status = await self.service._engine_call(self.service.adapter.start())
+        if status.listen_port is None:
+            raise ModelHubError("engine_down", status=503)
+        token = await self.service._engine_call(self.service.adapter.gateway_token())
+        return f"http://{status.listen_host}:{status.listen_port}", token
+
+    def _emit_channel_switch(self, current: ModelHubLaunch) -> None:
+        previous = self._last_launch.get(current.backend)
+        self._last_launch[current.backend] = current
+        if previous is None or previous.channel == current.channel:
+            return
+        if {previous.channel, current.channel} != {"native_cli", "hub"}:
+            return
+        reason = self._pending_switch_reason.pop(current.backend, None)
+        if reason is None:
+            reason = "recovery" if current.channel == "native_cli" else "manual"
+        self.service._record_event(
+            agent=cast(EventAgent, current.backend),
+            kind="channel_switch",
+            model_id=current.target_model,
+            reason=reason,
+            from_source=previous.source_id,
+            to_source=current.source_id,
+            now=self.service.now(),
+        )
+
+    async def resolve(self, backend: BackendName, requested_model: str) -> ModelHubLaunch:
+        requested_model = str(requested_model or "").strip()
+        config = self.service.store.load()
+        agent = config.agents[backend]
+        if agent.mode == "direct":
+            launch = ModelHubLaunch(
+                backend=backend,
+                channel="direct",
+                requested_model=requested_model,
+                target_model=requested_model,
+                runtime_model=requested_model,
+            )
+            self._emit_channel_switch(launch)
+            return launch
+        if not requested_model:
+            raise ModelHubError("mapping_target_unavailable", status=409)
+
+        target_model = self._target_model(config, backend, requested_model)
+        if target_model != requested_model:
+            self.service._record_event(
+                agent=cast(EventAgent, backend),
+                kind="mapping_applied",
+                model_id=target_model,
+                reason="mapping",
+                from_label=requested_model,
+                now=self.service.now(),
+            )
+        provider: str | None = None
+        if backend == "opencode":
+            try:
+                provider, target_model = parse_opencode_model_id(target_model)
+            except ValueError:
+                raise ModelHubError("mapping_target_unavailable", status=409) from None
+            if agent.menu is None or f"{provider}/{target_model}" not in agent.menu.checked:
+                raise ModelHubError("mapping_target_unavailable", status=409)
+        candidates = await self.service._resolution_candidates(backend, target_model, provider=provider)
+        if not candidates:
+            raise ModelHubError("mapping_target_unavailable", status=409)
+        source = candidates[0]
+        if source.supply_channel == "native_cli":
+            launch = ModelHubLaunch(
+                backend=backend,
+                channel="native_cli",
+                requested_model=requested_model,
+                target_model=target_model,
+                runtime_model=target_model,
+                source_id=source.id,
+            )
+        else:
+            gateway_base_url, gateway_token = await self._gateway_credentials()
+            prefix = await self._source_prefix(source.id)
+            launch = ModelHubLaunch(
+                backend=backend,
+                channel="hub",
+                requested_model=requested_model,
+                target_model=target_model,
+                runtime_model=f"{prefix}/{target_model}",
+                source_id=source.id,
+                gateway_base_url=gateway_base_url,
+                gateway_token=gateway_token,
+            )
+        self._emit_channel_switch(launch)
+        return launch
+
+    async def record_native_failure(self, context: Any, diagnostic: str) -> bool:
+        launch = launch_for_context(context)
+        if launch is None or launch.channel != "native_cli" or not launch.source_id:
+            return False
+        if getattr(context, _CONTEXT_FAILURE_RECORDED_ATTR, False):
+            return False
+        if _NATIVE_QUOTA_RE.search(diagnostic):
+            decision = ResolutionDecision("fallback", reason="quota_exhausted", cooldown_seconds=300)
+        elif _NATIVE_RATE_RE.search(diagnostic):
+            decision = ResolutionDecision("fallback", reason="rate_limited", cooldown_seconds=60)
+        else:
+            return False
+        config = self.service.store.load()
+        source = next((item for item in config.sources if item.id == launch.source_id), None)
+        if source is None:
+            return False
+        await self.service._cooldown(
+            source,
+            decision,
+            agent=cast(EventAgent, launch.backend),
+            model_id=launch.target_model,
+        )
+        setattr(context, _CONTEXT_FAILURE_RECORDED_ATTR, True)
+        self._pending_switch_reason[launch.backend] = cast(EventReason, decision.reason)
+        return True
+
+    async def prepare_opencode_overlay(self) -> OpenCodeOverlay | None:
+        config = self.service.store.load()
+        agent = config.agents["opencode"]
+        if agent.mode == "direct":
+            return None
+        checked = tuple(agent.menu.checked if agent.menu else ())
+        if not checked:
+            raise ModelHubError("mapping_target_unavailable", status=409)
+
+        gateway_base_url, gateway_token = await self._gateway_credentials()
+        providers: dict[str, dict[str, Any]] = {}
+        for identifier in sorted(checked):
+            try:
+                provider_id, model_id = parse_opencode_model_id(identifier)
+            except ValueError:
+                raise ModelHubError("mapping_target_unavailable", status=409) from None
+            candidates = await self.service._resolution_candidates(
+                "opencode",
+                model_id,
+                provider=provider_id,
+            )
+            source = next((candidate for candidate in candidates if candidate.supply_channel == "hub"), None)
+            if source is None:
+                raise ModelHubError("mapping_target_unavailable", status=409)
+            prefix = await self._source_prefix(source.id)
+            package = _provider_package(source.protocol)
+            base_url = _provider_base_url(gateway_base_url, source.protocol)
+            provider = providers.setdefault(
+                provider_id,
+                {
+                    "name": provider_id,
+                    "npm": package,
+                    "options": {"apiKey": gateway_token, "baseURL": base_url},
+                    "models": {},
+                },
+            )
+            if provider["npm"] != package or provider["options"]["baseURL"] != base_url:
+                raise ModelHubError("mapping_target_unavailable", status=409)
+            model = next(item for item in source.models if item.id == model_id)
+            provider["models"][model_id] = {
+                "id": f"{prefix}/{model_id}",
+                "name": model.display_name or model_id,
+            }
+
+        content = (
+            json.dumps(
+                {"$schema": "https://opencode.ai/config.json", "provider": providers},
+                ensure_ascii=True,
+                sort_keys=True,
+                separators=(",", ":"),
+            )
+            + "\n"
+        ).encode()
+        content_hash = hashlib.sha256(content).hexdigest()
+        self._secure_write_overlay(content)
+        return OpenCodeOverlay(
+            path=self.overlay_path,
+            content_hash=content_hash,
+            content=content,
+            checked_identifiers=checked,
+        )
+
+    def _secure_write_overlay(self, content: bytes) -> None:
+        self.overlay_path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+        try:
+            if self.overlay_path.read_bytes() == content:
+                return
+        except FileNotFoundError:
+            pass
+        descriptor, temporary_name = tempfile.mkstemp(
+            prefix=f".{self.overlay_path.name}.",
+            dir=self.overlay_path.parent,
+        )
+        try:
+            with os.fdopen(descriptor, "wb") as stream:
+                stream.write(content)
+                stream.flush()
+                os.fsync(stream.fileno())
+            os.chmod(temporary_name, 0o600)
+            os.replace(temporary_name, self.overlay_path)
+        finally:
+            try:
+                os.unlink(temporary_name)
+            except FileNotFoundError:
+                pass
+
+
+def opencode_model_for_overlay(model: str | None, overlay: OpenCodeOverlay | None) -> str | None:
+    if overlay is None:
+        return model
+    candidate = str(model or "").strip()
+    if not candidate:
+        return overlay.checked_identifiers[0]
+    if candidate in overlay.checked_identifiers:
+        return candidate
+    matches = [identifier for identifier in overlay.checked_identifiers if identifier.endswith(f"/{candidate}")]
+    if len(matches) == 1:
+        return matches[0]
+    raise ModelHubError("mapping_target_unavailable", status=409)

--- a/modules/agents/model_hub.py
+++ b/modules/agents/model_hub.py
@@ -113,14 +113,11 @@ def build_claude_hub_env(
 
     if launch.channel != "hub" or not launch.gateway_base_url or not launch.gateway_token:
         return dict(base_env)
-    result = dict(base_env)
-    for key in (
-        "ANTHROPIC_API_KEY",
-        "ANTHROPIC_AUTH_TOKEN",
-        "ANTHROPIC_BASE_URL",
-        "CLAUDE_CODE_OAUTH_TOKEN",
-    ):
-        result.pop(key, None)
+    result = {
+        key: value
+        for key, value in base_env.items()
+        if not key.startswith("ANTHROPIC_") and key != "CLAUDE_CODE_OAUTH_TOKEN"
+    }
     result["ANTHROPIC_BASE_URL"] = launch.gateway_base_url
     result["ANTHROPIC_AUTH_TOKEN"] = launch.gateway_token
     return result
@@ -152,6 +149,8 @@ def build_codex_hub_launch(
         f'model_providers.{provider}.env_key="AVIBE_MODEL_HUB_TOKEN"',
         "-c",
         f'model_providers.{provider}.wire_api="responses"',
+        "-c",
+        f"model_providers.{provider}.supports_websockets=false",
         "-c",
         f"model_providers.{provider}.requires_openai_auth=false",
     ]
@@ -198,9 +197,32 @@ class ModelHubRuntimeRouter:
             service = create_default_service(adapter=get_model_hub_engine_adapter())
         self.service = service
         self.overlay_path = overlay_path or paths.get_runtime_dir() / "model-hub" / "opencode-overlay.json"
-        self._last_launch: dict[BackendName, ModelHubLaunch] = {}
-        self._pending_switch_reason: dict[BackendName, EventReason] = {}
-        self._pending_source_failure: dict[BackendName, tuple[str, EventReason]] = {}
+        self._last_launch: dict[tuple[BackendName, str], ModelHubLaunch] = {}
+        self._pending_switch_reason: dict[tuple[BackendName, str], EventReason] = {}
+        self._pending_source_failure: dict[tuple[BackendName, str], tuple[str, EventReason]] = {}
+
+    @staticmethod
+    def _route_key(launch: ModelHubLaunch) -> tuple[BackendName, str]:
+        return launch.backend, launch.target_model
+
+    @staticmethod
+    def _is_bootstrap_unconfigured(config: ModelHubConfig, backend: BackendName) -> bool:
+        if not config.sources:
+            return True
+        if backend != "opencode":
+            return False
+        menu = config.agents[backend].menu
+        return menu is None or not menu.checked
+
+    @staticmethod
+    def _direct_launch(backend: BackendName, requested_model: str) -> ModelHubLaunch:
+        return ModelHubLaunch(
+            backend=backend,
+            channel="direct",
+            requested_model=requested_model,
+            target_model=requested_model,
+            runtime_model=requested_model,
+        )
 
     @staticmethod
     def _target_model(config: ModelHubConfig, backend: BackendName, requested_model: str) -> str:
@@ -241,13 +263,14 @@ class ModelHubRuntimeRouter:
         return f"http://{status.listen_host}:{status.listen_port}", token
 
     def _emit_channel_switch(self, current: ModelHubLaunch) -> None:
-        previous = self._last_launch.get(current.backend)
-        self._last_launch[current.backend] = current
+        route_key = self._route_key(current)
+        previous = self._last_launch.get(route_key)
+        self._last_launch[route_key] = current
         if previous is None or previous.channel == current.channel:
             return
         if {previous.channel, current.channel} != {"native_cli", "hub"}:
             return
-        reason = self._pending_switch_reason.pop(current.backend, None)
+        reason = self._pending_switch_reason.pop(route_key, None)
         if reason is None:
             reason = "recovery" if current.channel == "native_cli" else "manual"
         self.service._record_event(
@@ -261,17 +284,18 @@ class ModelHubRuntimeRouter:
         )
 
     def _emit_source_switch(self, current: ModelHubLaunch, config: ModelHubConfig) -> None:
-        pending = self._pending_source_failure.get(current.backend)
+        route_key = self._route_key(current)
+        pending = self._pending_source_failure.get(route_key)
         if pending is None or not current.source_id:
             return
         failed_source_id, reason = pending
         if failed_source_id == current.source_id:
-            self._pending_source_failure.pop(current.backend, None)
+            self._pending_source_failure.pop(route_key, None)
             return
         failed_source = next((source for source in config.sources if source.id == failed_source_id), None)
         current_source = next((source for source in config.sources if source.id == current.source_id), None)
         if failed_source is None or current_source is None:
-            self._pending_source_failure.pop(current.backend, None)
+            self._pending_source_failure.pop(route_key, None)
             return
         self.service._emit_switch(
             agent=cast(EventAgent, current.backend),
@@ -280,22 +304,21 @@ class ModelHubRuntimeRouter:
             failed_reason=reason,
             source=current_source,
         )
-        self._pending_source_failure.pop(current.backend, None)
+        self._pending_source_failure.pop(route_key, None)
 
     async def resolve(self, backend: BackendName, requested_model: str) -> ModelHubLaunch:
         requested_model = str(requested_model or "").strip()
         config = self.service.store.load()
         agent = config.agents[backend]
         if agent.mode == "direct":
-            launch = ModelHubLaunch(
-                backend=backend,
-                channel="direct",
-                requested_model=requested_model,
-                target_model=requested_model,
-                runtime_model=requested_model,
-            )
+            launch = self._direct_launch(backend, requested_model)
             self._emit_channel_switch(launch)
             return launch
+        # Fresh installs seed Hub mode before setup/migration has supplied any
+        # usable source or OpenCode menu. Until that bootstrap state is complete,
+        # preserve the native launch path; once configured, Hub remains fail-closed.
+        if self._is_bootstrap_unconfigured(config, backend):
+            return self._direct_launch(backend, requested_model)
         if not requested_model:
             raise ModelHubError("mapping_target_unavailable", status=409)
 
@@ -387,15 +410,18 @@ class ModelHubRuntimeRouter:
         )
         setattr(context, _CONTEXT_FAILURE_RECORDED_ATTR, True)
         reason = cast(EventReason, decision.reason)
-        self._pending_source_failure[launch.backend] = (launch.source_id, reason)
+        route_key = self._route_key(launch)
+        self._pending_source_failure[route_key] = (launch.source_id, reason)
         if launch.channel == "native_cli":
-            self._pending_switch_reason[launch.backend] = reason
+            self._pending_switch_reason[route_key] = reason
         return True
 
     async def prepare_opencode_overlay(self) -> OpenCodeOverlay | None:
         config = self.service.store.load()
         agent = config.agents["opencode"]
         if agent.mode == "direct":
+            return None
+        if self._is_bootstrap_unconfigured(config, "opencode"):
             return None
         checked = tuple(agent.menu.checked if agent.menu else ())
         if not checked:

--- a/modules/agents/model_hub.py
+++ b/modules/agents/model_hub.py
@@ -10,7 +10,7 @@ import re
 import tempfile
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Literal, Optional, cast
+from typing import Any, Callable, Literal, Mapping, Optional, cast
 
 from config import paths
 from config.v2_config import ModelHubConfig
@@ -85,6 +85,56 @@ def bind_launch(context: Any, launch: ModelHubLaunch) -> None:
 def launch_for_context(context: Any) -> ModelHubLaunch | None:
     value = getattr(context, _CONTEXT_LAUNCH_ATTR, None)
     return value if isinstance(value, ModelHubLaunch) else None
+
+
+def persisted_launch_identity(launch: ModelHubLaunch | None) -> dict[str, str] | None:
+    """Return the non-secret source identity needed to restore failure routing."""
+
+    if launch is None or launch.channel == "direct" or not launch.source_id:
+        return None
+    return {
+        "backend": launch.backend,
+        "channel": launch.channel,
+        "source_id": launch.source_id,
+        "target_model": launch.target_model,
+    }
+
+
+def bind_persisted_launch(context: Any, payload: object) -> ModelHubLaunch | None:
+    if not isinstance(payload, Mapping):
+        return None
+    backend = payload.get("backend")
+    channel = payload.get("channel")
+    source_id = payload.get("source_id")
+    target_model = payload.get("target_model")
+    if (
+        backend not in {"claude", "codex", "opencode"}
+        or channel not in {"native_cli", "hub"}
+        or not isinstance(source_id, str)
+        or not source_id
+        or not isinstance(target_model, str)
+        or not target_model
+    ):
+        return None
+    launch = ModelHubLaunch(
+        backend=cast(BackendName, backend),
+        channel=cast(LaunchChannel, channel),
+        requested_model=target_model,
+        target_model=target_model,
+        runtime_model=target_model,
+        source_id=source_id,
+    )
+    bind_launch(context, launch)
+    return launch
+
+
+def claude_setting_sources_for_launch(launch: ModelHubLaunch | None) -> list[str]:
+    if launch is not None and launch.channel == "hub":
+        # ~/.claude/settings.json env values override subprocess env. Keep
+        # project/local CLAUDE.md loading, but mask the user settings source so
+        # persisted native auth cannot bypass the ephemeral gateway injection.
+        return ["project", "local"]
+    return ["user", "project", "local"]
 
 
 async def resolve_model_hub_launch(
@@ -190,6 +240,7 @@ class ModelHubRuntimeRouter:
         *,
         service: ModelHubService | None = None,
         overlay_path: Path | None = None,
+        native_cli_ready: Callable[[BackendName], bool] | None = None,
     ) -> None:
         if service is None:
             from vibe.model_hub_runtime import get_model_hub_engine_adapter
@@ -197,9 +248,44 @@ class ModelHubRuntimeRouter:
             service = create_default_service(adapter=get_model_hub_engine_adapter())
         self.service = service
         self.overlay_path = overlay_path or paths.get_runtime_dir() / "model-hub" / "opencode-overlay.json"
+        self.native_cli_ready = native_cli_ready or self._default_native_cli_ready
         self._last_launch: dict[tuple[BackendName, str], ModelHubLaunch] = {}
         self._pending_switch_reason: dict[tuple[BackendName, str], EventReason] = {}
         self._pending_source_failure: dict[tuple[BackendName, str], tuple[str, EventReason]] = {}
+
+    @staticmethod
+    def _default_native_cli_ready(backend: BackendName) -> bool:
+        if backend == "claude":
+            from vibe.claude_config import read_claude_settings_env
+
+            conflicts = {"ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN", "ANTHROPIC_BASE_URL"}
+            settings_env = read_claude_settings_env()
+            return not any(key in settings_env or os.environ.get(key) for key in conflicts)
+        if backend != "codex":
+            return False
+
+        from vibe.codex_config import get_codex_config_paths, read_codex_auth_state
+
+        conflicts = {"OPENAI_API_KEY", "OPENAI_BASE_URL", "OPENAI_API_BASE", "CODEX_API_KEY"}
+        if any(os.environ.get(key) for key in conflicts):
+            return False
+        state = read_codex_auth_state()
+        if state.get("has_api_key") or not state.get("has_chatgpt_tokens") or state.get("base_url"):
+            return False
+        config_path, _ = get_codex_config_paths()
+        try:
+            if config_path.exists():
+                try:
+                    import tomllib  # type: ignore[attr-defined]
+                except ImportError:  # pragma: no cover - Python < 3.11
+                    import tomli as tomllib  # type: ignore[no-redef]
+                config = tomllib.loads(config_path.read_text(encoding="utf-8"))
+            else:
+                config = {}
+        except (OSError, ValueError):
+            return False
+        provider = config.get("model_provider") if isinstance(config, dict) else None
+        return provider is None or provider == "openai"
 
     @staticmethod
     def _route_key(launch: ModelHubLaunch) -> tuple[BackendName, str]:
@@ -361,7 +447,16 @@ class ModelHubRuntimeRouter:
         candidates = await self.service._resolution_candidates(backend, target_model, provider=provider)
         if not candidates:
             raise ModelHubError("mapping_target_unavailable", status=409)
-        source = candidates[0]
+        source = next(
+            (
+                candidate
+                for candidate in candidates
+                if candidate.supply_channel != "native_cli" or self.native_cli_ready(backend)
+            ),
+            None,
+        )
+        if source is None:
+            raise ModelHubError("mapping_target_unavailable", status=409)
         if source.supply_channel == "native_cli":
             if self.service.revocations.list():
                 try:

--- a/modules/agents/model_hub.py
+++ b/modules/agents/model_hub.py
@@ -16,7 +16,7 @@ from config import paths
 from config.v2_config import ModelHubConfig
 from core.handlers.model_hub.classification import ResolutionDecision
 from core.handlers.model_hub.events import EventAgent, EventReason
-from core.handlers.model_hub.identifiers import parse_opencode_model_id
+from core.handlers.model_hub.identifiers import opencode_provider_id, parse_opencode_model_id
 from core.handlers.model_hub.service import ModelHubError, ModelHubService, create_default_service
 
 
@@ -206,13 +206,31 @@ class ModelHubRuntimeRouter:
         return launch.backend, launch.target_model
 
     @staticmethod
-    def _is_bootstrap_unconfigured(config: ModelHubConfig, backend: BackendName) -> bool:
-        if not config.sources:
-            return True
-        if backend != "opencode":
+    def _is_bootstrap_unconfigured(
+        config: ModelHubConfig,
+        backend: BackendName,
+        requested_model: str = "",
+    ) -> bool:
+        agent = config.agents[backend]
+        if backend == "opencode":
+            return agent.menu is None or not agent.menu.checked
+
+        explicit_mapping = any(
+            mapping.enabled and mapping.builtin_id == requested_model
+            for mapping in agent.mappings
+        )
+        if explicit_mapping:
             return False
-        menu = config.agents[backend].menu
-        return menu is None or not menu.checked
+        target_model = ModelHubRuntimeRouter._target_model(config, backend, requested_model)
+        for source in config.sources:
+            if not any(model.id == target_model for model in source.models):
+                continue
+            if source.supply_channel == "hub":
+                return False
+            sanctioned_backend = {"anthropic": "claude", "openai": "codex"}.get(source.vendor)
+            if source.kind == "subscription" and sanctioned_backend == backend:
+                return False
+        return True
 
     @staticmethod
     def _direct_launch(backend: BackendName, requested_model: str) -> ModelHubLaunch:
@@ -266,11 +284,11 @@ class ModelHubRuntimeRouter:
         route_key = self._route_key(current)
         previous = self._last_launch.get(route_key)
         self._last_launch[route_key] = current
+        reason = self._pending_switch_reason.pop(route_key, None)
         if previous is None or previous.channel == current.channel:
             return
         if {previous.channel, current.channel} != {"native_cli", "hub"}:
             return
-        reason = self._pending_switch_reason.pop(route_key, None)
         if reason is None:
             reason = "recovery" if current.channel == "native_cli" else "manual"
         self.service._record_event(
@@ -314,10 +332,10 @@ class ModelHubRuntimeRouter:
             launch = self._direct_launch(backend, requested_model)
             self._emit_channel_switch(launch)
             return launch
-        # Fresh installs seed Hub mode before setup/migration has supplied any
-        # usable source or OpenCode menu. Until that bootstrap state is complete,
-        # preserve the native launch path; once configured, Hub remains fail-closed.
-        if self._is_bootstrap_unconfigured(config, backend):
+        # Fresh installs seed Hub mode before setup/migration has configured
+        # every backend/model route. Preserve native launch only for an
+        # unconfigured route; explicitly configured Hub routes remain fail-closed.
+        if self._is_bootstrap_unconfigured(config, backend, requested_model):
             return self._direct_launch(backend, requested_model)
         if not requested_model:
             raise ModelHubError("mapping_target_unavailable", status=409)
@@ -412,8 +430,7 @@ class ModelHubRuntimeRouter:
         reason = cast(EventReason, decision.reason)
         route_key = self._route_key(launch)
         self._pending_source_failure[route_key] = (launch.source_id, reason)
-        if launch.channel == "native_cli":
-            self._pending_switch_reason[route_key] = reason
+        self._pending_switch_reason[route_key] = reason
         return True
 
     async def prepare_opencode_overlay(self) -> OpenCodeOverlay | None:
@@ -429,6 +446,8 @@ class ModelHubRuntimeRouter:
 
         gateway_base_url, gateway_token = await self._gateway_credentials()
         providers: dict[str, dict[str, Any]] = {}
+        available_identifiers: list[str] = []
+        sources_by_id = {source.id: source for source in config.sources}
         for identifier in sorted(checked):
             try:
                 provider_id, model_id = parse_opencode_model_id(identifier)
@@ -441,7 +460,22 @@ class ModelHubRuntimeRouter:
             )
             source = next((candidate for candidate in candidates if candidate.supply_channel == "hub"), None)
             if source is None:
-                raise ModelHubError("mapping_target_unavailable", status=409)
+                # Keep a cooling/error route's public identifier stable in the
+                # overlay. Per-turn resolution still rejects that requested
+                # route, while unrelated checked models remain usable.
+                source = next(
+                    (
+                        candidate
+                        for source_id in config.priority_order
+                        if (candidate := sources_by_id.get(source_id)) is not None
+                        and candidate.supply_channel == "hub"
+                        and opencode_provider_id(candidate.vendor) == provider_id
+                        and any(model.id == model_id for model in candidate.models)
+                    ),
+                    None,
+                )
+            if source is None:
+                continue
             prefix = await self._source_prefix(source.id)
             package = _provider_package(source.protocol)
             base_url = _provider_base_url(gateway_base_url, source.protocol)
@@ -461,6 +495,10 @@ class ModelHubRuntimeRouter:
                 "id": f"{prefix}/{model_id}",
                 "name": model.display_name or model_id,
             }
+            available_identifiers.append(identifier)
+
+        if not available_identifiers:
+            raise ModelHubError("mapping_target_unavailable", status=409)
 
         content = (
             json.dumps(
@@ -477,7 +515,7 @@ class ModelHubRuntimeRouter:
             path=self.overlay_path,
             content_hash=content_hash,
             content=content,
-            checked_identifiers=checked,
+            checked_identifiers=tuple(available_identifiers),
         )
 
     def _secure_write_overlay(self, content: bytes) -> None:

--- a/modules/agents/model_hub.py
+++ b/modules/agents/model_hub.py
@@ -32,6 +32,11 @@ _NATIVE_QUOTA_RE = re.compile(
     re.IGNORECASE,
 )
 _NATIVE_RATE_RE = re.compile(r"(?:\b429\b|rate[_ -]?limit|too many requests)", re.IGNORECASE)
+_SERVER_ERROR_RE = re.compile(r"(?:\b5\d\d\b|server[_ -]?error|internal server error)", re.IGNORECASE)
+_NETWORK_ERROR_RE = re.compile(
+    r"(?:timed?\s*out|timeout|connection (?:failed|reset|refused)|network (?:error|unreachable))",
+    re.IGNORECASE,
+)
 
 
 @dataclass(frozen=True)
@@ -195,6 +200,7 @@ class ModelHubRuntimeRouter:
         self.overlay_path = overlay_path or paths.get_runtime_dir() / "model-hub" / "opencode-overlay.json"
         self._last_launch: dict[BackendName, ModelHubLaunch] = {}
         self._pending_switch_reason: dict[BackendName, EventReason] = {}
+        self._pending_source_failure: dict[BackendName, tuple[str, EventReason]] = {}
 
     @staticmethod
     def _target_model(config: ModelHubConfig, backend: BackendName, requested_model: str) -> str:
@@ -254,6 +260,28 @@ class ModelHubRuntimeRouter:
             now=self.service.now(),
         )
 
+    def _emit_source_switch(self, current: ModelHubLaunch, config: ModelHubConfig) -> None:
+        pending = self._pending_source_failure.get(current.backend)
+        if pending is None or not current.source_id:
+            return
+        failed_source_id, reason = pending
+        if failed_source_id == current.source_id:
+            self._pending_source_failure.pop(current.backend, None)
+            return
+        failed_source = next((source for source in config.sources if source.id == failed_source_id), None)
+        current_source = next((source for source in config.sources if source.id == current.source_id), None)
+        if failed_source is None or current_source is None:
+            self._pending_source_failure.pop(current.backend, None)
+            return
+        self.service._emit_switch(
+            agent=cast(EventAgent, current.backend),
+            model_id=current.target_model,
+            failed_source=failed_source,
+            failed_reason=reason,
+            source=current_source,
+        )
+        self._pending_source_failure.pop(current.backend, None)
+
     async def resolve(self, backend: BackendName, requested_model: str) -> ModelHubLaunch:
         requested_model = str(requested_model or "").strip()
         config = self.service.store.load()
@@ -294,6 +322,12 @@ class ModelHubRuntimeRouter:
             raise ModelHubError("mapping_target_unavailable", status=409)
         source = candidates[0]
         if source.supply_channel == "native_cli":
+            if self.service.revocations.list():
+                try:
+                    await self.service._ensure_engine_synced()
+                except ModelHubError:
+                    # Native launch is independent; the durable journal retries later.
+                    pass
             launch = ModelHubLaunch(
                 backend=backend,
                 channel="native_cli",
@@ -315,12 +349,19 @@ class ModelHubRuntimeRouter:
                 gateway_base_url=gateway_base_url,
                 gateway_token=gateway_token,
             )
+        self._emit_source_switch(launch, config)
         self._emit_channel_switch(launch)
         return launch
 
     async def record_native_failure(self, context: Any, diagnostic: str) -> bool:
+        """Record a terminal source failure for the next per-turn resolution.
+
+        The method name is retained for existing backend call sites; Hub launches
+        use the same cooldown state so the next turn can select a backup source.
+        """
+
         launch = launch_for_context(context)
-        if launch is None or launch.channel != "native_cli" or not launch.source_id:
+        if launch is None or launch.channel not in {"native_cli", "hub"} or not launch.source_id:
             return False
         if getattr(context, _CONTEXT_FAILURE_RECORDED_ATTR, False):
             return False
@@ -328,6 +369,10 @@ class ModelHubRuntimeRouter:
             decision = ResolutionDecision("fallback", reason="quota_exhausted", cooldown_seconds=300)
         elif _NATIVE_RATE_RE.search(diagnostic):
             decision = ResolutionDecision("fallback", reason="rate_limited", cooldown_seconds=60)
+        elif _SERVER_ERROR_RE.search(diagnostic):
+            decision = ResolutionDecision("fallback", reason="server_error", cooldown_seconds=30)
+        elif _NETWORK_ERROR_RE.search(diagnostic):
+            decision = ResolutionDecision("fallback", reason="network", cooldown_seconds=30)
         else:
             return False
         config = self.service.store.load()
@@ -341,7 +386,10 @@ class ModelHubRuntimeRouter:
             model_id=launch.target_model,
         )
         setattr(context, _CONTEXT_FAILURE_RECORDED_ATTR, True)
-        self._pending_switch_reason[launch.backend] = cast(EventReason, decision.reason)
+        reason = cast(EventReason, decision.reason)
+        self._pending_source_failure[launch.backend] = (launch.source_id, reason)
+        if launch.channel == "native_cli":
+            self._pending_switch_reason[launch.backend] = reason
         return True
 
     async def prepare_opencode_overlay(self) -> OpenCodeOverlay | None:

--- a/modules/agents/opencode/agent.py
+++ b/modules/agents/opencode/agent.py
@@ -20,7 +20,12 @@ from core.message_output import terminal_output_for
 from core.resource_governance import governor_from_controller
 from core.system_prompt_injection import build_system_prompt_injection, get_enabled_agents_for_prompt
 from modules.agents.base import AgentRequest, BaseAgent
-from modules.agents.model_hub import OpenCodeOverlay, opencode_model_for_overlay
+from modules.agents.model_hub import (
+    OpenCodeOverlay,
+    bind_launch,
+    opencode_model_for_overlay,
+    resolve_model_hub_launch,
+)
 
 from .caller_context import bind_session as bind_caller_context_session
 from .client_manager import OpenCodeClientManager
@@ -304,6 +309,13 @@ class OpenCodeAgent(OpenCodeMessageProcessorMixin, BaseAgent):
             if not model_str:
                 model_str = getattr(opencode_cfg, "default_model", None)
             model_str = opencode_model_for_overlay(model_str, model_hub_overlay)
+            if model_hub_runtime is not None and model_str:
+                launch = await resolve_model_hub_launch(
+                    self.controller,
+                    "opencode",
+                    model_str,
+                )
+                bind_launch(request.context, launch)
             # Bare model id (no ``provider/`` prefix): only inject ``providerID``
             # when the user has explicitly chosen a default provider in Settings.
             # Otherwise leave ``model_dict`` unset so OpenCode keeps using its own
@@ -475,6 +487,7 @@ class OpenCodeAgent(OpenCodeMessageProcessorMixin, BaseAgent):
             error_text = f"{error_name}: {error_details}" if error_details else error_name
 
             logger.error(f"OpenCode request failed: {error_text}", exc_info=True)
+            await self.record_model_hub_native_failure(request.context, error_text)
             try:
                 await server.abort_session(session_id, request.working_path)
             except Exception as abort_err:

--- a/modules/agents/opencode/agent.py
+++ b/modules/agents/opencode/agent.py
@@ -21,9 +21,11 @@ from core.resource_governance import governor_from_controller
 from core.system_prompt_injection import build_system_prompt_injection, get_enabled_agents_for_prompt
 from modules.agents.base import AgentRequest, BaseAgent
 from modules.agents.model_hub import (
+    ModelHubLaunch,
     OpenCodeOverlay,
     bind_launch,
     opencode_model_for_overlay,
+    persisted_launch_identity,
     resolve_model_hub_launch,
 )
 
@@ -196,6 +198,7 @@ class OpenCodeAgent(OpenCodeMessageProcessorMixin, BaseAgent):
     async def _process_message(self, request: AgentRequest) -> None:
         run_registered = False
         model_hub_overlay: OpenCodeOverlay | None = None
+        model_hub_launch: ModelHubLaunch | None = None
         # Bind early: get_or_create_session_id (below) can raise BEFORE assigning
         # session_id (a transient server error now that get_session raises on
         # non-404), and the error-cleanup paths reference session_id — keep it
@@ -310,12 +313,12 @@ class OpenCodeAgent(OpenCodeMessageProcessorMixin, BaseAgent):
                 model_str = getattr(opencode_cfg, "default_model", None)
             model_str = opencode_model_for_overlay(model_str, model_hub_overlay)
             if model_hub_runtime is not None and model_str:
-                launch = await resolve_model_hub_launch(
+                model_hub_launch = await resolve_model_hub_launch(
                     self.controller,
                     "opencode",
                     model_str,
                 )
-                bind_launch(request.context, launch)
+                bind_launch(request.context, model_hub_launch)
             # Bare model id (no ``provider/`` prefix): only inject ``providerID``
             # when the user has explicitly chosen a default provider in Settings.
             # Otherwise leave ``model_dict`` unset so OpenCode keeps using its own
@@ -417,6 +420,10 @@ class OpenCodeAgent(OpenCodeMessageProcessorMixin, BaseAgent):
             # scoped key so restored polls remain attached to typed scopes.
             raw_settings_key = _raw_settings_key_from_session_key(request.session_key)
             platform_payload = request.context.platform_specific or {}
+            processing_indicator = self.controller.processing_indicator.snapshot_request(request)
+            launch_identity = persisted_launch_identity(model_hub_launch)
+            if launch_identity is not None:
+                processing_indicator["model_hub_launch"] = launch_identity
 
             self.sessions.add_active_poll(
                 opencode_session_id=session_id,
@@ -430,7 +437,7 @@ class OpenCodeAgent(OpenCodeMessageProcessorMixin, BaseAgent):
                 ack_reaction_emoji=request.ack_reaction_emoji,
                 typing_indicator_active=request.typing_indicator_active,
                 context_token=str(platform_payload.get("context_token") or ""),
-                processing_indicator=self.controller.processing_indicator.snapshot_request(request),
+                processing_indicator=processing_indicator,
                 user_id=request.context.user_id or "",
                 platform=request.context.platform or platform_payload.get("platform") or "",
                 prompt_started_at=prompt_started_at,

--- a/modules/agents/opencode/agent.py
+++ b/modules/agents/opencode/agent.py
@@ -20,6 +20,7 @@ from core.message_output import terminal_output_for
 from core.resource_governance import governor_from_controller
 from core.system_prompt_injection import build_system_prompt_injection, get_enabled_agents_for_prompt
 from modules.agents.base import AgentRequest, BaseAgent
+from modules.agents.model_hub import OpenCodeOverlay, opencode_model_for_overlay
 
 from .caller_context import bind_session as bind_caller_context_session
 from .client_manager import OpenCodeClientManager
@@ -189,13 +190,21 @@ class OpenCodeAgent(OpenCodeMessageProcessorMixin, BaseAgent):
 
     async def _process_message(self, request: AgentRequest) -> None:
         run_registered = False
+        model_hub_overlay: OpenCodeOverlay | None = None
         # Bind early: get_or_create_session_id (below) can raise BEFORE assigning
         # session_id (a transient server error now that get_session raises on
         # non-404), and the error-cleanup paths reference session_id — keep it
         # defined so they can't trip UnboundLocalError (Codex P2).
         session_id = None
         try:
+            model_hub_runtime = getattr(self.controller, "model_hub_runtime", None)
+            prepare_overlay = getattr(model_hub_runtime, "prepare_opencode_overlay", None)
+            if callable(prepare_overlay):
+                model_hub_overlay = await prepare_overlay()
             server = await self._get_server()
+            configure_overlay = getattr(server, "configure_model_hub_overlay", None)
+            if callable(configure_overlay):
+                await configure_overlay(model_hub_overlay)
             await server.ensure_running()
         except Exception as e:
             logger.error(f"Failed to start OpenCode server: {e}", exc_info=True)
@@ -294,6 +303,7 @@ class OpenCodeAgent(OpenCodeMessageProcessorMixin, BaseAgent):
             opencode_cfg = getattr(self.controller.config, "opencode", None)
             if not model_str:
                 model_str = getattr(opencode_cfg, "default_model", None)
+            model_str = opencode_model_for_overlay(model_str, model_hub_overlay)
             # Bare model id (no ``provider/`` prefix): only inject ``providerID``
             # when the user has explicitly chosen a default provider in Settings.
             # Otherwise leave ``model_dict`` unset so OpenCode keeps using its own

--- a/modules/agents/opencode/agent.py
+++ b/modules/agents/opencode/agent.py
@@ -26,7 +26,7 @@ from modules.agents.model_hub import (
     bind_launch,
     opencode_model_for_overlay,
     persisted_launch_identity,
-    resolve_model_hub_launch,
+    resolve_opencode_overlay_launch,
 )
 
 from .caller_context import bind_session as bind_caller_context_session
@@ -313,10 +313,10 @@ class OpenCodeAgent(OpenCodeMessageProcessorMixin, BaseAgent):
                 model_str = getattr(opencode_cfg, "default_model", None)
             model_str = opencode_model_for_overlay(model_str, model_hub_overlay)
             if model_hub_runtime is not None and model_str:
-                model_hub_launch = await resolve_model_hub_launch(
+                model_hub_launch = await resolve_opencode_overlay_launch(
                     self.controller,
-                    "opencode",
                     model_str,
+                    model_hub_overlay,
                 )
                 bind_launch(request.context, model_hub_launch)
             # Bare model id (no ``provider/`` prefix): only inject ``providerID``

--- a/modules/agents/opencode/poll_loop.py
+++ b/modules/agents/opencode/poll_loop.py
@@ -338,6 +338,9 @@ class OpenCodePollLoop:
                                 )
 
                         diagnostic = f"{error_name} - {error_msg[:500]}".strip(" -")
+                        record_failure = getattr(self._agent, "record_model_hub_native_failure", None)
+                        if callable(record_failure):
+                            await record_failure(request.context, diagnostic)
                         message = f"OpenCode error: {diagnostic}"
                         await emit_backend_failure(
                             self._agent.controller,

--- a/modules/agents/opencode/poll_loop.py
+++ b/modules/agents/opencode/poll_loop.py
@@ -12,6 +12,7 @@ from core.backend_failure import emit_backend_failure
 from core.message_context import build_context_session_key
 from core.message_output import terminal_output_for, terminal_turn_output
 from modules.agents.base import AgentRequest
+from modules.agents.model_hub import bind_persisted_launch
 from modules.im import MessageContext
 from vibe.i18n import t as i18n_t
 
@@ -19,6 +20,15 @@ from .message_processor import is_empty_terminal_opencode_message
 from .server import OpenCodeServerManager
 
 logger = logging.getLogger(__name__)
+
+
+def _opencode_error_text(error: object) -> str:
+    if not isinstance(error, dict):
+        return str(error)
+    error_name = error.get("name", "UnknownError")
+    error_data = error.get("data", {})
+    error_message = error_data.get("message", "") if isinstance(error_data, dict) else str(error_data)
+    return f"{error_name} - {error_message[:500]}".strip(" -")
 
 
 def restored_platform_from_poll_info(poll_info) -> str:
@@ -79,6 +89,11 @@ class OpenCodePollLoop:
         config = getattr(controller, "config", None)
         lang = getattr(config, "language", "en")
         return str(i18n_t(key, lang, **kwargs))
+
+    async def _record_model_hub_failure(self, context: MessageContext, diagnostic: str) -> None:
+        record_failure = getattr(self._agent, "record_model_hub_native_failure", None)
+        if callable(record_failure):
+            await record_failure(context, diagnostic)
 
     def _build_restored_handle(self, poll_info):
         snapshot = poll_info.processing_indicator or {
@@ -296,15 +311,12 @@ class OpenCodePollLoop:
                     msg_error = last_info.get("error")
                     if msg_error and last_id != last_error_message_id:
                         last_error_message_id = last_id
-                        error_name = msg_error.get("name", "UnknownError")
-                        error_data = msg_error.get("data", {})
-                        error_msg = error_data.get("message", "") if isinstance(error_data, dict) else str(error_data)
+                        diagnostic = _opencode_error_text(msg_error)
 
                         logger.warning(
-                            "OpenCode message error detected for %s: %s - %s (retry %d/%d)",
+                            "OpenCode message error detected for %s: %s (retry %d/%d)",
                             session_id,
-                            error_name,
-                            error_msg[:200],
+                            diagnostic[:200],
                             error_retry_count,
                             error_retry_limit,
                         )
@@ -337,10 +349,7 @@ class OpenCodePollLoop:
                                     retry_err,
                                 )
 
-                        diagnostic = f"{error_name} - {error_msg[:500]}".strip(" -")
-                        record_failure = getattr(self._agent, "record_model_hub_native_failure", None)
-                        if callable(record_failure):
-                            await record_failure(request.context, diagnostic)
+                        await self._record_model_hub_failure(request.context, diagnostic)
                         message = f"OpenCode error: {diagnostic}"
                         await emit_backend_failure(
                             self._agent.controller,
@@ -397,6 +406,10 @@ class OpenCodePollLoop:
         session_id = poll_info.opencode_session_id
         restored_request = self._build_restored_ack_request(poll_info)
         context = restored_request.context
+        processing_snapshot = (
+            poll_info.processing_indicator if isinstance(poll_info.processing_indicator, dict) else {}
+        )
+        bind_persisted_launch(context, processing_snapshot.get("model_hub_launch"))
 
         await self._agent.controller.emit_agent_message(
             context,
@@ -526,12 +539,13 @@ class OpenCodePollLoop:
                         if time_info.get("completed"):
                             msg_error = last_info.get("error")
                             if msg_error:
-                                error_text = str(msg_error)
+                                error_text = _opencode_error_text(msg_error)
                                 if last_info.get("id") != last_error_message_id:
                                     error_retry_count = 0
                                     last_error_message_id = last_info.get("id")
                                 error_retry_count += 1
                                 if error_retry_count > error_retry_limit:
+                                    await self._record_model_hub_failure(context, error_text)
                                     message = f"OpenCode error: {error_text}"
                                     await emit_backend_failure(
                                         self._agent.controller,
@@ -604,6 +618,7 @@ class OpenCodePollLoop:
             error_text = f"{error_name}: {error_details}" if error_details else error_name
 
             logger.error(f"Restored OpenCode poll failed: {error_text}", exc_info=True)
+            await self._record_model_hub_failure(context, error_text)
             try:
                 await server.abort_session(session_id, poll_info.working_path)
             except Exception as abort_err:

--- a/modules/agents/opencode/server.py
+++ b/modules/agents/opencode/server.py
@@ -99,6 +99,8 @@ class OpenCodeServerManager:
         self._caller_context_plugin_refresh_pending = False
         self._pending_runtime_config: Optional[tuple[str, int, int]] = None
         self._last_prompt_started_at: dict[str, float] = {}
+        self._model_hub_overlay_path: Optional[str] = None
+        self._model_hub_overlay_hash: Optional[str] = None
 
     def _caller_context_path(self) -> str:
         return server_environment()["AVIBE_OPENCODE_CALLER_CONTEXT_PATH"]
@@ -369,6 +371,33 @@ class OpenCodeServerManager:
         active = info.get("active_run_sessions") if isinstance(info, dict) else None
         return isinstance(active, list) and bool(active)
 
+    async def configure_model_hub_overlay(self, overlay: Any | None) -> None:
+        """Apply a runtime-only overlay after all active OpenCode work drains."""
+
+        desired_path = str(overlay.path) if overlay is not None else None
+        desired_hash = str(overlay.content_hash) if overlay is not None else None
+        while True:
+            if self.runtime_has_active_turns():
+                await asyncio.sleep(0.05)
+                continue
+            async with self._get_lock():
+                if self._active_requests > 0 or self._has_active_run_sessions():
+                    continue
+                info = self._read_pid_file() or {}
+                effective_path = info.get("model_hub_overlay_path")
+                effective_hash = info.get("model_hub_overlay_hash")
+                if effective_path is None and effective_hash is None:
+                    effective_path = self._model_hub_overlay_path
+                    effective_hash = self._model_hub_overlay_hash
+                if (effective_path, effective_hash) == (desired_path, desired_hash):
+                    return
+                self._model_hub_overlay_path = desired_path
+                self._model_hub_overlay_hash = desired_hash
+                if await self._is_healthy():
+                    logger.info("Restarting OpenCode server after Model Hub overlay change")
+                    await self._restart_for_auth_refresh_locked()
+                return
+
     async def mark_run_active(self, session_id: str) -> None:
         async with self._get_lock():
             self._active_run_sessions.add(session_id)
@@ -430,6 +459,9 @@ class OpenCodeServerManager:
                 caller_context_path = self._caller_context_path()
             if isinstance(caller_context_path, str) and caller_context_path:
                 payload["caller_context_path"] = caller_context_path
+            if self._model_hub_overlay_path and self._model_hub_overlay_hash:
+                payload["model_hub_overlay_path"] = self._model_hub_overlay_path
+                payload["model_hub_overlay_hash"] = self._model_hub_overlay_hash
             self._pid_file.write_text(json.dumps(payload))
         except Exception as e:
             logger.debug(f"Failed to write OpenCode pid file: {e}")
@@ -1197,6 +1229,8 @@ class OpenCodeServerManager:
         env = os.environ.copy()
         env["OPENCODE_ENABLE_EXA"] = "1"
         env.update(server_environment())
+        if self._model_hub_overlay_path:
+            env["OPENCODE_CONFIG"] = self._model_hub_overlay_path
 
         try:
             self._process = await asyncio.create_subprocess_exec(

--- a/modules/agents/opencode/server.py
+++ b/modules/agents/opencode/server.py
@@ -42,6 +42,7 @@ DEFAULT_OPENCODE_PORT = 4096
 DEFAULT_OPENCODE_HOST = "127.0.0.1"
 SERVER_START_TIMEOUT = 15
 OPENCODE_LOG_TAIL_BYTES = 2_000_000
+MODEL_HUB_OVERLAY_DRAIN_TIMEOUT_SECONDS = 30.0
 _USE_CURRENT_CALLER_CONTEXT_PATH = object()
 _CURRENT_OWNER_PID = os.getpid()
 
@@ -101,6 +102,7 @@ class OpenCodeServerManager:
         self._last_prompt_started_at: dict[str, float] = {}
         self._model_hub_overlay_path: Optional[str] = None
         self._model_hub_overlay_hash: Optional[str] = None
+        self._model_hub_overlay_drain_timeout_seconds = MODEL_HUB_OVERLAY_DRAIN_TIMEOUT_SECONDS
 
     def _caller_context_path(self) -> str:
         return server_environment()["AVIBE_OPENCODE_CALLER_CONTEXT_PATH"]
@@ -376,27 +378,43 @@ class OpenCodeServerManager:
 
         desired_path = str(overlay.path) if overlay is not None else None
         desired_hash = str(overlay.content_hash) if overlay is not None else None
+        drain_deadline = time.monotonic() + self._model_hub_overlay_drain_timeout_seconds
         while True:
-            if self.runtime_has_active_turns():
-                await asyncio.sleep(0.05)
-                continue
+            should_wait = False
             async with self._get_lock():
                 if self._active_requests > 0 or self._has_active_run_sessions():
-                    continue
-                info = self._read_pid_file() or {}
-                effective_path = info.get("model_hub_overlay_path")
-                effective_hash = info.get("model_hub_overlay_hash")
-                if effective_path is None and effective_hash is None:
-                    effective_path = self._model_hub_overlay_path
-                    effective_hash = self._model_hub_overlay_hash
-                if (effective_path, effective_hash) == (desired_path, desired_hash):
-                    return
-                self._model_hub_overlay_path = desired_path
-                self._model_hub_overlay_hash = desired_hash
-                if await self._is_healthy():
-                    logger.info("Restarting OpenCode server after Model Hub overlay change")
-                    await self._restart_for_auth_refresh_locked()
-                return
+                    should_wait = True
+                else:
+                    info = self._read_pid_file() or {}
+                    current_server = self._pid_file_references_current_server(info)
+                    persisted_active = current_server and bool(info.get("active_run_sessions"))
+                    if persisted_active and time.monotonic() < drain_deadline:
+                        should_wait = True
+                    else:
+                        if persisted_active:
+                            logger.warning(
+                                "Ignoring stale OpenCode active-run metadata after %.1fs overlay drain timeout",
+                                self._model_hub_overlay_drain_timeout_seconds,
+                            )
+                        effective_path = info.get("model_hub_overlay_path") if current_server else None
+                        effective_hash = info.get("model_hub_overlay_hash") if current_server else None
+                        if effective_path is None and effective_hash is None:
+                            effective_path = self._model_hub_overlay_path
+                            effective_hash = self._model_hub_overlay_hash
+
+                        # Cache the desired state even when adopted pid metadata
+                        # already matches. A later crash must restart with the
+                        # same OPENCODE_CONFIG without relying on the old pid file.
+                        self._model_hub_overlay_path = desired_path
+                        self._model_hub_overlay_hash = desired_hash
+                        if (effective_path, effective_hash) == (desired_path, desired_hash):
+                            return
+                        if await self._is_healthy():
+                            logger.info("Restarting OpenCode server after Model Hub overlay change")
+                            await self._restart_for_auth_refresh_locked()
+                        return
+            if should_wait:
+                await asyncio.sleep(0.05)
 
     async def mark_run_active(self, session_id: str) -> None:
         async with self._get_lock():

--- a/modules/agents/opencode/server.py
+++ b/modules/agents/opencode/server.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 from contextlib import asynccontextmanager
 from datetime import datetime
+import hashlib
 import json
 import logging
 import os
@@ -102,6 +103,7 @@ class OpenCodeServerManager:
         self._last_prompt_started_at: dict[str, float] = {}
         self._model_hub_overlay_path: Optional[str] = None
         self._model_hub_overlay_hash: Optional[str] = None
+        self._model_hub_overlay_content: Optional[str] = None
         self._model_hub_overlay_drain_timeout_seconds = MODEL_HUB_OVERLAY_DRAIN_TIMEOUT_SECONDS
 
     def _caller_context_path(self) -> str:
@@ -378,6 +380,13 @@ class OpenCodeServerManager:
 
         desired_path = str(overlay.path) if overlay is not None else None
         desired_hash = str(overlay.content_hash) if overlay is not None else None
+        desired_content = None
+        if overlay is not None:
+            content = getattr(overlay, "content", None)
+            if isinstance(content, bytes):
+                desired_content = content.decode("utf-8")
+            elif isinstance(content, str):
+                desired_content = content
         drain_deadline = time.monotonic() + self._model_hub_overlay_drain_timeout_seconds
         while True:
             should_wait = False
@@ -407,6 +416,7 @@ class OpenCodeServerManager:
                         # same OPENCODE_CONFIG without relying on the old pid file.
                         self._model_hub_overlay_path = desired_path
                         self._model_hub_overlay_hash = desired_hash
+                        self._model_hub_overlay_content = desired_content
                         if (effective_path, effective_hash) == (desired_path, desired_hash):
                             return
                         if await self._is_healthy():
@@ -1249,6 +1259,19 @@ class OpenCodeServerManager:
         env.update(server_environment())
         if self._model_hub_overlay_path:
             env["OPENCODE_CONFIG"] = self._model_hub_overlay_path
+            content = self._model_hub_overlay_content
+            if content is None:
+                try:
+                    raw_content = Path(self._model_hub_overlay_path).read_bytes()
+                except OSError as exc:
+                    raise RuntimeError("Model Hub OpenCode overlay is unavailable") from exc
+                if hashlib.sha256(raw_content).hexdigest() != self._model_hub_overlay_hash:
+                    raise RuntimeError("Model Hub OpenCode overlay content hash changed")
+                content = raw_content.decode("utf-8")
+            # Inline config is OpenCode's runtime-override tier, loaded after
+            # project config. Reasserting the exact overlay here prevents a
+            # checked-in opencode.json from replacing Hub provider transport.
+            env["OPENCODE_CONFIG_CONTENT"] = content
 
         try:
             self._process = await asyncio.create_subprocess_exec(

--- a/tests/scenarios/model_hub/catalog.yaml
+++ b/tests/scenarios/model_hub/catalog.yaml
@@ -6,6 +6,7 @@ capability:
     - tests/test_model_hub_api.py
     - tests/test_model_hub_config.py
     - tests/test_model_hub_resolution.py
+    - tests/test_model_hub_injection.py
 status_legend:
   covered: closed-loop scenario coverage exists
   partial: unit or contract coverage exists but the cross-lane loop is incomplete
@@ -31,9 +32,46 @@ scenarios:
     test: tests/test_model_hub_resolution.py::test_mapping_is_scoped_to_the_requesting_backend
   - id: MH-OC-001
     name: OpenCode identifiers stay stable across mode switches
-    status: gap
+    status: covered
     kind: stability
     layer: scenario
+    test: tests/test_model_hub_injection.py::test_mh_ovl_001_identifiers_stay_stable_across_all_perturbations
+  - id: MH-CHAN-001
+    name: Native subscription exhaustion falls back and recovers per turn
+    status: covered
+    kind: recovery
+    layer: scenario
+    test: tests/test_model_hub_injection.py::test_mh_chan_001_native_quota_falls_back_then_recovers_next_turn
+  - id: MH-INJ-CLAUDE-001
+    name: Claude Hub launch uses environment-only gateway injection
+    status: covered
+    kind: injection
+    layer: scenario
+    test: tests/test_model_hub_injection.py::test_mh_inj_runtime_injection_never_writes_native_configs
+  - id: MH-INJ-CODEX-001
+    name: Codex Hub launch uses app-server runtime overrides
+    status: covered
+    kind: injection
+    layer: scenario
+    test: tests/test_model_hub_injection.py::test_mh_inj_runtime_injection_never_writes_native_configs
+  - id: MH-INJ-OPENCODE-001
+    name: OpenCode overlay changes drain work and restart with hash metadata
+    status: covered
+    kind: injection
+    layer: scenario
+    test: tests/test_model_hub_injection.py::test_mh_inj_opencode_overlay_change_drains_then_restarts_and_records_hash
+  - id: MH-INJ-DIRECT-001
+    name: Direct launches preserve native configuration and omit Hub injection
+    status: covered
+    kind: compatibility
+    layer: scenario
+    test: tests/test_model_hub_injection.py::test_mh_inj_runtime_injection_never_writes_native_configs
+  - id: MH-OVL-001
+    name: OpenCode visible identifiers survive source and runtime perturbations
+    status: covered
+    kind: stability
+    layer: scenario
+    test: tests/test_model_hub_injection.py::test_mh_ovl_001_identifiers_stay_stable_across_all_perturbations
   - id: MH-MIG-001
     name: Migration copies without modifying native configuration
     status: gap
@@ -66,6 +104,12 @@ next_priority:
   - MH-PRI-001
   - MH-MAP-001
   - MH-OC-001
+  - MH-CHAN-001
+  - MH-INJ-CLAUDE-001
+  - MH-INJ-CODEX-001
+  - MH-INJ-OPENCODE-001
+  - MH-INJ-DIRECT-001
+  - MH-OVL-001
   - MH-MIG-001
   - MH-OAUTH-A-001
   - MH-OAUTH-B-001

--- a/tests/test_codex_agent.py
+++ b/tests/test_codex_agent.py
@@ -2993,7 +2993,7 @@ class CodexTransportCommandTests(unittest.IsolatedAsyncioTestCase):
         Transport = transport_module.CodexTransport
 
         writes = []
-        created_cmd = {}
+        created_cmds = []
 
         class _FakeStdin:
             def __init__(self):
@@ -3038,7 +3038,7 @@ class CodexTransportCommandTests(unittest.IsolatedAsyncioTestCase):
                 return 0
 
         async def fake_create_subprocess_exec(*cmd, **kwargs):
-            created_cmd["cmd"] = list(cmd)
+            created_cmds.append(list(cmd))
             return _FakeProcess()
 
         with patch.object(
@@ -3049,10 +3049,26 @@ class CodexTransportCommandTests(unittest.IsolatedAsyncioTestCase):
             transport = Transport(binary="codex", cwd="/tmp/work")
             await transport.start()
             await transport.stop()
+            transport = Transport(
+                binary="codex",
+                cwd="/tmp/work",
+                runtime_args=["-c", 'model_provider="avibe_model_hub"'],
+            )
+            await transport.start()
+            await transport.stop()
 
         self.assertEqual(
-            created_cmd["cmd"],
-            ["codex", "--dangerously-bypass-approvals-and-sandbox", "app-server"],
+            created_cmds,
+            [
+                ["codex", "--dangerously-bypass-approvals-and-sandbox", "app-server"],
+                [
+                    "codex",
+                    "--dangerously-bypass-approvals-and-sandbox",
+                    "app-server",
+                    "-c",
+                    'model_provider="avibe_model_hub"',
+                ],
+            ],
         )
 
 

--- a/tests/test_model_hub_injection.py
+++ b/tests/test_model_hub_injection.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import json
 import stat
 from contextlib import suppress
@@ -291,7 +292,7 @@ def test_mh_chan_001_native_sources_only_dispatch_to_sanctioned_client(tmp_path:
     assert (launch.channel, launch.source_id) == ("hub", hub_openai.id)
 
 
-def test_mh_chan_001_hub_mode_without_sources_fails_closed(tmp_path: Path) -> None:
+def test_mh_chan_001_unconfigured_fresh_hub_preserves_native_launch(tmp_path: Path) -> None:
     service = _service(
         tmp_path,
         ModelHubConfig(sources=[], priority_order=[], agents=_agents()),
@@ -299,8 +300,30 @@ def test_mh_chan_001_hub_mode_without_sources_fails_closed(tmp_path: Path) -> No
         now=lambda: datetime(2026, 7, 23, tzinfo=timezone.utc),
     )
 
+    launch = asyncio.run(ModelHubRuntimeRouter(service=service).resolve("codex", "gpt-5"))
+
+    assert launch.channel == "direct"
+    assert service.events.list(limit=10) == []
+
+
+def test_mh_chan_001_configured_hub_stays_fail_closed_for_unavailable_model(tmp_path: Path) -> None:
+    hub = _source(
+        "src_hub0099",
+        kind="api_key",
+        vendor="openai",
+        protocol="openai_responses",
+        channel="hub",
+        model_ids=("gpt-5",),
+    )
+    service = _service(
+        tmp_path,
+        ModelHubConfig(sources=[hub], priority_order=[hub.id], agents=_agents()),
+        LaunchAdapter({hub.id: "route-hub"}),
+        now=lambda: datetime(2026, 7, 23, tzinfo=timezone.utc),
+    )
+
     with pytest.raises(ModelHubError) as exc_info:
-        asyncio.run(ModelHubRuntimeRouter(service=service).resolve("codex", "gpt-5"))
+        asyncio.run(ModelHubRuntimeRouter(service=service).resolve("codex", "unavailable-model"))
 
     assert exc_info.value.code == "mapping_target_unavailable"
 
@@ -336,6 +359,8 @@ def test_mh_inj_runtime_injection_never_writes_native_configs(tmp_path: Path, mo
             "ANTHROPIC_API_KEY": "upstream-key",
             "ANTHROPIC_AUTH_TOKEN": "upstream-token",
             "ANTHROPIC_BASE_URL": "https://upstream.invalid",
+            "ANTHROPIC_CUSTOM_HEADERS": "x-upstream-auth: stale",
+            "ANTHROPIC_MODEL": "stale-model",
         },
         hub_launch,
     )
@@ -352,6 +377,7 @@ def test_mh_inj_runtime_injection_never_writes_native_configs(tmp_path: Path, mo
         codex_launch,
     )
     assert codex_args[:2] == ["-c", 'model_provider="avibe_model_hub"']
+    assert "model_providers.avibe_model_hub.supports_websockets=false" in codex_args
     assert codex_env == {"PATH": "/bin", "AVIBE_MODEL_HUB_TOKEN": "gateway-only-token"}
 
     direct = ModelHubLaunch("claude", "direct", "model", "model", "model")
@@ -459,6 +485,59 @@ def test_mh_ovl_001_identifiers_stay_stable_across_all_perturbations(tmp_path: P
     assert stat.S_IMODE(router.overlay_path.stat().st_mode) == 0o600
 
 
+def test_mh_chan_001_switch_telemetry_is_isolated_per_model_route(tmp_path: Path) -> None:
+    native_a = _source(
+        "src_native_a",
+        kind="subscription",
+        vendor="openai",
+        protocol="openai_responses",
+        channel="native_cli",
+        model_ids=("model-a",),
+    )
+    hub_a = _source(
+        "src_hub_a",
+        kind="api_key",
+        vendor="openai",
+        protocol="openai_responses",
+        channel="hub",
+        model_ids=("model-a",),
+    )
+    hub_b = _source(
+        "src_hub_b",
+        kind="api_key",
+        vendor="openai",
+        protocol="openai_responses",
+        channel="hub",
+        model_ids=("model-b",),
+    )
+    config = ModelHubConfig(
+        sources=[native_a, hub_a, hub_b],
+        priority_order=[native_a.id, hub_a.id, hub_b.id],
+        agents=_agents(),
+    )
+    service = _service(
+        tmp_path,
+        config,
+        LaunchAdapter({hub_a.id: "route-a", hub_b.id: "route-b"}),
+        now=lambda: datetime(2026, 7, 23, tzinfo=timezone.utc),
+    )
+    router = ModelHubRuntimeRouter(service=service)
+
+    native_launch = asyncio.run(router.resolve("codex", "model-a"))
+    assert asyncio.run(router.resolve("codex", "model-b")).channel == "hub"
+    assert not [event for event in service.events.list(limit=20) if event["kind"] == "channel_switch"]
+
+    context = SimpleNamespace()
+    bind_launch(context, native_launch)
+    assert asyncio.run(router.record_native_failure(context, "usage quota exceeded")) is True
+    asyncio.run(router.resolve("codex", "model-b"))
+    assert not [event for event in service.events.list(limit=20) if event["kind"] == "switch"]
+
+    assert asyncio.run(router.resolve("codex", "model-a")).source_id == hub_a.id
+    switch_events = [event for event in service.events.list(limit=20) if event["kind"] in {"switch", "channel_switch"}]
+    assert {event["model_id"] for event in switch_events} == {"model-a"}
+
+
 def test_mh_inj_opencode_overlay_change_drains_then_restarts_and_records_hash(tmp_path: Path) -> None:
     """MH-INJ-OPENCODE-001: active work drains before overlay restart."""
 
@@ -547,11 +626,16 @@ def test_mh_inj_opencode_config_env_is_hub_only(tmp_path: Path, monkeypatch) -> 
     """MH-INJ-DIRECT-001: direct serve launch has no OPENCODE_CONFIG injection."""
 
     monkeypatch.delenv("OPENCODE_CONFIG", raising=False)
+    monkeypatch.delenv("OPENCODE_CONFIG_CONTENT", raising=False)
 
-    async def capture(overlay_path: str | None) -> dict:
+    async def capture(overlay_content: bytes | None) -> dict:
         manager = OpenCodeServerManager()
-        manager._pid_file = tmp_path / f"pid-{bool(overlay_path)}.json"
-        manager._model_hub_overlay_path = overlay_path
+        manager._pid_file = tmp_path / f"pid-{bool(overlay_content)}.json"
+        if overlay_content is not None:
+            overlay_path = tmp_path / "overlay.json"
+            overlay_path.write_bytes(overlay_content)
+            manager._model_hub_overlay_path = str(overlay_path)
+            manager._model_hub_overlay_hash = hashlib.sha256(overlay_content).hexdigest()
         manager._clear_pid_file = Mock()
         manager._write_pid_file = Mock()
         manager._apply_resource_governance = Mock()
@@ -564,10 +648,12 @@ def test_mh_inj_opencode_config_env_is_hub_only(tmp_path: Path, monkeypatch) -> 
             await manager._start_server()
         return spawn.await_args.kwargs["env"]
 
+    overlay_content = b'{"provider":{"openai":{}}}\n'
     direct_env = asyncio.run(capture(None))
-    hub_env = asyncio.run(capture(str(tmp_path / "overlay.json")))
+    hub_env = asyncio.run(capture(overlay_content))
     assert "OPENCODE_CONFIG" not in direct_env
     assert hub_env["OPENCODE_CONFIG"] == str(tmp_path / "overlay.json")
+    assert hub_env["OPENCODE_CONFIG_CONTENT"] == overlay_content.decode()
 
 
 def test_mh_chan_001_codex_resolves_only_after_session_queue_lock() -> None:
@@ -692,3 +778,18 @@ def test_mh_inj_claude_channel_change_waits_for_active_turn() -> None:
         handler.cleanup_session.assert_awaited_once_with(key)
 
     asyncio.run(exercise())
+
+
+def test_mh_inj_cached_claude_subagent_uses_resolved_native_model() -> None:
+    native = ModelHubLaunch(
+        "claude",
+        "native_cli",
+        "builtin-opus",
+        "claude-opus-4-6",
+        "claude-opus-4-6",
+        "src_native",
+    )
+    direct = ModelHubLaunch("claude", "direct", "builtin-opus", "builtin-opus", "builtin-opus")
+
+    assert SessionHandler._cached_claude_subagent_model("builtin-opus", native) == "claude-opus-4-6"
+    assert SessionHandler._cached_claude_subagent_model(None, direct) is None

--- a/tests/test_model_hub_injection.py
+++ b/tests/test_model_hub_injection.py
@@ -1,0 +1,424 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import stat
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock, patch
+
+from config.v2_config import (
+    ModelHubAgentSupplyConfig,
+    ModelHubConfig,
+    ModelHubMappingConfig,
+    ModelHubMenuConfig,
+    ModelHubModelConfig,
+    ModelHubSourceConfig,
+    ModelHubSourceStateConfig,
+)
+from core.handlers.model_hub.adapter import EngineHealth, EngineStatus
+from core.handlers.model_hub.events import BoundedEventLog
+from core.handlers.model_hub.revocations import CredentialRevocationJournal
+from core.handlers.model_hub.service import ModelHubService
+from modules.agents.model_hub import (
+    ModelHubLaunch,
+    ModelHubRuntimeRouter,
+    bind_launch,
+    build_claude_hub_env,
+    build_codex_hub_launch,
+    opencode_model_for_overlay,
+    overlay_identifier_bytes,
+)
+from modules.agents.codex.agent import CodexAgent
+from modules.agents.opencode.server import OpenCodeServerManager
+
+
+class MemoryStore:
+    def __init__(self, config: ModelHubConfig):
+        self.config = config
+
+    def load(self) -> ModelHubConfig:
+        return self.config
+
+    def save(self, config: ModelHubConfig) -> None:
+        self.config = config
+
+
+class LaunchAdapter:
+    def __init__(self, prefixes: dict[str, str], *, token: str = "local-gateway-token"):
+        self.prefixes = prefixes
+        self.token = token
+        self.starts = 0
+        self.syncs = 0
+
+    async def start(self):
+        self.starts += 1
+        return EngineStatus(EngineHealth.OK, "test", True, "127.0.0.1", 18443, None)
+
+    async def gateway_token(self):
+        return self.token
+
+    async def sync_sources(self, bindings):
+        self.syncs += 1
+
+    def source_prefix(self, source_id: str) -> str:
+        return self.prefixes[source_id]
+
+
+def _model(model_id: str, display_name: str | None = None) -> ModelHubModelConfig:
+    return ModelHubModelConfig(
+        id=model_id,
+        display_name=display_name,
+        provenance="discovered",
+    )
+
+
+def _source(
+    source_id: str,
+    *,
+    kind: str,
+    vendor: str,
+    protocol: str,
+    channel: str,
+    model_ids: tuple[str, ...],
+    state: str = "standby",
+    retry_at: str | None = None,
+) -> ModelHubSourceConfig:
+    return ModelHubSourceConfig(
+        id=source_id,
+        kind=kind,
+        vendor=vendor,
+        display_name=source_id,
+        protocol=protocol,
+        supply_channel=channel,
+        billing="monthly" if kind == "subscription" else "metered",
+        state=ModelHubSourceStateConfig(status=state, retry_at=retry_at),
+        models=[_model(model_id) for model_id in model_ids],
+        credential_ref=f"cred_{source_id}" if channel == "hub" else None,
+    )
+
+
+def _agents(*, mode: str = "hub") -> dict[str, ModelHubAgentSupplyConfig]:
+    return {
+        backend: ModelHubAgentSupplyConfig.default(backend, mode=mode)
+        for backend in ("claude", "codex", "opencode")
+    }
+
+
+def _service(
+    tmp_path: Path,
+    config: ModelHubConfig,
+    adapter: LaunchAdapter,
+    *,
+    now,
+) -> ModelHubService:
+    return ModelHubService(
+        store=MemoryStore(config),
+        adapter=adapter,
+        events=BoundedEventLog(tmp_path / "events.json"),
+        revocations=CredentialRevocationJournal(tmp_path / "revocations.json"),
+        now=now,
+    )
+
+
+def test_mh_chan_001_native_quota_falls_back_then_recovers_next_turn(tmp_path: Path) -> None:
+    """MH-CHAN-001: healthy -> exhausted -> recovering is decided per turn."""
+
+    clock = {"now": datetime(2026, 7, 23, 12, 0, tzinfo=timezone.utc)}
+    native = _source(
+        "src_native01",
+        kind="subscription",
+        vendor="openai",
+        protocol="openai_responses",
+        channel="native_cli",
+        model_ids=("gpt-5",),
+    )
+    hub = _source(
+        "src_hub0001",
+        kind="api_key",
+        vendor="openai",
+        protocol="openai_responses",
+        channel="hub",
+        model_ids=("gpt-5",),
+    )
+    agents = _agents()
+    agents["codex"].mappings = [ModelHubMappingConfig("default", "gpt-5", True)]
+    config = ModelHubConfig(
+        sources=[native, hub],
+        priority_order=[native.id, hub.id],
+        agents=agents,
+    )
+    adapter = LaunchAdapter({hub.id: "route-hub"})
+    service = _service(tmp_path, config, adapter, now=lambda: clock["now"])
+    router = ModelHubRuntimeRouter(service=service, overlay_path=tmp_path / "overlay.json")
+
+    healthy = asyncio.run(router.resolve("codex", "gpt-5"))
+    assert (healthy.channel, healthy.source_id, adapter.starts) == ("native_cli", native.id, 0)
+
+    context = SimpleNamespace()
+    bind_launch(context, healthy)
+    assert asyncio.run(router.record_native_failure(context, "usage quota exceeded")) is True
+    exhausted = asyncio.run(router.resolve("codex", "gpt-5"))
+    assert exhausted.channel == "hub"
+    assert exhausted.runtime_model == "route-hub/gpt-5"
+
+    clock["now"] += timedelta(seconds=301)
+    recovered = asyncio.run(router.resolve("codex", "gpt-5"))
+    assert (recovered.channel, recovered.source_id) == ("native_cli", native.id)
+    kinds = [event["kind"] for event in reversed(service.events.list(limit=20))]
+    assert kinds == ["cooldown", "channel_switch", "recover", "channel_switch"]
+    assert [event["reason"] for event in service.events.list(limit=20) if event["kind"] == "channel_switch"] == [
+        "recovery",
+        "quota_exhausted",
+    ]
+
+
+def test_mh_chan_001_native_sources_only_dispatch_to_sanctioned_client(tmp_path: Path) -> None:
+    native_claude = _source(
+        "src_native02",
+        kind="subscription",
+        vendor="anthropic",
+        protocol="anthropic",
+        channel="native_cli",
+        model_ids=("shared-model",),
+    )
+    hub_openai = _source(
+        "src_hub0002",
+        kind="api_key",
+        vendor="openai",
+        protocol="openai_responses",
+        channel="hub",
+        model_ids=("shared-model",),
+    )
+    config = ModelHubConfig(
+        sources=[native_claude, hub_openai],
+        priority_order=[native_claude.id, hub_openai.id],
+        agents=_agents(),
+    )
+    adapter = LaunchAdapter({hub_openai.id: "route-openai"})
+    service = _service(
+        tmp_path,
+        config,
+        adapter,
+        now=lambda: datetime(2026, 7, 23, tzinfo=timezone.utc),
+    )
+    launch = asyncio.run(ModelHubRuntimeRouter(service=service).resolve("codex", "shared-model"))
+    assert (launch.channel, launch.source_id) == ("hub", hub_openai.id)
+
+
+def test_mh_inj_runtime_injection_never_writes_native_configs(tmp_path: Path, monkeypatch) -> None:
+    """MH-INJ-*-001 + MH-INJ-DIRECT-001: injections are process-local only."""
+
+    home = tmp_path / "home"
+    native_paths = (
+        home / ".claude" / "settings.json",
+        home / ".codex" / "config.toml",
+        home / ".config" / "opencode" / "opencode.json",
+    )
+    for index, path in enumerate(native_paths):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(f"sentinel-{index}".encode())
+    before = {path: path.read_bytes() for path in native_paths}
+    monkeypatch.setenv("HOME", str(home))
+
+    hub_launch = ModelHubLaunch(
+        backend="claude",
+        channel="hub",
+        requested_model="claude-opus",
+        target_model="claude-opus",
+        runtime_model="route-claude/claude-opus",
+        source_id="src_hub0003",
+        gateway_base_url="http://127.0.0.1:18443",
+        gateway_token="gateway-only-token",
+    )
+    claude_env = build_claude_hub_env(
+        {
+            "PATH": "/bin",
+            "ANTHROPIC_API_KEY": "upstream-key",
+            "ANTHROPIC_AUTH_TOKEN": "upstream-token",
+            "ANTHROPIC_BASE_URL": "https://upstream.invalid",
+        },
+        hub_launch,
+    )
+    assert claude_env == {
+        "PATH": "/bin",
+        "ANTHROPIC_BASE_URL": "http://127.0.0.1:18443",
+        "ANTHROPIC_AUTH_TOKEN": "gateway-only-token",
+    }
+
+    codex_launch = ModelHubLaunch(**{**hub_launch.__dict__, "backend": "codex"})
+    codex_args, codex_env = build_codex_hub_launch(
+        [],
+        {"PATH": "/bin", "OPENAI_API_KEY": "upstream", "OPENAI_API_BASE": "https://old.invalid"},
+        codex_launch,
+    )
+    assert codex_args[:2] == ["-c", 'model_provider="avibe_model_hub"']
+    assert codex_env == {"PATH": "/bin", "AVIBE_MODEL_HUB_TOKEN": "gateway-only-token"}
+
+    direct = ModelHubLaunch("claude", "direct", "model", "model", "model")
+    base_env = {"ANTHROPIC_API_KEY": "native-value", "PATH": "/bin"}
+    assert build_claude_hub_env(base_env, direct) == base_env
+    assert build_codex_hub_launch(["--legacy"], base_env, direct) == (["--legacy"], None)
+    assert CodexAgent._is_managed_provider_transition("openai", "avibe_model_hub") is True
+    assert CodexAgent._is_managed_provider_transition("avibe_model_hub", "openai") is True
+    assert {path: path.read_bytes() for path in native_paths} == before
+
+
+def _opencode_config() -> ModelHubConfig:
+    anthropic = _source(
+        "src_hub0004",
+        kind="api_key",
+        vendor="anthropic",
+        protocol="anthropic",
+        channel="hub",
+        model_ids=("claude-opus",),
+    )
+    custom = _source(
+        "src_hub0005",
+        kind="api_key",
+        vendor="relay-vendor",
+        protocol="openai_compatible",
+        channel="hub",
+        model_ids=("local-model",),
+    )
+    agents = _agents()
+    agents["opencode"].menu = ModelHubMenuConfig(
+        view="featured",
+        checked=["anthropic/claude-opus", "custom/local-model"],
+    )
+    return ModelHubConfig(
+        sources=[anthropic, custom],
+        priority_order=[anthropic.id, custom.id],
+        agents=agents,
+    )
+
+
+def test_mh_ovl_001_identifiers_stay_stable_across_all_perturbations(tmp_path: Path) -> None:
+    """MH-OC-001/MH-OVL-001: visible identifiers never inherit source identity."""
+
+    config = _opencode_config()
+    adapter = LaunchAdapter(
+        {
+            "src_hub0004": "route-anthropic-a",
+            "src_hub0005": "route-custom-a",
+            "src_hub0006": "route-anthropic-b",
+        }
+    )
+    service = _service(
+        tmp_path,
+        config,
+        adapter,
+        now=lambda: datetime(2026, 7, 23, tzinfo=timezone.utc),
+    )
+    router = ModelHubRuntimeRouter(service=service, overlay_path=tmp_path / "runtime" / "opencode.json")
+    baseline = asyncio.run(router.prepare_opencode_overlay())
+    assert baseline is not None
+    stable_projection = overlay_identifier_bytes(baseline.content)
+    assert json.loads(stable_projection) == ["anthropic/claude-opus", "custom/local-model"]
+    assert opencode_model_for_overlay(None, baseline) == "anthropic/claude-opus"
+
+    config.agents["opencode"].mode = "direct"
+    assert asyncio.run(router.prepare_opencode_overlay()) is None
+    config.agents["opencode"].mode = "hub"
+    after_mode_switch = asyncio.run(router.prepare_opencode_overlay())
+
+    backup = _source(
+        "src_hub0006",
+        kind="api_key",
+        vendor="anthropic",
+        protocol="anthropic",
+        channel="hub",
+        model_ids=("claude-opus",),
+    )
+    config.sources.append(backup)
+    config.priority_order = [backup.id, *reversed(config.priority_order)]
+    after_add_reorder = asyncio.run(router.prepare_opencode_overlay())
+
+    backup.state = ModelHubSourceStateConfig(
+        status="cooldown",
+        retry_at=(datetime(2026, 7, 24, tzinfo=timezone.utc)).isoformat(),
+    )
+    after_cooldown = asyncio.run(router.prepare_opencode_overlay())
+    config.sources.remove(backup)
+    config.priority_order.remove(backup.id)
+    after_remove = asyncio.run(router.prepare_opencode_overlay())
+    after_engine_restart = asyncio.run(router.prepare_opencode_overlay())
+
+    overlays = (
+        after_mode_switch,
+        after_add_reorder,
+        after_cooldown,
+        after_remove,
+        after_engine_restart,
+    )
+    assert all(overlay is not None for overlay in overlays)
+    assert {overlay_identifier_bytes(overlay.content) for overlay in overlays if overlay} == {stable_projection}
+    payload = json.loads(after_remove.content)  # type: ignore[union-attr]
+    assert set(payload["provider"]) == {"anthropic", "custom"}
+    assert payload["provider"]["anthropic"]["npm"] == "@ai-sdk/anthropic"
+    assert payload["provider"]["custom"]["npm"] == "@ai-sdk/openai-compatible"
+    assert stat.S_IMODE(router.overlay_path.stat().st_mode) == 0o600
+
+
+def test_mh_inj_opencode_overlay_change_drains_then_restarts_and_records_hash(tmp_path: Path) -> None:
+    """MH-INJ-OPENCODE-001: active work drains before overlay restart."""
+
+    manager = OpenCodeServerManager()
+    manager._pid_file = tmp_path / "opencode_server.json"
+    manager._active_run_sessions.add("active-session")
+    manager._is_healthy = AsyncMock(return_value=True)
+    manager._restart_for_auth_refresh_locked = AsyncMock()
+    overlay = SimpleNamespace(path=tmp_path / "overlay.json", content_hash="abc123")
+
+    async def exercise() -> None:
+        async def finish_active_work() -> None:
+            await asyncio.sleep(0.02)
+            manager._active_run_sessions.clear()
+
+        finisher = asyncio.create_task(finish_active_work())
+        await manager.configure_model_hub_overlay(overlay)
+        await finisher
+
+    asyncio.run(exercise())
+    manager._restart_for_auth_refresh_locked.assert_awaited_once()
+    manager._write_pid_file(12345)
+    metadata = json.loads(manager._pid_file.read_text())
+    assert metadata["model_hub_overlay_hash"] == "abc123"
+    assert metadata["model_hub_overlay_path"] == str(overlay.path)
+
+
+def test_mh_inj_direct_opencode_overlay_is_a_noop(tmp_path: Path) -> None:
+    """MH-INJ-DIRECT-001: unchanged direct mode does not inspect the live CLI."""
+
+    manager = OpenCodeServerManager()
+    manager._pid_file = tmp_path / "opencode_server.json"
+    manager._is_healthy = AsyncMock(return_value=True)
+    asyncio.run(manager.configure_model_hub_overlay(None))
+    manager._is_healthy.assert_not_awaited()
+
+
+def test_mh_inj_opencode_config_env_is_hub_only(tmp_path: Path, monkeypatch) -> None:
+    """MH-INJ-DIRECT-001: direct serve launch has no OPENCODE_CONFIG injection."""
+
+    monkeypatch.delenv("OPENCODE_CONFIG", raising=False)
+
+    async def capture(overlay_path: str | None) -> dict:
+        manager = OpenCodeServerManager()
+        manager._pid_file = tmp_path / f"pid-{bool(overlay_path)}.json"
+        manager._model_hub_overlay_path = overlay_path
+        manager._clear_pid_file = Mock()
+        manager._write_pid_file = Mock()
+        manager._apply_resource_governance = Mock()
+        process = SimpleNamespace(pid=4321, returncode=None)
+        with (
+            patch("modules.agents.opencode.server.server_environment", return_value={"AVIBE_TEST": "1"}),
+            patch("modules.agents.opencode.server.asyncio.create_subprocess_exec", new=AsyncMock(return_value=process)) as spawn,
+        ):
+            await manager._start_server()
+        return spawn.await_args.kwargs["env"]
+
+    direct_env = asyncio.run(capture(None))
+    hub_env = asyncio.run(capture(str(tmp_path / "overlay.json")))
+    assert "OPENCODE_CONFIG" not in direct_env
+    assert hub_env["OPENCODE_CONFIG"] == str(tmp_path / "overlay.json")

--- a/tests/test_model_hub_injection.py
+++ b/tests/test_model_hub_injection.py
@@ -229,6 +229,47 @@ def test_mh_chan_001_hub_failure_cools_source_and_selects_backup(tmp_path: Path)
     assert [event["kind"] for event in reversed(service.events.list(limit=10))] == ["cooldown", "switch"]
 
 
+def test_mh_chan_001_hub_to_native_switch_keeps_failure_reason(tmp_path: Path) -> None:
+    hub = _source(
+        "src_hub_reason",
+        kind="api_key",
+        vendor="openai",
+        protocol="openai_responses",
+        channel="hub",
+        model_ids=("gpt-5",),
+    )
+    native = _source(
+        "src_native_reason",
+        kind="subscription",
+        vendor="openai",
+        protocol="openai_responses",
+        channel="native_cli",
+        model_ids=("gpt-5",),
+    )
+    service = _service(
+        tmp_path,
+        ModelHubConfig(
+            sources=[hub, native],
+            priority_order=[hub.id, native.id],
+            agents=_agents(),
+        ),
+        LaunchAdapter({hub.id: "route-hub"}),
+        now=lambda: datetime(2026, 7, 23, tzinfo=timezone.utc),
+    )
+    router = ModelHubRuntimeRouter(service=service)
+    initial = asyncio.run(router.resolve("codex", "gpt-5"))
+    context = SimpleNamespace()
+    bind_launch(context, initial)
+
+    assert asyncio.run(router.record_native_failure(context, "usage quota exceeded")) is True
+    assert asyncio.run(router.resolve("codex", "gpt-5")).channel == "native_cli"
+
+    channel_switch = next(
+        event for event in service.events.list(limit=10) if event["kind"] == "channel_switch"
+    )
+    assert channel_switch["reason"] == "quota_exhausted"
+
+
 def test_mh_chan_001_native_launch_replays_pending_revocations(tmp_path: Path) -> None:
     native = _source(
         "src_native11",
@@ -306,6 +347,31 @@ def test_mh_chan_001_unconfigured_fresh_hub_preserves_native_launch(tmp_path: Pa
     assert service.events.list(limit=10) == []
 
 
+def test_mh_chan_001_other_backend_source_does_not_activate_hub(tmp_path: Path) -> None:
+    codex_native = _source(
+        "src_native_other",
+        kind="subscription",
+        vendor="openai",
+        protocol="openai_responses",
+        channel="native_cli",
+        model_ids=("gpt-5",),
+    )
+    service = _service(
+        tmp_path,
+        ModelHubConfig(
+            sources=[codex_native],
+            priority_order=[codex_native.id],
+            agents=_agents(),
+        ),
+        LaunchAdapter({}),
+        now=lambda: datetime(2026, 7, 23, tzinfo=timezone.utc),
+    )
+
+    launch = asyncio.run(ModelHubRuntimeRouter(service=service).resolve("claude", "claude-opus"))
+
+    assert launch.channel == "direct"
+
+
 def test_mh_chan_001_configured_hub_stays_fail_closed_for_unavailable_model(tmp_path: Path) -> None:
     hub = _source(
         "src_hub0099",
@@ -315,9 +381,13 @@ def test_mh_chan_001_configured_hub_stays_fail_closed_for_unavailable_model(tmp_
         channel="hub",
         model_ids=("gpt-5",),
     )
+    agents = _agents()
+    agents["codex"].mappings = [
+        ModelHubMappingConfig("unavailable-model", "configured-but-missing", True)
+    ]
     service = _service(
         tmp_path,
-        ModelHubConfig(sources=[hub], priority_order=[hub.id], agents=_agents()),
+        ModelHubConfig(sources=[hub], priority_order=[hub.id], agents=agents),
         LaunchAdapter({hub.id: "route-hub"}),
         now=lambda: datetime(2026, 7, 23, tzinfo=timezone.utc),
     )
@@ -483,6 +553,45 @@ def test_mh_ovl_001_identifiers_stay_stable_across_all_perturbations(tmp_path: P
     assert payload["provider"]["anthropic"]["npm"] == "@ai-sdk/anthropic"
     assert payload["provider"]["custom"]["npm"] == "@ai-sdk/openai-compatible"
     assert stat.S_IMODE(router.overlay_path.stat().st_mode) == 0o600
+
+
+def test_mh_ovl_001_unavailable_menu_entry_does_not_block_healthy_model(tmp_path: Path) -> None:
+    config = _opencode_config()
+    anthropic = config.sources[0]
+    anthropic.state = ModelHubSourceStateConfig(
+        status="cooldown",
+        retry_at=datetime(2026, 7, 24, tzinfo=timezone.utc).isoformat(),
+    )
+    adapter = LaunchAdapter(
+        {
+            "src_hub0004": "route-anthropic",
+            "src_hub0005": "route-custom",
+        }
+    )
+    service = _service(
+        tmp_path,
+        config,
+        adapter,
+        now=lambda: datetime(2026, 7, 23, tzinfo=timezone.utc),
+    )
+    router = ModelHubRuntimeRouter(service=service, overlay_path=tmp_path / "overlay.json")
+
+    cooling_overlay = asyncio.run(router.prepare_opencode_overlay())
+    assert cooling_overlay is not None
+    assert json.loads(overlay_identifier_bytes(cooling_overlay.content)) == [
+        "anthropic/claude-opus",
+        "custom/local-model",
+    ]
+    assert opencode_model_for_overlay("custom/local-model", cooling_overlay) == "custom/local-model"
+    with pytest.raises(ModelHubError):
+        asyncio.run(router.resolve("opencode", "anthropic/claude-opus"))
+
+    config.sources.remove(anthropic)
+    config.priority_order.remove(anthropic.id)
+    reduced_overlay = asyncio.run(router.prepare_opencode_overlay())
+    assert reduced_overlay is not None
+    assert reduced_overlay.checked_identifiers == ("custom/local-model",)
+    assert opencode_model_for_overlay("custom/local-model", reduced_overlay) == "custom/local-model"
 
 
 def test_mh_chan_001_switch_telemetry_is_isolated_per_model_route(tmp_path: Path) -> None:
@@ -735,6 +844,78 @@ def test_mh_inj_codex_runtime_change_waits_for_shared_active_turn(tmp_path: Path
 
         old_transport.stop.assert_awaited_once()
         new_transport.start.assert_awaited_once()
+
+    asyncio.run(exercise())
+
+
+def test_mh_inj_codex_runtime_change_interrupts_current_session_first() -> None:
+    async def exercise() -> None:
+        agent = object.__new__(CodexAgent)
+        active = {"turn": "turn-current"}
+        transport = SimpleNamespace(
+            is_initialized=True,
+            runtime_fingerprint="direct",
+            send_request=AsyncMock(return_value={}),
+        )
+        interrupted_request = SimpleNamespace()
+
+        def clear_pending(turn_id: str):
+            assert turn_id == "turn-current"
+            active["turn"] = None
+            return interrupted_request
+
+        agent._transports = {"/work": transport}
+        agent._session_mgr = SimpleNamespace(get_thread_id=Mock(return_value="thread-current"))
+        agent._turn_registry = SimpleNamespace(get_active_turn=lambda _base: active["turn"])
+        agent._event_handler = SimpleNamespace(clear_pending=Mock(side_effect=clear_pending))
+        agent._remove_ack_reaction = AsyncMock()
+        request = SimpleNamespace(
+            working_path="/work",
+            base_session_id="session-current",
+        )
+        launch = ModelHubLaunch(
+            "codex",
+            "hub",
+            "gpt-5",
+            "gpt-5",
+            "route/gpt-5",
+            "src_hub",
+            "http://127.0.0.1:18443",
+            "token",
+        )
+
+        await agent._interrupt_active_turn_before_runtime_change(request, launch)
+
+        transport.send_request.assert_awaited_once_with(
+            "turn/interrupt",
+            {"threadId": "thread-current", "turnId": "turn-current"},
+        )
+        assert active["turn"] is None
+        agent._remove_ack_reaction.assert_awaited_once_with(interrupted_request)
+
+    asyncio.run(exercise())
+
+
+def test_mh_inj_codex_direct_resume_clears_implicit_hub_provider() -> None:
+    async def exercise() -> None:
+        agent = object.__new__(CodexAgent)
+        transport = SimpleNamespace(
+            send_request=AsyncMock(
+                side_effect=[
+                    {"config": {}},
+                    {"thread": {"id": "thread-existing", "modelProvider": "avibe_model_hub"}},
+                ]
+            )
+        )
+        request = SimpleNamespace(working_path="/work")
+
+        provider = await agent._resolve_resume_model_provider_override(
+            transport,
+            request,
+            "thread-existing",
+        )
+
+        assert provider == "openai"
 
     asyncio.run(exercise())
 

--- a/tests/test_model_hub_injection.py
+++ b/tests/test_model_hub_injection.py
@@ -3,10 +3,13 @@ from __future__ import annotations
 import asyncio
 import json
 import stat
+from contextlib import suppress
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
 
 from config.v2_config import (
     ModelHubAgentSupplyConfig,
@@ -20,7 +23,8 @@ from config.v2_config import (
 from core.handlers.model_hub.adapter import EngineHealth, EngineStatus
 from core.handlers.model_hub.events import BoundedEventLog
 from core.handlers.model_hub.revocations import CredentialRevocationJournal
-from core.handlers.model_hub.service import ModelHubService
+from core.handlers.model_hub.service import ModelHubError, ModelHubService
+from core.handlers.session_handler import SessionHandler
 from modules.agents.model_hub import (
     ModelHubLaunch,
     ModelHubRuntimeRouter,
@@ -51,6 +55,7 @@ class LaunchAdapter:
         self.token = token
         self.starts = 0
         self.syncs = 0
+        self.revoked: list[str] = []
 
     async def start(self):
         self.starts += 1
@@ -61,6 +66,9 @@ class LaunchAdapter:
 
     async def sync_sources(self, bindings):
         self.syncs += 1
+
+    async def revoke_credential(self, credential_ref: str):
+        self.revoked.append(credential_ref)
 
     def source_prefix(self, source_id: str) -> str:
         return self.prefixes[source_id]
@@ -167,11 +175,87 @@ def test_mh_chan_001_native_quota_falls_back_then_recovers_next_turn(tmp_path: P
     recovered = asyncio.run(router.resolve("codex", "gpt-5"))
     assert (recovered.channel, recovered.source_id) == ("native_cli", native.id)
     kinds = [event["kind"] for event in reversed(service.events.list(limit=20))]
-    assert kinds == ["cooldown", "channel_switch", "recover", "channel_switch"]
+    assert kinds == ["cooldown", "switch", "channel_switch", "recover", "channel_switch"]
     assert [event["reason"] for event in service.events.list(limit=20) if event["kind"] == "channel_switch"] == [
         "recovery",
         "quota_exhausted",
     ]
+
+
+def test_mh_chan_001_hub_failure_cools_source_and_selects_backup(tmp_path: Path) -> None:
+    first = _source(
+        "src_hub1001",
+        kind="api_key",
+        vendor="openai",
+        protocol="openai_responses",
+        channel="hub",
+        model_ids=("gpt-5",),
+    )
+    backup = _source(
+        "src_hub1002",
+        kind="api_key",
+        vendor="openai",
+        protocol="openai_responses",
+        channel="hub",
+        model_ids=("gpt-5",),
+    )
+    config = ModelHubConfig(
+        sources=[first, backup],
+        priority_order=[first.id, backup.id],
+        agents=_agents(),
+    )
+    adapter = LaunchAdapter({first.id: "route-first", backup.id: "route-backup"})
+    service = _service(
+        tmp_path,
+        config,
+        adapter,
+        now=lambda: datetime(2026, 7, 23, tzinfo=timezone.utc),
+    )
+    router = ModelHubRuntimeRouter(service=service)
+
+    initial = asyncio.run(router.resolve("codex", "gpt-5"))
+    context = SimpleNamespace()
+    bind_launch(context, initial)
+    assert asyncio.run(router.record_native_failure(context, "Provider API returned HTTP 503")) is True
+    fallback = asyncio.run(router.resolve("codex", "gpt-5"))
+
+    assert (fallback.channel, fallback.source_id, fallback.runtime_model) == (
+        "hub",
+        backup.id,
+        "route-backup/gpt-5",
+    )
+    assert first.state.status == "cooldown"
+    assert [event["kind"] for event in reversed(service.events.list(limit=10))] == ["cooldown", "switch"]
+
+
+def test_mh_chan_001_native_launch_replays_pending_revocations(tmp_path: Path) -> None:
+    native = _source(
+        "src_native11",
+        kind="subscription",
+        vendor="openai",
+        protocol="openai_responses",
+        channel="native_cli",
+        model_ids=("gpt-5",),
+    )
+    config = ModelHubConfig(
+        sources=[native],
+        priority_order=[native.id],
+        agents=_agents(),
+    )
+    adapter = LaunchAdapter({})
+    service = _service(
+        tmp_path,
+        config,
+        adapter,
+        now=lambda: datetime(2026, 7, 23, tzinfo=timezone.utc),
+    )
+    service.revocations.add("src_removed", "cred_removed")
+
+    launch = asyncio.run(ModelHubRuntimeRouter(service=service).resolve("codex", "gpt-5"))
+
+    assert launch.channel == "native_cli"
+    assert adapter.revoked == ["cred_removed"]
+    assert service.revocations.list() == []
 
 
 def test_mh_chan_001_native_sources_only_dispatch_to_sanctioned_client(tmp_path: Path) -> None:
@@ -205,6 +289,20 @@ def test_mh_chan_001_native_sources_only_dispatch_to_sanctioned_client(tmp_path:
     )
     launch = asyncio.run(ModelHubRuntimeRouter(service=service).resolve("codex", "shared-model"))
     assert (launch.channel, launch.source_id) == ("hub", hub_openai.id)
+
+
+def test_mh_chan_001_hub_mode_without_sources_fails_closed(tmp_path: Path) -> None:
+    service = _service(
+        tmp_path,
+        ModelHubConfig(sources=[], priority_order=[], agents=_agents()),
+        LaunchAdapter({}),
+        now=lambda: datetime(2026, 7, 23, tzinfo=timezone.utc),
+    )
+
+    with pytest.raises(ModelHubError) as exc_info:
+        asyncio.run(ModelHubRuntimeRouter(service=service).resolve("codex", "gpt-5"))
+
+    assert exc_info.value.code == "mapping_target_unavailable"
 
 
 def test_mh_inj_runtime_injection_never_writes_native_configs(tmp_path: Path, monkeypatch) -> None:
@@ -388,6 +486,53 @@ def test_mh_inj_opencode_overlay_change_drains_then_restarts_and_records_hash(tm
     assert metadata["model_hub_overlay_path"] == str(overlay.path)
 
 
+def test_mh_inj_opencode_matching_pid_overlay_is_cached_for_crash_recovery(tmp_path: Path) -> None:
+    manager = OpenCodeServerManager()
+    manager._pid_file = tmp_path / "opencode_server.json"
+    overlay = SimpleNamespace(path=tmp_path / "overlay.json", content_hash="same-hash")
+    manager._read_pid_file = Mock(
+        return_value={
+            "pid": 12345,
+            "port": manager.port,
+            "active_run_sessions": [],
+            "model_hub_overlay_path": str(overlay.path),
+            "model_hub_overlay_hash": overlay.content_hash,
+        }
+    )
+    manager._pid_file_references_current_server = Mock(return_value=True)
+    manager._is_healthy = AsyncMock(return_value=True)
+
+    asyncio.run(manager.configure_model_hub_overlay(overlay))
+
+    assert manager._model_hub_overlay_path == str(overlay.path)
+    assert manager._model_hub_overlay_hash == overlay.content_hash
+    manager._is_healthy.assert_not_awaited()
+
+
+def test_mh_inj_opencode_stale_persisted_active_run_is_bounded(tmp_path: Path) -> None:
+    manager = OpenCodeServerManager()
+    manager._pid_file = tmp_path / "opencode_server.json"
+    manager._model_hub_overlay_drain_timeout_seconds = 0
+    manager._read_pid_file = Mock(
+        return_value={
+            "pid": 12345,
+            "port": manager.port,
+            "active_run_sessions": ["stale-run"],
+            "model_hub_overlay_path": "/old-overlay.json",
+            "model_hub_overlay_hash": "old-hash",
+        }
+    )
+    manager._pid_file_references_current_server = Mock(return_value=True)
+    manager._is_healthy = AsyncMock(return_value=True)
+    manager._restart_for_auth_refresh_locked = AsyncMock()
+    overlay = SimpleNamespace(path=tmp_path / "overlay.json", content_hash="new-hash")
+
+    asyncio.run(manager.configure_model_hub_overlay(overlay))
+
+    manager._restart_for_auth_refresh_locked.assert_awaited_once()
+    assert manager._model_hub_overlay_hash == "new-hash"
+
+
 def test_mh_inj_direct_opencode_overlay_is_a_noop(tmp_path: Path) -> None:
     """MH-INJ-DIRECT-001: unchanged direct mode does not inspect the live CLI."""
 
@@ -423,3 +568,127 @@ def test_mh_inj_opencode_config_env_is_hub_only(tmp_path: Path, monkeypatch) -> 
     hub_env = asyncio.run(capture(str(tmp_path / "overlay.json")))
     assert "OPENCODE_CONFIG" not in direct_env
     assert hub_env["OPENCODE_CONFIG"] == str(tmp_path / "overlay.json")
+
+
+def test_mh_chan_001_codex_resolves_only_after_session_queue_lock() -> None:
+    async def exercise() -> None:
+        agent = object.__new__(CodexAgent)
+        lock = asyncio.Lock()
+        await lock.acquire()
+        resolver = AsyncMock()
+        agent._session_locks = {"session": lock}
+        agent.controller = SimpleNamespace(model_hub_runtime=SimpleNamespace(resolve=resolver))
+        request = SimpleNamespace(base_session_id="session")
+
+        task = asyncio.create_task(agent.handle_message(request))
+        await asyncio.sleep(0.02)
+        resolver.assert_not_awaited()
+        task.cancel()
+        lock.release()
+        with suppress(asyncio.CancelledError):
+            await task
+
+    asyncio.run(exercise())
+
+
+def test_mh_inj_codex_runtime_change_waits_for_shared_active_turn(tmp_path: Path) -> None:
+    async def exercise() -> None:
+        agent = object.__new__(CodexAgent)
+        active = {"value": True}
+        old_transport = SimpleNamespace(
+            is_initialized=True,
+            runtime_fingerprint="direct",
+            stop=AsyncMock(),
+        )
+        new_transport = SimpleNamespace(
+            start=AsyncMock(),
+            on_notification=Mock(),
+            on_server_request=Mock(),
+            pid=12345,
+        )
+        agent._transport_locks = {}
+        agent._transports = {str(tmp_path): old_transport}
+        agent._transport_last_activity = {}
+        agent._transport_cwd_inodes = {}
+        agent._session_mgr = SimpleNamespace(
+            sessions_for_cwd=Mock(return_value={"other-session"}),
+            invalidate_thread=Mock(),
+        )
+        agent._turn_registry = SimpleNamespace(
+            get_active_turn=lambda _session_id: "turn" if active["value"] else None,
+            clear_session=Mock(),
+        )
+        agent._clear_thread_developer_instructions = Mock()
+        agent._on_notification = Mock()
+        agent._on_server_request = AsyncMock()
+        agent.codex_config = SimpleNamespace(binary="codex", extra_args=[])
+        agent.controller = SimpleNamespace(resource_governor=None)
+        launch = ModelHubLaunch(
+            "codex",
+            "hub",
+            "gpt-5",
+            "gpt-5",
+            "route/gpt-5",
+            "src_hub",
+            "http://127.0.0.1:18443",
+            "token",
+        )
+
+        with (
+            patch("modules.agents.codex.agent.CodexTransport", return_value=new_transport),
+            patch(
+                "modules.agents.codex.agent.governor_from_controller",
+                return_value=SimpleNamespace(apply_to_pid=Mock()),
+            ),
+        ):
+            task = asyncio.create_task(agent._get_or_create_transport(str(tmp_path), launch))
+            await asyncio.sleep(0.02)
+            old_transport.stop.assert_not_awaited()
+            active["value"] = False
+            assert await task is new_transport
+
+        old_transport.stop.assert_awaited_once()
+        new_transport.start.assert_awaited_once()
+
+    asyncio.run(exercise())
+
+
+def test_mh_inj_claude_channel_change_waits_for_active_turn() -> None:
+    async def exercise() -> None:
+        handler = object.__new__(SessionHandler)
+        key = "session:/work"
+        client = SimpleNamespace(_vibe_model_hub_fingerprint="native_cli:src_native")
+        handler.claude_sessions = {key: client}
+        handler.active_sessions = {key}
+        handler.cleanup_session = AsyncMock()
+        launch = ModelHubLaunch(
+            "claude",
+            "hub",
+            "claude-opus",
+            "claude-opus",
+            "route/claude-opus",
+            "src_hub",
+            "http://127.0.0.1:18443",
+            "token",
+        )
+
+        task = asyncio.create_task(
+            handler._reuse_cached_claude_session_if_available(
+                composite_key=key,
+                base_session_id="session",
+                working_path="/work",
+                context=SimpleNamespace(),
+                session_key="settings",
+                stored_claude_session_id=None,
+                current_model="claude-opus",
+                agent_system_prompt=None,
+                model_hub_launch=launch,
+            )
+        )
+        await asyncio.sleep(0.02)
+        handler.cleanup_session.assert_not_awaited()
+        handler.active_sessions.clear()
+        assert await task is None
+        handler.cleanup_session.assert_awaited_once_with(key)
+
+    asyncio.run(exercise())

--- a/tests/test_model_hub_injection.py
+++ b/tests/test_model_hub_injection.py
@@ -410,6 +410,7 @@ def test_mh_inj_opencode_config_env_is_hub_only(tmp_path: Path, monkeypatch) -> 
         manager._clear_pid_file = Mock()
         manager._write_pid_file = Mock()
         manager._apply_resource_governance = Mock()
+        manager._is_healthy = AsyncMock(return_value=True)
         process = SimpleNamespace(pid=4321, returncode=None)
         with (
             patch("modules.agents.opencode.server.server_environment", return_value={"AVIBE_TEST": "1"}),

--- a/tests/test_model_hub_injection.py
+++ b/tests/test_model_hub_injection.py
@@ -857,7 +857,7 @@ def test_mh_inj_codex_runtime_change_interrupts_current_session_first() -> None:
             runtime_fingerprint="direct",
             send_request=AsyncMock(return_value={}),
         )
-        interrupted_request = SimpleNamespace()
+        interrupted_request = SimpleNamespace(context=object())
 
         def clear_pending(turn_id: str):
             assert turn_id == "turn-current"
@@ -867,7 +867,10 @@ def test_mh_inj_codex_runtime_change_interrupts_current_session_first() -> None:
         agent._transports = {"/work": transport}
         agent._session_mgr = SimpleNamespace(get_thread_id=Mock(return_value="thread-current"))
         agent._turn_registry = SimpleNamespace(get_active_turn=lambda _base: active["turn"])
-        agent._event_handler = SimpleNamespace(clear_pending=Mock(side_effect=clear_pending))
+        agent._event_handler = SimpleNamespace(
+            clear_pending=Mock(side_effect=clear_pending),
+            _release_stream_turn=Mock(),
+        )
         agent._remove_ack_reaction = AsyncMock()
         request = SimpleNamespace(
             working_path="/work",
@@ -892,6 +895,7 @@ def test_mh_inj_codex_runtime_change_interrupts_current_session_first() -> None:
         )
         assert active["turn"] is None
         agent._remove_ack_reaction.assert_awaited_once_with(interrupted_request)
+        agent._event_handler._release_stream_turn.assert_called_once_with(interrupted_request.context)
 
     asyncio.run(exercise())
 

--- a/tests/test_model_hub_injection.py
+++ b/tests/test_model_hub_injection.py
@@ -29,11 +29,15 @@ from core.handlers.session_handler import SessionHandler
 from modules.agents.model_hub import (
     ModelHubLaunch,
     ModelHubRuntimeRouter,
+    bind_persisted_launch,
     bind_launch,
     build_claude_hub_env,
     build_codex_hub_launch,
+    claude_setting_sources_for_launch,
+    launch_for_context,
     opencode_model_for_overlay,
     overlay_identifier_bytes,
+    persisted_launch_identity,
 )
 from modules.agents.codex.agent import CodexAgent
 from modules.agents.opencode.server import OpenCodeServerManager
@@ -131,6 +135,19 @@ def _service(
     )
 
 
+def _router(
+    service: ModelHubService,
+    *,
+    overlay_path: Path | None = None,
+    native_cli_ready=None,
+) -> ModelHubRuntimeRouter:
+    return ModelHubRuntimeRouter(
+        service=service,
+        overlay_path=overlay_path,
+        native_cli_ready=native_cli_ready or (lambda _backend: True),
+    )
+
+
 def test_mh_chan_001_native_quota_falls_back_then_recovers_next_turn(tmp_path: Path) -> None:
     """MH-CHAN-001: healthy -> exhausted -> recovering is decided per turn."""
 
@@ -160,7 +177,7 @@ def test_mh_chan_001_native_quota_falls_back_then_recovers_next_turn(tmp_path: P
     )
     adapter = LaunchAdapter({hub.id: "route-hub"})
     service = _service(tmp_path, config, adapter, now=lambda: clock["now"])
-    router = ModelHubRuntimeRouter(service=service, overlay_path=tmp_path / "overlay.json")
+    router = _router(service, overlay_path=tmp_path / "overlay.json")
 
     healthy = asyncio.run(router.resolve("codex", "gpt-5"))
     assert (healthy.channel, healthy.source_id, adapter.starts) == ("native_cli", native.id, 0)
@@ -212,7 +229,7 @@ def test_mh_chan_001_hub_failure_cools_source_and_selects_backup(tmp_path: Path)
         adapter,
         now=lambda: datetime(2026, 7, 23, tzinfo=timezone.utc),
     )
-    router = ModelHubRuntimeRouter(service=service)
+    router = _router(service)
 
     initial = asyncio.run(router.resolve("codex", "gpt-5"))
     context = SimpleNamespace()
@@ -256,7 +273,7 @@ def test_mh_chan_001_hub_to_native_switch_keeps_failure_reason(tmp_path: Path) -
         LaunchAdapter({hub.id: "route-hub"}),
         now=lambda: datetime(2026, 7, 23, tzinfo=timezone.utc),
     )
-    router = ModelHubRuntimeRouter(service=service)
+    router = _router(service)
     initial = asyncio.run(router.resolve("codex", "gpt-5"))
     context = SimpleNamespace()
     bind_launch(context, initial)
@@ -293,7 +310,7 @@ def test_mh_chan_001_native_launch_replays_pending_revocations(tmp_path: Path) -
     )
     service.revocations.add("src_removed", "cred_removed")
 
-    launch = asyncio.run(ModelHubRuntimeRouter(service=service).resolve("codex", "gpt-5"))
+    launch = asyncio.run(_router(service).resolve("codex", "gpt-5"))
 
     assert launch.channel == "native_cli"
     assert adapter.revoked == ["cred_removed"]
@@ -329,7 +346,7 @@ def test_mh_chan_001_native_sources_only_dispatch_to_sanctioned_client(tmp_path:
         adapter,
         now=lambda: datetime(2026, 7, 23, tzinfo=timezone.utc),
     )
-    launch = asyncio.run(ModelHubRuntimeRouter(service=service).resolve("codex", "shared-model"))
+    launch = asyncio.run(_router(service).resolve("codex", "shared-model"))
     assert (launch.channel, launch.source_id) == ("hub", hub_openai.id)
 
 
@@ -341,7 +358,7 @@ def test_mh_chan_001_unconfigured_fresh_hub_preserves_native_launch(tmp_path: Pa
         now=lambda: datetime(2026, 7, 23, tzinfo=timezone.utc),
     )
 
-    launch = asyncio.run(ModelHubRuntimeRouter(service=service).resolve("codex", "gpt-5"))
+    launch = asyncio.run(_router(service).resolve("codex", "gpt-5"))
 
     assert launch.channel == "direct"
     assert service.events.list(limit=10) == []
@@ -367,7 +384,7 @@ def test_mh_chan_001_other_backend_source_does_not_activate_hub(tmp_path: Path) 
         now=lambda: datetime(2026, 7, 23, tzinfo=timezone.utc),
     )
 
-    launch = asyncio.run(ModelHubRuntimeRouter(service=service).resolve("claude", "claude-opus"))
+    launch = asyncio.run(_router(service).resolve("claude", "claude-opus"))
 
     assert launch.channel == "direct"
 
@@ -393,9 +410,111 @@ def test_mh_chan_001_configured_hub_stays_fail_closed_for_unavailable_model(tmp_
     )
 
     with pytest.raises(ModelHubError) as exc_info:
-        asyncio.run(ModelHubRuntimeRouter(service=service).resolve("codex", "unavailable-model"))
+        asyncio.run(_router(service).resolve("codex", "unavailable-model"))
 
     assert exc_info.value.code == "mapping_target_unavailable"
+
+
+def test_mh_chan_001_invalid_native_runtime_skips_to_hub(tmp_path: Path) -> None:
+    native = _source(
+        "src_native_invalid",
+        kind="subscription",
+        vendor="openai",
+        protocol="openai_responses",
+        channel="native_cli",
+        model_ids=("gpt-5",),
+    )
+    hub = _source(
+        "src_hub_fallback",
+        kind="api_key",
+        vendor="openai",
+        protocol="openai_responses",
+        channel="hub",
+        model_ids=("gpt-5",),
+    )
+    service = _service(
+        tmp_path,
+        ModelHubConfig(
+            sources=[native, hub],
+            priority_order=[native.id, hub.id],
+            agents=_agents(),
+        ),
+        LaunchAdapter({hub.id: "route-hub"}),
+        now=lambda: datetime(2026, 7, 23, tzinfo=timezone.utc),
+    )
+
+    launch = asyncio.run(
+        _router(service, native_cli_ready=lambda backend: backend != "codex").resolve(
+            "codex", "gpt-5"
+        )
+    )
+
+    assert (launch.channel, launch.source_id, launch.runtime_model) == (
+        "hub",
+        hub.id,
+        "route-hub/gpt-5",
+    )
+    assert native.state.status == "standby"
+
+
+def test_mh_chan_001_codex_native_runtime_requires_chatgpt_oauth(
+    tmp_path: Path, monkeypatch
+) -> None:
+    codex_home = tmp_path / "codex-home"
+    codex_home.mkdir()
+    auth_path = codex_home / "auth.json"
+    config_path = codex_home / "config.toml"
+    auth_path.write_text(json.dumps({"tokens": {"access_token": "fixture-token"}}))
+    config_path.write_text("")
+    monkeypatch.setenv("CODEX_HOME", str(codex_home))
+    for key in ("OPENAI_API_KEY", "OPENAI_BASE_URL", "OPENAI_API_BASE", "CODEX_API_KEY"):
+        monkeypatch.delenv(key, raising=False)
+
+    assert ModelHubRuntimeRouter._default_native_cli_ready("codex") is True
+
+    config_path.write_text(
+        'model_provider = "relay"\n\n[model_providers.relay]\nbase_url = "https://relay.invalid/v1"\n'
+    )
+    assert ModelHubRuntimeRouter._default_native_cli_ready("codex") is False
+
+    config_path.write_text("")
+    auth_path.write_text(
+        json.dumps(
+            {
+                "tokens": {"access_token": "fixture-token"},
+                "OPENAI_API_KEY": "fixture-api-key",
+            }
+        )
+    )
+    assert ModelHubRuntimeRouter._default_native_cli_ready("codex") is False
+
+
+def test_mh_chan_001_persisted_launch_identity_is_non_secret_and_restorable() -> None:
+    launch = ModelHubLaunch(
+        backend="opencode",
+        channel="hub",
+        requested_model="openai/gpt-5",
+        target_model="gpt-5",
+        runtime_model="route-openai/gpt-5",
+        source_id="src_hub_restore",
+        gateway_base_url="http://127.0.0.1:18443",
+        gateway_token="gateway-secret",
+    )
+
+    identity = persisted_launch_identity(launch)
+    assert identity == {
+        "backend": "opencode",
+        "channel": "hub",
+        "source_id": "src_hub_restore",
+        "target_model": "gpt-5",
+    }
+    restored_context = SimpleNamespace()
+    restored = bind_persisted_launch(restored_context, identity)
+
+    assert restored == launch_for_context(restored_context)
+    assert restored is not None
+    assert restored.gateway_base_url is None
+    assert restored.gateway_token is None
 
 
 def test_mh_inj_runtime_injection_never_writes_native_configs(tmp_path: Path, monkeypatch) -> None:
@@ -451,9 +570,13 @@ def test_mh_inj_runtime_injection_never_writes_native_configs(tmp_path: Path, mo
     assert codex_env == {"PATH": "/bin", "AVIBE_MODEL_HUB_TOKEN": "gateway-only-token"}
 
     direct = ModelHubLaunch("claude", "direct", "model", "model", "model")
+    native = ModelHubLaunch("claude", "native_cli", "model", "model", "model", "src_native")
     base_env = {"ANTHROPIC_API_KEY": "native-value", "PATH": "/bin"}
     assert build_claude_hub_env(base_env, direct) == base_env
     assert build_codex_hub_launch(["--legacy"], base_env, direct) == (["--legacy"], None)
+    assert claude_setting_sources_for_launch(hub_launch) == ["project", "local"]
+    assert claude_setting_sources_for_launch(direct) == ["user", "project", "local"]
+    assert claude_setting_sources_for_launch(native) == ["user", "project", "local"]
     assert CodexAgent._is_managed_provider_transition("openai", "avibe_model_hub") is True
     assert CodexAgent._is_managed_provider_transition("avibe_model_hub", "openai") is True
     assert {path: path.read_bytes() for path in native_paths} == before
@@ -505,7 +628,7 @@ def test_mh_ovl_001_identifiers_stay_stable_across_all_perturbations(tmp_path: P
         adapter,
         now=lambda: datetime(2026, 7, 23, tzinfo=timezone.utc),
     )
-    router = ModelHubRuntimeRouter(service=service, overlay_path=tmp_path / "runtime" / "opencode.json")
+    router = _router(service, overlay_path=tmp_path / "runtime" / "opencode.json")
     baseline = asyncio.run(router.prepare_opencode_overlay())
     assert baseline is not None
     stable_projection = overlay_identifier_bytes(baseline.content)
@@ -574,7 +697,7 @@ def test_mh_ovl_001_unavailable_menu_entry_does_not_block_healthy_model(tmp_path
         adapter,
         now=lambda: datetime(2026, 7, 23, tzinfo=timezone.utc),
     )
-    router = ModelHubRuntimeRouter(service=service, overlay_path=tmp_path / "overlay.json")
+    router = _router(service, overlay_path=tmp_path / "overlay.json")
 
     cooling_overlay = asyncio.run(router.prepare_opencode_overlay())
     assert cooling_overlay is not None
@@ -630,7 +753,7 @@ def test_mh_chan_001_switch_telemetry_is_isolated_per_model_route(tmp_path: Path
         LaunchAdapter({hub_a.id: "route-a", hub_b.id: "route-b"}),
         now=lambda: datetime(2026, 7, 23, tzinfo=timezone.utc),
     )
-    router = ModelHubRuntimeRouter(service=service)
+    router = _router(service)
 
     native_launch = asyncio.run(router.resolve("codex", "model-a"))
     assert asyncio.run(router.resolve("codex", "model-b")).channel == "hub"

--- a/tests/test_model_hub_injection.py
+++ b/tests/test_model_hub_injection.py
@@ -38,6 +38,7 @@ from modules.agents.model_hub import (
     opencode_model_for_overlay,
     overlay_identifier_bytes,
     persisted_launch_identity,
+    resolve_opencode_overlay_launch,
 )
 from modules.agents.codex.agent import CodexAgent
 from modules.agents.opencode.server import OpenCodeServerManager
@@ -705,6 +706,8 @@ def test_mh_ovl_001_unavailable_menu_entry_does_not_block_healthy_model(tmp_path
         "anthropic/claude-opus",
         "custom/local-model",
     ]
+    assert cooling_overlay.available_identifiers == ("custom/local-model",)
+    assert opencode_model_for_overlay(None, cooling_overlay) == "custom/local-model"
     assert opencode_model_for_overlay("custom/local-model", cooling_overlay) == "custom/local-model"
     with pytest.raises(ModelHubError):
         asyncio.run(router.resolve("opencode", "anthropic/claude-opus"))
@@ -715,6 +718,68 @@ def test_mh_ovl_001_unavailable_menu_entry_does_not_block_healthy_model(tmp_path
     assert reduced_overlay is not None
     assert reduced_overlay.checked_identifiers == ("custom/local-model",)
     assert opencode_model_for_overlay("custom/local-model", reduced_overlay) == "custom/local-model"
+
+
+def test_mh_ovl_001_turn_uses_overlay_source_snapshot(tmp_path: Path) -> None:
+    primary = _source(
+        "src_hub_snapshot_a",
+        kind="api_key",
+        vendor="anthropic",
+        protocol="anthropic",
+        channel="hub",
+        model_ids=("claude-opus",),
+    )
+    backup = _source(
+        "src_hub_snapshot_b",
+        kind="api_key",
+        vendor="anthropic",
+        protocol="anthropic",
+        channel="hub",
+        model_ids=("claude-opus",),
+    )
+    agents = _agents()
+    agents["opencode"].menu = ModelHubMenuConfig(
+        view="featured",
+        checked=["anthropic/claude-opus"],
+    )
+    config = ModelHubConfig(
+        sources=[primary, backup],
+        priority_order=[primary.id, backup.id],
+        agents=agents,
+    )
+    adapter = LaunchAdapter(
+        {
+            primary.id: "route-snapshot-a",
+            backup.id: "route-snapshot-b",
+        }
+    )
+    service = _service(
+        tmp_path,
+        config,
+        adapter,
+        now=lambda: datetime(2026, 7, 23, tzinfo=timezone.utc),
+    )
+    router = _router(service, overlay_path=tmp_path / "overlay.json")
+    overlay = asyncio.run(router.prepare_opencode_overlay())
+    assert overlay is not None
+
+    config.priority_order = [backup.id, primary.id]
+    launch = asyncio.run(
+        resolve_opencode_overlay_launch(
+            SimpleNamespace(model_hub_runtime=router),
+            "anthropic/claude-opus",
+            overlay,
+        )
+    )
+
+    assert launch.source_id == primary.id
+    assert launch.runtime_model == "route-snapshot-a/claude-opus"
+    assert asyncio.run(router.resolve("opencode", "anthropic/claude-opus")).source_id == backup.id
+    context = SimpleNamespace()
+    bind_launch(context, launch)
+    assert asyncio.run(router.record_native_failure(context, "429 rate limit")) is True
+    assert primary.state.status == "cooldown"
+    assert backup.state.status == "standby"
 
 
 def test_mh_chan_001_switch_telemetry_is_isolated_per_model_route(tmp_path: Path) -> None:
@@ -1016,6 +1081,54 @@ def test_mh_inj_codex_runtime_change_interrupts_current_session_first() -> None:
             "turn/interrupt",
             {"threadId": "thread-current", "turnId": "turn-current"},
         )
+        assert active["turn"] is None
+        agent._remove_ack_reaction.assert_awaited_once_with(interrupted_request)
+        agent._event_handler._release_stream_turn.assert_called_once_with(interrupted_request.context)
+
+    asyncio.run(exercise())
+
+
+def test_mh_inj_codex_runtime_change_replaces_transport_when_interrupt_fails() -> None:
+    async def exercise() -> None:
+        agent = object.__new__(CodexAgent)
+        active = {"turn": "turn-current"}
+        transport = SimpleNamespace(
+            is_initialized=True,
+            runtime_fingerprint="direct",
+            send_request=AsyncMock(side_effect=ConnectionError("transport closed")),
+        )
+        interrupted_request = SimpleNamespace(context=object())
+
+        def clear_pending(turn_id: str):
+            assert turn_id == "turn-current"
+            active["turn"] = None
+            return interrupted_request
+
+        agent._transports = {"/work": transport}
+        agent._session_mgr = SimpleNamespace(get_thread_id=Mock(return_value="thread-current"))
+        agent._turn_registry = SimpleNamespace(get_active_turn=lambda _base: active["turn"])
+        agent._event_handler = SimpleNamespace(
+            clear_pending=Mock(side_effect=clear_pending),
+            _release_stream_turn=Mock(),
+        )
+        agent._remove_ack_reaction = AsyncMock()
+        request = SimpleNamespace(
+            working_path="/work",
+            base_session_id="session-current",
+        )
+        launch = ModelHubLaunch(
+            "codex",
+            "hub",
+            "gpt-5",
+            "gpt-5",
+            "route/gpt-5",
+            "src_hub",
+            "http://127.0.0.1:18443",
+            "token",
+        )
+
+        await agent._interrupt_active_turn_before_runtime_change(request, launch)
+
         assert active["turn"] is None
         agent._remove_ack_reaction.assert_awaited_once_with(interrupted_request)
         agent._event_handler._release_stream_turn.assert_called_once_with(interrupted_request.context)

--- a/tests/test_multi_platform_runtime.py
+++ b/tests/test_multi_platform_runtime.py
@@ -1438,6 +1438,7 @@ def test_opencode_poll_notifies_and_settles_on_retry_exhaustion():
     # failed settlement, then suppresses the idle "(No response from OpenCode)"
     # result that would overwrite the terminal state.
     emitted = []
+    model_hub_failures = []
 
     class _AuthSvc:
         async def maybe_emit_auth_recovery_message(
@@ -1483,6 +1484,10 @@ def test_opencode_poll_notifies_and_settles_on_retry_exhaustion():
         def _extract_response_text(self, message):
             return ""
 
+        async def record_model_hub_native_failure(self, context, diagnostic):
+            model_hub_failures.append((context, diagnostic))
+            return True
+
     class _Server:
         async def list_messages(self, session_id, directory):
             return [
@@ -1526,6 +1531,7 @@ def test_opencode_poll_notifies_and_settles_on_retry_exhaustion():
     assert [item[0] for item in emitted] == ["notify", "result"]
     assert emitted[0][1] == "OpenCode error: ProviderError - rate limited"
     assert emitted[1][1:] == ("", True, "silent", "ProviderError - rate limited")
+    assert model_hub_failures == [(request.context, "ProviderError - rate limited")]
 
 
 def test_opencode_poll_keeps_explicit_empty_completion_on_success_path():

--- a/tests/test_multi_platform_runtime.py
+++ b/tests/test_multi_platform_runtime.py
@@ -16,6 +16,7 @@ from config.v2_sessions import ActivePollInfo
 from core.message_dispatcher import ConsolidatedMessageDispatcher
 from core.processing_indicator import ProcessingIndicatorService
 from modules.agents.base import AgentRequest
+from modules.agents.model_hub import launch_for_context
 from modules.agents.service import AgentService
 from modules.agents.opencode.agent import OpenCodeAgent
 from modules.agents.opencode.poll_loop import OpenCodePollLoop
@@ -1786,6 +1787,116 @@ def test_opencode_restored_poll_keeps_empty_completion_successful():
     assert results[0][0] == "(No response from OpenCode)"
     assert results[0][1]["subtype"] == "warning"
     assert isinstance(results[0][1]["started_at"], float)
+
+
+def test_mh_chan_001_opencode_restored_poll_records_source_failure():
+    emitted = []
+    removed = []
+    model_hub_failures = []
+
+    class _AuthSvc:
+        async def maybe_emit_auth_recovery_message(
+            self, context, backend, message, *, output=None, terminal_error=None
+        ):
+            return False
+
+    class _Controller:
+        agent_auth_service = _AuthSvc()
+
+        def __init__(self):
+            self.config = type(
+                "Config", (), {"platform": "slack", "ack_mode": "reaction", "language": "en"}
+            )()
+            self.processing_indicator = ProcessingIndicatorService(self)
+
+        async def emit_agent_message(
+            self,
+            context,
+            message_type,
+            text,
+            parse_mode=None,
+            *,
+            is_error=False,
+            level="normal",
+            output=None,
+            terminal_error=None,
+        ):
+            emitted.append((message_type, text, is_error, level, terminal_error))
+
+    class _Sessions:
+        def remove_active_poll(self, session_id):
+            removed.append(session_id)
+
+        def update_active_poll_state(self, *args, **kwargs):
+            return None
+
+    class _Server:
+        async def list_messages(self, session_id, directory):
+            return [
+                {
+                    "info": {
+                        "id": "msg-restored-error",
+                        "role": "assistant",
+                        "time": {"completed": 1},
+                        "error": {"name": "ProviderError", "data": {"message": "quota exceeded"}},
+                    },
+                    "parts": [],
+                }
+            ]
+
+    server = _Server()
+
+    class _Agent:
+        opencode_config = type("OpenCodeConfig", (), {"error_retry_limit": 0})()
+        controller = _Controller()
+        sessions = _Sessions()
+
+        async def _get_server(self):
+            return server
+
+        def _extract_response_text(self, message):
+            return ""
+
+        def _to_relative_path(self, path, working_path):
+            return path
+
+        async def _remove_ack_reaction(self, request):
+            return None
+
+        async def record_model_hub_native_failure(self, context, diagnostic):
+            launch = launch_for_context(context)
+            model_hub_failures.append(
+                (launch.channel if launch else None, launch.source_id if launch else None, diagnostic)
+            )
+            return True
+
+    poll = ActivePollInfo(
+        opencode_session_id="oc-restored-error",
+        base_session_id="base",
+        channel_id="c",
+        thread_id="t",
+        settings_key="c",
+        working_path="/tmp/work",
+        baseline_message_ids=[],
+        platform="slack",
+        processing_indicator={
+            "platform": "slack",
+            "user_id": "u",
+            "channel_id": "c",
+            "model_hub_launch": {
+                "backend": "opencode",
+                "channel": "hub",
+                "source_id": "src_hub_restore",
+                "target_model": "gpt-5",
+            },
+        },
+    )
+
+    asyncio.run(OpenCodePollLoop(_Agent()).run_restored_poll_loop(poll))
+
+    assert model_hub_failures == [("hub", "src_hub_restore", "ProviderError - quota exceeded")]
+    assert removed == ["oc-restored-error"]
+    assert [item[0] for item in emitted] == ["notify", "notify", "result"]
 
 
 def test_processing_indicator_handle_is_source_of_truth_for_backend_cleanup():


### PR DESCRIPTION
## Capability

Adds Model Hub backend launch integration for per-turn native subscription dispatch and runtime-only Hub injection across Claude Code, Codex, and OpenCode.

- healthy sanctioned `native_cli` sources launch their native backend with zero Hub injection
- quota/rate-limit terminal failures enter the existing cooldown policy; the next turn falls back to Hub and recovery switches back on a later turn
- Claude uses process environment injection, Codex uses app-server `-c` overrides, and OpenCode uses a deterministic `OPENCODE_CONFIG` overlay with hash-aware drain/restart
- Direct mode retains the existing launch/config paths; Hub mode never writes native backend configuration

Depends on merged foundations #962, #963, and #966. This PR consumes those contracts/runtime components without modifying them.

## Scenarios

- `MH-CHAN-001`
- `MH-INJ-CLAUDE-001`
- `MH-INJ-CODEX-001`
- `MH-INJ-OPENCODE-001`
- `MH-INJ-DIRECT-001`
- `MH-OC-001`
- `MH-OVL-001`

## Core integration points

- `core/controller.py`: instantiate one controller-owned runtime router so all backend launches share cooldown and channel-switch state.
- `core/handlers/session_handler.py`: resolve and bind Claude's per-turn launch plan, recreate cached SDK clients when the effective channel changes, and apply Hub env only at process creation.

## Evidence

- **Unit:** focused Model Hub injection/poll tests: 29 passed; related shared launch-path suites: 239 passed.
- **Contract:** existing Model Hub service classification, source eligibility, events, and engine adapter contracts are consumed unchanged; `ruff check .` passes.
- **Scenario:** catalog entries above cover healthy/exhausted/recovery dispatch, sanctioned native origins, three injection forms, direct-mode no-op behavior, overlay hash restart, and byte-stable visible identifiers across all required perturbations.
- **CI group:** `scripts/ci_unit_tests.sh 0 1` ran all 248 unit-test files, one process each; all passed.
- **Residual manual checks:** no real user home or running Avibe service was touched. A live native subscription/gateway smoke remains for the final integration lane; all launch tests used isolated fixtures and temporary HOME/config paths.

## Residual risk

The frozen engine adapter contract does not expose its generated source prefix, so the injection router first accepts an optional adapter accessor and otherwise reads the concrete merged runtime adapter's state-store record. This is isolated in one helper and should become a formal adapter method in a future contract revision.
