### PR TITLE
fix(ui): tighten chat source chip label-title spacing

### DIFF
--- a/ui/src/components/workbench/ChatPage.tsx
+++ b/ui/src/components/workbench/ChatPage.tsx
@@ -3226,33 +3226,39 @@ const MessageRow = memo(function MessageRow({ message, session, messageFontSize,
         <div className="group/message flex max-w-[min(92%,860px)] flex-col items-start gap-1">
           <div className="flex items-center gap-2 px-0.5">
             <RoleAvatar tone="cyan"><Clock /></RoleAvatar>
-            {triggerLink?.kind === 'harness' ? (
-              // A9b: task/watch label deep-links to the Harness filtered view.
-              <button
-                type="button"
-                onClick={() => navigate(triggerLink.to)}
-                className="inline-flex items-center gap-1 text-[11px] font-medium text-cyan hover:underline"
-              >
-                {t(harnessChipLabelKey(message))}
-                <ArrowUpRight className="size-3 shrink-0" />
-              </button>
-            ) : (
-              <span className="text-[11px] font-medium text-cyan">{t(harnessChipLabelKey(message))}</span>
-            )}
-            {triggerLink?.kind === 'source' && (
-              // A9a: agent-callback shows the SOURCE session + links to its chat.
-              <>
-                <span className="text-[11px] text-muted">·</span>
+            {/* Label and source title read as one phrase ("From · <title>"), so they
+                sit in a tight cluster; the parent gap only spaces avatar ↔ cluster. */}
+            <span className="inline-flex min-w-0 items-center gap-1">
+              {triggerLink?.kind === 'harness' ? (
+                // A9b: task/watch label deep-links to the Harness filtered view.
                 <button
                   type="button"
                   onClick={() => navigate(triggerLink.to)}
-                  className="inline-flex min-w-0 items-center gap-1 text-[11px] font-medium text-cyan hover:underline"
+                  className="inline-flex items-center gap-1 text-[11px] font-medium text-cyan hover:underline"
                 >
-                  <span className="min-w-0 truncate">{triggerLink.label}</span>
+                  {t(harnessChipLabelKey(message))}
                   <ArrowUpRight className="size-3 shrink-0" />
                 </button>
-              </>
-            )}
+              ) : (
+                <span className="shrink-0 text-[11px] font-medium text-cyan">
+                  {t(harnessChipLabelKey(message))}
+                </span>
+              )}
+              {triggerLink?.kind === 'source' && (
+                // A9a: agent-callback shows the SOURCE session + links to its chat.
+                <>
+                  <span className="shrink-0 text-[11px] text-muted">·</span>
+                  <button
+                    type="button"
+                    onClick={() => navigate(triggerLink.to)}
+                    className="inline-flex min-w-0 items-center gap-1 text-[11px] font-medium text-cyan hover:underline"
+                  >
+                    <span className="min-w-0 truncate">{triggerLink.label}</span>
+                    <ArrowUpRight className="size-3 shrink-0" />
+                  </button>
+                </>
+              )}
+            </span>
           </div>
           <Button
             type="button"


### PR DESCRIPTION
## Capability

Chat page harness-trigger header: the source chip now reads as one phrase.

The chip introduced in #974 renders `<From> · <source session title>`. All three
parts were direct children of the header row's `gap-2` flex container, so the
`·` separator absorbed an 8px gap on *each* side — roughly a 20px trench in the
middle of a single phrase. Owner feedback (2026-07-26): "间隔好大".

Fix: label + `·` + title button are grouped into one nested
`inline-flex items-center gap-1` cluster. The parent `gap-2` now spaces only
avatar ↔ cluster, which is what it was for.

## Before / after (measured, not guessed)

Gap values resolved from the built stylesheet rather than from class names —
`ui/dist/assets/index-*.css` has `--spacing: .25rem`, `.gap-1{gap:calc(var(--spacing)*1)}`,
`.gap-2{gap:calc(var(--spacing)*2)}`:

| span | before | after |
| --- | --- | --- |
| avatar ↔ label | 8px | 8px (unchanged) |
| label ↔ `·` | 8px | 4px |
| `·` ↔ title | 8px | 4px |
| total label→title trench | 16px + dot glyph (~20px) | 8px + dot glyph (~12px) |

That matches the compact `A · B` form used everywhere else in this file — e.g.
`ChatPage.tsx:2075` renders `{kindLabel} · ` inside a single text node, where the
separator gets roughly half a space on each side.

## Scope

`ui/src/components/workbench/ChatPage.tsx` only. Pure layout regrouping — no
i18n changes, no `chatTrigger.ts` changes, no new tokens, no changed link
targets or trigger semantics.

- The `harness` branch (A9b task/watch deep link) and the `source` branch (A9a
  agent-callback deep link) keep their exact markup and handlers; only their
  parent grouping changed.
- With a `harness`-kind trigger the cluster holds a single child, so the render
  is byte-identical to before.

## Known-by-design ledger

- **`min-w-0` on the new cluster span** — required, not decorative. The cluster
  is a flex item (`min-width: auto` by default), so without it the title's
  existing `min-w-0 truncate` chain would be severed and narrow/mobile viewports
  would overflow instead of ellipsizing.
- **`shrink-0` on the label span and on the `·`** — the title button is the only
  element with a `truncate`, so it must be the one that absorbs shrinkage.
  Without these, a narrow viewport shrinks the un-truncatable label/separator
  boxes and their text overflows onto neighbours. This preserves the intended
  behaviour rather than changing it.
- **No new unit test** — the change has no behavioural surface a jsdom test can
  observe (jsdom performs no layout, so gap values are unmeasurable there).
  Evidence is the compiled-CSS measurement above plus the unchanged full suite.

## Evidence layers

- **Unit**: `npx vitest run` — 59 files, 435 tests, all pass (no regression;
  no test touches this markup).
- **Build**: `npm run build` in `ui/` — clean.
- **Lint**: `npx eslint src/components/workbench/ChatPage.tsx` — 8 errors /
  5 warnings, all pre-existing at lines 903–2888 (`no-explicit-any`,
  `react-hooks/*`); the edit sits at ~3227–3262 and adds none.
- **Contract**: n/a — single-file UI layout change, no cross-boundary shape.
- **Scenario**: n/a — no catalog under `tests/scenarios/` covers the workbench
  chat surface (`auth_setup`, `harness_failure_recovery`, `message_delivery`,
  `model_hub`, `telegram_topic_routing`, `tunnel_quality`).
- **Residual manual check**: visual confirmation of the tightened chip and of
  mobile-width truncation in a running UI is deferred to the orchestrator's
  integration/regression pass.

## Dependencies

None. #1018 touches workbench graph files with no overlap here.
