### PR TITLE
fix(runtime): use platform daemon spawn isolation

### DIFF
--- a/tests/test_restart_supervisor.py
+++ b/tests/test_restart_supervisor.py
@@ -39,6 +39,7 @@ def test_schedule_restart_spawns_supervisor_and_records_status(monkeypatch, tmp_
     monkeypatch.setattr(restart_supervisor, "get_restart_environment", lambda vibe_path=None: {"PATH": "/bin"})
     monkeypatch.setattr(restart_supervisor, "get_safe_cwd", lambda: str(tmp_path))
     monkeypatch.setattr(restart_supervisor, "_prune_restart_logs", lambda: None)
+    monkeypatch.setattr(restart_supervisor, "isolated_subprocess_kwargs", lambda: {"creationflags": 0x200})
 
     def fake_popen(command, **kwargs):
         calls["command"] = command
@@ -59,7 +60,8 @@ def test_schedule_restart_spawns_supervisor_and_records_status(monkeypatch, tmp_
     assert calls["command"][:2] == ["/bin/vibe", "__restart-supervisor"]
     assert calls["command"][calls["command"].index("--delay-seconds") + 1] == "60"
     assert "--prepare-show-runtime" not in calls["command"]
-    assert calls["kwargs"]["start_new_session"] is True
+    assert calls["kwargs"]["creationflags"] == 0x200
+    assert "start_new_session" not in calls["kwargs"]
     assert calls["kwargs"]["env"] == {"PATH": "/bin"}
     assert runtime.read_json(runtime.get_restart_status_path())["job_id"] == result["job_id"]
 

--- a/tests/test_service_logging_handlers.py
+++ b/tests/test_service_logging_handlers.py
@@ -90,6 +90,7 @@ def test_spawn_background_detaches_stdin(monkeypatch, tmp_path):
     sink_paths: list[Path] = []
 
     monkeypatch.setattr(runtime.paths, "get_runtime_dir", lambda: tmp_path)
+    monkeypatch.setattr(runtime, "isolated_subprocess_kwargs", lambda: {"creationflags": 0x200})
 
     class FakeSink:
         def __init__(self, path: Path):
@@ -116,10 +117,61 @@ def test_spawn_background_detaches_stdin(monkeypatch, tmp_path):
     stdin = captured["kwargs"]["stdin"]
     assert stdin.name == os.devnull
     assert stdin.closed is True
-    assert captured["kwargs"]["start_new_session"] is True
+    assert captured["kwargs"]["creationflags"] == 0x200
+    assert "start_new_session" not in captured["kwargs"]
     assert captured["kwargs"]["stdout"].closed is True
     assert captured["kwargs"]["stderr"].closed is True
     assert sink_paths == [tmp_path / "stdout.log", tmp_path / "stderr.log"]
+
+
+def test_runtime_log_sink_uses_platform_isolation(monkeypatch, tmp_path):
+    captured: dict[str, object] = {}
+
+    class FakePopen:
+        def __init__(self, args, **kwargs):
+            captured["args"] = args
+            captured["kwargs"] = kwargs
+
+    monkeypatch.setattr(runtime.subprocess, "Popen", FakePopen)
+    monkeypatch.setattr(runtime, "isolated_subprocess_kwargs", lambda: {"creationflags": 0x200})
+
+    runtime._spawn_runtime_log_sink(tmp_path / "runtime.log")
+
+    assert captured["kwargs"]["creationflags"] == 0x200
+    assert "start_new_session" not in captured["kwargs"]
+
+
+def test_generic_background_spawn_uses_platform_isolation(monkeypatch, tmp_path):
+    captured: dict[str, object] = {}
+    sink_paths: list[Path] = []
+
+    monkeypatch.setattr(runtime.paths, "get_runtime_dir", lambda: tmp_path)
+    monkeypatch.setattr(runtime, "isolated_subprocess_kwargs", lambda: {"creationflags": 0x200})
+
+    class FakeSink:
+        def __init__(self, path: Path):
+            self.stdin = path.open("wb")
+
+    def fake_sinks(stdout_path: Path, stderr_path: Path):
+        sink_paths.extend((stdout_path, stderr_path))
+        return FakeSink(tmp_path / "generic-stdout.pipe"), FakeSink(tmp_path / "generic-stderr.pipe")
+
+    class FakePopen:
+        pid = 24680
+
+        def __init__(self, args, **kwargs):
+            captured["args"] = args
+            captured["kwargs"] = kwargs
+
+    monkeypatch.setattr(runtime, "_spawn_runtime_log_sinks", fake_sinks)
+    monkeypatch.setattr(runtime.subprocess, "Popen", FakePopen)
+    pid_path = tmp_path / "ui.pid"
+
+    assert runtime.spawn_background(["python3", "ui.py"], pid_path, "ui-out.log", "ui-err.log") == 24680
+    assert captured["kwargs"]["creationflags"] == 0x200
+    assert "start_new_session" not in captured["kwargs"]
+    assert pid_path.read_text(encoding="utf-8") == "24680"
+    assert sink_paths == [tmp_path / "ui-out.log", tmp_path / "ui-err.log"]
 
 
 def test_main_import_does_not_load_controller() -> None:

--- a/vibe/restart_supervisor.py
+++ b/vibe/restart_supervisor.py
@@ -11,6 +11,7 @@ from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 from config import paths
+from core.process_isolation import isolated_subprocess_kwargs
 from vibe import runtime
 from vibe.upgrade import get_restart_command, get_restart_environment, get_restart_invocation_command, get_safe_cwd
 
@@ -486,10 +487,10 @@ def schedule_restart(
                 command,
                 stdout=log,
                 stderr=subprocess.STDOUT,
-                start_new_session=True,
                 close_fds=True,
                 cwd=get_safe_cwd(),
                 env=env,
+                **isolated_subprocess_kwargs(),
             )
     except OSError as exc:
         # The seed status above is now "scheduled"; if the job can't be spawned

--- a/vibe/runtime.py
+++ b/vibe/runtime.py
@@ -29,6 +29,7 @@ from config.v2_config import (
     SlackConfig,
     V2Config,
 )
+from core.process_isolation import isolated_subprocess_kwargs
 from vibe.log_sink import RUNTIME_LOG_MAX_BYTES, RUNTIME_LOG_RETAIN_BYTES
 
 
@@ -833,9 +834,9 @@ def _spawn_runtime_log_sink(path: Path) -> subprocess.Popen:
         stdin=subprocess.PIPE,
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
-        start_new_session=True,
         cwd=str(get_working_dir()),
         close_fds=True,
+        **isolated_subprocess_kwargs(),
     )
 
 
@@ -868,10 +869,10 @@ def spawn_background(args, pid_path, stdout_name: str, stderr_name: str, env: di
             stdin=stdin,
             stdout=stdout_sink.stdin,
             stderr=stderr_sink.stdin,
-            start_new_session=True,
             cwd=str(get_working_dir()),
             close_fds=True,
             env=env,
+            **isolated_subprocess_kwargs(),
         )
     finally:
         stdin.close()
@@ -898,10 +899,10 @@ def spawn_service_background_process(
             stdin=stdin,
             stdout=stdout_sink.stdin,
             stderr=stderr_sink.stdin,
-            start_new_session=True,
             cwd=str(get_working_dir()),
             close_fds=True,
             env=env,
+            **isolated_subprocess_kwargs(),
         )
     finally:
         stdin.close()


### PR DESCRIPTION
## Capability

Routes every long-lived Runtime launcher through the existing cross-platform process-isolation contract:

- Runtime log sinks
- generic UI and helper daemons
- the service daemon
- the restart supervisor

POSIX keeps `start_new_session=True`. Native Windows now receives `CREATE_NEW_PROCESS_GROUP` through `isolated_subprocess_kwargs()` instead of silently ignoring a POSIX-only keyword.

Integration target: `desktop`. This PR must not merge directly to `master`.

## Scenarios

- D01: desktop cold launch starts a detached Runtime without a Windows-only spawn mismatch
- D09: closing the Tauri window does not own or terminate the Runtime daemon
- D10: the restart supervisor remains isolated while replacing Runtime processes
- D12: native Windows service startup uses the shared Windows spawn contract without WSL

## Evidence

- **Unit:** 81 focused service logging, restart supervisor, process isolation, and service-lock tests passed locally.
- **Contract:** behavior tests inject Windows-style `creationflags` and prove log-sink, generic daemon, service, and restart-supervisor call sites consume the shared abstraction without also passing `start_new_session`.
- **Lint:** Ruff and `git diff --check` passed.
- **Residual manual:** graceful authenticated shutdown, Job Object owned-tree cleanup, and native parent-child-grandchild proof remain in the ProcessHost lifecycle PR after #1022 enters `desktop`.

## Dependencies

- No code dependency.
- This is the explicit pre-M2 spawn precondition. It does not claim the complete ProcessHost lifecycle contract.
