### PR TITLE
fix(workbench): hide session pin shortcut on mobile

### DIFF
--- a/ui/src/components/workbench/ProjectsPage.tsx
+++ b/ui/src/components/workbench/ProjectsPage.tsx
@@ -24,7 +24,6 @@ import clsx from 'clsx';
 
 import { useWorkbenchInbox } from '../../context/WorkbenchInboxContext';
 import { useWorkbenchProjectsTree } from '../../context/WorkbenchProjectsContext';
-import { SessionPinAction } from './SessionPinAction';
 import type { ProjectSessionsState } from '../../context/WorkbenchProjectsContext';
 import type { WorkbenchProject, WorkbenchSession } from '../../context/ApiContext';
 import { formatRelativeTime } from '../../lib/relativeTime';
@@ -254,7 +253,6 @@ const MobileSessionRow: React.FC<{
   const [menuOpen, setMenuOpen] = useState(false);
   const [archiveOpen, setArchiveOpen] = useState(false);
   const [renaming, setRenaming] = useState(false);
-  const [pinning, setPinning] = useState(false);
   const [draft, setDraft] = useState(session.title ?? '');
   const inputRef = useRef<HTMLInputElement | null>(null);
   const handledRef = useRef(false);
@@ -286,14 +284,12 @@ const MobileSessionRow: React.FC<{
   const togglePinned = async () => {
     if (pinningRef.current) return;
     pinningRef.current = true;
-    setPinning(true);
     try {
       await setSessionPinned(projectId, session.id, !session.pinned);
     } catch {
       // apiFetch already surfaced the error toast.
     } finally {
       pinningRef.current = false;
-      setPinning(false);
     }
   };
 
@@ -338,13 +334,6 @@ const MobileSessionRow: React.FC<{
           </span>
         )}
       </button>
-      <SessionPinAction
-        pinned={session.pinned}
-        pending={pinning}
-        pinLabel={t('workbench.sessionPin')}
-        unpinLabel={t('workbench.sessionUnpin')}
-        onToggle={() => void togglePinned()}
-      />
       <Popover open={menuOpen} onOpenChange={setMenuOpen}>
         <PopoverTrigger asChild>
           <Button


### PR DESCRIPTION
## What changed

- remove the inline session pin shortcut from the mobile Projects session row
- keep pin and unpin as the first action in the mobile ellipsis menu
- keep the desktop sidebar hover shortcut unchanged

## Scenarios

- Scenario IDs: none; no cataloged regression scenario covers this responsive UI detail

## Evidence

- Unit: focused `SessionPinAction` component tests passed (3 tests)
- Contract: TypeScript production build and targeted ESLint passed
- Scenario: mobile row structure now exposes only the session button and ellipsis action; pinning remains wired through the ellipsis menu
- Residual manual: verify the mobile Projects list at phone width in the post-merge regression environment

## Dependencies

- No unmerged dependency
