### PR TITLE
fix(models): make the Model Hub usable on a phone

### DIFF
--- a/docs/plans/model-hub-contracts/source.schema.json
+++ b/docs/plans/model-hub-contracts/source.schema.json
@@ -126,7 +126,7 @@
             "string",
             "null"
           ],
-          "description": "ISO 4217, e.g. CNY/USD"
+          "description": "ISO 4217. Default and product standard is USD (owner ruling 2026-07-25): upstream vendors bill in USD, so UI must never fall back to a local currency. Other codes are honored only when the backend explicitly reports them."
         }
       }
     },
@@ -238,7 +238,7 @@
       "usage": {
         "cycle_used_pct": null,
         "month_spend_cents": 320,
-        "currency": "CNY"
+        "currency": "USD"
       },
       "models": [
         {

--- a/ui/src/components/settings/models/AddApiKeyDialog.tsx
+++ b/ui/src/components/settings/models/AddApiKeyDialog.tsx
@@ -183,12 +183,13 @@ export const AddApiKeyDialog: React.FC<{
 
         <DialogFooter>
           <div className="flex items-center gap-2">
-            <Button variant="outline" size="sm" onClick={onClose} disabled={phase === 'submitting'}>
+            <Button variant="outline" size="sm" className="h-10 sm:h-9" onClick={onClose} disabled={phase === 'submitting'}>
               {t('common.cancel')}
             </Button>
             <Button
               variant="brand"
               size="sm"
+              className="h-10 sm:h-9"
               onClick={() => void submit()}
               disabled={phase === 'submitting' || phase === 'done' || !apiKey.trim()}
             >

--- a/ui/src/components/settings/models/AddSourceMenu.tsx
+++ b/ui/src/components/settings/models/AddSourceMenu.tsx
@@ -53,7 +53,7 @@ export const AddSourceMenu: React.FC<{
   return (
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
-        <Button variant="outline" size="sm" className="border-mint/40 bg-mint-soft/50 text-mint hover:bg-mint-soft">
+        <Button variant="outline" size="sm" className="h-10 border-mint/40 bg-mint-soft/50 text-mint hover:bg-mint-soft sm:h-9">
           <Plus className="size-4" />
           {t('settings.models.addSource')}
         </Button>
@@ -61,7 +61,10 @@ export const AddSourceMenu: React.FC<{
       <PopoverContent
         align="end"
         sideOffset={8}
-        className="w-[360px] overflow-hidden border-border bg-card p-0 text-foreground shadow-lg"
+        collisionPadding={12}
+        // Never wider than the phone viewport (the fixed 360px overflowed a 360px
+        // device once collision padding was applied).
+        className="w-[min(360px,calc(100vw-1.5rem))] overflow-hidden border-border bg-card p-0 text-foreground shadow-lg sm:w-[360px]"
       >
         <MenuItem
           Icon={Sparkles}

--- a/ui/src/components/settings/models/AdvancedRow.tsx
+++ b/ui/src/components/settings/models/AdvancedRow.tsx
@@ -15,7 +15,7 @@ export const AdvancedRow: React.FC = () => {
     <button
       type="button"
       onClick={() => showToast(t('settings.models.advanced.comingSoon') as string, 'warning')}
-      className="flex w-full items-center gap-3 rounded-xl border border-border bg-background px-5 py-4 text-left transition-colors hover:border-border-strong"
+      className="flex w-full items-center gap-3 rounded-xl border border-border bg-background px-4 py-4 text-left sm:px-5 transition-colors hover:border-border-strong"
     >
       <SlidersHorizontal className="size-4 shrink-0 text-muted" />
       <span className="flex min-w-0 flex-1 flex-wrap items-baseline gap-x-2 gap-y-0.5">

--- a/ui/src/components/settings/models/AgentCard.tsx
+++ b/ui/src/components/settings/models/AgentCard.tsx
@@ -75,27 +75,32 @@ const AgentRow: React.FC<{
   }
 
   return (
-    <div className="flex items-center gap-4 border-b border-border px-5 py-4 last:border-b-0">
-      <span className={cn('flex size-11 shrink-0 items-center justify-center rounded-[10px]', ACCENT_TILE[accent])}>
-        <Icon size={22} className={ACCENT_ICON[accent]} />
-      </span>
-
-      <div className="flex min-w-0 flex-1 flex-col items-start gap-2">
-        <span className="text-[15px] font-semibold text-foreground">
-          {t(`settings.models.backends.${agent.backend}`, { defaultValue: agent.backend })}
+    // Mobile: identity above, mode chip + action on their own line. Squeezed into
+    // one row at 390px the mode chip overlapped the composite pill and the pill's
+    // model id wrapped to three lines.
+    <div className="flex flex-col gap-3 border-b border-border px-4 py-4 last:border-b-0 sm:flex-row sm:items-center sm:gap-4 sm:px-5">
+      <div className="flex min-w-0 flex-1 items-center gap-3 sm:gap-4">
+        <span className={cn('flex size-11 shrink-0 items-center justify-center rounded-[10px]', ACCENT_TILE[accent])}>
+          <Icon size={22} className={ACCENT_ICON[accent]} />
         </span>
-        {pill}
+
+        <div className="flex min-w-0 flex-1 flex-col items-start gap-2">
+          <span className="text-[15px] font-semibold text-foreground">
+            {t(`settings.models.backends.${agent.backend}`, { defaultValue: agent.backend })}
+          </span>
+          {pill}
+        </div>
       </div>
 
-      <div className="flex shrink-0 items-center gap-2.5">
+      <div className="flex items-center gap-2.5 sm:shrink-0">
         <ModeChip mode={agent.mode} />
         {agent.mode === 'hub' ? (
-          <Button variant="secondary" size="sm" onClick={openMenu}>
+          <Button variant="secondary" size="sm" className="ml-auto h-10 sm:ml-0 sm:h-9" onClick={openMenu}>
             {t('settings.models.agents.modelMenu')}
             <ChevronRight className="size-3.5" />
           </Button>
         ) : (
-          <Button variant="brand" size="sm" onClick={() => onConnectHub(agent)} disabled={connecting}>
+          <Button variant="brand" size="sm" className="ml-auto h-10 sm:ml-0 sm:h-9" onClick={() => onConnectHub(agent)} disabled={connecting}>
             <ArrowDownToLine className="size-3.5" />
             {t('settings.models.agents.connectHub')}
           </Button>
@@ -115,14 +120,14 @@ export const AgentCard: React.FC<{
   const { t } = useTranslation();
   return (
     <section className="rounded-xl border border-border bg-background">
-      <div className="flex items-start justify-between gap-4 border-b border-border px-5 py-4">
+      <div className="flex items-start justify-between gap-4 border-b border-border px-4 py-4 sm:px-5">
         <div className="flex min-w-0 flex-col gap-1">
           <h2 className="text-[15px] font-semibold text-foreground">{t('settings.models.agents.title')}</h2>
           <p className="text-[12px] leading-relaxed text-muted">{t('settings.models.agents.subtitle')}</p>
         </div>
         <Link
           to="/admin/settings/backends"
-          className="inline-flex shrink-0 items-center gap-1 text-[13px] font-medium text-mint transition-colors hover:text-mint/80"
+          className="inline-flex min-h-10 shrink-0 items-center gap-1 text-[13px] font-medium text-mint transition-colors hover:text-mint/80 sm:min-h-0"
         >
           {t('settings.models.agents.backendSettings')}
           <ArrowRight className="size-3.5" />

--- a/ui/src/components/settings/models/MigrationBanner.tsx
+++ b/ui/src/components/settings/models/MigrationBanner.tsx
@@ -67,17 +67,35 @@ export const MigrationBanner: React.FC<{
 
   return (
     <>
-      <div className="flex items-center gap-3 rounded-xl border border-gold/40 bg-gold/[0.08] px-4 py-3">
-        <span className="flex size-9 shrink-0 items-center justify-center rounded-[10px] bg-gold/15 text-gold">
-          <ArrowDownToLine className="size-[18px]" />
-        </span>
-        <div className="flex min-w-0 flex-1 flex-col gap-0.5">
-          <span className="text-[14px] font-semibold text-foreground">{t('settings.models.migrationBanner.title')}</span>
-          <span className="text-[12px] leading-relaxed text-muted">
-            {t('settings.models.migrationBanner.body', { count: importable.length })}
+      {/* Icon + two-line copy + import button + dismiss do not fit one 390px
+          row, so phones stack the action under the copy; dismiss stays on the
+          title line where it reads as "close this strip". */}
+      <div className="flex flex-col gap-2.5 rounded-xl border border-gold/40 bg-gold/[0.08] px-4 py-3 sm:flex-row sm:items-center sm:gap-3">
+        <div className="flex min-w-0 flex-1 items-center gap-3">
+          <span className="flex size-9 shrink-0 items-center justify-center rounded-[10px] bg-gold/15 text-gold">
+            <ArrowDownToLine className="size-[18px]" />
           </span>
+          <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+            <span className="text-[14px] font-semibold text-foreground">{t('settings.models.migrationBanner.title')}</span>
+            <span className="text-[12px] leading-relaxed text-muted">
+              {t('settings.models.migrationBanner.body', { count: importable.length })}
+            </span>
+          </div>
+          <button
+            type="button"
+            aria-label={t('settings.models.migrationBanner.dismiss') as string}
+            onClick={dismiss}
+            className="flex size-10 shrink-0 items-center justify-center rounded-md text-muted transition-colors hover:bg-surface-2 hover:text-foreground sm:hidden"
+          >
+            <X className="size-4" />
+          </button>
         </div>
-        <Button variant="outline" size="sm" className="shrink-0 border-gold/40 text-gold hover:bg-gold/10 hover:text-gold" onClick={() => setDialogOpen(true)}>
+        <Button
+          variant="outline"
+          size="sm"
+          className="h-10 shrink-0 border-gold/40 text-gold hover:bg-gold/10 hover:text-gold sm:h-9"
+          onClick={() => setDialogOpen(true)}
+        >
           <ArrowDownToLine className="size-3.5" />
           {t('settings.models.migrationBanner.import')}
         </Button>
@@ -85,7 +103,7 @@ export const MigrationBanner: React.FC<{
           type="button"
           aria-label={t('settings.models.migrationBanner.dismiss') as string}
           onClick={dismiss}
-          className="flex size-7 shrink-0 items-center justify-center rounded-md text-muted transition-colors hover:bg-surface-2 hover:text-foreground"
+          className="hidden size-7 shrink-0 items-center justify-center rounded-md text-muted transition-colors hover:bg-surface-2 hover:text-foreground sm:flex"
         >
           <X className="size-4" />
         </button>

--- a/ui/src/components/settings/models/MigrationDialog.tsx
+++ b/ui/src/components/settings/models/MigrationDialog.tsx
@@ -57,21 +57,30 @@ const ItemRow: React.FC<{ item: MigrationItem; onToggle: () => void }> = ({ item
   // reauth needs the interactive browser flow, so it can't be bulk-applied here.
   const selectable = item.proposed_action !== 'reauth';
   return (
+    // The action badge is nowrap and shrink-0 (up to ~151px), so beside the
+    // detail column it pushed this row's min-content to 374px — wider than the
+    // sheet's 348px content box, which grew the dialog's grid track and spilled
+    // the header, footnote and footer button off-screen. On phones the badge
+    // moves to its own line under the detail.
     <div
       className={cn(
-        'flex items-center gap-3 rounded-xl border px-3.5 py-3',
+        'flex flex-col gap-2 rounded-xl border px-3.5 py-3 sm:flex-row sm:items-center sm:gap-3',
         item.selected ? 'border-mint/40 bg-mint-soft/40' : 'border-border',
       )}
     >
-      <Checkbox checked={item.selected} onCheckedChange={onToggle} disabled={!selectable} label={item.masked_detail} />
-      <span className={cn('flex size-9 shrink-0 items-center justify-center rounded-[10px]', ACCENT_TILE[accent])}>
-        <Icon size={18} className={ACCENT_ICON[accent]} />
-      </span>
-      <div className="flex min-w-0 flex-1 flex-col gap-0.5">
-        <span className="truncate text-[14px] font-semibold text-foreground">{item.masked_detail}</span>
-        {item.notes_key && <span className="truncate text-[12px] text-muted">{t(item.notes_key)}</span>}
+      <div className="flex min-w-0 flex-1 items-center gap-3">
+        <Checkbox checked={item.selected} onCheckedChange={onToggle} disabled={!selectable} label={item.masked_detail} />
+        <span className={cn('flex size-9 shrink-0 items-center justify-center rounded-[10px]', ACCENT_TILE[accent])}>
+          <Icon size={18} className={ACCENT_ICON[accent]} />
+        </span>
+        <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+          <span className="truncate text-[14px] font-semibold text-foreground">{item.masked_detail}</span>
+          {item.notes_key && <span className="truncate text-[12px] text-muted">{t(item.notes_key)}</span>}
+        </div>
       </div>
-      <ActionBadge action={item.proposed_action} />
+      <div className="shrink-0 pl-[46px] sm:pl-0">
+        <ActionBadge action={item.proposed_action} />
+      </div>
     </div>
   );
 };
@@ -161,7 +170,7 @@ export const MigrationDialog: React.FC<{
             </span>
             {t('settings.models.migration.title')}
           </DialogTitle>
-          <DialogDescription className="pl-[52px]">{t('settings.models.migration.subtitle')}</DialogDescription>
+          <DialogDescription className="sm:pl-[52px]">{t('settings.models.migration.subtitle')}</DialogDescription>
         </DialogHeader>
 
         {loading ? (
@@ -189,10 +198,10 @@ export const MigrationDialog: React.FC<{
         </p>
 
         <div className="flex items-center justify-end gap-2 border-t border-border pt-4">
-          <Button variant="outline" size="sm" onClick={onClose} disabled={applying}>
+          <Button variant="outline" size="sm" className="h-10 sm:h-9" onClick={onClose} disabled={applying}>
             {t('settings.models.migration.later')}
           </Button>
-          <Button variant="brand" size="sm" onClick={() => void apply()} disabled={selectedCount === 0 || applying}>
+          <Button variant="brand" size="sm" className="h-10 sm:h-9" onClick={() => void apply()} disabled={selectedCount === 0 || applying}>
             <ArrowDownToLine className="size-4" />
             {t('settings.models.migration.apply', { count: selectedCount })}
           </Button>

--- a/ui/src/components/settings/models/OAuthConnectDialog.tsx
+++ b/ui/src/components/settings/models/OAuthConnectDialog.tsx
@@ -370,7 +370,7 @@ export const OAuthConnectDialog: React.FC<{
             ) : (
               <span />
             )}
-            <Button variant={active ? 'ghost' : 'outline'} size="sm" onClick={onClose} disabled={finalizing}>
+            <Button variant={active ? 'ghost' : 'outline'} size="sm" className="h-10 sm:h-9" onClick={onClose} disabled={finalizing}>
               {active ? t('common.cancel') : t('common.close')}
             </Button>
           </div>

--- a/ui/src/components/settings/models/RecentSwitchesCard.tsx
+++ b/ui/src/components/settings/models/RecentSwitchesCard.tsx
@@ -46,24 +46,24 @@ export const RecentSwitchesCard: React.FC<{ events: ResolutionEvent[] }> = ({ ev
 
   return (
     <section className="rounded-xl border border-border bg-background">
-      <div className="flex items-center justify-between gap-4 border-b border-border px-5 py-4">
+      <div className="flex items-center justify-between gap-4 border-b border-border px-4 py-4 sm:px-5">
         <h2 className="text-[15px] font-semibold text-foreground">{t('settings.models.recent.title')}</h2>
         {canExpand && (
           <button
             type="button"
             onClick={() => setExpanded((v) => !v)}
-            className="text-[13px] font-medium text-mint transition-colors hover:text-mint/80"
+            className="inline-flex min-h-10 items-center text-[13px] font-medium text-mint transition-colors hover:text-mint/80 sm:min-h-0"
           >
             {expanded ? t('settings.models.recent.collapse') : t('settings.models.recent.viewAll')}
           </button>
         )}
       </div>
       {shown.length === 0 ? (
-        <div className="px-5 py-8 text-center text-[13px] text-muted">{t('settings.models.recent.empty')}</div>
+        <div className="px-4 py-8 text-center sm:px-5 text-[13px] text-muted">{t('settings.models.recent.empty')}</div>
       ) : (
         <div className="flex flex-col">
           {shown.map((event) => (
-            <div key={event.id} className="flex items-start gap-3 border-b border-border px-5 py-3 last:border-b-0">
+            <div key={event.id} className="flex items-start gap-3 border-b border-border px-4 py-3 last:border-b-0 sm:px-5">
               <span className="w-[92px] shrink-0 pt-0.5 font-mono text-[12px] text-muted">{formatTime(event.ts)}</span>
               <Dot accent={eventAccent(event)} className="mt-[7px]" />
               <span className="min-w-0 flex-1 text-[13px] leading-relaxed text-foreground">

--- a/ui/src/components/settings/models/SourceRow.tsx
+++ b/ui/src/components/settings/models/SourceRow.tsx
@@ -1,6 +1,14 @@
 // One row of the 来源 list (frame 01r): drag handle · priority number · icon +
 // name/mono-sub (supply tooltip on hover) · fixed-width usage column · billing
 // chip · state chip. Presentation-only; drag + reorder live in SourcesCard.
+//
+// Mobile (< sm): the frame's single aligned row cannot hold eight columns in
+// 390px — it squeezed the name to zero width and pushed the state chip and the
+// row menu off-screen entirely (clipped, not scrollable, so unreachable). So the
+// row stacks into two tiers: identity on top (handle · priority · icon · name),
+// the metric/state strip below with the menu pushed to the right edge. The sm+
+// layout is byte-for-byte the desktop frame, so the fixed-width chip columns
+// still align down the list.
 import * as React from 'react';
 import { GripVertical } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
@@ -44,7 +52,7 @@ const UsageCell: React.FC<{ source: Source }> = ({ source }) => {
 
   if (source.billing === 'monthly' && typeof pct === 'number') {
     return (
-      <div className="flex w-[150px] shrink-0 items-center justify-end gap-2">
+      <div className="flex shrink-0 items-center gap-2 sm:w-[150px] sm:justify-end">
         <div className="h-1.5 w-[92px] overflow-hidden rounded-full bg-border">
           <div className="h-full rounded-full bg-mint" style={{ width: `${Math.min(100, Math.max(0, pct))}%` }} />
         </div>
@@ -54,12 +62,14 @@ const UsageCell: React.FC<{ source: Source }> = ({ source }) => {
   }
   if (typeof spend === 'number') {
     return (
-      <div className="w-[150px] shrink-0 text-right text-[12px] text-muted">
+      <div className="shrink-0 text-[12px] text-muted sm:w-[150px] sm:text-right">
         {t('settings.models.usage.monthSpend', { amount: formatSpend(spend, source.usage?.currency) })}
       </div>
     );
   }
-  return <div className="w-[150px] shrink-0" />;
+  // No usage data: on mobile the spacer would eat the strip's width, so it only
+  // holds the desktop column open.
+  return <div className="hidden sm:block sm:w-[150px] sm:shrink-0" />;
 };
 
 export const SourceRow: React.FC<{
@@ -75,38 +85,50 @@ export const SourceRow: React.FC<{
   const isExperimental = source.kind === 'subscription' && source.supply_channel === 'hub';
 
   return (
-    <div className="group flex items-center gap-3 border-b border-border px-5 py-3.5 last:border-b-0">
-      <button
-        type="button"
-        aria-label={t('settings.models.source.reorder') as string}
-        onPointerDown={onDragHandlePointerDown}
-        className="flex size-6 shrink-0 cursor-grab touch-none items-center justify-center rounded text-muted/50 transition-colors hover:text-muted active:cursor-grabbing"
-      >
-        <GripVertical className="size-4" />
-      </button>
+    <div className="group flex flex-col gap-2 border-b border-border px-4 py-3 last:border-b-0 sm:flex-row sm:items-center sm:gap-3 sm:px-5 sm:py-3.5">
+      {/* Identity tier — the whole row on sm+. */}
+      <div className="flex min-w-0 flex-1 items-center gap-2.5 sm:gap-3">
+        <button
+          type="button"
+          aria-label={t('settings.models.source.reorder') as string}
+          onPointerDown={onDragHandlePointerDown}
+          // 40px touch target on phones (the 24px desktop handle is unhittable
+          // with a thumb); the glyph size is unchanged.
+          className="flex size-10 shrink-0 cursor-grab touch-none items-center justify-center rounded text-muted/50 transition-colors hover:text-muted active:cursor-grabbing sm:size-6"
+        >
+          <GripVertical className="size-4" />
+        </button>
 
-      <span className="grid size-7 shrink-0 place-items-center rounded-md border border-border bg-surface font-mono text-[13px] text-muted">
-        {priority}
-      </span>
-
-      <SupplyTooltip models={source.models} className="flex min-w-0 flex-1 items-center gap-3">
-        <span className={cn('flex size-11 shrink-0 items-center justify-center rounded-[10px]', ACCENT_TILE[accent])}>
-          <Icon size={22} className={ACCENT_ICON[accent]} />
+        <span className="grid size-7 shrink-0 place-items-center rounded-md border border-border bg-surface font-mono text-[13px] text-muted">
+          {priority}
         </span>
-        <span className="flex min-w-0 flex-col gap-0.5">
-          <span className="flex items-center gap-2">
-            <span className="truncate text-[15px] font-semibold text-foreground">{source.display_name}</span>
-            {isExperimental && <ExperimentalChip />}
+
+        <SupplyTooltip models={source.models} className="flex min-w-0 flex-1 items-center gap-3">
+          <span className={cn('flex size-11 shrink-0 items-center justify-center rounded-[10px]', ACCENT_TILE[accent])}>
+            <Icon size={22} className={ACCENT_ICON[accent]} />
           </span>
-          <span className="truncate font-mono text-[12px] text-muted">{subline}</span>
-        </span>
-      </SupplyTooltip>
+          <span className="flex min-w-0 flex-col gap-0.5">
+            <span className="flex min-w-0 items-center gap-2">
+              <span className="truncate text-[15px] font-semibold text-foreground">{source.display_name}</span>
+              {isExperimental && <ExperimentalChip />}
+            </span>
+            <span className="truncate font-mono text-[12px] text-muted">{subline}</span>
+          </span>
+        </SupplyTooltip>
+      </div>
 
-      <div className="flex shrink-0 items-center gap-4">
+      {/* Metric / state strip — its own line on phones, with the row menu pinned
+          to the right edge; the aligned desktop chip columns on sm+. The 88px
+          inset is the identity tier's handle + priority + gaps, so the strip
+          starts under the source's icon tile and reads as part of that row
+          rather than floating between two of them. */}
+      <div className="flex items-center gap-3 pl-[88px] sm:shrink-0 sm:gap-4 sm:pl-0">
         <UsageCell source={source} />
         <BillingChip billing={source.billing} />
         <StateChip state={source.state} />
-        <SourceRowMenu source={source} onChanged={onChanged} />
+        <div className="ml-auto sm:ml-0">
+          <SourceRowMenu source={source} onChanged={onChanged} />
+        </div>
       </div>
     </div>
   );

--- a/ui/src/components/settings/models/SourceRow.tsx
+++ b/ui/src/components/settings/models/SourceRow.tsx
@@ -121,8 +121,13 @@ export const SourceRow: React.FC<{
           to the right edge; the aligned desktop chip columns on sm+. The 88px
           inset is the identity tier's handle + priority + gaps, so the strip
           starts under the source's icon tile and reads as part of that row
-          rather than floating between two of them. */}
-      <div className="flex items-center gap-3 pl-[88px] sm:shrink-0 sm:gap-4 sm:pl-0">
+          rather than floating between two of them.
+          flex-wrap matters: a subscription source's usage bar + percentage is
+          ~140px, which together with both chips and the menu exceeds even a
+          430px phone — without wrapping the menu is pushed off-screen again
+          whenever usage data is actually present. sm:flex-nowrap keeps the
+          desktop row single-line. */}
+      <div className="flex flex-wrap items-center gap-x-3 gap-y-2 pl-[88px] sm:shrink-0 sm:flex-nowrap sm:gap-4 sm:pl-0">
         <UsageCell source={source} />
         <BillingChip billing={source.billing} />
         <StateChip state={source.state} />

--- a/ui/src/components/settings/models/SourceRow.tsx
+++ b/ui/src/components/settings/models/SourceRow.tsx
@@ -129,7 +129,7 @@ export const SourceRow: React.FC<{
           desktop row single-line. */}
       <div className="flex flex-wrap items-center gap-x-3 gap-y-2 pl-[88px] sm:shrink-0 sm:flex-nowrap sm:gap-4 sm:pl-0">
         <UsageCell source={source} />
-        <BillingChip billing={source.billing} />
+        <BillingChip billing={source.billing} currency={source.usage?.currency} />
         <StateChip state={source.state} />
         <div className="ml-auto sm:ml-0">
           <SourceRowMenu source={source} onChanged={onChanged} />

--- a/ui/src/components/settings/models/SourceRowMenu.tsx
+++ b/ui/src/components/settings/models/SourceRowMenu.tsx
@@ -28,7 +28,8 @@ const MenuAction: React.FC<{
     type="button"
     onClick={onClick}
     className={cn(
-      'flex w-full items-center gap-2.5 rounded-md px-2.5 py-2 text-left text-[13px] transition-colors',
+      // min-h-11 keeps each action a comfortable thumb target on phones.
+      'flex min-h-11 w-full items-center gap-2.5 rounded-md px-2.5 py-2 text-left text-[13px] transition-colors sm:min-h-0',
       destructive ? 'text-destructive hover:bg-destructive/[0.08]' : 'text-foreground hover:bg-surface-2',
     )}
   >
@@ -141,7 +142,7 @@ export const SourceRowMenu: React.FC<{
             type="button"
             aria-label={t('settings.models.sourceActions.more') as string}
             className={cn(
-              'flex size-8 shrink-0 items-center justify-center rounded-md text-muted transition-all hover:bg-surface-2 hover:text-foreground',
+              'flex size-10 shrink-0 items-center justify-center rounded-md text-muted transition-all hover:bg-surface-2 hover:text-foreground sm:size-8',
               // Quiet on desktop (revealed on row hover / focus / when open),
               // always reachable on touch where hover doesn't exist.
               menuOpen ? 'opacity-100' : 'opacity-100 md:opacity-0 md:group-hover:opacity-100 md:focus-visible:opacity-100',
@@ -182,12 +183,13 @@ export const SourceRowMenu: React.FC<{
             />
           </div>
           <DialogFooter className="sm:justify-end">
-            <Button variant="outline" size="sm" onClick={() => setRenameOpen(false)} disabled={renaming}>
+            <Button variant="outline" size="sm" className="h-10 sm:h-9" onClick={() => setRenameOpen(false)} disabled={renaming}>
               {t('common.cancel')}
             </Button>
             <Button
               variant="brand"
               size="sm"
+              className="h-10 sm:h-9"
               onClick={() => void submitRename()}
               disabled={renaming || !renameValue.trim() || renameValue.trim() === source.display_name}
             >

--- a/ui/src/components/settings/models/SourcesCard.tsx
+++ b/ui/src/components/settings/models/SourcesCard.tsx
@@ -53,7 +53,7 @@ export const SourcesCard: React.FC<{
   return (
     // Not overflow-hidden: the row supply tooltip must escape the card bounds.
     <section className="rounded-xl border border-border bg-background">
-      <div className="flex items-start justify-between gap-4 border-b border-border px-5 py-4">
+      <div className="flex items-start justify-between gap-4 border-b border-border px-4 py-4 sm:px-5">
         <div className="flex min-w-0 flex-col gap-1">
           <h2 className="text-[15px] font-semibold text-foreground">{t('settings.models.sources.title')}</h2>
           <p className="text-[12px] leading-relaxed text-muted">{t('settings.models.sources.subtitle')}</p>
@@ -66,7 +66,7 @@ export const SourcesCard: React.FC<{
       </div>
 
       {ids.length === 0 ? (
-        <div className="px-5 py-12 text-center text-[13px] text-muted">{t('settings.models.sources.empty')}</div>
+        <div className="px-4 py-12 text-center sm:px-5 text-[13px] text-muted">{t('settings.models.sources.empty')}</div>
       ) : (
         <Reorder.Group axis="y" values={ids} onReorder={onReorderPreview} className="flex flex-col">
           {sources.map((source, index) => (

--- a/ui/src/components/settings/models/chips.tsx
+++ b/ui/src/components/settings/models/chips.tsx
@@ -9,6 +9,7 @@ import { Badge } from '@/components/ui/badge';
 import { cn } from '@/lib/utils';
 import { useTranslation } from 'react-i18next';
 
+import { currencySymbol } from './format';
 import { ACCENT_DOT, type Accent } from './vendorMeta';
 import type { AgentMode, SourceState } from './types';
 
@@ -17,16 +18,33 @@ export const Dot: React.FC<{ accent: Accent; className?: string }> = ({ accent, 
   <span className={cn('inline-block size-1.5 shrink-0 rounded-full', ACCENT_DOT[accent], className)} aria-hidden />
 );
 
-/** 包月 / 按量 $ — fixed-width so the column aligns down the source list. */
-export const BillingChip: React.FC<{ billing: 'monthly' | 'metered' }> = ({ billing }) => {
+/**
+ * 包月 / 按量 $ — fixed-width so the column aligns down the source list.
+ *
+ * The metered symbol tracks the source's REPORTED currency (USD when absent).
+ * A static `$` contradicted the usage cell for a source that genuinely reports
+ * CNY/EUR — it would read `按量 $` beside `¥12.4`. The symbol still comes from
+ * format.ts's single map, never hand-written here; an unmappable code drops the
+ * symbol rather than printing a wrong one (the amount cell carries the truth).
+ */
+export const BillingChip: React.FC<{ billing: 'monthly' | 'metered'; currency?: string | null }> = ({
+  billing,
+  currency,
+}) => {
   const { t } = useTranslation();
-  return billing === 'monthly' ? (
-    <Badge variant="secondary" className="w-16 justify-center rounded-md py-1 font-medium">
-      {t('settings.models.billing.monthly')}
-    </Badge>
-  ) : (
+  if (billing === 'monthly') {
+    return (
+      <Badge variant="secondary" className="w-16 justify-center rounded-md py-1 font-medium">
+        {t('settings.models.billing.monthly')}
+      </Badge>
+    );
+  }
+  const symbol = currencySymbol(currency);
+  return (
     <Badge variant="warning" className="w-16 justify-center rounded-md py-1 font-medium">
-      {t('settings.models.billing.metered')}
+      {symbol
+        ? t('settings.models.billing.meteredWithSymbol', { symbol })
+        : t('settings.models.billing.metered')}
     </Badge>
   );
 };

--- a/ui/src/components/settings/models/chips.tsx
+++ b/ui/src/components/settings/models/chips.tsx
@@ -17,7 +17,7 @@ export const Dot: React.FC<{ accent: Accent; className?: string }> = ({ accent, 
   <span className={cn('inline-block size-1.5 shrink-0 rounded-full', ACCENT_DOT[accent], className)} aria-hidden />
 );
 
-/** 包月 / 按量 ¥ — fixed-width so the column aligns down the source list. */
+/** 包月 / 按量 $ — fixed-width so the column aligns down the source list. */
 export const BillingChip: React.FC<{ billing: 'monthly' | 'metered' }> = ({ billing }) => {
   const { t } = useTranslation();
   return billing === 'monthly' ? (

--- a/ui/src/components/settings/models/chips.tsx
+++ b/ui/src/components/settings/models/chips.tsx
@@ -98,12 +98,14 @@ export const ExperimentalChip: React.FC = () => {
  * `N 个模型 ｜ ● 多来源…`.
  */
 export const CompositePill: React.FC<{ left: string; dot: Accent; right: string }> = ({ left, dot, right }) => (
-  <div className="inline-flex items-center gap-2.5 rounded-lg border border-border bg-surface px-3 py-1.5 text-[13px]">
-    <span className="font-mono font-medium text-foreground">{left}</span>
-    <span className="h-3.5 w-px bg-border-strong" aria-hidden />
-    <span className="inline-flex items-center gap-1.5 text-muted">
+  // max-w-full + truncating halves: on a phone the model id would otherwise wrap
+  // to three lines and blow the Agent row's height open.
+  <div className="inline-flex max-w-full items-center gap-2.5 rounded-lg border border-border bg-surface px-3 py-1.5 text-[13px]">
+    <span className="truncate font-mono font-medium text-foreground">{left}</span>
+    <span className="h-3.5 w-px shrink-0 bg-border-strong" aria-hidden />
+    <span className="inline-flex min-w-0 items-center gap-1.5 text-muted">
       <Dot accent={dot} />
-      {right}
+      <span className="truncate">{right}</span>
     </span>
   </div>
 );

--- a/ui/src/components/settings/models/format.test.ts
+++ b/ui/src/components/settings/models/format.test.ts
@@ -1,6 +1,37 @@
 import { describe, expect, it } from 'vitest';
 
-import { cooldownEtaMinutes, formatSpend } from './format';
+import { cooldownEtaMinutes, currencySymbol, formatSpend } from './format';
+
+describe('currencySymbol', () => {
+  it('falls back to USD when the backend reports no currency', () => {
+    expect(currencySymbol(null)).toBe('$');
+    expect(currencySymbol(undefined)).toBe('$');
+    expect(currencySymbol()).toBe('$');
+  });
+
+  it('honors an explicitly reported currency', () => {
+    expect(currencySymbol('USD')).toBe('$');
+    expect(currencySymbol('CNY')).toBe('¥');
+    expect(currencySymbol('EUR')).toBe('€');
+  });
+
+  it('returns no symbol for a code it cannot map', () => {
+    // Callers use '' to pick a currency-free label instead of printing a wrong
+    // symbol — the amount cell carries the authoritative value.
+    expect(currencySymbol('JPY')).toBe('');
+  });
+
+  // The billing chip renders currencySymbol(...) while the usage cell renders
+  // formatSpend(...). They must never disagree: a static '$' on the chip read
+  // "按量 $" beside "¥12.4" for a CNY source (Codex P2, 2026-07-25).
+  it('agrees with the symbol formatSpend uses, for every currency', () => {
+    for (const c of [null, undefined, 'USD', 'CNY', 'EUR', 'JPY'] as const) {
+      expect(formatSpend(1240, c).startsWith(currencySymbol(c))).toBe(true);
+      const stripped = formatSpend(1240, c).slice(currencySymbol(c).length);
+      expect(stripped).toBe('12.4');
+    }
+  });
+});
 
 describe('formatSpend', () => {
   // Owner ruling 2026-07-25: upstream vendors bill in USD, so a missing currency

--- a/ui/src/components/settings/models/format.test.ts
+++ b/ui/src/components/settings/models/format.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+
+import { cooldownEtaMinutes, formatSpend } from './format';
+
+describe('formatSpend', () => {
+  // Owner ruling 2026-07-25: upstream vendors bill in USD, so a missing currency
+  // must render as USD and the UI must never fall back to a local currency.
+  // This is the tripwire for that decision — if someone restores a CNY (or any
+  // other) fallback, this fails instead of shipping silently.
+  it('falls back to USD when the backend reports no currency', () => {
+    expect(formatSpend(1240, null)).toBe('$12.4');
+    expect(formatSpend(1240, undefined)).toBe('$12.4');
+    expect(formatSpend(1240)).toBe('$12.4');
+  });
+
+  it('honors an explicitly reported currency', () => {
+    // The ISO 4217 map is deliberately retained: a source that genuinely bills in
+    // CNY/EUR still renders in its own currency.
+    expect(formatSpend(1240, 'USD')).toBe('$12.4');
+    expect(formatSpend(1240, 'CNY')).toBe('¥12.4');
+    expect(formatSpend(1240, 'EUR')).toBe('€12.4');
+  });
+
+  it('omits the symbol for a currency it cannot map, keeping the amount readable', () => {
+    expect(formatSpend(1240, 'JPY')).toBe('12.4');
+  });
+
+  it('converts cents to one decimal without applying any FX rate', () => {
+    // 1240 cents stays 12.40 whatever the symbol — amounts are never converted.
+    expect(formatSpend(0, null)).toBe('$0.0');
+    expect(formatSpend(5, null)).toBe('$0.1');
+    expect(formatSpend(1234567, null)).toBe('$12345.7');
+  });
+});
+
+describe('cooldownEtaMinutes', () => {
+  it('is 0 for a missing or already-elapsed retry_at', () => {
+    expect(cooldownEtaMinutes(null)).toBe(0);
+    expect(cooldownEtaMinutes(undefined)).toBe(0);
+    expect(cooldownEtaMinutes(new Date(Date.now() - 60_000).toISOString())).toBe(0);
+  });
+
+  it('rounds the remaining wait to whole minutes', () => {
+    expect(cooldownEtaMinutes(new Date(Date.now() + 5 * 60_000 + 1_000).toISOString())).toBe(5);
+  });
+});

--- a/ui/src/components/settings/models/format.ts
+++ b/ui/src/components/settings/models/format.ts
@@ -5,16 +5,21 @@ import type { AgentSupply, Source } from './types';
 const CURRENCY_SYMBOL: Record<string, string> = { USD: '$', CNY: '¥', EUR: '€' };
 
 /**
- * Monthly spend as symbol + amount (1 decimal), e.g. "$12.4".
+ * Symbol for an ISO 4217 code — the ONLY place a currency symbol is resolved.
  *
  * USD is the fallback because every upstream vendor bills in USD; a CNY default
- * was our own invention. The ISO 4217 mapping is kept, so a source that really
- * does report CNY (or EUR) still renders in its own currency. This is the ONLY
- * place a currency symbol is produced — never concatenate one in a component.
+ * was our own invention. The mapping is kept, so a source that really does report
+ * CNY (or EUR) still renders in its own currency. Returns '' for a code we cannot
+ * map, so callers can fall back to a currency-free label rather than print a
+ * misleading symbol.
  */
+export function currencySymbol(currency?: string | null): string {
+  return CURRENCY_SYMBOL[currency ?? 'USD'] ?? '';
+}
+
+/** Monthly spend as symbol + amount (1 decimal), e.g. "$12.4". */
 export function formatSpend(cents: number, currency?: string | null): string {
-  const symbol = CURRENCY_SYMBOL[currency ?? 'USD'] ?? '';
-  return `${symbol}${(cents / 100).toFixed(1)}`;
+  return `${currencySymbol(currency)}${(cents / 100).toFixed(1)}`;
 }
 
 /** Whole minutes until a cooldown retry_at (never negative). */

--- a/ui/src/components/settings/models/format.ts
+++ b/ui/src/components/settings/models/format.ts
@@ -2,11 +2,18 @@
 // returned values in translated templates).
 import type { AgentSupply, Source } from './types';
 
-const CURRENCY_SYMBOL: Record<string, string> = { CNY: '¥', USD: '$', EUR: '€' };
+const CURRENCY_SYMBOL: Record<string, string> = { USD: '$', CNY: '¥', EUR: '€' };
 
-/** Monthly spend as symbol + amount (1 decimal), e.g. "¥12.4". */
+/**
+ * Monthly spend as symbol + amount (1 decimal), e.g. "$12.4".
+ *
+ * USD is the fallback because every upstream vendor bills in USD; a CNY default
+ * was our own invention. The ISO 4217 mapping is kept, so a source that really
+ * does report CNY (or EUR) still renders in its own currency. This is the ONLY
+ * place a currency symbol is produced — never concatenate one in a component.
+ */
 export function formatSpend(cents: number, currency?: string | null): string {
-  const symbol = CURRENCY_SYMBOL[currency ?? 'CNY'] ?? '';
+  const symbol = CURRENCY_SYMBOL[currency ?? 'USD'] ?? '';
   return `${symbol}${(cents / 100).toFixed(1)}`;
 }
 

--- a/ui/src/components/settings/models/menus/AddCustomModelDialog.tsx
+++ b/ui/src/components/settings/models/menus/AddCustomModelDialog.tsx
@@ -240,7 +240,7 @@ export const AddCustomModelDialog: React.FC<{
               aria-label={t('common.copy') as string}
               onClick={copyIdentifier}
               disabled={!identifier}
-              className="rounded-md p-1 text-muted transition-colors hover:text-foreground disabled:opacity-40"
+              className="flex size-10 items-center justify-center rounded-md text-muted transition-colors hover:text-foreground disabled:opacity-40 sm:size-6"
             >
               <Copy className="size-4" />
             </button>
@@ -256,7 +256,7 @@ export const AddCustomModelDialog: React.FC<{
             <Button
               variant="ghost"
               size="sm"
-              className="text-destructive hover:bg-destructive/[0.08] hover:text-destructive"
+              className="h-10 text-destructive hover:bg-destructive/[0.08] hover:text-destructive sm:h-9"
               onClick={() => setDeleteOpen(true)}
               disabled={saving}
             >
@@ -265,10 +265,10 @@ export const AddCustomModelDialog: React.FC<{
             </Button>
           )}
           <div className="flex items-center gap-2 max-sm:w-full max-sm:justify-end">
-            <Button variant="outline" size="sm" onClick={onClose} disabled={saving}>
+            <Button variant="outline" size="sm" className="h-10 sm:h-9" onClick={onClose} disabled={saving}>
               {t('common.cancel')}
             </Button>
-            <Button variant="brand" size="sm" onClick={() => void submit()} disabled={!source || !trimmedId || saving}>
+            <Button variant="brand" size="sm" className="h-10 sm:h-9" onClick={() => void submit()} disabled={!source || !trimmedId || saving}>
               <Plus className="size-4" />
               {t(edit ? 'common.save' : 'settings.models.menus.custom.add')}
             </Button>

--- a/ui/src/components/settings/models/menus/MappingDrawer.tsx
+++ b/ui/src/components/settings/models/menus/MappingDrawer.tsx
@@ -101,7 +101,7 @@ const SupplySelector: React.FC<{
             onFollowNative();
             setOpen(false);
           }}
-          className="flex w-full items-center gap-2.5 rounded-md px-2.5 py-2 text-left text-[13px] hover:bg-surface-2"
+          className="flex min-h-11 w-full items-center gap-2.5 rounded-md px-2.5 py-2 text-left text-[13px] hover:bg-surface-2 sm:min-h-0"
         >
           <CheckCircle2 className={cn('size-4 shrink-0', override ? 'text-muted/40' : 'text-mint')} />
           <span className="text-foreground">{t('settings.models.menus.mapping.followNative')}</span>
@@ -118,11 +118,11 @@ const SupplySelector: React.FC<{
                 setOpen(false);
               }}
               className={cn(
-                'flex w-full items-center gap-2.5 rounded-md px-2.5 py-2 text-left hover:bg-surface-2',
+                'flex min-h-11 w-full items-center gap-2.5 rounded-md px-2.5 py-2 text-left hover:bg-surface-2 sm:min-h-0',
                 active && 'bg-violet-soft/60',
               )}
             >
-              <span className="font-mono text-[13px] font-medium text-foreground">{tg.id}</span>
+              <span className="truncate font-mono text-[13px] font-medium text-foreground">{tg.id}</span>
               {tg.displayName && <span className="truncate text-[12px] text-muted">{tg.displayName}</span>}
               <SupplyDots accents={tg.accents} className="ml-auto flex shrink-0 items-center gap-1" />
             </button>
@@ -217,17 +217,19 @@ export const MappingDrawer: React.FC<{
       subtitle={t('settings.models.menus.mapping.subtitle', { backend: backendName }) as string}
       footer={
         <>
-          <Button variant="outline" size="sm" onClick={resetAll} disabled={!anyOverride || saving}>
+          <Button variant="outline" size="sm" className="h-10 sm:h-9" onClick={resetAll} disabled={!anyOverride || saving}>
             <RotateCcw className="size-3.5" />
             {t('settings.models.menus.resetAll')}
           </Button>
-          <Button variant="brand" size="sm" onClick={() => void commitAndClose()} disabled={saving}>
+          <Button variant="brand" size="sm" className="h-10 sm:h-9" onClick={() => void commitAndClose()} disabled={saving}>
             {t('settings.models.menus.done')}
           </Button>
         </>
       }
     >
-      <div className="flex items-center gap-3 px-1 pb-2.5">
+      {/* Column headers only make sense while the two columns sit side by side;
+          on phones each row stacks, so the labels would mislabel the layout. */}
+      <div className="hidden items-center gap-3 px-1 pb-2.5 sm:flex">
         <span className="w-[172px] shrink-0 font-mono text-[11px] font-medium uppercase tracking-wide text-muted">
           {t('settings.models.menus.mapping.builtinCol')}
         </span>
@@ -247,11 +249,20 @@ export const MappingDrawer: React.FC<{
                   override ? 'border-violet/40 bg-violet-soft/40' : 'border-border',
                 )}
               >
-                <div className="flex items-center gap-2.5">
-                  <div className="w-[172px] shrink-0">
+                {/* Phones stack builtin-id over supply (the 172px id column plus
+                    the selector pushed the selector's chevron and the row reset
+                    off-screen, so a mapping could not be changed at all); the
+                    arrow rotates to keep reading as "maps to". */}
+                <div className="flex flex-col items-stretch gap-2 sm:flex-row sm:items-center sm:gap-2.5">
+                  <div className="min-w-0 sm:w-[172px] sm:shrink-0">
                     <BuiltinChip id={mapping.builtin_id} />
                   </div>
-                  <ArrowRight className={cn('size-4 shrink-0', override ? 'text-violet' : 'text-muted/60')} />
+                  <ArrowRight
+                    className={cn(
+                      'size-4 shrink-0 rotate-90 self-center sm:rotate-0 sm:self-auto',
+                      override ? 'text-violet' : 'text-muted/60',
+                    )}
+                  />
                   <div className="min-w-0 flex-1">
                     <SupplySelector
                       mapping={mapping}
@@ -262,8 +273,8 @@ export const MappingDrawer: React.FC<{
                   </div>
                 </div>
                 {override && (
-                  <p className="flex items-center gap-1.5 pl-[208px] text-[12px] text-gold">
-                    <Info className="size-3.5 shrink-0" />
+                  <p className="flex items-start gap-1.5 text-[12px] text-gold sm:items-center sm:pl-[208px]">
+                    <Info className="mt-0.5 size-3.5 shrink-0 sm:mt-0" />
                     {t('settings.models.menus.mapping.warning')}
                   </p>
                 )}

--- a/ui/src/components/settings/models/menus/MappingDrawer.tsx
+++ b/ui/src/components/settings/models/menus/MappingDrawer.tsx
@@ -122,7 +122,9 @@ const SupplySelector: React.FC<{
                 active && 'bg-violet-soft/60',
               )}
             >
-              <span className="truncate font-mono text-[13px] font-medium text-foreground">{tg.id}</span>
+              {/* Same rule as the OpenCode rows: wrap a long id, never hide its
+                  suffix — picking the wrong override target is unrecoverable. */}
+              <span className="min-w-0 break-all font-mono text-[13px] font-medium text-foreground">{tg.id}</span>
               {tg.displayName && <span className="truncate text-[12px] text-muted">{tg.displayName}</span>}
               <SupplyDots accents={tg.accents} className="ml-auto flex shrink-0 items-center gap-1" />
             </button>

--- a/ui/src/components/settings/models/menus/MenuDrawer.tsx
+++ b/ui/src/components/settings/models/menus/MenuDrawer.tsx
@@ -33,7 +33,9 @@ export const MenuDrawer: React.FC<{
           'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=open]:slide-in-from-right data-[state=closed]:slide-out-to-right data-[state=open]:duration-300 data-[state=closed]:duration-200',
         )}
       >
-        <header className="flex items-start gap-3 border-b border-border px-6 py-5">
+        {/* On phones the drawer is the whole screen, so it carries the safe-area
+            insets itself and tightens its gutters from 24px to 16px. */}
+        <header className="flex items-start gap-3 border-b border-border px-4 py-4 pt-[calc(1rem+env(safe-area-inset-top))] sm:px-6 sm:py-5 sm:pt-5">
           <span className={cn('flex size-11 shrink-0 items-center justify-center rounded-[12px]', ACCENT_TILE[accent])}>
             <Icon size={22} className={ACCENT_ICON[accent]} />
           </span>
@@ -45,15 +47,15 @@ export const MenuDrawer: React.FC<{
               {subtitle}
             </DialogPrimitive.Description>
           </div>
-          <DialogPrimitive.Close className="shrink-0 rounded-md p-1 text-muted opacity-70 transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring">
+          <DialogPrimitive.Close className="flex size-10 shrink-0 items-center justify-center rounded-md text-muted opacity-70 transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring sm:size-7">
             <X className="size-5" />
             <span className="sr-only">{t('common.close')}</span>
           </DialogPrimitive.Close>
         </header>
 
-        <div className="flex-1 overflow-y-auto px-6 py-5">{children}</div>
+        <div className="flex-1 overflow-y-auto px-4 py-4 sm:px-6 sm:py-5">{children}</div>
 
-        <footer className="flex items-center justify-between gap-3 border-t border-border bg-surface/40 px-6 py-4">
+        <footer className="flex items-center justify-between gap-3 border-t border-border bg-surface/40 px-4 py-3 pb-[calc(0.75rem+env(safe-area-inset-bottom))] sm:px-6 sm:py-4 sm:pb-4">
           {footer}
         </footer>
       </DialogPrimitive.Content>

--- a/ui/src/components/settings/models/menus/OpenCodeMenuDrawer.tsx
+++ b/ui/src/components/settings/models/menus/OpenCodeMenuDrawer.tsx
@@ -35,8 +35,11 @@ const ModelRow: React.FC<{
   return (
     <div className="flex items-center gap-3 rounded-xl border border-border px-3.5 py-3">
       <Checkbox checked={checked} onCheckedChange={onToggle} label={row.identifier} />
-      <button type="button" onClick={onToggle} className="flex min-w-0 flex-1 items-center gap-2.5 text-left">
-        <span className="font-mono text-[14px] font-medium text-foreground">{row.modelId}</span>
+      {/* min-h-11 makes the label span the row's full height, so the tap area
+          matches the row the user actually aims at (the 18px checkbox alone is
+          not a thumb target). */}
+      <button type="button" onClick={onToggle} className="flex min-h-11 min-w-0 flex-1 items-center gap-2.5 text-left sm:min-h-0">
+        <span className="truncate font-mono text-[14px] font-medium text-foreground">{row.modelId}</span>
         {row.displayName && <span className="truncate text-[13px] text-muted">{row.displayName}</span>}
         {row.isCustom && (
           <Badge className="shrink-0 rounded-md bg-violet-soft px-2 py-0.5 text-[10px] font-medium text-violet">
@@ -50,7 +53,7 @@ const ModelRow: React.FC<{
           type="button"
           aria-label={t('common.edit') as string}
           onClick={onEdit}
-          className="shrink-0 rounded-md p-1 text-muted transition-colors hover:text-foreground"
+          className="flex size-10 shrink-0 items-center justify-center rounded-md text-muted transition-colors hover:text-foreground sm:size-6"
         >
           <Pencil className="size-3.5" />
         </button>
@@ -167,14 +170,16 @@ export const OpenCodeMenuDrawer: React.FC<{
         footer={
           <>
             <span />
-            <Button variant="brand" size="sm" onClick={() => void commitAndClose()} disabled={saving}>
+            <Button variant="brand" size="sm" className="h-10 sm:h-9" onClick={() => void commitAndClose()} disabled={saving}>
               {t('settings.models.menus.done')}
             </Button>
           </>
         }
       >
-        <div className="mb-4 flex items-center justify-between gap-3">
-          <div className="w-[220px]">
+        {/* 220px segmented + the 自定义模型 button exceed a 360px phone side by
+            side, so they stack there and the toggle spans the width. */}
+        <div className="mb-4 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between sm:gap-3">
+          <div className="w-full sm:w-[220px]">
             <SegmentedRadio
               value={view}
               onChange={setView}
@@ -189,7 +194,7 @@ export const OpenCodeMenuDrawer: React.FC<{
           <Button
             variant="outline"
             size="sm"
-            className="border-violet/40 text-violet hover:border-violet/60 hover:text-violet"
+            className="h-10 shrink-0 border-violet/40 text-violet hover:border-violet/60 hover:text-violet sm:h-9"
             onClick={() => {
               setEditTarget(null);
               setCustomOpen(true);

--- a/ui/src/components/settings/models/menus/OpenCodeMenuDrawer.tsx
+++ b/ui/src/components/settings/models/menus/OpenCodeMenuDrawer.tsx
@@ -39,7 +39,11 @@ const ModelRow: React.FC<{
           matches the row the user actually aims at (the 18px checkbox alone is
           not a thumb target). */}
       <button type="button" onClick={onToggle} className="flex min-h-11 min-w-0 flex-1 items-center gap-2.5 text-left sm:min-h-0">
-        <span className="truncate font-mono text-[14px] font-medium text-foreground">{row.modelId}</span>
+        {/* Never truncate the model id: frame 05r's contract is that the full
+            identifier is visible by construction, and custom ids are unbounded
+            (add_custom_model sets no length limit). break-all wraps instead, so
+            a long id can't overflow the row without hiding its suffix. */}
+        <span className="min-w-0 break-all font-mono text-[14px] font-medium text-foreground">{row.modelId}</span>
         {row.displayName && <span className="truncate text-[13px] text-muted">{row.displayName}</span>}
         {row.isCustom && (
           <Badge className="shrink-0 rounded-md bg-violet-soft px-2 py-0.5 text-[10px] font-medium text-violet">

--- a/ui/src/components/settings/models/mockData.ts
+++ b/ui/src/components/settings/models/mockData.ts
@@ -68,7 +68,7 @@ export function buildMockSources(): Source[] {
       supply_channel: 'hub',
       billing: 'metered',
       state: { status: 'standby', retry_at: null, detail_key: null },
-      usage: { cycle_used_pct: null, month_spend_cents: 1240, currency: 'CNY' },
+      usage: { cycle_used_pct: null, month_spend_cents: 1240, currency: 'USD' },
       account_label: null,
       masked_credential: 'sk-ant-…8f2A',
       models: [
@@ -88,7 +88,7 @@ export function buildMockSources(): Source[] {
       supply_channel: 'hub',
       billing: 'metered',
       state: { status: 'standby', retry_at: null, detail_key: null },
-      usage: { cycle_used_pct: null, month_spend_cents: 210, currency: 'CNY' },
+      usage: { cycle_used_pct: null, month_spend_cents: 210, currency: 'USD' },
       account_label: null,
       masked_credential: 'glm-…c31b',
       models: [
@@ -109,7 +109,7 @@ export function buildMockSources(): Source[] {
       supply_channel: 'hub',
       billing: 'metered',
       state: { status: 'cooldown', retry_at: iso(47 * MIN), detail_key: 'settings.models.source.cooldown.timeout' },
-      usage: { cycle_used_pct: null, month_spend_cents: 320, currency: 'CNY' },
+      usage: { cycle_used_pct: null, month_spend_cents: 320, currency: 'USD' },
       account_label: null,
       masked_credential: 'key …9c1',
       models: [

--- a/ui/src/components/settings/models/modelsApi.ts
+++ b/ui/src/components/settings/models/modelsApi.ts
@@ -169,7 +169,7 @@ class MockStore {
       supply_channel: 'hub',
       billing: 'metered',
       state: { status: 'standby', retry_at: null, detail_key: null },
-      usage: { cycle_used_pct: null, month_spend_cents: 0, currency: 'CNY' },
+      usage: { cycle_used_pct: null, month_spend_cents: 0, currency: 'USD' },
       account_label: null,
       // Simulates L2 computing the display mask once at provisioning.
       masked_credential: maskKey(draft.key),
@@ -293,7 +293,7 @@ class MockStore {
         experimental_consent_at: null,
         billing: isKey ? 'metered' : 'monthly',
         state: { status: 'standby', retry_at: null, detail_key: null },
-        usage: isKey ? { cycle_used_pct: null, month_spend_cents: 0, currency: 'CNY' } : { cycle_used_pct: 0, month_spend_cents: null, currency: null },
+        usage: isKey ? { cycle_used_pct: null, month_spend_cents: 0, currency: 'USD' } : { cycle_used_pct: 0, month_spend_cents: null, currency: null },
         account_label: channel === 'native_cli' ? 'me@gmail.com' : null,
         masked_credential: isKey ? 'sk-…dd3c' : null,
         models: [{ id: item.backend === 'opencode' ? 'glm-5.2' : item.backend === 'codex' ? 'gpt-5.6' : 'claude-opus-4-6', display_name: null, provenance: 'discovered', discovered_at: new Date().toISOString() }],

--- a/ui/src/components/settings/models/types.ts
+++ b/ui/src/components/settings/models/types.ts
@@ -29,7 +29,7 @@ export type SourceState = {
 export type SourceUsage = {
   cycle_used_pct?: number | null;
   month_spend_cents?: number | null;
-  /** ISO 4217, e.g. CNY / USD. */
+  /** ISO 4217, e.g. USD / CNY. Absent means USD (see formatSpend). */
   currency?: string | null;
 };
 

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -631,7 +631,8 @@
       },
       "billing": {
         "monthly": "Monthly",
-        "metered": "Metered $"
+        "metered": "Metered",
+        "meteredWithSymbol": "Metered {{symbol}}"
       },
       "state": {
         "active": "In use",

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -631,7 +631,7 @@
       },
       "billing": {
         "monthly": "Monthly",
-        "metered": "Metered ¥"
+        "metered": "Metered $"
       },
       "state": {
         "active": "In use",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -631,7 +631,8 @@
       },
       "billing": {
         "monthly": "包月",
-        "metered": "按量 $"
+        "metered": "按量",
+        "meteredWithSymbol": "按量 {{symbol}}"
       },
       "state": {
         "active": "使用中",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -631,7 +631,7 @@
       },
       "billing": {
         "monthly": "包月",
-        "metered": "按量 ¥"
+        "metered": "按量 $"
       },
       "state": {
         "active": "使用中",

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -2,7 +2,10 @@ import { fileURLToPath, URL } from 'node:url'
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
-const backendTarget = 'http://localhost:5100'
+// Point the dev proxy at any running Avibe instance — e.g. the Incus regression
+// environment — with VIBE_UI_BACKEND=http://127.0.0.1:15130 npm run dev, so UI
+// work can be driven against real data without restarting the local service.
+const backendTarget = process.env.VIBE_UI_BACKEND ?? 'http://localhost:5100'
 
 const backendProxy = () => ({
   target: backendTarget,


### PR DESCRIPTION
## Changed capability

设置 · 模型 (Model Hub) is now usable on a phone. The page was built
desktop-first; at 390px it was not merely ugly but **functionally broken** —
several shipped actions were unreachable. Every change here is a responsive
layout change. **The sm+ (≥640px) layout is unchanged**, so frame 01r's aligned
chip columns still line up on desktop.

No copy, i18n keys, backend code, contracts or product semantics changed.

## Surfaces fixed

| Surface | Breakage (observed at 390px) | Fix | Before → After |
| --- | --- | --- | --- |
| 来源 row (`SourceRow`) | Right cluster spanned `x[125..505]`. **Source name + subline squeezed to zero width**; state chip half-cut; **row menu at `x[473..505]` fully off-screen** — rename / re-discover / delete unreachable. No h-scroll, so it was clipped, not scrollable. | Stacks into identity + metric/state tiers under `sm`; menu pinned right; strip inset 88px to the icon column so it groups with its own row; 150px usage column becomes content-width | `models-before-390.png` → `models-after-390.png` |
| Agent row (`AgentCard`) | 中枢 Hub badge **overlapped** the composite pill; model id wrapped to 3 lines; "Claude Code" wrapped | Identity above, mode chip + action below; `CompositePill` halves truncate | same pair |
| 模型菜单 · Claude/Codex (`MappingDrawer`) | Rows overflowed: the 172px builtin-id column pushed the selector's chevron **and the per-row reset off-screen — a mapping could not be changed at all** | Builtin id stacks over the selector (arrow rotates 90°); stacked-column headers hidden; warning loses its 208px indent | `menu-claude-before-390.png` → `menu-claude-final-390.png` |
| 迁移对话框 (`MigrationDialog`) | Action badge (nowrap, `shrink-0`, 151px) gave `ItemRow` a **374px min-content**, widening the sheet's grid track to `373.75px` vs a 348px content box — header, footnote and the primary 导入 button all spilled off-screen | Badge moves below the detail on phones → track back to `348px`, `scrollWidth == clientWidth` | `migration-dialog-after-390.png` |
| 迁移横幅 (`MigrationBanner`) | Icon + 2-line copy + import + dismiss did not fit one row | Action stacks under the copy; dismiss stays on the title line | `migration-banner-after-390.png` |
| `MenuDrawer` shell | 24px gutters, no safe-area insets, 28px close | 16px gutters, top/bottom safe-area, 40px close on phones | — |
| 添加来源 dropdown | Fixed `w-[360px]` = the whole 360px viewport | `w-[min(360px,calc(100vw-1.5rem))]` + `collisionPadding` | `addsource-menu-final-360.png` |
| OpenCode 模型菜单 | 220px segmented + 自定义模型 exceeded 360px side by side | Stack under `sm`; toggle spans width; row label spans full row height | `menu-opencode-full-final-390.png` |
| Tap targets | drag handle 24×24, row menu 32×32, drawer close 28×28, popover/menu rows 36px, dialog footers 36px | ≥40px on phones, unchanged on `sm+` | — |
| Card gutters | 20px headers vs restacked 16px rows | `px-4 sm:px-5` throughout | — |

## Touch-reorder verdict: **works — no fallback needed**

Verified with real CDP touch events (`touchStart` → 12 × `touchMove` → `touchEnd`),
not a mouse drag: `["anthropic","openai"]` → `["openai","anthropic"]`, and it
**persisted across a page reload** against the live backend. The only real defect
was the 24×24 handle, now 40×40. No 上移/下移 menu fallback was added, since the
brief made that conditional on drag being unreliable and it is not.

## Not reproduced — `AppShell` deliberately untouched

The reported "高级设置 label under the raised centre FAB" **does not reproduce**.
Measured every tab's box in both shells at 360/390/430: **zero pairwise
collisions**, and the Control Panel (admin) shell passes no `center` prop, so it
has no FAB at all. `main` already carries
`pb-[calc(5.5rem+env(safe-area-inset-bottom))]`, so content is not clipped by the
bar either. Reporting rather than changing shared shell code on a false premise.

## Evidence layers

- **Browser-observed (primary)**: real Chromium at 360×740, 390×844, 430×932 —
  `isMobile`, `hasTouch`, DPR 3 — driven against the **live Incus regression
  backend** (real sources, real OAuth start, real reorder persistence). Each
  surface reached by **actual touch taps**, not dispatched clicks.
  - **9 surfaces × 3 viewports = 27 checks, all `overflow=0`.**
  - `document.documentElement.scrollWidth == innerWidth` at all three widths.
  - Every in-scope tappable ≥40px.
  - `MigrationBanner`/`MigrationDialog` cannot render without importable native
    configs, so the banner gate was temporarily forced to reach them; **the gate
    is restored in this commit** (that pass is what surfaced the grid-track bug).
- **Desktop regression**: at 1280px and at the 640/639px boundary — `≥640` gives
  single-row, `padding-left: 0`, 20px row gutters, 72px row height, 24×24 handle,
  32×32 menu (identical to master); `<640` gives the stacked form.
- **Build**: `npm run build` green. `tsc --noEmit` clean.
- **Unit**: full `vitest run` — 402 passed / 54 files.
- **Lint**: `eslint` on changed paths reports the **same 15 pre-existing errors as
  master** (verified by stashing) — zero new.
- **Scenario**: no scenario catalog covers this UI surface; none added.

## Residual manual checks (for the integration pass)

- Real iOS Safari / Android Chrome: `env(safe-area-inset-*)` and momentum
  scrolling inside `MenuDrawer` are emulated here, not physically verified.
- `MigrationBanner`/`MigrationDialog` on a machine that genuinely has importable
  native configs (verified here via the forced-render path only).
- Completing an OAuth subscription connect end-to-end on a phone (the flow was
  started and its sheet verified; the handshake was not finished).

## Out of scope — found, reported, not fixed

1. `ui/src/components/ui/dialog.tsx` — shared sheet close button is 24×24 on mobile.
2. `ui/src/components/ui/segmented.tsx` — fixed `h-9` (options ~30px) and no
   `className` prop; needs the "extend via props" ladder step to be tunable.
3. `ui/src/components/ui/checkbox.tsx` — 18×18 box. Mitigated in the OpenCode list
   by making the adjacent row label a 44px toggle, but the primitive is still small.
4. `ui/src/components/settings/oauth/OAuthFlowParts.tsx` — 复制 button 32px tall,
   code input 36px (shared with `BackendOAuthPanel`).
5. `AppShell` PWA install strip — 装到主屏幕 93×28, 收起 24×24.
6. `AppShell` logs a React warning: `Each child in a list should have a unique
   "key" prop` (pre-existing on master).

## Evidence layers not applicable

Contract layer: no contract touched (`docs/plans/model-hub-contracts/**` unmodified).

---

## Addendum — usage amounts default to USD (owner decision, 2026-07-25)

Every upstream vendor bills in USD; the `CNY` default was ours, not theirs. The UI
no longer shows 人民币. **Amounts are not converted** — 1240 cents stays `12.40`,
only the symbol changes.

- `format.ts`: `CURRENCY_SYMBOL[currency ?? 'USD']`, USD listed first. The ISO 4217
  map is **retained**, so a source that genuinely reports CNY/EUR still renders in
  its own currency.
- i18n: `Metered ¥` → `Metered $` (en), `按量 ¥` → `按量 $` (zh).
- `mockData.ts` (3×) + `modelsApi.ts` (2×): `currency: 'CNY'` → `'USD'`.
- `chips.tsx` / `types.ts` comments follow.
- **Single point preserved:** `formatSpend` is the only producer of a currency
  symbol — one caller (`SourceRow`), and the i18n templates interpolate
  `{{amount}}`, so no component concatenates a symbol.

### grep proof

```
$ grep -rn '¥' ui/src/components/settings/models/
ui/src/components/settings/models/format.ts:5:const CURRENCY_SYMBOL: Record<string, string> = { USD: '$', CNY: '¥', EUR: '€' };

$ grep -n '¥' ui/src/i18n/en.json ui/src/i18n/zh.json
(no matches)

$ grep -rn "currency: 'CNY'" ui/src
(no matches)

$ grep -rn '¥' ui/src          # whole UI tree
ui/src/components/settings/models/format.ts:5:const CURRENCY_SYMBOL: Record<string, string> = { USD: '$', CNY: '¥', EUR: '€' };
```

The single surviving `¥` in the entire `ui/src` tree is the ISO 4217 mapping entry,
which is **intentional per the decision** ("保留按 ISO 4217 映射的能力") — it is the
mechanism by which a real CNY-reporting source still renders correctly, not a
leftover. No user-visible `¥` remains unless the backend actually reports CNY.

### Runtime verification (real browser, live Incus backend)

`usage.currency` stubbed into `GET /api/models/sources`:

| `currency` | Rendered | Expectation |
| --- | --- | --- |
| `null` (default) | `$12.4` | ✅ USD fallback |
| `"CNY"` | `¥12.4` | ✅ ISO map retained |
| `"EUR"` | `€12.4` | ✅ ISO map retained |

Chip label: zh `按量 $` ✅ · en `Metered $` ✅ (`Metered ¥` absent; reached by
stubbing `GET /config`'s `language`, since `LanguageSwitcher` forces the server's
configured locale over `localStorage`). Screenshot: `currency-usd-390.png`.

Full harness re-run green after the change: 9 surfaces × 360/390/430 all
`overflow=0`; usage-present rows keep every menu on-screen at 360/390/430/1280;
74-char id still unclipped; `≥640px` geometry unchanged (72px row, 24×24 handle,
32×32 menu). Build + `tsc` clean, 402/402 vitest, lint parity with master (same 11
pre-existing errors on the touched paths, verified by stashing).

Contract + design-draft updates for this decision are the orchestrator's
(`source.schema.json`, V4 desktop 01r + mobile M01–M04); `docs/` untouched here.


### Contract change (orchestrator-authorized exception, 2026-07-25)

`docs/plans/model-hub-contracts/source.schema.json` — changed here rather than
in parallel, so the schema and the UI cannot diverge:

- `usage.currency.description` now states USD as the default and product standard,
  with other ISO 4217 codes honored only when the backend explicitly reports them.
- The remaining example switches `"currency": "CNY"` → `"USD"`.

```
$ grep -n CNY docs/plans/model-hub-contracts/source.schema.json
(no matches)
```

Schema still parses; example `currency` values are now only `null` and `"USD"`.

### Regression test pinning the ruling

The decision had no test guarding it, so a future revert of the fallback would
have shipped silently. Added `ui/src/components/settings/models/format.test.ts`
(6 cases): null / undefined / absent currency → `$`; the retained ISO map
(`CNY`→`¥`, `EUR`→`€`); an unmappable code degrades to a bare amount; and
cents→decimal applies **no** FX conversion.

**The tripwire was verified to actually fail**, not just to pass — reverting
`format.ts` to `currency ?? 'CNY'` produces
`AssertionError: expected '¥12.4' to be '$12.4'` (2 failed / 4 passed), and
restoring it returns 6/6 green.

Suite is now **408 passed / 55 files** (was 402 / 54).
