### PR TITLE
feat(chat): Show Page annotation card, visibility by message type alone

### DIFF
--- a/ui/src/components/workbench/AnnotationMessage.test.tsx
+++ b/ui/src/components/workbench/AnnotationMessage.test.tsx
@@ -1,0 +1,268 @@
+import { createInstance } from 'i18next';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { I18nextProvider, initReactI18next } from 'react-i18next';
+import { describe, expect, it } from 'vitest';
+
+import en from '../../i18n/en.json';
+import zh from '../../i18n/zh.json';
+import { isProxyMediaUrl } from '../../lib/mediaProxy';
+import { isTranscriptMessage } from '../../lib/chatMessageTypes';
+import { AnnotationMessage, annotationTitleKey, claimAnnotation, readAnnotationView } from './AnnotationMessage';
+
+// The four rows of the frozen contract, verbatim:
+//   docs/plans/show-annotation-message-type/examples.json
+// They are copied rather than imported because the contract lives on Lane BE's
+// branch — copying them here is what makes this a CONTRACT test: if Lane BE's
+// serializer stops producing these shapes, its own assertions go red against
+// the same file and the two halves are still pinned to one artifact.
+//
+// ``metadata`` is carried in full on purpose. Nothing in the card may read it,
+// and the machine-text assertion below can only be honest if the machine text
+// is actually present in the fixture.
+const FORWARD_COMMENT = {
+  id: 'msg_01J8XK2Q4W',
+  type: 'annotation',
+  author: 'harness',
+  source: 'harness',
+  author_name: 'show_annotation',
+  text: '这里的标题太小了，正文和它几乎一样重',
+  content: {
+    text: '这里的标题太小了，正文和它几乎一样重',
+    annotation: { direction: 'user', action: 'created', quote: 'Model Hub' },
+  },
+  metadata: {
+    source: 'show_page',
+    show_event_id: 'evt_7f3a91c2',
+    show_event_type: 'human.annotation.created',
+    anchor_kind: 'element',
+    anchor_selector: 'main > section:nth-of-type(2) > h2',
+    _queued_dispatch_text:
+      "[show-annotation] comment\n\n这里的标题太小了，正文和它几乎一样重\n\nAnchor kind: element\n\nQuote: Model Hub\nAnchor: main > section:nth-of-type(2) > h2\n\nShow event id: evt_7f3a91c2\n\n如需在页面上原位回应，可执行：\n  vibe show reply evt_7f3a91c2 --message '<你的回答>'\n（也可以直接修改页面内容来响应，按场景选择。）",
+  },
+  created_at: '2026-07-27T10:14:02.417Z',
+};
+
+const FORWARD_QUEUED = {
+  id: 'msg_01J8XK5M8T',
+  type: 'queued',
+  author: 'harness',
+  source: 'harness',
+  author_name: 'show_annotation',
+  text: '这两个卡片的间距不一致',
+  content: {
+    text: '这两个卡片的间距不一致',
+    annotation: { direction: 'user', action: 'created' },
+    attachments: [
+      {
+        url: '/api/media/med_9a71c33f8b2e',
+        name: 'annotation-region.png',
+        mime: 'image/png',
+        kind: 'image',
+        width: 1240,
+        height: 620,
+      },
+    ],
+  },
+  metadata: {
+    source: 'show_page',
+    show_event_id: 'evt_b0c4d5e6',
+    anchor_kind: 'region',
+    screenshot_region: 'x=120 y=340 w=1240 h=620',
+    _queued_dispatch_text:
+      "[show-annotation] comment\n\n这两个卡片的间距不一致\n\nAnchor kind: region\nScreenshot: /Users/…/state/media/med_9a71c33f8b2e.png (1240x620)\n\nShow event id: evt_b0c4d5e6\n\n  vibe show reply evt_b0c4d5e6 --message '<你的回答>'",
+  },
+  created_at: '2026-07-27T10:15:48.006Z',
+};
+
+const REVERSE_MARK = {
+  id: 'msg_01J8XKB1Q9',
+  type: 'annotation',
+  author: 'agent',
+  source: null,
+  author_name: null,
+  text: '标题已经改成 20px/600，正文降到 14px，层级现在拉开了。',
+  content: {
+    text: '标题已经改成 20px/600，正文降到 14px，层级现在拉开了。',
+    annotation: { direction: 'agent', action: 'created', quote: 'Model Hub' },
+  },
+  metadata: { source: 'show_page', show_event_id: 'evt_c8d9e0f1' },
+  created_at: '2026-07-27T10:19:31.882Z',
+};
+
+const REVERSE_RESOLVED = {
+  id: 'msg_01J8XKF7R3',
+  type: 'annotation',
+  author: 'agent',
+  source: null,
+  author_name: null,
+  text: '间距统一到 16px 了。',
+  content: {
+    text: '间距统一到 16px 了。',
+    annotation: { direction: 'agent', action: 'resolved' },
+  },
+  metadata: { source: 'show_page', show_event_id: 'evt_d2e3f4a5' },
+  created_at: '2026-07-27T10:21:07.140Z',
+};
+
+const makeI18n = (lng: 'en' | 'zh') => {
+  const i18n = createInstance();
+  void i18n.use(initReactI18next).init({
+    lng,
+    fallbackLng: 'en',
+    resources: { en: { translation: en }, zh: { translation: zh } },
+    interpolation: { escapeValue: false },
+  });
+  return i18n;
+};
+
+// Mirrors how ChatPage feeds the card: the transcript builds the body,
+// attachment and timestamp nodes and the card only arranges them. The stand-ins
+// are marked so a presence assertion can tell them apart from card chrome.
+//
+// ``metadata`` is deliberately NOT a prop of the card, which is what makes the
+// no-machine-text property structural rather than incidental — there is no
+// parameter through which a dispatch string could reach the view.
+type Row = { id: string; type: string; text: string; content: unknown; created_at: string };
+
+const render = (row: Row, lng: 'en' | 'zh' = 'zh') => {
+  const view = claimAnnotation(row);
+  if (!view) throw new Error(`row ${row.id} was not claimed as an annotation`);
+  const attachments = (row.content as { attachments?: unknown[] }).attachments ?? [];
+  return renderToStaticMarkup(
+    <I18nextProvider i18n={makeI18n(lng)}>
+      <AnnotationMessage
+        messageId={row.id}
+        view={view}
+        body={<div data-part="body">{row.text}</div>}
+        attachments={attachments.length > 0 ? <div data-part="attachments" /> : null}
+        time={<span data-part="time">{row.created_at}</span>}
+        rowClass={(extra) => `flex w-full ${extra}`}
+      />
+    </I18nextProvider>,
+  );
+};
+
+describe('annotation card / frozen contract rows', () => {
+  it('titles and sides a forward user annotation by direction, not by author', () => {
+    // The single easiest thing to get wrong. This row is authored by ``harness``
+    // with author_name ``show_annotation``: read the author and it lands on the
+    // left behind a harness chip, which is the bug. Cross-assert the fixture's
+    // own author so the side assertion below cannot pass vacuously.
+    expect(FORWARD_COMMENT.author).toBe('harness');
+    expect(FORWARD_COMMENT.source).toBe('harness');
+
+    const html = render(FORWARD_COMMENT);
+    expect(html).toContain('用户批注');
+    expect(html).not.toContain('Agent 批注');
+    expect(html).toContain('justify-end');
+    expect(html).not.toContain('justify-start');
+  });
+
+  it('titles and sides a reverse agent mark by the same rule', () => {
+    const html = render(REVERSE_MARK);
+    expect(html).toContain('Agent 批注');
+    expect(html).not.toContain('用户批注');
+    expect(html).toContain('justify-start');
+    expect(html).not.toContain('justify-end');
+  });
+
+  it('draws the anchor quote only when the anchor carries copy', () => {
+    // Present on the comment row...
+    expect(render(FORWARD_COMMENT)).toContain('Model Hub');
+    // ...and absent on the region row, which has no quote. Nothing stands in for
+    // it: not the selector, not the anchor kind, not the event id, not the
+    // screenshot path (rule 05).
+    const queuedAsFlushed = { ...FORWARD_QUEUED, type: 'annotation' };
+    const html = render(queuedAsFlushed);
+    expect(readAnnotationView(queuedAsFlushed.content)?.quote).toBeUndefined();
+    expect(html).not.toContain('border-l-2');
+    expect(html).not.toContain('region');
+    expect(html).not.toContain('evt_b0c4d5e6');
+  });
+
+  it('marks only a resolved action, and never in the title', () => {
+    const created = render(REVERSE_MARK);
+    expect(created).not.toContain('已处理');
+
+    const resolved = render(REVERSE_RESOLVED);
+    expect(resolved).toContain('已处理');
+    // Rule 02/07: the action decorates the card, it does not rename it.
+    expect(resolved).toContain('Agent 批注');
+  });
+
+  it('routes the screenshot through the transcript attachment renderer', () => {
+    // Rule 06: the card renders the node the transcript already builds — there
+    // is no second image element in it.
+    const html = render({ ...FORWARD_QUEUED, type: 'annotation' });
+    expect(html).toContain('data-part="attachments"');
+    expect(html).not.toContain('<img');
+    // ...and the frozen url is one the existing renderer inlines rather than
+    // degrading to a click-through card.
+    const url = FORWARD_QUEUED.content.attachments[0].url;
+    expect(isProxyMediaUrl(url)).toBe(true);
+  });
+
+  it('keeps the agent-facing dispatch text out of the view entirely', () => {
+    // The machine text is real: it is in the fixture, on the row, right now.
+    const dispatch = FORWARD_COMMENT.metadata._queued_dispatch_text;
+    expect(dispatch).toContain('vibe show reply');
+    expect(dispatch).toContain('main > section:nth-of-type(2) > h2');
+    expect(dispatch).toContain('evt_7f3a91c2');
+
+    // None of it reaches the reader. The card is given the human text and
+    // nothing else — there is no ``metadata`` prop to leak through.
+    const html = render(FORWARD_COMMENT);
+    for (const machine of [
+      'vibe show reply',
+      '[show-annotation]',
+      'Anchor kind',
+      'main > section:nth-of-type(2) > h2',
+      'evt_7f3a91c2',
+      'show_annotation',
+      '/state/media/',
+    ]) {
+      expect(html).not.toContain(machine);
+    }
+    // The human text, meanwhile, is there.
+    expect(html).toContain('这里的标题太小了');
+  });
+
+  it('renders the same card in English', () => {
+    expect(render(FORWARD_COMMENT, 'en')).toContain('User annotation');
+    expect(render(REVERSE_MARK, 'en')).toContain('Agent annotation');
+    expect(render(REVERSE_RESOLVED, 'en')).toContain('Resolved');
+  });
+});
+
+describe('annotation claim (type decides, direction places)', () => {
+  it('claims the two annotation rows and refuses the queued one', () => {
+    expect(claimAnnotation(FORWARD_COMMENT)?.direction).toBe('user');
+    expect(claimAnnotation(REVERSE_MARK)?.direction).toBe('agent');
+    expect(claimAnnotation(REVERSE_RESOLVED)?.resolved).toBe(true);
+
+    // Same row, same ``show_page`` origin, same display record — only the type
+    // differs, and the type is the whole decision. It is not a card yet, and
+    // (asserted at its source) not in the transcript yet either.
+    expect(claimAnnotation(FORWARD_QUEUED)).toBeNull();
+    expect(isTranscriptMessage(FORWARD_QUEUED)).toBe(false);
+    expect(claimAnnotation({ ...FORWARD_QUEUED, type: 'annotation' })).not.toBeNull();
+    expect(isTranscriptMessage({ ...FORWARD_QUEUED, type: 'annotation' })).toBe(true);
+  });
+
+  it('degrades a row with no usable display record to an ordinary bubble', () => {
+    // A contract violation must not produce a card that cannot say whose
+    // annotation it is; it narrows to a plain row instead.
+    expect(claimAnnotation({ type: 'annotation', content: {} })).toBeNull();
+    expect(claimAnnotation({ type: 'annotation', content: { annotation: { direction: 'system' } } })).toBeNull();
+    expect(claimAnnotation({ type: 'annotation', content: null })).toBeNull();
+  });
+
+  it('maps each direction to its own title key, and only those two', () => {
+    expect(annotationTitleKey('user')).toBe('chat.annotation.titleUser');
+    expect(annotationTitleKey('agent')).toBe('chat.annotation.titleAgent');
+    expect(en.chat.annotation.titleUser).toBe('User annotation');
+    expect(zh.chat.annotation.titleUser).toBe('用户批注');
+    expect(zh.chat.annotation.titleAgent).toBe('Agent 批注');
+    expect(zh.chat.annotation.resolved).toBe('已处理');
+  });
+});

--- a/ui/src/components/workbench/AnnotationMessage.test.tsx
+++ b/ui/src/components/workbench/AnnotationMessage.test.tsx
@@ -66,10 +66,10 @@ const FORWARD_QUEUED = {
   metadata: {
     source: 'show_page',
     show_event_id: 'evt_b0c4d5e6',
-    anchor_kind: 'region',
-    screenshot_region: 'x=120 y=340 w=1240 h=620',
+    anchor_kind: 'screenshot',
+    screenshot_region: 'x:120, y:340, 1240x620',
     _queued_dispatch_text:
-      "[show-annotation] comment\n\n这两个卡片的间距不一致\n\nAnchor kind: region\nScreenshot: /Users/…/state/media/med_9a71c33f8b2e.png (1240x620)\n\nShow event id: evt_b0c4d5e6\n\n  vibe show reply evt_b0c4d5e6 --message '<你的回答>'",
+      "[show-annotation] comment\n\n这两个卡片的间距不一致\n\nAnchor kind: screenshot\nScreenshot: state/media/med_9a71c33f8b2e.png (1240x620)\nScreenshot region: x:120, y:340, 1240x620\n\nShow event id: evt_b0c4d5e6\n\n如需在页面上原位回应，可执行：\n  vibe show reply evt_b0c4d5e6 --message '<你的回答>'\n（也可以直接修改页面内容来响应，按场景选择。）",
   },
   created_at: '2026-07-27T10:15:48.006Z',
 };
@@ -176,7 +176,8 @@ describe('annotation card / frozen contract rows', () => {
     const html = render(queuedAsFlushed);
     expect(readAnnotationView(queuedAsFlushed.content)?.quote).toBeUndefined();
     expect(html).not.toContain('border-l-2');
-    expect(html).not.toContain('region');
+    expect(html).not.toContain('screenshot');
+    expect(html).not.toContain('state/media/');
     expect(html).not.toContain('evt_b0c4d5e6');
   });
 

--- a/ui/src/components/workbench/AnnotationMessage.tsx
+++ b/ui/src/components/workbench/AnnotationMessage.tsx
@@ -1,0 +1,176 @@
+import { Check, MapPin, MessageSquareQuote } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import clsx from 'clsx';
+
+import { RoleAvatar } from './RoleAvatar';
+
+// A Show Page annotation, in chat. Both directions are the same message type —
+// the user annotating the page, and the agent marking it back — and the card's
+// title is what says which. Design: design.pen m31JWV (states) + TxFKk (anatomy
+// and rules); the rule numbers cited below are that frame's.
+//
+// The card is a row component, not a page fragment: it takes the body,
+// attachment and timestamp nodes the transcript already builds and only adds
+// what is specific to an annotation (title, anchor quote, resolved marker), so
+// it cannot drift from the surrounding bubbles.
+
+// What the card actually draws, distilled from ``content.annotation``.
+//
+// ``action`` collapses to a boolean deliberately. Rule 07: only ``resolved``
+// draws a marker; created / updated / dismissed draw nothing beyond the body.
+// Not carrying the other three past the parse means no later edit can quietly
+// start branching on them without going back to the design first.
+export type AnnotationView = {
+  direction: 'user' | 'agent';
+  resolved: boolean;
+  quote?: string;
+};
+
+// Reads ``content.annotation`` off a chat row; null when the row carries no
+// usable display record.
+//
+// ``direction`` is the only thing that decides the side and the title — rule 01.
+// A forward annotation is authored by ``harness`` (it is turn input), so reading
+// ``author`` here would put the user's own annotation on the left behind a
+// harness chip. ``author`` is bookkeeping and never reaches the view.
+export function readAnnotationView(content: unknown): AnnotationView | null {
+  const raw = (content as { annotation?: unknown } | null | undefined)?.annotation;
+  if (!raw || typeof raw !== 'object') return null;
+  const { direction, action, quote } = raw as Record<string, unknown>;
+  if (direction !== 'user' && direction !== 'agent') return null;
+  return {
+    direction,
+    resolved: action === 'resolved',
+    // Rule 04: the strip needs copy the reader can find on the page. An empty
+    // string is the same as no quote.
+    quote: typeof quote === 'string' && quote.trim().length > 0 ? quote : undefined,
+  };
+}
+
+export const annotationTitleKey = (direction: AnnotationView['direction']): string =>
+  direction === 'user' ? 'chat.annotation.titleUser' : 'chat.annotation.titleAgent';
+
+// Whether a transcript row is drawn as the annotation card — the transcript's
+// claim check, in one place so the row branch and its test exercise the same
+// code.
+//
+// ``type`` decides, and nothing else: not ``author`` (a forward annotation is
+// authored by ``harness``), not ``source``, not ``metadata.source`` (a forward
+// annotation carries ``show_page`` in every state, including while queued). The
+// display record only narrows the claim further, so a row that somehow arrives
+// without a readable ``direction`` degrades to an ordinary bubble instead of a
+// card that cannot say whose annotation it is.
+export function claimAnnotation(message: { type: string; content?: unknown }): AnnotationView | null {
+  return message.type === 'annotation' ? readAnnotationView(message.content) : null;
+}
+
+type AnnotationMessageProps = {
+  messageId: string;
+  view: AnnotationView;
+  /** The transcript's own Markdown body node. */
+  body: React.ReactNode;
+  /** The transcript's own attachment renderer — rule 06: the screenshot reuses
+   *  the existing thumbnail, viewer modal and proxy-url guard, with no second
+   *  image element anywhere in the codebase. */
+  attachments: React.ReactNode;
+  /** The transcript's own hover-revealed timestamp — rule 03. */
+  time: React.ReactNode;
+  bodyStyle?: React.CSSProperties;
+  /** The transcript's row dressing (deep-link highlight); the card supplies only
+   *  the alignment, because the alignment is the part that depends on direction. */
+  rowClass: (extra: string) => string;
+};
+
+export const AnnotationMessage: React.FC<AnnotationMessageProps> = ({
+  messageId,
+  view,
+  body,
+  attachments,
+  time,
+  bodyStyle,
+  rowClass,
+}) => {
+  const { t } = useTranslation();
+  const fromUser = view.direction === 'user';
+
+  // Rule 02: two title values, and the action never enters the title. A resolved
+  // agent mark is still titled "Agent 批注" — the marker below says it is done.
+  const label = (
+    <span className={clsx('text-[11px] font-medium', fromUser ? 'text-cyan' : 'text-mint')}>
+      {t(annotationTitleKey(view.direction))}
+    </span>
+  );
+  const avatar = (
+    <RoleAvatar tone={fromUser ? 'cyan' : 'mint'}>
+      <MessageSquareQuote />
+    </RoleAvatar>
+  );
+
+  // Rule 04: drawn only when the anchor carries copy a reader can find on the
+  // page. When it does not, nothing is drawn — a selector, an anchor kind, an
+  // event id or a screenshot path is a locator the reader cannot use, so none of
+  // them stands in for the quote (rule 05).
+  const quoteNode = view.quote ? (
+    <div className="mb-[9px] flex w-full items-start gap-[7px] border-l-2 border-foreground/25 py-px pl-[9px]">
+      <span className="pt-[3px]">
+        <MapPin className="size-[11px] shrink-0 text-muted" />
+      </span>
+      <span className="min-w-0 break-words text-[12px] leading-[1.5] text-muted">{view.quote}</span>
+    </div>
+  ) : null;
+
+  // Rule 07.
+  const resolvedNode = view.resolved ? (
+    <div className="mt-[9px] flex w-full">
+      <span className="inline-flex items-center gap-1 rounded-full border border-mint/35 bg-mint-soft px-[9px] py-[3px] text-[10.5px] font-semibold text-mint">
+        <Check className="size-[11px] shrink-0" />
+        {t('chat.annotation.resolved')}
+      </span>
+    </div>
+  ) : null;
+
+  return (
+    <div data-message-id={messageId} className={rowClass(fromUser ? 'justify-end' : 'justify-start')}>
+      <div
+        className={clsx(
+          'group/message flex max-w-[min(92%,860px)] flex-col gap-1',
+          fromUser ? 'items-end' : 'items-start',
+        )}
+      >
+        {/* Mirrored head: the avatar always sits on the outer edge, so the two
+            directions read as a matched pair across the column. */}
+        <div className="flex items-center gap-2 px-0.5">
+          {fromUser ? (
+            <>
+              {label}
+              {avatar}
+            </>
+          ) : (
+            <>
+              {avatar}
+              {label}
+            </>
+          )}
+        </div>
+        <div
+          className={clsx(
+            // Rule 03: width, radius and timestamp are the existing chat bubble's.
+            // An annotation is a message, not a widget — it must not introduce a
+            // second bubble shape into the column.
+            'w-fit min-w-0 max-w-full rounded-2xl border px-3.5 py-2.5 leading-relaxed [&_pre]:max-w-full [&_pre]:overflow-x-auto [&_table]:w-full',
+            fromUser
+              ? 'rounded-tr-md border-border-strong bg-foreground/[0.06]'
+              : 'rounded-tl-md border-mint/25 bg-mint/[0.09]',
+          )}
+          style={bodyStyle}
+        >
+          {quoteNode}
+          {body}
+          {attachments}
+          {resolvedNode}
+        </div>
+        {time}
+      </div>
+    </div>
+  );
+};

--- a/ui/src/components/workbench/ChatPage.tsx
+++ b/ui/src/components/workbench/ChatPage.tsx
@@ -871,7 +871,13 @@ export const ChatPage: React.FC = () => {
       setShowToolCalls(bootstrap.config?.ui?.show_tool_calls !== false);
       // Merge (not replace) so a row that arrived over the stream during the
       // load isn't clobbered; the session-change reset keeps prior sessions out.
-      setMessages((prev) => mergeById(bootstrap.messages, prev));
+      // Filtered like every other entry point: the transcript decides what it
+      // shows by type, whatever a payload happens to contain. The bootstrap
+      // endpoint still widens its selection by ``metadata.source``, so without
+      // this a queued annotation opened the chat as a delivered bubble *and* sat
+      // in the queue strip — the exact double-render the live path already
+      // rejects (Codex P1).
+      setMessages((prev) => mergeById(bootstrap.messages.filter(isTranscriptMessage), prev));
       setOlderCursor(bootstrap.next_before_id ?? null);
       setHistoricalWindow(false);
       // Chat Activity chips for past turns: resync the per-turn summary (row text

--- a/ui/src/components/workbench/ChatPage.tsx
+++ b/ui/src/components/workbench/ChatPage.tsx
@@ -12,7 +12,7 @@ import { useRegisterComposerTarget, type ComposerInsertTarget } from '../../cont
 import type { SessionActivityItemKind, SessionActivityState, SessionRuntimeState, VaultRequest, VibeAgentBrief, WorkbenchMessage, WorkbenchSession } from '../../context/ApiContext';
 import { apiFetch } from '../../lib/apiFetch';
 import { normalizeChatMessageFontSize } from '../../lib/chatDisplay';
-import { isNotifyMessageType, isTerminalAgentMessage } from '../../lib/chatMessageTypes';
+import { isNotifyMessageType, isTerminalAgentMessage, isTranscriptMessage } from '../../lib/chatMessageTypes';
 import { useIosKeyboardInset } from '../../lib/useIosKeyboardInset';
 import { isProxyMediaUrl } from '../../lib/mediaProxy';
 import { localPath, type ShowPageLinkInfo } from '../../lib/showPageLinks';
@@ -101,17 +101,6 @@ const emptyRuntimeState = (): SessionRuntimeState => ({
   pending_activity_output_count: 0,
   connection: 'unknown',
 });
-
-// The transcript-visible message types — mirrors the server filter on
-// ``GET /api/sessions/{id}/messages`` so the live ``message.new`` feed appends
-// the same rows the initial load shows (assistant / tool_call are process log).
-const isTranscriptMessage = (msg: WorkbenchMessage): boolean =>
-  msg.type === 'user' ||
-  msg.type === 'harness' ||
-  msg.type === 'result' ||
-  msg.type === 'error' ||
-  msg.type === 'notify' ||
-  (msg.metadata as { source?: string } | null)?.source === 'show_page';
 
 // Bounded retained transcript window: cap how many message rows stay mounted so a
 // long streaming session (or a deep upward scroll) doesn't keep thousands of full
@@ -985,11 +974,11 @@ export const ChatPage: React.FC = () => {
         // Agent Activity rows (assistant / tool_call) only reach the browser when
         // the toggle streams them (message_mirror). Route them to the running
         // buffer — never the transcript. ``isTranscriptMessage`` already excludes
-        // them, so the feature-off path is unchanged. Show-Page marks are ALSO
-        // ``assistant`` rows but are transcript-visible (isTranscriptMessage keeps
-        // them) — let them fall through so they render in the chat, not the panel.
-        const isShowPage = (msg.metadata as { source?: string } | null)?.source === 'show_page';
-        if (showAgentActivityRef.current && isActivityMessageType(msg.type) && !isShowPage) {
+        // them, so the feature-off path is unchanged. A reverse Show Page mark is
+        // no longer an ``assistant`` row — it arrives typed ``annotation`` — so it
+        // cannot match here and needs no metadata-keyed exemption to escape the
+        // activity buffer.
+        if (showAgentActivityRef.current && isActivityMessageType(msg.type)) {
           if (!historicalWindowRef.current) ingestActivityRow(msg);
           return;
         }

--- a/ui/src/components/workbench/ChatPage.tsx
+++ b/ui/src/components/workbench/ChatPage.tsx
@@ -1,7 +1,7 @@
 import { Fragment, memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link, useLocation, useNavigate, useParams, useSearchParams } from 'react-router-dom';
-import { Activity, ArrowLeft, ArrowRight, ArrowUpRight, Bell, Bot, ChevronDown, ChevronRight, Clock, Eye, GitFork, Info, Loader2, MessageSquare, Pencil, Presentation, Terminal, Undo2, UploadCloud, X } from 'lucide-react';
+import { Activity, ArrowLeft, ArrowRight, ArrowUpRight, Bell, Bot, ChevronDown, ChevronRight, Clock, Eye, GitFork, Info, Loader2, MessageSquare, MessageSquareQuote, Pencil, Presentation, Terminal, Undo2, UploadCloud, X } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
 import clsx from 'clsx';
 
@@ -26,6 +26,8 @@ import {
   sortBackgroundActivities,
 } from '../../lib/backgroundActivity';
 import { chatTriggerLink, harnessChipLabelKey, isUnresolvedAgentCallback } from '../../lib/chatTrigger';
+import { AnnotationMessage, annotationTitleKey, claimAnnotation, readAnnotationView } from './AnnotationMessage';
+import { RoleAvatar } from './RoleAvatar';
 import { useFileDrop } from '../../lib/useFileDrop';
 import { quoteText } from '../../lib/quoteText';
 import { mergeById, insertMessageOrdered } from '../../lib/transcriptOrder';
@@ -1944,7 +1946,7 @@ export const ChatPage: React.FC = () => {
 // One queued message. Its text is a single truncated line by default; clicking
 // it expands to the full wrapped text (and clicking again collapses it) so a
 // long queued prompt can be read without sending it.
-const QueueRow: React.FC<{
+export const QueueRow: React.FC<{
   item: WorkbenchMessage;
   onRemove: (id: string) => void;
   onRecall: (item: WorkbenchMessage) => void;
@@ -1965,6 +1967,14 @@ const QueueRow: React.FC<{
   //    row would silently lose them. Both can still be deleted or left to send.
   const att = (item.content as Record<string, unknown> | undefined)?.attachments;
   const canRecall = item.source === 'user' && !(Array.isArray(att) && att.length > 0);
+  // Rule 08: a queued annotation belongs to the strip and nowhere else, so the
+  // strip is where it has to be identifiable. Same title as the card it will
+  // become, so the row the user is looking at and the bubble that replaces it
+  // read as one thing rather than two. Read directly rather than through
+  // ``claimAnnotation``: this row's type is ``queued`` by definition — that is
+  // precisely why it is here and not in the transcript — so the transcript's
+  // claim check would (correctly) reject it.
+  const annotationView = readAnnotationView(item.content);
   return (
     <div className="flex items-start gap-2 rounded-lg bg-surface-2 px-2.5 py-1.5">
       <div
@@ -1983,6 +1993,15 @@ const QueueRow: React.FC<{
           expanded ? 'whitespace-pre-wrap break-words' : 'truncate',
         )}
       >
+        {annotationView && (
+          <>
+            <span className="mr-2 inline-flex items-center gap-[5px] align-middle text-[10.5px] font-medium text-cyan">
+              <MessageSquareQuote className="size-[11px] shrink-0" />
+              {t(annotationTitleKey(annotationView.direction))}
+            </span>
+            <span className="mr-2 text-[11px] text-muted">·</span>
+          </>
+        )}
         {item.text}
       </div>
       {canRecall && (
@@ -3002,22 +3021,6 @@ const ForkSourceBanner: React.FC<{ sourceSessionId: string; sourceTitle: string 
   );
 };
 
-
-// Small role avatar — a tinted rounded square with a lucide glyph, shown on the
-// header line above a left-aligned message bubble (IM layout). Kept on its own
-// line with the name so it never eats into the bubble's usable width.
-const TONE_AVATAR: Record<'mint' | 'cyan' | 'gold' | 'muted', string> = {
-  mint: 'border-mint/30 bg-mint/[0.13] text-mint',
-  cyan: 'border-cyan/30 bg-cyan/[0.13] text-cyan',
-  gold: 'border-gold/30 bg-gold/[0.13] text-gold',
-  muted: 'border-border-strong bg-foreground/[0.06] text-muted',
-};
-const RoleAvatar: React.FC<{ tone: keyof typeof TONE_AVATAR; children: React.ReactNode }> = ({ tone, children }) => (
-  <span className={clsx('flex size-6 shrink-0 items-center justify-center rounded-lg border [&_svg]:size-3.5', TONE_AVATAR[tone])}>
-    {children}
-  </span>
-);
-
 // Shown while a turn is in flight but the reply hasn't landed yet — a left
 // agent bubble with three dots that fade in sequence (``.vr-typing-dot``
 // keyframes in index.css), so the user gets immediate feedback a reply is
@@ -3075,15 +3078,22 @@ const MessageRow = memo(function MessageRow({ message, session, messageFontSize,
   // Each branch composes this onto its own ``justify-*`` so alignment is kept.
   const rowClass = (extra: string) => clsx('flex w-full', extra, highlighted && 'msg-highlight');
 
+  // A Show Page annotation is claimed by its TYPE, before anything else gets to
+  // look at the row. It has to be first: a forward annotation is turn input, so
+  // it arrives authored by ``harness`` and the harness branch below would
+  // otherwise collapse the user's own annotation into a "Page annotation" chip.
+  // Which side it takes is then ``direction``'s decision alone, inside the card.
+  const annotationView = claimAnnotation(message);
+  const isAnnotation = annotationView !== null;
   // Runtime notifications and legacy error rows are compact status pills,
   // not Agent-authored answers.
-  const isNotify = isNotifyMessageType(message.type);
-  const isAgent = !isNotify && message.author === 'agent';
-  const isSystem = !isNotify && message.author === 'system';
+  const isNotify = !isAnnotation && isNotifyMessageType(message.type);
+  const isAgent = !isAnnotation && !isNotify && message.author === 'agent';
+  const isSystem = !isAnnotation && !isNotify && message.author === 'system';
   // A harness-origin row is turn input the human didn't type (scheduled task /
   // watch / webhook); collapsed by default so it doesn't dominate.
-  const isHarness = !isNotify && !isAgent && !isSystem && message.source === 'harness';
-  const isUser = !isNotify && !isAgent && !isSystem && !isHarness;
+  const isHarness = !isAnnotation && !isNotify && !isAgent && !isSystem && message.source === 'harness';
+  const isUser = !isAnnotation && !isNotify && !isAgent && !isSystem && !isHarness;
   // Trigger-message provenance click-through (contract A9a/A9b): agent-callback
   // rows link to the source session's chat; task/watch rows to the Harness view.
   const triggerLink = isHarness ? chatTriggerLink(message, t('chat.source.agentFallback')) : null;
@@ -3145,11 +3155,13 @@ const MessageRow = memo(function MessageRow({ message, session, messageFontSize,
   // Harness prompts and the user's own messages keep soft breaks so their
   // original line breaks stay visible (a harness prompt often mixes authored
   // Markdown with line-oriented waiter output); agent/system replies are
-  // authored Markdown and must not get stray hard breaks.
+  // authored Markdown and must not get stray hard breaks. A user annotation is
+  // typed into a page comment box, so it belongs with the former; an agent mark
+  // is authored Markdown like any other agent reply.
   const bodyNode = message.text ? (
     <Markdown
       content={message.text}
-      softBreaks={isUser || isHarness}
+      softBreaks={isUser || isHarness || annotationView?.direction === 'user'}
       references={(message.content as { references?: MentionReference[] } | null)?.references}
       // Only the agent's own replies may render `$<NAME>` as an interactive secret-input card;
       // user/harness/system bubbles with the marker stay plain text (no false "agent asked" card).
@@ -3171,6 +3183,25 @@ const MessageRow = memo(function MessageRow({ message, session, messageFontSize,
       {formatLocalDateTime(message.created_at)}
     </span>
   );
+
+  // ----- Annotation: the Show Page annotation card, side chosen by direction ---
+  // Returns before every author-derived branch below, for the same reason the
+  // flag is computed first. The card takes the body / attachment / timestamp
+  // nodes built above, so the screenshot rides the transcript's own attachment
+  // renderer (rule 06) and no second image element exists.
+  if (annotationView) {
+    return (
+      <AnnotationMessage
+        messageId={message.id}
+        view={annotationView}
+        body={bodyNode}
+        attachments={attachmentsNode}
+        time={time}
+        bodyStyle={messageFontStyle}
+        rowClass={rowClass}
+      />
+    );
+  }
 
   // ----- Notify: compact gold pill, left-aligned (a status marker) -----
   if (isNotify) {

--- a/ui/src/components/workbench/ChatQueueRow.test.tsx
+++ b/ui/src/components/workbench/ChatQueueRow.test.tsx
@@ -1,0 +1,58 @@
+import { createInstance } from 'i18next';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { I18nextProvider, initReactI18next } from 'react-i18next';
+import { describe, expect, it } from 'vitest';
+
+import en from '../../i18n/en.json';
+import zh from '../../i18n/zh.json';
+import type { WorkbenchMessage } from '../../context/ApiContext';
+import { QueueRow } from './ChatPage';
+
+const i18n = createInstance();
+void i18n.use(initReactI18next).init({
+  lng: 'zh',
+  fallbackLng: 'en',
+  resources: { en: { translation: en }, zh: { translation: zh } },
+  interpolation: { escapeValue: false },
+});
+
+const render = (item: Partial<WorkbenchMessage>) =>
+  renderToStaticMarkup(
+    <I18nextProvider i18n={i18n}>
+      <QueueRow
+        item={
+          {
+            id: 'msg_01J8XK5M8T',
+            type: 'queued',
+            author: 'harness',
+            source: 'harness',
+            text: '这两个卡片的间距不一致',
+            content: {},
+            created_at: '2026-07-27T10:15:48.006Z',
+            ...item,
+          } as WorkbenchMessage
+        }
+        onRemove={() => undefined}
+        onRecall={() => undefined}
+      />
+    </I18nextProvider>,
+  );
+
+describe('queue strip / a queued annotation', () => {
+  it('names the annotation in the strip, with the title its card will carry', () => {
+    // Rule 08: while it is queued the annotation lives in the strip and nowhere
+    // else, so this row is the only place the user can see it — it has to say
+    // what it is. Same title as the bubble that replaces it on flush.
+    const html = render({
+      content: { text: '这两个卡片的间距不一致', annotation: { direction: 'user', action: 'created' } },
+    });
+    expect(html).toContain('用户批注');
+    expect(html).toContain('这两个卡片的间距不一致');
+  });
+
+  it('leaves an ordinary queued prompt exactly as it was', () => {
+    const html = render({ source: 'user', content: {} });
+    expect(html).not.toContain('批注');
+    expect(html).toContain('这两个卡片的间距不一致');
+  });
+});

--- a/ui/src/components/workbench/RoleAvatar.tsx
+++ b/ui/src/components/workbench/RoleAvatar.tsx
@@ -1,0 +1,28 @@
+import clsx from 'clsx';
+
+// The tone-tinted 24px chip that leads every message head in Chat — agent,
+// system, harness and annotation all draw the same geometry, so a new row kind
+// inherits exactly the avatar its neighbours already have (design.pen m31JWV
+// draws the Claude head and the annotation head identically).
+//
+// Lives in its own module rather than inside ChatPage so a row component can
+// reuse it without importing the whole page back.
+const TONE_AVATAR: Record<'mint' | 'cyan' | 'gold' | 'muted', string> = {
+  mint: 'border-mint/30 bg-mint/[0.13] text-mint',
+  cyan: 'border-cyan/30 bg-cyan/[0.13] text-cyan',
+  gold: 'border-gold/30 bg-gold/[0.13] text-gold',
+  muted: 'border-border-strong bg-foreground/[0.06] text-muted',
+};
+
+export type RoleAvatarTone = keyof typeof TONE_AVATAR;
+
+export const RoleAvatar: React.FC<{ tone: RoleAvatarTone; children: React.ReactNode }> = ({ tone, children }) => (
+  <span
+    className={clsx(
+      'flex size-6 shrink-0 items-center justify-center rounded-lg border [&_svg]:size-3.5',
+      TONE_AVATAR[tone],
+    )}
+  >
+    {children}
+  </span>
+);

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -2835,11 +2835,15 @@
       "scheduled": "Scheduled task",
       "watch": "Watch",
       "webhook": "Webhook",
-      "showAnnotation": "Page annotation",
       "showIntent": "Page action",
       "harness": "From agent",
       "from": "From",
       "agentFallback": "agent"
+    },
+    "annotation": {
+      "titleUser": "User annotation",
+      "titleAgent": "Agent annotation",
+      "resolved": "Resolved"
     },
     "picker": {
       "agent": "Agent",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -2835,11 +2835,15 @@
       "scheduled": "定时任务",
       "watch": "Watch 监听",
       "webhook": "Webhook",
-      "showAnnotation": "页面批注",
       "showIntent": "页面操作",
       "harness": "来自 Agent",
       "from": "来自",
       "agentFallback": "智能体"
+    },
+    "annotation": {
+      "titleUser": "用户批注",
+      "titleAgent": "Agent 批注",
+      "resolved": "已处理"
     },
     "picker": {
       "agent": "Agent",

--- a/ui/src/lib/chatMessageTypes.test.ts
+++ b/ui/src/lib/chatMessageTypes.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs';
+
 import { describe, expect, it } from 'vitest';
 
 import { isNotifyMessageType, isTerminalAgentMessage, isTranscriptMessage } from './chatMessageTypes';
@@ -74,5 +76,35 @@ describe('isTranscriptMessage (visibility is a function of type alone)', () => {
     // ...and the same row appears exactly once the flush mints it. Nothing but
     // ``type`` changed between these two lines.
     expect(isTranscriptMessage({ ...queued, type: 'annotation' })).toBe(true);
+  });
+});
+
+// The guard is only worth as much as its coverage of the entry points. Chat
+// seeds its transcript from several payloads — the initial bootstrap, the tail
+// refresh, the older page, the reconnect window, the deep-link window — and one
+// of them shipping unfiltered is exactly the defect this change removes: the
+// bootstrap endpoint still widens its selection by ``metadata.source``, so an
+// unfiltered load put a queued annotation into the transcript AND the queue
+// strip while the live path correctly hid it (Codex P1).
+//
+// A render test can't reach this (Chat needs a DOM the suite doesn't have), and
+// a unit test of the predicate passes whether or not anyone calls it. So the
+// property is asserted where it actually lives: in the source. Every ``messages``
+// array read off an API response in ChatPage must be narrowed on the spot.
+describe('transcript entry points (every payload passes the guard)', () => {
+  it('narrows every API message payload in ChatPage with isTranscriptMessage', () => {
+    const source = readFileSync(new URL('../components/workbench/ChatPage.tsx', import.meta.url), 'utf8');
+    const reads = [...source.matchAll(/\.messages\b/g)];
+    // Not vacuous: the entry points are the five listed above.
+    expect(reads.length).toBeGreaterThanOrEqual(5);
+
+    const unfiltered = reads
+      .map((match) => {
+        const rest = source.slice(match.index + match[0].length).replace(/\s+/g, '');
+        const line = source.slice(0, match.index).split('\n').length;
+        return rest.startsWith('.filter(isTranscriptMessage)') ? null : `ChatPage.tsx:${line}`;
+      })
+      .filter(Boolean);
+    expect(unfiltered).toEqual([]);
   });
 });

--- a/ui/src/lib/chatMessageTypes.test.ts
+++ b/ui/src/lib/chatMessageTypes.test.ts
@@ -44,12 +44,23 @@ describe('isTerminalAgentMessage', () => {
 
 describe('isTranscriptMessage (visibility is a function of type alone)', () => {
   it('mirrors the server transcript types and keeps the process log out', () => {
-    for (const type of ['user', 'harness', 'result', 'error', 'notify', 'annotation']) {
+    for (const type of ['user', 'harness', 'result', 'error', 'notify', 'status', 'annotation']) {
       expect(isTranscriptMessage({ type })).toBe(true);
     }
     for (const type of ['assistant', 'tool_call', 'pending', 'queued']) {
       expect(isTranscriptMessage({ type })).toBe(false);
     }
+  });
+
+  // Both halves together, because the pair IS the definition of ``status``: it
+  // exists because the types a Show page update and a Show runtime error used to
+  // borrow — ``notify`` and ``error`` — also mean "the turn ended", so a page
+  // update cleared the awaiting state and a runtime hiccup marked the turn
+  // failed. ``isTerminalAgentMessage`` is where the UI makes that same call, so
+  // adding ``status`` to it would rebuild the bug on this side of the wire.
+  it('shows a Show status row without ending the turn', () => {
+    expect(isTranscriptMessage({ type: 'status' })).toBe(true);
+    expect(isTerminalAgentMessage({ author: 'agent', type: 'status' })).toBe(false);
   });
 
   // The exact defect this change removes. The guard used to keep ANY row whose

--- a/ui/src/lib/chatMessageTypes.test.ts
+++ b/ui/src/lib/chatMessageTypes.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { isNotifyMessageType, isTerminalAgentMessage } from './chatMessageTypes';
+import { isNotifyMessageType, isTerminalAgentMessage, isTranscriptMessage } from './chatMessageTypes';
 
 describe('isNotifyMessageType', () => {
   it('renders current and legacy failure rows as notifications', () => {
@@ -37,5 +37,42 @@ describe('isTerminalAgentMessage', () => {
       }),
     ).toBe(false);
     expect(isTerminalAgentMessage({ author: 'user', type: 'result' })).toBe(false);
+  });
+});
+
+describe('isTranscriptMessage (visibility is a function of type alone)', () => {
+  it('mirrors the server transcript types and keeps the process log out', () => {
+    for (const type of ['user', 'harness', 'result', 'error', 'notify', 'annotation']) {
+      expect(isTranscriptMessage({ type })).toBe(true);
+    }
+    for (const type of ['assistant', 'tool_call', 'pending', 'queued']) {
+      expect(isTranscriptMessage({ type })).toBe(false);
+    }
+  });
+
+  // The exact defect this change removes. The guard used to keep ANY row whose
+  // ``metadata.source`` was ``show_page`` regardless of its type — and a forward
+  // annotation carries that source in every state, so a still-queued annotation
+  // rendered as a delivered bubble while the identical row sat in the queue
+  // strip. This is the frozen queued example (examples.json, msg_01J8XK5M8T),
+  // ``show_page`` origin and all: it must stay out of the transcript. Widening
+  // the guard by origin again turns this red.
+  it('hides a queued annotation even though it came from a Show Page', () => {
+    const queued = {
+      id: 'msg_01J8XK5M8T',
+      type: 'queued',
+      author: 'harness',
+      source: 'harness',
+      author_name: 'show_annotation',
+      metadata: { source: 'show_page', show_event_id: 'evt_b0c4d5e6' },
+    };
+    // Cross-assert the fixture's own identity, so a drifting copy cannot make
+    // the real assertion below pass vacuously.
+    expect(queued.type).toBe('queued');
+    expect(queued.metadata.source).toBe('show_page');
+    expect(isTranscriptMessage(queued)).toBe(false);
+    // ...and the same row appears exactly once the flush mints it. Nothing but
+    // ``type`` changed between these two lines.
+    expect(isTranscriptMessage({ ...queued, type: 'annotation' })).toBe(true);
   });
 });

--- a/ui/src/lib/chatMessageTypes.ts
+++ b/ui/src/lib/chatMessageTypes.ts
@@ -1,6 +1,25 @@
 export const isNotifyMessageType = (type: string): boolean =>
   type === 'notify' || type === 'error';
 
+// The transcript-visible message types — a literal mirror of the server's
+// ``TRANSCRIPT_TYPES`` so the live ``message.new`` feed appends exactly the rows
+// the initial load shows (``assistant`` / ``tool_call`` are process log).
+const TRANSCRIPT_TYPES = new Set(['user', 'harness', 'result', 'error', 'notify', 'annotation']);
+
+// Whether a row belongs in the chat transcript.
+//
+// Visibility is a function of ``type`` ALONE — which is why the parameter is
+// narrowed to ``{ type }``: no caller and no future edit can reach ``author`` /
+// ``source`` / ``author_name`` / ``metadata`` from in here to widen or narrow
+// the set, even by accident. The clause this replaced kept any row whose
+// ``metadata.source`` was ``show_page`` whatever its type, and a forward
+// annotation carries that source in EVERY state — so a still-``queued``
+// annotation rendered as a delivered bubble while the same row sat in the queue
+// strip. An annotation becomes transcript-visible exactly once: when it is
+// minted as ``annotation``.
+export const isTranscriptMessage = (message: { type: string }): boolean =>
+  TRANSCRIPT_TYPES.has(message.type);
+
 type TerminalMessageCandidate = {
   author: string;
   type: string;

--- a/ui/src/lib/chatMessageTypes.ts
+++ b/ui/src/lib/chatMessageTypes.ts
@@ -4,7 +4,9 @@ export const isNotifyMessageType = (type: string): boolean =>
 // The transcript-visible message types — a literal mirror of the server's
 // ``TRANSCRIPT_TYPES`` so the live ``message.new`` feed appends exactly the rows
 // the initial load shows (``assistant`` / ``tool_call`` are process log).
-const TRANSCRIPT_TYPES = new Set(['user', 'harness', 'result', 'error', 'notify', 'annotation']);
+// ``status`` carries the Show rows that report on the page rather than on the
+// turn — a page update, a runtime error — and means visible, nothing more.
+const TRANSCRIPT_TYPES = new Set(['user', 'harness', 'result', 'error', 'notify', 'status', 'annotation']);
 
 // Whether a row belongs in the chat transcript.
 //

--- a/ui/src/lib/chatTrigger.test.ts
+++ b/ui/src/lib/chatTrigger.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
+import en from '../i18n/en.json';
+import zh from '../i18n/zh.json';
 import { chatTriggerLink, harnessChipLabelKey, isUnresolvedAgentCallback } from './chatTrigger';
 
 type Msg = Parameters<typeof chatTriggerLink>[0];
@@ -66,7 +68,6 @@ describe('chatTriggerLink', () => {
 
   it('does not navigate for webhook or unknown harness kinds without a source', () => {
     expect(link({ author_name: 'webhook' })).toBeNull();
-    expect(link({ author_name: 'show_annotation' })).toBeNull();
     expect(link({ author_name: 'show_intent' })).toBeNull();
     expect(link({ author_name: 'agent_run', source_session_id: null })).toBeNull();
   });
@@ -118,8 +119,17 @@ describe('harnessChipLabelKey (leading-label key by source presence)', () => {
     }
   });
 
-  it('uses Show-specific labels for annotation and intent triggers', () => {
-    expect(key({ author_name: 'show_annotation' })).toBe('chat.source.showAnnotation');
+  it('keeps the Show intent label (a page button action, not an annotation)', () => {
     expect(key({ author_name: 'show_intent' })).toBe('chat.source.showIntent');
+  });
+
+  it('no longer special-cases show_annotation — an annotation is not a harness trigger row', () => {
+    // An annotation now arrives typed ``annotation`` and renders as its own card,
+    // so this mapper never sees one and has no branch for it. A stray legacy row
+    // degrades to the generic harness label rather than resurrecting the deleted
+    // ``chat.source.showAnnotation`` string; re-adding the branch turns this red.
+    expect(key({ author_name: 'show_annotation' })).toBe('chat.source.harness');
+    expect(en.chat.source).not.toHaveProperty('showAnnotation');
+    expect(zh.chat.source).not.toHaveProperty('showAnnotation');
   });
 });

--- a/ui/src/lib/chatTrigger.ts
+++ b/ui/src/lib/chatTrigger.ts
@@ -69,7 +69,10 @@ export function chatTriggerLink(message: TriggerFields, agentFallback: string): 
   }
 
   const kind = message.author_name;
-  if (kind === 'show_annotation' || kind === 'show_intent') return null;
+  // ``show_intent`` (a page button action) stays a non-navigating harness row.
+  // ``show_annotation`` no longer reaches here at all: an annotation is typed
+  // ``annotation`` and renders as its own card, never as a harness trigger row.
+  if (kind === 'show_intent') return null;
   if (kind === 'watch' || TASK_KINDS.has(kind ?? '')) {
     const itemKind = kind === 'watch' ? 'watch' : 'task';
     return {
@@ -91,7 +94,6 @@ export function chatTriggerLink(message: TriggerFields, agentFallback: string): 
 export function harnessChipLabelKey(message: TriggerFields): string {
   if (message.source === 'harness' && message.source_session_id) return 'chat.source.from';
   const kind = message.author_name;
-  if (kind === 'show_annotation') return 'chat.source.showAnnotation';
   if (kind === 'show_intent') return 'chat.source.showIntent';
   if (kind === 'watch') return 'chat.source.watch';
   if (kind === 'webhook') return 'chat.source.webhook';


### PR DESCRIPTION
Lane UI half of the Show Page annotation change. Lane BE owns the Python (#1043); this is built against the frozen contract files, not against that branch.

> **Merge order: this lands with or after #1043, never before.** On `master` today the producer doesn't exist — `TRANSCRIPT_TYPES` has no `annotation` and `core/show_session_events.py` writes no `content.annotation` — and current agent marks are `assistant` rows kept visible *only* by the `metadata.source === 'show_page'` override this PR deletes. Merged alone, those marks would disappear. The answer is sequencing, not keeping the override: the override is the defect this change exists to remove (judgment calls below).
>
> Verified at #1043's head `8cb03624`, everything this half needs is there: `ANNOTATION_TYPE` is in `TRANSCRIPT_TYPES`; the `include_metadata_sources` back door is deleted (not softened) on that side too; `content.annotation` is written through one `writes_annotation` path fed by **both** `ANNOTATION_EVENT_TYPES` and `ASSISTANT_MARK_EVENT_TYPES`; and `storage/alembic/versions/20260727_0038_preserve_legacy_show_transcript.py` converts legacy `assistant` + `metadata.source = 'show_page'` rows to `notify`, which is itself a transcript type — so already-persisted marks stay visible once this clause is gone, and the downgrade is symmetric. The open review thread on `chatMessageTypes.ts` tracks this ordering; it is owned and resolved at the integration gate, not by a commit on this branch.

## What changed

**Transcript visibility is a function of `messages.type` alone.**
`isTranscriptMessage` used to end with `metadata.source === 'show_page'` — the mirror image of the backend defect this whole change exists to remove. A forward annotation carries that source in *every* state, so a still-`queued` annotation rendered as a delivered bubble while the identical row sat in the queue strip. The clause is gone, `annotation` is in the set, and the predicate's parameter is narrowed to `{ type }` so no caller and no future edit can reach `author` / `source` / `author_name` / `metadata` from inside it. One function, five call sites, fixed once. A second back door — an inline `metadata.source === 'show_page'` exemption in the live `onMessageNew` activity routing — is removed for the same reason; it is provably dead once annotations carry `type: 'annotation'`.

**`chatTrigger.ts` no longer special-cases `show_annotation`.** An annotation is not a harness trigger row. `show_intent` (a page button action) is untouched. `chat.source.showAnnotation` is deleted from both locales after grepping for callers.

**The annotation card.** Side and title come from `content.annotation.direction`, never from `author`. `claimAnnotation` is evaluated *first* in `MessageRow` and every other branch flag gained `!isAnnotation` — a forward annotation is turn input, so it is authored by `harness`, and the harness branch would otherwise collapse the user's own annotation into a "Page annotation" chip.

The card is a row component, not a page fragment: it is handed the body, attachment and timestamp nodes the transcript already builds. So the screenshot rides the **existing** attachment renderer with its thumbnail, viewer modal and proxy-URL guard (rule 06) — no second image element anywhere — and bubble width, radius and timestamp stay the chat's own (rule 03). The anchor strip is drawn only when `quote` is present, with nothing substituted when it is absent (rules 04, 05). `resolved` draws a chip and leaves the title alone (rules 02, 07). A queued annotation is named in the queue strip, since while queued that strip is the only place it appears (rule 08).

## Evidence

| Layer | What it covers |
| --- | --- |
| Unit — `chatMessageTypes.test.ts` | The negative property, asserted against `isTranscriptMessage` directly: the frozen queued row (`msg_01J8XK5M8T`), `metadata.source: show_page` and all, is **absent** from the transcript; the same object with `type: 'annotation'` is present. Widening the guard by origin again turns this red. |
| Contract — `AnnotationMessage.test.tsx` | All four frozen `examples.json` rows rendered: title text, side, quote-strip presence/absence, 「已处理」 presence/absence, attachment node + `isProxyMediaUrl` on the frozen URL. Plus the no-machine-text property — the fixture's `_queued_dispatch_text` is asserted to *contain* `vibe show reply` / the selector / the event id, and the rendered output to contain none of them. |
| Contract — `ChatQueueRow.test.tsx` | The queued annotation is titled in the strip; an ordinary queued prompt is unchanged. |
| Unit — `chatTrigger.test.ts` | `show_annotation` no longer maps to its own label (degrades to the generic harness label rather than resurrecting the deleted string); `show_intent` unchanged; both locale files asserted not to have `showAnnotation`. |
| Build | `cd ui && npm run build` passes. Full suite: 65 files, 560 tests, green. |
| Visual gate | Rendered the four rows as real cards plus the queue strip in the real dark theme, screenshotted, compared side by side against `export_nodes` of `m31JWV`. Compared: side per direction, title text, head order (avatar on the outer edge, mirrored), quote strip (2px rule + map-pin + muted 12px), resolved chip (mint pill, check, start-aligned below the body), attachment placement inside the bubble, timestamp placement, and the queue-row prefix (`icon 用户批注 · text`). The harness was deleted afterwards; no scaffolding is in the diff. |

Residual manual check: the real image path is exercised only through `isProxyMediaUrl` + the shared renderer, not with a live upload — that lands in regression once Lane BE's rows exist end to end.

## Judgment calls, for review

1. **`isTranscriptMessage` moved from `ChatPage.tsx` to `lib/chatMessageTypes.ts`.** Contract D names it `ChatPage.isTranscriptMessage`. It sits next to `isNotifyMessageType` and `isTerminalAgentMessage`, which is where its neighbours already are, and it makes the invariant unit-testable without pulling the component tree into vitest. Behaviour is identical; all five call sites import it.
2. **`claimAnnotation` narrows Contract D's `message.type === 'annotation'`** by also requiring a readable `direction`. It only ever *narrows*, never widens, and never consults author/source/metadata. A malformed row (a contract violation) degrades to a plain bubble instead of drawing a card that cannot say whose annotation it is.
3. **`RoleAvatar` promoted out of `ChatPage.tsx`** into its own module — the reuse ladder's "promote a near-duplicate into the shared layer". Without it, `AnnotationMessage → ChatPage → AnnotationMessage` is a cycle.
4. **Two deliberate token deltas from the frame — both are pre-existing Chat-wide divergence, not annotation-specific spec.** Verified at node level in `design.pen`, and tracked separately as a design-sync item; deliberately *not* fixed here.
   - **Bubble radius.** The annotation bubble (`dBOFA`) is `cornerRadius [16,6,16,16]` — and so is `m31JWV`'s **ordinary** user bubble (`M7Kvg`), identically. The frame is internally consistent; the 16/6-vs-20/8 gap is between the frame and the shipped `@theme` scale, across all of Chat, and it predates this change. Rule 03 says the annotation bubble's radius *is* the existing chat bubble's, so the existing classes are used verbatim.
   - **Avatar tint.** The frame's Agent-annotation avatar (`Lbcx5`) is `fill #5bffa029 / stroke #5BFFA04D / cornerRadius 8` — byte-identical to the Claude avatar (`brI1w`) in `PaPwD`. The frame treats every avatar as one primitive; `RoleAvatar` is the code's rendering of that primitive, currently at 13% / `rounded-lg`. Retuning a shared primitive for three points of alpha would move every other avatar in Chat.
5. **`#FFFFFF3D` (the quote strip's 2px rule) has no exact token.** `--border-strong` is `#FFFFFF24`, deliberately weaker. Mapped to `border-foreground/25` (24% ≈ 0x3D/255 = 23.9%) so it theme-flips instead of being a dark-only hex — a raw hex would be invisible in Light mode.
6. **`QueueRow` is now exported** so the strip's annotation title is testable and was renderable in the visual gate — the same pattern `HarnessPage.test.tsx` already uses.

No dependency added; `package-lock.json` untouched. `ui/dist` not committed.

Frozen contract: `docs/plans/show-annotation-message-type/{contract.ts,examples.json}` (on Lane BE's branch). The four rows are copied verbatim into the contract test rather than imported, so both lanes are pinned to one artifact from their own branches.



