### PR TITLE
refactor(messages): consume shared message type catalog

### DIFF
--- a/core/backend_failure.py
+++ b/core/backend_failure.py
@@ -6,6 +6,7 @@ import uuid
 from typing import Any
 
 from core.message_output import MessageOutput, terminal_output_for, terminal_turn_output
+from vibe.message_types import spec_for
 
 BACKEND_FAILURE_EVENT = "backend_failure"
 
@@ -13,10 +14,11 @@ BACKEND_FAILURE_EVENT = "backend_failure"
 def is_backend_failure_notification(message_type: str | None, metadata: Any) -> bool:
     """Whether a persisted message is the visible half of a terminal failure."""
 
+    normalized_type = str(message_type or "").strip()
+    event = metadata.get("event") if isinstance(metadata, dict) else None
     return (
-        str(message_type or "").strip() == "notify"
-        and isinstance(metadata, dict)
-        and metadata.get("event") == BACKEND_FAILURE_EVENT
+        event == BACKEND_FAILURE_EVENT
+        and event in spec_for(normalized_type)["terminalWhenEvents"]
     )
 
 

--- a/core/internal_server.py
+++ b/core/internal_server.py
@@ -43,11 +43,13 @@ from config import paths
 from core.services.dispatch import SOURCE_HUMAN, SOURCE_SCHEDULED
 from modules.im.base import MessageContext
 from storage.db import get_cached_sqlite_engine
+from vibe.message_types import types_with
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from core.controller import Controller
 
 logger = logging.getLogger(__name__)
+_ACCEPTED_RESERVATION_TYPES = set(types_with("acceptedReservation"))
 
 
 def default_socket_path() -> Path:
@@ -439,10 +441,9 @@ def create_app(controller: "Controller") -> FastAPI:
                     if accepted is not None
                     else messages_service.PENDING_TYPE
                 )
-            if active_message_id == user_message_id or reserved_type in {
-                "user",
-                messages_service.HARNESS_TYPE,
-            }:
+            if active_message_id == user_message_id or reserved_type in (
+                _ACCEPTED_RESERVATION_TYPES - {messages_service.QUEUED_TYPE}
+            ):
                 return JSONResponse(
                     status_code=202,
                     content={

--- a/core/message_mirror.py
+++ b/core/message_mirror.py
@@ -32,6 +32,7 @@ from sqlalchemy.exc import IntegrityError
 from modules.im.base import MessageContext
 from storage import agent_events_service, messages_service, settings_service
 from storage.db import get_cached_sqlite_engine
+from vibe.message_types import spec_for
 
 logger = logging.getLogger(__name__)
 
@@ -412,7 +413,7 @@ def persist_agent_message(
                 # hidden intermediate assistant stream.
                 if (
                     context.platform == "avibe"
-                    and message_type in ("result", "notify", "error")
+                    and spec_for(message_type)["inboxPreview"]
                     and row_session_id
                 ):
                     try:
@@ -469,7 +470,10 @@ def persist_agent_message(
         # open Chat consumer; publishing it would be dead traffic).
         if context.platform == "avibe" and not suppress_delivery and (
             message_type in messages_service.TRANSCRIPT_TYPES
-            or (message_type == "assistant" and _activity_streaming_enabled())
+            or (
+                spec_for(message_type)["activityRole"] == "activity"
+                and _activity_streaming_enabled()
+            )
         ):
             _publish_session_message(appended_row)
         if inbox_row is not None:

--- a/core/services/session_fork.py
+++ b/core/services/session_fork.py
@@ -14,18 +14,40 @@ from pathlib import Path
 from typing import Any, Optional
 
 from config import paths
-from core.backend_failure import BACKEND_FAILURE_EVENT, is_backend_failure_notification
+from core.backend_failure import is_backend_failure_notification
 from vibe.i18n import t
 from vibe.message_identity import INPUT_TURN_AUTHOR_TYPES, is_input_turn
+from vibe.message_types import spec_for, types_with
 
 TRIM_LATEST_RUNNING_TURN_BACKENDS = {"codex", "opencode"}
 # ``silent`` is the invisible completion marker (messages_service.SILENT_TYPE): a turn
 # that finished with no user-visible reply is still TERMINAL, so a fork created after
 # it must not trim/roll back the completed turn as if it were still running.
-TERMINAL_AGENT_OUTPUT_TYPES = {"result", "error", "silent"}
-SOURCE_PROGRESS_AGENT_OUTPUT_TYPES = {"assistant", *TERMINAL_AGENT_OUTPUT_TYPES}
+TERMINAL_AGENT_OUTPUT_TYPES = {
+    message_type
+    for message_type in types_with("activityRole")
+    if spec_for(message_type)["activityRole"] == "terminal"
+}
+SOURCE_PROGRESS_AGENT_OUTPUT_TYPES = {
+    message_type
+    for message_type in types_with("activityRole")
+    if spec_for(message_type)["activityRole"] in {"activity", "terminal"}
+}
 ACTIVE_SOURCE_RUN_STATUSES = ("pending", "queued", "processing", "running")
 INPUT_TURN_MESSAGE_TYPES = tuple(message_type for _, message_type in INPUT_TURN_AUTHOR_TYPES)
+_CONDITIONAL_TERMINAL_TYPES = types_with("terminalWhenEvents")
+_FORK_ANCHOR_TYPES = tuple(
+    dict.fromkeys(
+        (
+            *types_with("transcript"),
+            *(
+                message_type
+                for message_type in types_with("activityRole")
+                if message_type in TERMINAL_AGENT_OUTPUT_TYPES
+            ),
+        )
+    )
+)
 
 
 class SessionForkError(ValueError):
@@ -434,10 +456,14 @@ def fork_source_state(fork: dict[str, Any] | None) -> ForkSourceState:
                         messages.c.type.in_(
                             [*INPUT_TURN_MESSAGE_TYPES, *list(SOURCE_PROGRESS_AGENT_OUTPUT_TYPES)]
                         ),
-                        and_(
-                            messages.c.type == "notify",
-                            func.json_extract(messages.c.metadata_json, "$.event")
-                            == BACKEND_FAILURE_EVENT,
+                        *(
+                            and_(
+                                messages.c.type == message_type,
+                                func.json_extract(messages.c.metadata_json, "$.event").in_(
+                                    spec_for(message_type)["terminalWhenEvents"]
+                                ),
+                            )
+                            for message_type in _CONDITIONAL_TERMINAL_TYPES
                         ),
                     ),
                     after_anchor,
@@ -542,7 +568,6 @@ def _forked_session_title(source_title: str, lang: str = "en") -> str:
 def _latest_source_message_anchor(conn: Any, source_session_id: str) -> SourceMessageAnchor:
     from sqlalchemy import func, or_, select
 
-    from storage.messages_service import SILENT_TYPE, TRANSCRIPT_TYPES
     from storage.models import messages
 
     row = conn.execute(
@@ -554,7 +579,7 @@ def _latest_source_message_anchor(conn: Any, source_session_id: str) -> SourceMe
                 # finished silently is the anchor (a terminal, NOT a running input),
                 # otherwise the anchor falls back to the input row and the fork treats
                 # the completed turn as still running and trims/rolls it back.
-                messages.c.type.in_([*TRANSCRIPT_TYPES, SILENT_TYPE]),
+                messages.c.type.in_(_FORK_ANCHOR_TYPES),
                 func.json_extract(messages.c.metadata_json, "$.source") == "show_page",
             ),
         )

--- a/core/show_git.py
+++ b/core/show_git.py
@@ -16,7 +16,7 @@ from typing import Any
 
 from config import paths
 from core.git_binary import ResolvedGit, resolve_git
-from vibe.message_identity import HARNESS_TYPE
+from vibe.message_types import input_author_type_pairs
 
 logger = logging.getLogger(__name__)
 
@@ -53,6 +53,9 @@ _SCRUBBED_GIT_ENV = {
     "GIT_COMMITTER_DATE",
     "EMAIL",
 }
+_INPUT_TURN_MESSAGE_TYPES = tuple(
+    dict.fromkeys(message_type for _, message_type in input_author_type_pairs())
+)
 
 SHOW_GIT_AGENT_CONTRACT = (
     "History is saved automatically around each turn; do not manage versions yourself.",
@@ -279,13 +282,18 @@ def load_turn_checkpoint_context(session_id: str, *, after: str | None = None) -
                 )
             else:
                 message_query = (
-                    message_query.where(messages.c.type.in_(("user", "pending", HARNESS_TYPE)))
+                    message_query.where(
+                        messages.c.type.in_((*_INPUT_TURN_MESSAGE_TYPES, "pending"))
+                    )
                     .where(messages.c.created_at >= after)
                     .order_by(messages.c.created_at.asc(), messages.c.id.asc())
                     .limit(1)
                 )
             message_row = conn.execute(message_query).first()
-            if message_row is None or message_row.type not in {"user", "pending", HARNESS_TYPE}:
+            if message_row is None or message_row.type not in {
+                *_INPUT_TURN_MESSAGE_TYPES,
+                "pending",
+            }:
                 return TurnCheckpointContext()
             return TurnCheckpointContext(
                 message=_read_message_text(message_row.content_text, message_row.content_json),

--- a/core/web_push_notifications.py
+++ b/core/web_push_notifications.py
@@ -10,14 +10,17 @@ from typing import Any
 
 from sqlalchemy import or_, select
 
-from core.backend_failure import is_backend_failure_notification
 from storage import messages_service, web_push_service
 from storage.models import agent_sessions, messages
+from vibe.message_types import spec_for, types_with
 
 logger = logging.getLogger(__name__)
 
-_NOTIFIABLE_TYPES = {"result", "error", "notify"}
-_UNREAD_GATED_TYPES = {"result"}
+_NOTIFIABLE_TYPES = {
+    *types_with("webPush"),
+    *types_with("webPushWhenEvents"),
+}
+_UNREAD_GATED_TYPES = set(types_with("unread"))
 WEB_PUSH_NOTIFICATION_DELAY_SECONDS = 3.0
 WEB_PUSH_USER_KEY_METADATA = "_web_push_user_key"
 WEB_PUSH_USER_KEYS_METADATA = "_web_push_user_keys"
@@ -25,9 +28,13 @@ WEB_PUSH_USER_KEYS_METADATA = "_web_push_user_keys"
 
 def _is_notifiable_message(message_type: Any, metadata: Any = None) -> bool:
     normalized_type = str(message_type or "").strip()
-    return normalized_type in {"result", "error"} or is_backend_failure_notification(
-        normalized_type,
-        metadata,
+    spec = spec_for(normalized_type)
+    return bool(
+        spec["webPush"]
+        or (
+            isinstance(metadata, dict)
+            and metadata.get("event") in spec["webPushWhenEvents"]
+        )
     )
 
 

--- a/storage/agent_activity_service.py
+++ b/storage/agent_activity_service.py
@@ -34,7 +34,9 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from typing import Any, Optional
 
+from core.backend_failure import is_backend_failure_notification
 from storage import agent_events_service, messages_service
+from vibe.message_types import spec_for, types_with
 
 # Bound the scan. The Chat retains ~300 recent messages and pages older on
 # demand; covering the most-recent MESSAGE_SCAN_LIMIT transcript messages (and
@@ -47,14 +49,28 @@ EVENT_SCAN_LIMIT = 2000
 # terminals (result/error/notify/silent-marker), and the interim assistant activity
 # rows. The invisible ``silent`` marker is fetched here (it is NOT in TRANSCRIPT_TYPES)
 # so a turn that completed with no user-visible reply still has a terminal to close on.
+_CONDITIONAL_TERMINAL_TYPES = types_with("terminalWhenEvents")
+_TRANSCRIPT_ACTIVITY_TYPES = tuple(
+    message_type
+    for message_type in types_with("transcript")
+    if spec_for(message_type)["activityRole"] != "none"
+    or spec_for(message_type)["terminalWhenEvents"]
+)
+_NON_TRANSCRIPT_TERMINAL_TYPES = tuple(
+    message_type
+    for message_type in types_with("activityRole")
+    if spec_for(message_type)["activityRole"] == "terminal"
+    and message_type not in _TRANSCRIPT_ACTIVITY_TYPES
+)
+_ACTIVITY_TYPES = tuple(
+    message_type
+    for message_type in types_with("activityRole")
+    if spec_for(message_type)["activityRole"] == "activity"
+)
 _RELEVANT_MESSAGE_TYPES = (
-    "user",
-    messages_service.HARNESS_TYPE,
-    "result",
-    "error",
-    "notify",
-    messages_service.SILENT_TYPE,
-    "assistant",
+    *_TRANSCRIPT_ACTIVITY_TYPES,
+    *_NON_TRANSCRIPT_TERMINAL_TYPES,
+    *_ACTIVITY_TYPES,
 )
 
 
@@ -105,11 +121,11 @@ def _is_terminal(msg_type: Any, author: Any, metadata: Optional[dict]) -> bool:
     """
     if author != "agent":
         return False
-    if msg_type in ("result", "error", messages_service.SILENT_TYPE):
-        return True
-    if msg_type == "notify" and (metadata or {}).get("event") == "backend_failure":
-        return True
-    return False
+    spec = spec_for(msg_type if isinstance(msg_type, str) else "")
+    return (
+        spec["activityRole"] == "terminal"
+        or (metadata or {}).get("event") in spec["terminalWhenEvents"]
+    )
 
 
 def _terminal_status(msg_type: Any, metadata: Optional[dict] = None) -> str:
@@ -117,7 +133,10 @@ def _terminal_status(msg_type: Any, metadata: Optional[dict] = None) -> str:
     or a ``backend_failure`` notify."""
     if msg_type == "error":
         return "failed"
-    if msg_type == "notify" and (metadata or {}).get("event") == "backend_failure":
+    if (
+        msg_type in _CONDITIONAL_TERMINAL_TYPES
+        and is_backend_failure_notification(msg_type, metadata)
+    ):
         return "failed"
     return "done"
 
@@ -171,11 +190,12 @@ def _timeline(conn, session_id: str, *, include_text: bool) -> list[dict[str, An
         # must never act as a turn opener (would split an in-flight turn) nor as
         # activity — always ignore them in the grouping.
         show_page = metadata.get("source") == "show_page"
+        activity_role = spec_for(mtype if isinstance(mtype, str) else "")["activityRole"]
         if _is_terminal(mtype, author, metadata):
             kind = "terminal"
-        elif mtype in ("user", messages_service.HARNESS_TYPE) and not show_page:
+        elif activity_role == "turn_start" and not show_page:
             kind = "turn_start"
-        elif mtype == "assistant" and not show_page:
+        elif activity_role == "activity" and not show_page:
             kind = "activity"
         else:
             kind = "ignore"

--- a/storage/messages_service.py
+++ b/storage/messages_service.py
@@ -29,6 +29,7 @@ from storage.models import (
     scopes,
 )
 from vibe.message_identity import HARNESS_TYPE, INPUT_TURN_AUTHOR_TYPES
+from vibe.message_types import types_with, types_without
 
 
 def _utc_now_iso() -> str:
@@ -259,7 +260,7 @@ def search_messages(
         return {"sessions": [], "total": 0, "session_count": 0}
 
     like = escape_sql_like(cleaned)
-    type_list = list(types if types is not None else ("user", HARNESS_TYPE, "result"))
+    type_list = list(types if types is not None else types_with("searchable"))
     effective_limit = min(max(int(limit), 1), 200)
 
     stmt = (
@@ -707,13 +708,7 @@ HARNESS_DEDUPE_TYPE = "harness_dedupe"
 SILENT_TYPE = "silent"
 # Types that must never count as inbox conversation activity: the ephemeral user rows
 # above plus the invisible agent silent-completion marker.
-NON_CONVERSATION_TYPES = (
-    QUEUED_TYPE,
-    DRAFT_TYPE,
-    PENDING_TYPE,
-    HARNESS_DEDUPE_TYPE,
-    SILENT_TYPE,
-)
+NON_CONVERSATION_TYPES = types_without("inboxActivity")
 
 # The transcript-visible types — the SINGLE source of truth shared by the
 # history fetch (``list_session_messages``) AND the live ``message.new`` publish
@@ -726,7 +721,10 @@ NON_CONVERSATION_TYPES = (
 # terminal FAILED result (turned the dot red): shown in the conversation like any
 # terminal message, but the unread queries below stay ``result``-only so a failure
 # is not counted as an unread agent reply.
-TRANSCRIPT_TYPES = ("user", HARNESS_TYPE, "result", "notify", "error")
+TRANSCRIPT_TYPES = types_with("transcript")
+_INBOX_PREVIEW_TYPES = types_with("inboxPreview")
+_INBOX_SETTLES_REPLY_TYPES = types_with("inboxSettlesReply")
+_UNREAD_TYPES = types_with("unread")
 
 
 def enqueue_queued(
@@ -963,7 +961,7 @@ def unread_counts(
     query = (
         select(messages.c.scope_id, func.count(messages.c.id))
         .where(messages.c.author == "agent")
-        .where(messages.c.type == "result")
+        .where(messages.c.type.in_(_UNREAD_TYPES))
         .where(messages.c.read_at.is_(None))
         # Don't let an archived session's unread results inflate its scope badge
         # (keep null-session rows, which aren't attributable to any session).
@@ -1005,7 +1003,7 @@ def unread_counts_by_session(
     query = (
         select(messages.c.session_id, func.count(messages.c.id))
         .where(messages.c.author == "agent")
-        .where(messages.c.type == "result")
+        .where(messages.c.type.in_(_UNREAD_TYPES))
         .where(messages.c.read_at.is_(None))
         .where(messages.c.session_id.is_not(None))
         # Archived sessions are inert — their unread results must not light the
@@ -1103,15 +1101,14 @@ def list_inbox_sessions(
     # materialization as history grows.
     last_activity_at = _latest_message_value("created_at", conversation_only=True)
     last_author = _latest_message_value("author", conversation_only=True)
-    preview_id = _latest_message_value("id", types=("result", "notify", "error"))
-    preview_at = _latest_message_value("created_at", types=("result", "notify", "error"))
+    preview_id = _latest_message_value("id", types=_INBOX_PREVIEW_TYPES)
+    preview_at = _latest_message_value("created_at", types=_INBOX_PREVIEW_TYPES)
     # The awaiting/replied calc must count the INVISIBLE ``silent`` completion marker
     # as a reply too (a reply-less turn is still answered) — otherwise a silently
     # completed turn keeps the sidebar showing "awaiting the agent". The PREVIEW text
     # stays the last VISIBLE reply, so ``silent`` is included here but NOT in preview_*.
-    _terminal_types = ("result", "notify", "error", SILENT_TYPE)
-    last_terminal_id = _latest_message_value("id", types=_terminal_types)
-    last_terminal_at = _latest_message_value("created_at", types=_terminal_types)
+    last_terminal_id = _latest_message_value("id", types=_INBOX_SETTLES_REPLY_TYPES)
+    last_terminal_at = _latest_message_value("created_at", types=_INBOX_SETTLES_REPLY_TYPES)
     last_input_at = _latest_message_value(
         "created_at", conversation_only=True, input_turn_only=True
     )
@@ -1123,7 +1120,7 @@ def list_inbox_sessions(
         select(m.c.session_id.label("session_id"), func.count().label("unread_count"))
         .where(m.c.session_id.is_not(None))
         .where(m.c.author == "agent")
-        .where(m.c.type == "result")
+        .where(m.c.type.in_(_UNREAD_TYPES))
         .where(m.c.read_at.is_(None))
         .group_by(m.c.session_id)
     )

--- a/tests/test_message_type_catalog.py
+++ b/tests/test_message_type_catalog.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-import re
 from importlib import resources
 from typing import Any
 
@@ -55,12 +54,6 @@ def _sequence_params(statement: Any) -> set[tuple[str, ...]]:
     }
 
 
-def _message_type_equality_values(statement: Any) -> tuple[str, ...]:
-    compiled = statement.compile()
-    parameter_names = re.findall(r"\bmessages\.type = :(type_\d+)", str(compiled))
-    return tuple(compiled.params[name] for name in parameter_names)
-
-
 def test_catalog_resource_and_defaults_are_cross_language_data() -> None:
     document = _catalog_document()
     expected_default = {
@@ -74,18 +67,24 @@ def test_catalog_resource_and_defaults_are_cross_language_data() -> None:
 
 
 def test_transcript_types_match_current_constant() -> None:
-    assert types_with("transcript") == messages_service.TRANSCRIPT_TYPES
+    expected = ("user", "harness", "result", "notify", "error")
+    assert types_with("transcript") == expected
+    assert messages_service.TRANSCRIPT_TYPES == expected
 
 
 def test_searchable_types_match_current_default_query() -> None:
     connection = _CaptureConnection()
     messages_service.search_messages(connection, query="catalog-probe")
 
-    assert _sequence_params(connection.statements[-1]) == {types_with("searchable")}
+    expected = ("user", "harness", "result")
+    assert types_with("searchable") == expected
+    assert _sequence_params(connection.statements[-1]) == {expected}
 
 
 def test_inbox_activity_types_match_current_constant() -> None:
-    assert types_without("inboxActivity") == messages_service.NON_CONVERSATION_TYPES
+    expected = ("queued", "draft", "pending", "harness_dedupe", "silent")
+    assert types_without("inboxActivity") == expected
+    assert messages_service.NON_CONVERSATION_TYPES == expected
 
 
 def test_inbox_preview_and_settlement_types_match_current_query() -> None:
@@ -93,10 +92,17 @@ def test_inbox_preview_and_settlement_types_match_current_query() -> None:
     messages_service.list_inbox_sessions(connection)
     current_query_sets = _sequence_params(connection.statements[-1])
 
+    expected_preview = ("result", "notify", "error")
+    expected_settlement = ("result", "notify", "error", "silent")
+    expected_unread = ("result",)
+    assert types_with("inboxPreview") == expected_preview
+    assert types_with("inboxSettlesReply") == expected_settlement
+    assert types_with("unread") == expected_unread
     assert current_query_sets == {
         messages_service.NON_CONVERSATION_TYPES,
-        types_with("inboxPreview"),
-        types_with("inboxSettlesReply"),
+        expected_preview,
+        expected_settlement,
+        expected_unread,
     }
 
 
@@ -108,11 +114,15 @@ def test_unread_types_match_current_queries(query: Any) -> None:
     connection = _CaptureConnection()
     query(connection)
 
-    assert _message_type_equality_values(connection.statements[-1]) == types_with("unread")
+    expected = ("result",)
+    assert types_with("unread") == expected
+    assert _sequence_params(connection.statements[-1]) == {expected}
 
 
 def test_input_turn_pairs_match_current_constant() -> None:
-    assert input_author_type_pairs() == INPUT_TURN_AUTHOR_TYPES
+    expected = (("user", "user"), ("harness", "harness"))
+    assert input_author_type_pairs() == expected
+    assert INPUT_TURN_AUTHOR_TYPES == expected
 
 
 def test_activity_fetch_and_terminal_semantics_match_current_service() -> None:
@@ -122,36 +132,67 @@ def test_activity_fetch_and_terminal_semantics_match_current_service() -> None:
         if spec_for(message_type)["activityRole"] != "none"
         or spec_for(message_type)["terminalWhenEvents"]
     }
-    assert derived_relevant == set(agent_activity_service._RELEVANT_MESSAGE_TYPES)
+    expected_relevant = (
+        "user",
+        "harness",
+        "result",
+        "notify",
+        "error",
+        "silent",
+        "assistant",
+    )
+    assert derived_relevant == set(expected_relevant)
+    assert agent_activity_service._RELEVANT_MESSAGE_TYPES == expected_relevant
 
     for message_type in _catalog_types():
         spec = spec_for(message_type)
         for event in (None, "backend_failure", "other"):
             metadata = {"event": event} if event is not None else {}
-            expected = (
-                spec["activityRole"] == "terminal"
-                or event in spec["terminalWhenEvents"]
+            legacy_expected = (
+                message_type in {"result", "error", "silent"}
+                or (message_type == "notify" and event == "backend_failure")
             )
             assert (
+                spec["activityRole"] == "terminal"
+                or event in spec["terminalWhenEvents"]
+            ) is legacy_expected
+            assert (
                 agent_activity_service._is_terminal(message_type, "agent", metadata)
-                is expected
+                is legacy_expected
             )
+    assert not agent_activity_service._is_terminal(" result ", "agent", {})
+    assert (
+        agent_activity_service._terminal_status(
+            " notify ",
+            {"event": "backend_failure"},
+        )
+        == "done"
+    )
 
 
 def test_web_push_candidate_exact_and_unread_sets_match_current_service() -> None:
+    expected_candidates = {"result", "error", "notify"}
+    expected_unread = {"result"}
     assert set(types_with("webPush")) | set(
         types_with("webPushWhenEvents")
-    ) == web_push_notifications._NOTIFIABLE_TYPES
-    assert set(types_with("unread")) == web_push_notifications._UNREAD_GATED_TYPES
+    ) == expected_candidates
+    assert web_push_notifications._NOTIFIABLE_TYPES == expected_candidates
+    assert set(types_with("unread")) == expected_unread
+    assert web_push_notifications._UNREAD_GATED_TYPES == expected_unread
 
     for message_type in _catalog_types():
         spec = spec_for(message_type)
         for event in (None, "backend_failure", "other"):
             metadata = {"event": event} if event is not None else {}
-            expected = spec["webPush"] or event in spec["webPushWhenEvents"]
+            legacy_expected = message_type in {"result", "error"} or (
+                message_type == "notify" and event == "backend_failure"
+            )
+            assert (
+                spec["webPush"] or event in spec["webPushWhenEvents"]
+            ) is legacy_expected
             assert (
                 web_push_notifications._is_notifiable_message(message_type, metadata)
-                is expected
+                is legacy_expected
             )
 
 

--- a/tests/test_message_type_catalog.py
+++ b/tests/test_message_type_catalog.py
@@ -142,7 +142,7 @@ def test_activity_fetch_and_terminal_semantics_match_current_service() -> None:
         "assistant",
     )
     assert derived_relevant == set(expected_relevant)
-    assert agent_activity_service._RELEVANT_MESSAGE_TYPES == expected_relevant
+    assert set(agent_activity_service._RELEVANT_MESSAGE_TYPES) == set(expected_relevant)
 
     for message_type in _catalog_types():
         spec = spec_for(message_type)

--- a/tests/test_message_type_python_consumers.py
+++ b/tests/test_message_type_python_consumers.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from core import backend_failure, internal_server, show_git
+from core.services import session_fork
+from vibe import ui_server
+from vibe.message_types import spec_for, types_with
+
+
+def test_backend_failure_predicate_matches_legacy_type_and_event_pair() -> None:
+    for message_type in (
+        "user",
+        "harness",
+        "result",
+        "notify",
+        "error",
+        "assistant",
+        "tool_call",
+        "queued",
+        "draft",
+        "pending",
+        "harness_dedupe",
+        "silent",
+        "unknown",
+    ):
+        for event in (None, "backend_failure", "other"):
+            metadata = {"event": event} if event is not None else {}
+            legacy_expected = message_type == "notify" and event == "backend_failure"
+            catalog_expected = (
+                event == backend_failure.BACKEND_FAILURE_EVENT
+                and event in spec_for(message_type)["terminalWhenEvents"]
+            )
+            assert catalog_expected is legacy_expected
+            assert (
+                backend_failure.is_backend_failure_notification(message_type, metadata)
+                is legacy_expected
+            )
+    assert backend_failure.is_backend_failure_notification(
+        " notify ",
+        {"event": "backend_failure"},
+    )
+
+
+def test_reservation_acceptance_matches_legacy_consumers() -> None:
+    expected = {"user", "harness", "queued"}
+    assert set(types_with("acceptedReservation")) == expected
+    assert internal_server._ACCEPTED_RESERVATION_TYPES == expected
+    assert ui_server._ACCEPTED_RESERVATION_TYPES == expected
+
+
+def test_fork_activity_sets_match_legacy_values() -> None:
+    assert session_fork.TERMINAL_AGENT_OUTPUT_TYPES == {
+        "result",
+        "error",
+        "silent",
+    }
+    assert session_fork.SOURCE_PROGRESS_AGENT_OUTPUT_TYPES == {
+        "assistant",
+        "result",
+        "error",
+        "silent",
+    }
+    assert set(session_fork._FORK_ANCHOR_TYPES) == {
+        "user",
+        "harness",
+        "result",
+        "notify",
+        "error",
+        "silent",
+    }
+
+
+def test_show_git_input_message_types_match_legacy_values() -> None:
+    assert show_git._INPUT_TURN_MESSAGE_TYPES == ("user", "harness")
+
+
+def test_mirror_catalog_roles_match_legacy_type_sets() -> None:
+    assert set(types_with("inboxPreview")) == {"result", "notify", "error"}
+    assert {
+        message_type
+        for message_type in types_with("activityRole")
+        if spec_for(message_type)["activityRole"] == "activity"
+    } == {"assistant"}

--- a/vibe/message_identity.py
+++ b/vibe/message_identity.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 from typing import Optional
 
+from vibe.message_types import input_author_type_pairs
+
 HARNESS_TYPE = "harness"
-INPUT_TURN_AUTHOR_TYPES = (("user", "user"), ("harness", HARNESS_TYPE))
+INPUT_TURN_AUTHOR_TYPES = input_author_type_pairs()
 
 
 def is_input_turn(author: Optional[str], message_type: Optional[str]) -> bool:

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -58,10 +58,12 @@ from core.terminal_service import TERMINAL_SUPPORTED, TerminalService, TerminalS
 from modules.agents.catalog import AGENT_BACKENDS, supports_runtime_refresh
 from vibe.i18n import get_supported_languages, t
 from vibe.logging_config import application_log_paths
+from vibe.message_types import types_with
 from vibe.runtime import get_ui_dist_path, get_working_dir
 from vibe.sentry_integration import init_sentry
 
 logger = logging.getLogger(__name__)
+_ACCEPTED_RESERVATION_TYPES = set(types_with("acceptedReservation"))
 
 
 class _ShowEventDispatchOutcome(str, Enum):
@@ -9309,11 +9311,7 @@ async def _run_show_event_dispatch(
     if not isinstance(message, dict):
         return _ShowEventDispatchOutcome.FAILED
     message_type = message.get("type")
-    if message_type in {
-        messages_service.HARNESS_TYPE,
-        messages_service.QUEUED_TYPE,
-        "user",
-    }:
+    if message_type in _ACCEPTED_RESERVATION_TYPES:
         return _ShowEventDispatchOutcome.ACCEPTED
     if message_type != messages_service.PENDING_TYPE:
         return _ShowEventDispatchOutcome.FAILED
@@ -9363,11 +9361,7 @@ async def _run_show_event_dispatch(
         )
         return _ShowEventDispatchOutcome.FAILED
     settled = _settle_show_event_message(event_payload)
-    if settled and settled.get("type") in {
-        messages_service.HARNESS_TYPE,
-        messages_service.QUEUED_TYPE,
-        "user",
-    }:
+    if settled and settled.get("type") in _ACCEPTED_RESERVATION_TYPES:
         return _ShowEventDispatchOutcome.ACCEPTED
     return _ShowEventDispatchOutcome.FAILED
 


### PR DESCRIPTION
## Capability

Python message consumers now derive shared message-type policy from the catalog introduced by #1046. Existing exported constants remain available, and every replaced set or predicate is covered by a frozen legacy-value assertion.

This is a behavior-preserving de-duplication. It does not add message types, change annotation behavior, or modify persistence/frontend files.

## Scenarios

No scenario catalog IDs are affected. Existing message, inbox, activity, fork, Show dispatch, and web-push behavior is unchanged.

## Evidence

- Unit: 260 focused tests passed across catalog and affected Python consumers.
- Contract: catalog-derived transcript, search, inbox, activity, conditional-terminal, unread, web-push, reservation, input-turn, fork, and mirror policies equal their exact pre-refactor values.
- Scenario: the complete CI unit group passed all 262 test files on the rebased head.
- Static: Ruff and `git diff --check` passed.
- Residual manual: no manual product check is required for this pure policy-source refactor; cross-lane integration remains part of the orchestrator's final pass.

## Dependencies

- #1046 is merged and provides the catalog contract.
- #1049 is merged and is included in the current master base.

## Known By Design

- Existing `metadata.source == "show_page"` and `show_annotation` / `show_intent` author-name side channels remain intact. The current catalog has no proper annotation message type, so removing these compatibility paths would change behavior for persisted rows.
- Producer mappings, workflow-state sentinels, and the Show Git exclusion predicate remain literal where no catalog property answers the same question exactly.
- Direct `error` handling remains the activity failure-status discriminator because the catalog defines terminal membership, not done-versus-failed status.
