### PR TITLE
feat(ui): draw annotations as their own card and delete the frontend back doors

### DIFF
--- a/docs/plans/show-annotation-message-type.md
+++ b/docs/plans/show-annotation-message-type.md
@@ -157,9 +157,12 @@ The frontend consumes the frozen row shape in `contract.ts` and
 `examples.json`. It admits transcript rows by catalog type and chooses the
 annotation card's side and title from `content.annotation.direction`.
 Because `annotation` is shared by harness, user, and agent authors, search
-results classify the row from its actual `author`; the type's
-`inputAuthors=["harness"]` capability identifies only the harness input pair
-and is not a display-role shortcut.
+results classify the row from the `(author, type)` pair rather than from
+`author` alone. Within `annotation`, `author='agent'` is an agent reverse
+mark and every other author — including `harness`, which carries the user's
+own submitted annotation — is the user. The type's `inputAuthors=["harness"]`
+capability identifies the harness input pair only, and is never a
+display-role shortcut.
 
 This backend change does not modify `ui/`; the frontend implementation is
 delivered independently against the same frozen artifacts.

--- a/ui/src/components/workbench/AnnotationMessage.test.tsx
+++ b/ui/src/components/workbench/AnnotationMessage.test.tsx
@@ -1,0 +1,99 @@
+import { createInstance } from 'i18next';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { I18nextProvider, initReactI18next } from 'react-i18next';
+import { describe, expect, it } from 'vitest';
+
+import en from '../../i18n/en.json';
+import zh from '../../i18n/zh.json';
+import type { AnnotationView } from '../../lib/annotationView';
+import { AnnotationMessage } from './AnnotationMessage';
+import { AGENT_BUBBLE, USER_BUBBLE } from './chatBubble';
+
+const instance = (lng: 'en' | 'zh') => {
+  const i18n = createInstance();
+  void i18n.use(initReactI18next).init({
+    lng,
+    fallbackLng: 'en',
+    resources: { en: { translation: en }, zh: { translation: zh } },
+    interpolation: { escapeValue: false },
+  });
+  return i18n;
+};
+
+const render = (view: AnnotationView, lng: 'en' | 'zh' = 'en') =>
+  renderToStaticMarkup(
+    <I18nextProvider i18n={instance(lng)}>
+      <AnnotationMessage
+        messageId="msg_01J8XK2Q4W"
+        view={view}
+        body={<p>Body</p>}
+        attachments={<img alt="" src="/api/media/med_9a71c33f8b2e" />}
+        time={<span>12:04</span>}
+        rowClass={(extra) => `flex w-full ${extra}`}
+      />
+    </I18nextProvider>,
+  );
+
+const USER: AnnotationView = { direction: 'user', resolved: false };
+const AGENT: AnnotationView = { direction: 'agent', resolved: false };
+
+describe('AnnotationMessage', () => {
+  // Rule 01. The side is direction, full stop — the component is never told who
+  // authored the row, so there is nothing else it could side on.
+  it('sides the card by direction', () => {
+    expect(render(USER)).toContain('justify-end');
+    expect(render(AGENT)).toContain('justify-start');
+  });
+
+  // Rule 02: exactly two titles, and the action never enters them.
+  it('titles the card by direction only, in the UI language', () => {
+    expect(render(USER)).toContain('User annotation');
+    expect(render(AGENT)).toContain('Agent annotation');
+    expect(render(USER, 'zh')).toContain('用户批注');
+    expect(render(AGENT, 'zh')).toContain('Agent 批注');
+  });
+
+  it('keeps the title the same for a resolved mark', () => {
+    const html = render({ ...AGENT, resolved: true });
+    expect(html).toContain('Agent annotation');
+    expect(html).not.toContain('User annotation');
+  });
+
+  // Rule 03: the bubble IS the column's existing bubble. Asserting against the
+  // shared constants rather than a copied class string means a future restyle of
+  // the ordinary bubbles carries the card with it and cannot leave it behind.
+  it('reuses the transcript bubble the row would otherwise have drawn', () => {
+    // The Tailwind arbitrary-variant classes carry ``&``, which React escapes in
+    // the attribute; escape the constant the same way rather than loosening the
+    // match, so this stays an assertion about the WHOLE class string.
+    const asAttr = (cls: string) => cls.replaceAll('&', '&amp;');
+    expect(render(USER)).toContain(asAttr(USER_BUBBLE));
+    expect(render(AGENT)).toContain(asAttr(AGENT_BUBBLE));
+  });
+
+  // Rule 04: quoted only when the anchor carried copy the reader can find.
+  it('draws the anchor quote when there is one, and nothing when there is not', () => {
+    expect(render({ ...USER, quote: 'Model Hub' })).toContain('Model Hub');
+    expect(render(USER)).not.toContain('border-l-2');
+  });
+
+  // Rule 07: created / updated / dismissed draw no marker at all.
+  it('marks only a resolved annotation', () => {
+    expect(render({ ...AGENT, resolved: true })).toContain('Resolved');
+    expect(render({ ...AGENT, resolved: true }, 'zh')).toContain('已处理');
+    expect(render(AGENT)).not.toContain('Resolved');
+  });
+
+  // Rule 06: the screenshot is the transcript's own thumbnail, passed in. The card
+  // renders no image element of its own.
+  it('passes the transcript body, attachments and timestamp straight through', () => {
+    const html = render(USER);
+    expect(html).toContain('<p>Body</p>');
+    expect(html).toContain('/api/media/med_9a71c33f8b2e');
+    expect(html).toContain('12:04');
+  });
+
+  it('carries the deep-link row dressing so an annotation can be jumped to', () => {
+    expect(render(USER)).toContain('data-message-id="msg_01J8XK2Q4W"');
+  });
+});

--- a/ui/src/components/workbench/AnnotationMessage.test.tsx
+++ b/ui/src/components/workbench/AnnotationMessage.test.tsx
@@ -1,4 +1,5 @@
 import { createInstance } from 'i18next';
+import type { ReactNode } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { I18nextProvider, initReactI18next } from 'react-i18next';
 import { describe, expect, it } from 'vitest';
@@ -20,13 +21,13 @@ const instance = (lng: 'en' | 'zh') => {
   return i18n;
 };
 
-const render = (view: AnnotationView, lng: 'en' | 'zh' = 'en') =>
+const render = (view: AnnotationView, lng: 'en' | 'zh' = 'en', body: ReactNode = <p>Body</p>) =>
   renderToStaticMarkup(
     <I18nextProvider i18n={instance(lng)}>
       <AnnotationMessage
         messageId="msg_01J8XK2Q4W"
         view={view}
-        body={<p>Body</p>}
+        body={body}
         attachments={<img alt="" src="/api/media/med_9a71c33f8b2e" />}
         time={<span>12:04</span>}
         rowClass={(extra) => `flex w-full ${extra}`}
@@ -95,5 +96,18 @@ describe('AnnotationMessage', () => {
 
   it('carries the deep-link row dressing so an annotation can be jumped to', () => {
     expect(render(USER)).toContain('data-message-id="msg_01J8XK2Q4W"');
+  });
+
+  // The contract's empty case: authored text "may be empty, in which case the
+  // card renders title + quote + attachments alone". The transcript withholds its
+  // em-dash stand-in for exactly this row (drawsEmptyBodyPlaceholder), so what
+  // arrives here is a null body — and a pure highlight must still read as a
+  // complete annotation rather than as an empty bubble.
+  it('reads complete with no authored text at all', () => {
+    const html = render({ ...USER, quote: 'Model Hub' }, 'en', null);
+    expect(html).toContain('User annotation');
+    expect(html).toContain('Model Hub');
+    expect(html).toContain('/api/media/med_9a71c33f8b2e');
+    expect(html).not.toContain('—');
   });
 });

--- a/ui/src/components/workbench/AnnotationMessage.tsx
+++ b/ui/src/components/workbench/AnnotationMessage.tsx
@@ -1,0 +1,118 @@
+import { Check, MapPin, MessageSquareQuote } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import clsx from 'clsx';
+
+import { annotationTitleKey, type AnnotationView } from '../../lib/annotationView';
+import { AGENT_BUBBLE, USER_BUBBLE } from './chatBubble';
+import { RoleAvatar } from './RoleAvatar';
+
+// A Show Page annotation, in chat. Both directions are the same message type —
+// the user annotating the page, and the agent marking it back — and the card's
+// title is what says which. Design: design.pen m31JWV (states) + TxFKk (anatomy
+// and rules); the rule numbers cited below are that frame's.
+//
+// The card is a row component, not a page fragment: it takes the body,
+// attachment and timestamp nodes the transcript already builds and only adds
+// what is specific to an annotation (title, anchor quote, resolved marker), so
+// it cannot drift from the surrounding bubbles.
+
+type AnnotationMessageProps = {
+  messageId: string;
+  view: AnnotationView;
+  /** The transcript's own Markdown body node. */
+  body: React.ReactNode;
+  /** The transcript's own attachment renderer — rule 06: the screenshot reuses
+   *  the existing thumbnail, viewer modal and proxy-url guard, with no second
+   *  image element anywhere in the codebase. */
+  attachments: React.ReactNode;
+  /** The transcript's own hover-revealed timestamp — rule 03. */
+  time: React.ReactNode;
+  bodyStyle?: React.CSSProperties;
+  /** The transcript's row dressing (deep-link highlight); the card supplies only
+   *  the alignment, because the alignment is the part that depends on direction. */
+  rowClass: (extra: string) => string;
+};
+
+export const AnnotationMessage: React.FC<AnnotationMessageProps> = ({
+  messageId,
+  view,
+  body,
+  attachments,
+  time,
+  bodyStyle,
+  rowClass,
+}) => {
+  const { t } = useTranslation();
+  const fromUser = view.direction === 'user';
+
+  // Rule 02: two title values, and the action never enters the title. A resolved
+  // agent mark is still titled "Agent 批注" — the marker below says it is done.
+  const label = (
+    <span className={clsx('text-[11px] font-medium', fromUser ? 'text-cyan' : 'text-mint')}>
+      {t(annotationTitleKey(view.direction))}
+    </span>
+  );
+  const avatar = (
+    <RoleAvatar tone={fromUser ? 'cyan' : 'mint'}>
+      <MessageSquareQuote />
+    </RoleAvatar>
+  );
+
+  // Rule 04: drawn only when the anchor carries copy a reader can find on the
+  // page. When it does not, nothing is drawn — a selector, an anchor kind, an
+  // event id or a screenshot path is a locator the reader cannot use, so none of
+  // them stands in for the quote (rule 05).
+  const quoteNode = view.quote ? (
+    <div className="mb-[9px] flex w-full items-start gap-[7px] border-l-2 border-foreground/25 py-px pl-[9px]">
+      <span className="pt-[3px]">
+        <MapPin className="size-[11px] shrink-0 text-muted" />
+      </span>
+      <span className="min-w-0 break-words text-[12px] leading-[1.5] text-muted">{view.quote}</span>
+    </div>
+  ) : null;
+
+  // Rule 07.
+  const resolvedNode = view.resolved ? (
+    <div className="mt-[9px] flex w-full">
+      <span className="inline-flex items-center gap-1 rounded-full border border-mint/35 bg-mint-soft px-[9px] py-[3px] text-[10.5px] font-semibold text-mint">
+        <Check className="size-[11px] shrink-0" />
+        {t('chat.annotation.resolved')}
+      </span>
+    </div>
+  ) : null;
+
+  return (
+    <div data-message-id={messageId} className={rowClass(fromUser ? 'justify-end' : 'justify-start')}>
+      <div
+        className={clsx(
+          'group/message flex max-w-[min(92%,860px)] flex-col gap-1',
+          fromUser ? 'items-end' : 'items-start',
+        )}
+      >
+        {/* Mirrored head: the avatar always sits on the outer edge, so the two
+            directions read as a matched pair across the column. */}
+        <div className="flex items-center gap-2 px-0.5">
+          {fromUser ? (
+            <>
+              {label}
+              {avatar}
+            </>
+          ) : (
+            <>
+              {avatar}
+              {label}
+            </>
+          )}
+        </div>
+        {/* Rule 03: the bubble is the column's existing bubble, not a new shape. */}
+        <div className={fromUser ? USER_BUBBLE : AGENT_BUBBLE} style={bodyStyle}>
+          {quoteNode}
+          {body}
+          {attachments}
+          {resolvedNode}
+        </div>
+        {time}
+      </div>
+    </div>
+  );
+};

--- a/ui/src/components/workbench/ChatPage.tsx
+++ b/ui/src/components/workbench/ChatPage.tsx
@@ -14,7 +14,7 @@ import { apiFetch } from '../../lib/apiFetch';
 import { normalizeChatMessageFontSize } from '../../lib/chatDisplay';
 import { annotationTitleKey, readAnnotationView } from '../../lib/annotationView';
 import { isTerminalAgentMessage, isTranscriptMessage } from '../../lib/chatMessageTypes';
-import { chatRowKind } from '../../lib/chatRowKind';
+import { chatRowKind, isAgentAuthored } from '../../lib/chatRowKind';
 import { useIosKeyboardInset } from '../../lib/useIosKeyboardInset';
 import { isProxyMediaUrl } from '../../lib/mediaProxy';
 import { localPath, type ShowPageLinkInfo } from '../../lib/showPageLinks';
@@ -3095,6 +3095,10 @@ const MessageRow = memo(function MessageRow({ message, session, messageFontSize,
   const row = chatRowKind(message);
   const isNotify = row.kind === 'notify';
   const isAgent = row.kind === 'agent';
+  // ...and, separately, who wrote it. Only the agent's own words may carry the
+  // agent-authored Markdown affordances, and its reverse annotation is still its
+  // own words even though a different card draws it.
+  const agentAuthored = isAgentAuthored(message);
   const isHarness = row.kind === 'harness';
   const isUser = row.kind === 'user';
   // Trigger-message provenance click-through (contract A9a/A9b): agent-callback
@@ -3135,7 +3139,7 @@ const MessageRow = memo(function MessageRow({ message, session, messageFontSize,
   // THIS message's ``content`` (parsed server-side; the chosen answer recorded on
   // the same message is the single source of truth for the lock — no correlating
   // a separate user reply). IM channels render native buttons from the same parse.
-  const qr = isAgent
+  const qr = agentAuthored
     ? (message.content as { quick_replies?: unknown; quick_reply_chosen?: unknown } | null)
     : null;
   const quickReplyOptions = Array.isArray(qr?.quick_replies)
@@ -3166,9 +3170,11 @@ const MessageRow = memo(function MessageRow({ message, session, messageFontSize,
       // keeps their line breaks exactly as the ordinary user bubble does.
       softBreaks={isUser || isHarness || (row.kind === 'annotation' && row.annotation.direction === 'user')}
       references={(message.content as { references?: MentionReference[] } | null)?.references}
-      // Only the agent's own replies may render `$<NAME>` as an interactive secret-input card;
-      // user/harness/system bubbles with the marker stay plain text (no false "agent asked" card).
-      secretRequests={isAgent}
+      // Only the agent's own words may render `$<NAME>` as an interactive secret-input card;
+      // user/harness/system bubbles with the marker stay plain text (no false "agent asked"
+      // card). Keyed to authorship, not to the card family, so the agent's reverse annotation
+      // keeps the card it had before that row had its own type.
+      secretRequests={agentAuthored}
       className="vr-markdown--inherit-size"
     />
   ) : messageAttachments.length === 0 ? (

--- a/ui/src/components/workbench/ChatPage.tsx
+++ b/ui/src/components/workbench/ChatPage.tsx
@@ -1,7 +1,7 @@
 import { Fragment, memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link, useLocation, useNavigate, useParams, useSearchParams } from 'react-router-dom';
-import { Activity, ArrowLeft, ArrowRight, ArrowUpRight, Bell, Bot, ChevronDown, ChevronRight, Clock, Eye, GitFork, Info, Loader2, MessageSquare, MessageSquareQuote, Pencil, Presentation, Terminal, Undo2, UploadCloud, X } from 'lucide-react';
+import { Activity, ArrowLeft, ArrowRight, ArrowUpRight, Bell, Bot, ChevronDown, ChevronRight, Clock, Eye, GitFork, Image as ImageIcon, Info, Loader2, MapPin, MessageSquare, MessageSquareQuote, Pencil, Presentation, Terminal, Undo2, UploadCloud, X } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
 import clsx from 'clsx';
 
@@ -12,7 +12,7 @@ import { useRegisterComposerTarget, type ComposerInsertTarget } from '../../cont
 import type { SessionActivityItemKind, SessionActivityState, SessionRuntimeState, VaultRequest, VibeAgentBrief, WorkbenchMessage, WorkbenchSession } from '../../context/ApiContext';
 import { apiFetch } from '../../lib/apiFetch';
 import { normalizeChatMessageFontSize } from '../../lib/chatDisplay';
-import { annotationTitleKey, readAnnotationView } from '../../lib/annotationView';
+import { annotationStandIn, annotationTitleKey, readAnnotationView } from '../../lib/annotationView';
 import { isTerminalAgentMessage, isTranscriptMessage } from '../../lib/chatMessageTypes';
 import { chatRowKind, drawsEmptyBodyPlaceholder, isAgentAuthored } from '../../lib/chatRowKind';
 import { useIosKeyboardInset } from '../../lib/useIosKeyboardInset';
@@ -1974,7 +1974,8 @@ export const QueueRow: React.FC<{
   //  - recall can't carry uploaded files (content.attachments), so an attachment
   //    row would silently lose them. Both can still be deleted or left to send.
   const att = (item.content as Record<string, unknown> | undefined)?.attachments;
-  const canRecall = item.source === 'user' && !(Array.isArray(att) && att.length > 0);
+  const hasAttachments = Array.isArray(att) && att.length > 0;
+  const canRecall = item.source === 'user' && !hasAttachments;
   // Rule 08: a queued annotation belongs to the strip and nowhere else, so the
   // strip is where it has to be identifiable. Same title as the card it will
   // become, so the row the user is looking at and the bubble that replaces it
@@ -1986,6 +1987,10 @@ export const QueueRow: React.FC<{
   // classify it as anything but an annotation. The display record is on the row
   // from the moment it is queued; only its type changes when the flush lands.
   const annotationView = readAnnotationView(item.content);
+  // ``item.text`` is the annotator's authored words and nothing else, by
+  // contract — so an annotation that is only a highlight or only a boxed region
+  // has none, and would sit here as a title, a separator, and empty space.
+  const standIn = annotationView && annotationStandIn(annotationView, item.text, hasAttachments);
   return (
     <div className="flex items-start gap-2 rounded-lg bg-surface-2 px-2.5 py-1.5">
       <div
@@ -2010,10 +2015,24 @@ export const QueueRow: React.FC<{
               <MessageSquareQuote className="size-[11px] shrink-0" />
               {t(annotationTitleKey(annotationView.direction))}
             </span>
-            <span className="mr-2 text-[11px] text-muted">·</span>
+            {(item.text || standIn) && <span className="mr-2 text-[11px] text-muted">·</span>}
           </>
         )}
         {item.text}
+        {standIn?.kind === 'quote' && (
+          // The card's own quote treatment (pin + muted), flattened to the one
+          // line the strip has room for.
+          <span className="inline-flex items-center gap-[5px] align-middle text-muted">
+            <MapPin className="size-[11px] shrink-0" />
+            {standIn.quote}
+          </span>
+        )}
+        {standIn?.kind === 'screenshot' && (
+          <span className="inline-flex items-center gap-[5px] align-middle text-muted">
+            <ImageIcon className="size-[11px] shrink-0" />
+            {t('chat.annotation.screenshot')}
+          </span>
+        )}
       </div>
       {canRecall && (
         <Button

--- a/ui/src/components/workbench/ChatPage.tsx
+++ b/ui/src/components/workbench/ChatPage.tsx
@@ -1,7 +1,7 @@
 import { Fragment, memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link, useLocation, useNavigate, useParams, useSearchParams } from 'react-router-dom';
-import { Activity, ArrowLeft, ArrowRight, ArrowUpRight, Bell, Bot, ChevronDown, ChevronRight, Clock, Eye, GitFork, Info, Loader2, MessageSquare, Pencil, Presentation, Terminal, Undo2, UploadCloud, X } from 'lucide-react';
+import { Activity, ArrowLeft, ArrowRight, ArrowUpRight, Bell, Bot, ChevronDown, ChevronRight, Clock, Eye, GitFork, Info, Loader2, MessageSquare, MessageSquareQuote, Pencil, Presentation, Terminal, Undo2, UploadCloud, X } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
 import clsx from 'clsx';
 
@@ -12,8 +12,9 @@ import { useRegisterComposerTarget, type ComposerInsertTarget } from '../../cont
 import type { SessionActivityItemKind, SessionActivityState, SessionRuntimeState, VaultRequest, VibeAgentBrief, WorkbenchMessage, WorkbenchSession } from '../../context/ApiContext';
 import { apiFetch } from '../../lib/apiFetch';
 import { normalizeChatMessageFontSize } from '../../lib/chatDisplay';
-import { isNotifyMessageType, isTerminalAgentMessage } from '../../lib/chatMessageTypes';
-import { specFor } from '../../lib/messageTypes';
+import { annotationTitleKey, readAnnotationView } from '../../lib/annotationView';
+import { isTerminalAgentMessage, isTranscriptMessage } from '../../lib/chatMessageTypes';
+import { chatRowKind } from '../../lib/chatRowKind';
 import { useIosKeyboardInset } from '../../lib/useIosKeyboardInset';
 import { isProxyMediaUrl } from '../../lib/mediaProxy';
 import { localPath, type ShowPageLinkInfo } from '../../lib/showPageLinks';
@@ -27,6 +28,9 @@ import {
   sortBackgroundActivities,
 } from '../../lib/backgroundActivity';
 import { chatTriggerLink, harnessChipLabelKey, isUnresolvedAgentCallback } from '../../lib/chatTrigger';
+import { AnnotationMessage } from './AnnotationMessage';
+import { AGENT_BUBBLE, SYSTEM_BUBBLE, USER_BUBBLE } from './chatBubble';
+import { RoleAvatar } from './RoleAvatar';
 import { useFileDrop } from '../../lib/useFileDrop';
 import { quoteText } from '../../lib/quoteText';
 import { mergeById, insertMessageOrdered } from '../../lib/transcriptOrder';
@@ -102,17 +106,6 @@ const emptyRuntimeState = (): SessionRuntimeState => ({
   pending_activity_output_count: 0,
   connection: 'unknown',
 });
-
-// The transcript-visible message types — the shared catalog's ``transcript``
-// property, the same declaration the server filter on
-// ``GET /api/sessions/{id}/messages`` reads, so the live ``message.new`` feed
-// appends the same rows the initial load shows (assistant / tool_call are process
-// log). The ``show_page`` clause is NOT a message type: it is a metadata side
-// channel standing in for a Show-Page message type the server does not emit yet,
-// and it stays until the annotation rollout gives those rows a real type.
-const isTranscriptMessage = (msg: WorkbenchMessage): boolean =>
-  specFor(msg.type).transcript ||
-  (msg.metadata as { source?: string } | null)?.source === 'show_page';
 
 // Bounded retained transcript window: cap how many message rows stay mounted so a
 // long streaming session (or a deep upward scroll) doesn't keep thousands of full
@@ -881,7 +874,12 @@ export const ChatPage: React.FC = () => {
       setShowToolCalls(bootstrap.config?.ui?.show_tool_calls !== false);
       // Merge (not replace) so a row that arrived over the stream during the
       // load isn't clobbered; the session-change reset keeps prior sessions out.
-      setMessages((prev) => mergeById(bootstrap.messages, prev));
+      // Filtered like every other entry point: the transcript decides what it
+      // shows by type, whatever a payload happens to contain. First paint is a
+      // visibility decision too — unfiltered, a queued annotation opened the chat
+      // as a delivered bubble *and* sat in the queue strip, the exact double
+      // render the live path already rejects.
+      setMessages((prev) => mergeById(bootstrap.messages.filter(isTranscriptMessage), prev));
       setOlderCursor(bootstrap.next_before_id ?? null);
       setHistoricalWindow(false);
       // Chat Activity chips for past turns: resync the per-turn summary (row text
@@ -986,11 +984,11 @@ export const ChatPage: React.FC = () => {
         // Agent Activity rows (assistant / tool_call) only reach the browser when
         // the toggle streams them (message_mirror). Route them to the running
         // buffer — never the transcript. ``isTranscriptMessage`` already excludes
-        // them, so the feature-off path is unchanged. Show-Page marks are ALSO
-        // ``assistant`` rows but are transcript-visible (isTranscriptMessage keeps
-        // them) — let them fall through so they render in the chat, not the panel.
-        const isShowPage = (msg.metadata as { source?: string } | null)?.source === 'show_page';
-        if (showAgentActivityRef.current && isActivityMessageType(msg.type) && !isShowPage) {
+        // them, so the feature-off path is unchanged. A reverse Show Page mark is
+        // no longer an ``assistant`` row — it arrives typed ``annotation`` — so it
+        // cannot match here and needs no metadata-keyed exemption to escape the
+        // activity buffer.
+        if (showAgentActivityRef.current && isActivityMessageType(msg.type)) {
           if (!historicalWindowRef.current) ingestActivityRow(msg);
           return;
         }
@@ -1956,7 +1954,7 @@ export const ChatPage: React.FC = () => {
 // One queued message. Its text is a single truncated line by default; clicking
 // it expands to the full wrapped text (and clicking again collapses it) so a
 // long queued prompt can be read without sending it.
-const QueueRow: React.FC<{
+export const QueueRow: React.FC<{
   item: WorkbenchMessage;
   onRemove: (id: string) => void;
   onRecall: (item: WorkbenchMessage) => void;
@@ -1977,6 +1975,17 @@ const QueueRow: React.FC<{
   //    row would silently lose them. Both can still be deleted or left to send.
   const att = (item.content as Record<string, unknown> | undefined)?.attachments;
   const canRecall = item.source === 'user' && !(Array.isArray(att) && att.length > 0);
+  // Rule 08: a queued annotation belongs to the strip and nowhere else, so the
+  // strip is where it has to be identifiable. Same title as the card it will
+  // become, so the row the user is looking at and the bubble that replaces it
+  // read as one thing rather than two.
+  //
+  // Read straight from the content rather than through ``chatRowKind``: this
+  // row's type is ``queued`` by definition — that is precisely why it is here
+  // and not in the transcript — so the transcript's mapper would (correctly)
+  // classify it as anything but an annotation. The display record is on the row
+  // from the moment it is queued; only its type changes when the flush lands.
+  const annotationView = readAnnotationView(item.content);
   return (
     <div className="flex items-start gap-2 rounded-lg bg-surface-2 px-2.5 py-1.5">
       <div
@@ -1995,6 +2004,15 @@ const QueueRow: React.FC<{
           expanded ? 'whitespace-pre-wrap break-words' : 'truncate',
         )}
       >
+        {annotationView && (
+          <>
+            <span className="mr-2 inline-flex items-center gap-[5px] align-middle text-[10.5px] font-medium text-cyan">
+              <MessageSquareQuote className="size-[11px] shrink-0" />
+              {t(annotationTitleKey(annotationView.direction))}
+            </span>
+            <span className="mr-2 text-[11px] text-muted">·</span>
+          </>
+        )}
         {item.text}
       </div>
       {canRecall && (
@@ -3014,22 +3032,6 @@ const ForkSourceBanner: React.FC<{ sourceSessionId: string; sourceTitle: string 
   );
 };
 
-
-// Small role avatar — a tinted rounded square with a lucide glyph, shown on the
-// header line above a left-aligned message bubble (IM layout). Kept on its own
-// line with the name so it never eats into the bubble's usable width.
-const TONE_AVATAR: Record<'mint' | 'cyan' | 'gold' | 'muted', string> = {
-  mint: 'border-mint/30 bg-mint/[0.13] text-mint',
-  cyan: 'border-cyan/30 bg-cyan/[0.13] text-cyan',
-  gold: 'border-gold/30 bg-gold/[0.13] text-gold',
-  muted: 'border-border-strong bg-foreground/[0.06] text-muted',
-};
-const RoleAvatar: React.FC<{ tone: keyof typeof TONE_AVATAR; children: React.ReactNode }> = ({ tone, children }) => (
-  <span className={clsx('flex size-6 shrink-0 items-center justify-center rounded-lg border [&_svg]:size-3.5', TONE_AVATAR[tone])}>
-    {children}
-  </span>
-);
-
 // Shown while a turn is in flight but the reply hasn't landed yet — a left
 // agent bubble with three dots that fade in sequence (``.vr-typing-dot``
 // keyframes in index.css), so the user gets immediate feedback a reply is
@@ -3087,15 +3089,14 @@ const MessageRow = memo(function MessageRow({ message, session, messageFontSize,
   // Each branch composes this onto its own ``justify-*`` so alignment is kept.
   const rowClass = (extra: string) => clsx('flex w-full', extra, highlighted && 'msg-highlight');
 
-  // Runtime notifications and legacy error rows are compact status pills,
-  // not Agent-authored answers.
-  const isNotify = isNotifyMessageType(message.type);
-  const isAgent = !isNotify && message.author === 'agent';
-  const isSystem = !isNotify && message.author === 'system';
-  // A harness-origin row is turn input the human didn't type (scheduled task /
-  // watch / webhook); collapsed by default so it doesn't dominate.
-  const isHarness = !isNotify && !isAgent && !isSystem && message.source === 'harness';
-  const isUser = !isNotify && !isAgent && !isSystem && !isHarness;
+  // Which card family draws this row — one decision, made once, in a pure mapper
+  // (``chatRowKind``) so the ordering between the families is testable without
+  // mounting the page. Everything below reads the answer; nothing re-derives it.
+  const row = chatRowKind(message);
+  const isNotify = row.kind === 'notify';
+  const isAgent = row.kind === 'agent';
+  const isHarness = row.kind === 'harness';
+  const isUser = row.kind === 'user';
   // Trigger-message provenance click-through (contract A9a/A9b): agent-callback
   // rows link to the source session's chat; task/watch rows to the Harness view.
   const triggerLink = isHarness ? chatTriggerLink(message, t('chat.source.agentFallback')) : null;
@@ -3161,7 +3162,9 @@ const MessageRow = memo(function MessageRow({ message, session, messageFontSize,
   const bodyNode = message.text ? (
     <Markdown
       content={message.text}
-      softBreaks={isUser || isHarness}
+      // An annotation the user typed is the user's own words (rule 05), so it
+      // keeps their line breaks exactly as the ordinary user bubble does.
+      softBreaks={isUser || isHarness || (row.kind === 'annotation' && row.annotation.direction === 'user')}
       references={(message.content as { references?: MentionReference[] } | null)?.references}
       // Only the agent's own replies may render `$<NAME>` as an interactive secret-input card;
       // user/harness/system bubbles with the marker stay plain text (no false "agent asked" card).
@@ -3183,6 +3186,21 @@ const MessageRow = memo(function MessageRow({ message, session, messageFontSize,
       {formatLocalDateTime(message.created_at)}
     </span>
   );
+
+  // ----- Annotation: the Show Page card, sided by direction (design.pen m31JWV)
+  if (row.kind === 'annotation') {
+    return (
+      <AnnotationMessage
+        messageId={message.id}
+        view={row.annotation}
+        body={bodyNode}
+        attachments={attachmentsNode}
+        time={time}
+        bodyStyle={messageFontStyle}
+        rowClass={rowClass}
+      />
+    );
+  }
 
   // ----- Notify: compact gold pill, left-aligned (a status marker) -----
   if (isNotify) {
@@ -3207,10 +3225,7 @@ const MessageRow = memo(function MessageRow({ message, session, messageFontSize,
     return (
       <div data-message-id={message.id} className={rowClass('justify-end')}>
         <div className="group/message flex max-w-[min(92%,860px)] flex-col items-end gap-1">
-          <div
-            className="w-fit min-w-0 max-w-full rounded-2xl rounded-tr-md border border-border-strong bg-foreground/[0.06] px-3.5 py-2.5 leading-relaxed [&_pre]:max-w-full [&_pre]:overflow-x-auto [&_table]:w-full"
-            style={messageFontStyle}
-          >
+          <div className={USER_BUBBLE} style={messageFontStyle}>
             {bodyNode}
             {attachmentsNode}
           </div>
@@ -3295,13 +3310,7 @@ const MessageRow = memo(function MessageRow({ message, session, messageFontSize,
           <RoleAvatar tone={isAgent ? 'mint' : 'muted'}>{isAgent ? <Bot /> : <Info />}</RoleAvatar>
           {name && <span className="text-[11px] font-medium text-muted">{name}</span>}
         </div>
-        <div
-          className={clsx(
-            'w-fit min-w-0 max-w-full rounded-2xl rounded-tl-md border px-3.5 py-2.5 leading-relaxed [&_pre]:max-w-full [&_pre]:overflow-x-auto [&_table]:w-full',
-            isAgent ? 'border-mint/25 bg-mint/[0.09]' : 'border-border bg-foreground/[0.03]',
-          )}
-          style={messageFontStyle}
-        >
+        <div className={isAgent ? AGENT_BUBBLE : SYSTEM_BUBBLE} style={messageFontStyle}>
           {bodyNode}
           {attachmentsNode}
         </div>

--- a/ui/src/components/workbench/ChatPage.tsx
+++ b/ui/src/components/workbench/ChatPage.tsx
@@ -14,7 +14,7 @@ import { apiFetch } from '../../lib/apiFetch';
 import { normalizeChatMessageFontSize } from '../../lib/chatDisplay';
 import { annotationTitleKey, readAnnotationView } from '../../lib/annotationView';
 import { isTerminalAgentMessage, isTranscriptMessage } from '../../lib/chatMessageTypes';
-import { chatRowKind, isAgentAuthored } from '../../lib/chatRowKind';
+import { chatRowKind, drawsEmptyBodyPlaceholder, isAgentAuthored } from '../../lib/chatRowKind';
 import { useIosKeyboardInset } from '../../lib/useIosKeyboardInset';
 import { isProxyMediaUrl } from '../../lib/mediaProxy';
 import { localPath, type ShowPageLinkInfo } from '../../lib/showPageLinks';
@@ -3177,7 +3177,7 @@ const MessageRow = memo(function MessageRow({ message, session, messageFontSize,
       secretRequests={agentAuthored}
       className="vr-markdown--inherit-size"
     />
-  ) : messageAttachments.length === 0 ? (
+  ) : drawsEmptyBodyPlaceholder(row, messageAttachments.length > 0) ? (
     <div className="text-[13px] text-muted">—</div>
   ) : null;
 

--- a/ui/src/components/workbench/ChatQueueRow.test.tsx
+++ b/ui/src/components/workbench/ChatQueueRow.test.tsx
@@ -79,3 +79,78 @@ describe('QueueRow — a queued annotation in the strip (rule 08)', () => {
     expect(html).toContain('Agent annotation');
   });
 });
+
+// ``text`` is the annotator's own words and nothing else, so an annotation is
+// allowed to arrive with none: a pure highlight, or a boxed region submitted
+// without a comment. The strip is the ONLY place a queued row is visible, so
+// "no words" must not mean "no row".
+describe('QueueRow — a queued annotation nobody wrote words for', () => {
+  const wordless = (over: Partial<WorkbenchMessage> = {}) => queued({ text: '', ...over });
+  const withAnnotation = (annotation: Record<string, unknown>, attachments?: unknown[]) =>
+    ({ annotation, ...(attachments ? { attachments } : {}) }) as WorkbenchMessage['content'];
+  const screenshot = [{ url: '/api/media/med_9a71c33f8b2e', name: 'annotation-region.png', kind: 'image' }];
+
+  it('shows the boxed region a screenshot-only annotation is made of', () => {
+    const html = renderQueued(
+      wordless({ content: withAnnotation({ direction: 'user', action: 'created' }, screenshot) }),
+    );
+    expect(html).toContain('User annotation');
+    expect(html).toContain('Screenshot');
+  });
+
+  it('shows the highlight an anchor-only annotation is made of', () => {
+    const html = renderQueued(
+      wordless({ content: withAnnotation({ direction: 'user', action: 'created', quote: 'Model Hub' }) }),
+    );
+    expect(html).toContain('User annotation');
+    expect(html).toContain('Model Hub');
+  });
+
+  // Both present: the strip has one line and the card puts the quote above the
+  // screenshot, so the line takes the quote.
+  it('takes the quote over the screenshot, and the words over both', () => {
+    const both = withAnnotation({ direction: 'user', action: 'created', quote: 'Model Hub' }, screenshot);
+    const silent = renderQueued(wordless({ content: both }));
+    expect(silent).toContain('Model Hub');
+    expect(silent).not.toContain('Screenshot');
+
+    const spoken = renderQueued(queued({ text: 'The spacing is off', content: both }));
+    expect(spoken).toContain('The spacing is off');
+    expect(spoken).not.toContain('Model Hub');
+    expect(spoken).not.toContain('Screenshot');
+  });
+
+  // Neither a quote nor a region: nothing about the row can be shown that the
+  // reader could act on, so the title stands alone — without the separator that
+  // would promise something after it.
+  it('leaves no dangling separator when the title is all there is', () => {
+    const html = renderQueued(wordless({ content: withAnnotation({ direction: 'user', action: 'created' }) }));
+    expect(html).toContain('User annotation');
+    expect(html).not.toContain('·');
+  });
+
+  // Same requirement as the title, one level down: the strip entry and the card
+  // that replaces it on flush must show the reader the same quote, so sending
+  // does not appear to change what was annotated.
+  it('quotes what the card will quote', () => {
+    const view = { direction: 'user' as const, resolved: false, quote: 'Model Hub' };
+    const strip = renderQueued(
+      wordless({ content: withAnnotation({ direction: 'user', action: 'created', quote: view.quote }) }),
+    );
+    const card = wrap(
+      <AnnotationMessage
+        messageId="msg_01J8XK5M8T"
+        view={view}
+        body={null}
+        attachments={null}
+        time={null}
+        rowClass={(extra) => extra}
+      />,
+    );
+
+    for (const html of [strip, card]) {
+      expect(html).toContain('User annotation');
+      expect(html).toContain('Model Hub');
+    }
+  });
+});

--- a/ui/src/components/workbench/ChatQueueRow.test.tsx
+++ b/ui/src/components/workbench/ChatQueueRow.test.tsx
@@ -1,0 +1,81 @@
+import { createInstance } from 'i18next';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { I18nextProvider, initReactI18next } from 'react-i18next';
+import { describe, expect, it } from 'vitest';
+
+import en from '../../i18n/en.json';
+import type { WorkbenchMessage } from '../../context/ApiContext';
+import { AnnotationMessage } from './AnnotationMessage';
+import { QueueRow } from './ChatPage';
+
+const i18n = createInstance();
+void i18n.use(initReactI18next).init({
+  lng: 'en',
+  fallbackLng: 'en',
+  resources: { en: { translation: en } },
+  interpolation: { escapeValue: false },
+});
+
+const wrap = (ui: React.ReactElement) =>
+  renderToStaticMarkup(<I18nextProvider i18n={i18n}>{ui}</I18nextProvider>);
+
+// A queued forward annotation, exactly as the contract freezes it
+// (docs/plans/show-annotation-message-type/examples.json, msg_01J8XK5M8T): the
+// display record is already on the row; only ``type`` says it has not been sent.
+const queued = (over: Partial<WorkbenchMessage> = {}): WorkbenchMessage =>
+  ({
+    id: 'msg_01J8XK5M8T',
+    type: 'queued',
+    author: 'harness',
+    source: 'harness',
+    author_name: 'show_annotation',
+    text: 'This chart needs a legend',
+    content: { annotation: { direction: 'user', action: 'created' } },
+    metadata: { source: 'show_page' },
+    created_at: '2026-07-27T04:04:00Z',
+    ...over,
+  }) as WorkbenchMessage;
+
+const renderQueued = (item: WorkbenchMessage) =>
+  wrap(<QueueRow item={item} onRemove={() => undefined} onRecall={() => undefined} />);
+
+describe('QueueRow — a queued annotation in the strip (rule 08)', () => {
+  it('names a queued annotation, and leaves an ordinary queued prompt unlabelled', () => {
+    expect(renderQueued(queued())).toContain('User annotation');
+    expect(renderQueued(queued())).toContain('This chart needs a legend');
+
+    const plain = renderQueued(queued({ content: {} as WorkbenchMessage['content'] }));
+    expect(plain).not.toContain('User annotation');
+    expect(plain).not.toContain('Agent annotation');
+  });
+
+  // The point of the strip label. The row the user is looking at now and the
+  // bubble that replaces it when the queue flushes must name the same thing the
+  // same way — otherwise sending appears to turn one thing into another. Both
+  // sides are rendered here rather than compared by key, so a divergence in
+  // either renderer fails this.
+  it('uses the same title the card will use once the queue flushes', () => {
+    const strip = renderQueued(queued());
+    const card = wrap(
+      <AnnotationMessage
+        messageId="msg_01J8XK5M8T"
+        view={{ direction: 'user', resolved: false }}
+        body={null}
+        attachments={null}
+        time={null}
+        rowClass={(extra) => extra}
+      />,
+    );
+    const title = (html: string) => html.match(/(User|Agent) annotation/)?.[0];
+
+    expect(title(strip)).toBeDefined();
+    expect(title(strip)).toBe(title(card));
+  });
+
+  it('names a queued reverse mark with the agent title', () => {
+    const html = renderQueued(
+      queued({ content: { annotation: { direction: 'agent', action: 'created' } } as WorkbenchMessage['content'] }),
+    );
+    expect(html).toContain('Agent annotation');
+  });
+});

--- a/ui/src/components/workbench/RoleAvatar.tsx
+++ b/ui/src/components/workbench/RoleAvatar.tsx
@@ -1,0 +1,28 @@
+import clsx from 'clsx';
+
+// The tone-tinted 24px chip that leads every message head in Chat — agent,
+// system, harness and annotation all draw the same geometry, so a new row kind
+// inherits exactly the avatar its neighbours already have (design.pen m31JWV
+// draws the Claude head and the annotation head identically).
+//
+// Lives in its own module rather than inside ChatPage so a row component can
+// reuse it without importing the whole page back.
+const TONE_AVATAR: Record<'mint' | 'cyan' | 'gold' | 'muted', string> = {
+  mint: 'border-mint/30 bg-mint/[0.13] text-mint',
+  cyan: 'border-cyan/30 bg-cyan/[0.13] text-cyan',
+  gold: 'border-gold/30 bg-gold/[0.13] text-gold',
+  muted: 'border-border-strong bg-foreground/[0.06] text-muted',
+};
+
+export type RoleAvatarTone = keyof typeof TONE_AVATAR;
+
+export const RoleAvatar: React.FC<{ tone: RoleAvatarTone; children: React.ReactNode }> = ({ tone, children }) => (
+  <span
+    className={clsx(
+      'flex size-6 shrink-0 items-center justify-center rounded-lg border [&_svg]:size-3.5',
+      TONE_AVATAR[tone],
+    )}
+  >
+    {children}
+  </span>
+);

--- a/ui/src/components/workbench/chatBubble.ts
+++ b/ui/src/components/workbench/chatBubble.ts
@@ -1,0 +1,27 @@
+// The two message-bubble shapes the chat column draws, in one place.
+//
+// design.pen TxFKk rule 03 says the annotation card's bubble IS the existing
+// chat bubble — same width rule, same radius, same timestamp — because an
+// annotation is a message, not a widget, and a second bubble shape in the same
+// column reads as a different product. The frame backs that literally: its
+// annotation bubbles are byte-identical to the ordinary user / Claude bubbles
+// drawn beside them.
+//
+// Naming these makes that rule a fact instead of a comment: the card cannot
+// drift from the rows around it, because there is nothing to drift from.
+//
+// Shape is shared; only the corner notch (which points back at the head above
+// it) and the tint depend on which side the row takes.
+const BUBBLE_BASE =
+  'w-fit min-w-0 max-w-full rounded-2xl border px-3.5 py-2.5 leading-relaxed [&_pre]:max-w-full [&_pre]:overflow-x-auto [&_table]:w-full';
+const BUBBLE_RIGHT = `${BUBBLE_BASE} rounded-tr-md`;
+const BUBBLE_LEFT = `${BUBBLE_BASE} rounded-tl-md`;
+
+/** Right-aligned neutral bubble — the user's own words. */
+export const USER_BUBBLE = `${BUBBLE_RIGHT} border-border-strong bg-foreground/[0.06]`;
+
+/** Left-aligned mint bubble — the agent's own words. */
+export const AGENT_BUBBLE = `${BUBBLE_LEFT} border-mint/25 bg-mint/[0.09]`;
+
+/** Left-aligned neutral bubble — a system row, quieter than the agent's. */
+export const SYSTEM_BUBBLE = `${BUBBLE_LEFT} border-border bg-foreground/[0.03]`;

--- a/ui/src/components/workbench/search/SearchResultRow.test.ts
+++ b/ui/src/components/workbench/search/SearchResultRow.test.ts
@@ -13,4 +13,22 @@ describe('messageSearchRole', () => {
     expect(messageSearchRole({ author: 'user', source: 'user', type: 'user' })).toBe('you');
     expect(messageSearchRole({ author: 'agent', source: 'agent', type: 'result' })).toBe('agent');
   });
+
+  // ``annotation`` is the first type that carries both directions, so it is the
+  // first type whose ``inputAuthors`` cannot stand in for who wrote the row.
+  // Rows are the frozen contract shapes: forward is harness-authored, reverse is
+  // agent-authored with no source.
+  it('attributes an annotation by its author, not by the type accepting harness input', () => {
+    expect(
+      messageSearchRole({ author: 'harness', source: 'harness', type: 'annotation' }),
+    ).toBe('automated');
+    expect(messageSearchRole({ author: 'agent', source: null, type: 'annotation' })).toBe('agent');
+  });
+
+  // The catalog still decides a row whose author names nobody the mapping knows,
+  // so a future harness-input type inherits the automated treatment for free.
+  it('falls back to the catalog input-turn identity for an unknown author', () => {
+    expect(messageSearchRole({ author: 'system', source: null, type: 'harness' })).toBe('automated');
+    expect(messageSearchRole({ author: 'system', source: null, type: 'result' })).toBe('agent');
+  });
 });

--- a/ui/src/components/workbench/search/SearchResultRow.test.ts
+++ b/ui/src/components/workbench/search/SearchResultRow.test.ts
@@ -14,15 +14,27 @@ describe('messageSearchRole', () => {
     expect(messageSearchRole({ author: 'agent', source: 'agent', type: 'result' })).toBe('agent');
   });
 
-  // ``annotation`` is the first type that carries both directions, so it is the
-  // first type whose ``inputAuthors`` cannot stand in for who wrote the row.
-  // Rows are the frozen contract shapes: forward is harness-authored, reverse is
-  // agent-authored with no source.
-  it('attributes an annotation by its author, not by the type accepting harness input', () => {
-    expect(
-      messageSearchRole({ author: 'harness', source: 'harness', type: 'annotation' }),
-    ).toBe('automated');
+  // ``annotation`` is the first type that carries both directions, and the rows
+  // below are the frozen contract shapes: a forward annotation — the user's own
+  // words — is harness-authored because it enters as turn input, and a reverse
+  // mark is agent-authored with no source. Neither is automated: nobody
+  // scheduled them, so the harness author must not be read as one here.
+  it('reads an annotation as its direction, not as a harness-authored row', () => {
+    expect(messageSearchRole({ author: 'harness', source: 'harness', type: 'annotation' })).toBe(
+      'you',
+    );
     expect(messageSearchRole({ author: 'agent', source: null, type: 'annotation' })).toBe('agent');
+  });
+
+  // The same author/source pair on any other type is still automated, so the
+  // annotation case is a property of that type and not a hole in the rule.
+  it('keeps a harness-authored row of any other type automated', () => {
+    expect(messageSearchRole({ author: 'harness', source: 'harness', type: 'harness' })).toBe(
+      'automated',
+    );
+    expect(messageSearchRole({ author: 'harness', source: 'harness', type: 'result' })).toBe(
+      'automated',
+    );
   });
 
   // The catalog still decides a row whose author names nobody the mapping knows,

--- a/ui/src/components/workbench/search/messageSearchRole.ts
+++ b/ui/src/components/workbench/search/messageSearchRole.ts
@@ -6,14 +6,14 @@ export type MessageSearchRole = 'you' | 'automated' | 'agent';
 export const messageSearchRole = (
   match: Pick<MessageSearchMatch, 'author' | 'source' | 'type'>,
 ): MessageSearchRole => {
-  // The type test is the catalog's input-turn identity: a type accepted as harness
-  // input (``inputAuthors`` contains ``harness``), not a bare name comparison.
-  if (
-    match.author === 'harness' ||
-    match.source === 'harness' ||
-    specFor(match.type).inputAuthors.includes('harness')
-  ) {
-    return 'automated';
-  }
-  return match.author === 'user' ? 'you' : 'agent';
+  if (match.author === 'harness' || match.source === 'harness') return 'automated';
+  // ``inputAuthors`` is a permission — which authors may submit this type as
+  // input — not a claim about who wrote this row. A type can accept harness
+  // input and still carry rows nobody submitted: an annotation is one type in
+  // two directions, and the reverse one is written by the agent. So a row that
+  // names a known author is attributed to that author, and the catalog's
+  // input-turn identity only decides rows that do not.
+  if (match.author === 'user') return 'you';
+  if (match.author === 'agent') return 'agent';
+  return specFor(match.type).inputAuthors.includes('harness') ? 'automated' : 'agent';
 };

--- a/ui/src/components/workbench/search/messageSearchRole.ts
+++ b/ui/src/components/workbench/search/messageSearchRole.ts
@@ -6,14 +6,21 @@ export type MessageSearchRole = 'you' | 'automated' | 'agent';
 export const messageSearchRole = (
   match: Pick<MessageSearchMatch, 'author' | 'source' | 'type'>,
 ): MessageSearchRole => {
+  // An annotation is one type in two directions, and ``direction`` — the field
+  // that separates them — lives in ``content``, which a search match does not
+  // carry. Inside this type the frozen contract makes ``author`` stand in for it
+  // exactly: a forward annotation is the user's own, submitted as turn input and
+  // therefore recorded as harness-authored; a reverse mark is written by the
+  // agent. So here a harness author does NOT mean automated, which is why the
+  // type is settled before the author rules below rather than inside them.
+  if (match.type === 'annotation') return match.author === 'agent' ? 'agent' : 'you';
+
   if (match.author === 'harness' || match.source === 'harness') return 'automated';
-  // ``inputAuthors`` is a permission — which authors may submit this type as
-  // input — not a claim about who wrote this row. A type can accept harness
-  // input and still carry rows nobody submitted: an annotation is one type in
-  // two directions, and the reverse one is written by the agent. So a row that
-  // names a known author is attributed to that author, and the catalog's
-  // input-turn identity only decides rows that do not.
   if (match.author === 'user') return 'you';
   if (match.author === 'agent') return 'agent';
+  // ``inputAuthors`` is a permission — which authors may submit this type as
+  // input — not a claim about who wrote this row, so it only decides rows whose
+  // author names nobody above. Keeping it means a future harness-input type
+  // inherits the automated treatment without another edit here.
   return specFor(match.type).inputAuthors.includes('harness') ? 'automated' : 'agent';
 };

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -2843,7 +2843,8 @@
     "annotation": {
       "titleUser": "User annotation",
       "titleAgent": "Agent annotation",
-      "resolved": "Resolved"
+      "resolved": "Resolved",
+      "screenshot": "Screenshot"
     },
     "picker": {
       "agent": "Agent",

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -2835,11 +2835,15 @@
       "scheduled": "Scheduled task",
       "watch": "Watch",
       "webhook": "Webhook",
-      "showAnnotation": "Page annotation",
       "showIntent": "Page action",
       "harness": "From agent",
       "from": "From",
       "agentFallback": "agent"
+    },
+    "annotation": {
+      "titleUser": "User annotation",
+      "titleAgent": "Agent annotation",
+      "resolved": "Resolved"
     },
     "picker": {
       "agent": "Agent",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -2835,11 +2835,15 @@
       "scheduled": "定时任务",
       "watch": "Watch 监听",
       "webhook": "Webhook",
-      "showAnnotation": "页面批注",
       "showIntent": "页面操作",
       "harness": "来自 Agent",
       "from": "来自",
       "agentFallback": "智能体"
+    },
+    "annotation": {
+      "titleUser": "用户批注",
+      "titleAgent": "Agent 批注",
+      "resolved": "已处理"
     },
     "picker": {
       "agent": "Agent",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -2843,7 +2843,8 @@
     "annotation": {
       "titleUser": "用户批注",
       "titleAgent": "Agent 批注",
-      "resolved": "已处理"
+      "resolved": "已处理",
+      "screenshot": "截图"
     },
     "picker": {
       "agent": "Agent",

--- a/ui/src/lib/annotationView.test.ts
+++ b/ui/src/lib/annotationView.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+
+import { annotationStandIn, type AnnotationView } from './annotationView';
+
+const view = (over: Partial<AnnotationView> = {}): AnnotationView => ({
+  direction: 'user',
+  resolved: false,
+  ...over,
+});
+
+describe('annotationStandIn', () => {
+  it('stays out of the way when the annotator wrote something', () => {
+    expect(annotationStandIn(view({ quote: 'Model Hub' }), 'The heading is too small', true)).toBeNull();
+  });
+
+  it('treats blank text as no text', () => {
+    expect(annotationStandIn(view({ quote: 'Model Hub' }), '   ', false)).toEqual({
+      kind: 'quote',
+      quote: 'Model Hub',
+    });
+    expect(annotationStandIn(view(), '', true)).toEqual({ kind: 'screenshot' });
+    expect(annotationStandIn(view(), null, true)).toEqual({ kind: 'screenshot' });
+  });
+
+  // The card stacks quote above attachments; one line can hold one of them, so
+  // it takes the upper. A highlight the reader can find on the page beats
+  // "there is a picture".
+  it('prefers the quote to the screenshot, as the card stacks them', () => {
+    expect(annotationStandIn(view({ quote: 'Model Hub' }), '', true)).toEqual({
+      kind: 'quote',
+      quote: 'Model Hub',
+    });
+  });
+
+  it('leaves the title to stand alone when there is nothing to say', () => {
+    expect(annotationStandIn(view(), '', false)).toBeNull();
+  });
+
+  it('reads the same for a reverse mark', () => {
+    expect(annotationStandIn(view({ direction: 'agent' }), '', true)).toEqual({ kind: 'screenshot' });
+  });
+});

--- a/ui/src/lib/annotationView.ts
+++ b/ui/src/lib/annotationView.ts
@@ -1,0 +1,43 @@
+// What a Show Page annotation draws in chat, distilled from ``content.annotation``.
+// Design: design.pen m31JWV (states) + TxFKk (anatomy and rules); the rule
+// numbers cited below are that frame's.
+//
+// Pure, and separate from the card component, so the transcript's branch mapper
+// can depend on it without a lib → component import.
+
+export type AnnotationView = {
+  // Rule 01: direction alone decides the side and the title. A forward
+  // annotation is authored by ``harness`` (it is turn input), so reading
+  // ``author`` here would put the user's own annotation on the left behind a
+  // harness chip. ``author`` is bookkeeping and never reaches the view.
+  direction: 'user' | 'agent';
+  // Rule 07: only ``resolved`` draws a marker; created / updated / dismissed
+  // draw nothing beyond the body. Collapsing the action to a boolean means no
+  // later edit can quietly start branching on the other three without going
+  // back to the design first.
+  resolved: boolean;
+  quote?: string;
+};
+
+// Reads ``content.annotation`` off a chat row; null when the row carries no
+// usable display record.
+export function readAnnotationView(content: unknown): AnnotationView | null {
+  const raw = (content as { annotation?: unknown } | null | undefined)?.annotation;
+  if (!raw || typeof raw !== 'object') return null;
+  const { direction, action, quote } = raw as Record<string, unknown>;
+  if (direction !== 'user' && direction !== 'agent') return null;
+  return {
+    direction,
+    resolved: action === 'resolved',
+    // Rule 04: the strip needs copy the reader can find on the page. An empty
+    // string is the same as no quote.
+    quote: typeof quote === 'string' && quote.trim().length > 0 ? quote : undefined,
+  };
+}
+
+// Rule 02: exactly two title values, and the action never enters the title — a
+// resolved agent mark is still titled "Agent 批注"; the marker below the body is
+// what says it is done. The direction is data on the row; the words are frontend
+// i18n, so switching UI language re-labels existing rows instead of rewriting them.
+export const annotationTitleKey = (direction: AnnotationView['direction']): string =>
+  direction === 'user' ? 'chat.annotation.titleUser' : 'chat.annotation.titleAgent';

--- a/ui/src/lib/annotationView.ts
+++ b/ui/src/lib/annotationView.ts
@@ -41,3 +41,33 @@ export function readAnnotationView(content: unknown): AnnotationView | null {
 // i18n, so switching UI language re-labels existing rows instead of rewriting them.
 export const annotationTitleKey = (direction: AnnotationView['direction']): string =>
   direction === 'user' ? 'chat.annotation.titleUser' : 'chat.annotation.titleAgent';
+
+// What names a queued annotation on the strip's single line when its author
+// wrote no words.
+//
+// A queued annotation is visible in the strip and nowhere else — its type is
+// ``queued``, so the transcript cannot draw it — which makes that one line the
+// only account of what is waiting. Authored text is the whole line for an
+// ordinary queued prompt, but an annotation is allowed to carry none: a pure
+// highlight contributes its quote, a boxed region contributes its screenshot.
+// Left to the text alone, those two draw a title and then nothing.
+//
+// The card answers the same question by stacking quote and attachments under
+// the title. This picks whichever of them fits one line, in the order the card
+// stacks them, so the strip and the bubble that replaces it say the same thing.
+export type AnnotationStandIn = { kind: 'quote'; quote: string } | { kind: 'screenshot' } | null;
+
+export function annotationStandIn(
+  view: AnnotationView,
+  text: string | null | undefined,
+  hasAttachments: boolean,
+): AnnotationStandIn {
+  // The annotator's own words always speak for the row; a stand-in only ever
+  // fills a silence.
+  if (text && text.trim().length > 0) return null;
+  if (view.quote) return { kind: 'quote', quote: view.quote };
+  // Rule 05 in reverse: on the card a locator is never shown because the reader
+  // cannot use it, and the same holds here — an anchor with no quote and no
+  // region leaves the title to stand alone rather than printing a selector.
+  return hasAttachments ? { kind: 'screenshot' } : null;
+}

--- a/ui/src/lib/chatMessageTypes.test.ts
+++ b/ui/src/lib/chatMessageTypes.test.ts
@@ -1,6 +1,38 @@
 import { describe, expect, it } from 'vitest';
 
-import { isNotifyMessageType, isTerminalAgentMessage } from './chatMessageTypes';
+import { isNotifyMessageType, isTerminalAgentMessage, isTranscriptMessage } from './chatMessageTypes';
+
+describe('isTranscriptMessage', () => {
+  it('shows the rows the transcript has always shown, and hides process log', () => {
+    for (const type of ['user', 'harness', 'result', 'notify', 'error']) {
+      expect(isTranscriptMessage({ type }), type).toBe(true);
+    }
+    for (const type of ['assistant', 'tool_call', 'draft', 'pending', 'silent', 'future_type']) {
+      expect(isTranscriptMessage({ type }), type).toBe(false);
+    }
+  });
+
+  it('shows an annotation, in either direction', () => {
+    expect(isTranscriptMessage({ type: 'annotation' })).toBe(true);
+  });
+
+  // The back door this replaced. A forward annotation carries
+  // ``metadata.source === 'show_page'`` from the moment it is queued, so the old
+  // predicate showed it as a delivered bubble while the very same row was still
+  // sitting in the queue strip waiting to be sent. Only the type changes when the
+  // flush lands, and the type is now the only thing consulted.
+  it('hides a queued annotation however it is dressed', () => {
+    const queued = {
+      type: 'queued',
+      author: 'harness',
+      source: 'harness',
+      author_name: 'show_annotation',
+      metadata: { source: 'show_page', show_event_type: 'human.annotation.created' },
+      content: { annotation: { direction: 'user', action: 'created' } },
+    };
+    expect(isTranscriptMessage(queued)).toBe(false);
+  });
+});
 
 describe('isNotifyMessageType', () => {
   it('renders current and legacy failure rows as notifications', () => {

--- a/ui/src/lib/chatMessageTypes.ts
+++ b/ui/src/lib/chatMessageTypes.ts
@@ -3,6 +3,23 @@ import { specFor } from './messageTypes';
 // Status pills rather than authored answers — the catalog's ``status`` render kind.
 export const isNotifyMessageType = (type: string): boolean => specFor(type).render === 'status';
 
+// Whether a row belongs in the chat transcript — the catalog's ``transcript``
+// property, the same declaration the server filter on
+// ``GET /api/sessions/{id}/messages`` reads, so the live ``message.new`` feed
+// appends exactly the rows the initial load shows (assistant / tool_call are
+// process log).
+//
+// Visibility is a function of ``type`` ALONE, which is why the parameter is
+// narrowed to ``{ type }``: no caller and no future edit can reach ``author`` /
+// ``source`` / ``author_name`` / ``metadata`` from in here to widen the set,
+// even by accident. What that replaced was a ``metadata.source === 'show_page'``
+// clause standing in for a message type the server did not emit yet; it kept ANY
+// row of that origin whatever its type, and a forward annotation carries that
+// origin in EVERY state — so a still-``queued`` annotation rendered as a
+// delivered bubble while the same row sat in the queue strip. An annotation
+// becomes transcript-visible exactly once: when the flush mints it ``annotation``.
+export const isTranscriptMessage = (message: { type: string }): boolean => specFor(message.type).transcript;
+
 type TerminalMessageCandidate = {
   author: string;
   type: string;

--- a/ui/src/lib/chatRowKind.test.ts
+++ b/ui/src/lib/chatRowKind.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+
+import { chatRowKind } from './chatRowKind';
+
+const row = (over: Partial<Parameters<typeof chatRowKind>[0]>) =>
+  chatRowKind({ type: 'user', author: 'user', source: 'user', ...over });
+
+// The row shapes the contract freezes (docs/plans/show-annotation-message-type/
+// examples.json). A forward annotation is authored by ``harness``; a reverse mark
+// is authored by ``agent``. Both are ``type: 'annotation'``, and that is the only
+// thing either of them has in common.
+const FORWARD = {
+  type: 'annotation',
+  author: 'harness',
+  source: 'harness',
+  content: { annotation: { direction: 'user', action: 'created', quote: 'Model Hub' } },
+};
+const REVERSE = {
+  type: 'annotation',
+  author: 'agent',
+  source: null,
+  content: { annotation: { direction: 'agent', action: 'resolved' } },
+};
+
+describe('chatRowKind', () => {
+  it('keeps the pre-existing role families intact', () => {
+    expect(row({ author: 'user', source: 'user' })).toEqual({ kind: 'user' });
+    expect(row({ author: 'agent', type: 'result' })).toEqual({ kind: 'agent' });
+    expect(row({ author: 'system', type: 'user' })).toEqual({ kind: 'system' });
+    expect(row({ author: 'harness', source: 'harness', type: 'harness' })).toEqual({ kind: 'harness' });
+    expect(row({ author: 'agent', type: 'notify' })).toEqual({ kind: 'notify' });
+    expect(row({ author: 'agent', type: 'error' })).toEqual({ kind: 'notify' });
+  });
+
+  it('draws an annotation card for both directions', () => {
+    expect(chatRowKind(FORWARD)).toEqual({
+      kind: 'annotation',
+      annotation: { direction: 'user', resolved: false, quote: 'Model Hub' },
+    });
+    expect(chatRowKind(REVERSE)).toEqual({
+      kind: 'annotation',
+      annotation: { direction: 'agent', resolved: true, quote: undefined },
+    });
+  });
+
+  // The defect this lane exists to remove. A forward annotation is turn input, so
+  // it is authored by ``harness`` — under an author-first cascade it drew as a
+  // collapsed trigger row, and the user's own words sat behind a chip.
+  it('lets the type outvote the author, never the other way round', () => {
+    for (const author of ['harness', 'agent', 'system', 'user']) {
+      for (const source of ['harness', 'user', null]) {
+        expect(chatRowKind({ ...FORWARD, author, source }).kind, `${author}/${source}`).toBe('annotation');
+      }
+    }
+  });
+
+  // Rule 01: the side is direction, and direction is on the row. Two annotations
+  // with the SAME author land on opposite sides; two with the same direction land
+  // on the same side whoever authored them.
+  it('reads the side from direction, not from who authored the row', () => {
+    const asUser = chatRowKind({ ...FORWARD, author: 'agent' });
+    const asAgent = chatRowKind({ ...REVERSE, author: 'agent' });
+    expect(asUser).toMatchObject({ kind: 'annotation', annotation: { direction: 'user' } });
+    expect(asAgent).toMatchObject({ kind: 'annotation', annotation: { direction: 'agent' } });
+  });
+
+  // A queued annotation carries the identical content and metadata; only its type
+  // says it has not been sent. It belongs to the queue strip (rule 08), so the
+  // transcript mapper must not claim it — the old ``metadata.source`` back door
+  // did, which is how one row appeared twice.
+  it('does not claim a queued annotation for the transcript', () => {
+    expect(chatRowKind({ ...FORWARD, type: 'queued' }).kind).not.toBe('annotation');
+  });
+
+  // Contract D requires ``content.annotation`` on every row of the type, and the
+  // migration backfills it onto the historical reverse marks, so this is a
+  // backend defect. It must still degrade inside the family: falling back to the
+  // author cascade would draw a mark the AGENT wrote as the user's own bubble.
+  it('still draws a card when the display record is missing or malformed', () => {
+    for (const content of [undefined, null, {}, { annotation: null }, { annotation: { direction: 'sideways' } }]) {
+      expect(chatRowKind({ type: 'annotation', author: 'agent', source: null, content })).toEqual({
+        kind: 'annotation',
+        annotation: { direction: 'agent', resolved: false },
+      });
+    }
+  });
+});

--- a/ui/src/lib/chatRowKind.test.ts
+++ b/ui/src/lib/chatRowKind.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { chatRowKind } from './chatRowKind';
+import { chatRowKind, isAgentAuthored } from './chatRowKind';
 
 const row = (over: Partial<Parameters<typeof chatRowKind>[0]>) =>
   chatRowKind({ type: 'user', author: 'user', source: 'user', ...over });
@@ -83,5 +83,38 @@ describe('chatRowKind', () => {
         annotation: { direction: 'agent', resolved: false },
       });
     }
+  });
+});
+
+describe('isAgentAuthored', () => {
+  // The defect this exists to prevent, stated as the disagreement itself: on a
+  // reverse mark the two questions give different answers, and they are supposed
+  // to. Deriving authorship from the card family made ``$<NAME>`` in an agent's
+  // mark render as inert literal text where the same words in an ordinary reply
+  // render an interactive secret-input card.
+  it('keeps an agent mark agent-authored even though an annotation card draws it', () => {
+    expect(chatRowKind(REVERSE).kind).toBe('annotation');
+    expect(isAgentAuthored(REVERSE)).toBe(true);
+  });
+
+  // The other direction is the reason this is not simply ``type === 'annotation'``:
+  // a forward annotation is the USER's words on an agent-adjacent card, and must
+  // never be dressed as something the agent asked for.
+  it('never treats the user side of an annotation as agent-authored', () => {
+    expect(isAgentAuthored(FORWARD)).toBe(false);
+  });
+
+  // Everywhere else it must still agree with the flag it replaced
+  // (``!isNotify && author === 'agent'`` on master), so this is a fix confined to
+  // annotations rather than a widening of who gets the agent affordances.
+  it('matches the pre-annotation rule on every other row', () => {
+    expect(isAgentAuthored({ type: 'result', author: 'agent' })).toBe(true);
+    expect(isAgentAuthored({ type: 'user', author: 'user' })).toBe(false);
+    expect(isAgentAuthored({ type: 'harness', author: 'harness' })).toBe(false);
+    expect(isAgentAuthored({ type: 'result', author: 'system' })).toBe(false);
+    // A notify/error row draws a status pill with no Markdown body; it was
+    // excluded before and stays excluded.
+    expect(isAgentAuthored({ type: 'notify', author: 'agent' })).toBe(false);
+    expect(isAgentAuthored({ type: 'error', author: 'agent' })).toBe(false);
   });
 });

--- a/ui/src/lib/chatRowKind.test.ts
+++ b/ui/src/lib/chatRowKind.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { chatRowKind, isAgentAuthored } from './chatRowKind';
+import { chatRowKind, drawsEmptyBodyPlaceholder, isAgentAuthored } from './chatRowKind';
 
 const row = (over: Partial<Parameters<typeof chatRowKind>[0]>) =>
   chatRowKind({ type: 'user', author: 'user', source: 'user', ...over });
@@ -116,5 +116,34 @@ describe('isAgentAuthored', () => {
     // excluded before and stays excluded.
     expect(isAgentAuthored({ type: 'notify', author: 'agent' })).toBe(false);
     expect(isAgentAuthored({ type: 'error', author: 'agent' })).toBe(false);
+  });
+});
+
+describe('drawsEmptyBodyPlaceholder', () => {
+  // An ordinary row really is broken-looking when it is empty, which is why the
+  // stand-in exists at all.
+  it('fills an ordinary empty bubble', () => {
+    expect(drawsEmptyBodyPlaceholder({ kind: 'user' }, false)).toBe(true);
+    expect(drawsEmptyBodyPlaceholder({ kind: 'agent' }, false)).toBe(true);
+    expect(drawsEmptyBodyPlaceholder({ kind: 'harness' }, false)).toBe(true);
+  });
+
+  // The empty annotation is a real, supported shape in BOTH directions — a pure
+  // highlight the annotator submitted with no comment (backend: an empty
+  // ``comment`` / empty mark ``body``). The frozen contract says the card then
+  // renders its title, quote and attachments ALONE, so an em dash here would be
+  // a body the annotator never wrote.
+  it('leaves an empty annotation to its title and quote', () => {
+    for (const direction of ['user', 'agent'] as const) {
+      const row = { kind: 'annotation' as const, annotation: { direction, resolved: false } };
+      expect(drawsEmptyBodyPlaceholder(row, false)).toBe(false);
+    }
+  });
+
+  // Unchanged from before the card existed: an attachment already fills the
+  // bubble, so nothing stands in for the missing words.
+  it('never draws it when an attachment already fills the bubble', () => {
+    expect(drawsEmptyBodyPlaceholder({ kind: 'user' }, true)).toBe(false);
+    expect(drawsEmptyBodyPlaceholder({ kind: 'agent' }, true)).toBe(false);
   });
 });

--- a/ui/src/lib/chatRowKind.ts
+++ b/ui/src/lib/chatRowKind.ts
@@ -1,4 +1,7 @@
-// Which card family draws a transcript row.
+// Two adjacent questions about a transcript row, kept apart on purpose:
+// ``chatRowKind`` — which card family DRAWS it, and ``isAgentAuthored`` — who
+// WROTE it. They agreed on every row until ``annotation`` arrived, which is
+// exactly why they have to be asked separately now (see the second one below).
 //
 // A pure mapper so the branching is unit-tested without the component — the same
 // reason ``chatTrigger`` is one. It replaces a cascade of booleans read off the
@@ -58,4 +61,24 @@ export function chatRowKind(message: ChatRowFields): ChatRowKind {
   // watch / webhook); collapsed by default so it doesn't dominate.
   if (message.source === 'harness') return { kind: 'harness' };
   return { kind: 'user' };
+}
+
+// Did the AGENT write this row's text?
+//
+// Some Markdown affordances are earned by authorship, not by card family: a
+// ``$<NAME>`` marker becomes an interactive secret-input card only in the agent's
+// own words, because in anyone else's it would fake an "agent asked for this"
+// prompt. Before ``annotation`` existed, "drawn as the agent" and "written by the
+// agent" were the same rows, so one flag served both and the distinction cost
+// nothing to ignore.
+//
+// An agent's reverse mark broke that: it draws as an annotation and is still the
+// agent talking. Reading authorship off ``chatRowKind`` would silently strip the
+// card from it — re-creating, one field over, the same conflation this module
+// exists to delete. So this asks ``author`` directly, and equals
+// ``kind === 'agent'`` for every row EXCEPT an agent-authored annotation.
+export function isAgentAuthored(message: Pick<ChatRowFields, 'type' | 'author'>): boolean {
+  // Notify/error rows draw a status pill with no Markdown body at all; excluding
+  // them keeps this identical to the pre-annotation flag rather than widening it.
+  return !isNotifyMessageType(message.type) && message.author === 'agent';
 }

--- a/ui/src/lib/chatRowKind.ts
+++ b/ui/src/lib/chatRowKind.ts
@@ -1,7 +1,8 @@
-// Two adjacent questions about a transcript row, kept apart on purpose:
-// ``chatRowKind`` — which card family DRAWS it, and ``isAgentAuthored`` — who
-// WROTE it. They agreed on every row until ``annotation`` arrived, which is
-// exactly why they have to be asked separately now (see the second one below).
+// Three adjacent questions about a transcript row, kept apart on purpose:
+// ``chatRowKind`` — which card family DRAWS it, ``isAgentAuthored`` — who WROTE
+// it, and ``drawsEmptyBodyPlaceholder`` — whether an empty one still needs a
+// stand-in body. All three agreed on every row until ``annotation`` arrived,
+// which is exactly why they are asked separately now (see the two below).
 //
 // A pure mapper so the branching is unit-tested without the component — the same
 // reason ``chatTrigger`` is one. It replaces a cascade of booleans read off the
@@ -81,4 +82,19 @@ export function isAgentAuthored(message: Pick<ChatRowFields, 'type' | 'author'>)
   // Notify/error rows draw a status pill with no Markdown body at all; excluding
   // them keeps this identical to the pre-annotation flag rather than widening it.
   return !isNotifyMessageType(message.type) && message.author === 'agent';
+}
+
+// A row with no text: does it still need the ``—`` stand-in body?
+//
+// A bubble holding neither text nor attachment would draw as a bare rounded box
+// that reads as broken, so the transcript fills it with a muted em dash meaning
+// "this row really is empty".
+//
+// The annotation card is the one that is never bare — it always draws its title,
+// and usually the anchor quote — and an empty-text annotation is a SUPPORTED
+// shape rather than a defect: a pure highlight, where the quote is the whole of
+// what the annotator contributed. Both directions can be empty. So the stand-in
+// would not be filling a hole here, it would be adding a body nobody wrote.
+export function drawsEmptyBodyPlaceholder(row: ChatRowKind, hasAttachments: boolean): boolean {
+  return !hasAttachments && row.kind !== 'annotation';
 }

--- a/ui/src/lib/chatRowKind.ts
+++ b/ui/src/lib/chatRowKind.ts
@@ -1,0 +1,61 @@
+// Which card family draws a transcript row.
+//
+// A pure mapper so the branching is unit-tested without the component — the same
+// reason ``chatTrigger`` is one. It replaces a cascade of booleans read off the
+// row in ``MessageRow``, where the ordering between them was the load-bearing
+// part and nothing checked it.
+//
+// The ordering is the whole point. ``type`` is settled FIRST and returns, so a
+// message type can never be outvoted by who happens to be recorded as its
+// author. A forward annotation is authored by ``harness``: under the old
+// author/source-first cascade it drew as a collapsed trigger row behind a
+// "定时任务"-style chip, which is how an annotation looked before it had a type.
+//
+// ``author`` and ``source`` still decide among the ROLE families below, which is
+// what they legitimately describe. What they no longer do is decide whether a
+// typed row is that type.
+import { isNotifyMessageType } from './chatMessageTypes';
+import { readAnnotationView, type AnnotationView } from './annotationView';
+
+// A row typed ``annotation`` whose display record is unreadable. Every writer of
+// the type emits one, and the migration backfills ``direction: "agent"`` onto the
+// historical reverse marks, so reaching this is a backend defect — it is here so
+// the defect degrades INSIDE the annotation family (a card with the wrong title)
+// instead of escaping it (the user's own words, drawn as if the user typed them).
+const UNREADABLE_ANNOTATION: AnnotationView = { direction: 'agent', resolved: false };
+
+// The annotation case carries its view along, so a caller cannot narrow to the
+// family and then disagree with a second lookup about what is in it.
+export type ChatRowKind =
+  | { kind: 'annotation'; annotation: AnnotationView }
+  | { kind: 'notify' }
+  | { kind: 'agent' }
+  | { kind: 'system' }
+  | { kind: 'harness' }
+  | { kind: 'user' };
+
+type ChatRowFields = {
+  type: string;
+  author: string;
+  source?: string | null;
+  content?: unknown;
+};
+
+export function chatRowKind(message: ChatRowFields): ChatRowKind {
+  // Typed families first, and by ``type`` alone: not ``author``, not ``source``,
+  // not ``metadata.source`` (a forward annotation carries ``show_page`` in every
+  // state, including while it is still queued and belongs only to the strip).
+  if (message.type === 'annotation') {
+    return { kind: 'annotation', annotation: readAnnotationView(message.content) ?? UNREADABLE_ANNOTATION };
+  }
+  // Runtime notifications and legacy error rows are compact status pills, not
+  // Agent-authored answers.
+  if (isNotifyMessageType(message.type)) return { kind: 'notify' };
+
+  if (message.author === 'agent') return { kind: 'agent' };
+  if (message.author === 'system') return { kind: 'system' };
+  // A harness-origin row is turn input the human didn't type (scheduled task /
+  // watch / webhook); collapsed by default so it doesn't dominate.
+  if (message.source === 'harness') return { kind: 'harness' };
+  return { kind: 'user' };
+}

--- a/ui/src/lib/chatTrigger.test.ts
+++ b/ui/src/lib/chatTrigger.test.ts
@@ -66,7 +66,6 @@ describe('chatTriggerLink', () => {
 
   it('does not navigate for webhook or unknown harness kinds without a source', () => {
     expect(link({ author_name: 'webhook' })).toBeNull();
-    expect(link({ author_name: 'show_annotation' })).toBeNull();
     expect(link({ author_name: 'show_intent' })).toBeNull();
     expect(link({ author_name: 'agent_run', source_session_id: null })).toBeNull();
   });
@@ -118,8 +117,15 @@ describe('harnessChipLabelKey (leading-label key by source presence)', () => {
     }
   });
 
-  it('uses Show-specific labels for annotation and intent triggers', () => {
-    expect(key({ author_name: 'show_annotation' })).toBe('chat.source.showAnnotation');
+  it('keeps the Show-specific label for a page-button intent', () => {
     expect(key({ author_name: 'show_intent' })).toBe('chat.source.showIntent');
+  });
+
+  // An annotation is its own message type now and draws its own card, so it
+  // never reaches the harness chip. The branch that gave it a Show-specific
+  // label is gone along with the ``chat.source.showAnnotation`` string; this
+  // pins that it is not quietly re-added on the author_name side channel.
+  it('has no Show-specific label left for the retired show_annotation trigger', () => {
+    expect(key({ author_name: 'show_annotation' })).toBe('chat.source.harness');
   });
 });

--- a/ui/src/lib/chatTrigger.ts
+++ b/ui/src/lib/chatTrigger.ts
@@ -69,7 +69,10 @@ export function chatTriggerLink(message: TriggerFields, agentFallback: string): 
   }
 
   const kind = message.author_name;
-  if (kind === 'show_annotation' || kind === 'show_intent') return null;
+  // ``show_intent`` (a page button action) stays a non-navigating harness row.
+  // ``show_annotation`` no longer reaches here at all: an annotation is typed
+  // ``annotation`` and renders as its own card, never as a harness trigger row.
+  if (kind === 'show_intent') return null;
   if (kind === 'watch' || TASK_KINDS.has(kind ?? '')) {
     const itemKind = kind === 'watch' ? 'watch' : 'task';
     return {
@@ -91,7 +94,6 @@ export function chatTriggerLink(message: TriggerFields, agentFallback: string): 
 export function harnessChipLabelKey(message: TriggerFields): string {
   if (message.source === 'harness' && message.source_session_id) return 'chat.source.from';
   const kind = message.author_name;
-  if (kind === 'show_annotation') return 'chat.source.showAnnotation';
   if (kind === 'show_intent') return 'chat.source.showIntent';
   if (kind === 'watch') return 'chat.source.watch';
   if (kind === 'webhook') return 'chat.source.webhook';

--- a/ui/src/lib/messageTypes.test.ts
+++ b/ui/src/lib/messageTypes.test.ts
@@ -49,7 +49,15 @@ const PRE_REFACTOR_TYPES = [
   'silent',
 ] as const;
 
-// Unknown / non-type strings the predicates must also agree on.
+// Unknown / non-type strings the predicates must also agree on. ``show_annotation``
+// is one of them on purpose: it is an ``author_name``, never a message type, and
+// keeping it here pins that it does not become one by the back door.
+//
+// ``annotation`` is deliberately absent. This block is an equivalence oracle
+// against pre-refactor behavior, and ``annotation`` is behavior that did not
+// exist then — it had no type, so the transcript reached it through
+// ``metadata.source``. Its behavior is pinned by the tests that own it
+// (chatMessageTypes / AnnotationMessage), not by an oracle it postdates.
 const PROBE_TYPES: readonly string[] = [...PRE_REFACTOR_TYPES, 'show_annotation', 'future_type', ''];
 
 const wasTranscript = (type: string): boolean =>
@@ -75,9 +83,9 @@ const wasTerminalAgentMessage = (message: TerminalCandidate): boolean =>
 
 describe('catalog-derived predicates match pre-refactor behavior', () => {
   it('transcript visibility (ChatPage isTranscriptMessage)', () => {
-    // ``isTranscriptMessage`` is ``specFor(type).transcript`` OR the unchanged
-    // ``metadata.source === 'show_page'`` side channel, so the catalog property is
-    // the whole type-driven half of that predicate.
+    // ``isTranscriptMessage`` is now ``specFor(type).transcript`` and nothing
+    // else — the ``metadata.source`` side channel it used to be OR'd with is
+    // gone — so for these types the catalog property IS the predicate.
     for (const type of PROBE_TYPES) {
       expect(specFor(type).transcript, type).toBe(wasTranscript(type));
     }

--- a/ui/src/lib/messageTypes.test.ts
+++ b/ui/src/lib/messageTypes.test.ts
@@ -105,8 +105,11 @@ describe('catalog-derived predicates match pre-refactor behavior', () => {
 
   it('harness input-turn identity (messageSearchRole type branch)', () => {
     for (const type of PROBE_TYPES) {
-      // Neutral author/source so the type test alone decides the role.
-      const match = { author: 'agent', source: 'agent', type };
+      // A genuinely neutral author, so the type test alone decides the role.
+      // ``agent`` would not do: an agent-authored row is now attributed to the
+      // agent before the catalog is consulted, because a harness-input type can
+      // still carry agent-written rows (a reverse annotation is one).
+      const match = { author: 'system', source: 'system', type };
       expect(messageSearchRole(match), type).toBe(wasHarnessInputType(type) ? 'automated' : 'agent');
       expect(specFor(type).inputAuthors.includes('harness'), type).toBe(wasHarnessInputType(type));
     }


### PR DESCRIPTION
## Capability

Annotations become a first-class card in the transcript, and **chat visibility becomes a function of `type` alone**.

Before this PR the frontend decided four separate things — is this row in the transcript, does it survive live append, does it survive first paint, which card family draws it — by sniffing `metadata.source`, `author`, `source`, and `author_name`. Those four decisions now read the message-type catalog and nothing else.

This is Lane UI of the `annotation` message type. Per amendment A5 it no longer targets `master`: it is **based on `fix/show-annotation-real-type` (#1052)** and merges into that branch, so the visibility contract reaches `master` as one change instead of two individually-incorrect halves.

Every file this PR touches is under `ui/`, with one exception the owner authorized explicitly: a single paragraph of `docs/plans/show-annotation-message-type.md` (Contract D), amended to match A6 — see below. The shared catalog block and the render-enum widening come from the base branch, so the two deviations previously declared against `vibe/message_types.*` are gone.

## The card

It walks the reuse ladder from the existing harness row rather than forking it:

- the **same bubble** the column would otherwise have drawn — the user-side annotation is the user bubble, the agent-side one is the agent bubble, both now hoisted into `ui/src/components/workbench/chatBubble.ts` so a restyle of the ordinary bubbles carries the card with it and cannot leave it behind
- plus a mirrored title head, the anchor quote, and the resolved marker
- the screenshot is the transcript's own attachment node, passed through — the card renders no image of its own

Direction is data (`content.annotation.direction`); the two titles are frontend i18n, so a UI language switch relabels existing rows without rewriting them. `created` / `updated` / `dismissed` draw no marker — only `resolved` does. That collapse is what makes amendment A1's newly-migrated `assistant.mark.updated` rows render correctly with no frontend change.

A queued annotation shows the **same title in the queue strip** as it will in the transcript, so sending does not appear to turn one thing into another — and when its author wrote no words at all, the same quote or the same screenshot (round 4, below).

New strings, frontend only: `chat.annotation.titleUser`, `chat.annotation.titleAgent`, `chat.annotation.resolved`, `chat.annotation.screenshot`.

## Back doors deleted

| Where | What went |
| --- | --- |
| `ui/src/lib/chatMessageTypes.ts` | the `metadata.source === 'show_page'` clause — `isTranscriptMessage` is now the catalog's `transcript` flag. Nothing was hand-added to a list: the type is picked up automatically once it exists in the catalog. |
| `ChatPage.tsx` | the local `isTranscriptMessage` bypass, the live-append `isShowPage` guard, **and the chat bootstrap payload** — a fourth visibility decision, on the first-paint path, now behind the same guard |
| `ChatPage.tsx` | the `author` / `source` card-family cascade in `MessageRow` |
| `ui/src/lib/chatTrigger.ts` | the `show_annotation` harness-chip branch and its now-unused `chat.source.showAnnotation` string. **`show_intent` / 「页面操作」 is untouched.** |

An in-page duplicate of the role avatar was also folded into the shared `RoleAvatar`.

## The invariant

```
$ grep -rn "show_page" ui/src
ui/src/components/settings/SettingsMessagingPage.tsx:34:  'show_pages_prompt',
ui/src/components/settings/SettingsMessagingPage.tsx:423:              enabled={config.show_pages_prompt !== false}
ui/src/components/settings/SettingsMessagingPage.tsx:427:                  show_pages_prompt: !(config.show_pages_prompt !== false),
ui/src/components/workbench/ChatQueueRow.test.tsx:34:    metadata: { source: 'show_page' },
ui/src/lib/showPageLinks.ts:39:// rule in core/show_pages.validate_share_id so the field can give instant
ui/src/lib/chatMessageTypes.ts:15:// even by accident. What that replaced was a ``metadata.source === 'show_page'``
ui/src/lib/chatRowKind.ts:46:  // not ``metadata.source`` (a forward annotation carries ``show_page`` in every
ui/src/lib/chatMessageTypes.test.ts:20:  // ``metadata.source === 'show_page'`` from the moment it is queued, so the old
ui/src/lib/chatMessageTypes.test.ts:30:      metadata: { source: 'show_page', show_event_type: 'human.annotation.created' },
```

**Zero occurrences as a behavior key.** The nine hits are: three on the unrelated `show_pages_prompt` config key (substring match), four comments, one unrelated share-id comment, and one test fixture that deliberately still carries the old dressing in order to prove `type` outvotes it.

## Search authorship (amendment A6)

`messageSearchRole` labelled **both** directions of an annotation `Automated`. Two separate causes, and the second one is worth stating precisely because the amendment attributes both to the same line:

| direction | frozen row | was | now |
| --- | --- | --- | --- |
| forward — the user's own words | `author: harness, source: harness` | Automated | **You** |
| reverse — the agent's mark | `author: agent, source: null` | Automated | **Agent** |

The reverse case was the type clause, `specFor(type).inputAuthors.includes('harness')`. `inputAuthors` is a **permission** — which authors may submit this type as input — not a claim about who wrote a given row. `annotation` is the first type where those come apart, because it is one type in two directions.

The forward case is **not** that clause. A forward annotation enters as turn input, so the frozen contract records it `author: harness` — it is caught by the plain `author === 'harness'` rule that *precedes* the type clause, and removing or demoting the type clause does not move it. `direction` is the only field that separates the two, and `MessageSearchMatch` carries no `content`, so it is not readable here.

So the type is settled first, and inside it `author` stands in for `direction` exactly:

```ts
if (match.type === 'annotation') return match.author === 'agent' ? 'agent' : 'you';
```

A harness-authored row of any **other** type is still `Automated`, asserted directly so the annotation case reads as a property of that type rather than a hole in the rule. The `inputAuthors` clause survives as the fallback for rows whose author names nobody above, so a future harness-input type still inherits the automated treatment without another edit here.

> **The spec said the opposite, and the owner amended it.** `docs/plans/show-annotation-message-type.md` Contract D pinned *"search results classify the row from its actual `author`"* — which yields `Automated` for a user's own annotation, because a forward annotation is authored by `harness`. A6 originally restated that too; the owner ruled the amendment wrong and rewrote the paragraph to classify on the `(author, type)` pair. That one paragraph is the sole non-`ui/` change here, authorized for this purpose and nothing else in the file.

## Card family and authorship are two questions (round 2)

Review caught the mirror image of this PR's own defect. `secretRequests` — which renders `$<NAME>` as an interactive secret-input card — was reading `row.kind === 'agent'`. But that flag answers *which card draws this row*, and `secretRequests` is asking *who wrote these words*. The two agreed on every row that had ever existed, so one flag served both.

An agent's reverse mark is the first row where they come apart: the annotation card draws it, and it is still the agent talking. Under the card-family flag its `$<NAME>` went inert.

Authorship is now its own predicate beside `chatRowKind`, deliberately not inside it:

```ts
export function isAgentAuthored(message: Pick<ChatRowFields, 'type' | 'author'>): boolean {
  return !isNotifyMessageType(message.type) && message.author === 'agent';
}
```

That is `master`'s exact `isAgent` rule, so it differs from `row.kind === 'agent'` for precisely one row shape — an agent-authored annotation — and nothing else moves.

## An empty annotation is a real shape (round 3)

Authored text may be empty in **both** directions — the backend seeds exactly that in `test_annotation_card_can_have_empty_authored_text` (`comment: ""` / mark `body: ""`), and the contract's `text` field says the card then renders title + quote + attachments alone. It is a pure highlight: the reader selected something and submitted no comment, so the anchor quote *is* the contribution.

The transcript's em-dash stand-in — which keeps an ordinary empty bubble from reading as broken — was landing in that card. An annotation card is never bare (it always draws its title), so the dash was not filling a hole, it was adding a body nobody wrote. That decision is now a third row-level predicate rather than an inline ternary in `MessageRow`:

```ts
export function drawsEmptyBodyPlaceholder(row: ChatRowKind, hasAttachments: boolean): boolean {
  return !hasAttachments && row.kind !== 'annotation';
}
```

## A queued annotation nobody wrote words for (round 4)

Same shape, one surface further out. Raised against the backend at `core/show_session_events.py:1078`, but the remedy is here: `QueueRow` drew only `item.text`, and that field is the annotator's authored words and nothing else by contract. A pure highlight or a boxed region submitted without a comment therefore drew a title, a separator, and empty space — the user could see something was waiting behind the running turn but not what.

A queued annotation is visible in the strip **and nowhere else** — its type is `queued`, so the transcript cannot draw it, which is exactly what this PR's visibility contract guarantees. That one line is the only account of the row that exists.

The card answers the same question by stacking quote and attachments under the title. The strip has one line, so it takes whichever of them comes first in that stack:

```ts
export function annotationStandIn(view, text, hasAttachments) {
  if (text && text.trim().length > 0) return null;          // the author's own words speak for the row
  if (view.quote) return { kind: 'quote', quote: view.quote };
  return hasAttachments ? { kind: 'screenshot' } : null;    // rule 05: never a bare locator
}
```

Title, quote and strings are the card's own, so the strip entry and the bubble that replaces it on flush name the same thing the same way — asserted by rendering **both** and comparing, not by comparing keys. With nothing to show, the title stands alone and the separator goes with it, rather than promising something after it.

## Deviation: the `MessageRow` cascade is a pure mapper, not six booleans

The brief spelled it as `isAnnotation` evaluated first with `!isAnnotation` added to every other flag. `ui/src/lib/chatRowKind.ts` has identical semantics via early returns, because:

- `MessageRow` is not exported and needs a router plus several contexts, so the six-boolean form is not directly testable; the pattern that already exists beside it is `chatTrigger.ts`, whose own header reads *"A pure mapper so the branching is unit-tested without the component."*
- early returns make the ordering structural rather than a property that six separate `!isAnnotation` conjuncts have to keep agreeing about
- the returned discriminated union **carries the parsed view**, so a caller cannot narrow to `annotation` and then disagree with a second lookup about its contents

An unreadable `content.annotation` degrades *inside* the annotation family rather than returning `null`. Returning `null` would hand the row back to the author cascade — re-creating the exact back door this PR deletes, as an error path. So `chatRowKind(m).kind === 'annotation'` ⟺ `m.type === 'annotation'`, exactly.

## Evidence

**Unit** — 5 new test files, 4 extended; suite goes 64 files / 554 cases on `master` → **68 files / 595 cases, all passing**.

- `ui/src/lib/chatRowKind.test.ts` (new) — role families intact; both directions draw a card; an **author-outvote matrix**, 4 authors × 3 sources, all landing on `annotation`; the side reads from direction, not author; a queued annotation is not claimed; malformed content still draws a card. Plus `isAgentAuthored`, asserted as the **disagreement** rather than the implementation: a reverse mark is `kind: 'annotation'` *and* agent-authored; a forward annotation is never agent-authored; every other row matches the pre-annotation rule, notify/error exclusion included. Plus `drawsEmptyBodyPlaceholder`: an ordinary empty row still gets the dash, neither annotation direction does, an attachment still suppresses it
- `AnnotationMessage.test.tsx` — also renders the card with a **null body** and asserts title + quote + attachment present, no `—`
- `ui/src/components/workbench/AnnotationMessage.test.tsx` (new) — side, both titles in both languages, title unchanged when resolved, **bubble reuse asserted against the shared constants** rather than a copied class string, quote presence/absence, marker only when resolved, body/attachments/time passthrough, deep-link dressing
- `ui/src/components/workbench/ChatQueueRow.test.tsx` (new) — renders **both** the strip row and the card and asserts the extracted titles are equal, so a divergence in either renderer fails. Plus the wordless annotation: screenshot-only names its region, anchor-only names its highlight, the quote beats the screenshot and the words beat both, nothing to show leaves no dangling separator, and the strip's quote is cross-rendered against the card's
- `ui/src/lib/annotationView.test.ts` (new) — `annotationStandIn` directly: blank text counts as no text, the ordering rule, the reverse direction, and the title-alone case
- `SearchResultRow.test.ts` — both frozen directions land on You / Agent; a harness-authored row of any other type stays Automated; the catalog fallback still decides an unknown author
- `chatMessageTypes.test.ts` — the regression that names the old bug: a row dressed with `metadata.source: 'show_page'` + `author_name: 'show_annotation'` while still `type: 'queued'` is hidden
- `chatTrigger.test.ts` — `show_intent` still labelled; `show_annotation` now falls through to the ordinary harness label
- `messageTypes.test.ts` — the equivalence oracle's probe author moved to `system`, since `agent` is no longer neutral once authorship outranks the catalog

**Contract** — rendered against the frozen row shape in `docs/plans/show-annotation-message-type/contract.ts` / `examples.json`; the queue fixture is `msg_01J8XK5M8T` verbatim, and the search-role table above was produced by running the four frozen rows through the mapper.

**Backend tests on this base** — `pytest tests/test_message_type_catalog.py tests/test_sqlite_state_migration.py` → **82 passed**. The four cases that were red while this branch sat on `master` are green now that it sits on #1052; nothing in `tests/` was touched by this lane.

**Build** — `npm run build` clean. `tsc --noEmit` clean. ESLint on all touched files: the new files are clean; `ChatPage.tsx` carries the same 13 pre-existing problems it has on `master`, verified by linting `master`'s copy through stdin.

**Design** — the card was rendered through the real components against the built stylesheet and put side by side with the approved `design.pen` frames (`Chat · 批注消息 (Dark)` and its anatomy frame). Both directions, the quote rule, the resolved pill, the bubble reuse and the queue-strip title match. The scratch harness was removed.

**Residual manual** — the end-to-end annotate → queue → flush → card path is verified on the combined head, after this merges into #1052.

## One finding answered by ruling, not by code

Review also asked that `assistant.page.updated` and `system.runtime.error` be retyped to transcript-visible types before the compatibility clause is removed. The mechanism is exactly right — verified on this base, both families resolve to `assistant`, which is `transcript: false`, so they do leave the transcript.

That is the decided outcome. The owner's amendment states it directly: *"`assistant.page.updated` and `system.runtime.error` rows are the deliberate drop: they keep `assistant` and lose transcript visibility, per R1."* The catalog already agrees — `assistant` is an activity type, and these are bracket-tagged machine lines, not conversation. The half of the finding the owner accepted (amendment A4: stop publishing them live, so live and history stop disagreeing) is a producer change assigned to the base branch, #1052.

## The last open thread, closed by ruling

Review found that a historical forward annotation still typed `harness` loses its "Page annotation" label once the `author_name === 'show_annotation'` branch is deleted, and asked for the branch to be kept. The mechanism is right, and I held the thread open as a tracker against the base branch's migration.

The owner closed it on a fact that outranks the migration question: **the annotation feature has never shipped.** No release contains it, so no installation in the field holds a Show annotation row of any vintage — rows of that shape exist only on developer machines running this branch. The label branch would be dead code the day it merged: a display path guarding data that cannot come into existence, keyed on the one field this PR removes as a behaviour input. Not retained. Thread resolved.

The migration asymmetry is still worth closing on its own terms, and it belongs to #1052:

| stored event | `upgrade()` | `downgrade()` |
| --- | --- | --- |
| `assistant.mark.created` | → `annotation` | → `assistant` |
| `assistant.mark.updated` | **untouched** | → `assistant` |
| `assistant.mark.resolved` | → `annotation` | → `assistant` |
| `human.annotation.created` | **untouched** | → `harness` |

`downgrade()` carries a `human.annotation.created` clause with nothing to undo, because `upgrade()` never creates those rows — a downgrade handling rows its own upgrade cannot produce is the tell that the reverse direction was written to A1's full intent and the forward one was not. Codex independently filed the `updated` half as a separate P2 against the migration file. A1 also asks that file's docstring to name `assistant.page.updated` / `system.runtime.error` as the deliberate drop, so the omission reads as a decision.

Both are `storage/alembic/`, both are #1052's, and this PR merges into that branch — so nothing intermediate reaches `master` either way.

## Merge path

Per amendment A5 this is no longer a merge to `master`. It merges into **`fix/show-annotation-real-type`**; the combined head on #1052 then takes the review that can actually pass, and #1052 is the single merge to `master`.

