### PR TITLE
feat(agents): onboard existing Agents into Organization ACL

### DIFF
--- a/core/vibe_agents.py
+++ b/core/vibe_agents.py
@@ -146,6 +146,27 @@ def _require_agent_create_access(user_context: Any) -> None:
     raise VibeAgentAccessError("Agent access is not permitted.")
 
 
+def _require_agent_onboarding_access(user_context: Any):
+    """Require owner-equivalent access for Organization Agent publication."""
+
+    context = resolve_resource_access_context(user_context)
+    if context.is_trusted_local or context.is_instance_owner:
+        return context
+    raise VibeAgentAccessError("Agent access is not permitted.")
+
+
+def _agent_onboarding_counts(inventory: list[dict[str, Any]]) -> dict[str, int]:
+    return {
+        "total": len(inventory),
+        "system": sum(item.get("source") in {"builtin", "system"} for item in inventory),
+        "custom": sum(item.get("source") not in {"builtin", "system"} for item in inventory),
+        "not_onboarded": sum(item.get("status") == "not_onboarded" for item in inventory),
+        "private": sum(item.get("status") == "private" for item in inventory),
+        "published": sum(item.get("status") == "published" for item in inventory),
+        "conflicts": sum(item.get("status") == "managed_elsewhere" for item in inventory),
+    }
+
+
 @dataclass(frozen=True)
 class VibeAgent:
     id: str
@@ -302,6 +323,116 @@ class VibeAgentStore:
                 connection=conn,
             )
             return [self._from_row(row) for row in rows]
+
+    def organization_onboarding_inventory(self, *, user_context: Any = None) -> dict[str, Any]:
+        """Return the safe owner inventory for explicit Organization onboarding."""
+
+        from storage import resource_access_service
+
+        context = _require_agent_onboarding_access(user_context)
+        organization_id = context.organization_id if context.is_active_organization_member else None
+        if not organization_id or not context.subject:
+            return {
+                "available": False,
+                "organization_id": None,
+                "agents": [],
+                "counts": _agent_onboarding_counts([]),
+            }
+
+        with self.engine.connect() as conn:
+            rows = conn.execute(select(agents).order_by(agents.c.name)).mappings().all()
+            policies = {
+                str(policy["resource_id"]): policy
+                for policy in resource_access_service.list_resource_policies(
+                    resource_kind="agent",
+                    connection=conn,
+                )
+            }
+
+        inventory: list[dict[str, Any]] = []
+        for row in rows:
+            agent = self._from_row(row)
+            policy = policies.get(agent.id)
+            visible_policy = policy if policy and policy.get("organization_id") == organization_id else None
+            if policy is None:
+                status = "not_onboarded"
+            elif visible_policy is None:
+                status = "managed_elsewhere"
+            elif visible_policy.get("access_level") == "private":
+                status = "private"
+            else:
+                status = "published"
+            inventory.append(
+                {
+                    "id": agent.id,
+                    "name": agent.name,
+                    "backend": agent.backend,
+                    "source": agent.source,
+                    "enabled": agent.enabled,
+                    "status": status,
+                    "access_level": visible_policy.get("access_level") if visible_policy else None,
+                    "group_ids": list(visible_policy.get("group_ids") or []) if visible_policy else [],
+                    "policy_revision": int(visible_policy.get("policy_revision") or 0) if visible_policy else None,
+                    "applied_acl_revision": (
+                        int(visible_policy.get("last_applied_control_plane_revision") or 0)
+                        if visible_policy
+                        else None
+                    ),
+                }
+            )
+        return {
+            "available": True,
+            "organization_id": organization_id,
+            "agents": inventory,
+            "counts": _agent_onboarding_counts(inventory),
+        }
+
+    def onboard_organization_agents(self, *, user_context: Any = None) -> dict[str, Any]:
+        """Register every missing Agent as private without replacing any ACL."""
+
+        from storage import resource_access_service
+
+        context = _require_agent_onboarding_access(user_context)
+        if not context.is_active_organization_member or not context.organization_id or not context.subject:
+            raise VibeAgentAccessError("Agent access is not permitted.")
+
+        created = 0
+        unchanged = 0
+        conflicts = 0
+        with self.engine.begin() as conn:
+            rows = conn.execute(select(agents).order_by(agents.c.name)).mappings().all()
+            policies = {
+                str(policy["resource_id"]): policy
+                for policy in resource_access_service.list_resource_policies(
+                    resource_kind="agent",
+                    connection=conn,
+                )
+            }
+            for row in rows:
+                agent = self._from_row(row)
+                existing = policies.get(agent.id)
+                if existing is not None:
+                    if existing.get("organization_id") == context.organization_id:
+                        unchanged += 1
+                    else:
+                        conflicts += 1
+                    continue
+                resource_access_service.ensure_resource_policy(
+                    conn,
+                    resource_kind="agent",
+                    resource_id=agent.id,
+                    organization_id=context.organization_id,
+                    owner_user_id=context.subject,
+                    owner_email=context.email,
+                    access_level="private",
+                    created_by_user_id=context.subject,
+                    updated_by_user_id=context.subject,
+                )
+                created += 1
+
+        result = self.organization_onboarding_inventory(user_context=context)
+        result.update({"created": created, "unchanged": unchanged, "conflicts": conflicts})
+        return result
 
     def get(self, name: str) -> Optional[VibeAgent]:
         normalized = normalize_agent_name(name)

--- a/docs/plans/2026-07-27-agent-organization-onboarding.md
+++ b/docs/plans/2026-07-27-agent-organization-onboarding.md
@@ -1,0 +1,52 @@
+# Agent Organization Onboarding
+
+## Background
+
+Organization Resource ACL publishes only resources that already have a local
+policy. Agents created before an Instance became Organization-managed, including
+built-in backend Agents, therefore remain absent from the hosted Resource Access
+inventory. Missing policies fail closed for Organization members, but owners have
+no explicit way to register those Agents for later group publication.
+
+## Goal
+
+Give the signed Instance owner an explicit, safe, and repeatable onboarding path:
+
+- inventory every custom and built-in/system Agent from `core/vibe_agents.py`;
+- register every missing Agent as Organization-private;
+- preserve every existing policy and revision unchanged;
+- publish through the shared metadata-only Resource ACL sync path; and
+- direct owners to the hosted Resource Access console to grant selected Agents
+  to Organization groups.
+
+## Design
+
+`VibeAgentStore` owns the inventory and registration transaction because the
+Agent table is the source of truth. The service requires owner-equivalent Agent
+management access and an active signed Organization context before writing.
+Registration uses `ensure_resource_policy()`, whose insert-only contract prevents
+late onboarding from replacing an already-applied control-plane revision.
+
+The local API returns only Agent identity and ACL state: id, safe name, backend,
+source, enabled state, access level, group ids, and revisions. It never returns a
+prompt, Agent metadata/configuration, credentials, source paths, or execution
+output. Publication delegates to the shared Resource ACL descriptor builder so
+the display-name and metadata-revision behavior owned by issue #1054 remains a
+single contract.
+
+The Agents page renders the inventory only when onboarding is available. One
+owner action registers all missing Agents privately. Group selection stays in
+the existing hosted Resource Access console, which owns desired ACL revisions.
+
+## Verification
+
+- Upgrade path: legacy custom and built-in Agents become private, then an editor
+  sees only the Agents selected by a newer control-plane ACL intent.
+- Fresh install: built-in Agents and a newly created private Organization Agent
+  produce the intended editor-visible set after publication.
+- Idempotency: rerunning onboarding does not change existing access, groups, or
+  policy/control-plane revisions.
+- Redaction: published descriptors contain only the shared safe metadata fields.
+- Lifecycle: create-then-delete rename and deletion converge through the next
+  full resource-index snapshot.
+

--- a/tests/test_agent_organization_onboarding.py
+++ b/tests/test_agent_organization_onboarding.py
@@ -1,0 +1,362 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from core.vibe_agents import VibeAgentAccessError, VibeAgentStore
+from storage import resource_access_service
+from tests.test_ui_remote_access_auth import _remote_peer, _save_config
+from tests.ui_server_test_helpers import csrf_headers
+from vibe import remote_access
+from vibe.ui_server import app
+
+
+def _organization_context(
+    *,
+    subject: str = "owner-1",
+    instance_role: str = "owner",
+    group_ids: frozenset[str] = frozenset({"group-engineering"}),
+) -> resource_access_service.ResourceUserContext:
+    return resource_access_service.ResourceUserContext(
+        subject=subject,
+        email=f"{subject}@example.com",
+        organization_id="org-1",
+        organization_member_id=f"member-{subject}",
+        organization_role="member",
+        group_ids=group_ids,
+        instance_role=instance_role,
+        instance_access_source="organization_group",
+        is_remote=True,
+    )
+
+
+def _organization_cookie(config, *, instance_role: str) -> str:
+    return remote_access.make_session_cookie(
+        config,
+        "owner-1@example.com",
+        "owner-1",
+        session_claims={
+            "vibe_instance_id": "inst_123",
+            "vibe_instance_role": instance_role,
+            "vibe_instance_access_source": "organization_group",
+            "vibe_organization_id": "org-1",
+            "vibe_organization_member_id": "member-owner-1",
+            "vibe_organization_role": "member",
+            "vibe_group_ids": ["group-engineering"],
+            "vibe_membership_version": "membership-v2",
+        },
+    )
+
+
+def _apply_agent_intent(
+    store: VibeAgentStore,
+    agent_id: str,
+    *,
+    revision: int,
+    access_level: str,
+    group_ids: list[str] | None = None,
+) -> None:
+    with store.engine.begin() as connection:
+        resource_access_service.apply_control_plane_intent(
+            connection,
+            organization_id="org-1",
+            resource_kind="agent",
+            resource_id=agent_id,
+            revision=revision,
+            access_level=access_level,
+            group_ids=group_ids or [],
+        )
+
+
+def test_upgrade_onboarding_inventories_custom_and_system_agents_as_private(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    store = VibeAgentStore()
+    try:
+        legacy = store.create(
+            name="legacy-custom",
+            backend="codex",
+            system_prompt="legacy prompt",
+        )
+        builtins = store.ensure_builtin_default_agents(["codex", "claude"])
+
+        before = store.organization_onboarding_inventory(user_context=_organization_context())
+        assert before["counts"] == {
+            "total": 3,
+            "system": 2,
+            "custom": 1,
+            "not_onboarded": 3,
+            "private": 0,
+            "published": 0,
+            "conflicts": 0,
+        }
+
+        result = store.onboard_organization_agents(user_context=_organization_context())
+        assert result["created"] == 3
+        assert result["counts"]["private"] == 3
+        with store.engine.connect() as connection:
+            policies = resource_access_service.list_resource_policies(
+                resource_kind="agent",
+                organization_id="org-1",
+                connection=connection,
+            )
+        assert len(policies) == 3
+        assert all(policy["access_level"] == "private" for policy in policies)
+        assert all(policy["group_ids"] == [] for policy in policies)
+
+        _apply_agent_intent(
+            store,
+            legacy.id,
+            revision=1,
+            access_level="scope",
+            group_ids=["group-engineering"],
+        )
+        _apply_agent_intent(store, builtins[0].id, revision=1, access_level="public")
+        visible = {
+            agent.name
+            for agent in store.list_agents(
+                user_context=_organization_context(subject="editor-1", instance_role="editor"),
+            )
+        }
+        assert visible == {legacy.name, builtins[0].name}
+    finally:
+        store.close()
+
+
+def test_fresh_install_onboarding_preserves_new_private_agent_and_authorizes_intended_set(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    store = VibeAgentStore()
+    try:
+        builtin = store.ensure_builtin_default_agent(backend="codex")
+        custom = store.create(
+            name="fresh-private",
+            backend="codex",
+            user_context=_organization_context(),
+        )
+
+        result = store.onboard_organization_agents(user_context=_organization_context())
+        assert result["created"] == 1
+        assert result["unchanged"] == 1
+        assert result["counts"]["private"] == 2
+
+        _apply_agent_intent(
+            store,
+            builtin.id,
+            revision=1,
+            access_level="scope",
+            group_ids=["group-engineering"],
+        )
+        visible = store.list_agents(
+            user_context=_organization_context(subject="editor-1", instance_role="editor"),
+        )
+        assert [agent.name for agent in visible] == [builtin.name]
+        assert custom.name not in {agent.name for agent in visible}
+    finally:
+        store.close()
+
+
+def test_onboarding_is_owner_only_and_does_not_overwrite_existing_acl_revision(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    store = VibeAgentStore()
+    try:
+        agent = store.create(name="revisioned", backend="codex")
+        with pytest.raises(VibeAgentAccessError):
+            store.organization_onboarding_inventory(
+                user_context=_organization_context(subject="editor-1", instance_role="editor"),
+            )
+        with pytest.raises(VibeAgentAccessError):
+            store.onboard_organization_agents(
+                user_context=_organization_context(subject="editor-1", instance_role="editor"),
+            )
+
+        store.onboard_organization_agents(user_context=_organization_context())
+        _apply_agent_intent(
+            store,
+            agent.id,
+            revision=7,
+            access_level="scope",
+            group_ids=["group-engineering"],
+        )
+        with store.engine.connect() as connection:
+            before = resource_access_service.get_resource_policy(
+                "agent",
+                agent.id,
+                connection=connection,
+            )
+
+        rerun = store.onboard_organization_agents(user_context=_organization_context())
+        with store.engine.connect() as connection:
+            after = resource_access_service.get_resource_policy(
+                "agent",
+                agent.id,
+                connection=connection,
+            )
+
+        assert rerun["created"] == 0
+        assert rerun["unchanged"] == 1
+        assert after == before
+        assert after is not None
+        assert after["policy_revision"] == 7
+        assert after["last_applied_control_plane_revision"] == 7
+        assert after["group_ids"] == ["group-engineering"]
+    finally:
+        store.close()
+
+
+def test_onboarding_publication_redacts_prompt_credentials_paths_and_config(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    config = _save_config(tmp_path)
+    config.remote_access.vibe_cloud.enabled = True
+    config.remote_access.vibe_cloud.instance_id = "inst_123"
+    config.remote_access.vibe_cloud.instance_secret = "paired-device-secret"
+    store = VibeAgentStore()
+    try:
+        store.create(
+            name="safe-display-name",
+            backend="codex",
+            description="credential=description-secret",
+            system_prompt="prompt-secret /home/owner/private AGENT_TOKEN=token-secret",
+            source_ref="/home/owner/.codex/agents/private.md",
+            metadata={"credential": "metadata-secret", "cwd": "/home/owner/private"},
+        )
+        store.onboard_organization_agents(user_context=_organization_context())
+    finally:
+        store.close()
+
+    published: list[dict[str, Any]] = []
+
+    def device_request(_config, method: str, suffix: str, payload=None, **_kwargs):
+        if method == "PUT" and suffix == "resource-index":
+            published.extend(payload["resources"])
+            return {"organization_id": "org-1", "resources": payload["resources"]}
+        if method == "GET" and suffix == "resource-acl-intents":
+            return {"organization_id": "org-1", "poll_after_seconds": 30, "intents": []}
+        raise AssertionError((method, suffix, payload))
+
+    monkeypatch.setattr(remote_access, "_device_json_request", device_request)
+    result = remote_access.sync_resource_acl_once(config, organization_id="org-1")
+
+    assert result["ok"] is True
+    assert len(published) == 1
+    assert set(published[0]) <= {
+        "resource_id",
+        "resource_kind",
+        "display_name",
+        "owner_user_id",
+        "metadata_revision",
+        "applied_acl_revision",
+        "access_level",
+        "group_ids",
+        "sync_status",
+    }
+    serialized = json.dumps(published)
+    for forbidden in (
+        "prompt-secret",
+        "description-secret",
+        "token-secret",
+        "metadata-secret",
+        "/home/owner",
+        "system_prompt",
+        "source_ref",
+        "credential",
+        "cwd",
+    ):
+        assert forbidden not in serialized
+
+
+def test_agent_rename_and_delete_converge_in_full_resource_index(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    store = VibeAgentStore()
+    try:
+        old = store.create(name="old-name", backend="codex")
+        store.onboard_organization_agents(user_context=_organization_context())
+        renamed = store.create(
+            name="new-name",
+            backend="codex",
+            user_context=_organization_context(),
+        )
+        assert store.remove(old.name) is True
+
+        descriptors = remote_access._local_policy_resource_descriptors("org-1")
+        assert {item["resource_id"] for item in descriptors} == {renamed.id}
+        assert resource_access_service.list_resource_organization_ids() == ["org-1"]
+
+        assert store.remove(renamed.name) is True
+        assert remote_access._local_policy_resource_descriptors("org-1") == []
+        assert resource_access_service.list_resource_organization_ids() == ["org-1"]
+    finally:
+        store.close()
+
+
+def test_owner_http_workflow_lists_and_onboards_agents_while_editor_is_denied(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    config = _save_config(tmp_path)
+    store = VibeAgentStore()
+    try:
+        store.create(name="legacy-http", backend="codex", system_prompt="must-not-appear")
+    finally:
+        store.close()
+    monkeypatch.setattr(
+        remote_access,
+        "sync_resource_acl_once",
+        lambda *_args, **_kwargs: {"ok": True, "organizations": [{"organization_id": "org-1"}]},
+    )
+
+    client = app.test_client()
+    client.set_cookie(
+        remote_access.SESSION_COOKIE_NAME,
+        _organization_cookie(config, instance_role="owner"),
+        domain="alex.avibe.bot",
+    )
+    inventory = client.get(
+        "/api/agent-onboarding",
+        base_url="https://alex.avibe.bot",
+        environ_base=_remote_peer(),
+    )
+    onboarded = client.post(
+        "/api/agent-onboarding",
+        json={},
+        headers=csrf_headers(client, "https://alex.avibe.bot"),
+        base_url="https://alex.avibe.bot",
+        environ_base=_remote_peer(),
+    )
+
+    assert inventory.status_code == 200
+    assert inventory.get_json()["available"] is True
+    assert {item["name"] for item in inventory.get_json()["agents"]} >= {"legacy-http"}
+    assert all(
+        set(item)
+        <= {
+            "id",
+            "name",
+            "backend",
+            "source",
+            "enabled",
+            "status",
+            "access_level",
+            "group_ids",
+            "policy_revision",
+            "applied_acl_revision",
+        }
+        for item in inventory.get_json()["agents"]
+    )
+    assert onboarded.status_code == 200
+    assert onboarded.get_json()["counts"]["not_onboarded"] == 0
+    assert onboarded.get_json()["console_url"].endswith("/app/organizations/org-1/resources")
+
+    client.set_cookie(
+        remote_access.SESSION_COOKIE_NAME,
+        _organization_cookie(config, instance_role="editor"),
+        domain="alex.avibe.bot",
+    )
+    denied = client.get(
+        "/api/agent-onboarding",
+        base_url="https://alex.avibe.bot",
+        environ_base=_remote_peer(),
+    )
+    assert denied.status_code == 403
+    assert denied.get_json()["error"] == "instance_access_forbidden"

--- a/tests/test_agent_organization_onboarding.py
+++ b/tests/test_agent_organization_onboarding.py
@@ -300,11 +300,13 @@ def test_owner_http_workflow_lists_and_onboards_agents_while_editor_is_denied(mo
         store.create(name="legacy-http", backend="codex", system_prompt="must-not-appear")
     finally:
         store.close()
-    monkeypatch.setattr(
-        remote_access,
-        "sync_resource_acl_once",
-        lambda *_args, **_kwargs: {"ok": True, "organizations": [{"organization_id": "org-1"}]},
-    )
+    sync_requests: list[dict[str, object]] = []
+
+    def _sync_resource_acl_once(*_args, **kwargs):
+        sync_requests.append(kwargs)
+        return {"ok": True, "organizations": [{"organization_id": "org-1"}]}
+
+    monkeypatch.setattr(remote_access, "sync_resource_acl_once", _sync_resource_acl_once)
 
     client = app.test_client()
     client.set_cookie(
@@ -347,6 +349,24 @@ def test_owner_http_workflow_lists_and_onboards_agents_while_editor_is_denied(mo
     assert onboarded.status_code == 200
     assert onboarded.get_json()["counts"]["not_onboarded"] == 0
     assert onboarded.get_json()["console_url"].endswith("/app/organizations/org-1/resources")
+    assert len(sync_requests) == 1
+    published_legacy = next(
+        descriptor
+        for descriptor in sync_requests[0]["resources"]
+        if descriptor["resource_kind"] == "agent" and descriptor["display_name"] == "legacy-http"
+    )
+    assert set(published_legacy) == {
+        "resource_id",
+        "resource_kind",
+        "display_name",
+        "owner_user_id",
+        "metadata_revision",
+        "applied_acl_revision",
+        "access_level",
+        "group_ids",
+        "sync_status",
+    }
+    assert "must-not-appear" not in repr(sync_requests[0]["resources"])
 
     client.set_cookie(
         remote_access.SESSION_COOKIE_NAME,

--- a/ui/src/components/workbench/AgentsPage.tsx
+++ b/ui/src/components/workbench/AgentsPage.tsx
@@ -4,8 +4,10 @@ import {
   Bot,
   ChevronDown,
   ChevronRight,
+  ExternalLink,
   FileText,
   Funnel,
+  LockKeyhole,
   Loader2,
   Maximize2,
   Pencil,
@@ -13,6 +15,7 @@ import {
   Plus,
   RefreshCw,
   Search,
+  ShieldCheck,
   Star,
   Trash2,
   Upload,
@@ -22,7 +25,8 @@ import {
 import clsx from 'clsx';
 
 import { useApi } from '../../context/ApiContext';
-import type { VibeAgentBrief, VibeAgentFull } from '../../context/ApiContext';
+import type { VibeAgentBrief, VibeAgentFull, VibeAgentOnboardingResult } from '../../context/ApiContext';
+import { useInstanceAuthorization } from '../../context/InstanceAuthorizationContext';
 import { AgentGraphTab } from './AgentGraphTab';
 import { useToast } from '../../context/ToastContext';
 import { NewAgentDialog } from './NewAgentDialog';
@@ -65,6 +69,7 @@ export const AgentsPage: React.FC = () => {
   const { t } = useTranslation();
   const api = useApi();
   const { showToast } = useToast();
+  const { capabilities } = useInstanceAuthorization();
   const [agentsTab, setAgentsTab] = useState<AgentsTabKey>('definitions');
   const [runningActiveCount, setRunningActiveCount] = useState<number | null>(null);
   const [eventBridgeConnected, setEventBridgeConnected] = useState(false);
@@ -78,9 +83,25 @@ export const AgentsPage: React.FC = () => {
   const [search, setSearch] = useState('');
   const [backendFilter, setBackendFilter] = useState<Backend | 'all'>('all');
   const [importing, setImporting] = useState<Backend | null>(null);
+  const [onboardingInventory, setOnboardingInventory] = useState<VibeAgentOnboardingResult | null>(null);
+  const [onboardingExpanded, setOnboardingExpanded] = useState(false);
+  const [onboardingSubmitting, setOnboardingSubmitting] = useState(false);
   // Mobile drill-down: a row tap opens the detail full-screen. The agent
   // auto-selected on mount stays in the list view until the user drills in.
   const [detailOpen, setDetailOpen] = useState(false);
+
+  const refreshOnboarding = useCallback(async () => {
+    if (!capabilities.can_manage_agents) {
+      setOnboardingInventory(null);
+      return;
+    }
+    try {
+      const result = await api.getVibeAgentOnboarding();
+      setOnboardingInventory(result.available ? result : null);
+    } catch {
+      setOnboardingInventory(null);
+    }
+  }, [api, capabilities.can_manage_agents]);
 
   const refresh = useCallback(async () => {
     setLoading(true);
@@ -105,6 +126,10 @@ export const AgentsPage: React.FC = () => {
     refresh();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  useEffect(() => {
+    void refreshOnboarding();
+  }, [refreshOnboarding]);
 
   // Auto-select the default agent on first load so the detail panel has
   // something to show — eliminates the empty "select an agent" state
@@ -261,6 +286,7 @@ export const AgentsPage: React.FC = () => {
 
   const onCreated = (agent: VibeAgentFull) => {
     refresh().then(() => setSelected(agent));
+    void refreshOnboarding();
   };
 
 
@@ -291,6 +317,7 @@ export const AgentsPage: React.FC = () => {
   // and the new one is missing. Refresh and re-select the renamed agent.
   const onRenamed = (newName: string) => {
     refresh().then(() => selectAgent(newName));
+    void refreshOnboarding();
   };
 
   const onDelete = async () => {
@@ -302,6 +329,7 @@ export const AgentsPage: React.FC = () => {
       if (result.ok) {
         setSelected(null);
         refresh();
+        void refreshOnboarding();
       } else if (result.code === 'agent_in_use') {
         setError(t('agents.deleteInUse', { name: selected.name }));
       } else if (result.message) {
@@ -330,6 +358,7 @@ export const AgentsPage: React.FC = () => {
           showToast(t('agents.importSuccess', { imported, skipped }), 'success');
         }
         refresh();
+        void refreshOnboarding();
       } else {
         showToast(
           t('agents.importFailed', { error: result.message || result.error || result.code || 'unknown' }),
@@ -340,6 +369,25 @@ export const AgentsPage: React.FC = () => {
       showToast(t('agents.importFailed', { error: err?.message ?? String(err) }), 'error');
     } finally {
       setImporting(null);
+    }
+  };
+
+  const onOnboardAgents = async () => {
+    if (onboardingSubmitting) return;
+    setOnboardingSubmitting(true);
+    try {
+      const result = await api.onboardVibeAgents();
+      setOnboardingInventory(result);
+      showToast(
+        result.sync?.ok === false
+          ? t('agents.onboarding.savedPending')
+          : t('agents.onboarding.saved', { count: result.created ?? 0 }),
+        result.sync?.ok === false ? 'warning' : 'success',
+      );
+    } catch (err: any) {
+      showToast(t('agents.onboarding.failed', { error: err?.message ?? String(err) }), 'error');
+    } finally {
+      setOnboardingSubmitting(false);
     }
   };
 
@@ -355,7 +403,16 @@ export const AgentsPage: React.FC = () => {
         title={t('agents.title')}
         subtitle={t('agents.subtitle', { count: agents.length })}
         actions={
-          <Button type="button" variant="outline" size="xs" onClick={() => refresh()} disabled={loading}>
+          <Button
+            type="button"
+            variant="outline"
+            size="xs"
+            onClick={() => {
+              void refresh();
+              void refreshOnboarding();
+            }}
+            disabled={loading}
+          >
             <RefreshCw className={clsx('size-3.5', loading && 'animate-spin')} />
             {t('common.refresh')}
           </Button>
@@ -403,6 +460,17 @@ export const AgentsPage: React.FC = () => {
 
       {/* 运行 tab body — the run graph (replaces the old flat running list). */}
       {agentsTab === 'running' && <AgentGraphTab />}
+
+      {agentsTab === 'definitions' && onboardingInventory && (
+        <OrganizationAgentOnboarding
+          inventory={onboardingInventory}
+          expanded={onboardingExpanded}
+          submitting={onboardingSubmitting}
+          className={detailOpen ? 'max-lg:hidden' : undefined}
+          onExpandedChange={setOnboardingExpanded}
+          onOnboard={onOnboardAgents}
+        />
+      )}
 
       {/* Toolbar — design.pen Imduv: search + backend filter + spacer + Import + 新建 Agent */}
       <div className={clsx('flex flex-wrap items-center gap-2.5', agentsTab === 'running' ? 'hidden' : detailOpen && 'max-lg:hidden')}>
@@ -515,6 +583,124 @@ export const AgentsPage: React.FC = () => {
       <NewAgentDialog open={showNew} onClose={() => setShowNew(false)} onCreated={onCreated} />
       <GlobalPromptsDialog open={showGlobalPrompts} onClose={() => setShowGlobalPrompts(false)} />
     </div>
+  );
+};
+
+interface OrganizationAgentOnboardingProps {
+  inventory: VibeAgentOnboardingResult;
+  expanded: boolean;
+  submitting: boolean;
+  className?: string;
+  onExpandedChange: (expanded: boolean) => void;
+  onOnboard: () => void;
+}
+
+const OrganizationAgentOnboarding: React.FC<OrganizationAgentOnboardingProps> = ({
+  inventory,
+  expanded,
+  submitting,
+  className,
+  onExpandedChange,
+  onOnboard,
+}) => {
+  const { t } = useTranslation();
+  const counts = inventory.counts;
+  const onboarded = counts.private + counts.published;
+
+  return (
+    <section className={clsx('border-y border-border bg-surface-2/60 py-4', className)}>
+      <div className="flex flex-col gap-4 px-1 sm:px-4">
+        <div className="flex flex-col gap-3 lg:flex-row lg:items-center">
+          <div className="flex min-w-0 flex-1 items-start gap-3">
+            <span className="grid size-9 shrink-0 place-items-center rounded-md border border-mint/30 bg-mint-soft text-mint">
+              <ShieldCheck className="size-4" />
+            </span>
+            <div className="min-w-0">
+              <div className="text-[13px] font-bold text-foreground">{t('agents.onboarding.title')}</div>
+              <div className="mt-0.5 text-[11px] leading-5 text-muted">
+                {t('agents.onboarding.summary', {
+                  total: counts.total,
+                  custom: counts.custom,
+                  system: counts.system,
+                })}
+              </div>
+            </div>
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            <Badge variant={counts.not_onboarded > 0 ? 'warning' : 'secondary'}>
+              {t('agents.onboarding.notOnboardedCount', { count: counts.not_onboarded })}
+            </Badge>
+            <Badge variant="secondary">{t('agents.onboarding.privateCount', { count: counts.private })}</Badge>
+            <Badge variant="success">{t('agents.onboarding.publishedCount', { count: counts.published })}</Badge>
+            {counts.conflicts > 0 && (
+              <Badge variant="destructive">{t('agents.onboarding.conflictCount', { count: counts.conflicts })}</Badge>
+            )}
+          </div>
+        </div>
+
+        <div className="flex flex-wrap items-center gap-2 border-t border-border pt-3">
+          <button
+            type="button"
+            aria-expanded={expanded}
+            onClick={() => onExpandedChange(!expanded)}
+            className="flex min-w-0 items-center gap-2 text-[12px] font-medium text-foreground hover:text-mint"
+          >
+            <ChevronRight className={clsx('size-3.5 shrink-0 transition-transform', expanded && 'rotate-90')} />
+            {t('agents.onboarding.inventory', { count: counts.total })}
+          </button>
+          <div className="flex-1" />
+          <Button
+            type="button"
+            variant="outline"
+            size="xs"
+            onClick={onOnboard}
+            disabled={submitting || counts.not_onboarded === 0}
+          >
+            {submitting ? <Loader2 className="animate-spin" /> : <LockKeyhole />}
+            {counts.not_onboarded > 0
+              ? t('agents.onboarding.onboardPrivate')
+              : t('agents.onboarding.onboarded')}
+          </Button>
+          {inventory.console_url && onboarded > 0 && (
+            <Button asChild variant="accent" size="xs">
+              <a href={inventory.console_url} target="_blank" rel="noreferrer">
+                <ExternalLink />
+                {t('agents.onboarding.manageAccess')}
+              </a>
+            </Button>
+          )}
+        </div>
+
+        {expanded && (
+          <div className="divide-y divide-border border-t border-border">
+            {inventory.agents.map((agent) => {
+              const system = isSystemAgent(agent);
+              const statusVariant =
+                agent.status === 'published'
+                  ? 'success'
+                  : agent.status === 'not_onboarded'
+                    ? 'warning'
+                    : agent.status === 'managed_elsewhere'
+                      ? 'destructive'
+                      : 'secondary';
+              return (
+                <div key={agent.id} className="grid min-w-0 grid-cols-[minmax(0,1fr)_auto] items-center gap-3 py-2.5">
+                  <div className="min-w-0">
+                    <div className="truncate text-[12px] font-semibold text-foreground">{agent.name}</div>
+                    <div className="truncate font-mono text-[10px] text-muted">
+                      {agent.backend} · {system ? t('agents.onboarding.system') : t('agents.onboarding.custom')}
+                    </div>
+                  </div>
+                  <Badge variant={statusVariant} className="max-w-[45vw]">
+                    <span className="truncate">{t(`agents.onboarding.status.${agent.status}`)}</span>
+                  </Badge>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </section>
   );
 };
 

--- a/ui/src/context/ApiContext.tsx
+++ b/ui/src/context/ApiContext.tsx
@@ -624,6 +624,8 @@ export type ApiContextType = {
   listInbox: (params?: { platform?: string; unreadOnly?: boolean; limit?: number; before?: string; onlySession?: string; cache?: boolean; handleError?: boolean }) => Promise<InboxFeedResult>;
   connectWorkbenchEvents: (handlers: WorkbenchEventHandlers) => () => void;
   listVibeAgents: (params?: { backend?: string; includeDisabled?: boolean }) => Promise<{ ok: boolean; agents: VibeAgentBrief[]; default_agent_name: string | null }>;
+  getVibeAgentOnboarding: () => Promise<VibeAgentOnboardingResult>;
+  onboardVibeAgents: () => Promise<VibeAgentOnboardingResult>;
   getVibeAgent: (name: string) => Promise<{ ok: boolean; agent: VibeAgentFull; default_agent_name: string | null }>;
   createVibeAgent: (payload: VibeAgentCreatePayload) => Promise<{ ok: boolean; agent: VibeAgentFull }>;
   updateVibeAgent: (name: string, payload: VibeAgentUpdatePayload) => Promise<{ ok: boolean; agent: VibeAgentFull }>;
@@ -822,6 +824,40 @@ export type VibeAgentFull = VibeAgentBrief & {
   system_prompt: string | null;
   metadata: Record<string, unknown>;
   created_at: string;
+};
+
+export type VibeAgentOnboardingItem = {
+  id: string;
+  name: string;
+  backend: string;
+  source: string;
+  enabled: boolean;
+  status: 'not_onboarded' | 'private' | 'published' | 'managed_elsewhere';
+  access_level: 'private' | 'scope' | 'public' | null;
+  group_ids: string[];
+  policy_revision: number | null;
+  applied_acl_revision: number | null;
+};
+
+export type VibeAgentOnboardingResult = {
+  ok: boolean;
+  available: boolean;
+  organization_id: string | null;
+  console_url?: string;
+  agents: VibeAgentOnboardingItem[];
+  counts: {
+    total: number;
+    system: number;
+    custom: number;
+    not_onboarded: number;
+    private: number;
+    published: number;
+    conflicts: number;
+  };
+  created?: number;
+  unchanged?: number;
+  conflicts?: number;
+  sync?: { ok?: boolean; error?: string };
 };
 
 export type VibeAgentCreatePayload = {
@@ -2889,6 +2925,8 @@ export const ApiProvider: React.FC<{ children: React.ReactNode }> = ({ children 
       const qs = search.toString();
       return getCachedJson(qs ? `/api/agents?${qs}` : '/api/agents', 5_000);
     },
+    getVibeAgentOnboarding: () => getJson('/api/agent-onboarding'),
+    onboardVibeAgents: () => postJson('/api/agent-onboarding', {}),
     getVibeAgent: (name) => getCachedJson(`/api/agents/${encodeURIComponent(name)}`, 5_000),
     createVibeAgent: (payload) => postJson('/api/agents', payload),
     updateVibeAgent: async (name, payload) => {

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -2275,6 +2275,29 @@
       "definitions": "Definitions",
       "running": "Runs"
     },
+    "onboarding": {
+      "title": "Organization access",
+      "summary": "{{total}} Agents · {{custom}} custom · {{system}} system",
+      "inventory": "Agent inventory ({{count}})",
+      "notOnboardedCount": "{{count}} not onboarded",
+      "privateCount": "{{count}} private",
+      "publishedCount": "{{count}} published",
+      "conflictCount": "{{count}} unavailable",
+      "onboardPrivate": "Onboard privately",
+      "onboarded": "Onboarded",
+      "manageAccess": "Manage access",
+      "system": "system",
+      "custom": "custom",
+      "saved": "{{count}} Agents onboarded privately.",
+      "savedPending": "Agents are private locally; publication is pending.",
+      "failed": "Could not onboard Agents: {{error}}",
+      "status": {
+        "not_onboarded": "Not onboarded",
+        "private": "Private",
+        "published": "Published",
+        "managed_elsewhere": "Unavailable"
+      }
+    },
     "running": {
       "empty": "No agents are currently running.",
       "unreachableTitle": "Runtime unreachable",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -2275,6 +2275,29 @@
       "definitions": "定义",
       "running": "运行"
     },
+    "onboarding": {
+      "title": "组织访问",
+      "summary": "{{total}} 个 Agent · {{custom}} 个自定义 · {{system}} 个系统",
+      "inventory": "Agent 清单（{{count}}）",
+      "notOnboardedCount": "{{count}} 个未纳管",
+      "privateCount": "{{count}} 个私有",
+      "publishedCount": "{{count}} 个已发布",
+      "conflictCount": "{{count}} 个不可用",
+      "onboardPrivate": "按私有方式纳管",
+      "onboarded": "已纳管",
+      "manageAccess": "管理访问",
+      "system": "系统",
+      "custom": "自定义",
+      "saved": "已按私有方式纳管 {{count}} 个 Agent。",
+      "savedPending": "Agent 已在本地设为私有，等待发布。",
+      "failed": "无法纳管 Agent：{{error}}",
+      "status": {
+        "not_onboarded": "未纳管",
+        "private": "私有",
+        "published": "已发布",
+        "managed_elsewhere": "不可用"
+      }
+    },
     "running": {
       "empty": "当前没有正在运行的 Agent。",
       "unreachableTitle": "运行时不可达",

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -1410,6 +1410,61 @@ def get_vibe_agents(*, backend: Optional[str] = None, include_disabled: bool = F
         store.close()
 
 
+def _organization_resource_console_url(config: V2Config, organization_id: str) -> str:
+    backend_url = str(config.remote_access.vibe_cloud.backend_url or "https://avibe.bot").rstrip("/")
+    organization = urllib.parse.quote(organization_id, safe="")
+    return f"{backend_url}/app/organizations/{organization}/resources"
+
+
+def get_vibe_agent_onboarding() -> dict:
+    """Return the safe owner inventory for Organization Agent onboarding."""
+
+    config = V2Config.load()
+    _ensure_builtin_default_agents(config)
+    store = VibeAgentStore()
+    try:
+        result = store.organization_onboarding_inventory(
+            user_context=resolve_resource_access_context(),
+        )
+    finally:
+        store.close()
+    result["ok"] = True
+    if result.get("available") and result.get("organization_id"):
+        result["console_url"] = _organization_resource_console_url(
+            config,
+            str(result["organization_id"]),
+        )
+    return result
+
+
+def onboard_vibe_agents() -> dict:
+    """Register all existing Agents privately, then publish the safe index."""
+
+    from vibe import remote_access
+
+    config = V2Config.load()
+    _ensure_builtin_default_agents(config)
+    context = resolve_resource_access_context()
+    store = VibeAgentStore()
+    try:
+        result = store.onboard_organization_agents(user_context=context)
+    finally:
+        store.close()
+
+    organization_id = str(result["organization_id"])
+    result.update(
+        {
+            "ok": True,
+            "console_url": _organization_resource_console_url(config, organization_id),
+            "sync": remote_access.sync_resource_acl_once(
+                config,
+                organization_id=organization_id,
+            ),
+        }
+    )
+    return result
+
+
 def get_vibe_agent(name: str) -> dict:
     user_context = resolve_resource_access_context()
     store = VibeAgentStore()

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -1416,6 +1416,37 @@ def _organization_resource_console_url(config: V2Config, organization_id: str) -
     return f"{backend_url}/app/organizations/{organization}/resources"
 
 
+def _agent_onboarding_resource_descriptors(
+    organization_id: str,
+    inventory: list[dict],
+) -> list[dict]:
+    """Enrich the full ACL snapshot with safe Agent names for first publication."""
+
+    from vibe import remote_access
+
+    display_names: dict[str, str] = {}
+    for agent in inventory:
+        resource_id = str(agent.get("id") or "")
+        try:
+            display_names[resource_id] = remote_access._safe_resource_acl_identifier(
+                agent.get("name"),
+                limit=240,
+            )
+        except ValueError:
+            display_names[resource_id] = resource_id
+
+    # A resource-index update is a full snapshot. Preserve non-Agent resources
+    # while enriching newly onboarded Agent rows with their safe names.
+    descriptors = remote_access._local_policy_resource_descriptors(organization_id)
+    for descriptor in descriptors:
+        if descriptor.get("resource_kind") != "agent":
+            continue
+        display_name = display_names.get(str(descriptor.get("resource_id") or ""))
+        if display_name:
+            descriptor["display_name"] = display_name
+    return descriptors
+
+
 def get_vibe_agent_onboarding() -> dict:
     """Return the safe owner inventory for Organization Agent onboarding."""
 
@@ -1452,6 +1483,10 @@ def onboard_vibe_agents() -> dict:
         store.close()
 
     organization_id = str(result["organization_id"])
+    resources = _agent_onboarding_resource_descriptors(
+        organization_id,
+        list(result.get("agents") or []),
+    )
     result.update(
         {
             "ok": True,
@@ -1459,6 +1494,7 @@ def onboard_vibe_agents() -> dict:
             "sync": remote_access.sync_resource_acl_once(
                 config,
                 organization_id=organization_id,
+                resources=resources,
             ),
         }
     )

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -3707,6 +3707,20 @@ def vibe_agents_get():
         return _vibe_agent_error_response(exc)
 
 
+@app.route("/api/agent-onboarding", methods=["GET", "POST"])
+def vibe_agent_onboarding():
+    """Inventory or explicitly register existing Agents with Organization ACL."""
+
+    from vibe import api
+
+    try:
+        if request.method == "POST":
+            return jsonify(api.onboard_vibe_agents())
+        return jsonify(api.get_vibe_agent_onboarding())
+    except (ValueError, PermissionError) as exc:
+        return _vibe_agent_error_response(exc)
+
+
 @app.route("/api/running-agents", methods=["GET"])
 async def running_agents_get():
     """Proxy the controller's read-only running-agents snapshot to the workbench.


### PR DESCRIPTION
## Summary

- add an owner-only inventory for every existing custom and built-in/system Agent
- onboard legacy Agents explicitly as private Organization resources without changing existing ACL revisions
- expose the existing hosted Resource Access workflow so owners can publish selected Agents to Organization groups
- keep publication metadata limited to safe Agent identity and state fields, with rename/delete convergence through the full resource snapshot

## Capability

Adds **owner-managed Agent Organization onboarding and publication**. Editors continue to use only Agents selected by the resource ACL; onboarding and publication remain owner-only operations enforced in the service layer.

## Acceptance Criteria

- **1056-AC1 — inventory:** owners can inspect existing custom plus built-in/system Agents and their onboarding/publication state.
- **1056-AC2 — private default:** every missing legacy Agent policy is inserted as `private`, with no group grants or implicit member access.
- **1056-AC3 — selective publication:** owners can continue from the inventory to the supported hosted Resource Access workflow and grant selected Agents to groups.
- **1056-AC4 — metadata redaction:** the published index contains only resource identity, safe display metadata, enabled/state, access, group IDs, and revisions; no prompts, credentials, config, or local paths.
- **1056-AC5 — idempotency:** repeat onboarding inserts only missing policies and never updates existing access, groups, or revisions.
- **1056-AC6 — lifecycle sync:** Agent rename/delete snapshots converge the hosted index without stale resource entries.
- **1056-AC7 — upgrade/fresh install:** focused scenarios prove editors end with exactly the intended authorized Agent set after both upgrade and fresh-install onboarding.

## CONTRACT DEPENDENCY

- **#1054:** this lane consumes the safe Agent display-name/publication contract. It does not introduce prompt-derived names or duplicate display-metadata revision ownership.
- **#1055:** this lane consumes the documented owner-manages/editor-uses split. The local service boundary requires an instance owner for onboarding; editor usability remains determined by ACL-authorized resources.

## CONTRACT CHANGE

None. `vibe/authorization.py` is untouched.

## Evidence

- **Unit:** upgrade, fresh-install, owner gate, idempotency/revision preservation, redaction, and rename/delete tests.
- **Contract:** owner/editor HTTP route checks plus the existing remote resource-index payload contract.
- **Scenario:** upgrade and fresh-install flows assert the editor-visible Agent set after private, scoped, and public publication states.
- **Manual:** production UI build completed; no local service restart or Incus regression was performed. Integrated staging verification remains with the five-lane merge.

## Tests

- `uv run --frozen pytest -q tests/test_agent_organization_onboarding.py tests/test_resource_acl_agents.py tests/test_remote_resource_acl_sync.py tests/test_ui_resource_access_api.py` — 23 passed
- `uv run --frozen pytest -q tests/test_ui_api.py -k 'vibe_agent or agent_catalog or builtin_default'` — 15 passed, 80 deselected
- `uv run --frozen --with ruff ruff check core/vibe_agents.py vibe/api.py vibe/ui_server.py tests/test_agent_organization_onboarding.py` — passed
- `cd ui && npm run build` — passed
- `python3 -m json.tool ui/src/i18n/en.json` and `ui/src/i18n/zh.json` — passed
- `git diff --check` — passed

Closes #1056
