### PR TITLE
fix(workbench): refine session pin affordance

### DIFF
--- a/ui/src/components/workbench/SessionPinAction.test.tsx
+++ b/ui/src/components/workbench/SessionPinAction.test.tsx
@@ -32,11 +32,12 @@ describe('SessionPinAction', () => {
     expect(html).toContain('pointer-coarse:opacity-100');
   });
 
-  it('keeps a pinned action visible and gives hover feedback', () => {
+  it('keeps a pinned action visible without a resting background and gives hover feedback', () => {
     const html = renderAction(true);
 
     expect(html).toContain('aria-pressed="true"');
     expect(html).toContain('opacity-100');
+    expect(html).not.toMatch(/(?:class="|\s)bg-[^\s"]+/);
     expect(html).toContain('hover:bg-cyan/[0.18]');
     expect(html).toContain('hover:scale-105');
     expect(html).toContain('group-hover/pin:-rotate-12');
@@ -64,6 +65,7 @@ describe('SessionPinIndicator', () => {
     expect(html).toContain('role="img"');
     expect(html).toContain('aria-label="Pinned"');
     expect(html).toContain('text-cyan');
+    expect(html).not.toMatch(/(?:class="|\s)bg-[^\s"]+/);
     expect(html).not.toContain('<button');
   });
 });

--- a/ui/src/components/workbench/SessionPinAction.test.tsx
+++ b/ui/src/components/workbench/SessionPinAction.test.tsx
@@ -2,6 +2,7 @@ import { renderToStaticMarkup } from 'react-dom/server';
 import { describe, expect, it } from 'vitest';
 
 import { SessionPinAction, SessionPinIndicator } from './SessionPinAction';
+import { sessionPinRowPaddingClass } from './sessionPinLayout';
 
 const renderAction = (pinned: boolean, pending = false) =>
   renderToStaticMarkup(
@@ -67,5 +68,20 @@ describe('SessionPinIndicator', () => {
     expect(html).toContain('text-cyan');
     expect(html).not.toMatch(/(?:class="|\s)bg-[^\s"]+/);
     expect(html).not.toContain('<button');
+  });
+});
+
+describe('sessionPinRowPaddingClass', () => {
+  it('uses the full title width until an unpinned action is revealed', () => {
+    const className = sessionPinRowPaddingClass(false);
+
+    expect(className).toContain('pr-2.5');
+    expect(className).toContain('hover:pr-10');
+    expect(className).toContain('focus-within:pr-10');
+    expect(className).toContain('pointer-coarse:pr-10');
+  });
+
+  it('always reserves action space for a pinned session', () => {
+    expect(sessionPinRowPaddingClass(true)).toBe('pr-10');
   });
 });

--- a/ui/src/components/workbench/SessionPinAction.tsx
+++ b/ui/src/components/workbench/SessionPinAction.tsx
@@ -61,7 +61,7 @@ export const SessionPinAction: React.FC<SessionPinActionProps> = ({
           pending
             ? 'cursor-wait text-muted opacity-100 hover:translate-y-0 hover:scale-100'
             : pinned
-              ? 'bg-cyan/[0.10] text-cyan opacity-100 hover:bg-cyan/[0.18] hover:ring-1 hover:ring-cyan/30'
+              ? 'text-cyan opacity-100 hover:bg-cyan/[0.18] hover:ring-1 hover:ring-cyan/30'
               : 'text-muted opacity-0 hover:bg-foreground/[0.08] hover:text-foreground group-hover/sess:opacity-100 group-focus-within/sess:opacity-100 pointer-coarse:opacity-100',
         )}
       >

--- a/ui/src/components/workbench/WorkbenchSidebar.tsx
+++ b/ui/src/components/workbench/WorkbenchSidebar.tsx
@@ -40,6 +40,7 @@ import { useApi } from '../../context/ApiContext';
 import type { InboxSession, WorkbenchProject, WorkbenchSession } from '../../context/ApiContext';
 import { useToast } from '../../context/ToastContext';
 import { SessionPinAction } from './SessionPinAction';
+import { sessionPinRowPaddingClass } from './sessionPinLayout';
 import { formatRelativeTime } from '../../lib/relativeTime';
 import { Popover, PopoverAnchor, PopoverContent, PopoverTrigger } from '../ui/popover';
 import { ArchiveSessionDialog } from './ArchiveSessionDialog';
@@ -312,7 +313,8 @@ const SessionRow: React.FC<{
             setMenuOpen(true);
           }}
           className={clsx(
-            'group/sess relative flex items-center gap-2 rounded-md py-1.5 pl-[26px] pr-10 text-left transition',
+            'group/sess relative flex items-center gap-2 rounded-md py-1.5 pl-[26px] text-left transition-[background-color,padding-right] duration-150 ease-out motion-reduce:transition-none',
+            sessionPinRowPaddingClass(session.pinned),
             active
               ? 'border-l-2 border-mint bg-mint-soft pl-[24px] font-semibold text-foreground'
               : 'hover:bg-foreground/[0.04]',

--- a/ui/src/components/workbench/sessionPinLayout.ts
+++ b/ui/src/components/workbench/sessionPinLayout.ts
@@ -1,0 +1,4 @@
+export const sessionPinRowPaddingClass = (pinned: boolean) =>
+  pinned
+    ? 'pr-10'
+    : 'pr-2.5 hover:pr-10 focus-within:pr-10 pointer-coarse:pr-10';


### PR DESCRIPTION
## Summary

- remove the persistent cyan background from pinned session actions
- keep the pinned icon visible and preserve hover/focus interaction feedback
- lock both interactive and passive pinned icons to background-free resting states
- let unpinned session titles use the full row width until hover or keyboard focus reveals the pin action

## Scenarios

- No catalog scenario IDs apply to this visual-only session list adjustment.

## Evidence

- Unit: `SessionPinAction.test.tsx` (8 tests passed)
- Contract: no API or persistence contract changed
- Scenario: no scenario harness change required
- Lint: targeted ESLint passed
- Build: production UI build passed
- Browser: desktop regression data showed 2 pinned actions with transparent resting backgrounds and hover feedback still present
- Browser: an unpinned title used 169px at rest and 139px on hover while right padding expanded from 10px to 40px; the session row stayed 30px tall

## Residual manual checks

- Existing unrelated `MobileTabBar` missing-key console warning remains unchanged.
