### PR TITLE
refactor(storage): derive partial indexes from message catalog

### DIFF
--- a/storage/models.py
+++ b/storage/models.py
@@ -17,6 +17,8 @@ from sqlalchemy import (
     text,
 )
 
+from vibe.message_types import build_partial_index_predicate
+
 metadata = MetaData()
 
 state_meta = Table(
@@ -382,9 +384,7 @@ messages = Table(
         "session_id",
         text("created_at desc"),
         text("id desc"),
-        sqlite_where=text(
-            "session_id is not null and type not in ('queued', 'draft', 'pending', 'harness_dedupe', 'silent')"
-        ),
+        sqlite_where=text(build_partial_index_predicate("ix_messages_inbox_activity")),
     ),
     Index(
         "ix_messages_inbox_agent_reply",
@@ -392,7 +392,7 @@ messages = Table(
         "session_id",
         text("created_at desc"),
         text("id desc"),
-        sqlite_where=text("session_id is not null and type in ('result', 'notify', 'error')"),
+        sqlite_where=text(build_partial_index_predicate("ix_messages_inbox_agent_reply")),
     ),
     Index(
         "ix_messages_inbox_user_send",
@@ -400,10 +400,7 @@ messages = Table(
         "session_id",
         text("created_at desc"),
         text("id desc"),
-        sqlite_where=text(
-            "session_id is not null and ((author = 'user' and type = 'user') "
-            "or (author = 'harness' and type = 'harness'))"
-        ),
+        sqlite_where=text(build_partial_index_predicate("ix_messages_inbox_user_send")),
     ),
     Index("ix_messages_scope_created", "scope_id", "created_at"),
     Index("ix_messages_scope_unread", "scope_id", "read_at"),

--- a/tests/test_sqlite_state_migration.py
+++ b/tests/test_sqlite_state_migration.py
@@ -10,6 +10,8 @@ from pathlib import Path
 import pytest
 from alembic import command
 from alembic.script import ScriptDirectory
+from sqlalchemy.dialects.sqlite import dialect as sqlite_dialect
+from sqlalchemy.schema import CreateIndex
 
 from config import paths
 from config.v2_settings import ChannelSettings, RoutingSettings, SettingsState, SettingsStore
@@ -19,15 +21,49 @@ from storage import migrations
 from storage.migrations import UnsafeDefaultStateMigrationError, background_tables_ready, run_migrations
 from storage.models import metadata
 from storage.settings_service import SQLiteSettingsService
+from vibe.message_types import build_partial_index_predicate
 
 
 HEAD_REVISION = "20260726_0037"
+MESSAGE_PARTIAL_INDEX_PREDICATES = {
+    "ix_messages_inbox_activity": (
+        "session_id is not null and type not in "
+        "('queued', 'draft', 'pending', 'harness_dedupe', 'silent')"
+    ),
+    "ix_messages_inbox_agent_reply": (
+        "session_id is not null and type in ('result', 'notify', 'error')"
+    ),
+    "ix_messages_inbox_user_send": (
+        "session_id is not null and ((author = 'user' and type = 'user') "
+        "or (author = 'harness' and type = 'harness'))"
+    ),
+}
 
 
 def _index_sql(conn: sqlite3.Connection, name: str) -> str:
     row = conn.execute("select sql from sqlite_master where type = 'index' and name = ?", (name,)).fetchone()
     assert row is not None
     return str(row[0] or "")
+
+
+@pytest.mark.parametrize(
+    ("index_name", "expected_predicate"),
+    tuple(MESSAGE_PARTIAL_INDEX_PREDICATES.items()),
+)
+def test_message_partial_index_ddl_matches_catalog_contract(
+    index_name: str,
+    expected_predicate: str,
+) -> None:
+    index = next(index for index in metadata.tables["messages"].indexes if index.name == index_name)
+
+    catalog_predicate = build_partial_index_predicate(index_name)
+    ddl = str(CreateIndex(index).compile(dialect=sqlite_dialect()))
+
+    assert catalog_predicate == expected_predicate
+    assert ddl == (
+        f"CREATE INDEX {index_name} ON messages "
+        f"(platform, session_id, created_at desc, id desc) WHERE {expected_predicate}"
+    )
 
 
 class _Pre335Cursor(sqlite3.Cursor):


### PR DESCRIPTION
## Capability

- Makes the three SQLAlchemy `messages` partial-index definitions consume `build_partial_index_predicate(...)`.
- Pins the catalog-derived predicates and complete SQLite `CREATE INDEX` statements byte-for-byte in the migration test suite.
- Keeps every historical Alembic snapshot literal and adds no migration.

Dependency: #1046 (merged) provides the message-type catalog and predicate builder.

## Scenario coverage

No scenario catalog IDs are affected; this is a schema-definition refactor with unchanged emitted DDL.

## Evidence

### Unit

- `tests/test_sqlite_state_migration.py`: 66 passed.
- Catalog plus migration tests after the final rebase: 79 passed.
- Ruff: changed Python files pass.

### Contract

The before/after DDL diff is empty. Both sides emit:

```sql
CREATE INDEX ix_messages_inbox_activity ON messages (platform, session_id, created_at desc, id desc) WHERE session_id is not null and type not in ('queued', 'draft', 'pending', 'harness_dedupe', 'silent')
CREATE INDEX ix_messages_inbox_agent_reply ON messages (platform, session_id, created_at desc, id desc) WHERE session_id is not null and type in ('result', 'notify', 'error')
CREATE INDEX ix_messages_inbox_user_send ON messages (platform, session_id, created_at desc, id desc) WHERE session_id is not null and ((author = 'user' and type = 'user') or (author = 'harness' and type = 'harness'))
```

### Query plans

On representative analyzed SQLite data, the before/after `EXPLAIN QUERY PLAN` diff is empty and each top-1 Inbox probe still selects its intended partial index:

```text
SEARCH messages USING INDEX ix_messages_inbox_activity (platform=? AND session_id=?)
SEARCH messages USING INDEX ix_messages_inbox_agent_reply (platform=? AND session_id=?)
SEARCH messages USING INDEX ix_messages_inbox_user_send (platform=? AND session_id=?)
```

### CI group

- The full 261-file unit group ran. 259 files passed directly.
- The only two initial failures were SPA assertions caused by absent generated `ui/dist` in the fresh worktree; after provisioning the standard UI artifact, those files passed (146 and 21 tests).

### Residual manual checks

None. There is no runtime behavior or database migration to exercise manually.

## Known by design

- Alembic versions remain historical literal snapshots and do not import the live catalog.
- Catalog membership changes that alter these predicates still require an explicit future migration; this PR changes no membership and therefore needs none.
