### PR TITLE
fix(ui): avoid legacy session capability crash

### DIFF
--- a/ui/src/context/ApiContext.tsx
+++ b/ui/src/context/ApiContext.tsx
@@ -12,6 +12,9 @@ import {
   type WorkbenchEventConnectionState,
 } from '../lib/workbenchEventConnection';
 import type { DockDoc } from './DockContext';
+import { normalizeSessionInfo, type InstanceCapabilities, type SessionInfo } from '../lib/sessionInfo';
+
+export type { InstanceCapabilities, SessionInfo };
 
 // The workbench Dock API response shape ({ ok, dock }); the Dock document type
 // itself lives with the DockProvider that owns reconciliation.
@@ -1442,37 +1445,6 @@ export type RunningAgentCounts = {
 export type RunningAgentsResult =
   | { ok: true; agents: RunningAgent[]; counts: RunningAgentCounts; unreachable?: false }
   | { ok: false; unreachable: true; agents: RunningAgent[]; counts: Partial<RunningAgentCounts> };
-
-export type InstanceCapabilities = {
-  is_instance_owner: boolean;
-  can_read_instance: boolean;
-  can_chat: boolean;
-  can_manage_projects: boolean;
-  can_manage_agents: boolean;
-  can_manage_instance: boolean;
-  can_use_agents: boolean;
-  can_use_skills: boolean;
-  can_use_vault_secrets: boolean;
-  can_use_show_pages: boolean;
-  can_use_terminal_files: boolean;
-  can_use_terminal: boolean;
-  can_use_files: boolean;
-  can_use_system: boolean;
-};
-
-export type SessionInfo =
-  | { remote: false; instance_role?: 'owner'; capabilities?: InstanceCapabilities }
-  | { remote: true; authenticated: false; authorization_refresh_required?: boolean }
-  // sub is the stable OIDC subject; prefer it over email for per-account scoping (email can
-  // be absent or shared across subjects).
-  | {
-      remote: true;
-      authenticated: true;
-      email: string;
-      sub?: string;
-      instance_role: 'owner' | 'editor' | 'viewer';
-      capabilities: InstanceCapabilities;
-    };
 
 export type LogEntry = {
   timestamp: string;
@@ -3194,7 +3166,7 @@ export const ApiProvider: React.FC<{ children: React.ReactNode }> = ({ children 
     startRemoteAccess: () => postJson('/api/remote-access/start', {}),
     stopRemoteAccess: () => postJson('/api/remote-access/stop', {}),
     optimizeRemoteAccessRoute: () => postJson('/api/remote-access/optimize-route', {}),
-    getAuthSession: () => getJson('/api/session'),
+    getAuthSession: () => getJson('/api/session').then(normalizeSessionInfo),
     signOut: () => postJson('/auth/logout', {}),
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }), [showToast, t]);

--- a/ui/src/context/InstanceAuthorizationContext.tsx
+++ b/ui/src/context/InstanceAuthorizationContext.tsx
@@ -2,27 +2,10 @@
 import { createContext, useContext, useMemo, type ReactNode } from 'react';
 
 import type { InstanceCapabilities, SessionInfo } from './ApiContext';
-
-const DENIED_CAPABILITIES: InstanceCapabilities = {
-  is_instance_owner: false,
-  can_read_instance: false,
-  can_chat: false,
-  can_manage_projects: false,
-  can_manage_agents: false,
-  can_manage_instance: false,
-  can_use_agents: false,
-  can_use_skills: false,
-  can_use_vault_secrets: false,
-  can_use_show_pages: false,
-  can_use_terminal_files: false,
-  can_use_terminal: false,
-  can_use_files: false,
-  can_use_system: false,
-};
-
-const OWNER_CAPABILITIES: InstanceCapabilities = Object.fromEntries(
-  Object.keys(DENIED_CAPABILITIES).map((key) => [key, true]),
-) as InstanceCapabilities;
+import {
+  DENIED_INSTANCE_CAPABILITIES,
+  OWNER_INSTANCE_CAPABILITIES,
+} from '../lib/sessionInfo';
 
 interface InstanceAuthorizationValue {
   remote: boolean;
@@ -33,7 +16,7 @@ interface InstanceAuthorizationValue {
 const InstanceAuthorizationContext = createContext<InstanceAuthorizationValue>({
   remote: false,
   instanceRole: null,
-  capabilities: DENIED_CAPABILITIES,
+  capabilities: DENIED_INSTANCE_CAPABILITIES,
 });
 
 export const InstanceAuthorizationProvider = ({
@@ -48,11 +31,11 @@ export const InstanceAuthorizationProvider = ({
       return {
         remote: false,
         instanceRole: session.instance_role ?? 'owner',
-        capabilities: session.capabilities ?? OWNER_CAPABILITIES,
+        capabilities: session.capabilities ?? OWNER_INSTANCE_CAPABILITIES,
       };
     }
     if (!session.authenticated) {
-      return { remote: true, instanceRole: null, capabilities: DENIED_CAPABILITIES };
+      return { remote: true, instanceRole: null, capabilities: DENIED_INSTANCE_CAPABILITIES };
     }
     return {
       remote: true,

--- a/ui/src/lib/sessionInfo.test.ts
+++ b/ui/src/lib/sessionInfo.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  DENIED_INSTANCE_CAPABILITIES,
+  normalizeSessionInfo,
+  OWNER_INSTANCE_CAPABILITIES,
+} from './sessionInfo';
+
+describe('normalizeSessionInfo', () => {
+  it('preserves legacy authenticated remote sessions as owners', () => {
+    expect(
+      normalizeSessionInfo({
+        remote: true,
+        authenticated: true,
+        email: 'owner@example.com',
+        sub: 'owner-1',
+      }),
+    ).toEqual({
+      remote: true,
+      authenticated: true,
+      email: 'owner@example.com',
+      sub: 'owner-1',
+      instance_role: 'owner',
+      capabilities: OWNER_INSTANCE_CAPABILITIES,
+    });
+  });
+
+  it('preserves explicit current capabilities without granting missing fields', () => {
+    const session = normalizeSessionInfo({
+      remote: true,
+      authenticated: true,
+      email: 'viewer@example.com',
+      instance_role: 'viewer',
+      capabilities: {
+        can_read_instance: true,
+        can_use_show_pages: true,
+      },
+    });
+
+    expect(session).toEqual({
+      remote: true,
+      authenticated: true,
+      email: 'viewer@example.com',
+      instance_role: 'viewer',
+      capabilities: {
+        ...DENIED_INSTANCE_CAPABILITIES,
+        can_read_instance: true,
+        can_use_show_pages: true,
+      },
+    });
+  });
+
+  it('keeps local sessions owner-compatible when an older server omits capabilities', () => {
+    expect(normalizeSessionInfo({ remote: false })).toEqual({
+      remote: false,
+      instance_role: 'owner',
+      capabilities: OWNER_INSTANCE_CAPABILITIES,
+    });
+  });
+
+  it('fails closed for malformed session payloads', () => {
+    expect(normalizeSessionInfo(null)).toEqual({ remote: true, authenticated: false });
+  });
+});

--- a/ui/src/lib/sessionInfo.ts
+++ b/ui/src/lib/sessionInfo.ts
@@ -1,0 +1,103 @@
+export type InstanceCapabilities = {
+  is_instance_owner: boolean;
+  can_read_instance: boolean;
+  can_chat: boolean;
+  can_manage_projects: boolean;
+  can_manage_agents: boolean;
+  can_manage_instance: boolean;
+  can_use_agents: boolean;
+  can_use_skills: boolean;
+  can_use_vault_secrets: boolean;
+  can_use_show_pages: boolean;
+  can_use_terminal_files: boolean;
+  can_use_terminal: boolean;
+  can_use_files: boolean;
+  can_use_system: boolean;
+};
+
+export type SessionInfo =
+  | { remote: false; instance_role?: 'owner'; capabilities?: InstanceCapabilities }
+  | { remote: true; authenticated: false; authorization_refresh_required?: boolean }
+  | {
+      remote: true;
+      authenticated: true;
+      email: string;
+      sub?: string;
+      instance_role: 'owner' | 'editor' | 'viewer';
+      capabilities: InstanceCapabilities;
+    };
+
+export const DENIED_INSTANCE_CAPABILITIES: InstanceCapabilities = {
+  is_instance_owner: false,
+  can_read_instance: false,
+  can_chat: false,
+  can_manage_projects: false,
+  can_manage_agents: false,
+  can_manage_instance: false,
+  can_use_agents: false,
+  can_use_skills: false,
+  can_use_vault_secrets: false,
+  can_use_show_pages: false,
+  can_use_terminal_files: false,
+  can_use_terminal: false,
+  can_use_files: false,
+  can_use_system: false,
+};
+
+export const OWNER_INSTANCE_CAPABILITIES: InstanceCapabilities = Object.fromEntries(
+  Object.keys(DENIED_INSTANCE_CAPABILITIES).map((key) => [key, true]),
+) as InstanceCapabilities;
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const normalizeCapabilities = (value: Record<string, unknown>): InstanceCapabilities =>
+  Object.fromEntries(
+    Object.keys(DENIED_INSTANCE_CAPABILITIES).map((key) => [key, value[key] === true]),
+  ) as InstanceCapabilities;
+
+export const normalizeSessionInfo = (value: unknown): SessionInfo => {
+  if (!isRecord(value)) return { remote: true, authenticated: false };
+
+  if (value.remote === false) {
+    return {
+      remote: false,
+      instance_role: 'owner',
+      capabilities: OWNER_INSTANCE_CAPABILITIES,
+    };
+  }
+
+  if (value.remote !== true || value.authenticated !== true) {
+    return {
+      remote: true,
+      authenticated: false,
+      ...(value.authorization_refresh_required === true
+        ? { authorization_refresh_required: true }
+        : {}),
+    };
+  }
+
+  const rawCapabilities = isRecord(value.capabilities) ? value.capabilities : null;
+  // Releases before instance roles treated every authenticated remote user as
+  // the instance owner and did not return a capabilities object.
+  const capabilities = rawCapabilities
+    ? normalizeCapabilities(rawCapabilities)
+    : OWNER_INSTANCE_CAPABILITIES;
+  const instanceRole =
+    value.instance_role === 'owner' ||
+    value.instance_role === 'editor' ||
+    value.instance_role === 'viewer'
+      ? value.instance_role
+      : rawCapabilities && !capabilities.is_instance_owner
+        ? 'viewer'
+        : 'owner';
+
+  return {
+    remote: true,
+    authenticated: true,
+    email: typeof value.email === 'string' ? value.email : '',
+    ...(typeof value.sub === 'string' ? { sub: value.sub } : {}),
+    instance_role: instanceRole,
+    capabilities,
+  };
+};


### PR DESCRIPTION
## Summary

- normalize `/api/session` responses before AuthGuard and authorization consumers read them
- preserve legacy authenticated remote sessions as owners when older Avibe versions omit `capabilities`
- keep explicit current editor/viewer capabilities fail-closed for any missing field

## Root cause

The latest `org` UI trusted the TypeScript `SessionInfo` type at the network boundary and directly read `session.capabilities.can_manage_instance`. Older Avibe servers return authenticated remote sessions without `capabilities`, causing the render-time crash.

## Scenario coverage

- No scenario catalog change; this is a backward-compatibility normalization fix for the existing remote login flow.

## Evidence

- Unit: `npx vitest run src/lib/sessionInfo.test.ts` passed, 4 tests
- Contract: covers legacy remote owner, explicit viewer capabilities, legacy local session, and malformed payload
- Scenario: unchanged
- Residual manual checks: full UI build and live Incus regression were skipped at the users request for an immediate demo unblock