### PR TITLE
fix(memory): stop publishing Intel macOS runtime

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -119,8 +119,6 @@ jobs:
             artifact: linux-x64
           - os: ubuntu-24.04-arm
             artifact: linux-arm64
-          - os: macos-15-intel
-            artifact: darwin-x64
           - os: macos-14
             artifact: darwin-arm64
     steps:

--- a/.github/workflows/release_ai.yml
+++ b/.github/workflows/release_ai.yml
@@ -98,8 +98,6 @@ jobs:
             artifact: linux-x64
           - os: ubuntu-24.04-arm
             artifact: linux-arm64
-          - os: macos-15-intel
-            artifact: darwin-x64
           - os: macos-14
             artifact: darwin-arm64
     steps:

--- a/scripts/build_memory_runtime.py
+++ b/scripts/build_memory_runtime.py
@@ -25,7 +25,6 @@ BIN_PATH = "bin/python"
 MAX_ARCHIVE_BYTES = 1024 * 1024 * 1024
 EXPECTED_PLATFORMS = {
     "darwin-arm64",
-    "darwin-x64",
     "linux-arm64",
     "linux-x64",
 }

--- a/scripts/generate_memory_runtime_manifest.py
+++ b/scripts/generate_memory_runtime_manifest.py
@@ -18,7 +18,6 @@ BIN_PATH = "bin/python"
 MAX_ARCHIVE_BYTES = 1024 * 1024 * 1024
 EXPECTED_PLATFORMS = {
     "darwin-arm64",
-    "darwin-x64",
     "linux-arm64",
     "linux-x64",
 }

--- a/scripts/memory_runtime_release_guard.py
+++ b/scripts/memory_runtime_release_guard.py
@@ -20,7 +20,7 @@ RELEASE_DOWNLOAD_ROOT = "https://github.com/avibe-bot/avibe/releases/download"
 EXPECTED_PYTHON_VERSION = "3.12.12"
 EXPECTED_LOCK_SHA256 = "62b00f1a9ca04cc4ea4c5af51f389ba49acdea8786e5f7044d52823244502c57"
 EXPECTED_UV_VERSION = "0.9.18"
-EXPECTED_PLATFORMS = frozenset({"darwin-arm64", "darwin-x64", "linux-arm64", "linux-x64"})
+EXPECTED_PLATFORMS = frozenset({"darwin-arm64", "linux-arm64", "linux-x64"})
 MAX_ARCHIVE_BYTES = 1024 * 1024 * 1024
 
 

--- a/tests/test_memory_runtime_release.py
+++ b/tests/test_memory_runtime_release.py
@@ -10,10 +10,24 @@ from pathlib import Path
 import pytest
 
 from scripts import generate_memory_runtime_manifest as manifest_generator
-from scripts.build_memory_runtime import LOCK_SHA256, PYTHON_VERSION, UV_VERSION, create_archive, prune_runtime
+from scripts.build_memory_runtime import (
+    EXPECTED_PLATFORMS as BUILD_PLATFORMS,
+    LOCK_SHA256,
+    PYTHON_VERSION,
+    UV_VERSION,
+    create_archive,
+    prune_runtime,
+)
 
 
-PLATFORMS = ("darwin-arm64", "darwin-x64", "linux-arm64", "linux-x64")
+PLATFORMS = ("darwin-arm64", "linux-arm64", "linux-x64")
+
+
+def test_memory_runtime_release_platform_contract_excludes_darwin_x64() -> None:
+    expected = set(PLATFORMS)
+
+    assert BUILD_PLATFORMS == expected
+    assert manifest_generator.EXPECTED_PLATFORMS == expected
 
 
 def _write_archive(directory: Path, platform: str) -> tuple[Path, bytes]:
@@ -153,6 +167,15 @@ def test_create_memory_runtime_archive_rejects_symlinks(tmp_path: Path) -> None:
             runtime_root=runtime,
             output=tmp_path / "runtime.tar.gz",
             platform="darwin-arm64",
+        )
+
+
+def test_create_memory_runtime_archive_rejects_darwin_x64(tmp_path: Path) -> None:
+    with pytest.raises(SystemExit, match="Unsupported Memory Runtime platform: darwin-x64"):
+        create_archive(
+            runtime_root=tmp_path / "unused",
+            output=tmp_path / "runtime.tar.gz",
+            platform="darwin-x64",
         )
 
 

--- a/tests/test_memory_runtime_release_guard.py
+++ b/tests/test_memory_runtime_release_guard.py
@@ -12,6 +12,10 @@ import pytest
 from scripts import memory_runtime_release_guard as guard
 
 
+def test_guard_platform_contract_excludes_darwin_x64() -> None:
+    assert guard.EXPECTED_PLATFORMS == frozenset({"darwin-arm64", "linux-arm64", "linux-x64"})
+
+
 def _archive(binary: bytes) -> bytes:
     output = io.BytesIO()
     with gzip.GzipFile(fileobj=output, mode="wb", filename="", mtime=0) as compressed:

--- a/ui/src/components/settings/SettingsDependenciesPage.logic.ts
+++ b/ui/src/components/settings/SettingsDependenciesPage.logic.ts
@@ -1,0 +1,7 @@
+import type { DependencyItem } from '@/context/ApiContext';
+
+const INSTALLABLE_DEPENDENCIES = new Set(['askill', 'avault', 'show-runtime', 'memory-runtime', 'tmux']);
+
+export const dependencyHasInstallAction = (
+  dependency: Pick<DependencyItem, 'id' | 'status'>,
+): boolean => dependency.status !== 'unsupported' && INSTALLABLE_DEPENDENCIES.has(dependency.id);

--- a/ui/src/components/settings/SettingsDependenciesPage.test.ts
+++ b/ui/src/components/settings/SettingsDependenciesPage.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+
+import { dependencyHasInstallAction } from './SettingsDependenciesPage.logic';
+
+describe('dependencyHasInstallAction', () => {
+  it('hides install and repair actions for unsupported dependencies', () => {
+    expect(dependencyHasInstallAction({ id: 'memory-runtime', status: 'unsupported' })).toBe(false);
+  });
+
+  it('keeps supported dependency actions unchanged', () => {
+    expect(dependencyHasInstallAction({ id: 'memory-runtime', status: 'missing' })).toBe(true);
+    expect(dependencyHasInstallAction({ id: 'show-runtime', status: 'ready' })).toBe(true);
+    expect(dependencyHasInstallAction({ id: 'node', status: 'missing' })).toBe(false);
+  });
+});

--- a/ui/src/components/settings/SettingsDependenciesPage.tsx
+++ b/ui/src/components/settings/SettingsDependenciesPage.tsx
@@ -24,6 +24,7 @@ import { SettingsResourceRow } from './SettingsPrimitives';
 import { useApi } from '@/context/ApiContext';
 import type { DependencyItem, InstallResult } from '@/context/ApiContext';
 import { useToast } from '@/context/ToastContext';
+import { dependencyHasInstallAction } from './SettingsDependenciesPage.logic';
 
 // Mirrors design.pen "vibe-remote — Settings · Dependencies": one card per
 // required local runtime (icon tile + name/REQUIRED + detail + status pill +
@@ -135,12 +136,7 @@ export const SettingsDependenciesPage: React.FC = () => {
           {deps.map((d) => {
             const meta = DEP_META[d.id] ?? DEP_META.node;
             const installing = busy === d.id;
-            const showAction =
-              d.id === 'askill' ||
-              d.id === 'avault' ||
-              d.id === 'show-runtime' ||
-              d.id === 'memory-runtime' ||
-              d.id === 'tmux';
+            const showAction = dependencyHasInstallAction(d);
             return (
               <SettingsResourceRow
                 key={d.id}

--- a/vibe/memory_runtime_manifest.json
+++ b/vibe/memory_runtime_manifest.json
@@ -19,14 +19,6 @@
       "size": 1,
       "bin_path": "bin/python"
     },
-    "darwin-x64": {
-      "name": "memory-runtime-1.1.3-darwin-x64.tar.gz",
-      "url": "https://github.com/avibe-bot/avibe/releases/download/memory-runtime-v1.1.3-1/memory-runtime-1.1.3-darwin-x64.tar.gz",
-      "sha256": "0000000000000000000000000000000000000000000000000000000000000000",
-      "binary_sha256": "0000000000000000000000000000000000000000000000000000000000000000",
-      "size": 1,
-      "bin_path": "bin/python"
-    },
     "linux-arm64": {
       "name": "memory-runtime-1.1.3-linux-arm64.tar.gz",
       "url": "https://github.com/avibe-bot/avibe/releases/download/memory-runtime-v1.1.3-1/memory-runtime-1.1.3-linux-arm64.tar.gz",


### PR DESCRIPTION
## Summary

- remove `darwin-x64` from Memory Runtime release matrices, builder/manifest contracts, release guard, and the bundled manifest
- keep Show Runtime Intel macOS publishing unchanged
- hide install/repair actions when a dependency reports `unsupported`
- add release-contract and UI behavior coverage

## Why

EverOS 1.1.3 locks LanceDB 0.34.0, which does not publish a macOS x86_64 wheel. Continuing to advertise a `darwin-x64` Memory Runtime makes the release job fail deterministically.

## Affected scenarios

None. This is a release platform contract and has no matching scenario catalog entry.

## Evidence

- Unit: `uv run pytest tests/test_memory_runtime_release.py tests/test_memory_runtime_release_guard.py tests/test_local_deps.py -q` (90 passed)
- Unit/UI: targeted Vitest suite (2 passed) and targeted ESLint passed
- Contract: builder, manifest generator, bundled manifest, and release guard now agree on `darwin-arm64`, `linux-arm64`, and `linux-x64`; `darwin-x64` archive creation is rejected
- Platform resolution: the exact locked Memory Runtime requirements resolve for Apple arm64, Linux arm64, and Linux x64
- Build: `npm run build` passed
- Full pytest: 6003 passed, 17 skipped; 4 failures and 35 errors are unrelated existing environment/E2E issues (Show Runtime asset 404, missing pip in the uv environment, and platform registry identity assertions)
- Full ESLint: currently blocked by 344 existing errors; linting the changed UI files passed
- Residual manual check: actual archive builds remain covered by the GitHub release workflow
