### PR TITLE
fix(models): cascade deleted model references

### DIFF
--- a/core/handlers/model_hub/service.py
+++ b/core/handlers/model_hub/service.py
@@ -988,6 +988,7 @@ class ModelHubService:
                 raise ModelHubError("mode_switch_blocked", status=409)
             config.sources = [item for item in config.sources if item.id != source_id]
             config.priority_order = [item for item in config.priority_order if item != source_id]
+            self._prune_unavailable_agent_references(config)
             if source.credential_ref:
                 self.revocations.add(source.id, source.credential_ref)
             try:
@@ -1049,6 +1050,40 @@ class ModelHubService:
         if source.kind == "api_key":
             return source.supply_channel == "hub"
         return backend in _allowed_origins(source)
+
+    def _available_model_ids(self, config: ModelHubConfig, backend: str) -> set[str]:
+        return {
+            model.id
+            for source in config.sources
+            if self._eligible_for_agent(source, backend)
+            for model in source.models
+        }
+
+    def _available_opencode_identifiers(self, config: ModelHubConfig) -> set[str]:
+        return {
+            opencode_model_id(source.vendor, model.id)
+            for source in config.sources
+            if self._eligible_for_agent(source, "opencode")
+            for model in source.models
+        }
+
+    def _prune_unavailable_agent_references(self, config: ModelHubConfig) -> None:
+        for agent in config.agents.values():
+            if agent.menu_kind == "fixed":
+                available = self._available_model_ids(config, agent.backend)
+                agent.mappings = [
+                    mapping
+                    for mapping in agent.mappings
+                    if mapping.target_model_id in available
+                ]
+        opencode_menu = config.agents["opencode"].menu
+        if opencode_menu is not None:
+            available = self._available_opencode_identifiers(config)
+            opencode_menu.checked = [
+                identifier
+                for identifier in opencode_menu.checked
+                if identifier in available
+            ]
 
     def _source_available(self, source: ModelHubSourceConfig) -> bool:
         if source.state.status == "error":
@@ -1122,13 +1157,8 @@ class ModelHubService:
                 parsed = [ModelHubMappingConfig.from_payload(mapping) for mapping in mappings]
             except ValueError as exc:
                 raise ModelHubError("mapping_target_unavailable") from exc
-            available = {
-                model.id
-                for source in config.sources
-                if self._eligible_for_agent(source, backend)
-                for model in source.models
-            }
-            if any(mapping.enabled and mapping.target_model_id not in available for mapping in parsed):
+            available = self._available_model_ids(config, backend)
+            if any(mapping.target_model_id not in available for mapping in parsed):
                 raise ModelHubError("mapping_target_unavailable")
             agent.mappings = parsed
             self.store.save(config)
@@ -1142,12 +1172,7 @@ class ModelHubService:
                 parsed = ModelHubMenuConfig.from_payload(cast(dict, menu))
             except (TypeError, ValueError) as exc:
                 raise ModelHubError("mapping_target_unavailable") from exc
-            available = {
-                opencode_model_id(source.vendor, model.id)
-                for source in config.sources
-                if self._eligible_for_agent(source, "opencode")
-                for model in source.models
-            }
+            available = self._available_opencode_identifiers(config)
             if any(identifier not in available for identifier in parsed.checked):
                 raise ModelHubError("mapping_target_unavailable")
             agent.menu = parsed
@@ -1206,6 +1231,7 @@ class ModelHubService:
                 for model in source.models
                 if not (model.id == model_id and model.provenance == "manual")
             ]
+            self._prune_unavailable_agent_references(config)
             await self._commit_synced(previous, config)
             return source.to_payload()
 

--- a/tests/test_model_hub_resolution.py
+++ b/tests/test_model_hub_resolution.py
@@ -179,6 +179,56 @@ def _service(tmp_path, adapter, *, agents=None, now=None):
     )
 
 
+def _configure_referenced_manual_model(service, *, model_id: str = "retired-model"):
+    config = service.store.load()
+    config.sources[0].models.append(ModelHubModelConfig(id=model_id, provenance="manual"))
+    config.agents["claude"].mappings = [
+        ModelHubMappingConfig(
+            builtin_id="claude-opus-4-6",
+            target_model_id=model_id,
+            enabled=True,
+        )
+    ]
+    config.agents["opencode"].menu.checked = [
+        f"anthropic/{model_id}",
+        "anthropic/claude-opus-4-6",
+    ]
+    return config
+
+
+def _serialized_config(service) -> str:
+    return json.dumps(
+        service.store.load().to_payload(),
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+
+
+def _assert_no_references_to(service, model_id: str) -> None:
+    persisted = service.store.load()
+    mapping_targets = {
+        mapping.target_model_id
+        for agent in persisted.agents.values()
+        for mapping in agent.mappings
+    }
+    menu_target_models = {
+        identifier.partition("/")[2]
+        for agent in persisted.agents.values()
+        if agent.menu is not None
+        for identifier in agent.menu.checked
+    }
+    available_models = {
+        model.id
+        for source in persisted.sources
+        for model in source.models
+    }
+
+    assert mapping_targets <= available_models
+    assert menu_target_models <= available_models
+    assert (mapping_targets | menu_target_models).isdisjoint({model_id})
+
+
 @pytest.mark.parametrize(
     ("outcome", "refresh_attempted", "action", "reason"),
     [
@@ -679,6 +729,34 @@ def test_source_delete_does_not_revoke_when_config_save_fails(tmp_path):
     assert [source.id for source in service.store.load().sources] == ["src_primary01", "src_backup001"]
 
 
+@pytest.mark.parametrize(("force", "mode"), [(False, "direct"), (True, "hub")])
+def test_source_delete_cascades_agent_model_references(tmp_path, force, mode):
+    adapter = FakeAdapter([_outcome(RawOutcomeKind.SUCCESS, status=200)])
+    service = _service(tmp_path, adapter)
+    config = _configure_referenced_manual_model(service)
+    config.agents["claude"].mode = mode
+    config.agents["opencode"].mode = mode
+
+    asyncio.run(service.delete_source("src_primary01", force=force))
+
+    persisted = service.store.load()
+    assert [source.id for source in persisted.sources] == ["src_backup001"]
+    assert persisted.priority_order == ["src_backup001"]
+    _assert_no_references_to(service, "retired-model")
+    if force:
+        agents = {agent["backend"]: agent for agent in service.list_agents()}
+        assert agents["claude"]["current"]["source_id"] == "src_backup001"
+        assert agents["opencode"]["current"]["source_id"] == "src_backup001"
+        resolved = asyncio.run(
+            service.resolve(
+                backend="claude",
+                model_id="claude-opus-4-6",
+                request={},
+            )
+        )
+        assert resolved.source_id == agents["claude"]["current"]["source_id"]
+
+
 def test_deleting_last_hub_source_syncs_empty_binding_set(tmp_path):
     adapter = FakeAdapter([])
     service = _service(tmp_path, adapter)
@@ -696,15 +774,20 @@ def test_deleting_last_hub_source_syncs_empty_binding_set(tmp_path):
 def test_source_reference_survives_failed_credential_revoke(tmp_path):
     adapter = FakeAdapter([])
     service = _service(tmp_path, adapter)
-    service.store.load().sources[0].credential_ref = "cred_primary"
-    service.store.load().sources[1].credential_ref = "cred_backup"
+    config = _configure_referenced_manual_model(service)
+    config.sources[0].credential_ref = "cred_primary"
+    config.sources[1].credential_ref = "cred_backup"
+    before = _serialized_config(service)
     adapter.fail_revoke = True
 
     with pytest.raises(ModelHubError) as exc_info:
         asyncio.run(service.delete_source("src_primary01", force=True))
 
     assert exc_info.value.code == "engine_down"
+    assert _serialized_config(service) == before
     assert [source.id for source in service.store.load().sources] == ["src_primary01", "src_backup001"]
+    assert service.store.load().agents["claude"].mappings[0].target_model_id == "retired-model"
+    assert service.store.load().agents["opencode"].menu.checked[0] == "anthropic/retired-model"
     assert [tuple(binding.source_id for binding in batch) for batch in adapter.synced] == [
         ("src_backup001",),
         ("src_primary01", "src_backup001"),
@@ -765,6 +848,45 @@ def test_selected_custom_model_cannot_be_deleted(tmp_path):
 
     assert exc_info.value.code == "mode_switch_blocked"
     assert any(model.id == "manual-model" for model in service.store.load().sources[0].models)
+
+
+def test_custom_model_delete_cascades_agent_model_references(tmp_path):
+    service = _service(tmp_path, FakeAdapter([]))
+    config = _configure_referenced_manual_model(service)
+    config.agents["claude"].mode = "direct"
+    config.agents["opencode"].mode = "direct"
+
+    asyncio.run(service.delete_custom_model("src_primary01", "retired-model"))
+
+    persisted = service.store.load()
+    assert all(model.id != "retired-model" for model in persisted.sources[0].models)
+    _assert_no_references_to(service, "retired-model")
+    assert persisted.agents["claude"].mappings == []
+    assert persisted.agents["opencode"].menu.checked == ["anthropic/claude-opus-4-6"]
+
+
+@pytest.mark.parametrize("operation", ["source", "custom_model"])
+def test_delete_commit_failure_restores_agent_references_byte_for_byte(tmp_path, operation):
+    adapter = FakeAdapter([])
+    adapter.fail_sync = True
+    service = _service(tmp_path, adapter)
+    config = _configure_referenced_manual_model(service)
+    if operation == "custom_model":
+        config.agents["claude"].mode = "direct"
+        config.agents["opencode"].mode = "direct"
+    before = _serialized_config(service)
+
+    with pytest.raises(ModelHubError) as exc_info:
+        if operation == "source":
+            asyncio.run(service.delete_source("src_primary01", force=True))
+        else:
+            asyncio.run(service.delete_custom_model("src_primary01", "retired-model"))
+
+    assert exc_info.value.code == "engine_down"
+    assert _serialized_config(service) == before
+    restored = service.store.load()
+    assert restored.agents["claude"].mappings[0].target_model_id == "retired-model"
+    assert restored.agents["opencode"].menu.checked[0] == "anthropic/retired-model"
 
 
 def test_custom_model_preserves_slash_qualified_upstream_id(tmp_path):
@@ -853,6 +975,27 @@ def test_mapping_and_delete_guards_use_backend_eligible_sources(tmp_path):
     config.agents["claude"].mode = "direct"
     asyncio.run(service.delete_source("src_primary01"))
     assert [source.id for source in service.store.load().sources] == ["src_backup001"]
+
+
+def test_mapping_write_rejects_disabled_unavailable_target(tmp_path):
+    service = _service(tmp_path, FakeAdapter([]))
+
+    with pytest.raises(ModelHubError) as exc_info:
+        asyncio.run(
+            service.set_mappings(
+                "claude",
+                [
+                    {
+                        "builtin_id": "claude-opus-4-6",
+                        "target_model_id": "missing-model",
+                        "enabled": False,
+                    }
+                ],
+            )
+        )
+
+    assert exc_info.value.code == "mapping_target_unavailable"
+    assert service.store.load().agents["claude"].mappings == []
 
 
 def test_event_log_is_bounded_and_sanitizes_labels(tmp_path):


### PR DESCRIPTION
## Capability

Atomically remove Model Hub agent references that become unavailable when a
source or manual custom model is deleted.

Affected scenario IDs: `MH-MAP-001`, `MH-OC-001`, `MH-PRI-001`.

## Evidence before the fix

Minimal reproduction:

1. Source A supplies `retired-model`; source B supplies
   `claude-opus-4-6`.
2. Claude maps `claude-opus-4-6 -> retired-model`; OpenCode checks both
   `anthropic/retired-model` and `anthropic/claude-opus-4-6`.
3. Force-delete source A.

The persisted config retained both references. `GET /api/models/agents`
projected `current: null` for Claude and OpenCode, even though source B still
supplied the native model, and resolution of either stale selection failed
with `mapping_target_unavailable` (HTTP 409). There was no automatic fallback.
The same persisted dangling references could be produced by an ordinary delete
while the affected agent was in Direct mode, or by deleting a selected manual
model while that agent was in Direct mode.

## Change

- Compute backend-eligible model IDs and provider-qualified OpenCode IDs from
  the post-delete aggregate.
- In the same cloned config committed by `delete_source` and
  `delete_custom_model`, remove fixed mappings and checked OpenCode identifiers
  that no remaining eligible source supplies.
- Preserve honest supply semantics: if no checked/menu supply remains, the
  persisted selection is empty and `current` remains null.
- Reuse the same availability helpers in write validation. OpenCode already
  rejected every unavailable checked ID; fixed mappings now reject unavailable
  targets even when `enabled=false`, because a disabled entry still persists a
  model ID and can otherwise reintroduce stale state.

## ID-reference audit

- `priority_order` is the only other live config reference to a source ID; the
  existing source-delete mutation already removes it in the same commit.
- The engine source registry is a derived `SourceBinding` projection refreshed
  by `_commit_synced`; sync failure restores the complete previous config and
  previous engine projection.
- Resolution events are immutable historical audit facts, not route
  candidates, so their past source/model IDs must remain.
- OAuth flow bindings are bounded workflow/idempotency records, not routing
  references; a completed binding whose source was deleted is forgotten and
  returns `flow_not_found` on the next flow lookup.
- Pending credential revocations intentionally retain the deleted source ID
  until revoke succeeds, then remove it; this is recovery state, not supply.
- Migration item/source IDs are recomputed scan proposals rather than persisted
  references. Process-local launch history resolves IDs back through the
  current config and cannot select a deleted source.

## Transaction and rollback

The cascade runs on the same cloned `ModelHubConfig` before `_commit_synced`.
Config-save/sync failure restores the previous payload, and credential-revoke
failure restores the previous payload plus engine bindings. Tests compare the
serialized pre/post config byte-for-byte and cross-check both mappings and
OpenCode menu references.

## Evidence layers

- Unit: ordinary source delete, forced source delete, custom-model delete,
  unavailable disabled mapping write, engine-sync rollback, and
  credential-revoke rollback.
- Contract: no frozen contract files changed; existing response/error shapes
  are unchanged.
- Scenario: the repository Model Hub canonical group passed, 142 tests.
- Lint: Ruff passed on both changed files.
- Residual manual checks: no UI behavior changed. Incus/UI integration remains
  for the orchestrator's post-merge integration pass.

## Contract follow-up for the orchestrator

No schema shape changes are needed. To make the mutation guarantee explicit,
append this sentence to both delete rows in the frozen API contract when that
contract is next revised:

> On successful deletion, the server atomically removes any fixed mappings and
> OpenCode checked-menu identifiers that are no longer supplied by the
> remaining eligible sources.

Dependencies: none.
