### PR TITLE
fix(models): align the Model Hub mobile layout with the design frames

### DIFF
--- a/ui/src/components/settings/models/AddSourceMenu.tsx
+++ b/ui/src/components/settings/models/AddSourceMenu.tsx
@@ -68,17 +68,21 @@ export const AddSourceMenu: React.FC<{
   // Mobile only: which step of the chooser is showing.
   const [step, setStep] = React.useState<'type' | 'vendor'>('type');
 
-  const close = () => setOpen(false);
-  const pick = (fn: () => void) => () => {
-    close();
-    fn();
-  };
-
-  // Always reopen on the first step — landing back on the vendor list after a
-  // completed connect would be a confusing place to start.
+  // The chooser always opens on the first step. Resetting on the OPEN edge, not
+  // the close edge, is deliberate: closing happens through several paths (picking
+  // an entry, Escape, tapping the overlay, a future programmatic close) and any
+  // one of them that skips the reset leaves the next open on the vendor list.
+  // Opening only ever happens through the trigger, so this single place cannot be
+  // bypassed. (Codex P2, 2026-07-25: `pick` closed via a helper that set `open`
+  // directly and skipped the close-edge reset.)
   const onOpenChange = (next: boolean) => {
     setOpen(next);
-    if (!next) setStep('type');
+    if (next) setStep('type');
+  };
+
+  const pick = (fn: () => void) => () => {
+    setOpen(false);
+    fn();
   };
 
   const claude = {

--- a/ui/src/components/settings/models/AddSourceMenu.tsx
+++ b/ui/src/components/settings/models/AddSourceMenu.tsx
@@ -1,39 +1,59 @@
-// 添加来源 dropdown (frame 07): three entries — connect Claude / ChatGPT
-// subscription (→ OAuth connect dialog) and add API Key (→ form dialog). No
-// type-chooser dialog; the menu IS the chooser.
+// 添加来源 (frame 07): connect a Claude / ChatGPT subscription (→ OAuth connect
+// dialog) or add an API Key (→ form dialog). No type-chooser dialog on desktop;
+// the menu IS the chooser.
+//
+// On phones it becomes a bottom sheet, and the flat three-entry list becomes the
+// design's two-step chooser (design.pen M04 m04Sheet 0): 订阅账号 / API Key first,
+// vendor second. Three vendor-specific rows read as three unrelated products on a
+// small screen, where the actual decision the user is making is "subscription or
+// key". Desktop keeps the flat list — frame 07 has the room for it, and the wide
+// menu loses nothing by skipping a step.
 import * as React from 'react';
-import { ChevronRight, ExternalLink, KeyRound, Plus, Sparkles } from 'lucide-react';
+import { ChevronLeft, ChevronRight, ExternalLink, KeyRound, Plus, Sparkles } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
+import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { ResponsiveMenu } from '@/components/ui/responsive-menu';
 import { cn } from '@/lib/utils';
+import { useIsMobile } from '@/lib/useIsMobile';
 import { ACCENT_ICON, ACCENT_TILE } from './vendorMeta';
 
-type MenuItemProps = {
+const MenuItem: React.FC<{
   Icon: React.ComponentType<{ size?: number; className?: string }>;
   accentTile: string;
   accentIcon: string;
   title: string;
   subtitle: string;
+  badge?: string;
   Trailing: React.ComponentType<{ className?: string }>;
   onClick: () => void;
-};
-
-const MenuItem: React.FC<MenuItemProps> = ({ Icon, accentTile, accentIcon, title, subtitle, Trailing, onClick }) => (
+  /** Roomier type + wrapping subtitle for the touch sheet. */
+  large?: boolean;
+}> = ({ Icon, accentTile, accentIcon, title, subtitle, badge, Trailing, onClick, large }) => (
   <button
     type="button"
     onClick={onClick}
-    className="flex w-full items-center gap-3 border-b border-border px-4 py-3 text-left transition-colors last:border-b-0 hover:bg-surface-2"
+    className={cn(
+      'flex w-full items-center gap-3 border-b border-border px-4 py-3 text-left transition-colors last:border-b-0 hover:bg-surface-2',
+      large && 'items-start gap-3.5 py-4',
+    )}
   >
-    <span className={cn('flex size-10 shrink-0 items-center justify-center rounded-[10px]', accentTile)}>
-      <Icon size={20} className={accentIcon} />
+    <span className={cn('flex shrink-0 items-center justify-center rounded-[10px]', large ? 'size-11' : 'size-10', accentTile)}>
+      <Icon size={large ? 22 : 20} className={accentIcon} />
     </span>
     <span className="flex min-w-0 flex-1 flex-col gap-0.5">
-      <span className="text-[14px] font-semibold text-foreground">{title}</span>
-      <span className="truncate text-[12px] text-muted">{subtitle}</span>
+      <span className="flex items-center gap-2">
+        <span className={cn('font-semibold text-foreground', large ? 'text-[15px]' : 'text-[14px]')}>{title}</span>
+        {badge && (
+          <Badge variant="success" className="shrink-0 px-2 py-0.5 text-[10px]">
+            {badge}
+          </Badge>
+        )}
+      </span>
+      <span className={cn('text-[12px] text-muted', large ? 'leading-relaxed' : 'truncate')}>{subtitle}</span>
     </span>
-    <Trailing className="size-4 shrink-0 text-muted" />
+    <Trailing className={cn('size-4 shrink-0 text-muted', large && 'mt-1')} />
   </button>
 );
 
@@ -43,57 +63,127 @@ export const AddSourceMenu: React.FC<{
   onAddApiKey: () => void;
 }> = ({ onConnectClaude, onConnectChatGPT, onAddApiKey }) => {
   const { t } = useTranslation();
+  const isMobile = useIsMobile();
   const [open, setOpen] = React.useState(false);
+  // Mobile only: which step of the chooser is showing.
+  const [step, setStep] = React.useState<'type' | 'vendor'>('type');
 
+  const close = () => setOpen(false);
   const pick = (fn: () => void) => () => {
-    setOpen(false);
+    close();
     fn();
   };
 
+  // Always reopen on the first step — landing back on the vendor list after a
+  // completed connect would be a confusing place to start.
+  const onOpenChange = (next: boolean) => {
+    setOpen(next);
+    if (!next) setStep('type');
+  };
+
+  const claude = {
+    Icon: Sparkles,
+    accentTile: ACCENT_TILE.mint,
+    accentIcon: ACCENT_ICON.mint,
+    title: t('settings.models.addMenu.claude.title') as string,
+    subtitle: t('settings.models.addMenu.claude.subtitle') as string,
+    Trailing: ExternalLink,
+    onClick: pick(onConnectClaude),
+  };
+  const chatgpt = {
+    Icon: Sparkles,
+    accentTile: ACCENT_TILE.gold,
+    accentIcon: ACCENT_ICON.gold,
+    title: t('settings.models.addMenu.chatgpt.title') as string,
+    subtitle: t('settings.models.addMenu.chatgpt.subtitle') as string,
+    Trailing: ExternalLink,
+    onClick: pick(onConnectChatGPT),
+  };
+  const apiKey = {
+    Icon: KeyRound,
+    accentTile: ACCENT_TILE.violet,
+    accentIcon: ACCENT_ICON.violet,
+    title: t('settings.models.addMenu.apiKey.title') as string,
+    subtitle: t('settings.models.addMenu.apiKey.subtitle') as string,
+    Trailing: ChevronRight,
+    onClick: pick(onAddApiKey),
+  };
+
+  const vendorStep = step === 'vendor';
+
   return (
-    <Popover open={open} onOpenChange={setOpen}>
-      <PopoverTrigger asChild>
-        <Button variant="outline" size="sm" className="h-10 border-mint/40 bg-mint-soft/50 text-mint hover:bg-mint-soft sm:h-9">
+    <ResponsiveMenu
+      open={open}
+      onOpenChange={onOpenChange}
+      align="end"
+      sideOffset={8}
+      // Never wider than the phone viewport (the fixed 360px overflowed a 360px
+      // device once collision padding was applied).
+      className="w-[min(360px,calc(100vw-1.5rem))] overflow-hidden p-0 sm:w-[360px]"
+      sheetTitle={
+        vendorStep
+          ? (t('settings.models.addMenu.vendorTitle') as string)
+          : (t('settings.models.addMenu.sheetTitle') as string)
+      }
+      sheetDescription={
+        vendorStep
+          ? (t('settings.models.addMenu.vendorSubtitle') as string)
+          : (t('settings.models.addMenu.sheetSubtitle') as string)
+      }
+      sheetHeader={
+        vendorStep ? (
+          <div className="px-4 pb-2">
+            <button
+              type="button"
+              onClick={() => setStep('type')}
+              className="inline-flex min-h-10 items-center gap-1 text-[13px] font-medium text-mint transition-colors hover:text-mint/80"
+            >
+              <ChevronLeft className="size-4" />
+              {t('common.back')}
+            </button>
+          </div>
+        ) : undefined
+      }
+      trigger={
+        <Button
+          variant="outline"
+          size="sm"
+          // Full-width primary-looking button on phones (design.pen M01 m01AddBtn:
+          // mint-soft fill, 1.5px mint stroke); the quieter inline button on sm+.
+          className="h-11 w-full rounded-[11px] border-[1.5px] border-mint/70 bg-mint-soft text-mint hover:bg-mint-soft/80 sm:h-9 sm:w-auto sm:rounded-md sm:border sm:border-mint/40 sm:bg-mint-soft/50 sm:hover:bg-mint-soft"
+        >
           <Plus className="size-4" />
           {t('settings.models.addSource')}
         </Button>
-      </PopoverTrigger>
-      <PopoverContent
-        align="end"
-        sideOffset={8}
-        collisionPadding={12}
-        // Never wider than the phone viewport (the fixed 360px overflowed a 360px
-        // device once collision padding was applied).
-        className="w-[min(360px,calc(100vw-1.5rem))] overflow-hidden border-border bg-card p-0 text-foreground shadow-lg sm:w-[360px]"
-      >
-        <MenuItem
-          Icon={Sparkles}
-          accentTile={ACCENT_TILE.mint}
-          accentIcon={ACCENT_ICON.mint}
-          title={t('settings.models.addMenu.claude.title')}
-          subtitle={t('settings.models.addMenu.claude.subtitle')}
-          Trailing={ExternalLink}
-          onClick={pick(onConnectClaude)}
-        />
-        <MenuItem
-          Icon={Sparkles}
-          accentTile={ACCENT_TILE.gold}
-          accentIcon={ACCENT_ICON.gold}
-          title={t('settings.models.addMenu.chatgpt.title')}
-          subtitle={t('settings.models.addMenu.chatgpt.subtitle')}
-          Trailing={ExternalLink}
-          onClick={pick(onConnectChatGPT)}
-        />
-        <MenuItem
-          Icon={KeyRound}
-          accentTile={ACCENT_TILE.violet}
-          accentIcon={ACCENT_ICON.violet}
-          title={t('settings.models.addMenu.apiKey.title')}
-          subtitle={t('settings.models.addMenu.apiKey.subtitle')}
-          Trailing={ChevronRight}
-          onClick={pick(onAddApiKey)}
-        />
-      </PopoverContent>
-    </Popover>
+      }
+    >
+      {!isMobile ? (
+        <>
+          <MenuItem {...claude} />
+          <MenuItem {...chatgpt} />
+          <MenuItem {...apiKey} />
+        </>
+      ) : vendorStep ? (
+        <>
+          <MenuItem {...claude} large />
+          <MenuItem {...chatgpt} large />
+        </>
+      ) : (
+        <>
+          <MenuItem
+            Icon={Sparkles}
+            accentTile={ACCENT_TILE.mint}
+            accentIcon={ACCENT_ICON.mint}
+            title={t('settings.models.addMenu.subscription.title') as string}
+            subtitle={t('settings.models.addMenu.subscription.subtitle') as string}
+            badge={t('settings.models.addMenu.subscription.recommended') as string}
+            Trailing={ChevronRight}
+            onClick={() => setStep('vendor')}
+            large
+          />
+          <MenuItem {...apiKey} subtitle={t('settings.models.addMenu.apiKeySheetSubtitle') as string} large />
+        </>
+      )}
+    </ResponsiveMenu>
   );
 };

--- a/ui/src/components/settings/models/AgentCard.tsx
+++ b/ui/src/components/settings/models/AgentCard.tsx
@@ -74,37 +74,73 @@ const AgentRow: React.FC<{
     );
   }
 
+  // Direct mode had no second line at all, which read as "nothing to see here" —
+  // the truth is that this backend is still supplied by its own CLI config and the
+  // Hub isn't involved. Phones only: the desktop row keeps 直连 Direct beside its
+  // 接入中枢 button on one line, where a sentence has nowhere to go.
+  const mobileNote =
+    agent.mode === 'hub' ? null : (
+      <span className="text-[11.5px] leading-relaxed text-muted">{t('settings.models.agents.directNote')}</span>
+    );
+
+  const action =
+    agent.mode === 'hub' ? (
+      <Button variant="secondary" size="sm" className="h-11 w-full sm:h-9 sm:w-auto" onClick={openMenu}>
+        {t('settings.models.agents.modelMenu')}
+        <ChevronRight className="size-3.5" />
+      </Button>
+    ) : (
+      <Button
+        variant="brand"
+        size="sm"
+        className="h-11 w-full sm:h-9 sm:w-auto"
+        onClick={() => onConnectHub(agent)}
+        disabled={connecting}
+      >
+        <ArrowDownToLine className="size-3.5" />
+        {t('settings.models.agents.connectHub')}
+      </Button>
+    );
+
   return (
-    // Mobile: identity above, mode chip + action on their own line. Squeezed into
-    // one row at 390px the mode chip overlapped the composite pill and the pill's
-    // model id wrapped to three lines.
-    <div className="flex flex-col gap-3 border-b border-border px-4 py-4 last:border-b-0 sm:flex-row sm:items-center sm:gap-4 sm:px-5">
-      <div className="flex min-w-0 flex-1 items-center gap-3 sm:gap-4">
-        <span className={cn('flex size-11 shrink-0 items-center justify-center rounded-[10px]', ACCENT_TILE[accent])}>
-          <Icon size={22} className={ACCENT_ICON[accent]} />
+    // Mobile is three full-width tiers (design.pen M01 m01Ag*): identity + mode
+    // badge, the supply line, then the action. Squeezed into one row at 390px the
+    // mode chip overlapped the composite pill and the pill's model id wrapped to
+    // three lines; nesting the pill under the name (the desktop shape) also left
+    // it inset by the icon tile instead of spanning the row.
+    //
+    // The supply pill has two mount points because the desktop frame nests it
+    // under the name while mobile needs it as a full-width sibling — CSS cannot
+    // re-parent. It's stateless presentation and the inactive copy is
+    // display:none (so out of the a11y tree), which is the cheap half of the
+    // trade; the win is that the sm+ DOM stays exactly the reviewed desktop row.
+    <div className="flex flex-col gap-2.5 border-b border-border px-4 py-4 last:border-b-0 sm:flex-row sm:items-center sm:gap-4 sm:px-5">
+      <div className="flex min-w-0 items-center gap-2.5 sm:flex-1 sm:gap-4">
+        <span className={cn('flex size-[34px] shrink-0 items-center justify-center rounded-[10px] sm:size-11', ACCENT_TILE[accent])}>
+          <Icon className={cn('size-[18px] sm:size-[22px]', ACCENT_ICON[accent])} />
         </span>
 
         <div className="flex min-w-0 flex-1 flex-col items-start gap-2">
-          <span className="text-[15px] font-semibold text-foreground">
+          {/* truncate only on phones; sm+ keeps the desktop row's wrap behaviour. */}
+          <span className="truncate text-[14px] font-bold text-foreground sm:whitespace-normal sm:text-[15px] sm:font-semibold">
             {t(`settings.models.backends.${agent.backend}`, { defaultValue: agent.backend })}
           </span>
-          {pill}
+          {pill && <span className="hidden sm:block">{pill}</span>}
         </div>
+
+        {/* The mode badge belongs on the identity line on phones. */}
+        <span className="shrink-0 sm:hidden">
+          <ModeChip mode={agent.mode} />
+        </span>
       </div>
 
+      <div className="sm:hidden">{pill ?? mobileNote}</div>
+
       <div className="flex items-center gap-2.5 sm:shrink-0">
-        <ModeChip mode={agent.mode} />
-        {agent.mode === 'hub' ? (
-          <Button variant="secondary" size="sm" className="ml-auto h-10 sm:ml-0 sm:h-9" onClick={openMenu}>
-            {t('settings.models.agents.modelMenu')}
-            <ChevronRight className="size-3.5" />
-          </Button>
-        ) : (
-          <Button variant="brand" size="sm" className="ml-auto h-10 sm:ml-0 sm:h-9" onClick={() => onConnectHub(agent)} disabled={connecting}>
-            <ArrowDownToLine className="size-3.5" />
-            {t('settings.models.agents.connectHub')}
-          </Button>
-        )}
+        <span className="hidden sm:inline-flex">
+          <ModeChip mode={agent.mode} />
+        </span>
+        {action}
       </div>
     </div>
   );

--- a/ui/src/components/settings/models/RecentSwitchesCard.tsx
+++ b/ui/src/components/settings/models/RecentSwitchesCard.tsx
@@ -62,11 +62,21 @@ export const RecentSwitchesCard: React.FC<{ events: ResolutionEvent[] }> = ({ ev
         <div className="px-4 py-8 text-center sm:px-5 text-[13px] text-muted">{t('settings.models.recent.empty')}</div>
       ) : (
         <div className="flex flex-col">
+          {/* Phones stack the timestamp above the sentence (design.pen M01 m01Ev):
+              the desktop 92px time column left the message ~200px at 360, so a
+              one-line event wrapped to three or four. */}
           {shown.map((event) => (
-            <div key={event.id} className="flex items-start gap-3 border-b border-border px-4 py-3 last:border-b-0 sm:px-5">
-              <span className="w-[92px] shrink-0 pt-0.5 font-mono text-[12px] text-muted">{formatTime(event.ts)}</span>
-              <Dot accent={eventAccent(event)} className="mt-[7px]" />
-              <span className="min-w-0 flex-1 text-[13px] leading-relaxed text-foreground">
+            <div
+              key={event.id}
+              className="flex flex-col gap-1 border-b border-border px-4 py-2.5 last:border-b-0 sm:flex-row sm:items-start sm:gap-3 sm:py-3 sm:px-5"
+            >
+              <span className="flex items-center gap-2 sm:contents">
+                <Dot accent={eventAccent(event)} className="sm:mt-[7px] sm:order-2" />
+                <span className="font-mono text-[11px] text-muted sm:order-1 sm:w-[92px] sm:shrink-0 sm:pt-0.5 sm:text-[12px]">
+                  {formatTime(event.ts)}
+                </span>
+              </span>
+              <span className="min-w-0 flex-1 text-[12.5px] leading-relaxed text-foreground sm:order-3 sm:text-[13px]">
                 {zh ? event.human_zh : event.human_en}
               </span>
             </div>

--- a/ui/src/components/settings/models/SettingsModelsPage.tsx
+++ b/ui/src/components/settings/models/SettingsModelsPage.tsx
@@ -111,9 +111,8 @@ export const SettingsModelsPage: React.FC = () => {
     });
   };
 
-  const reorderCommit = () => {
+  const commitOrder = (order: string[]) => {
     const seq = ++reorderSeq.current;
-    const order = sourcesRef.current.map((s) => s.id);
     modelsApi
       .putPriority(order)
       .then((priority) => {
@@ -131,6 +130,19 @@ export const SettingsModelsPage: React.FC = () => {
         // list reflects the persisted (unchanged) order rather than a phantom one.
         void refreshSourcesAgents();
       });
+  };
+
+  // Drag end: the ordered state has already been re-rendered by the preview
+  // callbacks, so the mirror ref holds the freshest order.
+  const reorderCommit = () => commitOrder(sourcesRef.current.map((s) => s.id));
+
+  // Step reorder (the row menu's 上移/下移). Deliberately NOT preview-then-commit:
+  // the mirror ref is assigned during render, so a synchronous commit right after
+  // setSources would still read the pre-move order and persist it. Passing the
+  // order explicitly keeps both halves on the same value.
+  const reorderTo = (order: string[]) => {
+    reorderPreview(order);
+    commitOrder(order);
   };
 
   const connectHub = async (agent: AgentSupply) => {
@@ -184,6 +196,7 @@ export const SettingsModelsPage: React.FC = () => {
             sources={sources}
             onReorderPreview={reorderPreview}
             onReorderCommit={reorderCommit}
+            onReorderTo={reorderTo}
             onConnectClaude={() => setOauthVendor('anthropic')}
             onConnectChatGPT={() => setOauthVendor('openai')}
             onAddApiKey={() => setApiKeyOpen(true)}

--- a/ui/src/components/settings/models/SourceRow.tsx
+++ b/ui/src/components/settings/models/SourceRow.tsx
@@ -5,10 +5,11 @@
 // Mobile (< sm): the frame's single aligned row cannot hold eight columns in
 // 390px — it squeezed the name to zero width and pushed the state chip and the
 // row menu off-screen entirely (clipped, not scrollable, so unreachable). So the
-// row stacks into two tiers: identity on top (handle · priority · icon · name),
-// the metric/state strip below with the menu pushed to the right edge. The sm+
-// layout is byte-for-byte the desktop frame, so the fixed-width chip columns
-// still align down the list.
+// row stacks into two tiers per design.pen M01 (m01SrcL1 / m01SrcL2): identity +
+// the row menu on top, then billing · state · usage on a single second line,
+// inset 26px so it starts under the priority number. The sm+ layout is
+// byte-for-byte the desktop frame, so the fixed-width chip columns still align
+// down the list.
 import * as React from 'react';
 import { GripVertical } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
@@ -45,6 +46,12 @@ function useSubline(source: Source): string {
   return parts.join(' · ');
 }
 
+// On phones usage sits at the RIGHT END of the second tier and absorbs the slack
+// (design.pen M01 m01Use: fill_container + justify end), which also puts it after
+// the chips — hence `order-last`. On sm+ it reverts to the desktop frame's
+// leading fixed-width column.
+const USAGE_CELL = 'order-last flex-1 sm:order-none sm:w-[150px] sm:flex-none';
+
 const UsageCell: React.FC<{ source: Source }> = ({ source }) => {
   const { t } = useTranslation();
   const pct = source.usage?.cycle_used_pct;
@@ -52,23 +59,23 @@ const UsageCell: React.FC<{ source: Source }> = ({ source }) => {
 
   if (source.billing === 'monthly' && typeof pct === 'number') {
     return (
-      <div className="flex shrink-0 items-center gap-2 sm:w-[150px] sm:justify-end">
-        <div className="h-1.5 w-[92px] overflow-hidden rounded-full bg-border">
+      <div className={cn(USAGE_CELL, 'flex items-center justify-end gap-2')}>
+        <div className="h-1.5 w-14 overflow-hidden rounded-full bg-border sm:w-[92px]">
           <div className="h-full rounded-full bg-mint" style={{ width: `${Math.min(100, Math.max(0, pct))}%` }} />
         </div>
-        <span className="w-9 text-right font-mono text-[12px] text-muted">{Math.round(pct)}%</span>
+        <span className="text-right font-mono text-[10.5px] text-muted sm:w-9 sm:text-[12px]">{Math.round(pct)}%</span>
       </div>
     );
   }
   if (typeof spend === 'number') {
     return (
-      <div className="shrink-0 text-[12px] text-muted sm:w-[150px] sm:text-right">
+      <div className={cn(USAGE_CELL, 'truncate text-right font-mono text-[10.5px] text-muted sm:font-sans sm:text-[12px]')}>
         {t('settings.models.usage.monthSpend', { amount: formatSpend(spend, source.usage?.currency) })}
       </div>
     );
   }
-  // No usage data: on mobile the spacer would eat the strip's width, so it only
-  // holds the desktop column open.
+  // No usage data: on mobile the chips just stay left-aligned, so the spacer only
+  // exists to hold the desktop column open.
   return <div className="hidden sm:block sm:w-[150px] sm:shrink-0" />;
 };
 
@@ -76,18 +83,28 @@ export const SourceRow: React.FC<{
   source: Source;
   priority: number;
   onDragHandlePointerDown: (e: React.PointerEvent) => void;
+  /** False at the ends of the list — the matching menu action is disabled. */
+  canMoveUp: boolean;
+  canMoveDown: boolean;
+  /** Keyboard/screen-reader path for reordering; drag stays the primary one. */
+  onMove: (delta: -1 | 1) => void;
   /** Re-fetch after a row action (rename / re-discover / delete). */
   onChanged: () => void;
-}> = ({ source, priority, onDragHandlePointerDown, onChanged }) => {
+}> = ({ source, priority, onDragHandlePointerDown, canMoveUp, canMoveDown, onMove, onChanged }) => {
   const { t } = useTranslation();
   const { Icon, accent } = sourceVisual(source);
   const subline = useSubline(source);
   const isExperimental = source.kind === 'subscription' && source.supply_channel === 'hub';
 
   return (
-    <div className="group flex flex-col gap-2 border-b border-border px-4 py-3 last:border-b-0 sm:flex-row sm:items-center sm:gap-3 sm:px-5 sm:py-3.5">
-      {/* Identity tier — the whole row on sm+. */}
-      <div className="flex min-w-0 flex-1 items-center gap-2.5 sm:gap-3">
+    // One wrapping flex line, not two stacked tiers: the row menu has to sit at
+    // the end of the FIRST line on phones and at the end of the (single) row on
+    // sm+, which no amount of CSS can do if it lives inside one of two sibling
+    // containers. So identity / menu / metrics are siblings here and `order`
+    // rearranges them per breakpoint — one menu instance, one set of dialogs.
+    <div className="group flex flex-wrap items-center gap-x-2.5 gap-y-2.5 border-b border-border px-4 py-3 last:border-b-0 sm:flex-nowrap sm:gap-x-3 sm:px-5 sm:py-3.5">
+      {/* Identity — the leading segment on both breakpoints. */}
+      <div className="order-1 flex min-w-0 flex-1 items-center gap-2.5 sm:gap-3">
         <button
           type="button"
           aria-label={t('settings.models.source.reorder') as string}
@@ -99,41 +116,54 @@ export const SourceRow: React.FC<{
           <GripVertical className="size-4" />
         </button>
 
-        <span className="grid size-7 shrink-0 place-items-center rounded-md border border-border bg-surface font-mono text-[13px] text-muted">
+        <span className="grid size-[22px] shrink-0 place-items-center rounded-[7px] border border-border bg-surface font-mono text-[11px] font-bold text-muted sm:size-7 sm:rounded-md sm:text-[13px] sm:font-normal">
           {priority}
         </span>
 
-        <SupplyTooltip models={source.models} className="flex min-w-0 flex-1 items-center gap-3">
-          <span className={cn('flex size-11 shrink-0 items-center justify-center rounded-[10px]', ACCENT_TILE[accent])}>
-            <Icon size={22} className={ACCENT_ICON[accent]} />
+        <SupplyTooltip models={source.models} className="flex min-w-0 flex-1 items-center gap-2.5 sm:gap-3">
+          <span className={cn('flex size-[34px] shrink-0 items-center justify-center rounded-[10px] sm:size-11', ACCENT_TILE[accent])}>
+            <Icon className={cn('size-[18px] sm:size-[22px]', ACCENT_ICON[accent])} />
           </span>
           <span className="flex min-w-0 flex-col gap-0.5">
             <span className="flex min-w-0 items-center gap-2">
-              <span className="truncate text-[15px] font-semibold text-foreground">{source.display_name}</span>
+              <span className="truncate text-[13.5px] font-semibold text-foreground sm:text-[15px]">{source.display_name}</span>
               {isExperimental && <ExperimentalChip />}
             </span>
-            <span className="truncate font-mono text-[12px] text-muted">{subline}</span>
+            <span className="truncate font-mono text-[10.5px] text-muted sm:text-[12px]">{subline}</span>
           </span>
         </SupplyTooltip>
       </div>
 
-      {/* Metric / state strip — its own line on phones, with the row menu pinned
-          to the right edge; the aligned desktop chip columns on sm+. The 88px
-          inset is the identity tier's handle + priority + gaps, so the strip
-          starts under the source's icon tile and reads as part of that row
-          rather than floating between two of them.
-          flex-wrap matters: a subscription source's usage bar + percentage is
-          ~140px, which together with both chips and the menu exceeds even a
-          430px phone — without wrapping the menu is pushed off-screen again
-          whenever usage data is actually present. sm:flex-nowrap keeps the
-          desktop row single-line. */}
-      <div className="flex flex-wrap items-center gap-x-3 gap-y-2 pl-[88px] sm:shrink-0 sm:flex-nowrap sm:gap-4 sm:pl-0">
+      {/* Metric / state strip — a full-width second line on phones, inset 26px
+          (handle glyph + gap) so it starts under the priority number; the aligned
+          desktop chip columns on sm+.
+          flex-wrap here is the safety net, not the plan: measured at 360/390/430
+          in both locales every row stays on one line, including the widest English
+          combination ("$3.2 this month" · "Metered $" · "Cooling down"). It stays
+          wrap-capable so an unusually long future state label degrades to two
+          lines instead of clipping. sm:flex-nowrap keeps the desktop row
+          single-line. */}
+      <div className="order-3 flex w-full flex-wrap items-center gap-x-2 gap-y-2 pl-[26px] sm:order-2 sm:w-auto sm:shrink-0 sm:flex-nowrap sm:gap-4 sm:pl-0">
         <UsageCell source={source} />
         <BillingChip billing={source.billing} currency={source.usage?.currency} />
         <StateChip state={source.state} />
-        <div className="ml-auto sm:ml-0">
-          <SourceRowMenu source={source} onChanged={onChanged} />
-        </div>
+      </div>
+
+      {/* Thumb-reachable on the identity line on phones (design.pen M01 m01More,
+          36×36 on the handle/priority axis); trailing the desktop row on sm+.
+          sm:ml-1 restores the desktop frame's 16px gap before the menu — it used
+          to come from the metrics strip's own gap-4, and the row's gap-3 alone
+          pulled every chip column 4px right of the reviewed desktop layout
+          (caught by diffing the rendered geometry against master). */}
+      <div className="order-2 shrink-0 sm:order-3 sm:ml-1">
+        <SourceRowMenu
+          source={source}
+          priority={priority}
+          canMoveUp={canMoveUp}
+          canMoveDown={canMoveDown}
+          onMove={onMove}
+          onChanged={onChanged}
+        />
       </div>
     </div>
   );

--- a/ui/src/components/settings/models/SourceRowMenu.tsx
+++ b/ui/src/components/settings/models/SourceRowMenu.tsx
@@ -1,50 +1,79 @@
 // Per-row lifecycle actions for the 来源 list (frame 01r): an overflow menu that
 // stays out of the way (hidden until row hover / focus on desktop) and exposes
 // the contracted source mutations the list otherwise couldn't reach — rename
-// (PATCH), re-discover (POST /test, hub sources only), and delete (DELETE, with
-// the only-supplier guard escalating to a forced delete). Presentation lives in
-// SourceRow; this owns the actions + their dialogs so the row stays declarative.
+// (PATCH), re-discover (POST /test, hub sources only), reorder by one step, and
+// delete (DELETE, with the only-supplier guard escalating to a forced delete).
+// Presentation lives in SourceRow; this owns the actions + their dialogs so the
+// row stays declarative.
+//
+// On phones the menu presents as a bottom sheet (design.pen M02 m02SheetA) with
+// the row's identity in the header and a one-line rationale under each action,
+// because a thumb menu has no hover to explain itself. 上移一位 / 下移一位 live
+// here rather than as a visible button column: drag is the primary reordering
+// gesture, and these exist so the same thing is reachable by keyboard and screen
+// reader.
 import * as React from 'react';
-import { MoreHorizontal, Pencil, RefreshCw, Trash2 } from 'lucide-react';
+import { ArrowDown, ArrowUp, MoreHorizontal, Pencil, RefreshCw, Trash2 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
 import { Button } from '@/components/ui/button';
 import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
-import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { ResponsiveMenu } from '@/components/ui/responsive-menu';
 import { cn } from '@/lib/utils';
+import { useIsMobile } from '@/lib/useIsMobile';
 import { useToast } from '@/context/ToastContext';
 import { modelsApi } from './modelsApi';
+import { ACCENT_ICON, ACCENT_TILE, sourceVisual } from './vendorMeta';
 import type { Source } from './types';
 
 const MenuAction: React.FC<{
   Icon: React.ComponentType<{ className?: string }>;
   label: string;
+  /** Shown in the mobile sheet only — the popover stays a compact list. */
+  description?: string;
   onClick: () => void;
+  disabled?: boolean;
   destructive?: boolean;
-}> = ({ Icon, label, onClick, destructive }) => (
+}> = ({ Icon, label, description, onClick, disabled, destructive }) => (
   <button
     type="button"
     onClick={onClick}
+    disabled={disabled}
     className={cn(
       // min-h-11 keeps each action a comfortable thumb target on phones.
       'flex min-h-11 w-full items-center gap-2.5 rounded-md px-2.5 py-2 text-left text-[13px] transition-colors sm:min-h-0',
-      destructive ? 'text-destructive hover:bg-destructive/[0.08]' : 'text-foreground hover:bg-surface-2',
+      description && 'items-start gap-3 rounded-none border-b border-border px-4 py-3.5 last:border-b-0',
+      destructive ? 'text-destructive' : 'text-foreground',
+      disabled ? 'opacity-40' : destructive ? 'hover:bg-destructive/[0.08]' : 'hover:bg-surface-2',
     )}
   >
-    <Icon className="size-4 shrink-0" />
-    {label}
+    <Icon className={cn('size-4 shrink-0', description && 'mt-0.5 size-[18px]')} />
+    {description ? (
+      <span className="flex min-w-0 flex-col gap-0.5">
+        <span className="text-[14px] font-semibold">{label}</span>
+        <span className="text-[12px] leading-relaxed text-muted">{description}</span>
+      </span>
+    ) : (
+      label
+    )}
   </button>
 );
 
 export const SourceRowMenu: React.FC<{
   source: Source;
+  priority: number;
+  canMoveUp: boolean;
+  canMoveDown: boolean;
+  onMove: (delta: -1 | 1) => void;
   /** Re-fetch sources + agents after any successful mutation. */
   onChanged: () => void;
-}> = ({ source, onChanged }) => {
+}> = ({ source, priority, canMoveUp, canMoveDown, onMove, onChanged }) => {
   const { t } = useTranslation();
   const { showToast } = useToast();
+  const isMobile = useIsMobile();
+  const { Icon: SourceIcon, accent } = sourceVisual(source);
 
   const [menuOpen, setMenuOpen] = React.useState(false);
   const [renameOpen, setRenameOpen] = React.useState(false);
@@ -107,6 +136,11 @@ export const SourceRowMenu: React.FC<{
     }
   };
 
+  const move = (delta: -1 | 1) => {
+    setMenuOpen(false);
+    onMove(delta);
+  };
+
   const openDelete = () => {
     setMenuOpen(false);
     setForceMode(false);
@@ -134,31 +168,95 @@ export const SourceRowMenu: React.FC<{
     }
   };
 
+  // Descriptions only exist in the sheet; passing undefined on desktop is what
+  // keeps the popover a compact label list.
+  const hint = (key: string, opts?: Record<string, unknown>) =>
+    isMobile ? (t(`settings.models.sourceActions.${key}`, opts) as string) : undefined;
+
   return (
     <>
-      <Popover open={menuOpen} onOpenChange={setMenuOpen}>
-        <PopoverTrigger asChild>
+      <ResponsiveMenu
+        open={menuOpen}
+        onOpenChange={setMenuOpen}
+        sheetTitle={source.display_name}
+        sheetTitleVisible={false}
+        className="w-[200px]"
+        sheetHeader={
+          <div className="flex items-center gap-3 px-4 pb-3.5 pt-1">
+            <span className={cn('flex size-10 shrink-0 items-center justify-center rounded-[10px]', ACCENT_TILE[accent])}>
+              <SourceIcon className={cn('size-5', ACCENT_ICON[accent])} />
+            </span>
+            <span className="flex min-w-0 flex-col gap-0.5">
+              <span className="truncate text-[15px] font-bold text-foreground">{source.display_name}</span>
+              <span className="truncate text-[12px] text-muted">
+                {[
+                  t('settings.models.sourceActions.priorityLabel', { position: priority }),
+                  t(`settings.models.state.${source.state.status}`),
+                  t(`settings.models.billing.${source.billing}`),
+                ].join(' · ')}
+              </span>
+            </span>
+          </div>
+        }
+        trigger={
           <button
             type="button"
             aria-label={t('settings.models.sourceActions.more') as string}
             className={cn(
-              'flex size-10 shrink-0 items-center justify-center rounded-md text-muted transition-all hover:bg-surface-2 hover:text-foreground sm:size-8',
+              // The button is a 44×44 touch target while the drawn box inside it
+              // is the design's 36×36 (design.pen M01 m01More). Negative margins
+              // cancel the extra 8px so the visual box lands exactly where a bare
+              // 36px button would and the row height is unchanged — design size
+              // and the touch-target floor both hold, with no reliance on
+              // pseudo-element hit testing.
+              'group/more -my-1 -mr-1 flex size-11 shrink-0 items-center justify-center text-muted sm:m-0 sm:size-8',
               // Quiet on desktop (revealed on row hover / focus / when open),
               // always reachable on touch where hover doesn't exist.
               menuOpen ? 'opacity-100' : 'opacity-100 md:opacity-0 md:group-hover:opacity-100 md:focus-visible:opacity-100',
             )}
           >
-            {testing ? <RefreshCw className="size-4 animate-spin" /> : <MoreHorizontal className="size-4" />}
+            <span className="flex size-9 items-center justify-center rounded-[10px] border border-border bg-surface/60 transition-colors group-hover/more:bg-surface-2 group-hover/more:text-foreground sm:size-8 sm:border-transparent sm:bg-transparent">
+              {testing ? <RefreshCw className="size-4 animate-spin" /> : <MoreHorizontal className="size-4" />}
+            </span>
           </button>
-        </PopoverTrigger>
-        <PopoverContent align="end" sideOffset={6} className="w-[200px] border-border bg-card p-1.5 text-foreground shadow-lg">
-          <MenuAction Icon={Pencil} label={t('settings.models.sourceActions.rename') as string} onClick={openRename} />
-          {canRediscover && (
-            <MenuAction Icon={RefreshCw} label={t('settings.models.sourceActions.rediscover') as string} onClick={() => void rediscover()} />
-          )}
-          <MenuAction Icon={Trash2} label={t('settings.models.sourceActions.delete') as string} onClick={openDelete} destructive />
-        </PopoverContent>
-      </Popover>
+        }
+      >
+        <MenuAction
+          Icon={Pencil}
+          label={t('settings.models.sourceActions.rename') as string}
+          description={hint('renameHint')}
+          onClick={openRename}
+        />
+        {canRediscover && (
+          <MenuAction
+            Icon={RefreshCw}
+            label={t('settings.models.sourceActions.rediscover') as string}
+            description={hint('rediscoverHint')}
+            onClick={() => void rediscover()}
+          />
+        )}
+        <MenuAction
+          Icon={ArrowUp}
+          label={t('settings.models.sourceActions.moveUp') as string}
+          description={hint(canMoveUp ? 'moveUpHint' : 'moveUpHintAtTop', { position: priority })}
+          onClick={() => move(-1)}
+          disabled={!canMoveUp}
+        />
+        <MenuAction
+          Icon={ArrowDown}
+          label={t('settings.models.sourceActions.moveDown') as string}
+          description={hint(canMoveDown ? 'moveDownHint' : 'moveDownHintAtBottom')}
+          onClick={() => move(1)}
+          disabled={!canMoveDown}
+        />
+        <MenuAction
+          Icon={Trash2}
+          label={t('settings.models.sourceActions.delete') as string}
+          description={hint('deleteHint')}
+          onClick={openDelete}
+          destructive
+        />
+      </ResponsiveMenu>
 
       <Dialog open={renameOpen} onOpenChange={(v) => !v && !renaming && setRenameOpen(false)}>
         <DialogContent className="max-w-[420px] gap-4">

--- a/ui/src/components/settings/models/SourcesCard.tsx
+++ b/ui/src/components/settings/models/SourcesCard.tsx
@@ -2,20 +2,29 @@
 // drag-to-reorder priority list. Fully controlled — the ordered `sources` and
 // the reorder handlers live in the page, so this card holds no derived state.
 // Drag is restricted to each row's handle via framer-motion drag controls.
+//
+// Mobile header (design.pen M01 m01SrcHead): the title block and 添加来源 stack
+// instead of competing for one line, with 添加来源 as a full-width primary
+// button — at 360px the side-by-side desktop header squeezed the sub-line to two
+// or three lines and left the button a cramped tap target.
 import * as React from 'react';
 import { Reorder, useDragControls } from 'framer-motion';
 import { useTranslation } from 'react-i18next';
 
 import { AddSourceMenu } from './AddSourceMenu';
 import { SourceRow } from './SourceRow';
+import { movedOrder } from './reorder';
 import type { Source } from './types';
 
-const SourceReorderItem: React.FC<{ source: Source; priority: number; onCommit: () => void; onChanged: () => void }> = ({
-  source,
-  priority,
-  onCommit,
-  onChanged,
-}) => {
+const SourceReorderItem: React.FC<{
+  source: Source;
+  priority: number;
+  canMoveUp: boolean;
+  canMoveDown: boolean;
+  onMove: (delta: -1 | 1) => void;
+  onCommit: () => void;
+  onChanged: () => void;
+}> = ({ source, priority, canMoveUp, canMoveDown, onMove, onCommit, onChanged }) => {
   const controls = useDragControls();
   return (
     <Reorder.Item
@@ -29,6 +38,9 @@ const SourceReorderItem: React.FC<{ source: Source; priority: number; onCommit: 
         source={source}
         priority={priority}
         onDragHandlePointerDown={(e) => controls.start(e)}
+        canMoveUp={canMoveUp}
+        canMoveDown={canMoveDown}
+        onMove={onMove}
         onChanged={onChanged}
       />
     </Reorder.Item>
@@ -41,19 +53,35 @@ export const SourcesCard: React.FC<{
   onReorderPreview: (orderedIds: string[]) => void;
   /** Fires on drag end — persist the current order. */
   onReorderCommit: () => void;
+  /** Preview + persist an explicit order (the row menu's one-step reorder). */
+  onReorderTo: (orderedIds: string[]) => void;
   onConnectClaude: () => void;
   onConnectChatGPT: () => void;
   onAddApiKey: () => void;
   /** Re-fetch after a per-row action (rename / re-discover / delete). */
   onSourceChanged: () => void;
-}> = ({ sources, onReorderPreview, onReorderCommit, onConnectClaude, onConnectChatGPT, onAddApiKey, onSourceChanged }) => {
+}> = ({
+  sources,
+  onReorderPreview,
+  onReorderCommit,
+  onReorderTo,
+  onConnectClaude,
+  onConnectChatGPT,
+  onAddApiKey,
+  onSourceChanged,
+}) => {
   const { t } = useTranslation();
   const ids = sources.map((s) => s.id);
+
+  const moveByOneStep = (index: number, delta: -1 | 1) => {
+    const next = movedOrder(ids, index, delta);
+    onReorderTo(next);
+  };
 
   return (
     // Not overflow-hidden: the row supply tooltip must escape the card bounds.
     <section className="rounded-xl border border-border bg-background">
-      <div className="flex items-start justify-between gap-4 border-b border-border px-4 py-4 sm:px-5">
+      <div className="flex flex-col gap-2.5 border-b border-border px-4 py-4 sm:flex-row sm:items-start sm:justify-between sm:gap-4 sm:px-5">
         <div className="flex min-w-0 flex-col gap-1">
           <h2 className="text-[15px] font-semibold text-foreground">{t('settings.models.sources.title')}</h2>
           <p className="text-[12px] leading-relaxed text-muted">{t('settings.models.sources.subtitle')}</p>
@@ -70,7 +98,16 @@ export const SourcesCard: React.FC<{
       ) : (
         <Reorder.Group axis="y" values={ids} onReorder={onReorderPreview} className="flex flex-col">
           {sources.map((source, index) => (
-            <SourceReorderItem key={source.id} source={source} priority={index + 1} onCommit={onReorderCommit} onChanged={onSourceChanged} />
+            <SourceReorderItem
+              key={source.id}
+              source={source}
+              priority={index + 1}
+              canMoveUp={index > 0}
+              canMoveDown={index < sources.length - 1}
+              onMove={(delta) => moveByOneStep(index, delta)}
+              onCommit={onReorderCommit}
+              onChanged={onSourceChanged}
+            />
           ))}
         </Reorder.Group>
       )}

--- a/ui/src/components/settings/models/chips.tsx
+++ b/ui/src/components/settings/models/chips.tsx
@@ -19,7 +19,17 @@ export const Dot: React.FC<{ accent: Accent; className?: string }> = ({ accent, 
 );
 
 /**
- * 包月 / 按量 $ — fixed-width so the column aligns down the source list.
+ * Source-row chip metrics. On phones the row's second tier has to fit billing +
+ * state + usage on ONE line (design.pen M01 m01SrcL2), so the chips shrink to
+ * content-width pills — the desktop frame's fixed-width columns are what made
+ * that line overflow. From sm+ the fixed widths come back so the chip columns
+ * still align down the list, which is the whole point of them on a wide screen.
+ */
+const CHIP_MOBILE = 'rounded-full py-1';
+const BILLING_CHIP = cn(CHIP_MOBILE, 'font-medium sm:w-16 sm:justify-center');
+
+/**
+ * 包月 / 按量 $ — content-width on phones, fixed-width column on sm+.
  *
  * The metered symbol tracks the source's REPORTED currency (USD when absent).
  * A static `$` contradicted the usage cell for a source that genuinely reports
@@ -34,14 +44,14 @@ export const BillingChip: React.FC<{ billing: 'monthly' | 'metered'; currency?: 
   const { t } = useTranslation();
   if (billing === 'monthly') {
     return (
-      <Badge variant="secondary" className="w-16 justify-center rounded-md py-1 font-medium">
+      <Badge variant="secondary" className={cn(BILLING_CHIP, 'sm:rounded-md')}>
         {t('settings.models.billing.monthly')}
       </Badge>
     );
   }
   const symbol = currencySymbol(currency);
   return (
-    <Badge variant="warning" className="w-16 justify-center rounded-md py-1 font-medium">
+    <Badge variant="warning" className={cn(BILLING_CHIP, 'sm:rounded-md')}>
       {symbol
         ? t('settings.models.billing.meteredWithSymbol', { symbol })
         : t('settings.models.billing.metered')}
@@ -52,7 +62,7 @@ export const BillingChip: React.FC<{ billing: 'monthly' | 'metered'; currency?: 
 /** 使用中 / 备用 / 暂不可用 / 不可用 — fixed-width aligned column. */
 export const StateChip: React.FC<{ state: SourceState }> = ({ state }) => {
   const { t } = useTranslation();
-  const base = 'w-[86px] justify-center rounded-full py-1';
+  const base = cn(CHIP_MOBILE, 'sm:w-[86px] sm:justify-center');
   switch (state.status) {
     case 'active':
       return (

--- a/ui/src/components/settings/models/menus/MenuDrawer.tsx
+++ b/ui/src/components/settings/models/menus/MenuDrawer.tsx
@@ -1,15 +1,34 @@
-// Shared right-side sheet shell for the 模型菜单 drawers (frames 04 / 05r).
+// Shared sheet shell for the 模型菜单 drawers (frames 04 / 05r).
 // Built directly on the Radix dialog primitive (already a dependency) rather
-// than the centered `ui/dialog` Dialog, because these surfaces slide in from
-// the right edge and run full-height. Header (tinted icon tile + title +
-// subtitle + close), a scrollable body, and a sticky footer action bar.
+// than the centered `ui/dialog` Dialog, because these surfaces need a custom
+// header (tinted icon tile + title + subtitle + close), a scrollable body, and a
+// sticky footer action bar.
+//
+// Desktop: slides in from the right edge, full height. Phones: a bottom sheet at
+// ~91dvh (design.pen M03 m03Sheet, 730 of an 800 tall frame) — a right-edge
+// drawer on a phone is a full-screen takeover that hides where you came from,
+// and the sheet keeps the page visible behind it.
+//
+// The breakpoint is a JS branch rather than responsive classes because the two
+// shapes need opposite enter animations: `slide-in-from-bottom` and
+// `sm:slide-in-from-right` both apply at sm+, which slides the drawer in
+// diagonally. Picking one class set is clearer than zeroing the other axis.
 import * as React from 'react';
 import * as DialogPrimitive from '@radix-ui/react-dialog';
 import { X } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
 import { cn } from '@/lib/utils';
+import { useIsMobile } from '@/lib/useIsMobile';
 import { ACCENT_ICON, ACCENT_TILE, type Accent } from '../vendorMeta';
+
+const SHEET =
+  'inset-x-0 bottom-0 h-[91dvh] rounded-t-2xl border-t border-border ' +
+  'data-[state=open]:slide-in-from-bottom data-[state=closed]:slide-out-to-bottom';
+
+const DRAWER =
+  'inset-y-0 right-0 w-full max-w-[620px] border-l border-border ' +
+  'data-[state=open]:slide-in-from-right data-[state=closed]:slide-out-to-right';
 
 export const MenuDrawer: React.FC<{
   open: boolean;
@@ -23,43 +42,63 @@ export const MenuDrawer: React.FC<{
   children: React.ReactNode;
 }> = ({ open, onClose, Icon, accent, title, subtitle, footer, children }) => {
   const { t } = useTranslation();
+  const isMobile = useIsMobile();
+  const contentRef = React.useRef<HTMLDivElement>(null);
   return (
-  <DialogPrimitive.Root open={open} onOpenChange={(v) => !v && onClose()}>
-    <DialogPrimitive.Portal>
-      <DialogPrimitive.Overlay className="fixed inset-0 z-50 bg-background/70 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0" />
-      <DialogPrimitive.Content
-        className={cn(
-          'fixed inset-y-0 right-0 z-50 flex w-full max-w-[620px] flex-col border-l border-border bg-card shadow-2xl outline-none',
-          'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=open]:slide-in-from-right data-[state=closed]:slide-out-to-right data-[state=open]:duration-300 data-[state=closed]:duration-200',
-        )}
-      >
-        {/* On phones the drawer is the whole screen, so it carries the safe-area
-            insets itself and tightens its gutters from 24px to 16px. */}
-        <header className="flex items-start gap-3 border-b border-border px-4 py-4 pt-[calc(1rem+env(safe-area-inset-top))] sm:px-6 sm:py-5 sm:pt-5">
-          <span className={cn('flex size-11 shrink-0 items-center justify-center rounded-[12px]', ACCENT_TILE[accent])}>
-            <Icon size={22} className={ACCENT_ICON[accent]} />
-          </span>
-          <div className="flex min-w-0 flex-1 flex-col gap-1 pt-0.5">
-            <DialogPrimitive.Title className="text-[18px] font-bold leading-tight text-foreground">
-              {title}
-            </DialogPrimitive.Title>
-            <DialogPrimitive.Description className="text-[13px] leading-relaxed text-muted">
-              {subtitle}
-            </DialogPrimitive.Description>
-          </div>
-          <DialogPrimitive.Close className="flex size-10 shrink-0 items-center justify-center rounded-md text-muted opacity-70 transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring sm:size-7">
-            <X className="size-5" />
-            <span className="sr-only">{t('common.close')}</span>
-          </DialogPrimitive.Close>
-        </header>
+    <DialogPrimitive.Root open={open} onOpenChange={(v) => !v && onClose()}>
+      <DialogPrimitive.Portal>
+        <DialogPrimitive.Overlay className="fixed inset-0 z-50 bg-background/70 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0" />
+        <DialogPrimitive.Content
+          ref={contentRef}
+          // Without this Radix focuses the first tabbable child — the close X —
+          // so opening the menu paints a focus ring on the one control that
+          // throws the work away. Focus the panel instead; Tab / Escape and the
+          // focus trap are unaffected.
+          onOpenAutoFocus={(e) => {
+            e.preventDefault();
+            contentRef.current?.focus();
+          }}
+          tabIndex={-1}
+          className={cn(
+            'fixed z-50 flex flex-col bg-card shadow-2xl outline-none',
+            'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=open]:duration-300 data-[state=closed]:duration-200',
+            isMobile ? SHEET : DRAWER,
+          )}
+        >
+          {isMobile && <div className="mx-auto mt-2.5 h-1.5 w-10 shrink-0 rounded-full bg-border-strong" aria-hidden />}
 
-        <div className="flex-1 overflow-y-auto px-4 py-4 sm:px-6 sm:py-5">{children}</div>
+          {/* The desktop drawer runs to the top of the screen and carries the
+              safe-area inset itself; the sheet's top edge sits well below it. */}
+          <header
+            className={cn(
+              'flex items-start gap-3 border-b border-border px-4 py-4 sm:px-6 sm:py-5',
+              !isMobile && 'pt-[calc(1rem+env(safe-area-inset-top))] sm:pt-5',
+            )}
+          >
+            <span className={cn('flex size-10 shrink-0 items-center justify-center rounded-[12px] sm:size-11', ACCENT_TILE[accent])}>
+              <Icon size={isMobile ? 20 : 22} className={ACCENT_ICON[accent]} />
+            </span>
+            <div className="flex min-w-0 flex-1 flex-col gap-1 pt-0.5">
+              <DialogPrimitive.Title className="text-[16px] font-bold leading-tight text-foreground sm:text-[18px]">
+                {title}
+              </DialogPrimitive.Title>
+              <DialogPrimitive.Description className="text-[12px] leading-relaxed text-muted sm:text-[13px]">
+                {subtitle}
+              </DialogPrimitive.Description>
+            </div>
+            <DialogPrimitive.Close className="flex size-10 shrink-0 items-center justify-center rounded-md text-muted opacity-70 transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring sm:size-7">
+              <X className="size-5" />
+              <span className="sr-only">{t('common.close')}</span>
+            </DialogPrimitive.Close>
+          </header>
 
-        <footer className="flex items-center justify-between gap-3 border-t border-border bg-surface/40 px-4 py-3 pb-[calc(0.75rem+env(safe-area-inset-bottom))] sm:px-6 sm:py-4 sm:pb-4">
-          {footer}
-        </footer>
-      </DialogPrimitive.Content>
-    </DialogPrimitive.Portal>
-  </DialogPrimitive.Root>
+          <div className="flex-1 overflow-y-auto px-4 py-4 sm:px-6 sm:py-5">{children}</div>
+
+          <footer className="flex items-center justify-between gap-3 border-t border-border bg-surface/40 px-4 py-3 pb-[calc(0.75rem+env(safe-area-inset-bottom))] sm:px-6 sm:py-4 sm:pb-4">
+            {footer}
+          </footer>
+        </DialogPrimitive.Content>
+      </DialogPrimitive.Portal>
+    </DialogPrimitive.Root>
   );
 };

--- a/ui/src/components/settings/models/reorder.test.ts
+++ b/ui/src/components/settings/models/reorder.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+
+import { movedOrder } from './reorder';
+
+const IDS = ['a', 'b', 'c', 'd'];
+
+describe('movedOrder', () => {
+  it('swaps with the previous entry when moving up', () => {
+    expect(movedOrder(IDS, 2, -1)).toEqual(['a', 'c', 'b', 'd']);
+  });
+
+  it('swaps with the next entry when moving down', () => {
+    expect(movedOrder(IDS, 0, 1)).toEqual(['b', 'a', 'c', 'd']);
+  });
+
+  it('is a no-op at either end rather than dropping or duplicating an id', () => {
+    expect(movedOrder(IDS, 0, -1)).toEqual(IDS);
+    expect(movedOrder(IDS, 3, 1)).toEqual(IDS);
+  });
+
+  it('is a no-op for an out-of-range index', () => {
+    expect(movedOrder(IDS, -1, 1)).toEqual(IDS);
+    expect(movedOrder(IDS, 9, -1)).toEqual(IDS);
+  });
+
+  it('never mutates the input and always preserves the id multiset', () => {
+    const input = [...IDS];
+    for (let i = 0; i < input.length; i++) {
+      for (const d of [-1, 1]) {
+        const out = movedOrder(input, i, d);
+        expect(input).toEqual(IDS);
+        expect([...out].sort()).toEqual([...IDS].sort());
+        expect(out.length).toBe(IDS.length);
+      }
+    }
+  });
+
+  it('round-trips: moving down then back up restores the original order', () => {
+    const down = movedOrder(IDS, 1, 1);
+    expect(movedOrder(down, 2, -1)).toEqual(IDS);
+  });
+});

--- a/ui/src/components/settings/models/reorder.ts
+++ b/ui/src/components/settings/models/reorder.ts
@@ -1,0 +1,22 @@
+/**
+ * Priority reordering for the 来源 list.
+ *
+ * Kept as a pure function so the one-step reorder behind the row menu's
+ * 上移一位 / 下移一位 is testable without a DOM: the list order IS the spend
+ * order, so an off-by-one here silently changes which account gets billed first.
+ */
+
+/**
+ * The id order after moving `index` by `delta` positions.
+ *
+ * Returns the input order unchanged when the move would fall off either end, so
+ * callers can hand the result straight to the persist path without a second
+ * bounds check — a no-op move persists a no-op.
+ */
+export function movedOrder(ids: readonly string[], index: number, delta: number): string[] {
+  const target = index + delta;
+  if (index < 0 || index >= ids.length || target < 0 || target >= ids.length) return [...ids];
+  const next = [...ids];
+  [next[index], next[target]] = [next[target], next[index]];
+  return next;
+}

--- a/ui/src/components/ui/responsive-menu.tsx
+++ b/ui/src/components/ui/responsive-menu.tsx
@@ -1,0 +1,122 @@
+// A menu that keeps its desktop shape and changes its *presentation* on phones:
+// an anchored popover at md+, a bottom sheet below it.
+//
+// Why a JS breakpoint rather than responsive classes: a popover is positioned by
+// Radix at runtime against its trigger, so no amount of CSS can turn it into a
+// bottom-anchored sheet — the content has to mount under a different primitive.
+// Everything else here (padding, radius, safe-area) is plain Tailwind.
+//
+// The sheet owns the affordances a touch menu needs and a popover doesn't: a
+// grabber, an optional identity header, and an explicit 取消 row (a phone user
+// can't "click outside" as reliably as they can hit a button).
+import * as React from 'react';
+import * as DialogPrimitive from '@radix-ui/react-dialog';
+import { useTranslation } from 'react-i18next';
+
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { cn } from '@/lib/utils';
+import { useIsMobile } from '@/lib/useIsMobile';
+
+export const ResponsiveMenu: React.FC<{
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Opens the menu on both breakpoints; rendered via `asChild`. */
+  trigger: React.ReactNode;
+  /**
+   * The sheet's accessible name (Radix requires one). Also rendered as the
+   * visible heading unless `sheetTitleVisible` is false — pass false when
+   * `sheetHeader` already carries the surface's identity.
+   */
+  sheetTitle: string;
+  sheetTitleVisible?: boolean;
+  sheetDescription?: string;
+  /** Sheet-only header block rendered above the items (e.g. the row's identity). */
+  sheetHeader?: React.ReactNode;
+  /** Popover-only sizing/appearance. */
+  className?: string;
+  align?: 'start' | 'center' | 'end';
+  sideOffset?: number;
+  children: React.ReactNode;
+}> = ({
+  open,
+  onOpenChange,
+  trigger,
+  sheetTitle,
+  sheetTitleVisible = true,
+  sheetDescription,
+  sheetHeader,
+  className,
+  align = 'end',
+  sideOffset = 6,
+  children,
+}) => {
+  const { t } = useTranslation();
+  const isMobile = useIsMobile();
+  const contentRef = React.useRef<HTMLDivElement>(null);
+
+  if (!isMobile) {
+    return (
+      <Popover open={open} onOpenChange={onOpenChange}>
+        <PopoverTrigger asChild>{trigger}</PopoverTrigger>
+        <PopoverContent
+          align={align}
+          sideOffset={sideOffset}
+          className={cn('border-border bg-card p-1.5 text-foreground shadow-lg', className)}
+        >
+          {children}
+        </PopoverContent>
+      </Popover>
+    );
+  }
+
+  return (
+    <DialogPrimitive.Root open={open} onOpenChange={onOpenChange}>
+      <DialogPrimitive.Trigger asChild>{trigger}</DialogPrimitive.Trigger>
+      <DialogPrimitive.Portal>
+        <DialogPrimitive.Overlay className="fixed inset-0 z-50 bg-background/70 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0" />
+        <DialogPrimitive.Content
+          ref={contentRef}
+          // Radix focuses the first item on open, which paints a focus ring on
+          // 重命名 for someone who just tapped 「…」. Focus the panel itself
+          // instead: no ring, and Tab / Escape / the focus trap still work.
+          onOpenAutoFocus={(e) => {
+            e.preventDefault();
+            contentRef.current?.focus();
+          }}
+          tabIndex={-1}
+          className={cn(
+            'fixed inset-x-0 bottom-0 z-50 flex max-h-[88dvh] flex-col rounded-t-2xl border-t border-border bg-card pb-[env(safe-area-inset-bottom)] shadow-2xl outline-none',
+            'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=open]:slide-in-from-bottom data-[state=closed]:slide-out-to-bottom data-[state=open]:duration-300 data-[state=closed]:duration-200',
+          )}
+        >
+          <div className="mx-auto mt-2.5 h-1.5 w-10 shrink-0 rounded-full bg-border-strong" aria-hidden />
+
+          {sheetTitleVisible ? (
+            <div className={cn('flex flex-col gap-1 px-4 pt-3', sheetHeader ? 'pb-2' : 'pb-3')}>
+              <DialogPrimitive.Title className="text-[16px] font-bold leading-tight text-foreground">
+                {sheetTitle}
+              </DialogPrimitive.Title>
+              {sheetDescription && (
+                <DialogPrimitive.Description className="text-[12px] leading-relaxed text-muted">
+                  {sheetDescription}
+                </DialogPrimitive.Description>
+              )}
+            </div>
+          ) : (
+            <DialogPrimitive.Title className="sr-only">{sheetTitle}</DialogPrimitive.Title>
+          )}
+
+          {sheetHeader}
+
+          <div className="flex min-h-0 flex-1 flex-col overflow-y-auto border-t border-border">{children}</div>
+
+          <div className="shrink-0 px-4 pb-4 pt-3">
+            <DialogPrimitive.Close className="flex h-12 w-full items-center justify-center rounded-xl border border-border bg-surface text-[14px] font-semibold text-foreground transition-colors hover:bg-surface-2">
+              {t('common.cancel')}
+            </DialogPrimitive.Close>
+          </div>
+        </DialogPrimitive.Content>
+      </DialogPrimitive.Portal>
+    </DialogPrimitive.Root>
+  );
+};

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -664,7 +664,8 @@
         "modelCount": "{{count}} models",
         "multiSource": "Multiple sources",
         "multiSourceCustom": "Multiple sources · {{count}} custom",
-        "hubNoSupply": "On Hub · no source available yet (using Direct)"
+        "hubNoSupply": "On Hub · no source available yet (using Direct)",
+        "directNote": "Still supplied by the CLI's own config — not connected to the Hub"
       },
       "recent": {
         "title": "Recent switches",
@@ -691,6 +692,16 @@
         "apiKey": {
           "title": "Add API Key…",
           "subtitle": "Any vendor or compatible service, editable URL"
+        },
+        "sheetTitle": "Add source",
+        "sheetSubtitle": "There are only two kinds: a subscription account, or a key. A relay is just a key with a different URL.",
+        "vendorTitle": "Connect a subscription",
+        "vendorSubtitle": "Uses the CLI's own sign-in; the credential stays on this machine.",
+        "apiKeySheetSubtitle": "Official or third-party URLs both work; filling in a custom URL makes it a relay.",
+        "subscription": {
+          "title": "Subscription account",
+          "subtitle": "Claude Pro, ChatGPT Plus and the like. Uses the CLI's own sign-in; the credential stays in the local CLI.",
+          "recommended": "Recommended"
         }
       },
       "addKey": {
@@ -895,7 +906,17 @@
         "deleteForceBody": "“{{name}}” is the only supplier of a selected model; deleting it leaves that agent with no source. Force delete?",
         "deleteForceConfirm": "Force delete",
         "deleted": "Source deleted",
-        "deleteFailed": "Couldn't delete, please retry"
+        "deleteFailed": "Couldn't delete, please retry",
+        "priorityLabel": "Priority {{position}}",
+        "renameHint": "Changes the display name only — the credential is untouched",
+        "rediscoverHint": "Re-fetch the models this source can supply",
+        "moveUp": "Move up one",
+        "moveUpHint": "Gets used earlier",
+        "moveUpHintAtTop": "Already first — can't move up",
+        "moveDown": "Move down one",
+        "moveDownHint": "Gets used later",
+        "moveDownHintAtBottom": "Already last — can't move down",
+        "deleteHint": "You'll be asked to confirm first"
       },
       "migrationBanner": {
         "title": "Native configs ready to import",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -664,7 +664,8 @@
         "modelCount": "{{count}} 个模型",
         "multiSource": "多来源",
         "multiSourceCustom": "多来源 · 含 {{count}} 个自定义",
-        "hubNoSupply": "已接入中枢 · 暂无可用来源（当前走直连）"
+        "hubNoSupply": "已接入中枢 · 暂无可用来源（当前走直连）",
+        "directNote": "仍在用 CLI 原生配置供给，未接入中枢"
       },
       "recent": {
         "title": "最近切换",
@@ -691,6 +692,16 @@
         "apiKey": {
           "title": "添加 API Key…",
           "subtitle": "任何厂商或兼容服务，可改地址"
+        },
+        "sheetTitle": "添加来源",
+        "sheetSubtitle": "来源只有两类：订阅账号，或一把 Key。中转站 = 改了地址的 Key。",
+        "vendorTitle": "连接订阅账号",
+        "vendorSubtitle": "走 CLI 原生登录，凭证留在本机。",
+        "apiKeySheetSubtitle": "官方或第三方地址都行；填了自定义地址就是「中转站」。",
+        "subscription": {
+          "title": "订阅账号",
+          "subtitle": "Claude Pro / ChatGPT Plus 等。走 CLI 原生登录，凭证留在本机 CLI 里。",
+          "recommended": "推荐"
         }
       },
       "addKey": {
@@ -895,7 +906,17 @@
         "deleteForceBody": "「{{name}}」是某个已选模型的唯一供给，删除后相关 Agent 将无来源可用。确认强制删除？",
         "deleteForceConfirm": "强制删除",
         "deleted": "已删除来源",
-        "deleteFailed": "删除失败，请重试"
+        "deleteFailed": "删除失败，请重试",
+        "priorityLabel": "优先级 {{position}}",
+        "renameHint": "只改显示名，不动凭证",
+        "rediscoverHint": "重新拉取这个来源能供给的模型",
+        "moveUp": "上移一位",
+        "moveUpHint": "更早被使用",
+        "moveUpHintAtTop": "已在第 1 位，不能再上移",
+        "moveDown": "下移一位",
+        "moveDownHint": "更晚被使用",
+        "moveDownHintAtBottom": "已在最后一位，不能再下移",
+        "deleteHint": "删除前会再确认一次"
       },
       "migrationBanner": {
         "title": "发现可导入中枢的原生配置",

--- a/ui/src/lib/useIsMobile.ts
+++ b/ui/src/lib/useIsMobile.ts
@@ -1,0 +1,31 @@
+import * as React from 'react';
+
+// The phone breakpoint used across the app (Tailwind `md`), matching the
+// `max-md:` bottom-sheet styling in ui/dialog.tsx so a sheet and a dialog never
+// disagree about which side of the breakpoint they're on.
+const PHONE_QUERY = '(max-width: 767px)';
+
+/**
+ * True while the viewport is phone-sized.
+ *
+ * Only for surfaces whose *structure* differs per breakpoint — an anchored
+ * popover becoming a bottom sheet, say, where CSS alone can't re-parent the
+ * content. Prefer Tailwind responsive classes for anything that is purely
+ * visual; they need no JS and can't flash the wrong layout on first paint.
+ */
+export function useIsMobile(): boolean {
+  const [isMobile, setIsMobile] = React.useState(
+    () => typeof window !== 'undefined' && typeof window.matchMedia === 'function' && window.matchMedia(PHONE_QUERY).matches,
+  );
+
+  React.useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return;
+    const mql = window.matchMedia(PHONE_QUERY);
+    const sync = () => setIsMobile(mql.matches);
+    sync();
+    mql.addEventListener('change', sync);
+    return () => mql.removeEventListener('change', sync);
+  }, []);
+
+  return isMobile;
+}


### PR DESCRIPTION
## Capability

**设置 · 模型 (Model Hub) — mobile layout alignment (M2).** Second phone pass,
aligning the layout with `design.pen` frames **产品改造 M01–M04**. Scope is
`ui/src/components/settings/models/**` + two i18n files + two new shared UI
files; **no backend, contract, or workflow changes.**

The sm+ (desktop) layout is deliberately unchanged — see the regression evidence
below, which is the main risk this PR carries.

## What changed

| # | Change | Design source |
| - | ------ | ------------- |
| 1 | Row menu `…` moves to the end of the identity line; the second line drops the 40px button slot and the 88px inset (now 26px) | `M01 m01More` / `m01SrcL2` |
| 2 | `添加来源` is a full-width mint-soft button on its own line; header stacks | `M01 m01SrcHead` / `m01AddBtn` |
| 3 | Agent card is three full-width tiers; a Direct backend states `仍在用 CLI 原生配置供给，未接入中枢` | `M01 m01Ag*` |
| 4 | Billing · state · usage fit **one** second line (chips become content-width pills on phones, fixed-width columns from sm+) | `M01 m01SrcL2` |
| 5 | Row action menu + `添加来源` present as bottom sheets; `模型菜单` drawers become ~91dvh sheets with a sticky footer | `M02 m02SheetA`, `M03 m03Sheet`, `M04 m04Sheet` |
| 6 | Recent switches stack the timestamp above the sentence on phones | `M01 m01Ev` |
| 7 | Row menu gains `上移一位` / `下移一位` (a11y path; drag stays primary) | `M02` left panel |

Two new shared files, both because CSS alone could not do the job:

- `ui/src/lib/useIsMobile.ts` — the repo's 768px phone breakpoint as a hook (the
  same query `App.tsx` / `WindowManagerContext` already use).
- `ui/src/components/ui/responsive-menu.tsx` — anchored popover at md+, bottom
  sheet below. A Radix popover is positioned at runtime against its trigger, so
  it cannot become a bottom-anchored sheet by class alone; the content has to
  mount under a different primitive.

## Decisions worth flagging to the reviewer

1. **`排序` button is intentionally absent.** The brief said "put 上移/下移 only in
   the existing row panel, add no visible button column", but also "the header
   row keeps only `排序`". Those cannot both hold: master has no sort mode, so a
   `排序` button would open nothing. Implemented the first (row-panel actions, no
   ↑↓ column); the header is title + full-width `添加来源`. If the sort mode from
   `M02` right is wanted, that is an additive follow-up.
2. **`添加来源` is a two-step chooser on phones only** (订阅账号 / API Key → vendor),
   per `M04`; desktop keeps the flat three-entry popover from frame 07.
3. **Menu button is 36×36 as specced, inside a 44×44 touch target.** The design's
   36px is below the 40px floor set in #1003, so the drawn box is 36 and negative
   margins cancel the extra 8px — visual position and row height are unchanged.
4. **Second line is inset 26px (the design number), not aligned under the
   priority number.** The design derives 26 from a 16px grip; our handle is a
   40px touch target, so exact alignment would need 50px and cost 24px of the
   line we were trying to fit on one row.
5. `接入中枢` stays `variant="brand"` (solid) though `M01` draws it mint-soft, to
   avoid diverging from desktop. One-line change if you want the soft treatment.
6. The authorize **link** is one-tap copyable; the **auth code** field is a paste
   *target* (user pastes in), so "copyable" does not apply to it.

## Evidence

**Unit** — new `reorder.test.ts` (6 cases) pins the one-step reorder: swap up /
down, no-op at both ends, no-op out of range, never mutates input, always
preserves the id multiset, and round-trips. Existing `format.test.ts` still
passes (16 tests total).

**Contract** — none touched. The row menu's reorder reuses the existing
`PUT /priority` path (scenario **MH-PRI-001**) as a second UI entry point; the
request payload and semantics are unchanged.

**Manual / rendered** — driven in a real browser against the mock fixtures, which
(unlike the Incus fixtures, all `usage: null` + "no migratable config") actually
render every branch: usage bar, month spend, cooldown, hub/direct agents,
migration banner. Machine-checked, not eyeballed:

- **360 / 390 / 430, zh *and* en**: zero horizontal overflow, zero clipped boxes,
  all five rows' second line single-line (`height 27`), one menu instance per row,
  44×44 hit area confirmed by `elementFromPoint` 20px outside the visual box.
- **Cross-assertion** (the failure mode from the last round): the billing chip's
  currency symbol is asserted equal to the symbol in the spend amount per row —
  `按量 $` beside `$12.4`, never `¥12.4`. Passes at every width, both locales.
- **Reorder cross-assertion**: after tapping `下移一位`, the rendered order and a
  *fresh re-read of the API* are compared and match. This has teeth — committing
  from the render-time mirror ref instead of an explicit order would persist the
  pre-move order and fail here.
- **Desktop 1280 regression**: rendered geometry diffed against `master` (same
  harness, changes stashed). Found and fixed a real **4px** rightward shift of
  every chip column — moving the menu out of the metric strip replaced its
  `gap-4` with the row's `gap-3`; `sm:ml-1` restores it. Post-fix, desktop
  matches master exactly: identity 766, usage 839×150, billing 1005×64, state
  1085×86, menu 1187×32, gap-before-menu 16, row height 72.

**Gates** — `npm run build` (`tsc -b && vite build`, the CI UI gate) passes;
`eslint` clean on every file this PR touches (the 11 remaining errors are
pre-existing on master in `AddApiKeyDialog.tsx` / `modelsApi.ts` /
`vendorMeta.tsx`, untouched here). `ui/package-lock.json` deliberately **not**
committed — regenerating it on macOS prunes Linux platform entries (#682).

**Residual, not covered here**: real-device touch (drag vs scroll feel), dark
theme at phone widths, and the live `/api/models/*` path — the rendered checks
above ran against mock fixtures by design, since the Incus fixtures cannot
exercise these branches.
