### PR TITLE
feat(workbench): in-graph trigger detail panel + hide disabled triggers (M9)

### DIFF
--- a/docs/plans/agents-run-graph-contract.md
+++ b/docs/plans/agents-run-graph-contract.md
@@ -56,45 +56,24 @@ Amendments (orchestrator-approved):
   and disabled definitions with no in-window runs never appear. A disabled
   definition that DID fire in-window keeps its chip (it explains lineage) —
   client renders it dimmed with a disabled marker using the existing
-  `enabled` field. **(Default rendering amended by A11: disabled chips and
-  their trigger edges are hidden by default and revealed via the canvas
-  "Show disabled" legend toggle, still dimmed when shown.)**
+  `enabled` field.
+- **A11 (2026-07-26, owner feedback)**: trigger chips get an **in-graph
+  detail panel** (same interaction as session nodes) instead of navigating to
+  Harness on click: name, type (task schedule/next-run · watch command/runtime
+  state), enabled state, carrying session (click selects that node), recent
+  trigger runs (deep-links), in-place actions (enable/disable toggle; task
+  run-now; watch pause/resume) via the EXISTING harness API client methods —
+  no new backend. "Open in Harness" becomes a secondary link in the panel.
+  Additionally, chips with `enabled=false` are **hidden by default**
+  (together with their trigger edges); a "show disabled" switch in the canvas
+  LEGEND reveals them (dimmed + disabled marker per A10). Client-side only;
+  payload unchanged.
 - **A7 (2026-07-23, PR #956 review)**: graph endpoint path renamed
   `/api/agents/graph` → **`/api/agents-graph`**. Rationale: `/api/agents/…`
   is the agent-resource namespace and agent names are user-creatable slugs —
   an agent literally named `graph` would shadow the route. Endpoint and its
   sole consumer live in the same PR; no migration cost. Reserving the word
   `graph` in the agent-name domain was rejected.
-- **A11 (2026-07-26, owner graph-experience feedback — PR #1018)**: two
-  **client-side** trigger-chip changes (graph payload unchanged, `ui/**` only,
-  no new backend):
-  1. **Hide-disabled-by-default (amends A10).** A disabled definition's chip
-     **and its `trigger` edges are not rendered by default** — the dimmed
-     "explains lineage" chip A10 kept is now opt-in. A canvas legend toggle
-     **"Show disabled / 显示已禁用"** (default off, persisted in `localStorage`
-     via `lib/graphViewPrefs.ts`) reveals them, still dimmed with the
-     `· Disabled` marker per A10. Spawn edges and session lineage are always
-     preserved; only disabled `trigger` chips + their trigger edges hide. The
-     mobile grouped list shares the same `showDisabled` preference (disabled
-     pills hidden by default). Search may still target a hidden disabled chip:
-     the hit badges "Outside current filters" and flips the toggle on to locate
-     it (a pure client filter — no refetch).
-  2. **In-graph trigger detail panel.** Clicking a Task/Watch chip selects it
-     and opens the right-side detail panel (same interaction as a session node)
-     instead of navigating to Harness: name/type, task schedule + next-run or
-     watch command + runtime, enabled state, fired sessions (each row selects
-     that node), recent trigger runs (deep-link to
-     `/harness?tab=runs&run=<id>`), and an in-place enable/disable toggle — a
-     watch's toggle **is** its pause/resume — via the existing
-     `setHarnessTaskEnabled` / `setHarnessWatchEnabled` client (optimistic with
-     revert-on-error, then a graph refetch so the chip re-dims/re-hides). The
-     panel reads lineage from the **raw** (unfiltered) edges/maps, so a relation
-     stays truthful even when the chip is hidden by the toggle. A watch's
-     runtime (`running`/`pid`) is reconciled by re-polling the definition after
-     the toggle, because `WatchSupervisor` starts/stops the worker
-     asynchronously. "Open in Harness" survives as a secondary link. Task
-     run-now is **not** shipped (the Harness backend exposes only a `{enabled}`
-     PATCH; deferred to a candidate future backend micro-batch).
 
 ## 1. Visibility enum (M1 owns, M2 consumes)
 

--- a/docs/plans/agents-run-graph-contract.md
+++ b/docs/plans/agents-run-graph-contract.md
@@ -56,13 +56,45 @@ Amendments (orchestrator-approved):
   and disabled definitions with no in-window runs never appear. A disabled
   definition that DID fire in-window keeps its chip (it explains lineage) —
   client renders it dimmed with a disabled marker using the existing
-  `enabled` field.
+  `enabled` field. **(Default rendering amended by A11: disabled chips and
+  their trigger edges are hidden by default and revealed via the canvas
+  "Show disabled" legend toggle, still dimmed when shown.)**
 - **A7 (2026-07-23, PR #956 review)**: graph endpoint path renamed
   `/api/agents/graph` → **`/api/agents-graph`**. Rationale: `/api/agents/…`
   is the agent-resource namespace and agent names are user-creatable slugs —
   an agent literally named `graph` would shadow the route. Endpoint and its
   sole consumer live in the same PR; no migration cost. Reserving the word
   `graph` in the agent-name domain was rejected.
+- **A11 (2026-07-26, owner graph-experience feedback — PR #1018)**: two
+  **client-side** trigger-chip changes (graph payload unchanged, `ui/**` only,
+  no new backend):
+  1. **Hide-disabled-by-default (amends A10).** A disabled definition's chip
+     **and its `trigger` edges are not rendered by default** — the dimmed
+     "explains lineage" chip A10 kept is now opt-in. A canvas legend toggle
+     **"Show disabled / 显示已禁用"** (default off, persisted in `localStorage`
+     via `lib/graphViewPrefs.ts`) reveals them, still dimmed with the
+     `· Disabled` marker per A10. Spawn edges and session lineage are always
+     preserved; only disabled `trigger` chips + their trigger edges hide. The
+     mobile grouped list shares the same `showDisabled` preference (disabled
+     pills hidden by default). Search may still target a hidden disabled chip:
+     the hit badges "Outside current filters" and flips the toggle on to locate
+     it (a pure client filter — no refetch).
+  2. **In-graph trigger detail panel.** Clicking a Task/Watch chip selects it
+     and opens the right-side detail panel (same interaction as a session node)
+     instead of navigating to Harness: name/type, task schedule + next-run or
+     watch command + runtime, enabled state, fired sessions (each row selects
+     that node), recent trigger runs (deep-link to
+     `/harness?tab=runs&run=<id>`), and an in-place enable/disable toggle — a
+     watch's toggle **is** its pause/resume — via the existing
+     `setHarnessTaskEnabled` / `setHarnessWatchEnabled` client (optimistic with
+     revert-on-error, then a graph refetch so the chip re-dims/re-hides). The
+     panel reads lineage from the **raw** (unfiltered) edges/maps, so a relation
+     stays truthful even when the chip is hidden by the toggle. A watch's
+     runtime (`running`/`pid`) is reconciled by re-polling the definition after
+     the toggle, because `WatchSupervisor` starts/stops the worker
+     asynchronously. "Open in Harness" survives as a secondary link. Task
+     run-now is **not** shipped (the Harness backend exposes only a `{enabled}`
+     PATCH; deferred to a candidate future backend micro-batch).
 
 ## 1. Visibility enum (M1 owns, M2 consumes)
 

--- a/docs/plans/agents-run-graph-contract.md
+++ b/docs/plans/agents-run-graph-contract.md
@@ -61,9 +61,13 @@ Amendments (orchestrator-approved):
   detail panel** (same interaction as session nodes) instead of navigating to
   Harness on click: name, type (task schedule/next-run · watch command/runtime
   state), enabled state, carrying session (click selects that node), recent
-  trigger runs (deep-links), in-place actions (enable/disable toggle; task
-  run-now; watch pause/resume) via the EXISTING harness API client methods —
-  no new backend. "Open in Harness" becomes a secondary link in the panel.
+  trigger runs (deep-links), in-place actions (enable/disable toggle; watch
+  pause/resume) via the EXISTING harness API client methods — no new backend.
+  *Amended 2026-07-26 (PR #1018 review): task run-now is DEFERRED — no HTTP
+  endpoint exposes the `vibe task run` path yet and this batch is UI-only
+  (owner-approved deferral, tracked in the PR's Deferred ledger as a candidate
+  backend micro-batch). The panel ships without a run-now control until that
+  endpoint exists.* "Open in Harness" becomes a secondary link in the panel.
   Additionally, chips with `enabled=false` are **hidden by default**
   (together with their trigger edges); a "show disabled" switch in the canvas
   LEGEND reveals them (dimmed + disabled marker per A10). Client-side only;

--- a/ui/src/components/workbench/AgentGraphCanvas.tsx
+++ b/ui/src/components/workbench/AgentGraphCanvas.tsx
@@ -162,6 +162,11 @@ interface AgentGraphCanvasProps {
   // filtered out upstream when off; this drives the in-canvas switch.
   showDisabled: boolean;
   onToggleDisabled: (next: boolean) => void;
+  // Desktop fill height (px), computed from the viewport by the parent so the
+  // canvas consumes the page's remaining height and the detail panel can match
+  // it. Purely a viewport size — it never feeds the dagre layout, so a resize
+  // reflows the view without moving any node. Undefined ⇒ the intrinsic minimum.
+  heightPx?: number;
   // Changes when the user changes a filter; a new value re-fits the viewport to
   // the new layout. Unchanged across SSE/poll refreshes so they keep the view.
   fitKey: string;
@@ -193,6 +198,7 @@ const Flow: React.FC<AgentGraphCanvasProps> = ({
   selectedTriggerId,
   showDisabled,
   onToggleDisabled,
+  heightPx,
   fitKey,
   locate,
   onSelectNode,
@@ -368,7 +374,13 @@ const Flow: React.FC<AgentGraphCanvasProps> = ({
   }, [locate, layout, reactFlow]);
 
   return (
-    <div className="h-[600px] max-h-[72vh] w-full overflow-hidden rounded-2xl border border-border-strong bg-surface-3/60">
+    // The parent hands us an exact pixel height so the canvas fills the page's
+    // remaining space; the min-height floors it on short windows. React Flow
+    // observes this box and pans/zooms within it — it never re-runs the layout.
+    <div
+      className="min-h-[480px] w-full overflow-hidden rounded-2xl border border-border-strong bg-surface-3/60"
+      style={{ height: heightPx }}
+    >
       <InteractionContext.Provider value={interaction}>
         <ReactFlow
           nodes={rfNodes}

--- a/ui/src/components/workbench/AgentGraphCanvas.tsx
+++ b/ui/src/components/workbench/AgentGraphCanvas.tsx
@@ -33,6 +33,7 @@ import {
   TRIGGER_NODE_WIDTH,
   layoutLR,
 } from '../../lib/agentGraphLayout';
+import { Switch } from '../ui/switch';
 import { AgentGraphNodeCard } from './AgentGraphNodeCard';
 import { AgentGraphTriggerChip } from './AgentGraphTriggerChip';
 
@@ -53,8 +54,18 @@ type TriggerNodeData = {
 // node, shifts it under the cursor, and fires a spurious mouseleave→mouseenter
 // oscillation (the reported flicker). Custom nodes read this and toggle their
 // own classes; the node array changes only on real data changes.
-type CanvasInteraction = { highlighted: Set<string> | null; selectedId: string | null };
-const InteractionContext = createContext<CanvasInteraction>({ highlighted: null, selectedId: null });
+type CanvasInteraction = {
+  highlighted: Set<string> | null;
+  selectedId: string | null;
+  // Selected trigger definition_id (A11) — kept beside selectedId so a chip and a
+  // session node never both read as selected; the two are mutually exclusive.
+  selectedTriggerId: string | null;
+};
+const InteractionContext = createContext<CanvasInteraction>({
+  highlighted: null,
+  selectedId: null,
+  selectedTriggerId: null,
+});
 
 // Hidden handles anchor the edges; the card/chip fills the sized RF node box.
 const HANDLE_CLASS = '!h-1 !w-1 !min-w-0 !border-0 !bg-transparent';
@@ -81,11 +92,12 @@ const SessionRFNode: React.FC<NodeProps> = ({ id, data }) => {
 
 const TriggerRFNode: React.FC<NodeProps> = ({ id, data }) => {
   const d = data as unknown as TriggerNodeData;
-  const { highlighted } = useContext(InteractionContext);
+  const { highlighted, selectedTriggerId } = useContext(InteractionContext);
   return (
     <>
       <AgentGraphTriggerChip
         trigger={d.trigger}
+        selected={selectedTriggerId === d.trigger.definition_id}
         faded={!!highlighted && !highlighted.has(id)}
         onClick={() => d.onSelect(d.trigger.definition_id)}
       />
@@ -144,6 +156,12 @@ interface AgentGraphCanvasProps {
   triggerNodes: AgentGraphTriggerNode[];
   edges: AgentGraphEdge[];
   selectedId: string | null;
+  // Selected trigger definition_id (A11), mutually exclusive with selectedId.
+  selectedTriggerId: string | null;
+  // Legend "show disabled" toggle (A11): disabled chips + their trigger edges are
+  // filtered out upstream when off; this drives the in-canvas switch.
+  showDisabled: boolean;
+  onToggleDisabled: (next: boolean) => void;
   // Changes when the user changes a filter; a new value re-fits the viewport to
   // the new layout. Unchanged across SSE/poll refreshes so they keep the view.
   fitKey: string;
@@ -172,6 +190,9 @@ const Flow: React.FC<AgentGraphCanvasProps> = ({
   triggerNodes,
   edges,
   selectedId,
+  selectedTriggerId,
+  showDisabled,
+  onToggleDisabled,
   fitKey,
   locate,
   onSelectNode,
@@ -213,8 +234,8 @@ const Flow: React.FC<AgentGraphCanvasProps> = ({
   // Interaction state (hover highlight + selection) handed to custom nodes via
   // context so it never rebuilds the node array (see InteractionContext).
   const interaction = useMemo<CanvasInteraction>(
-    () => ({ highlighted, selectedId }),
-    [highlighted, selectedId],
+    () => ({ highlighted, selectedId, selectedTriggerId }),
+    [highlighted, selectedId, selectedTriggerId],
   );
 
   // Layout ranks along the call tree (spawn + trigger). Memoized on the rendered
@@ -372,7 +393,7 @@ const Flow: React.FC<AgentGraphCanvasProps> = ({
           <Background variant={BackgroundVariant.Dots} gap={22} size={1} className="opacity-40" />
           <Controls showInteractive={false} position="bottom-right" />
           <Panel position="bottom-left">
-            <Legend t={t} />
+            <Legend t={t} showDisabled={showDisabled} onToggleDisabled={onToggleDisabled} />
           </Panel>
         </ReactFlow>
       </InteractionContext.Provider>
@@ -380,7 +401,11 @@ const Flow: React.FC<AgentGraphCanvasProps> = ({
   );
 };
 
-const Legend: React.FC<{ t: (k: string) => string }> = ({ t }) => (
+const Legend: React.FC<{
+  t: (k: string) => string;
+  showDisabled: boolean;
+  onToggleDisabled: (next: boolean) => void;
+}> = ({ t, showDisabled, onToggleDisabled }) => (
   <div className="flex flex-wrap items-center gap-x-4 gap-y-1.5 rounded-xl border border-border-strong bg-surface/90 px-3 py-2 text-[11px] text-muted backdrop-blur">
     <LegendItem label={t('agents.graph.legend.spawn')}>
       <span className="h-[2px] w-5" style={{ background: 'var(--mint)' }} />
@@ -393,6 +418,15 @@ const Legend: React.FC<{ t: (k: string) => string }> = ({ t }) => (
     </LegendItem>
     {/* A8: callback edges are no longer drawn; the detail panel owns them. */}
     <span className="text-muted/70">{t('agents.graph.legend.callbackNote')}</span>
+    {/* A11: disabled trigger chips are hidden by default; this reveals them. */}
+    <span className="inline-flex items-center gap-1.5 border-l border-border-strong pl-3">
+      <Switch
+        checked={showDisabled}
+        onCheckedChange={onToggleDisabled}
+        label={t('agents.graph.legend.showDisabled')}
+      />
+      {t('agents.graph.legend.showDisabled')}
+    </span>
   </div>
 );
 

--- a/ui/src/components/workbench/AgentGraphMobileList.tsx
+++ b/ui/src/components/workbench/AgentGraphMobileList.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { CalendarClock, CornerDownRight, Eye } from 'lucide-react';
+import clsx from 'clsx';
 
 import {
   type AgentGraphEdge,
@@ -16,17 +17,23 @@ interface AgentGraphMobileListProps {
   triggerNodes: AgentGraphTriggerNode[];
   selectedId: string | null;
   onSelectNode: (sessionId: string) => void;
+  // Tapping a trigger pill opens the same right-side detail panel a node does
+  // (A11) — no canvas on mobile, but the chip is still an equal citizen.
+  onSelectTrigger: (definitionId: string) => void;
 }
 
 // Mobile fallback: the same graph payload rendered as a spawn-tree indented
 // list (no canvas). Depth comes from the spawn forest; a triggered lineage root
-// shows its Task/Watch source as a small chip above the card.
+// shows its Task/Watch source as a small chip above the card. Disabled triggers
+// are already filtered out of `triggerNodes` upstream (A11), so no pill for them
+// unless the shared "show disabled" preference is on.
 export const AgentGraphMobileList: React.FC<AgentGraphMobileListProps> = ({
   nodes,
   edges,
   triggerNodes,
   selectedId,
   onSelectNode,
+  onSelectTrigger,
 }) => {
   const { t } = useTranslation();
   const rows = useMemo(() => buildGraphForest(nodes, edges, triggerNodes), [nodes, edges, triggerNodes]);
@@ -45,15 +52,19 @@ export const AgentGraphMobileList: React.FC<AgentGraphMobileListProps> = ({
             </span>
           )}
           {trigger && (
-            <span
-              className={`inline-flex w-fit items-center gap-1 rounded-md border border-violet/40 bg-violet-soft px-1.5 py-0.5 text-[10px] font-medium text-violet${
-                trigger.enabled ? '' : ' opacity-60'
-              }`}
+            <button
+              type="button"
+              onClick={() => onSelectTrigger(trigger.definition_id)}
+              title={trigger.name ?? trigger.definition_id}
+              className={clsx(
+                'inline-flex w-fit items-center gap-1 rounded-md border border-violet/40 bg-violet-soft px-1.5 py-0.5 text-[10px] font-medium text-violet transition hover:brightness-110',
+                !trigger.enabled && 'opacity-60',
+              )}
             >
               {trigger.definition_type === 'watch' ? <Eye className="size-2.5" /> : <CalendarClock className="size-2.5" />}
               {trigger.name ?? trigger.definition_id}
               {!trigger.enabled && <span className="text-muted"> · {t('agents.graph.trigger.disabled')}</span>}
-            </span>
+            </button>
           )}
           <div className="h-[92px]">
             <AgentGraphNodeCard

--- a/ui/src/components/workbench/AgentGraphTab.tsx
+++ b/ui/src/components/workbench/AgentGraphTab.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import { AlertTriangle, ChevronDown, Clock, FolderClosed, Loader2, RefreshCw, ServerCrash } from 'lucide-react';
@@ -17,6 +17,7 @@ import {
   type AgentGraphTriggerNode,
   type GraphWindow,
   GRAPH_WINDOWS,
+  computeFillHeight,
   filterDisabledTriggers,
   isBackground,
   triggerRefId,
@@ -52,12 +53,68 @@ function useIsDesktop(): boolean {
   return !!desktop;
 }
 
+// Desktop-only fill height for the canvas + detail panel (design.pen KfgtJ —
+// fill_container). The desktop app shell is document-flow (no bounded-height
+// ancestor to inherit `h-full` from), so we size the graph area to the viewport
+// below its own measured top rather than a fixed calc: wrapped filters / warning
+// strips shrink it correctly, and a window resize re-fits it. Floored at
+// GRAPH_MIN_HEIGHT so a short window scrolls instead of crushing the canvas. This
+// number is a viewport size only — it never feeds the dagre layout — so a resize
+// reflows the view without moving a node (mirrors the M3 hover principle).
+const GRAPH_FILL_BOTTOM_GAP = 24; // gap between canvas bottom and viewport bottom
+const GRAPH_MIN_HEIGHT = 480; // owner floor — below this the page scrolls
+const GRAPH_FILL_TOP_ESTIMATE = 280; // first-frame seed only; useLayoutEffect corrects it
+
+function useGraphFillHeight(enabled: boolean): [(el: HTMLDivElement | null) => void, number | undefined] {
+  // The grid element mounts only once the graph is loaded, so track it as state:
+  // the layout effect re-runs (and measures) exactly when it appears/disappears.
+  const [gridEl, setGridEl] = useState<HTMLDivElement | null>(null);
+  const gridRef = useCallback((el: HTMLDivElement | null) => setGridEl(el), []);
+  const [height, setHeight] = useState<number | undefined>(() =>
+    typeof window !== 'undefined'
+      ? computeFillHeight(window.innerHeight, GRAPH_FILL_TOP_ESTIMATE, GRAPH_FILL_BOTTOM_GAP, GRAPH_MIN_HEIGHT)
+      : undefined,
+  );
+  useLayoutEffect(() => {
+    if (!enabled || !gridEl || typeof window === 'undefined') return;
+    let raf = 0;
+    const measure = () => {
+      const top = gridEl.getBoundingClientRect().top;
+      const next = computeFillHeight(window.innerHeight, top, GRAPH_FILL_BOTTOM_GAP, GRAPH_MIN_HEIGHT);
+      setHeight((prev) => (prev === next ? prev : next)); // idempotent ⇒ converges
+    };
+    // rAF-defer so the ResizeObserver never setState's inside its own delivery
+    // (avoids the "loop completed with undelivered notifications" warning); the
+    // measure is idempotent so it settles to a fixed point in a frame or two.
+    const schedule = () => {
+      cancelAnimationFrame(raf);
+      raf = requestAnimationFrame(measure);
+    };
+    measure(); // synchronous first pass, before paint
+    window.addEventListener('resize', schedule);
+    // Content above the graph (orphan strip, warning banners, a wrapped filter
+    // row) shifts our top offset without a window resize — observing the body
+    // catches those reflows.
+    const ro = new ResizeObserver(schedule);
+    ro.observe(document.body);
+    return () => {
+      cancelAnimationFrame(raf);
+      window.removeEventListener('resize', schedule);
+      ro.disconnect();
+    };
+  }, [enabled, gridEl]);
+  return [gridRef, enabled ? height : undefined];
+}
+
 export const AgentGraphTab: React.FC = () => {
   const { t } = useTranslation();
   const api = useApi();
   const { showToast } = useToast();
   const navigate = useNavigate();
   const isDesktop = useIsDesktop();
+  // Desktop canvas + detail panel fill the viewport below their own top; the ref
+  // goes on the graph-area grid so the measurement tracks it (mobile ⇒ undefined).
+  const [graphAreaRef, fillHeight] = useGraphFillHeight(isDesktop);
 
   const [graph, setGraph] = useState<GraphPayload | null>(null);
   // Session-less orphan processes (contract A3) — surfaced in a strip above the
@@ -332,6 +389,15 @@ export const AgentGraphTab: React.FC = () => {
   const selectedNode = selectedNodeId ? nodesById.get(selectedNodeId) ?? null : null;
   const selectedTrigger = selectedTriggerId ? triggersById.get(selectedTriggerId) ?? null : null;
   const detailOpen = !!selectedNode || !!selectedTrigger;
+
+  // The detail panel matches the canvas height on desktop (design.pen KfgtJ) so
+  // the two columns read as one pane; its body scrolls when the content is taller
+  // than the fill. On mobile (fillHeight === undefined) it stays natural-height.
+  const panelBoxClass = clsx(
+    'rounded-2xl border border-border-strong bg-surface p-5',
+    fillHeight != null ? 'overflow-y-auto' : 'self-start',
+  );
+  const panelBoxStyle = fillHeight != null ? { height: fillHeight } : undefined;
 
   // Lazy-load the broad search index for the current window/project. Skipped
   // when a fresh copy for this key is already cached; a stale flag (set by any
@@ -620,6 +686,7 @@ export const AgentGraphTab: React.FC = () => {
         </div>
       ) : (
         <div
+          ref={graphAreaRef}
           className={clsx(
             'grid gap-4',
             detailOpen ? 'grid-cols-1 lg:grid-cols-[minmax(0,1fr)_360px]' : 'grid-cols-1',
@@ -639,10 +706,14 @@ export const AgentGraphTab: React.FC = () => {
                 selectedTriggerId={selectedTriggerId}
                 showDisabled={showDisabled}
                 onToggleDisabled={setShowDisabledPersisted}
+                heightPx={fillHeight}
                 // Refit the viewport when the filters change the layout (small→
-                // large graph, different project/window); SSE-only refreshes keep
-                // the same key and preserve the current pan/zoom.
-                fitKey={`${windowSel}|${projectSel}|${mode}|${showBackground}`}
+                // large graph, different project/window, or revealing disabled
+                // chips); SSE-only refreshes keep the same key and preserve the
+                // current pan/zoom. A search-locate that flips showDisabled still
+                // wins — it re-pins fittedRef and its setCenter runs after this
+                // refit in the same frame.
+                fitKey={`${windowSel}|${projectSel}|${mode}|${showBackground}|${showDisabled}`}
                 locate={locate}
                 onSelectNode={selectNode}
                 onSelectTrigger={selectTrigger}
@@ -664,7 +735,7 @@ export const AgentGraphTab: React.FC = () => {
               trigger chip (A11). Both read lineage from the raw edges/maps so a
               hidden-by-toggle relation still shows truthfully. */}
           {selectedNode ? (
-            <div className="self-start rounded-2xl border border-border-strong bg-surface p-5">
+            <div className={panelBoxClass} style={panelBoxStyle}>
               <AgentGraphDetail
                 node={selectedNode}
                 nodesById={nodesById}
@@ -676,7 +747,7 @@ export const AgentGraphTab: React.FC = () => {
               />
             </div>
           ) : selectedTrigger ? (
-            <div className="self-start rounded-2xl border border-border-strong bg-surface p-5">
+            <div className={panelBoxClass} style={panelBoxStyle}>
               <AgentGraphTriggerDetail
                 trigger={selectedTrigger}
                 edges={edges}

--- a/ui/src/components/workbench/AgentGraphTab.tsx
+++ b/ui/src/components/workbench/AgentGraphTab.tsx
@@ -17,13 +17,16 @@ import {
   type AgentGraphTriggerNode,
   type GraphWindow,
   GRAPH_WINDOWS,
+  filterDisabledTriggers,
   isBackground,
   triggerRefId,
 } from '../../lib/agentGraph';
 import { searchGraph, type GraphSearchResult } from '../../lib/graphSearch';
+import { readGraphShowDisabled, writeGraphShowDisabled } from '../../lib/graphViewPrefs';
 import { AgentGraphCanvas } from './AgentGraphCanvas';
 import { AgentGraphMobileList } from './AgentGraphMobileList';
 import { AgentGraphDetail } from './AgentGraphDetail';
+import { AgentGraphTriggerDetail } from './AgentGraphTriggerDetail';
 import { AgentGraphOrphanStrip } from './AgentGraphOrphanStrip';
 import { AgentGraphSearch } from './AgentGraphSearch';
 
@@ -72,7 +75,26 @@ export const AgentGraphTab: React.FC = () => {
   const [projectSel, setProjectSel] = useState<string>('all');
   const [showBackground, setShowBackground] = useState(true);
 
+  // Selection is mutually exclusive: a session node OR a trigger chip, never
+  // both (A11 — a chip opens the same right-side panel a node does).
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
+  const [selectedTriggerId, setSelectedTriggerId] = useState<string | null>(null);
+  const selectNode = useCallback((id: string) => {
+    setSelectedNodeId(id);
+    setSelectedTriggerId(null);
+  }, []);
+  const selectTrigger = useCallback((id: string) => {
+    setSelectedTriggerId(id);
+    setSelectedNodeId(null);
+  }, []);
+
+  // A11: disabled trigger chips (+ their trigger edges) are hidden by default;
+  // the canvas legend switch reveals them and the choice is remembered locally.
+  const [showDisabled, setShowDisabled] = useState(readGraphShowDisabled);
+  const setShowDisabledPersisted = useCallback((next: boolean) => {
+    setShowDisabled(next);
+    writeGraphShowDisabled(next);
+  }, []);
 
   // ── Node search (M8) ──────────────────────────────────────────────────────
   // The display graph is server-filtered, so search runs over a separate broad
@@ -277,27 +299,39 @@ export const AgentGraphTab: React.FC = () => {
   const edges = useMemo(() => graph?.edges ?? [], [graph]);
 
   const nodesById = useMemo(() => new Map(nodes.map((n) => [n.session_id, n])), [nodes]);
+  // Raw (unfiltered) trigger map — the detail panels read lineage from this so a
+  // node's trigger still shows even when the chip is hidden by the legend toggle.
   const triggersById = useMemo(
     () => new Map(triggerNodes.map((tr) => [tr.definition_id, tr])),
     [triggerNodes],
   );
 
-  // Drop a stale selection once its node leaves the payload.
+  // A11 display filter: drop disabled chips + their trigger edges (unless the
+  // legend switch is on) before they reach the canvas/mobile list. Returned by
+  // reference when nothing is filtered, so the layout stays stable otherwise.
+  const { triggerNodes: displayTriggers, edges: displayEdges } = useMemo(
+    () => filterDisabledTriggers(triggerNodes, edges, showDisabled),
+    [triggerNodes, edges, showDisabled],
+  );
+  // The set of chips actually rendered — search membership ("outside filters")
+  // and reveal-on-select are judged against this, not the raw trigger map.
+  const displayTriggerIds = useMemo(
+    () => new Set(displayTriggers.map((tr) => tr.definition_id)),
+    [displayTriggers],
+  );
+
+  // Drop a stale selection once its node/chip leaves the payload. A selected chip
+  // survives a legend toggle (it's still in the raw payload) but not aging out.
   useEffect(() => {
     if (selectedNodeId && !nodesById.has(selectedNodeId)) setSelectedNodeId(null);
   }, [selectedNodeId, nodesById]);
+  useEffect(() => {
+    if (selectedTriggerId && !triggersById.has(selectedTriggerId)) setSelectedTriggerId(null);
+  }, [selectedTriggerId, triggersById]);
 
   const selectedNode = selectedNodeId ? nodesById.get(selectedNodeId) ?? null : null;
-
-  const onSelectTrigger = useCallback(
-    (definitionId: string) => {
-      const tab = triggersById.get(definitionId)?.definition_type === 'watch' ? 'watches' : 'tasks';
-      // Land on the matching Harness definitions tab (deep-select by id is a
-      // follow-up once Harness supports a ?task/?watch URL anchor).
-      navigate(`/harness?tab=${tab}`);
-    },
-    [navigate, triggersById],
-  );
+  const selectedTrigger = selectedTriggerId ? triggersById.get(selectedTriggerId) ?? null : null;
+  const detailOpen = !!selectedNode || !!selectedTrigger;
 
   // Lazy-load the broad search index for the current window/project. Skipped
   // when a fresh copy for this key is already cached; a stale flag (set by any
@@ -331,17 +365,18 @@ export const AgentGraphTab: React.FC = () => {
     // project/window). Show nothing until the fresh index arrives.
     const key = `${windowSel}|${projectSel}`;
     if (!searchIndex || searchIndex.key !== key) return [];
-    const all = searchGraph(searchQuery, searchIndex.nodes, searchIndex.triggers);
-    // Mobile renders the grouped list, not the canvas, and triggers have no
-    // detail panel — a trigger hit there would be a dead tap, so show nodes
-    // only (they still open the detail panel).
-    return isDesktop ? all : all.filter((r) => r.kind === 'node');
-  }, [searchQuery, searchIndex, windowSel, projectSel, isDesktop]);
+    // Both node and trigger hits are actionable on desktop AND mobile now: a
+    // trigger opens the same right-side detail panel (A11), so no kind is dropped.
+    return searchGraph(searchQuery, searchIndex.nodes, searchIndex.triggers);
+  }, [searchQuery, searchIndex, windowSel, projectSel]);
 
-  // A hit is "outside current filters" when it isn't in the visible payload.
+  // A hit is "outside current filters" when it isn't currently rendered. For a
+  // trigger that means either aged out of the window or hidden by the disabled
+  // toggle — both judged against the rendered chip set, so a disabled chip badges
+  // "outside filters" while the toggle is off and reveals itself on select.
   const isOutsideFilters = useCallback(
-    (r: GraphSearchResult) => (r.kind === 'node' ? !nodesById.has(r.id) : !triggersById.has(r.id)),
-    [nodesById, triggersById],
+    (r: GraphSearchResult) => (r.kind === 'node' ? !nodesById.has(r.id) : !displayTriggerIds.has(r.id)),
+    [nodesById, displayTriggerIds],
   );
 
   const requestLocate = useCallback((kind: 'node' | 'trigger', rfId: string) => {
@@ -354,14 +389,34 @@ export const AgentGraphTab: React.FC = () => {
   const onSelectResult = useCallback(
     (r: GraphSearchResult) => {
       const rfId = r.kind === 'node' ? r.id : triggerRefId(r.id);
-      const inDisplay = r.kind === 'node' ? nodesById.has(r.id) : triggersById.has(r.id);
-      if (inDisplay) {
-        if (r.kind === 'node') setSelectedNodeId(r.id);
-        requestLocate(r.kind, rfId);
-        return;
+      if (r.kind === 'node') {
+        // Already rendered → select + locate now.
+        if (nodesById.has(r.id)) {
+          selectNode(r.id);
+          requestLocate('node', rfId);
+          return;
+        }
+      } else {
+        // A rendered chip → select + locate now.
+        if (displayTriggerIds.has(r.id)) {
+          selectTrigger(r.id);
+          requestLocate('trigger', rfId);
+          return;
+        }
+        // In the payload but hidden by the "show disabled" toggle: M8's
+        // reveal-on-click — flip the legend switch, select, and locate. A pure
+        // client filter flip (no refetch); the canvas re-renders with the chip
+        // and the nonce'd locate resolves once it's laid out.
+        if (triggersById.has(r.id)) {
+          setShowDisabledPersisted(true);
+          selectTrigger(r.id);
+          requestLocate('trigger', rfId);
+          return;
+        }
       }
-      // Index & display share window/project, so a hit is hidden only by the
-      // active/background toggles — widen exactly what's needed.
+      // Outside the payload entirely: widen the server filters (index & display
+      // share window/project, so only active/background differ) and defer the
+      // locate to the pendingLocate effect once the refetch surfaces it.
       let flipped = false;
       if (r.kind === 'node') {
         if (isBackground(r.node) && !showBackground) {
@@ -384,14 +439,33 @@ export const AgentGraphTab: React.FC = () => {
           setMode('history');
           flipped = true;
         }
+        // A disabled chip stays filtered out even after it returns unless the
+        // legend toggle is on — reveal it too. This is a client-only filter
+        // (never triggers a refetch), so it must NOT count toward `flipped`.
+        if (!r.trigger.enabled && !showDisabled) {
+          setShowDisabledPersisted(true);
+        }
       }
       setPendingLocate({ kind: r.kind, id: r.id, rfId, graphAtRequest: graph });
-      // Already at the widest filters but still absent ⇒ the index is stale and
-      // the row aged out; force a refetch so the pendingLocate effect confirms
-      // (graph identity changes) and toasts rather than hanging.
+      // No server filter changed ⇒ no automatic refetch is coming; force one so
+      // the pendingLocate effect either surfaces the target or (graph identity
+      // changed, still absent) toasts rather than hanging.
       if (!flipped) void fetchGraph(false);
     },
-    [nodesById, triggersById, showBackground, mode, requestLocate, fetchGraph, graph],
+    [
+      nodesById,
+      triggersById,
+      displayTriggerIds,
+      showBackground,
+      mode,
+      showDisabled,
+      selectNode,
+      selectTrigger,
+      setShowDisabledPersisted,
+      requestLocate,
+      fetchGraph,
+      graph,
+    ],
   );
 
   // Resolve a deferred locate: fire once the widened payload includes the
@@ -400,19 +474,23 @@ export const AgentGraphTab: React.FC = () => {
   // tell the user, don't hang.
   useEffect(() => {
     if (!pendingLocate) return;
+    // A trigger must be in the *rendered* set (not just the raw payload) to be
+    // located — the reveal flip in onSelectResult guarantees a disabled chip is
+    // rendered by the time its refetch lands.
     const present =
       pendingLocate.kind === 'node'
         ? nodesById.has(pendingLocate.id)
-        : triggersById.has(pendingLocate.id);
+        : displayTriggerIds.has(pendingLocate.id);
     if (present) {
-      if (pendingLocate.kind === 'node') setSelectedNodeId(pendingLocate.id);
+      if (pendingLocate.kind === 'node') selectNode(pendingLocate.id);
+      else selectTrigger(pendingLocate.id);
       requestLocate(pendingLocate.kind, pendingLocate.rfId);
       setPendingLocate(null);
     } else if (graph !== pendingLocate.graphAtRequest) {
       showToast(t('agents.graph.search.noLongerInWindow'), 'warning');
       setPendingLocate(null);
     }
-  }, [pendingLocate, nodesById, triggersById, graph, requestLocate, showToast, t]);
+  }, [pendingLocate, nodesById, displayTriggerIds, graph, selectNode, selectTrigger, requestLocate, showToast, t]);
 
   const projectLabel = useMemo(() => {
     if (projectSel === 'all') return t('agents.graph.filters.projectAll');
@@ -544,10 +622,10 @@ export const AgentGraphTab: React.FC = () => {
         <div
           className={clsx(
             'grid gap-4',
-            selectedNode ? 'grid-cols-1 lg:grid-cols-[minmax(0,1fr)_360px]' : 'grid-cols-1',
+            detailOpen ? 'grid-cols-1 lg:grid-cols-[minmax(0,1fr)_360px]' : 'grid-cols-1',
           )}
         >
-          <div className={clsx('min-w-0', selectedNode && 'max-lg:hidden')}>
+          <div className={clsx('min-w-0', detailOpen && 'max-lg:hidden')}>
             {nodes.length === 0 ? (
               <div className="rounded-xl border border-dashed border-border bg-surface px-6 py-12 text-center text-[13px] text-muted">
                 {t('agents.graph.empty')}
@@ -555,30 +633,37 @@ export const AgentGraphTab: React.FC = () => {
             ) : isDesktop ? (
               <AgentGraphCanvas
                 nodes={nodes}
-                triggerNodes={triggerNodes}
-                edges={edges}
+                triggerNodes={displayTriggers}
+                edges={displayEdges}
                 selectedId={selectedNodeId}
+                selectedTriggerId={selectedTriggerId}
+                showDisabled={showDisabled}
+                onToggleDisabled={setShowDisabledPersisted}
                 // Refit the viewport when the filters change the layout (small→
                 // large graph, different project/window); SSE-only refreshes keep
                 // the same key and preserve the current pan/zoom.
                 fitKey={`${windowSel}|${projectSel}|${mode}|${showBackground}`}
                 locate={locate}
-                onSelectNode={setSelectedNodeId}
-                onSelectTrigger={onSelectTrigger}
+                onSelectNode={selectNode}
+                onSelectTrigger={selectTrigger}
                 onOpenChat={(id) => navigate(`/chat/${encodeURIComponent(id)}`)}
               />
             ) : (
               <AgentGraphMobileList
                 nodes={nodes}
-                edges={edges}
-                triggerNodes={triggerNodes}
+                edges={displayEdges}
+                triggerNodes={displayTriggers}
                 selectedId={selectedNodeId}
-                onSelectNode={setSelectedNodeId}
+                onSelectNode={selectNode}
+                onSelectTrigger={selectTrigger}
               />
             )}
           </div>
 
-          {selectedNode && (
+          {/* One right-side panel, mutually exclusive: a session node or a
+              trigger chip (A11). Both read lineage from the raw edges/maps so a
+              hidden-by-toggle relation still shows truthfully. */}
+          {selectedNode ? (
             <div className="self-start rounded-2xl border border-border-strong bg-surface p-5">
               <AgentGraphDetail
                 node={selectedNode}
@@ -586,11 +671,22 @@ export const AgentGraphTab: React.FC = () => {
                 edges={edges}
                 triggersById={triggersById}
                 onClose={() => setSelectedNodeId(null)}
-                onSelectNode={setSelectedNodeId}
+                onSelectNode={selectNode}
                 onRefresh={() => fetchGraph(true)}
               />
             </div>
-          )}
+          ) : selectedTrigger ? (
+            <div className="self-start rounded-2xl border border-border-strong bg-surface p-5">
+              <AgentGraphTriggerDetail
+                trigger={selectedTrigger}
+                edges={edges}
+                nodesById={nodesById}
+                onClose={() => setSelectedTriggerId(null)}
+                onSelectNode={selectNode}
+                onRefresh={() => fetchGraph(true)}
+              />
+            </div>
+          ) : null}
         </div>
       )}
     </div>

--- a/ui/src/components/workbench/AgentGraphTab.tsx
+++ b/ui/src/components/workbench/AgentGraphTab.tsx
@@ -648,6 +648,14 @@ export const AgentGraphTab: React.FC = () => {
           {t('agents.graph.filters.showBackground')}
           <Switch checked={showBackground} onCheckedChange={setShowBackground} label={t('agents.graph.filters.showBackground')} />
         </label>
+        {/* Mobile has no canvas legend, so surface the disabled-trigger toggle here;
+            otherwise a search-reveal (which forces showDisabled=true) can never be undone on mobile. */}
+        {!isDesktop && (
+          <label className="inline-flex items-center gap-2 text-[12px] text-muted">
+            {t('agents.graph.legend.showDisabled')}
+            <Switch checked={showDisabled} onCheckedChange={setShowDisabledPersisted} label={t('agents.graph.legend.showDisabled')} />
+          </label>
+        )}
         <Button type="button" variant="outline" size="xs" onClick={() => fetchGraph(false)} disabled={loading}>
           <RefreshCw className={clsx('size-3.5', loading && 'animate-spin')} />
           {t('common.refresh')}

--- a/ui/src/components/workbench/AgentGraphTab.tsx
+++ b/ui/src/components/workbench/AgentGraphTab.tsx
@@ -148,9 +148,18 @@ export const AgentGraphTab: React.FC = () => {
   // A11: disabled trigger chips (+ their trigger edges) are hidden by default;
   // the canvas legend switch reveals them and the choice is remembered locally.
   const [showDisabled, setShowDisabled] = useState(readGraphShowDisabled);
+  // A search-hit reveal of a hidden disabled chip is TRANSIENT — it must not
+  // write the persisted preference (owner ruling): only an explicit legend /
+  // mobile toggle persists. This session-only flag OR's into the effective
+  // visibility so a searched-for chip renders without changing what the user
+  // sees on the next load.
+  const [revealDisabled, setRevealDisabled] = useState(false);
+  const effectiveShowDisabled = showDisabled || revealDisabled;
   const setShowDisabledPersisted = useCallback((next: boolean) => {
     setShowDisabled(next);
     writeGraphShowDisabled(next);
+    // An explicit hide also clears any transient reveal, so "off" always hides.
+    if (!next) setRevealDisabled(false);
   }, []);
 
   // ── Node search (M8) ──────────────────────────────────────────────────────
@@ -364,11 +373,12 @@ export const AgentGraphTab: React.FC = () => {
   );
 
   // A11 display filter: drop disabled chips + their trigger edges (unless the
-  // legend switch is on) before they reach the canvas/mobile list. Returned by
-  // reference when nothing is filtered, so the layout stays stable otherwise.
+  // legend switch is on OR a search reveal is active) before they reach the
+  // canvas/mobile list. Returned by reference when nothing is filtered, so the
+  // layout stays stable otherwise.
   const { triggerNodes: displayTriggers, edges: displayEdges } = useMemo(
-    () => filterDisabledTriggers(triggerNodes, edges, showDisabled),
-    [triggerNodes, edges, showDisabled],
+    () => filterDisabledTriggers(triggerNodes, edges, effectiveShowDisabled),
+    [triggerNodes, edges, effectiveShowDisabled],
   );
   // The set of chips actually rendered — search membership ("outside filters")
   // and reveal-on-select are judged against this, not the raw trigger map.
@@ -470,11 +480,11 @@ export const AgentGraphTab: React.FC = () => {
           return;
         }
         // In the payload but hidden by the "show disabled" toggle: M8's
-        // reveal-on-click — flip the legend switch, select, and locate. A pure
-        // client filter flip (no refetch); the canvas re-renders with the chip
-        // and the nonce'd locate resolves once it's laid out.
+        // reveal-on-click — reveal TRANSIENTLY (session-only, no persisted pref),
+        // select, and locate. A pure client filter flip (no refetch); the canvas
+        // re-renders with the chip and the nonce'd locate resolves once it's out.
         if (triggersById.has(r.id)) {
-          setShowDisabledPersisted(true);
+          setRevealDisabled(true);
           selectTrigger(r.id);
           requestLocate('trigger', rfId);
           return;
@@ -505,11 +515,12 @@ export const AgentGraphTab: React.FC = () => {
           setMode('history');
           flipped = true;
         }
-        // A disabled chip stays filtered out even after it returns unless the
-        // legend toggle is on — reveal it too. This is a client-only filter
-        // (never triggers a refetch), so it must NOT count toward `flipped`.
-        if (!r.trigger.enabled && !showDisabled) {
-          setShowDisabledPersisted(true);
+        // A disabled chip stays filtered out even after it returns unless
+        // disabled chips are shown — reveal it TRANSIENTLY (session-only, no
+        // persisted pref). This is a client-only filter (never triggers a
+        // refetch), so it must NOT count toward `flipped`.
+        if (!r.trigger.enabled && !effectiveShowDisabled) {
+          setRevealDisabled(true);
         }
       }
       setPendingLocate({ kind: r.kind, id: r.id, rfId, graphAtRequest: graph });
@@ -524,10 +535,10 @@ export const AgentGraphTab: React.FC = () => {
       displayTriggerIds,
       showBackground,
       mode,
-      showDisabled,
+      effectiveShowDisabled,
       selectNode,
       selectTrigger,
-      setShowDisabledPersisted,
+      setRevealDisabled,
       requestLocate,
       fetchGraph,
       graph,
@@ -649,11 +660,13 @@ export const AgentGraphTab: React.FC = () => {
           <Switch checked={showBackground} onCheckedChange={setShowBackground} label={t('agents.graph.filters.showBackground')} />
         </label>
         {/* Mobile has no canvas legend, so surface the disabled-trigger toggle here;
-            otherwise a search-reveal (which forces showDisabled=true) can never be undone on mobile. */}
+            otherwise a transient search-reveal can never be turned off on mobile. This
+            switch persists the preference; its checked state tracks the effective value
+            so a transient reveal shows as on and can be toggled back off. */}
         {!isDesktop && (
           <label className="inline-flex items-center gap-2 text-[12px] text-muted">
             {t('agents.graph.legend.showDisabled')}
-            <Switch checked={showDisabled} onCheckedChange={setShowDisabledPersisted} label={t('agents.graph.legend.showDisabled')} />
+            <Switch checked={effectiveShowDisabled} onCheckedChange={setShowDisabledPersisted} label={t('agents.graph.legend.showDisabled')} />
           </label>
         )}
         <Button type="button" variant="outline" size="xs" onClick={() => fetchGraph(false)} disabled={loading}>
@@ -712,16 +725,16 @@ export const AgentGraphTab: React.FC = () => {
                 edges={displayEdges}
                 selectedId={selectedNodeId}
                 selectedTriggerId={selectedTriggerId}
-                showDisabled={showDisabled}
+                showDisabled={effectiveShowDisabled}
                 onToggleDisabled={setShowDisabledPersisted}
                 heightPx={fillHeight}
                 // Refit the viewport when the filters change the layout (small→
                 // large graph, different project/window, or revealing disabled
                 // chips); SSE-only refreshes keep the same key and preserve the
-                // current pan/zoom. A search-locate that flips showDisabled still
-                // wins — it re-pins fittedRef and its setCenter runs after this
-                // refit in the same frame.
-                fitKey={`${windowSel}|${projectSel}|${mode}|${showBackground}|${showDisabled}`}
+                // current pan/zoom. A search-locate that reveals disabled chips
+                // still wins — it re-pins fittedRef and its setCenter runs after
+                // this refit in the same frame.
+                fitKey={`${windowSel}|${projectSel}|${mode}|${showBackground}|${effectiveShowDisabled}`}
                 locate={locate}
                 onSelectNode={selectNode}
                 onSelectTrigger={selectTrigger}

--- a/ui/src/components/workbench/AgentGraphTriggerChip.tsx
+++ b/ui/src/components/workbench/AgentGraphTriggerChip.tsx
@@ -7,16 +7,20 @@ import type { AgentGraphTriggerNode } from '../../lib/agentGraph';
 interface AgentGraphTriggerChipProps {
   trigger: AgentGraphTriggerNode;
   faded?: boolean;
+  selected?: boolean;
   onClick?: () => void;
   className?: string;
 }
 
 // Task/Watch trigger source — a violet chip that sits left of the session it
-// fires (spec frame anu5U). Click jumps to the matching Harness definitions
-// tab. Fills its parent so the canvas box + dagre layout stay in lockstep.
+// fires (spec frame anu5U). Click selects it and opens the in-graph trigger
+// detail panel (A11), same interaction as a session node — the old jump to
+// Harness survives as a secondary link inside that panel. Fills its parent so
+// the canvas box + dagre layout stay in lockstep.
 export const AgentGraphTriggerChip: React.FC<AgentGraphTriggerChipProps> = ({
   trigger,
   faded = false,
+  selected = false,
   onClick,
   className,
 }) => {
@@ -37,7 +41,9 @@ export const AgentGraphTriggerChip: React.FC<AgentGraphTriggerChipProps> = ({
       onClick={onClick}
       title={name}
       className={clsx(
-        'flex h-full w-full items-center gap-2 rounded-xl border border-violet/40 bg-violet-soft px-3 py-2 text-left transition hover:brightness-110',
+        'flex h-full w-full items-center gap-2 rounded-xl border bg-violet-soft px-3 py-2 text-left transition hover:brightness-110',
+        // Selected mirrors the session card's colored-border + glow (violet here).
+        selected ? 'border-violet shadow-[0_0_20px_-6px_rgba(124,91,255,0.6)]' : 'border-violet/40',
         faded ? 'opacity-25' : disabled && 'opacity-60',
         className,
       )}

--- a/ui/src/components/workbench/AgentGraphTriggerDetail.tsx
+++ b/ui/src/components/workbench/AgentGraphTriggerDetail.tsx
@@ -21,6 +21,17 @@ import {
   triggerFiredSessionIds,
 } from '../../lib/agentGraph';
 
+// While a trigger detail panel is open, re-fetch its definition on this cadence
+// so a watch's runtime (running/pid) tracks WatchSupervisor's async worker
+// start/stop even without a local toggle, and a transient list-fetch failure
+// recovers on its own. Matches the tab's degraded-mode poll.
+const TRIGGER_DETAIL_POLL_MS = 4000;
+
+// Definition load lifecycle: loading → ready (row found) | absent (fetch OK but
+// row gone) | error (fetch threw — transient, the poll retries). 'absent'
+// disables the switch; 'error' does not.
+type DefState = 'loading' | 'ready' | 'absent' | 'error';
+
 interface AgentGraphTriggerDetailProps {
   trigger: AgentGraphTriggerNode;
   // Raw graph edges (not the disabled-filtered set) so the fired-session list is
@@ -59,8 +70,7 @@ export const AgentGraphTriggerDetail: React.FC<AgentGraphTriggerDetailProps> = (
   // is the sanctioned source; we find the row by id. No new backend (A11).
   const [task, setTask] = useState<HarnessTask | null>(null);
   const [watch, setWatch] = useState<HarnessWatch | null>(null);
-  const [defLoading, setDefLoading] = useState(true);
-  const [defMissing, setDefMissing] = useState(false);
+  const [defState, setDefState] = useState<DefState>('loading');
   const [runs, setRuns] = useState<HarnessRun[]>([]);
   // Enabled is optimistic-local so the switch reacts instantly; seeded from the
   // chip, then reconciled to the fetched definition / PATCH response.
@@ -70,63 +80,81 @@ export const AgentGraphTriggerDetail: React.FC<AgentGraphTriggerDetailProps> = (
   const definitionId = trigger.definition_id;
   const chipEnabled = trigger.enabled;
   // The definition this panel currently shows, mirrored into a ref so an async
-  // toggle can tell — after its await — whether the user has since selected a
-  // different chip. The panel instance is reused across selections, so a late
-  // PATCH resolution for a no-longer-active definition must not write state here.
+  // fetch/toggle can tell — after its await — whether the user has since selected
+  // a different chip. The panel instance is reused across selections, so a late
+  // resolution for a no-longer-active definition must not write state here.
   const activeDefIdRef = useRef(definitionId);
   activeDefIdRef.current = definitionId;
-  // Flips false on unmount so the bounded watch-runtime reconcile poll (which
-  // owns its own timers) never writes into a dead component.
-  const mountedRef = useRef(true);
-  useEffect(
-    () => () => {
-      mountedRef.current = false;
-    },
-    [],
-  );
-  // Bumped on every toggle so a still-running reconcile poll from a superseded
-  // toggle of the SAME definition (the switch re-enables once busy clears) can't
-  // write back a stale runtime.
-  const reconcileGenRef = useRef(0);
+  // Mirror `busy` into a ref so the freshness poll can skip a tick while a toggle
+  // is in flight without resubscribing the interval on every busy change.
+  const busyRef = useRef(busy);
+  busyRef.current = busy;
 
+  // Derived, so 'error' (transient) never disables the switch the way a genuine
+  // 'absent' does — a flaky list request must not leave a real trigger inert.
+  const defPending = defState === 'loading' || defState === 'error';
+  const defMissing = defState === 'absent';
+
+  // Load the definition on selection, then keep it fresh while the panel stays
+  // open. There is no single-item GET, so the full list endpoint is the source
+  // (no new backend). One steady path serves three needs:
+  //  • first load of name/schedule/command + enabled state;
+  //  • a watch's runtime (running/pid) tracks WatchSupervisor's async worker
+  //    start/stop even when nothing is toggled locally;
+  //  • a transient list-fetch failure recovers on the next tick instead of
+  //    leaving the trigger permanently non-actionable.
+  // Ticks are skipped while a toggle is in flight so the poll can't clobber the
+  // optimistic switch or the PATCH's authoritative response.
   useEffect(() => {
-    let cancelled = false;
     setTask(null);
     setWatch(null);
-    setDefLoading(true);
-    setDefMissing(false);
+    setDefState('loading');
     setEnabled(chipEnabled);
-    // Selecting another chip must not inherit the previous definition's rows or
-    // an in-flight toggle's busy/optimistic state (that toggle's late resolution
-    // is separately dropped via activeDefIdRef).
+    // A new chip must not inherit the previous definition's rows or an in-flight
+    // toggle's busy/optimistic state (that toggle's late resolution is separately
+    // dropped via activeDefIdRef).
     setRuns([]);
     setBusy(false);
 
-    void (async () => {
+    let stopped = false;
+    const loadDefinition = async () => {
+      if (stopped || busyRef.current || activeDefIdRef.current !== definitionId) return;
       try {
         if (isWatch) {
           const res = await api.listHarnessWatches();
-          const found = res.watches.find((w) => w.id === definitionId) ?? null;
-          if (cancelled) return;
-          setWatch(found);
-          if (found) setEnabled(found.enabled);
-          else setDefMissing(true);
+          if (stopped || busyRef.current || activeDefIdRef.current !== definitionId) return;
+          const found = res.watches.find((w) => w.id === definitionId);
+          if (found) {
+            setWatch(found);
+            setEnabled(found.enabled);
+            setDefState('ready');
+          } else {
+            setDefState('absent');
+          }
         } else {
           const res = await api.listHarnessTasks();
-          const found = res.tasks.find((tk) => tk.id === definitionId) ?? null;
-          if (cancelled) return;
-          setTask(found);
-          if (found) setEnabled(found.enabled);
-          else setDefMissing(true);
+          if (stopped || busyRef.current || activeDefIdRef.current !== definitionId) return;
+          const found = res.tasks.find((tk) => tk.id === definitionId);
+          if (found) {
+            setTask(found);
+            setEnabled(found.enabled);
+            setDefState('ready');
+          } else {
+            setDefState('absent');
+          }
         }
       } catch {
-        if (!cancelled) setDefMissing(true);
-      } finally {
-        if (!cancelled) setDefLoading(false);
+        // Keep any last-known row; only flag a transient error when there is
+        // nothing to show yet. The next tick retries either way.
+        if (!stopped && activeDefIdRef.current === definitionId) {
+          setDefState((s) => (s === 'ready' ? s : 'error'));
+        }
       }
-    })();
+    };
+    void loadDefinition();
+    const timer = window.setInterval(loadDefinition, TRIGGER_DETAIL_POLL_MS);
 
-    // Recent trigger runs for this definition — independent of the def fetch.
+    // Recent trigger runs for this definition — one-shot per selection, not polled.
     let runsCancelled = false;
     api
       .listHarnessRuns({ definitionId, limit: 6 })
@@ -136,8 +164,9 @@ export const AgentGraphTriggerDetail: React.FC<AgentGraphTriggerDetailProps> = (
       .catch(() => {});
 
     return () => {
-      cancelled = true;
+      stopped = true;
       runsCancelled = true;
+      window.clearInterval(timer);
     };
   }, [api, definitionId, isWatch, chipEnabled]);
 
@@ -159,39 +188,12 @@ export const AgentGraphTriggerDetail: React.FC<AgentGraphTriggerDetailProps> = (
       : t('agents.graph.triggerDetail.running')
     : t('agents.graph.triggerDetail.notRunning');
 
-  // A watch's worker is started/stopped by WatchSupervisor on its own async
-  // reconcile loop, so the enable/disable PATCH returns the pre-toggle runtime
-  // snapshot. Re-poll the definition (widening the gap) until the runtime's
-  // running state matches the new enabled value — or the budget is spent — so
-  // the panel settles on the real "Running / Not running" instead of a stale
-  // one. Reuses the list endpoint (there is no single-item GET; no new backend).
-  const reconcileWatchRuntime = async (callId: string, expectRunning: boolean, gen: number) => {
-    const stale = () =>
-      !mountedRef.current || activeDefIdRef.current !== callId || reconcileGenRef.current !== gen;
-    for (const delay of [500, 900, 1400, 2000, 2800]) {
-      await new Promise((resolve) => window.setTimeout(resolve, delay));
-      if (stale()) return;
-      let found: HarnessWatch | undefined;
-      try {
-        const res = await api.listHarnessWatches();
-        found = res.watches.find((w) => w.id === callId);
-      } catch {
-        continue; // transient list error — keep chasing within the budget
-      }
-      if (stale() || !found) return;
-      setWatch(found);
-      setEnabled(found.enabled);
-      if (found.runtime.running === expectRunning) return;
-    }
-  };
-
   const toggleEnabled = async (next: boolean) => {
     // Pin the definition this toggle acts on; if the user switches chips before
     // the PATCH resolves, the panel-local writes below bail so a stale response
     // can't overwrite the now-foreign definition's state in this reused panel.
     const callId = definitionId;
     const stillActive = () => activeDefIdRef.current === callId;
-    const gen = (reconcileGenRef.current += 1);
     setBusy(true);
     const prev = enabled;
     setEnabled(next); // optimistic
@@ -220,8 +222,8 @@ export const AgentGraphTriggerDetail: React.FC<AgentGraphTriggerDetailProps> = (
           t(next ? 'agents.graph.triggerDetail.enabledToast' : 'agents.graph.triggerDetail.disabledToast'),
           'success',
         );
-        // Watch runtime (running/pid) settles asynchronously — chase it.
-        if (isWatch) void reconcileWatchRuntime(callId, next, gen);
+        // No bespoke runtime chase here: the open-panel poll picks up the watch's
+        // settled running/pid once WatchSupervisor's async worker start/stop lands.
       }
     } catch (err) {
       // Revert + notify only while still viewing this definition. An HTTP error
@@ -276,7 +278,7 @@ export const AgentGraphTriggerDetail: React.FC<AgentGraphTriggerDetailProps> = (
         {isWatch ? (
           <>
             <Fact label={t('agents.graph.triggerDetail.command')}>
-              <span className="break-all font-mono text-[11px]">{defLoading && !watch ? '…' : commandText}</span>
+              <span className="break-all font-mono text-[11px]">{defPending && !watch ? '…' : commandText}</span>
             </Fact>
             <Fact label={t('agents.graph.triggerDetail.runtime')}>
               <span className="inline-flex items-center gap-1.5">
@@ -286,7 +288,7 @@ export const AgentGraphTriggerDetail: React.FC<AgentGraphTriggerDetailProps> = (
                     watch?.runtime?.running ? 'bg-mint' : 'bg-muted',
                   )}
                 />
-                {defLoading && !watch ? '…' : runtimeText}
+                {defPending && !watch ? '…' : runtimeText}
               </span>
             </Fact>
           </>
@@ -297,7 +299,7 @@ export const AgentGraphTriggerDetail: React.FC<AgentGraphTriggerDetailProps> = (
             </Fact>
             <Fact label={t('agents.graph.triggerDetail.nextRun')}>
               <span className="font-mono text-[11px]">
-                {defLoading && !task ? '…' : task?.next_run_at ? formatLocalDateTime(task.next_run_at) : '—'}
+                {defPending && !task ? '…' : task?.next_run_at ? formatLocalDateTime(task.next_run_at) : '—'}
               </span>
             </Fact>
           </>

--- a/ui/src/components/workbench/AgentGraphTriggerDetail.tsx
+++ b/ui/src/components/workbench/AgentGraphTriggerDetail.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import { CalendarClock, ChevronRight, ExternalLink, Eye, Loader2, Power, X } from 'lucide-react';
@@ -69,6 +69,12 @@ export const AgentGraphTriggerDetail: React.FC<AgentGraphTriggerDetailProps> = (
 
   const definitionId = trigger.definition_id;
   const chipEnabled = trigger.enabled;
+  // The definition this panel currently shows, mirrored into a ref so an async
+  // toggle can tell — after its await — whether the user has since selected a
+  // different chip. The panel instance is reused across selections, so a late
+  // PATCH resolution for a no-longer-active definition must not write state here.
+  const activeDefIdRef = useRef(definitionId);
+  activeDefIdRef.current = definitionId;
 
   useEffect(() => {
     let cancelled = false;
@@ -77,6 +83,11 @@ export const AgentGraphTriggerDetail: React.FC<AgentGraphTriggerDetailProps> = (
     setDefLoading(true);
     setDefMissing(false);
     setEnabled(chipEnabled);
+    // Selecting another chip must not inherit the previous definition's rows or
+    // an in-flight toggle's busy/optimistic state (that toggle's late resolution
+    // is separately dropped via activeDefIdRef).
+    setRuns([]);
+    setBusy(false);
 
     void (async () => {
       try {
@@ -136,20 +147,26 @@ export const AgentGraphTriggerDetail: React.FC<AgentGraphTriggerDetailProps> = (
     : t('agents.graph.triggerDetail.notRunning');
 
   const toggleEnabled = async (next: boolean) => {
+    // Pin the definition this toggle acts on; if the user switches chips before
+    // the PATCH resolves, every branch below bails so a stale response can't
+    // write the now-foreign definition's state into this reused panel.
+    const callId = definitionId;
     setBusy(true);
     const prev = enabled;
     setEnabled(next); // optimistic
     try {
       if (isWatch) {
-        const res = await api.setHarnessWatchEnabled(definitionId, next);
-        if (!res.ok) throw new Error('failed');
+        const res = await api.setHarnessWatchEnabled(callId, next);
+        if (activeDefIdRef.current !== callId) return;
+        if (!res.ok) throw new Error('toggle rejected');
         if (res.watch) {
           setWatch(res.watch);
           setEnabled(res.watch.enabled);
         }
       } else {
-        const res = await api.setHarnessTaskEnabled(definitionId, next);
-        if (!res.ok) throw new Error('failed');
+        const res = await api.setHarnessTaskEnabled(callId, next);
+        if (activeDefIdRef.current !== callId) return;
+        if (!res.ok) throw new Error('toggle rejected');
         if (res.task) {
           setTask(res.task);
           setEnabled(res.task.enabled);
@@ -160,11 +177,16 @@ export const AgentGraphTriggerDetail: React.FC<AgentGraphTriggerDetailProps> = (
         'success',
       );
       onRefresh();
-    } catch (err) {
-      setEnabled(prev); // revert
-      showToast(err instanceof Error ? err.message : String(err), 'error');
+    } catch {
+      // Only revert + notify while still viewing this definition — a switch has
+      // already reset enabled/busy for the newly-selected one. The message is a
+      // localized fallback, never the raw thrown control-flow string.
+      if (activeDefIdRef.current === callId) {
+        setEnabled(prev);
+        showToast(t('agents.graph.triggerDetail.toggleFailed'), 'error');
+      }
     } finally {
-      setBusy(false);
+      if (activeDefIdRef.current === callId) setBusy(false);
     }
   };
 

--- a/ui/src/components/workbench/AgentGraphTriggerDetail.tsx
+++ b/ui/src/components/workbench/AgentGraphTriggerDetail.tsx
@@ -1,0 +1,336 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Link } from 'react-router-dom';
+import { CalendarClock, ChevronRight, ExternalLink, Eye, Loader2, Power, X } from 'lucide-react';
+import clsx from 'clsx';
+
+import { useApi } from '../../context/ApiContext';
+import type { HarnessRun, HarnessTask, HarnessWatch } from '../../context/ApiContext';
+import { useToast } from '../../context/ToastContext';
+import { Button } from '../ui/button';
+import { Switch } from '../ui/switch';
+import { formatLocalDateTime } from '../../lib/datetime';
+import { formatRelativeTime } from '../../lib/relativeTime';
+import {
+  type AgentGraphEdge,
+  type AgentGraphNode,
+  type AgentGraphStatus,
+  type AgentGraphTriggerNode,
+  nodeDisplayTitle,
+  statusMeta,
+  triggerFiredSessionIds,
+} from '../../lib/agentGraph';
+
+interface AgentGraphTriggerDetailProps {
+  trigger: AgentGraphTriggerNode;
+  // Raw graph edges (not the disabled-filtered set) so the fired-session list is
+  // complete even while the chip itself is hidden by the legend toggle.
+  edges: AgentGraphEdge[];
+  nodesById: Map<string, AgentGraphNode>;
+  onClose: () => void;
+  onSelectNode: (sessionId: string) => void;
+  // Refetch the graph after an enable/disable so the chip re-dims / re-hides.
+  onRefresh: () => void;
+}
+
+// A11: clicking a Task/Watch chip opens this in-graph panel (same interaction as
+// a session node) instead of navigating to Harness. It surfaces the definition's
+// schedule/next-run (task) or command/runtime (watch), the sessions it fired,
+// recent trigger runs, and an in-place enable/disable toggle — a watch's toggle
+// IS its pause/resume. Everything reuses the existing harness API client methods;
+// "Open in Harness" survives as a secondary exit.
+export const AgentGraphTriggerDetail: React.FC<AgentGraphTriggerDetailProps> = ({
+  trigger,
+  edges,
+  nodesById,
+  onClose,
+  onSelectNode,
+  onRefresh,
+}) => {
+  const { t } = useTranslation();
+  const api = useApi();
+  const { showToast } = useToast();
+
+  const isWatch = trigger.definition_type === 'watch';
+  const name = trigger.name?.trim() || trigger.definition_id;
+
+  // Full definition (for next-run / command / runtime). There is no single-item
+  // GET, so the unparameterized list endpoint — which returns the complete set —
+  // is the sanctioned source; we find the row by id. No new backend (A11).
+  const [task, setTask] = useState<HarnessTask | null>(null);
+  const [watch, setWatch] = useState<HarnessWatch | null>(null);
+  const [defLoading, setDefLoading] = useState(true);
+  const [defMissing, setDefMissing] = useState(false);
+  const [runs, setRuns] = useState<HarnessRun[]>([]);
+  // Enabled is optimistic-local so the switch reacts instantly; seeded from the
+  // chip, then reconciled to the fetched definition / PATCH response.
+  const [enabled, setEnabled] = useState(trigger.enabled);
+  const [busy, setBusy] = useState(false);
+
+  const definitionId = trigger.definition_id;
+  const chipEnabled = trigger.enabled;
+
+  useEffect(() => {
+    let cancelled = false;
+    setTask(null);
+    setWatch(null);
+    setDefLoading(true);
+    setDefMissing(false);
+    setEnabled(chipEnabled);
+
+    void (async () => {
+      try {
+        if (isWatch) {
+          const res = await api.listHarnessWatches();
+          const found = res.watches.find((w) => w.id === definitionId) ?? null;
+          if (cancelled) return;
+          setWatch(found);
+          if (found) setEnabled(found.enabled);
+          else setDefMissing(true);
+        } else {
+          const res = await api.listHarnessTasks();
+          const found = res.tasks.find((tk) => tk.id === definitionId) ?? null;
+          if (cancelled) return;
+          setTask(found);
+          if (found) setEnabled(found.enabled);
+          else setDefMissing(true);
+        }
+      } catch {
+        if (!cancelled) setDefMissing(true);
+      } finally {
+        if (!cancelled) setDefLoading(false);
+      }
+    })();
+
+    // Recent trigger runs for this definition — independent of the def fetch.
+    let runsCancelled = false;
+    api
+      .listHarnessRuns({ definitionId, limit: 6 })
+      .then((res) => {
+        if (!runsCancelled) setRuns(res.runs ?? []);
+      })
+      .catch(() => {});
+
+    return () => {
+      cancelled = true;
+      runsCancelled = true;
+    };
+  }, [api, definitionId, isWatch, chipEnabled]);
+
+  // Sessions this definition fired in-window (newest first), restricted to nodes
+  // actually present in the graph so every row selects a real node.
+  const firedSessions = useMemo(
+    () => triggerFiredSessionIds(definitionId, edges).filter((id) => nodesById.has(id)),
+    [definitionId, edges, nodesById],
+  );
+
+  const scheduleText = trigger.schedule_label?.trim() || task?.cron || task?.run_at || task?.schedule_type || '—';
+  const commandText =
+    watch?.shell_command?.trim() ||
+    (Array.isArray(watch?.command) ? (watch?.command as unknown[]).join(' ') : '') ||
+    '—';
+  const runtimeText = watch?.runtime?.running
+    ? watch.runtime.pid != null
+      ? t('agents.graph.triggerDetail.runningPid', { pid: watch.runtime.pid })
+      : t('agents.graph.triggerDetail.running')
+    : t('agents.graph.triggerDetail.notRunning');
+
+  const toggleEnabled = async (next: boolean) => {
+    setBusy(true);
+    const prev = enabled;
+    setEnabled(next); // optimistic
+    try {
+      if (isWatch) {
+        const res = await api.setHarnessWatchEnabled(definitionId, next);
+        if (!res.ok) throw new Error('failed');
+        if (res.watch) {
+          setWatch(res.watch);
+          setEnabled(res.watch.enabled);
+        }
+      } else {
+        const res = await api.setHarnessTaskEnabled(definitionId, next);
+        if (!res.ok) throw new Error('failed');
+        if (res.task) {
+          setTask(res.task);
+          setEnabled(res.task.enabled);
+        }
+      }
+      showToast(
+        t(next ? 'agents.graph.triggerDetail.enabledToast' : 'agents.graph.triggerDetail.disabledToast'),
+        'success',
+      );
+      onRefresh();
+    } catch (err) {
+      setEnabled(prev); // revert
+      showToast(err instanceof Error ? err.message : String(err), 'error');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-3.5">
+      {/* Header: type + enabled pills + close */}
+      <div className="flex items-center gap-2">
+        <span className="inline-flex items-center gap-1.5 rounded-full border border-violet/40 bg-violet-soft px-2.5 py-0.5 text-[11px] font-semibold text-violet">
+          {isWatch ? <Eye className="size-3" /> : <CalendarClock className="size-3" />}
+          {t(isWatch ? 'agents.graph.triggerDetail.watchType' : 'agents.graph.triggerDetail.taskType')}
+        </span>
+        <span
+          className={clsx(
+            'inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[10px] font-semibold',
+            enabled
+              ? 'border-mint/40 bg-mint-soft text-mint'
+              : 'border-border-strong bg-foreground/[0.04] text-muted',
+          )}
+        >
+          {t(enabled ? 'agents.graph.triggerDetail.enabled' : 'agents.graph.triggerDetail.disabled')}
+        </span>
+        <span className="flex-1" />
+        <Button type="button" variant="ghost" size="icon" onClick={onClose} aria-label={t('common.close')} className="size-6">
+          <X className="size-3.5" />
+        </Button>
+      </div>
+
+      {/* Title + id */}
+      <div className="flex flex-col gap-1">
+        <div className="break-words text-[16px] font-bold text-foreground">{name}</div>
+        <div className="font-mono text-[10px] text-muted">{trigger.definition_id}</div>
+      </div>
+
+      <div className="h-px bg-border" />
+
+      {/* Facts: schedule/next-run (task) · command/runtime (watch) */}
+      <div className="flex flex-col gap-2.5">
+        {isWatch ? (
+          <>
+            <Fact label={t('agents.graph.triggerDetail.command')}>
+              <span className="break-all font-mono text-[11px]">{defLoading && !watch ? '…' : commandText}</span>
+            </Fact>
+            <Fact label={t('agents.graph.triggerDetail.runtime')}>
+              <span className="inline-flex items-center gap-1.5">
+                <span
+                  className={clsx(
+                    'size-1.5 rounded-full',
+                    watch?.runtime?.running ? 'bg-mint' : 'bg-muted',
+                  )}
+                />
+                {defLoading && !watch ? '…' : runtimeText}
+              </span>
+            </Fact>
+          </>
+        ) : (
+          <>
+            <Fact label={t('agents.graph.triggerDetail.schedule')}>
+              <span className="font-mono text-[11px]">{scheduleText}</span>
+            </Fact>
+            <Fact label={t('agents.graph.triggerDetail.nextRun')}>
+              <span className="font-mono text-[11px]">
+                {defLoading && !task ? '…' : task?.next_run_at ? formatLocalDateTime(task.next_run_at) : '—'}
+              </span>
+            </Fact>
+          </>
+        )}
+      </div>
+
+      {/* Triggered sessions — each selects that node on the graph */}
+      <div className="flex flex-col gap-1.5">
+        <SectionLabel>{t('agents.graph.triggerDetail.firedSessions')}</SectionLabel>
+        {firedSessions.length > 0 ? (
+          <div className="flex flex-col gap-1">
+            {firedSessions.map((id) => {
+              const node = nodesById.get(id)!;
+              return (
+                <button
+                  key={id}
+                  type="button"
+                  onClick={() => onSelectNode(id)}
+                  className="flex items-center gap-2 rounded-lg border border-border bg-surface px-2.5 py-1.5 text-left text-[11px] transition hover:border-border-strong"
+                >
+                  <span className={clsx('size-1.5 shrink-0 rounded-full', statusMeta(node.status).dotClass)} />
+                  <span className="min-w-0 flex-1 truncate text-foreground">{nodeDisplayTitle(node)}</span>
+                  <ChevronRight className="size-3.5 shrink-0 text-muted" />
+                </button>
+              );
+            })}
+          </div>
+        ) : (
+          <span className="text-[11px] text-muted">{t('agents.graph.triggerDetail.noFiredSessions')}</span>
+        )}
+      </div>
+
+      {/* Recent trigger runs (deep-linked into Harness) */}
+      {runs.length > 0 && (
+        <div className="flex flex-col gap-1.5">
+          <div className="flex items-center justify-between">
+            <SectionLabel>{t('agents.graph.triggerDetail.runsTitle')}</SectionLabel>
+            <Link to="/harness?tab=runs" className="text-[11px] font-medium text-cyan hover:underline">
+              {t('agents.graph.detail.viewAllInHarness')}
+            </Link>
+          </div>
+          <div className="flex flex-col gap-1">
+            {runs.map((run) => (
+              <Link
+                key={run.id}
+                to={`/harness?tab=runs&run=${encodeURIComponent(run.id)}`}
+                className="flex items-center gap-2 rounded-lg border border-border bg-surface px-2.5 py-1.5 text-[11px] transition hover:border-border-strong"
+              >
+                <span className={clsx('size-1.5 shrink-0 rounded-full', statusMeta(runStatus(run.status)).dotClass)} />
+                <code className="font-mono text-foreground">{run.id}</code>
+                <span className="text-muted">{t(statusMeta(runStatus(run.status)).labelKey)}</span>
+                <span className="flex-1" />
+                <span className="font-mono text-[10px] text-muted">{formatRelativeTime(run.created_at, t)}</span>
+              </Link>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Actions */}
+      <div className="flex flex-col gap-2 pt-1">
+        <div className="flex items-center justify-between rounded-lg border border-border bg-surface px-3 py-2">
+          <span className="inline-flex items-center gap-2 text-[12px] font-medium text-foreground">
+            <Power className="size-3.5 text-muted" />
+            {t(isWatch ? 'agents.graph.triggerDetail.watchActiveLabel' : 'agents.graph.triggerDetail.taskActiveLabel')}
+          </span>
+          <span className="inline-flex items-center gap-2">
+            {busy && <Loader2 className="size-3 animate-spin text-muted" />}
+            <Switch
+              checked={enabled}
+              onCheckedChange={toggleEnabled}
+              disabled={busy || defMissing}
+              label={t(isWatch ? 'agents.graph.triggerDetail.watchActiveLabel' : 'agents.graph.triggerDetail.taskActiveLabel')}
+            />
+          </span>
+        </div>
+        <Link
+          to={`/harness?tab=${isWatch ? 'watches' : 'tasks'}`}
+          className="inline-flex items-center justify-center gap-1.5 text-[11px] font-medium text-muted transition hover:text-foreground"
+        >
+          <ExternalLink className="size-3" />
+          {t('agents.graph.triggerDetail.openInHarness')}
+        </Link>
+      </div>
+    </div>
+  );
+};
+
+// A run row's stored status uses the run vocabulary; map it onto the node status
+// vocabulary the shared statusMeta understands (a live run's ``running`` reuses
+// the ``active`` dot). Mirrors AgentGraphDetail.runStatus.
+function runStatus(status: string): AgentGraphStatus {
+  if (status === 'running') return 'active';
+  const known: AgentGraphStatus[] = ['queued', 'succeeded', 'failed', 'canceled', 'idle', 'active', 'orphan'];
+  return (known as string[]).includes(status) ? (status as AgentGraphStatus) : 'idle';
+}
+
+const SectionLabel: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <span className="font-mono text-[10px] font-bold uppercase tracking-[0.12em] text-muted">{children}</span>
+);
+
+const Fact: React.FC<{ label: string; children: React.ReactNode }> = ({ label, children }) => (
+  <div className="flex items-start gap-3">
+    <span className="w-16 shrink-0 pt-0.5 font-mono text-[10px] font-bold uppercase tracking-wide text-muted">{label}</span>
+    <div className="min-w-0 flex-1 text-[12px] text-foreground">{children}</div>
+  </div>
+);

--- a/ui/src/components/workbench/AgentGraphTriggerDetail.tsx
+++ b/ui/src/components/workbench/AgentGraphTriggerDetail.tsx
@@ -371,7 +371,13 @@ export const AgentGraphTriggerDetail: React.FC<AgentGraphTriggerDetailProps> = (
             <Switch
               checked={enabled}
               onCheckedChange={toggleEnabled}
-              disabled={busy || defMissing}
+              // Also gate on defPending: a toggle fired before the first load
+              // settles could otherwise race the in-flight list GET, whose late
+              // setEnabled(found.enabled) would clobber the PATCH result. Because
+              // a transient error AFTER a successful load keeps state 'ready'
+              // (never 'error'), defPending only means "never loaded yet" — so
+              // this never re-disables a real trigger on a flaky refresh.
+              disabled={busy || defMissing || defPending}
               label={t(isWatch ? 'agents.graph.triggerDetail.watchActiveLabel' : 'agents.graph.triggerDetail.taskActiveLabel')}
             />
           </span>

--- a/ui/src/components/workbench/AgentGraphTriggerDetail.tsx
+++ b/ui/src/components/workbench/AgentGraphTriggerDetail.tsx
@@ -21,10 +21,12 @@ import {
   triggerFiredSessionIds,
 } from '../../lib/agentGraph';
 
-// While a trigger detail panel is open, re-fetch its definition on this cadence
-// so a watch's runtime (running/pid) tracks WatchSupervisor's async worker
-// start/stop even without a local toggle, and a transient list-fetch failure
-// recovers on its own. Matches the tab's degraded-mode poll.
+// While a trigger detail panel is open, re-fetch its definition AND recent runs
+// on this cadence so a watch's runtime (running/pid) tracks WatchSupervisor's
+// async worker start/stop even without a local toggle, newly-fired runs appear
+// without a reopen, and a transient list-fetch failure recovers on its own.
+// Background ticks are silent (no per-tick error toast). Matches the tab's
+// degraded-mode poll.
 const TRIGGER_DETAIL_POLL_MS = 4000;
 
 // Definition load lifecycle: loading → ready (row found) | absent (fetch OK but
@@ -95,16 +97,18 @@ export const AgentGraphTriggerDetail: React.FC<AgentGraphTriggerDetailProps> = (
   const defPending = defState === 'loading' || defState === 'error';
   const defMissing = defState === 'absent';
 
-  // Load the definition on selection, then keep it fresh while the panel stays
-  // open. There is no single-item GET, so the full list endpoint is the source
-  // (no new backend). One steady path serves three needs:
+  // Load the definition + recent runs on selection, then keep both fresh while
+  // the panel stays open. There is no single-item GET, so the full list endpoint
+  // is the source (no new backend). One steady path serves four needs:
   //  • first load of name/schedule/command + enabled state;
   //  • a watch's runtime (running/pid) tracks WatchSupervisor's async worker
   //    start/stop even when nothing is toggled locally;
+  //  • recent runs pick up a trigger that fires while the panel stays open;
   //  • a transient list-fetch failure recovers on the next tick instead of
   //    leaving the trigger permanently non-actionable.
-  // Ticks are skipped while a toggle is in flight so the poll can't clobber the
-  // optimistic switch or the PATCH's authoritative response.
+  // Definition ticks are skipped while a toggle is in flight so the poll can't
+  // clobber the optimistic switch or the PATCH's authoritative response, and
+  // background ticks are silent so a down endpoint can't toast every 4s.
   useEffect(() => {
     setTask(null);
     setWatch(null);
@@ -117,11 +121,16 @@ export const AgentGraphTriggerDetail: React.FC<AgentGraphTriggerDetailProps> = (
     setBusy(false);
 
     let stopped = false;
-    const loadDefinition = async () => {
+    // `silent` (background ticks) suppresses the API client's global error toast
+    // so a persistently-unavailable endpoint doesn't toast every 4s; the first
+    // foreground load still surfaces one toast. The panel's own '…' / disabled
+    // state is the durable error surface either way.
+    const loadDefinition = async (silent: boolean) => {
       if (stopped || busyRef.current || activeDefIdRef.current !== definitionId) return;
+      const opts = silent ? { handleError: false } : undefined;
       try {
         if (isWatch) {
-          const res = await api.listHarnessWatches();
+          const res = await api.listHarnessWatches(undefined, opts);
           if (stopped || busyRef.current || activeDefIdRef.current !== definitionId) return;
           const found = res.watches.find((w) => w.id === definitionId);
           if (found) {
@@ -132,7 +141,7 @@ export const AgentGraphTriggerDetail: React.FC<AgentGraphTriggerDetailProps> = (
             setDefState('absent');
           }
         } else {
-          const res = await api.listHarnessTasks();
+          const res = await api.listHarnessTasks(undefined, opts);
           if (stopped || busyRef.current || activeDefIdRef.current !== definitionId) return;
           const found = res.tasks.find((tk) => tk.id === definitionId);
           if (found) {
@@ -151,21 +160,31 @@ export const AgentGraphTriggerDetail: React.FC<AgentGraphTriggerDetailProps> = (
         }
       }
     };
-    void loadDefinition();
-    const timer = window.setInterval(loadDefinition, TRIGGER_DETAIL_POLL_MS);
 
-    // Recent trigger runs for this definition — one-shot per selection, not polled.
-    let runsCancelled = false;
-    api
-      .listHarnessRuns({ definitionId, limit: 6 })
-      .then((res) => {
-        if (!runsCancelled) setRuns(res.runs ?? []);
-      })
-      .catch(() => {});
+    // Recent trigger runs — refreshed on the SAME cadence so a run that fires
+    // while the panel stays open appears without a reopen (an SSE graph refresh
+    // doesn't reload these panel-local rows). Always silent: a runs failure has a
+    // self-evident empty state (the section just doesn't render) and needs no
+    // toast. Not gated on `busy` — runs are orthogonal to the enable toggle.
+    const loadRuns = async () => {
+      if (stopped || activeDefIdRef.current !== definitionId) return;
+      try {
+        const res = await api.listHarnessRuns({ definitionId, limit: 6 }, { handleError: false });
+        if (!stopped && activeDefIdRef.current === definitionId) setRuns(res.runs ?? []);
+      } catch {
+        // Keep the last-known rows; the next tick retries.
+      }
+    };
+
+    void loadDefinition(false);
+    void loadRuns();
+    const timer = window.setInterval(() => {
+      void loadDefinition(true);
+      void loadRuns();
+    }, TRIGGER_DETAIL_POLL_MS);
 
     return () => {
       stopped = true;
-      runsCancelled = true;
       window.clearInterval(timer);
     };
   }, [api, definitionId, isWatch, chipEnabled]);

--- a/ui/src/components/workbench/AgentGraphTriggerDetail.tsx
+++ b/ui/src/components/workbench/AgentGraphTriggerDetail.tsx
@@ -116,9 +116,16 @@ export const AgentGraphTriggerDetail: React.FC<AgentGraphTriggerDetailProps> = (
     setEnabled(chipEnabled);
     // A new chip must not inherit the previous definition's rows or an in-flight
     // toggle's busy/optimistic state (that toggle's late resolution is separately
-    // dropped via activeDefIdRef).
+    // dropped via activeDefIdRef). `setBusy(false)` only takes effect on the next
+    // render, so also clear the ref *synchronously* — otherwise this run's own
+    // immediate loadDefinition() would still read the previous trigger's
+    // busyRef===true and bail, stranding the new chip in `loading` (switch
+    // disabled) until the 4s interval fires. B has no in-flight toggle of its own,
+    // so an unconditional clear here is correct; the previous toggle's late writes
+    // stay gated by activeDefIdRef regardless of this ref.
     setRuns([]);
     setBusy(false);
+    busyRef.current = false;
 
     let stopped = false;
     // `silent` (background ticks) suppresses the API client's global error toast

--- a/ui/src/components/workbench/AgentGraphTriggerDetail.tsx
+++ b/ui/src/components/workbench/AgentGraphTriggerDetail.tsx
@@ -4,7 +4,7 @@ import { Link } from 'react-router-dom';
 import { CalendarClock, ChevronRight, ExternalLink, Eye, Loader2, Power, X } from 'lucide-react';
 import clsx from 'clsx';
 
-import { useApi } from '../../context/ApiContext';
+import { ApiError, useApi } from '../../context/ApiContext';
 import type { HarnessRun, HarnessTask, HarnessWatch } from '../../context/ApiContext';
 import { useToast } from '../../context/ToastContext';
 import { Button } from '../ui/button';
@@ -75,6 +75,19 @@ export const AgentGraphTriggerDetail: React.FC<AgentGraphTriggerDetailProps> = (
   // PATCH resolution for a no-longer-active definition must not write state here.
   const activeDefIdRef = useRef(definitionId);
   activeDefIdRef.current = definitionId;
+  // Flips false on unmount so the bounded watch-runtime reconcile poll (which
+  // owns its own timers) never writes into a dead component.
+  const mountedRef = useRef(true);
+  useEffect(
+    () => () => {
+      mountedRef.current = false;
+    },
+    [],
+  );
+  // Bumped on every toggle so a still-running reconcile poll from a superseded
+  // toggle of the SAME definition (the switch re-enables once busy clears) can't
+  // write back a stale runtime.
+  const reconcileGenRef = useRef(0);
 
   useEffect(() => {
     let cancelled = false;
@@ -146,47 +159,83 @@ export const AgentGraphTriggerDetail: React.FC<AgentGraphTriggerDetailProps> = (
       : t('agents.graph.triggerDetail.running')
     : t('agents.graph.triggerDetail.notRunning');
 
+  // A watch's worker is started/stopped by WatchSupervisor on its own async
+  // reconcile loop, so the enable/disable PATCH returns the pre-toggle runtime
+  // snapshot. Re-poll the definition (widening the gap) until the runtime's
+  // running state matches the new enabled value — or the budget is spent — so
+  // the panel settles on the real "Running / Not running" instead of a stale
+  // one. Reuses the list endpoint (there is no single-item GET; no new backend).
+  const reconcileWatchRuntime = async (callId: string, expectRunning: boolean, gen: number) => {
+    const stale = () =>
+      !mountedRef.current || activeDefIdRef.current !== callId || reconcileGenRef.current !== gen;
+    for (const delay of [500, 900, 1400, 2000, 2800]) {
+      await new Promise((resolve) => window.setTimeout(resolve, delay));
+      if (stale()) return;
+      let found: HarnessWatch | undefined;
+      try {
+        const res = await api.listHarnessWatches();
+        found = res.watches.find((w) => w.id === callId);
+      } catch {
+        continue; // transient list error — keep chasing within the budget
+      }
+      if (stale() || !found) return;
+      setWatch(found);
+      setEnabled(found.enabled);
+      if (found.runtime.running === expectRunning) return;
+    }
+  };
+
   const toggleEnabled = async (next: boolean) => {
     // Pin the definition this toggle acts on; if the user switches chips before
-    // the PATCH resolves, every branch below bails so a stale response can't
-    // write the now-foreign definition's state into this reused panel.
+    // the PATCH resolves, the panel-local writes below bail so a stale response
+    // can't overwrite the now-foreign definition's state in this reused panel.
     const callId = definitionId;
+    const stillActive = () => activeDefIdRef.current === callId;
+    const gen = (reconcileGenRef.current += 1);
     setBusy(true);
     const prev = enabled;
     setEnabled(next); // optimistic
     try {
       if (isWatch) {
         const res = await api.setHarnessWatchEnabled(callId, next);
-        if (activeDefIdRef.current !== callId) return;
         if (!res.ok) throw new Error('toggle rejected');
-        if (res.watch) {
+        if (stillActive() && res.watch) {
           setWatch(res.watch);
           setEnabled(res.watch.enabled);
         }
       } else {
         const res = await api.setHarnessTaskEnabled(callId, next);
-        if (activeDefIdRef.current !== callId) return;
         if (!res.ok) throw new Error('toggle rejected');
-        if (res.task) {
+        if (stillActive() && res.task) {
           setTask(res.task);
           setEnabled(res.task.enabled);
         }
       }
-      showToast(
-        t(next ? 'agents.graph.triggerDetail.enabledToast' : 'agents.graph.triggerDetail.disabledToast'),
-        'success',
-      );
+      // The change is committed server-side even if the user has since selected
+      // another chip, so refresh the graph unconditionally — the toggled chip
+      // must re-dim / re-hide now, not only after the next background poll.
       onRefresh();
-    } catch {
-      // Only revert + notify while still viewing this definition — a switch has
-      // already reset enabled/busy for the newly-selected one. The message is a
-      // localized fallback, never the raw thrown control-flow string.
-      if (activeDefIdRef.current === callId) {
+      if (stillActive()) {
+        showToast(
+          t(next ? 'agents.graph.triggerDetail.enabledToast' : 'agents.graph.triggerDetail.disabledToast'),
+          'success',
+        );
+        // Watch runtime (running/pid) settles asynchronously — chase it.
+        if (isWatch) void reconcileWatchRuntime(callId, next, gen);
+      }
+    } catch (err) {
+      // Revert + notify only while still viewing this definition. An HTTP error
+      // was already surfaced by the API client's global error toast, so only the
+      // soft ``{ ok: false }`` / network path (a non-ApiError throw) notifies
+      // here — one failure never yields two toasts.
+      if (stillActive()) {
         setEnabled(prev);
-        showToast(t('agents.graph.triggerDetail.toggleFailed'), 'error');
+        if (!(err instanceof ApiError)) {
+          showToast(t('agents.graph.triggerDetail.toggleFailed'), 'error');
+        }
       }
     } finally {
-      if (activeDefIdRef.current === callId) setBusy(false);
+      if (stillActive()) setBusy(false);
     }
   };
 

--- a/ui/src/components/workbench/AgentGraphTriggerDetail.tsx
+++ b/ui/src/components/workbench/AgentGraphTriggerDetail.tsx
@@ -177,22 +177,55 @@ export const AgentGraphTriggerDetail: React.FC<AgentGraphTriggerDetailProps> = (
       if (stopped || activeDefIdRef.current !== definitionId) return;
       try {
         const res = await api.listHarnessRuns({ definitionId, limit: 6 }, { handleError: false });
-        if (!stopped && activeDefIdRef.current === definitionId) setRuns(res.runs ?? []);
+        // A silent read (`handleError: false`) resolves with the error *body*
+        // instead of throwing, so on a transient 401/503 `res.runs` is absent.
+        // Only overwrite when the response actually carries a runs array —
+        // otherwise keep the last-known rows (the next tick retries) instead of
+        // blanking the recent-runs section during a blip.
+        if (!stopped && activeDefIdRef.current === definitionId && Array.isArray(res.runs)) {
+          setRuns(res.runs);
+        }
       } catch {
         // Keep the last-known rows; the next tick retries.
       }
     };
 
-    void loadDefinition(false);
-    void loadRuns();
-    const timer = window.setInterval(() => {
-      void loadDefinition(true);
-      void loadRuns();
-    }, TRIGGER_DETAIL_POLL_MS);
+    // Coalesce a poll pair: never start a new definition+runs pair while the
+    // previous one is still pending (mirrors AgentGraphTab.fetchGraph's
+    // `inFlightRef`). On a slow endpoint (SQLite lock, slow remote) unguarded
+    // ticks would pile up and could resolve out of order, letting an older
+    // snapshot clobber newer data.
+    let inFlight = false;
+    const refresh = async (silent: boolean) => {
+      if (stopped || inFlight) return;
+      inFlight = true;
+      try {
+        await Promise.all([loadDefinition(silent), loadRuns()]);
+      } finally {
+        inFlight = false;
+      }
+    };
+
+    void refresh(false);
+    // Skip ticks while the tab is hidden — an idle backgrounded panel must not
+    // keep issuing unpaginated list reads every 4s (matches AgentGraphTab's
+    // visibility-gated poll) — and refresh at once when visibility returns.
+    let timer: number | undefined;
+    const tick = () => {
+      if (stopped) return;
+      if (document.visibilityState === 'visible') void refresh(true);
+      timer = window.setTimeout(tick, TRIGGER_DETAIL_POLL_MS);
+    };
+    timer = window.setTimeout(tick, TRIGGER_DETAIL_POLL_MS);
+    const onVisibility = () => {
+      if (document.visibilityState === 'visible') void refresh(true);
+    };
+    document.addEventListener('visibilitychange', onVisibility);
 
     return () => {
       stopped = true;
-      window.clearInterval(timer);
+      if (timer !== undefined) window.clearTimeout(timer);
+      document.removeEventListener('visibilitychange', onVisibility);
     };
   }, [api, definitionId, isWatch, chipEnabled]);
 
@@ -203,7 +236,12 @@ export const AgentGraphTriggerDetail: React.FC<AgentGraphTriggerDetailProps> = (
     [definitionId, edges, nodesById],
   );
 
-  const scheduleText = trigger.schedule_label?.trim() || task?.cron || task?.run_at || task?.schedule_type || '—';
+  // Once the definition poll has loaded `task`, its cron/run_at is the fresh
+  // source of truth for the schedule; the graph payload's `schedule_label` is a
+  // snapshot that can lag a schedule edited elsewhere, so it is only the
+  // pre-load fallback.
+  const scheduleText =
+    task?.cron || task?.run_at || task?.schedule_type || trigger.schedule_label?.trim() || '—';
   const commandText =
     watch?.shell_command?.trim() ||
     (Array.isArray(watch?.command) ? (watch?.command as unknown[]).join(' ') : '') ||

--- a/ui/src/context/ApiContext.tsx
+++ b/ui/src/context/ApiContext.tsx
@@ -671,13 +671,17 @@ export type ApiContextType = {
   updateSkill: (name: string, params?: { scope?: SkillScope; projectId?: string }) => Promise<SkillsMutationResult>;
   getHarnessCounts: () => Promise<HarnessCountsResult>;
   getHarnessBootstrap: (params?: HarnessBootstrapParams) => Promise<HarnessBootstrapResult>;
-  listHarnessTasks: (params?: HarnessDefinitionsParams) => Promise<HarnessTasksResult>;
+  // ``opts.handleError: false`` suppresses the global error toast (and bypasses
+  // the read cache) for best-effort background polls — e.g. the open trigger
+  // detail panel's 4s refresh, which must not toast on every tick when an
+  // endpoint is down. Matches the getSession/vault handleError idiom.
+  listHarnessTasks: (params?: HarnessDefinitionsParams, opts?: { handleError?: boolean }) => Promise<HarnessTasksResult>;
   setHarnessTaskEnabled: (taskId: string, enabled: boolean) => Promise<{ ok: boolean; task?: HarnessTask }>;
   deleteHarnessTask: (taskId: string) => Promise<{ ok: boolean; id?: string }>;
-  listHarnessWatches: (params?: HarnessDefinitionsParams) => Promise<HarnessWatchesResult>;
+  listHarnessWatches: (params?: HarnessDefinitionsParams, opts?: { handleError?: boolean }) => Promise<HarnessWatchesResult>;
   setHarnessWatchEnabled: (watchId: string, enabled: boolean) => Promise<{ ok: boolean; watch?: HarnessWatch }>;
   deleteHarnessWatch: (watchId: string) => Promise<{ ok: boolean; id?: string }>;
-  listHarnessRuns: (params?: HarnessRunsParams) => Promise<HarnessRunsResult>;
+  listHarnessRuns: (params?: HarnessRunsParams, opts?: { handleError?: boolean }) => Promise<HarnessRunsResult>;
   getHarnessRun: (runId: string) => Promise<{ ok: boolean; run: HarnessRun }>;
   getRunningAgents: () => Promise<RunningAgentsResult>;
   // Agents · 运行图 graph payload (contract §3). Realtime — refetched off SSE,
@@ -2827,31 +2831,31 @@ export const ApiProvider: React.FC<{ children: React.ReactNode }> = ({ children 
       const qs = search.toString();
       return getCachedJson(qs ? `/api/harness/bootstrap?${qs}` : '/api/harness/bootstrap');
     },
-    listHarnessTasks: (params) => {
+    listHarnessTasks: (params, opts) => {
       const search = new URLSearchParams();
       if (params?.status) search.set('status', params.status);
       if (params?.query) search.set('query', params.query);
       if (params?.page) search.set('page', String(params.page));
       if (params?.limit) search.set('limit', String(params.limit));
       const qs = search.toString();
-      return getCachedJson(qs ? `/api/harness/tasks?${qs}` : '/api/harness/tasks');
+      return getCachedJson(qs ? `/api/harness/tasks?${qs}` : '/api/harness/tasks', undefined, opts);
     },
     setHarnessTaskEnabled: (taskId, enabled) =>
       patchJson(`/api/harness/tasks/${encodeURIComponent(taskId)}`, { enabled }),
     deleteHarnessTask: (taskId) => deleteJson(`/api/harness/tasks/${encodeURIComponent(taskId)}`),
-    listHarnessWatches: (params) => {
+    listHarnessWatches: (params, opts) => {
       const search = new URLSearchParams();
       if (params?.status) search.set('status', params.status);
       if (params?.query) search.set('query', params.query);
       if (params?.page) search.set('page', String(params.page));
       if (params?.limit) search.set('limit', String(params.limit));
       const qs = search.toString();
-      return getCachedJson(qs ? `/api/harness/watches?${qs}` : '/api/harness/watches');
+      return getCachedJson(qs ? `/api/harness/watches?${qs}` : '/api/harness/watches', undefined, opts);
     },
     setHarnessWatchEnabled: (watchId, enabled) =>
       patchJson(`/api/harness/watches/${encodeURIComponent(watchId)}`, { enabled }),
     deleteHarnessWatch: (watchId) => deleteJson(`/api/harness/watches/${encodeURIComponent(watchId)}`),
-    listHarnessRuns: (params) => {
+    listHarnessRuns: (params, opts) => {
       const search = new URLSearchParams();
       if (params?.status) search.set('status', params.status);
       if (params?.runType) search.set('run_type', params.runType);
@@ -2861,7 +2865,7 @@ export const ApiProvider: React.FC<{ children: React.ReactNode }> = ({ children 
       if (params?.page) search.set('page', String(params.page));
       if (params?.limit) search.set('limit', String(params.limit));
       const qs = search.toString();
-      return getCachedJson(qs ? `/api/harness/runs?${qs}` : '/api/harness/runs');
+      return getCachedJson(qs ? `/api/harness/runs?${qs}` : '/api/harness/runs', undefined, opts);
     },
     getHarnessRun: (runId) => getCachedJson(`/api/harness/runs/${encodeURIComponent(runId)}`),
     connectWorkbenchEvents: (handlers) => {

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -2299,6 +2299,27 @@
         "watch": "Watch",
         "disabled": "Disabled"
       },
+      "triggerDetail": {
+        "taskType": "Task",
+        "watchType": "Watch",
+        "enabled": "Enabled",
+        "disabled": "Disabled",
+        "schedule": "Schedule",
+        "nextRun": "Next run",
+        "command": "Command",
+        "runtime": "Runtime",
+        "running": "Running",
+        "runningPid": "Running · pid {{pid}}",
+        "notRunning": "Not running",
+        "firedSessions": "Triggered sessions",
+        "noFiredSessions": "No sessions triggered in this window.",
+        "runsTitle": "Recent runs",
+        "taskActiveLabel": "Enabled",
+        "watchActiveLabel": "Watching",
+        "enabledToast": "Enabled",
+        "disabledToast": "Disabled",
+        "openInHarness": "Open in Harness"
+      },
       "search": {
         "placeholder": "Find a session or trigger…",
         "loading": "Loading…",
@@ -2312,7 +2333,8 @@
         "spawn": "Spawn",
         "trigger": "Task / Watch",
         "background": "Background",
-        "callbackNote": "Reports-to only in detail panel"
+        "callbackNote": "Reports-to only in detail panel",
+        "showDisabled": "Show disabled"
       },
       "status": {
         "active": "running",

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -2318,7 +2318,8 @@
         "watchActiveLabel": "Watching",
         "enabledToast": "Enabled",
         "disabledToast": "Disabled",
-        "openInHarness": "Open in Harness"
+        "openInHarness": "Open in Harness",
+        "toggleFailed": "Couldn't update — try again."
       },
       "search": {
         "placeholder": "Find a session or trigger…",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -2318,7 +2318,8 @@
         "watchActiveLabel": "监视中",
         "enabledToast": "已启用",
         "disabledToast": "已禁用",
-        "openInHarness": "在 Harness 中打开"
+        "openInHarness": "在 Harness 中打开",
+        "toggleFailed": "更新失败,请重试。"
       },
       "search": {
         "placeholder": "查找会话或触发器…",
@@ -2333,7 +2334,8 @@
         "spawn": "启动",
         "trigger": "Task / Watch 触发",
         "background": "后台会话",
-        "callbackNote": "汇报关系只在详情面板"
+        "callbackNote": "汇报关系只在详情面板",
+        "showDisabled": "显示已禁用"
       },
       "status": {
         "active": "运行中",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -2299,6 +2299,27 @@
         "watch": "WATCH",
         "disabled": "已禁用"
       },
+      "triggerDetail": {
+        "taskType": "Task",
+        "watchType": "Watch",
+        "enabled": "已启用",
+        "disabled": "已禁用",
+        "schedule": "计划",
+        "nextRun": "下次运行",
+        "command": "命令",
+        "runtime": "运行时",
+        "running": "运行中",
+        "runningPid": "运行中 · pid {{pid}}",
+        "notRunning": "未运行",
+        "firedSessions": "触发的会话",
+        "noFiredSessions": "该窗口内未触发任何会话。",
+        "runsTitle": "最近运行",
+        "taskActiveLabel": "已启用",
+        "watchActiveLabel": "监视中",
+        "enabledToast": "已启用",
+        "disabledToast": "已禁用",
+        "openInHarness": "在 Harness 中打开"
+      },
       "search": {
         "placeholder": "查找会话或触发器…",
         "loading": "加载中…",

--- a/ui/src/lib/agentGraph.test.ts
+++ b/ui/src/lib/agentGraph.test.ts
@@ -5,6 +5,7 @@ import {
   type AgentGraphNode,
   type AgentGraphTriggerNode,
   buildGraphForest,
+  computeFillHeight,
   deriveLineage,
   filterDisabledTriggers,
   formatElapsed,
@@ -202,5 +203,21 @@ describe('triggerFiredSessionIds', () => {
 
   it('returns empty for a definition that fired nothing in-window', () => {
     expect(triggerFiredSessionIds('def_absent', edges)).toEqual([]);
+  });
+});
+
+describe('computeFillHeight (desktop canvas fill height)', () => {
+  it('fills the viewport below the graph top, minus the bottom gap', () => {
+    // 900 tall, graph starts 260 down, 24 gap ⇒ 616.
+    expect(computeFillHeight(900, 260, 24, 480)).toBe(616);
+  });
+
+  it('floors at the minimum when the window is too short to fit it', () => {
+    // Only 200px would remain — clamp up so the page scrolls instead of crushing.
+    expect(computeFillHeight(600, 376, 24, 480)).toBe(480);
+  });
+
+  it('rounds sub-pixel measurements to a whole number', () => {
+    expect(computeFillHeight(900, 260.4, 24, 480)).toBe(616); // 615.6 → 616
   });
 });

--- a/ui/src/lib/agentGraph.test.ts
+++ b/ui/src/lib/agentGraph.test.ts
@@ -6,10 +6,12 @@ import {
   type AgentGraphTriggerNode,
   buildGraphForest,
   deriveLineage,
+  filterDisabledTriggers,
   formatElapsed,
   isBackground,
   nodeDisplayTitle,
   statusMeta,
+  triggerFiredSessionIds,
 } from './agentGraph';
 
 function node(id: string, over: Partial<AgentGraphNode> = {}): AgentGraphNode {
@@ -146,5 +148,59 @@ describe('buildGraphForest', () => {
     const nodes = [node('old', { live: false }), node('hot', { live: true })];
     const rows = buildGraphForest(nodes, []);
     expect(rows[0].node.session_id).toBe('hot');
+  });
+});
+
+describe('filterDisabledTriggers (A11 hide-disabled)', () => {
+  const enabledTr: AgentGraphTriggerNode = { ...trigger, definition_id: 'def_on', enabled: true };
+  const disabledTr: AgentGraphTriggerNode = { ...trigger, definition_id: 'def_off', enabled: false };
+  const edges: AgentGraphEdge[] = [
+    { kind: 'spawn', from: 'root', to: 'child' },
+    { kind: 'trigger', from: 'def:def_on', to: 'a' },
+    { kind: 'trigger', from: 'def:def_off', to: 'b' },
+  ];
+
+  it('passes the same array refs through untouched when showDisabled is on', () => {
+    const triggers = [enabledTr, disabledTr];
+    const out = filterDisabledTriggers(triggers, edges, true);
+    expect(out.triggerNodes).toBe(triggers); // same reference — no needless re-layout
+    expect(out.edges).toBe(edges);
+  });
+
+  it('drops disabled chips and only their trigger edges when off', () => {
+    const out = filterDisabledTriggers([enabledTr, disabledTr], edges, false);
+    expect(out.triggerNodes).toEqual([enabledTr]);
+    // The disabled def's trigger edge is gone; the spawn edge and the enabled
+    // def's trigger edge survive.
+    expect(out.edges).toEqual([
+      { kind: 'spawn', from: 'root', to: 'child' },
+      { kind: 'trigger', from: 'def:def_on', to: 'a' },
+    ]);
+  });
+
+  it('returns inputs by reference when nothing is disabled', () => {
+    const only = [enabledTr];
+    const out = filterDisabledTriggers(only, edges, false);
+    expect(out.triggerNodes).toBe(only);
+    expect(out.edges).toBe(edges);
+  });
+});
+
+describe('triggerFiredSessionIds', () => {
+  const edges: AgentGraphEdge[] = [
+    { kind: 'trigger', from: 'def:def_1', to: 'ses_old', last_at: '2026-07-23T01:00:00Z' },
+    { kind: 'trigger', from: 'def:def_1', to: 'ses_new', last_at: '2026-07-23T05:00:00Z' },
+    // A repeat edge for the same session keeps the newest last_at, not a dupe.
+    { kind: 'trigger', from: 'def:def_1', to: 'ses_old', last_at: '2026-07-23T02:00:00Z' },
+    { kind: 'trigger', from: 'def:other', to: 'ses_x', last_at: '2026-07-23T09:00:00Z' },
+    { kind: 'spawn', from: 'def:def_1', to: 'ses_y' }, // non-trigger edge ignored
+  ];
+
+  it('returns the def’s fired sessions newest-first, de-duplicated', () => {
+    expect(triggerFiredSessionIds('def_1', edges)).toEqual(['ses_new', 'ses_old']);
+  });
+
+  it('returns empty for a definition that fired nothing in-window', () => {
+    expect(triggerFiredSessionIds('def_absent', edges)).toEqual([]);
   });
 });

--- a/ui/src/lib/agentGraph.ts
+++ b/ui/src/lib/agentGraph.ts
@@ -235,6 +235,24 @@ export function nodeDisplayTitle(node: Pick<AgentGraphNode, 'title' | 'agent_nam
   return node.agent_name ? `${node.agent_name} · ${suffix}` : suffix;
 }
 
+// Desktop run-graph fill height (design.pen KfgtJ — canvas fills its container):
+// the canvas (and the detail panel beside it) grow to consume the viewport below
+// the graph area's top, minus a small bottom gap, floored at a usable minimum so
+// a short window can't crush them — below the floor the page scrolls instead.
+// Pure so it's unit-testable; the DOM read (window.innerHeight and the graph's
+// getBoundingClientRect().top) lives in the component and feeds this. Resizing
+// only changes this number — never the dagre layout, which is keyed on the graph
+// data alone — so the viewport reflows without a re-layout (mirrors the M3 hover
+// principle: size changes touch the viewport, not the node positions).
+export function computeFillHeight(
+  viewportHeight: number,
+  topOffset: number,
+  bottomGap: number,
+  minHeight: number,
+): number {
+  return Math.max(minHeight, Math.round(viewportHeight - topOffset - bottomGap));
+}
+
 // ── Lineage derivation (facts panel) ─────────────────────────────────────────
 
 export type NodeLineage = {

--- a/ui/src/lib/agentGraph.ts
+++ b/ui/src/lib/agentGraph.ts
@@ -132,6 +132,49 @@ export function definitionIdFromRef(ref: string): string {
   return ref.startsWith(TRIGGER_PREFIX) ? ref.slice(TRIGGER_PREFIX.length) : ref;
 }
 
+// A11: disabled trigger chips are hidden by default. A chip only ever appears
+// because its definition fired in-window (A10), so this is a pure *display*
+// filter over the edge-derived set — the payload is unchanged and the legend
+// "show disabled" switch reveals them again. Enabled triggers and every
+// spawn/callback edge always pass through; only trigger edges sourced from a
+// hidden definition are dropped, so lineage between sessions is never touched.
+// Inputs are returned by reference when nothing is filtered, so downstream
+// memoized layout stays stable across unrelated refreshes.
+export function filterDisabledTriggers(
+  triggerNodes: AgentGraphTriggerNode[],
+  edges: AgentGraphEdge[],
+  showDisabled: boolean,
+): { triggerNodes: AgentGraphTriggerNode[]; edges: AgentGraphEdge[] } {
+  if (showDisabled) return { triggerNodes, edges };
+  const hiddenRefs = new Set<string>();
+  const keptTriggers: AgentGraphTriggerNode[] = [];
+  for (const tr of triggerNodes) {
+    if (tr.enabled) keptTriggers.push(tr);
+    else hiddenRefs.add(triggerRefId(tr.definition_id));
+  }
+  if (hiddenRefs.size === 0) return { triggerNodes, edges };
+  return {
+    triggerNodes: keptTriggers,
+    edges: edges.filter((e) => !(e.kind === 'trigger' && hiddenRefs.has(e.from))),
+  };
+}
+
+// Sessions a trigger definition fired within the current payload, newest first
+// and de-duplicated. Derived from its trigger edges (`from === def:<id>`); drives
+// the trigger detail panel's "triggered sessions" list, each row selecting that
+// graph node. Callers map the ids through the node set to drop any not rendered.
+export function triggerFiredSessionIds(definitionId: string, edges: AgentGraphEdge[]): string[] {
+  const ref = triggerRefId(definitionId);
+  const lastAtBySession = new Map<string, string | null | undefined>();
+  for (const e of edges) {
+    if (e.kind !== 'trigger' || e.from !== ref) continue;
+    if (!lastAtBySession.has(e.to) || laterAt(e.last_at, lastAtBySession.get(e.to)) > 0) {
+      lastAtBySession.set(e.to, e.last_at);
+    }
+  }
+  return [...lastAtBySession.entries()].sort((a, b) => laterAt(b[1], a[1])).map(([id]) => id);
+}
+
 // Per-status presentation, in one place (matches the spec frame anu5U). The
 // dot/border tone maps to design tokens; `dim` fades ended sessions.
 export type StatusTone = 'mint' | 'gold' | 'cyan' | 'muted' | 'destructive';

--- a/ui/src/lib/graphViewPrefs.ts
+++ b/ui/src/lib/graphViewPrefs.ts
@@ -1,0 +1,23 @@
+// Remembers the run-graph "show disabled triggers" legend toggle across visits.
+// Disabled trigger chips are hidden by default (contract A11); this persists the
+// user's opt-in so a reload doesn't silently re-hide the definitions they wanted
+// to see. Mirrors the localStorage conventions used elsewhere in the UI
+// (module-level key, SSR-safe, best-effort try/catch — see inboxFilterMemory).
+const SHOW_DISABLED_KEY = 'vibe-remote:graph-show-disabled';
+
+export function readGraphShowDisabled(): boolean {
+  try {
+    return window.localStorage.getItem(SHOW_DISABLED_KEY) === '1';
+  } catch {
+    // Best-effort persistence only (private mode / SSR / blocked storage).
+    return false;
+  }
+}
+
+export function writeGraphShowDisabled(value: boolean): void {
+  try {
+    window.localStorage.setItem(SHOW_DISABLED_KEY, value ? '1' : '0');
+  } catch {
+    // Best-effort persistence only.
+  }
+}


### PR DESCRIPTION
## Capability

Micro-batch **M9** (owner graph-experience feedback; contract amendments **A10/A11** in `docs/plans/agents-run-graph-contract.md`). Changes to the Agents run graph, `ui/**` only, **no new backend**:

### Part 1 — In-graph trigger detail panel (A11)
Clicking a purple Task/Watch chip no longer navigates to Harness. It now behaves exactly like selecting a session node — it selects the chip and opens the same right-side detail panel:

- **Content**: name + type; Task → schedule (cron/at) + next run time; Watch → command summary + runtime status (running / pid); enabled state; **fired sessions** (each row selects that graph node); **recent trigger runs** (row deep-links to `/harness?tab=runs&run=<id>`).
- **In-place actions**: enable/disable toggle via the existing harness API client (`setHarnessTaskEnabled` / `setHarnessWatchEnabled`) — a watch's toggle *is* its pause/resume. Optimistic with revert-on-error, then a graph refetch so the chip re-dims/re-hides.
- **Secondary exit**: "Open in Harness" link at the panel bottom (the old jump, downgraded).
- Selection is mutually exclusive (a node **or** a chip, never both). Panels read lineage from the **raw** edges/maps, so a relation stays truthful even when the chip is hidden by the toggle.

> **Deferred — Task「立即运行」/ run-now (needs backend, out of ui-only scope).** The contract's A11 line was formally **amended 2026-07-26** (this PR's review): run-now is owner-approved **deferred**. The Harness backend exposes only a `{enabled}` PATCH on `/api/harness/tasks/<id>` — there is no run-now POST, and the `vibe task run` execution path lives at the service layer (unreachable from the browser). So run-now is intentionally **not** shipped here, with **no placeholder button**. See the Deferred ledger below.

### Part 2 — Hide disabled by default + legend toggle (A10/A11)
- `enabled=false` chips **and their trigger edges** are not rendered by default (spawn edges + session lineage are always preserved).
- The canvas legend gains a **"Show disabled / 显示已禁用"** switch (default off); when on, disabled chips render per A10 (dimmed + `· Disabled` marker). State persisted in `localStorage` (`lib/graphViewPrefs.ts`, mirroring existing UI persistence idioms).
- **M8 search integration**: a hit on a hidden disabled chip badges "Outside current filters"; clicking it reveals the chip **transiently** — a session-only `revealDisabled` flag OR'd into the effective filter that does **not** write the persisted preference, so it is gone on the next load. Widening for an aged-out disabled chip reveals it the same transient way so the deferred locate resolves. Only the explicit legend switch (desktop) or the mobile show-disabled toggle writes the persisted preference; turning either off also clears an active transient reveal, so "off" always hides.

### Part 3 — Desktop canvas fills the remaining page height (owner add-on; design.pen KfgtJ `fill_container`)
The desktop graph canvas was a fixed `600px` box that left dead space below it. It now grows to fill the page's remaining vertical height, restoring the design intent:

- **Measured fill, not a fixed height**: `computeFillHeight(viewportHeight, top, gap, min)` (pure, in `lib/agentGraph.ts`) sizes the canvas to `innerHeight − measured-top − 24px`, floored at **480px** so a short window scrolls instead of crushing the canvas. `useGraphFillHeight` (in `AgentGraphTab`) reads the graph area's `getBoundingClientRect().top` and re-measures on `window resize` **and** a `document.body` `ResizeObserver` (rAF-deferred + idempotent set-if-changed), so content above the graph (orphan strip, warning banners, a wrapped filter row) that shifts the top is tracked without a `ResizeObserver` loop warning.
- **Viewport-only, never a re-layout**: the height feeds only the container size — the dagre layout memo is keyed on graph data alone, so a resize reflows the React Flow viewport (pan/zoom) **without moving a node** (same principle as the M3 hover-render fix).
- **Detail panel matches the canvas height** (design.pen KfgtJ) and scrolls its body when taller than the fill, so the two columns read as one pane.
- **Mobile is untouched**: `fillHeight` is desktop-gated (`undefined` on the mobile list), so the grouped list keeps its natural height.

### Mobile
The mobile grouped list has no canvas/legend, so: disabled pills are hidden by default and follow the **shared** `showDisabled` preference (adjustable on desktop, honored on mobile), surfaced here as an explicit filter-row toggle. Trigger pills are now clickable and open the same detail panel (selection hides the list and shows the panel full-width, matching node behavior). Search trigger hits are now actionable on mobile too — a transient reveal is undoable via that same mobile toggle. The Part 3 fill-height change does not affect mobile.

## Panel data lifecycle (A11 freshness)

The trigger detail panel is kept truthful by one **4s reconcile channel** (`TRIGGER_DETAIL_POLL_MS`) plus a `DefState` enum (`loading | ready | absent | error`) and the derived `defPending` / `defMissing` flags. A single effect keyed on `[api, definitionId, isWatch, chipEnabled]` owns both the immediate load and the `setInterval`; a `busyRef` mirror pauses the poll during a mutation, and an `activeDefIdRef` identity guard runs **before and after** each `await`. Every path a reviewer would worry about:

- **Open** — the effect fires `loadDefinition()` immediately (`DefState: loading → ready | absent | error`) and starts the 4s interval. While `defPending` (never-loaded), the enable/disable switch is `disabled`, so a trigger can't be toggled before its true `enabled` state has arrived.
- **Switch chip** — a new `definitionId` tears the effect down (`stopped = true`, `clearInterval`) and re-runs with state reset to `loading` and `activeDefIdRef` repointed. The identity guard discards a slow in-flight response from the previous chip, so chip A's reply can never land on chip B's panel. If A's enable/disable PATCH is *still in flight* when B is selected, the effect also clears `busyRef.current` **synchronously** (not just `setBusy(false)`, which lands a render later): otherwise B's own immediate load would read A's stale `busy === true` and bail, stranding B in `loading` until the 4s tick. A's late PATCH writes stay gated by `stillActive()` (`activeDefIdRef`), so clearing the ref can't let them land on B.
- **Mutate (toggle)** — optimistic `setEnabled`; `busyRef = true` pauses the poll; the PATCH runs; success confirms + triggers a graph refetch, error reverts + toasts. The PATCH's returned runtime is **not** trusted (see next).
- **Supervisor async** — `WatchSupervisor` starts/stops the worker **asynchronously**, so the enable/disable PATCH returns the *pre-toggle* runtime snapshot. The 4s channel re-reads the definition and converges the running/pid badge to truth within one interval — no reliance on the stale PATCH body, no manual refresh.
- **Runs fire while open** — the recent-runs list is refreshed on the **same** 4s interval (not a one-shot per selection), so a trigger that fires while its panel stays open surfaces within one interval; an SSE graph refresh doesn't reload these panel-local rows. This fetch is **always silent** (`handleError: false`): a failure keeps the last-known rows and leaves a self-evident empty state, never a per-tick toast. The definition ticks are silent on background but surface **one** toast on the first foreground load, so a genuinely-down endpoint is still reported once.
- **Transient failure** — a poll that throws does `setDefState((s) => s === 'ready' ? s : 'error')`: a flaky refresh keeps the last-known `ready` snapshot on screen (never blanks a real trigger), and because `defPending` only ever means "never loaded yet", a mid-session fetch error does **not** re-disable the toggle. The next good poll restores `ready`.
- **Close / reopen (incl. React StrictMode replay)** — one cleanup sets `stopped` and clears the single interval; both the definition load and the recent-runs load share that `stopped` flag plus the `activeDefIdRef` guard, so there is no post-unmount `setState` and no leaked timer. StrictMode's setup→cleanup→setup replay is safe: setup is idempotent (fresh refs + interval), cleanup fully tears down, and a reopen begins a clean `loading` cycle. The `revealDisabled` transient lives in the **parent** (`AgentGraphTab`), so it survives a panel close/reopen and is cleared only by an explicit hide or a reload.

## Scenario IDs
Run-graph contract **A10** (edge-derived trigger chips; disabled-but-fired chips dimmed) and **A11** (in-graph trigger detail panel + hide-disabled-by-default; run-now deferred per the 2026-07-26 amendment). Part 3 restores design.pen **KfgtJ** (`canvas height fill_container`). No `tests/scenarios` catalog entry covers the graph UI; coverage is unit + build + manual.

## Evidence layers
- **Unit**: extended `ui/src/lib/agentGraph.test.ts` for the extracted pure functions — `filterDisabledTriggers` (by-reference passthrough when nothing hidden; drops only disabled triggers + their `kind==='trigger'` edges), `triggerFiredSessionIds` (newest-first, de-duped), and `computeFillHeight` (fills below the top, floors at the minimum, rounds sub-pixel). Full suite green: **431/431 across 56 files**.
- **Contract**: A10/A11 recorded in `docs/plans/agents-run-graph-contract.md` (owner-filed; A11 run-now amendment re-synced verbatim in this PR); Part 3 maps to design.pen KfgtJ.
- **Build/typecheck**: `npm run build` (`tsc -b && vite build`) passes. ESLint: the changed graph files (`AgentGraphTab.tsx`, `AgentGraphTriggerDetail.tsx`, `lib/agentGraph.ts`) are clean; my `ApiContext.tsx` diff adds **zero** new findings — that legacy file carries 53 pre-existing `@typescript-eslint/no-explicit-any` errors (identical count with my diff stashed), left untouched as out-of-scope for this ui-only batch.
- **Residual manual**: chip-select ↔ node-select exclusivity, toggle persistence across reload, **transient** search reveal-on-select for hidden chips (gone on reload; undoable via the toggle), watch pause/resume via the toggle, runtime-badge convergence after a toggle (supervisor lag), a trigger firing while its panel stays open (recent-runs appears within one poll), **selecting a second trigger while the first's toggle is still in flight** (the new panel loads at once, no 4s `loading` stall), a background poll against a down endpoint (no per-tick toast), mobile pill → panel, and **desktop canvas + panel fill height across window resizes** (no node re-layout, floor at 480px) — to verify in Incus regression after merge. No `@testing-library/react` in this repo (component tests are static `renderToStaticMarkup`), so these effect-timing paths are covered by reasoning + manual verification rather than an interaction test, matching the existing test surface.

## Deferred ledger
- **Task run-now (「立即运行」)** — *deferred, owner-approved.* Requires a new Harness HTTP endpoint (a run-now POST over the existing `vibe task run` service path); this batch is `ui/**`-only, so shipping it would break the no-new-backend scope. The A11 contract line was amended 2026-07-26 to record the deferral, re-synced verbatim into this PR. Candidate follow-up **backend** micro-batch, to be opened when the owner expresses the need. No placeholder control ships in the meantime.

## Out of scope
No backend changes. Task run-now deferred (see the Deferred ledger).
