### PR TITLE
fix(agents): window-scope trigger chips (A10) + dim disabled chips

### DIFF
--- a/core/services/agent_graph.py
+++ b/core/services/agent_graph.py
@@ -276,7 +276,7 @@ def build_graph(
                 for row in _load_sessions(conn, extra):
                     session_by_id.setdefault(row["id"], row)
             session_rows = list(session_by_id.values())
-            edges, trigger_ids = _build_edges(runs_by_session, loaded_ids)
+            edges, trigger_ids = _build_edges(runs_by_session, loaded_ids, cutoff)
             trigger_nodes = _load_trigger_nodes(conn, trigger_ids)
     finally:
         if owned_engine:
@@ -461,8 +461,16 @@ def _lineage_refs(runs_by_session: dict[str, list[dict[str, Any]]]) -> set[str]:
 def _build_edges(
     runs_by_session: dict[str, list[dict[str, Any]]],
     candidate_ids: set[str],
+    cutoff: datetime,
 ) -> tuple[list[dict[str, Any]], set[str]]:
-    """Aggregate spawn / callback / trigger edges from the candidate runs."""
+    """Aggregate spawn / callback / trigger edges from the candidate runs.
+
+    Trigger edges are window-scoped (contract A10): a candidate session can carry
+    OLD trigger runs (it stays in scope via other in-window activity or lineage),
+    but a definition only earns a ``trigger`` edge — and thus a chip — from a run
+    that fired within the window. Spawn/callback stay full-lineage so an older
+    delegation's endpoints survive.
+    """
     spawn: dict[tuple[str, str], dict[str, Any]] = {}
     callback: dict[tuple[str, str], dict[str, Any]] = {}
     trigger: dict[tuple[str, str], dict[str, Any]] = {}
@@ -515,8 +523,18 @@ def _build_edges(
                     agg["last_at"] = created
                     agg["last_run_id"] = run.get("callback_run_id") or run.get("id")
                     agg["status"] = run.get("callback_status")
-            # trigger: definition → this session
-            if run.get("run_type") in _TRIGGER_RUN_TYPES and run.get("definition_id"):
+            # trigger: definition → this session. A10: only an IN-WINDOW trigger
+            # run earns a chip. A candidate session can carry old trigger runs (it
+            # stays in scope via other in-window activity or lineage); a historical
+            # or since-disabled definition must not resurface just because its old
+            # session lingers.
+            run_at = _parse_iso(created)
+            if (
+                run.get("run_type") in _TRIGGER_RUN_TYPES
+                and run.get("definition_id")
+                and run_at is not None
+                and run_at >= cutoff
+            ):
                 definition_id = run["definition_id"]
                 trigger_ids.add(definition_id)
                 key = (definition_id, session_id)

--- a/tests/test_agent_graph_service.py
+++ b/tests/test_agent_graph_service.py
@@ -787,3 +787,86 @@ def test_liveness_elapsed_from_winning_state_row():
     ])
     assert indexed["s"]["state"] == "active"
     assert indexed["s"]["elapsed_seconds"] == 42.0
+
+
+# ── A10: trigger chips are edge-derived (only definitions that fired in-window) ──
+
+
+@pytest.fixture()
+def a10_seeded(isolated_state):
+    """Four definitions to probe A10: enabled-with-run, enabled-idle,
+    disabled-no-run, disabled-with-in-window-run."""
+    engine = create_sqlite_engine()
+    with engine.begin() as conn:
+        _insert_scope(conn)
+        _insert_session(conn, "ses_run", scope_id=PROJECT_SCOPE, backend="claude", title="fired")
+        _insert_session(conn, "ses_dr", scope_id=PROJECT_SCOPE, backend="claude", title="disabled-fired")
+        _insert_definition(conn, "def_run", name="Enabled fired", cron="0 9 * * *", enabled=1)
+        _insert_definition(conn, "def_idle", name="Enabled idle", cron="0 9 * * *", enabled=1)
+        _insert_definition(conn, "def_dis_norun", name="Disabled idle", cron="0 9 * * *", enabled=0)
+        _insert_definition(conn, "def_dis_run", name="Disabled fired", cron="0 9 * * *", enabled=0)
+        _insert_run(conn, "run_dr_enabled", session_id="ses_run", run_type="scheduled",
+                    definition_id="def_run", created=NOW - timedelta(hours=2))
+        _insert_run(conn, "run_dr_disabled", session_id="ses_dr", run_type="scheduled",
+                    definition_id="def_dis_run", created=NOW - timedelta(hours=2))
+    return engine
+
+
+def _triggers_by_id(payload):
+    return {t["definition_id"]: t for t in payload["trigger_nodes"]}
+
+
+def test_a10_enabled_but_idle_definition_has_no_chip(a10_seeded):
+    triggers = _triggers_by_id(agent_graph.build_graph(live_agents=[], now=NOW, engine=a10_seeded, window="24h"))
+    assert "def_idle" not in triggers  # enabled but never triggered a session in-window
+
+
+def test_a10_disabled_definition_without_runs_has_no_chip(a10_seeded):
+    triggers = _triggers_by_id(agent_graph.build_graph(live_agents=[], now=NOW, engine=a10_seeded, window="24h"))
+    assert "def_dis_norun" not in triggers
+
+
+def test_a10_disabled_definition_that_fired_in_window_keeps_a_dimmable_chip(a10_seeded):
+    triggers = _triggers_by_id(agent_graph.build_graph(live_agents=[], now=NOW, engine=a10_seeded, window="24h"))
+    # It explains lineage, so the chip stays — flagged disabled for the client to dim.
+    assert "def_dis_run" in triggers
+    assert triggers["def_dis_run"]["enabled"] is False
+    # positive control: an enabled definition that fired is present and enabled.
+    assert triggers["def_run"]["enabled"] is True
+
+
+def test_a10_session_with_only_out_of_window_runs_has_no_chip(isolated_state):
+    """A session whose only run is outside the window is not a candidate, so its
+    (disabled) definition earns no chip — A10 ①."""
+    engine = create_sqlite_engine()
+    with engine.begin() as conn:
+        _insert_scope(conn)
+        # recent activity → session is an in-window candidate…
+        _insert_session(conn, "ses_hist", scope_id=PROJECT_SCOPE, backend="claude", title="long-lived",
+                        created=NOW - timedelta(days=3), last_active=NOW - timedelta(minutes=30))
+        _insert_definition(conn, "def_hist", name="Historical watch", definition_type="watch", enabled=0)
+        # …but its trigger run is 3 days old (out of the 24h window)
+        _insert_run(conn, "run_hist", session_id="ses_hist", run_type="watch",
+                    definition_id="def_hist", created=NOW - timedelta(days=3))
+    triggers = _triggers_by_id(agent_graph.build_graph(live_agents=[], now=NOW, engine=engine, window="24h"))
+    assert "def_hist" not in triggers, "out-of-window trigger run must NOT yield a chip (A10)"
+
+
+def test_a10_in_window_session_with_old_trigger_run_has_no_chip(isolated_state):
+    """The core A10 guard: a session stays in scope via an in-window agent run,
+    but its only trigger run is out-of-window — the definition triggered nothing
+    within the window, so no chip (this was the owner-reported explosion:
+    disabled/historical watch+task chips lingering on still-active sessions)."""
+    engine = create_sqlite_engine()
+    with engine.begin() as conn:
+        _insert_scope(conn)
+        _insert_session(conn, "ses_mix", scope_id=PROJECT_SCOPE, backend="claude", title="mixed")
+        _insert_definition(conn, "def_mix", name="Old watch", definition_type="watch", enabled=0)
+        # in-window agent run → ses_mix is a candidate
+        _insert_run(conn, "run_recent", session_id="ses_mix", status="succeeded",
+                    created=NOW - timedelta(hours=1))
+        # out-of-window trigger run from the disabled def
+        _insert_run(conn, "run_oldtrig", session_id="ses_mix", run_type="watch",
+                    definition_id="def_mix", created=NOW - timedelta(days=3))
+    triggers = _triggers_by_id(agent_graph.build_graph(live_agents=[], now=NOW, engine=engine, window="24h"))
+    assert "def_mix" not in triggers, "out-of-window trigger run on a candidate session must NOT chip (A10)"

--- a/ui/src/components/workbench/AgentGraphMobileList.tsx
+++ b/ui/src/components/workbench/AgentGraphMobileList.tsx
@@ -45,9 +45,14 @@ export const AgentGraphMobileList: React.FC<AgentGraphMobileListProps> = ({
             </span>
           )}
           {trigger && (
-            <span className="inline-flex w-fit items-center gap-1 rounded-md border border-violet/40 bg-violet-soft px-1.5 py-0.5 text-[10px] font-medium text-violet">
+            <span
+              className={`inline-flex w-fit items-center gap-1 rounded-md border border-violet/40 bg-violet-soft px-1.5 py-0.5 text-[10px] font-medium text-violet${
+                trigger.enabled ? '' : ' opacity-60'
+              }`}
+            >
               {trigger.definition_type === 'watch' ? <Eye className="size-2.5" /> : <CalendarClock className="size-2.5" />}
               {trigger.name ?? trigger.definition_id}
+              {!trigger.enabled && <span className="text-muted"> · {t('agents.graph.trigger.disabled')}</span>}
             </span>
           )}
           <div className="h-[92px]">

--- a/ui/src/components/workbench/AgentGraphTriggerChip.tsx
+++ b/ui/src/components/workbench/AgentGraphTriggerChip.tsx
@@ -25,6 +25,11 @@ export const AgentGraphTriggerChip: React.FC<AgentGraphTriggerChipProps> = ({
   const Icon = isWatch ? Eye : CalendarClock;
   const kindLabel = isWatch ? t('agents.graph.trigger.watch') : t('agents.graph.trigger.task');
   const name = trigger.name?.trim() || trigger.definition_id;
+  // A10: a disabled definition keeps its chip only because it fired in-window
+  // (it explains lineage) — dim it and tag it so it reads as historical. The
+  // interaction fade (hover de-emphasis) takes precedence so exactly one opacity
+  // applies.
+  const disabled = !trigger.enabled;
 
   return (
     <button
@@ -33,7 +38,7 @@ export const AgentGraphTriggerChip: React.FC<AgentGraphTriggerChipProps> = ({
       title={name}
       className={clsx(
         'flex h-full w-full items-center gap-2 rounded-xl border border-violet/40 bg-violet-soft px-3 py-2 text-left transition hover:brightness-110',
-        faded && 'opacity-25',
+        faded ? 'opacity-25' : disabled && 'opacity-60',
         className,
       )}
     >
@@ -44,6 +49,7 @@ export const AgentGraphTriggerChip: React.FC<AgentGraphTriggerChipProps> = ({
         <span className="truncate text-[12px] font-semibold text-foreground">{name}</span>
         <span className="truncate font-mono text-[10px] uppercase tracking-wide text-violet">
           {kindLabel}
+          {disabled && <span className="text-muted"> · {t('agents.graph.trigger.disabled')}</span>}
           {trigger.schedule_label && <span className="text-muted"> · {trigger.schedule_label}</span>}
         </span>
       </div>

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -2135,7 +2135,8 @@
       },
       "trigger": {
         "task": "Task",
-        "watch": "Watch"
+        "watch": "Watch",
+        "disabled": "Disabled"
       },
       "legend": {
         "spawn": "Spawn",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -2135,7 +2135,8 @@
       },
       "trigger": {
         "task": "TASK",
-        "watch": "WATCH"
+        "watch": "WATCH",
+        "disabled": "已禁用"
       },
       "legend": {
         "spawn": "启动",


### PR DESCRIPTION
## Capability

Owner feedback: the run graph rendered a trigger chip for **every** Harness
definition (including disabled/historical watch+task), exploding for users with
many definitions. Fix per contract **A10**: trigger chips are **edge-derived AND
window-scoped** — a definition earns a chip only if it actually triggered a session
**within the window**.

## Root cause + backend fix (`core/services/agent_graph.py`)

`_build_edges` counted trigger runs regardless of the window cutoff. A session
stays in scope via any in-window activity (or lineage), and `_load_runs` is
full-lineage, so an **old** trigger run on a still-retained session produced a
`trigger` edge → chip — even though the definition never fired in-window.

Now `_build_edges` counts a trigger run only when `created_at >= cutoff`. So:
- enabled-but-idle → no chip; disabled-with-no-in-window-run → no chip;
- a disabled definition that **did** fire in-window keeps its chip (it explains
  lineage) with `enabled=false`.
- Spawn/callback edges stay full-lineage (unchanged) so older delegations' endpoints survive.

## Frontend

An `enabled=false` trigger chip is **dimmed** (distinct from the interaction fade)
and tagged **"Disabled" / "已禁用"** (i18n en/zh), on both the desktop canvas chip
(`AgentGraphTriggerChip`) and the mobile list pill (`AgentGraphMobileList`).

## Scope

`agent_graph.py` + its tests + the graph chip components + i18n. Storage/CLI
untouched. The A10 contract entry (`docs/plans/agents-run-graph-contract.md`) is
orchestrator-maintained.

## Evidence

- **Unit** — 6 service tests (`test_agent_graph_service.py`): enabled-idle→no chip;
  disabled-no-run→no chip; disabled-in-window-run→chip `enabled=false` (+ enabled
  control); out-of-window-only session→no chip; **in-window session with an
  out-of-window trigger run→no chip** (the reported explosion). `pytest` **44
  passed**; full `vitest` **387 passed**.
- **Build/lint** — `npm run build` ✓, `ruff` clean, frontend eslint clean.
- **Contract** — implements A10 (edge-derived + window-scoped trigger chips).
  Scenario: none affected.
- **Residual manual** — graph with a since-disabled task that fired in-window shows
  one dimmed "Disabled" chip; enabled-idle / disabled-idle definitions show none.
