### PR TITLE
feat(runtime): add Windows control IPC

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -226,3 +226,34 @@ jobs:
           if (-not (Select-String -Path vibe-version.log -Pattern 'avibe-os ' -Quiet)) {
             throw "vibe version output missing expected marker"
           }
+
+  windows-control-ipc:
+    runs-on: windows-latest
+    needs: build-linux-artifacts
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09  # v5
+
+      - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0  # v5
+        with:
+          name: vibe-wheel-linux
+          path: dist
+
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6
+        with:
+          python-version: "3.12"
+          cache: "pip"
+          cache-dependency-path: |
+            pyproject.toml
+            uv.lock
+
+      - name: Install package and focused test dependency
+        shell: pwsh
+        run: |
+          $wheel = (Get-ChildItem dist\*.whl | Select-Object -First 1).FullName
+          if (-not $wheel) {
+            throw "Missing wheel artifact"
+          }
+          python -m pip install $wheel pytest
+
+      - name: Verify Windows Controller control IPC
+        run: python -m pytest tests/test_control_ipc.py -q

--- a/config/paths.py
+++ b/config/paths.py
@@ -170,6 +170,10 @@ def get_runtime_doctor_path() -> Path:
     return get_runtime_dir() / "doctor.json"
 
 
+def get_runtime_control_ipc_endpoint_path() -> Path:
+    return get_runtime_dir() / "control-ipc.json"
+
+
 def get_config_path() -> Path:
     return get_config_dir() / "config.json"
 

--- a/core/control_ipc.py
+++ b/core/control_ipc.py
@@ -1,0 +1,479 @@
+"""Cross-platform transport contract for the Controller's internal HTTP API."""
+
+from __future__ import annotations
+
+import errno
+import hmac
+import json
+import os
+import re
+import secrets
+import socket
+import stat
+import tempfile
+from abc import ABC, abstractmethod
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable, Iterator, Optional
+
+from config import paths
+
+CONTROL_IPC_SCHEMA_VERSION = 1
+CONTROL_IPC_INSTANCE_HEADER = "X-Avibe-Control-Instance"
+MAX_DESCRIPTOR_BYTES = 4096
+_DESCRIPTOR_FIELDS = frozenset(
+    {
+        "schema_version",
+        "transport",
+        "host",
+        "port",
+        "instance_id",
+        "bearer_token",
+    }
+)
+_INSTANCE_ID_RE = re.compile(r"[0-9a-f]{32}")
+_BEARER_TOKEN_RE = re.compile(r"[A-Za-z0-9_-]{43,128}")
+
+
+class ControlIpcDescriptorError(ValueError):
+    """Raised when the Windows endpoint descriptor is absent or invalid."""
+
+
+@dataclass(frozen=True)
+class ControlIpcDescriptor:
+    schema_version: int
+    transport: str
+    host: str
+    port: int
+    instance_id: str
+    bearer_token: str = field(repr=False)
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "schema_version": self.schema_version,
+            "transport": self.transport,
+            "host": self.host,
+            "port": self.port,
+            "instance_id": self.instance_id,
+            "bearer_token": self.bearer_token,
+        }
+
+
+@dataclass(frozen=True)
+class BoundControlIpc:
+    listener: socket.socket
+    transport: str
+    socket_path: Optional[Path] = None
+    descriptor: Optional[ControlIpcDescriptor] = None
+
+
+@dataclass(frozen=True)
+class ControlIpcClientEndpoint:
+    transport: str
+    socket_path: Optional[Path] = None
+    descriptor: Optional[ControlIpcDescriptor] = None
+
+    @property
+    def base_url(self) -> str:
+        if self.descriptor is None:
+            return "http://localhost"
+        return f"http://{self.descriptor.host}:{self.descriptor.port}"
+
+    @property
+    def headers(self) -> dict[str, str]:
+        if self.descriptor is None:
+            return {}
+        return {"Authorization": f"Bearer {self.descriptor.bearer_token}"}
+
+
+def default_unix_socket_path() -> Path:
+    override = os.environ.get("VIBE_INTERNAL_DISPATCH_SOCKET")
+    if override:
+        return Path(override).expanduser()
+    return paths.get_state_dir() / "dispatch.sock"
+
+
+def default_descriptor_path() -> Path:
+    return paths.get_runtime_control_ipc_endpoint_path()
+
+
+class ControlIpcHost(ABC):
+    """Own one pre-bound listener and its discoverable endpoint lifecycle."""
+
+    instance_id: Optional[str] = None
+    bearer_token: Optional[str] = None
+
+    @abstractmethod
+    def bind(self) -> BoundControlIpc:
+        raise NotImplementedError
+
+    @abstractmethod
+    def publish(self, bound: BoundControlIpc) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def cleanup(self, bound: BoundControlIpc) -> None:
+        raise NotImplementedError
+
+
+class PosixUnixSocketHost(ControlIpcHost):
+    def __init__(self, socket_path: Optional[Path] = None):
+        self.socket_path = (socket_path or default_unix_socket_path()).expanduser().resolve()
+
+    def bind(self) -> BoundControlIpc:
+        target = self.socket_path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        if target.exists() or target.is_symlink():
+            target.unlink()
+
+        previous_umask = os.umask(0o077)
+        listener = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        try:
+            listener.bind(str(target))
+            listener.listen(2048)
+            listener.setblocking(False)
+            try:
+                os.chmod(target, 0o600)
+            except OSError:
+                pass
+            return BoundControlIpc(
+                listener=listener,
+                transport="unix",
+                socket_path=target,
+            )
+        except Exception:
+            listener.close()
+            raise
+        finally:
+            os.umask(previous_umask)
+
+    def publish(self, bound: BoundControlIpc) -> None:
+        if bound.transport != "unix" or bound.socket_path != self.socket_path:
+            raise ValueError("bound endpoint does not belong to this Unix socket host")
+
+    def cleanup(self, bound: BoundControlIpc) -> None:
+        try:
+            bound.listener.close()
+        except OSError:
+            pass
+        target = bound.socket_path
+        if target is None:
+            return
+        try:
+            if target.exists() or target.is_symlink():
+                target.unlink()
+        except OSError:
+            pass
+
+
+class WindowsLoopbackHost(ControlIpcHost):
+    def __init__(
+        self,
+        descriptor_path: Optional[Path] = None,
+        *,
+        socket_factory: Callable[[int, int], socket.socket] = socket.socket,
+        max_bind_attempts: int = 3,
+        instance_id: Optional[str] = None,
+        bearer_token: Optional[str] = None,
+    ):
+        self.descriptor_path = _absolute_path(descriptor_path or default_descriptor_path())
+        self.socket_factory = socket_factory
+        self.max_bind_attempts = max(1, max_bind_attempts)
+        self.instance_id = instance_id or secrets.token_hex(16)
+        self.bearer_token = bearer_token or secrets.token_urlsafe(32)
+        _validate_instance_id(self.instance_id)
+        _validate_bearer_token(self.bearer_token)
+
+    def bind(self) -> BoundControlIpc:
+        for attempt in range(1, self.max_bind_attempts + 1):
+            listener = self.socket_factory(socket.AF_INET, socket.SOCK_STREAM)
+            try:
+                exclusive = getattr(socket, "SO_EXCLUSIVEADDRUSE", None)
+                if exclusive is not None:
+                    listener.setsockopt(socket.SOL_SOCKET, exclusive, 1)
+                listener.bind(("127.0.0.1", 0))
+                listener.listen(2048)
+                listener.setblocking(False)
+                host, port = listener.getsockname()[:2]
+                descriptor = ControlIpcDescriptor(
+                    schema_version=CONTROL_IPC_SCHEMA_VERSION,
+                    transport="tcp",
+                    host=str(host),
+                    port=int(port),
+                    instance_id=self.instance_id,
+                    bearer_token=self.bearer_token,
+                )
+                validate_descriptor(descriptor.to_dict())
+                return BoundControlIpc(
+                    listener=listener,
+                    transport="tcp",
+                    descriptor=descriptor,
+                )
+            except OSError as exc:
+                listener.close()
+                if exc.errno == errno.EADDRINUSE and attempt < self.max_bind_attempts:
+                    continue
+                raise
+            except Exception:
+                listener.close()
+                raise
+        raise AssertionError("unreachable")
+
+    def publish(self, bound: BoundControlIpc) -> None:
+        descriptor = bound.descriptor
+        if (
+            bound.transport != "tcp"
+            or descriptor is None
+            or descriptor.instance_id != self.instance_id
+            or not hmac.compare_digest(descriptor.bearer_token, self.bearer_token)
+        ):
+            raise ValueError("bound endpoint does not belong to this Windows host")
+        write_descriptor_atomic(self.descriptor_path, descriptor)
+
+    def cleanup(self, bound: BoundControlIpc) -> None:
+        try:
+            bound.listener.close()
+        except OSError:
+            pass
+        remove_descriptor_if_owned(
+            self.descriptor_path,
+            instance_id=self.instance_id,
+            bearer_token=self.bearer_token,
+        )
+
+
+def select_control_ipc_host(
+    *,
+    platform_name: Optional[str] = None,
+    socket_path: Optional[Path] = None,
+    descriptor_path: Optional[Path] = None,
+) -> ControlIpcHost:
+    platform_name = platform_name or os.name
+    if platform_name == "nt":
+        if socket_path is not None:
+            raise ValueError("Windows control IPC does not accept a Unix socket path")
+        return WindowsLoopbackHost(descriptor_path)
+    return PosixUnixSocketHost(socket_path)
+
+
+def resolve_client_endpoint(
+    *,
+    platform_name: Optional[str] = None,
+    socket_path: Optional[Path] = None,
+    descriptor_path: Optional[Path] = None,
+) -> ControlIpcClientEndpoint:
+    platform_name = platform_name or os.name
+    if socket_path is not None or platform_name != "nt":
+        target = (socket_path or default_unix_socket_path()).expanduser().resolve()
+        return ControlIpcClientEndpoint(transport="unix", socket_path=target)
+    descriptor = load_descriptor(descriptor_path or default_descriptor_path())
+    return ControlIpcClientEndpoint(transport="tcp", descriptor=descriptor)
+
+
+def validate_descriptor(payload: object) -> ControlIpcDescriptor:
+    if not isinstance(payload, dict):
+        raise ControlIpcDescriptorError("control IPC descriptor must be a JSON object")
+    if frozenset(payload) != _DESCRIPTOR_FIELDS:
+        raise ControlIpcDescriptorError("control IPC descriptor fields are invalid")
+
+    schema_version = payload.get("schema_version")
+    if type(schema_version) is not int or schema_version != CONTROL_IPC_SCHEMA_VERSION:
+        raise ControlIpcDescriptorError("control IPC descriptor schema is unsupported")
+    if payload.get("transport") != "tcp":
+        raise ControlIpcDescriptorError("control IPC descriptor transport is unsupported")
+    if payload.get("host") != "127.0.0.1":
+        raise ControlIpcDescriptorError("control IPC descriptor host is not loopback")
+
+    port = payload.get("port")
+    if type(port) is not int or not 1 <= port <= 65535:
+        raise ControlIpcDescriptorError("control IPC descriptor port is invalid")
+
+    instance_id = payload.get("instance_id")
+    bearer_token = payload.get("bearer_token")
+    _validate_instance_id(instance_id)
+    _validate_bearer_token(bearer_token)
+    return ControlIpcDescriptor(
+        schema_version=schema_version,
+        transport="tcp",
+        host="127.0.0.1",
+        port=port,
+        instance_id=instance_id,
+        bearer_token=bearer_token,
+    )
+
+
+def load_descriptor(descriptor_path: Path) -> ControlIpcDescriptor:
+    target = _absolute_path(descriptor_path)
+    if target.is_symlink():
+        raise ControlIpcDescriptorError(f"control IPC descriptor is a symlink at {target}")
+
+    flags = os.O_RDONLY
+    flags |= getattr(os, "O_CLOEXEC", 0)
+    flags |= getattr(os, "O_NOFOLLOW", 0)
+    try:
+        fd = os.open(target, flags)
+    except OSError as exc:
+        raise ControlIpcDescriptorError(f"control IPC descriptor is unavailable at {target}") from exc
+
+    try:
+        metadata = os.fstat(fd)
+        if not stat.S_ISREG(metadata.st_mode):
+            raise ControlIpcDescriptorError(f"control IPC descriptor is not a regular file at {target}")
+        if metadata.st_size <= 0 or metadata.st_size > MAX_DESCRIPTOR_BYTES:
+            raise ControlIpcDescriptorError(f"control IPC descriptor size is invalid at {target}")
+        with os.fdopen(fd, "r", encoding="utf-8") as stream:
+            fd = -1
+            raw = stream.read(MAX_DESCRIPTOR_BYTES + 1)
+    except (OSError, UnicodeError) as exc:
+        raise ControlIpcDescriptorError(f"control IPC descriptor is unreadable at {target}") from exc
+    finally:
+        if fd >= 0:
+            os.close(fd)
+
+    if len(raw.encode("utf-8")) > MAX_DESCRIPTOR_BYTES:
+        raise ControlIpcDescriptorError(f"control IPC descriptor size is invalid at {target}")
+    try:
+        payload = json.loads(raw)
+    except (TypeError, json.JSONDecodeError) as exc:
+        raise ControlIpcDescriptorError(f"control IPC descriptor JSON is invalid at {target}") from exc
+    return validate_descriptor(payload)
+
+
+def write_descriptor_atomic(
+    descriptor_path: Path,
+    descriptor: ControlIpcDescriptor,
+) -> None:
+    descriptor = validate_descriptor(descriptor.to_dict())
+    target = _absolute_path(descriptor_path)
+    _ensure_private_directory(target.parent)
+    with _descriptor_lock(target):
+        fd, temporary_name = tempfile.mkstemp(
+            prefix=f".{target.name}.",
+            suffix=".tmp",
+            dir=target.parent,
+        )
+        temporary = Path(temporary_name)
+        try:
+            try:
+                os.chmod(temporary, 0o600)
+            except OSError:
+                pass
+            with os.fdopen(fd, "w", encoding="utf-8", newline="\n") as stream:
+                fd = -1
+                json.dump(
+                    descriptor.to_dict(),
+                    stream,
+                    ensure_ascii=True,
+                    separators=(",", ":"),
+                    sort_keys=True,
+                )
+                stream.write("\n")
+                stream.flush()
+                os.fsync(stream.fileno())
+            os.replace(temporary, target)
+        finally:
+            if fd >= 0:
+                os.close(fd)
+            try:
+                temporary.unlink(missing_ok=True)
+            except OSError:
+                pass
+
+
+def remove_descriptor_if_owned(
+    descriptor_path: Path,
+    *,
+    instance_id: str,
+    bearer_token: str,
+) -> bool:
+    target = _absolute_path(descriptor_path)
+    try:
+        with _descriptor_lock(target):
+            try:
+                descriptor = load_descriptor(target)
+            except ControlIpcDescriptorError:
+                return False
+            if descriptor.instance_id != instance_id or not hmac.compare_digest(
+                descriptor.bearer_token,
+                bearer_token,
+            ):
+                return False
+            try:
+                target.unlink()
+            except FileNotFoundError:
+                return False
+            return True
+    except OSError:
+        return False
+
+
+def response_instance_matches(
+    descriptor: ControlIpcDescriptor,
+    response_instance_id: Optional[str],
+) -> bool:
+    return bool(response_instance_id) and hmac.compare_digest(
+        descriptor.instance_id,
+        response_instance_id,
+    )
+
+
+def _validate_instance_id(value: object) -> None:
+    if not isinstance(value, str) or _INSTANCE_ID_RE.fullmatch(value) is None:
+        raise ControlIpcDescriptorError("control IPC descriptor instance is invalid")
+
+
+def _validate_bearer_token(value: object) -> None:
+    if not isinstance(value, str) or _BEARER_TOKEN_RE.fullmatch(value) is None:
+        raise ControlIpcDescriptorError("control IPC descriptor credential is invalid")
+
+
+def _ensure_private_directory(directory: Path) -> None:
+    directory.mkdir(parents=True, exist_ok=True, mode=0o700)
+    if os.name != "nt":
+        try:
+            os.chmod(directory, 0o700)
+        except OSError:
+            pass
+
+
+def _absolute_path(path: Path) -> Path:
+    return Path(os.path.abspath(os.fspath(path.expanduser())))
+
+
+@contextmanager
+def _descriptor_lock(descriptor_path: Path) -> Iterator[None]:
+    lock_path = descriptor_path.with_name(f"{descriptor_path.name}.lock")
+    _ensure_private_directory(lock_path.parent)
+    fd = os.open(lock_path, os.O_RDWR | os.O_CREAT, 0o600)
+    try:
+        try:
+            os.chmod(lock_path, 0o600)
+        except OSError:
+            pass
+        if os.fstat(fd).st_size == 0:
+            os.write(fd, b"\0")
+            os.fsync(fd)
+        os.lseek(fd, 0, os.SEEK_SET)
+        if os.name == "nt":
+            import msvcrt
+
+            msvcrt.locking(fd, msvcrt.LK_LOCK, 1)
+        else:
+            import fcntl
+
+            fcntl.flock(fd, fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            os.lseek(fd, 0, os.SEEK_SET)
+            if os.name == "nt":
+                import msvcrt
+
+                msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
+            else:
+                import fcntl
+
+                fcntl.flock(fd, fcntl.LOCK_UN)
+    finally:
+        os.close(fd)

--- a/core/control_ipc.py
+++ b/core/control_ipc.py
@@ -40,6 +40,10 @@ class ControlIpcDescriptorError(ValueError):
     """Raised when the Windows endpoint descriptor is absent or invalid."""
 
 
+class ControlIpcSecurityError(PermissionError):
+    """Raised when a Windows control IPC path is not private to its owner."""
+
+
 @dataclass(frozen=True)
 class ControlIpcDescriptor:
     schema_version: int
@@ -306,7 +310,7 @@ def validate_descriptor(payload: object) -> ControlIpcDescriptor:
 def load_descriptor(descriptor_path: Path) -> ControlIpcDescriptor:
     target = _absolute_path(descriptor_path)
     try:
-        with _descriptor_lock(target):
+        with _descriptor_lock(target, prepare_directory=False):
             return _load_descriptor_unlocked(target)
     except ControlIpcDescriptorError:
         raise
@@ -330,6 +334,8 @@ def _load_descriptor_unlocked(target: Path) -> ControlIpcDescriptor:
         metadata = os.fstat(fd)
         if not stat.S_ISREG(metadata.st_mode):
             raise ControlIpcDescriptorError(f"control IPC descriptor is not a regular file at {target}")
+        if os.name == "nt":
+            _windows_security().validate_file_descriptor(fd, target)
         if metadata.st_size <= 0 or metadata.st_size > MAX_DESCRIPTOR_BYTES:
             raise ControlIpcDescriptorError(f"control IPC descriptor size is invalid at {target}")
         with os.fdopen(fd, "r", encoding="utf-8") as stream:
@@ -356,19 +362,23 @@ def write_descriptor_atomic(
 ) -> None:
     descriptor = validate_descriptor(descriptor.to_dict())
     target = _absolute_path(descriptor_path)
-    _ensure_private_directory(target.parent)
-    with _descriptor_lock(target):
-        fd, temporary_name = tempfile.mkstemp(
-            prefix=f".{target.name}.",
-            suffix=".tmp",
-            dir=target.parent,
-        )
-        temporary = Path(temporary_name)
+    _ensure_private_directory(target.parent, allow_repair=True)
+    with _descriptor_lock(target, prepare_directory=True):
+        if os.name == "nt":
+            fd, temporary = _windows_security().create_private_temporary_file(target)
+        else:
+            fd, temporary_name = tempfile.mkstemp(
+                prefix=f".{target.name}.",
+                suffix=".tmp",
+                dir=target.parent,
+            )
+            temporary = Path(temporary_name)
         try:
-            try:
-                os.chmod(temporary, 0o600)
-            except OSError:
-                pass
+            if os.name != "nt":
+                try:
+                    os.chmod(temporary, 0o600)
+                except OSError:
+                    pass
             with os.fdopen(fd, "w", encoding="utf-8", newline="\n") as stream:
                 fd = -1
                 json.dump(
@@ -381,7 +391,13 @@ def write_descriptor_atomic(
                 stream.write("\n")
                 stream.flush()
                 os.fsync(stream.fileno())
+            if os.name == "nt" and target.exists():
+                if target.is_symlink():
+                    raise ControlIpcSecurityError(f"control IPC descriptor security is invalid at {target}")
+                _windows_security().secure_existing_owned_path(target)
             os.replace(temporary, target)
+            if os.name == "nt":
+                _windows_security().validate_path(target)
         finally:
             if fd >= 0:
                 os.close(fd)
@@ -399,7 +415,7 @@ def remove_descriptor_if_owned(
 ) -> bool:
     target = _absolute_path(descriptor_path)
     try:
-        with _descriptor_lock(target):
+        with _descriptor_lock(target, prepare_directory=False):
             try:
                 descriptor = _load_descriptor_unlocked(target)
             except ControlIpcDescriptorError:
@@ -438,13 +454,15 @@ def _validate_bearer_token(value: object) -> None:
         raise ControlIpcDescriptorError("control IPC descriptor credential is invalid")
 
 
-def _ensure_private_directory(directory: Path) -> None:
+def _ensure_private_directory(directory: Path, *, allow_repair: bool = False) -> None:
+    if os.name == "nt":
+        _windows_security().ensure_private_directory(directory, allow_repair=allow_repair)
+        return
     directory.mkdir(parents=True, exist_ok=True, mode=0o700)
-    if os.name != "nt":
-        try:
-            os.chmod(directory, 0o700)
-        except OSError:
-            pass
+    try:
+        os.chmod(directory, 0o700)
+    except OSError:
+        pass
 
 
 def _absolute_path(path: Path) -> Path:
@@ -452,15 +470,26 @@ def _absolute_path(path: Path) -> Path:
 
 
 @contextmanager
-def _descriptor_lock(descriptor_path: Path) -> Iterator[None]:
+def _descriptor_lock(
+    descriptor_path: Path,
+    *,
+    prepare_directory: bool,
+) -> Iterator[None]:
     lock_path = descriptor_path.with_name(f"{descriptor_path.name}.lock")
-    _ensure_private_directory(lock_path.parent)
-    fd = os.open(lock_path, os.O_RDWR | os.O_CREAT, 0o600)
+    _ensure_private_directory(lock_path.parent, allow_repair=prepare_directory)
+    if os.name == "nt":
+        fd = _windows_security().open_private_lock_file(
+            lock_path,
+            allow_repair=prepare_directory,
+        )
+    else:
+        fd = os.open(lock_path, os.O_RDWR | os.O_CREAT, 0o600)
     try:
-        try:
-            os.chmod(lock_path, 0o600)
-        except OSError:
-            pass
+        if os.name != "nt":
+            try:
+                os.chmod(lock_path, 0o600)
+            except OSError:
+                pass
         if os.fstat(fd).st_size == 0:
             os.write(fd, b"\0")
             os.fsync(fd)
@@ -487,3 +516,549 @@ def _descriptor_lock(descriptor_path: Path) -> Iterator[None]:
                 fcntl.flock(fd, fcntl.LOCK_UN)
     finally:
         os.close(fd)
+
+
+class _WindowsSecurity:
+    """Minimal Win32 owner/DACL operations for control IPC artifacts."""
+
+    _SDDL_REVISION_1 = 1
+    _SE_FILE_OBJECT = 1
+    _OWNER_SECURITY_INFORMATION = 0x00000001
+    _DACL_SECURITY_INFORMATION = 0x00000004
+    _PROTECTED_DACL_SECURITY_INFORMATION = 0x80000000
+    _DACL_CONTROL_MASK = 0x0004 | 0x0008 | 0x0100 | 0x0400 | 0x1000
+    _SE_DACL_PROTECTED = 0x1000
+    _TOKEN_QUERY = 0x0008
+    _TOKEN_USER = 1
+    _ERROR_INSUFFICIENT_BUFFER = 122
+    _ERROR_FILE_EXISTS = 80
+    _ERROR_ALREADY_EXISTS = 183
+    _GENERIC_READ = 0x80000000
+    _GENERIC_WRITE = 0x40000000
+    _FILE_SHARE_READ = 0x00000001
+    _FILE_SHARE_WRITE = 0x00000002
+    _FILE_SHARE_DELETE = 0x00000004
+    _CREATE_NEW = 1
+    _OPEN_ALWAYS = 4
+    _FILE_ATTRIBUTE_NORMAL = 0x00000080
+    _ACL_SIZE_INFORMATION_CLASS = 2
+
+    def __init__(self) -> None:
+        import ctypes
+        from ctypes import wintypes
+
+        self.ctypes = ctypes
+        self.wintypes = wintypes
+        self.advapi32 = ctypes.WinDLL("advapi32", use_last_error=True)
+        self.kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+
+        class SecurityAttributes(ctypes.Structure):
+            _fields_ = [
+                ("nLength", wintypes.DWORD),
+                ("lpSecurityDescriptor", wintypes.LPVOID),
+                ("bInheritHandle", wintypes.BOOL),
+            ]
+
+        class SidAndAttributes(ctypes.Structure):
+            _fields_ = [
+                ("Sid", wintypes.LPVOID),
+                ("Attributes", wintypes.DWORD),
+            ]
+
+        class TokenUser(ctypes.Structure):
+            _fields_ = [("User", SidAndAttributes)]
+
+        class AclSizeInformation(ctypes.Structure):
+            _fields_ = [
+                ("AceCount", wintypes.DWORD),
+                ("AclBytesInUse", wintypes.DWORD),
+                ("AclBytesFree", wintypes.DWORD),
+            ]
+
+        self.SecurityAttributes = SecurityAttributes
+        self.TokenUser = TokenUser
+        self.AclSizeInformation = AclSizeInformation
+        self._configure_functions()
+        self.current_user_sid = self._read_current_user_sid()
+        self.sddl = f"O:{self.current_user_sid}D:P(A;;FA;;;{self.current_user_sid})(A;;FA;;;SY)"
+
+    def _configure_functions(self) -> None:
+        ctypes = self.ctypes
+        wintypes = self.wintypes
+
+        self.advapi32.OpenProcessToken.argtypes = [
+            wintypes.HANDLE,
+            wintypes.DWORD,
+            ctypes.POINTER(wintypes.HANDLE),
+        ]
+        self.advapi32.OpenProcessToken.restype = wintypes.BOOL
+        self.advapi32.GetTokenInformation.argtypes = [
+            wintypes.HANDLE,
+            ctypes.c_int,
+            wintypes.LPVOID,
+            wintypes.DWORD,
+            ctypes.POINTER(wintypes.DWORD),
+        ]
+        self.advapi32.GetTokenInformation.restype = wintypes.BOOL
+        self.advapi32.ConvertSidToStringSidW.argtypes = [
+            wintypes.LPVOID,
+            ctypes.POINTER(wintypes.LPWSTR),
+        ]
+        self.advapi32.ConvertSidToStringSidW.restype = wintypes.BOOL
+        self.advapi32.ConvertStringSecurityDescriptorToSecurityDescriptorW.argtypes = [
+            wintypes.LPCWSTR,
+            wintypes.DWORD,
+            ctypes.POINTER(wintypes.LPVOID),
+            ctypes.POINTER(wintypes.DWORD),
+        ]
+        self.advapi32.ConvertStringSecurityDescriptorToSecurityDescriptorW.restype = wintypes.BOOL
+        self.advapi32.GetSecurityDescriptorOwner.argtypes = [
+            wintypes.LPVOID,
+            ctypes.POINTER(wintypes.LPVOID),
+            ctypes.POINTER(wintypes.BOOL),
+        ]
+        self.advapi32.GetSecurityDescriptorOwner.restype = wintypes.BOOL
+        self.advapi32.GetSecurityDescriptorDacl.argtypes = [
+            wintypes.LPVOID,
+            ctypes.POINTER(wintypes.BOOL),
+            ctypes.POINTER(wintypes.LPVOID),
+            ctypes.POINTER(wintypes.BOOL),
+        ]
+        self.advapi32.GetSecurityDescriptorDacl.restype = wintypes.BOOL
+        self.advapi32.GetSecurityDescriptorControl.argtypes = [
+            wintypes.LPVOID,
+            ctypes.POINTER(wintypes.WORD),
+            ctypes.POINTER(wintypes.DWORD),
+        ]
+        self.advapi32.GetSecurityDescriptorControl.restype = wintypes.BOOL
+        self.advapi32.GetSecurityInfo.argtypes = [
+            wintypes.HANDLE,
+            ctypes.c_int,
+            wintypes.DWORD,
+            ctypes.POINTER(wintypes.LPVOID),
+            ctypes.POINTER(wintypes.LPVOID),
+            ctypes.POINTER(wintypes.LPVOID),
+            ctypes.POINTER(wintypes.LPVOID),
+            ctypes.POINTER(wintypes.LPVOID),
+        ]
+        self.advapi32.GetSecurityInfo.restype = wintypes.DWORD
+        self.advapi32.GetNamedSecurityInfoW.argtypes = [
+            wintypes.LPWSTR,
+            ctypes.c_int,
+            wintypes.DWORD,
+            ctypes.POINTER(wintypes.LPVOID),
+            ctypes.POINTER(wintypes.LPVOID),
+            ctypes.POINTER(wintypes.LPVOID),
+            ctypes.POINTER(wintypes.LPVOID),
+            ctypes.POINTER(wintypes.LPVOID),
+        ]
+        self.advapi32.GetNamedSecurityInfoW.restype = wintypes.DWORD
+        self.advapi32.SetNamedSecurityInfoW.argtypes = [
+            wintypes.LPWSTR,
+            ctypes.c_int,
+            wintypes.DWORD,
+            wintypes.LPVOID,
+            wintypes.LPVOID,
+            wintypes.LPVOID,
+            wintypes.LPVOID,
+        ]
+        self.advapi32.SetNamedSecurityInfoW.restype = wintypes.DWORD
+        self.advapi32.EqualSid.argtypes = [wintypes.LPVOID, wintypes.LPVOID]
+        self.advapi32.EqualSid.restype = wintypes.BOOL
+        self.advapi32.GetAclInformation.argtypes = [
+            wintypes.LPVOID,
+            wintypes.LPVOID,
+            wintypes.DWORD,
+            ctypes.c_int,
+        ]
+        self.advapi32.GetAclInformation.restype = wintypes.BOOL
+        self.advapi32.GetAce.argtypes = [
+            wintypes.LPVOID,
+            wintypes.DWORD,
+            ctypes.POINTER(wintypes.LPVOID),
+        ]
+        self.advapi32.GetAce.restype = wintypes.BOOL
+
+        self.kernel32.GetCurrentProcess.argtypes = []
+        self.kernel32.GetCurrentProcess.restype = wintypes.HANDLE
+        self.kernel32.CloseHandle.argtypes = [wintypes.HANDLE]
+        self.kernel32.CloseHandle.restype = wintypes.BOOL
+        self.kernel32.LocalFree.argtypes = [wintypes.HLOCAL]
+        self.kernel32.LocalFree.restype = wintypes.HLOCAL
+        self.kernel32.CreateDirectoryW.argtypes = [
+            wintypes.LPCWSTR,
+            ctypes.POINTER(self.SecurityAttributes),
+        ]
+        self.kernel32.CreateDirectoryW.restype = wintypes.BOOL
+        self.kernel32.CreateFileW.argtypes = [
+            wintypes.LPCWSTR,
+            wintypes.DWORD,
+            wintypes.DWORD,
+            ctypes.POINTER(self.SecurityAttributes),
+            wintypes.DWORD,
+            wintypes.DWORD,
+            wintypes.HANDLE,
+        ]
+        self.kernel32.CreateFileW.restype = wintypes.HANDLE
+
+    def _read_current_user_sid(self) -> str:
+        ctypes = self.ctypes
+        wintypes = self.wintypes
+        token = wintypes.HANDLE()
+        if not self.advapi32.OpenProcessToken(
+            self.kernel32.GetCurrentProcess(),
+            self._TOKEN_QUERY,
+            ctypes.byref(token),
+        ):
+            self._raise_last_error("cannot open the current process token")
+        try:
+            required = wintypes.DWORD()
+            self.advapi32.GetTokenInformation(
+                token,
+                self._TOKEN_USER,
+                None,
+                0,
+                ctypes.byref(required),
+            )
+            if ctypes.get_last_error() != self._ERROR_INSUFFICIENT_BUFFER:
+                self._raise_last_error("cannot size the current process token")
+            buffer = ctypes.create_string_buffer(required.value)
+            if not self.advapi32.GetTokenInformation(
+                token,
+                self._TOKEN_USER,
+                buffer,
+                required,
+                ctypes.byref(required),
+            ):
+                self._raise_last_error("cannot read the current process token")
+            token_user = ctypes.cast(buffer, ctypes.POINTER(self.TokenUser)).contents
+            sid_text = wintypes.LPWSTR()
+            if not self.advapi32.ConvertSidToStringSidW(
+                token_user.User.Sid,
+                ctypes.byref(sid_text),
+            ):
+                self._raise_last_error("cannot encode the current user SID")
+            try:
+                value = sid_text.value
+                if not value:
+                    raise ControlIpcSecurityError("the current process token has no user SID")
+                return value
+            finally:
+                self.kernel32.LocalFree(ctypes.cast(sid_text, wintypes.HLOCAL))
+        finally:
+            self.kernel32.CloseHandle(token)
+
+    @contextmanager
+    def _security_descriptor(self) -> Iterator[object]:
+        ctypes = self.ctypes
+        wintypes = self.wintypes
+        descriptor = wintypes.LPVOID()
+        size = wintypes.DWORD()
+        if not self.advapi32.ConvertStringSecurityDescriptorToSecurityDescriptorW(
+            self.sddl,
+            self._SDDL_REVISION_1,
+            ctypes.byref(descriptor),
+            ctypes.byref(size),
+        ):
+            self._raise_last_error("cannot construct the private security descriptor")
+        try:
+            yield descriptor
+        finally:
+            self.kernel32.LocalFree(descriptor)
+
+    @contextmanager
+    def _security_attributes(self) -> Iterator[object]:
+        ctypes = self.ctypes
+        with self._security_descriptor() as descriptor:
+            attributes = self.SecurityAttributes(
+                nLength=ctypes.sizeof(self.SecurityAttributes),
+                lpSecurityDescriptor=descriptor,
+                bInheritHandle=False,
+            )
+            yield attributes
+
+    def ensure_private_directory(self, directory: Path, *, allow_repair: bool) -> None:
+        directory = _absolute_path(directory)
+        if directory.exists():
+            if not directory.is_dir() or directory.is_symlink():
+                raise ControlIpcSecurityError(f"control IPC runtime directory security is invalid at {directory}")
+            if allow_repair:
+                self.secure_existing_owned_path(directory)
+            else:
+                self.validate_path(directory)
+            return
+
+        directory.parent.mkdir(parents=True, exist_ok=True)
+        with self._security_attributes() as attributes:
+            if not self.kernel32.CreateDirectoryW(str(directory), self.ctypes.byref(attributes)):
+                error = self.ctypes.get_last_error()
+                if error != self._ERROR_ALREADY_EXISTS:
+                    raise ControlIpcSecurityError(
+                        f"cannot create the control IPC runtime directory at {directory}"
+                    ) from self.ctypes.WinError(error)
+        self.validate_path(directory)
+
+    def open_private_lock_file(self, path: Path, *, allow_repair: bool) -> int:
+        if path.exists():
+            if path.is_symlink() or not path.is_file():
+                raise ControlIpcSecurityError(f"control IPC lock security is invalid at {path}")
+            if allow_repair:
+                self.secure_existing_owned_path(path)
+        fd = self._create_file(
+            path,
+            creation_disposition=self._OPEN_ALWAYS,
+            share_mode=(self._FILE_SHARE_READ | self._FILE_SHARE_WRITE | self._FILE_SHARE_DELETE),
+        )
+        try:
+            self.validate_file_descriptor(fd, path)
+        except Exception:
+            os.close(fd)
+            raise
+        return fd
+
+    def create_private_temporary_file(self, target: Path) -> tuple[int, Path]:
+        for _ in range(128):
+            temporary = target.with_name(f".{target.name}.{secrets.token_hex(16)}.tmp")
+            try:
+                fd = self._create_file(
+                    temporary,
+                    creation_disposition=self._CREATE_NEW,
+                    share_mode=0,
+                )
+            except FileExistsError:
+                continue
+            try:
+                self.validate_file_descriptor(fd, temporary)
+            except Exception:
+                os.close(fd)
+                temporary.unlink(missing_ok=True)
+                raise
+            return fd, temporary
+        raise FileExistsError(f"cannot allocate a private descriptor beside {target}")
+
+    def _create_file(
+        self,
+        path: Path,
+        *,
+        creation_disposition: int,
+        share_mode: int,
+    ) -> int:
+        import msvcrt
+
+        with self._security_attributes() as attributes:
+            handle = self.kernel32.CreateFileW(
+                str(path),
+                self._GENERIC_READ | self._GENERIC_WRITE,
+                share_mode,
+                self.ctypes.byref(attributes),
+                creation_disposition,
+                self._FILE_ATTRIBUTE_NORMAL,
+                None,
+            )
+        invalid_handle = self.ctypes.c_void_p(-1).value
+        if handle == invalid_handle:
+            error = self.ctypes.get_last_error()
+            if error in {self._ERROR_FILE_EXISTS, self._ERROR_ALREADY_EXISTS}:
+                raise FileExistsError(error, os.strerror(error), str(path))
+            raise ControlIpcSecurityError(
+                f"cannot create the private control IPC file at {path}"
+            ) from self.ctypes.WinError(error)
+        try:
+            return msvcrt.open_osfhandle(
+                handle,
+                os.O_RDWR | getattr(os, "O_BINARY", 0),
+            )
+        except Exception:
+            self.kernel32.CloseHandle(handle)
+            raise
+
+    def secure_existing_owned_path(self, path: Path) -> None:
+        if not self._named_path_owner_matches(path):
+            raise ControlIpcSecurityError(f"control IPC path is not owned by the current user at {path}")
+        with self._security_descriptor() as expected:
+            expected_dacl = self._descriptor_dacl(expected)
+            result = self.advapi32.SetNamedSecurityInfoW(
+                str(path),
+                self._SE_FILE_OBJECT,
+                self._DACL_SECURITY_INFORMATION | self._PROTECTED_DACL_SECURITY_INFORMATION,
+                None,
+                None,
+                expected_dacl,
+                None,
+            )
+            if result:
+                raise ControlIpcSecurityError(
+                    f"cannot secure the control IPC path at {path}"
+                ) from self.ctypes.WinError(result)
+        self.validate_path(path)
+
+    def validate_path(self, path: Path) -> None:
+        ctypes = self.ctypes
+        owner = self.wintypes.LPVOID()
+        dacl = self.wintypes.LPVOID()
+        descriptor = self.wintypes.LPVOID()
+        result = self.advapi32.GetNamedSecurityInfoW(
+            str(path),
+            self._SE_FILE_OBJECT,
+            self._OWNER_SECURITY_INFORMATION | self._DACL_SECURITY_INFORMATION,
+            ctypes.byref(owner),
+            None,
+            ctypes.byref(dacl),
+            None,
+            ctypes.byref(descriptor),
+        )
+        if result:
+            raise ControlIpcSecurityError(f"cannot inspect the control IPC path at {path}") from ctypes.WinError(result)
+        try:
+            self._validate_security_descriptor(owner, dacl, descriptor, path)
+        finally:
+            self.kernel32.LocalFree(descriptor)
+
+    def validate_file_descriptor(self, fd: int, path: Path) -> None:
+        import msvcrt
+
+        ctypes = self.ctypes
+        owner = self.wintypes.LPVOID()
+        dacl = self.wintypes.LPVOID()
+        descriptor = self.wintypes.LPVOID()
+        result = self.advapi32.GetSecurityInfo(
+            msvcrt.get_osfhandle(fd),
+            self._SE_FILE_OBJECT,
+            self._OWNER_SECURITY_INFORMATION | self._DACL_SECURITY_INFORMATION,
+            ctypes.byref(owner),
+            None,
+            ctypes.byref(dacl),
+            None,
+            ctypes.byref(descriptor),
+        )
+        if result:
+            raise ControlIpcSecurityError(f"cannot inspect the control IPC file at {path}") from ctypes.WinError(result)
+        try:
+            self._validate_security_descriptor(owner, dacl, descriptor, path)
+        finally:
+            self.kernel32.LocalFree(descriptor)
+
+    def _named_path_owner_matches(self, path: Path) -> bool:
+        ctypes = self.ctypes
+        owner = self.wintypes.LPVOID()
+        descriptor = self.wintypes.LPVOID()
+        result = self.advapi32.GetNamedSecurityInfoW(
+            str(path),
+            self._SE_FILE_OBJECT,
+            self._OWNER_SECURITY_INFORMATION,
+            ctypes.byref(owner),
+            None,
+            None,
+            None,
+            ctypes.byref(descriptor),
+        )
+        if result:
+            raise ControlIpcSecurityError(f"cannot inspect the control IPC path owner at {path}") from ctypes.WinError(
+                result
+            )
+        try:
+            with self._security_descriptor() as expected:
+                expected_owner = self._descriptor_owner(expected)
+                return bool(owner) and bool(self.advapi32.EqualSid(owner, expected_owner))
+        finally:
+            self.kernel32.LocalFree(descriptor)
+
+    def _validate_security_descriptor(
+        self,
+        owner: object,
+        dacl: object,
+        descriptor: object,
+        path: Path,
+    ) -> None:
+        control = self._descriptor_control(descriptor)
+        with self._security_descriptor() as expected:
+            expected_owner = self._descriptor_owner(expected)
+            expected_dacl = self._descriptor_dacl(expected)
+            expected_control = self._descriptor_control(expected)
+            valid = (
+                bool(owner)
+                and bool(dacl)
+                and bool(self.advapi32.EqualSid(owner, expected_owner))
+                and bool(control & self._SE_DACL_PROTECTED)
+                and (control & self._DACL_CONTROL_MASK) == (expected_control & self._DACL_CONTROL_MASK)
+                and self._acl_signature(dacl) == self._acl_signature(expected_dacl)
+            )
+        if not valid:
+            raise ControlIpcSecurityError(f"control IPC path owner or DACL is invalid at {path}")
+
+    def _descriptor_owner(self, descriptor: object) -> object:
+        owner = self.wintypes.LPVOID()
+        defaulted = self.wintypes.BOOL()
+        if not self.advapi32.GetSecurityDescriptorOwner(
+            descriptor,
+            self.ctypes.byref(owner),
+            self.ctypes.byref(defaulted),
+        ):
+            self._raise_last_error("cannot read the private descriptor owner")
+        if not owner:
+            raise ControlIpcSecurityError("private control IPC descriptor has no owner")
+        return owner
+
+    def _descriptor_dacl(self, descriptor: object) -> object:
+        present = self.wintypes.BOOL()
+        dacl = self.wintypes.LPVOID()
+        defaulted = self.wintypes.BOOL()
+        if not self.advapi32.GetSecurityDescriptorDacl(
+            descriptor,
+            self.ctypes.byref(present),
+            self.ctypes.byref(dacl),
+            self.ctypes.byref(defaulted),
+        ):
+            self._raise_last_error("cannot read the private descriptor DACL")
+        if not present or not dacl:
+            raise ControlIpcSecurityError("private control IPC descriptor has no DACL")
+        return dacl
+
+    def _descriptor_control(self, descriptor: object) -> int:
+        control = self.wintypes.WORD()
+        revision = self.wintypes.DWORD()
+        if not self.advapi32.GetSecurityDescriptorControl(
+            descriptor,
+            self.ctypes.byref(control),
+            self.ctypes.byref(revision),
+        ):
+            self._raise_last_error("cannot read control IPC DACL controls")
+        return control.value
+
+    def _acl_signature(self, acl: object) -> tuple[int, tuple[bytes, ...]]:
+        info = self.AclSizeInformation()
+        if not self.advapi32.GetAclInformation(
+            acl,
+            self.ctypes.byref(info),
+            self.ctypes.sizeof(info),
+            self._ACL_SIZE_INFORMATION_CLASS,
+        ):
+            self._raise_last_error("cannot inspect a control IPC DACL")
+        revision = self.ctypes.string_at(acl, 1)[0]
+        entries: list[bytes] = []
+        for index in range(info.AceCount):
+            ace = self.wintypes.LPVOID()
+            if not self.advapi32.GetAce(acl, index, self.ctypes.byref(ace)):
+                self._raise_last_error("cannot inspect a control IPC DACL entry")
+            header = self.ctypes.string_at(ace, 4)
+            size = int.from_bytes(header[2:4], "little")
+            if size < 4 or size > info.AclBytesInUse:
+                raise ControlIpcSecurityError("control IPC DACL entry size is invalid")
+            entries.append(self.ctypes.string_at(ace, size))
+        return revision, tuple(entries)
+
+    def _raise_last_error(self, message: str) -> None:
+        error = self.ctypes.get_last_error()
+        raise ControlIpcSecurityError(message) from self.ctypes.WinError(error)
+
+
+_WINDOWS_SECURITY: Optional[_WindowsSecurity] = None
+
+
+def _windows_security() -> _WindowsSecurity:
+    global _WINDOWS_SECURITY
+    if _WINDOWS_SECURITY is None:
+        if os.name != "nt":
+            raise RuntimeError("Windows control IPC security is unavailable")
+        _WINDOWS_SECURITY = _WindowsSecurity()
+    return _WINDOWS_SECURITY

--- a/core/control_ipc.py
+++ b/core/control_ipc.py
@@ -305,6 +305,16 @@ def validate_descriptor(payload: object) -> ControlIpcDescriptor:
 
 def load_descriptor(descriptor_path: Path) -> ControlIpcDescriptor:
     target = _absolute_path(descriptor_path)
+    try:
+        with _descriptor_lock(target):
+            return _load_descriptor_unlocked(target)
+    except ControlIpcDescriptorError:
+        raise
+    except OSError as exc:
+        raise ControlIpcDescriptorError(f"control IPC descriptor is unavailable at {target}") from exc
+
+
+def _load_descriptor_unlocked(target: Path) -> ControlIpcDescriptor:
     if target.is_symlink():
         raise ControlIpcDescriptorError(f"control IPC descriptor is a symlink at {target}")
 
@@ -391,7 +401,7 @@ def remove_descriptor_if_owned(
     try:
         with _descriptor_lock(target):
             try:
-                descriptor = load_descriptor(target)
+                descriptor = _load_descriptor_unlocked(target)
             except ControlIpcDescriptorError:
                 return False
             if descriptor.instance_id != instance_id or not hmac.compare_digest(

--- a/core/control_ipc.py
+++ b/core/control_ipc.py
@@ -1036,13 +1036,13 @@ class _WindowsSecurity:
             self._raise_last_error("cannot inspect a control IPC DACL")
         revision = self.ctypes.string_at(acl, 1)[0]
         entries: list[bytes] = []
-        for index in range(info.AceCount):
+        for index in range(info.AceCount.value):
             ace = self.wintypes.LPVOID()
             if not self.advapi32.GetAce(acl, index, self.ctypes.byref(ace)):
                 self._raise_last_error("cannot inspect a control IPC DACL entry")
             header = self.ctypes.string_at(ace, 4)
             size = int.from_bytes(header[2:4], "little")
-            if size < 4 or size > info.AclBytesInUse:
+            if size < 4 or size > info.AclBytesInUse.value:
                 raise ControlIpcSecurityError("control IPC DACL entry size is invalid")
             entries.append(self.ctypes.string_at(ace, size))
         return revision, tuple(entries)

--- a/core/control_ipc.py
+++ b/core/control_ipc.py
@@ -526,7 +526,7 @@ class _WindowsSecurity:
     _OWNER_SECURITY_INFORMATION = 0x00000001
     _DACL_SECURITY_INFORMATION = 0x00000004
     _PROTECTED_DACL_SECURITY_INFORMATION = 0x80000000
-    _DACL_CONTROL_MASK = 0x0004 | 0x0008 | 0x0100 | 0x0400 | 0x1000
+    _SE_DACL_PRESENT = 0x0004
     _SE_DACL_PROTECTED = 0x1000
     _TOKEN_QUERY = 0x0008
     _TOKEN_USER = 1
@@ -974,13 +974,12 @@ class _WindowsSecurity:
         with self._security_descriptor() as expected:
             expected_owner = self._descriptor_owner(expected)
             expected_dacl = self._descriptor_dacl(expected)
-            expected_control = self._descriptor_control(expected)
             valid = (
                 bool(owner)
                 and bool(dacl)
                 and bool(self.advapi32.EqualSid(owner, expected_owner))
+                and bool(control & self._SE_DACL_PRESENT)
                 and bool(control & self._SE_DACL_PROTECTED)
-                and (control & self._DACL_CONTROL_MASK) == (expected_control & self._DACL_CONTROL_MASK)
                 and self._acl_signature(dacl) == self._acl_signature(expected_dacl)
             )
         if not valid:
@@ -1025,7 +1024,7 @@ class _WindowsSecurity:
             self._raise_last_error("cannot read control IPC DACL controls")
         return control.value
 
-    def _acl_signature(self, acl: object) -> tuple[int, tuple[bytes, ...]]:
+    def _acl_signature(self, acl: object) -> tuple[bytes, ...]:
         info = self.AclSizeInformation()
         if not self.advapi32.GetAclInformation(
             acl,
@@ -1034,7 +1033,6 @@ class _WindowsSecurity:
             self._ACL_SIZE_INFORMATION_CLASS,
         ):
             self._raise_last_error("cannot inspect a control IPC DACL")
-        revision = self.ctypes.string_at(acl, 1)[0]
         ace_count = int(info.AceCount)
         acl_bytes_in_use = int(info.AclBytesInUse)
         entries: list[bytes] = []
@@ -1047,7 +1045,7 @@ class _WindowsSecurity:
             if size < 4 or size > acl_bytes_in_use:
                 raise ControlIpcSecurityError("control IPC DACL entry size is invalid")
             entries.append(self.ctypes.string_at(ace, size))
-        return revision, tuple(entries)
+        return tuple(sorted(entries))
 
     def _raise_last_error(self, message: str) -> None:
         error = self.ctypes.get_last_error()

--- a/core/control_ipc.py
+++ b/core/control_ipc.py
@@ -1035,14 +1035,16 @@ class _WindowsSecurity:
         ):
             self._raise_last_error("cannot inspect a control IPC DACL")
         revision = self.ctypes.string_at(acl, 1)[0]
+        ace_count = int(info.AceCount)
+        acl_bytes_in_use = int(info.AclBytesInUse)
         entries: list[bytes] = []
-        for index in range(info.AceCount.value):
+        for index in range(ace_count):
             ace = self.wintypes.LPVOID()
             if not self.advapi32.GetAce(acl, index, self.ctypes.byref(ace)):
                 self._raise_last_error("cannot inspect a control IPC DACL entry")
             header = self.ctypes.string_at(ace, 4)
             size = int.from_bytes(header[2:4], "little")
-            if size < 4 or size > info.AclBytesInUse.value:
+            if size < 4 or size > acl_bytes_in_use:
                 raise ControlIpcSecurityError("control IPC DACL entry size is invalid")
             entries.append(self.ctypes.string_at(ace, size))
         return revision, tuple(entries)

--- a/core/controller.py
+++ b/core/controller.py
@@ -1431,7 +1431,7 @@ class Controller:
             self.show_git_checkpoint_service.start()
             self._im_thread = threading.Thread(target=self._run_im_runtime, name="im-runtime", daemon=True)
             self._im_thread.start()
-            # Internal Unix-socket ASGI server for the Web UI / future
+            # Internal control-IPC ASGI server for the Web UI / future
             # ``vibe agent run --sync`` cross-process callers. Lives on
             # the same loop as the IM dispatch path so they share one
             # asyncio scheduler. See core/internal_server.py.
@@ -1451,18 +1451,19 @@ class Controller:
             logger.error(f"Error in main run loop: {e}", exc_info=True)
         finally:
             self.cleanup_sync()
-            # Best-effort: remove the dispatch socket so the next controller
-            # boot starts from a clean filesystem state. uvicorn unlinks
-            # the path on exit when it bound the socket itself, but it
-            # can be left behind on hard crashes.
+            # Let the transport owner close its listener and remove only the
+            # endpoint it published. This is required for the Windows descriptor:
+            # a stale Controller must not unlink a successor's endpoint.
             try:
-                from core import internal_server as _internal_server
-
-                sock_path = _internal_server.default_socket_path()
-                if sock_path.exists():
-                    sock_path.unlink()
-            except Exception:
+                internal_task = getattr(self, "_internal_server_task", None)
+                if internal_task is not None and not internal_task.done():
+                    internal_task.cancel()
+                    self._loop.run_until_complete(internal_task)
+            except asyncio.CancelledError:
                 pass
+            except Exception as exc:
+                logger.debug("Internal control IPC cleanup skipped: %s", exc)
+            self._internal_server_task = None
             if self._loop is not None:
                 try:
                     self._loop.stop()

--- a/core/internal_server.py
+++ b/core/internal_server.py
@@ -1,12 +1,11 @@
-"""Controller-side ASGI server bound to a Unix Domain Socket.
+"""Controller-side ASGI server on the platform control IPC transport.
 
 This is the C4 piece of Plan 2 from
 ``docs/plans/workbench-dispatch-architecture.md``: the controller process
-exposes a minimal FastAPI app on
-``~/.vibe_remote/state/dispatch.sock`` so cross-process callers (the
-separate UI server subprocess, future ``vibe agent run --sync`` flows)
-can invoke ``core.services.dispatch.dispatch_turn`` and stream the
-agent's output back over SSE chunked response.
+exposes a minimal FastAPI app over a POSIX UDS or authenticated Windows
+loopback listener so cross-process callers can invoke
+``core.services.dispatch.dispatch_turn`` and stream the agent's output back
+over an SSE chunked response.
 
 Three properties matter:
 
@@ -14,12 +13,10 @@ Three properties matter:
    background ``asyncio.Task`` on the loop that ``Controller.run()``
    creates. IM adapters share that loop. No cross-loop futures, no
    second uvicorn worker, no thread bridge.
-2. **Local-only.** Unix sockets are bind to a file path on the local
-   filesystem; no TCP listen, so external network exposure is
-   impossible.
-3. **Restrictive permissions.** The socket file is created under a
-   restrictive umask and chmod'd to ``0o600`` when the filesystem supports
-   it — defense in depth against shared hosts.
+2. **Local-only.** POSIX binds a Unix socket. Windows binds an authenticated
+   ephemeral listener on the literal IPv4 loopback address.
+3. **Restrictive discovery.** Unix sockets and Windows endpoint descriptors
+   use the narrowest practical current-user permissions.
 
 The endpoint set is intentionally tiny for v1 (``dispatch`` + a stub
 ``cancel``); follow-ups can grow it without changing the bind contract.
@@ -28,9 +25,9 @@ The endpoint set is intentionally tiny for v1 (``dispatch`` + a stub
 from __future__ import annotations
 
 import asyncio
+import hmac
 import json
 import logging
-import os
 import socket
 from pathlib import Path
 from types import SimpleNamespace
@@ -40,7 +37,7 @@ from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import JSONResponse, StreamingResponse
 from sqlalchemy.exc import IntegrityError
 
-from config import paths
+from core import control_ipc
 from core.services.dispatch import SOURCE_HUMAN, SOURCE_SCHEDULED, dispatch_turn
 from modules.im.base import MessageContext
 from storage.db import get_cached_sqlite_engine
@@ -60,13 +57,15 @@ def default_socket_path() -> Path:
     support Unix-socket permission operations.
     """
 
-    override = os.environ.get("VIBE_INTERNAL_DISPATCH_SOCKET")
-    if override:
-        return Path(override).expanduser()
-    return paths.get_state_dir() / "dispatch.sock"
+    return control_ipc.default_unix_socket_path()
 
 
-def create_app(controller: "Controller") -> FastAPI:
+def create_app(
+    controller: "Controller",
+    *,
+    instance_id: Optional[str] = None,
+    bearer_token: Optional[str] = None,
+) -> FastAPI:
     """Build the minimal FastAPI app the internal server exposes.
 
     Factored out so tests can mount the same routes against a fake
@@ -82,6 +81,28 @@ def create_app(controller: "Controller") -> FastAPI:
         redoc_url=None,
         openapi_url=None,
     )
+    if (instance_id is None) != (bearer_token is None):
+        raise ValueError("Windows control IPC requires both instance ID and bearer token")
+    if instance_id is not None and bearer_token is not None:
+
+        @app.middleware("http")
+        async def _authenticate_windows_control_ipc(request: Request, call_next):
+            scheme, separator, credential = request.headers.get("authorization", "").partition(" ")
+            authorized = (
+                separator == " "
+                and scheme.lower() == "bearer"
+                and bool(credential)
+                and hmac.compare_digest(credential, bearer_token)
+            )
+            if not authorized:
+                return JSONResponse(
+                    status_code=401,
+                    content={"detail": "unauthorized"},
+                    headers={"WWW-Authenticate": "Bearer"},
+                )
+            response = await call_next(request)
+            response.headers[control_ipc.CONTROL_IPC_INSTANCE_HEADER] = instance_id
+            return response
 
     # In-flight ``dispatch_turn`` tasks per session, each a ``Turn`` holding the
     # task + the routing ``MessageContext`` the turn STARTED under. The cancel
@@ -568,26 +589,33 @@ def create_app(controller: "Controller") -> FastAPI:
     return app
 
 
-async def serve(controller: "Controller", *, socket_path: Optional[Path] = None) -> None:
+async def serve(
+    controller: "Controller",
+    *,
+    socket_path: Optional[Path] = None,
+    descriptor_path: Optional[Path] = None,
+    platform_name: Optional[str] = None,
+) -> None:
     """Run the internal server forever on the current event loop.
 
-    Returns when the underlying uvicorn server exits (typically when the
-    controller's loop is shut down). Each call binds a fresh socket
-    file; pre-existing files at ``socket_path`` are removed first so
-    restarts don't fail with "address already in use".
-
-    Permissions: we tighten ``os.umask`` to ``0o077`` *before* uvicorn
-    binds the socket so the file is created with mode ``0o700`` and is
-    never readable / connectable by other local users — even briefly.
-    A best-effort post-bind ``os.chmod`` then forces the final mode in
-    case the platform's umask handling differs (some BSDs ignore umask
-    for AF_UNIX bind). Without the umask wrap there is a TOCTOU window
-    where the socket would be world-accessible between bind and chmod.
+    Returns when the underlying uvicorn server exits. POSIX pre-binds the
+    existing restrictive UDS endpoint. Windows pre-binds an authenticated
+    ephemeral loopback listener and atomically publishes its descriptor before
+    uvicorn starts accepting requests.
     """
 
     import uvicorn
 
-    app = create_app(controller)
+    host = control_ipc.select_control_ipc_host(
+        platform_name=platform_name,
+        socket_path=socket_path,
+        descriptor_path=descriptor_path,
+    )
+    app = create_app(
+        controller,
+        instance_id=host.instance_id,
+        bearer_token=host.bearer_token,
+    )
     manager = getattr(controller, "session_turns", None)
     recover_queue = getattr(manager, "recover_persisted_agent_run_queue", None)
     if callable(recover_queue):
@@ -609,19 +637,12 @@ async def serve(controller: "Controller", *, socket_path: Optional[Path] = None)
     )
     server = uvicorn.Server(config)
 
-    listener, target = _bind_socket(socket_path)
+    bound = host.bind()
     try:
-        await server.serve(sockets=[listener])
+        host.publish(bound)
+        await server.serve(sockets=[bound.listener])
     finally:
-        try:
-            listener.close()
-        except OSError:
-            pass
-        try:
-            if target.exists() or target.is_symlink():
-                target.unlink()
-        except OSError:
-            logger.debug("could not unlink internal dispatch socket %s", target, exc_info=True)
+        host.cleanup(bound)
 
 
 def _bind_socket(socket_path: Optional[Path] = None) -> tuple[socket.socket, Path]:
@@ -633,33 +654,20 @@ def _bind_socket(socket_path: Optional[Path] = None) -> tuple[socket.socket, Pat
     uvicorn's path chmod while keeping the endpoint local-only.
     """
 
-    target = (socket_path or default_socket_path()).expanduser().resolve()
-    target.parent.mkdir(parents=True, exist_ok=True)
-    if target.exists() or target.is_symlink():
-        try:
-            target.unlink()
-        except OSError:
-            logger.warning("could not unlink stale dispatch socket %s; bind may fail", target)
-
-    previous_umask = os.umask(0o077)
-    listener = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-    try:
-        listener.bind(str(target))
-        listener.listen(2048)
-        listener.setblocking(False)
-        try:
-            os.chmod(target, 0o600)
-        except OSError:
-            logger.warning("failed to chmod internal dispatch socket %s", target, exc_info=True)
-        return listener, target
-    except Exception:
-        listener.close()
-        raise
-    finally:
-        os.umask(previous_umask)
+    bound = control_ipc.PosixUnixSocketHost(socket_path).bind()
+    if bound.socket_path is None:
+        bound.listener.close()
+        raise RuntimeError("Unix control IPC bind returned no socket path")
+    return bound.listener, bound.socket_path
 
 
-def start(controller: "Controller", *, socket_path: Optional[Path] = None) -> asyncio.Task:
+def start(
+    controller: "Controller",
+    *,
+    socket_path: Optional[Path] = None,
+    descriptor_path: Optional[Path] = None,
+    platform_name: Optional[str] = None,
+) -> asyncio.Task:
     """Schedule the internal server to run on the controller's loop.
 
     Called from ``Controller.run`` once the loop is alive. Returns the
@@ -668,7 +676,15 @@ def start(controller: "Controller", *, socket_path: Optional[Path] = None) -> as
     """
 
     loop = asyncio.get_event_loop()
-    task = loop.create_task(serve(controller, socket_path=socket_path), name="internal-dispatch-server")
+    task = loop.create_task(
+        serve(
+            controller,
+            socket_path=socket_path,
+            descriptor_path=descriptor_path,
+            platform_name=platform_name,
+        ),
+        name="internal-dispatch-server",
+    )
 
     def _on_done(t: asyncio.Task) -> None:
         if t.cancelled():

--- a/core/internal_server.py
+++ b/core/internal_server.py
@@ -34,7 +34,7 @@ from types import SimpleNamespace
 from typing import Any, Optional, TYPE_CHECKING
 
 from fastapi import FastAPI, HTTPException, Request
-from fastapi.responses import JSONResponse, StreamingResponse
+from fastapi.responses import JSONResponse, PlainTextResponse, StreamingResponse
 from sqlalchemy.exc import IntegrityError
 
 from core import control_ipc
@@ -84,6 +84,14 @@ def create_app(
     if (instance_id is None) != (bearer_token is None):
         raise ValueError("Windows control IPC requires both instance ID and bearer token")
     if instance_id is not None and bearer_token is not None:
+
+        @app.exception_handler(Exception)
+        async def _windows_control_ipc_server_error(_request: Request, _exc: Exception):
+            return PlainTextResponse(
+                "Internal Server Error",
+                status_code=500,
+                headers={control_ipc.CONTROL_IPC_INSTANCE_HEADER: instance_id},
+            )
 
         @app.middleware("http")
         async def _authenticate_windows_control_ipc(request: Request, call_next):

--- a/docs/plans/windows-control-ipc.md
+++ b/docs/plans/windows-control-ipc.md
@@ -1,0 +1,243 @@
+# Windows Controller Control IPC
+
+## Status
+
+- Owner: Avibe Controller control IPC
+- Scope: the existing internal HTTP routes and SSE streams
+- POSIX transport: unchanged Unix-domain socket
+- Windows transport: authenticated ephemeral IPv4 loopback TCP
+- Contract version: 1
+
+## Goal
+
+The Controller and its local UI/CLI child processes need one HTTP transport on
+native Windows without changing the routes, response bodies, or SSE event
+ordering that already run over a Unix-domain socket on POSIX.
+
+This contract does not introduce custom HTTP over named pipes. It does not
+change Runtime process ownership, Tauri lifecycle, terminal, Vault credential
+IPC, agent backends, Show Runtime, dependency installation, or packaging.
+
+## Endpoint Selection
+
+### POSIX
+
+POSIX keeps the existing endpoint and behavior:
+
+- default socket: `${AVIBE_HOME}/state/dispatch.sock`;
+- override: `VIBE_INTERNAL_DISPATCH_SOCKET`;
+- transport: `AF_UNIX` stream socket;
+- socket mode: best-effort `0600` under a restrictive bind-time umask;
+- HTTP base URL used by clients: `http://localhost`;
+- no bearer header or endpoint descriptor.
+
+An explicit `socket_path` passed by an existing caller remains an explicit UDS
+endpoint. Existing POSIX callers do not read the Windows descriptor.
+
+### Windows
+
+The Controller pre-binds an `AF_INET` listener to `127.0.0.1:0`, calls
+`listen`, and then publishes:
+
+`%AVIBE_HOME%\runtime\control-ipc.json`
+
+`AVIBE_HOME` retains its existing meaning. The default therefore lives below
+the current user's Avibe home, not a machine-wide temporary directory.
+
+The UTF-8 JSON descriptor has exactly this version-1 shape:
+
+```json
+{
+  "schema_version": 1,
+  "transport": "tcp",
+  "host": "127.0.0.1",
+  "port": 49152,
+  "instance_id": "d69b9554dfb64cb6a1ca1df963fb3888",
+  "bearer_token": "43-or-more-URL-safe-random-characters"
+}
+```
+
+| Field | Producer | Consumer | Contract |
+| --- | --- | --- | --- |
+| `schema_version` | Controller host | internal clients | Integer `1`; any other value is unsupported |
+| `transport` | Controller host | internal clients | Literal `tcp` |
+| `host` | Controller host | internal clients | Literal `127.0.0.1`; hostnames, wildcard addresses, and non-loopback addresses are rejected |
+| `port` | bound listener | internal clients | Integer `1..65535`; it is read from the pre-bound listener |
+| `instance_id` | Controller host | server middleware and internal clients | 128-bit random lowercase hexadecimal identifier |
+| `bearer_token` | Controller host | server middleware and internal clients | At least 256 bits from the OS CSPRNG, encoded as URL-safe text |
+
+Unknown top-level fields are rejected in version 1. The descriptor is a local
+secret because it contains the bearer token.
+
+The Controller creates the runtime directory with the narrowest practical
+user-only semantics, creates descriptor and lock files as `0600` where mode
+bits are supported, and relies on the current user's inherited profile DACL on
+Windows. It never widens permissions. Descriptor contents, authorization
+headers, and bearer tokens must not appear in logs, exceptions, HTTP response
+bodies, or test failure output.
+
+## Producer And Consumer Ownership
+
+The Controller-side `ControlIpcHost` owns:
+
+1. transport selection;
+2. listener creation and pre-bind;
+3. instance ID and bearer generation;
+4. atomic descriptor publication;
+5. request authentication and instance response headers on Windows;
+6. owner-safe endpoint cleanup.
+
+`vibe.internal_client` owns:
+
+1. platform-specific endpoint discovery;
+2. strict descriptor parsing;
+3. attaching authentication to every Windows request and stream;
+4. checking the responding instance on every Windows response and stream;
+5. translating discovery, connect, authentication, and stale-instance failures
+   into the existing unavailable/timeout behavior.
+
+Any internal caller that opens `dispatch.sock` directly instead of using the
+shared client connection contract remains POSIX-only until its owning lane
+migrates it. The Windows server never provides an unauthenticated compatibility
+path for such callers.
+
+## Authentication And Instance Binding
+
+Every Windows request, including `GET /internal/health`, both SSE routes, and
+all mutating routes, carries:
+
+```text
+Authorization: Bearer <bearer_token>
+```
+
+The server compares the credential in constant time. Missing, malformed, or
+incorrect credentials receive a generic `401` response. The response does not
+echo the credential or explain which part failed.
+
+Every authenticated Windows response carries:
+
+```text
+X-Avibe-Control-Instance: <instance_id>
+```
+
+The client compares that value with the descriptor's `instance_id` before it
+accepts a response or consumes an SSE body. A missing or mismatched header is a
+stale-instance failure. This prevents a stale descriptor from silently
+connecting to an unrelated listener or a successor Controller that reused the
+same port.
+
+POSIX remains authenticated by possession and filesystem permissions of the
+Unix socket and does not require these HTTP headers.
+
+## Descriptor Validation
+
+A Windows client rejects the descriptor before opening a connection when any
+of the following is true:
+
+- the path is absent, a symlink, not a regular file, unreadable, or larger than
+  the bounded descriptor size;
+- JSON is malformed, is not an object, has missing or unknown fields, or uses
+  the wrong primitive types;
+- `schema_version` or `transport` is unsupported;
+- `host` is not exactly `127.0.0.1`;
+- `port` is outside `1..65535`;
+- `instance_id` is not the version-1 128-bit hexadecimal form;
+- `bearer_token` is not the version-1 URL-safe minimum-strength form.
+
+Errors identify only the descriptor category and path. They never include raw
+descriptor data.
+
+## Startup And Atomic Publication
+
+Windows startup is ordered:
+
+1. create the runtime directory and user-only lock file;
+2. create a fresh instance ID and bearer token;
+3. create a fresh TCP socket;
+4. enable exclusive-address semantics where Windows supports them;
+5. bind to `127.0.0.1:0`, call `listen`, and set non-blocking mode;
+6. read the assigned port from `getsockname`;
+7. write and `fsync` a user-only temporary descriptor in the runtime directory;
+8. while holding the descriptor lock, atomically replace
+   `control-ipc.json`;
+9. hand the already-bound listener to uvicorn.
+
+The stable descriptor never contains an unbound or requested port. Bind
+failure publishes nothing. Publication failure closes the listener and leaves
+the previous stable descriptor untouched.
+
+An `EADDRINUSE` result while binding the ephemeral listener is retried with a
+fresh socket up to three total bind attempts. Other bind errors fail startup
+immediately. The OS still selects every candidate port; Avibe does not scan or
+persist a preferred port.
+
+## Shutdown And Stale Instances
+
+Graceful shutdown first stops the server task and closes its listener. The
+Windows host then acquires the same descriptor lock used by publication,
+re-reads the stable descriptor, and removes it only when both `instance_id` and
+`bearer_token` match the current host.
+
+A stale Controller whose descriptor has already been atomically replaced by a
+successor therefore leaves the successor descriptor untouched. Missing,
+malformed, or non-owned descriptors are also left untouched.
+
+A hard crash can leave a descriptor behind. Clients treat connect failure,
+authentication failure, or instance-header mismatch as unavailable. A
+successor binds a fresh listener and atomically replaces the stale descriptor
+after bind succeeds.
+
+POSIX keeps its existing stale socket replacement on startup and socket unlink
+on graceful server shutdown.
+
+## Retry And Reconnect
+
+- Listener bind: only `EADDRINUSE`, at most three total attempts, always with a
+  fresh socket.
+- Descriptor publication: one atomic replace attempt while locked; a failure is
+  a startup failure and does not publish partial JSON.
+- Ordinary request: no hidden application-level retry. The existing caller
+  decides whether unavailable/timeout is retryable.
+- SSE connection: one descriptor snapshot per connection. The client does not
+  switch instances inside a live stream.
+- SSE reconnect: the existing subscriber reconnect loop calls the client again;
+  that new call re-reads the descriptor, re-authenticates, and validates the new
+  instance header.
+
+This avoids replaying mutating requests while allowing a long-lived SSE
+consumer to follow a restarted Controller safely.
+
+## HTTP And SSE Compatibility
+
+Windows exposes the same FastAPI application, methods, paths, status codes,
+JSON bodies, and SSE payloads as POSIX. Authentication is transport middleware,
+not route logic.
+
+For both `POST /internal/dispatch` and `GET /internal/events`:
+
+- uvicorn receives the pre-bound listener;
+- SSE framing remains `event:` followed by JSON `data:` and one blank line;
+- non-ASCII JSON content remains UTF-8 end to end;
+- event order is unchanged;
+- authentication and instance validation complete before the client consumes
+  the first SSE event;
+- a disconnect does not replay or reorder events; the existing route/caller
+  semantics decide what a new request observes.
+
+## Verification Contract
+
+Focused automated evidence must cover:
+
+- unchanged POSIX UDS selection and explicit UDS override;
+- Windows TCP descriptor selection and strict validation;
+- real loopback HTTP/SSE with non-ASCII dispatch data and preserved event order;
+- missing and incorrect bearer rejection;
+- stale descriptor and mismatched instance rejection;
+- atomic descriptor replacement without partial reads;
+- owner-safe cleanup after successor replacement;
+- occupied-port rebind behavior with a fresh socket;
+- SSE reconnect through a successor descriptor;
+- Ruff on every changed Python file.
+
+A focused `windows-latest` CI job is required until an existing Windows job
+installs the test dependencies and exercises this contract.

--- a/docs/plans/windows-control-ipc.md
+++ b/docs/plans/windows-control-ipc.md
@@ -69,12 +69,26 @@ The UTF-8 JSON descriptor has exactly this version-1 shape:
 Unknown top-level fields are rejected in version 1. The descriptor is a local
 secret because it contains the bearer token.
 
-The Controller creates the runtime directory with the narrowest practical
-user-only semantics, creates descriptor and lock files as `0600` where mode
-bits are supported, and relies on the current user's inherited profile DACL on
-Windows. It never widens permissions. Descriptor contents, authorization
-headers, and bearer tokens must not appear in logs, exceptions, HTTP response
-bodies, or test failure output.
+The Controller creates the runtime directory, lock file, temporary descriptor,
+and stable descriptor with explicit private security:
+
+- POSIX uses `0700` for the directory and `0600` for files;
+- Windows uses a protected, non-inherited DACL with full access granted only to
+  the current user SID and Local System, and records the current user SID as
+  owner.
+
+Windows creation passes this security descriptor to `CreateDirectoryW` and
+`CreateFileW`; it does not expose an inherited-permission file and tighten it
+afterward. Before consuming a descriptor, the client validates the opened
+file's owner and exact protected DACL. A descriptor, lock, or runtime directory
+with a different owner, an inherited DACL, or any additional allow entry is
+rejected. A producer may tighten an existing current-user-owned artifact during
+publication for upgrade compatibility, but it never changes or accepts an
+artifact owned by another principal. Windows security API failures fail startup
+or discovery closed.
+
+Descriptor contents, authorization headers, and bearer tokens must not appear
+in logs, exceptions, HTTP response bodies, or test failure output.
 
 ## Producer And Consumer Ownership
 
@@ -95,6 +109,10 @@ The Controller-side `ControlIpcHost` owns:
 4. checking the responding instance on every Windows response and stream;
 5. translating discovery, connect, authentication, and stale-instance failures
    into the existing unavailable/timeout behavior.
+
+The UI-process Model Hub RPC client uses this same endpoint discovery,
+transport, bearer header, and instance-response validation contract. It does
+not inspect `dispatch.sock` or construct a UDS transport independently.
 
 Any internal caller that opens `dispatch.sock` directly instead of using the
 shared client connection contract remains POSIX-only until its owning lane
@@ -119,6 +137,10 @@ Every authenticated Windows response carries:
 ```text
 X-Avibe-Control-Instance: <instance_id>
 ```
+
+This includes framework-generated `500 Internal Server Error` responses for
+unhandled route exceptions. The Windows-only error handler preserves the
+framework's status and plain-text body while adding the instance header.
 
 The client compares that value with the descriptor's `instance_id` before it
 accepts a response or consumes an SSE body. A missing or mismatched header is a
@@ -185,7 +207,8 @@ malformed, or non-owned descriptors are also left untouched.
 A hard crash can leave a descriptor behind. Clients treat connect failure,
 authentication failure, or instance-header mismatch as unavailable. A
 successor binds a fresh listener and atomically replaces the stale descriptor
-after bind succeeds.
+after bind succeeds. Each new host instance generates a new instance ID and
+bearer credential; neither credential is reused across a successor publication.
 
 POSIX keeps its existing stale socket replacement on startup and socket unlink
 on graceful server shutdown.
@@ -230,9 +253,16 @@ Focused automated evidence must cover:
 
 - unchanged POSIX UDS selection and explicit UDS override;
 - Windows TCP descriptor selection and strict validation;
+- Windows current-user/SYSTEM-only owner and DACL enforcement for the runtime
+  directory, lock, temporary descriptor, and stable descriptor;
+- rejection of widened or non-owner Windows artifacts, plus upgrade-time repair
+  only for current-user-owned artifacts;
 - real loopback HTTP/SSE with non-ASCII dispatch data and preserved event order;
 - missing and incorrect bearer rejection;
 - stale descriptor and mismatched instance rejection;
+- Model Hub sync and async RPCs through the shared Windows endpoint, bearer,
+  and instance validation;
+- instance headers on authenticated framework-generated 500 responses;
 - atomic descriptor replacement without partial reads;
 - owner-safe cleanup after successor replacement;
 - occupied-port rebind behavior with a fresh socket;

--- a/tests/test_control_ipc.py
+++ b/tests/test_control_ipc.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 import asyncio
 import errno
+import json
 import os
 import socket
+import subprocess
 import threading
 from contextlib import suppress
 from pathlib import Path
@@ -16,7 +18,7 @@ import pytest
 
 from core import control_ipc, internal_server, session_turns
 from modules.im import MessageContext
-from vibe import internal_client
+from vibe import internal_client, model_hub_client
 
 
 def _descriptor(
@@ -129,6 +131,133 @@ def test_descriptor_atomic_replace_preserves_previous_endpoint_on_failure(monkey
     assert not list(target.parent.glob(f".{target.name}.*.tmp"))
     if os.name != "nt":
         assert target.stat().st_mode & 0o077 == 0
+
+
+def test_new_windows_hosts_rotate_instance_and_bearer_credentials(tmp_path):
+    first = control_ipc.WindowsLoopbackHost(tmp_path / "control-ipc.json")
+    second = control_ipc.WindowsLoopbackHost(tmp_path / "control-ipc.json")
+
+    assert first.instance_id != second.instance_id
+    assert first.bearer_token != second.bearer_token
+
+
+@pytest.mark.skipif(os.name != "nt", reason="requires native Windows ACLs")
+def test_windows_control_ipc_artifacts_have_exact_private_security(monkeypatch, tmp_path):
+    target = tmp_path / "runtime" / "control-ipc.json"
+    descriptor = _descriptor()
+    security = control_ipc._windows_security()
+    original_replace = control_ipc.os.replace
+    temporary_checked = False
+
+    def _validate_temporary_before_replace(source, destination):
+        nonlocal temporary_checked
+        security.validate_path(Path(source))
+        temporary_checked = True
+        original_replace(source, destination)
+
+    monkeypatch.setattr(control_ipc.os, "replace", _validate_temporary_before_replace)
+
+    control_ipc.write_descriptor_atomic(target, descriptor)
+
+    assert temporary_checked
+    security.validate_path(target.parent)
+    security.validate_path(target.with_name(f"{target.name}.lock"))
+    security.validate_path(target)
+    assert control_ipc.load_descriptor(target) == descriptor
+    assert not list(target.parent.glob(f".{target.name}.*.tmp"))
+
+
+@pytest.mark.skipif(os.name != "nt", reason="requires native Windows ACLs")
+def test_windows_descriptor_reader_rejects_widened_dacl_and_writer_repairs_it(tmp_path):
+    target = tmp_path / "runtime" / "control-ipc.json"
+    first = _descriptor(instance_id="1" * 32, bearer_token="B" * 43)
+    successor = _descriptor(instance_id="2" * 32, bearer_token="C" * 43)
+    control_ipc.write_descriptor_atomic(target, first)
+
+    subprocess.run(
+        ["icacls", str(target), "/grant", "*S-1-1-0:R"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    with pytest.raises(control_ipc.ControlIpcDescriptorError):
+        control_ipc.load_descriptor(target)
+
+    control_ipc.write_descriptor_atomic(target, successor)
+    assert control_ipc.load_descriptor(target) == successor
+    control_ipc._windows_security().validate_path(target)
+
+
+@pytest.mark.skipif(os.name != "nt", reason="requires native Windows ACLs")
+def test_windows_descriptor_reader_rejects_widened_lock_and_writer_repairs_it(tmp_path):
+    target = tmp_path / "runtime" / "control-ipc.json"
+    descriptor = _descriptor()
+    control_ipc.write_descriptor_atomic(target, descriptor)
+    lock_path = target.with_name(f"{target.name}.lock")
+
+    subprocess.run(
+        ["icacls", str(lock_path), "/grant", "*S-1-1-0:R"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    with pytest.raises(control_ipc.ControlIpcDescriptorError):
+        control_ipc.load_descriptor(target)
+
+    control_ipc.write_descriptor_atomic(target, descriptor)
+    assert control_ipc.load_descriptor(target) == descriptor
+    control_ipc._windows_security().validate_path(lock_path)
+
+
+@pytest.mark.skipif(os.name != "nt", reason="requires native Windows ACLs")
+def test_windows_descriptor_reader_rejects_widened_runtime_directory(tmp_path):
+    target = tmp_path / "runtime" / "control-ipc.json"
+    descriptor = _descriptor()
+    control_ipc.write_descriptor_atomic(target, descriptor)
+
+    subprocess.run(
+        ["icacls", str(target.parent), "/grant", "*S-1-1-0:R"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    with pytest.raises(control_ipc.ControlIpcDescriptorError):
+        control_ipc.load_descriptor(target)
+
+    control_ipc.write_descriptor_atomic(target, descriptor)
+    assert control_ipc.load_descriptor(target) == descriptor
+    control_ipc._windows_security().validate_path(target.parent)
+
+
+@pytest.mark.skipif(os.name != "nt", reason="requires native Windows ACLs")
+def test_windows_descriptor_rejects_non_owner_and_security_api_failure(
+    monkeypatch,
+    tmp_path,
+):
+    target = tmp_path / "runtime" / "control-ipc.json"
+    descriptor = _descriptor()
+    control_ipc.write_descriptor_atomic(target, descriptor)
+    security = control_ipc._windows_security()
+
+    fd = os.open(target, os.O_RDONLY)
+    try:
+        with monkeypatch.context() as scoped:
+            scoped.setattr(security.advapi32, "EqualSid", lambda *_args: False)
+            with pytest.raises(
+                control_ipc.ControlIpcSecurityError,
+                match="owner or DACL",
+            ):
+                security.validate_file_descriptor(fd, target)
+    finally:
+        os.close(fd)
+
+    with monkeypatch.context() as scoped:
+        scoped.setattr(security.advapi32, "GetSecurityInfo", lambda *_args: 5)
+        with pytest.raises(control_ipc.ControlIpcDescriptorError):
+            control_ipc.load_descriptor(target)
 
 
 def test_descriptor_read_blocks_successor_publication_until_file_is_closed(monkeypatch, tmp_path):
@@ -253,6 +382,78 @@ def test_windows_client_rejects_stale_instance_header(monkeypatch, tmp_path):
 
     with pytest.raises(internal_client.InternalServerUnavailable, match="stale instance"):
         asyncio.run(internal_client.turn_state("ses_stale"))
+
+
+def test_model_hub_client_uses_windows_endpoint_auth_and_instance_validation(
+    monkeypatch,
+    tmp_path,
+):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    monkeypatch.setattr(internal_client, "_platform_name", lambda: "nt")
+    descriptor = _descriptor(instance_id="1" * 32, bearer_token="B" * 43)
+    control_ipc.write_descriptor_atomic(control_ipc.default_descriptor_path(), descriptor)
+    requests: list[tuple[str, str]] = []
+
+    def _handler(request: httpx.Request) -> httpx.Response:
+        payload = json.loads(request.content)
+        requests.append((payload["operation"], request.headers["authorization"]))
+        response_instance = "2" * 32 if payload["operation"] == "stale" else descriptor.instance_id
+        return httpx.Response(
+            200,
+            json={"ok": True, "result": payload["operation"]},
+            headers={control_ipc.CONTROL_IPC_INSTANCE_HEADER: response_instance},
+        )
+
+    transport = httpx.MockTransport(_handler)
+    monkeypatch.setattr(internal_client.httpx, "HTTPTransport", lambda **_kwargs: transport)
+    monkeypatch.setattr(internal_client.httpx, "AsyncHTTPTransport", lambda **_kwargs: transport)
+
+    assert model_hub_client._rpc_sync("sync") == "sync"
+    assert asyncio.run(model_hub_client._rpc("async")) == "async"
+    with pytest.raises(model_hub_client.ModelHubError) as exc_info:
+        model_hub_client._rpc_sync("stale")
+
+    assert exc_info.value.code == "engine_down"
+    assert requests == [
+        ("sync", f"Bearer {descriptor.bearer_token}"),
+        ("async", f"Bearer {descriptor.bearer_token}"),
+        ("stale", f"Bearer {descriptor.bearer_token}"),
+    ]
+
+
+def test_windows_unhandled_500_response_carries_instance_header():
+    descriptor = _descriptor(instance_id="1" * 32, bearer_token="B" * 43)
+    app = internal_server.create_app(
+        _controller_double(),
+        instance_id=descriptor.instance_id,
+        bearer_token=descriptor.bearer_token,
+    )
+
+    @app.get("/internal/test-unhandled-error")
+    async def _unhandled_error():
+        raise RuntimeError("test failure")
+
+    async def _run():
+        transport = httpx.ASGITransport(app=app, raise_app_exceptions=False)
+        async with httpx.AsyncClient(
+            transport=transport,
+            base_url="http://testserver",
+            headers={"Authorization": f"Bearer {descriptor.bearer_token}"},
+        ) as client:
+            return await client.get("/internal/test-unhandled-error")
+
+    response = asyncio.run(_run())
+
+    assert response.status_code == 500
+    assert response.text == "Internal Server Error"
+    assert response.headers[control_ipc.CONTROL_IPC_INSTANCE_HEADER] == descriptor.instance_id
+    internal_client._validate_response(
+        response,
+        control_ipc.ControlIpcClientEndpoint(
+            transport="tcp",
+            descriptor=descriptor,
+        ),
+    )
 
 
 def test_real_windows_loopback_auth_and_non_ascii_dispatch_sse(monkeypatch, tmp_path):

--- a/tests/test_control_ipc.py
+++ b/tests/test_control_ipc.py
@@ -1,0 +1,324 @@
+"""Contract tests for POSIX UDS and Windows loopback Controller IPC."""
+
+from __future__ import annotations
+
+import asyncio
+import errno
+import os
+import socket
+from contextlib import suppress
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+
+from core import control_ipc, internal_server, session_turns
+from modules.im import MessageContext
+from vibe import internal_client
+
+
+def _descriptor(
+    *,
+    port: int = 45678,
+    instance_id: str = "a" * 32,
+    bearer_token: str = "A" * 43,
+) -> control_ipc.ControlIpcDescriptor:
+    return control_ipc.ControlIpcDescriptor(
+        schema_version=1,
+        transport="tcp",
+        host="127.0.0.1",
+        port=port,
+        instance_id=instance_id,
+        bearer_token=bearer_token,
+    )
+
+
+def _controller_double() -> MagicMock:
+    controller = MagicMock()
+    controller._t = lambda key, **_kwargs: key
+    return controller
+
+
+async def _wait_until_ready(
+    task: asyncio.Task,
+    descriptor_path: Path,
+) -> control_ipc.ControlIpcDescriptor:
+    for _ in range(300):
+        if task.done():
+            await task
+        if descriptor_path.exists() and await internal_client.health():
+            return control_ipc.load_descriptor(descriptor_path)
+        await asyncio.sleep(0.01)
+    raise AssertionError("control IPC server did not become ready")
+
+
+async def _stop_server(task: asyncio.Task) -> None:
+    task.cancel()
+    with suppress(asyncio.CancelledError):
+        await task
+
+
+def test_endpoint_selection_keeps_posix_uds_and_uses_windows_descriptor(monkeypatch, tmp_path):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    monkeypatch.delenv("VIBE_INTERNAL_DISPATCH_SOCKET", raising=False)
+
+    posix = control_ipc.resolve_client_endpoint(platform_name="posix")
+    assert posix.transport == "unix"
+    assert posix.socket_path == (tmp_path / "state" / "dispatch.sock").resolve()
+    assert posix.descriptor is None
+
+    descriptor_path = control_ipc.default_descriptor_path()
+    expected = _descriptor()
+    control_ipc.write_descriptor_atomic(descriptor_path, expected)
+    windows = control_ipc.resolve_client_endpoint(platform_name="nt")
+    assert windows.transport == "tcp"
+    assert windows.socket_path is None
+    assert windows.descriptor == expected
+    assert windows.base_url == "http://127.0.0.1:45678"
+    assert windows.headers == {"Authorization": f"Bearer {expected.bearer_token}"}
+
+
+@pytest.mark.parametrize(
+    ("update", "message"),
+    [
+        ({"schema_version": 2}, "schema"),
+        ({"transport": "unix"}, "transport"),
+        ({"host": "0.0.0.0"}, "loopback"),
+        ({"host": "localhost"}, "loopback"),
+        ({"port": 0}, "port"),
+        ({"port": True}, "port"),
+        ({"instance_id": "short"}, "instance"),
+        ({"bearer_token": "guessable"}, "credential"),
+        ({"extra": "field"}, "fields"),
+    ],
+)
+def test_descriptor_validation_rejects_malformed_or_unsupported_data(update, message):
+    payload = _descriptor().to_dict()
+    payload.update(update)
+    with pytest.raises(control_ipc.ControlIpcDescriptorError, match=message):
+        control_ipc.validate_descriptor(payload)
+
+
+def test_descriptor_reader_rejects_malformed_json_without_echoing_contents(tmp_path):
+    target = tmp_path / "control-ipc.json"
+    marker = "must-not-appear-in-error"
+    target.write_text(f'{{"bearer_token":"{marker}"', encoding="utf-8")
+
+    with pytest.raises(control_ipc.ControlIpcDescriptorError) as exc:
+        control_ipc.load_descriptor(target)
+
+    assert marker not in str(exc.value)
+
+
+def test_descriptor_atomic_replace_preserves_previous_endpoint_on_failure(monkeypatch, tmp_path):
+    target = tmp_path / "runtime" / "control-ipc.json"
+    first = _descriptor(instance_id="1" * 32, bearer_token="B" * 43)
+    second = _descriptor(instance_id="2" * 32, bearer_token="C" * 43)
+    control_ipc.write_descriptor_atomic(target, first)
+
+    def _fail_replace(_source, _target):
+        raise PermissionError("replace blocked")
+
+    monkeypatch.setattr(control_ipc.os, "replace", _fail_replace)
+    with pytest.raises(PermissionError, match="replace blocked"):
+        control_ipc.write_descriptor_atomic(target, second)
+
+    assert control_ipc.load_descriptor(target) == first
+    assert not list(target.parent.glob(f".{target.name}.*.tmp"))
+    if os.name != "nt":
+        assert target.stat().st_mode & 0o077 == 0
+
+
+def test_shutdown_cleanup_does_not_remove_successor_descriptor(tmp_path):
+    target = tmp_path / "runtime" / "control-ipc.json"
+    first = control_ipc.WindowsLoopbackHost(
+        target,
+        instance_id="1" * 32,
+        bearer_token="B" * 43,
+    )
+    successor = control_ipc.WindowsLoopbackHost(
+        target,
+        instance_id="2" * 32,
+        bearer_token="C" * 43,
+    )
+    first_bound = first.bind()
+    successor_bound = successor.bind()
+    try:
+        assert not target.exists()
+        first.publish(first_bound)
+        successor.publish(successor_bound)
+
+        first.cleanup(first_bound)
+        assert control_ipc.load_descriptor(target) == successor_bound.descriptor
+    finally:
+        first_bound.listener.close()
+        successor.cleanup(successor_bound)
+
+    assert not target.exists()
+
+
+def test_ephemeral_bind_retries_address_in_use_with_fresh_socket(tmp_path):
+    attempts: list[object] = []
+
+    class OccupiedSocket:
+        def setsockopt(self, *_args):
+            return None
+
+        def bind(self, _address):
+            raise OSError(errno.EADDRINUSE, "occupied")
+
+        def close(self):
+            return None
+
+    def _socket_factory(family, kind):
+        attempts.append(object())
+        if len(attempts) == 1:
+            return OccupiedSocket()
+        return socket.socket(family, kind)
+
+    host = control_ipc.WindowsLoopbackHost(
+        tmp_path / "control-ipc.json",
+        socket_factory=_socket_factory,
+    )
+    bound = host.bind()
+    try:
+        assert len(attempts) == 2
+        assert bound.descriptor is not None
+        assert bound.descriptor.host == "127.0.0.1"
+        assert bound.descriptor.port > 0
+    finally:
+        host.cleanup(bound)
+
+
+def test_windows_client_rejects_stale_instance_header(monkeypatch, tmp_path):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    monkeypatch.setattr(internal_client, "_platform_name", lambda: "nt")
+    descriptor = _descriptor(instance_id="1" * 32)
+    control_ipc.write_descriptor_atomic(control_ipc.default_descriptor_path(), descriptor)
+
+    app = internal_server.create_app(
+        _controller_double(),
+        instance_id="2" * 32,
+        bearer_token=descriptor.bearer_token,
+    )
+    transport = httpx.ASGITransport(app=app)
+    monkeypatch.setattr(internal_client.httpx, "AsyncHTTPTransport", lambda **_kwargs: transport)
+
+    with pytest.raises(internal_client.InternalServerUnavailable, match="stale instance"):
+        asyncio.run(internal_client.turn_state("ses_stale"))
+
+
+def test_real_windows_loopback_auth_and_non_ascii_dispatch_sse(monkeypatch, tmp_path):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    monkeypatch.setattr(internal_client, "_platform_name", lambda: "nt")
+    monkeypatch.setattr(
+        session_turns.SessionTurnManager,
+        "recover_persisted_agent_run_queue",
+        lambda _self: asyncio.sleep(0, result=[]),
+    )
+    captured: dict[str, object] = {}
+    context = MessageContext(user_id="workbench", channel_id="unicode", platform="avibe")
+
+    async def _build_payload(payload):
+        captured["request_text"] = payload["text"]
+        return payload["text"], context
+
+    async def _dispatch(_controller, _context, text, *, on_chunk):
+        captured["dispatch_text"] = text
+        await on_chunk({"kind": "notify", "text": "你好，Windows"})
+        await on_chunk({"kind": "result", "text": "完成 ✓"})
+
+    monkeypatch.setattr(internal_server, "_build_dispatch_payload", _build_payload)
+    monkeypatch.setattr(internal_server, "dispatch_turn", _dispatch)
+
+    async def _run():
+        descriptor_path = control_ipc.default_descriptor_path()
+        task = asyncio.create_task(
+            internal_server.serve(
+                _controller_double(),
+                platform_name="nt",
+                descriptor_path=descriptor_path,
+            )
+        )
+        try:
+            descriptor = await _wait_until_ready(task, descriptor_path)
+            async with httpx.AsyncClient(base_url=f"http://{descriptor.host}:{descriptor.port}") as client:
+                missing = await client.get("/internal/health")
+                incorrect = await client.get(
+                    "/internal/health",
+                    headers={"Authorization": "Bearer definitely-wrong"},
+                )
+            assert missing.status_code == 401
+            assert incorrect.status_code == 401
+            assert descriptor.bearer_token not in missing.text
+            assert descriptor.bearer_token not in incorrect.text
+
+            events = [
+                event
+                async for event in internal_client.stream_dispatch(
+                    {"session_id": None, "text": "请处理 café 文件"}
+                )
+            ]
+            assert events == [
+                ("turn.start", {"session_id": None}),
+                ("turn.chunk", {"kind": "notify", "text": "你好，Windows"}),
+                ("turn.chunk", {"kind": "result", "text": "完成 ✓"}),
+                ("turn.end", {"session_id": None}),
+            ]
+        finally:
+            await _stop_server(task)
+        assert not descriptor_path.exists()
+
+    asyncio.run(_run())
+    assert captured == {
+        "request_text": "请处理 café 文件",
+        "dispatch_text": "请处理 café 文件",
+    }
+
+
+def test_sse_reconnect_loads_successor_descriptor(monkeypatch, tmp_path):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    monkeypatch.setattr(internal_client, "_platform_name", lambda: "nt")
+    monkeypatch.setattr(
+        session_turns.SessionTurnManager,
+        "recover_persisted_agent_run_queue",
+        lambda _self: asyncio.sleep(0, result=[]),
+    )
+
+    async def _first_event():
+        stream = internal_client.stream_events()
+        try:
+            return await anext(stream)
+        finally:
+            await stream.aclose()
+
+    async def _run():
+        descriptor_path = control_ipc.default_descriptor_path()
+        first_task = asyncio.create_task(
+            internal_server.serve(
+                _controller_double(),
+                platform_name="nt",
+                descriptor_path=descriptor_path,
+            )
+        )
+        first = await _wait_until_ready(first_task, descriptor_path)
+        assert await _first_event() == ("connected", {})
+
+        successor_task = asyncio.create_task(
+            internal_server.serve(
+                _controller_double(),
+                platform_name="nt",
+                descriptor_path=descriptor_path,
+            )
+        )
+        try:
+            successor = await _wait_until_ready(successor_task, descriptor_path)
+            assert successor.instance_id != first.instance_id
+            assert successor.bearer_token != first.bearer_token
+            assert await _first_event() == ("connected", {})
+        finally:
+            await _stop_server(successor_task)
+            await _stop_server(first_task)
+
+    asyncio.run(_run())

--- a/tests/test_control_ipc.py
+++ b/tests/test_control_ipc.py
@@ -6,6 +6,7 @@ import asyncio
 import errno
 import os
 import socket
+import threading
 from contextlib import suppress
 from pathlib import Path
 from unittest.mock import MagicMock
@@ -128,6 +129,51 @@ def test_descriptor_atomic_replace_preserves_previous_endpoint_on_failure(monkey
     assert not list(target.parent.glob(f".{target.name}.*.tmp"))
     if os.name != "nt":
         assert target.stat().st_mode & 0o077 == 0
+
+
+def test_descriptor_read_blocks_successor_publication_until_file_is_closed(monkeypatch, tmp_path):
+    target = tmp_path / "runtime" / "control-ipc.json"
+    first = _descriptor(instance_id="1" * 32, bearer_token="B" * 43)
+    successor = _descriptor(instance_id="2" * 32, bearer_token="C" * 43)
+    control_ipc.write_descriptor_atomic(target, first)
+
+    reader_open = threading.Event()
+    release_reader = threading.Event()
+    replace_started = threading.Event()
+    original_fdopen = control_ipc.os.fdopen
+    original_replace = control_ipc.os.replace
+
+    def _paused_fdopen(fd, mode, *args, **kwargs):
+        stream = original_fdopen(fd, mode, *args, **kwargs)
+        if mode == "r":
+            reader_open.set()
+            assert release_reader.wait(timeout=5)
+        return stream
+
+    def _observed_replace(source, destination):
+        replace_started.set()
+        return original_replace(source, destination)
+
+    monkeypatch.setattr(control_ipc.os, "fdopen", _paused_fdopen)
+    monkeypatch.setattr(control_ipc.os, "replace", _observed_replace)
+
+    read_result: list[control_ipc.ControlIpcDescriptor] = []
+    reader = threading.Thread(target=lambda: read_result.append(control_ipc.load_descriptor(target)))
+    publisher = threading.Thread(target=lambda: control_ipc.write_descriptor_atomic(target, successor))
+    reader.start()
+    assert reader_open.wait(timeout=5)
+    publisher.start()
+    assert not replace_started.wait(timeout=0.1)
+
+    release_reader.set()
+    reader.join(timeout=5)
+    publisher.join(timeout=5)
+
+    assert not reader.is_alive()
+    assert not publisher.is_alive()
+    assert read_result == [first]
+    assert replace_started.is_set()
+    assert control_ipc.load_descriptor(target) == successor
 
 
 def test_shutdown_cleanup_does_not_remove_successor_descriptor(tmp_path):

--- a/vibe/internal_client.py
+++ b/vibe/internal_client.py
@@ -1,10 +1,10 @@
-"""``httpx`` wrapper for talking to the controller's internal Unix socket.
+"""``httpx`` wrapper for the Controller's cross-platform control IPC.
 
 C5 of Plan 2 (see ``docs/plans/workbench-dispatch-architecture.md``).
 The UI server runs as its own subprocess; this module is how it reaches
 ``core.internal_server`` to start agent turns and observe their lifecycle.
 
-Single responsibility: keep all the socket-path / httpx-transport /
+Single responsibility: keep all the endpoint discovery / httpx-transport /
 SSE-parsing boilerplate out of the UI route bodies. Routes call
 ``dispatch_async(...)`` to start a fire-and-forget turn (the Chat page — the
 reply arrives over the persistent ``message.new`` session stream, not the
@@ -25,7 +25,7 @@ from typing import Any, AsyncIterator, Optional
 
 import httpx
 
-from config import paths
+from core import control_ipc
 
 logger = logging.getLogger(__name__)
 
@@ -56,10 +56,52 @@ def default_socket_path() -> Path:
     boundaries clean.
     """
 
-    override = os.environ.get("VIBE_INTERNAL_DISPATCH_SOCKET")
-    if override:
-        return Path(override).expanduser()
-    return paths.get_state_dir() / "dispatch.sock"
+    return control_ipc.default_unix_socket_path()
+
+
+def _platform_name() -> str:
+    return os.name
+
+
+def _resolve_endpoint(socket_path: Optional[Path]) -> control_ipc.ControlIpcClientEndpoint:
+    try:
+        endpoint = control_ipc.resolve_client_endpoint(
+            platform_name=_platform_name(),
+            socket_path=socket_path,
+        )
+    except control_ipc.ControlIpcDescriptorError as exc:
+        raise InternalServerUnavailable(str(exc)) from exc
+    if endpoint.transport == "unix":
+        target = endpoint.socket_path
+        if target is None or not target.exists():
+            raise InternalServerUnavailable(f"dispatch socket missing at {target}")
+    return endpoint
+
+
+def _async_transport(endpoint: control_ipc.ControlIpcClientEndpoint) -> httpx.AsyncBaseTransport:
+    if endpoint.transport == "unix":
+        return httpx.AsyncHTTPTransport(uds=str(endpoint.socket_path))
+    return httpx.AsyncHTTPTransport()
+
+
+def _sync_transport(endpoint: control_ipc.ControlIpcClientEndpoint) -> httpx.BaseTransport:
+    if endpoint.transport == "unix":
+        return httpx.HTTPTransport(uds=str(endpoint.socket_path))
+    return httpx.HTTPTransport()
+
+
+def _validate_response(
+    response: httpx.Response,
+    endpoint: control_ipc.ControlIpcClientEndpoint,
+) -> None:
+    descriptor = endpoint.descriptor
+    if descriptor is None:
+        return
+    if response.status_code == 401:
+        raise InternalServerUnavailable("control IPC authentication was rejected")
+    response_instance = response.headers.get(control_ipc.CONTROL_IPC_INSTANCE_HEADER)
+    if not control_ipc.response_instance_matches(descriptor, response_instance):
+        raise InternalServerUnavailable("control IPC response came from a stale instance")
 
 
 async def stream_dispatch(
@@ -80,15 +122,13 @@ async def stream_dispatch(
     flow (``_run_show_event_dispatch`` re-publishes each event as ``show.dispatch``).
     """
 
-    target = (socket_path or default_socket_path()).expanduser().resolve()
-    if not target.exists():
-        raise InternalServerUnavailable(f"dispatch socket missing at {target}")
-
-    transport = httpx.AsyncHTTPTransport(uds=str(target))
+    endpoint = _resolve_endpoint(socket_path)
+    transport = _async_transport(endpoint)
     try:
         async with httpx.AsyncClient(
             transport=transport,
-            base_url="http://localhost",
+            base_url=endpoint.base_url,
+            headers=endpoint.headers,
             timeout=httpx.Timeout(timeout, connect=5.0),
         ) as client:
             try:
@@ -97,6 +137,7 @@ async def stream_dispatch(
                 raise InternalServerUnavailable(str(exc)) from exc
 
             async with stream as resp:
+                _validate_response(resp, endpoint)
                 if resp.status_code >= 400:
                     detail = await resp.aread()
                     raise InternalServerUnavailable(
@@ -140,15 +181,13 @@ async def stream_events(
     subscriber loop can back off and reconnect.
     """
 
-    target = (socket_path or default_socket_path()).expanduser().resolve()
-    if not target.exists():
-        raise InternalServerUnavailable(f"dispatch socket missing at {target}")
-
-    transport = httpx.AsyncHTTPTransport(uds=str(target))
+    endpoint = _resolve_endpoint(socket_path)
+    transport = _async_transport(endpoint)
     try:
         async with httpx.AsyncClient(
             transport=transport,
-            base_url="http://localhost",
+            base_url=endpoint.base_url,
+            headers=endpoint.headers,
             timeout=httpx.Timeout(None, connect=5.0),
         ) as client:
             try:
@@ -157,6 +196,7 @@ async def stream_events(
                 raise InternalServerUnavailable(str(exc)) from exc
 
             async with stream as resp:
+                _validate_response(resp, endpoint)
                 if resp.status_code >= 400:
                     detail = await resp.aread()
                     raise InternalServerUnavailable(
@@ -193,18 +233,17 @@ async def publish_event(
 ) -> dict[str, Any]:
     """Ask the Controller process to publish an allowlisted SSE notification."""
 
-    target = (socket_path or default_socket_path()).expanduser().resolve()
-    if not target.exists():
-        raise InternalServerUnavailable(f"dispatch socket missing at {target}")
-
-    transport = httpx.AsyncHTTPTransport(uds=str(target))
+    endpoint = _resolve_endpoint(socket_path)
+    transport = _async_transport(endpoint)
     try:
         async with httpx.AsyncClient(
             transport=transport,
-            base_url="http://localhost",
+            base_url=endpoint.base_url,
+            headers=endpoint.headers,
             timeout=httpx.Timeout(timeout, connect=2.0),
         ) as client:
             resp = await client.post("/internal/events", json={"type": event_type, "data": data})
+            _validate_response(resp, endpoint)
             if resp.status_code >= 400:
                 detail = await resp.aread()
                 raise InternalServerUnavailable(f"events publish returned {resp.status_code}: {detail!r}")
@@ -224,18 +263,17 @@ def publish_event_sync(
 ) -> dict[str, Any]:
     """Synchronous wrapper for CLI/child-process notification publishers."""
 
-    target = (socket_path or default_socket_path()).expanduser().resolve()
-    if not target.exists():
-        raise InternalServerUnavailable(f"dispatch socket missing at {target}")
-
-    transport = httpx.HTTPTransport(uds=str(target))
+    endpoint = _resolve_endpoint(socket_path)
+    transport = _sync_transport(endpoint)
     try:
         with httpx.Client(
             transport=transport,
-            base_url="http://localhost",
+            base_url=endpoint.base_url,
+            headers=endpoint.headers,
             timeout=httpx.Timeout(timeout, connect=2.0),
         ) as client:
             resp = client.post("/internal/events", json={"type": event_type, "data": data})
+            _validate_response(resp, endpoint)
             if resp.status_code >= 400:
                 raise InternalServerUnavailable(
                     f"events publish returned {resp.status_code}: {resp.content!r}"
@@ -263,17 +301,17 @@ async def dispatch_async(
     ``InternalServerUnavailable`` on socket failure so the route can degrade.
     """
 
-    target = (socket_path or default_socket_path()).expanduser().resolve()
-    if not target.exists():
-        raise InternalServerUnavailable(f"dispatch socket missing at {target}")
-    transport = httpx.AsyncHTTPTransport(uds=str(target))
+    endpoint = _resolve_endpoint(socket_path)
+    transport = _async_transport(endpoint)
     try:
         async with httpx.AsyncClient(
             transport=transport,
-            base_url="http://localhost",
+            base_url=endpoint.base_url,
+            headers=endpoint.headers,
             timeout=httpx.Timeout(timeout, connect=5.0),
         ) as client:
             resp = await client.post("/internal/dispatch_async", json=payload)
+            _validate_response(resp, endpoint)
     except _SOCKET_ERRORS as exc:
         raise InternalServerUnavailable(str(exc)) from exc
     return {"status_code": resp.status_code, "body": resp.json() if resp.content else {}}
@@ -286,17 +324,17 @@ async def reconcile_platforms(
 ) -> dict[str, Any]:
     """Ask the controller to hot-apply the persisted platform configuration."""
 
-    target = (socket_path or default_socket_path()).expanduser().resolve()
-    if not target.exists():
-        raise InternalServerUnavailable(f"dispatch socket missing at {target}")
-    transport = httpx.AsyncHTTPTransport(uds=str(target))
+    endpoint = _resolve_endpoint(socket_path)
+    transport = _async_transport(endpoint)
     try:
         async with httpx.AsyncClient(
             transport=transport,
-            base_url="http://localhost",
+            base_url=endpoint.base_url,
+            headers=endpoint.headers,
             timeout=httpx.Timeout(timeout, connect=5.0),
         ) as client:
             resp = await client.post("/internal/reconcile-platforms")
+            _validate_response(resp, endpoint)
     except _SOCKET_ERRORS as exc:
         raise InternalServerUnavailable(str(exc)) from exc
     return {"status_code": resp.status_code, "body": resp.json() if resp.content else {}}
@@ -310,20 +348,20 @@ async def reconcile_agent_backends(
 ) -> dict[str, Any]:
     """Ask the controller to hot-apply persisted Agent backend config."""
 
-    target = (socket_path or default_socket_path()).expanduser().resolve()
-    if not target.exists():
-        raise InternalServerUnavailable(f"dispatch socket missing at {target}")
-    transport = httpx.AsyncHTTPTransport(uds=str(target))
+    endpoint = _resolve_endpoint(socket_path)
+    transport = _async_transport(endpoint)
     try:
         async with httpx.AsyncClient(
             transport=transport,
-            base_url="http://localhost",
+            base_url=endpoint.base_url,
+            headers=endpoint.headers,
             timeout=httpx.Timeout(timeout, connect=5.0),
         ) as client:
             resp = await client.post(
                 "/internal/reconcile-agent-backends",
                 json={"backends": backends},
             )
+            _validate_response(resp, endpoint)
     except _SOCKET_ERRORS as exc:
         raise InternalServerUnavailable(str(exc)) from exc
     return {"status_code": resp.status_code, "body": resp.json() if resp.content else {}}
@@ -337,17 +375,17 @@ async def notify_vault_request_created(
 ) -> dict[str, Any]:
     """Ask the controller to send the IM degradation notice for a Vault request."""
 
-    target = (socket_path or default_socket_path()).expanduser().resolve()
-    if not target.exists():
-        raise InternalServerUnavailable(f"dispatch socket missing at {target}")
-    transport = httpx.AsyncHTTPTransport(uds=str(target))
+    endpoint = _resolve_endpoint(socket_path)
+    transport = _async_transport(endpoint)
     try:
         async with httpx.AsyncClient(
             transport=transport,
-            base_url="http://localhost",
+            base_url=endpoint.base_url,
+            headers=endpoint.headers,
             timeout=httpx.Timeout(timeout, connect=2.0),
         ) as client:
             resp = await client.post("/internal/vault/request-created", json={"request": request_payload})
+            _validate_response(resp, endpoint)
             if resp.status_code >= 400:
                 detail = await resp.aread()
                 raise InternalServerUnavailable(
@@ -368,18 +406,17 @@ def notify_vault_request_created_sync(
 ) -> dict[str, Any]:
     """Synchronous wrapper for CLI/UI-server Vault request notifications."""
 
-    target = (socket_path or default_socket_path()).expanduser().resolve()
-    if not target.exists():
-        raise InternalServerUnavailable(f"dispatch socket missing at {target}")
-
-    transport = httpx.HTTPTransport(uds=str(target))
+    endpoint = _resolve_endpoint(socket_path)
+    transport = _sync_transport(endpoint)
     try:
         with httpx.Client(
             transport=transport,
-            base_url="http://localhost",
+            base_url=endpoint.base_url,
+            headers=endpoint.headers,
             timeout=httpx.Timeout(timeout, connect=2.0),
         ) as client:
             resp = client.post("/internal/vault/request-created", json={"request": request_payload})
+            _validate_response(resp, endpoint)
             if resp.status_code >= 400:
                 raise InternalServerUnavailable(
                     f"vault request notification returned {resp.status_code}: {resp.content!r}"
@@ -400,14 +437,13 @@ async def cancel_dispatch(session_id: str, *, socket_path: Optional[Path] = None
     so the UI route can fall back gracefully.
     """
 
-    target = (socket_path or default_socket_path()).expanduser().resolve()
-    if not target.exists():
-        raise InternalServerUnavailable(f"dispatch socket missing at {target}")
-    transport = httpx.AsyncHTTPTransport(uds=str(target))
+    endpoint = _resolve_endpoint(socket_path)
+    transport = _async_transport(endpoint)
     try:
         async with httpx.AsyncClient(
             transport=transport,
-            base_url="http://localhost",
+            base_url=endpoint.base_url,
+            headers=endpoint.headers,
             # The cancel now WAITS for the backend interrupt to confirm before
             # acking (so a refused stop keeps the turn cancellable), and a
             # Claude interrupt / OpenCode abort can take a few seconds — give it
@@ -415,6 +451,7 @@ async def cancel_dispatch(session_id: str, *, socket_path: Optional[Path] = None
             timeout=httpx.Timeout(30.0, connect=1.0),
         ) as client:
             resp = await client.post(f"/internal/cancel/{session_id}")
+            _validate_response(resp, endpoint)
     except _SOCKET_ERRORS as exc:
         raise InternalServerUnavailable(str(exc)) from exc
     return {"status_code": resp.status_code, "body": resp.json() if resp.content else {}}
@@ -429,17 +466,17 @@ async def end_running_agent(payload: dict[str, Any], *, socket_path: Optional[Pa
     so the timeout matches ``cancel_dispatch``.
     """
 
-    target = (socket_path or default_socket_path()).expanduser().resolve()
-    if not target.exists():
-        raise InternalServerUnavailable(f"dispatch socket missing at {target}")
-    transport = httpx.AsyncHTTPTransport(uds=str(target))
+    endpoint = _resolve_endpoint(socket_path)
+    transport = _async_transport(endpoint)
     try:
         async with httpx.AsyncClient(
             transport=transport,
-            base_url="http://localhost",
+            base_url=endpoint.base_url,
+            headers=endpoint.headers,
             timeout=httpx.Timeout(30.0, connect=1.0),
         ) as client:
             resp = await client.post("/internal/running-agents/end", json=payload)
+            _validate_response(resp, endpoint)
     except _SOCKET_ERRORS as exc:
         raise InternalServerUnavailable(str(exc)) from exc
     return {"status_code": resp.status_code, "body": resp.json() if resp.content else {}}
@@ -452,20 +489,20 @@ async def send_now(session_id: str, *, socket_path: Optional[Path] = None) -> di
     failure so the UI route can degrade.
     """
 
-    target = (socket_path or default_socket_path()).expanduser().resolve()
-    if not target.exists():
-        raise InternalServerUnavailable(f"dispatch socket missing at {target}")
-    transport = httpx.AsyncHTTPTransport(uds=str(target))
+    endpoint = _resolve_endpoint(socket_path)
+    transport = _async_transport(endpoint)
     try:
         async with httpx.AsyncClient(
             transport=transport,
-            base_url="http://localhost",
+            base_url=endpoint.base_url,
+            headers=endpoint.headers,
             # send-now interrupts the running turn before flushing, and that
             # backend stop can take a few seconds — match the cancel timeout so a
             # slow-but-successful interrupt isn't read-timed-out.
             timeout=httpx.Timeout(30.0, connect=1.0),
         ) as client:
             resp = await client.post(f"/internal/send-now/{session_id}")
+            _validate_response(resp, endpoint)
     except _SOCKET_ERRORS as exc:
         raise InternalServerUnavailable(str(exc)) from exc
     return {"status_code": resp.status_code, "body": resp.json() if resp.content else {}}
@@ -477,17 +514,17 @@ async def turn_state(session_id: str, *, socket_path: Optional[Path] = None) -> 
     ``{status_code, body}``; raises ``InternalServerUnavailable`` on socket
     failure so the route can degrade (assume idle)."""
 
-    target = (socket_path or default_socket_path()).expanduser().resolve()
-    if not target.exists():
-        raise InternalServerUnavailable(f"dispatch socket missing at {target}")
-    transport = httpx.AsyncHTTPTransport(uds=str(target))
+    endpoint = _resolve_endpoint(socket_path)
+    transport = _async_transport(endpoint)
     try:
         async with httpx.AsyncClient(
             transport=transport,
-            base_url="http://localhost",
+            base_url=endpoint.base_url,
+            headers=endpoint.headers,
             timeout=httpx.Timeout(1.0, connect=0.2),
         ) as client:
             resp = await client.get(f"/internal/turn-state/{session_id}")
+            _validate_response(resp, endpoint)
     except httpx.ReadTimeout as exc:
         raise InternalServerTimeout(str(exc)) from exc
     except _SOCKET_CONNECT_ERRORS as exc:
@@ -505,17 +542,17 @@ async def list_running_agents(*, socket_path: Optional[Path] = None) -> dict[str
     than ``turn_state``.
     """
 
-    target = (socket_path or default_socket_path()).expanduser().resolve()
-    if not target.exists():
-        raise InternalServerUnavailable(f"dispatch socket missing at {target}")
-    transport = httpx.AsyncHTTPTransport(uds=str(target))
+    endpoint = _resolve_endpoint(socket_path)
+    transport = _async_transport(endpoint)
     try:
         async with httpx.AsyncClient(
             transport=transport,
-            base_url="http://localhost",
+            base_url=endpoint.base_url,
+            headers=endpoint.headers,
             timeout=httpx.Timeout(3.0, connect=0.5),
         ) as client:
             resp = await client.get("/internal/running-agents")
+            _validate_response(resp, endpoint)
     except httpx.ReadTimeout as exc:
         raise InternalServerTimeout(str(exc)) from exc
     except _SOCKET_CONNECT_ERRORS as exc:
@@ -531,17 +568,17 @@ async def health(socket_path: Optional[Path] = None) -> bool:
     longer-lived dispatch stream.
     """
 
-    target = (socket_path or default_socket_path()).expanduser().resolve()
-    if not target.exists():
-        return False
-    transport = httpx.AsyncHTTPTransport(uds=str(target))
     try:
+        endpoint = _resolve_endpoint(socket_path)
+        transport = _async_transport(endpoint)
         async with httpx.AsyncClient(
             transport=transport,
-            base_url="http://localhost",
+            base_url=endpoint.base_url,
+            headers=endpoint.headers,
             timeout=httpx.Timeout(2.0, connect=1.0),
         ) as client:
             resp = await client.get("/internal/health")
+            _validate_response(resp, endpoint)
             return resp.status_code == 200 and (resp.json() or {}).get("ok") is True
     except Exception:
         return False

--- a/vibe/model_hub_client.py
+++ b/vibe/model_hub_client.py
@@ -7,10 +7,15 @@ from typing import Any, Optional
 import httpx
 
 from core.handlers.model_hub import ModelHubError
-from vibe.internal_client import default_socket_path
+from vibe import internal_client
 
 
-_TRANSPORT_ERRORS = (httpx.ConnectError, httpx.TimeoutException, OSError)
+_TRANSPORT_ERRORS = (
+    httpx.ConnectError,
+    httpx.TimeoutException,
+    OSError,
+    internal_client.InternalServerUnavailable,
+)
 _RPC_TIMEOUT_SECONDS = 300.0
 
 
@@ -35,40 +40,40 @@ def _decode(response: httpx.Response) -> Any:
 
 
 def _rpc_sync(operation: str, payload: Optional[dict[str, Any]] = None) -> Any:
-    target = default_socket_path().expanduser().resolve()
-    if not target.exists():
-        raise ModelHubError("engine_down", status=503)
-    transport = httpx.HTTPTransport(uds=str(target))
     try:
+        endpoint = internal_client._resolve_endpoint(None)
+        transport = internal_client._sync_transport(endpoint)
         with httpx.Client(
             transport=transport,
-            base_url="http://localhost",
+            base_url=endpoint.base_url,
+            headers=endpoint.headers,
             timeout=httpx.Timeout(_RPC_TIMEOUT_SECONDS, connect=2.0),
         ) as client:
             response = client.post(
                 "/internal/model-hub",
                 json={"operation": operation, "payload": payload or {}},
             )
+            internal_client._validate_response(response, endpoint)
     except _TRANSPORT_ERRORS:
         raise ModelHubError("engine_down", status=503) from None
     return _decode(response)
 
 
 async def _rpc(operation: str, payload: Optional[dict[str, Any]] = None) -> Any:
-    target = default_socket_path().expanduser().resolve()
-    if not target.exists():
-        raise ModelHubError("engine_down", status=503)
-    transport = httpx.AsyncHTTPTransport(uds=str(target))
     try:
+        endpoint = internal_client._resolve_endpoint(None)
+        transport = internal_client._async_transport(endpoint)
         async with httpx.AsyncClient(
             transport=transport,
-            base_url="http://localhost",
+            base_url=endpoint.base_url,
+            headers=endpoint.headers,
             timeout=httpx.Timeout(_RPC_TIMEOUT_SECONDS, connect=2.0),
         ) as client:
             response = await client.post(
                 "/internal/model-hub",
                 json={"operation": operation, "payload": payload or {}},
             )
+            internal_client._validate_response(response, endpoint)
     except _TRANSPORT_ERRORS:
         raise ModelHubError("engine_down", status=503) from None
     return _decode(response)


### PR DESCRIPTION
## Capability

Adds the first native Windows Controller control IPC transport while preserving
the existing POSIX Unix-domain socket contract and current internal HTTP/SSE
routes.

Integration target: `desktop`. This PR must not merge directly to `master`.

- pre-binds an ephemeral `127.0.0.1:0` listener on Windows;
- atomically publishes a strict endpoint descriptor with a fresh instance ID
  and CSPRNG bearer credential;
- creates and validates the runtime directory, lock, temporary descriptor, and
  stable descriptor with an explicit protected DACL granting full access only
  to the current user and Local System;
- authenticates every Windows request and stream and validates the responding
  Controller instance, including generated 500 responses;
- centralizes endpoint selection so shared internal and Model Hub clients use
  the same TCP/UDS transport, bearer header, successor discovery, and instance
  validation;
- keeps descriptor replacement and shutdown cleanup owner-safe;
- adds a focused `windows-latest` contract job.

The endpoint and Windows filesystem-security contracts were frozen before
implementation.

## Scenarios

- D03: streaming chat transport and reconnect semantics
- D12: native Windows Runtime control path without WSL

## Evidence

- **Unit:** strict descriptor validation, loopback-only bind, bind retry,
  credential rotation, atomic replace failure, owner-safe cleanup, bearer
  rejection, stale-instance rejection, Model Hub sync/async routing, and
  generated-500 instance identity.
- **Contract:** POSIX keeps UDS selection; Windows requires an exact protected
  current-user/SYSTEM DACL on directory, lock, temporary, and stable artifacts.
  Widened/non-owner artifacts and Win32 security API failures fail closed.
- **Scenario:** real uvicorn loopback dispatch preserves non-ASCII request/SSE
  data and ordered events; reconnect follows an atomically published successor
  descriptor.
- **Local:** `102 passed, 5 skipped` across control IPC, internal server, and
  internal client suites on macOS; Ruff and `git diff --check` passed. The five
  skipped tests are native Windows ACL tests.
- **CI:** `windows-control-ipc` runs the transport and real ACL contract on
  `windows-latest`.
- **Residual manual:** native Windows service start/stop and a real D12 Codex
  turn remain for the integrated Windows acceptance pass.

## Dependencies

None.

## Known Follow-up

Windows reparse points beyond ordinary symlinks need a separate focused path
integrity hardening pass. This does not weaken the current-user/SYSTEM DACL
contract or permit broader principals.
