### PR TITLE
feat(memory): admit authenticated remote sessions to Memory routes

### DIFF
--- a/core/internal_server.py
+++ b/core/internal_server.py
@@ -760,7 +760,11 @@ def create_app(
 
         session_id = str(request.headers.get(CALLER_SESSION_HEADER) or "").strip()
         user_key = str(request.headers.get(MEMORY_USER_KEY_HEADER) or "").strip()
-        if session_id or user_key != "avibe:local":
+        remote_prefix = "avibe:remote:"
+        if session_id or not (
+            user_key == "avibe:local"
+            or (user_key.startswith(remote_prefix) and len(user_key) > len(remote_prefix))
+        ):
             return None
         from core.memory.ui_access import MEMORY_UI_PROOF_HEADER, verify_ui_read_proof
 

--- a/core/memory/ui_access.py
+++ b/core/memory/ui_access.py
@@ -1,4 +1,4 @@
-"""Process-private proof for Memory reads initiated by the local Settings UI."""
+"""Process-private proof for Memory operations initiated by the trusted Settings UI."""
 
 from __future__ import annotations
 

--- a/docs/plans/memory-architecture-deepening.md
+++ b/docs/plans/memory-architecture-deepening.md
@@ -337,10 +337,11 @@ Neither cost is worth removing a state the CLI already detects, logs, and gives
 a one-line recovery for. Documented as a known limitation under `vibe start` in
 `docs/CLI.md` and `docs/CLI_ZH.md`.
 
-Scope note: the affected surface is the Web UI Memory Settings page, which
-reads as the `avibe:local` principal behind this proof. `vibe memory ...`
-uses the Agent session's controller-side principal association and is
-unaffected.
+Scope note: the affected surface is the Web UI Memory Settings page. Direct
+loopback reads use the `avibe:local` principal; authenticated Avibe Cloud reads
+use the remote Workbench account's `avibe:remote:<subject>` principal behind the
+same process-private proof. `vibe memory ...` uses the Agent session's
+controller-side principal association and is unaffected.
 
 `d8bfd0bb` also introduces one new behavior, reviewed and kept: when the service
 is freshly started and a UI is already running, the UI is restarted so the pair

--- a/docs/plans/memory-plugin-system.md
+++ b/docs/plans/memory-plugin-system.md
@@ -349,13 +349,14 @@ with different content.
 
 ## Security and Data Disclosure
 
-- Memory Settings and browser content routes require a direct loopback peer and
-  host, a same-origin Origin/Referer, no forwarded metadata, and CSRF for
-  mutations. LAN, proxy, Docker bridge, and Avibe Cloud browser routes cannot
-  read whether Memory is enabled or access its content.
-- Authenticated remote Workbench messages may receive a stable per-user capture
-  and Agent capability, but the remote browser cannot open the local Settings
-  data surface.
+- Memory Settings and browser content routes require either a direct loopback
+  connection or an authenticated Avibe Cloud session. Every request requires a
+  same-origin Origin/Referer, and mutations also require CSRF. LAN, arbitrary
+  proxy, and Docker bridge routes remain unable to read Memory state or content.
+- Authenticated Avibe Cloud browser reads use the same stable per-user principal
+  as that account's remote Workbench messages. The install-wide settings,
+  diagnostics, runtime restart, and Clear all controls remain owner operations
+  protected by the signed Cloud session and same-origin/CSRF checks.
 - The controller socket and EverOS socket are owner-only Unix-domain sockets in
   mode `0600`; the sidecar has no TCP listener and is not exposed through remote
   access.

--- a/tests/test_internal_client.py
+++ b/tests/test_internal_client.py
@@ -335,7 +335,7 @@ def test_memory_ui_read_helper_signs_the_fixed_local_owner(monkeypatch, socket_p
     )
 
 
-def test_memory_clear_signs_the_fixed_local_owner(monkeypatch, socket_path):
+def test_memory_clear_signs_the_selected_ui_owner(monkeypatch, socket_path):
     from core.memory import ui_access
 
     captured: dict[str, object] = {}
@@ -352,7 +352,10 @@ def test_memory_clear_signs_the_fixed_local_owner(monkeypatch, socket_path):
             "vibe.internal_client.httpx.AsyncHTTPTransport",
             return_value=httpx.MockTransport(handler),
         ):
-            return await internal_client.memory_clear(socket_path=socket_path)
+            return await internal_client.memory_clear(
+                user_key="avibe:remote:user-1",
+                socket_path=socket_path,
+            )
 
     result = asyncio.run(_go())
     headers = captured["headers"]
@@ -360,12 +363,12 @@ def test_memory_clear_signs_the_fixed_local_owner(monkeypatch, socket_path):
     assert result["status_code"] == 200
     assert captured["path"] == "/internal/memory/clear"
     assert captured["payload"] == {"confirm": True}
-    assert headers["x-avibe-memory-user-key"] == "avibe:local"
+    assert headers["x-avibe-memory-user-key"] == "avibe:remote:user-1"
     assert headers["x-avibe-memory-ui-proof"] == ui_access.build_ui_read_proof(
         "test-ui-controller-secret",
         method="POST",
         path="/internal/memory/clear",
-        user_key="avibe:local",
+        user_key="avibe:remote:user-1",
     )
 
 

--- a/tests/test_internal_server.py
+++ b/tests/test_internal_server.py
@@ -734,6 +734,80 @@ def test_memory_ui_reads_use_the_default_agent_session_project(tmp_path: Path):
     assert expected_project.startswith("p-") and len(expected_project) == 34
 
 
+def test_memory_ui_proof_accepts_an_authenticated_remote_workbench_principal():
+    from core.memory.http_headers import MEMORY_USER_KEY_HEADER
+    from core.memory.ui_access import MEMORY_UI_PROOF_HEADER, build_ui_read_proof
+
+    principal_id = "u-11111111111111111111111111111111"
+    runtime = types.SimpleNamespace(
+        principal_for_user_key=Mock(return_value=principal_id),
+        profile_payload=AsyncMock(return_value={"status": "ok", "items": []}),
+    )
+    controller = _build_controller_double()
+    controller.memory_runtime = runtime
+    secret = "test-ui-controller-secret"
+    app = internal_server.create_app(controller, memory_ui_secret=secret)
+    user_key = "avibe:remote:user-1"
+
+    async def _go():
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+            return await client.get(
+                "/internal/memory/profile",
+                headers={
+                    MEMORY_USER_KEY_HEADER: user_key,
+                    MEMORY_UI_PROOF_HEADER: build_ui_read_proof(
+                        secret,
+                        method="GET",
+                        path="/internal/memory/profile",
+                        user_key=user_key,
+                    ),
+                },
+            )
+
+    response = asyncio.run(_go())
+
+    assert response.status_code == 200
+    runtime.principal_for_user_key.assert_called_once_with(user_key)
+    runtime.profile_payload.assert_awaited_once()
+
+
+def test_memory_ui_proof_rejects_non_browser_principal_namespaces():
+    from core.memory.http_headers import MEMORY_USER_KEY_HEADER
+    from core.memory.ui_access import MEMORY_UI_PROOF_HEADER, build_ui_read_proof
+
+    runtime = types.SimpleNamespace(
+        principal_for_user_key=Mock(return_value="u-11111111111111111111111111111111"),
+        profile_payload=AsyncMock(return_value={"status": "ok", "items": []}),
+    )
+    controller = _build_controller_double()
+    controller.memory_runtime = runtime
+    secret = "test-ui-controller-secret"
+    app = internal_server.create_app(controller, memory_ui_secret=secret)
+    user_key = "slack:user-1"
+
+    async def _go():
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+            return await client.get(
+                "/internal/memory/profile",
+                headers={
+                    MEMORY_USER_KEY_HEADER: user_key,
+                    MEMORY_UI_PROOF_HEADER: build_ui_read_proof(
+                        secret,
+                        method="GET",
+                        path="/internal/memory/profile",
+                        user_key=user_key,
+                    ),
+                },
+            )
+
+    response = asyncio.run(_go())
+
+    assert response.status_code == 403
+    runtime.principal_for_user_key.assert_not_called()
+
+
 def test_memory_internal_read_rejects_agent_session_with_forged_local_owner_header():
     from core.memory.http_headers import (
         CALLER_SESSION_HEADER,

--- a/tests/test_ui_memory_routes.py
+++ b/tests/test_ui_memory_routes.py
@@ -490,3 +490,88 @@ def test_memory_runtime_restart_rejects_cross_origin_callers(monkeypatch, tmp_pa
 
     assert response.status_code == 403
     assert calls == []
+
+
+def _save_remote_config(tmp_path) -> V2Config:
+    from config.v2_config import RemoteAccessConfig
+
+    config = V2Config(
+        mode="self_host",
+        version="v2",
+        slack=SlackConfig(bot_token=""),
+        runtime=RuntimeConfig(default_cwd="."),
+        agents=AgentsConfig(),
+        remote_access=RemoteAccessConfig(),
+    )
+    cloud = config.remote_access.vibe_cloud
+    cloud.enabled = True
+    cloud.public_url = "https://alex.avibe.bot"
+    cloud.client_id = "vr_client_123"
+    cloud.instance_id = "inst_123"
+    cloud.session_secret = "session-secret"
+    cloud.authorization_endpoint = "https://backend.test/oauth/authorize"
+    cloud.redirect_uri = "https://alex.avibe.bot/auth/callback"
+    config.save()
+    return config
+
+
+def test_memory_status_allows_authenticated_remote_session(monkeypatch, tmp_path) -> None:
+    from vibe import remote_access
+
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    config = _save_remote_config(tmp_path)
+
+    async def status():
+        return {"status_code": 200, "body": {"state": "disabled", "data_exists": False}}
+
+    monkeypatch.setattr(internal_client, "memory_status", status)
+    client = app.test_client()
+    client.set_cookie(
+        remote_access.SESSION_COOKIE_NAME,
+        remote_access.make_session_cookie(config, "alex@example.com", "user-1"),
+        domain="alex.avibe.bot",
+    )
+    response = client.get(
+        "/api/memory/status",
+        headers={"Origin": "https://alex.avibe.bot"},
+        base_url="https://alex.avibe.bot",
+        environ_base={"REMOTE_ADDR": "203.0.113.10"},
+    )
+
+    assert response.status_code == 200
+    assert response.get_json()["state"] == "disabled"
+
+
+def test_memory_status_rejects_remote_session_without_cookie(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    _save_remote_config(tmp_path)
+
+    response = app.test_client().get(
+        "/api/memory/status",
+        headers={"Origin": "https://alex.avibe.bot"},
+        base_url="https://alex.avibe.bot",
+        environ_base={"REMOTE_ADDR": "203.0.113.10"},
+        follow_redirects=False,
+    )
+
+    # The global remote-access guard redirects unauthenticated GETs to login
+    # before the Memory route is reached.
+    assert response.status_code == 302
+
+
+def test_memory_admission_rejects_remote_session_with_foreign_origin(monkeypatch, tmp_path) -> None:
+    from vibe import remote_access
+
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    config = _save_remote_config(tmp_path)
+    cookie = remote_access.make_session_cookie(config, "alex@example.com", "user-1")
+
+    with app.test_request_context(
+        "/api/memory/status",
+        base_url="https://alex.avibe.bot",
+        headers={
+            "Origin": "https://evil.example",
+            "Cookie": f"{remote_access.SESSION_COOKIE_NAME}={cookie}",
+        },
+    ):
+        assert ui_server.is_memory_request_admitted() is False

--- a/tests/test_ui_memory_routes.py
+++ b/tests/test_ui_memory_routes.py
@@ -12,7 +12,7 @@ from config.v2_config import (
     V2Config,
 )
 from tests.ui_server_test_helpers import csrf_headers
-from vibe import api, internal_client, ui_memory_routes, ui_server
+from vibe import api, internal_client, remote_access, ui_memory_routes, ui_server
 from vibe.ui_server import app
 
 
@@ -24,6 +24,21 @@ def _save_config(tmp_path) -> None:
         runtime=RuntimeConfig(default_cwd="."),
         agents=AgentsConfig(),
     ).save()
+
+
+def _save_remote_config(tmp_path) -> V2Config:
+    _save_config(tmp_path)
+    config = V2Config.load()
+    cloud = config.remote_access.vibe_cloud
+    cloud.enabled = True
+    cloud.public_url = "https://alex.avibe.bot"
+    cloud.client_id = "vr_client_123"
+    cloud.instance_id = "inst_123"
+    cloud.session_secret = "session-secret"
+    cloud.authorization_endpoint = "https://backend.test/oauth/authorize"
+    cloud.redirect_uri = "https://alex.avibe.bot/auth/callback"
+    config.save()
+    return config
 
 
 def _local_headers() -> dict[str, str]:
@@ -74,6 +89,89 @@ def test_memory_direct_loopback_predicate_rejects_forwarding(monkeypatch) -> Non
         },
     ):
         assert ui_server.is_direct_loopback_memory_request() is False
+
+
+def test_memory_authenticated_avibe_cloud_uses_the_remote_workbench_principal(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    config = _save_remote_config(tmp_path)
+    calls: list[tuple[str, str]] = []
+
+    async def profile(*, user_key: str):
+        calls.append(("profile", user_key))
+        return {"status_code": 200, "body": {"status": "ok", "items": []}}
+
+    async def clear(*, user_key: str):
+        calls.append(("clear", user_key))
+        return {"status_code": 200, "body": {"status": "completed", "epoch": 2}}
+
+    monkeypatch.setattr(internal_client, "memory_profile", profile)
+    monkeypatch.setattr(internal_client, "memory_clear", clear)
+    client = app.test_client()
+    client.set_cookie(
+        remote_access.SESSION_COOKIE_NAME,
+        remote_access.make_session_cookie(config, "alex@example.com", "user-1"),
+        domain="alex.avibe.bot",
+    )
+    remote_headers = {"Origin": "https://alex.avibe.bot"}
+
+    settings_response = client.get(
+        "/api/memory/settings",
+        headers=remote_headers,
+        base_url="https://alex.avibe.bot",
+        environ_base={"REMOTE_ADDR": "203.0.113.10"},
+    )
+    profile_response = client.get(
+        "/api/memory/profile",
+        headers=remote_headers,
+        base_url="https://alex.avibe.bot",
+        environ_base={"REMOTE_ADDR": "203.0.113.10"},
+    )
+    clear_response = client.post(
+        "/api/memory/clear",
+        json={"confirm": True},
+        headers=csrf_headers(client, "https://alex.avibe.bot"),
+        base_url="https://alex.avibe.bot",
+        environ_base={"REMOTE_ADDR": "203.0.113.10"},
+    )
+
+    assert settings_response.status_code == 200
+    assert profile_response.status_code == 200
+    assert clear_response.status_code == 200
+    assert calls == [
+        ("profile", "avibe:remote:user-1"),
+        ("clear", "avibe:remote:user-1"),
+    ]
+
+
+def test_memory_avibe_cloud_read_still_requires_same_origin(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    config = _save_remote_config(tmp_path)
+    client = app.test_client()
+    client.set_cookie(
+        remote_access.SESSION_COOKIE_NAME,
+        remote_access.make_session_cookie(config, "alex@example.com", "user-1"),
+        domain="alex.avibe.bot",
+    )
+
+    missing_origin = client.get(
+        "/api/memory/settings",
+        base_url="https://alex.avibe.bot",
+        environ_base={"REMOTE_ADDR": "203.0.113.10"},
+    )
+    cross_origin = client.get(
+        "/api/memory/settings",
+        headers={"Origin": "https://attacker.example"},
+        base_url="https://alex.avibe.bot",
+        environ_base={"REMOTE_ADDR": "203.0.113.10"},
+    )
+
+    assert missing_origin.status_code == 403
+    assert missing_origin.get_json() == {"status": "failed", "error": "memory_disabled"}
+    assert cross_origin.status_code == 403
+    assert cross_origin.get_json() == {"status": "failed", "error": "memory_disabled"}
 
 
 def test_memory_status_proxies_controller_over_uds(monkeypatch, tmp_path) -> None:
@@ -490,88 +588,3 @@ def test_memory_runtime_restart_rejects_cross_origin_callers(monkeypatch, tmp_pa
 
     assert response.status_code == 403
     assert calls == []
-
-
-def _save_remote_config(tmp_path) -> V2Config:
-    from config.v2_config import RemoteAccessConfig
-
-    config = V2Config(
-        mode="self_host",
-        version="v2",
-        slack=SlackConfig(bot_token=""),
-        runtime=RuntimeConfig(default_cwd="."),
-        agents=AgentsConfig(),
-        remote_access=RemoteAccessConfig(),
-    )
-    cloud = config.remote_access.vibe_cloud
-    cloud.enabled = True
-    cloud.public_url = "https://alex.avibe.bot"
-    cloud.client_id = "vr_client_123"
-    cloud.instance_id = "inst_123"
-    cloud.session_secret = "session-secret"
-    cloud.authorization_endpoint = "https://backend.test/oauth/authorize"
-    cloud.redirect_uri = "https://alex.avibe.bot/auth/callback"
-    config.save()
-    return config
-
-
-def test_memory_status_allows_authenticated_remote_session(monkeypatch, tmp_path) -> None:
-    from vibe import remote_access
-
-    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
-    config = _save_remote_config(tmp_path)
-
-    async def status():
-        return {"status_code": 200, "body": {"state": "disabled", "data_exists": False}}
-
-    monkeypatch.setattr(internal_client, "memory_status", status)
-    client = app.test_client()
-    client.set_cookie(
-        remote_access.SESSION_COOKIE_NAME,
-        remote_access.make_session_cookie(config, "alex@example.com", "user-1"),
-        domain="alex.avibe.bot",
-    )
-    response = client.get(
-        "/api/memory/status",
-        headers={"Origin": "https://alex.avibe.bot"},
-        base_url="https://alex.avibe.bot",
-        environ_base={"REMOTE_ADDR": "203.0.113.10"},
-    )
-
-    assert response.status_code == 200
-    assert response.get_json()["state"] == "disabled"
-
-
-def test_memory_status_rejects_remote_session_without_cookie(monkeypatch, tmp_path) -> None:
-    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
-    _save_remote_config(tmp_path)
-
-    response = app.test_client().get(
-        "/api/memory/status",
-        headers={"Origin": "https://alex.avibe.bot"},
-        base_url="https://alex.avibe.bot",
-        environ_base={"REMOTE_ADDR": "203.0.113.10"},
-        follow_redirects=False,
-    )
-
-    # The global remote-access guard redirects unauthenticated GETs to login
-    # before the Memory route is reached.
-    assert response.status_code == 302
-
-
-def test_memory_admission_rejects_remote_session_with_foreign_origin(monkeypatch, tmp_path) -> None:
-    from vibe import remote_access
-
-    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
-    config = _save_remote_config(tmp_path)
-    cookie = remote_access.make_session_cookie(config, "alex@example.com", "user-1")
-
-    with app.test_request_context(
-        "/api/memory/status",
-        base_url="https://alex.avibe.bot",
-        headers={
-            "Origin": "https://evil.example",
-            "Cookie": f"{remote_access.SESSION_COOKIE_NAME}={cookie}",
-        },
-    ):
-        assert ui_server.is_memory_request_admitted() is False

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -3471,8 +3471,8 @@
       "settings": "Settings"
     },
     "remoteUnavailable": {
-      "title": "Available on this device only",
-      "description": "Memory settings and data are visible only from a direct connection to this Avibe install — not through Avibe Cloud or another remote route."
+      "title": "Sign-in required",
+      "description": "Memory settings and data require a direct connection to this Avibe install or a signed-in Avibe Cloud session."
     },
     "status": {
       "title": "Status",

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -3471,8 +3471,8 @@
       "settings": "Settings"
     },
     "remoteUnavailable": {
-      "title": "Sign-in required",
-      "description": "Memory settings and data require a direct connection to this Avibe install or a signed-in Avibe Cloud session."
+      "title": "Memory unavailable on this connection",
+      "description": "Connect directly to this Avibe install or use an authenticated Avibe Cloud session. Other remote routes remain blocked."
     },
     "status": {
       "title": "Status",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -3471,8 +3471,8 @@
       "settings": "设置"
     },
     "remoteUnavailable": {
-      "title": "需要登录后访问",
-      "description": "记忆的设置和数据需要直接连接到本机 Avibe，或通过已登录的 Avibe Cloud 会话访问。"
+      "title": "当前连接无法访问记忆",
+      "description": "请直接连接本机 Avibe，或使用已认证的 Avibe Cloud 会话。其他远程连接仍会被拒绝。"
     },
     "status": {
       "title": "状态",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -3471,8 +3471,8 @@
       "settings": "设置"
     },
     "remoteUnavailable": {
-      "title": "仅限本机访问",
-      "description": "记忆的设置和数据仅在直接连接到本机 Avibe 时可见——通过 Avibe Cloud 或其他远程方式无法访问。"
+      "title": "需要登录后访问",
+      "description": "记忆的设置和数据需要直接连接到本机 Avibe，或通过已登录的 Avibe Cloud 会话访问。"
     },
     "status": {
       "title": "状态",

--- a/ui/src/lib/memoryRead.ts
+++ b/ui/src/lib/memoryRead.ts
@@ -1,8 +1,7 @@
 import type { TFunction } from 'i18next';
 
 // Backend forbidden path (`_memory_forbidden_response`) returns exactly this closed shape for
-// every Memory route when the request is neither direct-loopback nor an authenticated
-// remote-access session. It is
+// every Memory route when the request isn't direct-loopback (e.g. opened via Avibe Cloud). It is
 // otherwise never produced by a settings/status/profile/search/clear success or config-disabled
 // path, so it's a safe signal to render the "available on this device only" static state instead
 // of a generic error.

--- a/ui/src/lib/memoryRead.ts
+++ b/ui/src/lib/memoryRead.ts
@@ -1,7 +1,8 @@
 import type { TFunction } from 'i18next';
 
 // Backend forbidden path (`_memory_forbidden_response`) returns exactly this closed shape for
-// every Memory route when the request isn't direct-loopback (e.g. opened via Avibe Cloud). It is
+// every Memory route when the request is neither direct-loopback nor an authenticated
+// Avibe Cloud session. It is
 // otherwise never produced by a settings/status/profile/search/clear success or config-disabled
 // path, so it's a safe signal to render the "available on this device only" static state instead
 // of a generic error.

--- a/ui/src/lib/memoryRead.ts
+++ b/ui/src/lib/memoryRead.ts
@@ -1,7 +1,8 @@
 import type { TFunction } from 'i18next';
 
 // Backend forbidden path (`_memory_forbidden_response`) returns exactly this closed shape for
-// every Memory route when the request isn't direct-loopback (e.g. opened via Avibe Cloud). It is
+// every Memory route when the request is neither direct-loopback nor an authenticated
+// remote-access session. It is
 // otherwise never produced by a settings/status/profile/search/clear success or config-disabled
 // path, so it's a safe signal to render the "available on this device only" static state instead
 // of a generic error.

--- a/vibe/internal_client.py
+++ b/vibe/internal_client.py
@@ -387,6 +387,7 @@ async def memory_search(
 
 async def memory_clear(
     *,
+    user_key: str,
     socket_path: Optional[Path] = None,
     timeout: float = MEMORY_CLEAR_TIMEOUT_SECONDS,
 ) -> dict[str, Any]:
@@ -397,7 +398,7 @@ async def memory_clear(
         headers=_memory_user_key_headers(
             "POST",
             "/internal/memory/clear",
-            "avibe:local",
+            user_key,
         ),
         socket_path=socket_path,
         timeout=timeout,

--- a/vibe/ui_memory_routes.py
+++ b/vibe/ui_memory_routes.py
@@ -1,6 +1,7 @@
 """The ``/api/memory/*`` UI surface.
 
-Every route here is direct-loopback only and answers with the closed Memory
+Every route here requires direct loopback or an authenticated remote-access
+session, and answers with the closed Memory
 result envelope (``{"status": "ok", ...}`` / ``{"status": "failed", "error":
 <closed code>}``) plus ``Cache-Control: no-store``. Keeping them in one module
 means the admission check, the envelope and the no-store header are stated once
@@ -23,8 +24,8 @@ from config.v2_config import V2Config
 from vibe.ui_compat import Response, jsonify
 
 
-def _direct_loopback_memory_request() -> bool:
-    """Ask ``ui_server`` for the strict Memory admission verdict.
+def _memory_request_admitted() -> bool:
+    """Ask ``ui_server`` for the Memory admission verdict.
 
     Late-bound on purpose: the predicate belongs with the other request-locality
     helpers in ``ui_server``, and resolving it per call keeps it patchable there.
@@ -32,7 +33,7 @@ def _direct_loopback_memory_request() -> bool:
 
     from vibe import ui_server
 
-    return ui_server.is_direct_loopback_memory_request()
+    return ui_server.is_memory_request_admitted()
 
 
 def _memory_response(payload: dict, *, status_code: int = 200) -> Response:
@@ -238,7 +239,7 @@ def register_memory_routes(app) -> None:
     @app.get("/api/memory/settings", include_in_schema=False)
     async def memory_settings_get(starlette_request: FastAPIRequest):
         async def handler():
-            if not _direct_loopback_memory_request():
+            if not _memory_request_admitted():
                 return _memory_forbidden_response()
             try:
                 return _memory_response(await asyncio.to_thread(_memory_settings_payload))
@@ -250,7 +251,7 @@ def register_memory_routes(app) -> None:
     @app.patch("/api/memory/settings", include_in_schema=False)
     async def memory_settings_patch(starlette_request: FastAPIRequest):
         async def handler():
-            if not _direct_loopback_memory_request():
+            if not _memory_request_admitted():
                 return _memory_forbidden_response()
             try:
                 patch_payload = await starlette_request.json()
@@ -263,7 +264,7 @@ def register_memory_routes(app) -> None:
     @app.get("/api/memory/status", include_in_schema=False)
     async def memory_status_get(starlette_request: FastAPIRequest):
         async def handler():
-            if not _direct_loopback_memory_request():
+            if not _memory_request_admitted():
                 return _memory_forbidden_response()
             from vibe import internal_client
 
@@ -274,7 +275,7 @@ def register_memory_routes(app) -> None:
     @app.get("/api/memory/failures", include_in_schema=False)
     async def memory_failures_get(starlette_request: FastAPIRequest):
         async def handler():
-            if not _direct_loopback_memory_request():
+            if not _memory_request_admitted():
                 return _memory_forbidden_response()
             from vibe import internal_client
 
@@ -285,7 +286,7 @@ def register_memory_routes(app) -> None:
     @app.get("/api/memory/profile", include_in_schema=False)
     async def memory_profile_get(starlette_request: FastAPIRequest):
         async def handler():
-            if not _direct_loopback_memory_request():
+            if not _memory_request_admitted():
                 return _memory_forbidden_response()
             from vibe import internal_client
 
@@ -298,7 +299,7 @@ def register_memory_routes(app) -> None:
     @app.post("/api/memory/search", include_in_schema=False)
     async def memory_search_post(starlette_request: FastAPIRequest):
         async def handler():
-            if not _direct_loopback_memory_request():
+            if not _memory_request_admitted():
                 return _memory_forbidden_response()
             try:
                 payload = await starlette_request.json()
@@ -330,7 +331,7 @@ def register_memory_routes(app) -> None:
         """
 
         async def handler():
-            if not _direct_loopback_memory_request():
+            if not _memory_request_admitted():
                 return _memory_forbidden_response()
             from vibe import internal_client
 
@@ -341,7 +342,7 @@ def register_memory_routes(app) -> None:
     @app.post("/api/memory/clear", include_in_schema=False)
     async def memory_clear_post(starlette_request: FastAPIRequest):
         async def handler():
-            if not _direct_loopback_memory_request():
+            if not _memory_request_admitted():
                 return _memory_forbidden_response()
             try:
                 payload = await starlette_request.json()

--- a/vibe/ui_memory_routes.py
+++ b/vibe/ui_memory_routes.py
@@ -1,8 +1,8 @@
 """The ``/api/memory/*`` UI surface.
 
-Every route here requires direct loopback or an authenticated remote-access
-session, and answers with the closed Memory
-result envelope (``{"status": "ok", ...}`` / ``{"status": "failed", "error":
+Every route here requires a trusted local or authenticated Avibe Cloud browser
+and answers with the closed Memory result envelope (``{"status": "ok", ...}`` /
+``{"status": "failed", "error":
 <closed code>}``) plus ``Cache-Control: no-store``. Keeping them in one module
 means the admission check, the envelope and the no-store header are stated once
 per route group instead of being scattered through ``vibe/ui_server.py``.
@@ -24,16 +24,16 @@ from config.v2_config import V2Config
 from vibe.ui_compat import Response, jsonify
 
 
-def _memory_request_admitted() -> bool:
-    """Ask ``ui_server`` for the Memory admission verdict.
+def _memory_ui_user_key() -> str | None:
+    """Ask ``ui_server`` for the trusted browser's Memory identity.
 
-    Late-bound on purpose: the predicate belongs with the other request-locality
+    Late-bound on purpose: the policy belongs with the other request-locality
     helpers in ``ui_server``, and resolving it per call keeps it patchable there.
     """
 
     from vibe import ui_server
 
-    return ui_server.is_memory_request_admitted()
+    return ui_server.memory_ui_user_key()
 
 
 def _memory_response(payload: dict, *, status_code: int = 200) -> Response:
@@ -239,7 +239,7 @@ def register_memory_routes(app) -> None:
     @app.get("/api/memory/settings", include_in_schema=False)
     async def memory_settings_get(starlette_request: FastAPIRequest):
         async def handler():
-            if not _memory_request_admitted():
+            if _memory_ui_user_key() is None:
                 return _memory_forbidden_response()
             try:
                 return _memory_response(await asyncio.to_thread(_memory_settings_payload))
@@ -251,7 +251,7 @@ def register_memory_routes(app) -> None:
     @app.patch("/api/memory/settings", include_in_schema=False)
     async def memory_settings_patch(starlette_request: FastAPIRequest):
         async def handler():
-            if not _memory_request_admitted():
+            if _memory_ui_user_key() is None:
                 return _memory_forbidden_response()
             try:
                 patch_payload = await starlette_request.json()
@@ -264,7 +264,7 @@ def register_memory_routes(app) -> None:
     @app.get("/api/memory/status", include_in_schema=False)
     async def memory_status_get(starlette_request: FastAPIRequest):
         async def handler():
-            if not _memory_request_admitted():
+            if _memory_ui_user_key() is None:
                 return _memory_forbidden_response()
             from vibe import internal_client
 
@@ -275,7 +275,7 @@ def register_memory_routes(app) -> None:
     @app.get("/api/memory/failures", include_in_schema=False)
     async def memory_failures_get(starlette_request: FastAPIRequest):
         async def handler():
-            if not _memory_request_admitted():
+            if _memory_ui_user_key() is None:
                 return _memory_forbidden_response()
             from vibe import internal_client
 
@@ -286,12 +286,13 @@ def register_memory_routes(app) -> None:
     @app.get("/api/memory/profile", include_in_schema=False)
     async def memory_profile_get(starlette_request: FastAPIRequest):
         async def handler():
-            if not _memory_request_admitted():
+            user_key = _memory_ui_user_key()
+            if user_key is None:
                 return _memory_forbidden_response()
             from vibe import internal_client
 
             return await _memory_internal_response(
-                lambda: internal_client.memory_profile(user_key="avibe:local")
+                lambda: internal_client.memory_profile(user_key=user_key)
             )
 
         return await app.dispatch_native_request(starlette_request, handler)
@@ -299,7 +300,8 @@ def register_memory_routes(app) -> None:
     @app.post("/api/memory/search", include_in_schema=False)
     async def memory_search_post(starlette_request: FastAPIRequest):
         async def handler():
-            if not _memory_request_admitted():
+            user_key = _memory_ui_user_key()
+            if user_key is None:
                 return _memory_forbidden_response()
             try:
                 payload = await starlette_request.json()
@@ -314,7 +316,7 @@ def register_memory_routes(app) -> None:
             from vibe import internal_client
 
             return await _memory_internal_response(
-                lambda: internal_client.memory_search(query, limit, user_key="avibe:local")
+                lambda: internal_client.memory_search(query, limit, user_key=user_key)
             )
 
         return await app.dispatch_native_request(starlette_request, handler)
@@ -331,7 +333,7 @@ def register_memory_routes(app) -> None:
         """
 
         async def handler():
-            if not _memory_request_admitted():
+            if _memory_ui_user_key() is None:
                 return _memory_forbidden_response()
             from vibe import internal_client
 
@@ -342,7 +344,8 @@ def register_memory_routes(app) -> None:
     @app.post("/api/memory/clear", include_in_schema=False)
     async def memory_clear_post(starlette_request: FastAPIRequest):
         async def handler():
-            if not _memory_request_admitted():
+            user_key = _memory_ui_user_key()
+            if user_key is None:
                 return _memory_forbidden_response()
             try:
                 payload = await starlette_request.json()
@@ -352,6 +355,8 @@ def register_memory_routes(app) -> None:
                 return _memory_response({"status": "failed", "error": "memory_invalid_input"}, status_code=400)
             from vibe import internal_client
 
-            return await _memory_internal_response(internal_client.memory_clear)
+            return await _memory_internal_response(
+                lambda: internal_client.memory_clear(user_key=user_key)
+            )
 
         return await app.dispatch_native_request(starlette_request, handler)

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -1364,12 +1364,11 @@ def _is_local_request(config: V2Config | None = None) -> bool:
 
 
 def is_direct_loopback_memory_request() -> bool:
-    """Strict direct-loopback Memory admission, intentionally narrower than UI local.
+    """Strict Memory-only browser admission, intentionally narrower than UI local.
 
-    Never accepts proxy forwarding, Docker bridge allowances or LAN setup
-    hosts: the browser must be directly connected over loopback and present a
-    same-origin header. Authenticated remote sessions are admitted separately
-    via ``is_memory_request_admitted``.
+    Memory content and settings never accept proxy forwarding, Docker bridge
+    allowances, LAN setup hosts, or remote-access cookies. The browser must be
+    directly connected over loopback and present a same-origin header.
     """
 
     if _has_forwarded_metadata() or not _is_loopback_peer() or not _is_loopback_host(request.host):
@@ -1378,32 +1377,39 @@ def is_direct_loopback_memory_request() -> bool:
     return bool(origin and _same_origin(origin, request.host_url.rstrip("/")))
 
 
-def _is_authenticated_remote_memory_request() -> bool:
-    """A remote-access request carrying a valid session cookie and a same-origin header.
+def memory_ui_user_key() -> str | None:
+    """Resolve the Memory principal for a trusted browser request.
 
-    Mirrors the admission bar of ``enforce_remote_access_cookie`` (enabled cloud
-    config + signed session cookie) and adds the same-origin requirement the
-    loopback path enforces, so cross-site reads stay rejected.
+    Direct loopback keeps the install-local identity. Remote browser access is
+    admitted only through the configured Avibe Cloud origin with a valid signed
+    session cookie; LAN and arbitrary proxy routes remain closed. Reads require
+    the same origin evidence as mutations so a remote session cookie cannot be
+    used as a cross-origin Memory oracle.
     """
 
+    if is_direct_loopback_memory_request():
+        return "avibe:local"
     config = _load_remote_access_config()
     if config is None or not _is_remote_access_request(config):
-        return False
-    cloud = config.remote_access.vibe_cloud
-    if not cloud.enabled or not cloud.session_secret:
-        return False
-    from vibe import remote_access
+        return None
+    source = _request_origin(request.headers.get("Origin")) or _request_origin(
+        request.headers.get("Referer")
+    )
+    if not source or not _same_origin(source, _current_origin()):
+        return None
+    try:
+        from vibe import remote_access
 
-    if remote_access.parse_session_cookie(config, request.cookies.get(remote_access.SESSION_COOKIE_NAME)) is None:
-        return False
-    origin = _request_origin(request.headers.get("Origin")) or _request_origin(request.headers.get("Referer"))
-    return bool(origin and _remote_access_public_origin_matches(origin, config))
-
-
-def is_memory_request_admitted() -> bool:
-    """Memory browser admission: direct loopback, or an authenticated remote session."""
-
-    return is_direct_loopback_memory_request() or _is_authenticated_remote_memory_request()
+        payload = remote_access.parse_session_cookie(
+            config,
+            request.cookies.get(remote_access.SESSION_COOKIE_NAME),
+        )
+    except Exception:
+        return None
+    subject = payload.get("sub") if isinstance(payload, dict) else None
+    if not isinstance(subject, str) or not subject.strip():
+        return None
+    return f"avibe:remote:{subject.strip()}"
 
 
 def _normalized_host(value: str | None) -> str:

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -1364,17 +1364,46 @@ def _is_local_request(config: V2Config | None = None) -> bool:
 
 
 def is_direct_loopback_memory_request() -> bool:
-    """Strict Memory-only browser admission, intentionally narrower than UI local.
+    """Strict direct-loopback Memory admission, intentionally narrower than UI local.
 
-    Memory content and settings never accept proxy forwarding, Docker bridge
-    allowances, LAN setup hosts, or remote-access cookies. The browser must be
-    directly connected over loopback and present a same-origin header.
+    Never accepts proxy forwarding, Docker bridge allowances or LAN setup
+    hosts: the browser must be directly connected over loopback and present a
+    same-origin header. Authenticated remote sessions are admitted separately
+    via ``is_memory_request_admitted``.
     """
 
     if _has_forwarded_metadata() or not _is_loopback_peer() or not _is_loopback_host(request.host):
         return False
     origin = _request_origin(request.headers.get("Origin")) or _request_origin(request.headers.get("Referer"))
     return bool(origin and _same_origin(origin, request.host_url.rstrip("/")))
+
+
+def _is_authenticated_remote_memory_request() -> bool:
+    """A remote-access request carrying a valid session cookie and a same-origin header.
+
+    Mirrors the admission bar of ``enforce_remote_access_cookie`` (enabled cloud
+    config + signed session cookie) and adds the same-origin requirement the
+    loopback path enforces, so cross-site reads stay rejected.
+    """
+
+    config = _load_remote_access_config()
+    if config is None or not _is_remote_access_request(config):
+        return False
+    cloud = config.remote_access.vibe_cloud
+    if not cloud.enabled or not cloud.session_secret:
+        return False
+    from vibe import remote_access
+
+    if remote_access.parse_session_cookie(config, request.cookies.get(remote_access.SESSION_COOKIE_NAME)) is None:
+        return False
+    origin = _request_origin(request.headers.get("Origin")) or _request_origin(request.headers.get("Referer"))
+    return bool(origin and _remote_access_public_origin_matches(origin, config))
+
+
+def is_memory_request_admitted() -> bool:
+    """Memory browser admission: direct loopback, or an authenticated remote session."""
+
+    return is_direct_loopback_memory_request() or _is_authenticated_remote_memory_request()
 
 
 def _normalized_host(value: str | None) -> str:


### PR DESCRIPTION
## Summary

- Allow Memory settings and data routes through an authenticated Avibe Cloud session while retaining direct-loopback access.
- Keep unauthenticated LAN, proxy, Docker-peer, and foreign-origin requests blocked.
- Propagate the authenticated remote identity through Memory API and internal-server calls so remote profiles/search remain isolated from the local profile.
- Update the Memory UI copy to describe the actual access boundary.

## Scope

- Base: `dev`
- Head: `feat/memory-remote-session-access`
- Capability: authenticated remote access to the existing Memory UI/API
- Scenario catalog: no dedicated Memory scenario IDs currently exist
- Dependencies: none added

## Evidence

- Python route/auth/internal-server coverage: 358 passed
- Ruff on changed Python files: passed
- UI import validation, TypeScript build, and Vite production build: passed
- The final source tree is byte-for-byte identical to the previously validated and locally deployed implementation at `83a6eb345e6df1c2282217bad196a63775f8e565`
- Local Incus regression previously verified signed Cloud requests to Memory settings, status, and failures with HTTP 200

## Boundaries

- Direct loopback access remains unchanged.
- Authenticated Cloud requests use the remote subject namespace; they do not inherit the local Memory identity.
- Installing the Memory runtime still does not enable Memory automatically.
- Residual manual check: a real public Cloud tunnel/provider session was not exercised; authentication and origin behavior are covered by route-level tests and signed local regression requests.
