### PR TITLE
fix(ui): distinguish queued agent runs from running in background banner

### DIFF
--- a/ui/src/components/workbench/ChatPage.tsx
+++ b/ui/src/components/workbench/ChatPage.tsx
@@ -2126,10 +2126,12 @@ const ActivityStrip: React.FC<{
   const firstLabel = first
     ? resolveActivityLabel(first, t(`chat.activities.kind.${activityKindI18nKey(first)}`))
     : '';
-  // Sorting puts in-progress items first, so a queued run in the headline slot
-  // means nothing is actively executing — drop the running glow (idle tone,
-  // muted icon, no mint shadow) so a waiting message can't look like live work.
-  const firstQueued = first ? isQueuedRun(first) : false;
+  // Mute the pill only when the banner consists SOLELY of queued delegated
+  // runs — a waiting message must not glow like live work. Any running item,
+  // watch, or task in the union keeps today's active treatment (pending items
+  // tie on rank and order by time, so checking only the headline row would
+  // mute a banner that still contains an enabled watch or scheduled task).
+  const queuedOnly = active.length > 0 && active.every(isQueuedRun);
   const expandable = active.length > 0;
   const navigateTo = (path: string) => {
     setOpen(false);
@@ -2138,18 +2140,18 @@ const ActivityStrip: React.FC<{
 
   const pill = (
     <StatusPill
-      tone={firstQueued ? 'idle' : 'running'}
+      tone={queuedOnly ? 'idle' : 'running'}
       role="status"
       aria-live="polite"
       className={clsx(
         'min-h-7 min-w-0 max-w-full gap-2 px-3 py-1 text-[11px] font-normal',
-        !firstQueued && 'shadow-sm shadow-mint/5',
+        !queuedOnly && 'shadow-sm shadow-mint/5',
         expandable && 'cursor-pointer select-none',
       )}
       indicator={
         active.length > 0 ? (
           <Activity
-            className={clsx('size-3.5 shrink-0', firstQueued ? 'text-muted' : 'text-mint')}
+            className={clsx('size-3.5 shrink-0', queuedOnly ? 'text-muted' : 'text-mint')}
             aria-hidden="true"
           />
         ) : (

--- a/ui/src/components/workbench/ChatPage.tsx
+++ b/ui/src/components/workbench/ChatPage.tsx
@@ -21,6 +21,7 @@ import {
   activityItemKind,
   activityKindI18nKey,
   harnessNavPath,
+  isQueuedRun,
   resolveActivityLabel,
   sortBackgroundActivities,
 } from '../../lib/backgroundActivity';
@@ -2054,6 +2055,9 @@ const ActivityRow: React.FC<{
   const label = resolveActivityLabel(item, kindLabel);
   const relative = formatRelativeTime(item.since ?? item.started_at, t);
   const isHarness = kind !== 'backend_activity';
+  // A queued delegated run is waiting, not executing — mute its icon box so it
+  // cannot read as in-progress (its kind label already says "Queued message").
+  const queued = isQueuedRun(item);
   const subtitle =
     kind === 'backend_activity' && item.backend ? `${item.backend} · ${relative}` : relative;
   const body = (
@@ -2061,7 +2065,7 @@ const ActivityRow: React.FC<{
       <span
         className={clsx(
           'flex size-8 shrink-0 items-center justify-center rounded-lg',
-          ACTIVITY_ITEM_TINT[kind],
+          queued ? 'bg-surface-2 text-muted' : ACTIVITY_ITEM_TINT[kind],
         )}
       >
         <Icon className="size-4" aria-hidden="true" />
@@ -2122,6 +2126,10 @@ const ActivityStrip: React.FC<{
   const firstLabel = first
     ? resolveActivityLabel(first, t(`chat.activities.kind.${activityKindI18nKey(first)}`))
     : '';
+  // Sorting puts in-progress items first, so a queued run in the headline slot
+  // means nothing is actively executing — drop the running glow (idle tone,
+  // muted icon, no mint shadow) so a waiting message can't look like live work.
+  const firstQueued = first ? isQueuedRun(first) : false;
   const expandable = active.length > 0;
   const navigateTo = (path: string) => {
     setOpen(false);
@@ -2130,16 +2138,20 @@ const ActivityStrip: React.FC<{
 
   const pill = (
     <StatusPill
-      tone="running"
+      tone={firstQueued ? 'idle' : 'running'}
       role="status"
       aria-live="polite"
       className={clsx(
-        'min-h-7 min-w-0 max-w-full gap-2 px-3 py-1 text-[11px] font-normal shadow-sm shadow-mint/5',
+        'min-h-7 min-w-0 max-w-full gap-2 px-3 py-1 text-[11px] font-normal',
+        !firstQueued && 'shadow-sm shadow-mint/5',
         expandable && 'cursor-pointer select-none',
       )}
       indicator={
         active.length > 0 ? (
-          <Activity className="size-3.5 shrink-0 text-mint" aria-hidden="true" />
+          <Activity
+            className={clsx('size-3.5 shrink-0', firstQueued ? 'text-muted' : 'text-mint')}
+            aria-hidden="true"
+          />
         ) : (
           <Loader2 className="size-3.5 shrink-0 animate-spin text-mint" aria-hidden="true" />
         )

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -2736,7 +2736,8 @@
         "task": "Task",
         "taskOneShot": "One-time",
         "taskRecurring": "Recurring",
-        "agentRun": "Agent run"
+        "agentRun": "Agent run",
+        "agentRunQueued": "Queued message"
       }
     },
     "agentActivity": {

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -2736,7 +2736,8 @@
         "task": "任务",
         "taskOneShot": "一次性",
         "taskRecurring": "周期性",
-        "agentRun": "Agent 运行"
+        "agentRun": "Agent 运行",
+        "agentRunQueued": "排队消息"
       }
     },
     "agentActivity": {

--- a/ui/src/lib/backgroundActivity.test.ts
+++ b/ui/src/lib/backgroundActivity.test.ts
@@ -7,6 +7,7 @@ import {
   harnessItemNativeId,
   harnessNavPath,
   isHarnessActivity,
+  isQueuedRun,
   resolveActivityLabel,
   sortBackgroundActivities,
 } from './backgroundActivity';
@@ -46,17 +47,48 @@ describe('activityItemKind', () => {
 
 describe('activityKindI18nKey', () => {
   it('classifies one-shot and recurring tasks from schedule_type', () => {
-    expect(activityKindI18nKey({ item_kind: 'task', schedule_type: 'at' })).toBe('taskOneShot');
-    expect(activityKindI18nKey({ item_kind: 'task', schedule_type: 'cron' })).toBe(
+    expect(activityKindI18nKey(item({ item_kind: 'task', schedule_type: 'at' }))).toBe(
+      'taskOneShot',
+    );
+    expect(activityKindI18nKey(item({ item_kind: 'task', schedule_type: 'cron' }))).toBe(
       'taskRecurring',
     );
   });
 
   it('does not infer recurrence from labels or other activity kinds', () => {
-    expect(activityKindI18nKey({ item_kind: 'task', schedule_type: null })).toBe('task');
-    expect(activityKindI18nKey({ item_kind: 'watch' })).toBe('watch');
-    expect(activityKindI18nKey({ item_kind: 'agent_run' })).toBe('agentRun');
-    expect(activityKindI18nKey({ item_kind: 'backend_activity' })).toBe('backendActivity');
+    expect(activityKindI18nKey(item({ item_kind: 'task', schedule_type: null }))).toBe('task');
+    expect(activityKindI18nKey(item({ item_kind: 'watch', status: 'enabled' }))).toBe('watch');
+    expect(activityKindI18nKey(item({ item_kind: 'agent_run' }))).toBe('agentRun');
+    expect(activityKindI18nKey(item({ item_kind: 'backend_activity' }))).toBe('backendActivity');
+  });
+
+  it('maps a queued delegated run to its own key, not "agentRun"', () => {
+    expect(activityKindI18nKey(item({ item_kind: 'agent_run', status: 'queued' }))).toBe(
+      'agentRunQueued',
+    );
+    // Executing forms keep the plain kind key.
+    expect(activityKindI18nKey(item({ item_kind: 'agent_run', status: 'running' }))).toBe(
+      'agentRun',
+    );
+    expect(activityKindI18nKey(item({ item_kind: 'agent_run', status: 'processing' }))).toBe(
+      'agentRun',
+    );
+  });
+
+  it('leaves non-run kinds untouched by a queued-looking status', () => {
+    expect(activityKindI18nKey(item({ item_kind: 'watch', status: 'queued' }))).toBe('watch');
+    expect(activityKindI18nKey(item({ item_kind: 'task', status: 'queued' }))).toBe('task');
+    expect(activityKindI18nKey(item({ status: 'queued' }))).toBe('backendActivity');
+  });
+});
+
+describe('isQueuedRun', () => {
+  it('is true only for a delegated run with status "queued"', () => {
+    expect(isQueuedRun(item({ item_kind: 'agent_run', status: 'queued' }))).toBe(true);
+    expect(isQueuedRun(item({ item_kind: 'agent_run', status: 'running' }))).toBe(false);
+    expect(isQueuedRun(item({ item_kind: 'agent_run', status: 'processing' }))).toBe(false);
+    expect(isQueuedRun(item({ item_kind: 'watch', status: 'queued' }))).toBe(false);
+    expect(isQueuedRun(item({ status: 'queued' }))).toBe(false);
   });
 });
 

--- a/ui/src/lib/backgroundActivity.test.ts
+++ b/ui/src/lib/backgroundActivity.test.ts
@@ -66,6 +66,11 @@ describe('activityKindI18nKey', () => {
     expect(activityKindI18nKey(item({ item_kind: 'agent_run', status: 'queued' }))).toBe(
       'agentRunQueued',
     );
+    // The raw/legacy alias the durable store may still carry (normalized to
+    // public "queued" by storage/background.RUN_STATUS_ALIASES).
+    expect(activityKindI18nKey(item({ item_kind: 'agent_run', status: 'pending' }))).toBe(
+      'agentRunQueued',
+    );
     // Executing forms keep the plain kind key.
     expect(activityKindI18nKey(item({ item_kind: 'agent_run', status: 'running' }))).toBe(
       'agentRun',
@@ -83,8 +88,10 @@ describe('activityKindI18nKey', () => {
 });
 
 describe('isQueuedRun', () => {
-  it('is true only for a delegated run with status "queued"', () => {
+  it('is true only for a delegated run with a waiting status', () => {
     expect(isQueuedRun(item({ item_kind: 'agent_run', status: 'queued' }))).toBe(true);
+    // Raw/legacy alias of "queued" (storage/background.RUN_STATUS_ALIASES).
+    expect(isQueuedRun(item({ item_kind: 'agent_run', status: 'pending' }))).toBe(true);
     expect(isQueuedRun(item({ item_kind: 'agent_run', status: 'running' }))).toBe(false);
     expect(isQueuedRun(item({ item_kind: 'agent_run', status: 'processing' }))).toBe(false);
     expect(isQueuedRun(item({ item_kind: 'watch', status: 'queued' }))).toBe(false);

--- a/ui/src/lib/backgroundActivity.ts
+++ b/ui/src/lib/backgroundActivity.ts
@@ -15,11 +15,22 @@ export function activityItemKind(
   return kind && HARNESS_ITEM_KINDS.includes(kind) ? kind : 'backend_activity';
 }
 
+// A delegated run that is waiting behind the target session's active turn.
+// Only agent runs carry ``queued``; watches/tasks have their own pending
+// statuses (``enabled`` / ``scheduled``) and keep their kind labels.
+export function isQueuedRun(
+  item: Pick<SessionActivityState, 'item_kind' | 'status'>,
+): boolean {
+  return activityItemKind(item) === 'agent_run' && item.status === 'queued';
+}
+
 // Task recurrence is an explicit durable field (`at` / `cron`). Keep this
 // mapping independent of task names so display text can never misclassify a
-// user-authored label that happens to mention scheduling words.
+// user-authored label that happens to mention scheduling words. A queued
+// delegated run maps to its own key ("Queued message") — labeling it "Agent
+// run" reads as still-executing and misled users about unfinished work.
 export function activityKindI18nKey(
-  item: Pick<SessionActivityState, 'item_kind' | 'schedule_type'>,
+  item: Pick<SessionActivityState, 'item_kind' | 'schedule_type' | 'status'>,
 ): string {
   const kind = activityItemKind(item);
   if (kind === 'task') {
@@ -27,7 +38,7 @@ export function activityKindI18nKey(
     if (item.schedule_type === 'cron') return 'taskRecurring';
   }
   if (kind === 'backend_activity') return 'backendActivity';
-  if (kind === 'agent_run') return 'agentRun';
+  if (kind === 'agent_run') return isQueuedRun(item) ? 'agentRunQueued' : 'agentRun';
   return kind;
 }
 

--- a/ui/src/lib/backgroundActivity.ts
+++ b/ui/src/lib/backgroundActivity.ts
@@ -15,13 +15,19 @@ export function activityItemKind(
   return kind && HARNESS_ITEM_KINDS.includes(kind) ? kind : 'backend_activity';
 }
 
+// Waiting-run statuses. ``queued`` is the normalized public form; ``pending``
+// is the raw/legacy alias the durable store may still carry (see
+// storage/background.RUN_STATUS_ALIASES) — same parity rule as
+// RUNNING_STATUSES below, or an aliased row would keep the running treatment.
+const QUEUED_RUN_STATUSES = new Set(['queued', 'pending']);
+
 // A delegated run that is waiting behind the target session's active turn.
-// Only agent runs carry ``queued``; watches/tasks have their own pending
-// statuses (``enabled`` / ``scheduled``) and keep their kind labels.
+// Only agent runs carry ``queued``/``pending``; watches/tasks have their own
+// pending statuses (``enabled`` / ``scheduled``) and keep their kind labels.
 export function isQueuedRun(
   item: Pick<SessionActivityState, 'item_kind' | 'status'>,
 ): boolean {
-  return activityItemKind(item) === 'agent_run' && item.status === 'queued';
+  return activityItemKind(item) === 'agent_run' && QUEUED_RUN_STATUSES.has(item.status);
 }
 
 // Task recurrence is an explicit durable field (`at` / `cron`). Keep this


### PR DESCRIPTION
## Capability

Workbench background-work banner (ActivityStrip + popover): a **queued** delegated agent run (`status=queued`) is now visually and textually distinct from a running one. Previously both rendered as 「Agent 运行」/"Agent run" with the running mint treatment, misleading users into thinking an old task was still executing (owner hit this directly).

- **Popover row**: queued runs read **「排队消息」 / "Queued message"** (new i18n key `chat.activities.kind.agentRunQueued`) with a muted icon box (`bg-surface-2 text-muted`) instead of the violet tint. Row click-through to Harness unchanged.
- **Compact pill**: when the headline (first-sorted) item is a queued run — which, given running-first sort order, means nothing is actively executing — the pill switches to the existing `idle` StatusPill tone with a muted icon and no mint glow shadow. Any running/processing item present keeps today's exact appearance.
- **Logic layer**: fixed where the defect lives — `activityKindI18nKey` in `ui/src/lib/backgroundActivity.ts` was status-blind for `agent_run`; added pure predicate `isQueuedRun`. Watches/tasks/backend activities are untouched by queued-looking statuses (guarded by tests).

## Evidence layers

- **Unit**: `backgroundActivity.test.ts` extended — queued→`agentRunQueued`, running/processing→`agentRun`, non-run kinds immune to `queued` status, `isQueuedRun` truth table (17/17 pass).
- **Contract**: no API/schema change; pure display classification of the existing `SessionActivityState.status` field.
- **Scenario**: no scenario catalog covers the banner; none added.
- **Residual manual checks**: real-browser look of the muted pill/row (jsdom can't assert visual tone) — deferred to the orchestrator's Incus regression pass.

## Verification

- `cd ui && npm run build` green (tsc + vite).
- eslint on touched files: 13 problems before AND after (all pre-existing on untouched lines; CI does not run eslint) — lint-neutral.
- No setState in effect bodies; strings via i18n en+zh.