### PR TITLE
fix(cli): remove duplicate definition payload aliases

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -317,6 +317,8 @@ vibe watch remove <watch-id>
 include `pagination.next_command` when more rows exist. Successful one-shot
 definitions are hidden by default. Add `--include-finished` to page through
 history. List output is always bounded; there is no unpaginated `--all` mode.
+Task and watch commands use `definition` for one record and `definitions` for
+lists; they do not duplicate those records under command-specific aliases.
 
 The waiter command is passed positionally after `--` (or as a single shell
 string via `--shell`). Use `vibe watch add --help` for the full surface,

--- a/docs/CLI_ZH.md
+++ b/docs/CLI_ZH.md
@@ -294,6 +294,8 @@ vibe watch remove <watch-id>
 `vibe task list` 和 `vibe watch list` 默认每页返回 20 条定义；还有下一页时，
 响应会包含 `pagination.next_command`。默认隐藏成功结束的一次性定义；使用
 `--include-finished` 分页查看历史。列表输出始终有上限，不提供无分页的 `--all` 模式。
+task 和 watch 命令用 `definition` 表示单条记录、用 `definitions` 表示列表，
+不会再通过命令专属别名重复输出同一份记录。
 
 waiter 命令放在 `--` 后面；或者通过 `--shell` 传入一整段 shell 字符串。
 完整参数请看 `vibe watch add --help`，包括 `--timeout`、`--lifetime-timeout`、

--- a/skills/use-avibe/SKILL.md
+++ b/skills/use-avibe/SKILL.md
@@ -809,6 +809,7 @@ Operational guidance:
 - use `vibe task update <id>` to keep the same task ID while changing name, schedule, message, agent, or target
 - use `vibe watch update <id> ...` when you must rename, retarget, or change the waiter/options
 - Agent-facing collection commands return 20 compact rows per page, cap `--limit` at 100, and have no unpaginated `--all` mode; follow `pagination.next_command` when more rows exist
+- read task/watch records from `definition` for detail commands and `definitions` for list commands; command-specific duplicate aliases are not emitted
 - use `--include-finished` for paginated task/watch one-shot history
 - both list commands hide successful one-shot definitions by default while failures stay visible; use `--include-finished` and follow `pagination.next_command` for bounded history
 - use `vibe task show <id>`, `vibe watch show <id>`, or `vibe runs show <run-id>` to inspect stored fields and runtime state

--- a/tests/test_cli_task_command.py
+++ b/tests/test_cli_task_command.py
@@ -610,6 +610,7 @@ def test_task_add_records_caller_context_metadata(tmp_path: Path, capsys) -> Non
 
     assert result == 0
     payload = json.loads(capsys.readouterr().out)
+    assert "task" not in payload
     expected = {
         "kind": "caller_context",
         "caller": {
@@ -620,8 +621,8 @@ def test_task_add_records_caller_context_metadata(tmp_path: Path, capsys) -> Non
             "native_session_id": "native-codex-1",
         },
     }
-    assert payload["task"]["metadata"]["created_by"] == expected
-    stored = cli.ScheduledTaskStore(store_path).get_task(payload["task"]["id"])
+    assert payload["definition"]["metadata"]["created_by"] == expected
+    stored = cli.ScheduledTaskStore(store_path).get_task(payload["definition"]["id"])
     assert stored is not None
     assert stored.metadata["created_by"] == expected
 
@@ -684,12 +685,12 @@ def test_task_add_create_per_run_scope_id_records_session_scope_metadata(tmp_pat
 
     assert result == 0
     payload = json.loads(capsys.readouterr().out)
-    assert payload["task"]["session_policy"] == "create_per_run"
-    assert payload["task"]["deliver_key"] is None
-    assert payload["task"]["cwd"] is None
-    assert payload["task"]["metadata"]["session_scope_id"] == "avibe::project::proj-scope-task"
-    assert "session_workdir" not in payload["task"]["metadata"]
-    assert payload["task"]["agent_name"] == "project-agent"
+    assert payload["definition"]["session_policy"] == "create_per_run"
+    assert payload["definition"]["deliver_key"] is None
+    assert payload["definition"]["cwd"] is None
+    assert payload["definition"]["metadata"]["session_scope_id"] == "avibe::project::proj-scope-task"
+    assert "session_workdir" not in payload["definition"]["metadata"]
+    assert payload["definition"]["agent_name"] == "project-agent"
 
 
 def test_task_add_create_per_run_without_scope_records_standalone_definition(tmp_path: Path, capsys) -> None:
@@ -717,7 +718,7 @@ def test_task_add_create_per_run_without_scope_records_standalone_definition(tmp
         result = cli.cmd_task_add(args)
 
     assert result == 0
-    task = json.loads(capsys.readouterr().out)["task"]
+    task = json.loads(capsys.readouterr().out)["definition"]
     assert task["session_policy"] == "create_per_run"
     assert task["session_id"] is None
     assert task["deliver_key"] is None
@@ -784,15 +785,15 @@ def test_task_add_create_session_scope_id_supports_project_scope(tmp_path: Path,
 
     assert result == 0
     payload = json.loads(capsys.readouterr().out)
-    assert payload["task"]["session_policy"] == "create_once"
-    target = cli.resolve_session_id_target(payload["task"]["session_id"], db_path=db_path)
+    assert payload["definition"]["session_policy"] == "create_once"
+    target = cli.resolve_session_id_target(payload["definition"]["session_id"], db_path=db_path)
     assert target.session_key.session_scope == "avibe::project::proj-once-task"
     assert target.visibility == "foreground"
     assert target.suppress_delivery is False
     assert target.workdir == str(tmp_path)
-    assert payload["task"]["cwd"] is None
-    assert payload["task"]["metadata"]["session_scope_id"] == "avibe::project::proj-once-task"
-    assert "session_workdir" not in payload["task"]["metadata"]
+    assert payload["definition"]["cwd"] is None
+    assert payload["definition"]["metadata"]["session_scope_id"] == "avibe::project::proj-once-task"
+    assert "session_workdir" not in payload["definition"]["metadata"]
 
 
 def test_task_add_create_session_scope_id_uses_unique_definition_anchors(tmp_path: Path, capsys) -> None:
@@ -867,7 +868,7 @@ def test_task_add_create_session_scope_id_uses_unique_definition_anchors(tmp_pat
                 ).mappings()
             )
 
-    assert {payload["task"]["session_id"] for payload in payloads} == {row["id"] for row in rows}
+    assert {payload["definition"]["session_id"] for payload in payloads} == {row["id"] for row in rows}
     anchors = {row["session_anchor"] for row in rows}
     assert len(anchors) == 2
     assert all(anchor.startswith("avibe_proj-once-unique:definition_") for anchor in anchors)
@@ -916,8 +917,8 @@ def test_task_add_defaults_target_to_caller_session(tmp_path: Path, capsys) -> N
 
     assert result == 0
     payload = json.loads(capsys.readouterr().out)
-    assert payload["task"]["session_id"] == "sesCaller"
-    assert payload["task"]["session_policy"] == "existing"
+    assert payload["definition"]["session_id"] == "sesCaller"
+    assert payload["definition"]["session_policy"] == "existing"
     assert payload["session_default_notice"] == {
         "code": "session_defaulted_to_caller",
         "message": "Task target Session defaulted to this Agent Session.",
@@ -1005,10 +1006,10 @@ def test_task_list_hides_completed_one_shots_by_default(tmp_path: Path, capsys) 
 
     assert result == 0
     payload = json.loads(capsys.readouterr().out)
-    ids = [item["id"] for item in payload["tasks"]]
+    ids = [item["id"] for item in payload["definitions"]]
     assert done.id not in ids
     assert failed.id in ids
-    assert next(item for item in payload["tasks"] if item["id"] == failed.id)["state"] == "failed"
+    assert next(item for item in payload["definitions"] if item["id"] == failed.id)["state"] == "failed"
 
 
 def test_task_list_brief_returns_scheduling_focused_view(tmp_path: Path, capsys) -> None:
@@ -1028,7 +1029,7 @@ def test_task_list_brief_returns_scheduling_focused_view(tmp_path: Path, capsys)
 
     assert result == 0
     payload = json.loads(capsys.readouterr().out)
-    entry = payload["tasks"][0]
+    entry = payload["definitions"][0]
     assert entry["id"] == task.id
     assert entry["display_name"] == "Hourly summary"
     assert "prompt" not in entry
@@ -1056,8 +1057,8 @@ def test_paused_recurring_task_keeps_failed_run_in_last_status(
         assert cli.cmd_task_list(brief=True) == 0
 
     payload = json.loads(capsys.readouterr().out)
-    assert payload["tasks"][0]["state"] == "paused"
-    assert payload["tasks"][0]["last_status"] == "failed"
+    assert payload["definitions"][0]["state"] == "paused"
+    assert payload["definitions"][0]["last_status"] == "failed"
 
 
 def test_task_list_defaults_to_first_page(tmp_path: Path, capsys) -> None:
@@ -1077,7 +1078,8 @@ def test_task_list_defaults_to_first_page(tmp_path: Path, capsys) -> None:
 
     assert result == 0
     payload = json.loads(capsys.readouterr().out)
-    assert len(payload["tasks"]) == 20
+    assert "tasks" not in payload
+    assert len(payload["definitions"]) == 20
     assert payload["pagination"] == {
         "page": 1,
         "limit": 20,
@@ -1117,8 +1119,8 @@ def test_task_list_keeps_enabled_tasks_ahead_of_paused_history(
         assert cli.cmd_task_list(brief=True) == 0
 
     payload = json.loads(capsys.readouterr().out)
-    assert payload["tasks"][0]["id"] == active.id
-    assert payload["tasks"][0]["state"] == "active"
+    assert payload["definitions"][0]["id"] == active.id
+    assert payload["definitions"][0]["state"] == "active"
     assert payload["pagination"]["has_more"] is True
 
 
@@ -1144,7 +1146,7 @@ def test_task_list_cli_dispatches_pagination_flags(
 
     assert exc.value.code == 0
     payload = json.loads(capsys.readouterr().out)
-    assert len(payload["tasks"]) == 2
+    assert len(payload["definitions"]) == 2
     assert payload["pagination"]["next_command"] == "vibe task list --page 2 --limit 2"
 
 
@@ -1180,7 +1182,7 @@ def test_task_list_order_is_stable_across_cron_boundaries(
     with patch("vibe.cli._task_store", return_value=store):
         assert cli.cmd_task_list(brief=True) == 0
 
-    first_ids = [item["id"] for item in json.loads(capsys.readouterr().out)["tasks"]]
+    first_ids = [item["id"] for item in json.loads(capsys.readouterr().out)["definitions"]]
 
     second_next_runs = {
         later.id: "2026-04-01T02:00:00+00:00",
@@ -1190,7 +1192,7 @@ def test_task_list_order_is_stable_across_cron_boundaries(
     with patch("vibe.cli._task_store", return_value=store):
         assert cli.cmd_task_list(brief=True) == 0
 
-    second_ids = [item["id"] for item in json.loads(capsys.readouterr().out)["tasks"]]
+    second_ids = [item["id"] for item in json.loads(capsys.readouterr().out)["definitions"]]
     assert second_ids == first_ids == [later.id, earlier.id]
 
 
@@ -1211,11 +1213,11 @@ def test_task_show_includes_derived_schedule_fields(tmp_path: Path, capsys) -> N
 
     assert result == 0
     payload = json.loads(capsys.readouterr().out)
-    assert payload["task"]["display_name"] == "Hourly summary"
-    assert payload["task"]["message_preview"] == "recurring summary prompt"
-    assert payload["task"]["next_run_at"] is not None
-    assert payload["task"]["state"] == "active"
-    assert payload["task"]["last_status"] == "never_run"
+    assert payload["definition"]["display_name"] == "Hourly summary"
+    assert payload["definition"]["message_preview"] == "recurring summary prompt"
+    assert payload["definition"]["next_run_at"] is not None
+    assert payload["definition"]["state"] == "active"
+    assert payload["definition"]["last_status"] == "never_run"
 
 
 def test_task_list_include_finished_includes_completed_one_shots(tmp_path: Path, capsys) -> None:
@@ -1235,7 +1237,7 @@ def test_task_list_include_finished_includes_completed_one_shots(tmp_path: Path,
 
     assert result == 0
     payload = json.loads(capsys.readouterr().out)
-    ids = [item["id"] for item in payload["tasks"]]
+    ids = [item["id"] for item in payload["definitions"]]
     assert done.id in ids
     assert payload["pagination"]["has_more"] is False
 
@@ -1261,7 +1263,7 @@ def test_task_list_include_finished_keeps_history_paginated(tmp_path: Path, caps
 
     assert result == 0
     payload = json.loads(capsys.readouterr().out)
-    assert len(payload["tasks"]) == 2
+    assert len(payload["definitions"]) == 2
     assert payload["pagination"]["has_more"] is True
     assert payload["pagination"]["next_command"] == (
         "vibe task list --include-finished --page 2 --limit 2"
@@ -1339,10 +1341,10 @@ def test_task_update_modifies_existing_task_without_changing_id(tmp_path: Path, 
 
     assert result == 0
     payload = json.loads(capsys.readouterr().out)
-    assert payload["task"]["id"] == task.id
-    assert payload["task"]["name"] == "Morning summary"
-    assert payload["task"]["cron"] == "*/30 * * * *"
-    assert payload["task"]["prompt"] == "updated"
+    assert payload["definition"]["id"] == task.id
+    assert payload["definition"]["name"] == "Morning summary"
+    assert payload["definition"]["cron"] == "*/30 * * * *"
+    assert payload["definition"]["prompt"] == "updated"
 
 
 def test_task_update_rejects_scope_without_session_creation(tmp_path: Path) -> None:
@@ -1480,10 +1482,10 @@ def test_task_update_create_session_preserves_existing_cwd_without_cwd_flag(tmp_
 
     assert result == 0
     payload = json.loads(capsys.readouterr().out)
-    assert payload["task"]["cwd"] == str(saved_cwd)
-    assert payload["task"]["metadata"]["session_workdir"] == str(saved_cwd)
+    assert payload["definition"]["cwd"] == str(saved_cwd)
+    assert payload["definition"]["metadata"]["session_workdir"] == str(saved_cwd)
     assert row["workdir"] == str(saved_cwd)
-    assert payload["task"]["session_id"] != "sesOld"
+    assert payload["definition"]["session_id"] != "sesOld"
 
 
 def test_task_update_session_key_clears_previous_session_id(tmp_path: Path, capsys) -> None:
@@ -1508,8 +1510,8 @@ def test_task_update_session_key_clears_previous_session_id(tmp_path: Path, caps
 
     assert result == 0
     payload = json.loads(capsys.readouterr().out)
-    assert payload["task"]["session_id"] is None
-    assert payload["task"]["session_key"] == "slack::channel::C456"
+    assert payload["definition"]["session_id"] is None
+    assert payload["definition"]["session_key"] == "slack::channel::C456"
 
 
 def test_task_update_replaces_post_to_with_deliver_key(tmp_path: Path, capsys) -> None:
@@ -1534,9 +1536,9 @@ def test_task_update_replaces_post_to_with_deliver_key(tmp_path: Path, capsys) -
 
     assert result == 0
     payload = json.loads(capsys.readouterr().out)
-    assert payload["task"]["id"] == task.id
-    assert payload["task"]["post_to"] is None
-    assert payload["task"]["deliver_key"] == "slack::channel::C999"
+    assert payload["definition"]["id"] == task.id
+    assert payload["definition"]["post_to"] is None
+    assert payload["definition"]["deliver_key"] == "slack::channel::C999"
 
 
 def test_task_update_reset_delivery_preserves_creation_scope_metadata(tmp_path: Path, capsys) -> None:
@@ -1570,9 +1572,9 @@ def test_task_update_reset_delivery_preserves_creation_scope_metadata(tmp_path: 
 
     assert result == 0
     payload = json.loads(capsys.readouterr().out)
-    assert payload["task"]["post_to"] is None
-    assert payload["task"]["deliver_key"] is None
-    assert payload["task"]["metadata"]["session_scope_id"] == "avibe::project::proj-reset-task"
+    assert payload["definition"]["post_to"] is None
+    assert payload["definition"]["deliver_key"] is None
+    assert payload["definition"]["metadata"]["session_scope_id"] == "avibe::project::proj-reset-task"
 
 
 def test_task_add_returns_reachability_warning_for_unbound_lark_dm(tmp_path: Path, capsys) -> None:
@@ -3006,7 +3008,7 @@ def test_task_add_create_per_run_ignores_unresolved_legacy_scope_backend(tmp_pat
     assert result == 0
     payload = json.loads(capsys.readouterr().out)
     assert payload["ok"] is True
-    assert payload["task"]["agent_name"] == default_agent.name
+    assert payload["definition"]["agent_name"] == default_agent.name
 
 
 def test_task_add_rejects_deprecated_prompt_argument() -> None:

--- a/tests/test_cli_watch_command.py
+++ b/tests/test_cli_watch_command.py
@@ -254,7 +254,7 @@ def test_watch_add_create_per_run_ignores_unresolved_legacy_scope_backend(tmp_pa
     assert result == 0
     payload = json.loads(capsys.readouterr().out)
     assert payload["ok"] is True
-    assert payload["watch"]["agent_name"] == default_agent.name
+    assert payload["definition"]["agent_name"] == default_agent.name
 
 
 def test_watch_add_creates_shell_watch(tmp_path: Path, capsys) -> None:
@@ -284,11 +284,12 @@ def test_watch_add_creates_shell_watch(tmp_path: Path, capsys) -> None:
     assert result == 0
     payload = json.loads(capsys.readouterr().out)
     assert payload["ok"] is True
-    assert payload["watch"]["name"] == "Wait for export"
-    assert payload["watch"]["shell_command"] == "python3 scripts/wait.py"
-    assert payload["watch"]["command"] == []
-    assert payload["watch"]["mode"] == "once"
-    assert payload["watch"]["retry_exit_codes"] == [75]
+    assert "watch" not in payload
+    assert payload["definition"]["name"] == "Wait for export"
+    assert payload["definition"]["shell_command"] == "python3 scripts/wait.py"
+    assert payload["definition"]["command"] == []
+    assert payload["definition"]["mode"] == "once"
+    assert payload["definition"]["retry_exit_codes"] == [75]
 
 
 def test_watch_add_records_caller_context_metadata(tmp_path: Path, capsys) -> None:
@@ -333,8 +334,8 @@ def test_watch_add_records_caller_context_metadata(tmp_path: Path, capsys) -> No
             "native_session_id": "native-opencode-1",
         },
     }
-    assert payload["watch"]["metadata"]["created_by"] == expected
-    stored = ManagedWatchStore(store_path).get_watch(payload["watch"]["id"])
+    assert payload["definition"]["metadata"]["created_by"] == expected
+    stored = ManagedWatchStore(store_path).get_watch(payload["definition"]["id"])
     assert stored is not None
     assert stored.metadata["created_by"] == expected
 
@@ -397,12 +398,12 @@ def test_watch_add_create_per_run_scope_id_records_session_scope_metadata(tmp_pa
 
     assert result == 0
     payload = json.loads(capsys.readouterr().out)
-    assert payload["watch"]["session_policy"] == "create_per_run"
-    assert payload["watch"]["deliver_key"] is None
-    assert payload["watch"]["cwd"] == str(invoke_dir)
-    assert payload["watch"]["metadata"]["session_scope_id"] == "avibe::project::proj-scope-watch"
-    assert "session_workdir" not in payload["watch"]["metadata"]
-    assert payload["watch"]["agent_name"] == "project-agent"
+    assert payload["definition"]["session_policy"] == "create_per_run"
+    assert payload["definition"]["deliver_key"] is None
+    assert payload["definition"]["cwd"] == str(invoke_dir)
+    assert payload["definition"]["metadata"]["session_scope_id"] == "avibe::project::proj-scope-watch"
+    assert "session_workdir" not in payload["definition"]["metadata"]
+    assert payload["definition"]["agent_name"] == "project-agent"
 
 
 def test_watch_add_create_per_run_without_scope_records_standalone_definition(tmp_path: Path, capsys) -> None:
@@ -434,7 +435,7 @@ def test_watch_add_create_per_run_without_scope_records_standalone_definition(tm
         result = cli.cmd_watch_add(args)
 
     assert result == 0
-    watch = json.loads(capsys.readouterr().out)["watch"]
+    watch = json.loads(capsys.readouterr().out)["definition"]
     assert watch["session_policy"] == "create_per_run"
     assert watch["session_id"] is None
     assert watch["deliver_key"] is None
@@ -500,12 +501,12 @@ def test_watch_add_create_session_scope_id_snapshots_scope_workdir(tmp_path: Pat
 
     assert result == 0
     payload = json.loads(capsys.readouterr().out)
-    target = cli.resolve_session_id_target(payload["watch"]["session_id"], db_path=db_path)
+    target = cli.resolve_session_id_target(payload["definition"]["session_id"], db_path=db_path)
     assert target.visibility == "foreground"
     assert target.suppress_delivery is False
     assert target.workdir == str(tmp_path)
-    assert payload["watch"]["cwd"] == str(invoke_dir)
-    assert "session_workdir" not in payload["watch"]["metadata"]
+    assert payload["definition"]["cwd"] == str(invoke_dir)
+    assert "session_workdir" not in payload["definition"]["metadata"]
 
 
 def test_watch_add_defaults_target_to_caller_session(tmp_path: Path, capsys) -> None:
@@ -553,8 +554,8 @@ def test_watch_add_defaults_target_to_caller_session(tmp_path: Path, capsys) -> 
 
     assert result == 0
     payload = json.loads(capsys.readouterr().out)
-    assert payload["watch"]["session_id"] == "sesCaller"
-    assert payload["watch"]["session_policy"] == "existing"
+    assert payload["definition"]["session_id"] == "sesCaller"
+    assert payload["definition"]["session_policy"] == "existing"
     assert payload["session_default_notice"] == {
         "code": "session_defaulted_to_caller",
         "message": "Watch target Session defaulted to this Agent Session.",
@@ -586,8 +587,8 @@ def test_watch_add_accepts_message_template(tmp_path: Path, capsys) -> None:
 
     assert result == 0
     payload = json.loads(capsys.readouterr().out)
-    assert payload["watch"]["message"] == "Summarize the waiter output."
-    assert payload["watch"]["prefix"] is None
+    assert payload["definition"]["message"] == "Summarize the waiter output."
+    assert payload["definition"]["prefix"] is None
 
 
 def test_watch_add_creates_exec_watch_with_retry_codes(tmp_path: Path, capsys) -> None:
@@ -624,9 +625,9 @@ def test_watch_add_creates_exec_watch_with_retry_codes(tmp_path: Path, capsys) -
 
     assert result == 0
     payload = json.loads(capsys.readouterr().out)
-    assert payload["watch"]["mode"] == "forever"
-    assert payload["watch"]["command"] == ["python3", "scripts/wait.py", "--build", "42"]
-    assert payload["watch"]["retry_exit_codes"] == [1, 75]
+    assert payload["definition"]["mode"] == "forever"
+    assert payload["definition"]["command"] == ["python3", "scripts/wait.py", "--build", "42"]
+    assert payload["definition"]["retry_exit_codes"] == [1, 75]
 
 
 def test_watch_add_persists_absolute_cwd(tmp_path: Path, capsys, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -657,7 +658,7 @@ def test_watch_add_persists_absolute_cwd(tmp_path: Path, capsys, monkeypatch: py
 
     assert result == 0
     payload = json.loads(capsys.readouterr().out)
-    assert payload["watch"]["cwd"] == str(workdir.resolve())
+    assert payload["definition"]["cwd"] == str(workdir.resolve())
 
 
 def test_watch_add_returns_structured_error_when_startup_fails(tmp_path: Path) -> None:
@@ -875,8 +876,8 @@ def test_watch_list_brief_includes_runtime_state(tmp_path: Path, capsys) -> None
 
     assert result == 0
     payload = json.loads(capsys.readouterr().out)
-    assert payload["watches"][0]["state"] == "running"
-    assert payload["watches"][0]["mode"] == "forever"
+    assert payload["definitions"][0]["state"] == "running"
+    assert payload["definitions"][0]["mode"] == "forever"
 
 
 def test_watch_list_hides_finished_one_shots_by_default(tmp_path: Path, capsys) -> None:
@@ -900,10 +901,10 @@ def test_watch_list_hides_finished_one_shots_by_default(tmp_path: Path, capsys) 
 
     assert result == 0
     payload = json.loads(capsys.readouterr().out)
-    ids = {item["id"] for item in payload["watches"]}
+    ids = {item["id"] for item in payload["definitions"]}
     assert ids == {active.id, failed.id, paused.id, failed_forever.id}
     assert completed.id not in ids
-    assert next(item for item in payload["watches"] if item["id"] == failed.id)["state"] == "failed"
+    assert next(item for item in payload["definitions"] if item["id"] == failed.id)["state"] == "failed"
 
 
 def test_resumed_then_paused_one_shot_remains_in_default_list(tmp_path: Path, capsys) -> None:
@@ -922,8 +923,8 @@ def test_resumed_then_paused_one_shot_remains_in_default_list(tmp_path: Path, ca
         assert cli.cmd_watch_list() == 0
 
     payload = json.loads(capsys.readouterr().out)
-    assert [item["id"] for item in payload["watches"]] == [watch.id]
-    assert payload["watches"][0]["state"] == "paused"
+    assert [item["id"] for item in payload["definitions"]] == [watch.id]
+    assert payload["definitions"][0]["state"] == "paused"
 
 
 def test_paused_forever_watch_changed_to_once_starts_new_lifecycle(
@@ -961,8 +962,8 @@ def test_paused_forever_watch_changed_to_once_starts_new_lifecycle(
         assert cli.cmd_watch_list() == 0
 
     payload = json.loads(capsys.readouterr().out)
-    assert [item["id"] for item in payload["watches"]] == [watch.id]
-    assert payload["watches"][0]["state"] == "paused"
+    assert [item["id"] for item in payload["definitions"]] == [watch.id]
+    assert payload["definitions"][0]["state"] == "paused"
 
 
 def test_watch_list_defaults_to_first_page(tmp_path: Path, capsys) -> None:
@@ -979,7 +980,8 @@ def test_watch_list_defaults_to_first_page(tmp_path: Path, capsys) -> None:
 
     assert result == 0
     payload = json.loads(capsys.readouterr().out)
-    assert len(payload["watches"]) == 20
+    assert "watches" not in payload
+    assert len(payload["definitions"]) == 20
     assert payload["pagination"] == {
         "page": 1,
         "limit": 20,
@@ -1010,7 +1012,7 @@ def test_watch_list_cli_dispatches_pagination_flags(
 
     assert exc.value.code == 0
     payload = json.loads(capsys.readouterr().out)
-    assert len(payload["watches"]) == 2
+    assert len(payload["definitions"]) == 2
     assert payload["pagination"]["next_command"] == "vibe watch list --page 2 --limit 2"
 
 
@@ -1033,7 +1035,7 @@ def test_watch_list_include_finished_keeps_history_paginated(tmp_path: Path, cap
 
     assert result == 0
     payload = json.loads(capsys.readouterr().out)
-    assert len(payload["watches"]) == 2
+    assert len(payload["definitions"]) == 2
     assert payload["pagination"]["has_more"] is True
     assert payload["pagination"]["next_command"] == (
         "vibe watch list --include-finished --page 2 --limit 2"
@@ -1072,11 +1074,11 @@ def test_watch_pause_resume_and_remove_update_store(tmp_path: Path, capsys) -> N
     ):
         assert cli.cmd_watch_set_enabled(watch.id, False) == 0
         paused = json.loads(capsys.readouterr().out)
-        assert paused["watch"]["enabled"] is False
+        assert paused["definition"]["enabled"] is False
 
         assert cli.cmd_watch_set_enabled(watch.id, True) == 0
         resumed = json.loads(capsys.readouterr().out)
-        assert resumed["watch"]["enabled"] is True
+        assert resumed["definition"]["enabled"] is True
 
         assert cli.cmd_watch_remove(watch.id) == 0
         removed = json.loads(capsys.readouterr().out)
@@ -1137,17 +1139,17 @@ def test_watch_update_renames_and_retargets_watch(tmp_path: Path, capsys) -> Non
 
     assert result == 0
     payload = json.loads(capsys.readouterr().out)
-    assert payload["watch"]["id"] == watch.id
-    assert payload["watch"]["name"] == "Watch deploy"
-    assert payload["watch"]["session_key"] == "slack::channel::C456"
-    assert payload["watch"]["post_to"] == "channel"
-    assert payload["watch"]["prefix"] == "Deploy finished."
-    assert payload["watch"]["mode"] == "forever"
-    assert payload["watch"]["timeout_seconds"] == 1200
-    assert payload["watch"]["lifetime_timeout_seconds"] == 7200
-    assert payload["watch"]["retry_exit_codes"] == [1, 75]
-    assert payload["watch"]["retry_delay_seconds"] == 10
-    assert payload["watch"]["shell_command"] == "python3 wait_deploy.py"
+    assert payload["definition"]["id"] == watch.id
+    assert payload["definition"]["name"] == "Watch deploy"
+    assert payload["definition"]["session_key"] == "slack::channel::C456"
+    assert payload["definition"]["post_to"] == "channel"
+    assert payload["definition"]["prefix"] == "Deploy finished."
+    assert payload["definition"]["mode"] == "forever"
+    assert payload["definition"]["timeout_seconds"] == 1200
+    assert payload["definition"]["lifetime_timeout_seconds"] == 7200
+    assert payload["definition"]["retry_exit_codes"] == [1, 75]
+    assert payload["definition"]["retry_delay_seconds"] == 10
+    assert payload["definition"]["shell_command"] == "python3 wait_deploy.py"
 
 
 def test_watch_update_session_key_clears_previous_session_id(tmp_path: Path, capsys) -> None:
@@ -1180,8 +1182,8 @@ def test_watch_update_session_key_clears_previous_session_id(tmp_path: Path, cap
 
     assert result == 0
     payload = json.loads(capsys.readouterr().out)
-    assert payload["watch"]["session_id"] is None
-    assert payload["watch"]["session_key"] == "slack::channel::C456"
+    assert payload["definition"]["session_id"] is None
+    assert payload["definition"]["session_key"] == "slack::channel::C456"
 
 
 def test_watch_update_reset_delivery_preserves_creation_scope_metadata(tmp_path: Path, capsys) -> None:
@@ -1222,10 +1224,10 @@ def test_watch_update_reset_delivery_preserves_creation_scope_metadata(tmp_path:
 
     assert result == 0
     payload = json.loads(capsys.readouterr().out)
-    assert payload["watch"]["post_to"] is None
-    assert payload["watch"]["deliver_key"] is None
-    assert payload["watch"]["metadata"]["session_scope_id"] == "avibe::project::proj-reset-watch"
-    assert payload["watch"]["metadata"]["session_workdir"] == str(tmp_path)
+    assert payload["definition"]["post_to"] is None
+    assert payload["definition"]["deliver_key"] is None
+    assert payload["definition"]["metadata"]["session_scope_id"] == "avibe::project::proj-reset-watch"
+    assert payload["definition"]["metadata"]["session_workdir"] == str(tmp_path)
 
 
 def test_watch_update_replaces_argv_command(tmp_path: Path, capsys) -> None:
@@ -1257,8 +1259,8 @@ def test_watch_update_replaces_argv_command(tmp_path: Path, capsys) -> None:
 
     assert result == 0
     payload = json.loads(capsys.readouterr().out)
-    assert payload["watch"]["command"] == ["python3", "wait_deploy.py", "--flag", "value"]
-    assert payload["watch"]["shell_command"] is None
+    assert payload["definition"]["command"] == ["python3", "wait_deploy.py", "--flag", "value"]
+    assert payload["definition"]["shell_command"] is None
 
 
 def test_watch_update_no_changes_returns_structured_error(tmp_path: Path) -> None:
@@ -1401,9 +1403,9 @@ def test_watch_update_allows_cwd_for_already_reserved_create_once_watch(tmp_path
 
     assert result == 0
     payload = json.loads(capsys.readouterr().out)
-    assert payload["watch"]["session_id"] == "sesExisting"
-    assert payload["watch"]["cwd"] == str(new_cwd)
-    assert "session_workdir" not in payload["watch"]["metadata"]
+    assert payload["definition"]["session_id"] == "sesExisting"
+    assert payload["definition"]["cwd"] == str(new_cwd)
+    assert "session_workdir" not in payload["definition"]["metadata"]
 
 
 def test_watch_update_rejects_deprecated_prompt_argument(tmp_path: Path) -> None:

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -288,19 +288,21 @@ def _paginated_fields(page_result, *, command: list[str], include_next_command: 
 def _print_definition_list_payload(
     items,
     *,
-    items_key: str,
     payload_for_item,
     command: list[str],
     page_request: PageRequest,
 ) -> None:
     result = page_sequence(items, page_request)
     item_payloads = [payload_for_item(item) for item in result.items]
-    payload = {
-        "definitions": item_payloads,
-        items_key: item_payloads,
+    _print_cli_payload(
+        "run_definitions",
+        definitions=item_payloads,
         **_paginated_fields(result, command=command),
-    }
-    _print_cli_payload("run_definitions", **payload)
+    )
+
+
+def _print_definition_payload(definition, **fields) -> None:
+    _print_cli_payload("run_definition", definition=definition, **fields)
 
 
 def _parse_cli_time_filter(value: str | None, *, field_name: str, help_command: str) -> str | None:
@@ -2665,16 +2667,11 @@ def cmd_task_add(args):
         warnings = _collect_target_warnings(session_target, delivery_target)
         task_payload = _task_payload(task)
         payload_fields = {
-            "definition": task_payload,
-            "task": task_payload,
             "warnings": warnings,
         }
         if session_default_notice:
             payload_fields["session_default_notice"] = session_default_notice
-        _print_cli_payload(
-            "run_definition",
-            **payload_fields,
-        )
+        _print_definition_payload(task_payload, **payload_fields)
         return 0
     except Exception as exc:
         _print_task_error(exc, help_command="vibe task add --help")
@@ -2697,7 +2694,6 @@ def cmd_task_list(
         command.append("--include-finished")
     _print_definition_list_payload(
         tasks,
-        items_key="tasks",
         payload_for_item=lambda task: _task_payload(task, brief=True),
         command=command,
         page_request=page_request,
@@ -2720,7 +2716,7 @@ def cmd_task_show(task_id: str):
         )
         return 1
     task_payload = _task_payload(task)
-    _print_cli_payload("run_definition", definition=task_payload, task=task_payload)
+    _print_definition_payload(task_payload)
     return 0
 
 
@@ -2741,7 +2737,7 @@ def cmd_task_set_enabled(task_id: str, enabled: bool):
         return 1
     updated = store.set_enabled(task_id, enabled)
     task_payload = _task_payload(updated)
-    _print_cli_payload("run_definition", definition=task_payload, task=task_payload)
+    _print_definition_payload(task_payload)
     return 0
 
 
@@ -3080,12 +3076,7 @@ def cmd_task_update(args):
         )
         warnings = _collect_target_warnings(session_target, delivery_target)
         task_payload = _task_payload(updated)
-        _print_cli_payload(
-            "run_definition",
-            definition=task_payload,
-            task=task_payload,
-            warnings=warnings,
-        )
+        _print_definition_payload(task_payload, warnings=warnings)
         return 0
     except Exception as exc:
         _print_task_error(exc, help_command="vibe task update --help")
@@ -7832,16 +7823,11 @@ def cmd_watch_add(args):
         warnings = _collect_target_warnings(session_target, delivery_target)
         watch_payload = _watch_payload(watch, runtime_entry)
         payload_fields = {
-            "definition": watch_payload,
-            "watch": watch_payload,
             "warnings": warnings,
         }
         if session_default_notice:
             payload_fields["session_default_notice"] = session_default_notice
-        _print_cli_payload(
-            "run_definition",
-            **payload_fields,
-        )
+        _print_definition_payload(watch_payload, **payload_fields)
         return 0
     except Exception as exc:
         _print_task_error(exc, help_command="vibe watch add --help")
@@ -7865,7 +7851,6 @@ def cmd_watch_list(
         command.append("--include-finished")
     _print_definition_list_payload(
         watches,
-        items_key="watches",
         payload_for_item=lambda watch: _watch_payload(watch, runtime_state.get(watch.id), brief=True),
         command=command,
         page_request=page_request,
@@ -7889,7 +7874,7 @@ def cmd_watch_show(watch_id: str):
         return 1
     runtime_entry = _watch_runtime_store().load().get("watches", {}).get(watch.id)
     watch_payload = _watch_payload(watch, runtime_entry)
-    _print_cli_payload("run_definition", definition=watch_payload, watch=watch_payload)
+    _print_definition_payload(watch_payload)
     return 0
 
 
@@ -7911,7 +7896,7 @@ def cmd_watch_set_enabled(watch_id: str, enabled: bool):
     updated = store.set_enabled(watch_id, enabled)
     runtime_entry = _watch_runtime_store().load().get("watches", {}).get(updated.id)
     watch_payload = _watch_payload(updated, runtime_entry)
-    _print_cli_payload("run_definition", definition=watch_payload, watch=watch_payload)
+    _print_definition_payload(watch_payload)
     return 0
 
 
@@ -8197,12 +8182,7 @@ def cmd_watch_update(args):
         runtime_entry = _watch_runtime_store().load().get("watches", {}).get(updated.id)
         warnings = _collect_target_warnings(session_target, delivery_target)
         watch_payload = _watch_payload(updated, runtime_entry)
-        _print_cli_payload(
-            "run_definition",
-            definition=watch_payload,
-            watch=watch_payload,
-            warnings=warnings,
-        )
+        _print_definition_payload(watch_payload, warnings=warnings)
         return 0
     except Exception as exc:
         _print_task_error(exc, help_command="vibe watch update --help")


### PR DESCRIPTION
## Summary

- capability: canonical task/watch CLI JSON payloads
- user-visible change: `run_definition` responses now emit only `definition`, and `run_definitions` responses emit only `definitions`; duplicate `task`, `tasks`, `watch`, and `watches` aliases are removed
- motivation: the aliases repeated the full records and consumed roughly half of task/watch list output, defeating the bounded-output work from #1013

This is an intentional pre-release contract cleanup. There is no compatibility flag because retaining the aliases would preserve the context-cost bug. Agent guidance and both CLI references now name the canonical fields.

## Scenario Coverage

- scenario IDs: none; this CLI JSON contract is not represented in the scenario catalog
- unit / contract coverage: task/watch add, list, show, update, pause, and resume tests now consume `definition(s)`; representative contract assertions reject the old aliases
- scenario coverage: all single-record task/watch paths share one payload helper, and both list paths share the existing paginated helper
- residual manual checks: smoke-test the installed CLI against live task/watch history in the next pre-release build

## Validation

- commands run: focused task/watch/pagination tests; broader CLI, session, scheduled-task, and watch tests; Ruff; diff checks
- result: 565 tests passed; Ruff and `git diff --check` passed

## Risks / Follow-ups

- risk: pre-release clients reading the command-specific aliases must switch to `definition` or `definitions`
- follow-up: none
