### PR TITLE
feat(model-hub): expand engine platform manifest

### DIFF
--- a/core/handlers/model_hub/service.py
+++ b/core/handlers/model_hub/service.py
@@ -87,27 +87,6 @@ _CREDENTIAL_QUERY_KEYS = {
     "token",
 }
 
-_RUNTIME_MANIFEST = {
-    "name": "cliproxyapi",
-    "version": "v7.2.95",
-    "source_sha": "f71ec0eb6776854457892452cf28c47f0d658251",
-    "assets": [
-        {
-            "platform": "darwin-arm64",
-            "url": "https://github.com/router-for-me/CLIProxyAPI/releases/download/v7.2.95/CLIProxyAPI_7.2.95_darwin_aarch64.tar.gz",
-            "size_bytes": 14384655,
-            "sha256": "c7ccc28b7db5d1799999a9e22725ccc6bd0e36d9aa023da6b52b7c1a71aad978",
-        },
-        {
-            "platform": "linux-amd64",
-            "url": "https://github.com/router-for-me/CLIProxyAPI/releases/download/v7.2.95/CLIProxyAPI_7.2.95_linux_amd64.tar.gz",
-            "size_bytes": 15401775,
-            "sha256": "826604e2dbf11913b0f373047f7bca1829eb2bab8a45d3a1916cc2534c7a9fd5",
-        },
-    ],
-}
-
-
 class ModelHubError(Exception):
     def __init__(self, code: str, *, status: int = 400):
         detail_key = f"modelHub.errors.{code}"
@@ -345,8 +324,11 @@ def _oauth_payload(flow: OAuthFlowState, *, channel: str) -> dict:
 
 
 def _runtime_payload(status: EngineStatus) -> dict:
+    # Import lazily to avoid the runtime adapter's dependency back on this service module.
+    from vibe.model_hub_runtime.installer import EngineRuntimeManager
+
     return {
-        "manifest": _RUNTIME_MANIFEST,
+        "manifest": EngineRuntimeManager().contract_manifest(),
         "status": {
             "installed_version": status.installed_version,
             "verified": status.verified,

--- a/docs/plans/model-hub-contracts/runtime-dependency.schema.json
+++ b/docs/plans/model-hub-contracts/runtime-dependency.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "model-hub/runtime-dependency.schema.json",
   "title": "RuntimeDependency",
-  "description": "Managed engine dependency manifest + status (spec §8; S3 verdict: generalize the Show Runtime managed-archive installer, effort M; process/health/config stay per-runtime). Pinned values below are the S1 survey result and are normative until the next explicit re-pin.",
+  "description": "Managed engine dependency manifest + status (spec §8; S3 verdict: generalize the Show Runtime managed-archive installer, effort M; process/health/config stay per-runtime). Pinned values below are the S1 survey result and are normative until the next explicit re-pin. Platform set expanded 2026-07-25 (orchestrator decision after F1 smoke proved linux-arm64 fail-closed blocks regression verification). Avibe-owned mirror remains the L7 pre-GA gate; URLs stay upstream until then.",
   "type": "object",
   "required": ["manifest", "status"],
   "additionalProperties": false,
@@ -22,7 +22,7 @@
             "required": ["platform", "url", "size_bytes", "sha256"],
             "additionalProperties": false,
             "properties": {
-              "platform": { "enum": ["darwin-arm64", "linux-amd64"] },
+              "platform": { "enum": ["darwin-arm64", "darwin-x64", "linux-amd64", "linux-arm64"] },
               "url": { "type": "string" },
               "size_bytes": { "type": "integer" },
               "sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" }
@@ -60,7 +60,9 @@
         "source_sha": "f71ec0eb6776854457892452cf28c47f0d658251",
         "assets": [
           { "platform": "darwin-arm64", "url": "https://github.com/router-for-me/CLIProxyAPI/releases/download/v7.2.95/<darwin-arm64-asset>", "size_bytes": 14384655, "sha256": "c7ccc28b7db5d1799999a9e22725ccc6bd0e36d9aa023da6b52b7c1a71aad978" },
-          { "platform": "linux-amd64", "url": "https://github.com/router-for-me/CLIProxyAPI/releases/download/v7.2.95/<linux-amd64-asset>", "size_bytes": 15401775, "sha256": "826604e2dbf11913b0f373047f7bca1829eb2bab8a45d3a1916cc2534c7a9fd5" }
+          { "platform": "darwin-x64", "url": "https://github.com/router-for-me/CLIProxyAPI/releases/download/v7.2.95/<darwin-x64-asset>", "size_bytes": 15372282, "sha256": "fbee90c29ee1047a8b3041d736500422bea22cd2ebb306782efcd74c0a10939c" },
+          { "platform": "linux-amd64", "url": "https://github.com/router-for-me/CLIProxyAPI/releases/download/v7.2.95/<linux-amd64-asset>", "size_bytes": 15401775, "sha256": "826604e2dbf11913b0f373047f7bca1829eb2bab8a45d3a1916cc2534c7a9fd5" },
+          { "platform": "linux-arm64", "url": "https://github.com/router-for-me/CLIProxyAPI/releases/download/v7.2.95/<linux-arm64-asset>", "size_bytes": 14062559, "sha256": "acc1173c73db2a2ee203438bac9a956491855d4955c5175855abc62d12ae0184" }
         ]
       },
       "status": {

--- a/tests/test_model_hub_api.py
+++ b/tests/test_model_hub_api.py
@@ -229,6 +229,22 @@ def test_runtime_status_starts_engine_before_reporting_health(tmp_path):
     assert runtime["status"]["verified"] is True
 
 
+def test_runtime_status_reports_packaged_engine_manifest(tmp_path):
+    from vibe.model_hub_runtime.installer import EngineRuntimeManager
+
+    service, _store, _adapter = _service(tmp_path)
+
+    runtime = asyncio.run(service.runtime_status())
+
+    assert runtime["manifest"] == EngineRuntimeManager(offline=True).contract_manifest()
+    assert [asset["platform"] for asset in runtime["manifest"]["assets"]] == [
+        "darwin-arm64",
+        "darwin-x64",
+        "linux-amd64",
+        "linux-arm64",
+    ]
+
+
 def test_runtime_status_falls_back_when_engine_cannot_start(tmp_path):
     class StartFailureAdapter(FakeAdapter):
         async def start(self):

--- a/tests/test_model_hub_runtime.py
+++ b/tests/test_model_hub_runtime.py
@@ -121,21 +121,89 @@ def test_packaged_manifest_matches_frozen_runtime_dependency_values(
                 "sha256": "c7ccc28b7db5d1799999a9e22725ccc6bd0e36d9aa023da6b52b7c1a71aad978",
             },
             {
+                "platform": "darwin-x64",
+                "url": "https://github.com/router-for-me/CLIProxyAPI/releases/download/v7.2.95/CLIProxyAPI_7.2.95_darwin_amd64.tar.gz",
+                "size_bytes": 15372282,
+                "sha256": "fbee90c29ee1047a8b3041d736500422bea22cd2ebb306782efcd74c0a10939c",
+            },
+            {
                 "platform": "linux-amd64",
                 "url": "https://github.com/router-for-me/CLIProxyAPI/releases/download/v7.2.95/CLIProxyAPI_7.2.95_linux_amd64.tar.gz",
                 "size_bytes": 15401775,
                 "sha256": "826604e2dbf11913b0f373047f7bca1829eb2bab8a45d3a1916cc2534c7a9fd5",
             },
+            {
+                "platform": "linux-arm64",
+                "url": "https://github.com/router-for-me/CLIProxyAPI/releases/download/v7.2.95/CLIProxyAPI_7.2.95_linux_aarch64.tar.gz",
+                "size_bytes": 14062559,
+                "sha256": "acc1173c73db2a2ee203438bac9a956491855d4955c5175855abc62d12ae0184",
+            },
         ],
     }
 
-    monkeypatch.setattr(managed_runtime, "runtime_platform_tag", lambda: "darwin-x64")
+    monkeypatch.setattr(managed_runtime, "runtime_platform_tag", lambda: "win32-x64")
     unsupported = EngineRuntimeManager(
         runtime_dir=tmp_path / "unsupported-runtime",
         offline=True,
     ).ensure()
     assert unsupported["ok"] is False
     assert unsupported["reason"] == "model_hub_engine_platform_unsupported"
+
+
+@pytest.mark.parametrize(
+    ("host_platform", "asset_platform", "size_bytes", "archive_sha256", "binary_sha256"),
+    [
+        (
+            "darwin-arm64",
+            "darwin-arm64",
+            14384655,
+            "c7ccc28b7db5d1799999a9e22725ccc6bd0e36d9aa023da6b52b7c1a71aad978",
+            "ad81a4c82700bf96eaa4cf5811690b0498ebcfe6087e26ffc0498b8fc8e867af",
+        ),
+        (
+            "darwin-x64",
+            "darwin-x64",
+            15372282,
+            "fbee90c29ee1047a8b3041d736500422bea22cd2ebb306782efcd74c0a10939c",
+            "6b5d209c3bc6adcff035060a862b9fe6eccf8f4ca3c8c0bb7fc88c0b625d38d5",
+        ),
+        (
+            "linux-x64",
+            "linux-amd64",
+            15401775,
+            "826604e2dbf11913b0f373047f7bca1829eb2bab8a45d3a1916cc2534c7a9fd5",
+            "2be8e4581fe802fe522126b273bc099c01910b6179dca4a4e1b451dd0c80a1c0",
+        ),
+        (
+            "linux-arm64",
+            "linux-arm64",
+            14062559,
+            "acc1173c73db2a2ee203438bac9a956491855d4955c5175855abc62d12ae0184",
+            "647a48ab6b2f5520d1279061c4a7aa7ff65729a68614495b1e431debbf4f8706",
+        ),
+    ],
+)
+def test_engine_installer_selects_verified_packaged_asset(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    host_platform: str,
+    asset_platform: str,
+    size_bytes: int,
+    archive_sha256: str,
+    binary_sha256: str,
+) -> None:
+    monkeypatch.setattr(managed_runtime, "runtime_platform_tag", lambda: host_platform)
+    manager = EngineRuntimeManager(runtime_dir=tmp_path / host_platform, offline=True)
+
+    manifest = manager._load_manifest(allow_network=False)
+
+    assert manifest is not None
+    archive = manager._manifest_archive_for_platform(manifest)
+    assert archive is not None
+    assert archive.platform == asset_platform
+    assert archive.size == size_bytes
+    assert archive.sha256 == archive_sha256
+    assert archive.binary_sha256 == binary_sha256
 
 
 def test_engine_installer_is_idempotent_and_rejects_tampered_archive(tmp_path: Path) -> None:

--- a/tests/test_model_hub_runtime.py
+++ b/tests/test_model_hub_runtime.py
@@ -150,6 +150,37 @@ def test_packaged_manifest_matches_frozen_runtime_dependency_values(
     assert unsupported["reason"] == "model_hub_engine_platform_unsupported"
 
 
+def test_contract_manifest_filters_unsupported_override_assets(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    payload = json.loads(Path("vibe/model_hub_runtime/cliproxyapi_manifest.json").read_text(encoding="utf-8"))
+    payload["assets"].append(
+        {
+            "platform": "win32-x64",
+            "url": "https://example.test/unsupported.zip",
+            "size_bytes": 1,
+            "sha256": "1" * 64,
+            "binary_sha256": "2" * 64,
+            "bin_path": "cli-proxy-api.exe",
+        }
+    )
+    manifest_path = tmp_path / "override.json"
+    manifest_path.write_text(json.dumps(payload), encoding="utf-8")
+    manager = EngineRuntimeManager(
+        runtime_dir=tmp_path / "runtime",
+        manifest_path=manifest_path,
+        offline=True,
+    )
+
+    assert "win32-x64" not in {asset["platform"] for asset in manager.contract_manifest()["assets"]}
+
+    monkeypatch.setattr(managed_runtime, "runtime_platform_tag", lambda: "win32-x64")
+    unsupported = manager.ensure()
+    assert unsupported["ok"] is False
+    assert unsupported["reason"] == "model_hub_engine_platform_unsupported"
+
+
 @pytest.mark.parametrize(
     ("host_platform", "asset_platform", "size_bytes", "archive_sha256", "binary_sha256"),
     [

--- a/ui/src/components/settings/models/types.ts
+++ b/ui/src/components/settings/models/types.ts
@@ -210,7 +210,7 @@ export type RuntimeDependency = {
     version: string;
     source_sha: string;
     assets: Array<{
-      platform: 'darwin-arm64' | 'linux-amd64';
+      platform: 'darwin-arm64' | 'darwin-x64' | 'linux-amd64' | 'linux-arm64';
       url: string;
       size_bytes: number;
       sha256: string;

--- a/vibe/model_hub_runtime/cliproxyapi_manifest.json
+++ b/vibe/model_hub_runtime/cliproxyapi_manifest.json
@@ -17,11 +17,27 @@
       "bin_path": "cli-proxy-api"
     },
     {
+      "platform": "darwin-x64",
+      "url": "https://github.com/router-for-me/CLIProxyAPI/releases/download/v7.2.95/CLIProxyAPI_7.2.95_darwin_amd64.tar.gz",
+      "size_bytes": 15372282,
+      "sha256": "fbee90c29ee1047a8b3041d736500422bea22cd2ebb306782efcd74c0a10939c",
+      "binary_sha256": "6b5d209c3bc6adcff035060a862b9fe6eccf8f4ca3c8c0bb7fc88c0b625d38d5",
+      "bin_path": "cli-proxy-api"
+    },
+    {
       "platform": "linux-amd64",
       "url": "https://github.com/router-for-me/CLIProxyAPI/releases/download/v7.2.95/CLIProxyAPI_7.2.95_linux_amd64.tar.gz",
       "size_bytes": 15401775,
       "sha256": "826604e2dbf11913b0f373047f7bca1829eb2bab8a45d3a1916cc2534c7a9fd5",
       "binary_sha256": "2be8e4581fe802fe522126b273bc099c01910b6179dca4a4e1b451dd0c80a1c0",
+      "bin_path": "cli-proxy-api"
+    },
+    {
+      "platform": "linux-arm64",
+      "url": "https://github.com/router-for-me/CLIProxyAPI/releases/download/v7.2.95/CLIProxyAPI_7.2.95_linux_aarch64.tar.gz",
+      "size_bytes": 14062559,
+      "sha256": "acc1173c73db2a2ee203438bac9a956491855d4955c5175855abc62d12ae0184",
+      "binary_sha256": "647a48ab6b2f5520d1279061c4a7aa7ff65729a68614495b1e431debbf4f8706",
       "bin_path": "cli-proxy-api"
     }
   ]

--- a/vibe/model_hub_runtime/installer.py
+++ b/vibe/model_hub_runtime/installer.py
@@ -27,6 +27,7 @@ _ENGINE_PLATFORM_MAP = {
     "linux-x64": "linux-amd64",
     "linux-arm64": "linux-arm64",
 }
+_ENGINE_ASSET_PLATFORMS = frozenset(_ENGINE_PLATFORM_MAP.values())
 _ENGINE_SPEC = ManagedRuntimeSpec(
     runtime_id="model_hub_engine",
     manifest_resource="model_hub_runtime/cliproxyapi_manifest.json",
@@ -78,6 +79,7 @@ class EngineRuntimeManager(ManagedRuntimeManager):
                     "sha256": asset["sha256"],
                 }
                 for asset in payload.get("assets", [])
+                if asset.get("platform") in _ENGINE_ASSET_PLATFORMS
             ],
         }
 

--- a/vibe/model_hub_runtime/installer.py
+++ b/vibe/model_hub_runtime/installer.py
@@ -20,6 +20,7 @@ from vibe.model_hub_runtime.environment import engine_subprocess_environment
 
 
 _ENGINE_VERSION_RE = re.compile(r"CLIProxyAPI Version:\s*([\w.-]+)")
+# A manifest override must not silently expand the engine's supported host set.
 _ENGINE_PLATFORM_MAP = {
     "darwin-arm64": "darwin-arm64",
     "darwin-x64": "darwin-x64",

--- a/vibe/model_hub_runtime/installer.py
+++ b/vibe/model_hub_runtime/installer.py
@@ -7,7 +7,9 @@ from pathlib import Path
 from typing import Any
 
 from config import paths
+from core import managed_runtime
 from core.managed_runtime import (
+    ManagedRuntimeArchive,
     ManagedRuntimeManager,
     ManagedRuntimeManifest,
     ManagedRuntimeSpec,
@@ -18,6 +20,12 @@ from vibe.model_hub_runtime.environment import engine_subprocess_environment
 
 
 _ENGINE_VERSION_RE = re.compile(r"CLIProxyAPI Version:\s*([\w.-]+)")
+_ENGINE_PLATFORM_MAP = {
+    "darwin-arm64": "darwin-arm64",
+    "darwin-x64": "darwin-x64",
+    "linux-x64": "linux-amd64",
+    "linux-arm64": "linux-arm64",
+}
 _ENGINE_SPEC = ManagedRuntimeSpec(
     runtime_id="model_hub_engine",
     manifest_resource="model_hub_runtime/cliproxyapi_manifest.json",
@@ -25,7 +33,6 @@ _ENGINE_SPEC = ManagedRuntimeSpec(
     default_bin_path="cli-proxy-api",
     archives_field="assets",
     archive_size_field="size_bytes",
-    platform_aliases=(("linux-x64", "linux-amd64"),),
 )
 
 
@@ -84,6 +91,16 @@ class EngineRuntimeManager(ManagedRuntimeManager):
             self._install_reason = "model_hub_engine_manifest_invalid"
             return False
         return True
+
+    def _manifest_archive_for_platform(
+        self,
+        manifest: ManagedRuntimeManifest,
+    ) -> ManagedRuntimeArchive | None:
+        asset_platform = _ENGINE_PLATFORM_MAP.get(managed_runtime.runtime_platform_tag())
+        archive = manifest.archives.get(asset_platform) if asset_platform is not None else None
+        if archive is None:
+            self._install_reason = "model_hub_engine_platform_unsupported"
+        return archive
 
     def _binary_version(self, binary: Path | None) -> str | None:
         if binary is None:


### PR DESCRIPTION
## Capability

Expand the pinned CLIProxyAPI v7.2.95 runtime from two to four supported host platforms by adding `darwin-x64` and `linux-arm64`. The engine installer now selects through an explicit host-to-asset table, while unlisted hosts such as Windows still fail closed with `model_hub_engine_platform_unsupported`.

## Upstream asset verification

Both upstream archives were downloaded directly from `router-for-me/CLIProxyAPI` release `v7.2.95`; archive size, archive SHA-256, and extracted binary SHA-256 were recomputed locally before pinning.

| Platform | Upstream asset | Size (bytes) | Archive SHA-256 | Binary SHA-256 |
| --- | --- | ---: | --- | --- |
| `darwin-x64` | `CLIProxyAPI_7.2.95_darwin_amd64.tar.gz` | 15,372,282 | `fbee90c29ee1047a8b3041d736500422bea22cd2ebb306782efcd74c0a10939c` | `6b5d209c3bc6adcff035060a862b9fe6eccf8f4ca3c8c0bb7fc88c0b625d38d5` |
| `linux-arm64` | `CLIProxyAPI_7.2.95_linux_aarch64.tar.gz` | 14,062,559 | `acc1173c73db2a2ee203438bac9a956491855d4955c5175855abc62d12ae0184` | `647a48ab6b2f5520d1279061c4a7aa7ff65729a68614495b1e431debbf4f8706` |

The linux-arm64 archive and binary hashes exactly match the temporary manifest used by F1's successful PR #994 Incus smoke.

## Orchestrator contract patch

**Applied verbatim.** The platform enum is now `["darwin-arm64", "darwin-x64", "linux-amd64", "linux-arm64"]`, and the schema description appends:

> Platform set expanded 2026-07-25 (orchestrator decision after F1 smoke proved linux-arm64 fail-closed blocks regression verification). Avibe-owned mirror remains the L7 pre-GA gate; URLs stay upstream until then.

The schema example was synchronized to the same four pinned platforms.

## Scenarios and evidence

- Scenario: `model_hub_engine_platform_unsupported` remains covered with `win32-x64` as a genuinely unsupported host.
- Unit: 33 focused Model Hub API tests and 41 runtime tests passed, including the status-manifest projection, override filtering, four-platform installer selection table, and manifest archive/binary integrity fixtures.
- Contract: both JSON documents parse successfully; the pinned manifest and schema example carry the expanded platform set.
- Static: Ruff passed on all four changed Python files; `git diff --check` passed.
- UI contract: the TypeScript platform mirror is synchronized and the full UI build passed.
- Asset: direct-download sizes and archive/binary SHA-256 values match the committed manifest; linux-arm64 also matches F1's recorded smoke override.

## Dependencies and residual checks

- Base includes merged PR #994; no unmerged dependency.
- Per instruction, no regression VM activity was performed. F1 already proved the linux-arm64 asset starts and stays healthy; darwin-x64 execution remains a platform-specific residual check.
- The Avibe-owned mirror remains the L7 pre-GA gate and is intentionally out of scope; manifest URLs remain upstream.
