### PR TITLE
ci(ui): run the Vitest suite in lint CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -46,6 +46,7 @@ jobs:
         run: |
           npm ci
           npm run validate:theme
+          npm test
           npm run build
 
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6

--- a/ui/package.json
+++ b/ui/package.json
@@ -12,6 +12,7 @@
     "build": "npm run validate:imports && tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview",
+    "test": "vitest run",
     "test:crypto": "vitest run src/lib/vaultCrypto.test.ts",
     "validate:theme": "node scripts/validate-theme.mjs"
   },

--- a/ui/src/lib/terminalFontSize.test.ts
+++ b/ui/src/lib/terminalFontSize.test.ts
@@ -58,7 +58,7 @@ describe('font size store factory', () => {
 
 describe('terminal font size preference', () => {
   it('starts at the default size', () => {
-    expect(getTerminalFontSize()).toBe(TERMINAL_FONT_DEFAULT + 1);
+    expect(getTerminalFontSize()).toBe(TERMINAL_FONT_DEFAULT);
   });
 
   it('adjusts up and down by whole steps', () => {

--- a/ui/src/lib/terminalFontSize.test.ts
+++ b/ui/src/lib/terminalFontSize.test.ts
@@ -58,7 +58,7 @@ describe('font size store factory', () => {
 
 describe('terminal font size preference', () => {
   it('starts at the default size', () => {
-    expect(getTerminalFontSize()).toBe(TERMINAL_FONT_DEFAULT);
+    expect(getTerminalFontSize()).toBe(TERMINAL_FONT_DEFAULT + 1);
   });
 
   it('adjusts up and down by whole steps', () => {


### PR DESCRIPTION
## Capability

Make the existing UI Vitest suite an independent required step of the lint workflow.

## Baseline measurement

- `origin/master` at `1a2d29d0`: 64 test files passed, 0 failed, 0 collection errors
- 554 tests passed
- The current tree contains 64 matching `ui/src/**/*.test.ts(x)` files, one fewer than the 65-file finding

## Changes

- Add `npm test` as the full `vitest run` suite while preserving `test:crypto`
- Run `npm test` in the UI artifact job after theme validation and before the build
- Leave release workflows and the build script unchanged

## Evidence

- Unit: `npm test` (64 files, 554 tests) and `npm run test:crypto` (24 tests)
- Contract: the full suite includes the existing contract tests without modifying them
- Scenario: the lint UI job installs from the existing lockfile, validates theme, tests, then builds
- Mutation: [lint run 30258931318](https://github.com/avibe-bot/avibe/actions/runs/30258931318) failed in `build-linux-artifacts` on head `f4a24f69` when one assertion was temporarily changed (1 failed / 63 passed files); the assertion was restored in the next commit
- Residual manual checks: no product runtime behavior changed

## Scenario IDs

- None; this is CI gate wiring rather than a product scenario change.
