### PR TITLE
feat: materialize recommended models in Agents

### DIFF
--- a/config/v2_compat.py
+++ b/config/v2_compat.py
@@ -20,7 +20,6 @@ class ClaudeCompatConfig:
     permission_mode: str
     cwd: str
     system_prompt: Optional[str] = None
-    default_model: Optional[str] = None
     cli_path: Optional[str] = None
     idle_timeout_seconds: int = DEFAULT_AGENT_IDLE_TIMEOUT_SECONDS
     auth_mode: str = "oauth"
@@ -43,7 +42,6 @@ class CodexCompatConfig:
     enabled: bool
     binary: str
     extra_args: list[str]
-    default_model: Optional[str] = None
     idle_timeout_seconds: int = DEFAULT_AGENT_IDLE_TIMEOUT_SECONDS
     auth_mode: str = "oauth"
 
@@ -54,7 +52,6 @@ class OpenCodeCompatConfig:
     binary: str
     port: int
     request_timeout_seconds: int
-    default_model: Optional[str] = None
     default_reasoning_effort: Optional[str] = None
     error_retry_limit: int = DEFAULT_OPENCODE_ERROR_RETRY_LIMIT  # Max retries on LLM stream errors (0 = no retry)
     # User's saved default provider from Settings → Backends → OpenCode.
@@ -104,7 +101,6 @@ def to_app_config(v2: V2Config) -> AppCompatConfig:
         permission_mode="bypassPermissions",
         cwd=v2.runtime.default_cwd,
         system_prompt=None,
-        default_model=v2.agents.claude.default_model,
         cli_path=v2.agents.claude.cli_path,
         idle_timeout_seconds=v2.agents.claude.idle_timeout_seconds,
         # Forward V2Config auth fields so ``session_handler`` can inject the
@@ -122,7 +118,6 @@ def to_app_config(v2: V2Config) -> AppCompatConfig:
             enabled=True,
             binary=v2.agents.codex.cli_path,
             extra_args=[],
-            default_model=v2.agents.codex.default_model,
             idle_timeout_seconds=v2.agents.codex.idle_timeout_seconds,
             auth_mode=v2.agents.codex.auth_mode,
         )
@@ -133,7 +128,6 @@ def to_app_config(v2: V2Config) -> AppCompatConfig:
             binary=v2.agents.opencode.cli_path,
             port=4096,
             request_timeout_seconds=60,
-            default_model=v2.agents.opencode.default_model,
             default_reasoning_effort=v2.agents.opencode.default_reasoning_effort,
             error_retry_limit=v2.agents.opencode.error_retry_limit,
             # Surface the user's saved provider choice so the OpenCode agent

--- a/config/v2_config.py
+++ b/config/v2_config.py
@@ -290,7 +290,6 @@ class OpenCodeConfig:
     enabled: bool = True
     cli_path: str = "opencode"
     default_agent: Optional[str] = None
-    default_model: Optional[str] = None
     default_reasoning_effort: Optional[str] = None
     error_retry_limit: int = DEFAULT_OPENCODE_ERROR_RETRY_LIMIT  # Max retries on LLM stream errors (0 = no retry)
     # Provider the user picked in Settings → Backends → OpenCode. The provider
@@ -306,7 +305,6 @@ class OpenCodeConfig:
 class ClaudeConfig:
     enabled: bool = True
     cli_path: str = "claude"
-    default_model: Optional[str] = None
     idle_timeout_seconds: int = DEFAULT_AGENT_IDLE_TIMEOUT_SECONDS
     # Auth model: "oauth" relies on Claude Code's own credential storage;
     # "api_key" injects ANTHROPIC_API_KEY (and optionally ANTHROPIC_BASE_URL)
@@ -331,7 +329,6 @@ class ClaudeConfig:
 class CodexConfig:
     enabled: bool = True
     cli_path: str = "codex"
-    default_model: Optional[str] = None
     idle_timeout_seconds: int = DEFAULT_AGENT_IDLE_TIMEOUT_SECONDS
     # Auth model: "oauth" defers to whatever ~/.codex/config.toml already
     # has (typically `auth.method = "ChatGPT"`); "api_key" writes the

--- a/core/agent_auth_service.py
+++ b/core/agent_auth_service.py
@@ -2401,7 +2401,7 @@ class AgentAuthService:
             return {"ok": False, "error": "opencode_server_unavailable"}
 
         # Match normal OpenCode turns: caller override, the selected OpenCode
-        # agent's model, Avibe's V2 fallback, then the provider catalog.
+        # Agent's model, then the provider catalog.
         chosen_model = (model or "").strip()
         backend_config = self._resolve_backend_config("opencode")
         default_provider = getattr(backend_config, "default_provider", None)
@@ -2414,15 +2414,6 @@ class AgentAuthService:
             chosen_model = (
                 resolve_opencode_configured_default_model(
                     runtime_agent_model,
-                    default_provider=default_provider,
-                    provider_id=provider_id,
-                )
-                or ""
-            )
-        if not chosen_model and backend_config is not None:
-            chosen_model = (
-                resolve_opencode_configured_default_model(
-                    getattr(backend_config, "default_model", None),
                     default_provider=default_provider,
                     provider_id=provider_id,
                 )

--- a/core/handlers/model_hub/service.py
+++ b/core/handlers/model_hub/service.py
@@ -156,20 +156,6 @@ class V2ModelHubConfigStore:
             config.model_hub = model_hub
             config.save()
 
-    def requested_model(self, backend: str) -> str:
-        try:
-            config = V2Config.load()
-        except FileNotFoundError:
-            config = default_config()
-        backend_config = getattr(config.agents, backend, None)
-        model = str(getattr(backend_config, "default_model", None) or "").strip()
-        if backend == "opencode" and model and "/" not in model:
-            provider = str(getattr(backend_config, "default_provider", None) or "").strip()
-            if provider:
-                return f"{provider}/{model}"
-        return model
-
-
 class UnavailableEngineAdapter:
     """Explicit fail-closed adapter for isolated callers and tests."""
 
@@ -461,11 +447,7 @@ class ModelHubService:
             ).strip()
             if requested_model:
                 return requested_model
-        return self._backend_default_model(agent.backend)
-
-    def _backend_default_model(self, backend: str) -> str:
-        getter = getattr(self.store, "requested_model", None)
-        return str(getter(backend) if callable(getter) else "").strip()
+        return ""
 
     def _unavailable_native_sources(
         self,
@@ -1755,11 +1737,9 @@ class ModelHubService:
             if named_agent is not None and named_agent not in names:
                 names.append(named_agent)
 
-        default_model = self._backend_default_model(backend)
-        add(default_model)
         if self.named_agents_override is not None:
             for name, pinned_model in self.named_agents_override(backend):
-                add(str(pinned_model or "").strip() or default_model, name)
+                add(pinned_model, name)
         if agent.menu_kind == "open" and agent.menu is not None:
             for identifier in agent.menu.checked:
                 add(identifier)
@@ -2074,15 +2054,6 @@ class ModelHubService:
             now=self.now(),
             unavailable_source_ids=unavailable_source_ids,
         )
-        current = (
-            {
-                "model_id": resolution.target_model,
-                "source_id": resolution.source.id,
-                "channel": resolution.source.supply_channel,
-            }
-            if resolution.source is not None
-            else None
-        )
         menu_model_ids = (
             builtin_models if builtin_models is not None else list(agent.menu.checked if agent.menu else ())
         )
@@ -2146,9 +2117,7 @@ class ModelHubService:
         named_agents = []
         if self.named_agents_override is not None:
             for name, pinned_model in self.named_agents_override(backend):
-                requested = str(pinned_model or "").strip() or self._backend_default_model(
-                    backend
-                )
+                requested = str(pinned_model or "").strip()
                 named_resolution = resolve_model_hub_turn(
                     config,
                     backend,
@@ -2172,7 +2141,6 @@ class ModelHubService:
             "selected_by_agent": selected_by_agent,
             "selected_model_id": selected_model_id,
             "selected_model_explicit": selected_model_explicit,
-            "current": current,
             "sources": sources,
             "supply_status": (
                 resolution.supply_status

--- a/core/handlers/session_handler.py
+++ b/core/handlers/session_handler.py
@@ -806,7 +806,7 @@ class SessionHandler(BaseHandler):
         # resolves DM users from the users store (not the stale channels store).
         routing = self._get_settings_manager(context).get_channel_routing(settings_key)
 
-        # Priority: subagent params > channel config > agent frontmatter > global default
+        # Priority: subagent params > channel config > Agent model.
         # Note: agent frontmatter model is applied later after loading agent file
         effective_agent = subagent_name or (routing.claude_agent if routing else None)
         # Store explicit model override (not including default yet)
@@ -825,7 +825,6 @@ class SessionHandler(BaseHandler):
             configured_agent_model = launch_agent_data.get("model") if launch_agent_data else None
             if configured_agent_model and configured_agent_model.lower() not in ("inherit", ""):
                 launch_model = configured_agent_model
-        launch_model = launch_model or self.config.claude.default_model
         cached_base = (
             f"{base_session_id}:{effective_agent}"
             if effective_agent
@@ -1000,8 +999,8 @@ class SessionHandler(BaseHandler):
         if agent_model and agent_model.lower() in ("inherit", ""):
             agent_model = None
 
-        # Determine final model: explicit override > agent frontmatter > global default
-        effective_model = explicit_model or agent_model or self.config.claude.default_model
+        # The routed Vibe Agent model is materialized into ``explicit_model``.
+        effective_model = explicit_model or agent_model
         from modules.agents.model_hub import (
             build_claude_hub_env,
             claude_setting_sources_for_launch,

--- a/core/vibe_agents.py
+++ b/core/vibe_agents.py
@@ -12,7 +12,7 @@ from typing import Any, Iterable, Optional
 from uuid import uuid4
 
 import yaml
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.exc import IntegrityError
 
 from config import paths
@@ -28,6 +28,11 @@ DEFAULT_AGENT_META_KEY = "default_agent_name"
 BUILTIN_DEFAULT_AGENT_METADATA = {"builtin": True, "builtin_default": True, "lock_delete": True}
 BUILTIN_BACKEND_ENABLED_META_KEY = "backend_enabled"
 SUPPORTED_AGENT_BACKENDS = {"codex", "claude", "opencode"}
+RECOMMENDED_AGENT_MODELS = {
+    "claude": "claude-opus-5",
+    "codex": "gpt-5.6-sol",
+    "opencode": "openai/gpt-5.6-sol",
+}
 _UNSET = object()
 
 
@@ -77,6 +82,10 @@ def validate_agent_backend(backend: str) -> str:
         supported = ", ".join(sorted(SUPPORTED_AGENT_BACKENDS))
         raise ValueError(f"unsupported agent backend: {backend}. Supported backends: {supported}")
     return value
+
+
+def recommended_agent_model(backend: str) -> str:
+    return RECOMMENDED_AGENT_MODELS[validate_agent_backend(backend)]
 
 
 def _json_dumps(value: Any) -> str:
@@ -142,6 +151,7 @@ class VibeAgentStore:
         else:
             run_migrations(self.db_path)
         self.engine = create_sqlite_engine(self.db_path)
+        self.prefill_missing_models()
         self._probe = SqliteInvalidationProbe(self.engine)
 
     def close(self) -> None:
@@ -150,6 +160,22 @@ class VibeAgentStore:
 
     def maybe_reload(self) -> bool:
         return self._probe.has_external_write()
+
+    def prefill_missing_models(self) -> int:
+        """Materialize release recommendations on legacy model-less Agents."""
+
+        now = _utc_now_iso()
+        updated = 0
+        with self.engine.begin() as conn:
+            for backend, model in RECOMMENDED_AGENT_MODELS.items():
+                result = conn.execute(
+                    agents.update()
+                    .where(agents.c.backend == backend)
+                    .where(agents.c.model.is_(None) | (func.trim(agents.c.model) == ""))
+                    .values(model=model, updated_at=now)
+                )
+                updated += int(result.rowcount or 0)
+        return updated
 
     def list_agents(self, *, include_disabled: bool = True) -> list[VibeAgent]:
         with self.engine.connect() as conn:
@@ -200,14 +226,15 @@ class VibeAgentStore:
         enabled: bool = True,
     ) -> VibeAgent:
         normalized = normalize_agent_name(name)
+        normalized_backend = validate_agent_backend(backend)
         now = _utc_now_iso()
         agent = VibeAgent(
             id=uuid4().hex[:12],
             name=str(name).strip(),
             normalized_name=normalized,
-            backend=validate_agent_backend(backend),
+            backend=normalized_backend,
             description=_clean_optional(description),
-            model=_clean_optional(model),
+            model=_clean_optional(model) or recommended_agent_model(normalized_backend),
             reasoning_effort=_clean_optional(reasoning_effort),
             system_prompt=_clean_optional(system_prompt),
             enabled=bool(enabled),
@@ -240,7 +267,7 @@ class VibeAgentStore:
         if description is not _UNSET:
             values["description"] = _clean_optional(description)
         if model is not _UNSET:
-            values["model"] = _clean_optional(model)
+            values["model"] = _clean_optional(model) or recommended_agent_model(existing.backend)
         if reasoning_effort is not _UNSET:
             values["reasoning_effort"] = _clean_optional(reasoning_effort)
         if system_prompt is not _UNSET:

--- a/docs/CODEX_SETUP.md
+++ b/docs/CODEX_SETUP.md
@@ -23,14 +23,16 @@ In `~/.vibe_remote/config/config.json`:
   "agents": {
     "codex": {
       "enabled": true,
-      "cli_path": "codex",
-      "default_model": "gpt-5-codex"
+      "cli_path": "codex"
     }
   }
 }
 ```
 
-No additional flag is required to bypass approvals—the bot always adds `--dangerously-bypass-approvals-and-sandbox`.
+Set the model on the Agents page. New Codex Agents without an explicit model are
+prefilled with Avibe's release recommendation, and that value remains visible and
+editable on the Agent. No additional flag is required to bypass approvals—the bot
+always adds `--dangerously-bypass-approvals-and-sandbox`.
 
 ## 3. Route chats to Codex
 

--- a/docs/plans/model-hub-contracts/agent-supply.schema.json
+++ b/docs/plans/model-hub-contracts/agent-supply.schema.json
@@ -15,29 +15,15 @@
     "menu_kind": { "enum": ["fixed", "open"] },
     "selected_by_agent": {
       "type": ["string", "null"],
-      "description": "v2 (07-29, review round 4): the Vibe Agent whose `model` produced `selected_model_id`, by name — or null when the value came from the backend default (`agents.<backend>.default_model`) because that Agent pins no model. WHY THIS EXISTS: model selection does not live at the backend grain. Several enabled Vibe Agents can share one backend and each carry their own `model` (SQLite `agents.backend` + `agents.model`; on this machine today three enabled Agents share backend `claude` with three different models), and routing follows the selected Vibe Agent, not the backend (AGENTS.md → Agent routing model). The shipped projection already resolves ONE Agent — the global default, and only if its backend matches (`core/controller.py::default_vibe_agent_model`) — so this record has always answered for exactly one route while looking like it answered for the backend. Naming the Agent makes that scope readable instead of implied: a caller can see whose model it is, and knows it is not a claim about every turn on this backend. A per-Agent answer for any OTHER Agent is obtained the way every other model-scoped question already is — by passing that Agent's model explicitly to `GET /chain?model=` or `POST /probe {model}` (api.md → grain of the agent record). Derived, never persisted; null while mode=direct.",
+      "description": "The Vibe Agent whose explicit `model` produced `selected_model_id`, by name. Model selection does not live at the backend grain: several enabled Vibe Agents can share one backend and each carry a different model. Derived, never persisted; null while mode=direct or when no routed Agent is projected.",
       "examples": ["pm", "evm-contract-audit"]
     },
     "selected_model_id": {
       "type": ["string", "null"],
-      "description": "v2 (07-29, review round 3): THE SELECTED MODEL of the route named by `selected_by_agent`, as the caller-facing MENU identifier — the built-in id for fixed menus, the prefixed vendor/model id for open menus. NOT a backend-wide fact (grain corrected 07-29, review round 4): it is the routed Vibe Agent's `model`, falling back to the backend default when that Agent pins none, and a different enabled Agent on the same backend can request a different model on its very next turn. Every projection below that depends on a model — `current`, `supply_status`, and the probe's default — therefore inherits that scope and answers for this route alone. Hoisted out of `current` in round 3, where round 2 had put it as `menu_model_id`. The bug was not merely that the selection was nested: `current` is null whenever nothing is runnable (`waiting` / `interrupted`), so the selection vanished from the payload in exactly the two states where the UI needs it most — 「当前无可用来源」 has to name the model it is talking about, the chain drill-in has to query one, and the probe has to default to one. A client would have had to remember the last non-null `current` and hope, or issue a second call. The two fields answer different questions and have different lifetimes: this one is a persisted user CHOICE that survives every supply state, while `current` is a momentary fact about the next turn. Nesting a choice inside a fact made the choice inherit the fact's nullability. null only when mode=direct (no hub selection exists). OPTIONAL here / required at the API boundary once the serializer emits it (README → required-vs-optional). Absent from this file's `examples` on purpose — they round-trip byte-faithfully through the shipped v1 serializer, which has no such field; the worked v2 payload including the `current: null` case lives in api.md.",
+      "description": "The selected model of the route named by `selected_by_agent`, in the caller-facing menu identifier namespace. It is the routed Vibe Agent's explicit model, never a backend-wide fallback. A different Agent on the same backend may request a different model on its next turn. null in direct mode or when no routed Agent is projected. OPTIONAL here and required at the API boundary.",
       "examples": ["claude-opus-4-6", "zhipuai/glm-5.2"]
     },
     "selected_model_explicit": { "type": "boolean", "description": "TRUE iff `selected_model_id` originates from the user's explicit configuration request; FALSE means no explicit model selection, including a resolver-picked value or no selected model." },
-    "current": {
-      "type": ["object", "null"],
-      "description": "What the next turn of THIS ROUTE would use (frame V6 01 supply row) — i.e. the first runnable candidate in this backend's chain for `selected_model_id`, which is the model of the Agent named by `selected_by_agent`. Inherits that grain: a different enabled Vibe Agent on the same backend requesting a different model has a different chain, and this field does not describe it (round 4). NULL IN THREE CASES, not one: (a) mode=direct; (b) `supply_status: \"waiting\"` — every candidate is cooling; (c) `supply_status: \"interrupted\"` — no candidate can recover unattended. In (b) and (c) the serializer MUST emit null rather than the last-used source: a stale `current` would render 使用中 for a source that will not be called, which is exactly the lie the taxonomy exists to prevent. Non-null ⇒ `supply_status` is ok or degraded. Carries only facts about that candidate — the selection itself is `selected_model_id`, one level up, because it outlives every one of these three nulls.",
-      "required": ["model_id", "source_id", "channel"],
-      "additionalProperties": false,
-      "properties": {
-        "model_id": {
-          "type": "string",
-          "description": "The RESOLVED upstream model id — what actually gets sent (e.g. `glm-5.2` or `claude-opus-4-5-20251101`). A property of this attempt, not of the selection, which is why it stays here while the selection moved out. NOT a valid input to the chain query or the probe: for open-menu backends the caller-facing identifier is prefixed (`zhipuai/glm-5.2`), while a fixed-menu native alias may be source-specific, so passing this value through would miss. Use the top-level `selected_model_id` for that. It equals `selected_model_id` only when neither an explicit mapping nor built-in native alias resolution changes the upstream id. Native alias resolution is automatic supply truth and does not create a mapping entry."
-        },
-        "source_id": { "type": "string" },
-        "channel": { "enum": ["native_cli", "hub"] }
-      }
-    },
     "sources": {
       "type": ["object", "null"],
       "description": "This backend's source order — the ordered SUBSET of sources it spends, plus the policy that governs the order (spec §4.2). Replaces the removed global priority contract. Optional in this schema only because the frozen legacy examples predate it; it is REQUIRED at the API boundary. null while mode=direct.",
@@ -107,7 +93,7 @@
               },
               "in_current_model_chain": {
                 "type": ["boolean", "null"],
-                "description": "Membership in the CAPABILITY chain for this AgentSupply record's `selected_model_id`, at the same routed-Agent grain as `current`. true includes blocked members because availability does not change capability; false is the explicit not-supplying-current-model flag that keeps a source visible to the drawer; null exactly when `selected_model_id` is null. OPTIONAL here and REQUIRED at the API boundary with the serializer, so frozen v1 examples remain byte-faithful."
+                "description": "Membership in the CAPABILITY chain for this AgentSupply record's `selected_model_id`, at the same routed-Agent grain. true includes blocked members because availability does not change capability; false is the explicit not-supplying-selected-model flag that keeps a source visible to the drawer; null exactly when `selected_model_id` is null. OPTIONAL here and REQUIRED at the API boundary with the serializer, so frozen v1 examples remain byte-faithful."
               },
               "process_availability_reason": {
                 "enum": ["native_cli_unavailable", null],
@@ -177,7 +163,7 @@
     },
     "named_agents": {
       "type": "array",
-      "description": "v3 read-only projection of every enabled named Vibe Agent on this backend. It is derived live from each Agent's pinned model, falling back to the backend default when the Agent inherits. The distinct name avoids collision with SupplyGap.agents, whose items are bare names inside a mutation-refusal payload.",
+      "description": "Read-only projection of every enabled named Vibe Agent on this backend, derived live from each Agent's explicit model. The distinct name avoids collision with SupplyGap.agents, whose items are bare names inside a mutation-refusal payload.",
       "items": {
         "type": "object",
         "required": ["name", "effective_model_id", "supply_status"],
@@ -186,7 +172,7 @@
           "name": { "type": "string", "minLength": 1 },
           "effective_model_id": {
             "type": ["string", "null"],
-            "description": "The Agent's pinned model, or the inherited backend default, in the caller-facing menu identifier namespace. null means no selection exists."
+            "description": "The Agent's explicit model in the caller-facing menu identifier namespace. null is retained only for compatibility with isolated callers that do not project the Agent catalog."
           },
           "supply_status": {
             "enum": ["ok", "degraded", "waiting", "interrupted", null],
@@ -218,7 +204,6 @@
         "properties": {
           "selected_model_id": { "type": "null" },
           "selected_by_agent": { "type": "null" },
-          "current": { "type": "null" },
           "sources": { "type": "null" },
           "supply_status": { "type": "null" },
           "model_supply": { "type": "null" },
@@ -232,7 +217,7 @@
       }
     },
     {
-      "$comment": "v3 Hub-mode half. `sources`, `model_supply`, and `named_agents` are non-null when present. Presence is deliberately enforced at the API boundary rather than here so the two frozen legacy examples, which predate these projections, remain valid. The selection fields are deliberately NOT constrained non-null: Hub with no explicit Vibe-Agent model and no backend default has no pinned selection. In that state each turn resolves the model carried by the request itself, so inventing a menu selection would be false state.",
+      "$comment": "v4 Hub-mode half. `sources`, `model_supply`, and `named_agents` are non-null when present. Presence is deliberately enforced at the API boundary rather than here so the frozen legacy examples remain valid. The selection fields are deliberately NOT constrained non-null because isolated service callers may not project the Vibe Agent catalog.",
       "if": { "properties": { "mode": { "const": "hub" } }, "required": ["mode"] },
       "then": {
         "properties": {
@@ -269,10 +254,9 @@
         "required": ["selected_model_id"]
       },
       "then": {
-        "required": ["selected_by_agent", "current", "supply_status"],
+        "required": ["selected_by_agent", "supply_status"],
         "properties": {
           "selected_by_agent": { "type": "null" },
-          "current": { "type": "null" },
           "supply_status": { "type": "null" }
         }
       }
@@ -302,32 +286,6 @@
           "supply_status": {
             "enum": ["ok", "degraded", "waiting", "interrupted"]
           }
-        }
-      }
-    },
-    {
-      "$comment": "v2 (07-29, review round 4): the two BLOCKED rollup values guarantee nothing is runnable, so `current` — 'what the next turn would use' — has nothing true to say and must be null. Round 3 documented this as three cases the serializer MUST honour and left all three writable; a stale `current` surviving into `waiting` renders 使用中 for a source that will not be called, which is the single lie the whole taxonomy was built to prevent (spec §4.5: `current` is null in both states, so neither ever renders a stale 使用中).",
-      "if": { "properties": { "supply_status": { "enum": ["waiting", "interrupted"] } }, "required": ["supply_status"] },
-      "then": { "properties": { "current": { "type": "null" } } }
-    },
-    {
-      "$comment": "v2 (07-29, review round 4): and the converse the field already claimed ('Non-null ⇒ supply_status is ok or degraded'), plus the mode half. A record that names a serving source while reporting a blocked rollup is contradictory in the other direction, and either half alone leaves that payload writable. PRESENCE DELIBERATELY NOT REQUIRED here (07-29, review round 5), the one declared exception to the rule that a non-null `then` constraint must also require its field: this file's frozen examples carry `current` with no `supply_status` at all — they round-trip byte-faithfully through the SHIPPED v1 serializer, which has no such field — so `required: [\"supply_status\"]` would fail the contract gate rather than strengthen it. The obligation moves to the API boundary, where the v2 serializer emits it (README → required-vs-optional). Absence is also the fail-safe direction: no rollup means no claim about health and no action-required claim, whereas the dangerous absences (`severity` on a needs_action event, `current` under an ok rollup) are all required above. The exception is enforced as a declared entry in the round-5 presence checker, so 'missing on purpose' cannot decay into 'missing by accident' (api.md → Serializer completeness).",
-      "if": { "properties": { "current": { "type": "object" } }, "required": ["current"] },
-      "then": {
-        "properties": {
-          "supply_status": { "enum": ["ok", "degraded"] },
-          "mode": { "const": "hub" }
-        }
-      }
-    },
-    {
-      "$comment": "v2 (07-29, review round 5): the RUNNABLE half of the rollup ⇒ `current`, which round 4 left open at both ends. It pinned 'blocked ⇒ current null' and 'current non-null ⇒ not blocked', and those two together still admit `supply_status: \"ok\"` with `current: null` — a record claiming 正在从链首供给 while refusing to name the source doing it. That is not a hypothetical shape: it is what a serializer produces the moment the rollup and the candidate are computed by different code paths and one of them returns early, and the drawer would render 使用中 with an empty source row. `ok` and `degraded` are DEFINED by something being served (§4.5: serving from the head of the chain / serving via a fallback), so the candidate exists by construction and the payload must carry it. `required` is part of the fix, not decoration: draft-07 `properties` only validates fields that are PRESENT, so a `then` naming `current` without requiring it passes any record that just omits the key — which is how the whole class of round-4 conditionals ended up weaker than it read. With this member the pair `supply_status` × `current` is total: each of the four rollup values determines whether a candidate is named, in both directions.",
-      "if": { "properties": { "supply_status": { "enum": ["ok", "degraded"] } }, "required": ["supply_status"] },
-      "then": {
-        "required": ["current"],
-        "properties": {
-          "current": { "type": "object" },
-          "mode": { "const": "hub" }
         }
       }
     },
@@ -379,7 +337,6 @@
       "backend": "claude",
       "mode": "hub",
       "menu_kind": "fixed",
-      "current": { "model_id": "claude-opus-4-6", "source_id": "src_claudepro1", "channel": "native_cli" },
       "mappings": [ { "builtin_id": "claude-opus-4-6", "target_model_id": "glm-5.2", "enabled": false } ],
       "menu": null,
       "builtin_models": ["claude-opus-4-6", "claude-sonnet-4-6", "claude-haiku-4-5"],
@@ -389,7 +346,6 @@
       "backend": "opencode",
       "mode": "hub",
       "menu_kind": "open",
-      "current": { "model_id": "glm-5.2", "source_id": "src_zhipukey01", "channel": "hub" },
       "mappings": [],
       "menu": { "view": "featured", "checked": ["anthropic/claude-opus-4-6", "openai/gpt-5.6", "zhipuai/glm-5.2", "zhipuai/glm-5.2-air"] },
       "builtin_models": null,

--- a/docs/plans/model-hub-contracts/api.md
+++ b/docs/plans/model-hub-contracts/api.md
@@ -80,11 +80,6 @@ Each backend entry on `GET /api/models/agents` carries the v3 API-boundary keys:
   "selected_by_agent": "pm",
   "selected_model_id": "claude-opus-4-6",
   "selected_model_explicit": true,
-  "current": {
-    "model_id": "claude-opus-4-6",
-    "source_id": "src_anthkey01",
-    "channel": "hub"
-  },
   "sources": {
     "policy": "follow",
     "order": ["src_claudepro1", "src_anthkey01"],
@@ -132,8 +127,8 @@ Each backend entry on `GET /api/models/agents` carries the v3 API-boundary keys:
 ```
 
 `named_agents` lists every enabled named Vibe Agent whose backend matches this
-record. `effective_model_id` is the Agent's pinned model, otherwise the backend
-default. `supply_status` is derived independently for that effective model. The
+record. `effective_model_id` is the Agent's explicit model. `supply_status` is
+derived independently for that effective model. The
 list name and object shape are intentionally distinct from `SupplyGap.agents`,
 which is a list of bare names inside a mutation result.
 
@@ -141,11 +136,9 @@ which is a list of bare names inside a mutation result.
 user's explicit configuration request. FALSE means no explicit model selection,
 including a resolver-picked value or no selected model.
 
-For a fixed native menu, `current.model_id` is the effective upstream id for the
-selected source. It may therefore differ from `selected_model_id` without an
-explicit mapping when built-in native alias resolution chooses a discovered dated
-model. Chain and probe inputs remain the caller-facing `selected_model_id`; each
-candidate derives its own effective upstream id.
+AgentSupply does not project a backend-level serving head. Chain and probe responses
+carry the effective upstream model and source for the named model request; the
+Agents payload stays at per-named-Agent selection and supply-status grain.
 
 Disabled Agents are absent. In Direct mode each named Agent may still have an
 effective model, but its Hub `supply_status` is null.
@@ -167,8 +160,8 @@ per-backend unavailable set beside the complete eligibility inventory, while
 
 ### Honest null selection
 
-Hub mode does not invent a default. When neither the routed Vibe Agent nor the
-backend configuration pins a model:
+An isolated Model Hub service that is not connected to the Vibe Agent catalog may
+still have no projected selection:
 
 ```json
 {
@@ -176,13 +169,12 @@ backend configuration pins a model:
   "selected_by_agent": null,
   "selected_model_id": null,
   "selected_model_explicit": false,
-  "current": null,
   "supply_status": null
 }
 ```
 
-This means “no pinned selection.” Each turn still resolves against the model carried
-by that request, including the CLI's own default. `sources`, `model_supply`, and
+This means “no projected Agent selection.” Each turn still resolves against the
+model carried by that request. `sources`, `model_supply`, and
 `named_agents` remain present and non-null in Hub mode. Each eligibility row keeps
 its process availability but carries `in_current_model_chain: null`.
 
@@ -282,16 +274,14 @@ extra `source` or `flow` nesting is added.
 }
 ```
 
-`agents` is the set of enabled named Vibe Agents whose effective model is the
-menu-side `model_id`, including Agents that inherit the backend default. It is
-present and may be empty.
+`agents` is the set of enabled named Vibe Agents whose explicit model is the
+menu-side `model_id`. It is present and may be empty.
 
 The protected model set for a backend is the union of:
 
-1. effective models of enabled named Vibe Agents;
-2. the backend default;
-3. checked open-menu models;
-4. the menu-side `builtin_id` of mappings whose `enabled` is true.
+1. explicit models of enabled named Vibe Agents;
+2. checked open-menu models;
+3. the menu-side `builtin_id` of mappings whose `enabled` is true.
 
 The guard evaluates each protected `(backend, model)` against the post-mutation
 state. It counts only runnable suppliers in that backend's enabled effective order,

--- a/docs/plans/model-hub-contracts/mirror-registry.json
+++ b/docs/plans/model-hub-contracts/mirror-registry.json
@@ -159,10 +159,6 @@
           "paths": ["/properties/supply_channel"]
         },
         {
-          "schema": "agent-supply.schema.json",
-          "paths": ["/properties/current/properties/channel"]
-        },
-        {
           "schema": "agent-chain.schema.json",
           "paths": ["/properties/chain/items/properties/channel"]
         },

--- a/modules/agents/codex/agent.py
+++ b/modules/agents/codex/agent.py
@@ -1274,7 +1274,7 @@ class CodexAgent(BaseAgent):
             except Exception as exc:
                 logger.warning("Failed to load Codex subagent %s: %s", effective_agent, exc)
 
-        effective_model = explicit_model or (agent_definition.model if agent_definition else None) or self.codex_config.default_model
+        effective_model = explicit_model or (agent_definition.model if agent_definition else None)
         if getattr(self.controller, "model_hub_runtime", None) is not None:
             from modules.agents.model_hub import launch_for_context
 

--- a/modules/agents/opencode/agent.py
+++ b/modules/agents/opencode/agent.py
@@ -727,8 +727,6 @@ class OpenCodeAgent(OpenCodeMessageProcessorMixin, BaseAgent):
             if not model_str:
                 model_str = server.get_agent_model_from_config(agent_to_use)
             opencode_cfg = getattr(self.controller.config, "opencode", None)
-            if not model_str:
-                model_str = getattr(opencode_cfg, "default_model", None)
             model_str = opencode_model_for_overlay(model_str, model_hub_overlay)
             if model_hub_runtime is not None and model_str:
                 model_hub_launch = await resolve_opencode_overlay_launch(

--- a/scripts/prepare_regression.py
+++ b/scripts/prepare_regression.py
@@ -195,7 +195,6 @@ def _build_config_payload() -> dict:
                 "enabled": True,
                 "cli_path": CONTAINER_OPENCODE_CLI,
                 "default_agent": _optional("REGRESSION_OPENCODE_AGENT"),
-                "default_model": _optional("REGRESSION_OPENCODE_MODEL") or "gpt-5.4",
                 "default_reasoning_effort": _optional("REGRESSION_OPENCODE_REASONING_EFFORT"),
                 "error_retry_limit": 1,
                 "default_provider": _optional("REGRESSION_OPENCODE_DEFAULT_PROVIDER") or "openai",
@@ -203,12 +202,10 @@ def _build_config_payload() -> dict:
             "claude": {
                 "enabled": True,
                 "cli_path": "claude",
-                "default_model": _optional("REGRESSION_CLAUDE_MODEL"),
             },
             "codex": {
                 "enabled": True,
                 "cli_path": "codex",
-                "default_model": _optional("REGRESSION_CODEX_MODEL"),
             },
         },
         "gateway": None,

--- a/skills/use-avibe/SKILL.md
+++ b/skills/use-avibe/SKILL.md
@@ -258,20 +258,17 @@ Important config payload shape:
       "enabled": true,
       "cli_path": "opencode",
       "default_agent": null,
-      "default_model": null,
       "default_reasoning_effort": null,
       "error_retry_limit": 1
     },
     "claude": {
       "enabled": true,
       "cli_path": "claude",
-      "default_model": null,
       "idle_timeout_seconds": 600
     },
     "codex": {
       "enabled": true,
       "cli_path": "codex",
-      "default_model": null,
       "idle_timeout_seconds": 600
     }
   },

--- a/skills/use-vibe-remote/SKILL.md
+++ b/skills/use-vibe-remote/SKILL.md
@@ -258,20 +258,17 @@ Important config payload shape:
       "enabled": true,
       "cli_path": "opencode",
       "default_agent": null,
-      "default_model": null,
       "default_reasoning_effort": null,
       "error_retry_limit": 1
     },
     "claude": {
       "enabled": true,
       "cli_path": "claude",
-      "default_model": null,
       "idle_timeout_seconds": 600
     },
     "codex": {
       "enabled": true,
       "cli_path": "codex",
-      "default_model": null,
       "idle_timeout_seconds": 600
     }
   },

--- a/tests/scenario_harness/model_hub_native_oauth.py
+++ b/tests/scenario_harness/model_hub_native_oauth.py
@@ -136,6 +136,7 @@ class NativeOAuthScenarioHarness:
             oauth_flows=OAuthFlowRegistry(state_dir / "oauth_flows.json"),
             revocations=CredentialRevocationJournal(state_dir / "revocations.json"),
             now=lambda: datetime(2026, 7, 25, 0, 0, tzinfo=timezone.utc),
+            requested_model_override=self.store.requested_model,
         )
 
 

--- a/tests/scenarios/model_hub/test_model_hub_live_resolution_scenarios.py
+++ b/tests/scenarios/model_hub/test_model_hub_live_resolution_scenarios.py
@@ -236,7 +236,7 @@ def test_unpinned_hub_projection_is_null_while_explicit_turn_resolves(
         )
         assert projected["selected_by_agent"] is None
         assert projected["selected_model_id"] is None
-        assert projected["current"] is None
+        assert "current" not in projected
         assert projected["supply_status"] is None
 
         gateway = ModelHubTurnGateway(service)

--- a/tests/scenarios/model_hub/test_model_hub_native_oauth_scenarios.py
+++ b/tests/scenarios/model_hub/test_model_hub_native_oauth_scenarios.py
@@ -107,7 +107,14 @@ def test_mh_oauth_native_001_claude_paste_code_happy_path(monkeypatch, tmp_path)
         for agent in client.get("/api/models/agents", base_url=BASE_URL).get_json()["agents"]
         if agent["backend"] == "claude"
     )
-    assert claude["current"]["source_id"] == started["source_id"]
+    assert "current" not in claude
+    assert claude["selected_model_id"] == "claude-opus-4-6"
+    assert claude["supply_status"] == "ok"
+    chain = client.get(
+        "/api/models/agents/claude/chain?model=claude-opus-4-6",
+        base_url=BASE_URL,
+    ).get_json()["chain"]
+    assert next(item for item in chain["chain"] if item["runnable"])["source_id"] == started["source_id"]
 
 
 def test_mh_oauth_native_002_codex_device_code_self_completes(monkeypatch, tmp_path):
@@ -234,7 +241,8 @@ def test_mh_oauth_native_003_cancel_and_timeout_terminate_cleanly(monkeypatch, t
         for agent in client.get("/api/models/agents", base_url=BASE_URL).get_json()["agents"]
         if agent["backend"] == "claude"
     )
-    assert claude["current"] is None
+    assert "current" not in claude
+    assert claude["supply_status"] == "interrupted"
 
     cancelled = client.post(
         "/api/models/oauth/start",

--- a/tests/test_api_save_config_merge.py
+++ b/tests/test_api_save_config_merge.py
@@ -93,6 +93,10 @@ def test_save_config_merges_partial_payload(monkeypatch, tmp_path):
     assert original.show_duration is True
     assert original.include_time_info is True
     assert original.update.auto_update is False
+    assert all(
+        not hasattr(getattr(original.agents, backend), "default_model")
+        for backend in ("claude", "codex", "opencode")
+    )
 
     updated = api.save_config({"show_duration": False, "include_time_info": False, "update": {"auto_update": True}})
 
@@ -105,7 +109,7 @@ def test_save_config_merges_partial_payload(monkeypatch, tmp_path):
     assert updated.runtime.default_cwd == "/tmp/workdir"
 
 
-def test_save_config_seeds_default_for_partial_payload_on_fresh_install(monkeypatch, tmp_path):
+def test_save_config_seeds_default_and_drops_retired_model_key(monkeypatch, tmp_path):
     """Regression: a fresh install (no config file yet) must accept the wizard's
     reused provider-config modal POSTing only ``{"agents": ...}``.
 
@@ -127,7 +131,7 @@ def test_save_config_seeds_default_for_partial_payload_on_fresh_install(monkeypa
     # The partial save merges onto the workbench-only default and persists.
     assert created.mode == "self_host"
     assert created.agents.claude.enabled is True
-    assert created.agents.claude.default_model == "sonnet"
+    assert not hasattr(created.agents.claude, "default_model")
     # Configuring a provider mid-wizard must not complete setup...
     assert created.setup_completed is False
     assert created.setup_state()["needs_setup"] is True

--- a/tests/test_claude_cli_path.py
+++ b/tests/test_claude_cli_path.py
@@ -25,7 +25,6 @@ class _ClaudeRuntimeConfig:
     permission_mode: str = "bypassPermissions"
     cwd: str = "/tmp/workdir"
     system_prompt: str | None = None
-    default_model: str | None = None
     cli_path: str | None = "/usr/local/bin/claude-proxy"
 
 
@@ -861,9 +860,12 @@ def test_session_handler_does_not_repeat_claude_model_control_request(monkeypatc
     monkeypatch.setattr(session_handler_module, "ClaudeSDKClient", _StubClaudeSDKClient)
 
     controller = _Controller(tmp_path)
-    controller.config.claude.default_model = "claude-sonnet-4-5"
     handler = SessionHandler(controller)
-    context = MessageContext(user_id="U123", channel_id="C123")
+    context = MessageContext(
+        user_id="U123",
+        channel_id="C123",
+        platform_specific={"agent_session_target": {"model": "claude-sonnet-4-5"}},
+    )
 
     first_client = _run_session(handler, context)
     second_client = _run_session(handler, context)
@@ -1096,12 +1098,15 @@ def test_session_handler_updates_cached_claude_model_only_when_changed(monkeypat
     monkeypatch.setattr(session_handler_module, "ClaudeSDKClient", _StubClaudeSDKClient)
 
     controller = _Controller(tmp_path)
-    controller.config.claude.default_model = "claude-sonnet-4-5"
     handler = SessionHandler(controller)
-    context = MessageContext(user_id="U123", channel_id="C123")
+    context = MessageContext(
+        user_id="U123",
+        channel_id="C123",
+        platform_specific={"agent_session_target": {"model": "claude-sonnet-4-5"}},
+    )
 
     client = _run_session(handler, context)
-    controller.config.claude.default_model = "claude-opus-4-1"
+    context.platform_specific["agent_session_target"]["model"] = "claude-opus-4-1"
 
     _run_session(handler, context)
     _run_session(handler, context)

--- a/tests/test_model_hub_api.py
+++ b/tests/test_model_hub_api.py
@@ -66,12 +66,16 @@ class MemoryStore:
                 for backend in ("claude", "codex", "opencode")
             }
         )
+        self.requested_models = {}
 
     def load(self):
         return self.config
 
     def save(self, config):
         self.config = config
+
+    def requested_model(self, backend):
+        return self.requested_models.get(backend, "")
 
 
 class FakeInvokeHandle:
@@ -233,6 +237,7 @@ def _service(tmp_path):
         oauth_flows=OAuthFlowRegistry(tmp_path / "oauth_flows.json"),
         revocations=CredentialRevocationJournal(tmp_path / "revocations.json"),
         now=lambda: datetime(2026, 7, 23, 3, 0, tzinfo=timezone.utc),
+        requested_model_override=lambda backend: store.requested_model(backend),
     )
     return service, store, adapter
 
@@ -419,8 +424,8 @@ def test_agents_endpoint_projects_each_enabled_named_agent_live(tmp_path):
         "codex": "gpt-5.3-codex",
     }.get(backend)
     service.named_agents_override = lambda backend: {
-        "claude": [("pm", None), ("reviewer", "claude-opus-4-6")],
-        "codex": [("codex", None)],
+        "claude": [("pm", "claude-sonnet-4-6"), ("reviewer", "claude-opus-4-6")],
+        "codex": [("codex", "gpt-5.3-codex")],
         "opencode": [],
     }[backend]
 
@@ -834,7 +839,7 @@ def test_model_hub_rest_api_contract(monkeypatch, tmp_path):
         headers=headers,
         base_url=base_url,
     )
-    assert response.get_json()["agent"]["current"] is None
+    assert "current" not in response.get_json()["agent"]
     response = client.get(
         "/api/models/agents/codex/chain?model=gpt-5",
         base_url=base_url,
@@ -850,7 +855,6 @@ def test_model_hub_rest_api_contract(monkeypatch, tmp_path):
             "selected_by_agent",
             "selected_model_id",
             "selected_model_explicit",
-            "current",
             "sources",
             "supply_status",
             "model_supply",
@@ -1226,6 +1230,9 @@ def test_native_reauth_post_login_discovery_failure_reports_honest_gaps(tmp_path
     store.config.sources.append(source)
     store.config.refresh_follow_orders()
     store.requested_model = lambda backend: ("claude-opus-4-6" if backend == "claude" else "")
+    service.named_agents_override = lambda backend: (
+        [("claude", "claude-opus-4-6")] if backend == "claude" else []
+    )
     flow = asyncio.run(
         service.reauth_source(
             source.id,
@@ -1251,7 +1258,7 @@ def test_native_reauth_post_login_discovery_failure_reports_honest_gaps(tmp_path
         {
             "backend": "claude",
             "model_id": "claude-opus-4-6",
-            "agents": [],
+                "agents": ["claude"],
         }
     ]
     assert store.config.sources[0].models == []
@@ -2644,6 +2651,9 @@ def test_credential_route_carries_body_force_override_and_structured_guard(
     store.requested_model = lambda backend: (
         "claude-opus-4-6" if backend == "claude" else ""
     )
+    service.named_agents_override = lambda backend: (
+        [("claude", "claude-opus-4-6")] if backend == "claude" else []
+    )
 
     async def discover_narrower(vendor, protocol, base_url, credential_ref):
         return ("replacement-only-model",)
@@ -2669,7 +2679,7 @@ def test_credential_route_carries_body_force_override_and_structured_guard(
         {
             "backend": "claude",
             "model_id": "claude-opus-4-6",
-            "agents": [],
+            "agents": ["claude"],
         }
     ]
     committed = client.put(

--- a/tests/test_model_hub_config.py
+++ b/tests/test_model_hub_config.py
@@ -169,12 +169,11 @@ def test_frozen_source_and_agent_examples_round_trip_byte_faithfully():
 
     for example in _schema("agent-supply.schema.json")["examples"]:
         agent = ModelHubAgentSupplyConfig.from_payload(example)
-        # `current`, `builtin_models` and `standard_vendors` are read-only
-        # endpoint projections (v1.2), not persisted config — reconstruct them
+        # `builtin_models` and `standard_vendors` are read-only endpoint
+        # projections (v1.2), not persisted config — reconstruct them
         # the way `_agent_payload` merges them onto to_payload().
         serialized = {
             **agent.to_payload(),
-            "current": example.get("current"),
             "builtin_models": example.get("builtin_models"),
             "standard_vendors": example.get("standard_vendors"),
         }
@@ -195,7 +194,7 @@ def test_every_frozen_schema_example_is_valid_and_json_round_trips():
             assert _canonical(json.loads(_canonical(example))) == _canonical(example)
 
 
-def test_agent_supply_contract_accepts_unmapped_native_alias_current():
+def test_agent_supply_contract_accepts_unmapped_native_alias_selection():
     payload = {
         "backend": "claude",
         "mode": "hub",
@@ -203,11 +202,6 @@ def test_agent_supply_contract_accepts_unmapped_native_alias_current():
         "selected_by_agent": None,
         "selected_model_id": "claude-opus-4-5",
         "selected_model_explicit": True,
-        "current": {
-            "model_id": "claude-opus-4-5-20251101",
-            "source_id": "src_anthropic1",
-            "channel": "hub",
-        },
         "sources": {
             "policy": "follow",
             "order": ["src_anthropic1"],
@@ -354,7 +348,6 @@ def test_v4_shape_amendments_reject_the_false_states_they_replace():
         "selected_by_agent": None,
         "selected_model_id": None,
         "selected_model_explicit": False,
-        "current": None,
         "sources": {"policy": "follow", "order": [], "eligibility": []},
         "supply_status": None,
         "mappings": [],
@@ -400,11 +393,6 @@ def test_v4_shape_amendments_reject_the_false_states_they_replace():
     signal_supply.update(
         {
             "selected_model_id": "claude-opus-4-6",
-            "current": {
-                "model_id": "claude-opus-4-6",
-                "source_id": "src_anthkey01",
-                "channel": "hub",
-            },
             "supply_status": "degraded",
         }
     )

--- a/tests/test_model_hub_injection.py
+++ b/tests/test_model_hub_injection.py
@@ -163,12 +163,14 @@ def _service(
     *,
     now,
 ) -> ModelHubService:
+    store = MemoryStore(config)
     return ModelHubService(
-        store=MemoryStore(config),
+        store=store,
         adapter=adapter,
         events=BoundedEventLog(tmp_path / "events.json"),
         revocations=CredentialRevocationJournal(tmp_path / "revocations.json"),
         now=now,
+        requested_model_override=store.requested_model,
     )
 
 
@@ -923,7 +925,7 @@ def test_agent_projection_matches_interrupted_unmapped_fixed_backend(tmp_path: P
     router = _router(service)
     with pytest.raises(ModelHubError, match="mapping_target_unavailable"):
         asyncio.run(router.resolve("claude", "claude-opus-4-6"))
-    assert projected["current"] is None
+    assert "current" not in projected
     assert projected["supply_status"] == "interrupted"
     assert adapter.starts == 0
     event = service.events.list(limit=10)[0]
@@ -933,8 +935,8 @@ def test_agent_projection_matches_interrupted_unmapped_fixed_backend(tmp_path: P
     )
 
 
-def test_agent_projection_uses_global_default_vibe_agent_model(tmp_path: Path) -> None:
-    """MH-CHAN-001: the global default Vibe Agent supplies the projected model."""
+def test_agent_projection_uses_explicit_default_vibe_agent_model(tmp_path: Path) -> None:
+    """MH-CHAN-001: the default Vibe Agent supplies its explicit model."""
 
     hub = _source(
         "src_hub_agent_model",
@@ -954,22 +956,29 @@ def test_agent_projection_uses_global_default_vibe_agent_model(tmp_path: Path) -
         LaunchAdapter({hub.id: "route-hub"}),
         now=lambda: datetime(2026, 7, 23, tzinfo=timezone.utc),
     )
-    service.store.requested_models["codex"] = "backend-default"
     service.requested_model_override = lambda backend: "agent-model" if backend == "codex" else None
     router = _router(service)
 
-    projected = next(agent for agent in service.list_agents() if agent["backend"] == "codex")["current"]
+    projected = next(agent for agent in service.list_agents() if agent["backend"] == "codex")
+    chain = service.agent_chain("codex", "agent-model")
+    candidate = next(item for item in chain["chain"] if item["runnable"])
     launch = asyncio.run(router.resolve("codex", "agent-model"))
 
-    assert projected == {
+    assert "current" not in projected
+    assert projected["selected_model_id"] == "agent-model"
+    assert {
+        "model_id": candidate["resolved_model_id"] or chain["model_id"],
+        "source_id": candidate["source_id"],
+        "channel": candidate["channel"],
+    } == {
         "model_id": launch.target_model,
         "source_id": launch.source_id,
         "channel": launch.channel,
     }
 
 
-def test_agent_projection_and_runtime_router_share_resolution_table(tmp_path: Path) -> None:
-    """MH-CHAN-001/MH-MAP-001/MH-OC-001: projection equals runtime resolution."""
+def test_agent_chain_and_runtime_router_share_resolution_table(tmp_path: Path) -> None:
+    """MH-CHAN-001/MH-MAP-001/MH-OC-001: chain equals runtime resolution."""
 
     fixed_hub = _source(
         "src_hub_mapped",
@@ -1121,7 +1130,7 @@ def test_agent_projection_and_runtime_router_share_resolution_table(tmp_path: Pa
         service.store.requested_models[backend] = requested_model
         router = _router(service)
 
-        projected = next(agent for agent in service.list_agents() if agent["backend"] == backend)["current"]
+        projected = next(agent for agent in service.list_agents() if agent["backend"] == backend)
         launch = asyncio.run(router.resolve(backend, requested_model))
         actual = (
             None
@@ -1133,7 +1142,16 @@ def test_agent_projection_and_runtime_router_share_resolution_table(tmp_path: Pa
             }
         )
 
-        assert projected == actual == expected
+        assert "current" not in projected
+        if expected is not None and requested_model:
+            chain = service.agent_chain(backend, requested_model)
+            candidate = next(item for item in chain["chain"] if item["runnable"])
+            assert {
+                "model_id": candidate["resolved_model_id"] or chain["model_id"],
+                "source_id": candidate["source_id"],
+                "channel": candidate["channel"],
+            } == expected
+        assert actual == expected
 
 
 def test_mh_chan_001_configured_hub_stays_fail_closed_for_unavailable_model(tmp_path: Path) -> None:
@@ -1237,10 +1255,17 @@ def test_projection_rechecks_expired_native_readiness_before_recovery(
     service.store.requested_models["codex"] = "gpt-5"
     router = _router(service, native_cli_ready=lambda _backend: False)
 
-    projected = next(agent for agent in service.list_agents() if agent["backend"] == "codex")["current"]
+    projected = next(agent for agent in service.list_agents() if agent["backend"] == "codex")
+    chain = service.agent_chain("codex", "gpt-5")
+    candidate = next(item for item in chain["chain"] if item["runnable"])
     launch = asyncio.run(router.resolve("codex", "gpt-5"))
 
-    assert projected == {
+    assert "current" not in projected
+    assert {
+        "model_id": candidate["resolved_model_id"] or chain["model_id"],
+        "source_id": candidate["source_id"],
+        "channel": candidate["channel"],
+    } == {
         "model_id": "gpt-5",
         "source_id": hub.id,
         "channel": "hub",
@@ -1404,11 +1429,18 @@ def test_mh_chan_001_verified_codex_keyring_source_remains_routable(
 
     clock["now"] += timedelta(seconds=301)
     service.store.requested_models["codex"] = "gpt-5"
-    projected = next(agent for agent in service.list_agents() if agent["backend"] == "codex")["current"]
+    projected = next(agent for agent in service.list_agents() if agent["backend"] == "codex")
+    chain = service.agent_chain("codex", "gpt-5")
+    candidate = next(item for item in chain["chain"] if item["runnable"])
     assert native.state.status == "cooldown"
     recovered = asyncio.run(router.resolve("codex", "gpt-5"))
 
-    assert projected == {
+    assert "current" not in projected
+    assert {
+        "model_id": candidate["resolved_model_id"] or chain["model_id"],
+        "source_id": candidate["source_id"],
+        "channel": candidate["channel"],
+    } == {
         "model_id": "gpt-5",
         "source_id": native.id,
         "channel": "native_cli",

--- a/tests/test_model_hub_l3.py
+++ b/tests/test_model_hub_l3.py
@@ -208,13 +208,15 @@ def _service(
     sources: list[ModelHubSourceConfig],
     outcomes: list[RawCallOutcome] | None = None,
 ) -> ModelHubService:
+    store = MemoryStore(_config(sources))
     return ModelHubService(
-        store=MemoryStore(_config(sources)),
+        store=store,
         adapter=ProbeAdapter(outcomes or []),
         events=BoundedEventLog(tmp_path / "events.json"),
         provenance=BoundedProvenanceStore(tmp_path / "provenance.json"),
         revocations=CredentialRevocationJournal(tmp_path / "revocations.json"),
         now=lambda: NOW,
+        requested_model_override=store.requested_model,
     )
 
 

--- a/tests/test_model_hub_resolution.py
+++ b/tests/test_model_hub_resolution.py
@@ -179,12 +179,14 @@ def _service(tmp_path, adapter, *, agents=None, now=None):
             policy="custom",
             order=[source.id for source in sources],
         )
+    store = MemoryStore(config)
     return ModelHubService(
-        store=MemoryStore(config),
+        store=store,
         adapter=adapter,
         events=BoundedEventLog(tmp_path / "events.json", max_entries=5),
         revocations=CredentialRevocationJournal(tmp_path / "revocations.json"),
         now=now or (lambda: datetime(2026, 7, 23, 3, 0, tzinfo=timezone.utc)),
+        requested_model_override=lambda backend: store.requested_model(backend),
     )
 
 
@@ -784,8 +786,8 @@ def test_wall_drawers_chain_probe_and_resolver_share_native_alias_supply_truth(
     )
     probe = asyncio.run(service.probe_agent("claude", "claude-opus-4-5"))
 
-    # The row wall consumes model_supply/current. Both drawers consume the chain
-    # endpoint. Probe and live resolution must carry those exact same bytes.
+    # The row wall consumes model_supply. Both drawers consume the chain
+    # endpoint. Probe and live resolution must carry that same resolved model.
     wall = next(
         row
         for row in agent["model_supply"]
@@ -793,8 +795,7 @@ def test_wall_drawers_chain_probe_and_resolver_share_native_alias_supply_truth(
     )
     assert wall["chain_length"] == len(chain["chain"]) == 1
     assert (
-        agent["current"]["model_id"]
-        == chain["chain"][0]["resolved_model_id"]
+        chain["chain"][0]["resolved_model_id"]
         == resolution.target_model
         == probe["model_id"]
         == effective_model
@@ -956,7 +957,7 @@ def test_runtime_alias_blocker_event_uses_requested_menu_id(tmp_path):
     assert blocker["model_id"] == "claude-opus-4-5"
 
 
-def test_opencode_provider_prefix_selects_matching_source_and_current_payload(tmp_path):
+def test_opencode_provider_prefix_selects_matching_source(tmp_path):
     adapter = FakeAdapter([_outcome(RawOutcomeKind.SUCCESS, status=200)])
     service = _service(tmp_path, adapter)
     config = service.store.load()
@@ -968,7 +969,7 @@ def test_opencode_provider_prefix_selects_matching_source_and_current_payload(tm
     config.sources[1].vendor = "anthropic"
     config.agents["opencode"].menu.checked = ["anthropic/claude-opus-4-6"]
 
-    current = next(agent for agent in service.list_agents() if agent["backend"] == "opencode")["current"]
+    chain = service.agent_chain("opencode", "anthropic/claude-opus-4-6")
     resolved = asyncio.run(
         service.resolve(
             backend="opencode",
@@ -977,7 +978,7 @@ def test_opencode_provider_prefix_selects_matching_source_and_current_payload(tm
         )
     )
 
-    assert current["source_id"] == "src_backup001"
+    assert chain["chain"][0]["source_id"] == "src_backup001"
     assert resolved.source_id == "src_backup001"
     assert adapter.invocations == [("src_backup001", "claude-opus-4-6", "opencode")]
     assert service.list_events(limit=10) == []
@@ -1034,7 +1035,7 @@ def test_opencode_unknown_vendor_uses_custom_provider_identifier(tmp_path):
     config.agents["opencode"].menu.checked = ["custom/claude-opus-4-6"]
 
     menu = asyncio.run(service.set_opencode_menu(config.agents["opencode"].menu.to_payload()))
-    current = next(agent for agent in service.list_agents() if agent["backend"] == "opencode")["current"]
+    chain = service.agent_chain("opencode", "custom/claude-opus-4-6")
     resolved = asyncio.run(
         service.resolve(
             backend="opencode",
@@ -1044,7 +1045,7 @@ def test_opencode_unknown_vendor_uses_custom_provider_identifier(tmp_path):
     )
 
     assert menu["menu"]["checked"] == ["custom/claude-opus-4-6"]
-    assert current["source_id"] == "src_primary01"
+    assert chain["chain"][0]["source_id"] == "src_primary01"
     assert resolved.source_id == "src_primary01"
 
 
@@ -1107,8 +1108,6 @@ def test_opencode_resolution_rejects_models_outside_checked_menu(tmp_path):
     service = _service(tmp_path, adapter)
     service.store.load().agents["opencode"].menu.checked = []
 
-    current = next(agent for agent in service.list_agents() if agent["backend"] == "opencode")["current"]
-
     with pytest.raises(ModelHubError) as exc_info:
         asyncio.run(
             service.resolve(
@@ -1119,7 +1118,6 @@ def test_opencode_resolution_rejects_models_outside_checked_menu(tmp_path):
         )
 
     assert exc_info.value.code == "mapping_target_unavailable"
-    assert current is None
     assert adapter.invocations == []
 
 
@@ -1147,25 +1145,6 @@ def test_persisted_hub_sources_sync_before_first_resolution(tmp_path):
         "src_primary01",
         "src_backup001",
     ]
-
-
-def test_agent_current_skips_cooldown_and_error_sources(tmp_path):
-    service = _service(tmp_path, FakeAdapter([]))
-    config = service.store.load()
-    config.sources[0].state = ModelHubSourceStateConfig(
-        status="cooldown",
-        retry_at="2026-07-23T03:05:00Z",
-    )
-
-    claude = next(agent for agent in service.list_agents() if agent["backend"] == "claude")
-    assert claude["current"]["source_id"] == "src_backup001"
-
-    config.sources[1].state = ModelHubSourceStateConfig(
-        status="error",
-        detail_key="models.source.error.unclassified",
-    )
-    claude = next(agent for agent in service.list_agents() if agent["backend"] == "claude")
-    assert claude["current"] is None
 
 
 @pytest.mark.parametrize(
@@ -1573,9 +1552,10 @@ def test_source_delete_cascades_agent_model_references(tmp_path, force, mode):
     assert all(agent.sources.order == ["src_backup001"] for agent in persisted.agents.values())
     _assert_no_references_to(service, "retired-model")
     if force:
-        agents = {agent["backend"]: agent for agent in service.list_agents()}
-        assert agents["claude"]["current"]["source_id"] == "src_backup001"
-        assert agents["opencode"]["current"]["source_id"] == "src_backup001"
+        claude_chain = service.agent_chain("claude", "claude-opus-4-6")
+        opencode_chain = service.agent_chain("opencode", "anthropic/claude-opus-4-6")
+        assert claude_chain["chain"][0]["source_id"] == "src_backup001"
+        assert opencode_chain["chain"][0]["source_id"] == "src_backup001"
         resolved = asyncio.run(
             service.resolve(
                 backend="claude",
@@ -1583,7 +1563,7 @@ def test_source_delete_cascades_agent_model_references(tmp_path, force, mode):
                 request={},
             )
         )
-        assert resolved.source_id == agents["claude"]["current"]["source_id"]
+        assert resolved.source_id == claude_chain["chain"][0]["source_id"]
 
 
 def test_deleting_last_hub_source_syncs_empty_binding_set(tmp_path):
@@ -2169,7 +2149,9 @@ def test_supply_guard_uses_only_enabled_menu_mappings_from_fresh_fixtures(
 def test_supply_guard_reports_menu_identifier_and_effective_named_agents(tmp_path):
     service, _adapter = _repair_guard_service(tmp_path, enabled=True)
     service.named_agents_override = lambda backend: (
-        [("pm", None), ("reviewer", "claude-opus-4-6")] if backend == "claude" else []
+        [("pm", "claude-opus-4-6"), ("reviewer", "claude-opus-4-6")]
+        if backend == "claude"
+        else []
     )
     service.store.requested_models["claude"] = "claude-opus-4-6"
 

--- a/tests/test_multi_platform_runtime.py
+++ b/tests/test_multi_platform_runtime.py
@@ -764,7 +764,6 @@ def test_opencode_prompt_disables_question_tool_for_all_platforms():
                             "OpenCodeConfig",
                             (),
                             {
-                                "default_model": "GPT-5.4",
                                 "default_provider": "openai",
                                 "default_reasoning_effort": "high",
                             },
@@ -777,7 +776,7 @@ def test_opencode_prompt_disables_question_tool_for_all_platforms():
             self.processing_indicator = type("Processing", (), {"snapshot_request": lambda self, request: {}})()
 
         def get_opencode_overrides(self, context):
-            return None, None, None
+            return None, "openai/gpt-5.4", None
 
     agent = OpenCodeAgent.__new__(OpenCodeAgent)
     agent.controller = _Controller()

--- a/tests/test_prepare_regression.py
+++ b/tests/test_prepare_regression.py
@@ -85,7 +85,7 @@ def test_prepare_generates_unified_state(tmp_path: Path, monkeypatch: pytest.Mon
     assert config["agents"]["codex"]["enabled"] is True
     assert "default_backend" not in config["agents"]
     assert config["agents"]["opencode"]["cli_path"] == "opencode"
-    assert config["agents"]["opencode"]["default_model"] == "gpt-5.4"
+    assert "default_model" not in config["agents"]["opencode"]
     assert config["agents"]["opencode"]["default_provider"] == "openai"
 
     # UI host propagated

--- a/tests/test_session_fork.py
+++ b/tests/test_session_fork.py
@@ -1490,11 +1490,12 @@ def test_forking_an_inherited_null_session_keeps_its_explicit_pins(
 
     agent_store = VibeAgentStore(db_path)
     try:
-        # Pins neither a model nor an effort, exactly like the session below.
+        # The Agent model is explicit by invariant; the session below pins it away.
         source_agent = agent_store.create(name="nightly", backend="claude")
     finally:
         agent_store.close()
-    assert source_agent.model is None and source_agent.reasoning_effort is None
+    assert source_agent.model == "claude-opus-5"
+    assert source_agent.reasoning_effort is None
 
     engine = create_sqlite_engine(db_path)
     with engine.begin() as conn:

--- a/tests/test_ui_api.py
+++ b/tests/test_ui_api.py
@@ -983,23 +983,21 @@ def test_opencode_provider_catalog_keeps_builtin_overrides_read_only(monkeypatch
 
 
 @pytest.mark.parametrize(
-    ("available_models", "configured_model", "runtime_model", "expected_model"),
+    ("available_models", "runtime_model", "expected_model"),
     [
-        ({"gpt-5.3-chat-latest": {}, "gpt-5.4": {}}, "gpt-5.4", None, "gpt-5.4"),
-        ({"gpt-5.3-chat-latest": {}}, "gpt-5.4-new", None, "gpt-5.4-new"),
+        ({"gpt-5.3-chat-latest": {}, "gpt-5.4": {}}, None, "gpt-5.3-chat-latest"),
+        ({"gpt-5.3-chat-latest": {}}, None, "gpt-5.3-chat-latest"),
         (
             {"gpt-5.3-chat-latest": {}, "gpt-5.4": {}, "gpt-5.4-runtime": {}},
-            "gpt-5.4",
             "openai/gpt-5.4-runtime",
             "gpt-5.4-runtime",
         ),
     ],
 )
-def test_opencode_provider_catalog_prefers_configured_agent_default_model(
+def test_opencode_provider_catalog_prefers_runtime_agent_model(
     monkeypatch,
     tmp_path,
     available_models,
-    configured_model,
     runtime_model,
     expected_model,
 ):
@@ -1045,7 +1043,6 @@ def test_opencode_provider_catalog_prefers_configured_agent_default_model(
             agents=SimpleNamespace(
                 opencode=SimpleNamespace(
                     default_provider="openai",
-                    default_model=configured_model,
                 )
             )
         ),
@@ -2115,8 +2112,6 @@ def test_agent_model_options_claude_strips_default_and_marks_default(monkeypatch
             },
         },
     )
-    monkeypatch.setattr(api, "_backend_default_model", lambda config, backend: "claude-opus-4-8")
-
     result = api.agent_model_options("claude")
 
     assert result["ok"] is True
@@ -2127,8 +2122,8 @@ def test_agent_model_options_claude_strips_default_and_marks_default(monkeypatch
     assert by_value["claude-opus-4-8"]["reasoning_efforts"] == ["low", "max"]
     assert by_value["claude-opus-4-8"]["label"] == "claude-opus-4-8 [1M]"
     assert by_value["claude-sonnet-4-6"]["label"] == "claude-sonnet-4-6"
-    assert by_value["claude-opus-4-8"]["default"] is True
-    assert by_value["claude-sonnet-4-6"]["default"] is False
+    assert "default" not in by_value["claude-opus-4-8"]
+    assert "default" not in by_value["claude-sonnet-4-6"]
 
 
 def test_agent_model_options_unknown_backend():
@@ -2161,7 +2156,6 @@ def test_agent_model_options_opencode_overlay_and_provider_filter(monkeypatch):
         },
     }
     monkeypatch.setattr(api, "opencode_options", lambda cwd: fake_opencode)
-    monkeypatch.setattr(api, "_backend_default_model", lambda config, backend: None)
     monkeypatch.setattr(opencode_config, "read_opencode_custom_providers", lambda **kw: {"deepseek": {}})
 
     result = api.agent_model_options("opencode")

--- a/tests/test_v2_compat_platforms.py
+++ b/tests/test_v2_compat_platforms.py
@@ -122,7 +122,7 @@ def test_to_app_config_uses_shared_agent_defaults() -> None:
     assert compat.opencode.error_retry_limit == DEFAULT_OPENCODE_ERROR_RETRY_LIMIT
 
 
-def test_to_app_config_exposes_opencode_default_model_fields() -> None:
+def test_to_app_config_exposes_opencode_provider_and_reasoning_fields() -> None:
     config = V2Config(
         mode="self_host",
         version="v2",
@@ -132,14 +132,12 @@ def test_to_app_config_exposes_opencode_default_model_fields() -> None:
         ui=UiConfig(),
         update=UpdateConfig(),
     )
-    config.agents.opencode.default_model = "gpt-5.4"
     config.agents.opencode.default_reasoning_effort = "high"
     config.agents.opencode.default_provider = "openai"
 
     compat = to_app_config(config)
 
     assert compat.opencode is not None
-    assert compat.opencode.default_model == "gpt-5.4"
     assert compat.opencode.default_reasoning_effort == "high"
     assert compat.opencode.default_provider == "openai"
 

--- a/tests/test_vibe_agent_model_prefill.py
+++ b/tests/test_vibe_agent_model_prefill.py
@@ -1,0 +1,92 @@
+import ast
+import json
+from pathlib import Path
+
+from core.vibe_agents import RECOMMENDED_AGENT_MODELS, VibeAgentStore
+from storage.models import agents
+
+
+def test_agent_creation_materializes_recommended_models(tmp_path: Path) -> None:
+    store = VibeAgentStore(tmp_path / "state.db")
+    try:
+        builtins = {
+            agent.backend: agent
+            for agent in store.ensure_builtin_default_agents(RECOMMENDED_AGENT_MODELS)
+        }
+        for backend, expected in RECOMMENDED_AGENT_MODELS.items():
+            assert builtins[backend].model == expected
+            created = store.create(name=f"new-{backend}", backend=backend)
+            assert created.model == expected
+
+        explicit = store.create(name="custom", backend="claude", model="claude-sonnet-5")
+        assert explicit.model == "claude-sonnet-5"
+    finally:
+        store.close()
+
+
+def test_missing_model_migration_is_idempotent_and_preserves_user_values(tmp_path: Path) -> None:
+    db_path = tmp_path / "state.db"
+    store = VibeAgentStore(db_path)
+    try:
+        missing = store.create(name="legacy", backend="codex", model="gpt-5.5")
+        explicit = store.create(name="user-set", backend="codex", model="gpt-5.4")
+        with store.engine.begin() as conn:
+            conn.execute(agents.update().where(agents.c.id == missing.id).values(model=None))
+    finally:
+        store.close()
+
+    migrated = VibeAgentStore(db_path)
+    try:
+        assert migrated.require("legacy").model == "gpt-5.6-sol"
+        assert migrated.require(explicit.name).model == "gpt-5.4"
+        assert migrated.prefill_missing_models() == 0
+    finally:
+        migrated.close()
+
+
+def test_clearing_agent_model_materializes_the_recommendation(tmp_path: Path) -> None:
+    store = VibeAgentStore(tmp_path / "state.db")
+    try:
+        store.create(name="worker", backend="opencode", model="anthropic/claude-opus-5")
+        updated = store.update("worker", model=None)
+        assert updated.model == "openai/gpt-5.6-sol"
+    finally:
+        store.close()
+
+
+def test_recommendations_exist_in_bundled_model_catalog() -> None:
+    root = Path(__file__).resolve().parents[1]
+    catalog = json.loads((root / "vibe/data/backend_models.json").read_text(encoding="utf-8"))
+    backends = catalog["backends"]
+    claude_models = {item["id"] for item in backends["claude"]["models"]}
+    codex_models = {item["id"] for item in backends["codex"]["models"]}
+
+    assert RECOMMENDED_AGENT_MODELS["claude"] in claude_models
+    assert RECOMMENDED_AGENT_MODELS["codex"] in codex_models
+    provider, opencode_model = RECOMMENDED_AGENT_MODELS["opencode"].split("/", 1)
+    assert provider == "openai"
+    assert opencode_model in codex_models
+
+
+def test_runtime_has_no_backend_default_model_reads() -> None:
+    root = Path(__file__).resolve().parents[1]
+    runtime_roots = [root / name for name in ("config", "core", "modules", "vibe", "scripts")]
+    matches = []
+    for runtime_root in runtime_roots:
+        for path in runtime_root.rglob("*.py"):
+            source = path.read_text(encoding="utf-8")
+            tree = ast.parse(source, filename=str(path))
+            for node in ast.walk(tree):
+                attribute_read = isinstance(node, ast.Attribute) and node.attr == "default_model"
+                getattr_read = (
+                    isinstance(node, ast.Call)
+                    and isinstance(node.func, ast.Name)
+                    and node.func.id == "getattr"
+                    and len(node.args) >= 2
+                    and isinstance(node.args[1], ast.Constant)
+                    and node.args[1].value == "default_model"
+                )
+                if attribute_read or getattr_read:
+                    matches.append(str(path.relative_to(root)))
+                    break
+    assert matches == []

--- a/tests/test_web_oauth_flow.py
+++ b/tests/test_web_oauth_flow.py
@@ -881,7 +881,7 @@ def test_opencode_provider_test_returns_excerpt_from_non_text_part(
     assert fake.inactive_calls == ["sess_probe"]
 
 
-def test_opencode_provider_test_prefers_configured_agent_default_model(
+def test_opencode_provider_test_uses_provider_catalog_without_agent_model(
     service: AgentAuthService, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     fake = _FakeOpencodeServer()
@@ -914,7 +914,6 @@ def test_opencode_provider_test_prefers_configured_agent_default_model(
         "_resolve_backend_config",
         lambda backend: SimpleNamespace(
             default_provider="openai",
-            default_model="gpt-5.4",
         )
         if backend == "opencode"
         else None,
@@ -923,10 +922,10 @@ def test_opencode_provider_test_prefers_configured_agent_default_model(
     result = _run(service.test_opencode_provider("openai"))
 
     assert result["ok"] is True
-    assert result["model"] == "gpt-5.4"
+    assert result["model"] == "gpt-5.3-chat-latest"
     assert fake.prompt_calls[-1]["model"] == {
         "providerID": "openai",
-        "modelID": "gpt-5.4",
+        "modelID": "gpt-5.3-chat-latest",
     }
 
 

--- a/ui/src/components/Wizard.tsx
+++ b/ui/src/components/Wizard.tsx
@@ -84,7 +84,6 @@ const buildConfigPayload = (data: any, enabledPlatformOverride?: string[]) => {
       enabled: data.agents?.opencode?.enabled ?? true,
       cli_path: data.agents?.opencode?.cli_path || 'opencode',
       default_agent: data.opencode_default_agent ?? data.agents?.opencode?.default_agent ?? null,
-      default_model: data.opencode_default_model ?? data.agents?.opencode?.default_model ?? null,
       default_reasoning_effort: data.opencode_default_reasoning_effort ?? data.agents?.opencode?.default_reasoning_effort ?? null,
     },
     claude: {
@@ -92,14 +91,12 @@ const buildConfigPayload = (data: any, enabledPlatformOverride?: string[]) => {
       ...data.agents?.claude,
       enabled: data.agents?.claude?.enabled ?? true,
       cli_path: data.agents?.claude?.cli_path || 'claude',
-      default_model: data.claude_default_model ?? data.agents?.claude?.default_model ?? null,
     },
     codex: {
       // Preserve existing codex config
       ...data.agents?.codex,
       enabled: data.agents?.codex?.enabled ?? false,
       cli_path: data.agents?.codex?.cli_path || 'codex',
-      default_model: data.codex_default_model ?? data.agents?.codex?.default_model ?? null,
     },
   },
   // Preserve gateway config entirely

--- a/ui/src/components/settings/models/AgentCard.test.tsx
+++ b/ui/src/components/settings/models/AgentCard.test.tsx
@@ -37,7 +37,6 @@ const agent = (over: Partial<AgentSupply> = {}): AgentSupply => ({
   menu_kind: 'fixed',
   selected_by_agent: null,
   selected_model_id: 'claude-opus-4-6',
-  current: { model_id: 'claude-opus-4-6', source_id: 'src_a', channel: 'hub' },
   sources: { policy: 'follow', order: ['src_a'], eligibility: [] },
   supply_status: 'ok',
   model_supply: [{ model_id: 'claude-opus-4-6', chain_length: 1 }],
@@ -105,15 +104,15 @@ const render = (
 );
 
 describe('AgentCard model list', () => {
-  it('shows every model, the current marker, and the actual serving source', () => {
+  it('shows every model and the actual serving source without a current badge', () => {
     const html = render(
       [agent()],
       chains(chain('claude-opus-4-6'), chain('claude-sonnet-4-6')),
     );
     expect(html).toContain('claude-opus-4-6');
     expect(html).toContain('claude-sonnet-4-6');
-    expect(html).toContain(zh.settings.models.current);
     expect(html).toContain('当前由 Anthropic API Key 供给');
+    expect(html).not.toContain('>当前</');
   });
 
   it('explains an automatic switch on the current model row', () => {
@@ -146,7 +145,7 @@ describe('AgentCard model list', () => {
   });
 
   it('renders an honest row-zero state when no model is selected', () => {
-    const html = render([agent({ selected_model_id: null, current: null })], chains(chain('claude-opus-4-6')));
+    const html = render([agent({ selected_model_id: null })], chains(chain('claude-opus-4-6')));
     expect(html).toContain(zh.settings.models.emptySelection.title);
     expect(html).toContain(zh.settings.models.emptySelection.action);
   });
@@ -218,7 +217,6 @@ describe('AgentCard model list', () => {
       backend: 'opencode',
       menu_kind: 'open',
       selected_model_id: 'anthropic/claude-opus-4-6',
-      current: null,
       sources: {
         policy: 'custom',
         order: ['src_enabled'],
@@ -250,7 +248,6 @@ describe('AgentCard model list', () => {
         backend: 'opencode',
         menu_kind: 'open',
         selected_model_id: null,
-        current: null,
         model_supply: [],
         mappings: [],
         menu: { view: 'featured', checked: [] },
@@ -301,7 +298,7 @@ describe('AgentCard model list', () => {
   });
 
   it('keeps Direct honest and offers the managed-mode action instead of order editing', () => {
-    const html = render([agent({ mode: 'direct', sources: null, current: null })], {});
+    const html = render([agent({ mode: 'direct', sources: null })], {});
     expect(html).toContain(zh.settings.models.modelStatus.direct);
     expect(html).toContain(zh.settings.models.agents.enableManaged);
     expect(html).not.toContain(zh.settings.models.agents.sourceOrder);

--- a/ui/src/components/settings/models/AgentCard.tsx
+++ b/ui/src/components/settings/models/AgentCard.tsx
@@ -288,7 +288,7 @@ const ModelRow: React.FC<{
   const { t } = useTranslation();
   const [expanded, setExpanded] = React.useState(false);
   const configurable = agent.mode === 'hub';
-  const current = agent.selected_model_id === modelId;
+  const selected = agent.selected_model_id === modelId;
   const head = runnableHead(read);
   const headIndex = read?.kind === 'ready' && head ? read.chain.chain.indexOf(head) : -1;
   const runtimeBlocked = head?.channel === 'hub' && Boolean(runtime && runtime.status.health !== 'ok');
@@ -342,7 +342,7 @@ const ModelRow: React.FC<{
     status = t('settings.models.modelStatus.ok') as string;
     const serving = sourceName(sources, head.source_id);
     detail = t(
-      current
+      selected
         ? headIndex > 0
           ? 'settings.models.modelStatus.currentSwitched'
           : 'settings.models.modelStatus.currentSource'
@@ -404,21 +404,14 @@ const ModelRow: React.FC<{
   ) : null;
 
   return (
-    <div className={cn('border-b border-border last:border-b-0', current && 'bg-mint-soft/35')} data-model-issue={needsAttention || undefined}>
+    <div className={cn('border-b border-border last:border-b-0', selected && 'bg-mint-soft/35')} data-model-issue={needsAttention || undefined}>
       <div className="group grid min-w-0 grid-cols-[minmax(0,1fr)] items-center gap-3 px-4 py-3 sm:grid-cols-[minmax(180px,0.9fr)_minmax(260px,1.4fr)_auto] sm:px-5">
         <button
           type="button"
           onClick={() => configurable && setExpanded((value) => !value)}
           className="min-w-0 text-left"
         >
-          <span className="flex min-w-0 items-center gap-2">
-            <span className="truncate font-mono text-[12.5px] font-semibold text-foreground">{modelId}</span>
-            {current && (
-              <Badge variant="success" className="shrink-0 px-1.5 py-0 text-[9.5px]">
-                {t('settings.models.current')}
-              </Badge>
-            )}
-          </span>
+          <span className="truncate font-mono text-[12.5px] font-semibold text-foreground">{modelId}</span>
         </button>
 
         <button

--- a/ui/src/components/settings/models/BackendSupplyModeCard.tsx
+++ b/ui/src/components/settings/models/BackendSupplyModeCard.tsx
@@ -189,12 +189,9 @@ export const BackendSupplyModeCard: React.FC<{ backend: AgentBackend }> = ({ bac
             backend: t(`settings.models.backends.${backend}`, { defaultValue: backend }),
           }) as string}
         >
-          {/* The banner asks the supply question, not the pin question: a Hub
-              backend with no pinned model has `current: null` and is perfectly
-              healthy, so keying the warning off that field warned the wrong
-              people — and reassured the interrupted ones with a Direct fallback
-              that does not exist. `fixHint` is appended only where a human can
-              actually do something; a cooling source needs no instructions. */}
+          {/* The banner asks the supply question. `fixHint` is appended only
+              where a human can actually do something; a cooling source needs
+              no instructions. */}
           {mode === 'hub' && isSupplyWarning(hubOutcome) && (
             <div className="flex items-start gap-2 rounded-lg border border-gold/40 bg-gold/[0.08] px-3.5 py-2.5 text-[12px] leading-relaxed text-foreground">
               <Info className="mt-0.5 size-3.5 shrink-0 text-gold" />

--- a/ui/src/components/settings/models/SettingsModelsPage.tsx
+++ b/ui/src/components/settings/models/SettingsModelsPage.tsx
@@ -315,10 +315,9 @@ export const SettingsModelsPage: React.FC = () => {
   const connectHub = async (agent: AgentSupply) => {
     setConnecting(agent.backend);
     try {
-      // What the PATCH echo means is a rule, not an ad-hoc read of one field —
-      // see connectOutcome, which exists because `current: null` conflates four
-      // unrelated states and the copy behind it promised a Direct fallback the
-      // resolver does not perform.
+      // What the PATCH echo means is a rule, not an ad-hoc read of one field.
+      // `connectOutcome` combines mode and supply status so the copy never
+      // promises a Direct fallback the resolver does not perform.
       const echoed = await modelsApi.setAgentMode(agent.backend, 'hub');
       const outcome = connectOutcome(echoed, sources);
       await agentSaved(echoed);

--- a/ui/src/components/settings/models/SupplyGapNote.tsx
+++ b/ui/src/components/settings/models/SupplyGapNote.tsx
@@ -4,7 +4,7 @@
 // says why that naming matters: 「删除后 pm 将没有可用来源」 is actionable where a
 // bare (backend, model) pair is not. So this renders the Agents first and the
 // model second, and falls back to the backend only when no named Agent runs the
-// pair — which is a real case (the backend default supplies it) and not a reason
+// pair — which is a real case (a mapping or Agent selection supplies it) and not a reason
 // to drop the entry.
 //
 // One component for all three sites — the forced-delete confirm, the forced

--- a/ui/src/components/settings/models/chips.tsx
+++ b/ui/src/components/settings/models/chips.tsx
@@ -12,7 +12,7 @@ import { useTranslation } from 'react-i18next';
 import { ACCENT_DOT, type Accent } from './vendorMeta';
 import type { AgentMode, SourceState } from './types';
 
-/** Status dot used in the ● 当前 chip and the 最近切换 list. */
+/** Shared status dot used by source supply and recent-switch rows. */
 export const Dot: React.FC<{ accent: Accent; className?: string }> = ({ accent, className }) => (
   <span className={cn('inline-block size-1.5 shrink-0 rounded-full', ACCENT_DOT[accent], className)} aria-hidden />
 );
@@ -87,22 +87,6 @@ export const StateChip: React.FC<{ state: SourceState }> = ({ state }) => {
     default:
       return null;
   }
-};
-
-/**
- * ● 当前 — the source this Agent is resolved onto right now (§4.3), which is a
- * per-Agent fact: the same source is 当前 for one backend and merely enabled for
- * another. Sits in the state chip's column, and the two are mutually exclusive by
- * construction — a source that isn't serving normally can't be the current one.
- */
-export const CurrentChip: React.FC = () => {
-  const { t } = useTranslation();
-  return (
-    <Badge variant="success" className={cn(CHIP_MOBILE, 'text-[10px] sm:text-[11px]')}>
-      <Dot accent="mint" />
-      {t('settings.models.current')}
-    </Badge>
-  );
 };
 
 /**

--- a/ui/src/components/settings/models/format.test.ts
+++ b/ui/src/components/settings/models/format.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { cooldownEtaMinutes, currencySymbol, formatNameList, formatSpend, friendlyModelName } from './format';
-import type { AgentSupply, Source, SuppliedModel } from './types';
+import { cooldownEtaMinutes, currencySymbol, formatNameList, formatSpend } from './format';
 
 describe('currencySymbol', () => {
   it('falls back to USD when the backend reports no currency', () => {
@@ -17,28 +16,19 @@ describe('currencySymbol', () => {
   });
 
   it('returns no symbol for a code it cannot map', () => {
-    // Callers use '' to pick a currency-free label instead of printing a wrong
-    // symbol — the amount cell carries the authoritative value.
     expect(currencySymbol('JPY')).toBe('');
   });
 
-  // The billing chip renders currencySymbol(...) while the usage cell renders
-  // formatSpend(...). They must never disagree: a static '$' on the chip read
-  // "按量 $" beside "¥12.4" for a CNY source (Codex P2, 2026-07-25).
   it('agrees with the symbol formatSpend uses, for every currency', () => {
-    for (const c of [null, undefined, 'USD', 'CNY', 'EUR', 'JPY'] as const) {
-      expect(formatSpend(1240, c).startsWith(currencySymbol(c))).toBe(true);
-      const stripped = formatSpend(1240, c).slice(currencySymbol(c).length);
+    for (const currency of [null, undefined, 'USD', 'CNY', 'EUR', 'JPY'] as const) {
+      expect(formatSpend(1240, currency).startsWith(currencySymbol(currency))).toBe(true);
+      const stripped = formatSpend(1240, currency).slice(currencySymbol(currency).length);
       expect(stripped).toBe('12.4');
     }
   });
 });
 
 describe('formatSpend', () => {
-  // Owner ruling 2026-07-25: upstream vendors bill in USD, so a missing currency
-  // must render as USD and the UI must never fall back to a local currency.
-  // This is the tripwire for that decision — if someone restores a CNY (or any
-  // other) fallback, this fails instead of shipping silently.
   it('falls back to USD when the backend reports no currency', () => {
     expect(formatSpend(1240, null)).toBe('$12.4');
     expect(formatSpend(1240, undefined)).toBe('$12.4');
@@ -46,19 +36,16 @@ describe('formatSpend', () => {
   });
 
   it('honors an explicitly reported currency', () => {
-    // The ISO 4217 map is deliberately retained: a source that genuinely bills in
-    // CNY/EUR still renders in its own currency.
     expect(formatSpend(1240, 'USD')).toBe('$12.4');
     expect(formatSpend(1240, 'CNY')).toBe('¥12.4');
     expect(formatSpend(1240, 'EUR')).toBe('€12.4');
   });
 
-  it('omits the symbol for a currency it cannot map, keeping the amount readable', () => {
+  it('omits the symbol for a currency it cannot map', () => {
     expect(formatSpend(1240, 'JPY')).toBe('12.4');
   });
 
   it('converts cents to one decimal without applying any FX rate', () => {
-    // 1240 cents stays 12.40 whatever the symbol — amounts are never converted.
     expect(formatSpend(0, null)).toBe('$0.0');
     expect(formatSpend(5, null)).toBe('$0.1');
     expect(formatSpend(1234567, null)).toBe('$12345.7');
@@ -66,22 +53,17 @@ describe('formatSpend', () => {
 });
 
 describe('formatNameList', () => {
-  // The regression: `names.join('、')` shipped Chinese punctuation into the English
-  // UI, where the attribution line read "No supply for agent-a、agent-b".
-  it('separates with the punctuation of the reader, not of the author', () => {
+  it('separates with the punctuation of the reader', () => {
     expect(formatNameList(['agent-a', 'agent-b'], 'zh')).toBe('agent-a、agent-b');
     expect(formatNameList(['agent-a', 'agent-b'], 'en')).toBe('agent-a, agent-b');
   });
 
-  it('works from the regional tags a browser actually reports', () => {
+  it('works from regional locale tags', () => {
     expect(formatNameList(['a', 'b'], 'zh-CN')).toBe('a、b');
     expect(formatNameList(['a', 'b'], 'en-US')).toBe('a, b');
   });
 
-  // `narrow` + `conjunction` is load-bearing, not a taste: `unit` joins Chinese
-  // with NOTHING ("ab"), and the wider styles add a 和 / "and" that the 11px line
-  // has no room for. Three names is where those differ, so three names is the test.
-  it('stays a plain separated list at three names, in both locales', () => {
+  it('stays a plain separated list at three names', () => {
     expect(formatNameList(['a', 'b', 'c'], 'zh')).toBe('a、b、c');
     expect(formatNameList(['a', 'b', 'c'], 'en')).toBe('a, b, c');
   });
@@ -101,160 +83,5 @@ describe('cooldownEtaMinutes', () => {
 
   it('rounds the remaining wait to whole minutes', () => {
     expect(cooldownEtaMinutes(new Date(Date.now() + 5 * 60_000 + 1_000).toISOString())).toBe(5);
-  });
-});
-
-describe('friendlyModelName', () => {
-  const model = (id: string, display_name: string | null = null): SuppliedModel => ({
-    id,
-    display_name,
-    provenance: 'discovered',
-  });
-
-  const src = (id: string, models: SuppliedModel[], vendor = 'custom'): Source => ({
-    id,
-    kind: 'api_key',
-    vendor,
-    display_name: id,
-    protocol: 'openai_compatible',
-    supply_channel: 'hub',
-    billing: 'metered',
-    state: { status: 'active' },
-    models,
-  });
-
-  const agent = (over: Partial<AgentSupply>): AgentSupply => ({
-    backend: 'claude',
-    mode: 'hub',
-    menu_kind: 'fixed',
-    ...over,
-  });
-
-  // An opencode agent: prefixed identifiers are its shape, and `standard_vendors`
-  // is the server's mirror of the vendor ids that may head one.
-  const opencode = (over: Partial<AgentSupply>): AgentSupply =>
-    agent({ backend: 'opencode', menu_kind: 'open', standard_vendors: ['anthropic', 'zhipuai'], ...over });
-
-  it('renders nothing when no model resolves', () => {
-    expect(friendlyModelName(agent({ current: null, selected_model_id: null }), [])).toBe('');
-  });
-
-  it('prefers the supplying source name over another source that also lists the model', () => {
-    const sources = [src('src_b', [model('m1', 'Wrong One')]), src('src_a', [model('m1', 'Right One')])];
-    const a = agent({ current: { model_id: 'm1', source_id: 'src_a', channel: 'hub' } });
-    expect(friendlyModelName(a, sources)).toBe('Right One');
-  });
-
-  it('falls back from 「what is serving」 to 「what was selected」', () => {
-    // `current` is null by contract while waiting or interrupted, and a model box
-    // that empties out exactly then hides WHICH model has no supply.
-    const a = agent({ current: null, selected_model_id: 'm1' });
-    expect(friendlyModelName(a, [src('src_a', [model('m1', 'Opus')])])).toBe('Opus');
-  });
-
-  // The 「bare id」 in the contract means NO PROVIDER PREFIX, which is not the same
-  // as no slash: `SuppliedModel.id` carries no `pattern`, so a relay endpoint or a
-  // manual entry may legitimately supply a slash-bearing id under its own name.
-  it('keeps a slash-bearing supplied id whole', () => {
-    const id = 'accounts/fireworks/models/llama-v3';
-    const sources = [src('relay', [model(id, 'Llama v3 (Fireworks)')])];
-    expect(friendlyModelName(agent({ selected_model_id: id }), sources)).toBe('Llama v3 (Fireworks)');
-  });
-
-  it('never collides a relay id with another source’s same-suffix model', () => {
-    // The bug: cutting through the last slash turned this into `llama-v3` and
-    // rendered the OTHER source's name for it. Rebuilt, that model is
-    // `custom/llama-v3` — not what was selected — so nothing matches.
-    const sources = [src('other', [model('llama-v3', 'Llama v3 (Together)')])];
-    const a = agent({ selected_model_id: 'accounts/fireworks/models/llama-v3' });
-    expect(friendlyModelName(a, sources)).toBe('accounts/fireworks/models/llama-v3');
-  });
-
-  it('renders an unknown id as selected rather than as its tail', () => {
-    expect(friendlyModelName(agent({ selected_model_id: 'vendor/x/unknown' }), [])).toBe('vendor/x/unknown');
-  });
-
-  it('renders a supplied id with no display name as itself', () => {
-    const sources = [src('relay', [model('accounts/f/models/llama-v3')])];
-    const a = agent({ selected_model_id: 'accounts/f/models/llama-v3' });
-    expect(friendlyModelName(a, sources)).toBe('accounts/f/models/llama-v3');
-  });
-
-  // The counter-example that keeps the second lookup alive: an opencode SELECTION
-  // is a prefixed identifier (`zhipuai/glm-5.2`) whose SuppliedModel.id is bare, so
-  // the full form is absent from the inventory and only the rebuild resolves it.
-  it('resolves a prefixed identifier against the source that supplies it bare', () => {
-    const sources = [src('glm', [model('glm-5.2', 'GLM-5.2')], 'zhipuai')];
-    expect(friendlyModelName(opencode({ selected_model_id: 'zhipuai/glm-5.2' }), sources)).toBe('GLM-5.2');
-  });
-
-  it('resolves to the bare id even when nothing names it', () => {
-    const sources = [src('glm', [model('glm-5.2')], 'zhipuai')];
-    expect(friendlyModelName(opencode({ selected_model_id: 'zhipuai/glm-5.2' }), sources)).toBe('glm-5.2');
-  });
-
-  // `custom/` is the identifier scheme's catch-all provider, so a non-standard
-  // vendor heads NO identifier of its own — a slash-count rule would have missed
-  // this one, and the rebuild gets it for free.
-  it('resolves a custom/ identifier supplied by a non-standard vendor', () => {
-    const sources = [src('relay', [model('glm-5.2-air', 'GLM-5.2 Air')], 'relay.example')];
-    expect(friendlyModelName(opencode({ selected_model_id: 'custom/glm-5.2-air' }), sources)).toBe('GLM-5.2 Air');
-  });
-
-  it('does not resolve a standard-vendor prefix the supplying source does not carry', () => {
-    // The relay's `glm-5.2` is `custom/glm-5.2`; claiming it for `zhipuai/glm-5.2`
-    // would name a vendor the user is not actually reaching.
-    const sources = [src('relay', [model('glm-5.2', 'GLM-5.2 (relay)')], 'relay.example')];
-    expect(friendlyModelName(opencode({ selected_model_id: 'zhipuai/glm-5.2' }), sources)).toBe('zhipuai/glm-5.2');
-  });
-
-  it('prefers the supplying source when two sources supply the same model', () => {
-    // `current.model_id` is the RESOLVED upstream id — bare even on an open menu,
-    // per the contract ("NOT a valid input to the chain query"). An earlier version
-    // of this test fed it prefixed, which the payload cannot produce.
-    const sources = [
-      src('glm_b', [model('glm-5.2', 'Wrong One')], 'zhipuai'),
-      src('glm_a', [model('glm-5.2', 'Right One')], 'zhipuai'),
-    ];
-    const a = opencode({ current: { model_id: 'glm-5.2', source_id: 'glm_a', channel: 'hub' } });
-    expect(friendlyModelName(a, sources)).toBe('Right One');
-  });
-
-  // ── Where the two axes DISAGREE ──────────────────────────────────────
-  // The 12 cases above all pin agreement: 「which source」 and 「which reading of
-  // the id」 point the same way, so they stayed green through a regression that
-  // nested the axes the wrong way round. These three make them conflict and
-  // assert which wins.
-
-  it('does not walk past the serving source to a source that can name the model', () => {
-    // The server named `glm_a`; its inventory does not (yet) list what it is
-    // running. The bare upstream id is the honest answer — `glm_b`'s name is for
-    // `glm_b`'s model, and borrowing it claims a route the user does not have.
-    const sources = [src('glm_b', [model('glm-5.2', 'Borrowed Name')], 'zhipuai'), src('glm_a', [], 'zhipuai')];
-    const a = opencode({ current: { model_id: 'glm-5.2', source_id: 'glm_a', channel: 'hub' } });
-    expect(friendlyModelName(a, sources)).toBe('glm-5.2');
-  });
-
-  it('reads an open-menu selection as an identifier even where another source lists it literally', () => {
-    // A relay can supply a model whose literal id looks like an identifier. On an
-    // open menu the selection IS an identifier, so the relay's `zhipuai/glm-5.2`
-    // rebuilds to `custom/zhipuai/glm-5.2` and does not answer for it — the
-    // exact-looking match is the wrong reading, not the stronger one.
-    const sources = [
-      src('relay', [model('zhipuai/glm-5.2', 'Wrong (relay)')], 'relay.example'),
-      src('glm', [model('glm-5.2', 'GLM-5.2')], 'zhipuai'),
-    ];
-    expect(friendlyModelName(opencode({ selected_model_id: 'zhipuai/glm-5.2' }), sources)).toBe('GLM-5.2');
-  });
-
-  it('names what is running, read as an upstream id, when a mapping redirected the selection', () => {
-    // 「我选的 anthropic/claude-opus-4-6, 实际在跑 glm-5.2」. Applying the identifier
-    // reading to a RESOLVED id would look for `zhipuai/glm-5.2` and miss.
-    const sources = [src('glm', [model('glm-5.2', 'GLM-5.2')], 'zhipuai')];
-    const a = opencode({
-      selected_model_id: 'anthropic/claude-opus-4-6',
-      current: { model_id: 'glm-5.2', source_id: 'glm', channel: 'hub' },
-    });
-    expect(friendlyModelName(a, sources)).toBe('GLM-5.2');
   });
 });

--- a/ui/src/components/settings/models/format.ts
+++ b/ui/src/components/settings/models/format.ts
@@ -1,8 +1,5 @@
 // Pure formatting helpers for the Model Hub UI (no i18n — callers wrap the
 // returned values in translated templates).
-import { buildIdentifier } from './menus/identifiers';
-import type { AgentSupply, Source, SuppliedModel } from './types';
-
 const CURRENCY_SYMBOL: Record<string, string> = { USD: '$', CNY: '¥', EUR: '€' };
 
 /**
@@ -42,79 +39,4 @@ export function cooldownEtaMinutes(retryAt?: string | null): number {
   if (!retryAt) return 0;
   const ms = new Date(retryAt).getTime() - Date.now();
   return Math.max(0, Math.round(ms / 60_000));
-}
-
-/**
- * Friendly name for the model a backend is set to run.
- *
- * Falls back from 「what is serving」 to 「what was selected」 on purpose: while an
- * Agent is waiting or interrupted `current` is null by contract, and a model box
- * that empties out at exactly the moment something went wrong hides the one fact
- * the user needs — WHICH model has no supply. The display name is then looked up
- * across all sources, since the source that used to name it may be the one that
- * just failed.
- *
- * A prefixed identifier is RESOLVED, never stripped. The old code cut through the
- * last slash first and unconditionally, on the reading that `SuppliedModel.id` is a
- * 「bare model id (no provider prefix)」 — but the contract puts no `pattern` on that
- * field, and 「no provider prefix」 is not 「no slash」. A relay endpoint supplies
- * `accounts/fireworks/models/llama-v3` under exactly that name, so the cut both lost
- * the metadata the id carries and matched some OTHER source's `llama-v3`, rendering
- * a model the user never selected.
- *
- * The fix is not a smarter cut — a bare tail is ambiguous in both directions, and
- * nothing about `llama-v3` says whether a prefix was dropped. It is to rebuild the
- * identifier the way the backend does. Per the frozen opencode overlay an identifier
- * is `inferProvider(source.vendor)/model.id`, so a supplied model can be matched on
- * provider AND id through the one function that owns that scheme, and a tail
- * collision becomes impossible rather than merely unlikely: `llama-v3` from a
- * `custom` source rebuilds to `custom/llama-v3`, which is not what was selected.
- *
- * An identifier neither lookup resolves renders as selected: verbose beats wrong.
- *
- * Two axes decide the lookup — WHICH SOURCE may answer, and WHICH READING of the id
- * to match on — and nesting them the wrong way round is a bug of its own. The source
- * axis outranks the form axis, because the server has already resolved which source
- * serves: an ordered scan that tries a stronger *form* match in a source the server
- * did NOT name walks past the serving source and renders someone else's model. So the
- * source is settled first, and the reading is not searched at all — it is dictated by
- * WHICH FIELD supplied the id, since the two fields are not the same shape:
- *
- *   `current.model_id`      the RESOLVED upstream id, mapping already applied — bare
- *                           even on an open menu ("NOT a valid input to the chain
- *                           query … the caller-facing identifier is prefixed").
- *                           Read exactly, and only against `current.source_id`.
- *   `selected_model_id`     the caller-facing MENU identifier — the built-in id for a
- *                           fixed menu, `vendor/model` for an open one. Read per
- *                           `menu_kind`, against every source: `current` is null
- *                           exactly when nothing is serving, so no source is
- *                           authoritative and none can be preferred honestly.
- */
-export function friendlyModelName(agent: AgentSupply, sources: Source[]): string {
-  const current = agent.current ?? null;
-  if (current) {
-    // One source, one reading. A miss renders the upstream id — which is the honest
-    // answer when the serving source's inventory cannot name what it is running,
-    // and strictly better than a name borrowed from a source that is not serving.
-    const serving = sources.find((s) => s.id === current.source_id);
-    const model = serving?.models.find((m) => m.id === current.model_id);
-    return model?.display_name || current.model_id;
-  }
-
-  const selected = agent.selected_model_id ?? null;
-  if (!selected) return '';
-
-  const standardVendors = new Set(agent.standard_vendors ?? []);
-  // `display_name || id`, not a `display_name` predicate: a supplied model with no
-  // name still owns its id and must not fall through to a later source.
-  const holds = (source: Source, model: SuppliedModel): boolean =>
-    agent.menu_kind === 'open'
-      ? buildIdentifier(source.vendor, model.id, standardVendors) === selected
-      : model.id === selected;
-  for (const source of sources) {
-    const model = source.models.find((m) => holds(source, m));
-    if (model) return model.display_name || model.id;
-  }
-
-  return selected;
 }

--- a/ui/src/components/settings/models/mockData.ts
+++ b/ui/src/components/settings/models/mockData.ts
@@ -151,7 +151,6 @@ export function buildMockAgents(sources: Source[] = buildMockSources()): AgentSu
       // A stored request stands behind the id, which is what the server reports
       // as explicit — the resolver-picked case only exists on the open menu.
       selected_model_explicit: true,
-      current: { model_id: 'claude-opus-4-6', source_id: 'src_claudepro1', channel: 'native_cli' },
       sources: {
         policy: 'custom',
         order: claudeOrder,
@@ -193,7 +192,6 @@ export function buildMockAgents(sources: Source[] = buildMockSources()): AgentSu
       selected_by_agent: 'codex',
       selected_model_id: 'gpt-5.6',
       selected_model_explicit: true,
-      current: { model_id: 'gpt-5.6', source_id: 'src_chatgptplus', channel: 'native_cli' },
       sources: {
         policy: 'follow',
         // Recomputed on every read: 跟随推荐 means a new source joins by itself.
@@ -223,7 +221,6 @@ export function buildMockAgents(sources: Source[] = buildMockSources()): AgentSu
       selected_by_agent: null,
       selected_model_id: null,
       selected_model_explicit: false,
-      current: null,
       sources: null,
       supply_status: null,
       model_supply: null,

--- a/ui/src/components/settings/models/modelRows.test.ts
+++ b/ui/src/components/settings/models/modelRows.test.ts
@@ -22,7 +22,6 @@ const agent = (over: Partial<AgentSupply> = {}): AgentSupply => ({
   menu_kind: 'fixed',
   selected_by_agent: null,
   selected_model_id: 'current-model',
-  current: null,
   sources: { policy: 'follow', order: [], eligibility: [] },
   supply_status: 'ok',
   model_supply: [{ model_id: 'supply-model', chain_length: 1 }],

--- a/ui/src/components/settings/models/modelsApi.ts
+++ b/ui/src/components/settings/models/modelsApi.ts
@@ -424,7 +424,7 @@ class MockStore {
   // Every read of an agent re-derives what the real server derives: the
   // per-backend order (recommended under `follow`, pruned under `custom`),
   // eligibility, and the supply rollup. That is what makes a drag-reorder or a
-  // source deletion move 使用中 in the demo instead of leaving it stale.
+  // source deletion update supply status in the demo instead of leaving it stale.
   private syncAgents() {
     for (const a of this.agents) {
       if (a.mode === 'direct') {
@@ -449,7 +449,6 @@ class MockStore {
    *  runnability (not blocked), then the rollup over the resulting chain. */
   private deriveSupply(a: AgentSupply) {
     if (a.mode === 'direct') {
-      a.current = null;
       a.selected_model_id = null;
       a.selected_model_explicit = false;
       a.selected_by_agent = null;
@@ -470,18 +469,15 @@ class MockStore {
     }
     const selected = a.selected_model_id ?? null;
     if (!selected) {
-      a.current = null;
       a.supply_status = null;
     } else {
       const chain = chainFor(selected);
       const head = chain.find(isRunnable) ?? null;
       const blocked = chain.filter((s) => !isRunnable(s));
       if (!head) {
-        a.current = null;
         a.supply_status =
           chain.length > 0 && blocked.every((s) => s.state.status === 'cooldown') ? 'waiting' : 'interrupted';
       } else {
-        a.current = { model_id: selected, source_id: head.id, channel: head.supply_channel };
         a.supply_status = head.id === chain[0]?.id && blocked.length === 0 ? 'ok' : 'degraded';
       }
     }
@@ -827,7 +823,7 @@ class MockStore {
     agent.mode = mode;
     if (mode === 'hub') {
       // Rejoining the hub starts on the recommendation, and picks up whatever
-      // model the backend defaults to (first built-in / first supplied id).
+      // model selected for the Agent (first built-in / first supplied id in mock mode).
       agent.sources = { policy: 'follow', order: [], eligibility: null };
       agent.selected_model_id = agent.builtin_models?.[0] ?? this.sources[0]?.models[0]?.id ?? null;
       // The server's default comes from the STORED per-backend request, so a

--- a/ui/src/components/settings/models/repair.test.ts
+++ b/ui/src/components/settings/models/repair.test.ts
@@ -341,7 +341,7 @@ const agent = (over: Partial<AgentSupply> = {}): AgentSupply => ({
   mode: 'hub',
   menu_kind: 'fixed',
   sources: { policy: 'follow', order: ['src_a'] },
-  current: { model_id: 'claude-opus-4-6', source_id: 'src_a', channel: 'hub' },
+  supply_status: 'ok',
   ...over,
 });
 
@@ -359,26 +359,6 @@ const probe = (over: Partial<ProbeResult> = {}): ProbeResult => ({
   via_mapping: false,
   error: null,
   ...over,
-});
-
-describe('dryRunPlan — whether 试跑 has anything to run (SourceOrderDrawer)', () => {
-  it('probes an Agent with a resolved chain head', () => {
-    expect(dryRunPlan(agent())).toEqual({ kind: 'probe', backend: 'claude' });
-    expect(dryRunPlan(agent({ backend: 'codex' }))).toEqual({ kind: 'probe', backend: 'codex' });
-  });
-
-  it('runs nothing in direct mode', () => {
-    // AC-7: the route refuses with `direct_mode`, because there is no `src_*`
-    // identity to report a turn against.
-    expect(dryRunPlan(agent({ mode: 'direct', sources: null, current: null }))).toEqual({ kind: 'none' });
-  });
-
-  it('runs nothing when there is no head', () => {
-    // A null `current` IS waiting/interrupted. The page already says so with the
-    // remedy attached; a probe would only re-report it as a failure the user has
-    // to re-read.
-    expect(dryRunPlan(agent({ current: null, supply_status: 'interrupted' }))).toEqual({ kind: 'none' });
-  });
 });
 
 describe('dryRunChainKey — which edits make a 试跑 report stop being about anything', () => {
@@ -443,13 +423,10 @@ describe('dryRunChainKey — which edits make a 试跑 report stop being about a
   });
 
   it('holds still for everything the server derives from those', () => {
-    // The trap this key exists inside: a failing 试跑 cools its own head down and
-    // the re-read it owes then moves `agent.current`, the rollup, and the source
-    // health behind it. Key on any of those and the failing run is the one whose
-    // answer erases itself. The head moving is what a failing report is FOR.
+    // A failing 试跑 cools its own head down, moving the rollup and source health.
+    // Neither is a selection/config fact.
     const same = key();
-    expect(key({ current: { model_id: 'glm-5.2', source_id: 'src_b', channel: 'hub' } })).toBe(same);
-    expect(key({ current: null, supply_status: 'interrupted' })).toBe(same);
+    expect(key({ supply_status: 'interrupted' })).toBe(same);
     expect(key({ supply_status: 'degraded' })).toBe(same);
   });
 
@@ -602,7 +579,7 @@ describe('dryRunOutcome — what the per-model probe came back with', () => {
   });
 
   it('falls back to the id when the source is gone', () => {
-    // Same tolerance `chainChips` keeps: an id that no longer resolves is still
+    // Same tolerance the source rows keep: an id that no longer resolves is still
     // more informative than an empty name.
     expect(dryRunOutcome(probe({ source_id: 'src_gone' }), [])).toEqual({
       kind: 'ok',
@@ -877,10 +854,10 @@ describe('dryRunRowView — a report that outlives the chain it was about', () =
   it('keeps the answer on screen after 试跑 itself took the head away', () => {
     // The case the row creates: probing the chain's last runnable source and
     // failing cools that source down, so the re-read `probeWroteState` demands
-    // comes back with `current: null` — and the plan the row is drawn from turns
-    // `none` under the sentence the click just produced. Dropping it there would
+    // comes back interrupted — and the plan the row is drawn from turns `none`
+    // under the sentence the click just produced. Dropping it there would
     // make the failing run the only one whose answer flashes past.
-    const headless = dryRunPlan(agent({ current: null, supply_status: 'interrupted' }));
+    const headless = dryRunPlan(agent({ supply_status: 'interrupted' }));
 
     expect(dryRunRowView(headless, { ...idle, line: 'Key A 没跑通' })).toEqual({
       backend: null,
@@ -893,7 +870,7 @@ describe('dryRunRowView — a report that outlives the chain it was about', () =
     // Direct mode, or a chain that was already stopped when the drawer opened. The
     // page states that one level up with the remedy attached; an empty row here, or
     // a disabled button, would only repeat it.
-    expect(dryRunRowView(dryRunPlan(agent({ mode: 'direct', sources: null, current: null })), idle)).toEqual({
+    expect(dryRunRowView(dryRunPlan(agent({ mode: 'direct', sources: null })), idle)).toEqual({
       backend: null,
       enabled: false,
       report: false,

--- a/ui/src/components/settings/models/repair.ts
+++ b/ui/src/components/settings/models/repair.ts
@@ -276,38 +276,19 @@ export const REPAIR_TOAST: Record<RepairOutcome['kind'], { key: string; tone: 's
 
 // ── 试跑 (dry run) ───────────────────────────────────────────────────────
 
-/**
- * Whether a dry run has anything real to run for this Agent.
- *
- * `none` covers direct mode (no `src_*` identity to report — the route refuses
- * with `direct_mode`, AC-7) and a null `current`, which is precisely
- * waiting/interrupted: there is no head, the page already says so with the
- * remedy attached, and a probe would only re-report it as a failure.
- *
- * No `model` in the request on purpose. `current.model_id` is the RESOLVED id
- * (post-mapping), while the route treats its `model` argument as the REQUESTED
- * one and maps it again — passing the head back would resolve twice and probe a
- * different model than the drawer displays. Omitted, the server uses the very
- * `_requested_model(agent)` that produced `current`, so the probe and the row
- * agree by construction rather than by a client-side guess.
- *
- * Note there is no `native` branch: 「don't fake a native test」 is honoured by
- * the SERVER, which answers a native_cli head with its CLI readiness and
- * `latency_ms: null` instead of sending a request. A client-side branch would
- * have to invent that readiness — the copy keys on the null latency instead.
- */
 export type DryRunPlan = { kind: 'probe'; backend: AgentBackend } | { kind: 'none' };
 
-/** A source's name for copy, falling back to its id — the same tolerance
- *  `chainChips` keeps for an id that no longer resolves. */
-const nameOf = (sources: Source[], id: string): string =>
-  sources.find((s) => s.id === id)?.display_name || id;
-
+/** A dry run exists only while a managed Agent has a runnable supply rollup. */
 export function dryRunPlan(agent: AgentSupply): DryRunPlan {
   if (agent.mode !== 'hub') return { kind: 'none' };
-  if (!agent.current) return { kind: 'none' };
+  if (agent.supply_status !== 'ok' && agent.supply_status !== 'degraded') return { kind: 'none' };
   return { kind: 'probe', backend: agent.backend };
 }
+
+/** A source's name for copy, falling back to its id — the same tolerance
+ *  the source rows keep for an id that no longer resolves. */
+const nameOf = (sources: Source[], id: string): string =>
+  sources.find((s) => s.id === id)?.display_name || id;
 
 /**
  * The identity of the chain a 试跑 report is ABOUT, so that a report outlives every
@@ -398,8 +379,8 @@ export function dryRunPlan(agent: AgentSupply): DryRunPlan {
  *   一次试跑; the cost of being narrow is a sentence that answers for a supplier
  *   chain that no longer exists. Only one of those two is a wrong answer.
  *
- * Excluded on purpose: `agent.current` and everything else about head health. The
- * head moving is what a failing report is FOR.
+ * Excluded on purpose: resolved-head state and everything else about health. A
+ * head moving is what a failing report is for.
  */
 export const dryRunChainKey = (
   agent: AgentSupply,
@@ -560,7 +541,7 @@ export type ProbeAnswer =
 export type ProbeArrival = {
   /** Whether this answer is still the answer to what the row is asking. */
   report: boolean;
-  /** Whether the source rows and ● 当前 behind this sheet are now stale. */
+  /** Whether the source rows and serving-chain status are now stale. */
   reread: boolean;
 };
 
@@ -572,37 +553,13 @@ export const probeArrival = (answer: ProbeAnswer, stillCurrent: boolean): ProbeA
       : mayHaveWritten(answer) || disprovedDrawnHead(answer.code),
 });
 
-/**
- * What the 试跑 row IS right now — which is not the same question as what the
- * chain is, because the row outlives the chain it reported on.
- *
- * Two rules, and neither is visible from `dryRunPlan` alone:
- *
- *  1. A REPORT survives losing its head. 试跑 is what takes the head away:
- *     probing the chain's last runnable source and failing cools that source
- *     down (`probeWroteState`), so the re-read that failure demands comes back
- *     with `current: null` and the plan turns `none`. Dropping the row there
- *     erases the sentence the click produced — making the failing run, the one
- *     the user most needs to read, the only one whose answer flashes past. So
- *     the CONTROL goes (there is nothing runnable to reach, and the page states
- *     that one level up with the remedy attached) while the LINE stays.
- *  2. The control waits for the drawer's save. That PUT is optimistic: the list
- *     — and the chain key the report is filed under — have already moved to the
- *     order the user dropped while the server still answers for the old one. A
- *     probe launched in that window reports on the superseded chain under the
- *     new one's key, and the key cannot clear it because it IS already the new
- *     key. Every other control in this drawer is disabled for that window; this
- *     one is not special.
- */
 export type DryRunRowView = {
-  /** The backend to probe, or `null` when there is nothing runnable to reach. */
   backend: AgentBackend | null;
-  /** Whether the control may be pressed now. */
   enabled: boolean;
-  /** Whether the last answer is still worth drawing. */
   report: boolean;
 };
 
+/** Keep a completed report visible even when its probe changes supply health. */
 export const dryRunRowView = (
   plan: DryRunPlan,
   row: { line: string | null; saving: boolean; running: boolean },

--- a/ui/src/components/settings/models/supply.test.ts
+++ b/ui/src/components/settings/models/supply.test.ts
@@ -1,23 +1,15 @@
-// The Models page's rules, tested where they live: as pure functions over the
-// contract types. Each `it` names the frame or the acceptance criterion that
-// decided the behaviour, because every one of these is a judgement someone can
-// otherwise "simplify" back into a boolean.
-import { describe, expect, it } from 'vitest';
-
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
 
 import {
   attribution,
-  chainChips,
-  chainRoles,
   hasAttribution,
   healthyButUnrunnable,
   isUnhealthy,
   needsAttention,
-  pageStatus,
 } from './supply';
-import type { AgentSupply, RuntimeDependency, Source, SourceState } from './types';
+import type { AgentSupply, Source, SourceState } from './types';
 
 const source = (id: string, state: SourceState, name = id): Source => ({
   id,
@@ -31,8 +23,6 @@ const source = (id: string, state: SourceState, name = id): Source => ({
   models: [],
 });
 
-/** A subscription served by rewriting the CLI's own config — no gateway, so no
- *  dependency on the engine (`model_hub.resolve()`'s native_cli branch). */
 const nativeSource = (id: string, state: SourceState, name = id): Source => ({
   ...source(id, state, name),
   kind: 'subscription',
@@ -51,15 +41,19 @@ const EXHAUSTED: SourceState = {
   retry_at: '2026-07-31T00:00:00Z',
   detail_key: 'models.source.cooldown.quota_exhausted',
 };
-const DEAD: SourceState = { status: 'needs_action', retry_at: null, detail_key: 'models.source.needs_action.oauth_expired' };
+const DEAD: SourceState = {
+  status: 'needs_action',
+  retry_at: null,
+  detail_key: 'models.source.needs_action.oauth_expired',
+};
 
 const hubAgent = (over: Partial<AgentSupply> = {}): AgentSupply => ({
   backend: 'claude',
   mode: 'hub',
   menu_kind: 'fixed',
-  selected_by_agent: null,
+  selected_by_agent: 'claude',
   selected_model_id: 'claude-opus-4-6',
-  current: { model_id: 'claude-opus-4-6', source_id: 'src_a', channel: 'hub' },
+  selected_model_explicit: true,
   sources: { policy: 'follow', order: ['src_a', 'src_b'], eligibility: [] },
   supply_status: 'ok',
   model_supply: [],
@@ -75,177 +69,44 @@ const directAgent = (): AgentSupply =>
   hubAgent({
     backend: 'opencode',
     mode: 'direct',
-    current: null,
+    selected_by_agent: null,
+    selected_model_id: null,
+    selected_model_explicit: false,
     sources: null,
     supply_status: null,
     model_supply: null,
   });
 
-/** The server's per-(source, backend) verdict that this machine cannot launch the
- *  source. `eligible: true` on purpose — the source MAY serve this backend, which
- *  is what makes the second question a separate one. */
 const cannotLaunch = (...ids: string[]) =>
-  ids.map((id) => ({ source_id: id, eligible: true, process_availability_reason: 'native_cli_unavailable' as const }));
+  ids.map((id) => ({
+    source_id: id,
+    eligible: true,
+    process_availability_reason: 'native_cli_unavailable' as const,
+  }));
 
-/** The same verdict on a source the selected model does not come from at all.
- *  `in_current_model_chain` is a claim about the ROUTE, built from the eligible
- *  sources carrying the model BEFORE health or runnability narrows them. */
 const cannotLaunchOffRoute = (...ids: string[]) =>
-  cannotLaunch(...ids).map((e) => ({ ...e, in_current_model_chain: false }));
-
-const runtime = (health: RuntimeDependency['status']['health']): RuntimeDependency => ({
-  manifest: { name: 'cliproxyapi', version: '1.0.0', source_sha: 'sha', assets: [] },
-  status: { installed_version: '1.0.0', verified: true, listening: null, health, last_check: null },
-});
+  cannotLaunch(...ids).map((eligibility) => ({ ...eligibility, in_current_model_chain: false }));
 
 describe('isUnhealthy', () => {
-  it('counts exactly the two serving statuses as healthy (§4.5)', () => {
+  it('treats only active and standby as healthy', () => {
     expect(isUnhealthy(ACTIVE)).toBe(false);
     expect(isUnhealthy(STANDBY)).toBe(false);
     expect(isUnhealthy(COOLING)).toBe(true);
     expect(isUnhealthy(DEAD)).toBe(true);
-    expect(isUnhealthy({ status: 'error', retry_at: null, detail_key: 'models.source.error.unclassified' })).toBe(true);
+    expect(isUnhealthy({ status: 'error' })).toBe(true);
   });
 });
 
 describe('needsAttention', () => {
-  // V6 01 draws a timed-out relay with a GRAY sub-line; V6 04 draws an exhausted
-  // subscription with a GOLD one. Gold means "a person has to do something".
-  it('stays gray for weather and turns gold for money (V6 01 vs V6 04)', () => {
+  it('distinguishes self-healing cooldowns from billing decisions', () => {
     expect(needsAttention(COOLING)).toBe(false);
-    expect(needsAttention({ status: 'cooldown', retry_at: null, detail_key: 'models.source.cooldown.rate_limited' })).toBe(
-      false,
-    );
     expect(needsAttention(EXHAUSTED)).toBe(true);
   });
 
-  it('is gold for every status that never heals unattended', () => {
+  it('includes every status that never heals unattended', () => {
     expect(needsAttention(DEAD)).toBe(true);
-    expect(needsAttention({ status: 'error', retry_at: null, detail_key: 'models.source.error.unclassified' })).toBe(true);
-  });
-
-  it('leaves a healthy source alone', () => {
+    expect(needsAttention({ status: 'error' })).toBe(true);
     expect(needsAttention(ACTIVE)).toBe(false);
-  });
-});
-
-describe('chainChips', () => {
-  const sources = [source('src_a', ACTIVE, 'ChatGPT Plus'), source('src_b', COOLING, 'relay.example')];
-
-  it('numbers the chain in this backend’s own order and marks 当前', () => {
-    const chips = chainChips(hubAgent(), sources);
-    expect(chips.map((c) => [c.position, c.label, c.tone])).toEqual([
-      [1, 'ChatGPT Plus', 'current'],
-      [2, 'relay.example', 'neutral'],
-    ]);
-  });
-
-  // V6 01: an unhealthy source BELOW 当前 is a warning about the next failover,
-  // not a record of one, so it keeps full contrast and only takes the gold dot.
-  it('does not dim an unhealthy source the resolver has not reached (V6 01)', () => {
-    const chips = chainChips(hubAgent(), sources);
-    expect(chips[1]).toMatchObject({ tone: 'neutral', unhealthy: true });
-  });
-
-  // V6 04: the same shape AFTER the failover — 当前 moved to position 2, so
-  // position 1 is now a record of what was skipped.
-  it('dims an unhealthy source the resolver has walked past (V6 04)', () => {
-    const agent = hubAgent({
-      current: { model_id: 'claude-opus-4-6', source_id: 'src_b', channel: 'hub' },
-    });
-    const chips = chainChips(agent, [source('src_a', EXHAUSTED, 'ChatGPT Plus'), source('src_b', ACTIVE, 'relay.example')]);
-    expect(chips.map((c) => c.tone)).toEqual(['skipped', 'current']);
-  });
-
-  it('keeps an unresolvable id visible under its bare id', () => {
-    const chips = chainChips(hubAgent(), [source('src_a', ACTIVE)]);
-    expect(chips[1]).toMatchObject({ sourceId: 'src_b', label: 'src_b', unhealthy: false });
-  });
-
-  // AC-7: a Direct backend has no Hub order at all.
-  it('draws nothing in Direct mode (AC-7)', () => {
-    expect(chainChips(directAgent(), sources)).toEqual([]);
-  });
-
-  // The second reason a position gets stepped over, and the one the source itself
-  // cannot report: its credential, its models and its state all read perfectly
-  // healthy, and the CLI that would serve it is not usable on this machine.
-  it('marks a healthy source this machine cannot launch, without calling it unhealthy', () => {
-    const agent = hubAgent({
-      sources: { policy: 'follow', order: ['src_a', 'src_b'], eligibility: cannotLaunch('src_b') },
-    });
-    const chips = chainChips(agent, [source('src_a', ACTIVE), nativeSource('src_b', ACTIVE)]);
-    expect(chips[1]).toMatchObject({ unhealthy: false, unavailable: true });
-  });
-
-  it('dims it once the resolver has walked past it, exactly like a broken one', () => {
-    const agent = hubAgent({
-      current: { model_id: 'claude-opus-4-6', source_id: 'src_b', channel: 'hub' },
-      sources: { policy: 'follow', order: ['src_a', 'src_b'], eligibility: cannotLaunch('src_a') },
-    });
-    const chips = chainChips(agent, [nativeSource('src_a', ACTIVE), source('src_b', ACTIVE)]);
-    expect(chips.map((c) => c.tone)).toEqual(['skipped', 'current']);
-  });
-
-  // One row, ONE reason. The two are not mutually exclusive server-side, and the
-  // row renders a single dot, so health takes the tie: it is the actionable one,
-  // and its gold dot is named by the source row's own state chip.
-  it('states one reason per row, and health wins the tie', () => {
-    const agent = hubAgent({
-      sources: { policy: 'follow', order: ['src_a', 'src_b'], eligibility: cannotLaunch('src_b') },
-    });
-    const chips = chainChips(agent, [source('src_a', ACTIVE), nativeSource('src_b', DEAD)]);
-    expect(chips[1]).toMatchObject({ unhealthy: true, unavailable: false });
-  });
-
-  it('reads a payload that says nothing as launchable', () => {
-    // An older server omits the optional field entirely. Silence must not draw a
-    // dim chain — every position would look stepped over.
-    const agent = hubAgent({ sources: { policy: 'follow', order: ['src_a', 'src_b'] } });
-    const chips = chainChips(agent, [source('src_a', ACTIVE), nativeSource('src_b', ACTIVE)]);
-    expect(chips.map((c) => c.unavailable)).toEqual([false, false]);
-  });
-
-  // The marker names a CAUSE for the failover, so it may only be spent on a
-  // position the failover was ever going to consider. This one does not carry the
-  // selected model: the resolver walks past it with the CLI signed in and the state
-  // green, and pointing at a remedy that changes nothing about the route is worse
-  // than pointing at nothing.
-  it('does not blame availability for a position the model never came from', () => {
-    const agent = hubAgent({
-      current: { model_id: 'claude-opus-4-6', source_id: 'src_b', channel: 'hub' },
-      sources: { policy: 'follow', order: ['src_a', 'src_b'], eligibility: cannotLaunchOffRoute('src_a') },
-    });
-    const chips = chainChips(agent, [nativeSource('src_a', ACTIVE), source('src_b', ACTIVE)]);
-    expect(chips[0]).toMatchObject({ unavailable: false, unhealthy: false, tone: 'neutral' });
-  });
-
-  it('keeps the marker when the server claims nothing about the route', () => {
-    // `in_current_model_chain` is null with nothing selected and absent from a server
-    // that predates the field. Silence is not exclusion: with no selected model the
-    // order IS the route, so this position really was stepped over for this reason.
-    const agent = hubAgent({
-      selected_model_id: null,
-      sources: {
-        policy: 'follow',
-        order: ['src_a', 'src_b'],
-        eligibility: cannotLaunch('src_b').map((e) => ({ ...e, in_current_model_chain: null })),
-      },
-    });
-    const chips = chainChips(agent, [source('src_a', ACTIVE), nativeSource('src_b', ACTIVE)]);
-    expect(chips[1]).toMatchObject({ unavailable: true });
-  });
-
-  it('still dims an off-route source that is genuinely broken', () => {
-    // The gate is on the availability disjunct only. 「Cannot serve right now」 is
-    // true of the source wherever it sits, and its gold dot is an early warning
-    // about the next failover rather than a reading of this one's route.
-    const agent = hubAgent({
-      current: { model_id: 'claude-opus-4-6', source_id: 'src_b', channel: 'hub' },
-      sources: { policy: 'follow', order: ['src_a', 'src_b'], eligibility: cannotLaunchOffRoute('src_a') },
-    });
-    const chips = chainChips(agent, [nativeSource('src_a', DEAD), source('src_b', ACTIVE)]);
-    expect(chips[0]).toMatchObject({ unhealthy: true, unavailable: false, tone: 'skipped' });
   });
 });
 
@@ -253,89 +114,35 @@ describe('healthyButUnrunnable', () => {
   const agentWith = (eligibility: NonNullable<AgentSupply['sources']>['eligibility']) =>
     hubAgent({ sources: { policy: 'follow', order: ['src_a', 'src_b'], eligibility } });
 
-  it('retracts a healthy row’s promise this machine cannot keep', () => {
-    // 供 … 全系 is a promise, and the source looks fine — nothing else on the row
-    // would tell the user that turning it on gets them nothing here.
+  it('retracts a healthy row promise this machine cannot keep', () => {
     expect(healthyButUnrunnable(agentWith(cannotLaunch('src_b')), nativeSource('src_b', ACTIVE))).toBe(true);
   });
 
   it('leaves the segment to health when the source is not serving', () => {
-    // Two answers compete for one segment of copy. A cooling or broken source is
-    // the one the user can act on, and its state chip has already raised it.
     const agent = agentWith(cannotLaunch('src_b'));
     expect(healthyButUnrunnable(agent, nativeSource('src_b', COOLING))).toBe(false);
     expect(healthyButUnrunnable(agent, nativeSource('src_b', DEAD))).toBe(false);
-    expect(healthyButUnrunnable(agent, nativeSource('src_b', EXHAUSTED))).toBe(false);
   });
 
   it('says nothing about a source this machine can launch', () => {
-    // Silence is runnable — the server names only what it has ruled out.
     expect(healthyButUnrunnable(agentWith([]), nativeSource('src_b', ACTIVE))).toBe(false);
-    expect(healthyButUnrunnable(agentWith(cannotLaunch('src_a')), nativeSource('src_b', ACTIVE))).toBe(false);
     expect(healthyButUnrunnable(hubAgent({ sources: null }), nativeSource('src_b', ACTIVE))).toBe(false);
   });
 
-  it('does not read the route’s answer as the model’s', () => {
-    // Deliberately ungated, unlike `unavailable` in `chainChips`: that marker blames
-    // a FAILOVER on a cause. A source row answers 「what would I get by turning this
-    // on」, and `in_current_model_chain` is only an answer about `sources.order` — so
-    // every 未启用 row reads `false` there, and a gate would silence exactly the rows
-    // that need it earliest.
-    expect(healthyButUnrunnable(agentWith(cannotLaunchOffRoute('src_c')), nativeSource('src_c', ACTIVE))).toBe(true);
-    // The server builds `eligibility` over every configured source, not just the
-    // ordered ones, so a row outside the order still carries its own verdict.
-    const offOrder = hubAgent({ sources: { policy: 'follow', order: ['src_a'], eligibility: cannotLaunch('src_c') } });
-    expect(healthyButUnrunnable(offOrder, nativeSource('src_c', ACTIVE))).toBe(true);
+  it('does not read route membership as process availability', () => {
+    expect(
+      healthyButUnrunnable(agentWith(cannotLaunchOffRoute('src_c')), nativeSource('src_c', ACTIVE)),
+    ).toBe(true);
   });
 
   it('is absent from the ordering-only drawer', () => {
-    // Supply truth moved to model rows. The drawer no longer makes availability
-    // claims and therefore has no reason to derive process or model state.
     const drawer = readFileSync(join(__dirname, 'SourceOrderDrawer.tsx'), 'utf8');
-
-    expect(drawer).not.toMatch(/healthyButUnrunnable/);
-    expect(drawer).not.toMatch(/processAvailabilityOf/);
-    expect(drawer).not.toMatch(/viaMapping|via_mapping|builtin_models|models\.some/);
-  });
-});
-
-describe('chainRoles', () => {
-  const sources = [source('src_a', ACTIVE), source('src_b', COOLING)];
-
-  it('enrolls every id a Hub chain lists', () => {
-    const { enrolled, displaced } = chainRoles([hubAgent()], sources);
-    expect([...enrolled].sort()).toEqual(['src_a', 'src_b']);
-    expect([...displaced]).toEqual([]);
-  });
-
-  it('displaces only what a resolver has already fallen off', () => {
-    const agent = hubAgent({ current: { model_id: 'm', source_id: 'src_b', channel: 'hub' } });
-    const { displaced } = chainRoles([agent], [source('src_a', EXHAUSTED), source('src_b', ACTIVE)]);
-    expect([...displaced]).toEqual(['src_a']);
-  });
-
-  it('ignores Direct-mode backends entirely', () => {
-    const { enrolled } = chainRoles([directAgent()], sources);
-    expect(enrolled.size).toBe(0);
-  });
-
-  // `skipped` now has a second cause, and this set is shared with the page pill —
-  // so the widening has to be shown to stay inside the surface that asked for it.
-  it('displaces a source the machine cannot launch, and the pill still says nothing', () => {
-    const agent = hubAgent({
-      current: { model_id: 'm', source_id: 'src_b', channel: 'hub' },
-      sources: { policy: 'follow', order: ['src_a', 'src_b'], eligibility: cannotLaunch('src_a') },
-    });
-    const inventory = [nativeSource('src_a', ACTIVE), nativeSource('src_b', ACTIVE)];
-    expect([...chainRoles([agent], inventory).displaced]).toEqual(['src_a']);
-    // `pageStatus` reads `displaced` only through `state.status === 'cooldown'`, and
-    // an unlaunchable source is healthy by construction — the two cannot overlap.
-    expect(pageStatus(inventory, [agent], runtime('ok'))).toEqual({ tone: 'ok', kind: 'ok', hubCount: 1 });
+    expect(drawer).not.toMatch(/healthyButUnrunnable|processAvailabilityOf/);
   });
 });
 
 describe('attribution (AC-9)', () => {
-  it('names the Agents whose own rollup says so, and no others', () => {
+  it('names only the Agents whose own rollup is affected', () => {
     const agent = hubAgent({
       named_agents: [
         { name: 'claude', effective_model_id: 'claude-opus-4-6', supply_status: 'interrupted' },
@@ -346,9 +153,7 @@ describe('attribution (AC-9)', () => {
     expect(attribution(agent)).toEqual({ interrupted: ['claude'], waiting: ['pm'], unassignedModels: [] });
   });
 
-  // The other half of AC-9: a ticked model nobody runs is attributed to the MODEL
-  // and to no Agent — the failure a per-backend rollup gets wrong.
-  it('attributes an empty chain under an unassigned model to the model alone', () => {
+  it('attributes an empty unassigned chain to the model alone', () => {
     const agent = hubAgent({
       named_agents: [{ name: 'claude', effective_model_id: 'claude-opus-4-6', supply_status: 'ok' }],
       model_supply: [
@@ -363,7 +168,7 @@ describe('attribution (AC-9)', () => {
     });
   });
 
-  it('never double-counts a model an Agent does run', () => {
+  it('never double-counts a model an Agent runs', () => {
     const agent = hubAgent({
       named_agents: [{ name: 'claude', effective_model_id: 'claude-haiku-4-5', supply_status: 'interrupted' }],
       model_supply: [{ model_id: 'claude-haiku-4-5', chain_length: 0 }],
@@ -375,143 +180,3 @@ describe('attribution (AC-9)', () => {
     expect(hasAttribution(attribution(directAgent()))).toBe(false);
   });
 });
-
-describe('pageStatus', () => {
-  it('reports the engine only when a Hub backend depends on it', () => {
-    const sources = [source('src_a', ACTIVE)];
-    expect(pageStatus(sources, [hubAgent()], runtime('down'))).toEqual({ tone: 'warn', kind: 'engineDown' });
-    expect(pageStatus(sources, [directAgent()], runtime('down'))).toEqual({ tone: 'neutral', kind: 'none' });
-  });
-
-  // 「on Hub」 is not the same question as 「needs the engine」. A native_cli source is
-  // launched by rewriting the CLI's own config — no gateway, and resolve() swallows
-  // an engine-sync failure there on purpose — so this Agent keeps working and the
-  // pill must not tell its owner otherwise.
-  it('stays quiet with the engine down when the whole chain is served natively', () => {
-    const sources = [nativeSource('src_a', ACTIVE), nativeSource('src_b', STANDBY)];
-    expect(pageStatus(sources, [hubAgent()], runtime('down'))).toEqual({ tone: 'ok', kind: 'ok', hubCount: 1 });
-  });
-
-  it('reports the engine as soon as one enrolled source is served through it', () => {
-    const sources = [nativeSource('src_a', ACTIVE), source('src_b', STANDBY)];
-    expect(pageStatus(sources, [hubAgent()], runtime('down'))).toEqual({ tone: 'warn', kind: 'engineDown' });
-  });
-
-  it('ignores a hub-channel source no chain has enrolled', () => {
-    const sources = [nativeSource('src_a', ACTIVE), nativeSource('src_b', ACTIVE), source('src_orphan', ACTIVE)];
-    expect(pageStatus(sources, [hubAgent()], runtime('down'))).toEqual({ tone: 'ok', kind: 'ok', hubCount: 1 });
-  });
-
-  // An empty order routes nothing through the engine either — and it is the state
-  // the row now reports as a coming failure, not as a Direct fallback.
-  it('says nothing about the engine for a Hub backend with no enabled source', () => {
-    const agent = hubAgent({ sources: { policy: 'custom', order: [], eligibility: [] }, current: null });
-    expect(pageStatus([source('src_a', ACTIVE)], [agent], runtime('down'))).toEqual({
-      tone: 'ok',
-      kind: 'ok',
-      hubCount: 1,
-    });
-  });
-
-  it('puts an interrupted Agent above a waiting one', () => {
-    const agents = [
-      hubAgent({ supply_status: 'waiting' }),
-      hubAgent({ backend: 'codex', supply_status: 'interrupted' }),
-    ];
-    expect(pageStatus([source('src_a', ACTIVE)], agents, runtime('ok'))).toEqual({
-      tone: 'warn',
-      kind: 'interrupted',
-      count: 1,
-    });
-  });
-
-  // ── The grain the pill counts at ─────────────────────────────────────
-  // `supply_status` answers for ONE route; the attribution line answers per named
-  // Agent, and the pill uses the same noun 「Agent」. So the pill has to count what
-  // the line names, or the two contradict each other on one screen.
-
-  it('counts interrupted named Agents, not the backends they sit on', () => {
-    const agent = hubAgent({
-      supply_status: 'ok',
-      named_agents: [
-        { name: 'claude', effective_model_id: 'claude-opus-4-6', supply_status: 'interrupted' },
-        { name: 'pm', effective_model_id: 'claude-sonnet-4-6', supply_status: 'interrupted' },
-        { name: 'reviewer', effective_model_id: 'claude-haiku-4-5', supply_status: 'ok' },
-      ],
-    });
-    expect(pageStatus([source('src_a', ACTIVE)], [agent], runtime('ok'))).toEqual({
-      tone: 'warn',
-      kind: 'interrupted',
-      count: 2,
-    });
-  });
-
-  it('does not let the route-level rollup speak over the per-Agent projection', () => {
-    // The finer projection wins in BOTH directions — a coarser 供给中断 cannot
-    // headline a page whose every named Agent is fine.
-    const agent = hubAgent({
-      supply_status: 'interrupted',
-      named_agents: [{ name: 'claude', effective_model_id: 'claude-opus-4-6', supply_status: 'ok' }],
-    });
-    expect(pageStatus([source('src_a', ACTIVE)], [agent], runtime('ok'))).toEqual({
-      tone: 'ok',
-      kind: 'ok',
-      hubCount: 1,
-    });
-  });
-
-  it('keeps the warning for a Hub backend that publishes no named Agent', () => {
-    // No enabled Agent on this backend, so there is no finer projection to read —
-    // the row's own verdict is the finest thing displayed, and must still be heard.
-    const agent = hubAgent({ supply_status: 'interrupted', named_agents: [] });
-    expect(pageStatus([source('src_a', ACTIVE)], [agent], runtime('ok'))).toEqual({
-      tone: 'warn',
-      kind: 'interrupted',
-      count: 1,
-    });
-  });
-
-  // V6 01: a cooling relay nobody has fallen off still reads 一切正常. The source
-  // row reports its own health; the pill speaks when the outage costs a turn.
-  it('stays green while an unhealthy source is below every 当前 (V6 01)', () => {
-    const sources = [source('src_a', ACTIVE), source('src_b', COOLING)];
-    expect(pageStatus(sources, [hubAgent()], runtime('ok'))).toEqual({ tone: 'ok', kind: 'ok', hubCount: 1 });
-  });
-
-  // V6 04: the same cooling source, one failover later.
-  it('reports the handled failover once a chain has fallen off the source (V6 04)', () => {
-    const sources = [source('src_a', EXHAUSTED, 'ChatGPT Plus'), source('src_b', ACTIVE)];
-    const agent = hubAgent({ current: { model_id: 'm', source_id: 'src_b', channel: 'hub' } });
-    expect(pageStatus(sources, [agent], runtime('ok'))).toEqual({
-      tone: 'warn',
-      kind: 'cooldown',
-      source: sources[0],
-      others: 0,
-    });
-  });
-
-  it('reports a dead source any chain lists, even at the tail', () => {
-    const sources = [source('src_a', ACTIVE), source('src_b', DEAD, 'Anthropic API Key')];
-    expect(pageStatus(sources, [hubAgent()], runtime('ok'))).toMatchObject({ kind: 'needsAction', others: 0 });
-  });
-
-  it('ignores a dead source no chain lists', () => {
-    const sources = [source('src_a', ACTIVE), source('src_b', ACTIVE), source('src_orphan', DEAD)];
-    expect(pageStatus(sources, [hubAgent()], runtime('ok'))).toEqual({ tone: 'ok', kind: 'ok', hubCount: 1 });
-  });
-
-  it('counts the rest of a bad batch into the same pill', () => {
-    const agent = hubAgent({ sources: { policy: 'follow', order: ['src_a', 'src_b', 'src_c'], eligibility: [] } });
-    const sources = [source('src_a', ACTIVE), source('src_b', DEAD), source('src_c', DEAD)];
-    expect(pageStatus(sources, [agent], runtime('ok'))).toMatchObject({ kind: 'needsAction', others: 1 });
-  });
-
-  it('says nothing at all when no backend is on the Hub', () => {
-    expect(pageStatus([source('src_a', DEAD)], [directAgent()], null)).toEqual({ tone: 'neutral', kind: 'none' });
-  });
-});
-
-// `connectOutcome` and `isSupplyWarning` moved to `sufficiency.ts` (and their tests
-// with them): deciding whether the next turn can run is one question, and this module
-// answered it with `order.length` while four other sites answered it with a length of
-// their own. What is left here is the per-source predicate that verdict consumes.

--- a/ui/src/components/settings/models/supply.ts
+++ b/ui/src/components/settings/models/supply.ts
@@ -1,14 +1,12 @@
 // Rules behind the Models page — deliberately outside the components, because
-// each one is a judgement the UI is not free to improvise: which source in a
-// chain is 当前, which chip the resolver has already walked past, which Agents a
-// supply failure is actually about (AC-9), and what the header pill is allowed to
-// claim. Rules deserve unit tests, and this repo's vitest setup has no DOM, so
-// they are plain functions over the contract types and nothing else.
-import { offCurrentModelChain, processAvailabilityOf } from './eligibility';
+// each one is a judgement the UI is not free to improvise: which Agents a supply
+// failure is actually about (AC-9), and whether a source is usable here. Rules
+// deserve unit tests, and this repo's vitest setup has no DOM, so they are plain
+// functions over the contract types and nothing else.
+import { processAvailabilityOf } from './eligibility';
 import type {
   AgentSupply,
   ModelSupply,
-  RuntimeDependency,
   Source,
   SourceState,
   SupplyStatus,
@@ -50,75 +48,6 @@ export const needsAttention = (state: SourceState): boolean =>
 // test, so the decision moved to `sufficiency.ts`, which owns it for all five.
 // Nothing here re-derives it; `isUnhealthy` above is the one predicate it consumes.
 
-// ── The Agent row's supply chain (design.pen 「V6 01」 / 「V6 04」) ─────────
-export type ChainTone = 'current' | 'skipped' | 'neutral';
-
-export type ChainChip = {
-  sourceId: string;
-  /** The source's display name, or the bare id when it no longer resolves. */
-  label: string;
-  /** 1-based position in this backend's order. */
-  position: number;
-  tone: ChainTone;
-  /** Draws the gold dot: this source cannot serve right now. */
-  unhealthy: boolean;
-  /** Draws the muted dot: healthy, on the route, and still not launchable here —
-   *  this process cannot sign the backend's CLI in with it. Never true at the same
-   *  time as `unhealthy`: the row states ONE reason, the one in the way. */
-  unavailable: boolean;
-};
-
-/**
- * `sources.order` as the numbered chain the Agent row draws.
- *
- * The `skipped` rule is what lets one branch reproduce both frames: V6 01 leaves
- * a cooling relay at position 3 fully legible, while V6 04 dims position 1 after
- * the failover moved 当前 to position 2. So a chip dims only when it is unhealthy
- * AND the resolver has already walked past it — an unhealthy source *after* 当前
- * is a warning about the next failover, not a record of one, and greying it out
- * would claim something that has not happened.
- *
- * A position can be stepped over for a second reason, and the strip has to draw it
- * or the frame contradicts itself: a `native_cli` source this process cannot sign
- * the CLI in with is skipped by the resolver while its own state reads `active`, so
- * without this the chain would show a healthy position 1 and 当前 sitting at 2 with
- * nothing between them to explain the move. It is ONE more disjunct in the same
- * 「walked past」 rule, and one more hue on the same dot — never a second dot and
- * never a second rule, because the question 「why did the resolver move on」 has one
- * answer per position. Health wins the tie: it is the one the user can act on, and
- * the source row next door already names it.
- *
- * That second disjunct is gated on route membership, and the gate is about what the
- * marker CLAIMS. 「Not launchable here」 names a CAUSE for the failover, and a
- * position the server reports as `in_current_model_chain: false` was going to be
- * walked past with the CLI signed in and the state green — it does not carry the
- * selected model at all. Marking it would blame the move on a remedy that changes
- * nothing. Health needs no such gate: 「cannot serve right now」 is true of the
- * source wherever it sits in whosever order. And the gate is on the Agent row only —
- * the all-sources drawer keeps the ungated fact, which is the surface the user goes
- * to in order to act on it.
- *
- * Returns [] in Direct mode: there is no Hub order to draw (AC-7).
- */
-export function chainChips(agent: AgentSupply, sources: Source[]): ChainChip[] {
-  const order = agent.sources?.order ?? [];
-  const currentId = agent.current?.source_id ?? null;
-  const currentIndex = currentId ? order.indexOf(currentId) : -1;
-  return order.map((sourceId, i) => {
-    const source = sources.find((s) => s.id === sourceId);
-    const unhealthy = source ? isUnhealthy(source.state) : false;
-    const unavailable =
-      !unhealthy && !offCurrentModelChain(agent, sourceId) && !processAvailabilityOf(agent, sourceId).runnable;
-    const tone: ChainTone =
-      sourceId === currentId
-        ? 'current'
-        : (unhealthy || unavailable) && currentIndex >= 0 && i < currentIndex
-          ? 'skipped'
-          : 'neutral';
-    return { sourceId, label: source?.display_name ?? sourceId, position: i + 1, tone, unhealthy, unavailable };
-  });
-}
-
 /**
  * Is this row's 供 … 全系 a promise this machine cannot keep — healthy, and still
  * not something the Agent's process can be launched against?
@@ -128,11 +57,8 @@ export function chainChips(agent: AgentSupply, sources: Source[]): ChainChip[] {
  * cooling or broken source is the one the user can act on, and its state chip has
  * already raised the question. So this is only about the row that looks fine.
  *
- * Ungated by route membership, and deliberately so — unlike `unavailable` in
- * `chainChips`, where the gate exists because that marker blames a FAILOVER on a
- * cause and must not name one for a position the resolver was walking past
- * anyway. A row in a source list is not explaining a move; it is answering 「what
- * would I get by turning this on」. And a 未启用 source sits outside
+ * Ungated by route membership, and deliberately so. A row in a source list is
+ * answering 「what would I get by turning this on」. A 未启用 source sits outside
  * `agent.sources.order`, which is the only list `in_current_model_chain` is an
  * answer about, so a gate there would read an ORDER fact as a MODEL one.
  *
@@ -187,134 +113,5 @@ export function attribution(agent: AgentSupply): SupplyAttribution {
   };
 }
 
-/**
- * The supply verdict for every subject the page actually shows, at the FINEST grain
- * it shows one — the projection any page-level headline has to be derived from.
- *
- * `AgentSupply.supply_status` is a rollup for ONE route (「the current selection」 of
- * the Agent named by `selected_by_agent`), so counting backends by it answers a
- * different question than the page asks: a backend with three enabled Agents draws
- * 「claude、pm、codex 供给中断」 in its attribution line and would have had the header
- * say 「1 个 Agent 供给中断」 — a coarser count standing above a finer contradiction
- * the same screen displays, in the same noun.
- *
- * `named_agents` is that finer grain (AC-9: the ENABLED named Agents, each with its
- * own rollup), and `attribution()` already reads it. A backend that publishes none
- * falls back to its own rollup rather than to silence: the row still draws a supply
- * verdict of its own (「供给中断」 when no source is enabled), so dropping it here
- * would lose a warning the page is making — the fallback is per-subject too, never a
- * mix of grains for one subject.
- */
-function displayedSupply(hubAgents: AgentSupply[]): (SupplyStatus | null)[] {
-  return hubAgents.flatMap((agent) => {
-    const named = agent.named_agents ?? [];
-    return named.length > 0 ? named.map((a) => a.supply_status) : [agent.supply_status ?? null];
-  });
-}
-
 export const hasAttribution = (a: SupplyAttribution): boolean =>
   a.interrupted.length > 0 || a.waiting.length > 0 || a.unassignedModels.length > 0;
-
-// ── What a source outage is actually costing right now ──────────────────
-export type ChainRoles = {
-  /** Listed in at least one Hub Agent's order — an outage here will bite. */
-  enrolled: Set<string>;
-  /** A Hub resolver has already walked past it: the failover has happened. */
-  displaced: Set<string>;
-};
-
-/**
- * Read the same chain the Agent rows draw, and answer the two questions the header
- * pill needs: is anything using this source, and has its outage already moved a
- * turn somewhere else.
- *
- * The pill cannot ask "is any source unhealthy" — V6 01 has a cooling relay at
- * position 3 and still reads 一切正常, because nothing was ever served from it.
- * The same shape becomes V6 04's 「已自动切换」 only once the cooling source is one
- * an Agent has fallen off. Position relative to 当前 is the whole difference, and
- * `chainChips` already computes it, so this reuses that judgement instead of
- * growing a second, driftable copy of it.
- */
-export function chainRoles(agents: AgentSupply[], sources: Source[]): ChainRoles {
-  const enrolled = new Set<string>();
-  const displaced = new Set<string>();
-  for (const agent of agents) {
-    if (agent.mode !== 'hub') continue;
-    for (const chip of chainChips(agent, sources)) {
-      enrolled.add(chip.sourceId);
-      if (chip.tone === 'skipped') displaced.add(chip.sourceId);
-    }
-  }
-  return { enrolled, displaced };
-}
-
-// ── The page header's status pill ───────────────────────────────────────
-/**
- * What the header pill says. A discriminated result rather than a translated
- * string: the ladder is a rule (worth testing), the copy is i18n (not this
- * module's business).
- */
-export type PageStatus =
-  | { tone: 'ok'; kind: 'ok'; hubCount: number }
-  | { tone: 'neutral'; kind: 'none' }
-  | { tone: 'warn'; kind: 'engineDown' }
-  | { tone: 'warn'; kind: 'interrupted' | 'waiting'; count: number }
-  | { tone: 'warn'; kind: 'needsAction' | 'cooldown'; source: Source; others: number };
-
-/**
- * Worst-first, and every branch is a thing the user can act on:
- *
- *   engine down     nothing on Hub can run at all
- *   interrupted     an Agent has no source left and needs the user
- *   waiting         an Agent is stalled but a source will come back on its own
- *   needs_action    a source someone's chain lists is dead until re-auth / top-up
- *   cooldown        a source stepped aside; the chain covered for it  ← V6 04
- *   ok / none       nothing to report
- *
- * `cooldown` deliberately outranks nothing: it is the only branch that reports a
- * problem the system already handled, which is exactly the V6 04 moment ("额度用完
- * · 已自动切换，恢复后切回") and the reason the pill cannot just be a boolean.
- *
- * Both source-level branches are gated on `chainRoles`, because an unhealthy source
- * is not by itself news — V6 01 draws a cooling relay AND 「一切正常 · 2 个 Agent
- * 已接入中枢」, since every Agent is still served from the head of its chain. The
- * source rows already report their own health; the pill speaks only when the outage
- * is costing someone a turn (`displaced`) or is waiting on a human (`needs_action`
- * under a chain that lists it).
- */
-export function pageStatus(
-  sources: Source[],
-  agents: AgentSupply[],
-  runtime: RuntimeDependency | null,
-): PageStatus {
-  const hubAgents = agents.filter((a) => a.mode === 'hub');
-  const { enrolled, displaced } = chainRoles(agents, sources);
-  // 「Hub mode」 is not the same question as 「needs the engine」, and only the second
-  // one licenses this branch. A `native_cli` source is launched by rewriting the
-  // CLI's own config — `model_hub.resolve()` builds that launch with no gateway and
-  // swallows an engine-sync failure outright ("Native launch is independent") — so a
-  // Hub Agent whose order enrolls only native sources keeps running with the engine
-  // down, and telling its owner that nothing works would be false. The engine
-  // becomes load-bearing exactly when someone's chain lists a `hub`-channel source.
-  // (A Direct-only install has nothing enrolled at all, so this covers it too.)
-  const needsEngine = sources.some((s) => s.supply_channel === 'hub' && enrolled.has(s.id));
-  if (needsEngine && runtime?.status.health !== 'ok') return { tone: 'warn', kind: 'engineDown' };
-
-  const subjects = displayedSupply(hubAgents);
-  const rollup = (status: SupplyStatus) => subjects.filter((s) => s === status).length;
-  const interrupted = rollup('interrupted');
-  if (interrupted > 0) return { tone: 'warn', kind: 'interrupted', count: interrupted };
-  const waiting = rollup('waiting');
-  if (waiting > 0) return { tone: 'warn', kind: 'waiting', count: waiting };
-
-  const dead = sources.filter(
-    (s) => (s.state.status === 'needs_action' || s.state.status === 'error') && enrolled.has(s.id),
-  );
-  if (dead.length > 0) return { tone: 'warn', kind: 'needsAction', source: dead[0], others: dead.length - 1 };
-  const cooling = sources.filter((s) => s.state.status === 'cooldown' && displaced.has(s.id));
-  if (cooling.length > 0) return { tone: 'warn', kind: 'cooldown', source: cooling[0], others: cooling.length - 1 };
-
-  return hubAgents.length === 0
-    ? { tone: 'neutral', kind: 'none' }
-    : { tone: 'ok', kind: 'ok', hubCount: hubAgents.length };
-}

--- a/ui/src/components/settings/models/types.ts
+++ b/ui/src/components/settings/models/types.ts
@@ -121,12 +121,6 @@ export type AgentBackend = 'claude' | 'codex' | 'opencode';
 export type AgentMode = 'hub' | 'direct';
 export type MenuKind = 'fixed' | 'open';
 
-export type AgentCurrent = {
-  model_id: string;
-  source_id: string;
-  channel: SupplyChannel;
-};
-
 export type AgentMapping = {
   /** real built-in model id, e.g. claude-opus-4-6. */
   builtin_id: string;
@@ -185,13 +179,12 @@ export type AgentSources = {
 
 /** Agent-level supply rollup (§4.5). `waiting` = every enabled source is
  *  cooling and one will come back; `interrupted` = nothing can serve the
- *  selection without the user acting. Both pin `current` to null, so a stale
- *  使用中 can never render. */
+ *  selection without the user acting. */
 export type SupplyStatus = 'ok' | 'degraded' | 'waiting' | 'interrupted';
 
 /** AC-9's per-Agent read projection: the ENABLED named Agents on this backend,
- *  each with the model it effectively runs (explicit selection or the backend
- *  default) and its own rollup. Empty for direct-mode backends. */
+ *  each with its explicitly configured model and its own rollup. Empty for
+ *  direct-mode backends. */
 export type NamedAgentSupply = {
   name: string;
   effective_model_id: string | null;
@@ -211,20 +204,15 @@ export type AgentSupply = {
   backend: AgentBackend;
   mode: AgentMode;
   menu_kind: MenuKind;
-  /** The named Agent whose selection `selected_model_id` came from, or null when
-   *  the backend default supplies it. null whenever `selected_model_id` is. */
+  /** The named Agent whose explicit selection `selected_model_id` came from.
+   *  null whenever `selected_model_id` is null. */
   selected_by_agent?: string | null;
   /** The model the next turn would ask for. null in direct mode and when no
    *  selection resolves — an honest null, never a guessed default. */
   selected_model_id?: string | null;
-  /** TRUE iff `selected_model_id` originates from the user's explicit
-   *  configuration request; FALSE also covers a resolver-picked value. The
-   *  server derives it from the stored request BEFORE resolving, which is what
-   *  makes it the one health-free way to read the id — see `dryRunChainKey`. */
+  /** TRUE iff `selected_model_id` originates from the Agent's explicit
+   *  configuration. FALSE covers a resolver-picked value. */
   selected_model_explicit?: boolean;
-  /** What the next turn would actually use (composite pill). null in exactly
-   *  three cases: mode=direct, supply_status=waiting, supply_status=interrupted. */
-  current?: AgentCurrent | null;
   /** Per-backend enabled subset + order + policy. null when mode=direct. */
   sources?: AgentSources | null;
   /** Rollup over `sources.order` for the current selection. null in direct mode

--- a/ui/src/components/settings/models/vocabulary.test.ts
+++ b/ui/src/components/settings/models/vocabulary.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
+import en from '../../../i18n/en.json';
 import zh from '../../../i18n/zh.json';
 
 const leaves = (node: unknown): string[] =>
@@ -13,6 +14,11 @@ describe('Models page vocabulary', () => {
   it('contains none of the retired user-facing terms', () => {
     const copy = leaves(zh.settings.models).join('\n');
     expect(copy).not.toMatch(/菜单固定|跟随推荐|中枢 Hub|按量\s*\$|映射|供给引擎|自定义顺序/);
+    expect(copy).not.toMatch(/按量(?!付费)/);
+    expect(zh.settings.models.billing.monthly).toBe('订阅');
+    expect(zh.settings.models.billing.metered).toBe('按量付费');
+    expect(en.settings.models.billing.monthly).toBe('Subscription');
+    expect(en.settings.models.billing.metered).toBe('Pay as you go');
     expect(zh.settings.models.order.customized).toBe('已改为手动');
     expect(zh.settings.models.order.restore).toBe('恢复默认');
   });

--- a/ui/src/components/shared/RoutingConfigPanel.tsx
+++ b/ui/src/components/shared/RoutingConfigPanel.tsx
@@ -199,8 +199,8 @@ export const RoutingConfigPanel: React.FC<RoutingConfigPanelProps> = ({
             // Resolve the DISPLAYED route. An explicit agent with an empty
             // model/effort means "inherit that agent's", so fall back to the
             // selected agent's own model/effort — otherwise the effort column
-            // resolves options against the backend defaults instead of the
-            // inherited model (e.g. a Claude agent's xhigh/max would vanish).
+            // resolves options without the inherited Agent model (e.g. a Claude
+            // agent's xhigh/max would vanish).
             // agent_backend also falls back to the default agent so the columns
             // resolve while inheriting the global default.
             agent_backend: selectedVibeAgent?.backend ?? defaultVibeAgent?.backend ?? null,

--- a/ui/src/components/steps/Summary.tsx
+++ b/ui/src/components/steps/Summary.tsx
@@ -437,7 +437,6 @@ const buildConfigPayload = (data: any) => {
         enabled: agents.opencode?.enabled ?? true,
         cli_path: agents.opencode?.cli_path || 'opencode',
         default_agent: data.opencode_default_agent ?? agents.opencode?.default_agent ?? null,
-        default_model: data.opencode_default_model ?? agents.opencode?.default_model ?? null,
         default_reasoning_effort:
           data.opencode_default_reasoning_effort ?? agents.opencode?.default_reasoning_effort ?? null,
       },
@@ -445,13 +444,11 @@ const buildConfigPayload = (data: any) => {
         ...agents.claude,
         enabled: agents.claude?.enabled ?? true,
         cli_path: agents.claude?.cli_path || 'claude',
-        default_model: data.claude_default_model ?? agents.claude?.default_model ?? null,
       },
       codex: {
         ...agents.codex,
         enabled: agents.codex?.enabled ?? false,
         cli_path: agents.codex?.cli_path || 'codex',
-        default_model: data.codex_default_model ?? agents.codex?.default_model ?? null,
       },
     },
     gateway: data.gateway,

--- a/ui/src/components/workbench/AgentsPage.tsx
+++ b/ui/src/components/workbench/AgentsPage.tsx
@@ -50,10 +50,6 @@ import {
   type Backend,
 } from '../../lib/backendAccent';
 
-// Sentinel option that clears the model override back to the backend default
-// (a combobox can't submit an empty value, so this is the explicit clear path).
-const MODEL_DEFAULT_OPTION = '__default__';
-
 type AgentsTabKey = 'definitions' | 'running';
 const AGENTS_TAB_ORDER: AgentsTabKey[] = ['definitions', 'running'];
 
@@ -928,18 +924,16 @@ const AgentDetailPanel: React.FC<DetailProps> = ({ agent, isDefault, onChange, o
         </div>
       </Field>
 
-      {/* Model — Combobox with chevron + searchable + custom values. The
-          leading "backend default" option lets the user clear the override
-          back to model: null (a combobox can't otherwise submit an empty
-          value, so picking it is the only clear path). */}
+      {/* Model — Combobox with chevron + searchable + custom values. */}
       <Field label={t('agents.detail.model')}>
         <Combobox
-          options={[{ value: MODEL_DEFAULT_OPTION, label: t('agents.detail.modelDefault') }, ...modelOptions]}
+          options={modelOptions}
           value={model}
           onValueChange={(next) => {
-            const value = next === MODEL_DEFAULT_OPTION ? '' : next;
+            const value = next.trim();
+            if (!value) return;
             setModel(value);
-            const patch: Partial<VibeAgentFull> = { model: value.trim() || null };
+            const patch: Partial<VibeAgentFull> = { model: value };
             // If the new model can't use the current effort, fall back to a
             // valid one and persist it in the same patch — otherwise the record
             // keeps an effort the model can't run (Codex P2).

--- a/ui/src/components/workbench/HarnessPage.tsx
+++ b/ui/src/components/workbench/HarnessPage.tsx
@@ -1719,7 +1719,7 @@ function deliveryLabel(postTo: string | null | undefined, t: (k: string) => stri
 
 // Agent executor: name + resolved backend·model·effort, with a jump to the
 // Agents page. agent_name can be null (the definition inherits the scope /
-// global default); model/effort can be null (backend default).
+// global default); model/effort can be null in legacy or partial records.
 const DetailAgent: React.FC<{ agentName: string | null; agent?: VibeAgentBrief }> = ({ agentName, agent }) => {
   const { t } = useTranslation();
   if (!agentName) {

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -648,7 +648,6 @@
         "reorder": "Reorder",
         "oauthSignedOut": "CLI subscription is signed out"
       },
-      "current": "Current",
       "order": {
         "title": "Source order · {{backend}}",
         "subtitle": "Used top to bottom; a failure switches to the next one and switches back once it recovers. This order only affects {{backend}}.",
@@ -666,8 +665,8 @@
         "ineligibleClientUnknown": "{{vendor}} subscriptions only work in their own official client"
       },
       "billing": {
-        "monthly": "Monthly",
-        "metered": "Metered"
+        "monthly": "Subscription",
+        "metered": "Pay as you go"
       },
       "state": {
         "active": "Healthy",
@@ -2612,7 +2611,6 @@
       "model": "Model",
       "modelPlaceholder": "Pick or type a model",
       "modelEmpty": "No matches — you can type a custom value.",
-      "modelDefault": "Backend default",
       "effort": "Reasoning effort",
       "systemPrompt": "System prompt",
       "systemPromptCount": "~{{count}} tokens",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -648,7 +648,6 @@
         "reorder": "拖动排序",
         "oauthSignedOut": "CLI 订阅未登录"
       },
-      "current": "当前",
       "order": {
         "title": "来源顺序 · {{backend}}",
         "subtitle": "从上到下依次使用；失败自动切到下一个，恢复后自动切回。这里的顺序只影响 {{backend}}。",
@@ -666,8 +665,8 @@
         "ineligibleClientUnknown": "{{vendor}} 订阅只能供它自己的官方客户端使用"
       },
       "billing": {
-        "monthly": "包月",
-        "metered": "按量"
+        "monthly": "订阅",
+        "metered": "按量付费"
       },
       "state": {
         "active": "正常",
@@ -2612,7 +2611,6 @@
       "model": "模型",
       "modelPlaceholder": "选择或输入模型",
       "modelEmpty": "找不到匹配的模型,可以直接输入。",
-      "modelDefault": "使用后端默认",
       "effort": "推理强度",
       "systemPrompt": "系统提示词",
       "systemPromptCount": "~{{count}} tokens",

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -5573,16 +5573,7 @@ def _effort_values(reasoning_entries: object) -> list[str]:
     return out
 
 
-def _backend_default_model(config: Optional[V2Config], backend: str) -> Optional[str]:
-    if config is None:
-        return None
-    agents = getattr(config, "agents", None)
-    backend_cfg = getattr(agents, backend, None) if agents is not None else None
-    value = getattr(backend_cfg, "default_model", None) if backend_cfg is not None else None
-    return value or None
-
-
-def _flat_catalog_models(catalog: dict, default_model: Optional[str]) -> list[dict]:
+def _flat_catalog_models(catalog: dict) -> list[dict]:
     """Shape claude_models()/codex_models() output into the unified models list."""
     reasoning_map = catalog.get("reasoning_options") or {}
     models: list[dict] = []
@@ -5593,7 +5584,6 @@ def _flat_catalog_models(catalog: dict, default_model: Optional[str]) -> list[di
             {
                 "value": model_id,
                 "label": (catalog.get("model_labels") or {}).get(model_id, model_id),
-                "default": bool(default_model) and model_id == default_model,
                 "reasoning_efforts": _effort_values(reasoning_map.get(model_id)),
             }
         )
@@ -5685,7 +5675,6 @@ def _opencode_model_options(
     return {
         "ok": True,
         "backend": "opencode",
-        "default_model": _backend_default_model(config, "opencode"),
         "default_provider": default_provider or None,
         "providers": providers_out,
         "models": models_out,
@@ -5706,8 +5695,8 @@ def agent_model_options(
     Single entry point wrapping ``claude_models`` / ``codex_models`` /
     ``opencode_options`` into one shape so the CLI and the Web UI can share it::
 
-        {ok, backend, default_model, models: [{value, default, reasoning_efforts,
-         provider?, source?}], providers?: [{id, name, custom}], source, live, notes}
+        {ok, backend, models: [{value, reasoning_efforts, provider?, source?}],
+         providers?: [{id, name, custom}], source, live, notes}
 
     ``provider`` filters OpenCode results (ignored for other backends). Narrowing
     to a single model is a presentation concern left to the caller.
@@ -5726,12 +5715,10 @@ def agent_model_options(
         data = claude_models()
         if not data.get("ok"):
             return {"ok": False, "backend": normalized_backend, "error": data.get("error") or "claude model lookup failed"}
-        default_model = _backend_default_model(config, "claude")
         result = {
             "ok": True,
             "backend": "claude",
-            "default_model": default_model,
-            "models": _flat_catalog_models(data, default_model),
+            "models": _flat_catalog_models(data),
             "source": data.get("source"),
             "live": bool(data.get("live")),
             "notes": data.get("notes"),
@@ -5741,12 +5728,10 @@ def agent_model_options(
         data = codex_models()
         if not data.get("ok"):
             return {"ok": False, "backend": normalized_backend, "error": data.get("error") or "codex model lookup failed"}
-        default_model = _backend_default_model(config, "codex")
         result = {
             "ok": True,
             "backend": "codex",
-            "default_model": default_model,
-            "models": _flat_catalog_models(data, default_model),
+            "models": _flat_catalog_models(data),
             "source": data.get("source"),
             "live": bool(data.get("live")),
             "notes": data.get("notes"),
@@ -9689,16 +9674,12 @@ async def _get_opencode_providers_async() -> dict:
     # it became a no-op (no state change to persist), silently
     # blocking users from picking Anthropic explicitly.
     default_provider: str | None = None
-    configured_default_model: str | None = None
     try:
         config = load_config()
         cfg = getattr(getattr(config, "agents", None), "opencode", None)
         configured_default = getattr(cfg, "default_provider", None)
         if isinstance(configured_default, str) and configured_default.strip():
             default_provider = configured_default.strip()
-        raw_default_model = getattr(cfg, "default_model", None)
-        if isinstance(raw_default_model, str) and raw_default_model.strip():
-            configured_default_model = raw_default_model.strip()
     except Exception:
         pass
 
@@ -9876,12 +9857,6 @@ async def _get_opencode_providers_async() -> dict:
             default_provider=default_provider,
             provider_id=pid,
         )
-        if not preferred_model:
-            preferred_model = resolve_opencode_configured_default_model(
-                configured_default_model,
-                default_provider=default_provider,
-                provider_id=pid,
-            )
         if preferred_model:
             preferred_model = resolve_opencode_model_id(
                 config_raw,

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -3590,7 +3590,6 @@ def cmd_agent_models(args):
             agent=agent.name if agent else None,
             backend=backend,
             current=current,
-            default_model=options.get("default_model"),
             providers=page_providers if providers is not None else None,
             models=page_models,
             source=options.get("source"),


### PR DESCRIPTION
## Summary

- Materialize release-owned model recommendations into every Vibe Agent record: Claude `claude-opus-5`, Codex `gpt-5.6-sol`, and OpenCode `openai/gpt-5.6-sol`.
- Migrate missing or blank Agent models idempotently without overwriting user selections, and retire the three backend `default_model` config keys and runtime fallback reads.
- Remove the Model Hub `AgentSupply.current` projection and its UI consumers; serving details remain available from the per-model chain API while `named_agents` keeps supply state at named-Agent grain.
- Remove the Models-page current badge, rename billing labels to Subscription / Pay as you go and 订阅 / 按量付费, and prevent bare 按量 from returning through the copy gate.

## Scenarios

- `MH-SEL-001`
- `MH-OAUTH-NATIVE-001`
- `MH-OAUTH-NATIVE-003`

## Evidence

- Unit: recommendation creation, upgrade migration, idempotence, no-overwrite, explicit reset, catalog membership, and runtime AST guard.
- Contract: Model Hub config/API/resolution trio, schema examples, API shape, mirror registry, and absence of `current`.
- Scenario: live null-selection projection and native OAuth success/interruption paths now assert chain and named supply state.
- Shared runtime: Claude/Codex/OpenCode launch-chain, multi-platform runtime, session fork, auth, config-save, and UI API groups.
- UI: 1,255 Vitest tests, TypeScript/Vite production build, theme validation, and bilingual vocabulary assertions.
- Repository: Ruff passed and wheel/sdist build passed. The monolithic pytest process reached 6,575 passed / 54 skipped; its two failures are the repository's documented cross-file `sys.modules` identity leak in `test_platform_registry`, and both tests pass in their isolated file process. CI's authoritative unit gate runs every test file in its own process.

## Review Ledger

- **Orchestrator-authorized, owner-vetoable:** targeted Model Hub contract amendment removing `AgentSupply.current` from the schema, `api.md`, and mirror registry.
- **Owner-vetoable:** English and Chinese billing vocabulary changes and the bare-按量 copy gate.

## Release Note

Existing `agents.<backend>.default_model` keys are now ignored and dropped when configuration is loaded. On upgrade, any Vibe Agent without a model receives the release recommendation as an explicit, visible Agent value; user-set models are never overwritten.

## Residual Manual Checks

- No manual visual pass was required for this copy/removal-only UI change; server-rendered component tests verify the removed badge and production build verifies every consumer of the removed payload type is gone.
