### PR TITLE
fix(workbench): preserve session row density

### DIFF
--- a/ui/src/components/workbench/ProjectsPage.tsx
+++ b/ui/src/components/workbench/ProjectsPage.tsx
@@ -35,6 +35,7 @@ import { ArchiveSessionDialog } from './ArchiveSessionDialog';
 import { NewProjectDialog } from './NewProjectDialog';
 import { ProjectAgentsMdDialog } from './ProjectAgentsMdDialog';
 import { ProjectSettingsDialog } from './ProjectSettingsDialog';
+import { SessionPinIndicator } from './SessionPinAction';
 
 const DOT: Record<string, string> = {
   running: 'bg-mint shadow-[0_0_7px_rgba(91,255,160,0.9)]',
@@ -324,6 +325,7 @@ const MobileSessionRow: React.FC<{
         <span className="min-w-0 flex-1 truncate text-[13px] font-medium">
           {session.title || `#${session.id.slice(-6)}`}
         </span>
+        <SessionPinIndicator pinned={session.pinned} label={t('workbench.sessionPinned')} />
         {unread > 0 ? (
           <span className="shrink-0 rounded-full bg-mint px-1.5 py-0.5 font-mono text-[10px] font-bold text-background">
             {unread > 99 ? '99+' : unread}

--- a/ui/src/components/workbench/SessionPinAction.test.tsx
+++ b/ui/src/components/workbench/SessionPinAction.test.tsx
@@ -1,7 +1,7 @@
 import { renderToStaticMarkup } from 'react-dom/server';
 import { describe, expect, it } from 'vitest';
 
-import { SessionPinAction } from './SessionPinAction';
+import { SessionPinAction, SessionPinIndicator } from './SessionPinAction';
 
 const renderAction = (pinned: boolean, pending = false) =>
   renderToStaticMarkup(
@@ -15,6 +15,13 @@ const renderAction = (pinned: boolean, pending = false) =>
   );
 
 describe('SessionPinAction', () => {
+  it('keeps the 24px action target out of the session row layout', () => {
+    const html = renderAction(false);
+
+    expect(html).toContain('absolute inset-y-0 right-2 flex items-center');
+    expect(html).toContain('grid size-6');
+  });
+
   it('reveals an unpinned action on row hover, keyboard focus, and coarse pointers', () => {
     const html = renderAction(false);
 
@@ -41,5 +48,22 @@ describe('SessionPinAction', () => {
     expect(html).toContain('disabled=""');
     expect(html).toContain('animate-spin');
     expect(html).toContain('cursor-wait');
+  });
+});
+
+describe('SessionPinIndicator', () => {
+  it('renders no passive status for an unpinned session', () => {
+    const html = renderToStaticMarkup(<SessionPinIndicator pinned={false} label="Pinned" />);
+
+    expect(html).toBe('');
+  });
+
+  it('renders a non-interactive status icon for a pinned session', () => {
+    const html = renderToStaticMarkup(<SessionPinIndicator pinned label="Pinned" />);
+
+    expect(html).toContain('role="img"');
+    expect(html).toContain('aria-label="Pinned"');
+    expect(html).toContain('text-cyan');
+    expect(html).not.toContain('<button');
   });
 });

--- a/ui/src/components/workbench/SessionPinAction.tsx
+++ b/ui/src/components/workbench/SessionPinAction.tsx
@@ -11,6 +11,27 @@ interface SessionPinActionProps {
   className?: string;
 }
 
+interface SessionPinIndicatorProps {
+  pinned: boolean;
+  label: string;
+  className?: string;
+}
+
+export const SessionPinIndicator: React.FC<SessionPinIndicatorProps> = ({ pinned, label, className }) => {
+  if (!pinned) return null;
+
+  return (
+    <span
+      role="img"
+      aria-label={label}
+      title={label}
+      className={clsx('flex shrink-0 text-cyan', className)}
+    >
+      <Pin className="size-3" aria-hidden="true" />
+    </span>
+  );
+};
+
 export const SessionPinAction: React.FC<SessionPinActionProps> = ({
   pinned,
   pending,
@@ -26,32 +47,33 @@ export const SessionPinAction: React.FC<SessionPinActionProps> = ({
   };
 
   return (
-    <button
-      type="button"
-      disabled={pending}
-      aria-label={label}
-      aria-pressed={pinned}
-      title={label}
-      onClick={handleClick}
-      className={clsx(
-        'group/pin grid size-6 shrink-0 place-items-center rounded-md transition-[opacity,transform,background-color,color,box-shadow] duration-150 ease-out',
-        'hover:-translate-y-px hover:scale-105 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-cyan/60 motion-reduce:transform-none',
-        pending
-          ? 'cursor-wait text-muted opacity-100 hover:translate-y-0 hover:scale-100'
-          : pinned
-            ? 'bg-cyan/[0.10] text-cyan opacity-100 hover:bg-cyan/[0.18] hover:ring-1 hover:ring-cyan/30'
-            : 'text-muted opacity-0 hover:bg-foreground/[0.08] hover:text-foreground group-hover/sess:opacity-100 group-focus-within/sess:opacity-100 pointer-coarse:opacity-100',
-        className,
-      )}
-    >
-      {pending ? (
-        <Loader2 className="size-3 animate-spin" aria-hidden="true" />
-      ) : (
-        <Pin
-          className="size-3 transition-transform duration-150 group-hover/pin:-rotate-12 group-hover/pin:scale-110 motion-reduce:transform-none"
-          aria-hidden="true"
-        />
-      )}
-    </button>
+    <span className={clsx('absolute inset-y-0 right-2 flex items-center', className)}>
+      <button
+        type="button"
+        disabled={pending}
+        aria-label={label}
+        aria-pressed={pinned}
+        title={label}
+        onClick={handleClick}
+        className={clsx(
+          'group/pin grid size-6 shrink-0 place-items-center rounded-md transition-[opacity,transform,background-color,color,box-shadow] duration-150 ease-out',
+          'hover:-translate-y-px hover:scale-105 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-cyan/60 motion-reduce:transform-none',
+          pending
+            ? 'cursor-wait text-muted opacity-100 hover:translate-y-0 hover:scale-100'
+            : pinned
+              ? 'bg-cyan/[0.10] text-cyan opacity-100 hover:bg-cyan/[0.18] hover:ring-1 hover:ring-cyan/30'
+              : 'text-muted opacity-0 hover:bg-foreground/[0.08] hover:text-foreground group-hover/sess:opacity-100 group-focus-within/sess:opacity-100 pointer-coarse:opacity-100',
+        )}
+      >
+        {pending ? (
+          <Loader2 className="size-3 animate-spin" aria-hidden="true" />
+        ) : (
+          <Pin
+            className="size-3 transition-transform duration-150 group-hover/pin:-rotate-12 group-hover/pin:scale-110 motion-reduce:transform-none"
+            aria-hidden="true"
+          />
+        )}
+      </button>
+    </span>
   );
 };

--- a/ui/src/components/workbench/WorkbenchSidebar.tsx
+++ b/ui/src/components/workbench/WorkbenchSidebar.tsx
@@ -312,7 +312,7 @@ const SessionRow: React.FC<{
             setMenuOpen(true);
           }}
           className={clsx(
-            'group/sess flex items-center gap-2 rounded-md py-1.5 pl-[26px] pr-2.5 text-left transition',
+            'group/sess relative flex items-center gap-2 rounded-md py-1.5 pl-[26px] pr-10 text-left transition',
             active
               ? 'border-l-2 border-mint bg-mint-soft pl-[24px] font-semibold text-foreground'
               : 'hover:bg-foreground/[0.04]',


### PR DESCRIPTION
## Capability

Preserve compact project session rows while keeping the desktop pin shortcut usable, and restore a passive pinned-state indicator on mobile without reintroducing a mobile pin shortcut.

## What changed

- position the 24px desktop pin action outside normal row layout so it no longer increases every session row's height
- reserve horizontal space for the overlaid action while retaining hover, focus, pending, pin, and unpin behavior
- render a non-interactive pinned indicator on mobile; pin and unpin remain in the overflow menu
- add regression coverage for the layout contract and passive mobile state indicator

## Scenarios

- Scenario catalog: no dedicated scenario IDs exist for project session pin presentation
- Desktop: pinned and unpinned rows remain 30px high; the 24px action stays centered with 3px inset and appears on hover
- Mobile: pinned rows show a passive indicator, unpinned rows do not, no inline pin button exists, and the overflow menu keeps Pin/Unpin first

## Evidence

- Unit: `npx vitest run` (56 files, 421 tests)
- Contract: focused `SessionPinAction` tests assert the action is out of normal layout and the mobile indicator is conditional and non-interactive
- Lint: targeted ESLint on all four changed UI files
- Build: production TypeScript/Vite build
- Scenario: headless Chrome against the existing local Incus master backend through the worktree Vite server at 1280x720 and 375x812
- Residual manual checks: browser console still reports the pre-existing `MobileTabBar` missing-key warning; no regression state was mutated

## Risk

Low. The change is presentation-only and does not alter pin persistence, ordering, or API behavior.
