### PR TITLE
fix(release): use gpt-5.6-sol for AI notes

### DIFF
--- a/.github/workflows/release_ai.yml
+++ b/.github/workflows/release_ai.yml
@@ -12,10 +12,10 @@ on:
         required: true
         type: string
       model:
-        description: "OpenAI model (default: gpt-5.5)"
+        description: "OpenAI model (default: gpt-5.6-sol)"
         required: false
         type: string
-        default: "gpt-5.5"
+        default: "gpt-5.6-sol"
       max_commits:
         description: "Max commits to summarize"
         required: false
@@ -312,7 +312,7 @@ jobs:
         id: notes
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          OPENAI_MODEL: ${{ github.event.inputs.model || 'gpt-5.5' }}
+          OPENAI_MODEL: ${{ github.event.inputs.model || 'gpt-5.6-sol' }}
           TAG: ${{ steps.tag.outputs.tag }}
           RANGE: ${{ steps.commits.outputs.range }}
           COMMIT_COUNT: ${{ steps.commits.outputs.commit_count }}


### PR DESCRIPTION
## Summary

- capability: generate AI-written release notes with the current release-notes model
- change the workflow-dispatch model default from `gpt-5.5` to `gpt-5.6-sol`
- use `gpt-5.6-sol` as the tag-trigger fallback while preserving the manual model override

## Scenario Coverage

- scenario IDs: none identified
- unit coverage: not applicable; this is a declarative workflow default
- contract coverage: verified all three workflow references use `gpt-5.6-sol` and no `gpt-5.5` reference remains in the workflow
- scenario coverage: none added
- residual manual checks: no release tag, workflow dispatch, or release publication was performed

## Validation

- parsed `.github/workflows/release_ai.yml` successfully
- verified exactly three `gpt-5.6-sol` references
- `git diff --check` passed

## Known By Design

- manual workflow dispatches can still override the model input
- push-tag releases use `gpt-5.6-sol` when no workflow-dispatch input exists
- OpenAI documents `gpt-5.6-sol` as an API model supported by both Chat Completions and Responses: https://developers.openai.com/api/docs/models/gpt-5.6-sol