### PR TITLE
fix(model-hub): wire default engine adapter

### DIFF
--- a/core/handlers/model_hub/errors.py
+++ b/core/handlers/model_hub/errors.py
@@ -1,0 +1,5 @@
+"""Shared Model Hub integration errors."""
+
+
+class ModelDiscoveryError(RuntimeError):
+    """A source credential or upstream catalog probe could not be validated."""

--- a/core/handlers/model_hub/oauth.py
+++ b/core/handlers/model_hub/oauth.py
@@ -37,7 +37,7 @@ class NativeOAuthUnavailableError(RuntimeError):
 
 
 class UnavailableNativeOAuthAdapter:
-    """L3 replaces this adapter when native CLI OAuth is wired."""
+    """Fail closed until a native CLI OAuth integration is available."""
 
     async def start_oauth(self, source_id: str, vendor: str) -> OAuthFlowState:
         raise NativeOAuthUnavailableError

--- a/core/handlers/model_hub/service.py
+++ b/core/handlers/model_hub/service.py
@@ -44,6 +44,7 @@ from .events import (
     build_resolution_event,
     contains_credential_material,
 )
+from .errors import ModelDiscoveryError
 from .identifiers import (
     STANDARD_OPENCODE_VENDOR_IDS,
     opencode_model_id,
@@ -144,7 +145,7 @@ class V2ModelHubConfigStore:
 
 
 class UnavailableEngineAdapter:
-    """Fail-closed placeholder until the L1 runtime implementation is present."""
+    """Explicit fail-closed adapter for isolated callers and tests."""
 
     async def ensure_installed(self) -> EngineStatus:
         return await self.status()
@@ -405,6 +406,8 @@ class ModelHubService:
             return await awaitable
         except OriginNotAllowedError:
             raise ModelHubError("mode_switch_blocked", status=409) from None
+        except ModelDiscoveryError:
+            raise ModelHubError("discovery_failed", status=502) from None
         except EngineUnavailableError:
             raise ModelHubError("engine_down", status=503) from None
         except NativeOAuthUnavailableError:
@@ -1142,7 +1145,7 @@ class ModelHubService:
         self.oauth_flows.forget(flow_id)
 
     async def runtime_status(self) -> dict:
-        return _runtime_payload(await self._engine_call(self.adapter.status()))
+        return _runtime_payload(await self._engine_call(self.adapter.start()))
 
     def migration_scan(self) -> dict:
         config = self.store.load()
@@ -1419,6 +1422,11 @@ def create_default_service(
     adapter: Optional[EngineAdapter] = None,
     native_oauth_adapter: Optional[OAuthAdapter] = None,
 ) -> ModelHubService:
+    if adapter is None:
+        from vibe.model_hub_runtime import get_model_hub_engine_adapter
+
+        adapter = get_model_hub_engine_adapter()
+
     def claude_oauth_probe() -> bool:
         from vibe.api import (
             _build_claude_status_probe_env,
@@ -1443,7 +1451,7 @@ def create_default_service(
 
     return ModelHubService(
         store=V2ModelHubConfigStore(),
-        adapter=adapter or UnavailableEngineAdapter(),
+        adapter=adapter,
         events=BoundedEventLog(paths.get_state_dir() / "model_hub_resolution_events.json"),
         native_oauth_adapter=native_oauth_adapter,
         oauth_flows=OAuthFlowRegistry(paths.get_state_dir() / "model_hub_oauth_flows.json"),

--- a/core/handlers/model_hub/service.py
+++ b/core/handlers/model_hub/service.py
@@ -1145,7 +1145,13 @@ class ModelHubService:
         self.oauth_flows.forget(flow_id)
 
     async def runtime_status(self) -> dict:
-        return _runtime_payload(await self._engine_call(self.adapter.start()))
+        try:
+            status = await self._engine_call(self.adapter.start())
+        except ModelHubError as exc:
+            if exc.code != "engine_down":
+                raise
+            status = await self._engine_call(self.adapter.status())
+        return _runtime_payload(status)
 
     def migration_scan(self) -> dict:
         config = self.store.load()

--- a/modules/agents/model_hub.py
+++ b/modules/agents/model_hub.py
@@ -257,9 +257,7 @@ class ModelHubRuntimeRouter:
         native_cli_ready: Callable[[BackendName], bool] | None = None,
     ) -> None:
         if service is None:
-            from vibe.model_hub_runtime import get_model_hub_engine_adapter
-
-            service = create_default_service(adapter=get_model_hub_engine_adapter())
+            service = create_default_service()
         self.service = service
         self.overlay_path = overlay_path or paths.get_runtime_dir() / "model-hub" / "opencode-overlay.json"
         self.native_cli_ready = native_cli_ready or self._default_native_cli_ready

--- a/tests/test_model_hub_api.py
+++ b/tests/test_model_hub_api.py
@@ -20,10 +20,11 @@ from core.handlers.model_hub.adapter import (
     RawCallOutcome,
     RawOutcomeKind,
 )
+from core.handlers.model_hub.errors import ModelDiscoveryError
 from core.handlers.model_hub.events import BoundedEventLog, ResolutionEvent
 from core.handlers.model_hub.oauth import OAuthFlowRegistry
 from core.handlers.model_hub.revocations import CredentialRevocationJournal
-from core.handlers.model_hub.service import ModelHubError, ModelHubService
+from core.handlers.model_hub.service import ModelHubError, ModelHubService, create_default_service
 from tests.ui_server_test_helpers import csrf_headers
 from vibe import ui_server
 from vibe.ui_server import app
@@ -185,6 +186,78 @@ def _service(tmp_path):
 def _assert_envelope(payload: dict, *, ok: bool = True):
     assert payload["ok"] is ok
     assert payload["contract_version"] == 1
+
+
+def test_default_service_uses_real_engine_adapter(monkeypatch, tmp_path):
+    from vibe.model_hub_runtime import adapter as runtime_adapter
+    from vibe.model_hub_runtime import supervisor as runtime_supervisor
+    from vibe.model_hub_runtime.adapter import CLIProxyEngineAdapter
+
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path / "avibe-home"))
+    monkeypatch.setattr(runtime_adapter, "_adapter", None)
+    monkeypatch.setattr(runtime_supervisor, "_supervisor", None)
+
+    service = create_default_service()
+
+    assert isinstance(service.adapter, CLIProxyEngineAdapter)
+    assert service.adapter.supervisor.state_store.root.is_relative_to(tmp_path)
+
+
+def test_runtime_status_starts_engine_before_reporting_health(tmp_path):
+    class LifecycleAdapter(FakeAdapter):
+        def __init__(self):
+            super().__init__()
+            self.start_calls = 0
+
+        async def start(self):
+            self.start_calls += 1
+            return await super().start()
+
+    adapter = LifecycleAdapter()
+    service = ModelHubService(
+        store=MemoryStore(),
+        adapter=adapter,
+        events=BoundedEventLog(tmp_path / "events.json"),
+        oauth_flows=OAuthFlowRegistry(tmp_path / "oauth_flows.json"),
+        revocations=CredentialRevocationJournal(tmp_path / "revocations.json"),
+    )
+
+    runtime = asyncio.run(service.runtime_status())
+
+    assert adapter.start_calls == 1
+    assert runtime["status"]["health"] == "ok"
+    assert runtime["status"]["verified"] is True
+
+
+def test_discovery_probe_failure_is_not_reported_as_engine_down(tmp_path):
+    class DiscoveryFailureAdapter(FakeAdapter):
+        async def discover_models(self, vendor, protocol, base_url, credential_ref):
+            raise ModelDiscoveryError("upstream rejected the credential")
+
+    store = MemoryStore()
+    adapter = DiscoveryFailureAdapter()
+    service = ModelHubService(
+        store=store,
+        adapter=adapter,
+        events=BoundedEventLog(tmp_path / "events.json"),
+        oauth_flows=OAuthFlowRegistry(tmp_path / "oauth_flows.json"),
+        revocations=CredentialRevocationJournal(tmp_path / "revocations.json"),
+    )
+
+    with pytest.raises(ModelHubError) as error:
+        asyncio.run(
+            service.create_source(
+                {
+                    "kind": "api_key",
+                    "vendor": "openai",
+                    "key": "sk-test-invalid-but-syntactically-valid",
+                }
+            )
+        )
+
+    assert error.value.code == "discovery_failed"
+    assert adapter.revoked == ["cred_test123"]
+    assert store.config.sources == []
 
 
 def test_agents_endpoint_projects_builtin_models_and_standard_vendors(tmp_path):

--- a/tests/test_model_hub_api.py
+++ b/tests/test_model_hub_api.py
@@ -229,6 +229,40 @@ def test_runtime_status_starts_engine_before_reporting_health(tmp_path):
     assert runtime["status"]["verified"] is True
 
 
+def test_runtime_status_falls_back_when_engine_cannot_start(tmp_path):
+    class StartFailureAdapter(FakeAdapter):
+        async def start(self):
+            raise RuntimeError("engine cannot start")
+
+        async def status(self):
+            return EngineStatus(
+                health=EngineHealth.NOT_INSTALLED,
+                installed_version=None,
+                verified=False,
+                listen_host="127.0.0.1",
+                listen_port=None,
+                last_check_iso=None,
+            )
+
+    service = ModelHubService(
+        store=MemoryStore(),
+        adapter=StartFailureAdapter(),
+        events=BoundedEventLog(tmp_path / "events.json"),
+        oauth_flows=OAuthFlowRegistry(tmp_path / "oauth_flows.json"),
+        revocations=CredentialRevocationJournal(tmp_path / "revocations.json"),
+    )
+
+    runtime = asyncio.run(service.runtime_status())
+
+    assert runtime["status"] == {
+        "installed_version": None,
+        "verified": False,
+        "listening": None,
+        "health": "not_installed",
+        "last_check": None,
+    }
+
+
 def test_discovery_probe_failure_is_not_reported_as_engine_down(tmp_path):
     class DiscoveryFailureAdapter(FakeAdapter):
         async def discover_models(self, vendor, protocol, base_url, credential_ref):

--- a/ui/src/components/settings/models/AddApiKeyDialog.tsx
+++ b/ui/src/components/settings/models/AddApiKeyDialog.tsx
@@ -3,7 +3,7 @@
 // relay endpoints); the primary button is test-and-add — it validates the key,
 // discovers models, and reports the count before the dialog dismisses.
 import * as React from 'react';
-import { CheckCircle2, Globe, KeyRound, Plus, Shield, TriangleAlert } from 'lucide-react';
+import { CheckCircle2, Globe, KeyRound, Plus, TriangleAlert } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
 import { Button } from '@/components/ui/button';
@@ -106,7 +106,8 @@ export const AddApiKeyDialog: React.FC<{
       closeTimer.current = window.setTimeout(onClose, 1500);
     } catch (e: any) {
       if (submitSeq.current !== seq) return;
-      setError(e?.code || e?.message || 'discovery_failed');
+      const code = e?.code || e?.message || 'discovery_failed';
+      setError(code === 'engine_down' ? (t('settings.models.errors.engineDown') as string) : code);
       setPhase('error');
     }
   };
@@ -180,11 +181,7 @@ export const AddApiKeyDialog: React.FC<{
           </div>
         )}
 
-        <DialogFooter className="items-center sm:justify-between">
-          <span className="flex items-center gap-1.5 text-[12px] text-mint">
-            <Shield className="size-3.5" />
-            {t('settings.models.addKey.vaultNote')}
-          </span>
+        <DialogFooter>
           <div className="flex items-center gap-2">
             <Button variant="outline" size="sm" onClick={onClose} disabled={phase === 'submitting'}>
               {t('common.cancel')}

--- a/ui/src/components/settings/models/AgentCard.tsx
+++ b/ui/src/components/settings/models/AgentCard.tsx
@@ -11,7 +11,7 @@ import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 import { useToast } from '@/context/ToastContext';
-import { CompositePill, MenuKindBadge, ModeChip } from './chips';
+import { CompositePill, ModeChip } from './chips';
 import { ACCENT_ICON, ACCENT_TILE, backendVisual, sourceAccent } from './vendorMeta';
 import { friendlyModelName } from './format';
 import { MODEL_MENUS_ENABLED } from './featureFlags';
@@ -71,12 +71,9 @@ const AgentRow: React.FC<{
       </span>
 
       <div className="flex min-w-0 flex-1 flex-col items-start gap-2">
-        <div className="flex items-center gap-2">
-          <span className="text-[15px] font-semibold text-foreground">
-            {t(`settings.models.backends.${agent.backend}`, { defaultValue: agent.backend })}
-          </span>
-          <MenuKindBadge kind={agent.menu_kind} />
-        </div>
+        <span className="text-[15px] font-semibold text-foreground">
+          {t(`settings.models.backends.${agent.backend}`, { defaultValue: agent.backend })}
+        </span>
         {pill}
       </div>
 

--- a/ui/src/components/settings/models/chips.tsx
+++ b/ui/src/components/settings/models/chips.tsx
@@ -81,16 +81,6 @@ export const ModeChip: React.FC<{ mode: AgentMode }> = ({ mode }) => {
   );
 };
 
-/** 菜单固定 / 菜单开放 — tiny label next to a backend name. */
-export const MenuKindBadge: React.FC<{ kind: 'fixed' | 'open' }> = ({ kind }) => {
-  const { t } = useTranslation();
-  return (
-    <Badge variant="secondary" className="rounded-md px-2 py-0.5 text-[10px] font-medium">
-      {kind === 'fixed' ? t('settings.models.menuKind.fixed') : t('settings.models.menuKind.open')}
-    </Badge>
-  );
-};
-
 /** 实验 — marks a consent-gated hub-held subscription source. */
 export const ExperimentalChip: React.FC = () => {
   const { t } = useTranslation();

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -648,9 +648,8 @@
         "hub": "Hub",
         "direct": "Direct"
       },
-      "menuKind": {
-        "fixed": "Fixed menu",
-        "open": "Open menu"
+      "errors": {
+        "engineDown": "Model engine is not ready yet; try again shortly"
       },
       "experimental": "Experimental",
       "agents": {
@@ -702,7 +701,6 @@
         "discovered": "Connected · discovered {{count}} models, added to the supply list",
         "failed": "Connection failed: {{detail}}",
         "testing": "Connecting…",
-        "vaultNote": "Stored locally; can go in Vault",
         "vendors": {
           "custom": "Custom · OpenAI / Anthropic compatible",
           "anthropic": "Anthropic",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -648,9 +648,8 @@
         "hub": "中枢 Hub",
         "direct": "直连 Direct"
       },
-      "menuKind": {
-        "fixed": "菜单固定",
-        "open": "菜单开放"
+      "errors": {
+        "engineDown": "模型引擎未就绪,请稍后重试"
       },
       "experimental": "实验",
       "agents": {
@@ -702,7 +701,6 @@
         "discovered": "连接成功 · 发现 {{count}} 个可用模型，已加入供应清单",
         "failed": "连接失败：{{detail}}",
         "testing": "连接中…",
-        "vaultNote": "只存本机，可入 Vault",
         "vendors": {
           "custom": "自定义 · OpenAI / Anthropic 兼容",
           "anthropic": "Anthropic",

--- a/vibe/model_hub_runtime/adapter.py
+++ b/vibe/model_hub_runtime/adapter.py
@@ -17,6 +17,7 @@ from core.handlers.model_hub.adapter import (
     RawOutcomeKind,
     SourceBinding,
 )
+from core.handlers.model_hub.errors import ModelDiscoveryError
 from vibe.model_hub_runtime.client import (
     EngineClient,
     EngineClientError,
@@ -235,7 +236,7 @@ class CLIProxyEngineAdapter:
                 secret=secret,
             )
         except EngineClientError as exc:
-            raise EngineStateError("model discovery failed") from exc
+            raise ModelDiscoveryError("model discovery failed") from exc
 
     async def start_oauth(self, source_id: str, vendor: str) -> OAuthFlowState:
         await asyncio.to_thread(self.state_store.validate_source_id, source_id)

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -3019,8 +3019,6 @@ def config_get():
     return jsonify(api.config_to_payload(config))
 
 
-_MODEL_HUB_ENGINE_ADAPTER = None
-_MODEL_HUB_NATIVE_OAUTH_ADAPTER = None
 _MODEL_HUB_SERVICE = None
 
 
@@ -3029,10 +3027,7 @@ def _model_hub_service():
 
     global _MODEL_HUB_SERVICE
     if _MODEL_HUB_SERVICE is None:
-        _MODEL_HUB_SERVICE = create_default_service(
-            adapter=_MODEL_HUB_ENGINE_ADAPTER,
-            native_oauth_adapter=_MODEL_HUB_NATIVE_OAUTH_ADAPTER,
-        )
+        _MODEL_HUB_SERVICE = create_default_service()
     return _MODEL_HUB_SERVICE
 
 


### PR DESCRIPTION
## Capability

Fix Model Hub's production default wiring so every `create_default_service()` caller receives the managed `CLIProxyEngineAdapter`. Runtime status now starts the on-demand engine before reporting health, while retaining degraded/not-installed status when startup is unavailable; API-key discovery failures retain their discovery-class error instead of collapsing to `engine_down`.

The Models UI also removes the owner-deleted Vault footer note and fixed/open agent badges, and translates the remaining `engine_down` add-key error.

## Scenarios

- Affected catalog scenarios: `MH-INJ-CLAUDE-001`, `MH-INJ-CODEX-001`, `MH-INJ-OPENCODE-001` (shared default runtime router prerequisite).
- The API-key test-and-add/runtime-bootstrap case is not yet represented by a catalog ID; this PR adds focused regression coverage and an Incus real-engine smoke.

## Class sweep

- `_MODEL_HUB_*` sweep: only the assigned cache `_MODEL_HUB_SERVICE` remains; the never-assigned engine and native-OAuth globals are deleted.
- `Optional[...] = None` / `| None = None` sweep across `vibe/ui_server.py`, `core/handlers/model_hub`, `modules/agents/model_hub.py`, and `vibe/model_hub_runtime` found only ordinary value defaults, constructor injection points, and owned singleton caches.
- No concrete native CLI OAuth adapter exists in the current tree. `UnavailableNativeOAuthAdapter` remains the explicit fail-closed implementation; no stub was added.

## Evidence

- Unit: `ruff check` passed on every changed Python file; 174 focused Model Hub tests passed.
- Contract: `docs/plans/model-hub-contracts/` is unchanged; `adapter-interface.py` SHA-256 remains `53185183ebc807e9bc8ee49bd49348af8c2f8bead0207ffdfd6968beb557e9c2`.
- Scenario: injection, resolution, configuration, API, runtime, and migration scenario suites are included in the 174 passing tests.
- UI: production TypeScript/Vite build passed; deleted keys/components have zero remaining references.
- Incus: isolated worktree project only, then deleted. The frozen default manifest first failed closed on this `linux-arm64` container with `model_hub_engine_platform_unsupported` (no download attempted). A temporary container-only v7.2.95 upstream arm64 manifest override then downloaded/verified/started the real engine in 2.640s: HTTP 200, version `v7.2.95`, `verified=true`, health `ok`, loopback listener and live `cli-proxy-api` process. A syntactically valid fake OpenAI key returned HTTP 502 `discovery_failed` in 1.112s, never `engine_down`; source state remained empty and `/health` stayed HTTP 200.

## Known by design / residual checks

- `linux-arm64` manifest expansion and mirror ownership remain L7 scope per the frozen contract; this PR does not alter the runtime manifest or mirror guard.
- Native CLI subscription OAuth remains fail-closed because no real adapter implementation exists yet.
- No real credential was used. Orchestrator integration should repeat the smoke once the L7 manifest supplies the regression host platform without an override.

## Dependencies

None.
