### PR TITLE
fix(models): remove empty selection state

### DIFF
--- a/ui/src/components/settings/models/AgentCard.test.tsx
+++ b/ui/src/components/settings/models/AgentCard.test.tsx
@@ -145,10 +145,11 @@ describe('AgentCard model list', () => {
     expect(html).toContain('当前已自动换到 OpenAI API Key');
   });
 
-  it('renders an honest row-zero state when no model is selected', () => {
+  it('does not turn an absent selection into a Models-page state', () => {
     const html = render([agent({ selected_model_id: null })], chains(chain('claude-opus-4-6')));
-    expect(html).toContain(zh.settings.models.emptySelection.title);
-    expect(html).toContain(zh.settings.models.emptySelection.action);
+    expect(html).toContain('claude-opus-4-6');
+    expect(html).not.toContain('尚未选择型号');
+    expect(html).not.toContain('href="/agents"');
   });
 
   it('gives an interrupted model its route door', () => {
@@ -244,7 +245,7 @@ describe('AgentCard model list', () => {
     const footer = render([open], {}, false, undefined, pending);
     expect(footer).toMatch(/<button[^>]*disabled=""[^>]*>(?:(?!<\/button>)[\s\S])*?管理型号<\/button>/);
 
-    const rowZero = render([
+    const emptyMenu = render([
       agent({
         backend: 'opencode',
         menu_kind: 'open',
@@ -255,7 +256,8 @@ describe('AgentCard model list', () => {
         builtin_models: null,
       }),
     ], {}, false, undefined, pending);
-    expect(rowZero).toMatch(/<button[^>]*disabled=""[^>]*>(?:(?!<\/button>)[\s\S])*?选择型号<\/button>/);
+    expect(emptyMenu).toContain(zh.settings.models.agents.emptyModels);
+    expect(emptyMenu).toMatch(/<button[^>]*disabled=""[^>]*>(?:(?!<\/button>)[\s\S])*?管理型号<\/button>/);
   });
 
   it('filters to affected rows without leaving healthy siblings behind', () => {

--- a/ui/src/components/settings/models/AgentCard.tsx
+++ b/ui/src/components/settings/models/AgentCard.tsx
@@ -4,7 +4,6 @@ import {
   ArrowDownUp,
   ChevronDown,
   ChevronRight,
-  CircleAlert,
   Loader2,
   Plus,
   Settings2,
@@ -30,7 +29,6 @@ import { serverText } from './serverCopy';
 import { ModelRoutePicker } from './ModelRoutePicker';
 import { useAnnounceEnrollment } from './menus/enrollment';
 import {
-  agentNeedsModelSelection,
   listedModelIds,
   modelChainKey,
   modelHasOffOrderSupplier,
@@ -461,44 +459,6 @@ const ModelRow: React.FC<{
   );
 };
 
-const EmptySelectionRow: React.FC<{
-  agent: AgentSupply;
-  pending: boolean;
-  onOpenModels: (agent: AgentSupply) => void;
-}> = ({
-  agent,
-  pending,
-  onOpenModels,
-}) => {
-  const { t } = useTranslation();
-  return (
-    <div className="flex flex-col gap-3 border-b border-destructive/25 bg-destructive/[0.035] px-4 py-4 sm:flex-row sm:items-center sm:justify-between sm:px-5" data-model-issue>
-      <span className="flex min-w-0 items-start gap-2.5">
-        <CircleAlert className="mt-0.5 size-4 shrink-0 text-destructive" />
-        <span>
-          <span className="block text-[12.5px] font-semibold text-foreground">{t('settings.models.emptySelection.title')}</span>
-          <span className="mt-0.5 block text-[11.5px] text-muted">{t('settings.models.emptySelection.body')}</span>
-        </span>
-      </span>
-      {agent.menu_kind === 'open' ? (
-        <Button
-          variant="outline"
-          size="sm"
-          className="h-9 shrink-0"
-          onClick={() => onOpenModels(agent)}
-          disabled={pending}
-        >
-          {t('settings.models.emptySelection.action')}
-        </Button>
-      ) : (
-        <Button asChild variant="outline" size="sm" className="h-9 shrink-0">
-          <Link to="/agents">{t('settings.models.emptySelection.action')}</Link>
-        </Button>
-      )}
-    </div>
-  );
-};
-
 const AgentModelCard: React.FC<{
   agent: AgentSupply;
   sources: Source[];
@@ -530,8 +490,7 @@ const AgentModelCard: React.FC<{
   const models = issuesOnly
     ? allModels.filter((modelId) => modelNeedsAttention(agent, modelId, chains[modelChainKey(agent.backend, modelId)], runtime))
     : allModels;
-  const emptySelection = agentNeedsModelSelection(agent);
-  if (issuesOnly && !emptySelection && models.length === 0) return null;
+  if (issuesOnly && models.length === 0) return null;
 
   return (
     <section className="overflow-hidden rounded-xl border border-border bg-background">
@@ -582,32 +541,9 @@ const AgentModelCard: React.FC<{
         )}
       </div>
 
-      {emptySelection && (
-        <EmptySelectionRow agent={agent} pending={props.pending} onOpenModels={props.onOpenModels} />
-      )}
-
-      {models.length === 0 && !emptySelection ? (
-        <div className="flex flex-col items-center gap-3 px-4 py-10 text-center sm:px-5">
+      {models.length === 0 ? (
+        <div className="px-4 py-10 text-center sm:px-5">
           <p className="text-[12.5px] text-muted">{t('settings.models.agents.emptyModels')}</p>
-          {agent.menu_kind === 'open' ? (
-            <Button
-              variant="outline"
-              size="sm"
-              className="h-9"
-              onClick={() => props.onOpenModels(agent)}
-              disabled={props.pending}
-            >
-              <Plus />
-              {t('settings.models.emptySelection.action')}
-            </Button>
-          ) : (
-            <Button asChild variant="outline" size="sm" className="h-9">
-              <Link to="/agents">
-                <Plus />
-                {t('settings.models.emptySelection.action')}
-              </Link>
-            </Button>
-          )}
         </div>
       ) : (
         models.map((modelId) => (
@@ -683,7 +619,6 @@ export const AgentCard: React.FC<{
         />
       ))}
       {props.issuesOnly && !agents.some((agent) => {
-        if (agentNeedsModelSelection(agent)) return true;
         return listedModelIds(agent).some((modelId) =>
           modelNeedsAttention(agent, modelId, props.chains[modelChainKey(agent.backend, modelId)], props.runtime),
         );

--- a/ui/src/components/settings/models/modelRows.test.ts
+++ b/ui/src/components/settings/models/modelRows.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
 import {
-  agentNeedsModelSelection,
   listedModelIds,
   manualModelSources,
   modelChainKey,
@@ -162,11 +161,10 @@ describe('model row projection', () => {
     expect(modelSupplierCounts([first, second]).get('shared-model')).toBe(2);
   });
 
-  it('counts an interrupted model and the honest row-zero state independently', () => {
+  it('counts an interrupted model without treating absent selection as another issue', () => {
     const row = read({ supply_state: 'interrupted', chain: [] });
     const a = agent({ selected_model_id: null, builtin_models: ['builtin-model'], model_supply: [] });
-    expect(agentNeedsModelSelection(a)).toBe(true);
-    expect(modelIssueCount([a], { [modelChainKey('claude', 'builtin-model')]: row })).toBe(2);
+    expect(modelIssueCount([a], { [modelChainKey('claude', 'builtin-model')]: row })).toBe(1);
   });
 
   it('attributes runtime failure only to a model whose current head uses the managed channel', () => {

--- a/ui/src/components/settings/models/modelRows.ts
+++ b/ui/src/components/settings/models/modelRows.ts
@@ -114,10 +114,6 @@ export function modelNeedsAttention(
   return agent.model_supply?.find((model) => model.model_id === modelId)?.chain_length === 0;
 }
 
-export function agentNeedsModelSelection(agent: AgentSupply): boolean {
-  return agent.mode === 'hub' && !agent.selected_model_id;
-}
-
 export function modelIssueCount(
   agents: AgentSupply[],
   chains: ModelChainIndex,
@@ -127,6 +123,6 @@ export function modelIssueCount(
     const modelIssues = listedModelIds(agent).filter((modelId) =>
       modelNeedsAttention(agent, modelId, chains[modelChainKey(agent.backend, modelId)], runtime),
     ).length;
-    return count + modelIssues + (agentNeedsModelSelection(agent) ? 1 : 0);
+    return count + modelIssues;
   }, 0);
 }

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -741,11 +741,6 @@
         "runtime": "Model service is not ready",
         "runtimeAction": "Resolve"
       },
-      "emptySelection": {
-        "title": "No model selected",
-        "body": "This agent has no current model and needs one before its next run.",
-        "action": "Choose model"
-      },
       "routes": {
         "title": "Supply method",
         "global": "Follow {{backend}}'s source order",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -741,11 +741,6 @@
         "runtime": "模型服务未就绪",
         "runtimeAction": "去处理"
       },
-      "emptySelection": {
-        "title": "尚未选择型号",
-        "body": "这个 Agent 现在没有当前型号，下一次运行前需要选择。",
-        "action": "选择型号"
-      },
       "routes": {
         "title": "供给方式",
         "global": "跟随 {{backend}} 来源顺序",


### PR DESCRIPTION
## Summary

- remove the absence-keyed empty-selection alert from Models agent cards
- stop counting a missing selected-model projection as a Models-page issue
- delete the obsolete English and Chinese copy while preserving OpenCode's genuine empty-menu state

## Scenarios

- No scenario-catalog IDs are affected; this is a narrow Models UI residue removal.

## Evidence

- Unit: full UI suite, 104 files / 1,297 tests passed; focused Models tests, 33 passed
- Contract: locale parity/copy gates passed; no API or schema contract changed
- Scenario: no scenario harness change required for this presentation-only state
- Build: production UI build and theme validation passed
- Static: changed-file ESLint passed; residue checks found no `emptySelection`, selection-absence conditional, or removed `current` payload consumer in the affected surface
- Residual manual check: OpenCode's empty menu remains covered and still opens through its existing Manage models control

Repo-wide ESLint still reports the existing unrelated baseline errors; none are in the changed files.
