### PR TITLE
fix(cli): unify bounded collection pagination

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -265,6 +265,7 @@ Testing guidance:
 - for IM integrations, stub/mock platform clients and validate outbound payload/schema behavior
 - for reusable capability-first testing guidance, use `standards/scenario-testing/AGENTS.md` as the entrypoint; project-specific scenario metadata lives under `tests/scenarios/`
 - when a scenario catalog exists, make the scenario ID visible in the automated test and in the PR description
+- treat CLI examples in injected system prompts as live callers: update them with CLI flag changes and keep parser-backed contract coverage so unsupported examples cannot ship
 - for multi-step auth/setup flows, update `tests/scenarios/auth_setup/catalog.yaml` and add or update a closed-loop scenario harness case under `tests/scenarios/auth_setup/test_auth_setup_scenarios.py`; keep provider-specific parsing and heuristics in focused unit tests
 - for UI changes, run `npm run build` in `ui/`
 - for cross-platform or user-facing verification, use the Incus regression workflow

--- a/core/system_prompt_injection.py
+++ b/core/system_prompt_injection.py
@@ -269,7 +269,7 @@ Relationship: Scope routes work; Agent defines who acts; Session holds continuit
 ### Inspecting Harness state
 Use `vibe data query` to inspect Avibe state with guarded read-only SQL before changing a Harness: confirm existing Agents, Sessions, Runs, scopes, tasks, watches, and routing facts instead of guessing.
 
-Examples: `vibe data query --sql "select name from sqlite_master where type='table' order by name" --all`; `vibe data query --sql "select name, sql from sqlite_master where type='table' and name in ('agents','agent_sessions','agent_runs','messages','scopes','scope_settings','run_definitions') order by name" --all`
+Examples: use `vibe data query --sql "select name from sqlite_master where type='table' order by name" --limit 100` for a broad schema inventory; use `vibe data query --sql "select name, sql from sqlite_master where type='table' and name in ('agents','agent_sessions','agent_runs','messages','scopes','scope_settings','run_definitions') order by name" --limit 20` for the focused Harness tables. Follow `pagination.next_command` if either result has more pages.
 
 Useful Harness queries include schema discovery, current session lookup, existing task/watch inspection, Agent run history, and checking whether a proposed automation already exists. Prefer this CLI over direct SQLite access.
 

--- a/core/watches.py
+++ b/core/watches.py
@@ -265,11 +265,7 @@ class ManagedWatchStore:
             # A resumed one-shot starts a new lifecycle. Keep historical runs in
             # the run store, but do not let the prior cycle make a later pause
             # look completed and disappear from the default definition list.
-            watch.last_started_at = None
-            watch.last_finished_at = None
-            watch.last_event_at = None
-            watch.last_exit_code = None
-            watch.last_error = None
+            self._clear_cycle_state(watch)
         watch.enabled = enabled
         watch.updated_at = _utc_now_iso()
         if self._sqlite is not None:
@@ -302,6 +298,11 @@ class ManagedWatchStore:
         metadata: Optional[dict[str, Any]] = None,
     ) -> ManagedWatch:
         watch = self._watches[watch_id]
+        if mode != watch.mode:
+            # A mode change starts a new lifecycle. Completion and failure
+            # metadata from the old mode remains available in run history, but
+            # must not determine the definition state under the new mode.
+            self._clear_cycle_state(watch)
         watch.name = name
         watch.session_key = session_key
         watch.session_id = session_id
@@ -329,6 +330,14 @@ class ManagedWatchStore:
             return watch
         self._save()
         return watch
+
+    @staticmethod
+    def _clear_cycle_state(watch: ManagedWatch) -> None:
+        watch.last_started_at = None
+        watch.last_finished_at = None
+        watch.last_event_at = None
+        watch.last_exit_code = None
+        watch.last_error = None
 
     def mark_cycle_start(self, watch_id: str) -> bool:
         self.maybe_reload()

--- a/core/watches.py
+++ b/core/watches.py
@@ -261,6 +261,15 @@ class ManagedWatchStore:
 
     def set_enabled(self, watch_id: str, enabled: bool) -> ManagedWatch:
         watch = self._watches[watch_id]
+        if enabled and not watch.enabled and watch.mode == "once":
+            # A resumed one-shot starts a new lifecycle. Keep historical runs in
+            # the run store, but do not let the prior cycle make a later pause
+            # look completed and disappear from the default definition list.
+            watch.last_started_at = None
+            watch.last_finished_at = None
+            watch.last_event_at = None
+            watch.last_exit_code = None
+            watch.last_error = None
         watch.enabled = enabled
         watch.updated_at = _utc_now_iso()
         if self._sqlite is not None:

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -14,6 +14,16 @@ vibe stop         # Stop all services
 
 ## Commands
 
+### Bounded list output
+
+Agent-facing collection commands share one pagination contract: `vibe agent list`,
+`vibe agent models`, `vibe runs list`, `vibe session list`, Vault list/find/tags,
+Show Page list/marks, `vibe data query`, `vibe task list`, and `vibe watch list`.
+They return 20 rows by default, accept `--page` and `--limit`, cap a page at 100,
+and never provide an unpaginated `--all` bypass. Follow
+`pagination.next_command` for the next page and use the corresponding `show` or
+`get` command for full record detail.
+
 ## Remote Web UI Access
 
 By default, the Web UI binds to `127.0.0.1:5123` on the machine where Avibe is running.
@@ -217,7 +227,7 @@ Create, inspect, update, run, pause, resume, or remove scheduled tasks.
 ```bash
 vibe task add --session-id sesk8m4q2p7x --cron '0 * * * *' --message 'Share the hourly summary.'
 vibe task add --cron '0 * * * *' --message 'Share the hourly summary.'   # inside an Avibe Agent shell
-vibe task list --brief
+vibe task list
 vibe task update <task-id> --cron '*/30 * * * *'
 vibe task run <task-id>
 vibe task remove <task-id>
@@ -295,7 +305,7 @@ vibe watch add \
   --message 'Build done. Summarize.' \
   --shell 'make build && ./scripts/post_build.sh'
 
-vibe watch list --brief
+vibe watch list
 vibe watch show <watch-id>
 vibe watch update <watch-id> --name 'Watch deployment' --timeout 1200
 vibe watch pause <watch-id>
@@ -306,7 +316,7 @@ vibe watch remove <watch-id>
 `vibe task list` and `vibe watch list` return 20 definitions per page and
 include `pagination.next_command` when more rows exist. Finished one-shot
 definitions are hidden by default. Add `--include-finished` to page through
-history, or use `--all` only for an intentional unpaginated export.
+history. List output is always bounded; there is no unpaginated `--all` mode.
 
 The waiter command is passed positionally after `--` (or as a single shell
 string via `--shell`). Use `vibe watch add --help` for the full surface,

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -314,7 +314,7 @@ vibe watch remove <watch-id>
 ```
 
 `vibe task list` and `vibe watch list` return 20 definitions per page and
-include `pagination.next_command` when more rows exist. Finished one-shot
+include `pagination.next_command` when more rows exist. Successful one-shot
 definitions are hidden by default. Add `--include-finished` to page through
 history. List output is always bounded; there is no unpaginated `--all` mode.
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -191,9 +191,9 @@ List, inspect, and rename Agent sessions. `list` and `get` are read-only; `updat
 changes the title only. Archived sessions are soft-deleted and never surfaced.
 
 ```bash
-vibe session list                       # active sessions, 10 per page, newest activity first
+vibe session list                       # active sessions, 20 per page by default, newest activity first
 vibe session list --type slack          # filter by platform (avibe = Web/Workbench)
-vibe session list --page 2              # next page (fixed 10 per page; there is no --limit)
+vibe session list --page 2 --limit 50   # request page 2 with 50 rows (maximum 100)
 vibe session get sesk8m4q2p7x           # full detail for one session
 vibe session get                        # inside an Avibe Agent shell, show the caller Session
 vibe session update sesk8m4q2p7x --title 'Release review'   # pass "" to clear the title

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -303,6 +303,11 @@ vibe watch resume <watch-id>
 vibe watch remove <watch-id>
 ```
 
+`vibe task list` and `vibe watch list` return 20 definitions per page and
+include `pagination.next_command` when more rows exist. Finished one-shot
+definitions are hidden by default. Add `--include-finished` to page through
+history, or use `--all` only for an intentional unpaginated export.
+
 The waiter command is passed positionally after `--` (or as a single shell
 string via `--shell`). Use `vibe watch add --help` for the full surface,
 including `--timeout` (per-cycle timeout in seconds), `--lifetime-timeout`

--- a/docs/CLI_ZH.md
+++ b/docs/CLI_ZH.md
@@ -13,6 +13,15 @@ vibe stop         # 停止所有服务
 
 ## 命令详解
 
+### 有界列表输出
+
+面向 Agent 的集合命令共用同一套分页契约：`vibe agent list`、`vibe agent models`、
+`vibe runs list`、`vibe session list`、Vault 的 list/find/tags、Show Page 的
+list/marks、`vibe data query`、`vibe task list` 和 `vibe watch list`。默认返回
+20 条，支持 `--page` 和 `--limit`，单页最多 100 条，且不提供无分页的 `--all`
+绕过。使用 `pagination.next_command` 继续翻页；完整记录详情通过对应的 `show`
+或 `get` 命令获取。
+
 ## 远程访问 Web UI
 
 默认情况下，Web UI 只监听在运行 Avibe 的那台机器的 `127.0.0.1:5123`。
@@ -199,7 +208,7 @@ vibe runs show                         # 在 Avibe Agent shell 内查看调用�
 ```bash
 vibe task add --session-id sesk8m4q2p7x --cron '0 * * * *' --message 'Share the hourly summary.'
 vibe task add --cron '0 * * * *' --message 'Share the hourly summary.'   # 在 Avibe Agent shell 内
-vibe task list --brief
+vibe task list
 vibe task update <task-id> --cron '*/30 * * * *'
 vibe task run <task-id>
 vibe task remove <task-id>
@@ -274,7 +283,7 @@ vibe watch add \
   --message 'Build done. Summarize.' \
   --shell 'make build && ./scripts/post_build.sh'
 
-vibe watch list --brief
+vibe watch list
 vibe watch show <watch-id>
 vibe watch update <watch-id> --name 'Watch deployment' --timeout 1200
 vibe watch pause <watch-id>
@@ -284,7 +293,7 @@ vibe watch remove <watch-id>
 
 `vibe task list` 和 `vibe watch list` 默认每页返回 20 条定义；还有下一页时，
 响应会包含 `pagination.next_command`。默认隐藏已经结束的一次性定义；使用
-`--include-finished` 分页查看历史，只在明确需要无分页完整导出时使用 `--all`。
+`--include-finished` 分页查看历史。列表输出始终有上限，不提供无分页的 `--all` 模式。
 
 waiter 命令放在 `--` 后面；或者通过 `--shell` 传入一整段 shell 字符串。
 完整参数请看 `vibe watch add --help`，包括 `--timeout`、`--lifetime-timeout`、

--- a/docs/CLI_ZH.md
+++ b/docs/CLI_ZH.md
@@ -292,7 +292,7 @@ vibe watch remove <watch-id>
 ```
 
 `vibe task list` 和 `vibe watch list` 默认每页返回 20 条定义；还有下一页时，
-响应会包含 `pagination.next_command`。默认隐藏已经结束的一次性定义；使用
+响应会包含 `pagination.next_command`。默认隐藏成功结束的一次性定义；使用
 `--include-finished` 分页查看历史。列表输出始终有上限，不提供无分页的 `--all` 模式。
 
 waiter 命令放在 `--` 后面；或者通过 `--shell` 传入一整段 shell 字符串。

--- a/docs/CLI_ZH.md
+++ b/docs/CLI_ZH.md
@@ -282,6 +282,10 @@ vibe watch resume <watch-id>
 vibe watch remove <watch-id>
 ```
 
+`vibe task list` 和 `vibe watch list` 默认每页返回 20 条定义；还有下一页时，
+响应会包含 `pagination.next_command`。默认隐藏已经结束的一次性定义；使用
+`--include-finished` 分页查看历史，只在明确需要无分页完整导出时使用 `--all`。
+
 waiter 命令放在 `--` 后面；或者通过 `--shell` 传入一整段 shell 字符串。
 完整参数请看 `vibe watch add --help`，包括 `--timeout`、`--lifetime-timeout`、
 `--forever`、`--retry-exit-code`、`--retry-delay`、`--name` 和 session creation 参数。

--- a/docs/CLI_ZH.md
+++ b/docs/CLI_ZH.md
@@ -174,9 +174,9 @@ vibe screenshot --json
 列出、查看并重命名 Agent 会话。`list` 与 `get` 是只读视图；`update` 只改标题。已归档会话视为软删除，任何情况下都不会被列出。
 
 ```bash
-vibe session list                       # 未归档会话，每页 10 条，按最近活跃倒序
+vibe session list                       # 未归档会话，默认每页 20 条，按最近活跃倒序
 vibe session list --type slack          # 按平台过滤（avibe = Web/Workbench）
-vibe session list --page 2              # 翻到下一页（固定每页 10 条；没有 --limit）
+vibe session list --page 2 --limit 50   # 第 2 页，每页 50 条（最多 100）
 vibe session get sesk8m4q2p7x           # 单个会话的完整明细
 vibe session get                        # 在 Avibe Agent shell 内查看调用方 Session
 vibe session update sesk8m4q2p7x --title 'Release review'   # 传 "" 可清空标题

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -513,6 +513,11 @@ These are important user-facing controls, but they are not text commands:
 
 The `vibe` executable controls the local service and async automation features.
 
+All Agent-facing collection commands use `--page` / `--limit`, default to 20
+compact rows, and cap each page at 100. They never expose an unpaginated `--all`
+mode. Continue with `pagination.next_command`; inspect one record with its
+`show` or `get` command.
+
 ## 5.1 Top-level CLI commands
 
 | Command | Purpose |
@@ -758,8 +763,11 @@ Important options:
 ### `vibe task list`
 
 ```bash
-vibe task list [--all] [--brief]
+vibe task list [--include-finished] [--page N] [--limit N]
 ```
+
+Returns compact rows, 20 per page by default and at most 100. Use
+`pagination.next_command` to continue; use `vibe task show <task_id>` for detail.
 
 ### `vibe task show`
 
@@ -915,6 +923,6 @@ Use the right command family for the job:
 vibe
 vibe status
 vibe doctor
-vibe task list --brief
+vibe task list
 vibe agent run --no-callback --session-id sesk8m4q2p7x --message 'Share the latest build summary.'
 ```

--- a/docs/COMMANDS_ZH.md
+++ b/docs/COMMANDS_ZH.md
@@ -492,6 +492,10 @@ bind vr-a3x9k2
 
 `vibe` 可执行文件负责管理本地服务与异步自动化能力。
 
+所有面向 Agent 的集合命令都使用 `--page` / `--limit`，默认返回 20 条紧凑记录，
+单页最多 100 条，并且不提供无分页的 `--all` 模式。按
+`pagination.next_command` 继续翻页；单条完整详情通过对应的 `show` 或 `get` 命令获取。
+
 ## 5.1 顶层 CLI 命令
 
 | 命令 | 作用 |
@@ -737,8 +741,11 @@ vibe task update <task_id> [options]
 ### `vibe task list`
 
 ```bash
-vibe task list [--all] [--brief]
+vibe task list [--include-finished] [--page N] [--limit N]
 ```
+
+默认每页返回 20 条紧凑记录，单页最多 100 条。按 `pagination.next_command`
+继续翻页；需要完整详情时使用 `vibe task show <task_id>`。
 
 ### `vibe task show`
 
@@ -887,6 +894,6 @@ fork 会保持源 Session 的 backend；只有 backend 不变时，`--agent`、`
 vibe
 vibe status
 vibe doctor
-vibe task list --brief
+vibe task list
 vibe agent run --no-callback --session-id sesk8m4q2p7x --message 'Share the latest build summary.'
 ```

--- a/docs/plans/cli-query-pagination.md
+++ b/docs/plans/cli-query-pagination.md
@@ -47,7 +47,7 @@ Text output should append a concise "more records" hint when `has_more` is true.
 
 Extend `vibe runs list` with:
 
-- `--page`, `--limit`, `--all`
+- `--page`, `--limit` (always bounded; no unpaginated bypass)
 - `--status`
 - `--type`
 - `--agent`
@@ -65,7 +65,7 @@ memory; it is compatibility-only.
 
 Extend `vibe show list` with:
 
-- `--page`, `--limit`, `--all`
+- `--page`, `--limit` (always bounded; no unpaginated bypass)
 - `--visibility`
 - `--session-id`
 - `--updated-after`

--- a/skills/use-avibe/SKILL.md
+++ b/skills/use-avibe/SKILL.md
@@ -810,7 +810,7 @@ Operational guidance:
 - use `vibe watch update <id> ...` when you must rename, retarget, or change the waiter/options
 - Agent-facing collection commands return 20 compact rows per page, cap `--limit` at 100, and have no unpaginated `--all` mode; follow `pagination.next_command` when more rows exist
 - use `--include-finished` for paginated task/watch one-shot history
-- both list commands hide finished one-shot definitions by default; use `--include-finished` and follow `pagination.next_command` for bounded history
+- both list commands hide successful one-shot definitions by default while failures stay visible; use `--include-finished` and follow `pagination.next_command` for bounded history
 - use `vibe task show <id>`, `vibe watch show <id>`, or `vibe runs show <run-id>` to inspect stored fields and runtime state
 - use `vibe task pause` / `vibe task resume` and `vibe watch pause` / `vibe watch resume` to disable a task or watch without deleting it
 - treat `warnings` from task, watch, agent-run, or runs commands as delivery-risk hints to fix proactively

--- a/skills/use-avibe/SKILL.md
+++ b/skills/use-avibe/SKILL.md
@@ -808,8 +808,9 @@ Operational guidance:
 - if this is the first time using `vibe task add`, `vibe agent run`, `vibe runs`, or `vibe watch add`, read the matching `--help` output first — watches accept additional flags like `--shell`, `--timeout` (per-cycle), `--lifetime-timeout` (overall), `--forever`, `--retry-exit-code`, and `--retry-delay`
 - use `vibe task update <id>` to keep the same task ID while changing name, schedule, message, agent, or target
 - use `vibe watch update <id> ...` when you must rename, retarget, or change the waiter/options
-- use `vibe task list --brief` and `vibe watch list --brief` for scheduling-focused summaries
-- `vibe task list` hides completed one-shot tasks by default; use `vibe task list --all` when you need full history
+- `vibe task list` and `vibe watch list` return 20 definitions per page; follow `pagination.next_command` when more rows exist
+- use `--brief` for scheduling-focused summaries and `--include-finished` for paginated one-shot history
+- both list commands hide finished one-shot definitions by default; use `--all` only when you intentionally need the complete unpaginated history
 - use `vibe task show <id>`, `vibe watch show <id>`, or `vibe runs show <run-id>` to inspect stored fields and runtime state
 - use `vibe task pause` / `vibe task resume` and `vibe watch pause` / `vibe watch resume` to disable a task or watch without deleting it
 - treat `warnings` from task, watch, agent-run, or runs commands as delivery-risk hints to fix proactively
@@ -957,7 +958,7 @@ Screenshots:
 
 Scheduled tasks:
 
-- `vibe task add`, `vibe task update`, `vibe task list [--all|--brief]`, `vibe task show <id>`, `vibe task run <id>`, `vibe task pause <id>`, `vibe task resume <id>`, `vibe task remove <id>`
+- `vibe task add`, `vibe task update`, `vibe task list [--brief] [--include-finished] [--page N] [--limit N] [--all]`, `vibe task show <id>`, `vibe task run <id>`, `vibe task pause <id>`, `vibe task resume <id>`, `vibe task remove <id>`
 
 Agent runs:
 
@@ -966,7 +967,7 @@ Agent runs:
 
 Watches:
 
-- `vibe watch add`, `vibe watch update <id>`, `vibe watch list [--brief]`, `vibe watch show <id>`, `vibe watch pause <id>`, `vibe watch resume <id>`, `vibe watch remove <id>`
+- `vibe watch add`, `vibe watch update <id>`, `vibe watch list [--brief] [--include-finished] [--page N] [--limit N] [--all]`, `vibe watch show <id>`, `vibe watch pause <id>`, `vibe watch resume <id>`, `vibe watch remove <id>`
 
 For any subcommand, prefer `<command> --help` before composing a new invocation. Harness commands default to this Agent Session inside an Avibe-injected Agent shell. Use `--session-id` only to target a different existing Session, `--same-scope` or `--scope-id` when creating a Session in a visible scope, and `--no-callback` only when an async Agent run will be inspected later through `vibe runs`. Use `--message` / `--message-file` for user messages. `vibe task add` and `vibe watch add` take `--name`; only `vibe task add` takes `--cron` / `--at` / `--timezone`; `vibe agent run` takes `--sync`; and `vibe watch add` takes its own waiter options (`--shell` or a positional command after `--`, `--cwd`, `--timeout`, `--forever`, `--lifetime-timeout`, `--retry-exit-code`, `--retry-delay`). Do not copy flags between task, watch, and agent-run commands without checking help.
 

--- a/skills/use-avibe/SKILL.md
+++ b/skills/use-avibe/SKILL.md
@@ -808,9 +808,9 @@ Operational guidance:
 - if this is the first time using `vibe task add`, `vibe agent run`, `vibe runs`, or `vibe watch add`, read the matching `--help` output first — watches accept additional flags like `--shell`, `--timeout` (per-cycle), `--lifetime-timeout` (overall), `--forever`, `--retry-exit-code`, and `--retry-delay`
 - use `vibe task update <id>` to keep the same task ID while changing name, schedule, message, agent, or target
 - use `vibe watch update <id> ...` when you must rename, retarget, or change the waiter/options
-- `vibe task list` and `vibe watch list` return 20 definitions per page; follow `pagination.next_command` when more rows exist
-- use `--brief` for scheduling-focused summaries and `--include-finished` for paginated one-shot history
-- both list commands hide finished one-shot definitions by default; use `--all` only when you intentionally need the complete unpaginated history
+- Agent-facing collection commands return 20 compact rows per page, cap `--limit` at 100, and have no unpaginated `--all` mode; follow `pagination.next_command` when more rows exist
+- use `--include-finished` for paginated task/watch one-shot history
+- both list commands hide finished one-shot definitions by default; use `--include-finished` and follow `pagination.next_command` for bounded history
 - use `vibe task show <id>`, `vibe watch show <id>`, or `vibe runs show <run-id>` to inspect stored fields and runtime state
 - use `vibe task pause` / `vibe task resume` and `vibe watch pause` / `vibe watch resume` to disable a task or watch without deleting it
 - treat `warnings` from task, watch, agent-run, or runs commands as delivery-risk hints to fix proactively
@@ -958,7 +958,7 @@ Screenshots:
 
 Scheduled tasks:
 
-- `vibe task add`, `vibe task update`, `vibe task list [--brief] [--include-finished] [--page N] [--limit N] [--all]`, `vibe task show <id>`, `vibe task run <id>`, `vibe task pause <id>`, `vibe task resume <id>`, `vibe task remove <id>`
+- `vibe task add`, `vibe task update`, `vibe task list [--include-finished] [--page N] [--limit N]`, `vibe task show <id>`, `vibe task run <id>`, `vibe task pause <id>`, `vibe task resume <id>`, `vibe task remove <id>`
 
 Agent runs:
 
@@ -967,7 +967,7 @@ Agent runs:
 
 Watches:
 
-- `vibe watch add`, `vibe watch update <id>`, `vibe watch list [--brief] [--include-finished] [--page N] [--limit N] [--all]`, `vibe watch show <id>`, `vibe watch pause <id>`, `vibe watch resume <id>`, `vibe watch remove <id>`
+- `vibe watch add`, `vibe watch update <id>`, `vibe watch list [--include-finished] [--page N] [--limit N]`, `vibe watch show <id>`, `vibe watch pause <id>`, `vibe watch resume <id>`, `vibe watch remove <id>`
 
 For any subcommand, prefer `<command> --help` before composing a new invocation. Harness commands default to this Agent Session inside an Avibe-injected Agent shell. Use `--session-id` only to target a different existing Session, `--same-scope` or `--scope-id` when creating a Session in a visible scope, and `--no-callback` only when an async Agent run will be inspected later through `vibe runs`. Use `--message` / `--message-file` for user messages. `vibe task add` and `vibe watch add` take `--name`; only `vibe task add` takes `--cron` / `--at` / `--timezone`; `vibe agent run` takes `--sync`; and `vibe watch add` takes its own waiter options (`--shell` or a positional command after `--`, `--cwd`, `--timeout`, `--forever`, `--lifetime-timeout`, `--retry-exit-code`, `--retry-delay`). Do not copy flags between task, watch, and agent-run commands without checking help.
 

--- a/skills/use-vibe-remote/SKILL.md
+++ b/skills/use-vibe-remote/SKILL.md
@@ -810,7 +810,7 @@ Operational guidance:
 - use `vibe watch update <id> ...` when you must rename, retarget, or change the waiter/options
 - Agent-facing collection commands return 20 compact rows per page, cap `--limit` at 100, and have no unpaginated `--all` mode; follow `pagination.next_command` when more rows exist
 - use `--include-finished` for paginated task/watch one-shot history
-- both list commands hide finished one-shot definitions by default; use `--include-finished` and follow `pagination.next_command` for bounded history
+- both list commands hide successful one-shot definitions by default while failures stay visible; use `--include-finished` and follow `pagination.next_command` for bounded history
 - use `vibe task show <id>`, `vibe watch show <id>`, or `vibe runs show <run-id>` to inspect stored fields and runtime state
 - use `vibe task pause` / `vibe task resume` and `vibe watch pause` / `vibe watch resume` to disable a task or watch without deleting it
 - treat `warnings` from task, watch, agent-run, or runs commands as delivery-risk hints to fix proactively

--- a/skills/use-vibe-remote/SKILL.md
+++ b/skills/use-vibe-remote/SKILL.md
@@ -808,8 +808,9 @@ Operational guidance:
 - if this is the first time using `vibe task add`, `vibe agent run`, `vibe runs`, or `vibe watch add`, read the matching `--help` output first — watches accept additional flags like `--shell`, `--timeout` (per-cycle), `--lifetime-timeout` (overall), `--forever`, `--retry-exit-code`, and `--retry-delay`
 - use `vibe task update <id>` to keep the same task ID while changing name, schedule, message, agent, or target
 - use `vibe watch update <id> ...` when you must rename, retarget, or change the waiter/options
-- use `vibe task list --brief` and `vibe watch list --brief` for scheduling-focused summaries
-- `vibe task list` hides completed one-shot tasks by default; use `vibe task list --all` when you need full history
+- `vibe task list` and `vibe watch list` return 20 definitions per page; follow `pagination.next_command` when more rows exist
+- use `--brief` for scheduling-focused summaries and `--include-finished` for paginated one-shot history
+- both list commands hide finished one-shot definitions by default; use `--all` only when you intentionally need the complete unpaginated history
 - use `vibe task show <id>`, `vibe watch show <id>`, or `vibe runs show <run-id>` to inspect stored fields and runtime state
 - use `vibe task pause` / `vibe task resume` and `vibe watch pause` / `vibe watch resume` to disable a task or watch without deleting it
 - treat `warnings` from task, watch, agent-run, or runs commands as delivery-risk hints to fix proactively
@@ -957,7 +958,7 @@ Screenshots:
 
 Scheduled tasks:
 
-- `vibe task add`, `vibe task update`, `vibe task list [--all|--brief]`, `vibe task show <id>`, `vibe task run <id>`, `vibe task pause <id>`, `vibe task resume <id>`, `vibe task remove <id>`
+- `vibe task add`, `vibe task update`, `vibe task list [--brief] [--include-finished] [--page N] [--limit N] [--all]`, `vibe task show <id>`, `vibe task run <id>`, `vibe task pause <id>`, `vibe task resume <id>`, `vibe task remove <id>`
 
 Agent runs:
 
@@ -966,7 +967,7 @@ Agent runs:
 
 Watches:
 
-- `vibe watch add`, `vibe watch update <id>`, `vibe watch list [--brief]`, `vibe watch show <id>`, `vibe watch pause <id>`, `vibe watch resume <id>`, `vibe watch remove <id>`
+- `vibe watch add`, `vibe watch update <id>`, `vibe watch list [--brief] [--include-finished] [--page N] [--limit N] [--all]`, `vibe watch show <id>`, `vibe watch pause <id>`, `vibe watch resume <id>`, `vibe watch remove <id>`
 
 For any subcommand, prefer `<command> --help` before composing a new invocation. Harness commands default to this Agent Session inside an Avibe-injected Agent shell. Use `--session-id` only to target a different existing Session, `--same-scope` or `--scope-id` when creating a Session in a visible scope, and `--no-callback` only when an async Agent run will be inspected later through `vibe runs`. Use `--message` / `--message-file` for user messages. `vibe task add` and `vibe watch add` take `--name`; only `vibe task add` takes `--cron` / `--at` / `--timezone`; `vibe agent run` takes `--sync`; and `vibe watch add` takes its own waiter options (`--shell` or a positional command after `--`, `--cwd`, `--timeout`, `--forever`, `--lifetime-timeout`, `--retry-exit-code`, `--retry-delay`). Do not copy flags between task, watch, and agent-run commands without checking help.
 

--- a/skills/use-vibe-remote/SKILL.md
+++ b/skills/use-vibe-remote/SKILL.md
@@ -808,9 +808,9 @@ Operational guidance:
 - if this is the first time using `vibe task add`, `vibe agent run`, `vibe runs`, or `vibe watch add`, read the matching `--help` output first — watches accept additional flags like `--shell`, `--timeout` (per-cycle), `--lifetime-timeout` (overall), `--forever`, `--retry-exit-code`, and `--retry-delay`
 - use `vibe task update <id>` to keep the same task ID while changing name, schedule, message, agent, or target
 - use `vibe watch update <id> ...` when you must rename, retarget, or change the waiter/options
-- `vibe task list` and `vibe watch list` return 20 definitions per page; follow `pagination.next_command` when more rows exist
-- use `--brief` for scheduling-focused summaries and `--include-finished` for paginated one-shot history
-- both list commands hide finished one-shot definitions by default; use `--all` only when you intentionally need the complete unpaginated history
+- Agent-facing collection commands return 20 compact rows per page, cap `--limit` at 100, and have no unpaginated `--all` mode; follow `pagination.next_command` when more rows exist
+- use `--include-finished` for paginated task/watch one-shot history
+- both list commands hide finished one-shot definitions by default; use `--include-finished` and follow `pagination.next_command` for bounded history
 - use `vibe task show <id>`, `vibe watch show <id>`, or `vibe runs show <run-id>` to inspect stored fields and runtime state
 - use `vibe task pause` / `vibe task resume` and `vibe watch pause` / `vibe watch resume` to disable a task or watch without deleting it
 - treat `warnings` from task, watch, agent-run, or runs commands as delivery-risk hints to fix proactively
@@ -958,7 +958,7 @@ Screenshots:
 
 Scheduled tasks:
 
-- `vibe task add`, `vibe task update`, `vibe task list [--brief] [--include-finished] [--page N] [--limit N] [--all]`, `vibe task show <id>`, `vibe task run <id>`, `vibe task pause <id>`, `vibe task resume <id>`, `vibe task remove <id>`
+- `vibe task add`, `vibe task update`, `vibe task list [--include-finished] [--page N] [--limit N]`, `vibe task show <id>`, `vibe task run <id>`, `vibe task pause <id>`, `vibe task resume <id>`, `vibe task remove <id>`
 
 Agent runs:
 
@@ -967,7 +967,7 @@ Agent runs:
 
 Watches:
 
-- `vibe watch add`, `vibe watch update <id>`, `vibe watch list [--brief] [--include-finished] [--page N] [--limit N] [--all]`, `vibe watch show <id>`, `vibe watch pause <id>`, `vibe watch resume <id>`, `vibe watch remove <id>`
+- `vibe watch add`, `vibe watch update <id>`, `vibe watch list [--include-finished] [--page N] [--limit N]`, `vibe watch show <id>`, `vibe watch pause <id>`, `vibe watch resume <id>`, `vibe watch remove <id>`
 
 For any subcommand, prefer `<command> --help` before composing a new invocation. Harness commands default to this Agent Session inside an Avibe-injected Agent shell. Use `--session-id` only to target a different existing Session, `--same-scope` or `--scope-id` when creating a Session in a visible scope, and `--no-callback` only when an async Agent run will be inspected later through `vibe runs`. Use `--message` / `--message-file` for user messages. `vibe task add` and `vibe watch add` take `--name`; only `vibe task add` takes `--cron` / `--at` / `--timezone`; `vibe agent run` takes `--sync`; and `vibe watch add` takes its own waiter options (`--shell` or a positional command after `--`, `--cwd`, `--timeout`, `--forever`, `--lifetime-timeout`, `--retry-exit-code`, `--retry-delay`). Do not copy flags between task, watch, and agent-run commands without checking help.
 

--- a/storage/pagination.py
+++ b/storage/pagination.py
@@ -35,12 +35,9 @@ def make_page_request(
     *,
     page: int | None = None,
     limit: int | None = None,
-    all_items: bool = False,
     default_limit: int = DEFAULT_PAGE_LIMIT,
     max_limit: int = MAX_PAGE_LIMIT,
-) -> PageRequest | None:
-    if all_items:
-        return None
+) -> PageRequest:
     resolved_page = page if page is not None else 1
     resolved_limit = limit if limit is not None else default_limit
     if resolved_page < 1:

--- a/tests/test_cli_agent_models.py
+++ b/tests/test_cli_agent_models.py
@@ -62,6 +62,35 @@ def test_cmd_agent_models_by_backend(monkeypatch):
     assert payload["models"][0]["value"] == "gpt-5.5"
 
 
+def test_cmd_agent_models_uses_shared_pagination(monkeypatch):
+    monkeypatch.setattr(
+        cli.api,
+        "agent_model_options",
+        lambda *a, **k: {
+            "ok": True,
+            "backend": "codex",
+            "default_model": None,
+            "models": [
+                {"value": f"gpt-{index:02d}", "default": False, "reasoning_efforts": ["high"]}
+                for index in range(25)
+            ],
+            "providers": None,
+            "source": "test catalog",
+            "live": False,
+            "notes": None,
+        },
+    )
+    args = cli.build_parser().parse_args(["agent", "models", "--backend", "codex"])
+
+    code, payload = _run(cli.cmd_agent_models, args)
+
+    assert code == 0
+    assert len(payload["models"]) == 20
+    assert payload["pagination"]["next_command"] == (
+        "vibe agent models --backend codex --page 2 --limit 20"
+    )
+
+
 def test_cmd_agent_models_requires_exactly_one_target():
     code, payload = _run(cli.cmd_agent_models, _models_ns())
     assert code == 1

--- a/tests/test_cli_agent_models.py
+++ b/tests/test_cli_agent_models.py
@@ -91,6 +91,56 @@ def test_cmd_agent_models_uses_shared_pagination(monkeypatch):
     )
 
 
+def test_cmd_agent_models_paginates_providers_and_models_together(monkeypatch):
+    monkeypatch.setattr(
+        cli.api,
+        "agent_model_options",
+        lambda *a, **k: {
+            "ok": True,
+            "backend": "opencode",
+            "default_model": None,
+            "providers": [
+                {"id": f"provider-{index:02d}", "name": f"Provider {index}", "custom": False}
+                for index in range(15)
+            ],
+            "models": [
+                {
+                    "value": f"provider-{index:02d}/model",
+                    "provider": f"provider-{index:02d}",
+                    "default": False,
+                    "reasoning_efforts": [],
+                }
+                for index in range(10)
+            ],
+            "source": "test catalog",
+            "live": True,
+            "notes": None,
+        },
+    )
+
+    first_args = cli.build_parser().parse_args(
+        ["agent", "models", "--backend", "opencode"]
+    )
+    code, first = _run(cli.cmd_agent_models, first_args)
+
+    assert code == 0
+    assert len(first["providers"]) == 15
+    assert len(first["models"]) == 5
+    assert first["pagination"]["returned"] == 20
+    assert first["pagination"]["has_more"] is True
+
+    second_args = cli.build_parser().parse_args(
+        ["agent", "models", "--backend", "opencode", "--page", "2"]
+    )
+    code, second = _run(cli.cmd_agent_models, second_args)
+
+    assert code == 0
+    assert second["providers"] == []
+    assert len(second["models"]) == 5
+    assert second["pagination"]["returned"] == 5
+    assert second["pagination"]["has_more"] is False
+
+
 def test_cmd_agent_models_requires_exactly_one_target():
     code, payload = _run(cli.cmd_agent_models, _models_ns())
     assert code == 1

--- a/tests/test_cli_pagination.py
+++ b/tests/test_cli_pagination.py
@@ -1,10 +1,65 @@
 from __future__ import annotations
 
+import argparse
 import json
 
 from config import paths
 from storage.background import SQLiteBackgroundTaskStore
 from vibe import cli
+
+
+def _command_parser(path: tuple[str, ...]):
+    parser = cli.build_parser()
+    for segment in path:
+        subparsers = next(
+            action for action in parser._actions if isinstance(action, argparse._SubParsersAction)
+        )
+        parser = subparsers.choices[segment]
+    return parser
+
+
+def _parser_flags(parser) -> set[str]:
+    return {flag for action in parser._actions for flag in action.option_strings}
+
+
+def _iter_command_parsers(parser, path=()):
+    for action in parser._actions:
+        if not isinstance(action, argparse._SubParsersAction):
+            continue
+        for name, child in action.choices.items():
+            child_path = (*path, name)
+            yield child_path, child
+            yield from _iter_command_parsers(child, child_path)
+
+
+def test_all_collection_commands_share_bounded_pagination_contract() -> None:
+    collection_commands = {
+        ("agent", "list"),
+        ("agent", "models"),
+        ("runs", "list"),
+        ("session", "list"),
+        ("vault", "list"),
+        ("vault", "find"),
+        ("vault", "tags"),
+        ("show", "list"),
+        ("show", "marks"),
+        ("data", "query"),
+        ("task", "list"),
+        ("watch", "list"),
+    }
+    parser = cli.build_parser()
+    discovered_list_commands = {
+        path
+        for path, _ in _iter_command_parsers(parser)
+        if path[-1] == "list" and path[-1] != "ls"
+    }
+
+    assert discovered_list_commands <= collection_commands
+    for path in collection_commands:
+        flags = _parser_flags(_command_parser(path))
+        assert "--page" in flags, path
+        assert "--limit" in flags, path
+        assert "--all" not in flags, path
 
 
 def test_runs_list_cli_defaults_to_first_page(monkeypatch, tmp_path, capsys) -> None:
@@ -141,6 +196,7 @@ def test_runs_list_cli_next_command_uses_absolute_time_filters(monkeypatch, tmp_
     assert "--created-after 2026-05-25T00:00:00+00:00" in payload["pagination"]["next_command"]
     assert "--created-after 2026-05-25T08:00:00+08:00" not in payload["pagination"]["next_command"]
     assert payload["pagination"]["next_command"].endswith("--page 2 --limit 10")
+    assert "message" not in payload["runs"][0]
 
 
 def test_runs_show_defaults_to_caller_run(monkeypatch, tmp_path, capsys) -> None:

--- a/tests/test_cli_pagination.py
+++ b/tests/test_cli_pagination.py
@@ -2,8 +2,12 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
+import shlex
 
 from config import paths
+from core.system_prompt_injection import build_system_prompt_injection
+from modules.im.base import MessageContext
 from storage.background import SQLiteBackgroundTaskStore
 from vibe import cli
 
@@ -30,6 +34,27 @@ def _iter_command_parsers(parser, path=()):
             child_path = (*path, name)
             yield child_path, child
             yield from _iter_command_parsers(child, child_path)
+
+
+def _prompt_command_parser(command: str):
+    tokens = shlex.split(command)
+    assert tokens[0] == "vibe"
+    parser = cli.build_parser()
+    path: list[str] = []
+    for token in tokens[1:]:
+        subparsers = next(
+            (
+                action
+                for action in parser._actions
+                if isinstance(action, argparse._SubParsersAction)
+            ),
+            None,
+        )
+        if subparsers is None or token not in subparsers.choices:
+            break
+        parser = subparsers.choices[token]
+        path.append(token)
+    return parser, tuple(path)
 
 
 def test_all_collection_commands_share_bounded_pagination_contract() -> None:
@@ -60,6 +85,32 @@ def test_all_collection_commands_share_bounded_pagination_contract() -> None:
         assert "--page" in flags, path
         assert "--limit" in flags, path
         assert "--all" not in flags, path
+
+
+def test_injected_vibe_commands_only_use_parser_supported_flags() -> None:
+    context = MessageContext(
+        user_id="user",
+        channel_id="channel",
+        platform="avibe",
+        platform_specific={"agent_session_id": "ses-test"},
+    )
+    prompt = build_system_prompt_injection(context=context)
+    commands = re.findall(r"`(vibe [^`\n]+)`", prompt)
+    checked_commands = 0
+
+    for command in commands:
+        mentioned_flags = set(re.findall(r"(?<![\w-])--[a-z][a-z0-9-]*", command))
+        if not mentioned_flags:
+            continue
+        parser, path = _prompt_command_parser(command)
+        unsupported_flags = mentioned_flags - _parser_flags(parser)
+        assert not unsupported_flags, (
+            f"Injected command {command!r} uses flags unsupported by "
+            f"{' '.join(('vibe', *path))}: {sorted(unsupported_flags)}"
+        )
+        checked_commands += 1
+
+    assert checked_commands >= 20
 
 
 def test_runs_list_cli_defaults_to_first_page(monkeypatch, tmp_path, capsys) -> None:

--- a/tests/test_cli_task_command.py
+++ b/tests/test_cli_task_command.py
@@ -237,7 +237,10 @@ def test_task_list_help_mentions_completed_one_shots_hidden_by_default(capsys) -
 
     assert exc.value.code == 0
     captured = capsys.readouterr()
-    assert "Completed one-shot tasks are hidden unless --all is used." in captured.out
+    assert "Finished one-shot tasks are hidden by default" in captured.out
+    assert "--include-finished" in captured.out
+    assert "--page" in captured.out
+    assert "--limit" in captured.out
     assert "--all" in captured.out
     assert "--brief" in captured.out
 
@@ -1006,6 +1009,61 @@ def test_task_list_brief_returns_scheduling_focused_view(tmp_path: Path, capsys)
     assert entry["state"] == "active"
 
 
+def test_task_list_defaults_to_first_page(tmp_path: Path, capsys) -> None:
+    store = cli.ScheduledTaskStore(tmp_path / "scheduled_tasks.json")
+    for index in range(25):
+        store.add_task(
+            name=f"Task {index:02d}",
+            session_key="slack::channel::C123",
+            prompt=f"task {index:02d}",
+            schedule_type="cron",
+            cron="0 * * * *",
+            timezone_name="UTC",
+        )
+
+    with patch("vibe.cli._task_store", return_value=store):
+        result = cli.cmd_task_list(brief=True)
+
+    assert result == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert len(payload["tasks"]) == 20
+    assert payload["pagination"] == {
+        "page": 1,
+        "limit": 20,
+        "returned": 20,
+        "has_more": True,
+        "next_page": 2,
+        "next_command": "vibe task list --brief --page 2 --limit 20",
+    }
+    assert payload["message"].endswith("vibe task list --brief --page 2 --limit 20")
+
+
+def test_task_list_cli_dispatches_pagination_flags(
+    tmp_path: Path,
+    capsys,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = cli.ScheduledTaskStore(tmp_path / "scheduled_tasks.json")
+    for index in range(3):
+        store.add_task(
+            name=f"Task {index}",
+            session_key="slack::channel::C123",
+            prompt=f"task {index}",
+            schedule_type="cron",
+            cron="0 * * * *",
+            timezone_name="UTC",
+        )
+
+    monkeypatch.setattr(sys, "argv", ["vibe", "task", "list", "--brief", "--limit", "2"])
+    with patch("vibe.cli._task_store", return_value=store), pytest.raises(SystemExit) as exc:
+        cli.main()
+
+    assert exc.value.code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert len(payload["tasks"]) == 2
+    assert payload["pagination"]["next_command"] == "vibe task list --brief --page 2 --limit 2"
+
+
 def test_task_list_sorts_by_next_run_instant_across_timezones(
     tmp_path: Path, capsys, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -1085,6 +1143,35 @@ def test_task_list_all_includes_completed_one_shots(tmp_path: Path, capsys) -> N
     payload = json.loads(capsys.readouterr().out)
     ids = [item["id"] for item in payload["tasks"]]
     assert done.id in ids
+    assert payload["pagination"]["has_more"] is False
+
+
+def test_task_list_include_finished_keeps_history_paginated(tmp_path: Path, capsys) -> None:
+    store = cli.ScheduledTaskStore(tmp_path / "scheduled_tasks.json")
+    for index in range(3):
+        done = store.add_task(
+            session_key="slack::channel::C123",
+            prompt=f"one-shot {index}",
+            schedule_type="at",
+            run_at="2026-03-31T09:00:00+08:00",
+            timezone_name="Asia/Shanghai",
+        )
+        store.mark_task_result(done.id, error=None)
+
+    with patch("vibe.cli._task_store", return_value=store):
+        result = cli.cmd_task_list(
+            include_finished=True,
+            brief=True,
+            page_request=cli.PageRequest(page=1, limit=2),
+        )
+
+    assert result == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert len(payload["tasks"]) == 2
+    assert payload["pagination"]["has_more"] is True
+    assert payload["pagination"]["next_command"] == (
+        "vibe task list --include-finished --brief --page 2 --limit 2"
+    )
 
 
 def test_task_run_enqueues_request(tmp_path: Path, capsys) -> None:

--- a/tests/test_cli_task_command.py
+++ b/tests/test_cli_task_command.py
@@ -78,10 +78,10 @@ def test_agent_enable_disable_cli_toggles_enabled_state(tmp_path: Path, capsys) 
         assert cli.cmd_agent_list(_parse_agent(["list", "--brief"])) == 0
         assert json.loads(capsys.readouterr().out)["agents"] == []
 
-        assert cli.cmd_agent_list(_parse_agent(["list", "--all", "--brief"])) == 0
-        all_payload = json.loads(capsys.readouterr().out)
-        assert all_payload["agents"][0]["name"] == "worker"
-        assert all_payload["agents"][0]["enabled"] is False
+        assert cli.cmd_agent_list(_parse_agent(["list", "--include-disabled"])) == 0
+        disabled_list_payload = json.loads(capsys.readouterr().out)
+        assert disabled_list_payload["agents"][0]["name"] == "worker"
+        assert disabled_list_payload["agents"][0]["enabled"] is False
 
         assert cli.cmd_agent_set_enabled(_parse_agent(["enable", "worker"]), enabled=True) == 0
         enabled_payload = json.loads(capsys.readouterr().out)
@@ -99,6 +99,24 @@ def test_disabled_agent_cannot_run(tmp_path: Path) -> None:
 
     assert result == 1
     assert payload["error"] == "agent 'worker' is disabled"
+
+
+def test_agent_list_is_bounded_and_compact_by_default(tmp_path: Path, capsys) -> None:
+    agent_store = cli.VibeAgentStore(tmp_path / "state" / "vibe.sqlite")
+    for index in range(25):
+        agent_store.create(
+            name=f"worker-{index:02d}",
+            backend="codex",
+            system_prompt="large detail that belongs in agent show",
+        )
+
+    with patch("vibe.cli._agent_store", return_value=agent_store):
+        assert cli.cmd_agent_list(_parse_agent(["list"])) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert len(payload["agents"]) == 20
+    assert "system_prompt" not in payload["agents"][0]
+    assert payload["pagination"]["next_command"] == "vibe agent list --page 2 --limit 20"
 
 
 def test_task_add_rejects_unsupported_platform() -> None:
@@ -241,8 +259,7 @@ def test_task_list_help_mentions_completed_one_shots_hidden_by_default(capsys) -
     assert "--include-finished" in captured.out
     assert "--page" in captured.out
     assert "--limit" in captured.out
-    assert "--all" in captured.out
-    assert "--brief" in captured.out
+    assert "--all" not in captured.out
 
 
 def test_task_update_help_includes_partial_update_guidance(capsys) -> None:
@@ -1033,9 +1050,9 @@ def test_task_list_defaults_to_first_page(tmp_path: Path, capsys) -> None:
         "returned": 20,
         "has_more": True,
         "next_page": 2,
-        "next_command": "vibe task list --brief --page 2 --limit 20",
+        "next_command": "vibe task list --page 2 --limit 20",
     }
-    assert payload["message"].endswith("vibe task list --brief --page 2 --limit 20")
+    assert payload["message"].endswith("vibe task list --page 2 --limit 20")
 
 
 def test_task_list_cli_dispatches_pagination_flags(
@@ -1054,17 +1071,17 @@ def test_task_list_cli_dispatches_pagination_flags(
             timezone_name="UTC",
         )
 
-    monkeypatch.setattr(sys, "argv", ["vibe", "task", "list", "--brief", "--limit", "2"])
+    monkeypatch.setattr(sys, "argv", ["vibe", "task", "list", "--limit", "2"])
     with patch("vibe.cli._task_store", return_value=store), pytest.raises(SystemExit) as exc:
         cli.main()
 
     assert exc.value.code == 0
     payload = json.loads(capsys.readouterr().out)
     assert len(payload["tasks"]) == 2
-    assert payload["pagination"]["next_command"] == "vibe task list --brief --page 2 --limit 2"
+    assert payload["pagination"]["next_command"] == "vibe task list --page 2 --limit 2"
 
 
-def test_task_list_sorts_by_next_run_instant_across_timezones(
+def test_task_list_order_is_stable_across_cron_boundaries(
     tmp_path: Path, capsys, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     store_path = tmp_path / "scheduled_tasks.json"
@@ -1085,19 +1102,29 @@ def test_task_list_sorts_by_next_run_instant_across_timezones(
         cron="0 * * * *",
         timezone_name="Asia/Shanghai",
     )
-    next_runs = {
+    later.created_at = "2026-04-01T00:00:00+00:00"
+    earlier.created_at = "2026-04-01T00:00:01+00:00"
+    first_next_runs = {
         later.id: "2026-04-01T09:30:00+08:00",
         earlier.id: "2026-04-01T01:00:00+00:00",
     }
-    monkeypatch.setattr(cli, "_task_next_run_at", lambda task: next_runs[task.id])
+    monkeypatch.setattr(cli, "_task_next_run_at", lambda task: first_next_runs[task.id])
 
     with patch("vibe.cli._task_store", return_value=store):
-        result = cli.cmd_task_list(brief=True)
+        assert cli.cmd_task_list(brief=True) == 0
 
-    assert result == 0
-    payload = json.loads(capsys.readouterr().out)
-    ordered_ids = [item["id"] for item in payload["tasks"]]
-    assert ordered_ids == [earlier.id, later.id]
+    first_ids = [item["id"] for item in json.loads(capsys.readouterr().out)["tasks"]]
+
+    second_next_runs = {
+        later.id: "2026-04-01T02:00:00+00:00",
+        earlier.id: "2026-04-01T10:00:00+00:00",
+    }
+    monkeypatch.setattr(cli, "_task_next_run_at", lambda task: second_next_runs[task.id])
+    with patch("vibe.cli._task_store", return_value=store):
+        assert cli.cmd_task_list(brief=True) == 0
+
+    second_ids = [item["id"] for item in json.loads(capsys.readouterr().out)["tasks"]]
+    assert second_ids == first_ids == [later.id, earlier.id]
 
 
 def test_task_show_includes_derived_schedule_fields(tmp_path: Path, capsys) -> None:
@@ -1124,7 +1151,7 @@ def test_task_show_includes_derived_schedule_fields(tmp_path: Path, capsys) -> N
     assert payload["task"]["last_status"] == "never_run"
 
 
-def test_task_list_all_includes_completed_one_shots(tmp_path: Path, capsys) -> None:
+def test_task_list_include_finished_includes_completed_one_shots(tmp_path: Path, capsys) -> None:
     store_path = tmp_path / "scheduled_tasks.json"
     store = cli.ScheduledTaskStore(store_path)
     done = store.add_task(
@@ -1137,7 +1164,7 @@ def test_task_list_all_includes_completed_one_shots(tmp_path: Path, capsys) -> N
     store.mark_task_result(done.id, error=None)
 
     with patch("vibe.cli._task_store", return_value=store):
-        result = cli.cmd_task_list(include_all=True)
+        result = cli.cmd_task_list(include_finished=True)
 
     assert result == 0
     payload = json.loads(capsys.readouterr().out)
@@ -1170,7 +1197,7 @@ def test_task_list_include_finished_keeps_history_paginated(tmp_path: Path, caps
     assert len(payload["tasks"]) == 2
     assert payload["pagination"]["has_more"] is True
     assert payload["pagination"]["next_command"] == (
-        "vibe task list --include-finished --brief --page 2 --limit 2"
+        "vibe task list --include-finished --page 2 --limit 2"
     )
 
 

--- a/tests/test_cli_task_command.py
+++ b/tests/test_cli_task_command.py
@@ -1036,6 +1036,30 @@ def test_task_list_brief_returns_scheduling_focused_view(tmp_path: Path, capsys)
     assert entry["state"] == "active"
 
 
+def test_paused_recurring_task_keeps_failed_run_in_last_status(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    store = cli.ScheduledTaskStore(tmp_path / "scheduled_tasks.json")
+    task = store.add_task(
+        name="Paused after failure",
+        session_key="slack::channel::C123",
+        prompt="recurring",
+        schedule_type="cron",
+        cron="0 * * * *",
+        timezone_name="UTC",
+    )
+    store.mark_task_result(task.id, error="delivery failed")
+    store.set_enabled(task.id, False)
+
+    with patch("vibe.cli._task_store", return_value=store):
+        assert cli.cmd_task_list(brief=True) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["tasks"][0]["state"] == "paused"
+    assert payload["tasks"][0]["last_status"] == "failed"
+
+
 def test_task_list_defaults_to_first_page(tmp_path: Path, capsys) -> None:
     store = cli.ScheduledTaskStore(tmp_path / "scheduled_tasks.json")
     for index in range(25):

--- a/tests/test_cli_task_command.py
+++ b/tests/test_cli_task_command.py
@@ -1065,6 +1065,39 @@ def test_task_list_defaults_to_first_page(tmp_path: Path, capsys) -> None:
     assert payload["message"].endswith("vibe task list --page 2 --limit 20")
 
 
+def test_task_list_keeps_enabled_tasks_ahead_of_paused_history(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    store = cli.ScheduledTaskStore(tmp_path / "scheduled_tasks.json")
+    for index in range(21):
+        paused = store.add_task(
+            name=f"Paused {index:02d}",
+            session_key="slack::channel::C123",
+            prompt=f"paused {index:02d}",
+            schedule_type="cron",
+            cron="0 * * * *",
+            timezone_name="UTC",
+        )
+        store.set_enabled(paused.id, False)
+    active = store.add_task(
+        name="Active",
+        session_key="slack::channel::C123",
+        prompt="active",
+        schedule_type="cron",
+        cron="0 * * * *",
+        timezone_name="UTC",
+    )
+
+    with patch("vibe.cli._task_store", return_value=store):
+        assert cli.cmd_task_list(brief=True) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["tasks"][0]["id"] == active.id
+    assert payload["tasks"][0]["state"] == "active"
+    assert payload["pagination"]["has_more"] is True
+
+
 def test_task_list_cli_dispatches_pagination_flags(
     tmp_path: Path,
     capsys,

--- a/tests/test_cli_task_command.py
+++ b/tests/test_cli_task_command.py
@@ -255,7 +255,7 @@ def test_task_list_help_mentions_completed_one_shots_hidden_by_default(capsys) -
 
     assert exc.value.code == 0
     captured = capsys.readouterr()
-    assert "Finished one-shot tasks are hidden by default" in captured.out
+    assert "Successful one-shot tasks are hidden by default" in captured.out
     assert "--include-finished" in captured.out
     assert "--page" in captured.out
     assert "--limit" in captured.out
@@ -991,6 +991,14 @@ def test_task_list_hides_completed_one_shots_by_default(tmp_path: Path, capsys) 
         timezone_name="Asia/Shanghai",
     )
     store.mark_task_result(done.id, error=None)
+    failed = store.add_task(
+        session_key="slack::channel::C123",
+        prompt="failed one-shot",
+        schedule_type="at",
+        run_at="2026-03-31T10:00:00+08:00",
+        timezone_name="Asia/Shanghai",
+    )
+    store.mark_task_result(failed.id, error="delivery failed")
 
     with patch("vibe.cli._task_store", return_value=store):
         result = cli.cmd_task_list()
@@ -999,6 +1007,8 @@ def test_task_list_hides_completed_one_shots_by_default(tmp_path: Path, capsys) 
     payload = json.loads(capsys.readouterr().out)
     ids = [item["id"] for item in payload["tasks"]]
     assert done.id not in ids
+    assert failed.id in ids
+    assert next(item for item in payload["tasks"] if item["id"] == failed.id)["state"] == "failed"
 
 
 def test_task_list_brief_returns_scheduling_focused_view(tmp_path: Path, capsys) -> None:

--- a/tests/test_cli_watch_command.py
+++ b/tests/test_cli_watch_command.py
@@ -125,7 +125,7 @@ def test_watch_list_help_describes_bounded_history(capsys) -> None:
     assert "--include-finished" in captured.out
     assert "--page" in captured.out
     assert "--limit" in captured.out
-    assert "--all" in captured.out
+    assert "--all" not in captured.out
 
 
 def test_watch_add_parser_keeps_top_level_command_name() -> None:
@@ -881,6 +881,26 @@ def test_watch_list_hides_finished_one_shots_by_default(tmp_path: Path, capsys) 
     assert failed.id not in ids
 
 
+def test_resumed_then_paused_one_shot_remains_in_default_list(tmp_path: Path, capsys) -> None:
+    store = ManagedWatchStore(tmp_path / "watches.json")
+    runtime_store = WatchRuntimeStateStore(tmp_path / "watch_runtime.json")
+    watch = _add_test_watch(store, name="Resumable")
+    store.mark_cycle_result(watch.id, exit_code=0, error=None, event_detected=True, disable=True)
+
+    store.set_enabled(watch.id, True)
+    store.set_enabled(watch.id, False)
+
+    with (
+        patch("vibe.cli._watch_store", return_value=store),
+        patch("vibe.cli._watch_runtime_store", return_value=runtime_store),
+    ):
+        assert cli.cmd_watch_list() == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert [item["id"] for item in payload["watches"]] == [watch.id]
+    assert payload["watches"][0]["state"] == "paused"
+
+
 def test_watch_list_defaults_to_first_page(tmp_path: Path, capsys) -> None:
     store = ManagedWatchStore(tmp_path / "watches.json")
     runtime_store = WatchRuntimeStateStore(tmp_path / "watch_runtime.json")
@@ -902,7 +922,7 @@ def test_watch_list_defaults_to_first_page(tmp_path: Path, capsys) -> None:
         "returned": 20,
         "has_more": True,
         "next_page": 2,
-        "next_command": "vibe watch list --brief --page 2 --limit 20",
+        "next_command": "vibe watch list --page 2 --limit 20",
     }
 
 
@@ -916,7 +936,7 @@ def test_watch_list_cli_dispatches_pagination_flags(
     for index in range(3):
         _add_test_watch(store, name=f"Watch {index}")
 
-    monkeypatch.setattr(sys, "argv", ["vibe", "watch", "list", "--brief", "--limit", "2"])
+    monkeypatch.setattr(sys, "argv", ["vibe", "watch", "list", "--limit", "2"])
     with (
         patch("vibe.cli._watch_store", return_value=store),
         patch("vibe.cli._watch_runtime_store", return_value=runtime_store),
@@ -927,7 +947,7 @@ def test_watch_list_cli_dispatches_pagination_flags(
     assert exc.value.code == 0
     payload = json.loads(capsys.readouterr().out)
     assert len(payload["watches"]) == 2
-    assert payload["pagination"]["next_command"] == "vibe watch list --brief --page 2 --limit 2"
+    assert payload["pagination"]["next_command"] == "vibe watch list --page 2 --limit 2"
 
 
 def test_watch_list_include_finished_keeps_history_paginated(tmp_path: Path, capsys) -> None:
@@ -952,7 +972,7 @@ def test_watch_list_include_finished_keeps_history_paginated(tmp_path: Path, cap
     assert len(payload["watches"]) == 2
     assert payload["pagination"]["has_more"] is True
     assert payload["pagination"]["next_command"] == (
-        "vibe watch list --include-finished --brief --page 2 --limit 2"
+        "vibe watch list --include-finished --page 2 --limit 2"
     )
 
 

--- a/tests/test_cli_watch_command.py
+++ b/tests/test_cli_watch_command.py
@@ -121,7 +121,7 @@ def test_watch_list_help_describes_bounded_history(capsys) -> None:
 
     assert exc.value.code == 0
     captured = capsys.readouterr()
-    assert "Finished one-shot watches are hidden by default" in captured.out
+    assert "Successful one-shot watches are hidden by default" in captured.out
     assert "--include-finished" in captured.out
     assert "--page" in captured.out
     assert "--limit" in captured.out
@@ -876,9 +876,9 @@ def test_watch_list_hides_finished_one_shots_by_default(tmp_path: Path, capsys) 
     assert result == 0
     payload = json.loads(capsys.readouterr().out)
     ids = {item["id"] for item in payload["watches"]}
-    assert ids == {active.id, paused.id, failed_forever.id}
+    assert ids == {active.id, failed.id, paused.id, failed_forever.id}
     assert completed.id not in ids
-    assert failed.id not in ids
+    assert next(item for item in payload["watches"] if item["id"] == failed.id)["state"] == "failed"
 
 
 def test_resumed_then_paused_one_shot_remains_in_default_list(tmp_path: Path, capsys) -> None:

--- a/tests/test_cli_watch_command.py
+++ b/tests/test_cli_watch_command.py
@@ -56,6 +56,29 @@ def _startup_ok(store: ManagedWatchStore, runtime_store: WatchRuntimeStateStore,
     return store.get_watch(watch_id), runtime_store.load().get("watches", {}).get(watch_id)
 
 
+def _add_test_watch(
+    store: ManagedWatchStore,
+    *,
+    name: str,
+    mode: str = "once",
+):
+    return store.add_watch(
+        name=name,
+        session_key="slack::channel::C123",
+        command=["python3", "wait.py"],
+        shell_command=None,
+        prefix=None,
+        cwd=None,
+        mode=mode,
+        timeout_seconds=600,
+        lifetime_timeout_seconds=0,
+        retry_exit_codes=[75],
+        retry_delay_seconds=30,
+        post_to=None,
+        deliver_key=None,
+    )
+
+
 def test_watch_help_describes_session_id_guidance(capsys) -> None:
     parser = cli.build_parser()
 
@@ -88,6 +111,21 @@ def test_watch_add_help_mentions_shell_and_lifetime_timeout(capsys) -> None:
     assert "--scope-id" in captured.out
     assert "--post-to" not in captured.out
     assert "--deliver-key" not in captured.out
+
+
+def test_watch_list_help_describes_bounded_history(capsys) -> None:
+    parser = cli.build_parser()
+
+    with pytest.raises(SystemExit) as exc:
+        parser.parse_args(["watch", "list", "--help"])
+
+    assert exc.value.code == 0
+    captured = capsys.readouterr()
+    assert "Finished one-shot watches are hidden by default" in captured.out
+    assert "--include-finished" in captured.out
+    assert "--page" in captured.out
+    assert "--limit" in captured.out
+    assert "--all" in captured.out
 
 
 def test_watch_add_parser_keeps_top_level_command_name() -> None:
@@ -814,6 +852,108 @@ def test_watch_list_brief_includes_runtime_state(tmp_path: Path, capsys) -> None
     payload = json.loads(capsys.readouterr().out)
     assert payload["watches"][0]["state"] == "running"
     assert payload["watches"][0]["mode"] == "forever"
+
+
+def test_watch_list_hides_finished_one_shots_by_default(tmp_path: Path, capsys) -> None:
+    store = ManagedWatchStore(tmp_path / "watches.json")
+    runtime_store = WatchRuntimeStateStore(tmp_path / "watch_runtime.json")
+    active = _add_test_watch(store, name="Active")
+    completed = _add_test_watch(store, name="Completed")
+    failed = _add_test_watch(store, name="Failed")
+    paused = _add_test_watch(store, name="Paused")
+    failed_forever = _add_test_watch(store, name="Failed forever", mode="forever")
+    store.mark_cycle_result(completed.id, exit_code=0, error=None, event_detected=True, disable=True)
+    store.mark_cycle_result(failed.id, exit_code=1, error="failed", disable=True)
+    store.set_enabled(paused.id, False)
+    store.mark_cycle_result(failed_forever.id, exit_code=1, error="failed", disable=True)
+
+    with (
+        patch("vibe.cli._watch_store", return_value=store),
+        patch("vibe.cli._watch_runtime_store", return_value=runtime_store),
+    ):
+        result = cli.cmd_watch_list(brief=True)
+
+    assert result == 0
+    payload = json.loads(capsys.readouterr().out)
+    ids = {item["id"] for item in payload["watches"]}
+    assert ids == {active.id, paused.id, failed_forever.id}
+    assert completed.id not in ids
+    assert failed.id not in ids
+
+
+def test_watch_list_defaults_to_first_page(tmp_path: Path, capsys) -> None:
+    store = ManagedWatchStore(tmp_path / "watches.json")
+    runtime_store = WatchRuntimeStateStore(tmp_path / "watch_runtime.json")
+    for index in range(25):
+        _add_test_watch(store, name=f"Watch {index:02d}")
+
+    with (
+        patch("vibe.cli._watch_store", return_value=store),
+        patch("vibe.cli._watch_runtime_store", return_value=runtime_store),
+    ):
+        result = cli.cmd_watch_list(brief=True)
+
+    assert result == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert len(payload["watches"]) == 20
+    assert payload["pagination"] == {
+        "page": 1,
+        "limit": 20,
+        "returned": 20,
+        "has_more": True,
+        "next_page": 2,
+        "next_command": "vibe watch list --brief --page 2 --limit 20",
+    }
+
+
+def test_watch_list_cli_dispatches_pagination_flags(
+    tmp_path: Path,
+    capsys,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = ManagedWatchStore(tmp_path / "watches.json")
+    runtime_store = WatchRuntimeStateStore(tmp_path / "watch_runtime.json")
+    for index in range(3):
+        _add_test_watch(store, name=f"Watch {index}")
+
+    monkeypatch.setattr(sys, "argv", ["vibe", "watch", "list", "--brief", "--limit", "2"])
+    with (
+        patch("vibe.cli._watch_store", return_value=store),
+        patch("vibe.cli._watch_runtime_store", return_value=runtime_store),
+        pytest.raises(SystemExit) as exc,
+    ):
+        cli.main()
+
+    assert exc.value.code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert len(payload["watches"]) == 2
+    assert payload["pagination"]["next_command"] == "vibe watch list --brief --page 2 --limit 2"
+
+
+def test_watch_list_include_finished_keeps_history_paginated(tmp_path: Path, capsys) -> None:
+    store = ManagedWatchStore(tmp_path / "watches.json")
+    runtime_store = WatchRuntimeStateStore(tmp_path / "watch_runtime.json")
+    for index in range(3):
+        watch = _add_test_watch(store, name=f"Finished {index}")
+        store.mark_cycle_result(watch.id, exit_code=0, error=None, event_detected=True, disable=True)
+
+    with (
+        patch("vibe.cli._watch_store", return_value=store),
+        patch("vibe.cli._watch_runtime_store", return_value=runtime_store),
+    ):
+        result = cli.cmd_watch_list(
+            include_finished=True,
+            brief=True,
+            page_request=cli.PageRequest(page=1, limit=2),
+        )
+
+    assert result == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert len(payload["watches"]) == 2
+    assert payload["pagination"]["has_more"] is True
+    assert payload["pagination"]["next_command"] == (
+        "vibe watch list --include-finished --brief --page 2 --limit 2"
+    )
 
 
 def test_watch_show_missing_returns_structured_error() -> None:

--- a/tests/test_cli_watch_command.py
+++ b/tests/test_cli_watch_command.py
@@ -901,6 +901,45 @@ def test_resumed_then_paused_one_shot_remains_in_default_list(tmp_path: Path, ca
     assert payload["watches"][0]["state"] == "paused"
 
 
+def test_paused_forever_watch_changed_to_once_starts_new_lifecycle(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    store = ManagedWatchStore(tmp_path / "watches.json")
+    runtime_store = WatchRuntimeStateStore(tmp_path / "watch_runtime.json")
+    watch = _add_test_watch(store, name="Change mode", mode="forever")
+    store.mark_cycle_result(watch.id, exit_code=0, error=None, event_detected=True, disable=False)
+    store.set_enabled(watch.id, False)
+    args = _parse_watch_update([watch.id, "--once"])
+
+    with (
+        patch("vibe.cli._ensure_config", return_value=_configured_v2({"slack"})),
+        patch("vibe.cli._watch_store", return_value=store),
+        patch("vibe.cli._watch_runtime_store", return_value=runtime_store),
+    ):
+        assert cli.cmd_watch_update(args) == 0
+
+    updated = store.get_watch(watch.id)
+    assert updated is not None
+    assert updated.mode == "once"
+    assert updated.last_started_at is None
+    assert updated.last_finished_at is None
+    assert updated.last_event_at is None
+    assert updated.last_exit_code is None
+    assert updated.last_error is None
+
+    capsys.readouterr()
+    with (
+        patch("vibe.cli._watch_store", return_value=store),
+        patch("vibe.cli._watch_runtime_store", return_value=runtime_store),
+    ):
+        assert cli.cmd_watch_list() == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert [item["id"] for item in payload["watches"]] == [watch.id]
+    assert payload["watches"][0]["state"] == "paused"
+
+
 def test_watch_list_defaults_to_first_page(tmp_path: Path, capsys) -> None:
     store = ManagedWatchStore(tmp_path / "watches.json")
     runtime_store = WatchRuntimeStateStore(tmp_path / "watch_runtime.json")

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -24,5 +24,3 @@ def test_make_page_request_validates_bounds() -> None:
 
     with pytest.raises(ValueError, match="limit must be <= 100"):
         make_page_request(limit=101)
-
-    assert make_page_request(all_items=True) is None

--- a/tests/test_session_cli.py
+++ b/tests/test_session_cli.py
@@ -101,16 +101,15 @@ def test_list_avibe_type_includes_foreground_standalone(monkeypatch, tmp_path, c
     }
 
 
-def test_list_pagination_fixed_ten_no_limit_flag(monkeypatch, tmp_path, capsys):
+def test_list_uses_shared_pagination_contract(monkeypatch, tmp_path, capsys):
     engine = _setup(monkeypatch, tmp_path)
-    for i in range(12):
+    for i in range(22):
         _seed(engine, f"ses{i:02d}", platform="slack", native="C1", last_active=f"2026-06-09T10:{i:02d}:00Z")
     _, page1 = _run(cli.cmd_session_list, ["session", "list"], capsys)
-    assert len(page1["sessions"]) == 10
+    assert len(page1["sessions"]) == 20
     assert page1["pagination"]["has_more"] is True
-    assert page1["pagination"]["next_command"] == "vibe session list --page 2"
-    assert "--limit" not in page1["pagination"]["next_command"]
-    _, page2 = _run(cli.cmd_session_list, ["session", "list", "--page", "2"], capsys)
+    assert page1["pagination"]["next_command"] == "vibe session list --page 2 --limit 20"
+    _, page2 = _run(cli.cmd_session_list, ["session", "list", "--page", "2", "--limit", "20"], capsys)
     assert len(page2["sessions"]) == 2
     assert page2["pagination"]["has_more"] is False
 

--- a/tests/test_show_pages.py
+++ b/tests/test_show_pages.py
@@ -2514,6 +2514,43 @@ def test_show_marks_filters_resolved_and_unmark_reports_partial_success(monkeypa
         store.close()
 
 
+def test_show_marks_uses_shared_pagination(monkeypatch, tmp_path, capsys):
+    from core.show_session_events import ShowSessionEventStore, stable_assistant_mark_id
+
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    paths.ensure_data_dirs()
+    _save_config()
+    _seed_show_cli_session()
+    store = ShowSessionEventStore()
+    try:
+        for index in range(25):
+            target = f"#mark-{index:02d}"
+            store.append(
+                "ses123",
+                {
+                    "type": "assistant.mark.created",
+                    "mark": {
+                        "id": stable_assistant_mark_id(scope="default", target=target),
+                        "target": target,
+                        "body": f"Mark {index}",
+                    },
+                },
+            )
+    finally:
+        store.close()
+
+    args = cli.build_parser().parse_args(
+        ["show", "marks", "--session-id", "ses123", "--json"]
+    )
+    assert cli.cmd_show(args) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert len(payload["marks"]) == 20
+    assert payload["pagination"]["next_command"] == (
+        "vibe show marks --session-id ses123 --json --page 2 --limit 20"
+    )
+
+
 def test_show_event_cli_records_generic_event(monkeypatch, tmp_path, capsys):
     from sqlalchemy import select
 

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -66,7 +66,14 @@ from vibe.upgrade import (
 from storage.db import create_sqlite_engine
 from storage.background import compute_next_run_at, normalize_run_status
 from storage.models import scope_settings, scopes
-from storage.pagination import DEFAULT_PAGE_LIMIT, PageRequest, make_page_request, page_sequence, pagination_payload
+from storage.pagination import (
+    DEFAULT_PAGE_LIMIT,
+    MAX_PAGE_LIMIT,
+    PageRequest,
+    make_page_request,
+    page_sequence,
+    pagination_payload,
+)
 from storage.read_only_query import ReadOnlyQueryError, run_read_only_query
 from storage.settings_service import make_scope_id
 
@@ -207,13 +214,12 @@ def _print_cli_payload(kind: str, **fields) -> None:
     print(json.dumps(_cli_payload(kind, **fields), indent=2))
 
 
-def _add_pagination_args(parser, *, help_command: str, all_help: str | None = None) -> None:
+def _add_pagination_args(parser, *, help_command: str) -> None:
     parser.add_argument("--page", type=int, help="Page number to return. Defaults to 1.")
-    parser.add_argument("--limit", type=int, help=f"Rows per page. Defaults to {DEFAULT_PAGE_LIMIT}.")
     parser.add_argument(
-        "--all",
-        action="store_true",
-        help=all_help or "Return all matching rows without pagination.",
+        "--limit",
+        type=int,
+        help=f"Rows per page. Defaults to {DEFAULT_PAGE_LIMIT}; maximum {MAX_PAGE_LIMIT}.",
     )
     parser.error_help_command = help_command
 
@@ -235,12 +241,11 @@ def _add_vault_approval_wait_args(parser, *, default_seconds: int = DEFAULT_VAUL
     )
 
 
-def _page_request_from_args(args, *, help_command: str) -> PageRequest | None:
+def _page_request_from_args(args, *, help_command: str) -> PageRequest:
     try:
         return make_page_request(
             page=getattr(args, "page", None),
             limit=getattr(args, "limit", None),
-            all_items=bool(getattr(args, "all", False)),
         )
     except ValueError as exc:
         raise TaskCliError(str(exc), code="invalid_pagination", help_command=help_command) from exc
@@ -251,8 +256,8 @@ def _add_optional_arg(parts: list[str], flag: str, value: object) -> None:
         parts.extend([flag, str(value)])
 
 
-def _next_command(parts: list[str], page_result, *, include_all: bool = False) -> str | None:
-    if include_all or page_result.next_page is None:
+def _next_command(parts: list[str], page_result) -> str | None:
+    if page_result.next_page is None:
         return None
     command = [*parts, "--page", str(page_result.next_page), "--limit", str(page_result.limit)]
     return shlex.join(command)
@@ -267,29 +272,33 @@ def _pagination_message(page_payload: dict) -> str | None:
     return "More records are available. Add --page to continue."
 
 
+def _paginated_fields(page_result, *, command: list[str], include_next_command: bool = True) -> dict:
+    page_payload = pagination_payload(
+        page_result,
+        next_command=_next_command(command, page_result) if include_next_command else None,
+    )
+    fields = {"pagination": page_payload}
+    message = _pagination_message(page_payload)
+    if message:
+        fields["message"] = message
+    return fields
+
+
 def _print_definition_list_payload(
     items,
     *,
     items_key: str,
     payload_for_item,
     command: list[str],
-    include_all: bool,
-    page_request: PageRequest | None,
+    page_request: PageRequest,
 ) -> None:
-    result = page_sequence(items, None if include_all else (page_request or PageRequest()))
+    result = page_sequence(items, page_request)
     item_payloads = [payload_for_item(item) for item in result.items]
-    page_payload = pagination_payload(
-        result,
-        next_command=_next_command(command, result, include_all=include_all),
-    )
     payload = {
         "definitions": item_payloads,
         items_key: item_payloads,
-        "pagination": page_payload,
+        **_paginated_fields(result, command=command),
     }
-    message = _pagination_message(page_payload)
-    if message:
-        payload["message"] = message
     _print_cli_payload("run_definitions", **payload)
 
 
@@ -428,7 +437,7 @@ def _watch_examples_text() -> str:
           vibe watch add --session-id sesk8m4q2p7x --name 'Wait for export' --message 'The export finished. Inspect it and continue.' --shell 'python3 scripts/wait_for_export.py'
           vibe watch add --create-session --scope-id slack::channel::C123 --message 'The CI job finished. Inspect the result.' -- python3 scripts/wait_for_ci.py --build 42
           vibe watch add --session-id sesk8m4q2p7x --forever --retry-exit-code 75 --retry-delay 60 --message 'The log pattern appeared. Continue from the result below.' --shell 'bash scripts/wait_for_log_pattern.sh'
-          vibe watch list --brief
+          vibe watch list
           vibe watch show 12ab34cd56ef
           vibe watch pause 12ab34cd56ef
         """
@@ -1519,21 +1528,6 @@ def _task_schedule_summary(task) -> str:
     return task.schedule_type
 
 
-def _task_next_run_sort_key(task):
-    next_run_at = _task_next_run_at(task)
-    if not next_run_at:
-        return (True, datetime.max.replace(tzinfo=timezone.utc))
-    try:
-        instant = datetime.fromisoformat(next_run_at)
-        if instant.tzinfo is None:
-            instant = instant.replace(tzinfo=timezone.utc)
-        else:
-            instant = instant.astimezone(timezone.utc)
-    except ValueError:
-        return (True, datetime.max.replace(tzinfo=timezone.utc))
-    return (False, instant)
-
-
 def _task_payload(task, *, brief: bool = False):
     derived = {
         "display_name": _task_display_name(task),
@@ -1567,14 +1561,9 @@ def _task_payload(task, *, brief: bool = False):
 
 
 def _sort_tasks_for_display(tasks):
-    return sorted(
-        tasks,
-        key=lambda item: (
-            *_task_next_run_sort_key(item),
-            item.created_at,
-            item.id,
-        ),
-    )
+    # Offset pagination requires an order that does not change merely because
+    # wall-clock time crossed a cron boundary between page requests.
+    return sorted(tasks, key=lambda item: (item.created_at, item.id))
 
 
 def _task_store() -> ScheduledTaskStore:
@@ -2637,27 +2626,23 @@ def cmd_task_add(args):
 
 def cmd_task_list(
     *,
-    include_all: bool = False,
     include_finished: bool = False,
-    brief: bool = False,
-    page_request: PageRequest | None = None,
+    brief: bool = True,
+    page_request: PageRequest = PageRequest(),
 ):
     store = _task_store()
     tasks = store.list_tasks()
-    if not include_all and not include_finished:
+    if not include_finished:
         tasks = [task for task in tasks if not _is_completed_one_shot(task)]
     tasks = _sort_tasks_for_display(tasks)
     command = ["vibe", "task", "list"]
     if include_finished:
         command.append("--include-finished")
-    if brief:
-        command.append("--brief")
     _print_definition_list_payload(
         tasks,
         items_key="tasks",
-        payload_for_item=lambda task: _task_payload(task, brief=brief),
+        payload_for_item=lambda task: _task_payload(task, brief=True),
         command=command,
-        include_all=include_all,
         page_request=page_request,
     )
     return 0
@@ -3182,20 +3167,33 @@ def _add_json_noop(parser) -> None:
 
 
 def cmd_agent_list(args):
-    store = _agent_store()
-    backend = getattr(args, "backend", None)
-    if getattr(args, "disabled", False):
-        include_disabled = True
-    else:
-        include_disabled = bool(getattr(args, "all", False))
-    agents = store.list_agents(include_disabled=include_disabled)
-    if backend:
-        agents = [agent for agent in agents if agent.backend == backend]
-    if getattr(args, "disabled", False):
-        agents = [agent for agent in agents if not agent.enabled]
-    agents = [_agent_payload(agent, brief=getattr(args, "brief", False)) for agent in agents]
-    _print_cli_payload("agents", agents=agents)
-    return 0
+    try:
+        page_request = _page_request_from_args(args, help_command="vibe agent list --help")
+        store = _agent_store()
+        backend = getattr(args, "backend", None)
+        disabled_only = bool(getattr(args, "disabled", False))
+        include_disabled = disabled_only or bool(getattr(args, "include_disabled", False))
+        agents = store.list_agents(include_disabled=include_disabled)
+        if backend:
+            agents = [agent for agent in agents if agent.backend == backend]
+        if disabled_only:
+            agents = [agent for agent in agents if not agent.enabled]
+        result = page_sequence(agents, page_request)
+        command = ["vibe", "agent", "list"]
+        _add_optional_arg(command, "--backend", backend)
+        if disabled_only:
+            command.append("--disabled")
+        elif include_disabled:
+            command.append("--include-disabled")
+        _print_cli_payload(
+            "agents",
+            agents=[_agent_payload(agent, brief=True) for agent in result.items],
+            **_paginated_fields(result, command=command),
+        )
+        return 0
+    except Exception as exc:
+        _print_task_error(exc, help_command="vibe agent list --help")
+        return 1
 
 
 def cmd_agent_show(args):
@@ -3297,6 +3295,15 @@ def cmd_agent_models(args):
         models = options.get("models", [])
         if model:
             models = [entry for entry in models if entry.get("value") == model]
+        page_request = _page_request_from_args(args, help_command="vibe agent models --help")
+        result = page_sequence(models, page_request)
+        command = ["vibe", "agent", "models"]
+        if name:
+            command.append(name)
+        else:
+            _add_optional_arg(command, "--backend", backend_arg)
+        _add_optional_arg(command, "--provider", provider)
+        _add_optional_arg(command, "--model", model)
         _print_cli_payload(
             "agent_models",
             agent=agent.name if agent else None,
@@ -3304,10 +3311,11 @@ def cmd_agent_models(args):
             current=current,
             default_model=options.get("default_model"),
             providers=options.get("providers"),
-            models=models,
+            models=result.items,
             source=options.get("source"),
             live=options.get("live", False),
             notes=options.get("notes"),
+            **_paginated_fields(result, command=command),
         )
         return 0
     except Exception as exc:
@@ -4417,14 +4425,10 @@ def cmd_runs_list(args):
         _add_optional_arg(command, "--q", getattr(args, "query", None))
         if getattr(args, "brief", False):
             command.append("--brief")
-        page_payload = pagination_payload(result, next_command=_next_command(command, result, include_all=bool(getattr(args, "all", False))))
-        message = _pagination_message(page_payload)
         payload = {
-            "runs": [_run_payload(run, brief=getattr(args, "brief", False)) for run in result.items],
-            "pagination": page_payload,
+            "runs": [_run_payload(run, brief=True) for run in result.items],
+            **_paginated_fields(result, command=command),
         }
-        if message:
-            payload["message"] = message
         _print_cli_payload("agent_runs", **payload)
         return 0
     except Exception as exc:
@@ -4651,22 +4655,15 @@ def cmd_data_query(args):
         elif sql_file and sql_file != "-":
             _add_optional_arg(command, "--sql-file", sql_file)
         omit_next_command = bool(sql_file == "-")
-        page_payload = pagination_payload(
-            result.pagination,
-            next_command=_next_command(
-                command,
-                result.pagination,
-                include_all=bool(getattr(args, "all", False)) or omit_next_command,
-            ),
-        )
-        message = _pagination_message(page_payload)
         payload = {
             "columns": result.columns,
             "rows": result.rows,
-            "pagination": page_payload,
+            **_paginated_fields(
+                result.pagination,
+                command=command,
+                include_next_command=not omit_next_command,
+            ),
         }
-        if message:
-            payload["message"] = message
         _print_cli_payload("data_query", **payload)
         return 0
     except ReadOnlyQueryError as exc:
@@ -4681,7 +4678,6 @@ def cmd_data_query(args):
 # read-only; ``update`` edits title, visibility, or scope placement. All three go through the shared
 # ``core.services.sessions`` business API (same entry the UI server uses) and
 # never surface archived (soft-deleted) sessions.
-_SESSION_PAGE_SIZE = 10
 # Lean list row: enough to locate a session and tell whether it is busy.
 _SESSION_LIST_FIELDS = (
     "id",
@@ -4747,29 +4743,29 @@ def cmd_session_list(args):
         platform = getattr(args, "type", None)
         if platform:
             _validate_session_type(platform)
-        page = getattr(args, "page", None)
-        page = int(page) if page is not None else 1
-        if page < 1:
-            raise TaskCliError("page must be >= 1", code="invalid_pagination", help_command="vibe session list --help")
+        page_request = _page_request_from_args(args, help_command="vibe session list --help")
         from core.services import sessions as sessions_service
 
         engine = _open_session_engine()
         with engine.connect() as conn:
             result = sessions_service.list_sessions_page(
-                conn, platform=platform, page=page, limit=_SESSION_PAGE_SIZE
+                conn,
+                platform=platform,
+                page=page_request.page,
+                limit=page_request.limit,
             )
         command = ["vibe", "session", "list"]
         _add_optional_arg(command, "--type", platform)
-        next_command = (
-            shlex.join([*command, "--page", str(result.next_page)])
-            if result.next_page is not None
-            else None
-        )
+        page_fields = _paginated_fields(result, command=command)
+        pagination_message = page_fields.pop("message", None)
+        message = _session_list_hint()
+        if pagination_message:
+            message = f"{pagination_message} {message}"
         _print_cli_payload(
             "agent_sessions",
             sessions=[_session_row(row, brief=True) for row in result.items],
-            pagination=pagination_payload(result, next_command=next_command),
-            message=_session_list_hint(),
+            **page_fields,
+            message=message,
         )
         return 0
     except Exception as exc:
@@ -5199,11 +5195,8 @@ def _vault_page_payload(
 ) -> tuple[list[dict], dict, str | None]:
     page_request = _page_request_from_args(args, help_command=help_command)
     result = page_sequence(items, page_request)
-    page_payload = pagination_payload(
-        result,
-        next_command=_next_command(command, result, include_all=bool(getattr(args, "all", False))),
-    )
-    return result.items, page_payload, _pagination_message(page_payload)
+    fields = _paginated_fields(result, command=command)
+    return result.items, fields["pagination"], fields.get("message")
 
 
 def _vault_lookup_next_steps(*, has_more: bool, has_filters: bool) -> list[str]:
@@ -7788,28 +7781,24 @@ def cmd_watch_add(args):
 
 def cmd_watch_list(
     *,
-    include_all: bool = False,
     include_finished: bool = False,
-    brief: bool = False,
-    page_request: PageRequest | None = None,
+    brief: bool = True,
+    page_request: PageRequest = PageRequest(),
 ):
     store = _watch_store()
     runtime_state = _watch_runtime_store().load().get("watches", {})
     watches = store.list_watches()
-    if not include_all and not include_finished:
+    if not include_finished:
         watches = [watch for watch in watches if not _is_finished_one_shot_watch(watch)]
     watches.sort(key=lambda item: (item.enabled is False, item.created_at, item.id))
     command = ["vibe", "watch", "list"]
     if include_finished:
         command.append("--include-finished")
-    if brief:
-        command.append("--brief")
     _print_definition_list_payload(
         watches,
         items_key="watches",
-        payload_for_item=lambda watch: _watch_payload(watch, runtime_state.get(watch.id), brief=brief),
+        payload_for_item=lambda watch: _watch_payload(watch, runtime_state.get(watch.id), brief=True),
         command=command,
-        include_all=include_all,
         page_request=page_request,
     )
     return 0
@@ -10318,18 +10307,14 @@ def cmd_show_list(args):
         _add_optional_arg(command, "--q", getattr(args, "query", None))
         if getattr(args, "json", False):
             command.append("--json")
-        page_payload = pagination_payload(result, next_command=_next_command(command, result, include_all=bool(getattr(args, "all", False))))
-        message = _pagination_message(page_payload)
         payload = {
             "ok": True,
             "count": len(result.items),
             "visibility": getattr(args, "visibility", None),
             "pages": [show_page_payload(page) for page in result.items],
-            "pagination": page_payload,
+            **_paginated_fields(result, command=command),
             "url_guidance": avibe_cloud_connect_guidance(),
         }
-        if message:
-            payload["message"] = message
         if getattr(args, "json", False):
             _print_json(payload)
         else:
@@ -10948,24 +10933,33 @@ def cmd_show_marks(args):
     event_store = ShowSessionEventStore()
     try:
         session_id, session_default_notice = _resolve_show_session_id(args, help_command="vibe show marks --help")
+        page_request = _page_request_from_args(args, help_command="vibe show marks --help")
         marks = [_show_mark_listing(mark) for mark in event_store.active_marks(session_id)]
+        page = page_sequence(marks, page_request)
+        command = ["vibe", "show", "marks", "--session-id", session_id]
+        if getattr(args, "json", False):
+            command.append("--json")
         result = {
             "ok": True,
             "session_id": session_id,
-            "count": len(marks),
-            "marks": marks,
+            "count": len(page.items),
+            "marks": page.items,
+            **_paginated_fields(page, command=command),
             **({"session_default_notice": session_default_notice} if session_default_notice else {}),
         }
         if getattr(args, "json", False):
             _print_json(result)
         else:
-            print(f"Assistant marks ({len(marks)} active):")
-            if not marks:
+            print(f"Assistant marks ({len(page.items)} shown):")
+            if not page.items:
                 print("  none")
-            for mark in marks:
+            for mark in page.items:
                 print(f"- {mark['id']}  {mark['kind']}  {mark['read_state']}")
                 print(f"  Target: {mark['target']}")
                 print(f"  Body: {mark['body_head']}")
+            if result.get("message"):
+                print("")
+                print(result["message"])
         return 0
     except Exception as exc:
         _print_show_page_error(exc)
@@ -11893,10 +11887,15 @@ def build_parser():
     agent_subparsers.required = True
 
     agent_list_parser = agent_subparsers.add_parser("list", help="List Avibe Agents")
-    agent_list_parser.add_argument("--brief", action="store_true", help="Show compact Agent rows")
+    agent_list_parser.add_argument("--brief", action="store_true", help=argparse.SUPPRESS)
     agent_list_parser.add_argument("--backend", choices=("codex", "claude", "opencode"), help="Filter by backend")
-    agent_list_parser.add_argument("--all", action="store_true", help="Include disabled Agents")
+    agent_list_parser.add_argument(
+        "--include-disabled",
+        action="store_true",
+        help="Include disabled Agents while keeping pagination",
+    )
     agent_list_parser.add_argument("--disabled", action="store_true", help="Show only disabled Agents")
+    _add_pagination_args(agent_list_parser, help_command="vibe agent list --help")
     _add_json_noop(agent_list_parser)
 
     agent_show_parser = agent_subparsers.add_parser("show", help="Show one Avibe Agent")
@@ -11928,6 +11927,7 @@ def build_parser():
         "--provider", help="Filter to one OpenCode provider id (OpenCode backend only)."
     )
     agent_models_parser.add_argument("--model", help="Only show reasoning efforts for this model id.")
+    _add_pagination_args(agent_models_parser, help_command="vibe agent models --help")
     _add_json_noop(agent_models_parser)
 
     agent_create_parser = agent_subparsers.add_parser("create", help="Create an Avibe Agent")
@@ -12067,7 +12067,7 @@ def build_parser():
     runs_list_parser.add_argument("--created-after", help="Filter by created_at >= timestamp, or relative value such as 6h or 7d")
     runs_list_parser.add_argument("--created-before", help="Filter by created_at <= timestamp, or relative value such as 6h or 7d")
     runs_list_parser.add_argument("--q", dest="query", help="Search common run text fields")
-    runs_list_parser.add_argument("--brief", action="store_true", help="Show compact run rows")
+    runs_list_parser.add_argument("--brief", action="store_true", help=argparse.SUPPRESS)
     _add_pagination_args(runs_list_parser, help_command="vibe runs list --help")
     _add_json_noop(runs_list_parser)
     runs_show_parser = runs_subparsers.add_parser("show", help="Show one Agent run")
@@ -12094,7 +12094,10 @@ def build_parser():
     session_list_parser = session_subparsers.add_parser(
         "list",
         help="List active sessions, most-recently-active first",
-        description="List active (non-archived) Agent sessions, 10 per page, newest activity first.",
+        description=(
+            f"List active (non-archived) Agent sessions, {DEFAULT_PAGE_LIMIT} per page, "
+            "newest activity first."
+        ),
         formatter_class=argparse.RawDescriptionHelpFormatter,
         error_help_command="vibe session list --help",
     )
@@ -12102,7 +12105,7 @@ def build_parser():
         "--type",
         help="Filter by platform: avibe (Web/Workbench), slack, discord, telegram, lark, wechat.",
     )
-    session_list_parser.add_argument("--page", type=int, help="Page number to return (10 per page). Defaults to 1.")
+    _add_pagination_args(session_list_parser, help_command="vibe session list --help")
     _add_json_noop(session_list_parser)
     session_get_parser = session_subparsers.add_parser(
         "get",
@@ -12617,6 +12620,7 @@ def build_parser():
         error_help_command="vibe show marks --help",
     )
     show_marks_parser.add_argument("--session-id", help="Agent Session ID for the Show Page.")
+    _add_pagination_args(show_marks_parser, help_command="vibe show marks --help")
     show_marks_parser.add_argument("--json", action="store_true", help="Print machine-readable state.")
 
     show_unmark_parser = show_subparsers.add_parser(
@@ -12788,7 +12792,7 @@ def build_parser():
         help="List scheduled tasks",
         description=(
             f"List stored scheduled tasks, {DEFAULT_PAGE_LIMIT} per page. Finished one-shot tasks are hidden by default; "
-            "use --include-finished to page through them or --all for an explicit unbounded result."
+            "use --include-finished to page through their history."
         ),
         epilog="Use the returned task IDs with 'vibe task show', 'vibe task update', 'vibe task run', 'vibe task pause', 'vibe task resume', or 'vibe task remove'.",
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -12803,13 +12807,9 @@ def build_parser():
     task_list_parser.add_argument(
         "--brief",
         action="store_true",
-        help="Show a compact scheduling-focused view instead of the full stored task payload",
+        help=argparse.SUPPRESS,
     )
-    _add_pagination_args(
-        task_list_parser,
-        help_command="vibe task list --help",
-        all_help="Return every stored task without pagination, including finished one-shot tasks.",
-    )
+    _add_pagination_args(task_list_parser, help_command="vibe task list --help")
     _add_json_noop(task_list_parser)
     _add_hidden_task_alias(task_subparsers, "ls", task_list_parser)
 
@@ -13094,7 +13094,7 @@ def build_parser():
         help="List background watches",
         description=(
             f"List stored managed background watches, {DEFAULT_PAGE_LIMIT} per page. Finished one-shot watches are hidden "
-            "by default; use --include-finished to page through them or --all for an explicit unbounded result."
+            "by default; use --include-finished to page through their history."
         ),
         epilog="Use the returned watch IDs with 'vibe watch show', 'vibe watch update', 'vibe watch pause', 'vibe watch resume', or 'vibe watch remove'.",
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -13108,13 +13108,9 @@ def build_parser():
     watch_list_parser.add_argument(
         "--brief",
         action="store_true",
-        help="Show a compact watcher-focused view instead of the full stored watch payload",
+        help=argparse.SUPPRESS,
     )
-    _add_pagination_args(
-        watch_list_parser,
-        help_command="vibe watch list --help",
-        all_help="Return every stored watch without pagination, including finished one-shot watches.",
-    )
+    _add_pagination_args(watch_list_parser, help_command="vibe watch list --help")
     _add_json_noop(watch_list_parser)
     _add_hidden_task_alias(watch_subparsers, "ls", watch_list_parser)
 
@@ -13321,9 +13317,8 @@ def main():
                 sys.exit(1)
             sys.exit(
                 cmd_task_list(
-                    include_all=getattr(args, "all", False),
                     include_finished=getattr(args, "include_finished", False),
-                    brief=getattr(args, "brief", False),
+                    brief=True,
                     page_request=page_request,
                 )
             )
@@ -13355,9 +13350,8 @@ def main():
                 sys.exit(1)
             sys.exit(
                 cmd_watch_list(
-                    include_all=getattr(args, "all", False),
                     include_finished=getattr(args, "include_finished", False),
-                    brief=getattr(args, "brief", False),
+                    brief=True,
                     page_request=page_request,
                 )
             )

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -1497,6 +1497,8 @@ def _task_display_name(task) -> str:
 def _task_state(task) -> str:
     if task.enabled:
         return "active"
+    if task.last_run_at and task.last_error:
+        return "failed"
     if _is_completed_one_shot(task):
         return "completed"
     return "paused"
@@ -1622,11 +1624,22 @@ def _supported_task_platforms() -> set[str]:
 
 
 def _is_completed_one_shot(task) -> bool:
-    return task.schedule_type == "at" and not task.enabled and bool(task.last_run_at)
+    return (
+        task.schedule_type == "at"
+        and not task.enabled
+        and bool(task.last_run_at)
+        and not task.last_error
+    )
 
 
 def _is_finished_one_shot_watch(watch) -> bool:
-    return watch.mode == "once" and not watch.enabled and bool(watch.last_finished_at)
+    return (
+        watch.mode == "once"
+        and not watch.enabled
+        and bool(watch.last_finished_at)
+        and not watch.last_error
+        and watch.last_exit_code in (None, 0)
+    )
 
 
 def _parse_validated_session_key(
@@ -12791,7 +12804,7 @@ def build_parser():
         "list",
         help="List scheduled tasks",
         description=(
-            f"List stored scheduled tasks, {DEFAULT_PAGE_LIMIT} per page. Finished one-shot tasks are hidden by default; "
+            f"List stored scheduled tasks, {DEFAULT_PAGE_LIMIT} per page. Successful one-shot tasks are hidden by default; "
             "use --include-finished to page through their history."
         ),
         epilog="Use the returned task IDs with 'vibe task show', 'vibe task update', 'vibe task run', 'vibe task pause', 'vibe task resume', or 'vibe task remove'.",
@@ -12802,7 +12815,7 @@ def build_parser():
     task_list_parser.add_argument(
         "--include-finished",
         action="store_true",
-        help="Include finished one-shot tasks while keeping pagination",
+        help="Include successful one-shot task history while keeping pagination",
     )
     task_list_parser.add_argument(
         "--brief",
@@ -13093,7 +13106,7 @@ def build_parser():
         "list",
         help="List background watches",
         description=(
-            f"List stored managed background watches, {DEFAULT_PAGE_LIMIT} per page. Finished one-shot watches are hidden "
+            f"List stored managed background watches, {DEFAULT_PAGE_LIMIT} per page. Successful one-shot watches are hidden "
             "by default; use --include-finished to page through their history."
         ),
         epilog="Use the returned watch IDs with 'vibe watch show', 'vibe watch update', 'vibe watch pause', 'vibe watch resume', or 'vibe watch remove'.",
@@ -13103,7 +13116,7 @@ def build_parser():
     watch_list_parser.add_argument(
         "--include-finished",
         action="store_true",
-        help="Include finished one-shot watches while keeping pagination",
+        help="Include successful one-shot watch history while keeping pagination",
     )
     watch_list_parser.add_argument(
         "--brief",
@@ -13312,7 +13325,7 @@ def main():
         if args.task_command in {"list", "ls"}:
             try:
                 page_request = _page_request_from_args(args, help_command="vibe task list --help")
-            except Exception as exc:
+            except TaskCliError as exc:
                 _print_task_error(exc, help_command="vibe task list --help")
                 sys.exit(1)
             sys.exit(
@@ -13345,7 +13358,7 @@ def main():
         if args.watch_command in {"list", "ls"}:
             try:
                 page_request = _page_request_from_args(args, help_command="vibe watch list --help")
-            except Exception as exc:
+            except TaskCliError as exc:
                 _print_task_error(exc, help_command="vibe watch list --help")
                 sys.exit(1)
             sys.exit(

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -1497,7 +1497,7 @@ def _task_display_name(task) -> str:
 def _task_state(task) -> str:
     if task.enabled:
         return "active"
-    if task.last_run_at and task.last_error:
+    if _is_failed_one_shot(task):
         return "failed"
     if _is_completed_one_shot(task):
         return "completed"
@@ -1631,6 +1631,15 @@ def _is_completed_one_shot(task) -> bool:
         and not task.enabled
         and bool(task.last_run_at)
         and not task.last_error
+    )
+
+
+def _is_failed_one_shot(task) -> bool:
+    return (
+        task.schedule_type == "at"
+        and not task.enabled
+        and bool(task.last_run_at)
+        and bool(task.last_error)
     )
 
 

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -1564,8 +1564,10 @@ def _task_payload(task, *, brief: bool = False):
 
 def _sort_tasks_for_display(tasks):
     # Offset pagination requires an order that does not change merely because
-    # wall-clock time crossed a cron boundary between page requests.
-    return sorted(tasks, key=lambda item: (item.created_at, item.id))
+    # wall-clock time crossed a cron boundary between page requests. Keep
+    # schedulable tasks ahead of paused/history rows without using next-run
+    # timestamps, which are time-dependent.
+    return sorted(tasks, key=lambda item: (item.enabled is False, item.created_at, item.id))
 
 
 def _task_store() -> ScheduledTaskStore:

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -207,10 +207,14 @@ def _print_cli_payload(kind: str, **fields) -> None:
     print(json.dumps(_cli_payload(kind, **fields), indent=2))
 
 
-def _add_pagination_args(parser, *, help_command: str) -> None:
+def _add_pagination_args(parser, *, help_command: str, all_help: str | None = None) -> None:
     parser.add_argument("--page", type=int, help="Page number to return. Defaults to 1.")
     parser.add_argument("--limit", type=int, help=f"Rows per page. Defaults to {DEFAULT_PAGE_LIMIT}.")
-    parser.add_argument("--all", action="store_true", help="Return all matching rows without pagination.")
+    parser.add_argument(
+        "--all",
+        action="store_true",
+        help=all_help or "Return all matching rows without pagination.",
+    )
     parser.error_help_command = help_command
 
 
@@ -261,6 +265,32 @@ def _pagination_message(page_payload: dict) -> str | None:
     if next_command:
         return f"More records are available. Continue with: {next_command}"
     return "More records are available. Add --page to continue."
+
+
+def _print_definition_list_payload(
+    items,
+    *,
+    items_key: str,
+    payload_for_item,
+    command: list[str],
+    include_all: bool,
+    page_request: PageRequest | None,
+) -> None:
+    result = page_sequence(items, None if include_all else (page_request or PageRequest()))
+    item_payloads = [payload_for_item(item) for item in result.items]
+    page_payload = pagination_payload(
+        result,
+        next_command=_next_command(command, result, include_all=include_all),
+    )
+    payload = {
+        "definitions": item_payloads,
+        items_key: item_payloads,
+        "pagination": page_payload,
+    }
+    message = _pagination_message(page_payload)
+    if message:
+        payload["message"] = message
+    _print_cli_payload("run_definitions", **payload)
 
 
 def _parse_cli_time_filter(value: str | None, *, field_name: str, help_command: str) -> str | None:
@@ -1606,6 +1636,10 @@ def _is_completed_one_shot(task) -> bool:
     return task.schedule_type == "at" and not task.enabled and bool(task.last_run_at)
 
 
+def _is_finished_one_shot_watch(watch) -> bool:
+    return watch.mode == "once" and not watch.enabled and bool(watch.last_finished_at)
+
+
 def _parse_validated_session_key(
     session_key: str,
     *,
@@ -2601,16 +2635,30 @@ def cmd_task_add(args):
         return 1
 
 
-def cmd_task_list(*, include_all: bool = False, brief: bool = False):
+def cmd_task_list(
+    *,
+    include_all: bool = False,
+    include_finished: bool = False,
+    brief: bool = False,
+    page_request: PageRequest | None = None,
+):
     store = _task_store()
     tasks = store.list_tasks()
-    if not include_all:
+    if not include_all and not include_finished:
         tasks = [task for task in tasks if not _is_completed_one_shot(task)]
     tasks = _sort_tasks_for_display(tasks)
-    _print_cli_payload(
-        "run_definitions",
-        definitions=[_task_payload(task, brief=brief) for task in tasks],
-        tasks=[_task_payload(task, brief=brief) for task in tasks],
+    command = ["vibe", "task", "list"]
+    if include_finished:
+        command.append("--include-finished")
+    if brief:
+        command.append("--brief")
+    _print_definition_list_payload(
+        tasks,
+        items_key="tasks",
+        payload_for_item=lambda task: _task_payload(task, brief=brief),
+        command=command,
+        include_all=include_all,
+        page_request=page_request,
     )
     return 0
 
@@ -7738,13 +7786,32 @@ def cmd_watch_add(args):
         return 1
 
 
-def cmd_watch_list(*, brief: bool = False):
+def cmd_watch_list(
+    *,
+    include_all: bool = False,
+    include_finished: bool = False,
+    brief: bool = False,
+    page_request: PageRequest | None = None,
+):
     store = _watch_store()
     runtime_state = _watch_runtime_store().load().get("watches", {})
     watches = store.list_watches()
+    if not include_all and not include_finished:
+        watches = [watch for watch in watches if not _is_finished_one_shot_watch(watch)]
     watches.sort(key=lambda item: (item.enabled is False, item.created_at, item.id))
-    watch_payloads = [_watch_payload(watch, runtime_state.get(watch.id), brief=brief) for watch in watches]
-    _print_cli_payload("run_definitions", definitions=watch_payloads, watches=watch_payloads)
+    command = ["vibe", "watch", "list"]
+    if include_finished:
+        command.append("--include-finished")
+    if brief:
+        command.append("--brief")
+    _print_definition_list_payload(
+        watches,
+        items_key="watches",
+        payload_for_item=lambda watch: _watch_payload(watch, runtime_state.get(watch.id), brief=brief),
+        command=command,
+        include_all=include_all,
+        page_request=page_request,
+    )
     return 0
 
 
@@ -12719,21 +12786,29 @@ def build_parser():
     task_subparsers.add_parser(
         "list",
         help="List scheduled tasks",
-        description="List stored scheduled tasks. Completed one-shot tasks are hidden unless --all is used.",
+        description=(
+            f"List stored scheduled tasks, {DEFAULT_PAGE_LIMIT} per page. Finished one-shot tasks are hidden by default; "
+            "use --include-finished to page through them or --all for an explicit unbounded result."
+        ),
         epilog="Use the returned task IDs with 'vibe task show', 'vibe task update', 'vibe task run', 'vibe task pause', 'vibe task resume', or 'vibe task remove'.",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         error_help_command="vibe task list --help",
     )
     task_list_parser = task_subparsers.choices["list"]
     task_list_parser.add_argument(
-        "--all",
+        "--include-finished",
         action="store_true",
-        help="Include completed one-shot tasks that are hidden by default",
+        help="Include finished one-shot tasks while keeping pagination",
     )
     task_list_parser.add_argument(
         "--brief",
         action="store_true",
         help="Show a compact scheduling-focused view instead of the full stored task payload",
+    )
+    _add_pagination_args(
+        task_list_parser,
+        help_command="vibe task list --help",
+        all_help="Return every stored task without pagination, including finished one-shot tasks.",
     )
     _add_json_noop(task_list_parser)
     _add_hidden_task_alias(task_subparsers, "ls", task_list_parser)
@@ -13017,15 +13092,28 @@ def build_parser():
     watch_list_parser = watch_subparsers.add_parser(
         "list",
         help="List background watches",
-        description="List stored managed background watches.",
+        description=(
+            f"List stored managed background watches, {DEFAULT_PAGE_LIMIT} per page. Finished one-shot watches are hidden "
+            "by default; use --include-finished to page through them or --all for an explicit unbounded result."
+        ),
         epilog="Use the returned watch IDs with 'vibe watch show', 'vibe watch update', 'vibe watch pause', 'vibe watch resume', or 'vibe watch remove'.",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         error_help_command="vibe watch list --help",
     )
     watch_list_parser.add_argument(
+        "--include-finished",
+        action="store_true",
+        help="Include finished one-shot watches while keeping pagination",
+    )
+    watch_list_parser.add_argument(
         "--brief",
         action="store_true",
         help="Show a compact watcher-focused view instead of the full stored watch payload",
+    )
+    _add_pagination_args(
+        watch_list_parser,
+        help_command="vibe watch list --help",
+        all_help="Return every stored watch without pagination, including finished one-shot watches.",
     )
     _add_json_noop(watch_list_parser)
     _add_hidden_task_alias(watch_subparsers, "ls", watch_list_parser)
@@ -13226,7 +13314,19 @@ def main():
         if args.task_command == "update":
             sys.exit(cmd_task_update(args))
         if args.task_command in {"list", "ls"}:
-            sys.exit(cmd_task_list(include_all=getattr(args, "all", False), brief=getattr(args, "brief", False)))
+            try:
+                page_request = _page_request_from_args(args, help_command="vibe task list --help")
+            except Exception as exc:
+                _print_task_error(exc, help_command="vibe task list --help")
+                sys.exit(1)
+            sys.exit(
+                cmd_task_list(
+                    include_all=getattr(args, "all", False),
+                    include_finished=getattr(args, "include_finished", False),
+                    brief=getattr(args, "brief", False),
+                    page_request=page_request,
+                )
+            )
         if args.task_command == "show":
             sys.exit(cmd_task_show(args.task_id))
         if args.task_command == "pause":
@@ -13248,7 +13348,19 @@ def main():
         if args.watch_command == "update":
             sys.exit(cmd_watch_update(args))
         if args.watch_command in {"list", "ls"}:
-            sys.exit(cmd_watch_list(brief=getattr(args, "brief", False)))
+            try:
+                page_request = _page_request_from_args(args, help_command="vibe watch list --help")
+            except Exception as exc:
+                _print_task_error(exc, help_command="vibe watch list --help")
+                sys.exit(1)
+            sys.exit(
+                cmd_watch_list(
+                    include_all=getattr(args, "all", False),
+                    include_finished=getattr(args, "include_finished", False),
+                    brief=getattr(args, "brief", False),
+                    page_request=page_request,
+                )
+            )
         if args.watch_command == "show":
             sys.exit(cmd_watch_show(args.watch_id))
         if args.watch_command == "pause":

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -3317,10 +3317,22 @@ def cmd_agent_models(args):
         # the displayed list, so an Agent's real model is never hidden from it.
         current = _agent_models_current(agent, options) if agent else None
         models = options.get("models", [])
+        providers = options.get("providers")
+        provider_rows = providers if isinstance(providers, list) else []
         if model:
             models = [entry for entry in models if entry.get("value") == model]
+            matching_provider_ids = {
+                entry.get("provider") for entry in models if entry.get("provider")
+            }
+            provider_rows = [
+                entry for entry in provider_rows if entry.get("id") in matching_provider_ids
+            ]
+        catalog_rows = [("provider", entry) for entry in provider_rows]
+        catalog_rows.extend(("model", entry) for entry in models)
         page_request = _page_request_from_args(args, help_command="vibe agent models --help")
-        result = page_sequence(models, page_request)
+        result = page_sequence(catalog_rows, page_request)
+        page_providers = [entry for kind, entry in result.items if kind == "provider"]
+        page_models = [entry for kind, entry in result.items if kind == "model"]
         command = ["vibe", "agent", "models"]
         if name:
             command.append(name)
@@ -3334,8 +3346,8 @@ def cmd_agent_models(args):
             backend=backend,
             current=current,
             default_model=options.get("default_model"),
-            providers=options.get("providers"),
-            models=result.items,
+            providers=page_providers if providers is not None else None,
+            models=page_models,
             source=options.get("source"),
             live=options.get("live", False),
             notes=options.get("notes"),


### PR DESCRIPTION
## What

- Give every Agent-facing collection command one bounded pagination contract: 20 rows by default, `--page` / `--limit`, and a hard per-page maximum of 100.
- Remove the unpaginated `--all` escape hatch. Task/watch history now uses `--include-finished` plus normal pagination; Agent disabled rows use `--include-disabled`.
- Make list rows compact by default and keep full record payloads behind the existing `show` / `get` commands.
- Apply the contract to Agent list/models, runs, sessions, Vault list/find/tags, Show Page list/marks, read-only data queries, tasks, and watches. Provider and model rows share one page budget in `agent models`.
- Hide successful one-shot definitions by default while keeping failures visible, keep enabled tasks ahead of paused history with stable ordering across pages, and reset stale watch cycle state when resuming one-shots or changing modes.
- Keep current definition state separate from run history: paused recurring tasks remain `paused` while `last_status` reports their failed run.
- Update English/Chinese CLI references, both Avibe usage skills, and the live Harness system-prompt examples.

Closes #1011.

## CLI migration

This is a repo-wide CLI contract change, not only a task/watch fix:

- `--all` is removed from the 12 collection commands above because it could dump an unbounded result into an Agent context. Use `--page`, `--limit`, and `pagination.next_command`.
- `vibe task list` and `vibe watch list` use `--include-finished` to include successful one-shot history while remaining paginated.
- The previous `vibe agent list --all` meaning is renamed to `--include-disabled`; that result also remains paginated.
- `vibe data query` stays bounded even when the caller controls the SQL. Explicit SQL `LIMIT` can narrow the query, while the CLI page envelope prevents a broad query from producing unbounded output.

## Affected scenarios

- None. This CLI list contract is not represented in the current scenario catalog.

## Evidence

- Unit/contract: `uv run pytest -q tests/test_cli_*.py tests/test_pagination.py tests/test_session_cli.py tests/test_show_pages.py tests/test_watches.py tests/test_scheduled_tasks.py` (524 passed).
- Lint: focused Ruff checks passed for all changed Python files.
- Parser contract: every current list/collection command requires `--page` / `--limit` and rejects `--all`.
- Prompt contract: rendered system-prompt `vibe` examples are checked against the live CLI parser, preventing injected examples from using unsupported flags.
- Live-state replay: copied the local SQLite state into an isolated `AVIBE_HOME` and ran the source CLI against all 1,149 stored watches. `vibe watch list --include-finished` returned 20 compact rows / 25,269 bytes with a next command; `--all` failed safely and `--limit 101` returned `invalid_pagination`.
- Residual manual: no running Avibe service was restarted. Finished-definition retention/pruning remains a separate storage-lifecycle concern.
