### PR TITLE
fix(show): queue annotations through unified turn entry

### DIFF
--- a/core/internal_server.py
+++ b/core/internal_server.py
@@ -273,6 +273,22 @@ def create_app(controller: "Controller") -> FastAPI:
                         messages.c.session_id == sid,
                     )
                 ).scalar_one_or_none()
+            if active_message_id == user_message_id:
+                # The manager's in-flight registry is definitive acceptance.
+                # Settle a still-claimed reservation here so a fast turn cannot
+                # disappear before a replay sees the accepted ``user`` state.
+                with get_cached_sqlite_engine().begin() as conn:
+                    messages_service.accept_dispatch_reservation(
+                        conn,
+                        user_message_id,
+                        "user",
+                    )
+                    reserved_type = conn.execute(
+                        select(messages.c.type).where(
+                            messages.c.id == user_message_id,
+                            messages.c.session_id == sid,
+                        )
+                    ).scalar_one_or_none()
             if active_message_id == user_message_id or reserved_type == "user":
                 return JSONResponse(
                     status_code=202,
@@ -338,7 +354,34 @@ def create_app(controller: "Controller") -> FastAPI:
                     "message_type": messages_service.QUEUED_TYPE,
                 },
             )
-        return JSONResponse(status_code=202, content={"ok": True, "session_id": session_id})
+        settled_type = None
+        if isinstance(user_message_id, str) and user_message_id and sid:
+            from sqlalchemy import select
+            from storage.models import messages
+
+            # ``manager.submit`` returned "started": the unified entry, not its
+            # HTTP caller, owns the only transition to accepted ``user``.
+            with get_cached_sqlite_engine().begin() as conn:
+                messages_service.accept_dispatch_reservation(
+                    conn,
+                    user_message_id,
+                    "user",
+                )
+                settled_type = conn.execute(
+                    select(messages.c.type).where(
+                        messages.c.id == user_message_id,
+                        messages.c.session_id == sid,
+                    )
+                ).scalar_one_or_none()
+        return JSONResponse(
+            status_code=202,
+            content={
+                "ok": True,
+                "session_id": session_id,
+                **({"message_id": user_message_id} if settled_type else {}),
+                **({"message_type": settled_type} if settled_type else {}),
+            },
+        )
 
     @app.post("/internal/reconcile-platforms")
     async def _reconcile_platforms() -> Any:

--- a/core/internal_server.py
+++ b/core/internal_server.py
@@ -5,8 +5,7 @@ This is the C4 piece of Plan 2 from
 exposes a minimal FastAPI app on
 ``~/.vibe_remote/state/dispatch.sock`` so cross-process callers (the
 separate UI server subprocess, future ``vibe agent run --sync`` flows)
-can invoke ``core.services.dispatch.dispatch_turn`` and stream the
-agent's output back over SSE chunked response.
+can submit turns to the controller-owned session turn manager.
 
 Three properties matter:
 
@@ -21,8 +20,8 @@ Three properties matter:
    restrictive umask and chmod'd to ``0o600`` when the filesystem supports
    it — defense in depth against shared hosts.
 
-The endpoint set is intentionally tiny for v1 (``dispatch`` + a stub
-``cancel``); follow-ups can grow it without changing the bind contract.
+The endpoint set is intentionally tiny; follow-ups can grow it without
+changing the bind contract.
 """
 
 from __future__ import annotations
@@ -41,7 +40,7 @@ from fastapi.responses import JSONResponse, StreamingResponse
 from sqlalchemy.exc import IntegrityError
 
 from config import paths
-from core.services.dispatch import SOURCE_HUMAN, SOURCE_SCHEDULED, dispatch_turn
+from core.services.dispatch import SOURCE_HUMAN, SOURCE_SCHEDULED
 from modules.im.base import MessageContext
 from storage.db import get_cached_sqlite_engine
 
@@ -72,7 +71,7 @@ def create_app(controller: "Controller") -> FastAPI:
     Factored out so tests can mount the same routes against a fake
     controller without spinning up uvicorn.
     """
-    from core.inbox_events import bus, mark_controller_process
+    from core.inbox_events import mark_controller_process
 
     mark_controller_process()
 
@@ -89,14 +88,14 @@ def create_app(controller: "Controller") -> FastAPI:
     # waiting for the agent to settle, and reuses the stored context so it
     # interrupts the backend the turn actually started on — even if the Chat
     # header changed the session's agent / model while the reply was streaming.
-    # Tasks are registered when the SSE response starts and removed in its
-    # ``finally`` so cancelled / completed sessions don't leak slots.
+    # Tasks are registered by ``SessionTurnManager`` before they run and removed
+    # in its ``finally`` so cancelled / completed sessions don't leak slots.
     # The turn owner (FSM) is created in Controller.__init__ so it exists for boot
     # stale-reset + OpenCode restore; reuse it here and bind the routing-context
     # builder now that the gate (which owns _build_session_context) is built. A fake
     # controller in tests may lack one — create it then. The registry bound below
     # is the SAME object the closures + ``controller.session_turn_gate`` use.
-    from core.session_turns import SessionTurnManager, Turn
+    from core.session_turns import SessionTurnManager
 
     manager = getattr(controller, "session_turns", None)
     if not isinstance(manager, SessionTurnManager):
@@ -106,18 +105,11 @@ def create_app(controller: "Controller") -> FastAPI:
         controller.session_turns = manager
     manager.bind_context(_build_session_context)
 
-    # The turn registry (``session_id -> Turn``) is owned by the manager; the legacy
-    # streaming ``/internal/dispatch`` (Show-page) endpoint below shares it directly,
-    # and tests inspect it via ``app.state``. The flush intents live ON each ``Turn``
-    # (set by ``manager.cancel`` / ``manager.send_now``), not in side sets here.
+    # The turn registry (``session_id -> Turn``) is owned by the manager and tests
+    # inspect it via ``app.state``. Flush intents live on each ``Turn`` (set by
+    # ``manager.cancel`` / ``manager.send_now``), not in side sets here.
     in_flight = manager.in_flight
     app.state.in_flight_dispatches = in_flight
-
-    async def _flush_queue(session_id: str) -> bool:
-        """Thin delegation to ``SessionTurnManager.flush_queue`` (FSM, Phase 1b):
-        pop + merge the send-while-busy queue and run it as the next turn. Returns
-        True if a turn was started, False on an empty queue / failure."""
-        return await manager.flush_queue(session_id)
 
     async def _submit_scheduled_turn(session_id: str, context: MessageContext, text: str) -> str:
         """Run a scheduled / watch turn through the SAME unified ``manager.submit``
@@ -231,126 +223,6 @@ def create_app(controller: "Controller") -> FastAPI:
         if not result.get("ok"):
             return JSONResponse(status_code=409, content=result)
         return result
-
-    @app.post("/internal/dispatch")
-    async def _dispatch(request: Request) -> Any:
-        """Streaming turn dispatch: runs a turn and proxies its notify/result
-        chunks back over an SSE response. The web **Chat** page no longer uses
-        this (it's fire-and-forget via ``/internal/dispatch_async`` +
-        ``message.new``); this backs the **Show-page** dispatch flow, where
-        ``ui_server._run_show_event_dispatch`` re-publishes each event as
-        ``show.dispatch`` for the open Show page."""
-        payload = await _safe_json(request)
-        try:
-            text, context = await _build_dispatch_payload(payload)
-        except ValueError as err:
-            return JSONResponse(status_code=400, content={"ok": False, "error": str(err)})
-
-        session_id = payload.get("session_id")
-
-        # One streaming turn per session. If a turn is already in flight for
-        # this session (a second browser tab, or a resend before the first
-        # finishes), refuse the new one HERE — before creating a task or
-        # touching ``in_flight`` — so we never overwrite the real turn's task
-        # handle. Overwriting it would orphan the running turn: its sink keeps
-        # streaming but ``/internal/cancel`` could no longer find the task to
-        # interrupt, so the Stop button would silently no-op.
-        if isinstance(session_id, str) and session_id:
-            existing = in_flight.get(session_id)
-            if existing is not None and not existing.task.done():
-                async def _busy_stream():
-                    yield _sse_event("turn.start", {"session_id": session_id})
-                    yield _sse_event(
-                        "turn.chunk",
-                        {
-                            "kind": "error",
-                            "text": controller._t("error.streamTurnInProgress"),
-                            "message_id": None,
-                        },
-                    )
-                    yield _sse_event("turn.end", {"session_id": session_id})
-
-                return StreamingResponse(
-                    _busy_stream(),
-                    media_type="text/event-stream",
-                    headers={"Cache-Control": "no-store", "X-Accel-Buffering": "no"},
-                )
-
-        # SSE chunked stream — the response body is fed by ``on_chunk``
-        # callbacks that the dispatcher fires for every successful
-        # ``emit_agent_message`` notify / result during the turn. The
-        # turn coroutine and the producer-consumer queue live on the
-        # same loop, so ordering is preserved.
-        chunk_queue: asyncio.Queue[Optional[dict]] = asyncio.Queue()
-
-        async def on_chunk(envelope: dict) -> None:
-            await chunk_queue.put(envelope)
-
-        async def _runner() -> None:
-            try:
-                await dispatch_turn(controller, context, text, on_chunk=on_chunk)
-            except asyncio.CancelledError:
-                # Surface a cancel envelope so the SSE consumer can
-                # distinguish "user stopped me" from "agent finished".
-                await chunk_queue.put({"kind": "cancelled", "text": ""})
-                raise
-            except Exception as err:
-                logger.exception("internal dispatch failed for session=%s", session_id)
-                await chunk_queue.put({"kind": "error", "text": str(err)})
-            finally:
-                # This legacy streaming route invokes dispatch_turn directly, so it
-                # bypasses SessionTurnManager._run_turn, which owns lifecycle bus
-                # events for Chat/scheduled turns. The two paths are exclusive:
-                # streaming lifecycle is owned here; manager lifecycle stays in
-                # core/session_turns.py. Publishing before the sentinel also makes
-                # post-turn subscribers finish before queued work can be flushed.
-                if isinstance(session_id, str) and session_id:
-                    bus.publish("turn.end", {"session_id": session_id})
-                # Sentinel signals end-of-stream to the consumer below.
-                await chunk_queue.put(None)
-
-        task = asyncio.create_task(_runner(), name="internal-dispatch")
-        if isinstance(session_id, str) and session_id:
-            in_flight[session_id] = Turn(task=task, context=context)
-            # create_task cannot run until this coroutine yields, so synchronous
-            # pre-turn subscribers complete before the backend can touch files.
-            bus.publish("turn.start", {"session_id": session_id})
-
-        async def _stream():
-            saw_cancel = False
-            reached_end = False
-            try:
-                yield _sse_event("turn.start", {"session_id": session_id})
-                while True:
-                    envelope = await chunk_queue.get()
-                    if envelope is None:
-                        reached_end = True
-                        break
-                    if envelope.get("kind") == "cancelled":
-                        saw_cancel = True
-                    yield _sse_event("turn.chunk", envelope)
-                yield _sse_event("turn.end", {"session_id": session_id})
-            finally:
-                if not task.done():
-                    task.cancel()
-                # Release the slot whether the task completed normally,
-                # was cancelled by the UI, or the SSE consumer
-                # disconnected mid-stream. ``pop`` is idempotent.
-                if isinstance(session_id, str):
-                    in_flight.pop(session_id, None)
-                    # This endpoint shares ``in_flight`` with the session, so a Chat
-                    # send during a Show-page dispatch enqueues behind it. Drain that
-                    # queue on NATURAL completion (not a Stop / consumer disconnect,
-                    # mirroring _run_turn's no-flush-on-cancel rule) so the queued
-                    # Chat message isn't stranded until manual intervention (Codex P2).
-                    if reached_end and not saw_cancel:
-                        await _flush_queue(session_id)
-
-        return StreamingResponse(
-            _stream(),
-            media_type="text/event-stream",
-            headers={"Cache-Control": "no-store", "X-Accel-Buffering": "no"},
-        )
 
     @app.post("/internal/dispatch_async")
     async def _dispatch_async(request: Request) -> Any:

--- a/core/internal_server.py
+++ b/core/internal_server.py
@@ -247,6 +247,18 @@ def create_app(controller: "Controller") -> FastAPI:
         session_id = payload.get("session_id")
         sid = session_id if isinstance(session_id, str) and session_id else None
         user_message_id = payload.get("user_message_id")
+        show_event_id = payload.get("show_event_id")
+        show_event_id = (
+            show_event_id.strip()
+            if isinstance(show_event_id, str) and show_event_id.strip()
+            else None
+        )
+        dispatch_owner = payload.get("dispatch_owner")
+        dispatch_owner = (
+            dispatch_owner.strip()
+            if isinstance(dispatch_owner, str) and dispatch_owner.strip()
+            else None
+        )
         reserved_type: str | None = None
 
         def _enqueue() -> None:
@@ -258,7 +270,124 @@ def create_app(controller: "Controller") -> FastAPI:
                 with engine.begin() as conn:
                     queue_pending_user_message(conn, user_message_id, text)
 
-        if isinstance(user_message_id, str) and user_message_id and sid:
+        if show_event_id:
+            from core.show_session_events import (
+                DISPATCH_ACCEPTED,
+                DISPATCH_IN_FLIGHT,
+                accept_show_dispatch,
+                get_show_dispatch_status,
+            )
+            from sqlalchemy import select
+            from storage.models import messages
+
+            if not sid or not dispatch_owner:
+                return JSONResponse(
+                    status_code=400,
+                    content={"ok": False, "error": "Show dispatch identity is incomplete."},
+                )
+            with get_cached_sqlite_engine().connect() as conn:
+                show_status = get_show_dispatch_status(
+                    conn,
+                    show_event_id,
+                    session_id=sid,
+                )
+            if show_status is None:
+                return JSONResponse(
+                    status_code=409,
+                    content={"ok": False, "code": "show_event_not_found"},
+                )
+            if show_status.session_status == "archived":
+                return JSONResponse(
+                    status_code=409,
+                    content={"ok": False, "code": "session_archived"},
+                )
+            if (
+                not isinstance(user_message_id, str)
+                or not user_message_id
+                or show_status.message_id != user_message_id
+            ):
+                return JSONResponse(
+                    status_code=409,
+                    content={"ok": False, "code": "show_event_message_mismatch"},
+                )
+
+            active = manager.in_flight.get(sid)
+            active_message_id = str(
+                getattr(getattr(active, "context", None), "message_id", None) or ""
+            ).strip()
+            if (
+                active_message_id == user_message_id
+                and show_status.state == DISPATCH_IN_FLIGHT
+                and show_status.owner == dispatch_owner
+            ):
+                with get_cached_sqlite_engine().begin() as conn:
+                    accept_show_dispatch(
+                        conn,
+                        show_event_id,
+                        session_id=sid,
+                        owner=dispatch_owner,
+                    )
+                    show_status = get_show_dispatch_status(
+                        conn,
+                        show_event_id,
+                        session_id=sid,
+                    )
+
+            if show_status is not None and show_status.state == DISPATCH_ACCEPTED:
+                current_message_id = show_status.message_id
+                current_message_type = None
+                if current_message_id:
+                    with get_cached_sqlite_engine().connect() as conn:
+                        current_message_type = conn.execute(
+                            select(messages.c.type).where(
+                                messages.c.id == current_message_id,
+                                messages.c.session_id == sid,
+                            )
+                        ).scalar_one_or_none()
+                return JSONResponse(
+                    status_code=202,
+                    content={
+                        "ok": True,
+                        "duplicate": True,
+                        "session_id": session_id,
+                        **(
+                            {"message_id": current_message_id}
+                            if current_message_id
+                            else {}
+                        ),
+                        **(
+                            {"message_type": current_message_type}
+                            if current_message_type
+                            else {}
+                        ),
+                        **(
+                            {"queued": True}
+                            if current_message_type == messages_service.QUEUED_TYPE
+                            else {}
+                        ),
+                    },
+                )
+            if (
+                show_status is None
+                or show_status.state != DISPATCH_IN_FLIGHT
+                or show_status.owner != dispatch_owner
+            ):
+                if show_status is None or show_status.state != DISPATCH_IN_FLIGHT:
+                    return JSONResponse(
+                        status_code=409,
+                        content={"ok": False, "code": "show_dispatch_not_claimed"},
+                    )
+                return JSONResponse(
+                    status_code=202,
+                    content={
+                        "ok": True,
+                        "duplicate": True,
+                        "dispatch_pending": True,
+                        "session_id": session_id,
+                    },
+                )
+
+        if not show_event_id and isinstance(user_message_id, str) and user_message_id and sid:
             from sqlalchemy import select
             from storage.models import messages
 
@@ -273,22 +402,13 @@ def create_app(controller: "Controller") -> FastAPI:
                         messages.c.session_id == sid,
                     )
                 ).scalar_one_or_none()
-            if active_message_id == user_message_id:
-                # The manager's in-flight registry is definitive acceptance.
-                # Settle a still-claimed reservation here so a fast turn cannot
-                # disappear before a replay sees the accepted ``user`` state.
+            if (
+                active_message_id == user_message_id
+                and reserved_type == messages_service.PENDING_TYPE
+            ):
                 with get_cached_sqlite_engine().begin() as conn:
-                    messages_service.accept_dispatch_reservation(
-                        conn,
-                        user_message_id,
-                        "user",
-                    )
-                    reserved_type = conn.execute(
-                        select(messages.c.type).where(
-                            messages.c.id == user_message_id,
-                            messages.c.session_id == sid,
-                        )
-                    ).scalar_one_or_none()
+                    messages_service.promote_pending(conn, user_message_id, "user")
+                reserved_type = "user"
             if active_message_id == user_message_id or reserved_type == "user":
                 return JSONResponse(
                     status_code=202,
@@ -314,6 +434,20 @@ def create_app(controller: "Controller") -> FastAPI:
                 )
 
         outcome = await manager.submit(sid, context, text, enqueue=_enqueue)
+        if show_event_id and sid and dispatch_owner:
+            from core.show_session_events import accept_show_dispatch
+
+            with get_cached_sqlite_engine().begin() as conn:
+                if not accept_show_dispatch(
+                    conn,
+                    show_event_id,
+                    session_id=sid,
+                    owner=dispatch_owner,
+                ):
+                    return JSONResponse(
+                        status_code=409,
+                        content={"ok": False, "code": "show_dispatch_claim_lost"},
+                    )
         if outcome == "enqueued":
             # An idle session can already have queue rows left by Stop. ``submit``
             # then drains synchronously before returning, so "enqueued" describes
@@ -322,14 +456,25 @@ def create_app(controller: "Controller") -> FastAPI:
             # missing row means the queue transaction merged it into a freshly
             # ordered visible row and already published that replacement.
             settled_type = None
-            if isinstance(user_message_id, str) and user_message_id and sid:
+            settled_message_id = user_message_id
+            if show_event_id and sid:
+                from core.show_session_events import get_show_dispatch_status
+
+                with get_cached_sqlite_engine().connect() as conn:
+                    show_status = get_show_dispatch_status(
+                        conn,
+                        show_event_id,
+                        session_id=sid,
+                    )
+                settled_message_id = show_status.message_id if show_status else None
+            if isinstance(settled_message_id, str) and settled_message_id and sid:
                 from sqlalchemy import select
                 from storage.models import messages
 
                 with get_cached_sqlite_engine().connect() as conn:
                     settled_type = conn.execute(
                         select(messages.c.type).where(
-                            messages.c.id == user_message_id,
+                            messages.c.id == settled_message_id,
                             messages.c.session_id == sid,
                         )
                     ).scalar_one_or_none()
@@ -340,7 +485,11 @@ def create_app(controller: "Controller") -> FastAPI:
                         "ok": True,
                         "drained": True,
                         "session_id": session_id,
-                        **({"message_id": user_message_id} if settled_type else {}),
+                        **(
+                            {"message_id": settled_message_id}
+                            if settled_type
+                            else {}
+                        ),
                         **({"message_type": settled_type} if settled_type else {}),
                     },
                 )
@@ -350,26 +499,30 @@ def create_app(controller: "Controller") -> FastAPI:
                     "ok": True,
                     "queued": True,
                     "session_id": session_id,
-                    "message_id": user_message_id,
+                    "message_id": settled_message_id,
                     "message_type": messages_service.QUEUED_TYPE,
                 },
             )
         settled_type = None
-        if isinstance(user_message_id, str) and user_message_id and sid:
+        settled_message_id = user_message_id
+        if show_event_id and sid:
+            from core.show_session_events import get_show_dispatch_status
+
+            with get_cached_sqlite_engine().connect() as conn:
+                show_status = get_show_dispatch_status(
+                    conn,
+                    show_event_id,
+                    session_id=sid,
+                )
+            settled_message_id = show_status.message_id if show_status else None
+        if isinstance(settled_message_id, str) and settled_message_id and sid:
             from sqlalchemy import select
             from storage.models import messages
 
-            # ``manager.submit`` returned "started": the unified entry, not its
-            # HTTP caller, owns the only transition to accepted ``user``.
-            with get_cached_sqlite_engine().begin() as conn:
-                messages_service.accept_dispatch_reservation(
-                    conn,
-                    user_message_id,
-                    "user",
-                )
+            with get_cached_sqlite_engine().connect() as conn:
                 settled_type = conn.execute(
                     select(messages.c.type).where(
-                        messages.c.id == user_message_id,
+                        messages.c.id == settled_message_id,
                         messages.c.session_id == sid,
                     )
                 ).scalar_one_or_none()
@@ -378,7 +531,7 @@ def create_app(controller: "Controller") -> FastAPI:
             content={
                 "ok": True,
                 "session_id": session_id,
-                **({"message_id": user_message_id} if settled_type else {}),
+                **({"message_id": settled_message_id} if settled_type else {}),
                 **({"message_type": settled_type} if settled_type else {}),
             },
         )

--- a/core/internal_server.py
+++ b/core/internal_server.py
@@ -95,7 +95,7 @@ def create_app(controller: "Controller") -> FastAPI:
     # builder now that the gate (which owns _build_session_context) is built. A fake
     # controller in tests may lack one — create it then. The registry bound below
     # is the SAME object the closures + ``controller.session_turn_gate`` use.
-    from core.session_turns import SessionTurnManager
+    from core.session_turns import SessionTurnManager, queue_pending_user_message
 
     manager = getattr(controller, "session_turns", None)
     if not isinstance(manager, SessionTurnManager):
@@ -248,13 +248,12 @@ def create_app(controller: "Controller") -> FastAPI:
 
         def _enqueue() -> None:
             # Chat already persisted the user's message as a ``pending`` row; promote
-            # it to ``queued`` so it drains via the queue after the active turn.
+            # it to ``queued`` so it drains via the queue after the active turn. Keep
+            # the exact agent-facing text separately from its transcript display text.
             if isinstance(user_message_id, str) and user_message_id:
-                from storage import messages_service
-
                 engine = get_cached_sqlite_engine()
                 with engine.begin() as conn:
-                    messages_service.promote_pending(conn, user_message_id, messages_service.QUEUED_TYPE)
+                    queue_pending_user_message(conn, user_message_id, text)
 
         outcome = await manager.submit(sid, context, text, enqueue=_enqueue)
         if outcome == "enqueued":

--- a/core/internal_server.py
+++ b/core/internal_server.py
@@ -255,6 +255,44 @@ def create_app(controller: "Controller") -> FastAPI:
                 with engine.begin() as conn:
                     queue_pending_user_message(conn, user_message_id, text)
 
+        if isinstance(user_message_id, str) and user_message_id and sid:
+            from sqlalchemy import select
+            from storage import messages_service
+            from storage.models import messages
+
+            active = manager.in_flight.get(sid)
+            active_message_id = str(
+                getattr(getattr(active, "context", None), "message_id", None) or ""
+            ).strip()
+            with get_cached_sqlite_engine().connect() as conn:
+                reserved_type = conn.execute(
+                    select(messages.c.type).where(
+                        messages.c.id == user_message_id,
+                        messages.c.session_id == sid,
+                    )
+                ).scalar_one_or_none()
+            if active_message_id == user_message_id or reserved_type == "user":
+                return JSONResponse(
+                    status_code=202,
+                    content={
+                        "ok": True,
+                        "duplicate": True,
+                        "session_id": session_id,
+                        "message_id": user_message_id,
+                    },
+                )
+            if reserved_type == messages_service.QUEUED_TYPE:
+                return JSONResponse(
+                    status_code=202,
+                    content={
+                        "ok": True,
+                        "queued": True,
+                        "duplicate": True,
+                        "session_id": session_id,
+                        "message_id": user_message_id,
+                    },
+                )
+
         outcome = await manager.submit(sid, context, text, enqueue=_enqueue)
         if outcome == "enqueued":
             return JSONResponse(
@@ -595,7 +633,7 @@ async def _build_dispatch_payload(payload: dict[str, Any]) -> tuple[str, Message
         channel_id=payload.get("channel_id"),
         platform=payload.get("platform"),
         thread_id=payload.get("thread_id"),
-        message_id=payload.get("message_id"),
+        message_id=payload.get("message_id") or payload.get("user_message_id"),
         files=files,
     )
     return text, context

--- a/core/internal_server.py
+++ b/core/internal_server.py
@@ -236,6 +236,8 @@ def create_app(controller: "Controller") -> FastAPI:
         Stop works), publishes the turn lifecycle, and flushes the
         send-while-busy queue when it settles.
         """
+        from storage import messages_service
+
         payload = await _safe_json(request)
         try:
             text, context = await _build_dispatch_payload(payload)
@@ -245,6 +247,7 @@ def create_app(controller: "Controller") -> FastAPI:
         session_id = payload.get("session_id")
         sid = session_id if isinstance(session_id, str) and session_id else None
         user_message_id = payload.get("user_message_id")
+        reserved_type: str | None = None
 
         def _enqueue() -> None:
             # Chat already persisted the user's message as a ``pending`` row; promote
@@ -257,7 +260,6 @@ def create_app(controller: "Controller") -> FastAPI:
 
         if isinstance(user_message_id, str) and user_message_id and sid:
             from sqlalchemy import select
-            from storage import messages_service
             from storage.models import messages
 
             active = manager.in_flight.get(sid)
@@ -279,6 +281,7 @@ def create_app(controller: "Controller") -> FastAPI:
                         "duplicate": True,
                         "session_id": session_id,
                         "message_id": user_message_id,
+                        **({"message_type": reserved_type} if reserved_type else {}),
                     },
                 )
             if reserved_type == messages_service.QUEUED_TYPE:
@@ -290,14 +293,50 @@ def create_app(controller: "Controller") -> FastAPI:
                         "duplicate": True,
                         "session_id": session_id,
                         "message_id": user_message_id,
+                        "message_type": messages_service.QUEUED_TYPE,
                     },
                 )
 
         outcome = await manager.submit(sid, context, text, enqueue=_enqueue)
         if outcome == "enqueued":
+            # An idle session can already have queue rows left by Stop. ``submit``
+            # then drains synchronously before returning, so "enqueued" describes
+            # how the row entered the manager, not necessarily its durable state.
+            # Read the reservation again before claiming it is still queued. A
+            # missing row means the queue transaction merged it into a freshly
+            # ordered visible row and already published that replacement.
+            settled_type = None
+            if isinstance(user_message_id, str) and user_message_id and sid:
+                from sqlalchemy import select
+                from storage.models import messages
+
+                with get_cached_sqlite_engine().connect() as conn:
+                    settled_type = conn.execute(
+                        select(messages.c.type).where(
+                            messages.c.id == user_message_id,
+                            messages.c.session_id == sid,
+                        )
+                    ).scalar_one_or_none()
+            if settled_type != messages_service.QUEUED_TYPE:
+                return JSONResponse(
+                    status_code=202,
+                    content={
+                        "ok": True,
+                        "drained": True,
+                        "session_id": session_id,
+                        **({"message_id": user_message_id} if settled_type else {}),
+                        **({"message_type": settled_type} if settled_type else {}),
+                    },
+                )
             return JSONResponse(
                 status_code=202,
-                content={"ok": True, "queued": True, "session_id": session_id, "message_id": user_message_id},
+                content={
+                    "ok": True,
+                    "queued": True,
+                    "session_id": session_id,
+                    "message_id": user_message_id,
+                    "message_type": messages_service.QUEUED_TYPE,
+                },
             )
         return JSONResponse(status_code=202, content={"ok": True, "session_id": session_id})
 

--- a/core/internal_server.py
+++ b/core/internal_server.py
@@ -260,22 +260,37 @@ def create_app(controller: "Controller") -> FastAPI:
             else None
         )
         reserved_type: str | None = None
+        enqueue_succeeded: bool | None = None
 
         def _enqueue() -> None:
+            nonlocal enqueue_succeeded
             # Chat already persisted the user's message as a ``pending`` row; promote
             # it to ``queued`` so it drains via the queue after the active turn. Keep
             # the exact agent-facing text separately from its transcript display text.
             if isinstance(user_message_id, str) and user_message_id:
                 engine = get_cached_sqlite_engine()
                 with engine.begin() as conn:
-                    queue_pending_user_message(conn, user_message_id, text)
+                    enqueue_succeeded = queue_pending_user_message(
+                        conn,
+                        user_message_id,
+                        text,
+                    )
+            else:
+                enqueue_succeeded = False
+
+        def _active_message_id() -> str:
+            active = manager.in_flight.get(sid) if sid else None
+            return str(
+                getattr(getattr(active, "context", None), "message_id", None) or ""
+            ).strip()
 
         if show_event_id:
             from core.show_session_events import (
                 DISPATCH_ACCEPTED,
+                DISPATCH_ARCHIVED,
                 DISPATCH_IN_FLIGHT,
-                accept_show_dispatch,
                 get_show_dispatch_status,
+                observe_and_settle_show_dispatch,
             )
             from sqlalchemy import select
             from storage.models import messages
@@ -297,6 +312,15 @@ def create_app(controller: "Controller") -> FastAPI:
                     content={"ok": False, "code": "show_event_not_found"},
                 )
             if show_status.session_status == "archived":
+                with get_cached_sqlite_engine().begin() as conn:
+                    observe_and_settle_show_dispatch(
+                        conn,
+                        show_event_id,
+                        session_id=sid,
+                        owner=dispatch_owner,
+                        active_message_id=_active_message_id(),
+                        enqueue_succeeded=None,
+                    )
                 return JSONResponse(
                     status_code=409,
                     content={"ok": False, "code": "session_archived"},
@@ -311,26 +335,20 @@ def create_app(controller: "Controller") -> FastAPI:
                     content={"ok": False, "code": "show_event_message_mismatch"},
                 )
 
-            active = manager.in_flight.get(sid)
-            active_message_id = str(
-                getattr(getattr(active, "context", None), "message_id", None) or ""
-            ).strip()
+            active_message_id = _active_message_id()
             if (
                 active_message_id == user_message_id
                 and show_status.state == DISPATCH_IN_FLIGHT
                 and show_status.owner == dispatch_owner
             ):
                 with get_cached_sqlite_engine().begin() as conn:
-                    accept_show_dispatch(
+                    show_status, _message_type = observe_and_settle_show_dispatch(
                         conn,
                         show_event_id,
                         session_id=sid,
                         owner=dispatch_owner,
-                    )
-                    show_status = get_show_dispatch_status(
-                        conn,
-                        show_event_id,
-                        session_id=sid,
+                        active_message_id=active_message_id,
+                        enqueue_succeeded=None,
                     )
 
             if show_status is not None and show_status.state == DISPATCH_ACCEPTED:
@@ -366,6 +384,11 @@ def create_app(controller: "Controller") -> FastAPI:
                             else {}
                         ),
                     },
+                )
+            if show_status is not None and show_status.state == DISPATCH_ARCHIVED:
+                return JSONResponse(
+                    status_code=409,
+                    content={"ok": False, "code": "session_archived"},
                 )
             if (
                 show_status is None
@@ -435,19 +458,42 @@ def create_app(controller: "Controller") -> FastAPI:
 
         outcome = await manager.submit(sid, context, text, enqueue=_enqueue)
         if show_event_id and sid and dispatch_owner:
-            from core.show_session_events import accept_show_dispatch
+            from core.show_session_events import (
+                DISPATCH_ACCEPTED,
+                DISPATCH_ARCHIVED,
+                DISPATCH_FAILED,
+                observe_and_settle_show_dispatch,
+            )
 
             with get_cached_sqlite_engine().begin() as conn:
-                if not accept_show_dispatch(
+                show_status, _message_type = observe_and_settle_show_dispatch(
                     conn,
                     show_event_id,
                     session_id=sid,
                     owner=dispatch_owner,
-                ):
-                    return JSONResponse(
-                        status_code=409,
-                        content={"ok": False, "code": "show_dispatch_claim_lost"},
-                    )
+                    active_message_id=_active_message_id(),
+                    enqueue_succeeded=enqueue_succeeded,
+                )
+            if show_status is None:
+                return JSONResponse(
+                    status_code=409,
+                    content={"ok": False, "code": "show_event_not_found"},
+                )
+            if show_status.state == DISPATCH_ARCHIVED:
+                return JSONResponse(
+                    status_code=409,
+                    content={"ok": False, "code": "session_archived"},
+                )
+            if show_status.state == DISPATCH_FAILED:
+                return JSONResponse(
+                    status_code=409,
+                    content={"ok": False, "code": "show_dispatch_reservation_lost"},
+                )
+            if show_status.state != DISPATCH_ACCEPTED:
+                return JSONResponse(
+                    status_code=409,
+                    content={"ok": False, "code": "show_dispatch_claim_lost"},
+                )
         if outcome == "enqueued":
             # An idle session can already have queue rows left by Stop. ``submit``
             # then drains synchronously before returning, so "enqueued" describes

--- a/core/internal_server.py
+++ b/core/internal_server.py
@@ -120,7 +120,8 @@ def create_app(controller: "Controller") -> FastAPI:
         a fresh ``queued`` row attributed to the harness.
         """
         if not session_id:
-            return await manager.submit(None, context, text, source=SOURCE_SCHEDULED)
+            submission = await manager.submit(None, context, text, source=SOURCE_SCHEDULED)
+            return submission.route
 
         native_message_id = str(getattr(context, "message_id", None) or "").strip()
         if native_message_id:
@@ -139,7 +140,7 @@ def create_app(controller: "Controller") -> FastAPI:
                 ):
                     return "duplicate"
 
-        def _enqueue() -> None:
+        def _enqueue() -> bool:
             from core.message_mirror import _scope_id_for_session
             from core.session_turns import SCHEDULED_PROVENANCE_KEY, capture_scheduled_provenance
             from storage import messages_service
@@ -153,22 +154,41 @@ def create_app(controller: "Controller") -> FastAPI:
             with engine.begin() as conn:
                 scope_id = _scope_id_for_session(conn, session_id)
                 try:
-                    messages_service.append(
-                        conn,
-                        scope_id=scope_id,
-                        session_id=session_id,
-                        platform="avibe",
-                        author="harness",
-                        source="harness",
-                        message_type=messages_service.QUEUED_TYPE,
-                        text=text,
-                        metadata={SCHEDULED_PROVENANCE_KEY: capture_scheduled_provenance(context)},
-                        native_message_id=native_message_id or None,
-                    )
+                    with conn.begin_nested():
+                        messages_service.append(
+                            conn,
+                            scope_id=scope_id,
+                            session_id=session_id,
+                            platform="avibe",
+                            author="harness",
+                            source="harness",
+                            message_type=messages_service.QUEUED_TYPE,
+                            text=text,
+                            metadata={SCHEDULED_PROVENANCE_KEY: capture_scheduled_provenance(context)},
+                            native_message_id=native_message_id or None,
+                        )
                 except IntegrityError:
                     logger.info("scheduled turn duplicate native id already queued: %s", native_message_id)
+                    return bool(
+                        native_message_id
+                        and messages_service.native_message_exists(
+                            conn,
+                            platform="avibe",
+                            native_message_id=native_message_id,
+                        )
+                    )
+            return True
 
-        return await manager.submit(session_id, context, text, source=SOURCE_SCHEDULED, enqueue=_enqueue)
+        submission = await manager.submit(
+            session_id,
+            context,
+            text,
+            source=SOURCE_SCHEDULED,
+            enqueue=_enqueue,
+        )
+        if submission.route == "enqueued" and submission.queue_persisted is not True:
+            raise RuntimeError("scheduled turn queue row was not persisted")
+        return submission.route
 
     @app.get("/internal/health")
     async def _health() -> dict[str, Any]:
@@ -260,23 +280,19 @@ def create_app(controller: "Controller") -> FastAPI:
             else None
         )
         reserved_type: str | None = None
-        enqueue_succeeded: bool | None = None
-
-        def _enqueue() -> None:
-            nonlocal enqueue_succeeded
+        def _enqueue() -> bool:
             # Chat already persisted the user's message as a ``pending`` row; promote
             # it to ``queued`` so it drains via the queue after the active turn. Keep
             # the exact agent-facing text separately from its transcript display text.
             if isinstance(user_message_id, str) and user_message_id:
                 engine = get_cached_sqlite_engine()
                 with engine.begin() as conn:
-                    enqueue_succeeded = queue_pending_user_message(
+                    return queue_pending_user_message(
                         conn,
                         user_message_id,
                         text,
                     )
-            else:
-                enqueue_succeeded = False
+            return False
 
         def _active_message_id() -> str:
             active = manager.in_flight.get(sid) if sid else None
@@ -319,7 +335,7 @@ def create_app(controller: "Controller") -> FastAPI:
                         session_id=sid,
                         owner=dispatch_owner,
                         active_message_id=_active_message_id(),
-                        enqueue_succeeded=None,
+                        queue_persisted=None,
                     )
                 return JSONResponse(
                     status_code=409,
@@ -348,7 +364,7 @@ def create_app(controller: "Controller") -> FastAPI:
                         session_id=sid,
                         owner=dispatch_owner,
                         active_message_id=active_message_id,
-                        enqueue_succeeded=None,
+                        queue_persisted=None,
                     )
 
             if show_status is not None and show_status.state == DISPATCH_ACCEPTED:
@@ -456,7 +472,9 @@ def create_app(controller: "Controller") -> FastAPI:
                     },
                 )
 
-        outcome = await manager.submit(sid, context, text, enqueue=_enqueue)
+        submission = await manager.submit(sid, context, text, enqueue=_enqueue)
+        settled_message_id = user_message_id
+        settled_type = None
         if show_event_id and sid and dispatch_owner:
             from core.show_session_events import (
                 DISPATCH_ACCEPTED,
@@ -466,13 +484,13 @@ def create_app(controller: "Controller") -> FastAPI:
             )
 
             with get_cached_sqlite_engine().begin() as conn:
-                show_status, _message_type = observe_and_settle_show_dispatch(
+                show_status, settled_type = observe_and_settle_show_dispatch(
                     conn,
                     show_event_id,
                     session_id=sid,
                     owner=dispatch_owner,
                     active_message_id=_active_message_id(),
-                    enqueue_succeeded=enqueue_succeeded,
+                    queue_persisted=submission.queue_persisted,
                 )
             if show_status is None:
                 return JSONResponse(
@@ -494,36 +512,30 @@ def create_app(controller: "Controller") -> FastAPI:
                     status_code=409,
                     content={"ok": False, "code": "show_dispatch_claim_lost"},
                 )
-        if outcome == "enqueued":
-            # An idle session can already have queue rows left by Stop. ``submit``
-            # then drains synchronously before returning, so "enqueued" describes
-            # how the row entered the manager, not necessarily its durable state.
-            # Read the reservation again before claiming it is still queued. A
-            # missing row means the queue transaction merged it into a freshly
-            # ordered visible row and already published that replacement.
-            settled_type = None
-            settled_message_id = user_message_id
-            if show_event_id and sid:
-                from core.show_session_events import get_show_dispatch_status
+            settled_message_id = show_status.message_id
 
-                with get_cached_sqlite_engine().connect() as conn:
-                    show_status = get_show_dispatch_status(
-                        conn,
-                        show_event_id,
-                        session_id=sid,
+        if (
+            not show_event_id
+            and isinstance(settled_message_id, str)
+            and settled_message_id
+            and sid
+        ):
+            from sqlalchemy import select
+            from storage.models import messages
+
+            with get_cached_sqlite_engine().connect() as conn:
+                settled_type = conn.execute(
+                    select(messages.c.type).where(
+                        messages.c.id == settled_message_id,
+                        messages.c.session_id == sid,
                     )
-                settled_message_id = show_status.message_id if show_status else None
-            if isinstance(settled_message_id, str) and settled_message_id and sid:
-                from sqlalchemy import select
-                from storage.models import messages
+                ).scalar_one_or_none()
 
-                with get_cached_sqlite_engine().connect() as conn:
-                    settled_type = conn.execute(
-                        select(messages.c.type).where(
-                            messages.c.id == settled_message_id,
-                            messages.c.session_id == sid,
-                        )
-                    ).scalar_one_or_none()
+        if submission.route == "enqueued":
+            # An idle session can already have queue rows left by Stop. ``submit``
+            # may drain synchronously before returning. The Show path uses the same
+            # observed settlement that decided acceptance; ordinary Chat reads its
+            # message once above. Neither response infers durability from the route.
             if settled_type != messages_service.QUEUED_TYPE:
                 return JSONResponse(
                     status_code=202,
@@ -549,29 +561,6 @@ def create_app(controller: "Controller") -> FastAPI:
                     "message_type": messages_service.QUEUED_TYPE,
                 },
             )
-        settled_type = None
-        settled_message_id = user_message_id
-        if show_event_id and sid:
-            from core.show_session_events import get_show_dispatch_status
-
-            with get_cached_sqlite_engine().connect() as conn:
-                show_status = get_show_dispatch_status(
-                    conn,
-                    show_event_id,
-                    session_id=sid,
-                )
-            settled_message_id = show_status.message_id if show_status else None
-        if isinstance(settled_message_id, str) and settled_message_id and sid:
-            from sqlalchemy import select
-            from storage.models import messages
-
-            with get_cached_sqlite_engine().connect() as conn:
-                settled_type = conn.execute(
-                    select(messages.c.type).where(
-                        messages.c.id == settled_message_id,
-                        messages.c.session_id == sid,
-                    )
-                ).scalar_one_or_none()
         return JSONResponse(
             status_code=202,
             content={

--- a/core/session_turns.py
+++ b/core/session_turns.py
@@ -677,6 +677,17 @@ def _timestamp_after_latest_session_message(
     return candidate.strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
+async def _wait_until_message_timestamp(created_at: str) -> None:
+    """Do not start a turn before its promoted prompt can sort before output."""
+    target = _parse_queue_timestamp(created_at)
+    now = _parse_queue_timestamp(_utc_now_iso())
+    if target is None or now is None:
+        return
+    delay = (target - now).total_seconds()
+    if delay > 0:
+        await asyncio.sleep(delay)
+
+
 def _repoint_message_dependents(
     conn: Connection,
     source_ids: list[str],
@@ -1367,6 +1378,12 @@ class SessionTurnManager:
         if not is_scheduled:
             # Carry the queued segment's uploaded files into the merged turn.
             context.files = file_attachments_from_specs(attachment_specs)
+            if user_row is not None:
+                # The stable queued row can have an older id than the active
+                # turn's terminal row. If ordering moved its timestamp into the
+                # next second, wait for that boundary before a fast result is
+                # allowed to persist in the same session.
+                await _wait_until_message_timestamp(str(user_row["created_at"]))
             await self._run(session_id, context, dispatch_text)
         else:
             # Restore the scheduled run's delivery / source provenance onto the rebuilt

--- a/core/session_turns.py
+++ b/core/session_turns.py
@@ -95,18 +95,18 @@ SCHEDULED_TARGET_AGENT_KEY = "scheduled_target_agent_name"
 
 
 def queue_pending_user_message(conn: Connection, message_id: str, dispatch_text: str) -> bool:
-    """Accept a reserved user row into the shared queue.
+    """Move a reserved or previously visible failed Show row into the queue.
 
     Queue rows keep user-visible transcript text in ``content_text``. The prompt
     submitted by an entry point may be richer (attachment paths, Show event IDs,
     reply guidance), so store that separately for ``flush_queue`` to replay.
-    This runs only from ``SessionTurnManager.submit``'s enqueue callback, making
-    the unified turn entry the sole writer of the accepted ``queued`` state.
+    This runs only from ``SessionTurnManager.submit``'s enqueue callback.
     """
+    queueable_types = (messages_service.PENDING_TYPE, "user")
     raw_metadata = conn.execute(
         select(messages.c.metadata_json).where(
             messages.c.id == message_id,
-            messages.c.type.in_(messages_service.DISPATCH_RESERVATION_TYPES),
+            messages.c.type.in_(queueable_types),
         )
     ).scalar_one_or_none()
     if raw_metadata is None:
@@ -122,7 +122,7 @@ def queue_pending_user_message(conn: Connection, message_id: str, dispatch_text:
         update(messages)
         .where(
             messages.c.id == message_id,
-            messages.c.type.in_(messages_service.DISPATCH_RESERVATION_TYPES),
+            messages.c.type.in_(queueable_types),
         )
         .values(
             type=messages_service.QUEUED_TYPE,

--- a/core/session_turns.py
+++ b/core/session_turns.py
@@ -20,7 +20,7 @@ import asyncio
 import json
 import logging
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Any, Callable, Optional
 
 from sqlalchemy import select, update
@@ -598,7 +598,11 @@ def _promote_merged_user_segment(
     merged_content: dict[str, Any] = {"text": text}
     if attachments:
         merged_content["attachments"] = attachments
-    updated_at = _utc_now_iso()
+    updated_at = _timestamp_after_latest_session_message(
+        conn,
+        session_id=str(canonical["session_id"]),
+        excluded_ids=[str(row["id"]) for row in segment],
+    )
     result = conn.execute(
         update(messages)
         .where(
@@ -639,6 +643,38 @@ def _promote_merged_user_segment(
         "created_at": updated_at,
         "updated_at": updated_at,
     }
+
+
+def _timestamp_after_latest_session_message(
+    conn: Connection,
+    *,
+    session_id: str,
+    excluded_ids: list[str],
+) -> str:
+    """Return a second-resolution timestamp after every settled session row.
+
+    Message IDs sort insertion order only within an equal timestamp. A promoted
+    queue row keeps its older ID, so it must move to a strictly later second than
+    the active turn's terminal row rather than tie with it.
+    """
+    latest = conn.execute(
+        select(messages.c.created_at)
+        .where(
+            messages.c.session_id == session_id,
+            ~messages.c.id.in_(excluded_ids),
+        )
+        .order_by(messages.c.created_at.desc(), messages.c.id.desc())
+        .limit(1)
+    ).scalar_one_or_none()
+    candidate = (_parse_queue_timestamp(_utc_now_iso()) or datetime.now(timezone.utc)).replace(
+        microsecond=0
+    )
+    latest_at = _parse_queue_timestamp(latest)
+    if latest_at is not None:
+        latest_second = latest_at.replace(microsecond=0)
+        if candidate <= latest_second:
+            candidate = latest_second + timedelta(seconds=1)
+    return candidate.strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
 def _repoint_message_dependents(
@@ -1288,11 +1324,14 @@ class SessionTurnManager:
                         )
                     )
                     user_owner = user_owners[0] if len(user_owners) == 1 else None
-                    user_metadata = None
+                    user_metadata = dict(segment[0].get("metadata") or {})
+                    user_metadata.pop(QUEUED_DISPATCH_TEXT_KEY, None)
+                    user_metadata.pop(WEB_PUSH_USER_KEY_METADATA, None)
+                    user_metadata.pop(WEB_PUSH_USER_KEYS_METADATA, None)
                     if user_owner:
-                        user_metadata = {WEB_PUSH_USER_KEY_METADATA: user_owner}
+                        user_metadata[WEB_PUSH_USER_KEY_METADATA] = user_owner
                     elif user_owners:
-                        user_metadata = {WEB_PUSH_USER_KEYS_METADATA: user_owners}
+                        user_metadata[WEB_PUSH_USER_KEYS_METADATA] = user_owners
                     attachment_specs = resolve_attachment_specs(
                         conn, session_id=session_id, attachments=queued_attachments
                     )

--- a/core/session_turns.py
+++ b/core/session_turns.py
@@ -20,7 +20,7 @@ import asyncio
 import json
 import logging
 from dataclasses import dataclass
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Callable, Optional
 
 from sqlalchemy import select, update
@@ -587,105 +587,46 @@ def _promote_merged_user_segment(
     metadata: Optional[dict[str, Any]],
     author_id: Optional[str],
 ) -> dict[str, Any]:
-    """Reuse the oldest queued row as the visible merged user message.
+    """Replace a queued segment with one freshly ordered visible user message.
 
-    Preserving that aggregate root keeps stable links from Show events and media.
-    Any later rows merged into it are retired after all message-owned records are
-    repointed to the canonical row.
+    ``messages`` sort by ``(created_at, id)`` and ids encode creation time. Reusing
+    an old queued id with a new timestamp makes that pair contradictory, so mint
+    both together and atomically repoint every dependent record.
     """
     canonical = segment[0]
-    canonical_id = str(canonical["id"])
     merged_content: dict[str, Any] = {"text": text}
     if attachments:
         merged_content["attachments"] = attachments
-    updated_at = _timestamp_after_latest_session_message(
+    visible = messages_service.append(
         conn,
+        scope_id=canonical.get("scope_id"),
         session_id=str(canonical["session_id"]),
-        excluded_ids=[str(row["id"]) for row in segment],
+        platform=str(canonical.get("platform") or "avibe"),
+        author="user",
+        message_type="user",
+        text=text,
+        content=merged_content,
+        metadata=metadata,
+        author_id=author_id,
+        source="user",
+        parent_native_message_id=canonical.get("parent_native_message_id"),
+        delivered_at=canonical.get("delivered_at"),
+        read_at=canonical.get("read_at"),
     )
-    result = conn.execute(
-        update(messages)
-        .where(
-            messages.c.id == canonical_id,
-            messages.c.type == messages_service.QUEUED_TYPE,
+    source_ids = [str(row["id"]) for row in segment]
+    visible_id = str(visible["id"])
+    _repoint_message_dependents(conn, source_ids, visible_id)
+    messages_service.delete_queued(conn, source_ids)
+
+    native_message_id = canonical.get("native_message_id")
+    if native_message_id:
+        conn.execute(
+            update(messages)
+            .where(messages.c.id == visible_id)
+            .values(native_message_id=native_message_id)
         )
-        .values(
-            author="user",
-            type="user",
-            author_id=author_id,
-            author_name=None,
-            source="user",
-            content_text=text,
-            content_json=json.dumps(merged_content),
-            metadata_json=json.dumps(metadata or {}),
-            created_at=updated_at,
-            updated_at=updated_at,
-        )
-    )
-    if result.rowcount != 1:
-        raise RuntimeError(f"queued message disappeared before merge: {canonical_id}")
-
-    retired_ids = [str(row["id"]) for row in segment[1:]]
-    if retired_ids:
-        _repoint_message_dependents(conn, retired_ids, canonical_id)
-        messages_service.delete_queued(conn, retired_ids)
-
-    return {
-        **canonical,
-        "author": "user",
-        "type": "user",
-        "author_id": author_id,
-        "author_name": None,
-        "source": "user",
-        "text": text,
-        "content": merged_content,
-        "metadata": metadata or {},
-        "created_at": updated_at,
-        "updated_at": updated_at,
-    }
-
-
-def _timestamp_after_latest_session_message(
-    conn: Connection,
-    *,
-    session_id: str,
-    excluded_ids: list[str],
-) -> str:
-    """Return a second-resolution timestamp after every settled session row.
-
-    Message IDs sort insertion order only within an equal timestamp. A promoted
-    queue row keeps its older ID, so it must move to a strictly later second than
-    the active turn's terminal row rather than tie with it.
-    """
-    latest = conn.execute(
-        select(messages.c.created_at)
-        .where(
-            messages.c.session_id == session_id,
-            ~messages.c.id.in_(excluded_ids),
-        )
-        .order_by(messages.c.created_at.desc(), messages.c.id.desc())
-        .limit(1)
-    ).scalar_one_or_none()
-    candidate = (_parse_queue_timestamp(_utc_now_iso()) or datetime.now(timezone.utc)).replace(
-        microsecond=0
-    )
-    latest_at = _parse_queue_timestamp(latest)
-    if latest_at is not None:
-        latest_second = latest_at.replace(microsecond=0)
-        if candidate <= latest_second:
-            candidate = latest_second + timedelta(seconds=1)
-    return candidate.strftime("%Y-%m-%dT%H:%M:%SZ")
-
-
-async def _wait_until_message_timestamp(created_at: str) -> None:
-    """Do not start a turn before its promoted prompt can sort before output."""
-    target = _parse_queue_timestamp(created_at)
-    now = _parse_queue_timestamp(_utc_now_iso())
-    if target is None or now is None:
-        return
-    delay = (target - now).total_seconds()
-    if delay > 0:
-        await asyncio.sleep(delay)
+        visible["native_message_id"] = native_message_id
+    return visible
 
 
 def _repoint_message_dependents(
@@ -1378,12 +1319,6 @@ class SessionTurnManager:
         if not is_scheduled:
             # Carry the queued segment's uploaded files into the merged turn.
             context.files = file_attachments_from_specs(attachment_specs)
-            if user_row is not None:
-                # The stable queued row can have an older id than the active
-                # turn's terminal row. If ordering moved its timestamp into the
-                # next second, wait for that boundary before a fast result is
-                # allowed to persist in the same session.
-                await _wait_until_message_timestamp(str(user_row["created_at"]))
             await self._run(session_id, context, dispatch_text)
         else:
             # Restore the scheduled run's delivery / source provenance onto the rebuilt

--- a/core/session_turns.py
+++ b/core/session_turns.py
@@ -23,8 +23,8 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Callable, Optional
 
-from sqlalchemy import select
-from sqlalchemy.engine import Engine
+from sqlalchemy import select, update
+from sqlalchemy.engine import Connection, Engine
 from sqlalchemy.exc import IntegrityError
 
 from core.web_push_notifications import WEB_PUSH_USER_KEY_METADATA, WEB_PUSH_USER_KEYS_METADATA
@@ -75,6 +75,7 @@ def _as_backend_activity_item(item: dict[str, Any]) -> dict[str, Any]:
 # a plain human turn (#84). Its PRESENCE also marks the row as a scheduled segment
 # (vs a user send) for flush_queue.
 SCHEDULED_PROVENANCE_KEY = "scheduled_provenance"
+QUEUED_DISPATCH_TEXT_KEY = "_queued_dispatch_text"
 SCHEDULED_QUEUE_MERGE_WINDOW_SECONDS = 60
 SCHEDULED_QUEUE_BURST_HINT_THRESHOLD = 3
 SCHEDULED_QUEUE_FULL_DETAIL_LIMIT = 3
@@ -91,6 +92,43 @@ _FLUSH_REBUILT_KEYS = frozenset(
     {"platform", "is_dm", "workbench_session_id", "agent_session_id", "agent_session_target", "turn_token"}
 )
 SCHEDULED_TARGET_AGENT_KEY = "scheduled_target_agent_name"
+
+
+def queue_pending_user_message(conn: Connection, message_id: str, dispatch_text: str) -> bool:
+    """Promote a reserved user row and retain the exact agent-facing prompt.
+
+    Queue rows keep user-visible transcript text in ``content_text``. The prompt
+    submitted by an entry point may be richer (attachment paths, Show event IDs,
+    reply guidance), so store that separately for ``flush_queue`` to replay.
+    """
+    raw_metadata = conn.execute(
+        select(messages.c.metadata_json).where(
+            messages.c.id == message_id,
+            messages.c.type == messages_service.PENDING_TYPE,
+        )
+    ).scalar_one_or_none()
+    if raw_metadata is None:
+        return False
+    try:
+        metadata = json.loads(raw_metadata or "{}")
+    except (TypeError, json.JSONDecodeError):
+        metadata = {}
+    if not isinstance(metadata, dict):
+        metadata = {}
+    metadata[QUEUED_DISPATCH_TEXT_KEY] = dispatch_text
+    result = conn.execute(
+        update(messages)
+        .where(
+            messages.c.id == message_id,
+            messages.c.type == messages_service.PENDING_TYPE,
+        )
+        .values(
+            type=messages_service.QUEUED_TYPE,
+            metadata_json=json.dumps(metadata),
+            updated_at=_utc_now_iso(),
+        )
+    )
+    return bool(result.rowcount)
 
 
 def capture_scheduled_provenance(context: "MessageContext") -> dict:
@@ -538,6 +576,89 @@ def _scheduled_claimed_queue_row_ids(conn: Any, segment: list[dict]) -> set[str]
             continue
         claimed_row_ids.update(native_to_row_ids.get(str(native_id or ""), set()))
     return claimed_row_ids
+
+
+def _promote_merged_user_segment(
+    conn: Connection,
+    segment: list[dict[str, Any]],
+    *,
+    text: str,
+    attachments: list[dict[str, Any]],
+    metadata: Optional[dict[str, Any]],
+    author_id: Optional[str],
+) -> dict[str, Any]:
+    """Reuse the oldest queued row as the visible merged user message.
+
+    Preserving that aggregate root keeps stable links from Show events and media.
+    Any later rows merged into it are retired after all message-owned records are
+    repointed to the canonical row.
+    """
+    canonical = segment[0]
+    canonical_id = str(canonical["id"])
+    merged_content: dict[str, Any] = {"text": text}
+    if attachments:
+        merged_content["attachments"] = attachments
+    updated_at = _utc_now_iso()
+    result = conn.execute(
+        update(messages)
+        .where(
+            messages.c.id == canonical_id,
+            messages.c.type == messages_service.QUEUED_TYPE,
+        )
+        .values(
+            author="user",
+            type="user",
+            author_id=author_id,
+            author_name=None,
+            source="user",
+            content_text=text,
+            content_json=json.dumps(merged_content),
+            metadata_json=json.dumps(metadata or {}),
+            created_at=updated_at,
+            updated_at=updated_at,
+        )
+    )
+    if result.rowcount != 1:
+        raise RuntimeError(f"queued message disappeared before merge: {canonical_id}")
+
+    retired_ids = [str(row["id"]) for row in segment[1:]]
+    if retired_ids:
+        _repoint_message_dependents(conn, retired_ids, canonical_id)
+        messages_service.delete_queued(conn, retired_ids)
+
+    return {
+        **canonical,
+        "author": "user",
+        "type": "user",
+        "author_id": author_id,
+        "author_name": None,
+        "source": "user",
+        "text": text,
+        "content": merged_content,
+        "metadata": metadata or {},
+        "created_at": updated_at,
+        "updated_at": updated_at,
+    }
+
+
+def _repoint_message_dependents(
+    conn: Connection,
+    source_ids: list[str],
+    target_id: str,
+) -> None:
+    """Retarget every foreign key to messages merged into one canonical row."""
+    for table in messages.metadata.tables.values():
+        if table is messages:
+            continue
+        for foreign_key in table.foreign_keys:
+            if foreign_key.column.table is not messages or foreign_key.column.name != messages.c.id.name:
+                continue
+            column = foreign_key.parent
+            conn.execute(
+                update(table)
+                .where(column.in_(source_ids))
+                .values({column.name: target_id})
+            )
 
 
 @dataclass
@@ -1047,6 +1168,7 @@ class SessionTurnManager:
         pending_agent_run_ids: list[str] = []
         pending_scheduled_segment: list[dict] = []
         claimed_agent_run_ids: list[str] = []
+        dispatch_text = ""
         engine = self._sqlite_engine()
         try:
             with run_update_event_transaction(engine) as conn:
@@ -1132,10 +1254,19 @@ class SessionTurnManager:
                         if _scheduled_provenance(r) is not None:
                             break
                         segment.append(r)
-                if segment and not pending_agent_run_ids:
+                if is_scheduled and segment and not pending_agent_run_ids:
                     messages_service.delete_queued(conn, [r["id"] for r in segment])
                 if not is_scheduled:
-                    texts = [r.get("text") for r in segment if (r.get("text") or "").strip()]
+                    texts = [str(r.get("text") or "") for r in segment if str(r.get("text") or "").strip()]
+                    dispatch_texts = [
+                        str((r.get("metadata") or {}).get(QUEUED_DISPATCH_TEXT_KEY) or r.get("text") or "")
+                        for r in segment
+                        if str(
+                            (r.get("metadata") or {}).get(QUEUED_DISPATCH_TEXT_KEY)
+                            or r.get("text")
+                            or ""
+                        ).strip()
+                    ]
                     # Carry attachments queued in this user segment so a file
                     # attached while the agent was busy still reaches the merged
                     # turn. An attachment-ONLY segment has empty texts but must
@@ -1146,6 +1277,7 @@ class SessionTurnManager:
                         for att in ((r.get("content") or {}).get("attachments") or [])
                     ]
                     if not texts and not queued_attachments:
+                        messages_service.delete_queued(conn, [r["id"] for r in segment])
                         return False
                     user_owners = list(
                         dict.fromkeys(
@@ -1164,16 +1296,13 @@ class SessionTurnManager:
                     attachment_specs = resolve_attachment_specs(
                         conn, session_id=session_id, attachments=queued_attachments
                     )
-                    user_row = messages_service.append(
+                    visible_text = "\n".join(texts)
+                    dispatch_text = "\n".join(dispatch_texts)
+                    user_row = _promote_merged_user_segment(
                         conn,
-                        scope_id=segment[0]["scope_id"],
-                        session_id=session_id,
-                        platform="avibe",
-                        author="user",
-                        source="user",
-                        message_type="user",
-                        text="\n".join(texts),
-                        content={"attachments": queued_attachments} if queued_attachments else None,
+                        segment,
+                        text=visible_text,
+                        attachments=queued_attachments,
                         metadata=user_metadata,
                         author_id=user_owner,
                     )
@@ -1199,7 +1328,7 @@ class SessionTurnManager:
         if not is_scheduled:
             # Carry the queued segment's uploaded files into the merged turn.
             context.files = file_attachments_from_specs(attachment_specs)
-            await self._run(session_id, context, user_row.get("text") or "")
+            await self._run(session_id, context, dispatch_text)
         else:
             # Restore the scheduled run's delivery / source provenance onto the rebuilt
             # (fresh-routing) context, then run as SOURCE_SCHEDULED — not a plain user

--- a/core/session_turns.py
+++ b/core/session_turns.py
@@ -95,16 +95,18 @@ SCHEDULED_TARGET_AGENT_KEY = "scheduled_target_agent_name"
 
 
 def queue_pending_user_message(conn: Connection, message_id: str, dispatch_text: str) -> bool:
-    """Promote a reserved user row and retain the exact agent-facing prompt.
+    """Accept a reserved user row into the shared queue.
 
     Queue rows keep user-visible transcript text in ``content_text``. The prompt
     submitted by an entry point may be richer (attachment paths, Show event IDs,
     reply guidance), so store that separately for ``flush_queue`` to replay.
+    This runs only from ``SessionTurnManager.submit``'s enqueue callback, making
+    the unified turn entry the sole writer of the accepted ``queued`` state.
     """
     raw_metadata = conn.execute(
         select(messages.c.metadata_json).where(
             messages.c.id == message_id,
-            messages.c.type == messages_service.PENDING_TYPE,
+            messages.c.type.in_(messages_service.DISPATCH_RESERVATION_TYPES),
         )
     ).scalar_one_or_none()
     if raw_metadata is None:
@@ -120,7 +122,7 @@ def queue_pending_user_message(conn: Connection, message_id: str, dispatch_text:
         update(messages)
         .where(
             messages.c.id == message_id,
-            messages.c.type == messages_service.PENDING_TYPE,
+            messages.c.type.in_(messages_service.DISPATCH_RESERVATION_TYPES),
         )
         .values(
             type=messages_service.QUEUED_TYPE,
@@ -291,6 +293,21 @@ def _collect_scheduled_segment(rows: list[dict]) -> list[dict]:
             break
         segment.append(row)
         latest = row
+    return segment
+
+
+def _collect_user_segment(rows: list[dict]) -> list[dict]:
+    """Collect one user turn without coalescing durable message identities."""
+    segment: list[dict] = []
+    for row in rows:
+        if _scheduled_provenance(row) is not None:
+            break
+        native_message_id = str(row.get("native_message_id") or "").strip()
+        if native_message_id:
+            if not segment:
+                segment.append(row)
+            break
+        segment.append(row)
     return segment
 
 
@@ -594,6 +611,13 @@ def _promote_merged_user_segment(
     both together and atomically repoint every dependent record.
     """
     canonical = segment[0]
+    native_message_ids = [
+        str(row.get("native_message_id") or "").strip()
+        for row in segment
+        if str(row.get("native_message_id") or "").strip()
+    ]
+    if native_message_ids and len(segment) != 1:
+        raise ValueError("independently identified user rows must flush as separate segments")
     merged_content: dict[str, Any] = {"text": text}
     if attachments:
         merged_content["attachments"] = attachments
@@ -618,7 +642,7 @@ def _promote_merged_user_segment(
     _repoint_message_dependents(conn, source_ids, visible_id)
     messages_service.delete_queued(conn, source_ids)
 
-    native_message_id = canonical.get("native_message_id")
+    native_message_id = native_message_ids[0] if native_message_ids else None
     if native_message_id:
         conn.execute(
             update(messages)
@@ -1118,13 +1142,15 @@ class SessionTurnManager:
         """Drain the send-while-busy queue ONE segment per call — the turn's
         completion re-flushes the next, so segments run in order, one at a time.
 
-        A leading run of consecutive USER rows is merged into a single user turn (the
-        user's choice — one dispatch, not N). A SCHEDULED row (it carries stored
-        provenance) is NOT merged: it runs as its OWN ``SOURCE_SCHEDULED`` turn with
-        its delivery / attribution provenance restored, so a scheduled run that was
-        enqueued behind an active turn keeps its suppress-delivery / delivery-target /
-        source when it finally runs (#84). Returns True if a turn was started, False
-        on an empty queue / failure."""
+        A leading run of anonymous USER rows is merged into one user turn (the
+        user's choice — one dispatch, not N). A row with ``native_message_id`` is
+        already an independently addressable event and therefore runs as its own
+        segment. A SCHEDULED row (it carries stored provenance) is NOT merged: it
+        runs as its OWN ``SOURCE_SCHEDULED`` turn with its delivery / attribution
+        provenance restored, so a scheduled run that was enqueued behind an active
+        turn keeps its suppress-delivery / delivery-target / source when it finally
+        runs (#84). Returns True if a turn was started, False on an empty queue /
+        failure."""
         from core.inbox_events import bus
         from core.workbench_media import file_attachments_from_specs, resolve_attachment_specs
         from storage.background import run_update_event_transaction
@@ -1235,13 +1261,7 @@ class SessionTurnManager:
                                     scheduled_text = coalesced_prompt
                             pending_scheduled_segment = segment
                 else:
-                    # User segment: the leading run of consecutive non-scheduled rows
-                    # (stop at the first scheduled row so it stays its own turn).
-                    segment = []
-                    for r in rows:
-                        if _scheduled_provenance(r) is not None:
-                            break
-                        segment.append(r)
+                    segment = _collect_user_segment(rows)
                 if is_scheduled and segment and not pending_agent_run_ids:
                     messages_service.delete_queued(conn, [r["id"] for r in segment])
                 if not is_scheduled:

--- a/core/session_turns.py
+++ b/core/session_turns.py
@@ -95,14 +95,14 @@ SCHEDULED_TARGET_AGENT_KEY = "scheduled_target_agent_name"
 
 
 def queue_pending_user_message(conn: Connection, message_id: str, dispatch_text: str) -> bool:
-    """Move a reserved or previously visible failed Show row into the queue.
+    """Move a reserved user row into the queue.
 
     Queue rows keep user-visible transcript text in ``content_text``. The prompt
     submitted by an entry point may be richer (attachment paths, Show event IDs,
     reply guidance), so store that separately for ``flush_queue`` to replay.
     This runs only from ``SessionTurnManager.submit``'s enqueue callback.
     """
-    queueable_types = (messages_service.PENDING_TYPE, "user")
+    queueable_types = (messages_service.PENDING_TYPE,)
     raw_metadata = conn.execute(
         select(messages.c.metadata_json).where(
             messages.c.id == message_id,
@@ -1354,6 +1354,7 @@ class SessionTurnManager:
         if not is_scheduled:
             # Carry the queued segment's uploaded files into the merged turn.
             context.files = file_attachments_from_specs(attachment_specs)
+            context.message_id = user_row["id"]
             await self._run(session_id, context, dispatch_text)
         else:
             # Restore the scheduled run's delivery / source provenance onto the rebuilt

--- a/core/session_turns.py
+++ b/core/session_turns.py
@@ -21,7 +21,7 @@ import json
 import logging
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING, Any, Callable, Optional
+from typing import TYPE_CHECKING, Any, Callable, Literal, Optional
 
 from sqlalchemy import select, update
 from sqlalchemy.engine import Connection, Engine
@@ -715,6 +715,14 @@ class Turn:
     cancel_settled_by: Optional[str] = None
 
 
+@dataclass(frozen=True)
+class TurnSubmissionResult:
+    """Routing decision plus the enqueue callback's durable-write result."""
+
+    route: Literal["ran", "enqueued"]
+    queue_persisted: bool | None = None
+
+
 class SessionTurnManager:
     """Owns the live per-session turn state + lifecycle for avibe sessions.
 
@@ -948,23 +956,27 @@ class SessionTurnManager:
         text: str,
         *,
         source: str = SOURCE_HUMAN,
-        enqueue: Optional[Callable[[], None]] = None,
-    ) -> str:
+        enqueue: Optional[Callable[[], bool]] = None,
+    ) -> TurnSubmissionResult:
         """Unified turn entry for BOTH Chat and the scheduler: idle → run now; busy
         (or a pre-existing send-while-busy queue) → enqueue and run later.
 
-        Returns ``"ran"`` or ``"enqueued"``. The busy / pre-existing-queue decision,
-        the idle-with-queue drain, and the run are unified here; the caller supplies
-        ``enqueue`` — a 0-arg callable that persists the SOURCE-specific queued row
-        (Chat promotes its pre-saved pending row; the scheduler appends a harness
-        row) — because that row's shape depends on the request. The in_flight check
-        and the enqueue have no ``await`` between them (single-threaded loop), so a
-        running turn cannot end + flush in the gap — the enqueue stays atomic.
+        The result separates the routing decision (``route``) from whether the
+        SOURCE-specific enqueue callback actually persisted its row
+        (``queue_persisted``). Chat promotes its pre-saved pending row; the
+        scheduler appends a harness row. Their shapes differ, so the caller owns the
+        write and reports its durable result through the callback.
+
+        The in_flight check and callback have no ``await`` between them, which only
+        prevents this event loop from finishing + flushing the active turn in that
+        gap. It does NOT make the callback atomic with external transactions such as
+        session archival; callers must use ``queue_persisted`` (and any domain-owned
+        post-submit observation) rather than infer durability from ``route``.
         """
         if not (isinstance(session_id, str) and session_id):
             # No session key (CLI-style) — just run; nothing to queue against.
             await self._run(None, context, text, source=source)
-            return "ran"
+            return TurnSubmissionResult(route="ran")
 
         backend = self._context_backend(context)
         entry = self.in_flight.get(session_id)
@@ -980,9 +992,8 @@ class SessionTurnManager:
             with self._sqlite_engine().connect() as conn:
                 should_enqueue = bool(messages_service.list_queued(conn, session_id))
         if should_enqueue:
-            if enqueue is not None:
-                enqueue()
-            if busy or backend in self._draining_backends:
+            queue_persisted = bool(enqueue()) if enqueue is not None else False
+            if queue_persisted and (busy or backend in self._draining_backends):
                 # The row joins the active turn's queue and stays until it drains —
                 # surface the queue growth NOW so the UI reflects it immediately
                 # (the later flush emits its own queue.updated when it pops). This
@@ -990,14 +1001,18 @@ class SessionTurnManager:
                 from core.inbox_events import bus
 
                 bus.publish("queue.updated", {"session_id": session_id})
-            else:
+            elif not busy and backend not in self._draining_backends:
                 # Idle + pre-existing queue → no running turn to flush behind, so
-                # drain the whole queue (this row included) now, in order. flush_queue
-                # publishes queue.updated itself.
+                # drain the durable queue now, in order. If this callback lost an
+                # archival race, only pre-existing rows remain. flush_queue publishes
+                # queue.updated itself.
                 await self.flush_queue(session_id)
-            return "enqueued"
+            return TurnSubmissionResult(
+                route="enqueued",
+                queue_persisted=queue_persisted,
+            )
         await self._run(session_id, context, text, source=source)
-        return "ran"
+        return TurnSubmissionResult(route="ran")
 
     async def _run(
         self,

--- a/core/show_session_events.py
+++ b/core/show_session_events.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import uuid
 from contextlib import ExitStack
 from dataclasses import dataclass
@@ -9,14 +10,14 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-from sqlalchemy import select, update
+from sqlalchemy import delete, select, update
 
 from config import paths
 from core.services import sessions as workbench_sessions_service
 from storage import messages_service
 from storage.db import create_sqlite_engine
 from storage.importer import ensure_sqlite_state, resolve_primary_platform_from_config
-from storage.models import agent_sessions, show_session_events
+from storage.models import agent_sessions, media_objects, show_session_events
 
 DEFAULT_MARK_SCOPE = "default"
 HUMAN_EVENT_TYPES = {
@@ -56,6 +57,17 @@ ASSISTANT_MARK_EVENT_TYPES = {
     "assistant.mark.resolved",
 }
 _EVENT_REQUEST_FINGERPRINT_KEY = "__avibe_request_fingerprint"
+DISPATCH_NONE = "none"
+DISPATCH_IN_FLIGHT = "in_flight"
+DISPATCH_ACCEPTED = "accepted"
+DISPATCH_FAILED = "failed"
+SHOW_DISPATCH_CLAIM_TTL_SECONDS = 60
+_DISPATCH_STATES = {
+    DISPATCH_NONE,
+    DISPATCH_IN_FLIGHT,
+    DISPATCH_ACCEPTED,
+    DISPATCH_FAILED,
+}
 
 
 class ShowSessionEventError(ValueError):
@@ -75,6 +87,269 @@ def show_event_requests_dispatch(event: dict[str, Any]) -> bool:
 
 
 @dataclass(frozen=True)
+class ShowDispatchStatus:
+    state: str
+    owner: str | None = None
+    claimed_at: str | None = None
+    message_id: str | None = None
+    session_status: str | None = None
+    claimed: bool = False
+
+
+def _dispatch_state_payload(raw: Any) -> dict[str, Any]:
+    parsed = _json_loads(raw, {})
+    if not isinstance(parsed, dict):
+        return {"state": DISPATCH_NONE}
+    state = parsed.get("state")
+    if state not in _DISPATCH_STATES:
+        return {"state": DISPATCH_NONE}
+    return parsed
+
+
+def _dispatch_state_json(
+    state: str,
+    *,
+    owner: str | None = None,
+    claimed_at: str | None = None,
+) -> str:
+    if state not in _DISPATCH_STATES:
+        raise ValueError(f"unsupported Show dispatch state: {state}")
+    payload: dict[str, Any] = {"state": state}
+    if state == DISPATCH_IN_FLIGHT:
+        if not owner or not claimed_at:
+            raise ValueError("in-flight Show dispatch state requires owner and claimed_at")
+        payload.update({"owner": owner, "claimed_at": claimed_at})
+    return _json_dumps(payload)
+
+
+def current_show_dispatch_owner() -> str:
+    """Stable identity for the current claimant process."""
+    from vibe.runtime import process_create_time
+
+    pid = os.getpid()
+    started_at = process_create_time(pid)
+    suffix = f"{started_at:.6f}" if isinstance(started_at, (int, float)) else "unknown"
+    return f"{pid}:{suffix}"
+
+
+def _show_dispatch_owner_is_alive(owner: str | None) -> bool:
+    if not isinstance(owner, str) or ":" not in owner:
+        return False
+    raw_pid, raw_started_at = owner.split(":", 1)
+    try:
+        pid = int(raw_pid)
+    except ValueError:
+        return False
+
+    from vibe.runtime import pid_alive, process_create_time
+
+    if not pid_alive(pid):
+        return False
+    if raw_started_at == "unknown":
+        return True
+    try:
+        expected_started_at = float(raw_started_at)
+    except ValueError:
+        return False
+    actual_started_at = process_create_time(pid)
+    return isinstance(actual_started_at, (int, float)) and abs(
+        actual_started_at - expected_started_at
+    ) < 0.001
+
+
+def _show_dispatch_claim_is_stale(claimed_at: str | None) -> bool:
+    try:
+        claimed = datetime.fromisoformat(str(claimed_at).replace("Z", "+00:00"))
+    except ValueError:
+        return True
+    if claimed.tzinfo is None:
+        claimed = claimed.replace(tzinfo=timezone.utc)
+    return (
+        datetime.now(timezone.utc) - claimed.astimezone(timezone.utc)
+    ).total_seconds() >= SHOW_DISPATCH_CLAIM_TTL_SECONDS
+
+
+def get_show_dispatch_status(
+    conn: Any,
+    event_id: str,
+    *,
+    session_id: str | None = None,
+) -> ShowDispatchStatus | None:
+    query = (
+        select(
+            show_session_events.c.dispatch_state,
+            show_session_events.c.message_id,
+            agent_sessions.c.status.label("session_status"),
+        )
+        .select_from(
+            show_session_events.join(
+                agent_sessions,
+                agent_sessions.c.id == show_session_events.c.session_id,
+            )
+        )
+        .where(show_session_events.c.id == event_id)
+    )
+    if session_id is not None:
+        query = query.where(show_session_events.c.session_id == session_id)
+    row = conn.execute(query.limit(1)).mappings().first()
+    if row is None:
+        return None
+    payload = _dispatch_state_payload(row["dispatch_state"])
+    return ShowDispatchStatus(
+        state=str(payload["state"]),
+        owner=_text_or_none(payload.get("owner")),
+        claimed_at=_text_or_none(payload.get("claimed_at")),
+        message_id=_text_or_none(row.get("message_id")),
+        session_status=_text_or_none(row.get("session_status")),
+    )
+
+
+def claim_show_dispatch(
+    conn: Any,
+    event_id: str,
+    *,
+    session_id: str,
+    owner: str | None = None,
+) -> ShowDispatchStatus | None:
+    """Atomically claim a retryable or provably abandoned Show dispatch."""
+    claim_owner = owner or current_show_dispatch_owner()
+    for _attempt in range(3):
+        row = conn.execute(
+            select(
+                show_session_events.c.dispatch_state,
+                show_session_events.c.message_id,
+                agent_sessions.c.status.label("session_status"),
+            )
+            .select_from(
+                show_session_events.join(
+                    agent_sessions,
+                    agent_sessions.c.id == show_session_events.c.session_id,
+                )
+            )
+            .where(
+                show_session_events.c.id == event_id,
+                show_session_events.c.session_id == session_id,
+            )
+            .limit(1)
+        ).mappings().first()
+        if row is None:
+            return None
+        payload = _dispatch_state_payload(row["dispatch_state"])
+        state = str(payload["state"])
+        status = ShowDispatchStatus(
+            state=state,
+            owner=_text_or_none(payload.get("owner")),
+            claimed_at=_text_or_none(payload.get("claimed_at")),
+            message_id=_text_or_none(row.get("message_id")),
+            session_status=_text_or_none(row.get("session_status")),
+        )
+        if status.session_status == "archived":
+            return status
+        if state == DISPATCH_ACCEPTED:
+            return status
+        if (
+            state == DISPATCH_IN_FLIGHT
+            and (
+                _show_dispatch_owner_is_alive(status.owner)
+                or not _show_dispatch_claim_is_stale(status.claimed_at)
+            )
+        ):
+            return status
+
+        claimed_at = _utc_now_iso()
+        raw_state = row["dispatch_state"]
+        result = conn.execute(
+            update(show_session_events)
+            .where(
+                show_session_events.c.id == event_id,
+                show_session_events.c.session_id == session_id,
+                show_session_events.c.dispatch_state == raw_state,
+            )
+            .values(
+                dispatch_state=_dispatch_state_json(
+                    DISPATCH_IN_FLIGHT,
+                    owner=claim_owner,
+                    claimed_at=claimed_at,
+                )
+            )
+        )
+        if result.rowcount:
+            return ShowDispatchStatus(
+                state=DISPATCH_IN_FLIGHT,
+                owner=claim_owner,
+                claimed_at=claimed_at,
+                message_id=status.message_id,
+                session_status=status.session_status,
+                claimed=True,
+            )
+    return get_show_dispatch_status(conn, event_id, session_id=session_id)
+
+
+def accept_show_dispatch(
+    conn: Any,
+    event_id: str,
+    *,
+    session_id: str,
+    owner: str,
+) -> bool:
+    """Persist controller acceptance for the matching claim owner."""
+    row = conn.execute(
+        select(show_session_events.c.dispatch_state).where(
+            show_session_events.c.id == event_id,
+            show_session_events.c.session_id == session_id,
+        )
+    ).scalar_one_or_none()
+    if row is None:
+        return False
+    payload = _dispatch_state_payload(row)
+    if payload["state"] == DISPATCH_ACCEPTED:
+        return True
+    if payload["state"] != DISPATCH_IN_FLIGHT or payload.get("owner") != owner:
+        return False
+    result = conn.execute(
+        update(show_session_events)
+        .where(
+            show_session_events.c.id == event_id,
+            show_session_events.c.session_id == session_id,
+            show_session_events.c.dispatch_state == row,
+        )
+        .values(dispatch_state=_dispatch_state_json(DISPATCH_ACCEPTED))
+    )
+    return bool(result.rowcount)
+
+
+def fail_show_dispatch(
+    conn: Any,
+    event_id: str,
+    *,
+    session_id: str,
+    owner: str,
+) -> bool:
+    """Make a definitively rejected claim retryable without changing rendering."""
+    row = conn.execute(
+        select(show_session_events.c.dispatch_state).where(
+            show_session_events.c.id == event_id,
+            show_session_events.c.session_id == session_id,
+        )
+    ).scalar_one_or_none()
+    if row is None:
+        return False
+    payload = _dispatch_state_payload(row)
+    if payload["state"] != DISPATCH_IN_FLIGHT or payload.get("owner") != owner:
+        return False
+    result = conn.execute(
+        update(show_session_events)
+        .where(
+            show_session_events.c.id == event_id,
+            show_session_events.c.session_id == session_id,
+            show_session_events.c.dispatch_state == row,
+        )
+        .values(dispatch_state=_dispatch_state_json(DISPATCH_FAILED))
+    )
+    return bool(result.rowcount)
+
+
+@dataclass(frozen=True)
 class ShowSessionEventStore:
     db_path: Path | None = None
 
@@ -89,6 +364,14 @@ class ShowSessionEventStore:
 
     def close(self) -> None:
         self.engine.dispose()
+
+    def get_dispatch_status(
+        self,
+        session_id: str,
+        event_id: str,
+    ) -> ShowDispatchStatus | None:
+        with self.engine.connect() as conn:
+            return get_show_dispatch_status(conn, event_id, session_id=session_id)
 
     def append(
         self,
@@ -179,6 +462,7 @@ class ShowSessionEventStore:
                         ),
                         transcript_text=transcript_text,
                         message_id=None,
+                        dispatch_state=_dispatch_state_json(DISPATCH_NONE),
                         created_at=created_at,
                     )
                 )
@@ -191,6 +475,15 @@ class ShowSessionEventStore:
                         payload=payload,
                         request_fingerprint=request_fingerprint,
                     )
+                    screenshot = _normalize_json_object(event_payload.get("screenshot"))
+                    attachment_id = _text_or_none(screenshot.get("attachmentId"))
+                    if attachment_id and screenshot_path:
+                        conn.execute(
+                            delete(media_objects).where(
+                                media_objects.c.token == attachment_id,
+                                media_objects.c.local_path == screenshot_path,
+                            )
+                        )
                     existing = _existing_event_payload(
                         conn,
                         event_id=event_id,
@@ -645,7 +938,32 @@ def _event_id(original_payload: dict[str, Any], event_payload: dict[str, Any]) -
     return _text_or_none(original_payload.get("id")) or _new_id("show_evt")
 
 
-def _event_request_content(event_type: str, payload: dict[str, Any]) -> dict[str, Any]:
+def _canonical_request_value(raw: Any) -> Any:
+    if isinstance(raw, dict):
+        return {
+            key: _canonical_request_value(value)
+            for key, value in raw.items()
+            if value is not None
+        }
+    if isinstance(raw, list):
+        return [_canonical_request_value(value) for value in raw]
+    return raw
+
+
+def _event_request_content(payload: dict[str, Any]) -> dict[str, Any]:
+    return _canonical_request_value(
+        {
+            key: value
+            for key, value in payload.items()
+            if key not in {"id", "type", "sessionId", "session_id"}
+        }
+    )
+
+
+def _legacy_event_request_content(
+    event_type: str,
+    payload: dict[str, Any],
+) -> dict[str, Any]:
     if event_type.startswith("assistant.mark."):
         raw = payload.get("mark") or payload.get("payload")
     elif event_type == "human.intent.submitted":
@@ -656,17 +974,14 @@ def _event_request_content(event_type: str, payload: dict[str, Any]) -> dict[str
         raw = payload.get("payload")
     if isinstance(raw, dict):
         return raw
-    content = dict(payload)
-    content.pop("id", None)
-    content.pop("type", None)
-    return content
+    return _event_request_content(payload)
 
 
 def _event_request_fingerprint(event_type: str, payload: dict[str, Any]) -> str:
     canonical = json.dumps(
         {
             "type": event_type,
-            "payload": _event_request_content(event_type, payload),
+            "payload": _event_request_content(payload),
         },
         ensure_ascii=False,
         separators=(",", ":"),
@@ -719,7 +1034,7 @@ def _assert_matching_event_replay(
         stored_fingerprint == request_fingerprint
         if isinstance(stored_fingerprint, str)
         else _legacy_request_matches_stored(
-            _event_request_content(event_type, payload),
+            _legacy_event_request_content(event_type, payload),
             stored_payload,
         )
     )

--- a/core/show_session_events.py
+++ b/core/show_session_events.py
@@ -145,12 +145,6 @@ class ShowSessionEventStore:
                 requests_dispatch = show_event_requests_dispatch(
                     {"type": event_type, "actor": actor, "payload": event_payload}
                 )
-                if requests_dispatch and not reserve_dispatch:
-                    raise ShowSessionEventError(
-                        "Dispatching Show events must use the unified turn entry.",
-                        code="dispatch_requires_turn_entry",
-                    )
-
                 conn.execute(
                     show_session_events.insert().values(
                         id=event_id,
@@ -174,7 +168,11 @@ class ShowSessionEventStore:
                         session_id=session_id,
                         platform="avibe",
                         author="agent" if actor in {"assistant", "system"} else "user",
-                        message_type=messages_service.PENDING_TYPE if requests_dispatch else None,
+                        message_type=(
+                            messages_service.PENDING_TYPE
+                            if requests_dispatch and reserve_dispatch
+                            else None
+                        ),
                         text=transcript_text,
                         content={"text": transcript_text, "show_event_type": event_type},
                         metadata={

--- a/core/show_session_events.py
+++ b/core/show_session_events.py
@@ -55,6 +55,7 @@ ASSISTANT_MARK_EVENT_TYPES = {
     "assistant.mark.updated",
     "assistant.mark.resolved",
 }
+_EVENT_REQUEST_FINGERPRINT_KEY = "__avibe_request_fingerprint"
 
 
 class ShowSessionEventError(ValueError):
@@ -102,6 +103,7 @@ class ShowSessionEventStore:
         actor = _actor_for_event(event_type)
         records_author = actor == "human" or (event_type == "assistant.mark.resolved" and author is not None)
         event_id = _event_id(payload, {})
+        request_fingerprint = _event_request_fingerprint(event_type, payload)
         created_at = _utc_now_iso()
 
         with ExitStack() as cleanup:
@@ -124,6 +126,14 @@ class ShowSessionEventStore:
                     scope_id=session["scope_id"],
                 )
                 if existing is not None:
+                    _assert_matching_event_replay(
+                        conn,
+                        event_id=event_id,
+                        session_id=session_id,
+                        event_type=event_type,
+                        payload=payload,
+                        request_fingerprint=request_fingerprint,
+                    )
                     return existing
 
                 stored_payload = payload
@@ -161,13 +171,26 @@ class ShowSessionEventStore:
                         actor=actor,
                         scope=scope,
                         anchor_json=_json_dumps(anchor),
-                        payload_json=_json_dumps(event_payload),
+                        payload_json=_json_dumps(
+                            {
+                                **event_payload,
+                                _EVENT_REQUEST_FINGERPRINT_KEY: request_fingerprint,
+                            }
+                        ),
                         transcript_text=transcript_text,
                         message_id=None,
                         created_at=created_at,
                     )
                 )
                 if inserted.rowcount == 0:
+                    _assert_matching_event_replay(
+                        conn,
+                        event_id=event_id,
+                        session_id=session_id,
+                        event_type=event_type,
+                        payload=payload,
+                        request_fingerprint=request_fingerprint,
+                    )
                     existing = _existing_event_payload(
                         conn,
                         event_id=event_id,
@@ -264,6 +287,23 @@ class ShowSessionEventStore:
                 .limit(1)
             ).mappings().first()
         return _row_to_payload(dict(row)) if row is not None else None
+
+    def get_event(self, session_id: str, event_id: str) -> dict[str, Any] | None:
+        """Return one event with its current transcript reservation state."""
+        with self.engine.connect() as conn:
+            session = conn.execute(
+                select(agent_sessions.c.scope_id)
+                .where(agent_sessions.c.id == session_id)
+                .limit(1)
+            ).first()
+            if session is None:
+                return None
+            return _existing_event_payload(
+                conn,
+                event_id=event_id,
+                session_id=session_id,
+                scope_id=session.scope_id,
+            )
 
     def recent_annotation_event_ids(self, session_id: str, *, limit: int = 10) -> list[str]:
         effective_limit = min(max(int(limit), 1), 50)
@@ -605,6 +645,91 @@ def _event_id(original_payload: dict[str, Any], event_payload: dict[str, Any]) -
     return _text_or_none(original_payload.get("id")) or _new_id("show_evt")
 
 
+def _event_request_content(event_type: str, payload: dict[str, Any]) -> dict[str, Any]:
+    if event_type.startswith("assistant.mark."):
+        raw = payload.get("mark") or payload.get("payload")
+    elif event_type == "human.intent.submitted":
+        raw = payload.get("payload")
+    elif event_type in ANNOTATION_EVENT_TYPES:
+        raw = payload.get("annotation") or payload.get("payload")
+    else:
+        raw = payload.get("payload")
+    if isinstance(raw, dict):
+        return raw
+    content = dict(payload)
+    content.pop("id", None)
+    content.pop("type", None)
+    return content
+
+
+def _event_request_fingerprint(event_type: str, payload: dict[str, Any]) -> str:
+    canonical = json.dumps(
+        {
+            "type": event_type,
+            "payload": _event_request_content(event_type, payload),
+        },
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _legacy_request_matches_stored(requested: Any, stored: Any) -> bool:
+    if isinstance(requested, dict):
+        if not isinstance(stored, dict):
+            return False
+        return all(
+            key == "dataUrl" or (key in stored and _legacy_request_matches_stored(value, stored[key]))
+            for key, value in requested.items()
+        )
+    if isinstance(requested, list):
+        return isinstance(stored, list) and len(requested) == len(stored) and all(
+            _legacy_request_matches_stored(requested_item, stored_item)
+            for requested_item, stored_item in zip(requested, stored, strict=True)
+        )
+    return requested == stored
+
+
+def _assert_matching_event_replay(
+    conn: Any,
+    *,
+    event_id: str,
+    session_id: str,
+    event_type: str,
+    payload: dict[str, Any],
+    request_fingerprint: str,
+) -> None:
+    row = conn.execute(
+        select(
+            show_session_events.c.session_id,
+            show_session_events.c.event_type,
+            show_session_events.c.payload_json,
+        ).where(show_session_events.c.id == event_id)
+    ).mappings().first()
+    if row is None:
+        return
+    stored_payload = _json_loads(row.get("payload_json"), {})
+    stored_fingerprint = (
+        stored_payload.get(_EVENT_REQUEST_FINGERPRINT_KEY)
+        if isinstance(stored_payload, dict)
+        else None
+    )
+    matches = row["session_id"] == session_id and row["event_type"] == event_type and (
+        stored_fingerprint == request_fingerprint
+        if isinstance(stored_fingerprint, str)
+        else _legacy_request_matches_stored(
+            _event_request_content(event_type, payload),
+            stored_payload,
+        )
+    )
+    if not matches:
+        raise ShowSessionEventError(
+            "Show event id is already bound to different event contents.",
+            code="event_id_conflict",
+        )
+
+
 def _format_transcript_header(
     family: str,
     *,
@@ -733,6 +858,9 @@ def _format_transcript_text(event_type: str, payload: dict[str, Any], anchor: di
 
 
 def _row_to_payload(row: dict[str, Any]) -> dict[str, Any]:
+    payload = _json_loads(row.get("payload_json"), {})
+    if isinstance(payload, dict):
+        payload.pop(_EVENT_REQUEST_FINGERPRINT_KEY, None)
     return {
         "id": row["id"],
         "session_id": row["session_id"],
@@ -740,7 +868,7 @@ def _row_to_payload(row: dict[str, Any]) -> dict[str, Any]:
         "actor": row["actor"],
         "scope": row["scope"],
         "anchor": _json_loads(row.get("anchor_json"), {}),
-        "payload": _json_loads(row.get("payload_json"), {}),
+        "payload": payload,
         "transcript_text": row.get("transcript_text"),
         "message_id": row.get("message_id"),
         "created_at": row.get("created_at"),

--- a/core/show_session_events.py
+++ b/core/show_session_events.py
@@ -117,6 +117,14 @@ class ShowSessionEventStore:
                 # events (which dispatch as new agent work) into an archived session.
                 if session["status"] == "archived":
                     raise ShowSessionEventError("Agent session is archived.", code="session_archived")
+                existing = _existing_event_payload(
+                    conn,
+                    event_id=event_id,
+                    session_id=session_id,
+                    scope_id=session["scope_id"],
+                )
+                if existing is not None:
+                    return existing
 
                 stored_payload = payload
                 if event_type == "assistant.mark.resolved":
@@ -145,8 +153,8 @@ class ShowSessionEventStore:
                 requests_dispatch = show_event_requests_dispatch(
                     {"type": event_type, "actor": actor, "payload": event_payload}
                 )
-                conn.execute(
-                    show_session_events.insert().values(
+                inserted = conn.execute(
+                    show_session_events.insert().prefix_with("OR IGNORE").values(
                         id=event_id,
                         session_id=session_id,
                         event_type=event_type,
@@ -159,6 +167,16 @@ class ShowSessionEventStore:
                         created_at=created_at,
                     )
                 )
+                if inserted.rowcount == 0:
+                    existing = _existing_event_payload(
+                        conn,
+                        event_id=event_id,
+                        session_id=session_id,
+                        scope_id=session["scope_id"],
+                    )
+                    if existing is None:
+                        raise RuntimeError(f"show event id conflict without stored row: {event_id}")
+                    return existing
                 message: dict[str, Any] | None = None
                 message_id: str | None = None
                 if transcript_text:
@@ -727,6 +745,40 @@ def _row_to_payload(row: dict[str, Any]) -> dict[str, Any]:
         "message_id": row.get("message_id"),
         "created_at": row.get("created_at"),
     }
+
+
+def _existing_event_payload(
+    conn: Any,
+    *,
+    event_id: str,
+    session_id: str,
+    scope_id: str | None,
+) -> dict[str, Any] | None:
+    row = conn.execute(
+        select(show_session_events).where(
+            show_session_events.c.id == event_id,
+            show_session_events.c.session_id == session_id,
+        )
+    ).mappings().first()
+    if row is None:
+        return None
+    event = _row_to_payload(dict(row))
+    event["scope_id"] = scope_id
+    message_id = event.get("message_id")
+    message = None
+    if isinstance(message_id, str) and message_id:
+        window = messages_service.list_session_messages(
+            conn,
+            session_id=session_id,
+            around_id=message_id,
+            limit=1,
+        )
+        message = next(
+            (item for item in window["messages"] if item.get("id") == message_id),
+            None,
+        )
+    event["message"] = message
+    return event
 
 
 def _required_text(raw: Any, field: str) -> str:

--- a/core/show_session_events.py
+++ b/core/show_session_events.py
@@ -63,6 +63,16 @@ class ShowSessionEventError(ValueError):
         self.code = code
 
 
+def show_event_requests_dispatch(event: dict[str, Any]) -> bool:
+    """Whether a normalized Show event should start an agent turn."""
+    if event.get("actor") != "human":
+        return False
+    if event.get("type") not in {"human.intent.submitted", "human.annotation.created"}:
+        return False
+    payload = event.get("payload")
+    return isinstance(payload, dict) and bool(payload.get("dispatch"))
+
+
 @dataclass(frozen=True)
 class ShowSessionEventStore:
     db_path: Path | None = None
@@ -131,6 +141,9 @@ class ShowSessionEventStore:
                 )
                 if records_author:
                     event_payload["author"] = _normalize_human_author(author)
+                requests_dispatch = show_event_requests_dispatch(
+                    {"type": event_type, "actor": actor, "payload": event_payload}
+                )
 
                 conn.execute(
                     show_session_events.insert().values(
@@ -155,6 +168,7 @@ class ShowSessionEventStore:
                         session_id=session_id,
                         platform="avibe",
                         author="agent" if actor in {"assistant", "system"} else "user",
+                        message_type=messages_service.PENDING_TYPE if requests_dispatch else None,
                         text=transcript_text,
                         content={"text": transcript_text, "show_event_type": event_type},
                         metadata={

--- a/core/show_session_events.py
+++ b/core/show_session_events.py
@@ -95,6 +95,7 @@ class ShowSessionEventStore:
         payload: dict[str, Any],
         *,
         author: dict[str, str] | None = None,
+        reserve_dispatch: bool = False,
     ) -> dict[str, Any]:
         validate_show_event_payload_session(session_id, payload)
         event_type = _validate_event_type(payload.get("type"))
@@ -144,6 +145,11 @@ class ShowSessionEventStore:
                 requests_dispatch = show_event_requests_dispatch(
                     {"type": event_type, "actor": actor, "payload": event_payload}
                 )
+                if requests_dispatch and not reserve_dispatch:
+                    raise ShowSessionEventError(
+                        "Dispatching Show events must use the unified turn entry.",
+                        code="dispatch_requires_turn_entry",
+                    )
 
                 conn.execute(
                     show_session_events.insert().values(

--- a/core/show_session_events.py
+++ b/core/show_session_events.py
@@ -406,7 +406,7 @@ def observe_and_settle_show_dispatch(
     session_id: str,
     owner: str,
     active_message_id: str | None,
-    enqueue_succeeded: bool | None,
+    queue_persisted: bool | None,
 ) -> tuple[ShowDispatchStatus | None, str | None]:
     """Settle from the durable reservation observed after unified submission."""
     row = (
@@ -461,7 +461,7 @@ def observe_and_settle_show_dispatch(
         and message_type == messages_service.QUEUED_TYPE
     )
     reservation_observed = started or queued
-    if enqueue_succeeded is False and not reservation_observed:
+    if queue_persisted is False and not reservation_observed:
         terminal_state = (
             DISPATCH_ARCHIVED
             if status.session_status == "archived"

--- a/core/show_session_events.py
+++ b/core/show_session_events.py
@@ -19,7 +19,7 @@ from core.services import sessions as workbench_sessions_service
 from storage import messages_service
 from storage.db import create_sqlite_engine
 from storage.importer import ensure_sqlite_state, resolve_primary_platform_from_config
-from storage.models import agent_sessions, media_objects, show_session_events
+from storage.models import agent_sessions, media_objects, messages, show_session_events
 from vibe.i18n import t as i18n_t
 
 DEFAULT_MARK_SCOPE = "default"
@@ -64,12 +64,19 @@ DISPATCH_NONE = "none"
 DISPATCH_IN_FLIGHT = "in_flight"
 DISPATCH_ACCEPTED = "accepted"
 DISPATCH_FAILED = "failed"
+DISPATCH_ARCHIVED = "archived"
 SHOW_DISPATCH_CLAIM_TTL_SECONDS = 60
 _DISPATCH_STATES = {
     DISPATCH_NONE,
     DISPATCH_IN_FLIGHT,
     DISPATCH_ACCEPTED,
     DISPATCH_FAILED,
+    DISPATCH_ARCHIVED,
+}
+_TERMINAL_DISPATCH_STATES = {
+    DISPATCH_ACCEPTED,
+    DISPATCH_FAILED,
+    DISPATCH_ARCHIVED,
 }
 SHOW_EVENT_ERROR_I18N_KEYS = {
     "event_id_conflict": "show.event.idConflict",
@@ -317,7 +324,7 @@ def claim_show_dispatch(
         )
         if status.session_status == "archived":
             return status
-        if state == DISPATCH_ACCEPTED:
+        if state in {DISPATCH_ACCEPTED, DISPATCH_ARCHIVED}:
             return status
         if (
             state == DISPATCH_IN_FLIGHT
@@ -354,14 +361,17 @@ def claim_show_dispatch(
     return get_show_dispatch_status(conn, event_id, session_id=session_id)
 
 
-def accept_show_dispatch(
+def settle_show_dispatch(
     conn: Any,
     event_id: str,
     *,
     session_id: str,
     owner: str,
+    state: str,
 ) -> bool:
-    """Persist controller acceptance for the matching claim owner."""
+    """Persist one observed terminal outcome for the matching claim owner."""
+    if state not in _TERMINAL_DISPATCH_STATES:
+        raise ValueError(f"unsupported terminal Show dispatch state: {state}")
     row = conn.execute(
         select(show_session_events.c.dispatch_state).where(
             show_session_events.c.id == event_id,
@@ -371,8 +381,10 @@ def accept_show_dispatch(
     if row is None:
         return False
     payload = _dispatch_state_payload(row)
-    if payload["state"] == DISPATCH_ACCEPTED:
+    if payload["state"] == state:
         return True
+    if payload["state"] in _TERMINAL_DISPATCH_STATES:
+        return False
     if payload["state"] != DISPATCH_IN_FLIGHT or payload.get("owner") != owner:
         return False
     result = conn.execute(
@@ -382,40 +394,102 @@ def accept_show_dispatch(
             show_session_events.c.session_id == session_id,
             show_session_events.c.dispatch_state == row,
         )
-        .values(dispatch_state=_dispatch_state_json(DISPATCH_ACCEPTED))
+        .values(dispatch_state=_dispatch_state_json(state))
     )
     return bool(result.rowcount)
 
 
-def fail_show_dispatch(
+def observe_and_settle_show_dispatch(
     conn: Any,
     event_id: str,
     *,
     session_id: str,
     owner: str,
-) -> bool:
-    """Make a definitively rejected claim retryable without changing rendering."""
-    row = conn.execute(
-        select(show_session_events.c.dispatch_state).where(
-            show_session_events.c.id == event_id,
-            show_session_events.c.session_id == session_id,
+    active_message_id: str | None,
+    enqueue_succeeded: bool | None,
+) -> tuple[ShowDispatchStatus | None, str | None]:
+    """Settle from the durable reservation observed after unified submission."""
+    row = (
+        conn.execute(
+            select(
+                show_session_events.c.dispatch_state,
+                show_session_events.c.message_id,
+                agent_sessions.c.status.label("session_status"),
+                messages.c.id.label("stored_message_id"),
+                messages.c.type.label("message_type"),
+            )
+            .select_from(
+                show_session_events.join(
+                    agent_sessions,
+                    agent_sessions.c.id == show_session_events.c.session_id,
+                ).outerjoin(
+                    messages,
+                    (messages.c.id == show_session_events.c.message_id)
+                    & (messages.c.session_id == show_session_events.c.session_id),
+                )
+            )
+            .where(
+                show_session_events.c.id == event_id,
+                show_session_events.c.session_id == session_id,
+            )
+            .limit(1)
         )
-    ).scalar_one_or_none()
-    if row is None:
-        return False
-    payload = _dispatch_state_payload(row)
-    if payload["state"] != DISPATCH_IN_FLIGHT or payload.get("owner") != owner:
-        return False
-    result = conn.execute(
-        update(show_session_events)
-        .where(
-            show_session_events.c.id == event_id,
-            show_session_events.c.session_id == session_id,
-            show_session_events.c.dispatch_state == row,
-        )
-        .values(dispatch_state=_dispatch_state_json(DISPATCH_FAILED))
+        .mappings()
+        .first()
     )
-    return bool(result.rowcount)
+    if row is None:
+        return None, None
+
+    payload = _dispatch_state_payload(row["dispatch_state"])
+    status = ShowDispatchStatus(
+        state=str(payload["state"]),
+        owner=_text_or_none(payload.get("owner")),
+        claimed_at=_text_or_none(payload.get("claimed_at")),
+        message_id=_text_or_none(row.get("message_id")),
+        session_status=_text_or_none(row.get("session_status")),
+    )
+    message_type = _text_or_none(row.get("message_type"))
+    if status.state in _TERMINAL_DISPATCH_STATES:
+        return status, message_type
+    if status.state != DISPATCH_IN_FLIGHT or status.owner != owner:
+        return status, message_type
+
+    stored_message_id = _text_or_none(row.get("stored_message_id"))
+    started = bool(stored_message_id and stored_message_id == active_message_id)
+    queued = bool(
+        stored_message_id
+        and message_type == messages_service.QUEUED_TYPE
+    )
+    reservation_observed = started or queued
+    if enqueue_succeeded is False and not reservation_observed:
+        terminal_state = (
+            DISPATCH_ARCHIVED
+            if status.session_status == "archived"
+            else DISPATCH_FAILED
+        )
+    elif reservation_observed:
+        terminal_state = DISPATCH_ACCEPTED
+    elif status.session_status == "archived":
+        terminal_state = DISPATCH_ARCHIVED
+    else:
+        terminal_state = DISPATCH_FAILED
+
+    if not settle_show_dispatch(
+        conn,
+        event_id,
+        session_id=session_id,
+        owner=owner,
+        state=terminal_state,
+    ):
+        return get_show_dispatch_status(conn, event_id, session_id=session_id), message_type
+    return (
+        ShowDispatchStatus(
+            state=terminal_state,
+            message_id=status.message_id,
+            session_status=status.session_status,
+        ),
+        message_type,
+    )
 
 
 @dataclass(frozen=True)

--- a/core/show_session_events.py
+++ b/core/show_session_events.py
@@ -3,21 +3,24 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import threading
 import uuid
-from contextlib import ExitStack
+from contextlib import ExitStack, contextmanager
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, Iterator
 
 from sqlalchemy import delete, select, update
 
 from config import paths
+from config.v2_config import V2Config
 from core.services import sessions as workbench_sessions_service
 from storage import messages_service
 from storage.db import create_sqlite_engine
 from storage.importer import ensure_sqlite_state, resolve_primary_platform_from_config
 from storage.models import agent_sessions, media_objects, show_session_events
+from vibe.i18n import t as i18n_t
 
 DEFAULT_MARK_SCOPE = "default"
 HUMAN_EVENT_TYPES = {
@@ -68,12 +71,31 @@ _DISPATCH_STATES = {
     DISPATCH_ACCEPTED,
     DISPATCH_FAILED,
 }
+SHOW_EVENT_ERROR_I18N_KEYS = {
+    "event_id_conflict": "show.event.idConflict",
+    "show_event_dispatch_failed": "show.event.dispatchFailed",
+    "show_event_dispatch_pending": "show.event.acceptanceUnknown",
+}
+_ACTIVE_SHOW_DISPATCH_ATTEMPTS: set[str] = set()
+_ACTIVE_SHOW_DISPATCH_ATTEMPTS_LOCK = threading.Lock()
 
 
 class ShowSessionEventError(ValueError):
     def __init__(self, message: str, *, code: str):
         super().__init__(message)
         self.code = code
+
+
+def localized_show_event_error(code: str) -> ShowSessionEventError:
+    """Build a localized user-facing Show event error for a stable code."""
+    translation_key = SHOW_EVENT_ERROR_I18N_KEYS.get(code)
+    if translation_key is None:
+        raise ValueError(f"unsupported localized Show event error code: {code}")
+    try:
+        language = V2Config.load().language
+    except Exception:
+        language = "en"
+    return ShowSessionEventError(i18n_t(translation_key, language), code=code)
 
 
 def show_event_requests_dispatch(event: dict[str, Any]) -> bool:
@@ -94,6 +116,13 @@ class ShowDispatchStatus:
     message_id: str | None = None
     session_status: str | None = None
     claimed: bool = False
+
+
+@dataclass(frozen=True)
+class _ShowDispatchOwnerIdentity:
+    pid: int
+    started_at: str
+    attempt_id: str | None
 
 
 def _dispatch_state_payload(raw: Any) -> dict[str, Any]:
@@ -122,36 +151,62 @@ def _dispatch_state_json(
     return _json_dumps(payload)
 
 
-def current_show_dispatch_owner() -> str:
-    """Stable identity for the current claimant process."""
+def _current_show_dispatch_process_identity() -> tuple[int, str]:
     from vibe.runtime import process_create_time
 
     pid = os.getpid()
     started_at = process_create_time(pid)
     suffix = f"{started_at:.6f}" if isinstance(started_at, (int, float)) else "unknown"
-    return f"{pid}:{suffix}"
+    return pid, suffix
+
+
+def _parse_show_dispatch_owner(owner: str | None) -> _ShowDispatchOwnerIdentity | None:
+    if not isinstance(owner, str):
+        return None
+    parts = owner.split(":", 2)
+    if len(parts) < 2:
+        return None
+    try:
+        pid = int(parts[0])
+    except ValueError:
+        return None
+    return _ShowDispatchOwnerIdentity(
+        pid=pid,
+        started_at=parts[1],
+        attempt_id=parts[2] if len(parts) == 3 and parts[2] else None,
+    )
+
+
+@contextmanager
+def show_dispatch_attempt() -> Iterator[str]:
+    """Register one live dispatch attempt and yield its durable claim owner."""
+    pid, started_at = _current_show_dispatch_process_identity()
+    attempt_id = uuid.uuid4().hex
+    with _ACTIVE_SHOW_DISPATCH_ATTEMPTS_LOCK:
+        _ACTIVE_SHOW_DISPATCH_ATTEMPTS.add(attempt_id)
+    try:
+        yield f"{pid}:{started_at}:{attempt_id}"
+    finally:
+        with _ACTIVE_SHOW_DISPATCH_ATTEMPTS_LOCK:
+            _ACTIVE_SHOW_DISPATCH_ATTEMPTS.discard(attempt_id)
 
 
 def _show_dispatch_owner_is_alive(owner: str | None) -> bool:
-    if not isinstance(owner, str) or ":" not in owner:
-        return False
-    raw_pid, raw_started_at = owner.split(":", 1)
-    try:
-        pid = int(raw_pid)
-    except ValueError:
+    identity = _parse_show_dispatch_owner(owner)
+    if identity is None:
         return False
 
     from vibe.runtime import pid_alive, process_create_time
 
-    if not pid_alive(pid):
+    if not pid_alive(identity.pid):
         return False
-    if raw_started_at == "unknown":
+    if identity.started_at == "unknown":
         return True
     try:
-        expected_started_at = float(raw_started_at)
+        expected_started_at = float(identity.started_at)
     except ValueError:
         return False
-    actual_started_at = process_create_time(pid)
+    actual_started_at = process_create_time(identity.pid)
     return isinstance(actual_started_at, (int, float)) and abs(
         actual_started_at - expected_started_at
     ) < 0.001
@@ -167,6 +222,24 @@ def _show_dispatch_claim_is_stale(claimed_at: str | None) -> bool:
     return (
         datetime.now(timezone.utc) - claimed.astimezone(timezone.utc)
     ).total_seconds() >= SHOW_DISPATCH_CLAIM_TTL_SECONDS
+
+
+def _show_dispatch_claim_is_active(
+    owner: str | None,
+    claimed_at: str | None,
+) -> bool:
+    identity = _parse_show_dispatch_owner(owner)
+    if identity is not None and identity.attempt_id is not None:
+        current_pid, current_started_at = _current_show_dispatch_process_identity()
+        if (
+            identity.pid == current_pid
+            and identity.started_at == current_started_at
+        ):
+            with _ACTIVE_SHOW_DISPATCH_ATTEMPTS_LOCK:
+                return identity.attempt_id in _ACTIVE_SHOW_DISPATCH_ATTEMPTS
+    return _show_dispatch_owner_is_alive(owner) or not _show_dispatch_claim_is_stale(
+        claimed_at
+    )
 
 
 def get_show_dispatch_status(
@@ -209,10 +282,9 @@ def claim_show_dispatch(
     event_id: str,
     *,
     session_id: str,
-    owner: str | None = None,
+    owner: str,
 ) -> ShowDispatchStatus | None:
     """Atomically claim a retryable or provably abandoned Show dispatch."""
-    claim_owner = owner or current_show_dispatch_owner()
     for _attempt in range(3):
         row = conn.execute(
             select(
@@ -249,10 +321,7 @@ def claim_show_dispatch(
             return status
         if (
             state == DISPATCH_IN_FLIGHT
-            and (
-                _show_dispatch_owner_is_alive(status.owner)
-                or not _show_dispatch_claim_is_stale(status.claimed_at)
-            )
+            and _show_dispatch_claim_is_active(status.owner, status.claimed_at)
         ):
             return status
 
@@ -268,7 +337,7 @@ def claim_show_dispatch(
             .values(
                 dispatch_state=_dispatch_state_json(
                     DISPATCH_IN_FLIGHT,
-                    owner=claim_owner,
+                    owner=owner,
                     claimed_at=claimed_at,
                 )
             )
@@ -276,7 +345,7 @@ def claim_show_dispatch(
         if result.rowcount:
             return ShowDispatchStatus(
                 state=DISPATCH_IN_FLIGHT,
-                owner=claim_owner,
+                owner=owner,
                 claimed_at=claimed_at,
                 message_id=status.message_id,
                 session_status=status.session_status,
@@ -1039,10 +1108,7 @@ def _assert_matching_event_replay(
         )
     )
     if not matches:
-        raise ShowSessionEventError(
-            "Show event id is already bound to different event contents.",
-            code="event_id_conflict",
-        )
+        raise localized_show_event_error("event_id_conflict")
 
 
 def _format_transcript_header(

--- a/core/show_session_events.py
+++ b/core/show_session_events.py
@@ -126,6 +126,41 @@ class ShowDispatchStatus:
 
 
 @dataclass(frozen=True)
+class ShowDispatchSettlement:
+    """Observed dispatch lifecycle plus the current transcript presentation."""
+
+    status: ShowDispatchStatus
+    message: dict[str, Any] | None
+    message_promoted: bool = False
+
+    @property
+    def can_publish_message_new(self) -> bool:
+        return bool(
+            self.message_promoted
+            and self.message
+            and self.message.get("type") == "user"
+            and self.status.state in {DISPATCH_ACCEPTED, DISPATCH_FAILED}
+        )
+
+    @property
+    def can_publish_queue_updated(self) -> bool:
+        return bool(
+            self.status.state == DISPATCH_ACCEPTED
+            and self.message
+            and self.message.get("type") == messages_service.QUEUED_TYPE
+        )
+
+    @property
+    def can_report_success(self) -> bool:
+        return bool(
+            self.status.state == DISPATCH_ACCEPTED
+            and self.message
+            and self.message.get("type")
+            in {"user", messages_service.QUEUED_TYPE}
+        )
+
+
+@dataclass(frozen=True)
 class _ShowDispatchOwnerIdentity:
     pid: int
     started_at: str
@@ -323,6 +358,20 @@ def claim_show_dispatch(
             session_status=_text_or_none(row.get("session_status")),
         )
         if status.session_status == "archived":
+            if state not in {DISPATCH_ACCEPTED, DISPATCH_ARCHIVED}:
+                if settle_show_dispatch(
+                    conn,
+                    event_id,
+                    session_id=session_id,
+                    owner=None,
+                    state=DISPATCH_ARCHIVED,
+                ):
+                    return ShowDispatchStatus(
+                        state=DISPATCH_ARCHIVED,
+                        message_id=status.message_id,
+                        session_status=status.session_status,
+                    )
+                continue
             return status
         if state in {DISPATCH_ACCEPTED, DISPATCH_ARCHIVED}:
             return status
@@ -366,7 +415,7 @@ def settle_show_dispatch(
     event_id: str,
     *,
     session_id: str,
-    owner: str,
+    owner: str | None,
     state: str,
 ) -> bool:
     """Persist one observed terminal outcome for the matching claim owner."""
@@ -383,9 +432,14 @@ def settle_show_dispatch(
     payload = _dispatch_state_payload(row)
     if payload["state"] == state:
         return True
-    if payload["state"] in _TERMINAL_DISPATCH_STATES:
+    if owner is None:
+        if state != DISPATCH_ARCHIVED:
+            raise ValueError("ownerless Show dispatch settlement must be archived")
+        if payload["state"] in {DISPATCH_ACCEPTED, DISPATCH_ARCHIVED}:
+            return False
+    elif payload["state"] in _TERMINAL_DISPATCH_STATES:
         return False
-    if payload["state"] != DISPATCH_IN_FLIGHT or payload.get("owner") != owner:
+    elif payload["state"] != DISPATCH_IN_FLIGHT or payload.get("owner") != owner:
         return False
     result = conn.execute(
         update(show_session_events)
@@ -492,6 +546,80 @@ def observe_and_settle_show_dispatch(
     )
 
 
+def reconcile_show_dispatch_settlement(
+    conn: Any,
+    event_id: str,
+    *,
+    session_id: str,
+) -> ShowDispatchSettlement | None:
+    """Read back one dispatch settlement and repair its transcript presentation."""
+
+    row = (
+        conn.execute(
+            select(
+                show_session_events.c.dispatch_state,
+                show_session_events.c.message_id,
+                agent_sessions.c.scope_id,
+                agent_sessions.c.status.label("session_status"),
+                messages.c.type.label("message_type"),
+            )
+            .select_from(
+                show_session_events.join(
+                    agent_sessions,
+                    agent_sessions.c.id == show_session_events.c.session_id,
+                ).outerjoin(
+                    messages,
+                    (messages.c.id == show_session_events.c.message_id)
+                    & (messages.c.session_id == show_session_events.c.session_id),
+                )
+            )
+            .where(
+                show_session_events.c.id == event_id,
+                show_session_events.c.session_id == session_id,
+            )
+            .limit(1)
+        )
+        .mappings()
+        .first()
+    )
+    if row is None:
+        return None
+
+    payload = _dispatch_state_payload(row["dispatch_state"])
+    status = ShowDispatchStatus(
+        state=str(payload["state"]),
+        owner=_text_or_none(payload.get("owner")),
+        claimed_at=_text_or_none(payload.get("claimed_at")),
+        message_id=_text_or_none(row.get("message_id")),
+        session_status=_text_or_none(row.get("session_status")),
+    )
+    message_id = status.message_id
+    message_promoted = False
+    if (
+        message_id
+        and row.get("message_type") == messages_service.PENDING_TYPE
+        and status.state in {DISPATCH_ACCEPTED, DISPATCH_FAILED}
+    ):
+        message_promoted = messages_service.promote_pending(
+            conn,
+            message_id,
+            "user",
+        )
+
+    event = _existing_event_payload(
+        conn,
+        event_id=event_id,
+        session_id=session_id,
+        scope_id=_text_or_none(row.get("scope_id")),
+    )
+    message = event.get("message") if event is not None else None
+    return ShowDispatchSettlement(
+        status=status,
+        message=message if isinstance(message, dict) else None,
+        message_promoted=message_promoted,
+    )
+
+
 @dataclass(frozen=True)
 class ShowSessionEventStore:
     db_path: Path | None = None
@@ -515,6 +643,46 @@ class ShowSessionEventStore:
     ) -> ShowDispatchStatus | None:
         with self.engine.connect() as conn:
             return get_show_dispatch_status(conn, event_id, session_id=session_id)
+
+    def reconcile_dispatch_settlement(
+        self,
+        session_id: str,
+        event_id: str,
+    ) -> ShowDispatchSettlement | None:
+        with self.engine.begin() as conn:
+            return reconcile_show_dispatch_settlement(
+                conn,
+                event_id,
+                session_id=session_id,
+            )
+
+    def reconcile_dispatch_messages(self) -> int:
+        """Repair terminal Show events whose transcript row stayed pending."""
+
+        with self.engine.begin() as conn:
+            rows = conn.execute(
+                select(
+                    show_session_events.c.id,
+                    show_session_events.c.session_id,
+                )
+                .select_from(
+                    show_session_events.join(
+                        messages,
+                        messages.c.id == show_session_events.c.message_id,
+                    )
+                )
+                .where(messages.c.type == messages_service.PENDING_TYPE)
+            ).all()
+            reconciled = 0
+            for event_id, session_id in rows:
+                settlement = reconcile_show_dispatch_settlement(
+                    conn,
+                    str(event_id),
+                    session_id=str(session_id),
+                )
+                if settlement is not None and settlement.message_promoted:
+                    reconciled += 1
+            return reconciled
 
     def append(
         self,

--- a/docs/plans/show-session-event-pipeline.md
+++ b/docs/plans/show-session-event-pipeline.md
@@ -16,8 +16,11 @@ endpoint, stream endpoint, or write token.
 - `show_session_events` persists typed events and links transcript messages.
 - Private `/show/<session-id>/__show/events` accepts authenticated event POSTs.
 - Private and public Show Pages can list and stream events.
-- `dispatch: true` human intent and annotation events stream an agent turn back
-  through `show.dispatch` events.
+- `dispatch: true` human intent and annotation events reserve a pending
+  transcript row, then enter the same `/internal/dispatch_async` turn path as
+  Chat. `SessionTurnManager` starts or queues the turn; accepted prompts and
+  replies surface through the session-scoped `message.new` stream, while queued
+  prompts surface through `queue.updated`.
 - The static Vibe Remote template reads the write token cookie, but managed
   runtime pages currently depend on their own generated config and can miss the
   token.

--- a/docs/plans/show-session-event-pipeline.md
+++ b/docs/plans/show-session-event-pipeline.md
@@ -16,11 +16,14 @@ endpoint, stream endpoint, or write token.
 - `show_session_events` persists typed events and links transcript messages.
 - Private `/show/<session-id>/__show/events` accepts authenticated event POSTs.
 - Private and public Show Pages can list and stream events.
-- `dispatch: true` human intent and annotation events reserve a pending
-  transcript row, then enter the same `/internal/dispatch_async` turn path as
-  Chat. `SessionTurnManager` starts or queues the turn; accepted prompts and
-  replies surface through the session-scoped `message.new` stream, while queued
-  prompts surface through `queue.updated`.
+- `dispatch: true` human intent and annotation events reserve a transcript row
+  keyed by `show:<event-id>`, then enter the same `/internal/dispatch_async`
+  turn path as Chat. The row moves from `pending` to `dispatching` while that
+  acceptance is unknown; only the unified controller may settle it as visible
+  `user` or durable `queued`, while a definitive pre-acceptance failure becomes
+  retryable `dispatch_failed`. CLI timeouts query this state instead of blindly
+  resubmitting. Accepted prompts and replies surface through the session-scoped
+  `message.new` stream, while queued prompts surface through `queue.updated`.
 - The static Vibe Remote template reads the write token cookie, but managed
   runtime pages currently depend on their own generated config and can miss the
   token.

--- a/docs/plans/show-session-event-pipeline.md
+++ b/docs/plans/show-session-event-pipeline.md
@@ -18,12 +18,14 @@ endpoint, stream endpoint, or write token.
 - Private and public Show Pages can list and stream events.
 - `dispatch: true` human intent and annotation events reserve a transcript row
   keyed by `show:<event-id>`, then enter the same `/internal/dispatch_async`
-  turn path as Chat. The row moves from `pending` to `dispatching` while that
-  acceptance is unknown; only the unified controller may settle it as visible
-  `user` or durable `queued`, while a definitive pre-acceptance failure becomes
-  retryable `dispatch_failed`. CLI timeouts query this state instead of blindly
-  resubmitting. Accepted prompts and replies surface through the session-scoped
-  `message.new` stream, while queued prompts surface through `queue.updated`.
+  turn path as Chat. The transcript row stays hidden as `pending` until that
+  unified entry starts the turn or promotes it to the shared `queued` state.
+  Dispatch lifecycle belongs to the stable event row, not the transcript row:
+  `none` becomes an `in_flight` claim with owner and claim time, and only the unified
+  controller may write `accepted`; definitive rejection writes retryable
+  `failed`. CLI timeouts query that event state instead of blindly resubmitting.
+  Visible prompts and replies surface through the session-scoped `message.new`
+  stream, while queued prompts surface through `queue.updated`.
 - The static Vibe Remote template reads the write token cookie, but managed
   runtime pages currently depend on their own generated config and can miss the
   token.

--- a/docs/plans/workbench-dispatch-architecture.md
+++ b/docs/plans/workbench-dispatch-architecture.md
@@ -66,10 +66,13 @@ sections below.
   distinct from author role, plus `author_name` / `author_id`. Harness turns
   render a Scheduled-task / Watch badge.
 - Send-while-busy **queue** + cross-device **draft** reuse the `messages` table
-  (no new table). A send reservation is `pending`, becomes `dispatching` while
-  controller acceptance is unknown, and is settled only by the unified entry as
-  `user` or `queued`; a definitive pre-acceptance rejection becomes retryable
-  `dispatch_failed`. Stop keeps the queue; "立即发送" interrupts + flushes.
+  (no new queue table). A transcript reservation is hidden as `pending`; the
+  unified entry either starts the turn so its caller renders the row as `user`,
+  or moves it to `queued` for the shared drain. For Show events, dispatch
+  lifecycle is stored independently on the stable `show_session_events` row as
+  `none` / `in_flight` / `accepted` / `failed`, so rendering changes and queue
+  replacement cannot erase acceptance or make a retry ambiguous. Stop keeps the
+  queue; "立即发送" interrupts + flushes.
 
 ## 1. Why This Document Exists
 

--- a/docs/plans/workbench-dispatch-architecture.md
+++ b/docs/plans/workbench-dispatch-architecture.md
@@ -66,8 +66,10 @@ sections below.
   distinct from author role, plus `author_name` / `author_id`. Harness turns
   render a Scheduled-task / Watch badge.
 - Send-while-busy **queue** + cross-device **draft** reuse the `messages` table
-  via `queued` / `draft` / `pending` types (no new table). Stop keeps the queue;
-  "立即发送" interrupts + flushes.
+  (no new table). A send reservation is `pending`, becomes `dispatching` while
+  controller acceptance is unknown, and is settled only by the unified entry as
+  `user` or `queued`; a definitive pre-acceptance rejection becomes retryable
+  `dispatch_failed`. Stop keeps the queue; "立即发送" interrupts + flushes.
 
 ## 1. Why This Document Exists
 

--- a/docs/plans/workbench-dispatch-architecture.md
+++ b/docs/plans/workbench-dispatch-architecture.md
@@ -27,18 +27,17 @@ sections below.
    **fire-and-forget**: `POST .../messages` → `/internal/dispatch_async` (202),
    reply arrives over the stream. A closed tab can't cancel an in-flight turn.
 
-2. **Legacy per-turn Chat stream retired (Step 6).** The Chat page's
+2. **Legacy per-turn dispatch stream retired (Step 6, completed for Show in
+   2026-07).** The Chat page's
    `?stream=1` proxy was removed: the ui_server `?stream=1` route branch (the
    Chat page is now fire-and-forget). The turn-sink / `on_chunk` machinery stays
    — `dispatch_async` drives it with a no-op `on_chunk` to keep `in_flight`
    populated (Stop) and to flush the send-while-busy queue on settle.
-   **Correction:** `internal_client.stream_dispatch` + the streaming
-   `POST /internal/dispatch` endpoint were initially removed too, but the merged
-   show-annotation feature (#360) streams a turn back to the Show page via
-   `ui_server._run_show_event_dispatch` → `stream_dispatch`, so both were
-   restored. The streaming dispatch is NOT dead — it backs the Show-page flow;
-   only the Chat `?stream=1` route is gone. (Guarded by
-   `test_show_event_dispatch_streams_via_stream_dispatch`.)
+   Show annotations now use the same `POST /internal/dispatch_async` entry with
+   their reserved transcript `message_id`. `SessionTurnManager.submit` decides
+   start versus enqueue; replies arrive on the session-scoped `message.new`
+   stream. `internal_client.stream_dispatch`, `POST /internal/dispatch`, and
+   the unconsumed `show.dispatch` republishing path are removed.
 
 3. **`turn_token` is load-bearing — NOT rolled back.** The plan treated the
    per-turn token as scaffolding. It is now the completion guard: `_stream_chunk`

--- a/storage/alembic/versions/20260726_0035_show_event_dispatch_state.py
+++ b/storage/alembic/versions/20260726_0035_show_event_dispatch_state.py
@@ -1,0 +1,45 @@
+"""move Show dispatch lifecycle onto Show events
+
+Revision ID: 20260726_0035
+Revises: 20260724_0034
+Create Date: 2026-07-26
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "20260726_0035"
+down_revision = "20260724_0034"
+branch_labels = None
+depends_on = None
+
+_NONE_STATE = '{"state":"none"}'
+
+
+def _columns(bind, table: str) -> set[str]:
+    return {
+        str(row[1])
+        for row in bind.exec_driver_sql(f'pragma table_info("{table}")').fetchall()
+    }
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    if "dispatch_state" not in _columns(bind, "show_session_events"):
+        op.add_column(
+            "show_session_events",
+            sa.Column(
+                "dispatch_state",
+                sa.Text(),
+                nullable=False,
+                server_default=_NONE_STATE,
+            ),
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    if "dispatch_state" in _columns(bind, "show_session_events"):
+        op.drop_column("show_session_events", "dispatch_state")

--- a/storage/alembic/versions/20260726_0035_show_event_dispatch_state.py
+++ b/storage/alembic/versions/20260726_0035_show_event_dispatch_state.py
@@ -16,6 +16,7 @@ branch_labels = None
 depends_on = None
 
 _NONE_STATE = '{"state":"none"}'
+_ACCEPTED_STATE = '{"state":"accepted"}'
 
 
 def _columns(bind, table: str) -> set[str]:
@@ -36,6 +37,12 @@ def upgrade() -> None:
                 nullable=False,
                 server_default=_NONE_STATE,
             ),
+        )
+        op.execute(
+            sa.text(
+                "update show_session_events "
+                "set dispatch_state = :accepted_state"
+            ).bindparams(accepted_state=_ACCEPTED_STATE)
         )
 
 

--- a/storage/messages_service.py
+++ b/storage/messages_service.py
@@ -671,20 +671,6 @@ DRAFT_TYPE = "draft"
 # This stops another tab from briefly seeing the row as a sent prompt during the
 # dispatch window (Codex P2).
 PENDING_TYPE = "pending"
-# A Show dispatch owner has claimed the reservation and is waiting for the
-# unified controller entry to decide whether it started or queued the turn.
-# Retries must observe this state without submitting again: the original
-# controller request may still be completing after its HTTP caller timed out.
-DISPATCHING_TYPE = "dispatching"
-# The dispatch owner received a definitive rejection before the unified entry
-# accepted the turn. This reservation remains retryable under the same
-# ``native_message_id`` / Show event identity.
-DISPATCH_FAILED_TYPE = "dispatch_failed"
-DISPATCH_RESERVATION_TYPES = (
-    PENDING_TYPE,
-    DISPATCHING_TYPE,
-    DISPATCH_FAILED_TYPE,
-)
 # Hidden row used only to keep native-message-id dedupe coverage after multiple
 # queued harness callbacks are coalesced into one dispatched turn.
 HARNESS_DEDUPE_TYPE = "harness_dedupe"
@@ -703,7 +689,7 @@ SILENT_TYPE = "silent"
 NON_CONVERSATION_TYPES = (
     QUEUED_TYPE,
     DRAFT_TYPE,
-    *DISPATCH_RESERVATION_TYPES,
+    PENDING_TYPE,
     HARNESS_DEDUPE_TYPE,
     SILENT_TYPE,
 )
@@ -826,78 +812,21 @@ def clear_queued(conn: Connection, session_id: str) -> int:
 
 
 def clear_pending(conn: Connection, session_id: str) -> int:
-    """Drop ALL unsettled send reservations for a session.
+    """Drop unsettled transcript reservations for a session.
 
-    Used by archive: a send that reserved or claimed its row just before the
-    archive committed must not later become an accepted turn for a terminal
-    session. Returns the number removed.
+    Show dispatch lifecycle is stored on ``show_session_events``; message type
+    only controls whether the reserved transcript row is rendered.
     """
     result = conn.execute(
         delete(messages)
         .where(messages.c.session_id == session_id)
-        .where(messages.c.type.in_(DISPATCH_RESERVATION_TYPES))
+        .where(messages.c.type == PENDING_TYPE)
     )
     return result.rowcount or 0
 
 
-def claim_dispatch_reservation(conn: Connection, message_id: str) -> tuple[Optional[str], bool]:
-    """Claim a new/failed reservation for one dispatch attempt.
-
-    Returns ``(durable_type, claimed)``. Exactly one concurrent caller can
-    change ``pending`` / ``dispatch_failed`` to ``dispatching``; other callers
-    observe ``dispatching`` (or the accepted ``user`` / ``queued`` state) with
-    ``claimed=False`` and must not submit again.
-    """
-    result = conn.execute(
-        update(messages)
-        .where(messages.c.id == message_id)
-        .where(messages.c.type.in_((PENDING_TYPE, DISPATCH_FAILED_TYPE)))
-        .values(type=DISPATCHING_TYPE, updated_at=_utc_now_iso())
-    )
-    if result.rowcount:
-        return DISPATCHING_TYPE, True
-    current_type = conn.execute(
-        select(messages.c.type).where(messages.c.id == message_id)
-    ).scalar_one_or_none()
-    return current_type, False
-
-
-def fail_dispatch_reservation(conn: Connection, message_id: str) -> bool:
-    """Mark a claimed dispatch as definitively failed and retryable."""
-    result = conn.execute(
-        update(messages)
-        .where(messages.c.id == message_id)
-        .where(messages.c.type == DISPATCHING_TYPE)
-        .values(type=DISPATCH_FAILED_TYPE, updated_at=_utc_now_iso())
-    )
-    return bool(result.rowcount)
-
-
-def accept_dispatch_reservation(conn: Connection, message_id: str, to_type: str) -> bool:
-    """Set the unified controller's accepted state for one reservation.
-
-    This is the only transition into ``user`` or ``queued`` for a dispatched
-    row. Callers may claim/fail a reservation, but only the controller path that
-    owns ``SessionTurnManager.submit`` may call this function.
-    """
-    if to_type not in {"user", QUEUED_TYPE}:
-        raise ValueError(f"unsupported accepted dispatch type: {to_type}")
-    result = conn.execute(
-        update(messages)
-        .where(messages.c.id == message_id)
-        .where(messages.c.type.in_(DISPATCH_RESERVATION_TYPES))
-        .values(type=to_type, updated_at=_utc_now_iso())
-    )
-    return bool(result.rowcount)
-
-
 def promote_pending(conn: Connection, message_id: str, to_type: str) -> bool:
-    """Promote a reservation that does not enter the turn controller.
-
-    Dispatched rows use ``accept_dispatch_reservation`` exclusively from the
-    unified controller. This narrower helper remains for local no-turn messages
-    that were reserved for request atomicity and can become visible immediately.
-    """
+    """Change only the rendering state of one reserved transcript row."""
     result = conn.execute(
         update(messages)
         .where(messages.c.id == message_id)

--- a/storage/messages_service.py
+++ b/storage/messages_service.py
@@ -671,6 +671,20 @@ DRAFT_TYPE = "draft"
 # This stops another tab from briefly seeing the row as a sent prompt during the
 # dispatch window (Codex P2).
 PENDING_TYPE = "pending"
+# A Show dispatch owner has claimed the reservation and is waiting for the
+# unified controller entry to decide whether it started or queued the turn.
+# Retries must observe this state without submitting again: the original
+# controller request may still be completing after its HTTP caller timed out.
+DISPATCHING_TYPE = "dispatching"
+# The dispatch owner received a definitive rejection before the unified entry
+# accepted the turn. This reservation remains retryable under the same
+# ``native_message_id`` / Show event identity.
+DISPATCH_FAILED_TYPE = "dispatch_failed"
+DISPATCH_RESERVATION_TYPES = (
+    PENDING_TYPE,
+    DISPATCHING_TYPE,
+    DISPATCH_FAILED_TYPE,
+)
 # Hidden row used only to keep native-message-id dedupe coverage after multiple
 # queued harness callbacks are coalesced into one dispatched turn.
 HARNESS_DEDUPE_TYPE = "harness_dedupe"
@@ -686,7 +700,13 @@ HARNESS_DEDUPE_TYPE = "harness_dedupe"
 SILENT_TYPE = "silent"
 # Types that must never count as inbox conversation activity: the ephemeral user rows
 # above plus the invisible agent silent-completion marker.
-NON_CONVERSATION_TYPES = (QUEUED_TYPE, DRAFT_TYPE, PENDING_TYPE, HARNESS_DEDUPE_TYPE, SILENT_TYPE)
+NON_CONVERSATION_TYPES = (
+    QUEUED_TYPE,
+    DRAFT_TYPE,
+    *DISPATCH_RESERVATION_TYPES,
+    HARNESS_DEDUPE_TYPE,
+    SILENT_TYPE,
+)
 
 # The transcript-visible types — the SINGLE source of truth shared by the
 # history fetch (``list_session_messages``) AND the live ``message.new`` publish
@@ -806,26 +826,77 @@ def clear_queued(conn: Connection, session_id: str) -> int:
 
 
 def clear_pending(conn: Connection, session_id: str) -> int:
-    """Drop ALL ``pending`` send reservations for a session. Used by archive: a
-    send that reserved its row just before the archive committed must not later
-    be promoted into a visible message / accepted turn for a now-terminal session
-    — once the row is gone, ``promote_pending`` no-ops on the in-flight send.
-    Returns the number removed."""
+    """Drop ALL unsettled send reservations for a session.
+
+    Used by archive: a send that reserved or claimed its row just before the
+    archive committed must not later become an accepted turn for a terminal
+    session. Returns the number removed.
+    """
     result = conn.execute(
         delete(messages)
         .where(messages.c.session_id == session_id)
-        .where(messages.c.type == PENDING_TYPE)
+        .where(messages.c.type.in_(DISPATCH_RESERVATION_TYPES))
     )
     return result.rowcount or 0
 
 
+def claim_dispatch_reservation(conn: Connection, message_id: str) -> tuple[Optional[str], bool]:
+    """Claim a new/failed reservation for one dispatch attempt.
+
+    Returns ``(durable_type, claimed)``. Exactly one concurrent caller can
+    change ``pending`` / ``dispatch_failed`` to ``dispatching``; other callers
+    observe ``dispatching`` (or the accepted ``user`` / ``queued`` state) with
+    ``claimed=False`` and must not submit again.
+    """
+    result = conn.execute(
+        update(messages)
+        .where(messages.c.id == message_id)
+        .where(messages.c.type.in_((PENDING_TYPE, DISPATCH_FAILED_TYPE)))
+        .values(type=DISPATCHING_TYPE, updated_at=_utc_now_iso())
+    )
+    if result.rowcount:
+        return DISPATCHING_TYPE, True
+    current_type = conn.execute(
+        select(messages.c.type).where(messages.c.id == message_id)
+    ).scalar_one_or_none()
+    return current_type, False
+
+
+def fail_dispatch_reservation(conn: Connection, message_id: str) -> bool:
+    """Mark a claimed dispatch as definitively failed and retryable."""
+    result = conn.execute(
+        update(messages)
+        .where(messages.c.id == message_id)
+        .where(messages.c.type == DISPATCHING_TYPE)
+        .values(type=DISPATCH_FAILED_TYPE, updated_at=_utc_now_iso())
+    )
+    return bool(result.rowcount)
+
+
+def accept_dispatch_reservation(conn: Connection, message_id: str, to_type: str) -> bool:
+    """Set the unified controller's accepted state for one reservation.
+
+    This is the only transition into ``user`` or ``queued`` for a dispatched
+    row. Callers may claim/fail a reservation, but only the controller path that
+    owns ``SessionTurnManager.submit`` may call this function.
+    """
+    if to_type not in {"user", QUEUED_TYPE}:
+        raise ValueError(f"unsupported accepted dispatch type: {to_type}")
+    result = conn.execute(
+        update(messages)
+        .where(messages.c.id == message_id)
+        .where(messages.c.type.in_(DISPATCH_RESERVATION_TYPES))
+        .values(type=to_type, updated_at=_utc_now_iso())
+    )
+    return bool(result.rowcount)
+
+
 def promote_pending(conn: Connection, message_id: str, to_type: str) -> bool:
-    """Promote a reserved ``pending`` row to its decided type — ``user`` once the
-    turn is accepted, or ``queued`` when a turn is already running. The row is
-    persisted as ``pending`` BEFORE dispatch (reserving its (created_at, id) for
-    correct ordering) and stays hidden until this promotes it, so no other tab
-    can briefly see it as a sent prompt during the dispatch window. Returns True
-    if a pending row was promoted.
+    """Promote a reservation that does not enter the turn controller.
+
+    Dispatched rows use ``accept_dispatch_reservation`` exclusively from the
+    unified controller. This narrower helper remains for local no-turn messages
+    that were reserved for request atomicity and can become visible immediately.
     """
     result = conn.execute(
         update(messages)

--- a/storage/models.py
+++ b/storage/models.py
@@ -298,6 +298,7 @@ show_session_events = Table(
     Column("payload_json", Text, nullable=False),
     Column("transcript_text", Text, nullable=True),
     Column("message_id", String, ForeignKey("messages.id", ondelete="SET NULL"), nullable=True),
+    Column("dispatch_state", Text, nullable=False, server_default='{"state":"none"}'),
     Column("created_at", String, nullable=False),
     Index("ix_show_session_events_session_created", "session_id", "created_at"),
     Index("ix_show_session_events_type_created", "event_type", "created_at"),

--- a/tests/test_i18n_backend_keys.py
+++ b/tests/test_i18n_backend_keys.py
@@ -17,6 +17,7 @@ import pytest
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from core.run_settlement import SETTLEMENT_I18N_KEYS, SWEEP_I18N_KEYS
+from core.show_session_events import SHOW_EVENT_ERROR_I18N_KEYS
 from storage.background import (
     SWEEP_REASON_ORPHANED,
     SWEEP_REASON_QUEUE_HOLD_EXPIRED,
@@ -80,3 +81,14 @@ def test_sweep_reason_i18n_map_covers_every_store_sweep_reason() -> None:
         SWEEP_REASON_TRANSPORT_UNAVAILABLE,
         SWEEP_REASON_QUEUE_HOLD_EXPIRED,
     }
+
+
+@pytest.mark.parametrize(
+    "code,key",
+    sorted(SHOW_EVENT_ERROR_I18N_KEYS.items()),
+)
+def test_every_show_event_error_resolves(code: str, key: str) -> None:
+    for lang in get_supported_languages():
+        resolved = t(key, lang)
+        assert resolved != key, f"{key} is not translated in {lang} (code={code})"
+        assert resolved.strip()

--- a/tests/test_internal_client.py
+++ b/tests/test_internal_client.py
@@ -100,6 +100,30 @@ def test_dispatch_async_missing_socket_raises_unavailable(tmp_path):
         asyncio.run(internal_client.dispatch_async({"session_id": "s", "text": "x"}, socket_path=sock))
 
 
+def test_dispatch_async_read_timeout_reports_acceptance_unknown(tmp_path):
+    sock = tmp_path / "dispatch.sock"
+    sock.touch()
+
+    class TimingOutClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return None
+
+        async def post(self, _path, json):
+            raise httpx.ReadTimeout("response deadline elapsed")
+
+    with patch("vibe.internal_client.httpx.AsyncClient", return_value=TimingOutClient()):
+        with pytest.raises(internal_client.InternalServerTimeout):
+            asyncio.run(
+                internal_client.dispatch_async(
+                    {"session_id": "s", "text": "x"},
+                    socket_path=sock,
+                )
+            )
+
+
 def test_reconcile_platforms_round_trip(tmp_path):
     app = FastAPI()
     calls: list[bool] = []

--- a/tests/test_internal_server.py
+++ b/tests/test_internal_server.py
@@ -791,6 +791,116 @@ def test_dispatch_async_deduplicates_replayed_reserved_message(
     assert rows[0]["type"] == stored_type
 
 
+def test_failed_show_dispatch_retries_same_event_through_manager_once(monkeypatch, tmp_path):
+    from core.services import sessions as sessions_service
+    from core.show_session_events import ShowSessionEventError
+    from storage import messages_service
+    from storage.db import create_sqlite_engine
+    from storage.importer import ensure_sqlite_state
+    from storage.settings_service import upsert_scope
+    from vibe import internal_client, ui_server
+    from vibe.sse_broker import broker
+
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    ensure_sqlite_state()
+    engine = create_sqlite_engine()
+    with engine.begin() as conn:
+        scope_id = upsert_scope(
+            conn,
+            platform="avibe",
+            scope_type="project",
+            native_id="proj_show_retry",
+            now="2026-05-31T00:00:00Z",
+        )
+        _seed_project_workdir(conn, scope_id, tmp_path)
+        session = sessions_service.create_session(
+            conn,
+            scope_id=scope_id,
+            agent_backend="claude",
+            agent_name="worker",
+        )
+
+    turn_started = asyncio.Event()
+
+    async def handler(_context, _text):
+        turn_started.set()
+
+    controller = _build_controller_double(handler)
+    app = internal_server.create_app(controller)
+    transport = httpx.ASGITransport(app=app)
+    manager = controller.session_turns
+    real_submit = manager.submit
+    submissions = []
+
+    async def tracked_submit(*args, **kwargs):
+        submissions.append((args, kwargs))
+        return await real_submit(*args, **kwargs)
+
+    monkeypatch.setattr(manager, "submit", tracked_submit)
+    attempts = 0
+
+    async def retrying_dispatch(payload, **_kwargs):
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise internal_client.InternalServerUnavailable("controller unavailable")
+        async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+            response = await client.post("/internal/dispatch_async", json=payload)
+            await asyncio.sleep(0)
+        return {
+            "status_code": response.status_code,
+            "body": response.json(),
+        }
+
+    monkeypatch.setattr(internal_client, "dispatch_async", retrying_dispatch)
+    published = []
+    monkeypatch.setattr(broker, "publish", lambda event, data: published.append((event, data)))
+    event_input = {
+        "id": "show_evt_retry_acceptance",
+        "type": "human.annotation.created",
+        "annotation": {
+            "intent": "comment",
+            "comment": "Retry this exact annotation.",
+            "dispatch": True,
+        },
+    }
+
+    with pytest.raises(ShowSessionEventError):
+        ui_server.record_local_show_event(
+            session["id"],
+            event_input,
+            dispatch_sync=True,
+        )
+
+    with engine.connect() as conn:
+        pending = messages_service.list_session_messages(
+            conn,
+            session_id=session["id"],
+            types=(messages_service.PENDING_TYPE,),
+        )["messages"]
+        visible = messages_service.list_session_messages(
+            conn,
+            session_id=session["id"],
+            types=("user",),
+        )["messages"]
+    assert len(pending) == 1
+    assert visible == []
+    assert [event_type for event_type, _data in published] == ["show.event"]
+    assert submissions == []
+
+    retried = ui_server.record_local_show_event(
+        session["id"],
+        event_input,
+        dispatch_sync=True,
+    )
+
+    assert retried["id"] == event_input["id"]
+    assert retried["message"]["type"] == "user"
+    assert len(submissions) == 1
+    assert turn_started.is_set()
+    controller.message_handler.handle_user_message.assert_awaited_once()
+
+
 def test_dispatch_async_queues_show_annotation_and_runs_it_after_active_turn(monkeypatch, tmp_path):
     from core.services import sessions as sessions_service
     from core.show_session_events import ShowSessionEventStore

--- a/tests/test_internal_server.py
+++ b/tests/test_internal_server.py
@@ -819,10 +819,11 @@ def test_dispatch_async_queues_show_annotation_and_runs_it_after_active_turn(mon
 
 def test_flush_promoted_user_row_sorts_after_preceding_result(tmp_path, monkeypatch):
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    clock = {"now": "2026-06-22T00:00:37.500000+00:00"}
     monkeypatch.setattr(
         session_turns,
         "_utc_now_iso",
-        lambda: "2026-06-22T00:00:37.500000+00:00",
+        lambda: clock["now"],
     )
     session_id = _seed_avibe_session_with_queue([("queued follow-up", None)])
 
@@ -857,7 +858,29 @@ def test_flush_promoted_user_row_sorts_after_preceding_result(tmp_path, monkeypa
             )
         )
 
+    delays = []
+
+    async def fake_sleep(delay):
+        delays.append(delay)
+        clock["now"] = "2026-06-22T00:00:38+00:00"
+
+    monkeypatch.setattr(session_turns.asyncio, "sleep", fake_sleep)
+    monkeypatch.setattr(messages_service, "_utc_now_iso", lambda: "2026-06-22T00:00:38Z")
     manager, _runs = _manager_capturing_runs()
+
+    async def append_fast_result(sid, context, text, *, source=SOURCE_HUMAN):
+        with create_sqlite_engine().begin() as conn:
+            messages_service.append(
+                conn,
+                scope_id=context.platform_specific.get("scope_id"),
+                session_id=sid,
+                platform="avibe",
+                author="agent",
+                message_type="result",
+                text="fast queued result",
+            )
+
+    manager._run = append_fast_result
     assert asyncio.run(manager.flush_queue(session_id)) is True
 
     with create_sqlite_engine().connect() as conn:
@@ -869,7 +892,9 @@ def test_flush_promoted_user_row_sorts_after_preceding_result(tmp_path, monkeypa
     assert [(row["type"], row["text"]) for row in transcript["messages"]] == [
         ("result", "preceding result"),
         ("user", "queued follow-up"),
+        ("result", "fast queued result"),
     ]
+    assert delays == [0.5]
 
 
 def test_async_dispatch_flushes_queue_on_turn_end(monkeypatch, tmp_path):

--- a/tests/test_internal_server.py
+++ b/tests/test_internal_server.py
@@ -1032,7 +1032,10 @@ def test_dispatch_async_reports_show_row_synchronously_drained_from_idle_queue(
     assert linked_message_id == visible[0]["id"]
 
 
-def test_flush_promoted_user_row_sorts_after_preceding_result(tmp_path, monkeypatch):
+def test_flush_promoted_user_row_uses_fresh_id_for_same_second_order(
+    tmp_path,
+    monkeypatch,
+):
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     session_id = _seed_avibe_session_with_queue([("queued follow-up", None)])
 
@@ -1078,6 +1081,14 @@ def test_flush_promoted_user_row_sorts_after_preceding_result(tmp_path, monkeypa
         )
 
     manager, _runs = _manager_capturing_runs()
+    from core.inbox_events import bus
+
+    published = []
+    monkeypatch.setattr(
+        bus,
+        "publish",
+        lambda event_type, data: published.append((event_type, data)),
+    )
 
     async def append_fast_result(sid, context, text, *, source=SOURCE_HUMAN):
         with create_sqlite_engine().begin() as conn:
@@ -1091,6 +1102,10 @@ def test_flush_promoted_user_row_sorts_after_preceding_result(tmp_path, monkeypa
                 text="fast queued result",
             )
 
+    async def fail_if_sleeping(_delay):
+        pytest.fail("queue promotion must not wait for wall-clock time")
+
+    monkeypatch.setattr(session_turns.asyncio, "sleep", fail_if_sleeping)
     manager._run = append_fast_result
     assert asyncio.run(manager.flush_queue(session_id)) is True
 
@@ -1105,12 +1120,102 @@ def test_flush_promoted_user_row_sorts_after_preceding_result(tmp_path, monkeypa
         ("user", "queued follow-up"),
         ("result", "fast queued result"),
     ]
+    assert [row["created_at"] for row in transcript["messages"]] == [
+        "2026-06-22T00:00:37Z",
+        "2026-06-22T00:00:37Z",
+        "2026-06-22T00:00:37Z",
+    ]
     assert [row["id"] for row in transcript["messages"]] == [
         "msg_000000000000100aaaaaaaa",
         "msg_000000000000200aaaaaaaa",
         "msg_000000000000300aaaaaaaa",
     ]
     assert queued_id not in {row["id"] for row in transcript["messages"]}
+    assert [
+        (event_type, data.get("id"))
+        for event_type, data in published
+        if event_type == "message.new"
+    ] == [("message.new", "msg_000000000000200aaaaaaaa")]
+    assert not hasattr(session_turns, "_timestamp_after_latest_session_message")
+    assert not hasattr(session_turns, "_wait_until_message_timestamp")
+
+
+def test_flush_promoted_user_row_repoints_canonical_and_merged_dependencies(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    session_id = _seed_avibe_session_with_queue(
+        [
+            ("canonical queued message", None),
+            ("merged queued message", None),
+        ]
+    )
+
+    from storage import messages_service
+    from storage.db import create_sqlite_engine
+    from storage.models import media_objects, messages, show_session_events
+
+    engine = create_sqlite_engine()
+    with engine.begin() as conn:
+        queued = messages_service.list_queued(conn, session_id)
+        canonical_id = queued[0]["id"]
+        merged_id = queued[1]["id"]
+        for index, message_id in enumerate((canonical_id, merged_id), start=1):
+            conn.execute(
+                show_session_events.insert().values(
+                    id=f"show_evt_repoint_{index}",
+                    session_id=session_id,
+                    event_type="human.annotation.created",
+                    actor="human",
+                    scope="page",
+                    anchor_json="{}",
+                    payload_json="{}",
+                    transcript_text=f"annotation {index}",
+                    message_id=message_id,
+                    created_at=f"2026-06-22T00:00:0{index}Z",
+                )
+            )
+            conn.execute(
+                media_objects.insert().values(
+                    token=f"media_repoint_{index}",
+                    scope_id=queued[index - 1]["scope_id"],
+                    session_id=session_id,
+                    message_id=message_id,
+                    kind="file",
+                    source="user_upload",
+                    local_path=f"/tmp/repoint-{index}.txt",
+                    created_at=f"2026-06-22T00:00:0{index}Z",
+                )
+            )
+
+    manager, _runs = _manager_capturing_runs()
+    assert asyncio.run(manager.flush_queue(session_id)) is True
+
+    with engine.connect() as conn:
+        visible = messages_service.list_session_messages(
+            conn,
+            session_id=session_id,
+            types=("user",),
+        )["messages"]
+        event_message_ids = conn.execute(
+            select(show_session_events.c.message_id).order_by(
+                show_session_events.c.id
+            )
+        ).scalars().all()
+        media_message_ids = conn.execute(
+            select(media_objects.c.message_id).order_by(media_objects.c.token)
+        ).scalars().all()
+        old_ids = conn.execute(
+            select(messages.c.id).where(messages.c.id.in_((canonical_id, merged_id)))
+        ).scalars().all()
+
+    assert len(visible) == 1
+    visible_id = visible[0]["id"]
+    assert visible_id not in {canonical_id, merged_id}
+    assert event_message_ids == [visible_id, visible_id]
+    assert media_message_ids == [visible_id, visible_id]
+    assert old_ids == []
 
 
 def test_async_dispatch_flushes_queue_on_turn_end(monkeypatch, tmp_path):

--- a/tests/test_internal_server.py
+++ b/tests/test_internal_server.py
@@ -792,9 +792,125 @@ def test_dispatch_async_deduplicates_replayed_reserved_message(
     assert rows[0]["type"] == expected_type
 
 
+@pytest.mark.parametrize(
+    ("case", "expected_code"),
+    [
+        ("missing_event", "show_event_not_found"),
+        ("missing_message", "show_event_message_mismatch"),
+        ("archived", "session_archived"),
+    ],
+)
+def test_dispatch_async_rejects_missing_or_archived_show_reservation(
+    monkeypatch,
+    tmp_path,
+    case,
+    expected_code,
+):
+    from sqlalchemy import delete, update
+
+    from core.services import sessions as sessions_service
+    from core.show_session_events import (
+        ShowSessionEventStore,
+        claim_show_dispatch,
+    )
+    from storage.db import create_sqlite_engine
+    from storage.importer import ensure_sqlite_state
+    from storage.models import agent_sessions, messages
+    from storage.settings_service import upsert_scope
+
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    ensure_sqlite_state()
+    engine = create_sqlite_engine()
+    with engine.begin() as conn:
+        scope_id = upsert_scope(
+            conn,
+            platform="avibe",
+            scope_type="project",
+            native_id=f"proj_show_reject_{case}",
+            now="2026-05-31T00:00:00Z",
+        )
+        _seed_project_workdir(conn, scope_id, tmp_path)
+        session = sessions_service.create_session(
+            conn,
+            scope_id=scope_id,
+            agent_backend="claude",
+            agent_name="worker",
+        )
+
+    event_id = "show_evt_missing"
+    message_id = "msg_missing"
+    owner = "101:1.0"
+    if case != "missing_event":
+        store = ShowSessionEventStore()
+        try:
+            event = store.append(
+                session["id"],
+                {
+                    "id": f"show_evt_{case}",
+                    "type": "human.annotation.created",
+                    "annotation": {
+                        "intent": "comment",
+                        "comment": "Do not submit this turn.",
+                        "dispatch": True,
+                    },
+                },
+                reserve_dispatch=True,
+            )
+        finally:
+            store.close()
+        event_id = event["id"]
+        message_id = event["message_id"]
+        with engine.begin() as conn:
+            claimed = claim_show_dispatch(
+                conn,
+                event_id,
+                session_id=session["id"],
+                owner=owner,
+            )
+            assert claimed is not None and claimed.claimed
+            if case == "missing_message":
+                conn.execute(delete(messages).where(messages.c.id == message_id))
+            if case == "archived":
+                conn.execute(
+                    update(agent_sessions)
+                    .where(agent_sessions.c.id == session["id"])
+                    .values(status="archived")
+                )
+
+    controller = _build_controller_double()
+    app = internal_server.create_app(controller)
+    transport = httpx.ASGITransport(app=app)
+
+    async def _go():
+        async with httpx.AsyncClient(
+            transport=transport,
+            base_url="http://testserver",
+        ) as client:
+            return await client.post(
+                "/internal/dispatch_async",
+                json={
+                    "session_id": session["id"],
+                    "text": "Do not submit this turn.",
+                    "user_message_id": message_id,
+                    "show_event_id": event_id,
+                    "dispatch_owner": owner,
+                },
+            )
+
+    response = asyncio.run(_go())
+
+    assert response.status_code == 409
+    assert response.json()["code"] == expected_code
+    controller.message_handler.handle_user_message.assert_not_awaited()
+
+
 def test_failed_show_dispatch_retries_same_event_through_manager_once(monkeypatch, tmp_path):
     from core.services import sessions as sessions_service
-    from core.show_session_events import ShowSessionEventError
+    from core.show_session_events import (
+        DISPATCH_FAILED,
+        ShowSessionEventError,
+        ShowSessionEventStore,
+    )
     from storage import messages_service
     from storage.db import create_sqlite_engine
     from storage.importer import ensure_sqlite_state
@@ -873,20 +989,25 @@ def test_failed_show_dispatch_retries_same_event_through_manager_once(monkeypatc
             dispatch_sync=True,
         )
 
+    store = ShowSessionEventStore()
+    try:
+        dispatch_status = store.get_dispatch_status(session["id"], event_input["id"])
+    finally:
+        store.close()
     with engine.connect() as conn:
-        failed = messages_service.list_session_messages(
-            conn,
-            session_id=session["id"],
-            types=(messages_service.DISPATCH_FAILED_TYPE,),
-        )["messages"]
         visible = messages_service.list_session_messages(
             conn,
             session_id=session["id"],
             types=("user",),
         )["messages"]
-    assert len(failed) == 1
-    assert visible == []
-    assert [event_type for event_type, _data in published] == ["show.event"]
+    assert dispatch_status is not None
+    assert dispatch_status.state == DISPATCH_FAILED
+    assert len(visible) == 1
+    assert [event_type for event_type, _data in published] == [
+        "show.event",
+        "message.new",
+        "session.activity",
+    ]
     assert submissions == []
 
     retried = ui_server.record_local_show_event(
@@ -1128,7 +1249,11 @@ def test_slow_live_show_post_cli_timeout_waits_without_duplicate_submit(
 
 def test_dispatch_async_queues_show_annotation_and_runs_it_after_active_turn(monkeypatch, tmp_path):
     from core.services import sessions as sessions_service
-    from core.show_session_events import ShowSessionEventStore
+    from core.show_session_events import (
+        DISPATCH_ACCEPTED,
+        ShowSessionEventStore,
+        claim_show_dispatch,
+    )
     from storage import messages_service
     from storage.db import create_sqlite_engine
     from storage.importer import ensure_sqlite_state
@@ -1200,6 +1325,15 @@ def test_dispatch_async_queues_show_annotation_and_runs_it_after_active_turn(mon
                 f"Show event ID: {annotation['id']}\n"
                 "Reply on the Show Page with `vibe show reply`."
             )
+            dispatch_owner = "101:1.0"
+            with engine.begin() as conn:
+                claimed = claim_show_dispatch(
+                    conn,
+                    annotation["id"],
+                    session_id=session_id,
+                    owner=dispatch_owner,
+                )
+                assert claimed is not None and claimed.claimed
 
             queued = await client.post(
                 "/internal/dispatch_async",
@@ -1207,6 +1341,8 @@ def test_dispatch_async_queues_show_annotation_and_runs_it_after_active_turn(mon
                     "session_id": session_id,
                     "text": enriched_dispatch_text,
                     "user_message_id": annotation["message_id"],
+                    "show_event_id": annotation["id"],
+                    "dispatch_owner": dispatch_owner,
                 },
             )
             assert queued.status_code == 202
@@ -1244,12 +1380,19 @@ def test_dispatch_async_queues_show_annotation_and_runs_it_after_active_turn(mon
         linked_message_id = conn.execute(
             select(show_session_events.c.message_id).where(show_session_events.c.id == annotation["id"])
         ).scalar_one()
+    store = ShowSessionEventStore()
+    try:
+        dispatch_status = store.get_dispatch_status(session_id, annotation["id"])
+    finally:
+        store.close()
     assert [message["text"] for message in visible["messages"]] == [annotation["transcript_text"]]
     assert visible["messages"][0]["id"] != annotation["message_id"]
     assert visible["messages"][0]["metadata"]["source"] == "show_page"
     assert visible["messages"][0]["metadata"]["show_event_id"] == annotation["id"]
     assert session_turns.QUEUED_DISPATCH_TEXT_KEY not in visible["messages"][0]["metadata"]
     assert linked_message_id == visible["messages"][0]["id"]
+    assert dispatch_status is not None
+    assert dispatch_status.state == DISPATCH_ACCEPTED
 
 
 def test_dispatch_async_keeps_identified_show_row_after_idle_anonymous_queue(
@@ -1257,7 +1400,7 @@ def test_dispatch_async_keeps_identified_show_row_after_idle_anonymous_queue(
     tmp_path,
 ):
     from core.services import sessions as sessions_service
-    from core.show_session_events import ShowSessionEventStore
+    from core.show_session_events import ShowSessionEventStore, claim_show_dispatch
     from storage import messages_service
     from storage.db import create_sqlite_engine
     from storage.importer import ensure_sqlite_state
@@ -1325,6 +1468,15 @@ def test_dispatch_async_keeps_identified_show_row_after_idle_anonymous_queue(
 
     manager._run = capture_run
     transport = httpx.ASGITransport(app=app)
+    dispatch_owner = "101:1.0"
+    with engine.begin() as conn:
+        claimed = claim_show_dispatch(
+            conn,
+            annotation["id"],
+            session_id=session["id"],
+            owner=dispatch_owner,
+        )
+        assert claimed is not None and claimed.claimed
 
     async def _go():
         async with httpx.AsyncClient(
@@ -1337,6 +1489,8 @@ def test_dispatch_async_keeps_identified_show_row_after_idle_anonymous_queue(
                     "session_id": session["id"],
                     "text": annotation["transcript_text"],
                     "user_message_id": annotation["message_id"],
+                    "show_event_id": annotation["id"],
+                    "dispatch_owner": dispatch_owner,
                 },
             )
 

--- a/tests/test_internal_server.py
+++ b/tests/test_internal_server.py
@@ -759,21 +759,30 @@ def test_dispatch_async_queues_show_annotation_and_runs_it_after_active_turn(mon
             finally:
                 store.close()
             assert annotation["message"]["type"] == messages_service.PENDING_TYPE
+            enriched_dispatch_text = (
+                f"{annotation['transcript_text']}\n\n"
+                f"Show event ID: {annotation['id']}\n"
+                "Reply on the Show Page with `vibe show reply`."
+            )
 
             queued = await client.post(
                 "/internal/dispatch_async",
                 json={
                     "session_id": session_id,
-                    "text": annotation["transcript_text"],
+                    "text": enriched_dispatch_text,
                     "user_message_id": annotation["message_id"],
                 },
             )
             assert queued.status_code == 202
             assert queued.json()["queued"] is True
             with engine.connect() as conn:
-                assert [row["id"] for row in messages_service.list_queued(conn, session_id)] == [
-                    annotation["message_id"]
-                ]
+                queued_rows = messages_service.list_queued(conn, session_id)
+                assert [row["id"] for row in queued_rows] == [annotation["message_id"]]
+                assert queued_rows[0]["text"] == annotation["transcript_text"]
+                assert (
+                    queued_rows[0]["metadata"][session_turns.QUEUED_DISPATCH_TEXT_KEY]
+                    == enriched_dispatch_text
+                )
                 visible = messages_service.list_session_messages(
                     conn,
                     session_id=session_id,
@@ -787,14 +796,21 @@ def test_dispatch_async_queues_show_annotation_and_runs_it_after_active_turn(mon
                 if len(seen_texts) == 2 and session_id not in app.state.in_flight_dispatches:
                     break
                 await asyncio.sleep(0.02)
-            return annotation
+            return annotation, enriched_dispatch_text
 
-    annotation = asyncio.run(_go())
-    assert seen_texts == ["active turn", annotation["transcript_text"]]
+    annotation, enriched_dispatch_text = asyncio.run(_go())
+    assert seen_texts == ["active turn", enriched_dispatch_text]
     with engine.connect() as conn:
+        from storage.models import show_session_events
+
         assert messages_service.list_queued(conn, session_id) == []
         visible = messages_service.list_session_messages(conn, session_id=session_id, types=("user",))
+        linked_message_id = conn.execute(
+            select(show_session_events.c.message_id).where(show_session_events.c.id == annotation["id"])
+        ).scalar_one()
     assert [message["text"] for message in visible["messages"]] == [annotation["transcript_text"]]
+    assert visible["messages"][0]["id"] == annotation["message_id"]
+    assert linked_message_id == annotation["message_id"]
 
 
 def test_async_dispatch_flushes_queue_on_turn_end(monkeypatch, tmp_path):

--- a/tests/test_internal_server.py
+++ b/tests/test_internal_server.py
@@ -157,63 +157,16 @@ def test_bind_socket_prebinds_unix_listener():
 def test_create_app_exposes_minimal_endpoints():
     app = internal_server.create_app(_build_controller_double())
     routes = {(r.path, tuple(sorted(r.methods))) for r in app.routes if hasattr(r, "methods")}
-    # Endpoints locked by the design doc §7.4 v1 row + the health probe. Both
-    # dispatch shapes exist: ``/internal/dispatch_async`` (fire-and-forget, the
-    # Chat page) and the streaming ``/internal/dispatch`` (the Show-page dispatch
-    # flow re-publishes its SSE chunks as ``show.dispatch``).
+    # All interactive sources use the fire-and-forget turn entry.
     assert ("/internal/health", ("GET",)) in routes
     assert ("/internal/dispatch_async", ("POST",)) in routes
     assert ("/internal/reconcile-platforms", ("POST",)) in routes
     assert ("/internal/reconcile-agent-backends", ("POST",)) in routes
     assert ("/internal/model-hub", ("POST",)) in routes
     assert ("/internal/cancel/{session_id}", ("POST",)) in routes
-    assert ("/internal/dispatch", ("POST",)) in routes
+    assert ("/internal/dispatch", ("POST",)) not in routes
     assert ("/internal/events", ("GET",)) in routes
     assert ("/internal/events", ("POST",)) in routes
-
-
-def test_streaming_dispatch_publishes_single_bus_lifecycle(monkeypatch):
-    """The Show-page stream owns one bus lifecycle because it bypasses the FSM."""
-    from core import inbox_events
-
-    context = MessageContext(user_id="workbench", channel_id="ses_show", platform="avibe")
-
-    async def _build_payload(_payload):
-        return "edit the show page", context
-
-    async def _dispatch_turn(_controller, _context, _text, *, on_chunk=None):
-        assert on_chunk is not None
-        await on_chunk({"kind": "result", "text": "done"})
-
-    monkeypatch.setattr(internal_server, "_build_dispatch_payload", _build_payload)
-    monkeypatch.setattr(internal_server, "dispatch_turn", _dispatch_turn)
-    controller = _build_controller_double()
-    app = internal_server.create_app(controller)
-    transport = httpx.ASGITransport(app=app)
-    lifecycle = []
-
-    async def _go():
-        subscription_id = inbox_events.bus.subscribe_callback(
-            lambda event_type, data: lifecycle.append((event_type, data))
-            if event_type in {"turn.start", "turn.end"}
-            else None
-        )
-        try:
-            async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
-                return await client.post(
-                    "/internal/dispatch",
-                    json={"session_id": "ses_show", "text": "edit the show page"},
-                )
-        finally:
-            inbox_events.bus.unsubscribe(subscription_id)
-
-    response = asyncio.run(_go())
-
-    assert response.status_code == 200
-    assert lifecycle == [
-        ("turn.start", {"session_id": "ses_show"}),
-        ("turn.end", {"session_id": "ses_show"}),
-    ]
 
 
 # ---------------------------------------------------------------------
@@ -736,6 +689,112 @@ def test_dispatch_async_enqueues_during_busy_turn(monkeypatch, tmp_path):
         assert [q["text"] for q in messages_service.list_queued(conn, session_id)] == ["while busy"]
         transcript = messages_service.list_session_messages(conn, session_id=session_id, types=("user",))
     assert transcript["messages"] == []
+
+
+def test_dispatch_async_queues_show_annotation_and_runs_it_after_active_turn(monkeypatch, tmp_path):
+    from core.services import sessions as sessions_service
+    from core.show_session_events import ShowSessionEventStore
+    from storage import messages_service
+    from storage.db import create_sqlite_engine
+    from storage.importer import ensure_sqlite_state
+    from storage.settings_service import upsert_scope
+
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    ensure_sqlite_state()
+    engine = create_sqlite_engine()
+    with engine.begin() as conn:
+        scope_id = upsert_scope(
+            conn,
+            platform="avibe",
+            scope_type="project",
+            native_id="proj_show_queue",
+            now="2026-05-31T00:00:00Z",
+        )
+        _seed_project_workdir(conn, scope_id, tmp_path)
+        session = sessions_service.create_session(
+            conn,
+            scope_id=scope_id,
+            agent_backend="claude",
+            agent_name="worker",
+        )
+    session_id = session["id"]
+
+    first_started = asyncio.Event()
+    release_first = asyncio.Event()
+    seen_texts: list[str] = []
+
+    async def handler(ctx, text):
+        seen_texts.append(text)
+        if text == "active turn":
+            first_started.set()
+            await release_first.wait()
+        controller.mark_turn_complete(ctx)
+
+    controller = _build_controller_double(handler=handler)
+    app = internal_server.create_app(controller)
+    transport = httpx.ASGITransport(app=app)
+
+    async def _go():
+        async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+            first = await client.post(
+                "/internal/dispatch_async",
+                json={"session_id": session_id, "text": "active turn"},
+            )
+            assert first.status_code == 202
+            await asyncio.wait_for(first_started.wait(), timeout=3)
+
+            store = ShowSessionEventStore()
+            try:
+                annotation = store.append(
+                    session_id,
+                    {
+                        "type": "human.annotation.created",
+                        "annotation": {
+                            "intent": "comment",
+                            "comment": "Deliver after the active turn.",
+                            "dispatch": True,
+                        },
+                    },
+                )
+            finally:
+                store.close()
+            assert annotation["message"]["type"] == messages_service.PENDING_TYPE
+
+            queued = await client.post(
+                "/internal/dispatch_async",
+                json={
+                    "session_id": session_id,
+                    "text": annotation["transcript_text"],
+                    "user_message_id": annotation["message_id"],
+                },
+            )
+            assert queued.status_code == 202
+            assert queued.json()["queued"] is True
+            with engine.connect() as conn:
+                assert [row["id"] for row in messages_service.list_queued(conn, session_id)] == [
+                    annotation["message_id"]
+                ]
+                visible = messages_service.list_session_messages(
+                    conn,
+                    session_id=session_id,
+                    types=("user",),
+                )
+            assert visible["messages"] == []
+            assert seen_texts == ["active turn"]
+
+            release_first.set()
+            for _ in range(200):
+                if len(seen_texts) == 2 and session_id not in app.state.in_flight_dispatches:
+                    break
+                await asyncio.sleep(0.02)
+            return annotation
+
+    annotation = asyncio.run(_go())
+    assert seen_texts == ["active turn", annotation["transcript_text"]]
+    with engine.connect() as conn:
+        assert messages_service.list_queued(conn, session_id) == []
+        visible = messages_service.list_session_messages(conn, session_id=session_id, types=("user",))
+    assert [message["text"] for message in visible["messages"]] == [annotation["transcript_text"]]
 
 
 def test_async_dispatch_flushes_queue_on_turn_end(monkeypatch, tmp_path):

--- a/tests/test_internal_server.py
+++ b/tests/test_internal_server.py
@@ -693,11 +693,11 @@ def test_dispatch_async_enqueues_during_busy_turn(monkeypatch, tmp_path):
 
 
 @pytest.mark.parametrize(
-    ("stored_type", "active_same_message", "expect_queued"),
+    ("stored_type", "active_same_message", "expect_queued", "expected_type"),
     (
-        ("pending", True, False),
-        ("queued", False, True),
-        ("user", False, False),
+        ("pending", True, False, "user"),
+        ("queued", False, True, "queued"),
+        ("user", False, False, "user"),
     ),
 )
 def test_dispatch_async_deduplicates_replayed_reserved_message(
@@ -706,6 +706,7 @@ def test_dispatch_async_deduplicates_replayed_reserved_message(
     stored_type,
     active_same_message,
     expect_queued,
+    expected_type,
 ):
     from core.services import sessions as sessions_service
     from storage import messages_service
@@ -788,7 +789,7 @@ def test_dispatch_async_deduplicates_replayed_reserved_message(
             session_id=session["id"],
         )["messages"]
     assert [item["id"] for item in rows] == [row["id"]]
-    assert rows[0]["type"] == stored_type
+    assert rows[0]["type"] == expected_type
 
 
 def test_failed_show_dispatch_retries_same_event_through_manager_once(monkeypatch, tmp_path):
@@ -873,17 +874,17 @@ def test_failed_show_dispatch_retries_same_event_through_manager_once(monkeypatc
         )
 
     with engine.connect() as conn:
-        pending = messages_service.list_session_messages(
+        failed = messages_service.list_session_messages(
             conn,
             session_id=session["id"],
-            types=(messages_service.PENDING_TYPE,),
+            types=(messages_service.DISPATCH_FAILED_TYPE,),
         )["messages"]
         visible = messages_service.list_session_messages(
             conn,
             session_id=session["id"],
             types=("user",),
         )["messages"]
-    assert len(pending) == 1
+    assert len(failed) == 1
     assert visible == []
     assert [event_type for event_type, _data in published] == ["show.event"]
     assert submissions == []
@@ -899,6 +900,230 @@ def test_failed_show_dispatch_retries_same_event_through_manager_once(monkeypatc
     assert len(submissions) == 1
     assert turn_started.is_set()
     controller.message_handler.handle_user_message.assert_awaited_once()
+
+
+def test_ambiguous_show_dispatch_timeout_reconciles_accepted_turn_once(
+    monkeypatch,
+    tmp_path,
+):
+    from core.services import sessions as sessions_service
+    from core.show_session_events import ShowSessionEventStore
+    from storage.db import create_sqlite_engine
+    from storage.importer import ensure_sqlite_state
+    from storage.settings_service import upsert_scope
+    from vibe import internal_client, ui_server
+
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    ensure_sqlite_state()
+    engine = create_sqlite_engine()
+    with engine.begin() as conn:
+        scope_id = upsert_scope(
+            conn,
+            platform="avibe",
+            scope_type="project",
+            native_id="proj_show_timeout",
+            now="2026-05-31T00:00:00Z",
+        )
+        _seed_project_workdir(conn, scope_id, tmp_path)
+        session = sessions_service.create_session(
+            conn,
+            scope_id=scope_id,
+            agent_backend="claude",
+            agent_name="worker",
+        )
+
+    turn_started = asyncio.Event()
+
+    async def handler(_context, _text):
+        turn_started.set()
+
+    controller = _build_controller_double(handler)
+    internal_app = internal_server.create_app(controller)
+    transport = httpx.ASGITransport(app=internal_app)
+    manager = controller.session_turns
+    real_submit = manager.submit
+    submissions = []
+
+    async def tracked_submit(*args, **kwargs):
+        submissions.append((args, kwargs))
+        return await real_submit(*args, **kwargs)
+
+    monkeypatch.setattr(manager, "submit", tracked_submit)
+
+    async def accepted_without_response(payload, **_kwargs):
+        async with httpx.AsyncClient(
+            transport=transport,
+            base_url="http://testserver",
+        ) as client:
+            response = await client.post("/internal/dispatch_async", json=payload)
+        assert response.status_code == 202
+        raise internal_client.InternalServerTimeout("response was lost")
+
+    monkeypatch.setattr(internal_client, "dispatch_async", accepted_without_response)
+    store = ShowSessionEventStore()
+    try:
+        event = store.append(
+            session["id"],
+            {
+                "id": "show_evt_timeout_acceptance",
+                "type": "human.annotation.created",
+                "annotation": {
+                    "intent": "comment",
+                    "comment": "Accept this despite the lost response.",
+                    "dispatch": True,
+                },
+            },
+            reserve_dispatch=True,
+        )
+    finally:
+        store.close()
+
+    async def _go():
+        first = await ui_server._run_show_event_dispatch(event)
+        replay = await ui_server._run_show_event_dispatch(event)
+        await asyncio.wait_for(turn_started.wait(), timeout=1)
+        return first, replay
+
+    assert asyncio.run(_go()) == (True, True)
+    assert len(submissions) == 1
+    controller.message_handler.handle_user_message.assert_awaited_once()
+    assert event["message"]["type"] == "user"
+
+
+def test_slow_live_show_post_cli_timeout_waits_without_duplicate_submit(
+    monkeypatch,
+    tmp_path,
+    capsys,
+):
+    import json
+    import threading
+
+    from core.services import sessions as sessions_service
+    from core.show_session_events import ShowSessionEventStore
+    from storage.db import create_sqlite_engine
+    from storage.importer import ensure_sqlite_state
+    from storage.settings_service import upsert_scope
+    from vibe import cli, internal_client, ui_server
+
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    ensure_sqlite_state()
+    engine = create_sqlite_engine()
+    with engine.begin() as conn:
+        scope_id = upsert_scope(
+            conn,
+            platform="avibe",
+            scope_type="project",
+            native_id="proj_show_cli_timeout",
+            now="2026-05-31T00:00:00Z",
+        )
+        _seed_project_workdir(conn, scope_id, tmp_path)
+        session = sessions_service.create_session(
+            conn,
+            scope_id=scope_id,
+            agent_backend="claude",
+            agent_name="worker",
+        )
+
+    turn_started = threading.Event()
+
+    async def handler(_context, _text):
+        turn_started.set()
+
+    controller = _build_controller_double(handler)
+    internal_app = internal_server.create_app(controller)
+    transport = httpx.ASGITransport(app=internal_app)
+    manager = controller.session_turns
+    real_submit = manager.submit
+    submissions = []
+
+    async def tracked_submit(*args, **kwargs):
+        submissions.append((args, kwargs))
+        return await real_submit(*args, **kwargs)
+
+    monkeypatch.setattr(manager, "submit", tracked_submit)
+    dispatch_entered = threading.Event()
+    release_dispatch = threading.Event()
+    request_thread: threading.Thread | None = None
+    request_errors: list[BaseException] = []
+
+    async def slow_dispatch(payload, **_kwargs):
+        dispatch_entered.set()
+        assert await asyncio.to_thread(release_dispatch.wait, 2)
+        async with httpx.AsyncClient(
+            transport=transport,
+            base_url="http://testserver",
+        ) as client:
+            response = await client.post("/internal/dispatch_async", json=payload)
+        return {"status_code": response.status_code, "body": response.json()}
+
+    monkeypatch.setattr(internal_client, "dispatch_async", slow_dispatch)
+
+    def timeout_after_live_request(request, **_kwargs):
+        nonlocal request_thread
+        posted = json.loads(request.data.decode("utf-8"))
+
+        def run_live_request():
+            try:
+                store = ShowSessionEventStore()
+                try:
+                    event = store.append(
+                        session["id"],
+                        posted,
+                        reserve_dispatch=True,
+                    )
+                finally:
+                    store.close()
+                asyncio.run(ui_server._run_show_event_dispatch(event))
+            except BaseException as exc:  # pragma: no cover - thread relay
+                request_errors.append(exc)
+
+        request_thread = threading.Thread(target=run_live_request)
+        request_thread.start()
+        assert dispatch_entered.wait(1)
+        threading.Timer(0.1, release_dispatch.set).start()
+        raise TimeoutError("CLI deadline elapsed")
+
+    monkeypatch.setattr(cli.urllib.request, "urlopen", timeout_after_live_request)
+    monkeypatch.setattr(
+        cli,
+        "_local_show_events_url",
+        lambda session_id: f"http://127.0.0.1:5123/api/show/sessions/{session_id}/events",
+    )
+    monkeypatch.setattr(
+        ui_server,
+        "record_local_show_event",
+        lambda *args, **kwargs: pytest.fail("ambiguous timeout must not use local fallback"),
+    )
+    event_input = {
+        "id": "show_evt_slow_live_cli",
+        "type": "human.annotation.created",
+        "annotation": {
+            "intent": "comment",
+            "comment": "Wait for the original live request.",
+            "dispatch": True,
+        },
+    }
+    args = cli.build_parser().parse_args(
+        [
+            "show",
+            "event",
+            "--session-id",
+            session["id"],
+            "--event-json",
+            json.dumps(event_input),
+            "--json",
+        ]
+    )
+
+    assert cli.cmd_show(args) == 0
+    assert request_thread is not None
+    request_thread.join(2)
+    assert not request_thread.is_alive()
+    assert request_errors == []
+    assert len(submissions) == 1
+    assert turn_started.wait(1)
+    controller.message_handler.handle_user_message.assert_awaited_once()
+    assert json.loads(capsys.readouterr().out)["event_id"] == event_input["id"]
 
 
 def test_dispatch_async_queues_show_annotation_and_runs_it_after_active_turn(monkeypatch, tmp_path):
@@ -1027,7 +1252,7 @@ def test_dispatch_async_queues_show_annotation_and_runs_it_after_active_turn(mon
     assert linked_message_id == visible["messages"][0]["id"]
 
 
-def test_dispatch_async_reports_show_row_synchronously_drained_from_idle_queue(
+def test_dispatch_async_keeps_identified_show_row_after_idle_anonymous_queue(
     monkeypatch,
     tmp_path,
 ):
@@ -1118,13 +1343,12 @@ def test_dispatch_async_reports_show_row_synchronously_drained_from_idle_queue(
     response = asyncio.run(_go())
 
     assert response.status_code == 202
-    assert response.json()["drained"] is True
-    assert response.json().get("queued") is None
+    assert response.json()["queued"] is True
+    assert response.json().get("drained") is None
     assert len(runs) == 1
-    assert "older stopped message" in runs[0][1]
-    assert annotation["transcript_text"] in runs[0][1]
+    assert runs[0][1] == "older stopped message"
     with engine.connect() as conn:
-        assert messages_service.list_queued(conn, session["id"]) == []
+        queued = messages_service.list_queued(conn, session["id"])
         linked_message_id = conn.execute(
             select(show_session_events.c.message_id).where(
                 show_session_events.c.id == annotation["id"]
@@ -1138,8 +1362,33 @@ def test_dispatch_async_reports_show_row_synchronously_drained_from_idle_queue(
             session_id=session["id"],
             types=("user",),
         )["messages"]
+    assert [row["id"] for row in queued] == [annotation["message_id"]]
+    assert original_exists == annotation["message_id"]
+    assert linked_message_id == annotation["message_id"]
+    assert [row["text"] for row in visible] == ["older stopped message"]
+
+    assert asyncio.run(manager.flush_queue(session["id"])) is True
+    with engine.connect() as conn:
+        linked_message_id = conn.execute(
+            select(show_session_events.c.message_id).where(
+                show_session_events.c.id == annotation["id"]
+            )
+        ).scalar_one()
+        original_exists = conn.execute(
+            select(messages.c.id).where(messages.c.id == annotation["message_id"])
+        ).scalar_one_or_none()
+        visible = messages_service.list_session_messages(
+            conn,
+            session_id=session["id"],
+            types=("user",),
+        )["messages"]
+    assert [run[1] for run in runs] == [
+        "older stopped message",
+        annotation["transcript_text"],
+    ]
     assert original_exists is None
-    assert linked_message_id == visible[0]["id"]
+    assert linked_message_id == visible[1]["id"]
+    assert visible[1]["native_message_id"] == f"show:{annotation['id']}"
 
 
 def test_flush_promoted_user_row_uses_fresh_id_for_same_second_order(
@@ -1326,6 +1575,79 @@ def test_flush_promoted_user_row_repoints_canonical_and_merged_dependencies(
     assert event_message_ids == [visible_id, visible_id]
     assert media_message_ids == [visible_id, visible_id]
     assert old_ids == []
+
+
+def test_flush_keeps_independently_identified_user_rows_as_separate_turns(
+    tmp_path,
+    monkeypatch,
+):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    session_id = _seed_avibe_session_with_queue(
+        [
+            ("first show annotation", None),
+            ("second show annotation", None),
+        ]
+    )
+
+    from sqlalchemy import update
+
+    from storage import messages_service
+    from storage.db import create_sqlite_engine
+    from storage.models import messages, show_session_events
+
+    engine = create_sqlite_engine()
+    with engine.begin() as conn:
+        queued = messages_service.list_queued(conn, session_id)
+        for index, row in enumerate(queued, start=1):
+            event_id = f"show_evt_identity_{index}"
+            conn.execute(
+                update(messages)
+                .where(messages.c.id == row["id"])
+                .values(native_message_id=f"show:{event_id}")
+            )
+            conn.execute(
+                show_session_events.insert().values(
+                    id=event_id,
+                    session_id=session_id,
+                    event_type="human.annotation.created",
+                    actor="human",
+                    scope="default",
+                    anchor_json="{}",
+                    payload_json="{}",
+                    transcript_text=row["text"],
+                    message_id=row["id"],
+                    created_at=f"2026-06-22T00:00:0{index}Z",
+                )
+            )
+
+    manager, runs = _manager_capturing_runs()
+    assert asyncio.run(manager.flush_queue(session_id)) is True
+    assert asyncio.run(manager.flush_queue(session_id)) is True
+
+    with engine.connect() as conn:
+        visible = messages_service.list_session_messages(
+            conn,
+            session_id=session_id,
+            types=("user",),
+        )["messages"]
+        event_links = conn.execute(
+            select(show_session_events.c.id, show_session_events.c.message_id).order_by(
+                show_session_events.c.id
+            )
+        ).all()
+
+    assert [text for text, _source, _context in runs] == [
+        "first show annotation",
+        "second show annotation",
+    ]
+    assert [row["native_message_id"] for row in visible] == [
+        "show:show_evt_identity_1",
+        "show:show_evt_identity_2",
+    ]
+    assert event_links == [
+        ("show_evt_identity_1", visible[0]["id"]),
+        ("show_evt_identity_2", visible[1]["id"]),
+    ]
 
 
 def test_async_dispatch_flushes_queue_on_turn_end(monkeypatch, tmp_path):

--- a/tests/test_internal_server.py
+++ b/tests/test_internal_server.py
@@ -917,6 +917,121 @@ def test_dispatch_async_queues_show_annotation_and_runs_it_after_active_turn(mon
     assert linked_message_id == visible["messages"][0]["id"]
 
 
+def test_dispatch_async_reports_show_row_synchronously_drained_from_idle_queue(
+    monkeypatch,
+    tmp_path,
+):
+    from core.services import sessions as sessions_service
+    from core.show_session_events import ShowSessionEventStore
+    from storage import messages_service
+    from storage.db import create_sqlite_engine
+    from storage.importer import ensure_sqlite_state
+    from storage.models import messages, show_session_events
+    from storage.settings_service import upsert_scope
+
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    ensure_sqlite_state()
+    engine = create_sqlite_engine()
+    with engine.begin() as conn:
+        scope_id = upsert_scope(
+            conn,
+            platform="avibe",
+            scope_type="project",
+            native_id="proj_show_idle_queue",
+            now="2026-05-31T00:00:00Z",
+        )
+        _seed_project_workdir(conn, scope_id, tmp_path)
+        session = sessions_service.create_session(
+            conn,
+            scope_id=scope_id,
+            agent_backend="claude",
+            agent_name="worker",
+        )
+        messages_service.append(
+            conn,
+            scope_id=scope_id,
+            session_id=session["id"],
+            platform="avibe",
+            author="user",
+            source="user",
+            message_type=messages_service.QUEUED_TYPE,
+            text="older stopped message",
+        )
+    store = ShowSessionEventStore()
+    try:
+        annotation = store.append(
+            session["id"],
+            {
+                "type": "human.annotation.created",
+                "annotation": {
+                    "intent": "comment",
+                    "comment": "Join and drain.",
+                    "dispatch": True,
+                },
+            },
+            reserve_dispatch=True,
+        )
+    finally:
+        store.close()
+
+    controller = _build_controller_double()
+    app = internal_server.create_app(controller)
+    manager = controller.session_turns
+    manager._build_context = lambda sid: MessageContext(
+        user_id="U",
+        channel_id="C",
+        platform="avibe",
+        platform_specific={"agent_session_id": sid},
+    )
+    runs = []
+
+    async def capture_run(sid, context, text, *, source=SOURCE_HUMAN):
+        runs.append((sid, text, source))
+
+    manager._run = capture_run
+    transport = httpx.ASGITransport(app=app)
+
+    async def _go():
+        async with httpx.AsyncClient(
+            transport=transport,
+            base_url="http://testserver",
+        ) as client:
+            return await client.post(
+                "/internal/dispatch_async",
+                json={
+                    "session_id": session["id"],
+                    "text": annotation["transcript_text"],
+                    "user_message_id": annotation["message_id"],
+                },
+            )
+
+    response = asyncio.run(_go())
+
+    assert response.status_code == 202
+    assert response.json()["drained"] is True
+    assert response.json().get("queued") is None
+    assert len(runs) == 1
+    assert "older stopped message" in runs[0][1]
+    assert annotation["transcript_text"] in runs[0][1]
+    with engine.connect() as conn:
+        assert messages_service.list_queued(conn, session["id"]) == []
+        linked_message_id = conn.execute(
+            select(show_session_events.c.message_id).where(
+                show_session_events.c.id == annotation["id"]
+            )
+        ).scalar_one()
+        original_exists = conn.execute(
+            select(messages.c.id).where(messages.c.id == annotation["message_id"])
+        ).scalar_one_or_none()
+        visible = messages_service.list_session_messages(
+            conn,
+            session_id=session["id"],
+            types=("user",),
+        )["messages"]
+    assert original_exists is None
+    assert linked_message_id == visible[0]["id"]
+
+
 def test_flush_promoted_user_row_sorts_after_preceding_result(tmp_path, monkeypatch):
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     session_id = _seed_avibe_session_with_queue([("queued follow-up", None)])

--- a/tests/test_internal_server.py
+++ b/tests/test_internal_server.py
@@ -24,6 +24,7 @@ from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, Mock
 
 import httpx
+import pytest
 from sqlalchemy import select
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
@@ -691,6 +692,105 @@ def test_dispatch_async_enqueues_during_busy_turn(monkeypatch, tmp_path):
     assert transcript["messages"] == []
 
 
+@pytest.mark.parametrize(
+    ("stored_type", "active_same_message", "expect_queued"),
+    (
+        ("pending", True, False),
+        ("queued", False, True),
+        ("user", False, False),
+    ),
+)
+def test_dispatch_async_deduplicates_replayed_reserved_message(
+    monkeypatch,
+    tmp_path,
+    stored_type,
+    active_same_message,
+    expect_queued,
+):
+    from core.services import sessions as sessions_service
+    from storage import messages_service
+    from storage.db import create_sqlite_engine
+    from storage.importer import ensure_sqlite_state
+    from storage.settings_service import upsert_scope
+
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    ensure_sqlite_state()
+    engine = create_sqlite_engine()
+    with engine.begin() as conn:
+        scope_id = upsert_scope(
+            conn,
+            platform="avibe",
+            scope_type="project",
+            native_id=f"proj_replay_{stored_type}",
+            now="2026-05-31T00:00:00Z",
+        )
+        _seed_project_workdir(conn, scope_id, tmp_path)
+        session = sessions_service.create_session(
+            conn,
+            scope_id=scope_id,
+            agent_backend="claude",
+            agent_name="worker",
+        )
+        row = messages_service.append(
+            conn,
+            scope_id=scope_id,
+            session_id=session["id"],
+            platform="avibe",
+            author="user",
+            source="user",
+            message_type=stored_type,
+            text="same show event",
+        )
+
+    controller = _build_controller_double()
+    app = internal_server.create_app(controller)
+    transport = httpx.ASGITransport(app=app)
+
+    async def _go():
+        active_task = None
+        if active_same_message:
+            active_task = asyncio.create_task(asyncio.sleep(60))
+            app.state.in_flight_dispatches[session["id"]] = session_turns.Turn(
+                task=active_task,
+                context=MessageContext(
+                    user_id="U",
+                    channel_id="C",
+                    platform="avibe",
+                    message_id=row["id"],
+                ),
+            )
+        try:
+            async with httpx.AsyncClient(
+                transport=transport,
+                base_url="http://testserver",
+            ) as client:
+                return await client.post(
+                    "/internal/dispatch_async",
+                    json={
+                        "session_id": session["id"],
+                        "text": "same show event",
+                        "user_message_id": row["id"],
+                    },
+                )
+        finally:
+            if active_task is not None:
+                active_task.cancel()
+
+    response = asyncio.run(_go())
+
+    assert response.status_code == 202
+    assert response.json()["duplicate"] is True
+    assert bool(response.json().get("queued")) is expect_queued
+    controller.message_handler.handle_user_message.assert_not_awaited()
+    with engine.connect() as conn:
+        rows = messages_service.list_session_messages(
+            conn,
+            session_id=session["id"],
+        )["messages"]
+    assert [item["id"] for item in rows] == [row["id"]]
+    assert rows[0]["type"] == stored_type
+
+
 def test_dispatch_async_queues_show_annotation_and_runs_it_after_active_turn(monkeypatch, tmp_path):
     from core.services import sessions as sessions_service
     from core.show_session_events import ShowSessionEventStore
@@ -810,21 +910,15 @@ def test_dispatch_async_queues_show_annotation_and_runs_it_after_active_turn(mon
             select(show_session_events.c.message_id).where(show_session_events.c.id == annotation["id"])
         ).scalar_one()
     assert [message["text"] for message in visible["messages"]] == [annotation["transcript_text"]]
-    assert visible["messages"][0]["id"] == annotation["message_id"]
+    assert visible["messages"][0]["id"] != annotation["message_id"]
     assert visible["messages"][0]["metadata"]["source"] == "show_page"
     assert visible["messages"][0]["metadata"]["show_event_id"] == annotation["id"]
     assert session_turns.QUEUED_DISPATCH_TEXT_KEY not in visible["messages"][0]["metadata"]
-    assert linked_message_id == annotation["message_id"]
+    assert linked_message_id == visible["messages"][0]["id"]
 
 
 def test_flush_promoted_user_row_sorts_after_preceding_result(tmp_path, monkeypatch):
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
-    clock = {"now": "2026-06-22T00:00:37.500000+00:00"}
-    monkeypatch.setattr(
-        session_turns,
-        "_utc_now_iso",
-        lambda: clock["now"],
-    )
     session_id = _seed_avibe_session_with_queue([("queued follow-up", None)])
 
     from sqlalchemy import update
@@ -835,11 +929,21 @@ def test_flush_promoted_user_row_sorts_after_preceding_result(tmp_path, monkeypa
 
     with create_sqlite_engine().begin() as conn:
         queued = messages_service.list_queued(conn, session_id)[0]
+        queued_id = queued["id"]
         conn.execute(
             update(messages)
             .where(messages.c.id == queued["id"])
             .values(created_at="2026-06-22T00:00:36Z")
         )
+        generated_ids = iter(
+            (
+                "msg_000000000000100aaaaaaaa",
+                "msg_000000000000200aaaaaaaa",
+                "msg_000000000000300aaaaaaaa",
+            )
+        )
+        monkeypatch.setattr(messages_service, "_new_message_id", lambda: next(generated_ids))
+        monkeypatch.setattr(messages_service, "_utc_now_iso", lambda: "2026-06-22T00:00:37Z")
         result = messages_service.append(
             conn,
             scope_id=queued["scope_id"],
@@ -858,14 +962,6 @@ def test_flush_promoted_user_row_sorts_after_preceding_result(tmp_path, monkeypa
             )
         )
 
-    delays = []
-
-    async def fake_sleep(delay):
-        delays.append(delay)
-        clock["now"] = "2026-06-22T00:00:38+00:00"
-
-    monkeypatch.setattr(session_turns.asyncio, "sleep", fake_sleep)
-    monkeypatch.setattr(messages_service, "_utc_now_iso", lambda: "2026-06-22T00:00:38Z")
     manager, _runs = _manager_capturing_runs()
 
     async def append_fast_result(sid, context, text, *, source=SOURCE_HUMAN):
@@ -894,7 +990,12 @@ def test_flush_promoted_user_row_sorts_after_preceding_result(tmp_path, monkeypa
         ("user", "queued follow-up"),
         ("result", "fast queued result"),
     ]
-    assert delays == [0.5]
+    assert [row["id"] for row in transcript["messages"]] == [
+        "msg_000000000000100aaaaaaaa",
+        "msg_000000000000200aaaaaaaa",
+        "msg_000000000000300aaaaaaaa",
+    ]
+    assert queued_id not in {row["id"] for row in transcript["messages"]}
 
 
 def test_async_dispatch_flushes_queue_on_turn_end(monkeypatch, tmp_path):

--- a/tests/test_internal_server.py
+++ b/tests/test_internal_server.py
@@ -755,6 +755,7 @@ def test_dispatch_async_queues_show_annotation_and_runs_it_after_active_turn(mon
                             "dispatch": True,
                         },
                     },
+                    reserve_dispatch=True,
                 )
             finally:
                 store.close()

--- a/tests/test_internal_server.py
+++ b/tests/test_internal_server.py
@@ -811,7 +811,65 @@ def test_dispatch_async_queues_show_annotation_and_runs_it_after_active_turn(mon
         ).scalar_one()
     assert [message["text"] for message in visible["messages"]] == [annotation["transcript_text"]]
     assert visible["messages"][0]["id"] == annotation["message_id"]
+    assert visible["messages"][0]["metadata"]["source"] == "show_page"
+    assert visible["messages"][0]["metadata"]["show_event_id"] == annotation["id"]
+    assert session_turns.QUEUED_DISPATCH_TEXT_KEY not in visible["messages"][0]["metadata"]
     assert linked_message_id == annotation["message_id"]
+
+
+def test_flush_promoted_user_row_sorts_after_preceding_result(tmp_path, monkeypatch):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    monkeypatch.setattr(
+        session_turns,
+        "_utc_now_iso",
+        lambda: "2026-06-22T00:00:37.500000+00:00",
+    )
+    session_id = _seed_avibe_session_with_queue([("queued follow-up", None)])
+
+    from sqlalchemy import update
+
+    from storage import messages_service
+    from storage.db import create_sqlite_engine
+    from storage.models import messages
+
+    with create_sqlite_engine().begin() as conn:
+        queued = messages_service.list_queued(conn, session_id)[0]
+        conn.execute(
+            update(messages)
+            .where(messages.c.id == queued["id"])
+            .values(created_at="2026-06-22T00:00:36Z")
+        )
+        result = messages_service.append(
+            conn,
+            scope_id=queued["scope_id"],
+            session_id=session_id,
+            platform="avibe",
+            author="agent",
+            message_type="result",
+            text="preceding result",
+        )
+        conn.execute(
+            update(messages)
+            .where(messages.c.id == result["id"])
+            .values(
+                created_at="2026-06-22T00:00:37Z",
+                updated_at="2026-06-22T00:00:37Z",
+            )
+        )
+
+    manager, _runs = _manager_capturing_runs()
+    assert asyncio.run(manager.flush_queue(session_id)) is True
+
+    with create_sqlite_engine().connect() as conn:
+        transcript = messages_service.list_session_messages(
+            conn,
+            session_id=session_id,
+            types=("user", "result"),
+        )
+    assert [(row["type"], row["text"]) for row in transcript["messages"]] == [
+        ("result", "preceding result"),
+        ("user", "queued follow-up"),
+    ]
 
 
 def test_async_dispatch_flushes_queue_on_turn_end(monkeypatch, tmp_path):

--- a/tests/test_internal_server.py
+++ b/tests/test_internal_server.py
@@ -4108,6 +4108,8 @@ def test_flush_continues_after_dropping_duplicate_scheduled_segment(tmp_path, mo
     assert [(text, source) for text, source, _ in runs] == [("queued user follow-up", SOURCE_HUMAN)]
     with create_sqlite_engine().begin() as conn:
         assert messages_service.list_queued(conn, session_id) == []
+        visible = messages_service.list_session_messages(conn, session_id=session_id, types=("user",))
+    assert runs[0][2].message_id == visible["messages"][0]["id"]
 
 
 def test_flush_does_not_coalesce_scheduled_callbacks_outside_window(tmp_path, monkeypatch):

--- a/tests/test_internal_server.py
+++ b/tests/test_internal_server.py
@@ -978,8 +978,11 @@ def test_dispatch_async_archive_race_never_marks_lost_show_reservation_accepted(
         submissions += 1
         with engine.begin() as conn:
             sessions_service.archive_session(conn, session_id)
-        enqueue()
-        return "enqueued"
+        queue_persisted = enqueue()
+        return session_turns.TurnSubmissionResult(
+            route="enqueued",
+            queue_persisted=queue_persisted,
+        )
 
     monkeypatch.setattr(controller.session_turns, "submit", archive_during_submit)
 
@@ -2327,7 +2330,7 @@ def test_release_for_backend_refresh_leaves_other_backend_turn_running():
 def test_backend_drain_queues_idle_session_without_dispatching():
     controller = _build_controller_double()
     manager = session_turns.SessionTurnManager(controller)
-    enqueue = Mock()
+    enqueue = Mock(return_value=True)
     context = MessageContext(user_id="U", channel_id="ses_codex", platform="avibe")
     context.platform_specific = {
         "agent_session_id": "ses_codex",
@@ -2340,17 +2343,44 @@ def test_backend_drain_queues_idle_session_without_dispatching():
 
     result = asyncio.run(_go())
 
-    assert result == "enqueued"
+    assert result == session_turns.TurnSubmissionResult(
+        route="enqueued",
+        queue_persisted=True,
+    )
     enqueue.assert_called_once_with()
     assert manager.is_in_flight("ses_codex") is False
     assert manager._deferred_restart_sessions == {"codex": {"ses_codex"}}
+
+
+def test_backend_drain_exposes_failed_queue_persistence():
+    controller = _build_controller_double()
+    manager = session_turns.SessionTurnManager(controller)
+    enqueue = Mock(return_value=False)
+    context = MessageContext(user_id="U", channel_id="ses_codex", platform="avibe")
+    context.platform_specific = {
+        "agent_session_id": "ses_codex",
+        "agent_session_target": {"agent_backend": "codex"},
+    }
+
+    async def _go():
+        manager.begin_backend_drain("codex")
+        return await manager.submit("ses_codex", context, "next", enqueue=enqueue)
+
+    result = asyncio.run(_go())
+
+    assert result == session_turns.TurnSubmissionResult(
+        route="enqueued",
+        queue_persisted=False,
+    )
+    enqueue.assert_called_once_with()
+    assert manager.is_in_flight("ses_codex") is False
 
 
 def test_backend_drain_resolves_inherited_default_agent_backend():
     controller = _build_controller_double()
     controller.resolve_agent_for_context = Mock(return_value="codex")
     manager = session_turns.SessionTurnManager(controller)
-    enqueue = Mock()
+    enqueue = Mock(return_value=True)
     context = MessageContext(user_id="U", channel_id="ses_default", platform="avibe")
     context.platform_specific = {
         "agent_session_id": "ses_default",
@@ -2361,7 +2391,10 @@ def test_backend_drain_resolves_inherited_default_agent_backend():
         manager.begin_backend_drain("codex")
         return await manager.submit("ses_default", context, "next", enqueue=enqueue)
 
-    assert asyncio.run(_go()) == "enqueued"
+    assert asyncio.run(_go()) == session_turns.TurnSubmissionResult(
+        route="enqueued",
+        queue_persisted=True,
+    )
     enqueue.assert_called_once_with()
     controller.resolve_agent_for_context.assert_called_once_with(context)
     assert manager._deferred_restart_sessions == {"codex": {"ses_default"}}

--- a/tests/test_internal_server.py
+++ b/tests/test_internal_server.py
@@ -1105,7 +1105,10 @@ def test_ambiguous_show_dispatch_timeout_reconciles_accepted_turn_once(
         await asyncio.wait_for(turn_started.wait(), timeout=1)
         return first, replay
 
-    assert asyncio.run(_go()) == (True, True)
+    assert asyncio.run(_go()) == (
+        ui_server._ShowEventDispatchOutcome.ACCEPTED,
+        ui_server._ShowEventDispatchOutcome.ACCEPTED,
+    )
     assert len(submissions) == 1
     controller.message_handler.handle_user_message.assert_awaited_once()
     assert event["message"]["type"] == "user"

--- a/tests/test_internal_server.py
+++ b/tests/test_internal_server.py
@@ -904,6 +904,126 @@ def test_dispatch_async_rejects_missing_or_archived_show_reservation(
     controller.message_handler.handle_user_message.assert_not_awaited()
 
 
+def test_dispatch_async_archive_race_never_marks_lost_show_reservation_accepted(
+    monkeypatch,
+    tmp_path,
+):
+    from core.services import sessions as sessions_service
+    from core.show_session_events import (
+        DISPATCH_ARCHIVED,
+        DISPATCH_IN_FLIGHT,
+        ShowSessionEventStore,
+        claim_show_dispatch,
+    )
+    from storage.db import create_sqlite_engine
+    from storage.importer import ensure_sqlite_state
+    from storage.models import messages
+    from storage.settings_service import upsert_scope
+
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    ensure_sqlite_state()
+    engine = create_sqlite_engine()
+    with engine.begin() as conn:
+        scope_id = upsert_scope(
+            conn,
+            platform="avibe",
+            scope_type="project",
+            native_id="proj_show_archive_race",
+            now="2026-05-31T00:00:00Z",
+        )
+        _seed_project_workdir(conn, scope_id, tmp_path)
+        session = sessions_service.create_session(
+            conn,
+            scope_id=scope_id,
+            agent_backend="claude",
+            agent_name="worker",
+        )
+
+    store = ShowSessionEventStore()
+    try:
+        event = store.append(
+            session["id"],
+            {
+                "id": "show_evt_archive_during_submit",
+                "type": "human.annotation.created",
+                "annotation": {
+                    "intent": "comment",
+                    "comment": "Do not lose this annotation as a false success.",
+                    "dispatch": True,
+                },
+            },
+            reserve_dispatch=True,
+        )
+    finally:
+        store.close()
+    owner = "101:1.0:attempt"
+    with engine.begin() as conn:
+        claimed = claim_show_dispatch(
+            conn,
+            event["id"],
+            session_id=session["id"],
+            owner=owner,
+        )
+    assert claimed is not None
+    assert claimed.state == DISPATCH_IN_FLIGHT
+    assert claimed.claimed is True
+
+    controller = _build_controller_double()
+    app = internal_server.create_app(controller)
+    transport = httpx.ASGITransport(app=app)
+    submissions = 0
+
+    async def archive_during_submit(session_id, _context, _text, *, enqueue, **_kwargs):
+        nonlocal submissions
+        submissions += 1
+        with engine.begin() as conn:
+            sessions_service.archive_session(conn, session_id)
+        enqueue()
+        return "enqueued"
+
+    monkeypatch.setattr(controller.session_turns, "submit", archive_during_submit)
+
+    async def _post():
+        async with httpx.AsyncClient(
+            transport=transport,
+            base_url="http://testserver",
+        ) as client:
+            payload = {
+                "session_id": session["id"],
+                "text": event["transcript_text"],
+                "user_message_id": event["message_id"],
+                "show_event_id": event["id"],
+                "dispatch_owner": owner,
+            }
+            return (
+                await client.post("/internal/dispatch_async", json=payload),
+                await client.post("/internal/dispatch_async", json=payload),
+            )
+
+    first, replay = asyncio.run(_post())
+
+    assert first.status_code == 409
+    assert first.json()["code"] == "session_archived"
+    assert replay.status_code == 409
+    assert replay.json()["code"] == "session_archived"
+    assert submissions == 1
+    controller.message_handler.handle_user_message.assert_not_awaited()
+    store = ShowSessionEventStore()
+    try:
+        dispatch_status = store.get_dispatch_status(session["id"], event["id"])
+    finally:
+        store.close()
+    assert dispatch_status is not None
+    assert dispatch_status.state == DISPATCH_ARCHIVED
+    with engine.connect() as conn:
+        assert (
+            conn.execute(
+                select(messages.c.id).where(messages.c.id == event["message_id"])
+            ).scalar_one_or_none()
+            is None
+        )
+
+
 def test_failed_show_dispatch_retries_same_event_through_manager_once(monkeypatch, tmp_path):
     from core.services import sessions as sessions_service
     from core.show_session_events import (

--- a/tests/test_queued_message_writer_policy.py
+++ b/tests/test_queued_message_writer_policy.py
@@ -1,0 +1,60 @@
+"""Keep the durable send-while-busy queue owned by controller/storage code."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+QUEUED_TYPE_WRITER_ALLOWLIST = {
+    "core/internal_server.py",
+    "core/session_turns.py",
+    "storage/messages_service.py",
+    "storage/workbench_sessions_service.py",
+}
+
+
+def _is_queued_type(node: ast.expr) -> bool:
+    return (
+        isinstance(node, ast.Constant)
+        and node.value == "queued"
+        or isinstance(node, ast.Name)
+        and node.id == "QUEUED_TYPE"
+        or isinstance(node, ast.Attribute)
+        and node.attr == "QUEUED_TYPE"
+    )
+
+
+def _writes_queued_message_type(tree: ast.AST) -> bool:
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.keyword)
+            and node.arg in {"type", "message_type"}
+            and _is_queued_type(node.value)
+        ):
+            return True
+        if isinstance(node, ast.Dict):
+            for key, value in zip(node.keys, node.values, strict=True):
+                if (
+                    isinstance(key, ast.Constant)
+                    and key.value in {"type", "message_type"}
+                    and _is_queued_type(value)
+                ):
+                    return True
+    return False
+
+
+def test_only_controller_and_storage_modules_write_queued_message_type():
+    # ``queued`` is executable queue state, not a Web presentation state. Keep
+    # its writers confined to the controller and storage ownership boundary.
+    writer_modules = {
+        path.relative_to(REPO_ROOT).as_posix()
+        for root in ("core", "storage", "vibe")
+        for path in (REPO_ROOT / root).rglob("*.py")
+        if _writes_queued_message_type(
+            ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        )
+    }
+
+    assert writer_modules <= QUEUED_TYPE_WRITER_ALLOWLIST

--- a/tests/test_scheduled_tasks.py
+++ b/tests/test_scheduled_tasks.py
@@ -3359,7 +3359,9 @@ def test_workbench_turn_settles_its_agent_run_when_no_result_arrives(
     )
 
     async def _exercise() -> None:
-        assert await manager.submit(session_id, context, "stop me", source=SOURCE_SCHEDULED) == "ran"
+        assert (
+            await manager.submit(session_id, context, "stop me", source=SOURCE_SCHEDULED)
+        ).route == "ran"
         for _ in range(400):
             if request_store.get_run(primary)["status"] != "running":
                 break
@@ -3429,8 +3431,7 @@ def test_backend_refresh_settles_its_run_as_a_refresh_not_a_user_stop(
     async def _exercise() -> None:
         assert (
             await manager.submit(session_id, context, "interrupted by a config save", source=SOURCE_SCHEDULED)
-            == "ran"
-        )
+        ).route == "ran"
         await asyncio.wait_for(dispatch_started.wait(), timeout=5)
         released = await manager.release_for_backend_refresh(
             backend="codex", base_session_ids={session_id}
@@ -3501,8 +3502,7 @@ def test_turn_only_result_leaves_an_activity_owned_run_alone(
             await manager.submit(
                 session_id, context, "delivery failed, activity requeued", source=SOURCE_SCHEDULED
             )
-            == "ran"
-        )
+        ).route == "ran"
         for _ in range(400):
             if session_id not in manager.in_flight:
                 break
@@ -3614,8 +3614,7 @@ def test_sweep_spares_a_hold_parked_behind_a_live_session_turn(
             await manager.submit(
                 session_id, context, "the long legitimate turn", source=SOURCE_SCHEDULED
             )
-            == "ran"
-        )
+        ).route == "ran"
         await asyncio.wait_for(dispatch_started.wait(), timeout=5)
         assert manager.busy_session_ids() == {session_id}
 

--- a/tests/test_show_git_turn_entrypoints.py
+++ b/tests/test_show_git_turn_entrypoints.py
@@ -205,7 +205,7 @@ def test_all_turn_entrypoints_reach_checkpoint_subscriber(monkeypatch, tmp_path)
     contexts = {
         "im_message": _context("im_message", platform="slack"),
         "workbench_chat": _context("workbench_chat", platform="avibe"),
-        "internal_dispatch": _context("internal_dispatch", platform="avibe"),
+        "show_page": _context("show_page", platform="avibe"),
         "agent_run_sync": _context("agent_run_sync", platform="slack", trigger_kind="agent_run"),
         "agent_run_async": _context("agent_run_async", platform="slack", trigger_kind="agent_run"),
         "scheduled_task": _context("scheduled_task", platform="slack", trigger_kind="scheduled"),
@@ -278,10 +278,14 @@ def test_all_turn_entrypoints_reach_checkpoint_subscriber(monkeypatch, tmp_path)
         transport = httpx.ASGITransport(app=app)
         async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
             response = await client.post(
-                "/internal/dispatch",
-                json={"session_id": "ses_internal_dispatch", "entrypoint": "internal_dispatch"},
+                "/internal/dispatch_async",
+                json={"session_id": "ses_show_page", "entrypoint": "show_page"},
             )
-        assert response.status_code == 200
+        assert response.status_code == 202
+        for _ in range(100):
+            if checkpoint_calls["ses_show_page"] == [PRE_TURN, POST_TURN]:
+                break
+            await asyncio.sleep(0.01)
 
         # Sync and async CLI modes enqueue the same Agent Run execution; only
         # the CLI caller's wait behavior differs. Exercise that executor twice.

--- a/tests/test_show_pages.py
+++ b/tests/test_show_pages.py
@@ -3022,6 +3022,7 @@ def test_show_event_cli_dispatch_fallback_records_and_dispatches(monkeypatch, tm
 
     async def _fake_run_dispatch(event):
         dispatched.append(event)
+        return True
 
     monkeypatch.setattr("vibe.ui_server._run_show_event_dispatch", _fake_run_dispatch)
 
@@ -3047,6 +3048,81 @@ def test_show_event_cli_dispatch_fallback_records_and_dispatches(monkeypatch, tm
     assert dispatched and dispatched[0]["id"] == payload["event"]["id"]
     with engine.connect() as conn:
         assert conn.execute(select(show_session_events.c.id)).scalar_one() == payload["event"]["id"]
+
+
+def test_show_event_cli_embedded_dispatch_fallback_uses_sync_bridge(monkeypatch, tmp_path):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    paths.ensure_data_dirs()
+    _save_config()
+    monkeypatch.setattr(cli.runtime, "read_status", lambda: {"ui_pid": None})
+    captured = {}
+
+    def fake_record(session_id, payload, *, dispatch_sync):
+        captured.update(
+            session_id=session_id,
+            payload=payload,
+            dispatch_sync=dispatch_sync,
+        )
+        return {"id": "show_evt_local", "type": payload["type"], "message_id": "msg_local"}
+
+    monkeypatch.setattr("vibe.ui_server.record_local_show_event", fake_record)
+    args = cli.build_parser().parse_args(
+        [
+            "show",
+            "event",
+            "--session-id",
+            "ses123",
+            "--event-json",
+            json.dumps(
+                {
+                    "type": "human.annotation.created",
+                    "annotation": {"comment": "Deliver me.", "dispatch": True},
+                }
+            ),
+            "--json",
+        ]
+    )
+
+    assert cli.cmd_show(args) == 0
+    assert captured["dispatch_sync"] is True
+    assert captured["payload"]["annotation"]["dispatch"] is True
+
+
+def test_show_event_cli_timeout_does_not_replay_locally(monkeypatch, tmp_path, capsys):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    paths.ensure_data_dirs()
+    _save_config()
+    monkeypatch.setattr(cli.runtime, "read_status", lambda: {"ui_pid": 123})
+    monkeypatch.setattr(
+        cli.urllib.request,
+        "urlopen",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(TimeoutError()),
+    )
+    replayed = []
+    monkeypatch.setattr(
+        "vibe.ui_server.record_local_show_event",
+        lambda *args, **kwargs: replayed.append((args, kwargs)),
+    )
+    args = cli.build_parser().parse_args(
+        [
+            "show",
+            "event",
+            "--session-id",
+            "ses123",
+            "--event-json",
+            json.dumps(
+                {
+                    "type": "human.annotation.created",
+                    "annotation": {"comment": "Maybe accepted.", "dispatch": True},
+                }
+            ),
+            "--json",
+        ]
+    )
+
+    assert cli.cmd_show(args) == 1
+    assert replayed == []
+    assert json.loads(capsys.readouterr().err)["code"] == "show_event_acceptance_unknown"
 
 
 def test_show_event_cli_fallback_rejects_mismatched_session_id(monkeypatch, tmp_path, capsys):

--- a/tests/test_show_pages.py
+++ b/tests/test_show_pages.py
@@ -3140,6 +3140,61 @@ def test_show_event_cli_timeout_replays_same_event_identity_locally(monkeypatch,
     assert replay_payload["id"] == posted["id"]
 
 
+def test_show_event_cli_http_502_replays_same_event_identity_locally(monkeypatch, tmp_path):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    paths.ensure_data_dirs()
+    _save_config()
+    monkeypatch.setattr(cli.runtime, "read_status", lambda: {"ui_pid": 123})
+    posted = {}
+
+    def bad_gateway_after_receiving(request, **_kwargs):
+        posted.update(json.loads(request.data.decode("utf-8")))
+        raise cli.urllib.error.HTTPError(
+            request.full_url,
+            502,
+            "Bad Gateway",
+            {},
+            None,
+        )
+
+    monkeypatch.setattr(cli.urllib.request, "urlopen", bad_gateway_after_receiving)
+    replayed = []
+
+    def record_local(session_id, payload, *, dispatch_sync):
+        replayed.append((session_id, payload, dispatch_sync))
+        return {
+            "id": payload["id"],
+            "type": payload["type"],
+            "message_id": "msg_local",
+        }
+
+    monkeypatch.setattr("vibe.ui_server.record_local_show_event", record_local)
+    args = cli.build_parser().parse_args(
+        [
+            "show",
+            "event",
+            "--session-id",
+            "ses123",
+            "--event-json",
+            json.dumps(
+                {
+                    "type": "human.annotation.created",
+                    "annotation": {"comment": "Retry after 502.", "dispatch": True},
+                }
+            ),
+            "--json",
+        ]
+    )
+
+    assert cli.cmd_show(args) == 0
+    assert len(replayed) == 1
+    replay_session_id, replay_payload, dispatch_sync = replayed[0]
+    assert replay_session_id == "ses123"
+    assert dispatch_sync is True
+    assert posted["id"].startswith("show_evt_")
+    assert replay_payload["id"] == posted["id"]
+
+
 def test_show_event_cli_fallback_rejects_mismatched_session_id(monkeypatch, tmp_path, capsys):
     from sqlalchemy import select
 

--- a/tests/test_show_pages.py
+++ b/tests/test_show_pages.py
@@ -3088,7 +3088,12 @@ def test_show_event_cli_embedded_dispatch_fallback_uses_sync_bridge(monkeypatch,
     assert captured["payload"]["annotation"]["dispatch"] is True
 
 
-def test_show_event_cli_timeout_replays_same_event_identity_locally(monkeypatch, tmp_path):
+@pytest.mark.parametrize("blank_event_id", [None, "", "   "])
+def test_show_event_cli_timeout_replaces_blank_id_before_local_retry(
+    monkeypatch,
+    tmp_path,
+    blank_event_id,
+):
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     paths.ensure_data_dirs()
     _save_config()
@@ -3123,6 +3128,7 @@ def test_show_event_cli_timeout_replays_same_event_identity_locally(monkeypatch,
             "--event-json",
             json.dumps(
                 {
+                    "id": blank_event_id,
                     "type": "human.annotation.created",
                     "annotation": {"comment": "Maybe accepted.", "dispatch": True},
                 }

--- a/tests/test_show_pages.py
+++ b/tests/test_show_pages.py
@@ -3088,20 +3088,31 @@ def test_show_event_cli_embedded_dispatch_fallback_uses_sync_bridge(monkeypatch,
     assert captured["payload"]["annotation"]["dispatch"] is True
 
 
-def test_show_event_cli_timeout_does_not_replay_locally(monkeypatch, tmp_path, capsys):
+def test_show_event_cli_timeout_replays_same_event_identity_locally(monkeypatch, tmp_path):
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     paths.ensure_data_dirs()
     _save_config()
     monkeypatch.setattr(cli.runtime, "read_status", lambda: {"ui_pid": 123})
-    monkeypatch.setattr(
-        cli.urllib.request,
-        "urlopen",
-        lambda *_args, **_kwargs: (_ for _ in ()).throw(TimeoutError()),
-    )
+    posted = {}
+
+    def timeout_after_receiving(request, **_kwargs):
+        posted.update(json.loads(request.data.decode("utf-8")))
+        raise TimeoutError()
+
+    monkeypatch.setattr(cli.urllib.request, "urlopen", timeout_after_receiving)
     replayed = []
+
+    def record_local(session_id, payload, *, dispatch_sync):
+        replayed.append((session_id, payload, dispatch_sync))
+        return {
+            "id": payload["id"],
+            "type": payload["type"],
+            "message_id": "msg_local",
+        }
+
     monkeypatch.setattr(
         "vibe.ui_server.record_local_show_event",
-        lambda *args, **kwargs: replayed.append((args, kwargs)),
+        record_local,
     )
     args = cli.build_parser().parse_args(
         [
@@ -3120,9 +3131,13 @@ def test_show_event_cli_timeout_does_not_replay_locally(monkeypatch, tmp_path, c
         ]
     )
 
-    assert cli.cmd_show(args) == 1
-    assert replayed == []
-    assert json.loads(capsys.readouterr().err)["code"] == "show_event_acceptance_unknown"
+    assert cli.cmd_show(args) == 0
+    assert len(replayed) == 1
+    replay_session_id, replay_payload, dispatch_sync = replayed[0]
+    assert replay_session_id == "ses123"
+    assert dispatch_sync is True
+    assert posted["id"].startswith("show_evt_")
+    assert replay_payload["id"] == posted["id"]
 
 
 def test_show_event_cli_fallback_rejects_mismatched_session_id(monkeypatch, tmp_path, capsys):

--- a/tests/test_show_pages.py
+++ b/tests/test_show_pages.py
@@ -3146,6 +3146,44 @@ def test_show_event_cli_timeout_replaces_blank_id_before_local_retry(
     assert replay_payload["id"] == posted["id"]
 
 
+def test_show_event_cli_timeout_poll_reuses_one_event_store(monkeypatch):
+    from core.show_session_events import (
+        DISPATCH_ACCEPTED,
+        DISPATCH_IN_FLIGHT,
+        ShowDispatchStatus,
+    )
+
+    instances = []
+
+    class FakeStore:
+        def __init__(self):
+            self.states = iter((DISPATCH_IN_FLIGHT, DISPATCH_ACCEPTED))
+            self.closed = False
+            instances.append(self)
+
+        def get_dispatch_status(self, session_id, event_id):
+            return ShowDispatchStatus(state=next(self.states))
+
+        def get_event(self, session_id, event_id):
+            return {"id": event_id, "session_id": session_id}
+
+        def close(self):
+            self.closed = True
+
+    monkeypatch.setattr("core.show_session_events.ShowSessionEventStore", FakeStore)
+    monkeypatch.setattr(cli.time, "sleep", lambda _delay: None)
+
+    resolved = cli._resolve_show_event_after_ambiguous_live_timeout(
+        "ses123",
+        {"id": "show_evt_poll_once"},
+        wait_seconds=1,
+    )
+
+    assert resolved == {"id": "show_evt_poll_once", "session_id": "ses123"}
+    assert len(instances) == 1
+    assert instances[0].closed
+
+
 def test_show_event_cli_http_502_replays_same_event_identity_locally(monkeypatch, tmp_path):
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     paths.ensure_data_dirs()

--- a/tests/test_show_pages.py
+++ b/tests/test_show_pages.py
@@ -3152,6 +3152,7 @@ def test_show_event_cli_timeout_poll_reuses_one_event_store(monkeypatch):
     from core.show_session_events import (
         DISPATCH_ACCEPTED,
         DISPATCH_IN_FLIGHT,
+        ShowDispatchSettlement,
         ShowDispatchStatus,
     )
 
@@ -3168,6 +3169,16 @@ def test_show_event_cli_timeout_poll_reuses_one_event_store(monkeypatch):
 
         def get_event(self, session_id, event_id):
             return {"id": event_id, "session_id": session_id}
+
+        def reconcile_dispatch_settlement(self, session_id, event_id):
+            return ShowDispatchSettlement(
+                status=ShowDispatchStatus(state=DISPATCH_ACCEPTED),
+                message={
+                    "id": "msg_poll_once",
+                    "session_id": session_id,
+                    "type": "user",
+                },
+            )
 
         def close(self):
             self.closed = True

--- a/tests/test_show_pages.py
+++ b/tests/test_show_pages.py
@@ -3021,8 +3021,10 @@ def test_show_event_cli_dispatch_fallback_records_and_dispatches(monkeypatch, tm
     dispatched = []
 
     async def _fake_run_dispatch(event):
+        from vibe import ui_server
+
         dispatched.append(event)
-        return True
+        return ui_server._ShowEventDispatchOutcome.ACCEPTED
 
     monkeypatch.setattr("vibe.ui_server._run_show_event_dispatch", _fake_run_dispatch)
 
@@ -3182,6 +3184,86 @@ def test_show_event_cli_timeout_poll_reuses_one_event_store(monkeypatch):
     assert resolved == {"id": "show_evt_poll_once", "session_id": "ses123"}
     assert len(instances) == 1
     assert instances[0].closed
+
+
+def test_show_event_cli_pending_response_polls_instead_of_falling_back(
+    monkeypatch,
+):
+    payload = {
+        "id": "show_evt_pending_response",
+        "type": "human.annotation.created",
+    }
+    resolved = {"id": payload["id"], "session_id": "ses123"}
+    polls = []
+
+    class PendingResponse:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def read(self):
+            return json.dumps(
+                {
+                    "ok": True,
+                    "dispatch_pending": True,
+                    "event": payload,
+                }
+            ).encode()
+
+    monkeypatch.setattr(
+        cli,
+        "_local_show_events_url",
+        lambda _session_id: "http://127.0.0.1:5123/api/show/sessions/ses123/events",
+    )
+    monkeypatch.setattr(
+        cli.urllib.request,
+        "urlopen",
+        lambda _request, **_kwargs: PendingResponse(),
+    )
+    monkeypatch.setattr(
+        cli,
+        "_resolve_show_event_after_ambiguous_live_timeout",
+        lambda session_id, event: polls.append((session_id, event)) or resolved,
+    )
+
+    result = cli._post_show_event_to_live_ui("ses123", payload)
+
+    assert result == resolved
+    assert polls == [("ses123", payload)]
+
+
+def test_show_event_cli_pending_timeout_is_localized(monkeypatch):
+    from core.show_session_events import (
+        DISPATCH_IN_FLIGHT,
+        ShowDispatchStatus,
+        ShowSessionEventError,
+    )
+
+    class FakeStore:
+        def get_dispatch_status(self, _session_id, _event_id):
+            return ShowDispatchStatus(state=DISPATCH_IN_FLIGHT)
+
+        def close(self):
+            return None
+
+    class _Config:
+        language = "zh"
+
+    monkeypatch.setattr("core.show_session_events.ShowSessionEventStore", FakeStore)
+    monkeypatch.setattr("core.show_session_events.V2Config.load", lambda: _Config())
+    monkeypatch.setattr(cli.time, "monotonic", iter((0.0, 2.0)).__next__)
+
+    with pytest.raises(ShowSessionEventError) as exc_info:
+        cli._resolve_show_event_after_ambiguous_live_timeout(
+            "ses123",
+            {"id": "show_evt_pending_i18n"},
+            wait_seconds=1,
+        )
+
+    assert exc_info.value.code == "show_event_dispatch_pending"
+    assert str(exc_info.value) == "Show 事件可能仍在处理中，未在本地重复提交。"
 
 
 def test_show_event_cli_http_502_replays_same_event_identity_locally(monkeypatch, tmp_path):

--- a/tests/test_show_session_events.py
+++ b/tests/test_show_session_events.py
@@ -9,7 +9,12 @@ from pathlib import Path
 import pytest
 from sqlalchemy import select
 
-from core.show_session_events import ShowSessionEventError, ShowSessionEventStore, _format_transcript_text
+from core.show_session_events import (
+    ShowSessionEventError,
+    ShowSessionEventStore,
+    _format_transcript_text,
+    show_event_requests_dispatch,
+)
 from storage.db import create_sqlite_engine
 from storage.importer import ensure_sqlite_state
 from storage.models import agent_sessions, media_objects, messages, show_session_events
@@ -216,8 +221,6 @@ def test_show_event_store_keeps_remote_author_out_of_intent_fallback_text(isolat
 
 
 def test_annotation_control_event_has_no_transcript_or_dispatch(isolated_state):
-    from vibe.ui_server import _show_event_requests_dispatch
-
     _seed_session()
     store = ShowSessionEventStore()
     try:
@@ -236,7 +239,7 @@ def test_annotation_control_event_has_no_transcript_or_dispatch(isolated_state):
     assert event["transcript_text"] == ""
     assert event["message_id"] is None
     assert event["message"] is None
-    assert _show_event_requests_dispatch(event) is False
+    assert show_event_requests_dispatch(event) is False
 
     engine = create_sqlite_engine()
     with engine.connect() as conn:
@@ -878,47 +881,70 @@ def test_show_event_store_lists_after_cursor(isolated_state):
     assert [event["id"] for event in page["events"]] == [second["id"]]
 
 
-def test_show_event_dispatch_streams_via_stream_dispatch(isolated_state, monkeypatch):
-    """Regression guard: the Show-page dispatch flow MUST call
-    ``internal_client.stream_dispatch`` and re-publish each turn event as
-    ``show.dispatch``. Step 6 removed ``stream_dispatch`` as dead, but the merged
-    show-annotation feature still depends on it — without this test that removal
-    passed CI yet broke the Show page at runtime (Codex P2)."""
-    import asyncio
+def test_dispatching_show_event_reserves_pending_transcript_row(isolated_state):
+    from storage import messages_service
 
+    _seed_session("ses_show")
+    store = ShowSessionEventStore()
+    try:
+        dispatching = store.append(
+            "ses_show",
+            {
+                "type": "human.annotation.created",
+                "annotation": {"intent": "comment", "comment": "Queue this.", "dispatch": True},
+            },
+        )
+        non_dispatching = store.append(
+            "ses_show",
+            {
+                "type": "human.annotation.created",
+                "annotation": {"intent": "comment", "comment": "Record only.", "dispatch": False},
+            },
+        )
+    finally:
+        store.close()
+
+    assert dispatching["message"]["type"] == messages_service.PENDING_TYPE
+    assert non_dispatching["message"]["type"] == "user"
+    engine = create_sqlite_engine()
+    with engine.connect() as conn:
+        visible = messages_service.list_session_messages(conn, session_id="ses_show", types=("user",))
+        queued = messages_service.list_queued(conn, "ses_show")
+    assert [message["text"] for message in visible["messages"]] == [non_dispatching["transcript_text"]]
+    assert queued == []
+
+
+def test_record_local_show_event_dispatch_sync_uses_unified_entry(isolated_state, monkeypatch):
     from vibe import internal_client, ui_server
     from vibe.sse_broker import broker
 
+    _seed_session("ses_show")
+    dispatches = []
     published: list[tuple[str, dict]] = []
     monkeypatch.setattr(broker, "publish", lambda event, data: published.append((event, data)))
 
-    async def fake_stream_dispatch(payload, **kwargs):
-        assert payload["session_id"] == "ses_show" and payload["text"] == "do the thing"
-        yield ("turn.start", {"session_id": "ses_show"})
-        yield ("turn.chunk", {"text": "working", "kind": "notify"})
-        yield ("turn.end", {"session_id": "ses_show"})
+    async def fake_dispatch_async(payload, **kwargs):
+        dispatches.append(payload)
+        return {"status_code": 202, "body": {"ok": True}}
 
-    # setattr requires the attribute to exist — so this also asserts stream_dispatch
-    # wasn't removed again.
-    monkeypatch.setattr(internal_client, "stream_dispatch", fake_stream_dispatch)
-
-    asyncio.run(
-        ui_server._run_show_event_dispatch(
-            {
-                "id": "evt1",
-                "session_id": "ses_show",
-                "scope_id": "scope1",
-                "transcript_text": "do the thing",
-                "message_id": "m1",
-            }
-        )
+    monkeypatch.setattr(internal_client, "dispatch_async", fake_dispatch_async)
+    event = ui_server.record_local_show_event(
+        "ses_show",
+        {
+            "type": "human.annotation.created",
+            "annotation": {"intent": "comment", "comment": "Deliver this.", "dispatch": True},
+        },
+        dispatch_sync=True,
     )
 
-    assert [d["event"] for (e, d) in published if e == "show.dispatch"] == [
-        "turn.start",
-        "turn.chunk",
-        "turn.end",
+    assert dispatches[0]["user_message_id"] == event["message_id"]
+    assert event["message"]["type"] == "user"
+    assert [name for name, _data in published] == [
+        "show.event",
+        "message.new",
+        "session.activity",
     ]
+    assert published[1][1]["id"] == event["message_id"]
 
 
 @pytest.mark.parametrize(
@@ -939,12 +965,11 @@ def test_annotation_dispatch_text_adds_event_id_and_optional_reply_guidance(monk
 
     captured = []
 
-    async def fake_stream_dispatch(payload, **kwargs):
+    async def fake_dispatch_async(payload, **kwargs):
         captured.append(payload)
-        if False:
-            yield None
+        return {"status_code": 202, "body": {"ok": True, "queued": True}}
 
-    monkeypatch.setattr(internal_client, "stream_dispatch", fake_stream_dispatch)
+    monkeypatch.setattr(internal_client, "dispatch_async", fake_dispatch_async)
     label = intent or "comment"
     event = {
         "id": "show_evt_1a2b3c4d",
@@ -954,6 +979,7 @@ def test_annotation_dispatch_text_adds_event_id_and_optional_reply_guidance(monk
         "payload": {"intent": intent} if intent is not None else {},
         "transcript_text": f"[show-annotation] {label}\n\nReview this.",
         "message_id": "m1",
+        "message": {"id": "m1", "type": "pending"},
     }
 
     asyncio.run(ui_server._run_show_event_dispatch(event))

--- a/tests/test_show_session_events.py
+++ b/tests/test_show_session_events.py
@@ -1015,7 +1015,7 @@ def test_record_local_show_event_dispatch_sync_uses_unified_entry(isolated_state
     assert published[1][1]["id"] == event["message_id"]
 
 
-def test_record_local_show_event_reports_failed_sync_dispatch_after_visible_record(
+def test_record_local_show_event_reports_failed_sync_dispatch_with_pending_record(
     isolated_state,
     monkeypatch,
 ):
@@ -1046,9 +1046,15 @@ def test_record_local_show_event_reports_failed_sync_dispatch_after_visible_reco
     finally:
         store.close()
     with create_sqlite_engine().connect() as conn:
+        pending = messages_service.list_session_messages(
+            conn,
+            session_id="ses_show",
+            types=(messages_service.PENDING_TYPE,),
+        )
         visible = messages_service.list_session_messages(conn, session_id="ses_show", types=("user",))
         queued = messages_service.list_queued(conn, "ses_show")
-    assert [row["text"] for row in visible["messages"]] == [stored_event["transcript_text"]]
+    assert [row["text"] for row in pending["messages"]] == [stored_event["transcript_text"]]
+    assert visible["messages"] == []
     assert queued == []
 
 

--- a/tests/test_show_session_events.py
+++ b/tests/test_show_session_events.py
@@ -916,28 +916,31 @@ def test_dispatching_show_event_reserves_pending_transcript_row(isolated_state):
     assert queued == []
 
 
-def test_dispatching_show_event_requires_unified_turn_entry(isolated_state):
+def test_direct_dispatching_show_event_stays_visible_without_reservation(isolated_state):
+    from storage import messages_service
+
     _seed_session("ses_show")
     store = ShowSessionEventStore()
     try:
-        with pytest.raises(ShowSessionEventError) as exc_info:
-            store.append(
-                "ses_show",
-                {
-                    "type": "human.annotation.created",
-                    "annotation": {
-                        "intent": "comment",
-                        "comment": "Do not strand this.",
-                        "dispatch": True,
-                    },
+        event = store.append(
+            "ses_show",
+            {
+                "type": "human.annotation.created",
+                "annotation": {
+                    "intent": "comment",
+                    "comment": "Record this visibly.",
+                    "dispatch": True,
                 },
-            )
+            },
+        )
         events = store.list("ses_show")
     finally:
         store.close()
 
-    assert exc_info.value.code == "dispatch_requires_turn_entry"
-    assert events["events"] == []
+    assert event["message"]["type"] == "user"
+    assert [item["id"] for item in events["events"]] == [event["id"]]
+    with create_sqlite_engine().connect() as conn:
+        assert messages_service.list_queued(conn, "ses_show") == []
 
 
 def test_record_local_show_event_dispatch_sync_uses_unified_entry(isolated_state, monkeypatch):
@@ -971,6 +974,43 @@ def test_record_local_show_event_dispatch_sync_uses_unified_entry(isolated_state
         "session.activity",
     ]
     assert published[1][1]["id"] == event["message_id"]
+
+
+def test_record_local_show_event_reports_failed_sync_dispatch_after_visible_record(
+    isolated_state,
+    monkeypatch,
+):
+    from storage import messages_service
+    from vibe import internal_client, ui_server
+
+    _seed_session("ses_show")
+
+    async def fake_dispatch_async(payload, **kwargs):
+        raise internal_client.InternalServerUnavailable("controller unavailable")
+
+    monkeypatch.setattr(internal_client, "dispatch_async", fake_dispatch_async)
+    stored_event = None
+    with pytest.raises(ShowSessionEventError) as exc_info:
+        ui_server.record_local_show_event(
+            "ses_show",
+            {
+                "type": "human.annotation.created",
+                "annotation": {"intent": "comment", "comment": "Record this.", "dispatch": True},
+            },
+            dispatch_sync=True,
+        )
+
+    assert exc_info.value.code == "show_event_dispatch_failed"
+    store = ShowSessionEventStore()
+    try:
+        stored_event = store.list("ses_show")["events"][0]
+    finally:
+        store.close()
+    with create_sqlite_engine().connect() as conn:
+        visible = messages_service.list_session_messages(conn, session_id="ses_show", types=("user",))
+        queued = messages_service.list_queued(conn, "ses_show")
+    assert [row["text"] for row in visible["messages"]] == [stored_event["transcript_text"]]
+    assert queued == []
 
 
 @pytest.mark.parametrize(

--- a/tests/test_show_session_events.py
+++ b/tests/test_show_session_events.py
@@ -955,6 +955,43 @@ def test_dispatching_show_event_retry_reuses_event_and_transcript_row(isolated_s
     assert len(message_rows) == 1
 
 
+def test_show_event_store_rejects_reused_id_with_different_contents(isolated_state):
+    _seed_session("ses_show_conflict")
+    first_payload = {
+        "id": "show_evt_bound_identity",
+        "type": "human.annotation.created",
+        "annotation": {
+            "intent": "comment",
+            "comment": "Deliver the original annotation.",
+            "dispatch": True,
+        },
+    }
+    conflicting_payload = {
+        **first_payload,
+        "annotation": {
+            **first_payload["annotation"],
+            "comment": "Silently replace it with different work.",
+        },
+    }
+
+    store = ShowSessionEventStore()
+    try:
+        first = store.append("ses_show_conflict", first_payload, reserve_dispatch=True)
+        with pytest.raises(ShowSessionEventError) as exc_info:
+            store.append(
+                "ses_show_conflict",
+                conflicting_payload,
+                reserve_dispatch=True,
+            )
+        stored = store.get_event("ses_show_conflict", first["id"])
+    finally:
+        store.close()
+
+    assert exc_info.value.code == "event_id_conflict"
+    assert stored is not None
+    assert stored["payload"]["comment"] == "Deliver the original annotation."
+
+
 def test_direct_dispatching_show_event_stays_visible_without_reservation(isolated_state):
     from storage import messages_service
 
@@ -992,7 +1029,15 @@ def test_record_local_show_event_dispatch_sync_uses_unified_entry(isolated_state
     monkeypatch.setattr(broker, "publish", lambda event, data: published.append((event, data)))
 
     async def fake_dispatch_async(payload, **kwargs):
+        from storage import messages_service
+
         dispatches.append(payload)
+        with create_sqlite_engine().begin() as conn:
+            assert messages_service.accept_dispatch_reservation(
+                conn,
+                payload["user_message_id"],
+                "user",
+            )
         return {"status_code": 202, "body": {"ok": True}}
 
     monkeypatch.setattr(internal_client, "dispatch_async", fake_dispatch_async)
@@ -1015,7 +1060,7 @@ def test_record_local_show_event_dispatch_sync_uses_unified_entry(isolated_state
     assert published[1][1]["id"] == event["message_id"]
 
 
-def test_record_local_show_event_reports_failed_sync_dispatch_with_pending_record(
+def test_record_local_show_event_reports_failed_sync_dispatch_with_retryable_record(
     isolated_state,
     monkeypatch,
 ):
@@ -1046,16 +1091,68 @@ def test_record_local_show_event_reports_failed_sync_dispatch_with_pending_recor
     finally:
         store.close()
     with create_sqlite_engine().connect() as conn:
-        pending = messages_service.list_session_messages(
+        failed = messages_service.list_session_messages(
             conn,
             session_id="ses_show",
-            types=(messages_service.PENDING_TYPE,),
+            types=(messages_service.DISPATCH_FAILED_TYPE,),
         )
         visible = messages_service.list_session_messages(conn, session_id="ses_show", types=("user",))
         queued = messages_service.list_queued(conn, "ses_show")
-    assert [row["text"] for row in pending["messages"]] == [stored_event["transcript_text"]]
+    assert [row["text"] for row in failed["messages"]] == [stored_event["transcript_text"]]
     assert visible["messages"] == []
     assert queued == []
+
+
+def test_ambiguous_show_dispatch_stays_in_flight_and_is_not_resubmitted(
+    isolated_state,
+    monkeypatch,
+):
+    from storage import messages_service
+    from vibe import internal_client, ui_server
+
+    _seed_session("ses_show")
+    attempts = 0
+
+    async def fake_dispatch_async(payload, **kwargs):
+        nonlocal attempts
+        attempts += 1
+        raise internal_client.InternalServerTimeout("acceptance unknown")
+
+    monkeypatch.setattr(internal_client, "dispatch_async", fake_dispatch_async)
+    payload = {
+        "id": "show_evt_ambiguous_timeout",
+        "type": "human.annotation.created",
+        "annotation": {
+            "intent": "comment",
+            "comment": "Do not submit this twice.",
+            "dispatch": True,
+        },
+    }
+
+    for _attempt in range(2):
+        with pytest.raises(ShowSessionEventError) as exc_info:
+            ui_server.record_local_show_event(
+                "ses_show",
+                payload,
+                dispatch_sync=True,
+            )
+        assert exc_info.value.code == "show_event_dispatch_failed"
+
+    store = ShowSessionEventStore()
+    try:
+        event = store.get_event("ses_show", payload["id"])
+    finally:
+        store.close()
+    assert attempts == 1
+    assert event is not None
+    assert event["message"]["type"] == messages_service.DISPATCHING_TYPE
+    with create_sqlite_engine().connect() as conn:
+        visible = messages_service.list_session_messages(
+            conn,
+            session_id="ses_show",
+            types=("user",),
+        )
+    assert visible["messages"] == []
 
 
 @pytest.mark.parametrize(
@@ -1072,15 +1169,31 @@ def test_record_local_show_event_reports_failed_sync_dispatch_with_pending_recor
 def test_annotation_dispatch_text_adds_event_id_and_optional_reply_guidance(monkeypatch, intent, expects_guidance):
     import asyncio
 
+    from storage import messages_service
     from vibe import internal_client, ui_server
 
     captured = []
 
     async def fake_dispatch_async(payload, **kwargs):
         captured.append(payload)
-        return {"status_code": 202, "body": {"ok": True, "queued": True}}
+        return {"status_code": 202, "body": {"ok": True}}
 
     monkeypatch.setattr(internal_client, "dispatch_async", fake_dispatch_async)
+    monkeypatch.setattr(
+        messages_service,
+        "claim_dispatch_reservation",
+        lambda conn, message_id: (messages_service.DISPATCHING_TYPE, True),
+    )
+    monkeypatch.setattr(
+        ui_server,
+        "_load_show_event_message",
+        lambda event: {"id": "m1", "type": "user"},
+    )
+    monkeypatch.setattr(
+        ui_server,
+        "_publish_accepted_user_message",
+        lambda row, **kwargs: row,
+    )
     label = intent or "comment"
     event = {
         "id": "show_evt_1a2b3c4d",

--- a/tests/test_show_session_events.py
+++ b/tests/test_show_session_events.py
@@ -916,6 +916,45 @@ def test_dispatching_show_event_reserves_pending_transcript_row(isolated_state):
     assert queued == []
 
 
+def test_dispatching_show_event_retry_reuses_event_and_transcript_row(isolated_state):
+    from storage import messages_service
+
+    _seed_session("ses_show_retry")
+    payload = {
+        "id": "show_evt_retry_identity",
+        "type": "human.annotation.created",
+        "annotation": {
+            "intent": "comment",
+            "comment": "Deliver exactly once.",
+            "dispatch": True,
+        },
+    }
+    store = ShowSessionEventStore()
+    try:
+        first = store.append("ses_show_retry", payload, reserve_dispatch=True)
+        replay = store.append("ses_show_retry", payload, reserve_dispatch=True)
+    finally:
+        store.close()
+
+    assert replay["id"] == first["id"]
+    assert replay["message_id"] == first["message_id"]
+    assert replay["message"]["type"] == messages_service.PENDING_TYPE
+    engine = create_sqlite_engine()
+    with engine.connect() as conn:
+        event_rows = conn.execute(
+            select(show_session_events).where(
+                show_session_events.c.id == "show_evt_retry_identity"
+            )
+        ).mappings().all()
+        message_rows = conn.execute(
+            select(messages).where(
+                messages.c.native_message_id == "show:show_evt_retry_identity"
+            )
+        ).mappings().all()
+    assert len(event_rows) == 1
+    assert len(message_rows) == 1
+
+
 def test_direct_dispatching_show_event_stays_visible_without_reservation(isolated_state):
     from storage import messages_service
 

--- a/tests/test_show_session_events.py
+++ b/tests/test_show_session_events.py
@@ -10,9 +10,16 @@ import pytest
 from sqlalchemy import select
 
 from core.show_session_events import (
+    DISPATCH_ACCEPTED,
+    DISPATCH_FAILED,
+    DISPATCH_IN_FLIGHT,
+    DISPATCH_NONE,
     ShowSessionEventError,
     ShowSessionEventStore,
     _format_transcript_text,
+    accept_show_dispatch,
+    claim_show_dispatch,
+    fail_show_dispatch,
     show_event_requests_dispatch,
 )
 from storage.db import create_sqlite_engine
@@ -421,6 +428,52 @@ def test_show_event_store_materializes_screenshot_attachment(isolated_state):
     assert media_row["source"] == "show_annotation"
     assert media_row["local_path"] == str(local_path)
     assert "dataUrl" not in stored_payload["screenshot"]
+
+
+def test_show_event_store_rolls_back_media_from_losing_idempotent_insert(
+    isolated_state,
+    monkeypatch,
+):
+    import core.show_session_events as show_events
+
+    _seed_session()
+    payload = {
+        "id": "show_evt_screenshot_race",
+        "type": "human.annotation.created",
+        "annotation": {
+            "intent": "comment",
+            "comment": "Keep only the winning screenshot.",
+            "screenshot": {
+                "dataUrl": _image_data_url("image/png", _png_bytes(4, 3)),
+            },
+        },
+    }
+    store = ShowSessionEventStore()
+    try:
+        winner = store.append("ses_mark", payload)
+        real_existing = show_events._existing_event_payload
+        calls = 0
+
+        def miss_preflight_once(*args, **kwargs):
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                return None
+            return real_existing(*args, **kwargs)
+
+        monkeypatch.setattr(show_events, "_existing_event_payload", miss_preflight_once)
+        replay = store.append("ses_mark", payload)
+    finally:
+        store.close()
+
+    with create_sqlite_engine().connect() as conn:
+        media_rows = conn.execute(select(media_objects)).mappings().all()
+    attachment_dir = Path(winner["payload"]["screenshot"]["path"]).parent
+    assert replay["id"] == winner["id"]
+    assert len(media_rows) == 1
+    assert [path.resolve() for path in attachment_dir.iterdir()] == [
+        Path(winner["payload"]["screenshot"]["path"]).resolve()
+    ]
 
 
 def test_show_event_store_materializes_webp_without_conversion(isolated_state):
@@ -992,6 +1045,117 @@ def test_show_event_store_rejects_reused_id_with_different_contents(isolated_sta
     assert stored["payload"]["comment"] == "Deliver the original annotation."
 
 
+def test_show_event_store_fingerprint_includes_sibling_anchor(isolated_state):
+    _seed_session("ses_show_anchor_conflict")
+    original = {
+        "id": "show_evt_anchor_identity",
+        "type": "human.annotation.created",
+        "anchor": {"selector": "#summary"},
+        "annotation": {
+            "intent": "comment",
+            "comment": "Review this target.",
+            "dispatch": True,
+        },
+    }
+    store = ShowSessionEventStore()
+    try:
+        store.append("ses_show_anchor_conflict", original, reserve_dispatch=True)
+        with pytest.raises(ShowSessionEventError) as exc_info:
+            store.append(
+                "ses_show_anchor_conflict",
+                {**original, "anchor": {"selector": "#other"}},
+                reserve_dispatch=True,
+            )
+    finally:
+        store.close()
+
+    assert exc_info.value.code == "event_id_conflict"
+
+
+def test_show_dispatch_state_owns_claim_recovery_and_acceptance(
+    isolated_state,
+    monkeypatch,
+):
+    import core.show_session_events as show_events
+
+    _seed_session("ses_show_state")
+    store = ShowSessionEventStore()
+    try:
+        event = store.append(
+            "ses_show_state",
+            {
+                "id": "show_evt_state_machine",
+                "type": "human.annotation.created",
+                "annotation": {
+                    "intent": "comment",
+                    "comment": "Dispatch exactly once.",
+                    "dispatch": True,
+                },
+            },
+            reserve_dispatch=True,
+        )
+    finally:
+        store.close()
+
+    engine = create_sqlite_engine()
+    with engine.begin() as conn:
+        initial = show_events.get_show_dispatch_status(
+            conn,
+            event["id"],
+            session_id="ses_show_state",
+        )
+        first = claim_show_dispatch(
+            conn,
+            event["id"],
+            session_id="ses_show_state",
+            owner="101:1.0",
+        )
+    assert initial is not None and initial.state == DISPATCH_NONE
+    assert first is not None and first.claimed
+    assert first.state == DISPATCH_IN_FLIGHT
+    assert first.claimed_at
+
+    monkeypatch.setattr(show_events, "_show_dispatch_owner_is_alive", lambda owner: True)
+    with engine.begin() as conn:
+        live = claim_show_dispatch(
+            conn,
+            event["id"],
+            session_id="ses_show_state",
+            owner="202:2.0",
+        )
+    assert live is not None and not live.claimed
+    assert live.owner == "101:1.0"
+
+    monkeypatch.setattr(show_events, "_show_dispatch_owner_is_alive", lambda owner: False)
+    monkeypatch.setattr(show_events, "_show_dispatch_claim_is_stale", lambda claimed_at: True)
+    with engine.begin() as conn:
+        recovered = claim_show_dispatch(
+            conn,
+            event["id"],
+            session_id="ses_show_state",
+            owner="202:2.0",
+        )
+        assert recovered is not None and recovered.claimed
+        assert accept_show_dispatch(
+            conn,
+            event["id"],
+            session_id="ses_show_state",
+            owner="202:2.0",
+        )
+        assert not fail_show_dispatch(
+            conn,
+            event["id"],
+            session_id="ses_show_state",
+            owner="202:2.0",
+        )
+        accepted = show_events.get_show_dispatch_status(
+            conn,
+            event["id"],
+            session_id="ses_show_state",
+        )
+    assert accepted is not None and accepted.state == DISPATCH_ACCEPTED
+
+
 def test_direct_dispatching_show_event_stays_visible_without_reservation(isolated_state):
     from storage import messages_service
 
@@ -1029,14 +1193,13 @@ def test_record_local_show_event_dispatch_sync_uses_unified_entry(isolated_state
     monkeypatch.setattr(broker, "publish", lambda event, data: published.append((event, data)))
 
     async def fake_dispatch_async(payload, **kwargs):
-        from storage import messages_service
-
         dispatches.append(payload)
         with create_sqlite_engine().begin() as conn:
-            assert messages_service.accept_dispatch_reservation(
+            assert accept_show_dispatch(
                 conn,
-                payload["user_message_id"],
-                "user",
+                payload["show_event_id"],
+                session_id=payload["session_id"],
+                owner=payload["dispatch_owner"],
             )
         return {"status_code": 202, "body": {"ok": True}}
 
@@ -1088,18 +1251,15 @@ def test_record_local_show_event_reports_failed_sync_dispatch_with_retryable_rec
     store = ShowSessionEventStore()
     try:
         stored_event = store.list("ses_show")["events"][0]
+        dispatch_status = store.get_dispatch_status("ses_show", stored_event["id"])
     finally:
         store.close()
     with create_sqlite_engine().connect() as conn:
-        failed = messages_service.list_session_messages(
-            conn,
-            session_id="ses_show",
-            types=(messages_service.DISPATCH_FAILED_TYPE,),
-        )
         visible = messages_service.list_session_messages(conn, session_id="ses_show", types=("user",))
         queued = messages_service.list_queued(conn, "ses_show")
-    assert [row["text"] for row in failed["messages"]] == [stored_event["transcript_text"]]
-    assert visible["messages"] == []
+    assert dispatch_status is not None
+    assert dispatch_status.state == DISPATCH_FAILED
+    assert [row["text"] for row in visible["messages"]] == [stored_event["transcript_text"]]
     assert queued == []
 
 
@@ -1141,11 +1301,14 @@ def test_ambiguous_show_dispatch_stays_in_flight_and_is_not_resubmitted(
     store = ShowSessionEventStore()
     try:
         event = store.get_event("ses_show", payload["id"])
+        dispatch_status = store.get_dispatch_status("ses_show", payload["id"])
     finally:
         store.close()
     assert attempts == 1
     assert event is not None
-    assert event["message"]["type"] == messages_service.DISPATCHING_TYPE
+    assert event["message"]["type"] == messages_service.PENDING_TYPE
+    assert dispatch_status is not None
+    assert dispatch_status.state == DISPATCH_IN_FLIGHT
     with create_sqlite_engine().connect() as conn:
         visible = messages_service.list_session_messages(
             conn,
@@ -1166,34 +1329,9 @@ def test_ambiguous_show_dispatch_stays_in_flight_and_is_not_resubmitted(
         ("approve", False),
     ],
 )
-def test_annotation_dispatch_text_adds_event_id_and_optional_reply_guidance(monkeypatch, intent, expects_guidance):
-    import asyncio
+def test_annotation_dispatch_text_adds_event_id_and_optional_reply_guidance(intent, expects_guidance):
+    from vibe import ui_server
 
-    from storage import messages_service
-    from vibe import internal_client, ui_server
-
-    captured = []
-
-    async def fake_dispatch_async(payload, **kwargs):
-        captured.append(payload)
-        return {"status_code": 202, "body": {"ok": True}}
-
-    monkeypatch.setattr(internal_client, "dispatch_async", fake_dispatch_async)
-    monkeypatch.setattr(
-        messages_service,
-        "claim_dispatch_reservation",
-        lambda conn, message_id: (messages_service.DISPATCHING_TYPE, True),
-    )
-    monkeypatch.setattr(
-        ui_server,
-        "_load_show_event_message",
-        lambda event: {"id": "m1", "type": "user"},
-    )
-    monkeypatch.setattr(
-        ui_server,
-        "_publish_accepted_user_message",
-        lambda row, **kwargs: row,
-    )
     label = intent or "comment"
     event = {
         "id": "show_evt_1a2b3c4d",
@@ -1206,15 +1344,15 @@ def test_annotation_dispatch_text_adds_event_id_and_optional_reply_guidance(monk
         "message": {"id": "m1", "type": "pending"},
     }
 
-    asyncio.run(ui_server._run_show_event_dispatch(event))
+    dispatch_text = ui_server._show_event_dispatch_text(event)
 
     assert event["transcript_text"] == f"[show-annotation] {label}\n\nReview this."
-    assert "Show event id: show_evt_1a2b3c4d" in captured[0]["text"]
+    assert "Show event id: show_evt_1a2b3c4d" in dispatch_text
     guidance = (
         "如需在页面上原位回应，可执行：\n"
         "  vibe show reply show_evt_1a2b3c4d --message '<你的回答>'\n"
         "（也可以直接修改页面内容来响应，按场景选择。）"
     )
-    assert (guidance in captured[0]["text"]) is expects_guidance
+    assert (guidance in dispatch_text) is expects_guidance
     if expects_guidance:
-        assert captured[0]["text"].endswith(guidance)
+        assert dispatch_text.endswith(guidance)

--- a/tests/test_show_session_events.py
+++ b/tests/test_show_session_events.py
@@ -734,6 +734,7 @@ def test_show_event_store_records_intent_dispatch_payload(isolated_state):
                     "dispatch": True,
                 },
             },
+            reserve_dispatch=True,
         )
     finally:
         store.close()
@@ -893,6 +894,7 @@ def test_dispatching_show_event_reserves_pending_transcript_row(isolated_state):
                 "type": "human.annotation.created",
                 "annotation": {"intent": "comment", "comment": "Queue this.", "dispatch": True},
             },
+            reserve_dispatch=True,
         )
         non_dispatching = store.append(
             "ses_show",
@@ -912,6 +914,30 @@ def test_dispatching_show_event_reserves_pending_transcript_row(isolated_state):
         queued = messages_service.list_queued(conn, "ses_show")
     assert [message["text"] for message in visible["messages"]] == [non_dispatching["transcript_text"]]
     assert queued == []
+
+
+def test_dispatching_show_event_requires_unified_turn_entry(isolated_state):
+    _seed_session("ses_show")
+    store = ShowSessionEventStore()
+    try:
+        with pytest.raises(ShowSessionEventError) as exc_info:
+            store.append(
+                "ses_show",
+                {
+                    "type": "human.annotation.created",
+                    "annotation": {
+                        "intent": "comment",
+                        "comment": "Do not strand this.",
+                        "dispatch": True,
+                    },
+                },
+            )
+        events = store.list("ses_show")
+    finally:
+        store.close()
+
+    assert exc_info.value.code == "dispatch_requires_turn_entry"
+    assert events["events"] == []
 
 
 def test_record_local_show_event_dispatch_sync_uses_unified_entry(isolated_state, monkeypatch):

--- a/tests/test_show_session_events.py
+++ b/tests/test_show_session_events.py
@@ -12,9 +12,12 @@ from sqlalchemy import select
 
 from core.show_session_events import (
     DISPATCH_ACCEPTED,
+    DISPATCH_ARCHIVED,
     DISPATCH_FAILED,
     DISPATCH_IN_FLIGHT,
     DISPATCH_NONE,
+    ShowDispatchSettlement,
+    ShowDispatchStatus,
     ShowSessionEventError,
     ShowSessionEventStore,
     _format_transcript_text,
@@ -1160,6 +1163,76 @@ def test_show_dispatch_state_owns_claim_recovery_and_acceptance(
     assert accepted is not None and accepted.state == DISPATCH_ACCEPTED
 
 
+@pytest.mark.parametrize("initial_state", (DISPATCH_NONE, DISPATCH_FAILED))
+def test_claim_persists_archived_when_session_was_archived_before_claim(
+    isolated_state,
+    initial_state,
+):
+    from core.services import sessions as sessions_service
+
+    _seed_session("ses_show_preclaim_archive")
+    store = ShowSessionEventStore()
+    try:
+        event = store.append(
+            "ses_show_preclaim_archive",
+            {
+                "id": f"show_evt_preclaim_archive_{initial_state}",
+                "type": "human.annotation.created",
+                "annotation": {
+                    "comment": "This session was archived before dispatch.",
+                    "dispatch": True,
+                },
+            },
+            reserve_dispatch=True,
+        )
+    finally:
+        store.close()
+
+    engine = create_sqlite_engine()
+    with engine.begin() as conn:
+        if initial_state == DISPATCH_FAILED:
+            first = claim_show_dispatch(
+                conn,
+                event["id"],
+                session_id="ses_show_preclaim_archive",
+                owner="1:old-process:failed-attempt",
+            )
+            assert first is not None and first.claimed
+            assert settle_show_dispatch(
+                conn,
+                event["id"],
+                session_id="ses_show_preclaim_archive",
+                owner="1:old-process:failed-attempt",
+                state=DISPATCH_FAILED,
+            )
+        sessions_service.archive_session(
+            conn,
+            "ses_show_preclaim_archive",
+        )
+
+    with engine.begin() as conn:
+        archived = claim_show_dispatch(
+            conn,
+            event["id"],
+            session_id="ses_show_preclaim_archive",
+            owner="1:new-process:retry-attempt",
+        )
+
+    assert archived is not None
+    assert archived.state == DISPATCH_ARCHIVED
+    assert archived.claimed is False
+    store = ShowSessionEventStore()
+    try:
+        persisted = store.get_dispatch_status(
+            "ses_show_preclaim_archive",
+            event["id"],
+        )
+    finally:
+        store.close()
+    assert persisted is not None
+    assert persisted.state == DISPATCH_ARCHIVED
+
+
 def test_same_process_show_dispatch_claim_uses_live_attempt_not_age(
     isolated_state,
     monkeypatch,
@@ -1251,6 +1324,148 @@ def test_localized_show_event_errors_follow_configured_language(
     assert str(conflict) == "此 Show 事件 ID 已绑定到不同的事件内容。"
     assert pending.code == "show_event_dispatch_pending"
     assert str(pending) == "Show 事件可能仍在处理中，未在本地重复提交。"
+
+
+@pytest.mark.parametrize(
+    (
+        "state",
+        "message_type",
+        "promoted",
+        "publish_message",
+        "publish_queue",
+        "report_success",
+    ),
+    [
+        (DISPATCH_NONE, "pending", False, False, False, False),
+        (DISPATCH_IN_FLIGHT, "pending", False, False, False, False),
+        (DISPATCH_ACCEPTED, "pending", False, False, False, False),
+        (DISPATCH_ACCEPTED, "user", True, True, False, True),
+        (DISPATCH_ACCEPTED, "user", False, False, False, True),
+        (DISPATCH_ACCEPTED, "queued", False, False, True, True),
+        (DISPATCH_FAILED, "user", True, True, False, False),
+        (DISPATCH_ARCHIVED, "user", False, False, False, False),
+    ],
+)
+def test_show_dispatch_outward_promises_derive_from_observed_settlement(
+    state,
+    message_type,
+    promoted,
+    publish_message,
+    publish_queue,
+    report_success,
+):
+    settlement = ShowDispatchSettlement(
+        status=ShowDispatchStatus(state=state),
+        message={"id": "msg_settlement", "type": message_type},
+        message_promoted=promoted,
+    )
+
+    assert settlement.can_publish_message_new is publish_message
+    assert settlement.can_publish_queue_updated is publish_queue
+    assert settlement.can_report_success is report_success
+
+
+def test_startup_reconciles_accepted_dispatch_with_pending_transcript(
+    isolated_state,
+):
+    from storage import messages_service
+    from vibe import ui_server
+
+    _seed_session("ses_show_restart")
+    store = ShowSessionEventStore()
+    try:
+        event = store.append(
+            "ses_show_restart",
+            {
+                "id": "show_evt_restart_reconcile",
+                "type": "human.annotation.created",
+                "annotation": {
+                    "comment": "Recover my accepted prompt after restart.",
+                    "dispatch": True,
+                },
+            },
+            reserve_dispatch=True,
+        )
+    finally:
+        store.close()
+
+    with create_sqlite_engine().begin() as conn:
+        claimed = claim_show_dispatch(
+            conn,
+            event["id"],
+            session_id="ses_show_restart",
+            owner="1:old-process:attempt",
+        )
+        assert claimed is not None and claimed.claimed
+        assert settle_show_dispatch(
+            conn,
+            event["id"],
+            session_id="ses_show_restart",
+            owner="1:old-process:attempt",
+            state=DISPATCH_ACCEPTED,
+        )
+    assert event["message"]["type"] == messages_service.PENDING_TYPE
+
+    ui_server.reconcile_show_dispatch_messages_on_startup()
+
+    restarted_store = ShowSessionEventStore()
+    try:
+        recovered = restarted_store.get_event(
+            "ses_show_restart",
+            event["id"],
+        )
+    finally:
+        restarted_store.close()
+    assert recovered is not None
+    assert recovered["message"]["type"] == "user"
+
+
+def test_cli_reports_accepted_dispatch_only_after_linked_message_reconciles(
+    isolated_state,
+):
+    from vibe import cli
+
+    _seed_session("ses_show_cli_settlement")
+    store = ShowSessionEventStore()
+    try:
+        event = store.append(
+            "ses_show_cli_settlement",
+            {
+                "id": "show_evt_cli_settlement",
+                "type": "human.annotation.created",
+                "annotation": {
+                    "comment": "Do not report success while I am hidden.",
+                    "dispatch": True,
+                },
+            },
+            reserve_dispatch=True,
+        )
+    finally:
+        store.close()
+
+    with create_sqlite_engine().begin() as conn:
+        claimed = claim_show_dispatch(
+            conn,
+            event["id"],
+            session_id="ses_show_cli_settlement",
+            owner="1:cli-process:attempt",
+        )
+        assert claimed is not None and claimed.claimed
+        assert settle_show_dispatch(
+            conn,
+            event["id"],
+            session_id="ses_show_cli_settlement",
+            owner="1:cli-process:attempt",
+            state=DISPATCH_ACCEPTED,
+        )
+
+    recovered = cli._resolve_show_event_after_ambiguous_live_timeout(
+        "ses_show_cli_settlement",
+        {"id": event["id"]},
+        wait_seconds=0,
+    )
+    assert recovered is not None
+    assert recovered["message"]["type"] == "user"
 
 
 def test_concurrent_show_dispatch_replay_reports_in_flight_without_resubmit(

--- a/tests/test_show_session_events.py
+++ b/tests/test_show_session_events.py
@@ -18,10 +18,9 @@ from core.show_session_events import (
     ShowSessionEventError,
     ShowSessionEventStore,
     _format_transcript_text,
-    accept_show_dispatch,
     claim_show_dispatch,
-    fail_show_dispatch,
     localized_show_event_error,
+    settle_show_dispatch,
     show_dispatch_attempt,
     show_event_requests_dispatch,
 )
@@ -1139,17 +1138,19 @@ def test_show_dispatch_state_owns_claim_recovery_and_acceptance(
             owner="202:2.0",
         )
         assert recovered is not None and recovered.claimed
-        assert accept_show_dispatch(
+        assert settle_show_dispatch(
             conn,
             event["id"],
             session_id="ses_show_state",
             owner="202:2.0",
+            state=DISPATCH_ACCEPTED,
         )
-        assert not fail_show_dispatch(
+        assert not settle_show_dispatch(
             conn,
             event["id"],
             session_id="ses_show_state",
             owner="202:2.0",
+            state=DISPATCH_FAILED,
         )
         accepted = show_events.get_show_dispatch_status(
             conn,
@@ -1288,11 +1289,12 @@ def test_concurrent_show_dispatch_replay_reports_in_flight_without_resubmit(
             dispatch_entered.set()
             await release_dispatch.wait()
             with engine.begin() as conn:
-                assert accept_show_dispatch(
+                assert settle_show_dispatch(
                     conn,
                     payload["show_event_id"],
                     session_id=payload["session_id"],
                     owner=payload["dispatch_owner"],
+                    state=DISPATCH_ACCEPTED,
                 )
             return {"status_code": 202, "body": {"ok": True}}
 
@@ -1359,11 +1361,12 @@ def test_cancelled_show_dispatch_attempt_is_immediately_reclaimable(
 
         async def accepted_dispatch(payload, **_kwargs):
             with engine.begin() as conn:
-                assert accept_show_dispatch(
+                assert settle_show_dispatch(
                     conn,
                     payload["show_event_id"],
                     session_id=payload["session_id"],
                     owner=payload["dispatch_owner"],
+                    state=DISPATCH_ACCEPTED,
                 )
             return {"status_code": 202, "body": {"ok": True}}
 
@@ -1412,11 +1415,12 @@ def test_record_local_show_event_dispatch_sync_uses_unified_entry(isolated_state
     async def fake_dispatch_async(payload, **kwargs):
         dispatches.append(payload)
         with create_sqlite_engine().begin() as conn:
-            assert accept_show_dispatch(
+            assert settle_show_dispatch(
                 conn,
                 payload["show_event_id"],
                 session_id=payload["session_id"],
                 owner=payload["dispatch_owner"],
+                state=DISPATCH_ACCEPTED,
             )
         return {"status_code": 202, "body": {"ok": True}}
 

--- a/tests/test_show_session_events.py
+++ b/tests/test_show_session_events.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import base64
 import json
 import struct
@@ -20,6 +21,8 @@ from core.show_session_events import (
     accept_show_dispatch,
     claim_show_dispatch,
     fail_show_dispatch,
+    localized_show_event_error,
+    show_dispatch_attempt,
     show_event_requests_dispatch,
 )
 from storage.db import create_sqlite_engine
@@ -1156,6 +1159,220 @@ def test_show_dispatch_state_owns_claim_recovery_and_acceptance(
     assert accepted is not None and accepted.state == DISPATCH_ACCEPTED
 
 
+def test_same_process_show_dispatch_claim_uses_live_attempt_not_age(
+    isolated_state,
+    monkeypatch,
+):
+    from core import show_session_events as show_events
+
+    _seed_session("ses_show_attempt")
+    store = ShowSessionEventStore()
+    try:
+        event = store.append(
+            "ses_show_attempt",
+            {
+                "id": "show_evt_attempt_identity",
+                "type": "human.annotation.created",
+                "annotation": {
+                    "comment": "Keep a slow live attempt exclusive.",
+                    "dispatch": True,
+                },
+            },
+            reserve_dispatch=True,
+        )
+    finally:
+        store.close()
+
+    engine = create_sqlite_engine()
+    monkeypatch.setattr(
+        show_events,
+        "_show_dispatch_claim_is_stale",
+        lambda _claimed_at: True,
+    )
+    with show_dispatch_attempt() as live_owner:
+        with engine.begin() as conn:
+            first = claim_show_dispatch(
+                conn,
+                event["id"],
+                session_id="ses_show_attempt",
+                owner=live_owner,
+            )
+        assert first is not None and first.claimed
+
+        with show_dispatch_attempt() as competing_owner:
+            with engine.begin() as conn:
+                blocked = claim_show_dispatch(
+                    conn,
+                    event["id"],
+                    session_id="ses_show_attempt",
+                    owner=competing_owner,
+                )
+        assert blocked is not None and not blocked.claimed
+        assert blocked.owner == live_owner
+
+    monkeypatch.setattr(
+        show_events,
+        "_show_dispatch_claim_is_stale",
+        lambda _claimed_at: False,
+    )
+    monkeypatch.setattr(
+        show_events,
+        "_show_dispatch_owner_is_alive",
+        lambda _owner: True,
+    )
+    with show_dispatch_attempt() as retry_owner:
+        with engine.begin() as conn:
+            recovered = claim_show_dispatch(
+                conn,
+                event["id"],
+                session_id="ses_show_attempt",
+                owner=retry_owner,
+            )
+        assert recovered is not None and recovered.claimed
+        assert recovered.owner == retry_owner
+
+
+def test_localized_show_event_errors_follow_configured_language(
+    monkeypatch,
+):
+    class _Config:
+        language = "zh"
+
+    monkeypatch.setattr(
+        "core.show_session_events.V2Config.load",
+        lambda: _Config(),
+    )
+
+    conflict = localized_show_event_error("event_id_conflict")
+    pending = localized_show_event_error("show_event_dispatch_pending")
+
+    assert conflict.code == "event_id_conflict"
+    assert str(conflict) == "此 Show 事件 ID 已绑定到不同的事件内容。"
+    assert pending.code == "show_event_dispatch_pending"
+    assert str(pending) == "Show 事件可能仍在处理中，未在本地重复提交。"
+
+
+def test_concurrent_show_dispatch_replay_reports_in_flight_without_resubmit(
+    isolated_state,
+    monkeypatch,
+):
+    from vibe import internal_client, ui_server
+
+    _seed_session("ses_show_concurrent")
+    store = ShowSessionEventStore()
+    try:
+        event = store.append(
+            "ses_show_concurrent",
+            {
+                "id": "show_evt_concurrent_attempt",
+                "type": "human.annotation.created",
+                "annotation": {
+                    "comment": "Submit this once while the first call is active.",
+                    "dispatch": True,
+                },
+            },
+            reserve_dispatch=True,
+        )
+    finally:
+        store.close()
+
+    engine = create_sqlite_engine()
+
+    async def _go():
+        dispatch_entered = asyncio.Event()
+        release_dispatch = asyncio.Event()
+        dispatches = []
+
+        async def slow_dispatch(payload, **_kwargs):
+            dispatches.append(payload)
+            dispatch_entered.set()
+            await release_dispatch.wait()
+            with engine.begin() as conn:
+                assert accept_show_dispatch(
+                    conn,
+                    payload["show_event_id"],
+                    session_id=payload["session_id"],
+                    owner=payload["dispatch_owner"],
+                )
+            return {"status_code": 202, "body": {"ok": True}}
+
+        monkeypatch.setattr(internal_client, "dispatch_async", slow_dispatch)
+        first_task = asyncio.create_task(
+            ui_server._run_show_event_dispatch(event),
+        )
+        await asyncio.wait_for(dispatch_entered.wait(), timeout=1)
+        replay = await ui_server._run_show_event_dispatch(event)
+        assert replay is ui_server._ShowEventDispatchOutcome.IN_FLIGHT
+        assert len(dispatches) == 1
+        release_dispatch.set()
+        first = await asyncio.wait_for(first_task, timeout=1)
+        return first, replay, dispatches
+
+    first, replay, dispatches = asyncio.run(_go())
+
+    assert first is ui_server._ShowEventDispatchOutcome.ACCEPTED
+    assert replay is ui_server._ShowEventDispatchOutcome.IN_FLIGHT
+    assert len(dispatches) == 1
+
+
+def test_cancelled_show_dispatch_attempt_is_immediately_reclaimable(
+    isolated_state,
+    monkeypatch,
+):
+    from vibe import internal_client, ui_server
+
+    _seed_session("ses_show_cancelled")
+    store = ShowSessionEventStore()
+    try:
+        event = store.append(
+            "ses_show_cancelled",
+            {
+                "id": "show_evt_cancelled_attempt",
+                "type": "human.annotation.created",
+                "annotation": {
+                    "comment": "Retry after the first caller is cancelled.",
+                    "dispatch": True,
+                },
+            },
+            reserve_dispatch=True,
+        )
+    finally:
+        store.close()
+
+    engine = create_sqlite_engine()
+
+    async def _go():
+        dispatch_entered = asyncio.Event()
+
+        async def cancelled_dispatch(_payload, **_kwargs):
+            dispatch_entered.set()
+            await asyncio.Future()
+
+        monkeypatch.setattr(internal_client, "dispatch_async", cancelled_dispatch)
+        abandoned = asyncio.create_task(
+            ui_server._run_show_event_dispatch(event),
+        )
+        await asyncio.wait_for(dispatch_entered.wait(), timeout=1)
+        abandoned.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await abandoned
+
+        async def accepted_dispatch(payload, **_kwargs):
+            with engine.begin() as conn:
+                assert accept_show_dispatch(
+                    conn,
+                    payload["show_event_id"],
+                    session_id=payload["session_id"],
+                    owner=payload["dispatch_owner"],
+                )
+            return {"status_code": 202, "body": {"ok": True}}
+
+        monkeypatch.setattr(internal_client, "dispatch_async", accepted_dispatch)
+        return await ui_server._run_show_event_dispatch(event)
+
+    assert asyncio.run(_go()) is ui_server._ShowEventDispatchOutcome.ACCEPTED
+
+
 def test_direct_dispatching_show_event_stays_visible_without_reservation(isolated_state):
     from storage import messages_service
 
@@ -1263,7 +1480,7 @@ def test_record_local_show_event_reports_failed_sync_dispatch_with_retryable_rec
     assert queued == []
 
 
-def test_ambiguous_show_dispatch_stays_in_flight_and_is_not_resubmitted(
+def test_ended_ambiguous_show_dispatch_attempt_is_immediately_retryable(
     isolated_state,
     monkeypatch,
 ):
@@ -1296,7 +1513,7 @@ def test_ambiguous_show_dispatch_stays_in_flight_and_is_not_resubmitted(
                 payload,
                 dispatch_sync=True,
             )
-        assert exc_info.value.code == "show_event_dispatch_failed"
+        assert exc_info.value.code == "show_event_dispatch_pending"
 
     store = ShowSessionEventStore()
     try:
@@ -1304,7 +1521,7 @@ def test_ambiguous_show_dispatch_stays_in_flight_and_is_not_resubmitted(
         dispatch_status = store.get_dispatch_status("ses_show", payload["id"])
     finally:
         store.close()
-    assert attempts == 1
+    assert attempts == 2
     assert event is not None
     assert event["message"]["type"] == messages_service.PENDING_TYPE
     assert dispatch_status is not None

--- a/tests/test_sqlite_state_migration.py
+++ b/tests/test_sqlite_state_migration.py
@@ -19,7 +19,7 @@ from storage.models import metadata
 from storage.settings_service import SQLiteSettingsService
 
 
-HEAD_REVISION = "20260724_0034"
+HEAD_REVISION = "20260726_0035"
 
 
 def _index_sql(conn: sqlite3.Connection, name: str) -> str:
@@ -134,6 +134,14 @@ def test_run_migrations_creates_initial_schema(tmp_path: Path) -> None:
         assert "width_px" in media_columns  # 20260604_0015: zero-shift image box
         assert "height_px" in media_columns
         assert media_scope_not_null == 0  # standalone sessions can own uploads
+        show_event_columns = {
+            row[1]: row for row in conn.execute("pragma table_info(show_session_events)")
+        }
+        assert show_event_columns["dispatch_state"][3] == 1
+        assert (
+            str(show_event_columns["dispatch_state"][4]).strip("'")
+            == '{"state":"none"}'
+        )
         background_columns = {
             row[1]
             for row in conn.execute(

--- a/tests/test_sqlite_state_migration.py
+++ b/tests/test_sqlite_state_migration.py
@@ -153,6 +153,54 @@ def test_run_migrations_creates_initial_schema(tmp_path: Path) -> None:
         assert version == (HEAD_REVISION,)
 
 
+def test_show_dispatch_state_migration_accepts_legacy_rows_and_defaults_new_rows(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "vibe.sqlite"
+    run_migrations(db_path, revision="20260724_0034")
+    now = "2026-07-26T00:00:00Z"
+
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """
+            insert into show_session_events (
+                id, session_id, event_type, actor, scope, anchor_json,
+                payload_json, transcript_text, message_id, created_at
+            ) values (
+                'show_evt_legacy', 'ses_legacy', 'human.annotation.created',
+                'human', 'default', '{}', '{}', 'Legacy annotation', null, ?
+            )
+            """,
+            (now,),
+        )
+        conn.commit()
+
+    run_migrations(db_path)
+
+    with sqlite3.connect(db_path) as conn:
+        legacy_state = conn.execute(
+            "select dispatch_state from show_session_events where id = 'show_evt_legacy'"
+        ).fetchone()
+        conn.execute(
+            """
+            insert into show_session_events (
+                id, session_id, event_type, actor, scope, anchor_json,
+                payload_json, transcript_text, message_id, created_at
+            ) values (
+                'show_evt_new', 'ses_new', 'human.annotation.created',
+                'human', 'default', '{}', '{}', 'New annotation', null, ?
+            )
+            """,
+            (now,),
+        )
+        new_state = conn.execute(
+            "select dispatch_state from show_session_events where id = 'show_evt_new'"
+        ).fetchone()
+
+    assert legacy_state == ('{"state":"accepted"}',)
+    assert new_state == ('{"state":"none"}',)
+
+
 def test_session_pinning_migration_preserves_existing_sessions_as_unpinned(tmp_path: Path) -> None:
     db_path = tmp_path / "vibe.sqlite"
     run_migrations(db_path, revision="20260723_0033")

--- a/tests/test_ui_session_stream.py
+++ b/tests/test_ui_session_stream.py
@@ -146,14 +146,14 @@ def test_route_enqueues_when_turn_in_progress(isolated_state, tmp_path):
     _, session_id = _make_session(tmp_path)
 
     async def dispatch(payload):
-        from storage import messages_service
+        from core.session_turns import queue_pending_user_message
         from storage.db import create_sqlite_engine
 
         with create_sqlite_engine().begin() as conn:
-            assert messages_service.accept_dispatch_reservation(
+            assert queue_pending_user_message(
                 conn,
                 payload["user_message_id"],
-                messages_service.QUEUED_TYPE,
+                payload["text"],
             )
         return {"status_code": 202, "body": {"ok": True, "queued": True}}
 

--- a/tests/test_ui_session_stream.py
+++ b/tests/test_ui_session_stream.py
@@ -145,7 +145,19 @@ def test_route_enqueues_when_turn_in_progress(isolated_state, tmp_path):
 
     _, session_id = _make_session(tmp_path)
 
-    dispatch_mock = AsyncMock(return_value={"status_code": 202, "body": {"ok": True, "queued": True}})
+    async def dispatch(payload):
+        from storage import messages_service
+        from storage.db import create_sqlite_engine
+
+        with create_sqlite_engine().begin() as conn:
+            assert messages_service.accept_dispatch_reservation(
+                conn,
+                payload["user_message_id"],
+                messages_service.QUEUED_TYPE,
+            )
+        return {"status_code": 202, "body": {"ok": True, "queued": True}}
+
+    dispatch_mock = AsyncMock(side_effect=dispatch)
     with patch("vibe.internal_client.dispatch_async", dispatch_mock):
         client = app.test_client()
         headers = csrf_headers(client)

--- a/tests/test_ui_session_stream.py
+++ b/tests/test_ui_session_stream.py
@@ -178,7 +178,64 @@ def test_route_enqueues_when_turn_in_progress(isolated_state, tmp_path):
     assert sent["user_message_id"] == body["id"]
 
 
-def test_route_timeout_never_publishes_unsettled_pending_row(
+@pytest.mark.parametrize(
+    ("error_kind", "expected_status"),
+    (("timeout", 504), ("ambiguous", 502)),
+)
+def test_route_ambiguous_failure_settles_unowned_pending_visible_without_queueing(
+    isolated_state,
+    tmp_path,
+    monkeypatch,
+    error_kind,
+    expected_status,
+):
+    from storage import messages_service
+    from storage.db import create_sqlite_engine
+    from vibe import internal_client
+    from vibe.ui_server import app
+
+    _, session_id = _make_session(tmp_path)
+    published = []
+
+    async def fail_after_connect(_payload):
+        if error_kind == "timeout":
+            raise internal_client.InternalServerTimeout("acceptance unknown")
+        raise RuntimeError("ambiguous response")
+
+    monkeypatch.setattr(
+        "vibe.sse_broker.broker.publish",
+        lambda event_type, data: published.append((event_type, data)),
+    )
+    dispatch_mock = AsyncMock(side_effect=fail_after_connect)
+    with patch("vibe.internal_client.dispatch_async", dispatch_mock):
+        client = app.test_client()
+        response = client.post(
+            f"/api/sessions/{session_id}/messages",
+            json={"text": "settle this after the timeout"},
+            headers=csrf_headers(client),
+        )
+
+    assert response.status_code == expected_status
+    body = response.get_json()
+    assert body["dispatch_error"] == "dispatch_pending"
+    assert body["type"] == "user"
+    dispatch_mock.assert_awaited_once()
+
+    with create_sqlite_engine().connect() as conn:
+        queued = messages_service.list_queued(conn, session_id)
+        visible = messages_service.list_session_messages(
+            conn,
+            session_id=session_id,
+            around_id=body["id"],
+            limit=1,
+            types=messages_service.TRANSCRIPT_TYPES,
+        )
+    assert queued == []
+    assert [row["id"] for row in visible["messages"]] == [body["id"]]
+    assert [event_type for event_type, _data in published].count("message.new") == 1
+
+
+def test_route_timeout_observes_controller_queue_without_republishing(
     isolated_state,
     tmp_path,
     monkeypatch,
@@ -192,36 +249,39 @@ def test_route_timeout_never_publishes_unsettled_pending_row(
     _, session_id = _make_session(tmp_path)
     published = []
 
-    async def timeout_after_connect(_payload):
-        raise internal_client.InternalServerTimeout("acceptance unknown")
+    async def timeout_after_controller_queues(payload):
+        with create_sqlite_engine().begin() as conn:
+            assert queue_pending_user_message(
+                conn,
+                payload["user_message_id"],
+                payload["text"],
+            )
+        raise internal_client.InternalServerTimeout("response lost after enqueue")
 
     monkeypatch.setattr(
         "vibe.sse_broker.broker.publish",
         lambda event_type, data: published.append((event_type, data)),
     )
-    with patch("vibe.internal_client.dispatch_async", timeout_after_connect):
+    dispatch_mock = AsyncMock(side_effect=timeout_after_controller_queues)
+    with patch("vibe.internal_client.dispatch_async", dispatch_mock):
         client = app.test_client()
         response = client.post(
             f"/api/sessions/{session_id}/messages",
-            json={"text": "settle this after the timeout"},
+            json={"text": "already queued by the controller"},
             headers=csrf_headers(client),
         )
 
     assert response.status_code == 504
     body = response.get_json()
     assert body["dispatch_error"] == "dispatch_pending"
-    assert body["type"] == messages_service.PENDING_TYPE
-    assert all(event_type != "message.new" for event_type, _data in published)
+    assert body["type"] == messages_service.QUEUED_TYPE
+    dispatch_mock.assert_awaited_once()
 
-    with create_sqlite_engine().begin() as conn:
-        assert queue_pending_user_message(
-            conn,
-            body["id"],
-            body["text"],
-        )
+    with create_sqlite_engine().connect() as conn:
         queued = messages_service.list_queued(conn, session_id)
     assert [row["id"] for row in queued] == [body["id"]]
-    assert all(event_type != "message.new" for event_type, _data in published)
+    assert "message.new" not in [event_type for event_type, _data in published]
+    assert [event_type for event_type, _data in published].count("queue.updated") == 1
 
 
 def test_create_session_without_backend_defers_to_default_agent(isolated_state, tmp_path):

--- a/tests/test_ui_session_stream.py
+++ b/tests/test_ui_session_stream.py
@@ -178,6 +178,52 @@ def test_route_enqueues_when_turn_in_progress(isolated_state, tmp_path):
     assert sent["user_message_id"] == body["id"]
 
 
+def test_route_timeout_never_publishes_unsettled_pending_row(
+    isolated_state,
+    tmp_path,
+    monkeypatch,
+):
+    from core.session_turns import queue_pending_user_message
+    from storage import messages_service
+    from storage.db import create_sqlite_engine
+    from vibe import internal_client
+    from vibe.ui_server import app
+
+    _, session_id = _make_session(tmp_path)
+    published = []
+
+    async def timeout_after_connect(_payload):
+        raise internal_client.InternalServerTimeout("acceptance unknown")
+
+    monkeypatch.setattr(
+        "vibe.sse_broker.broker.publish",
+        lambda event_type, data: published.append((event_type, data)),
+    )
+    with patch("vibe.internal_client.dispatch_async", timeout_after_connect):
+        client = app.test_client()
+        response = client.post(
+            f"/api/sessions/{session_id}/messages",
+            json={"text": "settle this after the timeout"},
+            headers=csrf_headers(client),
+        )
+
+    assert response.status_code == 504
+    body = response.get_json()
+    assert body["dispatch_error"] == "dispatch_pending"
+    assert body["type"] == messages_service.PENDING_TYPE
+    assert all(event_type != "message.new" for event_type, _data in published)
+
+    with create_sqlite_engine().begin() as conn:
+        assert queue_pending_user_message(
+            conn,
+            body["id"],
+            body["text"],
+        )
+        queued = messages_service.list_queued(conn, session_id)
+    assert [row["id"] for row in queued] == [body["id"]]
+    assert all(event_type != "message.new" for event_type, _data in published)
+
+
 def test_create_session_without_backend_defers_to_default_agent(isolated_state, tmp_path):
     """POST /api/sessions with no ``agent_backend`` must NOT stamp a concrete
     backend onto the session. A stamped backend is treated by message_handler

--- a/tests/test_ui_show_pages.py
+++ b/tests/test_ui_show_pages.py
@@ -2704,6 +2704,38 @@ def test_cli_show_event_ingress_records_and_publishes(monkeypatch, tmp_path):
     assert [event_type for event_type, _data in published] == ["show.event", "message.new", "session.activity"]
 
 
+def test_cli_show_event_dispatch_settles_inside_fallback_budget(monkeypatch, tmp_path):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    _save_config(tmp_path)
+    _create_agent_session("ses123")
+    monkeypatch.setattr("vibe.ui_server._SHOW_EVENT_DISPATCH_ACCEPT_TIMEOUT_SECONDS", 0.01)
+
+    async def stalled_dispatch(payload, **kwargs):
+        await asyncio.Event().wait()
+
+    with patch("vibe.internal_client.dispatch_async", stalled_dispatch):
+        response = app.test_client().post(
+            "/api/show/sessions/ses123/events",
+            base_url="http://127.0.0.1:5123",
+            headers={
+                "Content-Type": "application/json",
+                "X-Vibe-Show-Client": "cli",
+                "X-Vibe-Show-Cli-Token": show_cli_event_token(),
+            },
+            json={
+                "type": "human.annotation.created",
+                "annotation": {
+                    "intent": "comment",
+                    "comment": "Do not duplicate this.",
+                    "dispatch": True,
+                },
+            },
+        )
+
+    assert response.status_code == 201
+    assert response.get_json()["event"]["message"]["type"] == "user"
+
+
 def test_cli_show_event_ingress_requires_cli_token(monkeypatch, tmp_path):
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)

--- a/tests/test_ui_show_pages.py
+++ b/tests/test_ui_show_pages.py
@@ -177,15 +177,24 @@ def _create_agent_session(session_id: str, *, status: str = "active") -> None:
         )
 
 
-def _accept_dispatch(message_id: str, message_type: str = "user") -> None:
+def _accept_dispatch(payload: dict, message_type: str = "user") -> None:
+    from core.session_turns import queue_pending_user_message
+    from core.show_session_events import accept_show_dispatch
     from storage import messages_service
     from storage.db import create_sqlite_engine
 
     with create_sqlite_engine().begin() as conn:
-        assert messages_service.accept_dispatch_reservation(
+        if message_type == messages_service.QUEUED_TYPE:
+            assert queue_pending_user_message(
+                conn,
+                payload["user_message_id"],
+                payload["text"],
+            )
+        assert accept_show_dispatch(
             conn,
-            message_id,
-            message_type,
+            payload["show_event_id"],
+            session_id=payload["session_id"],
+            owner=payload["dispatch_owner"],
         )
 
 
@@ -2057,7 +2066,7 @@ def test_private_show_page_idle_dispatch_promotes_visible_user_row(monkeypatch, 
 
     async def fake_dispatch_async(payload, **kwargs):
         dispatches.append(payload)
-        _accept_dispatch(payload["user_message_id"])
+        _accept_dispatch(payload)
         dispatch_done.set()
         return {"status_code": 202, "body": {"ok": True}}
 
@@ -2123,7 +2132,7 @@ def test_private_show_page_waits_for_turn_acceptance_before_responding(monkeypat
         dispatch_entered.set()
         released = await asyncio.to_thread(release_dispatch.wait, 2)
         assert released
-        _accept_dispatch(payload["user_message_id"])
+        _accept_dispatch(payload)
         return {"status_code": 202, "body": {"ok": True}}
 
     def post_event():
@@ -2203,8 +2212,12 @@ def test_private_show_page_unavailable_dispatch_is_retryable_and_not_reported_as
     body = response.get_json()
     assert body["ok"] is False
     assert body["code"] == "show_event_dispatch_failed"
-    assert body["event"]["message"]["type"] == "dispatch_failed"
-    assert [event_type for event_type, _data in published] == ["show.event"]
+    assert body["event"]["message"]["type"] == "user"
+    assert [event_type for event_type, _data in published] == [
+        "show.event",
+        "message.new",
+        "session.activity",
+    ]
 
 
 def test_private_show_page_returns_promoted_row_after_synchronous_queue_drain(
@@ -2246,6 +2259,7 @@ def test_private_show_page_returns_promoted_row_after_synchronous_queue_drain(
                 metadata=metadata,
                 author_id=None,
             )
+        _accept_dispatch(payload)
         settled.update(original_id=payload["user_message_id"], visible=visible)
         return {"status_code": 202, "body": {"ok": True, "drained": True}}
 
@@ -2294,7 +2308,7 @@ def test_private_show_page_busy_dispatch_queues_without_message_new(monkeypatch,
     async def fake_dispatch_async(payload, **kwargs):
         from storage import messages_service
 
-        _accept_dispatch(payload["user_message_id"], messages_service.QUEUED_TYPE)
+        _accept_dispatch(payload, messages_service.QUEUED_TYPE)
         dispatch_done.set()
         return {"status_code": 202, "body": {"ok": True, "queued": True}}
 
@@ -2416,7 +2430,7 @@ def test_private_show_page_dispatches_screenshot_annotation_batch(monkeypatch, t
 
     async def fake_dispatch_async(payload, **kwargs):
         dispatches.append(payload)
-        _accept_dispatch(payload["user_message_id"])
+        _accept_dispatch(payload)
         dispatch_done.set()
         return {"status_code": 202, "body": {"ok": True}}
 
@@ -2898,7 +2912,7 @@ def test_cli_show_event_dispatch_waits_for_unambiguous_acceptance(monkeypatch, t
         dispatch_entered.set()
         released = await asyncio.to_thread(release_dispatch.wait, 2)
         assert released
-        _accept_dispatch(payload["user_message_id"])
+        _accept_dispatch(payload)
         return {"status_code": 202, "body": {"ok": True}}
 
     def post_event():

--- a/tests/test_ui_show_pages.py
+++ b/tests/test_ui_show_pages.py
@@ -8,6 +8,7 @@ import socket
 import ssl
 import struct
 import tarfile
+import threading
 import urllib.error
 import zlib
 from pathlib import Path
@@ -2041,6 +2042,55 @@ def test_private_show_page_idle_dispatch_promotes_visible_user_row(monkeypatch, 
     assert [message["id"] for message in transcript["messages"]] == [
         response.get_json()["event"]["message_id"]
     ]
+
+
+def test_private_show_page_waits_for_turn_acceptance_before_responding(monkeypatch, tmp_path):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    _save_config(tmp_path)
+    _create_agent_session("ses123")
+    _create_show_page("ses123", "private")
+    token = "session-write-token"
+    monkeypatch.setattr("vibe.ui_server.show_event_write_token", lambda session_id: token)
+    dispatch_entered = threading.Event()
+    release_dispatch = threading.Event()
+    result = {}
+
+    async def fake_dispatch_async(payload, **kwargs):
+        dispatch_entered.set()
+        released = await asyncio.to_thread(release_dispatch.wait, 2)
+        assert released
+        return {"status_code": 202, "body": {"ok": True}}
+
+    def post_event():
+        result["response"] = app.test_client().post(
+            "/show/ses123/__show/events",
+            base_url="http://127.0.0.1:5123",
+            headers={
+                "Origin": "http://127.0.0.1:5123",
+                "Content-Type": "application/json",
+                "X-Vibe-Show-Token": token,
+            },
+            json={
+                "type": "human.annotation.created",
+                "annotation": {
+                    "intent": "comment",
+                    "comment": "Wait for queue acceptance.",
+                    "dispatch": True,
+                },
+            },
+        )
+
+    with patch("vibe.internal_client.dispatch_async", fake_dispatch_async):
+        request_thread = threading.Thread(target=post_event)
+        request_thread.start()
+        assert dispatch_entered.wait(1)
+        assert request_thread.is_alive()
+        release_dispatch.set()
+        request_thread.join(2)
+
+    assert not request_thread.is_alive()
+    assert result["response"].status_code == 201
+    assert result["response"].get_json()["event"]["message"]["type"] == "user"
 
 
 def test_private_show_page_busy_dispatch_queues_without_message_new(monkeypatch, tmp_path):

--- a/tests/test_ui_show_pages.py
+++ b/tests/test_ui_show_pages.py
@@ -2096,6 +2096,132 @@ def test_private_show_page_waits_for_turn_acceptance_before_responding(monkeypat
     assert dispatch_kwargs == {"timeout": None}
 
 
+def test_private_show_page_dispatch_failure_is_reported_after_recording(
+    monkeypatch,
+    tmp_path,
+):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    _save_config(tmp_path)
+    _create_agent_session("ses123")
+    _create_show_page("ses123", "private")
+    token = "session-write-token"
+    monkeypatch.setattr("vibe.ui_server.show_event_write_token", lambda session_id: token)
+    published = []
+    monkeypatch.setattr(
+        "vibe.sse_broker.broker.publish",
+        lambda event_type, data: published.append((event_type, data)),
+    )
+
+    async def fake_dispatch_async(payload, **kwargs):
+        return {
+            "status_code": 503,
+            "body": {"ok": False, "error": "controller unavailable"},
+        }
+
+    with patch("vibe.internal_client.dispatch_async", fake_dispatch_async):
+        response = app.test_client().post(
+            "/show/ses123/__show/events",
+            base_url="http://127.0.0.1:5123",
+            headers={
+                "Origin": "http://127.0.0.1:5123",
+                "Content-Type": "application/json",
+                "X-Vibe-Show-Token": token,
+            },
+            json={
+                "type": "human.annotation.created",
+                "annotation": {
+                    "intent": "comment",
+                    "comment": "Record but report failed delivery.",
+                    "dispatch": True,
+                },
+            },
+        )
+
+    assert response.status_code == 502
+    body = response.get_json()
+    assert body["ok"] is False
+    assert body["code"] == "show_event_dispatch_failed"
+    assert body["event"]["message"]["type"] == "user"
+    assert [event_type for event_type, _data in published] == [
+        "show.event",
+        "message.new",
+        "session.activity",
+    ]
+
+
+def test_private_show_page_returns_promoted_row_after_synchronous_queue_drain(
+    monkeypatch,
+    tmp_path,
+):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    _save_config(tmp_path)
+    _create_agent_session("ses123")
+    _create_show_page("ses123", "private")
+    token = "session-write-token"
+    monkeypatch.setattr("vibe.ui_server.show_event_write_token", lambda session_id: token)
+    published = []
+    monkeypatch.setattr(
+        "vibe.sse_broker.broker.publish",
+        lambda event_type, data: published.append((event_type, data)),
+    )
+    settled = {}
+
+    async def fake_dispatch_async(payload, **kwargs):
+        from core import session_turns
+        from storage import messages_service
+        from storage.db import create_sqlite_engine
+
+        with create_sqlite_engine().begin() as conn:
+            assert session_turns.queue_pending_user_message(
+                conn,
+                payload["user_message_id"],
+                payload["text"],
+            )
+            segment = messages_service.list_queued(conn, "ses123")
+            metadata = dict(segment[0]["metadata"])
+            metadata.pop(session_turns.QUEUED_DISPATCH_TEXT_KEY)
+            visible = session_turns._promote_merged_user_segment(
+                conn,
+                segment,
+                text=segment[0]["text"],
+                attachments=[],
+                metadata=metadata,
+                author_id=None,
+            )
+        settled.update(original_id=payload["user_message_id"], visible=visible)
+        return {"status_code": 202, "body": {"ok": True, "drained": True}}
+
+    with patch("vibe.internal_client.dispatch_async", fake_dispatch_async):
+        response = app.test_client().post(
+            "/show/ses123/__show/events",
+            base_url="http://127.0.0.1:5123",
+            headers={
+                "Origin": "http://127.0.0.1:5123",
+                "Content-Type": "application/json",
+                "X-Vibe-Show-Token": token,
+            },
+            json={
+                "type": "human.annotation.created",
+                "annotation": {
+                    "intent": "comment",
+                    "comment": "Drain before the 202 returns.",
+                    "dispatch": True,
+                },
+            },
+        )
+
+    assert response.status_code == 201
+    event = response.get_json()["event"]
+    assert settled["visible"]["id"] != settled["original_id"]
+    assert event["message_id"] == settled["visible"]["id"]
+    assert event["message"]["id"] == settled["visible"]["id"]
+    assert event["message"]["type"] == "user"
+    # The real manager already publishes the promoted row. The route only
+    # published the event before entering our fake adapter and must not emit a
+    # stale pending/queued message afterwards.
+    assert [event_type for event_type, _data in published] == ["show.event"]
+
+
 def test_private_show_page_busy_dispatch_queues_without_message_new(monkeypatch, tmp_path):
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)

--- a/tests/test_ui_show_pages.py
+++ b/tests/test_ui_show_pages.py
@@ -1981,7 +1981,7 @@ def test_private_show_page_rejects_mismatched_event_session_id(monkeypatch, tmp_
     assert response.get_json()["code"] == "session_mismatch"
 
 
-def test_private_show_page_dispatches_human_show_event(monkeypatch, tmp_path):
+def test_private_show_page_idle_dispatch_promotes_visible_user_row(monkeypatch, tmp_path):
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)
     _create_agent_session("ses123")
@@ -1993,13 +1993,12 @@ def test_private_show_page_dispatches_human_show_event(monkeypatch, tmp_path):
     dispatches = []
     dispatch_done = asyncio.Event()
 
-    async def fake_stream_dispatch(payload, **kwargs):
+    async def fake_dispatch_async(payload, **kwargs):
         dispatches.append(payload)
         dispatch_done.set()
-        yield "turn.start", {"session_id": payload["session_id"]}
-        yield "turn.end", {"session_id": payload["session_id"]}
+        return {"status_code": 202, "body": {"ok": True}}
 
-    with patch("vibe.internal_client.stream_dispatch", fake_stream_dispatch):
+    with patch("vibe.internal_client.dispatch_async", fake_dispatch_async):
         response = app.test_client().post(
             "/show/ses123/__show/events",
             base_url="http://127.0.0.1:5123",
@@ -2026,7 +2025,119 @@ def test_private_show_page_dispatches_human_show_event(monkeypatch, tmp_path):
     assert dispatches[0]["session_id"] == "ses123"
     assert "Pick B." in dispatches[0]["text"]
     assert dispatches[0]["user_message_id"] == response.get_json()["event"]["message_id"]
-    assert "show.dispatch" in [event_type for event_type, _data in published]
+    assert dispatches[0]["files"] == []
+    assert [event_type for event_type, _data in published] == [
+        "show.event",
+        "message.new",
+        "session.activity",
+    ]
+    assert published[1][1]["type"] == "user"
+
+    from storage import messages_service
+    from storage.db import create_sqlite_engine
+
+    with create_sqlite_engine().connect() as conn:
+        transcript = messages_service.list_session_messages(conn, session_id="ses123", types=("user",))
+    assert [message["id"] for message in transcript["messages"]] == [
+        response.get_json()["event"]["message_id"]
+    ]
+
+
+def test_private_show_page_busy_dispatch_queues_without_message_new(monkeypatch, tmp_path):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    _save_config(tmp_path)
+    _create_agent_session("ses123")
+    _create_show_page("ses123", "private")
+    token = "session-write-token"
+    monkeypatch.setattr("vibe.ui_server.show_event_write_token", lambda session_id: token)
+    published = []
+    monkeypatch.setattr("vibe.sse_broker.broker.publish", lambda event_type, data: published.append((event_type, data)))
+    dispatch_done = asyncio.Event()
+
+    async def fake_dispatch_async(payload, **kwargs):
+        from storage import messages_service
+        from storage.db import create_sqlite_engine
+
+        with create_sqlite_engine().begin() as conn:
+            assert messages_service.promote_pending(
+                conn,
+                payload["user_message_id"],
+                messages_service.QUEUED_TYPE,
+            )
+        dispatch_done.set()
+        return {"status_code": 202, "body": {"ok": True, "queued": True}}
+
+    with patch("vibe.internal_client.dispatch_async", fake_dispatch_async):
+        response = app.test_client().post(
+            "/show/ses123/__show/events",
+            base_url="http://127.0.0.1:5123",
+            headers={
+                "Origin": "http://127.0.0.1:5123",
+                "Content-Type": "application/json",
+                "X-Vibe-Show-Token": token,
+            },
+            json={
+                "type": "human.annotation.created",
+                "annotation": {
+                    "intent": "comment",
+                    "comment": "Queue this annotation.",
+                    "dispatch": True,
+                },
+            },
+        )
+
+    assert response.status_code == 201
+    asyncio.run(asyncio.wait_for(dispatch_done.wait(), timeout=1))
+    message_id = response.get_json()["event"]["message_id"]
+
+    from storage import messages_service
+    from storage.db import create_sqlite_engine
+
+    with create_sqlite_engine().connect() as conn:
+        queued = messages_service.list_queued(conn, "ses123")
+        transcript = messages_service.list_session_messages(conn, session_id="ses123", types=("user",))
+    assert [(message["id"], message["text"]) for message in queued] == [
+        (message_id, response.get_json()["event"]["transcript_text"])
+    ]
+    assert transcript["messages"] == []
+    assert [event_type for event_type, _data in published] == ["show.event", "queue.updated"]
+
+
+def test_private_show_page_non_dispatching_annotation_stays_immediately_visible(monkeypatch, tmp_path):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    _save_config(tmp_path)
+    _create_agent_session("ses123")
+    _create_show_page("ses123", "private")
+    token = "session-write-token"
+    monkeypatch.setattr("vibe.ui_server.show_event_write_token", lambda session_id: token)
+    published = []
+    monkeypatch.setattr("vibe.sse_broker.broker.publish", lambda event_type, data: published.append((event_type, data)))
+
+    response = app.test_client().post(
+        "/show/ses123/__show/events",
+        base_url="http://127.0.0.1:5123",
+        headers={
+            "Origin": "http://127.0.0.1:5123",
+            "Content-Type": "application/json",
+            "X-Vibe-Show-Token": token,
+        },
+        json={
+            "type": "human.annotation.created",
+            "annotation": {
+                "intent": "comment",
+                "comment": "Record this without dispatch.",
+                "dispatch": False,
+            },
+        },
+    )
+
+    assert response.status_code == 201
+    assert response.get_json()["event"]["message"]["type"] == "user"
+    assert [event_type for event_type, _data in published] == [
+        "show.event",
+        "message.new",
+        "session.activity",
+    ]
 
 
 def test_private_show_page_publishes_annotation_control_without_message_or_dispatch(monkeypatch, tmp_path):
@@ -2072,13 +2183,12 @@ def test_private_show_page_dispatches_screenshot_annotation_batch(monkeypatch, t
     dispatches = []
     dispatch_done = asyncio.Event()
 
-    async def fake_stream_dispatch(payload, **kwargs):
+    async def fake_dispatch_async(payload, **kwargs):
         dispatches.append(payload)
         dispatch_done.set()
-        yield "turn.start", {"session_id": payload["session_id"]}
-        yield "turn.end", {"session_id": payload["session_id"]}
+        return {"status_code": 202, "body": {"ok": True}}
 
-    with patch("vibe.internal_client.stream_dispatch", fake_stream_dispatch):
+    with patch("vibe.internal_client.dispatch_async", fake_dispatch_async):
         response = app.test_client().post(
             "/show/ses123/__show/events",
             base_url="http://127.0.0.1:5123",
@@ -2379,92 +2489,6 @@ def test_show_events_stream_replays_all_persisted_pages_before_live(monkeypatch,
     assert "id: show_evt_500" in body
     assert '"id": "show_evt_000"' in body
     assert '"id": "show_evt_500"' in body
-
-
-def test_show_events_stream_forwards_live_dispatch_events(monkeypatch, tmp_path):
-    from vibe.sse_broker import broker
-    from vibe.ui_server import _show_events_stream
-
-    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
-    _save_config(tmp_path)
-    _create_agent_session("ses123")
-    _create_show_page("ses123", "private")
-
-    async def _collect_live_dispatch() -> str:
-        response = await _show_events_stream("ses123")
-        iterator = response.body_iterator.__aiter__()
-        chunks = []
-        try:
-            chunks.append(await iterator.__anext__())
-            broker.publish(
-                "show.dispatch",
-                {
-                    "session_id": "ses123",
-                    "scope_id": "scope123",
-                    "show_event_id": "show_evt_1",
-                    "event": "turn.chunk",
-                    "data": {"text": "hello"},
-                },
-            )
-            chunks.append(await asyncio.wait_for(iterator.__anext__(), timeout=1))
-        finally:
-            await iterator.aclose()
-        return "".join(chunk.decode("utf-8") if isinstance(chunk, bytes) else chunk for chunk in chunks)
-
-    body = asyncio.run(_collect_live_dispatch())
-
-    assert "event: show.dispatch" in body
-    assert '"show_event_id": "show_evt_1"' in body
-
-
-def test_public_show_events_stream_redacts_nested_dispatch_ids(monkeypatch, tmp_path):
-    from vibe.sse_broker import broker
-    from vibe.ui_server import _show_events_stream
-
-    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
-    _save_config(tmp_path)
-    _create_agent_session("ses123")
-    share_id = _create_show_page("ses123", "public")
-
-    async def _collect_live_dispatch() -> str:
-        response = await _show_events_stream(
-            "ses123",
-            public=True,
-            public_share_id=share_id,
-        )
-        iterator = response.body_iterator.__aiter__()
-        chunks = []
-        try:
-            chunks.append(await iterator.__anext__())
-            broker.publish(
-                "show.dispatch",
-                {
-                    "session_id": "ses123",
-                    "scope_id": "scope123",
-                    "show_event_id": "show_evt_1",
-                    "event": "turn.chunk",
-                    "data": {
-                        "text": "hello",
-                        "session_id": "ses123",
-                        "message_id": "msg123",
-                        "nested": {"scope_id": "scope123", "user_message_id": "msg123"},
-                    },
-                },
-            )
-            chunks.append(await asyncio.wait_for(iterator.__anext__(), timeout=1))
-        finally:
-            await iterator.aclose()
-        return "".join(chunk.decode("utf-8") if isinstance(chunk, bytes) else chunk for chunk in chunks)
-
-    body = asyncio.run(_collect_live_dispatch())
-
-    assert "event: show.dispatch" in body
-    assert '"show_event_id": "show_evt_1"' in body
-    assert '"text": "hello"' in body
-    assert '"session_id"' not in body
-    assert '"scope_id"' not in body
-    assert '"message_id"' not in body
-    assert '"user_message_id"' not in body
 
 
 def test_public_show_page_events_redact_internal_ids(monkeypatch, tmp_path):

--- a/tests/test_ui_show_pages.py
+++ b/tests/test_ui_show_pages.py
@@ -2054,8 +2054,10 @@ def test_private_show_page_waits_for_turn_acceptance_before_responding(monkeypat
     dispatch_entered = threading.Event()
     release_dispatch = threading.Event()
     result = {}
+    dispatch_kwargs = {}
 
     async def fake_dispatch_async(payload, **kwargs):
+        dispatch_kwargs.update(kwargs)
         dispatch_entered.set()
         released = await asyncio.to_thread(release_dispatch.wait, 2)
         assert released
@@ -2091,6 +2093,7 @@ def test_private_show_page_waits_for_turn_acceptance_before_responding(monkeypat
     assert not request_thread.is_alive()
     assert result["response"].status_code == 201
     assert result["response"].get_json()["event"]["message"]["type"] == "user"
+    assert dispatch_kwargs == {"timeout": None}
 
 
 def test_private_show_page_busy_dispatch_queues_without_message_new(monkeypatch, tmp_path):
@@ -2704,17 +2707,22 @@ def test_cli_show_event_ingress_records_and_publishes(monkeypatch, tmp_path):
     assert [event_type for event_type, _data in published] == ["show.event", "message.new", "session.activity"]
 
 
-def test_cli_show_event_dispatch_settles_inside_fallback_budget(monkeypatch, tmp_path):
+def test_cli_show_event_dispatch_waits_for_unambiguous_acceptance(monkeypatch, tmp_path):
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)
     _create_agent_session("ses123")
-    monkeypatch.setattr("vibe.ui_server._SHOW_EVENT_DISPATCH_ACCEPT_TIMEOUT_SECONDS", 0.01)
+    dispatch_entered = threading.Event()
+    release_dispatch = threading.Event()
+    result = {}
 
     async def stalled_dispatch(payload, **kwargs):
-        await asyncio.Event().wait()
+        dispatch_entered.set()
+        released = await asyncio.to_thread(release_dispatch.wait, 2)
+        assert released
+        return {"status_code": 202, "body": {"ok": True}}
 
-    with patch("vibe.internal_client.dispatch_async", stalled_dispatch):
-        response = app.test_client().post(
+    def post_event():
+        result["response"] = app.test_client().post(
             "/api/show/sessions/ses123/events",
             base_url="http://127.0.0.1:5123",
             headers={
@@ -2732,8 +2740,17 @@ def test_cli_show_event_dispatch_settles_inside_fallback_budget(monkeypatch, tmp
             },
         )
 
-    assert response.status_code == 201
-    assert response.get_json()["event"]["message"]["type"] == "user"
+    with patch("vibe.internal_client.dispatch_async", stalled_dispatch):
+        request_thread = threading.Thread(target=post_event)
+        request_thread.start()
+        assert dispatch_entered.wait(1)
+        assert request_thread.is_alive()
+        release_dispatch.set()
+        request_thread.join(2)
+
+    assert not request_thread.is_alive()
+    assert result["response"].status_code == 201
+    assert result["response"].get_json()["event"]["message"]["type"] == "user"
 
 
 def test_cli_show_event_ingress_requires_cli_token(monkeypatch, tmp_path):

--- a/tests/test_ui_show_pages.py
+++ b/tests/test_ui_show_pages.py
@@ -2096,10 +2096,12 @@ def test_private_show_page_waits_for_turn_acceptance_before_responding(monkeypat
     assert dispatch_kwargs == {"timeout": None}
 
 
-def test_private_show_page_dispatch_failure_is_reported_after_recording(
+def test_private_show_page_unavailable_dispatch_stays_pending_and_is_not_reported_as_delivered(
     monkeypatch,
     tmp_path,
 ):
+    from vibe import internal_client
+
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)
     _create_agent_session("ses123")
@@ -2113,10 +2115,7 @@ def test_private_show_page_dispatch_failure_is_reported_after_recording(
     )
 
     async def fake_dispatch_async(payload, **kwargs):
-        return {
-            "status_code": 503,
-            "body": {"ok": False, "error": "controller unavailable"},
-        }
+        raise internal_client.InternalServerUnavailable("controller unavailable")
 
     with patch("vibe.internal_client.dispatch_async", fake_dispatch_async):
         response = app.test_client().post(
@@ -2141,12 +2140,8 @@ def test_private_show_page_dispatch_failure_is_reported_after_recording(
     body = response.get_json()
     assert body["ok"] is False
     assert body["code"] == "show_event_dispatch_failed"
-    assert body["event"]["message"]["type"] == "user"
-    assert [event_type for event_type, _data in published] == [
-        "show.event",
-        "message.new",
-        "session.activity",
-    ]
+    assert body["event"]["message"]["type"] == "pending"
+    assert [event_type for event_type, _data in published] == ["show.event"]
 
 
 def test_private_show_page_returns_promoted_row_after_synchronous_queue_drain(

--- a/tests/test_ui_show_pages.py
+++ b/tests/test_ui_show_pages.py
@@ -177,6 +177,18 @@ def _create_agent_session(session_id: str, *, status: str = "active") -> None:
         )
 
 
+def _accept_dispatch(message_id: str, message_type: str = "user") -> None:
+    from storage import messages_service
+    from storage.db import create_sqlite_engine
+
+    with create_sqlite_engine().begin() as conn:
+        assert messages_service.accept_dispatch_reservation(
+            conn,
+            message_id,
+            message_type,
+        )
+
+
 def _write_runtime_archive(tmp_path: Path, *, text: str = "#!/usr/bin/env node\n") -> Path:
     archive_root = tmp_path / f"archive-root-{hashlib.sha256(text.encode()).hexdigest()[:8]}"
     cli_path = archive_root / "node_modules" / "@avibe" / "show-runtime" / "dist" / "cli.js"
@@ -1982,6 +1994,55 @@ def test_private_show_page_rejects_mismatched_event_session_id(monkeypatch, tmp_
     assert response.get_json()["code"] == "session_mismatch"
 
 
+def test_private_show_page_rejects_reused_event_id_with_different_contents(
+    monkeypatch,
+    tmp_path,
+):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    _save_config(tmp_path)
+    _create_agent_session("ses123")
+    _create_show_page("ses123", "private")
+    token = "session-write-token"
+    monkeypatch.setattr("vibe.ui_server.show_event_write_token", lambda session_id: token)
+    headers = {
+        "Origin": "http://127.0.0.1:5123",
+        "Content-Type": "application/json",
+        "X-Vibe-Show-Token": token,
+    }
+    original = {
+        "id": "show_evt_payload_conflict",
+        "type": "human.annotation.created",
+        "annotation": {
+            "intent": "comment",
+            "comment": "Original annotation.",
+            "dispatch": False,
+        },
+    }
+
+    first = app.test_client().post(
+        "/show/ses123/__show/events",
+        base_url="http://127.0.0.1:5123",
+        headers=headers,
+        json=original,
+    )
+    conflict = app.test_client().post(
+        "/show/ses123/__show/events",
+        base_url="http://127.0.0.1:5123",
+        headers=headers,
+        json={
+            **original,
+            "annotation": {
+                **original["annotation"],
+                "comment": "Different annotation.",
+            },
+        },
+    )
+
+    assert first.status_code == 201
+    assert conflict.status_code == 409
+    assert conflict.get_json()["code"] == "event_id_conflict"
+
+
 def test_private_show_page_idle_dispatch_promotes_visible_user_row(monkeypatch, tmp_path):
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)
@@ -1996,6 +2057,7 @@ def test_private_show_page_idle_dispatch_promotes_visible_user_row(monkeypatch, 
 
     async def fake_dispatch_async(payload, **kwargs):
         dispatches.append(payload)
+        _accept_dispatch(payload["user_message_id"])
         dispatch_done.set()
         return {"status_code": 202, "body": {"ok": True}}
 
@@ -2061,6 +2123,7 @@ def test_private_show_page_waits_for_turn_acceptance_before_responding(monkeypat
         dispatch_entered.set()
         released = await asyncio.to_thread(release_dispatch.wait, 2)
         assert released
+        _accept_dispatch(payload["user_message_id"])
         return {"status_code": 202, "body": {"ok": True}}
 
     def post_event():
@@ -2096,7 +2159,7 @@ def test_private_show_page_waits_for_turn_acceptance_before_responding(monkeypat
     assert dispatch_kwargs == {"timeout": None}
 
 
-def test_private_show_page_unavailable_dispatch_stays_pending_and_is_not_reported_as_delivered(
+def test_private_show_page_unavailable_dispatch_is_retryable_and_not_reported_as_delivered(
     monkeypatch,
     tmp_path,
 ):
@@ -2140,7 +2203,7 @@ def test_private_show_page_unavailable_dispatch_stays_pending_and_is_not_reporte
     body = response.get_json()
     assert body["ok"] is False
     assert body["code"] == "show_event_dispatch_failed"
-    assert body["event"]["message"]["type"] == "pending"
+    assert body["event"]["message"]["type"] == "dispatch_failed"
     assert [event_type for event_type, _data in published] == ["show.event"]
 
 
@@ -2230,14 +2293,8 @@ def test_private_show_page_busy_dispatch_queues_without_message_new(monkeypatch,
 
     async def fake_dispatch_async(payload, **kwargs):
         from storage import messages_service
-        from storage.db import create_sqlite_engine
 
-        with create_sqlite_engine().begin() as conn:
-            assert messages_service.promote_pending(
-                conn,
-                payload["user_message_id"],
-                messages_service.QUEUED_TYPE,
-            )
+        _accept_dispatch(payload["user_message_id"], messages_service.QUEUED_TYPE)
         dispatch_done.set()
         return {"status_code": 202, "body": {"ok": True, "queued": True}}
 
@@ -2359,6 +2416,7 @@ def test_private_show_page_dispatches_screenshot_annotation_batch(monkeypatch, t
 
     async def fake_dispatch_async(payload, **kwargs):
         dispatches.append(payload)
+        _accept_dispatch(payload["user_message_id"])
         dispatch_done.set()
         return {"status_code": 202, "body": {"ok": True}}
 
@@ -2840,6 +2898,7 @@ def test_cli_show_event_dispatch_waits_for_unambiguous_acceptance(monkeypatch, t
         dispatch_entered.set()
         released = await asyncio.to_thread(release_dispatch.wait, 2)
         assert released
+        _accept_dispatch(payload["user_message_id"])
         return {"status_code": 202, "body": {"ok": True}}
 
     def post_event():

--- a/tests/test_ui_show_pages.py
+++ b/tests/test_ui_show_pages.py
@@ -2008,7 +2008,9 @@ def test_private_show_page_rejects_reused_event_id_with_different_contents(
     tmp_path,
 ):
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
-    _save_config(tmp_path)
+    config = _save_config(tmp_path)
+    config.language = "zh"
+    config.save()
     _create_agent_session("ses123")
     _create_show_page("ses123", "private")
     token = "session-write-token"
@@ -2050,6 +2052,7 @@ def test_private_show_page_rejects_reused_event_id_with_different_contents(
     assert first.status_code == 201
     assert conflict.status_code == 409
     assert conflict.get_json()["code"] == "event_id_conflict"
+    assert conflict.get_json()["error"] == "此 Show 事件 ID 已绑定到不同的事件内容。"
 
 
 def test_private_show_page_idle_dispatch_promotes_visible_user_row(monkeypatch, tmp_path):
@@ -2218,6 +2221,51 @@ def test_private_show_page_unavailable_dispatch_is_retryable_and_not_reported_as
         "message.new",
         "session.activity",
     ]
+
+
+def test_private_show_page_concurrent_dispatch_replay_returns_pending(
+    monkeypatch,
+    tmp_path,
+):
+    from storage import messages_service
+
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    _save_config(tmp_path)
+    _create_agent_session("ses123")
+    _create_show_page("ses123", "private")
+    token = "session-write-token"
+    monkeypatch.setattr("vibe.ui_server.show_event_write_token", lambda session_id: token)
+
+    async def already_in_flight(_event):
+        return ui_server._ShowEventDispatchOutcome.IN_FLIGHT
+
+    monkeypatch.setattr(
+        "vibe.ui_server._run_show_event_dispatch",
+        already_in_flight,
+    )
+    response = app.test_client().post(
+        "/show/ses123/__show/events",
+        base_url="http://127.0.0.1:5123",
+        headers={
+            "Origin": "http://127.0.0.1:5123",
+            "Content-Type": "application/json",
+            "X-Vibe-Show-Token": token,
+        },
+        json={
+            "id": "show_evt_concurrent_http",
+            "type": "human.annotation.created",
+            "annotation": {
+                "comment": "The first request still owns this dispatch.",
+                "dispatch": True,
+            },
+        },
+    )
+
+    assert response.status_code == 202
+    body = response.get_json()
+    assert body["ok"] is True
+    assert body["dispatch_pending"] is True
+    assert body["event"]["message"]["type"] == messages_service.PENDING_TYPE
 
 
 def test_private_show_page_returns_promoted_row_after_synchronous_queue_drain(

--- a/tests/test_ui_show_pages.py
+++ b/tests/test_ui_show_pages.py
@@ -179,7 +179,7 @@ def _create_agent_session(session_id: str, *, status: str = "active") -> None:
 
 def _accept_dispatch(payload: dict, message_type: str = "user") -> None:
     from core.session_turns import queue_pending_user_message
-    from core.show_session_events import accept_show_dispatch
+    from core.show_session_events import DISPATCH_ACCEPTED, settle_show_dispatch
     from storage import messages_service
     from storage.db import create_sqlite_engine
 
@@ -190,11 +190,12 @@ def _accept_dispatch(payload: dict, message_type: str = "user") -> None:
                 payload["user_message_id"],
                 payload["text"],
             )
-        assert accept_show_dispatch(
+        assert settle_show_dispatch(
             conn,
             payload["show_event_id"],
             session_id=payload["session_id"],
             owner=payload["dispatch_owner"],
+            state=DISPATCH_ACCEPTED,
         )
 
 

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -10668,6 +10668,8 @@ def _request_show_page_prewarm_best_effort(session_id: str, *, base_path: str | 
 
 def _post_show_event_to_live_ui(session_id: str, payload: dict) -> dict | None:
     from core.show_pages import SHOW_CLI_EVENT_TOKEN_HEADER, show_cli_event_token
+    from core.show_session_events import ShowSessionEventError
+    from vibe.i18n import t
 
     url = _local_show_events_url(session_id)
     if not url:
@@ -10686,7 +10688,21 @@ def _post_show_event_to_live_ui(session_id: str, payload: dict) -> dict | None:
     try:
         with urllib.request.urlopen(request, timeout=3) as response:
             parsed = json.loads(response.read().decode("utf-8"))
-    except (OSError, TimeoutError, urllib.error.URLError, urllib.error.HTTPError, json.JSONDecodeError, ValueError):
+    except TimeoutError as exc:
+        # The live endpoint may still be settling the reserved row. Do not replay
+        # locally and create a second event while acceptance is unknown.
+        raise ShowSessionEventError(
+            t("show.event.acceptanceUnknown", V2Config.load().language),
+            code="show_event_acceptance_unknown",
+        ) from exc
+    except urllib.error.URLError as exc:
+        if isinstance(exc.reason, TimeoutError):
+            raise ShowSessionEventError(
+                t("show.event.acceptanceUnknown", V2Config.load().language),
+                code="show_event_acceptance_unknown",
+            ) from exc
+        return None
+    except (OSError, urllib.error.HTTPError, json.JSONDecodeError, ValueError):
         return None
     return parsed.get("event") if isinstance(parsed, dict) and parsed.get("ok") is True else None
 
@@ -11116,10 +11132,8 @@ def cmd_show_unmark(args):
 
 def cmd_show_event(args):
     from core.show_pages import ShowPageStore
-    from core.show_session_events import ShowSessionEventStore
 
     page_store = ShowPageStore()
-    event_store = None
     try:
         session_id, session_default_notice = _resolve_show_session_id(args, help_command="vibe show event --help")
         page = page_store.ensure(session_id)
@@ -11130,13 +11144,12 @@ def cmd_show_event(args):
             payload = _with_show_event_dispatch(payload)
         event = _post_show_event_to_live_ui(session_id, payload)
         if event is None:
-            if args.dispatch:
-                from vibe.ui_server import record_local_show_event
+            # The local bridge handles both shapes: non-dispatch events are
+            # immediately visible, while any normalized dispatch:true event
+            # reserves and synchronously settles through the unified entry.
+            from vibe.ui_server import record_local_show_event
 
-                event = record_local_show_event(session_id, payload, dispatch_sync=True)
-            else:
-                event_store = ShowSessionEventStore()
-                event = event_store.append(session_id, payload)
+            event = record_local_show_event(session_id, payload, dispatch_sync=True)
         result = _show_page_result(
             page,
             message="Show event recorded.",
@@ -11162,8 +11175,6 @@ def cmd_show_event(args):
         return 1
     finally:
         page_store.close()
-        if event_store is not None:
-            event_store.close()
 
 
 def cmd_show_annotate(args):

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -10687,12 +10687,64 @@ def _post_show_event_to_live_ui(session_id: str, payload: dict) -> dict | None:
         with urllib.request.urlopen(request, timeout=3) as response:
             parsed = json.loads(response.read().decode("utf-8"))
     except TimeoutError:
+        return _resolve_show_event_after_ambiguous_live_timeout(session_id, payload)
+    except urllib.error.HTTPError:
         return None
     except urllib.error.URLError as exc:
+        if isinstance(exc.reason, TimeoutError):
+            return _resolve_show_event_after_ambiguous_live_timeout(session_id, payload)
         return None
-    except (OSError, urllib.error.HTTPError, json.JSONDecodeError, ValueError):
+    except (OSError, json.JSONDecodeError, ValueError):
         return None
     return parsed.get("event") if isinstance(parsed, dict) and parsed.get("ok") is True else None
+
+
+def _resolve_show_event_after_ambiguous_live_timeout(
+    session_id: str,
+    payload: dict,
+    *,
+    wait_seconds: float = 15.0,
+) -> dict | None:
+    """Query the durable reservation after a live POST times out.
+
+    ``dispatching`` means the original request may still reach the unified
+    manager, so this path waits/reports instead of blindly submitting again.
+    ``dispatch_failed`` is definitive and allows the existing local fallback.
+    """
+    from core.show_session_events import ShowSessionEventError, ShowSessionEventStore
+    from storage import messages_service
+
+    event_id = payload.get("id")
+    if not isinstance(event_id, str) or not event_id:
+        return None
+    deadline = time.monotonic() + wait_seconds
+    while True:
+        store = ShowSessionEventStore()
+        try:
+            event = store.get_event(session_id, event_id)
+        finally:
+            store.close()
+        if event is None:
+            return None
+        message = event.get("message")
+        if not isinstance(message, dict):
+            return event
+        message_type = message.get("type")
+        if message_type in {"user", messages_service.QUEUED_TYPE}:
+            return event
+        if message_type == messages_service.DISPATCH_FAILED_TYPE:
+            return None
+        if message_type not in {
+            messages_service.PENDING_TYPE,
+            messages_service.DISPATCHING_TYPE,
+        }:
+            return event
+        if time.monotonic() >= deadline:
+            raise ShowSessionEventError(
+                "Show event dispatch is still pending; retry after its status settles.",
+                code="show_event_dispatch_pending",
+            )
+        time.sleep(0.05)
 
 
 def _post_show_mark_to_live_ui(session_id: str, payload: dict) -> dict | None:
@@ -11130,7 +11182,12 @@ def cmd_show_event(args):
             payload = {**payload, "type": args.type}
         if args.dispatch:
             payload = _with_show_event_dispatch(payload)
-        payload.setdefault("id", f"show_evt_{uuid4().hex[:16]}")
+        event_id = payload.get("id")
+        payload["id"] = (
+            event_id.strip()
+            if isinstance(event_id, str) and event_id.strip()
+            else f"show_evt_{uuid4().hex[:16]}"
+        )
         event = _post_show_event_to_live_ui(session_id, payload)
         if event is None:
             # The local bridge handles both shapes: non-dispatch events are

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -10668,8 +10668,6 @@ def _request_show_page_prewarm_best_effort(session_id: str, *, base_path: str | 
 
 def _post_show_event_to_live_ui(session_id: str, payload: dict) -> dict | None:
     from core.show_pages import SHOW_CLI_EVENT_TOKEN_HEADER, show_cli_event_token
-    from core.show_session_events import ShowSessionEventError
-    from vibe.i18n import t
 
     url = _local_show_events_url(session_id)
     if not url:
@@ -10688,19 +10686,9 @@ def _post_show_event_to_live_ui(session_id: str, payload: dict) -> dict | None:
     try:
         with urllib.request.urlopen(request, timeout=3) as response:
             parsed = json.loads(response.read().decode("utf-8"))
-    except TimeoutError as exc:
-        # The live endpoint may still be settling the reserved row. Do not replay
-        # locally and create a second event while acceptance is unknown.
-        raise ShowSessionEventError(
-            t("show.event.acceptanceUnknown", V2Config.load().language),
-            code="show_event_acceptance_unknown",
-        ) from exc
+    except TimeoutError:
+        return None
     except urllib.error.URLError as exc:
-        if isinstance(exc.reason, TimeoutError):
-            raise ShowSessionEventError(
-                t("show.event.acceptanceUnknown", V2Config.load().language),
-                code="show_event_acceptance_unknown",
-            ) from exc
         return None
     except (OSError, urllib.error.HTTPError, json.JSONDecodeError, ValueError):
         return None
@@ -11142,6 +11130,7 @@ def cmd_show_event(args):
             payload = {**payload, "type": args.type}
         if args.dispatch:
             payload = _with_show_event_dispatch(payload)
+        payload.setdefault("id", f"show_evt_{uuid4().hex[:16]}")
         event = _post_show_event_to_live_ui(session_id, payload)
         if event is None:
             # The local bridge handles both shapes: non-dispatch events are

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -10705,46 +10705,40 @@ def _resolve_show_event_after_ambiguous_live_timeout(
     *,
     wait_seconds: float = 15.0,
 ) -> dict | None:
-    """Query the durable reservation after a live POST times out.
-
-    ``dispatching`` means the original request may still reach the unified
-    manager, so this path waits/reports instead of blindly submitting again.
-    ``dispatch_failed`` is definitive and allows the existing local fallback.
-    """
-    from core.show_session_events import ShowSessionEventError, ShowSessionEventStore
-    from storage import messages_service
+    """Query the event-owned dispatch lifecycle after a live POST times out."""
+    from core.show_session_events import (
+        DISPATCH_ACCEPTED,
+        DISPATCH_FAILED,
+        DISPATCH_IN_FLIGHT,
+        DISPATCH_NONE,
+        ShowSessionEventError,
+        ShowSessionEventStore,
+    )
 
     event_id = payload.get("id")
     if not isinstance(event_id, str) or not event_id:
         return None
     deadline = time.monotonic() + wait_seconds
-    while True:
-        store = ShowSessionEventStore()
-        try:
-            event = store.get_event(session_id, event_id)
-        finally:
-            store.close()
-        if event is None:
-            return None
-        message = event.get("message")
-        if not isinstance(message, dict):
-            return event
-        message_type = message.get("type")
-        if message_type in {"user", messages_service.QUEUED_TYPE}:
-            return event
-        if message_type == messages_service.DISPATCH_FAILED_TYPE:
-            return None
-        if message_type not in {
-            messages_service.PENDING_TYPE,
-            messages_service.DISPATCHING_TYPE,
-        }:
-            return event
-        if time.monotonic() >= deadline:
-            raise ShowSessionEventError(
-                "Show event dispatch is still pending; retry after its status settles.",
-                code="show_event_dispatch_pending",
-            )
-        time.sleep(0.05)
+    store = ShowSessionEventStore()
+    try:
+        while True:
+            status = store.get_dispatch_status(session_id, event_id)
+            if status is None:
+                return None
+            if status.state == DISPATCH_ACCEPTED:
+                return store.get_event(session_id, event_id)
+            if status.state in {DISPATCH_NONE, DISPATCH_FAILED}:
+                return None
+            if status.state != DISPATCH_IN_FLIGHT:
+                return store.get_event(session_id, event_id)
+            if time.monotonic() >= deadline:
+                raise ShowSessionEventError(
+                    "Show event dispatch is still pending; retry after its status settles.",
+                    code="show_event_dispatch_pending",
+                )
+            time.sleep(0.05)
+    finally:
+        store.close()
 
 
 def _post_show_mark_to_live_ui(session_id: str, payload: dict) -> dict | None:

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -10712,6 +10712,7 @@ def _resolve_show_event_after_ambiguous_live_timeout(
     """Query the event-owned dispatch lifecycle after a live POST times out."""
     from core.show_session_events import (
         DISPATCH_ACCEPTED,
+        DISPATCH_ARCHIVED,
         DISPATCH_FAILED,
         DISPATCH_IN_FLIGHT,
         DISPATCH_NONE,
@@ -10731,6 +10732,8 @@ def _resolve_show_event_after_ambiguous_live_timeout(
                 return None
             if status.state == DISPATCH_ACCEPTED:
                 return store.get_event(session_id, event_id)
+            if status.state == DISPATCH_ARCHIVED:
+                raise localized_show_event_error("show_event_dispatch_failed")
             if status.state in {DISPATCH_NONE, DISPATCH_FAILED}:
                 return None
             if status.state != DISPATCH_IN_FLIGHT:

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -10731,7 +10731,13 @@ def _resolve_show_event_after_ambiguous_live_timeout(
             if status is None:
                 return None
             if status.state == DISPATCH_ACCEPTED:
-                return store.get_event(session_id, event_id)
+                settlement = store.reconcile_dispatch_settlement(
+                    session_id,
+                    event_id,
+                )
+                if settlement is not None and settlement.can_report_success:
+                    return store.get_event(session_id, event_id)
+                raise localized_show_event_error("show_event_dispatch_failed")
             if status.state == DISPATCH_ARCHIVED:
                 raise localized_show_event_error("show_event_dispatch_failed")
             if status.state in {DISPATCH_NONE, DISPATCH_FAILED}:

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -10696,7 +10696,11 @@ def _post_show_event_to_live_ui(session_id: str, payload: dict) -> dict | None:
         return None
     except (OSError, json.JSONDecodeError, ValueError):
         return None
-    return parsed.get("event") if isinstance(parsed, dict) and parsed.get("ok") is True else None
+    if not isinstance(parsed, dict):
+        return None
+    if parsed.get("dispatch_pending") is True:
+        return _resolve_show_event_after_ambiguous_live_timeout(session_id, payload)
+    return parsed.get("event") if parsed.get("ok") is True else None
 
 
 def _resolve_show_event_after_ambiguous_live_timeout(
@@ -10711,8 +10715,8 @@ def _resolve_show_event_after_ambiguous_live_timeout(
         DISPATCH_FAILED,
         DISPATCH_IN_FLIGHT,
         DISPATCH_NONE,
-        ShowSessionEventError,
         ShowSessionEventStore,
+        localized_show_event_error,
     )
 
     event_id = payload.get("id")
@@ -10732,10 +10736,7 @@ def _resolve_show_event_after_ambiguous_live_timeout(
             if status.state != DISPATCH_IN_FLIGHT:
                 return store.get_event(session_id, event_id)
             if time.monotonic() >= deadline:
-                raise ShowSessionEventError(
-                    "Show event dispatch is still pending; retry after its status settles.",
-                    code="show_event_dispatch_pending",
-                )
+                raise localized_show_event_error("show_event_dispatch_pending")
             time.sleep(0.05)
     finally:
         store.close()

--- a/vibe/i18n/en.json
+++ b/vibe/i18n/en.json
@@ -12,6 +12,12 @@
     "title": "Fork {title}",
     "titleUntitled": "Fork"
   },
+  "show": {
+    "event": {
+      "acceptanceUnknown": "The Show event may still be processing. It was not replayed locally.",
+      "dispatchFailed": "The Show event was recorded, but its agent turn could not be delivered."
+    }
+  },
   "harness": {
     "watch": {
       "supervisorFailed": "Watch worker supervisor failed: {detail}",

--- a/vibe/i18n/en.json
+++ b/vibe/i18n/en.json
@@ -15,7 +15,8 @@
   "show": {
     "event": {
       "acceptanceUnknown": "The Show event may still be processing. It was not replayed locally.",
-      "dispatchFailed": "The Show event was recorded, but its agent turn could not be delivered."
+      "dispatchFailed": "The Show event was recorded, but its agent turn could not be delivered.",
+      "idConflict": "This Show event ID is already bound to different event contents."
     }
   },
   "harness": {

--- a/vibe/i18n/zh.json
+++ b/vibe/i18n/zh.json
@@ -12,6 +12,12 @@
     "title": "复刻 {title}",
     "titleUntitled": "复刻"
   },
+  "show": {
+    "event": {
+      "acceptanceUnknown": "Show 事件可能仍在处理中，未在本地重复提交。",
+      "dispatchFailed": "Show 事件已记录，但未能投递对应的 Agent turn。"
+    }
+  },
   "harness": {
     "watch": {
       "supervisorFailed": "Watch 监控进程失败：{detail}",

--- a/vibe/i18n/zh.json
+++ b/vibe/i18n/zh.json
@@ -15,7 +15,8 @@
   "show": {
     "event": {
       "acceptanceUnknown": "Show 事件可能仍在处理中，未在本地重复提交。",
-      "dispatchFailed": "Show 事件已记录，但未能投递对应的 Agent turn。"
+      "dispatchFailed": "Show 事件已记录，但未能投递对应的 Agent turn。",
+      "idConflict": "此 Show 事件 ID 已绑定到不同的事件内容。"
     }
   },
   "harness": {

--- a/vibe/internal_client.py
+++ b/vibe/internal_client.py
@@ -185,7 +185,7 @@ async def dispatch_async(
     payload: dict[str, Any],
     *,
     socket_path: Optional[Path] = None,
-    timeout: float = 10.0,
+    timeout: float | None = 10.0,
 ) -> dict[str, Any]:
     """Start a fire-and-forget turn on the controller and return immediately.
 

--- a/vibe/internal_client.py
+++ b/vibe/internal_client.py
@@ -33,12 +33,7 @@ _SOCKET_CONNECT_ERRORS = (httpx.ConnectError, httpx.ConnectTimeout, OSError)
 
 
 class InternalServerUnavailable(Exception):
-    """Raised when the dispatch socket cannot be reached.
-
-    Routes should catch this and degrade to the queue-based fallback so
-    a controller crash or socket-bind race doesn't take down the
-    user-facing send-compose flow.
-    """
+    """Raised when the dispatch socket cannot be reached before acceptance."""
 
 
 class InternalServerTimeout(Exception):
@@ -193,8 +188,9 @@ async def dispatch_async(
     responds ``202`` right away (the reply arrives over the persistent
     ``message.new`` session stream, not this response). Returns
     ``{"status_code", "body"}`` so the caller can distinguish a started turn
-    (202) from a concurrent-turn refusal (409). Raises
-    ``InternalServerUnavailable`` on socket failure so the route can degrade.
+    from one accepted into the shared queue. A pre-connect failure raises
+    ``InternalServerUnavailable``; a post-connect timeout raises
+    ``InternalServerTimeout`` because acceptance is unknown.
     """
 
     target = (socket_path or default_socket_path()).expanduser().resolve()
@@ -208,8 +204,12 @@ async def dispatch_async(
             timeout=httpx.Timeout(timeout, connect=5.0),
         ) as client:
             resp = await client.post("/internal/dispatch_async", json=payload)
-    except _SOCKET_ERRORS as exc:
+    except _SOCKET_CONNECT_ERRORS as exc:
         raise InternalServerUnavailable(str(exc)) from exc
+    except httpx.TimeoutException as exc:
+        # Once the socket connected, a timeout is acceptance-unknown: the
+        # controller request may still settle the durable reservation.
+        raise InternalServerTimeout(str(exc)) from exc
     return {"status_code": resp.status_code, "body": resp.json() if resp.content else {}}
 
 

--- a/vibe/internal_client.py
+++ b/vibe/internal_client.py
@@ -6,13 +6,12 @@ The UI server runs as its own subprocess; this module is how it reaches
 
 Single responsibility: keep all the socket-path / httpx-transport /
 SSE-parsing boilerplate out of the UI route bodies. Routes call
-``dispatch_async(...)`` to start a fire-and-forget turn (the Chat page — the
-reply arrives over the persistent ``message.new`` session stream, not the
-response), ``stream_dispatch(...)`` to run a turn and stream its chunks back
-(the Show-page dispatch flow), ``stream_events(...)`` to subscribe to the
-controller's event feed, and ``cancel_dispatch`` / ``send_now`` /
-``turn_state`` / ``health`` for the turn-control surface — each raising
-``InternalServerUnavailable`` so the route can degrade gracefully.
+``dispatch_async(...)`` to start a fire-and-forget turn (the reply arrives over
+the persistent ``message.new`` session stream, not the response),
+``stream_events(...)`` to subscribe to the controller's event feed, and
+``cancel_dispatch`` / ``send_now`` / ``turn_state`` / ``health`` for the
+turn-control surface — each raising ``InternalServerUnavailable`` so the route
+can degrade gracefully.
 """
 
 from __future__ import annotations
@@ -60,71 +59,6 @@ def default_socket_path() -> Path:
     if override:
         return Path(override).expanduser()
     return paths.get_state_dir() / "dispatch.sock"
-
-
-async def stream_dispatch(
-    payload: dict[str, Any],
-    *,
-    socket_path: Optional[Path] = None,
-    timeout: float = 1800.0,
-) -> AsyncIterator[tuple[str, dict[str, Any]]]:
-    """Send a dispatch request and yield the turn's SSE events as they arrive.
-
-    Each yielded tuple is ``(event_name, parsed_data)`` — e.g. ``("turn.start",
-    {...})``, ``("turn.chunk", {...})``, ``("turn.end", {...})``. The caller
-    re-encodes them for the browser. Raises ``InternalServerUnavailable`` for
-    connect-time failures so the caller can degrade.
-
-    NB: the web **Chat** page no longer uses this (it's fire-and-forget +
-    ``message.new``); this streaming round-trip backs the **Show-page** dispatch
-    flow (``_run_show_event_dispatch`` re-publishes each event as ``show.dispatch``).
-    """
-
-    target = (socket_path or default_socket_path()).expanduser().resolve()
-    if not target.exists():
-        raise InternalServerUnavailable(f"dispatch socket missing at {target}")
-
-    transport = httpx.AsyncHTTPTransport(uds=str(target))
-    try:
-        async with httpx.AsyncClient(
-            transport=transport,
-            base_url="http://localhost",
-            timeout=httpx.Timeout(timeout, connect=5.0),
-        ) as client:
-            try:
-                stream = client.stream("POST", "/internal/dispatch", json=payload)
-            except _SOCKET_ERRORS as exc:
-                raise InternalServerUnavailable(str(exc)) from exc
-
-            async with stream as resp:
-                if resp.status_code >= 400:
-                    detail = await resp.aread()
-                    raise InternalServerUnavailable(
-                        f"dispatch endpoint returned {resp.status_code}: {detail!r}"
-                    )
-
-                current_event: Optional[str] = None
-                async for line in resp.aiter_lines():
-                    if not line:
-                        # Blank line ends an SSE event block; reset the
-                        # event-name buffer so a missing ``event:`` field
-                        # on the next block defaults to ``message``.
-                        current_event = None
-                        continue
-                    if line.startswith("event:"):
-                        current_event = line.split(":", 1)[1].strip()
-                    elif line.startswith("data:"):
-                        raw = line[5:].lstrip()
-                        try:
-                            parsed = json.loads(raw)
-                        except json.JSONDecodeError:
-                            logger.warning("internal_client: invalid SSE data line %r", raw)
-                            continue
-                        yield (current_event or "message", parsed)
-    except InternalServerUnavailable:
-        raise
-    except _SOCKET_ERRORS as exc:
-        raise InternalServerUnavailable(str(exc)) from exc
 
 
 async def stream_events(

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -7542,7 +7542,9 @@ def _promote_and_publish_pending_user_message(
     queued: bool = False,
 ) -> dict[str, Any]:
     """Make a reserved user row visible after the unified turn entry accepts it."""
+    from sqlalchemy import select
     from storage import messages_service
+    from storage.models import messages
     from vibe.sse_broker import broker
 
     if queued:
@@ -7554,7 +7556,15 @@ def _promote_and_publish_pending_user_message(
     engine = _projects_engine()
     with engine.begin() as conn:
         promoted = messages_service.promote_pending(conn, row["id"], "user")
+        current_type = conn.execute(
+            select(messages.c.type).where(messages.c.id == row["id"])
+        ).scalar_one_or_none()
     if not promoted:
+        # A replay can observe a row already settled by the first request. Keep
+        # that durable state instead of misreporting every non-pending row as
+        # queued.
+        if current_type == "user":
+            return {**row, "type": "user"}
         # The controller owns pending -> queued when a turn is already active.
         broker.publish("queue.updated", {"session_id": session_id, "scope_id": scope_id})
         return {**row, "type": messages_service.QUEUED_TYPE}

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -7751,6 +7751,11 @@ async def sessions_messages_create(session_id: str):
     if status == 202 and quick_reply_for:
         with engine.begin() as conn:
             messages_service.set_quick_reply_chosen(conn, session_id, quick_reply_for, dispatch_text)
+    if status == 202 and body.get("drained"):
+        # The row joined an idle pre-existing queue and was synchronously merged
+        # before acceptance returned. ``flush_queue`` already published the
+        # freshly ordered replacement; do not append the retired reservation.
+        return jsonify({"drained": True}), 202
     if status == 202 and body.get("queued"):
         # Enqueued behind a running turn: the controller already promoted the
         # row pending→queued, so it stays OUT of the transcript (no
@@ -9061,7 +9066,24 @@ async def _show_event_response_from_payload(
         # The internal endpoint returns after SessionTurnManager has either
         # started or queued the turn. Settle the pending transcript row before
         # acknowledging the Show event so a successful POST cannot strand it.
-        await _run_show_event_dispatch(event_payload)
+        accepted = await _run_show_event_dispatch(event_payload)
+        if not accepted:
+            exc = _show_event_dispatch_error()
+            return (
+                jsonify(
+                    {
+                        "ok": False,
+                        "code": exc.code,
+                        "error": str(exc),
+                        "event": _show_event_response_payload(
+                            event_payload,
+                            public=public,
+                            public_share_id=public_share_id,
+                        ),
+                    }
+                ),
+                502,
+            )
     return (
         jsonify(
             {
@@ -9093,14 +9115,7 @@ def record_local_show_event(session_id: str, payload: dict[str, Any], *, dispatc
             # without waiting for the agent turn itself.
             accepted = asyncio.run(_run_show_event_dispatch(event_payload))
             if not accepted:
-                try:
-                    language = V2Config.load().language
-                except Exception:
-                    language = "en"
-                raise ShowSessionEventError(
-                    t("show.event.dispatchFailed", language),
-                    code="show_event_dispatch_failed",
-                )
+                raise _show_event_dispatch_error()
             return event_payload
     _dispatch_show_event_if_requested(event_payload)
     return event_payload
@@ -9185,6 +9200,28 @@ async def _run_show_event_dispatch(event_payload: dict[str, Any]) -> bool:
 
     status = result.get("status_code", 500)
     body = result.get("body") or {}
+    if status == 202 and body.get("drained"):
+        settled_message = _load_show_event_message(event_payload)
+        if settled_message is not None:
+            event_payload["message_id"] = settled_message["id"]
+            event_payload["message"] = settled_message
+            return True
+    settled_message_id = body.get("message_id")
+    if (
+        status == 202
+        and body.get("message_type") == "user"
+        and isinstance(settled_message_id, str)
+        and settled_message_id
+    ):
+        settled_message = _load_session_message(session_id, settled_message_id)
+        if settled_message is not None:
+            # An idle pre-existing queue may have synchronously drained before
+            # the 202 reached this process. The manager already published the
+            # freshly ordered row; return that durable identity without
+            # re-publishing the stale pending reservation as queued.
+            event_payload["message_id"] = settled_message_id
+            event_payload["message"] = settled_message
+            return True
     if status == 202 and body.get("queued"):
         event_payload["message"] = _promote_and_publish_pending_user_message(
             message,
@@ -9209,6 +9246,55 @@ async def _run_show_event_dispatch(event_payload: dict[str, Any]) -> bool:
         activity_event="show_event",
     )
     return status == 202
+
+
+def _show_event_dispatch_error() -> ShowSessionEventError:
+    try:
+        language = V2Config.load().language
+    except Exception:
+        language = "en"
+    return ShowSessionEventError(
+        t("show.event.dispatchFailed", language),
+        code="show_event_dispatch_failed",
+    )
+
+
+def _load_session_message(session_id: str, message_id: str) -> dict[str, Any] | None:
+    from storage import messages_service
+
+    with _projects_engine().connect() as conn:
+        window = messages_service.list_session_messages(
+            conn,
+            session_id=session_id,
+            around_id=message_id,
+            limit=1,
+        )
+    return next(
+        (item for item in window["messages"] if item.get("id") == message_id),
+        None,
+    )
+
+
+def _load_show_event_message(event_payload: dict[str, Any]) -> dict[str, Any] | None:
+    from sqlalchemy import select
+    from storage.models import show_session_events
+
+    session_id = event_payload.get("session_id")
+    event_id = event_payload.get("id")
+    if not isinstance(session_id, str) or not session_id:
+        return None
+    if not isinstance(event_id, str) or not event_id:
+        return None
+    with _projects_engine().connect() as conn:
+        message_id = conn.execute(
+            select(show_session_events.c.message_id).where(
+                show_session_events.c.id == event_id,
+                show_session_events.c.session_id == session_id,
+            )
+        ).scalar_one_or_none()
+    if not isinstance(message_id, str) or not message_id:
+        return None
+    return _load_session_message(session_id, message_id)
 
 
 def _show_event_dispatch_text(event_payload: dict[str, Any]) -> str:

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -9121,6 +9121,9 @@ def _dispatch_show_event_if_requested(event_payload: dict[str, Any]) -> None:
     loop.create_task(_run_show_event_dispatch(event_payload))
 
 
+_SHOW_EVENT_DISPATCH_ACCEPT_TIMEOUT_SECONDS = 2.0
+
+
 async def _run_show_event_dispatch(event_payload: dict[str, Any]) -> None:
     from vibe import internal_client
 
@@ -9140,7 +9143,22 @@ async def _run_show_event_dispatch(event_payload: dict[str, Any]) -> None:
     if not isinstance(message, dict):
         return
     try:
-        result = await internal_client.dispatch_async(dispatch_payload)
+        # The CLI live-UI bridge has a three-second request budget before it
+        # falls back to a local write. Bound this local acceptance round-trip
+        # inside that budget so one slow controller cannot dispatch both paths.
+        result = await asyncio.wait_for(
+            internal_client.dispatch_async(dispatch_payload),
+            timeout=_SHOW_EVENT_DISPATCH_ACCEPT_TIMEOUT_SECONDS,
+        )
+    except asyncio.TimeoutError:
+        logger.warning("show event dispatch acceptance timed out for session %s", session_id)
+        event_payload["message"] = _promote_and_publish_pending_user_message(
+            message,
+            session_id=session_id,
+            scope_id=scope_id if isinstance(scope_id, str) else None,
+            activity_event="show_event",
+        )
+        return
     except internal_client.InternalServerUnavailable as exc:
         logger.warning("show event dispatch unavailable for session %s: %s", session_id, exc)
         event_payload["message"] = _promote_and_publish_pending_user_message(

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -7533,56 +7533,75 @@ def asr_status():
         return jsonify({"available": False})
 
 
-def _promote_and_publish_pending_user_message(
+def _publish_visible_user_message(
     row: dict[str, Any],
     *,
     session_id: str,
     scope_id: str | None,
     activity_event: str = "user_message",
-    queued: bool = False,
 ) -> dict[str, Any]:
-    """Make a reserved user row visible after the unified turn entry accepts it."""
-    from sqlalchemy import select
+    """Publish one already-visible user row through the shared fan-out."""
     from storage import messages_service
-    from storage.models import messages
     from vibe.sse_broker import broker
 
-    if queued:
-        # The controller already promoted pending -> queued inside the manager's
-        # enqueue callback; this process only fans out the decided queue state.
-        broker.publish("queue.updated", {"session_id": session_id, "scope_id": scope_id})
-        return {**row, "type": messages_service.QUEUED_TYPE}
-
-    engine = _projects_engine()
-    with engine.begin() as conn:
-        promoted = messages_service.promote_pending(conn, row["id"], "user")
-        current_type = conn.execute(
-            select(messages.c.type).where(messages.c.id == row["id"])
-        ).scalar_one_or_none()
-    if not promoted:
-        # A replay can observe a row already settled by the first request. Keep
-        # that durable state instead of misreporting every non-pending row as
-        # queued.
-        if current_type == "user":
-            return {**row, "type": "user"}
-        # The controller owns pending -> queued when a turn is already active.
-        broker.publish("queue.updated", {"session_id": session_id, "scope_id": scope_id})
-        return {**row, "type": messages_service.QUEUED_TYPE}
-
-    visible = {**row, "type": "user"}
-    broker.publish("message.new", visible)
+    broker.publish("message.new", row)
     broker.publish(
         "session.activity",
         {"session_id": session_id, "scope_id": scope_id, "event": activity_event},
     )
     try:
-        with engine.connect() as conn:
+        with _projects_engine().connect() as conn:
             inbox_row = messages_service.get_inbox_session(conn, session_id, platform="avibe")
         if inbox_row is not None:
             broker.publish("inbox.session.updated", inbox_row)
     except Exception:
         logger.debug("inbox.session.updated publish (user message) failed", exc_info=True)
-    return visible
+    return row
+
+
+def _promote_and_publish_pending_user_message(
+    row: dict[str, Any],
+    *,
+    session_id: str,
+    scope_id: str | None,
+) -> dict[str, Any]:
+    """Publish a no-turn user row after locally making it transcript-visible."""
+    from storage import messages_service
+
+    with _projects_engine().begin() as conn:
+        messages_service.promote_pending(conn, row["id"], "user")
+    return _publish_visible_user_message(
+        {**row, "type": "user"},
+        session_id=session_id,
+        scope_id=scope_id,
+    )
+
+
+def _publish_accepted_user_message(
+    row: dict[str, Any],
+    *,
+    session_id: str,
+    scope_id: str | None,
+    activity_event: str = "user_message",
+) -> dict[str, Any]:
+    """Fan out the durable state written by the unified controller entry."""
+    from storage import messages_service
+    from vibe.sse_broker import broker
+
+    settled = _load_session_message(session_id, row["id"])
+    if settled is None:
+        return row
+    if settled.get("type") == messages_service.QUEUED_TYPE:
+        broker.publish("queue.updated", {"session_id": session_id, "scope_id": scope_id})
+        return settled
+    if settled.get("type") == "user":
+        return _publish_visible_user_message(
+            settled,
+            session_id=session_id,
+            scope_id=scope_id,
+            activity_event=activity_event,
+        )
+    return settled
 
 
 @app.route("/api/sessions/<session_id>/messages", methods=["POST"])
@@ -7718,30 +7737,45 @@ async def sessions_messages_create(session_id: str):
         "user_message_id": message.get("id"),
         "files": attachment_specs,
     }
+    with engine.begin() as conn:
+        messages_service.claim_dispatch_reservation(conn, message["id"])
     try:
         result = await internal_client.dispatch_async(dispatch_payload)
+    except internal_client.InternalServerTimeout as exc:
+        return jsonify(
+            {
+                **message,
+                "type": messages_service.DISPATCHING_TYPE,
+                "dispatch_error": "dispatch_pending",
+                "detail": str(exc),
+            }
+        ), 504
     except internal_client.InternalServerUnavailable as exc:
-        # Couldn't reach the controller — promote + surface the row so the
-        # user still sees their message, plus the failure.
-        published = _promote_and_publish_pending_user_message(
-            message,
-            session_id=session_id,
-            scope_id=session["scope_id"],
-        )
-        return jsonify({**published, "dispatch_error": "internal_unavailable", "detail": str(exc)}), 502
+        with engine.begin() as conn:
+            messages_service.fail_dispatch_reservation(conn, message["id"])
+        return jsonify(
+            {
+                **message,
+                "type": messages_service.DISPATCH_FAILED_TYPE,
+                "dispatch_error": "internal_unavailable",
+                "detail": str(exc),
+            }
+        ), 502
     except Exception as exc:
-        # The socket existed but the call failed another way (ReadTimeout, a
-        # non-JSON / 500 response, etc.). The row is still reserved as hidden
-        # ``pending`` and the draft was cleared, so WITHOUT this the user's text
-        # would vanish from both transcript and queue behind an error. Promote +
-        # publish it with the error, same as the unavailable branch (Codex P2).
-        logger.warning("dispatch_async call failed for session %s: %s", session_id, exc, exc_info=True)
-        published = _promote_and_publish_pending_user_message(
-            message,
-            session_id=session_id,
-            scope_id=session["scope_id"],
+        logger.warning(
+            "dispatch_async acceptance is unknown for session %s: %s",
+            session_id,
+            exc,
+            exc_info=True,
         )
-        return jsonify({**published, "dispatch_error": "dispatch_failed", "detail": str(exc)}), 502
+        return jsonify(
+            {
+                **message,
+                "type": messages_service.DISPATCHING_TYPE,
+                "dispatch_error": "dispatch_pending",
+                "detail": str(exc),
+            }
+        ), 502
     status = result.get("status_code", 500)
     body = result.get("body") or {}
     # Quick-reply accepted (turn started OR queued) → record the choice on the
@@ -7760,29 +7794,31 @@ async def sessions_messages_create(session_id: str):
         # Enqueued behind a running turn: the controller already promoted the
         # row pending→queued, so it stays OUT of the transcript (no
         # message.new); show it above the composer via queue.updated.
-        queued = _promote_and_publish_pending_user_message(
+        queued = _publish_accepted_user_message(
             message,
             session_id=session_id,
             scope_id=session["scope_id"],
-            queued=True,
         )
         return jsonify({**queued, "queued": True}), 202
     if status == 202:
-        # Turn started — promote + publish the prompt.
+        # Turn started — the controller already settled the row as ``user``.
         return jsonify(
-            _promote_and_publish_pending_user_message(
+            _publish_accepted_user_message(
                 message,
                 session_id=session_id,
                 scope_id=session["scope_id"],
             )
         ), 201
-    # Dispatch failed: still promote + show the row + the error.
-    published = _promote_and_publish_pending_user_message(
-        message,
-        session_id=session_id,
-        scope_id=session["scope_id"],
-    )
-    return jsonify({**published, "dispatch_error": "dispatch_failed", "detail": body}), 502
+    with engine.begin() as conn:
+        messages_service.fail_dispatch_reservation(conn, message["id"])
+    return jsonify(
+        {
+            **message,
+            "type": messages_service.DISPATCH_FAILED_TYPE,
+            "dispatch_error": "dispatch_failed",
+            "detail": body,
+        }
+    ), 502
 
 
 @app.route("/api/sessions/<session_id>/cancel", methods=["POST"])
@@ -8930,7 +8966,7 @@ def _show_page_runtime_failure_response(
 
 def _show_session_event_error_response(exc: Exception):
     code = getattr(exc, "code", "show_session_event_failed")
-    status = 404 if code == "session_not_found" else 400
+    status = 404 if code == "session_not_found" else 409 if code == "event_id_conflict" else 400
     return jsonify({"ok": False, "code": code, "error": str(exc)}), status
 
 
@@ -9122,11 +9158,15 @@ def record_local_show_event(session_id: str, payload: dict[str, Any], *, dispatc
 
 
 def _publish_show_session_event(event_payload: dict[str, Any]) -> None:
+    from storage import messages_service
     from vibe.sse_broker import broker
 
     broker.publish("show.event", event_payload)
     message = event_payload.get("message")
-    if isinstance(message, dict) and message.get("type") == "pending":
+    if (
+        isinstance(message, dict)
+        and message.get("type") in messages_service.DISPATCH_RESERVATION_TYPES
+    ):
         return
     if isinstance(message, dict):
         broker.publish("message.new", message)
@@ -9157,6 +9197,7 @@ def _dispatch_show_event_if_requested(event_payload: dict[str, Any]) -> None:
 
 
 async def _run_show_event_dispatch(event_payload: dict[str, Any]) -> bool:
+    from storage import messages_service
     from vibe import internal_client
 
     session_id = event_payload.get("session_id")
@@ -9174,20 +9215,79 @@ async def _run_show_event_dispatch(event_payload: dict[str, Any]) -> bool:
     message = event_payload.get("message")
     if not isinstance(message, dict):
         return False
+    with _projects_engine().begin() as conn:
+        reservation_type, claimed = messages_service.claim_dispatch_reservation(
+            conn,
+            message["id"],
+        )
+    if not claimed:
+        settled_message = _load_show_event_message(event_payload)
+        if settled_message is not None:
+            event_payload["message_id"] = settled_message["id"]
+            event_payload["message"] = settled_message
+            reservation_type = settled_message.get("type")
+        return reservation_type in {"user", messages_service.QUEUED_TYPE}
+
     try:
-        # A dispatch timeout is ambiguous: the controller may still enqueue after
-        # the client coroutine is cancelled. Wait for the manager's quick 202
-        # decision so the pending row is settled exactly once.
         result = await internal_client.dispatch_async(dispatch_payload, timeout=None)
+    except internal_client.InternalServerTimeout as exc:
+        logger.warning("show event dispatch still pending for session %s: %s", session_id, exc)
+        settled_message = _load_show_event_message(event_payload)
+        if settled_message is not None:
+            event_payload["message_id"] = settled_message["id"]
+            event_payload["message"] = settled_message
+            if settled_message.get("type") in {"user", messages_service.QUEUED_TYPE}:
+                if settled_message["id"] == message["id"]:
+                    event_payload["message"] = _publish_accepted_user_message(
+                        settled_message,
+                        session_id=session_id,
+                        scope_id=scope_id if isinstance(scope_id, str) else None,
+                        activity_event="show_event",
+                    )
+                return True
+        # The durable state is still acceptance-unknown. A concurrent CLI or
+        # browser retry sees ``dispatching`` and never submits a second turn.
+        event_payload["message"] = {
+            **message,
+            "type": messages_service.DISPATCHING_TYPE,
+        }
+        return False
     except internal_client.InternalServerUnavailable as exc:
         logger.warning("show event dispatch unavailable for session %s: %s", session_id, exc)
+        with _projects_engine().begin() as conn:
+            messages_service.fail_dispatch_reservation(conn, message["id"])
+        event_payload["message"] = {
+            **message,
+            "type": messages_service.DISPATCH_FAILED_TYPE,
+        }
         return False
     except Exception as exc:  # pragma: no cover - defensive
-        logger.exception("show event dispatch failed")
+        # A protocol/read failure after connect is acceptance-unknown too. Only a
+        # definitive controller rejection may make the reservation retryable.
+        logger.exception("show event dispatch acceptance is unknown")
+        event_payload["message"] = {
+            **message,
+            "type": messages_service.DISPATCHING_TYPE,
+        }
         return False
 
     status = result.get("status_code", 500)
     body = result.get("body") or {}
+    if status != 202:
+        logger.warning(
+            "show event dispatch failed for session %s: status=%s body=%s",
+            session_id,
+            status,
+            body,
+        )
+        with _projects_engine().begin() as conn:
+            messages_service.fail_dispatch_reservation(conn, message["id"])
+        event_payload["message"] = {
+            **message,
+            "type": messages_service.DISPATCH_FAILED_TYPE,
+        }
+        return False
+
     if status == 202 and body.get("drained"):
         settled_message = _load_show_event_message(event_payload)
         if settled_message is not None:
@@ -9203,37 +9303,31 @@ async def _run_show_event_dispatch(event_payload: dict[str, Any]) -> bool:
     ):
         settled_message = _load_session_message(session_id, settled_message_id)
         if settled_message is not None:
-            # An idle pre-existing queue may have synchronously drained before
-            # the 202 reached this process. The manager already published the
-            # freshly ordered row; return that durable identity without
-            # re-publishing the stale pending reservation as queued.
             event_payload["message_id"] = settled_message_id
+            # A synchronous queue drain already published the freshly promoted
+            # row from SessionTurnManager.flush_queue.
             event_payload["message"] = settled_message
             return True
     if status == 202 and body.get("queued"):
-        event_payload["message"] = _promote_and_publish_pending_user_message(
+        event_payload["message"] = _publish_accepted_user_message(
             message,
             session_id=session_id,
             scope_id=scope_id if isinstance(scope_id, str) else None,
             activity_event="show_event",
-            queued=True,
         )
         return True
 
-    if status != 202:
-        logger.warning(
-            "show event dispatch failed for session %s: status=%s body=%s",
-            session_id,
-            status,
-            body,
-        )
-    event_payload["message"] = _promote_and_publish_pending_user_message(
-        message,
+    settled_message = _load_show_event_message(event_payload)
+    if settled_message is None or settled_message.get("type") != "user":
+        return False
+    event_payload["message_id"] = settled_message["id"]
+    event_payload["message"] = _publish_accepted_user_message(
+        settled_message,
         session_id=session_id,
         scope_id=scope_id if isinstance(scope_id, str) else None,
         activity_event="show_event",
     )
-    return status == 202
+    return True
 
 
 def _show_event_dispatch_error() -> ShowSessionEventError:

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -9012,7 +9012,7 @@ def _show_me_response(author: dict[str, str] | None, *, write_token: str | None 
     return response
 
 
-def _show_event_response_from_payload(
+async def _show_event_response_from_payload(
     session_id: str,
     payload: dict[str, Any],
     *,
@@ -9034,15 +9034,23 @@ def _show_event_response_from_payload(
         )
     store = _show_session_event_store()
     try:
-        event_payload = store.append(session_id, payload, author=author)
+        event_payload = store.append(
+            session_id,
+            payload,
+            author=author,
+            reserve_dispatch=allow_dispatch,
+        )
     except Exception as exc:
         return _show_session_event_error_response(exc)
     finally:
         store.close()
 
     _publish_show_session_event(event_payload)
-    if allow_dispatch:
-        _dispatch_show_event_if_requested(event_payload)
+    if allow_dispatch and show_event_requests_dispatch(event_payload):
+        # The internal endpoint returns after SessionTurnManager has either
+        # started or queued the turn. Settle the pending transcript row before
+        # acknowledging the Show event so a successful POST cannot strand it.
+        await _run_show_event_dispatch(event_payload)
     return (
         jsonify(
             {
@@ -9061,7 +9069,7 @@ def _show_event_response_from_payload(
 def record_local_show_event(session_id: str, payload: dict[str, Any], *, dispatch_sync: bool = False) -> dict[str, Any]:
     store = _show_session_event_store()
     try:
-        event_payload = store.append(session_id, payload)
+        event_payload = store.append(session_id, payload, reserve_dispatch=True)
     finally:
         store.close()
     _publish_show_session_event(event_payload)
@@ -9389,7 +9397,7 @@ async def _show_events_response(
     if not _show_event_write_authorized(session_id):
         return jsonify({"ok": False, "code": "show_event_write_forbidden"}), 403
 
-    return _show_event_response_from_payload(
+    return await _show_event_response_from_payload(
         session_id,
         _show_events_payload_from_request(),
         author=_show_request_author(),
@@ -9397,10 +9405,10 @@ async def _show_events_response(
 
 
 @app.route("/api/show/sessions/<session_id>/events", methods=["POST"])
-def show_session_events_create(session_id: str):
+async def show_session_events_create(session_id: str):
     if not _is_cli_show_event_request():
         return jsonify({"ok": False, "code": "forbidden"}), 403
-    return _show_event_response_from_payload(session_id, _show_events_payload_from_request())
+    return await _show_event_response_from_payload(session_id, _show_events_payload_from_request())
 
 
 @app.route("/api/show/sessions/<session_id>/prewarm", methods=["POST"])
@@ -10261,7 +10269,7 @@ async def serve_public_show_page(share_id, asset_path):
                     ),
                     400,
                 )
-            return _show_event_response_from_payload(
+            return await _show_event_response_from_payload(
                 page.session_id,
                 payload,
                 author=author,

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -9181,21 +9181,9 @@ async def _run_show_event_dispatch(event_payload: dict[str, Any]) -> bool:
         result = await internal_client.dispatch_async(dispatch_payload, timeout=None)
     except internal_client.InternalServerUnavailable as exc:
         logger.warning("show event dispatch unavailable for session %s: %s", session_id, exc)
-        event_payload["message"] = _promote_and_publish_pending_user_message(
-            message,
-            session_id=session_id,
-            scope_id=scope_id if isinstance(scope_id, str) else None,
-            activity_event="show_event",
-        )
         return False
     except Exception as exc:  # pragma: no cover - defensive
         logger.exception("show event dispatch failed")
-        event_payload["message"] = _promote_and_publish_pending_user_message(
-            message,
-            session_id=session_id,
-            scope_id=scope_id if isinstance(scope_id, str) else None,
-            activity_event="show_event",
-        )
         return False
 
     status = result.get("status_code", 500)

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -48,6 +48,7 @@ from core.show_pages import (
 )
 from core.show_session_events import (
     HUMAN_EVENT_TYPES,
+    ShowSessionEventError,
     show_event_payload_session_mismatch,
     show_event_requests_dispatch,
 )
@@ -9080,7 +9081,16 @@ def record_local_show_event(session_id: str, payload: dict[str, Any], *, dispatc
             # The 202 endpoint returns after the manager accepts or queues the
             # turn, so CLI callers can synchronously settle the pending row
             # without waiting for the agent turn itself.
-            asyncio.run(_run_show_event_dispatch(event_payload))
+            accepted = asyncio.run(_run_show_event_dispatch(event_payload))
+            if not accepted:
+                try:
+                    language = V2Config.load().language
+                except Exception:
+                    language = "en"
+                raise ShowSessionEventError(
+                    t("show.event.dispatchFailed", language),
+                    code="show_event_dispatch_failed",
+                )
             return event_payload
     _dispatch_show_event_if_requested(event_payload)
     return event_payload
@@ -9121,17 +9131,14 @@ def _dispatch_show_event_if_requested(event_payload: dict[str, Any]) -> None:
     loop.create_task(_run_show_event_dispatch(event_payload))
 
 
-_SHOW_EVENT_DISPATCH_ACCEPT_TIMEOUT_SECONDS = 2.0
-
-
-async def _run_show_event_dispatch(event_payload: dict[str, Any]) -> None:
+async def _run_show_event_dispatch(event_payload: dict[str, Any]) -> bool:
     from vibe import internal_client
 
     session_id = event_payload.get("session_id")
     scope_id = event_payload.get("scope_id")
     transcript_text = event_payload.get("transcript_text")
     if not isinstance(session_id, str) or not session_id or not isinstance(transcript_text, str) or not transcript_text.strip():
-        return
+        return False
     dispatch_payload = {
         "session_id": session_id,
         "text": _show_event_dispatch_text(event_payload),
@@ -9141,24 +9148,12 @@ async def _run_show_event_dispatch(event_payload: dict[str, Any]) -> None:
     }
     message = event_payload.get("message")
     if not isinstance(message, dict):
-        return
+        return False
     try:
-        # The CLI live-UI bridge has a three-second request budget before it
-        # falls back to a local write. Bound this local acceptance round-trip
-        # inside that budget so one slow controller cannot dispatch both paths.
-        result = await asyncio.wait_for(
-            internal_client.dispatch_async(dispatch_payload),
-            timeout=_SHOW_EVENT_DISPATCH_ACCEPT_TIMEOUT_SECONDS,
-        )
-    except asyncio.TimeoutError:
-        logger.warning("show event dispatch acceptance timed out for session %s", session_id)
-        event_payload["message"] = _promote_and_publish_pending_user_message(
-            message,
-            session_id=session_id,
-            scope_id=scope_id if isinstance(scope_id, str) else None,
-            activity_event="show_event",
-        )
-        return
+        # A dispatch timeout is ambiguous: the controller may still enqueue after
+        # the client coroutine is cancelled. Wait for the manager's quick 202
+        # decision so the pending row is settled exactly once.
+        result = await internal_client.dispatch_async(dispatch_payload, timeout=None)
     except internal_client.InternalServerUnavailable as exc:
         logger.warning("show event dispatch unavailable for session %s: %s", session_id, exc)
         event_payload["message"] = _promote_and_publish_pending_user_message(
@@ -9167,7 +9162,7 @@ async def _run_show_event_dispatch(event_payload: dict[str, Any]) -> None:
             scope_id=scope_id if isinstance(scope_id, str) else None,
             activity_event="show_event",
         )
-        return
+        return False
     except Exception as exc:  # pragma: no cover - defensive
         logger.exception("show event dispatch failed")
         event_payload["message"] = _promote_and_publish_pending_user_message(
@@ -9176,7 +9171,7 @@ async def _run_show_event_dispatch(event_payload: dict[str, Any]) -> None:
             scope_id=scope_id if isinstance(scope_id, str) else None,
             activity_event="show_event",
         )
-        return
+        return False
 
     status = result.get("status_code", 500)
     body = result.get("body") or {}
@@ -9188,7 +9183,7 @@ async def _run_show_event_dispatch(event_payload: dict[str, Any]) -> None:
             activity_event="show_event",
             queued=True,
         )
-        return
+        return True
 
     if status != 202:
         logger.warning(
@@ -9203,6 +9198,7 @@ async def _run_show_event_dispatch(event_payload: dict[str, Any]) -> None:
         scope_id=scope_id if isinstance(scope_id, str) else None,
         activity_event="show_event",
     )
+    return status == 202
 
 
 def _show_event_dispatch_text(event_payload: dict[str, Any]) -> str:

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -7564,37 +7564,21 @@ def _promote_and_publish_pending_user_message(
     *,
     session_id: str,
     scope_id: str | None,
-) -> dict[str, Any]:
-    """Publish a no-turn user row after locally making it transcript-visible."""
-    from storage import messages_service
-
-    with _projects_engine().begin() as conn:
-        messages_service.promote_pending(conn, row["id"], "user")
-    return _publish_visible_user_message(
-        {**row, "type": "user"},
-        session_id=session_id,
-        scope_id=scope_id,
-    )
-
-
-def _publish_accepted_user_message(
-    row: dict[str, Any],
-    *,
-    session_id: str,
-    scope_id: str | None,
     activity_event: str = "user_message",
-) -> dict[str, Any]:
-    """Fan out the durable state written by the unified controller entry."""
+) -> dict[str, Any] | None:
+    """Settle one reserved row without publishing a stale or pending snapshot."""
     from storage import messages_service
     from vibe.sse_broker import broker
 
+    with _projects_engine().begin() as conn:
+        promoted = messages_service.promote_pending(conn, row["id"], "user")
     settled = _load_session_message(session_id, row["id"])
     if settled is None:
-        return row
+        return None
     if settled.get("type") == messages_service.QUEUED_TYPE:
         broker.publish("queue.updated", {"session_id": session_id, "scope_id": scope_id})
         return settled
-    if settled.get("type") == "user":
+    if promoted and settled.get("type") == "user":
         return _publish_visible_user_message(
             settled,
             session_id=session_id,
@@ -7737,26 +7721,30 @@ async def sessions_messages_create(session_id: str):
         "user_message_id": message.get("id"),
         "files": attachment_specs,
     }
-    with engine.begin() as conn:
-        messages_service.claim_dispatch_reservation(conn, message["id"])
     try:
         result = await internal_client.dispatch_async(dispatch_payload)
     except internal_client.InternalServerTimeout as exc:
+        published = _promote_and_publish_pending_user_message(
+            message,
+            session_id=session_id,
+            scope_id=session["scope_id"],
+        ) or message
         return jsonify(
             {
-                **message,
-                "type": messages_service.DISPATCHING_TYPE,
+                **published,
                 "dispatch_error": "dispatch_pending",
                 "detail": str(exc),
             }
         ), 504
     except internal_client.InternalServerUnavailable as exc:
-        with engine.begin() as conn:
-            messages_service.fail_dispatch_reservation(conn, message["id"])
+        published = _promote_and_publish_pending_user_message(
+            message,
+            session_id=session_id,
+            scope_id=session["scope_id"],
+        ) or message
         return jsonify(
             {
-                **message,
-                "type": messages_service.DISPATCH_FAILED_TYPE,
+                **published,
                 "dispatch_error": "internal_unavailable",
                 "detail": str(exc),
             }
@@ -7768,10 +7756,14 @@ async def sessions_messages_create(session_id: str):
             exc,
             exc_info=True,
         )
+        published = _promote_and_publish_pending_user_message(
+            message,
+            session_id=session_id,
+            scope_id=session["scope_id"],
+        ) or message
         return jsonify(
             {
-                **message,
-                "type": messages_service.DISPATCHING_TYPE,
+                **published,
                 "dispatch_error": "dispatch_pending",
                 "detail": str(exc),
             }
@@ -7794,27 +7786,31 @@ async def sessions_messages_create(session_id: str):
         # Enqueued behind a running turn: the controller already promoted the
         # row pending→queued, so it stays OUT of the transcript (no
         # message.new); show it above the composer via queue.updated.
-        queued = _publish_accepted_user_message(
+        queued = _promote_and_publish_pending_user_message(
             message,
             session_id=session_id,
             scope_id=session["scope_id"],
-        )
+        ) or message
         return jsonify({**queued, "queued": True}), 202
     if status == 202:
-        # Turn started — the controller already settled the row as ``user``.
+        # Turn started: the caller owns the rendering transition, while the
+        # unified manager owns only the turn/queue decision.
+        settled = _promote_and_publish_pending_user_message(
+            message,
+            session_id=session_id,
+            scope_id=session["scope_id"],
+        ) or message
         return jsonify(
-            _publish_accepted_user_message(
-                message,
-                session_id=session_id,
-                scope_id=session["scope_id"],
-            )
+            settled
         ), 201
-    with engine.begin() as conn:
-        messages_service.fail_dispatch_reservation(conn, message["id"])
+    published = _promote_and_publish_pending_user_message(
+        message,
+        session_id=session_id,
+        scope_id=session["scope_id"],
+    ) or message
     return jsonify(
         {
-            **message,
-            "type": messages_service.DISPATCH_FAILED_TYPE,
+            **published,
             "dispatch_error": "dispatch_failed",
             "detail": body,
         }
@@ -9158,15 +9154,11 @@ def record_local_show_event(session_id: str, payload: dict[str, Any], *, dispatc
 
 
 def _publish_show_session_event(event_payload: dict[str, Any]) -> None:
-    from storage import messages_service
     from vibe.sse_broker import broker
 
     broker.publish("show.event", event_payload)
     message = event_payload.get("message")
-    if (
-        isinstance(message, dict)
-        and message.get("type") in messages_service.DISPATCH_RESERVATION_TYPES
-    ):
+    if show_event_requests_dispatch(event_payload):
         return
     if isinstance(message, dict):
         broker.publish("message.new", message)
@@ -9197,78 +9189,92 @@ def _dispatch_show_event_if_requested(event_payload: dict[str, Any]) -> None:
 
 
 async def _run_show_event_dispatch(event_payload: dict[str, Any]) -> bool:
-    from storage import messages_service
+    from core.show_session_events import (
+        DISPATCH_ACCEPTED,
+        DISPATCH_IN_FLIGHT,
+        claim_show_dispatch,
+        current_show_dispatch_owner,
+        fail_show_dispatch,
+        get_show_dispatch_status,
+    )
     from vibe import internal_client
 
     session_id = event_payload.get("session_id")
     scope_id = event_payload.get("scope_id")
+    event_id = event_payload.get("id")
     transcript_text = event_payload.get("transcript_text")
-    if not isinstance(session_id, str) or not session_id or not isinstance(transcript_text, str) or not transcript_text.strip():
+    if (
+        not isinstance(session_id, str)
+        or not session_id
+        or not isinstance(event_id, str)
+        or not event_id
+        or not isinstance(transcript_text, str)
+        or not transcript_text.strip()
+    ):
         return False
+    owner = current_show_dispatch_owner()
+    with _projects_engine().begin() as conn:
+        dispatch_status = claim_show_dispatch(
+            conn,
+            event_id,
+            session_id=session_id,
+            owner=owner,
+        )
+    if dispatch_status is None or dispatch_status.session_status == "archived":
+        return False
+    if dispatch_status.state == DISPATCH_ACCEPTED:
+        return _settle_show_event_message(event_payload) is not None
+    if dispatch_status.state != DISPATCH_IN_FLIGHT or not dispatch_status.claimed:
+        return False
+
+    message = _load_show_event_message(event_payload)
+    if message is None:
+        with _projects_engine().begin() as conn:
+            fail_show_dispatch(conn, event_id, session_id=session_id, owner=owner)
+        return False
+    event_payload["message_id"] = message["id"]
+    event_payload["message"] = message
     dispatch_payload = {
         "session_id": session_id,
         "text": _show_event_dispatch_text(event_payload),
         "scope_id": scope_id,
-        "user_message_id": event_payload.get("message_id"),
+        "user_message_id": message["id"],
+        "show_event_id": event_id,
+        "dispatch_owner": owner,
         "files": [],
     }
-    message = event_payload.get("message")
-    if not isinstance(message, dict):
-        return False
-    with _projects_engine().begin() as conn:
-        reservation_type, claimed = messages_service.claim_dispatch_reservation(
-            conn,
-            message["id"],
-        )
-    if not claimed:
-        settled_message = _load_show_event_message(event_payload)
-        if settled_message is not None:
-            event_payload["message_id"] = settled_message["id"]
-            event_payload["message"] = settled_message
-            reservation_type = settled_message.get("type")
-        return reservation_type in {"user", messages_service.QUEUED_TYPE}
 
     try:
         result = await internal_client.dispatch_async(dispatch_payload, timeout=None)
     except internal_client.InternalServerTimeout as exc:
         logger.warning("show event dispatch still pending for session %s: %s", session_id, exc)
-        settled_message = _load_show_event_message(event_payload)
-        if settled_message is not None:
-            event_payload["message_id"] = settled_message["id"]
-            event_payload["message"] = settled_message
-            if settled_message.get("type") in {"user", messages_service.QUEUED_TYPE}:
-                if settled_message["id"] == message["id"]:
-                    event_payload["message"] = _publish_accepted_user_message(
-                        settled_message,
-                        session_id=session_id,
-                        scope_id=scope_id if isinstance(scope_id, str) else None,
-                        activity_event="show_event",
-                    )
-                return True
-        # The durable state is still acceptance-unknown. A concurrent CLI or
-        # browser retry sees ``dispatching`` and never submits a second turn.
-        event_payload["message"] = {
-            **message,
-            "type": messages_service.DISPATCHING_TYPE,
-        }
-        return False
+        with _projects_engine().connect() as conn:
+            dispatch_status = get_show_dispatch_status(
+                conn,
+                event_id,
+                session_id=session_id,
+            )
+        return (
+            dispatch_status is not None
+            and dispatch_status.state == DISPATCH_ACCEPTED
+            and _settle_show_event_message(event_payload) is not None
+        )
     except internal_client.InternalServerUnavailable as exc:
         logger.warning("show event dispatch unavailable for session %s: %s", session_id, exc)
         with _projects_engine().begin() as conn:
-            messages_service.fail_dispatch_reservation(conn, message["id"])
-        event_payload["message"] = {
-            **message,
-            "type": messages_service.DISPATCH_FAILED_TYPE,
-        }
+            fail_show_dispatch(conn, event_id, session_id=session_id, owner=owner)
+        _settle_show_event_message(event_payload)
         return False
     except Exception as exc:  # pragma: no cover - defensive
-        # A protocol/read failure after connect is acceptance-unknown too. Only a
-        # definitive controller rejection may make the reservation retryable.
         logger.exception("show event dispatch acceptance is unknown")
-        event_payload["message"] = {
-            **message,
-            "type": messages_service.DISPATCHING_TYPE,
-        }
+        with _projects_engine().connect() as conn:
+            dispatch_status = get_show_dispatch_status(
+                conn,
+                event_id,
+                session_id=session_id,
+            )
+        if dispatch_status is not None and dispatch_status.state == DISPATCH_ACCEPTED:
+            return _settle_show_event_message(event_payload) is not None
         return False
 
     status = result.get("status_code", 500)
@@ -9281,53 +9287,38 @@ async def _run_show_event_dispatch(event_payload: dict[str, Any]) -> bool:
             body,
         )
         with _projects_engine().begin() as conn:
-            messages_service.fail_dispatch_reservation(conn, message["id"])
-        event_payload["message"] = {
-            **message,
-            "type": messages_service.DISPATCH_FAILED_TYPE,
-        }
+            fail_show_dispatch(conn, event_id, session_id=session_id, owner=owner)
+        _settle_show_event_message(event_payload)
         return False
 
-    if status == 202 and body.get("drained"):
-        settled_message = _load_show_event_message(event_payload)
-        if settled_message is not None:
-            event_payload["message_id"] = settled_message["id"]
-            event_payload["message"] = settled_message
-            return True
-    settled_message_id = body.get("message_id")
-    if (
-        status == 202
-        and body.get("message_type") == "user"
-        and isinstance(settled_message_id, str)
-        and settled_message_id
-    ):
-        settled_message = _load_session_message(session_id, settled_message_id)
-        if settled_message is not None:
-            event_payload["message_id"] = settled_message_id
-            # A synchronous queue drain already published the freshly promoted
-            # row from SessionTurnManager.flush_queue.
-            event_payload["message"] = settled_message
-            return True
-    if status == 202 and body.get("queued"):
-        event_payload["message"] = _publish_accepted_user_message(
-            message,
+    with _projects_engine().connect() as conn:
+        dispatch_status = get_show_dispatch_status(
+            conn,
+            event_id,
             session_id=session_id,
-            scope_id=scope_id if isinstance(scope_id, str) else None,
-            activity_event="show_event",
         )
-        return True
-
-    settled_message = _load_show_event_message(event_payload)
-    if settled_message is None or settled_message.get("type") != "user":
+    if dispatch_status is None or dispatch_status.state != DISPATCH_ACCEPTED:
         return False
-    event_payload["message_id"] = settled_message["id"]
-    event_payload["message"] = _publish_accepted_user_message(
-        settled_message,
-        session_id=session_id,
-        scope_id=scope_id if isinstance(scope_id, str) else None,
+    return _settle_show_event_message(event_payload) is not None
+
+
+def _settle_show_event_message(event_payload: dict[str, Any]) -> dict[str, Any] | None:
+    message = _load_show_event_message(event_payload)
+    if message is None:
+        return None
+    event_payload["message_id"] = message["id"]
+    settled = _promote_and_publish_pending_user_message(
+        message,
+        session_id=str(event_payload["session_id"]),
+        scope_id=(
+            str(event_payload["scope_id"])
+            if isinstance(event_payload.get("scope_id"), str)
+            else None
+        ),
         activity_event="show_event",
     )
-    return True
+    event_payload["message"] = settled or message
+    return event_payload["message"]
 
 
 def _show_event_dispatch_error() -> ShowSessionEventError:

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -46,7 +46,11 @@ from core.show_pages import (
     show_event_write_token,
     show_public_event_write_token,
 )
-from core.show_session_events import HUMAN_EVENT_TYPES, show_event_payload_session_mismatch
+from core.show_session_events import (
+    HUMAN_EVENT_TYPES,
+    show_event_payload_session_mismatch,
+    show_event_requests_dispatch,
+)
 from core.terminal_service import TERMINAL_SUPPORTED, TerminalService, TerminalServiceError, sanitize_session_id
 from modules.agents.catalog import AGENT_BACKENDS, supports_runtime_refresh
 from vibe.i18n import get_supported_languages, t
@@ -7528,6 +7532,48 @@ def asr_status():
         return jsonify({"available": False})
 
 
+def _promote_and_publish_pending_user_message(
+    row: dict[str, Any],
+    *,
+    session_id: str,
+    scope_id: str | None,
+    activity_event: str = "user_message",
+    queued: bool = False,
+) -> dict[str, Any]:
+    """Make a reserved user row visible after the unified turn entry accepts it."""
+    from storage import messages_service
+    from vibe.sse_broker import broker
+
+    if queued:
+        # The controller already promoted pending -> queued inside the manager's
+        # enqueue callback; this process only fans out the decided queue state.
+        broker.publish("queue.updated", {"session_id": session_id, "scope_id": scope_id})
+        return {**row, "type": messages_service.QUEUED_TYPE}
+
+    engine = _projects_engine()
+    with engine.begin() as conn:
+        promoted = messages_service.promote_pending(conn, row["id"], "user")
+    if not promoted:
+        # The controller owns pending -> queued when a turn is already active.
+        broker.publish("queue.updated", {"session_id": session_id, "scope_id": scope_id})
+        return {**row, "type": messages_service.QUEUED_TYPE}
+
+    visible = {**row, "type": "user"}
+    broker.publish("message.new", visible)
+    broker.publish(
+        "session.activity",
+        {"session_id": session_id, "scope_id": scope_id, "event": activity_event},
+    )
+    try:
+        with engine.connect() as conn:
+            inbox_row = messages_service.get_inbox_session(conn, session_id, platform="avibe")
+        if inbox_row is not None:
+            broker.publish("inbox.session.updated", inbox_row)
+    except Exception:
+        logger.debug("inbox.session.updated publish (user message) failed", exc_info=True)
+    return visible
+
+
 @app.route("/api/sessions/<session_id>/messages", methods=["POST"])
 async def sessions_messages_create(session_id: str):
     """Persist a user message and fire-and-forget the agent turn.
@@ -7546,7 +7592,6 @@ async def sessions_messages_create(session_id: str):
     from core.services import sessions as workbench_sessions_service
     from storage import messages_service
     from vibe import internal_client
-    from vibe.sse_broker import broker
 
     payload = request.json or {}
     text = payload.get("text")
@@ -7634,37 +7679,6 @@ async def sessions_messages_create(session_id: str):
             workbench_sessions_service.touch_session(conn, session_id)
         return row
 
-    def _promote_and_publish(row: dict) -> dict:
-        """Promote the reserved pending row to a transcript-visible ``user`` row
-        and fan it out (message.new + activity + inbox bump). Returns the row
-        with its type corrected. The agent-reply side rides the controller→
-        browser bridge, but the user row is persisted in this UI process so the
-        controller bus never sees it."""
-        with engine.begin() as conn:
-            promoted = messages_service.promote_pending(conn, row["id"], "user")
-        if not promoted:
-            # The row wasn't pending anymore: the controller already promoted it
-            # (e.g. enqueued as 'queued' via the busy-session path) before our
-            # dispatch call failed/returned. Don't publish a phantom 'user'
-            # transcript row alongside the still-queued item — nudge the queue view
-            # and report it as queued instead (Codex P2).
-            broker.publish("queue.updated", {"session_id": session_id, "scope_id": session["scope_id"]})
-            return {**row, "type": "queued"}
-        row = {**row, "type": "user"}
-        broker.publish("message.new", row)
-        broker.publish(
-            "session.activity",
-            {"session_id": session_id, "scope_id": session["scope_id"], "event": "user_message"},
-        )
-        try:
-            with engine.connect() as conn:
-                inbox_row = messages_service.get_inbox_session(conn, session_id, platform="avibe")
-            if inbox_row is not None:
-                broker.publish("inbox.session.updated", inbox_row)
-        except Exception:
-            logger.debug("inbox.session.updated publish (user message) failed", exc_info=True)
-        return row
-
     # Reserve the row FIRST (pending), then decide by the dispatch outcome.
     message = _persist_user_row()
     if message is None:
@@ -7674,7 +7688,13 @@ async def sessions_messages_create(session_id: str):
     # promote + publish the row, no turn. Attachments WITHOUT text still run a
     # turn (the agent reads the files), so they aren't caught here.
     if not dispatch_text.strip() and not attachment_specs:
-        return jsonify(_promote_and_publish(message)), 201
+        return jsonify(
+            _promote_and_publish_pending_user_message(
+                message,
+                session_id=session_id,
+                scope_id=session["scope_id"],
+            )
+        ), 201
     # Session/page-scoped model (the web Chat): fire-and-forget the turn; the
     # reply arrives over ``message.new``. The controller atomically either lets
     # the turn start (we then promote the row to user) or — if a turn is already
@@ -7692,7 +7712,11 @@ async def sessions_messages_create(session_id: str):
     except internal_client.InternalServerUnavailable as exc:
         # Couldn't reach the controller — promote + surface the row so the
         # user still sees their message, plus the failure.
-        published = _promote_and_publish(message)
+        published = _promote_and_publish_pending_user_message(
+            message,
+            session_id=session_id,
+            scope_id=session["scope_id"],
+        )
         return jsonify({**published, "dispatch_error": "internal_unavailable", "detail": str(exc)}), 502
     except Exception as exc:
         # The socket existed but the call failed another way (ReadTimeout, a
@@ -7701,7 +7725,11 @@ async def sessions_messages_create(session_id: str):
         # would vanish from both transcript and queue behind an error. Promote +
         # publish it with the error, same as the unavailable branch (Codex P2).
         logger.warning("dispatch_async call failed for session %s: %s", session_id, exc, exc_info=True)
-        published = _promote_and_publish(message)
+        published = _promote_and_publish_pending_user_message(
+            message,
+            session_id=session_id,
+            scope_id=session["scope_id"],
+        )
         return jsonify({**published, "dispatch_error": "dispatch_failed", "detail": str(exc)}), 502
     status = result.get("status_code", 500)
     body = result.get("body") or {}
@@ -7716,13 +7744,28 @@ async def sessions_messages_create(session_id: str):
         # Enqueued behind a running turn: the controller already promoted the
         # row pending→queued, so it stays OUT of the transcript (no
         # message.new); show it above the composer via queue.updated.
-        broker.publish("queue.updated", {"session_id": session_id, "scope_id": session["scope_id"]})
-        return jsonify({**message, "type": "queued", "queued": True}), 202
+        queued = _promote_and_publish_pending_user_message(
+            message,
+            session_id=session_id,
+            scope_id=session["scope_id"],
+            queued=True,
+        )
+        return jsonify({**queued, "queued": True}), 202
     if status == 202:
         # Turn started — promote + publish the prompt.
-        return jsonify(_promote_and_publish(message)), 201
+        return jsonify(
+            _promote_and_publish_pending_user_message(
+                message,
+                session_id=session_id,
+                scope_id=session["scope_id"],
+            )
+        ), 201
     # Dispatch failed: still promote + show the row + the error.
-    published = _promote_and_publish(message)
+    published = _promote_and_publish_pending_user_message(
+        message,
+        session_id=session_id,
+        scope_id=session["scope_id"],
+    )
     return jsonify({**published, "dispatch_error": "dispatch_failed", "detail": body}), 502
 
 
@@ -9022,13 +9065,16 @@ def record_local_show_event(session_id: str, payload: dict[str, Any], *, dispatc
     finally:
         store.close()
     _publish_show_session_event(event_payload)
-    if dispatch_sync and _show_event_requests_dispatch(event_payload):
+    if dispatch_sync and show_event_requests_dispatch(event_payload):
         try:
-            asyncio.run(_run_show_event_dispatch(event_payload))
+            asyncio.get_running_loop()
         except RuntimeError:
-            _dispatch_show_event_if_requested(event_payload)
-    else:
-        _dispatch_show_event_if_requested(event_payload)
+            # The 202 endpoint returns after the manager accepts or queues the
+            # turn, so CLI callers can synchronously settle the pending row
+            # without waiting for the agent turn itself.
+            asyncio.run(_run_show_event_dispatch(event_payload))
+            return event_payload
+    _dispatch_show_event_if_requested(event_payload)
     return event_payload
 
 
@@ -9037,6 +9083,8 @@ def _publish_show_session_event(event_payload: dict[str, Any]) -> None:
 
     broker.publish("show.event", event_payload)
     message = event_payload.get("message")
+    if isinstance(message, dict) and message.get("type") == "pending":
+        return
     if isinstance(message, dict):
         broker.publish("message.new", message)
     broker.publish(
@@ -9050,7 +9098,7 @@ def _publish_show_session_event(event_payload: dict[str, Any]) -> None:
 
 
 def _dispatch_show_event_if_requested(event_payload: dict[str, Any]) -> None:
-    if not _show_event_requests_dispatch(event_payload):
+    if not show_event_requests_dispatch(event_payload):
         return
     try:
         loop = asyncio.get_running_loop()
@@ -9063,17 +9111,6 @@ def _dispatch_show_event_if_requested(event_payload: dict[str, Any]) -> None:
         thread.start()
         return
     loop.create_task(_run_show_event_dispatch(event_payload))
-
-
-def _show_event_requests_dispatch(event_payload: dict[str, Any]) -> bool:
-    if event_payload.get("actor") != "human":
-        return False
-    if event_payload.get("type") not in {"human.intent.submitted", "human.annotation.created"}:
-        return False
-    payload = event_payload.get("payload")
-    if not isinstance(payload, dict):
-        return False
-    return bool(payload.get("dispatch"))
 
 
 async def _run_show_event_dispatch(event_payload: dict[str, Any]) -> None:
@@ -9089,22 +9126,57 @@ async def _run_show_event_dispatch(event_payload: dict[str, Any]) -> None:
         "text": _show_event_dispatch_text(event_payload),
         "scope_id": scope_id,
         "user_message_id": event_payload.get("message_id"),
-        "message_id": event_payload.get("message_id"),
-        "platform": "avibe",
-        "channel_id": session_id,
+        "files": [],
     }
+    message = event_payload.get("message")
+    if not isinstance(message, dict):
+        return
     try:
-        async for event_name, data in internal_client.stream_dispatch(dispatch_payload):
-            _publish_show_dispatch_event(event_payload, event_name, data)
+        result = await internal_client.dispatch_async(dispatch_payload)
     except internal_client.InternalServerUnavailable as exc:
-        _publish_show_dispatch_event(
-            event_payload,
-            "stream.error",
-            {"reason": "internal_server_unavailable", "detail": str(exc)},
+        logger.warning("show event dispatch unavailable for session %s: %s", session_id, exc)
+        event_payload["message"] = _promote_and_publish_pending_user_message(
+            message,
+            session_id=session_id,
+            scope_id=scope_id if isinstance(scope_id, str) else None,
+            activity_event="show_event",
         )
+        return
     except Exception as exc:  # pragma: no cover - defensive
         logger.exception("show event dispatch failed")
-        _publish_show_dispatch_event(event_payload, "stream.error", {"reason": "dispatch_failed", "detail": str(exc)})
+        event_payload["message"] = _promote_and_publish_pending_user_message(
+            message,
+            session_id=session_id,
+            scope_id=scope_id if isinstance(scope_id, str) else None,
+            activity_event="show_event",
+        )
+        return
+
+    status = result.get("status_code", 500)
+    body = result.get("body") or {}
+    if status == 202 and body.get("queued"):
+        event_payload["message"] = _promote_and_publish_pending_user_message(
+            message,
+            session_id=session_id,
+            scope_id=scope_id if isinstance(scope_id, str) else None,
+            activity_event="show_event",
+            queued=True,
+        )
+        return
+
+    if status != 202:
+        logger.warning(
+            "show event dispatch failed for session %s: status=%s body=%s",
+            session_id,
+            status,
+            body,
+        )
+    event_payload["message"] = _promote_and_publish_pending_user_message(
+        message,
+        session_id=session_id,
+        scope_id=scope_id if isinstance(scope_id, str) else None,
+        activity_event="show_event",
+    )
 
 
 def _show_event_dispatch_text(event_payload: dict[str, Any]) -> str:
@@ -9130,21 +9202,6 @@ def _show_event_dispatch_text(event_payload: dict[str, Any]) -> str:
             ]
         )
     return "\n".join(lines)
-
-
-def _publish_show_dispatch_event(event_payload: dict[str, Any], event_name: str, data: Any) -> None:
-    from vibe.sse_broker import broker
-
-    broker.publish(
-        "show.dispatch",
-        {
-            "show_event_id": event_payload.get("id"),
-            "session_id": event_payload.get("session_id"),
-            "scope_id": event_payload.get("scope_id"),
-            "event": event_name,
-            "data": data,
-        },
-    )
 
 
 def _show_event_response_payload(
@@ -9188,28 +9245,6 @@ def _show_event_response_payload(
                 public_event["transcript_text"] = transcript_text.replace(local_path, public_ref)
         public_event["payload"] = public_payload
     return public_event
-
-
-def _show_dispatch_response_payload(event_payload: dict[str, Any], *, public: bool = False) -> dict[str, Any]:
-    if not public:
-        return event_payload
-    return {
-        key: _redact_public_dispatch_value(value)
-        for key, value in event_payload.items()
-        if key not in {"session_id", "scope_id", "message_id", "message", "user_message_id"}
-    }
-
-
-def _redact_public_dispatch_value(value: Any) -> Any:
-    if isinstance(value, dict):
-        return {
-            key: _redact_public_dispatch_value(nested)
-            for key, nested in value.items()
-            if key not in {"session_id", "scope_id", "message_id", "message", "user_message_id"}
-        }
-    if isinstance(value, list):
-        return [_redact_public_dispatch_value(item) for item in value]
-    return value
 
 
 def _show_events_list_payload(
@@ -9299,8 +9334,6 @@ async def _show_events_stream(
                                 public_share_id=public_share_id,
                             ),
                         )
-                    elif event_type == "show.dispatch" and isinstance(event_payload, dict) and _event_visible(event_payload):
-                        yield _sse_frame("show.dispatch", _show_dispatch_response_payload(event_payload, public=public))
                 except asyncio.TimeoutError:
                     yield ": ping\n\n"
         except asyncio.CancelledError:

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -7733,7 +7733,11 @@ async def sessions_messages_create(session_id: str):
     try:
         result = await internal_client.dispatch_async(dispatch_payload)
     except internal_client.InternalServerTimeout as exc:
-        observed = _load_session_message(session_id, message["id"]) or message
+        observed = _promote_and_publish_pending_user_message(
+            message,
+            session_id=session_id,
+            scope_id=session["scope_id"],
+        ) or message
         return jsonify(
             {
                 **observed,
@@ -7761,7 +7765,11 @@ async def sessions_messages_create(session_id: str):
             exc,
             exc_info=True,
         )
-        observed = _load_session_message(session_id, message["id"]) or message
+        observed = _promote_and_publish_pending_user_message(
+            message,
+            session_id=session_id,
+            scope_id=session["scope_id"],
+        ) or message
         return jsonify(
             {
                 **observed,

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -9219,10 +9219,12 @@ async def _run_show_event_dispatch(
 ) -> _ShowEventDispatchOutcome:
     from core.show_session_events import (
         DISPATCH_ACCEPTED,
+        DISPATCH_ARCHIVED,
+        DISPATCH_FAILED,
         DISPATCH_IN_FLIGHT,
         claim_show_dispatch,
-        fail_show_dispatch,
         get_show_dispatch_status,
+        settle_show_dispatch,
         show_dispatch_attempt,
     )
     from vibe import internal_client
@@ -9249,7 +9251,11 @@ async def _run_show_event_dispatch(
                 session_id=session_id,
                 owner=owner,
             )
-        if dispatch_status is None or dispatch_status.session_status == "archived":
+        if (
+            dispatch_status is None
+            or dispatch_status.session_status == "archived"
+            or dispatch_status.state == DISPATCH_ARCHIVED
+        ):
             return _ShowEventDispatchOutcome.FAILED
         if dispatch_status.state == DISPATCH_ACCEPTED:
             return (
@@ -9265,7 +9271,13 @@ async def _run_show_event_dispatch(
         message = _load_show_event_message(event_payload)
         if message is None:
             with _projects_engine().begin() as conn:
-                fail_show_dispatch(conn, event_id, session_id=session_id, owner=owner)
+                settle_show_dispatch(
+                    conn,
+                    event_id,
+                    session_id=session_id,
+                    owner=owner,
+                    state=DISPATCH_FAILED,
+                )
             return _ShowEventDispatchOutcome.FAILED
         event_payload["message_id"] = message["id"]
         event_payload["message"] = message
@@ -9310,7 +9322,13 @@ async def _run_show_event_dispatch(
                 exc,
             )
             with _projects_engine().begin() as conn:
-                fail_show_dispatch(conn, event_id, session_id=session_id, owner=owner)
+                settle_show_dispatch(
+                    conn,
+                    event_id,
+                    session_id=session_id,
+                    owner=owner,
+                    state=DISPATCH_FAILED,
+                )
             _settle_show_event_message(event_payload)
             return _ShowEventDispatchOutcome.FAILED
         except Exception:  # pragma: no cover - defensive
@@ -9339,7 +9357,13 @@ async def _run_show_event_dispatch(
                 body,
             )
             with _projects_engine().begin() as conn:
-                fail_show_dispatch(conn, event_id, session_id=session_id, owner=owner)
+                settle_show_dispatch(
+                    conn,
+                    event_id,
+                    session_id=session_id,
+                    owner=owner,
+                    state=DISPATCH_FAILED,
+                )
             _settle_show_event_message(event_payload)
             return _ShowEventDispatchOutcome.FAILED
 

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -20,6 +20,7 @@ import time
 from collections import OrderedDict, deque
 from contextlib import contextmanager
 from datetime import datetime, timezone
+from enum import Enum
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, Callable
@@ -49,6 +50,7 @@ from core.show_pages import (
 from core.show_session_events import (
     HUMAN_EVENT_TYPES,
     ShowSessionEventError,
+    localized_show_event_error,
     show_event_payload_session_mismatch,
     show_event_requests_dispatch,
 )
@@ -60,6 +62,13 @@ from vibe.runtime import get_ui_dist_path, get_working_dir
 from vibe.sentry_integration import init_sentry
 
 logger = logging.getLogger(__name__)
+
+
+class _ShowEventDispatchOutcome(str, Enum):
+    ACCEPTED = "accepted"
+    IN_FLIGHT = "in_flight"
+    FAILED = "failed"
+
 
 # Python's mimetypes map omits .webmanifest; register it so the PWA manifest is
 # served as a type browsers accept (an octet-stream manifest is rejected).
@@ -9098,8 +9107,23 @@ async def _show_event_response_from_payload(
         # The internal endpoint returns after SessionTurnManager has either
         # started or queued the turn. Settle the pending transcript row before
         # acknowledging the Show event so a successful POST cannot strand it.
-        accepted = await _run_show_event_dispatch(event_payload)
-        if not accepted:
+        dispatch_outcome = await _run_show_event_dispatch(event_payload)
+        if dispatch_outcome is _ShowEventDispatchOutcome.IN_FLIGHT:
+            return (
+                jsonify(
+                    {
+                        "ok": True,
+                        "dispatch_pending": True,
+                        "event": _show_event_response_payload(
+                            event_payload,
+                            public=public,
+                            public_share_id=public_share_id,
+                        ),
+                    }
+                ),
+                202,
+            )
+        if dispatch_outcome is _ShowEventDispatchOutcome.FAILED:
             exc = _show_event_dispatch_error()
             return (
                 jsonify(
@@ -9145,8 +9169,10 @@ def record_local_show_event(session_id: str, payload: dict[str, Any], *, dispatc
             # The 202 endpoint returns after the manager accepts or queues the
             # turn, so CLI callers can synchronously settle the pending row
             # without waiting for the agent turn itself.
-            accepted = asyncio.run(_run_show_event_dispatch(event_payload))
-            if not accepted:
+            dispatch_outcome = asyncio.run(_run_show_event_dispatch(event_payload))
+            if dispatch_outcome is _ShowEventDispatchOutcome.IN_FLIGHT:
+                raise _show_event_dispatch_pending_error()
+            if dispatch_outcome is _ShowEventDispatchOutcome.FAILED:
                 raise _show_event_dispatch_error()
             return event_payload
     _dispatch_show_event_if_requested(event_payload)
@@ -9188,14 +9214,16 @@ def _dispatch_show_event_if_requested(event_payload: dict[str, Any]) -> None:
     loop.create_task(_run_show_event_dispatch(event_payload))
 
 
-async def _run_show_event_dispatch(event_payload: dict[str, Any]) -> bool:
+async def _run_show_event_dispatch(
+    event_payload: dict[str, Any],
+) -> _ShowEventDispatchOutcome:
     from core.show_session_events import (
         DISPATCH_ACCEPTED,
         DISPATCH_IN_FLIGHT,
         claim_show_dispatch,
-        current_show_dispatch_owner,
         fail_show_dispatch,
         get_show_dispatch_status,
+        show_dispatch_attempt,
     )
     from vibe import internal_client
 
@@ -9211,95 +9239,125 @@ async def _run_show_event_dispatch(event_payload: dict[str, Any]) -> bool:
         or not isinstance(transcript_text, str)
         or not transcript_text.strip()
     ):
-        return False
-    owner = current_show_dispatch_owner()
-    with _projects_engine().begin() as conn:
-        dispatch_status = claim_show_dispatch(
-            conn,
-            event_id,
-            session_id=session_id,
-            owner=owner,
-        )
-    if dispatch_status is None or dispatch_status.session_status == "archived":
-        return False
-    if dispatch_status.state == DISPATCH_ACCEPTED:
-        return _settle_show_event_message(event_payload) is not None
-    if dispatch_status.state != DISPATCH_IN_FLIGHT or not dispatch_status.claimed:
-        return False
+        return _ShowEventDispatchOutcome.FAILED
 
-    message = _load_show_event_message(event_payload)
-    if message is None:
+    with show_dispatch_attempt() as owner:
         with _projects_engine().begin() as conn:
-            fail_show_dispatch(conn, event_id, session_id=session_id, owner=owner)
-        return False
-    event_payload["message_id"] = message["id"]
-    event_payload["message"] = message
-    dispatch_payload = {
-        "session_id": session_id,
-        "text": _show_event_dispatch_text(event_payload),
-        "scope_id": scope_id,
-        "user_message_id": message["id"],
-        "show_event_id": event_id,
-        "dispatch_owner": owner,
-        "files": [],
-    }
+            dispatch_status = claim_show_dispatch(
+                conn,
+                event_id,
+                session_id=session_id,
+                owner=owner,
+            )
+        if dispatch_status is None or dispatch_status.session_status == "archived":
+            return _ShowEventDispatchOutcome.FAILED
+        if dispatch_status.state == DISPATCH_ACCEPTED:
+            return (
+                _ShowEventDispatchOutcome.ACCEPTED
+                if _settle_show_event_message(event_payload) is not None
+                else _ShowEventDispatchOutcome.FAILED
+            )
+        if dispatch_status.state == DISPATCH_IN_FLIGHT and not dispatch_status.claimed:
+            return _ShowEventDispatchOutcome.IN_FLIGHT
+        if dispatch_status.state != DISPATCH_IN_FLIGHT:
+            return _ShowEventDispatchOutcome.FAILED
 
-    try:
-        result = await internal_client.dispatch_async(dispatch_payload, timeout=None)
-    except internal_client.InternalServerTimeout as exc:
-        logger.warning("show event dispatch still pending for session %s: %s", session_id, exc)
+        message = _load_show_event_message(event_payload)
+        if message is None:
+            with _projects_engine().begin() as conn:
+                fail_show_dispatch(conn, event_id, session_id=session_id, owner=owner)
+            return _ShowEventDispatchOutcome.FAILED
+        event_payload["message_id"] = message["id"]
+        event_payload["message"] = message
+        dispatch_payload = {
+            "session_id": session_id,
+            "text": _show_event_dispatch_text(event_payload),
+            "scope_id": scope_id,
+            "user_message_id": message["id"],
+            "show_event_id": event_id,
+            "dispatch_owner": owner,
+            "files": [],
+        }
+
+        try:
+            result = await internal_client.dispatch_async(
+                dispatch_payload,
+                timeout=None,
+            )
+        except internal_client.InternalServerTimeout as exc:
+            logger.warning(
+                "show event dispatch still pending for session %s: %s",
+                session_id,
+                exc,
+            )
+            with _projects_engine().connect() as conn:
+                dispatch_status = get_show_dispatch_status(
+                    conn,
+                    event_id,
+                    session_id=session_id,
+                )
+            if (
+                dispatch_status is not None
+                and dispatch_status.state == DISPATCH_ACCEPTED
+                and _settle_show_event_message(event_payload) is not None
+            ):
+                return _ShowEventDispatchOutcome.ACCEPTED
+            return _ShowEventDispatchOutcome.IN_FLIGHT
+        except internal_client.InternalServerUnavailable as exc:
+            logger.warning(
+                "show event dispatch unavailable for session %s: %s",
+                session_id,
+                exc,
+            )
+            with _projects_engine().begin() as conn:
+                fail_show_dispatch(conn, event_id, session_id=session_id, owner=owner)
+            _settle_show_event_message(event_payload)
+            return _ShowEventDispatchOutcome.FAILED
+        except Exception:  # pragma: no cover - defensive
+            logger.exception("show event dispatch acceptance is unknown")
+            with _projects_engine().connect() as conn:
+                dispatch_status = get_show_dispatch_status(
+                    conn,
+                    event_id,
+                    session_id=session_id,
+                )
+            if (
+                dispatch_status is not None
+                and dispatch_status.state == DISPATCH_ACCEPTED
+                and _settle_show_event_message(event_payload) is not None
+            ):
+                return _ShowEventDispatchOutcome.ACCEPTED
+            return _ShowEventDispatchOutcome.IN_FLIGHT
+
+        status = result.get("status_code", 500)
+        body = result.get("body") or {}
+        if status != 202:
+            logger.warning(
+                "show event dispatch failed for session %s: status=%s body=%s",
+                session_id,
+                status,
+                body,
+            )
+            with _projects_engine().begin() as conn:
+                fail_show_dispatch(conn, event_id, session_id=session_id, owner=owner)
+            _settle_show_event_message(event_payload)
+            return _ShowEventDispatchOutcome.FAILED
+
         with _projects_engine().connect() as conn:
             dispatch_status = get_show_dispatch_status(
                 conn,
                 event_id,
                 session_id=session_id,
             )
+        if dispatch_status is None:
+            return _ShowEventDispatchOutcome.FAILED
+        if dispatch_status.state != DISPATCH_ACCEPTED:
+            return _ShowEventDispatchOutcome.IN_FLIGHT
         return (
-            dispatch_status is not None
-            and dispatch_status.state == DISPATCH_ACCEPTED
-            and _settle_show_event_message(event_payload) is not None
+            _ShowEventDispatchOutcome.ACCEPTED
+            if _settle_show_event_message(event_payload) is not None
+            else _ShowEventDispatchOutcome.FAILED
         )
-    except internal_client.InternalServerUnavailable as exc:
-        logger.warning("show event dispatch unavailable for session %s: %s", session_id, exc)
-        with _projects_engine().begin() as conn:
-            fail_show_dispatch(conn, event_id, session_id=session_id, owner=owner)
-        _settle_show_event_message(event_payload)
-        return False
-    except Exception as exc:  # pragma: no cover - defensive
-        logger.exception("show event dispatch acceptance is unknown")
-        with _projects_engine().connect() as conn:
-            dispatch_status = get_show_dispatch_status(
-                conn,
-                event_id,
-                session_id=session_id,
-            )
-        if dispatch_status is not None and dispatch_status.state == DISPATCH_ACCEPTED:
-            return _settle_show_event_message(event_payload) is not None
-        return False
-
-    status = result.get("status_code", 500)
-    body = result.get("body") or {}
-    if status != 202:
-        logger.warning(
-            "show event dispatch failed for session %s: status=%s body=%s",
-            session_id,
-            status,
-            body,
-        )
-        with _projects_engine().begin() as conn:
-            fail_show_dispatch(conn, event_id, session_id=session_id, owner=owner)
-        _settle_show_event_message(event_payload)
-        return False
-
-    with _projects_engine().connect() as conn:
-        dispatch_status = get_show_dispatch_status(
-            conn,
-            event_id,
-            session_id=session_id,
-        )
-    if dispatch_status is None or dispatch_status.state != DISPATCH_ACCEPTED:
-        return False
-    return _settle_show_event_message(event_payload) is not None
 
 
 def _settle_show_event_message(event_payload: dict[str, Any]) -> dict[str, Any] | None:
@@ -9322,14 +9380,11 @@ def _settle_show_event_message(event_payload: dict[str, Any]) -> dict[str, Any] 
 
 
 def _show_event_dispatch_error() -> ShowSessionEventError:
-    try:
-        language = V2Config.load().language
-    except Exception:
-        language = "en"
-    return ShowSessionEventError(
-        t("show.event.dispatchFailed", language),
-        code="show_event_dispatch_failed",
-    )
+    return localized_show_event_error("show_event_dispatch_failed")
+
+
+def _show_event_dispatch_pending_error() -> ShowSessionEventError:
+    return localized_show_event_error("show_event_dispatch_pending")
 
 
 def _load_session_message(session_id: str, message_id: str) -> dict[str, Any] | None:

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -7733,14 +7733,10 @@ async def sessions_messages_create(session_id: str):
     try:
         result = await internal_client.dispatch_async(dispatch_payload)
     except internal_client.InternalServerTimeout as exc:
-        published = _promote_and_publish_pending_user_message(
-            message,
-            session_id=session_id,
-            scope_id=session["scope_id"],
-        ) or message
+        observed = _load_session_message(session_id, message["id"]) or message
         return jsonify(
             {
-                **published,
+                **observed,
                 "dispatch_error": "dispatch_pending",
                 "detail": str(exc),
             }
@@ -7765,14 +7761,10 @@ async def sessions_messages_create(session_id: str):
             exc,
             exc_info=True,
         )
-        published = _promote_and_publish_pending_user_message(
-            message,
-            session_id=session_id,
-            scope_id=session["scope_id"],
-        ) or message
+        observed = _load_session_message(session_id, message["id"]) or message
         return jsonify(
             {
-                **published,
+                **observed,
                 "dispatch_error": "dispatch_pending",
                 "detail": str(exc),
             }
@@ -9223,7 +9215,6 @@ async def _run_show_event_dispatch(
         DISPATCH_FAILED,
         DISPATCH_IN_FLIGHT,
         claim_show_dispatch,
-        get_show_dispatch_status,
         settle_show_dispatch,
         show_dispatch_attempt,
     )
@@ -9258,18 +9249,17 @@ async def _run_show_event_dispatch(
         ):
             return _ShowEventDispatchOutcome.FAILED
         if dispatch_status.state == DISPATCH_ACCEPTED:
-            return (
-                _ShowEventDispatchOutcome.ACCEPTED
-                if _settle_show_event_message(event_payload) is not None
-                else _ShowEventDispatchOutcome.FAILED
+            return _show_event_dispatch_outcome(
+                _reconcile_show_event_dispatch(event_payload)
             )
         if dispatch_status.state == DISPATCH_IN_FLIGHT and not dispatch_status.claimed:
             return _ShowEventDispatchOutcome.IN_FLIGHT
         if dispatch_status.state != DISPATCH_IN_FLIGHT:
             return _ShowEventDispatchOutcome.FAILED
 
-        message = _load_show_event_message(event_payload)
-        if message is None:
+        settlement = _reconcile_show_event_dispatch(event_payload)
+        message = settlement.message if settlement is not None else None
+        if not isinstance(message, dict):
             with _projects_engine().begin() as conn:
                 settle_show_dispatch(
                     conn,
@@ -9278,9 +9268,9 @@ async def _run_show_event_dispatch(
                     owner=owner,
                     state=DISPATCH_FAILED,
                 )
-            return _ShowEventDispatchOutcome.FAILED
-        event_payload["message_id"] = message["id"]
-        event_payload["message"] = message
+            return _show_event_dispatch_outcome(
+                _reconcile_show_event_dispatch(event_payload)
+            )
         dispatch_payload = {
             "session_id": session_id,
             "text": _show_event_dispatch_text(event_payload),
@@ -9302,19 +9292,9 @@ async def _run_show_event_dispatch(
                 session_id,
                 exc,
             )
-            with _projects_engine().connect() as conn:
-                dispatch_status = get_show_dispatch_status(
-                    conn,
-                    event_id,
-                    session_id=session_id,
-                )
-            if (
-                dispatch_status is not None
-                and dispatch_status.state == DISPATCH_ACCEPTED
-                and _settle_show_event_message(event_payload) is not None
-            ):
-                return _ShowEventDispatchOutcome.ACCEPTED
-            return _ShowEventDispatchOutcome.IN_FLIGHT
+            return _show_event_dispatch_outcome(
+                _reconcile_show_event_dispatch(event_payload)
+            )
         except internal_client.InternalServerUnavailable as exc:
             logger.warning(
                 "show event dispatch unavailable for session %s: %s",
@@ -9329,23 +9309,14 @@ async def _run_show_event_dispatch(
                     owner=owner,
                     state=DISPATCH_FAILED,
                 )
-            _settle_show_event_message(event_payload)
-            return _ShowEventDispatchOutcome.FAILED
+            return _show_event_dispatch_outcome(
+                _reconcile_show_event_dispatch(event_payload)
+            )
         except Exception:  # pragma: no cover - defensive
             logger.exception("show event dispatch acceptance is unknown")
-            with _projects_engine().connect() as conn:
-                dispatch_status = get_show_dispatch_status(
-                    conn,
-                    event_id,
-                    session_id=session_id,
-                )
-            if (
-                dispatch_status is not None
-                and dispatch_status.state == DISPATCH_ACCEPTED
-                and _settle_show_event_message(event_payload) is not None
-            ):
-                return _ShowEventDispatchOutcome.ACCEPTED
-            return _ShowEventDispatchOutcome.IN_FLIGHT
+            return _show_event_dispatch_outcome(
+                _reconcile_show_event_dispatch(event_payload)
+            )
 
         status = result.get("status_code", 500)
         body = result.get("body") or {}
@@ -9364,43 +9335,75 @@ async def _run_show_event_dispatch(
                     owner=owner,
                     state=DISPATCH_FAILED,
                 )
-            _settle_show_event_message(event_payload)
-            return _ShowEventDispatchOutcome.FAILED
-
-        with _projects_engine().connect() as conn:
-            dispatch_status = get_show_dispatch_status(
-                conn,
-                event_id,
-                session_id=session_id,
+            return _show_event_dispatch_outcome(
+                _reconcile_show_event_dispatch(event_payload)
             )
-        if dispatch_status is None:
-            return _ShowEventDispatchOutcome.FAILED
-        if dispatch_status.state != DISPATCH_ACCEPTED:
-            return _ShowEventDispatchOutcome.IN_FLIGHT
-        return (
-            _ShowEventDispatchOutcome.ACCEPTED
-            if _settle_show_event_message(event_payload) is not None
-            else _ShowEventDispatchOutcome.FAILED
+        return _show_event_dispatch_outcome(
+            _reconcile_show_event_dispatch(event_payload)
         )
 
 
-def _settle_show_event_message(event_payload: dict[str, Any]) -> dict[str, Any] | None:
-    message = _load_show_event_message(event_payload)
-    if message is None:
+def _reconcile_show_event_dispatch(
+    event_payload: dict[str, Any],
+) -> Any | None:
+    from core.show_session_events import ShowSessionEventStore
+
+    session_id = event_payload.get("session_id")
+    event_id = event_payload.get("id")
+    if not isinstance(session_id, str) or not session_id:
         return None
+    if not isinstance(event_id, str) or not event_id:
+        return None
+    store = ShowSessionEventStore()
+    try:
+        settlement = store.reconcile_dispatch_settlement(session_id, event_id)
+    finally:
+        store.close()
+    if settlement is None or settlement.message is None:
+        return settlement
+
+    message = settlement.message
     event_payload["message_id"] = message["id"]
-    settled = _promote_and_publish_pending_user_message(
-        message,
-        session_id=str(event_payload["session_id"]),
-        scope_id=(
-            str(event_payload["scope_id"])
-            if isinstance(event_payload.get("scope_id"), str)
-            else None
-        ),
-        activity_event="show_event",
+    event_payload["message"] = message
+    if settlement.can_publish_message_new:
+        _publish_visible_user_message(
+            message,
+            session_id=session_id,
+            scope_id=(
+                str(event_payload["scope_id"])
+                if isinstance(event_payload.get("scope_id"), str)
+                else None
+            ),
+            activity_event="show_event",
+        )
+    elif settlement.can_publish_queue_updated:
+        from vibe.sse_broker import broker
+
+        broker.publish(
+            "queue.updated",
+            {
+                "session_id": session_id,
+                "scope_id": event_payload.get("scope_id"),
+            },
+        )
+    return settlement
+
+
+def _show_event_dispatch_outcome(
+    settlement: Any | None,
+) -> _ShowEventDispatchOutcome:
+    from core.show_session_events import (
+        DISPATCH_IN_FLIGHT,
+        DISPATCH_NONE,
     )
-    event_payload["message"] = settled or message
-    return event_payload["message"]
+
+    if settlement is None:
+        return _ShowEventDispatchOutcome.FAILED
+    if settlement.can_report_success:
+        return _ShowEventDispatchOutcome.ACCEPTED
+    if settlement.status.state in {DISPATCH_NONE, DISPATCH_IN_FLIGHT}:
+        return _ShowEventDispatchOutcome.IN_FLIGHT
+    return _ShowEventDispatchOutcome.FAILED
 
 
 def _show_event_dispatch_error() -> ShowSessionEventError:
@@ -9425,28 +9428,6 @@ def _load_session_message(session_id: str, message_id: str) -> dict[str, Any] | 
         (item for item in window["messages"] if item.get("id") == message_id),
         None,
     )
-
-
-def _load_show_event_message(event_payload: dict[str, Any]) -> dict[str, Any] | None:
-    from sqlalchemy import select
-    from storage.models import show_session_events
-
-    session_id = event_payload.get("session_id")
-    event_id = event_payload.get("id")
-    if not isinstance(session_id, str) or not session_id:
-        return None
-    if not isinstance(event_id, str) or not event_id:
-        return None
-    with _projects_engine().connect() as conn:
-        message_id = conn.execute(
-            select(show_session_events.c.message_id).where(
-                show_session_events.c.id == event_id,
-                show_session_events.c.session_id == session_id,
-            )
-        ).scalar_one_or_none()
-    if not isinstance(message_id, str) or not message_id:
-        return None
-    return _load_session_message(session_id, message_id)
 
 
 def _show_event_dispatch_text(event_payload: dict[str, Any]) -> str:
@@ -10792,6 +10773,19 @@ async def _start_startup_dependency_reconcile() -> None:
         )
 
 
+def reconcile_show_dispatch_messages_on_startup() -> None:
+    store = _show_session_event_store()
+    try:
+        reconciled = store.reconcile_dispatch_messages()
+    finally:
+        store.close()
+    if reconciled:
+        logger.info(
+            "Reconciled %s terminal Show dispatch transcript reservation(s)",
+            reconciled,
+        )
+
+
 async def _stop_startup_dependency_reconcile() -> None:
     global _startup_dependency_reconcile_task
     task, _startup_dependency_reconcile_task = _startup_dependency_reconcile_task, None
@@ -10806,6 +10800,7 @@ async def _stop_startup_dependency_reconcile() -> None:
 
 
 app.add_event_handler("startup", sweep_orphan_show_runtime_servers_on_startup)
+app.add_event_handler("startup", reconcile_show_dispatch_messages_on_startup)
 app.add_event_handler("startup", _start_startup_dependency_reconcile)
 app.add_event_handler("shutdown", _stop_startup_dependency_reconcile)
 app.add_event_handler("shutdown", stop_show_runtime_on_shutdown)


### PR DESCRIPTION
## Summary

- route dispatching Show Page events through the same asynchronous turn entry used by Chat and the scheduler
- reserve dispatching Show transcript rows before submission, but keep dispatch acceptance on the stable `show_session_events` identity instead of overloading `messages.type`
- persist one event-owned lifecycle: `none -> in_flight(owner, claimed_at) -> accepted|failed|archived`; only the unified controller may write `accepted`
- identify each dispatch claim as `pid:process-start:attempt-id` and use the current process's active-attempt set as the authoritative same-incarnation liveness signal
- settle controller submission from the reservation observed after `SessionTurnManager.submit`: a started or durably queued row becomes `accepted`, a missing reservation in an archived session becomes `archived`, and any other missing reservation becomes retryable `failed`
- make `SessionTurnManager.submit` return both its route (`ran`/`enqueued`) and the enqueue callback's durable-write result, instead of silently discarding a failed pending-to-queued transition
- recover a provably abandoned/cancelled claim immediately, preserve genuinely live slow attempts, retry definite failures, and deduplicate accepted or still-live submissions without a second `SessionTurnManager.submit`
- return a tri-state dispatch outcome (`accepted`, `in_flight`, `failed`) so a concurrent replay is reported as pending rather than as a transport failure
- keep transcript rendering independent: failed submissions may remain visible and retryable, queued annotations stay out of the transcript, and accepted idle annotations become visible user rows
- normalize blank event IDs once before the first live attempt, bind event IDs to canonical request content, and include sibling fields such as `anchor` in conflict detection
- retain independently identified Show annotations as separate queue segments, mint a fresh sortable message ID on promotion, and repoint the event/media links transactionally
- roll back screenshot media created by a losing idempotent insert and reuse one event store during CLI timeout polling
- remove the unconsumed legacy streaming dispatch endpoint, client, `show.dispatch` fan-out, and its queue-flush special case
- update the authoritative dispatch plans without changing public Show write/redaction/auth or POST-body contracts

## Scenarios

- busy Show Page annotation: queue without `message.new`, then run after the active turn
- idle Show Page annotation: start immediately and settle as a visible user message
- archive between the controller precheck and enqueue callback: remove the reservation and settle `archived`, never false-success `accepted`
- slow live Show POST plus the CLI three-second timeout path: inspect the event-owned state and submit exactly once
- ambiguous internal response after acceptance: recover the accepted event without a second submit
- cancelled same-process attempt: release its claim immediately; slow active attempt: remain non-reclaimable regardless of age
- definite dispatch failure then same-ID retry: submit once on the successful retry
- same event ID with different canonical content: return conflict without dropping the new request as a false success
- concurrent screenshot replay: retain only the winning event's media registration/file
- two identified Show events in the queue: retain two turns and both stable event links
- non-dispatch Show events and offline/direct non-dispatch writes: retain existing immediate publish behavior

No numbered scenario catalog entry exists for these paths.

Latest implementation ruling applied here: **2026-07-26 17:54:14 UTC+08:00**.

## Design Notes

The stable Show event row is the aggregate root for dispatch identity and
lifecycle. Migration `20260726_0035` adds one `dispatch_state` column containing
the state and, only while in flight, the claim owner and timestamp. Existing
rows are backfilled to `accepted`; the server default stays `none` for new rows.
`archived` is a distinct terminal attempt outcome: the session has no dispatch
target, but the annotation must never be reported as successfully accepted.

A claim owner is a dispatch-attempt identity, not merely a process identity:
`pid:process-start:attempt-id`. The UI process maintains the active attempt IDs
under a lock. For its own process incarnation that set is authoritative: an
active slow attempt cannot be reclaimed based on age, while an ended or
cancelled attempt is immediately reclaimable. Foreign process incarnations use
the existing PID/start-time check plus TTL fallback. Session archive is checked
through the event's session, so deleting or replacing a transcript row cannot
authorize a new submission.

`messages.type` is again limited to transcript/queue presentation:
`pending`, `queued`, or visible `user`. The temporary
`dispatching`/`dispatch_failed` message types and their checkpoint exceptions
were deleted. A definite delivery failure marks the event `failed` while making
the user's annotation visible; retry still reaches the unified manager because
visibility no longer implies acceptance. A completed fast turn leaves the event
`accepted`, so replay remains deduplicated after the transcript reservation has
been promoted.

The boundary now distinguishes routing from durability. `SessionTurnManager.submit`
returns `TurnSubmissionResult(route, queue_persisted)`, and both source-specific
enqueue callbacks return whether their row is actually durable. This fixes the
old `Callable[[], None]` contract, where the manager could only report
`enqueued` even when an archive transaction had already deleted the reservation.
The atomicity note is narrowed accordingly: no `await` protects the controller
loop from its own turn-flush interleaving, but does not make enqueue atomic with
external archive transactions.

Production calls persist a terminal lifecycle through exactly one function,
`settle_show_dispatch`; there is one terminal `dispatch_state` UPDATE in
`core/show_session_events.py`. The sole production path that asks it to write
`accepted` is `observe_and_settle_show_dispatch`, which combines the manager's
queue-persistence result with one post-submit join of the event, current message,
and session. A matching active turn or persisted `queued` row is observed
acceptance. If the row is gone, the same read produces `archived` for an archived
session or `failed` otherwise. The accepted state and the HTTP 202 response both
derive from this one observation; neither infers durability from control-flow
arrival or the `enqueued` route. Definite transport failures use the same terminal
writer based on the observed controller response.

The CLI timeout path is automatic and state-driven. Blank/null/whitespace event
IDs are normalized once before the first POST. After an ambiguous three-second
transport timeout, one reused `ShowSessionEventStore` polls the same event:
accepted returns the existing event, in-flight waits/reports, failed retries,
and archived reports failure rather than success. The event request fingerprint
is exclusion-based: only outer transport identity fields are excluded, so
future payload fields participate in conflict detection by default. Pending and
same-ID conflict errors use backend i18n keys.

Queue promotion uses the existing microsecond-sortable message ID generator.
The fresh visible row gets an honest promotion timestamp and a fresh ID; the
Show event and media dependents are repointed in the same transaction. Client
code does not retain pending transcript IDs: the Show Runtime SDK reconciles by
Show event ID, and server responses/event streams return the current linked
message.

State-write audit after the boundary fix:

- `none`: non-terminal creation from the recorded dispatch intent
- `in_flight`: non-terminal CAS claim from the event row plus attempt ownership
- `accepted`: observed only after submit from an active matching reservation or a
  durable queued row, with the callback persistence result carried by the manager
- `archived`: observed from the joined session after the reservation is absent
- `failed`: observed from a missing non-archived reservation or a definite
controller/transport rejection

There is **1 terminal SQL write point**: every
`accepted`/`failed`/`archived` transition passes through
`settle_show_dispatch`. No terminal state is asserted merely because execution
reached a line.

All outward delivery promises use the same read-back settlement projection.
The event row, its current linked message, and session state are joined on one
connection so a synchronous queue drain cannot leave the route holding a stale
message ID. `message.new`, `queue.updated`, Show HTTP success, and CLI success
are derived from that projection rather than control-flow arrival. Startup and
event-touch reconciliation promote the recoverable `accepted`/`failed` plus
`pending` crash state, while an archive observed before claim is atomically
persisted as the distinct `archived` terminal state.

Ordinary Chat has no later event-owned reconciler, so an ambiguous controller
timeout settles its reservation before returning. It reuses the existing
conditional promote-and-read-back helper: a row still owned by the endpoint is
made visible as `user`; a row the controller already persisted as `queued` is
observed without being overwritten and only produces `queue.updated`. The UI
endpoint never writes `queued` itself, and an ambiguous failure never submits
the prompt a second time.

Known-by-design ledger:

- A replay of a pre-migration Show event can reuse the same event ID, event
  type, and annotation text with a different anchor and resolve to the stored
  event. Only legacy rows without the new request fingerprint take this path;
  new events bind sibling fields including the anchor. This annotation-only
  compatibility edge is accepted rather than adding migration-time payload
  reconstruction.

Merge-order note (verified by trial merge, 2026-07-26): PR #1015 and PR #1026
touch the same areas. A three-way merge of the two heads produces exactly **five
conflicts, and every one is a pure additive union** — neither side loses
anything:

| File | Conflicting region | Resolution |
| --- | --- | --- |
| `core/show_session_events.py` | the `storage.models` import line | keep #1015's line (`agent_sessions, media_objects, messages, show_session_events`); it is a superset of #1026's |
| `core/show_session_events.py` | the constant block after `ASSISTANT_MARK_EVENT_TYPES` | keep **both** blocks — #1015's `DISPATCH_*` / `SHOW_EVENT_ERROR_I18N_KEYS` and #1026's `ASSISTANT_MARK_TRANSCRIPT_I18N_KEYS` / `MARK_*` are disjoint |
| `tests/test_show_session_events.py` | the `from core.show_session_events import (...)` name list | union both lists, isort order |
| `vibe/i18n/en.json` | the top-level `show` object | keep **both** sub-objects: `show.event` (#1015) and `show.mark` (#1026) |
| `vibe/i18n/zh.json` | the top-level `show` object | same |

`tests/test_show_session_events.py` conflicts as well — an earlier version of
this note listed only the event module and the two locale files.

The union resolution above was actually built and exercised: `ruff check` clean,
and `test_show_session_events.py` + `test_show_pages.py` + `test_internal_server.py`
+ `test_queued_message_writer_policy.py` together give **326 passed**. Every other
shared file (`core/internal_server.py`, `vibe/ui_server.py`, `vibe/cli.py`,
`tests/test_internal_server.py`, `tests/test_show_pages.py`) auto-merges cleanly.

## Evidence

### Unit and contract

- Focused current-head settlement/archive group: **10 passed**
- Shared-module group, including the scheduler caller and queued-writer policy:
  **708 passed**
- Full suite: **5752 passed, 54 skipped, 3 subtests passed**
  - two `test_platform_registry.py` class-identity assertions fail only in the
    full-suite process; both passed immediately in isolated rerun (**2 passed**)
    and this PR changes no platform-registry code
- regression coverage includes:
  - archive during submit: real archive teardown clears the reservation, callback reports failure, state settles `archived`, replay does not submit again
  - unified entry returns `queue_persisted=false` when its source callback loses the durable write
  - recursive queue drain carries the promoted row's fresh ID into the active
    turn context before post-submit acceptance is observed
  - live same-process attempt liveness, cancellation reclaim, and concurrent replay pending response
  - slow live POST plus CLI timeout polling
  - ambiguous acceptance and definite-failure recovery
  - exactly one `SessionTurnManager.submit` for each recovery case
  - event-owned acceptance surviving fast completion and message replacement
  - missing event/message and archived-session rejection before submission
  - migration backfill (`accepted` for legacy rows, `none` for new rows)
  - sibling-field conflicts, blank-ID normalization, screenshot loser cleanup,
    separate identified queue segments, and localized pending/conflict errors
  - AST policy guard: any module that writes `messages.type=queued` must remain
    inside the hard-coded controller/storage ownership allowlist; Web code has
    no authority to create executable queue rows
- Ruff passed on every changed Python file
- `git diff --check` passed
- consumer scan found no `show.dispatch`, `stream_dispatch`, or
  `/internal/dispatch` consumer in `ui/src` or `vibe-show-runtime/packages`
- existing public/redaction/auth and POST-body contract coverage remains green

### Local Incus regression

Ran the macOS local regression environment at runtime-equivalent parent commit
`65464caeccb2e2d8e8189e6406a689ee25b7aaa2`; deployment metadata reported
`dirty=false`. The orchestrator explicitly waived another Incus run for the
final AST policy and bounded queue-bookkeeping changes on head `94b4dbdc`.

Busy queue-to-delivery through the real private Show Page endpoint:

- a Chat prompt started an agent turn
- while that turn was still `in_flight`, private Show event
  `show_evt_live_65464cae_1785060375674` was posted
- the Show POST returned HTTP 201 with reservation
  `msg_0065780c19b730cb1bc0bf0` already `type=queued`
- no `message.new` was published for the queued reservation
- the annotation then promoted to fresh visible user row
  `msg_0065780c1ec84e8cd8b5d88` after the active result, retaining Show event
  identity and starting the queued annotation's turn
- the queued annotation produced result `msg_0065780c2265d90b4b0a327`;
  final state was idle with an empty queue

The same exact deployed source also ran seven focused regression cases inside
the Incus instance:

- Chat timeout/ambiguous failure promotes an endpoint-owned pending reservation
  to a visible user row, leaves no execution-queue row, and calls dispatch once
- when the controller already queued the row before its response is lost, the
  endpoint observes that queue entry without `message.new` or a second write
- `accepted` plus `pending` is reconciled to a visible linked row on startup and
  before CLI success
- archive observed before claim, including a retryable failed event, is
  persisted as `archived`
- synchronous queue drain repoint/delete returns the current linked message
  instead of a false 502
- busy Show dispatch remains queued without `message.new`

### Evidence layers

- unit: event lifecycle, archive race, attempt liveness, tri-state outcome,
  i18n, idempotency, controller writer boundary, CLI recovery, queue promotion,
  media rollback
- contract: authoritative dispatch plans updated; legacy endpoint absent; Show
  POST/public contracts unchanged
- scenario: busy queue-to-delivery, idle start, archive race,
  slow/ambiguous/failure recovery, stable event identity
- residual manual check: none for this lane; both current-head local Incus
  acceptance probes passed

