### PR TITLE
fix(show): render agent marks as plain language in chat

### DIFF
--- a/core/show_session_events.py
+++ b/core/show_session_events.py
@@ -17,6 +17,7 @@ from storage import messages_service
 from storage.db import create_sqlite_engine
 from storage.importer import ensure_sqlite_state, resolve_primary_platform_from_config
 from storage.models import agent_sessions, show_session_events
+from vibe.i18n import t as i18n_t
 
 DEFAULT_MARK_SCOPE = "default"
 HUMAN_EVENT_TYPES = {
@@ -55,6 +56,22 @@ ASSISTANT_MARK_EVENT_TYPES = {
     "assistant.mark.updated",
     "assistant.mark.resolved",
 }
+# Assistant marks are projected into the chat as a message the *user* reads, so
+# every member needs its own plain-language label. Keeping the mapping next to
+# the event set (and asserting they enumerate each other in tests) means a fourth
+# mark event fails a test instead of leaking a raw i18n key into a conversation.
+ASSISTANT_MARK_TRANSCRIPT_I18N_KEYS = {
+    "assistant.mark.created": "show.mark.created",
+    "assistant.mark.updated": "show.mark.updated",
+    "assistant.mark.resolved": "show.mark.resolved",
+}
+# Longest locator the transcript header will carry before eliding; a header is one
+# line, and anchor text can be a whole paragraph of page copy.
+MARK_LOCATOR_MAX_LENGTH = 60
+# CSS combinators, attribute/pseudo syntax, and quoting. Whitespace is checked
+# separately because it is also the descendant combinator.
+_SELECTOR_SYNTAX_CHARS = frozenset("#.>[]:()=~+*,\"'|/\\")
+_SYNTHETIC_MARK_ID_PREFIXES = ("mark-", "mark_")
 
 
 class ShowSessionEventError(ValueError):
@@ -92,6 +109,9 @@ class ShowSessionEventStore:
         records_author = actor == "human" or (event_type == "assistant.mark.resolved" and author is not None)
         event_id = _event_id(payload, {})
         created_at = _utc_now_iso()
+        # Resolved once per append, outside the transaction: transcript text is
+        # rendered for the user at write time, so it needs their display language.
+        lang = _configured_language()
 
         with ExitStack() as cleanup:
             with self.engine.begin() as conn:
@@ -127,7 +147,7 @@ class ShowSessionEventStore:
                 transcript_text = (
                     ""
                     if event_type == "assistant.mark.resolved" and author is not None
-                    else _format_transcript_text(event_type, event_payload, anchor)
+                    else _format_transcript_text(event_type, event_payload, anchor, lang=lang)
                 )
                 if records_author:
                     event_payload["author"] = _normalize_human_author(author)
@@ -585,29 +605,94 @@ def _format_transcript_header(
     return f"[{' '.join(parts)}]"
 
 
-def _format_transcript_text(event_type: str, payload: dict[str, Any], anchor: dict[str, Any]) -> str:
+def is_human_readable_mark_target(raw: Any) -> bool:
+    """Whether a mark ``target`` reads as a name the user would recognize.
+
+    ``target`` is whatever the agent handed to ``vibe show mark``: usually a CSS
+    selector, or a synthetic ``mark-<scope>-<id>`` handle minted by the Show SDK.
+    Neither means anything to the person reading the chat, so the transcript drops
+    the locator rather than printing machine text at them.
+    """
+    value = _text_or_none(raw)
+    if not value:
+        return False
+    if value.lower().startswith(_SYNTHETIC_MARK_ID_PREFIXES):
+        return False
+    if any(char.isspace() for char in value):
+        return False
+    return not any(char in _SELECTOR_SYNTAX_CHARS for char in value)
+
+
+def _condense_mark_locator(value: str) -> str:
+    collapsed = " ".join(value.split())
+    if len(collapsed) <= MARK_LOCATOR_MAX_LENGTH:
+        return collapsed
+    return collapsed[: MARK_LOCATOR_MAX_LENGTH - 1].rstrip() + "…"
+
+
+def _mark_locator(payload: dict[str, Any], anchor: dict[str, Any]) -> str | None:
+    """Words the user can match against the page, or nothing at all.
+
+    Anchor text is copy they can actually see, so it wins; ``target`` is only
+    usable when it happens to read as a name. There is no third fallback on
+    purpose — a selector printed as "where" is worse than no "where" at all.
+    """
+    anchor_text = _text_or_none(anchor.get("text"))
+    if anchor_text:
+        return _condense_mark_locator(anchor_text)
+    target = payload.get("target")
+    return _text_or_none(target) if is_human_readable_mark_target(target) else None
+
+
+def _configured_language() -> str:
+    """Display language for user-visible transcript text.
+
+    The store has no controller to read config off, so it loads the persisted
+    config directly; a headless run with no config file (tests, a fresh CLI) falls
+    back to English, the documented default.
+    """
+    from config.v2_config import V2Config
+
+    try:
+        return str(getattr(V2Config.load(), "language", "en") or "en")
+    except (OSError, ValueError):
+        return "en"
+
+
+def _format_assistant_mark_text(
+    event_type: str,
+    payload: dict[str, Any],
+    anchor: dict[str, Any],
+    *,
+    lang: str,
+) -> str:
+    """Render an assistant mark as the chat message a user reads.
+
+    The agent's own words are the message; everything else is a short header that
+    says what happened and, when it can be said in plain words, where.
+    """
+    header = i18n_t(ASSISTANT_MARK_TRANSCRIPT_I18N_KEYS[event_type], lang)
+    scope = _text_or_none(payload.get("scope")) or DEFAULT_MARK_SCOPE
+    if scope != DEFAULT_MARK_SCOPE:
+        header = i18n_t("show.mark.scopeSuffix", lang, header=header, scope=scope)
+    locator = _mark_locator(payload, anchor)
+    if locator:
+        header = i18n_t("show.mark.targetSuffix", lang, header=header, target=locator)
+    body = str(payload.get("body") or "").strip()
+    return f"{header}\n\n{body}" if body else header
+
+
+def _format_transcript_text(
+    event_type: str,
+    payload: dict[str, Any],
+    anchor: dict[str, Any],
+    *,
+    lang: str = "en",
+) -> str:
     if event_type == "system.annotation.control":
         return ""
-    if event_type.startswith("assistant.mark."):
-        action = event_type.split(".")[-1]
-        header = _format_transcript_header(
-            "agent-mark",
-            scope=payload.get("scope"),
-            action=action,
-            default_action="created",
-        )
-        lines = [
-            f"{header} {payload.get('target')}",
-            "",
-            str(payload.get("body") or "").strip(),
-        ]
-        selector = _text_or_none(anchor.get("selector"))
-        if selector:
-            lines.extend(["", f"Anchor: {selector}"])
-        text = _text_or_none(anchor.get("text"))
-        if text:
-            lines.append(f"Text: {text}")
-        return "\n".join(lines)
+    if event_type in ASSISTANT_MARK_TRANSCRIPT_I18N_KEYS:
+        return _format_assistant_mark_text(event_type, payload, anchor, lang=lang)
 
     if event_type == "human.intent.submitted":
         text = _text_or_none(payload.get("text") or payload.get("comment") or payload.get("value"))

--- a/core/show_session_events.py
+++ b/core/show_session_events.py
@@ -65,8 +65,14 @@ ASSISTANT_MARK_TRANSCRIPT_I18N_KEYS = {
     "assistant.mark.updated": "show.mark.updated",
     "assistant.mark.resolved": "show.mark.resolved",
 }
+# Anchor fields that hold copy the user can actually see on the page, best first.
+# Both are real: ``vibe show mark --anchor-text`` writes ``text``, while
+# ``vibe show reply`` copies the annotation's anchor verbatim, and a text-range
+# annotation carries its selected copy as ``textQuote``. Reading only one of them
+# throws away the user's own words on exactly the marks that quote them back.
+ANCHOR_HUMAN_COPY_KEYS = ("textQuote", "text")
 # Longest locator the transcript header will carry before eliding; a header is one
-# line, and anchor text can be a whole paragraph of page copy.
+# line, and anchor copy can be a whole paragraph of the page.
 MARK_LOCATOR_MAX_LENGTH = 60
 # CSS combinators, attribute/pseudo syntax, and quoting. Whitespace is checked
 # separately because it is also the descendant combinator.
@@ -633,15 +639,21 @@ def _condense_mark_locator(value: str) -> str:
 def _mark_locator(payload: dict[str, Any], anchor: dict[str, Any]) -> str | None:
     """Words the user can match against the page, or nothing at all.
 
-    Anchor text is copy they can actually see, so it wins; ``target`` is only
+    Anchor copy is text they can actually see, so it wins; ``target`` is only
     usable when it happens to read as a name. There is no third fallback on
     purpose — a selector printed as "where" is worse than no "where" at all.
+
+    Every result goes through :func:`_condense_mark_locator` on the way out,
+    because the header is one line no matter which source filled it.
     """
-    anchor_text = _text_or_none(anchor.get("text"))
-    if anchor_text:
-        return _condense_mark_locator(anchor_text)
+    for key in ANCHOR_HUMAN_COPY_KEYS:
+        anchor_copy = _text_or_none(anchor.get(key))
+        if anchor_copy:
+            return _condense_mark_locator(anchor_copy)
     target = payload.get("target")
-    return _text_or_none(target) if is_human_readable_mark_target(target) else None
+    if not is_human_readable_mark_target(target):
+        return None
+    return _condense_mark_locator(str(target))
 
 
 def _configured_language() -> str:

--- a/core/show_session_events.py
+++ b/core/show_session_events.py
@@ -70,15 +70,22 @@ ASSISTANT_MARK_TRANSCRIPT_I18N_KEYS = {
 # ``text``, while ``vibe show reply`` copies the annotation's anchor verbatim and
 # a text-range annotation carries its selected copy as ``textQuote``.
 #
-# Deliberately excluded is the mark's ``target``. Its contract is machine text --
-# ``vibe show mark`` documents it as "Target mark id or selector" -- so no rule can
-# tell a bare type selector like ``button`` or ``summary`` from a page label of the
-# same shape. Rather than adjudicate that ambiguity with a predicate (a blacklist
-# that reads complete and never is), the transcript never prints the field.
+# Deliberately excluded is every locator the mark itself carries. ``vibe show mark``
+# documents ``target`` as "Target mark id or selector" and ``scope`` as an
+# organizational key, so both are machine text by contract -- and no rule can tell a
+# bare type selector like ``button`` or a scope like ``hero`` from a page label of the
+# same shape. Rather than adjudicate that ambiguity with a predicate (a blacklist that
+# reads complete and never is), the transcript prints neither.
 ANCHOR_HUMAN_COPY_KEYS = ("textQuote", "text")
 # Longest locator the transcript header will carry before eliding; a header is one
 # line, and anchor copy can be a whole paragraph of the page.
 MARK_LOCATOR_MAX_LENGTH = 60
+# Everything a stored mark is made of. ``body`` is the agent's own words and the only
+# member the user-facing header may render; the rest are ids, timestamps, and the
+# machine-text locators above -- written for the runtime, not for a reader. The
+# transcript invariant is asserted over this enumeration, so a field added here has to
+# prove it stays out of chat rather than leaking on the next release.
+MARK_PAYLOAD_KEYS = ("id", "scope", "target", "body", "createdAt", "updatedAt", "replyTo")
 
 
 class ShowSessionEventError(ValueError):
@@ -357,7 +364,7 @@ def _prepare_mark_resolution(conn: Any, session_id: str, payload: dict[str, Any]
 
     mark = {
         key: active_mark[key]
-        for key in ("id", "scope", "target", "body", "createdAt", "updatedAt", "replyTo")
+        for key in MARK_PAYLOAD_KEYS
         if active_mark.get(key) is not None
     }
     return {
@@ -658,13 +665,19 @@ def _format_assistant_mark_text(
 ) -> str:
     """Render an assistant mark as the chat message a user reads.
 
-    The agent's own words are the message; everything else is a short header that
-    says what happened and, when it can be said in plain words, where.
+    The agent's own words are the message; the header is a short line saying what
+    happened and, when it can be said in plain words, where.
+
+    The header is assembled from exactly two sources, and that is the invariant:
+    a closed label map keyed by event type, and anchor copy the user can see on
+    the page. No free-form field of the mark reaches the user -- not ``target``
+    (see :data:`ANCHOR_HUMAN_COPY_KEYS`), and not ``scope``, which namespaces the
+    synthetic mark id in :func:`stable_assistant_mark_id`, never appears anywhere
+    on the page, and so names nothing the reader could go and look at. ``body``,
+    the agent's own ``--message``, is the one payload field that is human words by
+    construction, and it is the message rather than the header.
     """
     header = i18n_t(ASSISTANT_MARK_TRANSCRIPT_I18N_KEYS[event_type], lang)
-    scope = _text_or_none(payload.get("scope")) or DEFAULT_MARK_SCOPE
-    if scope != DEFAULT_MARK_SCOPE:
-        header = i18n_t("show.mark.scopeSuffix", lang, header=header, scope=scope)
     locator = _mark_locator(anchor)
     if locator:
         header = i18n_t("show.mark.quoteSuffix", lang, header=header, quote=locator)

--- a/core/show_session_events.py
+++ b/core/show_session_events.py
@@ -65,19 +65,20 @@ ASSISTANT_MARK_TRANSCRIPT_I18N_KEYS = {
     "assistant.mark.updated": "show.mark.updated",
     "assistant.mark.resolved": "show.mark.resolved",
 }
-# Anchor fields that hold copy the user can actually see on the page, best first.
-# Both are real: ``vibe show mark --anchor-text`` writes ``text``, while
-# ``vibe show reply`` copies the annotation's anchor verbatim, and a text-range
-# annotation carries its selected copy as ``textQuote``. Reading only one of them
-# throws away the user's own words on exactly the marks that quote them back.
+# The *only* fields the user-facing locator may come from, best first. Both hold
+# copy the user can see on the page: ``vibe show mark --anchor-text`` writes
+# ``text``, while ``vibe show reply`` copies the annotation's anchor verbatim and
+# a text-range annotation carries its selected copy as ``textQuote``.
+#
+# Deliberately excluded is the mark's ``target``. Its contract is machine text --
+# ``vibe show mark`` documents it as "Target mark id or selector" -- so no rule can
+# tell a bare type selector like ``button`` or ``summary`` from a page label of the
+# same shape. Rather than adjudicate that ambiguity with a predicate (a blacklist
+# that reads complete and never is), the transcript never prints the field.
 ANCHOR_HUMAN_COPY_KEYS = ("textQuote", "text")
 # Longest locator the transcript header will carry before eliding; a header is one
 # line, and anchor copy can be a whole paragraph of the page.
 MARK_LOCATOR_MAX_LENGTH = 60
-# CSS combinators, attribute/pseudo syntax, and quoting. Whitespace is checked
-# separately because it is also the descendant combinator.
-_SELECTOR_SYNTAX_CHARS = frozenset("#.>[]:()=~+*,\"'|/\\")
-_SYNTHETIC_MARK_ID_PREFIXES = ("mark-", "mark_")
 
 
 class ShowSessionEventError(ValueError):
@@ -611,24 +612,6 @@ def _format_transcript_header(
     return f"[{' '.join(parts)}]"
 
 
-def is_human_readable_mark_target(raw: Any) -> bool:
-    """Whether a mark ``target`` reads as a name the user would recognize.
-
-    ``target`` is whatever the agent handed to ``vibe show mark``: usually a CSS
-    selector, or a synthetic ``mark-<scope>-<id>`` handle minted by the Show SDK.
-    Neither means anything to the person reading the chat, so the transcript drops
-    the locator rather than printing machine text at them.
-    """
-    value = _text_or_none(raw)
-    if not value:
-        return False
-    if value.lower().startswith(_SYNTHETIC_MARK_ID_PREFIXES):
-        return False
-    if any(char.isspace() for char in value):
-        return False
-    return not any(char in _SELECTOR_SYNTAX_CHARS for char in value)
-
-
 def _condense_mark_locator(value: str) -> str:
     collapsed = " ".join(value.split())
     if len(collapsed) <= MARK_LOCATOR_MAX_LENGTH:
@@ -636,24 +619,19 @@ def _condense_mark_locator(value: str) -> str:
     return collapsed[: MARK_LOCATOR_MAX_LENGTH - 1].rstrip() + "…"
 
 
-def _mark_locator(payload: dict[str, Any], anchor: dict[str, Any]) -> str | None:
+def _mark_locator(anchor: dict[str, Any]) -> str | None:
     """Words the user can match against the page, or nothing at all.
 
-    Anchor copy is text they can actually see, so it wins; ``target`` is only
-    usable when it happens to read as a name. There is no third fallback on
-    purpose — a selector printed as "where" is worse than no "where" at all.
-
-    Every result goes through :func:`_condense_mark_locator` on the way out,
-    because the header is one line no matter which source filled it.
+    Only anchor copy qualifies — see :data:`ANCHOR_HUMAN_COPY_KEYS` for why the
+    mark's ``target`` is not a fallback. Without it the header simply says what
+    happened and the agent's own message says the rest; a locator the user cannot
+    read is not a locator, just noise wearing the word "where".
     """
     for key in ANCHOR_HUMAN_COPY_KEYS:
         anchor_copy = _text_or_none(anchor.get(key))
         if anchor_copy:
             return _condense_mark_locator(anchor_copy)
-    target = payload.get("target")
-    if not is_human_readable_mark_target(target):
-        return None
-    return _condense_mark_locator(str(target))
+    return None
 
 
 def _configured_language() -> str:
@@ -687,9 +665,9 @@ def _format_assistant_mark_text(
     scope = _text_or_none(payload.get("scope")) or DEFAULT_MARK_SCOPE
     if scope != DEFAULT_MARK_SCOPE:
         header = i18n_t("show.mark.scopeSuffix", lang, header=header, scope=scope)
-    locator = _mark_locator(payload, anchor)
+    locator = _mark_locator(anchor)
     if locator:
-        header = i18n_t("show.mark.targetSuffix", lang, header=header, target=locator)
+        header = i18n_t("show.mark.quoteSuffix", lang, header=header, quote=locator)
     body = str(payload.get("body") or "").strip()
     return f"{header}\n\n{body}" if body else header
 

--- a/tests/test_show_pages.py
+++ b/tests/test_show_pages.py
@@ -2382,6 +2382,10 @@ def test_show_reply_copies_annotation_anchor_and_replaces_prior_reply(monkeypatc
     assert first["mark_id"] == second["mark_id"]
     assert first["event"]["anchor"] == annotation["anchor"]
     assert first["event"]["payload"]["target"] == "#revenue-card"
+    # A reply copies the annotation's anchor, so the chat message can quote the copy
+    # the user highlighted; the reply target is the selector and stays out of sight.
+    assert first["event"]["transcript_text"] == "Page note · “Revenue”\n\nFirst answer."
+    assert "#revenue-card" not in first["event"]["transcript_text"]
     assert first["event"]["payload"]["replyTo"] == annotation["id"]
     assert second["replaced"] is True
     assert "vibe show marks" in second["replacement_notice"]

--- a/tests/test_show_pages.py
+++ b/tests/test_show_pages.py
@@ -2206,7 +2206,9 @@ def test_show_mark_cli_records_event_and_message(monkeypatch, tmp_path, capsys):
     assert payload["ok"] is True
     assert payload["event"]["type"] == "assistant.mark.created"
     assert payload["event"]["message_id"]
-    assert payload["event"]["transcript_text"].startswith("[agent-mark] mark-default-summary")
+    # No anchor text and a synthetic target: the header stands alone rather than
+    # falling back to printing the handle at the user.
+    assert payload["event"]["transcript_text"] == "Page note\n\nReview this summary."
 
     with engine.connect() as conn:
         assert conn.execute(select(show_session_events.c.id)).scalar_one() == payload["event"]["id"]
@@ -2296,7 +2298,7 @@ def test_show_mark_cli_posts_to_live_ui_when_running(monkeypatch, tmp_path, caps
                         "scope": "default",
                         "anchor": {},
                         "payload": {},
-                        "transcript_text": "[agent-mark] mark-default-summary\n\nReview this summary.",
+                        "transcript_text": "Page note\n\nReview this summary.",
                         "message_id": "msg_live",
                         "message": {"id": "msg_live"},
                         "created_at": "now",

--- a/tests/test_show_pages.py
+++ b/tests/test_show_pages.py
@@ -2215,6 +2215,83 @@ def test_show_mark_cli_records_event_and_message(monkeypatch, tmp_path, capsys):
         assert "Review this summary." in conn.execute(select(messages.c.content_text)).scalar_one()
 
 
+@pytest.mark.parametrize(
+    ("flags", "expected_anchor"),
+    [
+        (["--anchor-text", "Checkout"], {"text": "Checkout"}),
+        (["--anchor-selector", "#cta"], {"selector": "#cta"}),
+        (
+            ["--anchor-selector", "#cta", "--anchor-text", "Checkout"],
+            {"selector": "#cta", "text": "Checkout"},
+        ),
+    ],
+    ids=["text-only", "selector-only", "both"],
+)
+def test_show_mark_keeps_anchor_text_without_a_selector(monkeypatch, tmp_path, capsys, flags, expected_anchor):
+    """``--anchor-text`` alone is a valid invocation and must survive.
+
+    The parser advertises the two anchor flags independently, but the payload used
+    to build an anchor only when a selector was present, so a standalone
+    ``--anchor-text`` was silently discarded. That was invisible while the
+    transcript fell back to printing ``target``; now that the locator comes only
+    from anchor copy, dropping it loses the one human-readable locator the agent
+    supplied.
+    """
+    from sqlalchemy import select
+
+    from storage import messages_service
+    from storage.db import create_sqlite_engine
+    from storage.importer import ensure_sqlite_state
+    from storage.models import agent_sessions, show_session_events
+    from storage.settings_service import upsert_scope
+
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    paths.ensure_data_dirs()
+    _save_config()
+    ensure_sqlite_state()
+
+    engine = create_sqlite_engine()
+    now = messages_service._utc_now_iso()
+    with engine.begin() as conn:
+        scope_id = upsert_scope(conn, platform="avibe", scope_type="project", native_id="proj_show", now=now)
+        conn.execute(
+            agent_sessions.insert().values(
+                id="ses123",
+                scope_id=scope_id,
+                agent_backend="codex",
+                agent_variant="default",
+                session_anchor="anchor_ses123",
+                native_session_id="",
+                status="active",
+                metadata_json="{}",
+                created_at=now,
+                updated_at=now,
+                last_active_at=now,
+            )
+        )
+
+    args = cli.build_parser().parse_args(
+        ["show", "mark", "--session-id", "ses123", "--target", "cta", "--body", "Aligned it.", "--json", *flags]
+    )
+    assert cli.cmd_show(args) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is True
+
+    with engine.connect() as conn:
+        anchor = json.loads(conn.execute(select(show_session_events.c.anchor_json)).scalar_one())
+    assert anchor == expected_anchor
+
+    # The user-facing echo locates the mark whenever anchor copy was supplied, and
+    # never leaks the selector that may sit beside it.
+    transcript = payload["event"]["transcript_text"]
+    if "text" in expected_anchor:
+        assert transcript == "Page note · “Checkout”\n\nAligned it."
+    else:
+        assert transcript == "Page note\n\nAligned it."
+    assert "#cta" not in transcript
+
+
 def test_show_mark_defaults_to_caller_session(monkeypatch, tmp_path, capsys):
     from sqlalchemy import select
 

--- a/tests/test_show_session_events.py
+++ b/tests/test_show_session_events.py
@@ -9,7 +9,15 @@ from pathlib import Path
 import pytest
 from sqlalchemy import select
 
-from core.show_session_events import ShowSessionEventError, ShowSessionEventStore, _format_transcript_text
+from core.show_session_events import (
+    ASSISTANT_MARK_EVENT_TYPES,
+    ASSISTANT_MARK_TRANSCRIPT_I18N_KEYS,
+    MARK_LOCATOR_MAX_LENGTH,
+    ShowSessionEventError,
+    ShowSessionEventStore,
+    _format_transcript_text,
+    is_human_readable_mark_target,
+)
 from storage.db import create_sqlite_engine
 from storage.importer import ensure_sqlite_state
 from storage.models import agent_sessions, media_objects, messages, show_session_events
@@ -106,8 +114,11 @@ def test_show_event_store_records_assistant_mark_and_transcript_message(isolated
     assert event["scope"] == "default"
     assert event["message_id"]
     assert event["message"]["id"] == event["message_id"]
-    assert "[agent-mark] mark-default-summary" in event["transcript_text"]
-    assert "Anchor: [mark-default='summary']" in event["transcript_text"]
+    # The user reads this one, so it says what happened and quotes copy they can
+    # see on the page — never the synthetic target or the selector behind it.
+    assert event["transcript_text"] == 'Page note · “Quarterly summary”\n\nReview this summary again.'
+    assert "mark-default-summary" not in event["transcript_text"]
+    assert "[mark-default='summary']" not in event["transcript_text"]
 
     with engine.connect() as conn:
         event_row = conn.execute(select(show_session_events)).mappings().one()
@@ -768,17 +779,17 @@ def test_show_event_store_records_assistant_page_update(isolated_state):
         (
             "assistant.mark.created",
             {"scope": "default", "target": "summary", "body": "Created."},
-            "[agent-mark] summary",
+            "Page note · “summary”",
         ),
         (
             "assistant.mark.resolved",
             {"scope": "default", "target": "summary", "body": "Resolved."},
-            "[agent-mark resolved] summary",
+            "Page note (resolved) · “summary”",
         ),
         (
             "assistant.mark.updated",
             {"scope": "review", "target": "summary", "body": "Updated."},
-            "[agent-mark updated scope=review] summary",
+            "Page note (updated) · review · “summary”",
         ),
         (
             "human.intent.submitted",
@@ -816,6 +827,136 @@ def test_show_event_transcript_headers_only_render_deviations(event_type, payloa
     transcript = _format_transcript_text(event_type, payload, {})
 
     assert transcript.splitlines()[0] == expected_header
+
+
+@pytest.mark.parametrize(
+    ("target", "readable"),
+    [
+        ("#root > div.grid > section:nth-child(3) .cta-button", False),  # CSS selector
+        ("mark-default-summary", False),  # synthetic mark handle
+        ("summary", True),  # a name
+        (None, False),  # nothing to say
+    ],
+)
+def test_mark_target_is_only_human_readable_when_it_reads_as_a_name(target, readable):
+    assert is_human_readable_mark_target(target) is readable
+
+
+@pytest.mark.parametrize(
+    ("payload", "anchor"),
+    [
+        (
+            {"target": "#root > div.grid > section:nth-child(3) .cta-button", "body": "Aligned it."},
+            {"selector": "#root > div.grid > section:nth-child(3) .cta-button"},
+        ),
+        ({"target": "mark-default-summary", "body": "Aligned it."}, {"selector": "[mark-default='summary']"}),
+        ({"target": "mark_9f2a7c1d", "body": "Aligned it."}, {}),
+        ({"target": "[data-testid='cta']", "body": "Aligned it."}, {}),
+    ],
+)
+def test_assistant_mark_transcript_never_shows_machine_locators(payload, anchor):
+    """The hard invariant: a user never reads a selector or a synthetic id."""
+    transcript = _format_transcript_text("assistant.mark.created", payload, anchor)
+
+    assert transcript == "Page note\n\nAligned it."
+    assert payload["target"] not in transcript
+    for selector in anchor.values():
+        assert selector not in transcript
+
+
+def test_assistant_mark_transcript_prefers_page_copy_over_target():
+    transcript = _format_transcript_text(
+        "assistant.mark.created",
+        {"target": "cta", "body": "Aligned it."},
+        {"selector": "#root .cta-button", "text": "Get started"},
+    )
+
+    assert transcript == "Page note · “Get started”\n\nAligned it."
+
+
+def test_assistant_mark_transcript_renders_in_the_configured_language():
+    transcript = _format_transcript_text(
+        "assistant.mark.updated",
+        {"target": "cta", "body": "改了按钮的对齐方式，和设计稿一致了"},
+        {"text": "开始使用"},
+        lang="zh",
+    )
+
+    assert transcript == "页面批注（已更新） ·「开始使用」\n\n改了按钮的对齐方式，和设计稿一致了"
+
+
+def test_assistant_mark_transcript_keeps_the_whole_body():
+    body = "Detail. " * 200
+    transcript = _format_transcript_text(
+        "assistant.mark.created",
+        {"target": "cta", "body": body},
+        {"text": "Get started"},
+    )
+
+    assert transcript.endswith(body.strip())
+
+
+def test_assistant_mark_locator_is_condensed_to_one_line():
+    transcript = _format_transcript_text(
+        "assistant.mark.created",
+        {"target": "cta", "body": "Aligned it."},
+        {"text": "Get\n started " + "x" * MARK_LOCATOR_MAX_LENGTH},
+    )
+    header = transcript.splitlines()[0]
+
+    assert header.startswith("Page note · “Get started x")
+    assert header.endswith("…”")
+    assert len(transcript.splitlines()) == 3  # header, blank, body
+
+
+def test_every_assistant_mark_event_has_a_plain_language_label():
+    """Adding a fourth mark event must fail here, not leak a raw key into chat."""
+    from vibe.i18n import get_supported_languages, t as i18n_t
+
+    assert set(ASSISTANT_MARK_TRANSCRIPT_I18N_KEYS) == ASSISTANT_MARK_EVENT_TYPES
+    for lang in get_supported_languages():
+        for key in ASSISTANT_MARK_TRANSCRIPT_I18N_KEYS.values():
+            assert i18n_t(key, lang) != key
+
+
+def test_appended_mark_speaks_the_users_configured_language(isolated_state):
+    """The store has no controller, so prove it still reaches the saved language."""
+    from config.v2_config import (
+        AgentsConfig,
+        PlatformsConfig,
+        RuntimeConfig,
+        SlackConfig,
+        UiConfig,
+        V2Config,
+    )
+
+    V2Config(
+        mode="self_host",
+        version="v2",
+        platform="slack",
+        platforms=PlatformsConfig(enabled=["slack"], primary="slack"),
+        slack=SlackConfig(bot_token=""),
+        runtime=RuntimeConfig(default_cwd="."),
+        agents=AgentsConfig(),
+        ui=UiConfig(),
+        language="zh",
+    ).save()
+
+    _seed_session()
+    store = ShowSessionEventStore()
+    try:
+        event = store.append(
+            "ses_mark",
+            {
+                "type": "assistant.mark.created",
+                "mark": {"target": "#hero > .cta", "body": "按钮对齐改好了"},
+                "anchor": {"text": "开始使用"},
+            },
+        )
+    finally:
+        store.close()
+
+    assert event["transcript_text"] == "页面批注 ·「开始使用」\n\n按钮对齐改好了"
 
 
 def test_show_event_store_rejects_unknown_session(isolated_state):

--- a/tests/test_show_session_events.py
+++ b/tests/test_show_session_events.py
@@ -10,6 +10,7 @@ import pytest
 from sqlalchemy import select
 
 from core.show_session_events import (
+    ANCHOR_HUMAN_COPY_KEYS,
     ASSISTANT_MARK_EVENT_TYPES,
     ASSISTANT_MARK_TRANSCRIPT_I18N_KEYS,
     MARK_LOCATOR_MAX_LENGTH,
@@ -894,6 +895,56 @@ def test_assistant_mark_transcript_keeps_the_whole_body():
     )
 
     assert transcript.endswith(body.strip())
+
+
+def test_assistant_mark_transcript_quotes_a_text_range_anchor():
+    """`vibe show reply` copies the annotation anchor, which carries ``textQuote``."""
+    transcript = _format_transcript_text(
+        "assistant.mark.created",
+        {"target": "#revenue-card", "body": "Q3 restated the figure."},
+        {"kind": "text-range", "selector": "#revenue-card", "textQuote": "Revenue"},
+    )
+
+    assert transcript == "Page note · “Revenue”\n\nQ3 restated the figure."
+    assert "#revenue-card" not in transcript
+
+
+@pytest.mark.parametrize("copy_key", ANCHOR_HUMAN_COPY_KEYS)
+def test_both_transcript_directions_read_the_same_anchor_copy_fields(copy_key):
+    """The user-facing and agent-facing formatters must agree on where copy lives.
+
+    Adding a third anchor copy field to one side and not the other silently drops
+    the user's own words from whichever transcript forgot it, so pin both here.
+    """
+    mark = _format_transcript_text(
+        "assistant.mark.created",
+        {"target": "#revenue-card", "body": "Answered."},
+        {"selector": "#revenue-card", copy_key: "Revenue"},
+    )
+    annotation = _format_transcript_text(
+        "human.annotation.created",
+        {"comment": "Why?"},
+        {"selector": "#revenue-card", copy_key: "Revenue"},
+    )
+
+    assert mark == "Page note · “Revenue”\n\nAnswered."
+    assert "Quote: Revenue" in annotation
+
+
+@pytest.mark.parametrize("anchor", [{}, {"text": ""}], ids=["no-anchor", "blank-copy"])
+def test_assistant_mark_condenses_every_locator_source(anchor):
+    """Whichever source fills the locator, the header stays one bounded line."""
+    long_name = "Onboarding" * MARK_LOCATOR_MAX_LENGTH
+    transcript = _format_transcript_text(
+        "assistant.mark.created",
+        {"target": long_name, "body": "Aligned it."},
+        anchor,
+    )
+    header = transcript.splitlines()[0]
+
+    assert header.startswith("Page note · “Onboarding")
+    assert header.endswith("…”")
+    assert len(header) < len(long_name)
 
 
 def test_assistant_mark_locator_is_condensed_to_one_line():

--- a/tests/test_show_session_events.py
+++ b/tests/test_show_session_events.py
@@ -17,7 +17,6 @@ from core.show_session_events import (
     ShowSessionEventError,
     ShowSessionEventStore,
     _format_transcript_text,
-    is_human_readable_mark_target,
 )
 from storage.db import create_sqlite_engine
 from storage.importer import ensure_sqlite_state
@@ -777,20 +776,23 @@ def test_show_event_store_records_assistant_page_update(isolated_state):
 @pytest.mark.parametrize(
     ("event_type", "payload", "expected_header"),
     [
+        # These three carry a `target` that no header renders: the mark cases are
+        # here to pin action and scope wording, and they double as a reminder that
+        # the field master used to print is now invisible whatever else varies.
         (
             "assistant.mark.created",
             {"scope": "default", "target": "summary", "body": "Created."},
-            "Page note · “summary”",
+            "Page note",
         ),
         (
             "assistant.mark.resolved",
             {"scope": "default", "target": "summary", "body": "Resolved."},
-            "Page note (resolved) · “summary”",
+            "Page note (resolved)",
         ),
         (
             "assistant.mark.updated",
             {"scope": "review", "target": "summary", "body": "Updated."},
-            "Page note (updated) · review · “summary”",
+            "Page note (updated) · review",
         ),
         (
             "human.intent.submitted",
@@ -831,41 +833,35 @@ def test_show_event_transcript_headers_only_render_deviations(event_type, payloa
 
 
 @pytest.mark.parametrize(
-    ("target", "readable"),
+    "target",
     [
-        ("#root > div.grid > section:nth-child(3) .cta-button", False),  # CSS selector
-        ("mark-default-summary", False),  # synthetic mark handle
-        ("summary", True),  # a name
-        (None, False),  # nothing to say
+        "#root > div.grid > section:nth-child(3) .cta-button",  # compound selector
+        "mark-default-summary",  # synthetic mark handle
+        "mark_9f2a7c1d",  # synthetic mark handle, underscore form
+        "[data-testid='cta']",  # attribute selector
+        "button",  # bare type selector -- indistinguishable from a page label
+        "summary",  # ditto, and the documented example in `vibe show mark --help`
+        "Get started",  # reads like copy, but the field's contract is machine text
+        None,  # nothing to say
     ],
 )
-def test_mark_target_is_only_human_readable_when_it_reads_as_a_name(target, readable):
-    assert is_human_readable_mark_target(target) is readable
+def test_assistant_mark_transcript_never_shows_the_mark_target(target):
+    """The hard invariant, enforced structurally: ``target`` is never printed.
 
-
-@pytest.mark.parametrize(
-    ("payload", "anchor"),
-    [
-        (
-            {"target": "#root > div.grid > section:nth-child(3) .cta-button", "body": "Aligned it."},
-            {"selector": "#root > div.grid > section:nth-child(3) .cta-button"},
-        ),
-        ({"target": "mark-default-summary", "body": "Aligned it."}, {"selector": "[mark-default='summary']"}),
-        ({"target": "mark_9f2a7c1d", "body": "Aligned it."}, {}),
-        ({"target": "[data-testid='cta']", "body": "Aligned it."}, {}),
-    ],
-)
-def test_assistant_mark_transcript_never_shows_machine_locators(payload, anchor):
-    """The hard invariant: a user never reads a selector or a synthetic id."""
-    transcript = _format_transcript_text("assistant.mark.created", payload, anchor)
+    Every value here is what an agent may legitimately pass to ``vibe show mark``.
+    ``button`` and ``summary`` are the reason this is a blanket rule rather than a
+    predicate: as strings they are both valid bare type selectors and plausible page
+    labels, so no test on the text can separate the safe case from the unsafe one.
+    The last case shows the cost we accepted -- copy in the wrong field is dropped
+    too, because the field cannot promise it is copy.
+    """
+    transcript = _format_transcript_text("assistant.mark.created", {"target": target, "body": "Aligned it."}, {})
 
     assert transcript == "Page note\n\nAligned it."
-    assert payload["target"] not in transcript
-    for selector in anchor.values():
-        assert selector not in transcript
 
 
-def test_assistant_mark_transcript_prefers_page_copy_over_target():
+def test_assistant_mark_transcript_quotes_page_copy_the_user_can_see():
+    """The anchor is the only human source, so it is the only thing that locates."""
     transcript = _format_transcript_text(
         "assistant.mark.created",
         {"target": "cta", "body": "Aligned it."},
@@ -873,6 +869,7 @@ def test_assistant_mark_transcript_prefers_page_copy_over_target():
     )
 
     assert transcript == "Page note · “Get started”\n\nAligned it."
+    assert "#root .cta-button" not in transcript
 
 
 def test_assistant_mark_transcript_renders_in_the_configured_language():
@@ -931,27 +928,21 @@ def test_both_transcript_directions_read_the_same_anchor_copy_fields(copy_key):
     assert "Quote: Revenue" in annotation
 
 
-@pytest.mark.parametrize("anchor", [{}, {"text": ""}], ids=["no-anchor", "blank-copy"])
-def test_assistant_mark_condenses_every_locator_source(anchor):
-    """Whichever source fills the locator, the header stays one bounded line."""
-    long_name = "Onboarding" * MARK_LOCATOR_MAX_LENGTH
-    transcript = _format_transcript_text(
-        "assistant.mark.created",
-        {"target": long_name, "body": "Aligned it."},
-        anchor,
-    )
-    header = transcript.splitlines()[0]
+@pytest.mark.parametrize("anchor", [{}, {"text": ""}, {"selector": "#cta"}], ids=["absent", "blank", "selector-only"])
+def test_assistant_mark_without_page_copy_is_just_the_agents_words(anchor):
+    """No human locator available: say what happened, then get out of the way."""
+    transcript = _format_transcript_text("assistant.mark.created", {"target": "cta", "body": "Aligned it."}, anchor)
 
-    assert header.startswith("Page note · “Onboarding")
-    assert header.endswith("…”")
-    assert len(header) < len(long_name)
+    assert transcript == "Page note\n\nAligned it."
 
 
-def test_assistant_mark_locator_is_condensed_to_one_line():
+@pytest.mark.parametrize("copy_key", ANCHOR_HUMAN_COPY_KEYS)
+def test_assistant_mark_condenses_every_locator_source(copy_key):
+    """Whichever copy field fills the locator, the header stays one bounded line."""
     transcript = _format_transcript_text(
         "assistant.mark.created",
         {"target": "cta", "body": "Aligned it."},
-        {"text": "Get\n started " + "x" * MARK_LOCATOR_MAX_LENGTH},
+        {copy_key: "Get\n started " + "x" * MARK_LOCATOR_MAX_LENGTH},
     )
     header = transcript.splitlines()[0]
 

--- a/tests/test_show_session_events.py
+++ b/tests/test_show_session_events.py
@@ -14,6 +14,7 @@ from core.show_session_events import (
     ASSISTANT_MARK_EVENT_TYPES,
     ASSISTANT_MARK_TRANSCRIPT_I18N_KEYS,
     MARK_LOCATOR_MAX_LENGTH,
+    MARK_PAYLOAD_KEYS,
     ShowSessionEventError,
     ShowSessionEventStore,
     _format_transcript_text,
@@ -776,9 +777,12 @@ def test_show_event_store_records_assistant_page_update(isolated_state):
 @pytest.mark.parametrize(
     ("event_type", "payload", "expected_header"),
     [
-        # These three carry a `target` that no header renders: the mark cases are
-        # here to pin action and scope wording, and they double as a reminder that
-        # the field master used to print is now invisible whatever else varies.
+        # The three mark rows pin the action wording. They also carry a `scope` and
+        # a `target` that no header renders, so the rows below double as the
+        # contrast this table exists to show: the very same `scope: "review"` that
+        # is invisible to the user in a mark stays visible to the Agent in the
+        # `[show-intent ...]` / `[show-annotation ...]` rows further down, because
+        # only there is it something the reader can act on.
         (
             "assistant.mark.created",
             {"scope": "default", "target": "summary", "body": "Created."},
@@ -792,7 +796,7 @@ def test_show_event_store_records_assistant_page_update(isolated_state):
         (
             "assistant.mark.updated",
             {"scope": "review", "target": "summary", "body": "Updated."},
-            "Page note (updated) · review",
+            "Page note (updated)",
         ),
         (
             "human.intent.submitted",
@@ -858,6 +862,63 @@ def test_assistant_mark_transcript_never_shows_the_mark_target(target):
     transcript = _format_transcript_text("assistant.mark.created", {"target": target, "body": "Aligned it."}, {})
 
     assert transcript == "Page note\n\nAligned it."
+
+
+@pytest.mark.parametrize(
+    "scope",
+    [
+        "#hero",  # a selector used as a filing key
+        "mark_9f2a7c1d",  # a synthetic id used as a filing key
+        "summary",  # indistinguishable from a page label, exactly like `target`
+        "review",  # reads perfectly well -- and still names nothing on the page
+    ],
+)
+def test_assistant_mark_transcript_never_shows_the_mark_scope(scope):
+    """``scope`` is dropped for a reason ``target`` did not even need.
+
+    It is unvalidated free text that namespaces the synthetic mark id, so it is
+    machine text by contract. But it fails a second test too: it is rendered
+    nowhere on the page, so even the well-behaved ``review`` names nothing the
+    reader could go and look at. A locator has to point at something visible.
+
+    The same value stays visible in the *agent*-facing direction -- see the
+    ``[show-intent scope=review]`` rows in the shared header table -- because
+    there the reader can act on it.
+    """
+    payload = {"scope": scope, "target": "cta", "body": "Aligned it."}
+
+    transcript = _format_transcript_text("assistant.mark.created", payload, {})
+
+    assert transcript == "Page note\n\nAligned it."
+
+
+def test_no_machine_field_of_a_mark_ever_reaches_the_chat():
+    """Closes the class instead of patching one member of it.
+
+    Two rounds of review found the same leak in two different fields. Rather than
+    wait for a third, this drives every field a stored mark is made of, each
+    holding text a user must never be shown, and asserts the chat message is the
+    header plus the agent's own words. The equality check makes the enumeration
+    binding: adding a key to ``MARK_PAYLOAD_KEYS`` fails here until someone
+    classifies it as the agent's words or as machine text.
+    """
+    machine_text = {
+        "id": "mark_9f2a7c1d",
+        "scope": "#hero",
+        "target": "#root > div.grid > section:nth-child(3) .cta-button",
+        "createdAt": "2026-07-26T10:00:00+00:00",
+        "updatedAt": "2026-07-26T10:05:00+00:00",
+        "replyTo": "mark_0badc0de",
+    }
+    assert set(machine_text) | {"body"} == set(MARK_PAYLOAD_KEYS)
+
+    transcript = _format_transcript_text(
+        "assistant.mark.created", {**machine_text, "body": "Aligned it."}, {}
+    )
+
+    assert transcript == "Page note\n\nAligned it."
+    for key, value in machine_text.items():
+        assert value not in transcript, f"{key} leaked into the chat"
 
 
 def test_assistant_mark_transcript_quotes_page_copy_the_user_can_see():

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -10879,10 +10879,17 @@ def cmd_show_mark(args):
                 "body": body,
             },
         }
-        if args.anchor_selector:
-            payload["anchor"] = {"selector": args.anchor_selector}
-            if args.anchor_text:
-                payload["anchor"]["text"] = args.anchor_text
+        # Either flag alone is a valid invocation -- the parser advertises them
+        # independently -- and `--anchor-text` is the one the chat transcript reads
+        # to tell the user where a mark landed, so nesting it under the selector
+        # dropped exactly the copy that locates the mark for a human.
+        anchor = {
+            key: value
+            for key, value in (("selector", args.anchor_selector), ("text", args.anchor_text))
+            if value
+        }
+        if anchor:
+            payload["anchor"] = anchor
         event = _record_show_mark_event(session_id, payload, event_store)
         result = _show_page_result(
             page,

--- a/vibe/i18n/en.json
+++ b/vibe/i18n/en.json
@@ -12,6 +12,15 @@
     "title": "Fork {title}",
     "titleUntitled": "Fork"
   },
+  "show": {
+    "mark": {
+      "created": "Page note",
+      "updated": "Page note (updated)",
+      "resolved": "Page note (resolved)",
+      "scopeSuffix": "{header} · {scope}",
+      "targetSuffix": "{header} · “{target}”"
+    }
+  },
   "harness": {
     "watch": {
       "supervisorFailed": "Watch worker supervisor failed: {detail}",

--- a/vibe/i18n/en.json
+++ b/vibe/i18n/en.json
@@ -18,7 +18,7 @@
       "updated": "Page note (updated)",
       "resolved": "Page note (resolved)",
       "scopeSuffix": "{header} · {scope}",
-      "targetSuffix": "{header} · “{target}”"
+      "quoteSuffix": "{header} · “{quote}”"
     }
   },
   "harness": {

--- a/vibe/i18n/en.json
+++ b/vibe/i18n/en.json
@@ -17,7 +17,6 @@
       "created": "Page note",
       "updated": "Page note (updated)",
       "resolved": "Page note (resolved)",
-      "scopeSuffix": "{header} · {scope}",
       "quoteSuffix": "{header} · “{quote}”"
     }
   },

--- a/vibe/i18n/zh.json
+++ b/vibe/i18n/zh.json
@@ -12,6 +12,15 @@
     "title": "复刻 {title}",
     "titleUntitled": "复刻"
   },
+  "show": {
+    "mark": {
+      "created": "页面批注",
+      "updated": "页面批注（已更新）",
+      "resolved": "页面批注（已处理）",
+      "scopeSuffix": "{header} · {scope}",
+      "targetSuffix": "{header} ·「{target}」"
+    }
+  },
   "harness": {
     "watch": {
       "supervisorFailed": "Watch 监控进程失败：{detail}",

--- a/vibe/i18n/zh.json
+++ b/vibe/i18n/zh.json
@@ -18,7 +18,7 @@
       "updated": "页面批注（已更新）",
       "resolved": "页面批注（已处理）",
       "scopeSuffix": "{header} · {scope}",
-      "targetSuffix": "{header} ·「{target}」"
+      "quoteSuffix": "{header} ·「{quote}」"
     }
   },
   "harness": {

--- a/vibe/i18n/zh.json
+++ b/vibe/i18n/zh.json
@@ -17,7 +17,6 @@
       "created": "页面批注",
       "updated": "页面批注（已更新）",
       "resolved": "页面批注（已处理）",
-      "scopeSuffix": "{header} · {scope}",
       "quoteSuffix": "{header} ·「{quote}」"
     }
   },


### PR DESCRIPTION
## Capability

Agent reverse-annotations (`vibe show mark`) echo into the chat as a message the **user** reads. That message used to carry machine text at them:

```
[agent-mark] scope=default action=created
Anchor: [mark-default='summary']
Text: Quarterly summary
Review this summary again.
```

Now it reads as words:

```
页面批注 ·「开始使用」

改了按钮的对齐方式，和设计稿一致了
```

Rules the new formatter enforces:

- **No machine text in user-visible copy, ever.** Not a CSS selector, not a `mark-<scope>-<id>` synthetic id, not a filing key. This is a hard invariant with dedicated tests, not a formatting preference.
- **The header is assembled from exactly two sources, and nothing else can reach it**: a closed label map keyed by event type, and anchor copy the user can see on the page. Every free-form field a mark carries — `target`, `scope`, ids, timestamps — is structurally excluded, because the formatter never reads it. See [round 2](#review-round-2-cd061f75) and [round 3](#review-round-3-3b6a5bd7) for why that is a blanket rule rather than a filter.
- **The locator comes only from anchor copy** — `ANCHOR_HUMAN_COPY_KEYS = ("textQuote", "text")`, best first, both real producers: `vibe show mark --anchor-text` writes `text`, and `vibe show reply` copies the annotation's anchor verbatim where a text-range annotation carries its selected copy as `textQuote`. When no anchor copy exists the locator is omitted entirely: the header says what happened, and the agent's own `--message` says the rest.
- **`body` is the message**: always present, always first priority, never truncated. It is also the *only* payload field the user ever sees, because it is the only one that is human words by construction. Only the one-line header elides (locator condensed to 60 chars).
- **Action is a word, not a key-value**: created → `页面批注`, updated → `页面批注（已更新）`, resolved → `页面批注（已处理）`. Never `action=created`, never `scope=review`.

## Only the agent direction changed

`_format_transcript_text` carries two event classes in **opposite** directions:

| branch | message `author` | who reads it | selectors are |
| --- | --- | --- | --- |
| `assistant.mark.*` | `agent` | **the user** | noise → **rewritten here** |
| `human.intent.submitted`, `ANNOTATION_EVENT_TYPES` | `user` | **the Agent** | the only locating basis → **untouched** |

The human/annotation branches — including their `Anchor: {selector}`, `Quote:`, and `Screenshot:` lines — are **byte-identical to master**, verified mechanically by extracting both function bodies and comparing. Cleaning those up too would leave the agent unable to find what the user marked on the page. `_format_transcript_header` is kept in place because those two branches still use it. The existing `assistant.mark.resolved` + `author is not None` silence logic is unchanged.

## Evidence

**Unit** — `tests/test_show_session_events.py`, `tests/test_show_pages.py` (converted old-format assertions at 2209 / 2299):

- `test_no_machine_field_of_a_mark_ever_reaches_the_chat` — **the class-closing test.** Drives every field a stored mark is made of, each holding text a user must never see, and asserts the message is the header plus the agent's own words. Its equality check against `MARK_PAYLOAD_KEYS` makes the enumeration binding: adding a key there fails this test until someone classifies it.
- `test_assistant_mark_transcript_never_shows_the_mark_target` — parametrized over every value an agent may legitimately pass: compound selector, both synthetic-id spellings, attribute selector, the bare type selectors `button` and `summary`, the human-looking `Get started`, and `None`. The header is bare in all eight.
- `test_assistant_mark_transcript_never_shows_the_mark_scope` — same for `scope`, including the well-behaved `review` that still names nothing on the page.
- `test_assistant_mark_transcript_quotes_page_copy_the_user_can_see` — anchor copy locates, and the sibling `selector` on the same anchor does not leak.
- `test_assistant_mark_without_page_copy_is_just_the_agents_words` — absent / blank / selector-only anchors all render header + body.
- `test_assistant_mark_transcript_keeps_the_whole_body` — 1600-char body arrives intact.
- `test_assistant_mark_condenses_every_locator_source` — parametrized over `ANCHOR_HUMAN_COPY_KEYS`, so a third copy field cannot skip condensation.
- `test_show_mark_keeps_anchor_text_without_a_selector` — the round-4 regression: `--anchor-text` alone survives into the anchor and into the echo.
- `test_assistant_mark_transcript_quotes_a_text_range_anchor` plus an end-to-end assertion on the existing `vibe show reply` CLI test: replying to a text-range annotation renders `Page note · “Revenue”` and never `#revenue-card`.
- `test_both_transcript_directions_read_the_same_anchor_copy_fields` — parametrized over `ANCHOR_HUMAN_COPY_KEYS` and driving **both** formatters, so a copy field added to one direction alone fails a test.
- `test_show_event_transcript_headers_only_render_deviations` — the shared header table, which now doubles as the two-directions contrast: the same `scope: "review"` is invisible in a mark row and visible in the `[show-intent scope=review]` row below it.
- `test_assistant_mark_transcript_renders_in_the_configured_language` and `test_appended_mark_speaks_the_users_configured_language` — the latter goes end-to-end through `store.append()` with a `language = "zh"` config in an isolated `AVIBE_HOME`, proving the store reaches the user's language with no controller to read it off.
- `test_every_assistant_mark_event_has_a_plain_language_label` — closes the class: the label mapping must enumerate `ASSISTANT_MARK_EVENT_TYPES` and every key must resolve in every supported language, so a fourth mark event fails a test instead of leaking a raw i18n key into a conversation.

**Contract / scenario** — no catalog covers this path; none added.

**Residual manual** — rendered output verified by direct probe in both languages, including the drop-the-locator case.

**Gates** — `pytest tests/test_show_session_events.py tests/test_show_pages.py tests/test_i18n_backend_keys.py tests/test_ui_show_pages.py tests/test_internal_server.py tests/test_session_archive.py tests/test_show_git_turn_entrypoints.py` → 508 passed, plus the full local suite (2 failures in `tests/test_platform_registry.py`, both reproduced on a clean `origin/master` checkout — pre-existing, unrelated). `ruff check core/ tests/ vibe/` → clean.

## Review round 1 (d02f3eb8)

Both P2 findings confirmed real, and they were the same shape: the locator step did not cover the full anchor contract, and did not bound every source it accepts. Fixed structurally rather than as two spot patches — copy fields became one declaration consumed by both directions' tests, and condensation moved to the single exit of `_mark_locator`. The `textQuote` miss was the more consequential of the two: it blanked the locator on replies to highlighted copy, which is precisely where the user's own words were available.

## Review round 2 (cd061f75)

<a id="review-round-2-cd061f75"></a>

Confirmed real, and fixed by **removing the field rather than tightening the rule**.

Probing `is_human_readable_mark_target` against the inputs an agent may legitimately pass showed it was **inverted relative to its own purpose**:

| `target` | old predicate | should be |
| --- | --- | --- |
| `button` | ✅ human-readable | ❌ bare type selector |
| `main`, `h1`, `div`, `section`, `nav`, `footer` | ✅ human-readable | ❌ bare type selectors |
| `summary` | ✅ human-readable | ❌ bare type selector |
| `Get started` | ❌ machine text | ✅ **this is the human case** |
| `Revenue`, `开始使用` | ✅ | ✅ |
| `#hero > .cta`, `mark-default-x` | ❌ | ❌ |

`Get started` failed because "contains whitespace" was there to catch the descendant combinator (`div p`) and caught human phrases with it. The rule admitted the selectors and rejected the copy.

**Why no stricter predicate was written.** `summary` is simultaneously a valid bare type selector, a plausible page label, and the documented example in `vibe show mark`'s own help (`--target summary`). Good case and bad case are *the same string*, so no test on the text separates them — any predicate here is a blacklist, incomplete by construction but reading as if complete. A third finding of the same class was the signal that the mechanism was wrong, not that the list was short.

**Root cause.** `target` is contractually machine text: its CLI help reads *"Target mark id or selector"*, and the guidance injected into agents (`core/system_prompt_injection.py:95`) tells them to pass `<selector-or-anchor>`. Human copy has its own field, `--anchor-text`, which this PR already reads. "Does this selector read like a name?" was a category error.

**Change.** `_mark_locator` reads only anchor copy; `is_human_readable_mark_target`, `_SELECTOR_SYNTAX_CHARS`, and `_SYNTHETIC_MARK_ID_PREFIXES` are deleted rather than left as dead code, along with the predicate's unit test. The invariant is now structural: the transcript cannot print a selector because it never reads the field that holds one.

**Cost accepted.** A mark that carries a human-sounding `target` and no `--anchor-text` loses its locator — the `Get started` row above pins that deliberately. A locator the user cannot read is not a locator, and the field cannot promise it is copy.

## Review round 3 (3b6a5bd7)

<a id="review-round-3-3b6a5bd7"></a>

Confirmed real. `scope` was the same leak as round 2 in a different field: unvalidated free text inserted verbatim into the header, so `vibe show mark --scope '#hero'` rendered `Page note · #hero`.

Two rounds finding the same leak in two fields is a signal about the approach, not about those two fields, so this round **closes the class instead of patching its second member**.

**Why omit rather than validate.** The review offered "render only a separately validated human-facing label" as the alternative. That is the predicate deleted one commit ago, with the identical hole: `summary` is as plausible a scope name as it is a bare type selector, so no rule separates them. Scope also fails a second test that `target` did not — it namespaces the synthetic mark id in `stable_assistant_mark_id` (`sha256(f"{scope}\0{identity}")` → `mark_<digest>`) and is rendered **nowhere on the page**. Even the well-behaved `review` names nothing the reader could go and look at, so it is not a locator in the best case either.

**The structural change.** The header is now assembled from exactly two sources — a closed label map keyed by event type, and anchor copy — and `MARK_PAYLOAD_KEYS` enumerates everything a stored mark is made of. That constant is also the single source `_prepare_mark_resolution` reads, so the enumeration cannot drift from the thing it claims to enumerate. `test_no_machine_field_of_a_mark_ever_reaches_the_chat` drives all seven fields holding machine text and asserts only `body` survives; its equality check fails the moment a field is added without being classified.

Both new guards were mutation-tested: re-introducing the scope suffix fails 5 tests, and adding an unclassified key to `MARK_PAYLOAD_KEYS` fails the enumeration check.

**Note on the same field in the other direction.** `scope` is *kept* in the agent-facing branches (`[show-intent scope=review]`), which remain byte-identical to master. Same field, opposite decision, because the reader is different: the Agent can act on a filing key, the user cannot see one.

## Review round 4 (d25b9fa7)

Confirmed real, and a **different class** from rounds 1–3 — those were machine text leaking *in*; this is human copy being dropped *out*.

`vibe show mark --anchor-text "Checkout"` with no `--anchor-selector` built no anchor at all: `cmd_show_mark` created `payload["anchor"]` only inside `if args.anchor_selector`, so the text was silently discarded — even though the parser advertises the two flags independently. Pre-existing, and invisible for as long as the transcript fell back to printing `target`. Removing that fallback is what surfaced it: the echo degraded to a bare `Page note` and lost the one human-readable locator the agent had supplied.

Fixed at the root rather than in the formatter — the anchor is now built from whichever anchor flags are present. Of the review's two options, preserving the text beats rejecting the combination: `--anchor-text` is documented as independent, and it is precisely the field this PR designates as *the* sanctioned human locator, so refusing text-only would reject the invocation agents should be using. A sweep found this was the only site constructing a mark anchor from CLI args.

`test_show_mark_keeps_anchor_text_without_a_selector` covers text-only / selector-only / both, asserting the stored anchor and the rendered transcript, and pins that a selector sitting beside the copy still never reaches the user. Mutation-tested: restoring the nested build fails the text-only case.

## Known by design

1. **Copy goes through `vibe/i18n/` rather than being hardcoded Chinese.** `AGENTS.md` §6 makes `vibe/i18n/` mandatory for backend user-facing strings, `tests/test_i18n_backend_keys.py` is a CI parity guard, and `core/` already reaches for `i18n_t` elsewhere (`session_turns.py`). Routing it this way still delivers Chinese to a `language = "zh"` user while an English user is not shown a Chinese blob. Language is resolved once per `append()`, straight off the persisted config, following the `core/scheduled_tasks.py` / `core/update_checker.py` precedent for a store with no controller — a headless run with no config falls back to English.

2. **⚠️ Overlaps #1015 — whoever merges second unions by hand.** [#1015](https://github.com/avibe-bot/avibe/pull/1015) (`fix(show): queue annotations through unified turn entry`, head `e1509f14`) edits the same four files. A test merge conflicts in all four, in five places, and **every conflict is two adjacent pure insertions — the resolution is always "keep both", never "pick one":**

   | file | collision | resolve by |
   | --- | --- | --- |
   | `core/show_session_events.py` | the `storage.models` import line — #1015 widened it to `agent_sessions, media_objects, messages, show_session_events` | keep #1015's line; it is a superset |
   | `core/show_session_events.py` | both insert right after `ASSISTANT_MARK_EVENT_TYPES` (#1015: dispatch-state constants; here: label map + anchor keys) | keep both blocks |
   | `tests/test_show_session_events.py` | both add imports and new tests | keep both |
   | `vibe/i18n/en.json` | both add a top-level `"show"` at the `fork` → `harness` slot (#1015: `show.event.*`; here: `show.mark.*`) | **union the sub-objects under one `show` key** |
   | `vibe/i18n/zh.json` | same | same |

   The i18n rows are the dangerous ones. I deliberately took the visible conflict rather than dodging it by inserting elsewhere: that would merge *cleanly* into a **duplicate top-level `show` key**, where the second silently wins and one PR's strings vanish with no diff to notice. `tests/test_i18n_backend_keys.py` enforces en/zh parity, not key uniqueness, so it would not catch it either.

   Re-verified against #1015 head `e1509f14` on 2026-07-26: the union resolution builds, `ruff check` is clean, and the four affected test files give **326 passed**.


