### PR TITLE
fix(telegram): sync private command scope

### DIFF
--- a/modules/im/telegram.py
+++ b/modules/im/telegram.py
@@ -276,24 +276,36 @@ class TelegramBot(BaseIMClient):
         ]
 
     async def _sync_command_menu(self) -> None:
-        registrations: list[tuple[Optional[str], str]] = [(None, "en")]
-        registrations.extend(
+        languages: list[tuple[Optional[str], str]] = [(None, "en")]
+        languages.extend(
             (language, language)
             for language in get_supported_languages()
             if re.fullmatch(r"[a-z]{2}", language)
         )
+        scopes: tuple[Optional[dict[str, str]], ...] = (
+            None,
+            {"type": "all_private_chats"},
+        )
 
-        for language_code, translation_language in registrations:
-            try:
-                await telegram_api.set_my_commands(
-                    self.config.bot_token,
-                    self._build_command_menu(translation_language),
-                    language_code=language_code,
-                    proxy_url=self._proxy_url,
-                )
-            except Exception as err:
-                label = language_code or "default"
-                logger.warning("Failed to sync Telegram command menu for %s: %s", label, err)
+        for scope in scopes:
+            for language_code, translation_language in languages:
+                try:
+                    await telegram_api.set_my_commands(
+                        self.config.bot_token,
+                        self._build_command_menu(translation_language),
+                        scope=scope,
+                        language_code=language_code,
+                        proxy_url=self._proxy_url,
+                    )
+                except Exception as err:
+                    scope_label = scope["type"] if scope else "default"
+                    language_label = language_code or "default"
+                    logger.warning(
+                        "Failed to sync Telegram command menu for scope=%s language=%s: %s",
+                        scope_label,
+                        language_label,
+                        err,
+                    )
 
         try:
             await telegram_api.set_chat_menu_button(

--- a/modules/im/telegram_api.py
+++ b/modules/im/telegram_api.py
@@ -111,10 +111,13 @@ async def set_my_commands(
     bot_token: str,
     commands: list[dict[str, str]],
     *,
+    scope: Optional[dict[str, Any]] = None,
     language_code: Optional[str] = None,
     proxy_url: Optional[str] = None,
 ) -> dict[str, Any]:
     payload: dict[str, Any] = {"commands": commands}
+    if scope is not None:
+        payload["scope"] = scope
     if language_code:
         payload["language_code"] = language_code
     return await call_api(bot_token, "setMyCommands", payload, proxy_url=proxy_url)

--- a/tests/test_telegram_bot.py
+++ b/tests/test_telegram_bot.py
@@ -542,9 +542,19 @@ def test_sync_command_menu_registers_localized_commands_and_menu_button() -> Non
         ) as menu_mock:
             asyncio.run(bot._sync_command_menu())
 
-    assert [call.kwargs["language_code"] for call in commands_mock.await_args_list] == [None, "en", "zh"]
+    assert [
+        (call.kwargs["scope"], call.kwargs["language_code"])
+        for call in commands_mock.await_args_list
+    ] == [
+        (None, None),
+        (None, "en"),
+        (None, "zh"),
+        ({"type": "all_private_chats"}, None),
+        ({"type": "all_private_chats"}, "en"),
+        ({"type": "all_private_chats"}, "zh"),
+    ]
     default_commands = commands_mock.await_args_list[0].args[1]
-    chinese_commands = commands_mock.await_args_list[2].args[1]
+    chinese_private_commands = commands_mock.await_args_list[5].args[1]
     assert [item["command"] for item in default_commands] == [
         "start",
         "new",
@@ -556,7 +566,7 @@ def test_sync_command_menu_registers_localized_commands_and_menu_button() -> Non
         "stop",
     ]
     assert default_commands[0]["description"] == "Open the main menu"
-    assert chinese_commands[0]["description"] == "打开主菜单"
+    assert chinese_private_commands[0]["description"] == "打开主菜单"
     assert all(call.kwargs["proxy_url"] == "socks5://127.0.0.1:1080" for call in commands_mock.await_args_list)
     menu_mock.assert_awaited_once_with(
         "123456:test-token",
@@ -570,7 +580,7 @@ def test_sync_command_menu_keeps_going_after_registration_failure() -> None:
 
     with patch(
         "modules.im.telegram.telegram_api.set_my_commands",
-        new=AsyncMock(side_effect=[RuntimeError("default failed"), {"ok": True}, {"ok": True}]),
+        new=AsyncMock(side_effect=[RuntimeError("default failed")] + [{"ok": True}] * 5),
     ) as commands_mock:
         with patch(
             "modules.im.telegram.telegram_api.set_chat_menu_button",
@@ -578,7 +588,7 @@ def test_sync_command_menu_keeps_going_after_registration_failure() -> None:
         ) as menu_mock:
             asyncio.run(bot._sync_command_menu())
 
-    assert commands_mock.await_count == 3
+    assert commands_mock.await_count == 6
     menu_mock.assert_awaited_once()
 
 
@@ -591,6 +601,7 @@ def test_set_my_commands_builds_language_payload_and_uses_proxy() -> None:
             telegram_api.set_my_commands(
                 "123456:test-token",
                 [{"command": "start", "description": "Open the main menu"}],
+                scope={"type": "all_private_chats"},
                 language_code="en",
                 proxy_url="socks5://127.0.0.1:1080",
             )
@@ -601,6 +612,7 @@ def test_set_my_commands_builds_language_payload_and_uses_proxy() -> None:
         "setMyCommands",
         {
             "commands": [{"command": "start", "description": "Open the main menu"}],
+            "scope": {"type": "all_private_chats"},
             "language_code": "en",
         },
         proxy_url="socks5://127.0.0.1:1080",


### PR DESCRIPTION
## Summary

- synchronize Telegram commands for both the default scope and `all_private_chats`
- prevent narrower BotFather or legacy private-chat commands from shadowing Avibe's eight-command menu
- add scoped Bot API payload coverage while preserving best-effort startup behavior

## Capability and scenarios

- Capability: Telegram native command-menu scope reconciliation
- Scenario IDs: none; no Telegram command-menu scenario catalog exists

## Evidence

- Unit: 122 focused Telegram, proxy/auth, and multi-platform runtime tests passed
- Contract: tests assert default/private scope, default/English/Chinese language, proxy, and menu-button payloads
- Scenario: live regression Bot API read-back reproduced the precedence bug: default had eight commands while `all_private_chats` had only `start` and `setup`
- Residual manual: after deployment, reopen the regression Bot DM and confirm all eight commands are visible

## Risk

- Avibe intentionally replaces an existing broad private-chat command list on startup
- per-chat command scopes remain untouched
