### PR TITLE
feat(model-hub): expose explicit model selection

### DIFF
--- a/core/handlers/model_hub/service.py
+++ b/core/handlers/model_hub/service.py
@@ -2106,6 +2106,7 @@ class ModelHubService:
             if agent.mode == "hub"
             else None
         )
+        selected_model_explicit = agent.mode == "hub" and bool(requested_model)
         current_chain_source_ids = {
             source.id
             for source in resolution.matching_sources
@@ -2170,6 +2171,7 @@ class ModelHubService:
             **agent.to_payload(),
             "selected_by_agent": selected_by_agent,
             "selected_model_id": selected_model_id,
+            "selected_model_explicit": selected_model_explicit,
             "current": current,
             "sources": sources,
             "supply_status": (

--- a/docs/plans/model-hub-contracts/agent-supply.schema.json
+++ b/docs/plans/model-hub-contracts/agent-supply.schema.json
@@ -23,6 +23,7 @@
       "description": "v2 (07-29, review round 3): THE SELECTED MODEL of the route named by `selected_by_agent`, as the caller-facing MENU identifier — the built-in id for fixed menus, the prefixed vendor/model id for open menus. NOT a backend-wide fact (grain corrected 07-29, review round 4): it is the routed Vibe Agent's `model`, falling back to the backend default when that Agent pins none, and a different enabled Agent on the same backend can request a different model on its very next turn. Every projection below that depends on a model — `current`, `supply_status`, and the probe's default — therefore inherits that scope and answers for this route alone. Hoisted out of `current` in round 3, where round 2 had put it as `menu_model_id`. The bug was not merely that the selection was nested: `current` is null whenever nothing is runnable (`waiting` / `interrupted`), so the selection vanished from the payload in exactly the two states where the UI needs it most — 「当前无可用来源」 has to name the model it is talking about, the chain drill-in has to query one, and the probe has to default to one. A client would have had to remember the last non-null `current` and hope, or issue a second call. The two fields answer different questions and have different lifetimes: this one is a persisted user CHOICE that survives every supply state, while `current` is a momentary fact about the next turn. Nesting a choice inside a fact made the choice inherit the fact's nullability. null only when mode=direct (no hub selection exists). OPTIONAL here / required at the API boundary once the serializer emits it (README → required-vs-optional). Absent from this file's `examples` on purpose — they round-trip byte-faithfully through the shipped v1 serializer, which has no such field; the worked v2 payload including the `current: null` case lives in api.md.",
       "examples": ["claude-opus-4-6", "zhipuai/glm-5.2"]
     },
+    "selected_model_explicit": { "type": "boolean", "description": "TRUE iff `selected_model_id` originates from the user's explicit configuration request; FALSE means no explicit model selection, including a resolver-picked value or no selected model." },
     "current": {
       "type": ["object", "null"],
       "description": "What the next turn of THIS ROUTE would use (frame V6 01 supply row) — i.e. the first runnable candidate in this backend's chain for `selected_model_id`, which is the model of the Agent named by `selected_by_agent`. Inherits that grain: a different enabled Vibe Agent on the same backend requesting a different model has a different chain, and this field does not describe it (round 4). NULL IN THREE CASES, not one: (a) mode=direct; (b) `supply_status: \"waiting\"` — every candidate is cooling; (c) `supply_status: \"interrupted\"` — no candidate can recover unattended. In (b) and (c) the serializer MUST emit null rather than the last-used source: a stale `current` would render 使用中 for a source that will not be called, which is exactly the lie the taxonomy exists to prevent. Non-null ⇒ `supply_status` is ok or degraded. Carries only facts about that candidate — the selection itself is `selected_model_id`, one level up, because it outlives every one of these three nulls.",
@@ -273,6 +274,19 @@
           "selected_by_agent": { "type": "null" },
           "current": { "type": "null" },
           "supply_status": { "type": "null" }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": { "selected_model_explicit": { "const": true } },
+        "required": ["selected_model_explicit"]
+      },
+      "then": {
+        "required": ["mode", "selected_model_id"],
+        "properties": {
+          "mode": { "const": "hub" },
+          "selected_model_id": { "type": "string" }
         }
       }
     },

--- a/docs/plans/model-hub-contracts/api.md
+++ b/docs/plans/model-hub-contracts/api.md
@@ -71,6 +71,7 @@ Each backend entry on `GET /api/models/agents` carries the v3 API-boundary keys:
   "mode": "hub",
   "selected_by_agent": "pm",
   "selected_model_id": "claude-opus-4-6",
+  "selected_model_explicit": true,
   "current": {
     "model_id": "claude-opus-4-6",
     "source_id": "src_anthkey01",
@@ -128,6 +129,10 @@ default. `supply_status` is derived independently for that effective model. The
 list name and object shape are intentionally distinct from `SupplyGap.agents`,
 which is a list of bare names inside a mutation result.
 
+`selected_model_explicit` is TRUE iff `selected_model_id` originates from the
+user's explicit configuration request. FALSE means no explicit model selection,
+including a resolver-picked value or no selected model.
+
 Disabled Agents are absent. In Direct mode each named Agent may still have an
 effective model, but its Hub `supply_status` is null.
 
@@ -156,6 +161,7 @@ backend configuration pins a model:
   "mode": "hub",
   "selected_by_agent": null,
   "selected_model_id": null,
+  "selected_model_explicit": false,
   "current": null,
   "supply_status": null
 }
@@ -620,7 +626,7 @@ contract harness and API-boundary tests enforce:
 | probe `source_id` names an existing source | probe assembler |
 | non-null event endpoints name existing sources at emission time | event emitter |
 | `channel_switch.from_source == channel_switch.to_source` | event emitter |
-| API AgentSupply includes `selected_by_agent`, `selected_model_id`, `sources`, `supply_status`, `model_supply`, and `named_agents`; source creation returns both `adopted_by` and `skipped_by` | API payload test |
+| API AgentSupply includes `selected_by_agent`, `selected_model_id`, `selected_model_explicit`, `sources`, `supply_status`, `model_supply`, and `named_agents`; source creation returns both `adopted_by` and `skipped_by` | API payload test |
 | every OAuthFlow response includes `intent` | API payload test |
 | contract and in-repo adapter interface copies are byte-identical; the five retained-material enum members and ref-pairing predicates are mutation-tested | contract harness |
 

--- a/tests/test_model_hub_api.py
+++ b/tests/test_model_hub_api.py
@@ -849,6 +849,7 @@ def test_model_hub_rest_api_contract(monkeypatch, tmp_path):
         assert {
             "selected_by_agent",
             "selected_model_id",
+            "selected_model_explicit",
             "current",
             "sources",
             "supply_status",

--- a/tests/test_model_hub_config.py
+++ b/tests/test_model_hub_config.py
@@ -313,6 +313,7 @@ def test_v4_shape_amendments_reject_the_false_states_they_replace():
         "menu_kind": "fixed",
         "selected_by_agent": None,
         "selected_model_id": None,
+        "selected_model_explicit": False,
         "current": None,
         "sources": {"policy": "follow", "order": [], "eligibility": []},
         "supply_status": None,
@@ -336,6 +337,13 @@ def test_v4_shape_amendments_reject_the_false_states_they_replace():
     }
     with pytest.raises(ValidationError):
         supply_validator.validate(invented)
+
+    invalid_explicitness = {
+        **base_supply,
+        "selected_model_explicit": True,
+    }
+    with pytest.raises(ValidationError):
+        supply_validator.validate(invalid_explicitness)
 
     invalid_reason = copy.deepcopy(base_supply)
     invalid_reason["sources"]["eligibility"] = [

--- a/tests/test_model_hub_resolution.py
+++ b/tests/test_model_hub_resolution.py
@@ -663,6 +663,48 @@ def test_opencode_provider_prefix_selects_matching_source_and_current_payload(tm
     assert config.sources[0].state.status == "cooldown"
 
 
+def test_opencode_agent_supply_distinguishes_explicit_pin_from_resolver_pick(tmp_path):
+    service = _service(tmp_path, FakeAdapter([]))
+    service.store.load().agents["opencode"].menu.checked = [
+        "anthropic/claude-opus-4-6"
+    ]
+
+    resolver_picked = service.get_agent_sources("opencode")
+
+    assert resolver_picked["selected_model_id"] == "anthropic/claude-opus-4-6"
+    assert resolver_picked["selected_model_explicit"] is False
+
+    service.requested_model_override = lambda backend: (
+        "anthropic/claude-opus-4-6" if backend == "opencode" else None
+    )
+    explicit_pin = service.get_agent_sources("opencode")
+
+    assert explicit_pin["selected_model_id"] == "anthropic/claude-opus-4-6"
+    assert explicit_pin["selected_model_explicit"] is True
+
+
+@pytest.mark.parametrize(
+    ("requested_model", "expected_model", "expected_explicit"),
+    [
+        ("claude-opus-4-6", "claude-opus-4-6", True),
+        ("", None, False),
+    ],
+)
+def test_fixed_menu_agent_supply_marks_only_configured_selection_explicit(
+    tmp_path,
+    requested_model,
+    expected_model,
+    expected_explicit,
+):
+    service = _service(tmp_path, FakeAdapter([]))
+    service.store.requested_models["claude"] = requested_model
+
+    agent = service.get_agent_sources("claude")
+
+    assert agent["selected_model_id"] == expected_model
+    assert agent["selected_model_explicit"] is expected_explicit
+
+
 def test_opencode_unknown_vendor_uses_custom_provider_identifier(tmp_path):
     adapter = FakeAdapter([_outcome(RawOutcomeKind.SUCCESS, status=200)])
     service = _service(tmp_path, adapter)


### PR DESCRIPTION
## Summary

- Add `selected_model_explicit` beside `selected_model_id` on every AgentSupply payload.
- Report true for a model supplied by an explicit configuration request and false for an OpenCode resolver pick or no explicit selection.
- Add the authorized additive contract field and API serializer-completeness guard.

## Scenarios

- MH-OC-001
- MH-CHAN-001

## Evidence

- Unit: Model Hub config/API/resolution trio, 239 passed.
- Contract: AgentSupply schema and API boundary updated; contract harness included in the trio.
- Scenario: Model Hub scenarios, 54 passed.
- Static: Ruff and `git diff --check` passed.
- Residual manual: none; L5 UI consumption remains outside this server-only PR.

## Dependencies

- None.

## Known By Design / Decision Ledger

- Owner-vetoable: orchestrator-authorized targeted additive contract field from L5's #1101 escalation. At master `829a9ad1`, `resolver.py:171-181` health-picks an OpenCode candidate when the configuration request is empty, while `resolver.py:191-201` only normalizes a non-empty explicit request. The payload now exposes that provenance without consulting health in the UI.
- Owner-vetoable: `selected_model_explicit` is derived only at the AgentSupply boundary and is not persisted; no vocabulary or mirror-registry row is added because the registry does not track payload field names.
- Owner-vetoable review clarification: false means no explicit model selection, covering resolver-picked and absent values; the schema rejects true unless Hub mode carries a non-null selected model.
