### PR TITLE
feat(desktop): add headless runtime start contract

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -5,6 +5,7 @@
 ```bash
 vibe              # Alias for vibe start
 vibe start        # Start Avibe if needed (opens web UI)
+vibe start --no-open-browser  # Start/reuse Avibe without opening a browser
 vibe status       # Check service status
 vibe restart      # Restart all services (use --delay-seconds when agent-triggered)
 vibe remote       # Guided Avibe Cloud remote-access setup
@@ -52,15 +53,17 @@ vibe
 
 ### `vibe start`
 
-Start Avibe if needed. Opens the web UI in your browser.
+Start Avibe if needed. Opens the web UI in your browser unless you suppress it.
 
 ```bash
 vibe start
+vibe start --no-open-browser
 ```
 
 **Behavior:**
 - Reuses the main service and Web UI if they are already running
 - Opens the setup wizard at `http://127.0.0.1:5123`
+- With `--no-open-browser`, keeps the service/UI lifecycle the same but does not launch a system browser window
 - **Preserves running processes** — Use `vibe restart` when you need an explicit restart
 
 ### `vibe stop`

--- a/docs/CLI_ZH.md
+++ b/docs/CLI_ZH.md
@@ -5,6 +5,7 @@
 ```bash
 vibe              # vibe start 的别名
 vibe start        # 按需启动 Avibe（打开 Web UI）
+vibe start --no-open-browser  # 启动/复用 Avibe，但不打开浏览器
 vibe status       # 查看服务状态
 vibe remote       # 引导式配置 Avibe Cloud 远程访问
 vibe screenshot   # 截取本机桌面截图
@@ -50,15 +51,17 @@ vibe
 
 ### `vibe start`
 
-按需启动 Avibe。会在浏览器中打开 Web UI。
+按需启动 Avibe。默认会在浏览器中打开 Web UI；也可以显式抑制。
 
 ```bash
 vibe start
+vibe start --no-open-browser
 ```
 
 **行为：**
 - 如果主服务与 Web UI 已在运行，则复用现有进程
 - 打开设置向导 `http://127.0.0.1:5123`
+- 使用 `--no-open-browser` 时，服务和 Web UI 的启动/复用逻辑不变，但不会额外拉起系统浏览器窗口
 - **保留已运行的进程** — 需要明确重启时请使用 `vibe restart`
 
 ### `vibe stop`

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -523,7 +523,7 @@ mode. Continue with `pagination.next_command`; inspect one record with its
 | Command | Purpose |
 | --- | --- |
 | `vibe` | Alias for `vibe start` |
-| `vibe start` | Start the service and Web UI if needed; reuse already-running processes |
+| `vibe start` | Start the service and Web UI if needed; reuse already-running processes; `--no-open-browser` suppresses the browser launch |
 | `vibe stop` | Stop the service and UI; also terminates OpenCode server |
 | `vibe restart` | Stop then start again |
 | `vibe status` | Print runtime status JSON |
@@ -552,7 +552,10 @@ vibe
 
 ```bash
 vibe start
+vibe start --no-open-browser
 ```
+
+- `--no-open-browser` keeps the same start/reuse semantics but suppresses the browser launch. This is the supported contract for desktop shells that own their own WebView.
 
 - starts the main service if it is not already running
 - opens the Web UI

--- a/docs/COMMANDS_ZH.md
+++ b/docs/COMMANDS_ZH.md
@@ -501,7 +501,7 @@ bind vr-a3x9k2
 | 命令 | 作用 |
 | --- | --- |
 | `vibe` | `vibe start` 的别名 |
-| `vibe start` | 按需启动服务与 Web UI；已运行时复用现有进程 |
+| `vibe start` | 按需启动服务与 Web UI；已运行时复用现有进程；`--no-open-browser` 可禁止自动打开浏览器 |
 | `vibe stop` | 停止服务与 UI，同时终止 OpenCode server |
 | `vibe restart` | 停止后重新启动 |
 | `vibe status` | 输出运行状态 JSON |
@@ -530,7 +530,10 @@ vibe
 
 ```bash
 vibe start
+vibe start --no-open-browser
 ```
+
+- `--no-open-browser` 会保留相同的启动/复用语义，但不会自动打开浏览器；桌面壳这类自带 WebView 的调用方应使用这个契约。
 
 - 如果主服务尚未运行，则启动主服务
 - 打开 Web UI

--- a/tests/test_vibe_cli.py
+++ b/tests/test_vibe_cli.py
@@ -612,6 +612,28 @@ def test_cmd_start_ensures_services_without_stopping(monkeypatch):
     assert not any(call == "stop" for call in calls)
 
 
+def test_cmd_start_can_suppress_configured_browser_open(monkeypatch):
+    config = SimpleNamespace(
+        has_configured_platform_credentials=lambda: True,
+        ui=SimpleNamespace(setup_host="127.0.0.1", setup_port=5123, open_browser=True),
+    )
+    opened = []
+
+    monkeypatch.setattr(cli.paths, "ensure_data_dirs", lambda: None)
+    monkeypatch.setattr(cli, "_ensure_config", lambda: config)
+    monkeypatch.setattr(cli, "_write_status", lambda *args, **kwargs: None)
+    monkeypatch.setattr(cli.runtime, "start_service", lambda **kwargs: 1234)
+    monkeypatch.setattr(cli.runtime, "effective_ui_bind_host", lambda cfg: "127.0.0.1")
+    monkeypatch.setattr(cli.runtime, "start_ui", lambda host, port: 5678)
+    monkeypatch.setattr(cli.runtime, "service_pid_recorded", lambda pid: True)
+    monkeypatch.setattr(cli.runtime, "write_status", lambda *args: None)
+    monkeypatch.setattr(cli, "_open_browser", lambda url: opened.append(url) or True)
+
+    assert cli.cmd_start(open_browser=False) == 0
+
+    assert opened == []
+
+
 def test_cmd_start_keeps_ui_up_while_service_lock_is_slow(monkeypatch):
     calls = []
     config = SimpleNamespace(
@@ -1670,6 +1692,15 @@ def test_start_parser_accepts_start_command():
     args = parser.parse_args(["start"])
 
     assert args.command == "start"
+    assert args.open_browser is None
+
+
+def test_start_parser_accepts_no_open_browser():
+    parser = cli.build_parser()
+    args = parser.parse_args(["start", "--no-open-browser"])
+
+    assert args.command == "start"
+    assert args.open_browser is False
 
 
 def test_remote_parser_accepts_pairing_command():

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -9796,7 +9796,7 @@ def _confirm_doctor_repair(targets: list[str]) -> bool:
     return answer.strip().lower() == "yes"
 
 
-def cmd_start():
+def cmd_start(*, open_browser: bool | None = None):
     _guard_cli_default_state_migration()
     paths.ensure_data_dirs()
     config = _ensure_config()
@@ -9849,7 +9849,8 @@ def cmd_start():
     print("")
 
     # If running over SSH, avoid trying to open a browser on the server.
-    if config.ui.open_browser and not _in_ssh_session():
+    should_open_browser = config.ui.open_browser if open_browser is None else open_browser
+    if should_open_browser and not _in_ssh_session():
         opened = _open_browser(ui_url)
         if not opened:
             print(f"(Tip) Could not auto-open a browser. Open this URL manually: {ui_url}")
@@ -11761,7 +11762,14 @@ def build_parser():
     subparsers = parser.add_subparsers(dest="command")
 
     subparsers.add_parser("stop", help="Stop all services")
-    subparsers.add_parser("start", help="Start services if needed without stopping running processes")
+    start_parser = subparsers.add_parser("start", help="Start services if needed without stopping running processes")
+    start_parser.add_argument(
+        "--no-open-browser",
+        dest="open_browser",
+        action="store_false",
+        default=None,
+        help="Start services without opening the Web UI in the system browser.",
+    )
     restart_parser = subparsers.add_parser("restart", help="Restart all services")
     restart_parser.add_argument(
         "--delay-seconds",
@@ -13238,7 +13246,7 @@ def main():
     if args.command == "stop":
         sys.exit(cmd_stop())
     if args.command == "start":
-        sys.exit(cmd_start())
+        sys.exit(cmd_start(open_browser=args.open_browser))
     if args.command == "restart":
         sys.exit(_cmd_restart_with_delay(args.delay_seconds))
     if args.command == "__restart-supervisor":


### PR DESCRIPTION
## Capability

Adds an explicit headless launcher contract for desktop shells and other native hosts:

- `vibe start --no-open-browser` starts or adopts the existing Runtime services without opening the system browser;
- ordinary `vibe start` keeps the configured browser behavior unchanged;
- the CLI passes the override directly into `cmd_start` without changing service ownership or restart semantics;
- the public English and Chinese CLI references document the new launcher contract.

Integration target: `desktop`. This PR must not merge directly to `master`.

The Tauri host PR #1025 consumes this contract but does not contain Python Runtime changes.

## Scenarios

- D01: a desktop shell can cold-start the installed Runtime without opening a duplicate browser window.
- D02: normal start/adoption semantics remain unchanged.
- D09: the desktop window remains the only UI window opened by the shell launch path.

## Evidence

- **Unit:** parser defaults and `--no-open-browser` parsing; configured browser suppression through `cmd_start`.
- **Contract:** `None` preserves configuration, while `False` explicitly suppresses browser launch; all four English and Chinese public CLI references expose the flag and its behavior.
- **Scenario:** focused CLI tests exercise the shell-required behavior without starting real services.
- **Local:** 115 focused CLI tests passed; `git show --check` passed; paired English and Chinese references contain matching flag coverage.
- **Residual manual:** packaged Tauri cold start is covered by D01 in #1025 and the native acceptance suite.

## Scope

`vibe/cli.py`, `tests/test_vibe_cli.py`, `docs/CLI.md`, `docs/CLI_ZH.md`, `docs/COMMANDS.md`, and `docs/COMMANDS_ZH.md`.
