### PR TITLE
fix(harness): bound long run detail titles

### DIFF
--- a/ui/src/components/workbench/HarnessPage.test.tsx
+++ b/ui/src/components/workbench/HarnessPage.test.tsx
@@ -7,7 +7,14 @@ import { describe, expect, it } from 'vitest';
 
 import en from '../../i18n/en.json';
 import type { HarnessRun, HarnessSessionSummary, HarnessWatch } from '../../context/ApiContext';
-import { DetailSession, RunTriggerChip, WatchDetail, harnessEmptyStateKey, harnessTabFromParam } from './HarnessPage';
+import {
+  DetailSession,
+  RunDetail,
+  RunTriggerChip,
+  WatchDetail,
+  harnessEmptyStateKey,
+  harnessTabFromParam,
+} from './HarnessPage';
 import { RUN_TYPES, harnessSessionState, runRowTitle, runStatusLabel, runTypeLabel, runTypeOptions } from './harnessRuns';
 
 const i18n = createInstance();
@@ -147,6 +154,18 @@ describe('runRowTitle', () => {
   it('never slices the title — truncation is the row layout\'s job', () => {
     const long = 'x'.repeat(400);
     expect(runRowTitle({ message: long, prompt: null, definition_name: null }, 'Agent run')).toBe(long);
+  });
+});
+
+describe('RunDetail title', () => {
+  it('bounds a pathological title while preserving the complete message', () => {
+    const message = `Fix the parser regression.\\n\\n${'Preserve every trailing constraint. '.repeat(40)}`;
+    const html = render(<RunDetail run={run({ message })} />);
+
+    expect(html).toContain('line-clamp-2');
+    expect(html).toContain('break-words');
+    expect(html).toContain(`title="${message.trim()}"`);
+    expect(html).toContain(message);
   });
 });
 

--- a/ui/src/components/workbench/HarnessPage.tsx
+++ b/ui/src/components/workbench/HarnessPage.tsx
@@ -1507,17 +1507,21 @@ interface RunDetailProps {
   run: HarnessRun;
 }
 
-const RunDetail: React.FC<RunDetailProps> = ({ run }) => {
+export const RunDetail: React.FC<RunDetailProps> = ({ run }) => {
   const { t } = useTranslation();
   const typeLabel = runTypeLabel(run.run_type || run.request_type, t);
+  const title = runRowTitle(run, typeLabel);
   return (
     <div className="flex flex-col gap-4">
       <div className="flex items-start gap-2">
         <span className="mt-0.5">
           <RunStatusIcon status={run.status} />
         </span>
-        <span className="min-w-0 flex-1 text-[13px] font-semibold text-foreground">
-          {runRowTitle(run, typeLabel)}
+        <span
+          className="line-clamp-2 min-w-0 flex-1 break-words text-[13px] font-semibold text-foreground"
+          title={title}
+        >
+          {title}
         </span>
         <span
           className={clsx(


### PR DESCRIPTION
## What

- clamp Harness Run detail headings to two lines
- allow long unbroken words to wrap within the detail column
- preserve the complete derived title in the native tooltip and the complete prompt in the Message field
- add a regression test for a long single-line prompt containing literal `\n` sequences

## Why

Run `b83477d6ed6a` stored literal `\n` characters instead of real newlines. The title mapper correctly preserved that input, but the selected Run detail rendered the resulting multi-kilobyte title without a visual bound and expanded the panel.

This fix constrains presentation without unescaping or slicing stored text, so code samples containing literal `\n` remain faithful and Harness search semantics stay unchanged.

## Evidence

- Unit: `npx vitest run src/components/workbench/HarnessPage.test.tsx` (32 passed)
- Contract: full title remains available through `title`; full message remains in the Message field
- UI suite: `npm test` (86 files, 870 tests passed)
- Build: `npm run build`
- Scenario: no catalog change; the HFR catalog covers runtime recovery rather than bounded visual presentation
- Residual manual: browser check of the selected Run detail at desktop and mobile widths

## Lint

`npm run lint -- --max-warnings=0` remains blocked by the repository baseline (403 existing problems). The changed files report no errors on the changed lines.
