### PR TITLE
docs(messages): document inputAuthors, compact AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,6 @@ Default mindset:
 - treat the system as **multi-platform, multi-backend** first
 - prefer root-cause fixes over narrow patches
 - preserve user-visible behavior unless the task explicitly changes product behavior
-- make the next agent/platform inherit correct behavior automatically
 
 ## 2. Design Philosophy and Architecture
 
@@ -72,11 +71,7 @@ Common commands:
 - inspect: `vibe status`
 - stop: `vibe stop`
 
-Use local `vibe` for:
-
-- local packaging checks
-- local CLI behavior checks
-- editable-install UI preview when explicitly needed
+Use local `vibe` for local packaging or CLI behavior checks.
 
 Hard rule:
 
@@ -164,18 +159,14 @@ Source-of-truth rule:
 - if the user already put you on an existing branch/worktree, continue there unless asked to move
 - keep commits small and focused; avoid mixing unrelated changes
 
-### Planning for Non-Trivial Work
+### Planning and Documentation
 
 - if the task is complex or ambiguous, create a short plan before large changes
 - capture background, goal, solution, and todo items in `docs/plans/`
 - implementations should follow the plan and update it when scope changes materially
 - if requirements are unclear, ask early before committing to a large direction
-
-### Documentation Expectations
-
 - update user documentation alongside user-visible features or changed workflows
-- store project-specific plans, investigations, and summaries under `docs/`
-- do not put ad-hoc project documentation in the repo root
+- keep project-specific plans, investigations, and summaries under `docs/`, never in the repo root
 
 ### Worktrees
 
@@ -207,8 +198,7 @@ Source-of-truth rule:
   final review and merge; an explicit merge instruction from them is carried
   out directly after a mechanical `mergeStateStatus == CLEAN` check, never by
   spawning another agent to re-review
-- keep expensive full-suite gates on GitHub CI by default, then require those
-  CI checks to pass before merge
+- require the GitHub CI checks to pass before merge
 
 ### Pre-Push Requirements
 
@@ -246,29 +236,20 @@ Source-of-truth rule:
 ### Frontend (UI)
 
 - source lives in `ui/`; build with `cd ui && npm run build`; `ui/dist/` is served by `vibe/ui_server.py`
-- reuse `ui/src/components/ui/` primitives first (`Button`, `Badge`, `Card`, `Input`, `Popover`, `Dialog`, etc.); extend via variants/sizes/props before creating new primitives
-- follow the reuse ladder for UI and shared backend logic: inventory existing patterns -> reuse -> extend -> promote near-duplicates -> create a reusable unit only when needed; extract on the third repeat
+- follow the reuse ladder for UI and shared backend logic: inventory existing patterns -> reuse (`ui/src/components/ui/` primitives such as `Button`, `Badge`, `Card`, `Input`, `Popover`, `Dialog` first) -> extend via variants/sizes/props -> promote near-duplicates -> create a reusable unit only when needed; extract on the third repeat
 - `../avibe-docs/design.pen` is the visual source of truth; map spacing, type, radius, color, and shadow to exact tokens/classes, add missing tokens instead of hardcoding, and verify against the exported frame when visual fidelity matters
-- installed `vibe` uses packaged UI assets, not raw repo `ui/dist/`; for packaged CLI/UI preview, build UI and reinstall from a normal wheel, not `uv tool install --force --editable .`
-- do not run editable installs against system Python, and do not restart local `vibe` for UI checks unless the user explicitly requests that local-service workflow
+- installed `vibe` uses packaged UI assets, not raw repo `ui/dist/`; for packaged CLI/UI preview, build UI and reinstall from a normal wheel — never `uv tool install --force --editable .`, and never an editable install against system Python
 
 ## 7. Testing and Validation
 
-- prefer the smallest relevant checks first: focused pytest, targeted scripts, or narrow manual validation
-- keep slow full-suite gates in GitHub CI rather than running them locally for every feature PR
 - add tests when an existing test pattern already exists
 - do not introduce a brand-new test framework unless requested
-
-Testing guidance:
-
 - use pytest-style tests (`test_<feature>.py`) colocated or under `tests/`
 - for IM integrations, stub/mock platform clients and validate outbound payload/schema behavior
 - for reusable capability-first testing guidance, use `standards/scenario-testing/AGENTS.md` as the entrypoint; project-specific scenario metadata lives under `tests/scenarios/`
 - when a scenario catalog exists, make the scenario ID visible in the automated test and in the PR description
 - treat CLI examples in injected system prompts as live callers: update them with CLI flag changes and keep parser-backed contract coverage so unsupported examples cannot ship
 - for multi-step auth/setup flows, update `tests/scenarios/auth_setup/catalog.yaml` and add or update a closed-loop scenario harness case under `tests/scenarios/auth_setup/test_auth_setup_scenarios.py`; keep provider-specific parsing and heuristics in focused unit tests
-- for UI changes, run `npm run build` in `ui/`
-- for cross-platform or user-facing verification, use the Incus regression workflow
 - until CI fully covers a flow, do a manual sanity check for the affected workflow when practical
 
 ## 8. Git, Security, and Operational Safety

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -204,6 +204,7 @@ Source-of-truth rule:
 
 - run the smallest relevant validation first, then broader checks as needed
 - before `git push`, run `ruff check` on changed Python files at minimum
+- for UI changes, run `npm run build` in `ui/` before pushing
 - fix lint errors before pushing; CI runs `pre-commit run --all-files` with Ruff
 - do not require a full local CI run before opening or updating a PR; prefer focused local validation and let GitHub CI run the slow gates asynchronously
 

--- a/vibe/message_types.py
+++ b/vibe/message_types.py
@@ -125,7 +125,12 @@ def types_without(property_name: str) -> tuple[str, ...]:
 
 
 def input_author_type_pairs() -> tuple[tuple[str, str], ...]:
-    """Return accepted ``(author, message_type)`` input-turn pairs in catalog order."""
+    """Return accepted ``(author, message_type)`` input-turn pairs in catalog order.
+
+    ``inputAuthors`` lists the authors permitted to submit that type as input; it never
+    says who wrote a given row. ``annotation`` is two-way, so a row's identity and
+    direction come from its own ``author`` / ``source``.
+    """
 
     return tuple(
         (author, message_type)

--- a/vibe/message_types.py
+++ b/vibe/message_types.py
@@ -127,9 +127,10 @@ def types_without(property_name: str) -> tuple[str, ...]:
 def input_author_type_pairs() -> tuple[tuple[str, str], ...]:
     """Return accepted ``(author, message_type)`` input-turn pairs in catalog order.
 
-    ``inputAuthors`` lists the authors permitted to submit that type as input; it never
-    says who wrote a given row. ``annotation`` is two-way, so a row's identity and
-    direction come from its own ``author`` / ``source``.
+    ``inputAuthors`` lists the authors permitted to submit that type as input; it never says
+    who wrote a given row. ``annotation`` is two-way, and ``content.annotation.direction`` is
+    its authoritative direction field: ``author`` / ``source`` only classify the input turn,
+    which is why a user's own annotation is stored with ``author = harness``.
     """
 
     return tuple(

--- a/vibe/message_types.py
+++ b/vibe/message_types.py
@@ -127,10 +127,10 @@ def types_without(property_name: str) -> tuple[str, ...]:
 def input_author_type_pairs() -> tuple[tuple[str, str], ...]:
     """Return accepted ``(author, message_type)`` input-turn pairs in catalog order.
 
-    ``inputAuthors`` lists the authors permitted to submit that type as input; it never says
-    who wrote a given row. ``annotation`` is two-way, and ``content.annotation.direction`` is
-    its authoritative direction field: ``author`` / ``source`` only classify the input turn,
-    which is why a user's own annotation is stored with ``author = harness``.
+    ``inputAuthors`` lists the authors permitted to submit that type as input, so an input turn is
+    classified by this ``(author, type)`` pair alone; it never says who wrote a given row.
+    ``annotation`` is two-way and its direction lives in ``content.annotation.direction``, never in
+    ``author``, which is ``harness`` on a user annotation dispatched as agent input.
     """
 
     return tuple(

--- a/vibe/message_types.py
+++ b/vibe/message_types.py
@@ -127,10 +127,10 @@ def types_without(property_name: str) -> tuple[str, ...]:
 def input_author_type_pairs() -> tuple[tuple[str, str], ...]:
     """Return accepted ``(author, message_type)`` input-turn pairs in catalog order.
 
-    ``inputAuthors`` lists the authors permitted to submit that type as input, so an input turn is
-    classified by this ``(author, type)`` pair alone; it never says who wrote a given row.
+    ``inputAuthors`` names the stored authors whose rows of that type count as an input turn; it is
+    classification, not a write-time permission, and never claims who wrote a given row.
     ``annotation`` is two-way and its direction lives in ``content.annotation.direction``, never in
-    ``author``, which is ``harness`` on a user annotation dispatched as agent input.
+    ``author``, which is ``harness`` only on a user annotation dispatched as agent input.
     """
 
     return tuple(


### PR DESCRIPTION
## Changed capability

Two edits: one clarification added where the field is read, and a reduction that pays for it.

### 1. `inputAuthors` is documented adjacent to its reader

`vibe/message_types.json` declares `inputAuthors` per type and JSON cannot carry a comment, so the meaning now lives in the docstring of `input_author_type_pairs()` in `vibe/message_types.py` — the accepted-input-pairs helper that reads the field:

> `inputAuthors` names the stored authors whose rows of that type count as an input turn; it is classification, not a write-time permission, and never claims who wrote a given row. `annotation` is two-way and its direction lives in `content.annotation.direction`, never in `author`, which is `harness` only on a user annotation dispatched as agent input.

`ui/src/lib/messageTypes.ts` is deliberately untouched: it derives property names from `keyof typeof catalog.defaults` and never names `inputAuthors`, so there is no declaration there to mirror.

Nothing was added to `AGENTS.md` — a lesson learned from one field in one feature does not belong in a file that loads into every agent's context.

### 2. `AGENTS.md` gets shorter

Every deletion is a rule the file already states elsewhere; each survives in its more actionable location.

| Deleted from | Why no future agent needs it |
| --- | --- |
| §1 `make the next agent/platform inherit correct behavior automatically` | §2's decision checklist item 4 asks the identical question as a check |
| §3 the three-bullet `Use local vibe for:` list (now one sentence) | packaging/CLI checks survive in the sentence; the dropped `editable-install UI preview` bullet contradicted §6, which owns UI preview and requires a normal wheel |
| §5 `### Documentation Expectations` heading + `do not put ad-hoc project documentation in the repo root` | merged into `### Planning and Documentation`; "under `docs/`, never in the repo root" is one rule that was written as two bullets |
| §5 `keep expensive full-suite gates on GitHub CI by default` | Pre-Push already says to let GitHub CI run the slow gates asynchronously; only the merge-gate half needed to survive |
| §6 `reuse ui/src/components/ui/ primitives first …` | the next bullet is the same ladder in general form; the primitive list moved into it |
| §6 `do not restart local vibe for UI checks …` | §3's hard rule already forbids restarting the local service for routine verification; the editable-install clause merged upward |
| §7 `prefer the smallest relevant checks first` | §5 Pre-Push states it as a pre-push instruction |
| §7 `keep slow full-suite gates in GitHub CI …` | same rule as the §5 line above, third occurrence |
| §7 `Testing guidance:` heading | it split one list of testing rules into two lists of testing rules |
| §7 `for UI changes, run npm run build in ui/` | ~~§6 Frontend gives the build command~~ — **not a dedupe; restored** in `49a99a41` as a §5 Pre-Push bullet, where pre-push gates now live: §6 says where the source is and how to build, not that a UI change must build before pushing |
| §7 `for cross-platform or user-facing verification, use the Incus regression workflow` | §3 states it as a hard rule |

Nothing was deleted as stale-by-falsehood: every claim in `AGENTS.md` was checked against the code and holds — `state_meta.default_agent_name` is live at `core/vibe_agents.py:27`, `REGRESSION_SHOW_RUNTIME_SOURCE` resolves through `regression_env("SHOW_RUNTIME_SOURCE", "github-source")` in `scripts/incus_regression.py`, and every referenced path still exists. Neither `AGENTS.md` nor the lane standard contains any statement about Show annotations (zero matches for `annotat`), so there was no stale annotation text to remove in either file.

## Net line delta

| File | Before | After | Delta |
| --- | --- | --- | --- |
| `AGENTS.md` | 296 | 278 | **−18** |
| `vibe/message_types.py` | 185 | 191 | +6 (docstring; not part of the doc budget) |

The one clarification is paid for by deletions: net **−18** doc lines in this PR.

## Not in this diff

`.agents/skills/pr-delivery-loop/SKILL.md` was edited in the same pass — §1a's second bullet sharpened to state the invariant mechanically ("seed one row of every shape that already exists, run the change, and assert the rows are unchanged — never list which shapes are skipped") plus three incident-coordinate trims, −3 lines. That file lives in the multi-repo workspace under `~/vibe-remote-project/.agents/`, which is not a git repository and is not tracked by this repo, so it cannot be committed here. Combined doc delta across both files: **−21**.

## Review follow-up

Four Codex P2s, all correct, all on the same sentence of this docstring. Each was verified at the source before the wording changed.

| Finding | Verified against | Fix |
| --- | --- | --- |
| direction is not in `author` / `source` | `core/show_session_events.py:887` writes `content.annotation.direction`; `ui/src/lib/annotationView.ts:12` says `author` "never reaches the view"; `source` is `None` on non-harness-input rows | `9309c717` names `content.annotation.direction` |
| `source` is not part of input-turn identity | `is_input_turn()` is `(author, message_type) in INPUT_TURN_AUTHOR_TYPES` (`vibe/message_identity.py:16`), and this function's own predicate emits `(author = ... and type = ...)` with no `source` | `164657bc` drops `source` from the contract |
| harness authorship applies only to dispatching annotations | `harness_input = requests_dispatch`, and `show_event_requests_dispatch()` returns `bool(payload.get("dispatch"))`, so a `dispatch: false` annotation stores `author="user"` | `164657bc` qualifies it to "dispatched as agent input" |
| `inputAuthors` is classification, not permission | all eight consumers classify stored rows (`message_identity:16`, `internal_server:402`, `show_git:40`, `session_fork:127,501`, `messages_service:1103`, `codex/agent.py:1061`, `opencode/session.py:115`, `messageSearchRole.ts:25`); nothing validates a write against the field | `fd6ceb8e` rewords to classification |

`AGENTS.md` is untouched by all four fixes, so the doc delta is unchanged.

**Known follow-up, deliberately not in this diff:** `ui/src/components/workbench/search/messageSearchRole.ts:21` carries the same stale "`inputAuthors` is a permission" framing in a comment. The owner scoped this PR to the Python docstring plus the `AGENTS.md` reductions, so that one-line correction is handed to them rather than widening this diff.

### Restored on review

This line was cut from §7 as a duplicate of §6's build command:

> - for UI changes, run `npm run build` in `ui/`

It was not one: §6 documents where the UI source lives and how to build it, while this line is a gate — a UI change that does not compile fails CI. Restored in `49a99a41` as a §5 Pre-Push requirement next to the `ruff check` bullet, which is where pre-push gates live after this PR. Ten deletions stand; this one is reversed, so `AGENTS.md` lands at −18.

## Evidence layers

- **unit**: `tests/test_message_type_catalog.py` — 14 passed
- **lint**: `ruff check vibe/message_types.py` — clean
- **contract**: unaffected — no catalog value, helper signature, or SQL predicate changed; the only Python edit is a docstring
- **scenario**: none — no scenario catalog covers agent-guidance prose
- **residual manual checks**: none




