### PR TITLE
fix(model-hub): resolve live turns before streaming

### DIFF
--- a/core/controller.py
+++ b/core/controller.py
@@ -225,11 +225,21 @@ class Controller:
 
         self.session_turns = SessionTurnManager(self)
 
-        # Model Hub owns per-turn supply selection. Backend adapters consume
-        # the resulting launch plan without persisting native CLI config.
+        # The controller is the single Model Hub aggregate and engine owner.
+        # The UI process reaches this instance through the internal Unix socket.
+        from core.handlers.model_hub import create_default_service
+        from core.handlers.model_hub.turn_gateway import ModelHubTurnGateway
         from modules.agents.model_hub import ModelHubRuntimeRouter
+        from vibe.model_hub_runtime import get_model_hub_engine_adapter
 
-        self.model_hub_runtime = ModelHubRuntimeRouter()
+        self.model_hub_service = create_default_service(
+            adapter=get_model_hub_engine_adapter(),
+        )
+        self.model_hub_turn_gateway = ModelHubTurnGateway(self.model_hub_service)
+        self.model_hub_runtime = ModelHubRuntimeRouter(
+            service=self.model_hub_service,
+            turn_gateway=self.model_hub_turn_gateway,
+        )
 
         # Initialize core modules
         self._init_modules()
@@ -1533,6 +1543,7 @@ class Controller:
         _stop_loop_coroutine(self.scheduled_task_service.stop(), "Scheduled task service")
         _stop_loop_coroutine(self.watch_service.stop(), "Watch service")
         _stop_loop_coroutine(self.runtime_command_watcher.stop(), "Runtime command watcher")
+        _stop_loop_coroutine(self.model_hub_turn_gateway.close(), "Model Hub turn gateway")
         show_git_checkpoint_service = getattr(self, "show_git_checkpoint_service", None)
         if show_git_checkpoint_service is not None:
             show_git_checkpoint_service.stop()

--- a/core/controller.py
+++ b/core/controller.py
@@ -1540,7 +1540,9 @@ class Controller:
         _stop_loop_coroutine(self.scheduled_task_service.stop(), "Scheduled task service")
         _stop_loop_coroutine(self.watch_service.stop(), "Watch service")
         _stop_loop_coroutine(self.runtime_command_watcher.stop(), "Runtime command watcher")
-        _stop_loop_coroutine(self.model_hub_turn_gateway.close(), "Model Hub turn gateway")
+        model_hub_turn_gateway = getattr(self, "model_hub_turn_gateway", None)
+        if model_hub_turn_gateway is not None:
+            _stop_loop_coroutine(model_hub_turn_gateway.close(), "Model Hub turn gateway")
         show_git_checkpoint_service = getattr(self, "show_git_checkpoint_service", None)
         if show_git_checkpoint_service is not None:
             show_git_checkpoint_service.stop()

--- a/core/handlers/model_hub/request.py
+++ b/core/handlers/model_hub/request.py
@@ -8,6 +8,13 @@ from typing import Any, Mapping
 class ModelHubRequest(dict[str, Any]):
     """Raw request body plus the protocol spoken by the local caller."""
 
-    def __init__(self, payload: Mapping[str, Any], *, protocol: str) -> None:
+    def __init__(
+        self,
+        payload: Mapping[str, Any],
+        *,
+        protocol: str,
+        headers: Mapping[str, str] | None = None,
+    ) -> None:
         super().__init__(payload)
         self.protocol = protocol
+        self.headers = dict(headers or {})

--- a/core/handlers/model_hub/request.py
+++ b/core/handlers/model_hub/request.py
@@ -1,0 +1,13 @@
+"""Request metadata carried through the frozen EngineAdapter mapping surface."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+
+class ModelHubRequest(dict[str, Any]):
+    """Raw request body plus the protocol spoken by the local caller."""
+
+    def __init__(self, payload: Mapping[str, Any], *, protocol: str) -> None:
+        super().__init__(payload)
+        self.protocol = protocol

--- a/core/handlers/model_hub/rpc.py
+++ b/core/handlers/model_hub/rpc.py
@@ -1,0 +1,60 @@
+"""Allowlisted RPC surface for the controller-owned Model Hub service."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .service import ModelHubError, ModelHubService
+
+
+async def dispatch_model_hub_rpc(
+    service: ModelHubService,
+    operation: str,
+    payload: dict[str, Any],
+) -> Any:
+    if operation == "list_sources":
+        return service.list_sources()
+    if operation == "create_source":
+        return await service.create_source(payload.get("source"))
+    if operation == "patch_source":
+        return await service.patch_source(payload.get("source_id"), payload.get("patch"))
+    if operation == "delete_source":
+        await service.delete_source(payload.get("source_id"), force=payload.get("force") is True)
+        return None
+    if operation == "test_source":
+        source, discovered = await service.test_source(payload.get("source_id"))
+        return {"source": source, "discovered": discovered}
+    if operation == "priority":
+        return service.priority()
+    if operation == "set_priority":
+        return await service.set_priority(payload.get("order"))
+    if operation == "list_agents":
+        return service.list_agents()
+    if operation == "set_agent_mode":
+        return await service.set_agent_mode(payload.get("backend"), payload.get("mode"))
+    if operation == "set_mappings":
+        return await service.set_mappings(payload.get("backend"), payload.get("mappings"))
+    if operation == "set_opencode_menu":
+        return await service.set_opencode_menu(payload.get("menu"))
+    if operation == "add_custom_model":
+        return await service.add_custom_model(payload.get("model"))
+    if operation == "delete_custom_model":
+        return await service.delete_custom_model(payload.get("source_id"), payload.get("model_id"))
+    if operation == "list_events":
+        return service.list_events(limit=payload.get("limit", 20), before=payload.get("before"))
+    if operation == "oauth_start":
+        return await service.oauth_start(payload.get("oauth"))
+    if operation == "oauth_status":
+        return await service.oauth_status(payload.get("flow_id"))
+    if operation == "oauth_submit":
+        return await service.oauth_submit(payload.get("oauth"))
+    if operation == "oauth_cancel":
+        await service.oauth_cancel(payload.get("flow_id"))
+        return None
+    if operation == "migration_scan":
+        return service.migration_scan()
+    if operation == "migration_apply":
+        return await service.migration_apply(payload.get("item_ids"))
+    if operation == "runtime_status":
+        return await service.runtime_status()
+    raise ModelHubError("source_not_found", status=404)

--- a/core/handlers/model_hub/service.py
+++ b/core/handlers/model_hub/service.py
@@ -1176,6 +1176,7 @@ class ModelHubService:
         model_id: str,
         *,
         provider: Optional[str] = None,
+        supply_channel: Literal["hub"] | None = None,
     ) -> list[ModelHubSourceConfig]:
         async with self._mutation_lock:
             config = self.store.load()
@@ -1186,6 +1187,7 @@ class ModelHubService:
                 source = by_id[source_id]
                 matches_request = (
                     self._eligible_for_agent(source, backend)
+                    and (supply_channel is None or source.supply_channel == supply_channel)
                     and (provider is None or opencode_provider_id(source.vendor) == provider)
                     and any(model.id == model_id for model in source.models)
                 )
@@ -1295,6 +1297,7 @@ class ModelHubService:
         model_id: str,
         request: Mapping[str, Any],
         stream: bool = False,
+        supply_channel: Literal["hub"] | None = None,
     ) -> ResolvedInvocation:
         if backend not in {"claude", "codex", "opencode"}:
             raise ModelHubError("mapping_target_unavailable")
@@ -1330,7 +1333,12 @@ class ModelHubService:
                 from_label=model_id,
                 now=self.now(),
             )
-        candidates = await self._resolution_candidates(backend, target_model, provider=provider)
+        candidates = await self._resolution_candidates(
+            backend,
+            target_model,
+            provider=provider,
+            supply_channel=supply_channel,
+        )
         if not candidates:
             raise ModelHubError("mapping_target_unavailable", status=409)
 
@@ -1405,6 +1413,15 @@ class ModelHubService:
                     source=source,
                 )
                 return ResolvedInvocation(source.id, target_model, handle, outcome)
+            if decision.action == "surface":
+                raise ModelHubError(
+                    decision.error_code or outcome.error_code or "engine_down",
+                    status=(
+                        outcome.http_status
+                        if outcome.http_status is not None and 400 <= outcome.http_status <= 599
+                        else 502
+                    ),
+                )
             if decision.action == "fallback":
                 await self._cooldown(source, decision, agent=event_agent, model_id=target_model)
                 failed_source = source

--- a/core/handlers/model_hub/turn_gateway.py
+++ b/core/handlers/model_hub/turn_gateway.py
@@ -28,6 +28,13 @@ _REQUEST_PROTOCOLS: Final = {
     "responses": "openai_responses",
     "chat/completions": "openai_chat",
 }
+_PROTOCOL_HEADERS: Final = frozenset(
+    {
+        "anthropic-beta",
+        "anthropic-version",
+        "openai-beta",
+    }
+)
 
 
 class ModelHubTurnGateway:
@@ -114,10 +121,19 @@ class ModelHubTurnGateway:
             return self._error_response(status=400, code="invalid_request_error")
 
         try:
+            protocol_headers = {
+                name.lower(): value
+                for name, value in request.headers.items()
+                if name.lower() in _PROTOCOL_HEADERS
+            }
             resolved = await self.service.resolve(
                 backend=backend,
                 model_id=model_id,
-                request=ModelHubRequest(payload, protocol=_REQUEST_PROTOCOLS[endpoint]),
+                request=ModelHubRequest(
+                    payload,
+                    protocol=_REQUEST_PROTOCOLS[endpoint],
+                    headers=protocol_headers,
+                ),
                 stream=stream,
                 supply_channel="hub",
             )

--- a/core/handlers/model_hub/turn_gateway.py
+++ b/core/handlers/model_hub/turn_gateway.py
@@ -1,0 +1,195 @@
+"""Loopback HTTP gateway that applies Model Hub resolution to live turns."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import secrets
+import socket
+from typing import Final
+
+from aiohttp import web
+
+from .adapter import RawCallOutcome, RawOutcomeKind
+from .request import ModelHubRequest
+from .service import ModelHubError, ModelHubService, ResolvedInvocation
+
+
+_MAX_REQUEST_BYTES: Final = 16 * 1024 * 1024
+_SUPPORTED_PATHS: Final = frozenset(
+    {
+        "messages",
+        "responses",
+        "chat/completions",
+    }
+)
+_REQUEST_PROTOCOLS: Final = {
+    "messages": "anthropic",
+    "responses": "openai_responses",
+    "chat/completions": "openai_chat",
+}
+
+
+class ModelHubTurnGateway:
+    """Expose the controller-owned resolver to backend CLI HTTP clients."""
+
+    def __init__(self, service: ModelHubService) -> None:
+        self.service = service
+        self._tokens = {
+            backend: secrets.token_urlsafe(32)
+            for backend in ("claude", "codex", "opencode")
+        }
+        self._start_lock = asyncio.Lock()
+        self._runner: web.AppRunner | None = None
+        self._site: web.SockSite | None = None
+        self._base_url: str | None = None
+
+    async def endpoint(self, backend: str) -> tuple[str, str]:
+        if backend not in {"claude", "codex", "opencode"}:
+            raise ModelHubError("mapping_target_unavailable", status=409)
+        await self._ensure_started()
+        assert self._base_url is not None
+        return f"{self._base_url}/{backend}", self._tokens[backend]
+
+    async def close(self) -> None:
+        runner = self._runner
+        self._runner = None
+        self._site = None
+        self._base_url = None
+        if runner is not None:
+            await runner.cleanup()
+
+    async def _ensure_started(self) -> None:
+        if self._runner is not None:
+            return
+        async with self._start_lock:
+            if self._runner is not None:
+                return
+            app = web.Application(client_max_size=_MAX_REQUEST_BYTES)
+            app.router.add_post("/{backend}/v1/{endpoint:.*}", self._handle_request)
+            runner = web.AppRunner(app, access_log=None)
+            await runner.setup()
+            listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            listener.bind(("127.0.0.1", 0))
+            listener.listen(128)
+            listener.setblocking(False)
+            site = web.SockSite(runner, listener)
+            try:
+                await site.start()
+            except Exception:
+                listener.close()
+                await runner.cleanup()
+                raise
+            port = int(listener.getsockname()[1])
+            self._runner = runner
+            self._site = site
+            self._base_url = f"http://127.0.0.1:{port}"
+
+    def _authorized(self, request: web.Request, backend: str) -> bool:
+        expected = self._tokens.get(backend)
+        if expected is None:
+            return False
+        authorization = request.headers.get("Authorization", "")
+        bearer = authorization[7:] if authorization.lower().startswith("bearer ") else ""
+        api_key = request.headers.get("x-api-key", "")
+        return secrets.compare_digest(bearer, expected) or secrets.compare_digest(api_key, expected)
+
+    async def _handle_request(self, request: web.Request) -> web.StreamResponse:
+        backend = request.match_info["backend"]
+        if not self._authorized(request, backend):
+            return self._error_response(status=401, code="authentication_error")
+        endpoint = request.match_info["endpoint"].strip("/")
+        if backend not in {"claude", "codex", "opencode"} or endpoint not in _SUPPORTED_PATHS:
+            return self._error_response(status=404, code="not_found_error")
+        try:
+            payload = await request.json(loads=json.loads)
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            return self._error_response(status=400, code="invalid_request_error")
+        if not isinstance(payload, dict):
+            return self._error_response(status=400, code="invalid_request_error")
+        model_id = payload.get("model")
+        stream = payload.get("stream", False)
+        if not isinstance(model_id, str) or not model_id or not isinstance(stream, bool):
+            return self._error_response(status=400, code="invalid_request_error")
+
+        try:
+            resolved = await self.service.resolve(
+                backend=backend,
+                model_id=model_id,
+                request=ModelHubRequest(payload, protocol=_REQUEST_PROTOCOLS[endpoint]),
+                stream=stream,
+                supply_channel="hub",
+            )
+        except ModelHubError as exc:
+            return self._error_response(status=exc.status, code=exc.code)
+        return await self._resolved_response(request, resolved, stream=stream)
+
+    async def _resolved_response(
+        self,
+        request: web.Request,
+        resolved: ResolvedInvocation,
+        *,
+        stream: bool,
+    ) -> web.StreamResponse:
+        if resolved.supply_channel != "hub":
+            return self._error_response(status=409, code="mode_switch_blocked")
+        if resolved.outcome is not None:
+            return self._outcome_response(resolved.outcome)
+        handle = resolved.handle
+        if handle is None or handle.stream is None:
+            return self._error_response(status=502, code="engine_down")
+
+        if not stream:
+            payload = bytearray()
+            async for chunk in handle.stream:
+                payload.extend(chunk)
+            await handle.outcome()
+            return web.Response(
+                status=200,
+                body=bytes(payload),
+                content_type="application/json",
+                headers={"Cache-Control": "no-store", "X-Content-Type-Options": "nosniff"},
+            )
+
+        response = web.StreamResponse(
+            status=200,
+            headers={
+                "Cache-Control": "no-store",
+                "Content-Type": "text/event-stream",
+                "X-Accel-Buffering": "no",
+                "X-Content-Type-Options": "nosniff",
+            },
+        )
+        await response.prepare(request)
+        try:
+            async for chunk in handle.stream:
+                await response.write(chunk)
+        finally:
+            await handle.outcome()
+        await response.write_eof()
+        return response
+
+    @staticmethod
+    def _outcome_response(outcome: RawCallOutcome) -> web.Response:
+        if outcome.kind == RawOutcomeKind.SUCCESS:
+            return web.Response(status=200, body=b"{}", content_type="application/json")
+        status = outcome.http_status if outcome.http_status and 400 <= outcome.http_status <= 599 else 502
+        return ModelHubTurnGateway._error_response(
+            status=status,
+            code=outcome.error_code or "api_error",
+        )
+
+    @staticmethod
+    def _error_response(*, status: int, code: str) -> web.Response:
+        return web.json_response(
+            {
+                "error": {
+                    "type": code,
+                    "code": code,
+                    "message": "Model Hub request failed",
+                }
+            },
+            status=status,
+            headers={"Cache-Control": "no-store", "X-Content-Type-Options": "nosniff"},
+        )

--- a/core/internal_server.py
+++ b/core/internal_server.py
@@ -424,6 +424,30 @@ def create_app(controller: "Controller") -> FastAPI:
             logger.exception("internal Agent backend reconcile failed")
             return JSONResponse(status_code=500, content={"ok": False, "error": str(exc)})
 
+    @app.post("/internal/model-hub")
+    async def _model_hub(request: Request) -> Any:
+        """Dispatch UI operations to the controller-owned Model Hub aggregate."""
+
+        from core.handlers.model_hub import ModelHubError
+        from core.handlers.model_hub.rpc import dispatch_model_hub_rpc
+
+        body = await _safe_json(request)
+        operation = body.get("operation") if isinstance(body, dict) else None
+        payload = body.get("payload") if isinstance(body, dict) else None
+        if not isinstance(operation, str) or not isinstance(payload, dict):
+            return JSONResponse(status_code=400, content={"ok": False, "error": "discovery_failed"})
+        service = getattr(controller, "model_hub_service", None)
+        if service is None:
+            return JSONResponse(status_code=503, content={"ok": False, "error": "engine_down"})
+        try:
+            result = await dispatch_model_hub_rpc(service, operation, payload)
+        except ModelHubError as exc:
+            response = {"ok": False, "error": exc.code}
+            if exc.detail:
+                response["detail"] = exc.detail
+            return JSONResponse(status_code=exc.status, content=response)
+        return {"ok": True, "result": result}
+
     @app.get("/internal/events")
     async def _events() -> Any:
         """Long-lived SSE feed of Controller-side inbox events.

--- a/modules/agents/model_hub.py
+++ b/modules/agents/model_hub.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from typing import Any, Callable, Literal, Mapping, Optional, cast
 
 from config import paths
-from config.v2_config import ModelHubConfig
+from config.v2_config import ModelHubConfig, ModelHubSourceConfig
 from core.handlers.model_hub.classification import ResolutionDecision
 from core.handlers.model_hub.events import EventAgent, EventReason
 from core.handlers.model_hub.identifiers import opencode_provider_id, parse_opencode_model_id
@@ -253,6 +253,7 @@ class ModelHubRuntimeRouter:
         self,
         *,
         service: ModelHubService | None = None,
+        turn_gateway: Any | None = None,
         overlay_path: Path | None = None,
         native_cli_ready: Callable[[BackendName], bool] | None = None,
     ) -> None:
@@ -261,11 +262,10 @@ class ModelHubRuntimeRouter:
 
             service = create_default_service(adapter=get_model_hub_engine_adapter())
         self.service = service
+        self.turn_gateway = turn_gateway
         self.overlay_path = overlay_path or paths.get_runtime_dir() / "model-hub" / "opencode-overlay.json"
         self.native_cli_ready = native_cli_ready or self._default_native_cli_ready
         self._last_launch: dict[tuple[BackendName, str], ModelHubLaunch] = {}
-        self._pending_switch_reason: dict[tuple[BackendName, str], EventReason] = {}
-        self._pending_source_failure: dict[tuple[BackendName, str], tuple[str, EventReason]] = {}
 
     @staticmethod
     def _default_native_cli_ready(backend: BackendName) -> bool:
@@ -372,7 +372,9 @@ class ModelHubRuntimeRouter:
                 return prefix
         raise ModelHubError("engine_down", status=503)
 
-    async def _gateway_credentials(self) -> tuple[str, str]:
+    async def _gateway_credentials(self, backend: BackendName) -> tuple[str, str]:
+        if self.turn_gateway is not None:
+            return await self.turn_gateway.endpoint(backend)
         await self.service._ensure_engine_synced()
         status = await self.service._engine_call(self.service.adapter.start())
         if status.listen_port is None:
@@ -380,17 +382,93 @@ class ModelHubRuntimeRouter:
         token = await self.service._engine_call(self.service.adapter.gateway_token())
         return f"http://{status.listen_host}:{status.listen_port}", token
 
-    def _emit_channel_switch(self, current: ModelHubLaunch) -> None:
+    @staticmethod
+    def _source_for_id(
+        config: ModelHubConfig,
+        source_id: object,
+    ) -> ModelHubSourceConfig | None:
+        if not isinstance(source_id, str):
+            return None
+        return next((source for source in config.sources if source.id == source_id), None)
+
+    def _transition_context(
+        self,
+        current: ModelHubLaunch,
+        config: ModelHubConfig,
+    ) -> tuple[ModelHubLaunch | None, ModelHubSourceConfig | None, EventReason | None]:
         route_key = self._route_key(current)
         previous = self._last_launch.get(route_key)
-        self._last_launch[route_key] = current
-        reason = self._pending_switch_reason.pop(route_key, None)
+        route_events = [
+            event
+            for event in self.service.events.list(limit=100)
+            if event.get("agent") == current.backend and event.get("model_id") == current.target_model
+        ]
+        pending_source: ModelHubSourceConfig | None = None
+        pending_reason: EventReason | None = None
+        for index, event in enumerate(route_events):
+            if event.get("kind") != "cooldown":
+                continue
+            failed_source_id = event.get("from_source")
+            consumed = any(
+                (
+                    newer.get("kind") == "switch"
+                    and newer.get("from_source") == failed_source_id
+                )
+                or (
+                    newer.get("kind") == "recover"
+                    and newer.get("to_source") == failed_source_id
+                )
+                for newer in route_events[:index]
+            )
+            if not consumed:
+                pending_source = self._source_for_id(config, failed_source_id)
+                reason = event.get("reason")
+                if reason in {"quota_exhausted", "rate_limited", "server_error", "network"}:
+                    pending_reason = cast(EventReason, reason)
+                break
+
+        if previous is None:
+            for event in route_events:
+                if event.get("kind") == "cooldown":
+                    source = self._source_for_id(config, event.get("from_source"))
+                elif event.get("kind") in {"switch", "channel_switch"}:
+                    source = self._source_for_id(config, event.get("to_source"))
+                else:
+                    continue
+                if source is not None:
+                    previous = ModelHubLaunch(
+                        backend=current.backend,
+                        channel=cast(LaunchChannel, source.supply_channel),
+                        requested_model=current.requested_model,
+                        target_model=current.target_model,
+                        runtime_model=current.runtime_model,
+                        source_id=source.id,
+                    )
+                    break
+        return previous, pending_source, pending_reason
+
+    def _emit_transition(self, current: ModelHubLaunch, config: ModelHubConfig) -> None:
+        previous, failed_source, failed_reason = self._transition_context(current, config)
+        self._last_launch[self._route_key(current)] = current
+        current_source = self._source_for_id(config, current.source_id)
+        if (
+            failed_source is not None
+            and failed_reason is not None
+            and current_source is not None
+            and failed_source.id != current_source.id
+        ):
+            self.service._emit_switch(
+                agent=cast(EventAgent, current.backend),
+                model_id=current.target_model,
+                failed_source=failed_source,
+                failed_reason=failed_reason,
+                source=current_source,
+            )
         if previous is None or previous.channel == current.channel:
             return
         if {previous.channel, current.channel} != {"native_cli", "hub"}:
             return
-        if reason is None:
-            reason = "recovery" if current.channel == "native_cli" else "manual"
+        reason = failed_reason or ("recovery" if current.channel == "native_cli" else "manual")
         self.service._record_event(
             agent=cast(EventAgent, current.backend),
             kind="channel_switch",
@@ -401,36 +479,13 @@ class ModelHubRuntimeRouter:
             now=self.service.now(),
         )
 
-    def _emit_source_switch(self, current: ModelHubLaunch, config: ModelHubConfig) -> None:
-        route_key = self._route_key(current)
-        pending = self._pending_source_failure.get(route_key)
-        if pending is None or not current.source_id:
-            return
-        failed_source_id, reason = pending
-        if failed_source_id == current.source_id:
-            self._pending_source_failure.pop(route_key, None)
-            return
-        failed_source = next((source for source in config.sources if source.id == failed_source_id), None)
-        current_source = next((source for source in config.sources if source.id == current.source_id), None)
-        if failed_source is None or current_source is None:
-            self._pending_source_failure.pop(route_key, None)
-            return
-        self.service._emit_switch(
-            agent=cast(EventAgent, current.backend),
-            model_id=current.target_model,
-            failed_source=failed_source,
-            failed_reason=reason,
-            source=current_source,
-        )
-        self._pending_source_failure.pop(route_key, None)
-
     async def resolve(self, backend: BackendName, requested_model: str) -> ModelHubLaunch:
         requested_model = str(requested_model or "").strip()
         config = self.service.store.load()
         agent = config.agents[backend]
         if agent.mode == "direct":
             launch = self._direct_launch(backend, requested_model)
-            self._emit_channel_switch(launch)
+            self._emit_transition(launch, config)
             return launch
         # Fresh installs seed Hub mode before setup/migration has configured
         # every backend/model route. Preserve native launch only for an
@@ -487,20 +542,22 @@ class ModelHubRuntimeRouter:
                 source_id=source.id,
             )
         else:
-            gateway_base_url, gateway_token = await self._gateway_credentials()
-            prefix = await self._source_prefix(source.id)
+            gateway_base_url, gateway_token = await self._gateway_credentials(backend)
+            runtime_model = target_model
+            if self.turn_gateway is None:
+                prefix = await self._source_prefix(source.id)
+                runtime_model = f"{prefix}/{target_model}"
             launch = ModelHubLaunch(
                 backend=backend,
                 channel="hub",
                 requested_model=requested_model,
                 target_model=target_model,
-                runtime_model=f"{prefix}/{target_model}",
+                runtime_model=runtime_model,
                 source_id=source.id,
                 gateway_base_url=gateway_base_url,
                 gateway_token=gateway_token,
             )
-        self._emit_source_switch(launch, config)
-        self._emit_channel_switch(launch)
+        self._emit_transition(launch, config)
         return launch
 
     async def resolve_opencode_overlay_launch(
@@ -517,8 +574,7 @@ class ModelHubRuntimeRouter:
         if launch is None:
             raise ModelHubError("mapping_target_unavailable", status=409)
         config = self.service.store.load()
-        self._emit_source_switch(launch, config)
-        self._emit_channel_switch(launch)
+        self._emit_transition(launch, config)
         return launch
 
     async def record_native_failure(self, context: Any, diagnostic: str) -> bool:
@@ -530,6 +586,8 @@ class ModelHubRuntimeRouter:
 
         launch = launch_for_context(context)
         if launch is None or launch.channel not in {"native_cli", "hub"} or not launch.source_id:
+            return False
+        if launch.channel == "hub" and self.turn_gateway is not None:
             return False
         if getattr(context, _CONTEXT_FAILURE_RECORDED_ATTR, False):
             return False
@@ -554,10 +612,6 @@ class ModelHubRuntimeRouter:
             model_id=launch.target_model,
         )
         setattr(context, _CONTEXT_FAILURE_RECORDED_ATTR, True)
-        reason = cast(EventReason, decision.reason)
-        route_key = self._route_key(launch)
-        self._pending_source_failure[route_key] = (launch.source_id, reason)
-        self._pending_switch_reason[route_key] = reason
         return True
 
     async def prepare_opencode_overlay(self) -> OpenCodeOverlay | None:
@@ -571,7 +625,7 @@ class ModelHubRuntimeRouter:
         if not checked:
             raise ModelHubError("mapping_target_unavailable", status=409)
 
-        gateway_base_url, gateway_token = await self._gateway_credentials()
+        gateway_base_url, gateway_token = await self._gateway_credentials("opencode")
         providers: dict[str, dict[str, Any]] = {}
         projected_identifiers: list[str] = []
         available_identifiers: list[str] = []
@@ -609,7 +663,6 @@ class ModelHubRuntimeRouter:
                 )
             if source is None:
                 continue
-            prefix = await self._source_prefix(source.id)
             package = _provider_package(source.protocol)
             base_url = _provider_base_url(gateway_base_url, source.protocol)
             provider = providers.setdefault(
@@ -624,8 +677,12 @@ class ModelHubRuntimeRouter:
             if provider["npm"] != package or provider["options"]["baseURL"] != base_url:
                 raise ModelHubError("mapping_target_unavailable", status=409)
             model = next(item for item in source.models if item.id == model_id)
+            runtime_model = identifier
+            if self.turn_gateway is None:
+                prefix = await self._source_prefix(source.id)
+                runtime_model = f"{prefix}/{model_id}"
             provider["models"][model_id] = {
-                "id": f"{prefix}/{model_id}",
+                "id": runtime_model,
                 "name": model.display_name or model_id,
             }
             projected_identifiers.append(identifier)
@@ -637,7 +694,7 @@ class ModelHubRuntimeRouter:
                         channel="hub",
                         requested_model=identifier,
                         target_model=model_id,
-                        runtime_model=f"{prefix}/{model_id}",
+                        runtime_model=runtime_model,
                         source_id=source.id,
                         gateway_base_url=gateway_base_url,
                         gateway_token=gateway_token,

--- a/tests/scenarios/model_hub/catalog.yaml
+++ b/tests/scenarios/model_hub/catalog.yaml
@@ -7,11 +7,36 @@ capability:
     - tests/test_model_hub_config.py
     - tests/test_model_hub_resolution.py
     - tests/test_model_hub_injection.py
+    - tests/scenarios/model_hub/test_model_hub_live_resolution_scenarios.py
 status_legend:
   covered: closed-loop scenario coverage exists
   partial: unit or contract coverage exists but the cross-lane loop is incomplete
   gap: owned by a later lane or integration pass
 scenarios:
+  - id: MH-RES-LIVE-001
+    name: Live turn retries an eligible backup before streaming starts
+    status: covered
+    kind: recovery
+    layer: scenario
+    test: tests/scenarios/model_hub/test_model_hub_live_resolution_scenarios.py::test_mh_res_live_001_pre_stream_failure_falls_back_within_turn
+  - id: MH-RES-LIVE-002
+    name: Live turn refreshes one 401 exactly once
+    status: covered
+    kind: recovery
+    layer: scenario
+    test: tests/scenarios/model_hub/test_model_hub_live_resolution_scenarios.py::test_mh_res_live_002_401_refreshes_once_in_live_turn
+  - id: MH-RES-LIVE-003
+    name: Live turn never retries after response streaming starts
+    status: covered
+    kind: compatibility
+    layer: scenario
+    test: tests/scenarios/model_hub/test_model_hub_live_resolution_scenarios.py::test_mh_res_live_003_started_stream_never_retries
+  - id: MH-EVT-002
+    name: Causal switch events survive service restart
+    status: covered
+    kind: recovery
+    layer: scenario
+    test: tests/scenarios/model_hub/test_model_hub_live_resolution_scenarios.py::test_mh_evt_002_switch_events_survive_router_and_service_restart
   - id: MH-RES-001
     name: Quota-exhausted failover and recovery switchback
     status: partial

--- a/tests/scenarios/model_hub/test_model_hub_live_resolution_scenarios.py
+++ b/tests/scenarios/model_hub/test_model_hub_live_resolution_scenarios.py
@@ -1,0 +1,421 @@
+from __future__ import annotations
+
+import asyncio
+from collections import deque
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from types import SimpleNamespace
+from typing import AsyncIterator
+
+import aiohttp
+import pytest
+
+from config.v2_config import (
+    ModelHubAgentSupplyConfig,
+    ModelHubConfig,
+    ModelHubModelConfig,
+    ModelHubSourceConfig,
+    ModelHubSourceStateConfig,
+)
+from core.handlers.model_hub.adapter import (
+    EngineHealth,
+    EngineStatus,
+    RawCallOutcome,
+    RawOutcomeKind,
+)
+from core.handlers.model_hub.events import BoundedEventLog
+from core.handlers.model_hub.revocations import CredentialRevocationJournal
+from core.handlers.model_hub.service import ModelHubService
+from core.handlers.model_hub.turn_gateway import ModelHubTurnGateway
+from modules.agents.model_hub import ModelHubRuntimeRouter, bind_launch
+
+
+class MemoryStore:
+    def __init__(self, config: ModelHubConfig) -> None:
+        self.config = config
+
+    def load(self) -> ModelHubConfig:
+        return self.config
+
+    def save(self, config: ModelHubConfig) -> None:
+        self.config = config
+
+
+@dataclass(frozen=True)
+class AdapterResult:
+    kind: RawOutcomeKind
+    status: int | None = None
+    code: str | None = None
+    body: bytes | None = None
+    stream_started: bool = False
+
+
+class InvokeHandle:
+    def __init__(self, outcome: RawCallOutcome, body: bytes | None) -> None:
+        self._outcome = outcome
+        self._body = body
+
+    @property
+    def stream(self) -> AsyncIterator[bytes] | None:
+        if self._body is None:
+            return None
+
+        async def chunks() -> AsyncIterator[bytes]:
+            yield self._body
+
+        return chunks()
+
+    async def outcome(self) -> RawCallOutcome:
+        return self._outcome
+
+
+class AdapterBoundaryFake:
+    def __init__(self, results: list[AdapterResult]) -> None:
+        self.results = deque(results)
+        self.invocations: list[tuple[str, str, str]] = []
+
+    async def start(self) -> EngineStatus:
+        return EngineStatus(EngineHealth.OK, "test", True, "127.0.0.1", 18443, None)
+
+    async def gateway_token(self) -> str:
+        return "unused-engine-token"
+
+    async def sync_sources(self, bindings) -> None:
+        return None
+
+    async def revoke_credential(self, credential_ref: str) -> None:
+        return None
+
+    async def invoke(self, source_id, model_id, request, stream, origin) -> InvokeHandle:
+        self.invocations.append((source_id, model_id, origin))
+        result = self.results.popleft()
+        outcome = RawCallOutcome(
+            kind=result.kind,
+            http_status=result.status,
+            error_code=result.code,
+            redacted_message=None,
+            stream_started=result.stream_started,
+            model_id=model_id,
+            source_id=source_id,
+        )
+        return InvokeHandle(outcome, result.body)
+
+
+def _source(
+    source_id: str,
+    *,
+    channel: str = "hub",
+    kind: str = "api_key",
+) -> ModelHubSourceConfig:
+    return ModelHubSourceConfig(
+        id=source_id,
+        kind=kind,
+        vendor="openai" if kind == "subscription" else "anthropic",
+        display_name=source_id,
+        protocol="openai_responses" if kind == "subscription" else "anthropic",
+        supply_channel=channel,
+        billing="monthly" if kind == "subscription" else "metered",
+        state=ModelHubSourceStateConfig(status="standby"),
+        models=[ModelHubModelConfig(id="model-live", provenance="discovered")],
+        credential_ref=f"cred_{source_id}" if channel == "hub" else None,
+    )
+
+
+def _config(*sources: ModelHubSourceConfig) -> ModelHubConfig:
+    return ModelHubConfig(
+        sources=list(sources),
+        priority_order=[source.id for source in sources],
+        agents={
+            backend: ModelHubAgentSupplyConfig.default(backend, mode="hub")
+            for backend in ("claude", "codex", "opencode")
+        },
+    )
+
+
+def _service(
+    tmp_path: Path,
+    store: MemoryStore,
+    adapter: AdapterBoundaryFake,
+    *,
+    now,
+) -> ModelHubService:
+    return ModelHubService(
+        store=store,
+        adapter=adapter,
+        events=BoundedEventLog(tmp_path / "events.json"),
+        revocations=CredentialRevocationJournal(tmp_path / "revocations.json"),
+        now=now,
+    )
+
+
+async def _post_turn(
+    launch,
+    *,
+    endpoint: str = "messages",
+    stream: bool = False,
+) -> tuple[int, bytes]:
+    headers = {"Authorization": f"Bearer {launch.gateway_token}"}
+    async with aiohttp.ClientSession(trust_env=False) as client:
+        async with client.post(
+            f"{launch.gateway_base_url}/v1/{endpoint}",
+            headers=headers,
+            json={"model": launch.runtime_model, "messages": [], "stream": stream},
+        ) as response:
+            return response.status, await response.read()
+
+
+@pytest.mark.parametrize(
+    ("backend", "requested_model", "endpoint"),
+    [
+        ("claude", "model-live", "messages"),
+        ("codex", "model-live", "responses"),
+        ("opencode", "anthropic/model-live", "messages"),
+    ],
+)
+@pytest.mark.parametrize(
+    ("failed", "reason"),
+    [
+        (AdapterResult(RawOutcomeKind.HTTP_ERROR, status=429), "rate_limited"),
+        (AdapterResult(RawOutcomeKind.HTTP_ERROR, status=403, code="quota_exhausted"), "quota_exhausted"),
+        (AdapterResult(RawOutcomeKind.HTTP_ERROR, status=503), "server_error"),
+        (AdapterResult(RawOutcomeKind.NETWORK_ERROR), "network"),
+    ],
+)
+def test_mh_res_live_001_pre_stream_failure_falls_back_within_turn(
+    tmp_path: Path,
+    backend: str,
+    requested_model: str,
+    endpoint: str,
+    failed: AdapterResult,
+    reason: str,
+) -> None:
+    """MH-RES-LIVE-001: the real turn gateway completes on candidate two."""
+
+    async def exercise() -> None:
+        clock = [datetime(2026, 7, 25, tzinfo=timezone.utc)]
+        adapter = AdapterBoundaryFake(
+            [
+                failed,
+                AdapterResult(RawOutcomeKind.SUCCESS, status=200, body=b'{"ok":true}'),
+                AdapterResult(RawOutcomeKind.SUCCESS, status=200, body=b'{"recovered":true}'),
+            ]
+        )
+        store = MemoryStore(_config(_source("src_primary"), _source("src_backup")))
+        assert store.config.agents["opencode"].menu is not None
+        store.config.agents["opencode"].menu.checked = ["anthropic/model-live"]
+        service = _service(tmp_path, store, adapter, now=lambda: clock[0])
+        gateway = ModelHubTurnGateway(service)
+        router = ModelHubRuntimeRouter(service=service, turn_gateway=gateway)
+        try:
+            if backend == "opencode":
+                overlay = await router.prepare_opencode_overlay()
+                assert overlay is not None
+                launch = await router.resolve_opencode_overlay_launch(overlay, requested_model)
+            else:
+                launch = await router.resolve(backend, requested_model)
+            status, body = await _post_turn(launch, endpoint=endpoint)
+            assert status == 200
+            assert body == b'{"ok":true}'
+            assert [call[0] for call in adapter.invocations] == ["src_primary", "src_backup"]
+            assert store.load().sources[0].state.status == "cooldown"
+            assert [event["kind"] for event in service.list_events(limit=5)[:2]] == ["switch", "cooldown"]
+            assert service.list_events(limit=5)[1]["reason"] == reason
+
+            clock[0] += timedelta(minutes=6)
+            if backend == "opencode":
+                recovered_overlay = await router.prepare_opencode_overlay()
+                assert recovered_overlay is not None
+                recovered_launch = await router.resolve_opencode_overlay_launch(
+                    recovered_overlay,
+                    requested_model,
+                )
+            else:
+                recovered_launch = await router.resolve(backend, requested_model)
+            recovered_status, recovered_body = await _post_turn(
+                recovered_launch,
+                endpoint=endpoint,
+            )
+            assert recovered_status == 200
+            assert recovered_body == b'{"recovered":true}'
+            assert adapter.invocations[-1][0] == "src_primary"
+        finally:
+            await gateway.close()
+
+    asyncio.run(exercise())
+
+
+def test_mh_res_live_002_401_refreshes_once_in_live_turn(tmp_path: Path) -> None:
+    """MH-RES-LIVE-002: a 401 retries the same source exactly once."""
+
+    async def exercise() -> None:
+        adapter = AdapterBoundaryFake(
+            [
+                AdapterResult(RawOutcomeKind.HTTP_ERROR, status=401),
+                AdapterResult(RawOutcomeKind.SUCCESS, status=200, body=b'{"ok":true}'),
+            ]
+        )
+        store = MemoryStore(_config(_source("src_primary"), _source("src_backup")))
+        service = _service(
+            tmp_path,
+            store,
+            adapter,
+            now=lambda: datetime(2026, 7, 25, tzinfo=timezone.utc),
+        )
+        gateway = ModelHubTurnGateway(service)
+        router = ModelHubRuntimeRouter(service=service, turn_gateway=gateway)
+        try:
+            status, body = await _post_turn(await router.resolve("claude", "model-live"))
+            assert status == 200
+            assert body == b'{"ok":true}'
+            assert [call[0] for call in adapter.invocations] == ["src_primary", "src_primary"]
+            assert store.load().sources[0].state.status == "standby"
+        finally:
+            await gateway.close()
+
+    asyncio.run(exercise())
+
+
+def test_mh_res_live_002_second_401_surfaces_without_fallback(tmp_path: Path) -> None:
+    """MH-RES-LIVE-002: a second 401 is terminal for the selected source."""
+
+    async def exercise() -> None:
+        adapter = AdapterBoundaryFake(
+            [
+                AdapterResult(RawOutcomeKind.HTTP_ERROR, status=401),
+                AdapterResult(RawOutcomeKind.HTTP_ERROR, status=401),
+                AdapterResult(RawOutcomeKind.SUCCESS, status=200, body=b'{"backup":true}'),
+            ]
+        )
+        store = MemoryStore(_config(_source("src_primary"), _source("src_backup")))
+        service = _service(
+            tmp_path,
+            store,
+            adapter,
+            now=lambda: datetime(2026, 7, 25, tzinfo=timezone.utc),
+        )
+        gateway = ModelHubTurnGateway(service)
+        router = ModelHubRuntimeRouter(service=service, turn_gateway=gateway)
+        try:
+            status, _body = await _post_turn(await router.resolve("claude", "model-live"))
+            assert status == 401
+            assert [call[0] for call in adapter.invocations] == ["src_primary", "src_primary"]
+            assert store.load().sources[0].state.status == "standby"
+        finally:
+            await gateway.close()
+
+    asyncio.run(exercise())
+
+
+def test_mh_res_live_003_started_stream_never_retries(tmp_path: Path) -> None:
+    """MH-RES-LIVE-003: bytes already emitted make the source terminal."""
+
+    async def exercise() -> None:
+        adapter = AdapterBoundaryFake(
+            [
+                AdapterResult(
+                    RawOutcomeKind.HTTP_ERROR,
+                    status=429,
+                    body=b"data: partial\n\n",
+                    stream_started=True,
+                ),
+                AdapterResult(RawOutcomeKind.SUCCESS, status=200, body=b"data: backup\n\n"),
+            ]
+        )
+        store = MemoryStore(_config(_source("src_primary"), _source("src_backup")))
+        service = _service(
+            tmp_path,
+            store,
+            adapter,
+            now=lambda: datetime(2026, 7, 25, tzinfo=timezone.utc),
+        )
+        gateway = ModelHubTurnGateway(service)
+        router = ModelHubRuntimeRouter(service=service, turn_gateway=gateway)
+        try:
+            status, body = await _post_turn(await router.resolve("claude", "model-live"), stream=True)
+            assert status == 200
+            assert body == b"data: partial\n\n"
+            assert [call[0] for call in adapter.invocations] == ["src_primary"]
+            assert store.load().sources[0].state.status == "standby"
+        finally:
+            await gateway.close()
+
+    asyncio.run(exercise())
+
+
+def test_turn_gateway_tokens_are_bound_to_backend_origin(tmp_path: Path) -> None:
+    async def exercise() -> None:
+        adapter = AdapterBoundaryFake(
+            [AdapterResult(RawOutcomeKind.SUCCESS, status=200, body=b'{"ok":true}')]
+        )
+        store = MemoryStore(_config(_source("src_primary")))
+        service = _service(
+            tmp_path,
+            store,
+            adapter,
+            now=lambda: datetime(2026, 7, 25, tzinfo=timezone.utc),
+        )
+        gateway = ModelHubTurnGateway(service)
+        try:
+            claude_url, _claude_token = await gateway.endpoint("claude")
+            _codex_url, codex_token = await gateway.endpoint("codex")
+            async with aiohttp.ClientSession(trust_env=False) as client:
+                async with client.post(
+                    f"{claude_url}/v1/messages",
+                    headers={"Authorization": f"Bearer {codex_token}"},
+                    json={"model": "model-live", "messages": []},
+                ) as response:
+                    assert response.status == 401
+            assert adapter.invocations == []
+        finally:
+            await gateway.close()
+
+    asyncio.run(exercise())
+
+
+def test_mh_evt_002_switch_events_survive_router_and_service_restart(tmp_path: Path) -> None:
+    """MH-EVT-002: persisted cooldown causality survives process-local state loss."""
+
+    async def exercise() -> None:
+        clock = datetime(2026, 7, 25, tzinfo=timezone.utc)
+        native = _source("src_native", channel="native_cli", kind="subscription")
+        backup = _source("src_backup")
+        store = MemoryStore(_config(native, backup))
+        first_adapter = AdapterBoundaryFake([])
+        first_service = _service(tmp_path, store, first_adapter, now=lambda: clock)
+        first_gateway = ModelHubTurnGateway(first_service)
+        first_router = ModelHubRuntimeRouter(
+            service=first_service,
+            turn_gateway=first_gateway,
+            native_cli_ready=lambda backend: True,
+        )
+        launch = await first_router.resolve("codex", "model-live")
+        assert launch.channel == "native_cli"
+        context = SimpleNamespace()
+        bind_launch(context, launch)
+        assert await first_router.record_native_failure(context, "usage quota exceeded") is True
+        await first_gateway.close()
+
+        second_adapter = AdapterBoundaryFake([])
+        second_service = _service(tmp_path, store, second_adapter, now=lambda: clock)
+        second_gateway = ModelHubTurnGateway(second_service)
+        second_router = ModelHubRuntimeRouter(
+            service=second_service,
+            turn_gateway=second_gateway,
+            native_cli_ready=lambda backend: True,
+        )
+        try:
+            fallback = await second_router.resolve("codex", "model-live")
+            assert fallback.channel == "hub"
+            persisted = BoundedEventLog(tmp_path / "events.json").list(limit=10)
+            assert [event["kind"] for event in persisted[:3]] == [
+                "channel_switch",
+                "switch",
+                "cooldown",
+            ]
+            assert persisted[0]["from_source"] == "src_native"
+            assert persisted[0]["to_source"] == "src_backup"
+        finally:
+            await second_gateway.close()
+
+    asyncio.run(exercise())

--- a/tests/scenarios/model_hub/test_model_hub_live_resolution_scenarios.py
+++ b/tests/scenarios/model_hub/test_model_hub_live_resolution_scenarios.py
@@ -74,6 +74,7 @@ class AdapterBoundaryFake:
     def __init__(self, results: list[AdapterResult]) -> None:
         self.results = deque(results)
         self.invocations: list[tuple[str, str, str]] = []
+        self.requests: list[object] = []
 
     async def start(self) -> EngineStatus:
         return EngineStatus(EngineHealth.OK, "test", True, "127.0.0.1", 18443, None)
@@ -89,6 +90,7 @@ class AdapterBoundaryFake:
 
     async def invoke(self, source_id, model_id, request, stream, origin) -> InvokeHandle:
         self.invocations.append((source_id, model_id, origin))
+        self.requests.append(request)
         result = self.results.popleft()
         outcome = RawCallOutcome(
             kind=result.kind,
@@ -367,6 +369,42 @@ def test_turn_gateway_tokens_are_bound_to_backend_origin(tmp_path: Path) -> None
                 ) as response:
                     assert response.status == 401
             assert adapter.invocations == []
+        finally:
+            await gateway.close()
+
+    asyncio.run(exercise())
+
+
+def test_turn_gateway_preserves_only_protocol_capability_headers(tmp_path: Path) -> None:
+    async def exercise() -> None:
+        adapter = AdapterBoundaryFake(
+            [AdapterResult(RawOutcomeKind.SUCCESS, status=200, body=b'{"ok":true}')]
+        )
+        store = MemoryStore(_config(_source("src_primary")))
+        service = _service(
+            tmp_path,
+            store,
+            adapter,
+            now=lambda: datetime(2026, 7, 25, tzinfo=timezone.utc),
+        )
+        gateway = ModelHubTurnGateway(service)
+        try:
+            base_url, token = await gateway.endpoint("claude")
+            async with aiohttp.ClientSession(trust_env=False) as client:
+                async with client.post(
+                    f"{base_url}/v1/messages",
+                    headers={
+                        "x-api-key": token,
+                        "Authorization": "Bearer upstream-must-not-cross",
+                        "anthropic-beta": "interleaved-thinking",
+                    },
+                    json={"model": "model-live", "messages": []},
+                ) as response:
+                    assert response.status == 200
+            request = adapter.requests[0]
+            assert getattr(request, "headers") == {
+                "anthropic-beta": "interleaved-thinking",
+            }
         finally:
             await gateway.close()
 

--- a/tests/test_internal_server.py
+++ b/tests/test_internal_server.py
@@ -159,6 +159,7 @@ def test_create_app_exposes_minimal_endpoints():
     assert ("/internal/dispatch_async", ("POST",)) in routes
     assert ("/internal/reconcile-platforms", ("POST",)) in routes
     assert ("/internal/reconcile-agent-backends", ("POST",)) in routes
+    assert ("/internal/model-hub", ("POST",)) in routes
     assert ("/internal/cancel/{session_id}", ("POST",)) in routes
     assert ("/internal/dispatch", ("POST",)) in routes
     assert ("/internal/events", ("GET",)) in routes
@@ -226,6 +227,27 @@ def test_health_endpoint():
     resp = asyncio.run(_health_round_trip())
     assert resp.status_code == 200
     assert resp.json() == {"ok": True, "service": "vibe-remote-internal", "version": 1}
+
+
+def test_model_hub_rpc_uses_controller_owned_service():
+    controller = _build_controller_double()
+    controller.model_hub_service = MagicMock()
+    controller.model_hub_service.list_sources.return_value = [{"id": "src_owned"}]
+    app = internal_server.create_app(controller)
+
+    async def _go():
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+            return await client.post(
+                "/internal/model-hub",
+                json={"operation": "list_sources", "payload": {}},
+            )
+
+    response = asyncio.run(_go())
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": True, "result": [{"id": "src_owned"}]}
+    controller.model_hub_service.list_sources.assert_called_once_with()
 
 
 async def _publish_event_round_trip():

--- a/tests/test_model_hub_api.py
+++ b/tests/test_model_hub_api.py
@@ -24,6 +24,7 @@ from core.handlers.model_hub.events import BoundedEventLog, ResolutionEvent
 from core.handlers.model_hub.oauth import OAuthFlowRegistry
 from core.handlers.model_hub.revocations import CredentialRevocationJournal
 from core.handlers.model_hub.service import ModelHubError, ModelHubService
+from vibe.model_hub_client import ModelHubRemoteService, _decode
 from tests.ui_server_test_helpers import csrf_headers
 from vibe import ui_server
 from vibe.ui_server import app
@@ -208,6 +209,35 @@ def test_agents_endpoint_projects_builtin_models_and_standard_vendors(tmp_path):
 
     assert agents["opencode"]["builtin_models"] is None
     assert agents["opencode"]["standard_vendors"] == sorted(STANDARD_OPENCODE_VENDOR_IDS)
+
+
+def test_ui_model_hub_default_is_controller_rpc_client(monkeypatch):
+    monkeypatch.setattr(ui_server, "_MODEL_HUB_SERVICE", None)
+
+    service = ui_server._model_hub_service()
+
+    assert isinstance(service, ModelHubRemoteService)
+    assert not hasattr(service, "adapter")
+
+
+def test_ui_model_hub_rpc_preserves_controller_error_contract():
+    import httpx
+
+    response = httpx.Response(
+        409,
+        json={
+            "ok": False,
+            "error": "mode_switch_blocked",
+            "detail": "modelHub.errors.mode_switch_blocked",
+        },
+    )
+
+    with pytest.raises(ModelHubError) as exc_info:
+        _decode(response)
+
+    assert exc_info.value.code == "mode_switch_blocked"
+    assert exc_info.value.status == 409
+    assert exc_info.value.detail == "modelHub.errors.mode_switch_blocked"
 
 
 def test_model_hub_rest_api_contract(monkeypatch, tmp_path):

--- a/tests/test_model_hub_runtime.py
+++ b/tests/test_model_hub_runtime.py
@@ -25,6 +25,7 @@ from core.handlers.model_hub.adapter import (
     RawOutcomeKind,
     SourceBinding,
 )
+from core.handlers.model_hub.request import ModelHubRequest
 from vibe.model_hub_runtime import client as client_module
 from vibe.model_hub_runtime.adapter import CLIProxyEngineAdapter
 from vibe.model_hub_runtime.client import EngineClient, EngineClientError
@@ -761,6 +762,75 @@ def test_adapter_enforces_origin_and_returns_raw_outcomes(tmp_path: Path) -> Non
     asyncio.run(run())
 
 
+@pytest.mark.parametrize(
+    ("source_protocol", "origin", "caller_protocol", "request_protocol"),
+    [
+        ("openai_compatible", "claude", "openai_chat", "anthropic"),
+        ("anthropic", "codex", "anthropic", "openai_responses"),
+        ("openai_chat", "opencode", "anthropic", "anthropic"),
+    ],
+)
+def test_adapter_uses_origin_protocol_for_engine_translation(
+    tmp_path: Path,
+    source_protocol: str,
+    origin: str,
+    caller_protocol: str,
+    request_protocol: str,
+) -> None:
+    class Client:
+        def __init__(self) -> None:
+            self.request_protocol = None
+
+        async def invoke(
+            self,
+            source,
+            model_id,
+            request,
+            *,
+            stream,
+            request_protocol=None,
+        ):
+            self.request_protocol = request_protocol
+            return object()
+
+    class Supervisor:
+        def __init__(self, client: Client) -> None:
+            self._client = client
+
+        def client(self):
+            return self._client
+
+    async def run() -> None:
+        store = EngineStateStore(tmp_path / "state")
+        credential_ref = store.store_api_key(
+            "upstream-secret",
+            vendor="custom",
+            protocol=source_protocol,
+            base_url="https://api.example.test/v1",
+        )
+        store.sync_sources(
+            [
+                _binding(
+                    credential_ref,
+                    protocol=source_protocol,
+                    allowed_origins=(origin,),
+                )
+            ]
+        )
+        client = Client()
+        adapter = CLIProxyEngineAdapter(
+            supervisor=Supervisor(client),  # type: ignore[arg-type]
+            state_store=store,
+        )
+
+        request = ModelHubRequest({}, protocol=caller_protocol)
+        await adapter.invoke("src_fixture123", "model-a", request, False, origin)
+
+        assert client.request_protocol == request_protocol
+
+    asyncio.run(run())
+
+
 def test_adapter_restores_source_projection_when_restart_fails(tmp_path: Path) -> None:
     class Supervisor:
         def __init__(self) -> None:
@@ -813,7 +883,7 @@ def test_adapter_serializes_source_sync_with_new_invocations(tmp_path: Path) -> 
     invoked_refs: list[str] = []
 
     class Client:
-        async def invoke(self, source, model_id, request, *, stream):
+        async def invoke(self, source, model_id, request, *, stream, request_protocol=None):
             invoked_refs.append(source.credential_ref)
             return object()
 

--- a/tests/test_model_hub_runtime.py
+++ b/tests/test_model_hub_runtime.py
@@ -789,8 +789,10 @@ def test_adapter_uses_origin_protocol_for_engine_translation(
             *,
             stream,
             request_protocol=None,
+            request_headers=None,
         ):
             self.request_protocol = request_protocol
+            self.request_headers = request_headers
             return object()
 
     class Supervisor:
@@ -823,10 +825,18 @@ def test_adapter_uses_origin_protocol_for_engine_translation(
             state_store=store,
         )
 
-        request = ModelHubRequest({}, protocol=caller_protocol)
+        request = ModelHubRequest(
+            {},
+            protocol=caller_protocol,
+            headers={"anthropic-beta": "interleaved-thinking", "authorization": "never-forward"},
+        )
         await adapter.invoke("src_fixture123", "model-a", request, False, origin)
 
         assert client.request_protocol == request_protocol
+        assert client.request_headers == {
+            "anthropic-beta": "interleaved-thinking",
+            "authorization": "never-forward",
+        }
 
     asyncio.run(run())
 
@@ -883,7 +893,16 @@ def test_adapter_serializes_source_sync_with_new_invocations(tmp_path: Path) -> 
     invoked_refs: list[str] = []
 
     class Client:
-        async def invoke(self, source, model_id, request, *, stream, request_protocol=None):
+        async def invoke(
+            self,
+            source,
+            model_id,
+            request,
+            *,
+            stream,
+            request_protocol=None,
+            request_headers=None,
+        ):
             invoked_refs.append(source.credential_ref)
             return object()
 

--- a/vibe/model_hub_client.py
+++ b/vibe/model_hub_client.py
@@ -1,0 +1,145 @@
+"""UI-process client for the controller-owned Model Hub service."""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+import httpx
+
+from core.handlers.model_hub import ModelHubError
+from vibe.internal_client import default_socket_path
+
+
+_TRANSPORT_ERRORS = (httpx.ConnectError, httpx.TimeoutException, OSError)
+_RPC_TIMEOUT_SECONDS = 300.0
+
+
+def _decode(response: httpx.Response) -> Any:
+    try:
+        body = response.json()
+    except ValueError:
+        raise ModelHubError("engine_down", status=503) from None
+    if not isinstance(body, dict):
+        raise ModelHubError("engine_down", status=503)
+    if response.status_code >= 400 or body.get("ok") is not True:
+        code = body.get("error")
+        detail = body.get("detail")
+        error = ModelHubError(
+            code if isinstance(code, str) else "engine_down",
+            status=response.status_code if response.status_code >= 400 else 503,
+        )
+        if isinstance(detail, str):
+            error.detail = detail
+        raise error
+    return body.get("result")
+
+
+def _rpc_sync(operation: str, payload: Optional[dict[str, Any]] = None) -> Any:
+    target = default_socket_path().expanduser().resolve()
+    if not target.exists():
+        raise ModelHubError("engine_down", status=503)
+    transport = httpx.HTTPTransport(uds=str(target))
+    try:
+        with httpx.Client(
+            transport=transport,
+            base_url="http://localhost",
+            timeout=httpx.Timeout(_RPC_TIMEOUT_SECONDS, connect=2.0),
+        ) as client:
+            response = client.post(
+                "/internal/model-hub",
+                json={"operation": operation, "payload": payload or {}},
+            )
+    except _TRANSPORT_ERRORS:
+        raise ModelHubError("engine_down", status=503) from None
+    return _decode(response)
+
+
+async def _rpc(operation: str, payload: Optional[dict[str, Any]] = None) -> Any:
+    target = default_socket_path().expanduser().resolve()
+    if not target.exists():
+        raise ModelHubError("engine_down", status=503)
+    transport = httpx.AsyncHTTPTransport(uds=str(target))
+    try:
+        async with httpx.AsyncClient(
+            transport=transport,
+            base_url="http://localhost",
+            timeout=httpx.Timeout(_RPC_TIMEOUT_SECONDS, connect=2.0),
+        ) as client:
+            response = await client.post(
+                "/internal/model-hub",
+                json={"operation": operation, "payload": payload or {}},
+            )
+    except _TRANSPORT_ERRORS:
+        raise ModelHubError("engine_down", status=503) from None
+    return _decode(response)
+
+
+class ModelHubRemoteService:
+    """Mirror the UI-facing service API without owning config or engine state."""
+
+    def list_sources(self) -> list[dict]:
+        return _rpc_sync("list_sources")
+
+    async def create_source(self, payload: dict) -> dict:
+        return await _rpc("create_source", {"source": payload})
+
+    async def patch_source(self, source_id: str, payload: dict) -> dict:
+        return await _rpc("patch_source", {"source_id": source_id, "patch": payload})
+
+    async def delete_source(self, source_id: str, *, force: bool = False) -> None:
+        await _rpc("delete_source", {"source_id": source_id, "force": force})
+
+    async def test_source(self, source_id: str) -> tuple[dict, int]:
+        result = await _rpc("test_source", {"source_id": source_id})
+        return result["source"], result["discovered"]
+
+    def priority(self) -> dict:
+        return _rpc_sync("priority")
+
+    async def set_priority(self, order: object) -> dict:
+        return await _rpc("set_priority", {"order": order})
+
+    def list_agents(self) -> list[dict]:
+        return _rpc_sync("list_agents")
+
+    async def set_agent_mode(self, backend: str, mode: object) -> dict:
+        return await _rpc("set_agent_mode", {"backend": backend, "mode": mode})
+
+    async def set_mappings(self, backend: str, mappings: object) -> dict:
+        return await _rpc("set_mappings", {"backend": backend, "mappings": mappings})
+
+    async def set_opencode_menu(self, menu: object) -> dict:
+        return await _rpc("set_opencode_menu", {"menu": menu})
+
+    async def add_custom_model(self, payload: dict) -> dict:
+        return await _rpc("add_custom_model", {"model": payload})
+
+    async def delete_custom_model(self, source_id: object, model_id: object) -> dict:
+        return await _rpc(
+            "delete_custom_model",
+            {"source_id": source_id, "model_id": model_id},
+        )
+
+    def list_events(self, *, limit: int = 20, before: Optional[str] = None) -> list[dict]:
+        return _rpc_sync("list_events", {"limit": limit, "before": before})
+
+    async def oauth_start(self, payload: dict) -> dict:
+        return await _rpc("oauth_start", {"oauth": payload})
+
+    async def oauth_status(self, flow_id: str) -> dict:
+        return await _rpc("oauth_status", {"flow_id": flow_id})
+
+    async def oauth_submit(self, payload: dict) -> dict:
+        return await _rpc("oauth_submit", {"oauth": payload})
+
+    async def oauth_cancel(self, flow_id: object) -> None:
+        await _rpc("oauth_cancel", {"flow_id": flow_id})
+
+    def migration_scan(self) -> dict:
+        return _rpc_sync("migration_scan")
+
+    async def migration_apply(self, item_ids: object) -> dict:
+        return await _rpc("migration_apply", {"item_ids": item_ids})
+
+    async def runtime_status(self) -> dict:
+        return await _rpc("runtime_status")

--- a/vibe/model_hub_runtime/adapter.py
+++ b/vibe/model_hub_runtime/adapter.py
@@ -393,7 +393,17 @@ class CLIProxyEngineAdapter:
                         source_id=source_id,
                     )
                 )
-            return await client.invoke(source, model_id, request, stream=stream)
+            request_protocol = {
+                "claude": "anthropic",
+                "codex": "openai_responses",
+            }.get(origin, getattr(request, "protocol", None) or source.protocol)
+            return await client.invoke(
+                source,
+                model_id,
+                request,
+                stream=stream,
+                request_protocol=request_protocol,
+            )
 
     async def _complete_oauth(self, flow: _OAuthFlow, client: EngineClient) -> None:
         inventory = await asyncio.to_thread(_auth_inventory, client)

--- a/vibe/model_hub_runtime/adapter.py
+++ b/vibe/model_hub_runtime/adapter.py
@@ -404,6 +404,7 @@ class CLIProxyEngineAdapter:
                 request,
                 stream=stream,
                 request_protocol=request_protocol,
+                request_headers=getattr(request, "headers", None),
             )
 
     async def _complete_oauth(self, flow: _OAuthFlow, client: EngineClient) -> None:

--- a/vibe/model_hub_runtime/client.py
+++ b/vibe/model_hub_runtime/client.py
@@ -139,8 +139,10 @@ class EngineClient:
         request: Mapping[str, Any],
         *,
         stream: bool,
+        request_protocol: str | None = None,
     ) -> EngineInvokeHandle:
-        endpoint = _endpoint_for_protocol(source.protocol)
+        request_protocol = request_protocol or source.protocol
+        endpoint = _endpoint_for_protocol(request_protocol)
         body = dict(request)
         body["model"] = f"{source.prefix}/{model_id}"
         body["stream"] = stream
@@ -148,7 +150,7 @@ class EngineClient:
             "Authorization": f"Bearer {self.connection.gateway_token}",
             "Content-Type": "application/json",
         }
-        if source.protocol == "anthropic":
+        if request_protocol == "anthropic":
             headers["anthropic-version"] = "2023-06-01"
 
         timeout = aiohttp.ClientTimeout(

--- a/vibe/model_hub_runtime/client.py
+++ b/vibe/model_hub_runtime/client.py
@@ -43,6 +43,7 @@ _OFFICIAL_BASE_URLS = {
     "openai": "https://api.openai.com/v1",
     "codex": "https://api.openai.com/v1",
 }
+_PROTOCOL_HEADERS = frozenset({"anthropic-beta", "anthropic-version", "openai-beta"})
 
 
 class EngineClientError(RuntimeError):
@@ -140,6 +141,7 @@ class EngineClient:
         *,
         stream: bool,
         request_protocol: str | None = None,
+        request_headers: Mapping[str, str] | None = None,
     ) -> EngineInvokeHandle:
         request_protocol = request_protocol or source.protocol
         endpoint = _endpoint_for_protocol(request_protocol)
@@ -147,11 +149,18 @@ class EngineClient:
         body["model"] = f"{source.prefix}/{model_id}"
         body["stream"] = stream
         headers = {
-            "Authorization": f"Bearer {self.connection.gateway_token}",
-            "Content-Type": "application/json",
+            key.lower(): value
+            for key, value in (request_headers or {}).items()
+            if key.lower() in _PROTOCOL_HEADERS
         }
+        headers.update(
+            {
+                "Authorization": f"Bearer {self.connection.gateway_token}",
+                "Content-Type": "application/json",
+            }
+        )
         if request_protocol == "anthropic":
-            headers["anthropic-version"] = "2023-06-01"
+            headers.setdefault("anthropic-version", "2023-06-01")
 
         timeout = aiohttp.ClientTimeout(
             total=None,

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -3019,20 +3019,15 @@ def config_get():
     return jsonify(api.config_to_payload(config))
 
 
-_MODEL_HUB_ENGINE_ADAPTER = None
-_MODEL_HUB_NATIVE_OAUTH_ADAPTER = None
 _MODEL_HUB_SERVICE = None
 
 
 def _model_hub_service():
-    from core.handlers.model_hub import create_default_service
+    from vibe.model_hub_client import ModelHubRemoteService
 
     global _MODEL_HUB_SERVICE
     if _MODEL_HUB_SERVICE is None:
-        _MODEL_HUB_SERVICE = create_default_service(
-            adapter=_MODEL_HUB_ENGINE_ADAPTER,
-            native_oauth_adapter=_MODEL_HUB_NATIVE_OAUTH_ADAPTER,
-        )
+        _MODEL_HUB_SERVICE = ModelHubRemoteService()
     return _MODEL_HUB_SERVICE
 
 
@@ -3058,7 +3053,12 @@ def _model_hub_json_object(error: str = "discovery_failed", *, status: int = 400
 
 @app.route("/api/models/sources", methods=["GET"])
 def model_hub_sources_get():
-    return _model_hub_success(sources=_model_hub_service().list_sources())
+    from core.handlers.model_hub import ModelHubError
+
+    try:
+        return _model_hub_success(sources=_model_hub_service().list_sources())
+    except ModelHubError as exc:
+        return _model_hub_error(exc)
 
 
 @app.route("/api/models/sources", methods=["POST"])
@@ -3108,8 +3108,13 @@ async def model_hub_sources_test(source_id):
 
 @app.route("/api/models/priority", methods=["GET"])
 def model_hub_priority_get():
-    priority = _model_hub_service().priority()
-    return _model_hub_success(order=priority["order"])
+    from core.handlers.model_hub import ModelHubError
+
+    try:
+        priority = _model_hub_service().priority()
+        return _model_hub_success(order=priority["order"])
+    except ModelHubError as exc:
+        return _model_hub_error(exc)
 
 
 @app.route("/api/models/priority", methods=["PUT"])
@@ -3127,7 +3132,12 @@ async def model_hub_priority_put():
 
 @app.route("/api/models/agents", methods=["GET"])
 def model_hub_agents_get():
-    return _model_hub_success(agents=_model_hub_service().list_agents())
+    from core.handlers.model_hub import ModelHubError
+
+    try:
+        return _model_hub_success(agents=_model_hub_service().list_agents())
+    except ModelHubError as exc:
+        return _model_hub_error(exc)
 
 
 @app.route("/api/models/agents/<backend>/mode", methods=["PATCH"])
@@ -3198,12 +3208,17 @@ async def model_hub_custom_models_delete():
 
 @app.route("/api/models/events", methods=["GET"])
 def model_hub_events_get():
+    from core.handlers.model_hub import ModelHubError
+
     try:
         limit = int(request.args.get("limit") or 20)
     except (TypeError, ValueError):
         limit = 20
-    events = _model_hub_service().list_events(limit=limit, before=request.args.get("before") or None)
-    return _model_hub_success(events=events)
+    try:
+        events = _model_hub_service().list_events(limit=limit, before=request.args.get("before") or None)
+        return _model_hub_success(events=events)
+    except ModelHubError as exc:
+        return _model_hub_error(exc)
 
 
 @app.route("/api/models/oauth/start", methods=["POST"])
@@ -3257,7 +3272,12 @@ async def model_hub_oauth_cancel():
 
 @app.route("/api/models/migration/scan", methods=["POST"])
 def model_hub_migration_scan():
-    return _model_hub_success(**_model_hub_service().migration_scan())
+    from core.handlers.model_hub import ModelHubError
+
+    try:
+        return _model_hub_success(**_model_hub_service().migration_scan())
+    except ModelHubError as exc:
+        return _model_hub_error(exc)
 
 
 @app.route("/api/models/migration/apply", methods=["POST"])


### PR DESCRIPTION
## Capability

Route production Hub turns through the existing `ModelHubService.resolve()` policy instead of injecting a single concrete engine source. A controller-owned loopback gateway now receives the real Claude, Codex, and OpenCode request, runs mapping and ordered Hub-candidate resolution, retries eligible pre-stream failures within that request, performs one same-source 401 refresh retry, preserves the no-retry-after-stream boundary, and lets the managed engine translate from the caller protocol to the selected source protocol.

The controller is now the sole Model Hub aggregate, config mutation, and engine lifecycle owner. The UI process reaches that owner through an allowlisted RPC on the existing internal Unix socket; it no longer constructs a second service/adapter. Native failure transitions reconstruct their pending source/reason from the file-backed resolution event log, so the next `switch` and `channel_switch` events remain causal after service restart.

## Scenarios

- `MH-RES-LIVE-001`: Claude, Codex, and OpenCode live loopback requests fall through on 429, explicit quota, transient 5xx, and network failures before stream start; cooldown and next-turn recovery are asserted.
- `MH-RES-LIVE-002`: 401 retries the same source exactly once; a second 401 surfaces without selecting a backup.
- `MH-RES-LIVE-003`: a started stream is returned once and never replayed on a backup.
- `MH-EVT-002`: `switch` and `channel_switch` survive a new service/router instance backed by the same event file.

## Evidence

- Unit: 264 focused Model Hub/API/runtime/injection/configuration/scenario tests passed.
- Contract: the frozen adapter and resolution-event contracts are unchanged; caller protocol metadata travels inside the existing request mapping and `EngineAdapter.invoke()` signature is unchanged.
- Scenario: the four catalog IDs above execute the real router -> HTTP gateway -> resolver path with fakes only at the adapter boundary.
- Static: `ruff check`, Python compilation, and `git diff --check` passed.
- Residual manual checks: no real vendor credential or billable inference was used; the orchestrator-owned combined regression pass remains after lane merges.

## F1 dependency

None. #994 is merged and incorporated at `427080c8`; this PR reuses its default managed-adapter factory and retains its runtime-status/discovery fixes while moving UI ownership to controller RPC.

## Residual

- Native CLI step-0 remains process-per-turn as specified; this gateway arbitrates only the Hub-channel tier.
- UI lifecycle actions, native OAuth, platform manifest expansion, and combined Incus regression remain in their assigned lanes.
