### PR TITLE
fix(apps): merge mobile appearance into more

### DIFF
--- a/ui/src/components/apps/MobileDockDrawer.tsx
+++ b/ui/src/components/apps/MobileDockDrawer.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useRef, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import { LayoutGrid, Minus, MoreHorizontal, PinOff, Settings, Sun, UserRound, X } from 'lucide-react';
+import { LayoutGrid, Minus, MoreHorizontal, PinOff, Settings, UserRound, X } from 'lucide-react';
 
 import { APP_REGISTRY, type AppDefinition, type AppId } from '../../apps/registry';
 import { showPageAvatar, showPageIconUrl } from '../../apps/showPageAvatar';
@@ -25,7 +25,7 @@ type ResidentTile =
   | { kind: 'builtin'; id: string; def: AppDefinition }
   | { kind: 'showpage'; id: string; sessionId: string; title: string; iconVersion: string | null };
 
-type FooterSheet = 'account' | 'appearance' | 'more';
+type FooterSheet = 'account' | 'more';
 
 export const MobileDockDrawer: React.FC<{ open: boolean; onClose: () => void }> = ({ open, onClose }) => {
   const { t } = useTranslation();
@@ -39,7 +39,7 @@ export const MobileDockDrawer: React.FC<{ open: boolean; onClose: () => void }> 
   // isn't used here — its close backdrop is z-40, below this z-50 drawer, so taps
   // outside the menu would fall through to the tiles instead of dismissing it.
   const [menu, setMenu] = useState<{ item: ResidentTile; label: string } | null>(null);
-  // Which footer overflow sheet is open (账号 / 外观 / 更多) — one reusable shell.
+  // Which footer overflow sheet is open (账号 / 更多) — one reusable shell.
   const [sheet, setSheet] = useState<FooterSheet | null>(null);
 
   // Long-press detection: a press-hold opens the manage menu and suppresses the
@@ -108,7 +108,6 @@ export const MobileDockDrawer: React.FC<{ open: boolean; onClose: () => void }> 
 
   const sheetTitle: Record<FooterSheet, string> = {
     account: t('more.account'),
-    appearance: t('more.appearance'),
     more: t('nav.more'),
   };
 
@@ -221,8 +220,9 @@ export const MobileDockDrawer: React.FC<{ open: boolean; onClose: () => void }> 
           </button>
         )}
 
-        {/* Footer chip row — the absorbed More-page content. 设置 navigates; the
-            rest open a small overflow sheet. */}
+        {/* Footer chip row — the absorbed More-page content. 设置 navigates; 账号
+            and 更多 open a small overflow sheet. Appearance lives inside 更多 so
+            the three English labels fit without truncation. */}
         <div className="mt-4 flex items-stretch gap-2 border-t border-border pt-3">
           <Link to="/admin/dashboard" onClick={onClose} className={chipClass}>
             <Settings className="size-4 shrink-0" />
@@ -234,10 +234,6 @@ export const MobileDockDrawer: React.FC<{ open: boolean; onClose: () => void }> 
               <span className="truncate">{t('more.account')}</span>
             </button>
           )}
-          <button type="button" onClick={() => setSheet('appearance')} className={chipClass}>
-            <Sun className="size-4 shrink-0" />
-            <span className="truncate">{t('more.appearance')}</span>
-          </button>
           <button type="button" onClick={() => setSheet('more')} className={chipClass}>
             <MoreHorizontal className="size-4 shrink-0" />
             <span className="truncate">{t('nav.more')}</span>
@@ -287,7 +283,7 @@ export const MobileDockDrawer: React.FC<{ open: boolean; onClose: () => void }> 
         </div>
       )}
 
-      {/* Footer overflow sheet (账号 / 外观 / 更多) — a focused bottom modal above
+      {/* Footer overflow sheet (账号 / 更多) — a focused bottom modal above
           the drawer. Backdrop closes only the sheet, returning to the drawer. */}
       {sheet && (
         <div className="fixed inset-0 z-[60]" role="dialog" aria-modal="true">
@@ -312,8 +308,12 @@ export const MobileDockDrawer: React.FC<{ open: boolean; onClose: () => void }> 
             </div>
             <div className="pt-2">
               {sheet === 'account' && <MoreAccountSection />}
-              {sheet === 'appearance' && <MoreAppearanceSection />}
-              {sheet === 'more' && <MoreConnectionSection />}
+              {sheet === 'more' && (
+                <div className="flex flex-col gap-3">
+                  <MoreAppearanceSection />
+                  <MoreConnectionSection />
+                </div>
+              )}
             </div>
           </div>
         </div>

--- a/ui/src/components/workbench/MorePage.tsx
+++ b/ui/src/components/workbench/MorePage.tsx
@@ -13,11 +13,12 @@ import { VersionBadge } from '../VersionBadge';
 // The former mobile "More" page has been absorbed into the mobile Dock drawer
 // (§7.1b): its Apps list is now the drawer's tile grid, its Control Panel bridge
 // is the drawer's 设置 chip, and the remaining bits — appearance, account, and the
-// read-only connection/status — are these three reusable sections, surfaced from
-// the drawer footer chips. Extracting them keeps the capability intact while the
-// `/more` route retires (redirects home). No standalone page component remains.
+// read-only connection/status — are these three reusable sections. Account has a
+// footer chip; appearance and connection share the 更多 sheet. Extracting them
+// keeps the capability intact while the `/more` route retires (redirects home).
+// No standalone page component remains.
 
-/** Appearance controls (theme + language). The drawer's 外观 chip. */
+/** Appearance controls (theme + language). Shown inside the drawer's 更多 sheet. */
 export const MoreAppearanceSection: React.FC = () => {
   const { t } = useTranslation();
   return (
@@ -63,8 +64,8 @@ export const MoreAccountSection: React.FC = () => {
   );
 };
 
-/** Read-only service status + version, plus the host address. The drawer's 更多
- *  overflow — everything that didn't earn its own chip. */
+/** Read-only service status + version, plus the host address. Shown after
+ *  appearance inside the drawer's 更多 sheet. */
 export const MoreConnectionSection: React.FC = () => {
   const { t } = useTranslation();
   const { status } = useStatus();


### PR DESCRIPTION
## Summary

- reduce the signed-in mobile Dock footer from four actions to three: Settings, Account, and More
- move appearance controls into the More sheet above connection and runtime status
- preserve the local signed-out layout, where only Settings and More are shown

## Evidence

- Unit: `npm test` (70 files, 631 tests)
- Contract: not applicable; no API, persistence, route, or i18n contract changed
- Scenario: no cataloged scenario IDs are affected by this presentation-only change
- Build: `npm run build`
- Lint: ESLint passed for both changed components
- Manual: verified at 390x844 in English for signed-in and signed-out states; all footer labels fit without overflow, and the More sheet contains Appearance plus runtime status

## Dependencies

None.

## Residual Checks

- A real authenticated remote-session regression was not rerun; the signed-in visual state was exercised with a browser-only intercepted session response, without changing backend state.

## Known By Design

- Account remains hidden for local or unauthenticated sessions, leaving a two-action Settings / More footer.
