### PR TITLE
feat(claude): add Opus 5 model metadata

### DIFF
--- a/modules/agents/opencode/utils.py
+++ b/modules/agents/opencode/utils.py
@@ -474,6 +474,7 @@ def _supports_claude_xhigh_reasoning(target_model: Optional[str]) -> bool:
     return (
         normalized_model in _CLAUDE_OPUS_ALIASES
         or normalized_model in _CLAUDE_SONNET_ALIASES
+        or normalized_model.startswith("claude-opus-5")
         or normalized_model.startswith("claude-opus-4-7")
         or normalized_model.startswith("claude-opus-4-8")
         or normalized_model.startswith("claude-sonnet-5")
@@ -488,6 +489,7 @@ def _supports_claude_max_reasoning(target_model: Optional[str]) -> bool:
     return (
         normalized_model in _CLAUDE_OPUS_ALIASES
         or normalized_model in _CLAUDE_SONNET_ALIASES
+        or normalized_model.startswith("claude-opus-5")
         or normalized_model.startswith("claude-opus-4-6")
         or normalized_model.startswith("claude-opus-4-7")
         or normalized_model.startswith("claude-opus-4-8")
@@ -504,6 +506,7 @@ def supports_claude_1m_context(target_model: Optional[str]) -> bool:
     return (
         normalized_model in _CLAUDE_OPUS_ALIASES
         or normalized_model in _CLAUDE_SONNET_ALIASES
+        or normalized_model.startswith("claude-opus-5")
         or normalized_model.startswith("claude-opus-4-6")
         or normalized_model.startswith("claude-opus-4-7")
         or normalized_model.startswith("claude-opus-4-8")
@@ -554,8 +557,8 @@ def build_claude_reasoning_options(
     """Return the canonical Claude reasoning-effort option list for a model.
 
     Claude currently supports `low` / `medium` / `high` broadly. Newer
-    Opus 4.7, Opus 4.8, and Sonnet 5 models add `xhigh`; Opus 4.8,
-    4.7, 4.6, Sonnet 5, and Sonnet 4.6 also support `max`.
+    Opus 4.7, Opus 4.8, Opus 5, and Sonnet 5 models add `xhigh`; those
+    models plus Opus 4.6 and Sonnet 4.6 also support `max`.
     """
 
     efforts = list(reasoning_efforts) if reasoning_efforts is not None else list(_CLAUDE_REASONING_EFFORTS)

--- a/tests/test_backend_model_catalog.py
+++ b/tests/test_backend_model_catalog.py
@@ -196,6 +196,8 @@ def test_claude_snapshot_merges_configured_custom_models(monkeypatch, tmp_path):
 
     assert "custom-claude-model" in snapshot["models"]
     assert "custom-fast-model" in snapshot["models"]
+    assert snapshot["models"][:2] == ["claude-fable-5", "claude-opus-5"]
+    assert snapshot["model_labels"]["claude-opus-5"] == "claude-opus-5 [1M]"
     assert snapshot["model_labels"]["claude-opus-4-6"] == "claude-opus-4-6 [1M]"
 
 

--- a/tests/test_claude_model_catalog.py
+++ b/tests/test_claude_model_catalog.py
@@ -18,6 +18,11 @@ def test_sonnet_5_is_tracked_in_catalog_and_fallback():
     assert "claude-sonnet-5" in FALLBACK_CLAUDE_MODELS
 
 
+def test_opus_5_is_tracked_in_catalog_and_fallback():
+    assert "claude-opus-5" in load_catalog_models()
+    assert "claude-opus-5" in FALLBACK_CLAUDE_MODELS
+
+
 def test_catalog_excludes_dated_4_6_and_later_internal_ids():
     models = load_catalog_models()
 
@@ -25,6 +30,7 @@ def test_catalog_excludes_dated_4_6_and_later_internal_ids():
     assert "claude-sonnet-4-6-20251114" not in models
     assert "claude-sonnet-5-20260630" not in sort_catalog_models(["claude-sonnet-5-20260630"])
     assert "claude-fable-5-20260609" not in sort_catalog_models(["claude-fable-5-20260609"])
+    assert "claude-opus-5-20260724" not in sort_catalog_models(["claude-opus-5-20260724"])
 
 
 def test_fable_sorts_above_other_families():
@@ -45,14 +51,14 @@ def test_bundle_inference_detects_fable_and_skips_mythos_preview(tmp_path):
     bundle = tmp_path / "cli.js"
     bundle.write_bytes(
         b'pick("claude-fable-5");fallback="claude-opus-4-8";'
-        b'"claude-sonnet-5";"claude-opus-4-6-20251101";'
+        b'"claude-opus-5";"claude-sonnet-5";"claude-opus-4-6-20251101";'
         b'"claude-sonnet-4-6-20251114";"claude-sonnet-5-20260630";'
-        b'"claude-fable-5-20260609";"claude-mythos-preview"'
+        b'"claude-fable-5-20260609";"claude-opus-5-20260724";"claude-mythos-preview"'
     )
 
     models = infer_models_from_bundle(bundle)
 
-    assert models == ["claude-fable-5", "claude-opus-4-8", "claude-sonnet-5"]
+    assert models == ["claude-fable-5", "claude-opus-5", "claude-opus-4-8", "claude-sonnet-5"]
     # `claude-mythos-preview` carries no version segment and is not a publicly
     # callable model, so it must not leak into the catalog.
     assert "claude-mythos-preview" not in models
@@ -62,3 +68,4 @@ def test_bundle_inference_detects_fable_and_skips_mythos_preview(tmp_path):
     assert "claude-sonnet-4-6-20251114" not in models
     assert "claude-sonnet-5-20260630" not in models
     assert "claude-fable-5-20260609" not in models
+    assert "claude-opus-5-20260724" not in models

--- a/tests/test_claude_reasoning_options.py
+++ b/tests/test_claude_reasoning_options.py
@@ -41,6 +41,12 @@ def test_claude_reasoning_options_add_xhigh_and_max_for_opus_48() -> None:
     assert [item["value"] for item in options] == ["__default__", "low", "medium", "high", "xhigh", "max"]
 
 
+def test_claude_reasoning_options_add_xhigh_and_max_for_opus_5() -> None:
+    options = build_claude_reasoning_options("claude-opus-5")
+
+    assert [item["value"] for item in options] == ["__default__", "low", "medium", "high", "xhigh", "max"]
+
+
 def test_claude_reasoning_options_add_xhigh_and_max_for_fable_5() -> None:
     options = build_claude_reasoning_options("claude-fable-5")
 
@@ -121,6 +127,8 @@ def test_normalize_claude_reasoning_effort_drops_invalid_efforts() -> None:
     assert normalize_claude_reasoning_effort("claude-opus-4-7", "max") == "max"
     assert normalize_claude_reasoning_effort("claude-opus-4-8", "xhigh") == "xhigh"
     assert normalize_claude_reasoning_effort("claude-opus-4-8", "max") == "max"
+    assert normalize_claude_reasoning_effort("claude-opus-5", "xhigh") == "xhigh"
+    assert normalize_claude_reasoning_effort("claude-opus-5", "max") == "max"
     assert normalize_claude_reasoning_effort("claude-opus-4-6", "max") == "max"
     assert normalize_claude_reasoning_effort("claude-sonnet-5", "xhigh") == "xhigh"
     assert normalize_claude_reasoning_effort("claude-sonnet-5", "max") == "max"
@@ -136,6 +144,7 @@ def test_normalize_claude_reasoning_effort_drops_invalid_efforts() -> None:
 
 
 def test_claude_1m_context_labels() -> None:
+    assert format_claude_model_label("claude-opus-5") == "claude-opus-5 [1M]"
     assert format_claude_model_label("claude-opus-4-8") == "claude-opus-4-8 [1M]"
     assert format_claude_model_label("claude-opus-4-7") == "claude-opus-4-7 [1M]"
     assert format_claude_model_label("claude-opus-4-6") == "claude-opus-4-6 [1M]"

--- a/tests/test_ui_api.py
+++ b/tests/test_ui_api.py
@@ -1989,12 +1989,14 @@ def test_claude_models_merge_catalog_and_settings(monkeypatch, tmp_path):
 
     assert result["ok"] is True
     assert result["models"][0] == "claude-fable-5"
+    assert result["models"][1] == "claude-opus-5"
     assert "opus" in result["models"]
     assert "sonnet" in result["models"]
     assert "haiku" in result["models"]
     assert "opus[1m]" in result["models"]
     assert "claude-haiku-4-5-20251001" in result["models"]
     assert result["models"].count("claude-sonnet-4-6") == 1
+    assert result["model_labels"]["claude-opus-5"] == "claude-opus-5 [1M]"
     assert result["model_labels"]["claude-opus-4-6"] == "claude-opus-4-6 [1M]"
     assert result["model_labels"]["claude-sonnet-4-6"] == "claude-sonnet-4-6 [1M]"
     assert result["model_labels"]["opus"] == "opus [1M]"

--- a/vibe/claude_model_catalog.py
+++ b/vibe/claude_model_catalog.py
@@ -9,6 +9,7 @@ from typing import Iterable
 DEFAULT_CLAUDE_MODEL_ALIASES: tuple[str, ...] = ("opus", "sonnet", "haiku")
 FALLBACK_CLAUDE_MODELS: tuple[str, ...] = (
     "claude-fable-5",
+    "claude-opus-5",
     "claude-opus-4-8",
     "claude-opus-4-7",
     "claude-opus-4-6",

--- a/vibe/data/backend_models.json
+++ b/vibe/data/backend_models.json
@@ -4,6 +4,7 @@
     "claude": {
       "models": [
         {"id": "claude-fable-5", "reasoning_efforts": ["low", "medium", "high", "xhigh", "max"]},
+        {"id": "claude-opus-5", "reasoning_efforts": ["low", "medium", "high", "xhigh", "max"]},
         {"id": "claude-opus-4-8", "reasoning_efforts": ["low", "medium", "high", "xhigh", "max"]},
         {"id": "claude-opus-4-7", "reasoning_efforts": ["low", "medium", "high", "xhigh", "max"]},
         {"id": "claude-opus-4-6", "reasoning_efforts": ["low", "medium", "high", "max"]},

--- a/vibe/data/claude_models.json
+++ b/vibe/data/claude_models.json
@@ -1,6 +1,7 @@
 {
   "models": [
     "claude-fable-5",
+    "claude-opus-5",
     "claude-opus-4",
     "claude-opus-4-20250514",
     "claude-opus-4-8",


### PR DESCRIPTION
## Summary

- add the official `claude-opus-5` API model to the tracked Claude catalog, runtime fallback, and bundled backend catalog
- expose its 1M context label and full `low`, `medium`, `high`, `xhigh`, and `max` effort ladder
- keep dated Claude 5 internal identifiers filtered from user-facing model choices

Official references:
- https://platform.claude.com/docs/en/about-claude/models/overview
- https://platform.claude.com/docs/en/release-notes/overview

## Evidence

- Unit: 132 focused catalog, reasoning, backend snapshot, and API tests passed
- Contract: Claude model snapshot asserts Opus 5 ordering, label, and reasoning metadata
- Scenario: no catalog scenario IDs are defined for this metadata-only change
- Manual: JSON validation, Ruff, and direct snapshot/label/reasoning probes passed

## Residual checks

- The installed Claude Code 2.1.206 bundle does not advertise Opus 5 yet, so the official public ID is intentionally tracked explicitly until bundle discovery catches up.
