### PR TITLE
fix(remote-access): recover hostname follow-up commits into org

### DIFF
--- a/docs/superpowers/plans/2026-07-23-custom-hostname-migration-compatibility.md
+++ b/docs/superpowers/plans/2026-07-23-custom-hostname-migration-compatibility.md
@@ -1,6 +1,16 @@
-# Custom Hostname Migration Compatibility Implementation Plan
+# Custom Hostname Migration Compatibility Implementation Plan (Historical)
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **Status:** Superseded by the `org` integration. Do not execute the unchecked
+> steps against the current tree; they are preserved as a record of the original
+> feature-branch repair.
+
+## Org Integration Resolution
+
+`org` already contains the released `20260716_0030` and `20260721_0031`
+migrations. Its linear chain uses `20260723_0032` for session visibility,
+`20260725_0035` for resource ACLs, and `20260725_0038` as the schema head. The
+follow-up recovery therefore retained that chain and added only the hermetic
+released-`0030` upgrade regression from this plan.
 
 **Goal:** Start the custom-hostname heartbeat branch against released Avibe state and complete remote authentication through `max.fileguard.io`.
 

--- a/docs/superpowers/plans/2026-07-23-custom-hostname-migration-compatibility.md
+++ b/docs/superpowers/plans/2026-07-23-custom-hostname-migration-compatibility.md
@@ -1,0 +1,49 @@
+# Custom Hostname Migration Compatibility Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Start the custom-hostname heartbeat branch against released Avibe state and complete remote authentication through `max.fileguard.io`.
+
+**Architecture:** Linearize the branch's Alembic history after the released `20260716_0030` and `20260721_0031` revisions, then verify the real service-to-backend-to-browser flow. All automated migration probes use temporary databases; the default state is touched only by the managed service startup after focused tests pass.
+
+**Tech Stack:** Python 3.11, Alembic, SQLite, pytest, Avibe CLI/API, Cloudflare tunnel, OIDC.
+
+---
+
+### Task 1: Reproduce Released-State Upgrade Failure
+
+**Files:**
+- Modify: `tests/test_sqlite_state_migration.py`
+
+- [ ] Add `test_run_migrations_upgrades_released_0030_to_acl_head`, which creates a temporary database at `20260716_0030`, runs `run_migrations`, and asserts the final revision, the `silent` inbox predicate, and ACL tables.
+- [ ] Run `pytest tests/test_sqlite_state_migration.py::test_run_migrations_upgrades_released_0030_to_acl_head -q`.
+- [ ] Confirm it fails because `20260716_0030` cannot be resolved by the branch.
+
+### Task 2: Linearize Alembic History
+
+**Files:**
+- Create: `storage/alembic/versions/20260716_0030_harness_input_index.py`
+- Create: `storage/alembic/versions/20260721_0031_silent_marker_inbox_index.py`
+- Rename: `storage/alembic/versions/20260720_0030_resource_access_policies.py` to `storage/alembic/versions/20260723_0032_resource_access_policies.py`
+- Modify: `storage/migrations.py`
+- Modify: `tests/test_sqlite_state_migration.py`
+
+- [ ] Copy the two released migration definitions exactly from `origin/master`.
+- [ ] Change the ACL migration revision to `20260723_0032` with `down_revision = "20260721_0031"`.
+- [ ] Set `LATEST_SCHEMA_REVISION` and the test `HEAD_REVISION` to `20260723_0032`.
+- [ ] Re-run the focused released-state upgrade test and confirm it passes.
+- [ ] Run all of `tests/test_sqlite_state_migration.py` and the focused remote-access test files.
+- [ ] Run Ruff on every changed Python file.
+
+### Task 3: Apply and Verify the Runtime
+
+**Files:**
+- Runtime only; no additional source files expected.
+
+- [ ] Reinstall the current branch into the `uv tool` environment.
+- [ ] Start a managed restart with `AVIBE_ALLOW_DEV_STATE_MIGRATION=1` because this is an intentional source-checkout migration of default state.
+- [ ] Poll the local `/status` endpoint until the main service has a live PID and remains healthy.
+- [ ] Confirm logs show a successful runtime-status heartbeat and no Alembic startup error.
+- [ ] Confirm the active-hostname snapshot includes `max.fileguard.io` through read-only runtime evidence.
+- [ ] Request `https://max.fileguard.io/` without following redirects and confirm an OIDC 302 response.
+- [ ] Complete the browser login flow and confirm the callback stays on `max.fileguard.io`.

--- a/docs/superpowers/specs/2026-07-23-custom-hostname-migration-compatibility-design.md
+++ b/docs/superpowers/specs/2026-07-23-custom-hostname-migration-compatibility-design.md
@@ -1,4 +1,8 @@
-# Custom Hostname Migration Compatibility Design
+# Custom Hostname Migration Compatibility Design (Historical)
+
+> **Status:** Superseded by the `org` integration. The feature-branch numbering
+> below documents the original repair and must not be applied to the current
+> migration chain.
 
 ## Problem
 
@@ -14,6 +18,15 @@ Preserve the existing database and move forward on one migration chain:
 4. Set the local schema head to `20260723_0032`.
 
 This lets databases created by current releases upgrade normally while retaining the ACL branch's schema. It does not stamp, downgrade, reset, or directly edit user state.
+
+## Org Integration Resolution
+
+The current `org` chain already includes the released `20260716_0030` and
+`20260721_0031` migrations. It assigns `20260723_0032` to session visibility,
+places the resource ACL migration at `20260725_0035`, and advances the schema
+head to `20260725_0038`. Recovering this follow-up preserves those revisions and
+ports the released-`0030` upgrade regression without renaming migrations or
+rewinding the schema head.
 
 ## Verification
 

--- a/docs/superpowers/specs/2026-07-23-custom-hostname-migration-compatibility-design.md
+++ b/docs/superpowers/specs/2026-07-23-custom-hostname-migration-compatibility-design.md
@@ -1,0 +1,32 @@
+# Custom Hostname Migration Compatibility Design
+
+## Problem
+
+The custom-hostname heartbeat branch cannot start against the default Avibe state database. The database is stamped at `20260716_0030`, while the branch contains a different migration head, `20260720_0030`, descending directly from `20260707_0029`. Alembic therefore cannot resolve the installed database revision. The main service exits before it can send runtime-status heartbeats, so the Web UI never receives the backend's `active_hostnames` snapshot and rejects `max.fileguard.io`.
+
+## Design
+
+Preserve the existing database and move forward on one migration chain:
+
+1. Add the released `20260716_0030_harness_input_index` migration.
+2. Add the released `20260721_0031_silent_marker_inbox_index` migration, descending from `20260716_0030`.
+3. Rename the unreleased resource ACL migration to `20260723_0032_resource_access_policies` and make it descend from `20260721_0031`.
+4. Set the local schema head to `20260723_0032`.
+
+This lets databases created by current releases upgrade normally while retaining the ACL branch's schema. It does not stamp, downgrade, reset, or directly edit user state.
+
+## Verification
+
+- A hermetic migration test starts at `20260716_0030`, upgrades to head, and verifies both the released `0031` index behavior and ACL tables.
+- Existing migration, remote-access heartbeat, and OAuth host tests pass.
+- The source install starts the main service with a new PID.
+- A successful heartbeat persists `max.fileguard.io` as an active hostname.
+- `https://max.fileguard.io/` returns an OIDC redirect instead of `remote_access_host_mismatch`.
+- Browser authentication returns to `https://max.fileguard.io/auth/callback` and completes successfully.
+
+## Safety
+
+- Do not reset or downgrade `~/.avibe` state.
+- Do not modify pairing, tunnel, or remote-access credentials.
+- Do not merge unrelated current-master changes into this feature branch.
+- Keep the existing independent UI process and tunnel configuration intact except for the required managed restart.

--- a/tests/test_sqlite_state_migration.py
+++ b/tests/test_sqlite_state_migration.py
@@ -121,7 +121,9 @@ def test_run_migrations_creates_initial_schema(tmp_path: Path) -> None:
         assert "ix_messages_inbox_agent_reply" in message_indexes
         assert "ix_messages_inbox_user_send" in message_indexes
         assert "harness_dedupe" in _index_sql(conn, "ix_messages_inbox_activity")
-        assert "author = 'harness'" in _index_sql(conn, "ix_messages_inbox_user_send")
+        user_send_index_sql = _index_sql(conn, "ix_messages_inbox_user_send")
+        assert "author = 'user' and type = 'user'" in user_send_index_sql
+        assert "author = 'harness' and type = 'harness'" in user_send_index_sql
         assert "uq_vault_secrets_name_folded" in vault_secret_indexes
         assert "lower(name)" in _index_sql(conn, "uq_vault_secrets_name_folded").lower()
         assert "ix_vault_auth_factors_kind_rp" in vault_auth_factor_indexes
@@ -674,6 +676,42 @@ def test_run_migrations_adds_agent_events_from_previous_head(tmp_path: Path) -> 
     assert "ix_agent_events_turn_sequence_id" in agent_event_indexes
 
 
+def test_run_migrations_upgrades_released_0030_to_acl_head(tmp_path: Path) -> None:
+    db_path = tmp_path / "vibe.sqlite"
+
+    run_migrations(db_path, revision="20260707_0029")
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            "update messages set author = 'harness', type = 'harness' "
+            "where source = 'harness' and author = 'user' and type = 'user'"
+        )
+        conn.execute("drop index if exists ix_messages_inbox_user_send")
+        conn.execute(
+            "create index ix_messages_inbox_user_send "
+            "on messages (platform, session_id, created_at desc, id desc) "
+            "where session_id is not null and "
+            "((author = 'user' and type = 'user') or "
+            "(author = 'harness' and type = 'harness'))"
+        )
+        conn.execute(
+            "update alembic_version set version_num = '20260716_0030'"
+        )
+        conn.commit()
+
+    run_migrations(db_path)
+
+    with sqlite3.connect(db_path) as conn:
+        version = conn.execute("select version_num from alembic_version").fetchone()
+        tables = {
+            row[0]
+            for row in conn.execute("select name from sqlite_master where type = 'table'")
+        }
+        assert version == (HEAD_REVISION,)
+        assert "'silent'" in _index_sql(conn, "ix_messages_inbox_activity")
+        assert "resource_access_policies" in tables
+        assert "resource_access_groups" in tables
+
+
 def test_run_migrations_rebuilds_inbox_indexes_for_harness_inputs(tmp_path: Path) -> None:
     db_path = tmp_path / "vibe.sqlite"
 
@@ -688,7 +726,9 @@ def test_run_migrations_rebuilds_inbox_indexes_for_harness_inputs(tmp_path: Path
         version = conn.execute("select version_num from alembic_version").fetchone()
         assert version == (HEAD_REVISION,)
         assert "harness_dedupe" in _index_sql(conn, "ix_messages_inbox_activity")
-        assert "author = 'harness'" in _index_sql(conn, "ix_messages_inbox_user_send")
+        user_send_index_sql = _index_sql(conn, "ix_messages_inbox_user_send")
+        assert "author = 'user' and type = 'user'" in user_send_index_sql
+        assert "author = 'harness' and type = 'harness'" in user_send_index_sql
 
 
 def test_run_migrations_backfills_legacy_harness_prompt_identity(tmp_path: Path) -> None:

--- a/ui/agentation.d.ts
+++ b/ui/agentation.d.ts
@@ -1,0 +1,11 @@
+declare module 'agentation' {
+  import type { ComponentType } from 'react';
+
+  type AgentationProps = {
+    copyToClipboard?: boolean;
+    onCopy?: (text: string) => void;
+    onSubmit?: (output: string) => void;
+  };
+
+  export const Agentation: ComponentType<AgentationProps>;
+}

--- a/ui/tsconfig.app.json
+++ b/ui/tsconfig.app.json
@@ -28,6 +28,6 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["src"],
+  "include": ["src", "agentation.d.ts"],
   "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx"]
 }


### PR DESCRIPTION
## Summary

- Recover the 3 dangling follow-up commits from `feat/custom-hostname-heartbeat`: the released-schema migration path, omission of an unknown observed origin, and the Agentation module declaration.
- These commits were missing because the manual `org` integration landed the earlier hostname work while later source-branch commits remained untracked by any PR.
- Preserve `org`'s newer linear Alembic chain through `20260725_0038`; add a regression proving a released `20260716_0030` database upgrades through the ACL schema.
- Complete the Agentation declaration for current `org` TypeScript configuration so the production UI build consumes it.

## Evidence

- Unit: `uv run pytest -q tests/test_sqlite_state_migration.py` (63 passed).
- Contract / remote access: `uv run pytest -q tests/test_remote_access_vibe_cloud.py tests/test_ui_remote_access_auth.py` (275 passed).
- Scenario: RA-TQ-007 remains covered in `tests/test_remote_access_vibe_cloud.py`; no scenario catalog behavior changed.
- Lint: `uvx ruff check tests/test_sqlite_state_migration.py tests/test_remote_access_vibe_cloud.py vibe/remote_access.py` (passed).
- UI: `cd ui && npm run build` (passed).
- Residual manual checks: none; no local service restart or Incus regression was performed, per lane scope.