### PR TITLE
fix(show): align launch and window controls

### DIFF
--- a/ui/src/components/apps/AppWindow.tsx
+++ b/ui/src/components/apps/AppWindow.tsx
@@ -312,6 +312,7 @@ export const AppWindow: React.FC<{
               onPointerDown={(e) => e.stopPropagation()}
               onClick={(e) => e.stopPropagation()}
               onDoubleClick={(e) => e.stopPropagation()}
+              className="flex size-6 shrink-0 items-center justify-center"
             >
               <ShowPageAnnotateControl
                 compact

--- a/ui/src/components/workbench/ShowPageAnnotateControl.test.tsx
+++ b/ui/src/components/workbench/ShowPageAnnotateControl.test.tsx
@@ -33,5 +33,7 @@ describe('ShowPageAnnotateControl compact presentation', () => {
 
     expect(html.match(/<button/g)).toHaveLength(1);
     expect(html).toContain('aria-label="Annotate"');
+    expect(html).toContain('text-muted');
+    expect(html).toContain('hover:text-foreground');
   });
 });

--- a/ui/src/components/workbench/ShowPageAnnotateControl.tsx
+++ b/ui/src/components/workbench/ShowPageAnnotateControl.tsx
@@ -128,7 +128,11 @@ export const ShowPageAnnotateControl: React.FC<ShowPageAnnotateControlProps> = (
         type="button"
         variant={compact ? 'ghost' : 'outline'}
         size="icon"
-        className={clsx(compact ? 'size-6 shrink-0 border-0 shadow-none' : 'size-7 shrink-0')}
+        className={clsx(
+          compact
+            ? 'size-6 shrink-0 rounded-md border-0 text-muted shadow-none hover:bg-foreground/[0.06] hover:text-foreground'
+            : 'size-7 shrink-0',
+        )}
         disabled
         aria-label={t('chat.showPage.annotate.unavailable')}
         title={t('chat.showPage.annotate.unavailable')}
@@ -205,9 +209,13 @@ export const ShowPageAnnotateControl: React.FC<ShowPageAnnotateControlProps> = (
           <PopoverTrigger asChild>
             <Button
               type="button"
-              variant={enabled ? 'default' : compact ? 'ghost' : 'outline'}
+              variant={compact ? 'ghost' : enabled ? 'default' : 'outline'}
               size="icon"
-              className={clsx(compact ? 'size-6 shrink-0 rounded-md' : 'size-7 shrink-0')}
+              className={clsx(
+                compact
+                  ? 'size-6 shrink-0 rounded-md text-muted hover:bg-foreground/[0.06] hover:text-foreground'
+                  : 'size-7 shrink-0',
+              )}
               aria-label={toggleLabel}
               title={toggleLabel}
             >

--- a/ui/src/components/workbench/ShowPageLaunchControl.tsx
+++ b/ui/src/components/workbench/ShowPageLaunchControl.tsx
@@ -1,12 +1,10 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import {
   AppWindow,
-  ChevronRight,
   ExternalLink,
   Loader2,
   MessageSquare,
   Presentation,
-  SquareArrowOutUpRight,
 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
@@ -54,7 +52,6 @@ export const ShowPageLaunchControl: React.FC<ShowPageLaunchControlProps> = ({
   const dock = useDock();
   const { begin: beginShowPageDrag, end: endShowPageDrag } = useShowPageDrag();
   const [menuOpen, setMenuOpen] = useState(false);
-  const [dragCue, setDragCue] = useState<ViewportPoint | null>(null);
   const dragRef = useRef<ActiveDrag | null>(null);
   const suppressClickRef = useRef(false);
   const hoverTimerRef = useRef<number | null>(null);
@@ -145,18 +142,15 @@ export const ShowPageLaunchControl: React.FC<ShowPageLaunchControlProps> = ({
       if (!active) return;
       const target = event.target instanceof Element ? event.target : null;
       if (target?.closest(SHOW_PAGE_DOCK_DROP_SELECTOR)) {
-        setDragCue(null);
         return;
       }
       const point = { x: event.clientX, y: event.clientY };
       if (!isShowPageWindowDrop(active.start, point)) {
-        setDragCue(null);
         if (event.dataTransfer) event.dataTransfer.dropEffect = 'none';
         return;
       }
       event.preventDefault();
       if (event.dataTransfer) event.dataTransfer.dropEffect = 'copy';
-      setDragCue(point);
     };
 
     const onDrop = (event: DragEvent) => {
@@ -168,7 +162,6 @@ export const ShowPageLaunchControl: React.FC<ShowPageLaunchControlProps> = ({
       if (!isShowPageWindowDrop(active.start, point)) return;
       event.preventDefault();
       dragRef.current = null;
-      setDragCue(null);
       endShowPageDrag();
       setGestureActive(false);
       void openWindow(point);
@@ -184,7 +177,6 @@ export const ShowPageLaunchControl: React.FC<ShowPageLaunchControlProps> = ({
 
   const endDrag = () => {
     dragRef.current = null;
-    setDragCue(null);
     endShowPageDrag();
     setGestureActive(false);
     window.setTimeout(() => {
@@ -266,7 +258,7 @@ export const ShowPageLaunchControl: React.FC<ShowPageLaunchControlProps> = ({
           align="end"
           side="bottom"
           sideOffset={6}
-          className="w-44 p-1"
+          className="w-fit min-w-32 p-1"
           onMouseEnter={clearHoverTimer}
           onMouseLeave={closeHoverMenu}
           onOpenAutoFocus={(event) => event.preventDefault()}
@@ -300,35 +292,24 @@ export const ShowPageLaunchControl: React.FC<ShowPageLaunchControlProps> = ({
               type="button"
               role="menuitem"
               onClick={() => void openWindow()}
-              className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-[12.5px] text-foreground transition-colors hover:bg-cyan-soft"
+              className="flex w-full items-center gap-2 whitespace-nowrap rounded-md px-2 py-1.5 text-left text-[12.5px] text-foreground transition-colors hover:bg-cyan-soft"
             >
               <AppWindow className="size-3.5 shrink-0 text-cyan" />
-              <span className="flex-1">{t('chat.showPage.newWindow')}</span>
-              <ChevronRight className="size-3.5 shrink-0 text-muted" />
+              <span>{t('chat.showPage.newWindow')}</span>
             </button>
             <button
               type="button"
               role="menuitem"
               onClick={() => void openLink()}
-              className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-[12.5px] text-foreground transition-colors hover:bg-cyan-soft"
+              className="flex w-full items-center gap-2 whitespace-nowrap rounded-md px-2 py-1.5 text-left text-[12.5px] text-foreground transition-colors hover:bg-cyan-soft"
             >
               <ExternalLink className="size-3.5 shrink-0 text-mint" />
-              <span className="flex-1">{t('chat.showPage.newLink')}</span>
-              <ChevronRight className="size-3.5 shrink-0 text-muted" />
+              <span>{t('chat.showPage.newLink')}</span>
             </button>
           </div>
         </PopoverContent>
       </Popover>
 
-      {dragCue && (
-        <span
-          aria-hidden
-          style={{ left: dragCue.x + 14, top: dragCue.y + 14 }}
-          className="pointer-events-none fixed z-[80] grid size-8 place-items-center rounded-md border border-cyan/60 bg-surface-3 text-cyan shadow-lg"
-        >
-          <SquareArrowOutUpRight className="size-4" />
-        </span>
-      )}
     </>
   );
 };

--- a/ui/src/lib/showPageLaunch.test.ts
+++ b/ui/src/lib/showPageLaunch.test.ts
@@ -27,8 +27,8 @@ describe('isShowPageWindowDrop', () => {
 });
 
 describe('showPageWindowOrigin', () => {
-  it('anchors the title bar near the pointer and keeps it on-screen', () => {
-    expect(showPageWindowOrigin({ x: 420, y: 260 })).toEqual({ x: 384, y: 246 });
+  it('anchors the title bar at the pointer and keeps it on-screen', () => {
+    expect(showPageWindowOrigin({ x: 420, y: 260 })).toEqual({ x: 420, y: 260 });
     expect(showPageWindowOrigin({ x: 4, y: 3 })).toEqual({ x: 8, y: 8 });
   });
 });

--- a/ui/src/lib/showPageLaunch.ts
+++ b/ui/src/lib/showPageLaunch.ts
@@ -11,10 +11,10 @@ export function isShowPageWindowDrop(start: ViewportPoint, current: ViewportPoin
   return current.y - start.y >= SHOW_PAGE_WINDOW_DRAG_THRESHOLD_PX;
 }
 
-/** Put the new window's title bar just above and left of the release point. */
+/** Use the release point as the new window's origin, bounded by the viewport edge. */
 export function showPageWindowOrigin(point: ViewportPoint): ViewportPoint {
   return {
-    x: Math.max(8, Math.round(point.x - 36)),
-    y: Math.max(8, Math.round(point.y - 14)),
+    x: Math.max(8, Math.round(point.x)),
+    y: Math.max(8, Math.round(point.y)),
   };
 }


### PR DESCRIPTION
## What

- replace the lagging custom drag badge with the browser-native copy indicator
- position free-drop Show Page windows at the exact release point
- align the window annotation control with the adjacent title-bar controls
- keep the compact annotation control muted until hover, including its enabled state
- remove trailing chevrons and excess width from the Visualize hover menu

## Why

The native drag preview and the separately rendered React badge used different anchors and update paths, so they visibly drifted apart. The launch helper also offset the resulting window from the release point. In Show Page window chrome, the compact annotation trigger inherited a stronger foreground/default-button treatment and sat inside a baseline-aligned wrapper, making it darker and vertically inconsistent with its neighbors.

## Evidence

- Unit: `npm test -- --run` (94 files, 1179 tests passed)
- Focused: `npx vitest run src/lib/showPageLaunch.test.ts src/components/workbench/ShowPageAnnotateControl.test.tsx` (4 tests passed)
- Contract: free-drop window origin now equals the bounded viewport release point
- UI build: `npm run build`
- Lint: changed TypeScript/TSX files pass ESLint
- Scenario: browser-verified release `(900, 300)` produced final window `left: 900px; top: 300px`; all three title-bar controls measured `24x24` on the same y-axis; menu items render one semantic icon each with content-fit width
- Residual manual checks: native OS drag cursor appearance varies by browser/platform

## Scope

- Follow-up polish for #1109
- No scenario catalog IDs apply to this presentation-only correction
