### PR TITLE
feat(desktop): expose loopback runtime endpoint

### DIFF
--- a/tests/test_desktop_runtime.py
+++ b/tests/test_desktop_runtime.py
@@ -1,0 +1,373 @@
+from __future__ import annotations
+
+import json
+import socket
+from types import SimpleNamespace
+
+import pytest
+
+from config import paths
+from config.v2_config import (
+    AgentsConfig,
+    PlatformsConfig,
+    RemoteAccessConfig,
+    RuntimeConfig,
+    SlackConfig,
+    UiConfig,
+    V2Config,
+)
+from vibe import cli, runtime
+from vibe.desktop_runtime import (
+    desktop_endpoint_payload,
+    desktop_origin,
+    requires_desktop_loopback_listener,
+    ui_listener_hosts,
+)
+from vibe.ui_server import _bind_ui_sockets, app
+
+
+@pytest.mark.parametrize(
+    ("bind_host", "expected_origin", "expected_listeners"),
+    [
+        ("127.0.0.1", "http://127.0.0.1:5123", ("127.0.0.1",)),
+        ("0.0.0.0", "http://127.0.0.1:5123", ("0.0.0.0",)),
+        ("192.168.1.20", "http://127.0.0.1:5123", ("192.168.1.20", "127.0.0.1")),
+        ("100.97.103.112", "http://127.0.0.1:5123", ("100.97.103.112", "127.0.0.1")),
+        ("::1", "http://[::1]:5123", ("::1",)),
+        ("::", "http://[::1]:5123", ("::",)),
+        ("fd7a:115c:a1e0::42", "http://[::1]:5123", ("fd7a:115c:a1e0::42", "::1")),
+    ],
+)
+def test_desktop_origin_and_listener_contract(bind_host, expected_origin, expected_listeners):
+    assert desktop_origin(bind_host, 5123) == expected_origin
+    assert desktop_endpoint_payload(bind_host, 5123) == {
+        "schema_version": 1,
+        "origin": expected_origin,
+    }
+    assert ui_listener_hosts(bind_host) == expected_listeners
+
+
+def test_specific_hostname_gets_ipv4_desktop_listener():
+    assert requires_desktop_loopback_listener("192.0.2.20.example.invalid") is True
+    assert ui_listener_hosts("192.0.2.20.example.invalid") == (
+        "192.0.2.20.example.invalid",
+        "127.0.0.1",
+    )
+
+
+def test_localhost_does_not_add_duplicate_listener():
+    assert requires_desktop_loopback_listener("localhost") is False
+    assert ui_listener_hosts("localhost") == ("localhost",)
+
+
+def test_hostname_resolving_to_loopback_does_not_add_duplicate_listener(monkeypatch):
+    monkeypatch.setattr(
+        socket,
+        "getaddrinfo",
+        lambda *_args, **_kwargs: [
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("127.0.0.1", 0))
+        ],
+    )
+    assert requires_desktop_loopback_listener("avibe-loopback.test") is False
+    assert ui_listener_hosts("avibe-loopback.test") == ("avibe-loopback.test",)
+
+
+@pytest.mark.parametrize("port", [0, -1, 65536, True, "5123"])
+def test_desktop_origin_rejects_invalid_ports(port):
+    with pytest.raises(ValueError, match="between 1 and 65535"):
+        desktop_origin("127.0.0.1", port)
+
+
+def test_bind_ui_sockets_adds_same_port_loopback_for_specific_bind(monkeypatch):
+    calls = []
+    sockets = [object(), object()]
+
+    def fake_bind(host, port):
+        calls.append((host, port))
+        return sockets[len(calls) - 1]
+
+    monkeypatch.setattr("vibe.ui_server._bind_ui_socket", fake_bind)
+
+    assert _bind_ui_sockets("100.97.103.112", 5123) == sockets
+    assert calls == [("100.97.103.112", 5123), ("127.0.0.1", 5123)]
+
+
+@pytest.mark.parametrize("bind_host", ["0.0.0.0", "127.0.0.1", "::", "::1", "*"])
+def test_bind_ui_sockets_does_not_duplicate_wildcard_or_loopback(bind_host, monkeypatch):
+    calls = []
+
+    def fake_bind(host, port):
+        calls.append((host, port))
+        return object()
+
+    monkeypatch.setattr("vibe.ui_server._bind_ui_socket", fake_bind)
+
+    assert len(_bind_ui_sockets(bind_host, 5123)) == 1
+    assert calls == [(bind_host, 5123)]
+
+
+def test_bind_ui_sockets_closes_primary_when_loopback_bind_fails(monkeypatch):
+    class FakeSocket:
+        closed = False
+
+        def close(self):
+            self.closed = True
+
+    primary = FakeSocket()
+
+    def fake_bind(host, _port):
+        if host == "127.0.0.1":
+            raise OSError("loopback unavailable")
+        return primary
+
+    monkeypatch.setattr("vibe.ui_server._bind_ui_socket", fake_bind)
+
+    with pytest.raises(OSError, match="loopback unavailable"):
+        _bind_ui_sockets("192.168.1.20", 5123)
+
+    assert primary.closed is True
+
+
+def test_ui_health_urls_require_primary_and_desktop_listener():
+    assert runtime._ui_health_urls("100.97.103.112", 5123) == (
+        "http://100.97.103.112:5123/health",
+        "http://127.0.0.1:5123/health",
+    )
+    assert runtime._ui_health_urls("fd7a:115c:a1e0::42", 5123) == (
+        "http://[fd7a:115c:a1e0::42]:5123/health",
+        "http://[::1]:5123/health",
+    )
+
+
+def test_ui_server_health_fails_when_old_specific_bind_lacks_desktop_listener(monkeypatch):
+    calls = []
+
+    class Response:
+        status = 200
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return None
+
+    def fake_urlopen(url, timeout):
+        calls.append((url, timeout))
+        if url == "http://127.0.0.1:5123/health":
+            raise OSError("connection refused")
+        return Response()
+
+    monkeypatch.setattr(runtime.urllib.request, "urlopen", fake_urlopen)
+
+    assert runtime.ui_server_healthy("100.97.103.112", 5123) is False
+    assert calls == [
+        ("http://100.97.103.112:5123/health", 0.5),
+        ("http://127.0.0.1:5123/health", 0.5),
+    ]
+
+
+def test_start_ui_restarts_old_specific_bind_without_desktop_listener(tmp_path, monkeypatch):
+    monkeypatch.setattr(paths, "get_vibe_remote_dir", lambda: tmp_path / ".avibe")
+    runtime.ensure_dirs()
+    paths.get_runtime_ui_pid_path().write_text("12345", encoding="utf-8")
+    stopped = []
+
+    class Response:
+        status = 200
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return None
+
+    def fake_urlopen(url, timeout):
+        del timeout
+        if url == "http://127.0.0.1:5123/health":
+            raise OSError("old UI has no loopback listener")
+        return Response()
+
+    def fake_spawn(_args, pid_path, _stdout_name, _stderr_name, env=None):
+        del env
+        pid_path.write_text("67890", encoding="utf-8")
+        return 67890
+
+    monkeypatch.setattr(runtime.urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.setattr(runtime, "pid_alive", lambda pid: pid == 12345)
+    monkeypatch.setattr(
+        runtime,
+        "get_process_command",
+        lambda pid: "from vibe.ui_server import run_ui_server; run_ui_server('100.97.103.112', 5123)"
+        if pid == 12345
+        else None,
+    )
+    monkeypatch.setattr(runtime, "stop_pid", lambda pid: stopped.append(pid) or True)
+    monkeypatch.setattr(runtime, "spawn_background", fake_spawn)
+    monkeypatch.setattr(runtime, "wait_for_ui_server", lambda _host, _port: True)
+
+    assert runtime.start_ui("100.97.103.112", 5123) == 67890
+    assert stopped == [12345]
+
+
+def test_desktop_endpoint_cli_emits_only_schema_v1_json(monkeypatch, capsys):
+    config = SimpleNamespace(ui=SimpleNamespace(setup_port=6123))
+    monkeypatch.setattr(cli, "_guard_cli_default_state_migration", lambda: None)
+    monkeypatch.setattr(cli, "_ensure_config", lambda: config)
+    monkeypatch.setattr(cli.runtime, "effective_ui_bind_host", lambda _config: "100.97.103.112")
+    monkeypatch.setattr(cli, "_open_browser", lambda _url: pytest.fail("desktop endpoint must not open a browser"))
+
+    assert cli.cmd_desktop_endpoint() == 0
+
+    captured = capsys.readouterr()
+    assert captured.out == '{"schema_version":1,"origin":"http://127.0.0.1:6123"}\n'
+    assert captured.err == ""
+
+
+def test_desktop_endpoint_cli_parser_requires_explicit_json():
+    args = cli.build_parser().parse_args(["desktop", "endpoint", "--json"])
+    assert args.command == "desktop"
+    assert args.desktop_command == "endpoint"
+    assert args.json is True
+
+    with pytest.raises(SystemExit) as exc:
+        cli.build_parser().parse_args(["desktop", "endpoint"])
+    assert exc.value.code == 2
+
+
+def _ready_response(monkeypatch, owners, *, controller_ready):
+    owner_iter = iter(owners)
+
+    def resolve_owner(*, include_starting):
+        return next(owner_iter)
+
+    async def health():
+        return controller_ready
+
+    monkeypatch.setattr(runtime, "resolve_service_owner_pid", resolve_owner)
+    monkeypatch.setattr("vibe.internal_client.health", health)
+    return app.test_client().get("/ready", base_url="http://127.0.0.1:5123")
+
+
+def test_ready_reports_service_starting(monkeypatch):
+    response = _ready_response(monkeypatch, [None, 1234], controller_ready=False)
+    assert response.status_code == 503
+    assert response.get_json() == {"ready": False, "code": "service_starting"}
+
+
+def test_ready_reports_service_unavailable(monkeypatch):
+    response = _ready_response(monkeypatch, [None, None], controller_ready=False)
+    assert response.status_code == 503
+    assert response.get_json() == {"ready": False, "code": "service_unavailable"}
+
+
+def test_ready_reports_controller_unavailable(monkeypatch):
+    response = _ready_response(monkeypatch, [1234, 1234], controller_ready=False)
+    assert response.status_code == 503
+    assert response.get_json() == {"ready": False, "code": "controller_unavailable"}
+
+
+def test_ready_reports_owner_race_after_controller_probe(monkeypatch):
+    response = _ready_response(monkeypatch, [1234, 5678], controller_ready=True)
+    assert response.status_code == 503
+    assert response.get_json() == {"ready": False, "code": "ownership_lost"}
+
+
+def test_ready_reports_owner_loss_even_when_controller_probe_fails(monkeypatch):
+    response = _ready_response(monkeypatch, [1234, None], controller_ready=False)
+    assert response.status_code == 503
+    assert response.get_json() == {"ready": False, "code": "ownership_lost"}
+
+
+def test_ready_requires_stable_owner_and_healthy_controller(monkeypatch):
+    response = _ready_response(monkeypatch, [1234, 1234], controller_ready=True)
+    assert response.status_code == 200
+    assert response.get_json() == {"ready": True}
+    assert response.headers["Cache-Control"] == "no-store"
+
+
+def _save_remote_access_config(monkeypatch, tmp_path):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    config = V2Config(
+        mode="self_host",
+        version="v2",
+        platform="slack",
+        platforms=PlatformsConfig(enabled=["slack"], primary="slack"),
+        slack=SlackConfig(bot_token=""),
+        runtime=RuntimeConfig(default_cwd="."),
+        agents=AgentsConfig(),
+        ui=UiConfig(),
+        remote_access=RemoteAccessConfig(),
+    )
+    cloud = config.remote_access.vibe_cloud
+    cloud.enabled = True
+    cloud.public_url = "https://alex.avibe.bot"
+    cloud.client_id = "vr_client_123"
+    cloud.instance_id = "inst_123"
+    cloud.session_secret = "session-secret"
+    cloud.authorization_endpoint = "https://backend.test/oauth/authorize"
+    cloud.redirect_uri = "https://alex.avibe.bot/auth/callback"
+    config.save()
+
+
+@pytest.mark.parametrize(
+    ("base_url", "remote_addr", "headers"),
+    [
+        ("http://attacker.example", "127.0.0.1", {}),
+        ("http://127.0.0.1:5123", "203.0.113.10", {}),
+        ("http://127.0.0.1.example", "127.0.0.1", {}),
+        (
+            "http://127.0.0.1:5123",
+            "127.0.0.1",
+            {"X-Forwarded-For": "203.0.113.10"},
+        ),
+    ],
+)
+def test_desktop_runtime_host_header_contract_rejects_non_loopback_local_trust(
+    monkeypatch,
+    tmp_path,
+    base_url,
+    remote_addr,
+    headers,
+):
+    _save_remote_access_config(monkeypatch, tmp_path)
+
+    async def fail_health():
+        pytest.fail("blocked Host must not reach the readiness route")
+
+    monkeypatch.setattr("vibe.internal_client.health", fail_health)
+
+    response = app.test_client().get(
+        "/ready",
+        base_url=base_url,
+        environ_base={"REMOTE_ADDR": remote_addr},
+        headers=headers,
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 503
+    assert response.get_json()["error"] == "remote_access_host_mismatch"
+
+
+def test_bind_ui_socket_uses_ipv6_family(monkeypatch):
+    created_families = []
+
+    class FakeSocket:
+        def setsockopt(self, *_args):
+            return None
+
+        def bind(self, address):
+            assert address == ("::1", 5123)
+
+        def set_inheritable(self, _value):
+            return None
+
+    def fake_socket(family):
+        created_families.append(family)
+        return FakeSocket()
+
+    monkeypatch.setattr(socket, "socket", fake_socket)
+
+    from vibe.ui_server import _bind_ui_socket
+
+    _bind_ui_socket("::1", 5123)
+    assert created_families == [socket.AF_INET6]

--- a/tests/test_desktop_runtime.py
+++ b/tests/test_desktop_runtime.py
@@ -30,6 +30,7 @@ from vibe.ui_server import _bind_ui_sockets, app
     ("bind_host", "expected_origin", "expected_listeners"),
     [
         ("127.0.0.1", "http://127.0.0.1:5123", ("127.0.0.1",)),
+        ("127.0.0.2", "http://127.0.0.1:5123", ("127.0.0.2", "127.0.0.1")),
         ("0.0.0.0", "http://127.0.0.1:5123", ("0.0.0.0",)),
         ("192.168.1.20", "http://127.0.0.1:5123", ("192.168.1.20", "127.0.0.1")),
         ("100.97.103.112", "http://127.0.0.1:5123", ("100.97.103.112", "127.0.0.1")),
@@ -70,6 +71,21 @@ def test_hostname_resolving_to_loopback_does_not_add_duplicate_listener(monkeypa
     )
     assert requires_desktop_loopback_listener("avibe-loopback.test") is False
     assert ui_listener_hosts("avibe-loopback.test") == ("avibe-loopback.test",)
+
+
+def test_hostname_resolving_to_another_ipv4_loopback_adds_advertised_listener(monkeypatch):
+    monkeypatch.setattr(
+        socket,
+        "getaddrinfo",
+        lambda *_args, **_kwargs: [
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("127.0.0.2", 0))
+        ],
+    )
+    assert requires_desktop_loopback_listener("avibe-other-loopback.test") is True
+    assert ui_listener_hosts("avibe-other-loopback.test") == (
+        "avibe-other-loopback.test",
+        "127.0.0.1",
+    )
 
 
 @pytest.mark.parametrize("port", [0, -1, 65536, True, "5123"])

--- a/tests/test_desktop_runtime.py
+++ b/tests/test_desktop_runtime.py
@@ -147,11 +147,11 @@ def test_bind_ui_sockets_closes_primary_when_loopback_bind_fails(monkeypatch):
 def test_ui_health_urls_require_primary_and_desktop_listener():
     assert runtime._ui_health_urls("100.97.103.112", 5123) == (
         "http://100.97.103.112:5123/health",
-        "http://127.0.0.1:5123/health",
+        "http://127.0.0.1:5123/ready",
     )
     assert runtime._ui_health_urls("fd7a:115c:a1e0::42", 5123) == (
         "http://[fd7a:115c:a1e0::42]:5123/health",
-        "http://[::1]:5123/health",
+        "http://[::1]:5123/ready",
     )
 
 
@@ -159,7 +159,9 @@ def test_ui_server_health_fails_when_old_specific_bind_lacks_desktop_listener(mo
     calls = []
 
     class Response:
-        status = 200
+        def __init__(self, payload=b""):
+            self.status = 200
+            self._payload = payload
 
         def __enter__(self):
             return self
@@ -167,9 +169,12 @@ def test_ui_server_health_fails_when_old_specific_bind_lacks_desktop_listener(mo
         def __exit__(self, *_args):
             return None
 
+        def read(self):
+            return self._payload
+
     def fake_urlopen(url, timeout):
         calls.append((url, timeout))
-        if url == "http://127.0.0.1:5123/health":
+        if url == "http://127.0.0.1:5123/ready":
             raise OSError("connection refused")
         return Response()
 
@@ -178,8 +183,34 @@ def test_ui_server_health_fails_when_old_specific_bind_lacks_desktop_listener(mo
     assert runtime.ui_server_healthy("100.97.103.112", 5123) is False
     assert calls == [
         ("http://100.97.103.112:5123/health", 0.5),
-        ("http://127.0.0.1:5123/health", 0.5),
+        ("http://127.0.0.1:5123/ready", 0.5),
     ]
+
+
+def test_ui_server_health_requires_versioned_ready_identity_for_companion_listener(monkeypatch):
+    class Response:
+        def __init__(self, payload):
+            self.status = 200
+            self._payload = payload
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return None
+
+        def read(self):
+            return self._payload
+
+    def fake_urlopen(url, timeout):
+        del timeout
+        if url.endswith("/ready"):
+            return Response(b'{\"ready\":true}')
+        return Response(b"")
+
+    monkeypatch.setattr(runtime.urllib.request, "urlopen", fake_urlopen)
+
+    assert runtime.ui_server_healthy("100.97.103.112", 5123) is False
 
 
 def test_start_ui_restarts_old_specific_bind_without_desktop_listener(tmp_path, monkeypatch):
@@ -189,7 +220,9 @@ def test_start_ui_restarts_old_specific_bind_without_desktop_listener(tmp_path, 
     stopped = []
 
     class Response:
-        status = 200
+        def __init__(self, payload=b""):
+            self.status = 200
+            self._payload = payload
 
         def __enter__(self):
             return self
@@ -197,9 +230,12 @@ def test_start_ui_restarts_old_specific_bind_without_desktop_listener(tmp_path, 
         def __exit__(self, *_args):
             return None
 
+        def read(self):
+            return self._payload
+
     def fake_urlopen(url, timeout):
         del timeout
-        if url == "http://127.0.0.1:5123/health":
+        if url == "http://127.0.0.1:5123/ready":
             raise OSError("old UI has no loopback listener")
         return Response()
 

--- a/tests/test_desktop_runtime.py
+++ b/tests/test_desktop_runtime.py
@@ -281,7 +281,11 @@ def test_ready_reports_owner_loss_even_when_controller_probe_fails(monkeypatch):
 def test_ready_requires_stable_owner_and_healthy_controller(monkeypatch):
     response = _ready_response(monkeypatch, [1234, 1234], controller_ready=True)
     assert response.status_code == 200
-    assert response.get_json() == {"ready": True}
+    assert response.get_json() == {
+        "schema_version": 1,
+        "product": "avibe",
+        "ready": True,
+    }
     assert response.headers["Cache-Control"] == "no-store"
 
 

--- a/tests/test_desktop_runtime.py
+++ b/tests/test_desktop_runtime.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
+import asyncio
+import io
 import json
 import socket
+import threading
+import urllib.error
 from types import SimpleNamespace
 
 import pytest
@@ -88,7 +92,36 @@ def test_hostname_resolving_to_another_ipv4_loopback_adds_advertised_listener(mo
     )
 
 
-@pytest.mark.parametrize("port", [0, -1, 65536, True, "5123"])
+def test_numeric_string_port_is_normalized_for_endpoint_and_health_urls():
+    assert desktop_origin("127.0.0.1", "05123") == "http://127.0.0.1:5123"
+    assert desktop_endpoint_payload("127.0.0.1", "5123") == {
+        "schema_version": 1,
+        "origin": "http://127.0.0.1:5123",
+    }
+    assert runtime._ui_health_urls("127.0.0.1", "5123") == (
+        "http://127.0.0.1:5123/health",
+        "http://127.0.0.1:5123/ready",
+    )
+
+
+@pytest.mark.parametrize(
+    "port",
+    [
+        0,
+        -1,
+        65536,
+        True,
+        None,
+        5123.0,
+        "",
+        "0",
+        "65536",
+        " 5123",
+        "+5123",
+        "5123.0",
+        "１２３４",
+    ],
+)
 def test_desktop_origin_rejects_invalid_ports(port):
     with pytest.raises(ValueError, match="between 1 and 65535"):
         desktop_origin("127.0.0.1", port)
@@ -224,6 +257,89 @@ def test_ui_server_health_requires_versioned_ready_identity_for_companion_listen
     assert runtime.ui_server_healthy("100.97.103.112", 5123) is False
 
 
+def test_ui_server_compatibility_accepts_versioned_not_ready_identity(monkeypatch):
+    payload = json.dumps(
+        {
+            "schema_version": 1,
+            "product": "avibe",
+            "ready": False,
+            "code": "controller_unavailable",
+        }
+    ).encode("utf-8")
+
+    class Response:
+        status = 200
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return None
+
+    def fake_urlopen(url, timeout):
+        del timeout
+        if url.endswith("/ready"):
+            raise urllib.error.HTTPError(
+                url,
+                503,
+                "Service Unavailable",
+                {},
+                io.BytesIO(payload),
+            )
+        return Response()
+
+    monkeypatch.setattr(runtime.urllib.request, "urlopen", fake_urlopen)
+
+    assert runtime.ui_server_healthy("100.97.103.112", 5123) is False
+    assert runtime._ui_server_compatible("100.97.103.112", 5123) is True
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"ready": False, "code": "controller_unavailable"},
+        {
+            "schema_version": 1,
+            "product": "other",
+            "ready": False,
+            "code": "controller_unavailable",
+        },
+        {
+            "schema_version": 1,
+            "product": "avibe",
+            "ready": False,
+        },
+    ],
+)
+def test_ui_server_compatibility_rejects_invalid_not_ready_identity(monkeypatch, payload):
+    encoded_payload = json.dumps(payload).encode("utf-8")
+
+    class Response:
+        status = 200
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return None
+
+    def fake_urlopen(url, timeout):
+        del timeout
+        if url.endswith("/ready"):
+            raise urllib.error.HTTPError(
+                url,
+                503,
+                "Service Unavailable",
+                {},
+                io.BytesIO(encoded_payload),
+            )
+        return Response()
+
+    monkeypatch.setattr(runtime.urllib.request, "urlopen", fake_urlopen)
+
+    assert runtime._ui_server_compatible("100.97.103.112", 5123) is False
+
+
 def test_start_ui_restarts_old_specific_bind_without_desktop_listener(tmp_path, monkeypatch):
     monkeypatch.setattr(paths, "get_vibe_remote_dir", lambda: tmp_path / ".avibe")
     runtime.ensure_dirs()
@@ -270,6 +386,59 @@ def test_start_ui_restarts_old_specific_bind_without_desktop_listener(tmp_path, 
 
     assert runtime.start_ui("100.97.103.112", 5123) == 67890
     assert stopped == [12345]
+
+
+def test_start_ui_adopts_versioned_not_ready_ui(tmp_path, monkeypatch):
+    monkeypatch.setattr(paths, "get_vibe_remote_dir", lambda: tmp_path / ".avibe")
+    runtime.ensure_dirs()
+    paths.get_runtime_ui_pid_path().write_text("12345", encoding="utf-8")
+    payload = json.dumps(
+        {
+            "schema_version": 1,
+            "product": "avibe",
+            "ready": False,
+            "code": "service_starting",
+        }
+    ).encode("utf-8")
+
+    class Response:
+        status = 200
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return None
+
+    def fake_urlopen(url, timeout):
+        del timeout
+        if url.endswith("/ready"):
+            raise urllib.error.HTTPError(
+                url,
+                503,
+                "Service Unavailable",
+                {},
+                io.BytesIO(payload),
+            )
+        return Response()
+
+    monkeypatch.setattr(runtime.urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.setattr(runtime, "pid_alive", lambda pid: pid == 12345)
+    monkeypatch.setattr(
+        runtime,
+        "get_process_command",
+        lambda pid: "from vibe.ui_server import run_ui_server; run_ui_server('100.97.103.112', 5123)"
+        if pid == 12345
+        else None,
+    )
+    monkeypatch.setattr(runtime, "stop_pid", lambda _pid: pytest.fail("compatible UI must not be stopped"))
+    monkeypatch.setattr(
+        runtime,
+        "spawn_background",
+        lambda *_args, **_kwargs: pytest.fail("compatible UI must not be replaced"),
+    )
+
+    assert runtime.start_ui("100.97.103.112", 5123) == 12345
 
 
 @pytest.mark.parametrize("host", ["127.0.0.1", "0.0.0.0"])
@@ -363,31 +532,56 @@ def _ready_response(monkeypatch, owners, *, controller_ready):
 def test_ready_reports_service_starting(monkeypatch):
     response = _ready_response(monkeypatch, [None, 1234], controller_ready=False)
     assert response.status_code == 503
-    assert response.get_json() == {"ready": False, "code": "service_starting"}
+    assert response.get_json() == {
+        "schema_version": 1,
+        "product": "avibe",
+        "ready": False,
+        "code": "service_starting",
+    }
 
 
 def test_ready_reports_service_unavailable(monkeypatch):
     response = _ready_response(monkeypatch, [None, None], controller_ready=False)
     assert response.status_code == 503
-    assert response.get_json() == {"ready": False, "code": "service_unavailable"}
+    assert response.get_json() == {
+        "schema_version": 1,
+        "product": "avibe",
+        "ready": False,
+        "code": "service_unavailable",
+    }
 
 
 def test_ready_reports_controller_unavailable(monkeypatch):
     response = _ready_response(monkeypatch, [1234, 1234], controller_ready=False)
     assert response.status_code == 503
-    assert response.get_json() == {"ready": False, "code": "controller_unavailable"}
+    assert response.get_json() == {
+        "schema_version": 1,
+        "product": "avibe",
+        "ready": False,
+        "code": "controller_unavailable",
+    }
 
 
 def test_ready_reports_owner_race_after_controller_probe(monkeypatch):
     response = _ready_response(monkeypatch, [1234, 5678], controller_ready=True)
     assert response.status_code == 503
-    assert response.get_json() == {"ready": False, "code": "ownership_lost"}
+    assert response.get_json() == {
+        "schema_version": 1,
+        "product": "avibe",
+        "ready": False,
+        "code": "ownership_lost",
+    }
 
 
 def test_ready_reports_owner_loss_even_when_controller_probe_fails(monkeypatch):
     response = _ready_response(monkeypatch, [1234, None], controller_ready=False)
     assert response.status_code == 503
-    assert response.get_json() == {"ready": False, "code": "ownership_lost"}
+    assert response.get_json() == {
+        "schema_version": 1,
+        "product": "avibe",
+        "ready": False,
+        "code": "ownership_lost",
+    }
 
 
 def test_ready_requires_stable_owner_and_healthy_controller(monkeypatch):
@@ -399,6 +593,58 @@ def test_ready_requires_stable_owner_and_healthy_controller(monkeypatch):
         "ready": True,
     }
     assert response.headers["Cache-Control"] == "no-store"
+
+
+def test_ready_offloads_all_service_owner_probes(monkeypatch):
+    owner_iter = iter([1234, 1234, None, 5678])
+    owner_calls = []
+    offloaded_calls = []
+    original_to_thread = asyncio.to_thread
+
+    def resolve_owner(*, include_starting):
+        owner_calls.append((include_starting, threading.get_ident()))
+        return next(owner_iter)
+
+    async def health():
+        return True
+
+    async def track_to_thread(func, *args, **kwargs):
+        event_loop_thread = threading.get_ident()
+        result = await original_to_thread(func, *args, **kwargs)
+        offloaded_calls.append((func, kwargs, event_loop_thread))
+        return result
+
+    monkeypatch.setattr(runtime, "resolve_service_owner_pid", resolve_owner)
+    monkeypatch.setattr("vibe.internal_client.health", health)
+    monkeypatch.setattr("vibe.ui_server.asyncio.to_thread", track_to_thread)
+
+    client = app.test_client()
+    ready_response = client.get("/ready", base_url="http://127.0.0.1:5123")
+    starting_response = client.get("/ready", base_url="http://127.0.0.1:5123")
+
+    assert ready_response.status_code == 200
+    assert starting_response.status_code == 503
+    assert [include_starting for include_starting, _thread in owner_calls] == [
+        False,
+        False,
+        False,
+        True,
+    ]
+    assert [kwargs["include_starting"] for _func, kwargs, _thread in offloaded_calls] == [
+        False,
+        False,
+        False,
+        True,
+    ]
+    assert all(func is resolve_owner for func, _kwargs, _thread in offloaded_calls)
+    assert all(
+        worker_thread != event_loop_thread
+        for (_include_starting, worker_thread), (_func, _kwargs, event_loop_thread) in zip(
+            owner_calls,
+            offloaded_calls,
+            strict=True,
+        )
+    )
 
 
 def _save_remote_access_config(monkeypatch, tmp_path):

--- a/tests/test_desktop_runtime.py
+++ b/tests/test_desktop_runtime.py
@@ -65,7 +65,15 @@ def test_specific_hostname_gets_ipv4_desktop_listener(monkeypatch):
     )
 
 
-def test_localhost_does_not_add_duplicate_listener():
+def test_localhost_does_not_add_duplicate_listener(monkeypatch):
+    monkeypatch.setattr(
+        socket,
+        "getaddrinfo",
+        lambda *_args, **_kwargs: [
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("127.0.0.1", 0))
+        ],
+    )
+
     assert requires_desktop_loopback_listener("localhost") is False
     assert ui_listener_hosts("localhost") == ("localhost",)
 

--- a/tests/test_desktop_runtime.py
+++ b/tests/test_desktop_runtime.py
@@ -155,6 +155,17 @@ def test_ui_health_urls_require_primary_and_desktop_listener():
     )
 
 
+def test_ui_health_urls_require_ready_identity_on_default_loopback_bind():
+    assert runtime._ui_health_urls("127.0.0.1", 5123) == (
+        "http://127.0.0.1:5123/health",
+        "http://127.0.0.1:5123/ready",
+    )
+    assert runtime._ui_health_urls("0.0.0.0", 5123) == (
+        "http://127.0.0.1:5123/health",
+        "http://127.0.0.1:5123/ready",
+    )
+
+
 def test_ui_server_health_fails_when_old_specific_bind_lacks_desktop_listener(monkeypatch):
     calls = []
 
@@ -258,6 +269,55 @@ def test_start_ui_restarts_old_specific_bind_without_desktop_listener(tmp_path, 
     monkeypatch.setattr(runtime, "wait_for_ui_server", lambda _host, _port: True)
 
     assert runtime.start_ui("100.97.103.112", 5123) == 67890
+    assert stopped == [12345]
+
+
+@pytest.mark.parametrize("host", ["127.0.0.1", "0.0.0.0"])
+def test_start_ui_restarts_old_default_or_wildcard_ui_without_ready_identity(tmp_path, monkeypatch, host):
+    monkeypatch.setattr(paths, "get_vibe_remote_dir", lambda: tmp_path / ".avibe")
+    runtime.ensure_dirs()
+    paths.get_runtime_ui_pid_path().write_text("12345", encoding="utf-8")
+    stopped = []
+
+    class Response:
+        def __init__(self, payload=b""):
+            self.status = 200
+            self._payload = payload
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return None
+
+        def read(self):
+            return self._payload
+
+    def fake_urlopen(url, timeout):
+        del timeout
+        if url.endswith("/ready"):
+            raise OSError("old UI lacks ready contract")
+        return Response()
+
+    def fake_spawn(_args, pid_path, _stdout_name, _stderr_name, env=None):
+        del env
+        pid_path.write_text("67890", encoding="utf-8")
+        return 67890
+
+    monkeypatch.setattr(runtime.urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.setattr(runtime, "pid_alive", lambda pid: pid == 12345)
+    monkeypatch.setattr(
+        runtime,
+        "get_process_command",
+        lambda pid: f"from vibe.ui_server import run_ui_server; run_ui_server('{host}', 5123)"
+        if pid == 12345
+        else None,
+    )
+    monkeypatch.setattr(runtime, "stop_pid", lambda pid: stopped.append(pid) or True)
+    monkeypatch.setattr(runtime, "spawn_background", fake_spawn)
+    monkeypatch.setattr(runtime, "wait_for_ui_server", lambda _host, _port: True)
+
+    assert runtime.start_ui(host, 5123) == 67890
     assert stopped == [12345]
 
 

--- a/tests/test_desktop_runtime.py
+++ b/tests/test_desktop_runtime.py
@@ -257,6 +257,48 @@ def test_ui_server_health_requires_versioned_ready_identity_for_companion_listen
     assert runtime.ui_server_healthy("100.97.103.112", 5123) is False
 
 
+@pytest.mark.parametrize(
+    ("status", "payload"),
+    [
+        (
+            200,
+            {
+                "schema_version": 1,
+                "product": "avibe",
+                "ready": 1,
+            },
+        ),
+        (
+            503,
+            {
+                "schema_version": True,
+                "product": "avibe",
+                "ready": False,
+                "code": "service_starting",
+            },
+        ),
+        (
+            503,
+            {
+                "schema_version": 1,
+                "product": "avibe",
+                "ready": 0,
+                "code": "service_starting",
+            },
+        ),
+    ],
+)
+def test_ready_identity_rejects_bool_integer_equivalence(status, payload):
+    class Response:
+        def __init__(self):
+            self.status = status
+
+        def read(self):
+            return json.dumps(payload).encode("utf-8")
+
+    assert runtime._ui_ready_identity_state(Response()) is None
+
+
 def test_ui_server_compatibility_accepts_versioned_not_ready_identity(monkeypatch):
     payload = json.dumps(
         {
@@ -410,8 +452,10 @@ def test_start_ui_adopts_versioned_not_ready_ui(tmp_path, monkeypatch):
         def __exit__(self, *_args):
             return None
 
+    probe_timeouts = []
+
     def fake_urlopen(url, timeout):
-        del timeout
+        probe_timeouts.append(timeout)
         if url.endswith("/ready"):
             raise urllib.error.HTTPError(
                 url,
@@ -439,6 +483,7 @@ def test_start_ui_adopts_versioned_not_ready_ui(tmp_path, monkeypatch):
     )
 
     assert runtime.start_ui("100.97.103.112", 5123) == 12345
+    assert probe_timeouts == [runtime.UI_ADOPTION_PROBE_TIMEOUT_SECONDS] * 2
 
 
 @pytest.mark.parametrize("host", ["127.0.0.1", "0.0.0.0"])

--- a/tests/test_desktop_runtime.py
+++ b/tests/test_desktop_runtime.py
@@ -52,7 +52,12 @@ def test_desktop_origin_and_listener_contract(bind_host, expected_origin, expect
     assert ui_listener_hosts(bind_host) == expected_listeners
 
 
-def test_specific_hostname_gets_ipv4_desktop_listener():
+def test_specific_hostname_gets_ipv4_desktop_listener(monkeypatch):
+    def unresolved(*_args, **_kwargs):
+        raise socket.gaierror("unresolved test hostname")
+
+    monkeypatch.setattr(socket, "getaddrinfo", unresolved)
+
     assert requires_desktop_loopback_listener("192.0.2.20.example.invalid") is True
     assert ui_listener_hosts("192.0.2.20.example.invalid") == (
         "192.0.2.20.example.invalid",
@@ -486,6 +491,25 @@ def test_start_ui_adopts_versioned_not_ready_ui(tmp_path, monkeypatch):
     assert probe_timeouts == [runtime.UI_ADOPTION_PROBE_TIMEOUT_SECONDS] * 2
 
 
+def test_start_ui_normalizes_numeric_string_port_before_spawning(tmp_path, monkeypatch):
+    monkeypatch.setattr(paths, "get_vibe_remote_dir", lambda: tmp_path / ".avibe")
+    runtime.ensure_dirs()
+    spawned = []
+
+    def fake_spawn(args, pid_path, stdout_name, stderr_name, env=None):
+        spawned.append((args, pid_path, stdout_name, stderr_name, env))
+        return 67890
+
+    monkeypatch.setattr(runtime, "spawn_background", fake_spawn)
+
+    assert runtime.start_ui("127.0.0.1", "05123", wait_for_ready=False) == 67890
+    assert spawned[0][0] == [
+        runtime.sys.executable,
+        "-c",
+        "from vibe.ui_server import run_ui_server; run_ui_server('127.0.0.1', 5123)",
+    ]
+
+
 @pytest.mark.parametrize("host", ["127.0.0.1", "0.0.0.0"])
 def test_start_ui_restarts_old_default_or_wildcard_ui_without_ready_identity(tmp_path, monkeypatch, host):
     monkeypatch.setattr(paths, "get_vibe_remote_dir", lambda: tmp_path / ".avibe")
@@ -638,6 +662,41 @@ def test_ready_requires_stable_owner_and_healthy_controller(monkeypatch):
         "ready": True,
     }
     assert response.headers["Cache-Control"] == "no-store"
+
+
+@pytest.mark.parametrize(
+    ("owners", "controller_ready"),
+    [
+        ([OSError("lock unreadable")], False),
+        ([None, OSError("lock unreadable")], False),
+        ([1234, OSError("lock unreadable")], True),
+    ],
+)
+def test_ready_preserves_schema_when_owner_probe_fails(monkeypatch, owners, controller_ready):
+    owner_iter = iter(owners)
+
+    def resolve_owner(*, include_starting):
+        del include_starting
+        result = next(owner_iter)
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+    async def health():
+        return controller_ready
+
+    monkeypatch.setattr(runtime, "resolve_service_owner_pid", resolve_owner)
+    monkeypatch.setattr("vibe.internal_client.health", health)
+
+    response = app.test_client().get("/ready", base_url="http://127.0.0.1:5123")
+
+    assert response.status_code == 503
+    assert response.get_json() == {
+        "schema_version": 1,
+        "product": "avibe",
+        "ready": False,
+        "code": "owner_probe_failed",
+    }
 
 
 def test_ready_offloads_all_service_owner_probes(monkeypatch):

--- a/tests/test_vibe_cli.py
+++ b/tests/test_vibe_cli.py
@@ -1965,7 +1965,11 @@ def test_start_ui_reuses_existing_live_pid(tmp_path, monkeypatch):
     paths.get_runtime_ui_pid_path().write_text("12345", encoding="utf-8")
 
     monkeypatch.setattr(runtime, "pid_alive", lambda pid: pid == 12345)
-    monkeypatch.setattr(runtime, "ui_server_healthy", lambda host, port: host == "127.0.0.1" and port == 5123)
+    monkeypatch.setattr(
+        runtime,
+        "_ui_server_compatible",
+        lambda host, port: host == "127.0.0.1" and port == 5123,
+    )
     monkeypatch.setattr(
         runtime,
         "get_process_command",

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -9858,6 +9858,19 @@ def cmd_start():
     return 0
 
 
+def cmd_desktop_endpoint() -> int:
+    """Print the desktop shell's loopback endpoint descriptor."""
+
+    from vibe.desktop_runtime import desktop_endpoint_payload
+
+    _guard_cli_default_state_migration()
+    config = _ensure_config()
+    bind_host = runtime.effective_ui_bind_host(config)
+    payload = desktop_endpoint_payload(bind_host, config.ui.setup_port)
+    print(json.dumps(payload, separators=(",", ":")))
+    return 0
+
+
 def cmd_vibe():
     """Compatibility default: bare `vibe` starts services and opens the Web UI."""
     return cmd_start()
@@ -11762,6 +11775,10 @@ def build_parser():
 
     subparsers.add_parser("stop", help="Stop all services")
     subparsers.add_parser("start", help="Start services if needed without stopping running processes")
+    desktop_parser = subparsers.add_parser("desktop", help=argparse.SUPPRESS)
+    desktop_subparsers = desktop_parser.add_subparsers(dest="desktop_command", required=True)
+    desktop_endpoint_parser = desktop_subparsers.add_parser("endpoint", help=argparse.SUPPRESS)
+    desktop_endpoint_parser.add_argument("--json", action="store_true", required=True, help=argparse.SUPPRESS)
     restart_parser = subparsers.add_parser("restart", help="Restart all services")
     restart_parser.add_argument(
         "--delay-seconds",
@@ -13239,6 +13256,8 @@ def main():
         sys.exit(cmd_stop())
     if args.command == "start":
         sys.exit(cmd_start())
+    if args.command == "desktop" and args.desktop_command == "endpoint":
+        sys.exit(cmd_desktop_endpoint())
     if args.command == "restart":
         sys.exit(_cmd_restart_with_delay(args.delay_seconds))
     if args.command == "__restart-supervisor":

--- a/vibe/desktop_runtime.py
+++ b/vibe/desktop_runtime.py
@@ -44,8 +44,6 @@ def requires_desktop_loopback_listener(bind_host: str | None) -> bool:
     host = _normalized_bind_host(bind_host)
     if host == "*":
         return False
-    if host.lower() == "localhost":
-        return False
     try:
         address = ipaddress.ip_address(host)
     except ValueError:
@@ -62,7 +60,8 @@ def requires_desktop_loopback_listener(bind_host: str | None) -> bool:
             address = ipaddress.ip_address(resolved[0][4][0])
         except (IndexError, OSError, ValueError):
             return True
-    return not address.is_loopback and not address.is_unspecified
+    advertised = ipaddress.ip_address(desktop_loopback_host(host))
+    return not address.is_unspecified and address != advertised
 
 
 def ui_listener_hosts(bind_host: str | None) -> tuple[str, ...]:

--- a/vibe/desktop_runtime.py
+++ b/vibe/desktop_runtime.py
@@ -1,0 +1,93 @@
+"""Desktop-shell endpoint and listener contracts.
+
+The desktop shell always connects through a literal loopback origin, even when
+the user's primary UI bind is a specific LAN or overlay-network address.  The
+UI process owns both listeners so the shell never has to interpret Avibe
+configuration or broaden its navigation policy.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import socket
+from typing import Literal, TypedDict
+
+DESKTOP_ENDPOINT_SCHEMA_VERSION: Literal[1] = 1
+
+
+class DesktopEndpointPayload(TypedDict):
+    schema_version: Literal[1]
+    origin: str
+
+
+def _normalized_bind_host(bind_host: str | None) -> str:
+    host = (bind_host or "127.0.0.1").strip()
+    if host.startswith("[") and host.endswith("]"):
+        return host[1:-1]
+    return host
+
+
+def _bind_family(bind_host: str | None) -> socket.AddressFamily:
+    host = _normalized_bind_host(bind_host)
+    return socket.AF_INET6 if ":" in host else socket.AF_INET
+
+
+def desktop_loopback_host(bind_host: str | None) -> str:
+    """Return the literal loopback matching the primary bind's IP family."""
+
+    return "::1" if _bind_family(bind_host) == socket.AF_INET6 else "127.0.0.1"
+
+
+def requires_desktop_loopback_listener(bind_host: str | None) -> bool:
+    """Whether a specific primary bind needs a second loopback listener."""
+
+    host = _normalized_bind_host(bind_host)
+    if host == "*":
+        return False
+    if host.lower() == "localhost":
+        return False
+    try:
+        address = ipaddress.ip_address(host)
+    except ValueError:
+        # Match the first address the same-family socket bind will select. A
+        # loopback-only hostname already serves the desktop; an unresolved or
+        # non-loopback name still needs the companion listener.
+        try:
+            resolved = socket.getaddrinfo(
+                host,
+                None,
+                family=_bind_family(host),
+                type=socket.SOCK_STREAM,
+            )
+            address = ipaddress.ip_address(resolved[0][4][0])
+        except (IndexError, OSError, ValueError):
+            return True
+    return not address.is_loopback and not address.is_unspecified
+
+
+def ui_listener_hosts(bind_host: str | None) -> tuple[str, ...]:
+    """Return the primary listener plus any desktop-only loopback listener."""
+
+    primary = "127.0.0.1" if bind_host is None else bind_host.strip()
+    if requires_desktop_loopback_listener(primary):
+        return primary, desktop_loopback_host(primary)
+    return (primary,)
+
+
+def desktop_origin(bind_host: str | None, port: int) -> str:
+    """Build the desktop shell's exact loopback origin."""
+
+    if isinstance(port, bool) or not isinstance(port, int) or not 1 <= port <= 65535:
+        raise ValueError("desktop endpoint port must be between 1 and 65535")
+    loopback = desktop_loopback_host(bind_host)
+    rendered_host = f"[{loopback}]" if ":" in loopback else loopback
+    return f"http://{rendered_host}:{port}"
+
+
+def desktop_endpoint_payload(bind_host: str | None, port: int) -> DesktopEndpointPayload:
+    """Return the frozen schema-v1 descriptor consumed by the desktop shell."""
+
+    return {
+        "schema_version": DESKTOP_ENDPOINT_SCHEMA_VERSION,
+        "origin": desktop_origin(bind_host, port),
+    }

--- a/vibe/desktop_runtime.py
+++ b/vibe/desktop_runtime.py
@@ -73,7 +73,7 @@ def ui_listener_hosts(bind_host: str | None) -> tuple[str, ...]:
     return (primary,)
 
 
-def _normalized_port(port: int | str) -> int:
+def normalize_desktop_port(port: int | str) -> int:
     if isinstance(port, str):
         if not port.isascii() or not port.isdecimal():
             raise ValueError("desktop endpoint port must be between 1 and 65535")
@@ -86,7 +86,7 @@ def _normalized_port(port: int | str) -> int:
 def desktop_origin(bind_host: str | None, port: int | str) -> str:
     """Build the desktop shell's exact loopback origin."""
 
-    normalized_port = _normalized_port(port)
+    normalized_port = normalize_desktop_port(port)
     loopback = desktop_loopback_host(bind_host)
     rendered_host = f"[{loopback}]" if ":" in loopback else loopback
     return f"http://{rendered_host}:{normalized_port}"

--- a/vibe/desktop_runtime.py
+++ b/vibe/desktop_runtime.py
@@ -73,17 +73,29 @@ def ui_listener_hosts(bind_host: str | None) -> tuple[str, ...]:
     return (primary,)
 
 
-def desktop_origin(bind_host: str | None, port: int) -> str:
-    """Build the desktop shell's exact loopback origin."""
-
+def _normalized_port(port: int | str) -> int:
+    if isinstance(port, str):
+        if not port.isascii() or not port.isdecimal():
+            raise ValueError("desktop endpoint port must be between 1 and 65535")
+        port = int(port)
     if isinstance(port, bool) or not isinstance(port, int) or not 1 <= port <= 65535:
         raise ValueError("desktop endpoint port must be between 1 and 65535")
+    return port
+
+
+def desktop_origin(bind_host: str | None, port: int | str) -> str:
+    """Build the desktop shell's exact loopback origin."""
+
+    normalized_port = _normalized_port(port)
     loopback = desktop_loopback_host(bind_host)
     rendered_host = f"[{loopback}]" if ":" in loopback else loopback
-    return f"http://{rendered_host}:{port}"
+    return f"http://{rendered_host}:{normalized_port}"
 
 
-def desktop_endpoint_payload(bind_host: str | None, port: int) -> DesktopEndpointPayload:
+def desktop_endpoint_payload(
+    bind_host: str | None,
+    port: int | str,
+) -> DesktopEndpointPayload:
     """Return the frozen schema-v1 descriptor consumed by the desktop shell."""
 
     return {

--- a/vibe/runtime.py
+++ b/vibe/runtime.py
@@ -1577,8 +1577,16 @@ def _ui_health_urls(host: str, port: int) -> tuple[str, ...]:
     primary_url = _ui_health_url(host, port)
     if not requires_desktop_loopback_listener(host):
         return (primary_url,)
-    desktop_url = f"{desktop_origin(host, port)}/health"
+    desktop_url = f"{desktop_origin(host, port)}/ready"
     return primary_url, desktop_url
+
+
+def _ui_ready_identity_healthy(response) -> bool:
+    try:
+        payload = json.loads(response.read().decode("utf-8"))
+    except (AttributeError, OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return False
+    return payload == {"schema_version": 1, "product": "avibe", "ready": True}
 
 
 def ui_server_healthy(host: str, port: int, timeout: float = 0.5) -> bool:
@@ -1586,6 +1594,8 @@ def ui_server_healthy(host: str, port: int, timeout: float = 0.5) -> bool:
         try:
             with urllib.request.urlopen(health_url, timeout=timeout) as response:
                 if response.status != 200:
+                    return False
+                if health_url.endswith("/ready") and not _ui_ready_identity_healthy(response):
                     return False
         except (OSError, urllib.error.URLError, TimeoutError, ValueError):
             return False

--- a/vibe/runtime.py
+++ b/vibe/runtime.py
@@ -1571,12 +1571,25 @@ def _ui_health_url(host: str, port: int) -> str:
     return f"http://{health_host}:{port}/health"
 
 
+def _ui_health_urls(host: str, port: int) -> tuple[str, ...]:
+    from vibe.desktop_runtime import desktop_origin, requires_desktop_loopback_listener
+
+    primary_url = _ui_health_url(host, port)
+    if not requires_desktop_loopback_listener(host):
+        return (primary_url,)
+    desktop_url = f"{desktop_origin(host, port)}/health"
+    return primary_url, desktop_url
+
+
 def ui_server_healthy(host: str, port: int, timeout: float = 0.5) -> bool:
-    try:
-        with urllib.request.urlopen(_ui_health_url(host, port), timeout=timeout) as response:
-            return response.status == 200
-    except (OSError, urllib.error.URLError, TimeoutError, ValueError):
-        return False
+    for health_url in _ui_health_urls(host, port):
+        try:
+            with urllib.request.urlopen(health_url, timeout=timeout) as response:
+                if response.status != 200:
+                    return False
+        except (OSError, urllib.error.URLError, TimeoutError, ValueError):
+            return False
+    return True
 
 
 def wait_for_ui_server(host: str, port: int, timeout: float = 5.0) -> bool:
@@ -1679,9 +1692,9 @@ def start_ui(host, port, *, wait_for_ready: bool = True):
                 return existing_pid
             if _pid_matches_ui_server(existing_pid):
                 logger.warning(
-                    "Stopping stale UI process pid=%s because health check failed for %s",
+                    "Stopping stale UI process pid=%s because required health checks failed for %s",
                     existing_pid,
-                    _ui_health_url(host, port),
+                    ", ".join(_ui_health_urls(host, port)),
                 )
                 stop_pid(existing_pid)
             else:
@@ -1699,7 +1712,11 @@ def start_ui(host, port, *, wait_for_ready: bool = True):
         "ui_stderr.log",
     )
     if wait_for_ready and not wait_for_ui_server(host, port):
-        logger.warning("Started UI pid=%s but health check did not pass for %s", pid, _ui_health_url(host, port))
+        logger.warning(
+            "Started UI pid=%s but required health checks did not pass for %s",
+            pid,
+            ", ".join(_ui_health_urls(host, port)),
+        )
     return pid
 
 

--- a/vibe/runtime.py
+++ b/vibe/runtime.py
@@ -99,6 +99,8 @@ MAIN_PATH = get_service_main_path()
 _SERVICE_LOCK = threading.Lock()
 _SERVICE_INSTANCE_LOCK_HANDLE = None
 _SERVICE_START_PROCESSES: dict[int, subprocess.Popen] = {}
+# /ready can spend up to two seconds in the Controller health probe.
+UI_ADOPTION_PROBE_TIMEOUT_SECONDS = 3.0
 
 
 def _rounded_seconds(seconds: float) -> float:
@@ -1588,14 +1590,17 @@ def _ui_ready_identity_state(response) -> bool | None:
     except (AttributeError, OSError, UnicodeDecodeError, json.JSONDecodeError):
         return None
 
-    if response.status == 200 and payload == {
-        "schema_version": 1,
-        "product": "avibe",
-        "ready": True,
-    }:
+    if not isinstance(payload, dict):
+        return None
+    if type(payload.get("schema_version")) is not int or payload["schema_version"] != 1:
+        return None
+    if payload.get("product") != "avibe" or type(payload.get("ready")) is not bool:
+        return None
+
+    if response.status == 200 and payload == {"schema_version": 1, "product": "avibe", "ready": True}:
         return True
 
-    code = payload.get("code") if isinstance(payload, dict) else None
+    code = payload.get("code")
     if (
         response.status == 503
         and isinstance(code, str)
@@ -1633,7 +1638,11 @@ def ui_server_healthy(host: str, port: int, timeout: float = 0.5) -> bool:
     return _ui_server_readiness(host, port, timeout=timeout) is True
 
 
-def _ui_server_compatible(host: str, port: int, timeout: float = 0.5) -> bool:
+def _ui_server_compatible(
+    host: str,
+    port: int,
+    timeout: float = UI_ADOPTION_PROBE_TIMEOUT_SECONDS,
+) -> bool:
     return _ui_server_readiness(host, port, timeout=timeout) is not None
 
 

--- a/vibe/runtime.py
+++ b/vibe/runtime.py
@@ -1572,13 +1572,14 @@ def _ui_health_url(host: str, port: int) -> str:
 
 
 def _ui_health_urls(host: str, port: int) -> tuple[str, ...]:
-    from vibe.desktop_runtime import desktop_origin, requires_desktop_loopback_listener
+    from vibe.desktop_runtime import desktop_origin
 
     primary_url = _ui_health_url(host, port)
-    if not requires_desktop_loopback_listener(host):
-        return (primary_url,)
     desktop_url = f"{desktop_origin(host, port)}/ready"
-    return primary_url, desktop_url
+    urls = [primary_url]
+    if desktop_url not in urls:
+        urls.append(desktop_url)
+    return tuple(urls)
 
 
 def _ui_ready_identity_healthy(response) -> bool:

--- a/vibe/runtime.py
+++ b/vibe/runtime.py
@@ -1735,6 +1735,9 @@ def effective_ui_bind_host(config: V2Config, requested_host: str | None = None) 
 
 
 def start_ui(host, port, *, wait_for_ready: bool = True):
+    from vibe.desktop_runtime import normalize_desktop_port
+
+    port = normalize_desktop_port(port)
     pid_path = paths.get_runtime_ui_pid_path()
     if pid_path.exists():
         try:

--- a/vibe/runtime.py
+++ b/vibe/runtime.py
@@ -1582,25 +1582,59 @@ def _ui_health_urls(host: str, port: int) -> tuple[str, ...]:
     return tuple(urls)
 
 
-def _ui_ready_identity_healthy(response) -> bool:
+def _ui_ready_identity_state(response) -> bool | None:
     try:
         payload = json.loads(response.read().decode("utf-8"))
     except (AttributeError, OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return None
+
+    if response.status == 200 and payload == {
+        "schema_version": 1,
+        "product": "avibe",
+        "ready": True,
+    }:
+        return True
+
+    code = payload.get("code") if isinstance(payload, dict) else None
+    if (
+        response.status == 503
+        and isinstance(code, str)
+        and bool(code)
+        and payload
+        == {
+            "schema_version": 1,
+            "product": "avibe",
+            "ready": False,
+            "code": code,
+        }
+    ):
         return False
-    return payload == {"schema_version": 1, "product": "avibe", "ready": True}
+    return None
 
 
-def ui_server_healthy(host: str, port: int, timeout: float = 0.5) -> bool:
+def _ui_server_readiness(host: str, port: int, timeout: float = 0.5) -> bool | None:
     for health_url in _ui_health_urls(host, port):
         try:
             with urllib.request.urlopen(health_url, timeout=timeout) as response:
+                if health_url.endswith("/ready"):
+                    return _ui_ready_identity_state(response)
                 if response.status != 200:
-                    return False
-                if health_url.endswith("/ready") and not _ui_ready_identity_healthy(response):
-                    return False
+                    return None
+        except urllib.error.HTTPError as exc:
+            if health_url.endswith("/ready"):
+                return _ui_ready_identity_state(exc)
+            return None
         except (OSError, urllib.error.URLError, TimeoutError, ValueError):
-            return False
-    return True
+            return None
+    return None
+
+
+def ui_server_healthy(host: str, port: int, timeout: float = 0.5) -> bool:
+    return _ui_server_readiness(host, port, timeout=timeout) is True
+
+
+def _ui_server_compatible(host: str, port: int, timeout: float = 0.5) -> bool:
+    return _ui_server_readiness(host, port, timeout=timeout) is not None
 
 
 def wait_for_ui_server(host: str, port: int, timeout: float = 5.0) -> bool:
@@ -1699,11 +1733,11 @@ def start_ui(host, port, *, wait_for_ready: bool = True):
         except Exception:
             existing_pid = 0
         if existing_pid and pid_alive(existing_pid):
-            if _pid_matches_ui_server(existing_pid) and ui_server_healthy(host, port):
+            if _pid_matches_ui_server(existing_pid) and _ui_server_compatible(host, port):
                 return existing_pid
             if _pid_matches_ui_server(existing_pid):
                 logger.warning(
-                    "Stopping stale UI process pid=%s because required health checks failed for %s",
+                    "Stopping stale UI process pid=%s because required listener or identity checks failed for %s",
                     existing_pid,
                     ", ".join(_ui_health_urls(host, port)),
                 )

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -2406,7 +2406,7 @@ async def ready():
         return response({"ready": False, "code": "ownership_lost"}, 503)
     if not controller_ready:
         return response({"ready": False, "code": "controller_unavailable"}, 503)
-    return response({"ready": True})
+    return response({"schema_version": 1, "product": "avibe", "ready": True})
 
 
 @app.websocket("/ws/echo")

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -2383,6 +2383,32 @@ def status():
     return jsonify(payload)
 
 
+@app.route("/ready")
+async def ready():
+    """Report whether the UI and its authoritative Controller are ready."""
+
+    from vibe import internal_client, runtime
+
+    def response(payload: dict[str, Any], status_code: int = 200):
+        result = jsonify(payload)
+        result.headers["Cache-Control"] = "no-store"
+        return result if status_code == 200 else (result, status_code)
+
+    owner_before = runtime.resolve_service_owner_pid(include_starting=False)
+    if owner_before is None:
+        starting_owner = runtime.resolve_service_owner_pid(include_starting=True)
+        code = "service_starting" if starting_owner is not None else "service_unavailable"
+        return response({"ready": False, "code": code}, 503)
+
+    controller_ready = await internal_client.health()
+    owner_after = runtime.resolve_service_owner_pid(include_starting=False)
+    if owner_after != owner_before:
+        return response({"ready": False, "code": "ownership_lost"}, 503)
+    if not controller_ready:
+        return response({"ready": False, "code": "controller_unavailable"}, 503)
+    return response({"ready": True})
+
+
 @app.websocket("/ws/echo")
 async def websocket_echo(websocket: WebSocket):
     if os.environ.get("VIBE_UI_ENABLE_WS_ECHO", "").lower() not in {"1", "true", "yes", "on"}:
@@ -10535,6 +10561,20 @@ def _bind_ui_socket(host: str, port: int) -> socket.socket:
     return sock
 
 
+def _bind_ui_sockets(host: str, port: int) -> list[socket.socket]:
+    from vibe.desktop_runtime import ui_listener_hosts
+
+    sockets: list[socket.socket] = []
+    try:
+        for listener_host in ui_listener_hosts(host):
+            sockets.append(_bind_ui_socket(listener_host, port))
+    except OSError:
+        for sock in sockets:
+            sock.close()
+        raise
+    return sockets
+
+
 def run_ui_server(host: str, port: int) -> None:
     """Start the FastAPI UI server."""
     global _UI_RUNTIME_ACTIVE, _server
@@ -10563,7 +10603,7 @@ def run_ui_server(host: str, port: int) -> None:
 
     # Retry binding in case of TIME_WAIT or port still held by old server during reload
     for attempt in range(10):
-        bound_socket: socket.socket | None = None
+        bound_sockets: list[socket.socket] = []
         try:
             uvicorn_config = uvicorn.Config(
                 app,
@@ -10575,7 +10615,7 @@ def run_ui_server(host: str, port: int) -> None:
                 lifespan="on",
                 workers=1,
             )
-            bound_socket = _bind_ui_socket(host, port)
+            bound_sockets = _bind_ui_sockets(host, port)
             _server = uvicorn.Server(uvicorn_config)
             # Reconcile remote_access in the background so cloudflared download/
             # connector start does not block /health and the rest of the UI
@@ -10588,12 +10628,12 @@ def run_ui_server(host: str, port: int) -> None:
             ).start()
             _UI_RUNTIME_ACTIVE = True
             try:
-                _server.run(sockets=[bound_socket])
+                _server.run(sockets=bound_sockets)
             finally:
                 _UI_RUNTIME_ACTIVE = False
             break
         except OSError as e:
-            if bound_socket is not None:
+            for bound_socket in bound_sockets:
                 bound_socket.close()
             if e.errno == 48 and attempt < 9:  # Address already in use (macOS)
                 print(f"Port {port} in use, retrying in 1s... (attempt {attempt + 1})")

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -2389,24 +2389,38 @@ async def ready():
 
     from vibe import internal_client, runtime
 
+    identity = {"schema_version": 1, "product": "avibe"}
+
     def response(payload: dict[str, Any], status_code: int = 200):
         result = jsonify(payload)
         result.headers["Cache-Control"] = "no-store"
         return result if status_code == 200 else (result, status_code)
 
-    owner_before = runtime.resolve_service_owner_pid(include_starting=False)
+    def unavailable(code: str):
+        return response({**identity, "ready": False, "code": code}, 503)
+
+    owner_before = await asyncio.to_thread(
+        runtime.resolve_service_owner_pid,
+        include_starting=False,
+    )
     if owner_before is None:
-        starting_owner = runtime.resolve_service_owner_pid(include_starting=True)
+        starting_owner = await asyncio.to_thread(
+            runtime.resolve_service_owner_pid,
+            include_starting=True,
+        )
         code = "service_starting" if starting_owner is not None else "service_unavailable"
-        return response({"ready": False, "code": code}, 503)
+        return unavailable(code)
 
     controller_ready = await internal_client.health()
-    owner_after = runtime.resolve_service_owner_pid(include_starting=False)
+    owner_after = await asyncio.to_thread(
+        runtime.resolve_service_owner_pid,
+        include_starting=False,
+    )
     if owner_after != owner_before:
-        return response({"ready": False, "code": "ownership_lost"}, 503)
+        return unavailable("ownership_lost")
     if not controller_ready:
-        return response({"ready": False, "code": "controller_unavailable"}, 503)
-    return response({"schema_version": 1, "product": "avibe", "ready": True})
+        return unavailable("controller_unavailable")
+    return response({**identity, "ready": True})
 
 
 @app.websocket("/ws/echo")

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -2399,23 +2399,32 @@ async def ready():
     def unavailable(code: str):
         return response({**identity, "ready": False, "code": code}, 503)
 
-    owner_before = await asyncio.to_thread(
-        runtime.resolve_service_owner_pid,
-        include_starting=False,
-    )
+    owner_probe_failed = object()
+
+    async def resolve_owner(*, include_starting: bool):
+        try:
+            return await asyncio.to_thread(
+                runtime.resolve_service_owner_pid,
+                include_starting=include_starting,
+            )
+        except Exception:
+            logger.exception("Failed to resolve service ownership for readiness")
+            return owner_probe_failed
+
+    owner_before = await resolve_owner(include_starting=False)
+    if owner_before is owner_probe_failed:
+        return unavailable("owner_probe_failed")
     if owner_before is None:
-        starting_owner = await asyncio.to_thread(
-            runtime.resolve_service_owner_pid,
-            include_starting=True,
-        )
+        starting_owner = await resolve_owner(include_starting=True)
+        if starting_owner is owner_probe_failed:
+            return unavailable("owner_probe_failed")
         code = "service_starting" if starting_owner is not None else "service_unavailable"
         return unavailable(code)
 
     controller_ready = await internal_client.health()
-    owner_after = await asyncio.to_thread(
-        runtime.resolve_service_owner_pid,
-        include_starting=False,
-    )
+    owner_after = await resolve_owner(include_starting=False)
+    if owner_after is owner_probe_failed:
+        return unavailable("owner_probe_failed")
     if owner_after != owner_before:
         return unavailable("ownership_lost")
     if not controller_ready:


### PR DESCRIPTION
## Capability

Adds the Python-owned desktop Runtime endpoint contract used by the Tauri shell:

- `vibe desktop endpoint --json` emits a strict schema-v1 literal-loopback origin derived from the effective V2 UI binding
- numeric-string UI ports from compatible persisted V2 config are normalized on both descriptor and UI launch paths while invalid ports remain rejected
- the existing UI process adds the exact advertised same-port loopback listener whenever its primary bind does not already cover that address, including noncanonical `127/8` binds
- `GET /ready` proves UI reachability, exact Avibe identity, stable service-lock ownership, and Controller control-IPC health without running filesystem/process owner probes on the ASGI event loop
- all `/ready` outcomes, including owner-probe failures, carry exact typed schema-v1 Avibe identity; startup preserves a compatible UI while its Controller is still starting, gives the route enough time to complete its own health probe, and replaces older or malformed readiness contracts

The primary listener, remote-access authentication, Host validation, and Runtime ownership remain unchanged.

Integration target: `desktop`. This PR must not merge directly to `master`.

## Scenarios

- D01: cold launch
- D02: adopt an existing Runtime
- D09: deterministic window/runtime lifecycle
- D10: Runtime crash diagnosis and recovery readiness

## Evidence

- **Unit:** 66 focused descriptor, listener, readiness, CLI, IPv4/IPv6, port-compatibility, typed-identity, adoption-timeout, owner-failure, event-loop offload, hermetic DNS, and Host-trust tests passed locally.
- **Contract:** schema v1 exact typed JSON for affirmative and negative `/ready` responses; named desktop Host-header trust regression; exact readiness result codes, canonical launch ports, and tri-state adoption behavior.
- **Scenario:** 360 focused and adjacent runtime/remote-auth tests passed locally on macOS.
- **Integration:** after merging the current `desktop` base containing the headless start, Windows control IPC, and Windows ProcessHost contracts, 353 composed CLI/runtime/IPC/process tests passed with 5 Windows-only skips.
- **Build/Lint:** Ruff passed on all changed Python files; `git diff --check` passed.
- **Residual manual:** native Windows dual-socket and Controller readiness proof remains part of the packaged desktop integration pass.

## Dependencies

- No remaining merge dependency.
