### PR TITLE
feat(acl): port organization resource access control to org

### DIFF
--- a/core/dock_store.py
+++ b/core/dock_store.py
@@ -258,7 +258,7 @@ def pin_show_page(
     store = ShowPageStore(db_path)
     try:
         try:
-            store.require_access(session_id, user_context=context)
+            store.require_management(session_id, user_context=context)
         except ShowPageError as exc:
             if exc.code == "show_page_not_found":
                 raise DockError("This session has no Show Page to pin.", code="show_page_not_found") from exc

--- a/core/dock_store.py
+++ b/core/dock_store.py
@@ -35,7 +35,7 @@ from pathlib import Path
 from typing import Any
 
 from core.chat_discovery import get_state_meta, set_state_meta
-from core.show_pages import ShowPageStore, validate_session_id
+from core.show_pages import ShowPageError, ShowPageStore, validate_session_id
 from storage.sessions_service import read_session_display_meta
 
 # The single state_meta key holding the whole dock document.
@@ -170,12 +170,62 @@ def _save(doc: dict[str, Any], db_path: Path | None) -> None:
     set_state_meta(DOCK_STATE_KEY, doc, db_path=db_path)
 
 
-def load_dock(*, db_path: Path | None = None) -> dict[str, Any]:
+def _resource_context(user_context: Any):
+    from storage.resource_access_service import resolve_resource_access_context
+
+    return resolve_resource_access_context(user_context)
+
+
+def _filter_dock_for_access(
+    doc: dict[str, Any],
+    *,
+    user_context: Any,
+    db_path: Path | None,
+) -> dict[str, Any]:
+    if not user_context.is_remote:
+        return doc
+    store = ShowPageStore(db_path)
+    try:
+        accessible_pins = []
+        for pin in doc["pins"]:
+            try:
+                store.require_access(pin["session_id"], user_context=user_context)
+            except ShowPageError:
+                continue
+            accessible_pins.append(pin)
+    finally:
+        store.close()
+    return _reconcile(doc["order"], accessible_pins)
+
+
+def _require_show_page_management(
+    session_ids: set[str],
+    *,
+    user_context: Any,
+    db_path: Path | None,
+) -> None:
+    if not user_context.is_remote or not session_ids:
+        return
+    store = ShowPageStore(db_path)
+    try:
+        for session_id in sorted(session_ids):
+            store.require_management(session_id, user_context=user_context)
+    finally:
+        store.close()
+
+
+def load_dock(*, db_path: Path | None = None, user_context: Any = None) -> dict[str, Any]:
     """Return the reconciled Dock document ``{order, pins}``."""
-    return _load(db_path)
+    context = _resource_context(user_context)
+    return _filter_dock_for_access(_load(db_path), user_context=context, db_path=db_path)
 
 
-def pin_show_page(session_id: str, *, db_path: Path | None = None) -> dict[str, Any]:
+def pin_show_page(
+    session_id: str,
+    *,
+    db_path: Path | None = None,
+    user_context: Any = None,
+) -> dict[str, Any]:
     """Pin a session's Show Page to the Dock (idempotent).
 
     Captures the session's current title as ``title_snapshot`` so the tile stays
@@ -184,19 +234,27 @@ def pin_show_page(session_id: str, *, db_path: Path | None = None) -> dict[str, 
     (→ 404). Never creates a page — pinning only records an existing one.
     """
     session_id = validate_session_id(session_id)
+    context = _resource_context(user_context)
     store = ShowPageStore(db_path)
     try:
-        page = store.get(session_id)
+        try:
+            store.require_access(session_id, user_context=context)
+        except ShowPageError as exc:
+            if exc.code == "show_page_not_found":
+                raise DockError("This session has no Show Page to pin.", code="show_page_not_found") from exc
+            raise
     finally:
         store.close()
-    if page is None:
-        raise DockError("This session has no Show Page to pin.", code="show_page_not_found")
 
     # Serialize the whole read-modify-write so a concurrent pin can't lost-update.
     with _DOCK_MUTATION_LOCK:
         doc = _load(db_path)
         if any(pin["session_id"] == session_id for pin in doc["pins"]):
-            return doc  # already pinned → idempotent no-op (keeps its place + snapshot)
+            return _filter_dock_for_access(
+                doc,
+                user_context=context,
+                db_path=db_path,
+            )  # already pinned → idempotent no-op (keeps its place + snapshot)
 
         # Bound the installed set to the same fixed budget reconcile clamps to, so
         # a new pin can't grow ``pins`` past what a read would keep (which would
@@ -212,10 +270,15 @@ def pin_show_page(session_id: str, *, db_path: Path | None = None) -> dict[str, 
         doc["order"].append(_show_id(session_id))
         doc = _reconcile(doc["order"], doc["pins"])
         _save(doc, db_path)
-        return doc
+        return _filter_dock_for_access(doc, user_context=context, db_path=db_path)
 
 
-def unpin_show_page(session_id: str, *, db_path: Path | None = None) -> dict[str, Any]:
+def unpin_show_page(
+    session_id: str,
+    *,
+    db_path: Path | None = None,
+    user_context: Any = None,
+) -> dict[str, Any]:
     """Remove a pinned Show Page from the Dock (idempotent; never 404s).
 
     Unpin is Dock-only — it leaves the Show Page itself, its visibility, and any
@@ -223,19 +286,31 @@ def unpin_show_page(session_id: str, *, db_path: Path | None = None) -> dict[str
     """
     sid = (session_id or "").strip()
     show_id = _show_id(sid)
+    context = _resource_context(user_context)
     with _DOCK_MUTATION_LOCK:
         doc = _load(db_path)
         pinned = any(pin["session_id"] == sid for pin in doc["pins"])
         if not pinned and show_id not in doc["order"]:
-            return doc  # nothing to remove → idempotent no-op
+            return _filter_dock_for_access(
+                doc,
+                user_context=context,
+                db_path=db_path,
+            )  # nothing to remove → idempotent no-op
+        _require_show_page_management({sid}, user_context=context, db_path=db_path)
         pins = [pin for pin in doc["pins"] if pin["session_id"] != sid]
         order = [item for item in doc["order"] if item != show_id]
         doc = _reconcile(order, pins)
         _save(doc, db_path)
-        return doc
+        return _filter_dock_for_access(doc, user_context=context, db_path=db_path)
 
 
-def set_dock_order(order: Any, *, known: Any = None, db_path: Path | None = None) -> dict[str, Any]:
+def set_dock_order(
+    order: Any,
+    *,
+    known: Any = None,
+    db_path: Path | None = None,
+    user_context: Any = None,
+) -> dict[str, Any]:
     """Persist the docked subset, in order.
 
     Under the two-layer model (§7.1c) the order is a SUBSET of the known ids
@@ -262,9 +337,12 @@ def set_dock_order(order: Any, *, known: Any = None, db_path: Path | None = None
     if len(order) != len(set(order)):
         raise DockError("Dock order has duplicate ids.", code="invalid_order")
 
+    context = _resource_context(user_context)
     with _DOCK_MUTATION_LOCK:
         doc = _load(db_path)
-        server_known = set(BUILTIN_DOCK_IDS) | {_show_id(pin["session_id"]) for pin in doc["pins"]}
+        visible_doc = _filter_dock_for_access(doc, user_context=context, db_path=db_path)
+        known_doc = visible_doc if context.is_remote else doc
+        server_known = set(BUILTIN_DOCK_IDS) | {_show_id(pin["session_id"]) for pin in known_doc["pins"]}
         if known is not None:
             if not isinstance(known, list) or not all(isinstance(item, str) for item in known):
                 raise DockError("Dock known-set must be a list of ids.", code="invalid_order")
@@ -273,6 +351,13 @@ def set_dock_order(order: Any, *, known: Any = None, db_path: Path | None = None
         if not set(order) <= server_known:
             raise DockError("Dock order has an unknown id.", code="invalid_order")
 
+        affected_sessions = {
+            item.removeprefix(SHOW_PREFIX)
+            for item in {*doc["order"], *order}
+            if item.startswith(SHOW_PREFIX)
+        }
+        _require_show_page_management(affected_sessions, user_context=context, db_path=db_path)
+
         doc = {"order": list(order), "pins": doc["pins"]}
         _save(doc, db_path)
-        return doc
+        return _filter_dock_for_access(doc, user_context=context, db_path=db_path)

--- a/core/dock_store.py
+++ b/core/dock_store.py
@@ -182,7 +182,7 @@ def _filter_dock_for_access(
     user_context: Any,
     db_path: Path | None,
 ) -> dict[str, Any]:
-    if not user_context.is_remote:
+    if user_context.is_trusted_local:
         return doc
     store = ShowPageStore(db_path)
     try:
@@ -204,7 +204,7 @@ def _require_show_page_management(
     user_context: Any,
     db_path: Path | None,
 ) -> None:
-    if not user_context.is_remote or not session_ids:
+    if user_context.is_trusted_local or not session_ids:
         return
     store = ShowPageStore(db_path)
     try:
@@ -361,7 +361,7 @@ def set_dock_order(
     with _DOCK_MUTATION_LOCK:
         doc = _load(db_path)
         visible_doc = _filter_dock_for_access(doc, user_context=context, db_path=db_path)
-        known_doc = visible_doc if context.is_remote else doc
+        known_doc = doc if context.is_trusted_local else visible_doc
         server_known = set(BUILTIN_DOCK_IDS) | {_show_id(pin["session_id"]) for pin in known_doc["pins"]}
         if known is not None:
             if not isinstance(known, list) or not all(isinstance(item, str) for item in known):
@@ -380,7 +380,7 @@ def set_dock_order(
 
         merged_order = (
             _merge_visible_order(doc["order"], order, server_known)
-            if context.is_remote
+            if not context.is_trusted_local
             else list(order)
         )
         doc = {"order": merged_order, "pins": doc["pins"]}

--- a/core/dock_store.py
+++ b/core/dock_store.py
@@ -214,6 +214,26 @@ def _require_show_page_management(
         store.close()
 
 
+def _merge_visible_order(
+    current_order: list[str],
+    submitted_order: list[str],
+    visible_ids: set[str],
+) -> list[str]:
+    """Replace visible order slots while retaining inaccessible docked items."""
+
+    submitted = iter(submitted_order)
+    merged: list[str] = []
+    for item in current_order:
+        if item not in visible_ids:
+            merged.append(item)
+            continue
+        replacement = next(submitted, None)
+        if replacement is not None:
+            merged.append(replacement)
+    merged.extend(submitted)
+    return merged
+
+
 def load_dock(*, db_path: Path | None = None, user_context: Any = None) -> dict[str, Any]:
     """Return the reconciled Dock document ``{order, pins}``."""
     context = _resource_context(user_context)
@@ -353,11 +373,16 @@ def set_dock_order(
 
         affected_sessions = {
             item.removeprefix(SHOW_PREFIX)
-            for item in {*doc["order"], *order}
+            for item in {*visible_doc["order"], *order}
             if item.startswith(SHOW_PREFIX)
         }
         _require_show_page_management(affected_sessions, user_context=context, db_path=db_path)
 
-        doc = {"order": list(order), "pins": doc["pins"]}
+        merged_order = (
+            _merge_visible_order(doc["order"], order, server_known)
+            if context.is_remote
+            else list(order)
+        )
+        doc = {"order": merged_order, "pins": doc["pins"]}
         _save(doc, db_path)
         return _filter_dock_for_access(doc, user_context=context, db_path=db_path)

--- a/core/scheduled_tasks.py
+++ b/core/scheduled_tasks.py
@@ -709,7 +709,11 @@ class ScheduledTaskStore:
         run_at: Optional[str] = None,
         timezone_name: str,
         metadata: Optional[dict[str, Any]] = None,
+        user_context: Any = None,
     ) -> ScheduledTask:
+        from core.vibe_agents import ensure_agent_name_access
+
+        ensure_agent_name_access(agent_name, user_context=user_context)
         task = ScheduledTask(
             id=uuid4().hex[:12],
             name=name,
@@ -768,7 +772,11 @@ class ScheduledTaskStore:
         cwd: Optional[str] = None,
         update_cwd: bool = False,
         metadata: Optional[dict[str, Any]] = None,
+        user_context: Any = None,
     ) -> ScheduledTask:
+        from core.vibe_agents import ensure_agent_name_access
+
+        ensure_agent_name_access(agent_name, user_context=user_context)
         task = self._tasks[task_id]
         task.name = name
         task.session_key = session_key

--- a/core/scheduled_tasks.py
+++ b/core/scheduled_tasks.py
@@ -712,6 +712,7 @@ class ScheduledTaskStore:
         user_context: Any = None,
     ) -> ScheduledTask:
         from core.vibe_agents import ensure_agent_name_access
+        from storage.resource_access_service import metadata_with_resource_user_context
 
         ensure_agent_name_access(agent_name, user_context=user_context)
         task = ScheduledTask(
@@ -729,7 +730,7 @@ class ScheduledTaskStore:
             cron=cron,
             run_at=run_at,
             timezone=timezone_name,
-            metadata=dict(metadata or {}),
+            metadata=metadata_with_resource_user_context(metadata, user_context),
         )
         return self.upsert_task(task)
 
@@ -775,6 +776,7 @@ class ScheduledTaskStore:
         user_context: Any = None,
     ) -> ScheduledTask:
         from core.vibe_agents import ensure_agent_name_access
+        from storage.resource_access_service import metadata_with_resource_user_context
 
         ensure_agent_name_access(agent_name, user_context=user_context)
         task = self._tasks[task_id]
@@ -794,8 +796,10 @@ class ScheduledTaskStore:
         task.cron = cron
         task.run_at = run_at
         task.timezone = timezone_name
-        if metadata is not None:
-            task.metadata = dict(metadata)
+        task.metadata = metadata_with_resource_user_context(
+            metadata if metadata is not None else task.metadata,
+            user_context,
+        )
         task.updated_at = _utc_now_iso()
         if self._sqlite is not None:
             self._sqlite.upsert_scheduled_task(task.to_dict())
@@ -2392,16 +2396,23 @@ class ScheduledTaskService:
             elif request.request_type in {"hook_send", "watch", "webhook"}:
                 if not request.prompt:
                     raise ValueError("hook request requires prompt")
+                user_context = self._resource_user_context(request.metadata)
                 if request.session_policy == "create_per_run":
                     session_id = self._reserve_runtime_session(
                         agent_name=request.agent_name,
                         deliver_key=request.deliver_key,
                         metadata=request.metadata,
                         workdir=request.metadata.get("session_workdir") if isinstance(request.metadata, dict) else None,
+                        user_context=user_context,
                     )
                     session_key = ""
                 elif not (request.session_id or request.session_key):
                     raise ValueError("hook request requires session_id or session_key")
+                resource_access_kwargs = (
+                    {"metadata": request.metadata, "user_context": user_context}
+                    if user_context is not None
+                    else {}
+                )
                 error = await self._execute_request(
                     session_key=session_key,
                     session_id=session_id,
@@ -2412,6 +2423,7 @@ class ScheduledTaskService:
                     task_id=task_id,
                     trigger_kind=request.request_type if request.request_type != "hook_send" else "hook",
                     agent_name=request.agent_name,
+                    **resource_access_kwargs,
                 )
             elif request.request_type == "agent_run":
                 message = _agent_run_message_for_request(request)
@@ -2495,6 +2507,7 @@ class ScheduledTaskService:
         error: Optional[str] = None
         session_id = task.session_id
         session_key = task.session_key
+        user_context = self._resource_user_context(task.metadata)
         try:
             if task.session_policy == "create_per_run":
                 session_id = self._reserve_runtime_session(
@@ -2502,8 +2515,14 @@ class ScheduledTaskService:
                     deliver_key=task.deliver_key,
                     metadata=task.metadata,
                     workdir=task.cwd,
+                    user_context=user_context,
                 )
                 session_key = ""
+            resource_access_kwargs = (
+                {"metadata": task.metadata, "user_context": user_context}
+                if user_context is not None
+                else {}
+            )
             error = await self._execute_request(
                 session_key=session_key,
                 session_id=session_id,
@@ -2514,6 +2533,7 @@ class ScheduledTaskService:
                 task_id=task.id,
                 trigger_kind="scheduled",
                 agent_name=task.agent_name,
+                **resource_access_kwargs,
             )
         except asyncio.CancelledError:
             self.reconcile_jobs()
@@ -2548,6 +2568,11 @@ class ScheduledTaskService:
         from core.services.dispatch import SOURCE_SCHEDULED, dispatch_turn
 
         target_info = resolve_session_id_target(session_id) if session_id else None
+        self._require_execution_agent_access(
+            agent_name=agent_name,
+            target_info=target_info,
+            user_context=self._resource_user_context(metadata),
+        )
         target = target_info.session_key if target_info else parse_session_key(session_key or "")
         delivery_target = self._resolve_delivery_target(
             session_target=target,
@@ -2624,6 +2649,7 @@ class ScheduledTaskService:
         deliver_key: Optional[str],
         metadata: Optional[dict[str, Any]] = None,
         workdir: Optional[str] = None,
+        user_context: Any = None,
     ) -> str:
         scope_id = ""
         if isinstance(metadata, dict):
@@ -2651,6 +2677,12 @@ class ScheduledTaskService:
             scope_target = self._resolve_scope_agent_target(scope_id) if scope_id and not agent_name else _ScopeAgentTarget(None)
             resolved_agent_name = agent_name or scope_target.agent_name
             agent = agent_store.require_enabled(resolved_agent_name) if resolved_agent_name else agent_store.get_default_agent()
+            if agent is not None and user_context is not None:
+                agent = agent_store.require_accessible(
+                    agent.name,
+                    user_context=user_context,
+                    enabled_only=True,
+                )
         finally:
             agent_store.close()
         if agent is None:
@@ -2724,8 +2756,15 @@ class ScheduledTaskService:
         trigger_kind: str,
         session_id: Optional[str] = None,
         agent_name: Optional[str] = None,
+        metadata: Optional[dict[str, Any]] = None,
+        user_context: Any = None,
     ) -> Optional[str]:
         target_info = resolve_session_id_target(session_id) if session_id else None
+        self._require_execution_agent_access(
+            agent_name=agent_name,
+            target_info=target_info,
+            user_context=user_context,
+        )
         target = target_info.session_key if target_info else parse_session_key(session_key or "")
         delivery_target = self._resolve_delivery_target(
             session_target=target,
@@ -2741,6 +2780,7 @@ class ScheduledTaskService:
             session_id=session_id,
             agent_name=agent_name,
             target_info=target_info,
+            metadata=metadata,
         )
         # A scheduled avibe turn drives the sidebar dot through the SAME two
         # chokepoints as any other turn — inbound AgentService.handle_message
@@ -2767,6 +2807,45 @@ class ScheduledTaskService:
             message=prompt,
             parsed_session_key=target,
         )
+
+    @staticmethod
+    def _resource_user_context(metadata: Optional[dict[str, Any]]) -> Any:
+        from storage.resource_access_service import resource_user_context_from_metadata
+
+        return resource_user_context_from_metadata(metadata)
+
+    @staticmethod
+    def _require_execution_agent_access(
+        *,
+        agent_name: Optional[str],
+        target_info: Optional[ResolvedSessionIdTarget],
+        user_context: Any,
+    ) -> None:
+        if user_context is None:
+            return
+
+        from core.vibe_agents import VibeAgentAccessError, VibeAgentStore, ensure_agent_selection_access
+
+        selected_name = str(agent_name or "").strip() or None
+        selected_id = None
+        if selected_name is None and target_info is not None:
+            selected_name = str(target_info.agent_name or "").strip() or None
+            selected_id = str(target_info.agent_id or "").strip() or None
+        if selected_name is None and selected_id is None:
+            raise VibeAgentAccessError("Agent access is not permitted.")
+
+        store = VibeAgentStore()
+        try:
+            with store.engine.connect() as connection:
+                ensure_agent_selection_access(
+                    connection,
+                    agent_name=selected_name,
+                    agent_id=selected_id,
+                    user_context=user_context,
+                    missing_is_error=True,
+                )
+        finally:
+            store.close()
 
     async def _build_context(
         self,

--- a/core/services/skills.py
+++ b/core/services/skills.py
@@ -25,9 +25,11 @@ the project folder.
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import json
 import logging
 import os
+import re
 from typing import Any, Optional
 
 logger = logging.getLogger(__name__)
@@ -41,6 +43,7 @@ BACKEND_TO_AGENT: dict[str, str] = {
     "codex": "codex",
 }
 AGENT_TO_BACKEND: dict[str, str] = {agent: backend for backend, agent in BACKEND_TO_AGENT.items()}
+_SKILL_RESOURCE_SCOPES = frozenset({"global", "project"})
 
 
 class SkillsError(Exception):
@@ -51,6 +54,13 @@ class SkillsError(Exception):
         self.code = code
         self.message = message
         self.details = details
+
+
+class SkillAccessError(SkillsError):
+    """Raised when a remote caller cannot use or manage a Skill resource."""
+
+    def __init__(self) -> None:
+        super().__init__("resource_access_forbidden", "Skill access is not permitted.")
 
 
 def _subprocess_env(askill_path: str) -> dict[str, str]:
@@ -177,6 +187,375 @@ def _cwd_for(scope: str, project_dir: Optional[str]) -> Optional[str]:
     return project_dir if scope != "global" else None
 
 
+def resolve_resource_access_context(user_context: Any = None):
+    """Resolve request ACL context while preserving trusted local Skill use."""
+
+    from storage import resource_access_service
+
+    if isinstance(user_context, resource_access_service.ResourceUserContext):
+        return user_context
+    if user_context is not None:
+        return resource_access_service.current_resource_context(user_context, is_remote=True)
+
+    context = resource_access_service.current_resource_context()
+    if context.is_remote or context.is_trusted_local:
+        return context
+    return resource_access_service.ResourceUserContext(is_trusted_local=True)
+
+
+def _normalize_skill_name(name: Any) -> str:
+    normalized = re.sub(r"[^a-z0-9]+", "-", str(name or "").strip().lower()).strip("-")
+    if not normalized:
+        raise SkillsError("invalid_skill", "skill name is required")
+    return normalized
+
+
+def _backend_from_agent_ref(value: Any) -> str | None:
+    candidates: list[Any]
+    if isinstance(value, dict):
+        candidates = [value.get("backend"), value.get("id"), value.get("name")]
+    else:
+        candidates = [value]
+    for candidate in candidates:
+        normalized = str(candidate or "").strip().lower()
+        if normalized in BACKEND_TO_AGENT:
+            return normalized
+        if normalized in AGENT_TO_BACKEND:
+            return AGENT_TO_BACKEND[normalized]
+    return None
+
+
+def _normalized_backends(backends: Optional[list[str]]) -> list[str]:
+    result: list[str] = []
+    for backend in backends or []:
+        normalized = _backend_from_agent_ref(backend)
+        if normalized is None:
+            raise SkillsError("invalid_backend", f"unknown backend: {backend}")
+        if normalized not in result:
+            result.append(normalized)
+    return result
+
+
+def _project_resource_segment(scope: str, project_dir: Optional[str]) -> str:
+    if scope == "global":
+        return "global"
+    if scope != "project":
+        raise SkillsError("invalid_scope", f"unknown scope: {scope}")
+    if not project_dir:
+        raise SkillsError("project_required", "a project is required for project-scoped skills")
+    canonical_path = os.path.normcase(os.path.realpath(os.path.abspath(project_dir)))
+    return f"project-{hashlib.sha256(canonical_path.encode('utf-8')).hexdigest()[:24]}"
+
+
+def skill_resource_id(
+    backend: str,
+    *,
+    scope: str,
+    project_dir: Optional[str],
+    name: str,
+) -> str:
+    """Return the stable local ACL descriptor for one backend-specific Skill."""
+
+    normalized_backend = _backend_from_agent_ref(backend)
+    if normalized_backend is None:
+        raise SkillsError("invalid_backend", f"unknown backend: {backend}")
+    if scope not in _SKILL_RESOURCE_SCOPES:
+        raise SkillsError("invalid_scope", f"unknown scope: {scope}")
+    return ":".join(
+        [
+            normalized_backend,
+            scope,
+            _project_resource_segment(scope, project_dir),
+            _normalize_skill_name(name),
+        ]
+    )
+
+
+def _skill_scope(skill: dict[str, Any], requested_scope: str) -> str | None:
+    scope = str(skill.get("scope") or "").strip().lower()
+    if scope in _SKILL_RESOURCE_SCOPES:
+        return scope
+    if requested_scope in _SKILL_RESOURCE_SCOPES:
+        return requested_scope
+    return None
+
+
+def _skill_backend_entries(skill: dict[str, Any], selected_backends: Optional[list[str]]) -> list[tuple[str, int | None]]:
+    raw_agents = skill.get("agents")
+    if isinstance(raw_agents, list):
+        result: list[tuple[str, int | None]] = []
+        for index, agent in enumerate(raw_agents):
+            backend = _backend_from_agent_ref(agent)
+            if backend is not None:
+                result.append((backend, index))
+        if selected_backends:
+            selected = set(_normalized_backends(selected_backends))
+            result = [item for item in result if item[0] in selected]
+        return result
+    return [(backend, None) for backend in _normalized_backends(selected_backends)]
+
+
+def _skill_resource_descriptors(
+    skills: list[dict[str, Any]],
+    *,
+    requested_scope: str,
+    project_dir: Optional[str],
+    backends: Optional[list[str]],
+) -> list[dict[str, Any]]:
+    descriptors: list[dict[str, Any]] = []
+    for skill_index, skill in enumerate(skills):
+        scope = _skill_scope(skill, requested_scope)
+        name = skill.get("name")
+        if scope is None or not isinstance(name, str):
+            continue
+        try:
+            entries = _skill_backend_entries(skill, backends)
+            for backend, agent_index in entries:
+                descriptors.append(
+                    {
+                        "id": skill_resource_id(
+                            backend,
+                            scope=scope,
+                            project_dir=project_dir,
+                            name=name,
+                        ),
+                        "skill_index": skill_index,
+                        "agent_index": agent_index,
+                    }
+                )
+        except SkillsError:
+            # A malformed askill row must not become visible to a remote caller.
+            continue
+    return descriptors
+
+
+def _filter_skill_listing(
+    result: dict[str, Any],
+    *,
+    scope: str,
+    project_dir: Optional[str],
+    backends: Optional[list[str]],
+    user_context: Any = None,
+) -> dict[str, Any]:
+    """Filter askill's value-free list payload through local Skill ACLs."""
+
+    if not result.get("ok") or not isinstance(result.get("skills"), list):
+        return result
+    context = resolve_resource_access_context(user_context)
+    if context.is_trusted_local:
+        return result
+
+    raw_skills = [dict(skill) for skill in result["skills"] if isinstance(skill, dict)]
+    descriptors = _skill_resource_descriptors(
+        raw_skills,
+        requested_scope=scope,
+        project_dir=project_dir,
+        backends=backends,
+    )
+    if not descriptors:
+        filtered_skills: list[dict[str, Any]] = []
+    else:
+        from storage import resource_access_service
+        from storage.db import get_cached_sqlite_engine
+
+        engine = get_cached_sqlite_engine()
+        with engine.connect() as connection:
+            accessible = resource_access_service.filter_accessible_resources(
+                context,
+                "skill",
+                descriptors,
+                connection=connection,
+            )
+        allowed = {(item["skill_index"], item["agent_index"]) for item in accessible}
+        filtered_skills = []
+        for skill_index, skill in enumerate(raw_skills):
+            matching = [item for item in descriptors if item["skill_index"] == skill_index]
+            if not matching or not any((item["skill_index"], item["agent_index"]) in allowed for item in matching):
+                continue
+            raw_agents = skill.get("agents")
+            if isinstance(raw_agents, list):
+                skill["agents"] = [
+                    agent
+                    for agent_index, agent in enumerate(raw_agents)
+                    if (skill_index, agent_index) in allowed
+                ]
+                if not skill["agents"]:
+                    continue
+            filtered_skills.append(skill)
+
+    filtered = dict(result)
+    filtered["skills"] = filtered_skills
+    if isinstance(result.get("summary"), dict):
+        summary = dict(result["summary"])
+        summary["global"] = sum(1 for skill in filtered_skills if skill.get("scope") == "global")
+        summary["project"] = sum(1 for skill in filtered_skills if skill.get("scope") == "project")
+        filtered["summary"] = summary
+    return filtered
+
+
+def _resource_ids_for_skill_name(
+    name: str,
+    *,
+    scope: str,
+    project_dir: Optional[str],
+    backends: Optional[list[str]],
+) -> list[str]:
+    return [
+        skill_resource_id(backend, scope=scope, project_dir=project_dir, name=name)
+        for backend in _normalized_backends(backends) or list(BACKEND_TO_AGENT)
+    ]
+
+
+def _require_skill_management_access(
+    resource_ids: list[str],
+    *,
+    user_context: Any,
+    allow_missing_policy: bool,
+) -> None:
+    from storage import resource_access_service
+    from storage.db import get_cached_sqlite_engine
+
+    context = resolve_resource_access_context(user_context)
+    if context.is_trusted_local:
+        return
+    engine = get_cached_sqlite_engine()
+    with engine.connect() as connection:
+        for resource_id in resource_ids:
+            policy = resource_access_service.get_resource_policy("skill", resource_id, connection=connection)
+            if policy is None:
+                if allow_missing_policy or context.is_instance_owner:
+                    continue
+                raise SkillAccessError()
+            if not resource_access_service.can_manage_resource_acl(
+                context,
+                "skill",
+                resource_id,
+                connection=connection,
+            ):
+                raise SkillAccessError()
+
+
+def _require_skill_create_access(user_context: Any) -> None:
+    context = resolve_resource_access_context(user_context)
+    if context.is_trusted_local or context.is_instance_owner:
+        return
+    if context.is_remote and context.is_active_organization_member and context.subject:
+        return
+    raise SkillAccessError()
+
+
+def _skill_names_from_payload(payload: dict[str, Any]) -> list[str]:
+    names: list[str] = []
+    direct = payload.get("skill")
+    if isinstance(direct, str):
+        names.append(direct)
+    for key in ("skills", "results"):
+        entries = payload.get(key)
+        if not isinstance(entries, list):
+            continue
+        for entry in entries:
+            if isinstance(entry, str):
+                names.append(entry)
+                continue
+            if not isinstance(entry, dict):
+                continue
+            for candidate in (entry.get("skill"), entry.get("name")):
+                if isinstance(candidate, str):
+                    names.append(candidate)
+                    break
+    return list(dict.fromkeys(name for name in names if name.strip()))
+
+
+def _result_backends(result: dict[str, Any], fallback: Optional[list[str]]) -> list[str]:
+    for key in ("selectedAgents", "agents", "removedAgents"):
+        raw_agents = result.get(key)
+        if not isinstance(raw_agents, list):
+            continue
+        resolved = [backend for agent in raw_agents if (backend := _backend_from_agent_ref(agent)) is not None]
+        if resolved:
+            return list(dict.fromkeys(resolved))
+    return _normalized_backends(fallback) or list(BACKEND_TO_AGENT)
+
+
+def _register_created_skill_policies(
+    names: list[str],
+    *,
+    scope: str,
+    project_dir: Optional[str],
+    backends: list[str],
+    user_context: Any,
+) -> None:
+    from storage import resource_access_service
+    from storage.db import get_cached_sqlite_engine
+
+    context = resolve_resource_access_context(user_context)
+    if not (context.is_remote and context.is_active_organization_member and context.subject):
+        return
+    engine = get_cached_sqlite_engine()
+    with engine.begin() as connection:
+        for name in names:
+            for backend in backends:
+                resource_access_service.ensure_resource_policy(
+                    connection,
+                    resource_kind="skill",
+                    resource_id=skill_resource_id(
+                        backend,
+                        scope=scope,
+                        project_dir=project_dir,
+                        name=name,
+                    ),
+                    organization_id=context.organization_id,
+                    owner_user_id=context.subject,
+                    owner_email=context.email,
+                    access_level="private",
+                    created_by_user_id=context.subject,
+                    updated_by_user_id=context.subject,
+                )
+
+
+async def _installed_skill_resource_ids(
+    askill_path: str,
+    name: str,
+    *,
+    scope: str,
+    project_dir: Optional[str],
+    backends: Optional[list[str]],
+) -> list[str]:
+    listing = await _run_askill(
+        askill_path,
+        ["list", *_list_scope_flag(scope), *_agent_flags(backends)],
+        cwd=_cwd_for(scope, project_dir),
+    )
+    raw_skills = listing.get("skills") if isinstance(listing.get("skills"), list) else []
+    target_name = _normalize_skill_name(name)
+    resource_ids: list[str] = []
+    for skill in raw_skills:
+        if not isinstance(skill, dict):
+            continue
+        try:
+            row_name = _normalize_skill_name(skill.get("name"))
+        except SkillsError:
+            continue
+        if row_name != target_name:
+            continue
+        row_scope = _skill_scope(skill, scope)
+        if row_scope is None:
+            continue
+        entries = _skill_backend_entries(skill, backends)
+        if not entries:
+            raise SkillAccessError()
+        for backend, _agent_index in entries:
+            resource_ids.append(
+                skill_resource_id(
+                    backend,
+                    scope=row_scope,
+                    project_dir=project_dir,
+                    name=str(skill["name"]),
+                )
+            )
+    return list(dict.fromkeys(resource_ids))
+
+
 # --- public API -----------------------------------------------------------
 
 
@@ -186,6 +565,7 @@ async def list_skills(
     scope: str = "all",
     project_dir: Optional[str] = None,
     backends: Optional[list[str]] = None,
+    user_context: Any = None,
 ) -> dict[str, Any]:
     """List installed skills. ``scope`` is ``all`` | ``global`` | ``project``.
 
@@ -194,7 +574,14 @@ async def list_skills(
     source / installSource / timestamps natively (askill v0.1.13+).
     """
     args = ["list", *_list_scope_flag(scope), *_agent_flags(backends)]
-    return await _run_askill(askill_path, args, cwd=_cwd_for(scope, project_dir))
+    result = await _run_askill(askill_path, args, cwd=_cwd_for(scope, project_dir))
+    return _filter_skill_listing(
+        result,
+        scope=scope,
+        project_dir=project_dir,
+        backends=backends,
+        user_context=user_context,
+    )
 
 
 async def preview_source(
@@ -223,6 +610,7 @@ async def add_skill(
     all_skills: bool = False,
     skill: Optional[str] = None,
     copy: bool = False,
+    user_context: Any = None,
 ) -> dict[str, Any]:
     """Install skill(s) from a source. Non-interactive (``-y``).
 
@@ -235,6 +623,25 @@ async def add_skill(
         raise SkillsError("missing_source", "no source provided")
     if scope not in ("global", "project"):
         raise SkillsError("invalid_scope", "install scope must be global or project")
+    context = resolve_resource_access_context(user_context)
+    if not context.is_trusted_local:
+        _require_skill_create_access(context)
+        target_names = [skill] if skill else []
+        if not target_names:
+            preview = await _run_askill(askill_path, ["add", source, "--list"], cwd=_cwd_for(scope, project_dir))
+            if preview.get("ok"):
+                target_names = _skill_names_from_payload(preview)
+        for target_name in target_names:
+            _require_skill_management_access(
+                _resource_ids_for_skill_name(
+                    target_name,
+                    scope=scope,
+                    project_dir=project_dir,
+                    backends=backends,
+                ),
+                user_context=context,
+                allow_missing_policy=True,
+            )
     args = ["add", source, *_target_scope_flag(scope), *_agent_flags(backends)]
     if skill:
         args += ["--skill", skill]
@@ -263,6 +670,18 @@ async def add_skill(
                     "message": "No matching skill was found in this source — nothing was installed.",
                 },
             }
+    if result.get("ok"):
+        names = _skill_names_from_payload(result)
+        if not names and skill:
+            names = [skill]
+        if names:
+            _register_created_skill_policies(
+                names,
+                scope=scope,
+                project_dir=project_dir,
+                backends=_result_backends(result, backends),
+                user_context=context,
+            )
     return result
 
 
@@ -273,6 +692,7 @@ async def remove_skill(
     scope: str = "project",
     project_dir: Optional[str] = None,
     backends: Optional[list[str]] = None,
+    user_context: Any = None,
 ) -> dict[str, Any]:
     """Remove an installed skill, optionally from specific backends only.
 
@@ -282,6 +702,21 @@ async def remove_skill(
         raise SkillsError("missing_skill", "no skill name provided")
     if scope not in ("global", "project"):
         raise SkillsError("invalid_scope", "remove scope must be global or project")
+    context = resolve_resource_access_context(user_context)
+    if not context.is_trusted_local:
+        resource_ids = await _installed_skill_resource_ids(
+            askill_path,
+            name,
+            scope=scope,
+            project_dir=project_dir,
+            backends=backends,
+        )
+        if resource_ids:
+            _require_skill_management_access(
+                resource_ids,
+                user_context=context,
+                allow_missing_policy=False,
+            )
     args = ["remove", name, *_target_scope_flag(scope), *_agent_flags(backends)]
     return await _run_askill(askill_path, args, cwd=_cwd_for(scope, project_dir))
 
@@ -320,9 +755,27 @@ async def update(
     *,
     scope: str = "project",
     project_dir: Optional[str] = None,
+    user_context: Any = None,
 ) -> dict[str, Any]:
     """Update one installed skill. Maps to ``askill update <name> [-g] -y``."""
     if not name:
         raise SkillsError("missing_skill", "no skill name provided")
+    if scope not in ("global", "project"):
+        raise SkillsError("invalid_scope", "update scope must be global or project")
+    context = resolve_resource_access_context(user_context)
+    if not context.is_trusted_local:
+        resource_ids = await _installed_skill_resource_ids(
+            askill_path,
+            name,
+            scope=scope,
+            project_dir=project_dir,
+            backends=None,
+        )
+        if resource_ids:
+            _require_skill_management_access(
+                resource_ids,
+                user_context=context,
+                allow_missing_policy=False,
+            )
     args = ["update", name, *_target_scope_flag(scope), "-y"]
     return await _run_askill(askill_path, args, cwd=_cwd_for(scope, project_dir))

--- a/core/services/skills.py
+++ b/core/services/skills.py
@@ -192,15 +192,7 @@ def resolve_resource_access_context(user_context: Any = None):
 
     from storage import resource_access_service
 
-    if isinstance(user_context, resource_access_service.ResourceUserContext):
-        return user_context
-    if user_context is not None:
-        return resource_access_service.current_resource_context(user_context, is_remote=True)
-
-    context = resource_access_service.current_resource_context()
-    if context.is_remote or context.is_trusted_local:
-        return context
-    return resource_access_service.ResourceUserContext(is_trusted_local=True)
+    return resource_access_service.resolve_resource_access_context(user_context)
 
 
 def _normalize_skill_name(name: Any) -> str:

--- a/core/services/skills.py
+++ b/core/services/skills.py
@@ -469,6 +469,21 @@ def _result_backends(result: dict[str, Any], fallback: Optional[list[str]]) -> l
     return _normalized_backends(fallback) or list(BACKEND_TO_AGENT)
 
 
+def _removed_backends(result: dict[str, Any], fallback: Optional[list[str]]) -> list[str]:
+    if "removedAgents" in result:
+        raw_agents = result.get("removedAgents")
+        if not isinstance(raw_agents, list):
+            return []
+        return list(
+            dict.fromkeys(
+                backend
+                for agent in raw_agents
+                if (backend := _backend_from_agent_ref(agent)) is not None
+            )
+        )
+    return _normalized_backends(fallback) or list(BACKEND_TO_AGENT)
+
+
 def _register_created_skill_policies(
     names: list[str],
     *,
@@ -503,6 +518,20 @@ def _register_created_skill_policies(
                     created_by_user_id=context.subject,
                     updated_by_user_id=context.subject,
                 )
+
+
+def _delete_skill_policies(resource_ids: list[str]) -> None:
+    if not resource_ids:
+        return
+    from storage import resource_access_service
+    from storage.db import get_cached_sqlite_engine
+    from storage.importer import ensure_sqlite_state
+
+    ensure_sqlite_state()
+    engine = get_cached_sqlite_engine()
+    with engine.begin() as connection:
+        for resource_id in resource_ids:
+            resource_access_service.delete_resource_policy(connection, "skill", resource_id)
 
 
 async def _installed_skill_resource_ids(
@@ -710,7 +739,18 @@ async def remove_skill(
                 allow_missing_policy=False,
             )
     args = ["remove", name, *_target_scope_flag(scope), *_agent_flags(backends)]
-    return await _run_askill(askill_path, args, cwd=_cwd_for(scope, project_dir))
+    result = await _run_askill(askill_path, args, cwd=_cwd_for(scope, project_dir))
+    if result.get("ok"):
+        removed_backends = _removed_backends(result, backends)
+        _delete_skill_policies(
+            _resource_ids_for_skill_name(
+                name,
+                scope=scope,
+                project_dir=project_dir,
+                backends=removed_backends,
+            )
+        )
+    return result
 
 
 async def find_skills(askill_path: str, query: str = "") -> dict[str, Any]:

--- a/core/services/skills.py
+++ b/core/services/skills.py
@@ -773,6 +773,7 @@ async def check(
     *,
     scope: str = "project",
     project_dir: Optional[str] = None,
+    user_context: Any = None,
 ) -> dict[str, Any]:
     """Check installed skills for available updates (no install).
 
@@ -781,7 +782,26 @@ async def check(
     ``uncheckable``) plus ``localVersion`` / ``remoteVersion``.
     """
     args = ["check", *_target_scope_flag(scope)]
-    return await _run_askill(askill_path, args, cwd=_cwd_for(scope, project_dir))
+    result = await _run_askill(askill_path, args, cwd=_cwd_for(scope, project_dir))
+    context = resolve_resource_access_context(user_context)
+    filtered = _filter_skill_listing(
+        result,
+        scope=scope,
+        project_dir=project_dir,
+        backends=list(BACKEND_TO_AGENT),
+        user_context=context,
+    )
+    if context.is_trusted_local or not isinstance(filtered.get("summary"), dict):
+        return filtered
+    skills = filtered.get("skills") if isinstance(filtered.get("skills"), list) else []
+    statuses = [str(skill.get("status") or "") for skill in skills if isinstance(skill, dict)]
+    filtered["summary"] = {
+        "total": len(skills),
+        "updateAvailable": statuses.count("update_available"),
+        "upToDate": statuses.count("up_to_date"),
+        "uncheckable": statuses.count("uncheckable"),
+    }
+    return filtered
 
 
 async def update(

--- a/core/services/skills.py
+++ b/core/services/skills.py
@@ -547,7 +547,9 @@ async def _installed_skill_resource_ids(
         ["list", *_list_scope_flag(scope), *_agent_flags(backends)],
         cwd=_cwd_for(scope, project_dir),
     )
-    raw_skills = listing.get("skills") if isinstance(listing.get("skills"), list) else []
+    if not listing.get("ok") or not isinstance(listing.get("skills"), list):
+        raise SkillAccessError()
+    raw_skills = listing["skills"]
     target_name = _normalize_skill_name(name)
     resource_ids: list[str] = []
     for skill in raw_skills:
@@ -574,6 +576,8 @@ async def _installed_skill_resource_ids(
                     name=str(skill["name"]),
                 )
             )
+    if not resource_ids:
+        raise SkillAccessError()
     return list(dict.fromkeys(resource_ids))
 
 
@@ -732,12 +736,11 @@ async def remove_skill(
             project_dir=project_dir,
             backends=backends,
         )
-        if resource_ids:
-            _require_skill_management_access(
-                resource_ids,
-                user_context=context,
-                allow_missing_policy=False,
-            )
+        _require_skill_management_access(
+            resource_ids,
+            user_context=context,
+            allow_missing_policy=False,
+        )
     args = ["remove", name, *_target_scope_flag(scope), *_agent_flags(backends)]
     result = await _run_askill(askill_path, args, cwd=_cwd_for(scope, project_dir))
     if result.get("ok"):
@@ -803,11 +806,10 @@ async def update(
             project_dir=project_dir,
             backends=None,
         )
-        if resource_ids:
-            _require_skill_management_access(
-                resource_ids,
-                user_context=context,
-                allow_missing_policy=False,
-            )
+        _require_skill_management_access(
+            resource_ids,
+            user_context=context,
+            allow_missing_policy=False,
+        )
     args = ["update", name, *_target_scope_flag(scope), "-y"]
     return await _run_askill(askill_path, args, cwd=_cwd_for(scope, project_dir))

--- a/core/services/skills.py
+++ b/core/services/skills.py
@@ -534,6 +534,46 @@ def _delete_skill_policies(resource_ids: list[str]) -> None:
             resource_access_service.delete_resource_policy(connection, "skill", resource_id)
 
 
+def _installed_skill_resource_ids_from_listing(
+    listing: dict[str, Any],
+    name: str,
+    *,
+    scope: str,
+    project_dir: Optional[str],
+    backends: Optional[list[str]],
+) -> list[str]:
+    if not listing.get("ok") or not isinstance(listing.get("skills"), list):
+        raise SkillAccessError()
+    target_name = _normalize_skill_name(name)
+    resource_ids: list[str] = []
+    for skill in listing["skills"]:
+        if not isinstance(skill, dict):
+            continue
+        try:
+            row_name = _normalize_skill_name(skill.get("name"))
+        except SkillsError:
+            continue
+        if row_name != target_name:
+            continue
+        row_scope = _skill_scope(skill, scope)
+        if row_scope is None:
+            continue
+        all_entries = _skill_backend_entries(skill, None)
+        if not all_entries:
+            raise SkillAccessError()
+        entries = _skill_backend_entries(skill, backends) if backends else all_entries
+        for backend, _agent_index in entries:
+            resource_ids.append(
+                skill_resource_id(
+                    backend,
+                    scope=row_scope,
+                    project_dir=project_dir,
+                    name=str(skill["name"]),
+                )
+            )
+    return list(dict.fromkeys(resource_ids))
+
+
 async def _installed_skill_resource_ids(
     askill_path: str,
     name: str,
@@ -547,38 +587,16 @@ async def _installed_skill_resource_ids(
         ["list", *_list_scope_flag(scope), *_agent_flags(backends)],
         cwd=_cwd_for(scope, project_dir),
     )
-    if not listing.get("ok") or not isinstance(listing.get("skills"), list):
-        raise SkillAccessError()
-    raw_skills = listing["skills"]
-    target_name = _normalize_skill_name(name)
-    resource_ids: list[str] = []
-    for skill in raw_skills:
-        if not isinstance(skill, dict):
-            continue
-        try:
-            row_name = _normalize_skill_name(skill.get("name"))
-        except SkillsError:
-            continue
-        if row_name != target_name:
-            continue
-        row_scope = _skill_scope(skill, scope)
-        if row_scope is None:
-            continue
-        entries = _skill_backend_entries(skill, backends)
-        if not entries:
-            raise SkillAccessError()
-        for backend, _agent_index in entries:
-            resource_ids.append(
-                skill_resource_id(
-                    backend,
-                    scope=row_scope,
-                    project_dir=project_dir,
-                    name=str(skill["name"]),
-                )
-            )
+    resource_ids = _installed_skill_resource_ids_from_listing(
+        listing,
+        name,
+        scope=scope,
+        project_dir=project_dir,
+        backends=backends,
+    )
     if not resource_ids:
         raise SkillAccessError()
-    return list(dict.fromkeys(resource_ids))
+    return resource_ids
 
 
 # --- public API -----------------------------------------------------------
@@ -656,6 +674,8 @@ async def add_skill(
             preview = await _run_askill(askill_path, ["add", source, "--list"], cwd=_cwd_for(scope, project_dir))
             if preview.get("ok"):
                 target_names = _skill_names_from_payload(preview)
+        if not target_names:
+            raise SkillAccessError()
         for target_name in target_names:
             _require_skill_management_access(
                 _resource_ids_for_skill_name(
@@ -667,6 +687,25 @@ async def add_skill(
                 user_context=context,
                 allow_missing_policy=True,
             )
+        listing = await _run_askill(
+            askill_path,
+            ["list", *_list_scope_flag(scope), *_agent_flags(backends)],
+            cwd=_cwd_for(scope, project_dir),
+        )
+        for target_name in target_names:
+            installed_resource_ids = _installed_skill_resource_ids_from_listing(
+                listing,
+                target_name,
+                scope=scope,
+                project_dir=project_dir,
+                backends=backends,
+            )
+            if installed_resource_ids:
+                _require_skill_management_access(
+                    installed_resource_ids,
+                    user_context=context,
+                    allow_missing_policy=False,
+                )
     args = ["add", source, *_target_scope_flag(scope), *_agent_flags(backends)]
     if skill:
         args += ["--skill", skill]

--- a/core/show_pages.py
+++ b/core/show_pages.py
@@ -198,15 +198,7 @@ def _resolve_resource_access_context(user_context: Any = None):
 
     from storage import resource_access_service
 
-    if isinstance(user_context, resource_access_service.ResourceUserContext):
-        return user_context
-    if user_context is not None:
-        return resource_access_service.current_resource_context(user_context, is_remote=True)
-
-    context = resource_access_service.current_resource_context()
-    if context.is_remote or context.is_trusted_local:
-        return context
-    return resource_access_service.ResourceUserContext(is_trusted_local=True)
+    return resource_access_service.resolve_resource_access_context(user_context)
 
 
 def private_url(session_id: str, *, config: V2Config | None = None) -> str | None:
@@ -271,6 +263,22 @@ class ShowPageStore:
             self._require_resource_access(conn, session_id, context)
             return _page_from_row(row)
 
+    def require_management(self, session_id: str, *, user_context: Any = None) -> ShowPage:
+        """Return a Show Page only when the caller may change its resource."""
+
+        session_id = validate_session_id(session_id)
+        context = _resolve_resource_access_context(user_context)
+        with self.engine.connect() as conn:
+            row = (
+                conn.execute(select(show_pages).where(show_pages.c.session_id == session_id).limit(1))
+                .mappings()
+                .first()
+            )
+            if row is None:
+                raise ShowPageError("This session has no Show Page.", code="show_page_not_found")
+            self._require_resource_management(conn, session_id, context)
+            return _page_from_row(row)
+
     def list(self, *, visibility: str | None = None, user_context: Any = None) -> list[ShowPage]:
         result = self.list_page(visibility=visibility, page_request=None, user_context=user_context)
         return result.items
@@ -325,6 +333,18 @@ class ShowPageStore:
         from storage import resource_access_service
 
         if not resource_access_service.can_use_resource(
+            user_context,
+            "show_page",
+            session_id,
+            connection=connection,
+        ):
+            raise ShowPageError("Show Page access is not permitted.", code="resource_access_forbidden")
+
+    @staticmethod
+    def _require_resource_management(connection, session_id: str, user_context: Any) -> None:
+        from storage import resource_access_service
+
+        if not resource_access_service.can_manage_resource_acl(
             user_context,
             "show_page",
             session_id,
@@ -498,7 +518,7 @@ class ShowPageStore:
         if visibility == VISIBILITY_PUBLIC and not page.share_id:
             values["share_id"] = self._unique_share_id()
         with self.engine.begin() as conn:
-            self._require_resource_access(conn, session_id, context)
+            self._require_resource_management(conn, session_id, context)
             # Archive is terminal and takes the page offline on purpose — never let
             # an archived session's page be brought back online / re-shared. Checked
             # in the SAME txn as the write so a concurrent archive can't slip in
@@ -544,7 +564,7 @@ class ShowPageStore:
         new_share_id = self._unique_share_id()
         now = _utc_now_iso()
         with self.engine.begin() as conn:
-            self._require_resource_access(conn, session_id, context)
+            self._require_resource_management(conn, session_id, context)
             conn.execute(
                 update(show_pages)
                 .where(show_pages.c.session_id == session_id)
@@ -590,7 +610,7 @@ class ShowPageStore:
         previous_share_id: str | None = None
         try:
             with self.engine.begin() as conn:
-                self._require_resource_access(conn, session_id, context)
+                self._require_resource_management(conn, session_id, context)
                 # Read visibility, archive status, and the current suffix in the
                 # SAME transaction as the write so a concurrent flip to private/
                 # offline, an archive, or another session claiming the suffix

--- a/core/show_pages.py
+++ b/core/show_pages.py
@@ -507,9 +507,9 @@ class ShowPageStore:
             raise ShowPageError(f"Unsupported visibility: {visibility}", code="invalid_visibility")
         existing = self.get(session_id)
         if existing is not None:
-            # Check access before reporting a terminal lifecycle state so an
+            # Check management before reporting a terminal lifecycle state so an
             # unauthorized remote user cannot probe page/session details.
-            page = self.ensure(session_id, user_context=context)
+            page = self.require_management(session_id, user_context=context)
         else:
             page = None
         # Reject republish BEFORE ``ensure`` so it doesn't first materialize a
@@ -556,7 +556,7 @@ class ShowPageStore:
         context = _resolve_resource_access_context(user_context)
         existing = self.get(session_id)
         if existing is not None:
-            page = self.ensure(session_id, user_context=context)
+            page = self.require_management(session_id, user_context=context)
         else:
             page = None
         # Same guard as update_visibility, before ``ensure`` materializes a page:
@@ -608,7 +608,7 @@ class ShowPageStore:
         new_share_id = validate_share_id(share_id)
         existing = self.get(session_id)
         if existing is not None:
-            self.ensure(session_id, user_context=context)
+            self.require_management(session_id, user_context=context)
         # Pre-guard before ``ensure`` so a stale/direct call never materializes a
         # default page for an archived (terminal) session. The in-txn re-reads
         # below are the atomic authority for the concurrent-archive / concurrent

--- a/core/show_pages.py
+++ b/core/show_pages.py
@@ -23,7 +23,7 @@ from core.show_git import format_agent_contract
 from storage.db import create_sqlite_engine
 from storage.importer import ensure_sqlite_state, resolve_primary_platform_from_config
 from storage.models import agent_sessions, show_pages
-from storage.pagination import PageRequest, PageResult, page_result_from_limit_plus_one
+from storage.pagination import PageRequest, PageResult, page_sequence
 
 VISIBILITY_PRIVATE = "private"
 VISIBILITY_PUBLIC = "public"
@@ -193,6 +193,22 @@ def _like_pattern(value: str, *, prefix: bool = False, contains: bool = False) -
     return escaped
 
 
+def _resolve_resource_access_context(user_context: Any = None):
+    """Resolve request ACL context while retaining trusted local workflows."""
+
+    from storage import resource_access_service
+
+    if isinstance(user_context, resource_access_service.ResourceUserContext):
+        return user_context
+    if user_context is not None:
+        return resource_access_service.current_resource_context(user_context, is_remote=True)
+
+    context = resource_access_service.current_resource_context()
+    if context.is_remote or context.is_trusted_local:
+        return context
+    return resource_access_service.ResourceUserContext(is_trusted_local=True)
+
+
 def private_url(session_id: str, *, config: V2Config | None = None) -> str | None:
     base = base_public_url(config)
     if not base:
@@ -239,8 +255,24 @@ class ShowPageStore:
             )
             return _page_from_row(row) if row else None
 
-    def list(self, *, visibility: str | None = None) -> list[ShowPage]:
-        result = self.list_page(visibility=visibility, page_request=None)
+    def require_access(self, session_id: str, *, user_context: Any = None) -> ShowPage:
+        """Return a Show Page only when the caller may use its ACL resource."""
+
+        session_id = validate_session_id(session_id)
+        context = _resolve_resource_access_context(user_context)
+        with self.engine.connect() as conn:
+            row = (
+                conn.execute(select(show_pages).where(show_pages.c.session_id == session_id).limit(1))
+                .mappings()
+                .first()
+            )
+            if row is None:
+                raise ShowPageError("This session has no Show Page.", code="show_page_not_found")
+            self._require_resource_access(conn, session_id, context)
+            return _page_from_row(row)
+
+    def list(self, *, visibility: str | None = None, user_context: Any = None) -> list[ShowPage]:
+        result = self.list_page(visibility=visibility, page_request=None, user_context=user_context)
         return result.items
 
     def list_page(
@@ -252,7 +284,11 @@ class ShowPageStore:
         updated_before: str | None = None,
         query: str | None = None,
         page_request: PageRequest | None,
+        user_context: Any = None,
     ) -> PageResult[ShowPage]:
+        from storage import resource_access_service
+
+        context = _resolve_resource_access_context(user_context)
         if visibility is not None and visibility not in VISIBILITIES:
             raise ShowPageError(f"Unsupported visibility: {visibility}", code="invalid_visibility")
         statement = select(show_pages)
@@ -274,17 +310,57 @@ class ShowPageStore:
                 )
             )
         statement = statement.order_by(show_pages.c.updated_at.desc(), show_pages.c.session_id.asc())
-        if page_request is not None:
-            statement = statement.offset(page_request.offset).limit(page_request.limit + 1)
         with self.engine.connect() as conn:
             rows = conn.execute(statement).mappings().all()
-        return page_result_from_limit_plus_one((_page_from_row(row) for row in rows), page_request)
+            rows = resource_access_service.filter_accessible_resources(
+                context,
+                "show_page",
+                rows,
+                connection=conn,
+            )
+        return page_sequence([_page_from_row(row) for row in rows], page_request)
 
-    def ensure(self, session_id: str) -> ShowPage:
+    @staticmethod
+    def _require_resource_access(connection, session_id: str, user_context: Any) -> None:
+        from storage import resource_access_service
+
+        if not resource_access_service.can_use_resource(
+            user_context,
+            "show_page",
+            session_id,
+            connection=connection,
+        ):
+            raise ShowPageError("Show Page access is not permitted.", code="resource_access_forbidden")
+
+    @staticmethod
+    def _require_create_access(user_context: Any) -> None:
+        if user_context.is_trusted_local or user_context.is_instance_owner:
+            return
+        if user_context.is_remote and user_context.is_active_organization_member and user_context.subject:
+            return
+        raise ShowPageError("Show Page access is not permitted.", code="resource_access_forbidden")
+
+    @staticmethod
+    def _register_created_resource_policy(connection, session_id: str, user_context: Any) -> None:
+        from storage import resource_access_service
+
+        if not (user_context.is_remote and user_context.is_active_organization_member and user_context.subject):
+            return
+        resource_access_service.ensure_resource_policy(
+            connection,
+            resource_kind="show_page",
+            resource_id=session_id,
+            organization_id=user_context.organization_id,
+            owner_user_id=user_context.subject,
+            owner_email=user_context.email,
+            access_level="private",
+            created_by_user_id=user_context.subject,
+            updated_by_user_id=user_context.subject,
+        )
+
+    def ensure(self, session_id: str, *, user_context: Any = None) -> ShowPage:
         session_id = validate_session_id(session_id)
-        existing = self.get(session_id)
-        if existing is not None:
-            return existing
+        context = _resolve_resource_access_context(user_context)
         now = _utc_now_iso()
         page = ShowPage(
             session_id=session_id,
@@ -295,6 +371,15 @@ class ShowPageStore:
             updated_at=now,
         )
         with self.engine.begin() as conn:
+            existing = (
+                conn.execute(select(show_pages).where(show_pages.c.session_id == session_id).limit(1))
+                .mappings()
+                .first()
+            )
+            if existing is not None:
+                self._require_resource_access(conn, session_id, context)
+                return _page_from_row(existing)
+            self._require_create_access(context)
             conn.execute(
                 insert(show_pages).values(
                     session_id=page.session_id,
@@ -305,9 +390,10 @@ class ShowPageStore:
                     updated_at=page.updated_at,
                 )
             )
+            self._register_created_resource_policy(conn, session_id, context)
         return page
 
-    def ensure_active(self, session_id: str) -> tuple[ShowPage, bool]:
+    def ensure_active(self, session_id: str, *, user_context: Any = None) -> tuple[ShowPage, bool]:
         """Atomically ensure a page for a NON-archived session; return (page, created).
 
         The existing-row check, the archived check and the insert all run in ONE
@@ -318,6 +404,7 @@ class ShowPageStore:
         is returned untouched (archive already took it offline).
         """
         session_id = validate_session_id(session_id)
+        context = _resolve_resource_access_context(user_context)
         now = _utc_now_iso()
         with self.engine.begin() as conn:
             existing = (
@@ -326,7 +413,9 @@ class ShowPageStore:
                 .first()
             )
             if existing is not None:
+                self._require_resource_access(conn, session_id, context)
                 return _page_from_row(existing), False
+            self._require_create_access(context)
             status = conn.execute(
                 select(agent_sessions.c.status).where(agent_sessions.c.id == session_id)
             ).scalar_one_or_none()
@@ -356,11 +445,15 @@ class ShowPageStore:
                 )
             )
             created = bool(result.rowcount and result.rowcount > 0)
+            if created:
+                self._register_created_resource_policy(conn, session_id, context)
             row = (
                 conn.execute(select(show_pages).where(show_pages.c.session_id == session_id).limit(1))
                 .mappings()
                 .first()
             )
+            assert row is not None
+            self._require_resource_access(conn, session_id, context)
         return _page_from_row(row), created
 
     def is_archived(self, session_id: str) -> bool:
@@ -373,10 +466,18 @@ class ShowPageStore:
             ).scalar_one_or_none()
         return status == "archived"
 
-    def update_visibility(self, session_id: str, visibility: str) -> ShowPage:
+    def update_visibility(self, session_id: str, visibility: str, *, user_context: Any = None) -> ShowPage:
         session_id = validate_session_id(session_id)
+        context = _resolve_resource_access_context(user_context)
         if visibility not in VISIBILITIES:
             raise ShowPageError(f"Unsupported visibility: {visibility}", code="invalid_visibility")
+        existing = self.get(session_id)
+        if existing is not None:
+            # Check access before reporting a terminal lifecycle state so an
+            # unauthorized remote user cannot probe page/session details.
+            page = self.ensure(session_id, user_context=context)
+        else:
+            page = None
         # Reject republish BEFORE ``ensure`` so it doesn't first materialize a
         # default (private) page row for an archived session — that would leave
         # ``/show/<id>/`` enabled for a terminal session. The in-txn check below
@@ -386,7 +487,8 @@ class ShowPageStore:
                 "Cannot republish the Show Page of an archived session.",
                 code="session_archived",
             )
-        page = self.ensure(session_id)
+        if page is None:
+            page = self.ensure(session_id, user_context=context)
         now = _utc_now_iso()
         values: dict[str, Any] = {
             "visibility": visibility,
@@ -396,6 +498,7 @@ class ShowPageStore:
         if visibility == VISIBILITY_PUBLIC and not page.share_id:
             values["share_id"] = self._unique_share_id()
         with self.engine.begin() as conn:
+            self._require_resource_access(conn, session_id, context)
             # Archive is terminal and takes the page offline on purpose — never let
             # an archived session's page be brought back online / re-shared. Checked
             # in the SAME txn as the write so a concurrent archive can't slip in
@@ -414,8 +517,14 @@ class ShowPageStore:
         assert updated is not None
         return updated
 
-    def rotate_share(self, session_id: str) -> tuple[ShowPage, str | None]:
+    def rotate_share(self, session_id: str, *, user_context: Any = None) -> tuple[ShowPage, str | None]:
         session_id = validate_session_id(session_id)
+        context = _resolve_resource_access_context(user_context)
+        existing = self.get(session_id)
+        if existing is not None:
+            page = self.ensure(session_id, user_context=context)
+        else:
+            page = None
         # Same guard as update_visibility, before ``ensure`` materializes a page:
         # an archived session is terminal, so its share link can't be rotated /
         # re-enabled (and a stale/direct call must not create a default page).
@@ -424,7 +533,8 @@ class ShowPageStore:
                 "Cannot rotate the share link of an archived session.",
                 code="session_archived",
             )
-        page = self.ensure(session_id)
+        if page is None:
+            page = self.ensure(session_id, user_context=context)
         if page.visibility != VISIBILITY_PUBLIC:
             raise ShowPageError(
                 "Share links can only be rotated while the Show Page is public.",
@@ -434,6 +544,7 @@ class ShowPageStore:
         new_share_id = self._unique_share_id()
         now = _utc_now_iso()
         with self.engine.begin() as conn:
+            self._require_resource_access(conn, session_id, context)
             conn.execute(
                 update(show_pages)
                 .where(show_pages.c.session_id == session_id)
@@ -443,7 +554,13 @@ class ShowPageStore:
         assert updated is not None
         return updated, previous_share_id
 
-    def set_share_id(self, session_id: str, share_id: str) -> tuple[ShowPage, str | None]:
+    def set_share_id(
+        self,
+        session_id: str,
+        share_id: str,
+        *,
+        user_context: Any = None,
+    ) -> tuple[ShowPage, str | None]:
         """Set a custom public share suffix; return (page, previous_share_id).
 
         A custom suffix is just a chosen value for the same ``share_id`` that
@@ -453,7 +570,11 @@ class ShowPageStore:
         new value revokes the previous public URL, exactly like a rotate.
         """
         session_id = validate_session_id(session_id)
+        context = _resolve_resource_access_context(user_context)
         new_share_id = validate_share_id(share_id)
+        existing = self.get(session_id)
+        if existing is not None:
+            self.ensure(session_id, user_context=context)
         # Pre-guard before ``ensure`` so a stale/direct call never materializes a
         # default page for an archived (terminal) session. The in-txn re-reads
         # below are the atomic authority for the concurrent-archive / concurrent
@@ -463,11 +584,13 @@ class ShowPageStore:
                 "Cannot change the share link of an archived session.",
                 code="session_archived",
             )
-        self.ensure(session_id)
+        if existing is None:
+            self.ensure(session_id, user_context=context)
         now = _utc_now_iso()
         previous_share_id: str | None = None
         try:
             with self.engine.begin() as conn:
+                self._require_resource_access(conn, session_id, context)
                 # Read visibility, archive status, and the current suffix in the
                 # SAME transaction as the write so a concurrent flip to private/
                 # offline, an archive, or another session claiming the suffix

--- a/core/show_pages.py
+++ b/core/show_pages.py
@@ -14,6 +14,7 @@ from typing import Any
 from urllib.parse import unquote, urljoin, urlsplit
 
 from sqlalchemy import insert, or_, select, update
+from sqlalchemy.engine import Connection
 from sqlalchemy.exc import IntegrityError
 
 from config import paths
@@ -201,6 +202,27 @@ def _resolve_resource_access_context(user_context: Any = None):
     return resource_access_service.resolve_resource_access_context(user_context)
 
 
+def require_show_page_management(
+    connection: Connection,
+    session_id: str,
+    *,
+    user_context: Any = None,
+) -> None:
+    """Require management access using the caller's active transaction."""
+
+    from storage import resource_access_service
+
+    session_id = validate_session_id(session_id)
+    context = _resolve_resource_access_context(user_context)
+    if not resource_access_service.can_manage_resource_acl(
+        context,
+        "show_page",
+        session_id,
+        connection=connection,
+    ):
+        raise ShowPageError("Show Page access is not permitted.", code="resource_access_forbidden")
+
+
 def private_url(session_id: str, *, config: V2Config | None = None) -> str | None:
     base = base_public_url(config)
     if not base:
@@ -342,15 +364,7 @@ class ShowPageStore:
 
     @staticmethod
     def _require_resource_management(connection, session_id: str, user_context: Any) -> None:
-        from storage import resource_access_service
-
-        if not resource_access_service.can_manage_resource_acl(
-            user_context,
-            "show_page",
-            session_id,
-            connection=connection,
-        ):
-            raise ShowPageError("Show Page access is not permitted.", code="resource_access_forbidden")
+        require_show_page_management(connection, session_id, user_context=user_context)
 
     @staticmethod
     def _require_create_access(user_context: Any) -> None:

--- a/core/vibe_agents.py
+++ b/core/vibe_agents.py
@@ -31,6 +31,10 @@ SUPPORTED_AGENT_BACKENDS = {"codex", "claude", "opencode"}
 _UNSET = object()
 
 
+class VibeAgentAccessError(PermissionError):
+    """Raised when the caller is not allowed to use a Vibe Agent."""
+
+
 def _utc_now_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
 
@@ -61,6 +65,91 @@ def _json_loads(value: str | None, default: Any) -> Any:
         return json.loads(value)
     except (TypeError, ValueError):
         return default
+
+
+def resolve_resource_access_context(user_context: Any = None):
+    """Resolve a request context while preserving local service behavior.
+
+    Domain services are also called from the local CLI and background workers,
+    where there is no HTTP request to inspect. Those callers are local by
+    construction. Remote requests always carry an explicit remote context, so
+    they remain subject to the local ACL projection.
+    """
+
+    from storage import resource_access_service
+
+    if isinstance(user_context, resource_access_service.ResourceUserContext):
+        return user_context
+    if user_context is not None:
+        return resource_access_service.current_resource_context(user_context, is_remote=True)
+
+    context = resource_access_service.current_resource_context()
+    if context.is_remote or context.is_trusted_local:
+        return context
+    return resource_access_service.ResourceUserContext(is_trusted_local=True)
+
+
+def ensure_agent_selection_access(
+    connection,
+    *,
+    agent_name: str | None = None,
+    agent_id: str | None = None,
+    user_context: Any = None,
+    missing_is_error: bool = False,
+) -> "VibeAgent | None":
+    """Return a selected Agent only when the request may use it.
+
+    ``agent_id`` is the ACL resource identifier. A supplied name and id must
+    resolve to the same row so a caller cannot authorize one Agent and persist
+    another in a session or background definition.
+    """
+
+    from storage import resource_access_service
+
+    selected_name = str(agent_name or "").strip()
+    selected_id = str(agent_id or "").strip()
+    if not selected_name and not selected_id:
+        return None
+
+    context = resolve_resource_access_context(user_context)
+    statement = select(agents)
+    if selected_id:
+        statement = statement.where(agents.c.id == selected_id)
+    if selected_name:
+        statement = statement.where(agents.c.normalized_name == normalize_agent_name(selected_name))
+    row = connection.execute(statement.limit(1)).mappings().first()
+    if row is None:
+        if context.is_remote or missing_is_error:
+            raise LookupError("Agent not found")
+        # Older local callers may hold a backend/name pairing that predates the
+        # Vibe Agent catalog. Preserve that local compatibility; a remote
+        # request never receives the same exception.
+        return None
+
+    agent = VibeAgentStore._from_row(row)
+    if not resource_access_service.can_use_resource(context, "agent", agent.id, connection=connection):
+        raise VibeAgentAccessError("Agent access is not permitted.")
+    return agent
+
+
+def ensure_agent_name_access(agent_name: str | None, *, user_context: Any = None) -> None:
+    """Reject a remote task/watch binding to an inaccessible named Agent.
+
+    Local task and watch definitions are created outside an HTTP request and
+    intentionally retain their existing trusted-local behavior. A remote
+    request gets the same id-backed authorization used by session creation.
+    """
+
+    if not str(agent_name or "").strip():
+        return
+    context = resolve_resource_access_context(user_context)
+    if not context.is_remote:
+        return
+    store = VibeAgentStore()
+    try:
+        store.require_accessible(str(agent_name), user_context=context)
+    finally:
+        store.close()
 
 
 @dataclass(frozen=True)
@@ -122,12 +211,21 @@ class VibeAgentStore:
     def maybe_reload(self) -> bool:
         return self._probe.has_external_write()
 
-    def list_agents(self, *, include_disabled: bool = True) -> list[VibeAgent]:
+    def list_agents(self, *, include_disabled: bool = True, user_context: Any = None) -> list[VibeAgent]:
+        from storage import resource_access_service
+
+        context = resolve_resource_access_context(user_context)
         with self.engine.connect() as conn:
             stmt = select(agents).order_by(agents.c.name)
             if not include_disabled:
                 stmt = stmt.where(agents.c.enabled == 1)
-            rows = conn.execute(stmt).mappings()
+            rows = conn.execute(stmt).mappings().all()
+            rows = resource_access_service.filter_accessible_resources(
+                context,
+                "agent",
+                rows,
+                connection=conn,
+            )
             return [self._from_row(row) for row in rows]
 
     def get(self, name: str) -> Optional[VibeAgent]:
@@ -150,6 +248,21 @@ class VibeAgentStore:
             raise ValueError(f"agent '{agent.name}' is disabled")
         return agent
 
+    def require_accessible(self, name: str, *, user_context: Any = None, enabled_only: bool = False) -> VibeAgent:
+        """Return an Agent only when the caller may use its ACL resource."""
+
+        with self.engine.connect() as conn:
+            agent = ensure_agent_selection_access(
+                conn,
+                agent_name=name,
+                user_context=user_context,
+                missing_is_error=True,
+            )
+        assert agent is not None
+        if enabled_only and not agent.enabled:
+            raise ValueError(f"agent '{agent.name}' is disabled")
+        return agent
+
     def create(
         self,
         *,
@@ -163,8 +276,12 @@ class VibeAgentStore:
         source_ref: Optional[str] = None,
         metadata: Optional[dict[str, Any]] = None,
         enabled: bool = True,
+        user_context: Any = None,
     ) -> VibeAgent:
+        from storage import resource_access_service
+
         normalized = normalize_agent_name(name)
+        context = resolve_resource_access_context(user_context)
         now = _utc_now_iso()
         agent = VibeAgent(
             id=uuid4().hex[:12],
@@ -185,6 +302,18 @@ class VibeAgentStore:
         try:
             with self.engine.begin() as conn:
                 conn.execute(agents.insert().values(**self._values(agent)))
+                if source != "builtin" and context.is_remote and context.is_active_organization_member and context.subject:
+                    resource_access_service.ensure_resource_policy(
+                        conn,
+                        resource_kind="agent",
+                        resource_id=agent.id,
+                        organization_id=context.organization_id,
+                        owner_user_id=context.subject,
+                        owner_email=context.email,
+                        access_level="private",
+                        created_by_user_id=context.subject,
+                        updated_by_user_id=context.subject,
+                    )
         except IntegrityError as exc:
             raise ValueError(f"agent '{name}' already exists") from exc
         return agent
@@ -426,7 +555,14 @@ class VibeAgentStore:
         if fallback is not None and (fallback.enabled or not enabled_only):
             return fallback
         if enabled_only:
-            agents_list = self.list_agents(include_disabled=False)
+            # This resolver maintains the instance-wide default. It must not let
+            # one remote caller's ACL-filtered catalog rewrite that global state.
+            from storage.resource_access_service import ResourceUserContext
+
+            agents_list = self.list_agents(
+                include_disabled=False,
+                user_context=ResourceUserContext(is_trusted_local=True),
+            )
             return agents_list[0] if agents_list else None
         return None
 

--- a/core/vibe_agents.py
+++ b/core/vibe_agents.py
@@ -251,13 +251,16 @@ class VibeAgentStore:
     def require_accessible(self, name: str, *, user_context: Any = None, enabled_only: bool = False) -> VibeAgent:
         """Return an Agent only when the caller may use its ACL resource."""
 
-        with self.engine.connect() as conn:
-            agent = ensure_agent_selection_access(
-                conn,
-                agent_name=name,
-                user_context=user_context,
-                missing_is_error=True,
-            )
+        try:
+            with self.engine.connect() as conn:
+                agent = ensure_agent_selection_access(
+                    conn,
+                    agent_name=name,
+                    user_context=user_context,
+                    missing_is_error=True,
+                )
+        except LookupError as exc:
+            raise ValueError(f"agent '{name}' not found") from exc
         assert agent is not None
         if enabled_only and not agent.enabled:
             raise ValueError(f"agent '{agent.name}' is disabled")

--- a/core/vibe_agents.py
+++ b/core/vibe_agents.py
@@ -225,6 +225,26 @@ def ensure_default_agent_access(
     return agent
 
 
+def ensure_session_agent_access(
+    connection,
+    session: dict[str, Any],
+    *,
+    user_context: Any = None,
+) -> VibeAgent | None:
+    """Revalidate the Agent selected by a persisted session before dispatch."""
+
+    if session.get("agent_id") or session.get("agent_name"):
+        return ensure_agent_selection_access(
+            connection,
+            agent_name=session.get("agent_name"),
+            agent_id=session.get("agent_id"),
+            user_context=user_context,
+        )
+    if not session.get("agent_backend"):
+        return ensure_default_agent_access(connection, user_context=user_context)
+    return None
+
+
 @dataclass(frozen=True)
 class AgentImportCandidate:
     name: str
@@ -430,6 +450,8 @@ class VibeAgentStore:
         return self.update(name, enabled=enabled)
 
     def remove(self, name: str) -> bool:
+        from storage import resource_access_service
+
         agent = self.get(name)
         if agent is None:
             return False
@@ -438,6 +460,8 @@ class VibeAgentStore:
         normalized = agent.normalized_name
         with self.engine.begin() as conn:
             result = conn.execute(agents.delete().where(agents.c.normalized_name == normalized))
+            if result.rowcount:
+                resource_access_service.delete_resource_policy(conn, "agent", agent.id)
             return bool(result.rowcount)
 
     def reference_counts(self, name: str) -> dict[str, int]:

--- a/core/vibe_agents.py
+++ b/core/vibe_agents.py
@@ -167,6 +167,64 @@ class VibeAgent:
         return asdict(self)
 
 
+def resolve_effective_default_agent(connection, *, enabled_only: bool = True) -> VibeAgent | None:
+    """Resolve the same instance-wide default used by runtime dispatch."""
+
+    raw_name = connection.execute(
+        select(state_meta.c.value_json).where(state_meta.c.key == DEFAULT_AGENT_META_KEY).limit(1)
+    ).scalar_one_or_none()
+    configured_name = _json_loads(raw_name, None)
+    candidates = [configured_name, DEFAULT_AGENT_NAME]
+    seen: set[str] = set()
+    for candidate in candidates:
+        if not isinstance(candidate, str) or not candidate.strip():
+            continue
+        try:
+            normalized = normalize_agent_name(candidate)
+        except ValueError:
+            continue
+        if normalized in seen:
+            continue
+        seen.add(normalized)
+        statement = select(agents).where(agents.c.normalized_name == normalized)
+        if enabled_only:
+            statement = statement.where(agents.c.enabled == 1)
+        row = connection.execute(statement.limit(1)).mappings().first()
+        if row is not None:
+            return VibeAgentStore._from_row(row)
+
+    if not enabled_only:
+        return None
+    row = connection.execute(select(agents).where(agents.c.enabled == 1).order_by(agents.c.name).limit(1)).mappings().first()
+    return VibeAgentStore._from_row(row) if row is not None else None
+
+
+def ensure_default_agent_access(
+    connection,
+    *,
+    user_context: Any = None,
+    missing_is_error: bool = False,
+) -> VibeAgent | None:
+    """Resolve and authorize the effective default Agent for a remote caller."""
+
+    from storage import resource_access_service
+
+    context = resolve_resource_access_context(user_context)
+    agent = resolve_effective_default_agent(connection)
+    if agent is None:
+        if context.is_remote or missing_is_error:
+            raise LookupError("Default Agent not found")
+        return None
+    if not resource_access_service.can_use_resource(
+        context,
+        "agent",
+        agent.id,
+        connection=connection,
+    ):
+        raise VibeAgentAccessError("Agent access is not permitted.")
+    return agent
+
+
 @dataclass(frozen=True)
 class AgentImportCandidate:
     name: str
@@ -575,25 +633,8 @@ class VibeAgentStore:
             )
 
     def get_default_agent(self, *, enabled_only: bool = True) -> Optional[VibeAgent]:
-        name = self.get_default_agent_name()
-        if name:
-            agent = self.get(name)
-            if agent is not None and (agent.enabled or not enabled_only):
-                return agent
-        fallback = self.get(DEFAULT_AGENT_NAME)
-        if fallback is not None and (fallback.enabled or not enabled_only):
-            return fallback
-        if enabled_only:
-            # This resolver maintains the instance-wide default. It must not let
-            # one remote caller's ACL-filtered catalog rewrite that global state.
-            from storage.resource_access_service import ResourceUserContext
-
-            agents_list = self.list_agents(
-                include_disabled=False,
-                user_context=ResourceUserContext(is_trusted_local=True),
-            )
-            return agents_list[0] if agents_list else None
-        return None
+        with self.engine.connect() as conn:
+            return resolve_effective_default_agent(conn, enabled_only=enabled_only)
 
     @staticmethod
     def _from_row(row: Any) -> VibeAgent:

--- a/core/vibe_agents.py
+++ b/core/vibe_agents.py
@@ -233,15 +233,18 @@ def ensure_session_agent_access(
 ) -> VibeAgent | None:
     """Revalidate the Agent selected by a persisted session before dispatch."""
 
+    context = resolve_resource_access_context(user_context)
     if session.get("agent_id") or session.get("agent_name"):
         return ensure_agent_selection_access(
             connection,
             agent_name=session.get("agent_name"),
             agent_id=session.get("agent_id"),
-            user_context=user_context,
+            user_context=context,
         )
     if not session.get("agent_backend"):
-        return ensure_default_agent_access(connection, user_context=user_context)
+        return ensure_default_agent_access(connection, user_context=context)
+    if context.is_remote:
+        raise VibeAgentAccessError("Agent access is not permitted.")
     return None
 
 

--- a/core/vibe_agents.py
+++ b/core/vibe_agents.py
@@ -68,25 +68,11 @@ def _json_loads(value: str | None, default: Any) -> Any:
 
 
 def resolve_resource_access_context(user_context: Any = None):
-    """Resolve a request context while preserving local service behavior.
-
-    Domain services are also called from the local CLI and background workers,
-    where there is no HTTP request to inspect. Those callers are local by
-    construction. Remote requests always carry an explicit remote context, so
-    they remain subject to the local ACL projection.
-    """
+    """Resolve request ACL context while preserving local service behavior."""
 
     from storage import resource_access_service
 
-    if isinstance(user_context, resource_access_service.ResourceUserContext):
-        return user_context
-    if user_context is not None:
-        return resource_access_service.current_resource_context(user_context, is_remote=True)
-
-    context = resource_access_service.current_resource_context()
-    if context.is_remote or context.is_trusted_local:
-        return context
-    return resource_access_service.ResourceUserContext(is_trusted_local=True)
+    return resource_access_service.resolve_resource_access_context(user_context)
 
 
 def ensure_agent_selection_access(
@@ -150,6 +136,14 @@ def ensure_agent_name_access(agent_name: str | None, *, user_context: Any = None
         store.require_accessible(str(agent_name), user_context=context)
     finally:
         store.close()
+
+
+def _require_agent_create_access(user_context: Any) -> None:
+    if user_context.is_trusted_local or user_context.is_instance_owner:
+        return
+    if user_context.is_remote and user_context.is_active_organization_member and user_context.subject:
+        return
+    raise VibeAgentAccessError("Agent access is not permitted.")
 
 
 @dataclass(frozen=True)
@@ -266,6 +260,28 @@ class VibeAgentStore:
             raise ValueError(f"agent '{agent.name}' is disabled")
         return agent
 
+    def require_manageable(self, name: str, *, user_context: Any = None) -> VibeAgent:
+        """Return an Agent only when the caller may change its resource."""
+
+        from storage import resource_access_service
+
+        context = resolve_resource_access_context(user_context)
+        with self.engine.connect() as conn:
+            row = conn.execute(
+                select(agents).where(agents.c.normalized_name == normalize_agent_name(name)).limit(1)
+            ).mappings().first()
+            if row is None:
+                raise ValueError(f"agent '{name}' not found")
+            agent = self._from_row(row)
+            if not resource_access_service.can_manage_resource_acl(
+                context,
+                "agent",
+                agent.id,
+                connection=conn,
+            ):
+                raise VibeAgentAccessError("Agent access is not permitted.")
+            return agent
+
     def create(
         self,
         *,
@@ -285,6 +301,8 @@ class VibeAgentStore:
 
         normalized = normalize_agent_name(name)
         context = resolve_resource_access_context(user_context)
+        if source != "builtin":
+            _require_agent_create_access(context)
         now = _utc_now_iso()
         agent = VibeAgent(
             id=uuid4().hex[:12],
@@ -387,7 +405,12 @@ class VibeAgentStore:
             "definitions": len(definition_count),
         }
 
-    def import_candidates(self, candidates: Iterable[AgentImportCandidate]) -> AgentImportResult:
+    def import_candidates(
+        self,
+        candidates: Iterable[AgentImportCandidate],
+        *,
+        user_context: Any = None,
+    ) -> AgentImportResult:
         imported: list[VibeAgent] = []
         skipped: list[dict[str, Any]] = []
         for candidate in candidates:
@@ -406,8 +429,11 @@ class VibeAgentStore:
                         source=candidate.source,
                         source_ref=candidate.source_ref,
                         metadata=candidate.metadata,
+                        user_context=user_context,
                     )
                 )
+            except VibeAgentAccessError:
+                raise
             except Exception as exc:
                 skipped.append({"name": candidate.name, "reason": "invalid", "error": str(exc)})
         return AgentImportResult(imported=imported, skipped=skipped)

--- a/core/watches.py
+++ b/core/watches.py
@@ -225,7 +225,11 @@ class ManagedWatchStore:
         session_policy: Optional[str] = None,
         message: Optional[str] = None,
         metadata: Optional[dict[str, Any]] = None,
+        user_context: Any = None,
     ) -> ManagedWatch:
+        from core.vibe_agents import ensure_agent_name_access
+
+        ensure_agent_name_access(agent_name, user_context=user_context)
         watch = ManagedWatch(
             id=uuid4().hex[:12],
             name=name,
@@ -291,7 +295,11 @@ class ManagedWatchStore:
         session_policy: Optional[str] = None,
         message: Optional[str] = None,
         metadata: Optional[dict[str, Any]] = None,
+        user_context: Any = None,
     ) -> ManagedWatch:
+        from core.vibe_agents import ensure_agent_name_access
+
+        ensure_agent_name_access(agent_name, user_context=user_context)
         watch = self._watches[watch_id]
         watch.name = name
         watch.session_key = session_key

--- a/core/watches.py
+++ b/core/watches.py
@@ -228,6 +228,7 @@ class ManagedWatchStore:
         user_context: Any = None,
     ) -> ManagedWatch:
         from core.vibe_agents import ensure_agent_name_access
+        from storage.resource_access_service import metadata_with_resource_user_context
 
         ensure_agent_name_access(agent_name, user_context=user_context)
         watch = ManagedWatch(
@@ -249,7 +250,7 @@ class ManagedWatchStore:
             retry_delay_seconds=retry_delay_seconds,
             post_to=post_to,
             deliver_key=deliver_key,
-            metadata=dict(metadata or {}),
+            metadata=metadata_with_resource_user_context(metadata, user_context),
         )
         return self.upsert_watch(watch)
 
@@ -298,6 +299,7 @@ class ManagedWatchStore:
         user_context: Any = None,
     ) -> ManagedWatch:
         from core.vibe_agents import ensure_agent_name_access
+        from storage.resource_access_service import metadata_with_resource_user_context
 
         ensure_agent_name_access(agent_name, user_context=user_context)
         watch = self._watches[watch_id]
@@ -320,8 +322,10 @@ class ManagedWatchStore:
         watch.retry_delay_seconds = retry_delay_seconds
         watch.post_to = post_to
         watch.deliver_key = deliver_key
-        if metadata is not None:
-            watch.metadata = dict(metadata)
+        watch.metadata = metadata_with_resource_user_context(
+            metadata if metadata is not None else watch.metadata,
+            user_context,
+        )
         watch.updated_at = _utc_now_iso()
         if self._sqlite is not None:
             self._sqlite.upsert_watch(watch.to_dict())

--- a/docs/plans/resource-acl-sync.md
+++ b/docs/plans/resource-acl-sync.md
@@ -1,0 +1,33 @@
+# Resource ACL Sync Foundation
+
+## Background
+
+Organization membership arrives at the local runtime in a signed OIDC ID token,
+while resource content remains local. The runtime therefore needs a local ACL
+projection that can be updated only by versioned control-plane intents.
+
+## Goal
+
+Add the SQLite policy state, signed-session organization context, and paired
+device sync needed by later resource-specific enforcement work. This change
+does not add enforcement to agents, vaults, skills, or Show Pages.
+
+## Design
+
+- Store one policy per `(resource_kind, resource_id)` and group bindings in a
+  separate table with a cascading composite foreign key.
+- Keep OIDC organization claims in the signed local remote-access cookie. A
+  membership-bearing cookie re-enters OIDC at its refresh boundary rather than
+  extending stale group claims indefinitely.
+- Publish safe resource metadata and the currently applied ACL revision over
+  the paired-instance device channel. Pull a newer intent, apply it in one
+  SQLite transaction, then acknowledge that exact revision.
+- Do not mutate an organization policy through a local standalone revision.
+  The hosted organization resource API remains the writer of desired intents.
+
+## Verification
+
+- Unit test private, public, scoped, and missing-group policy evaluation.
+- Unit test newer-only intent application, exact ACK behavior, and offline
+  retention of the prior local policy.
+- Run the repository's unit, static syntax, and lint commands before commit.

--- a/docs/plans/resource-acl-sync.md
+++ b/docs/plans/resource-acl-sync.md
@@ -1,4 +1,4 @@
-# Resource ACL Sync Foundation
+# Organization Resource ACL
 
 ## Background
 
@@ -8,9 +8,10 @@ projection that can be updated only by versioned control-plane intents.
 
 ## Goal
 
-Add the SQLite policy state, signed-session organization context, and paired
-device sync needed by later resource-specific enforcement work. This change
-does not add enforcement to agents, vaults, skills, or Show Pages.
+Keep resource content local while enforcing organization-managed access for
+Agents, Vault secrets, Skills, and Show Pages. The hosted control plane owns
+desired ACL policy; the paired local runtime stores and enforces a transactional
+projection of that policy.
 
 ## Design
 
@@ -24,10 +25,48 @@ does not add enforcement to agents, vaults, skills, or Show Pages.
   SQLite transaction, then acknowledge that exact revision.
 - Do not mutate an organization policy through a local standalone revision.
   The hosted organization resource API remains the writer of desired intents.
+- Treat a missing policy as local-private. Trusted local callers and the signed
+  instance owner retain access to legacy resources; other remote callers fail
+  closed.
+- Register resources created by an active organization member as private and
+  owned by that member. External instance guests cannot create organization
+  resources.
+
+## Authorization model
+
+- `private`: only the resource owner can use the resource.
+- `public`: any active member of the resource's organization can use it.
+- `scope`: active organization members can use it when at least one signed
+  group claim matches a policy group binding.
+- Resource owners and organization owners/admins can manage an existing
+  resource. Public or scoped use does not imply management access.
+- Trusted local requests bypass organization ACLs. Remote identity, instance
+  role, organization membership, and group claims must come from the validated
+  OIDC exchange and signed local session cookie.
+
+## Enforcement
+
+- Agents: filter listing and lookup, gate use, and require management access
+  for update/removal.
+- Vault secrets: filter metadata, gate secret use and request creation, and
+  require management access for metadata, rotation, pin, and deletion changes.
+- Skills: filter backend-specific global/project resources, gate updates and
+  removals, and register remotely created Skills.
+- Show Pages: filter listing and lookup, gate session access, and require
+  management access for visibility, share, icon, and archive mutations. Public
+  share URLs remain governed by Show Page visibility rather than organization
+  ACL.
+
+Instance-wide endpoint roles and project ownership are separate authorization
+layers. They are intentionally not derived from organization resource ACL and
+are tracked in avibe-bot/avibe#981 and avibe-bot/avibe#982.
 
 ## Verification
 
 - Unit test private, public, scoped, and missing-group policy evaluation.
 - Unit test newer-only intent application, exact ACK behavior, and offline
   retention of the prior local policy.
+- Unit test list filtering, use checks, management checks, private policy
+  registration, and fail-closed request context resolution for every resource
+  kind.
 - Run the repository's unit, static syntax, and lint commands before commit.

--- a/storage/alembic/versions/20260725_0035_resource_access_policies.py
+++ b/storage/alembic/versions/20260725_0035_resource_access_policies.py
@@ -1,0 +1,97 @@
+"""add local resource access policies
+
+Revision ID: 20260725_0035
+Revises: 20260724_0034
+Create Date: 2026-07-25
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision = "20260725_0035"
+down_revision = "20260724_0034"
+branch_labels = None
+depends_on = None
+
+
+def _table_exists(name: str) -> bool:
+    bind = op.get_bind()
+    return bind.exec_driver_sql(
+        "select 1 from sqlite_master where type = 'table' and name = ?",
+        (name,),
+    ).first() is not None
+
+
+def upgrade() -> None:
+    if not _table_exists("resource_access_policies"):
+        op.create_table(
+            "resource_access_policies",
+            sa.Column("resource_kind", sa.String(), nullable=False),
+            sa.Column("resource_id", sa.String(), nullable=False),
+            sa.Column("organization_id", sa.String(), nullable=True),
+            sa.Column("owner_user_id", sa.String(), nullable=True),
+            sa.Column("owner_email", sa.String(), nullable=True),
+            sa.Column("access_level", sa.String(), nullable=False, server_default="private"),
+            sa.Column("created_by_user_id", sa.String(), nullable=True),
+            sa.Column("updated_by_user_id", sa.String(), nullable=True),
+            sa.Column("policy_revision", sa.Integer(), nullable=False, server_default="0"),
+            sa.Column("last_applied_control_plane_revision", sa.Integer(), nullable=True),
+            sa.Column("created_at", sa.String(), nullable=False),
+            sa.Column("updated_at", sa.String(), nullable=False),
+            sa.CheckConstraint(
+                "resource_kind in ('agent', 'vault_secret', 'skill', 'show_page')",
+                name="ck_resource_access_policies_kind",
+            ),
+            sa.CheckConstraint(
+                "access_level in ('public', 'scope', 'private')",
+                name="ck_resource_access_policies_access_level",
+            ),
+            sa.PrimaryKeyConstraint("resource_kind", "resource_id"),
+        )
+    op.create_index(
+        "ix_resource_access_policies_org_level",
+        "resource_access_policies",
+        ["organization_id", "access_level", "resource_kind"],
+        if_not_exists=True,
+    )
+    op.create_index(
+        "ix_resource_access_policies_owner",
+        "resource_access_policies",
+        ["owner_user_id", "resource_kind"],
+        if_not_exists=True,
+    )
+
+    if not _table_exists("resource_access_groups"):
+        op.create_table(
+            "resource_access_groups",
+            sa.Column("resource_kind", sa.String(), nullable=False),
+            sa.Column("resource_id", sa.String(), nullable=False),
+            sa.Column("group_id", sa.String(), nullable=False),
+            sa.Column("organization_id", sa.String(), nullable=False),
+            sa.Column("created_at", sa.String(), nullable=False),
+            sa.ForeignKeyConstraint(
+                ["resource_kind", "resource_id"],
+                ["resource_access_policies.resource_kind", "resource_access_policies.resource_id"],
+                ondelete="CASCADE",
+            ),
+            sa.PrimaryKeyConstraint("resource_kind", "resource_id", "group_id"),
+        )
+    op.create_index(
+        "ix_resource_access_groups_group",
+        "resource_access_groups",
+        ["organization_id", "group_id", "resource_kind"],
+        if_not_exists=True,
+    )
+
+
+def downgrade() -> None:
+    if _table_exists("resource_access_groups"):
+        op.drop_index("ix_resource_access_groups_group", table_name="resource_access_groups", if_exists=True)
+        op.drop_table("resource_access_groups")
+    op.drop_index("ix_resource_access_policies_owner", table_name="resource_access_policies", if_exists=True)
+    op.drop_index("ix_resource_access_policies_org_level", table_name="resource_access_policies", if_exists=True)
+    if _table_exists("resource_access_policies"):
+        op.drop_table("resource_access_policies")

--- a/storage/migrations.py
+++ b/storage/migrations.py
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 _MIGRATION_LOCK = threading.RLock()
 
 INITIAL_REVISION = "20260501_0001"
-LATEST_SCHEMA_REVISION = "20260622_0023"
+LATEST_SCHEMA_REVISION = "20260725_0035"
 REMOVE_LEGACY_DEFAULT_AGENT_REVISION = "20260530_0008"
 ALLOW_DEV_STATE_MIGRATION_ENV = "AVIBE_ALLOW_DEV_STATE_MIGRATION"
 INITIAL_TABLES = {
@@ -58,6 +58,8 @@ HEAD_TABLES = INITIAL_TABLES | {
     "vault_audit",
     "vault_auth_factors",
     "vault_operation_challenges",
+    "resource_access_policies",
+    "resource_access_groups",
 }
 PRE_SHOW_SESSION_EVENTS_HEAD_TABLES = INITIAL_TABLES | {
     "run_definitions",
@@ -110,6 +112,17 @@ HEAD_ONLY_REQUIRED_COLUMNS = {
     "vault_grants": {"agent_ready", "agent_ready_at"},
     "vault_auth_factors": {"credential_id", "public_key", "alg", "sign_count"},
     "vault_operation_challenges": {"challenge_hash", "rp_id", "origin", "expires_at", "consumed_at"},
+    "resource_access_policies": {
+        "organization_id",
+        "owner_user_id",
+        "owner_email",
+        "access_level",
+        "policy_revision",
+        "last_applied_control_plane_revision",
+        "created_by_user_id",
+        "updated_by_user_id",
+    },
+    "resource_access_groups": {"organization_id", "group_id"},
 }
 UNRELEASED_OLD_INITIAL_TABLES = [
     "session_messages",
@@ -714,6 +727,23 @@ def _ensure_vault_authz_indexes(conn: sqlite3.Connection, tables: set[str]) -> N
         )
 
 
+def _ensure_resource_access_indexes(conn: sqlite3.Connection, tables: set[str]) -> None:
+    if "resource_access_policies" in tables:
+        conn.execute(
+            "create index if not exists ix_resource_access_policies_org_level "
+            "on resource_access_policies (organization_id, access_level, resource_kind)"
+        )
+        conn.execute(
+            "create index if not exists ix_resource_access_policies_owner "
+            "on resource_access_policies (owner_user_id, resource_kind)"
+        )
+    if "resource_access_groups" in tables:
+        conn.execute(
+            "create index if not exists ix_resource_access_groups_group "
+            "on resource_access_groups (organization_id, group_id, resource_kind)"
+        )
+
+
 def _delete_historical_message_tool_calls(conn: sqlite3.Connection, tables: set[str]) -> None:
     if "messages" not in tables:
         return
@@ -742,6 +772,7 @@ def _ensure_head_indexes(conn: sqlite3.Connection, tables: set[str]) -> None:
     _ensure_messages_query_indexes(conn, tables)
     _ensure_agent_events_indexes(conn, tables)
     _ensure_vault_authz_indexes(conn, tables)
+    _ensure_resource_access_indexes(conn, tables)
 
 
 def _missing_head_schema_description(conn: sqlite3.Connection, tables: set[str]) -> str:

--- a/storage/models.py
+++ b/storage/models.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 from sqlalchemy import (
+    CheckConstraint,
     Column,
     DDL,
     Float,
     ForeignKey,
+    ForeignKeyConstraint,
     Index,
     Integer,
     MetaData,
@@ -474,6 +476,57 @@ web_push_subscriptions = Table(
     UniqueConstraint("endpoint", name="uq_web_push_subscriptions_endpoint"),
     Index("ix_web_push_subscriptions_user_enabled", "user_key", "enabled"),
     Index("ix_web_push_subscriptions_user_device", "user_key", "device_id"),
+)
+
+# Resource ACLs are local enforcement state. The hosted control plane receives
+# only safe metadata and desired revisions; it never stores local resource
+# content or secret values.
+resource_access_policies = Table(
+    "resource_access_policies",
+    metadata,
+    Column("resource_kind", String, primary_key=True),
+    Column("resource_id", String, primary_key=True),
+    Column("organization_id", String, nullable=True),
+    Column("owner_user_id", String, nullable=True),
+    Column("owner_email", String, nullable=True),
+    Column("access_level", String, nullable=False, server_default=text("'private'")),
+    Column("created_by_user_id", String, nullable=True),
+    Column("updated_by_user_id", String, nullable=True),
+    Column("policy_revision", Integer, nullable=False, server_default=text("0")),
+    Column("last_applied_control_plane_revision", Integer, nullable=True),
+    Column("created_at", String, nullable=False),
+    Column("updated_at", String, nullable=False),
+    CheckConstraint(
+        "resource_kind in ('agent', 'vault_secret', 'skill', 'show_page')",
+        name="ck_resource_access_policies_kind",
+    ),
+    CheckConstraint(
+        "access_level in ('public', 'scope', 'private')",
+        name="ck_resource_access_policies_access_level",
+    ),
+    Index(
+        "ix_resource_access_policies_org_level",
+        "organization_id",
+        "access_level",
+        "resource_kind",
+    ),
+    Index("ix_resource_access_policies_owner", "owner_user_id", "resource_kind"),
+)
+
+resource_access_groups = Table(
+    "resource_access_groups",
+    metadata,
+    Column("resource_kind", String, primary_key=True),
+    Column("resource_id", String, primary_key=True),
+    Column("group_id", String, primary_key=True),
+    Column("organization_id", String, nullable=False),
+    Column("created_at", String, nullable=False),
+    ForeignKeyConstraint(
+        ["resource_kind", "resource_id"],
+        ["resource_access_policies.resource_kind", "resource_access_policies.resource_id"],
+        ondelete="CASCADE",
+    ),
+    Index("ix_resource_access_groups_group", "organization_id", "group_id", "resource_kind"),
 )
 
 # Vaults — secret management for agents.

--- a/storage/resource_access_service.py
+++ b/storage/resource_access_service.py
@@ -1,0 +1,609 @@
+"""Local organization resource-policy state and evaluation helpers.
+
+The control plane owns desired ACL intents. This module owns the local applied
+policy used by future resource services, and deliberately stores no resource
+content, prompts, paths, outputs, or secret values.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Iterator
+
+from sqlalchemy import select
+from sqlalchemy.engine import Connection
+
+from storage.db import get_cached_sqlite_engine
+from storage.models import resource_access_groups, resource_access_policies
+
+
+RESOURCE_KINDS = frozenset({"agent", "vault_secret", "skill", "show_page"})
+ACCESS_LEVELS = frozenset({"public", "scope", "private"})
+ORGANIZATION_ROLES = frozenset({"owner", "admin", "member"})
+
+
+class ResourceAccessError(ValueError):
+    """A stable, non-sensitive policy or intent validation error."""
+
+    def __init__(self, code: str):
+        super().__init__(code)
+        self.code = code
+
+
+@dataclass(frozen=True)
+class ResourceUserContext:
+    subject: str | None = None
+    email: str | None = None
+    organization_id: str | None = None
+    organization_member_id: str | None = None
+    organization_role: str | None = None
+    group_ids: frozenset[str] | None = None
+    membership_version: str | None = None
+    instance_access_source: str | None = None
+    is_remote: bool = False
+    is_trusted_local: bool = False
+
+    @property
+    def is_active_organization_member(self) -> bool:
+        return bool(
+            self.organization_id
+            and self.organization_member_id
+            and self.organization_role in ORGANIZATION_ROLES
+        )
+
+    @property
+    def is_instance_owner(self) -> bool:
+        return self.instance_access_source == "owner" and bool(self.subject)
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _clean_optional_string(value: Any, *, limit: int = 200) -> str | None:
+    if not isinstance(value, str):
+        return None
+    cleaned = value.strip()
+    if not cleaned or len(cleaned) > limit or any(ord(char) < 32 or ord(char) == 127 for char in cleaned):
+        return None
+    return cleaned
+
+
+def _required_identifier(value: Any, *, code: str) -> str:
+    cleaned = _clean_optional_string(value)
+    if cleaned is None:
+        raise ResourceAccessError(code)
+    return cleaned
+
+
+def _validate_resource_kind(resource_kind: Any) -> str:
+    if resource_kind not in RESOURCE_KINDS:
+        raise ResourceAccessError("invalid_resource_kind")
+    return str(resource_kind)
+
+
+def _validate_access_level(access_level: Any) -> str:
+    if access_level not in ACCESS_LEVELS:
+        raise ResourceAccessError("invalid_resource_acl_intent")
+    return str(access_level)
+
+
+def _normalize_group_ids(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if not isinstance(value, (list, tuple, set, frozenset)):
+        raise ResourceAccessError("invalid_resource_acl_intent")
+    result: list[str] = []
+    seen: set[str] = set()
+    for item in value:
+        group_id = _clean_optional_string(item)
+        if group_id is None:
+            raise ResourceAccessError("invalid_resource_acl_intent")
+        if group_id not in seen:
+            seen.add(group_id)
+            result.append(group_id)
+    return result
+
+
+def _validate_policy_values(access_level: Any, group_ids: Any, organization_id: str | None) -> tuple[str, list[str]]:
+    normalized_level = _validate_access_level(access_level)
+    normalized_groups = _normalize_group_ids(group_ids)
+    if normalized_level == "scope":
+        if not organization_id or not normalized_groups:
+            raise ResourceAccessError("invalid_resource_acl_intent")
+    elif normalized_groups:
+        raise ResourceAccessError("invalid_resource_acl_intent")
+    return normalized_level, normalized_groups
+
+
+def normalize_policy_request(
+    access_level: Any,
+    group_ids: Any,
+    organization_id: str | None,
+) -> tuple[str, list[str]]:
+    """Validate one policy request and normalize ignored non-scope groups."""
+
+    if access_level in {"private", "public"}:
+        group_ids = []
+    return _validate_policy_values(access_level, group_ids, _clean_optional_string(organization_id))
+
+
+def _context_from_mapping(
+    payload: Mapping[str, Any] | None,
+    *,
+    is_remote: bool,
+    is_trusted_local: bool,
+) -> ResourceUserContext:
+    data = payload or {}
+    organization_id = _clean_optional_string(data.get("vibe_organization_id", data.get("organization_id")))
+    raw_groups = data.get("vibe_group_ids", data.get("group_ids"))
+    group_ids: frozenset[str] | None = None
+    if organization_id and isinstance(raw_groups, (list, tuple, set, frozenset)):
+        cleaned_groups = [_clean_optional_string(value) for value in raw_groups]
+        if all(value is not None for value in cleaned_groups):
+            group_ids = frozenset(value for value in cleaned_groups if value is not None)
+    role = _clean_optional_string(data.get("vibe_organization_role", data.get("organization_role")))
+    if role not in ORGANIZATION_ROLES:
+        role = None
+    return ResourceUserContext(
+        subject=_clean_optional_string(data.get("sub")),
+        email=_clean_optional_string(data.get("email"), limit=320),
+        organization_id=organization_id,
+        organization_member_id=_clean_optional_string(
+            data.get("vibe_organization_member_id", data.get("organization_member_id"))
+        ),
+        organization_role=role,
+        group_ids=group_ids,
+        membership_version=_clean_optional_string(
+            data.get("vibe_membership_version", data.get("membership_version"))
+        ),
+        instance_access_source=_clean_optional_string(
+            data.get("vibe_instance_access_source", data.get("instance_access_source"))
+        ),
+        is_remote=is_remote,
+        is_trusted_local=is_trusted_local,
+    )
+
+
+def current_resource_context(
+    session_payload: Mapping[str, Any] | None = None,
+    *,
+    is_remote: bool | None = None,
+    is_trusted_local: bool | None = None,
+) -> ResourceUserContext:
+    """Return the request's local resource-access context.
+
+    Callers that already parsed the signed session should pass it explicitly.
+    The no-argument form is intentionally best-effort for future service-layer
+    callers running inside the UI request context; outside a request it returns
+    an untrusted anonymous context rather than guessing at an identity.
+    """
+
+    if session_payload is not None or is_remote is not None or is_trusted_local is not None:
+        return _context_from_mapping(
+            session_payload,
+            is_remote=bool(is_remote if is_remote is not None else session_payload is not None),
+            is_trusted_local=bool(is_trusted_local),
+        )
+
+    try:
+        from vibe import remote_access, ui_server
+
+        config = ui_server._load_remote_access_config()
+        remote_request = bool(
+            config is not None
+            and ui_server._is_remote_access_request(config)
+            and not ui_server._is_local_request(config)
+        )
+        if remote_request and config is not None:
+            payload = remote_access.parse_session_cookie(
+                config,
+                ui_server.request.cookies.get(remote_access.SESSION_COOKIE_NAME),
+            )
+            return _context_from_mapping(payload, is_remote=True, is_trusted_local=False)
+        return _context_from_mapping(
+            None,
+            is_remote=False,
+            is_trusted_local=bool(ui_server._is_local_request(config)),
+        )
+    except Exception:
+        return ResourceUserContext()
+
+
+def _as_context(user_context: ResourceUserContext | Mapping[str, Any] | None) -> ResourceUserContext:
+    if isinstance(user_context, ResourceUserContext):
+        return user_context
+    if isinstance(user_context, Mapping):
+        return _context_from_mapping(user_context, is_remote=True, is_trusted_local=False)
+    return ResourceUserContext()
+
+
+@contextmanager
+def _connection(connection: Connection | None) -> Iterator[Connection]:
+    if connection is not None:
+        yield connection
+        return
+    engine = get_cached_sqlite_engine()
+    with engine.connect() as active_connection:
+        yield active_connection
+
+
+def _policy_row(connection: Connection, resource_kind: str, resource_id: str) -> dict[str, Any] | None:
+    row = connection.execute(
+        select(resource_access_policies)
+        .where(resource_access_policies.c.resource_kind == resource_kind)
+        .where(resource_access_policies.c.resource_id == resource_id)
+        .limit(1)
+    ).mappings().first()
+    return dict(row) if row else None
+
+
+def _policy_groups(connection: Connection, resource_kind: str, resource_id: str) -> list[str]:
+    return [
+        str(row["group_id"])
+        for row in connection.execute(
+            select(resource_access_groups.c.group_id)
+            .where(resource_access_groups.c.resource_kind == resource_kind)
+            .where(resource_access_groups.c.resource_id == resource_id)
+            .order_by(resource_access_groups.c.group_id)
+        ).mappings()
+    ]
+
+
+def _serialize_policy(connection: Connection, policy: Mapping[str, Any]) -> dict[str, Any]:
+    data = dict(policy)
+    data["group_ids"] = _policy_groups(connection, str(data["resource_kind"]), str(data["resource_id"]))
+    return data
+
+
+def get_resource_policy(
+    resource_kind: str,
+    resource_id: str,
+    *,
+    connection: Connection | None = None,
+) -> dict[str, Any] | None:
+    kind = _validate_resource_kind(resource_kind)
+    identifier = _required_identifier(resource_id, code="invalid_resource_id")
+    with _connection(connection) as conn:
+        policy = _policy_row(conn, kind, identifier)
+        return _serialize_policy(conn, policy) if policy else None
+
+
+def list_resource_policies(
+    *,
+    resource_kind: str | None = None,
+    organization_id: str | None = None,
+    owner_user_id: str | None = None,
+    connection: Connection | None = None,
+) -> list[dict[str, Any]]:
+    kind = _validate_resource_kind(resource_kind) if resource_kind is not None else None
+    organization = _clean_optional_string(organization_id) if organization_id is not None else None
+    owner = _clean_optional_string(owner_user_id) if owner_user_id is not None else None
+    statement = select(resource_access_policies).order_by(
+        resource_access_policies.c.resource_kind,
+        resource_access_policies.c.resource_id,
+    )
+    if kind is not None:
+        statement = statement.where(resource_access_policies.c.resource_kind == kind)
+    if organization is not None:
+        statement = statement.where(resource_access_policies.c.organization_id == organization)
+    if owner is not None:
+        statement = statement.where(resource_access_policies.c.owner_user_id == owner)
+    with _connection(connection) as conn:
+        return [_serialize_policy(conn, row) for row in conn.execute(statement).mappings()]
+
+
+def ensure_resource_policy(
+    connection: Connection,
+    *,
+    resource_kind: str,
+    resource_id: str,
+    organization_id: str | None,
+    owner_user_id: str | None,
+    owner_email: str | None = None,
+    access_level: str = "private",
+    group_ids: Sequence[str] | None = None,
+    created_by_user_id: str | None = None,
+    updated_by_user_id: str | None = None,
+    policy_revision: int = 0,
+    last_applied_control_plane_revision: int | None = None,
+) -> dict[str, Any]:
+    """Create a resource policy if it does not already exist.
+
+    Resource-specific services should use this at creation time. It never
+    overwrites an existing policy, which prevents a late resource registration
+    from replacing a control-plane intent already applied locally.
+    """
+
+    kind = _validate_resource_kind(resource_kind)
+    identifier = _required_identifier(resource_id, code="invalid_resource_id")
+    organization = _clean_optional_string(organization_id)
+    owner = _clean_optional_string(owner_user_id)
+    normalized_level, normalized_groups = _validate_policy_values(access_level, group_ids, organization)
+    if policy_revision < 0 or last_applied_control_plane_revision is not None and last_applied_control_plane_revision < 0:
+        raise ResourceAccessError("invalid_resource_acl_intent")
+    existing = _policy_row(connection, kind, identifier)
+    if existing:
+        return _serialize_policy(connection, existing)
+    now = _utc_now_iso()
+    connection.execute(
+        resource_access_policies.insert().values(
+            resource_kind=kind,
+            resource_id=identifier,
+            organization_id=organization,
+            owner_user_id=owner,
+            owner_email=_clean_optional_string(owner_email, limit=320),
+            access_level=normalized_level,
+            created_by_user_id=_clean_optional_string(created_by_user_id),
+            updated_by_user_id=_clean_optional_string(updated_by_user_id),
+            policy_revision=policy_revision,
+            last_applied_control_plane_revision=last_applied_control_plane_revision,
+            created_at=now,
+            updated_at=now,
+        )
+    )
+    _replace_policy_groups(connection, kind, identifier, organization, normalized_groups, now)
+    policy = _policy_row(connection, kind, identifier)
+    assert policy is not None
+    return _serialize_policy(connection, policy)
+
+
+def _replace_policy_groups(
+    connection: Connection,
+    resource_kind: str,
+    resource_id: str,
+    organization_id: str | None,
+    group_ids: Sequence[str],
+    now: str,
+) -> None:
+    connection.execute(
+        resource_access_groups.delete()
+        .where(resource_access_groups.c.resource_kind == resource_kind)
+        .where(resource_access_groups.c.resource_id == resource_id)
+    )
+    if not group_ids:
+        return
+    if organization_id is None:
+        raise ResourceAccessError("invalid_resource_acl_intent")
+    connection.execute(
+        resource_access_groups.insert(),
+        [
+            {
+                "resource_kind": resource_kind,
+                "resource_id": resource_id,
+                "group_id": group_id,
+                "organization_id": organization_id,
+                "created_at": now,
+            }
+            for group_id in group_ids
+        ],
+    )
+
+
+def _policy_allows(context: ResourceUserContext, policy: Mapping[str, Any] | None, group_ids: Sequence[str]) -> bool:
+    if context.is_trusted_local:
+        return True
+    if policy is None:
+        # A legacy no-policy resource is local-private. The paired instance's
+        # owner retains legacy access, while remote organization members do not.
+        return context.is_instance_owner
+
+    owner_user_id = _clean_optional_string(policy.get("owner_user_id"))
+    if policy.get("access_level") == "private":
+        return bool(owner_user_id and context.subject and owner_user_id == context.subject)
+
+    organization_id = _clean_optional_string(policy.get("organization_id"))
+    if not organization_id or context.organization_id != organization_id or not context.is_active_organization_member:
+        return False
+    if policy.get("access_level") == "public":
+        return True
+    if policy.get("access_level") == "scope":
+        # Missing and empty are intentionally distinct: a missing group claim
+        # must fail closed, and an active member with no matching group also
+        # cannot use a scoped resource.
+        return bool(context.group_ids and set(group_ids).intersection(context.group_ids))
+    return False
+
+
+def can_use_resource(
+    user_context: ResourceUserContext | Mapping[str, Any] | None,
+    resource_kind: str,
+    resource_id: str,
+    *,
+    connection: Connection | None = None,
+) -> bool:
+    context = _as_context(user_context)
+    kind = _validate_resource_kind(resource_kind)
+    identifier = _required_identifier(resource_id, code="invalid_resource_id")
+    with _connection(connection) as conn:
+        policy = _policy_row(conn, kind, identifier)
+        groups = _policy_groups(conn, kind, identifier) if policy else []
+        return _policy_allows(context, policy, groups)
+
+
+def can_manage_resource_acl(
+    user_context: ResourceUserContext | Mapping[str, Any] | None,
+    resource_kind: str,
+    resource_id: str,
+    *,
+    connection: Connection | None = None,
+) -> bool:
+    context = _as_context(user_context)
+    kind = _validate_resource_kind(resource_kind)
+    identifier = _required_identifier(resource_id, code="invalid_resource_id")
+    if context.is_trusted_local:
+        return True
+    with _connection(connection) as conn:
+        policy = _policy_row(conn, kind, identifier)
+    if policy is None:
+        return context.is_instance_owner
+    owner_user_id = _clean_optional_string(policy.get("owner_user_id"))
+    if owner_user_id and context.subject and owner_user_id == context.subject:
+        return True
+    return bool(
+        context.is_active_organization_member
+        and context.organization_id == _clean_optional_string(policy.get("organization_id"))
+        and context.organization_role in {"owner", "admin"}
+    )
+
+
+def _row_resource_id(row: Any) -> str | None:
+    keys = ("resource_id", "id", "session_id", "name", "key")
+    if isinstance(row, Mapping):
+        for key in keys:
+            value = _clean_optional_string(row.get(key))
+            if value is not None:
+                return value
+        return None
+    for key in keys:
+        value = _clean_optional_string(getattr(row, key, None))
+        if value is not None:
+            return value
+    return None
+
+
+def filter_accessible_resources(
+    user_context: ResourceUserContext | Mapping[str, Any] | None,
+    resource_kind: str,
+    rows: Sequence[Any],
+    *,
+    connection: Connection | None = None,
+) -> list[Any]:
+    """Filter generic resource rows without coupling to any resource domain.
+
+    Rows may be mappings or objects and should expose one of `resource_id`,
+    `id`, `session_id`, `name`, or `key`. Unknown rows are excluded rather than
+    accidentally exposed.
+    """
+
+    context = _as_context(user_context)
+    kind = _validate_resource_kind(resource_kind)
+    candidates = [(row, _row_resource_id(row)) for row in rows]
+    identifiers = [identifier for _, identifier in candidates if identifier is not None]
+    if not identifiers:
+        return []
+    with _connection(connection) as conn:
+        policy_rows = conn.execute(
+            select(resource_access_policies)
+            .where(resource_access_policies.c.resource_kind == kind)
+            .where(resource_access_policies.c.resource_id.in_(identifiers))
+        ).mappings()
+        policies = {str(row["resource_id"]): dict(row) for row in policy_rows}
+        groups = {
+            identifier: _policy_groups(conn, kind, identifier)
+            for identifier in policies
+        }
+    return [
+        row
+        for row, identifier in candidates
+        if identifier is not None and _policy_allows(context, policies.get(identifier), groups.get(identifier, []))
+    ]
+
+
+def apply_control_plane_intent(
+    connection: Connection,
+    *,
+    organization_id: str,
+    resource_kind: str,
+    resource_id: str,
+    revision: int,
+    access_level: str,
+    group_ids: Sequence[str],
+    updated_by_user_id: str = "control_plane",
+) -> dict[str, Any]:
+    """Atomically apply a newer hosted ACL intent to one local policy.
+
+    The caller owns the surrounding transaction. A stale or already-applied
+    revision never rewrites the current policy, which makes retrying a device
+    poll safe.
+    """
+
+    organization = _required_identifier(organization_id, code="invalid_organization_id")
+    kind = _validate_resource_kind(resource_kind)
+    identifier = _required_identifier(resource_id, code="invalid_resource_id")
+    if not isinstance(revision, int) or isinstance(revision, bool) or revision < 0:
+        raise ResourceAccessError("invalid_resource_acl_intent")
+    normalized_level, normalized_groups = _validate_policy_values(access_level, group_ids, organization)
+    policy = _policy_row(connection, kind, identifier)
+    if policy is None:
+        raise ResourceAccessError("resource_not_found")
+    if _clean_optional_string(policy.get("organization_id")) != organization:
+        raise ResourceAccessError("resource_organization_mismatch")
+
+    last_applied = policy.get("last_applied_control_plane_revision")
+    last_revision = int(last_applied) if isinstance(last_applied, int) else -1
+    policy_revision = int(policy.get("policy_revision") or 0)
+    if revision < last_revision or revision < policy_revision:
+        return {"status": "stale", "policy": _serialize_policy(connection, policy)}
+    if revision == last_revision:
+        return {"status": "already_applied", "policy": _serialize_policy(connection, policy)}
+
+    if normalized_groups:
+        conflicting_group = connection.execute(
+            select(resource_access_groups.c.group_id)
+            .where(resource_access_groups.c.group_id.in_(normalized_groups))
+            .where(resource_access_groups.c.organization_id != organization)
+            .limit(1)
+        ).first()
+        if conflicting_group is not None:
+            raise ResourceAccessError("resource_group_organization_mismatch")
+
+    now = _utc_now_iso()
+    connection.execute(
+        resource_access_policies.update()
+        .where(resource_access_policies.c.resource_kind == kind)
+        .where(resource_access_policies.c.resource_id == identifier)
+        .values(
+            access_level=normalized_level,
+            policy_revision=revision,
+            last_applied_control_plane_revision=revision,
+            updated_by_user_id=_clean_optional_string(updated_by_user_id) or "control_plane",
+            updated_at=now,
+        )
+    )
+    _replace_policy_groups(connection, kind, identifier, organization, normalized_groups, now)
+    updated = _policy_row(connection, kind, identifier)
+    assert updated is not None
+    return {"status": "applied", "policy": _serialize_policy(connection, updated)}
+
+
+def update_local_non_organization_policy(
+    connection: Connection,
+    *,
+    resource_kind: str,
+    resource_id: str,
+    access_level: str,
+    group_ids: Sequence[str] | None,
+    updated_by_user_id: str | None,
+) -> dict[str, Any]:
+    """Update a personal/local policy without touching control-plane revisions."""
+
+    kind = _validate_resource_kind(resource_kind)
+    identifier = _required_identifier(resource_id, code="invalid_resource_id")
+    policy = _policy_row(connection, kind, identifier)
+    if policy is None:
+        raise ResourceAccessError("resource_not_found")
+    organization = _clean_optional_string(policy.get("organization_id"))
+    if organization is not None:
+        raise ResourceAccessError("resource_acl_control_plane_required")
+    normalized_level, normalized_groups = _validate_policy_values(access_level, group_ids, None)
+    now = _utc_now_iso()
+    next_revision = int(policy.get("policy_revision") or 0) + 1
+    connection.execute(
+        resource_access_policies.update()
+        .where(resource_access_policies.c.resource_kind == kind)
+        .where(resource_access_policies.c.resource_id == identifier)
+        .values(
+            access_level=normalized_level,
+            policy_revision=next_revision,
+            updated_by_user_id=_clean_optional_string(updated_by_user_id),
+            updated_at=now,
+        )
+    )
+    _replace_policy_groups(connection, kind, identifier, None, normalized_groups, now)
+    updated = _policy_row(connection, kind, identifier)
+    assert updated is not None
+    return _serialize_policy(connection, updated)

--- a/storage/resource_access_service.py
+++ b/storage/resource_access_service.py
@@ -111,6 +111,11 @@ def _normalize_group_ids(value: Any) -> list[str]:
 def _validate_policy_values(access_level: Any, group_ids: Any, organization_id: str | None) -> tuple[str, list[str]]:
     normalized_level = _validate_access_level(access_level)
     normalized_groups = _normalize_group_ids(group_ids)
+    if normalized_level in {"public", "scope"} and not organization_id:
+        # Public and scoped policies are organization semantics. A personal
+        # resource stays private rather than accepting a policy no context can
+        # safely authorize.
+        raise ResourceAccessError("invalid_resource_acl_intent")
     if normalized_level == "scope":
         if not organization_id or not normalized_groups:
             raise ResourceAccessError("invalid_resource_acl_intent")

--- a/storage/resource_access_service.py
+++ b/storage/resource_access_service.py
@@ -23,6 +23,7 @@ from storage.models import resource_access_groups, resource_access_policies
 RESOURCE_KINDS = frozenset({"agent", "vault_secret", "skill", "show_page"})
 ACCESS_LEVELS = frozenset({"public", "scope", "private"})
 ORGANIZATION_ROLES = frozenset({"owner", "admin", "member"})
+RESOURCE_USER_CONTEXT_METADATA_KEY = "resource_user_context"
 
 
 class ResourceAccessError(ValueError):
@@ -239,6 +240,44 @@ def resolve_resource_access_context(
     if has_request_context():
         return context
     return ResourceUserContext(is_trusted_local=True)
+
+
+def metadata_with_resource_user_context(
+    metadata: Mapping[str, Any] | None,
+    user_context: ResourceUserContext | Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Store the minimum remote identity needed to recheck deferred work."""
+
+    result = dict(metadata or {})
+    result.pop(RESOURCE_USER_CONTEXT_METADATA_KEY, None)
+    context = resolve_resource_access_context(user_context)
+    if not context.is_remote:
+        return result
+
+    result[RESOURCE_USER_CONTEXT_METADATA_KEY] = {
+        "sub": context.subject,
+        "vibe_organization_id": context.organization_id,
+        "vibe_organization_member_id": context.organization_member_id,
+        "vibe_organization_role": context.organization_role,
+        "vibe_group_ids": sorted(context.group_ids) if context.group_ids is not None else None,
+        "vibe_membership_version": context.membership_version,
+        "vibe_instance_role": context.instance_role,
+        "vibe_instance_access_source": context.instance_access_source,
+    }
+    return result
+
+
+def resource_user_context_from_metadata(
+    metadata: Mapping[str, Any] | None,
+) -> ResourceUserContext | None:
+    """Restore a remote definition creator context, or None for local legacy work."""
+
+    if not isinstance(metadata, Mapping):
+        return None
+    snapshot = metadata.get(RESOURCE_USER_CONTEXT_METADATA_KEY)
+    if not isinstance(snapshot, Mapping):
+        return None
+    return current_resource_context(snapshot, is_remote=True, is_trusted_local=False)
 
 
 def _as_context(user_context: ResourceUserContext | Mapping[str, Any] | None) -> ResourceUserContext:

--- a/storage/resource_access_service.py
+++ b/storage/resource_access_service.py
@@ -42,6 +42,7 @@ class ResourceUserContext:
     organization_role: str | None = None
     group_ids: frozenset[str] | None = None
     membership_version: str | None = None
+    instance_role: str | None = None
     instance_access_source: str | None = None
     is_remote: bool = False
     is_trusted_local: bool = False
@@ -56,7 +57,7 @@ class ResourceUserContext:
 
     @property
     def is_instance_owner(self) -> bool:
-        return self.instance_access_source == "owner" and bool(self.subject)
+        return self.instance_role == "owner" and bool(self.subject)
 
 
 def _utc_now_iso() -> str:
@@ -165,6 +166,7 @@ def _context_from_mapping(
         membership_version=_clean_optional_string(
             data.get("vibe_membership_version", data.get("membership_version"))
         ),
+        instance_role=_clean_optional_string(data.get("vibe_instance_role", data.get("instance_role"))),
         instance_access_source=_clean_optional_string(
             data.get("vibe_instance_access_source", data.get("instance_access_source"))
         ),

--- a/storage/resource_access_service.py
+++ b/storage/resource_access_service.py
@@ -593,6 +593,47 @@ def _policy_allows(context: ResourceUserContext, policy: Mapping[str, Any] | Non
     return False
 
 
+def _policy_allows_management(context: ResourceUserContext, policy: Mapping[str, Any] | None) -> bool:
+    if context.is_trusted_local:
+        return True
+    if policy is None:
+        return context.is_instance_owner
+    owner_user_id = _clean_optional_string(policy.get("owner_user_id"))
+    if owner_user_id and context.subject and owner_user_id == context.subject:
+        return True
+    return bool(
+        context.is_active_organization_member
+        and context.organization_id == _clean_optional_string(policy.get("organization_id"))
+        and context.organization_role in {"owner", "admin"}
+    )
+
+
+def can_use_resource_policy_snapshot(
+    user_context: ResourceUserContext | Mapping[str, Any] | None,
+    policy: Mapping[str, Any] | None,
+) -> bool:
+    """Evaluate a server-owned policy snapshot for immutable history."""
+
+    context = _as_context(user_context)
+    if policy is not None and not isinstance(policy, Mapping):
+        return False
+    group_ids = policy.get("group_ids") if policy is not None else []
+    if not isinstance(group_ids, (list, tuple, set, frozenset)):
+        return False
+    return _policy_allows(context, policy, [str(group_id) for group_id in group_ids])
+
+
+def can_manage_resource_policy_snapshot(
+    user_context: ResourceUserContext | Mapping[str, Any] | None,
+    policy: Mapping[str, Any] | None,
+) -> bool:
+    """Evaluate management access from a server-owned policy snapshot."""
+
+    if policy is not None and not isinstance(policy, Mapping):
+        return False
+    return _policy_allows_management(_as_context(user_context), policy)
+
+
 def can_use_resource(
     user_context: ResourceUserContext | Mapping[str, Any] | None,
     resource_kind: str,
@@ -623,16 +664,7 @@ def can_manage_resource_acl(
         return True
     with _connection(connection) as conn:
         policy = _policy_row(conn, kind, identifier)
-    if policy is None:
-        return context.is_instance_owner
-    owner_user_id = _clean_optional_string(policy.get("owner_user_id"))
-    if owner_user_id and context.subject and owner_user_id == context.subject:
-        return True
-    return bool(
-        context.is_active_organization_member
-        and context.organization_id == _clean_optional_string(policy.get("organization_id"))
-        and context.organization_role in {"owner", "admin"}
-    )
+    return _policy_allows_management(context, policy)
 
 
 def _row_resource_id(row: Any) -> str | None:

--- a/storage/resource_access_service.py
+++ b/storage/resource_access_service.py
@@ -379,6 +379,24 @@ def ensure_resource_policy(
     return _serialize_policy(connection, policy)
 
 
+def delete_resource_policy(connection: Connection, resource_kind: str, resource_id: str) -> bool:
+    """Delete local policy state when its local resource is permanently removed."""
+
+    kind = _validate_resource_kind(resource_kind)
+    identifier = _required_identifier(resource_id, code="invalid_resource_id")
+    connection.execute(
+        resource_access_groups.delete()
+        .where(resource_access_groups.c.resource_kind == kind)
+        .where(resource_access_groups.c.resource_id == identifier)
+    )
+    result = connection.execute(
+        resource_access_policies.delete()
+        .where(resource_access_policies.c.resource_kind == kind)
+        .where(resource_access_policies.c.resource_id == identifier)
+    )
+    return bool(result.rowcount)
+
+
 def _replace_policy_groups(
     connection: Connection,
     resource_kind: str,

--- a/storage/resource_access_service.py
+++ b/storage/resource_access_service.py
@@ -220,6 +220,27 @@ def current_resource_context(
         return ResourceUserContext()
 
 
+def resolve_resource_access_context(
+    user_context: ResourceUserContext | Mapping[str, Any] | None = None,
+) -> ResourceUserContext:
+    """Resolve ACL context, trusting implicit local use only outside HTTP."""
+
+    if isinstance(user_context, ResourceUserContext):
+        return user_context
+    if isinstance(user_context, Mapping):
+        return current_resource_context(user_context, is_remote=True)
+
+    context = current_resource_context()
+    if context.is_remote or context.is_trusted_local:
+        return context
+
+    from vibe.ui_compat import has_request_context
+
+    if has_request_context():
+        return context
+    return ResourceUserContext(is_trusted_local=True)
+
+
 def _as_context(user_context: ResourceUserContext | Mapping[str, Any] | None) -> ResourceUserContext:
     if isinstance(user_context, ResourceUserContext):
         return user_context

--- a/storage/resource_access_service.py
+++ b/storage/resource_access_service.py
@@ -578,7 +578,13 @@ def _policy_allows(context: ResourceUserContext, policy: Mapping[str, Any] | Non
 
     owner_user_id = _clean_optional_string(policy.get("owner_user_id"))
     if policy.get("access_level") == "private":
-        return bool(owner_user_id and context.subject and owner_user_id == context.subject)
+        if not (owner_user_id and context.subject and owner_user_id == context.subject):
+            return False
+        organization_id = _clean_optional_string(policy.get("organization_id"))
+        return bool(
+            not organization_id
+            or context.is_active_organization_member and context.organization_id == organization_id
+        )
 
     organization_id = _clean_optional_string(policy.get("organization_id"))
     if not organization_id or context.organization_id != organization_id or not context.is_active_organization_member:
@@ -600,7 +606,11 @@ def _policy_allows_management(context: ResourceUserContext, policy: Mapping[str,
         return context.is_instance_owner
     owner_user_id = _clean_optional_string(policy.get("owner_user_id"))
     if owner_user_id and context.subject and owner_user_id == context.subject:
-        return True
+        organization_id = _clean_optional_string(policy.get("organization_id"))
+        return bool(
+            not organization_id
+            or context.is_active_organization_member and context.organization_id == organization_id
+        )
     return bool(
         context.is_active_organization_member
         and context.organization_id == _clean_optional_string(policy.get("organization_id"))

--- a/storage/resource_access_service.py
+++ b/storage/resource_access_service.py
@@ -7,6 +7,8 @@ content, prompts, paths, outputs, or secret values.
 
 from __future__ import annotations
 
+import json
+import time
 from collections.abc import Mapping, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass
@@ -17,13 +19,14 @@ from sqlalchemy import select
 from sqlalchemy.engine import Connection
 
 from storage.db import get_cached_sqlite_engine
-from storage.models import resource_access_groups, resource_access_policies
+from storage.models import resource_access_groups, resource_access_policies, state_meta
 
 
 RESOURCE_KINDS = frozenset({"agent", "vault_secret", "skill", "show_page"})
 ACCESS_LEVELS = frozenset({"public", "scope", "private"})
 ORGANIZATION_ROLES = frozenset({"owner", "admin", "member"})
 RESOURCE_USER_CONTEXT_METADATA_KEY = "resource_user_context"
+RESOURCE_ORGANIZATIONS_META_KEY = "resource_access_organizations"
 
 
 class ResourceAccessError(ValueError):
@@ -43,6 +46,7 @@ class ResourceUserContext:
     organization_role: str | None = None
     group_ids: frozenset[str] | None = None
     membership_version: str | None = None
+    claims_issued_at: int | None = None
     instance_role: str | None = None
     instance_access_source: str | None = None
     is_remote: bool = False
@@ -72,6 +76,16 @@ def _clean_optional_string(value: Any, *, limit: int = 200) -> str | None:
     if not cleaned or len(cleaned) > limit or any(ord(char) < 32 or ord(char) == 127 for char in cleaned):
         return None
     return cleaned
+
+
+def _clean_positive_int(value: Any) -> int | None:
+    if isinstance(value, bool):
+        return None
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed > 0 else None
 
 
 def _required_identifier(value: Any, *, code: str) -> str:
@@ -167,6 +181,7 @@ def _context_from_mapping(
         membership_version=_clean_optional_string(
             data.get("vibe_membership_version", data.get("membership_version"))
         ),
+        claims_issued_at=_clean_positive_int(data.get("claims_issued_at", data.get("iat"))),
         instance_role=_clean_optional_string(data.get("vibe_instance_role", data.get("instance_role"))),
         instance_access_source=_clean_optional_string(
             data.get("vibe_instance_access_source", data.get("instance_access_source"))
@@ -263,12 +278,22 @@ def metadata_with_resource_user_context(
         "vibe_membership_version": context.membership_version,
         "vibe_instance_role": context.instance_role,
         "vibe_instance_access_source": context.instance_access_source,
+        "authorization_expires_at": _resource_context_expires_at(context),
     }
     return result
 
 
+def _resource_context_expires_at(context: ResourceUserContext) -> int:
+    from vibe.remote_access import SESSION_AUTHORIZATION_REFRESH_SECONDS
+
+    issued_at = context.claims_issued_at or int(time.time())
+    return issued_at + SESSION_AUTHORIZATION_REFRESH_SECONDS
+
+
 def resource_user_context_from_metadata(
     metadata: Mapping[str, Any] | None,
+    *,
+    now: int | None = None,
 ) -> ResourceUserContext | None:
     """Restore a remote definition creator context, or None for local legacy work."""
 
@@ -277,6 +302,9 @@ def resource_user_context_from_metadata(
     snapshot = metadata.get(RESOURCE_USER_CONTEXT_METADATA_KEY)
     if not isinstance(snapshot, Mapping):
         return None
+    expires_at = _clean_positive_int(snapshot.get("authorization_expires_at"))
+    if expires_at is None or expires_at <= (now if now is not None else int(time.time())):
+        raise ResourceAccessError("resource_authorization_expired")
     return current_resource_context(snapshot, is_remote=True, is_trusted_local=False)
 
 
@@ -296,6 +324,73 @@ def _connection(connection: Connection | None) -> Iterator[Connection]:
     engine = get_cached_sqlite_engine()
     with engine.connect() as active_connection:
         yield active_connection
+
+
+def _stored_resource_organizations(connection: Connection) -> set[str]:
+    raw_value = connection.execute(
+        select(state_meta.c.value_json).where(state_meta.c.key == RESOURCE_ORGANIZATIONS_META_KEY)
+    ).scalar_one_or_none()
+    try:
+        values = json.loads(raw_value) if raw_value else []
+    except (TypeError, ValueError):
+        return set()
+    if not isinstance(values, list):
+        return set()
+    return {
+        organization
+        for value in values
+        if (organization := _clean_optional_string(value)) is not None
+    }
+
+
+def _store_resource_organizations(connection: Connection, organizations: set[str]) -> None:
+    connection.execute(state_meta.delete().where(state_meta.c.key == RESOURCE_ORGANIZATIONS_META_KEY))
+    if not organizations:
+        return
+    connection.execute(
+        state_meta.insert().values(
+            key=RESOURCE_ORGANIZATIONS_META_KEY,
+            value_json=json.dumps(sorted(organizations), separators=(",", ":")),
+            updated_at=_utc_now_iso(),
+        )
+    )
+
+
+def remember_resource_organization(connection: Connection, organization_id: str | None) -> None:
+    organization = _clean_optional_string(organization_id)
+    if organization is None:
+        return
+    organizations = _stored_resource_organizations(connection)
+    if organization in organizations:
+        return
+    organizations.add(organization)
+    _store_resource_organizations(connection, organizations)
+
+
+def forget_resource_organization(connection: Connection, organization_id: str) -> None:
+    organization = _required_identifier(organization_id, code="invalid_organization_id")
+    organizations = _stored_resource_organizations(connection)
+    if organization not in organizations:
+        return
+    organizations.remove(organization)
+    _store_resource_organizations(connection, organizations)
+
+
+def list_resource_organization_ids(*, connection: Connection | None = None) -> list[str]:
+    """List current and pending-empty-index organizations for device sync."""
+
+    with _connection(connection) as conn:
+        organizations = _stored_resource_organizations(conn)
+        organizations.update(
+            str(row.organization_id)
+            for row in conn.execute(
+                select(resource_access_policies.c.organization_id)
+                .where(resource_access_policies.c.organization_id.is_not(None))
+                .distinct()
+            )
+            if row.organization_id
+        )
+    return sorted(organizations)
 
 
 def _policy_row(connection: Connection, resource_kind: str, resource_id: str) -> dict[str, Any] | None:
@@ -394,7 +489,9 @@ def ensure_resource_policy(
         raise ResourceAccessError("invalid_resource_acl_intent")
     existing = _policy_row(connection, kind, identifier)
     if existing:
+        remember_resource_organization(connection, existing.get("organization_id"))
         return _serialize_policy(connection, existing)
+    remember_resource_organization(connection, organization)
     now = _utc_now_iso()
     connection.execute(
         resource_access_policies.insert().values(
@@ -423,6 +520,9 @@ def delete_resource_policy(connection: Connection, resource_kind: str, resource_
 
     kind = _validate_resource_kind(resource_kind)
     identifier = _required_identifier(resource_id, code="invalid_resource_id")
+    policy = _policy_row(connection, kind, identifier)
+    if policy is not None:
+        remember_resource_organization(connection, policy.get("organization_id"))
     connection.execute(
         resource_access_groups.delete()
         .where(resource_access_groups.c.resource_kind == kind)

--- a/storage/vault_service.py
+++ b/storage/vault_service.py
@@ -2593,11 +2593,14 @@ def delete_secret(
     cache: VaultGrantRuntimeCache = GRANT_RUNTIME_CACHE,
     user_context: Any = None,
 ) -> None:
+    from storage import resource_access_service
+
     context = resolve_resource_access_context(user_context)
     row = _require_secret_resource_management(conn, _require_row(conn, name), context)
     _expire_pending_requests_for_secret(conn, name, reason="request-expired-envelope-changed")
     _expire_active_grants_for_secret(conn, name, cache=cache, reason="grant-expired-envelope-changed")
     conn.execute(vault_secrets.delete().where(vault_secrets.c.name == name))
+    resource_access_service.delete_resource_policy(conn, "vault_secret", str(row["id"]))
     if row.get("protection") == "protected":
         _disable_webauthn_factors_if_vault_deestablished(conn)
     audit(conn, "deleted", secret_name=name)

--- a/storage/vault_service.py
+++ b/storage/vault_service.py
@@ -1728,6 +1728,45 @@ def require_secret_access(conn: Connection, name: str, *, user_context: Any = No
     return _require_secret_resource_access(conn, _require_row(conn, name), resolve_resource_access_context(user_context))
 
 
+def _require_secret_names_access(
+    conn: Connection,
+    names: list[str],
+    *,
+    user_context: Any = None,
+    management: bool = False,
+) -> None:
+    context = resolve_resource_access_context(user_context)
+    if context.is_trusted_local:
+        return
+    member_names = sorted({str(name) for name in names if str(name)})
+    if not member_names:
+        raise VaultSecretAccessError("Vault secret access is not permitted.")
+    secret_rows = {
+        str(row["name"]): dict(row)
+        for row in conn.execute(select(vault_secrets).where(vault_secrets.c.name.in_(member_names))).mappings()
+    }
+    if set(secret_rows) != set(member_names):
+        raise VaultSecretAccessError("Vault secret access is not permitted.")
+    require = _require_secret_resource_management if management else _require_secret_resource_access
+    for name in member_names:
+        require(conn, secret_rows[name], context)
+
+
+def _require_grant_secret_access(
+    conn: Connection,
+    row: dict[str, Any],
+    *,
+    user_context: Any = None,
+    management: bool = False,
+) -> None:
+    _require_secret_names_access(
+        conn,
+        _grant_member_names(row),
+        user_context=user_context,
+        management=management,
+    )
+
+
 def _register_created_secret_resource_policy(conn: Connection, secret_id: str, user_context: Any) -> None:
     """Register remote organization-created Vault secrets as private resources."""
 
@@ -4189,6 +4228,7 @@ def list_grants(
     status: str | None = "active",
     session_id: str | None = None,
     cache: VaultGrantRuntimeCache = GRANT_RUNTIME_CACHE,
+    user_context: Any = None,
 ) -> list[dict[str, Any]]:
     expire_grants(conn, cache=cache)
     query = select(vault_grants).order_by(vault_grants.c.created_at.desc(), vault_grants.c.id.desc())
@@ -4198,7 +4238,18 @@ def list_grants(
         query = query.where(vault_grants.c.status == status)
     if session_id is not None:
         query = query.where(or_(vault_grants.c.session_id.is_(None), vault_grants.c.session_id == session_id))
-    return [_grant_payload(conn, dict(row), cache=cache) for row in conn.execute(query).mappings()]
+    context = resolve_resource_access_context(user_context)
+    rows = [dict(row) for row in conn.execute(query).mappings()]
+    if not context.is_trusted_local:
+        accessible_rows: list[dict[str, Any]] = []
+        for row in rows:
+            try:
+                _require_grant_secret_access(conn, row, user_context=context)
+            except VaultSecretAccessError:
+                continue
+            accessible_rows.append(row)
+        rows = accessible_rows
+    return [_grant_payload(conn, row, cache=cache) for row in rows]
 
 
 def get_grant_created_by_request(
@@ -4238,11 +4289,13 @@ def revoke_grant(
     grant_id: str,
     *,
     cache: VaultGrantRuntimeCache = GRANT_RUNTIME_CACHE,
+    user_context: Any = None,
 ) -> dict[str, Any]:
     row = conn.execute(select(vault_grants).where(vault_grants.c.id == grant_id)).mappings().first()
     if row is None:
         raise GrantNotFoundError(grant_id)
     row_dict = dict(row)
+    _require_grant_secret_access(conn, row_dict, user_context=user_context, management=True)
     if row_dict.get("status") not in ACTIVE_GRANT_STATES:
         raise GrantNotActiveError(grant_id)
     now = _now()
@@ -4616,8 +4669,59 @@ def resolve_secret_access(
     return {"status": "approval_required", "secret": _meta_payload(row), "request": request_payload}
 
 
-def list_audit(conn: Connection, *, secret_name: str | None = None, limit: int = 100) -> list[dict[str, Any]]:
-    query = select(vault_audit).order_by(vault_audit.c.ts.desc(), vault_audit.c.id.desc()).limit(limit)
+def _require_audit_row_access(conn: Connection, row: dict[str, Any], *, user_context: Any = None) -> None:
+    context = resolve_resource_access_context(user_context)
+    if context.is_trusted_local:
+        return
+
+    covered_names: set[str] = set()
+    request_id = str(row.get("request_id") or "")
+    if request_id:
+        request_row = conn.execute(select(vault_requests).where(vault_requests.c.id == request_id)).mappings().first()
+        if request_row is None:
+            raise VaultSecretAccessError("Vault secret access is not permitted.")
+        request_dict = dict(request_row)
+        _require_request_secret_access(conn, request_dict, user_context=context)
+        covered_names.update(_request_member_names(request_dict))
+
+    grant_id = str(row.get("grant_id") or "")
+    if grant_id:
+        grant_row = conn.execute(select(vault_grants).where(vault_grants.c.id == grant_id)).mappings().first()
+        if grant_row is None:
+            raise VaultSecretAccessError("Vault secret access is not permitted.")
+        grant_dict = dict(grant_row)
+        _require_grant_secret_access(conn, grant_dict, user_context=context)
+        covered_names.update(_grant_member_names(grant_dict))
+
+    direct_name = str(row.get("secret_name") or "")
+    if direct_name and direct_name not in covered_names:
+        _require_secret_names_access(conn, [direct_name], user_context=context)
+        covered_names.add(direct_name)
+    if not covered_names and not context.is_instance_owner:
+        raise VaultSecretAccessError("Vault secret access is not permitted.")
+
+
+def list_audit(
+    conn: Connection,
+    *,
+    secret_name: str | None = None,
+    limit: int = 100,
+    user_context: Any = None,
+) -> list[dict[str, Any]]:
+    context = resolve_resource_access_context(user_context)
+    query = select(vault_audit).order_by(vault_audit.c.ts.desc(), vault_audit.c.id.desc())
     if secret_name is not None:
         query = query.where(vault_audit.c.secret_name == secret_name)
-    return [dict(row) for row in conn.execute(query).mappings()]
+    if context.is_trusted_local:
+        query = query.limit(limit)
+    rows = [dict(row) for row in conn.execute(query).mappings()]
+    if not context.is_trusted_local:
+        accessible_rows: list[dict[str, Any]] = []
+        for row in rows:
+            try:
+                _require_audit_row_access(conn, row, user_context=context)
+            except VaultSecretAccessError:
+                continue
+            accessible_rows.append(row)
+        rows = accessible_rows[:limit]
+    return rows

--- a/storage/vault_service.py
+++ b/storage/vault_service.py
@@ -1648,15 +1648,7 @@ def resolve_resource_access_context(user_context: Any = None):
 
     from storage import resource_access_service
 
-    if isinstance(user_context, resource_access_service.ResourceUserContext):
-        return user_context
-    if user_context is not None:
-        return resource_access_service.current_resource_context(user_context, is_remote=True)
-
-    context = resource_access_service.current_resource_context()
-    if context.is_remote or context.is_trusted_local:
-        return context
-    return resource_access_service.ResourceUserContext(is_trusted_local=True)
+    return resource_access_service.resolve_resource_access_context(user_context)
 
 
 def _require_secret_resource_access(conn: Connection, row: dict[str, Any], user_context: Any) -> dict[str, Any]:
@@ -1673,6 +1665,31 @@ def _require_secret_resource_access(conn: Connection, row: dict[str, Any], user_
     ):
         raise VaultSecretAccessError("Vault secret access is not permitted.")
     return row
+
+
+def _require_secret_resource_management(conn: Connection, row: dict[str, Any], user_context: Any) -> dict[str, Any]:
+    """Return a secret row only when the caller may change its ACL resource."""
+
+    from storage import resource_access_service
+
+    resource_id = str(row.get("id") or "")
+    if not resource_id or not resource_access_service.can_manage_resource_acl(
+        user_context,
+        "vault_secret",
+        resource_id,
+        connection=conn,
+    ):
+        raise VaultSecretAccessError("Vault secret access is not permitted.")
+    return row
+
+
+def require_secret_create_access(*, user_context: Any = None):
+    context = resolve_resource_access_context(user_context)
+    if context.is_trusted_local or context.is_instance_owner:
+        return context
+    if context.is_remote and context.is_active_organization_member and context.subject:
+        return context
+    raise VaultSecretAccessError("Vault secret access is not permitted.")
 
 
 def require_secret_access(conn: Connection, name: str, *, user_context: Any = None) -> dict[str, Any]:
@@ -2137,7 +2154,7 @@ def create_secret(
         if not isinstance(authz_factor_registration, dict):
             raise ProtectedAuthzSetupRequiredError("protected vault establishment requires a passkey authorization factor")
 
-    context = resolve_resource_access_context(user_context)
+    context = require_secret_create_access(user_context=user_context)
     secret_id = _id("vlt")
     now = _now()
     normalized_tags = _normalize_tags(tags)
@@ -2216,8 +2233,15 @@ def link_secret_to_skills(conn: Connection, secret_name: str, skills: list[str],
     audit(conn, "tags-updated", secret_name=secret_name, delivery={"source": source, "tags": updated})
 
 
-def update_secret_tags(conn: Connection, secret_name: str, tags: list[str]) -> dict[str, Any]:
-    row = _require_row(conn, secret_name)
+def update_secret_tags(
+    conn: Connection,
+    secret_name: str,
+    tags: list[str],
+    *,
+    user_context: Any = None,
+) -> dict[str, Any]:
+    context = resolve_resource_access_context(user_context)
+    row = _require_secret_resource_management(conn, _require_row(conn, secret_name), context)
     normalized = _normalize_tags(tags)
     conn.execute(
         vault_secrets.update()
@@ -2237,6 +2261,7 @@ def update_secret_metadata(
     policy: Any = _UNSET,
     cache: VaultGrantRuntimeCache = GRANT_RUNTIME_CACHE,
     release_scopes: list[dict[str, str]] | None = None,
+    user_context: Any = None,
 ) -> dict[str, Any]:
     """Update value-free metadata only.
 
@@ -2245,7 +2270,8 @@ def update_secret_metadata(
     authorization boundary, so policy changes expire relevant requests/grants.
     """
 
-    row = _require_row(conn, secret_name)
+    context = resolve_resource_access_context(user_context)
+    row = _require_secret_resource_management(conn, _require_row(conn, secret_name), context)
     values: dict[str, Any] = {}
     fields: list[str] = []
 
@@ -2312,8 +2338,10 @@ def update_secret_classification(
     kind: str | None = None,
     protection: str | None = None,
     cache: VaultGrantRuntimeCache = GRANT_RUNTIME_CACHE,
+    user_context: Any = None,
 ) -> dict[str, Any]:
-    row = _require_row(conn, secret_name)
+    context = resolve_resource_access_context(user_context)
+    row = _require_secret_resource_management(conn, _require_row(conn, secret_name), context)
     values: dict[str, Any] = {}
     if kind is not None:
         normalized_kind = kind.strip().lower()
@@ -2361,7 +2389,7 @@ def store_pubkey_pin(
 ) -> dict[str, Any]:
     """Store avault pubkey pin/attestation metadata without touching value fields."""
     context = resolve_resource_access_context(user_context)
-    row = _require_secret_resource_access(conn, _require_row(conn, name), context)
+    row = _require_secret_resource_management(conn, _require_row(conn, name), context)
     public_meta = _public_meta(row.get("public_meta"))
     public_meta["avault_pubkey_pin"] = {
         key: value
@@ -2518,8 +2546,10 @@ def rotate_secret(
     sealed: Sealed,
     *,
     cache: VaultGrantRuntimeCache = GRANT_RUNTIME_CACHE,
+    user_context: Any = None,
 ) -> dict[str, Any]:
-    row = _require_row(conn, name)
+    context = resolve_resource_access_context(user_context)
+    row = _require_secret_resource_management(conn, _require_row(conn, name), context)
     public_meta = _public_meta(row.get("public_meta"))
     public_meta.pop("preview", None)
     _expire_pending_requests_for_secret(conn, name, reason="request-expired-envelope-changed")
@@ -2561,11 +2591,10 @@ def delete_secret(
     name: str,
     *,
     cache: VaultGrantRuntimeCache = GRANT_RUNTIME_CACHE,
+    user_context: Any = None,
 ) -> None:
-    row = conn.execute(select(vault_secrets).where(vault_secrets.c.name == name)).mappings().first()
-    if row is None:
-        raise SecretNotFoundError(name)
-    row = dict(row)
+    context = resolve_resource_access_context(user_context)
+    row = _require_secret_resource_management(conn, _require_row(conn, name), context)
     _expire_pending_requests_for_secret(conn, name, reason="request-expired-envelope-changed")
     _expire_active_grants_for_secret(conn, name, cache=cache, reason="grant-expired-envelope-changed")
     conn.execute(vault_secrets.delete().where(vault_secrets.c.name == name))

--- a/storage/vault_service.py
+++ b/storage/vault_service.py
@@ -1490,6 +1490,36 @@ def _request_member_names(row: dict[str, Any]) -> list[str]:
     return sorted(set(members))
 
 
+def _require_request_secret_access(
+    conn: Connection,
+    row: dict[str, Any],
+    *,
+    user_context: Any = None,
+    management: bool = False,
+) -> None:
+    """Authorize a request before hydrating or mutating its member secrets."""
+
+    context = resolve_resource_access_context(user_context)
+    if context.is_trusted_local:
+        return
+    member_names = _request_member_names(row)
+    if not member_names:
+        raise VaultSecretAccessError("Vault secret access is not permitted.")
+    secret_rows = {
+        str(secret_row["name"]): dict(secret_row)
+        for secret_row in conn.execute(select(vault_secrets).where(vault_secrets.c.name.in_(member_names))).mappings()
+    }
+    if set(secret_rows) != set(member_names):
+        # Provision requests legitimately precede the secret. Only the paired
+        # instance owner may inspect or decide those owner-level requests.
+        if context.is_instance_owner and row.get("request_type") == "provision":
+            return
+        raise VaultSecretAccessError("Vault secret access is not permitted.")
+    require = _require_secret_resource_management if management else _require_secret_resource_access
+    for name in member_names:
+        require(conn, secret_rows[name], context)
+
+
 def _request_covers_any_member(row: dict[str, Any], members: set[str]) -> bool:
     if not members:
         return False
@@ -3329,8 +3359,15 @@ def complete_sign_request(
     return _request_row_payload(dict(updated), conn=conn, audience=REQUEST_AUDIENCE_AGENT)
 
 
-def get_request(conn: Connection, request_id: str, *, audience: str | None = REQUEST_AUDIENCE_UI) -> dict[str, Any]:
+def get_request(
+    conn: Connection,
+    request_id: str,
+    *,
+    audience: str | None = REQUEST_AUDIENCE_UI,
+    user_context: Any = None,
+) -> dict[str, Any]:
     row_dict = _load_request_row(conn, request_id)
+    _require_request_secret_access(conn, row_dict, user_context=user_context)
     return _request_row_payload(row_dict, conn=conn, audience=audience)
 
 
@@ -3529,7 +3566,10 @@ def deny_request(
     *,
     requester: Any = None,
     reason: str | None = None,
+    user_context: Any = None,
 ) -> dict[str, Any]:
+    request_row = _load_request_row(conn, request_id)
+    _require_request_secret_access(conn, request_row, user_context=user_context, management=True)
     row_dict = _load_request_for_transition(
         conn,
         request_id,
@@ -3569,6 +3609,7 @@ def list_requests(
     request_type: str | None = None,
     limit: int = 100,
     session: str | None = None,
+    user_context: Any = None,
 ) -> list[dict[str, Any]]:
     _expire_pending_requests(conn)
     query = select(vault_requests).order_by(vault_requests.c.created_at.desc(), vault_requests.c.id.desc())
@@ -3583,6 +3624,16 @@ def list_requests(
     rows = [dict(row) for row in conn.execute(query).mappings()]
     if session is not None:
         rows = [row for row in rows if _request_session_id(row) == session][:limit]
+    context = resolve_resource_access_context(user_context)
+    if not context.is_trusted_local:
+        accessible_rows: list[dict[str, Any]] = []
+        for row in rows:
+            try:
+                _require_request_secret_access(conn, row, user_context=context)
+            except VaultSecretAccessError:
+                continue
+            accessible_rows.append(row)
+        rows = accessible_rows
     return [_request_row_payload(row, conn=conn, audience=REQUEST_AUDIENCE_UI) for row in rows]
 
 

--- a/storage/vault_service.py
+++ b/storage/vault_service.py
@@ -3757,7 +3757,12 @@ def list_requests(
     return [_request_row_payload(row, conn=conn, audience=REQUEST_AUDIENCE_UI) for row in rows]
 
 
-def resolve_pending_provision_request_by_name(conn: Connection, name: str) -> tuple[dict[str, Any] | None, bool]:
+def resolve_pending_provision_request_by_name(
+    conn: Connection,
+    name: str,
+    *,
+    user_context: Any = None,
+) -> tuple[dict[str, Any] | None, bool]:
     _expire_pending_requests(conn)
     rows = list(
         conn.execute(
@@ -3771,8 +3776,11 @@ def resolve_pending_provision_request_by_name(conn: Connection, name: str) -> tu
             .limit(2)
         ).mappings()
     )
-    if len(rows) == 1:
-        return _request_row_payload(dict(rows[0]), conn=conn, audience=REQUEST_AUDIENCE_UI), False
+    row_dicts = [dict(row) for row in rows]
+    for row in row_dicts:
+        _require_request_secret_access(conn, row, user_context=user_context)
+    if len(row_dicts) == 1:
+        return _request_row_payload(row_dicts[0], conn=conn, audience=REQUEST_AUDIENCE_UI), False
     return None, len(rows) > 1
 
 
@@ -3781,7 +3789,12 @@ def find_pending_provision_request(conn: Connection, name: str) -> dict[str, Any
     return request
 
 
-def get_pending_provision_request(conn: Connection, request_id: str) -> dict[str, Any] | None:
+def get_pending_provision_request(
+    conn: Connection,
+    request_id: str,
+    *,
+    user_context: Any = None,
+) -> dict[str, Any] | None:
     _expire_pending_requests(conn)
     row = (
         conn.execute(
@@ -3798,7 +3811,9 @@ def get_pending_provision_request(conn: Connection, request_id: str) -> dict[str
     )
     if row is None:
         return None
-    return _request_row_payload(dict(row), conn=conn, audience=REQUEST_AUDIENCE_UI)
+    row_dict = dict(row)
+    _require_request_secret_access(conn, row_dict, user_context=user_context)
+    return _request_row_payload(row_dict, conn=conn, audience=REQUEST_AUDIENCE_UI)
 
 
 def _expire_grant_rows(

--- a/storage/vault_service.py
+++ b/storage/vault_service.py
@@ -3612,19 +3612,20 @@ def list_requests(
     user_context: Any = None,
 ) -> list[dict[str, Any]]:
     _expire_pending_requests(conn)
+    context = resolve_resource_access_context(user_context)
     query = select(vault_requests).order_by(vault_requests.c.created_at.desc(), vault_requests.c.id.desc())
     if status is not None:
         query = query.where(vault_requests.c.status == status)
     if request_type is not None:
         query = query.where(vault_requests.c.request_type == request_type)
-    # session_id lives in the request JSON (not a column), so a session-scoped query must filter
-    # in Python BEFORE limiting — else a global page could truncate this session's older rows.
-    if session is None:
+    # Session and remote ACL filters run in Python, so apply the limit only after
+    # those filters or newer inaccessible rows could hide older visible requests.
+    requires_post_filter = session is not None or not context.is_trusted_local
+    if not requires_post_filter:
         query = query.limit(limit)
     rows = [dict(row) for row in conn.execute(query).mappings()]
     if session is not None:
-        rows = [row for row in rows if _request_session_id(row) == session][:limit]
-    context = resolve_resource_access_context(user_context)
+        rows = [row for row in rows if _request_session_id(row) == session]
     if not context.is_trusted_local:
         accessible_rows: list[dict[str, Any]] = []
         for row in rows:
@@ -3634,6 +3635,8 @@ def list_requests(
                 continue
             accessible_rows.append(row)
         rows = accessible_rows
+    if requires_post_filter:
+        rows = rows[:limit]
     return [_request_row_payload(row, conn=conn, audience=REQUEST_AUDIENCE_UI) for row in rows]
 
 

--- a/storage/vault_service.py
+++ b/storage/vault_service.py
@@ -25,7 +25,7 @@ from datetime import datetime, timedelta, timezone
 from typing import Any
 from urllib.parse import urlsplit
 
-from sqlalchemy import func, or_, select
+from sqlalchemy import and_, func, or_, select
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from sqlalchemy.engine import Connection
 from sqlalchemy.exc import IntegrityError
@@ -69,6 +69,9 @@ SUPPORTED_SIGNATURE_SCHEMES = {
 REQUEST_AUDIENCE_AGENT = "agent"
 REQUEST_AUDIENCE_UI = "ui"
 REQUEST_AUDIENCES = {REQUEST_AUDIENCE_AGENT, REQUEST_AUDIENCE_UI}
+_AUDIT_ACCESS_SNAPSHOT_KEY = "_resource_access_snapshot"
+_REMOTE_AUDIT_MIN_BATCH_SIZE = 25
+_REMOTE_AUDIT_MAX_BATCH_SIZE = 200
 PROVISION_SPEC_FORBIDDEN_KEYS = {
     "value",
     "sealed",
@@ -1641,6 +1644,66 @@ def _reject_keypair_value_delivery(row: dict[str, Any], name: str) -> None:
         raise KeypairNotValueDeliverableError(f"{name} is a signing key; use vault_sign instead of value delivery")
 
 
+def _audit_reference_secret_names(
+    conn: Connection,
+    *,
+    secret_name: str | None,
+    request_id: str | None,
+    grant_id: str | None,
+) -> list[str]:
+    names = {str(secret_name)} if secret_name else set()
+    if request_id:
+        request_row = conn.execute(select(vault_requests).where(vault_requests.c.id == request_id)).mappings().first()
+        if request_row is not None:
+            names.update(_request_member_names(dict(request_row)))
+    if grant_id:
+        grant_row = conn.execute(select(vault_grants).where(vault_grants.c.id == grant_id)).mappings().first()
+        if grant_row is not None:
+            names.update(_grant_member_names(dict(grant_row)))
+    return sorted(name for name in names if name)
+
+
+def _build_audit_access_snapshot(conn: Connection, names: list[str]) -> dict[str, Any] | None:
+    from storage import resource_access_service
+
+    normalized_names = sorted({str(name) for name in names if str(name)})
+    if not normalized_names:
+        return None
+    secret_rows = {
+        str(row["name"]): dict(row)
+        for row in conn.execute(select(vault_secrets).where(vault_secrets.c.name.in_(normalized_names))).mappings()
+    }
+    resources: list[dict[str, Any]] = []
+    for name in normalized_names:
+        secret_row = secret_rows.get(name)
+        if secret_row is None:
+            continue
+        resource_id = str(secret_row.get("id") or "")
+        if not resource_id:
+            continue
+        resources.append(
+            {
+                "name": name,
+                "resource_id": resource_id,
+                "policy": resource_access_service.get_resource_policy(
+                    "vault_secret",
+                    resource_id,
+                    connection=conn,
+                ),
+            }
+        )
+    return {"version": 1, "resources": resources} if resources else None
+
+
+def _audit_public_row(row: dict[str, Any]) -> dict[str, Any]:
+    payload = dict(row)
+    delivery = _loads(payload.get("delivery"))
+    if isinstance(delivery, dict) and _AUDIT_ACCESS_SNAPSHOT_KEY in delivery:
+        delivery.pop(_AUDIT_ACCESS_SNAPSHOT_KEY, None)
+        payload["delivery"] = json.dumps(delivery) if delivery else None
+    return payload
+
+
 def audit(
     conn: Connection,
     event: str,
@@ -1650,8 +1713,22 @@ def audit(
     delivery: Any = None,
     request_id: str | None = None,
     grant_id: str | None = None,
+    access_snapshot: dict[str, Any] | None = None,
 ) -> None:
     """Append one audit row. Callers pass only non-secret summaries."""
+    snapshot = access_snapshot or _build_audit_access_snapshot(
+        conn,
+        _audit_reference_secret_names(
+            conn,
+            secret_name=secret_name,
+            request_id=request_id,
+            grant_id=grant_id,
+        ),
+    )
+    stored_delivery = delivery
+    if snapshot is not None and (delivery is None or isinstance(delivery, dict)):
+        stored_delivery = dict(delivery or {})
+        stored_delivery[_AUDIT_ACCESS_SNAPSHOT_KEY] = snapshot
     conn.execute(
         vault_audit.insert().values(
             id=_id("vau"),
@@ -1659,7 +1736,7 @@ def audit(
             event=event,
             secret_name=secret_name,
             requester=json.dumps(requester) if requester is not None else None,
-            delivery=json.dumps(delivery) if delivery is not None else None,
+            delivery=json.dumps(stored_delivery) if stored_delivery is not None else None,
             request_id=request_id,
             grant_id=grant_id,
         )
@@ -2666,13 +2743,14 @@ def delete_secret(
 
     context = resolve_resource_access_context(user_context)
     row = _require_secret_resource_management(conn, _require_row(conn, name), context)
+    audit_snapshot = _build_audit_access_snapshot(conn, [name])
     _expire_pending_requests_for_secret(conn, name, reason="request-expired-envelope-changed")
     _expire_active_grants_for_secret(conn, name, cache=cache, reason="grant-expired-envelope-changed")
     conn.execute(vault_secrets.delete().where(vault_secrets.c.name == name))
     resource_access_service.delete_resource_policy(conn, "vault_secret", str(row["id"]))
     if row.get("protection") == "protected":
         _disable_webauthn_factors_if_vault_deestablished(conn)
-    audit(conn, "deleted", secret_name=name)
+    audit(conn, "deleted", secret_name=name, access_snapshot=audit_snapshot)
 
 
 def get_secret_policy(conn: Connection, name: str, *, user_context: Any = None) -> dict[str, Any]:
@@ -4669,36 +4747,178 @@ def resolve_secret_access(
     return {"status": "approval_required", "secret": _meta_payload(row), "request": request_payload}
 
 
-def _require_audit_row_access(conn: Connection, row: dict[str, Any], *, user_context: Any = None) -> None:
+def _audit_access_snapshot(row: dict[str, Any]) -> tuple[bool, dict[str, Any] | None]:
+    delivery = _loads(row.get("delivery"))
+    if not isinstance(delivery, dict) or _AUDIT_ACCESS_SNAPSHOT_KEY not in delivery:
+        return False, None
+    snapshot = delivery.get(_AUDIT_ACCESS_SNAPSHOT_KEY)
+    if not isinstance(snapshot, dict) or snapshot.get("version") != 1 or not isinstance(snapshot.get("resources"), list):
+        return True, None
+    return True, snapshot
+
+
+def _audit_snapshot_allows(context: Any, snapshot: dict[str, Any]) -> bool:
+    from storage import resource_access_service
+
+    resources = snapshot.get("resources")
+    if not isinstance(resources, list) or not resources:
+        return False
+    for resource in resources:
+        if not isinstance(resource, dict) or not str(resource.get("name") or "") or not str(resource.get("resource_id") or ""):
+            return False
+        policy = resource.get("policy")
+        if not (
+            resource_access_service.can_use_resource_policy_snapshot(context, policy)
+            or resource_access_service.can_manage_resource_policy_snapshot(context, policy)
+        ):
+            return False
+    return True
+
+
+def _audit_reference_names_for_row(
+    conn: Connection,
+    row: dict[str, Any],
+    *,
+    request_members: dict[str, list[str] | None],
+    grant_members: dict[str, list[str] | None],
+) -> list[str]:
+    names = {str(row.get("secret_name") or "")} - {""}
+    request_id = str(row.get("request_id") or "")
+    if request_id:
+        if request_id not in request_members:
+            request_row = conn.execute(select(vault_requests).where(vault_requests.c.id == request_id)).mappings().first()
+            request_members[request_id] = _request_member_names(dict(request_row)) if request_row is not None else None
+        members = request_members[request_id]
+        if members is None:
+            raise VaultSecretAccessError("Vault secret access is not permitted.")
+        names.update(members)
+
+    grant_id = str(row.get("grant_id") or "")
+    if grant_id:
+        if grant_id not in grant_members:
+            grant_row = conn.execute(select(vault_grants).where(vault_grants.c.id == grant_id)).mappings().first()
+            grant_members[grant_id] = _grant_member_names(dict(grant_row)) if grant_row is not None else None
+        members = grant_members[grant_id]
+        if members is None:
+            raise VaultSecretAccessError("Vault secret access is not permitted.")
+        names.update(members)
+    return sorted(names)
+
+
+def _deleted_audit_policy_snapshot(
+    conn: Connection,
+    name: str,
+    *,
+    tombstone_policies: dict[str, tuple[bool, Any]],
+) -> tuple[bool, Any]:
+    if name in tombstone_policies:
+        return tombstone_policies[name]
+    row = (
+        conn.execute(
+            select(vault_audit)
+            .where(vault_audit.c.secret_name == name, vault_audit.c.event == "deleted")
+            .order_by(vault_audit.c.ts.desc(), vault_audit.c.id.desc())
+            .limit(1)
+        )
+        .mappings()
+        .first()
+    )
+    if row is not None:
+        present, snapshot = _audit_access_snapshot(dict(row))
+        if present and snapshot is not None:
+            for resource in snapshot["resources"]:
+                if isinstance(resource, dict) and resource.get("name") == name:
+                    result = (True, resource.get("policy"))
+                    tombstone_policies[name] = result
+                    return result
+    result = (False, None)
+    tombstone_policies[name] = result
+    return result
+
+
+def _audit_secret_name_allowed(
+    conn: Connection,
+    name: str,
+    *,
+    context: Any,
+    access_by_name: dict[str, bool],
+    tombstone_policies: dict[str, tuple[bool, Any]],
+) -> bool:
+    from storage import resource_access_service
+
+    if name in access_by_name:
+        return access_by_name[name]
+    secret_row = conn.execute(select(vault_secrets.c.id).where(vault_secrets.c.name == name).limit(1)).first()
+    if secret_row is not None:
+        policy = resource_access_service.get_resource_policy(
+            "vault_secret",
+            str(secret_row.id),
+            connection=conn,
+        )
+        allowed = bool(
+            resource_access_service.can_use_resource_policy_snapshot(context, policy)
+            or resource_access_service.can_manage_resource_policy_snapshot(context, policy)
+        )
+    else:
+        has_tombstone, policy = _deleted_audit_policy_snapshot(
+            conn,
+            name,
+            tombstone_policies=tombstone_policies,
+        )
+        allowed = bool(
+            has_tombstone
+            and (
+                resource_access_service.can_use_resource_policy_snapshot(context, policy)
+                or resource_access_service.can_manage_resource_policy_snapshot(context, policy)
+            )
+        )
+        if not has_tombstone:
+            allowed = bool(context.is_instance_owner)
+    access_by_name[name] = allowed
+    return allowed
+
+
+def _require_audit_row_access(
+    conn: Connection,
+    row: dict[str, Any],
+    *,
+    user_context: Any = None,
+    request_members: dict[str, list[str] | None] | None = None,
+    grant_members: dict[str, list[str] | None] | None = None,
+    access_by_name: dict[str, bool] | None = None,
+    tombstone_policies: dict[str, tuple[bool, Any]] | None = None,
+) -> None:
     context = resolve_resource_access_context(user_context)
     if context.is_trusted_local:
         return
 
-    covered_names: set[str] = set()
-    request_id = str(row.get("request_id") or "")
-    if request_id:
-        request_row = conn.execute(select(vault_requests).where(vault_requests.c.id == request_id)).mappings().first()
-        if request_row is None:
+    snapshot_present, snapshot = _audit_access_snapshot(row)
+    if snapshot_present:
+        if snapshot is None or not _audit_snapshot_allows(context, snapshot):
             raise VaultSecretAccessError("Vault secret access is not permitted.")
-        request_dict = dict(request_row)
-        _require_request_secret_access(conn, request_dict, user_context=context)
-        covered_names.update(_request_member_names(request_dict))
+        return
 
-    grant_id = str(row.get("grant_id") or "")
-    if grant_id:
-        grant_row = conn.execute(select(vault_grants).where(vault_grants.c.id == grant_id)).mappings().first()
-        if grant_row is None:
-            raise VaultSecretAccessError("Vault secret access is not permitted.")
-        grant_dict = dict(grant_row)
-        _require_grant_secret_access(conn, grant_dict, user_context=context)
-        covered_names.update(_grant_member_names(grant_dict))
-
-    direct_name = str(row.get("secret_name") or "")
-    if direct_name and direct_name not in covered_names:
-        _require_secret_names_access(conn, [direct_name], user_context=context)
-        covered_names.add(direct_name)
-    if not covered_names and not context.is_instance_owner:
+    names = _audit_reference_names_for_row(
+        conn,
+        row,
+        request_members=request_members if request_members is not None else {},
+        grant_members=grant_members if grant_members is not None else {},
+    )
+    if not names:
+        if context.is_instance_owner:
+            return
         raise VaultSecretAccessError("Vault secret access is not permitted.")
+    name_access = access_by_name if access_by_name is not None else {}
+    tombstones = tombstone_policies if tombstone_policies is not None else {}
+    for name in names:
+        if not _audit_secret_name_allowed(
+            conn,
+            name,
+            context=context,
+            access_by_name=name_access,
+            tombstone_policies=tombstones,
+        ):
+            raise VaultSecretAccessError("Vault secret access is not permitted.")
 
 
 def list_audit(
@@ -4709,19 +4929,58 @@ def list_audit(
     user_context: Any = None,
 ) -> list[dict[str, Any]]:
     context = resolve_resource_access_context(user_context)
-    query = select(vault_audit).order_by(vault_audit.c.ts.desc(), vault_audit.c.id.desc())
-    if secret_name is not None:
-        query = query.where(vault_audit.c.secret_name == secret_name)
+    requested_limit = max(0, limit)
+    if requested_limit == 0:
+        return []
     if context.is_trusted_local:
-        query = query.limit(limit)
-    rows = [dict(row) for row in conn.execute(query).mappings()]
-    if not context.is_trusted_local:
-        accessible_rows: list[dict[str, Any]] = []
-        for row in rows:
+        query = select(vault_audit).order_by(vault_audit.c.ts.desc(), vault_audit.c.id.desc())
+        if secret_name is not None:
+            query = query.where(vault_audit.c.secret_name == secret_name)
+        rows = [dict(row) for row in conn.execute(query.limit(requested_limit)).mappings()]
+        return [_audit_public_row(row) for row in rows]
+
+    batch_size = max(
+        _REMOTE_AUDIT_MIN_BATCH_SIZE,
+        min(_REMOTE_AUDIT_MAX_BATCH_SIZE, requested_limit * 2),
+    )
+    accessible_rows: list[dict[str, Any]] = []
+    cursor: tuple[str, str] | None = None
+    request_members: dict[str, list[str] | None] = {}
+    grant_members: dict[str, list[str] | None] = {}
+    access_by_name: dict[str, bool] = {}
+    tombstone_policies: dict[str, tuple[bool, Any]] = {}
+    while len(accessible_rows) < requested_limit:
+        query = select(vault_audit).order_by(vault_audit.c.ts.desc(), vault_audit.c.id.desc())
+        if secret_name is not None:
+            query = query.where(vault_audit.c.secret_name == secret_name)
+        if cursor is not None:
+            cursor_ts, cursor_id = cursor
+            query = query.where(
+                or_(
+                    vault_audit.c.ts < cursor_ts,
+                    and_(vault_audit.c.ts == cursor_ts, vault_audit.c.id < cursor_id),
+                )
+            )
+        batch = [dict(row) for row in conn.execute(query.limit(batch_size)).mappings()]
+        if not batch:
+            break
+        cursor = (str(batch[-1]["ts"]), str(batch[-1]["id"]))
+        for row in batch:
             try:
-                _require_audit_row_access(conn, row, user_context=context)
+                _require_audit_row_access(
+                    conn,
+                    row,
+                    user_context=context,
+                    request_members=request_members,
+                    grant_members=grant_members,
+                    access_by_name=access_by_name,
+                    tombstone_policies=tombstone_policies,
+                )
             except VaultSecretAccessError:
                 continue
             accessible_rows.append(row)
-        rows = accessible_rows[:limit]
-    return rows
+            if len(accessible_rows) >= requested_limit:
+                break
+        if len(batch) < batch_size:
+            break
+    return [_audit_public_row(row) for row in accessible_rows]

--- a/storage/vault_service.py
+++ b/storage/vault_service.py
@@ -156,6 +156,10 @@ class SecretNotFoundError(VaultServiceError):
     pass
 
 
+class VaultSecretAccessError(VaultServiceError):
+    """Raised when the current caller cannot use a Vault secret."""
+
+
 class RequestNotFoundError(VaultServiceError):
     pass
 
@@ -1592,9 +1596,9 @@ def sign_headless_allowed(row: dict[str, Any]) -> bool:
     return not _secret_always_ask(row)
 
 
-def sign_needs_approval(conn: Connection, name: str) -> bool:
+def sign_needs_approval(conn: Connection, name: str, *, user_context: Any = None) -> bool:
     """True when `vibe vault sign` must create a pending approval request for `name`."""
-    return not sign_headless_allowed(_require_row(conn, name))
+    return not sign_headless_allowed(require_secret_access(conn, name, user_context=user_context))
 
 
 def _reject_unsignable_keypair(row: dict[str, Any], name: str) -> None:
@@ -1637,6 +1641,64 @@ def _require_row(conn: Connection, name: str) -> dict[str, Any]:
     if row is None:
         raise SecretNotFoundError(name)
     return dict(row)
+
+
+def resolve_resource_access_context(user_context: Any = None):
+    """Resolve request ACL context while preserving trusted local Vault use."""
+
+    from storage import resource_access_service
+
+    if isinstance(user_context, resource_access_service.ResourceUserContext):
+        return user_context
+    if user_context is not None:
+        return resource_access_service.current_resource_context(user_context, is_remote=True)
+
+    context = resource_access_service.current_resource_context()
+    if context.is_remote or context.is_trusted_local:
+        return context
+    return resource_access_service.ResourceUserContext(is_trusted_local=True)
+
+
+def _require_secret_resource_access(conn: Connection, row: dict[str, Any], user_context: Any) -> dict[str, Any]:
+    """Return a secret row only when the caller may use its ACL resource."""
+
+    from storage import resource_access_service
+
+    resource_id = str(row.get("id") or "")
+    if not resource_id or not resource_access_service.can_use_resource(
+        user_context,
+        "vault_secret",
+        resource_id,
+        connection=conn,
+    ):
+        raise VaultSecretAccessError("Vault secret access is not permitted.")
+    return row
+
+
+def require_secret_access(conn: Connection, name: str, *, user_context: Any = None) -> dict[str, Any]:
+    """Look up a secret by name and require access to its id-backed ACL resource."""
+
+    return _require_secret_resource_access(conn, _require_row(conn, name), resolve_resource_access_context(user_context))
+
+
+def _register_created_secret_resource_policy(conn: Connection, secret_id: str, user_context: Any) -> None:
+    """Register remote organization-created Vault secrets as private resources."""
+
+    from storage import resource_access_service
+
+    if not (user_context.is_remote and user_context.is_active_organization_member and user_context.subject):
+        return
+    resource_access_service.ensure_resource_policy(
+        conn,
+        resource_kind="vault_secret",
+        resource_id=secret_id,
+        organization_id=user_context.organization_id,
+        owner_user_id=user_context.subject,
+        owner_email=user_context.email,
+        access_level="private",
+        created_by_user_id=user_context.subject,
+        updated_by_user_id=user_context.subject,
+    )
 
 
 def _new_challenge() -> tuple[str, str]:
@@ -2018,6 +2080,7 @@ def create_secret(
     authz_factor_registration: dict[str, Any] | None = None,
     authz_factor_origin: str | None = None,
     provision_request_id: str | None = None,
+    user_context: Any = None,
 ) -> dict[str, Any]:
     """Create a secret from a caller-supplied encrypted envelope; return masked metadata.
 
@@ -2074,6 +2137,8 @@ def create_secret(
         if not isinstance(authz_factor_registration, dict):
             raise ProtectedAuthzSetupRequiredError("protected vault establishment requires a passkey authorization factor")
 
+    context = resolve_resource_access_context(user_context)
+    secret_id = _id("vlt")
     now = _now()
     normalized_tags = _normalize_tags(tags)
     public_meta = dict(public_meta or {})
@@ -2082,7 +2147,7 @@ def create_secret(
     try:
         conn.execute(
             vault_secrets.insert().values(
-                id=_id("vlt"),
+                id=secret_id,
                 name=name,
                 tags=json.dumps(normalized_tags) if normalized_tags else None,
                 kind=kind,
@@ -2108,6 +2173,7 @@ def create_secret(
         if existing_name is not None and existing_name != name:
             raise SecretNameCaseConflictError(name, existing_name) from exc
         raise SecretExistsError(name) from exc
+    _register_created_secret_resource_policy(conn, secret_id, context)
     audit(conn, "created", secret_name=name)
     if establishing_vmk and protection == "protected":
         # Vestigial after protected-delete authz was removed: the sandbox still
@@ -2270,25 +2336,32 @@ def update_secret_classification(
     return _meta_payload(_require_row(conn, secret_name))
 
 
-def get_secret_meta(conn: Connection, name: str) -> dict[str, Any]:
-    return _meta_payload(_require_row(conn, name))
+def get_secret_meta(conn: Connection, name: str, *, user_context: Any = None) -> dict[str, Any]:
+    return _meta_payload(require_secret_access(conn, name, user_context=user_context))
 
 
-def get_signing_public_key(conn: Connection, name: str) -> dict[str, Any] | None:
+def get_signing_public_key(conn: Connection, name: str, *, user_context: Any = None) -> dict[str, Any] | None:
     """Raw pinned signing public key ({curve, public_key}) from storage.
 
     The masked meta payload exposes only derived addresses (not the raw key), so
     server-side signature verification reads the pinned key from here instead.
     Returns ``None`` when the secret has no pinned signing key.
     """
-    public_meta = _public_meta(_require_row(conn, name).get("public_meta"))
+    public_meta = _public_meta(require_secret_access(conn, name, user_context=user_context).get("public_meta"))
     signing_public_key = public_meta.get("signing_public_key")
     return signing_public_key if isinstance(signing_public_key, dict) else None
 
 
-def store_pubkey_pin(conn: Connection, name: str, pin: dict[str, Any]) -> dict[str, Any]:
+def store_pubkey_pin(
+    conn: Connection,
+    name: str,
+    pin: dict[str, Any],
+    *,
+    user_context: Any = None,
+) -> dict[str, Any]:
     """Store avault pubkey pin/attestation metadata without touching value fields."""
-    row = _require_row(conn, name)
+    context = resolve_resource_access_context(user_context)
+    row = _require_secret_resource_access(conn, _require_row(conn, name), context)
     public_meta = _public_meta(row.get("public_meta"))
     public_meta["avault_pubkey_pin"] = {
         key: value
@@ -2306,7 +2379,7 @@ def store_pubkey_pin(conn: Connection, name: str, pin: dict[str, Any]) -> dict[s
         secret_name=name,
         delivery={"fingerprint": public_meta["avault_pubkey_pin"].get("fingerprint")},
     )
-    return get_secret_meta(conn, name)
+    return get_secret_meta(conn, name, user_context=context)
 
 
 def _normalize_secret_filter_values(values: list[str] | None, *, field: str) -> list[str]:
@@ -2360,10 +2433,21 @@ def list_secrets(
     query: str | None = None,
     kind: str | None = None,
     protection: str | None = None,
+    user_context: Any = None,
 ) -> list[dict[str, Any]]:
     """Masked, value-free list. Never decrypts."""
+    from storage import resource_access_service
+
+    context = resolve_resource_access_context(user_context)
     stmt = select(vault_secrets).order_by(vault_secrets.c.name)
-    rows = [_meta_payload(dict(row)) for row in conn.execute(stmt).mappings()]
+    raw_rows = [dict(row) for row in conn.execute(stmt).mappings()]
+    accessible_rows = resource_access_service.filter_accessible_resources(
+        context,
+        "vault_secret",
+        raw_rows,
+        connection=conn,
+    )
+    rows = [_meta_payload(row) for row in accessible_rows]
     normalized_tags = _normalize_secret_filter_values([tag] if tag is not None else [], field="tags")
     normalized_tags.extend(_normalize_secret_filter_values(tags, field="tags"))
     normalized_tags = list(dict.fromkeys(normalized_tags))
@@ -2383,14 +2467,20 @@ def list_secrets(
     return rows
 
 
-def list_secret_tags(conn: Connection, *, query: str | None = None, tag_type: str | None = None) -> list[dict[str, Any]]:
+def list_secret_tags(
+    conn: Connection,
+    *,
+    query: str | None = None,
+    tag_type: str | None = None,
+    user_context: Any = None,
+) -> list[dict[str, Any]]:
     """Return value-free tag inventory with secret counts."""
 
     normalized_type = (tag_type or "").strip().lower()
     if normalized_type and normalized_type not in {"tag", "skill"}:
         raise VaultServiceError("tag type must be tag or skill")
     counts: dict[str, int] = {}
-    for secret in list_secrets(conn):
+    for secret in list_secrets(conn, user_context=user_context):
         for tag in secret.get("tags", []):
             if isinstance(tag, str) and tag:
                 counts[tag] = counts.get(tag, 0) + 1
@@ -2484,12 +2574,12 @@ def delete_secret(
     audit(conn, "deleted", secret_name=name)
 
 
-def get_secret_policy(conn: Connection, name: str) -> dict[str, Any]:
+def get_secret_policy(conn: Connection, name: str, *, user_context: Any = None) -> dict[str, Any]:
     """Return the secret's non-secret policy dict (allowed_hosts, auth scheme)."""
-    return _loads(_require_row(conn, name).get("policy")) or {}
+    return _loads(require_secret_access(conn, name, user_context=user_context).get("policy")) or {}
 
 
-def get_envelope(conn: Connection, name: str) -> Sealed:
+def get_envelope(conn: Connection, name: str, *, user_context: Any = None) -> Sealed:
     """Return one standard-tier secret's stored envelope (no decrypt, no audit).
 
     For the brokered ``fetch`` proxy: the caller hands the envelope to the avault
@@ -2499,23 +2589,23 @@ def get_envelope(conn: Connection, name: str) -> Sealed:
     Protected delivery must go through :func:`resolve_secret_access` and the
     resident avault agent so Python never opens released DEKs or plaintext.
     """
-    row = _require_row(conn, name)
+    row = require_secret_access(conn, name, user_context=user_context)
     if row.get("protection") != "standard":
         raise UnsupportedProtectionError(f"{name} is protected-tier; use resident-agent grant delivery")
     _reject_keypair_value_delivery(row, name)
     return _row_sealed(row)
 
 
-def get_protected_envelope(conn: Connection, name: str) -> Sealed:
-    row = _require_row(conn, name)
+def get_protected_envelope(conn: Connection, name: str, *, user_context: Any = None) -> Sealed:
+    row = require_secret_access(conn, name, user_context=user_context)
     if row.get("protection") != "protected":
         raise UnsupportedProtectionError(f"{name} is standard-tier")
     _reject_keypair_value_delivery(row, name)
     return _row_sealed(row)
 
 
-def get_protected_record_envelope(conn: Connection, name: str) -> Sealed:
-    row = _require_row(conn, name)
+def get_protected_record_envelope(conn: Connection, name: str, *, user_context: Any = None) -> Sealed:
+    row = require_secret_access(conn, name, user_context=user_context)
     if row.get("protection") != "protected":
         raise UnsupportedProtectionError(f"{name} is standard-tier")
     _reject_keypair_value_delivery(row, name)
@@ -2569,7 +2659,7 @@ def record_reveal_use(
     audit(conn, "revealed", secret_name=name, requester=requester, delivery=delivery, request_id=request_id)
 
 
-def get_envelopes(conn: Connection, names: list[str]) -> dict[str, Sealed]:
+def get_envelopes(conn: Connection, names: list[str], *, user_context: Any = None) -> dict[str, Sealed]:
     """Return the stored envelopes for the requested secrets (standard tier; no decrypt).
 
     Validates the WHOLE batch (all names exist + standard tier) BEFORE returning any, so a
@@ -2578,9 +2668,10 @@ def get_envelopes(conn: Connection, names: list[str]) -> dict[str, Sealed]:
     :func:`record_deliveries` only after the delivery side effect succeeds, so a failed
     delivery never shows as delivered. This layer never decrypts.
     """
+    context = resolve_resource_access_context(user_context)
     out: dict[str, Sealed] = {}
     for name in names:
-        row = _require_row(conn, name)
+        row = _require_secret_resource_access(conn, _require_row(conn, name), context)
         if row.get("protection") != "standard":
             raise UnsupportedProtectionError(f"{name} is protected-tier; use resident-agent grant delivery")
         _reject_keypair_value_delivery(row, name)
@@ -2588,25 +2679,25 @@ def get_envelopes(conn: Connection, names: list[str]) -> dict[str, Sealed]:
     return out
 
 
-def get_key_envelope(conn: Connection, name: str) -> Sealed:
+def get_key_envelope(conn: Connection, name: str, *, user_context: Any = None) -> Sealed:
     """Return a locally-stored key envelope for signing.
 
     This is still envelope-only; the caller hands it to avault (standard tier) or to
     browser-side signing (protected tier). The private key never returns to Python.
     """
-    row = _require_row(conn, name)
+    row = require_secret_access(conn, name, user_context=user_context)
     if row.get("ciphertext") is None or row.get("nonce") is None or row.get("wrap_meta") is None:
         raise VaultServiceError(f"{name} does not have a local key envelope")
     return _row_sealed(row)
 
 
-def get_signing_envelope(conn: Connection, name: str) -> Sealed:
-    row = _require_row(conn, name)
+def get_signing_envelope(conn: Connection, name: str, *, user_context: Any = None) -> Sealed:
+    row = require_secret_access(conn, name, user_context=user_context)
     if row.get("kind") != "keypair":
         raise InvalidRequestError(f"{name} is not a signing key")
     if row.get("signer_kind") not in (None, "local"):
         raise InvalidRequestError(f"{name} is not locally signable")
-    return get_key_envelope(conn, name)
+    return get_key_envelope(conn, name, user_context=user_context)
 
 
 def record_deliveries(conn: Connection, names: list[str], *, requester: Any = None, mode: str | None = None) -> None:
@@ -2781,13 +2872,16 @@ def expand_value_delivery_selector(
     tags: list[str] | None = None,
     skills: list[str] | None = None,
     source_selector: dict[str, Any] | None = None,
+    user_context: Any = None,
 ) -> dict[str, Any]:
     selector = _source_selector_payload(source_selector or {"env": env or [], "tags": tags or [], "skills": skills or []})
+    context = resolve_resource_access_context(user_context)
     selections: list[dict[str, Any]] = []
     env_by_secret: dict[str, str] = {}
     secret_by_env: dict[str, str] = {}
 
     def add_selection(row: dict[str, Any], env_name: str) -> None:
+        _require_secret_resource_access(conn, row, context)
         secret_name = str(row["name"])
         _reject_keypair_value_delivery(row, secret_name)
         existing_env = env_by_secret.get(secret_name)
@@ -2830,8 +2924,9 @@ def _request_member_rows_for_selector(
     conn: Connection,
     *,
     source_selector: dict[str, Any],
+    user_context: Any = None,
 ) -> list[dict[str, Any]]:
-    expanded = expand_value_delivery_selector(conn, source_selector=source_selector)
+    expanded = expand_value_delivery_selector(conn, source_selector=source_selector, user_context=user_context)
     rows: list[dict[str, Any]] = []
     for item in expanded["secrets"]:
         row = _require_row(conn, str(item["name"]))
@@ -2867,20 +2962,40 @@ def _filter_request_rows_to_protected_names(
     return filtered
 
 
-def _member_rows_for_names(conn: Connection, member_names: list[str]) -> list[dict[str, Any]]:
+def _member_rows_for_names(
+    conn: Connection,
+    member_names: list[str],
+    *,
+    user_context: Any = None,
+) -> list[dict[str, Any]]:
+    context = resolve_resource_access_context(user_context)
     rows: list[dict[str, Any]] = []
     for name in member_names:
-        row = _require_row(conn, str(name))
+        row = _require_secret_resource_access(conn, _require_row(conn, str(name)), context)
         _reject_keypair_value_delivery(row, str(name))
         rows.append(row)
     return rows
 
 
-def grantable_member_metas(conn: Connection, member_names: list[str]) -> list[dict[str, Any]]:
-    return [_meta_payload(row) for row in _member_rows_for_names(conn, member_names) if _secret_access_grantable(row)]
+def grantable_member_metas(
+    conn: Connection,
+    member_names: list[str],
+    *,
+    user_context: Any = None,
+) -> list[dict[str, Any]]:
+    return [
+        _meta_payload(row)
+        for row in _member_rows_for_names(conn, member_names, user_context=user_context)
+        if _secret_access_grantable(row)
+    ]
 
 
-def request_grantable_member_metas(conn: Connection, request_id: str) -> list[dict[str, Any]]:
+def request_grantable_member_metas(
+    conn: Connection,
+    request_id: str,
+    *,
+    user_context: Any = None,
+) -> list[dict[str, Any]]:
     row = _load_request_for_transition(
         conn,
         str(request_id),
@@ -2891,7 +3006,7 @@ def request_grantable_member_metas(conn: Connection, request_id: str) -> list[di
         expired_message="grant approval request has expired",
     )
     option = _request_grant_option(row)
-    rows = _member_rows_for_names(conn, option.members)
+    rows = _member_rows_for_names(conn, option.members, user_context=user_context)
     return [_meta_payload(row) for row in rows]
 
 
@@ -2981,25 +3096,27 @@ def create_access_request(
     message_id: str | None = None,
     expires_at: str | None = None,
     audience: str | None = None,
+    user_context: Any = None,
 ) -> dict[str, Any]:
     if purpose not in GRANT_PURPOSES:
         raise InvalidRequestError(f"invalid grant purpose: {purpose!r}")
+    context = resolve_resource_access_context(user_context)
     payload_audience = audience or _request_audience_from_requester(requester)
-    request_id = _id("vrq")
     delivery_payload = dict(delivery or {})
     requester_payload = requester if isinstance(requester, dict) else {}
     default_selector = {"env": [name]} if name else None
     selector = _source_selector_payload(source_selector or default_selector)
-    rows = _request_member_rows_for_selector(conn, source_selector=selector)
+    rows = _request_member_rows_for_selector(conn, source_selector=selector, user_context=context)
     protected_delivery_names = _protected_delivery_names(delivery_payload)
     if protected_delivery_names:
         rows = _filter_request_rows_to_protected_names(rows, protected_delivery_names)
     if name:
-        direct_row = _require_row(conn, name)
+        direct_row = _require_secret_resource_access(conn, _require_row(conn, name), context)
         if not _secret_access_requestable(direct_row):
             raise NotGrantableError(f"{name} is not access-requestable")
     if not rows:
         raise NotGrantableError("selector has no protected or approval-required static secrets")
+    request_id = _id("vrq")
     if len(rows) == 1 and _secret_always_ask(rows[0]) and rows[0].get("protection") == "standard":
         one_shot = True
     else:
@@ -3050,10 +3167,12 @@ def create_sign_request(
     delivery: dict[str, Any] | None = None,
     message_id: str | None = None,
     expires_at: str | None = None,
+    user_context: Any = None,
 ) -> dict[str, Any]:
     if scheme not in SUPPORTED_SIGNATURE_SCHEMES:
         raise InvalidRequestError(f"unsupported signature scheme: {scheme}")
-    row = _require_row(conn, name)
+    context = resolve_resource_access_context(user_context)
+    row = _require_secret_resource_access(conn, _require_row(conn, name), context)
     if row.get("kind") != "keypair":
         raise InvalidRequestError(f"{name} is not a signing key")
     if row.get("signer_kind") not in (None, "local"):
@@ -3831,13 +3950,15 @@ def create_grant(
     expected_member_names: set[str] | list[str] | tuple[str, ...] | None = None,
     cache_ready: bool = True,
     cache: VaultGrantRuntimeCache = GRANT_RUNTIME_CACHE,
+    user_context: Any = None,
 ) -> dict[str, Any]:
     if purpose not in GRANT_PURPOSES:
         raise InvalidGrantError(f"invalid grant purpose: {purpose!r}")
     if not request_id:
         raise InvalidRequestError("grant creation requires an approval request")
+    context = resolve_resource_access_context(user_context)
     selector = _source_selector_payload(source_selector)
-    live_rows = _member_rows_for_names(conn, member_names)
+    live_rows = _member_rows_for_names(conn, member_names, user_context=context)
     live_members = [row["name"] for row in live_rows]
     if not live_members:
         raise NotGrantableError("grant has no static secrets")
@@ -4128,6 +4249,64 @@ def revoke_session_grants(
     return revoked
 
 
+def resource_policy_narrowed(previous: dict[str, Any] | None, updated: dict[str, Any] | None) -> bool:
+    """Whether a Vault ACL update removes access granted by the prior policy."""
+
+    if not previous or not updated:
+        return False
+    previous_level = str(previous.get("access_level") or "")
+    updated_level = str(updated.get("access_level") or "")
+    if previous_level == "public":
+        return updated_level in {"scope", "private"}
+    if previous_level != "scope":
+        return False
+    if updated_level == "private":
+        return True
+    if updated_level != "scope":
+        return False
+    previous_groups = {str(group_id) for group_id in previous.get("group_ids") or [] if isinstance(group_id, str)}
+    updated_groups = {str(group_id) for group_id in updated.get("group_ids") or [] if isinstance(group_id, str)}
+    return not previous_groups.issubset(updated_groups)
+
+
+def revoke_active_grants_for_secret_resource(
+    conn: Connection,
+    resource_id: str,
+    *,
+    cache: VaultGrantRuntimeCache = GRANT_RUNTIME_CACHE,
+    reason: str = "grant-revoked-resource-access-narrowed",
+) -> list[dict[str, Any]]:
+    """Revoke active grants for the Vault secret identified by its ACL resource id."""
+
+    row = conn.execute(select(vault_secrets).where(vault_secrets.c.id == resource_id).limit(1)).mappings().first()
+    if row is None:
+        return []
+    secret_name = str(row["name"])
+    active_rows = active_grant_rows_for_secret(conn, secret_name)
+    if not active_rows:
+        return []
+    now = _now()
+    revoked_rows: list[dict[str, Any]] = []
+    for grant_row in active_rows:
+        result = conn.execute(
+            vault_grants.update()
+            .where(vault_grants.c.id == grant_row["id"], vault_grants.c.status.in_(ACTIVE_GRANT_STATES))
+            .values(status="revoked", revoked_at=now, agent_ready=0, agent_ready_at=None)
+        )
+        if result.rowcount != 1:
+            continue
+        cache.drop(str(grant_row["id"]))
+        audit(
+            conn,
+            reason,
+            secret_name=secret_name,
+            grant_id=str(grant_row["id"]),
+            delivery={"grant_id": str(grant_row["id"]), "resource_id": resource_id},
+        )
+        revoked_rows.append(grant_row)
+    return revoked_rows
+
+
 def find_active_grant_for_secret(
     conn: Connection,
     secret_name: str,
@@ -4296,6 +4475,7 @@ def resolve_secret_access(
     create_request: bool = True,
     cache: VaultGrantRuntimeCache = GRANT_RUNTIME_CACHE,
     reserve_one_shot: bool = False,
+    user_context: Any = None,
 ) -> dict[str, Any]:
     """Resolve an agent access attempt without exposing the value.
 
@@ -4304,7 +4484,8 @@ def resolve_secret_access(
     avault agent; if the agent reports that its in-memory cache is gone, callers
     expire the grant and re-run this resolver to create a fresh approval request.
     """
-    row = _require_row(conn, name)
+    context = resolve_resource_access_context(user_context)
+    row = _require_secret_resource_access(conn, _require_row(conn, name), context)
     if purpose not in GRANT_PURPOSES:
         raise InvalidRequestError(f"invalid grant purpose: {purpose!r}")
     _reject_keypair_value_delivery(row, name)
@@ -4344,6 +4525,7 @@ def resolve_secret_access(
             purpose=purpose,
             requester=requester,
             delivery=delivery_payload,
+            user_context=context,
         )
     return {"status": "approval_required", "secret": _meta_payload(row), "request": request_payload}
 

--- a/storage/workbench_sessions_service.py
+++ b/storage/workbench_sessions_service.py
@@ -956,7 +956,12 @@ def derive_session_harness_activities(conn: Connection, session_id: str) -> list
     return items
 
 
-def archive_session(conn: Connection, session_id: str) -> dict[str, Any]:
+def archive_session(
+    conn: Connection,
+    session_id: str,
+    *,
+    user_context: Any = None,
+) -> dict[str, Any]:
     """Permanently archive a session and reclaim everything bound to it.
 
     Archive is terminal (there is no un-archive) — so we don't just flip a flag,
@@ -978,6 +983,14 @@ def archive_session(conn: Connection, session_id: str) -> dict[str, Any]:
     ).scalar_one_or_none()
     if existing is None:
         raise LookupError(f"Session not found: {session_id}")
+
+    page_exists = conn.execute(
+        select(show_pages.c.session_id).where(show_pages.c.session_id == session_id)
+    ).scalar_one_or_none()
+    if page_exists is not None:
+        from core.show_pages import require_show_page_management
+
+        require_show_page_management(conn, session_id, user_context=user_context)
     now = _utc_now_iso()
 
     # 1) Mark archived + clear any stale "running" dot, and VACATE the thread

--- a/storage/workbench_sessions_service.py
+++ b/storage/workbench_sessions_service.py
@@ -342,16 +342,21 @@ def create_session(
     )
 
     context = resolve_resource_access_context(user_context)
-    if context.is_remote and not agent_name and not agent_id and not agent_backend:
-        default_agent = ensure_default_agent_access(
-            conn,
-            user_context=context,
-            missing_is_error=True,
-        )
-        assert default_agent is not None
-        agent_id = default_agent.id
-        agent_name = default_agent.name
-        agent_backend = default_agent.backend
+    if context.is_remote and not agent_name and not agent_id:
+        if agent_backend:
+            from core.vibe_agents import VibeAgentAccessError
+
+            raise VibeAgentAccessError("Agent access is not permitted.")
+        else:
+            default_agent = ensure_default_agent_access(
+                conn,
+                user_context=context,
+                missing_is_error=True,
+            )
+            assert default_agent is not None
+            agent_id = default_agent.id
+            agent_name = default_agent.name
+            agent_backend = default_agent.backend
 
     if agent_name or agent_id:
         ensure_agent_selection_access(
@@ -446,14 +451,26 @@ def update_session(
         agent_backend = _backend_for_agent_name(conn, str(agent_name or "")) if agent_name else None
         derived_backend = True
 
-    if agent_name is not _UNSET or agent_id is not _UNSET:
-        from core.vibe_agents import ensure_agent_selection_access
+    from core.vibe_agents import VibeAgentAccessError, ensure_agent_selection_access, resolve_resource_access_context
 
+    context = resolve_resource_access_context(user_context)
+    requested_agent_name = "" if agent_name is _UNSET else str(agent_name or "").strip()
+    requested_agent_id = "" if agent_id is _UNSET else str(agent_id or "").strip()
+    if (
+        context.is_remote
+        and agent_backend is not _UNSET
+        and bool(str(agent_backend or "").strip())
+        and not requested_agent_name
+        and not requested_agent_id
+    ):
+        raise VibeAgentAccessError("Agent access is not permitted.")
+
+    if agent_name is not _UNSET or agent_id is not _UNSET:
         ensure_agent_selection_access(
             conn,
             agent_name=None if agent_name is _UNSET else agent_name,
             agent_id=None if agent_id is _UNSET else agent_id,
-            user_context=user_context,
+            user_context=context,
         )
 
     # Backend is pinned once a NATIVE conversation exists: the native can only

--- a/storage/workbench_sessions_service.py
+++ b/storage/workbench_sessions_service.py
@@ -281,6 +281,7 @@ def create_session(
     title: Optional[str] = None,
     visibility: str = "foreground",
     metadata: Optional[dict[str, Any]] = None,
+    user_context: Any = None,
 ) -> dict[str, Any]:
     """Create a session in a Scope or as a standalone session.
 
@@ -333,6 +334,16 @@ def create_session(
             model = scope_row.get("model")
         if reasoning_effort is None:
             reasoning_effort = scope_row.get("reasoning_effort")
+
+    if agent_name or agent_id:
+        from core.vibe_agents import ensure_agent_selection_access
+
+        ensure_agent_selection_access(
+            conn,
+            agent_name=agent_name,
+            agent_id=agent_id,
+            user_context=user_context,
+        )
 
     now = _utc_now_iso()
     variant = agent_variant or agent_backend or "default"
@@ -399,6 +410,7 @@ def update_session(
     visibility: Any = _UNSET,
     pinned: Any = _UNSET,
     scope_id: Any = _UNSET,
+    user_context: Any = None,
 ) -> dict[str, Any]:
     existing = conn.execute(
         select(
@@ -417,6 +429,16 @@ def update_session(
     if agent_name is not _UNSET and agent_backend is _UNSET:
         agent_backend = _backend_for_agent_name(conn, str(agent_name or "")) if agent_name else None
         derived_backend = True
+
+    if agent_name is not _UNSET or agent_id is not _UNSET:
+        from core.vibe_agents import ensure_agent_selection_access
+
+        ensure_agent_selection_access(
+            conn,
+            agent_name=None if agent_name is _UNSET else agent_name,
+            agent_id=None if agent_id is _UNSET else agent_id,
+            user_context=user_context,
+        )
 
     # Backend is pinned once a NATIVE conversation exists: the native can only
     # be resumed by the backend that created it, so switching (or clearing) the

--- a/storage/workbench_sessions_service.py
+++ b/storage/workbench_sessions_service.py
@@ -359,12 +359,18 @@ def create_session(
             agent_backend = default_agent.backend
 
     if agent_name or agent_id:
-        ensure_agent_selection_access(
+        selected_agent = ensure_agent_selection_access(
             conn,
             agent_name=agent_name,
             agent_id=agent_id,
             user_context=context,
         )
+        if selected_agent is not None:
+            if agent_backend and agent_backend != selected_agent.backend:
+                raise ValueError("Agent backend does not match selected Agent")
+            agent_id = selected_agent.id
+            agent_name = selected_agent.name
+            agent_backend = selected_agent.backend
 
     now = _utc_now_iso()
     variant = agent_variant or agent_backend or "default"
@@ -447,31 +453,56 @@ def update_session(
         raise LookupError(f"Session not found: {session_id}")
 
     derived_backend = False
-    if agent_name is not _UNSET and agent_backend is _UNSET:
-        agent_backend = _backend_for_agent_name(conn, str(agent_name or "")) if agent_name else None
-        derived_backend = True
-
-    from core.vibe_agents import VibeAgentAccessError, ensure_agent_selection_access, resolve_resource_access_context
+    from core.vibe_agents import (
+        VibeAgentAccessError,
+        ensure_agent_selection_access,
+        ensure_default_agent_access,
+        resolve_resource_access_context,
+    )
 
     context = resolve_resource_access_context(user_context)
-    requested_agent_name = "" if agent_name is _UNSET else str(agent_name or "").strip()
-    requested_agent_id = "" if agent_id is _UNSET else str(agent_id or "").strip()
-    if (
-        context.is_remote
-        and agent_backend is not _UNSET
-        and bool(str(agent_backend or "").strip())
-        and not requested_agent_name
-        and not requested_agent_id
-    ):
-        raise VibeAgentAccessError("Agent access is not permitted.")
-
-    if agent_name is not _UNSET or agent_id is not _UNSET:
-        ensure_agent_selection_access(
+    selector_changed = agent_name is not _UNSET or agent_id is not _UNSET
+    selected_agent = None
+    if selector_changed:
+        selected_agent = ensure_agent_selection_access(
             conn,
             agent_name=None if agent_name is _UNSET else agent_name,
             agent_id=None if agent_id is _UNSET else agent_id,
             user_context=context,
         )
+        if selected_agent is None and context.is_remote:
+            selected_agent = ensure_default_agent_access(
+                conn,
+                user_context=context,
+                missing_is_error=True,
+            )
+        if selected_agent is not None:
+            requested_backend = str(agent_backend or "").strip() if agent_backend is not _UNSET else ""
+            if requested_backend and requested_backend != selected_agent.backend:
+                raise ValueError("Agent backend does not match selected Agent")
+            agent_id = selected_agent.id
+            agent_name = selected_agent.name
+            if not requested_backend:
+                agent_backend = selected_agent.backend
+                derived_backend = True
+        else:
+            # Preserve legacy local names/ids that predate the Agent catalog,
+            # but clear the omitted half so it cannot remain stale.
+            requested_name = "" if agent_name is _UNSET else str(agent_name or "").strip()
+            requested_id = "" if agent_id is _UNSET else str(agent_id or "").strip()
+            agent_name = requested_name or None
+            agent_id = requested_id or None
+            if agent_backend is _UNSET and requested_name:
+                agent_backend = _backend_for_agent_name(conn, requested_name)
+                derived_backend = True
+
+    if (
+        context.is_remote
+        and agent_backend is not _UNSET
+        and bool(str(agent_backend or "").strip())
+        and selected_agent is None
+    ):
+        raise VibeAgentAccessError("Agent access is not permitted.")
 
     # Backend is pinned once a NATIVE conversation exists: the native can only
     # be resumed by the backend that created it, so switching (or clearing) the

--- a/storage/workbench_sessions_service.py
+++ b/storage/workbench_sessions_service.py
@@ -335,14 +335,30 @@ def create_session(
         if reasoning_effort is None:
             reasoning_effort = scope_row.get("reasoning_effort")
 
-    if agent_name or agent_id:
-        from core.vibe_agents import ensure_agent_selection_access
+    from core.vibe_agents import (
+        ensure_agent_selection_access,
+        ensure_default_agent_access,
+        resolve_resource_access_context,
+    )
 
+    context = resolve_resource_access_context(user_context)
+    if context.is_remote and not agent_name and not agent_id and not agent_backend:
+        default_agent = ensure_default_agent_access(
+            conn,
+            user_context=context,
+            missing_is_error=True,
+        )
+        assert default_agent is not None
+        agent_id = default_agent.id
+        agent_name = default_agent.name
+        agent_backend = default_agent.backend
+
+    if agent_name or agent_id:
         ensure_agent_selection_access(
             conn,
             agent_name=agent_name,
             agent_id=agent_id,
-            user_context=user_context,
+            user_context=context,
         )
 
     now = _utc_now_iso()

--- a/tests/test_remote_access_vibe_cloud.py
+++ b/tests/test_remote_access_vibe_cloud.py
@@ -89,6 +89,109 @@ def test_parse_session_cookie_returns_payload_for_fresh_token() -> None:
     assert payload["instance_id"] == "inst_123"
 
 
+def test_session_cookie_persists_validated_organization_claims() -> None:
+    config = _config()
+    cookie = remote_access.make_session_cookie(
+        config,
+        "member@example.com",
+        "user-1",
+        session_claims={
+            "vibe_instance_id": "inst_123",
+            "vibe_instance_access_source": "organization_group",
+            "vibe_organization_id": "org-1",
+            "vibe_organization_member_id": "member-1",
+            "vibe_organization_role": "member",
+            "vibe_group_ids": ["group-engineering"],
+            "vibe_membership_version": "membership-v2",
+        },
+    )
+
+    payload = remote_access.parse_session_cookie(config, cookie)
+
+    assert payload is not None
+    assert payload["vibe_organization_id"] == "org-1"
+    assert payload["vibe_group_ids"] == ["group-engineering"]
+    assert payload["vibe_membership_version"] == "membership-v2"
+    assert remote_access.session_needs_membership_refresh(
+        payload,
+        now=int(payload["claims_issued_at"]) + remote_access.SESSION_ORGANIZATION_REFRESH_SECONDS,
+    ) is True
+
+
+def test_session_claims_reject_external_guest_organization_context() -> None:
+    config = _config()
+
+    with pytest.raises(remote_access.OAuthCodeExchangeError, match="invalid_organization_claims"):
+        remote_access.session_claims_from_oidc(
+            config,
+            {
+                "vibe_instance_id": "inst_123",
+                "vibe_instance_access_source": "email_domain",
+                "vibe_organization_id": "org-1",
+                "vibe_organization_member_id": "member-1",
+                "vibe_organization_role": "member",
+                "vibe_group_ids": ["group-engineering"],
+            },
+        )
+
+
+def test_exchange_oauth_code_returns_claims_safe_for_the_local_session(monkeypatch) -> None:
+    config = _config()
+
+    class ResponseStub:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {"id_token": "id-token"}
+
+    class JwkClientStub:
+        def __init__(self, uri):
+            self.uri = uri
+
+        def get_signing_key_from_jwt(self, id_token):
+            assert id_token == "id-token"
+            return type("SigningKey", (), {"key": "public-key"})()
+
+    monkeypatch.setattr(remote_access.requests, "post", lambda *args, **kwargs: ResponseStub())
+    monkeypatch.setattr(remote_access, "PyJWKClient", JwkClientStub)
+    monkeypatch.setattr(
+        remote_access.jwt,
+        "decode",
+        lambda *args, **kwargs: {
+            "email": "member@example.com",
+            "sub": "user-1",
+            "email_verified": True,
+            "vibe_instance_id": "inst_123",
+            "vibe_instance_access_source": "organization_group",
+            "vibe_organization_id": "org-1",
+            "vibe_organization_member_id": "member-1",
+            "vibe_organization_role": "member",
+            "vibe_group_ids": ["group-engineering"],
+        },
+    )
+
+    result = remote_access.exchange_oauth_code(config, "code-1", "verifier-1")
+    cookie = remote_access.make_session_cookie(
+        config,
+        result["claims"]["email"],
+        result["claims"]["sub"],
+        session_claims=result["session_claims"],
+    )
+    payload = remote_access.parse_session_cookie(config, cookie)
+
+    assert result["session_claims"] == {
+        "vibe_instance_id": "inst_123",
+        "vibe_instance_access_source": "organization_group",
+        "vibe_organization_id": "org-1",
+        "vibe_organization_member_id": "member-1",
+        "vibe_organization_role": "member",
+        "vibe_group_ids": ["group-engineering"],
+    }
+    assert payload is not None
+    assert payload["vibe_organization_id"] == "org-1"
+
+
 def test_parse_session_cookie_rejects_tampered_signature() -> None:
     config = _config()
     cookie = remote_access.make_session_cookie(config, "alex@example.com", "user-1")
@@ -229,6 +332,7 @@ def test_exchange_oauth_code_allows_30_seconds_of_clock_skew(
             "iat": issued_at,
             "exp": issued_at + 300,
             "vibe_instance_id": config.remote_access.vibe_cloud.instance_id,
+            "vibe_instance_access_source": "owner",
             "email_verified": True,
         },
         private_key,

--- a/tests/test_remote_access_vibe_cloud.py
+++ b/tests/test_remote_access_vibe_cloud.py
@@ -135,6 +135,20 @@ def test_session_claims_reject_external_guest_organization_context() -> None:
         )
 
 
+def test_session_claims_reject_partial_organization_context() -> None:
+    config = _config()
+
+    with pytest.raises(remote_access.OAuthCodeExchangeError, match="invalid_organization_claims"):
+        remote_access.session_claims_from_oidc(
+            config,
+            {
+                "vibe_instance_id": "inst_123",
+                "vibe_instance_access_source": "owner",
+                "vibe_organization_id": None,
+            },
+        )
+
+
 def test_exchange_oauth_code_returns_claims_safe_for_the_local_session(monkeypatch) -> None:
     config = _config()
 

--- a/tests/test_remote_access_vibe_cloud.py
+++ b/tests/test_remote_access_vibe_cloud.py
@@ -2023,3 +2023,20 @@ def test_cloud_token_for_request_returns_none_without_valid_session(monkeypatch)
 
     assert remote_access.cloud_token_for_request(config, None) is None
     assert remote_access.cloud_token_for_request(config, "bogus.cookie") is None
+
+
+def test_cloud_token_for_request_rejects_stale_authorization(monkeypatch) -> None:
+    config = _cloud_broker_config()
+    cookie = remote_session_cookie(config, "alex@example.com", "user-1")
+    mint_called = False
+
+    def fake_mint(*args, **kwargs):
+        nonlocal mint_called
+        mint_called = True
+        return {"access_token": "must-not-mint", "expires_in": 60}
+
+    monkeypatch.setattr(remote_access, "session_needs_authorization_refresh", lambda payload: True)
+    monkeypatch.setattr(remote_access, "mint_cloud_token", fake_mint)
+
+    assert remote_access.cloud_token_for_request(config, cookie) is None
+    assert mint_called is False

--- a/tests/test_remote_access_vibe_cloud.py
+++ b/tests/test_remote_access_vibe_cloud.py
@@ -4,12 +4,14 @@ import ipaddress
 import json
 import threading
 import time
+import urllib.parse
 
 import pytest
 from cryptography.hazmat.primitives.asymmetric import rsa
 
 from config import paths
 from config.v2_config import AgentsConfig, PlatformsConfig, RemoteAccessConfig, RuntimeConfig, SlackConfig, UiConfig, V2Config
+from tests.ui_server_test_helpers import remote_session_cookie
 from vibe import remote_access
 from vibe import runtime
 
@@ -64,7 +66,7 @@ def _config() -> V2Config:
 def test_session_cookie_roundtrip() -> None:
     config = _config()
 
-    cookie = remote_access.make_session_cookie(config, "alex@example.com", "user-1")
+    cookie = remote_session_cookie(config, "alex@example.com", "user-1")
 
     assert remote_access.validate_session_cookie(config, cookie) is True
     assert remote_access.validate_session_cookie(config, cookie + "x") is False
@@ -79,7 +81,7 @@ def test_session_cookie_rejects_empty_session_secret() -> None:
 
 def test_parse_session_cookie_returns_payload_for_fresh_token() -> None:
     config = _config()
-    cookie = remote_access.make_session_cookie(config, "alex@example.com", "user-1")
+    cookie = remote_session_cookie(config, "alex@example.com", "user-1")
 
     payload = remote_access.parse_session_cookie(config, cookie)
 
@@ -87,16 +89,49 @@ def test_parse_session_cookie_returns_payload_for_fresh_token() -> None:
     assert payload["email"] == "alex@example.com"
     assert payload["sub"] == "user-1"
     assert payload["instance_id"] == "inst_123"
+    assert payload["vibe_instance_role"] == "owner"
+
+
+def test_parse_session_cookie_rejects_legacy_roleless_payload() -> None:
+    config = _config()
+    issued_at = int(time.time())
+    payload = {
+        "email": "alex@example.com",
+        "sub": "user-1",
+        "instance_id": "inst_123",
+        "vibe_instance_id": "inst_123",
+        "vibe_instance_access_source": "owner",
+        "iat": issued_at,
+        "exp": issued_at + remote_access.SESSION_TTL_SECONDS,
+    }
+    payload_text = urllib.parse.quote(json.dumps(payload, separators=(",", ":")), safe="")
+    signature = remote_access._session_signature(config.remote_access.vibe_cloud.session_secret, payload_text)
+
+    assert remote_access.parse_session_cookie(config, f"{payload_text}.{signature}") is None
+
+
+def test_session_claims_reject_missing_or_unknown_instance_role() -> None:
+    config = _config()
+    base_claims = {
+        "vibe_instance_id": "inst_123",
+        "vibe_instance_access_source": "owner",
+    }
+
+    with pytest.raises(remote_access.OAuthCodeExchangeError, match="invalid_instance_role"):
+        remote_access.session_claims_from_oidc(config, base_claims)
+    with pytest.raises(remote_access.OAuthCodeExchangeError, match="invalid_instance_role"):
+        remote_access.session_claims_from_oidc(config, {**base_claims, "vibe_instance_role": "admin"})
 
 
 def test_session_cookie_persists_validated_organization_claims() -> None:
     config = _config()
-    cookie = remote_access.make_session_cookie(
+    cookie = remote_session_cookie(
         config,
         "member@example.com",
         "user-1",
         session_claims={
             "vibe_instance_id": "inst_123",
+            "vibe_instance_role": "viewer",
             "vibe_instance_access_source": "organization_group",
             "vibe_organization_id": "org-1",
             "vibe_organization_member_id": "member-1",
@@ -112,27 +147,29 @@ def test_session_cookie_persists_validated_organization_claims() -> None:
     assert payload["vibe_organization_id"] == "org-1"
     assert payload["vibe_group_ids"] == ["group-engineering"]
     assert payload["vibe_membership_version"] == "membership-v2"
-    assert remote_access.session_needs_membership_refresh(
+    assert remote_access.session_needs_authorization_refresh(
         payload,
-        now=int(payload["claims_issued_at"]) + remote_access.SESSION_ORGANIZATION_REFRESH_SECONDS,
+        now=int(payload["claims_issued_at"]) + remote_access.SESSION_AUTHORIZATION_REFRESH_SECONDS,
     ) is True
 
 
-def test_session_claims_reject_external_guest_organization_context() -> None:
+def test_session_claims_accept_organization_member_authorized_by_email() -> None:
     config = _config()
 
-    with pytest.raises(remote_access.OAuthCodeExchangeError, match="invalid_organization_claims"):
-        remote_access.session_claims_from_oidc(
-            config,
-            {
-                "vibe_instance_id": "inst_123",
-                "vibe_instance_access_source": "email_domain",
-                "vibe_organization_id": "org-1",
-                "vibe_organization_member_id": "member-1",
-                "vibe_organization_role": "member",
-                "vibe_group_ids": ["group-engineering"],
-            },
-        )
+    claims = remote_access.session_claims_from_oidc(
+        config,
+        {
+            "vibe_instance_id": "inst_123",
+            "vibe_instance_role": "viewer",
+            "vibe_instance_access_source": "email_domain",
+            "vibe_organization_id": "org-1",
+            "vibe_organization_member_id": "member-1",
+            "vibe_organization_role": "member",
+            "vibe_group_ids": ["group-engineering"],
+        },
+    )
+
+    assert claims["vibe_organization_id"] == "org-1"
 
 
 def test_session_claims_reject_partial_organization_context() -> None:
@@ -143,6 +180,7 @@ def test_session_claims_reject_partial_organization_context() -> None:
             config,
             {
                 "vibe_instance_id": "inst_123",
+                "vibe_instance_role": "owner",
                 "vibe_instance_access_source": "owner",
                 "vibe_organization_id": None,
             },
@@ -177,6 +215,7 @@ def test_exchange_oauth_code_returns_claims_safe_for_the_local_session(monkeypat
             "sub": "user-1",
             "email_verified": True,
             "vibe_instance_id": "inst_123",
+            "vibe_instance_role": "viewer",
             "vibe_instance_access_source": "organization_group",
             "vibe_organization_id": "org-1",
             "vibe_organization_member_id": "member-1",
@@ -186,7 +225,7 @@ def test_exchange_oauth_code_returns_claims_safe_for_the_local_session(monkeypat
     )
 
     result = remote_access.exchange_oauth_code(config, "code-1", "verifier-1")
-    cookie = remote_access.make_session_cookie(
+    cookie = remote_session_cookie(
         config,
         result["claims"]["email"],
         result["claims"]["sub"],
@@ -196,6 +235,7 @@ def test_exchange_oauth_code_returns_claims_safe_for_the_local_session(monkeypat
 
     assert result["session_claims"] == {
         "vibe_instance_id": "inst_123",
+        "vibe_instance_role": "viewer",
         "vibe_instance_access_source": "organization_group",
         "vibe_organization_id": "org-1",
         "vibe_organization_member_id": "member-1",
@@ -208,7 +248,7 @@ def test_exchange_oauth_code_returns_claims_safe_for_the_local_session(monkeypat
 
 def test_parse_session_cookie_rejects_tampered_signature() -> None:
     config = _config()
-    cookie = remote_access.make_session_cookie(config, "alex@example.com", "user-1")
+    cookie = remote_session_cookie(config, "alex@example.com", "user-1")
 
     assert remote_access.parse_session_cookie(config, cookie + "x") is None
 
@@ -227,7 +267,7 @@ def test_make_session_cookie_requires_session_secret() -> None:
     config.remote_access.vibe_cloud.session_secret = ""
 
     with pytest.raises(ValueError, match="session secret"):
-        remote_access.make_session_cookie(config, "alex@example.com", "user-1")
+        remote_session_cookie(config, "alex@example.com", "user-1")
 
 
 def test_exchange_oauth_code_wraps_token_endpoint_rejection(monkeypatch) -> None:
@@ -346,6 +386,7 @@ def test_exchange_oauth_code_allows_30_seconds_of_clock_skew(
             "iat": issued_at,
             "exp": issued_at + 300,
             "vibe_instance_id": config.remote_access.vibe_cloud.instance_id,
+            "vibe_instance_role": "owner",
             "vibe_instance_access_source": "owner",
             "email_verified": True,
         },
@@ -1932,7 +1973,7 @@ def test_mint_cloud_token_returns_none_on_backend_error(monkeypatch) -> None:
 
 def test_cloud_token_for_request_mints_for_authenticated_user(monkeypatch) -> None:
     config = _cloud_broker_config()
-    cookie = remote_access.make_session_cookie(config, "alex@example.com", "user-1")
+    cookie = remote_session_cookie(config, "alex@example.com", "user-1")
 
     monkeypatch.setattr(
         remote_access,

--- a/tests/test_remote_access_vibe_cloud.py
+++ b/tests/test_remote_access_vibe_cloud.py
@@ -153,6 +153,29 @@ def test_session_cookie_persists_validated_organization_claims() -> None:
     ) is True
 
 
+def test_session_cookie_rejects_organization_claims_that_exceed_browser_limits() -> None:
+    config = _config()
+    group_ids = [f"00000000-0000-4000-8000-{index:012d}" for index in range(100)]
+
+    with pytest.raises(remote_access.OAuthCodeExchangeError) as error:
+        remote_access.make_session_cookie(
+            config,
+            "member@example.com",
+            "user-1",
+            session_claims={
+                "vibe_instance_id": "inst_123",
+                "vibe_instance_role": "viewer",
+                "vibe_instance_access_source": "organization_group",
+                "vibe_organization_id": "org-1",
+                "vibe_organization_member_id": "member-1",
+                "vibe_organization_role": "member",
+                "vibe_group_ids": group_ids,
+            },
+        )
+
+    assert error.value.reason == "session_cookie_too_large"
+
+
 def test_session_claims_accept_organization_member_authorized_by_email() -> None:
     config = _config()
 

--- a/tests/test_remote_resource_acl_sync.py
+++ b/tests/test_remote_resource_acl_sync.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from config import paths
+from config.v2_config import AgentsConfig, PlatformsConfig, RemoteAccessConfig, RuntimeConfig, SlackConfig, UiConfig, V2Config
+from storage import resource_access_service
+from storage.db import get_cached_sqlite_engine
+from storage.migrations import run_migrations
+from vibe import remote_access
+
+
+@dataclass
+class _Response:
+    payload: dict[str, Any]
+    status_code: int = 200
+
+    def json(self) -> dict[str, Any]:
+        return self.payload
+
+
+def _config() -> V2Config:
+    config = V2Config(
+        mode="self_host",
+        version="v2",
+        platform="slack",
+        platforms=PlatformsConfig(enabled=["slack"], primary="slack"),
+        slack=SlackConfig(bot_token=""),
+        runtime=RuntimeConfig(default_cwd="."),
+        agents=AgentsConfig(),
+        ui=UiConfig(),
+        remote_access=RemoteAccessConfig(),
+    )
+    cloud = config.remote_access.vibe_cloud
+    cloud.enabled = True
+    cloud.backend_url = "https://backend.test"
+    cloud.instance_id = "inst-1"
+    cloud.instance_secret = "paired-device-secret"
+    return config
+
+
+def _seed_policy() -> None:
+    paths.ensure_data_dirs()
+    run_migrations()
+    engine = get_cached_sqlite_engine()
+    with engine.begin() as connection:
+        resource_access_service.ensure_resource_policy(
+            connection,
+            resource_kind="agent",
+            resource_id="agent-1",
+            organization_id="org-1",
+            owner_user_id="owner-1",
+            access_level="private",
+            policy_revision=1,
+            last_applied_control_plane_revision=1,
+        )
+
+
+def _descriptor() -> dict[str, Any]:
+    return {
+        "resource_kind": "agent",
+        "resource_id": "agent-1",
+        "display_name": "Research agent",
+        "owner_user_id": "owner-1",
+        "metadata_revision": 1,
+        "applied_acl_revision": 1,
+        "access_level": "private",
+        "group_ids": [],
+    }
+
+
+def test_sync_applies_only_newer_intent_and_acknowledges_exact_revision(monkeypatch) -> None:
+    _seed_policy()
+    config = _config()
+    calls: list[dict[str, Any]] = []
+    responses = iter(
+        [
+            _Response({"organization_id": "org-1", "resources": []}),
+            _Response(
+                {
+                    "organization_id": "org-1",
+                    "poll_after_seconds": 30,
+                    "intents": [
+                        {
+                            "resource_kind": "agent",
+                            "resource_id": "agent-1",
+                            "revision": 2,
+                            "access_level": "scope",
+                            "group_ids": ["group-engineering"],
+                        }
+                    ],
+                }
+            ),
+            _Response({"resource": {"resource_kind": "agent", "resource_id": "agent-1"}}),
+            _Response({"organization_id": "org-1", "resources": []}),
+            _Response(
+                {
+                    "organization_id": "org-1",
+                    "poll_after_seconds": 30,
+                    "intents": [
+                        {
+                            "resource_kind": "agent",
+                            "resource_id": "agent-1",
+                            "revision": 1,
+                            "access_level": "private",
+                            "group_ids": [],
+                        }
+                    ],
+                }
+            ),
+        ]
+    )
+
+    def request(method: str, url: str, **kwargs: Any) -> _Response:
+        calls.append({"method": method, "url": url, **kwargs})
+        return next(responses)
+
+    monkeypatch.setattr(remote_access.requests, "request", request)
+
+    first = remote_access.sync_resource_acl_once(
+        config,
+        organization_id="org-1",
+        resources=[_descriptor()],
+    )
+    second = remote_access.sync_resource_acl_once(
+        config,
+        organization_id="org-1",
+        resources=[_descriptor()],
+    )
+
+    assert first["ok"] is True
+    assert first["organizations"][0]["applied"] == 1
+    assert second["ok"] is True
+    assert second["organizations"][0]["skipped"] == 1
+    assert [call["method"] for call in calls] == ["PUT", "GET", "POST", "PUT", "GET"]
+    assert calls[0]["headers"]["X-Vibe-Device-Secret"] == "paired-device-secret"
+    assert set(calls[0]["json"]["resources"][0]) <= {
+        "resource_id",
+        "resource_kind",
+        "display_name",
+        "owner_user_id",
+        "metadata_revision",
+        "applied_acl_revision",
+        "access_level",
+        "group_ids",
+        "sync_status",
+    }
+    assert calls[2]["json"] == {
+        "resource_kind": "agent",
+        "resource_id": "agent-1",
+        "revision": 2,
+        "outcome": "applied",
+    }
+
+    engine = get_cached_sqlite_engine()
+    with engine.connect() as connection:
+        policy = resource_access_service.get_resource_policy("agent", "agent-1", connection=connection)
+    assert policy is not None
+    assert policy["access_level"] == "scope"
+    assert policy["group_ids"] == ["group-engineering"]
+    assert policy["last_applied_control_plane_revision"] == 2
+
+
+def test_sync_offline_retains_last_applied_policy(monkeypatch) -> None:
+    _seed_policy()
+    config = _config()
+
+    def request(*_args: Any, **_kwargs: Any):
+        raise remote_access.requests.ConnectionError("offline")
+
+    monkeypatch.setattr(remote_access.requests, "request", request)
+
+    result = remote_access.sync_resource_acl_once(
+        config,
+        organization_id="org-1",
+        resources=[_descriptor()],
+    )
+
+    assert result["ok"] is False
+    assert result["organizations"][0]["error"] == "resource_acl_sync_failed"
+    engine = get_cached_sqlite_engine()
+    with engine.connect() as connection:
+        policy = resource_access_service.get_resource_policy("agent", "agent-1", connection=connection)
+    assert policy is not None
+    assert policy["access_level"] == "private"
+    assert policy["last_applied_control_plane_revision"] == 1

--- a/tests/test_remote_resource_acl_sync.py
+++ b/tests/test_remote_resource_acl_sync.py
@@ -185,3 +185,52 @@ def test_sync_offline_retains_last_applied_policy(monkeypatch) -> None:
     assert policy is not None
     assert policy["access_level"] == "private"
     assert policy["last_applied_control_plane_revision"] == 1
+
+
+def test_sync_publishes_empty_index_after_last_organization_policy_is_deleted(monkeypatch) -> None:
+    _seed_policy()
+    config = _config()
+    engine = get_cached_sqlite_engine()
+    with engine.begin() as connection:
+        assert resource_access_service.delete_resource_policy(
+            connection,
+            "agent",
+            "agent-1",
+        )
+    assert resource_access_service.list_resource_organization_ids() == ["org-1"]
+
+    def offline_request(*_args: Any, **_kwargs: Any):
+        raise remote_access.requests.ConnectionError("offline")
+
+    monkeypatch.setattr(remote_access.requests, "request", offline_request)
+    offline = remote_access.sync_resource_acl_once(config)
+    assert offline["ok"] is False
+    assert resource_access_service.list_resource_organization_ids() == ["org-1"]
+
+    calls: list[dict[str, Any]] = []
+    responses = iter(
+        [
+            _Response({"organization_id": "org-1", "resources": []}),
+            _Response(
+                {
+                    "organization_id": "org-1",
+                    "poll_after_seconds": 30,
+                    "intents": [],
+                }
+            ),
+        ]
+    )
+
+    def request(method: str, url: str, **kwargs: Any) -> _Response:
+        calls.append({"method": method, "url": url, **kwargs})
+        return next(responses)
+
+    monkeypatch.setattr(remote_access.requests, "request", request)
+
+    result = remote_access.sync_resource_acl_once(config)
+
+    assert result["ok"] is True
+    assert result["organizations"][0]["organization_id"] == "org-1"
+    assert [call["method"] for call in calls] == ["PUT", "GET"]
+    assert calls[0]["json"]["resources"] == []
+    assert resource_access_service.list_resource_organization_ids() == []

--- a/tests/test_remote_resource_acl_sync.py
+++ b/tests/test_remote_resource_acl_sync.py
@@ -234,3 +234,29 @@ def test_sync_publishes_empty_index_after_last_organization_policy_is_deleted(mo
     assert [call["method"] for call in calls] == ["PUT", "GET"]
     assert calls[0]["json"]["resources"] == []
     assert resource_access_service.list_resource_organization_ids() == []
+
+
+def test_poll_delay_honors_successful_organization_backoff() -> None:
+    result = {
+        "ok": False,
+        "organizations": [
+            {"organization_id": "org-1", "ok": True, "poll_after_seconds": 45},
+            {"organization_id": "org-2", "ok": True, "poll_after_seconds": 120},
+            {"organization_id": "org-3", "ok": False, "poll_after_seconds": 300},
+        ],
+    }
+
+    assert remote_access._resource_acl_poll_delay(result, 30) == 120
+
+
+def test_poll_delay_falls_back_without_valid_successful_result() -> None:
+    result = {
+        "ok": False,
+        "organizations": [
+            {"organization_id": "org-1", "ok": False, "poll_after_seconds": 120},
+            {"organization_id": "org-2", "ok": True, "poll_after_seconds": 0},
+            {"organization_id": "org-3", "ok": True, "poll_after_seconds": "invalid"},
+        ],
+    }
+
+    assert remote_access._resource_acl_poll_delay(result, 30) == 30

--- a/tests/test_remote_resource_acl_sync.py
+++ b/tests/test_remote_resource_acl_sync.py
@@ -236,6 +236,35 @@ def test_sync_publishes_empty_index_after_last_organization_policy_is_deleted(mo
     assert resource_access_service.list_resource_organization_ids() == []
 
 
+def test_malformed_intent_keeps_empty_organization_queued_for_retry(monkeypatch) -> None:
+    _seed_policy()
+    config = _config()
+    engine = get_cached_sqlite_engine()
+    with engine.begin() as connection:
+        assert resource_access_service.delete_resource_policy(connection, "agent", "agent-1")
+
+    responses = iter(
+        [
+            _Response({"organization_id": "org-1", "resources": []}),
+            _Response(
+                {
+                    "organization_id": "org-1",
+                    "poll_after_seconds": 30,
+                    "intents": [{"resource_kind": "invalid"}],
+                }
+            ),
+        ]
+    )
+    monkeypatch.setattr(remote_access.requests, "request", lambda *_args, **_kwargs: next(responses))
+
+    result = remote_access.sync_resource_acl_once(config)
+
+    assert result["ok"] is False
+    assert result["organizations"][0]["rejected"] == 1
+    assert result["organizations"][0]["ack_errors"] == 1
+    assert resource_access_service.list_resource_organization_ids() == ["org-1"]
+
+
 def test_poll_delay_honors_successful_organization_backoff() -> None:
     result = {
         "ok": False,

--- a/tests/test_remote_resource_acl_sync.py
+++ b/tests/test_remote_resource_acl_sync.py
@@ -265,6 +265,63 @@ def test_malformed_intent_keeps_empty_organization_queued_for_retry(monkeypatch)
     assert resource_access_service.list_resource_organization_ids() == ["org-1"]
 
 
+def test_transient_apply_failure_leaves_intent_unacknowledged(monkeypatch) -> None:
+    _seed_policy()
+    config = _config()
+    calls: list[dict[str, Any]] = []
+    responses = iter(
+        [
+            _Response({"organization_id": "org-1", "resources": []}),
+            _Response(
+                {
+                    "organization_id": "org-1",
+                    "poll_after_seconds": 30,
+                    "intents": [
+                        {
+                            "resource_kind": "agent",
+                            "resource_id": "agent-1",
+                            "revision": 2,
+                            "access_level": "public",
+                            "group_ids": [],
+                        }
+                    ],
+                }
+            ),
+        ]
+    )
+
+    def request(method: str, url: str, **kwargs: Any) -> _Response:
+        calls.append({"method": method, "url": url, **kwargs})
+        return next(responses)
+
+    monkeypatch.setattr(remote_access.requests, "request", request)
+    monkeypatch.setattr(
+        resource_access_service,
+        "apply_control_plane_intent",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError("database is busy")),
+    )
+
+    result = remote_access.sync_resource_acl_once(
+        config,
+        organization_id="org-1",
+        resources=[_descriptor()],
+    )
+
+    organization = result["organizations"][0]
+    assert result["ok"] is False
+    assert organization["rejected"] == 0
+    assert organization["acknowledged"] == 0
+    assert organization["ack_errors"] == 1
+    assert [call["method"] for call in calls] == ["PUT", "GET"]
+
+    engine = get_cached_sqlite_engine()
+    with engine.connect() as connection:
+        policy = resource_access_service.get_resource_policy("agent", "agent-1", connection=connection)
+    assert policy is not None
+    assert policy["access_level"] == "private"
+    assert policy["last_applied_control_plane_revision"] == 1
+
+
 def test_poll_delay_honors_successful_organization_backoff() -> None:
     result = {
         "ok": False,

--- a/tests/test_resource_access_service.py
+++ b/tests/test_resource_access_service.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import pytest
+
 from storage import resource_access_service
 from storage.db import create_sqlite_engine
 from storage.migrations import run_migrations
@@ -102,5 +104,24 @@ def test_no_policy_is_local_private_but_instance_owner_keeps_legacy_access(tmp_p
             assert not resource_access_service.can_use_resource(member, "agent", "legacy-agent", connection=connection)
             assert resource_access_service.can_use_resource(owner, "agent", "legacy-agent", connection=connection)
             assert resource_access_service.can_use_resource(local, "agent", "legacy-agent", connection=connection)
+    finally:
+        engine.dispose()
+
+
+def test_personal_resources_cannot_use_organization_access_levels(tmp_path) -> None:
+    db = tmp_path / "vibe.sqlite"
+    run_migrations(db)
+    engine = create_sqlite_engine(db)
+    try:
+        with engine.begin() as connection:
+            with pytest.raises(resource_access_service.ResourceAccessError, match="invalid_resource_acl_intent"):
+                resource_access_service.ensure_resource_policy(
+                    connection,
+                    resource_kind="agent",
+                    resource_id="personal-agent",
+                    organization_id=None,
+                    owner_user_id="owner-1",
+                    access_level="public",
+                )
     finally:
         engine.dispose()

--- a/tests/test_resource_access_service.py
+++ b/tests/test_resource_access_service.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from storage import resource_access_service
+from storage.db import create_sqlite_engine
+from storage.migrations import run_migrations
+
+
+def _context(
+    subject: str,
+    *,
+    organization_id: str | None = "org-1",
+    group_ids: frozenset[str] | None = frozenset(),
+    role: str | None = "member",
+    access_source: str = "organization_group",
+) -> resource_access_service.ResourceUserContext:
+    return resource_access_service.ResourceUserContext(
+        subject=subject,
+        organization_id=organization_id,
+        organization_member_id="member-1" if organization_id else None,
+        organization_role=role,
+        group_ids=group_ids,
+        instance_access_source=access_source,
+        is_remote=True,
+    )
+
+
+def _seed_policies(connection) -> None:
+    resource_access_service.ensure_resource_policy(
+        connection,
+        resource_kind="agent",
+        resource_id="private-agent",
+        organization_id="org-1",
+        owner_user_id="owner-1",
+        access_level="private",
+    )
+    resource_access_service.ensure_resource_policy(
+        connection,
+        resource_kind="agent",
+        resource_id="public-agent",
+        organization_id="org-1",
+        owner_user_id="owner-1",
+        access_level="public",
+    )
+    resource_access_service.ensure_resource_policy(
+        connection,
+        resource_kind="agent",
+        resource_id="scoped-agent",
+        organization_id="org-1",
+        owner_user_id="owner-1",
+        access_level="scope",
+        group_ids=["group-engineering"],
+    )
+
+
+def test_policy_evaluation_private_public_scope_and_missing_group_context(tmp_path) -> None:
+    db = tmp_path / "vibe.sqlite"
+    run_migrations(db)
+    engine = create_sqlite_engine(db)
+    try:
+        with engine.begin() as connection:
+            _seed_policies(connection)
+
+            owner = _context("owner-1")
+            engineering_member = _context("member-2", group_ids=frozenset({"group-engineering"}))
+            member_without_groups = _context("member-3", group_ids=None)
+            member_other_group = _context("member-4", group_ids=frozenset({"group-sales"}))
+            outside_org = _context("member-5", organization_id="org-2", group_ids=frozenset({"group-engineering"}))
+
+            assert resource_access_service.can_use_resource(owner, "agent", "private-agent", connection=connection)
+            assert not resource_access_service.can_use_resource(
+                engineering_member, "agent", "private-agent", connection=connection
+            )
+
+            assert resource_access_service.can_use_resource(
+                engineering_member, "agent", "public-agent", connection=connection
+            )
+            assert not resource_access_service.can_use_resource(outside_org, "agent", "public-agent", connection=connection)
+
+            assert resource_access_service.can_use_resource(
+                engineering_member, "agent", "scoped-agent", connection=connection
+            )
+            assert not resource_access_service.can_use_resource(
+                member_without_groups, "agent", "scoped-agent", connection=connection
+            )
+            assert not resource_access_service.can_use_resource(
+                member_other_group, "agent", "scoped-agent", connection=connection
+            )
+    finally:
+        engine.dispose()
+
+
+def test_no_policy_is_local_private_but_instance_owner_keeps_legacy_access(tmp_path) -> None:
+    db = tmp_path / "vibe.sqlite"
+    run_migrations(db)
+    engine = create_sqlite_engine(db)
+    try:
+        with engine.connect() as connection:
+            member = _context("member-1", group_ids=frozenset({"group-engineering"}))
+            owner = _context("owner-1", access_source="owner")
+            local = resource_access_service.ResourceUserContext(is_trusted_local=True)
+
+            assert not resource_access_service.can_use_resource(member, "agent", "legacy-agent", connection=connection)
+            assert resource_access_service.can_use_resource(owner, "agent", "legacy-agent", connection=connection)
+            assert resource_access_service.can_use_resource(local, "agent", "legacy-agent", connection=connection)
+    finally:
+        engine.dispose()

--- a/tests/test_resource_access_service.py
+++ b/tests/test_resource_access_service.py
@@ -13,6 +13,7 @@ def _context(
     organization_id: str | None = "org-1",
     group_ids: frozenset[str] | None = frozenset(),
     role: str | None = "member",
+    instance_role: str = "viewer",
     access_source: str = "organization_group",
 ) -> resource_access_service.ResourceUserContext:
     return resource_access_service.ResourceUserContext(
@@ -21,6 +22,7 @@ def _context(
         organization_member_id="member-1" if organization_id else None,
         organization_role=role,
         group_ids=group_ids,
+        instance_role=instance_role,
         instance_access_source=access_source,
         is_remote=True,
     )
@@ -98,11 +100,18 @@ def test_no_policy_is_local_private_but_instance_owner_keeps_legacy_access(tmp_p
     try:
         with engine.connect() as connection:
             member = _context("member-1", group_ids=frozenset({"group-engineering"}))
-            owner = _context("owner-1", access_source="owner")
+            owner = _context("owner-1", instance_role="owner", access_source="owner")
+            diagnostic_owner = _context("member-2", instance_role="viewer", access_source="owner")
             local = resource_access_service.ResourceUserContext(is_trusted_local=True)
 
             assert not resource_access_service.can_use_resource(member, "agent", "legacy-agent", connection=connection)
             assert resource_access_service.can_use_resource(owner, "agent", "legacy-agent", connection=connection)
+            assert not resource_access_service.can_use_resource(
+                diagnostic_owner,
+                "agent",
+                "legacy-agent",
+                connection=connection,
+            )
             assert resource_access_service.can_use_resource(local, "agent", "legacy-agent", connection=connection)
     finally:
         engine.dispose()

--- a/tests/test_resource_access_service.py
+++ b/tests/test_resource_access_service.py
@@ -134,6 +134,39 @@ def test_request_context_resolution_failure_does_not_become_trusted_local(monkey
     assert local_context.is_trusted_local is True
 
 
+def test_deferred_remote_context_expires_at_authorization_refresh_boundary() -> None:
+    from vibe import remote_access
+
+    issued_at = 1_700_000_000
+    context = resource_access_service.ResourceUserContext(
+        subject="member-1",
+        organization_id="org-1",
+        organization_member_id="organization-member-1",
+        organization_role="member",
+        group_ids=frozenset({"group-engineering"}),
+        membership_version="membership-v2",
+        instance_role="viewer",
+        instance_access_source="organization_group",
+        claims_issued_at=issued_at,
+        is_remote=True,
+    )
+
+    metadata = resource_access_service.metadata_with_resource_user_context({}, context)
+    expires_at = issued_at + remote_access.SESSION_AUTHORIZATION_REFRESH_SECONDS
+
+    restored = resource_access_service.resource_user_context_from_metadata(
+        metadata,
+        now=expires_at - 1,
+    )
+    assert restored is not None
+    assert restored.subject == "member-1"
+    with pytest.raises(resource_access_service.ResourceAccessError, match="resource_authorization_expired"):
+        resource_access_service.resource_user_context_from_metadata(
+            metadata,
+            now=expires_at,
+        )
+
+
 def test_personal_resources_cannot_use_organization_access_levels(tmp_path) -> None:
     db = tmp_path / "vibe.sqlite"
     run_migrations(db)

--- a/tests/test_resource_access_service.py
+++ b/tests/test_resource_access_service.py
@@ -117,6 +117,23 @@ def test_no_policy_is_local_private_but_instance_owner_keeps_legacy_access(tmp_p
         engine.dispose()
 
 
+def test_request_context_resolution_failure_does_not_become_trusted_local(monkeypatch) -> None:
+    from vibe.ui_server import app
+
+    monkeypatch.setattr(
+        resource_access_service,
+        "current_resource_context",
+        lambda *args, **kwargs: resource_access_service.ResourceUserContext(),
+    )
+
+    with app.test_request_context("/api/agents", base_url="https://alex.avibe.bot"):
+        request_context = resource_access_service.resolve_resource_access_context()
+    local_context = resource_access_service.resolve_resource_access_context()
+
+    assert request_context.is_trusted_local is False
+    assert local_context.is_trusted_local is True
+
+
 def test_personal_resources_cannot_use_organization_access_levels(tmp_path) -> None:
     db = tmp_path / "vibe.sqlite"
     run_migrations(db)

--- a/tests/test_resource_access_service.py
+++ b/tests/test_resource_access_service.py
@@ -117,6 +117,56 @@ def test_no_policy_is_local_private_but_instance_owner_keeps_legacy_access(tmp_p
         engine.dispose()
 
 
+def test_removed_org_owner_loses_org_private_resources_but_keeps_personal_resources(tmp_path) -> None:
+    db = tmp_path / "vibe.sqlite"
+    run_migrations(db)
+    engine = create_sqlite_engine(db)
+    try:
+        with engine.begin() as connection:
+            _seed_policies(connection)
+            resource_access_service.ensure_resource_policy(
+                connection,
+                resource_kind="agent",
+                resource_id="personal-agent",
+                organization_id=None,
+                owner_user_id="owner-1",
+                access_level="private",
+            )
+            removed_owner = _context(
+                "owner-1",
+                organization_id=None,
+                role=None,
+                access_source="email_invitation",
+            )
+
+            assert not resource_access_service.can_use_resource(
+                removed_owner,
+                "agent",
+                "private-agent",
+                connection=connection,
+            )
+            assert not resource_access_service.can_manage_resource_acl(
+                removed_owner,
+                "agent",
+                "private-agent",
+                connection=connection,
+            )
+            assert resource_access_service.can_use_resource(
+                removed_owner,
+                "agent",
+                "personal-agent",
+                connection=connection,
+            )
+            assert resource_access_service.can_manage_resource_acl(
+                removed_owner,
+                "agent",
+                "personal-agent",
+                connection=connection,
+            )
+    finally:
+        engine.dispose()
+
+
 def test_request_context_resolution_failure_does_not_become_trusted_local(monkeypatch) -> None:
     from vibe.ui_server import app
 

--- a/tests/test_resource_acl_agents.py
+++ b/tests/test_resource_acl_agents.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+import pytest
+
+from core.scheduled_tasks import ScheduledTaskStore
+from core.vibe_agents import VibeAgent, VibeAgentAccessError, VibeAgentStore
+from core.watches import ManagedWatchStore
+from storage import resource_access_service, workbench_sessions_service
+from storage.db import get_cached_sqlite_engine
+from storage.settings_service import upsert_scope
+from tests.test_ui_remote_access_auth import _remote_peer, _save_config
+from tests.ui_server_test_helpers import csrf_headers
+from vibe import remote_access
+from vibe.ui_server import app
+
+
+def _organization_context(
+    subject: str,
+    *,
+    group_ids: frozenset[str] | None = frozenset({"group-engineering"}),
+) -> resource_access_service.ResourceUserContext:
+    return resource_access_service.ResourceUserContext(
+        subject=subject,
+        email=f"{subject}@example.com",
+        organization_id="org-1",
+        organization_member_id=f"member-{subject}",
+        organization_role="member",
+        group_ids=group_ids,
+        instance_access_source="organization_group",
+        is_remote=True,
+    )
+
+
+def _organization_cookie(config, *, subject: str, groups: list[str] | None = None) -> str:
+    claims = {
+        "vibe_instance_id": "inst_123",
+        "vibe_instance_access_source": "organization_group",
+        "vibe_organization_id": "org-1",
+        "vibe_organization_member_id": f"member-{subject}",
+        "vibe_organization_role": "member",
+        "vibe_membership_version": "membership-v2",
+    }
+    if groups is not None:
+        claims["vibe_group_ids"] = groups
+    return remote_access.make_session_cookie(
+        config,
+        f"{subject}@example.com",
+        subject,
+        session_claims=claims,
+    )
+
+
+def _seed_agents_with_policies() -> tuple[VibeAgentStore, dict[str, VibeAgent]]:
+    store = VibeAgentStore()
+    agents = {
+        "private": store.create(name="private-agent", backend="codex"),
+        "public": store.create(name="public-agent", backend="codex"),
+        "scope": store.create(name="scope-agent", backend="codex"),
+    }
+    with store.engine.begin() as connection:
+        resource_access_service.ensure_resource_policy(
+            connection,
+            resource_kind="agent",
+            resource_id=agents["private"].id,
+            organization_id="org-1",
+            owner_user_id="owner-1",
+            access_level="private",
+        )
+        resource_access_service.ensure_resource_policy(
+            connection,
+            resource_kind="agent",
+            resource_id=agents["public"].id,
+            organization_id="org-1",
+            owner_user_id="owner-1",
+            access_level="public",
+        )
+        resource_access_service.ensure_resource_policy(
+            connection,
+            resource_kind="agent",
+            resource_id=agents["scope"].id,
+            organization_id="org-1",
+            owner_user_id="owner-1",
+            access_level="scope",
+            group_ids=["group-engineering"],
+        )
+    return store, agents
+
+
+def test_agent_catalog_filters_private_public_scope_and_missing_group_context(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    store, _agents = _seed_agents_with_policies()
+    try:
+        owner_names = {agent.name for agent in store.list_agents(user_context=_organization_context("owner-1"))}
+        member_names = {agent.name for agent in store.list_agents(user_context=_organization_context("member-1"))}
+        no_group_names = {
+            agent.name
+            for agent in store.list_agents(user_context=_organization_context("member-2", group_ids=None))
+        }
+    finally:
+        store.close()
+
+    assert owner_names == {"private-agent", "public-agent", "scope-agent"}
+    assert member_names == {"public-agent", "scope-agent"}
+    assert no_group_names == {"public-agent"}
+
+
+def test_remote_agent_creation_defaults_to_private_organization_policy(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    config = _save_config(tmp_path)
+    client = app.test_client()
+    client.set_cookie(
+        remote_access.SESSION_COOKIE_NAME,
+        _organization_cookie(config, subject="member-1", groups=["group-engineering"]),
+        domain="alex.avibe.bot",
+    )
+
+    response = client.post(
+        "/api/agents",
+        json={"name": "remote-private", "backend": "codex"},
+        headers=csrf_headers(client, "https://alex.avibe.bot"),
+        base_url="https://alex.avibe.bot",
+        environ_base=_remote_peer(),
+    )
+
+    assert response.status_code == 200
+    agent_id = response.get_json()["agent"]["id"]
+    engine = get_cached_sqlite_engine()
+    with engine.connect() as connection:
+        policy = resource_access_service.get_resource_policy("agent", agent_id, connection=connection)
+    assert policy is not None
+    assert policy["organization_id"] == "org-1"
+    assert policy["owner_user_id"] == "member-1"
+    assert policy["access_level"] == "private"
+
+
+def test_remote_agent_request_and_selection_reject_inaccessible_agent(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    config = _save_config(tmp_path)
+    store, agents = _seed_agents_with_policies()
+    store.close()
+    private_agent = agents["private"]
+    context = _organization_context("member-1")
+
+    client = app.test_client()
+    client.set_cookie(
+        remote_access.SESSION_COOKIE_NAME,
+        _organization_cookie(config, subject="member-1", groups=["group-engineering"]),
+        domain="alex.avibe.bot",
+    )
+    response = client.get(
+        "/api/agents/private-agent",
+        base_url="https://alex.avibe.bot",
+        environ_base=_remote_peer(),
+    )
+
+    assert response.status_code == 403
+    assert response.get_json()["code"] == "agent_access_forbidden"
+    catalog = client.get(
+        "/api/agents",
+        base_url="https://alex.avibe.bot",
+        environ_base=_remote_peer(),
+    )
+    assert catalog.status_code == 200
+    assert {agent["name"] for agent in catalog.get_json()["agents"]} == {"public-agent", "scope-agent"}
+
+    engine = get_cached_sqlite_engine()
+    with engine.begin() as connection:
+        scope_id = upsert_scope(
+            connection,
+            platform="avibe",
+            scope_type="project",
+            native_id="proj_acl_agents",
+            now="2026-07-20T00:00:00Z",
+        )
+        with pytest.raises(VibeAgentAccessError):
+            workbench_sessions_service.create_session(
+                connection,
+                scope_id=scope_id,
+                agent_backend="codex",
+                agent_name=private_agent.name,
+                agent_id=private_agent.id,
+                user_context=context,
+            )
+
+    with pytest.raises(VibeAgentAccessError):
+        ScheduledTaskStore(tmp_path / "tasks.json").add_task(
+            session_key="avibe::project::proj_acl_agents",
+            prompt="run",
+            schedule_type="cron",
+            agent_name=private_agent.name,
+            cron="0 * * * *",
+            timezone_name="UTC",
+            user_context=context,
+        )
+    with pytest.raises(VibeAgentAccessError):
+        ManagedWatchStore(tmp_path / "watches.json").add_watch(
+            name="acl watch",
+            session_key="avibe::project::proj_acl_agents",
+            command=["true"],
+            shell_command=None,
+            prefix=None,
+            cwd=str(tmp_path),
+            mode="once",
+            timeout_seconds=1,
+            lifetime_timeout_seconds=0,
+            retry_exit_codes=[75],
+            retry_delay_seconds=1,
+            post_to=None,
+            deliver_key=None,
+            agent_name=private_agent.name,
+            user_context=context,
+        )

--- a/tests/test_resource_acl_agents.py
+++ b/tests/test_resource_acl_agents.py
@@ -240,6 +240,27 @@ def test_remote_agent_request_and_selection_reject_inaccessible_agent(monkeypatc
                 agent_backend="",
                 user_context=context,
             )
+        with pytest.raises(VibeAgentAccessError):
+            workbench_sessions_service.create_session(
+                connection,
+                scope_id=scope_id,
+                agent_backend="codex",
+                user_context=context,
+            )
+        backend_only_session = workbench_sessions_service.create_session(
+            connection,
+            scope_id=scope_id,
+            agent_backend="codex",
+            user_context=resource_access_service.ResourceUserContext(is_trusted_local=True),
+        )
+        with pytest.raises(VibeAgentAccessError):
+            workbench_sessions_service.update_session(
+                connection,
+                backend_only_session["id"],
+                agent_backend="claude",
+                agent_name=None,
+                user_context=context,
+            )
     blocked_default = client.post(
         "/api/sessions",
         json={"project_id": "proj_acl_agents"},
@@ -248,6 +269,14 @@ def test_remote_agent_request_and_selection_reject_inaccessible_agent(monkeypatc
         environ_base=_remote_peer(),
     )
     assert blocked_default.status_code == 403
+    blocked_backend_only = client.post(
+        "/api/sessions",
+        json={"project_id": "proj_acl_agents", "agent_backend": "codex"},
+        headers=csrf_headers(client, "https://alex.avibe.bot"),
+        base_url="https://alex.avibe.bot",
+        environ_base=_remote_peer(),
+    )
+    assert blocked_backend_only.status_code == 403
 
     store = VibeAgentStore()
     try:
@@ -274,6 +303,17 @@ def test_remote_agent_request_and_selection_reject_inaccessible_agent(monkeypatc
         return {"status_code": 202, "body": {}}
 
     monkeypatch.setattr("vibe.internal_client.dispatch_async", dispatch_async)
+    blocked_legacy_turn = client.post(
+        f"/api/sessions/{backend_only_session['id']}/messages",
+        json={"text": "must not dispatch"},
+        headers=csrf_headers(client, "https://alex.avibe.bot"),
+        base_url="https://alex.avibe.bot",
+        environ_base=_remote_peer(),
+    )
+    assert blocked_legacy_turn.status_code == 403
+    assert blocked_legacy_turn.get_json()["code"] == "agent_access_forbidden"
+    assert dispatch_calls == []
+
     with engine.begin() as connection:
         resource_access_service.apply_control_plane_intent(
             connection,

--- a/tests/test_resource_acl_agents.py
+++ b/tests/test_resource_acl_agents.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import pytest
 
 from core.scheduled_tasks import ScheduledTaskStore
-from core.vibe_agents import VibeAgent, VibeAgentAccessError, VibeAgentStore
+from core.vibe_agents import AgentImportCandidate, VibeAgent, VibeAgentAccessError, VibeAgentStore
 from core.watches import ManagedWatchStore
 from storage import resource_access_service, workbench_sessions_service
 from storage.db import get_cached_sqlite_engine
@@ -26,6 +26,7 @@ def _organization_context(
         organization_member_id=f"member-{subject}",
         organization_role="member",
         group_ids=group_ids,
+        instance_role="viewer",
         instance_access_source="organization_group",
         is_remote=True,
     )
@@ -34,6 +35,7 @@ def _organization_context(
 def _organization_cookie(config, *, subject: str, groups: list[str] | None = None) -> str:
     claims = {
         "vibe_instance_id": "inst_123",
+        "vibe_instance_role": "viewer",
         "vibe_instance_access_source": "organization_group",
         "vibe_organization_id": "org-1",
         "vibe_organization_member_id": f"member-{subject}",
@@ -160,8 +162,17 @@ def test_remote_agent_request_and_selection_reject_inaccessible_agent(monkeypatc
         base_url="https://alex.avibe.bot",
         environ_base=_remote_peer(),
     )
+    public_mutation = client.patch(
+        "/api/agents/public-agent",
+        json={"description": "not allowed"},
+        headers=csrf_headers(client, "https://alex.avibe.bot"),
+        base_url="https://alex.avibe.bot",
+        environ_base=_remote_peer(),
+    )
     assert catalog.status_code == 200
     assert {agent["name"] for agent in catalog.get_json()["agents"]} == {"public-agent", "scope-agent"}
+    assert public_mutation.status_code == 403
+    assert public_mutation.get_json()["code"] == "agent_access_forbidden"
 
     engine = get_cached_sqlite_engine()
     with engine.begin() as connection:
@@ -210,3 +221,32 @@ def test_remote_agent_request_and_selection_reject_inaccessible_agent(monkeypatc
             agent_name=private_agent.name,
             user_context=context,
         )
+
+
+def test_remote_external_guest_cannot_create_agent(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    store = VibeAgentStore()
+    try:
+        with pytest.raises(VibeAgentAccessError):
+            store.create(
+                name="guest-agent",
+                backend="codex",
+                user_context=resource_access_service.ResourceUserContext(
+                    subject="guest-1",
+                    instance_role="viewer",
+                    instance_access_source="email",
+                    is_remote=True,
+                ),
+            )
+        with pytest.raises(VibeAgentAccessError):
+            store.import_candidates(
+                [AgentImportCandidate(name="guest-import", backend="codex")],
+                user_context=resource_access_service.ResourceUserContext(
+                    subject="guest-1",
+                    instance_role="viewer",
+                    instance_access_source="email",
+                    is_remote=True,
+                ),
+            )
+    finally:
+        store.close()

--- a/tests/test_resource_acl_agents.py
+++ b/tests/test_resource_acl_agents.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
 import pytest
+from sqlalchemy import select
 
 from core.scheduled_tasks import ScheduledTaskStore
 from core.vibe_agents import AgentImportCandidate, VibeAgent, VibeAgentAccessError, VibeAgentStore
 from core.watches import ManagedWatchStore
 from storage import resource_access_service, workbench_sessions_service
 from storage.db import get_cached_sqlite_engine
+from storage.models import resource_access_groups, resource_access_policies
 from storage.settings_service import upsert_scope
 from tests.test_ui_remote_access_auth import _remote_peer, _save_config
 from tests.ui_server_test_helpers import csrf_headers
@@ -104,6 +106,43 @@ def test_agent_catalog_filters_private_public_scope_and_missing_group_context(mo
     assert owner_names == {"private-agent", "public-agent", "scope-agent"}
     assert member_names == {"public-agent", "scope-agent"}
     assert no_group_names == {"public-agent"}
+
+
+def test_agent_removal_deletes_resource_policy_and_groups(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    store = VibeAgentStore()
+    try:
+        agent = store.create(name="removed-agent", backend="codex")
+        with store.engine.begin() as connection:
+            resource_access_service.ensure_resource_policy(
+                connection,
+                resource_kind="agent",
+                resource_id=agent.id,
+                organization_id="org-1",
+                owner_user_id="owner-1",
+                access_level="scope",
+                group_ids=["group-engineering"],
+            )
+
+        assert store.remove(agent.name) is True
+        with store.engine.connect() as connection:
+            policies = connection.execute(
+                select(resource_access_policies).where(
+                    resource_access_policies.c.resource_kind == "agent",
+                    resource_access_policies.c.resource_id == agent.id,
+                )
+            ).all()
+            groups = connection.execute(
+                select(resource_access_groups).where(
+                    resource_access_groups.c.resource_kind == "agent",
+                    resource_access_groups.c.resource_id == agent.id,
+                )
+            ).all()
+    finally:
+        store.close()
+
+    assert policies == []
+    assert groups == []
 
 
 def test_remote_agent_creation_defaults_to_private_organization_policy(monkeypatch, tmp_path) -> None:
@@ -227,6 +266,34 @@ def test_remote_agent_request_and_selection_reject_inaccessible_agent(monkeypatc
     assert session["agent_id"] == public_agent.id
     assert session["agent_name"] == public_agent.name
     assert session["agent_backend"] == public_agent.backend
+
+    dispatch_calls = []
+
+    async def dispatch_async(payload):
+        dispatch_calls.append(payload)
+        return {"status_code": 202, "body": {}}
+
+    monkeypatch.setattr("vibe.internal_client.dispatch_async", dispatch_async)
+    with engine.begin() as connection:
+        resource_access_service.apply_control_plane_intent(
+            connection,
+            organization_id="org-1",
+            resource_kind="agent",
+            resource_id=public_agent.id,
+            revision=1,
+            access_level="private",
+            group_ids=[],
+        )
+    revoked_turn = client.post(
+        f"/api/sessions/{session['id']}/messages",
+        json={"text": "must not dispatch"},
+        headers=csrf_headers(client, "https://alex.avibe.bot"),
+        base_url="https://alex.avibe.bot",
+        environ_base=_remote_peer(),
+    )
+    assert revoked_turn.status_code == 403
+    assert revoked_turn.get_json()["code"] == "agent_access_forbidden"
+    assert dispatch_calls == []
 
     with pytest.raises(VibeAgentAccessError):
         ScheduledTaskStore(tmp_path / "tasks.json").add_task(

--- a/tests/test_resource_acl_agents.py
+++ b/tests/test_resource_acl_agents.py
@@ -217,6 +217,20 @@ def test_remote_agent_request_and_selection_reject_inaccessible_agent(monkeypatc
     assert {agent["name"] for agent in catalog.get_json()["agents"]} == {"public-agent", "scope-agent"}
     assert public_mutation.status_code == 403
     assert public_mutation.get_json()["code"] == "agent_access_forbidden"
+    default_mutation = client.post(
+        "/api/agents/default",
+        json={"name": public_agent.name},
+        headers=csrf_headers(client, "https://alex.avibe.bot"),
+        base_url="https://alex.avibe.bot",
+        environ_base=_remote_peer(),
+    )
+    assert default_mutation.status_code == 403
+    assert default_mutation.get_json()["code"] == "agent_access_forbidden"
+    store = VibeAgentStore()
+    try:
+        assert store.get_default_agent_name() == private_agent.name
+    finally:
+        store.close()
 
     engine = get_cached_sqlite_engine()
     with engine.begin() as connection:

--- a/tests/test_resource_acl_agents.py
+++ b/tests/test_resource_acl_agents.py
@@ -177,6 +177,54 @@ def test_remote_agent_creation_defaults_to_private_organization_policy(monkeypat
     assert policy["access_level"] == "private"
 
 
+def test_remote_partial_agent_updates_persist_canonical_selector_pair(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    store, agents = _seed_agents_with_policies()
+    store.close()
+    engine = get_cached_sqlite_engine()
+    with engine.begin() as connection:
+        scope_id = upsert_scope(
+            connection,
+            platform="avibe",
+            scope_type="project",
+            native_id="proj_partial_agent",
+            now="2026-07-20T00:00:00Z",
+        )
+        session = workbench_sessions_service.create_session(
+            connection,
+            scope_id=scope_id,
+            agent_backend="",
+            agent_id=agents["public"].id,
+            user_context=_organization_context("member-1"),
+        )
+        by_name = workbench_sessions_service.update_session(
+            connection,
+            session["id"],
+            agent_name=agents["scope"].name,
+            user_context=_organization_context("member-1"),
+        )
+        by_id = workbench_sessions_service.update_session(
+            connection,
+            session["id"],
+            agent_id=agents["public"].id,
+            user_context=_organization_context("member-1"),
+        )
+
+    assert (session["agent_id"], session["agent_name"], session["agent_backend"]) == (
+        agents["public"].id,
+        agents["public"].name,
+        agents["public"].backend,
+    )
+    assert (by_name["agent_id"], by_name["agent_name"]) == (
+        agents["scope"].id,
+        agents["scope"].name,
+    )
+    assert (by_id["agent_id"], by_id["agent_name"]) == (
+        agents["public"].id,
+        agents["public"].name,
+    )
+
+
 def test_remote_agent_request_and_selection_reject_inaccessible_agent(monkeypatch, tmp_path) -> None:
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     config = _save_config(tmp_path)

--- a/tests/test_resource_acl_agents.py
+++ b/tests/test_resource_acl_agents.py
@@ -139,8 +139,10 @@ def test_remote_agent_request_and_selection_reject_inaccessible_agent(monkeypatc
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     config = _save_config(tmp_path)
     store, agents = _seed_agents_with_policies()
-    store.close()
     private_agent = agents["private"]
+    public_agent = agents["public"]
+    store.set_default_agent_name(private_agent.name)
+    store.close()
     context = _organization_context("member-1")
 
     client = app.test_client()
@@ -192,6 +194,39 @@ def test_remote_agent_request_and_selection_reject_inaccessible_agent(monkeypatc
                 agent_id=private_agent.id,
                 user_context=context,
             )
+        with pytest.raises(VibeAgentAccessError):
+            workbench_sessions_service.create_session(
+                connection,
+                scope_id=scope_id,
+                agent_backend="",
+                user_context=context,
+            )
+    blocked_default = client.post(
+        "/api/sessions",
+        json={"project_id": "proj_acl_agents"},
+        headers=csrf_headers(client, "https://alex.avibe.bot"),
+        base_url="https://alex.avibe.bot",
+        environ_base=_remote_peer(),
+    )
+    assert blocked_default.status_code == 403
+
+    store = VibeAgentStore()
+    try:
+        store.set_default_agent_name(public_agent.name)
+    finally:
+        store.close()
+    allowed_default = client.post(
+        "/api/sessions",
+        json={"project_id": "proj_acl_agents"},
+        headers=csrf_headers(client, "https://alex.avibe.bot"),
+        base_url="https://alex.avibe.bot",
+        environ_base=_remote_peer(),
+    )
+    assert allowed_default.status_code == 201
+    session = allowed_default.get_json()
+    assert session["agent_id"] == public_agent.id
+    assert session["agent_name"] == public_agent.name
+    assert session["agent_backend"] == public_agent.backend
 
     with pytest.raises(VibeAgentAccessError):
         ScheduledTaskStore(tmp_path / "tasks.json").add_task(

--- a/tests/test_resource_acl_agents.py
+++ b/tests/test_resource_acl_agents.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+import asyncio
+from types import SimpleNamespace
+
 import pytest
 from sqlalchemy import select
 
-from core.scheduled_tasks import ScheduledTaskStore
+from core.scheduled_tasks import ScheduledTaskService, ScheduledTaskStore, TaskExecutionStore
 from core.vibe_agents import AgentImportCandidate, VibeAgent, VibeAgentAccessError, VibeAgentStore
 from core.watches import ManagedWatchStore
 from storage import resource_access_service, workbench_sessions_service
@@ -392,3 +395,87 @@ def test_remote_external_guest_cannot_create_agent(monkeypatch, tmp_path) -> Non
             )
     finally:
         store.close()
+
+
+def test_remote_background_definitions_recheck_agent_acl_before_dispatch(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    agent_store, agents = _seed_agents_with_policies()
+    context = _organization_context("member-1")
+    task_store = ScheduledTaskStore(tmp_path / "tasks.json")
+    watch_store = ManagedWatchStore(tmp_path / "watches.json")
+    request_store = TaskExecutionStore(tmp_path / "task_requests")
+    try:
+        task = task_store.add_task(
+            session_key="slack::channel::C123",
+            prompt="run task",
+            schedule_type="cron",
+            agent_name=agents["public"].name,
+            cron="0 * * * *",
+            timezone_name="UTC",
+            metadata={
+                resource_access_service.RESOURCE_USER_CONTEXT_METADATA_KEY: {
+                    "sub": "owner-1",
+                }
+            },
+            user_context=context,
+        )
+        watch = watch_store.add_watch(
+            name="acl watch",
+            session_key="slack::channel::C123",
+            command=["true"],
+            shell_command=None,
+            prefix=None,
+            cwd=str(tmp_path),
+            mode="once",
+            timeout_seconds=1,
+            lifetime_timeout_seconds=0,
+            retry_exit_codes=[75],
+            retry_delay_seconds=1,
+            post_to=None,
+            deliver_key=None,
+            agent_name=agents["public"].name,
+            user_context=context,
+        )
+        assert task.metadata[resource_access_service.RESOURCE_USER_CONTEXT_METADATA_KEY]["sub"] == "member-1"
+        assert watch.metadata[resource_access_service.RESOURCE_USER_CONTEXT_METADATA_KEY]["sub"] == "member-1"
+
+        with agent_store.engine.begin() as connection:
+            resource_access_service.apply_control_plane_intent(
+                connection,
+                organization_id="org-1",
+                resource_kind="agent",
+                resource_id=agents["public"].id,
+                revision=1,
+                access_level="private",
+                group_ids=[],
+            )
+
+        service = ScheduledTaskService(
+            controller=SimpleNamespace(),
+            store=task_store,
+            request_store=request_store,
+        )
+        task_result = asyncio.run(
+            service._execute_task(task, execution_id="task-run", disable_one_shot=False)
+        )
+        assert task_result.error == "Agent access is not permitted."
+
+        request = request_store.enqueue_hook_send(
+            session_key=watch.session_key,
+            prompt="run watch",
+            agent_name=watch.agent_name,
+            session_policy=watch.session_policy,
+            run_type="watch",
+            definition_id=watch.id,
+            source_kind="watch",
+            metadata=watch.metadata,
+        )
+        claimed = request_store.claim(request.id)
+        assert claimed is not None
+        asyncio.run(service._execute_claimed_request(claimed))
+        completed = request_store.get_run(request.id)
+        assert completed is not None
+        assert completed["status"] == "failed"
+        assert completed["error"] == "Agent access is not permitted."
+    finally:
+        agent_store.close()

--- a/tests/test_resource_acl_show_pages.py
+++ b/tests/test_resource_acl_show_pages.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+import pytest
+
+from core.show_pages import ShowPageError, ShowPageStore, public_url
+from storage import resource_access_service
+from tests.test_ui_remote_access_auth import _remote_peer, _save_config
+from tests.ui_server_test_helpers import csrf_headers
+from vibe import remote_access
+from vibe.ui_server import app
+
+
+def _organization_context(
+    subject: str,
+    *,
+    group_ids: frozenset[str] | None = frozenset({"group-engineering"}),
+) -> resource_access_service.ResourceUserContext:
+    return resource_access_service.ResourceUserContext(
+        subject=subject,
+        email=f"{subject}@example.com",
+        organization_id="org-1",
+        organization_member_id=f"member-{subject}",
+        organization_role="member",
+        group_ids=group_ids,
+        instance_access_source="organization_group",
+        is_remote=True,
+    )
+
+
+def _organization_cookie(config, *, subject: str, groups: list[str] | None = None) -> str:
+    claims = {
+        "vibe_instance_id": "inst_123",
+        "vibe_instance_access_source": "organization_group",
+        "vibe_organization_id": "org-1",
+        "vibe_organization_member_id": f"member-{subject}",
+        "vibe_organization_role": "member",
+        "vibe_membership_version": "membership-v2",
+    }
+    if groups is not None:
+        claims["vibe_group_ids"] = groups
+    return remote_access.make_session_cookie(
+        config,
+        f"{subject}@example.com",
+        subject,
+        session_claims=claims,
+    )
+
+
+def _seed_show_pages_with_policies() -> ShowPageStore:
+    store = ShowPageStore()
+    for session_id in ("ses-private", "ses-public", "ses-scope"):
+        store.ensure(session_id)
+    with store.engine.begin() as connection:
+        resource_access_service.ensure_resource_policy(
+            connection,
+            resource_kind="show_page",
+            resource_id="ses-private",
+            organization_id="org-1",
+            owner_user_id="owner-1",
+            access_level="private",
+        )
+        resource_access_service.ensure_resource_policy(
+            connection,
+            resource_kind="show_page",
+            resource_id="ses-public",
+            organization_id="org-1",
+            owner_user_id="owner-1",
+            access_level="public",
+        )
+        resource_access_service.ensure_resource_policy(
+            connection,
+            resource_kind="show_page",
+            resource_id="ses-scope",
+            organization_id="org-1",
+            owner_user_id="owner-1",
+            access_level="scope",
+            group_ids=["group-engineering"],
+        )
+    return store
+
+
+def test_show_page_list_filters_private_public_scope_and_missing_group_context(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    store = _seed_show_pages_with_policies()
+    try:
+        owner_ids = {page.session_id for page in store.list(user_context=_organization_context("owner-1"))}
+        member_ids = {page.session_id for page in store.list(user_context=_organization_context("member-1"))}
+        no_group_ids = {
+            page.session_id
+            for page in store.list(user_context=_organization_context("member-2", group_ids=None))
+        }
+    finally:
+        store.close()
+
+    assert owner_ids == {"ses-private", "ses-public", "ses-scope"}
+    assert member_ids == {"ses-public", "ses-scope"}
+    assert no_group_ids == {"ses-public"}
+
+
+def test_remote_show_page_list_and_direct_requests_enforce_policy(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    config = _save_config(tmp_path)
+    store = _seed_show_pages_with_policies()
+    store.close()
+    client = app.test_client()
+    client.set_cookie(
+        remote_access.SESSION_COOKIE_NAME,
+        _organization_cookie(config, subject="member-1", groups=["group-engineering"]),
+        domain="alex.avibe.bot",
+    )
+
+    catalog = client.get(
+        "/api/show-pages",
+        base_url="https://alex.avibe.bot",
+        environ_base=_remote_peer(),
+    )
+    mutation = client.post(
+        "/api/show-pages/ses-private/visibility",
+        json={"visibility": "offline"},
+        headers=csrf_headers(client, "https://alex.avibe.bot"),
+        base_url="https://alex.avibe.bot",
+        environ_base=_remote_peer(),
+    )
+    page = client.get(
+        "/show/ses-private/",
+        base_url="https://alex.avibe.bot",
+        environ_base=_remote_peer(),
+        follow_redirects=False,
+    )
+
+    assert catalog.status_code == 200
+    assert {item["session_id"] for item in catalog.get_json()["pages"]} == {"ses-public", "ses-scope"}
+    assert mutation.status_code == 403
+    assert mutation.get_json()["code"] == "resource_access_forbidden"
+    assert page.status_code == 403
+
+
+def test_remote_show_page_creation_defaults_private_and_org_public_does_not_share(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    owner_context = _organization_context("owner-1")
+    store = ShowPageStore()
+    try:
+        page = store.ensure("ses-org-public", user_context=owner_context)
+        with store.engine.begin() as connection:
+            policy = resource_access_service.get_resource_policy(
+                "show_page",
+                page.session_id,
+                connection=connection,
+            )
+            assert policy is not None
+            assert policy["organization_id"] == "org-1"
+            assert policy["owner_user_id"] == "owner-1"
+            assert policy["access_level"] == "private"
+            resource_access_service.apply_control_plane_intent(
+                connection,
+                organization_id="org-1",
+                resource_kind="show_page",
+                resource_id=page.session_id,
+                revision=1,
+                access_level="public",
+                group_ids=[],
+            )
+        updated = store.get(page.session_id)
+        assert updated is not None
+        assert updated.visibility == "private"
+        assert updated.share_id is None
+        assert public_url(updated.share_id) is None
+    finally:
+        store.close()
+
+
+def test_show_page_scope_without_group_context_fails_closed(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    store = _seed_show_pages_with_policies()
+    try:
+        with pytest.raises(ShowPageError, match="Show Page access is not permitted") as excinfo:
+            store.require_access("ses-scope", user_context=_organization_context("member-1", group_ids=None))
+    finally:
+        store.close()
+
+    assert excinfo.value.code == "resource_access_forbidden"

--- a/tests/test_resource_acl_show_pages.py
+++ b/tests/test_resource_acl_show_pages.py
@@ -4,6 +4,7 @@ import pytest
 from sqlalchemy import select
 
 from config import paths
+from core.dock_store import BUILTIN_DOCK_IDS, DockError
 from core.show_pages import ShowPageError, ShowPageStore, public_url
 from storage import projects_service, resource_access_service
 from storage import workbench_sessions_service as sessions_service
@@ -287,6 +288,28 @@ def test_remote_admin_dock_order_preserves_hidden_private_pins(monkeypatch, tmp_
     owner_dock = api.get_dock(user_context=owner)["dock"]
     assert "show:ses-private" in owner_dock["order"]
     assert [item for item in owner_dock["order"] if item != "show:ses-private"] == submitted
+
+
+def test_untrusted_dock_context_fails_closed(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    _save_config(tmp_path)
+    store = _seed_show_pages_with_policies()
+    store.close()
+    owner = _organization_context("owner-1")
+    api.pin_dock_show_page("ses-public", user_context=owner)
+
+    unresolved = resource_access_service.ResourceUserContext()
+    dock = api.get_dock(user_context=unresolved)["dock"]
+
+    assert dock["pins"] == []
+    assert "show:ses-public" not in dock["order"]
+    with pytest.raises(ShowPageError, match="Show Page access is not permitted"):
+        api.unpin_dock_show_page("ses-public", user_context=unresolved)
+    with pytest.raises(DockError, match="unknown id"):
+        api.set_dock_order(
+            [*BUILTIN_DOCK_IDS, "show:ses-public"],
+            user_context=unresolved,
+        )
 
 
 def test_remote_member_cannot_archive_session_with_another_owners_page(monkeypatch, tmp_path) -> None:

--- a/tests/test_resource_acl_show_pages.py
+++ b/tests/test_resource_acl_show_pages.py
@@ -224,6 +224,14 @@ def test_remote_dock_filters_private_pins_and_authorizes_mutations(monkeypatch, 
     store.close()
     owner = _organization_context("owner-1")
     member = _organization_context("member-1")
+    admin = _organization_context(
+        "admin-1",
+        group_ids=frozenset({"group-sales"}),
+        organization_role="admin",
+    )
+    with pytest.raises(ShowPageError, match="Show Page access is not permitted"):
+        api.pin_dock_show_page("ses-public", user_context=member)
+    api.pin_dock_show_page("ses-scope", user_context=admin)
     for session_id in ("ses-private", "ses-public", "ses-scope"):
         api.pin_dock_show_page(session_id, user_context=owner)
 

--- a/tests/test_resource_acl_show_pages.py
+++ b/tests/test_resource_acl_show_pages.py
@@ -22,6 +22,7 @@ def _organization_context(
         organization_member_id=f"member-{subject}",
         organization_role="member",
         group_ids=group_ids,
+        instance_role="viewer",
         instance_access_source="organization_group",
         is_remote=True,
     )
@@ -30,6 +31,7 @@ def _organization_context(
 def _organization_cookie(config, *, subject: str, groups: list[str] | None = None) -> str:
     claims = {
         "vibe_instance_id": "inst_123",
+        "vibe_instance_role": "viewer",
         "vibe_instance_access_source": "organization_group",
         "vibe_organization_id": "org-1",
         "vibe_organization_member_id": f"member-{subject}",
@@ -115,7 +117,7 @@ def test_remote_show_page_list_and_direct_requests_enforce_policy(monkeypatch, t
         environ_base=_remote_peer(),
     )
     mutation = client.post(
-        "/api/show-pages/ses-private/visibility",
+        "/api/show-pages/ses-public/visibility",
         json={"visibility": "offline"},
         headers=csrf_headers(client, "https://alex.avibe.bot"),
         base_url="https://alex.avibe.bot",

--- a/tests/test_resource_acl_show_pages.py
+++ b/tests/test_resource_acl_show_pages.py
@@ -6,7 +6,7 @@ from core.show_pages import ShowPageError, ShowPageStore, public_url
 from storage import resource_access_service
 from tests.test_ui_remote_access_auth import _remote_peer, _save_config
 from tests.ui_server_test_helpers import csrf_headers
-from vibe import remote_access
+from vibe import api, remote_access
 from vibe.ui_server import app
 
 
@@ -181,3 +181,40 @@ def test_show_page_scope_without_group_context_fails_closed(monkeypatch, tmp_pat
         store.close()
 
     assert excinfo.value.code == "resource_access_forbidden"
+
+
+def test_remote_dock_filters_private_pins_and_authorizes_mutations(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    config = _save_config(tmp_path)
+    store = _seed_show_pages_with_policies()
+    store.close()
+    owner = _organization_context("owner-1")
+    member = _organization_context("member-1")
+    for session_id in ("ses-private", "ses-public", "ses-scope"):
+        api.pin_dock_show_page(session_id, user_context=owner)
+
+    dock = api.get_dock(user_context=member)["dock"]
+    visible_ids = {pin["session_id"] for pin in dock["pins"]}
+    assert visible_ids == {"ses-public", "ses-scope"}
+    assert "show:ses-private" not in dock["order"]
+    with pytest.raises(ShowPageError, match="Show Page access is not permitted"):
+        api.pin_dock_show_page("ses-private", user_context=member)
+    with pytest.raises(ShowPageError, match="Show Page access is not permitted"):
+        api.unpin_dock_show_page("ses-public", user_context=member)
+    with pytest.raises(ShowPageError, match="Show Page access is not permitted"):
+        api.set_dock_order([], user_context=member)
+
+    client = app.test_client()
+    client.set_cookie(
+        remote_access.SESSION_COOKIE_NAME,
+        _organization_cookie(config, subject="member-1", groups=["group-engineering"]),
+        domain="alex.avibe.bot",
+    )
+    response = client.delete(
+        "/api/dock/pins/ses-public",
+        headers=csrf_headers(client, "https://alex.avibe.bot"),
+        base_url="https://alex.avibe.bot",
+        environ_base=_remote_peer(),
+    )
+    assert response.status_code == 403
+    assert response.get_json()["code"] == "resource_access_forbidden"

--- a/tests/test_resource_acl_show_pages.py
+++ b/tests/test_resource_acl_show_pages.py
@@ -1,9 +1,15 @@
 from __future__ import annotations
 
 import pytest
+from sqlalchemy import select
 
+from config import paths
 from core.show_pages import ShowPageError, ShowPageStore, public_url
-from storage import resource_access_service
+from storage import projects_service, resource_access_service
+from storage import workbench_sessions_service as sessions_service
+from storage.db import create_sqlite_engine
+from storage.importer import ensure_sqlite_state
+from storage.models import agent_sessions, show_pages
 from tests.test_ui_remote_access_auth import _remote_peer, _save_config
 from tests.ui_server_test_helpers import csrf_headers
 from vibe import api, remote_access
@@ -14,13 +20,14 @@ def _organization_context(
     subject: str,
     *,
     group_ids: frozenset[str] | None = frozenset({"group-engineering"}),
+    organization_role: str = "member",
 ) -> resource_access_service.ResourceUserContext:
     return resource_access_service.ResourceUserContext(
         subject=subject,
         email=f"{subject}@example.com",
         organization_id="org-1",
         organization_member_id=f"member-{subject}",
-        organization_role="member",
+        organization_role=organization_role,
         group_ids=group_ids,
         instance_role="viewer",
         instance_access_source="organization_group",
@@ -218,3 +225,87 @@ def test_remote_dock_filters_private_pins_and_authorizes_mutations(monkeypatch, 
     )
     assert response.status_code == 403
     assert response.get_json()["code"] == "resource_access_forbidden"
+
+
+def test_remote_admin_dock_order_preserves_hidden_private_pins(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    _save_config(tmp_path)
+    store = _seed_show_pages_with_policies()
+    store.close()
+    owner = _organization_context("owner-1")
+    admin = _organization_context("admin-1", organization_role="admin")
+    for session_id in ("ses-private", "ses-public", "ses-scope"):
+        api.pin_dock_show_page(session_id, user_context=owner)
+
+    visible = api.get_dock(user_context=admin)["dock"]
+    known = [
+        "files",
+        "terminal",
+        "editor",
+        "library",
+        *(f"show:{pin['session_id']}" for pin in visible["pins"]),
+    ]
+    submitted = ["show:ses-scope", "show:ses-public", "files"]
+    updated = api.set_dock_order(submitted, known=known, user_context=admin)["dock"]
+
+    assert updated["order"] == submitted
+    owner_dock = api.get_dock(user_context=owner)["dock"]
+    assert "show:ses-private" in owner_dock["order"]
+    assert [item for item in owner_dock["order"] if item != "show:ses-private"] == submitted
+
+
+def test_remote_member_cannot_archive_session_with_another_owners_page(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    config = _save_config(tmp_path)
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    ensure_sqlite_state()
+    engine = create_sqlite_engine(paths.get_sqlite_state_path())
+    try:
+        with engine.begin() as connection:
+            project = projects_service.create_project(connection, str(project_dir))
+            session_id = sessions_service.create_session(
+                connection,
+                scope_id=project["scope_id"],
+                agent_backend="claude",
+            )["id"]
+
+        store = ShowPageStore()
+        try:
+            store.ensure(session_id)
+            with store.engine.begin() as connection:
+                resource_access_service.ensure_resource_policy(
+                    connection,
+                    resource_kind="show_page",
+                    resource_id=session_id,
+                    organization_id="org-1",
+                    owner_user_id="owner-1",
+                    access_level="private",
+                )
+        finally:
+            store.close()
+
+        client = app.test_client()
+        client.set_cookie(
+            remote_access.SESSION_COOKIE_NAME,
+            _organization_cookie(config, subject="member-1", groups=["group-engineering"]),
+            domain="alex.avibe.bot",
+        )
+        response = client.delete(
+            f"/api/sessions/{session_id}",
+            headers=csrf_headers(client, "https://alex.avibe.bot"),
+            base_url="https://alex.avibe.bot",
+            environ_base=_remote_peer(),
+        )
+
+        assert response.status_code == 403
+        assert response.get_json()["code"] == "resource_access_forbidden"
+        with engine.connect() as connection:
+            assert connection.execute(
+                select(agent_sessions.c.status).where(agent_sessions.c.id == session_id)
+            ).scalar_one() == "active"
+            assert connection.execute(
+                select(show_pages.c.visibility).where(show_pages.c.session_id == session_id)
+            ).scalar_one() == "private"
+    finally:
+        engine.dispose()

--- a/tests/test_resource_acl_show_pages.py
+++ b/tests/test_resource_acl_show_pages.py
@@ -190,6 +190,33 @@ def test_show_page_scope_without_group_context_fails_closed(monkeypatch, tmp_pat
     assert excinfo.value.code == "resource_access_forbidden"
 
 
+def test_remote_admin_can_manage_pages_without_use_access(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    store = _seed_show_pages_with_policies()
+    admin = _organization_context(
+        "admin-1",
+        group_ids=frozenset({"group-sales"}),
+        organization_role="admin",
+    )
+    try:
+        with pytest.raises(ShowPageError, match="Show Page access is not permitted"):
+            store.require_access("ses-private", user_context=admin)
+        private_page = store.update_visibility("ses-private", "public", user_context=admin)
+        rotated, previous_share_id = store.rotate_share("ses-private", user_context=admin)
+        custom, rotated_share_id = store.set_share_id("ses-private", "admin-link", user_context=admin)
+
+        assert private_page.visibility == "public"
+        assert previous_share_id == private_page.share_id
+        assert rotated_share_id == rotated.share_id
+        assert custom.share_id == "admin-link"
+
+        with pytest.raises(ShowPageError, match="Show Page access is not permitted"):
+            store.require_access("ses-scope", user_context=admin)
+        assert store.update_visibility("ses-scope", "offline", user_context=admin).visibility == "offline"
+    finally:
+        store.close()
+
+
 def test_remote_dock_filters_private_pins_and_authorizes_mutations(monkeypatch, tmp_path) -> None:
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     config = _save_config(tmp_path)

--- a/tests/test_resource_acl_vaults.py
+++ b/tests/test_resource_acl_vaults.py
@@ -1,0 +1,255 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+from sqlalchemy import select
+
+from storage import resource_access_service, vault_service
+from storage.db import create_sqlite_engine
+from storage.models import metadata, vault_grants, vault_requests, vault_secrets
+from storage.vault_crypto import Sealed
+from vibe import remote_access
+
+
+def _context(
+    subject: str,
+    *,
+    group_ids: frozenset[str] | None = frozenset({"group-engineering"}),
+) -> resource_access_service.ResourceUserContext:
+    return resource_access_service.ResourceUserContext(
+        subject=subject,
+        email=f"{subject}@example.com",
+        organization_id="org-1",
+        organization_member_id=f"member-{subject}",
+        organization_role="member",
+        group_ids=group_ids,
+        instance_access_source="organization_group",
+        is_remote=True,
+    )
+
+
+@pytest.fixture
+def vault(tmp_path):
+    vault_service.GRANT_RUNTIME_CACHE.clear()
+    engine = create_sqlite_engine(tmp_path / "vault_acl.sqlite")
+    metadata.create_all(engine)
+    try:
+        yield engine
+    finally:
+        engine.dispose()
+
+
+def _sealed(name: str) -> Sealed:
+    return Sealed(ciphertext=f"ciphertext-{name}", nonce=f"nonce-{name}", wrap_meta=f"wrap-{name}")
+
+
+def _create_secret(conn, name: str, **kwargs) -> None:
+    vault_service.create_secret(conn, name=name, sealed=_sealed(name), **kwargs)
+
+
+def _secret_id(conn, name: str) -> str:
+    return str(conn.execute(select(vault_secrets.c.id).where(vault_secrets.c.name == name)).scalar_one())
+
+
+def _set_policy(
+    conn,
+    name: str,
+    *,
+    access_level: str,
+    group_ids: list[str] | None = None,
+) -> str:
+    resource_id = _secret_id(conn, name)
+    resource_access_service.ensure_resource_policy(
+        conn,
+        resource_kind="vault_secret",
+        resource_id=resource_id,
+        organization_id="org-1",
+        owner_user_id="owner-1",
+        access_level=access_level,
+        group_ids=group_ids,
+        policy_revision=1,
+        last_applied_control_plane_revision=1,
+    )
+    return resource_id
+
+
+def _grant_from_request(conn, request: dict, *, user_context) -> dict:
+    option = request["card"]["grant_options"][0]
+    return vault_service.create_grant(
+        conn,
+        member_names=option["member_snapshot"],
+        source_selector=option["source_selector"],
+        purpose=option["purpose"],
+        request_id=request["id"],
+        user_context=user_context,
+    )
+
+
+def test_vault_list_filters_acl_rows_without_returning_envelopes(vault) -> None:
+    with vault.begin() as conn:
+        _create_secret(conn, "PRIVATE_KEY")
+        _create_secret(conn, "PUBLIC_KEY")
+        _create_secret(conn, "SCOPED_KEY")
+        _set_policy(conn, "PRIVATE_KEY", access_level="private")
+        _set_policy(conn, "PUBLIC_KEY", access_level="public")
+        _set_policy(conn, "SCOPED_KEY", access_level="scope", group_ids=["group-engineering"])
+
+    with vault.connect() as conn:
+        owner_rows = vault_service.list_secrets(conn, user_context=_context("owner-1"))
+        member_rows = vault_service.list_secrets(conn, user_context=_context("member-1"))
+        no_group_rows = vault_service.list_secrets(conn, user_context=_context("member-2", group_ids=None))
+
+    assert {row["name"] for row in owner_rows} == {"PRIVATE_KEY", "PUBLIC_KEY", "SCOPED_KEY"}
+    assert {row["name"] for row in member_rows} == {"PUBLIC_KEY", "SCOPED_KEY"}
+    assert {row["name"] for row in no_group_rows} == {"PUBLIC_KEY"}
+    serialized = json.dumps(member_rows)
+    assert "ciphertext-" not in serialized
+    assert "nonce-" not in serialized
+    assert "wrap-" not in serialized
+    assert "ciphertext" not in serialized
+    assert "wrap_meta" not in serialized
+
+
+def test_inaccessible_vault_requests_and_grants_fail_before_mutating_state(vault) -> None:
+    owner = _context("owner-1")
+    member = _context("member-1")
+    with vault.begin() as conn:
+        _create_secret(conn, "PRIVATE_ACCESS", protection="protected")
+        _create_secret(conn, "PRIVATE_SIGN", kind="keypair", signer_kind="local")
+        _set_policy(conn, "PRIVATE_ACCESS", access_level="private")
+        _set_policy(conn, "PRIVATE_SIGN", access_level="private")
+        owner_request = vault_service.create_access_request(conn, "PRIVATE_ACCESS", user_context=owner)
+
+        with pytest.raises(vault_service.VaultSecretAccessError):
+            vault_service.create_access_request(conn, "PRIVATE_ACCESS", user_context=member)
+        with pytest.raises(vault_service.VaultSecretAccessError):
+            vault_service.create_sign_request(
+                conn,
+                "PRIVATE_SIGN",
+                digest="00" * 32,
+                scheme="ecdsa-secp256k1-recoverable",
+                user_context=member,
+            )
+
+        option = owner_request["card"]["grant_options"][0]
+        with pytest.raises(vault_service.VaultSecretAccessError):
+            vault_service.create_grant(
+                conn,
+                member_names=option["member_snapshot"],
+                source_selector=option["source_selector"],
+                purpose=option["purpose"],
+                request_id=owner_request["id"],
+                user_context=member,
+            )
+
+        requests = list(conn.execute(select(vault_requests)).mappings())
+        grants = list(conn.execute(select(vault_grants)).mappings())
+
+    assert [row["id"] for row in requests] == [owner_request["id"]]
+    assert requests[0]["status"] == "pending"
+    assert grants == []
+
+
+@pytest.mark.parametrize(
+    "selector",
+    [
+        {"env": ["PRIVATE_SELECTOR"]},
+        {"tags": ["deploy"]},
+        {"skills": ["release"]},
+    ],
+)
+def test_cli_selector_resolution_rejects_inaccessible_secrets(vault, selector: dict) -> None:
+    with vault.begin() as conn:
+        _create_secret(conn, "PRIVATE_SELECTOR", tags=["deploy", "skill:release"])
+        _set_policy(conn, "PRIVATE_SELECTOR", access_level="private")
+        with pytest.raises(vault_service.VaultSecretAccessError):
+            vault_service.expand_value_delivery_selector(
+                conn,
+                user_context=_context("member-1"),
+                **selector,
+            )
+        assert list(conn.execute(select(vault_requests)).mappings()) == []
+        assert list(conn.execute(select(vault_grants)).mappings()) == []
+
+
+def test_remote_created_secret_registers_private_organization_policy(vault) -> None:
+    creator = _context("member-1")
+    with vault.begin() as conn:
+        _create_secret(conn, "REMOTE_CREATED", user_context=creator)
+        policy = resource_access_service.get_resource_policy(
+            "vault_secret",
+            _secret_id(conn, "REMOTE_CREATED"),
+            connection=conn,
+        )
+
+    assert policy is not None
+    assert policy["organization_id"] == "org-1"
+    assert policy["owner_user_id"] == "member-1"
+    assert policy["access_level"] == "private"
+
+
+@pytest.mark.parametrize(
+    ("initial_level", "initial_groups", "updated_level", "updated_groups"),
+    [
+        ("public", None, "scope", ["group-engineering"]),
+        ("scope", ["group-engineering", "group-sales"], "scope", ["group-engineering"]),
+    ],
+)
+def test_narrowed_vault_policy_revokes_active_grants(
+    vault,
+    monkeypatch,
+    initial_level: str,
+    initial_groups: list[str] | None,
+    updated_level: str,
+    updated_groups: list[str],
+) -> None:
+    owner = _context("owner-1")
+    with vault.begin() as conn:
+        _create_secret(conn, "NARROWED_KEY", protection="protected")
+        resource_id = _set_policy(
+            conn,
+            "NARROWED_KEY",
+            access_level=initial_level,
+            group_ids=initial_groups,
+        )
+        request = vault_service.create_access_request(conn, "NARROWED_KEY", user_context=owner)
+        grant = _grant_from_request(conn, request, user_context=owner)
+
+    monkeypatch.setattr("storage.db.get_cached_sqlite_engine", lambda: vault)
+    monkeypatch.setattr(
+        remote_access,
+        "publish_resource_index",
+        lambda *_args, **_kwargs: {"organization_id": "org-1", "resources": []},
+    )
+    monkeypatch.setattr(
+        remote_access,
+        "pull_resource_acl_intents",
+        lambda *_args, **_kwargs: {
+            "organization_id": "org-1",
+            "intents": [
+                {
+                    "resource_kind": "vault_secret",
+                    "resource_id": resource_id,
+                    "revision": 2,
+                    "access_level": updated_level,
+                    "group_ids": updated_groups,
+                }
+            ],
+        },
+    )
+    monkeypatch.setattr(remote_access, "acknowledge_resource_acl_intent", lambda *_args, **_kwargs: {})
+    releases: list[dict] = []
+    monkeypatch.setattr(
+        remote_access.api,
+        "release_vault_agent_scopes",
+        lambda scopes, *, reason: releases.append({"scopes": scopes, "reason": reason}),
+    )
+
+    result = remote_access._sync_one_organization(None, organization_id="org-1", resources=[])
+
+    assert result["applied"] == 1
+    with vault.connect() as conn:
+        status = conn.execute(select(vault_grants.c.status).where(vault_grants.c.id == grant["id"])).scalar_one()
+    assert status == "revoked"
+    assert releases == [{"scopes": [{"grant_id": grant["id"]}], "reason": "resource-access-policy-narrowed"}]

--- a/tests/test_resource_acl_vaults.py
+++ b/tests/test_resource_acl_vaults.py
@@ -24,6 +24,7 @@ def _context(
         organization_member_id=f"member-{subject}",
         organization_role="member",
         group_ids=group_ids,
+        instance_role="viewer",
         instance_access_source="organization_group",
         is_remote=True,
     )
@@ -187,6 +188,54 @@ def test_remote_created_secret_registers_private_organization_policy(vault) -> N
     assert policy["organization_id"] == "org-1"
     assert policy["owner_user_id"] == "member-1"
     assert policy["access_level"] == "private"
+
+
+def test_public_vault_use_does_not_grant_management(vault) -> None:
+    with vault.begin() as conn:
+        _create_secret(conn, "PUBLIC_MANAGEMENT")
+        _set_policy(conn, "PUBLIC_MANAGEMENT", access_level="public")
+
+        assert vault_service.get_secret_meta(
+            conn,
+            "PUBLIC_MANAGEMENT",
+            user_context=_context("member-1"),
+        )["name"] == "PUBLIC_MANAGEMENT"
+        with pytest.raises(vault_service.VaultSecretAccessError):
+            vault_service.update_secret_metadata(
+                conn,
+                "PUBLIC_MANAGEMENT",
+                description="not allowed",
+                user_context=_context("member-1"),
+            )
+        with pytest.raises(vault_service.VaultSecretAccessError):
+            vault_service.delete_secret(
+                conn,
+                "PUBLIC_MANAGEMENT",
+                user_context=_context("member-1"),
+            )
+
+        updated = vault_service.update_secret_metadata(
+            conn,
+            "PUBLIC_MANAGEMENT",
+            description="owner update",
+            user_context=_context("owner-1"),
+        )
+
+    assert updated["description"] == "owner update"
+
+
+def test_remote_external_guest_cannot_create_vault_secret(vault) -> None:
+    guest = resource_access_service.ResourceUserContext(
+        subject="guest-1",
+        instance_role="viewer",
+        instance_access_source="email",
+        is_remote=True,
+    )
+
+    with vault.begin() as conn:
+        with pytest.raises(vault_service.VaultSecretAccessError):
+            _create_secret(conn, "GUEST_CREATED", user_context=guest)
+        assert conn.execute(select(vault_secrets).where(vault_secrets.c.name == "GUEST_CREATED")).first() is None
 
 
 @pytest.mark.parametrize(

--- a/tests/test_resource_acl_vaults.py
+++ b/tests/test_resource_acl_vaults.py
@@ -7,7 +7,14 @@ from sqlalchemy import select
 
 from storage import resource_access_service, vault_service
 from storage.db import create_sqlite_engine
-from storage.models import metadata, vault_grants, vault_requests, vault_secrets
+from storage.models import (
+    metadata,
+    resource_access_groups,
+    resource_access_policies,
+    vault_grants,
+    vault_requests,
+    vault_secrets,
+)
 from storage.vault_crypto import Sealed
 from vibe import remote_access
 
@@ -188,6 +195,34 @@ def test_remote_created_secret_registers_private_organization_policy(vault) -> N
     assert policy["organization_id"] == "org-1"
     assert policy["owner_user_id"] == "member-1"
     assert policy["access_level"] == "private"
+
+
+def test_vault_secret_removal_deletes_resource_policy_and_groups(vault) -> None:
+    with vault.begin() as conn:
+        _create_secret(conn, "REMOVED_SECRET")
+        resource_id = _set_policy(
+            conn,
+            "REMOVED_SECRET",
+            access_level="scope",
+            group_ids=["group-engineering"],
+        )
+
+        vault_service.delete_secret(conn, "REMOVED_SECRET", user_context=_context("owner-1"))
+        policies = conn.execute(
+            select(resource_access_policies).where(
+                resource_access_policies.c.resource_kind == "vault_secret",
+                resource_access_policies.c.resource_id == resource_id,
+            )
+        ).all()
+        groups = conn.execute(
+            select(resource_access_groups).where(
+                resource_access_groups.c.resource_kind == "vault_secret",
+                resource_access_groups.c.resource_id == resource_id,
+            )
+        ).all()
+
+    assert policies == []
+    assert groups == []
 
 
 def test_public_vault_use_does_not_grant_management(vault) -> None:

--- a/tests/test_resource_acl_vaults.py
+++ b/tests/test_resource_acl_vaults.py
@@ -197,6 +197,43 @@ def test_vault_request_reads_and_denial_enforce_member_secret_acls(vault) -> Non
     assert denied["status"] == "denied"
 
 
+def test_pending_provision_lookups_require_instance_owner(vault, monkeypatch) -> None:
+    owner = _context("owner-1", instance_role="owner")
+    member = _context("member-1")
+    with vault.begin() as conn:
+        provision = vault_service.create_provision_request(conn, "MISSING_SECRET")
+        with pytest.raises(vault_service.VaultSecretAccessError):
+            vault_service.resolve_pending_provision_request_by_name(
+                conn,
+                "MISSING_SECRET",
+                user_context=member,
+            )
+        with pytest.raises(vault_service.VaultSecretAccessError):
+            vault_service.get_pending_provision_request(
+                conn,
+                provision["id"],
+                user_context=member,
+            )
+        visible, ambiguous = vault_service.resolve_pending_provision_request_by_name(
+            conn,
+            "MISSING_SECRET",
+            user_context=owner,
+        )
+
+    assert visible is not None
+    assert visible["id"] == provision["id"]
+    assert ambiguous is False
+
+    monkeypatch.setattr(api, "_vault_engine", lambda: vault)
+    monkeypatch.setattr(api, "resolve_resource_access_context", lambda: member)
+    with pytest.raises(api.VaultApiError) as by_name:
+        api.get_vault_provision_request_by_name("MISSING_SECRET")
+    with pytest.raises(api.VaultApiError) as by_id:
+        api.get_vault_provision_request(provision["id"])
+    assert by_name.value.status == 403
+    assert by_id.value.status == 403
+
+
 def test_vault_request_limit_applies_after_acl_filtering(vault) -> None:
     owner = _context("owner-1")
     member = _context("member-1")

--- a/tests/test_resource_acl_vaults.py
+++ b/tests/test_resource_acl_vaults.py
@@ -24,15 +24,17 @@ def _context(
     subject: str,
     *,
     group_ids: frozenset[str] | None = frozenset({"group-engineering"}),
+    role: str = "member",
+    instance_role: str = "viewer",
 ) -> resource_access_service.ResourceUserContext:
     return resource_access_service.ResourceUserContext(
         subject=subject,
         email=f"{subject}@example.com",
         organization_id="org-1",
         organization_member_id=f"member-{subject}",
-        organization_role="member",
+        organization_role=role,
         group_ids=group_ids,
-        instance_role="viewer",
+        instance_role=instance_role,
         instance_access_source="organization_group",
         is_remote=True,
     )
@@ -261,6 +263,51 @@ def test_vault_audit_filters_secret_request_and_grant_metadata_before_limit(vaul
     assert [row["event"] for row in visible] == ["member-visible"]
     assert owner_request["id"] not in json.dumps(visible)
     assert owner_grant["id"] not in json.dumps(visible)
+
+
+def test_deleted_secret_audit_history_uses_acl_tombstone_without_exposing_it(vault) -> None:
+    owner = _context("member-1")
+    admin = _context("admin-1", role="admin")
+    outsider = _context("member-2")
+    with vault.begin() as conn:
+        _create_secret(conn, "DELETED_AUDIT", protection="protected")
+        _set_policy(conn, "DELETED_AUDIT", access_level="private", owner_user_id="member-1")
+        vault_service.audit(conn, "before-delete", secret_name="DELETED_AUDIT")
+        vault_service.delete_secret(conn, "DELETED_AUDIT", user_context=admin)
+
+        owner_rows = vault_service.list_audit(conn, secret_name="DELETED_AUDIT", user_context=owner)
+        admin_rows = vault_service.list_audit(conn, secret_name="DELETED_AUDIT", user_context=admin)
+        outsider_rows = vault_service.list_audit(conn, secret_name="DELETED_AUDIT", user_context=outsider)
+
+    expected_events = {"before-delete", "deleted"}
+    assert expected_events <= {row["event"] for row in owner_rows}
+    assert expected_events <= {row["event"] for row in admin_rows}
+    assert outsider_rows == []
+    assert vault_service._AUDIT_ACCESS_SNAPSHOT_KEY not in json.dumps(owner_rows)
+    assert vault_service._AUDIT_ACCESS_SNAPSHOT_KEY not in json.dumps(admin_rows)
+
+
+def test_remote_audit_uses_bounded_keyset_batches_until_limit_is_visible(vault, monkeypatch) -> None:
+    member = _context("member-1")
+    monkeypatch.setattr(vault_service, "_REMOTE_AUDIT_MIN_BATCH_SIZE", 2)
+    monkeypatch.setattr(vault_service, "_REMOTE_AUDIT_MAX_BATCH_SIZE", 2)
+    with vault.begin() as conn:
+        _create_secret(conn, "BATCH_VISIBLE")
+        _create_secret(conn, "BATCH_HIDDEN")
+        _set_policy(conn, "BATCH_VISIBLE", access_level="public")
+        _set_policy(conn, "BATCH_HIDDEN", access_level="private")
+        vault_service.audit(conn, "batch-visible", secret_name="BATCH_VISIBLE")
+        for index in range(5):
+            vault_service.audit(
+                conn,
+                f"batch-hidden-{index}",
+                secret_name="BATCH_HIDDEN",
+            )
+
+        visible = vault_service.list_audit(conn, limit=1, user_context=member)
+
+    assert [row["event"] for row in visible] == ["batch-visible"]
+    assert vault_service._AUDIT_ACCESS_SNAPSHOT_KEY not in json.dumps(visible)
 
 
 def test_vault_api_grant_and_audit_endpoints_use_current_resource_context(vault, monkeypatch) -> None:

--- a/tests/test_resource_acl_vaults.py
+++ b/tests/test_resource_acl_vaults.py
@@ -11,6 +11,7 @@ from storage.models import (
     metadata,
     resource_access_groups,
     resource_access_policies,
+    state_meta,
     vault_grants,
     vault_requests,
     vault_secrets,
@@ -337,3 +338,76 @@ def test_narrowed_vault_policy_revokes_active_grants(
         status = conn.execute(select(vault_grants.c.status).where(vault_grants.c.id == grant["id"])).scalar_one()
     assert status == "revoked"
     assert releases == [{"scopes": [{"grant_id": grant["id"]}], "reason": "resource-access-policy-narrowed"}]
+
+
+def test_narrowed_vault_release_failure_stays_pending_until_retry_succeeds(vault, monkeypatch) -> None:
+    owner = _context("owner-1")
+    with vault.begin() as conn:
+        _create_secret(conn, "RETRY_RELEASE_KEY", protection="protected")
+        resource_id = _set_policy(conn, "RETRY_RELEASE_KEY", access_level="public")
+        request = vault_service.create_access_request(conn, "RETRY_RELEASE_KEY", user_context=owner)
+        grant = _grant_from_request(conn, request, user_context=owner)
+
+    intent = {
+        "resource_kind": "vault_secret",
+        "resource_id": resource_id,
+        "revision": 2,
+        "access_level": "private",
+        "group_ids": [],
+    }
+    monkeypatch.setattr("storage.db.get_cached_sqlite_engine", lambda: vault)
+    monkeypatch.setattr(
+        remote_access,
+        "publish_resource_index",
+        lambda *_args, **_kwargs: {"organization_id": "org-1", "resources": []},
+    )
+    monkeypatch.setattr(
+        remote_access,
+        "pull_resource_acl_intents",
+        lambda *_args, **_kwargs: {"organization_id": "org-1", "intents": [intent]},
+    )
+    acknowledgements: list[dict] = []
+    monkeypatch.setattr(
+        remote_access,
+        "acknowledge_resource_acl_intent",
+        lambda *_args, **kwargs: acknowledgements.append(kwargs),
+    )
+    releases: list[list[dict[str, str]]] = []
+
+    def release(scopes, *, reason):
+        releases.append([dict(scope) for scope in scopes])
+        if len(releases) == 1:
+            raise RuntimeError("resident release failed")
+
+    monkeypatch.setattr(remote_access.api, "release_vault_agent_scopes", release)
+
+    first = remote_access._sync_one_organization(None, organization_id="org-1", resources=[])
+    pending_key = remote_access._pending_vault_release_key("org-1", resource_id, 2)
+    with vault.connect() as conn:
+        pending_after_failure = conn.execute(
+            select(state_meta.c.value_json).where(state_meta.c.key == pending_key)
+        ).scalar_one_or_none()
+
+    second = remote_access._sync_one_organization(None, organization_id="org-1", resources=[])
+    with vault.connect() as conn:
+        pending_after_success = conn.execute(
+            select(state_meta.c.value_json).where(state_meta.c.key == pending_key)
+        ).scalar_one_or_none()
+
+    assert first["ok"] is False
+    assert first["applied"] == 1
+    assert first["acknowledged"] == 0
+    assert first["ack_errors"] == 1
+    assert pending_after_failure is not None
+    assert second["ok"] is True
+    assert second["acknowledged"] == 1
+    assert pending_after_success is None
+    assert releases == [[{"grant_id": grant["id"]}], [{"grant_id": grant["id"]}]]
+    assert acknowledgements == [
+        {
+            "resource_kind": "vault_secret",
+            "resource_id": resource_id,
+            "revision": 2,
+            "outcome": "applied",
+        }
+    ]

--- a/tests/test_resource_acl_vaults.py
+++ b/tests/test_resource_acl_vaults.py
@@ -160,6 +160,40 @@ def test_inaccessible_vault_requests_and_grants_fail_before_mutating_state(vault
     assert grants == []
 
 
+def test_vault_request_reads_and_denial_enforce_member_secret_acls(vault) -> None:
+    owner = _context("owner-1")
+    member = _context("member-1")
+    with vault.begin() as conn:
+        _create_secret(conn, "PRIVATE_REQUEST", protection="protected")
+        _create_secret(conn, "PUBLIC_REQUEST", protection="protected")
+        _set_policy(conn, "PRIVATE_REQUEST", access_level="private")
+        _set_policy(conn, "PUBLIC_REQUEST", access_level="public")
+        private_request = vault_service.create_access_request(conn, "PRIVATE_REQUEST", user_context=owner)
+        public_request = vault_service.create_access_request(conn, "PUBLIC_REQUEST", user_context=owner)
+
+        visible = vault_service.list_requests(conn, user_context=member)
+        with pytest.raises(vault_service.VaultSecretAccessError):
+            vault_service.get_request(conn, private_request["id"], user_context=member)
+        with pytest.raises(vault_service.VaultSecretAccessError):
+            vault_service.deny_request(conn, private_request["id"], user_context=member)
+        with pytest.raises(vault_service.VaultSecretAccessError):
+            vault_service.deny_request(conn, public_request["id"], user_context=member)
+
+        statuses_before_owner_decision = dict(
+            conn.execute(select(vault_requests.c.id, vault_requests.c.status)).all()
+        )
+        owner_payload = vault_service.get_request(conn, private_request["id"], user_context=owner)
+        denied = vault_service.deny_request(conn, private_request["id"], user_context=owner)
+
+    assert [request["id"] for request in visible] == [public_request["id"]]
+    assert "secret_unlock_material" in owner_payload["card"]
+    assert statuses_before_owner_decision == {
+        private_request["id"]: "pending",
+        public_request["id"]: "pending",
+    }
+    assert denied["status"] == "denied"
+
+
 @pytest.mark.parametrize(
     "selector",
     [

--- a/tests/test_resource_acl_vaults.py
+++ b/tests/test_resource_acl_vaults.py
@@ -17,7 +17,7 @@ from storage.models import (
     vault_secrets,
 )
 from storage.vault_crypto import Sealed
-from vibe import remote_access
+from vibe import api, remote_access
 
 
 def _context(
@@ -67,6 +67,7 @@ def _set_policy(
     *,
     access_level: str,
     group_ids: list[str] | None = None,
+    owner_user_id: str = "owner-1",
 ) -> str:
     resource_id = _secret_id(conn, name)
     resource_access_service.ensure_resource_policy(
@@ -74,7 +75,7 @@ def _set_policy(
         resource_kind="vault_secret",
         resource_id=resource_id,
         organization_id="org-1",
-        owner_user_id="owner-1",
+        owner_user_id=owner_user_id,
         access_level=access_level,
         group_ids=group_ids,
         policy_revision=1,
@@ -208,6 +209,99 @@ def test_vault_request_limit_applies_after_acl_filtering(vault) -> None:
         visible = vault_service.list_requests(conn, limit=1, user_context=member)
 
     assert [request["id"] for request in visible] == [visible_request["id"]]
+
+
+def test_vault_grant_reads_and_revocation_enforce_all_member_secret_acls(vault) -> None:
+    owner = _context("owner-1")
+    member = _context("member-1")
+    with vault.begin() as conn:
+        _create_secret(conn, "OWNER_GRANT", protection="protected")
+        _create_secret(conn, "MEMBER_GRANT", protection="protected")
+        _set_policy(conn, "OWNER_GRANT", access_level="private")
+        _set_policy(conn, "MEMBER_GRANT", access_level="private", owner_user_id="member-1")
+        owner_request = vault_service.create_access_request(conn, "OWNER_GRANT", user_context=owner)
+        member_request = vault_service.create_access_request(conn, "MEMBER_GRANT", user_context=member)
+        owner_grant = _grant_from_request(conn, owner_request, user_context=owner)
+        member_grant = _grant_from_request(conn, member_request, user_context=member)
+
+        visible = vault_service.list_grants(conn, user_context=member)
+        with pytest.raises(vault_service.VaultSecretAccessError):
+            vault_service.revoke_grant(conn, owner_grant["id"], user_context=member)
+        owner_status = conn.execute(
+            select(vault_grants.c.status).where(vault_grants.c.id == owner_grant["id"])
+        ).scalar_one()
+        revoked = vault_service.revoke_grant(conn, member_grant["id"], user_context=member)
+
+    assert [grant["id"] for grant in visible] == [member_grant["id"]]
+    assert owner_status == "active"
+    assert revoked["status"] == "revoked"
+
+
+def test_vault_audit_filters_secret_request_and_grant_metadata_before_limit(vault) -> None:
+    owner = _context("owner-1")
+    member = _context("member-1")
+    with vault.begin() as conn:
+        _create_secret(conn, "OWNER_AUDIT", protection="protected")
+        _create_secret(conn, "MEMBER_AUDIT", protection="protected")
+        _set_policy(conn, "OWNER_AUDIT", access_level="private")
+        _set_policy(conn, "MEMBER_AUDIT", access_level="private", owner_user_id="member-1")
+        owner_request = vault_service.create_access_request(conn, "OWNER_AUDIT", user_context=owner)
+        owner_grant = _grant_from_request(conn, owner_request, user_context=owner)
+        vault_service.audit(conn, "member-visible", secret_name="MEMBER_AUDIT")
+        vault_service.audit(
+            conn,
+            "owner-hidden",
+            request_id=owner_request["id"],
+            grant_id=owner_grant["id"],
+            delivery={"grant_id": owner_grant["id"]},
+        )
+
+        visible = vault_service.list_audit(conn, limit=1, user_context=member)
+
+    assert [row["event"] for row in visible] == ["member-visible"]
+    assert owner_request["id"] not in json.dumps(visible)
+    assert owner_grant["id"] not in json.dumps(visible)
+
+
+def test_vault_api_grant_and_audit_endpoints_use_current_resource_context(vault, monkeypatch) -> None:
+    owner = _context("owner-1")
+    member = _context("member-1")
+    with vault.begin() as conn:
+        _create_secret(conn, "API_OWNER", protection="protected")
+        _create_secret(conn, "API_MEMBER", protection="protected")
+        _set_policy(conn, "API_OWNER", access_level="private")
+        _set_policy(conn, "API_MEMBER", access_level="private", owner_user_id="member-1")
+        owner_request = vault_service.create_access_request(conn, "API_OWNER", user_context=owner)
+        member_request = vault_service.create_access_request(conn, "API_MEMBER", user_context=member)
+        owner_grant = _grant_from_request(conn, owner_request, user_context=owner)
+        member_grant = _grant_from_request(conn, member_request, user_context=member)
+        vault_service.audit(conn, "api-member-visible", secret_name="API_MEMBER")
+
+    releases: list[list[dict[str, str]]] = []
+    monkeypatch.setattr(api, "_vault_engine", lambda: vault)
+    monkeypatch.setattr(api, "resolve_resource_access_context", lambda: member)
+    monkeypatch.setattr(
+        api,
+        "release_vault_agent_scopes",
+        lambda scopes, *, reason: releases.append([dict(scope) for scope in scopes]),
+    )
+
+    grants = api.get_vault_grants()["grants"]
+    audit_rows = api.get_vault_audit()["events"]
+    with pytest.raises(api.VaultApiError) as exc:
+        api.revoke_vault_grant(owner_grant["id"])
+
+    with vault.connect() as conn:
+        owner_status = conn.execute(
+            select(vault_grants.c.status).where(vault_grants.c.id == owner_grant["id"])
+        ).scalar_one()
+
+    assert [grant["id"] for grant in grants] == [member_grant["id"]]
+    assert "api-member-visible" in {row["event"] for row in audit_rows}
+    assert owner_grant["id"] not in json.dumps(audit_rows)
+    assert exc.value.status == 403
+    assert owner_status == "active"
+    assert releases == []
 
 
 @pytest.mark.parametrize(

--- a/tests/test_resource_acl_vaults.py
+++ b/tests/test_resource_acl_vaults.py
@@ -194,6 +194,22 @@ def test_vault_request_reads_and_denial_enforce_member_secret_acls(vault) -> Non
     assert denied["status"] == "denied"
 
 
+def test_vault_request_limit_applies_after_acl_filtering(vault) -> None:
+    owner = _context("owner-1")
+    member = _context("member-1")
+    with vault.begin() as conn:
+        _create_secret(conn, "VISIBLE_REQUEST", protection="protected")
+        _create_secret(conn, "HIDDEN_REQUEST", protection="protected")
+        _set_policy(conn, "VISIBLE_REQUEST", access_level="public")
+        _set_policy(conn, "HIDDEN_REQUEST", access_level="private")
+        visible_request = vault_service.create_access_request(conn, "VISIBLE_REQUEST", user_context=owner)
+        vault_service.create_access_request(conn, "HIDDEN_REQUEST", user_context=owner)
+
+        visible = vault_service.list_requests(conn, limit=1, user_context=member)
+
+    assert [request["id"] for request in visible] == [visible_request["id"]]
+
+
 @pytest.mark.parametrize(
     "selector",
     [

--- a/tests/test_skills_service.py
+++ b/tests/test_skills_service.py
@@ -12,6 +12,9 @@ import asyncio
 import os
 
 import pytest
+from storage import resource_access_service
+from storage.db import create_sqlite_engine
+from storage.models import metadata
 
 from core.services import skills
 
@@ -30,6 +33,64 @@ class _Recorder:
     async def __call__(self, askill_path, args, *, cwd=None, timeout=skills.DEFAULT_TIMEOUT):
         self.calls.append({"path": askill_path, "args": list(args), "cwd": cwd})
         return self.result
+
+
+class _SequenceRecorder(_Recorder):
+    def __init__(self, results):
+        super().__init__(None)
+        self.results = list(results)
+
+    async def __call__(self, askill_path, args, *, cwd=None, timeout=skills.DEFAULT_TIMEOUT):
+        self.calls.append({"path": askill_path, "args": list(args), "cwd": cwd})
+        return self.results.pop(0)
+
+
+def _organization_context(
+    subject: str,
+    *,
+    group_ids: frozenset[str] | None = frozenset({"group-engineering"}),
+    role: str = "member",
+) -> resource_access_service.ResourceUserContext:
+    return resource_access_service.ResourceUserContext(
+        subject=subject,
+        email=f"{subject}@example.com",
+        organization_id="org-1",
+        organization_member_id=f"member-{subject}",
+        organization_role=role,
+        group_ids=group_ids,
+        instance_access_source="organization_group",
+        is_remote=True,
+    )
+
+
+def _skills_engine(monkeypatch, tmp_path):
+    engine = create_sqlite_engine(tmp_path / "skills_acl.sqlite")
+    metadata.create_all(engine)
+    monkeypatch.setattr("storage.db.get_cached_sqlite_engine", lambda: engine)
+    return engine
+
+
+def _skill_row(name: str) -> dict:
+    return {
+        "name": name,
+        "scope": "global",
+        "path": f"/skills/{name}",
+        "agents": [{"id": "codex", "name": "Codex"}],
+    }
+
+
+def _seed_skill_policy(conn, name: str, *, access_level: str, group_ids: list[str] | None = None) -> str:
+    resource_id = skills.skill_resource_id("codex", scope="global", project_dir=None, name=name)
+    resource_access_service.ensure_resource_policy(
+        conn,
+        resource_kind="skill",
+        resource_id=resource_id,
+        organization_id="org-1",
+        owner_user_id="owner-1",
+        access_level=access_level,
+        group_ids=group_ids,
+    )
+    return resource_id
 
 
 def test_list_global_uses_g_no_cwd(monkeypatch):
@@ -151,6 +212,164 @@ def test_update_one_skill(monkeypatch):
     assert rec.calls[0]["cwd"] == "/p"
     _run(skills.update("askill", "pdf-tools", scope="global"))
     assert rec.calls[1]["args"] == ["update", "pdf-tools", "-g", "-y"]
+
+
+def test_skill_resource_id_is_stable_and_backend_scoped(tmp_path) -> None:
+    global_id = skills.skill_resource_id("codex", scope="global", project_dir=None, name="Release Tools")
+    project_id = skills.skill_resource_id(
+        "codex",
+        scope="project",
+        project_dir=str(tmp_path / "project"),
+        name="Release Tools",
+    )
+
+    assert global_id == "codex:global:global:release-tools"
+    assert project_id.startswith("codex:project:project-")
+    assert project_id.endswith(":release-tools")
+    assert project_id == skills.skill_resource_id(
+        "codex",
+        scope="project",
+        project_dir=str(tmp_path / "project"),
+        name="Release Tools",
+    )
+
+
+def test_list_skills_filters_private_public_scope_and_missing_group_context(monkeypatch, tmp_path) -> None:
+    engine = _skills_engine(monkeypatch, tmp_path)
+    try:
+        with engine.begin() as connection:
+            _seed_skill_policy(connection, "private-skill", access_level="private")
+            _seed_skill_policy(connection, "public-skill", access_level="public")
+            _seed_skill_policy(
+                connection,
+                "scoped-skill",
+                access_level="scope",
+                group_ids=["group-engineering"],
+            )
+
+        rec = _Recorder(
+            {
+                "ok": True,
+                "summary": {"global": 3, "project": 0},
+                "skills": [_skill_row("private-skill"), _skill_row("public-skill"), _skill_row("scoped-skill")],
+            }
+        )
+        monkeypatch.setattr(skills, "_run_askill", rec)
+
+        owner = _run(skills.list_skills("askill", scope="global", user_context=_organization_context("owner-1")))
+        member = _run(skills.list_skills("askill", scope="global", user_context=_organization_context("member-1")))
+        missing_groups = _run(
+            skills.list_skills("askill", scope="global", user_context=_organization_context("member-2", group_ids=None))
+        )
+    finally:
+        engine.dispose()
+
+    assert [skill["name"] for skill in owner["skills"]] == ["private-skill", "public-skill", "scoped-skill"]
+    assert [skill["name"] for skill in member["skills"]] == ["public-skill", "scoped-skill"]
+    assert [skill["name"] for skill in missing_groups["skills"]] == ["public-skill"]
+    assert missing_groups["summary"] == {"global": 1, "project": 0}
+
+
+def test_remote_skill_mutations_require_owner_or_organization_admin(monkeypatch, tmp_path) -> None:
+    engine = _skills_engine(monkeypatch, tmp_path)
+    listing = {"ok": True, "skills": [_skill_row("private-skill")]}
+    try:
+        with engine.begin() as connection:
+            _seed_skill_policy(connection, "private-skill", access_level="private")
+
+        member_recorder = _SequenceRecorder([listing])
+        monkeypatch.setattr(skills, "_run_askill", member_recorder)
+        with pytest.raises(skills.SkillAccessError) as member_error:
+            _run(
+                skills.remove_skill(
+                    "askill",
+                    "private-skill",
+                    scope="global",
+                    user_context=_organization_context("member-1"),
+                )
+            )
+        assert member_error.value.code == "resource_access_forbidden"
+        assert [call["args"] for call in member_recorder.calls] == [["list", "-g"]]
+
+        owner_recorder = _SequenceRecorder([listing, {"ok": True}])
+        monkeypatch.setattr(skills, "_run_askill", owner_recorder)
+        assert _run(
+            skills.remove_skill(
+                "askill",
+                "private-skill",
+                scope="global",
+                user_context=_organization_context("owner-1"),
+            )
+        ) == {"ok": True}
+        assert [call["args"] for call in owner_recorder.calls] == [["list", "-g"], ["remove", "private-skill", "-g"]]
+
+        admin_recorder = _SequenceRecorder([listing, {"ok": True}])
+        monkeypatch.setattr(skills, "_run_askill", admin_recorder)
+        assert _run(
+            skills.update(
+                "askill",
+                "private-skill",
+                scope="global",
+                user_context=_organization_context("member-2", role="admin"),
+            )
+        ) == {"ok": True}
+        assert [call["args"] for call in admin_recorder.calls] == [["list", "-g"], ["update", "private-skill", "-g", "-y"]]
+
+        add_recorder = _Recorder({"ok": True, "action": "install", "summary": {"skills": 1}})
+        monkeypatch.setattr(skills, "_run_askill", add_recorder)
+        with pytest.raises(skills.SkillAccessError):
+            _run(
+                skills.add_skill(
+                    "askill",
+                    "gh:owner/repo",
+                    scope="global",
+                    skill="private-skill",
+                    backends=["codex"],
+                    user_context=_organization_context("member-1"),
+                )
+            )
+        assert add_recorder.calls == []
+    finally:
+        engine.dispose()
+
+
+def test_remote_skill_add_registers_private_policy(monkeypatch, tmp_path) -> None:
+    engine = _skills_engine(monkeypatch, tmp_path)
+    try:
+        rec = _Recorder(
+            {
+                "ok": True,
+                "action": "install",
+                "summary": {"skills": 1},
+                "selectedAgents": ["codex"],
+                "results": [{"skill": "new-skill", "success": True}],
+            }
+        )
+        monkeypatch.setattr(skills, "_run_askill", rec)
+
+        result = _run(
+            skills.add_skill(
+                "askill",
+                "gh:owner/repo",
+                scope="global",
+                skill="new-skill",
+                backends=["codex"],
+                user_context=_organization_context("member-1"),
+            )
+        )
+        with engine.connect() as connection:
+            policy = resource_access_service.get_resource_policy(
+                "skill",
+                skills.skill_resource_id("codex", scope="global", project_dir=None, name="new-skill"),
+                connection=connection,
+            )
+    finally:
+        engine.dispose()
+
+    assert result["ok"] is True
+    assert policy is not None
+    assert policy["owner_user_id"] == "member-1"
+    assert policy["access_level"] == "private"
 
 
 def test_invalid_backend_raises(monkeypatch):

--- a/tests/test_skills_service.py
+++ b/tests/test_skills_service.py
@@ -58,6 +58,7 @@ def _organization_context(
         organization_member_id=f"member-{subject}",
         organization_role=role,
         group_ids=group_ids,
+        instance_role="viewer",
         instance_access_source="organization_group",
         is_remote=True,
     )

--- a/tests/test_skills_service.py
+++ b/tests/test_skills_service.py
@@ -80,8 +80,15 @@ def _skill_row(name: str) -> dict:
     }
 
 
-def _seed_skill_policy(conn, name: str, *, access_level: str, group_ids: list[str] | None = None) -> str:
-    resource_id = skills.skill_resource_id("codex", scope="global", project_dir=None, name=name)
+def _seed_skill_policy(
+    conn,
+    name: str,
+    *,
+    access_level: str,
+    group_ids: list[str] | None = None,
+    backend: str = "codex",
+) -> str:
+    resource_id = skills.skill_resource_id(backend, scope="global", project_dir=None, name=name)
     resource_access_service.ensure_resource_policy(
         conn,
         resource_kind="skill",
@@ -303,6 +310,15 @@ def test_remote_skill_mutations_require_owner_or_organization_admin(monkeypatch,
             )
         ) == {"ok": True}
         assert [call["args"] for call in owner_recorder.calls] == [["list", "-g"], ["remove", "private-skill", "-g"]]
+        with engine.connect() as connection:
+            assert resource_access_service.get_resource_policy(
+                "skill",
+                skills.skill_resource_id("codex", scope="global", project_dir=None, name="private-skill"),
+                connection=connection,
+            ) is None
+
+        with engine.begin() as connection:
+            _seed_skill_policy(connection, "private-skill", access_level="private")
 
         admin_recorder = _SequenceRecorder([listing, {"ok": True}])
         monkeypatch.setattr(skills, "_run_askill", admin_recorder)
@@ -332,6 +348,61 @@ def test_remote_skill_mutations_require_owner_or_organization_admin(monkeypatch,
         assert add_recorder.calls == []
     finally:
         engine.dispose()
+
+
+def test_remove_skill_deletes_only_policies_for_removed_backends(monkeypatch, tmp_path) -> None:
+    engine = _skills_engine(monkeypatch, tmp_path)
+    listing = {
+        "ok": True,
+        "skills": [
+            {
+                **_skill_row("shared-skill"),
+                "agents": [
+                    {"id": "codex", "name": "Codex"},
+                    {"id": "claude", "name": "Claude"},
+                ],
+            }
+        ],
+    }
+    try:
+        with engine.begin() as connection:
+            codex_id = _seed_skill_policy(connection, "shared-skill", access_level="private")
+            claude_id = _seed_skill_policy(
+                connection,
+                "shared-skill",
+                access_level="private",
+                backend="claude",
+            )
+        recorder = _SequenceRecorder(
+            [
+                listing,
+                {
+                    "ok": True,
+                    "selectedAgents": ["codex", "claude"],
+                    "removedAgents": ["codex"],
+                },
+            ]
+        )
+        monkeypatch.setattr(skills, "_run_askill", recorder)
+
+        result = _run(
+            skills.remove_skill(
+                "askill",
+                "shared-skill",
+                scope="global",
+                backends=["codex", "claude"],
+                user_context=_organization_context("owner-1"),
+            )
+        )
+        with engine.connect() as connection:
+            codex_policy = resource_access_service.get_resource_policy("skill", codex_id, connection=connection)
+            claude_policy = resource_access_service.get_resource_policy("skill", claude_id, connection=connection)
+    finally:
+        engine.dispose()
+
+    assert result["ok"] is True
+    assert codex_policy is None
+    assert claude_policy is not None
 
 
 def test_remote_skill_add_registers_private_policy(monkeypatch, tmp_path) -> None:

--- a/tests/test_skills_service.py
+++ b/tests/test_skills_service.py
@@ -278,6 +278,48 @@ def test_list_skills_filters_private_public_scope_and_missing_group_context(monk
     assert missing_groups["summary"] == {"global": 1, "project": 0}
 
 
+def test_check_skills_filters_acl_rows_and_recomputes_summary(monkeypatch, tmp_path) -> None:
+    engine = _skills_engine(monkeypatch, tmp_path)
+    try:
+        with engine.begin() as connection:
+            _seed_skill_policy(connection, "private-skill", access_level="private")
+            _seed_skill_policy(connection, "public-skill", access_level="public")
+            _seed_skill_policy(
+                connection,
+                "scoped-skill",
+                access_level="scope",
+                group_ids=["group-engineering"],
+            )
+        rec = _Recorder(
+            {
+                "ok": True,
+                "summary": {"total": 3, "updateAvailable": 2, "upToDate": 1, "uncheckable": 0},
+                "skills": [
+                    {"name": "private-skill", "scope": "global", "status": "update_available"},
+                    {"name": "public-skill", "scope": "global", "status": "up_to_date"},
+                    {"name": "scoped-skill", "scope": "global", "status": "update_available"},
+                ],
+            }
+        )
+        monkeypatch.setattr(skills, "_run_askill", rec)
+
+        member = _run(skills.check("askill", scope="global", user_context=_organization_context("member-1")))
+        missing_groups = _run(
+            skills.check(
+                "askill",
+                scope="global",
+                user_context=_organization_context("member-2", group_ids=None),
+            )
+        )
+    finally:
+        engine.dispose()
+
+    assert [skill["name"] for skill in member["skills"]] == ["public-skill", "scoped-skill"]
+    assert member["summary"] == {"total": 2, "updateAvailable": 1, "upToDate": 1, "uncheckable": 0}
+    assert [skill["name"] for skill in missing_groups["skills"]] == ["public-skill"]
+    assert missing_groups["summary"] == {"total": 1, "updateAvailable": 0, "upToDate": 1, "uncheckable": 0}
+
+
 def test_remote_skill_mutations_require_owner_or_organization_admin(monkeypatch, tmp_path) -> None:
     engine = _skills_engine(monkeypatch, tmp_path)
     listing = {"ok": True, "skills": [_skill_row("private-skill")]}

--- a/tests/test_skills_service.py
+++ b/tests/test_skills_service.py
@@ -405,6 +405,47 @@ def test_remove_skill_deletes_only_policies_for_removed_backends(monkeypatch, tm
     assert claude_policy is not None
 
 
+@pytest.mark.parametrize("operation", ["remove", "update"])
+@pytest.mark.parametrize(
+    "listing",
+    [
+        {"ok": False, "error": {"code": "list_failed"}},
+        {"ok": True, "skills": []},
+        {"ok": True, "skills": "invalid"},
+    ],
+)
+def test_remote_skill_mutations_fail_closed_when_preflight_cannot_resolve_target(
+    monkeypatch,
+    tmp_path,
+    operation: str,
+    listing: dict,
+) -> None:
+    engine = _skills_engine(monkeypatch, tmp_path)
+    recorder = _SequenceRecorder([listing])
+    monkeypatch.setattr(skills, "_run_askill", recorder)
+    try:
+        if operation == "remove":
+            mutation = skills.remove_skill(
+                "askill",
+                "missing-skill",
+                scope="global",
+                user_context=_organization_context("owner-1"),
+            )
+        else:
+            mutation = skills.update(
+                "askill",
+                "missing-skill",
+                scope="global",
+                user_context=_organization_context("owner-1"),
+            )
+        with pytest.raises(skills.SkillAccessError):
+            _run(mutation)
+    finally:
+        engine.dispose()
+
+    assert [call["args"] for call in recorder.calls] == [["list", "-g"]]
+
+
 def test_remote_skill_add_registers_private_policy(monkeypatch, tmp_path) -> None:
     engine = _skills_engine(monkeypatch, tmp_path)
     try:

--- a/tests/test_skills_service.py
+++ b/tests/test_skills_service.py
@@ -50,6 +50,7 @@ def _organization_context(
     *,
     group_ids: frozenset[str] | None = frozenset({"group-engineering"}),
     role: str = "member",
+    instance_role: str = "viewer",
 ) -> resource_access_service.ResourceUserContext:
     return resource_access_service.ResourceUserContext(
         subject=subject,
@@ -58,7 +59,7 @@ def _organization_context(
         organization_member_id=f"member-{subject}",
         organization_role=role,
         group_ids=group_ids,
-        instance_role="viewer",
+        instance_role=instance_role,
         instance_access_source="organization_group",
         is_remote=True,
     )
@@ -491,14 +492,17 @@ def test_remote_skill_mutations_fail_closed_when_preflight_cannot_resolve_target
 def test_remote_skill_add_registers_private_policy(monkeypatch, tmp_path) -> None:
     engine = _skills_engine(monkeypatch, tmp_path)
     try:
-        rec = _Recorder(
-            {
-                "ok": True,
-                "action": "install",
-                "summary": {"skills": 1},
-                "selectedAgents": ["codex"],
-                "results": [{"skill": "new-skill", "success": True}],
-            }
+        rec = _SequenceRecorder(
+            [
+                {"ok": True, "skills": []},
+                {
+                    "ok": True,
+                    "action": "install",
+                    "summary": {"skills": 1},
+                    "selectedAgents": ["codex"],
+                    "results": [{"skill": "new-skill", "success": True}],
+                },
+            ]
         )
         monkeypatch.setattr(skills, "_run_askill", rec)
 
@@ -525,6 +529,87 @@ def test_remote_skill_add_registers_private_policy(monkeypatch, tmp_path) -> Non
     assert policy is not None
     assert policy["owner_user_id"] == "member-1"
     assert policy["access_level"] == "private"
+
+
+def test_remote_skill_add_requires_instance_owner_for_installed_legacy_skill(monkeypatch, tmp_path) -> None:
+    engine = _skills_engine(monkeypatch, tmp_path)
+    listing = {"ok": True, "skills": [_skill_row("legacy-skill")]}
+    member_recorder = _SequenceRecorder([listing])
+    monkeypatch.setattr(skills, "_run_askill", member_recorder)
+    try:
+        with pytest.raises(skills.SkillAccessError):
+            _run(
+                skills.add_skill(
+                    "askill",
+                    "gh:owner/repo",
+                    scope="global",
+                    skill="legacy-skill",
+                    backends=["codex"],
+                    user_context=_organization_context("member-1"),
+                )
+            )
+
+        owner_recorder = _SequenceRecorder(
+            [
+                listing,
+                {
+                    "ok": True,
+                    "action": "install",
+                    "summary": {"skills": 1},
+                    "selectedAgents": ["codex"],
+                    "results": [{"skill": "legacy-skill", "success": True}],
+                },
+            ]
+        )
+        monkeypatch.setattr(skills, "_run_askill", owner_recorder)
+        result = _run(
+            skills.add_skill(
+                "askill",
+                "gh:owner/repo",
+                scope="global",
+                skill="legacy-skill",
+                backends=["codex"],
+                user_context=_organization_context("owner-1", instance_role="owner"),
+            )
+        )
+    finally:
+        engine.dispose()
+
+    assert [call["args"] for call in member_recorder.calls] == [["list", "-g", "-a", "codex"]]
+    assert [call["args"] for call in owner_recorder.calls] == [
+        ["list", "-g", "-a", "codex"],
+        ["add", "gh:owner/repo", "-g", "-a", "codex", "--skill", "legacy-skill", "-y"],
+    ]
+    assert result["ok"] is True
+
+
+def test_remote_skill_add_fails_closed_for_unresolved_installed_backend(monkeypatch, tmp_path) -> None:
+    engine = _skills_engine(monkeypatch, tmp_path)
+    recorder = _SequenceRecorder(
+        [
+            {
+                "ok": True,
+                "skills": [{**_skill_row("legacy-skill"), "agents": [{"id": "unknown"}]}],
+            }
+        ]
+    )
+    monkeypatch.setattr(skills, "_run_askill", recorder)
+    try:
+        with pytest.raises(skills.SkillAccessError):
+            _run(
+                skills.add_skill(
+                    "askill",
+                    "gh:owner/repo",
+                    scope="global",
+                    skill="legacy-skill",
+                    backends=["codex"],
+                    user_context=_organization_context("member-1"),
+                )
+            )
+    finally:
+        engine.dispose()
+
+    assert [call["args"] for call in recorder.calls] == [["list", "-g", "-a", "codex"]]
 
 
 def test_invalid_backend_raises(monkeypatch):

--- a/tests/test_sqlite_state_migration.py
+++ b/tests/test_sqlite_state_migration.py
@@ -19,7 +19,7 @@ from storage.models import metadata
 from storage.settings_service import SQLiteSettingsService
 
 
-HEAD_REVISION = "20260724_0034"
+HEAD_REVISION = "20260725_0035"
 
 
 def _index_sql(conn: sqlite3.Connection, name: str) -> str:
@@ -54,6 +54,8 @@ def test_run_migrations_creates_initial_schema(tmp_path: Path) -> None:
         assert "web_push_subscriptions" in tables
         assert "vault_auth_factors" in tables
         assert "vault_operation_challenges" in tables
+        assert "resource_access_policies" in tables
+        assert "resource_access_groups" in tables
         agent_event_indexes = {
             row[1]
             for row in conn.execute(
@@ -94,6 +96,18 @@ def test_run_migrations_creates_initial_schema(tmp_path: Path) -> None:
                 "select seq, name from pragma_index_list('vault_operation_challenges')",
             )
         }
+        resource_policy_indexes = {
+            row[1]
+            for row in conn.execute(
+                "select seq, name from pragma_index_list('resource_access_policies')",
+            )
+        }
+        resource_group_indexes = {
+            row[1]
+            for row in conn.execute(
+                "select seq, name from pragma_index_list('resource_access_groups')",
+            )
+        }
         assert "ix_messages_session_created_id" in message_indexes
         assert "ix_messages_session_type_created_id" in message_indexes
         assert "ix_messages_platform_session_created_id" in message_indexes
@@ -109,6 +123,9 @@ def test_run_migrations_creates_initial_schema(tmp_path: Path) -> None:
         assert "ix_vault_auth_factors_kind_rp" in vault_auth_factor_indexes
         assert "ix_vault_operation_challenges_lookup" in vault_challenge_indexes
         assert "ix_vault_operation_challenges_consumed" in vault_challenge_indexes
+        assert "ix_resource_access_policies_org_level" in resource_policy_indexes
+        assert "ix_resource_access_policies_owner" in resource_policy_indexes
+        assert "ix_resource_access_groups_group" in resource_group_indexes
         assert "trg_vault_requests_pending_provision_name_case_insert" in vault_request_triggers
         assert "trg_vault_requests_pending_provision_name_case_update" in vault_request_triggers
         agent_session_indexes = {

--- a/tests/test_terminal_backend.py
+++ b/tests/test_terminal_backend.py
@@ -34,7 +34,7 @@ from core.terminal_service import (
     _tmux_socket_name,
     sanitize_session_id,
 )
-from tests.ui_server_test_helpers import csrf_headers
+from tests.ui_server_test_helpers import csrf_headers, remote_session_cookie
 from vibe import remote_access
 from vibe import ui_server
 from vibe.ui_server import app
@@ -1629,7 +1629,7 @@ def test_terminal_delete_scopes_remote_subject_and_rejects_cross_subject(monkeyp
     user_two_client = app.test_client()
     user_two_client.set_cookie(
         remote_access.SESSION_COOKIE_NAME,
-        remote_access.make_session_cookie(config, "user-2@example.com", "user-2"),
+        remote_session_cookie(config, "user-2@example.com", "user-2"),
         domain="alex.avibe.bot",
     )
     headers = csrf_headers(user_two_client, "https://alex.avibe.bot")

--- a/tests/test_ui_remote_access_auth.py
+++ b/tests/test_ui_remote_access_auth.py
@@ -726,6 +726,27 @@ def test_remote_host_requires_authorization_refresh_before_mutation(monkeypatch,
     assert refreshed is None
 
 
+def test_remote_api_get_requires_top_level_authorization_refresh(monkeypatch, tmp_path):
+    import time as _time
+
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    config = _save_config(tmp_path)
+    near_exp = int(_time.time()) + (remote_access.SESSION_TTL_SECONDS // 2) - 60
+    cookie = _forged_session_cookie(config, near_exp)
+    client = app.test_client()
+    client.set_cookie(remote_access.SESSION_COOKIE_NAME, cookie, domain="alex.avibe.bot")
+
+    response = client.get(
+        "/api/config",
+        base_url="https://alex.avibe.bot",
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 401
+    assert response.get_json()["error"] == "remote_access_authorization_refresh_required"
+    assert response.headers.get("Location") is None
+
+
 def test_remote_host_fails_closed_when_config_load_fails(monkeypatch):
     def fail_load():
         raise ValueError("corrupt config")

--- a/tests/test_ui_remote_access_auth.py
+++ b/tests/test_ui_remote_access_auth.py
@@ -1174,6 +1174,52 @@ def test_remote_callback_rejects_nonce_mismatch(monkeypatch, tmp_path):
     assert 'href="/dashboard"' in response.text
 
 
+def test_remote_callback_rejects_oversized_session_cookie_without_redirect_loop(monkeypatch, tmp_path):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    config = _save_config(tmp_path)
+    client = app.test_client()
+
+    with app.test_request_context("/dashboard", base_url="https://alex.avibe.bot"):
+        redirect = ui_server._redirect_to_vibe_cloud_login(config)
+    oauth_cookie = redirect.headers["Set-Cookie"].split(";", 1)[0].split("=", 1)[1]
+    client.set_cookie(ui_server.REMOTE_OAUTH_COOKIE_NAME, oauth_cookie, domain="alex.avibe.bot")
+    oauth_state = ui_server._read_oauth_cookie(config.remote_access.vibe_cloud.session_secret, oauth_cookie)
+    group_ids = [f"00000000-0000-4000-8000-{index:012d}" for index in range(100)]
+
+    monkeypatch.setattr(
+        remote_access,
+        "exchange_oauth_code",
+        lambda cfg, code, verifier: {
+            "claims": {
+                "email": "member@example.com",
+                "sub": "user-1",
+                "nonce": oauth_state["nonce"],
+            },
+            "session_claims": {
+                "vibe_instance_id": "inst_123",
+                "vibe_instance_role": "viewer",
+                "vibe_instance_access_source": "organization_group",
+                "vibe_organization_id": "org-1",
+                "vibe_organization_member_id": "member-1",
+                "vibe_organization_role": "member",
+                "vibe_group_ids": group_ids,
+            },
+        },
+    )
+
+    response = client.get(
+        f"/auth/callback?code=test-code&state={oauth_state['state']}",
+        base_url="https://alex.avibe.bot",
+    )
+
+    assert response.status_code == 400
+    assert "reason: session_cookie_too_large" in response.text
+    assert not any(
+        header.startswith(f"{remote_access.SESSION_COOKIE_NAME}=")
+        for header in response.headers.getlist("Set-Cookie")
+    )
+
+
 def test_remote_callback_explains_pairing_mismatch(monkeypatch, tmp_path):
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     config = _save_config(tmp_path)

--- a/tests/test_ui_remote_access_auth.py
+++ b/tests/test_ui_remote_access_auth.py
@@ -663,6 +663,53 @@ def _forged_session_cookie(config: V2Config, exp: int, *, email: str = "alex@exa
     return f"{payload_text}.{signature}"
 
 
+def test_remote_session_probe_reports_unauthenticated_when_authorization_refresh_required(monkeypatch, tmp_path):
+    import time as _time
+
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    config = _save_config(tmp_path)
+    near_exp = int(_time.time()) + (remote_access.SESSION_TTL_SECONDS // 2) - 60
+    client = app.test_client()
+    client.set_cookie(
+        remote_access.SESSION_COOKIE_NAME,
+        _forged_session_cookie(config, near_exp),
+        domain="alex.avibe.bot",
+    )
+
+    response = client.get("/api/session", base_url="https://alex.avibe.bot")
+
+    assert response.status_code == 200
+    assert response.get_json() == {"remote": True, "authenticated": False}
+
+
+def test_cloud_token_requires_authorization_refresh_before_mint(monkeypatch, tmp_path):
+    import time as _time
+
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    config = _save_config(tmp_path)
+    near_exp = int(_time.time()) + (remote_access.SESSION_TTL_SECONDS // 2) - 60
+    mint_called = False
+
+    def fake_mint(*args, **kwargs):
+        nonlocal mint_called
+        mint_called = True
+        return {"access_token": "must-not-mint", "expires_in": 60}
+
+    monkeypatch.setattr(remote_access, "mint_cloud_token", fake_mint)
+    client = app.test_client()
+    client.set_cookie(
+        remote_access.SESSION_COOKIE_NAME,
+        _forged_session_cookie(config, near_exp),
+        domain="alex.avibe.bot",
+    )
+
+    response = client.get("/api/cloud/token", base_url="https://alex.avibe.bot")
+
+    assert response.status_code == 401
+    assert response.get_json()["error"] == "remote_access_authorization_refresh_required"
+    assert mint_called is False
+
+
 def test_remote_host_does_not_renew_fresh_cookie(monkeypatch, tmp_path):
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     config = _save_config(tmp_path)

--- a/tests/test_ui_remote_access_auth.py
+++ b/tests/test_ui_remote_access_auth.py
@@ -11,7 +11,7 @@ import pytest
 
 from config.v2_config import AgentsConfig, PlatformsConfig, RemoteAccessConfig, RuntimeConfig, SlackConfig, UiConfig, V2Config
 from config.v2_config import CONFIG_LOCK
-from tests.ui_server_test_helpers import csrf_headers
+from tests.ui_server_test_helpers import csrf_headers, remote_session_cookie
 from vibe import api
 from vibe import remote_access
 from vibe import ui_server
@@ -93,6 +93,14 @@ def _save_config(tmp_path) -> V2Config:
     cloud.redirect_uri = "https://alex.avibe.bot/auth/callback"
     config.save()
     return config
+
+
+def _owner_session_claims(config: V2Config) -> dict[str, str]:
+    return {
+        "vibe_instance_id": config.remote_access.vibe_cloud.instance_id,
+        "vibe_instance_role": "owner",
+        "vibe_instance_access_source": "owner",
+    }
 
 
 def _remote_peer() -> dict[str, str]:
@@ -606,7 +614,7 @@ def test_remote_host_allows_valid_remote_session(monkeypatch, tmp_path):
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     config = _save_config(tmp_path)
     client = app.test_client()
-    client.set_cookie(remote_access.SESSION_COOKIE_NAME, remote_access.make_session_cookie(config, "alex@example.com", "user-1"), domain="alex.avibe.bot")
+    client.set_cookie(remote_access.SESSION_COOKIE_NAME, remote_session_cookie(config, "alex@example.com", "user-1"), domain="alex.avibe.bot")
 
     response = client.get("/dashboard", base_url="https://alex.avibe.bot", follow_redirects=False)
 
@@ -619,7 +627,7 @@ def test_remote_session_info_includes_authenticated_subject(monkeypatch, tmp_pat
     client = app.test_client()
     client.set_cookie(
         remote_access.SESSION_COOKIE_NAME,
-        remote_access.make_session_cookie(config, "alex@example.com", "user-1"),
+        remote_session_cookie(config, "alex@example.com", "user-1"),
         domain="alex.avibe.bot",
     )
 
@@ -643,8 +651,12 @@ def _forged_session_cookie(config: V2Config, exp: int, *, email: str = "alex@exa
         "email": email,
         "sub": subject,
         "instance_id": cloud.instance_id,
+        "vibe_instance_id": cloud.instance_id,
+        "vibe_instance_role": "owner",
+        "vibe_instance_access_source": "owner",
         "iat": exp - remote_access.SESSION_TTL_SECONDS,
         "exp": exp,
+        "claims_issued_at": exp - remote_access.SESSION_TTL_SECONDS,
     }
     payload_text = urllib.parse.quote(json.dumps(payload, separators=(",", ":")), safe="")
     signature = remote_access._session_signature(cloud.session_secret, payload_text)
@@ -657,7 +669,7 @@ def test_remote_host_does_not_renew_fresh_cookie(monkeypatch, tmp_path):
     client = app.test_client()
     client.set_cookie(
         remote_access.SESSION_COOKIE_NAME,
-        remote_access.make_session_cookie(config, "alex@example.com", "user-1"),
+        remote_session_cookie(config, "alex@example.com", "user-1"),
         domain="alex.avibe.bot",
     )
 
@@ -667,7 +679,7 @@ def test_remote_host_does_not_renew_fresh_cookie(monkeypatch, tmp_path):
     assert not any(h.startswith(f"{remote_access.SESSION_COOKIE_NAME}=") for h in set_cookie_headers)
 
 
-def test_remote_host_renews_cookie_past_half_ttl(monkeypatch, tmp_path):
+def test_remote_host_refreshes_authorization_past_half_ttl(monkeypatch, tmp_path):
     import time as _time
 
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
@@ -679,26 +691,17 @@ def test_remote_host_renews_cookie_past_half_ttl(monkeypatch, tmp_path):
 
     response = client.get("/dashboard", base_url="https://alex.avibe.bot", follow_redirects=False)
 
-    refreshed = next(
-        (h for h in response.headers.getlist("Set-Cookie") if h.startswith(f"{remote_access.SESSION_COOKIE_NAME}=")),
-        None,
-    )
-    assert refreshed is not None
-    assert "HttpOnly" in refreshed
-    assert "Secure" in refreshed
-    new_value = refreshed.split(";", 1)[0].split("=", 1)[1]
-    assert new_value != cookie
-    payload = remote_access.parse_session_cookie(config, new_value)
-    assert payload is not None
-    assert payload["email"] == "alex@example.com"
-    assert payload["sub"] == "user-1"
-    assert payload["exp"] > near_exp
+    refreshed = [
+        header
+        for header in response.headers.getlist("Set-Cookie")
+        if header.startswith(f"{remote_access.SESSION_COOKIE_NAME}=")
+    ]
+    assert response.status_code == 302
+    assert response.headers["Location"].startswith("https://backend.test/oauth/authorize?")
+    assert refreshed == []
 
 
-def test_remote_host_does_not_renew_cookie_on_rejected_post(monkeypatch, tmp_path):
-    """A near-expiry cookie must NOT be slid by a request that later fails
-    a guard like CSRF/origin. Otherwise repeated rejected mutations could
-    keep a stolen session alive indefinitely."""
+def test_remote_host_requires_authorization_refresh_before_mutation(monkeypatch, tmp_path):
     import time as _time
 
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
@@ -708,16 +711,14 @@ def test_remote_host_does_not_renew_cookie_on_rejected_post(monkeypatch, tmp_pat
     client = app.test_client()
     client.set_cookie(remote_access.SESSION_COOKIE_NAME, cookie, domain="alex.avibe.bot")
 
-    # POST /config without CSRF/origin headers — protect_mutating_ui_requests
-    # will reject this with 403 inside the same request lifecycle that already
-    # set g.remote_session_renew in enforce_remote_access_cookie.
     response = client.post(
         "/api/config",
         json={"remote_access": {"vibe_cloud": {"enabled": False}}},
         base_url="https://alex.avibe.bot",
     )
 
-    assert response.status_code == 403
+    assert response.status_code == 401
+    assert response.get_json()["error"] == "remote_access_authorization_refresh_required"
     refreshed = next(
         (h for h in response.headers.getlist("Set-Cookie") if h.startswith(f"{remote_access.SESSION_COOKIE_NAME}=")),
         None,
@@ -1053,7 +1054,7 @@ def test_remote_config_post_accepts_public_origin_default_https_port(monkeypatch
     client = app.test_client()
     client.set_cookie(
         remote_access.SESSION_COOKIE_NAME,
-        remote_access.make_session_cookie(config, "alex@example.com", "user-1"),
+        remote_session_cookie(config, "alex@example.com", "user-1"),
         domain="alex.avibe.bot",
     )
     headers = csrf_headers(client, "https://alex.avibe.bot")
@@ -1157,7 +1158,8 @@ def test_remote_callback_rejects_nonce_mismatch(monkeypatch, tmp_path):
                 "email": "alex@example.com",
                 "sub": "user-1",
                 "nonce": "wrong-nonce",
-            }
+            },
+            "session_claims": _owner_session_claims(cfg),
         },
     )
 
@@ -1436,7 +1438,10 @@ def test_remote_callback_recovers_via_store_when_cookie_state_desyncs(monkeypatc
 
     def exchange(cfg, code, verifier):
         captured["verifier"] = verifier
-        return {"claims": {"email": "alex@example.com", "sub": "user-1", "nonce": "nonce-approved"}}
+        return {
+            "claims": {"email": "alex@example.com", "sub": "user-1", "nonce": "nonce-approved"},
+            "session_claims": _owner_session_claims(cfg),
+        }
 
     monkeypatch.setattr(remote_access, "exchange_oauth_code", exchange)
 
@@ -1761,7 +1766,8 @@ def test_remote_callback_accepts_html_escaped_state_separator(monkeypatch, tmp_p
                 "email": "alex@example.com",
                 "sub": "user-1",
                 "nonce": "nonce-1",
-            }
+            },
+            "session_claims": _owner_session_claims(cfg),
         }
 
     monkeypatch.setattr(remote_access, "exchange_oauth_code", exchange)
@@ -1797,7 +1803,8 @@ def test_remote_callback_sanitizes_protocol_relative_next(monkeypatch, tmp_path)
                 "email": "alex@example.com",
                 "sub": "user-1",
                 "nonce": "nonce-1",
-            }
+            },
+            "session_claims": _owner_session_claims(cfg),
         },
     )
 
@@ -2033,7 +2040,7 @@ def test_terminal_websocket_rejects_remote_same_host_different_origin(monkeypatc
     client = app.test_client()
     client.set_cookie(
         remote_access.SESSION_COOKIE_NAME,
-        remote_access.make_session_cookie(config, "alex@example.com", "user-1"),
+        remote_session_cookie(config, "alex@example.com", "user-1"),
         domain="alex.avibe.bot",
     )
 
@@ -2067,7 +2074,7 @@ def test_terminal_websocket_accepts_remote_exact_trusted_origin(monkeypatch, tmp
     client = app.test_client()
     client.set_cookie(
         remote_access.SESSION_COOKIE_NAME,
-        remote_access.make_session_cookie(config, "alex@example.com", "user-1"),
+        remote_session_cookie(config, "alex@example.com", "user-1"),
         domain="alex.avibe.bot",
     )
 
@@ -2113,7 +2120,7 @@ def test_terminal_websocket_scopes_remote_session_id_by_authenticated_subject(mo
         client = app.test_client()
         client.set_cookie(
             remote_access.SESSION_COOKIE_NAME,
-            remote_access.make_session_cookie(config, f"{subject}@example.com", subject),
+            remote_session_cookie(config, f"{subject}@example.com", subject),
             domain="alex.avibe.bot",
         )
         with client.websocket_connect(

--- a/tests/test_ui_resource_access_api.py
+++ b/tests/test_ui_resource_access_api.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+from config import paths
+from storage import resource_access_service
+from storage.db import get_cached_sqlite_engine
+from storage.migrations import run_migrations
+from tests.test_ui_remote_access_auth import _save_config
+from tests.ui_server_test_helpers import csrf_headers
+from vibe import remote_access
+from vibe.ui_server import app
+
+
+def _organization_cookie(config) -> str:
+    return remote_access.make_session_cookie(
+        config,
+        "member@example.com",
+        "member-1",
+        session_claims={
+            "vibe_instance_id": "inst_123",
+            "vibe_instance_access_source": "organization_group",
+            "vibe_organization_id": "org-1",
+            "vibe_organization_member_id": "organization-member-1",
+            "vibe_organization_role": "admin",
+            "vibe_group_ids": ["group-engineering"],
+            "vibe_membership_version": "membership-v2",
+        },
+    )
+
+
+def _external_guest_cookie(config) -> str:
+    return remote_access.make_session_cookie(
+        config,
+        "guest@example.com",
+        "guest-1",
+        session_claims={
+            "vibe_instance_id": "inst_123",
+            "vibe_instance_access_source": "email",
+        },
+    )
+
+
+def _seed_organization_policy() -> None:
+    paths.ensure_data_dirs()
+    run_migrations()
+    engine = get_cached_sqlite_engine()
+    with engine.begin() as connection:
+        resource_access_service.ensure_resource_policy(
+            connection,
+            resource_kind="agent",
+            resource_id="agent-1",
+            organization_id="org-1",
+            owner_user_id="owner-1",
+            access_level="scope",
+            group_ids=["group-engineering"],
+            policy_revision=2,
+            last_applied_control_plane_revision=2,
+        )
+
+
+def test_organization_context_and_policy_routes_use_signed_cookie_claims(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    config = _save_config(tmp_path)
+    _seed_organization_policy()
+    client = app.test_client()
+    client.set_cookie(
+        remote_access.SESSION_COOKIE_NAME,
+        _organization_cookie(config),
+        domain="alex.avibe.bot",
+    )
+
+    context = client.get("/api/org/context", base_url="https://alex.avibe.bot")
+    groups = client.get("/api/org/groups", base_url="https://alex.avibe.bot")
+    policies = client.get("/api/resource-policies?kind=agent", base_url="https://alex.avibe.bot")
+
+    assert context.status_code == 200
+    assert context.get_json()["organization"] == {
+        "id": "org-1",
+        "member_id": "organization-member-1",
+        "role": "admin",
+        "group_ids": ["group-engineering"],
+        "membership_version": "membership-v2",
+    }
+    assert groups.get_json() == {"groups": [{"id": "group-engineering", "name": None, "archived_at": None}]}
+    assert policies.status_code == 200
+    assert policies.get_json()["policies"] == [
+        {
+            "resource_kind": "agent",
+            "resource_id": "agent-1",
+            "access_level": "scope",
+            "owner_user_id": "owner-1",
+            "organization_id": "org-1",
+            "group_ids": ["group-engineering"],
+            "policy_revision": 2,
+            "last_applied_control_plane_revision": 2,
+            "can_use": True,
+            "can_manage": True,
+        }
+    ]
+
+
+def test_organization_policy_put_does_not_create_local_revision(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    config = _save_config(tmp_path)
+    _seed_organization_policy()
+    client = app.test_client()
+    client.set_cookie(
+        remote_access.SESSION_COOKIE_NAME,
+        _organization_cookie(config),
+        domain="alex.avibe.bot",
+    )
+    monkeypatch.setattr(
+        remote_access,
+        "sync_resource_acl_once",
+        lambda *_args, **_kwargs: {"ok": True, "organizations": [{"organization_id": "org-1"}]},
+    )
+
+    response = client.put(
+        "/api/resource-policies/agent/agent-1",
+        json={"access_level": "public", "group_ids": []},
+        headers=csrf_headers(client, "https://alex.avibe.bot"),
+        base_url="https://alex.avibe.bot",
+    )
+
+    assert response.status_code == 409
+    assert response.get_json()["error"] == "resource_acl_control_plane_required"
+    engine = get_cached_sqlite_engine()
+    with engine.connect() as connection:
+        policy = resource_access_service.get_resource_policy("agent", "agent-1", connection=connection)
+    assert policy is not None
+    assert policy["access_level"] == "scope"
+    assert policy["policy_revision"] == 2
+
+
+def test_external_guest_cannot_update_an_organization_policy(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    config = _save_config(tmp_path)
+    _seed_organization_policy()
+    client = app.test_client()
+    client.set_cookie(
+        remote_access.SESSION_COOKIE_NAME,
+        _external_guest_cookie(config),
+        domain="alex.avibe.bot",
+    )
+
+    response = client.put(
+        "/api/resource-policies/agent/agent-1",
+        json={"access_level": "public", "group_ids": []},
+        headers=csrf_headers(client, "https://alex.avibe.bot"),
+        base_url="https://alex.avibe.bot",
+    )
+
+    assert response.status_code == 404
+    assert response.get_json()["error"] == "resource_not_found"

--- a/tests/test_ui_resource_access_api.py
+++ b/tests/test_ui_resource_access_api.py
@@ -5,18 +5,19 @@ from storage import resource_access_service
 from storage.db import get_cached_sqlite_engine
 from storage.migrations import run_migrations
 from tests.test_ui_remote_access_auth import _save_config
-from tests.ui_server_test_helpers import csrf_headers
+from tests.ui_server_test_helpers import csrf_headers, remote_session_cookie
 from vibe import remote_access
 from vibe.ui_server import app
 
 
 def _organization_cookie(config) -> str:
-    return remote_access.make_session_cookie(
+    return remote_session_cookie(
         config,
         "member@example.com",
         "member-1",
         session_claims={
             "vibe_instance_id": "inst_123",
+            "vibe_instance_role": "viewer",
             "vibe_instance_access_source": "organization_group",
             "vibe_organization_id": "org-1",
             "vibe_organization_member_id": "organization-member-1",
@@ -28,12 +29,13 @@ def _organization_cookie(config) -> str:
 
 
 def _external_guest_cookie(config) -> str:
-    return remote_access.make_session_cookie(
+    return remote_session_cookie(
         config,
         "guest@example.com",
         "guest-1",
         session_claims={
             "vibe_instance_id": "inst_123",
+            "vibe_instance_role": "viewer",
             "vibe_instance_access_source": "email",
         },
     )
@@ -73,6 +75,7 @@ def test_organization_context_and_policy_routes_use_signed_cookie_claims(monkeyp
     policies = client.get("/api/resource-policies?kind=agent", base_url="https://alex.avibe.bot")
 
     assert context.status_code == 200
+    assert context.get_json()["instance_role"] == "viewer"
     assert context.get_json()["organization"] == {
         "id": "org-1",
         "member_id": "organization-member-1",

--- a/tests/test_ui_show_pages.py
+++ b/tests/test_ui_show_pages.py
@@ -33,7 +33,7 @@ from core.show_runtime import (
     set_show_runtime_manager_for_tests,
 )
 from tests.test_ui_remote_access_auth import _mock_interface, _remote_peer, _save_config
-from tests.ui_server_test_helpers import csrf_headers
+from tests.ui_server_test_helpers import csrf_headers, remote_session_cookie
 from vibe import remote_access, ui_server
 from vibe.ui_server import app
 
@@ -1020,7 +1020,7 @@ def test_public_show_page_injects_auth_aware_annotation_config(monkeypatch, tmp_
     if authenticated:
         client.set_cookie(
             remote_access.SESSION_COOKIE_NAME,
-            remote_access.make_session_cookie(config, "alex@example.com", "user-1"),
+            remote_session_cookie(config, "alex@example.com", "user-1"),
             domain="alex.avibe.bot",
         )
     try:
@@ -1915,7 +1915,7 @@ def test_public_show_me_accepts_valid_workbench_session(monkeypatch, tmp_path):
     client = app.test_client()
     client.set_cookie(
         remote_access.SESSION_COOKIE_NAME,
-        remote_access.make_session_cookie(config, "alex@example.com", "user-1"),
+        remote_session_cookie(config, "alex@example.com", "user-1"),
         domain="alex.avibe.bot",
     )
 
@@ -2206,7 +2206,7 @@ def test_private_show_page_records_remote_oauth_author(monkeypatch, tmp_path):
     client = app.test_client()
     client.set_cookie(
         remote_access.SESSION_COOKIE_NAME,
-        remote_access.make_session_cookie(config, "alex@example.com", "user-1"),
+        remote_session_cookie(config, "alex@example.com", "user-1"),
         domain="alex.avibe.bot",
     )
 
@@ -2256,7 +2256,7 @@ def test_private_show_page_accepts_mark_read_receipt_and_records_reader(monkeypa
     client = app.test_client()
     client.set_cookie(
         remote_access.SESSION_COOKIE_NAME,
-        remote_access.make_session_cookie(config, "reader@example.com", "user-1"),
+        remote_session_cookie(config, "reader@example.com", "user-1"),
         domain="alex.avibe.bot",
     )
     response = client.post(
@@ -2794,7 +2794,7 @@ def test_public_show_page_events_require_share_token(monkeypatch, tmp_path):
     client = app.test_client()
     client.set_cookie(
         remote_access.SESSION_COOKIE_NAME,
-        remote_access.make_session_cookie(config, "alex@example.com", "user-1"),
+        remote_session_cookie(config, "alex@example.com", "user-1"),
         domain="alex.avibe.bot",
     )
 
@@ -2829,7 +2829,7 @@ def test_public_show_page_events_require_matching_share_referer(monkeypatch, tmp
     client = app.test_client()
     client.set_cookie(
         remote_access.SESSION_COOKIE_NAME,
-        remote_access.make_session_cookie(config, "alex@example.com", "user-1"),
+        remote_session_cookie(config, "alex@example.com", "user-1"),
         domain="alex.avibe.bot",
     )
     headers = _public_show_write_headers(share_id)
@@ -2858,7 +2858,7 @@ def test_public_show_page_events_reject_cross_share_token(monkeypatch, tmp_path)
     client = app.test_client()
     client.set_cookie(
         remote_access.SESSION_COOKIE_NAME,
-        remote_access.make_session_cookie(config, "alex@example.com", "user-1"),
+        remote_session_cookie(config, "alex@example.com", "user-1"),
         domain="alex.avibe.bot",
     )
 
@@ -2882,7 +2882,7 @@ def test_public_show_page_events_reject_token_from_previous_share_owner(monkeypa
     client = app.test_client()
     client.set_cookie(
         remote_access.SESSION_COOKIE_NAME,
-        remote_access.make_session_cookie(config, "alex@example.com", "user-1"),
+        remote_session_cookie(config, "alex@example.com", "user-1"),
         domain="alex.avibe.bot",
     )
 
@@ -2908,7 +2908,7 @@ def test_public_show_page_events_accept_oauth_user_and_record_author(monkeypatch
     client = app.test_client()
     client.set_cookie(
         remote_access.SESSION_COOKIE_NAME,
-        remote_access.make_session_cookie(config, "member@example.com", "user-2"),
+        remote_session_cookie(config, "member@example.com", "user-2"),
         domain="alex.avibe.bot",
     )
 
@@ -2957,7 +2957,7 @@ def test_public_show_page_redacts_materialized_screenshot_path(monkeypatch, tmp_
     client = app.test_client()
     client.set_cookie(
         remote_access.SESSION_COOKIE_NAME,
-        remote_access.make_session_cookie(config, "member@example.com", "user-2"),
+        remote_session_cookie(config, "member@example.com", "user-2"),
         domain="alex.avibe.bot",
     )
 
@@ -3050,7 +3050,7 @@ def test_public_show_page_accepts_mark_read_receipt_and_records_reader(monkeypat
     client = app.test_client()
     client.set_cookie(
         remote_access.SESSION_COOKIE_NAME,
-        remote_access.make_session_cookie(config, "reader@example.com", "user-2"),
+        remote_session_cookie(config, "reader@example.com", "user-2"),
         domain="alex.avibe.bot",
     )
     response = client.post(
@@ -3095,7 +3095,7 @@ def test_public_show_page_rejects_resolution_for_unknown_mark(monkeypatch, tmp_p
     client = app.test_client()
     client.set_cookie(
         remote_access.SESSION_COOKIE_NAME,
-        remote_access.make_session_cookie(config, "reader@example.com", "user-2"),
+        remote_session_cookie(config, "reader@example.com", "user-2"),
         domain="alex.avibe.bot",
     )
 
@@ -3130,7 +3130,7 @@ def test_public_show_page_events_accept_injected_share_session_id(monkeypatch, t
     client = app.test_client()
     client.set_cookie(
         remote_access.SESSION_COOKIE_NAME,
-        remote_access.make_session_cookie(config, "member@example.com", "user-2"),
+        remote_session_cookie(config, "member@example.com", "user-2"),
         domain="alex.avibe.bot",
     )
 
@@ -3159,7 +3159,7 @@ def test_public_show_page_intent_fallback_does_not_expose_author_email(monkeypat
     client = app.test_client()
     client.set_cookie(
         remote_access.SESSION_COOKIE_NAME,
-        remote_access.make_session_cookie(config, "member@example.com", "user-2"),
+        remote_session_cookie(config, "member@example.com", "user-2"),
         domain="alex.avibe.bot",
     )
 
@@ -3193,7 +3193,7 @@ def test_public_show_page_events_ignore_client_event_id_and_dispatch(monkeypatch
     client = app.test_client()
     client.set_cookie(
         remote_access.SESSION_COOKIE_NAME,
-        remote_access.make_session_cookie(config, "member@example.com", "user-2"),
+        remote_session_cookie(config, "member@example.com", "user-2"),
         domain="alex.avibe.bot",
     )
 
@@ -3227,7 +3227,7 @@ def test_public_show_page_events_reject_non_human_types(monkeypatch, tmp_path, e
     client = app.test_client()
     client.set_cookie(
         remote_access.SESSION_COOKIE_NAME,
-        remote_access.make_session_cookie(config, "member@example.com", "user-2"),
+        remote_session_cookie(config, "member@example.com", "user-2"),
         domain="alex.avibe.bot",
     )
 
@@ -4657,7 +4657,7 @@ def test_private_show_page_hmr_websocket_accepts_remote_session(monkeypatch, tmp
     client = app.test_client()
     client.set_cookie(
         remote_access.SESSION_COOKIE_NAME,
-        remote_access.make_session_cookie(config, "alex@example.com", "user-1"),
+        remote_session_cookie(config, "alex@example.com", "user-1"),
         domain="alex.avibe.bot",
     )
     try:

--- a/tests/ui_server_test_helpers.py
+++ b/tests/ui_server_test_helpers.py
@@ -3,6 +3,30 @@ from __future__ import annotations
 from urllib.parse import urlparse
 
 
+def remote_session_cookie(
+    config,
+    email: str,
+    subject: str,
+    *,
+    session_claims: dict | None = None,
+) -> str:
+    from vibe import remote_access
+
+    claims = session_claims
+    if claims is None:
+        claims = {
+            "vibe_instance_id": config.remote_access.vibe_cloud.instance_id,
+            "vibe_instance_role": "owner",
+            "vibe_instance_access_source": "owner",
+        }
+    return remote_access.make_session_cookie(
+        config,
+        email,
+        subject,
+        session_claims=claims,
+    )
+
+
 def csrf_headers(client, base_url: str = "http://localhost") -> dict[str, str]:
     response = client.get("/api/csrf-token", base_url=base_url)
     assert response.status_code == 200

--- a/ui/src/lib/apiFetch.test.ts
+++ b/ui/src/lib/apiFetch.test.ts
@@ -19,20 +19,21 @@ describe('apiFetch remote auth recovery', () => {
     vi.clearAllMocks();
   });
 
-  it('hands an expired remote session to the PWA auth gate', async () => {
-    vi.stubGlobal(
-      'fetch',
-      vi.fn(async () =>
-        Response.json({ error: 'remote_access_login_required' }, { status: 401 }),
-      ),
-    );
+  it.each(['remote_access_login_required', 'remote_access_authorization_refresh_required'])(
+    'hands remote auth recovery error %s to the PWA auth gate',
+    async (error) => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn(async () => Response.json({ error }, { status: 401 })),
+      );
 
-    const response = await apiFetch('/api/inbox');
+      const response = await apiFetch('/api/inbox');
 
-    expect(response.status).toBe(401);
-    await vi.waitFor(() => expect(deferRemoteAuthRedirect).toHaveBeenCalledOnce());
-    expect(window.location.assign).not.toHaveBeenCalled();
-  });
+      expect(response.status).toBe(401);
+      await vi.waitFor(() => expect(deferRemoteAuthRedirect).toHaveBeenCalledOnce());
+      expect(window.location.assign).not.toHaveBeenCalled();
+    },
+  );
 
   it('does not start remote auth for an unrelated 401', async () => {
     vi.stubGlobal(

--- a/ui/src/lib/apiFetch.ts
+++ b/ui/src/lib/apiFetch.ts
@@ -3,6 +3,10 @@ import { deferRemoteAuthRedirect } from './remoteAuth';
 const CSRF_COOKIE_NAME = 'vibe_csrf_token';
 const CSRF_HEADER_NAME = 'X-Vibe-CSRF-Token';
 const MUTATING_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
+const REMOTE_AUTH_RECOVERY_ERRORS = new Set([
+  'remote_access_login_required',
+  'remote_access_authorization_refresh_required',
+]);
 
 let csrfTokenPromise: Promise<string> | null = null;
 
@@ -73,7 +77,7 @@ export async function apiFetch(input: RequestInfo | URL, init: RequestInit = {})
   // once and then stops re-running on ordinary navigation (so it doesn't
   // re-mount the shell on every sidebar click). If the Avibe Cloud cookie
   // expires after that, no component re-checks auth — but the server starts
-  // answering /api/* with 401 `remote_access_login_required`. Detect it here
+  // answering /api/* with a remote login/authorization-refresh 401. Detect it here
   // and trigger the same full-page login redirect the guard uses, so the user
   // lands on the login flow instead of a wall of silently-failing fetches.
   if (response.status === 401) {
@@ -95,7 +99,7 @@ async function maybeRedirectOnRemoteAuthExpiry(response: Response): Promise<void
     // Non-JSON 401 — not the remote-access signal; let the caller handle it.
     return;
   }
-  if ((payload as { error?: string } | null)?.error !== 'remote_access_login_required') {
+  if (!REMOTE_AUTH_RECOVERY_ERRORS.has((payload as { error?: string } | null)?.error || '')) {
     return;
   }
   // A cross-origin OAuth redirect from an iOS Home-Screen app opens in a

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -1482,9 +1482,10 @@ def remove_vibe_agent(name: str) -> dict:
 def set_default_vibe_agent(name: str) -> dict:
     store = VibeAgentStore()
     try:
-        store.require_accessible(name, user_context=resolve_resource_access_context(), enabled_only=True)
+        agent = store.require_manageable(name, user_context=resolve_resource_access_context())
+        if not agent.enabled:
+            raise ValueError(f"agent '{agent.name}' is disabled")
         store.set_default_agent_name(name)
-        agent = store.require(name)
         return {"ok": True, "default_agent_name": agent.name, "agent": _vibe_agent_payload(agent, brief=True)}
     finally:
         store.close()

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -2658,7 +2658,12 @@ def get_vault_audit(*, secret_name: Optional[str] = None, limit: int = 100) -> d
 
     engine = _vault_engine()
     with engine.connect() as conn:
-        events = vault_service.list_audit(conn, secret_name=secret_name, limit=limit)
+        events = vault_service.list_audit(
+            conn,
+            secret_name=secret_name,
+            limit=limit,
+            user_context=resolve_resource_access_context(),
+        )
     return {"ok": True, "events": events}
 
 
@@ -2966,7 +2971,12 @@ def get_vault_grants(*, status: Optional[str] = "active", session_id: Optional[s
 
     engine = _vault_engine()
     with engine.begin() as conn:
-        grants = vault_service.list_grants(conn, status=status, session_id=session_id)
+        grants = vault_service.list_grants(
+            conn,
+            status=status,
+            session_id=session_id,
+            user_context=resolve_resource_access_context(),
+        )
     return {"ok": True, "grants": grants}
 
 
@@ -3884,12 +3894,18 @@ def revoke_vault_grant(grant_id: str) -> dict:
         with engine.begin() as conn:
             grant_row = conn.execute(select(vault_service.vault_grants).where(vault_service.vault_grants.c.id == grant_id)).mappings().first()
             grant_rows = [dict(grant_row)] if grant_row is not None else []
-            grant = vault_service.revoke_grant(conn, grant_id)
+            grant = vault_service.revoke_grant(
+                conn,
+                grant_id,
+                user_context=resolve_resource_access_context(),
+            )
             release_scopes = vault_service.agent_release_scopes_after_rows(conn, grant_rows)
     except vault_service.GrantNotFoundError as exc:
         raise VaultApiError(f"grant '{grant_id}' not found", code="grant_not_found", status=404) from exc
     except vault_service.GrantNotActiveError as exc:
         raise VaultApiError(f"grant '{grant_id}' is not active", code="grant_not_active", status=409) from exc
+    except vault_service.VaultSecretAccessError as exc:
+        raise _vault_secret_access_forbidden(exc) from exc
     release_vault_agent_scopes(release_scopes, reason=f"revoke_vault_grant:{grant_id}")
     _publish_vaults_updated(
         scope="grant",

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -1227,9 +1227,7 @@ def upload_show_page_icon(
     config = V2Config.load()
     store = ShowPageStore()
     try:
-        page = store.get(session_id)
-        if page is None:
-            raise ShowPageError("This session has no Show Page.", code="show_page_not_found")
+        page = store.require_access(session_id)
         if store.is_archived(session_id):
             # Archiving leaves the page offline and terminal; the other mutators guard it
             # with session_archived, so a direct icon upload must not slip past that.

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -11305,10 +11305,21 @@ async def _skills_guarded(call):
 
 
 async def list_skills(
-    *, scope: str = "all", project_dir: Optional[str] = None, backends: Optional[List[str]] = None
+    *,
+    scope: str = "all",
+    project_dir: Optional[str] = None,
+    backends: Optional[List[str]] = None,
+    user_context: Any = None,
 ) -> dict:
+    context = resolve_resource_access_context() if user_context is None else user_context
     return await _skills_guarded(
-        lambda askill, svc: svc.list_skills(askill, scope=scope, project_dir=project_dir, backends=backends)
+        lambda askill, svc: svc.list_skills(
+            askill,
+            scope=scope,
+            project_dir=project_dir,
+            backends=backends,
+            user_context=context,
+        )
     )
 
 
@@ -11325,7 +11336,9 @@ async def add_skill(
     all_skills: bool = False,
     skill: Optional[str] = None,
     copy: bool = False,
+    user_context: Any = None,
 ) -> dict:
+    context = resolve_resource_access_context() if user_context is None else user_context
     return await _skills_guarded(
         lambda askill, svc: svc.add_skill(
             askill,
@@ -11336,15 +11349,29 @@ async def add_skill(
             all_skills=all_skills,
             skill=skill,
             copy=copy,
+            user_context=context,
         )
     )
 
 
 async def remove_skill(
-    name: str, *, scope: str = "project", project_dir: Optional[str] = None, backends: Optional[List[str]] = None
+    name: str,
+    *,
+    scope: str = "project",
+    project_dir: Optional[str] = None,
+    backends: Optional[List[str]] = None,
+    user_context: Any = None,
 ) -> dict:
+    context = resolve_resource_access_context() if user_context is None else user_context
     return await _skills_guarded(
-        lambda askill, svc: svc.remove_skill(askill, name, scope=scope, project_dir=project_dir, backends=backends)
+        lambda askill, svc: svc.remove_skill(
+            askill,
+            name,
+            scope=scope,
+            project_dir=project_dir,
+            backends=backends,
+            user_context=context,
+        )
     )
 
 
@@ -11356,8 +11383,23 @@ async def check_skills(*, scope: str = "project", project_dir: Optional[str] = N
     return await _skills_guarded(lambda askill, svc: svc.check(askill, scope=scope, project_dir=project_dir))
 
 
-async def update_skill(name: str, *, scope: str = "project", project_dir: Optional[str] = None) -> dict:
-    return await _skills_guarded(lambda askill, svc: svc.update(askill, name, scope=scope, project_dir=project_dir))
+async def update_skill(
+    name: str,
+    *,
+    scope: str = "project",
+    project_dir: Optional[str] = None,
+    user_context: Any = None,
+) -> dict:
+    context = resolve_resource_access_context() if user_context is None else user_context
+    return await _skills_guarded(
+        lambda askill, svc: svc.update(
+            askill,
+            name,
+            scope=scope,
+            project_dir=project_dir,
+            user_context=context,
+        )
+    )
 
 
 async def upload_skill_zip(payload: dict, *, project_dir: Optional[str] = None) -> dict:

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -1499,6 +1499,12 @@ class VaultApiError(ValueError):
         self.status = status
 
 
+def _vault_secret_access_forbidden(exc: Exception) -> VaultApiError:
+    """Translate the storage-layer Vault ACL denial into the REST contract."""
+
+    return VaultApiError(str(exc), code="resource_access_forbidden", status=403)
+
+
 def _publish_vaults_updated(
     *,
     scope: str,
@@ -1970,6 +1976,8 @@ def create_vault_agent_bindings_batch(payload: dict) -> dict:
                 vault_service.save_vault_settings(conn, {"last_grant_ttl": duration["last_grant_ttl"]})
     except vault_service.RequestNotFoundError as exc:
         raise VaultApiError(f"request '{request_id}' not found", code="request_not_found", status=404) from exc
+    except vault_service.VaultSecretAccessError as exc:
+        raise _vault_secret_access_forbidden(exc) from exc
     except vault_service.InvalidRequestError as exc:
         raise VaultApiError(str(exc), code="invalid_request", status=409) from exc
     except vault_service.InvalidGrantError as exc:
@@ -2128,6 +2136,8 @@ def create_vault_agent_binding(payload: dict) -> dict:
                 vault_service.save_vault_settings(conn, {"last_grant_ttl": duration["last_grant_ttl"]})
     except vault_service.SecretNotFoundError as exc:
         raise VaultApiError(f"secret '{name}' not found", code="secret_not_found", status=404) from exc
+    except vault_service.VaultSecretAccessError as exc:
+        raise _vault_secret_access_forbidden(exc) from exc
     except vault_service.RequestNotFoundError as exc:
         raise VaultApiError(f"request '{request_id}' not found", code="request_not_found", status=404) from exc
     except vault_service.InvalidRequestError as exc:
@@ -2249,6 +2259,8 @@ def create_vault_reveal_context(name: str, payload: dict | None = None) -> dict:
             signed_context = _signed_operation_context(context, key)
     except vault_service.SecretNotFoundError as exc:
         raise VaultApiError(f"secret '{secret_name}' not found", code="secret_not_found", status=404) from exc
+    except vault_service.VaultSecretAccessError as exc:
+        raise _vault_secret_access_forbidden(exc) from exc
     except vault_service.KeypairNotValueDeliverableError as exc:
         raise VaultApiError(str(exc), code="keypair_not_value_deliverable", status=409) from exc
     return {"ok": True, "context": signed_context, "envelope": envelope_payload}
@@ -2822,6 +2834,8 @@ def request_vault_access(payload: dict) -> dict:
     except vault_service.SecretNotFoundError as exc:
         missing_name = name or str(exc)
         raise VaultApiError(f"secret '{missing_name}' not found", code="secret_not_found", status=404) from exc
+    except vault_service.VaultSecretAccessError as exc:
+        raise _vault_secret_access_forbidden(exc) from exc
     except vault_service.NotGrantableError as exc:
         raise VaultApiError(str(exc), code="not_grantable", status=409) from exc
     except vault_service.KeypairNotValueDeliverableError as exc:
@@ -2881,6 +2895,8 @@ def request_vault_sign(payload: dict) -> dict:
             )
     except vault_service.SecretNotFoundError as exc:
         raise VaultApiError(f"secret '{name}' not found", code="secret_not_found", status=404) from exc
+    except vault_service.VaultSecretAccessError as exc:
+        raise _vault_secret_access_forbidden(exc) from exc
     except vault_service.InvalidRequestError as exc:
         raise VaultApiError(str(exc), code="invalid_request", status=409) from exc
     except vault_service.VaultServiceError as exc:
@@ -3334,6 +3350,7 @@ def create_vault_grant(payload: dict) -> dict:
             grantable_members = vault_service.request_grantable_member_metas(conn, request_id)
         except (
             vault_service.SecretNotFoundError,
+            vault_service.VaultSecretAccessError,
             vault_service.RequestNotFoundError,
             vault_service.InvalidRequestError,
             vault_service.InvalidGrantError,
@@ -3342,6 +3359,8 @@ def create_vault_grant(payload: dict) -> dict:
             grantable_members = []
     if isinstance(preflight_error, vault_service.SecretNotFoundError):
         raise VaultApiError(f"secret '{preflight_error}' not found", code="secret_not_found", status=404) from preflight_error
+    if isinstance(preflight_error, vault_service.VaultSecretAccessError):
+        raise _vault_secret_access_forbidden(preflight_error) from preflight_error
     if isinstance(preflight_error, vault_service.RequestNotFoundError):
         raise VaultApiError(f"request '{preflight_error}' not found", code="request_not_found", status=404) from preflight_error
     if isinstance(preflight_error, vault_service.InvalidRequestError):
@@ -3410,6 +3429,8 @@ def create_vault_grant(payload: dict) -> dict:
             )
     except vault_service.NotGrantableError as exc:
         raise VaultApiError(str(exc), code="not_grantable", status=409) from exc
+    except vault_service.VaultSecretAccessError as exc:
+        raise _vault_secret_access_forbidden(exc) from exc
     except vault_service.SecretNotFoundError as exc:
         raise VaultApiError(f"secret '{exc}' not found", code="secret_not_found", status=404) from exc
     except vault_service.RequestNotFoundError as exc:
@@ -3973,6 +3994,8 @@ def vault_sign(payload: dict) -> dict:
                     key_envelope = vault_service.get_key_envelope(conn, name)
     except vault_service.SecretNotFoundError as exc:
         raise VaultApiError(f"secret '{name}' not found", code="secret_not_found", status=404) from exc
+    except vault_service.VaultSecretAccessError as exc:
+        raise _vault_secret_access_forbidden(exc) from exc
     except vault_service.RequestNotFoundError as exc:
         raise VaultApiError(f"request '{exc}' not found", code="request_not_found", status=404) from exc
     except vault_service.InvalidRequestError as exc:

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -68,9 +68,11 @@ from modules.agents.catalog import (
 )
 from modules.agents.subagent_router import list_codex_subagents
 from core.vibe_agents import (
+    VibeAgentAccessError,
     VibeAgentStore,
     iter_global_agent_files,
     parse_agent_file,
+    resolve_resource_access_context,
     validate_agent_backend,
 )
 from core.process_isolation import isolated_subprocess_kwargs, signal_process_tree, KILL_SIGNAL
@@ -1330,13 +1332,19 @@ def _parse_agent_enabled_field(payload: dict, *, default: Optional[bool] = None)
 
 def get_vibe_agents(*, backend: Optional[str] = None, include_disabled: bool = False) -> dict:
     _ensure_builtin_default_agents()
+    user_context = resolve_resource_access_context()
     store = VibeAgentStore()
     try:
         normalized_backend = validate_agent_backend(backend) if backend else None
-        agents = store.list_agents(include_disabled=include_disabled)
+        agents = store.list_agents(include_disabled=include_disabled, user_context=user_context)
         if normalized_backend:
             agents = [agent for agent in agents if agent.backend == normalized_backend]
         default_agent = store.get_default_agent()
+        if default_agent is not None:
+            try:
+                default_agent = store.require_accessible(default_agent.name, user_context=user_context)
+            except VibeAgentAccessError:
+                default_agent = None
         return {
             "ok": True,
             "agents": [_vibe_agent_payload(agent, brief=True) for agent in agents],
@@ -1347,10 +1355,16 @@ def get_vibe_agents(*, backend: Optional[str] = None, include_disabled: bool = F
 
 
 def get_vibe_agent(name: str) -> dict:
+    user_context = resolve_resource_access_context()
     store = VibeAgentStore()
     try:
-        agent = store.require(name)
+        agent = store.require_accessible(name, user_context=user_context)
         default_agent = store.get_default_agent()
+        if default_agent is not None:
+            try:
+                default_agent = store.require_accessible(default_agent.name, user_context=user_context)
+            except VibeAgentAccessError:
+                default_agent = None
         return {
             "ok": True,
             "agent": _vibe_agent_payload(agent),
@@ -1377,6 +1391,7 @@ def create_vibe_agent(payload: dict) -> dict:
             system_prompt=payload.get("system_prompt"),
             metadata=metadata,
             enabled=_parse_agent_enabled_field(payload, default=True),
+            user_context=resolve_resource_access_context(),
         )
         return {"ok": True, "agent": _vibe_agent_payload(agent)}
     finally:
@@ -1427,6 +1442,7 @@ def update_vibe_agent(name: str, payload: dict) -> dict:
 
     store = VibeAgentStore()
     try:
+        store.require_accessible(name, user_context=resolve_resource_access_context())
         agent = store.update(name, **kwargs)
         return {"ok": True, "agent": _vibe_agent_payload(agent)}
     finally:
@@ -1436,6 +1452,7 @@ def update_vibe_agent(name: str, payload: dict) -> dict:
 def remove_vibe_agent(name: str) -> dict:
     store = VibeAgentStore()
     try:
+        store.require_accessible(name, user_context=resolve_resource_access_context())
         counts = store.reference_counts(name)
         if any(counts.values()):
             return {
@@ -1462,6 +1479,7 @@ def remove_vibe_agent(name: str) -> dict:
 def set_default_vibe_agent(name: str) -> dict:
     store = VibeAgentStore()
     try:
+        store.require_accessible(name, user_context=resolve_resource_access_context(), enabled_only=True)
         store.set_default_agent_name(name)
         agent = store.require(name)
         return {"ok": True, "default_agent_name": agent.name, "agent": _vibe_agent_payload(agent, brief=True)}

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -1227,7 +1227,7 @@ def upload_show_page_icon(
     config = V2Config.load()
     store = ShowPageStore()
     try:
-        page = store.require_access(session_id)
+        page = store.require_management(session_id)
         if store.is_archived(session_id):
             # Archiving leaves the page offline and terminal; the other mutators guard it
             # with session_archived, so a direct icon upload must not slip past that.
@@ -1440,7 +1440,7 @@ def update_vibe_agent(name: str, payload: dict) -> dict:
 
     store = VibeAgentStore()
     try:
-        store.require_accessible(name, user_context=resolve_resource_access_context())
+        store.require_manageable(name, user_context=resolve_resource_access_context())
         agent = store.update(name, **kwargs)
         return {"ok": True, "agent": _vibe_agent_payload(agent)}
     finally:
@@ -1450,7 +1450,7 @@ def update_vibe_agent(name: str, payload: dict) -> dict:
 def remove_vibe_agent(name: str) -> dict:
     store = VibeAgentStore()
     try:
-        store.require_accessible(name, user_context=resolve_resource_access_context())
+        store.require_manageable(name, user_context=resolve_resource_access_context())
         counts = store.reference_counts(name)
         if any(counts.values()):
             return {
@@ -2484,6 +2484,10 @@ def create_vault_secret(payload: dict, *, origin: str | None = None) -> dict:
         signer_kind = str(signer_kind)
     provision_request_id = str(payload.get("provision_request_id") or "") or None
     atomic_protected_establishment = establishing_vmk and protection == "protected"
+    try:
+        user_context = vault_service.require_secret_create_access()
+    except vault_service.VaultSecretAccessError as exc:
+        raise _vault_secret_access_forbidden(exc) from exc
     engine = _vault_engine()
     try:
         # Establishment defers preflight to create_secret's write-serialized
@@ -2551,6 +2555,7 @@ def create_vault_secret(payload: dict, *, origin: str | None = None) -> dict:
                 authz_factor_registration=authz_factor_registration if isinstance(authz_factor_registration, dict) else None,
                 authz_factor_origin=origin,
                 provision_request_id=provision_request_id,
+                user_context=user_context,
             )
     except vault_service.InvalidSecretNameError as exc:
         raise VaultApiError("invalid secret name (use ^[A-Za-z_][A-Za-z0-9_]*$)", code="invalid_name") from exc
@@ -2576,6 +2581,8 @@ def create_vault_secret(payload: dict, *, origin: str | None = None) -> dict:
         raise VaultApiError(str(exc), code="protected_authz_setup_required", status=409) from exc
     except vault_service.InvalidProtectedAuthzError as exc:
         raise VaultApiError(str(exc), code="invalid_protected_authz", status=409) from exc
+    except vault_service.VaultSecretAccessError as exc:
+        raise _vault_secret_access_forbidden(exc) from exc
     except vault_service.VaultServiceError as exc:
         raise VaultApiError(str(exc), code="vault_error") from exc
     _publish_vaults_updated(
@@ -2613,6 +2620,8 @@ def update_vault_secret(name: str, payload: dict) -> dict:
             meta = vault_service.update_secret_metadata(conn, secret_name, release_scopes=release_scopes, **kwargs)
     except vault_service.SecretNotFoundError as exc:
         raise VaultApiError(f"secret '{secret_name}' not found", code="secret_not_found", status=404) from exc
+    except vault_service.VaultSecretAccessError as exc:
+        raise _vault_secret_access_forbidden(exc) from exc
     except vault_service.VaultServiceError as exc:
         raise VaultApiError(str(exc), code="invalid_metadata", status=409) from exc
     release_vault_agent_scopes(release_scopes, reason="update_vault_secret")
@@ -2632,6 +2641,8 @@ def delete_vault_secret(name: str) -> dict:
             release_scopes = vault_service.agent_release_scopes_after_rows(conn, grant_rows)
     except vault_service.SecretNotFoundError as exc:
         raise VaultApiError(f"secret '{name}' not found", code="secret_not_found", status=404) from exc
+    except vault_service.VaultSecretAccessError as exc:
+        raise _vault_secret_access_forbidden(exc) from exc
     release_vault_agent_scopes(release_scopes, reason="delete_vault_secret")
     _publish_vaults_updated(scope="secret", secret_name=name)
     return {"ok": True, "removed": True, "name": name}
@@ -4094,6 +4105,8 @@ def store_vault_pubkey_pin(payload: dict) -> dict:
             meta = vault_service.store_pubkey_pin(conn, name, pin)
     except vault_service.SecretNotFoundError as exc:
         raise VaultApiError(f"secret '{name}' not found", code="secret_not_found", status=404) from exc
+    except vault_service.VaultSecretAccessError as exc:
+        raise _vault_secret_access_forbidden(exc) from exc
     _publish_vaults_updated(scope="secret", secret_name=meta.get("name") or name)
     return {"ok": True, "secret": meta}
 
@@ -4139,7 +4152,7 @@ def import_vibe_agents(payload: dict) -> dict:
 
     store = VibeAgentStore()
     try:
-        result = store.import_candidates(candidates)
+        result = store.import_candidates(candidates, user_context=resolve_resource_access_context())
         return {
             "ok": True,
             "imported": [_vibe_agent_payload(agent, brief=True) for agent in result.imported],

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -2686,8 +2686,15 @@ def get_vault_provision_request_by_name(name: str) -> dict:
     if not vault_crypto.is_valid_secret_name(requested_name):
         raise VaultApiError("invalid secret name (use ^[A-Za-z_][A-Za-z0-9_]*$)", code="invalid_name")
     engine = _vault_engine()
-    with engine.begin() as conn:
-        request, ambiguous = vault_service.resolve_pending_provision_request_by_name(conn, requested_name)
+    try:
+        with engine.begin() as conn:
+            request, ambiguous = vault_service.resolve_pending_provision_request_by_name(
+                conn,
+                requested_name,
+                user_context=resolve_resource_access_context(),
+            )
+    except vault_service.VaultSecretAccessError as exc:
+        raise _vault_secret_access_forbidden(exc) from exc
     return {"ok": True, "request": request, "ambiguous": ambiguous}
 
 
@@ -2698,8 +2705,15 @@ def get_vault_provision_request(request_id: str) -> dict:
     if not requested_id:
         raise VaultApiError("request_id is required", code="missing_request_id")
     engine = _vault_engine()
-    with engine.begin() as conn:
-        request = vault_service.get_pending_provision_request(conn, requested_id)
+    try:
+        with engine.begin() as conn:
+            request = vault_service.get_pending_provision_request(
+                conn,
+                requested_id,
+                user_context=resolve_resource_access_context(),
+            )
+    except vault_service.VaultSecretAccessError as exc:
+        raise _vault_secret_access_forbidden(exc) from exc
     return {"ok": True, "request": request}
 
 

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -1242,14 +1242,14 @@ def upload_show_page_icon(
     return {"ok": True, **_apply_session_meta([payload])[0]}
 
 
-def get_dock() -> dict:
+def get_dock(*, user_context: Any = None) -> dict:
     """The workbench Dock document — resident-tile order + pinned Show Pages."""
     from core.dock_store import load_dock
 
-    return {"ok": True, "dock": load_dock()}
+    return {"ok": True, "dock": load_dock(user_context=user_context)}
 
 
-def pin_dock_show_page(session_id: str) -> dict:
+def pin_dock_show_page(session_id: str, *, user_context: Any = None) -> dict:
     """Pin a session's Show Page to the Dock (idempotent).
 
     Raises ``ShowPageError`` (malformed id → 400) or ``DockError`` (no Show Page
@@ -1257,24 +1257,29 @@ def pin_dock_show_page(session_id: str) -> dict:
     """
     from core.dock_store import pin_show_page
 
-    return {"ok": True, "dock": pin_show_page(session_id)}
+    return {"ok": True, "dock": pin_show_page(session_id, user_context=user_context)}
 
 
-def unpin_dock_show_page(session_id: str) -> dict:
+def unpin_dock_show_page(session_id: str, *, user_context: Any = None) -> dict:
     """Unpin a Show Page from the Dock (idempotent; leaves the page untouched)."""
     from core.dock_store import unpin_show_page
 
-    return {"ok": True, "dock": unpin_show_page(session_id)}
+    return {"ok": True, "dock": unpin_show_page(session_id, user_context=user_context)}
 
 
-def set_dock_order(order: list, known: list | None = None) -> dict:
+def set_dock_order(
+    order: list,
+    known: list | None = None,
+    *,
+    user_context: Any = None,
+) -> dict:
     """Persist a new resident-tile (docked-subset) order. ``known`` is the
     client's optimistic-concurrency baseline id set; when it no longer matches the
     server's, the write is rejected as stale so a stale tab can't silently undock a
     newer pin. Raises ``DockError`` for an invalid/stale order, mapped to a 400."""
     from core.dock_store import set_dock_order as _set_dock_order
 
-    return {"ok": True, "dock": _set_dock_order(order, known=known)}
+    return {"ok": True, "dock": _set_dock_order(order, known=known, user_context=user_context)}
 
 
 def get_workbench_prefs() -> dict:
@@ -2757,6 +2762,8 @@ def get_vault_request(request_id: str, *, audience: str | None = None) -> dict:
             result = _vault_request_result(conn, request)
     except vault_service.RequestNotFoundError as exc:
         raise VaultApiError(f"request '{request_id}' not found", code="request_not_found", status=404) from exc
+    except vault_service.VaultSecretAccessError as exc:
+        raise _vault_secret_access_forbidden(exc) from exc
     payload = {"ok": True, "request": request}
     if result is not None:
         payload["result"] = result
@@ -2941,6 +2948,8 @@ def deny_vault_request(request_id: str, payload: dict | None = None) -> dict:
             )
     except vault_service.RequestNotFoundError as exc:
         raise VaultApiError(f"request '{request_id}' not found", code="request_not_found", status=404) from exc
+    except vault_service.VaultSecretAccessError as exc:
+        raise _vault_secret_access_forbidden(exc) from exc
     except vault_service.InvalidRequestError as exc:
         raise VaultApiError(str(exc), code="invalid_request", status=409) from exc
     _publish_vaults_updated(
@@ -11392,8 +11401,21 @@ async def find_skills(query: str = "") -> dict:
     return await _skills_guarded(lambda askill, svc: svc.find_skills(askill, query))
 
 
-async def check_skills(*, scope: str = "project", project_dir: Optional[str] = None) -> dict:
-    return await _skills_guarded(lambda askill, svc: svc.check(askill, scope=scope, project_dir=project_dir))
+async def check_skills(
+    *,
+    scope: str = "project",
+    project_dir: Optional[str] = None,
+    user_context: Any = None,
+) -> dict:
+    context = resolve_resource_access_context() if user_context is None else user_context
+    return await _skills_guarded(
+        lambda askill, svc: svc.check(
+            askill,
+            scope=scope,
+            project_dir=project_dir,
+            user_context=context,
+        )
+    )
 
 
 async def update_skill(

--- a/vibe/remote_access.py
+++ b/vibe/remote_access.py
@@ -29,7 +29,7 @@ import threading
 import time
 import urllib.parse
 from pathlib import Path
-from typing import Any
+from typing import Any, Mapping, Sequence
 
 import jwt
 import requests
@@ -45,6 +45,7 @@ logger = logging.getLogger(__name__)
 CLOUDFLARED_BASE_URL = "https://github.com/cloudflare/cloudflared/releases/latest/download"
 SESSION_COOKIE_NAME = "__Host-vibe_remote_session"
 SESSION_TTL_SECONDS = 24 * 60 * 60
+SESSION_ORGANIZATION_REFRESH_SECONDS = SESSION_TTL_SECONDS // 2
 OAUTH_ID_TOKEN_CLOCK_LEEWAY_SECONDS = 30
 _CONNECTOR_LOCK = threading.RLock()
 _STATUS_HEARTBEAT_LOCK = threading.Lock()
@@ -54,6 +55,7 @@ _STATUS_REPORT_THREADS: set[threading.Thread] = set()
 _STATUS_REPORT_PENDING: tuple[V2Config | None, str, str | None] | None = None
 _STATUS_REPORT_ATEXIT_REGISTERED = False
 STATUS_HEARTBEAT_SECONDS = 5 * 60
+RESOURCE_ACL_SYNC_INTERVAL_SECONDS = 30
 QUALITY_REPORT_SECONDS = 60
 QUALITY_SAMPLE_SECONDS = tunnel_quality.SAMPLE_INTERVAL_SECONDS
 STATUS_LOG_TAIL_BYTES = 64 * 1024
@@ -75,6 +77,15 @@ _RECOVERY_ATTEMPTS: list[float] = []
 _RECOVERY_CANCEL_EVENT = threading.Event()
 _RECOVERY_MANUAL_BYPASS_USED = False
 _RECOVERY_EMERGENCY_BYPASS_USED = False
+_RESOURCE_ACL_SYNC_LOCK = threading.Lock()
+_RESOURCE_ACL_SYNC_POLL_LOCK = threading.Lock()
+_RESOURCE_ACL_SYNC_POLL_STARTED = False
+_RESOURCE_ACL_SYNC_ERROR_CODE_RE = re.compile(r"\A[a-z0-9][a-z0-9_:-]{0,119}\Z")
+_RESOURCE_ACL_RESOURCE_KINDS = frozenset({"agent", "vault_secret", "skill", "show_page"})
+_RESOURCE_ACL_ACCESS_LEVELS = frozenset({"public", "scope", "private"})
+_RESOURCE_ACL_SYNC_STATUSES = frozenset({"in_sync", "pending", "offline", "error", "deleted"})
+_INSTANCE_ACCESS_SOURCES = frozenset({"owner", "public_instance", "email", "email_domain", "organization_group"})
+_ORGANIZATION_ROLES = frozenset({"owner", "admin", "member"})
 _BLOCKED_PAIRING_BACKEND_HOSTS = {
     "localhost",
     "localhost.localdomain",
@@ -617,6 +628,437 @@ def cloud_token_for_request(
         "expires_at": int(time.time()) + int(minted.get("expires_in", 0) or 0),
         "scope": scope,
     }
+
+
+def _resource_acl_sync_configured(config: V2Config | None) -> bool:
+    if config is None:
+        return False
+    cloud = config.remote_access.vibe_cloud
+    return bool(cloud.enabled and cloud.instance_id and cloud.instance_secret and cloud.backend_url)
+
+
+def _resource_acl_device_url(config: V2Config, suffix: str) -> str:
+    cloud = config.remote_access.vibe_cloud
+    instance_id = urllib.parse.quote(str(cloud.instance_id), safe="")
+    return f"{cloud.backend_url.rstrip('/')}/api/v1/instances/{instance_id}/{suffix.lstrip('/')}"
+
+
+def _device_json_request(
+    config: V2Config,
+    method: str,
+    suffix: str,
+    payload: dict[str, Any] | None = None,
+    *,
+    timeout: float = 8.0,
+) -> dict[str, Any]:
+    """Make a paired-instance device request without exposing its secret.
+
+    This is intentionally separate from pairing's pinned-host request path. The
+    backend URL here was accepted and normalized during pairing, and the device
+    secret only travels in the required request header.
+    """
+
+    cloud = config.remote_access.vibe_cloud
+    headers = {
+        "Accept": "application/json",
+        "User-Agent": "avibe/dev",
+        "X-Vibe-Device-Secret": str(cloud.instance_secret),
+    }
+    try:
+        response = requests.request(
+            method,
+            _resource_acl_device_url(config, suffix),
+            json=payload,
+            headers=headers,
+            timeout=timeout,
+            allow_redirects=False,
+        )
+    except requests.RequestException as exc:
+        raise RuntimeError("resource_acl_device_unavailable") from exc
+    if 300 <= response.status_code < 400:
+        raise BackendRequestError(response.status_code, {"error": "backend_http_redirect_blocked"})
+    if response.status_code >= 400:
+        try:
+            error_payload = response.json()
+        except ValueError:
+            error_payload = {}
+        if not isinstance(error_payload, dict):
+            error_payload = {}
+        error_payload.setdefault("error", "resource_acl_device_rejected")
+        raise BackendRequestError(response.status_code, error_payload)
+    try:
+        parsed = response.json()
+    except ValueError as exc:
+        raise RuntimeError("resource_acl_device_invalid_response") from exc
+    if not isinstance(parsed, dict):
+        raise RuntimeError("resource_acl_device_invalid_response")
+    return parsed
+
+
+def _safe_resource_acl_identifier(value: Any, *, code: str = "invalid_resource_metadata", limit: int = 200) -> str:
+    if not isinstance(value, str):
+        raise ValueError(code)
+    cleaned = value.strip()
+    if (
+        not cleaned
+        or len(cleaned) > limit
+        or any(ord(char) < 32 or ord(char) == 127 for char in cleaned)
+        or "/" in cleaned
+        or "\\" in cleaned
+    ):
+        raise ValueError(code)
+    return cleaned
+
+
+def _safe_resource_acl_revision(value: Any) -> int:
+    if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+        raise ValueError("invalid_resource_metadata")
+    return value
+
+
+def _normalize_resource_index_descriptor(resource: Mapping[str, Any]) -> dict[str, Any]:
+    resource_kind = resource.get("resource_kind")
+    if resource_kind not in _RESOURCE_ACL_RESOURCE_KINDS:
+        raise ValueError("invalid_resource_metadata")
+    access_level = resource.get("access_level", "private")
+    if access_level not in _RESOURCE_ACL_ACCESS_LEVELS:
+        raise ValueError("invalid_resource_metadata")
+    raw_groups = resource.get("group_ids", [])
+    if not isinstance(raw_groups, (list, tuple, set, frozenset)):
+        raise ValueError("invalid_resource_metadata")
+    group_ids = [_safe_resource_acl_identifier(group_id) for group_id in raw_groups]
+    if len(set(group_ids)) != len(group_ids) or len(group_ids) > 256:
+        raise ValueError("invalid_resource_metadata")
+    if access_level == "scope" and not group_ids:
+        raise ValueError("invalid_resource_metadata")
+    if access_level != "scope" and group_ids:
+        raise ValueError("invalid_resource_metadata")
+    descriptor = {
+        "resource_id": _safe_resource_acl_identifier(resource.get("resource_id")),
+        "resource_kind": resource_kind,
+        "display_name": _safe_resource_acl_identifier(resource.get("display_name"), limit=240),
+        "metadata_revision": _safe_resource_acl_revision(resource.get("metadata_revision")),
+        "applied_acl_revision": _safe_resource_acl_revision(resource.get("applied_acl_revision")),
+        # T5a's baseline endpoint requires access metadata on the first
+        # publication. These are ACL identifiers only, never resource content.
+        "access_level": access_level,
+        "group_ids": group_ids,
+    }
+    owner_user_id = resource.get("owner_user_id")
+    if owner_user_id is not None:
+        descriptor["owner_user_id"] = _safe_resource_acl_identifier(owner_user_id)
+    sync_status = resource.get("sync_status")
+    if sync_status is not None:
+        if sync_status not in _RESOURCE_ACL_SYNC_STATUSES:
+            raise ValueError("invalid_resource_metadata")
+        descriptor["sync_status"] = sync_status
+    return descriptor
+
+
+def publish_resource_index(
+    config: V2Config,
+    *,
+    organization_id: str,
+    resources: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    """Publish the device-safe resource index and applied ACL revisions."""
+
+    if not _resource_acl_sync_configured(config):
+        raise RuntimeError("resource_acl_sync_not_configured")
+    organization = _safe_resource_acl_identifier(organization_id, code="invalid_organization_id")
+    descriptors = [_normalize_resource_index_descriptor(resource) for resource in resources]
+    return _device_json_request(
+        config,
+        "PUT",
+        "resource-index",
+        {"organization_id": organization, "resources": descriptors},
+    )
+
+
+def pull_resource_acl_intents(config: V2Config) -> dict[str, Any]:
+    """Fetch the current desired organization ACL intents for this device."""
+
+    if not _resource_acl_sync_configured(config):
+        raise RuntimeError("resource_acl_sync_not_configured")
+    return _device_json_request(config, "GET", "resource-acl-intents")
+
+
+def acknowledge_resource_acl_intent(
+    config: V2Config,
+    *,
+    resource_kind: str,
+    resource_id: str,
+    revision: int,
+    outcome: str,
+    error_code: str | None = None,
+) -> dict[str, Any]:
+    """Acknowledge exactly one applied or rejected control-plane revision."""
+
+    if resource_kind not in _RESOURCE_ACL_RESOURCE_KINDS:
+        raise ValueError("invalid_resource_metadata")
+    if outcome not in {"applied", "rejected"}:
+        raise ValueError("invalid_resource_metadata")
+    payload: dict[str, Any] = {
+        "resource_kind": resource_kind,
+        "resource_id": _safe_resource_acl_identifier(resource_id),
+        "revision": _safe_resource_acl_revision(revision),
+        "outcome": outcome,
+    }
+    if outcome == "rejected":
+        if not isinstance(error_code, str) or not _RESOURCE_ACL_SYNC_ERROR_CODE_RE.fullmatch(error_code):
+            raise ValueError("invalid_resource_metadata")
+        payload["error_code"] = error_code
+    elif error_code is not None:
+        raise ValueError("invalid_resource_metadata")
+    return _device_json_request(config, "POST", "resource-acl-acks", payload)
+
+
+def _resource_acl_sync_error_code(exc: BaseException) -> str:
+    if isinstance(exc, BackendRequestError):
+        candidate = exc.payload.get("error")
+        if isinstance(candidate, str) and _RESOURCE_ACL_SYNC_ERROR_CODE_RE.fullmatch(candidate):
+            return candidate
+    candidate = getattr(exc, "code", None)
+    if isinstance(candidate, str) and _RESOURCE_ACL_SYNC_ERROR_CODE_RE.fullmatch(candidate):
+        return candidate
+    return "resource_acl_sync_failed"
+
+
+def _local_policy_resource_descriptors(organization_id: str) -> list[dict[str, Any]]:
+    from storage import resource_access_service
+
+    policies = resource_access_service.list_resource_policies(organization_id=organization_id)
+    return [
+        {
+            "resource_id": policy["resource_id"],
+            "resource_kind": policy["resource_kind"],
+            # Resource-specific services can later supply richer safe names.
+            "display_name": policy["resource_id"],
+            "owner_user_id": policy.get("owner_user_id"),
+            "metadata_revision": int(policy.get("policy_revision") or 0),
+            "applied_acl_revision": int(policy.get("last_applied_control_plane_revision") or 0),
+            "access_level": policy["access_level"],
+            "group_ids": policy.get("group_ids") or [],
+            "sync_status": "in_sync",
+        }
+        for policy in policies
+    ]
+
+
+def _validated_intent_fields(intent: Any) -> tuple[str, str, int, str, list[str]]:
+    if not isinstance(intent, Mapping):
+        raise ValueError("invalid_resource_acl_intent")
+    resource_kind = intent.get("resource_kind")
+    if resource_kind not in _RESOURCE_ACL_RESOURCE_KINDS:
+        raise ValueError("invalid_resource_acl_intent")
+    resource_id = _safe_resource_acl_identifier(intent.get("resource_id"), code="invalid_resource_acl_intent")
+    revision = _safe_resource_acl_revision(intent.get("revision"))
+    access_level = intent.get("access_level")
+    if access_level not in _RESOURCE_ACL_ACCESS_LEVELS:
+        raise ValueError("invalid_resource_acl_intent")
+    raw_groups = intent.get("group_ids")
+    if not isinstance(raw_groups, list):
+        raise ValueError("invalid_resource_acl_intent")
+    group_ids = [_safe_resource_acl_identifier(group_id, code="invalid_resource_acl_intent") for group_id in raw_groups]
+    if len(set(group_ids)) != len(group_ids) or len(group_ids) > 256:
+        raise ValueError("invalid_resource_acl_intent")
+    if access_level == "scope" and not group_ids:
+        raise ValueError("invalid_resource_acl_intent")
+    if access_level != "scope" and group_ids:
+        raise ValueError("invalid_resource_acl_intent")
+    return str(resource_kind), resource_id, revision, str(access_level), group_ids
+
+
+def _sync_one_organization(
+    config: V2Config,
+    *,
+    organization_id: str,
+    resources: Sequence[Mapping[str, Any]] | None,
+) -> dict[str, Any]:
+    from storage import resource_access_service
+    from storage.db import get_cached_sqlite_engine
+
+    organization = _safe_resource_acl_identifier(organization_id, code="invalid_organization_id")
+    descriptors = list(resources) if resources is not None else _local_policy_resource_descriptors(organization)
+    try:
+        publication = publish_resource_index(config, organization_id=organization, resources=descriptors)
+        if publication.get("organization_id") != organization:
+            return {"organization_id": organization, "ok": False, "error": "resource_organization_mismatch"}
+        pulled = pull_resource_acl_intents(config)
+    except Exception as exc:
+        return {"organization_id": organization, "ok": False, "error": _resource_acl_sync_error_code(exc)}
+    if pulled.get("organization_id") != organization:
+        return {"organization_id": organization, "ok": False, "error": "resource_organization_mismatch"}
+    intents = pulled.get("intents")
+    if not isinstance(intents, list):
+        return {"organization_id": organization, "ok": False, "error": "resource_acl_device_invalid_response"}
+
+    applied = 0
+    rejected = 0
+    acknowledged = 0
+    skipped = 0
+    ack_errors = 0
+    engine = get_cached_sqlite_engine()
+    for raw_intent in intents:
+        try:
+            resource_kind, resource_id, revision, access_level, group_ids = _validated_intent_fields(raw_intent)
+        except Exception:
+            # A malformed device response is not safe to acknowledge because it
+            # does not identify an exact valid revision.
+            rejected += 1
+            continue
+        try:
+            with engine.begin() as connection:
+                outcome = resource_access_service.apply_control_plane_intent(
+                    connection,
+                    organization_id=organization,
+                    resource_kind=resource_kind,
+                    resource_id=resource_id,
+                    revision=revision,
+                    access_level=access_level,
+                    group_ids=group_ids,
+                )
+            if outcome["status"] == "stale":
+                skipped += 1
+                continue
+            if outcome["status"] == "applied":
+                applied += 1
+            try:
+                acknowledge_resource_acl_intent(
+                    config,
+                    resource_kind=resource_kind,
+                    resource_id=resource_id,
+                    revision=revision,
+                    outcome="applied",
+                )
+                acknowledged += 1
+            except Exception:
+                # Keep the committed local policy. The next poll receives the
+                # same pending intent and retries this exact acknowledgement.
+                ack_errors += 1
+        except resource_access_service.ResourceAccessError as exc:
+            rejected += 1
+            try:
+                acknowledge_resource_acl_intent(
+                    config,
+                    resource_kind=resource_kind,
+                    resource_id=resource_id,
+                    revision=revision,
+                    outcome="rejected",
+                    error_code=_resource_acl_sync_error_code(exc),
+                )
+                acknowledged += 1
+            except Exception:
+                ack_errors += 1
+        except Exception:
+            rejected += 1
+            try:
+                acknowledge_resource_acl_intent(
+                    config,
+                    resource_kind=resource_kind,
+                    resource_id=resource_id,
+                    revision=revision,
+                    outcome="rejected",
+                    error_code="resource_acl_apply_failed",
+                )
+                acknowledged += 1
+            except Exception:
+                ack_errors += 1
+    return {
+        "organization_id": organization,
+        "ok": ack_errors == 0,
+        "applied": applied,
+        "rejected": rejected,
+        "acknowledged": acknowledged,
+        "skipped": skipped,
+        "ack_errors": ack_errors,
+        "poll_after_seconds": int(pulled.get("poll_after_seconds") or RESOURCE_ACL_SYNC_INTERVAL_SECONDS),
+    }
+
+
+def sync_resource_acl_once(
+    config: V2Config | None = None,
+    *,
+    organization_id: str | None = None,
+    resources: Sequence[Mapping[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Publish applied state, pull intents, atomically apply, and ACK them.
+
+    Network failures leave the SQLite policy untouched. A caller can provide
+    richer safe descriptors for one organization; otherwise the persisted local
+    policy rows supply a conservative index baseline.
+    """
+
+    if not _RESOURCE_ACL_SYNC_LOCK.acquire(blocking=False):
+        return {"ok": False, "error": "resource_acl_sync_in_progress"}
+    try:
+        config = config or V2Config.load()
+        if not _resource_acl_sync_configured(config):
+            return {"ok": False, "error": "resource_acl_sync_not_configured"}
+        if resources is not None and organization_id is None:
+            return {"ok": False, "error": "invalid_organization_id"}
+        if organization_id is not None:
+            organizations = [_safe_resource_acl_identifier(organization_id, code="invalid_organization_id")]
+        else:
+            from storage import resource_access_service
+
+            organizations = sorted(
+                {
+                    str(policy["organization_id"])
+                    for policy in resource_access_service.list_resource_policies()
+                    if policy.get("organization_id")
+                }
+            )
+        results = [
+            _sync_one_organization(
+                config,
+                organization_id=organization,
+                resources=resources if resources is not None else None,
+            )
+            for organization in organizations
+        ]
+        return {"ok": all(result.get("ok") for result in results), "organizations": results}
+    except Exception as exc:
+        return {"ok": False, "error": _resource_acl_sync_error_code(exc)}
+    finally:
+        _RESOURCE_ACL_SYNC_LOCK.release()
+
+
+def start_resource_acl_sync_polling(
+    config: V2Config | None = None,
+    *,
+    interval_seconds: int = RESOURCE_ACL_SYNC_INTERVAL_SECONDS,
+) -> None:
+    """Start the paired-device ACL poller once for the UI process."""
+
+    global _RESOURCE_ACL_SYNC_POLL_STARTED
+    if config is None:
+        try:
+            config = V2Config.load()
+        except Exception:
+            return
+    if not _resource_acl_sync_configured(config):
+        return
+
+    def loop() -> None:
+        while True:
+            result = sync_resource_acl_once()
+            if not result.get("ok") and result.get("error") not in {
+                "resource_acl_sync_not_configured",
+                "resource_acl_sync_in_progress",
+            }:
+                logger.debug("Resource ACL sync poll did not complete: %s", result.get("error"))
+            time.sleep(max(1, interval_seconds))
+
+    with _RESOURCE_ACL_SYNC_POLL_LOCK:
+        if _RESOURCE_ACL_SYNC_POLL_STARTED:
+            return
+        try:
+            thread = threading.Thread(target=loop, name="vibe-resource-acl-sync", daemon=True)
+            thread.start()
+        except Exception:
+            return
+        _RESOURCE_ACL_SYNC_POLL_STARTED = True
 
 
 def drain_runtime_status_reports(timeout_seconds: float = STATUS_REPORT_DRAIN_SECONDS) -> None:
@@ -1325,10 +1767,11 @@ def start_tunnel_quality_monitor(interval_seconds: float = QUALITY_SAMPLE_SECOND
 
 
 def start_runtime_monitoring(config: V2Config | None = None) -> None:
-    """Ensure the UI-owned heartbeat and quality workers are running."""
+    """Ensure the UI-owned remote-access workers are running."""
 
     start_tunnel_quality_monitor()
     start_status_heartbeat(config)
+    start_resource_acl_sync_polling(config)
 
 
 def stop(config: V2Config | None = None) -> dict[str, Any]:
@@ -1915,7 +2358,88 @@ def _session_signature(secret: str, payload: str) -> str:
     return hmac.new(secret.encode("utf-8"), payload.encode("utf-8"), hashlib.sha256).hexdigest()
 
 
-def make_session_cookie(config: V2Config, email: str, subject: str) -> str:
+_ORGANIZATION_SESSION_CLAIM_KEYS = (
+    "vibe_organization_id",
+    "vibe_organization_member_id",
+    "vibe_organization_role",
+    "vibe_group_ids",
+    "vibe_membership_version",
+)
+
+
+def _oidc_claim_string(value: Any, *, reason: str, limit: int = 200) -> str:
+    if not isinstance(value, str):
+        raise OAuthCodeExchangeError(reason)
+    cleaned = value.strip()
+    if not cleaned or len(cleaned) > limit or any(ord(char) < 32 or ord(char) == 127 for char in cleaned):
+        raise OAuthCodeExchangeError(reason)
+    return cleaned
+
+
+def session_claims_from_oidc(config: V2Config, claims: Mapping[str, Any]) -> dict[str, Any]:
+    """Select and validate the OIDC claims safe to retain in the local cookie.
+
+    Current paired control planes must satisfy the frozen claim shape. Only the
+    selected values are copied, so unrelated ID-token data never enters the
+    local browser session.
+    """
+
+    instance_id = _oidc_claim_string(claims.get("vibe_instance_id"), reason="invalid_instance_id")
+    if instance_id != config.remote_access.vibe_cloud.instance_id:
+        raise OAuthCodeExchangeError("invalid_instance_id")
+    access_source_raw = claims.get("vibe_instance_access_source")
+    organization_claim_present = any(key in claims and claims.get(key) is not None for key in _ORGANIZATION_SESSION_CLAIM_KEYS)
+    if access_source_raw is None:
+        raise OAuthCodeExchangeError("invalid_instance_access_source")
+    access_source = _oidc_claim_string(access_source_raw, reason="invalid_instance_access_source")
+    if access_source not in _INSTANCE_ACCESS_SOURCES:
+        raise OAuthCodeExchangeError("invalid_instance_access_source")
+
+    session_claims: dict[str, Any] = {
+        "vibe_instance_id": instance_id,
+        "vibe_instance_access_source": access_source,
+    }
+    if not organization_claim_present:
+        return session_claims
+    if access_source in {"email", "email_domain"}:
+        # External guests must never receive local organization/group context.
+        raise OAuthCodeExchangeError("invalid_organization_claims")
+    organization_id = _oidc_claim_string(claims.get("vibe_organization_id"), reason="invalid_organization_claims")
+    member_id = _oidc_claim_string(claims.get("vibe_organization_member_id"), reason="invalid_organization_claims")
+    role = _oidc_claim_string(claims.get("vibe_organization_role"), reason="invalid_organization_claims")
+    if role not in _ORGANIZATION_ROLES:
+        raise OAuthCodeExchangeError("invalid_organization_claims")
+    raw_group_ids = claims.get("vibe_group_ids")
+    if not isinstance(raw_group_ids, list) or len(raw_group_ids) > 256:
+        raise OAuthCodeExchangeError("invalid_organization_claims")
+    group_ids = [_oidc_claim_string(group_id, reason="invalid_organization_claims") for group_id in raw_group_ids]
+    if len(set(group_ids)) != len(group_ids):
+        raise OAuthCodeExchangeError("invalid_organization_claims")
+    session_claims.update(
+        {
+            "vibe_organization_id": organization_id,
+            "vibe_organization_member_id": member_id,
+            "vibe_organization_role": role,
+            "vibe_group_ids": group_ids,
+        }
+    )
+    membership_version = claims.get("vibe_membership_version")
+    if membership_version is not None:
+        if isinstance(membership_version, int) and not isinstance(membership_version, bool):
+            membership_version = str(membership_version)
+        session_claims["vibe_membership_version"] = _oidc_claim_string(
+            membership_version,
+            reason="invalid_organization_claims",
+        )
+    return session_claims
+
+
+def make_session_cookie(
+    config: V2Config,
+    email: str,
+    subject: str,
+    session_claims: Mapping[str, Any] | None = None,
+) -> str:
     cloud = config.remote_access.vibe_cloud
     if not cloud.session_secret:
         raise ValueError("Remote access session secret is not configured")
@@ -1927,6 +2451,21 @@ def make_session_cookie(config: V2Config, email: str, subject: str) -> str:
         "iat": issued_at,
         "exp": issued_at + SESSION_TTL_SECONDS,
     }
+    has_oidc_session_claims = bool(
+        session_claims
+        and any(
+            key in session_claims
+            for key in ("vibe_instance_id", "vibe_instance_access_source", *_ORGANIZATION_SESSION_CLAIM_KEYS)
+        )
+    )
+    if has_oidc_session_claims:
+        assert session_claims is not None
+        selected_claims = session_claims_from_oidc(config, session_claims)
+        payload.update(selected_claims)
+        if selected_claims.get("vibe_organization_id"):
+            # Membership/group claims must be refreshed through OIDC instead of
+            # being slid indefinitely from a stale signed local cookie.
+            payload["claims_issued_at"] = issued_at
     payload_text = urllib.parse.quote(json.dumps(payload, separators=(",", ":")), safe="")
     signature = _session_signature(cloud.session_secret, payload_text)
     return f"{payload_text}.{signature}"
@@ -1946,10 +2485,30 @@ def parse_session_cookie(config: V2Config, cookie_value: str | None) -> dict[str
         payload = json.loads(urllib.parse.unquote(payload_text))
     except Exception:
         return None
+    if not isinstance(payload, dict):
+        return None
     if payload.get("instance_id") != cloud.instance_id:
         return None
     if int(payload.get("exp", 0)) <= int(time.time()):
         return None
+    has_session_claims = any(
+        key in payload
+        for key in ("vibe_instance_id", "vibe_instance_access_source", *_ORGANIZATION_SESSION_CLAIM_KEYS)
+    )
+    if has_session_claims:
+        try:
+            selected_claims = session_claims_from_oidc(config, payload)
+        except OAuthCodeExchangeError:
+            return None
+        if not selected_claims:
+            return None
+        if selected_claims.get("vibe_organization_id"):
+            try:
+                claims_issued_at = int(payload.get("claims_issued_at", payload.get("iat", 0)))
+            except (TypeError, ValueError):
+                return None
+            if claims_issued_at <= 0:
+                return None
     return payload
 
 
@@ -1966,6 +2525,19 @@ def session_needs_renewal(payload: dict[str, Any], now: int | None = None) -> bo
     """
     current = now if now is not None else int(time.time())
     return int(payload.get("exp", 0)) - current < SESSION_TTL_SECONDS // 2
+
+
+def session_needs_membership_refresh(payload: Mapping[str, Any], now: int | None = None) -> bool:
+    """Return whether an organization-bearing session must refresh via OIDC."""
+
+    if not payload.get("vibe_organization_id"):
+        return False
+    current = now if now is not None else int(time.time())
+    try:
+        claims_issued_at = int(payload.get("claims_issued_at", payload.get("iat", 0)))
+    except (TypeError, ValueError):
+        return True
+    return claims_issued_at <= 0 or current - claims_issued_at >= SESSION_ORGANIZATION_REFRESH_SECONDS
 
 
 def authorization_url(config: V2Config, state: str, nonce: str, code_challenge: str) -> str:
@@ -2043,7 +2615,11 @@ def exchange_oauth_code(config: V2Config, code: str, code_verifier: str) -> dict
         raise OAuthCodeExchangeError("invalid_instance_id")
     if not claims.get("email_verified"):
         raise OAuthCodeExchangeError("email_not_verified")
-    return {"claims": claims, "token": token_payload}
+    return {
+        "claims": claims,
+        "session_claims": session_claims_from_oidc(config, claims),
+        "token": token_payload,
+    }
 
 
 # --- OAuth handshake store -------------------------------------------------

--- a/vibe/remote_access.py
+++ b/vibe/remote_access.py
@@ -2388,7 +2388,10 @@ def session_claims_from_oidc(config: V2Config, claims: Mapping[str, Any]) -> dic
     if instance_id != config.remote_access.vibe_cloud.instance_id:
         raise OAuthCodeExchangeError("invalid_instance_id")
     access_source_raw = claims.get("vibe_instance_access_source")
-    organization_claim_present = any(key in claims and claims.get(key) is not None for key in _ORGANIZATION_SESSION_CLAIM_KEYS)
+    # An explicit null is not equivalent to an omitted organization claim. It
+    # is a malformed frozen-claim shape and must not silently downgrade into a
+    # base-only session.
+    organization_claim_present = any(key in claims for key in _ORGANIZATION_SESSION_CLAIM_KEYS)
     if access_source_raw is None:
         raise OAuthCodeExchangeError("invalid_instance_access_source")
     access_source = _oidc_claim_string(access_source_raw, reason="invalid_instance_access_source")

--- a/vibe/remote_access.py
+++ b/vibe/remote_access.py
@@ -617,7 +617,7 @@ def cloud_token_for_request(
     """
     config = config or V2Config.load()
     payload = parse_session_cookie(config, cookie_value)
-    if payload is None:
+    if payload is None or session_needs_authorization_refresh(payload):
         return None
     email = str(payload.get("email", "")).strip()
     sub = str(payload.get("sub", "")).strip()

--- a/vibe/remote_access.py
+++ b/vibe/remote_access.py
@@ -46,6 +46,9 @@ CLOUDFLARED_BASE_URL = "https://github.com/cloudflare/cloudflared/releases/lates
 SESSION_COOKIE_NAME = "__Host-vibe_remote_session"
 SESSION_TTL_SECONDS = 24 * 60 * 60
 SESSION_AUTHORIZATION_REFRESH_SECONDS = SESSION_TTL_SECONDS // 2
+# Keep enough headroom for the cookie name and attributes under the common
+# 4096-byte per-cookie browser limit.
+SESSION_COOKIE_MAX_VALUE_BYTES = 3800
 OAUTH_ID_TOKEN_CLOCK_LEEWAY_SECONDS = 30
 _CONNECTOR_LOCK = threading.RLock()
 _STATUS_HEARTBEAT_LOCK = threading.Lock()
@@ -2487,11 +2490,16 @@ def make_session_cookie(
     payload["claims_issued_at"] = issued_at
     payload_text = urllib.parse.quote(json.dumps(payload, separators=(",", ":")), safe="")
     signature = _session_signature(cloud.session_secret, payload_text)
-    return f"{payload_text}.{signature}"
+    cookie_value = f"{payload_text}.{signature}"
+    if len(cookie_value.encode("ascii")) > SESSION_COOKIE_MAX_VALUE_BYTES:
+        raise OAuthCodeExchangeError("session_cookie_too_large")
+    return cookie_value
 
 
 def parse_session_cookie(config: V2Config, cookie_value: str | None) -> dict[str, Any] | None:
     if not cookie_value or "." not in cookie_value:
+        return None
+    if len(cookie_value.encode("utf-8")) > SESSION_COOKIE_MAX_VALUE_BYTES:
         return None
     cloud = config.remote_access.vibe_cloud
     if not cloud.session_secret:

--- a/vibe/remote_access.py
+++ b/vibe/remote_access.py
@@ -45,7 +45,7 @@ logger = logging.getLogger(__name__)
 CLOUDFLARED_BASE_URL = "https://github.com/cloudflare/cloudflared/releases/latest/download"
 SESSION_COOKIE_NAME = "__Host-vibe_remote_session"
 SESSION_TTL_SECONDS = 24 * 60 * 60
-SESSION_ORGANIZATION_REFRESH_SECONDS = SESSION_TTL_SECONDS // 2
+SESSION_AUTHORIZATION_REFRESH_SECONDS = SESSION_TTL_SECONDS // 2
 OAUTH_ID_TOKEN_CLOCK_LEEWAY_SECONDS = 30
 _CONNECTOR_LOCK = threading.RLock()
 _STATUS_HEARTBEAT_LOCK = threading.Lock()
@@ -84,6 +84,7 @@ _RESOURCE_ACL_SYNC_ERROR_CODE_RE = re.compile(r"\A[a-z0-9][a-z0-9_:-]{0,119}\Z")
 _RESOURCE_ACL_RESOURCE_KINDS = frozenset({"agent", "vault_secret", "skill", "show_page"})
 _RESOURCE_ACL_ACCESS_LEVELS = frozenset({"public", "scope", "private"})
 _RESOURCE_ACL_SYNC_STATUSES = frozenset({"in_sync", "pending", "offline", "error", "deleted"})
+_INSTANCE_ACCESS_ROLES = frozenset({"owner", "editor", "viewer"})
 _INSTANCE_ACCESS_SOURCES = frozenset({"owner", "public_instance", "email", "email_domain", "organization_group"})
 _ORGANIZATION_ROLES = frozenset({"owner", "admin", "member"})
 _BLOCKED_PAIRING_BACKEND_HOSTS = {
@@ -2387,6 +2388,9 @@ def session_claims_from_oidc(config: V2Config, claims: Mapping[str, Any]) -> dic
     instance_id = _oidc_claim_string(claims.get("vibe_instance_id"), reason="invalid_instance_id")
     if instance_id != config.remote_access.vibe_cloud.instance_id:
         raise OAuthCodeExchangeError("invalid_instance_id")
+    instance_role = _oidc_claim_string(claims.get("vibe_instance_role"), reason="invalid_instance_role")
+    if instance_role not in _INSTANCE_ACCESS_ROLES:
+        raise OAuthCodeExchangeError("invalid_instance_role")
     access_source_raw = claims.get("vibe_instance_access_source")
     # An explicit null is not equivalent to an omitted organization claim. It
     # is a malformed frozen-claim shape and must not silently downgrade into a
@@ -2400,13 +2404,11 @@ def session_claims_from_oidc(config: V2Config, claims: Mapping[str, Any]) -> dic
 
     session_claims: dict[str, Any] = {
         "vibe_instance_id": instance_id,
+        "vibe_instance_role": instance_role,
         "vibe_instance_access_source": access_source,
     }
     if not organization_claim_present:
         return session_claims
-    if access_source in {"email", "email_domain"}:
-        # External guests must never receive local organization/group context.
-        raise OAuthCodeExchangeError("invalid_organization_claims")
     organization_id = _oidc_claim_string(claims.get("vibe_organization_id"), reason="invalid_organization_claims")
     member_id = _oidc_claim_string(claims.get("vibe_organization_member_id"), reason="invalid_organization_claims")
     role = _oidc_claim_string(claims.get("vibe_organization_role"), reason="invalid_organization_claims")
@@ -2441,7 +2443,8 @@ def make_session_cookie(
     config: V2Config,
     email: str,
     subject: str,
-    session_claims: Mapping[str, Any] | None = None,
+    *,
+    session_claims: Mapping[str, Any],
 ) -> str:
     cloud = config.remote_access.vibe_cloud
     if not cloud.session_secret:
@@ -2454,21 +2457,11 @@ def make_session_cookie(
         "iat": issued_at,
         "exp": issued_at + SESSION_TTL_SECONDS,
     }
-    has_oidc_session_claims = bool(
-        session_claims
-        and any(
-            key in session_claims
-            for key in ("vibe_instance_id", "vibe_instance_access_source", *_ORGANIZATION_SESSION_CLAIM_KEYS)
-        )
-    )
-    if has_oidc_session_claims:
-        assert session_claims is not None
-        selected_claims = session_claims_from_oidc(config, session_claims)
-        payload.update(selected_claims)
-        if selected_claims.get("vibe_organization_id"):
-            # Membership/group claims must be refreshed through OIDC instead of
-            # being slid indefinitely from a stale signed local cookie.
-            payload["claims_issued_at"] = issued_at
+    selected_claims = session_claims_from_oidc(config, session_claims)
+    payload.update(selected_claims)
+    # Instance roles and optional organization membership must be refreshed
+    # through OIDC instead of being slid indefinitely from a local cookie.
+    payload["claims_issued_at"] = issued_at
     payload_text = urllib.parse.quote(json.dumps(payload, separators=(",", ":")), safe="")
     signature = _session_signature(cloud.session_secret, payload_text)
     return f"{payload_text}.{signature}"
@@ -2494,24 +2487,16 @@ def parse_session_cookie(config: V2Config, cookie_value: str | None) -> dict[str
         return None
     if int(payload.get("exp", 0)) <= int(time.time()):
         return None
-    has_session_claims = any(
-        key in payload
-        for key in ("vibe_instance_id", "vibe_instance_access_source", *_ORGANIZATION_SESSION_CLAIM_KEYS)
-    )
-    if has_session_claims:
-        try:
-            selected_claims = session_claims_from_oidc(config, payload)
-        except OAuthCodeExchangeError:
-            return None
-        if not selected_claims:
-            return None
-        if selected_claims.get("vibe_organization_id"):
-            try:
-                claims_issued_at = int(payload.get("claims_issued_at", payload.get("iat", 0)))
-            except (TypeError, ValueError):
-                return None
-            if claims_issued_at <= 0:
-                return None
+    try:
+        session_claims_from_oidc(config, payload)
+    except OAuthCodeExchangeError:
+        return None
+    try:
+        claims_issued_at = int(payload.get("claims_issued_at", payload.get("iat", 0)))
+    except (TypeError, ValueError):
+        return None
+    if claims_issued_at <= 0:
+        return None
     return payload
 
 
@@ -2530,17 +2515,15 @@ def session_needs_renewal(payload: dict[str, Any], now: int | None = None) -> bo
     return int(payload.get("exp", 0)) - current < SESSION_TTL_SECONDS // 2
 
 
-def session_needs_membership_refresh(payload: Mapping[str, Any], now: int | None = None) -> bool:
-    """Return whether an organization-bearing session must refresh via OIDC."""
+def session_needs_authorization_refresh(payload: Mapping[str, Any], now: int | None = None) -> bool:
+    """Return whether signed authorization claims must refresh via OIDC."""
 
-    if not payload.get("vibe_organization_id"):
-        return False
     current = now if now is not None else int(time.time())
     try:
         claims_issued_at = int(payload.get("claims_issued_at", payload.get("iat", 0)))
     except (TypeError, ValueError):
         return True
-    return claims_issued_at <= 0 or current - claims_issued_at >= SESSION_ORGANIZATION_REFRESH_SECONDS
+    return claims_issued_at <= 0 or current - claims_issued_at >= SESSION_AUTHORIZATION_REFRESH_SECONDS
 
 
 def authorization_url(config: V2Config, state: str, nonce: str, code_challenge: str) -> str:

--- a/vibe/remote_access.py
+++ b/vibe/remote_access.py
@@ -1050,6 +1050,13 @@ def _sync_one_organization(
                 acknowledged += 1
             except Exception:
                 ack_errors += 1
+    if ack_errors == 0 and not descriptors:
+        try:
+            with engine.begin() as connection:
+                resource_access_service.forget_resource_organization(connection, organization)
+        except Exception:
+            logger.warning("failed to clear published empty resource organization", exc_info=True)
+            ack_errors += 1
     return {
         "organization_id": organization,
         "ok": ack_errors == 0,
@@ -1088,13 +1095,7 @@ def sync_resource_acl_once(
         else:
             from storage import resource_access_service
 
-            organizations = sorted(
-                {
-                    str(policy["organization_id"])
-                    for policy in resource_access_service.list_resource_policies()
-                    if policy.get("organization_id")
-                }
-            )
+            organizations = resource_access_service.list_resource_organization_ids()
         results = [
             _sync_one_organization(
                 config,

--- a/vibe/remote_access.py
+++ b/vibe/remote_access.py
@@ -87,6 +87,7 @@ _RESOURCE_ACL_SYNC_ERROR_CODE_RE = re.compile(r"\A[a-z0-9][a-z0-9_:-]{0,119}\Z")
 _RESOURCE_ACL_RESOURCE_KINDS = frozenset({"agent", "vault_secret", "skill", "show_page"})
 _RESOURCE_ACL_ACCESS_LEVELS = frozenset({"public", "scope", "private"})
 _RESOURCE_ACL_SYNC_STATUSES = frozenset({"in_sync", "pending", "offline", "error", "deleted"})
+_RESOURCE_ACL_PENDING_VAULT_RELEASE_PREFIX = "resource_acl_pending_vault_release:"
 _INSTANCE_ACCESS_ROLES = frozenset({"owner", "editor", "viewer"})
 _INSTANCE_ACCESS_SOURCES = frozenset({"owner", "public_instance", "email", "email_domain", "organization_group"})
 _ORGANIZATION_ROLES = frozenset({"owner", "admin", "member"})
@@ -873,6 +874,45 @@ def _validated_intent_fields(intent: Any) -> tuple[str, str, int, str, list[str]
     return str(resource_kind), resource_id, revision, str(access_level), group_ids
 
 
+def _pending_vault_release_key(organization_id: str, resource_id: str, revision: int) -> str:
+    digest = hashlib.sha256(f"{organization_id}\0{resource_id}\0{revision}".encode()).hexdigest()
+    return f"{_RESOURCE_ACL_PENDING_VAULT_RELEASE_PREFIX}{digest}"
+
+
+def _load_pending_vault_release_scopes(connection, key: str) -> list[dict[str, str]]:
+    from sqlalchemy import select
+    from storage.models import state_meta
+
+    raw_value = connection.execute(select(state_meta.c.value_json).where(state_meta.c.key == key)).scalar_one_or_none()
+    try:
+        value = json.loads(raw_value) if raw_value else []
+    except (TypeError, ValueError):
+        return []
+    if not isinstance(value, list):
+        return []
+    grant_ids = [str(item.get("grant_id") or "") for item in value if isinstance(item, Mapping)]
+    return [{"grant_id": grant_id} for grant_id in dict.fromkeys(grant_ids) if grant_id]
+
+
+def _store_pending_vault_release_scopes(connection, key: str, scopes: list[dict[str, str]]) -> None:
+    from storage.models import state_meta
+
+    connection.execute(state_meta.delete().where(state_meta.c.key == key))
+    connection.execute(
+        state_meta.insert().values(
+            key=key,
+            value_json=json.dumps(scopes, separators=(",", ":")),
+            updated_at=datetime.now().astimezone().isoformat(),
+        )
+    )
+
+
+def _clear_pending_vault_release_scopes(connection, key: str) -> None:
+    from storage.models import state_meta
+
+    connection.execute(state_meta.delete().where(state_meta.c.key == key))
+
+
 def _sync_one_organization(
     config: V2Config,
     *,
@@ -912,6 +952,11 @@ def _sync_one_organization(
             rejected += 1
             continue
         release_scopes: list[dict[str, str]] = []
+        release_key = (
+            _pending_vault_release_key(organization, resource_id, revision)
+            if resource_kind == "vault_secret"
+            else None
+        )
         try:
             with engine.begin() as connection:
                 previous_policy = resource_access_service.get_resource_policy(
@@ -937,6 +982,12 @@ def _sync_one_organization(
                             resource_id,
                         )
                         release_scopes = vault_service.agent_release_scopes_after_rows(connection, revoked_rows)
+                        if release_scopes and release_key is not None:
+                            _store_pending_vault_release_scopes(connection, release_key, release_scopes)
+                if release_key is not None:
+                    release_scopes = _load_pending_vault_release_scopes(connection, release_key)
+            if outcome["status"] == "applied":
+                applied += 1
             if release_scopes:
                 try:
                     api.release_vault_agent_scopes(
@@ -945,11 +996,19 @@ def _sync_one_organization(
                     )
                 except Exception:
                     logger.warning("failed to release narrowed Vault grant scopes", exc_info=True)
+                    ack_errors += 1
+                    continue
+                try:
+                    with engine.begin() as connection:
+                        assert release_key is not None
+                        _clear_pending_vault_release_scopes(connection, release_key)
+                except Exception:
+                    logger.warning("failed to clear pending narrowed Vault grant release", exc_info=True)
+                    ack_errors += 1
+                    continue
             if outcome["status"] == "stale":
                 skipped += 1
                 continue
-            if outcome["status"] == "applied":
-                applied += 1
             try:
                 acknowledge_resource_acl_intent(
                     config,

--- a/vibe/remote_access.py
+++ b/vibe/remote_access.py
@@ -1038,19 +1038,11 @@ def _sync_one_organization(
             except Exception:
                 ack_errors += 1
         except Exception:
-            rejected += 1
-            try:
-                acknowledge_resource_acl_intent(
-                    config,
-                    resource_kind=resource_kind,
-                    resource_id=resource_id,
-                    revision=revision,
-                    outcome="rejected",
-                    error_code="resource_acl_apply_failed",
-                )
-                acknowledged += 1
-            except Exception:
-                ack_errors += 1
+            # Unexpected storage or I/O failures are retryable. Do not let the
+            # control plane retire the intent while the previous ACL may still
+            # be active locally.
+            logger.warning("failed to apply resource ACL intent", exc_info=True)
+            ack_errors += 1
     if ack_errors == 0 and not descriptors:
         try:
             with engine.begin() as connection:

--- a/vibe/remote_access.py
+++ b/vibe/remote_access.py
@@ -1111,6 +1111,30 @@ def sync_resource_acl_once(
         _RESOURCE_ACL_SYNC_LOCK.release()
 
 
+def _resource_acl_poll_delay(result: Mapping[str, Any], fallback_seconds: int) -> int:
+    fallback = max(1, fallback_seconds)
+    organizations = result.get("organizations")
+    if not isinstance(organizations, list):
+        return fallback
+
+    delays: list[int] = []
+    for organization in organizations:
+        if not isinstance(organization, Mapping) or not organization.get("ok"):
+            continue
+        raw_delay = organization.get("poll_after_seconds")
+        if isinstance(raw_delay, bool):
+            continue
+        try:
+            delay = int(raw_delay)
+        except (TypeError, ValueError):
+            continue
+        if delay > 0:
+            delays.append(delay)
+    # One poller serves every organization, so do not poll any organization
+    # sooner than the control plane requested.
+    return max(delays, default=fallback)
+
+
 def start_resource_acl_sync_polling(
     config: V2Config | None = None,
     *,
@@ -1135,7 +1159,7 @@ def start_resource_acl_sync_polling(
                 "resource_acl_sync_in_progress",
             }:
                 logger.debug("Resource ACL sync poll did not complete: %s", result.get("error"))
-            time.sleep(max(1, interval_seconds))
+            time.sleep(_resource_acl_poll_delay(result, interval_seconds))
 
     with _RESOURCE_ACL_SYNC_POLL_LOCK:
         if _RESOURCE_ACL_SYNC_POLL_STARTED:

--- a/vibe/remote_access.py
+++ b/vibe/remote_access.py
@@ -950,6 +950,7 @@ def _sync_one_organization(
             # A malformed device response is not safe to acknowledge because it
             # does not identify an exact valid revision.
             rejected += 1
+            ack_errors += 1
             continue
         release_scopes: list[dict[str, str]] = []
         release_key = (

--- a/vibe/remote_access.py
+++ b/vibe/remote_access.py
@@ -908,8 +908,14 @@ def _sync_one_organization(
             # does not identify an exact valid revision.
             rejected += 1
             continue
+        release_scopes: list[dict[str, str]] = []
         try:
             with engine.begin() as connection:
+                previous_policy = resource_access_service.get_resource_policy(
+                    resource_kind,
+                    resource_id,
+                    connection=connection,
+                )
                 outcome = resource_access_service.apply_control_plane_intent(
                     connection,
                     organization_id=organization,
@@ -919,6 +925,23 @@ def _sync_one_organization(
                     access_level=access_level,
                     group_ids=group_ids,
                 )
+                if resource_kind == "vault_secret" and outcome["status"] == "applied":
+                    from storage import vault_service
+
+                    if vault_service.resource_policy_narrowed(previous_policy, outcome["policy"]):
+                        revoked_rows = vault_service.revoke_active_grants_for_secret_resource(
+                            connection,
+                            resource_id,
+                        )
+                        release_scopes = vault_service.agent_release_scopes_after_rows(connection, revoked_rows)
+            if release_scopes:
+                try:
+                    api.release_vault_agent_scopes(
+                        release_scopes,
+                        reason="resource-access-policy-narrowed",
+                    )
+                except Exception:
+                    logger.warning("failed to release narrowed Vault grant scopes", exc_info=True)
             if outcome["status"] == "stale":
                 skipped += 1
                 continue

--- a/vibe/ui_compat.py
+++ b/vibe/ui_compat.py
@@ -105,6 +105,14 @@ request = _LocalProxy(lambda: _request_var.get())
 g = _LocalProxy(lambda: _g_var.get())
 
 
+def has_request_context() -> bool:
+    try:
+        _request_var.get()
+    except LookupError:
+        return False
+    return True
+
+
 def jsonify(*args: Any, **kwargs: Any) -> JSONResponse:
     if args and kwargs:
         raise TypeError("jsonify() behavior with args and kwargs is unsupported")

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -6936,6 +6936,7 @@ async def sessions_archive(session_id: str):
     session is already archived + guarded, so a turn that slips through just
     writes into hidden history rather than re-surfacing the session.
     """
+    from core.show_pages import ShowPageError
     from core.services import sessions as workbench_sessions_service
     from vibe.sse_broker import broker
 
@@ -6945,6 +6946,8 @@ async def sessions_archive(session_id: str):
             session = workbench_sessions_service.archive_session(conn, session_id)
     except LookupError as err:
         return jsonify({"error": str(err)}), 404
+    except ShowPageError as err:
+        return _show_page_error_response(err)
 
     revoked_vault_scopes = session.pop("revoked_vault_grant_scopes", [])
 

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -4039,7 +4039,12 @@ def _dock_error_response(exc):
     # A missing Show Page (nothing to pin) is a 404; a malformed id or a bad
     # order is a 400. Structured ``error`` so the Web UI's shared handler can
     # localize via ``errors.<code>`` and fall back to the human message.
-    status = 404 if code in {"show_page_not_found", "session_not_found"} else 400
+    if code == "resource_access_forbidden":
+        status = 403
+    elif code in {"show_page_not_found", "session_not_found"}:
+        status = 404
+    else:
+        status = 400
     message = str(exc)
     return jsonify({"ok": False, "error": {"code": code, "message": message}, "code": code, "message": message}), status
 
@@ -4079,6 +4084,7 @@ def dock_unpin_delete(session_id):
 @app.route("/api/dock/order", methods=["PUT"])
 def dock_order_put():
     from core.dock_store import DockError
+    from core.show_pages import ShowPageError
     from vibe import api
 
     payload = request.json or {}
@@ -4088,7 +4094,7 @@ def dock_order_put():
         # longer matches the server's, so a stale tab can't silently undock a pin
         # another tab installed.
         return jsonify(api.set_dock_order(payload.get("order"), known=payload.get("known")))
-    except DockError as exc:
+    except (DockError, ShowPageError) as exc:
         return _dock_error_response(exc)
 
 

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -2112,12 +2112,12 @@ def enforce_remote_access_cookie():
         return jsonify({"ok": False, "error": "remote_access_session_secret_missing"}), 503
     payload = remote_access.parse_session_cookie(config, request.cookies.get(remote_access.SESSION_COOKIE_NAME))
     if payload is not None:
-        if remote_access.session_needs_membership_refresh(payload):
+        if remote_access.session_needs_authorization_refresh(payload):
             if request.method == "GET":
                 if _auth_rate_limited():
                     return _auth_rate_limit_response()
                 return _redirect_to_vibe_cloud_login(config)
-            return jsonify({"ok": False, "error": "remote_access_membership_refresh_required"}), 401
+            return jsonify({"ok": False, "error": "remote_access_authorization_refresh_required"}), 401
         if remote_access.session_needs_renewal(payload):
             g.remote_session_renew = payload
         return None
@@ -2578,7 +2578,7 @@ def _remote_access_websocket_session_payload(websocket: Any, config: V2Config | 
         config,
         websocket.cookies.get(remote_access.SESSION_COOKIE_NAME),
     )
-    if payload is not None and remote_access.session_needs_membership_refresh(payload):
+    if payload is not None and remote_access.session_needs_authorization_refresh(payload):
         return None
     return payload
 
@@ -4651,14 +4651,7 @@ def remote_access_auth_callback():
         claims = result["claims"]
         session_claims = result.get("session_claims")
         if not isinstance(session_claims, dict):
-            # Compatibility for a previously paired backend and test doubles
-            # that return the historical minimal claim set. Production
-            # `exchange_oauth_code` always returns validated session_claims.
-            session_claims = (
-                remote_access.session_claims_from_oidc(config, claims)
-                if claims.get("vibe_instance_id")
-                else {}
-            )
+            raise remote_access.OAuthCodeExchangeError("invalid_session_claims")
     except Exception as exc:
         # Unauthenticated-reachable (valid handshake + bad code), so rate-limited.
         reason = exc.reason if isinstance(exc, remote_access.OAuthCodeExchangeError) else exc.__class__.__name__
@@ -4675,7 +4668,7 @@ def remote_access_auth_callback():
             config,
             str(claims.get("email", "")),
             str(claims.get("sub", "")),
-            session_claims=session_claims or None,
+            session_claims=session_claims,
         ),
         httponly=True,
         secure=True,
@@ -4787,6 +4780,7 @@ def organization_context_get():
             "user": {"sub": user_context.subject, "email": user_context.email},
             "instance_id": _payload.get("vibe_instance_id", _payload.get("instance_id")),
             "organization": organization,
+            "instance_role": user_context.instance_role,
             "instance_access_source": user_context.instance_access_source,
         }
     )

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -2113,7 +2113,7 @@ def enforce_remote_access_cookie():
     payload = remote_access.parse_session_cookie(config, request.cookies.get(remote_access.SESSION_COOKIE_NAME))
     if payload is not None:
         if remote_access.session_needs_authorization_refresh(payload):
-            if request.method == "GET":
+            if request.method == "GET" and not request.path.startswith("/api/"):
                 if _auth_rate_limited():
                     return _auth_rate_limit_response()
                 return _redirect_to_vibe_cloud_login(config)

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -4700,16 +4700,23 @@ def remote_access_auth_callback():
         return _oauth_callback_error_response(error, next_target=next_target, diagnostics=diagnostics)
     if claims.get("nonce") != handshake_nonce:
         return _oauth_callback_error_response("invalid_oauth_nonce", next_target=next_target)
-    response = Response(status=302)
-    response.headers["Location"] = _safe_remote_redirect_target(next_target)
-    response.set_cookie(
-        remote_access.SESSION_COOKIE_NAME,
-        remote_access.make_session_cookie(
+    try:
+        session_cookie = remote_access.make_session_cookie(
             config,
             str(claims.get("email", "")),
             str(claims.get("sub", "")),
             session_claims=session_claims,
-        ),
+        )
+    except Exception as exc:
+        reason = exc.reason if isinstance(exc, remote_access.OAuthCodeExchangeError) else exc.__class__.__name__
+        _log_oauth_diag("exchange_failed", "vibe cloud session cookie creation failed: reason=%s", reason)
+        error, diagnostics = _oauth_exchange_error_diagnostics(exc)
+        return _oauth_callback_error_response(error, next_target=next_target, diagnostics=diagnostics)
+    response = Response(status=302)
+    response.headers["Location"] = _safe_remote_redirect_target(next_target)
+    response.set_cookie(
+        remote_access.SESSION_COOKIE_NAME,
+        session_cookie,
         httponly=True,
         secure=True,
         samesite="Lax",
@@ -7866,6 +7873,9 @@ async def sessions_messages_create(session_id: str):
     try:
         with engine.connect() as conn:
             session = workbench_sessions_service.get_session(conn, session_id)
+            from core.vibe_agents import ensure_session_agent_access
+
+            ensure_session_agent_access(conn, session)
             # Archived sessions are terminal + inert: refuse to start a turn on one
             # even via a stale/direct request (the workbench hides them from the
             # list, so this only fires on a leftover tab or a hand-crafted call).
@@ -7881,6 +7891,8 @@ async def sessions_messages_create(session_id: str):
                 return jsonify({"already_answered": True}), 200
     except LookupError as err:
         return jsonify({"error": str(err)}), 404
+    except PermissionError as err:
+        return jsonify({"error": str(err), "code": "agent_access_forbidden"}), 403
 
     dispatch_text = (
         (text if isinstance(text, str) else None)

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -3329,8 +3329,10 @@ def agent_backends_get():
     return jsonify(api.get_agent_backend_catalog())
 
 
-def _vibe_agent_error_response(exc: ValueError):
+def _vibe_agent_error_response(exc: Exception):
     message = str(exc)
+    if isinstance(exc, PermissionError):
+        return jsonify({"ok": False, "code": "agent_access_forbidden", "message": message}), 403
     lowered = message.lower()
     if "not found" in lowered:
         return jsonify({"ok": False, "code": "agent_not_found", "message": message}), 404
@@ -3368,7 +3370,7 @@ def vibe_agents_get():
             "yes",
         }
         return jsonify(api.get_vibe_agents(backend=request.args.get("backend") or None, include_disabled=include_disabled))
-    except ValueError as exc:
+    except (ValueError, PermissionError) as exc:
         return _vibe_agent_error_response(exc)
 
 
@@ -3463,7 +3465,7 @@ def vibe_agent_get(name):
 
     try:
         return jsonify(api.get_vibe_agent(name))
-    except ValueError as exc:
+    except (ValueError, PermissionError) as exc:
         return _vibe_agent_error_response(exc)
 
 
@@ -3473,7 +3475,7 @@ def vibe_agents_post():
 
     try:
         return jsonify(api.create_vibe_agent(request.json or {}))
-    except ValueError as exc:
+    except (ValueError, PermissionError) as exc:
         return _vibe_agent_error_response(exc)
 
 
@@ -3483,7 +3485,7 @@ def vibe_agents_import_post():
 
     try:
         return _vibe_agent_result_response(api.import_vibe_agents(request.json or {}))
-    except ValueError as exc:
+    except (ValueError, PermissionError) as exc:
         return _vibe_agent_error_response(exc)
 
 
@@ -3494,7 +3496,7 @@ def vibe_agents_default_post():
     payload = request.json or {}
     try:
         return jsonify(api.set_default_vibe_agent(payload.get("name") or ""))
-    except ValueError as exc:
+    except (ValueError, PermissionError) as exc:
         return _vibe_agent_error_response(exc)
 
 
@@ -3504,7 +3506,7 @@ def vibe_agent_patch(name):
 
     try:
         return jsonify(api.update_vibe_agent(name, request.json or {}))
-    except ValueError as exc:
+    except (ValueError, PermissionError) as exc:
         return _vibe_agent_error_response(exc)
 
 
@@ -3514,7 +3516,7 @@ def vibe_agent_delete(name):
 
     try:
         return _vibe_agent_result_response(api.remove_vibe_agent(name))
-    except ValueError as exc:
+    except (ValueError, PermissionError) as exc:
         return _vibe_agent_error_response(exc)
 
 
@@ -6773,8 +6775,10 @@ async def sessions_update(session_id: str):
             session = workbench_sessions_service.update_session(conn, session_id, **updatable)
     except LookupError as err:
         return jsonify({"error": str(err)}), 404
-    except (ValueError, PermissionError) as err:
+    except ValueError as err:
         return jsonify({"error": str(err)}), 400
+    except PermissionError as err:
+        return jsonify({"error": str(err)}), 403
     except workbench_sessions_service.SessionBackendLockedError as err:
         # A session is pinned to its backend once it has a conversation (or a
         # running turn); the UI may switch the agent within the same backend,

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -4744,7 +4744,7 @@ def api_session():
         payload = remote_access.parse_session_cookie(
             config, request.cookies.get(remote_access.SESSION_COOKIE_NAME)
         )
-        if payload is None:
+        if payload is None or remote_access.session_needs_authorization_refresh(payload):
             response = jsonify({"remote": True, "authenticated": False})
         else:
             response = jsonify(
@@ -5015,8 +5015,12 @@ def api_cloud_token():
     config = _load_remote_access_config()
     if config is None:
         return jsonify({"error": "cloud_unavailable"}), 503
+    cookie_value = request.cookies.get(remote_access.SESSION_COOKIE_NAME)
+    payload = remote_access.parse_session_cookie(config, cookie_value)
+    if payload is not None and remote_access.session_needs_authorization_refresh(payload):
+        return jsonify({"ok": False, "error": "remote_access_authorization_refresh_required"}), 401
     result = remote_access.cloud_token_for_request(
-        config, request.cookies.get(remote_access.SESSION_COOKIE_NAME)
+        config, cookie_value
     )
     if result is None:
         return jsonify({"error": "cloud_unavailable"}), 503

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -2112,8 +2112,14 @@ def enforce_remote_access_cookie():
         return jsonify({"ok": False, "error": "remote_access_session_secret_missing"}), 503
     payload = remote_access.parse_session_cookie(config, request.cookies.get(remote_access.SESSION_COOKIE_NAME))
     if payload is not None:
+        if remote_access.session_needs_membership_refresh(payload):
+            if request.method == "GET":
+                if _auth_rate_limited():
+                    return _auth_rate_limit_response()
+                return _redirect_to_vibe_cloud_login(config)
+            return jsonify({"ok": False, "error": "remote_access_membership_refresh_required"}), 401
         if remote_access.session_needs_renewal(payload):
-            g.remote_session_renew = (str(payload.get("email", "")), str(payload.get("sub", "")))
+            g.remote_session_renew = payload
         return None
     if request.method == "GET":
         # Bound unauthenticated login-start floods at the door (this writes a
@@ -2244,10 +2250,13 @@ def renew_remote_access_cookie(response: Response) -> Response:
         return response
     from vibe import remote_access
 
-    email, subject = renew
+    if not isinstance(renew, dict):
+        return response
+    email = str(renew.get("email", ""))
+    subject = str(renew.get("sub", ""))
     response.set_cookie(
         remote_access.SESSION_COOKIE_NAME,
-        remote_access.make_session_cookie(config, email, subject),
+        remote_access.make_session_cookie(config, email, subject, session_claims=renew),
         httponly=True,
         secure=True,
         samesite="Lax",
@@ -2565,10 +2574,13 @@ def _remote_access_websocket_session_payload(websocket: Any, config: V2Config | 
 
     if not config.remote_access.vibe_cloud.enabled or not config.remote_access.vibe_cloud.session_secret:
         return None
-    return remote_access.parse_session_cookie(
+    payload = remote_access.parse_session_cookie(
         config,
         websocket.cookies.get(remote_access.SESSION_COOKIE_NAME),
     )
+    if payload is not None and remote_access.session_needs_membership_refresh(payload):
+        return None
+    return payload
 
 
 def _remote_access_websocket_subject(websocket: Any) -> str | None:
@@ -4637,6 +4649,16 @@ def remote_access_auth_callback():
     try:
         result = remote_access.exchange_oauth_code(config, _oauth_callback_arg("code") or "", code_verifier)
         claims = result["claims"]
+        session_claims = result.get("session_claims")
+        if not isinstance(session_claims, dict):
+            # Compatibility for a previously paired backend and test doubles
+            # that return the historical minimal claim set. Production
+            # `exchange_oauth_code` always returns validated session_claims.
+            session_claims = (
+                remote_access.session_claims_from_oidc(config, claims)
+                if claims.get("vibe_instance_id")
+                else {}
+            )
     except Exception as exc:
         # Unauthenticated-reachable (valid handshake + bad code), so rate-limited.
         reason = exc.reason if isinstance(exc, remote_access.OAuthCodeExchangeError) else exc.__class__.__name__
@@ -4649,7 +4671,12 @@ def remote_access_auth_callback():
     response.headers["Location"] = _safe_remote_redirect_target(next_target)
     response.set_cookie(
         remote_access.SESSION_COOKIE_NAME,
-        remote_access.make_session_cookie(config, str(claims.get("email", "")), str(claims.get("sub", ""))),
+        remote_access.make_session_cookie(
+            config,
+            str(claims.get("email", "")),
+            str(claims.get("sub", "")),
+            session_claims=session_claims or None,
+        ),
         httponly=True,
         secure=True,
         samesite="Lax",
@@ -4686,6 +4713,247 @@ def api_session():
     response.headers["Cache-Control"] = "no-store, private"
     response.headers["Vary"] = "Cookie"
     return response
+
+
+def _remote_resource_access_context():
+    """Resolve the signed remote session required by local ACL metadata APIs."""
+
+    from storage import resource_access_service
+    from vibe import remote_access
+
+    config = _load_remote_access_config()
+    if (
+        config is None
+        or not config.remote_access.vibe_cloud.enabled
+        or not _is_remote_access_request(config)
+    ):
+        return None, None, None
+    payload = remote_access.parse_session_cookie(
+        config,
+        request.cookies.get(remote_access.SESSION_COOKIE_NAME),
+    )
+    if payload is None:
+        return config, None, None
+    return config, payload, resource_access_service.current_resource_context(
+        payload,
+        is_remote=True,
+        is_trusted_local=False,
+    )
+
+
+def _resource_policy_api_payload(policy: dict[str, Any], user_context: Any, connection: Any) -> dict[str, Any]:
+    from storage import resource_access_service
+
+    return {
+        "resource_kind": policy["resource_kind"],
+        "resource_id": policy["resource_id"],
+        "access_level": policy["access_level"],
+        "owner_user_id": policy.get("owner_user_id"),
+        "organization_id": policy.get("organization_id"),
+        "group_ids": policy.get("group_ids") or [],
+        "policy_revision": policy.get("policy_revision"),
+        "last_applied_control_plane_revision": policy.get("last_applied_control_plane_revision"),
+        "can_use": resource_access_service.can_use_resource(
+            user_context,
+            policy["resource_kind"],
+            policy["resource_id"],
+            connection=connection,
+        ),
+        "can_manage": resource_access_service.can_manage_resource_acl(
+            user_context,
+            policy["resource_kind"],
+            policy["resource_id"],
+            connection=connection,
+        ),
+    }
+
+
+@app.route("/api/org/context", methods=["GET"])
+def organization_context_get():
+    _config, _payload, user_context = _remote_resource_access_context()
+    if user_context is None:
+        return jsonify({"error": "remote_access_context_required"}), 401
+    organization = None
+    if user_context.is_active_organization_member:
+        organization = {
+            "id": user_context.organization_id,
+            "member_id": user_context.organization_member_id,
+            "role": user_context.organization_role,
+            "group_ids": sorted(user_context.group_ids or []),
+            "membership_version": user_context.membership_version,
+        }
+    response = jsonify(
+        {
+            "user": {"sub": user_context.subject, "email": user_context.email},
+            "instance_id": _payload.get("vibe_instance_id", _payload.get("instance_id")),
+            "organization": organization,
+            "instance_access_source": user_context.instance_access_source,
+        }
+    )
+    response.headers["Cache-Control"] = "no-store, private"
+    response.headers["Vary"] = "Cookie"
+    return response
+
+
+@app.route("/api/org/groups", methods=["GET"])
+def organization_groups_get():
+    _config, _payload, user_context = _remote_resource_access_context()
+    if user_context is None:
+        return jsonify({"error": "remote_access_context_required"}), 401
+    if not user_context.is_active_organization_member:
+        return jsonify({"error": "organization_context_required"}), 403
+    # The frozen device protocol carries group IDs but no mutable group metadata.
+    # These are signed current-member groups, not an authorization cache; a later
+    # metadata endpoint can enrich names and archived state without affecting ACL
+    # evaluation.
+    response = jsonify(
+        {
+            "groups": [
+                {"id": group_id, "name": None, "archived_at": None}
+                for group_id in sorted(user_context.group_ids or [])
+            ]
+        }
+    )
+    response.headers["Cache-Control"] = "no-store, private"
+    response.headers["Vary"] = "Cookie"
+    return response
+
+
+@app.route("/api/resource-policies", methods=["GET"])
+def resource_policies_get():
+    from storage import resource_access_service
+
+    _config, _payload, user_context = _remote_resource_access_context()
+    if user_context is None:
+        return jsonify({"error": "remote_access_context_required"}), 401
+    resource_kind = request.args.get("kind")
+    if resource_kind and resource_kind not in resource_access_service.RESOURCE_KINDS:
+        return jsonify({"error": "invalid_resource_kind"}), 422
+    engine = _projects_engine()
+    try:
+        with engine.connect() as connection:
+            if user_context.is_active_organization_member:
+                policies = resource_access_service.list_resource_policies(
+                    resource_kind=resource_kind,
+                    organization_id=user_context.organization_id,
+                    connection=connection,
+                )
+            elif user_context.subject:
+                policies = resource_access_service.list_resource_policies(
+                    resource_kind=resource_kind,
+                    owner_user_id=user_context.subject,
+                    connection=connection,
+                )
+            else:
+                policies = []
+            serialized = [
+                _resource_policy_api_payload(policy, user_context, connection)
+                for policy in policies
+                if resource_access_service.can_use_resource(
+                    user_context,
+                    policy["resource_kind"],
+                    policy["resource_id"],
+                    connection=connection,
+                )
+                or resource_access_service.can_manage_resource_acl(
+                    user_context,
+                    policy["resource_kind"],
+                    policy["resource_id"],
+                    connection=connection,
+                )
+            ]
+    finally:
+        engine.dispose()
+    response = jsonify({"policies": serialized})
+    response.headers["Cache-Control"] = "no-store, private"
+    response.headers["Vary"] = "Cookie"
+    return response
+
+
+@app.route("/api/resource-policies/<resource_kind>/<resource_id>", methods=["PUT"])
+def resource_policy_put(resource_kind: str, resource_id: str):
+    from storage import resource_access_service
+    from vibe import remote_access
+
+    config, _payload, user_context = _remote_resource_access_context()
+    if user_context is None:
+        return jsonify({"error": "remote_access_context_required"}), 401
+    if resource_kind not in resource_access_service.RESOURCE_KINDS:
+        return jsonify({"error": "invalid_resource_kind"}), 422
+    body = request.json or {}
+    if not isinstance(body, dict):
+        return jsonify({"error": "invalid_request"}), 422
+
+    engine = _projects_engine()
+    try:
+        with engine.connect() as connection:
+            policy = resource_access_service.get_resource_policy(
+                resource_kind,
+                resource_id,
+                connection=connection,
+            )
+            if policy is None:
+                return jsonify({"error": "resource_not_found"}), 404
+            if policy.get("organization_id") and policy.get("organization_id") != user_context.organization_id:
+                return jsonify({"error": "resource_not_found"}), 404
+            if policy.get("organization_id") and not user_context.is_active_organization_member:
+                return jsonify({"error": "organization_context_required"}), 403
+            if not resource_access_service.can_manage_resource_acl(
+                user_context,
+                resource_kind,
+                resource_id,
+                connection=connection,
+            ):
+                return jsonify({"error": "resource_acl_forbidden"}), 403
+
+        try:
+            access_level, group_ids = resource_access_service.normalize_policy_request(
+                body.get("access_level"),
+                body.get("group_ids", []),
+                policy.get("organization_id"),
+            )
+        except resource_access_service.ResourceAccessError as exc:
+            return jsonify({"error": exc.code}), 422
+
+        if policy.get("organization_id"):
+            # Desired organization ACLs are written by the hosted resource API.
+            # This local route only reconciles an intent before returning state;
+            # it never invents a local revision that could overwrite a newer one.
+            sync = remote_access.sync_resource_acl_once(config, organization_id=str(policy["organization_id"]))
+            if not sync.get("ok"):
+                return jsonify({"error": sync.get("error") or "resource_acl_sync_failed", "sync": sync}), 503
+            with engine.connect() as connection:
+                refreshed = resource_access_service.get_resource_policy(
+                    resource_kind,
+                    resource_id,
+                    connection=connection,
+                )
+                if refreshed is None:
+                    return jsonify({"error": "resource_not_found"}), 404
+                serialized = _resource_policy_api_payload(refreshed, user_context, connection)
+            if refreshed["access_level"] == access_level and sorted(refreshed.get("group_ids") or []) == sorted(group_ids):
+                return jsonify({"policy": serialized, "sync": sync})
+            return jsonify(
+                {
+                    "error": "resource_acl_control_plane_required",
+                    "policy": serialized,
+                    "sync": sync,
+                }
+            ), 409
+
+        with engine.begin() as connection:
+            updated = resource_access_service.update_local_non_organization_policy(
+                connection,
+                resource_kind=resource_kind,
+                resource_id=resource_id,
+                access_level=access_level,
+                group_ids=group_ids,
+                updated_by_user_id=user_context.subject,
+            )
+            serialized = _resource_policy_api_payload(updated, user_context, connection)
+        return jsonify({"policy": serialized})
+    finally:
+        engine.dispose()
 
 
 @app.route("/api/cloud/token", methods=["GET"])

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -2408,7 +2408,7 @@ async def websocket_echo(websocket: WebSocket):
 
 @app.websocket("/show/{session_id}/__vite_hmr")
 async def show_runtime_hmr_websocket(websocket: WebSocket, session_id: str):
-    from core.show_pages import ShowPageStore
+    from core.show_pages import ShowPageError, ShowPageStore
 
     if not _show_runtime_hmr_origin_allowed(websocket):
         await websocket.close(code=1008)
@@ -2419,7 +2419,14 @@ async def show_runtime_hmr_websocket(websocket: WebSocket, session_id: str):
 
     store = ShowPageStore()
     try:
-        page = store.get(session_id)
+        try:
+            page = store.require_access(
+                session_id,
+                user_context=_show_runtime_websocket_resource_context(websocket),
+            )
+        except ShowPageError:
+            await websocket.close(code=1008)
+            return
         # Amendment (§2.3, 2026-07-13): the authed /show/ surface serves public
         # pages too, so a public page framed in the Dock app must also get live
         # HMR. Mirror the serve route's private+public visibility gate here.
@@ -2556,6 +2563,24 @@ def _show_runtime_websocket_authorized(websocket: Any) -> bool:
     if _websocket_normalized_host(websocket) != _remote_access_public_host(config):
         return False
     return _remote_access_websocket_session_payload(websocket, config) is not None
+
+
+def _show_runtime_websocket_resource_context(websocket: Any):
+    """Build the ACL context from the same signed session used by the socket gate."""
+
+    from storage import resource_access_service
+
+    config = _load_remote_access_config()
+    if config is None or _websocket_is_local_request(websocket, config):
+        return resource_access_service.ResourceUserContext(is_trusted_local=True)
+    payload = _remote_access_websocket_session_payload(websocket, config)
+    if payload is None:
+        return resource_access_service.ResourceUserContext()
+    return resource_access_service.current_resource_context(
+        payload,
+        is_remote=True,
+        is_trusted_local=False,
+    )
 
 
 def _show_runtime_hmr_origin_allowed(websocket: Any) -> bool:
@@ -3874,7 +3899,10 @@ def _show_page_error_response(exc):
     code = getattr(exc, "code", "invalid_show_page_request")
     # A conflict (not a malformed request) when the page is in the wrong state or
     # the chosen suffix is already claimed.
-    status = 409 if code in {"not_public", "share_id_taken"} else 400
+    if code == "resource_access_forbidden":
+        status = 403
+    else:
+        status = 409 if code in {"not_public", "share_id_taken"} else 400
     message = str(exc)
     # Structured ``error`` so the Web UI's shared handler localizes via
     # ``errors.<code>`` and falls back to the human message (not the raw code)
@@ -3946,6 +3974,12 @@ def _show_page_icon_not_found():
     return response
 
 
+def _show_page_access_forbidden_response():
+    response = Response("", status=403, mimetype="text/plain")
+    response.headers["Cache-Control"] = "no-store"
+    return response
+
+
 @app.route("/api/show-pages/<session_id>/icon", methods=["GET", "HEAD"])
 def show_page_icon_get(session_id):
     # The page's own HTML icon, served as the single chokepoint (§7.1f): ALL href
@@ -3964,7 +3998,7 @@ def show_page_icon_get(session_id):
     try:
         store = ShowPageStore()
         try:
-            page = store.get(session_id)
+            page = store.require_access(session_id)
             # Any of the user's own pages — private, public, OR offline — may serve
             # its static icon: the payload advertises an icon token for all of them
             # and the inventory lists them, so gating by visibility would strand
@@ -3990,7 +4024,11 @@ def show_page_icon_get(session_id):
         # content revert. A plain Response also never honors `Range` (no 206/416).
         response.headers["Cache-Control"] = "private, max-age=604800, immutable"
         return response
-    except (ShowPageError, ValueError, OSError):
+    except ShowPageError as exc:
+        if exc.code == "resource_access_forbidden":
+            return _show_page_access_forbidden_response()
+        return _show_page_icon_not_found()
+    except (ValueError, OSError):
         # Enforce the bytes-or-404 contract at the boundary: a bad session id, a bad
         # page-authored icon, or a file that vanished mid-race must fall back, not 500.
         return _show_page_icon_not_found()
@@ -7245,6 +7283,7 @@ def _show_page_icon_upload_error(code: str, message: str):
     status = {
         "show_page_not_found": 404,
         "session_not_found": 404,
+        "resource_access_forbidden": 403,
         "icon_too_large": 413,
         "invalid_icon_type": 415,
     }.get(code, 400)
@@ -10311,12 +10350,15 @@ def stop_show_runtime_on_shutdown() -> None:
 
 @app.route("/show/<session_id>")
 def redirect_private_show_page_to_canonical_path(session_id):
-    from core.show_pages import ShowPageStore
+    from core.show_pages import ShowPageError, ShowPageStore
 
     store = ShowPageStore()
     try:
-        page = store.get(session_id)
-        if page is None:
+        try:
+            page = store.require_access(session_id)
+        except ShowPageError as exc:
+            if exc.code == "resource_access_forbidden":
+                return _show_page_access_forbidden_response()
             return _show_page_not_found_response()
         # Amendment (§2.3, 2026-07-13): the authed /show/ surface serves public
         # pages too, so the sibling no-trailing-slash canonical redirect must
@@ -10339,12 +10381,15 @@ def redirect_private_show_page_to_canonical_path(session_id):
     methods=["GET", "HEAD", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
 )
 async def serve_private_show_page(session_id, asset_path):
-    from core.show_pages import ShowPageStore, ensure_show_page_dir
+    from core.show_pages import ShowPageError, ShowPageStore, ensure_show_page_dir
 
     store = ShowPageStore()
     try:
-        page = store.get(session_id)
-        if page is None:
+        try:
+            page = store.require_access(session_id)
+        except ShowPageError as exc:
+            if exc.code == "resource_access_forbidden":
+                return _show_page_access_forbidden_response()
             return _show_page_not_found_response()
         if page.visibility == "offline":
             return _show_page_offline_response()


### PR DESCRIPTION
## Capability

Ports the existing organization resource ACL implementation onto the current `org` integration line.

- Adds the local SQLite ACL projection and the `20260725_0035` migration.
- Carries signed instance and organization claims through OIDC/local sessions, with fail-closed refresh behavior.
- Syncs versioned resource metadata and ACL intents over the paired-device channel.
- Exposes the local organization/resource-access APIs.
- Enforces private, organization-public, and group-scoped access for Agents, Vault secrets, Skills, and Show Pages.
- Separates resource use from resource management and rejects external instance guests when creating organization resources.
- Preserves trusted local workflows and legacy-resource access for the signed instance owner.

## Scope

Instance-wide endpoint roles and project ownership are separate authorization layers and remain tracked by #981 and #982.

Scenario IDs: none (no catalog entries exist for this capability).

## Evidence

- Unit/contract: 110 ACL, remote-sync, migration, and resource API tests passed.
- Service/API: 200 Vault service and API tests passed.
- Integration/regression: 738 remote-auth, Show Page, terminal, and UI API tests passed.
- Static: Ruff passed for every changed Python file; `git diff --check` passed.
- Residual manual checks: no live paired-control-plane or browser walkthrough was run locally; GitHub CI remains the full-suite gate.
