### PR TITLE
fix(resource-acl): publish human-readable resource names

### DIFF
--- a/core/services/skills.py
+++ b/core/services/skills.py
@@ -263,6 +263,27 @@ def skill_resource_id(
     )
 
 
+def get_skill_resource_metadata(resource_id: str) -> dict[str, str] | None:
+    """Resolve the display name encoded by a validated Skill resource ID."""
+
+    parts = str(resource_id or "").split(":")
+    if len(parts) != 4:
+        return None
+    backend, scope, project_segment, name = parts
+    if (
+        _backend_from_agent_ref(backend) != backend
+        or scope not in _SKILL_RESOURCE_SCOPES
+        or not project_segment
+    ):
+        return None
+    try:
+        if _normalize_skill_name(name) != name:
+            return None
+    except SkillsError:
+        return None
+    return {"display_name": name}
+
+
 def _skill_scope(skill: dict[str, Any], requested_scope: str) -> str | None:
     scope = str(skill.get("scope") or "").strip().lower()
     if scope in _SKILL_RESOURCE_SCOPES:

--- a/core/show_pages.py
+++ b/core/show_pages.py
@@ -90,6 +90,34 @@ class ShowPage:
         return self.visibility == VISIBILITY_OFFLINE
 
 
+def get_show_page_resource_metadata(connection: Connection, session_id: str) -> dict[str, str] | None:
+    """Return the Show Page title metadata allowed in the hosted index."""
+
+    row = connection.execute(
+        select(
+            show_pages.c.session_id,
+            show_pages.c.updated_at.label("page_updated_at"),
+            agent_sessions.c.title,
+            agent_sessions.c.updated_at.label("session_updated_at"),
+        )
+        .select_from(
+            show_pages.outerjoin(
+                agent_sessions,
+                agent_sessions.c.id == show_pages.c.session_id,
+            )
+        )
+        .where(show_pages.c.session_id == session_id)
+        .limit(1)
+    ).mappings().first()
+    if row is None:
+        return None
+    title = str(row["title"] or "").strip()
+    return {
+        "display_name": title or str(row["session_id"]),
+        "updated_at": str(row["session_updated_at"] or row["page_updated_at"]),
+    }
+
+
 def validate_session_id(session_id: str) -> str:
     value = (session_id or "").strip()
     if not value:

--- a/core/vibe_agents.py
+++ b/core/vibe_agents.py
@@ -13,6 +13,7 @@ from uuid import uuid4
 
 import yaml
 from sqlalchemy import select
+from sqlalchemy.engine import Connection
 from sqlalchemy.exc import IntegrityError
 
 from config import paths
@@ -33,6 +34,20 @@ _UNSET = object()
 
 class VibeAgentAccessError(PermissionError):
     """Raised when the caller is not allowed to use a Vibe Agent."""
+
+
+def get_agent_resource_metadata(connection: Connection, resource_id: str) -> dict[str, str] | None:
+    """Return the safe Agent fields allowed in the hosted resource index."""
+
+    row = connection.execute(
+        select(agents.c.name, agents.c.updated_at).where(agents.c.id == resource_id).limit(1)
+    ).mappings().first()
+    if row is None:
+        return None
+    return {
+        "display_name": str(row["name"]),
+        "updated_at": str(row["updated_at"]),
+    }
 
 
 def _utc_now_iso() -> str:

--- a/storage/vault_service.py
+++ b/storage/vault_service.py
@@ -2514,6 +2514,22 @@ def get_secret_meta(conn: Connection, name: str, *, user_context: Any = None) ->
     return _meta_payload(require_secret_access(conn, name, user_context=user_context))
 
 
+def get_secret_resource_metadata(conn: Connection, resource_id: str) -> dict[str, str] | None:
+    """Return value-free Vault metadata allowed in the hosted resource index."""
+
+    row = conn.execute(
+        select(vault_secrets.c.name, vault_secrets.c.updated_at)
+        .where(vault_secrets.c.id == resource_id)
+        .limit(1)
+    ).mappings().first()
+    if row is None:
+        return None
+    return {
+        "display_name": str(row["name"]),
+        "updated_at": str(row["updated_at"]),
+    }
+
+
 def get_signing_public_key(conn: Connection, name: str, *, user_context: Any = None) -> dict[str, Any] | None:
     """Raw pinned signing public key ({curve, public_key}) from storage.
 

--- a/tests/test_remote_resource_acl_sync.py
+++ b/tests/test_remote_resource_acl_sync.py
@@ -3,11 +3,15 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
+from sqlalchemy import update
+
 from config import paths
 from config.v2_config import AgentsConfig, PlatformsConfig, RemoteAccessConfig, RuntimeConfig, SlackConfig, UiConfig, V2Config
+from core.services.skills import skill_resource_id
 from storage import resource_access_service
 from storage.db import get_cached_sqlite_engine
 from storage.migrations import run_migrations
+from storage.models import agent_sessions, agents, show_pages, vault_secrets
 from vibe import remote_access
 
 
@@ -68,6 +72,229 @@ def _descriptor() -> dict[str, Any]:
         "access_level": "private",
         "group_ids": [],
     }
+
+
+def _seed_named_resources() -> dict[str, str]:
+    paths.ensure_data_dirs()
+    run_migrations()
+    engine = get_cached_sqlite_engine()
+    created_at = "2026-07-27T20:00:00.000001+00:00"
+    resource_ids = {
+        "agent": "agent-safe-name",
+        "vault_secret": "vlt_safe_name",
+        "skill": skill_resource_id(
+            "codex",
+            scope="global",
+            project_dir=None,
+            name="release-notes",
+        ),
+        "show_page": "ses-safe-name",
+    }
+    with engine.begin() as connection:
+        connection.execute(
+            agents.insert().values(
+                id=resource_ids["agent"],
+                name="Research Agent",
+                normalized_name="research-agent",
+                description="private-agent-description",
+                backend="codex",
+                model="private-agent-model",
+                reasoning_effort="high",
+                system_prompt="private-agent-prompt",
+                enabled=1,
+                source="user",
+                source_ref="/private/agent/source",
+                metadata_json='{"execution_output":"private-agent-output"}',
+                created_at=created_at,
+                updated_at=created_at,
+            )
+        )
+        connection.execute(
+            vault_secrets.insert().values(
+                id=resource_ids["vault_secret"],
+                name="PRODUCTION_API_KEY",
+                tags='["private-vault-tag"]',
+                kind="static",
+                protection="standard",
+                source="manual",
+                ciphertext="private-vault-ciphertext",
+                nonce="private-vault-nonce",
+                wrap_meta="private-vault-wrap",
+                public_meta='{"description":"private-vault-description"}',
+                policy='{"allowed_hosts":["private.example"]}',
+                use_count=0,
+                created_at=created_at,
+                updated_at=created_at,
+            )
+        )
+        connection.execute(
+            agent_sessions.insert().values(
+                id=resource_ids["show_page"],
+                scope_id=None,
+                agent_backend="codex",
+                agent_variant="default",
+                session_anchor="private-show-anchor",
+                workdir="/private/show/workspace",
+                native_session_id="private-native-session",
+                title="Quarterly Results",
+                status="active",
+                metadata_json='{"execution_output":"private-show-output"}',
+                created_at=created_at,
+                updated_at=created_at,
+                last_active_at=created_at,
+            )
+        )
+        connection.execute(
+            show_pages.insert().values(
+                session_id=resource_ids["show_page"],
+                visibility="private",
+                share_id=None,
+                offline_at=None,
+                created_at=created_at,
+                updated_at=created_at,
+            )
+        )
+        for resource_kind, resource_id in resource_ids.items():
+            resource_access_service.ensure_resource_policy(
+                connection,
+                resource_kind=resource_kind,
+                resource_id=resource_id,
+                organization_id="org-1",
+                owner_user_id="owner-1",
+                access_level="private",
+                policy_revision=3,
+                last_applied_control_plane_revision=2,
+            )
+    return resource_ids
+
+
+def test_local_descriptors_resolve_all_resource_names_without_content() -> None:
+    resource_ids = _seed_named_resources()
+
+    descriptors = remote_access._local_policy_resource_descriptors("org-1")
+    by_kind = {descriptor["resource_kind"]: descriptor for descriptor in descriptors}
+
+    assert set(by_kind) == {"agent", "vault_secret", "skill", "show_page"}
+    assert by_kind["agent"]["display_name"] == "Research Agent"
+    assert by_kind["vault_secret"]["display_name"] == "PRODUCTION_API_KEY"
+    assert by_kind["skill"]["display_name"] == "release-notes"
+    assert by_kind["show_page"]["display_name"] == "Quarterly Results"
+    allowed_descriptor_fields = {
+        "resource_id",
+        "resource_kind",
+        "display_name",
+        "owner_user_id",
+        "metadata_revision",
+        "applied_acl_revision",
+        "access_level",
+        "group_ids",
+        "sync_status",
+    }
+    for resource_kind, resource_id in resource_ids.items():
+        assert set(by_kind[resource_kind]) == allowed_descriptor_fields
+        assert by_kind[resource_kind]["resource_id"] == resource_id
+        assert by_kind[resource_kind]["metadata_revision"] >= 3
+
+    serialized = repr(descriptors)
+    for forbidden in (
+        "private-agent-description",
+        "private-agent-model",
+        "private-agent-prompt",
+        "private-agent-output",
+        "/private/agent/source",
+        "private-vault-tag",
+        "private-vault-ciphertext",
+        "private-vault-nonce",
+        "private-vault-wrap",
+        "private-vault-description",
+        "private.example",
+        "private-show-anchor",
+        "/private/show/workspace",
+        "private-native-session",
+        "private-show-output",
+    ):
+        assert forbidden not in serialized
+
+
+def test_local_descriptor_title_revision_and_safe_fallback() -> None:
+    resource_ids = _seed_named_resources()
+    first = {
+        item["resource_kind"]: item
+        for item in remote_access._local_policy_resource_descriptors("org-1")
+    }["show_page"]
+    engine = get_cached_sqlite_engine()
+    with engine.begin() as connection:
+        connection.execute(
+            update(agent_sessions)
+            .where(agent_sessions.c.id == resource_ids["show_page"])
+            .values(
+                title="Executive Overview",
+                updated_at="2026-07-27T20:00:00.000002+00:00",
+            )
+        )
+
+    renamed = {
+        item["resource_kind"]: item
+        for item in remote_access._local_policy_resource_descriptors("org-1")
+    }["show_page"]
+    assert renamed["display_name"] == "Executive Overview"
+    assert renamed["metadata_revision"] > first["metadata_revision"]
+
+    with engine.begin() as connection:
+        connection.execute(
+            update(agent_sessions)
+            .where(agent_sessions.c.id == resource_ids["show_page"])
+            .values(
+                title=None,
+                updated_at="2026-07-27T20:00:00.000003+00:00",
+            )
+        )
+    untitled = {
+        item["resource_kind"]: item
+        for item in remote_access._local_policy_resource_descriptors("org-1")
+    }["show_page"]
+    assert untitled["display_name"] == resource_ids["show_page"]
+    assert untitled["metadata_revision"] > renamed["metadata_revision"]
+
+    with engine.begin() as connection:
+        connection.execute(
+            update(agent_sessions)
+            .where(agent_sessions.c.id == resource_ids["show_page"])
+            .values(
+                title="/private/show/title",
+                updated_at="2026-07-27T20:00:00.000004+00:00",
+            )
+        )
+    unsafe = {
+        item["resource_kind"]: item
+        for item in remote_access._local_policy_resource_descriptors("org-1")
+    }["show_page"]
+    assert unsafe["display_name"] == resource_ids["show_page"]
+    assert unsafe["metadata_revision"] > untitled["metadata_revision"]
+    assert "/private/show/title" not in repr(unsafe)
+
+
+def test_local_descriptors_omit_missing_source_rows() -> None:
+    paths.ensure_data_dirs()
+    run_migrations()
+    engine = get_cached_sqlite_engine()
+    with engine.begin() as connection:
+        for resource_kind, resource_id in (
+            ("agent", "missing-agent"),
+            ("vault_secret", "missing-vault"),
+            ("skill", "missing-skill"),
+            ("show_page", "missing-show-page"),
+        ):
+            resource_access_service.ensure_resource_policy(
+                connection,
+                resource_kind=resource_kind,
+                resource_id=resource_id,
+                organization_id="org-1",
+                owner_user_id="owner-1",
+                access_level="private",
+            )
+
+    assert remote_access._local_policy_resource_descriptors("org-1") == []
 
 
 def test_sync_applies_only_newer_intent_and_acknowledges_exact_revision(monkeypatch) -> None:

--- a/vibe/remote_access.py
+++ b/vibe/remote_access.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import atexit
 import base64
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timezone
 import hashlib
 import hmac
 import http.client
@@ -96,6 +96,7 @@ _RESOURCE_ACL_SYNC_ERROR_CODE_RE = re.compile(r"\A[a-z0-9][a-z0-9_:-]{0,119}\Z")
 _RESOURCE_ACL_RESOURCE_KINDS = frozenset({"agent", "vault_secret", "skill", "show_page"})
 _RESOURCE_ACL_ACCESS_LEVELS = frozenset({"public", "scope", "private"})
 _RESOURCE_ACL_SYNC_STATUSES = frozenset({"in_sync", "pending", "offline", "error", "deleted"})
+_RESOURCE_ACL_MAX_REVISION = (1 << 53) - 1
 _RESOURCE_ACL_PENDING_VAULT_RELEASE_PREFIX = "resource_acl_pending_vault_release:"
 _INSTANCE_ACCESS_ROLES = frozenset({"owner", "editor", "viewer"})
 _INSTANCE_ACCESS_SOURCES = frozenset({"owner", "public_instance", "email", "email_domain", "organization_group"})
@@ -925,25 +926,88 @@ def _resource_acl_sync_error_code(exc: BaseException) -> str:
     return "resource_acl_sync_failed"
 
 
+def _resource_metadata_revision(value: Any) -> int:
+    if not isinstance(value, str) or not value.strip():
+        return 0
+    try:
+        parsed = datetime.fromisoformat(value.strip().replace("Z", "+00:00"))
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return max(0, min(int(parsed.timestamp() * 1_000_000), _RESOURCE_ACL_MAX_REVISION))
+    except (OverflowError, ValueError):
+        return 0
+
+
+def _local_resource_metadata(connection, resource_kind: str, resource_id: str) -> Mapping[str, Any] | None:
+    if resource_kind == "agent":
+        from core.vibe_agents import get_agent_resource_metadata
+
+        return get_agent_resource_metadata(connection, resource_id)
+    if resource_kind == "vault_secret":
+        from storage.vault_service import get_secret_resource_metadata
+
+        return get_secret_resource_metadata(connection, resource_id)
+    if resource_kind == "skill":
+        from core.services.skills import get_skill_resource_metadata
+
+        return get_skill_resource_metadata(resource_id)
+    if resource_kind == "show_page":
+        from core.show_pages import get_show_page_resource_metadata
+
+        return get_show_page_resource_metadata(connection, resource_id)
+    return None
+
+
+def _safe_resource_display_name(value: Any, fallback: str) -> str:
+    try:
+        return _safe_resource_acl_identifier(value, limit=240)
+    except ValueError:
+        return _safe_resource_acl_identifier(fallback, limit=240)
+
+
 def _local_policy_resource_descriptors(organization_id: str) -> list[dict[str, Any]]:
     from storage import resource_access_service
+    from storage.db import get_cached_sqlite_engine
 
-    policies = resource_access_service.list_resource_policies(organization_id=organization_id)
-    return [
-        {
-            "resource_id": policy["resource_id"],
-            "resource_kind": policy["resource_kind"],
-            # Resource-specific services can later supply richer safe names.
-            "display_name": policy["resource_id"],
-            "owner_user_id": policy.get("owner_user_id"),
-            "metadata_revision": int(policy.get("policy_revision") or 0),
-            "applied_acl_revision": int(policy.get("last_applied_control_plane_revision") or 0),
-            "access_level": policy["access_level"],
-            "group_ids": policy.get("group_ids") or [],
-            "sync_status": "in_sync",
-        }
-        for policy in policies
-    ]
+    descriptors: list[dict[str, Any]] = []
+    engine = get_cached_sqlite_engine()
+    with engine.connect() as connection:
+        policies = resource_access_service.list_resource_policies(
+            organization_id=organization_id,
+            connection=connection,
+        )
+        for policy in policies:
+            metadata = _local_resource_metadata(
+                connection,
+                str(policy["resource_kind"]),
+                str(policy["resource_id"]),
+            )
+            # Omitting a missing source row lets snapshot reconciliation publish
+            # the existing control-plane deletion state without exposing stale data.
+            if metadata is None:
+                continue
+            descriptors.append(
+                {
+                    "resource_id": policy["resource_id"],
+                    "resource_kind": policy["resource_kind"],
+                    "display_name": _safe_resource_display_name(
+                        metadata.get("display_name"),
+                        str(policy["resource_id"]),
+                    ),
+                    "owner_user_id": policy.get("owner_user_id"),
+                    "metadata_revision": max(
+                        int(policy.get("policy_revision") or 0),
+                        _resource_metadata_revision(metadata.get("updated_at")),
+                    ),
+                    "applied_acl_revision": int(
+                        policy.get("last_applied_control_plane_revision") or 0
+                    ),
+                    "access_level": policy["access_level"],
+                    "group_ids": policy.get("group_ids") or [],
+                    "sync_status": "in_sync",
+                }
+            )
+    return descriptors
 
 
 def _validated_intent_fields(intent: Any) -> tuple[str, str, int, str, list[str]]:


### PR DESCRIPTION
## Capability

Publishes human-readable, metadata-only names for Organization Resource ACL entries from each resource's owning local service.

Closes #1054

## Acceptance Criteria

- **AC-1:** Agent, Vault secret, Skill, and Show Page descriptors resolve human-readable display names.
- **AC-2:** Publication remains limited to the resource-index allowlist; prompts, secret values/envelopes, paths, metadata bodies, and execution output are excluded.
- **AC-3:** Source update timestamps produce monotonic metadata revisions, including Show Page title changes.
- **AC-4:** Untitled/unsafe Show Page titles use the stable session ID; missing source rows are omitted so snapshot reconciliation marks them deleted.
- **AC-5:** Unit coverage exercises descriptor resolution and redaction for all four resource kinds.
- **AC-6:** The hosted console now receives actual resource names; residual staging UI confirmation remains manual.

## Evidence

- **Unit:** `tests/test_remote_resource_acl_sync.py` (10 passed).
- **Related regression:** Agent, Vault, Skill, and Show Page ACL/service suites (201 passed).
- **Contract:** Exact descriptor-field allowlist, revision changes, deterministic fallback, and missing-row snapshot behavior covered.
- **Scenario:** No resource-index scenario catalog entry exists; no scenario files changed.
- **Manual:** No Incus or staging run in this lane; staging Resource Access UI remains the residual check.
- **Static:** Ruff passed on every changed Python file; `py_compile` passed.

## CONTRACT CHANGE

None. `vibe/authorization.py` and all use/manage capability methods are unchanged.

## Shared Authorization Surface

None.