### PR TITLE
fix(workbench): add mobile session background action

### DIFF
--- a/ui/src/components/workbench/ProjectsPage.tsx
+++ b/ui/src/components/workbench/ProjectsPage.tsx
@@ -6,6 +6,7 @@ import {
   ChevronDown,
   ChevronRight,
   Ellipsis,
+  EyeOff,
   FileText,
   Folder,
   FolderOpen,
@@ -25,8 +26,11 @@ import clsx from 'clsx';
 import { useWorkbenchInbox } from '../../context/WorkbenchInboxContext';
 import { useWorkbenchProjectsTree } from '../../context/WorkbenchProjectsContext';
 import type { ProjectSessionsState } from '../../context/WorkbenchProjectsContext';
+import { useApi } from '../../context/ApiContext';
 import type { WorkbenchProject, WorkbenchSession } from '../../context/ApiContext';
+import { useToast } from '../../context/ToastContext';
 import { formatRelativeTime } from '../../lib/relativeTime';
+import { hideSessionToBackground } from '../../lib/sessionVisibilityActions';
 import { Badge } from '../ui/badge';
 import { Button } from '../ui/button';
 import { Input } from '../ui/input';
@@ -249,6 +253,8 @@ const MobileSessionRow: React.FC<{
   onOpen: () => void;
 }> = ({ projectId, session, unread, onOpen }) => {
   const { t } = useTranslation();
+  const api = useApi();
+  const { showToast } = useToast();
   const { renameSession, setSessionPinned, archiveSession, forkSession } = useWorkbenchProjectsTree();
   const navigate = useNavigate();
   const [menuOpen, setMenuOpen] = useState(false);
@@ -391,6 +397,21 @@ const MobileSessionRow: React.FC<{
               {t('workbench.sessionFork')}
             </MenuItem>
           )}
+          <MenuItem
+            icon={EyeOff}
+            onClick={() => {
+              setMenuOpen(false);
+              void hideSessionToBackground({
+                sessionId: session.id,
+                setSessionVisibility: api.setSessionVisibility,
+                showToast,
+                hiddenMessage: t('workbench.sessionHiddenToast'),
+                undoLabel: t('common.undo'),
+              });
+            }}
+          >
+            {t('workbench.sessionHideToBackground')}
+          </MenuItem>
           <MenuItem
             icon={Archive}
             danger

--- a/ui/src/components/workbench/WorkbenchSidebar.tsx
+++ b/ui/src/components/workbench/WorkbenchSidebar.tsx
@@ -42,6 +42,7 @@ import { useToast } from '../../context/ToastContext';
 import { SessionPinAction } from './SessionPinAction';
 import { sessionPinRowPaddingClass } from './sessionPinLayout';
 import { formatRelativeTime } from '../../lib/relativeTime';
+import { hideSessionToBackground } from '../../lib/sessionVisibilityActions';
 import { Popover, PopoverAnchor, PopoverContent, PopoverTrigger } from '../ui/popover';
 import { ArchiveSessionDialog } from './ArchiveSessionDialog';
 import { Button } from '../ui/button';
@@ -426,24 +427,15 @@ const SessionRow: React.FC<{
         </button>
         <button
           type="button"
-          onClick={async () => {
+          onClick={() => {
             setMenuOpen(false);
-            try {
-              // Move to background (M1 PATCH). The row leaves the list on its own
-              // via the A6 session.activity pipeline — no client-side removal. Not
-              // a delete: offer an immediate Undo and say where it went. Hiding the
-              // currently-open chat is fine — we don't navigate; it just leaves the
-              // list while the chat stays usable.
-              await api.setSessionVisibility(session.id, 'background');
-              showToast(t('workbench.sessionHiddenToast'), 'success', {
-                label: t('common.undo'),
-                onClick: () => {
-                  void api.setSessionVisibility(session.id, 'foreground');
-                },
-              });
-            } catch (err) {
-              showToast(err instanceof Error ? err.message : String(err), 'error');
-            }
+            void hideSessionToBackground({
+              sessionId: session.id,
+              setSessionVisibility: api.setSessionVisibility,
+              showToast,
+              hiddenMessage: t('workbench.sessionHiddenToast'),
+              undoLabel: t('common.undo'),
+            });
           }}
           className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-[12px] text-foreground transition hover:bg-foreground/[0.04]"
         >

--- a/ui/src/lib/sessionVisibilityActions.test.ts
+++ b/ui/src/lib/sessionVisibilityActions.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { hideSessionToBackground } from './sessionVisibilityActions';
+
+describe('hideSessionToBackground', () => {
+  it('moves the session to the background and exposes an undo action', async () => {
+    const setSessionVisibility = vi.fn().mockResolvedValue(undefined);
+    const showToast = vi.fn();
+
+    await hideSessionToBackground({
+      sessionId: 'sess-1',
+      setSessionVisibility,
+      showToast,
+      hiddenMessage: 'Session hidden',
+      undoLabel: 'Undo',
+    });
+
+    expect(setSessionVisibility).toHaveBeenCalledWith('sess-1', 'background');
+    expect(showToast).toHaveBeenCalledWith(
+      'Session hidden',
+      'success',
+      expect.objectContaining({ label: 'Undo' }),
+    );
+
+    const action = showToast.mock.calls[0][2];
+    action.onClick();
+    expect(setSessionVisibility).toHaveBeenLastCalledWith('sess-1', 'foreground');
+  });
+
+  it('surfaces visibility failures without offering undo', async () => {
+    const setSessionVisibility = vi.fn().mockRejectedValue(new Error('Visibility update failed'));
+    const showToast = vi.fn();
+
+    await hideSessionToBackground({
+      sessionId: 'sess-1',
+      setSessionVisibility,
+      showToast,
+      hiddenMessage: 'Session hidden',
+      undoLabel: 'Undo',
+    });
+
+    expect(showToast).toHaveBeenCalledOnce();
+    expect(showToast).toHaveBeenCalledWith('Visibility update failed', 'error');
+  });
+});

--- a/ui/src/lib/sessionVisibilityActions.ts
+++ b/ui/src/lib/sessionVisibilityActions.ts
@@ -1,0 +1,31 @@
+import type { ToastAction } from '../context/toastCoalesce';
+
+type SessionVisibility = 'foreground' | 'background';
+type SetSessionVisibility = (sessionId: string, visibility: SessionVisibility) => Promise<unknown>;
+type ShowToast = (
+  message: string,
+  type?: 'success' | 'error' | 'warning',
+  action?: ToastAction,
+) => void;
+
+export async function hideSessionToBackground(args: {
+  sessionId: string;
+  setSessionVisibility: SetSessionVisibility;
+  showToast: ShowToast;
+  hiddenMessage: string;
+  undoLabel: string;
+}): Promise<void> {
+  const { sessionId, setSessionVisibility, showToast, hiddenMessage, undoLabel } = args;
+
+  try {
+    await setSessionVisibility(sessionId, 'background');
+    showToast(hiddenMessage, 'success', {
+      label: undoLabel,
+      onClick: () => {
+        void setSessionVisibility(sessionId, 'foreground');
+      },
+    });
+  } catch (err) {
+    showToast(err instanceof Error ? err.message : String(err), 'error');
+  }
+}


### PR DESCRIPTION
## What

- add **Hide to background** to the mobile Projects session menu
- reuse one visibility action for desktop and mobile so both surfaces keep the same background, error, and Undo behavior
- cover the shared action with focused success, Undo, and failure tests

## Scenarios

- M1 session visibility PATCH: move a foreground Workbench session to background from the mobile Projects surface
- M1 restore path: restore the hidden session to foreground from the Undo toast

## Evidence

- Unit: `npx vitest run src/lib/sessionVisibilityActions.test.ts` (2 passed)
- Contract: both desktop and mobile call the existing `setSessionVisibility(sessionId, visibility)` API
- Scenario: mobile menu exposes the existing localized action and closes before the visibility mutation
- Build: targeted ESLint passed; `npm run build` passed
- Residual manual: visual browser verification was not run because the in-app browser was unavailable

## Risk

Low. The backend visibility contract and translations are unchanged; this only exposes the existing action on mobile and shares the existing desktop behavior.
