### PR TITLE
feat(workbench): add session pin hover action

### DIFF
--- a/ui/src/components/workbench/ProjectsPage.tsx
+++ b/ui/src/components/workbench/ProjectsPage.tsx
@@ -24,6 +24,7 @@ import clsx from 'clsx';
 
 import { useWorkbenchInbox } from '../../context/WorkbenchInboxContext';
 import { useWorkbenchProjectsTree } from '../../context/WorkbenchProjectsContext';
+import { SessionPinAction } from './SessionPinAction';
 import type { ProjectSessionsState } from '../../context/WorkbenchProjectsContext';
 import type { WorkbenchProject, WorkbenchSession } from '../../context/ApiContext';
 import { formatRelativeTime } from '../../lib/relativeTime';
@@ -253,6 +254,7 @@ const MobileSessionRow: React.FC<{
   const [menuOpen, setMenuOpen] = useState(false);
   const [archiveOpen, setArchiveOpen] = useState(false);
   const [renaming, setRenaming] = useState(false);
+  const [pinning, setPinning] = useState(false);
   const [draft, setDraft] = useState(session.title ?? '');
   const inputRef = useRef<HTMLInputElement | null>(null);
   const handledRef = useRef(false);
@@ -281,6 +283,20 @@ const MobileSessionRow: React.FC<{
     setRenaming(false);
   };
 
+  const togglePinned = async () => {
+    if (pinningRef.current) return;
+    pinningRef.current = true;
+    setPinning(true);
+    try {
+      await setSessionPinned(projectId, session.id, !session.pinned);
+    } catch {
+      // apiFetch already surfaced the error toast.
+    } finally {
+      pinningRef.current = false;
+      setPinning(false);
+    }
+  };
+
   if (renaming) {
     return (
       <div className="flex items-center gap-2 px-3 py-2">
@@ -302,7 +318,7 @@ const MobileSessionRow: React.FC<{
   }
 
   return (
-    <div className="flex items-center">
+    <div className="group/sess flex items-center">
       <button
         type="button"
         onClick={onOpen}
@@ -312,15 +328,6 @@ const MobileSessionRow: React.FC<{
         <span className="min-w-0 flex-1 truncate text-[13px] font-medium">
           {session.title || `#${session.id.slice(-6)}`}
         </span>
-        {session.pinned && (
-          <span
-            className="flex shrink-0 text-cyan"
-            aria-label={t('workbench.sessionPinned')}
-            title={t('workbench.sessionPinned')}
-          >
-            <Pin className="size-3.5" aria-hidden="true" />
-          </span>
-        )}
         {unread > 0 ? (
           <span className="shrink-0 rounded-full bg-mint px-1.5 py-0.5 font-mono text-[10px] font-bold text-background">
             {unread > 99 ? '99+' : unread}
@@ -331,6 +338,13 @@ const MobileSessionRow: React.FC<{
           </span>
         )}
       </button>
+      <SessionPinAction
+        pinned={session.pinned}
+        pending={pinning}
+        pinLabel={t('workbench.sessionPin')}
+        unpinLabel={t('workbench.sessionUnpin')}
+        onToggle={() => void togglePinned()}
+      />
       <Popover open={menuOpen} onOpenChange={setMenuOpen}>
         <PopoverTrigger asChild>
           <Button
@@ -348,15 +362,7 @@ const MobileSessionRow: React.FC<{
             icon={session.pinned ? PinOff : Pin}
             onClick={() => {
               setMenuOpen(false);
-              if (pinningRef.current) return;
-              pinningRef.current = true;
-              void setSessionPinned(projectId, session.id, !session.pinned)
-                .catch(() => {
-                  // apiFetch already surfaced the error toast.
-                })
-                .finally(() => {
-                  pinningRef.current = false;
-                });
+              void togglePinned();
             }}
           >
             {t(session.pinned ? 'workbench.sessionUnpin' : 'workbench.sessionPin')}

--- a/ui/src/components/workbench/SessionPinAction.test.tsx
+++ b/ui/src/components/workbench/SessionPinAction.test.tsx
@@ -1,0 +1,45 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+
+import { SessionPinAction } from './SessionPinAction';
+
+const renderAction = (pinned: boolean, pending = false) =>
+  renderToStaticMarkup(
+    <SessionPinAction
+      pinned={pinned}
+      pending={pending}
+      pinLabel="Pin to top"
+      unpinLabel="Unpin"
+      onToggle={() => undefined}
+    />,
+  );
+
+describe('SessionPinAction', () => {
+  it('reveals an unpinned action on row hover, keyboard focus, and coarse pointers', () => {
+    const html = renderAction(false);
+
+    expect(html).toContain('aria-pressed="false"');
+    expect(html).toContain('opacity-0');
+    expect(html).toContain('group-hover/sess:opacity-100');
+    expect(html).toContain('group-focus-within/sess:opacity-100');
+    expect(html).toContain('pointer-coarse:opacity-100');
+  });
+
+  it('keeps a pinned action visible and gives hover feedback', () => {
+    const html = renderAction(true);
+
+    expect(html).toContain('aria-pressed="true"');
+    expect(html).toContain('opacity-100');
+    expect(html).toContain('hover:bg-cyan/[0.18]');
+    expect(html).toContain('hover:scale-105');
+    expect(html).toContain('group-hover/pin:-rotate-12');
+  });
+
+  it('shows a disabled progress state while persistence is pending', () => {
+    const html = renderAction(false, true);
+
+    expect(html).toContain('disabled=""');
+    expect(html).toContain('animate-spin');
+    expect(html).toContain('cursor-wait');
+  });
+});

--- a/ui/src/components/workbench/SessionPinAction.tsx
+++ b/ui/src/components/workbench/SessionPinAction.tsx
@@ -1,0 +1,57 @@
+import clsx from 'clsx';
+import { Loader2, Pin } from 'lucide-react';
+import type { MouseEventHandler } from 'react';
+
+interface SessionPinActionProps {
+  pinned: boolean;
+  pending: boolean;
+  pinLabel: string;
+  unpinLabel: string;
+  onToggle: () => void;
+  className?: string;
+}
+
+export const SessionPinAction: React.FC<SessionPinActionProps> = ({
+  pinned,
+  pending,
+  pinLabel,
+  unpinLabel,
+  onToggle,
+  className,
+}) => {
+  const label = pinned ? unpinLabel : pinLabel;
+  const handleClick: MouseEventHandler<HTMLButtonElement> = (event) => {
+    event.stopPropagation();
+    onToggle();
+  };
+
+  return (
+    <button
+      type="button"
+      disabled={pending}
+      aria-label={label}
+      aria-pressed={pinned}
+      title={label}
+      onClick={handleClick}
+      className={clsx(
+        'group/pin grid size-6 shrink-0 place-items-center rounded-md transition-[opacity,transform,background-color,color,box-shadow] duration-150 ease-out',
+        'hover:-translate-y-px hover:scale-105 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-cyan/60 motion-reduce:transform-none',
+        pending
+          ? 'cursor-wait text-muted opacity-100 hover:translate-y-0 hover:scale-100'
+          : pinned
+            ? 'bg-cyan/[0.10] text-cyan opacity-100 hover:bg-cyan/[0.18] hover:ring-1 hover:ring-cyan/30'
+            : 'text-muted opacity-0 hover:bg-foreground/[0.08] hover:text-foreground group-hover/sess:opacity-100 group-focus-within/sess:opacity-100 pointer-coarse:opacity-100',
+        className,
+      )}
+    >
+      {pending ? (
+        <Loader2 className="size-3 animate-spin" aria-hidden="true" />
+      ) : (
+        <Pin
+          className="size-3 transition-transform duration-150 group-hover/pin:-rotate-12 group-hover/pin:scale-110 motion-reduce:transform-none"
+          aria-hidden="true"
+        />
+      )}
+    </button>
+  );
+};

--- a/ui/src/components/workbench/WorkbenchSidebar.tsx
+++ b/ui/src/components/workbench/WorkbenchSidebar.tsx
@@ -39,6 +39,7 @@ import { useUnsavedChangesActionGuard } from '../../context/useUnsavedChangesAct
 import { useApi } from '../../context/ApiContext';
 import type { InboxSession, WorkbenchProject, WorkbenchSession } from '../../context/ApiContext';
 import { useToast } from '../../context/ToastContext';
+import { SessionPinAction } from './SessionPinAction';
 import { formatRelativeTime } from '../../lib/relativeTime';
 import { Popover, PopoverAnchor, PopoverContent, PopoverTrigger } from '../ui/popover';
 import { ArchiveSessionDialog } from './ArchiveSessionDialog';
@@ -229,6 +230,7 @@ const SessionRow: React.FC<{
   const [archiveOpen, setArchiveOpen] = useState(false);
   const [forking, setForking] = useState(false);
   const [pinning, setPinning] = useState(false);
+  const pinningRef = useRef(false);
   const [renaming, setRenaming] = useState(false);
   const [draft, setDraft] = useState(session.title ?? '');
   const inputRef = useRef<HTMLInputElement | null>(null);
@@ -287,13 +289,24 @@ const SessionRow: React.FC<{
 
   const displayName = session.title?.trim() || t('workbench.untitledSession');
   const canFork = !!session.native_session_id && !forking;
+  const togglePinned = async () => {
+    if (pinningRef.current) return;
+    pinningRef.current = true;
+    setPinning(true);
+    try {
+      await onSetPinned(session.id, !session.pinned);
+    } catch {
+      // apiFetch already surfaced the error toast.
+    } finally {
+      pinningRef.current = false;
+      setPinning(false);
+    }
+  };
   return (
     <>
     <Popover open={menuOpen} onOpenChange={setMenuOpen}>
       <PopoverAnchor asChild>
-        <button
-          type="button"
-          onClick={() => navigate(`/chat/${encodeURIComponent(session.id)}`)}
+        <div
           onContextMenu={(e) => {
             e.preventDefault();
             setMenuOpen(true);
@@ -305,52 +318,48 @@ const SessionRow: React.FC<{
               : 'hover:bg-foreground/[0.04]',
           )}
         >
-          <span
-            title={t(`workbench.sessionStatus.${session.agent_status}`)}
-            className={clsx(
-              'size-[5px] shrink-0 rounded-full',
-              STATUS_DOT_CLASS[session.agent_status] ?? STATUS_DOT_CLASS.idle,
-            )}
-          />
-          <span
-            className={clsx(
-              'flex-1 truncate text-[12px]',
-              active ? 'font-semibold text-foreground' : 'font-medium text-foreground',
-            )}
+          <button
+            type="button"
+            onClick={() => navigate(`/chat/${encodeURIComponent(session.id)}`)}
+            className="flex min-w-0 flex-1 items-center gap-2 text-left focus-visible:outline-none"
           >
-            {displayName}
-          </span>
-          {session.pinned && (
             <span
-              className="flex shrink-0 text-cyan"
-              aria-label={t('workbench.sessionPinned')}
-              title={t('workbench.sessionPinned')}
+              title={t(`workbench.sessionStatus.${session.agent_status}`)}
+              className={clsx(
+                'size-[5px] shrink-0 rounded-full',
+                STATUS_DOT_CLASS[session.agent_status] ?? STATUS_DOT_CLASS.idle,
+              )}
+            />
+            <span
+              className={clsx(
+                'flex-1 truncate text-[12px]',
+                active ? 'font-semibold text-foreground' : 'font-medium text-foreground',
+              )}
             >
-              <Pin className="size-3" aria-hidden="true" />
+              {displayName}
             </span>
-          )}
-          {unread > 0 && (
-            <span className="inline-flex min-w-[1.1rem] items-center justify-center rounded-full bg-mint px-1.5 font-mono text-[9px] font-bold text-[#080812]">
-              {unread > 99 ? '99+' : unread}
-            </span>
-          )}
-        </button>
+            {unread > 0 && (
+              <span className="inline-flex min-w-[1.1rem] items-center justify-center rounded-full bg-mint px-1.5 font-mono text-[9px] font-bold text-[#080812]">
+                {unread > 99 ? '99+' : unread}
+              </span>
+            )}
+          </button>
+          <SessionPinAction
+            pinned={session.pinned}
+            pending={pinning}
+            pinLabel={t('workbench.sessionPin')}
+            unpinLabel={t('workbench.sessionUnpin')}
+            onToggle={() => void togglePinned()}
+          />
+        </div>
       </PopoverAnchor>
       <PopoverContent align="start" className="w-[176px] p-1">
         <button
           type="button"
           disabled={pinning}
-          onClick={async () => {
-            if (pinning) return;
+          onClick={() => {
             setMenuOpen(false);
-            setPinning(true);
-            try {
-              await onSetPinned(session.id, !session.pinned);
-            } catch {
-              // apiFetch already surfaced the error toast.
-            } finally {
-              setPinning(false);
-            }
+            void togglePinned();
           }}
           className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-[12px] text-foreground transition hover:bg-foreground/[0.04] disabled:cursor-not-allowed disabled:text-muted"
         >

--- a/ui/src/components/workbench/WorkbenchSidebar.tsx
+++ b/ui/src/components/workbench/WorkbenchSidebar.tsx
@@ -264,7 +264,7 @@ const SessionRow: React.FC<{
 
   if (renaming) {
     return (
-      <div className="flex items-center gap-2 py-1.5 pl-[30px] pr-2.5">
+      <div className="flex items-center gap-2 py-1.5 pl-[26px] pr-2.5">
         <span
           className={clsx(
             'size-[5px] shrink-0 rounded-full',
@@ -312,9 +312,9 @@ const SessionRow: React.FC<{
             setMenuOpen(true);
           }}
           className={clsx(
-            'group/sess flex items-center gap-2 rounded-md py-1.5 pl-[30px] pr-2.5 text-left transition',
+            'group/sess flex items-center gap-2 rounded-md py-1.5 pl-[26px] pr-2.5 text-left transition',
             active
-              ? 'border-l-2 border-mint bg-mint-soft pl-[28px] font-semibold text-foreground'
+              ? 'border-l-2 border-mint bg-mint-soft pl-[24px] font-semibold text-foreground'
               : 'hover:bg-foreground/[0.04]',
           )}
         >


### PR DESCRIPTION
## Summary

- show a direct pin action when a session row is hovered or keyboard-focused
- keep pinned actions visible and make the same control available on touch layouts
- add background, lift, scale, and pin-rotation feedback without shifting row layout
- reuse one guarded toggle path for the quick action and the existing session menu

## Capability

Direct session pin/unpin from project session rows.

## Scenario IDs

- None (no existing scenario catalog entry covers project session row actions).

## Evidence

- Unit: `SessionPinAction` interaction-state coverage plus existing session ordering tests (4 tests passed)
- Contract: reuses the existing persisted `PATCH /api/sessions/:id` pin contract and live session reconciliation unchanged
- Scenario: isolated browser runtime verified hidden-to-visible hover behavior, interactive hover styling, pin/unpin reorder, and no accidental chat navigation
- Responsive: verified desktop sidebar and 390px Projects layout; coarse-pointer visibility is pinned by component coverage
- Build: focused ESLint and production UI build passed
- Residual manual: none
