### PR TITLE
fix(sessions): preserve backend ownership on legacy import conflict

### DIFF
--- a/storage/sessions_service.py
+++ b/storage/sessions_service.py
@@ -29,6 +29,7 @@ from storage.agent_session_rows import (
     snapshot_scope_workdir,
 )
 from storage.models import (
+    agents,
     agent_sessions,
     metadata,
     run_definitions,
@@ -1252,23 +1253,19 @@ class SQLiteSessionsService:
                         dedup_key = (scope_id, base_anchor)
                         if dedup_key in seen_anchor_rows:
                             continue
-                        imported_backend = _agent_backend(str(agent_name))
+                        imported_variant = str(agent_name) or "default"
+                        imported_backend = _agent_backend_for_import(conn, imported_variant)
                         existing_anchor_row = _find_scope_anchor_row(
                             conn,
                             scope_id=scope_id,
                             session_anchor=base_anchor,
                         )
-                        imported_variant = str(agent_name) or "default"
                         if existing_anchor_row is not None:
                             existing_backend = str(existing_anchor_row["agent_backend"] or "").strip()
                             existing_variant = str(existing_anchor_row["agent_variant"] or "default").strip()
                             existing_is_owned = existing_backend not in {"", "default"}
                             same_variant = existing_variant == imported_variant
-                            imported_is_owned = imported_backend != "unknown"
-                            if existing_is_owned and (
-                                (imported_is_owned and existing_backend != imported_backend)
-                                or (not imported_is_owned and not same_variant)
-                            ):
+                            if existing_is_owned and not same_variant and existing_backend != imported_backend:
                                 logger.warning(
                                     "Skipping legacy session import that would relabel anchor row across backends "
                                     "scope_id=%s anchor=%s existing_backend=%s existing_variant=%s "
@@ -1281,7 +1278,7 @@ class SQLiteSessionsService:
                                     imported_variant,
                                 )
                                 continue
-                            if not existing_is_owned and imported_is_owned:
+                            if not existing_is_owned and imported_backend != "unknown":
                                 conn.execute(
                                     agent_sessions.update()
                                     .where(agent_sessions.c.id == str(existing_anchor_row["id"]))
@@ -1659,6 +1656,23 @@ _ROUTING_SENTINEL_VARIANTS = {"", "default", *_BACKEND_AGENT_NAMES}
 
 def _agent_backend(agent_name: str) -> str:
     return agent_name if agent_name in _BACKEND_AGENT_NAMES else "unknown"
+
+
+def _agent_backend_for_import(conn: Connection, agent_name: str) -> str:
+    """Resolve a legacy mapping name through built-ins and the Vibe Agent catalog."""
+    requested = str(agent_name or "").strip()
+    backend = _agent_backend(requested)
+    if backend != "unknown":
+        return backend
+    normalized = re.sub(r"[^a-z0-9_-]+", "-", requested.lower()).strip("-_")
+    if not normalized:
+        return "unknown"
+    catalog_backend = conn.execute(
+        select(agents.c.backend)
+        .where(or_(agents.c.name == requested, agents.c.normalized_name == normalized))
+        .limit(1)
+    ).scalar_one_or_none()
+    return str(catalog_backend) if catalog_backend in _BACKEND_AGENT_NAMES else "unknown"
 
 
 def _agent_session_name_predicate(agent_name: str) -> Any:

--- a/storage/sessions_service.py
+++ b/storage/sessions_service.py
@@ -741,8 +741,8 @@ class SQLiteSessionsService:
                         )
                         if existing_anchor_row is not None:
                             existing_backend = str(existing_anchor_row["agent_backend"] or "").strip()
-                            if existing_backend and existing_backend != imported_backend:
-                                seen_anchor_rows[dedup_key] = str(existing_anchor_row["id"])
+                            existing_is_owned = existing_backend not in {"", "default"}
+                            if existing_is_owned and existing_backend != imported_backend:
                                 logger.warning(
                                     "Skipping legacy session import that would relabel anchor row across backends "
                                     "scope_id=%s anchor=%s existing_backend=%s imported_backend=%s",

--- a/storage/sessions_service.py
+++ b/storage/sessions_service.py
@@ -739,6 +739,7 @@ class SQLiteSessionsService:
                             scope_id=scope_id,
                             session_anchor=base_anchor,
                         )
+                        imported_variant = str(agent_name) or "default"
                         if existing_anchor_row is not None:
                             existing_backend = str(existing_anchor_row["agent_backend"] or "").strip()
                             existing_is_owned = existing_backend not in {"", "default"}
@@ -752,10 +753,20 @@ class SQLiteSessionsService:
                                     imported_backend,
                                 )
                                 continue
+                            if not existing_is_owned:
+                                conn.execute(
+                                    agent_sessions.update()
+                                    .where(agent_sessions.c.id == str(existing_anchor_row["id"]))
+                                    .values(
+                                        agent_backend=imported_backend,
+                                        agent_variant=imported_variant,
+                                        updated_at=now,
+                                    )
+                                )
                         encoded_session_id = encode_session_value(native_session_id)
                         row_key = _session_row_key(
                             scope_id=scope_id,
-                            agent_variant=str(agent_name) or "default",
+                            agent_variant=imported_variant,
                             session_anchor=base_anchor,
                             native_session_id=encoded_session_id,
                         )
@@ -769,7 +780,7 @@ class SQLiteSessionsService:
                             id=row_id,
                             scope_id=scope_id,
                             agent_backend=imported_backend,
-                            agent_variant=str(agent_name) or "default",
+                            agent_variant=imported_variant,
                             model=None,
                             reasoning_effort=None,
                             session_anchor=base_anchor,

--- a/storage/sessions_service.py
+++ b/storage/sessions_service.py
@@ -1261,18 +1261,27 @@ class SQLiteSessionsService:
                         imported_variant = str(agent_name) or "default"
                         if existing_anchor_row is not None:
                             existing_backend = str(existing_anchor_row["agent_backend"] or "").strip()
+                            existing_variant = str(existing_anchor_row["agent_variant"] or "default").strip()
                             existing_is_owned = existing_backend not in {"", "default"}
-                            if existing_is_owned and existing_backend != imported_backend:
+                            same_variant = existing_variant == imported_variant
+                            imported_is_owned = imported_backend != "unknown"
+                            if existing_is_owned and (
+                                (imported_is_owned and existing_backend != imported_backend)
+                                or (not imported_is_owned and not same_variant)
+                            ):
                                 logger.warning(
                                     "Skipping legacy session import that would relabel anchor row across backends "
-                                    "scope_id=%s anchor=%s existing_backend=%s imported_backend=%s",
+                                    "scope_id=%s anchor=%s existing_backend=%s existing_variant=%s "
+                                    "imported_backend=%s imported_variant=%s",
                                     scope_id,
                                     base_anchor,
                                     existing_backend,
+                                    existing_variant,
                                     imported_backend,
+                                    imported_variant,
                                 )
                                 continue
-                            if not existing_is_owned:
+                            if not existing_is_owned and imported_is_owned:
                                 conn.execute(
                                     agent_sessions.update()
                                     .where(agent_sessions.c.id == str(existing_anchor_row["id"]))
@@ -1858,7 +1867,7 @@ def _find_scope_anchor_row(
 ) -> Mapping[str, Any] | None:
     return (
         conn.execute(
-            select(agent_sessions.c.id, agent_sessions.c.agent_backend)
+            select(agent_sessions.c.id, agent_sessions.c.agent_backend, agent_sessions.c.agent_variant)
             .where(agent_sessions.c.scope_id == scope_id)
             .where(agent_sessions.c.session_anchor == str(session_anchor))
             .order_by(agent_sessions.c.last_active_at.desc(), agent_sessions.c.id.desc())

--- a/storage/sessions_service.py
+++ b/storage/sessions_service.py
@@ -6,7 +6,7 @@ import re
 import secrets
 from datetime import datetime, timezone, timedelta
 from pathlib import Path
-from typing import Any
+from typing import Any, Mapping
 
 from sqlalchemy import Connection, case, func, select
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
@@ -733,6 +733,25 @@ class SQLiteSessionsService:
                         dedup_key = (scope_id, base_anchor)
                         if dedup_key in seen_anchor_rows:
                             continue
+                        imported_backend = _agent_backend(str(agent_name))
+                        existing_anchor_row = _find_scope_anchor_row(
+                            conn,
+                            scope_id=scope_id,
+                            session_anchor=base_anchor,
+                        )
+                        if existing_anchor_row is not None:
+                            existing_backend = str(existing_anchor_row["agent_backend"] or "").strip()
+                            if existing_backend and existing_backend != imported_backend:
+                                seen_anchor_rows[dedup_key] = str(existing_anchor_row["id"])
+                                logger.warning(
+                                    "Skipping legacy session import that would relabel anchor row across backends "
+                                    "scope_id=%s anchor=%s existing_backend=%s imported_backend=%s",
+                                    scope_id,
+                                    base_anchor,
+                                    existing_backend,
+                                    imported_backend,
+                                )
+                                continue
                         encoded_session_id = encode_session_value(native_session_id)
                         row_key = _session_row_key(
                             scope_id=scope_id,
@@ -741,11 +760,7 @@ class SQLiteSessionsService:
                             native_session_id=encoded_session_id,
                         )
                         row_id = (
-                            _find_row_id_for_scope_anchor(
-                                conn,
-                                scope_id=scope_id,
-                                session_anchor=base_anchor,
-                            )
+                            str(existing_anchor_row["id"]) if existing_anchor_row is not None else None
                             or existing_session_ids.get(row_key)
                             or _new_session_id(used_session_ids)
                         )
@@ -753,7 +768,7 @@ class SQLiteSessionsService:
                         stmt = sqlite_insert(agent_sessions).values(
                             id=row_id,
                             scope_id=scope_id,
-                            agent_backend=_agent_backend(str(agent_name)),
+                            agent_backend=imported_backend,
                             agent_variant=str(agent_name) or "default",
                             model=None,
                             reasoning_effort=None,
@@ -772,8 +787,6 @@ class SQLiteSessionsService:
                                 index_elements=[agent_sessions.c.id],
                                 set_={
                                     "scope_id": stmt.excluded.scope_id,
-                                    "agent_backend": stmt.excluded.agent_backend,
-                                    "agent_variant": stmt.excluded.agent_variant,
                                     "session_anchor": stmt.excluded.session_anchor,
                                     "native_session_id": stmt.excluded.native_session_id,
                                     "status": stmt.excluded.status,
@@ -1197,6 +1210,25 @@ def _find_row_id_for_scope_anchor(
         .order_by(agent_sessions.c.last_active_at.desc(), agent_sessions.c.id.desc())
         .limit(1)
     ).scalar_one_or_none()
+
+
+def _find_scope_anchor_row(
+    conn: Connection,
+    *,
+    scope_id: str | None,
+    session_anchor: str,
+) -> Mapping[str, Any] | None:
+    return (
+        conn.execute(
+            select(agent_sessions.c.id, agent_sessions.c.agent_backend)
+            .where(agent_sessions.c.scope_id == scope_id)
+            .where(agent_sessions.c.session_anchor == str(session_anchor))
+            .order_by(agent_sessions.c.last_active_at.desc(), agent_sessions.c.id.desc())
+            .limit(1)
+        )
+        .mappings()
+        .first()
+    )
 
 
 def _runtime_record_values(

--- a/storage/sessions_service.py
+++ b/storage/sessions_service.py
@@ -1293,6 +1293,17 @@ class SQLiteSessionsService:
                             same_agent_identity = (
                                 imported_agent_id is not None and existing_agent_id == imported_agent_id
                             )
+                            same_agent_name = (
+                                imported_agent_name is not None
+                                and existing_agent_name is not None
+                                and _normalize_agent_name_key(existing_agent_name)
+                                == _normalize_agent_name_key(imported_agent_name)
+                            )
+                            imported_variant_matches_existing_agent = (
+                                existing_agent_name is not None
+                                and _normalize_agent_name_key(imported_variant)
+                                == _normalize_agent_name_key(existing_agent_name)
+                            )
                             backend_conflicts = imported_backend != "unknown" and existing_backend != imported_backend
                             variant_conflicts = (
                                 not same_variant
@@ -1315,7 +1326,14 @@ class SQLiteSessionsService:
                                 )
                                 skip_mapping = True
                                 break
-                            identity_conflicts = False
+                            identity_conflicts = (
+                                existing_identity_is_durable
+                                and imported_backend == "unknown"
+                                and imported_agent_id is None
+                                and imported_agent_name is None
+                                and (existing_agent_id is not None or existing_agent_name is not None)
+                                and not imported_variant_matches_existing_agent
+                            )
                             if existing_identity_is_durable and imported_agent_id is not None and existing_agent_id not in {
                                 None,
                                 imported_agent_id,
@@ -1324,6 +1342,8 @@ class SQLiteSessionsService:
                             if (
                                 existing_identity_is_durable
                                 and imported_agent_name is not None
+                                and not same_agent_identity
+                                and not same_agent_name
                                 and existing_agent_name not in {
                                     None,
                                     imported_agent_name,
@@ -1344,6 +1364,8 @@ class SQLiteSessionsService:
                                 )
                                 skip_mapping = True
                                 break
+                            backfills_agent_id = imported_agent_id is not None and existing_agent_id is None
+                            backfills_agent_name = imported_agent_name is not None and existing_agent_name is None
                             update_values: dict[str, Any] = {"updated_at": now}
                             if not existing_is_owned:
                                 update_values["agent_variant"] = imported_variant
@@ -1366,9 +1388,9 @@ class SQLiteSessionsService:
                                 update_values["agent_name"] = imported_agent_name
                             if sentinel_variant_compatible and existing_variant != imported_variant:
                                 update_values["agent_variant"] = imported_variant
-                            if imported_agent_id is not None and existing_agent_id is None:
+                            if backfills_agent_id:
                                 update_values["agent_id"] = imported_agent_id
-                            if imported_agent_name is not None and existing_agent_name is None:
+                            if backfills_agent_name:
                                 update_values["agent_name"] = imported_agent_name
                             if len(update_values) <= 1:
                                 break
@@ -1377,7 +1399,12 @@ class SQLiteSessionsService:
                                 .where(agent_sessions.c.id == str(existing_anchor_row["id"]))
                                 .where(agent_sessions.c.status != "archived")
                             )
-                            if not existing_is_owned or sentinel_variant_compatible:
+                            if (
+                                not existing_is_owned
+                                or sentinel_variant_compatible
+                                or backfills_agent_id
+                                or backfills_agent_name
+                            ):
                                 update_stmt = update_stmt.where(
                                     func.coalesce(agent_sessions.c.agent_backend, "") == observed_backend
                                 ).where(func.coalesce(agent_sessions.c.agent_variant, "") == observed_variant)
@@ -1388,11 +1415,11 @@ class SQLiteSessionsService:
                                     func.coalesce(agent_sessions.c.agent_name, "") == observed_agent_name
                                 )
                             else:
-                                if imported_agent_id is not None and existing_agent_id is None:
+                                if backfills_agent_id:
                                     update_stmt = update_stmt.where(
                                         func.coalesce(agent_sessions.c.agent_id, "") == observed_agent_id
                                     )
-                                if imported_agent_name is not None and existing_agent_name is None:
+                                if backfills_agent_name:
                                     update_stmt = update_stmt.where(
                                         func.coalesce(agent_sessions.c.agent_name, "") == observed_agent_name
                                     )
@@ -1792,10 +1819,14 @@ def _is_sentinel_variant(agent_variant: str) -> bool:
     return str(agent_variant or "").strip() in {"", "default"}
 
 
+def _normalize_agent_name_key(agent_name: str) -> str:
+    return re.sub(r"[^a-z0-9_-]+", "-", str(agent_name or "").strip().lower()).strip("-_")
+
+
 def _resolve_imported_agent_identity(conn: Connection, agent_name: str) -> tuple[str, str | None, str | None]:
     """Resolve a legacy mapping name through built-ins and the Vibe Agent catalog."""
     requested = str(agent_name or "").strip()
-    normalized = re.sub(r"[^a-z0-9_-]+", "-", requested.lower()).strip("-_")
+    normalized = _normalize_agent_name_key(requested)
     if normalized:
         catalog_agent = conn.execute(
             select(agents.c.id, agents.c.name, agents.c.backend)

--- a/storage/sessions_service.py
+++ b/storage/sessions_service.py
@@ -1239,9 +1239,31 @@ class SQLiteSessionsService:
                 if not isinstance(agent_maps, dict):
                     continue
                 scope_id = resolve_scope_from_legacy_key(conn, str(scope_key), now=now)
+                resolved_imported_identities: dict[str, tuple[str, str | None, str | None]] = {}
+                normalized_anchors: dict[tuple[str, str], str] = {}
+                anchor_owner_candidates: dict[
+                    str, list[tuple[str, str, str | None, str | None]]
+                ] = {}
+                for candidate_name, candidate_thread_map in agent_maps.items():
+                    if not isinstance(candidate_thread_map, dict):
+                        continue
+                    candidate_variant = str(candidate_name) or "default"
+                    candidate_identity = _resolve_imported_agent_identity(conn, candidate_variant)
+                    resolved_imported_identities[candidate_variant] = candidate_identity
+                    for candidate_thread_id in candidate_thread_map:
+                        candidate_thread_key = str(candidate_thread_id)
+                        candidate_anchor = _base_session_anchor(candidate_thread_key)
+                        normalized_anchors[(candidate_variant, candidate_thread_key)] = candidate_anchor
+                        anchor_owner_candidates.setdefault(candidate_anchor, []).append(
+                            (candidate_variant, *candidate_identity)
+                        )
                 for agent_name, thread_map in agent_maps.items():
                     if not isinstance(thread_map, dict):
                         continue
+                    imported_variant = str(agent_name) or "default"
+                    imported_backend, imported_agent_id, imported_agent_name = resolved_imported_identities[
+                        imported_variant
+                    ]
                     for thread_id, native_session_id in thread_map.items():
                         thread_key = str(thread_id)
                         # Normalise OpenCode ``base:/cwd`` composites to the bare
@@ -1249,14 +1271,10 @@ class SQLiteSessionsService:
                         # subagent ``base:<name>`` anchors are preserved. Workdir is
                         # snapshotted from scope settings, never inferred from the
                         # legacy anchor suffix.
-                        base_anchor = _base_session_anchor(thread_key)
+                        base_anchor = normalized_anchors[(imported_variant, thread_key)]
                         dedup_key = (scope_id, base_anchor)
                         if dedup_key in seen_anchor_rows:
                             continue
-                        imported_variant = str(agent_name) or "default"
-                        imported_backend, imported_agent_id, imported_agent_name = _resolve_imported_agent_identity(
-                            conn, imported_variant
-                        )
                         encoded_session_id = encode_session_value(native_session_id)
                         existing_anchor_row = _find_scope_anchor_row(
                             conn,
@@ -1290,20 +1308,8 @@ class SQLiteSessionsService:
                             # Prefer a legacy mapping for the reserved owner when one
                             # exists; otherwise an unbound route reservation is
                             # provisional and may be adopted by the imported session.
-                            has_existing_owner_mapping = False
-                            for candidate_name, candidate_thread_map in agent_maps.items():
-                                if not isinstance(candidate_thread_map, dict) or not any(
-                                    _base_session_anchor(str(candidate_thread_id)) == base_anchor
-                                    for candidate_thread_id in candidate_thread_map
-                                ):
-                                    continue
-                                candidate_variant = str(candidate_name) or "default"
-                                (
-                                    candidate_backend,
-                                    candidate_agent_id,
-                                    candidate_agent_name,
-                                ) = _resolve_imported_agent_identity(conn, candidate_variant)
-                                if _import_matches_existing_owner(
+                            has_existing_owner_mapping = any(
+                                _import_matches_existing_owner(
                                     existing_backend=existing_backend,
                                     existing_variant=existing_variant,
                                     existing_agent_id=existing_agent_id,
@@ -1312,9 +1318,14 @@ class SQLiteSessionsService:
                                     imported_variant=candidate_variant,
                                     imported_agent_id=candidate_agent_id,
                                     imported_agent_name=candidate_agent_name,
-                                ):
-                                    has_existing_owner_mapping = True
-                                    break
+                                )
+                                for (
+                                    candidate_variant,
+                                    candidate_backend,
+                                    candidate_agent_id,
+                                    candidate_agent_name,
+                                ) in anchor_owner_candidates.get(base_anchor, ())
+                            )
                             adopts_unbound_route = (
                                 not existing_native_session_id
                                 and not import_matches_existing_owner

--- a/storage/sessions_service.py
+++ b/storage/sessions_service.py
@@ -1277,14 +1277,19 @@ class SQLiteSessionsService:
                             existing_native_session_id = observed_native_session_id.strip()
                             existing_is_owned = _is_owned_backend(existing_backend)
                             existing_variant_is_owned = not _is_sentinel_variant(existing_variant)
+                            import_matches_existing_owner = _import_matches_existing_owner(
+                                existing_backend=existing_backend,
+                                existing_variant=existing_variant,
+                                existing_agent_id=existing_agent_id,
+                                existing_agent_name=existing_agent_name,
+                                imported_backend=imported_backend,
+                                imported_variant=imported_variant,
+                                imported_agent_id=imported_agent_id,
+                                imported_agent_name=imported_agent_name,
+                            )
                             # Prefer a legacy mapping for the reserved owner when one
-                            # exists; otherwise an unbound cross-backend reservation is
+                            # exists; otherwise an unbound route reservation is
                             # provisional and may be adopted by the imported session.
-                            existing_owner_keys = {
-                                _normalize_agent_name_key(value)
-                                for value in (existing_backend, existing_variant, existing_agent_name)
-                                if value
-                            }
                             has_existing_owner_mapping = False
                             for candidate_name, candidate_thread_map in agent_maps.items():
                                 if not isinstance(candidate_thread_map, dict) or not any(
@@ -1293,28 +1298,26 @@ class SQLiteSessionsService:
                                 ):
                                     continue
                                 candidate_variant = str(candidate_name) or "default"
-                                _, candidate_agent_id, candidate_agent_name = _resolve_imported_agent_identity(
-                                    conn, candidate_variant
-                                )
-                                if (
-                                    _normalize_agent_name_key(candidate_variant) in existing_owner_keys
-                                    or (
-                                        existing_agent_id is not None
-                                        and candidate_agent_id == existing_agent_id
-                                    )
-                                    or (
-                                        existing_agent_name is not None
-                                        and candidate_agent_name is not None
-                                        and _normalize_agent_name_key(candidate_agent_name)
-                                        == _normalize_agent_name_key(existing_agent_name)
-                                    )
+                                (
+                                    candidate_backend,
+                                    candidate_agent_id,
+                                    candidate_agent_name,
+                                ) = _resolve_imported_agent_identity(conn, candidate_variant)
+                                if _import_matches_existing_owner(
+                                    existing_backend=existing_backend,
+                                    existing_variant=existing_variant,
+                                    existing_agent_id=existing_agent_id,
+                                    existing_agent_name=existing_agent_name,
+                                    imported_backend=candidate_backend,
+                                    imported_variant=candidate_variant,
+                                    imported_agent_id=candidate_agent_id,
+                                    imported_agent_name=candidate_agent_name,
                                 ):
                                     has_existing_owner_mapping = True
                                     break
                             adopts_unbound_route = (
                                 not existing_native_session_id
-                                and imported_backend != "unknown"
-                                and existing_backend != imported_backend
+                                and not import_matches_existing_owner
                                 and not has_existing_owner_mapping
                             )
                             existing_identity_is_durable = (
@@ -1332,9 +1335,11 @@ class SQLiteSessionsService:
                                     imported_backend == "unknown" or existing_backend == imported_backend
                                 )
                             )
-                            same_variant = _normalize_agent_name_key(
-                                existing_variant
-                            ) == _normalize_agent_name_key(imported_variant)
+                            replaces_route_owner = not import_matches_existing_owner and (
+                                not existing_is_owned
+                                or adopts_unbound_route
+                                or sentinel_variant_compatible
+                            )
                             same_agent_identity = (
                                 imported_agent_id is not None and existing_agent_id == imported_agent_id
                             )
@@ -1351,10 +1356,8 @@ class SQLiteSessionsService:
                             )
                             backend_conflicts = imported_backend != "unknown" and existing_backend != imported_backend
                             variant_conflicts = (
-                                not same_variant
+                                not import_matches_existing_owner
                                 and not sentinel_variant_compatible
-                                and not same_agent_identity
-                                and not same_agent_name
                             )
                             if not adopts_unbound_route and (
                                 (existing_variant_is_owned and variant_conflicts)
@@ -1419,17 +1422,17 @@ class SQLiteSessionsService:
                                 update_values["agent_backend"] = (
                                     imported_backend if imported_backend != "unknown" else existing_backend or "default"
                                 )
-                                if imported_backend != "unknown" and imported_backend != existing_backend:
-                                    update_values["model"] = None
-                                    update_values["reasoning_effort"] = None
-                                    update_values["metadata_json"] = json.dumps(
-                                        reconcile_explicit_overrides(
-                                            _json_loads(existing_anchor_row["metadata_json"], {}),
-                                            cleared=OVERRIDABLE_SETTING_COLUMNS,
-                                        ),
-                                        separators=(",", ":"),
-                                        ensure_ascii=False,
-                                    )
+                            if replaces_route_owner:
+                                update_values["model"] = None
+                                update_values["reasoning_effort"] = None
+                                update_values["metadata_json"] = json.dumps(
+                                    reconcile_explicit_overrides(
+                                        _json_loads(existing_anchor_row["metadata_json"], {}),
+                                        cleared=OVERRIDABLE_SETTING_COLUMNS,
+                                    ),
+                                    separators=(",", ":"),
+                                    ensure_ascii=False,
+                                )
                             if not preserves_existing_identity:
                                 update_values["agent_id"] = imported_agent_id
                                 update_values["agent_name"] = imported_agent_name
@@ -1893,6 +1896,42 @@ def _is_sentinel_variant(agent_variant: str) -> bool:
 
 def _normalize_agent_name_key(agent_name: str) -> str:
     return re.sub(r"[^a-z0-9_-]+", "-", str(agent_name or "").strip().lower()).strip("-_")
+
+
+def _import_matches_existing_owner(
+    *,
+    existing_backend: str,
+    existing_variant: str,
+    existing_agent_id: str | None,
+    existing_agent_name: str | None,
+    imported_backend: str,
+    imported_variant: str,
+    imported_agent_id: str | None,
+    imported_agent_name: str | None,
+) -> bool:
+    """Compare owners from most-specific Agent identity to generic backend aliases."""
+    if existing_agent_id is not None and imported_agent_id is not None:
+        return existing_agent_id == imported_agent_id
+    if existing_agent_name is not None:
+        existing_name_key = _normalize_agent_name_key(existing_agent_name)
+        return existing_name_key in {
+            _normalize_agent_name_key(imported_variant),
+            _normalize_agent_name_key(imported_agent_name or ""),
+        }
+    if existing_agent_id is not None:
+        return False
+
+    existing_variant_key = _normalize_agent_name_key(existing_variant)
+    imported_variant_key = _normalize_agent_name_key(imported_variant)
+    if not _is_sentinel_variant(existing_variant) and existing_variant_key not in _BACKEND_AGENT_NAMES:
+        return existing_variant_key == imported_variant_key
+    if imported_agent_id is not None or imported_agent_name is not None:
+        return False
+    return imported_variant_key == existing_variant_key or (
+        imported_backend == existing_backend
+        and imported_backend != "unknown"
+        and imported_variant_key == _normalize_agent_name_key(existing_backend)
+    )
 
 
 def _resolve_imported_agent_identity(conn: Connection, agent_name: str) -> tuple[str, str | None, str | None]:

--- a/storage/sessions_service.py
+++ b/storage/sessions_service.py
@@ -1268,13 +1268,22 @@ class SQLiteSessionsService:
                             existing_variant = str(existing_anchor_row["agent_variant"] or "default").strip()
                             existing_agent_id = str(existing_anchor_row["agent_id"] or "").strip() or None
                             existing_agent_name = str(existing_anchor_row["agent_name"] or "").strip() or None
+                            existing_native_session_id = str(
+                                existing_anchor_row["native_session_id"] or ""
+                            ).strip()
                             existing_is_owned = _is_owned_backend(existing_backend)
                             existing_variant_is_owned = not _is_sentinel_variant(existing_variant)
+                            existing_identity_is_durable = (
+                                existing_is_owned
+                                or existing_variant_is_owned
+                                or bool(existing_native_session_id)
+                            )
                             sentinel_variant_compatible = (
                                 existing_is_owned
                                 and _is_sentinel_variant(existing_variant)
-                                and imported_backend != "unknown"
-                                and existing_backend == imported_backend
+                                and (
+                                    imported_backend == "unknown" or existing_backend == imported_backend
+                                )
                             )
                             same_variant = existing_variant == imported_variant
                             backend_conflicts = imported_backend != "unknown" and existing_backend != imported_backend
@@ -1296,15 +1305,19 @@ class SQLiteSessionsService:
                                 skip_mapping = True
                                 break
                             identity_conflicts = False
-                            if existing_is_owned and imported_agent_id is not None and existing_agent_id not in {
+                            if existing_identity_is_durable and imported_agent_id is not None and existing_agent_id not in {
                                 None,
                                 imported_agent_id,
                             }:
                                 identity_conflicts = True
-                            if existing_is_owned and imported_agent_name is not None and existing_agent_name not in {
-                                None,
-                                imported_agent_name,
-                            }:
+                            if (
+                                existing_identity_is_durable
+                                and imported_agent_name is not None
+                                and existing_agent_name not in {
+                                    None,
+                                    imported_agent_name,
+                                }
+                            ):
                                 identity_conflicts = True
                             if identity_conflicts:
                                 logger.warning(
@@ -1337,13 +1350,14 @@ class SQLiteSessionsService:
                                         separators=(",", ":"),
                                         ensure_ascii=False,
                                     )
+                            if not existing_identity_is_durable:
                                 update_values["agent_id"] = imported_agent_id
                                 update_values["agent_name"] = imported_agent_name
                             if sentinel_variant_compatible and existing_variant != imported_variant:
                                 update_values["agent_variant"] = imported_variant
-                            if existing_is_owned and imported_agent_id is not None and existing_agent_id is None:
+                            if imported_agent_id is not None and existing_agent_id is None:
                                 update_values["agent_id"] = imported_agent_id
-                            if existing_is_owned and imported_agent_name is not None and existing_agent_name is None:
+                            if imported_agent_name is not None and existing_agent_name is None:
                                 update_values["agent_name"] = imported_agent_name
                             if len(update_values) <= 1:
                                 break
@@ -1356,10 +1370,17 @@ class SQLiteSessionsService:
                                 update_stmt = update_stmt.where(
                                     func.coalesce(agent_sessions.c.agent_backend, "") == existing_backend
                                 ).where(func.coalesce(agent_sessions.c.agent_variant, "default") == existing_variant)
-                            if existing_is_owned and imported_agent_id is not None and existing_agent_id is None:
-                                update_stmt = update_stmt.where(func.coalesce(agent_sessions.c.agent_id, "") == "")
-                            if existing_is_owned and imported_agent_name is not None and existing_agent_name is None:
-                                update_stmt = update_stmt.where(func.coalesce(agent_sessions.c.agent_name, "") == "")
+                            if not existing_identity_is_durable:
+                                update_stmt = update_stmt.where(
+                                    func.coalesce(agent_sessions.c.agent_id, "") == (existing_agent_id or "")
+                                ).where(
+                                    func.coalesce(agent_sessions.c.agent_name, "") == (existing_agent_name or "")
+                                )
+                            else:
+                                if imported_agent_id is not None and existing_agent_id is None:
+                                    update_stmt = update_stmt.where(func.coalesce(agent_sessions.c.agent_id, "") == "")
+                                if imported_agent_name is not None and existing_agent_name is None:
+                                    update_stmt = update_stmt.where(func.coalesce(agent_sessions.c.agent_name, "") == "")
                             if conn.execute(update_stmt.values(**update_values)).rowcount:
                                 break
                             logger.warning(
@@ -1989,6 +2010,7 @@ def _find_scope_anchor_row(
                 agent_sessions.c.agent_variant,
                 agent_sessions.c.agent_id,
                 agent_sessions.c.agent_name,
+                agent_sessions.c.native_session_id,
                 agent_sessions.c.model,
                 agent_sessions.c.reasoning_effort,
                 agent_sessions.c.metadata_json,

--- a/storage/sessions_service.py
+++ b/storage/sessions_service.py
@@ -1254,7 +1254,9 @@ class SQLiteSessionsService:
                         if dedup_key in seen_anchor_rows:
                             continue
                         imported_variant = str(agent_name) or "default"
-                        imported_backend = _agent_backend_for_import(conn, imported_variant)
+                        imported_backend, imported_agent_id, imported_agent_name = _resolve_imported_agent_identity(
+                            conn, imported_variant
+                        )
                         existing_anchor_row = _find_scope_anchor_row(
                             conn,
                             scope_id=scope_id,
@@ -1265,9 +1267,9 @@ class SQLiteSessionsService:
                             existing_variant = str(existing_anchor_row["agent_variant"] or "default").strip()
                             existing_is_owned = existing_backend not in {"", "default"}
                             same_variant = existing_variant == imported_variant
-                            if existing_is_owned and not same_variant and existing_backend != imported_backend:
+                            if existing_is_owned and not same_variant:
                                 logger.warning(
-                                    "Skipping legacy session import that would relabel anchor row across backends "
+                                    "Skipping legacy session import that would relabel anchor row to a different owner "
                                     "scope_id=%s anchor=%s existing_backend=%s existing_variant=%s "
                                     "imported_backend=%s imported_variant=%s",
                                     scope_id,
@@ -1278,15 +1280,21 @@ class SQLiteSessionsService:
                                     imported_variant,
                                 )
                                 continue
-                            if not existing_is_owned and imported_backend != "unknown":
+                            update_values: dict[str, Any] = {"updated_at": now}
+                            if not existing_is_owned:
+                                update_values["agent_variant"] = imported_variant
+                                update_values["agent_backend"] = (
+                                    imported_backend if imported_backend != "unknown" else existing_backend or "default"
+                                )
+                            if imported_agent_id is not None:
+                                update_values["agent_id"] = imported_agent_id
+                            if imported_agent_name is not None:
+                                update_values["agent_name"] = imported_agent_name
+                            if len(update_values) > 1:
                                 conn.execute(
                                     agent_sessions.update()
                                     .where(agent_sessions.c.id == str(existing_anchor_row["id"]))
-                                    .values(
-                                        agent_backend=imported_backend,
-                                        agent_variant=imported_variant,
-                                        updated_at=now,
-                                    )
+                                    .values(**update_values)
                                 )
                         encoded_session_id = encode_session_value(native_session_id)
                         row_key = _session_row_key(
@@ -1304,6 +1312,8 @@ class SQLiteSessionsService:
                         stmt = sqlite_insert(agent_sessions).values(
                             id=row_id,
                             scope_id=scope_id,
+                            agent_id=imported_agent_id,
+                            agent_name=imported_agent_name,
                             agent_backend=imported_backend,
                             agent_variant=imported_variant,
                             model=None,
@@ -1658,21 +1668,26 @@ def _agent_backend(agent_name: str) -> str:
     return agent_name if agent_name in _BACKEND_AGENT_NAMES else "unknown"
 
 
-def _agent_backend_for_import(conn: Connection, agent_name: str) -> str:
+def _resolve_imported_agent_identity(conn: Connection, agent_name: str) -> tuple[str, str | None, str | None]:
     """Resolve a legacy mapping name through built-ins and the Vibe Agent catalog."""
     requested = str(agent_name or "").strip()
     backend = _agent_backend(requested)
     if backend != "unknown":
-        return backend
+        return (backend, None, None)
     normalized = re.sub(r"[^a-z0-9_-]+", "-", requested.lower()).strip("-_")
     if not normalized:
-        return "unknown"
-    catalog_backend = conn.execute(
-        select(agents.c.backend)
+        return ("unknown", None, None)
+    catalog_agent = conn.execute(
+        select(agents.c.id, agents.c.name, agents.c.backend)
         .where(or_(agents.c.name == requested, agents.c.normalized_name == normalized))
         .limit(1)
-    ).scalar_one_or_none()
-    return str(catalog_backend) if catalog_backend in _BACKEND_AGENT_NAMES else "unknown"
+    ).mappings().one_or_none()
+    if catalog_agent is None:
+        return ("unknown", None, None)
+    catalog_backend = str(catalog_agent["backend"] or "").strip()
+    if catalog_backend not in _BACKEND_AGENT_NAMES:
+        return ("unknown", None, None)
+    return (catalog_backend, str(catalog_agent["id"]), str(catalog_agent["name"]))
 
 
 def _agent_session_name_predicate(agent_name: str) -> Any:

--- a/storage/sessions_service.py
+++ b/storage/sessions_service.py
@@ -1262,15 +1262,23 @@ class SQLiteSessionsService:
                             scope_id=scope_id,
                             session_anchor=base_anchor,
                         )
-                        if existing_anchor_row is not None:
+                        skip_mapping = False
+                        while existing_anchor_row is not None:
                             existing_backend = str(existing_anchor_row["agent_backend"] or "").strip()
                             existing_variant = str(existing_anchor_row["agent_variant"] or "default").strip()
                             existing_agent_id = str(existing_anchor_row["agent_id"] or "").strip() or None
                             existing_agent_name = str(existing_anchor_row["agent_name"] or "").strip() or None
                             existing_is_owned = _is_owned_backend(existing_backend)
+                            sentinel_variant_compatible = (
+                                existing_is_owned
+                                and _is_sentinel_variant(existing_variant)
+                                and imported_backend != "unknown"
+                                and existing_backend == imported_backend
+                            )
                             same_variant = existing_variant == imported_variant
                             backend_conflicts = imported_backend != "unknown" and existing_backend != imported_backend
-                            if existing_is_owned and (not same_variant or backend_conflicts):
+                            variant_conflicts = not same_variant and not sentinel_variant_compatible
+                            if existing_is_owned and (variant_conflicts or backend_conflicts):
                                 logger.warning(
                                     "Skipping legacy session import that would relabel anchor row to a different owner "
                                     "scope_id=%s anchor=%s existing_backend=%s existing_variant=%s "
@@ -1282,7 +1290,8 @@ class SQLiteSessionsService:
                                     imported_backend,
                                     imported_variant,
                                 )
-                                continue
+                                skip_mapping = True
+                                break
                             identity_conflicts = False
                             if existing_is_owned and imported_agent_id is not None and existing_agent_id not in {
                                 None,
@@ -1306,7 +1315,8 @@ class SQLiteSessionsService:
                                     imported_agent_id,
                                     imported_agent_name,
                                 )
-                                continue
+                                skip_mapping = True
+                                break
                             update_values: dict[str, Any] = {"updated_at": now}
                             if not existing_is_owned:
                                 update_values["agent_variant"] = imported_variant
@@ -1326,16 +1336,43 @@ class SQLiteSessionsService:
                                     )
                                 update_values["agent_id"] = imported_agent_id
                                 update_values["agent_name"] = imported_agent_name
+                            if sentinel_variant_compatible and existing_variant != imported_variant:
+                                update_values["agent_variant"] = imported_variant
                             if existing_is_owned and imported_agent_id is not None and existing_agent_id is None:
                                 update_values["agent_id"] = imported_agent_id
                             if existing_is_owned and imported_agent_name is not None and existing_agent_name is None:
                                 update_values["agent_name"] = imported_agent_name
-                            if len(update_values) > 1:
-                                conn.execute(
-                                    agent_sessions.update()
-                                    .where(agent_sessions.c.id == str(existing_anchor_row["id"]))
-                                    .values(**update_values)
-                                )
+                            if len(update_values) <= 1:
+                                break
+                            update_stmt = (
+                                agent_sessions.update()
+                                .where(agent_sessions.c.id == str(existing_anchor_row["id"]))
+                                .where(agent_sessions.c.status != "archived")
+                            )
+                            if not existing_is_owned or sentinel_variant_compatible:
+                                update_stmt = update_stmt.where(
+                                    func.coalesce(agent_sessions.c.agent_backend, "") == existing_backend
+                                ).where(func.coalesce(agent_sessions.c.agent_variant, "default") == existing_variant)
+                            if existing_is_owned and imported_agent_id is not None and existing_agent_id is None:
+                                update_stmt = update_stmt.where(func.coalesce(agent_sessions.c.agent_id, "") == "")
+                            if existing_is_owned and imported_agent_name is not None and existing_agent_name is None:
+                                update_stmt = update_stmt.where(func.coalesce(agent_sessions.c.agent_name, "") == "")
+                            if conn.execute(update_stmt.values(**update_values)).rowcount:
+                                break
+                            logger.warning(
+                                "Lost the legacy-import anchor update race for session %s; re-resolving the anchor "
+                                "instead (imported backend=%s variant=%s)",
+                                existing_anchor_row["id"],
+                                imported_backend,
+                                imported_variant,
+                            )
+                            existing_anchor_row = _find_scope_anchor_row(
+                                conn,
+                                scope_id=scope_id,
+                                session_anchor=base_anchor,
+                            )
+                        if skip_mapping:
+                            continue
                         encoded_session_id = encode_session_value(native_session_id)
                         row_key = _session_row_key(
                             scope_id=scope_id,
@@ -1712,26 +1749,29 @@ def _is_owned_backend(agent_backend: str) -> bool:
     return str(agent_backend or "").strip() not in {"", "default", "unknown"}
 
 
+def _is_sentinel_variant(agent_variant: str) -> bool:
+    return str(agent_variant or "").strip() in {"", "default"}
+
+
 def _resolve_imported_agent_identity(conn: Connection, agent_name: str) -> tuple[str, str | None, str | None]:
     """Resolve a legacy mapping name through built-ins and the Vibe Agent catalog."""
     requested = str(agent_name or "").strip()
+    normalized = re.sub(r"[^a-z0-9_-]+", "-", requested.lower()).strip("-_")
+    if normalized:
+        catalog_agent = conn.execute(
+            select(agents.c.id, agents.c.name, agents.c.backend)
+            .where(or_(agents.c.name == requested, agents.c.normalized_name == normalized))
+            .limit(1)
+        ).mappings().one_or_none()
+        if catalog_agent is not None:
+            catalog_backend = str(catalog_agent["backend"] or "").strip()
+            if catalog_backend not in _BACKEND_AGENT_NAMES:
+                return ("unknown", None, None)
+            return (catalog_backend, str(catalog_agent["id"]), str(catalog_agent["name"]))
     backend = _agent_backend(requested)
     if backend != "unknown":
         return (backend, None, None)
-    normalized = re.sub(r"[^a-z0-9_-]+", "-", requested.lower()).strip("-_")
-    if not normalized:
-        return ("unknown", None, None)
-    catalog_agent = conn.execute(
-        select(agents.c.id, agents.c.name, agents.c.backend)
-        .where(or_(agents.c.name == requested, agents.c.normalized_name == normalized))
-        .limit(1)
-    ).mappings().one_or_none()
-    if catalog_agent is None:
-        return ("unknown", None, None)
-    catalog_backend = str(catalog_agent["backend"] or "").strip()
-    if catalog_backend not in _BACKEND_AGENT_NAMES:
-        return ("unknown", None, None)
-    return (catalog_backend, str(catalog_agent["id"]), str(catalog_agent["name"]))
+    return ("unknown", None, None)
 
 
 def _agent_session_name_predicate(agent_name: str) -> Any:
@@ -1952,6 +1992,7 @@ def _find_scope_anchor_row(
             )
             .where(agent_sessions.c.scope_id == scope_id)
             .where(agent_sessions.c.session_anchor == str(session_anchor))
+            .where(agent_sessions.c.status != "archived")
             .order_by(agent_sessions.c.last_active_at.desc(), agent_sessions.c.id.desc())
             .limit(1)
         )

--- a/storage/sessions_service.py
+++ b/storage/sessions_service.py
@@ -1265,6 +1265,8 @@ class SQLiteSessionsService:
                         if existing_anchor_row is not None:
                             existing_backend = str(existing_anchor_row["agent_backend"] or "").strip()
                             existing_variant = str(existing_anchor_row["agent_variant"] or "default").strip()
+                            existing_agent_id = str(existing_anchor_row["agent_id"] or "").strip() or None
+                            existing_agent_name = str(existing_anchor_row["agent_name"] or "").strip() or None
                             existing_is_owned = _is_owned_backend(existing_backend)
                             same_variant = existing_variant == imported_variant
                             backend_conflicts = imported_backend != "unknown" and existing_backend != imported_backend
@@ -1281,15 +1283,52 @@ class SQLiteSessionsService:
                                     imported_variant,
                                 )
                                 continue
+                            identity_conflicts = False
+                            if existing_is_owned and imported_agent_id is not None and existing_agent_id not in {
+                                None,
+                                imported_agent_id,
+                            }:
+                                identity_conflicts = True
+                            if existing_is_owned and imported_agent_name is not None and existing_agent_name not in {
+                                None,
+                                imported_agent_name,
+                            }:
+                                identity_conflicts = True
+                            if identity_conflicts:
+                                logger.warning(
+                                    "Skipping legacy session import that would replace the durable Agent identity "
+                                    "scope_id=%s anchor=%s existing_agent_id=%s existing_agent_name=%s "
+                                    "imported_agent_id=%s imported_agent_name=%s",
+                                    scope_id,
+                                    base_anchor,
+                                    existing_agent_id,
+                                    existing_agent_name,
+                                    imported_agent_id,
+                                    imported_agent_name,
+                                )
+                                continue
                             update_values: dict[str, Any] = {"updated_at": now}
                             if not existing_is_owned:
                                 update_values["agent_variant"] = imported_variant
                                 update_values["agent_backend"] = (
                                     imported_backend if imported_backend != "unknown" else existing_backend or "default"
                                 )
-                            if imported_agent_id is not None:
+                                if imported_backend != "unknown" and imported_backend != existing_backend:
+                                    update_values["model"] = None
+                                    update_values["reasoning_effort"] = None
+                                    update_values["metadata_json"] = json.dumps(
+                                        reconcile_explicit_overrides(
+                                            _json_loads(existing_anchor_row["metadata_json"], {}),
+                                            cleared=OVERRIDABLE_SETTING_COLUMNS,
+                                        ),
+                                        separators=(",", ":"),
+                                        ensure_ascii=False,
+                                    )
                                 update_values["agent_id"] = imported_agent_id
-                            if imported_agent_name is not None:
+                                update_values["agent_name"] = imported_agent_name
+                            if existing_is_owned and imported_agent_id is not None and existing_agent_id is None:
+                                update_values["agent_id"] = imported_agent_id
+                            if existing_is_owned and imported_agent_name is not None and existing_agent_name is None:
                                 update_values["agent_name"] = imported_agent_name
                             if len(update_values) > 1:
                                 conn.execute(
@@ -1901,7 +1940,16 @@ def _find_scope_anchor_row(
 ) -> Mapping[str, Any] | None:
     return (
         conn.execute(
-            select(agent_sessions.c.id, agent_sessions.c.agent_backend, agent_sessions.c.agent_variant)
+            select(
+                agent_sessions.c.id,
+                agent_sessions.c.agent_backend,
+                agent_sessions.c.agent_variant,
+                agent_sessions.c.agent_id,
+                agent_sessions.c.agent_name,
+                agent_sessions.c.model,
+                agent_sessions.c.reasoning_effort,
+                agent_sessions.c.metadata_json,
+            )
             .where(agent_sessions.c.scope_id == scope_id)
             .where(agent_sessions.c.session_anchor == str(session_anchor))
             .order_by(agent_sessions.c.last_active_at.desc(), agent_sessions.c.id.desc())

--- a/storage/sessions_service.py
+++ b/storage/sessions_service.py
@@ -1265,9 +1265,10 @@ class SQLiteSessionsService:
                         if existing_anchor_row is not None:
                             existing_backend = str(existing_anchor_row["agent_backend"] or "").strip()
                             existing_variant = str(existing_anchor_row["agent_variant"] or "default").strip()
-                            existing_is_owned = existing_backend not in {"", "default"}
+                            existing_is_owned = _is_owned_backend(existing_backend)
                             same_variant = existing_variant == imported_variant
-                            if existing_is_owned and not same_variant:
+                            backend_conflicts = imported_backend != "unknown" and existing_backend != imported_backend
+                            if existing_is_owned and (not same_variant or backend_conflicts):
                                 logger.warning(
                                     "Skipping legacy session import that would relabel anchor row to a different owner "
                                     "scope_id=%s anchor=%s existing_backend=%s existing_variant=%s "
@@ -1666,6 +1667,10 @@ _ROUTING_SENTINEL_VARIANTS = {"", "default", *_BACKEND_AGENT_NAMES}
 
 def _agent_backend(agent_name: str) -> str:
     return agent_name if agent_name in _BACKEND_AGENT_NAMES else "unknown"
+
+
+def _is_owned_backend(agent_backend: str) -> bool:
+    return str(agent_backend or "").strip() not in {"", "default", "unknown"}
 
 
 def _resolve_imported_agent_identity(conn: Connection, agent_name: str) -> tuple[str, str | None, str | None]:

--- a/storage/sessions_service.py
+++ b/storage/sessions_service.py
@@ -1269,6 +1269,7 @@ class SQLiteSessionsService:
                             existing_agent_id = str(existing_anchor_row["agent_id"] or "").strip() or None
                             existing_agent_name = str(existing_anchor_row["agent_name"] or "").strip() or None
                             existing_is_owned = _is_owned_backend(existing_backend)
+                            existing_variant_is_owned = not _is_sentinel_variant(existing_variant)
                             sentinel_variant_compatible = (
                                 existing_is_owned
                                 and _is_sentinel_variant(existing_variant)
@@ -1278,7 +1279,9 @@ class SQLiteSessionsService:
                             same_variant = existing_variant == imported_variant
                             backend_conflicts = imported_backend != "unknown" and existing_backend != imported_backend
                             variant_conflicts = not same_variant and not sentinel_variant_compatible
-                            if existing_is_owned and (variant_conflicts or backend_conflicts):
+                            if (existing_variant_is_owned and variant_conflicts) or (
+                                existing_is_owned and backend_conflicts
+                            ):
                                 logger.warning(
                                     "Skipping legacy session import that would relabel anchor row to a different owner "
                                     "scope_id=%s anchor=%s existing_backend=%s existing_variant=%s "

--- a/storage/sessions_service.py
+++ b/storage/sessions_service.py
@@ -1285,15 +1285,32 @@ class SQLiteSessionsService:
                                 for value in (existing_backend, existing_variant, existing_agent_name)
                                 if value
                             }
-                            has_existing_owner_mapping = any(
-                                isinstance(candidate_thread_map, dict)
-                                and _normalize_agent_name_key(str(candidate_name)) in existing_owner_keys
-                                and any(
+                            has_existing_owner_mapping = False
+                            for candidate_name, candidate_thread_map in agent_maps.items():
+                                if not isinstance(candidate_thread_map, dict) or not any(
                                     _base_session_anchor(str(candidate_thread_id)) == base_anchor
                                     for candidate_thread_id in candidate_thread_map
+                                ):
+                                    continue
+                                candidate_variant = str(candidate_name) or "default"
+                                _, candidate_agent_id, candidate_agent_name = _resolve_imported_agent_identity(
+                                    conn, candidate_variant
                                 )
-                                for candidate_name, candidate_thread_map in agent_maps.items()
-                            )
+                                if (
+                                    _normalize_agent_name_key(candidate_variant) in existing_owner_keys
+                                    or (
+                                        existing_agent_id is not None
+                                        and candidate_agent_id == existing_agent_id
+                                    )
+                                    or (
+                                        existing_agent_name is not None
+                                        and candidate_agent_name is not None
+                                        and _normalize_agent_name_key(candidate_agent_name)
+                                        == _normalize_agent_name_key(existing_agent_name)
+                                    )
+                                ):
+                                    has_existing_owner_mapping = True
+                                    break
                             adopts_unbound_route = (
                                 not existing_native_session_id
                                 and imported_backend != "unknown"
@@ -1315,7 +1332,9 @@ class SQLiteSessionsService:
                                     imported_backend == "unknown" or existing_backend == imported_backend
                                 )
                             )
-                            same_variant = existing_variant == imported_variant
+                            same_variant = _normalize_agent_name_key(
+                                existing_variant
+                            ) == _normalize_agent_name_key(imported_variant)
                             same_agent_identity = (
                                 imported_agent_id is not None and existing_agent_id == imported_agent_id
                             )

--- a/storage/sessions_service.py
+++ b/storage/sessions_service.py
@@ -1257,6 +1257,7 @@ class SQLiteSessionsService:
                         imported_backend, imported_agent_id, imported_agent_name = _resolve_imported_agent_identity(
                             conn, imported_variant
                         )
+                        encoded_session_id = encode_session_value(native_session_id)
                         existing_anchor_row = _find_scope_anchor_row(
                             conn,
                             scope_id=scope_id,
@@ -1268,13 +1269,12 @@ class SQLiteSessionsService:
                             observed_variant = str(existing_anchor_row["agent_variant"] or "")
                             observed_agent_id = str(existing_anchor_row["agent_id"] or "")
                             observed_agent_name = str(existing_anchor_row["agent_name"] or "")
+                            observed_native_session_id = str(existing_anchor_row["native_session_id"] or "")
                             existing_backend = observed_backend.strip()
                             existing_variant = observed_variant.strip() or "default"
                             existing_agent_id = observed_agent_id.strip() or None
                             existing_agent_name = observed_agent_name.strip() or None
-                            existing_native_session_id = str(
-                                existing_anchor_row["native_session_id"] or ""
-                            ).strip()
+                            existing_native_session_id = observed_native_session_id.strip()
                             existing_is_owned = _is_owned_backend(existing_backend)
                             existing_variant_is_owned = not _is_sentinel_variant(existing_variant)
                             existing_identity_is_durable = (
@@ -1309,6 +1309,7 @@ class SQLiteSessionsService:
                                 not same_variant
                                 and not sentinel_variant_compatible
                                 and not same_agent_identity
+                                and not same_agent_name
                             )
                             if (existing_variant_is_owned and variant_conflicts) or (
                                 existing_is_owned and backend_conflicts
@@ -1392,37 +1393,19 @@ class SQLiteSessionsService:
                                 update_values["agent_id"] = imported_agent_id
                             if backfills_agent_name:
                                 update_values["agent_name"] = imported_agent_name
-                            if len(update_values) <= 1:
-                                break
                             update_stmt = (
                                 agent_sessions.update()
                                 .where(agent_sessions.c.id == str(existing_anchor_row["id"]))
                                 .where(agent_sessions.c.status != "archived")
-                            )
-                            if (
-                                not existing_is_owned
-                                or sentinel_variant_compatible
-                                or backfills_agent_id
-                                or backfills_agent_name
-                            ):
-                                update_stmt = update_stmt.where(
-                                    func.coalesce(agent_sessions.c.agent_backend, "") == observed_backend
-                                ).where(func.coalesce(agent_sessions.c.agent_variant, "") == observed_variant)
-                            if not existing_identity_is_durable:
-                                update_stmt = update_stmt.where(
-                                    func.coalesce(agent_sessions.c.agent_id, "") == observed_agent_id
-                                ).where(
-                                    func.coalesce(agent_sessions.c.agent_name, "") == observed_agent_name
+                                .where(func.coalesce(agent_sessions.c.agent_backend, "") == observed_backend)
+                                .where(func.coalesce(agent_sessions.c.agent_variant, "") == observed_variant)
+                                .where(func.coalesce(agent_sessions.c.agent_id, "") == observed_agent_id)
+                                .where(func.coalesce(agent_sessions.c.agent_name, "") == observed_agent_name)
+                                .where(
+                                    func.coalesce(agent_sessions.c.native_session_id, "")
+                                    == observed_native_session_id
                                 )
-                            else:
-                                if backfills_agent_id:
-                                    update_stmt = update_stmt.where(
-                                        func.coalesce(agent_sessions.c.agent_id, "") == observed_agent_id
-                                    )
-                                if backfills_agent_name:
-                                    update_stmt = update_stmt.where(
-                                        func.coalesce(agent_sessions.c.agent_name, "") == observed_agent_name
-                                    )
+                            )
                             if conn.execute(update_stmt.values(**update_values)).rowcount:
                                 break
                             logger.warning(
@@ -1432,14 +1415,42 @@ class SQLiteSessionsService:
                                 imported_backend,
                                 imported_variant,
                             )
-                            existing_anchor_row = _find_scope_anchor_row(
+                            refreshed_anchor_row = _find_scope_anchor_row(
                                 conn,
                                 scope_id=scope_id,
                                 session_anchor=base_anchor,
                             )
+                            if refreshed_anchor_row is None:
+                                logger.warning(
+                                    "Skipping legacy session import because the anchor disappeared during update "
+                                    "scope_id=%s anchor=%s imported_backend=%s imported_variant=%s",
+                                    scope_id,
+                                    base_anchor,
+                                    imported_backend,
+                                    imported_variant,
+                                )
+                                skip_mapping = True
+                                break
+                            refreshed_native_session_id = str(
+                                refreshed_anchor_row["native_session_id"] or ""
+                            )
+                            if (
+                                refreshed_native_session_id != observed_native_session_id
+                                and refreshed_native_session_id != encoded_session_id
+                            ):
+                                logger.warning(
+                                    "Skipping legacy session import after losing a concurrent native-session claim "
+                                    "scope_id=%s anchor=%s winner_native_session_id=%s imported_variant=%s",
+                                    scope_id,
+                                    base_anchor,
+                                    refreshed_native_session_id,
+                                    imported_variant,
+                                )
+                                skip_mapping = True
+                                break
+                            existing_anchor_row = refreshed_anchor_row
                         if skip_mapping:
                             continue
-                        encoded_session_id = encode_session_value(native_session_id)
                         row_key = _session_row_key(
                             scope_id=scope_id,
                             agent_variant=imported_variant,

--- a/storage/sessions_service.py
+++ b/storage/sessions_service.py
@@ -1277,10 +1277,36 @@ class SQLiteSessionsService:
                             existing_native_session_id = observed_native_session_id.strip()
                             existing_is_owned = _is_owned_backend(existing_backend)
                             existing_variant_is_owned = not _is_sentinel_variant(existing_variant)
+                            # Prefer a legacy mapping for the reserved owner when one
+                            # exists; otherwise an unbound cross-backend reservation is
+                            # provisional and may be adopted by the imported session.
+                            existing_owner_keys = {
+                                _normalize_agent_name_key(value)
+                                for value in (existing_backend, existing_variant, existing_agent_name)
+                                if value
+                            }
+                            has_existing_owner_mapping = any(
+                                isinstance(candidate_thread_map, dict)
+                                and _normalize_agent_name_key(str(candidate_name)) in existing_owner_keys
+                                and any(
+                                    _base_session_anchor(str(candidate_thread_id)) == base_anchor
+                                    for candidate_thread_id in candidate_thread_map
+                                )
+                                for candidate_name, candidate_thread_map in agent_maps.items()
+                            )
+                            adopts_unbound_route = (
+                                not existing_native_session_id
+                                and imported_backend != "unknown"
+                                and existing_backend != imported_backend
+                                and not has_existing_owner_mapping
+                            )
                             existing_identity_is_durable = (
                                 existing_is_owned
                                 or existing_variant_is_owned
                                 or bool(existing_native_session_id)
+                            )
+                            preserves_existing_identity = (
+                                existing_identity_is_durable and not adopts_unbound_route
                             )
                             sentinel_variant_compatible = (
                                 existing_is_owned
@@ -1311,8 +1337,9 @@ class SQLiteSessionsService:
                                 and not same_agent_identity
                                 and not same_agent_name
                             )
-                            if (existing_variant_is_owned and variant_conflicts) or (
-                                existing_is_owned and backend_conflicts
+                            if not adopts_unbound_route and (
+                                (existing_variant_is_owned and variant_conflicts)
+                                or (existing_is_owned and backend_conflicts)
                             ):
                                 logger.warning(
                                     "Skipping legacy session import that would relabel anchor row to a different owner "
@@ -1328,20 +1355,20 @@ class SQLiteSessionsService:
                                 skip_mapping = True
                                 break
                             identity_conflicts = (
-                                existing_identity_is_durable
+                                preserves_existing_identity
                                 and imported_backend == "unknown"
                                 and imported_agent_id is None
                                 and imported_agent_name is None
                                 and (existing_agent_id is not None or existing_agent_name is not None)
                                 and not imported_variant_matches_existing_agent
                             )
-                            if existing_identity_is_durable and imported_agent_id is not None and existing_agent_id not in {
+                            if preserves_existing_identity and imported_agent_id is not None and existing_agent_id not in {
                                 None,
                                 imported_agent_id,
                             }:
                                 identity_conflicts = True
                             if (
-                                existing_identity_is_durable
+                                preserves_existing_identity
                                 and imported_agent_name is not None
                                 and not same_agent_identity
                                 and not same_agent_name
@@ -1368,7 +1395,7 @@ class SQLiteSessionsService:
                             backfills_agent_id = imported_agent_id is not None and existing_agent_id is None
                             backfills_agent_name = imported_agent_name is not None and existing_agent_name is None
                             update_values: dict[str, Any] = {"updated_at": now}
-                            if not existing_is_owned:
+                            if not existing_is_owned or adopts_unbound_route:
                                 update_values["agent_variant"] = imported_variant
                                 update_values["agent_backend"] = (
                                     imported_backend if imported_backend != "unknown" else existing_backend or "default"
@@ -1384,7 +1411,7 @@ class SQLiteSessionsService:
                                         separators=(",", ":"),
                                         ensure_ascii=False,
                                     )
-                            if not existing_identity_is_durable:
+                            if not preserves_existing_identity:
                                 update_values["agent_id"] = imported_agent_id
                                 update_values["agent_name"] = imported_agent_name
                             if sentinel_variant_compatible and existing_variant != imported_variant:
@@ -1434,6 +1461,21 @@ class SQLiteSessionsService:
                             refreshed_native_session_id = str(
                                 refreshed_anchor_row["native_session_id"] or ""
                             )
+                            refreshed_route = tuple(
+                                str(refreshed_anchor_row[column] or "")
+                                for column in ("agent_backend", "agent_variant")
+                            )
+                            if refreshed_route != (observed_backend, observed_variant):
+                                logger.warning(
+                                    "Skipping legacy session import after losing a concurrent route claim "
+                                    "scope_id=%s anchor=%s imported_backend=%s imported_variant=%s",
+                                    scope_id,
+                                    base_anchor,
+                                    imported_backend,
+                                    imported_variant,
+                                )
+                                skip_mapping = True
+                                break
                             if (
                                 refreshed_native_session_id != observed_native_session_id
                                 and refreshed_native_session_id != encoded_session_id

--- a/storage/sessions_service.py
+++ b/storage/sessions_service.py
@@ -1264,10 +1264,14 @@ class SQLiteSessionsService:
                         )
                         skip_mapping = False
                         while existing_anchor_row is not None:
-                            existing_backend = str(existing_anchor_row["agent_backend"] or "").strip()
-                            existing_variant = str(existing_anchor_row["agent_variant"] or "default").strip()
-                            existing_agent_id = str(existing_anchor_row["agent_id"] or "").strip() or None
-                            existing_agent_name = str(existing_anchor_row["agent_name"] or "").strip() or None
+                            observed_backend = str(existing_anchor_row["agent_backend"] or "")
+                            observed_variant = str(existing_anchor_row["agent_variant"] or "")
+                            observed_agent_id = str(existing_anchor_row["agent_id"] or "")
+                            observed_agent_name = str(existing_anchor_row["agent_name"] or "")
+                            existing_backend = observed_backend.strip()
+                            existing_variant = observed_variant.strip() or "default"
+                            existing_agent_id = observed_agent_id.strip() or None
+                            existing_agent_name = observed_agent_name.strip() or None
                             existing_native_session_id = str(
                                 existing_anchor_row["native_session_id"] or ""
                             ).strip()
@@ -1286,8 +1290,15 @@ class SQLiteSessionsService:
                                 )
                             )
                             same_variant = existing_variant == imported_variant
+                            same_agent_identity = (
+                                imported_agent_id is not None and existing_agent_id == imported_agent_id
+                            )
                             backend_conflicts = imported_backend != "unknown" and existing_backend != imported_backend
-                            variant_conflicts = not same_variant and not sentinel_variant_compatible
+                            variant_conflicts = (
+                                not same_variant
+                                and not sentinel_variant_compatible
+                                and not same_agent_identity
+                            )
                             if (existing_variant_is_owned and variant_conflicts) or (
                                 existing_is_owned and backend_conflicts
                             ):
@@ -1368,19 +1379,23 @@ class SQLiteSessionsService:
                             )
                             if not existing_is_owned or sentinel_variant_compatible:
                                 update_stmt = update_stmt.where(
-                                    func.coalesce(agent_sessions.c.agent_backend, "") == existing_backend
-                                ).where(func.coalesce(agent_sessions.c.agent_variant, "default") == existing_variant)
+                                    func.coalesce(agent_sessions.c.agent_backend, "") == observed_backend
+                                ).where(func.coalesce(agent_sessions.c.agent_variant, "") == observed_variant)
                             if not existing_identity_is_durable:
                                 update_stmt = update_stmt.where(
-                                    func.coalesce(agent_sessions.c.agent_id, "") == (existing_agent_id or "")
+                                    func.coalesce(agent_sessions.c.agent_id, "") == observed_agent_id
                                 ).where(
-                                    func.coalesce(agent_sessions.c.agent_name, "") == (existing_agent_name or "")
+                                    func.coalesce(agent_sessions.c.agent_name, "") == observed_agent_name
                                 )
                             else:
                                 if imported_agent_id is not None and existing_agent_id is None:
-                                    update_stmt = update_stmt.where(func.coalesce(agent_sessions.c.agent_id, "") == "")
+                                    update_stmt = update_stmt.where(
+                                        func.coalesce(agent_sessions.c.agent_id, "") == observed_agent_id
+                                    )
                                 if imported_agent_name is not None and existing_agent_name is None:
-                                    update_stmt = update_stmt.where(func.coalesce(agent_sessions.c.agent_name, "") == "")
+                                    update_stmt = update_stmt.where(
+                                        func.coalesce(agent_sessions.c.agent_name, "") == observed_agent_name
+                                    )
                             if conn.execute(update_stmt.values(**update_values)).rowcount:
                                 break
                             logger.warning(

--- a/storage/sessions_service.py
+++ b/storage/sessions_service.py
@@ -1283,6 +1283,17 @@ class SQLiteSessionsService:
                         )
                         skip_mapping = False
                         while existing_anchor_row is not None:
+                            if str(existing_anchor_row["status"] or "") == "archived":
+                                logger.warning(
+                                    "Skipping legacy session import because an archived row owns the anchor "
+                                    "scope_id=%s anchor=%s imported_backend=%s imported_variant=%s",
+                                    scope_id,
+                                    base_anchor,
+                                    imported_backend,
+                                    imported_variant,
+                                )
+                                skip_mapping = True
+                                break
                             observed_backend = str(existing_anchor_row["agent_backend"] or "")
                             observed_variant = str(existing_anchor_row["agent_variant"] or "")
                             observed_agent_id = str(existing_anchor_row["agent_id"] or "")
@@ -2182,10 +2193,10 @@ def _find_scope_anchor_row(
                 agent_sessions.c.model,
                 agent_sessions.c.reasoning_effort,
                 agent_sessions.c.metadata_json,
+                agent_sessions.c.status,
             )
             .where(agent_sessions.c.scope_id == scope_id)
             .where(agent_sessions.c.session_anchor == str(session_anchor))
-            .where(agent_sessions.c.status != "archived")
             .order_by(agent_sessions.c.last_active_at.desc(), agent_sessions.c.id.desc())
             .limit(1)
         )

--- a/tests/test_session_route_writer_policy.py
+++ b/tests/test_session_route_writer_policy.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SESSIONS_SERVICE_PATH = REPO_ROOT / "storage/sessions_service.py"
+ROUTE_OWNED_FIELDS = {"agent_backend", "agent_variant"}
+
+
+def _save_state_upsert_set_keys(tree: ast.AST) -> set[str]:
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.FunctionDef) or node.name != "save_state":
+            continue
+        for child in ast.walk(node):
+            if not isinstance(child, ast.Call):
+                continue
+            if not isinstance(child.func, ast.Attribute) or child.func.attr != "on_conflict_do_update":
+                continue
+            for keyword in child.keywords:
+                if keyword.arg != "set_" or not isinstance(keyword.value, ast.Dict):
+                    continue
+                keys: set[str] = set()
+                for key in keyword.value.keys:
+                    if isinstance(key, ast.Constant) and isinstance(key.value, str):
+                        keys.add(key.value)
+                return keys
+    return set()
+
+
+def test_save_state_upsert_set_clause_does_not_relabel_backend_owned_route():
+    tree = ast.parse(SESSIONS_SERVICE_PATH.read_text(encoding="utf-8"), filename=str(SESSIONS_SERVICE_PATH))
+    keys = _save_state_upsert_set_keys(tree)
+
+    assert keys, "save_state upsert set_= clause not found; test needs updating"
+    assert keys.isdisjoint(ROUTE_OWNED_FIELDS)

--- a/tests/test_session_route_writer_policy.py
+++ b/tests/test_session_route_writer_policy.py
@@ -9,7 +9,7 @@ SESSIONS_SERVICE_PATH = REPO_ROOT / "storage/sessions_service.py"
 ROUTE_OWNED_FIELDS = {"agent_backend", "agent_variant"}
 
 
-def _save_state_upsert_set_keys(tree: ast.AST) -> set[str]:
+def _save_state_agent_session_upsert_set_keys(tree: ast.AST) -> set[str]:
     for node in ast.walk(tree):
         if not isinstance(node, ast.FunctionDef) or node.name != "save_state":
             continue
@@ -21,17 +21,19 @@ def _save_state_upsert_set_keys(tree: ast.AST) -> set[str]:
             for keyword in child.keywords:
                 if keyword.arg != "set_" or not isinstance(keyword.value, ast.Dict):
                     continue
-                keys: set[str] = set()
-                for key in keyword.value.keys:
-                    if isinstance(key, ast.Constant) and isinstance(key.value, str):
-                        keys.add(key.value)
-                return keys
+                keys = {
+                    key.value
+                    for key in keyword.value.keys
+                    if isinstance(key, ast.Constant) and isinstance(key.value, str)
+                }
+                if {"scope_id", "session_anchor", "native_session_id"}.issubset(keys):
+                    return keys
     return set()
 
 
 def test_save_state_upsert_set_clause_does_not_relabel_backend_owned_route():
     tree = ast.parse(SESSIONS_SERVICE_PATH.read_text(encoding="utf-8"), filename=str(SESSIONS_SERVICE_PATH))
-    keys = _save_state_upsert_set_keys(tree)
+    keys = _save_state_agent_session_upsert_set_keys(tree)
 
     assert keys, "save_state upsert set_= clause not found; test needs updating"
     assert keys.isdisjoint(ROUTE_OWNED_FIELDS)

--- a/tests/test_sqlite_sessions_store.py
+++ b/tests/test_sqlite_sessions_store.py
@@ -913,15 +913,22 @@ def test_save_state_sets_registered_custom_agent_identity_on_existing_owned_row(
         service.close()
 
 
-def test_save_state_identity_backfill_loses_concurrent_route_claim(tmp_path: Path) -> None:
-    db_path = tmp_path / "vibe.sqlite"
-    service = SQLiteSessionsService(db_path)
-    race_fired = 0
-    anchor_snapshot_prefix = (
-        "SELECT agent_sessions.id, agent_sessions.agent_backend, agent_sessions.agent_variant, "
-        "agent_sessions.agent_id, agent_sessions.agent_name, agent_sessions.native_session_id"
-    )
+_SAVE_STATE_ANCHOR_SNAPSHOT_PREFIX = (
+    "SELECT agent_sessions.id, agent_sessions.agent_backend, agent_sessions.agent_variant, "
+    "agent_sessions.agent_id, agent_sessions.agent_name, agent_sessions.native_session_id"
+)
 
+
+def _commit_route_claim_after_save_state_snapshot(
+    engine,
+    db_path: Path,
+    *,
+    session_id: str,
+    values: dict,
+) -> dict:
+    state = {"fired": 0}
+
+    @event.listens_for(engine, "after_cursor_execute")
     def claim_route_after_snapshot(
         _conn: object,
         _cursor: object,
@@ -930,21 +937,26 @@ def test_save_state_identity_backfill_loses_concurrent_route_claim(tmp_path: Pat
         _context: object,
         _executemany: object,
     ) -> None:
-        nonlocal race_fired
-        if race_fired or not " ".join(statement.split()).startswith(anchor_snapshot_prefix):
+        if state["fired"] or not " ".join(statement.split()).startswith(
+            _SAVE_STATE_ANCHOR_SNAPSHOT_PREFIX
+        ):
             return
-        race_fired += 1
+        state["fired"] += 1
         other = create_sqlite_engine(db_path)
         try:
             with other.begin() as other_conn:
                 other_conn.execute(
-                    agent_sessions.update()
-                    .where(agent_sessions.c.id == session_id)
-                    .values(agent_backend="opencode", agent_variant="writer")
+                    agent_sessions.update().where(agent_sessions.c.id == session_id).values(**values)
                 )
         finally:
             other.dispose()
 
+    return state
+
+
+def test_save_state_identity_backfill_loses_concurrent_route_claim(tmp_path: Path) -> None:
+    db_path = tmp_path / "vibe.sqlite"
+    service = SQLiteSessionsService(db_path)
     try:
         with service.engine.begin() as conn:
             scope_id = resolve_scope_from_legacy_key(conn, "slack::C123", now="2026-07-28T00:00:00Z")
@@ -979,24 +991,26 @@ def test_save_state_identity_backfill_loses_concurrent_route_claim(tmp_path: Pat
                 require_workdir=False,
             )
 
-        event.listen(service.engine, "after_cursor_execute", claim_route_after_snapshot)
-        try:
-            service.save_state(
-                SessionState(
-                    session_mappings={
-                        "slack::C123": {
-                            "reviewer": {
-                                "slack_171717.123": "reviewer-native",
-                            }
+        race = _commit_route_claim_after_save_state_snapshot(
+            service.engine,
+            db_path,
+            session_id=session_id,
+            values={"agent_backend": "opencode", "agent_variant": "writer"},
+        )
+        service.save_state(
+            SessionState(
+                session_mappings={
+                    "slack::C123": {
+                        "reviewer": {
+                            "slack_171717.123": "reviewer-native",
                         }
                     }
-                )
+                }
             )
-        finally:
-            event.remove(service.engine, "after_cursor_execute", claim_route_after_snapshot)
+        )
 
         row = service.get_agent_session_by_id(session_id)
-        assert race_fired == 1
+        assert race["fired"] == 1
         assert row is not None
         assert row["agent_backend"] == "opencode"
         assert row["agent_variant"] == "writer"
@@ -1007,7 +1021,68 @@ def test_save_state_identity_backfill_loses_concurrent_route_claim(tmp_path: Pat
         service.close()
 
 
-def test_save_state_accepts_matching_agent_identity_across_variant_aliases(tmp_path: Path) -> None:
+@pytest.mark.parametrize("winner_backend", ["claude", "codex"])
+def test_save_state_final_native_bind_loses_concurrent_claim(
+    tmp_path: Path, winner_backend: str
+) -> None:
+    db_path = tmp_path / "vibe.sqlite"
+    service = SQLiteSessionsService(db_path)
+    try:
+        with service.engine.begin() as conn:
+            scope_id = resolve_scope_from_legacy_key(conn, "slack::C123", now="2026-07-28T00:00:00Z")
+            assert scope_id is not None
+            session_id = create_agent_session_row(
+                conn,
+                scope_id=scope_id,
+                agent_backend="codex",
+                agent_variant="codex",
+                session_anchor="slack_171717.123",
+                native_session_id="",
+                workdir="/tmp",
+                metadata={"legacy_scope_key": "slack::C123"},
+                require_workdir=False,
+            )
+
+        race = _commit_route_claim_after_save_state_snapshot(
+            service.engine,
+            db_path,
+            session_id=session_id,
+            values={
+                "agent_backend": winner_backend,
+                "agent_variant": winner_backend,
+                "agent_id": f"agent-{winner_backend}",
+                "agent_name": f"{winner_backend}-reviewer",
+                "native_session_id": f"{winner_backend}-native",
+            },
+        )
+        service.save_state(
+            SessionState(
+                session_mappings={
+                    "slack::C123": {
+                        "codex": {
+                            "slack_171717.123": "codex-native",
+                        }
+                    }
+                }
+            )
+        )
+
+        row = service.get_agent_session_by_id(session_id)
+        assert race["fired"] == 1
+        assert row is not None
+        assert row["agent_backend"] == winner_backend
+        assert row["agent_variant"] == winner_backend
+        assert row["agent_id"] == f"agent-{winner_backend}"
+        assert row["agent_name"] == f"{winner_backend}-reviewer"
+        assert row["native_session_id"] == f"{winner_backend}-native"
+    finally:
+        service.close()
+
+
+@pytest.mark.parametrize("existing_agent_id", ["agent-reviewer", None])
+def test_save_state_accepts_matching_agent_identity_across_variant_aliases(
+    tmp_path: Path, existing_agent_id: str | None
+) -> None:
     db_path = tmp_path / "vibe.sqlite"
     service = SQLiteSessionsService(db_path)
     try:
@@ -1040,7 +1115,7 @@ def test_save_state_accepts_matching_agent_identity_across_variant_aliases(tmp_p
                 session_anchor="slack_171717.123",
                 native_session_id="",
                 workdir="/tmp",
-                agent_id="agent-reviewer",
+                agent_id=existing_agent_id,
                 agent_name="Reviewer",
                 metadata={"legacy_scope_key": "slack::C123"},
                 require_workdir=False,

--- a/tests/test_sqlite_sessions_store.py
+++ b/tests/test_sqlite_sessions_store.py
@@ -10,6 +10,7 @@ import pytest
 from sqlalchemy import event, select
 from sqlalchemy.exc import OperationalError
 
+import storage.sessions_service as sessions_service_module
 from config import paths
 from config.v2_sessions import ActivePollInfo, SessionState, SessionsStore
 from modules.sessions_facade import SessionsFacade
@@ -1154,6 +1155,58 @@ def test_save_state_preserves_durable_agent_identity_on_legacy_backend(
         assert row["agent_id"] == "agent-reviewer-deleted"
         assert row["agent_name"] == "reviewer"
         assert row["native_session_id"] == "reviewer-native"
+    finally:
+        service.close()
+
+
+def test_save_state_indexes_legacy_owner_candidates_once_per_scope(tmp_path: Path) -> None:
+    db_path = tmp_path / "vibe.sqlite"
+    service = SQLiteSessionsService(db_path)
+    thread_count = 12
+    try:
+        with service.engine.begin() as conn:
+            scope_id = resolve_scope_from_legacy_key(conn, "slack::C123", now="2026-07-28T00:00:00Z")
+            assert scope_id is not None
+            for index in range(thread_count):
+                create_agent_session_row(
+                    conn,
+                    scope_id=scope_id,
+                    agent_backend="codex",
+                    agent_variant="codex",
+                    session_anchor=f"slack_{index}",
+                    native_session_id="",
+                    workdir="/tmp",
+                    metadata={"legacy_scope_key": "slack::C123"},
+                    require_workdir=False,
+                )
+
+        with (
+            patch.object(
+                sessions_service_module,
+                "_resolve_imported_agent_identity",
+                wraps=sessions_service_module._resolve_imported_agent_identity,
+            ) as resolve_identity,
+            patch.object(
+                sessions_service_module,
+                "_base_session_anchor",
+                wraps=sessions_service_module._base_session_anchor,
+            ) as normalize_anchor,
+        ):
+            service.save_state(
+                SessionState(
+                    session_mappings={
+                        "slack::C123": {
+                            "codex": {
+                                f"slack_{index}": f"codex-native-{index}"
+                                for index in range(thread_count)
+                            }
+                        }
+                    }
+                )
+            )
+
+        assert resolve_identity.call_count == 1
+        assert normalize_anchor.call_count == thread_count
     finally:
         service.close()
 

--- a/tests/test_sqlite_sessions_store.py
+++ b/tests/test_sqlite_sessions_store.py
@@ -985,6 +985,55 @@ def test_save_state_skips_conflicting_backend_and_imports_later_matching_owner(t
         service.close()
 
 
+@pytest.mark.parametrize("legacy_backend", ["default", "unknown"])
+def test_save_state_preserves_custom_variant_owner_with_legacy_backend(
+    tmp_path: Path, legacy_backend: str
+) -> None:
+    db_path = tmp_path / "vibe.sqlite"
+    service = SQLiteSessionsService(db_path)
+    try:
+        with service.engine.begin() as conn:
+            scope_id = resolve_scope_from_legacy_key(conn, "slack::C123", now="2026-07-28T00:00:00Z")
+            assert scope_id is not None
+            session_id = create_agent_session_row(
+                conn,
+                scope_id=scope_id,
+                agent_backend=legacy_backend,
+                agent_variant="reviewer",
+                session_anchor="slack_171717.123",
+                native_session_id="reviewer-native",
+                workdir="/tmp",
+                metadata={"legacy_scope_key": "slack::C123"},
+                require_workdir=False,
+            )
+
+        service.save_state(
+            SessionState(
+                session_mappings={
+                    "slack::C123": {
+                        "writer": {
+                            "slack_171717.123": "writer-native",
+                        },
+                        "reviewer": {
+                            "slack_171717.123": "reviewer-native",
+                        },
+                    }
+                }
+            )
+        )
+
+        row = service.get_agent_session_by_id(session_id)
+        assert row is not None
+        assert row["agent_backend"] == legacy_backend
+        assert row["agent_variant"] == "reviewer"
+        assert row["native_session_id"] == "reviewer-native"
+        mappings = service.load_state().session_mappings["slack::C123"]
+        assert mappings["reviewer"]["slack_171717.123"] == "reviewer-native"
+        assert "writer" not in mappings
+    finally:
+        service.close()
+
+
 def test_save_state_skips_conflicting_custom_variant_with_same_backend_and_imports_owner(tmp_path: Path) -> None:
     db_path = tmp_path / "vibe.sqlite"
     service = SQLiteSessionsService(db_path)

--- a/tests/test_sqlite_sessions_store.py
+++ b/tests/test_sqlite_sessions_store.py
@@ -716,6 +716,96 @@ def test_save_state_preserves_unregistered_custom_variant_on_default_sentinel(tm
         service.close()
 
 
+def test_save_state_adopts_unregistered_custom_variant_on_concrete_backend_sentinel(tmp_path: Path) -> None:
+    db_path = tmp_path / "vibe.sqlite"
+    service = SQLiteSessionsService(db_path)
+    try:
+        with service.engine.begin() as conn:
+            scope_id = resolve_scope_from_legacy_key(conn, "slack::C123", now="2026-07-28T00:00:00Z")
+            assert scope_id is not None
+            session_id = create_agent_session_row(
+                conn,
+                scope_id=scope_id,
+                agent_backend="codex",
+                agent_variant="default",
+                session_anchor="slack_171717.123",
+                native_session_id="",
+                workdir="/tmp",
+                metadata={"legacy_scope_key": "slack::C123"},
+                require_workdir=False,
+            )
+
+        service.save_state(
+            SessionState(
+                session_mappings={
+                    "slack::C123": {
+                        "reviewer": {
+                            "slack_171717.123": "reviewer-native",
+                        }
+                    }
+                }
+            )
+        )
+
+        row = service.get_agent_session_by_id(session_id)
+        assert row is not None
+        assert row["agent_backend"] == "codex"
+        assert row["agent_variant"] == "reviewer"
+        assert row["native_session_id"] == "reviewer-native"
+        mappings = service.load_state().session_mappings["slack::C123"]
+        assert mappings["reviewer"]["slack_171717.123"] == "reviewer-native"
+        assert "default" not in mappings
+    finally:
+        service.close()
+
+
+@pytest.mark.parametrize("legacy_backend", ["default", "unknown"])
+def test_save_state_preserves_durable_agent_identity_on_legacy_backend(
+    tmp_path: Path, legacy_backend: str
+) -> None:
+    db_path = tmp_path / "vibe.sqlite"
+    service = SQLiteSessionsService(db_path)
+    try:
+        with service.engine.begin() as conn:
+            scope_id = resolve_scope_from_legacy_key(conn, "slack::C123", now="2026-07-28T00:00:00Z")
+            assert scope_id is not None
+            session_id = create_agent_session_row(
+                conn,
+                scope_id=scope_id,
+                agent_backend=legacy_backend,
+                agent_variant="reviewer",
+                session_anchor="slack_171717.123",
+                native_session_id="reviewer-native",
+                workdir="/tmp",
+                agent_id="agent-reviewer-deleted",
+                agent_name="reviewer",
+                metadata={"legacy_scope_key": "slack::C123"},
+                require_workdir=False,
+            )
+
+        service.save_state(
+            SessionState(
+                session_mappings={
+                    "slack::C123": {
+                        "reviewer": {
+                            "slack_171717.123": "reviewer-native",
+                        }
+                    }
+                }
+            )
+        )
+
+        row = service.get_agent_session_by_id(session_id)
+        assert row is not None
+        assert row["agent_backend"] == legacy_backend
+        assert row["agent_variant"] == "reviewer"
+        assert row["agent_id"] == "agent-reviewer-deleted"
+        assert row["agent_name"] == "reviewer"
+        assert row["native_session_id"] == "reviewer-native"
+    finally:
+        service.close()
+
+
 def test_save_state_sets_registered_custom_agent_identity_on_existing_owned_row(tmp_path: Path) -> None:
     db_path = tmp_path / "vibe.sqlite"
     service = SQLiteSessionsService(db_path)
@@ -776,7 +866,8 @@ def test_save_state_sets_registered_custom_agent_identity_on_existing_owned_row(
         service.close()
 
 
-def test_save_state_preserves_existing_owned_agent_identity(tmp_path: Path) -> None:
+@pytest.mark.parametrize("existing_backend", ["codex", "default", "unknown"])
+def test_save_state_preserves_existing_agent_identity(tmp_path: Path, existing_backend: str) -> None:
     db_path = tmp_path / "vibe.sqlite"
     service = SQLiteSessionsService(db_path)
     try:
@@ -804,7 +895,7 @@ def test_save_state_preserves_existing_owned_agent_identity(tmp_path: Path) -> N
             session_id = create_agent_session_row(
                 conn,
                 scope_id=scope_id,
-                agent_backend="codex",
+                agent_backend=existing_backend,
                 agent_variant="reviewer",
                 session_anchor="slack_171717.123",
                 native_session_id="existing-native",
@@ -829,7 +920,7 @@ def test_save_state_preserves_existing_owned_agent_identity(tmp_path: Path) -> N
 
         row = service.get_agent_session_by_id(session_id)
         assert row is not None
-        assert row["agent_backend"] == "codex"
+        assert row["agent_backend"] == existing_backend
         assert row["agent_variant"] == "reviewer"
         assert row["agent_id"] == "agent-reviewer-old"
         assert row["agent_name"] == "reviewer-old"

--- a/tests/test_sqlite_sessions_store.py
+++ b/tests/test_sqlite_sessions_store.py
@@ -866,6 +866,68 @@ def test_save_state_sets_registered_custom_agent_identity_on_existing_owned_row(
         service.close()
 
 
+def test_save_state_accepts_matching_agent_identity_across_variant_aliases(tmp_path: Path) -> None:
+    db_path = tmp_path / "vibe.sqlite"
+    service = SQLiteSessionsService(db_path)
+    try:
+        with service.engine.begin() as conn:
+            scope_id = resolve_scope_from_legacy_key(conn, "slack::C123", now="2026-07-28T00:00:00Z")
+            assert scope_id is not None
+            conn.execute(
+                agents.insert().values(
+                    id="agent-reviewer",
+                    name="reviewer",
+                    normalized_name="reviewer",
+                    description=None,
+                    backend="codex",
+                    model=None,
+                    reasoning_effort=None,
+                    system_prompt=None,
+                    enabled=1,
+                    source="user",
+                    source_ref=None,
+                    metadata_json="{}",
+                    created_at="2026-07-28T00:00:00Z",
+                    updated_at="2026-07-28T00:00:00Z",
+                )
+            )
+            session_id = create_agent_session_row(
+                conn,
+                scope_id=scope_id,
+                agent_backend="codex",
+                agent_variant="codex",
+                session_anchor="slack_171717.123",
+                native_session_id="",
+                workdir="/tmp",
+                agent_id="agent-reviewer",
+                agent_name="reviewer",
+                metadata={"legacy_scope_key": "slack::C123"},
+                require_workdir=False,
+            )
+
+        service.save_state(
+            SessionState(
+                session_mappings={
+                    "slack::C123": {
+                        "reviewer": {
+                            "slack_171717.123": "reviewer-native",
+                        }
+                    }
+                }
+            )
+        )
+
+        row = service.get_agent_session_by_id(session_id)
+        assert row is not None
+        assert row["agent_id"] == "agent-reviewer"
+        assert row["agent_name"] == "reviewer"
+        assert row["agent_backend"] == "codex"
+        assert row["agent_variant"] == "codex"
+        assert row["native_session_id"] == "reviewer-native"
+    finally:
+        service.close()
+
+
 @pytest.mark.parametrize("existing_backend", ["codex", "default", "unknown"])
 def test_save_state_preserves_existing_agent_identity(tmp_path: Path, existing_backend: str) -> None:
     db_path = tmp_path / "vibe.sqlite"
@@ -966,6 +1028,70 @@ def test_save_state_accepts_default_variant_when_backend_already_matches(tmp_pat
         assert row["agent_variant"] == "codex"
         assert row["native_session_id"] == "codex-native"
         assert service.load_state().session_mappings["slack::C123"]["codex"]["slack_171717.123"] == "codex-native"
+    finally:
+        service.close()
+
+
+def test_save_state_compares_retry_guard_with_raw_empty_variant(tmp_path: Path) -> None:
+    db_path = tmp_path / "vibe.sqlite"
+    service = SQLiteSessionsService(db_path)
+    update_attempts = 0
+
+    def reject_repeated_agent_session_update(
+        _conn: object,
+        _cursor: object,
+        statement: str,
+        _parameters: object,
+        _context: object,
+        _executemany: object,
+    ) -> None:
+        nonlocal update_attempts
+        if statement.lstrip().upper().startswith("UPDATE AGENT_SESSIONS SET"):
+            update_attempts += 1
+            if update_attempts > 1:
+                raise AssertionError("save_state retried an unchanged legacy anchor row")
+
+    try:
+        with service.engine.begin() as conn:
+            scope_id = resolve_scope_from_legacy_key(conn, "slack::C123", now="2026-07-28T00:00:00Z")
+            assert scope_id is not None
+            session_id = create_agent_session_row(
+                conn,
+                scope_id=scope_id,
+                agent_backend="codex",
+                agent_variant="default",
+                session_anchor="slack_171717.123",
+                native_session_id="",
+                workdir="/tmp",
+                metadata={"legacy_scope_key": "slack::C123"},
+                require_workdir=False,
+            )
+            conn.execute(
+                agent_sessions.update().where(agent_sessions.c.id == session_id).values(agent_variant="")
+            )
+
+        event.listen(service.engine, "before_cursor_execute", reject_repeated_agent_session_update)
+        try:
+            service.save_state(
+                SessionState(
+                    session_mappings={
+                        "slack::C123": {
+                            "codex": {
+                                "slack_171717.123": "codex-native",
+                            }
+                        }
+                    }
+                )
+            )
+        finally:
+            event.remove(service.engine, "before_cursor_execute", reject_repeated_agent_session_update)
+
+        row = service.get_agent_session_by_id(session_id)
+        assert row is not None
+        assert update_attempts == 1
+        assert row["agent_backend"] == "codex"
+        assert row["agent_variant"] == "codex"
+        assert row["native_session_id"] == "codex-native"
     finally:
         service.close()
 

--- a/tests/test_sqlite_sessions_store.py
+++ b/tests/test_sqlite_sessions_store.py
@@ -393,6 +393,70 @@ def test_save_state_adopts_unbound_reservation_across_backends(tmp_path: Path) -
         service.close()
 
 
+def test_save_state_owner_lookahead_matches_registered_agent_id(tmp_path: Path) -> None:
+    db_path = tmp_path / "vibe.sqlite"
+    service = SQLiteSessionsService(db_path)
+    try:
+        with service.engine.begin() as conn:
+            scope_id = resolve_scope_from_legacy_key(conn, "slack::C123", now="2026-07-28T00:00:00Z")
+            assert scope_id is not None
+            conn.execute(
+                agents.insert().values(
+                    id="agent-reviewer",
+                    name="reviewer",
+                    normalized_name="reviewer",
+                    description=None,
+                    backend="codex",
+                    model=None,
+                    reasoning_effort=None,
+                    system_prompt=None,
+                    enabled=1,
+                    source="user",
+                    source_ref=None,
+                    metadata_json="{}",
+                    created_at="2026-07-28T00:00:00Z",
+                    updated_at="2026-07-28T00:00:00Z",
+                )
+            )
+            session_id = create_agent_session_row(
+                conn,
+                scope_id=scope_id,
+                agent_backend="codex",
+                agent_variant="codex",
+                session_anchor="slack_171717.123",
+                native_session_id="",
+                workdir="/tmp",
+                agent_id="agent-reviewer",
+                metadata={"legacy_scope_key": "slack::C123"},
+                require_workdir=False,
+            )
+
+        service.save_state(
+            SessionState(
+                session_mappings={
+                    "slack::C123": {
+                        "claude": {
+                            "slack_171717.123": "claude-native",
+                        },
+                        "reviewer": {
+                            "slack_171717.123": "reviewer-native",
+                        },
+                    }
+                }
+            )
+        )
+
+        row = service.get_agent_session_by_id(session_id)
+        assert row is not None
+        assert row["agent_backend"] == "codex"
+        assert row["agent_variant"] == "codex"
+        assert row["agent_id"] == "agent-reviewer"
+        assert row["agent_name"] == "reviewer"
+        assert row["native_session_id"] == "reviewer-native"
+    finally:
+        service.close()
+
+
 def test_save_state_keeps_default_sentinel_for_default_import(tmp_path: Path) -> None:
     db_path = tmp_path / "vibe.sqlite"
     service = SQLiteSessionsService(db_path)
@@ -905,7 +969,10 @@ def test_save_state_preserves_durable_agent_identity_on_legacy_backend(
         service.close()
 
 
-def test_save_state_sets_registered_custom_agent_identity_on_existing_owned_row(tmp_path: Path) -> None:
+@pytest.mark.parametrize("existing_variant", ["reviewer", "Reviewer"])
+def test_save_state_sets_registered_custom_agent_identity_on_existing_owned_row(
+    tmp_path: Path, existing_variant: str
+) -> None:
     db_path = tmp_path / "vibe.sqlite"
     service = SQLiteSessionsService(db_path)
     try:
@@ -934,7 +1001,7 @@ def test_save_state_sets_registered_custom_agent_identity_on_existing_owned_row(
                 conn,
                 scope_id=scope_id,
                 agent_backend="codex",
-                agent_variant="reviewer",
+                agent_variant=existing_variant,
                 session_anchor="slack_171717.123",
                 native_session_id="",
                 workdir="/tmp",
@@ -959,7 +1026,7 @@ def test_save_state_sets_registered_custom_agent_identity_on_existing_owned_row(
         assert row["agent_id"] == "agent-reviewer"
         assert row["agent_name"] == "reviewer"
         assert row["agent_backend"] == "codex"
-        assert row["agent_variant"] == "reviewer"
+        assert row["agent_variant"] == existing_variant
         assert row["native_session_id"] == "reviewer-native"
     finally:
         service.close()

--- a/tests/test_sqlite_sessions_store.py
+++ b/tests/test_sqlite_sessions_store.py
@@ -544,6 +544,75 @@ def test_save_state_upgrades_unknown_legacy_backend_to_registered_custom_owner(t
         service.close()
 
 
+def test_save_state_clears_route_fields_when_registered_agent_adopts_sentinel(tmp_path: Path) -> None:
+    db_path = tmp_path / "vibe.sqlite"
+    service = SQLiteSessionsService(db_path)
+    try:
+        with service.engine.begin() as conn:
+            scope_id = resolve_scope_from_legacy_key(conn, "slack::C123", now="2026-07-28T00:00:00Z")
+            assert scope_id is not None
+            conn.execute(
+                agents.insert().values(
+                    id="agent-reviewer",
+                    name="reviewer",
+                    normalized_name="reviewer",
+                    description=None,
+                    backend="codex",
+                    model=None,
+                    reasoning_effort=None,
+                    system_prompt=None,
+                    enabled=1,
+                    source="user",
+                    source_ref=None,
+                    metadata_json="{}",
+                    created_at="2026-07-28T00:00:00Z",
+                    updated_at="2026-07-28T00:00:00Z",
+                )
+            )
+            session_id = create_agent_session_row(
+                conn,
+                scope_id=scope_id,
+                agent_backend="unknown",
+                agent_variant="default",
+                session_anchor="slack_171717.123",
+                native_session_id="",
+                workdir="/tmp",
+                agent_id="stale-agent",
+                agent_name="stale-reviewer",
+                model="gpt-5-old",
+                reasoning_effort="high",
+                metadata={
+                    "legacy_scope_key": "slack::C123",
+                    "explicit_setting_overrides": ["model", "reasoning_effort"],
+                },
+                require_workdir=False,
+            )
+
+        service.save_state(
+            SessionState(
+                session_mappings={
+                    "slack::C123": {
+                        "reviewer": {
+                            "slack_171717.123": "reviewer-native",
+                        }
+                    }
+                }
+            )
+        )
+
+        row = service.get_agent_session_by_id(session_id)
+        assert row is not None
+        assert row["agent_backend"] == "codex"
+        assert row["agent_variant"] == "reviewer"
+        assert row["agent_id"] == "agent-reviewer"
+        assert row["agent_name"] == "reviewer"
+        assert row["model"] is None
+        assert row["reasoning_effort"] is None
+        assert "explicit_setting_overrides" not in json.loads(row["metadata_json"] or "{}")
+    finally:
+        service.close()
+
+
 def test_save_state_preserves_unregistered_custom_variant_on_default_sentinel(tmp_path: Path) -> None:
     db_path = tmp_path / "vibe.sqlite"
     service = SQLiteSessionsService(db_path)
@@ -643,6 +712,68 @@ def test_save_state_sets_registered_custom_agent_identity_on_existing_owned_row(
         assert row["agent_backend"] == "codex"
         assert row["agent_variant"] == "reviewer"
         assert row["native_session_id"] == "reviewer-native"
+    finally:
+        service.close()
+
+
+def test_save_state_preserves_existing_owned_agent_identity(tmp_path: Path) -> None:
+    db_path = tmp_path / "vibe.sqlite"
+    service = SQLiteSessionsService(db_path)
+    try:
+        with service.engine.begin() as conn:
+            scope_id = resolve_scope_from_legacy_key(conn, "slack::C123", now="2026-07-28T00:00:00Z")
+            assert scope_id is not None
+            conn.execute(
+                agents.insert().values(
+                    id="agent-reviewer-new",
+                    name="reviewer",
+                    normalized_name="reviewer",
+                    description=None,
+                    backend="codex",
+                    model=None,
+                    reasoning_effort=None,
+                    system_prompt=None,
+                    enabled=1,
+                    source="user",
+                    source_ref=None,
+                    metadata_json="{}",
+                    created_at="2026-07-28T00:00:00Z",
+                    updated_at="2026-07-28T00:00:00Z",
+                )
+            )
+            session_id = create_agent_session_row(
+                conn,
+                scope_id=scope_id,
+                agent_backend="codex",
+                agent_variant="reviewer",
+                session_anchor="slack_171717.123",
+                native_session_id="existing-native",
+                workdir="/tmp",
+                agent_id="agent-reviewer-old",
+                agent_name="reviewer-old",
+                metadata={"legacy_scope_key": "slack::C123"},
+                require_workdir=False,
+            )
+
+        service.save_state(
+            SessionState(
+                session_mappings={
+                    "slack::C123": {
+                        "reviewer": {
+                            "slack_171717.123": "reviewer-native",
+                        }
+                    }
+                }
+            )
+        )
+
+        row = service.get_agent_session_by_id(session_id)
+        assert row is not None
+        assert row["agent_backend"] == "codex"
+        assert row["agent_variant"] == "reviewer"
+        assert row["agent_id"] == "agent-reviewer-old"
+        assert row["agent_name"] == "reviewer-old"
+        assert row["native_session_id"] == "existing-native"
     finally:
         service.close()
 

--- a/tests/test_sqlite_sessions_store.py
+++ b/tests/test_sqlite_sessions_store.py
@@ -15,7 +15,7 @@ from config.v2_sessions import ActivePollInfo, SessionState, SessionsStore
 from modules.sessions_facade import SessionsFacade
 from storage.agent_session_rows import create_agent_session_row
 from storage.db import create_sqlite_engine
-from storage.models import agent_sessions, run_definitions
+from storage.models import agent_sessions, agents, run_definitions
 from storage.sessions_service import SQLiteSessionsService, resolve_scope_from_legacy_key
 from storage.settings_service import upsert_scope
 
@@ -417,6 +417,67 @@ def test_save_state_matches_existing_custom_variant_without_relabeling_backend(t
         assert row["agent_backend"] == "opencode"
         assert row["agent_variant"] == "reviewer"
         assert row["native_session_id"] == "reviewer-native"
+    finally:
+        service.close()
+
+
+def test_save_state_adopts_registered_custom_agent_into_default_sentinel(tmp_path: Path) -> None:
+    db_path = tmp_path / "vibe.sqlite"
+    service = SQLiteSessionsService(db_path)
+    try:
+        with service.engine.begin() as conn:
+            scope_id = resolve_scope_from_legacy_key(conn, "slack::C123", now="2026-07-28T00:00:00Z")
+            assert scope_id is not None
+            conn.execute(
+                agents.insert().values(
+                    id="agent-reviewer",
+                    name="reviewer",
+                    normalized_name="reviewer",
+                    description=None,
+                    backend="codex",
+                    model=None,
+                    reasoning_effort=None,
+                    system_prompt=None,
+                    enabled=1,
+                    source="user",
+                    source_ref=None,
+                    metadata_json="{}",
+                    created_at="2026-07-28T00:00:00Z",
+                    updated_at="2026-07-28T00:00:00Z",
+                )
+            )
+            session_id = create_agent_session_row(
+                conn,
+                scope_id=scope_id,
+                agent_backend="default",
+                agent_variant="default",
+                session_anchor="slack_171717.123",
+                native_session_id="",
+                workdir="/tmp",
+                metadata={"legacy_scope_key": "slack::C123"},
+                require_workdir=False,
+            )
+
+        service.save_state(
+            SessionState(
+                session_mappings={
+                    "slack::C123": {
+                        "reviewer": {
+                            "slack_171717.123": "reviewer-native",
+                        }
+                    }
+                }
+            )
+        )
+
+        row = service.get_agent_session_by_id(session_id)
+        assert row is not None
+        assert row["agent_backend"] == "codex"
+        assert row["agent_variant"] == "reviewer"
+        assert row["native_session_id"] == "reviewer-native"
+        assert service.load_state().session_mappings["slack::C123"]["reviewer"]["slack_171717.123"] == (
+            "reviewer-native"
+        )
     finally:
         service.close()
 

--- a/tests/test_sqlite_sessions_store.py
+++ b/tests/test_sqlite_sessions_store.py
@@ -288,7 +288,7 @@ def test_save_state_does_not_relabel_existing_anchor_row_to_different_backend(tm
         assert row["native_session_id"] == "claude-native"
         assert row["model"] == "claude-sonnet-4-6"
         assert row["reasoning_effort"] == "high"
-        assert row["metadata"]["explicit_setting_overrides"] == {
+        assert json.loads(row["metadata_json"])["explicit_setting_overrides"] == {
             "model": True,
             "reasoning_effort": True,
         }

--- a/tests/test_sqlite_sessions_store.py
+++ b/tests/test_sqlite_sessions_store.py
@@ -341,6 +341,58 @@ def test_save_state_allows_legacy_default_anchor_row_to_adopt_imported_backend(t
         service.close()
 
 
+def test_save_state_adopts_unbound_reservation_across_backends(tmp_path: Path) -> None:
+    db_path = tmp_path / "vibe.sqlite"
+    service = SQLiteSessionsService(db_path)
+    try:
+        with service.engine.begin() as conn:
+            scope_id = resolve_scope_from_legacy_key(conn, "slack::C123", now="2026-07-28T00:00:00Z")
+            assert scope_id is not None
+            session_id = create_agent_session_row(
+                conn,
+                scope_id=scope_id,
+                agent_backend="codex",
+                agent_variant="codex",
+                session_anchor="slack_171717.123",
+                native_session_id="",
+                workdir="/tmp",
+                agent_id="agent-codex",
+                agent_name="codex-reviewer",
+                model="gpt-5-old",
+                reasoning_effort="high",
+                metadata={
+                    "legacy_scope_key": "slack::C123",
+                    "explicit_setting_overrides": ["model", "reasoning_effort"],
+                },
+                require_workdir=False,
+            )
+
+        service.save_state(
+            SessionState(
+                session_mappings={
+                    "slack::C123": {
+                        "claude": {
+                            "slack_171717.123": "claude-native",
+                        }
+                    }
+                }
+            )
+        )
+
+        row = service.get_agent_session_by_id(session_id)
+        assert row is not None
+        assert row["agent_backend"] == "claude"
+        assert row["agent_variant"] == "claude"
+        assert row["agent_id"] is None
+        assert row["agent_name"] is None
+        assert row["model"] is None
+        assert row["reasoning_effort"] is None
+        assert "explicit_setting_overrides" not in json.loads(row["metadata_json"] or "{}")
+        assert row["native_session_id"] == "claude-native"
+    finally:
+        service.close()
+
+
 def test_save_state_keeps_default_sentinel_for_default_import(tmp_path: Path) -> None:
     db_path = tmp_path / "vibe.sqlite"
     service = SQLiteSessionsService(db_path)

--- a/tests/test_sqlite_sessions_store.py
+++ b/tests/test_sqlite_sessions_store.py
@@ -613,6 +613,66 @@ def test_save_state_clears_route_fields_when_registered_agent_adopts_sentinel(tm
         service.close()
 
 
+def test_save_state_prefers_catalog_identity_over_backend_name_fallback(tmp_path: Path) -> None:
+    db_path = tmp_path / "vibe.sqlite"
+    service = SQLiteSessionsService(db_path)
+    try:
+        with service.engine.begin() as conn:
+            scope_id = resolve_scope_from_legacy_key(conn, "slack::C123", now="2026-07-28T00:00:00Z")
+            assert scope_id is not None
+            conn.execute(
+                agents.insert().values(
+                    id="agent-codex-opencode",
+                    name="codex",
+                    normalized_name="codex",
+                    description=None,
+                    backend="opencode",
+                    model=None,
+                    reasoning_effort=None,
+                    system_prompt=None,
+                    enabled=1,
+                    source="user",
+                    source_ref=None,
+                    metadata_json="{}",
+                    created_at="2026-07-28T00:00:00Z",
+                    updated_at="2026-07-28T00:00:00Z",
+                )
+            )
+            session_id = create_agent_session_row(
+                conn,
+                scope_id=scope_id,
+                agent_backend="default",
+                agent_variant="default",
+                session_anchor="slack_171717.123",
+                native_session_id="",
+                workdir="/tmp",
+                metadata={"legacy_scope_key": "slack::C123"},
+                require_workdir=False,
+            )
+
+        service.save_state(
+            SessionState(
+                session_mappings={
+                    "slack::C123": {
+                        "codex": {
+                            "slack_171717.123": "codex-native",
+                        }
+                    }
+                }
+            )
+        )
+
+        row = service.get_agent_session_by_id(session_id)
+        assert row is not None
+        assert row["agent_backend"] == "opencode"
+        assert row["agent_variant"] == "codex"
+        assert row["agent_id"] == "agent-codex-opencode"
+        assert row["agent_name"] == "codex"
+        assert row["native_session_id"] == "codex-native"
+    finally:
+        service.close()
+
+
 def test_save_state_preserves_unregistered_custom_variant_on_default_sentinel(tmp_path: Path) -> None:
     db_path = tmp_path / "vibe.sqlite"
     service = SQLiteSessionsService(db_path)
@@ -774,6 +834,47 @@ def test_save_state_preserves_existing_owned_agent_identity(tmp_path: Path) -> N
         assert row["agent_id"] == "agent-reviewer-old"
         assert row["agent_name"] == "reviewer-old"
         assert row["native_session_id"] == "existing-native"
+    finally:
+        service.close()
+
+
+def test_save_state_accepts_default_variant_when_backend_already_matches(tmp_path: Path) -> None:
+    db_path = tmp_path / "vibe.sqlite"
+    service = SQLiteSessionsService(db_path)
+    try:
+        with service.engine.begin() as conn:
+            scope_id = resolve_scope_from_legacy_key(conn, "slack::C123", now="2026-07-28T00:00:00Z")
+            assert scope_id is not None
+            session_id = create_agent_session_row(
+                conn,
+                scope_id=scope_id,
+                agent_backend="codex",
+                agent_variant="default",
+                session_anchor="slack_171717.123",
+                native_session_id="",
+                workdir="/tmp",
+                metadata={"legacy_scope_key": "slack::C123"},
+                require_workdir=False,
+            )
+
+        service.save_state(
+            SessionState(
+                session_mappings={
+                    "slack::C123": {
+                        "codex": {
+                            "slack_171717.123": "codex-native",
+                        }
+                    }
+                }
+            )
+        )
+
+        row = service.get_agent_session_by_id(session_id)
+        assert row is not None
+        assert row["agent_backend"] == "codex"
+        assert row["agent_variant"] == "codex"
+        assert row["native_session_id"] == "codex-native"
+        assert service.load_state().session_mappings["slack::C123"]["codex"]["slack_171717.123"] == "codex-native"
     finally:
         service.close()
 

--- a/tests/test_sqlite_sessions_store.py
+++ b/tests/test_sqlite_sessions_store.py
@@ -484,6 +484,66 @@ def test_save_state_adopts_registered_custom_agent_into_default_sentinel(tmp_pat
         service.close()
 
 
+def test_save_state_upgrades_unknown_legacy_backend_to_registered_custom_owner(tmp_path: Path) -> None:
+    db_path = tmp_path / "vibe.sqlite"
+    service = SQLiteSessionsService(db_path)
+    try:
+        with service.engine.begin() as conn:
+            scope_id = resolve_scope_from_legacy_key(conn, "slack::C123", now="2026-07-28T00:00:00Z")
+            assert scope_id is not None
+            conn.execute(
+                agents.insert().values(
+                    id="agent-reviewer",
+                    name="reviewer",
+                    normalized_name="reviewer",
+                    description=None,
+                    backend="codex",
+                    model=None,
+                    reasoning_effort=None,
+                    system_prompt=None,
+                    enabled=1,
+                    source="user",
+                    source_ref=None,
+                    metadata_json="{}",
+                    created_at="2026-07-28T00:00:00Z",
+                    updated_at="2026-07-28T00:00:00Z",
+                )
+            )
+            session_id = create_agent_session_row(
+                conn,
+                scope_id=scope_id,
+                agent_backend="unknown",
+                agent_variant="reviewer",
+                session_anchor="slack_171717.123",
+                native_session_id="",
+                workdir="/tmp",
+                metadata={"legacy_scope_key": "slack::C123"},
+                require_workdir=False,
+            )
+
+        service.save_state(
+            SessionState(
+                session_mappings={
+                    "slack::C123": {
+                        "reviewer": {
+                            "slack_171717.123": "reviewer-native",
+                        }
+                    }
+                }
+            )
+        )
+
+        row = service.get_agent_session_by_id(session_id)
+        assert row is not None
+        assert row["agent_backend"] == "codex"
+        assert row["agent_variant"] == "reviewer"
+        assert row["agent_id"] == "agent-reviewer"
+        assert row["agent_name"] == "reviewer"
+        assert row["native_session_id"] == "reviewer-native"
+    finally:
+        service.close()
+
+
 def test_save_state_preserves_unregistered_custom_variant_on_default_sentinel(tmp_path: Path) -> None:
     db_path = tmp_path / "vibe.sqlite"
     service = SQLiteSessionsService(db_path)
@@ -583,6 +643,66 @@ def test_save_state_sets_registered_custom_agent_identity_on_existing_owned_row(
         assert row["agent_backend"] == "codex"
         assert row["agent_variant"] == "reviewer"
         assert row["native_session_id"] == "reviewer-native"
+    finally:
+        service.close()
+
+
+def test_save_state_skips_same_variant_when_catalog_backend_disagrees_with_owned_row(tmp_path: Path) -> None:
+    db_path = tmp_path / "vibe.sqlite"
+    service = SQLiteSessionsService(db_path)
+    try:
+        with service.engine.begin() as conn:
+            scope_id = resolve_scope_from_legacy_key(conn, "slack::C123", now="2026-07-28T00:00:00Z")
+            assert scope_id is not None
+            conn.execute(
+                agents.insert().values(
+                    id="agent-reviewer",
+                    name="reviewer",
+                    normalized_name="reviewer",
+                    description=None,
+                    backend="codex",
+                    model=None,
+                    reasoning_effort=None,
+                    system_prompt=None,
+                    enabled=1,
+                    source="user",
+                    source_ref=None,
+                    metadata_json="{}",
+                    created_at="2026-07-28T00:00:00Z",
+                    updated_at="2026-07-28T00:00:00Z",
+                )
+            )
+            session_id = create_agent_session_row(
+                conn,
+                scope_id=scope_id,
+                agent_backend="opencode",
+                agent_variant="reviewer",
+                session_anchor="slack_171717.123",
+                native_session_id="existing-native",
+                workdir="/tmp",
+                metadata={"legacy_scope_key": "slack::C123"},
+                require_workdir=False,
+            )
+
+        service.save_state(
+            SessionState(
+                session_mappings={
+                    "slack::C123": {
+                        "reviewer": {
+                            "slack_171717.123": "reviewer-native",
+                        }
+                    }
+                }
+            )
+        )
+
+        row = service.get_agent_session_by_id(session_id)
+        assert row is not None
+        assert row["agent_backend"] == "opencode"
+        assert row["agent_variant"] == "reviewer"
+        assert row["agent_id"] is None
+        assert row["agent_name"] is None
+        assert row["native_session_id"] == "existing-native"
     finally:
         service.close()
 

--- a/tests/test_sqlite_sessions_store.py
+++ b/tests/test_sqlite_sessions_store.py
@@ -393,6 +393,195 @@ def test_save_state_adopts_unbound_reservation_across_backends(tmp_path: Path) -
         service.close()
 
 
+def test_save_state_adopts_unbound_reservation_when_agent_changes_on_same_backend(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "vibe.sqlite"
+    service = SQLiteSessionsService(db_path)
+    try:
+        with service.engine.begin() as conn:
+            scope_id = resolve_scope_from_legacy_key(conn, "slack::C123", now="2026-07-28T00:00:00Z")
+            assert scope_id is not None
+            conn.execute(
+                agents.insert().values(
+                    id="agent-reviewer",
+                    name="reviewer",
+                    normalized_name="reviewer",
+                    description=None,
+                    backend="codex",
+                    model=None,
+                    reasoning_effort=None,
+                    system_prompt=None,
+                    enabled=1,
+                    source="user",
+                    source_ref=None,
+                    metadata_json="{}",
+                    created_at="2026-07-28T00:00:00Z",
+                    updated_at="2026-07-28T00:00:00Z",
+                )
+            )
+            session_id = create_agent_session_row(
+                conn,
+                scope_id=scope_id,
+                agent_backend="codex",
+                agent_variant="codex",
+                session_anchor="slack_171717.123",
+                native_session_id="",
+                workdir="/tmp",
+                model="gpt-5-old",
+                reasoning_effort="high",
+                metadata={
+                    "legacy_scope_key": "slack::C123",
+                    "explicit_setting_overrides": ["model", "reasoning_effort"],
+                },
+                require_workdir=False,
+            )
+
+        service.save_state(
+            SessionState(
+                session_mappings={
+                    "slack::C123": {
+                        "reviewer": {
+                            "slack_171717.123": "reviewer-native",
+                        }
+                    }
+                }
+            )
+        )
+
+        row = service.get_agent_session_by_id(session_id)
+        assert row is not None
+        assert row["agent_backend"] == "codex"
+        assert row["agent_variant"] == "reviewer"
+        assert row["agent_id"] == "agent-reviewer"
+        assert row["agent_name"] == "reviewer"
+        assert row["model"] is None
+        assert row["reasoning_effort"] is None
+        assert "explicit_setting_overrides" not in json.loads(row["metadata_json"] or "{}")
+        assert row["native_session_id"] == "reviewer-native"
+    finally:
+        service.close()
+
+
+def test_save_state_clears_route_fields_when_agent_replaces_bound_sentinel_variant(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "vibe.sqlite"
+    service = SQLiteSessionsService(db_path)
+    try:
+        with service.engine.begin() as conn:
+            scope_id = resolve_scope_from_legacy_key(conn, "slack::C123", now="2026-07-28T00:00:00Z")
+            assert scope_id is not None
+            conn.execute(
+                agents.insert().values(
+                    id="agent-reviewer",
+                    name="reviewer",
+                    normalized_name="reviewer",
+                    description=None,
+                    backend="codex",
+                    model=None,
+                    reasoning_effort=None,
+                    system_prompt=None,
+                    enabled=1,
+                    source="user",
+                    source_ref=None,
+                    metadata_json="{}",
+                    created_at="2026-07-28T00:00:00Z",
+                    updated_at="2026-07-28T00:00:00Z",
+                )
+            )
+            session_id = create_agent_session_row(
+                conn,
+                scope_id=scope_id,
+                agent_backend="codex",
+                agent_variant="default",
+                session_anchor="slack_171717.123",
+                native_session_id="legacy-native",
+                workdir="/tmp",
+                model="gpt-5-old",
+                reasoning_effort="high",
+                metadata={
+                    "legacy_scope_key": "slack::C123",
+                    "explicit_setting_overrides": ["model", "reasoning_effort"],
+                },
+                require_workdir=False,
+            )
+
+        service.save_state(
+            SessionState(
+                session_mappings={
+                    "slack::C123": {
+                        "reviewer": {
+                            "slack_171717.123": "reviewer-native",
+                        }
+                    }
+                }
+            )
+        )
+
+        row = service.get_agent_session_by_id(session_id)
+        assert row is not None
+        assert row["agent_backend"] == "codex"
+        assert row["agent_variant"] == "reviewer"
+        assert row["agent_id"] == "agent-reviewer"
+        assert row["agent_name"] == "reviewer"
+        assert row["model"] is None
+        assert row["reasoning_effort"] is None
+        assert "explicit_setting_overrides" not in json.loads(row["metadata_json"] or "{}")
+        assert row["native_session_id"] == "reviewer-native"
+    finally:
+        service.close()
+
+
+def test_save_state_backend_alias_does_not_override_specific_reserved_owner(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "vibe.sqlite"
+    service = SQLiteSessionsService(db_path)
+    try:
+        with service.engine.begin() as conn:
+            scope_id = resolve_scope_from_legacy_key(conn, "slack::C123", now="2026-07-28T00:00:00Z")
+            assert scope_id is not None
+            session_id = create_agent_session_row(
+                conn,
+                scope_id=scope_id,
+                agent_backend="codex",
+                agent_variant="reviewer",
+                session_anchor="slack_171717.123",
+                native_session_id="",
+                workdir="/tmp",
+                agent_id="agent-reviewer",
+                agent_name="reviewer",
+                metadata={"legacy_scope_key": "slack::C123"},
+                require_workdir=False,
+            )
+
+        service.save_state(
+            SessionState(
+                session_mappings={
+                    "slack::C123": {
+                        "claude": {
+                            "slack_171717.123": "claude-native",
+                        },
+                        "codex": {
+                            "slack_171717.123": "codex-native",
+                        },
+                    }
+                }
+            )
+        )
+
+        row = service.get_agent_session_by_id(session_id)
+        assert row is not None
+        assert row["agent_backend"] == "claude"
+        assert row["agent_variant"] == "claude"
+        assert row["agent_id"] is None
+        assert row["agent_name"] is None
+        assert row["native_session_id"] == "claude-native"
+    finally:
+        service.close()
+
+
 def test_save_state_owner_lookahead_matches_registered_agent_id(tmp_path: Path) -> None:
     db_path = tmp_path / "vibe.sqlite"
     service = SQLiteSessionsService(db_path)

--- a/tests/test_sqlite_sessions_store.py
+++ b/tests/test_sqlite_sessions_store.py
@@ -474,10 +474,115 @@ def test_save_state_adopts_registered_custom_agent_into_default_sentinel(tmp_pat
         assert row is not None
         assert row["agent_backend"] == "codex"
         assert row["agent_variant"] == "reviewer"
+        assert row["agent_id"] == "agent-reviewer"
+        assert row["agent_name"] == "reviewer"
         assert row["native_session_id"] == "reviewer-native"
         assert service.load_state().session_mappings["slack::C123"]["reviewer"]["slack_171717.123"] == (
             "reviewer-native"
         )
+    finally:
+        service.close()
+
+
+def test_save_state_preserves_unregistered_custom_variant_on_default_sentinel(tmp_path: Path) -> None:
+    db_path = tmp_path / "vibe.sqlite"
+    service = SQLiteSessionsService(db_path)
+    try:
+        with service.engine.begin() as conn:
+            scope_id = resolve_scope_from_legacy_key(conn, "slack::C123", now="2026-07-28T00:00:00Z")
+            assert scope_id is not None
+            session_id = create_agent_session_row(
+                conn,
+                scope_id=scope_id,
+                agent_backend="default",
+                agent_variant="default",
+                session_anchor="slack_171717.123",
+                native_session_id="",
+                workdir="/tmp",
+                metadata={"legacy_scope_key": "slack::C123"},
+                require_workdir=False,
+            )
+
+        service.save_state(
+            SessionState(
+                session_mappings={
+                    "slack::C123": {
+                        "reviewer": {
+                            "slack_171717.123": "reviewer-native",
+                        }
+                    }
+                }
+            )
+        )
+
+        row = service.get_agent_session_by_id(session_id)
+        assert row is not None
+        assert row["agent_backend"] == "default"
+        assert row["agent_variant"] == "reviewer"
+        assert row["native_session_id"] == "reviewer-native"
+        assert service.load_state().session_mappings["slack::C123"]["reviewer"]["slack_171717.123"] == (
+            "reviewer-native"
+        )
+    finally:
+        service.close()
+
+
+def test_save_state_sets_registered_custom_agent_identity_on_existing_owned_row(tmp_path: Path) -> None:
+    db_path = tmp_path / "vibe.sqlite"
+    service = SQLiteSessionsService(db_path)
+    try:
+        with service.engine.begin() as conn:
+            scope_id = resolve_scope_from_legacy_key(conn, "slack::C123", now="2026-07-28T00:00:00Z")
+            assert scope_id is not None
+            conn.execute(
+                agents.insert().values(
+                    id="agent-reviewer",
+                    name="reviewer",
+                    normalized_name="reviewer",
+                    description=None,
+                    backend="codex",
+                    model=None,
+                    reasoning_effort=None,
+                    system_prompt=None,
+                    enabled=1,
+                    source="user",
+                    source_ref=None,
+                    metadata_json="{}",
+                    created_at="2026-07-28T00:00:00Z",
+                    updated_at="2026-07-28T00:00:00Z",
+                )
+            )
+            session_id = create_agent_session_row(
+                conn,
+                scope_id=scope_id,
+                agent_backend="codex",
+                agent_variant="reviewer",
+                session_anchor="slack_171717.123",
+                native_session_id="",
+                workdir="/tmp",
+                metadata={"legacy_scope_key": "slack::C123"},
+                require_workdir=False,
+            )
+
+        service.save_state(
+            SessionState(
+                session_mappings={
+                    "slack::C123": {
+                        "reviewer": {
+                            "slack_171717.123": "reviewer-native",
+                        }
+                    }
+                }
+            )
+        )
+
+        row = service.get_agent_session_by_id(session_id)
+        assert row is not None
+        assert row["agent_id"] == "agent-reviewer"
+        assert row["agent_name"] == "reviewer"
+        assert row["agent_backend"] == "codex"
+        assert row["agent_variant"] == "reviewer"
+        assert row["native_session_id"] == "reviewer-native"
     finally:
         service.close()
 
@@ -524,6 +629,88 @@ def test_save_state_skips_conflicting_backend_and_imports_later_matching_owner(t
         mappings = service.load_state().session_mappings["slack::C123"]
         assert mappings["claude"]["slack_171717.123"] == "claude-native"
         assert "codex" not in mappings
+    finally:
+        service.close()
+
+
+def test_save_state_skips_conflicting_custom_variant_with_same_backend_and_imports_owner(tmp_path: Path) -> None:
+    db_path = tmp_path / "vibe.sqlite"
+    service = SQLiteSessionsService(db_path)
+    try:
+        with service.engine.begin() as conn:
+            scope_id = resolve_scope_from_legacy_key(conn, "slack::C123", now="2026-07-28T00:00:00Z")
+            assert scope_id is not None
+            conn.execute(
+                agents.insert(),
+                [
+                    {
+                        "id": "agent-reviewer",
+                        "name": "reviewer",
+                        "normalized_name": "reviewer",
+                        "description": None,
+                        "backend": "codex",
+                        "model": None,
+                        "reasoning_effort": None,
+                        "system_prompt": None,
+                        "enabled": 1,
+                        "source": "user",
+                        "source_ref": None,
+                        "metadata_json": "{}",
+                        "created_at": "2026-07-28T00:00:00Z",
+                        "updated_at": "2026-07-28T00:00:00Z",
+                    },
+                    {
+                        "id": "agent-writer",
+                        "name": "writer",
+                        "normalized_name": "writer",
+                        "description": None,
+                        "backend": "codex",
+                        "model": None,
+                        "reasoning_effort": None,
+                        "system_prompt": None,
+                        "enabled": 1,
+                        "source": "user",
+                        "source_ref": None,
+                        "metadata_json": "{}",
+                        "created_at": "2026-07-28T00:00:00Z",
+                        "updated_at": "2026-07-28T00:00:00Z",
+                    },
+                ],
+            )
+            session_id = create_agent_session_row(
+                conn,
+                scope_id=scope_id,
+                agent_backend="codex",
+                agent_variant="reviewer",
+                session_anchor="slack_171717.123",
+                native_session_id="",
+                workdir="/tmp",
+                metadata={"legacy_scope_key": "slack::C123"},
+                require_workdir=False,
+            )
+
+        service.save_state(
+            SessionState(
+                session_mappings={
+                    "slack::C123": {
+                        "writer": {
+                            "slack_171717.123": "writer-native",
+                        },
+                        "reviewer": {
+                            "slack_171717.123": "reviewer-native",
+                        },
+                    }
+                }
+            )
+        )
+
+        row = service.get_agent_session_by_id(session_id)
+        assert row is not None
+        assert row["agent_id"] == "agent-reviewer"
+        assert row["agent_name"] == "reviewer"
+        assert row["agent_backend"] == "codex"
+        assert row["agent_variant"] == "reviewer"
+        assert row["native_session_id"] == "reviewer-native"
     finally:
         service.close()
 

--- a/tests/test_sqlite_sessions_store.py
+++ b/tests/test_sqlite_sessions_store.py
@@ -341,6 +341,86 @@ def test_save_state_allows_legacy_default_anchor_row_to_adopt_imported_backend(t
         service.close()
 
 
+def test_save_state_keeps_default_sentinel_for_default_import(tmp_path: Path) -> None:
+    db_path = tmp_path / "vibe.sqlite"
+    service = SQLiteSessionsService(db_path)
+    try:
+        with service.engine.begin() as conn:
+            scope_id = resolve_scope_from_legacy_key(conn, "slack::C123", now="2026-07-28T00:00:00Z")
+            assert scope_id is not None
+            session_id = create_agent_session_row(
+                conn,
+                scope_id=scope_id,
+                agent_backend="default",
+                agent_variant="default",
+                session_anchor="slack_171717.123",
+                native_session_id="",
+                workdir="/tmp",
+                metadata={"legacy_scope_key": "slack::C123"},
+                require_workdir=False,
+            )
+
+        service.save_state(
+            SessionState(
+                session_mappings={
+                    "slack::C123": {
+                        "default": {
+                            "slack_171717.123": "legacy-native",
+                        }
+                    }
+                }
+            )
+        )
+
+        row = service.get_agent_session_by_id(session_id)
+        assert row is not None
+        assert row["agent_backend"] == "default"
+        assert row["agent_variant"] == "default"
+        assert row["native_session_id"] == "legacy-native"
+    finally:
+        service.close()
+
+
+def test_save_state_matches_existing_custom_variant_without_relabeling_backend(tmp_path: Path) -> None:
+    db_path = tmp_path / "vibe.sqlite"
+    service = SQLiteSessionsService(db_path)
+    try:
+        with service.engine.begin() as conn:
+            scope_id = resolve_scope_from_legacy_key(conn, "slack::C123", now="2026-07-28T00:00:00Z")
+            assert scope_id is not None
+            session_id = create_agent_session_row(
+                conn,
+                scope_id=scope_id,
+                agent_backend="opencode",
+                agent_variant="reviewer",
+                session_anchor="slack_171717.123",
+                native_session_id="",
+                workdir="/tmp",
+                metadata={"legacy_scope_key": "slack::C123"},
+                require_workdir=False,
+            )
+
+        service.save_state(
+            SessionState(
+                session_mappings={
+                    "slack::C123": {
+                        "reviewer": {
+                            "slack_171717.123": "reviewer-native",
+                        }
+                    }
+                }
+            )
+        )
+
+        row = service.get_agent_session_by_id(session_id)
+        assert row is not None
+        assert row["agent_backend"] == "opencode"
+        assert row["agent_variant"] == "reviewer"
+        assert row["native_session_id"] == "reviewer-native"
+    finally:
+        service.close()
+
+
 def test_save_state_skips_conflicting_backend_and_imports_later_matching_owner(tmp_path: Path) -> None:
     db_path = tmp_path / "vibe.sqlite"
     service = SQLiteSessionsService(db_path)

--- a/tests/test_sqlite_sessions_store.py
+++ b/tests/test_sqlite_sessions_store.py
@@ -298,6 +298,93 @@ def test_save_state_does_not_relabel_existing_anchor_row_to_different_backend(tm
         service.close()
 
 
+def test_save_state_allows_legacy_default_anchor_row_to_adopt_imported_backend(tmp_path: Path) -> None:
+    db_path = tmp_path / "vibe.sqlite"
+    service = SQLiteSessionsService(db_path)
+    try:
+        with service.engine.begin() as conn:
+            scope_id = resolve_scope_from_legacy_key(conn, "slack::C123", now="2026-07-28T00:00:00Z")
+            assert scope_id is not None
+            session_id = create_agent_session_row(
+                conn,
+                scope_id=scope_id,
+                agent_backend="default",
+                agent_variant="default",
+                session_anchor="slack_171717.123",
+                native_session_id="",
+                workdir="/tmp",
+                metadata={"legacy_scope_key": "slack::C123"},
+                require_workdir=False,
+            )
+
+        service.save_state(
+            SessionState(
+                session_mappings={
+                    "slack::C123": {
+                        "codex": {
+                            "slack_171717.123": "codex-native",
+                        }
+                    }
+                }
+            )
+        )
+
+        row = service.get_agent_session_by_id(session_id)
+        assert row is not None
+        assert row["agent_backend"] == "codex"
+        assert row["agent_variant"] == "codex"
+        assert row["native_session_id"] == "codex-native"
+        assert service.load_state().session_mappings["slack::C123"]["codex"]["slack_171717.123"] == "codex-native"
+    finally:
+        service.close()
+
+
+def test_save_state_skips_conflicting_backend_and_imports_later_matching_owner(tmp_path: Path) -> None:
+    db_path = tmp_path / "vibe.sqlite"
+    service = SQLiteSessionsService(db_path)
+    try:
+        with service.engine.begin() as conn:
+            scope_id = resolve_scope_from_legacy_key(conn, "slack::C123", now="2026-07-28T00:00:00Z")
+            assert scope_id is not None
+            session_id = create_agent_session_row(
+                conn,
+                scope_id=scope_id,
+                agent_backend="claude",
+                agent_variant="claude",
+                session_anchor="slack_171717.123",
+                native_session_id="",
+                workdir="/tmp",
+                metadata={"legacy_scope_key": "slack::C123"},
+                require_workdir=False,
+            )
+
+        service.save_state(
+            SessionState(
+                session_mappings={
+                    "slack::C123": {
+                        "codex": {
+                            "slack_171717.123": "codex-native",
+                        },
+                        "claude": {
+                            "slack_171717.123": "claude-native",
+                        },
+                    }
+                }
+            )
+        )
+
+        row = service.get_agent_session_by_id(session_id)
+        assert row is not None
+        assert row["agent_backend"] == "claude"
+        assert row["agent_variant"] == "claude"
+        assert row["native_session_id"] == "claude-native"
+        mappings = service.load_state().session_mappings["slack::C123"]
+        assert mappings["claude"]["slack_171717.123"] == "claude-native"
+        assert "codex" not in mappings
+    finally:
+        service.close()
+
+
 def test_sqlite_sessions_service_reserves_then_binds_agent_session_id(tmp_path: Path) -> None:
     db_path = tmp_path / "vibe.sqlite"
     service = SQLiteSessionsService(db_path)

--- a/tests/test_sqlite_sessions_store.py
+++ b/tests/test_sqlite_sessions_store.py
@@ -301,6 +301,62 @@ def test_save_state_does_not_relabel_existing_anchor_row_to_different_backend(tm
         service.close()
 
 
+def test_save_state_skips_import_when_archived_row_owns_anchor(tmp_path: Path) -> None:
+    db_path = tmp_path / "vibe.sqlite"
+    service = SQLiteSessionsService(db_path)
+    try:
+        with service.engine.begin() as conn:
+            scope_id = resolve_scope_from_legacy_key(conn, "slack::C123", now="2026-07-28T00:00:00Z")
+            assert scope_id is not None
+            archived_id = create_agent_session_row(
+                conn,
+                scope_id=scope_id,
+                agent_backend="claude",
+                agent_variant="claude",
+                session_anchor="slack_171717.123",
+                native_session_id="archived-native",
+                status="archived",
+                workdir="/tmp",
+                metadata={"legacy_scope_key": "slack::C123"},
+                require_workdir=False,
+            )
+
+        service.save_state(
+            SessionState(
+                session_mappings={
+                    "slack::C123": {
+                        "codex": {
+                            "slack_171717.123": "codex-native",
+                        }
+                    }
+                }
+            )
+        )
+
+        with service.engine.connect() as conn:
+            rows = conn.execute(
+                select(
+                    agent_sessions.c.id,
+                    agent_sessions.c.agent_backend,
+                    agent_sessions.c.agent_variant,
+                    agent_sessions.c.native_session_id,
+                    agent_sessions.c.status,
+                ).where(agent_sessions.c.scope_id == scope_id)
+            ).mappings().all()
+
+        assert rows == [
+            {
+                "id": archived_id,
+                "agent_backend": "claude",
+                "agent_variant": "claude",
+                "native_session_id": "archived-native",
+                "status": "archived",
+            }
+        ]
+    finally:
+        service.close()
+
+
 def test_save_state_allows_legacy_default_anchor_row_to_adopt_imported_backend(tmp_path: Path) -> None:
     db_path = tmp_path / "vibe.sqlite"
     service = SQLiteSessionsService(db_path)

--- a/tests/test_sqlite_sessions_store.py
+++ b/tests/test_sqlite_sessions_store.py
@@ -759,6 +759,53 @@ def test_save_state_adopts_unregistered_custom_variant_on_concrete_backend_senti
         service.close()
 
 
+def test_save_state_rejects_unresolved_variant_that_contradicts_durable_identity(tmp_path: Path) -> None:
+    db_path = tmp_path / "vibe.sqlite"
+    service = SQLiteSessionsService(db_path)
+    try:
+        with service.engine.begin() as conn:
+            scope_id = resolve_scope_from_legacy_key(conn, "slack::C123", now="2026-07-28T00:00:00Z")
+            assert scope_id is not None
+            session_id = create_agent_session_row(
+                conn,
+                scope_id=scope_id,
+                agent_backend="codex",
+                agent_variant="default",
+                session_anchor="slack_171717.123",
+                native_session_id="",
+                workdir="/tmp",
+                agent_id="agent-reviewer-deleted",
+                agent_name="Reviewer",
+                metadata={"legacy_scope_key": "slack::C123"},
+                require_workdir=False,
+            )
+
+        service.save_state(
+            SessionState(
+                session_mappings={
+                    "slack::C123": {
+                        "writer": {
+                            "slack_171717.123": "writer-native",
+                        },
+                        "reviewer": {
+                            "slack_171717.123": "reviewer-native",
+                        },
+                    }
+                }
+            )
+        )
+
+        row = service.get_agent_session_by_id(session_id)
+        assert row is not None
+        assert row["agent_backend"] == "codex"
+        assert row["agent_variant"] == "reviewer"
+        assert row["agent_id"] == "agent-reviewer-deleted"
+        assert row["agent_name"] == "Reviewer"
+        assert row["native_session_id"] == "reviewer-native"
+    finally:
+        service.close()
+
+
 @pytest.mark.parametrize("legacy_backend", ["default", "unknown"])
 def test_save_state_preserves_durable_agent_identity_on_legacy_backend(
     tmp_path: Path, legacy_backend: str
@@ -866,6 +913,100 @@ def test_save_state_sets_registered_custom_agent_identity_on_existing_owned_row(
         service.close()
 
 
+def test_save_state_identity_backfill_loses_concurrent_route_claim(tmp_path: Path) -> None:
+    db_path = tmp_path / "vibe.sqlite"
+    service = SQLiteSessionsService(db_path)
+    race_fired = 0
+    anchor_snapshot_prefix = (
+        "SELECT agent_sessions.id, agent_sessions.agent_backend, agent_sessions.agent_variant, "
+        "agent_sessions.agent_id, agent_sessions.agent_name, agent_sessions.native_session_id"
+    )
+
+    def claim_route_after_snapshot(
+        _conn: object,
+        _cursor: object,
+        statement: str,
+        _parameters: object,
+        _context: object,
+        _executemany: object,
+    ) -> None:
+        nonlocal race_fired
+        if race_fired or not " ".join(statement.split()).startswith(anchor_snapshot_prefix):
+            return
+        race_fired += 1
+        other = create_sqlite_engine(db_path)
+        try:
+            with other.begin() as other_conn:
+                other_conn.execute(
+                    agent_sessions.update()
+                    .where(agent_sessions.c.id == session_id)
+                    .values(agent_backend="opencode", agent_variant="writer")
+                )
+        finally:
+            other.dispose()
+
+    try:
+        with service.engine.begin() as conn:
+            scope_id = resolve_scope_from_legacy_key(conn, "slack::C123", now="2026-07-28T00:00:00Z")
+            assert scope_id is not None
+            conn.execute(
+                agents.insert().values(
+                    id="agent-reviewer",
+                    name="reviewer",
+                    normalized_name="reviewer",
+                    description=None,
+                    backend="codex",
+                    model=None,
+                    reasoning_effort=None,
+                    system_prompt=None,
+                    enabled=1,
+                    source="user",
+                    source_ref=None,
+                    metadata_json="{}",
+                    created_at="2026-07-28T00:00:00Z",
+                    updated_at="2026-07-28T00:00:00Z",
+                )
+            )
+            session_id = create_agent_session_row(
+                conn,
+                scope_id=scope_id,
+                agent_backend="codex",
+                agent_variant="reviewer",
+                session_anchor="slack_171717.123",
+                native_session_id="",
+                workdir="/tmp",
+                metadata={"legacy_scope_key": "slack::C123"},
+                require_workdir=False,
+            )
+
+        event.listen(service.engine, "after_cursor_execute", claim_route_after_snapshot)
+        try:
+            service.save_state(
+                SessionState(
+                    session_mappings={
+                        "slack::C123": {
+                            "reviewer": {
+                                "slack_171717.123": "reviewer-native",
+                            }
+                        }
+                    }
+                )
+            )
+        finally:
+            event.remove(service.engine, "after_cursor_execute", claim_route_after_snapshot)
+
+        row = service.get_agent_session_by_id(session_id)
+        assert race_fired == 1
+        assert row is not None
+        assert row["agent_backend"] == "opencode"
+        assert row["agent_variant"] == "writer"
+        assert row["agent_id"] is None
+        assert row["agent_name"] is None
+        assert row["native_session_id"] == ""
+    finally:
+        service.close()
+
+
 def test_save_state_accepts_matching_agent_identity_across_variant_aliases(tmp_path: Path) -> None:
     db_path = tmp_path / "vibe.sqlite"
     service = SQLiteSessionsService(db_path)
@@ -900,7 +1041,7 @@ def test_save_state_accepts_matching_agent_identity_across_variant_aliases(tmp_p
                 native_session_id="",
                 workdir="/tmp",
                 agent_id="agent-reviewer",
-                agent_name="reviewer",
+                agent_name="Reviewer",
                 metadata={"legacy_scope_key": "slack::C123"},
                 require_workdir=False,
             )
@@ -920,7 +1061,7 @@ def test_save_state_accepts_matching_agent_identity_across_variant_aliases(tmp_p
         row = service.get_agent_session_by_id(session_id)
         assert row is not None
         assert row["agent_id"] == "agent-reviewer"
-        assert row["agent_name"] == "reviewer"
+        assert row["agent_name"] == "Reviewer"
         assert row["agent_backend"] == "codex"
         assert row["agent_variant"] == "codex"
         assert row["native_session_id"] == "reviewer-native"

--- a/tests/test_sqlite_sessions_store.py
+++ b/tests/test_sqlite_sessions_store.py
@@ -242,6 +242,62 @@ def test_sqlite_sessions_service_updates_logical_agent_session_on_save(tmp_path:
         service.close()
 
 
+def test_save_state_does_not_relabel_existing_anchor_row_to_different_backend(tmp_path: Path) -> None:
+    db_path = tmp_path / "vibe.sqlite"
+    service = SQLiteSessionsService(db_path)
+    try:
+        with service.engine.begin() as conn:
+            scope_id = resolve_scope_from_legacy_key(conn, "slack::C123", now="2026-07-28T00:00:00Z")
+            assert scope_id is not None
+            session_id = create_agent_session_row(
+                conn,
+                scope_id=scope_id,
+                agent_backend="claude",
+                agent_variant="claude",
+                session_anchor="slack_171717.123",
+                native_session_id="claude-native",
+                model="claude-sonnet-4-6",
+                reasoning_effort="high",
+                workdir="/tmp",
+                metadata={
+                    "legacy_scope_key": "slack::C123",
+                    "explicit_setting_overrides": {
+                        "model": True,
+                        "reasoning_effort": True,
+                    },
+                },
+                require_workdir=False,
+            )
+
+        service.save_state(
+            SessionState(
+                session_mappings={
+                    "slack::C123": {
+                        "codex": {
+                            "slack_171717.123": "codex-native",
+                        }
+                    }
+                }
+            )
+        )
+
+        row = service.get_agent_session_by_id(session_id)
+        assert row is not None
+        assert row["agent_backend"] == "claude"
+        assert row["agent_variant"] == "claude"
+        assert row["native_session_id"] == "claude-native"
+        assert row["model"] == "claude-sonnet-4-6"
+        assert row["reasoning_effort"] == "high"
+        assert row["metadata"]["explicit_setting_overrides"] == {
+            "model": True,
+            "reasoning_effort": True,
+        }
+        assert service.load_state().session_mappings["slack::C123"]["claude"]["slack_171717.123"] == "claude-native"
+        assert "codex" not in service.load_state().session_mappings["slack::C123"]
+    finally:
+        service.close()
+
+
 def test_sqlite_sessions_service_reserves_then_binds_agent_session_id(tmp_path: Path) -> None:
     db_path = tmp_path / "vibe.sqlite"
     service = SQLiteSessionsService(db_path)


### PR DESCRIPTION
Closes #1076

## Summary

- capability: preserve existing backend, custom-variant, native-session, and durable Agent identity ownership when legacy session import hits an existing `(scope, anchor)` row
- user-visible change: legacy import no longer relabels an existing session or replaces a selected Agent because another mapping appeared first; unresolved custom variants can still adopt compatible placeholder rows
- motivation: prevent mixed session rows where ownership changes while the native session or backend-owned route settings still belong to the previous owner

## Scenario Coverage

- scenario IDs: none
- unit / contract coverage: regression coverage for conflicting legacy imports, archived-anchor preservation, `default` / `unknown` / empty sentinels, durable and placeholder Agent identities, stable IDs with stale names, normalized variant/name aliases, identity-first owner matching, catalog-resolved owner lookahead, scope-level owner-index performance, unresolved variant conflicts, matching identity across variant aliases, concrete-backend sentinel variants, same- and cross-backend reservation adoption, owner-change route-field reconciliation, import ordering, and real two-connection route/native-binding ownership races
- static coverage: guard for the `save_state()` upsert `set_=` clause
- scenario coverage: none
- residual manual checks: none; this is a hermetic SQLite legacy-import path

## Validation

- `uvx ruff check storage/sessions_service.py tests/test_sqlite_sessions_store.py`
- `.venv/bin/python -m pytest -q tests/test_sqlite_sessions_store.py tests/test_session_route_writer_policy.py`
- result: Ruff passed; 118 tests passed

## Risks / Follow-ups

- risk: this preserves bound or matching-owner sessions on conflict; an unbound cross-backend reservation is adoptable only when the legacy state has no mapping for its reserved owner
- follow-up: if maintainers want legacy import to override durable ownership, that should be a separate change with full backend-owned route reconciliation
