### PR TITLE
fix: archive agents without breaking references

### DIFF
--- a/config/v2_settings.py
+++ b/config/v2_settings.py
@@ -27,6 +27,7 @@ _BIND_CODE_PREFIX = "vr-"
 _BIND_CODE_RANDOM_LENGTH = 10
 _BIND_CODE_ALPHABET = string.ascii_letters + string.digits
 _MAX_ACTIVE_BIND_CODES = 10
+_UNSET_AGENT_BINDING = object()
 
 
 def normalize_show_message_types(show_message_types: Optional[List[str]]) -> List[str]:
@@ -219,6 +220,9 @@ class ChannelSettings:
     # Per-channel require_bind gate: None/False=off (any channel member), True=only
     # process messages from bound users; unbound senders are silently ignored.
     require_bind: Optional[bool] = None
+    # Internal optimistic-concurrency token. It is populated from SQLite and
+    # deliberately omitted from API payloads and persisted settings JSON.
+    _agent_name_at_load: object = field(default=_UNSET_AGENT_BINDING, repr=False, compare=False)
 
 
 @dataclass
@@ -239,6 +243,7 @@ class UserSettings:
     routing: RoutingSettings = field(default_factory=RoutingSettings)
     dm_chat_id: str = ""
     pending_bind_menu_hint: bool = False
+    _agent_name_at_load: object = field(default=_UNSET_AGENT_BINDING, repr=False, compare=False)
 
 
 @dataclass
@@ -548,9 +553,12 @@ class SettingsStore:
 
     def set_channels_for_platform(self, platform: str, channels: Dict[str, ChannelSettings]) -> None:
         prefix = f"{platform}{SCOPED_KEY_SEP}"
-        self.settings.channels = {k: v for k, v in self.settings.channels.items() if not k.startswith(prefix)}
+        previous = self.settings.channels
+        self.settings.channels = {k: v for k, v in previous.items() if not k.startswith(prefix)}
         for channel_id, settings in channels.items():
-            self.settings.channels[self._channel_key(str(channel_id), platform)] = settings
+            key = self._channel_key(str(channel_id), platform)
+            self._carry_agent_binding_expectation(previous.get(key), settings)
+            self.settings.channels[key] = settings
 
     def get_threads_for_platform(self, platform: str) -> Dict[str, Dict[str, ChannelSettings]]:
         result: Dict[str, Dict[str, ChannelSettings]] = {}
@@ -593,7 +601,9 @@ class SettingsStore:
         settings: ChannelSettings,
         platform: Optional[str] = None,
     ) -> None:
-        self.settings.threads[self._thread_key(channel_id, thread_id, platform)] = settings
+        key = self._thread_key(channel_id, thread_id, platform)
+        self._carry_agent_binding_expectation(self.settings.threads.get(key), settings)
+        self.settings.threads[key] = settings
         self.save()
 
     def delete_thread(
@@ -653,9 +663,12 @@ class SettingsStore:
 
     def set_users_for_platform(self, platform: str, users: Dict[str, UserSettings]) -> None:
         prefix = f"{platform}{SCOPED_KEY_SEP}"
-        self.settings.users = {k: v for k, v in self.settings.users.items() if not k.startswith(prefix)}
+        previous = self.settings.users
+        self.settings.users = {k: v for k, v in previous.items() if not k.startswith(prefix)}
         for user_id, settings in users.items():
-            self.settings.users[self._user_key(str(user_id), platform)] = settings
+            key = self._user_key(str(user_id), platform)
+            self._carry_agent_binding_expectation(previous.get(key), settings)
+            self.settings.users[key] = settings
 
     def get_channel(self, channel_id: str, platform: Optional[str] = None) -> ChannelSettings:
         key = self._channel_key(channel_id, platform)
@@ -681,6 +694,7 @@ class SettingsStore:
 
     def update_channel(self, channel_id: str, settings: ChannelSettings, platform: Optional[str] = None) -> None:
         key = self._channel_key(channel_id, platform)
+        self._carry_agent_binding_expectation(self.settings.channels.get(key), settings)
         self.settings.channels[key] = settings
         self.save()
 
@@ -807,8 +821,20 @@ class SettingsStore:
             return True, is_admin
 
     def update_user(self, user_id: str, settings: UserSettings, platform: Optional[str] = None) -> None:
-        self.settings.users[self._user_key(user_id, platform)] = settings
+        key = self._user_key(user_id, platform)
+        self._carry_agent_binding_expectation(self.settings.users.get(key), settings)
+        self.settings.users[key] = settings
         self.save()
+
+    @staticmethod
+    def _carry_agent_binding_expectation(previous: object, current: object) -> None:
+        if previous is None:
+            setattr(current, "_agent_name_at_load", None)
+            return
+        expected = getattr(previous, "_agent_name_at_load", _UNSET_AGENT_BINDING)
+        if expected is _UNSET_AGENT_BINDING:
+            expected = getattr(getattr(previous, "routing", None), "agent_name", None)
+        setattr(current, "_agent_name_at_load", expected)
 
     def remove_user(self, user_id: str, platform: Optional[str] = None) -> bool:
         key = self._user_key(user_id, platform)

--- a/config/v2_settings.py
+++ b/config/v2_settings.py
@@ -527,7 +527,13 @@ class SettingsStore:
         self._file_mtime += 1
 
     def save(self) -> None:
-        self._service.save_state(self.settings)
+        try:
+            self._service.save_state(self.settings)
+        except Exception:
+            # API helpers mutate the singleton before saving. A refused transaction
+            # must restore the durable snapshot before any later read or save.
+            self._load()
+            raise
         self._service.has_external_write()
         self._file_mtime += 1
 

--- a/config/v2_settings.py
+++ b/config/v2_settings.py
@@ -220,8 +220,8 @@ class ChannelSettings:
     # Per-channel require_bind gate: None/False=off (any channel member), True=only
     # process messages from bound users; unbound senders are silently ignored.
     require_bind: Optional[bool] = None
-    # Internal optimistic-concurrency token. It is populated from SQLite and
-    # deliberately omitted from API payloads and persisted settings JSON.
+    # Internal optimistic-concurrency token. The API mirrors it as
+    # ``expected_agent_name`` while persisted settings JSON omits it.
     _agent_name_at_load: object = field(default=_UNSET_AGENT_BINDING, repr=False, compare=False)
 
 
@@ -834,6 +834,9 @@ class SettingsStore:
 
     @staticmethod
     def _carry_agent_binding_expectation(previous: object, current: object) -> None:
+        current_expected = getattr(current, "_agent_name_at_load", _UNSET_AGENT_BINDING)
+        if current_expected is not _UNSET_AGENT_BINDING:
+            return
         if previous is None:
             setattr(current, "_agent_name_at_load", None)
             return

--- a/core/controller.py
+++ b/core/controller.py
@@ -1261,12 +1261,15 @@ class Controller:
         4. AgentService.default_agent / first registered backend compatibility fallback
         """
         target = self._agent_run_target_payload(context)
+        payload = context.platform_specific or {}
+        target_agent_id = payload.get("vibe_agent_id") or (target.get("agent_id") if target else None)
         target_agent_name = target.get("agent_name") if target else None
         target_backend = target.get("agent_backend") if target else None
-        if target_agent_name:
+        if target_agent_id or target_agent_name:
             vibe_agent = self.resolve_vibe_agent_for_context(
                 context,
-                override_agent_name=str(target_agent_name),
+                override_agent_id=str(target_agent_id) if target_agent_id else None,
+                override_agent_name=str(target_agent_name) if target_agent_name else None,
                 required=False,
             )
             if vibe_agent:
@@ -1293,6 +1296,7 @@ class Controller:
         self,
         context: MessageContext,
         *,
+        override_agent_id: Optional[str] = None,
         override_agent_name: Optional[str] = None,
         required: bool = True,
     ) -> Optional[VibeAgent]:
@@ -1307,7 +1311,10 @@ class Controller:
         agent_name = override_agent_name or (target.get("agent_name") if target else None) or (
             routing.agent_name if routing else None
         )
+        agent_id = override_agent_id or (target.get("agent_id") if target else None)
         try:
+            if agent_id:
+                return self.vibe_agent_store.require_reference_by_id(str(agent_id))
             if agent_name:
                 return self.vibe_agent_store.require_reference(agent_name)
             default_agent = self.vibe_agent_store.get_default_agent()
@@ -1319,7 +1326,11 @@ class Controller:
         except Exception as exc:
             if required:
                 raise
-            logger.warning("Scope references Vibe Agent '%s' but it cannot be resolved: %s", agent_name or "default", exc)
+            logger.warning(
+                "Scope references Vibe Agent '%s' but it cannot be resolved: %s",
+                agent_id or agent_name or "default",
+                exc,
+            )
             return None
 
     @staticmethod

--- a/core/controller.py
+++ b/core/controller.py
@@ -1309,7 +1309,7 @@ class Controller:
         )
         try:
             if agent_name:
-                return self.vibe_agent_store.require_enabled(agent_name)
+                return self.vibe_agent_store.require_reference(agent_name)
             default_agent = self.vibe_agent_store.get_default_agent()
             if default_agent is not None:
                 return default_agent

--- a/core/handlers/message_handler.py
+++ b/core/handlers/message_handler.py
@@ -206,14 +206,23 @@ class MessageHandler(BaseHandler):
             requested_vibe_agent = platform_payload.get("vibe_agent_name")
             requested_vibe_agent_id = platform_payload.get("vibe_agent_id")
             session_target = platform_payload.get("agent_session_target")
+            durable_agent_identity = bool(requested_vibe_agent_id)
             if not requested_vibe_agent_id and isinstance(session_target, dict):
                 requested_vibe_agent_id = session_target.get("agent_id")
             if not requested_vibe_agent and isinstance(session_target, dict):
                 requested_vibe_agent = session_target.get("agent_name")
+            if isinstance(session_target, dict) and (
+                session_target.get("agent_id") or session_target.get("agent_name")
+            ):
+                durable_agent_identity = True
             if not requested_vibe_agent:
                 requested_vibe_agent = resolved_target.get("agent_name")
             if not requested_vibe_agent_id:
                 requested_vibe_agent_id = resolved_target.get("agent_id")
+            if resolved_target and (
+                resolved_target.get("agent_id") or resolved_target.get("agent_name")
+            ):
+                durable_agent_identity = True
             session_agent_backend = (
                 str(session_target["agent_backend"])
                 if isinstance(session_target, dict) and session_target.get("agent_backend")
@@ -245,7 +254,10 @@ class MessageHandler(BaseHandler):
                     except Exception:
                         logger.debug("find_session_for_anchor failed; falling back to routing", exc_info=True)
                 if existing_thread:
-                    requested_vibe_agent = existing_thread.get("agent_name") or requested_vibe_agent
+                    existing_agent_name = existing_thread.get("agent_name")
+                    requested_vibe_agent = existing_agent_name or requested_vibe_agent
+                    if existing_agent_name:
+                        durable_agent_identity = True
                     session_agent_backend = existing_thread.get("agent_backend") or session_agent_backend
                     # Scope is only placement. A persisted session's visibility is
                     # the single outward-delivery gate, including ordinary IM turns
@@ -259,7 +271,7 @@ class MessageHandler(BaseHandler):
             if (requested_vibe_agent_id or requested_vibe_agent) and callable(resolve_vibe_agent):
                 resolve_kwargs = {
                     "override_agent_name": requested_vibe_agent,
-                    "required": False,
+                    "required": durable_agent_identity,
                 }
                 if requested_vibe_agent_id:
                     resolve_kwargs["override_agent_id"] = requested_vibe_agent_id

--- a/core/handlers/message_handler.py
+++ b/core/handlers/message_handler.py
@@ -255,9 +255,11 @@ class MessageHandler(BaseHandler):
                     except Exception:
                         logger.debug("find_session_for_anchor failed; falling back to routing", exc_info=True)
                 if existing_thread:
+                    existing_agent_id = existing_thread.get("agent_id")
                     existing_agent_name = existing_thread.get("agent_name")
+                    requested_vibe_agent_id = existing_agent_id or requested_vibe_agent_id
                     requested_vibe_agent = existing_agent_name or requested_vibe_agent
-                    if existing_agent_name:
+                    if existing_agent_id or existing_agent_name:
                         durable_agent_identity = True
                     session_agent_backend = existing_thread.get("agent_backend") or session_agent_backend
                     # Scope is only placement. A persisted session's visibility is

--- a/core/handlers/message_handler.py
+++ b/core/handlers/message_handler.py
@@ -206,7 +206,8 @@ class MessageHandler(BaseHandler):
             requested_vibe_agent = platform_payload.get("vibe_agent_name")
             requested_vibe_agent_id = platform_payload.get("vibe_agent_id")
             session_target = platform_payload.get("agent_session_target")
-            durable_agent_identity = bool(requested_vibe_agent_id)
+            scope_agent_name = getattr(routing, "agent_name", None) if routing else None
+            durable_agent_identity = bool(requested_vibe_agent_id or scope_agent_name)
             if not requested_vibe_agent_id and isinstance(session_target, dict):
                 requested_vibe_agent_id = session_target.get("agent_id")
             if not requested_vibe_agent and isinstance(session_target, dict):
@@ -277,7 +278,7 @@ class MessageHandler(BaseHandler):
                     resolve_kwargs["override_agent_id"] = requested_vibe_agent_id
                 vibe_agent = resolve_vibe_agent(context, **resolve_kwargs)
             elif callable(resolve_vibe_agent) and not session_agent_backend:
-                vibe_agent = resolve_vibe_agent(context, required=False)
+                vibe_agent = resolve_vibe_agent(context, required=durable_agent_identity)
             if vibe_agent:
                 agent_name = vibe_agent.backend
             elif session_agent_backend:

--- a/core/handlers/message_handler.py
+++ b/core/handlers/message_handler.py
@@ -277,7 +277,9 @@ class MessageHandler(BaseHandler):
                 if requested_vibe_agent_id:
                     resolve_kwargs["override_agent_id"] = requested_vibe_agent_id
                 vibe_agent = resolve_vibe_agent(context, **resolve_kwargs)
-            elif callable(resolve_vibe_agent) and not session_agent_backend:
+            elif callable(resolve_vibe_agent) and (
+                durable_agent_identity or not session_agent_backend
+            ):
                 vibe_agent = resolve_vibe_agent(context, required=durable_agent_identity)
             if vibe_agent:
                 agent_name = vibe_agent.backend

--- a/core/handlers/message_handler.py
+++ b/core/handlers/message_handler.py
@@ -204,11 +204,16 @@ class MessageHandler(BaseHandler):
                 else self._get_settings_manager(context).get_channel_routing(settings_key)
             )
             requested_vibe_agent = platform_payload.get("vibe_agent_name")
+            requested_vibe_agent_id = platform_payload.get("vibe_agent_id")
             session_target = platform_payload.get("agent_session_target")
+            if not requested_vibe_agent_id and isinstance(session_target, dict):
+                requested_vibe_agent_id = session_target.get("agent_id")
             if not requested_vibe_agent and isinstance(session_target, dict):
                 requested_vibe_agent = session_target.get("agent_name")
             if not requested_vibe_agent:
                 requested_vibe_agent = resolved_target.get("agent_name")
+            if not requested_vibe_agent_id:
+                requested_vibe_agent_id = resolved_target.get("agent_id")
             session_agent_backend = (
                 str(session_target["agent_backend"])
                 if isinstance(session_target, dict) and session_target.get("agent_backend")
@@ -251,12 +256,14 @@ class MessageHandler(BaseHandler):
                     context.platform_specific = platform_payload
             resolve_vibe_agent = getattr(self.controller, "resolve_vibe_agent_for_context", None)
             vibe_agent = None
-            if requested_vibe_agent and callable(resolve_vibe_agent):
-                vibe_agent = resolve_vibe_agent(
-                    context,
-                    override_agent_name=requested_vibe_agent,
-                    required=False,
-                )
+            if (requested_vibe_agent_id or requested_vibe_agent) and callable(resolve_vibe_agent):
+                resolve_kwargs = {
+                    "override_agent_name": requested_vibe_agent,
+                    "required": False,
+                }
+                if requested_vibe_agent_id:
+                    resolve_kwargs["override_agent_id"] = requested_vibe_agent_id
+                vibe_agent = resolve_vibe_agent(context, **resolve_kwargs)
             elif callable(resolve_vibe_agent) and not session_agent_backend:
                 vibe_agent = resolve_vibe_agent(context, required=False)
             if vibe_agent:

--- a/core/scheduled_tasks.py
+++ b/core/scheduled_tasks.py
@@ -1170,7 +1170,13 @@ class ScheduledTaskStore:
             metadata=task.metadata,
         )
 
-    def _write_task(self, task: ScheduledTask, expect: DefinitionWriteExpectation) -> bool:
+    def _write_task(
+        self,
+        task: ScheduledTask,
+        expect: DefinitionWriteExpectation,
+        *,
+        expected_enabled_agent_id: Optional[str] = None,
+    ) -> bool:
         """Persist a whole task row; ``False`` means the guard refused the write.
 
         On refusal the in-memory mirror is reloaded, so the store never keeps serving
@@ -1186,7 +1192,11 @@ class ScheduledTaskStore:
             if self._sqlite is None:
                 self._save()
                 return True
-            landed = self._sqlite.upsert_scheduled_task(task.to_dict(), expect=expect)
+            landed = self._sqlite.upsert_scheduled_task(
+                task.to_dict(),
+                expect=expect,
+                expected_enabled_agent_id=expected_enabled_agent_id,
+            )
         except Exception:
             self._reload_after_lost_write(task.id)
             raise
@@ -1219,7 +1229,12 @@ class ScheduledTaskStore:
             self._signature = None
             self._reload_required = True
 
-    def upsert_task(self, task: ScheduledTask) -> ScheduledTask:
+    def upsert_task(
+        self,
+        task: ScheduledTask,
+        *,
+        expected_enabled_agent_id: Optional[str] = None,
+    ) -> ScheduledTask:
         """Create or adopt a whole task row (unguarded: the payload is not a re-read).
 
         The mirror rolls back with the write here too (HFR-275, the watch store's twin).
@@ -1235,7 +1250,10 @@ class ScheduledTaskStore:
             if self._sqlite is not None:
                 # No ``expect``: this is the create/adopt entry point (``add_task``),
                 # where the payload is not derived from a stored row.
-                self._sqlite.upsert_scheduled_task(task.to_dict())
+                self._sqlite.upsert_scheduled_task(
+                    task.to_dict(),
+                    expected_enabled_agent_id=expected_enabled_agent_id,
+                )
                 return task
             self._save()
         except Exception:
@@ -1260,6 +1278,7 @@ class ScheduledTaskStore:
         run_at: Optional[str] = None,
         timezone_name: str,
         metadata: Optional[dict[str, Any]] = None,
+        expected_enabled_agent_id: Optional[str] = None,
     ) -> ScheduledTask:
         task = ScheduledTask(
             id=uuid4().hex[:12],
@@ -1278,7 +1297,10 @@ class ScheduledTaskStore:
             timezone=timezone_name,
             metadata=dict(metadata or {}),
         )
-        return self.upsert_task(task)
+        return self.upsert_task(
+            task,
+            expected_enabled_agent_id=expected_enabled_agent_id,
+        )
 
     def remove_task(self, task_id: str) -> bool:
         """Delete a task; the mirror rolls back with the delete (HFR-275).
@@ -1333,6 +1355,7 @@ class ScheduledTaskStore:
         cwd: Optional[str] = None,
         update_cwd: bool = False,
         metadata: Optional[dict[str, Any]] = None,
+        expected_enabled_agent_id: Optional[str] = None,
     ) -> ScheduledTask:
         task = self._tasks[task_id]
         # Captured before the first mutation: this is the state the CALLER read
@@ -1358,7 +1381,11 @@ class ScheduledTaskStore:
         if metadata is not None:
             task.metadata = dict(metadata)
         task.updated_at = _utc_now_iso()
-        if not self._write_task(task, expect):
+        if not self._write_task(
+            task,
+            expect,
+            expected_enabled_agent_id=expected_enabled_agent_id,
+        ):
             # The edit did NOT land, and its payload would have restored the Session
             # binding, enabled state and reclaim snapshot the teardown just changed.
             # Raising is the contract: ``cmd_task_update`` prints an error and exits
@@ -1554,9 +1581,17 @@ class TaskExecutionStore:
         payload["updated_at"] = request.created_at
         return payload
 
-    def enqueue(self, request: TaskExecutionRequest) -> TaskExecutionRequest:
+    def enqueue(
+        self,
+        request: TaskExecutionRequest,
+        *,
+        expected_enabled_agent_id: Optional[str] = None,
+    ) -> TaskExecutionRequest:
         if self._sqlite is not None:
-            self._sqlite.enqueue_run(self.queued_run_payload(request))
+            self._sqlite.enqueue_run(
+                self.queued_run_payload(request),
+                expected_enabled_agent_id=expected_enabled_agent_id,
+            )
             return request
         self._ensure_dirs()
         path = self._request_path(request.id, state="pending")
@@ -1737,6 +1772,7 @@ class TaskExecutionStore:
         callback_active: bool = True,
         delivery_intent: str = AGENT_RUN_DELIVERY_QUEUE,
         metadata: Optional[dict[str, Any]] = None,
+        expected_enabled_agent_id: Optional[str] = None,
     ) -> TaskExecutionRequest:
         if not (message or "").strip():
             # Refuse at the door: a blank prompt never reaches an agent backend
@@ -1769,7 +1805,8 @@ class TaskExecutionStore:
                 reasoning_effort=reasoning_effort,
                 session_policy=session_policy,
                 metadata=run_metadata,
-            )
+            ),
+            expected_enabled_agent_id=expected_enabled_agent_id,
         )
 
     def list_pending(self) -> list[TaskExecutionRequest]:
@@ -2290,10 +2327,11 @@ class TaskExecutionStore:
 
         if self._sqlite is None:
             return request
-        payload = self._sqlite.get_run(request.id)
+        payload = self._sqlite.refresh_run_agent_reference(request.id)
         if payload is None:
             return request
         request.agent_name = payload.get("agent_name")
+        request.agent_id = payload.get("agent_id")
         return request
 
     def requeue(self, request_id: str, *, metadata: Optional[dict[str, Any]] = None) -> None:
@@ -4885,10 +4923,16 @@ class ScheduledTaskService:
                 task_id = task.id
                 session_key = task.session_key
                 session_id = task.session_id
+                task_agent_id = (
+                    request.agent_id
+                    if task.agent_name and task.agent_name == request.agent_name
+                    else None
+                )
                 result = await self._execute_task(
                     task,
                     execution_id=request.id,
                     disable_one_shot=request.source_kind == "scheduler",
+                    agent_id=task_agent_id,
                 )
                 error = result.error
                 session_key = result.session_key
@@ -4900,6 +4944,7 @@ class ScheduledTaskService:
                 if request.session_policy == "create_per_run":
                     session_id = self._reserve_runtime_session(
                         agent_name=request.agent_name,
+                        agent_id=request.agent_id,
                         deliver_key=request.deliver_key,
                         metadata=request.metadata,
                         workdir=request.metadata.get("session_workdir") if isinstance(request.metadata, dict) else None,
@@ -4917,6 +4962,7 @@ class ScheduledTaskService:
                     task_id=task_id,
                     trigger_kind=request.request_type if request.request_type != "hook_send" else "hook",
                     agent_name=request.agent_name,
+                    **({"agent_id": request.agent_id} if request.agent_id else {}),
                 )
             elif request.request_type == "agent_run":
                 message = _agent_run_message_for_request(request)
@@ -4936,6 +4982,7 @@ class ScheduledTaskService:
                     message=message,
                     execution_id=request.id,
                     agent_name=request.agent_name,
+                    **({"agent_id": request.agent_id} if request.agent_id else {}),
                     metadata={
                         **(request.metadata or {}),
                         "source_kind": request.source_kind,
@@ -5076,6 +5123,7 @@ class ScheduledTaskService:
         *,
         execution_id: str,
         disable_one_shot: bool,
+        agent_id: Optional[str] = None,
     ) -> TaskExecutionResult:
         error: Optional[str] = None
         failure_code: Optional[str] = None
@@ -5092,6 +5140,7 @@ class ScheduledTaskService:
             if task.session_policy == "create_per_run":
                 session_id = self._reserve_runtime_session(
                     agent_name=task.agent_name,
+                    agent_id=agent_id,
                     deliver_key=task.deliver_key,
                     metadata=task.metadata,
                     workdir=task.cwd,
@@ -5107,6 +5156,7 @@ class ScheduledTaskService:
                 task_id=task.id,
                 trigger_kind="scheduled",
                 agent_name=task.agent_name,
+                **({"agent_id": agent_id} if agent_id else {}),
             )
         except asyncio.CancelledError:
             self.reconcile_jobs()
@@ -5139,6 +5189,11 @@ class ScheduledTaskService:
                         task_id=task.id,
                         trigger_kind="scheduled",
                         agent_name=task.agent_name,
+                        **(
+                            {"agent_id": agent_id}
+                            if agent_id and task.agent_name
+                            else {}
+                        ),
                     )
                 except asyncio.CancelledError:
                     self.reconcile_jobs()
@@ -5204,6 +5259,7 @@ class ScheduledTaskService:
         execution_id: str,
         session_id: Optional[str] = None,
         agent_name: Optional[str] = None,
+        agent_id: Optional[str] = None,
         metadata: Optional[dict[str, Any]] = None,
     ) -> AgentRunExecutionResult:
         """Execute one direct Agent Run and wait for the real terminal result.
@@ -5238,6 +5294,7 @@ class ScheduledTaskService:
             trigger_kind="agent_run",
             session_id=session_id,
             agent_name=agent_name,
+            agent_id=agent_id,
             target_info=target_info,
             metadata=metadata,
         )
@@ -5952,6 +6009,7 @@ class ScheduledTaskService:
         self,
         *,
         agent_name: Optional[str] = None,
+        agent_id: Optional[str] = None,
         deliver_key: Optional[str],
         metadata: Optional[dict[str, Any]] = None,
         workdir: Optional[str] = None,
@@ -6009,9 +6067,18 @@ class ScheduledTaskService:
         ensure_sqlite_state(primary_platform=resolve_primary_platform_from_config(config_paths.get_state_dir()))
         agent_store = VibeAgentStore()
         try:
-            scope_target = self._resolve_scope_agent_target(scope_id) if scope_id and not agent_name else _ScopeAgentTarget(None)
+            scope_target = (
+                self._resolve_scope_agent_target(scope_id)
+                if scope_id and not agent_name and not agent_id
+                else _ScopeAgentTarget(None)
+            )
             resolved_agent_name = agent_name or scope_target.agent_name
-            agent = agent_store.require_reference(resolved_agent_name) if resolved_agent_name else agent_store.get_default_agent()
+            if agent_id:
+                agent = agent_store.require_reference_by_id(agent_id)
+            elif resolved_agent_name:
+                agent = agent_store.require_reference(resolved_agent_name)
+            else:
+                agent = agent_store.get_default_agent()
         finally:
             agent_store.close()
         if agent is None:
@@ -6417,6 +6484,7 @@ class ScheduledTaskService:
         trigger_kind: str,
         session_id: Optional[str] = None,
         agent_name: Optional[str] = None,
+        agent_id: Optional[str] = None,
     ) -> Optional[str]:
         target_info = resolve_session_id_target(session_id) if session_id else None
         target = target_info.session_key if target_info else parse_session_key(session_key or "")
@@ -6433,6 +6501,7 @@ class ScheduledTaskService:
             trigger_kind=trigger_kind,
             session_id=session_id,
             agent_name=agent_name,
+            agent_id=agent_id,
             target_info=target_info,
         )
         # A scheduled avibe turn drives the sidebar dot through the SAME two
@@ -6471,6 +6540,7 @@ class ScheduledTaskService:
         trigger_kind: str = "scheduled",
         session_id: Optional[str] = None,
         agent_name: Optional[str] = None,
+        agent_id: Optional[str] = None,
         target_info: Optional[ResolvedSessionIdTarget] = None,
         metadata: Optional[dict[str, Any]] = None,
     ) -> MessageContext:
@@ -6535,6 +6605,7 @@ class ScheduledTaskService:
                 # attribute the injected prompt to its precise definition.
                 "task_definition_id": task_id,
                 "vibe_agent_name": agent_name,
+                "vibe_agent_id": agent_id,
                 "source_kind": (metadata or {}).get("source_kind"),
                 "source_actor": (metadata or {}).get("source_actor"),
                 "parent_run_id": (metadata or {}).get("parent_run_id"),

--- a/core/scheduled_tasks.py
+++ b/core/scheduled_tasks.py
@@ -1690,6 +1690,7 @@ class TaskExecutionStore:
         source_actor: Optional[str] = None,
         parent_run_id: Optional[str] = None,
         metadata: Optional[dict[str, Any]] = None,
+        expected_enabled_agent_id: Optional[str] = None,
     ) -> TaskExecutionRequest:
         return self.enqueue(
             self.build_hook_send(
@@ -1706,7 +1707,8 @@ class TaskExecutionStore:
                 source_actor=source_actor,
                 parent_run_id=parent_run_id,
                 metadata=metadata,
-            )
+            ),
+            expected_enabled_agent_id=expected_enabled_agent_id,
         )
 
     def build_hook_send(

--- a/core/scheduled_tasks.py
+++ b/core/scheduled_tasks.py
@@ -863,6 +863,7 @@ class TaskExecutionRequest:
     deliver_key: Optional[str] = None
     prompt: Optional[str] = None
     message: Optional[str] = None
+    message_payload: Any = None
     source_kind: Optional[str] = None
     source_actor: Optional[str] = None
     parent_run_id: Optional[str] = None
@@ -892,6 +893,7 @@ class TaskExecutionRequest:
             deliver_key=payload.get("deliver_key"),
             prompt=payload.get("prompt"),
             message=payload.get("message") or payload.get("prompt"),
+            message_payload=payload.get("message_payload"),
             source_kind=payload.get("source_kind"),
             source_actor=payload.get("source_actor"),
             parent_run_id=payload.get("parent_run_id"),
@@ -1673,9 +1675,21 @@ class TaskExecutionStore:
         )
         if self._sqlite is None:
             return self.enqueue(request)
-        identity = self._sqlite.enqueue_definition_run(self.queued_run_payload(request))
-        request.agent_name = identity.get("agent_name")
-        request.agent_id = identity.get("agent_id")
+        snapshot = self._sqlite.enqueue_definition_run(self.queued_run_payload(request))
+        for field_name in (
+            "agent_name",
+            "agent_id",
+            "session_policy",
+            "session_id",
+            "session_key",
+            "post_to",
+            "deliver_key",
+            "prompt",
+            "message",
+            "message_payload",
+            "metadata",
+        ):
+            setattr(request, field_name, snapshot.get(field_name))
         return request
 
     def enqueue_hook_send(

--- a/core/scheduled_tasks.py
+++ b/core/scheduled_tasks.py
@@ -5999,7 +5999,7 @@ class ScheduledTaskService:
         try:
             scope_target = self._resolve_scope_agent_target(scope_id) if scope_id and not agent_name else _ScopeAgentTarget(None)
             resolved_agent_name = agent_name or scope_target.agent_name
-            agent = agent_store.require_enabled(resolved_agent_name) if resolved_agent_name else agent_store.get_default_agent()
+            agent = agent_store.require_reference(resolved_agent_name) if resolved_agent_name else agent_store.get_default_agent()
         finally:
             agent_store.close()
         if agent is None:

--- a/core/scheduled_tasks.py
+++ b/core/scheduled_tasks.py
@@ -2285,6 +2285,17 @@ class TaskExecutionStore:
         payload = json.loads(processing_path.read_text(encoding="utf-8"))
         return TaskExecutionRequest.from_dict(payload)
 
+    def refresh_claimed_request(self, request: TaskExecutionRequest) -> TaskExecutionRequest:
+        """Refresh the Agent name that a catalog rename may rewrite after claim."""
+
+        if self._sqlite is None:
+            return request
+        payload = self._sqlite.get_run(request.id)
+        if payload is None:
+            return request
+        request.agent_name = payload.get("agent_name")
+        return request
+
     def requeue(self, request_id: str, *, metadata: Optional[dict[str, Any]] = None) -> None:
         if self._sqlite is not None:
             if metadata is not None:
@@ -4851,6 +4862,7 @@ class ScheduledTaskService:
             logger.error("Claimed request %s crashed: %r", request_id, exc, exc_info=exc)
 
     async def _execute_claimed_request(self, request: TaskExecutionRequest) -> None:
+        request = self.request_store.refresh_claimed_request(request)
         error: Optional[str] = None
         #: The structured CLASS of this run's failure, when the failure has one. Kept
         #: beside ``error`` rather than parsed back out of it: the text is a sentence

--- a/core/scheduled_tasks.py
+++ b/core/scheduled_tasks.py
@@ -1178,6 +1178,7 @@ class ScheduledTaskStore:
         expect: DefinitionWriteExpectation,
         *,
         expected_enabled_agent_id: Optional[str] = None,
+        expected_reference_agent_id: Optional[str] = None,
     ) -> bool:
         """Persist a whole task row; ``False`` means the guard refused the write.
 
@@ -1198,6 +1199,7 @@ class ScheduledTaskStore:
                 task.to_dict(),
                 expect=expect,
                 expected_enabled_agent_id=expected_enabled_agent_id,
+                expected_reference_agent_id=expected_reference_agent_id,
             )
         except Exception:
             self._reload_after_lost_write(task.id)
@@ -1236,6 +1238,7 @@ class ScheduledTaskStore:
         task: ScheduledTask,
         *,
         expected_enabled_agent_id: Optional[str] = None,
+        expected_reference_agent_id: Optional[str] = None,
     ) -> ScheduledTask:
         """Create or adopt a whole task row (unguarded: the payload is not a re-read).
 
@@ -1255,7 +1258,11 @@ class ScheduledTaskStore:
                 self._sqlite.upsert_scheduled_task(
                     task.to_dict(),
                     expected_enabled_agent_id=expected_enabled_agent_id,
+                    expected_reference_agent_id=expected_reference_agent_id,
                 )
+                if expected_reference_agent_id is not None:
+                    self.load()
+                    return self._tasks[task.id]
                 return task
             self._save()
         except Exception:
@@ -1281,6 +1288,7 @@ class ScheduledTaskStore:
         timezone_name: str,
         metadata: Optional[dict[str, Any]] = None,
         expected_enabled_agent_id: Optional[str] = None,
+        expected_reference_agent_id: Optional[str] = None,
     ) -> ScheduledTask:
         task = ScheduledTask(
             id=uuid4().hex[:12],
@@ -1302,6 +1310,7 @@ class ScheduledTaskStore:
         return self.upsert_task(
             task,
             expected_enabled_agent_id=expected_enabled_agent_id,
+            expected_reference_agent_id=expected_reference_agent_id,
         )
 
     def remove_task(self, task_id: str) -> bool:
@@ -1358,6 +1367,7 @@ class ScheduledTaskStore:
         update_cwd: bool = False,
         metadata: Optional[dict[str, Any]] = None,
         expected_enabled_agent_id: Optional[str] = None,
+        expected_reference_agent_id: Optional[str] = None,
     ) -> ScheduledTask:
         task = self._tasks[task_id]
         # Captured before the first mutation: this is the state the CALLER read
@@ -1387,12 +1397,16 @@ class ScheduledTaskStore:
             task,
             expect,
             expected_enabled_agent_id=expected_enabled_agent_id,
+            expected_reference_agent_id=expected_reference_agent_id,
         ):
             # The edit did NOT land, and its payload would have restored the Session
             # binding, enabled state and reclaim snapshot the teardown just changed.
             # Raising is the contract: ``cmd_task_update`` prints an error and exits
             # non-zero instead of echoing a task the database never accepted.
             raise DefinitionWriteConflict(task_id, definition_type="scheduled task")
+        if expected_reference_agent_id is not None:
+            self.load()
+            return self._tasks[task_id]
         return task
 
     def record_binding_recovery(
@@ -1588,12 +1602,19 @@ class TaskExecutionStore:
         request: TaskExecutionRequest,
         *,
         expected_enabled_agent_id: Optional[str] = None,
+        expected_reference_agent_id: Optional[str] = None,
     ) -> TaskExecutionRequest:
         if self._sqlite is not None:
             self._sqlite.enqueue_run(
                 self.queued_run_payload(request),
                 expected_enabled_agent_id=expected_enabled_agent_id,
+                expected_reference_agent_id=expected_reference_agent_id,
             )
+            if expected_reference_agent_id is not None:
+                stored = self._sqlite.get_run(request.id)
+                if stored is not None:
+                    request.agent_id = stored.get("agent_id")
+                    request.agent_name = stored.get("agent_name")
             return request
         self._ensure_dirs()
         path = self._request_path(request.id, state="pending")
@@ -1709,6 +1730,8 @@ class TaskExecutionStore:
         parent_run_id: Optional[str] = None,
         metadata: Optional[dict[str, Any]] = None,
         expected_enabled_agent_id: Optional[str] = None,
+        expected_reference_agent_id: Optional[str] = None,
+        agent_id: Optional[str] = None,
     ) -> TaskExecutionRequest:
         return self.enqueue(
             self.build_hook_send(
@@ -1718,6 +1741,7 @@ class TaskExecutionStore:
                 post_to=post_to,
                 deliver_key=deliver_key,
                 agent_name=agent_name,
+                agent_id=agent_id,
                 session_policy=session_policy,
                 run_type=run_type,
                 definition_id=definition_id,
@@ -1727,6 +1751,7 @@ class TaskExecutionStore:
                 metadata=metadata,
             ),
             expected_enabled_agent_id=expected_enabled_agent_id,
+            expected_reference_agent_id=expected_reference_agent_id,
         )
 
     def build_hook_send(
@@ -1738,6 +1763,7 @@ class TaskExecutionStore:
         post_to: Optional[str] = None,
         deliver_key: Optional[str] = None,
         agent_name: Optional[str] = None,
+        agent_id: Optional[str] = None,
         session_policy: Optional[str] = None,
         run_type: str = "hook_send",
         definition_id: Optional[str] = None,
@@ -1767,6 +1793,7 @@ class TaskExecutionStore:
             source_actor=source_actor,
             parent_run_id=parent_run_id,
             agent_name=agent_name,
+            agent_id=agent_id,
             session_policy=session_policy,
             metadata=dict(metadata or {}),
         )

--- a/core/scheduled_tasks.py
+++ b/core/scheduled_tasks.py
@@ -1654,25 +1654,29 @@ class TaskExecutionStore:
         parent_run_id: Optional[str] = None,
         metadata: Optional[dict[str, Any]] = None,
     ) -> TaskExecutionRequest:
-        return self.enqueue(
-            TaskExecutionRequest(
-                id=uuid4().hex[:12],
-                request_type=run_type,
-                task_id=definition_id,
-                session_key=session_key,
-                session_id=session_id,
-                post_to=post_to,
-                deliver_key=deliver_key,
-                prompt=prompt,
-                message=prompt,
-                source_kind=source_kind,
-                source_actor=source_actor,
-                parent_run_id=parent_run_id,
-                agent_name=agent_name,
-                session_policy=session_policy,
-                metadata=dict(metadata or {}),
-            )
+        request = TaskExecutionRequest(
+            id=uuid4().hex[:12],
+            request_type=run_type,
+            task_id=definition_id,
+            session_key=session_key,
+            session_id=session_id,
+            post_to=post_to,
+            deliver_key=deliver_key,
+            prompt=prompt,
+            message=prompt,
+            source_kind=source_kind,
+            source_actor=source_actor,
+            parent_run_id=parent_run_id,
+            agent_name=agent_name,
+            session_policy=session_policy,
+            metadata=dict(metadata or {}),
         )
+        if self._sqlite is None:
+            return self.enqueue(request)
+        identity = self._sqlite.enqueue_definition_run(self.queued_run_payload(request))
+        request.agent_name = identity.get("agent_name")
+        request.agent_id = identity.get("agent_id")
+        return request
 
     def enqueue_hook_send(
         self,

--- a/core/services/agent_graph.py
+++ b/core/services/agent_graph.py
@@ -32,16 +32,17 @@ Scope is joined LEFT (``scope_id`` is nullable): a NULL scope renders as the
 
 from __future__ import annotations
 
+import json
 from datetime import datetime, timedelta, timezone
 from typing import Any, Iterable, Mapping, Optional, Sequence
 
-from sqlalchemy import select
+from sqlalchemy import and_, or_, select
 from sqlalchemy.engine import Engine
 
 from storage.agent_session_rows import session_openable_in_chat
 from storage.background import _status_query_values, normalize_run_status
 from storage.db import create_sqlite_engine
-from storage.models import agent_runs, agent_sessions, run_definitions, scope_settings, scopes
+from storage.models import agents, agent_runs, agent_sessions, run_definitions, scope_settings, scopes
 
 # History window → lookback seconds. ``24h`` is the default (contract §3).
 WINDOW_SECONDS: dict[str, int] = {
@@ -394,6 +395,9 @@ def _load_sessions(conn, candidate_ids: set[str]) -> list[dict[str, Any]]:
         scopes.c.scope_type.label("scope_scope_type"),
         scopes.c.native_type.label("scope_native_type"),
         scope_settings.c.enabled.label("scope_enabled"),
+        agents.c.name.label("catalog_agent_name"),
+        agents.c.archived_at.label("catalog_agent_archived_at"),
+        agents.c.metadata_json.label("catalog_agent_metadata_json"),
     ]
     stmt = (
         select(*cols)
@@ -401,10 +405,36 @@ def _load_sessions(conn, candidate_ids: set[str]) -> list[dict[str, Any]]:
             agent_sessions
             .outerjoin(scopes, agent_sessions.c.scope_id == scopes.c.id)
             .outerjoin(scope_settings, agent_sessions.c.scope_id == scope_settings.c.scope_id)
+            .outerjoin(
+                agents,
+                or_(
+                    agents.c.id == agent_sessions.c.agent_id,
+                    and_(
+                        agent_sessions.c.agent_id.is_(None),
+                        agents.c.name == agent_sessions.c.agent_name,
+                    ),
+                ),
+            )
         )
         .where(agent_sessions.c.id.in_(candidate_ids))
     )
     return [dict(row) for row in conn.execute(stmt).mappings()]
+
+
+def _session_agent_display_name(row: Mapping[str, Any]) -> Optional[str]:
+    internal_name = str(row.get("agent_name") or "").strip()
+    catalog_name = str(row.get("catalog_agent_name") or "").strip()
+    if row.get("catalog_agent_archived_at"):
+        try:
+            metadata = json.loads(row.get("catalog_agent_metadata_json") or "{}")
+        except (TypeError, ValueError):
+            metadata = {}
+        archive = metadata.get("_avibe_archive") if isinstance(metadata, dict) else None
+        if isinstance(archive, dict):
+            original_name = str(archive.get("original_name") or "").strip()
+            if original_name:
+                return original_name
+    return catalog_name or internal_name or None
 
 
 def _load_runs(conn, candidate_ids: set[str]) -> dict[str, list[dict[str, Any]]]:
@@ -630,6 +660,7 @@ def _build_nodes(
             "session_id": session_id,
             "title": row.get("title"),
             "agent_name": row.get("agent_name"),
+            "agent_display_name": _session_agent_display_name(row),
             "agent_backend": row.get("agent_backend"),
             "model": row.get("model"),
             "reasoning_effort": row.get("reasoning_effort"),

--- a/core/services/session_fork.py
+++ b/core/services/session_fork.py
@@ -152,7 +152,7 @@ def reserve_forked_session(
     from sqlalchemy import select
 
     from core.vibe_agents import VibeAgentStore
-    from storage.agent_session_rows import create_agent_session_row, utc_now_iso
+    from storage.agent_session_rows import create_agent_session_row, reserve_write_lock, utc_now_iso
     from storage.db import create_sqlite_engine
     from storage.importer import ensure_sqlite_state, resolve_primary_platform_from_config
     from storage.models import agent_sessions
@@ -165,6 +165,7 @@ def reserve_forked_session(
     agent_store = VibeAgentStore(path)
     try:
         with engine.begin() as conn:
+            reserve_write_lock(conn)
             row = conn.execute(
                 select(agent_sessions).where(agent_sessions.c.id == str(source_session_id)).limit(1)
             ).mappings().first()

--- a/core/services/session_fork.py
+++ b/core/services/session_fork.py
@@ -49,9 +49,23 @@ _FORK_ANCHOR_TYPES = tuple(
     )
 )
 
+SESSION_AGENT_UNAVAILABLE_CODE = "session_agent_unavailable"
+SESSION_AGENT_UNAVAILABLE_I18N_KEY = "error.sessionFork.agentUnavailable"
+
 
 class SessionForkError(ValueError):
     """Raised when a Session cannot be forked."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        code: str = "session_fork_failed",
+        details: Optional[dict[str, Any]] = None,
+    ) -> None:
+        super().__init__(message)
+        self.code = code
+        self.details = details or {}
 
 
 @dataclass(frozen=True)
@@ -224,7 +238,9 @@ def reserve_forked_session(
                     )
                 except LookupError as exc:
                     raise SessionForkError(
-                        "source session Agent is unavailable; choose an enabled Agent override"
+                        "source session Agent is unavailable; choose an enabled Agent override",
+                        code=SESSION_AGENT_UNAVAILABLE_CODE,
+                        details={"source_session_id": source_session_id},
                     ) from exc
                 if inherited_agent["backend"] != source_backend:
                     raise SessionForkError(

--- a/core/services/session_fork.py
+++ b/core/services/session_fork.py
@@ -157,6 +157,7 @@ def reserve_forked_session(
     from storage.importer import ensure_sqlite_state, resolve_primary_platform_from_config
     from storage.models import agent_sessions
     from storage.session_reclaim import reconcile_explicit_overrides
+    from storage.workbench_sessions_service import require_enabled_agent_identity
 
     path = db_path or paths.get_sqlite_state_path()
     if db_path is None:
@@ -213,9 +214,35 @@ def reserve_forked_session(
                     "agent backend does not match the source session backend"
                 )
 
-            target_agent_id = override_agent.id if override_agent else row["agent_id"]
-            target_agent_name = override_agent.name if override_agent else row["agent_name"]
-            target_backend = override_agent.backend if override_agent else source_backend
+            inherited_agent = None
+            if override_agent is None and (row["agent_id"] or row["agent_name"]):
+                try:
+                    inherited_agent = require_enabled_agent_identity(
+                        conn,
+                        agent_id=row["agent_id"],
+                        agent_name=row["agent_name"],
+                    )
+                except LookupError as exc:
+                    raise SessionForkError(
+                        "source session Agent is unavailable; choose an enabled Agent override"
+                    ) from exc
+                if inherited_agent["backend"] != source_backend:
+                    raise SessionForkError(
+                        "source session Agent backend does not match the session backend"
+                    )
+
+            if override_agent is not None:
+                target_agent_id = override_agent.id
+                target_agent_name = override_agent.name
+                target_backend = override_agent.backend
+            elif inherited_agent is not None:
+                target_agent_id = inherited_agent["id"]
+                target_agent_name = inherited_agent["name"]
+                target_backend = inherited_agent["backend"]
+            else:
+                target_agent_id = None
+                target_agent_name = None
+                target_backend = source_backend
             target_variant = target_backend if override_agent else str(row["agent_variant"] or target_backend)
             now = utc_now_iso()
             target_model = _clean_optional(model) if model is not None else row["model"]

--- a/core/services/sessions.py
+++ b/core/services/sessions.py
@@ -52,6 +52,7 @@ from storage.workbench_sessions_service import (
     list_sessions_page,
     reset_running_agent_status,
     require_enabled_agent_backend,
+    require_enabled_agent_identity,
     set_agent_status,
     touch_session,
     update_session,

--- a/core/services/sessions.py
+++ b/core/services/sessions.py
@@ -51,6 +51,7 @@ from storage.workbench_sessions_service import (
     list_sessions,
     list_sessions_page,
     reset_running_agent_status,
+    require_enabled_agent_backend,
     set_agent_status,
     touch_session,
     update_session,

--- a/core/services/sessions.py
+++ b/core/services/sessions.py
@@ -167,6 +167,7 @@ def reserve_agent_session(
     metadata: Optional[dict] = None,
     db_path: Optional[Path] = None,
     require_enabled_agent: bool = False,
+    expected_reference_agent_id: Optional[str] = None,
 ) -> Optional[str]:
     """Reserve a new ``agent_sessions`` row keyed by an IM-style scope.
 
@@ -189,6 +190,7 @@ def reserve_agent_session(
             visibility=visibility,
             metadata=metadata,
             require_enabled_agent=require_enabled_agent,
+            expected_reference_agent_id=expected_reference_agent_id,
         )
     finally:
         service.close()
@@ -207,6 +209,7 @@ def reserve_standalone_agent_session(
     metadata: Optional[dict] = None,
     db_path: Optional[Path] = None,
     require_enabled_agent: bool = False,
+    expected_reference_agent_id: Optional[str] = None,
 ) -> Optional[str]:
     """Reserve a background-capable session with no Scope."""
 
@@ -223,6 +226,7 @@ def reserve_standalone_agent_session(
             visibility=visibility,
             metadata=metadata,
             require_enabled_agent=require_enabled_agent,
+            expected_reference_agent_id=expected_reference_agent_id,
         )
     finally:
         service.close()

--- a/core/services/sessions.py
+++ b/core/services/sessions.py
@@ -165,6 +165,7 @@ def reserve_agent_session(
     visibility: str = "foreground",
     metadata: Optional[dict] = None,
     db_path: Optional[Path] = None,
+    require_enabled_agent: bool = False,
 ) -> Optional[str]:
     """Reserve a new ``agent_sessions`` row keyed by an IM-style scope.
 
@@ -186,6 +187,7 @@ def reserve_agent_session(
             workdir=workdir,
             visibility=visibility,
             metadata=metadata,
+            require_enabled_agent=require_enabled_agent,
         )
     finally:
         service.close()
@@ -203,6 +205,7 @@ def reserve_standalone_agent_session(
     visibility: str = "background",
     metadata: Optional[dict] = None,
     db_path: Optional[Path] = None,
+    require_enabled_agent: bool = False,
 ) -> Optional[str]:
     """Reserve a background-capable session with no Scope."""
 
@@ -218,6 +221,7 @@ def reserve_standalone_agent_session(
             workdir=workdir,
             visibility=visibility,
             metadata=metadata,
+            require_enabled_agent=require_enabled_agent,
         )
     finally:
         service.close()

--- a/core/vibe_agents.py
+++ b/core/vibe_agents.py
@@ -99,6 +99,15 @@ class AgentArchivedEditError(ValueError):
         self.agent_name = str(agent_name)
 
 
+class AgentReferenceRewriteError(ValueError):
+    """A durable Agent reference cannot be rewritten without losing data."""
+
+    code = "agent_reference_metadata_invalid"
+
+    def __init__(self) -> None:
+        super().__init__(self.code)
+
+
 class AgentNameValidationError(ValueError):
     """A public Agent name violates a catalog namespace rule."""
 
@@ -128,6 +137,19 @@ def _matches_agent_reference(value: Any, reference_names: frozenset[str]) -> boo
         return normalize_agent_name(value) in reference_names
     except ValueError:
         return False
+
+
+def _owns_agent_reference(
+    reference_id: Any,
+    reference_name: Any,
+    *,
+    agent_id: str,
+    reference_names: frozenset[str],
+) -> bool:
+    stable_id = str(reference_id or "").strip()
+    if stable_id:
+        return stable_id == agent_id
+    return _matches_agent_reference(reference_name, reference_names)
 
 
 def _validated_public_agent_name(name: str) -> tuple[str, str]:
@@ -201,15 +223,11 @@ def _rewrite_definition_agent_name(
         payload = json.loads("{}" if raw is None else raw)
     except (TypeError, ValueError) as exc:
         if direct_binding_changed:
-            raise ValueError(
-                "cannot rewrite Agent reference because definition metadata is malformed"
-            ) from exc
+            raise AgentReferenceRewriteError() from exc
         return raw or "{}", False
     if not isinstance(payload, dict):
         if direct_binding_changed:
-            raise ValueError(
-                "cannot rewrite Agent reference because definition metadata is not an object"
-            )
+            raise AgentReferenceRewriteError()
         return raw or "{}", False
     changed = direct_binding_changed
     snapshot = payload.get("session_settings_snapshot")
@@ -228,6 +246,8 @@ def _rewrite_queued_agent_provenance(
     raw: str | None,
     reference_names: frozenset[str],
     new_name: str,
+    *,
+    agent_id: str,
 ) -> tuple[str, bool]:
     """Move routing names captured on a queued Workbench harness message."""
 
@@ -246,12 +266,20 @@ def _rewrite_queued_agent_provenance(
 
     changed = False
     for key in ("vibe_agent_name", "scheduled_target_agent_name"):
-        if _matches_agent_reference(spec.get(key), reference_names):
+        if _owns_agent_reference(
+            spec.get("vibe_agent_id"),
+            spec.get(key),
+            agent_id=agent_id,
+            reference_names=reference_names,
+        ):
             spec[key] = new_name
             changed = True
     target = spec.get("agent_session_target")
-    if isinstance(target, dict) and _matches_agent_reference(
-        target.get("agent_name"), reference_names
+    if isinstance(target, dict) and _owns_agent_reference(
+        target.get("agent_id"),
+        target.get("agent_name"),
+        agent_id=agent_id,
+        reference_names=reference_names,
     ):
         target["agent_name"] = new_name
         changed = True
@@ -575,6 +603,7 @@ class VibeAgentStore:
                 )
                 self._rewrite_references(
                     conn,
+                    agent_id=agent.id,
                     reference_names=frozenset((agent.name, agent.normalized_name)),
                     new_name=raw_new_name,
                     revision=now,
@@ -638,7 +667,7 @@ class VibeAgentStore:
             )
 
             reference_names = frozenset((agent.name, agent.normalized_name))
-            references = self._reference_counts(conn, reference_names)
+            references = self._reference_counts(conn, reference_names, agent_id=agent.id)
             archive_metadata = {
                 "original_name": agent.name,
                 "archived_at": now,
@@ -659,6 +688,7 @@ class VibeAgentStore:
             )
             self._rewrite_references(
                 conn,
+                agent_id=agent.id,
                 reference_names=reference_names,
                 new_name=archived_name,
                 revision=now,
@@ -733,7 +763,7 @@ class VibeAgentStore:
             normalized_name=normalize_agent_name(original_name),
         )
         reference_names = frozenset((agent.name, agent.normalized_name))
-        references = self._reference_counts(conn, reference_names)
+        references = self._reference_counts(conn, reference_names, agent_id=agent.id)
         conn.execute(
             agents.update()
             .where(agents.c.id == agent.id)
@@ -745,6 +775,7 @@ class VibeAgentStore:
         )
         self._rewrite_references(
             conn,
+            agent_id=agent.id,
             reference_names=reference_names,
             new_name=archived_name,
             revision=now,
@@ -784,17 +815,23 @@ class VibeAgentStore:
             return self._reference_counts(
                 conn,
                 frozenset((agent.name, agent.normalized_name)),
+                agent_id=agent.id,
             )
 
     @staticmethod
-    def _reference_counts(conn: Any, reference_names: frozenset[str]) -> dict[str, int]:
+    def _reference_counts(
+        conn: Any,
+        reference_names: frozenset[str],
+        *,
+        agent_id: str,
+    ) -> dict[str, int]:
         reference_names = _normalized_agent_reference_names(reference_names)
         scope_names = conn.execute(
             select(scope_settings.c.agent_name).where(scope_settings.c.agent_name.is_not(None))
         ).scalars()
-        session_names = conn.execute(
-            select(agent_sessions.c.agent_name).where(agent_sessions.c.agent_name.is_not(None))
-        ).scalars()
+        session_rows = conn.execute(
+            select(agent_sessions.c.agent_id, agent_sessions.c.agent_name)
+        ).mappings()
         definition_names = conn.execute(
             select(run_definitions.c.agent_name)
             .where(run_definitions.c.agent_name.is_not(None))
@@ -803,7 +840,13 @@ class VibeAgentStore:
         return {
             "scopes": sum(_matches_agent_reference(name, reference_names) for name in scope_names),
             "sessions": sum(
-                _matches_agent_reference(name, reference_names) for name in session_names
+                _owns_agent_reference(
+                    row["agent_id"],
+                    row["agent_name"],
+                    agent_id=agent_id,
+                    reference_names=reference_names,
+                )
+                for row in session_rows
             ),
             "definitions": sum(
                 _matches_agent_reference(name, reference_names) for name in definition_names
@@ -814,6 +857,7 @@ class VibeAgentStore:
     def _rewrite_references(
         conn: Any,
         *,
+        agent_id: str,
         reference_names: frozenset[str],
         new_name: str,
         revision: str,
@@ -822,11 +866,14 @@ class VibeAgentStore:
         session_ids = [
             row["id"]
             for row in conn.execute(
-                select(agent_sessions.c.id, agent_sessions.c.agent_name).where(
-                    agent_sessions.c.agent_name.is_not(None)
-                )
+                select(agent_sessions.c.id, agent_sessions.c.agent_id, agent_sessions.c.agent_name)
             ).mappings()
-            if _matches_agent_reference(row["agent_name"], reference_names)
+            if _owns_agent_reference(
+                row["agent_id"],
+                row["agent_name"],
+                agent_id=agent_id,
+                reference_names=reference_names,
+            )
         ]
         if session_ids:
             conn.execute(
@@ -838,11 +885,15 @@ class VibeAgentStore:
         run_ids = [
             row["id"]
             for row in conn.execute(
-                select(agent_runs.c.id, agent_runs.c.agent_name)
-                .where(agent_runs.c.agent_name.is_not(None))
+                select(agent_runs.c.id, agent_runs.c.agent_id, agent_runs.c.agent_name)
                 .where(agent_runs.c.status.in_(("pending", "queued", "processing", "running")))
             ).mappings()
-            if _matches_agent_reference(row["agent_name"], reference_names)
+            if _owns_agent_reference(
+                row["agent_id"],
+                row["agent_name"],
+                agent_id=agent_id,
+                reference_names=reference_names,
+            )
         ]
         if run_ids:
             conn.execute(
@@ -856,7 +907,10 @@ class VibeAgentStore:
         ).mappings().all()
         for row in queued_rows:
             metadata, changed = _rewrite_queued_agent_provenance(
-                row["metadata_json"], reference_names, new_name
+                row["metadata_json"],
+                reference_names,
+                new_name,
+                agent_id=agent_id,
             )
             if changed:
                 conn.execute(

--- a/core/vibe_agents.py
+++ b/core/vibe_agents.py
@@ -89,6 +89,16 @@ class AgentArchiveError(ValueError):
         self.agent_name = str(agent_name)
 
 
+class AgentArchivedEditError(ValueError):
+    """An archived Agent is read-only on public mutation surfaces."""
+
+    code = "agent_archived_read_only"
+
+    def __init__(self, *, agent_name: str) -> None:
+        super().__init__(self.code)
+        self.agent_name = str(agent_name)
+
+
 class AgentNameValidationError(ValueError):
     """A public Agent name violates a catalog namespace rule."""
 
@@ -496,7 +506,7 @@ class VibeAgentStore:
                 )
             existing = self._from_row(row)
             if existing.archived_at is not None:
-                raise ValueError(f"agent '{name}' is archived and cannot be edited")
+                raise AgentArchivedEditError(agent_name=name)
 
             values: dict[str, Any] = {"updated_at": _utc_now_iso()}
             if description is not _UNSET:
@@ -518,7 +528,7 @@ class VibeAgentStore:
                 .values(**values)
             )
             if result.rowcount != 1:
-                raise ValueError(f"agent '{name}' is archived and cannot be edited")
+                raise AgentArchivedEditError(agent_name=name)
             updated = conn.execute(
                 select(agents).where(agents.c.id == existing.id).limit(1)
             ).mappings().one()
@@ -543,7 +553,7 @@ class VibeAgentStore:
                     )
                 agent = self._from_row(row)
                 if agent.archived_at is not None:
-                    raise ValueError(f"agent '{name}' is archived and cannot be renamed")
+                    raise AgentArchivedEditError(agent_name=name)
                 if is_builtin_default_agent(agent):
                     raise ValueError(f"agent '{agent.name}' is built in and cannot be renamed")
                 if new_normalized == agent.normalized_name:
@@ -876,6 +886,7 @@ class VibeAgentStore:
 
         definition_rows = conn.execute(
             select(run_definitions.c.id, run_definitions.c.agent_name, run_definitions.c.metadata_json)
+            .where(run_definitions.c.deleted_at.is_(None))
         ).mappings().all()
         for row in definition_rows:
             values = {}

--- a/core/vibe_agents.py
+++ b/core/vibe_agents.py
@@ -591,6 +591,10 @@ class VibeAgentStore:
 
             default_name = self._default_agent_name(conn)
             effective_default = self._effective_default_agent(conn)
+            explicit_default_matches = (
+                default_name is not None
+                and normalize_agent_name(default_name) == agent.normalized_name
+            )
             replacement = None
             if effective_default is not None and effective_default.id == agent.id:
                 replacement = self._archive_default_replacement(conn, agent)
@@ -599,6 +603,8 @@ class VibeAgentStore:
                         "the default Agent cannot be archived without another enabled Agent",
                         code="agent_no_default_replacement",
                     )
+            elif explicit_default_matches:
+                replacement = effective_default
 
             archived_name, archived_normalized = self._available_archive_name(
                 conn,
@@ -633,6 +639,12 @@ class VibeAgentStore:
             )
             if replacement is not None:
                 self._write_default_agent_name(conn, replacement.name, now=now)
+                remaining_default_name = replacement.name
+            elif explicit_default_matches:
+                conn.execute(state_meta.delete().where(state_meta.c.key == DEFAULT_AGENT_META_KEY))
+                remaining_default_name = None
+            else:
+                remaining_default_name = default_name
 
             archived_agent = VibeAgent(
                 **{
@@ -650,7 +662,7 @@ class VibeAgentStore:
                 original_name=agent.name,
                 archived_name=archived_name,
                 references=references,
-                default_agent_name=replacement.name if replacement is not None else default_name,
+                default_agent_name=remaining_default_name,
             )
 
     @staticmethod

--- a/core/vibe_agents.py
+++ b/core/vibe_agents.py
@@ -91,6 +91,15 @@ def normalize_agent_name(name: str) -> str:
     return normalized
 
 
+def _validated_public_agent_name(name: str) -> tuple[str, str]:
+    raw_name = str(name or "").strip()
+    if raw_name.startswith("_"):
+        raise ValueError("agent names starting with '_' are reserved for Avibe")
+    if "/" in raw_name or "\\" in raw_name:
+        raise ValueError("agent names cannot contain path separators")
+    return raw_name, normalize_agent_name(raw_name)
+
+
 def validate_agent_backend(backend: str) -> str:
     value = str(backend or "").strip().lower()
     if value not in SUPPORTED_AGENT_BACKENDS:
@@ -327,10 +336,7 @@ class VibeAgentStore:
         metadata: Optional[dict[str, Any]] = None,
         enabled: bool = True,
     ) -> VibeAgent:
-        raw_name = str(name or "").strip()
-        if raw_name.startswith("_"):
-            raise ValueError("agent names starting with '_' are reserved for Avibe")
-        normalized = normalize_agent_name(name)
+        raw_name, normalized = _validated_public_agent_name(name)
         normalized_backend = validate_agent_backend(backend)
         now = _utc_now_iso()
         agent = VibeAgent(
@@ -411,10 +417,7 @@ class VibeAgentStore:
         return self.update(name, enabled=enabled)
 
     def rename(self, name: str, new_name: str) -> VibeAgent:
-        raw_new_name = str(new_name or "").strip()
-        if raw_new_name.startswith("_"):
-            raise ValueError("agent names starting with '_' are reserved for Avibe")
-        new_normalized = normalize_agent_name(raw_new_name)
+        raw_new_name, new_normalized = _validated_public_agent_name(new_name)
         old_normalized = normalize_agent_name(name)
         now = _utc_now_iso()
         try:

--- a/core/vibe_agents.py
+++ b/core/vibe_agents.py
@@ -99,6 +99,17 @@ def normalize_agent_name(name: str) -> str:
     return normalized
 
 
+def _normalized_agent_reference_names(reference_names: Iterable[str]) -> frozenset[str]:
+    return frozenset(normalize_agent_name(name) for name in reference_names)
+
+
+def _matches_agent_reference(value: Any, reference_names: frozenset[str]) -> bool:
+    try:
+        return normalize_agent_name(value) in reference_names
+    except ValueError:
+        return False
+
+
 def _validated_public_agent_name(name: str) -> tuple[str, str]:
     raw_name = str(name or "").strip()
     if raw_name.startswith("_"):
@@ -146,7 +157,7 @@ def _rewrite_scope_agent_name(
         return raw or "{}", False
     changed = False
     for key in ("agent_name", "agent"):
-        if routing.get(key) in reference_names:
+        if _matches_agent_reference(routing.get(key), reference_names):
             routing[key] = new_name
             changed = True
     return (_json_dumps(payload), True) if changed else (raw or "{}", False)
@@ -176,7 +187,9 @@ def _rewrite_definition_agent_name(
         return raw or "{}", False
     changed = direct_binding_changed
     snapshot = payload.get("session_settings_snapshot")
-    if isinstance(snapshot, dict) and snapshot.get("agent_name") in reference_names:
+    if isinstance(snapshot, dict) and _matches_agent_reference(
+        snapshot.get("agent_name"), reference_names
+    ):
         snapshot["agent_name"] = new_name
         changed = True
     if not changed:
@@ -207,11 +220,13 @@ def _rewrite_queued_agent_provenance(
 
     changed = False
     for key in ("vibe_agent_name", "scheduled_target_agent_name"):
-        if spec.get(key) in reference_names:
+        if _matches_agent_reference(spec.get(key), reference_names):
             spec[key] = new_name
             changed = True
     target = spec.get("agent_session_target")
-    if isinstance(target, dict) and target.get("agent_name") in reference_names:
+    if isinstance(target, dict) and _matches_agent_reference(
+        target.get("agent_name"), reference_names
+    ):
         target["agent_name"] = new_name
         changed = True
     return (_json_dumps(payload), True) if changed else (raw or "{}", False)
@@ -734,28 +749,25 @@ class VibeAgentStore:
 
     @staticmethod
     def _reference_counts(conn: Any, reference_names: frozenset[str]) -> dict[str, int]:
+        reference_names = _normalized_agent_reference_names(reference_names)
+        scope_names = conn.execute(
+            select(scope_settings.c.agent_name).where(scope_settings.c.agent_name.is_not(None))
+        ).scalars()
+        session_names = conn.execute(
+            select(agent_sessions.c.agent_name).where(agent_sessions.c.agent_name.is_not(None))
+        ).scalars()
+        definition_names = conn.execute(
+            select(run_definitions.c.agent_name)
+            .where(run_definitions.c.agent_name.is_not(None))
+            .where(run_definitions.c.deleted_at.is_(None))
+        ).scalars()
         return {
-            "scopes": int(
-                conn.execute(
-                    select(func.count())
-                    .select_from(scope_settings)
-                    .where(scope_settings.c.agent_name.in_(reference_names))
-                ).scalar_one()
+            "scopes": sum(_matches_agent_reference(name, reference_names) for name in scope_names),
+            "sessions": sum(
+                _matches_agent_reference(name, reference_names) for name in session_names
             ),
-            "sessions": int(
-                conn.execute(
-                    select(func.count())
-                    .select_from(agent_sessions)
-                    .where(agent_sessions.c.agent_name.in_(reference_names))
-                ).scalar_one()
-            ),
-            "definitions": int(
-                conn.execute(
-                    select(func.count())
-                    .select_from(run_definitions)
-                    .where(run_definitions.c.agent_name.in_(reference_names))
-                    .where(run_definitions.c.deleted_at.is_(None))
-                ).scalar_one()
+            "definitions": sum(
+                _matches_agent_reference(name, reference_names) for name in definition_names
             ),
         }
 
@@ -767,17 +779,38 @@ class VibeAgentStore:
         new_name: str,
         revision: str,
     ) -> None:
-        conn.execute(
-            agent_sessions.update()
-            .where(agent_sessions.c.agent_name.in_(reference_names))
-            .values(agent_name=new_name)
-        )
-        conn.execute(
-            agent_runs.update()
-            .where(agent_runs.c.agent_name.in_(reference_names))
-            .where(agent_runs.c.status.in_(("pending", "queued", "processing", "running")))
-            .values(agent_name=new_name)
-        )
+        reference_names = _normalized_agent_reference_names(reference_names)
+        session_ids = [
+            row["id"]
+            for row in conn.execute(
+                select(agent_sessions.c.id, agent_sessions.c.agent_name).where(
+                    agent_sessions.c.agent_name.is_not(None)
+                )
+            ).mappings()
+            if _matches_agent_reference(row["agent_name"], reference_names)
+        ]
+        if session_ids:
+            conn.execute(
+                agent_sessions.update()
+                .where(agent_sessions.c.id.in_(session_ids))
+                .values(agent_name=new_name)
+            )
+
+        run_ids = [
+            row["id"]
+            for row in conn.execute(
+                select(agent_runs.c.id, agent_runs.c.agent_name)
+                .where(agent_runs.c.agent_name.is_not(None))
+                .where(agent_runs.c.status.in_(("pending", "queued", "processing", "running")))
+            ).mappings()
+            if _matches_agent_reference(row["agent_name"], reference_names)
+        ]
+        if run_ids:
+            conn.execute(
+                agent_runs.update()
+                .where(agent_runs.c.id.in_(run_ids))
+                .values(agent_name=new_name)
+            )
 
         queued_rows = conn.execute(
             select(messages.c.id, messages.c.metadata_json).where(messages.c.type == "queued")
@@ -798,7 +831,7 @@ class VibeAgentStore:
         ).mappings().all()
         for row in scope_rows:
             values: dict[str, Any] = {}
-            if row["agent_name"] in reference_names:
+            if _matches_agent_reference(row["agent_name"], reference_names):
                 values["agent_name"] = new_name
             settings, changed = _rewrite_scope_agent_name(
                 row["settings_json"], reference_names, new_name
@@ -817,7 +850,7 @@ class VibeAgentStore:
         ).mappings().all()
         for row in definition_rows:
             values = {}
-            direct_binding_changed = row["agent_name"] in reference_names
+            direct_binding_changed = _matches_agent_reference(row["agent_name"], reference_names)
             if direct_binding_changed:
                 values["agent_name"] = new_name
             metadata, changed = _rewrite_definition_agent_name(

--- a/core/vibe_agents.py
+++ b/core/vibe_agents.py
@@ -16,6 +16,7 @@ from sqlalchemy import func, or_, select
 from sqlalchemy.exc import IntegrityError
 
 from config import paths
+from storage.agent_session_rows import reserve_write_lock
 from storage.db import SqliteInvalidationProbe, create_sqlite_engine
 from storage.importer import ensure_sqlite_state, resolve_primary_platform_from_config
 from storage.migrations import guard_source_checkout_default_state_migration, run_migrations
@@ -366,25 +367,45 @@ class VibeAgentStore:
         metadata: Any = _UNSET,
         enabled: Any = _UNSET,
     ) -> VibeAgent:
-        existing = self.require(name)
-        if existing.archived_at is not None:
-            raise ValueError(f"agent '{name}' is archived and cannot be edited")
-        values: dict[str, Any] = {"updated_at": _utc_now_iso()}
-        if description is not _UNSET:
-            values["description"] = _clean_optional(description)
-        if model is not _UNSET:
-            values["model"] = _clean_optional(model) or recommended_agent_model(existing.backend)
-        if reasoning_effort is not _UNSET:
-            values["reasoning_effort"] = _clean_optional(reasoning_effort)
-        if system_prompt is not _UNSET:
-            values["system_prompt"] = _clean_optional(system_prompt)
-        if metadata is not _UNSET:
-            values["metadata_json"] = _json_dumps(dict(metadata or {}))
-        if enabled is not _UNSET:
-            values["enabled"] = 1 if bool(enabled) else 0
+        normalized = normalize_agent_name(name)
         with self.engine.begin() as conn:
-            conn.execute(agents.update().where(agents.c.id == existing.id).values(**values))
-        return self.require(name)
+            reserve_write_lock(conn)
+            row = conn.execute(
+                select(agents).where(agents.c.normalized_name == normalized).limit(1)
+            ).mappings().first()
+            if row is None:
+                raise AgentUnavailableError(
+                    f"agent '{name}' not found", agent_name=name, reason="missing"
+                )
+            existing = self._from_row(row)
+            if existing.archived_at is not None:
+                raise ValueError(f"agent '{name}' is archived and cannot be edited")
+
+            values: dict[str, Any] = {"updated_at": _utc_now_iso()}
+            if description is not _UNSET:
+                values["description"] = _clean_optional(description)
+            if model is not _UNSET:
+                values["model"] = _clean_optional(model) or recommended_agent_model(existing.backend)
+            if reasoning_effort is not _UNSET:
+                values["reasoning_effort"] = _clean_optional(reasoning_effort)
+            if system_prompt is not _UNSET:
+                values["system_prompt"] = _clean_optional(system_prompt)
+            if metadata is not _UNSET:
+                values["metadata_json"] = _json_dumps(dict(metadata or {}))
+            if enabled is not _UNSET:
+                values["enabled"] = 1 if bool(enabled) else 0
+            result = conn.execute(
+                agents.update()
+                .where(agents.c.id == existing.id)
+                .where(agents.c.archived_at.is_(None))
+                .values(**values)
+            )
+            if result.rowcount != 1:
+                raise ValueError(f"agent '{name}' is archived and cannot be edited")
+            updated = conn.execute(
+                select(agents).where(agents.c.id == existing.id).limit(1)
+            ).mappings().one()
+            return self._from_row(updated)
 
     def set_enabled(self, name: str, enabled: bool) -> VibeAgent:
         return self.update(name, enabled=enabled)
@@ -398,6 +419,7 @@ class VibeAgentStore:
         now = _utc_now_iso()
         try:
             with self.engine.begin() as conn:
+                reserve_write_lock(conn)
                 row = conn.execute(
                     select(agents).where(agents.c.normalized_name == old_normalized).limit(1)
                 ).mappings().first()
@@ -435,14 +457,18 @@ class VibeAgentStore:
                 )
                 if self._default_agent_name(conn) == agent.name:
                     self._write_default_agent_name(conn, raw_new_name, now=now)
+                updated = conn.execute(
+                    select(agents).where(agents.c.id == agent.id).limit(1)
+                ).mappings().one()
         except IntegrityError as exc:
             raise ValueError(f"agent '{new_name}' already exists") from exc
-        return self.require(raw_new_name)
+        return self._from_row(updated)
 
     def archive(self, name: str) -> Optional[AgentArchiveResult]:
         normalized = normalize_agent_name(name)
         now = _utc_now_iso()
         with self.engine.begin() as conn:
+            reserve_write_lock(conn)
             row = conn.execute(
                 select(agents).where(agents.c.normalized_name == normalized).limit(1)
             ).mappings().first()
@@ -884,17 +910,25 @@ class VibeAgentStore:
             return self._default_agent_name(conn)
 
     def set_default_agent_name(self, name: str) -> None:
-        agent = self.require_enabled(name)
+        normalized = normalize_agent_name(name)
         now = _utc_now_iso()
         with self.engine.begin() as conn:
-            conn.execute(state_meta.delete().where(state_meta.c.key == DEFAULT_AGENT_META_KEY))
-            conn.execute(
-                state_meta.insert().values(
-                    key=DEFAULT_AGENT_META_KEY,
-                    value_json=_json_dumps(agent.name),
-                    updated_at=now,
+            reserve_write_lock(conn)
+            row = conn.execute(
+                select(agents).where(agents.c.normalized_name == normalized).limit(1)
+            ).mappings().first()
+            if row is None:
+                raise AgentUnavailableError(
+                    f"agent '{name}' not found", agent_name=name, reason="missing"
                 )
-            )
+            agent = self._from_row(row)
+            if not agent.enabled or agent.archived_at is not None:
+                raise AgentUnavailableError(
+                    f"agent '{agent.name}' is disabled",
+                    agent_name=agent.name,
+                    reason="disabled",
+                )
+            self._write_default_agent_name(conn, agent.name, now=now)
 
     def get_default_agent(self, *, enabled_only: bool = True) -> Optional[VibeAgent]:
         name = self.get_default_agent_name()

--- a/core/vibe_agents.py
+++ b/core/vibe_agents.py
@@ -590,8 +590,9 @@ class VibeAgentStore:
                 )
 
             default_name = self._default_agent_name(conn)
+            effective_default = self._effective_default_agent(conn)
             replacement = None
-            if default_name == agent.name:
+            if effective_default is not None and effective_default.id == agent.id:
                 replacement = self._archive_default_replacement(conn, agent)
                 if replacement is None:
                     raise AgentArchiveError(
@@ -905,6 +906,39 @@ class VibeAgentStore:
             if candidate.backend == archived.backend:
                 return candidate
         return candidates[0] if candidates else None
+
+    @staticmethod
+    def _effective_default_agent(conn: Any) -> Optional[VibeAgent]:
+        explicit_name = VibeAgentStore._default_agent_name(conn)
+        if explicit_name:
+            explicit = conn.execute(
+                select(agents)
+                .where(agents.c.normalized_name == normalize_agent_name(explicit_name))
+                .where(agents.c.enabled == 1)
+                .where(agents.c.archived_at.is_(None))
+                .limit(1)
+            ).mappings().first()
+            if explicit is not None:
+                return VibeAgentStore._from_row(explicit)
+
+        fallback = conn.execute(
+            select(agents)
+            .where(agents.c.normalized_name == normalize_agent_name(DEFAULT_AGENT_NAME))
+            .where(agents.c.enabled == 1)
+            .where(agents.c.archived_at.is_(None))
+            .limit(1)
+        ).mappings().first()
+        if fallback is not None:
+            return VibeAgentStore._from_row(fallback)
+
+        first_enabled = conn.execute(
+            select(agents)
+            .where(agents.c.enabled == 1)
+            .where(agents.c.archived_at.is_(None))
+            .order_by(agents.c.name)
+            .limit(1)
+        ).mappings().first()
+        return VibeAgentStore._from_row(first_enabled) if first_enabled is not None else None
 
     def import_candidates(self, candidates: Iterable[AgentImportCandidate]) -> AgentImportResult:
         imported: list[VibeAgent] = []

--- a/core/vibe_agents.py
+++ b/core/vibe_agents.py
@@ -89,6 +89,15 @@ class AgentArchiveError(ValueError):
         self.agent_name = str(agent_name)
 
 
+class AgentNameValidationError(ValueError):
+    """A public Agent name violates a catalog namespace rule."""
+
+    def __init__(self, *, code: str, agent_name: str) -> None:
+        super().__init__(code)
+        self.code = code
+        self.agent_name = str(agent_name)
+
+
 def _utc_now_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
 
@@ -114,9 +123,15 @@ def _matches_agent_reference(value: Any, reference_names: frozenset[str]) -> boo
 def _validated_public_agent_name(name: str) -> tuple[str, str]:
     raw_name = str(name or "").strip()
     if raw_name.startswith("_"):
-        raise ValueError("agent names starting with '_' are reserved for Avibe")
+        raise AgentNameValidationError(
+            code="agent_name_reserved",
+            agent_name=raw_name,
+        )
     if "/" in raw_name or "\\" in raw_name:
-        raise ValueError("agent names cannot contain path separators")
+        raise AgentNameValidationError(
+            code="agent_name_path_separator",
+            agent_name=raw_name,
+        )
     return raw_name, normalize_agent_name(raw_name)
 
 

--- a/core/vibe_agents.py
+++ b/core/vibe_agents.py
@@ -19,7 +19,8 @@ from config import paths
 from storage.db import SqliteInvalidationProbe, create_sqlite_engine
 from storage.importer import ensure_sqlite_state, resolve_primary_platform_from_config
 from storage.migrations import guard_source_checkout_default_state_migration, run_migrations
-from storage.models import agent_sessions, agents, run_definitions, scope_settings, state_meta
+from storage.models import agent_runs, agent_sessions, agents, run_definitions, scope_settings, state_meta
+from storage.session_reclaim import DEFINITION_AGENT_BINDING_REVISION_KEY
 
 logger = logging.getLogger(__name__)
 
@@ -126,14 +127,25 @@ def _rewrite_scope_agent_name(raw: str | None, old_name: str, new_name: str) -> 
     return (_json_dumps(payload), True) if changed else (raw or "{}", False)
 
 
-def _rewrite_definition_agent_name(raw: str | None, old_name: str, new_name: str) -> tuple[str, bool]:
+def _rewrite_definition_agent_name(
+    raw: str | None,
+    old_name: str,
+    new_name: str,
+    *,
+    direct_binding_changed: bool,
+    revision: str,
+) -> tuple[str, bool]:
     payload = _json_loads(raw, {})
     if not isinstance(payload, dict):
-        return raw or "{}", False
+        payload = {}
+    changed = direct_binding_changed
     snapshot = payload.get("session_settings_snapshot")
-    if not isinstance(snapshot, dict) or snapshot.get("agent_name") != old_name:
+    if isinstance(snapshot, dict) and snapshot.get("agent_name") == old_name:
+        snapshot["agent_name"] = new_name
+        changed = True
+    if not changed:
         return raw or "{}", False
-    snapshot["agent_name"] = new_name
+    payload[DEFINITION_AGENT_BINDING_REVISION_KEY] = revision
     return _json_dumps(payload), True
 
 
@@ -412,7 +424,12 @@ class VibeAgentStore:
                     .where(agents.c.id == agent.id)
                     .values(name=raw_new_name, normalized_name=new_normalized, updated_at=now)
                 )
-                self._rewrite_references(conn, old_name=agent.name, new_name=raw_new_name)
+                self._rewrite_references(
+                    conn,
+                    old_name=agent.name,
+                    new_name=raw_new_name,
+                    revision=now,
+                )
                 if self._default_agent_name(conn) == agent.name:
                     self._write_default_agent_name(conn, raw_new_name, now=now)
         except IntegrityError as exc:
@@ -477,7 +494,12 @@ class VibeAgentStore:
                     updated_at=now,
                 )
             )
-            self._rewrite_references(conn, old_name=agent.name, new_name=archived_name)
+            self._rewrite_references(
+                conn,
+                old_name=agent.name,
+                new_name=archived_name,
+                revision=now,
+            )
             if replacement is not None:
                 self._write_default_agent_name(conn, replacement.name, now=now)
 
@@ -542,10 +564,22 @@ class VibeAgentStore:
         }
 
     @staticmethod
-    def _rewrite_references(conn: Any, *, old_name: str, new_name: str) -> None:
+    def _rewrite_references(
+        conn: Any,
+        *,
+        old_name: str,
+        new_name: str,
+        revision: str,
+    ) -> None:
         conn.execute(
             agent_sessions.update()
             .where(agent_sessions.c.agent_name == old_name)
+            .values(agent_name=new_name)
+        )
+        conn.execute(
+            agent_runs.update()
+            .where(agent_runs.c.agent_name == old_name)
+            .where(agent_runs.c.status.in_(("pending", "queued", "processing", "running")))
             .values(agent_name=new_name)
         )
 
@@ -571,9 +605,16 @@ class VibeAgentStore:
         ).mappings().all()
         for row in definition_rows:
             values = {}
-            if row["agent_name"] == old_name:
+            direct_binding_changed = row["agent_name"] == old_name
+            if direct_binding_changed:
                 values["agent_name"] = new_name
-            metadata, changed = _rewrite_definition_agent_name(row["metadata_json"], old_name, new_name)
+            metadata, changed = _rewrite_definition_agent_name(
+                row["metadata_json"],
+                old_name,
+                new_name,
+                direct_binding_changed=direct_binding_changed,
+                revision=revision,
+            )
             if changed:
                 values["metadata_json"] = metadata
             if values:

--- a/core/vibe_agents.py
+++ b/core/vibe_agents.py
@@ -12,7 +12,7 @@ from typing import Any, Iterable, Optional
 from uuid import uuid4
 
 import yaml
-from sqlalchemy import func, select
+from sqlalchemy import func, or_, select
 from sqlalchemy.exc import IntegrityError
 
 from config import paths
@@ -27,6 +27,8 @@ DEFAULT_AGENT_NAME = "default"
 DEFAULT_AGENT_META_KEY = "default_agent_name"
 BUILTIN_DEFAULT_AGENT_METADATA = {"builtin": True, "builtin_default": True, "lock_delete": True}
 BUILTIN_BACKEND_ENABLED_META_KEY = "backend_enabled"
+AGENT_ARCHIVE_METADATA_KEY = "_avibe_archive"
+ARCHIVED_AGENT_NAME_PREFIX = "_archived_"
 SUPPORTED_AGENT_BACKENDS = {"codex", "claude", "opencode"}
 RECOMMENDED_AGENT_MODELS = {
     "claude": "claude-opus-5",
@@ -65,6 +67,14 @@ class AgentUnavailableError(ValueError):
         self.reason = str(reason)
 
 
+class AgentArchiveError(ValueError):
+    """A catalog rule refused an otherwise valid archive request."""
+
+    def __init__(self, message: str, *, code: str) -> None:
+        super().__init__(message)
+        self.code = code
+
+
 def _utc_now_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
 
@@ -101,6 +111,32 @@ def _json_loads(value: str | None, default: Any) -> Any:
         return default
 
 
+def _rewrite_scope_agent_name(raw: str | None, old_name: str, new_name: str) -> tuple[str, bool]:
+    payload = _json_loads(raw, {})
+    if not isinstance(payload, dict):
+        return raw or "{}", False
+    routing = payload.get("routing")
+    if not isinstance(routing, dict):
+        return raw or "{}", False
+    changed = False
+    for key in ("agent_name", "agent"):
+        if routing.get(key) == old_name:
+            routing[key] = new_name
+            changed = True
+    return (_json_dumps(payload), True) if changed else (raw or "{}", False)
+
+
+def _rewrite_definition_agent_name(raw: str | None, old_name: str, new_name: str) -> tuple[str, bool]:
+    payload = _json_loads(raw, {})
+    if not isinstance(payload, dict):
+        return raw or "{}", False
+    snapshot = payload.get("session_settings_snapshot")
+    if not isinstance(snapshot, dict) or snapshot.get("agent_name") != old_name:
+        return raw or "{}", False
+    snapshot["agent_name"] = new_name
+    return _json_dumps(payload), True
+
+
 @dataclass(frozen=True)
 class VibeAgent:
     id: str
@@ -115,11 +151,34 @@ class VibeAgent:
     source: str = "user"
     source_ref: Optional[str] = None
     metadata: dict[str, Any] = field(default_factory=dict)
+    archived_at: Optional[str] = None
     created_at: str = field(default_factory=_utc_now_iso)
     updated_at: str = field(default_factory=_utc_now_iso)
 
     def to_dict(self) -> dict[str, Any]:
-        return asdict(self)
+        payload = asdict(self)
+        payload["archived"] = self.archived_at is not None
+        payload["display_name"] = archived_agent_original_name(self) or self.name
+        return payload
+
+
+@dataclass(frozen=True)
+class AgentArchiveResult:
+    agent: VibeAgent
+    original_name: str
+    archived_name: str
+    references: dict[str, int]
+    default_agent_name: Optional[str] = None
+
+
+def archived_agent_original_name(agent: VibeAgent) -> Optional[str]:
+    if agent.archived_at is None:
+        return None
+    archive_metadata = agent.metadata.get(AGENT_ARCHIVE_METADATA_KEY)
+    if not isinstance(archive_metadata, dict):
+        return None
+    original_name = str(archive_metadata.get("original_name") or "").strip()
+    return original_name or None
 
 
 @dataclass(frozen=True)
@@ -171,17 +230,28 @@ class VibeAgentStore:
                 result = conn.execute(
                     agents.update()
                     .where(agents.c.backend == backend)
+                    .where(agents.c.archived_at.is_(None))
                     .where(agents.c.model.is_(None) | (func.trim(agents.c.model) == ""))
                     .values(model=model, updated_at=now)
                 )
                 updated += int(result.rowcount or 0)
         return updated
 
-    def list_agents(self, *, include_disabled: bool = True) -> list[VibeAgent]:
+    def list_agents(
+        self,
+        *,
+        include_disabled: bool = True,
+        include_archived: bool = False,
+    ) -> list[VibeAgent]:
         with self.engine.connect() as conn:
             stmt = select(agents).order_by(agents.c.name)
             if not include_disabled:
-                stmt = stmt.where(agents.c.enabled == 1)
+                if include_archived:
+                    stmt = stmt.where(or_(agents.c.enabled == 1, agents.c.archived_at.is_not(None)))
+                else:
+                    stmt = stmt.where(agents.c.enabled == 1)
+            if not include_archived:
+                stmt = stmt.where(agents.c.archived_at.is_(None))
             rows = conn.execute(stmt).mappings()
             return [self._from_row(row) for row in rows]
 
@@ -205,7 +275,23 @@ class VibeAgentStore:
 
     def require_enabled(self, name: str) -> VibeAgent:
         agent = self.require(name)
-        if not agent.enabled:
+        if not agent.enabled or agent.archived_at is not None:
+            raise AgentUnavailableError(
+                f"agent '{agent.name}' is disabled", agent_name=agent.name, reason="disabled"
+            )
+        return agent
+
+    def require_reference(self, name: str) -> VibeAgent:
+        """Resolve a durable Agent reference, including a disabled archive."""
+
+        agent = self.require(name)
+        archive_metadata = agent.metadata.get(AGENT_ARCHIVE_METADATA_KEY)
+        archived_was_enabled = (
+            archive_metadata.get("was_enabled", True)
+            if isinstance(archive_metadata, dict)
+            else True
+        )
+        if not agent.enabled and (agent.archived_at is None or not archived_was_enabled):
             raise AgentUnavailableError(
                 f"agent '{agent.name}' is disabled", agent_name=agent.name, reason="disabled"
             )
@@ -225,12 +311,15 @@ class VibeAgentStore:
         metadata: Optional[dict[str, Any]] = None,
         enabled: bool = True,
     ) -> VibeAgent:
+        raw_name = str(name or "").strip()
+        if raw_name.startswith("_"):
+            raise ValueError("agent names starting with '_' are reserved for Avibe")
         normalized = normalize_agent_name(name)
         normalized_backend = validate_agent_backend(backend)
         now = _utc_now_iso()
         agent = VibeAgent(
             id=uuid4().hex[:12],
-            name=str(name).strip(),
+            name=raw_name,
             normalized_name=normalized,
             backend=normalized_backend,
             description=_clean_optional(description),
@@ -263,6 +352,8 @@ class VibeAgentStore:
         enabled: Any = _UNSET,
     ) -> VibeAgent:
         existing = self.require(name)
+        if existing.archived_at is not None:
+            raise ValueError(f"agent '{name}' is archived and cannot be edited")
         values: dict[str, Any] = {"updated_at": _utc_now_iso()}
         if description is not _UNSET:
             values["description"] = _clean_optional(description)
@@ -283,6 +374,132 @@ class VibeAgentStore:
     def set_enabled(self, name: str, enabled: bool) -> VibeAgent:
         return self.update(name, enabled=enabled)
 
+    def rename(self, name: str, new_name: str) -> VibeAgent:
+        raw_new_name = str(new_name or "").strip()
+        if raw_new_name.startswith("_"):
+            raise ValueError("agent names starting with '_' are reserved for Avibe")
+        new_normalized = normalize_agent_name(raw_new_name)
+        old_normalized = normalize_agent_name(name)
+        now = _utc_now_iso()
+        try:
+            with self.engine.begin() as conn:
+                row = conn.execute(
+                    select(agents).where(agents.c.normalized_name == old_normalized).limit(1)
+                ).mappings().first()
+                if row is None:
+                    raise AgentUnavailableError(
+                        f"agent '{name}' not found", agent_name=name, reason="missing"
+                    )
+                agent = self._from_row(row)
+                if agent.archived_at is not None:
+                    raise ValueError(f"agent '{name}' is archived and cannot be renamed")
+                if is_builtin_default_agent(agent):
+                    raise ValueError(f"agent '{agent.name}' is built in and cannot be renamed")
+                if new_normalized == agent.normalized_name:
+                    if raw_new_name == agent.name:
+                        return agent
+                collision = conn.execute(
+                    select(agents.c.id)
+                    .where(agents.c.normalized_name == new_normalized)
+                    .where(agents.c.id != agent.id)
+                    .limit(1)
+                ).first()
+                if collision is not None:
+                    raise ValueError(f"agent '{new_name}' already exists")
+
+                conn.execute(
+                    agents.update()
+                    .where(agents.c.id == agent.id)
+                    .values(name=raw_new_name, normalized_name=new_normalized, updated_at=now)
+                )
+                self._rewrite_references(conn, old_name=agent.name, new_name=raw_new_name)
+                if self._default_agent_name(conn) == agent.name:
+                    self._write_default_agent_name(conn, raw_new_name, now=now)
+        except IntegrityError as exc:
+            raise ValueError(f"agent '{new_name}' already exists") from exc
+        return self.require(raw_new_name)
+
+    def archive(self, name: str) -> Optional[AgentArchiveResult]:
+        normalized = normalize_agent_name(name)
+        now = _utc_now_iso()
+        with self.engine.begin() as conn:
+            row = conn.execute(
+                select(agents).where(agents.c.normalized_name == normalized).limit(1)
+            ).mappings().first()
+            if row is None:
+                return None
+            agent = self._from_row(row)
+            if is_builtin_default_agent(agent):
+                raise AgentArchiveError(
+                    f"agent '{agent.name}' is built in and cannot be deleted",
+                    code="agent_builtin",
+                )
+            if agent.archived_at is not None:
+                raise AgentArchiveError(
+                    f"agent '{agent.name}' is already archived",
+                    code="agent_already_archived",
+                )
+
+            default_name = self._default_agent_name(conn)
+            replacement = None
+            if default_name == agent.name:
+                replacement = self._archive_default_replacement(conn, agent)
+                if replacement is None:
+                    raise AgentArchiveError(
+                        "the default Agent cannot be archived without another enabled Agent",
+                        code="agent_no_default_replacement",
+                    )
+
+            archived_name = f"{ARCHIVED_AGENT_NAME_PREFIX}{uuid4().hex}"
+            archived_normalized = normalize_agent_name(archived_name)
+            while conn.execute(
+                select(agents.c.id).where(agents.c.normalized_name == archived_normalized).limit(1)
+            ).first() is not None:
+                archived_name = f"{ARCHIVED_AGENT_NAME_PREFIX}{uuid4().hex}"
+                archived_normalized = normalize_agent_name(archived_name)
+
+            references = self._reference_counts(conn, agent.name)
+            archive_metadata = {
+                "original_name": agent.name,
+                "archived_at": now,
+                "was_enabled": agent.enabled,
+            }
+            metadata = {**agent.metadata, AGENT_ARCHIVE_METADATA_KEY: archive_metadata}
+            conn.execute(
+                agents.update()
+                .where(agents.c.id == agent.id)
+                .values(
+                    name=archived_name,
+                    normalized_name=archived_normalized,
+                    enabled=0,
+                    metadata_json=_json_dumps(metadata),
+                    archived_at=now,
+                    updated_at=now,
+                )
+            )
+            self._rewrite_references(conn, old_name=agent.name, new_name=archived_name)
+            if replacement is not None:
+                self._write_default_agent_name(conn, replacement.name, now=now)
+
+            archived_agent = VibeAgent(
+                **{
+                    **asdict(agent),
+                    "name": archived_name,
+                    "normalized_name": archived_normalized,
+                    "enabled": False,
+                    "metadata": metadata,
+                    "archived_at": now,
+                    "updated_at": now,
+                }
+            )
+            return AgentArchiveResult(
+                agent=archived_agent,
+                original_name=agent.name,
+                archived_name=archived_name,
+                references=references,
+                default_agent_name=replacement.name if replacement is not None else default_name,
+            )
+
     def remove(self, name: str) -> bool:
         agent = self.get(name)
         if agent is None:
@@ -295,27 +512,113 @@ class VibeAgentStore:
             return bool(result.rowcount)
 
     def reference_counts(self, name: str) -> dict[str, int]:
-        normalized = normalize_agent_name(name)
-        agent = self.get(normalized)
+        agent = self.get(name)
         if agent is None:
             return {}
         with self.engine.connect() as conn:
-            scope_count = conn.execute(
-                select(scope_settings.c.scope_id).where(scope_settings.c.agent_name == agent.name)
-            ).fetchall()
-            session_count = conn.execute(
-                select(agent_sessions.c.id).where(agent_sessions.c.agent_name == agent.name)
-            ).fetchall()
-            definition_count = conn.execute(
-                select(run_definitions.c.id)
-                .where(run_definitions.c.agent_name == agent.name)
-                .where(run_definitions.c.deleted_at.is_(None))
-            ).fetchall()
+            return self._reference_counts(conn, agent.name)
+
+    @staticmethod
+    def _reference_counts(conn: Any, name: str) -> dict[str, int]:
         return {
-            "scopes": len(scope_count),
-            "sessions": len(session_count),
-            "definitions": len(definition_count),
+            "scopes": int(
+                conn.execute(
+                    select(func.count()).select_from(scope_settings).where(scope_settings.c.agent_name == name)
+                ).scalar_one()
+            ),
+            "sessions": int(
+                conn.execute(
+                    select(func.count()).select_from(agent_sessions).where(agent_sessions.c.agent_name == name)
+                ).scalar_one()
+            ),
+            "definitions": int(
+                conn.execute(
+                    select(func.count())
+                    .select_from(run_definitions)
+                    .where(run_definitions.c.agent_name == name)
+                    .where(run_definitions.c.deleted_at.is_(None))
+                ).scalar_one()
+            ),
         }
+
+    @staticmethod
+    def _rewrite_references(conn: Any, *, old_name: str, new_name: str) -> None:
+        conn.execute(
+            agent_sessions.update()
+            .where(agent_sessions.c.agent_name == old_name)
+            .values(agent_name=new_name)
+        )
+
+        scope_rows = conn.execute(
+            select(scope_settings.c.scope_id, scope_settings.c.agent_name, scope_settings.c.settings_json)
+        ).mappings().all()
+        for row in scope_rows:
+            values: dict[str, Any] = {}
+            if row["agent_name"] == old_name:
+                values["agent_name"] = new_name
+            settings, changed = _rewrite_scope_agent_name(row["settings_json"], old_name, new_name)
+            if changed:
+                values["settings_json"] = settings
+            if values:
+                conn.execute(
+                    scope_settings.update()
+                    .where(scope_settings.c.scope_id == row["scope_id"])
+                    .values(**values)
+                )
+
+        definition_rows = conn.execute(
+            select(run_definitions.c.id, run_definitions.c.agent_name, run_definitions.c.metadata_json)
+        ).mappings().all()
+        for row in definition_rows:
+            values = {}
+            if row["agent_name"] == old_name:
+                values["agent_name"] = new_name
+            metadata, changed = _rewrite_definition_agent_name(row["metadata_json"], old_name, new_name)
+            if changed:
+                values["metadata_json"] = metadata
+            if values:
+                conn.execute(
+                    run_definitions.update()
+                    .where(run_definitions.c.id == row["id"])
+                    .values(**values)
+                )
+
+    @staticmethod
+    def _default_agent_name(conn: Any) -> Optional[str]:
+        value = conn.execute(
+            select(state_meta.c.value_json).where(state_meta.c.key == DEFAULT_AGENT_META_KEY).limit(1)
+        ).scalar_one_or_none()
+        payload = _json_loads(value, None)
+        return str(payload).strip() if payload else None
+
+    @staticmethod
+    def _write_default_agent_name(conn: Any, name: str, *, now: str) -> None:
+        conn.execute(state_meta.delete().where(state_meta.c.key == DEFAULT_AGENT_META_KEY))
+        conn.execute(
+            state_meta.insert().values(
+                key=DEFAULT_AGENT_META_KEY,
+                value_json=_json_dumps(name),
+                updated_at=now,
+            )
+        )
+
+    @staticmethod
+    def _archive_default_replacement(conn: Any, archived: VibeAgent) -> Optional[VibeAgent]:
+        rows = conn.execute(
+            select(agents)
+            .where(agents.c.id != archived.id)
+            .where(agents.c.enabled == 1)
+            .where(agents.c.archived_at.is_(None))
+            .order_by(agents.c.name)
+        ).mappings()
+        candidates = [VibeAgentStore._from_row(row) for row in rows]
+        for candidate in candidates:
+            if candidate.backend == archived.backend and is_builtin_default_agent(candidate):
+                return candidate
+        for candidate in candidates:
+            if candidate.backend == archived.backend:
+                return candidate
+        return candidates[0] if candidates else None
 
     def import_candidates(self, candidates: Iterable[AgentImportCandidate]) -> AgentImportResult:
         imported: list[VibeAgent] = []
@@ -459,11 +762,7 @@ class VibeAgentStore:
 
     def get_default_agent_name(self) -> Optional[str]:
         with self.engine.connect() as conn:
-            value = conn.execute(
-                select(state_meta.c.value_json).where(state_meta.c.key == DEFAULT_AGENT_META_KEY).limit(1)
-            ).scalar_one_or_none()
-        payload = _json_loads(value, None)
-        return str(payload).strip() if payload else None
+            return self._default_agent_name(conn)
 
     def set_default_agent_name(self, name: str) -> None:
         agent = self.require_enabled(name)
@@ -507,6 +806,7 @@ class VibeAgentStore:
             source=row["source"],
             source_ref=row["source_ref"],
             metadata=_json_loads(row["metadata_json"], {}),
+            archived_at=row.get("archived_at"),
             created_at=row["created_at"],
             updated_at=row["updated_at"],
         )
@@ -526,6 +826,7 @@ class VibeAgentStore:
             "source": agent.source,
             "source_ref": agent.source_ref,
             "metadata_json": _json_dumps(agent.metadata),
+            "archived_at": agent.archived_at,
             "created_at": agent.created_at,
             "updated_at": agent.updated_at,
         }

--- a/core/vibe_agents.py
+++ b/core/vibe_agents.py
@@ -125,7 +125,11 @@ def _json_loads(value: str | None, default: Any) -> Any:
         return default
 
 
-def _rewrite_scope_agent_name(raw: str | None, old_name: str, new_name: str) -> tuple[str, bool]:
+def _rewrite_scope_agent_name(
+    raw: str | None,
+    reference_names: frozenset[str],
+    new_name: str,
+) -> tuple[str, bool]:
     payload = _json_loads(raw, {})
     if not isinstance(payload, dict):
         return raw or "{}", False
@@ -134,7 +138,7 @@ def _rewrite_scope_agent_name(raw: str | None, old_name: str, new_name: str) -> 
         return raw or "{}", False
     changed = False
     for key in ("agent_name", "agent"):
-        if routing.get(key) == old_name:
+        if routing.get(key) in reference_names:
             routing[key] = new_name
             changed = True
     return (_json_dumps(payload), True) if changed else (raw or "{}", False)
@@ -142,7 +146,7 @@ def _rewrite_scope_agent_name(raw: str | None, old_name: str, new_name: str) -> 
 
 def _rewrite_definition_agent_name(
     raw: str | None,
-    old_name: str,
+    reference_names: frozenset[str],
     new_name: str,
     *,
     direct_binding_changed: bool,
@@ -153,7 +157,7 @@ def _rewrite_definition_agent_name(
         payload = {}
     changed = direct_binding_changed
     snapshot = payload.get("session_settings_snapshot")
-    if isinstance(snapshot, dict) and snapshot.get("agent_name") == old_name:
+    if isinstance(snapshot, dict) and snapshot.get("agent_name") in reference_names:
         snapshot["agent_name"] = new_name
         changed = True
     if not changed:
@@ -288,6 +292,16 @@ class VibeAgentStore:
             ).mappings().first()
             return self._from_row(row) if row else None
 
+    def get_by_id(self, agent_id: str) -> Optional[VibeAgent]:
+        cleaned = str(agent_id or "").strip()
+        if not cleaned:
+            return None
+        with self.engine.connect() as conn:
+            row = conn.execute(
+                select(agents).where(agents.c.id == cleaned).limit(1)
+            ).mappings().first()
+            return self._from_row(row) if row else None
+
     def require(self, name: str) -> VibeAgent:
         agent = self.get(name)
         if agent is None:
@@ -309,7 +323,22 @@ class VibeAgentStore:
     def require_reference(self, name: str) -> VibeAgent:
         """Resolve a durable Agent reference, including a disabled archive."""
 
-        agent = self.require(name)
+        return self._require_reference_agent(self.require(name))
+
+    def require_reference_by_id(self, agent_id: str) -> VibeAgent:
+        """Resolve a durable Agent identity across rename/archive operations."""
+
+        agent = self.get_by_id(agent_id)
+        if agent is None:
+            raise AgentUnavailableError(
+                f"agent id '{agent_id}' not found",
+                agent_name=str(agent_id),
+                reason="missing",
+            )
+        return self._require_reference_agent(agent)
+
+    @staticmethod
+    def _require_reference_agent(agent: VibeAgent) -> VibeAgent:
         archive_metadata = agent.metadata.get(AGENT_ARCHIVE_METADATA_KEY)
         archived_was_enabled = (
             archive_metadata.get("was_enabled", True)
@@ -454,7 +483,7 @@ class VibeAgentStore:
                 )
                 self._rewrite_references(
                     conn,
-                    old_name=agent.name,
+                    reference_names=frozenset((agent.name, agent.normalized_name)),
                     new_name=raw_new_name,
                     revision=now,
                 )
@@ -509,7 +538,8 @@ class VibeAgentStore:
                 normalized_name=agent.normalized_name,
             )
 
-            references = self._reference_counts(conn, agent.name)
+            reference_names = frozenset((agent.name, agent.normalized_name))
+            references = self._reference_counts(conn, reference_names)
             archive_metadata = {
                 "original_name": agent.name,
                 "archived_at": now,
@@ -530,7 +560,7 @@ class VibeAgentStore:
             )
             self._rewrite_references(
                 conn,
-                old_name=agent.name,
+                reference_names=reference_names,
                 new_name=archived_name,
                 revision=now,
             )
@@ -597,7 +627,8 @@ class VibeAgentStore:
             conn,
             normalized_name=normalize_agent_name(original_name),
         )
-        references = self._reference_counts(conn, agent.name)
+        reference_names = frozenset((agent.name, agent.normalized_name))
+        references = self._reference_counts(conn, reference_names)
         conn.execute(
             agents.update()
             .where(agents.c.id == agent.id)
@@ -609,7 +640,7 @@ class VibeAgentStore:
         )
         self._rewrite_references(
             conn,
-            old_name=agent.name,
+            reference_names=reference_names,
             new_name=archived_name,
             revision=now,
         )
@@ -645,26 +676,33 @@ class VibeAgentStore:
         if agent is None:
             return {}
         with self.engine.connect() as conn:
-            return self._reference_counts(conn, agent.name)
+            return self._reference_counts(
+                conn,
+                frozenset((agent.name, agent.normalized_name)),
+            )
 
     @staticmethod
-    def _reference_counts(conn: Any, name: str) -> dict[str, int]:
+    def _reference_counts(conn: Any, reference_names: frozenset[str]) -> dict[str, int]:
         return {
             "scopes": int(
                 conn.execute(
-                    select(func.count()).select_from(scope_settings).where(scope_settings.c.agent_name == name)
+                    select(func.count())
+                    .select_from(scope_settings)
+                    .where(scope_settings.c.agent_name.in_(reference_names))
                 ).scalar_one()
             ),
             "sessions": int(
                 conn.execute(
-                    select(func.count()).select_from(agent_sessions).where(agent_sessions.c.agent_name == name)
+                    select(func.count())
+                    .select_from(agent_sessions)
+                    .where(agent_sessions.c.agent_name.in_(reference_names))
                 ).scalar_one()
             ),
             "definitions": int(
                 conn.execute(
                     select(func.count())
                     .select_from(run_definitions)
-                    .where(run_definitions.c.agent_name == name)
+                    .where(run_definitions.c.agent_name.in_(reference_names))
                     .where(run_definitions.c.deleted_at.is_(None))
                 ).scalar_one()
             ),
@@ -674,18 +712,18 @@ class VibeAgentStore:
     def _rewrite_references(
         conn: Any,
         *,
-        old_name: str,
+        reference_names: frozenset[str],
         new_name: str,
         revision: str,
     ) -> None:
         conn.execute(
             agent_sessions.update()
-            .where(agent_sessions.c.agent_name == old_name)
+            .where(agent_sessions.c.agent_name.in_(reference_names))
             .values(agent_name=new_name)
         )
         conn.execute(
             agent_runs.update()
-            .where(agent_runs.c.agent_name == old_name)
+            .where(agent_runs.c.agent_name.in_(reference_names))
             .where(agent_runs.c.status.in_(("pending", "queued", "processing", "running")))
             .values(agent_name=new_name)
         )
@@ -695,9 +733,11 @@ class VibeAgentStore:
         ).mappings().all()
         for row in scope_rows:
             values: dict[str, Any] = {}
-            if row["agent_name"] == old_name:
+            if row["agent_name"] in reference_names:
                 values["agent_name"] = new_name
-            settings, changed = _rewrite_scope_agent_name(row["settings_json"], old_name, new_name)
+            settings, changed = _rewrite_scope_agent_name(
+                row["settings_json"], reference_names, new_name
+            )
             if changed:
                 values["settings_json"] = settings
             if values:
@@ -712,12 +752,12 @@ class VibeAgentStore:
         ).mappings().all()
         for row in definition_rows:
             values = {}
-            direct_binding_changed = row["agent_name"] == old_name
+            direct_binding_changed = row["agent_name"] in reference_names
             if direct_binding_changed:
                 values["agent_name"] = new_name
             metadata, changed = _rewrite_definition_agent_name(
                 row["metadata_json"],
-                old_name,
+                reference_names,
                 new_name,
                 direct_binding_changed=direct_binding_changed,
                 revision=revision,

--- a/core/vibe_agents.py
+++ b/core/vibe_agents.py
@@ -8,7 +8,7 @@ import re
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Iterable, Optional
+from typing import Any, Iterable, Mapping, Optional
 from uuid import uuid4
 
 import yaml
@@ -330,6 +330,25 @@ def archived_agent_original_name(agent: VibeAgent) -> Optional[str]:
     return original_name or None
 
 
+def agent_reference_is_usable(
+    *,
+    enabled: bool,
+    archived_at: Optional[str],
+    metadata: Mapping[str, Any] | None,
+) -> bool:
+    """Return whether an Agent may back an existing durable reference."""
+
+    if enabled:
+        return True
+    archive_metadata = (metadata or {}).get(AGENT_ARCHIVE_METADATA_KEY)
+    archived_was_enabled = (
+        archive_metadata.get("was_enabled", True)
+        if isinstance(archive_metadata, dict)
+        else True
+    )
+    return archived_at is not None and bool(archived_was_enabled)
+
+
 @dataclass(frozen=True)
 class AgentImportCandidate:
     name: str
@@ -459,13 +478,11 @@ class VibeAgentStore:
 
     @staticmethod
     def _require_reference_agent(agent: VibeAgent) -> VibeAgent:
-        archive_metadata = agent.metadata.get(AGENT_ARCHIVE_METADATA_KEY)
-        archived_was_enabled = (
-            archive_metadata.get("was_enabled", True)
-            if isinstance(archive_metadata, dict)
-            else True
-        )
-        if not agent.enabled and (agent.archived_at is None or not archived_was_enabled):
+        if not agent_reference_is_usable(
+            enabled=agent.enabled,
+            archived_at=agent.archived_at,
+            metadata=agent.metadata,
+        ):
             raise AgentUnavailableError(
                 f"agent '{agent.name}' is disabled", agent_name=agent.name, reason="disabled"
             )

--- a/core/vibe_agents.py
+++ b/core/vibe_agents.py
@@ -20,7 +20,15 @@ from storage.agent_session_rows import reserve_write_lock
 from storage.db import SqliteInvalidationProbe, create_sqlite_engine
 from storage.importer import ensure_sqlite_state, resolve_primary_platform_from_config
 from storage.migrations import guard_source_checkout_default_state_migration, run_migrations
-from storage.models import agent_runs, agent_sessions, agents, run_definitions, scope_settings, state_meta
+from storage.models import (
+    agent_runs,
+    agent_sessions,
+    agents,
+    messages,
+    run_definitions,
+    scope_settings,
+    state_meta,
+)
 from storage.session_reclaim import DEFINITION_AGENT_BINDING_REVISION_KEY
 
 logger = logging.getLogger(__name__)
@@ -152,9 +160,20 @@ def _rewrite_definition_agent_name(
     direct_binding_changed: bool,
     revision: str,
 ) -> tuple[str, bool]:
-    payload = _json_loads(raw, {})
+    try:
+        payload = json.loads("{}" if raw is None else raw)
+    except (TypeError, ValueError) as exc:
+        if direct_binding_changed:
+            raise ValueError(
+                "cannot rewrite Agent reference because definition metadata is malformed"
+            ) from exc
+        return raw or "{}", False
     if not isinstance(payload, dict):
-        payload = {}
+        if direct_binding_changed:
+            raise ValueError(
+                "cannot rewrite Agent reference because definition metadata is not an object"
+            )
+        return raw or "{}", False
     changed = direct_binding_changed
     snapshot = payload.get("session_settings_snapshot")
     if isinstance(snapshot, dict) and snapshot.get("agent_name") in reference_names:
@@ -164,6 +183,38 @@ def _rewrite_definition_agent_name(
         return raw or "{}", False
     payload[DEFINITION_AGENT_BINDING_REVISION_KEY] = revision
     return _json_dumps(payload), True
+
+
+def _rewrite_queued_agent_provenance(
+    raw: str | None,
+    reference_names: frozenset[str],
+    new_name: str,
+) -> tuple[str, bool]:
+    """Move routing names captured on a queued Workbench harness message."""
+
+    try:
+        payload = json.loads(raw or "{}")
+    except (TypeError, ValueError):
+        return raw or "{}", False
+    if not isinstance(payload, dict):
+        return raw or "{}", False
+    provenance = payload.get("scheduled_provenance")
+    if not isinstance(provenance, dict):
+        return raw or "{}", False
+    spec = provenance.get("platform_specific")
+    if not isinstance(spec, dict):
+        return raw or "{}", False
+
+    changed = False
+    for key in ("vibe_agent_name", "scheduled_target_agent_name"):
+        if spec.get(key) in reference_names:
+            spec[key] = new_name
+            changed = True
+    target = spec.get("agent_session_target")
+    if isinstance(target, dict) and target.get("agent_name") in reference_names:
+        target["agent_name"] = new_name
+        changed = True
+    return (_json_dumps(payload), True) if changed else (raw or "{}", False)
 
 
 @dataclass(frozen=True)
@@ -727,6 +778,20 @@ class VibeAgentStore:
             .where(agent_runs.c.status.in_(("pending", "queued", "processing", "running")))
             .values(agent_name=new_name)
         )
+
+        queued_rows = conn.execute(
+            select(messages.c.id, messages.c.metadata_json).where(messages.c.type == "queued")
+        ).mappings().all()
+        for row in queued_rows:
+            metadata, changed = _rewrite_queued_agent_provenance(
+                row["metadata_json"], reference_names, new_name
+            )
+            if changed:
+                conn.execute(
+                    messages.update()
+                    .where(messages.c.id == row["id"])
+                    .values(metadata_json=metadata)
+                )
 
         scope_rows = conn.execute(
             select(scope_settings.c.scope_id, scope_settings.c.agent_name, scope_settings.c.settings_json)

--- a/core/vibe_agents.py
+++ b/core/vibe_agents.py
@@ -83,9 +83,10 @@ class AgentUnavailableError(ValueError):
 class AgentArchiveError(ValueError):
     """A catalog rule refused an otherwise valid archive request."""
 
-    def __init__(self, message: str, *, code: str) -> None:
-        super().__init__(message)
+    def __init__(self, *, code: str, agent_name: str) -> None:
+        super().__init__(code)
         self.code = code
+        self.agent_name = str(agent_name)
 
 
 def _utc_now_iso() -> str:
@@ -578,15 +579,15 @@ class VibeAgentStore:
             agent = self._from_row(row)
             if is_builtin_default_agent(agent):
                 raise AgentArchiveError(
-                    f"agent '{agent.name}' is built in and cannot be deleted",
                     code="agent_builtin",
+                    agent_name=agent.name,
                 )
             if agent.archived_at is not None:
                 if agent.name.startswith(LEGACY_ARCHIVED_AGENT_NAME_PREFIX):
                     return self._compact_legacy_archive(conn, agent, now=now)
                 raise AgentArchiveError(
-                    f"agent '{agent.name}' is already archived",
                     code="agent_already_archived",
+                    agent_name=agent.name,
                 )
 
             default_name = self._default_agent_name(conn)
@@ -600,8 +601,8 @@ class VibeAgentStore:
                 replacement = self._archive_default_replacement(conn, agent)
                 if replacement is None:
                     raise AgentArchiveError(
-                        "the default Agent cannot be archived without another enabled Agent",
                         code="agent_no_default_replacement",
+                        agent_name=agent.name,
                     )
             elif explicit_default_matches:
                 replacement = effective_default

--- a/core/vibe_agents.py
+++ b/core/vibe_agents.py
@@ -29,7 +29,10 @@ DEFAULT_AGENT_META_KEY = "default_agent_name"
 BUILTIN_DEFAULT_AGENT_METADATA = {"builtin": True, "builtin_default": True, "lock_delete": True}
 BUILTIN_BACKEND_ENABLED_META_KEY = "backend_enabled"
 AGENT_ARCHIVE_METADATA_KEY = "_avibe_archive"
-ARCHIVED_AGENT_NAME_PREFIX = "_archived_"
+ARCHIVED_AGENT_NAME_PREFIX = "_"
+LEGACY_ARCHIVED_AGENT_NAME_PREFIX = "_archived_"
+ARCHIVED_AGENT_SLUG_LENGTH = 12
+ARCHIVED_AGENT_TOKEN_LENGTH = 4
 SUPPORTED_AGENT_BACKENDS = {"codex", "claude", "opencode"}
 RECOMMENDED_AGENT_MODELS = {
     "claude": "claude-opus-5",
@@ -444,7 +447,10 @@ class VibeAgentStore:
                 select(agents).where(agents.c.normalized_name == normalized).limit(1)
             ).mappings().first()
             if row is None:
-                return None
+                legacy = self._legacy_archive_for_original_name(conn, normalized)
+                if legacy is None:
+                    return None
+                return self._compact_legacy_archive(conn, legacy, now=now)
             agent = self._from_row(row)
             if is_builtin_default_agent(agent):
                 raise AgentArchiveError(
@@ -452,6 +458,8 @@ class VibeAgentStore:
                     code="agent_builtin",
                 )
             if agent.archived_at is not None:
+                if agent.name.startswith(LEGACY_ARCHIVED_AGENT_NAME_PREFIX):
+                    return self._compact_legacy_archive(conn, agent, now=now)
                 raise AgentArchiveError(
                     f"agent '{agent.name}' is already archived",
                     code="agent_already_archived",
@@ -467,13 +475,10 @@ class VibeAgentStore:
                         code="agent_no_default_replacement",
                     )
 
-            archived_name = f"{ARCHIVED_AGENT_NAME_PREFIX}{uuid4().hex}"
-            archived_normalized = normalize_agent_name(archived_name)
-            while conn.execute(
-                select(agents.c.id).where(agents.c.normalized_name == archived_normalized).limit(1)
-            ).first() is not None:
-                archived_name = f"{ARCHIVED_AGENT_NAME_PREFIX}{uuid4().hex}"
-                archived_normalized = normalize_agent_name(archived_name)
+            archived_name, archived_normalized = self._available_archive_name(
+                conn,
+                normalized_name=agent.normalized_name,
+            )
 
             references = self._reference_counts(conn, agent.name)
             archive_metadata = {
@@ -521,6 +526,79 @@ class VibeAgentStore:
                 references=references,
                 default_agent_name=replacement.name if replacement is not None else default_name,
             )
+
+    @staticmethod
+    def _available_archive_name(conn: Any, *, normalized_name: str) -> tuple[str, str]:
+        slug = str(normalized_name or "agent").strip("-_")[:ARCHIVED_AGENT_SLUG_LENGTH] or "agent"
+        while True:
+            token = uuid4().hex[:ARCHIVED_AGENT_TOKEN_LENGTH]
+            archived_name = f"{ARCHIVED_AGENT_NAME_PREFIX}{slug}-{token}"
+            archived_normalized = normalize_agent_name(archived_name)
+            collision = conn.execute(
+                select(agents.c.id).where(agents.c.normalized_name == archived_normalized).limit(1)
+            ).first()
+            if collision is None:
+                return archived_name, archived_normalized
+
+    @staticmethod
+    def _legacy_archive_for_original_name(conn: Any, normalized_name: str) -> Optional[VibeAgent]:
+        rows = conn.execute(
+            select(agents)
+            .where(agents.c.archived_at.is_not(None))
+            .order_by(agents.c.updated_at.desc())
+        ).mappings()
+        for row in rows:
+            agent = VibeAgentStore._from_row(row)
+            if not agent.name.startswith(LEGACY_ARCHIVED_AGENT_NAME_PREFIX):
+                continue
+            original_name = archived_agent_original_name(agent)
+            if original_name and normalize_agent_name(original_name) == normalized_name:
+                return agent
+        return None
+
+    def _compact_legacy_archive(
+        self,
+        conn: Any,
+        agent: VibeAgent,
+        *,
+        now: str,
+    ) -> AgentArchiveResult:
+        original_name = archived_agent_original_name(agent) or agent.name
+        archived_name, archived_normalized = self._available_archive_name(
+            conn,
+            normalized_name=normalize_agent_name(original_name),
+        )
+        references = self._reference_counts(conn, agent.name)
+        conn.execute(
+            agents.update()
+            .where(agents.c.id == agent.id)
+            .values(
+                name=archived_name,
+                normalized_name=archived_normalized,
+                updated_at=now,
+            )
+        )
+        self._rewrite_references(
+            conn,
+            old_name=agent.name,
+            new_name=archived_name,
+            revision=now,
+        )
+        archived_agent = VibeAgent(
+            **{
+                **asdict(agent),
+                "name": archived_name,
+                "normalized_name": archived_normalized,
+                "updated_at": now,
+            }
+        )
+        return AgentArchiveResult(
+            agent=archived_agent,
+            original_name=original_name,
+            archived_name=archived_name,
+            references=references,
+            default_agent_name=self._default_agent_name(conn),
+        )
 
     def remove(self, name: str) -> bool:
         agent = self.get(name)

--- a/core/vibe_agents.py
+++ b/core/vibe_agents.py
@@ -625,7 +625,15 @@ class VibeAgentStore:
                     new_name=raw_new_name,
                     revision=now,
                 )
-                if self._default_agent_name(conn) == agent.name:
+                default_name = self._default_agent_name(conn)
+                try:
+                    default_matches = (
+                        default_name is not None
+                        and normalize_agent_name(default_name) == agent.normalized_name
+                    )
+                except ValueError:
+                    default_matches = False
+                if default_matches:
                     self._write_default_agent_name(conn, raw_new_name, now=now)
                 updated = conn.execute(
                     select(agents).where(agents.c.id == agent.id).limit(1)

--- a/core/watches.py
+++ b/core/watches.py
@@ -387,6 +387,7 @@ class ManagedWatchStore:
         expect: DefinitionWriteExpectation,
         *,
         queued_run: Optional[dict[str, Any]] = None,
+        expected_enabled_agent_id: Optional[str] = None,
     ) -> bool:
         """Persist a whole watch row; ``False`` means the guard refused the write.
 
@@ -415,7 +416,11 @@ class ManagedWatchStore:
                 self._save()
                 return True
             if queued_run is None:
-                landed = self._sqlite.upsert_watch(watch.to_dict(), expect=expect)
+                landed = self._sqlite.upsert_watch(
+                    watch.to_dict(),
+                    expect=expect,
+                    expected_enabled_agent_id=expected_enabled_agent_id,
+                )
             else:
                 landed = self._sqlite.upsert_watch_with_queued_run(
                     watch.to_dict(), expect=expect, run_payload=queued_run
@@ -454,7 +459,12 @@ class ManagedWatchStore:
             self._signature = None
             self._reload_required = True
 
-    def upsert_watch(self, watch: ManagedWatch) -> ManagedWatch:
+    def upsert_watch(
+        self,
+        watch: ManagedWatch,
+        *,
+        expected_enabled_agent_id: Optional[str] = None,
+    ) -> ManagedWatch:
         """Create or adopt a whole watch row (unguarded: the payload is not a re-read).
 
         The mirror rolls back with the write here too (HFR-275). This is the one entry
@@ -470,7 +480,10 @@ class ManagedWatchStore:
             if self._sqlite is not None:
                 # No ``expect``: the create/adopt entry point (``add_watch``), whose
                 # payload is not derived from a stored row.
-                self._sqlite.upsert_watch(watch.to_dict())
+                self._sqlite.upsert_watch(
+                    watch.to_dict(),
+                    expected_enabled_agent_id=expected_enabled_agent_id,
+                )
                 return watch
             self._save()
         except Exception:
@@ -499,6 +512,7 @@ class ManagedWatchStore:
         session_policy: Optional[str] = None,
         message: Optional[str] = None,
         metadata: Optional[dict[str, Any]] = None,
+        expected_enabled_agent_id: Optional[str] = None,
     ) -> ManagedWatch:
         watch = ManagedWatch(
             id=uuid4().hex[:12],
@@ -521,7 +535,10 @@ class ManagedWatchStore:
             deliver_key=deliver_key,
             metadata=dict(metadata or {}),
         )
-        return self.upsert_watch(watch)
+        return self.upsert_watch(
+            watch,
+            expected_enabled_agent_id=expected_enabled_agent_id,
+        )
 
     def remove_watch(self, watch_id: str) -> bool:
         """Delete a watch; the mirror rolls back with the delete (HFR-275).
@@ -586,6 +603,7 @@ class ManagedWatchStore:
         session_policy: Optional[str] = None,
         message: Optional[str] = None,
         metadata: Optional[dict[str, Any]] = None,
+        expected_enabled_agent_id: Optional[str] = None,
     ) -> ManagedWatch:
         watch = self._watches[watch_id]
         # Captured before the first mutation: the state ``vibe watch update`` read and
@@ -618,7 +636,11 @@ class ManagedWatchStore:
         if metadata is not None:
             watch.metadata = dict(metadata)
         watch.updated_at = _utc_now_iso()
-        if not self._write_watch(watch, expect):
+        if not self._write_watch(
+            watch,
+            expect,
+            expected_enabled_agent_id=expected_enabled_agent_id,
+        ):
             # The edit did NOT land. ``cmd_watch_update`` turns this into a non-zero
             # exit with an error payload instead of echoing an unwritten watch.
             raise DefinitionWriteConflict(watch_id, definition_type="watch")

--- a/core/watches.py
+++ b/core/watches.py
@@ -388,6 +388,7 @@ class ManagedWatchStore:
         *,
         queued_run: Optional[dict[str, Any]] = None,
         expected_enabled_agent_id: Optional[str] = None,
+        expected_reference_agent_id: Optional[str] = None,
     ) -> bool:
         """Persist a whole watch row; ``False`` means the guard refused the write.
 
@@ -420,6 +421,7 @@ class ManagedWatchStore:
                     watch.to_dict(),
                     expect=expect,
                     expected_enabled_agent_id=expected_enabled_agent_id,
+                    expected_reference_agent_id=expected_reference_agent_id,
                 )
             else:
                 landed = self._sqlite.upsert_watch_with_queued_run(
@@ -464,6 +466,7 @@ class ManagedWatchStore:
         watch: ManagedWatch,
         *,
         expected_enabled_agent_id: Optional[str] = None,
+        expected_reference_agent_id: Optional[str] = None,
     ) -> ManagedWatch:
         """Create or adopt a whole watch row (unguarded: the payload is not a re-read).
 
@@ -483,7 +486,11 @@ class ManagedWatchStore:
                 self._sqlite.upsert_watch(
                     watch.to_dict(),
                     expected_enabled_agent_id=expected_enabled_agent_id,
+                    expected_reference_agent_id=expected_reference_agent_id,
                 )
+                if expected_reference_agent_id is not None:
+                    self.load()
+                    return self._watches[watch.id]
                 return watch
             self._save()
         except Exception:
@@ -513,6 +520,7 @@ class ManagedWatchStore:
         message: Optional[str] = None,
         metadata: Optional[dict[str, Any]] = None,
         expected_enabled_agent_id: Optional[str] = None,
+        expected_reference_agent_id: Optional[str] = None,
     ) -> ManagedWatch:
         watch = ManagedWatch(
             id=uuid4().hex[:12],
@@ -538,6 +546,7 @@ class ManagedWatchStore:
         return self.upsert_watch(
             watch,
             expected_enabled_agent_id=expected_enabled_agent_id,
+            expected_reference_agent_id=expected_reference_agent_id,
         )
 
     def remove_watch(self, watch_id: str) -> bool:
@@ -604,6 +613,7 @@ class ManagedWatchStore:
         message: Optional[str] = None,
         metadata: Optional[dict[str, Any]] = None,
         expected_enabled_agent_id: Optional[str] = None,
+        expected_reference_agent_id: Optional[str] = None,
     ) -> ManagedWatch:
         watch = self._watches[watch_id]
         # Captured before the first mutation: the state ``vibe watch update`` read and
@@ -640,10 +650,14 @@ class ManagedWatchStore:
             watch,
             expect,
             expected_enabled_agent_id=expected_enabled_agent_id,
+            expected_reference_agent_id=expected_reference_agent_id,
         ):
             # The edit did NOT land. ``cmd_watch_update`` turns this into a non-zero
             # exit with an error payload instead of echoing an unwritten watch.
             raise DefinitionWriteConflict(watch_id, definition_type="watch")
+        if expected_reference_agent_id is not None:
+            self.load()
+            return self._watches[watch_id]
         return watch
 
     @staticmethod

--- a/docs/plans/agent-archive-delete.md
+++ b/docs/plans/agent-archive-delete.md
@@ -11,11 +11,12 @@ Make Agent deletion preserve every durable reference while removing the Agent fr
   - renames the Agent to an opaque `_archived_<id>` name;
   - disables it and records `archived_at` plus its original display name;
   - rewrites scope, Session, and task/watch definition references to the archived name;
+  - rewrites nonterminal Agent Run references so queued work keeps its exact Agent configuration;
   - rewrites structured name snapshots embedded in scope and definition JSON;
   - moves the global default to another enabled, visible Agent when necessary.
 - Archived Agents are excluded from normal catalog lists, including lists that include ordinary disabled Agents.
 - An Agent archived while enabled may resolve only through a persisted reference. An Agent that was already disabled stays unusable. Neither can be selected for new work, edited, enabled, or made the default.
-- Historical run and event records keep their original Agent name because they are immutable execution snapshots, not live references.
+- Terminal run and event records keep their original Agent name because they are immutable execution snapshots, not live references.
 - Built-in Agents retain their existing deletion lock.
 - User-visible rename updates the existing Agent row and the same durable references atomically; it no longer clones and deletes.
 
@@ -23,10 +24,13 @@ Make Agent deletion preserve every durable reference while removing the Agent fr
 
 The Agent row is updated first inside a single write transaction, followed by every live reference. Any validation or write failure rolls the entire operation back. The old public name becomes available only after all references point to the archived name.
 
+Definition rewrites stamp a dedicated Agent-binding revision in metadata. Full-row task/watch updates compare that marker, so a payload read before rename/archive cannot restore the old public name after the transaction commits.
+
 ## Compatibility
 
 - The DELETE API and `vibe agent remove` command keep their existing entry points, but return archive details instead of rejecting referenced Agents.
 - Existing Sessions and scheduled definitions resolve disabled archived Agents through a reference-only resolver. Direct Agent selection continues to require an enabled, visible Agent.
+- Session create/update rejects archived Agent names, and an archived project default is not inherited by a new Session.
 - API payloads expose the original display name for archived Agents while retaining the internal name as the reference key.
 
 ## Verification

--- a/docs/plans/agent-archive-delete.md
+++ b/docs/plans/agent-archive-delete.md
@@ -1,0 +1,38 @@
+# Agent Archive Delete
+
+## Goal
+
+Make Agent deletion preserve every durable reference while removing the Agent from normal user-facing catalogs and selectors.
+
+## Contract
+
+- User-created and imported Agent names cannot start with `_`; that namespace is reserved for Avibe internals.
+- Deleting a non-built-in Agent is one SQLite transaction that:
+  - renames the Agent to an opaque `_archived_<id>` name;
+  - disables it and records `archived_at` plus its original display name;
+  - rewrites scope, Session, and task/watch definition references to the archived name;
+  - rewrites structured name snapshots embedded in scope and definition JSON;
+  - moves the global default to another enabled, visible Agent when necessary.
+- Archived Agents are excluded from normal catalog lists, including lists that include ordinary disabled Agents.
+- An Agent archived while enabled may resolve only through a persisted reference. An Agent that was already disabled stays unusable. Neither can be selected for new work, edited, enabled, or made the default.
+- Historical run and event records keep their original Agent name because they are immutable execution snapshots, not live references.
+- Built-in Agents retain their existing deletion lock.
+- User-visible rename updates the existing Agent row and the same durable references atomically; it no longer clones and deletes.
+
+## Atomicity
+
+The Agent row is updated first inside a single write transaction, followed by every live reference. Any validation or write failure rolls the entire operation back. The old public name becomes available only after all references point to the archived name.
+
+## Compatibility
+
+- The DELETE API and `vibe agent remove` command keep their existing entry points, but return archive details instead of rejecting referenced Agents.
+- Existing Sessions and scheduled definitions resolve disabled archived Agents through a reference-only resolver. Direct Agent selection continues to require an enabled, visible Agent.
+- API payloads expose the original display name for archived Agents while retaining the internal name as the reference key.
+
+## Verification
+
+1. Unit-test name reservation, catalog hiding, default reassignment, reference migration, JSON migration, and rollback.
+2. Exercise API and CLI deletion contracts against temporary SQLite state.
+3. Verify existing Session/task execution can resolve the archived Agent while direct selection cannot.
+4. Build the UI and run focused backend tests.
+5. Use the shipped CLI path to archive the local `pm` Agent only after isolated verification passes, then confirm all reference counts moved and no active/queued run was disturbed.

--- a/docs/plans/agent-archive-delete.md
+++ b/docs/plans/agent-archive-delete.md
@@ -8,7 +8,7 @@ Make Agent deletion preserve every durable reference while removing the Agent fr
 
 - User-created and imported Agent names cannot start with `_`; that namespace is reserved for Avibe internals.
 - Deleting a non-built-in Agent is one SQLite transaction that:
-  - renames the Agent to an opaque `_archived_<id>` name;
+  - renames the Agent to a short internal name such as `_pm-a1b2`;
   - disables it and records `archived_at` plus its original display name;
   - rewrites scope, Session, and task/watch definition references to the archived name;
   - rewrites nonterminal Agent Run references so queued work keeps its exact Agent configuration;

--- a/docs/plans/agent-archive-delete.md
+++ b/docs/plans/agent-archive-delete.md
@@ -26,6 +26,8 @@ The Agent row is updated first inside a single write transaction, followed by ev
 
 Definition rewrites stamp a dedicated Agent-binding revision in metadata. Full-row task/watch updates compare that marker, so a payload read before rename/archive cannot restore the old public name after the transaction commits.
 
+Agent edits, default selection, lifecycle changes, and Project route saves reserve SQLite's writer slot before reading the state they decide from. A Project may preserve its exact archived binding, but a stale or newly assigned unavailable Agent name is rejected.
+
 ## Compatibility
 
 - The DELETE API and `vibe agent remove` command keep their existing entry points, but return archive details instead of rejecting referenced Agents.

--- a/storage/alembic/versions/20260731_0043_agent_archived_at.py
+++ b/storage/alembic/versions/20260731_0043_agent_archived_at.py
@@ -1,0 +1,35 @@
+"""add explicit Agent archive state
+
+Revision ID: 20260731_0043
+Revises: 20260729_0042
+Create Date: 2026-07-31
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "20260731_0043"
+down_revision = "20260729_0042"
+branch_labels = None
+depends_on = None
+
+
+def _columns(bind, table: str) -> set[str]:
+    return {str(column["name"]) for column in sa.inspect(bind).get_columns(table)}
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    tables = set(sa.inspect(bind).get_table_names())
+    if "agents" in tables and "archived_at" not in _columns(bind, "agents"):
+        op.add_column("agents", sa.Column("archived_at", sa.String(), nullable=True))
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    tables = set(sa.inspect(bind).get_table_names())
+    if "agents" in tables and "archived_at" in _columns(bind, "agents"):
+        with op.batch_alter_table("agents") as batch_op:
+            batch_op.drop_column("archived_at")

--- a/storage/background.py
+++ b/storage/background.py
@@ -2567,8 +2567,8 @@ class SQLiteBackgroundTaskStore:
                 )
             enqueue_run_in_connection(conn, values)
 
-    def enqueue_definition_run(self, payload: dict[str, Any]) -> dict[str, Optional[str]]:
-        """Pin an existing definition run to its current Agent under one write lock."""
+    def enqueue_definition_run(self, payload: dict[str, Any]) -> dict[str, Any]:
+        """Enqueue one internally consistent snapshot of a live definition."""
 
         values = self._run_values(payload)
         definition_id = str(values.get("definition_id") or "").strip()
@@ -2577,19 +2577,61 @@ class SQLiteBackgroundTaskStore:
         with run_update_event_transaction(self.engine) as conn:
             reserve_write_lock(conn)
             definition = conn.execute(
-                select(run_definitions.c.agent_name)
+                select(
+                    run_definitions.c.agent_name,
+                    run_definitions.c.session_policy,
+                    run_definitions.c.session_id,
+                    run_definitions.c.legacy_session_key,
+                    run_definitions.c.post_to,
+                    run_definitions.c.deliver_key,
+                    run_definitions.c.prompt,
+                    run_definitions.c.message,
+                    run_definitions.c.message_payload_json,
+                    run_definitions.c.metadata_json,
+                    run_definitions.c.enabled,
+                    run_definitions.c.deleted_at,
+                )
                 .where(run_definitions.c.id == definition_id)
                 .limit(1)
             ).mappings().first()
             if definition is not None:
+                if definition["deleted_at"] is not None:
+                    raise ValueError(f"definition '{definition_id}' not found")
+                if not bool(definition["enabled"]):
+                    raise ValueError(f"definition '{definition_id}' is disabled")
+
                 current_name = str(definition["agent_name"] or "").strip() or None
                 identity = _resolve_agent_identity_by_name(conn, current_name)
-                values["agent_name"] = identity["name"] if identity else current_name
-                values["agent_id"] = identity["id"] if identity else None
+                message = definition["message"] or definition["prompt"]
+                metadata = _json_loads(definition["metadata_json"], {})
+                if not isinstance(metadata, dict):
+                    metadata = {}
+                values.update(
+                    agent_name=identity["name"] if identity else current_name,
+                    agent_id=identity["id"] if identity else None,
+                    session_policy=definition["session_policy"],
+                    session_id=definition["session_id"],
+                    legacy_session_key=definition["legacy_session_key"],
+                    post_to=definition["post_to"],
+                    deliver_key=definition["deliver_key"],
+                    prompt=definition["prompt"] or message,
+                    message=message,
+                    message_payload_json=definition["message_payload_json"],
+                    metadata_json=_json_dumps(metadata),
+                )
             enqueue_run_in_connection(conn, values)
         return {
             "agent_name": values["agent_name"],
             "agent_id": values["agent_id"],
+            "session_policy": values["session_policy"],
+            "session_id": values["session_id"],
+            "session_key": values["legacy_session_key"],
+            "post_to": values["post_to"],
+            "deliver_key": values["deliver_key"],
+            "prompt": values["prompt"],
+            "message": values["message"],
+            "message_payload": _json_loads(values["message_payload_json"], None),
+            "metadata": _json_loads(values["metadata_json"], {}),
         }
 
     def refresh_run_agent_reference(self, run_id: str) -> Optional[dict[str, Any]]:

--- a/storage/background.py
+++ b/storage/background.py
@@ -95,6 +95,26 @@ def _require_enabled_agent_identity(
         raise ValueError(f"agent '{name}' was archived, disabled, renamed, or replaced before the write")
 
 
+def _require_agent_reference_identity(
+    conn: Any,
+    *,
+    expected_agent_id: Optional[str],
+) -> dict[str, str]:
+    """Resolve an existing durable Agent reference by ID inside its write."""
+
+    agent_id = str(expected_agent_id or "").strip()
+    if not agent_id:
+        raise ValueError("an Agent identity is required for this reference write")
+    row = conn.execute(
+        select(agents.c.id, agents.c.name)
+        .where(agents.c.id == agent_id)
+        .limit(1)
+    ).mappings().first()
+    if row is None:
+        raise ValueError(f"agent reference '{agent_id}' no longer exists")
+    return {"id": str(row["id"]), "name": str(row["name"])}
+
+
 def _resolve_agent_identity_by_name(conn: Any, agent_name: Any) -> Optional[dict[str, str]]:
     """Resolve legacy spelling to the catalog's canonical durable identity."""
 
@@ -2306,6 +2326,7 @@ class SQLiteBackgroundTaskStore:
         *,
         expect: DefinitionWriteExpectation | None = None,
         expected_enabled_agent_id: Optional[str] = None,
+        expected_reference_agent_id: Optional[str] = None,
     ) -> bool:
         """Write a whole scheduled-task row. ``False`` means the write was REFUSED.
 
@@ -2320,6 +2341,7 @@ class SQLiteBackgroundTaskStore:
             expect=expect,
             definition_type="scheduled task",
             expected_enabled_agent_id=expected_enabled_agent_id,
+            expected_reference_agent_id=expected_reference_agent_id,
         )
 
     def upsert_scheduled_task_with_binding_notice(
@@ -2470,6 +2492,7 @@ class SQLiteBackgroundTaskStore:
         *,
         expect: DefinitionWriteExpectation | None = None,
         expected_enabled_agent_id: Optional[str] = None,
+        expected_reference_agent_id: Optional[str] = None,
     ) -> bool:
         """Write a whole watch row. ``False`` means the write was REFUSED.
 
@@ -2483,6 +2506,7 @@ class SQLiteBackgroundTaskStore:
             expect=expect,
             definition_type="watch",
             expected_enabled_agent_id=expected_enabled_agent_id,
+            expected_reference_agent_id=expected_reference_agent_id,
         )
 
     def _upsert_definition(
@@ -2492,17 +2516,25 @@ class SQLiteBackgroundTaskStore:
         expect: DefinitionWriteExpectation | None,
         definition_type: str,
         expected_enabled_agent_id: Optional[str] = None,
+        expected_reference_agent_id: Optional[str] = None,
     ) -> bool:
         """The one full-row ``run_definitions`` write, guarded once for both types."""
 
         with self.engine.begin() as conn:
-            if expected_enabled_agent_id is not None:
+            if expected_enabled_agent_id is not None or expected_reference_agent_id is not None:
                 reserve_write_lock(conn)
+            if expected_enabled_agent_id is not None:
                 _require_enabled_agent_identity(
                     conn,
                     agent_name=values.get("agent_name"),
                     expected_agent_id=expected_enabled_agent_id,
                 )
+            elif expected_reference_agent_id is not None:
+                identity = _require_agent_reference_identity(
+                    conn,
+                    expected_agent_id=expected_reference_agent_id,
+                )
+                values["agent_name"] = identity["name"]
             return upsert_definition_in_connection(
                 conn, values, expect=expect, definition_type=definition_type
             )
@@ -2555,16 +2587,25 @@ class SQLiteBackgroundTaskStore:
         payload: dict[str, Any],
         *,
         expected_enabled_agent_id: Optional[str] = None,
+        expected_reference_agent_id: Optional[str] = None,
     ) -> None:
         values = self._run_values(payload)
         with run_update_event_transaction(self.engine) as conn:
-            if expected_enabled_agent_id is not None:
+            if expected_enabled_agent_id is not None or expected_reference_agent_id is not None:
                 reserve_write_lock(conn)
+            if expected_enabled_agent_id is not None:
                 _require_enabled_agent_identity(
                     conn,
                     agent_name=values.get("agent_name"),
                     expected_agent_id=expected_enabled_agent_id,
                 )
+            elif expected_reference_agent_id is not None:
+                identity = _require_agent_reference_identity(
+                    conn,
+                    expected_agent_id=expected_reference_agent_id,
+                )
+                values["agent_id"] = identity["id"]
+                values["agent_name"] = identity["name"]
             enqueue_run_in_connection(conn, values)
 
     def enqueue_definition_run(self, payload: dict[str, Any]) -> dict[str, Any]:

--- a/storage/background.py
+++ b/storage/background.py
@@ -43,7 +43,7 @@ from storage.migrations import (
     guard_source_checkout_default_state_migration,
     initialize_background_tables,
 )
-from storage.models import agent_runs, agent_sessions, messages, run_definitions, scopes
+from storage.models import agents, agent_runs, agent_sessions, messages, run_definitions, scopes
 from storage.pagination import PageRequest, PageResult, page_result_from_limit_plus_one
 from storage.sqlite_semantics import sqlite_cast_integer
 from storage.session_reclaim import (
@@ -69,6 +69,30 @@ def _json_loads(value: Optional[str], default: Any) -> Any:
 
 def _utc_now_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
+
+
+def _require_enabled_agent_identity(
+    conn: Any,
+    *,
+    agent_name: Optional[str],
+    expected_agent_id: Optional[str],
+) -> None:
+    """Validate one direct Agent selection inside its durable write transaction."""
+
+    name = str(agent_name or "").strip()
+    agent_id = str(expected_agent_id or "").strip()
+    if not name or not agent_id:
+        raise ValueError("an enabled Agent identity is required for this write")
+    row = conn.execute(
+        select(agents.c.id)
+        .where(agents.c.id == agent_id)
+        .where(agents.c.name == name)
+        .where(agents.c.enabled == 1)
+        .where(agents.c.archived_at.is_(None))
+        .limit(1)
+    ).first()
+    if row is None:
+        raise ValueError(f"agent '{name}' was archived, disabled, renamed, or replaced before the write")
 
 
 def resolve_run_at(run_at: str, timezone_name: Optional[str]) -> datetime:
@@ -2255,7 +2279,11 @@ class SQLiteBackgroundTaskStore:
             )[0]
 
     def upsert_scheduled_task(
-        self, payload: dict[str, Any], *, expect: DefinitionWriteExpectation | None = None
+        self,
+        payload: dict[str, Any],
+        *,
+        expect: DefinitionWriteExpectation | None = None,
+        expected_enabled_agent_id: Optional[str] = None,
     ) -> bool:
         """Write a whole scheduled-task row. ``False`` means the write was REFUSED.
 
@@ -2266,7 +2294,10 @@ class SQLiteBackgroundTaskStore:
         """
 
         return self._upsert_definition(
-            self._scheduled_task_values(payload), expect=expect, definition_type="scheduled task"
+            self._scheduled_task_values(payload),
+            expect=expect,
+            definition_type="scheduled task",
+            expected_enabled_agent_id=expected_enabled_agent_id,
         )
 
     def upsert_scheduled_task_with_binding_notice(
@@ -2412,7 +2443,11 @@ class SQLiteBackgroundTaskStore:
             return self._enrich_definitions([self._watch_from_row(row)], conn, definition_type="watch")[0]
 
     def upsert_watch(
-        self, payload: dict[str, Any], *, expect: DefinitionWriteExpectation | None = None
+        self,
+        payload: dict[str, Any],
+        *,
+        expect: DefinitionWriteExpectation | None = None,
+        expected_enabled_agent_id: Optional[str] = None,
     ) -> bool:
         """Write a whole watch row. ``False`` means the write was REFUSED.
 
@@ -2422,7 +2457,10 @@ class SQLiteBackgroundTaskStore:
         """
 
         return self._upsert_definition(
-            self._watch_values(payload), expect=expect, definition_type="watch"
+            self._watch_values(payload),
+            expect=expect,
+            definition_type="watch",
+            expected_enabled_agent_id=expected_enabled_agent_id,
         )
 
     def _upsert_definition(
@@ -2431,10 +2469,18 @@ class SQLiteBackgroundTaskStore:
         *,
         expect: DefinitionWriteExpectation | None,
         definition_type: str,
+        expected_enabled_agent_id: Optional[str] = None,
     ) -> bool:
         """The one full-row ``run_definitions`` write, guarded once for both types."""
 
         with self.engine.begin() as conn:
+            if expected_enabled_agent_id is not None:
+                reserve_write_lock(conn)
+                _require_enabled_agent_identity(
+                    conn,
+                    agent_name=values.get("agent_name"),
+                    expected_agent_id=expected_enabled_agent_id,
+                )
             return upsert_definition_in_connection(
                 conn, values, expect=expect, definition_type=definition_type
             )
@@ -2482,10 +2528,70 @@ class SQLiteBackgroundTaskStore:
             enqueue_run_in_connection(conn, run_values)
         return True
 
-    def enqueue_run(self, payload: dict[str, Any]) -> None:
+    def enqueue_run(
+        self,
+        payload: dict[str, Any],
+        *,
+        expected_enabled_agent_id: Optional[str] = None,
+    ) -> None:
         values = self._run_values(payload)
         with run_update_event_transaction(self.engine) as conn:
+            if expected_enabled_agent_id is not None:
+                reserve_write_lock(conn)
+                _require_enabled_agent_identity(
+                    conn,
+                    agent_name=values.get("agent_name"),
+                    expected_agent_id=expected_enabled_agent_id,
+                )
             enqueue_run_in_connection(conn, values)
+
+    def refresh_run_agent_reference(self, run_id: str) -> Optional[dict[str, Any]]:
+        """Pin a claimed run to an Agent id while serialized with archive/rename."""
+
+        cleaned_run_id = str(run_id or "").strip()
+        if not cleaned_run_id:
+            return None
+        with run_update_event_transaction(self.engine) as conn:
+            reserve_write_lock(conn)
+            run = conn.execute(
+                select(agent_runs.c.agent_id, agent_runs.c.agent_name)
+                .where(agent_runs.c.id == cleaned_run_id)
+                .limit(1)
+            ).mappings().first()
+            if run is None:
+                return None
+            agent_id = str(run["agent_id"] or "").strip()
+            agent_name = str(run["agent_name"] or "").strip()
+            agent = None
+            if agent_id:
+                agent = conn.execute(
+                    select(agents.c.id, agents.c.name)
+                    .where(agents.c.id == agent_id)
+                    .limit(1)
+                ).mappings().first()
+            elif agent_name:
+                agent = conn.execute(
+                    select(agents.c.id, agents.c.name)
+                    .where(
+                        or_(
+                            agents.c.name == agent_name,
+                            agents.c.normalized_name == agent_name,
+                        )
+                    )
+                    .limit(1)
+                ).mappings().first()
+            if agent is None:
+                return {"agent_id": agent_id or None, "agent_name": agent_name or None}
+            canonical_id = str(agent["id"])
+            canonical_name = str(agent["name"])
+            if canonical_id != agent_id or canonical_name != agent_name:
+                conn.execute(
+                    update(agent_runs)
+                    .where(agent_runs.c.id == cleaned_run_id)
+                    .values(agent_id=canonical_id, agent_name=canonical_name)
+                )
+                _defer_run_ids_updated_from_connection(conn, [cleaned_run_id])
+            return {"agent_id": canonical_id, "agent_name": canonical_name}
 
     def list_runs(self, *, status: Optional[str] = None) -> list[dict[str, Any]]:
         stmt = self._runs_query(status=status).order_by(agent_runs.c.created_at, agent_runs.c.id)

--- a/storage/background.py
+++ b/storage/background.py
@@ -46,7 +46,10 @@ from storage.migrations import (
 from storage.models import agent_runs, agent_sessions, messages, run_definitions, scopes
 from storage.pagination import PageRequest, PageResult, page_result_from_limit_plus_one
 from storage.sqlite_semantics import sqlite_cast_integer
-from storage.session_reclaim import SESSION_SETTINGS_SNAPSHOT_KEY
+from storage.session_reclaim import (
+    DEFINITION_AGENT_BINDING_REVISION_KEY,
+    SESSION_SETTINGS_SNAPSHOT_KEY,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -260,6 +263,10 @@ class DefinitionWriteExpectation:
       snapshot is what a later ``create_once`` rebind reads to carry the old
       workdir / agent / model forward, so restoring the pre-teardown metadata sends
       the task back on the wrong route (D3) with every other guard satisfied.
+    * the Agent binding revision -- rename/archive stamps this dedicated marker
+      whenever it rewrites either the direct Agent or the reclaim snapshot. It
+      catches stale pre-rewrite payloads without treating ordinary internal
+      rebinds or run-result stamps as conflicts.
 
     DELIBERATELY NOT ``updated_at``, and not the whole row. A row-version guard
     would refuse every benign concurrent write -- a run result landing while the
@@ -274,6 +281,7 @@ class DefinitionWriteExpectation:
     #: ``session_settings_snapshot.captured_at`` as read, ``None``/"" when the
     #: definition carried no reclaim snapshot.
     snapshot_captured_at: Optional[str] = None
+    agent_binding_revision: Optional[str] = None
 
     @classmethod
     def from_read(
@@ -291,6 +299,7 @@ class DefinitionWriteExpectation:
             enabled=bool(enabled),
             deleted_at=str(deleted_at) if deleted_at else None,
             snapshot_captured_at=reclaim_snapshot_marker(metadata),
+            agent_binding_revision=definition_agent_binding_revision(metadata),
         )
 
 
@@ -311,6 +320,15 @@ def reclaim_snapshot_marker(metadata: Any) -> Optional[str]:
     return str(captured_at) if captured_at else None
 
 
+def definition_agent_binding_revision(metadata: Any) -> Optional[str]:
+    """Rename/archive revision carried by definition metadata, if present."""
+
+    if not isinstance(metadata, dict):
+        return None
+    revision = metadata.get(DEFINITION_AGENT_BINDING_REVISION_KEY)
+    return str(revision) if revision else None
+
+
 #: ``captured_at`` of the reclaim snapshot, read in SQL. Guarded by ``json_valid``
 #: because ``metadata_json`` is user-visible text on legacy rows: a bare
 #: ``json_extract`` over a malformed blob raises, which would turn "this row has no
@@ -321,6 +339,17 @@ _RECLAIM_SNAPSHOT_MARKER_SQL = case(
         func.json_extract(
             run_definitions.c.metadata_json,
             f"$.{SESSION_SETTINGS_SNAPSHOT_KEY}.captured_at",
+        ),
+    ),
+    else_=None,
+)
+
+_AGENT_BINDING_REVISION_SQL = case(
+    (
+        func.json_valid(run_definitions.c.metadata_json) == 1,
+        func.json_extract(
+            run_definitions.c.metadata_json,
+            f"$.{DEFINITION_AGENT_BINDING_REVISION_KEY}",
         ),
     ),
     else_=None,
@@ -342,6 +371,7 @@ def definition_state_unchanged(expect: DefinitionWriteExpectation) -> list[Any]:
         run_definitions.c.enabled == (1 if expect.enabled else 0),
         unchanged_text(run_definitions.c.deleted_at, expect.deleted_at),
         unchanged_text(_RECLAIM_SNAPSHOT_MARKER_SQL, expect.snapshot_captured_at),
+        unchanged_text(_AGENT_BINDING_REVISION_SQL, expect.agent_binding_revision),
     ]
 
 
@@ -2114,7 +2144,8 @@ def upsert_definition_in_connection(
     # best-effort runtime stamp).
     logger.warning(
         "Refused a stale full-row write for %s %s: its Session binding, enabled "
-        "state, deletion or reclaim snapshot changed after the payload was read",
+        "state, deletion, reclaim snapshot or Agent binding revision changed after "
+        "the payload was read",
         definition_type,
         values["id"],
     )

--- a/storage/background.py
+++ b/storage/background.py
@@ -95,6 +95,28 @@ def _require_enabled_agent_identity(
         raise ValueError(f"agent '{name}' was archived, disabled, renamed, or replaced before the write")
 
 
+def _resolve_agent_identity_by_name(conn: Any, agent_name: Any) -> Optional[dict[str, str]]:
+    """Resolve legacy spelling to the catalog's canonical durable identity."""
+
+    cleaned_name = str(agent_name or "").strip()
+    if not cleaned_name:
+        return None
+    from core.vibe_agents import normalize_agent_name
+
+    try:
+        normalized_name = normalize_agent_name(cleaned_name)
+    except ValueError:
+        return None
+    row = conn.execute(
+        select(agents.c.id, agents.c.name)
+        .where(agents.c.normalized_name == normalized_name)
+        .limit(1)
+    ).mappings().first()
+    if row is None:
+        return None
+    return {"id": str(row["id"]), "name": str(row["name"])}
+
+
 def resolve_run_at(run_at: str, timezone_name: Optional[str]) -> datetime:
     """The instant a one-shot ``run_at`` names, in the task's own timezone.
 
@@ -2545,6 +2567,31 @@ class SQLiteBackgroundTaskStore:
                 )
             enqueue_run_in_connection(conn, values)
 
+    def enqueue_definition_run(self, payload: dict[str, Any]) -> dict[str, Optional[str]]:
+        """Pin an existing definition run to its current Agent under one write lock."""
+
+        values = self._run_values(payload)
+        definition_id = str(values.get("definition_id") or "").strip()
+        if not definition_id:
+            raise ValueError("definition id is required")
+        with run_update_event_transaction(self.engine) as conn:
+            reserve_write_lock(conn)
+            definition = conn.execute(
+                select(run_definitions.c.agent_name)
+                .where(run_definitions.c.id == definition_id)
+                .limit(1)
+            ).mappings().first()
+            if definition is not None:
+                current_name = str(definition["agent_name"] or "").strip() or None
+                identity = _resolve_agent_identity_by_name(conn, current_name)
+                values["agent_name"] = identity["name"] if identity else current_name
+                values["agent_id"] = identity["id"] if identity else None
+            enqueue_run_in_connection(conn, values)
+        return {
+            "agent_name": values["agent_name"],
+            "agent_id": values["agent_id"],
+        }
+
     def refresh_run_agent_reference(self, run_id: str) -> Optional[dict[str, Any]]:
         """Pin a claimed run to an Agent id while serialized with archive/rename."""
 
@@ -2570,16 +2617,7 @@ class SQLiteBackgroundTaskStore:
                     .limit(1)
                 ).mappings().first()
             elif agent_name:
-                agent = conn.execute(
-                    select(agents.c.id, agents.c.name)
-                    .where(
-                        or_(
-                            agents.c.name == agent_name,
-                            agents.c.normalized_name == agent_name,
-                        )
-                    )
-                    .limit(1)
-                ).mappings().first()
+                agent = _resolve_agent_identity_by_name(conn, agent_name)
             if agent is None:
                 return {"agent_id": agent_id or None, "agent_name": agent_name or None}
             canonical_id = str(agent["id"])

--- a/storage/background.py
+++ b/storage/background.py
@@ -106,12 +106,26 @@ def _require_agent_reference_identity(
     if not agent_id:
         raise ValueError("an Agent identity is required for this reference write")
     row = conn.execute(
-        select(agents.c.id, agents.c.name)
+        select(
+            agents.c.id,
+            agents.c.name,
+            agents.c.enabled,
+            agents.c.archived_at,
+            agents.c.metadata_json,
+        )
         .where(agents.c.id == agent_id)
         .limit(1)
     ).mappings().first()
     if row is None:
         raise ValueError(f"agent reference '{agent_id}' no longer exists")
+    from core.vibe_agents import agent_reference_is_usable
+
+    if not agent_reference_is_usable(
+        enabled=bool(row["enabled"]),
+        archived_at=row["archived_at"],
+        metadata=_json_loads(row["metadata_json"], {}),
+    ):
+        raise ValueError(f"agent reference '{row['name']}' is disabled")
     return {"id": str(row["id"]), "name": str(row["name"])}
 
 

--- a/storage/messages_service.py
+++ b/storage/messages_service.py
@@ -25,11 +25,13 @@ from storage.db import escape_sql_like
 from storage.models import (
     agent_runs,
     agent_sessions,
+    agents,
     messages,
     scope_settings,
     scopes,
 )
 from storage.pagination import PageRequest, PageResult, page_result_from_limit_plus_one
+from storage.sessions_service import session_agent_display_label
 from vibe.message_identity import HARNESS_TYPE, INPUT_TURN_AUTHOR_TYPES
 from vibe.message_types import types_with, types_without
 
@@ -185,11 +187,35 @@ def _attach_agent_run_provenance(
 
     meta_by_session: dict[str, dict[str, Optional[str]]] = {}
     for row in conn.execute(
-        select(agent_sessions.c.id, agent_sessions.c.title, agent_sessions.c.agent_name).where(
+        select(
+            agent_sessions.c.id,
+            agent_sessions.c.title,
+            agent_sessions.c.agent_name,
+            agent_sessions.c.agent_backend,
+            agents.c.name.label("catalog_agent_name"),
+            agents.c.archived_at.label("catalog_agent_archived_at"),
+            agents.c.metadata_json.label("catalog_agent_metadata_json"),
+        )
+        .select_from(
+            agent_sessions.outerjoin(
+                agents,
+                or_(
+                    agents.c.id == agent_sessions.c.agent_id,
+                    and_(
+                        agent_sessions.c.agent_id.is_(None),
+                        agents.c.name == agent_sessions.c.agent_name,
+                    ),
+                ),
+            )
+        )
+        .where(
             agent_sessions.c.id.in_(set(source_by_exec.values()))
         )
     ).mappings():
-        meta_by_session[row["id"]] = {"title": row["title"], "agent_name": row["agent_name"]}
+        meta_by_session[row["id"]] = {
+            "title": row["title"],
+            "agent_name": session_agent_display_label(row),
+        }
 
     for payload in payloads:
         source_id = source_by_exec.get(exec_by_msg.get(payload["id"], ""))

--- a/storage/migrations.py
+++ b/storage/migrations.py
@@ -595,6 +595,7 @@ def _ensure_agents_table(conn: sqlite3.Connection, tables: set[str]) -> bool:
             source varchar not null,
             source_ref text,
             metadata_json text not null,
+            archived_at varchar,
             created_at varchar not null,
             updated_at varchar not null,
             constraint uq_agents_normalized_name unique (normalized_name)
@@ -612,6 +613,9 @@ def _repair_initial_required_columns(conn: sqlite3.Connection, tables: set[str])
         columns = _column_names(conn, "agents")
         if "enabled" not in columns:
             conn.execute('alter table "agents" add column "enabled" INTEGER not null default 1')
+            changed = True
+        if "archived_at" not in columns:
+            conn.execute('alter table "agents" add column "archived_at" VARCHAR')
             changed = True
     if "scope_settings" in tables:
         columns = _column_names(conn, "scope_settings")

--- a/storage/models.py
+++ b/storage/models.py
@@ -44,6 +44,7 @@ agents = Table(
     Column("source", String, nullable=False),
     Column("source_ref", Text, nullable=True),
     Column("metadata_json", Text, nullable=False),
+    Column("archived_at", String, nullable=True),
     Column("created_at", String, nullable=False),
     Column("updated_at", String, nullable=False),
     UniqueConstraint("normalized_name", name="uq_agents_normalized_name"),

--- a/storage/projects_service.py
+++ b/storage/projects_service.py
@@ -336,9 +336,15 @@ def update_project(
     if agent_name is not _UNSET:
         requested_agent = str(agent_name or "").strip() or None
         if requested_agent is not None and requested_agent != current_agent_name:
+            from core.vibe_agents import normalize_agent_name
+
+            try:
+                normalized_agent = normalize_agent_name(requested_agent)
+            except ValueError as exc:
+                raise ValueError(f"Agent is unavailable: {requested_agent}") from exc
             available_agent = conn.execute(
                 select(agents.c.name)
-                .where(agents.c.name == requested_agent)
+                .where(agents.c.normalized_name == normalized_agent)
                 .where(agents.c.enabled == 1)
                 .where(agents.c.archived_at.is_(None))
                 .limit(1)

--- a/storage/projects_service.py
+++ b/storage/projects_service.py
@@ -104,6 +104,27 @@ _UNSET: Any = object()
 # project inherit it; see ``workbench_sessions_service.create_session``.
 _DEFAULT_AGENT_FIELDS = ("agent_name", "agent_variant", "model", "reasoning_effort")
 
+
+class StaleProjectAgentBindingError(ValueError):
+    """The project route changed after the caller loaded it."""
+
+    code = "project_agent_conflict"
+
+    def __init__(
+        self,
+        *,
+        project_id: str,
+        expected_agent_id: str | None,
+        current_agent_id: str | None,
+    ) -> None:
+        super().__init__(self.code)
+        self.details = {
+            "project_id": project_id,
+            "expected_agent_id": expected_agent_id,
+            "current_agent_id": current_agent_id,
+        }
+
+
 # Single source of truth for the columns every project payload reads, so
 # ``list_projects`` and ``_project_payload`` can never select different shapes.
 _PROJECT_COLUMNS = (
@@ -116,6 +137,7 @@ _PROJECT_COLUMNS = (
     scope_settings.c.enabled,
     scope_settings.c.workdir,
     scope_settings.c.agent_name,
+    agents.c.id.label("agent_id"),
     agents.c.backend.label("agent_backend"),
     scope_settings.c.agent_variant,
     scope_settings.c.model,
@@ -133,6 +155,7 @@ def _default_agent_from_row(row: Any) -> Optional[dict[str, Any]]:
     if not agent_name:
         return None
     payload = {field: row[field] for field in _DEFAULT_AGENT_FIELDS}
+    payload["agent_id"] = row["agent_id"]
     payload["agent_backend"] = row["agent_backend"]
     return payload
 
@@ -296,6 +319,8 @@ def update_project(
     *,
     display_name: Optional[str] = None,
     folder_path: Optional[str] = None,
+    agent_id: Any = _UNSET,
+    expected_agent_id: Any = _UNSET,
     agent_name: Any = _UNSET,
     agent_variant: Any = _UNSET,
     model: Any = _UNSET,
@@ -314,9 +339,24 @@ def update_project(
     existing = conn.execute(select(scopes.c.id).where(scopes.c.id == scope_id)).scalar_one_or_none()
     if existing is None:
         raise LookupError(f"Project not found: {project_id}")
-    current_agent_name = conn.execute(
-        select(scope_settings.c.agent_name).where(scope_settings.c.scope_id == scope_id)
-    ).scalar_one_or_none()
+    current_agent = conn.execute(
+        select(scope_settings.c.agent_name, agents.c.id.label("agent_id"))
+        .select_from(
+            scope_settings.outerjoin(agents, agents.c.name == scope_settings.c.agent_name)
+        )
+        .where(scope_settings.c.scope_id == scope_id)
+    ).mappings().first()
+    current_agent_name = current_agent["agent_name"] if current_agent is not None else None
+    current_agent_id = current_agent["agent_id"] if current_agent is not None else None
+
+    if expected_agent_id is not _UNSET:
+        cleaned_expected_id = str(expected_agent_id or "").strip() or None
+        if cleaned_expected_id != current_agent_id:
+            raise StaleProjectAgentBindingError(
+                project_id=project_id,
+                expected_agent_id=cleaned_expected_id,
+                current_agent_id=current_agent_id,
+            )
 
     now = _utc_now_iso()
     if display_name is not None:
@@ -333,7 +373,22 @@ def update_project(
     settings_values: dict[str, Any] = {}
     if folder_path is not None:
         settings_values["workdir"] = str(_resolve_folder(folder_path))
-    if agent_name is not _UNSET:
+    if agent_id is not _UNSET and str(agent_id or "").strip():
+        cleaned_agent_id = str(agent_id).strip()
+        selected_agent = conn.execute(
+            select(agents.c.id, agents.c.name, agents.c.enabled, agents.c.archived_at)
+            .where(agents.c.id == cleaned_agent_id)
+            .limit(1)
+        ).mappings().first()
+        if selected_agent is None:
+            raise ValueError(f"Agent is unavailable: {cleaned_agent_id}")
+        preserves_current_identity = cleaned_agent_id == current_agent_id
+        if not preserves_current_identity and (
+            not bool(selected_agent["enabled"]) or selected_agent["archived_at"] is not None
+        ):
+            raise ValueError(f"Agent is unavailable: {selected_agent['name']}")
+        agent_name = selected_agent["name"]
+    elif agent_name is not _UNSET:
         requested_agent = str(agent_name or "").strip() or None
         if requested_agent is not None and requested_agent != current_agent_name:
             from core.vibe_agents import normalize_agent_name

--- a/storage/projects_service.py
+++ b/storage/projects_service.py
@@ -21,6 +21,7 @@ from typing import Any, Optional
 from sqlalchemy import select, update
 from sqlalchemy.engine import Connection
 
+from storage.agent_session_rows import reserve_write_lock
 from storage.models import agents, scope_settings, scopes
 
 
@@ -308,10 +309,14 @@ def update_project(
     by sending ``None``s. Empty strings normalize to ``None`` so an empty pick
     clears too.
     """
+    reserve_write_lock(conn)
     scope_id = _make_scope_id(project_id)
     existing = conn.execute(select(scopes.c.id).where(scopes.c.id == scope_id)).scalar_one_or_none()
     if existing is None:
         raise LookupError(f"Project not found: {project_id}")
+    current_agent_name = conn.execute(
+        select(scope_settings.c.agent_name).where(scope_settings.c.scope_id == scope_id)
+    ).scalar_one_or_none()
 
     now = _utc_now_iso()
     if display_name is not None:
@@ -328,6 +333,19 @@ def update_project(
     settings_values: dict[str, Any] = {}
     if folder_path is not None:
         settings_values["workdir"] = str(_resolve_folder(folder_path))
+    if agent_name is not _UNSET:
+        requested_agent = str(agent_name or "").strip() or None
+        if requested_agent is not None and requested_agent != current_agent_name:
+            available_agent = conn.execute(
+                select(agents.c.name)
+                .where(agents.c.name == requested_agent)
+                .where(agents.c.enabled == 1)
+                .where(agents.c.archived_at.is_(None))
+                .limit(1)
+            ).scalar_one_or_none()
+            if available_agent is None:
+                raise ValueError(f"Agent is unavailable: {requested_agent}")
+            agent_name = available_agent
     for field_name, value in (
         ("agent_name", agent_name),
         ("agent_variant", agent_variant),

--- a/storage/projects_service.py
+++ b/storage/projects_service.py
@@ -125,6 +125,16 @@ class StaleProjectAgentBindingError(ValueError):
         }
 
 
+class ProjectAgentUnavailableError(ValueError):
+    """The requested Agent cannot be selected for a new project route."""
+
+    code = "project_agent_unavailable"
+
+    def __init__(self, *, agent_name: str) -> None:
+        super().__init__(self.code)
+        self.agent_name = agent_name
+
+
 # Single source of truth for the columns every project payload reads, so
 # ``list_projects`` and ``_project_payload`` can never select different shapes.
 _PROJECT_COLUMNS = (
@@ -381,12 +391,12 @@ def update_project(
             .limit(1)
         ).mappings().first()
         if selected_agent is None:
-            raise ValueError(f"Agent is unavailable: {cleaned_agent_id}")
+            raise ProjectAgentUnavailableError(agent_name=cleaned_agent_id)
         preserves_current_identity = cleaned_agent_id == current_agent_id
         if not preserves_current_identity and (
             not bool(selected_agent["enabled"]) or selected_agent["archived_at"] is not None
         ):
-            raise ValueError(f"Agent is unavailable: {selected_agent['name']}")
+            raise ProjectAgentUnavailableError(agent_name=selected_agent["name"])
         agent_name = selected_agent["name"]
     elif agent_name is not _UNSET:
         requested_agent = str(agent_name or "").strip() or None
@@ -396,7 +406,7 @@ def update_project(
             try:
                 normalized_agent = normalize_agent_name(requested_agent)
             except ValueError as exc:
-                raise ValueError(f"Agent is unavailable: {requested_agent}") from exc
+                raise ProjectAgentUnavailableError(agent_name=requested_agent) from exc
             available_agent = conn.execute(
                 select(agents.c.name)
                 .where(agents.c.normalized_name == normalized_agent)
@@ -405,7 +415,7 @@ def update_project(
                 .limit(1)
             ).scalar_one_or_none()
             if available_agent is None:
-                raise ValueError(f"Agent is unavailable: {requested_agent}")
+                raise ProjectAgentUnavailableError(agent_name=requested_agent)
             agent_name = available_agent
     for field_name, value in (
         ("agent_name", agent_name),

--- a/storage/session_reclaim.py
+++ b/storage/session_reclaim.py
@@ -47,6 +47,10 @@ ReclaimMode = Literal["delete", "pause"]
 #: workdir / agent / model forward instead of resetting to scope defaults.
 SESSION_SETTINGS_SNAPSHOT_KEY = "session_settings_snapshot"
 
+#: Compare-and-set marker stamped when Agent rename/archive rewrites a
+#: definition's direct or snapshotted Agent reference.
+DEFINITION_AGENT_BINDING_REVISION_KEY = "_avibe_agent_binding_revision"
+
 #: Durable SESSION-metadata key listing the settings this session pins
 #: EXPLICITLY, so a stored NULL can be told apart from an absent value.
 #:

--- a/storage/sessions_service.py
+++ b/storage/sessions_service.py
@@ -116,7 +116,7 @@ def _set_native_once(conn: Connection, row_id: str, encoded_session_id: str) -> 
 _BACKEND_LABELS = {"claude": "Claude", "codex": "Codex", "opencode": "OpenCode"}
 
 
-def _session_agent_display_label(row: Mapping[str, Any]) -> str | None:
+def session_agent_display_label(row: Mapping[str, Any]) -> str | None:
     agent_name = str(row["agent_name"] or "").strip()
     catalog_name = str(row["catalog_agent_name"] or "").strip()
     if row["catalog_agent_archived_at"]:
@@ -187,7 +187,7 @@ def read_session_display_meta(
     for row in rows:
         title = str(row["title"] or "").strip() or None
         platform = str(row["platform"] or "").strip() or None
-        agent = _session_agent_display_label(row)
+        agent = session_agent_display_label(row)
         meta[str(row["id"])] = {"title": title, "platform": platform, "agent": agent}
     return meta
 

--- a/storage/sessions_service.py
+++ b/storage/sessions_service.py
@@ -78,6 +78,18 @@ def _require_enabled_agent_identity(
         )
 
 
+def _catalog_agent_name_value(agent_id: str | None, fallback_name: str) -> Any:
+    """Resolve an Agent's current routing name in the statement that persists it."""
+
+    cleaned_id = str(agent_id or "").strip()
+    if not cleaned_id:
+        return fallback_name
+    return func.coalesce(
+        select(agents.c.name).where(agents.c.id == cleaned_id).limit(1).scalar_subquery(),
+        fallback_name,
+    )
+
+
 def _set_native_once(conn: Connection, row_id: str, encoded_session_id: str) -> bool:
     """Return True iff a row's ``native_session_id`` should be written now.
 
@@ -590,6 +602,11 @@ class SQLiteSessionsService:
     ) -> str | None:
         """Bind a backend-native session id to the stable Vibe session row."""
         now = _utc_now_iso()
+        persisted_agent_name = (
+            _catalog_agent_name_value(vibe_agent_id, vibe_agent_name)
+            if vibe_agent_name is not None
+            else None
+        )
         with self.engine.begin() as conn:
             scope_id = resolve_scope_from_legacy_key(conn, str(scope_key), now=now)
             if scope_id is None:
@@ -616,7 +633,7 @@ class SQLiteSessionsService:
                     native_session_id=encoded_session_id,
                     workdir=requested_workdir,
                     agent_id=vibe_agent_id,
-                    agent_name=vibe_agent_name,
+                    agent_name=persisted_agent_name,
                     model=None,
                     reasoning_effort=None,
                     metadata={"legacy_scope_key": str(scope_key)},
@@ -655,7 +672,14 @@ class SQLiteSessionsService:
             if vibe_agent_id is not None:
                 values["agent_id"] = vibe_agent_id
             if vibe_agent_name is not None:
-                values["agent_name"] = vibe_agent_name
+                values["agent_name"] = (
+                    case(
+                        (agent_sessions.c.agent_id == vibe_agent_id, agent_sessions.c.agent_name),
+                        else_=persisted_agent_name,
+                    )
+                    if vibe_agent_id is not None
+                    else persisted_agent_name
+                )
             # WRITE-ONCE: a row's native_session_id is bound exactly once and never
             # changed. Never let a recapture, fork, subagent, or any fallback
             # overwrite an existing native (product invariant — one agent session ↔
@@ -786,7 +810,15 @@ class SQLiteSessionsService:
         if vibe_agent_id is not None:
             values["agent_id"] = vibe_agent_id
         if vibe_agent_name is not None:
-            values["agent_name"] = vibe_agent_name
+            persisted_agent_name = _catalog_agent_name_value(vibe_agent_id, vibe_agent_name)
+            values["agent_name"] = (
+                case(
+                    (agent_sessions.c.agent_id == vibe_agent_id, agent_sessions.c.agent_name),
+                    else_=persisted_agent_name,
+                )
+                if vibe_agent_id is not None
+                else persisted_agent_name
+            )
         requested_backend = (
             str(vibe_agent_backend or "") if vibe_agent_backend is not None else None
         )

--- a/storage/sessions_service.py
+++ b/storage/sessions_service.py
@@ -54,6 +54,30 @@ SESSION_ID_ALPHABET = "23456789abcdefghjkmnpqrstuvwxyz"
 logger = logging.getLogger(__name__)
 
 
+def _require_enabled_agent_identity(
+    conn: Connection,
+    *,
+    agent_id: str | None,
+    agent_name: str | None,
+) -> None:
+    cleaned_id = str(agent_id or "").strip()
+    cleaned_name = str(agent_name or "").strip()
+    if not cleaned_id or not cleaned_name:
+        raise ValueError("an enabled Agent identity is required for this session")
+    row = conn.execute(
+        select(agents.c.id)
+        .where(agents.c.id == cleaned_id)
+        .where(agents.c.name == cleaned_name)
+        .where(agents.c.enabled == 1)
+        .where(agents.c.archived_at.is_(None))
+        .limit(1)
+    ).first()
+    if row is None:
+        raise ValueError(
+            f"agent '{cleaned_name}' was archived, disabled, renamed, or replaced before session creation"
+        )
+
+
 def _set_native_once(conn: Connection, row_id: str, encoded_session_id: str) -> bool:
     """Return True iff a row's ``native_session_id`` should be written now.
 
@@ -196,10 +220,18 @@ class SQLiteSessionsService:
         workdir: str | None = None,
         visibility: str = "foreground",
         metadata: dict[str, Any] | None = None,
+        require_enabled_agent: bool = False,
     ) -> str | None:
         now = _utc_now_iso()
         backend = str(agent_backend or "default")
         with self.engine.begin() as conn:
+            if require_enabled_agent:
+                reserve_write_lock(conn)
+                _require_enabled_agent_identity(
+                    conn,
+                    agent_id=agent_id,
+                    agent_name=agent_name,
+                )
             scope_id = resolve_scope_from_legacy_key(conn, str(scope_key), now=now)
             if scope_id is None:
                 return None
@@ -233,11 +265,19 @@ class SQLiteSessionsService:
         workdir: str | None = None,
         visibility: str = "background",
         metadata: dict[str, Any] | None = None,
+        require_enabled_agent: bool = False,
     ) -> str:
         """Reserve a session with no Scope and its own lazy Show workspace."""
         now = _utc_now_iso()
         backend = str(agent_backend or "default")
         with self.engine.begin() as conn:
+            if require_enabled_agent:
+                reserve_write_lock(conn)
+                _require_enabled_agent_identity(
+                    conn,
+                    agent_id=agent_id,
+                    agent_name=agent_name,
+                )
             session_id = new_session_id(conn)
             resolved_workdir = normalize_workdir(workdir)
             if resolved_workdir is None:

--- a/storage/sessions_service.py
+++ b/storage/sessions_service.py
@@ -8,7 +8,7 @@ from datetime import datetime, timezone, timedelta
 from pathlib import Path
 from typing import Any, Mapping
 
-from sqlalchemy import Connection, case, func, or_, select
+from sqlalchemy import Connection, and_, case, func, or_, select
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from sqlalchemy.exc import IntegrityError
 
@@ -104,6 +104,23 @@ def _set_native_once(conn: Connection, row_id: str, encoded_session_id: str) -> 
 _BACKEND_LABELS = {"claude": "Claude", "codex": "Codex", "opencode": "OpenCode"}
 
 
+def _session_agent_display_label(row: Mapping[str, Any]) -> str | None:
+    agent_name = str(row["agent_name"] or "").strip()
+    catalog_name = str(row["catalog_agent_name"] or "").strip()
+    if row["catalog_agent_archived_at"]:
+        try:
+            metadata_json = json.loads(row["catalog_agent_metadata_json"] or "{}")
+        except (TypeError, ValueError):
+            metadata_json = {}
+        archive = metadata_json.get("_avibe_archive") if isinstance(metadata_json, dict) else None
+        if isinstance(archive, dict):
+            original_name = str(archive.get("original_name") or "").strip()
+            if original_name:
+                return original_name
+    backend = str(row["agent_backend"] or "").strip()
+    return catalog_name or agent_name or _BACKEND_LABELS.get(backend, backend or None)
+
+
 def read_session_display_meta(
     session_ids: list[str], *, db_path: Path | None = None
 ) -> dict[str, dict[str, str | None]]:
@@ -127,10 +144,25 @@ def read_session_display_meta(
                         agent_sessions.c.title,
                         agent_sessions.c.agent_name,
                         agent_sessions.c.agent_backend,
+                        agents.c.name.label("catalog_agent_name"),
+                        agents.c.archived_at.label("catalog_agent_archived_at"),
+                        agents.c.metadata_json.label("catalog_agent_metadata_json"),
                         scopes.c.platform,
                     )
                     .select_from(
-                        agent_sessions.join(scopes, scopes.c.id == agent_sessions.c.scope_id, isouter=True)
+                        agent_sessions
+                        .join(scopes, scopes.c.id == agent_sessions.c.scope_id, isouter=True)
+                        .join(
+                            agents,
+                            or_(
+                                agents.c.id == agent_sessions.c.agent_id,
+                                and_(
+                                    agent_sessions.c.agent_id.is_(None),
+                                    agents.c.name == agent_sessions.c.agent_name,
+                                ),
+                            ),
+                            isouter=True,
+                        )
                     )
                     .where(agent_sessions.c.id.in_(ids))
                 )
@@ -143,9 +175,7 @@ def read_session_display_meta(
     for row in rows:
         title = str(row["title"] or "").strip() or None
         platform = str(row["platform"] or "").strip() or None
-        agent_name = str(row["agent_name"] or "").strip()
-        backend = str(row["agent_backend"] or "").strip()
-        agent = agent_name or _BACKEND_LABELS.get(backend, backend or None)
+        agent = _session_agent_display_label(row)
         meta[str(row["id"])] = {"title": title, "platform": platform, "agent": agent}
     return meta
 

--- a/storage/sessions_service.py
+++ b/storage/sessions_service.py
@@ -78,6 +78,28 @@ def _require_enabled_agent_identity(
         )
 
 
+def _require_agent_reference_identity(
+    conn: Connection,
+    *,
+    expected_agent_id: str | None,
+) -> dict[str, str]:
+    cleaned_id = str(expected_agent_id or "").strip()
+    if not cleaned_id:
+        raise ValueError("an Agent identity is required for this session reference")
+    row = conn.execute(
+        select(agents.c.id, agents.c.name, agents.c.backend)
+        .where(agents.c.id == cleaned_id)
+        .limit(1)
+    ).mappings().first()
+    if row is None:
+        raise ValueError(f"agent reference '{cleaned_id}' no longer exists")
+    return {
+        "id": str(row["id"]),
+        "name": str(row["name"]),
+        "backend": str(row["backend"]),
+    }
+
+
 def _catalog_agent_name_value(agent_id: str | None, fallback_name: str) -> Any:
     """Resolve an Agent's current routing name in the statement that persists it."""
 
@@ -263,6 +285,7 @@ class SQLiteSessionsService:
         visibility: str = "foreground",
         metadata: dict[str, Any] | None = None,
         require_enabled_agent: bool = False,
+        expected_reference_agent_id: str | None = None,
     ) -> str | None:
         now = _utc_now_iso()
         backend = str(agent_backend or "default")
@@ -274,6 +297,15 @@ class SQLiteSessionsService:
                     agent_id=agent_id,
                     agent_name=agent_name,
                 )
+            elif expected_reference_agent_id is not None:
+                reserve_write_lock(conn)
+                identity = _require_agent_reference_identity(
+                    conn,
+                    expected_agent_id=expected_reference_agent_id,
+                )
+                agent_id = identity["id"]
+                agent_name = identity["name"]
+                backend = identity["backend"]
             scope_id = resolve_scope_from_legacy_key(conn, str(scope_key), now=now)
             if scope_id is None:
                 return None
@@ -308,6 +340,7 @@ class SQLiteSessionsService:
         visibility: str = "background",
         metadata: dict[str, Any] | None = None,
         require_enabled_agent: bool = False,
+        expected_reference_agent_id: str | None = None,
     ) -> str:
         """Reserve a session with no Scope and its own lazy Show workspace."""
         now = _utc_now_iso()
@@ -320,6 +353,15 @@ class SQLiteSessionsService:
                     agent_id=agent_id,
                     agent_name=agent_name,
                 )
+            elif expected_reference_agent_id is not None:
+                reserve_write_lock(conn)
+                identity = _require_agent_reference_identity(
+                    conn,
+                    expected_agent_id=expected_reference_agent_id,
+                )
+                agent_id = identity["id"]
+                agent_name = identity["name"]
+                backend = identity["backend"]
             session_id = new_session_id(conn)
             resolved_workdir = normalize_workdir(workdir)
             if resolved_workdir is None:

--- a/storage/sessions_service.py
+++ b/storage/sessions_service.py
@@ -87,12 +87,27 @@ def _require_agent_reference_identity(
     if not cleaned_id:
         raise ValueError("an Agent identity is required for this session reference")
     row = conn.execute(
-        select(agents.c.id, agents.c.name, agents.c.backend)
+        select(
+            agents.c.id,
+            agents.c.name,
+            agents.c.backend,
+            agents.c.enabled,
+            agents.c.archived_at,
+            agents.c.metadata_json,
+        )
         .where(agents.c.id == cleaned_id)
         .limit(1)
     ).mappings().first()
     if row is None:
         raise ValueError(f"agent reference '{cleaned_id}' no longer exists")
+    from core.vibe_agents import agent_reference_is_usable
+
+    if not agent_reference_is_usable(
+        enabled=bool(row["enabled"]),
+        archived_at=row["archived_at"],
+        metadata=_json_loads(row["metadata_json"], {}),
+    ):
+        raise ValueError(f"agent reference '{row['name']}' is disabled")
     return {
         "id": str(row["id"]),
         "name": str(row["name"]),

--- a/storage/settings_service.py
+++ b/storage/settings_service.py
@@ -251,10 +251,12 @@ class SQLiteSettingsService:
         ).scalar_one_or_none()
         if current == expected:
             if item.routing.agent_name != current:
-                SQLiteSettingsService._require_enabled_agent_binding(
+                canonical_agent_name = SQLiteSettingsService._require_enabled_agent_binding(
                     conn,
                     item.routing.agent_name,
                 )
+                if canonical_agent_name != item.routing.agent_name:
+                    return replace(item.routing, agent_name=canonical_agent_name)
             return item.routing
         if item.routing.agent_name == expected:
             return replace(item.routing, agent_name=current)
@@ -263,18 +265,25 @@ class SQLiteSettingsService:
         )
 
     @staticmethod
-    def _require_enabled_agent_binding(conn: Connection, agent_name: str | None) -> None:
+    def _require_enabled_agent_binding(conn: Connection, agent_name: str | None) -> str | None:
         if not agent_name:
-            return
+            return None
+        from core.vibe_agents import normalize_agent_name
+
+        try:
+            normalized_name = normalize_agent_name(agent_name)
+        except ValueError as exc:
+            raise ScopeAgentUnavailableError(f"Agent is unavailable: {agent_name}") from exc
         available = conn.execute(
-            select(agents.c.id)
-            .where(agents.c.name == agent_name)
+            select(agents.c.name)
+            .where(agents.c.normalized_name == normalized_name)
             .where(agents.c.enabled == 1)
             .where(agents.c.archived_at.is_(None))
             .limit(1)
-        ).first()
+        ).scalar_one_or_none()
         if available is None:
             raise ScopeAgentUnavailableError(f"Agent is unavailable: {agent_name}")
+        return str(available)
 
     def _upsert_scope_settings(self, conn: Connection, *, scope_id: str, **values: Any) -> None:
         """Insert or update one scope's settings row by scope_id — no delete.

--- a/storage/settings_service.py
+++ b/storage/settings_service.py
@@ -37,7 +37,11 @@ _MANAGED_SCOPE_TYPES = ("channel", "thread", "platform", "guild", "user")
 
 
 class StaleScopeAgentBindingError(ValueError):
-    pass
+    code = "settings_conflict"
+
+    def __init__(self, *, scope_id: str) -> None:
+        super().__init__(self.code)
+        self.scope_id = scope_id
 
 
 class ScopeAgentUnavailableError(ValueError):
@@ -260,9 +264,7 @@ class SQLiteSettingsService:
             return item.routing
         if item.routing.agent_name == expected:
             return replace(item.routing, agent_name=current)
-        raise StaleScopeAgentBindingError(
-            f"Agent binding changed while settings were open: {scope_id}"
-        )
+        raise StaleScopeAgentBindingError(scope_id=scope_id)
 
     @staticmethod
     def _require_enabled_agent_binding(conn: Connection, agent_name: str | None) -> str | None:

--- a/storage/settings_service.py
+++ b/storage/settings_service.py
@@ -45,7 +45,11 @@ class StaleScopeAgentBindingError(ValueError):
 
 
 class ScopeAgentUnavailableError(ValueError):
-    pass
+    code = "agent_unavailable"
+
+    def __init__(self, *, agent_name: str) -> None:
+        super().__init__(self.code)
+        self.agent_name = agent_name
 
 
 class SQLiteSettingsService:
@@ -275,7 +279,7 @@ class SQLiteSettingsService:
         try:
             normalized_name = normalize_agent_name(agent_name)
         except ValueError as exc:
-            raise ScopeAgentUnavailableError(f"Agent is unavailable: {agent_name}") from exc
+            raise ScopeAgentUnavailableError(agent_name=agent_name) from exc
         available = conn.execute(
             select(agents.c.name)
             .where(agents.c.normalized_name == normalized_name)
@@ -284,7 +288,7 @@ class SQLiteSettingsService:
             .limit(1)
         ).scalar_one_or_none()
         if available is None:
-            raise ScopeAgentUnavailableError(f"Agent is unavailable: {agent_name}")
+            raise ScopeAgentUnavailableError(agent_name=agent_name)
         return str(available)
 
     def _upsert_scope_settings(self, conn: Connection, *, scope_id: str, **values: Any) -> None:

--- a/storage/settings_service.py
+++ b/storage/settings_service.py
@@ -26,7 +26,7 @@ from config.v2_settings import (
 )
 from storage.agent_session_rows import reserve_write_lock
 from storage.db import SqliteInvalidationProbe, create_sqlite_engine
-from storage.models import auth_codes, scope_settings, scopes
+from storage.models import agents, auth_codes, scope_settings, scopes
 
 SETTINGS_VERSION = 1
 GUILD_POLICY_KIND = "guild_policy"
@@ -37,6 +37,10 @@ _MANAGED_SCOPE_TYPES = ("channel", "thread", "platform", "guild", "user")
 
 
 class StaleScopeAgentBindingError(ValueError):
+    pass
+
+
+class ScopeAgentUnavailableError(ValueError):
     pass
 
 
@@ -246,12 +250,31 @@ class SQLiteSettingsService:
             select(scope_settings.c.agent_name).where(scope_settings.c.scope_id == scope_id)
         ).scalar_one_or_none()
         if current == expected:
+            if item.routing.agent_name != current:
+                SQLiteSettingsService._require_enabled_agent_binding(
+                    conn,
+                    item.routing.agent_name,
+                )
             return item.routing
         if item.routing.agent_name == expected:
             return replace(item.routing, agent_name=current)
         raise StaleScopeAgentBindingError(
             f"Agent binding changed while settings were open: {scope_id}"
         )
+
+    @staticmethod
+    def _require_enabled_agent_binding(conn: Connection, agent_name: str | None) -> None:
+        if not agent_name:
+            return
+        available = conn.execute(
+            select(agents.c.id)
+            .where(agents.c.name == agent_name)
+            .where(agents.c.enabled == 1)
+            .where(agents.c.archived_at.is_(None))
+            .limit(1)
+        ).first()
+        if available is None:
+            raise ScopeAgentUnavailableError(f"Agent is unavailable: {agent_name}")
 
     def _upsert_scope_settings(self, conn: Connection, *, scope_id: str, **values: Any) -> None:
         """Insert or update one scope's settings row by scope_id — no delete.

--- a/storage/settings_service.py
+++ b/storage/settings_service.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import json
-from dataclasses import asdict
+from dataclasses import asdict, replace
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -16,6 +16,7 @@ from config.v2_settings import (
     RoutingSettings,
     SettingsState,
     UserSettings,
+    _UNSET_AGENT_BINDING,
     _make_scoped_key,
     _split_scoped_key,
     make_thread_native_id,
@@ -23,6 +24,7 @@ from config.v2_settings import (
     normalize_show_message_types,
     split_thread_native_id,
 )
+from storage.agent_session_rows import reserve_write_lock
 from storage.db import SqliteInvalidationProbe, create_sqlite_engine
 from storage.models import auth_codes, scope_settings, scopes
 
@@ -32,6 +34,10 @@ GUILD_POLICY_KIND = "guild_policy"
 # (storage.projects_service) share the scope_settings table but are NOT managed
 # here, so save_state must never delete or overwrite their rows.
 _MANAGED_SCOPE_TYPES = ("channel", "thread", "platform", "guild", "user")
+
+
+class StaleScopeAgentBindingError(ValueError):
+    pass
 
 
 class SQLiteSettingsService:
@@ -60,7 +66,9 @@ class SQLiteSettingsService:
             )
 
     def save_state(self, state: SettingsState) -> None:
+        saved_bindings: list[tuple[ChannelSettings | UserSettings, RoutingSettings]] = []
         with self.engine.begin() as conn:
+            reserve_write_lock(conn)
             now = _utc_now_iso()
             # Per-row reconcile (NOT a delete-everything rewrite): upsert each
             # managed scope's settings, then delete only the managed rows that
@@ -72,7 +80,8 @@ class SQLiteSettingsService:
             for scoped_key, item in state.channels.items():
                 platform, channel_id = _split_scoped_key(scoped_key)
                 scope_id = upsert_scope(conn, platform or "unknown", "channel", channel_id, now=now)
-                routing = asdict(item.routing)
+                routed = self._reconcile_agent_binding(conn, scope_id, item)
+                routing = asdict(routed)
                 self._upsert_scope_settings(
                     conn,
                     scope_id=scope_id,
@@ -90,9 +99,10 @@ class SQLiteSettingsService:
                     created_at=now,
                     updated_at=now,
                     settings_version=SETTINGS_VERSION,
-                    **_routing_columns(item.routing),
+                    **_routing_columns(routed),
                 )
                 kept.add(scope_id)
+                saved_bindings.append((item, routed))
 
             for scoped_key, item in state.threads.items():
                 platform, native_id = _split_scoped_key(scoped_key)
@@ -114,7 +124,8 @@ class SQLiteSettingsService:
                     native_type="forum_topic" if resolved_platform == "telegram" else "thread",
                     now=now,
                 )
-                routing = asdict(item.routing)
+                routed = self._reconcile_agent_binding(conn, scope_id, item)
+                routing = asdict(routed)
                 self._upsert_scope_settings(
                     conn,
                     scope_id=scope_id,
@@ -132,9 +143,10 @@ class SQLiteSettingsService:
                     created_at=now,
                     updated_at=now,
                     settings_version=SETTINGS_VERSION,
-                    **_routing_columns(item.routing),
+                    **_routing_columns(routed),
                 )
                 kept.add(scope_id)
+                saved_bindings.append((item, routed))
 
             for platform in sorted(state.guild_scope_platforms):
                 scope_id = upsert_scope(conn, platform, "platform", platform, now=now)
@@ -188,7 +200,8 @@ class SQLiteSettingsService:
                     is_private=True,
                     now=now,
                 )
-                routing = asdict(item.routing)
+                routed = self._reconcile_agent_binding(conn, scope_id, item)
+                routing = asdict(routed)
                 self._upsert_scope_settings(
                     conn,
                     scope_id=scope_id,
@@ -208,12 +221,37 @@ class SQLiteSettingsService:
                     ),
                     created_at=now,
                     updated_at=now,
-                    **_routing_columns(item.routing),
+                    **_routing_columns(routed),
                 )
                 kept.add(scope_id)
+                saved_bindings.append((item, routed))
 
             self._delete_removed_scope_settings(conn, kept)
             self._sync_bind_codes(conn, state.bind_codes, now)
+
+        for item, routing in saved_bindings:
+            item.routing = routing
+            item._agent_name_at_load = routing.agent_name
+
+    @staticmethod
+    def _reconcile_agent_binding(
+        conn: Connection,
+        scope_id: str,
+        item: ChannelSettings | UserSettings,
+    ) -> RoutingSettings:
+        expected = item._agent_name_at_load
+        if expected is _UNSET_AGENT_BINDING:
+            return item.routing
+        current = conn.execute(
+            select(scope_settings.c.agent_name).where(scope_settings.c.scope_id == scope_id)
+        ).scalar_one_or_none()
+        if current == expected:
+            return item.routing
+        if item.routing.agent_name == expected:
+            return replace(item.routing, agent_name=current)
+        raise StaleScopeAgentBindingError(
+            f"Agent binding changed while settings were open: {scope_id}"
+        )
 
     def _upsert_scope_settings(self, conn: Connection, *, scope_id: str, **values: Any) -> None:
         """Insert or update one scope's settings row by scope_id — no delete.
@@ -284,6 +322,7 @@ class SQLiteSettingsService:
                 routing=_routing_from_row(row, payload),
                 require_mention=_nullable_bool(row["require_mention"]),
                 require_bind=payload.get("require_bind"),
+                _agent_name_at_load=row["agent_name"],
             )
         return result
 
@@ -305,6 +344,7 @@ class SQLiteSettingsService:
                 routing=_routing_from_row(row, payload),
                 require_mention=_nullable_bool(row["require_mention"]),
                 require_bind=payload.get("require_bind"),
+                _agent_name_at_load=row["agent_name"],
             )
         return result
 
@@ -344,6 +384,7 @@ class SQLiteSettingsService:
                 routing=_routing_from_row(row, payload),
                 dm_chat_id=str(payload.get("dm_chat_id") or ""),
                 pending_bind_menu_hint=bool(payload.get("pending_bind_menu_hint", False)),
+                _agent_name_at_load=row["agent_name"],
             )
         return result
 

--- a/storage/workbench_sessions_service.py
+++ b/storage/workbench_sessions_service.py
@@ -319,7 +319,14 @@ def create_session(
             )
             .select_from(
                 scopes.outerjoin(scope_settings, scope_settings.c.scope_id == scopes.c.id)
-                .outerjoin(agents, agents.c.name == scope_settings.c.agent_name)
+                .outerjoin(
+                    agents,
+                    and_(
+                        agents.c.name == scope_settings.c.agent_name,
+                        agents.c.enabled == 1,
+                        agents.c.archived_at.is_(None),
+                    ),
+                )
             )
             .where(scopes.c.id == scope_id)
         ).mappings().first()
@@ -705,6 +712,23 @@ def _backend_for_agent_name(conn: Connection, agent_name: str) -> str:
         return ""
     backend = conn.execute(select(agents.c.backend).where(agents.c.name == cleaned)).scalar_one_or_none()
     return str(backend or "")
+
+
+def require_enabled_agent_backend(conn: Connection, agent_name: str) -> str:
+    """Validate a newly assigned Agent and return its backend."""
+
+    cleaned = str(agent_name or "").strip()
+    if not cleaned:
+        return ""
+    backend = conn.execute(
+        select(agents.c.backend)
+        .where(agents.c.name == cleaned)
+        .where(agents.c.enabled == 1)
+        .where(agents.c.archived_at.is_(None))
+    ).scalar_one_or_none()
+    if backend is None:
+        raise LookupError(f"Agent not found or disabled: {cleaned}")
+    return str(backend)
 
 
 def derive_backend_for_agent_name(conn: Connection, agent_name: str) -> str:

--- a/storage/workbench_sessions_service.py
+++ b/storage/workbench_sessions_service.py
@@ -720,15 +720,32 @@ def require_enabled_agent_backend(conn: Connection, agent_name: str) -> str:
     cleaned = str(agent_name or "").strip()
     if not cleaned:
         return ""
-    backend = conn.execute(
-        select(agents.c.backend)
-        .where(agents.c.name == cleaned)
+    return require_enabled_agent_identity(conn, agent_name=cleaned)["backend"]
+
+
+def require_enabled_agent_identity(
+    conn: Connection,
+    *,
+    agent_id: Optional[str] = None,
+    agent_name: Optional[str] = None,
+) -> dict[str, str]:
+    """Resolve one enabled Agent while requiring every supplied identity field to match."""
+
+    cleaned_id = str(agent_id or "").strip()
+    cleaned_name = str(agent_name or "").strip()
+    stmt = (
+        select(agents.c.id, agents.c.name, agents.c.backend)
         .where(agents.c.enabled == 1)
         .where(agents.c.archived_at.is_(None))
-    ).scalar_one_or_none()
-    if backend is None:
-        raise LookupError(f"Agent not found or disabled: {cleaned}")
-    return str(backend)
+    )
+    if cleaned_id:
+        stmt = stmt.where(agents.c.id == cleaned_id)
+    if cleaned_name:
+        stmt = stmt.where(agents.c.name == cleaned_name)
+    row = conn.execute(stmt.limit(1)).mappings().first() if cleaned_id or cleaned_name else None
+    if row is None:
+        raise LookupError(f"Agent not found or disabled: {cleaned_name or cleaned_id}")
+    return {"id": str(row["id"]), "name": str(row["name"]), "backend": str(row["backend"])}
 
 
 def derive_backend_for_agent_name(conn: Connection, agent_name: str) -> str:

--- a/storage/workbench_sessions_service.py
+++ b/storage/workbench_sessions_service.py
@@ -731,6 +731,8 @@ def require_enabled_agent_identity(
 ) -> dict[str, str]:
     """Resolve one enabled Agent while requiring every supplied identity field to match."""
 
+    from core.vibe_agents import normalize_agent_name
+
     cleaned_id = str(agent_id or "").strip()
     cleaned_name = str(agent_name or "").strip()
     stmt = (
@@ -741,7 +743,11 @@ def require_enabled_agent_identity(
     if cleaned_id:
         stmt = stmt.where(agents.c.id == cleaned_id)
     if cleaned_name:
-        stmt = stmt.where(agents.c.name == cleaned_name)
+        try:
+            normalized_name = normalize_agent_name(cleaned_name)
+        except ValueError as exc:
+            raise LookupError(f"Agent not found or disabled: {cleaned_name}") from exc
+        stmt = stmt.where(agents.c.normalized_name == normalized_name)
     row = conn.execute(stmt.limit(1)).mappings().first() if cleaned_id or cleaned_name else None
     if row is None:
         raise LookupError(f"Agent not found or disabled: {cleaned_name or cleaned_id}")

--- a/tests/test_agent_graph_service.py
+++ b/tests/test_agent_graph_service.py
@@ -20,6 +20,7 @@ import pytest
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from core.services import agent_graph
+from core.vibe_agents import VibeAgentStore
 from storage.db import create_sqlite_engine
 from storage.importer import ensure_sqlite_state
 from storage.models import agent_runs, agent_sessions, run_definitions, scope_settings, scopes
@@ -146,6 +147,38 @@ def _insert_run(conn, run_id, *, session_id, status="succeeded", run_type="agent
             metadata_json="{}",
         )
     )
+
+
+def test_graph_projects_archived_agent_display_name(isolated_state) -> None:
+    store = VibeAgentStore()
+    try:
+        original = store.create(name="pm", backend="claude")
+        archived = store.archive(original.name)
+        assert archived is not None
+        with store.engine.begin() as conn:
+            _insert_session(conn, "ses_archived_agent", scope_id=None)
+            conn.execute(
+                agent_sessions.update()
+                .where(agent_sessions.c.id == "ses_archived_agent")
+                .values(
+                    agent_id=original.id,
+                    agent_name=archived.archived_name,
+                )
+            )
+            _insert_run(
+                conn,
+                "run_archived_agent",
+                session_id="ses_archived_agent",
+                created=NOW - timedelta(minutes=5),
+            )
+
+        payload = agent_graph.build_graph(live_agents=[], now=NOW, engine=store.engine)
+
+        node = _nodes_by_id(payload)["ses_archived_agent"]
+        assert node["agent_name"] == archived.archived_name
+        assert node["agent_display_name"] == "pm"
+    finally:
+        store.close()
 
 
 def _insert_definition(conn, definition_id, *, definition_type="scheduled",

--- a/tests/test_agent_graph_service.py
+++ b/tests/test_agent_graph_service.py
@@ -153,6 +153,7 @@ def test_graph_projects_archived_agent_display_name(isolated_state) -> None:
     store = VibeAgentStore()
     try:
         original = store.create(name="pm", backend="claude")
+        store.create(name="zz-fallback", backend="claude")
         archived = store.archive(original.name)
         assert archived is not None
         with store.engine.begin() as conn:

--- a/tests/test_cli_agent_run_schema.py
+++ b/tests/test_cli_agent_run_schema.py
@@ -1533,6 +1533,42 @@ def test_agent_run_fork_rejects_cross_backend_agent(tmp_path: Path, capsys) -> N
     assert payload["code"] == "session_fork_failed"
 
 
+def test_agent_run_fork_localizes_unavailable_source_agent(monkeypatch) -> None:
+    from core.services.session_fork import (
+        SESSION_AGENT_UNAVAILABLE_CODE,
+        SESSION_AGENT_UNAVAILABLE_I18N_KEY,
+        SessionForkError,
+    )
+    from vibe.i18n import t as i18n_t
+
+    error = SessionForkError(
+        "source session Agent is unavailable; choose an enabled Agent override",
+        code=SESSION_AGENT_UNAVAILABLE_CODE,
+        details={"source_session_id": "ses-source"},
+    )
+    monkeypatch.setattr(cli.V2Config, "load", lambda: SimpleNamespace(language="zh"))
+    monkeypatch.setattr(
+        "core.services.session_fork.reserve_forked_session",
+        lambda **_kwargs: (_ for _ in ()).throw(error),
+    )
+
+    with pytest.raises(cli.TaskCliError) as exc_info:
+        cli._reserve_forked_cli_session(
+            source_session_id="ses-source",
+            agent_name=None,
+            model=None,
+            reasoning_effort=None,
+            scope_key=None,
+            visibility="foreground",
+        )
+
+    exc = exc_info.value
+    assert exc.code == SESSION_AGENT_UNAVAILABLE_CODE
+    assert str(exc) == i18n_t(f"{SESSION_AGENT_UNAVAILABLE_I18N_KEY}.message", "zh")
+    assert exc.hint == i18n_t(f"{SESSION_AGENT_UNAVAILABLE_I18N_KEY}.hint", "zh")
+    assert exc.details == {"source_session_id": "ses-source"}
+
+
 def test_agent_run_callerless_session_workdir_uses_show_workspace(tmp_path: Path, capsys, monkeypatch) -> None:
     """A caller-less run reserves a standalone Session in its Show workspace."""
     from storage.importer import ensure_sqlite_state

--- a/tests/test_cli_agent_run_schema.py
+++ b/tests/test_cli_agent_run_schema.py
@@ -131,6 +131,72 @@ def test_agent_run_default_async_envelope_schema(tmp_path: Path, capsys) -> None
     assert run["parent_run_id"] is None
 
 
+def test_agent_run_releases_reserved_session_when_guarded_enqueue_loses(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    from sqlalchemy import func, select
+
+    from storage.db import create_sqlite_engine
+    from storage.importer import ensure_sqlite_state
+    from storage.models import agent_runs, agent_sessions
+
+    state_home = tmp_path / "home"
+    with patch.dict("os.environ", {"AVIBE_HOME": str(state_home)}):
+        ensure_sqlite_state()
+        db_path = state_home / "state" / "vibe.sqlite"
+        agent_store = cli.VibeAgentStore(db_path)
+        agent_store.create(name="worker", backend="codex")
+        agent_store.create(name="fallback", backend="codex")
+        agent_store.set_default_agent_name("fallback")
+        request_store = cli.TaskExecutionStore()
+        original_enqueue = request_store.enqueue_agent_run
+        args = _parse_agent_run(
+            ["--agent", "worker", "--no-callback", "--message", "hi"]
+        )
+
+        def _archive_before_guarded_enqueue(**kwargs):
+            archived = agent_store.archive("worker")
+            assert archived is not None
+            return original_enqueue(**kwargs)
+
+        try:
+            with (
+                patch("vibe.cli._agent_store", return_value=agent_store),
+                patch("vibe.cli._task_request_store", return_value=request_store),
+                patch.object(
+                    request_store,
+                    "enqueue_agent_run",
+                    side_effect=_archive_before_guarded_enqueue,
+                ),
+                patch("vibe.cli.paths.get_sqlite_state_path", return_value=db_path),
+                patch("vibe.cli._primary_platform", return_value="slack"),
+            ):
+                result = cli.cmd_agent_run(args)
+
+            engine = create_sqlite_engine(db_path)
+            try:
+                with engine.connect() as conn:
+                    session_count = conn.execute(
+                        select(func.count()).select_from(agent_sessions)
+                    ).scalar_one()
+                    run_count = conn.execute(
+                        select(func.count()).select_from(agent_runs)
+                    ).scalar_one()
+            finally:
+                engine.dispose()
+        finally:
+            if request_store.sqlite_backend is not None:
+                request_store.sqlite_backend.close()
+            agent_store.close()
+
+    assert result == 1
+    payload = json.loads(capsys.readouterr().err)
+    assert "archived, disabled, renamed, or replaced" in payload["error"]
+    assert session_count == 0
+    assert run_count == 0
+
+
 def test_agent_run_explicit_async_flag_remains_compatible(tmp_path: Path, capsys) -> None:
     db_path = tmp_path / "state" / "vibe.sqlite"
     agent_store = cli.VibeAgentStore(db_path)

--- a/tests/test_cli_task_command.py
+++ b/tests/test_cli_task_command.py
@@ -3213,6 +3213,42 @@ def test_scope_derived_agent_target_preserves_the_stable_reference(tmp_path: Pat
     assert cli._agent_write_guard_ids(resolution) == (None, original.id)
 
 
+def test_session_derived_agent_target_prefers_the_stable_id(tmp_path: Path) -> None:
+    db_path = tmp_path / "state" / "vibe.sqlite"
+    agent_store = cli.VibeAgentStore(db_path)
+    original = agent_store.create(name="pm", backend="claude")
+    agent_store.create(name="archive-fallback", backend="codex")
+    archived = agent_store.archive(original.name)
+    assert archived is not None
+    replacement = agent_store.create(name="pm", backend="claude")
+
+    with (
+        patch("vibe.cli._agent_store", return_value=agent_store),
+        patch(
+            "vibe.cli.resolve_session_id_target",
+            return_value=SimpleNamespace(
+                agent_id=original.id,
+                agent_name=replacement.name,
+                agent_backend=original.backend,
+            ),
+        ),
+    ):
+        resolution = cli._resolve_agent_target(
+            agent_name=None,
+            session_id="ses_preserved",
+            session_key="",
+            help_command="vibe agent run --help",
+        )
+
+    assert resolution.agent is not None
+    assert resolution.agent.id == original.id
+    assert resolution.agent.id != replacement.id
+    assert resolution.agent.name == archived.archived_name
+    assert resolution.requires_enabled_write_guard is False
+    assert resolution.preserves_existing_reference is True
+    assert cli._agent_write_guard_ids(resolution) == (None, original.id)
+
+
 def test_resolve_agent_for_target_allows_unresolved_legacy_scope_backend_without_session_creation(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_cli_task_command.py
+++ b/tests/test_cli_task_command.py
@@ -101,6 +101,59 @@ def test_disabled_agent_cannot_run(tmp_path: Path) -> None:
     assert payload["error"] == "agent 'worker' is disabled"
 
 
+def test_task_update_preserves_archived_agent_reference(capsys) -> None:
+    db_path = cli.paths.get_sqlite_state_path()
+    agent_store = cli.VibeAgentStore(db_path)
+    try:
+        agent = agent_store.create(name="pm", backend="codex")
+        store = cli.ScheduledTaskStore()
+        task = store.add_task(
+            name="Daily review",
+            session_key="slack::channel::C123",
+            prompt="review",
+            schedule_type="cron",
+            agent_name=agent.name,
+            cron="0 9 * * *",
+            timezone_name="UTC",
+        )
+        archived = agent_store.archive(agent.name)
+        assert archived is not None
+        store.load()
+
+        args = cli.build_parser().parse_args(
+            ["task", "update", task.id, "--name", "Renamed review"]
+        )
+        with (
+            patch("vibe.cli._ensure_config", return_value=_configured_v2({"slack"})),
+            patch("vibe.cli._task_store", return_value=store),
+            patch(
+                "vibe.cli._agent_store",
+                side_effect=lambda: cli.VibeAgentStore(db_path),
+            ),
+        ):
+            assert cli.cmd_task_update(args) == 0
+
+        assert json.loads(capsys.readouterr().out)["definition"]["agent_name"] == archived.archived_name
+        assert cli.ScheduledTaskStore().get_task(task.id).agent_name == archived.archived_name
+
+        explicit = cli.build_parser().parse_args(
+            ["task", "update", task.id, "--agent", archived.archived_name]
+        )
+        with (
+            patch("vibe.cli._ensure_config", return_value=_configured_v2({"slack"})),
+            patch("vibe.cli._task_store", return_value=cli.ScheduledTaskStore()),
+            patch(
+                "vibe.cli._agent_store",
+                side_effect=lambda: cli.VibeAgentStore(db_path),
+            ),
+        ):
+            result, payload = _capture_stderr_json(cli.cmd_task_update, explicit)
+        assert result == 1
+        assert "disabled" in payload["error"]
+    finally:
+        agent_store.close()
+
+
 def test_agent_remove_cli_archives_agent(tmp_path: Path, capsys) -> None:
     agent_store = cli.VibeAgentStore(tmp_path / "state" / "vibe.sqlite")
     try:

--- a/tests/test_cli_task_command.py
+++ b/tests/test_cli_task_command.py
@@ -963,7 +963,7 @@ def test_task_add_releases_create_once_session_when_definition_write_fails(monke
             ),
         ),
         patch(
-            "vibe.cli._release_definition_session_reservation",
+            "vibe.cli._release_cli_session_reservation",
             side_effect=lambda session_id, *, reason: released.append((session_id, reason)) or True,
         ),
     ):

--- a/tests/test_cli_task_command.py
+++ b/tests/test_cli_task_command.py
@@ -101,6 +101,22 @@ def test_disabled_agent_cannot_run(tmp_path: Path) -> None:
     assert payload["error"] == "agent 'worker' is disabled"
 
 
+def test_agent_remove_cli_archives_agent(tmp_path: Path, capsys) -> None:
+    agent_store = cli.VibeAgentStore(tmp_path / "state" / "vibe.sqlite")
+    try:
+        agent_store.create(name="worker", backend="codex")
+        with patch("vibe.cli._agent_store", return_value=agent_store):
+            assert cli.cmd_agent_remove(_parse_agent(["remove", "worker"])) == 0
+
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["removed_agent"] == "worker"
+        assert payload["archived_agent"]["name"].startswith("_archived_")
+        assert payload["archived_agent"]["display_name"] == "worker"
+        assert agent_store.get("worker") is None
+    finally:
+        agent_store.close()
+
+
 def test_agent_list_is_bounded_and_compact_by_default(tmp_path: Path, capsys) -> None:
     agent_store = cli.VibeAgentStore(tmp_path / "state" / "vibe.sqlite")
     for index in range(25):

--- a/tests/test_cli_task_command.py
+++ b/tests/test_cli_task_command.py
@@ -3207,11 +3207,20 @@ def test_task_add_create_per_run_ignores_unresolved_legacy_scope_backend(tmp_pat
             "hello",
         ]
     )
+    task_store = cli.ScheduledTaskStore(tmp_path / "scheduled_tasks.json")
+    original_add_task = task_store.add_task
+    captured: dict[str, object] = {}
+
+    def add_task(**kwargs):
+        captured.update(kwargs)
+        return original_add_task(**kwargs)
 
     with (
         patch("vibe.cli.paths.get_state_dir", return_value=db_path.parent),
         patch("vibe.cli.paths.get_sqlite_state_path", return_value=db_path),
         patch("vibe.cli._ensure_config", return_value=_configured_v2({"slack"})),
+        patch("vibe.cli._task_store", return_value=task_store),
+        patch.object(task_store, "add_task", side_effect=add_task),
     ):
         result = cli.cmd_task_add(args)
 
@@ -3219,6 +3228,7 @@ def test_task_add_create_per_run_ignores_unresolved_legacy_scope_backend(tmp_pat
     payload = json.loads(capsys.readouterr().out)
     assert payload["ok"] is True
     assert payload["definition"]["agent_name"] == default_agent.name
+    assert captured["expected_enabled_agent_id"] == default_agent.id
 
 
 def test_task_add_rejects_deprecated_prompt_argument() -> None:

--- a/tests/test_cli_task_command.py
+++ b/tests/test_cli_task_command.py
@@ -2825,6 +2825,22 @@ def test_agent_create_accepts_effort_alias(tmp_path: Path, capsys) -> None:
     assert payload["agent"]["reasoning_effort"] == "high"
 
 
+def test_agent_create_localizes_reserved_name_error(tmp_path: Path) -> None:
+    agent_store = cli.VibeAgentStore(tmp_path / "state" / "vibe.sqlite")
+    args = _parse_agent(["create", "_hidden", "--backend", "codex"])
+
+    with (
+        patch("vibe.cli._agent_store", return_value=agent_store),
+        patch("vibe.cli.V2Config.load", return_value=SimpleNamespace(language="zh")),
+    ):
+        result, payload = _capture_stderr_json(cli.cmd_agent_create, args)
+
+    assert result == 1
+    assert payload["code"] == "agent_name_reserved"
+    assert payload["error"] == "Agent 名称不能以下划线 `_` 开头；该命名空间由 Avibe 保留。"
+    assert payload["hint"] == "请选择不以下划线 `_` 开头的 Agent 名称。"
+
+
 def test_agent_default_cli_sets_default_agent(tmp_path: Path, capsys) -> None:
     db_path = tmp_path / "state" / "vibe.sqlite"
     agent_store = cli.VibeAgentStore(db_path)

--- a/tests/test_cli_task_command.py
+++ b/tests/test_cli_task_command.py
@@ -172,6 +172,31 @@ def test_agent_remove_cli_archives_agent(tmp_path: Path, capsys) -> None:
         agent_store.close()
 
 
+def test_agent_remove_cli_localizes_archive_refusal(tmp_path: Path) -> None:
+    agent_store = cli.VibeAgentStore(tmp_path / "state" / "vibe.sqlite")
+    try:
+        agent_store.create(name="only-agent", backend="codex")
+        agent_store.set_default_agent_name("only-agent")
+        with (
+            patch("vibe.cli._agent_store", return_value=agent_store),
+            patch(
+                "vibe.cli.V2Config.load",
+                return_value=SimpleNamespace(language="zh"),
+            ),
+        ):
+            result, payload = _capture_stderr_json(
+                cli.cmd_agent_remove,
+                _parse_agent(["remove", "only-agent"]),
+            )
+
+        assert result == 1
+        assert payload["code"] == "agent_no_default_replacement"
+        assert payload["error"] == "没有其他已启用 Agent 时，无法归档默认 Agent `only-agent`。"
+        assert payload["hint"] == "归档当前默认 Agent 前，请保留另一个已启用 Agent。"
+    finally:
+        agent_store.close()
+
+
 def test_agent_list_is_bounded_and_compact_by_default(tmp_path: Path, capsys) -> None:
     agent_store = cli.VibeAgentStore(tmp_path / "state" / "vibe.sqlite")
     for index in range(25):

--- a/tests/test_cli_task_command.py
+++ b/tests/test_cli_task_command.py
@@ -110,7 +110,7 @@ def test_agent_remove_cli_archives_agent(tmp_path: Path, capsys) -> None:
 
         payload = json.loads(capsys.readouterr().out)
         assert payload["removed_agent"] == "worker"
-        assert payload["archived_agent"]["name"].startswith("_archived_")
+        assert payload["archived_agent"]["name"].startswith("_worker-")
         assert payload["archived_agent"]["display_name"] == "worker"
         assert agent_store.get("worker") is None
     finally:

--- a/tests/test_cli_task_command.py
+++ b/tests/test_cli_task_command.py
@@ -105,6 +105,7 @@ def test_task_update_preserves_archived_agent_reference(capsys) -> None:
     db_path = cli.paths.get_sqlite_state_path()
     agent_store = cli.VibeAgentStore(db_path)
     try:
+        agent_store.create(name="archive-fallback", backend="codex")
         agent = agent_store.create(name="pm", backend="codex")
         store = cli.ScheduledTaskStore()
         task = store.add_task(
@@ -157,6 +158,7 @@ def test_task_update_preserves_archived_agent_reference(capsys) -> None:
 def test_agent_remove_cli_archives_agent(tmp_path: Path, capsys) -> None:
     agent_store = cli.VibeAgentStore(tmp_path / "state" / "vibe.sqlite")
     try:
+        agent_store.create(name="archive-fallback", backend="codex")
         agent_store.create(name="worker", backend="codex")
         with patch("vibe.cli._agent_store", return_value=agent_store):
             assert cli.cmd_agent_remove(_parse_agent(["remove", "worker"])) == 0
@@ -1794,6 +1796,41 @@ def test_hook_send_deprecation_warning_names_callback_policy(tmp_path: Path, cap
     assert "vibe hook send is deprecated" in payload["deprecation_warning"]
     assert "--no-callback" in payload["deprecation_warning"]
     assert "--callback-session-id <session-id>" in payload["deprecation_warning"]
+
+
+def test_hook_send_guards_an_explicit_agent_inside_enqueue(tmp_path: Path, capsys) -> None:
+    args = _parse_hook_send(
+        [
+            "--session-key",
+            "slack::channel::C123",
+            "--agent",
+            "worker",
+            "--message",
+            "hello",
+        ]
+    )
+    agent_store = cli.VibeAgentStore(tmp_path / "state" / "vibe.sqlite")
+    agent = agent_store.create(name="worker", backend="codex")
+    captured: dict[str, object] = {}
+
+    def enqueue_hook_send(**kwargs):
+        captured.update(kwargs)
+        return SimpleNamespace(id="run-hook", request_type="agent_run")
+
+    with (
+        patch("vibe.cli._ensure_config", return_value=_configured_v2({"slack"})),
+        patch("vibe.cli._agent_store", return_value=agent_store),
+        patch(
+            "vibe.cli._task_request_store",
+            return_value=SimpleNamespace(enqueue_hook_send=enqueue_hook_send),
+        ),
+    ):
+        result = cli.cmd_hook_send(args)
+
+    assert result == 0
+    assert json.loads(capsys.readouterr().out)["run_id"] == "run-hook"
+    assert captured["agent_name"] == agent.name
+    assert captured["expected_enabled_agent_id"] == agent.id
 
 
 def test_hook_send_rejects_conflicting_delivery_target_flags(capsys) -> None:

--- a/tests/test_cli_task_command.py
+++ b/tests/test_cli_task_command.py
@@ -197,6 +197,26 @@ def test_agent_remove_cli_localizes_archive_refusal(tmp_path: Path) -> None:
         agent_store.close()
 
 
+def test_agent_remove_cli_localizes_invalid_reference_metadata() -> None:
+    def refuse_archive(_name):
+        raise cli.AgentReferenceRewriteError()
+
+    store = SimpleNamespace(archive=refuse_archive)
+    with (
+        patch("vibe.cli._agent_store", return_value=store),
+        patch("vibe.cli.V2Config.load", return_value=SimpleNamespace(language="zh")),
+    ):
+        result, payload = _capture_stderr_json(
+            cli.cmd_agent_remove,
+            _parse_agent(["remove", "worker"]),
+        )
+
+    assert result == 1
+    assert payload["code"] == "agent_reference_metadata_invalid"
+    assert payload["error"] == "任务或监控包含无效元数据，Avibe 无法更新 Agent 引用。"
+    assert payload["hint"] == "请修复或删除元数据异常的任务或监控，然后重试。"
+
+
 def test_agent_update_and_enable_localize_archived_edit_refusal(tmp_path: Path) -> None:
     agent_store = cli.VibeAgentStore(tmp_path / "state" / "vibe.sqlite")
     try:

--- a/tests/test_cli_task_command.py
+++ b/tests/test_cli_task_command.py
@@ -3147,6 +3147,72 @@ def test_resolve_agent_for_target_ignores_deprecated_scope_backend(tmp_path: Pat
     assert "agent_name" not in json.loads(row[2])["routing"]
 
 
+def test_scope_derived_agent_target_preserves_the_stable_reference(tmp_path: Path) -> None:
+    db_path = tmp_path / "state" / "vibe.sqlite"
+    agent_store = cli.VibeAgentStore(db_path)
+    original = agent_store.create(name="pm", backend="claude")
+    agent_store.create(name="archive-fallback", backend="codex")
+    from storage.importer import ensure_sqlite_state
+    from storage.models import scope_settings
+    from storage.settings_service import upsert_scope
+
+    ensure_sqlite_state(db_path=db_path, primary_platform="slack")
+    with cli.create_sqlite_engine(db_path).begin() as conn:
+        now = "2026-08-01T00:00:00+00:00"
+        scope_id = upsert_scope(conn, "slack", "channel", "C123", now=now)
+        conn.execute(
+            scope_settings.insert().values(
+                scope_id=scope_id,
+                enabled=1,
+                role=None,
+                workdir=None,
+                agent_name=original.name,
+                agent_backend=original.backend,
+                agent_variant=None,
+                model=None,
+                reasoning_effort=None,
+                require_mention=None,
+                settings_version=1,
+                settings_json="{}",
+                created_at=now,
+                updated_at=now,
+            )
+        )
+
+    with (
+        patch("vibe.cli.paths.get_state_dir", return_value=db_path.parent),
+        patch("vibe.cli.paths.get_sqlite_state_path", return_value=db_path),
+    ):
+        captured_scope = cli._resolve_scope_routing_target("slack::channel::C123")
+
+    assert captured_scope == cli._ScopeRoutingTarget(original.name, original.id)
+    archived = agent_store.archive(original.name)
+    assert archived is not None
+    replacement = agent_store.create(name="pm", backend="claude")
+
+    with (
+        patch("vibe.cli._agent_store", return_value=agent_store),
+        patch(
+            "vibe.cli._resolve_scope_routing_target",
+            return_value=captured_scope,
+        ),
+    ):
+        resolution = cli._resolve_agent_target(
+            agent_name=None,
+            session_id=None,
+            session_key="slack::channel::C123",
+            help_command="vibe task add --help",
+        )
+
+    assert resolution.agent is not None
+    assert resolution.agent.id == original.id
+    assert resolution.agent.id != replacement.id
+    assert resolution.agent.name == archived.archived_name
+    assert resolution.requires_enabled_write_guard is False
+    assert resolution.preserves_existing_reference is True
+    assert cli._agent_write_guard_ids(resolution) == (None, original.id)
+
+
 def test_resolve_agent_for_target_allows_unresolved_legacy_scope_backend_without_session_creation(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_cli_task_command.py
+++ b/tests/test_cli_task_command.py
@@ -1858,6 +1858,42 @@ def test_hook_send_guards_an_explicit_agent_inside_enqueue(tmp_path: Path, capsy
     assert captured["expected_enabled_agent_id"] == agent.id
 
 
+def test_hook_send_guards_the_implicit_default_agent_inside_enqueue(tmp_path: Path, capsys) -> None:
+    args = _parse_hook_send(
+        [
+            "--session-key",
+            "slack::channel::C123",
+            "--message",
+            "hello",
+        ]
+    )
+    db_path = tmp_path / "state" / "vibe.sqlite"
+    agent_store = cli.VibeAgentStore(db_path)
+    default_agent = agent_store.ensure_default_agent(backend="codex")
+    captured: dict[str, object] = {}
+
+    def enqueue_hook_send(**kwargs):
+        captured.update(kwargs)
+        return SimpleNamespace(id="run-hook", request_type="agent_run")
+
+    with (
+        patch("vibe.cli.paths.get_state_dir", return_value=db_path.parent),
+        patch("vibe.cli.paths.get_sqlite_state_path", return_value=db_path),
+        patch("vibe.cli._ensure_config", return_value=_configured_v2({"slack"})),
+        patch("vibe.cli._agent_store", return_value=agent_store),
+        patch(
+            "vibe.cli._task_request_store",
+            return_value=SimpleNamespace(enqueue_hook_send=enqueue_hook_send),
+        ),
+    ):
+        result = cli.cmd_hook_send(args)
+
+    assert result == 0
+    assert json.loads(capsys.readouterr().out)["run_id"] == "run-hook"
+    assert captured["agent_name"] == default_agent.name
+    assert captured["expected_enabled_agent_id"] == default_agent.id
+
+
 def test_hook_send_rejects_conflicting_delivery_target_flags(capsys) -> None:
     parser = cli.build_parser()
 

--- a/tests/test_cli_task_command.py
+++ b/tests/test_cli_task_command.py
@@ -197,6 +197,35 @@ def test_agent_remove_cli_localizes_archive_refusal(tmp_path: Path) -> None:
         agent_store.close()
 
 
+def test_agent_update_and_enable_localize_archived_edit_refusal(tmp_path: Path) -> None:
+    agent_store = cli.VibeAgentStore(tmp_path / "state" / "vibe.sqlite")
+    try:
+        agent_store.create(name="archive-fallback", backend="codex")
+        agent_store.create(name="worker", backend="codex")
+        archived = agent_store.archive("worker")
+        assert archived is not None
+        with (
+            patch("vibe.cli._agent_store", return_value=agent_store),
+            patch("vibe.cli.V2Config.load", return_value=SimpleNamespace(language="zh")),
+        ):
+            update_result, update_payload = _capture_stderr_json(
+                cli.cmd_agent_update,
+                _parse_agent(["update", archived.archived_name, "--description", "changed"]),
+            )
+            enable_result, enable_payload = _capture_stderr_json(
+                lambda parsed: cli.cmd_agent_set_enabled(parsed, enabled=True),
+                _parse_agent(["enable", archived.archived_name]),
+            )
+
+        for result, payload in ((update_result, update_payload), (enable_result, enable_payload)):
+            assert result == 1
+            assert payload["code"] == "agent_archived_read_only"
+            assert payload["error"] == f"Agent `{archived.archived_name}` 已归档，无法编辑。"
+            assert payload["hint"] == "已归档 Agent 为只读状态，仅供现有持久引用继续使用。"
+    finally:
+        agent_store.close()
+
+
 def test_agent_list_is_bounded_and_compact_by_default(tmp_path: Path, capsys) -> None:
     agent_store = cli.VibeAgentStore(tmp_path / "state" / "vibe.sqlite")
     for index in range(25):
@@ -895,6 +924,59 @@ def test_task_add_create_session_scope_id_supports_project_scope(tmp_path: Path,
     assert payload["definition"]["cwd"] is None
     assert payload["definition"]["metadata"]["session_scope_id"] == "avibe::project::proj-once-task"
     assert "session_workdir" not in payload["definition"]["metadata"]
+
+
+def test_task_add_releases_create_once_session_when_definition_write_fails(monkeypatch) -> None:
+    _no_caller_context(monkeypatch)
+    args = _parse_task_add(
+        [
+            "--create-session",
+            "--scope-id",
+            "avibe::project::proj-cleanup-task",
+            "--at",
+            "2026-08-02T00:00:00+00:00",
+            "--message",
+            "hello",
+        ]
+    )
+    released: list[tuple[str, str]] = []
+    agent = SimpleNamespace(id="agent-pm", name="pm", backend="claude")
+
+    with (
+        patch(
+            "vibe.cli._resolve_agent_target",
+            return_value=SimpleNamespace(agent=agent, requires_enabled_write_guard=True),
+        ),
+        patch(
+            "vibe.cli._resolve_definition_scope_key",
+            return_value="avibe::project::proj-cleanup-task",
+        ),
+        patch("vibe.cli._resolve_definition_session_cwd", return_value=None),
+        patch("vibe.cli._reserve_definition_session", return_value="ses-reserved-task"),
+        patch("vibe.cli._validate_definition_delivery_target", return_value=(None, None)),
+        patch(
+            "vibe.cli._task_store",
+            return_value=SimpleNamespace(
+                add_task=lambda **_kwargs: (_ for _ in ()).throw(
+                    ValueError("agent 'pm' was archived before the write")
+                )
+            ),
+        ),
+        patch(
+            "vibe.cli._release_definition_session_reservation",
+            side_effect=lambda session_id, *, reason: released.append((session_id, reason)) or True,
+        ),
+    ):
+        result, payload = _capture_stderr_json(cli.cmd_task_add, args)
+
+    assert result == 1
+    assert "archived before the write" in payload["error"]
+    assert released == [
+        (
+            "ses-reserved-task",
+            "task creation failed before its Session reservation was adopted",
+        )
+    ]
 
 
 def test_task_add_create_session_scope_id_uses_unique_definition_anchors(tmp_path: Path, capsys) -> None:

--- a/tests/test_cli_watch_command.py
+++ b/tests/test_cli_watch_command.py
@@ -302,12 +302,26 @@ def test_watch_add_create_per_run_ignores_unresolved_legacy_scope_backend(tmp_pa
             "echo done",
         ]
     )
+    store = ManagedWatchStore(tmp_path / "watches.json")
+    runtime_store = WatchRuntimeStateStore(tmp_path / "watch_runtime.json")
+    original_add_watch = store.add_watch
+    captured: dict[str, object] = {}
+
+    def add_watch(**kwargs):
+        captured.update(kwargs)
+        return original_add_watch(**kwargs)
 
     with (
         patch("vibe.cli.paths.get_state_dir", return_value=db_path.parent),
         patch("vibe.cli.paths.get_sqlite_state_path", return_value=db_path),
         patch("vibe.cli._ensure_config", return_value=_configured_v2({"slack"})),
-        patch("vibe.cli._wait_for_watch_startup", side_effect=lambda *args, **kwargs: _startup_ok(args[0], args[1], args[2])),
+        patch("vibe.cli._watch_store", return_value=store),
+        patch("vibe.cli._watch_runtime_store", return_value=runtime_store),
+        patch.object(store, "add_watch", side_effect=add_watch),
+        patch(
+            "vibe.cli._wait_for_watch_startup",
+            side_effect=lambda *args, **kwargs: _startup_ok(args[0], args[1], args[2]),
+        ),
     ):
         result = cli.cmd_watch_add(args)
 
@@ -315,6 +329,7 @@ def test_watch_add_create_per_run_ignores_unresolved_legacy_scope_backend(tmp_pa
     payload = json.loads(capsys.readouterr().out)
     assert payload["ok"] is True
     assert payload["definition"]["agent_name"] == default_agent.name
+    assert captured["expected_enabled_agent_id"] == default_agent.id
 
 
 def test_watch_add_creates_shell_watch(tmp_path: Path, capsys) -> None:

--- a/tests/test_cli_watch_command.py
+++ b/tests/test_cli_watch_command.py
@@ -332,6 +332,62 @@ def test_watch_add_create_per_run_ignores_unresolved_legacy_scope_backend(tmp_pa
     assert captured["expected_enabled_agent_id"] == default_agent.id
 
 
+def test_watch_add_releases_create_once_session_when_definition_write_fails(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    monkeypatch.delenv("AVIBE_SESSION_ID", raising=False)
+    args = _parse_watch_add(
+        [
+            "--create-session",
+            "--scope-id",
+            "avibe::project::proj-cleanup-watch",
+            "--cwd",
+            str(tmp_path),
+            "--shell",
+            "true",
+        ]
+    )
+    released: list[tuple[str, str]] = []
+    agent = SimpleNamespace(id="agent-pm", name="pm", backend="claude")
+
+    with (
+        patch(
+            "vibe.cli._resolve_agent_target",
+            return_value=SimpleNamespace(agent=agent, requires_enabled_write_guard=True),
+        ),
+        patch(
+            "vibe.cli._resolve_definition_scope_key",
+            return_value="avibe::project::proj-cleanup-watch",
+        ),
+        patch("vibe.cli._resolve_definition_session_cwd", return_value=str(tmp_path)),
+        patch("vibe.cli._reserve_definition_session", return_value="ses-reserved-watch"),
+        patch("vibe.cli._validate_definition_delivery_target", return_value=(None, None)),
+        patch(
+            "vibe.cli._watch_store",
+            return_value=SimpleNamespace(
+                add_watch=lambda **_kwargs: (_ for _ in ()).throw(
+                    ValueError("agent 'pm' was archived before the write")
+                )
+            ),
+        ),
+        patch(
+            "vibe.cli._release_definition_session_reservation",
+            side_effect=lambda session_id, *, reason: released.append((session_id, reason)) or True,
+        ),
+    ):
+        result, payload = _capture_stderr_json(cli.cmd_watch_add, args)
+
+    assert result == 1
+    assert "archived before the write" in payload["error"]
+    assert released == [
+        (
+            "ses-reserved-watch",
+            "watch creation failed before its Session reservation was adopted",
+        )
+    ]
+
+
 def test_watch_add_creates_shell_watch(tmp_path: Path, capsys) -> None:
     store = ManagedWatchStore(tmp_path / "watches.json")
     runtime_store = WatchRuntimeStateStore(tmp_path / "watch_runtime.json")

--- a/tests/test_cli_watch_command.py
+++ b/tests/test_cli_watch_command.py
@@ -113,6 +113,65 @@ def test_watch_add_help_mentions_shell_and_lifetime_timeout(capsys) -> None:
     assert "--deliver-key" not in captured.out
 
 
+def test_watch_update_preserves_archived_agent_reference(tmp_path: Path, capsys) -> None:
+    db_path = cli.paths.get_sqlite_state_path()
+    agent_store = cli.VibeAgentStore(db_path)
+    try:
+        agent = agent_store.create(name="pm", backend="codex")
+        store = ManagedWatchStore()
+        watch = store.add_watch(
+            name="Review watch",
+            session_key="slack::channel::C123",
+            agent_name=agent.name,
+            command=["python3", "wait.py"],
+            shell_command=None,
+            prefix=None,
+            cwd=None,
+            mode="once",
+            timeout_seconds=600,
+            lifetime_timeout_seconds=0,
+            retry_exit_codes=[75],
+            retry_delay_seconds=30,
+            post_to=None,
+            deliver_key=None,
+        )
+        archived = agent_store.archive(agent.name)
+        assert archived is not None
+        store.load()
+        runtime_store = WatchRuntimeStateStore(tmp_path / "watch_runtime.json")
+
+        args = _parse_watch_update([watch.id, "--name", "Renamed watch"])
+        with (
+            patch("vibe.cli._ensure_config", return_value=_configured_v2({"slack"})),
+            patch("vibe.cli._watch_store", return_value=store),
+            patch("vibe.cli._watch_runtime_store", return_value=runtime_store),
+            patch(
+                "vibe.cli._agent_store",
+                side_effect=lambda: cli.VibeAgentStore(db_path),
+            ),
+        ):
+            assert cli.cmd_watch_update(args) == 0
+
+        assert json.loads(capsys.readouterr().out)["definition"]["agent_name"] == archived.archived_name
+        assert ManagedWatchStore().get_watch(watch.id).agent_name == archived.archived_name
+
+        explicit = _parse_watch_update([watch.id, "--agent", archived.archived_name])
+        with (
+            patch("vibe.cli._ensure_config", return_value=_configured_v2({"slack"})),
+            patch("vibe.cli._watch_store", return_value=ManagedWatchStore()),
+            patch("vibe.cli._watch_runtime_store", return_value=runtime_store),
+            patch(
+                "vibe.cli._agent_store",
+                side_effect=lambda: cli.VibeAgentStore(db_path),
+            ),
+        ):
+            result, payload = _capture_stderr_json(cli.cmd_watch_update, explicit)
+        assert result == 1
+        assert "disabled" in payload["error"]
+    finally:
+        agent_store.close()
+
+
 def test_watch_list_help_describes_bounded_history(capsys) -> None:
     parser = cli.build_parser()
 

--- a/tests/test_cli_watch_command.py
+++ b/tests/test_cli_watch_command.py
@@ -372,7 +372,7 @@ def test_watch_add_releases_create_once_session_when_definition_write_fails(
             ),
         ),
         patch(
-            "vibe.cli._release_definition_session_reservation",
+            "vibe.cli._release_cli_session_reservation",
             side_effect=lambda session_id, *, reason: released.append((session_id, reason)) or True,
         ),
     ):

--- a/tests/test_cli_watch_command.py
+++ b/tests/test_cli_watch_command.py
@@ -118,6 +118,7 @@ def test_watch_update_preserves_archived_agent_reference(tmp_path: Path, capsys)
     agent_store = cli.VibeAgentStore(db_path)
     try:
         agent = agent_store.create(name="pm", backend="codex")
+        agent_store.create(name="zz-fallback", backend="codex")
         store = ManagedWatchStore()
         watch = store.add_watch(
             name="Review watch",

--- a/tests/test_controller_vibe_agent_routing.py
+++ b/tests/test_controller_vibe_agent_routing.py
@@ -174,7 +174,7 @@ def test_avibe_run_target_agent_does_not_read_im_routing() -> None:
     controller._get_settings_key = lambda context: context.channel_id
     controller.agent_service = SimpleNamespace(agents={"codex": object(), "claude": object()})
     controller.vibe_agent_store = SimpleNamespace(
-        require_enabled=lambda name: reviewer if name == "reviewer" else None,
+        require_reference=lambda name: reviewer if name == "reviewer" else None,
         get_builtin_default_agent_for_backend=lambda backend: None,
         get_default_agent=lambda: SimpleNamespace(name="default", backend="claude"),
     )

--- a/tests/test_message_handler_typing.py
+++ b/tests/test_message_handler_typing.py
@@ -727,6 +727,54 @@ class MessageHandlerTypingTests(unittest.IsolatedAsyncioTestCase):
             any("archived Agent is disabled" in text for _, text in controller.im_client.sent_messages)
         )
 
+    async def test_unusable_persisted_scope_agent_does_not_fallback_to_backend(self):
+        controller = _StubController(platform="slack", ack_mode="reaction", typing_result=True)
+        controller.settings_manager.routing = type(
+            "Routing",
+            (),
+            {"agent_name": "_worker-ab12"},
+        )()
+        observed = {}
+
+        def _reject_archived_agent(
+            _context,
+            *,
+            override_agent_id=None,
+            override_agent_name=None,
+            required=False,
+        ):
+            observed.update(
+                agent_id=override_agent_id,
+                agent_name=override_agent_name,
+                required=required,
+            )
+            raise ValueError("archived scope Agent is disabled")
+
+        controller.resolve_vibe_agent_for_context = _reject_archived_agent
+        handler = MessageHandler(controller)
+        handler.set_session_handler(_StubSessionHandler())
+        context = MessageContext(
+            user_id="U1",
+            channel_id="C1",
+            message_id="m1",
+            platform="slack",
+        )
+
+        await handler.handle_user_message(context, "start a new thread")
+
+        self.assertEqual(
+            observed,
+            {
+                "agent_id": None,
+                "agent_name": None,
+                "required": True,
+            },
+        )
+        self.assertEqual(controller.agent_service.requests, [])
+        self.assertTrue(
+            any("archived scope Agent is disabled" in text for _, text in controller.im_client.sent_messages)
+        )
+
     async def test_existing_session_backend_does_not_attach_default_vibe_agent_metadata(self):
         controller = _StubController(platform="slack", ack_mode="reaction", typing_result=True)
         handler = MessageHandler(controller)

--- a/tests/test_message_handler_typing.py
+++ b/tests/test_message_handler_typing.py
@@ -676,6 +676,67 @@ class MessageHandlerTypingTests(unittest.IsolatedAsyncioTestCase):
         agent_name, _ = controller.agent_service.requests[0]
         self.assertEqual(agent_name, "codex")
 
+    async def test_existing_im_thread_resolves_agent_by_stable_id(self):
+        controller = _StubController(platform="slack", ack_mode="reaction", typing_result=True)
+        controller.settings_manager.sessions.find_session_for_anchor = lambda *_args: {
+            "id": "ses_preserved",
+            "agent_id": "agent-original",
+            "agent_name": "pm",
+            "agent_backend": "claude",
+            "visibility": "foreground",
+        }
+        observed = {}
+
+        def _resolve_agent(
+            _context,
+            *,
+            override_agent_id=None,
+            override_agent_name=None,
+            required=False,
+        ):
+            observed.update(
+                agent_id=override_agent_id,
+                agent_name=override_agent_name,
+                required=required,
+            )
+            return type(
+                "VibeAgent",
+                (),
+                {
+                    "id": "agent-original",
+                    "name": "_pm-ab12",
+                    "backend": "claude",
+                    "model": "claude-opus",
+                    "reasoning_effort": None,
+                    "system_prompt": None,
+                },
+            )()
+
+        controller.resolve_vibe_agent_for_context = _resolve_agent
+        handler = MessageHandler(controller)
+        handler.set_session_handler(_StubSessionHandler())
+        context = MessageContext(
+            user_id="U1",
+            channel_id="C1",
+            message_id="m1",
+            platform="slack",
+        )
+
+        await handler.handle_user_message(context, "continue")
+
+        self.assertEqual(
+            observed,
+            {
+                "agent_id": "agent-original",
+                "agent_name": "pm",
+                "required": True,
+            },
+        )
+        agent_name, request = controller.agent_service.requests[0]
+        self.assertEqual(agent_name, "claude")
+        self.assertEqual(request.vibe_agent_id, "agent-original")
+        self.assertEqual(request.vibe_agent_name, "_pm-ab12")
+
     async def test_unusable_durable_session_agent_does_not_fallback_to_backend(self):
         controller = _StubController(platform="avibe", ack_mode="reaction", typing_result=True)
         observed = {}

--- a/tests/test_message_handler_typing.py
+++ b/tests/test_message_handler_typing.py
@@ -758,6 +758,7 @@ class MessageHandlerTypingTests(unittest.IsolatedAsyncioTestCase):
             channel_id="C1",
             message_id="m1",
             platform="slack",
+            platform_specific={"agent_run_target": {"agent_backend": "codex"}},
         )
 
         await handler.handle_user_message(context, "start a new thread")

--- a/tests/test_message_handler_typing.py
+++ b/tests/test_message_handler_typing.py
@@ -214,7 +214,13 @@ class _StubController:
     def resolve_agent_for_context(self, context):
         return "codex"
 
-    def resolve_vibe_agent_for_context(self, context, override_agent_name=None, required=False):
+    def resolve_vibe_agent_for_context(
+        self,
+        context,
+        override_agent_id=None,
+        override_agent_name=None,
+        required=False,
+    ):
         if override_agent_name:
             return type(
                 "VibeAgent",
@@ -669,6 +675,57 @@ class MessageHandlerTypingTests(unittest.IsolatedAsyncioTestCase):
 
         agent_name, _ = controller.agent_service.requests[0]
         self.assertEqual(agent_name, "codex")
+
+    async def test_unusable_durable_session_agent_does_not_fallback_to_backend(self):
+        controller = _StubController(platform="avibe", ack_mode="reaction", typing_result=True)
+        observed = {}
+
+        def _reject_archived_agent(
+            _context,
+            *,
+            override_agent_id=None,
+            override_agent_name=None,
+            required=False,
+        ):
+            observed.update(
+                agent_id=override_agent_id,
+                agent_name=override_agent_name,
+                required=required,
+            )
+            raise ValueError("archived Agent is disabled")
+
+        controller.resolve_vibe_agent_for_context = _reject_archived_agent
+        handler = MessageHandler(controller)
+        handler.set_session_handler(_StubSessionHandler())
+        context = MessageContext(
+            user_id="workbench",
+            channel_id="ses_archived",
+            message_id="m1",
+            platform="avibe",
+            platform_specific={
+                "agent_session_target": {
+                    "id": "ses_archived",
+                    "agent_id": "agent-archived",
+                    "agent_name": "_worker-ab12",
+                    "agent_backend": "codex",
+                }
+            },
+        )
+
+        await handler.handle_user_message(context, "continue")
+
+        self.assertEqual(
+            observed,
+            {
+                "agent_id": "agent-archived",
+                "agent_name": "_worker-ab12",
+                "required": True,
+            },
+        )
+        self.assertEqual(controller.agent_service.requests, [])
+        self.assertTrue(
+            any("archived Agent is disabled" in text for _, text in controller.im_client.sent_messages)
+        )
 
     async def test_existing_session_backend_does_not_attach_default_vibe_agent_metadata(self):
         controller = _StubController(platform="slack", ack_mode="reaction", typing_result=True)

--- a/tests/test_messages_service.py
+++ b/tests/test_messages_service.py
@@ -107,11 +107,21 @@ def test_agent_run_message_provenance_enrichment(isolated_state):
     #  - source_kind='callback' → source_actor is a run id; the source is the
     #    PARENT (delegated) run's session.
     # A non-agent_run harness message (task trigger) is left untouched.
+    from core.vibe_agents import VibeAgentStore
+
+    store = VibeAgentStore()
+    store.create(name="archive-fallback", backend="claude")
+    caller_agent = store.create(name="pm", backend="claude")
     engine = create_sqlite_engine()
     with engine.begin() as conn:
         scope_id = _seed_scope(conn)
         _seed_session(conn, scope_id, "ses_target")
-        _seed_titled_agent_session(conn, scope_id, "ses_caller", title="Caller 总控", agent_name="pm")
+        _seed_titled_agent_session(conn, scope_id, "ses_caller", title=None, agent_name="pm")
+        conn.execute(
+            agent_sessions.update()
+            .where(agent_sessions.c.id == "ses_caller")
+            .values(agent_id=caller_agent.id)
+        )
         _seed_titled_agent_session(conn, scope_id, "ses_delegated", title="Delegated 审计", agent_name="evm")
         # Agent spawn: source_actor is the caller session.
         _insert_agent_run(conn, "execAgent", session_id="ses_target",
@@ -131,11 +141,15 @@ def test_agent_run_message_provenance_enrichment(isolated_state):
                             author_id="def_1", native_message_id="scheduled:def_1:execB",
                             msg_id="msg_task", created_at="2026-05-30T10:00:02Z")
 
+    archived = store.archive("pm")
+    assert archived is not None
+    store.close()
+
     with engine.connect() as conn:
         result = messages_service.list_session_messages(conn, session_id="ses_target")
     by_id = {m["id"]: m for m in result["messages"]}
     assert by_id["msg_agent"]["source_session_id"] == "ses_caller"
-    assert by_id["msg_agent"]["source_session_title"] == "Caller 总控"
+    assert by_id["msg_agent"]["source_session_title"] is None
     assert by_id["msg_agent"]["source_session_agent_name"] == "pm"
     # Callback resolves through the parent run's session, not the run-id source_actor.
     assert by_id["msg_cb"]["source_session_id"] == "ses_delegated"

--- a/tests/test_projects_service.py
+++ b/tests/test_projects_service.py
@@ -389,8 +389,10 @@ def test_project_agent_save_serializes_with_archive_and_rejects_stale_route(engi
         assert preserved["default_agent"]["agent_name"] == archived.archived_name
 
         with engine.begin() as conn:
-            with pytest.raises(ValueError, match="Agent is unavailable: pm"):
+            with pytest.raises(projects_service.ProjectAgentUnavailableError) as exc:
                 projects_service.update_project(conn, created["id"], agent_name="pm")
+        assert exc.value.code == "project_agent_unavailable"
+        assert exc.value.agent_name == "pm"
         with engine.connect() as conn:
             stored_name = conn.execute(
                 select(scope_settings.c.agent_name).where(

--- a/tests/test_projects_service.py
+++ b/tests/test_projects_service.py
@@ -312,6 +312,7 @@ def test_update_project_clears_default_agent(engine, tmp_path):
 
 def test_project_agent_save_serializes_with_archive_and_rejects_stale_route(engine, tmp_path):
     _ensure_agent("pm", "claude")
+    _ensure_agent("zz-fallback", "claude")
     folder = tmp_path / "proj"
     folder.mkdir()
     with engine.begin() as conn:

--- a/tests/test_projects_service.py
+++ b/tests/test_projects_service.py
@@ -291,6 +291,28 @@ def test_update_project_sets_and_reads_default_agent(engine, tmp_path):
     assert listed["default_agent"]["agent_backend"] == "claude"
 
 
+def test_update_project_canonicalizes_normalized_agent_name(engine, tmp_path):
+    _ensure_agent("Project Manager", "claude")
+    folder = tmp_path / "proj"
+    folder.mkdir()
+
+    with engine.begin() as conn:
+        created = projects_service.create_project(conn, str(folder))
+        updated = projects_service.update_project(
+            conn,
+            created["id"],
+            agent_name="PROJECT-MANAGER",
+        )
+        stored_name = conn.execute(
+            select(scope_settings.c.agent_name).where(
+                scope_settings.c.scope_id == created["scope_id"]
+            )
+        ).scalar_one()
+
+    assert updated["default_agent"]["agent_name"] == "Project Manager"
+    assert stored_name == "Project Manager"
+
+
 def test_update_project_clears_default_agent(engine, tmp_path):
     _ensure_agent("codex", "codex")
     folder = tmp_path / "proj"

--- a/tests/test_projects_service.py
+++ b/tests/test_projects_service.py
@@ -8,7 +8,11 @@ project is restored after archiving, without a dedicated unarchive endpoint.
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
+from sqlalchemy import event, select
+from sqlalchemy.exc import OperationalError
 
 from core.vibe_agents import VibeAgentStore
 from storage import projects_service
@@ -288,6 +292,7 @@ def test_update_project_sets_and_reads_default_agent(engine, tmp_path):
 
 
 def test_update_project_clears_default_agent(engine, tmp_path):
+    _ensure_agent("codex", "codex")
     folder = tmp_path / "proj"
     folder.mkdir()
     with engine.begin() as conn:
@@ -303,6 +308,72 @@ def test_update_project_clears_default_agent(engine, tmp_path):
             reasoning_effort=None,
         )
     assert cleared["default_agent"] is None
+
+
+def test_project_agent_save_serializes_with_archive_and_rejects_stale_route(engine, tmp_path):
+    _ensure_agent("pm", "claude")
+    folder = tmp_path / "proj"
+    folder.mkdir()
+    with engine.begin() as conn:
+        created = projects_service.create_project(conn, str(folder))
+        projects_service.update_project(conn, created["id"], agent_name="pm")
+
+    competitor = VibeAgentStore(Path(str(engine.url.database)))
+    race: dict[str, object] = {"fired": 0, "refused": [], "committed": 0}
+
+    @event.listens_for(competitor.engine, "checkout")
+    def _no_wait(dbapi_connection, *_args) -> None:
+        cursor = dbapi_connection.cursor()
+        cursor.execute("PRAGMA busy_timeout = 0")
+        cursor.close()
+
+    @event.listens_for(engine, "after_cursor_execute")
+    def _archive_on_project_read(
+        _conn, _cursor, statement, _parameters, _context, _executemany
+    ) -> None:
+        normalized = " ".join(statement.split())
+        if race["fired"] or "SELECT scopes.id FROM scopes WHERE scopes.id" not in normalized:
+            return
+        race["fired"] = 1
+        try:
+            competitor.archive("pm")
+        except OperationalError as exc:
+            race["refused"].append(str(exc))
+        else:
+            race["committed"] = 1
+
+    try:
+        with engine.begin() as conn:
+            updated = projects_service.update_project(conn, created["id"], agent_name="pm")
+        assert updated["default_agent"]["agent_name"] == "pm"
+        assert race["fired"] == 1
+        assert race["committed"] == 0
+        assert len(race["refused"]) == 1
+
+        archived = competitor.archive("pm")
+        assert archived is not None
+        with engine.begin() as conn:
+            preserved = projects_service.update_project(
+                conn,
+                created["id"],
+                display_name="Still archived",
+                agent_name=archived.archived_name,
+            )
+        assert preserved["display_name"] == "Still archived"
+        assert preserved["default_agent"]["agent_name"] == archived.archived_name
+
+        with engine.begin() as conn:
+            with pytest.raises(ValueError, match="Agent is unavailable: pm"):
+                projects_service.update_project(conn, created["id"], agent_name="pm")
+        with engine.connect() as conn:
+            stored_name = conn.execute(
+                select(scope_settings.c.agent_name).where(
+                    scope_settings.c.scope_id == created["scope_id"]
+                )
+            ).scalar_one()
+        assert stored_name == archived.archived_name
+    finally:
+        competitor.close()
 
 
 def test_rename_leaves_default_agent_untouched(engine, tmp_path):

--- a/tests/test_projects_service.py
+++ b/tests/test_projects_service.py
@@ -29,11 +29,13 @@ def engine():
     return create_sqlite_engine()
 
 
-def _ensure_agent(name: str, backend: str) -> None:
+def _ensure_agent(name: str, backend: str) -> str:
     store = VibeAgentStore()
     try:
-        if store.get(name) is None:
-            store.create(name=name, backend=backend)
+        agent = store.get(name)
+        if agent is None:
+            agent = store.create(name=name, backend=backend)
+        return agent.id
     finally:
         store.close()
 
@@ -263,7 +265,7 @@ def test_new_project_has_no_default_agent(engine, tmp_path):
 
 
 def test_update_project_sets_and_reads_default_agent(engine, tmp_path):
-    _ensure_agent("claude", "claude")
+    agent_id = _ensure_agent("claude", "claude")
     folder = tmp_path / "proj"
     folder.mkdir()
     with engine.begin() as conn:
@@ -277,6 +279,7 @@ def test_update_project_sets_and_reads_default_agent(engine, tmp_path):
             reasoning_effort="high",
         )
     assert updated["default_agent"] == {
+        "agent_id": agent_id,
         "agent_backend": "claude",
         "agent_name": "claude",
         "agent_variant": "claude",
@@ -397,6 +400,63 @@ def test_project_agent_save_serializes_with_archive_and_rejects_stale_route(engi
         assert stored_name == archived.archived_name
     finally:
         competitor.close()
+
+
+def test_project_agent_save_uses_stable_id_when_the_public_name_is_reused(engine, tmp_path):
+    original_id = _ensure_agent("pm", "claude")
+    _ensure_agent("zz-fallback", "claude")
+    folder = tmp_path / "proj"
+    folder.mkdir()
+    with engine.begin() as conn:
+        created = projects_service.create_project(conn, str(folder))
+        projects_service.update_project(conn, created["id"], agent_name="pm")
+
+    store = VibeAgentStore(Path(str(engine.url.database)))
+    try:
+        archived = store.archive("pm")
+        assert archived is not None
+        replacement = store.create(name="pm", backend="codex")
+
+        with engine.begin() as conn:
+            preserved = projects_service.update_project(
+                conn,
+                created["id"],
+                agent_id=original_id,
+                expected_agent_id=original_id,
+                agent_name="pm",
+                model="updated-model",
+            )
+        assert preserved["default_agent"]["agent_id"] == original_id
+        assert preserved["default_agent"]["agent_name"] == archived.archived_name
+        assert preserved["default_agent"]["model"] == "updated-model"
+
+        with engine.begin() as conn:
+            rebound = projects_service.update_project(
+                conn,
+                created["id"],
+                agent_id=replacement.id,
+                expected_agent_id=original_id,
+                agent_name=replacement.name,
+            )
+        assert rebound["default_agent"]["agent_id"] == replacement.id
+        assert rebound["default_agent"]["agent_name"] == replacement.name
+
+        with engine.begin() as conn:
+            with pytest.raises(projects_service.StaleProjectAgentBindingError) as exc:
+                projects_service.update_project(
+                    conn,
+                    created["id"],
+                    agent_id=original_id,
+                    expected_agent_id=original_id,
+                    agent_name="pm",
+                )
+        assert exc.value.details == {
+            "project_id": created["id"],
+            "expected_agent_id": original_id,
+            "current_agent_id": replacement.id,
+        }
+    finally:
+        store.close()
 
 
 def test_rename_leaves_default_agent_untouched(engine, tmp_path):

--- a/tests/test_scheduled_tasks.py
+++ b/tests/test_scheduled_tasks.py
@@ -6830,6 +6830,69 @@ def test_claimed_request_refreshes_agent_name_after_archive(monkeypatch, tmp_pat
         agent_store.close()
 
 
+def test_claimed_request_keeps_agent_identity_when_archive_lands_after_refresh(
+    monkeypatch, tmp_path: Path
+) -> None:
+    from core.vibe_agents import VibeAgentStore
+
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    agent_store = VibeAgentStore()
+    try:
+        agent = agent_store.create(name="pm", backend="claude")
+        request_store = TaskExecutionStore()
+        request = request_store.enqueue_hook_send(
+            session_key="slack::channel::C123",
+            prompt="continue",
+            agent_name=agent.name,
+        )
+        claimed = request_store.claim(request.id)
+        assert claimed is not None
+
+        original_refresh = request_store.refresh_claimed_request
+        archived_result = None
+
+        def _refresh_then_archive(item):
+            nonlocal archived_result
+            refreshed = original_refresh(item)
+            assert refreshed.agent_id == agent.id
+            archived_result = agent_store.archive(agent.name)
+            return refreshed
+
+        request_store.refresh_claimed_request = _refresh_then_archive  # type: ignore[method-assign]
+        calls: list[dict[str, Any]] = []
+        service = ScheduledTaskService(
+            controller=SimpleNamespace(),
+            store=ScheduledTaskStore(),
+            request_store=request_store,
+        )
+
+        async def _execute_request(**kwargs):
+            calls.append(kwargs)
+            return None
+
+        service._execute_request = _execute_request  # type: ignore[method-assign]
+        asyncio.run(service._execute_claimed_request(claimed))
+
+        assert archived_result is not None
+        assert calls == [
+            {
+                "session_key": "slack::channel::C123",
+                "session_id": None,
+                "post_to": None,
+                "deliver_key": None,
+                "prompt": "continue",
+                "execution_id": request.id,
+                "task_id": None,
+                "trigger_kind": "hook",
+                "agent_name": "pm",
+                "agent_id": agent.id,
+            }
+        ]
+        assert agent_store.require_reference_by_id(agent.id).name == archived_result.archived_name
+    finally:
+        agent_store.close()
+
+
 def test_drain_requests_agent_run_passes_agent_name(tmp_path: Path) -> None:
     request_store = TaskExecutionStore(tmp_path / "task_requests")
     request = request_store.enqueue_agent_run(

--- a/tests/test_scheduled_tasks.py
+++ b/tests/test_scheduled_tasks.py
@@ -9928,7 +9928,7 @@ def test_rebind_propagates_an_operational_fault_instead_of_resetting_the_route(
     def _contended(self, name):  # noqa: ANN001
         raise OperationalError("SELECT agents.id ...", {}, sqlite3.OperationalError("database is locked"))
 
-    monkeypatch.setattr(VibeAgentStore, "require_enabled", _contended)
+    monkeypatch.setattr(VibeAgentStore, "require_reference", _contended)
 
     reloaded = store.get_task(task.id)
     assert reloaded is not None

--- a/tests/test_scheduled_tasks.py
+++ b/tests/test_scheduled_tasks.py
@@ -6798,6 +6798,7 @@ def test_claimed_request_refreshes_agent_name_after_archive(monkeypatch, tmp_pat
     agent_store = VibeAgentStore()
     try:
         agent = agent_store.create(name="pm", backend="claude")
+        agent_store.create(name="zz-fallback", backend="claude")
         request_store = TaskExecutionStore()
         request = request_store.enqueue_hook_send(
             session_key="slack::channel::C123",
@@ -6839,6 +6840,7 @@ def test_claimed_request_keeps_agent_identity_when_archive_lands_after_refresh(
     agent_store = VibeAgentStore()
     try:
         agent = agent_store.create(name="pm", backend="claude")
+        agent_store.create(name="zz-fallback", backend="claude")
         request_store = TaskExecutionStore()
         request = request_store.enqueue_hook_send(
             session_key="slack::channel::C123",

--- a/tests/test_scheduled_tasks.py
+++ b/tests/test_scheduled_tasks.py
@@ -6791,6 +6791,45 @@ def test_drain_requests_records_scheduled_create_per_run_reserved_session(tmp_pa
     assert payload["session_key"] == ""
 
 
+def test_claimed_request_refreshes_agent_name_after_archive(monkeypatch, tmp_path: Path) -> None:
+    from core.vibe_agents import VibeAgentStore
+
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    agent_store = VibeAgentStore()
+    try:
+        agent = agent_store.create(name="pm", backend="claude")
+        request_store = TaskExecutionStore()
+        request = request_store.enqueue_hook_send(
+            session_key="slack::channel::C123",
+            prompt="continue",
+            agent_name=agent.name,
+        )
+        claimed = request_store.claim(request.id)
+        assert claimed is not None
+        assert claimed.agent_name == "pm"
+
+        archived = agent_store.archive("pm")
+        assert archived is not None
+        calls: list[dict[str, Any]] = []
+        service = ScheduledTaskService(
+            controller=SimpleNamespace(),
+            store=ScheduledTaskStore(),
+            request_store=request_store,
+        )
+
+        async def _execute_request(**kwargs):
+            calls.append(kwargs)
+            return None
+
+        service._execute_request = _execute_request  # type: ignore[method-assign]
+        asyncio.run(service._execute_claimed_request(claimed))
+
+        assert len(calls) == 1
+        assert calls[0]["agent_name"] == archived.archived_name
+    finally:
+        agent_store.close()
+
+
 def test_drain_requests_agent_run_passes_agent_name(tmp_path: Path) -> None:
     request_store = TaskExecutionStore(tmp_path / "task_requests")
     request = request_store.enqueue_agent_run(

--- a/tests/test_session_fork.py
+++ b/tests/test_session_fork.py
@@ -934,6 +934,35 @@ def test_reserve_forked_session_rejects_archived_inherited_agent(tmp_path: Path)
     assert result.agent_name == replacement.name
 
 
+def test_reserve_forked_session_canonicalizes_legacy_inherited_agent_name(tmp_path: Path) -> None:
+    db_path = tmp_path / "vibe.sqlite"
+    source_id = _seed_source_session(db_path, tmp_path)
+    engine = create_sqlite_engine(db_path)
+    try:
+        with engine.begin() as conn:
+            conn.execute(
+                agent_sessions.update()
+                .where(agent_sessions.c.id == source_id)
+                .values(agent_name="WORKER")
+            )
+    finally:
+        engine.dispose()
+
+    result = reserve_forked_session(source_session_id=source_id, db_path=db_path)
+
+    assert result.agent_name == "worker"
+    engine = create_sqlite_engine(db_path)
+    try:
+        with engine.connect() as conn:
+            assert conn.execute(
+                select(agent_sessions.c.agent_name).where(
+                    agent_sessions.c.id == result.session_id
+                )
+            ).scalar_one() == "worker"
+    finally:
+        engine.dispose()
+
+
 def test_reserve_forked_session_agent_override_keeps_source_model_when_not_overridden(tmp_path: Path) -> None:
     db_path = tmp_path / "vibe.sqlite"
     source_id = _seed_source_session(db_path, tmp_path)

--- a/tests/test_session_fork.py
+++ b/tests/test_session_fork.py
@@ -8,6 +8,7 @@ import pytest
 from sqlalchemy import func, select
 
 from core.services.session_fork import (
+    SESSION_AGENT_UNAVAILABLE_CODE,
     SessionForkError,
     SourceMessageAnchor,
     fork_anchor_is_terminal_agent_output,
@@ -912,8 +913,10 @@ def test_reserve_forked_session_rejects_archived_inherited_agent(tmp_path: Path)
     finally:
         engine.dispose()
 
-    with pytest.raises(SessionForkError, match="source session Agent is unavailable"):
+    with pytest.raises(SessionForkError, match="source session Agent is unavailable") as exc_info:
         reserve_forked_session(source_session_id=source_id, db_path=db_path)
+    assert exc_info.value.code == SESSION_AGENT_UNAVAILABLE_CODE
+    assert exc_info.value.details == {"source_session_id": source_id}
 
     engine = create_sqlite_engine(db_path)
     try:

--- a/tests/test_session_fork.py
+++ b/tests/test_session_fork.py
@@ -5,7 +5,7 @@ import sqlite3
 from pathlib import Path
 
 import pytest
-from sqlalchemy import select
+from sqlalchemy import func, select
 
 from core.services.session_fork import (
     SessionForkError,
@@ -29,8 +29,13 @@ from storage.sessions_service import SQLiteSessionsService
 from storage.settings_service import upsert_scope
 
 
-def _seed_source_session(db_path: Path, tmp_path: Path) -> str:
+def _seed_source_session(db_path: Path, tmp_path: Path, *, backend: str = "codex") -> str:
     SQLiteSessionsService(db_path).close()
+    store = VibeAgentStore(db_path)
+    try:
+        worker = store.create(name="worker", backend=backend)
+    finally:
+        store.close()
     engine = create_sqlite_engine(db_path)
     try:
         with engine.begin() as conn:
@@ -48,8 +53,8 @@ def _seed_source_session(db_path: Path, tmp_path: Path) -> str:
                     role=None,
                     workdir=str(tmp_path),
                     agent_name="worker",
-                    agent_backend="codex",
-                    agent_variant="codex",
+                    agent_backend=backend,
+                    agent_variant=backend,
                     model="gpt-5",
                     reasoning_effort="medium",
                     require_mention=None,
@@ -63,9 +68,9 @@ def _seed_source_session(db_path: Path, tmp_path: Path) -> str:
                 conn,
                 scope_id=scope_id,
                 session_anchor=None,
-                agent_backend="codex",
-                agent_variant="codex",
-                agent_id="agent-worker",
+                agent_backend=backend,
+                agent_variant=backend,
+                agent_id=worker.id,
                 agent_name="worker",
                 model="gpt-5",
                 reasoning_effort="medium",
@@ -228,7 +233,7 @@ def test_reserve_forked_session_infers_running_input_anchor_without_live_hint(
 
 def test_reserve_forked_session_does_not_infer_trim_for_claude(tmp_path: Path) -> None:
     db_path = tmp_path / "vibe.sqlite"
-    source_id = _seed_source_session(db_path, tmp_path)
+    source_id = _seed_source_session(db_path, tmp_path, backend="claude")
     engine = create_sqlite_engine(db_path)
     try:
         with engine.begin() as conn:
@@ -304,7 +309,7 @@ def test_reserve_forked_opencode_running_fork_records_frozen_native_message(
     xdg_home = tmp_path / "xdg"
     monkeypatch.setenv("XDG_DATA_HOME", str(xdg_home))
     _seed_opencode_messages(xdg_home, "oc-source", ["user", "assistant", "user"])
-    source_id = _seed_source_session(db_path, tmp_path)
+    source_id = _seed_source_session(db_path, tmp_path, backend="opencode")
     engine = create_sqlite_engine(db_path)
     try:
         with engine.begin() as conn:
@@ -378,7 +383,7 @@ def test_reserve_forked_opencode_active_run_freezes_native_boundary_without_live
     xdg_home = tmp_path / "xdg"
     monkeypatch.setenv("XDG_DATA_HOME", str(xdg_home))
     _seed_opencode_messages(xdg_home, "oc-source", ["user", "assistant", "user"])
-    source_id = _seed_source_session(db_path, tmp_path)
+    source_id = _seed_source_session(db_path, tmp_path, backend="opencode")
     engine = create_sqlite_engine(db_path)
     try:
         with engine.begin() as conn:
@@ -466,7 +471,7 @@ def test_reserve_forked_opencode_running_first_turn_records_user_boundary(
     xdg_home = tmp_path / "xdg"
     monkeypatch.setenv("XDG_DATA_HOME", str(xdg_home))
     _seed_opencode_messages(xdg_home, "oc-source", ["user"])
-    source_id = _seed_source_session(db_path, tmp_path)
+    source_id = _seed_source_session(db_path, tmp_path, backend="opencode")
     engine = create_sqlite_engine(db_path)
     try:
         with engine.begin() as conn:
@@ -513,7 +518,7 @@ def test_reserve_forked_session_clears_stale_opencode_active_run_boundary(
     xdg_home = tmp_path / "xdg"
     monkeypatch.setenv("XDG_DATA_HOME", str(xdg_home))
     _seed_opencode_messages(xdg_home, "oc-source", ["user"])
-    source_id = _seed_source_session(db_path, tmp_path)
+    source_id = _seed_source_session(db_path, tmp_path, backend="opencode")
     engine = create_sqlite_engine(db_path)
     try:
         with engine.begin() as conn:
@@ -561,7 +566,7 @@ def test_reserve_forked_opencode_missing_boundary_preserves_trim_intent(
     xdg_home = tmp_path / "xdg"
     monkeypatch.setenv("XDG_DATA_HOME", str(xdg_home))
     _seed_opencode_messages(xdg_home, "oc-source", [])
-    source_id = _seed_source_session(db_path, tmp_path)
+    source_id = _seed_source_session(db_path, tmp_path, backend="opencode")
     engine = create_sqlite_engine(db_path)
     try:
         with engine.begin() as conn:
@@ -694,6 +699,11 @@ def test_reserve_forked_session_keeps_im_anchor_and_resets_variant_for_agent_ove
 def test_reserve_forked_session_reanchors_when_moved_to_new_im_scope(tmp_path: Path) -> None:
     db_path = tmp_path / "vibe.sqlite"
     SQLiteSessionsService(db_path).close()
+    store = VibeAgentStore(db_path)
+    try:
+        worker = store.create(name="worker", backend="codex")
+    finally:
+        store.close()
     engine = create_sqlite_engine(db_path)
     try:
         with engine.begin() as conn:
@@ -736,7 +746,7 @@ def test_reserve_forked_session_reanchors_when_moved_to_new_im_scope(tmp_path: P
                 session_anchor="slack_171717.123",
                 agent_backend="codex",
                 agent_variant="codex",
-                agent_id="agent-worker",
+                agent_id=worker.id,
                 agent_name="worker",
                 workdir=str(tmp_path),
                 native_session_id="thread-source",
@@ -794,6 +804,11 @@ def test_reserve_forked_session_reanchors_when_moved_to_new_im_scope(tmp_path: P
 def test_reserve_forked_session_reanchors_explicit_parent_scope(tmp_path: Path) -> None:
     db_path = tmp_path / "vibe.sqlite"
     SQLiteSessionsService(db_path).close()
+    store = VibeAgentStore(db_path)
+    try:
+        worker = store.create(name="worker", backend="codex")
+    finally:
+        store.close()
     engine = create_sqlite_engine(db_path)
     try:
         with engine.begin() as conn:
@@ -828,7 +843,7 @@ def test_reserve_forked_session_reanchors_explicit_parent_scope(tmp_path: Path) 
                 session_anchor="slack_171717.123",
                 agent_backend="codex",
                 agent_variant="codex",
-                agent_id="agent-worker",
+                agent_id=worker.id,
                 agent_name="worker",
                 workdir=str(tmp_path),
                 native_session_id="thread-source",
@@ -875,6 +890,48 @@ def test_reserve_forked_session_rejects_backend_change(tmp_path: Path) -> None:
             agent_name="claude-worker",
             db_path=db_path,
         )
+
+
+def test_reserve_forked_session_rejects_archived_inherited_agent(tmp_path: Path) -> None:
+    db_path = tmp_path / "vibe.sqlite"
+    source_id = _seed_source_session(db_path, tmp_path)
+    store = VibeAgentStore(db_path)
+    try:
+        replacement = store.create(name="reviewer", backend="codex")
+        archived = store.archive("worker")
+        assert archived is not None
+    finally:
+        store.close()
+
+    engine = create_sqlite_engine(db_path)
+    try:
+        with engine.connect() as conn:
+            session_count = conn.execute(
+                select(func.count()).select_from(agent_sessions)
+            ).scalar_one()
+    finally:
+        engine.dispose()
+
+    with pytest.raises(SessionForkError, match="source session Agent is unavailable"):
+        reserve_forked_session(source_session_id=source_id, db_path=db_path)
+
+    engine = create_sqlite_engine(db_path)
+    try:
+        with engine.connect() as conn:
+            assert (
+                conn.execute(select(func.count()).select_from(agent_sessions)).scalar_one()
+                == session_count
+            )
+    finally:
+        engine.dispose()
+
+    result = reserve_forked_session(
+        source_session_id=source_id,
+        agent_name=replacement.name,
+        db_path=db_path,
+    )
+    assert result.agent_id == replacement.id
+    assert result.agent_name == replacement.name
 
 
 def test_reserve_forked_session_agent_override_keeps_source_model_when_not_overridden(tmp_path: Path) -> None:

--- a/tests/test_show_pages_admin_api.py
+++ b/tests/test_show_pages_admin_api.py
@@ -93,6 +93,7 @@ def test_list_show_pages_preserves_archived_agent_display_name(monkeypatch, tmp_
     store = VibeAgentStore()
     try:
         original = store.create(name="pm", backend="claude")
+        store.create(name="zz-fallback", backend="claude")
         _seed_session(
             "ses_archived_agent",
             agent_id=original.id,

--- a/tests/test_show_pages_admin_api.py
+++ b/tests/test_show_pages_admin_api.py
@@ -8,7 +8,13 @@ from vibe import api
 from vibe.ui_server import app
 
 
-def _seed_session(session_id: str, *, title: str | None = None) -> None:
+def _seed_session(
+    session_id: str,
+    *,
+    title: str | None = None,
+    agent_id: str | None = None,
+    agent_name: str | None = None,
+) -> None:
     from storage import messages_service
     from storage.db import create_sqlite_engine
     from storage.importer import ensure_sqlite_state
@@ -25,6 +31,8 @@ def _seed_session(session_id: str, *, title: str | None = None) -> None:
                 agent_sessions.insert().values(
                     id=session_id,
                     scope_id=scope_id,
+                    agent_id=agent_id,
+                    agent_name=agent_name,
                     agent_backend="claude",
                     agent_variant="default",
                     session_anchor="anchor_" + session_id,
@@ -74,6 +82,39 @@ def test_list_show_pages_orders_newest_first_and_joins_title(monkeypatch, tmp_pa
     assert by_id["ses_plain"]["visibility"] == "private"
     updated_ats = [page["updated_at"] for page in result["pages"]]
     assert updated_ats == sorted(updated_ats, reverse=True)
+
+
+def test_list_show_pages_preserves_archived_agent_display_name(monkeypatch, tmp_path):
+    from core.vibe_agents import VibeAgentStore
+    from storage.models import agent_sessions
+
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    _save_config(tmp_path)
+    store = VibeAgentStore()
+    try:
+        original = store.create(name="pm", backend="claude")
+        _seed_session(
+            "ses_archived_agent",
+            agent_id=original.id,
+            agent_name=original.name,
+        )
+        _set_visibility("ses_archived_agent", "private")
+
+        archived = store.archive(original.name)
+        assert archived is not None
+        result = api.list_show_pages()
+
+        page = next(item for item in result["pages"] if item["session_id"] == "ses_archived_agent")
+        assert page["agent"] == "pm"
+        with store.engine.connect() as conn:
+            internal_name = conn.execute(
+                agent_sessions.select()
+                .with_only_columns(agent_sessions.c.agent_name)
+                .where(agent_sessions.c.id == "ses_archived_agent")
+            ).scalar_one()
+        assert internal_name == archived.archived_name
+    finally:
+        store.close()
 
 
 def test_set_show_page_visibility_public_then_offline(monkeypatch, tmp_path):

--- a/tests/test_sqlite_settings_store.py
+++ b/tests/test_sqlite_settings_store.py
@@ -617,6 +617,32 @@ def test_settings_save_rejects_new_archived_binding_but_preserves_existing(tmp_p
         store.close()
 
 
+def test_settings_save_canonicalizes_normalized_agent_binding(tmp_path: Path) -> None:
+    settings_path = tmp_path / "settings.json"
+    store = SettingsStore(settings_path)
+    agent_store = VibeAgentStore(tmp_path / "vibe.sqlite")
+    try:
+        agent_store.create(name="Project Manager", backend="claude")
+
+        settings = ChannelSettings(
+            enabled=True,
+            routing=RoutingSettings(agent_name="PROJECT-MANAGER"),
+        )
+        store.update_channel("C1", settings, platform="slack")
+
+        assert settings.routing.agent_name == "Project Manager"
+        with agent_store.engine.connect() as conn:
+            stored_name = conn.execute(
+                select(scope_settings.c.agent_name).where(
+                    scope_settings.c.scope_id == "slack::channel::C1"
+                )
+            ).scalar_one()
+        assert stored_name == "Project Manager"
+    finally:
+        agent_store.close()
+        store.close()
+
+
 def test_settings_save_preserves_observed_scope_metadata(tmp_path: Path) -> None:
     db_path = tmp_path / "vibe.sqlite"
     run_migrations(db_path)

--- a/tests/test_sqlite_settings_store.py
+++ b/tests/test_sqlite_settings_store.py
@@ -18,6 +18,7 @@ from storage.models import scope_settings, scopes
 from storage.sessions_service import SQLiteSessionsService
 from storage.settings_service import (
     SQLiteSettingsService,
+    ScopeAgentUnavailableError,
     StaleScopeAgentBindingError,
     upsert_scope,
 )
@@ -69,6 +70,8 @@ def test_channel_require_bind_persists(tmp_path: Path) -> None:
 
 def test_telegram_thread_settings_round_trip_and_parent_fallback(tmp_path: Path) -> None:
     settings_path = tmp_path / "settings.json"
+    agent_store = VibeAgentStore(tmp_path / "vibe.sqlite")
+    agent_store.create(name="reviewer", backend="codex")
     store = SettingsStore(settings_path)
     parent = ChannelSettings(enabled=True, require_mention=True, require_bind=False)
     topic = ChannelSettings(
@@ -101,6 +104,7 @@ def test_telegram_thread_settings_round_trip_and_parent_fallback(tmp_path: Path)
         assert reloaded.find_effective_channel("-1001", thread_id="42", platform="telegram").require_mention is True
     finally:
         reloaded.close()
+        agent_store.close()
 
 
 def test_bound_and_enabled_user_checks_are_separate(tmp_path: Path) -> None:
@@ -559,6 +563,52 @@ def test_settings_save_serializes_and_reconciles_stale_agent_bindings(tmp_path: 
             conflicting_store.close()
         store.close()
         agents_store.close()
+
+
+def test_settings_save_rejects_new_archived_binding_but_preserves_existing(tmp_path: Path) -> None:
+    settings_path = tmp_path / "settings.json"
+    store = SettingsStore(settings_path)
+    agent_store = VibeAgentStore(tmp_path / "vibe.sqlite")
+    try:
+        agent_store.create(name="pm", backend="claude")
+        store.update_channel(
+            "C1",
+            ChannelSettings(enabled=True, routing=RoutingSettings(agent_name="pm")),
+            platform="slack",
+        )
+        archived = agent_store.archive("pm")
+        assert archived is not None
+
+        reloaded = SettingsStore(settings_path)
+        try:
+            existing = reloaded.find_channel("C1", platform="slack")
+            assert existing is not None
+            assert existing.routing.agent_name == archived.archived_name
+            existing.custom_cwd = "/preserved"
+            reloaded.save()
+
+            with pytest.raises(ScopeAgentUnavailableError, match="Agent is unavailable"):
+                reloaded.update_channel(
+                    "C2",
+                    ChannelSettings(
+                        enabled=True,
+                        routing=RoutingSettings(agent_name=archived.archived_name),
+                    ),
+                    platform="slack",
+                )
+        finally:
+            reloaded.close()
+
+        with agent_store.engine.connect() as conn:
+            rows = conn.execute(
+                select(scope_settings.c.scope_id, scope_settings.c.agent_name, scope_settings.c.workdir)
+                .where(scope_settings.c.scope_id.in_(("slack::channel::C1", "slack::channel::C2")))
+                .order_by(scope_settings.c.scope_id)
+            ).all()
+        assert rows == [("slack::channel::C1", archived.archived_name, "/preserved")]
+    finally:
+        agent_store.close()
+        store.close()
 
 
 def test_settings_save_preserves_observed_scope_metadata(tmp_path: Path) -> None:

--- a/tests/test_sqlite_settings_store.py
+++ b/tests/test_sqlite_settings_store.py
@@ -453,6 +453,7 @@ def test_settings_save_serializes_and_reconciles_stale_agent_bindings(tmp_path: 
     conflicting_store = None
     try:
         agents_store.create(name="pm", backend="claude")
+        agents_store.create(name="zz-fallback", backend="claude")
         route = RoutingSettings(agent_name="pm")
         store.update_channel(
             "C1",
@@ -574,6 +575,7 @@ def test_settings_save_rejects_new_archived_binding_but_preserves_existing(tmp_p
     agent_store = VibeAgentStore(tmp_path / "vibe.sqlite")
     try:
         agent_store.create(name="pm", backend="claude")
+        agent_store.create(name="zz-fallback", backend="claude")
         store.update_channel(
             "C1",
             ChannelSettings(enabled=True, routing=RoutingSettings(agent_name="pm")),

--- a/tests/test_sqlite_settings_store.py
+++ b/tests/test_sqlite_settings_store.py
@@ -571,6 +571,50 @@ def test_settings_save_serializes_and_reconciles_stale_agent_bindings(tmp_path: 
         agents_store.close()
 
 
+def test_client_binding_expectation_survives_server_reload_before_scope_save(tmp_path: Path) -> None:
+    settings_path = tmp_path / "settings.json"
+    initial = SettingsStore(settings_path)
+    agent_store = VibeAgentStore(tmp_path / "vibe.sqlite")
+    reloaded = None
+    try:
+        original = agent_store.create(name="pm", backend="claude")
+        agent_store.create(name="zz-fallback", backend="claude")
+        initial.update_channel(
+            "C1",
+            ChannelSettings(enabled=True, routing=RoutingSettings(agent_name=original.name)),
+            platform="slack",
+        )
+
+        archived = agent_store.archive(original.name)
+        assert archived is not None
+        replacement = agent_store.create(name="pm", backend="codex")
+        reloaded = SettingsStore(settings_path)
+        stale_form = ChannelSettings(
+            enabled=True,
+            custom_cwd="/saved-after-reload",
+            routing=RoutingSettings(agent_name="pm"),
+            _agent_name_at_load="pm",
+        )
+
+        reloaded.set_channels_for_platform("slack", {"C1": stale_form})
+        reloaded.save()
+
+        assert stale_form.routing.agent_name == archived.archived_name
+        with agent_store.engine.connect() as conn:
+            stored = conn.execute(
+                select(scope_settings.c.agent_name, scope_settings.c.workdir).where(
+                    scope_settings.c.scope_id == "slack::channel::C1"
+                )
+            ).one()
+        assert stored == (archived.archived_name, "/saved-after-reload")
+        assert stored.agent_name != replacement.name
+    finally:
+        if reloaded is not None:
+            reloaded.close()
+        initial.close()
+        agent_store.close()
+
+
 def test_settings_save_rejects_new_archived_binding_but_preserves_existing(tmp_path: Path) -> None:
     settings_path = tmp_path / "settings.json"
     store = SettingsStore(settings_path)
@@ -594,7 +638,7 @@ def test_settings_save_rejects_new_archived_binding_but_preserves_existing(tmp_p
             existing.custom_cwd = "/preserved"
             reloaded.save()
 
-            with pytest.raises(ScopeAgentUnavailableError, match="Agent is unavailable"):
+            with pytest.raises(ScopeAgentUnavailableError) as unavailable:
                 reloaded.update_channel(
                     "C2",
                     ChannelSettings(
@@ -603,6 +647,8 @@ def test_settings_save_rejects_new_archived_binding_but_preserves_existing(tmp_p
                     ),
                     platform="slack",
                 )
+            assert unavailable.value.code == "agent_unavailable"
+            assert unavailable.value.agent_name == archived.archived_name
             assert reloaded.find_channel("C2", platform="slack") is None
         finally:
             reloaded.close()

--- a/tests/test_sqlite_settings_store.py
+++ b/tests/test_sqlite_settings_store.py
@@ -509,6 +509,9 @@ def test_settings_save_serializes_and_reconciles_stale_agent_bindings(tmp_path: 
         conflicting.routing.agent_name = "codex"
         with pytest.raises(StaleScopeAgentBindingError, match="Agent binding changed"):
             conflicting_store.update_channel("C1", conflicting, platform="slack")
+        refreshed_conflict = conflicting_store.find_channel("C1", platform="slack")
+        assert refreshed_conflict is not None
+        assert refreshed_conflict.routing.agent_name == archived.archived_name
 
         store.settings.channels["slack::C1"].custom_cwd = "/stale-channel"
         store.settings.threads["slack::C1/T1"].custom_cwd = "/stale-thread"
@@ -596,6 +599,7 @@ def test_settings_save_rejects_new_archived_binding_but_preserves_existing(tmp_p
                     ),
                     platform="slack",
                 )
+            assert reloaded.find_channel("C2", platform="slack") is None
         finally:
             reloaded.close()
 

--- a/tests/test_sqlite_settings_store.py
+++ b/tests/test_sqlite_settings_store.py
@@ -4,17 +4,23 @@ import json
 from pathlib import Path
 
 import pytest
-from sqlalchemy import select
+from sqlalchemy import event, select
+from sqlalchemy.exc import OperationalError
 
 from config import paths
 from config import v2_settings
 from config.v2_settings import ChannelSettings, RoutingSettings, SettingsState, SettingsStore, UserSettings
+from core.vibe_agents import VibeAgentStore
 from storage import projects_service
 from storage.db import create_sqlite_engine
 from storage.migrations import run_migrations
 from storage.models import scope_settings, scopes
 from storage.sessions_service import SQLiteSessionsService
-from storage.settings_service import SQLiteSettingsService, upsert_scope
+from storage.settings_service import (
+    SQLiteSettingsService,
+    StaleScopeAgentBindingError,
+    upsert_scope,
+)
 from modules.settings_manager import SettingsManager
 
 
@@ -434,6 +440,125 @@ def test_save_state_preserves_project_scope_settings(tmp_path: Path) -> None:
 
     assert row is not None, "project scope_settings was deleted by a settings save"
     assert row[0] == str(folder.resolve())
+
+
+def test_settings_save_serializes_and_reconciles_stale_agent_bindings(tmp_path: Path) -> None:
+    settings_path = tmp_path / "settings.json"
+    store = SettingsStore(settings_path)
+    agents_store = VibeAgentStore(tmp_path / "vibe.sqlite")
+    conflicting_store = None
+    try:
+        agents_store.create(name="pm", backend="claude")
+        route = RoutingSettings(agent_name="pm")
+        store.update_channel(
+            "C1",
+            ChannelSettings(enabled=True, routing=route),
+            platform="slack",
+        )
+        store.update_thread(
+            "C1",
+            "T1",
+            ChannelSettings(enabled=True, routing=RoutingSettings(agent_name="pm")),
+            platform="slack",
+        )
+        store.update_user(
+            "U1",
+            UserSettings(display_name="Pat", routing=RoutingSettings(agent_name="pm")),
+            platform="slack",
+        )
+
+        race: dict[str, object] = {"fired": 0, "refused": [], "committed": 0}
+
+        @event.listens_for(agents_store.engine, "checkout")
+        def _no_wait(dbapi_connection, *_args) -> None:
+            cursor = dbapi_connection.cursor()
+            cursor.execute("PRAGMA busy_timeout = 0")
+            cursor.close()
+
+        @event.listens_for(store._service.engine, "after_cursor_execute")
+        def _archive_on_binding_read(
+            _conn, _cursor, statement, _parameters, _context, _executemany
+        ) -> None:
+            normalized = " ".join(statement.split())
+            if race["fired"] or "SELECT scope_settings.agent_name" not in normalized:
+                return
+            race["fired"] = 1
+            try:
+                agents_store.archive("pm")
+            except OperationalError as exc:
+                race["refused"].append(str(exc))
+            else:
+                race["committed"] = 1
+
+        store.save()
+        assert race["fired"] == 1
+        assert race["committed"] == 0
+        assert len(race["refused"]) == 1
+
+        conflicting_store = SettingsStore(settings_path)
+        archived = agents_store.archive("pm")
+        assert archived is not None
+        replacement = agents_store.create(name="pm", backend="codex")
+
+        conflicting = conflicting_store.find_channel("C1", platform="slack")
+        assert conflicting is not None
+        conflicting.routing.agent_name = "codex"
+        with pytest.raises(StaleScopeAgentBindingError, match="Agent binding changed"):
+            conflicting_store.update_channel("C1", conflicting, platform="slack")
+
+        store.settings.channels["slack::C1"].custom_cwd = "/stale-channel"
+        store.settings.threads["slack::C1/T1"].custom_cwd = "/stale-thread"
+        store.settings.users["slack::U1"].custom_cwd = "/stale-user"
+        store.save()
+        assert store.settings.channels["slack::C1"].routing.agent_name == archived.archived_name
+        assert store.settings.threads["slack::C1/T1"].routing.agent_name == archived.archived_name
+        assert store.settings.users["slack::U1"].routing.agent_name == archived.archived_name
+
+        with agents_store.engine.connect() as conn:
+            rows = conn.execute(
+                select(
+                    scopes.c.scope_type,
+                    scope_settings.c.agent_name,
+                    scope_settings.c.workdir,
+                    scope_settings.c.settings_json,
+                )
+                .select_from(scopes.join(scope_settings, scope_settings.c.scope_id == scopes.c.id))
+                .where(scopes.c.id.in_(("slack::channel::C1", "slack::thread::C1/T1", "slack::user::U1")))
+                .order_by(scopes.c.scope_type)
+            ).mappings().all()
+        assert len(rows) == 3
+        assert {row["agent_name"] for row in rows} == {archived.archived_name}
+        assert {row["workdir"] for row in rows} == {
+            "/stale-channel",
+            "/stale-thread",
+            "/stale-user",
+        }
+        assert {
+            json.loads(row["settings_json"])["routing"]["agent_name"] for row in rows
+        } == {archived.archived_name}
+
+        store.close()
+        fresh = SettingsStore(settings_path)
+        try:
+            channel = fresh.find_channel("C1", platform="slack")
+            assert channel is not None
+            channel.routing.agent_name = replacement.name
+            fresh.update_channel("C1", channel, platform="slack")
+        finally:
+            fresh.close()
+
+        with agents_store.engine.connect() as conn:
+            rebound = conn.execute(
+                select(scope_settings.c.agent_name).where(
+                    scope_settings.c.scope_id == "slack::channel::C1"
+                )
+            ).scalar_one()
+        assert rebound == replacement.name
+    finally:
+        if conflicting_store is not None:
+            conflicting_store.close()
+        store.close()
+        agents_store.close()
 
 
 def test_settings_save_preserves_observed_scope_metadata(tmp_path: Path) -> None:

--- a/tests/test_sqlite_settings_store.py
+++ b/tests/test_sqlite_settings_store.py
@@ -508,8 +508,10 @@ def test_settings_save_serializes_and_reconciles_stale_agent_bindings(tmp_path: 
         conflicting = conflicting_store.find_channel("C1", platform="slack")
         assert conflicting is not None
         conflicting.routing.agent_name = "codex"
-        with pytest.raises(StaleScopeAgentBindingError, match="Agent binding changed"):
+        with pytest.raises(StaleScopeAgentBindingError) as exc:
             conflicting_store.update_channel("C1", conflicting, platform="slack")
+        assert exc.value.code == "settings_conflict"
+        assert exc.value.scope_id == "slack::channel::C1"
         refreshed_conflict = conflicting_store.find_channel("C1", platform="slack")
         assert refreshed_conflict is not None
         assert refreshed_conflict.routing.agent_name == archived.archived_name

--- a/tests/test_sqlite_state_migration.py
+++ b/tests/test_sqlite_state_migration.py
@@ -26,7 +26,7 @@ from storage.settings_service import SQLiteSettingsService
 from vibe.message_types import build_partial_index_predicate
 
 
-HEAD_REVISION = "20260729_0042"
+HEAD_REVISION = "20260731_0043"
 MESSAGE_PARTIAL_INDEX_PREDICATES = {
     "ix_messages_inbox_activity": (
         "session_id is not null and type not in "

--- a/tests/test_ui_api.py
+++ b/tests/test_ui_api.py
@@ -2830,6 +2830,29 @@ def test_vibe_agent_api_localizes_archive_refusal(tmp_path, monkeypatch):
     assert result["message"] == "没有其他已启用 Agent 时，无法归档默认 Agent `only-agent`。"
 
 
+def test_vibe_agent_api_localizes_reserved_create_and_rename_names(tmp_path, monkeypatch):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path / ".vibe_remote"))
+    monkeypatch.setattr(
+        api.V2Config,
+        "load",
+        staticmethod(lambda: type("Config", (), {"language": "zh"})()),
+    )
+
+    create_result = api.create_vibe_agent({"name": "_hidden", "backend": "codex"})
+    api.create_vibe_agent({"name": "worker", "backend": "codex"})
+    rename_result = api.update_vibe_agent("worker", {"name": "review/team"})
+
+    assert create_result == {
+        "ok": False,
+        "code": "agent_name_reserved",
+        "message": "Agent 名称不能以下划线 `_` 开头；该命名空间由 Avibe 保留。",
+        "hint": "请选择不以下划线 `_` 开头的 Agent 名称。",
+    }
+    assert rename_result["ok"] is False
+    assert rename_result["code"] == "agent_name_path_separator"
+    assert rename_result["message"] == "Agent 名称不能包含 `/` 或 `\\`。"
+
+
 def test_vibe_agent_catalog_ensures_builtin_defaults_for_enabled_backends(tmp_path, monkeypatch):
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path / ".vibe_remote"))
 

--- a/tests/test_ui_api.py
+++ b/tests/test_ui_api.py
@@ -2697,7 +2697,9 @@ def test_telegram_topic_settings_api_and_discovery_payload(tmp_path, monkeypatch
     # Scenario: TELEGRAM-TOPIC-001
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path / ".avibe"))
     SettingsStore.reset_instance()
+    agent_store = VibeAgentStore()
     try:
+        agent_store.create(name="reviewer", backend="codex")
         store = SettingsStore.get_instance()
         store.update_channel("-1001", ChannelSettings(enabled=True, require_mention=True), platform="telegram")
         chat_discovery.remember_chat(
@@ -2736,6 +2738,7 @@ def test_telegram_topic_settings_api_and_discovery_payload(tmp_path, monkeypatch
         assert api.get_settings("telegram")["threads"] == {}
     finally:
         SettingsStore.reset_instance()
+        agent_store.close()
 
 
 def test_telegram_topic_settings_materialize_inherited_mention_default(tmp_path, monkeypatch):

--- a/tests/test_ui_api.py
+++ b/tests/test_ui_api.py
@@ -2830,6 +2830,29 @@ def test_vibe_agent_api_localizes_archive_refusal(tmp_path, monkeypatch):
     assert result["message"] == "没有其他已启用 Agent 时，无法归档默认 Agent `only-agent`。"
 
 
+def test_vibe_agent_api_localizes_archived_edit_refusal(tmp_path, monkeypatch):
+    store = VibeAgentStore(tmp_path / "state" / "vibe.sqlite")
+    store.create(name="archive-fallback", backend="codex")
+    store.create(name="worker", backend="codex")
+    archived = store.archive("worker")
+    assert archived is not None
+    monkeypatch.setattr(api, "VibeAgentStore", lambda: store)
+    monkeypatch.setattr(
+        api.V2Config,
+        "load",
+        staticmethod(lambda: type("Config", (), {"language": "zh"})()),
+    )
+
+    result = api.update_vibe_agent(archived.archived_name, {"description": "changed"})
+
+    assert result == {
+        "ok": False,
+        "code": "agent_archived_read_only",
+        "message": f"Agent `{archived.archived_name}` 已归档，无法编辑。",
+        "hint": "已归档 Agent 为只读状态，仅供现有持久引用继续使用。",
+    }
+
+
 def test_vibe_agent_api_localizes_reserved_create_and_rename_names(tmp_path, monkeypatch):
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path / ".vibe_remote"))
     monkeypatch.setattr(

--- a/tests/test_ui_api.py
+++ b/tests/test_ui_api.py
@@ -2830,6 +2830,31 @@ def test_vibe_agent_api_localizes_archive_refusal(tmp_path, monkeypatch):
     assert result["message"] == "没有其他已启用 Agent 时，无法归档默认 Agent `only-agent`。"
 
 
+def test_vibe_agent_api_localizes_invalid_reference_metadata_on_rename(monkeypatch):
+    class RefusingStore:
+        def rename(self, _name, _new_name):
+            raise api.AgentReferenceRewriteError()
+
+        def close(self):
+            return None
+
+    monkeypatch.setattr(api, "VibeAgentStore", RefusingStore)
+    monkeypatch.setattr(
+        api.V2Config,
+        "load",
+        staticmethod(lambda: type("Config", (), {"language": "zh"})()),
+    )
+
+    result = api.update_vibe_agent("worker", {"name": "renamed-worker"})
+
+    assert result == {
+        "ok": False,
+        "code": "agent_reference_metadata_invalid",
+        "message": "任务或监控包含无效元数据，Avibe 无法更新 Agent 引用。",
+        "hint": "请修复或删除元数据异常的任务或监控，然后重试。",
+    }
+
+
 def test_vibe_agent_api_localizes_archived_edit_refusal(tmp_path, monkeypatch):
     store = VibeAgentStore(tmp_path / "state" / "vibe.sqlite")
     store.create(name="archive-fallback", backend="codex")

--- a/tests/test_ui_api.py
+++ b/tests/test_ui_api.py
@@ -2798,6 +2798,7 @@ def test_vibe_agent_api_crud_and_settings_catalog(tmp_path, monkeypatch):
 def test_vibe_agent_api_delete_archives_and_hides_agent(tmp_path, monkeypatch):
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path / ".vibe_remote"))
     api.create_vibe_agent({"name": "reviewer", "backend": "codex"})
+    api.create_vibe_agent({"name": "zz-fallback", "backend": "codex"})
 
     removed = api.remove_vibe_agent("reviewer")
 
@@ -2958,6 +2959,7 @@ def test_builtin_default_agent_does_not_lock_existing_user_agent(tmp_path, monke
     store = VibeAgentStore()
     try:
         created = store.create(name="opencode", backend="opencode")
+        store.create(name="zz-fallback", backend="opencode")
         ensured = store.ensure_builtin_default_agent(backend="opencode")
 
         assert ensured.id == created.id

--- a/tests/test_ui_api.py
+++ b/tests/test_ui_api.py
@@ -2729,6 +2729,7 @@ def test_telegram_topic_settings_api_and_discovery_payload(tmp_path, monkeypatch
         assert saved["ok"] is True
         assert settings["threads"]["-1001"]["42"]["require_mention"] is False
         assert settings["threads"]["-1001"]["42"]["require_bind"] is True
+        assert settings["threads"]["-1001"]["42"]["expected_agent_name"] == "reviewer"
         group = next(channel for channel in chats["channels"] if channel["id"] == "-1001")
         assert group["topics"][0]["name"] == "Releases"
         assert group["topics"][0]["configured"] is True

--- a/tests/test_ui_api.py
+++ b/tests/test_ui_api.py
@@ -2792,6 +2792,22 @@ def test_vibe_agent_api_crud_and_settings_catalog(tmp_path, monkeypatch):
     assert updated["agent"]["model"] == "gpt-5.5"
 
 
+def test_vibe_agent_api_delete_archives_and_hides_agent(tmp_path, monkeypatch):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path / ".vibe_remote"))
+    api.create_vibe_agent({"name": "reviewer", "backend": "codex"})
+
+    removed = api.remove_vibe_agent("reviewer")
+
+    assert removed["ok"] is True
+    assert removed["removed_agent"] == "reviewer"
+    assert removed["archived_agent"]["name"].startswith("_archived_")
+    assert removed["archived_agent"]["display_name"] == "reviewer"
+    assert removed["archived_agent"]["archived"] is True
+    assert "reviewer" not in [agent["name"] for agent in api.get_vibe_agents(include_disabled=True)["agents"]]
+    archived = api.get_vibe_agents(include_disabled=True, include_archived=True)["agents"]
+    assert removed["archived_agent"]["name"] in [agent["name"] for agent in archived]
+
+
 def test_vibe_agent_catalog_ensures_builtin_defaults_for_enabled_backends(tmp_path, monkeypatch):
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path / ".vibe_remote"))
 

--- a/tests/test_ui_api.py
+++ b/tests/test_ui_api.py
@@ -2812,6 +2812,24 @@ def test_vibe_agent_api_delete_archives_and_hides_agent(tmp_path, monkeypatch):
     assert removed["archived_agent"]["name"] in [agent["name"] for agent in archived]
 
 
+def test_vibe_agent_api_localizes_archive_refusal(tmp_path, monkeypatch):
+    store = VibeAgentStore(tmp_path / "state" / "vibe.sqlite")
+    store.create(name="only-agent", backend="codex")
+    store.set_default_agent_name("only-agent")
+    monkeypatch.setattr(api, "VibeAgentStore", lambda: store)
+    monkeypatch.setattr(
+        api.V2Config,
+        "load",
+        staticmethod(lambda: type("Config", (), {"language": "zh"})()),
+    )
+
+    result = api.remove_vibe_agent("only-agent")
+
+    assert result["ok"] is False
+    assert result["code"] == "agent_no_default_replacement"
+    assert result["message"] == "没有其他已启用 Agent 时，无法归档默认 Agent `only-agent`。"
+
+
 def test_vibe_agent_catalog_ensures_builtin_defaults_for_enabled_backends(tmp_path, monkeypatch):
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path / ".vibe_remote"))
 

--- a/tests/test_ui_api.py
+++ b/tests/test_ui_api.py
@@ -2800,7 +2800,7 @@ def test_vibe_agent_api_delete_archives_and_hides_agent(tmp_path, monkeypatch):
 
     assert removed["ok"] is True
     assert removed["removed_agent"] == "reviewer"
-    assert removed["archived_agent"]["name"].startswith("_archived_")
+    assert removed["archived_agent"]["name"].startswith("_reviewer-")
     assert removed["archived_agent"]["display_name"] == "reviewer"
     assert removed["archived_agent"]["archived"] is True
     assert "reviewer" not in [agent["name"] for agent in api.get_vibe_agents(include_disabled=True)["agents"]]

--- a/tests/test_ui_server_fastapi.py
+++ b/tests/test_ui_server_fastapi.py
@@ -1105,6 +1105,48 @@ def test_workbench_projects_bootstrap_returns_requested_session_pages(monkeypatc
     assert page["next_before_id"] == page["sessions"][0]["id"]
 
 
+def test_project_patch_rejects_stale_agent_route_after_archive(monkeypatch, tmp_path):
+    from core.vibe_agents import VibeAgentStore
+    from sqlalchemy import select
+    from storage.db import create_sqlite_engine
+    from storage.models import scope_settings
+    from storage.projects_service import create_project, update_project
+
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    ensure_sqlite_state()
+    engine = create_sqlite_engine()
+    folder = tmp_path / "project"
+    folder.mkdir()
+    store = VibeAgentStore()
+    try:
+        store.create(name="pm", backend="claude")
+        with engine.begin() as conn:
+            project = create_project(conn, str(folder), display_name="Project")
+            update_project(conn, project["id"], agent_name="pm")
+        archived = store.archive("pm")
+        assert archived is not None
+
+        client = app.test_client()
+        response = client.patch(
+            f"/api/projects/{project['id']}",
+            json={"agent_name": "pm"},
+            headers=csrf_headers(client),
+        )
+
+        assert response.status_code == 400
+        assert response.get_json() == {"error": "Agent is unavailable: pm"}
+        with engine.connect() as conn:
+            stored_name = conn.execute(
+                select(scope_settings.c.agent_name).where(
+                    scope_settings.c.scope_id == project["scope_id"]
+                )
+            ).scalar_one()
+        assert stored_name == archived.archived_name
+    finally:
+        store.close()
+        engine.dispose()
+
+
 def test_config_get_on_fresh_install_returns_default_needing_setup(monkeypatch, tmp_path):
     # Fresh install edge: no config file exists yet, but the setup wizard
     # (and the reused provider-config modal that calls getConfig()) must be

--- a/tests/test_ui_server_fastapi.py
+++ b/tests/test_ui_server_fastapi.py
@@ -2582,3 +2582,127 @@ def test_sessions_create_preserves_metadata_without_web_push_owner(monkeypatch, 
     metadata = response.get_json()["metadata"]
     assert metadata["client"] == "test"
     assert "_web_push_user_key" not in metadata
+
+
+def test_sessions_create_locks_before_agent_validation(monkeypatch, tmp_path):
+    from core.vibe_agents import VibeAgentStore
+    from sqlalchemy import event
+    from sqlalchemy.exc import OperationalError
+    from storage.db import create_sqlite_engine
+    from storage.projects_service import create_project
+
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    ensure_sqlite_state()
+    route_engine = create_sqlite_engine()
+    agent_store = VibeAgentStore()
+    competitor = VibeAgentStore()
+    try:
+        agent_store.create(name="pm", backend="codex")
+        project_dir = tmp_path / "locked-create-project"
+        project_dir.mkdir()
+        with route_engine.begin() as conn:
+            project = create_project(conn, str(project_dir), display_name="Project")
+
+        race = {"fired": 0, "refused": 0, "committed": 0}
+
+        @event.listens_for(competitor.engine, "checkout")
+        def _no_wait(dbapi_connection, *_args) -> None:
+            cursor = dbapi_connection.cursor()
+            cursor.execute("PRAGMA busy_timeout = 0")
+            cursor.close()
+
+        @event.listens_for(route_engine, "after_cursor_execute")
+        def _archive_on_agent_read(
+            _conn, _cursor, statement, _parameters, _context, _executemany
+        ) -> None:
+            if race["fired"] or "FROM agents" not in " ".join(statement.split()):
+                return
+            race["fired"] = 1
+            try:
+                competitor.archive("pm")
+            except OperationalError:
+                race["refused"] = 1
+            else:
+                race["committed"] = 1
+
+        monkeypatch.setattr(ui_server, "_projects_engine", lambda: route_engine)
+        client = app.test_client()
+        response = client.post(
+            "/api/sessions",
+            json={"project_id": project["id"], "agent_name": "pm", "agent_backend": "codex"},
+            headers=csrf_headers(client),
+        )
+
+        assert response.status_code == 201
+        assert response.get_json()["agent_name"] == "pm"
+        assert race == {"fired": 1, "refused": 1, "committed": 0}
+    finally:
+        competitor.close()
+        agent_store.close()
+        route_engine.dispose()
+
+
+def test_sessions_patch_locks_before_agent_validation(monkeypatch, tmp_path):
+    from core.vibe_agents import VibeAgentStore
+    from sqlalchemy import event
+    from sqlalchemy.exc import OperationalError
+    from storage.db import create_sqlite_engine
+    from storage.projects_service import create_project
+    from storage.workbench_sessions_service import create_session
+
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    ensure_sqlite_state()
+    route_engine = create_sqlite_engine()
+    agent_store = VibeAgentStore()
+    competitor = VibeAgentStore()
+    try:
+        agent_store.create(name="pm", backend="codex")
+        agent_store.create(name="reviewer", backend="codex")
+        project_dir = tmp_path / "locked-patch-project"
+        project_dir.mkdir()
+        with route_engine.begin() as conn:
+            project = create_project(conn, str(project_dir), display_name="Project")
+            session = create_session(
+                conn,
+                scope_id=project["scope_id"],
+                agent_name="pm",
+                agent_backend="codex",
+            )
+
+        race = {"fired": 0, "refused": 0, "committed": 0}
+
+        @event.listens_for(competitor.engine, "checkout")
+        def _no_wait(dbapi_connection, *_args) -> None:
+            cursor = dbapi_connection.cursor()
+            cursor.execute("PRAGMA busy_timeout = 0")
+            cursor.close()
+
+        @event.listens_for(route_engine, "after_cursor_execute")
+        def _archive_on_agent_read(
+            _conn, _cursor, statement, _parameters, _context, _executemany
+        ) -> None:
+            if race["fired"] or "FROM agents" not in " ".join(statement.split()):
+                return
+            race["fired"] = 1
+            try:
+                competitor.archive("reviewer")
+            except OperationalError:
+                race["refused"] = 1
+            else:
+                race["committed"] = 1
+
+        monkeypatch.setattr(ui_server, "_projects_engine", lambda: route_engine)
+        client = app.test_client()
+        response = client.patch(
+            f"/api/sessions/{session['id']}",
+            json={"agent_name": "reviewer", "agent_backend": "codex"},
+            headers=csrf_headers(client),
+        )
+
+        assert response.status_code == 200
+        assert response.get_json()["agent_name"] == "reviewer"
+        assert race == {"fired": 1, "refused": 1, "committed": 0}
+    finally:
+        competitor.close()
+        agent_store.close()
+        route_engine.dispose()

--- a/tests/test_ui_server_fastapi.py
+++ b/tests/test_ui_server_fastapi.py
@@ -1,5 +1,6 @@
 import gzip
 import json
+from types import SimpleNamespace
 
 import pytest
 
@@ -115,13 +116,19 @@ def test_thread_settings_routes_use_native_fastapi(monkeypatch):
     assert deleted_scopes == [("telegram", "-1001", "42")]
 
 
-def test_scope_settings_routes_report_stale_agent_binding_conflicts(monkeypatch):
+def test_scope_settings_routes_report_localized_stale_agent_binding_conflicts(monkeypatch):
+    from core.services import settings as settings_service
     from storage.settings_service import StaleScopeAgentBindingError
     from vibe import api
 
     def stale(*_args, **_kwargs):
-        raise StaleScopeAgentBindingError("Agent binding changed while settings were open")
+        raise StaleScopeAgentBindingError(scope_id="slack::channel::C1")
 
+    monkeypatch.setattr(
+        settings_service,
+        "load_config_or_default",
+        lambda: SimpleNamespace(language="zh"),
+    )
     monkeypatch.setattr(api, "save_settings", stale)
     monkeypatch.setattr(api, "save_thread_settings", stale)
     monkeypatch.setattr(api, "save_users", stale)
@@ -143,11 +150,13 @@ def test_scope_settings_routes_report_stale_agent_binding_conflicts(monkeypatch)
         assert response.get_json() == {
             "ok": False,
             "code": "settings_conflict",
-            "message": "Agent binding changed while settings were open",
+            "message": "这些设置打开后，Agent 路由已发生变化。",
             "error": {
                 "code": "settings_conflict",
-                "message": "Agent binding changed while settings were open",
+                "message": "这些设置打开后，Agent 路由已发生变化。",
             },
+            "hint": "请重新加载设置后再次修改。",
+            "details": {"scope_id": "slack::channel::C1"},
         }
 
 
@@ -1230,6 +1239,66 @@ def test_project_patch_rejects_stale_agent_route_after_archive(monkeypatch, tmp_
     finally:
         store.close()
         engine.dispose()
+
+
+def test_project_patch_forwards_stable_agent_ids_and_localizes_conflicts(monkeypatch):
+    from core.services import settings as settings_service
+    from storage import projects_service
+
+    captured: dict[str, object] = {}
+
+    def stale(_conn, project_id, **kwargs):
+        captured.update({"project_id": project_id, **kwargs})
+        raise projects_service.StaleProjectAgentBindingError(
+            project_id=project_id,
+            expected_agent_id="agent-original",
+            current_agent_id="agent-replacement",
+        )
+
+    monkeypatch.setattr(projects_service, "update_project", stale)
+    monkeypatch.setattr(
+        settings_service,
+        "load_config_or_default",
+        lambda: SimpleNamespace(language="zh"),
+    )
+
+    client = app.test_client()
+    response = client.patch(
+        "/api/projects/proj-stale",
+        json={
+            "agent_id": "agent-original",
+            "expected_agent_id": "agent-original",
+            "agent_name": "pm",
+            "model": "updated-model",
+        },
+        headers=csrf_headers(client),
+    )
+
+    assert captured == {
+        "project_id": "proj-stale",
+        "display_name": None,
+        "folder_path": None,
+        "agent_id": "agent-original",
+        "expected_agent_id": "agent-original",
+        "agent_name": "pm",
+        "model": "updated-model",
+    }
+    assert response.status_code == 409
+    assert response.get_json() == {
+        "ok": False,
+        "code": "project_agent_conflict",
+        "message": "项目设置打开后，该项目的 Agent 已发生变化。",
+        "error": {
+            "code": "project_agent_conflict",
+            "message": "项目设置打开后，该项目的 Agent 已发生变化。",
+        },
+        "hint": "请重新加载项目设置后再次修改。",
+        "details": {
+            "project_id": "proj-stale",
+            "expected_agent_id": "agent-original",
+            "current_agent_id": "agent-replacement",
+        },
+    }
 
 
 def test_config_get_on_fresh_install_returns_default_needing_setup(monkeypatch, tmp_path):

--- a/tests/test_ui_server_fastapi.py
+++ b/tests/test_ui_server_fastapi.py
@@ -160,6 +160,50 @@ def test_scope_settings_routes_report_localized_stale_agent_binding_conflicts(mo
         }
 
 
+def test_scope_settings_routes_localize_unavailable_agent_errors(monkeypatch):
+    from core.services import settings as settings_service
+    from storage.settings_service import ScopeAgentUnavailableError
+    from vibe import api
+
+    def unavailable(*_args, **_kwargs):
+        raise ScopeAgentUnavailableError(agent_name="pm")
+
+    monkeypatch.setattr(
+        settings_service,
+        "load_config_or_default",
+        lambda: SimpleNamespace(language="zh"),
+    )
+    monkeypatch.setattr(api, "save_settings", unavailable)
+    monkeypatch.setattr(api, "save_thread_settings", unavailable)
+    monkeypatch.setattr(api, "save_users", unavailable)
+
+    client = app.test_client()
+    headers = csrf_headers(client)
+    responses = (
+        client.post("/api/settings", json={"platform": "slack"}, headers=headers),
+        client.post(
+            "/api/settings/thread",
+            json={"platform": "telegram", "channel_id": "C1", "thread_id": "T1", "settings": {}},
+            headers=headers,
+        ),
+        client.post("/api/users", json={"platform": "slack", "users": {}}, headers=headers),
+    )
+
+    for response in responses:
+        assert response.status_code == 400
+        assert response.get_json() == {
+            "ok": False,
+            "code": "agent_unavailable",
+            "message": "Agent `pm` 无法用于此路由。",
+            "error": {
+                "code": "agent_unavailable",
+                "message": "Agent `pm` 无法用于此路由。",
+            },
+            "hint": "请选择一个已启用的 Agent 后重新保存。",
+            "details": {"agent_name": "pm"},
+        }
+
+
 def test_status_endpoint_uses_fast_runtime_status(monkeypatch):
     from vibe import runtime
 

--- a/tests/test_ui_server_fastapi.py
+++ b/tests/test_ui_server_fastapi.py
@@ -1156,6 +1156,7 @@ def test_project_patch_rejects_stale_agent_route_after_archive(monkeypatch, tmp_
     store = VibeAgentStore()
     try:
         store.create(name="pm", backend="claude")
+        store.create(name="zz-fallback", backend="claude")
         with engine.begin() as conn:
             project = create_project(conn, str(folder), display_name="Project")
             update_project(conn, project["id"], agent_name="pm")

--- a/tests/test_ui_server_fastapi.py
+++ b/tests/test_ui_server_fastapi.py
@@ -317,7 +317,10 @@ def _machine_coded_error_builders():
     below fails for any coded body that skips the shared builder entirely, so a route
     cannot quietly opt out of this list.
     """
-    from core.services.session_fork import SessionForkError
+    from core.services.session_fork import (
+        SESSION_AGENT_UNAVAILABLE_CODE,
+        SessionForkError,
+    )
     from storage.workbench_sessions_service import SessionBackendLockedError
 
     class _Coded(Exception):
@@ -382,6 +385,18 @@ def _machine_coded_error_builders():
             409,
         ),
         (
+            "fork_agent_unavailable",
+            lambda: ui_server._session_fork_error_response(
+                SessionForkError(
+                    "source session Agent is unavailable",
+                    code=SESSION_AGENT_UNAVAILABLE_CODE,
+                    details={"source_session_id": "ses_1"},
+                )
+            ),
+            SESSION_AGENT_UNAVAILABLE_CODE,
+            409,
+        ),
+        (
             "fork_failed",
             lambda: ui_server._session_fork_error_response(SessionForkError("something else broke")),
             "session_fork_failed",
@@ -442,6 +457,39 @@ def test_machine_coded_error_bodies_survive_the_ui_error_parse(
     assert body["code"] == expected_code, label
     assert isinstance(body["message"], str) and body["message"], label
     assert body["error"]["message"] == body["message"], label
+
+
+def test_session_fork_agent_unavailable_message_follows_configured_language(monkeypatch, tmp_path):
+    from config import paths
+    from core.services.session_fork import (
+        SESSION_AGENT_UNAVAILABLE_CODE,
+        SESSION_AGENT_UNAVAILABLE_I18N_KEY,
+        SessionForkError,
+    )
+    from core.services.settings import default_config
+    from vibe.i18n import t as i18n_t
+
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    config = default_config()
+    config.language = "zh"
+    config.save(paths.get_config_path())
+    error = SessionForkError(
+        "source session Agent is unavailable; choose an enabled Agent override",
+        code=SESSION_AGENT_UNAVAILABLE_CODE,
+        details={"source_session_id": "ses_1"},
+    )
+
+    response, status = ui_server._session_fork_error_response(error)
+    body = json.loads(response.body)
+    expected_message = i18n_t(f"{SESSION_AGENT_UNAVAILABLE_I18N_KEY}.message", "zh")
+    expected_hint = i18n_t(f"{SESSION_AGENT_UNAVAILABLE_I18N_KEY}.hint", "zh")
+
+    assert status == 409
+    assert body["code"] == SESSION_AGENT_UNAVAILABLE_CODE
+    assert body["message"] == expected_message
+    assert body["message"] != str(error)
+    assert body["hint"] == expected_hint
+    assert body["source_session_id"] == "ses_1"
 
 
 # Coded bodies that deliberately keep the flat shape, each with the reason it cannot

--- a/tests/test_ui_server_fastapi.py
+++ b/tests/test_ui_server_fastapi.py
@@ -1244,12 +1244,18 @@ def test_workbench_projects_bootstrap_returns_requested_session_pages(monkeypatc
 
 def test_project_patch_rejects_stale_agent_route_after_archive(monkeypatch, tmp_path):
     from core.vibe_agents import VibeAgentStore
+    from core.services import settings as settings_service
     from sqlalchemy import select
     from storage.db import create_sqlite_engine
     from storage.models import scope_settings
     from storage.projects_service import create_project, update_project
 
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    monkeypatch.setattr(
+        settings_service,
+        "load_config_or_default",
+        lambda: SimpleNamespace(language="zh"),
+    )
     ensure_sqlite_state()
     engine = create_sqlite_engine()
     folder = tmp_path / "project"
@@ -1272,7 +1278,17 @@ def test_project_patch_rejects_stale_agent_route_after_archive(monkeypatch, tmp_
         )
 
         assert response.status_code == 400
-        assert response.get_json() == {"error": "Agent is unavailable: pm"}
+        assert response.get_json() == {
+            "ok": False,
+            "code": "project_agent_unavailable",
+            "message": "Agent `pm` 无法用于此项目。",
+            "error": {
+                "code": "project_agent_unavailable",
+                "message": "Agent `pm` 无法用于此项目。",
+            },
+            "hint": "请选择一个已启用的 Agent 后重新保存项目设置。",
+            "details": {"agent_name": "pm"},
+        }
         with engine.connect() as conn:
             stored_name = conn.execute(
                 select(scope_settings.c.agent_name).where(

--- a/tests/test_ui_server_fastapi.py
+++ b/tests/test_ui_server_fastapi.py
@@ -115,6 +115,42 @@ def test_thread_settings_routes_use_native_fastapi(monkeypatch):
     assert deleted_scopes == [("telegram", "-1001", "42")]
 
 
+def test_scope_settings_routes_report_stale_agent_binding_conflicts(monkeypatch):
+    from storage.settings_service import StaleScopeAgentBindingError
+    from vibe import api
+
+    def stale(*_args, **_kwargs):
+        raise StaleScopeAgentBindingError("Agent binding changed while settings were open")
+
+    monkeypatch.setattr(api, "save_settings", stale)
+    monkeypatch.setattr(api, "save_thread_settings", stale)
+    monkeypatch.setattr(api, "save_users", stale)
+
+    client = app.test_client()
+    headers = csrf_headers(client)
+    responses = (
+        client.post("/api/settings", json={"platform": "slack"}, headers=headers),
+        client.post(
+            "/api/settings/thread",
+            json={"platform": "telegram", "channel_id": "C1", "thread_id": "T1", "settings": {}},
+            headers=headers,
+        ),
+        client.post("/api/users", json={"platform": "slack", "users": {}}, headers=headers),
+    )
+
+    for response in responses:
+        assert response.status_code == 409
+        assert response.get_json() == {
+            "ok": False,
+            "code": "settings_conflict",
+            "message": "Agent binding changed while settings were open",
+            "error": {
+                "code": "settings_conflict",
+                "message": "Agent binding changed while settings were open",
+            },
+        }
+
+
 def test_status_endpoint_uses_fast_runtime_status(monkeypatch):
     from vibe import runtime
 

--- a/tests/test_ui_server_install.py
+++ b/tests/test_ui_server_install.py
@@ -199,6 +199,20 @@ def test_vibe_agent_routes_return_structured_client_errors(monkeypatch, tmp_path
     assert invalid_delete.status_code == 400
     assert invalid_delete.get_json()["code"] == "invalid_agent_request"
 
+    client.post(
+        "/api/agents",
+        json={"name": "archive-fallback", "backend": "codex"},
+        headers=headers,
+    )
+    archived = client.delete("/api/agents/worker", headers=headers).get_json()["archived_agent"]
+    archived_edit = client.patch(
+        f"/api/agents/{archived['name']}",
+        json={"description": "changed"},
+        headers=headers,
+    )
+    assert archived_edit.status_code == 409
+    assert archived_edit.get_json()["code"] == "agent_archived_read_only"
+
 
 def test_install_job_dedupes_running_backend(monkeypatch):
     calls: list[str] = []

--- a/tests/test_ui_session_stream.py
+++ b/tests/test_ui_session_stream.py
@@ -82,6 +82,17 @@ def _make_session(tmp_path: Path) -> tuple[str, str]:
     return scope_id, session["id"]
 
 
+def _ensure_vibe_agent(name: str, backend: str) -> None:
+    from core.vibe_agents import VibeAgentStore
+
+    store = VibeAgentStore()
+    try:
+        if store.get(name) is None:
+            store.create(name=name, backend=backend)
+    finally:
+        store.close()
+
+
 def _seed_opencode_messages(xdg_home: Path, native_session_id: str, roles: list[str]) -> None:
     db_path = xdg_home / "opencode" / "opencode.db"
     db_path.parent.mkdir(parents=True, exist_ok=True)
@@ -484,6 +495,56 @@ def test_create_session_without_backend_defers_to_default_agent(isolated_state, 
     assert not response.get_json().get("agent_backend")
 
 
+def test_create_and_patch_session_reject_archived_agent(isolated_state, tmp_path):
+    from core.vibe_agents import VibeAgentStore
+    from storage import projects_service
+    from storage.db import create_sqlite_engine
+    from vibe.ui_server import app
+
+    engine = create_sqlite_engine()
+    with engine.begin() as conn:
+        project = projects_service.create_project(conn, folder_path=str(tmp_path))
+
+    store = VibeAgentStore()
+    try:
+        store.create(name="retired-reviewer", backend="codex")
+        archived = store.archive("retired-reviewer")
+        assert archived is not None
+    finally:
+        store.close()
+
+    client = app.test_client()
+    headers = csrf_headers(client)
+    create_response = client.post(
+        "/api/sessions",
+        json={
+            "project_id": project["id"],
+            "agent_backend": "codex",
+            "agent_name": archived.archived_name,
+        },
+        headers=headers,
+    )
+    assert create_response.status_code == 404
+    assert "not found or disabled" in create_response.get_json()["error"]
+
+    session_response = client.post(
+        "/api/sessions",
+        json={"project_id": project["id"]},
+        headers=headers,
+    )
+    session_id = session_response.get_json()["id"]
+    patch_response = client.patch(
+        f"/api/sessions/{session_id}",
+        json={
+            "agent_backend": "codex",
+            "agent_name": archived.archived_name,
+        },
+        headers=headers,
+    )
+    assert patch_response.status_code == 404
+    assert "not found or disabled" in patch_response.get_json()["error"]
+
+
 def test_fork_session_creates_new_workbench_session(isolated_state, tmp_path):
     """POST /api/sessions/<id>/fork reserves a new Avibe Session row that is
     ready for the native backend fork on the first turn, and returns the row the
@@ -701,6 +762,7 @@ def test_patch_rejects_backend_switch_for_pending_fork(isolated_state, tmp_path)
     from vibe.ui_server import app
 
     _, session_id = _make_session(tmp_path)
+    _ensure_vibe_agent("codex", "codex")
     engine = create_sqlite_engine()
     with engine.begin() as conn:
         conn.execute(
@@ -1101,6 +1163,7 @@ def test_patch_backend_switch_blocked_while_turn_in_flight(isolated_state, tmp_p
     from vibe.ui_server import app
 
     _, session_id = _make_session(tmp_path)
+    _ensure_vibe_agent("codex", "codex")
 
     in_flight = AsyncMock(return_value={"status_code": 200, "body": {"ok": True, "in_flight": True}})
     with patch("vibe.internal_client.turn_state", in_flight):
@@ -1373,6 +1436,7 @@ def test_patch_same_backend_change_skips_in_flight_gate(isolated_state, tmp_path
     from vibe.ui_server import app
 
     _, session_id = _make_session(tmp_path)
+    _ensure_vibe_agent("claude-pro", "claude")
 
     gate = AsyncMock(return_value={"status_code": 200, "body": {"ok": True, "in_flight": True}})
     with patch("vibe.internal_client.turn_state", gate):
@@ -1395,6 +1459,7 @@ def test_patch_backend_switch_allowed_when_idle(isolated_state, tmp_path):
     from vibe.ui_server import app
 
     _, session_id = _make_session(tmp_path)
+    _ensure_vibe_agent("codex", "codex")
 
     idle = AsyncMock(return_value={"status_code": 200, "body": {"ok": True, "in_flight": False}})
     with patch("vibe.internal_client.turn_state", idle):
@@ -1418,6 +1483,7 @@ def test_patch_backend_switch_falls_back_to_row_guard_when_controller_down(isola
     from vibe.ui_server import app
 
     _, session_id = _make_session(tmp_path)
+    _ensure_vibe_agent("codex", "codex")
 
     async def unavailable(session_id_inner):
         raise internal_client.InternalServerUnavailable("socket missing")

--- a/tests/test_ui_session_stream.py
+++ b/tests/test_ui_session_stream.py
@@ -38,7 +38,12 @@ def isolated_state(monkeypatch, tmp_path):
     yield tmp_path
 
 
-def _make_session(tmp_path: Path) -> tuple[str, str]:
+def _make_session(
+    tmp_path: Path,
+    *,
+    agent_name: str = "worker",
+    agent_backend: str = "claude",
+) -> tuple[str, str]:
     """Create a real avibe project + session row so the route handler
     can find it. Returns ``(scope_id, session_id)``.
     """
@@ -46,6 +51,7 @@ def _make_session(tmp_path: Path) -> tuple[str, str]:
     from core.services import sessions as sessions_service
     from storage.db import create_sqlite_engine
 
+    agent = _ensure_vibe_agent(agent_name, agent_backend)
     engine = create_sqlite_engine()
     with engine.begin() as conn:
         scope_id = upsert_scope(
@@ -76,19 +82,22 @@ def _make_session(tmp_path: Path) -> tuple[str, str]:
         session = sessions_service.create_session(
             conn,
             scope_id=scope_id,
-            agent_backend="claude",
-            agent_name="worker",
+            agent_backend=agent.backend,
+            agent_id=agent.id,
+            agent_name=agent.name,
         )
     return scope_id, session["id"]
 
 
-def _ensure_vibe_agent(name: str, backend: str) -> None:
+def _ensure_vibe_agent(name: str, backend: str):
     from core.vibe_agents import VibeAgentStore
 
     store = VibeAgentStore()
     try:
-        if store.get(name) is None:
-            store.create(name=name, backend=backend)
+        agent = store.get(name)
+        if agent is None:
+            agent = store.create(name=name, backend=backend)
+        return agent
     finally:
         store.close()
 
@@ -703,7 +712,11 @@ def test_fork_session_marks_running_source_for_trim(isolated_state, tmp_path, mo
     xdg_home = tmp_path / "xdg"
     monkeypatch.setenv("XDG_DATA_HOME", str(xdg_home))
     _seed_opencode_messages(xdg_home, "native-source-1", ["user", "assistant", "user"])
-    scope_id, session_id = _make_session(tmp_path)
+    scope_id, session_id = _make_session(
+        tmp_path,
+        agent_name="opencode",
+        agent_backend="opencode",
+    )
     engine = create_sqlite_engine()
     with engine.begin() as conn:
         conn.execute(
@@ -796,7 +809,11 @@ def test_fork_session_trims_post_accept_open_code_before_native_turn_starts(isol
     xdg_home = tmp_path / "xdg"
     monkeypatch.setenv("XDG_DATA_HOME", str(xdg_home))
     _seed_opencode_messages(xdg_home, "native-source-1", ["user"])
-    _, session_id = _make_session(tmp_path)
+    _, session_id = _make_session(
+        tmp_path,
+        agent_name="opencode",
+        agent_backend="opencode",
+    )
     engine = create_sqlite_engine()
     with engine.begin() as conn:
         conn.execute(

--- a/tests/test_ui_session_stream.py
+++ b/tests/test_ui_session_stream.py
@@ -507,6 +507,7 @@ def test_create_and_patch_session_reject_archived_agent(isolated_state, tmp_path
 
     store = VibeAgentStore()
     try:
+        store.create(name="archive-fallback", backend="codex")
         original = store.create(name="retired-reviewer", backend="codex")
         archived = store.archive("retired-reviewer")
         assert archived is not None
@@ -622,6 +623,17 @@ def test_create_and_patch_session_canonicalize_agent_identity(isolated_state, tm
         agent.name,
         agent.backend,
     )
+
+    cleared_response = client.patch(
+        f"/api/sessions/{plain_response.get_json()['id']}",
+        json={"agent_name": None},
+        headers=headers,
+    )
+    assert cleared_response.status_code == 200
+    cleared = cleared_response.get_json()
+    assert cleared["agent_id"] is None
+    assert cleared["agent_name"] is None
+    assert cleared["agent_backend"] == ""
 
 
 def test_fork_session_creates_new_workbench_session(isolated_state, tmp_path):

--- a/tests/test_ui_session_stream.py
+++ b/tests/test_ui_session_stream.py
@@ -507,9 +507,10 @@ def test_create_and_patch_session_reject_archived_agent(isolated_state, tmp_path
 
     store = VibeAgentStore()
     try:
-        store.create(name="retired-reviewer", backend="codex")
+        original = store.create(name="retired-reviewer", backend="codex")
         archived = store.archive("retired-reviewer")
         assert archived is not None
+        replacement = store.create(name="retired-reviewer", backend="codex")
     finally:
         store.close()
 
@@ -527,6 +528,18 @@ def test_create_and_patch_session_reject_archived_agent(isolated_state, tmp_path
     assert create_response.status_code == 404
     assert "not found or disabled" in create_response.get_json()["error"]
 
+    for invalid_identity in (
+        {"agent_id": original.id},
+        {"agent_id": original.id, "agent_name": replacement.name},
+    ):
+        create_response = client.post(
+            "/api/sessions",
+            json={"project_id": project["id"], **invalid_identity},
+            headers=headers,
+        )
+        assert create_response.status_code == 404
+        assert "not found or disabled" in create_response.get_json()["error"]
+
     session_response = client.post(
         "/api/sessions",
         json={"project_id": project["id"]},
@@ -543,6 +556,72 @@ def test_create_and_patch_session_reject_archived_agent(isolated_state, tmp_path
     )
     assert patch_response.status_code == 404
     assert "not found or disabled" in patch_response.get_json()["error"]
+
+    for invalid_identity in (
+        {"agent_id": original.id},
+        {"agent_id": original.id, "agent_name": replacement.name},
+    ):
+        patch_response = client.patch(
+            f"/api/sessions/{session_id}",
+            json=invalid_identity,
+            headers=headers,
+        )
+        assert patch_response.status_code == 404
+        assert "not found or disabled" in patch_response.get_json()["error"]
+
+
+def test_create_and_patch_session_canonicalize_agent_identity(isolated_state, tmp_path):
+    from core.vibe_agents import VibeAgentStore
+    from storage import projects_service
+    from storage.db import create_sqlite_engine
+    from vibe.ui_server import app
+
+    engine = create_sqlite_engine()
+    with engine.begin() as conn:
+        project = projects_service.create_project(conn, folder_path=str(tmp_path))
+
+    store = VibeAgentStore()
+    try:
+        agent = store.create(name="active-reviewer", backend="codex")
+    finally:
+        store.close()
+
+    client = app.test_client()
+    headers = csrf_headers(client)
+    create_response = client.post(
+        "/api/sessions",
+        json={
+            "project_id": project["id"],
+            "agent_id": agent.id,
+            "agent_backend": "claude",
+        },
+        headers=headers,
+    )
+    assert create_response.status_code == 201
+    created = create_response.get_json()
+    assert (created["agent_id"], created["agent_name"], created["agent_backend"]) == (
+        agent.id,
+        agent.name,
+        agent.backend,
+    )
+
+    plain_response = client.post(
+        "/api/sessions",
+        json={"project_id": project["id"]},
+        headers=headers,
+    )
+    patch_response = client.patch(
+        f"/api/sessions/{plain_response.get_json()['id']}",
+        json={"agent_id": agent.id},
+        headers=headers,
+    )
+    assert patch_response.status_code == 200
+    patched = patch_response.get_json()
+    assert (patched["agent_id"], patched["agent_name"], patched["agent_backend"]) == (
+        agent.id,
+        agent.name,
+        agent.backend,
+    )
 
 
 def test_fork_session_creates_new_workbench_session(isolated_state, tmp_path):

--- a/tests/test_user_platform_scope.py
+++ b/tests/test_user_platform_scope.py
@@ -7,6 +7,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from config.v2_settings import RoutingSettings, SettingsStore, UserSettings
 from core.controller import Controller
+from core.vibe_agents import VibeAgentStore
 from modules.im import MessageContext
 from modules.settings_manager import SettingsManager
 from vibe import api
@@ -86,9 +87,12 @@ def test_toggle_admin_is_scoped_per_platform(monkeypatch, tmp_path):
     assert store.get_user("U1", platform="wechat").is_admin is True
 
 
-def test_controller_codex_overrides_resolve_dm_user_scope(monkeypatch, tmp_path):
+def test_controller_codex_overrides_resolve_dm_user_scope(monkeypatch, tmp_path, request):
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     SettingsStore.reset_instance()
+    agent_store = VibeAgentStore()
+    request.addfinalizer(agent_store.close)
+    agent_store.create(name="codex", backend="codex")
     store = SettingsStore.get_instance()
     store.set_users_for_platform(
         "slack",

--- a/tests/test_vibe_agent_archive.py
+++ b/tests/test_vibe_agent_archive.py
@@ -33,6 +33,10 @@ NOW = "2026-07-31T14:00:00+00:00"
 SCOPE_ID = "avibe::project::proj_archive"
 
 
+def _create_archive_fallback(store: VibeAgentStore) -> None:
+    store.create(name="archive-fallback", backend="codex")
+
+
 def _race_archive_at_agent_read(
     primary: VibeAgentStore,
     competitor: VibeAgentStore,
@@ -423,6 +427,7 @@ def test_direct_write_rejects_a_new_agent_that_reuses_the_selected_name(tmp_path
     agent_store = VibeAgentStore(db_path)
     background = SQLiteBackgroundTaskStore(db_path)
     try:
+        _create_archive_fallback(agent_store)
         original = agent_store.create(name="pm", backend="claude")
         archived = agent_store.archive(original.name)
         assert archived is not None
@@ -484,6 +489,7 @@ def test_rename_moves_references_and_default_without_changing_agent_identity(tmp
 def test_archive_invalidates_stale_definition_writes_for_direct_and_snapshot_bindings(tmp_path) -> None:
     store = VibeAgentStore(tmp_path / "state" / "vibe.sqlite")
     try:
+        _create_archive_fallback(store)
         store.create(name="pm", backend="claude")
         rows = (
             {"id": "task_direct", "agent_name": "pm", "metadata_json": "{}"},
@@ -609,6 +615,40 @@ def test_archive_rolls_back_when_default_has_no_replacement(tmp_path) -> None:
         store.close()
 
 
+def test_archive_protects_the_only_effective_default_without_explicit_metadata(tmp_path) -> None:
+    store = VibeAgentStore(tmp_path / "state" / "vibe.sqlite")
+    try:
+        original = store.create(name="only-agent", backend="codex")
+        assert store.get_default_agent_name() is None
+        assert store.get_default_agent().id == original.id
+
+        with pytest.raises(ValueError, match="without another enabled Agent"):
+            store.archive(original.name)
+
+        assert store.require(original.name).id == original.id
+        assert store.get_default_agent_name() is None
+    finally:
+        store.close()
+
+
+def test_archive_persists_replacement_for_the_effective_fallback_default(tmp_path) -> None:
+    store = VibeAgentStore(tmp_path / "state" / "vibe.sqlite")
+    try:
+        original = store.create(name="alpha", backend="codex")
+        replacement = store.create(name="beta", backend="claude")
+        assert store.get_default_agent_name() is None
+        assert store.get_default_agent().id == original.id
+
+        result = store.archive(original.name)
+
+        assert result is not None
+        assert result.default_agent_name == replacement.name
+        assert store.get_default_agent_name() == replacement.name
+        assert store.get_default_agent().id == replacement.id
+    finally:
+        store.close()
+
+
 @pytest.mark.parametrize(
     "stored_name",
     ("project-manager", "PROJECT-MANAGER", "Project Manager", "Project.Manager"),
@@ -616,6 +656,7 @@ def test_archive_rolls_back_when_default_has_no_replacement(tmp_path) -> None:
 def test_archive_moves_normalized_equivalent_references(tmp_path, stored_name: str) -> None:
     store = VibeAgentStore(tmp_path / "state" / "vibe.sqlite")
     try:
+        _create_archive_fallback(store)
         original = store.create(name="Project Manager", backend="claude")
         _seed_references(store, stored_name)
 
@@ -656,9 +697,59 @@ def test_archive_moves_normalized_equivalent_references(tmp_path, stored_name: s
         store.close()
 
 
+@pytest.mark.parametrize("bind_by_id", (False, True))
+def test_late_native_bind_preserves_archived_session_routing_name(tmp_path, bind_by_id: bool) -> None:
+    store = VibeAgentStore(tmp_path / "state" / "vibe.sqlite")
+    service = None
+    try:
+        _create_archive_fallback(store)
+        original = store.create(name="Project Manager", backend="claude")
+        _seed_references(store, original.name)
+        with store.engine.begin() as conn:
+            conn.execute(
+                agent_sessions.update()
+                .where(agent_sessions.c.id == "ses_archive")
+                .values(agent_id=original.id)
+            )
+        result = store.archive(original.name)
+        assert result is not None
+
+        service = SQLiteSessionsService(store.db_path)
+        if bind_by_id:
+            bound = service.bind_agent_session_by_id(
+                session_id="ses_archive",
+                native_session_id="native-pm",
+                vibe_agent_id=original.id,
+                vibe_agent_name=original.name,
+                vibe_agent_backend=original.backend,
+            )
+        else:
+            bound = service.bind_agent_session(
+                scope_key="avibe::project::proj_archive",
+                agent_name=original.backend,
+                session_anchor="ses_archive",
+                native_session_id="native-pm",
+                vibe_agent_id=original.id,
+                vibe_agent_name=original.name,
+            )
+
+        assert bound == "ses_archive"
+        with store.engine.connect() as conn:
+            session = conn.execute(
+                select(agent_sessions).where(agent_sessions.c.id == "ses_archive")
+            ).mappings().one()
+        assert session["agent_id"] == original.id
+        assert session["agent_name"] == result.archived_name
+    finally:
+        if service is not None:
+            service.close()
+        store.close()
+
+
 def test_archive_refuses_to_overwrite_malformed_definition_metadata(tmp_path) -> None:
     store = VibeAgentStore(tmp_path / "state" / "vibe.sqlite")
     try:
+        _create_archive_fallback(store)
         original = store.create(name="pm", backend="claude")
         with store.engine.begin() as conn:
             conn.execute(
@@ -692,6 +783,7 @@ def test_archive_refuses_to_overwrite_malformed_definition_metadata(tmp_path) ->
 def test_archive_rolls_back_when_reference_migration_fails(tmp_path, monkeypatch) -> None:
     store = VibeAgentStore(tmp_path / "state" / "vibe.sqlite")
     try:
+        _create_archive_fallback(store)
         original = store.create(name="worker", backend="codex")
 
         def fail_reference_migration(*_args, **_kwargs):

--- a/tests/test_vibe_agent_archive.py
+++ b/tests/test_vibe_agent_archive.py
@@ -12,6 +12,7 @@ from core.vibe_agents import (
     AgentArchivedEditError,
     AgentArchiveError,
     AgentNameValidationError,
+    AgentReferenceRewriteError,
     AgentUnavailableError,
     VibeAgentStore,
     normalize_agent_name,
@@ -546,6 +547,137 @@ def test_existing_definition_enqueue_pins_the_post_archive_agent_identity(tmp_pa
         agent_store.close()
 
 
+def test_existing_definition_enqueue_uses_one_current_definition_snapshot(tmp_path) -> None:
+    db_path = tmp_path / "state" / "vibe.sqlite"
+    agent_store = VibeAgentStore(db_path)
+    background = SQLiteBackgroundTaskStore(db_path)
+    requests = TaskExecutionStore(tmp_path / "task_requests")
+    requests._sqlite = background
+    try:
+        agent = agent_store.create(name="current-worker", backend="claude")
+        with agent_store.engine.begin() as conn:
+            conn.execute(
+                run_definitions.insert().values(
+                    id="task_current_snapshot",
+                    definition_type="scheduled",
+                    name="current snapshot",
+                    agent_name=agent.name,
+                    session_policy="create_per_run",
+                    session_id="ses-current",
+                    legacy_session_key="slack::channel::current",
+                    post_to="scope",
+                    deliver_key="slack::channel::C2",
+                    prompt="current prompt",
+                    message="current message",
+                    message_payload_json=json.dumps({"text": "current payload"}),
+                    enabled=1,
+                    created_at=NOW,
+                    updated_at=NOW,
+                    metadata_json=json.dumps({"version": 2}),
+                )
+            )
+
+        queued = requests.enqueue_definition_run(
+            definition_id="task_current_snapshot",
+            run_type="scheduled",
+            source_kind="scheduler",
+            session_key="slack::channel::stale",
+            session_id="ses-stale",
+            post_to="none",
+            deliver_key="slack::channel::C1",
+            prompt="stale prompt",
+            agent_name="stale-worker",
+            session_policy="existing",
+            metadata={"version": 1},
+        )
+
+        expected = {
+            "agent_name": agent.name,
+            "agent_id": agent.id,
+            "session_policy": "create_per_run",
+            "session_id": "ses-current",
+            "session_key": "slack::channel::current",
+            "post_to": "scope",
+            "deliver_key": "slack::channel::C2",
+            "prompt": "current prompt",
+            "message": "current message",
+            "message_payload": {"text": "current payload"},
+            "metadata": {"version": 2},
+        }
+        assert {key: getattr(queued, key) for key in expected} == expected
+        stored = background.get_run(queued.id)
+        assert stored is not None
+        assert {key: stored[key] for key in expected} == expected
+    finally:
+        background.close()
+        agent_store.close()
+
+
+def test_archive_does_not_rewrite_reused_name_owned_by_another_agent_id(tmp_path) -> None:
+    store = VibeAgentStore(tmp_path / "state" / "vibe.sqlite")
+    try:
+        _create_archive_fallback(store)
+        first = store.create(name="pm", backend="claude")
+        first_archive = store.archive(first.name)
+        assert first_archive is not None
+        replacement = store.create(name="pm", backend="claude")
+        with store.engine.begin() as conn:
+            conn.execute(
+                agent_sessions.insert().values(
+                    id="ses_stale_reused_name",
+                    scope_id=None,
+                    agent_id=first.id,
+                    agent_name=replacement.name,
+                    agent_backend="claude",
+                    agent_variant="claude",
+                    model=None,
+                    reasoning_effort=None,
+                    session_anchor="ses_stale_reused_name",
+                    workdir=None,
+                    native_session_id="native-first",
+                    title="Stable first Agent",
+                    status="active",
+                    visibility="foreground",
+                    pinned=0,
+                    agent_status="idle",
+                    metadata_json="{}",
+                    created_at=NOW,
+                    updated_at=NOW,
+                    last_active_at=NOW,
+                )
+            )
+            conn.execute(
+                agent_runs.insert().values(
+                    id="run_stale_reused_name",
+                    run_type="agent_run",
+                    status="queued",
+                    agent_id=first.id,
+                    agent_name=replacement.name,
+                    created_at=NOW,
+                    updated_at=NOW,
+                    metadata_json="{}",
+                )
+            )
+
+        result = store.archive(replacement.name)
+
+        assert result is not None
+        assert result.references["sessions"] == 0
+        with store.engine.connect() as conn:
+            session_name = conn.execute(
+                select(agent_sessions.c.agent_name).where(
+                    agent_sessions.c.id == "ses_stale_reused_name"
+                )
+            ).scalar_one()
+            run_name = conn.execute(
+                select(agent_runs.c.agent_name).where(agent_runs.c.id == "run_stale_reused_name")
+            ).scalar_one()
+        assert session_name == "pm"
+        assert run_name == "pm"
+    finally:
+        store.close()
+
+
 def test_rename_moves_references_and_default_without_changing_agent_identity(tmp_path) -> None:
     store = VibeAgentStore(tmp_path / "state" / "vibe.sqlite")
     try:
@@ -668,6 +800,7 @@ def test_remove_compacts_legacy_archive_name_and_moves_its_references(tmp_path) 
             )
             store._rewrite_references(
                 conn,
+                agent_id=original.id,
                 reference_names=frozenset((original.name, original.normalized_name)),
                 new_name=legacy_name,
                 revision=NOW,
@@ -906,8 +1039,9 @@ def test_archive_refuses_to_overwrite_malformed_definition_metadata(tmp_path) ->
                 )
             )
 
-        with pytest.raises(ValueError, match="definition metadata is malformed"):
+        with pytest.raises(AgentReferenceRewriteError) as exc_info:
             store.archive(original.name)
+        assert exc_info.value.code == "agent_reference_metadata_invalid"
 
         assert store.require_enabled(original.name).id == original.id
         with store.engine.connect() as conn:

--- a/tests/test_vibe_agent_archive.py
+++ b/tests/test_vibe_agent_archive.py
@@ -557,6 +557,65 @@ def test_existing_reference_writes_canonicalize_by_stable_agent_id(
         agent_store.close()
 
 
+@pytest.mark.parametrize("write_kind", ["scheduled", "watch", "run", "session"])
+def test_existing_reference_writes_reject_an_ordinary_disabled_agent(
+    tmp_path, write_kind: str
+) -> None:
+    db_path = tmp_path / "state" / "vibe.sqlite"
+    agent_store = VibeAgentStore(db_path)
+    background = SQLiteBackgroundTaskStore(db_path)
+    sessions = SQLiteSessionsService(db_path)
+    try:
+        disabled = agent_store.create(name="paused", backend="claude", enabled=False)
+
+        with pytest.raises(ValueError, match="agent reference 'paused' is disabled"):
+            if write_kind == "scheduled":
+                background.upsert_scheduled_task(
+                    {
+                        "id": "scheduled_disabled_reference",
+                        "agent_name": disabled.name,
+                        "prompt": "continue",
+                        "schedule_type": "at",
+                        "run_at": NOW,
+                        "timezone": "UTC",
+                    },
+                    expected_reference_agent_id=disabled.id,
+                )
+            elif write_kind == "watch":
+                background.upsert_watch(
+                    {
+                        "id": "watch_disabled_reference",
+                        "agent_name": disabled.name,
+                        "command": ["true"],
+                        "mode": "once",
+                    },
+                    expected_reference_agent_id=disabled.id,
+                )
+            elif write_kind == "run":
+                background.enqueue_run(
+                    {
+                        "id": "run_disabled_reference",
+                        "agent_name": disabled.name,
+                        "request_type": "agent_run",
+                        "status": "queued",
+                        "message": "continue",
+                    },
+                    expected_reference_agent_id=disabled.id,
+                )
+            else:
+                sessions.reserve_standalone_agent_session(
+                    agent_backend=disabled.backend,
+                    session_anchor="disabled-reference",
+                    agent_id=disabled.id,
+                    agent_name=disabled.name,
+                    expected_reference_agent_id=disabled.id,
+                )
+    finally:
+        sessions.close()
+        background.close()
+        agent_store.close()
+
+
 def test_claim_refresh_normalizes_a_legacy_run_name_before_pinning_identity(tmp_path) -> None:
     db_path = tmp_path / "state" / "vibe.sqlite"
     agent_store = VibeAgentStore(db_path)

--- a/tests/test_vibe_agent_archive.py
+++ b/tests/test_vibe_agent_archive.py
@@ -444,6 +444,11 @@ def test_user_agent_names_cannot_enter_internal_namespace(tmp_path) -> None:
         store.create(name="worker", backend="codex")
         with pytest.raises(ValueError, match="reserved for Avibe"):
             store.rename("worker", "_hidden")
+        for invalid_name in ("review/team", r"review\team"):
+            with pytest.raises(ValueError, match="path separators"):
+                store.create(name=invalid_name, backend="codex")
+            with pytest.raises(ValueError, match="path separators"):
+                store.rename("worker", invalid_name)
     finally:
         store.close()
 

--- a/tests/test_vibe_agent_archive.py
+++ b/tests/test_vibe_agent_archive.py
@@ -12,8 +12,13 @@ from core.vibe_agents import (
     VibeAgentStore,
     normalize_agent_name,
 )
-from storage.background import DefinitionWriteExpectation, definition_state_unchanged
+from storage.background import (
+    DefinitionWriteExpectation,
+    SQLiteBackgroundTaskStore,
+    definition_state_unchanged,
+)
 from storage.models import agent_runs, agent_sessions, agents, run_definitions, scope_settings, scopes
+from storage.sessions_service import SQLiteSessionsService
 
 
 NOW = "2026-07-31T14:00:00+00:00"
@@ -36,6 +41,33 @@ def _race_archive_at_agent_read(
     def _archive_on_read(_conn, _cursor, statement, _parameters, _context, _executemany) -> None:
         normalized = " ".join(statement.split())
         if state["fired"] or "FROM agents WHERE agents.normalized_name" not in normalized:
+            return
+        state["fired"] = 1
+        try:
+            competitor.archive("pm")
+        except OperationalError as exc:
+            state["refused"].append(str(exc))
+        else:
+            state["committed"] = 1
+
+    return state
+
+
+def _race_archive_at_identity_read(primary_engine, competitor: VibeAgentStore) -> dict[str, object]:
+    state: dict[str, object] = {"fired": 0, "refused": [], "committed": 0}
+
+    @event.listens_for(competitor.engine, "checkout")
+    def _no_wait(dbapi_connection, *_args) -> None:
+        cursor = dbapi_connection.cursor()
+        cursor.execute("PRAGMA busy_timeout = 0")
+        cursor.close()
+
+    @event.listens_for(primary_engine, "after_cursor_execute")
+    def _archive_on_identity_read(
+        _conn, _cursor, statement, _parameters, _context, _executemany
+    ) -> None:
+        normalized = " ".join(statement.split())
+        if state["fired"] or "FROM agents" not in normalized or "agents.id =" not in normalized:
             return
         state["fired"] = 1
         try:
@@ -255,6 +287,124 @@ def test_default_selection_holds_the_write_lock_before_agent_validation(tmp_path
         primary.close()
 
 
+@pytest.mark.parametrize("write_kind", ["scheduled", "watch", "run"])
+def test_direct_definition_and_run_assignments_validate_under_the_write_lock(
+    tmp_path, write_kind: str
+) -> None:
+    db_path = tmp_path / "state" / "vibe.sqlite"
+    agent_store = VibeAgentStore(db_path)
+    competitor = VibeAgentStore(db_path)
+    background = SQLiteBackgroundTaskStore(db_path)
+    try:
+        agent = agent_store.create(name="pm", backend="claude")
+        race = _race_archive_at_identity_read(background.engine, competitor)
+        common = {
+            "id": f"{write_kind}_direct",
+            "agent_name": agent.name,
+            "created_at": NOW,
+            "updated_at": NOW,
+        }
+
+        if write_kind == "scheduled":
+            background.upsert_scheduled_task(
+                {
+                    **common,
+                    "prompt": "continue",
+                    "schedule_type": "at",
+                    "run_at": NOW,
+                    "timezone": "UTC",
+                },
+                expected_enabled_agent_id=agent.id,
+            )
+        elif write_kind == "watch":
+            background.upsert_watch(
+                {
+                    **common,
+                    "command": ["true"],
+                    "mode": "once",
+                },
+                expected_enabled_agent_id=agent.id,
+            )
+        else:
+            background.enqueue_run(
+                {
+                    **common,
+                    "agent_id": agent.id,
+                    "request_type": "agent_run",
+                    "status": "queued",
+                    "message": "continue",
+                },
+                expected_enabled_agent_id=agent.id,
+            )
+
+        assert race["fired"] == 1
+        assert race["committed"] == 0
+        assert len(race["refused"]) == 1
+        assert agent_store.require_enabled(agent.name).id == agent.id
+    finally:
+        background.close()
+        competitor.close()
+        agent_store.close()
+
+
+def test_direct_session_assignment_validates_under_the_write_lock(tmp_path) -> None:
+    db_path = tmp_path / "state" / "vibe.sqlite"
+    agent_store = VibeAgentStore(db_path)
+    competitor = VibeAgentStore(db_path)
+    sessions = SQLiteSessionsService(db_path)
+    try:
+        agent = agent_store.create(name="pm", backend="claude")
+        race = _race_archive_at_identity_read(sessions.engine, competitor)
+
+        session_id = sessions.reserve_standalone_agent_session(
+            agent_backend=agent.backend,
+            session_anchor="direct-agent-run",
+            agent_id=agent.id,
+            agent_name=agent.name,
+            require_enabled_agent=True,
+        )
+
+        assert session_id
+        assert race["fired"] == 1
+        assert race["committed"] == 0
+        assert len(race["refused"]) == 1
+        assert agent_store.require_enabled(agent.name).id == agent.id
+    finally:
+        sessions.close()
+        competitor.close()
+        agent_store.close()
+
+
+def test_direct_write_rejects_a_new_agent_that_reuses_the_selected_name(tmp_path) -> None:
+    db_path = tmp_path / "state" / "vibe.sqlite"
+    agent_store = VibeAgentStore(db_path)
+    background = SQLiteBackgroundTaskStore(db_path)
+    try:
+        original = agent_store.create(name="pm", backend="claude")
+        archived = agent_store.archive(original.name)
+        assert archived is not None
+        replacement = agent_store.create(name="pm", backend="claude")
+
+        with pytest.raises(ValueError, match="replaced before the write"):
+            background.enqueue_run(
+                {
+                    "id": "run_stale_identity",
+                    "agent_name": replacement.name,
+                    "agent_id": original.id,
+                    "request_type": "agent_run",
+                    "status": "queued",
+                    "message": "continue",
+                    "created_at": NOW,
+                    "updated_at": NOW,
+                },
+                expected_enabled_agent_id=original.id,
+            )
+        assert background.get_run("run_stale_identity") is None
+    finally:
+        background.close()
+        agent_store.close()
+
+
 def test_rename_moves_references_and_default_without_changing_agent_identity(tmp_path) -> None:
     store = VibeAgentStore(tmp_path / "state" / "vibe.sqlite")
     try:
@@ -376,7 +526,7 @@ def test_remove_compacts_legacy_archive_name_and_moves_its_references(tmp_path) 
             )
             store._rewrite_references(
                 conn,
-                old_name=original.name,
+                reference_names=frozenset((original.name, original.normalized_name)),
                 new_name=legacy_name,
                 revision=NOW,
             )
@@ -412,6 +562,42 @@ def test_archive_rolls_back_when_default_has_no_replacement(tmp_path) -> None:
 
         assert store.require(original.name).id == original.id
         assert store.get_default_agent_name() == original.name
+    finally:
+        store.close()
+
+
+def test_archive_moves_references_that_use_the_normalized_agent_alias(tmp_path) -> None:
+    store = VibeAgentStore(tmp_path / "state" / "vibe.sqlite")
+    try:
+        original = store.create(name="Project Manager", backend="claude")
+        _seed_references(store, original.normalized_name)
+
+        result = store.archive(original.name)
+
+        assert result is not None
+        assert result.references == {"scopes": 1, "sessions": 1, "definitions": 1}
+        assert store.require_reference_by_id(original.id).name == result.archived_name
+        with store.engine.connect() as conn:
+            scope = conn.execute(select(scope_settings)).mappings().one()
+            session = conn.execute(select(agent_sessions)).mappings().one()
+            definitions = conn.execute(select(run_definitions)).mappings().all()
+            live_runs = conn.execute(
+                select(agent_runs.c.agent_name).where(
+                    agent_runs.c.status.in_(("pending", "queued", "processing", "running"))
+                )
+            ).scalars().all()
+        assert scope["agent_name"] == result.archived_name
+        assert json.loads(scope["settings_json"])["routing"] == {
+            "agent_name": result.archived_name,
+            "agent": result.archived_name,
+        }
+        assert session["agent_name"] == result.archived_name
+        assert {row["agent_name"] for row in definitions} == {result.archived_name}
+        assert {
+            json.loads(row["metadata_json"])["session_settings_snapshot"]["agent_name"]
+            for row in definitions
+        } == {result.archived_name}
+        assert set(live_runs) == {result.archived_name}
     finally:
         store.close()
 

--- a/tests/test_vibe_agent_archive.py
+++ b/tests/test_vibe_agent_archive.py
@@ -17,7 +17,15 @@ from storage.background import (
     SQLiteBackgroundTaskStore,
     definition_state_unchanged,
 )
-from storage.models import agent_runs, agent_sessions, agents, run_definitions, scope_settings, scopes
+from storage.models import (
+    agent_runs,
+    agent_sessions,
+    agents,
+    messages,
+    run_definitions,
+    scope_settings,
+    scopes,
+)
 from storage.sessions_service import SQLiteSessionsService
 
 
@@ -171,6 +179,32 @@ def _seed_references(store: VibeAgentStore, agent_name: str) -> None:
                     metadata_json="{}",
                 )
             )
+        conn.execute(
+            messages.insert().values(
+                id="msg_queued_archive",
+                scope_id=SCOPE_ID,
+                session_id="ses_archive",
+                platform="avibe",
+                author="harness",
+                type="queued",
+                source="harness",
+                content_text="continue",
+                content_json=json.dumps({"text": "continue"}),
+                metadata_json=json.dumps(
+                    {
+                        "scheduled_provenance": {
+                            "platform_specific": {
+                                "vibe_agent_name": agent_name,
+                                "scheduled_target_agent_name": agent_name,
+                                "agent_session_target": {"agent_name": agent_name},
+                            }
+                        }
+                    }
+                ),
+                created_at=NOW,
+                updated_at=NOW,
+            )
+        )
 
 
 def test_archive_atomically_moves_live_references_and_hides_agent(tmp_path) -> None:
@@ -217,6 +251,11 @@ def test_archive_atomically_moves_live_references_and_hides_agent(tmp_path) -> N
             session = conn.execute(select(agent_sessions)).mappings().one()
             definitions = conn.execute(select(run_definitions).order_by(run_definitions.c.id)).mappings().all()
             runs = conn.execute(select(agent_runs.c.status, agent_runs.c.agent_name)).mappings().all()
+            queued_metadata = json.loads(
+                conn.execute(
+                    select(messages.c.metadata_json).where(messages.c.id == "msg_queued_archive")
+                ).scalar_one()
+            )
         assert scope["agent_name"] == result.archived_name
         assert json.loads(scope["settings_json"])["routing"] == {
             "agent_name": result.archived_name,
@@ -238,6 +277,10 @@ def test_archive_atomically_moves_live_references_and_hides_agent(tmp_path) -> N
             for row in runs
             if row["status"] in {"succeeded", "failed", "canceled"}
         } == {"pm"}
+        queued_spec = queued_metadata["scheduled_provenance"]["platform_specific"]
+        assert queued_spec["vibe_agent_name"] == result.archived_name
+        assert queued_spec["scheduled_target_agent_name"] == result.archived_name
+        assert queued_spec["agent_session_target"]["agent_name"] == result.archived_name
 
         replacement = store.create(name="pm", backend="claude")
         assert replacement.id != original.id
@@ -598,6 +641,39 @@ def test_archive_moves_references_that_use_the_normalized_agent_alias(tmp_path) 
             for row in definitions
         } == {result.archived_name}
         assert set(live_runs) == {result.archived_name}
+    finally:
+        store.close()
+
+
+def test_archive_refuses_to_overwrite_malformed_definition_metadata(tmp_path) -> None:
+    store = VibeAgentStore(tmp_path / "state" / "vibe.sqlite")
+    try:
+        original = store.create(name="pm", backend="claude")
+        with store.engine.begin() as conn:
+            conn.execute(
+                run_definitions.insert().values(
+                    id="task_malformed",
+                    definition_type="scheduled",
+                    name="Malformed metadata",
+                    agent_name=original.name,
+                    enabled=0,
+                    created_at=NOW,
+                    updated_at=NOW,
+                    metadata_json="{not-json",
+                )
+            )
+
+        with pytest.raises(ValueError, match="definition metadata is malformed"):
+            store.archive(original.name)
+
+        assert store.require_enabled(original.name).id == original.id
+        with store.engine.connect() as conn:
+            row = conn.execute(
+                select(run_definitions.c.agent_name, run_definitions.c.metadata_json).where(
+                    run_definitions.c.id == "task_malformed"
+                )
+            ).one()
+        assert row == (original.name, "{not-json")
     finally:
         store.close()
 

--- a/tests/test_vibe_agent_archive.py
+++ b/tests/test_vibe_agent_archive.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import json
 
 import pytest
-from sqlalchemy import select, update
+from sqlalchemy import event, select, update
+from sqlalchemy.exc import OperationalError
 
 from core.vibe_agents import (
     AGENT_ARCHIVE_METADATA_KEY,
@@ -17,6 +18,34 @@ from storage.models import agent_runs, agent_sessions, agents, run_definitions, 
 
 NOW = "2026-07-31T14:00:00+00:00"
 SCOPE_ID = "avibe::project::proj_archive"
+
+
+def _race_archive_at_agent_read(
+    primary: VibeAgentStore,
+    competitor: VibeAgentStore,
+) -> dict[str, object]:
+    state: dict[str, object] = {"fired": 0, "refused": [], "committed": 0}
+
+    @event.listens_for(competitor.engine, "checkout")
+    def _no_wait(dbapi_connection, *_args) -> None:
+        cursor = dbapi_connection.cursor()
+        cursor.execute("PRAGMA busy_timeout = 0")
+        cursor.close()
+
+    @event.listens_for(primary.engine, "after_cursor_execute")
+    def _archive_on_read(_conn, _cursor, statement, _parameters, _context, _executemany) -> None:
+        normalized = " ".join(statement.split())
+        if state["fired"] or "FROM agents WHERE agents.normalized_name" not in normalized:
+            return
+        state["fired"] = 1
+        try:
+            competitor.archive("pm")
+        except OperationalError as exc:
+            state["refused"].append(str(exc))
+        else:
+            state["committed"] = 1
+
+    return state
 
 
 def _seed_references(store: VibeAgentStore, agent_name: str) -> None:
@@ -182,6 +211,48 @@ def test_archive_atomically_moves_live_references_and_hides_agent(tmp_path) -> N
         assert replacement.id != original.id
     finally:
         store.close()
+
+
+def test_update_holds_the_write_lock_before_checking_archived_state(tmp_path) -> None:
+    db_path = tmp_path / "state" / "vibe.sqlite"
+    primary = VibeAgentStore(db_path)
+    competitor = VibeAgentStore(db_path)
+    try:
+        primary.create(name="pm", backend="claude", enabled=False)
+        race = _race_archive_at_agent_read(primary, competitor)
+
+        updated = primary.set_enabled("pm", True)
+
+        assert updated.enabled is True
+        assert race["fired"] == 1
+        assert race["committed"] == 0
+        assert len(race["refused"]) == 1
+        assert primary.require("pm").archived_at is None
+    finally:
+        competitor.close()
+        primary.close()
+
+
+def test_default_selection_holds_the_write_lock_before_agent_validation(tmp_path) -> None:
+    db_path = tmp_path / "state" / "vibe.sqlite"
+    primary = VibeAgentStore(db_path)
+    competitor = VibeAgentStore(db_path)
+    try:
+        primary.create(name="fallback", backend="claude")
+        primary.create(name="pm", backend="claude")
+        primary.set_default_agent_name("fallback")
+        race = _race_archive_at_agent_read(primary, competitor)
+
+        primary.set_default_agent_name("pm")
+
+        assert race["fired"] == 1
+        assert race["committed"] == 0
+        assert len(race["refused"]) == 1
+        assert primary.get_default_agent_name() == "pm"
+        assert primary.require("pm").archived_at is None
+    finally:
+        competitor.close()
+        primary.close()
 
 
 def test_rename_moves_references_and_default_without_changing_agent_identity(tmp_path) -> None:

--- a/tests/test_vibe_agent_archive.py
+++ b/tests/test_vibe_agent_archive.py
@@ -609,11 +609,15 @@ def test_archive_rolls_back_when_default_has_no_replacement(tmp_path) -> None:
         store.close()
 
 
-def test_archive_moves_references_that_use_the_normalized_agent_alias(tmp_path) -> None:
+@pytest.mark.parametrize(
+    "stored_name",
+    ("project-manager", "PROJECT-MANAGER", "Project Manager", "Project.Manager"),
+)
+def test_archive_moves_normalized_equivalent_references(tmp_path, stored_name: str) -> None:
     store = VibeAgentStore(tmp_path / "state" / "vibe.sqlite")
     try:
         original = store.create(name="Project Manager", backend="claude")
-        _seed_references(store, original.normalized_name)
+        _seed_references(store, stored_name)
 
         result = store.archive(original.name)
 
@@ -629,6 +633,9 @@ def test_archive_moves_references_that_use_the_normalized_agent_alias(tmp_path) 
                     agent_runs.c.status.in_(("pending", "queued", "processing", "running"))
                 )
             ).scalars().all()
+            queued_metadata = conn.execute(
+                select(messages.c.metadata_json).where(messages.c.id == "msg_queued_archive")
+            ).scalar_one()
         assert scope["agent_name"] == result.archived_name
         assert json.loads(scope["settings_json"])["routing"] == {
             "agent_name": result.archived_name,
@@ -641,6 +648,10 @@ def test_archive_moves_references_that_use_the_normalized_agent_alias(tmp_path) 
             for row in definitions
         } == {result.archived_name}
         assert set(live_runs) == {result.archived_name}
+        queued_spec = json.loads(queued_metadata)["scheduled_provenance"]["platform_specific"]
+        assert queued_spec["vibe_agent_name"] == result.archived_name
+        assert queued_spec["scheduled_target_agent_name"] == result.archived_name
+        assert queued_spec["agent_session_target"]["agent_name"] == result.archived_name
     finally:
         store.close()
 

--- a/tests/test_vibe_agent_archive.py
+++ b/tests/test_vibe_agent_archive.py
@@ -8,6 +8,7 @@ from sqlalchemy.exc import OperationalError
 
 from core.vibe_agents import (
     AGENT_ARCHIVE_METADATA_KEY,
+    AgentArchiveError,
     AgentUnavailableError,
     VibeAgentStore,
     normalize_agent_name,
@@ -606,8 +607,10 @@ def test_archive_rolls_back_when_default_has_no_replacement(tmp_path) -> None:
         original = store.create(name="only-agent", backend="codex")
         store.set_default_agent_name(original.name)
 
-        with pytest.raises(ValueError, match="without another enabled Agent"):
+        with pytest.raises(AgentArchiveError) as exc_info:
             store.archive(original.name)
+        assert exc_info.value.code == "agent_no_default_replacement"
+        assert exc_info.value.agent_name == original.name
 
         assert store.require(original.name).id == original.id
         assert store.get_default_agent_name() == original.name
@@ -622,8 +625,10 @@ def test_archive_protects_the_only_effective_default_without_explicit_metadata(t
         assert store.get_default_agent_name() is None
         assert store.get_default_agent().id == original.id
 
-        with pytest.raises(ValueError, match="without another enabled Agent"):
+        with pytest.raises(AgentArchiveError) as exc_info:
             store.archive(original.name)
+        assert exc_info.value.code == "agent_no_default_replacement"
+        assert exc_info.value.agent_name == original.name
 
         assert store.require(original.name).id == original.id
         assert store.get_default_agent_name() is None

--- a/tests/test_vibe_agent_archive.py
+++ b/tests/test_vibe_agent_archive.py
@@ -9,6 +9,7 @@ from sqlalchemy.exc import OperationalError
 from core.scheduled_tasks import TaskExecutionStore
 from core.vibe_agents import (
     AGENT_ARCHIVE_METADATA_KEY,
+    AgentArchivedEditError,
     AgentArchiveError,
     AgentNameValidationError,
     AgentUnavailableError,
@@ -247,8 +248,12 @@ def test_archive_atomically_moves_live_references_and_hides_agent(tmp_path) -> N
         assert store.require_reference(result.archived_name).id == original.id
         with pytest.raises(AgentUnavailableError, match="disabled"):
             store.require_enabled(result.archived_name)
-        with pytest.raises(ValueError, match="archived and cannot be edited"):
+        with pytest.raises(AgentArchivedEditError) as edit_error:
             store.set_enabled(result.archived_name, True)
+        assert edit_error.value.code == "agent_archived_read_only"
+        assert edit_error.value.agent_name == result.archived_name
+        with pytest.raises(AgentArchivedEditError):
+            store.rename(result.archived_name, "restored-pm")
 
         listed_with_archives = store.list_agents(include_disabled=True, include_archived=True)
         assert any(agent.id == original.id for agent in listed_with_archives)
@@ -269,11 +274,15 @@ def test_archive_atomically_moves_live_references_and_hides_agent(tmp_path) -> N
             "agent": result.archived_name,
         }
         assert session["agent_name"] == result.archived_name
-        assert {row["agent_name"] for row in definitions} == {result.archived_name}
-        assert {
-            json.loads(row["metadata_json"])["session_settings_snapshot"]["agent_name"]
-            for row in definitions
-        } == {result.archived_name}
+        definitions_by_id = {row["id"]: row for row in definitions}
+        assert definitions_by_id["task_live"]["agent_name"] == result.archived_name
+        assert definitions_by_id["watch_deleted"]["agent_name"] == "pm"
+        assert json.loads(definitions_by_id["task_live"]["metadata_json"])[
+            "session_settings_snapshot"
+        ]["agent_name"] == result.archived_name
+        assert json.loads(definitions_by_id["watch_deleted"]["metadata_json"])[
+            "session_settings_snapshot"
+        ]["agent_name"] == "pm"
         assert {
             row["agent_name"]
             for row in runs
@@ -811,11 +820,15 @@ def test_archive_moves_normalized_equivalent_references(tmp_path, stored_name: s
             "agent": result.archived_name,
         }
         assert session["agent_name"] == result.archived_name
-        assert {row["agent_name"] for row in definitions} == {result.archived_name}
-        assert {
-            json.loads(row["metadata_json"])["session_settings_snapshot"]["agent_name"]
-            for row in definitions
-        } == {result.archived_name}
+        definitions_by_id = {row["id"]: row for row in definitions}
+        assert definitions_by_id["task_live"]["agent_name"] == result.archived_name
+        assert definitions_by_id["watch_deleted"]["agent_name"] == stored_name
+        assert json.loads(definitions_by_id["task_live"]["metadata_json"])[
+            "session_settings_snapshot"
+        ]["agent_name"] == result.archived_name
+        assert json.loads(definitions_by_id["watch_deleted"]["metadata_json"])[
+            "session_settings_snapshot"
+        ]["agent_name"] == stored_name
         assert set(live_runs) == {result.archived_name}
         queued_spec = json.loads(queued_metadata)["scheduled_provenance"]["platform_specific"]
         assert queued_spec["vibe_agent_name"] == result.archived_name
@@ -904,6 +917,43 @@ def test_archive_refuses_to_overwrite_malformed_definition_metadata(tmp_path) ->
                 )
             ).one()
         assert row == (original.name, "{not-json")
+    finally:
+        store.close()
+
+
+def test_archive_ignores_soft_deleted_definition_metadata(tmp_path) -> None:
+    store = VibeAgentStore(tmp_path / "state" / "vibe.sqlite")
+    try:
+        _create_archive_fallback(store)
+        original = store.create(name="pm", backend="claude")
+        with store.engine.begin() as conn:
+            conn.execute(
+                run_definitions.insert().values(
+                    id="task_deleted_malformed",
+                    definition_type="scheduled",
+                    name="Deleted malformed metadata",
+                    agent_name=original.name,
+                    enabled=0,
+                    deleted_at=NOW,
+                    created_at=NOW,
+                    updated_at=NOW,
+                    metadata_json="{not-json",
+                )
+            )
+
+        archived = store.archive(original.name)
+
+        assert archived is not None
+        assert archived.references["definitions"] == 0
+        with store.engine.connect() as conn:
+            row = conn.execute(
+                select(
+                    run_definitions.c.agent_name,
+                    run_definitions.c.metadata_json,
+                    run_definitions.c.deleted_at,
+                ).where(run_definitions.c.id == "task_deleted_malformed")
+            ).one()
+        assert row == (original.name, "{not-json", NOW)
     finally:
         store.close()
 

--- a/tests/test_vibe_agent_archive.py
+++ b/tests/test_vibe_agent_archive.py
@@ -6,9 +6,11 @@ import pytest
 from sqlalchemy import event, select, update
 from sqlalchemy.exc import OperationalError
 
+from core.scheduled_tasks import TaskExecutionStore
 from core.vibe_agents import (
     AGENT_ARCHIVE_METADATA_KEY,
     AgentArchiveError,
+    AgentNameValidationError,
     AgentUnavailableError,
     VibeAgentStore,
     normalize_agent_name,
@@ -454,6 +456,87 @@ def test_direct_write_rejects_a_new_agent_that_reuses_the_selected_name(tmp_path
         agent_store.close()
 
 
+def test_claim_refresh_normalizes_a_legacy_run_name_before_pinning_identity(tmp_path) -> None:
+    db_path = tmp_path / "state" / "vibe.sqlite"
+    agent_store = VibeAgentStore(db_path)
+    background = SQLiteBackgroundTaskStore(db_path)
+    try:
+        agent = agent_store.create(name="project-manager", backend="claude")
+        background.enqueue_run(
+            {
+                "id": "run_legacy_spelling",
+                "agent_name": "PROJECT-MANAGER",
+                "request_type": "scheduled",
+                "status": "queued",
+                "message": "continue",
+                "created_at": NOW,
+                "updated_at": NOW,
+            }
+        )
+
+        pinned = background.refresh_run_agent_reference("run_legacy_spelling")
+
+        assert pinned == {"agent_id": agent.id, "agent_name": agent.name}
+        stored = background.get_run("run_legacy_spelling")
+        assert stored is not None
+        assert stored["agent_id"] == agent.id
+        assert stored["agent_name"] == agent.name
+    finally:
+        background.close()
+        agent_store.close()
+
+
+def test_existing_definition_enqueue_pins_the_post_archive_agent_identity(tmp_path) -> None:
+    db_path = tmp_path / "state" / "vibe.sqlite"
+    agent_store = VibeAgentStore(db_path)
+    background = SQLiteBackgroundTaskStore(db_path)
+    requests = TaskExecutionStore(tmp_path / "task_requests")
+    requests._sqlite = background
+    try:
+        _create_archive_fallback(agent_store)
+        original = agent_store.create(name="pm", backend="claude")
+        with agent_store.engine.begin() as conn:
+            conn.execute(
+                run_definitions.insert().values(
+                    id="task_enqueue_race",
+                    definition_type="scheduled",
+                    name="enqueue race",
+                    agent_name=original.name,
+                    enabled=1,
+                    created_at=NOW,
+                    updated_at=NOW,
+                    metadata_json="{}",
+                )
+            )
+
+        stale_agent_name = original.name
+        archived = agent_store.archive(original.name)
+        assert archived is not None
+
+        queued = requests.enqueue_definition_run(
+            definition_id="task_enqueue_race",
+            run_type="scheduled",
+            source_kind="scheduler",
+            session_key="",
+            session_id=None,
+            post_to=None,
+            deliver_key=None,
+            prompt="continue",
+            agent_name=stale_agent_name,
+            session_policy="create_once",
+        )
+
+        assert queued.agent_id == original.id
+        assert queued.agent_name == archived.archived_name
+        stored = background.get_run(queued.id)
+        assert stored is not None
+        assert stored["agent_id"] == original.id
+        assert stored["agent_name"] == archived.archived_name
+    finally:
+        background.close()
+        agent_store.close()
+
+
 def test_rename_moves_references_and_default_without_changing_agent_identity(tmp_path) -> None:
     store = VibeAgentStore(tmp_path / "state" / "vibe.sqlite")
     try:
@@ -849,16 +932,20 @@ def test_archive_rolls_back_when_reference_migration_fails(tmp_path, monkeypatch
 def test_user_agent_names_cannot_enter_internal_namespace(tmp_path) -> None:
     store = VibeAgentStore(tmp_path / "state" / "vibe.sqlite")
     try:
-        with pytest.raises(ValueError, match="reserved for Avibe"):
+        with pytest.raises(AgentNameValidationError) as create_reserved:
             store.create(name="_hidden", backend="codex")
+        assert create_reserved.value.code == "agent_name_reserved"
         store.create(name="worker", backend="codex")
-        with pytest.raises(ValueError, match="reserved for Avibe"):
+        with pytest.raises(AgentNameValidationError) as rename_reserved:
             store.rename("worker", "_hidden")
+        assert rename_reserved.value.code == "agent_name_reserved"
         for invalid_name in ("review/team", r"review\team"):
-            with pytest.raises(ValueError, match="path separators"):
+            with pytest.raises(AgentNameValidationError) as create_path:
                 store.create(name=invalid_name, backend="codex")
-            with pytest.raises(ValueError, match="path separators"):
+            assert create_path.value.code == "agent_name_path_separator"
+            with pytest.raises(AgentNameValidationError) as rename_path:
                 store.rename("worker", invalid_name)
+            assert rename_path.value.code == "agent_name_path_separator"
     finally:
         store.close()
 

--- a/tests/test_vibe_agent_archive.py
+++ b/tests/test_vibe_agent_archive.py
@@ -5,9 +5,14 @@ import json
 import pytest
 from sqlalchemy import select, update
 
-from core.vibe_agents import AgentUnavailableError, VibeAgentStore
+from core.vibe_agents import (
+    AGENT_ARCHIVE_METADATA_KEY,
+    AgentUnavailableError,
+    VibeAgentStore,
+    normalize_agent_name,
+)
 from storage.background import DefinitionWriteExpectation, definition_state_unchanged
-from storage.models import agent_runs, agent_sessions, run_definitions, scope_settings, scopes
+from storage.models import agent_runs, agent_sessions, agents, run_definitions, scope_settings, scopes
 
 
 NOW = "2026-07-31T14:00:00+00:00"
@@ -124,7 +129,8 @@ def test_archive_atomically_moves_live_references_and_hides_agent(tmp_path) -> N
 
         assert result is not None
         assert result.original_name == "pm"
-        assert result.archived_name.startswith("_archived_")
+        assert result.archived_name.startswith("_pm-")
+        assert len(result.archived_name) == len("_pm-") + 4
         assert result.references == {"scopes": 1, "sessions": 1, "definitions": 1}
         assert result.default_agent_name == "claude-fallback"
         assert store.get_default_agent_name() == "claude-fallback"
@@ -269,6 +275,57 @@ def test_archive_invalidates_stale_definition_writes_for_direct_and_snapshot_bin
             json.loads(stored["task_snapshot"]["metadata_json"])["session_settings_snapshot"]["agent_name"]
             == archived.archived_name
         )
+    finally:
+        store.close()
+
+
+def test_remove_compacts_legacy_archive_name_and_moves_its_references(tmp_path) -> None:
+    store = VibeAgentStore(tmp_path / "state" / "vibe.sqlite")
+    try:
+        original = store.create(name="pm", backend="claude")
+        _seed_references(store, original.name)
+        legacy_name = "_archived_500f78fda90b4b06920bf89f187fb47d"
+        archive_metadata = {
+            "original_name": original.name,
+            "archived_at": NOW,
+            "was_enabled": True,
+        }
+        with store.engine.begin() as conn:
+            conn.execute(
+                agents.update()
+                .where(agents.c.id == original.id)
+                .values(
+                    name=legacy_name,
+                    normalized_name=normalize_agent_name(legacy_name),
+                    enabled=0,
+                    metadata_json=json.dumps({AGENT_ARCHIVE_METADATA_KEY: archive_metadata}),
+                    archived_at=NOW,
+                    updated_at=NOW,
+                )
+            )
+            store._rewrite_references(
+                conn,
+                old_name=original.name,
+                new_name=legacy_name,
+                revision=NOW,
+            )
+
+        compacted = store.archive("pm")
+
+        assert compacted is not None
+        assert compacted.original_name == "pm"
+        assert compacted.archived_name.startswith("_pm-")
+        assert len(compacted.archived_name) == len("_pm-") + 4
+        assert compacted.references == {"scopes": 1, "sessions": 1, "definitions": 1}
+        assert store.get(legacy_name) is None
+        assert store.require(compacted.archived_name).to_dict()["display_name"] == "pm"
+        with store.engine.connect() as conn:
+            assert conn.execute(
+                select(agent_sessions.c.id).where(agent_sessions.c.agent_name == legacy_name)
+            ).first() is None
+            assert conn.execute(
+                select(run_definitions.c.id).where(run_definitions.c.agent_name == legacy_name)
+            ).first() is None
     finally:
         store.close()
 

--- a/tests/test_vibe_agent_archive.py
+++ b/tests/test_vibe_agent_archive.py
@@ -466,6 +466,97 @@ def test_direct_write_rejects_a_new_agent_that_reuses_the_selected_name(tmp_path
         agent_store.close()
 
 
+@pytest.mark.parametrize("write_kind", ["scheduled", "watch", "run", "session"])
+def test_existing_reference_writes_canonicalize_by_stable_agent_id(
+    tmp_path, write_kind: str
+) -> None:
+    db_path = tmp_path / "state" / "vibe.sqlite"
+    agent_store = VibeAgentStore(db_path)
+    background = SQLiteBackgroundTaskStore(db_path)
+    sessions = SQLiteSessionsService(db_path)
+    try:
+        _create_archive_fallback(agent_store)
+        original = agent_store.create(name="pm", backend="claude")
+        archived = agent_store.archive(original.name)
+        assert archived is not None
+        replacement = agent_store.create(name="pm", backend="codex")
+
+        if write_kind == "scheduled":
+            background.upsert_scheduled_task(
+                {
+                    "id": "scheduled_reference",
+                    "agent_name": replacement.name,
+                    "prompt": "continue",
+                    "schedule_type": "at",
+                    "run_at": NOW,
+                    "timezone": "UTC",
+                    "created_at": NOW,
+                    "updated_at": NOW,
+                },
+                expected_reference_agent_id=original.id,
+            )
+            with background.engine.connect() as conn:
+                stored_name = conn.execute(
+                    select(run_definitions.c.agent_name).where(
+                        run_definitions.c.id == "scheduled_reference"
+                    )
+                ).scalar_one()
+            assert stored_name == archived.archived_name
+        elif write_kind == "watch":
+            background.upsert_watch(
+                {
+                    "id": "watch_reference",
+                    "agent_name": replacement.name,
+                    "command": ["true"],
+                    "mode": "once",
+                    "created_at": NOW,
+                    "updated_at": NOW,
+                },
+                expected_reference_agent_id=original.id,
+            )
+            with background.engine.connect() as conn:
+                stored_name = conn.execute(
+                    select(run_definitions.c.agent_name).where(
+                        run_definitions.c.id == "watch_reference"
+                    )
+                ).scalar_one()
+            assert stored_name == archived.archived_name
+        elif write_kind == "run":
+            background.enqueue_run(
+                {
+                    "id": "run_reference",
+                    "agent_name": replacement.name,
+                    "request_type": "agent_run",
+                    "status": "queued",
+                    "message": "continue",
+                    "created_at": NOW,
+                    "updated_at": NOW,
+                },
+                expected_reference_agent_id=original.id,
+            )
+            stored = background.get_run("run_reference")
+            assert stored is not None
+            assert stored["agent_id"] == original.id
+            assert stored["agent_name"] == archived.archived_name
+        else:
+            session_id = sessions.reserve_standalone_agent_session(
+                agent_backend=replacement.backend,
+                session_anchor="reference",
+                agent_id=original.id,
+                agent_name=replacement.name,
+                expected_reference_agent_id=original.id,
+            )
+            stored = sessions.get_agent_session_by_id(session_id)
+            assert stored is not None
+            assert stored["agent_id"] == original.id
+            assert stored["agent_name"] == archived.archived_name
+            assert stored["agent_backend"] == original.backend
+    finally:
+        sessions.close()
+        background.close()
+        agent_store.close()
+
+
 def test_claim_refresh_normalizes_a_legacy_run_name_before_pinning_identity(tmp_path) -> None:
     db_path = tmp_path / "state" / "vibe.sqlite"
     agent_store = VibeAgentStore(db_path)

--- a/tests/test_vibe_agent_archive.py
+++ b/tests/test_vibe_agent_archive.py
@@ -649,6 +649,46 @@ def test_archive_persists_replacement_for_the_effective_fallback_default(tmp_pat
         store.close()
 
 
+def test_archive_replaces_disabled_explicit_default_pointer(tmp_path) -> None:
+    store = VibeAgentStore(tmp_path / "state" / "vibe.sqlite")
+    try:
+        original = store.create(name="alpha", backend="codex")
+        replacement = store.create(name="beta", backend="claude")
+        store.set_default_agent_name(original.name)
+        store.set_enabled(original.name, False)
+        assert store.get_default_agent().id == replacement.id
+
+        result = store.archive(original.name)
+
+        assert result is not None
+        assert result.default_agent_name == replacement.name
+        assert store.get_default_agent_name() == replacement.name
+        recreated = store.create(name=original.name, backend="opencode")
+        assert store.get_default_agent().id == replacement.id
+        assert store.get_default_agent().id != recreated.id
+    finally:
+        store.close()
+
+
+def test_archive_clears_disabled_explicit_default_without_fallback(tmp_path) -> None:
+    store = VibeAgentStore(tmp_path / "state" / "vibe.sqlite")
+    try:
+        original = store.create(name="alpha", backend="codex")
+        store.set_default_agent_name(original.name)
+        store.set_enabled(original.name, False)
+        assert store.get_default_agent() is None
+
+        result = store.archive(original.name)
+
+        assert result is not None
+        assert result.default_agent_name is None
+        assert store.get_default_agent_name() is None
+        store.create(name=original.name, backend="opencode")
+        assert store.get_default_agent_name() is None
+    finally:
+        store.close()
+
+
 @pytest.mark.parametrize(
     "stored_name",
     ("project-manager", "PROJECT-MANAGER", "Project Manager", "Project.Manager"),

--- a/tests/test_vibe_agent_archive.py
+++ b/tests/test_vibe_agent_archive.py
@@ -1,0 +1,237 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+from sqlalchemy import select
+
+from core.vibe_agents import AgentUnavailableError, VibeAgentStore
+from storage.models import agent_sessions, run_definitions, scope_settings, scopes
+
+
+NOW = "2026-07-31T14:00:00+00:00"
+SCOPE_ID = "avibe::project::proj_archive"
+
+
+def _seed_references(store: VibeAgentStore, agent_name: str) -> None:
+    with store.engine.begin() as conn:
+        conn.execute(
+            scopes.insert().values(
+                id=SCOPE_ID,
+                platform="avibe",
+                scope_type="project",
+                native_id="proj_archive",
+                parent_scope_id=None,
+                display_name="Archive test",
+                native_type="project",
+                is_private=0,
+                supports_threads=1,
+                metadata_json="{}",
+                first_seen_at=NOW,
+                last_seen_at=NOW,
+                updated_at=NOW,
+            )
+        )
+        conn.execute(
+            scope_settings.insert().values(
+                scope_id=SCOPE_ID,
+                enabled=1,
+                role=None,
+                workdir="/tmp/archive-test",
+                agent_name=agent_name,
+                agent_backend="claude",
+                agent_variant="claude",
+                model=None,
+                reasoning_effort=None,
+                require_mention=None,
+                settings_version=1,
+                settings_json=json.dumps(
+                    {"routing": {"agent_name": agent_name, "agent": agent_name}}
+                ),
+                created_at=NOW,
+                updated_at=NOW,
+            )
+        )
+        conn.execute(
+            agent_sessions.insert().values(
+                id="ses_archive",
+                scope_id=SCOPE_ID,
+                agent_id=None,
+                agent_name=agent_name,
+                agent_backend="claude",
+                agent_variant="claude",
+                model=None,
+                reasoning_effort=None,
+                session_anchor="ses_archive",
+                workdir="/tmp/archive-test",
+                native_session_id="",
+                title="Archive test",
+                status="active",
+                visibility="foreground",
+                pinned=0,
+                agent_status="idle",
+                metadata_json="{}",
+                created_at=NOW,
+                updated_at=NOW,
+                last_active_at=NOW,
+            )
+        )
+        for definition_id, deleted_at in (("task_live", None), ("watch_deleted", NOW)):
+            conn.execute(
+                run_definitions.insert().values(
+                    id=definition_id,
+                    definition_type="scheduled" if definition_id == "task_live" else "watch",
+                    name=definition_id,
+                    agent_name=agent_name,
+                    enabled=0,
+                    deleted_at=deleted_at,
+                    created_at=NOW,
+                    updated_at=NOW,
+                    metadata_json=json.dumps(
+                        {"session_settings_snapshot": {"agent_name": agent_name}}
+                    ),
+                )
+            )
+
+
+def test_archive_atomically_moves_live_references_and_hides_agent(tmp_path) -> None:
+    store = VibeAgentStore(tmp_path / "state" / "vibe.sqlite")
+    try:
+        store.create(name="claude-fallback", backend="claude")
+        original = store.create(
+            name="pm",
+            backend="claude",
+            description="Project manager",
+            system_prompt="Keep the project moving.",
+        )
+        store.set_default_agent_name("pm")
+        _seed_references(store, "pm")
+
+        result = store.archive("pm")
+
+        assert result is not None
+        assert result.original_name == "pm"
+        assert result.archived_name.startswith("_archived_")
+        assert result.references == {"scopes": 1, "sessions": 1, "definitions": 1}
+        assert result.default_agent_name == "claude-fallback"
+        assert store.get_default_agent_name() == "claude-fallback"
+        assert store.get("pm") is None
+        assert all(agent.id != original.id for agent in store.list_agents(include_disabled=True))
+
+        archived = store.require(result.archived_name)
+        assert archived.id == original.id
+        assert archived.enabled is False
+        assert archived.archived_at is not None
+        assert archived.to_dict()["display_name"] == "pm"
+        assert store.require_reference(result.archived_name).id == original.id
+        with pytest.raises(AgentUnavailableError, match="disabled"):
+            store.require_enabled(result.archived_name)
+        with pytest.raises(ValueError, match="archived and cannot be edited"):
+            store.set_enabled(result.archived_name, True)
+
+        listed_with_archives = store.list_agents(include_disabled=True, include_archived=True)
+        assert any(agent.id == original.id for agent in listed_with_archives)
+
+        with store.engine.connect() as conn:
+            scope = conn.execute(select(scope_settings)).mappings().one()
+            session = conn.execute(select(agent_sessions)).mappings().one()
+            definitions = conn.execute(select(run_definitions).order_by(run_definitions.c.id)).mappings().all()
+        assert scope["agent_name"] == result.archived_name
+        assert json.loads(scope["settings_json"])["routing"] == {
+            "agent_name": result.archived_name,
+            "agent": result.archived_name,
+        }
+        assert session["agent_name"] == result.archived_name
+        assert {row["agent_name"] for row in definitions} == {result.archived_name}
+        assert {
+            json.loads(row["metadata_json"])["session_settings_snapshot"]["agent_name"]
+            for row in definitions
+        } == {result.archived_name}
+
+        replacement = store.create(name="pm", backend="claude")
+        assert replacement.id != original.id
+    finally:
+        store.close()
+
+
+def test_rename_moves_references_and_default_without_changing_agent_identity(tmp_path) -> None:
+    store = VibeAgentStore(tmp_path / "state" / "vibe.sqlite")
+    try:
+        original = store.create(name="pm", backend="claude")
+        store.set_default_agent_name("pm")
+        _seed_references(store, "pm")
+
+        renamed = store.rename("pm", "project-manager")
+
+        assert renamed.id == original.id
+        assert store.get_default_agent_name() == "project-manager"
+        assert store.reference_counts("project-manager") == {
+            "scopes": 1,
+            "sessions": 1,
+            "definitions": 1,
+        }
+        assert store.get("pm") is None
+    finally:
+        store.close()
+
+
+def test_archive_rolls_back_when_default_has_no_replacement(tmp_path) -> None:
+    store = VibeAgentStore(tmp_path / "state" / "vibe.sqlite")
+    try:
+        original = store.create(name="only-agent", backend="codex")
+        store.set_default_agent_name(original.name)
+
+        with pytest.raises(ValueError, match="without another enabled Agent"):
+            store.archive(original.name)
+
+        assert store.require(original.name).id == original.id
+        assert store.get_default_agent_name() == original.name
+    finally:
+        store.close()
+
+
+def test_archive_rolls_back_when_reference_migration_fails(tmp_path, monkeypatch) -> None:
+    store = VibeAgentStore(tmp_path / "state" / "vibe.sqlite")
+    try:
+        original = store.create(name="worker", backend="codex")
+
+        def fail_reference_migration(*_args, **_kwargs):
+            raise RuntimeError("injected reference migration failure")
+
+        monkeypatch.setattr(store, "_rewrite_references", fail_reference_migration)
+        with pytest.raises(RuntimeError, match="injected reference migration failure"):
+            store.archive(original.name)
+
+        restored = store.require(original.name)
+        assert restored.id == original.id
+        assert restored.archived_at is None
+        assert restored.enabled is True
+    finally:
+        store.close()
+
+
+def test_user_agent_names_cannot_enter_internal_namespace(tmp_path) -> None:
+    store = VibeAgentStore(tmp_path / "state" / "vibe.sqlite")
+    try:
+        with pytest.raises(ValueError, match="reserved for Avibe"):
+            store.create(name="_hidden", backend="codex")
+        store.create(name="worker", backend="codex")
+        with pytest.raises(ValueError, match="reserved for Avibe"):
+            store.rename("worker", "_hidden")
+    finally:
+        store.close()
+
+
+def test_ordinary_disabled_agent_is_not_a_resolvable_reference(tmp_path) -> None:
+    store = VibeAgentStore(tmp_path / "state" / "vibe.sqlite")
+    try:
+        store.create(name="paused", backend="codex", enabled=False)
+        with pytest.raises(AgentUnavailableError, match="disabled"):
+            store.require_reference("paused")
+
+        archived = store.archive("paused")
+        assert archived is not None
+        with pytest.raises(AgentUnavailableError, match="disabled"):
+            store.require_reference(archived.archived_name)
+    finally:
+        store.close()

--- a/tests/test_vibe_agent_archive.py
+++ b/tests/test_vibe_agent_archive.py
@@ -30,6 +30,7 @@ from storage.models import (
     run_definitions,
     scope_settings,
     scopes,
+    state_meta,
 )
 from storage.sessions_service import SQLiteSessionsService
 
@@ -857,6 +858,31 @@ def test_rename_moves_references_and_default_without_changing_agent_identity(tmp
             for row in runs
             if row["status"] in {"succeeded", "failed", "canceled"}
         } == {"pm"}
+    finally:
+        store.close()
+
+
+def test_rename_updates_normalized_equivalent_legacy_default(tmp_path) -> None:
+    store = VibeAgentStore(tmp_path / "state" / "vibe.sqlite")
+    try:
+        original = store.create(name="Project Manager", backend="claude")
+        with store.engine.begin() as conn:
+            conn.execute(
+                state_meta.insert().values(
+                    key="default_agent_name",
+                    value_json=json.dumps("PROJECT-MANAGER"),
+                    updated_at=NOW,
+                )
+            )
+        assert store.get_default_agent() is not None
+        assert store.get_default_agent().id == original.id
+
+        renamed = store.rename(original.name, "review-lead")
+
+        assert renamed.id == original.id
+        assert store.get_default_agent_name() == renamed.name
+        assert store.get_default_agent() is not None
+        assert store.get_default_agent().id == original.id
     finally:
         store.close()
 

--- a/tests/test_vibe_agent_archive.py
+++ b/tests/test_vibe_agent_archive.py
@@ -3,10 +3,11 @@ from __future__ import annotations
 import json
 
 import pytest
-from sqlalchemy import select
+from sqlalchemy import select, update
 
 from core.vibe_agents import AgentUnavailableError, VibeAgentStore
-from storage.models import agent_sessions, run_definitions, scope_settings, scopes
+from storage.background import DefinitionWriteExpectation, definition_state_unchanged
+from storage.models import agent_runs, agent_sessions, run_definitions, scope_settings, scopes
 
 
 NOW = "2026-07-31T14:00:00+00:00"
@@ -92,6 +93,18 @@ def _seed_references(store: VibeAgentStore, agent_name: str) -> None:
                     ),
                 )
             )
+        for status in ("pending", "queued", "processing", "running", "succeeded", "failed", "canceled"):
+            conn.execute(
+                agent_runs.insert().values(
+                    id=f"run_{status}",
+                    run_type="agent",
+                    status=status,
+                    agent_name=agent_name,
+                    created_at=NOW,
+                    updated_at=NOW,
+                    metadata_json="{}",
+                )
+            )
 
 
 def test_archive_atomically_moves_live_references_and_hides_agent(tmp_path) -> None:
@@ -136,6 +149,7 @@ def test_archive_atomically_moves_live_references_and_hides_agent(tmp_path) -> N
             scope = conn.execute(select(scope_settings)).mappings().one()
             session = conn.execute(select(agent_sessions)).mappings().one()
             definitions = conn.execute(select(run_definitions).order_by(run_definitions.c.id)).mappings().all()
+            runs = conn.execute(select(agent_runs.c.status, agent_runs.c.agent_name)).mappings().all()
         assert scope["agent_name"] == result.archived_name
         assert json.loads(scope["settings_json"])["routing"] == {
             "agent_name": result.archived_name,
@@ -147,6 +161,16 @@ def test_archive_atomically_moves_live_references_and_hides_agent(tmp_path) -> N
             json.loads(row["metadata_json"])["session_settings_snapshot"]["agent_name"]
             for row in definitions
         } == {result.archived_name}
+        assert {
+            row["agent_name"]
+            for row in runs
+            if row["status"] in {"pending", "queued", "processing", "running"}
+        } == {result.archived_name}
+        assert {
+            row["agent_name"]
+            for row in runs
+            if row["status"] in {"succeeded", "failed", "canceled"}
+        } == {"pm"}
 
         replacement = store.create(name="pm", backend="claude")
         assert replacement.id != original.id
@@ -171,6 +195,80 @@ def test_rename_moves_references_and_default_without_changing_agent_identity(tmp
             "definitions": 1,
         }
         assert store.get("pm") is None
+        with store.engine.connect() as conn:
+            runs = conn.execute(select(agent_runs.c.status, agent_runs.c.agent_name)).mappings().all()
+        assert {
+            row["agent_name"]
+            for row in runs
+            if row["status"] in {"pending", "queued", "processing", "running"}
+        } == {"project-manager"}
+        assert {
+            row["agent_name"]
+            for row in runs
+            if row["status"] in {"succeeded", "failed", "canceled"}
+        } == {"pm"}
+    finally:
+        store.close()
+
+
+def test_archive_invalidates_stale_definition_writes_for_direct_and_snapshot_bindings(tmp_path) -> None:
+    store = VibeAgentStore(tmp_path / "state" / "vibe.sqlite")
+    try:
+        store.create(name="pm", backend="claude")
+        rows = (
+            {"id": "task_direct", "agent_name": "pm", "metadata_json": "{}"},
+            {
+                "id": "task_snapshot",
+                "agent_name": None,
+                "metadata_json": json.dumps(
+                    {
+                        "session_settings_snapshot": {
+                            "agent_name": "pm",
+                            "captured_at": NOW,
+                        }
+                    }
+                ),
+            },
+        )
+        expectations: dict[str, DefinitionWriteExpectation] = {}
+        with store.engine.begin() as conn:
+            for row in rows:
+                conn.execute(
+                    run_definitions.insert().values(
+                        id=row["id"],
+                        definition_type="scheduled",
+                        name=row["id"],
+                        agent_name=row["agent_name"],
+                        enabled=0,
+                        created_at=NOW,
+                        updated_at=NOW,
+                        metadata_json=row["metadata_json"],
+                    )
+                )
+                expectations[row["id"]] = DefinitionWriteExpectation.from_read(
+                    enabled=False,
+                    metadata=json.loads(row["metadata_json"]),
+                )
+
+        archived = store.archive("pm")
+        assert archived is not None
+
+        with store.engine.begin() as conn:
+            for row in rows:
+                stale_write = conn.execute(
+                    update(run_definitions)
+                    .where(run_definitions.c.id == row["id"])
+                    .where(*definition_state_unchanged(expectations[row["id"]]))
+                    .values(agent_name=row["agent_name"], metadata_json=row["metadata_json"])
+                )
+                assert stale_write.rowcount == 0
+
+            stored = {row["id"]: row for row in conn.execute(select(run_definitions)).mappings().all()}
+        assert stored["task_direct"]["agent_name"] == archived.archived_name
+        assert (
+            json.loads(stored["task_snapshot"]["metadata_json"])["session_settings_snapshot"]["agent_name"]
+            == archived.archived_name
+        )
     finally:
         store.close()
 

--- a/tests/test_workbench_session_defaults.py
+++ b/tests/test_workbench_session_defaults.py
@@ -105,6 +105,7 @@ def test_explicit_agent_name_derives_backend_on_create(engine, tmp_path):
 
 def test_archived_project_default_is_not_inherited_by_new_session(engine, tmp_path):
     _ensure_agent("retired-default", "claude")
+    _ensure_agent("zz-fallback", "claude")
     created = _project_with_default(
         engine,
         tmp_path,

--- a/tests/test_workbench_session_defaults.py
+++ b/tests/test_workbench_session_defaults.py
@@ -103,6 +103,31 @@ def test_explicit_agent_name_derives_backend_on_create(engine, tmp_path):
     assert session["agent_variant"] == "codex"
 
 
+def test_archived_project_default_is_not_inherited_by_new_session(engine, tmp_path):
+    _ensure_agent("retired-default", "claude")
+    created = _project_with_default(
+        engine,
+        tmp_path,
+        agent_name="retired-default",
+    )
+    store = VibeAgentStore()
+    try:
+        archived = store.archive("retired-default")
+        assert archived is not None
+    finally:
+        store.close()
+
+    with engine.begin() as conn:
+        session = workbench_sessions_service.create_session(
+            conn,
+            scope_id=created["scope_id"],
+            agent_backend="",
+        )
+
+    assert session["agent_name"] is None
+    assert (session["agent_backend"] or "") == ""
+
+
 def test_agent_name_update_derives_backend(engine, tmp_path):
     _ensure_agent("reviewer", "codex")
     created = _project_with_default(engine, tmp_path)

--- a/ui/src/components/steps/ChannelList.tsx
+++ b/ui/src/components/steps/ChannelList.tsx
@@ -52,6 +52,7 @@ interface ChannelListProps {
 }
 
 export interface ChannelConfig {
+  expected_agent_name?: string | null;
   enabled: boolean;
   show_message_types: string[];
   custom_cwd: string;

--- a/ui/src/components/steps/ChannelList.tsx
+++ b/ui/src/components/steps/ChannelList.tsx
@@ -1590,7 +1590,7 @@ export const ChannelList: React.FC<ChannelListProps> = ({ data = {}, onNext, onB
                     : channelConfig.routing.opencode_model
               );
               const agentSummary = selectedAgent
-                ? `${selectedAgent.name}${selectedAgent.model ? ` / ${selectedAgent.model}` : ''}`
+                ? `${selectedAgent.display_name || selectedAgent.name}${selectedAgent.model ? ` / ${selectedAgent.model}` : ''}`
                 : `${effectiveBackend === 'claude' ? 'Claude' : effectiveBackend === 'codex' ? 'Codex' : 'OpenCode'}${backendModel ? ` / ${backendModel}` : ''}`;
 
               return (

--- a/ui/src/components/steps/UserList.tsx
+++ b/ui/src/components/steps/UserList.tsx
@@ -763,7 +763,7 @@ export const UserList: React.FC = () => {
               const displayName = displayNameForUser(u);
               const metaPrefix = userConfig.enabled
                 ? selectedAgent
-                  ? `${selectedAgent.name}${selectedAgent.model ? `/${selectedAgent.model}` : ''}`
+                  ? `${selectedAgent.display_name || selectedAgent.name}${selectedAgent.model ? `/${selectedAgent.model}` : ''}`
                   : `${backendLabel(effectiveBackend)}${backendModel ? `/${backendModel}` : ''}`
                 : t('userList.disabled', { defaultValue: 'Disabled' });
 

--- a/ui/src/components/steps/UserList.tsx
+++ b/ui/src/components/steps/UserList.tsx
@@ -26,6 +26,7 @@ import { Button } from '../ui/button';
 import { Input } from '../ui/input';
 
 interface UserConfig {
+  expected_agent_name?: string | null;
   display_name: string;
   is_admin: boolean;
   bound_at: string;

--- a/ui/src/components/workbench/AgentGraphDetail.tsx
+++ b/ui/src/components/workbench/AgentGraphDetail.tsx
@@ -198,7 +198,11 @@ export const AgentGraphDetail: React.FC<AgentGraphDetailProps> = ({
       <div className="flex flex-col gap-1">
         <div className="text-[16px] font-bold text-foreground">{nodeDisplayTitle(node)}</div>
         <div className="flex flex-wrap items-center gap-1.5 text-[11px] text-muted">
-          {node.agent_name && <span className="font-medium text-foreground">{node.agent_name}</span>}
+          {(node.agent_display_name || node.agent_name) && (
+            <span className="font-medium text-foreground">
+              {node.agent_display_name || node.agent_name}
+            </span>
+          )}
           {node.agent_backend && (
             <span className="rounded border border-border-strong bg-foreground/[0.04] px-1 font-mono text-[9px] font-bold uppercase">
               {node.agent_backend}

--- a/ui/src/components/workbench/AgentGraphNodeCard.tsx
+++ b/ui/src/components/workbench/AgentGraphNodeCard.tsx
@@ -72,7 +72,7 @@ export const AgentGraphNodeCard: React.FC<AgentGraphNodeCardProps> = ({
       <div className="flex min-w-0 items-center gap-1.5">
         <StatusGlyph node={node} />
         <span className="truncate text-[12px] font-semibold text-foreground">
-          {node.agent_name ?? '—'}
+          {node.agent_display_name ?? node.agent_name ?? '—'}
         </span>
         {node.agent_backend && (
           <span

--- a/ui/src/components/workbench/AgentRoutePicker.tsx
+++ b/ui/src/components/workbench/AgentRoutePicker.tsx
@@ -142,15 +142,18 @@ export const AgentRoutePicker: React.FC<AgentRoutePickerProps> = ({
   const currentAgent = displayValue.agent_name;
   const currentModel = displayValue.model;
   const currentEffort = displayValue.reasoning_effort;
-  const triggerLabel = (routeIsDefault && defaultLabel) || currentAgent || defaultLabel || t('chat.pickAgent');
-  const compactTriggerLabel = currentAgent || defaultLabel || t('chat.pickAgent');
+  const currentAgentLabel = displayedAgent?.display_name || currentAgent;
+  const triggerLabel = (routeIsDefault && defaultLabel) || currentAgentLabel || defaultLabel || t('chat.pickAgent');
+  const compactTriggerLabel = currentAgentLabel || defaultLabel || t('chat.pickAgent');
 
   const allowedBackendSet = useMemo(
     () => new Set((allowedBackends ?? []).map((item) => item.trim()).filter(Boolean)),
     [allowedBackends],
   );
   const visibleAgents = useMemo(
-    () => (allowedBackendSet.size === 0 ? agents : agents.filter((agent) => allowedBackendSet.has(agent.backend))),
+    () => agents.filter(
+      (agent) => agent.enabled && !agent.archived && (allowedBackendSet.size === 0 || allowedBackendSet.has(agent.backend)),
+    ),
     [agents, allowedBackendSet],
   );
 

--- a/ui/src/components/workbench/AgentsPage.tsx
+++ b/ui/src/components/workbench/AgentsPage.tsx
@@ -298,8 +298,6 @@ export const AgentsPage: React.FC = () => {
       if (result.ok) {
         setSelected(null);
         refresh();
-      } else if (result.code === 'agent_in_use') {
-        setError(t('agents.deleteInUse', { name: selected.name }));
       } else if (result.message) {
         setError(result.message);
       }
@@ -655,8 +653,8 @@ interface DetailProps {
 // Mirrors design.pen s7QaWQ. Header (name + close X) → Enable card →
 // Name → Backend (read-only) → Model (Combobox) → Reasoning effort →
 // System Prompt (collapsible) → footer Run / Delete. Name is editable
-// for user agents (rename = create-then-delete since backend keeps name
-// as the immutable reference id). System agents lock the name.
+// for user agents. The backend renames the row and its references atomically;
+// system agents keep their locked identity.
 const AgentDetailPanel: React.FC<DetailProps> = ({ agent, isDefault, onChange, onSetDefault, onRenamed, onDelete, onClose }) => {
   const { t } = useTranslation();
   const api = useApi();
@@ -725,9 +723,8 @@ const AgentDetailPanel: React.FC<DetailProps> = ({ agent, isDefault, onChange, o
   // Effort options follow the backend + selected model when the catalog provides them.
   const effortOptions = resolveEffortOptions(agent.backend, model, reasoningOptions);
 
-  // Backend rejects PATCH /agents/<name> with a new name; the supported
-  // way to rename is create-then-delete. We only let user agents do this
-  // (system agents block both delete and name change).
+  // Only user Agents can be renamed; the backend moves every durable name
+  // reference in the same transaction.
   const commitRename = async () => {
     const trimmed = name.trim();
     if (!trimmed || trimmed === agent.name) {
@@ -740,37 +737,8 @@ const AgentDetailPanel: React.FC<DetailProps> = ({ agent, isDefault, onChange, o
     }
     setRenaming(true);
     try {
-      // Clone with new name first so we never end up nameless on failure.
-      await api.createVibeAgent({
-        name: trimmed,
-        backend: agent.backend,
-        description: agent.description,
-        model: agent.model,
-        reasoning_effort: agent.reasoning_effort,
-        system_prompt: agent.system_prompt,
-        metadata: agent.metadata,
-        enabled: agent.enabled,
-      });
-      const removeResult = await api.removeVibeAgent(agent.name);
-      if (!removeResult.ok) {
-        // Old name still has references — keep it but tell the user the
-        // new one exists too.
-        showToast(removeResult.message || t('agents.renameKeptOld'), 'warning');
-      } else {
-        showToast(t('agents.renameSuccess'), 'success');
-      }
-      // Carry the default over to the new name. removeVibeAgent() drops the
-      // old row without moving default_agent_name, so renaming the default
-      // agent would otherwise silently fall the default back to another agent.
-      if (isDefault) {
-        try {
-          await api.setDefaultVibeAgent(trimmed);
-        } catch (defErr: any) {
-          showToast(defErr?.message ?? String(defErr), 'warning');
-        }
-      }
-      // Refresh the list and re-select the renamed agent so the old name
-      // drops out and the clone shows as the selected detail row.
+      await api.updateVibeAgent(agent.name, { name: trimmed });
+      showToast(t('agents.renameSuccess'), 'success');
       onRenamed(trimmed);
     } catch (err: any) {
       showToast(err?.message ?? String(err), 'error');

--- a/ui/src/components/workbench/ChatArchivedReadOnly.test.tsx
+++ b/ui/src/components/workbench/ChatArchivedReadOnly.test.tsx
@@ -11,7 +11,7 @@ import { selectApiErrorFields } from '../../context/ApiContext';
 import type { VaultRequest, VibeAgentBrief, WorkbenchMessage, WorkbenchSession } from '../../context/ApiContext';
 import { ToastProvider } from '../../context/ToastContext';
 import { isVoiceControlDisabled } from '../../lib/voiceRecording';
-import { ChatHeaderBar, MessageRow, ThinkingBubble } from './ChatPage';
+import { ChatHeaderBar, MessageRow, ThinkingBubble, sessionAgentDisplayName } from './ChatPage';
 import { Composer } from './Composer';
 import { QuickReplies } from './QuickReplies';
 import {
@@ -224,6 +224,13 @@ describe('read-only transcript withdraws session writes', () => {
 });
 
 describe('archived Agent display names', () => {
+  it('keeps the display name when a mounted catalog still has the pre-archive name', () => {
+    const staleCatalogAgent = { ...archivedPm, name: 'pm' };
+    const archivedSession = session({ agent_id: archivedPm.id, agent_name: archivedPm.name });
+
+    expect(sessionAgentDisplayName(archivedSession, [staleCatalogAgent])).toBe('pm');
+  });
+
   it('uses the catalog display name in thinking and transcript bubbles', () => {
     const archivedSession = session({ agent_name: archivedPm.name });
     const displayName = archivedPm.display_name;

--- a/ui/src/components/workbench/ChatArchivedReadOnly.test.tsx
+++ b/ui/src/components/workbench/ChatArchivedReadOnly.test.tsx
@@ -8,10 +8,10 @@ import { describe, expect, it } from 'vitest';
 import en from '../../i18n/en.json';
 import zh from '../../i18n/zh.json';
 import { selectApiErrorFields } from '../../context/ApiContext';
-import type { VaultRequest, WorkbenchMessage, WorkbenchSession } from '../../context/ApiContext';
+import type { VaultRequest, VibeAgentBrief, WorkbenchMessage, WorkbenchSession } from '../../context/ApiContext';
 import { ToastProvider } from '../../context/ToastContext';
 import { isVoiceControlDisabled } from '../../lib/voiceRecording';
-import { ChatHeaderBar, MessageRow } from './ChatPage';
+import { ChatHeaderBar, MessageRow, ThinkingBubble } from './ChatPage';
 import { Composer } from './Composer';
 import { QuickReplies } from './QuickReplies';
 import {
@@ -67,6 +67,21 @@ const session = (over: Partial<WorkbenchSession> = {}): WorkbenchSession =>
     metadata: {},
     ...over,
   }) as WorkbenchSession;
+
+const archivedPm = {
+  id: 'agt-pm',
+  name: '_pm-8dd7',
+  display_name: 'pm',
+  description: null,
+  backend: 'codex',
+  model: null,
+  reasoning_effort: null,
+  enabled: false,
+  archived: true,
+  archived_at: '2026-07-31T14:00:00Z',
+  source: 'user',
+  updated_at: '2026-07-31T14:00:00Z',
+} satisfies VibeAgentBrief;
 
 // An agent reply carrying a quick-reply group, which is the transcript control
 // that POSTs a new message when clicked.
@@ -205,6 +220,30 @@ describe('read-only transcript withdraws session writes', () => {
     expect(archived).toContain('Ship it');
     expect(archived).toContain('Ship it now, or wait for review?');
     expect(countDisabledButtons(archived)).toBe(2);
+  });
+});
+
+describe('archived Agent display names', () => {
+  it('uses the catalog display name in thinking and transcript bubbles', () => {
+    const archivedSession = session({ agent_name: archivedPm.name });
+    const displayName = archivedPm.display_name;
+
+    const thinking = render(
+      <ThinkingBubble session={archivedSession} agentDisplayName={displayName} />,
+    );
+    const message = render(
+      <MessageRow
+        message={agentWithQuickReplies()}
+        session={archivedSession}
+        agentDisplayName={displayName}
+        messageFontSize={13}
+      />,
+    );
+
+    expect(thinking).toContain('>pm</span>');
+    expect(message).toContain('>pm</span>');
+    expect(thinking).not.toContain(archivedPm.name);
+    expect(message).not.toContain(archivedPm.name);
   });
 });
 

--- a/ui/src/components/workbench/ChatPage.tsx
+++ b/ui/src/components/workbench/ChatPage.tsx
@@ -2616,6 +2616,7 @@ export const ChatHeaderBar: React.FC<ChatHeaderBarProps> = ({ session, agents, d
   const readOnly = readOnlyReason !== null;
   const showPageActions = showPageControlActions(readOnly, showPageMode);
   const defaultAgent = defaultAgentName ? agents.find((agent) => agent.name === defaultAgentName) : null;
+  const sessionAgent = session.agent_name ? agents.find((agent) => agent.name === session.agent_name) : null;
   // Backend locks once a NATIVE conversation exists — a native can only be
   // resumed by the backend that created it — or while a turn is RUNNING (the
   // in-flight turn binds its native on the current route any moment); mirrors
@@ -2679,7 +2680,7 @@ export const ChatHeaderBar: React.FC<ChatHeaderBarProps> = ({ session, agents, d
           <div className="flex min-w-0 shrink-0 items-center gap-1.5">
             {readOnlyReason === 'archived' && (
               <span className="truncate text-[12px] font-medium text-muted">
-                {session.agent_name || (defaultAgent ? defaultAgent.name : t('newSession.defaultAgent'))}
+                {sessionAgent?.display_name || session.agent_name || (defaultAgent ? defaultAgent.name : t('newSession.defaultAgent'))}
               </span>
             )}
             <Badge variant="secondary" className="shrink-0 px-1.5 py-0 text-[10px] font-bold">

--- a/ui/src/components/workbench/ChatPage.tsx
+++ b/ui/src/components/workbench/ChatPage.tsx
@@ -101,13 +101,16 @@ import {
 // ``in_flight:true``; only an idle reading (past the post-send grace) clears it.
 const WORKING_RECONCILE_INTERVAL_MS = 60 * 1000;
 
-function sessionAgentDisplayName(
-  session: Pick<WorkbenchSession, 'agent_name'>,
+export function sessionAgentDisplayName(
+  session: Pick<WorkbenchSession, 'agent_id' | 'agent_name'>,
   agents: VibeAgentBrief[],
 ): string | null {
   const agentName = session.agent_name?.trim() || null;
   if (!agentName) return null;
-  return agents.find((agent) => agent.name === agentName)?.display_name?.trim() || agentName;
+  const agent =
+    (session.agent_id ? agents.find((candidate) => candidate.id === session.agent_id) : undefined) ??
+    agents.find((candidate) => candidate.name === agentName);
+  return agent?.display_name?.trim() || agentName;
 }
 
 // Grace window after we optimistically set ``working`` from a local send before

--- a/ui/src/components/workbench/ChatPage.tsx
+++ b/ui/src/components/workbench/ChatPage.tsx
@@ -101,6 +101,15 @@ import {
 // ``in_flight:true``; only an idle reading (past the post-send grace) clears it.
 const WORKING_RECONCILE_INTERVAL_MS = 60 * 1000;
 
+function sessionAgentDisplayName(
+  session: Pick<WorkbenchSession, 'agent_name'>,
+  agents: VibeAgentBrief[],
+): string | null {
+  const agentName = session.agent_name?.trim() || null;
+  if (!agentName) return null;
+  return agents.find((agent) => agent.name === agentName)?.display_name?.trim() || agentName;
+}
+
 // Grace window after we optimistically set ``working`` from a local send before
 // an idle ``/turn-state`` reading is trusted to CLEAR it. A just-sent turn isn't
 // registered in the controller's in-flight map until POST→dispatch_async lands,
@@ -1980,6 +1989,8 @@ export const ChatPage: React.FC = () => {
     );
   }
 
+  const agentDisplayName = sessionAgentDisplayName(session, agents);
+
   return (
     // Fill the viewport so the transcript is the only scrolling region and
     // the compose bar genuinely anchors to the bottom. The outer AppShell
@@ -2084,6 +2095,7 @@ export const ChatPage: React.FC = () => {
         <Transcript
           messages={messages}
           session={session}
+          agentDisplayName={agentDisplayName}
           working={working}
           hasOlder={!!olderCursor}
           loadingOlder={loadingOlder}
@@ -2616,7 +2628,7 @@ export const ChatHeaderBar: React.FC<ChatHeaderBarProps> = ({ session, agents, d
   const readOnly = readOnlyReason !== null;
   const showPageActions = showPageControlActions(readOnly, showPageMode);
   const defaultAgent = defaultAgentName ? agents.find((agent) => agent.name === defaultAgentName) : null;
-  const sessionAgent = session.agent_name ? agents.find((agent) => agent.name === session.agent_name) : null;
+  const sessionAgentLabel = sessionAgentDisplayName(session, agents);
   // Backend locks once a NATIVE conversation exists — a native can only be
   // resumed by the backend that created it — or while a turn is RUNNING (the
   // in-flight turn binds its native on the current route any moment); mirrors
@@ -2680,7 +2692,7 @@ export const ChatHeaderBar: React.FC<ChatHeaderBarProps> = ({ session, agents, d
           <div className="flex min-w-0 shrink-0 items-center gap-1.5">
             {readOnlyReason === 'archived' && (
               <span className="truncate text-[12px] font-medium text-muted">
-                {sessionAgent?.display_name || session.agent_name || (defaultAgent ? defaultAgent.name : t('newSession.defaultAgent'))}
+                {sessionAgentLabel || (defaultAgent ? defaultAgent.name : t('newSession.defaultAgent'))}
               </span>
             )}
             <Badge variant="secondary" className="shrink-0 px-1.5 py-0 text-[10px] font-bold">
@@ -2833,6 +2845,7 @@ const TitleField: React.FC<TitleFieldProps> = ({ title, onCommit, readOnly }) =>
 interface TranscriptProps {
   messages: WorkbenchMessage[];
   session: WorkbenchSession;
+  agentDisplayName: string | null;
   working: boolean;
   hasOlder: boolean;
   loadingOlder: boolean;
@@ -2889,6 +2902,7 @@ interface TranscriptProps {
 const Transcript: React.FC<TranscriptProps> = ({
   messages,
   session,
+  agentDisplayName,
   working,
   hasOlder,
   loadingOlder,
@@ -3322,6 +3336,7 @@ const Transcript: React.FC<TranscriptProps> = ({
                 <MessageRow
                   message={message}
                   session={session}
+                  agentDisplayName={agentDisplayName}
                   messageFontSize={messageFontSize}
                   onQuickReply={onQuickReply}
                   vaultRequests={provisionRequestsByMessage.get(message.id)}
@@ -3346,7 +3361,7 @@ const Transcript: React.FC<TranscriptProps> = ({
               onToggleTools={activity.onToggleTools}
             />
           ) : showThinking ? (
-            <ThinkingBubble session={session} />
+            <ThinkingBubble session={session} agentDisplayName={agentDisplayName} />
           ) : null}
           {footer}
         </div>
@@ -3399,14 +3414,19 @@ const ForkSourceBanner: React.FC<{ sourceSessionId: string; sourceTitle: string 
 // agent bubble with three dots that fade in sequence (``.vr-typing-dot``
 // keyframes in index.css), so the user gets immediate feedback a reply is
 // coming (feedback #1).
-const ThinkingBubble: React.FC<{ session: WorkbenchSession }> = ({ session }) => {
+export const ThinkingBubble: React.FC<{
+  session: WorkbenchSession;
+  agentDisplayName: string | null;
+}> = ({ session, agentDisplayName }) => {
   const { t } = useTranslation();
   return (
     <div className="flex w-full justify-start">
       <div className="group/message flex max-w-[min(92%,860px)] flex-col items-start gap-1">
         <div className="flex items-center gap-2 px-0.5">
           <RoleAvatar tone="mint"><Bot /></RoleAvatar>
-          <span className="text-[11px] font-medium text-muted">{session.agent_name || t('chat.thinking')}</span>
+          <span className="text-[11px] font-medium text-muted">
+            {agentDisplayName || session.agent_name || t('chat.thinking')}
+          </span>
         </div>
         <div className="w-fit rounded-2xl rounded-tl-md border border-mint/25 bg-mint/[0.09] px-3.5 py-2.5">
           <div className="flex items-center gap-1 py-0.5">
@@ -3423,6 +3443,7 @@ const ThinkingBubble: React.FC<{ session: WorkbenchSession }> = ({ session }) =>
 type MessageRowProps = {
   message: WorkbenchMessage;
   session: WorkbenchSession;
+  agentDisplayName?: string | null;
   messageFontSize: number;
   onQuickReply?: (messageId: string, choice: string) => boolean | void | Promise<boolean | void>;
   vaultRequests?: VaultRequest[];
@@ -3452,6 +3473,7 @@ type MessageRowProps = {
 export const MessageRow = memo(function MessageRow({
   message,
   session,
+  agentDisplayName,
   messageFontSize,
   onQuickReply,
   vaultRequests,
@@ -3720,7 +3742,9 @@ export const MessageRow = memo(function MessageRow({
   }
 
   // ----- Agent / system: left-aligned bubble with avatar + name header -----
-  const name = isAgent ? session.agent_name || message.author_name : message.author_name;
+  const name = isAgent
+    ? agentDisplayName || session.agent_name || message.author_name
+    : message.author_name;
   return (
     <div data-message-id={message.id} className={rowClass('justify-start')}>
       <div className="group/message flex max-w-[min(92%,860px)] flex-col items-start gap-1">

--- a/ui/src/components/workbench/HarnessPage.test.tsx
+++ b/ui/src/components/workbench/HarnessPage.test.tsx
@@ -7,6 +7,7 @@ import { describe, expect, it } from 'vitest';
 
 import en from '../../i18n/en.json';
 import type {
+  ApiContextType,
   HarnessRun,
   HarnessSessionSummary,
   HarnessWatch,
@@ -22,6 +23,7 @@ import {
   harnessEmptyStateKey,
   harnessTabFromParam,
 } from './HarnessPage';
+import { loadHarnessAgentCatalog } from './harnessAgents';
 import { RUN_TYPES, harnessSessionState, runRowTitle, runStatusLabel, runTypeLabel, runTypeOptions } from './harnessRuns';
 
 const i18n = createInstance();
@@ -132,6 +134,36 @@ describe('harnessEmptyStateKey', () => {
   ] as const)('distinguishes an empty store from an empty %s view', (kind, emptyKey, filteredKey) => {
     expect(harnessEmptyStateKey(kind, false)).toBe(emptyKey);
     expect(harnessEmptyStateKey(kind, true)).toBe(filteredKey);
+  });
+});
+
+describe('loadHarnessAgentCatalog', () => {
+  it('bypasses the read cache and indexes a newly archived Agent by its internal name', async () => {
+    const archived = {
+      id: 'agent-pm',
+      name: '_pm-a1b2',
+      display_name: 'pm',
+      description: null,
+      backend: 'codex',
+      model: null,
+      reasoning_effort: null,
+      enabled: false,
+      archived: true,
+      archived_at: '2026-07-31T21:00:00Z',
+      source: 'custom',
+      updated_at: '2026-07-31T21:00:00Z',
+    } satisfies VibeAgentBrief;
+    let params: Parameters<ApiContextType['listVibeAgents']>[0] = undefined;
+
+    const catalog = await loadHarnessAgentCatalog({
+      listVibeAgents: async (nextParams) => {
+        params = nextParams;
+        return { ok: true, agents: [archived], default_agent_name: 'codex' };
+      },
+    });
+
+    expect(params).toEqual({ includeDisabled: true, includeArchived: true, cache: false });
+    expect(catalog).toEqual({ '_pm-a1b2': archived });
   });
 });
 

--- a/ui/src/components/workbench/HarnessPage.test.tsx
+++ b/ui/src/components/workbench/HarnessPage.test.tsx
@@ -6,13 +6,19 @@ import { MemoryRouter } from 'react-router-dom';
 import { describe, expect, it } from 'vitest';
 
 import en from '../../i18n/en.json';
-import type { HarnessRun, HarnessSessionSummary, HarnessWatch } from '../../context/ApiContext';
+import type {
+  HarnessRun,
+  HarnessSessionSummary,
+  HarnessWatch,
+  VibeAgentBrief,
+} from '../../context/ApiContext';
 import {
   DetailSession,
   HealthBadge,
   RunDetail,
   RunTriggerChip,
   WatchDetail,
+  agentDisplayName,
   harnessEmptyStateKey,
   harnessTabFromParam,
 } from './HarnessPage';
@@ -167,6 +173,28 @@ describe('RunDetail title', () => {
     expect(html).toContain('break-words');
     expect(html).toContain(`title="${message.trim()}"`);
     expect(html).toContain(message);
+  });
+
+  it('uses the archived Agent display name instead of its routing name', () => {
+    const agent: VibeAgentBrief = {
+      id: 'agent-pm',
+      name: '_pm-8dd7',
+      display_name: 'pm',
+      description: null,
+      backend: 'codex',
+      model: null,
+      reasoning_effort: null,
+      enabled: false,
+      archived: true,
+      archived_at: '2026-07-31T00:00:00Z',
+      source: 'user',
+      updated_at: '2026-07-31T00:00:00Z',
+    };
+    const html = render(<RunDetail run={run({ agent_name: agent.name })} agent={agent} />);
+
+    expect(agentDisplayName(agent.name, agent)).toBe('pm');
+    expect(html).toContain('>pm<');
+    expect(html).not.toContain('_pm-8dd7');
   });
 });
 

--- a/ui/src/components/workbench/HarnessPage.tsx
+++ b/ui/src/components/workbench/HarnessPage.tsx
@@ -816,6 +816,7 @@ export const HarnessPage: React.FC = () => {
           {tab === 'runs' && (
             <RunsList
               runs={runs}
+              agentsByName={agentsByName}
               loading={loading}
               hasStoredRows={runCounts.all > 0}
               selectedId={selection?.kind === 'run' ? selection.id : null}
@@ -858,7 +859,7 @@ export const HarnessPage: React.FC = () => {
                 pending={!!pendingMutation[selectedWatch.id]}
               />
             ) : selectedRun ? (
-              <RunDetail run={selectedRun} />
+              <RunDetail run={selectedRun} agent={agentsByName[selectedRun.agent_name ?? '']} />
             ) : null}
           </div>
         )}
@@ -1414,6 +1415,7 @@ export const WatchDetail: React.FC<WatchDetailProps> = ({ watch, agent, onToggle
 
 interface RunsListProps {
   runs: HarnessRun[];
+  agentsByName: Record<string, VibeAgentBrief>;
   loading: boolean;
   hasStoredRows: boolean;
   selectedId: string | null;
@@ -1426,6 +1428,7 @@ interface RunsListProps {
 
 const RunsList: React.FC<RunsListProps> = ({
   runs,
+  agentsByName,
   loading,
   hasStoredRows,
   selectedId,
@@ -1480,7 +1483,9 @@ const RunsList: React.FC<RunsListProps> = ({
                   {run.agent_name && (
                     <span className="inline-flex min-w-0 items-center gap-1">
                       <Bot className="size-3 shrink-0" />
-                      <span className="truncate">{run.agent_name}</span>
+                      <span className="truncate">
+                        {agentDisplayName(run.agent_name, agentsByName[run.agent_name])}
+                      </span>
                     </span>
                   )}
                   <RunSessionLabel run={run} />
@@ -1558,9 +1563,17 @@ const RunSessionLabel: React.FC<{ run: HarnessRun }> = ({ run }) => {
 
 interface RunDetailProps {
   run: HarnessRun;
+  agent?: VibeAgentBrief;
 }
 
-export const RunDetail: React.FC<RunDetailProps> = ({ run }) => {
+export function agentDisplayName(
+  agentName: string | null | undefined,
+  agent?: Pick<VibeAgentBrief, 'display_name'>,
+): string {
+  return agent?.display_name || agentName || '—';
+}
+
+export const RunDetail: React.FC<RunDetailProps> = ({ run, agent }) => {
   const { t } = useTranslation();
   const typeLabel = runTypeLabel(run.run_type || run.request_type, t);
   const title = runRowTitle(run, typeLabel);
@@ -1594,7 +1607,7 @@ export const RunDetail: React.FC<RunDetailProps> = ({ run }) => {
         <span className="text-[12px] text-foreground">{typeLabel}</span>
       </DetailField>
       <DetailField label={t('harness.detail.agent')}>
-        <span className="text-[12px] text-foreground">{run.agent_name || '—'}</span>
+        <span className="text-[12px] text-foreground">{agentDisplayName(run.agent_name, agent)}</span>
         {run.agent_backend && <span className="ml-2 font-mono text-[10px] text-muted">{run.agent_backend}</span>}
         {run.model && <span className="ml-2 font-mono text-[10px] text-muted">{run.model}</span>}
       </DetailField>

--- a/ui/src/components/workbench/HarnessPage.tsx
+++ b/ui/src/components/workbench/HarnessPage.tsx
@@ -399,7 +399,7 @@ export const HarnessPage: React.FC = () => {
   useEffect(() => {
     let cancelled = false;
     api
-      .listVibeAgents({ includeDisabled: true })
+      .listVibeAgents({ includeDisabled: true, includeArchived: true })
       .then((res) => {
         if (cancelled) return;
         const map: Record<string, VibeAgentBrief> = {};
@@ -1790,15 +1790,17 @@ const DetailAgent: React.FC<{ agentName: string | null; agent?: VibeAgentBrief }
   return (
     <div className="flex min-w-0 items-center gap-2">
       <Bot className="size-3.5 shrink-0 text-violet" />
-      <span className="shrink-0 text-[12px] font-medium text-foreground">{agentName}</span>
+      <span className="shrink-0 text-[12px] font-medium text-foreground">{agent?.display_name || agentName}</span>
       {meta && <span className="min-w-0 flex-1 truncate font-mono text-[10px] text-muted">{meta}</span>}
-      <Link
-        to="/agents"
-        className="ml-auto inline-flex shrink-0 items-center gap-0.5 text-[11px] font-medium text-violet hover:underline"
-      >
-        {t('harness.detail.openInAgents')}
-        <ArrowUpRight className="size-3" />
-      </Link>
+      {!agent?.archived && (
+        <Link
+          to="/agents"
+          className="ml-auto inline-flex shrink-0 items-center gap-0.5 text-[11px] font-medium text-violet hover:underline"
+        >
+          {t('harness.detail.openInAgents')}
+          <ArrowUpRight className="size-3" />
+        </Link>
+      )}
     </div>
   );
 };

--- a/ui/src/components/workbench/HarnessPage.tsx
+++ b/ui/src/components/workbench/HarnessPage.tsx
@@ -79,6 +79,7 @@ import type {
   HarnessLifecycleState,
   HarnessRowAlert,
 } from './harnessLifecycle';
+import { loadHarnessAgentCatalog } from './harnessAgents';
 import { Badge } from '../ui/badge';
 import { Button } from '../ui/button';
 import { Switch } from '../ui/switch';
@@ -188,6 +189,7 @@ export const HarnessPage: React.FC = () => {
   const [selectedRun, setSelectedRun] = useState<HarnessRun | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [agentsByName, setAgentsByName] = useState<Record<string, VibeAgentBrief>>({});
   // Per-id pending state so the row's toggle / delete buttons can show a
   // spinner without disabling siblings.
   const [pendingMutation, setPendingMutation] = useState<Record<string, boolean>>({});
@@ -209,6 +211,7 @@ export const HarnessPage: React.FC = () => {
   const [runTypeFilter, setRunTypeFilter] = useState<RunTypeFilter>('default');
   const [debouncedSearch, setDebouncedSearch] = useState('');
   const refreshSeq = useRef(0);
+  const agentRefreshSeq = useRef(0);
   // URL scope from the background-work banner (spec req 4): ?tab / ?session /
   // ?run deep-link into a session-scoped tab (removable "只看本会话" chip) or a
   // specific run. One-way URL -> state, keyed per-param so a user's tab click
@@ -385,32 +388,32 @@ export const HarnessPage: React.FC = () => {
     refresh();
   }, [refresh]);
 
+  const refreshAgents = useCallback(async () => {
+    const seq = agentRefreshSeq.current + 1;
+    agentRefreshSeq.current = seq;
+    try {
+      const agents = await loadHarnessAgentCatalog(api);
+      if (agentRefreshSeq.current === seq) setAgentsByName(agents);
+    } catch {
+      // Harness data remains usable when the optional Agent metadata lookup fails.
+    }
+  }, [api]);
+
+  useEffect(() => {
+    void refreshAgents();
+    return () => {
+      agentRefreshSeq.current += 1;
+    };
+  }, [refreshAgents]);
+
   useEffect(() => {
     return api.connectWorkbenchEvents({
       onRunsUpdated: () => {
         void refresh();
+        void refreshAgents();
       },
     });
-  }, [api, refresh]);
-
-  // Resolve agent_name → backend/model/effort for the detail panels: the
-  // task/watch payload stores only the name. Fetched once on mount.
-  const [agentsByName, setAgentsByName] = useState<Record<string, VibeAgentBrief>>({});
-  useEffect(() => {
-    let cancelled = false;
-    api
-      .listVibeAgents({ includeDisabled: true, includeArchived: true })
-      .then((res) => {
-        if (cancelled) return;
-        const map: Record<string, VibeAgentBrief> = {};
-        for (const a of res.agents) map[a.name] = a;
-        setAgentsByName(map);
-      })
-      .catch(() => {});
-    return () => {
-      cancelled = true;
-    };
-  }, [api]);
+  }, [api, refresh, refreshAgents]);
 
   const markPending = useCallback((id: string, value: boolean) => {
     setPendingMutation((prev) => {

--- a/ui/src/components/workbench/ProjectSettingsDialog.tsx
+++ b/ui/src/components/workbench/ProjectSettingsDialog.tsx
@@ -60,6 +60,7 @@ export const ProjectSettingsDialog: React.FC<{
     // absent field keeps its stored value.
     const merged: ProjectDefaultAgent = {
       agent_backend: null,
+      agent_id: 'agent_id' in patch ? patch.agent_id ?? null : current?.agent_id ?? null,
       agent_name: 'agent_name' in patch ? patch.agent_name ?? null : current?.agent_name ?? null,
       agent_variant: 'agent_variant' in patch ? patch.agent_variant ?? null : current?.agent_variant ?? null,
       model: 'model' in patch ? patch.model ?? null : current?.model ?? null,
@@ -67,7 +68,7 @@ export const ProjectSettingsDialog: React.FC<{
         'reasoning_effort' in patch ? patch.reasoning_effort ?? null : current?.reasoning_effort ?? null,
     };
     try {
-      await setProjectDefaultAgent(project.id, merged);
+      await setProjectDefaultAgent(project.id, merged, current?.agent_id ?? null);
     } catch {
       // apiFetch already surfaced the error toast; keep the dialog open.
     }

--- a/ui/src/components/workbench/ProjectSettingsDialog.tsx
+++ b/ui/src/components/workbench/ProjectSettingsDialog.tsx
@@ -37,7 +37,7 @@ export const ProjectSettingsDialog: React.FC<{
     if (!open) return;
     let cancelled = false;
     api
-      .listVibeAgents({ includeDisabled: false })
+      .listVibeAgents({ includeDisabled: false, includeArchived: true })
       .then((res) => {
         if (!cancelled) setAgents(res.agents);
       })

--- a/ui/src/components/workbench/harnessAgents.ts
+++ b/ui/src/components/workbench/harnessAgents.ts
@@ -1,0 +1,12 @@
+import type { ApiContextType, VibeAgentBrief } from '../../context/ApiContext';
+
+export async function loadHarnessAgentCatalog(
+  api: Pick<ApiContextType, 'listVibeAgents'>,
+): Promise<Record<string, VibeAgentBrief>> {
+  const result = await api.listVibeAgents({
+    includeDisabled: true,
+    includeArchived: true,
+    cache: false,
+  });
+  return Object.fromEntries(result.agents.map((agent) => [agent.name, agent]));
+}

--- a/ui/src/context/ApiContext.tsx
+++ b/ui/src/context/ApiContext.tsx
@@ -628,12 +628,12 @@ export type ApiContextType = {
   setSessionDraft: (sessionId: string, text: string) => Promise<{ ok: boolean }>;
   listInbox: (params?: { platform?: string; unreadOnly?: boolean; limit?: number; before?: string; onlySession?: string; cache?: boolean; handleError?: boolean }) => Promise<InboxFeedResult>;
   connectWorkbenchEvents: (handlers: WorkbenchEventHandlers) => () => void;
-  listVibeAgents: (params?: { backend?: string; includeDisabled?: boolean }) => Promise<{ ok: boolean; agents: VibeAgentBrief[]; default_agent_name: string | null }>;
+  listVibeAgents: (params?: { backend?: string; includeDisabled?: boolean; includeArchived?: boolean }) => Promise<{ ok: boolean; agents: VibeAgentBrief[]; default_agent_name: string | null }>;
   getVibeAgent: (name: string) => Promise<{ ok: boolean; agent: VibeAgentFull; default_agent_name: string | null }>;
   createVibeAgent: (payload: VibeAgentCreatePayload) => Promise<{ ok: boolean; agent: VibeAgentFull }>;
   updateVibeAgent: (name: string, payload: VibeAgentUpdatePayload) => Promise<{ ok: boolean; agent: VibeAgentFull }>;
   setDefaultVibeAgent: (name: string) => Promise<{ ok: boolean; default_agent_name: string; agent: VibeAgentBrief }>;
-  removeVibeAgent: (name: string) => Promise<{ ok: boolean; code?: string; message?: string; references?: Record<string, number>; removed_agent?: string }>;
+  removeVibeAgent: (name: string) => Promise<{ ok: boolean; code?: string; message?: string; references?: Record<string, number>; removed_agent?: string; archived_agent?: VibeAgentBrief; default_agent_name?: string | null }>;
   listVaultSecrets: () => Promise<{ ok: boolean; secrets: VaultSecret[] }>;
   getVaultVmk: () => Promise<VaultVmkResult>;
   getVaultPubkey: () => Promise<{ ok: boolean; public_key: string; fingerprint: string }>;
@@ -827,11 +827,14 @@ export type WorkbenchSessionUpdate = {
 export type VibeAgentBrief = {
   id: string;
   name: string;
+  display_name: string;
   description: string | null;
   backend: string;
   model: string | null;
   reasoning_effort: string | null;
   enabled: boolean;
+  archived: boolean;
+  archived_at: string | null;
   source: string;
   updated_at: string;
 };
@@ -940,6 +943,7 @@ export type SkillsCheckResult = {
 };
 
 export type VibeAgentUpdatePayload = {
+  name?: string;
   description?: string | null;
   model?: string | null;
   reasoning_effort?: string | null;
@@ -2904,6 +2908,7 @@ export const ApiProvider: React.FC<{ children: React.ReactNode }> = ({ children 
       const search = new URLSearchParams();
       if (params?.backend) search.set('backend', params.backend);
       if (params?.includeDisabled) search.set('include_disabled', '1');
+      if (params?.includeArchived) search.set('include_archived', '1');
       const qs = search.toString();
       return getCachedJson(qs ? `/api/agents?${qs}` : '/api/agents', 5_000);
     },

--- a/ui/src/context/ApiContext.tsx
+++ b/ui/src/context/ApiContext.tsx
@@ -552,6 +552,8 @@ export type ApiContextType = {
       display_name?: string;
       folder_path?: string;
       agent_backend?: string | null;
+      agent_id?: string | null;
+      expected_agent_id?: string | null;
       agent_name?: string | null;
       agent_variant?: string | null;
       model?: string | null;
@@ -734,6 +736,7 @@ export type ApiContextType = {
 // absent field) means "no project default" → fall back to the global default.
 export type ProjectDefaultAgent = {
   agent_backend: string | null;
+  agent_id: string | null;
   agent_name: string | null;
   agent_variant: string | null;
   model: string | null;

--- a/ui/src/context/ApiContext.tsx
+++ b/ui/src/context/ApiContext.tsx
@@ -628,7 +628,12 @@ export type ApiContextType = {
   setSessionDraft: (sessionId: string, text: string) => Promise<{ ok: boolean }>;
   listInbox: (params?: { platform?: string; unreadOnly?: boolean; limit?: number; before?: string; onlySession?: string; cache?: boolean; handleError?: boolean }) => Promise<InboxFeedResult>;
   connectWorkbenchEvents: (handlers: WorkbenchEventHandlers) => () => void;
-  listVibeAgents: (params?: { backend?: string; includeDisabled?: boolean; includeArchived?: boolean }) => Promise<{ ok: boolean; agents: VibeAgentBrief[]; default_agent_name: string | null }>;
+  listVibeAgents: (params?: {
+    backend?: string;
+    includeDisabled?: boolean;
+    includeArchived?: boolean;
+    cache?: boolean;
+  }) => Promise<{ ok: boolean; agents: VibeAgentBrief[]; default_agent_name: string | null }>;
   getVibeAgent: (name: string) => Promise<{ ok: boolean; agent: VibeAgentFull; default_agent_name: string | null }>;
   createVibeAgent: (payload: VibeAgentCreatePayload) => Promise<{ ok: boolean; agent: VibeAgentFull }>;
   updateVibeAgent: (name: string, payload: VibeAgentUpdatePayload) => Promise<{ ok: boolean; agent: VibeAgentFull }>;
@@ -2910,7 +2915,8 @@ export const ApiProvider: React.FC<{ children: React.ReactNode }> = ({ children 
       if (params?.includeDisabled) search.set('include_disabled', '1');
       if (params?.includeArchived) search.set('include_archived', '1');
       const qs = search.toString();
-      return getCachedJson(qs ? `/api/agents?${qs}` : '/api/agents', 5_000);
+      const path = qs ? `/api/agents?${qs}` : '/api/agents';
+      return params?.cache === false ? getJson(path) : getCachedJson(path, 5_000);
     },
     getVibeAgent: (name) => getCachedJson(`/api/agents/${encodeURIComponent(name)}`, 5_000),
     createVibeAgent: (payload) => postJson('/api/agents', payload),

--- a/ui/src/context/WorkbenchProjectsContext.tsx
+++ b/ui/src/context/WorkbenchProjectsContext.tsx
@@ -62,7 +62,11 @@ export interface WorkbenchProjectsTree {
    *  shared cache so the sidebar + Projects page reflect it. Pass an all-null
    *  route to clear the default back to the global default. Throws on failure
    *  (the apiFetch layer already surfaced a toast) so the dialog can react. */
-  setProjectDefaultAgent: (projectId: string, route: ProjectDefaultAgent) => Promise<void>;
+  setProjectDefaultAgent: (
+    projectId: string,
+    route: ProjectDefaultAgent,
+    expectedAgentId: string | null,
+  ) => Promise<void>;
   archiveProject: (projectId: string) => Promise<void>;
   /** Throws on failure so the row's inline editor can fall back; patches title on success. */
   renameSession: (projectId: string, sessionId: string, title: string) => Promise<void>;
@@ -583,11 +587,13 @@ export const WorkbenchProjectsProvider: React.FC<{ children: ReactNode }> = ({ c
   );
 
   const setProjectDefaultAgent = useCallback(
-    async (projectId: string, route: ProjectDefaultAgent) => {
+    async (projectId: string, route: ProjectDefaultAgent, expectedAgentId: string | null) => {
       // Always send the full 5-field route: a complete set is coherent whether
       // the user picked an agent (all set) or cleared it (all null → default
       // dropped). Let failures propagate — apiFetch already toasted.
       const updated = await api.updateProject(projectId, {
+        agent_id: route.agent_id,
+        expected_agent_id: expectedAgentId,
         agent_name: route.agent_name,
         agent_variant: route.agent_variant,
         model: route.model,

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -2588,7 +2588,6 @@
     "importFailed": "Import failed: {{error}}",
     "importNoneFound": "No {{backend}} agents found on disk to import.",
     "renameSuccess": "Agent renamed",
-    "renameKeptOld": "Agent renamed (old one kept due to references)",
     "searchPlaceholder": "Search agents…",
     "backendFilter": "Backend",
     "backendAll": "All",
@@ -2597,8 +2596,7 @@
     "empty": "No agents yet. Create one to start a conversation.",
     "selectPrompt": "Select an agent to view its configuration.",
     "makeDefault": "Make default",
-    "deleteConfirm": "Delete agent \"{{name}}\"? This cannot be undone.",
-    "deleteInUse": "Agent \"{{name}}\" is currently in use by one or more channels and cannot be deleted.",
+    "deleteConfirm": "Archive agent \"{{name}}\"? It will disappear from Agents, while existing sessions and automations keep their saved configuration.",
     "detail": {
       "enabled": "Enabled",
       "enabledHint": "Disabling keeps the agent in the registry but excludes it from new sessions; running sessions are unaffected.",

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -1181,6 +1181,7 @@
     "invalid_share_id": "A custom link may use only 3–64 letters, numbers, dash, or underscore, starting and ending with a letter or number.",
     "missing_share_id": "Enter a custom link first.",
     "not_public": "Make the Show Page public first to change its link.",
+    "session_agent_unavailable": "The source session's Agent is no longer available. Choose an enabled Agent to fork this session.",
     "session_archived": "This session is archived, so its Show Page can't be changed.",
     "reserved_session": "Avibe owns this session — it only receives workspace notifications.",
     "invalid_icon_type": "The icon must be an SVG, PNG, ICO, JPEG, or WebP image.",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -1181,6 +1181,7 @@
     "invalid_share_id": "自定义链接只能用 3–64 位字母、数字、短横线或下划线，且首尾为字母或数字。",
     "missing_share_id": "请先输入自定义链接。",
     "not_public": "请先把展示页面设为公开，再修改链接。",
+    "session_agent_unavailable": "源会话的 Agent 已不可用。请选择一个已启用的 Agent 来复刻此会话。",
     "session_archived": "该会话已归档，无法修改它的展示页面。",
     "reserved_session": "该会话由 Avibe 管理，只接收工作区通知。",
     "invalid_icon_type": "图标必须是 SVG、PNG、ICO、JPEG 或 WebP 图片。",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -2588,7 +2588,6 @@
     "importFailed": "导入失败:{{error}}",
     "importNoneFound": "磁盘上没有找到可导入的 {{backend}} Agent。",
     "renameSuccess": "Agent 已重命名",
-    "renameKeptOld": "Agent 已重命名(旧名因被引用而保留)",
     "searchPlaceholder": "搜索 Agent…",
     "backendFilter": "Backend",
     "backendAll": "全部",
@@ -2597,8 +2596,7 @@
     "noSearchMatch": "没有匹配的 Agent。",
     "selectPrompt": "选择一个 Agent 查看配置。",
     "makeDefault": "设为默认",
-    "deleteConfirm": "确认删除 Agent \"{{name}}\"？此操作不可撤销。",
-    "deleteInUse": "Agent \"{{name}}\" 正被一个或多个频道使用,无法删除。",
+    "deleteConfirm": "确认归档 Agent \"{{name}}\"？它将从 Agent 列表中消失，但已有会话和自动化仍会使用已保存的配置。",
     "detail": {
       "enabled": "已启用",
       "enabledHint": "关掉后此 Agent 不会被新会话选用,已运行的会话不受影响",

--- a/ui/src/lib/agentGraph.test.ts
+++ b/ui/src/lib/agentGraph.test.ts
@@ -89,6 +89,11 @@ describe('nodeDisplayTitle', () => {
   it('prefers the title, else agent + session suffix', () => {
     expect(nodeDisplayTitle(node('ses_abc', { title: 'Root' }))).toBe('Root');
     expect(nodeDisplayTitle(node('ses_123456', { title: null, agent_name: 'pm' }))).toBe('pm · 123456');
+    expect(nodeDisplayTitle(node('ses_123456', {
+      title: null,
+      agent_name: '_pm-8dd7',
+      agent_display_name: 'pm',
+    }))).toBe('pm · 123456');
   });
 });
 

--- a/ui/src/lib/agentGraph.ts
+++ b/ui/src/lib/agentGraph.ts
@@ -36,6 +36,7 @@ export type AgentGraphNode = {
   session_id: string;
   title: string | null;
   agent_name: string | null;
+  agent_display_name?: string | null;
   agent_backend: string | null;
   model: string | null;
   reasoning_effort: string | null;

--- a/ui/src/lib/agentGraph.ts
+++ b/ui/src/lib/agentGraph.ts
@@ -241,11 +241,14 @@ export function runElapsedSeconds(
   return Math.max(0, (end - start) / 1000);
 }
 
-// Fallback label when a node has no title: agent name + short session suffix.
-export function nodeDisplayTitle(node: Pick<AgentGraphNode, 'title' | 'agent_name' | 'session_id'>): string {
+// Fallback label when a node has no title: display name + short session suffix.
+export function nodeDisplayTitle(
+  node: Pick<AgentGraphNode, 'title' | 'agent_name' | 'agent_display_name' | 'session_id'>,
+): string {
   if (node.title && node.title.trim()) return node.title;
   const suffix = node.session_id.length > 6 ? node.session_id.slice(-6) : node.session_id;
-  return node.agent_name ? `${node.agent_name} · ${suffix}` : suffix;
+  const agentLabel = node.agent_display_name?.trim() || node.agent_name;
+  return agentLabel ? `${agentLabel} · ${suffix}` : suffix;
 }
 
 // Desktop run-graph fill height (design.pen KfgtJ — canvas fills its container):

--- a/ui/src/lib/useNewSession.test.ts
+++ b/ui/src/lib/useNewSession.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+
+import type { VibeAgentBrief, WorkbenchProject } from '../context/ApiContext';
+import { isProjectDefaultAgentAvailable } from './useNewSession';
+
+const project = (agentName: string): WorkbenchProject =>
+  ({
+    default_agent: { agent_name: agentName },
+  }) as WorkbenchProject;
+
+const agent = (over: Partial<VibeAgentBrief>): VibeAgentBrief =>
+  ({
+    id: 'agent-1',
+    name: 'pm',
+    display_name: 'pm',
+    description: null,
+    backend: 'claude',
+    model: null,
+    reasoning_effort: null,
+    enabled: true,
+    archived: false,
+    archived_at: null,
+    source: 'user',
+    updated_at: '2026-08-01T00:00:00Z',
+    ...over,
+  }) as VibeAgentBrief;
+
+describe('isProjectDefaultAgentAvailable', () => {
+  it('accepts an enabled live project default', () => {
+    expect(isProjectDefaultAgentAvailable(project('pm'), [agent({})])).toBe(true);
+  });
+
+  it('rejects an archived internal project default that is absent from the live catalog', () => {
+    expect(isProjectDefaultAgentAvailable(project('_pm-8dd7'), [agent({ name: 'codex' })])).toBe(false);
+  });
+
+  it('rejects disabled or archived catalog entries', () => {
+    expect(isProjectDefaultAgentAvailable(project('pm'), [agent({ enabled: false })])).toBe(false);
+    expect(isProjectDefaultAgentAvailable(project('pm'), [agent({ archived: true })])).toBe(false);
+  });
+});

--- a/ui/src/lib/useNewSession.test.ts
+++ b/ui/src/lib/useNewSession.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import type { VibeAgentBrief, WorkbenchProject } from '../context/ApiContext';
-import { isProjectDefaultAgentAvailable } from './useNewSession';
+import { isProjectDefaultAgentAvailable, projectDefaultAgentRoute } from './useNewSession';
 
 const project = (agentName: string): WorkbenchProject =>
   ({
@@ -46,5 +46,27 @@ describe('isProjectDefaultAgentAvailable', () => {
   it('rejects disabled or archived catalog entries', () => {
     expect(isProjectDefaultAgentAvailable(project('pm'), [agent({ enabled: false })])).toBe(false);
     expect(isProjectDefaultAgentAvailable(project('pm'), [agent({ archived: true })])).toBe(false);
+  });
+});
+
+describe('projectDefaultAgentRoute', () => {
+  it('pins the project Agent by stable ID for session creation', () => {
+    const target = project('pm');
+    target.default_agent = {
+      agent_backend: 'claude',
+      agent_id: 'agent-original',
+      agent_name: 'pm',
+      agent_variant: 'claude',
+      model: 'claude-opus-5',
+      reasoning_effort: 'high',
+    };
+
+    expect(projectDefaultAgentRoute(target, [agent({ id: 'agent-replacement' })])).toEqual({
+      agent_name: 'pm',
+      agent_id: 'agent-original',
+      agent_variant: 'claude',
+      model: 'claude-opus-5',
+      reasoning_effort: 'high',
+    });
   });
 });

--- a/ui/src/lib/useNewSession.test.ts
+++ b/ui/src/lib/useNewSession.test.ts
@@ -30,6 +30,15 @@ describe('isProjectDefaultAgentAvailable', () => {
     expect(isProjectDefaultAgentAvailable(project('pm'), [agent({})])).toBe(true);
   });
 
+  it('accepts a legacy normalized-equivalent project default', () => {
+    expect(
+      isProjectDefaultAgentAvailable(
+        project('PROJECT-MANAGER'),
+        [agent({ name: 'Project Manager' })],
+      ),
+    ).toBe(true);
+  });
+
   it('rejects an archived internal project default that is absent from the live catalog', () => {
     expect(isProjectDefaultAgentAvailable(project('_pm-8dd7'), [agent({ name: 'codex' })])).toBe(false);
   });

--- a/ui/src/lib/useNewSession.ts
+++ b/ui/src/lib/useNewSession.ts
@@ -48,6 +48,15 @@ export interface NewSessionState {
   upsertSelectProject: (project: WorkbenchProject) => void;
 }
 
+export function isProjectDefaultAgentAvailable(
+  project: WorkbenchProject | null,
+  agents: VibeAgentBrief[],
+): boolean {
+  const name = project?.default_agent?.agent_name;
+  if (!name) return false;
+  return agents.some((agent) => agent.name === name && agent.enabled && !agent.archived);
+}
+
 const sortByRecent = (list: WorkbenchProject[]) =>
   list
     .slice()
@@ -121,8 +130,12 @@ export function useNewSession({ active = true, loadErrorText, createFailedText }
     setUserPick((prev) => (Object.keys(prev).length ? {} : prev));
   }
 
-  // The selected project's default Agent as a route (empty when it has none).
+  // The selected project's default Agent as a route. An archived binding stays
+  // on the project for durable history, but the enabled catalog intentionally
+  // excludes it, so a new chat falls back to the live global default.
+  const projectDefaultAvailable = isProjectDefaultAgentAvailable(target, agents);
   const projectDefaultRoute = useMemo<AgentRouteSelection>(() => {
+    if (!projectDefaultAvailable) return {};
     const def = target?.default_agent;
     return def
       ? {
@@ -132,7 +145,7 @@ export function useNewSession({ active = true, loadErrorText, createFailedText }
           reasoning_effort: def.reasoning_effort,
         }
       : {};
-  }, [target?.default_agent]);
+  }, [projectDefaultAvailable, target?.default_agent]);
 
   // The GLOBAL default Agent resolved to a concrete route, looked up from the
   // agents list by name. The picker needs a concrete route to render the model
@@ -190,7 +203,9 @@ export function useNewSession({ active = true, loadErrorText, createFailedText }
 
   // Label for the picker's "Default" option: the project default's agent when
   // set, otherwise the global default agent.
-  const effectiveDefaultAgentName = target?.default_agent?.agent_name ?? defaultAgentName;
+  const effectiveDefaultAgentName = projectDefaultAvailable
+    ? target?.default_agent?.agent_name ?? defaultAgentName
+    : defaultAgentName;
 
   const send = useCallback(
     async (text: string): Promise<{ sessionId: string; initialMessage: string } | null> => {

--- a/ui/src/lib/useNewSession.ts
+++ b/ui/src/lib/useNewSession.ts
@@ -63,6 +63,23 @@ export function isProjectDefaultAgentAvailable(
   );
 }
 
+export function projectDefaultAgentRoute(
+  project: WorkbenchProject | null,
+  agents: VibeAgentBrief[],
+): AgentRouteSelection {
+  if (!isProjectDefaultAgentAvailable(project, agents)) return {};
+  const def = project?.default_agent;
+  return def
+    ? {
+        agent_name: def.agent_name,
+        agent_id: def.agent_id,
+        agent_variant: def.agent_variant,
+        model: def.model,
+        reasoning_effort: def.reasoning_effort,
+      }
+    : {};
+}
+
 const sortByRecent = (list: WorkbenchProject[]) =>
   list
     .slice()
@@ -140,18 +157,10 @@ export function useNewSession({ active = true, loadErrorText, createFailedText }
   // on the project for durable history, but the enabled catalog intentionally
   // excludes it, so a new chat falls back to the live global default.
   const projectDefaultAvailable = isProjectDefaultAgentAvailable(target, agents);
-  const projectDefaultRoute = useMemo<AgentRouteSelection>(() => {
-    if (!projectDefaultAvailable) return {};
-    const def = target?.default_agent;
-    return def
-      ? {
-          agent_name: def.agent_name,
-          agent_variant: def.agent_variant,
-          model: def.model,
-          reasoning_effort: def.reasoning_effort,
-        }
-      : {};
-  }, [projectDefaultAvailable, target?.default_agent]);
+  const projectDefaultRoute = useMemo<AgentRouteSelection>(
+    () => projectDefaultAgentRoute(target, agents),
+    [target, agents],
+  );
 
   // The GLOBAL default Agent resolved to a concrete route, looked up from the
   // agents list by name. The picker needs a concrete route to render the model

--- a/ui/src/lib/useNewSession.ts
+++ b/ui/src/lib/useNewSession.ts
@@ -48,13 +48,19 @@ export interface NewSessionState {
   upsertSelectProject: (project: WorkbenchProject) => void;
 }
 
+const normalizeAgentName = (name: string) =>
+  name.trim().toLowerCase().replace(/[^a-z0-9_-]+/g, '-').replace(/^[-_]+|[-_]+$/g, '');
+
 export function isProjectDefaultAgentAvailable(
   project: WorkbenchProject | null,
   agents: VibeAgentBrief[],
 ): boolean {
   const name = project?.default_agent?.agent_name;
   if (!name) return false;
-  return agents.some((agent) => agent.name === name && agent.enabled && !agent.archived);
+  const normalizedName = normalizeAgentName(name);
+  return agents.some(
+    (agent) => normalizeAgentName(agent.name) === normalizedName && agent.enabled && !agent.archived,
+  );
 }
 
 const sortByRecent = (list: WorkbenchProject[]) =>

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -68,6 +68,7 @@ from modules.agents.catalog import (
 )
 from modules.agents.subagent_router import list_codex_subagents
 from core.vibe_agents import (
+    AgentArchivedEditError,
     AgentArchiveError,
     AgentNameValidationError,
     VibeAgentStore,
@@ -1449,6 +1450,8 @@ def update_vibe_agent(name: str, payload: dict) -> dict:
             agent = store.rename(name, new_name) if renaming else store.update(name, **kwargs)
         except AgentNameValidationError as exc:
             return _agent_name_validation_error(exc)
+        except AgentArchivedEditError as exc:
+            return _agent_archived_edit_error(exc)
         return {"ok": True, "agent": _vibe_agent_payload(agent)}
     finally:
         store.close()
@@ -1460,6 +1463,20 @@ def _agent_name_validation_error(exc: AgentNameValidationError) -> dict:
     except Exception:
         lang = "en"
     key = f"error.agentNameValidation.{exc.code}"
+    return {
+        "ok": False,
+        "code": exc.code,
+        "message": backend_t(f"{key}.message", lang, agent=exc.agent_name),
+        "hint": backend_t(f"{key}.hint", lang, agent=exc.agent_name),
+    }
+
+
+def _agent_archived_edit_error(exc: AgentArchivedEditError) -> dict:
+    try:
+        lang = V2Config.load().language
+    except Exception:
+        lang = "en"
+    key = f"error.agentLifecycle.{exc.code}"
     return {
         "ok": False,
         "code": exc.code,

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -69,6 +69,7 @@ from modules.agents.catalog import (
 from modules.agents.subagent_router import list_codex_subagents
 from core.vibe_agents import (
     AgentArchiveError,
+    AgentNameValidationError,
     VibeAgentStore,
     iter_global_agent_files,
     parse_agent_file,
@@ -1380,16 +1381,19 @@ def create_vibe_agent(payload: dict) -> dict:
         raise ValueError("Agent metadata must be an object")
     store = VibeAgentStore()
     try:
-        agent = store.create(
-            name=str(payload.get("name") or "").strip(),
-            backend=validate_agent_backend(str(payload.get("backend") or "")),
-            description=payload.get("description"),
-            model=payload.get("model"),
-            reasoning_effort=payload.get("reasoning_effort") or payload.get("effort"),
-            system_prompt=payload.get("system_prompt"),
-            metadata=metadata,
-            enabled=_parse_agent_enabled_field(payload, default=True),
-        )
+        try:
+            agent = store.create(
+                name=str(payload.get("name") or "").strip(),
+                backend=validate_agent_backend(str(payload.get("backend") or "")),
+                description=payload.get("description"),
+                model=payload.get("model"),
+                reasoning_effort=payload.get("reasoning_effort") or payload.get("effort"),
+                system_prompt=payload.get("system_prompt"),
+                metadata=metadata,
+                enabled=_parse_agent_enabled_field(payload, default=True),
+            )
+        except AgentNameValidationError as exc:
+            return _agent_name_validation_error(exc)
         return {"ok": True, "agent": _vibe_agent_payload(agent)}
     finally:
         store.close()
@@ -1441,10 +1445,27 @@ def update_vibe_agent(name: str, payload: dict) -> dict:
 
     store = VibeAgentStore()
     try:
-        agent = store.rename(name, new_name) if renaming else store.update(name, **kwargs)
+        try:
+            agent = store.rename(name, new_name) if renaming else store.update(name, **kwargs)
+        except AgentNameValidationError as exc:
+            return _agent_name_validation_error(exc)
         return {"ok": True, "agent": _vibe_agent_payload(agent)}
     finally:
         store.close()
+
+
+def _agent_name_validation_error(exc: AgentNameValidationError) -> dict:
+    try:
+        lang = V2Config.load().language
+    except Exception:
+        lang = "en"
+    key = f"error.agentNameValidation.{exc.code}"
+    return {
+        "ok": False,
+        "code": exc.code,
+        "message": backend_t(f"{key}.message", lang, agent=exc.agent_name),
+        "hint": backend_t(f"{key}.hint", lang, agent=exc.agent_name),
+    }
 
 
 def remove_vibe_agent(name: str) -> dict:

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -71,6 +71,7 @@ from core.vibe_agents import (
     AgentArchivedEditError,
     AgentArchiveError,
     AgentNameValidationError,
+    AgentReferenceRewriteError,
     VibeAgentStore,
     iter_global_agent_files,
     parse_agent_file,
@@ -1452,6 +1453,8 @@ def update_vibe_agent(name: str, payload: dict) -> dict:
             return _agent_name_validation_error(exc)
         except AgentArchivedEditError as exc:
             return _agent_archived_edit_error(exc)
+        except AgentReferenceRewriteError as exc:
+            return _agent_reference_rewrite_error(exc)
         return {"ok": True, "agent": _vibe_agent_payload(agent)}
     finally:
         store.close()
@@ -1485,6 +1488,20 @@ def _agent_archived_edit_error(exc: AgentArchivedEditError) -> dict:
     }
 
 
+def _agent_reference_rewrite_error(exc: AgentReferenceRewriteError) -> dict:
+    try:
+        lang = V2Config.load().language
+    except Exception:
+        lang = "en"
+    key = f"error.agentLifecycle.{exc.code}"
+    return {
+        "ok": False,
+        "code": exc.code,
+        "message": backend_t(f"{key}.message", lang),
+        "hint": backend_t(f"{key}.hint", lang),
+    }
+
+
 def remove_vibe_agent(name: str) -> dict:
     store = VibeAgentStore()
     try:
@@ -1504,6 +1521,8 @@ def remove_vibe_agent(name: str) -> dict:
                     agent=exc.agent_name,
                 ),
             }
+        except AgentReferenceRewriteError as exc:
+            return _agent_reference_rewrite_error(exc)
         if archived is None:
             return {"ok": False, "code": "agent_not_found", "message": f"agent '{name}' not found"}
         return {

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -68,6 +68,7 @@ from modules.agents.catalog import (
 )
 from modules.agents.subagent_router import list_codex_subagents
 from core.vibe_agents import (
+    AgentArchiveError,
     VibeAgentStore,
     iter_global_agent_files,
     parse_agent_file,
@@ -1308,11 +1309,14 @@ def _vibe_agent_payload(agent, *, brief: bool = False) -> dict:
         return {
             "id": payload["id"],
             "name": payload["name"],
+            "display_name": payload["display_name"],
             "description": payload["description"],
             "backend": payload["backend"],
             "model": payload["model"],
             "reasoning_effort": payload["reasoning_effort"],
             "enabled": payload["enabled"],
+            "archived": payload["archived"],
+            "archived_at": payload["archived_at"],
             "source": payload["source"],
             "updated_at": payload["updated_at"],
         }
@@ -1328,12 +1332,20 @@ def _parse_agent_enabled_field(payload: dict, *, default: Optional[bool] = None)
     raise ValueError("Agent enabled must be a JSON boolean")
 
 
-def get_vibe_agents(*, backend: Optional[str] = None, include_disabled: bool = False) -> dict:
+def get_vibe_agents(
+    *,
+    backend: Optional[str] = None,
+    include_disabled: bool = False,
+    include_archived: bool = False,
+) -> dict:
     _ensure_builtin_default_agents()
     store = VibeAgentStore()
     try:
         normalized_backend = validate_agent_backend(backend) if backend else None
-        agents = store.list_agents(include_disabled=include_disabled)
+        agents = store.list_agents(
+            include_disabled=include_disabled,
+            include_archived=include_archived,
+        )
         if normalized_backend:
             agents = [agent for agent in agents if agent.backend == normalized_backend]
         default_agent = store.get_default_agent()
@@ -1386,8 +1398,6 @@ def create_vibe_agent(payload: dict) -> dict:
 def update_vibe_agent(name: str, payload: dict) -> dict:
     if not isinstance(payload, dict):
         raise ValueError("Agent payload must be an object")
-    if "name" in payload and str(payload.get("name") or "").strip() and str(payload.get("name")).strip() != name:
-        raise ValueError("Agent name is immutable")
     if "backend" in payload:
         raise ValueError("Agent backend is immutable")
 
@@ -1422,12 +1432,16 @@ def update_vibe_agent(name: str, payload: dict) -> dict:
     unknown = sorted(set(payload) - allowed_fields - {"name"})
     if unknown:
         raise ValueError(f"Unsupported Agent fields: {', '.join(unknown)}")
-    if not kwargs:
+    new_name = str(payload.get("name") or "").strip() if "name" in payload else ""
+    renaming = bool(new_name and new_name != name)
+    if renaming and kwargs:
+        raise ValueError("Agent rename cannot be combined with other field updates")
+    if not kwargs and not renaming:
         raise ValueError("No editable Agent fields were provided")
 
     store = VibeAgentStore()
     try:
-        agent = store.update(name, **kwargs)
+        agent = store.rename(name, new_name) if renaming else store.update(name, **kwargs)
         return {"ok": True, "agent": _vibe_agent_payload(agent)}
     finally:
         store.close()
@@ -1436,25 +1450,23 @@ def update_vibe_agent(name: str, payload: dict) -> dict:
 def remove_vibe_agent(name: str) -> dict:
     store = VibeAgentStore()
     try:
-        counts = store.reference_counts(name)
-        if any(counts.values()):
-            return {
-                "ok": False,
-                "code": "agent_in_use",
-                "message": f"agent '{name}' is still referenced",
-                "references": counts,
-            }
         try:
-            removed = store.remove(name)
-        except ValueError as exc:
+            archived = store.archive(name)
+        except AgentArchiveError as exc:
             return {
                 "ok": False,
-                "code": "agent_builtin",
+                "code": exc.code,
                 "message": str(exc),
             }
-        if not removed:
+        if archived is None:
             return {"ok": False, "code": "agent_not_found", "message": f"agent '{name}' not found"}
-        return {"ok": True, "removed_agent": name}
+        return {
+            "ok": True,
+            "removed_agent": archived.original_name,
+            "archived_agent": _vibe_agent_payload(archived.agent, brief=True),
+            "references": archived.references,
+            "default_agent_name": archived.default_agent_name,
+        }
     finally:
         store.close()
 
@@ -4116,7 +4128,7 @@ def get_settings(platform: Optional[str] = None) -> dict:
     if target_platform == "discord":
         _migrate_discord_guild_scope_from_config(store)
     payload = _settings_to_payload(store, platform=target_platform)
-    payload["agent_catalog"] = get_vibe_agents()
+    payload["agent_catalog"] = get_vibe_agents(include_archived=True)
     return payload
 
 

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -1453,10 +1453,18 @@ def remove_vibe_agent(name: str) -> dict:
         try:
             archived = store.archive(name)
         except AgentArchiveError as exc:
+            try:
+                lang = V2Config.load().language
+            except Exception:
+                lang = "en"
             return {
                 "ok": False,
                 "code": exc.code,
-                "message": str(exc),
+                "message": backend_t(
+                    f"error.agentArchive.{exc.code}.message",
+                    lang,
+                    agent=exc.agent_name,
+                ),
             }
         if archived is None:
             return {"ok": False, "code": "agent_not_found", "message": f"agent '{name}' not found"}

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -34,6 +34,7 @@ from config.v2_settings import (
     GuildSettings,
     UserSettings,
     RoutingSettings,
+    _UNSET_AGENT_BINDING,
     normalize_show_message_types,
     _parse_routing,
     _routing_to_dict,
@@ -4249,6 +4250,9 @@ def save_settings(payload: dict) -> dict:
                 routing=_parse_routing(_normalize_backend_routing_payload(channel_payload.get("routing") or {})),
                 require_mention=channel_payload.get("require_mention"),
                 require_bind=channel_payload.get("require_bind"),
+                _agent_name_at_load=channel_payload.get(
+                    "expected_agent_name", _UNSET_AGENT_BINDING
+                ),
             )
         store.set_channels_for_platform(platform, channels)
     if "guilds" in payload or "guild_allowlist" in payload:
@@ -4294,6 +4298,9 @@ def save_thread_settings(payload: dict) -> dict:
         routing=routing,
         require_mention=require_mention,
         require_bind=settings_payload.get("require_bind", base.require_bind),
+        _agent_name_at_load=settings_payload.get(
+            "expected_agent_name", _UNSET_AGENT_BINDING
+        ),
     )
     store.update_thread(channel_id, thread_id, settings, platform=platform)
     return {
@@ -5045,7 +5052,15 @@ def _scope_settings_payload(settings: ChannelSettings, platform: str) -> dict:
         "require_mention": settings.require_mention,
         "require_bind": settings.require_bind,
         "routing": routing_to_compat_dict(settings.routing),
+        "expected_agent_name": _agent_binding_expectation(settings),
     }
+
+
+def _agent_binding_expectation(settings: ChannelSettings | UserSettings) -> Optional[str]:
+    expected_agent_name = settings._agent_name_at_load
+    if expected_agent_name is _UNSET_AGENT_BINDING:
+        return settings.routing.agent_name
+    return expected_agent_name
 
 
 def _settings_to_payload(store: SettingsStore, platform: str) -> dict:
@@ -5084,6 +5099,7 @@ def _settings_to_payload(store: SettingsStore, platform: str) -> dict:
             "show_message_types": _normalize_show_message_types_for_platform(u.show_message_types, platform),
             "custom_cwd": u.custom_cwd,
             "routing": routing_to_compat_dict(u.routing),
+            "expected_agent_name": _agent_binding_expectation(u),
         }
     for bc in store.settings.bind_codes:
         payload["bind_codes"].append(
@@ -11036,6 +11052,7 @@ def get_users(platform: Optional[str] = None) -> dict:
             "show_message_types": _normalize_show_message_types_for_platform(u.show_message_types, platform),
             "custom_cwd": u.custom_cwd,
             "routing": routing_to_compat_dict(u.routing),
+            "expected_agent_name": _agent_binding_expectation(u),
         }
     return {"ok": True, "users": users}
 
@@ -11061,6 +11078,7 @@ def save_users(payload: dict) -> dict:
             routing=_parse_routing(_normalize_backend_routing_payload(up.get("routing") or {})),
             dm_chat_id=existing.dm_chat_id if existing else "",
             pending_bind_menu_hint=existing.pending_bind_menu_hint if existing else False,
+            _agent_name_at_load=up.get("expected_agent_name", _UNSET_AGENT_BINDING),
         )
 
     # Merge instead of replace: update existing users and add new ones,

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -47,7 +47,7 @@ from core.scheduled_tasks import (
     session_anchor_for_target,
 )
 from core.caller_context import caller_context_from_env
-from core.vibe_agents import AgentArchiveError, AgentNameValidationError, VibeAgent, VibeAgentStore, iter_global_agent_files, parse_agent_file, validate_agent_backend
+from core.vibe_agents import AgentArchivedEditError, AgentArchiveError, AgentNameValidationError, VibeAgent, VibeAgentStore, iter_global_agent_files, parse_agent_file, validate_agent_backend
 from core.watches import (
     DEFAULT_RETRY_EXIT_CODE,
     WATCH_RECOVERY_ENTRY_TIMEOUT_SECONDS,
@@ -2915,6 +2915,7 @@ def _wait_for_watch_startup(
 
 
 def cmd_task_add(args):
+    reserved_session_id: Optional[str] = None
     try:
         caller_context = caller_context_from_env()
         session_default_notice = _apply_caller_session_default(
@@ -2968,6 +2969,7 @@ def cmd_task_add(args):
                 help_command="vibe task add --help",
                 require_enabled_agent=expected_enabled_agent_id is not None,
             )
+            reserved_session_id = session_id
         session_target, delivery_target = _validate_definition_delivery_target(
             session_policy=session_policy,
             session_id=session_id,
@@ -3047,6 +3049,7 @@ def cmd_task_add(args):
                 metadata=_definition_metadata_with_scope(caller_context, scope_id=scope_key, session_workdir=cwd),
                 expected_enabled_agent_id=expected_enabled_agent_id,
             )
+        reserved_session_id = None
         warnings = _collect_target_warnings(session_target, delivery_target)
         task_payload = _task_mutation_payload(task)
         payload_fields = {
@@ -3057,6 +3060,11 @@ def cmd_task_add(args):
         _print_definition_payload(task_payload, **payload_fields)
         return 0
     except Exception as exc:
+        if reserved_session_id:
+            _release_definition_session_reservation(
+                reserved_session_id,
+                reason="task creation failed before its Session reservation was adopted",
+            )
         _print_task_error(exc, help_command="vibe task add --help")
         return 1
 
@@ -3156,6 +3164,7 @@ def cmd_task_remove(task_id: str):
 
 
 def cmd_task_update(args):
+    reserved_session_id: Optional[str] = None
     try:
         store = _task_store()
         task = store.get_task(args.task_id)
@@ -3441,6 +3450,7 @@ def cmd_task_update(args):
                 help_command="vibe task update --help",
                 require_enabled_agent=expected_enabled_agent_id is not None,
             )
+            reserved_session_id = session_id
             session_key = ""
         if session_policy == "existing":
             metadata.pop("session_workdir", None)
@@ -3518,11 +3528,17 @@ def cmd_task_update(args):
             metadata=metadata,
             expected_enabled_agent_id=expected_enabled_agent_id,
         )
+        reserved_session_id = None
         warnings = _collect_target_warnings(session_target, delivery_target)
         task_payload = _task_mutation_payload(updated)
         _print_definition_payload(task_payload, warnings=warnings)
         return 0
     except DefinitionWriteConflict as exc:
+        if reserved_session_id:
+            _release_definition_session_reservation(
+                reserved_session_id,
+                reason="task update failed before its Session reservation was adopted",
+            )
         _print_task_error(
             _definition_conflict_cli_error(
                 exc,
@@ -3532,6 +3548,11 @@ def cmd_task_update(args):
         )
         return 1
     except Exception as exc:
+        if reserved_session_id:
+            _release_definition_session_reservation(
+                reserved_session_id,
+                reason="task update failed before its Session reservation was adopted",
+            )
         _print_task_error(exc, help_command="vibe task update --help")
         return 1
 
@@ -3960,6 +3981,9 @@ def cmd_agent_update(args):
         agent = _agent_store().update(args.name, **kwargs)
         _print_cli_payload("agent", agent=_agent_payload(agent), **_agent_value_warning_fields(agent))
         return 0
+    except AgentArchivedEditError as exc:
+        _print_task_error(_agent_archived_edit_cli_error(exc))
+        return 1
     except Exception as exc:
         _print_task_error(exc)
         return 1
@@ -3970,9 +3994,26 @@ def cmd_agent_set_enabled(args, *, enabled: bool):
         agent = _agent_store().set_enabled(args.name, enabled)
         _print_cli_payload("agent", agent=_agent_payload(agent))
         return 0
+    except AgentArchivedEditError as exc:
+        _print_task_error(_agent_archived_edit_cli_error(exc))
+        return 1
     except Exception as exc:
         _print_task_error(exc)
         return 1
+
+
+def _agent_archived_edit_cli_error(exc: AgentArchivedEditError) -> TaskCliError:
+    try:
+        lang = V2Config.load().language
+    except Exception:
+        lang = "en"
+    key = f"error.agentLifecycle.{exc.code}"
+    return TaskCliError(
+        i18n_t(f"{key}.message", lang, agent=exc.agent_name),
+        code=exc.code,
+        hint=i18n_t(f"{key}.hint", lang, agent=exc.agent_name),
+        details={"agent": exc.agent_name},
+    )
 
 
 def cmd_agent_remove(args):
@@ -4705,6 +4746,32 @@ def _reserve_definition_session(
             help_command=help_command,
         )
     return session_id
+
+
+def _release_definition_session_reservation(session_id: str, *, reason: str) -> bool:
+    """Release only the unadopted Session reserved by a failed CLI mutation."""
+
+    from storage.sessions_service import SQLiteSessionsService
+
+    service: Optional[SQLiteSessionsService] = None
+    try:
+        service = SQLiteSessionsService(paths.get_sqlite_state_path())
+        return service.release_reserved_agent_session(session_id, reason=reason)
+    except Exception:
+        logger.exception(
+            "Could not release the reserved Agent Session %s after a failed definition mutation",
+            session_id,
+        )
+        return False
+    finally:
+        if service is not None:
+            try:
+                service.close()
+            except Exception:
+                logger.exception(
+                    "Could not close the Session store after releasing reservation %s",
+                    session_id,
+                )
 
 
 def cmd_agent_run(args):
@@ -8485,6 +8552,7 @@ def cmd_vault_key_import(args):
 
 
 def cmd_watch_add(args):
+    reserved_session_id: Optional[str] = None
     try:
         caller_context = caller_context_from_env()
         session_default_notice = _apply_caller_session_default(
@@ -8538,6 +8606,7 @@ def cmd_watch_add(args):
                 help_command="vibe watch add --help",
                 require_enabled_agent=expected_enabled_agent_id is not None,
             )
+            reserved_session_id = session_id
         session_target, delivery_target = _validate_definition_delivery_target(
             session_policy=session_policy,
             session_id=session_id,
@@ -8587,6 +8656,7 @@ def cmd_watch_add(args):
             metadata=_definition_metadata_with_scope(caller_context, scope_id=scope_key, session_workdir=session_workdir),
             expected_enabled_agent_id=expected_enabled_agent_id,
         )
+        reserved_session_id = None
         runtime_store = _watch_runtime_store()
         watch, runtime_entry = _wait_for_watch_startup(store, runtime_store, watch.id)
         warnings = _collect_target_warnings(session_target, delivery_target)
@@ -8599,6 +8669,11 @@ def cmd_watch_add(args):
         _print_definition_payload(watch_payload, **payload_fields)
         return 0
     except Exception as exc:
+        if reserved_session_id:
+            _release_definition_session_reservation(
+                reserved_session_id,
+                reason="watch creation failed before its Session reservation was adopted",
+            )
         _print_task_error(exc, help_command="vibe watch add --help")
         return 1
 
@@ -8678,6 +8753,7 @@ def cmd_watch_set_enabled(watch_id: str, enabled: bool):
 
 
 def cmd_watch_update(args):
+    reserved_session_id: Optional[str] = None
     try:
         store = _watch_store()
         watch = store.get_watch(args.watch_id)
@@ -8938,6 +9014,7 @@ def cmd_watch_update(args):
                 help_command="vibe watch update --help",
                 require_enabled_agent=expected_enabled_agent_id is not None,
             )
+            reserved_session_id = session_id
             session_key = ""
         if session_workdir:
             metadata["session_workdir"] = session_workdir
@@ -9007,12 +9084,18 @@ def cmd_watch_update(args):
             **changes,
             expected_enabled_agent_id=expected_enabled_agent_id,
         )
+        reserved_session_id = None
         runtime_entry = _watch_runtime_store().load().get("watches", {}).get(updated.id)
         warnings = _collect_target_warnings(session_target, delivery_target)
         watch_payload = _watch_mutation_payload(updated, runtime_entry)
         _print_definition_payload(watch_payload, warnings=warnings)
         return 0
     except DefinitionWriteConflict as exc:
+        if reserved_session_id:
+            _release_definition_session_reservation(
+                reserved_session_id,
+                reason="watch update failed before its Session reservation was adopted",
+            )
         _print_task_error(
             _definition_conflict_cli_error(
                 exc,
@@ -9022,6 +9105,11 @@ def cmd_watch_update(args):
         )
         return 1
     except Exception as exc:
+        if reserved_session_id:
+            _release_definition_session_reservation(
+                reserved_session_id,
+                reason="watch update failed before its Session reservation was adopted",
+            )
         _print_task_error(exc, help_command="vibe watch update --help")
         return 1
 

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -4615,7 +4615,12 @@ def _reserve_forked_cli_session(
     scope_key: Optional[str],
     visibility: str,
 ):
-    from core.services.session_fork import SessionForkError, reserve_forked_session
+    from core.services.session_fork import (
+        SESSION_AGENT_UNAVAILABLE_CODE,
+        SESSION_AGENT_UNAVAILABLE_I18N_KEY,
+        SessionForkError,
+        reserve_forked_session,
+    )
 
     try:
         return reserve_forked_session(
@@ -4628,6 +4633,19 @@ def _reserve_forked_cli_session(
             db_path=paths.get_sqlite_state_path(),
         )
     except SessionForkError as exc:
+        if exc.code == SESSION_AGENT_UNAVAILABLE_CODE:
+            try:
+                lang = V2Config.load().language
+            except Exception:
+                lang = "en"
+            key = SESSION_AGENT_UNAVAILABLE_I18N_KEY
+            raise TaskCliError(
+                i18n_t(f"{key}.message", lang),
+                code=exc.code,
+                hint=i18n_t(f"{key}.hint", lang),
+                help_command="vibe agent run --help",
+                details={"source_session_id": source_session_id, **exc.details},
+            ) from exc
         raise TaskCliError(
             str(exc),
             code="session_fork_failed",

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -3963,13 +3963,21 @@ def cmd_agent_remove(args):
         try:
             archived = store.archive(args.name)
         except AgentArchiveError as exc:
+            try:
+                lang = V2Config.load().language
+            except Exception:
+                lang = "en"
             raise TaskCliError(
-                str(exc),
+                i18n_t(
+                    f"error.agentArchive.{exc.code}.message",
+                    lang,
+                    agent=exc.agent_name,
+                ),
                 code=exc.code,
-                hint=(
-                    "Built-in default Agents are created from enabled Backends and cannot be deleted."
-                    if exc.code == "agent_builtin"
-                    else "Keep another enabled Agent available when archiving the current default."
+                hint=i18n_t(
+                    f"error.agentArchive.{exc.code}.hint",
+                    lang,
+                    agent=exc.agent_name,
                 ),
                 details={"agent": args.name},
             ) from exc

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -47,7 +47,7 @@ from core.scheduled_tasks import (
     session_anchor_for_target,
 )
 from core.caller_context import caller_context_from_env
-from core.vibe_agents import AgentArchiveError, VibeAgent, VibeAgentStore, iter_global_agent_files, parse_agent_file, validate_agent_backend
+from core.vibe_agents import AgentArchiveError, AgentNameValidationError, VibeAgent, VibeAgentStore, iter_global_agent_files, parse_agent_file, validate_agent_backend
 from core.watches import (
     DEFAULT_RETRY_EXIT_CODE,
     WATCH_RECOVERY_ENTRY_TIMEOUT_SECONDS,
@@ -3901,6 +3901,21 @@ def cmd_agent_create(args):
         )
         _print_cli_payload("agent", agent=_agent_payload(agent), **_agent_value_warning_fields(agent))
         return 0
+    except AgentNameValidationError as exc:
+        try:
+            lang = V2Config.load().language
+        except Exception:
+            lang = "en"
+        key = f"error.agentNameValidation.{exc.code}"
+        _print_task_error(
+            TaskCliError(
+                i18n_t(f"{key}.message", lang, agent=exc.agent_name),
+                code=exc.code,
+                hint=i18n_t(f"{key}.hint", lang, agent=exc.agent_name),
+                details={"agent": exc.agent_name},
+            )
+        )
+        return 1
     except Exception as exc:
         _print_task_error(exc)
         return 1

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -3591,12 +3591,13 @@ def cmd_hook_send(args):
             help_command="vibe hook send --help",
             example_command="vibe hook send --session-id sesk8m4q2p7x",
         )
-        agent = _resolve_agent_for_target(
+        agent_resolution = _resolve_agent_target(
             agent_name=getattr(args, "agent", None),
             session_id=session_id,
             session_key=session_key,
             help_command="vibe hook send --help",
         )
+        agent = agent_resolution.agent
         request = _task_request_store().enqueue_hook_send(
             session_key=session_key,
             session_id=session_id,
@@ -3607,7 +3608,9 @@ def cmd_hook_send(args):
             run_type="agent_run",
             source_kind="cli",
             expected_enabled_agent_id=(
-                agent.id if agent is not None and bool(getattr(args, "agent", None)) else None
+                agent.id
+                if agent is not None and agent_resolution.requires_enabled_write_guard
+                else None
             ),
         )
         warnings = _collect_target_warnings(session_target, delivery_target)

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -47,7 +47,7 @@ from core.scheduled_tasks import (
     session_anchor_for_target,
 )
 from core.caller_context import caller_context_from_env
-from core.vibe_agents import AgentArchivedEditError, AgentArchiveError, AgentNameValidationError, VibeAgent, VibeAgentStore, iter_global_agent_files, parse_agent_file, validate_agent_backend
+from core.vibe_agents import AgentArchivedEditError, AgentArchiveError, AgentNameValidationError, AgentReferenceRewriteError, VibeAgent, VibeAgentStore, iter_global_agent_files, parse_agent_file, validate_agent_backend
 from core.watches import (
     DEFAULT_RETRY_EXIT_CODE,
     WATCH_RECOVERY_ENTRY_TIMEOUT_SECONDS,
@@ -4016,6 +4016,19 @@ def _agent_archived_edit_cli_error(exc: AgentArchivedEditError) -> TaskCliError:
     )
 
 
+def _agent_reference_rewrite_cli_error(exc: AgentReferenceRewriteError) -> TaskCliError:
+    try:
+        lang = V2Config.load().language
+    except Exception:
+        lang = "en"
+    key = f"error.agentLifecycle.{exc.code}"
+    return TaskCliError(
+        i18n_t(f"{key}.message", lang),
+        code=exc.code,
+        hint=i18n_t(f"{key}.hint", lang),
+    )
+
+
 def cmd_agent_remove(args):
     try:
         store = _agent_store()
@@ -4040,6 +4053,8 @@ def cmd_agent_remove(args):
                 ),
                 details={"agent": args.name},
             ) from exc
+        except AgentReferenceRewriteError as exc:
+            raise _agent_reference_rewrite_cli_error(exc) from exc
         if archived is None:
             raise TaskCliError(f"agent '{args.name}' not found", code="agent_not_found", details={"agent": args.name})
         _print_cli_payload(

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -3061,7 +3061,7 @@ def cmd_task_add(args):
         return 0
     except Exception as exc:
         if reserved_session_id:
-            _release_definition_session_reservation(
+            _release_cli_session_reservation(
                 reserved_session_id,
                 reason="task creation failed before its Session reservation was adopted",
             )
@@ -3535,7 +3535,7 @@ def cmd_task_update(args):
         return 0
     except DefinitionWriteConflict as exc:
         if reserved_session_id:
-            _release_definition_session_reservation(
+            _release_cli_session_reservation(
                 reserved_session_id,
                 reason="task update failed before its Session reservation was adopted",
             )
@@ -3549,7 +3549,7 @@ def cmd_task_update(args):
         return 1
     except Exception as exc:
         if reserved_session_id:
-            _release_definition_session_reservation(
+            _release_cli_session_reservation(
                 reserved_session_id,
                 reason="task update failed before its Session reservation was adopted",
             )
@@ -4748,7 +4748,7 @@ def _reserve_definition_session(
     return session_id
 
 
-def _release_definition_session_reservation(session_id: str, *, reason: str) -> bool:
+def _release_cli_session_reservation(session_id: str, *, reason: str) -> bool:
     """Release only the unadopted Session reserved by a failed CLI mutation."""
 
     from storage.sessions_service import SQLiteSessionsService
@@ -4759,7 +4759,7 @@ def _release_definition_session_reservation(session_id: str, *, reason: str) -> 
         return service.release_reserved_agent_session(session_id, reason=reason)
     except Exception:
         logger.exception(
-            "Could not release the reserved Agent Session %s after a failed definition mutation",
+            "Could not release the reserved Agent Session %s after a failed CLI mutation",
             session_id,
         )
         return False
@@ -4775,6 +4775,7 @@ def _release_definition_session_reservation(session_id: str, *, reason: str) -> 
 
 
 def cmd_agent_run(args):
+    reserved_session_id: Optional[str] = None
     try:
         caller_context = caller_context_from_env()
         visibility = (getattr(args, "visibility", None) or "background").strip()
@@ -4912,6 +4913,7 @@ def cmd_agent_run(args):
                 session_anchor_target=legacy_reservation_target,
                 visibility=visibility,
             )
+            reserved_session_id = session_id
         elif session_policy == "none":
             session_id = _reserve_cli_session(
                 agent=agent,
@@ -4920,6 +4922,7 @@ def cmd_agent_run(args):
                 metadata=session_metadata,
                 visibility=visibility,
             )
+            reserved_session_id = session_id
         elif session_policy == "fork":
             fork_result = _reserve_forked_cli_session(
                 source_session_id=source_session_id or "",
@@ -4930,6 +4933,7 @@ def cmd_agent_run(args):
                 visibility=visibility,
             )
             session_id = fork_result.session_id
+            reserved_session_id = session_id
             if agent_name:
                 agent = _agent_store().require_enabled(agent_name)
         if session_id and not session_key:
@@ -4979,6 +4983,7 @@ def cmd_agent_run(args):
             metadata=provenance_metadata or None,
             expected_enabled_agent_id=(agent.id if agent is not None and bool(agent_name) else None),
         )
+        reserved_session_id = None
         resolved_scope_id = _scope_id_payload_from_session(session_id)
         payload = {
             "accepted": True,
@@ -5028,6 +5033,11 @@ def cmd_agent_run(args):
         _print_cli_payload("agent_run", **payload)
         return 0
     except Exception as exc:
+        if reserved_session_id:
+            _release_cli_session_reservation(
+                reserved_session_id,
+                reason="Agent Run enqueue failed before its Session reservation was adopted",
+            )
         _print_task_error(exc, help_command="vibe agent run --help")
         return 1
 
@@ -8670,7 +8680,7 @@ def cmd_watch_add(args):
         return 0
     except Exception as exc:
         if reserved_session_id:
-            _release_definition_session_reservation(
+            _release_cli_session_reservation(
                 reserved_session_id,
                 reason="watch creation failed before its Session reservation was adopted",
             )
@@ -9092,7 +9102,7 @@ def cmd_watch_update(args):
         return 0
     except DefinitionWriteConflict as exc:
         if reserved_session_id:
-            _release_definition_session_reservation(
+            _release_cli_session_reservation(
                 reserved_session_id,
                 reason="watch update failed before its Session reservation was adopted",
             )
@@ -9106,7 +9116,7 @@ def cmd_watch_update(args):
         return 1
     except Exception as exc:
         if reserved_session_id:
-            _release_definition_session_reservation(
+            _release_cli_session_reservation(
                 reserved_session_id,
                 reason="watch update failed before its Session reservation was adopted",
             )

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -47,7 +47,7 @@ from core.scheduled_tasks import (
     session_anchor_for_target,
 )
 from core.caller_context import caller_context_from_env
-from core.vibe_agents import VibeAgent, VibeAgentStore, iter_global_agent_files, parse_agent_file, validate_agent_backend
+from core.vibe_agents import AgentArchiveError, VibeAgent, VibeAgentStore, iter_global_agent_files, parse_agent_file, validate_agent_backend
 from core.watches import (
     DEFAULT_RETRY_EXIT_CODE,
     WATCH_RECOVERY_ENTRY_TIMEOUT_SECONDS,
@@ -2503,7 +2503,7 @@ def _resolve_agent_for_target(
         requested = store.require_enabled(agent_name) if agent_name else None
         if session_id:
             target = resolve_session_id_target(session_id)
-            session_agent = store.require_enabled(target.agent_name) if target.agent_name else None
+            session_agent = store.require_reference(target.agent_name) if target.agent_name else None
             if requested is not None and session_agent is not None and requested.name != session_agent.name:
                 raise TaskCliError(
                     "agent does not match the existing session agent",
@@ -2537,7 +2537,7 @@ def _resolve_agent_for_target(
         if session_key:
             scope_target = _resolve_scope_routing_target(session_key)
             if scope_target.agent_name:
-                return store.require_enabled(scope_target.agent_name)
+                return store.require_reference(scope_target.agent_name)
 
         return store.get_default_agent()
     finally:
@@ -2559,7 +2559,7 @@ def _resolve_agent_for_session_reservation(
     store = _agent_store()
     try:
         if resolved_agent_name:
-            return store.require_enabled(resolved_agent_name)
+            return store.require_reference(resolved_agent_name)
         return store.get_default_agent()
     finally:
         store.close()
@@ -2730,10 +2730,13 @@ def _agent_payload(agent, *, brief: bool = False) -> dict:
         return {
             "id": payload["id"],
             "name": payload["name"],
+            "display_name": payload["display_name"],
             "backend": payload["backend"],
             "model": payload["model"],
             "reasoning_effort": payload["reasoning_effort"],
             "enabled": payload["enabled"],
+            "archived": payload["archived"],
+            "archived_at": payload["archived_at"],
             "source": payload["source"],
             "updated_at": payload["updated_at"],
         }
@@ -3897,26 +3900,28 @@ def cmd_agent_set_enabled(args, *, enabled: bool):
 def cmd_agent_remove(args):
     try:
         store = _agent_store()
-        counts = store.reference_counts(args.name)
-        if any(counts.values()):
-            raise TaskCliError(
-                f"agent '{args.name}' is still referenced",
-                code="agent_in_use",
-                hint="Reassign or remove the referencing scopes, sessions, tasks, or watches before deleting this Agent.",
-                details={"agent": args.name, "references": counts},
-            )
         try:
-            removed = store.remove(args.name)
-        except ValueError as exc:
+            archived = store.archive(args.name)
+        except AgentArchiveError as exc:
             raise TaskCliError(
                 str(exc),
-                code="agent_builtin",
-                hint="Built-in default Agents are created from enabled Backends and cannot be deleted.",
+                code=exc.code,
+                hint=(
+                    "Built-in default Agents are created from enabled Backends and cannot be deleted."
+                    if exc.code == "agent_builtin"
+                    else "Keep another enabled Agent available when archiving the current default."
+                ),
                 details={"agent": args.name},
             ) from exc
-        if not removed:
+        if archived is None:
             raise TaskCliError(f"agent '{args.name}' not found", code="agent_not_found", details={"agent": args.name})
-        _print_cli_payload("agent", removed_agent=args.name)
+        _print_cli_payload(
+            "agent",
+            removed_agent=archived.original_name,
+            archived_agent=_agent_payload(archived.agent, brief=True),
+            references=archived.references,
+            default_agent_name=archived.default_agent_name,
+        )
         return 0
     except Exception as exc:
         _print_task_error(exc)

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -2497,10 +2497,17 @@ def _resolve_agent_for_target(
     session_id: Optional[str],
     session_key: str,
     help_command: str,
+    existing_agent_reference: bool = False,
 ):
     store = _agent_store()
     try:
-        requested = store.require_enabled(agent_name) if agent_name else None
+        requested = None
+        if agent_name:
+            requested = (
+                store.require_reference(agent_name)
+                if existing_agent_reference
+                else store.require_enabled(agent_name)
+            )
         if session_id:
             target = resolve_session_id_target(session_id)
             session_agent = store.require_reference(target.agent_name) if target.agent_name else None
@@ -3374,6 +3381,7 @@ def cmd_task_update(args):
                 session_id=session_id,
                 session_key=session_key,
                 help_command="vibe task update --help",
+                existing_agent_reference=not explicit_agent_requested,
             )
             agent_name = agent.name if agent else None
         if session_policy == "create_once" and (
@@ -8799,6 +8807,7 @@ def cmd_watch_update(args):
                 session_id=session_id,
                 session_key=session_key,
                 help_command="vibe watch update --help",
+                existing_agent_reference=not explicit_agent_requested,
             )
             agent_name = agent.name if agent else None
         if session_policy == "create_once" and (

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -2925,12 +2925,16 @@ def cmd_task_add(args):
             help_command="vibe task add --help",
         )
         agent_name = agent.name if agent else None
+        expected_enabled_agent_id = (
+            agent.id if agent is not None and bool((getattr(args, "agent", None) or "").strip()) else None
+        )
         if session_policy == "create_once":
             session_id = _reserve_definition_session(
                 agent_name=agent_name,
                 deliver_key=scope_key or "",
                 workdir=cwd,
                 help_command="vibe task add --help",
+                require_enabled_agent=expected_enabled_agent_id is not None,
             )
         session_target, delivery_target = _validate_definition_delivery_target(
             session_policy=session_policy,
@@ -2981,6 +2985,7 @@ def cmd_task_add(args):
                 cron=args.cron,
                 timezone_name=timezone_name,
                 metadata=_definition_metadata_with_scope(caller_context, scope_id=scope_key, session_workdir=cwd),
+                expected_enabled_agent_id=expected_enabled_agent_id,
             )
         else:
             try:
@@ -3008,6 +3013,7 @@ def cmd_task_add(args):
                 run_at=run_at,
                 timezone_name=timezone_name,
                 metadata=_definition_metadata_with_scope(caller_context, scope_id=scope_key, session_workdir=cwd),
+                expected_enabled_agent_id=expected_enabled_agent_id,
             )
         warnings = _collect_target_warnings(session_target, delivery_target)
         task_payload = _task_mutation_payload(task)
@@ -3384,6 +3390,11 @@ def cmd_task_update(args):
                 existing_agent_reference=not explicit_agent_requested,
             )
             agent_name = agent.name if agent else None
+        expected_enabled_agent_id = (
+            _agent_store().require_enabled(agent_name).id
+            if explicit_agent_requested and agent_name
+            else None
+        )
         if session_policy == "create_once" and (
             getattr(args, "create_session", False) or not session_id
         ):
@@ -3392,6 +3403,7 @@ def cmd_task_update(args):
                 deliver_key=scope_key,
                 workdir=cwd,
                 help_command="vibe task update --help",
+                require_enabled_agent=expected_enabled_agent_id is not None,
             )
             session_key = ""
         if session_policy == "existing":
@@ -3468,6 +3480,7 @@ def cmd_task_update(args):
             run_at=run_at,
             timezone_name=timezone_name,
             metadata=metadata,
+            expected_enabled_agent_id=expected_enabled_agent_id,
         )
         warnings = _collect_target_warnings(session_target, delivery_target)
         task_payload = _task_mutation_payload(updated)
@@ -4494,6 +4507,7 @@ def _reserve_cli_session(
             workdir=workdir,
             visibility=visibility,
             metadata={"scope_placement": "explicit", **dict(metadata or {})},
+            require_enabled_agent=True,
         )
     else:
         session_anchor = f"standalone_{uuid4().hex[:12]}"
@@ -4507,6 +4521,7 @@ def _reserve_cli_session(
             workdir=workdir,
             visibility=visibility,
             metadata=metadata,
+            require_enabled_agent=True,
         )
     if not session_id:
         raise TaskCliError(
@@ -4566,6 +4581,7 @@ def _reserve_definition_session(
     deliver_key: str,
     help_command: str,
     workdir: Optional[str] = None,
+    require_enabled_agent: bool = False,
 ) -> str:
     from core.services import sessions as sessions_service
 
@@ -4597,6 +4613,7 @@ def _reserve_definition_session(
         reasoning_effort=agent.reasoning_effort if agent else None,
         workdir=workdir,
         visibility="foreground",
+        require_enabled_agent=require_enabled_agent,
     )
     if not session_id:
         raise TaskCliError(
@@ -4810,6 +4827,7 @@ def cmd_agent_run(args):
             callback_active=run_async,
             delivery_intent=delivery_intent,
             metadata=provenance_metadata or None,
+            expected_enabled_agent_id=(agent.id if agent is not None and bool(agent_name) else None),
         )
         resolved_scope_id = _scope_id_payload_from_session(session_id)
         payload = {
@@ -8411,6 +8429,9 @@ def cmd_watch_add(args):
             help_command="vibe watch add --help",
         )
         agent_name = agent.name if agent else None
+        expected_enabled_agent_id = (
+            agent.id if agent is not None and bool((getattr(args, "agent", None) or "").strip()) else None
+        )
         cwd = _resolve_watch_cwd(args.cwd, help_command="vibe watch add --help", default_to_invocation=True)
         session_workdir = (
             _resolve_definition_session_cwd(
@@ -8429,6 +8450,7 @@ def cmd_watch_add(args):
                 deliver_key=scope_key or "",
                 workdir=session_workdir,
                 help_command="vibe watch add --help",
+                require_enabled_agent=expected_enabled_agent_id is not None,
             )
         session_target, delivery_target = _validate_definition_delivery_target(
             session_policy=session_policy,
@@ -8477,6 +8499,7 @@ def cmd_watch_add(args):
             agent_name=agent_name,
             session_policy=session_policy,
             metadata=_definition_metadata_with_scope(caller_context, scope_id=scope_key, session_workdir=session_workdir),
+            expected_enabled_agent_id=expected_enabled_agent_id,
         )
         runtime_store = _watch_runtime_store()
         watch, runtime_entry = _wait_for_watch_startup(store, runtime_store, watch.id)
@@ -8810,6 +8833,11 @@ def cmd_watch_update(args):
                 existing_agent_reference=not explicit_agent_requested,
             )
             agent_name = agent.name if agent else None
+        expected_enabled_agent_id = (
+            _agent_store().require_enabled(agent_name).id
+            if explicit_agent_requested and agent_name
+            else None
+        )
         if session_policy == "create_once" and (
             getattr(args, "create_session", False) or not session_id
         ):
@@ -8818,6 +8846,7 @@ def cmd_watch_update(args):
                 deliver_key=scope_key,
                 workdir=session_workdir,
                 help_command="vibe watch update --help",
+                require_enabled_agent=expected_enabled_agent_id is not None,
             )
             session_key = ""
         if session_workdir:
@@ -8883,7 +8912,11 @@ def cmd_watch_update(args):
                 details={"watch_id": args.watch_id},
             )
 
-        updated = store.update_watch(args.watch_id, **changes)
+        updated = store.update_watch(
+            args.watch_id,
+            **changes,
+            expected_enabled_agent_id=expected_enabled_agent_id,
+        )
         runtime_entry = _watch_runtime_store().load().get("watches", {}).get(updated.id)
         warnings = _collect_target_warnings(session_target, delivery_target)
         watch_payload = _watch_mutation_payload(updated, runtime_entry)

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -2534,7 +2534,13 @@ def _resolve_agent_target(
             )
         if session_id:
             target = resolve_session_id_target(session_id)
-            session_agent = store.require_reference(target.agent_name) if target.agent_name else None
+            session_agent = (
+                store.require_reference_by_id(target.agent_id)
+                if target.agent_id
+                else store.require_reference(target.agent_name)
+                if target.agent_name
+                else None
+            )
             if requested is not None and session_agent is not None and requested.name != session_agent.name:
                 raise TaskCliError(
                     "agent does not match the existing session agent",

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -76,7 +76,7 @@ from storage.background import (
     compute_next_run_at,
     normalize_run_status,
 )
-from storage.models import scope_settings, scopes
+from storage.models import agents, scope_settings, scopes
 from storage.pagination import (
     DEFAULT_PAGE_LIMIT,
     MAX_PAGE_LIMIT,
@@ -2457,37 +2457,56 @@ def _validate_agent_name_arg(agent_name: Optional[str]) -> Optional[str]:
 
 class _ScopeRoutingTarget(NamedTuple):
     agent_name: Optional[str]
+    agent_id: Optional[str]
 
 
 class _AgentTargetResolution(NamedTuple):
     agent: Optional[VibeAgent]
     requires_enabled_write_guard: bool
+    preserves_existing_reference: bool = False
+
+
+def _agent_write_guard_ids(
+    resolution: _AgentTargetResolution,
+) -> tuple[Optional[str], Optional[str]]:
+    agent = resolution.agent
+    if agent is None:
+        return None, None
+    if resolution.requires_enabled_write_guard:
+        return agent.id, None
+    if getattr(resolution, "preserves_existing_reference", False):
+        return None, agent.id
+    return None, None
 
 
 def _resolve_scope_routing_target(session_key: str) -> _ScopeRoutingTarget:
     if not session_key:
-        return _ScopeRoutingTarget(None)
+        return _ScopeRoutingTarget(None, None)
     try:
         parsed = parse_scope_id(session_key)
     except ValueError:
         try:
             parsed = parse_session_key(session_key)
         except ValueError:
-            return _ScopeRoutingTarget(None)
+            return _ScopeRoutingTarget(None, None)
     scope_id = make_scope_id(parsed.platform, parsed.scope_type, parsed.scope_id)
     _ensure_cli_sqlite_state()
     engine = create_sqlite_engine(paths.get_sqlite_state_path())
     try:
         with engine.connect() as conn:
             row = conn.execute(
-                select(scope_settings.c.agent_name)
+                select(scope_settings.c.agent_name, agents.c.id.label("agent_id"))
+                .select_from(
+                    scope_settings.outerjoin(agents, agents.c.name == scope_settings.c.agent_name)
+                )
                 .where(scope_settings.c.scope_id == scope_id)
                 .limit(1)
             ).first()
             if row is None:
-                return _ScopeRoutingTarget(None)
+                return _ScopeRoutingTarget(None, None)
             agent_name = str(row.agent_name).strip() if row.agent_name else None
-            return _ScopeRoutingTarget(agent_name)
+            agent_id = str(row.agent_id).strip() if row.agent_id else None
+            return _ScopeRoutingTarget(agent_name, agent_id)
     finally:
         engine.dispose()
 
@@ -2544,17 +2563,27 @@ def _resolve_agent_target(
             return _AgentTargetResolution(
                 session_agent or requested,
                 requested is not None and not existing_agent_reference,
+                requested is None or existing_agent_reference,
             )
 
         if requested is not None:
-            return _AgentTargetResolution(requested, not existing_agent_reference)
+            return _AgentTargetResolution(
+                requested,
+                not existing_agent_reference,
+                existing_agent_reference,
+            )
 
         if session_key:
             scope_target = _resolve_scope_routing_target(session_key)
             if scope_target.agent_name:
                 return _AgentTargetResolution(
-                    store.require_reference(scope_target.agent_name),
+                    (
+                        store.require_reference_by_id(scope_target.agent_id)
+                        if scope_target.agent_id
+                        else store.require_reference(scope_target.agent_name)
+                    ),
                     False,
+                    True,
                 )
 
         default_agent = store.get_default_agent()
@@ -2583,17 +2612,22 @@ def _resolve_agent_for_target(
 def _resolve_agent_for_session_reservation(
     *,
     agent_name: Optional[str],
+    agent_id: Optional[str] = None,
     deliver_key: str,
     help_command: str,
 ) -> Optional[VibeAgent]:
     resolved_agent_name = agent_name
-    scope_target = _ScopeRoutingTarget(None)
+    scope_target = _ScopeRoutingTarget(None, None)
     if not resolved_agent_name:
         scope_target = _resolve_scope_routing_target(deliver_key)
         resolved_agent_name = scope_target.agent_name
 
     store = _agent_store()
     try:
+        if agent_id:
+            return store.require_reference_by_id(agent_id)
+        if scope_target.agent_id:
+            return store.require_reference_by_id(scope_target.agent_id)
         if resolved_agent_name:
             return store.require_reference(resolved_agent_name)
         return store.get_default_agent()
@@ -2956,18 +2990,18 @@ def cmd_task_add(args):
         )
         agent = agent_resolution.agent
         agent_name = agent.name if agent else None
-        expected_enabled_agent_id = (
-            agent.id
-            if agent is not None and agent_resolution.requires_enabled_write_guard
-            else None
+        expected_enabled_agent_id, expected_reference_agent_id = _agent_write_guard_ids(
+            agent_resolution
         )
         if session_policy == "create_once":
             session_id = _reserve_definition_session(
                 agent_name=agent_name,
+                agent_id=agent.id if agent else None,
                 deliver_key=scope_key or "",
                 workdir=cwd,
                 help_command="vibe task add --help",
                 require_enabled_agent=expected_enabled_agent_id is not None,
+                expected_reference_agent_id=expected_reference_agent_id,
             )
             reserved_session_id = session_id
         session_target, delivery_target = _validate_definition_delivery_target(
@@ -3020,6 +3054,7 @@ def cmd_task_add(args):
                 timezone_name=timezone_name,
                 metadata=_definition_metadata_with_scope(caller_context, scope_id=scope_key, session_workdir=cwd),
                 expected_enabled_agent_id=expected_enabled_agent_id,
+                expected_reference_agent_id=expected_reference_agent_id,
             )
         else:
             try:
@@ -3048,6 +3083,7 @@ def cmd_task_add(args):
                 timezone_name=timezone_name,
                 metadata=_definition_metadata_with_scope(caller_context, scope_id=scope_key, session_workdir=cwd),
                 expected_enabled_agent_id=expected_enabled_agent_id,
+                expected_reference_agent_id=expected_reference_agent_id,
             )
         reserved_session_id = None
         warnings = _collect_target_warnings(session_target, delivery_target)
@@ -3434,21 +3470,20 @@ def cmd_task_update(args):
             )
             agent = agent_resolution.agent
             agent_name = agent.name if agent else None
-        expected_enabled_agent_id = (
-            agent_resolution.agent.id
-            if agent_resolution.agent is not None
-            and agent_resolution.requires_enabled_write_guard
-            else None
+        expected_enabled_agent_id, expected_reference_agent_id = _agent_write_guard_ids(
+            agent_resolution
         )
         if session_policy == "create_once" and (
             getattr(args, "create_session", False) or not session_id
         ):
             session_id = _reserve_definition_session(
                 agent_name=agent_name,
+                agent_id=agent.id if agent else None,
                 deliver_key=scope_key,
                 workdir=cwd,
                 help_command="vibe task update --help",
                 require_enabled_agent=expected_enabled_agent_id is not None,
+                expected_reference_agent_id=expected_reference_agent_id,
             )
             reserved_session_id = session_id
             session_key = ""
@@ -3527,6 +3562,7 @@ def cmd_task_update(args):
             timezone_name=timezone_name,
             metadata=metadata,
             expected_enabled_agent_id=expected_enabled_agent_id,
+            expected_reference_agent_id=expected_reference_agent_id,
         )
         reserved_session_id = None
         warnings = _collect_target_warnings(session_target, delivery_target)
@@ -3626,11 +3662,18 @@ def cmd_hook_send(args):
             deliver_key=args.deliver_key,
             prompt=message,
             agent_name=agent.name if agent else None,
+            agent_id=agent.id if agent else None,
             run_type="agent_run",
             source_kind="cli",
             expected_enabled_agent_id=(
                 agent.id
                 if agent is not None and agent_resolution.requires_enabled_write_guard
+                else None
+            ),
+            expected_reference_agent_id=(
+                agent.id
+                if agent is not None
+                and getattr(agent_resolution, "preserves_existing_reference", False)
                 else None
             ),
         )
@@ -4717,10 +4760,12 @@ def _reserve_forked_cli_session(
 def _reserve_definition_session(
     *,
     agent_name: Optional[str],
+    agent_id: Optional[str] = None,
     deliver_key: str,
     help_command: str,
     workdir: Optional[str] = None,
     require_enabled_agent: bool = False,
+    expected_reference_agent_id: Optional[str] = None,
 ) -> str:
     from core.services import sessions as sessions_service
 
@@ -4730,6 +4775,7 @@ def _reserve_definition_session(
         target = _parse_validated_session_key(deliver_key, help_command=help_command)
     agent = _resolve_agent_for_session_reservation(
         agent_name=agent_name,
+        agent_id=agent_id,
         deliver_key=deliver_key,
         help_command=help_command,
     )
@@ -4753,6 +4799,7 @@ def _reserve_definition_session(
         workdir=workdir,
         visibility="foreground",
         require_enabled_agent=require_enabled_agent,
+        expected_reference_agent_id=expected_reference_agent_id,
     )
     if not session_id:
         raise TaskCliError(
@@ -8606,10 +8653,8 @@ def cmd_watch_add(args):
         )
         agent = agent_resolution.agent
         agent_name = agent.name if agent else None
-        expected_enabled_agent_id = (
-            agent.id
-            if agent is not None and agent_resolution.requires_enabled_write_guard
-            else None
+        expected_enabled_agent_id, expected_reference_agent_id = _agent_write_guard_ids(
+            agent_resolution
         )
         cwd = _resolve_watch_cwd(args.cwd, help_command="vibe watch add --help", default_to_invocation=True)
         session_workdir = (
@@ -8626,10 +8671,12 @@ def cmd_watch_add(args):
         if session_policy == "create_once":
             session_id = _reserve_definition_session(
                 agent_name=agent_name,
+                agent_id=agent.id if agent else None,
                 deliver_key=scope_key or "",
                 workdir=session_workdir,
                 help_command="vibe watch add --help",
                 require_enabled_agent=expected_enabled_agent_id is not None,
+                expected_reference_agent_id=expected_reference_agent_id,
             )
             reserved_session_id = session_id
         session_target, delivery_target = _validate_definition_delivery_target(
@@ -8680,6 +8727,7 @@ def cmd_watch_add(args):
             session_policy=session_policy,
             metadata=_definition_metadata_with_scope(caller_context, scope_id=scope_key, session_workdir=session_workdir),
             expected_enabled_agent_id=expected_enabled_agent_id,
+            expected_reference_agent_id=expected_reference_agent_id,
         )
         reserved_session_id = None
         runtime_store = _watch_runtime_store()
@@ -9023,21 +9071,20 @@ def cmd_watch_update(args):
             )
             agent = agent_resolution.agent
             agent_name = agent.name if agent else None
-        expected_enabled_agent_id = (
-            agent_resolution.agent.id
-            if agent_resolution.agent is not None
-            and agent_resolution.requires_enabled_write_guard
-            else None
+        expected_enabled_agent_id, expected_reference_agent_id = _agent_write_guard_ids(
+            agent_resolution
         )
         if session_policy == "create_once" and (
             getattr(args, "create_session", False) or not session_id
         ):
             session_id = _reserve_definition_session(
                 agent_name=agent_name,
+                agent_id=agent.id if agent else None,
                 deliver_key=scope_key,
                 workdir=session_workdir,
                 help_command="vibe watch update --help",
                 require_enabled_agent=expected_enabled_agent_id is not None,
+                expected_reference_agent_id=expected_reference_agent_id,
             )
             reserved_session_id = session_id
             session_key = ""
@@ -9108,6 +9155,7 @@ def cmd_watch_update(args):
             args.watch_id,
             **changes,
             expected_enabled_agent_id=expected_enabled_agent_id,
+            expected_reference_agent_id=expected_reference_agent_id,
         )
         reserved_session_id = None
         runtime_entry = _watch_runtime_store().load().get("watches", {}).get(updated.id)

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -2459,6 +2459,11 @@ class _ScopeRoutingTarget(NamedTuple):
     agent_name: Optional[str]
 
 
+class _AgentTargetResolution(NamedTuple):
+    agent: Optional[VibeAgent]
+    requires_enabled_write_guard: bool
+
+
 def _resolve_scope_routing_target(session_key: str) -> _ScopeRoutingTarget:
     if not session_key:
         return _ScopeRoutingTarget(None)
@@ -2491,14 +2496,14 @@ def _resolve_scope_agent_name(session_key: str) -> Optional[str]:
     return _resolve_scope_routing_target(session_key).agent_name
 
 
-def _resolve_agent_for_target(
+def _resolve_agent_target(
     *,
     agent_name: Optional[str],
     session_id: Optional[str],
     session_key: str,
     help_command: str,
     existing_agent_reference: bool = False,
-):
+) -> _AgentTargetResolution:
     store = _agent_store()
     try:
         requested = None
@@ -2536,19 +2541,43 @@ def _resolve_agent_for_target(
                     },
                     help_command=help_command,
                 )
-            return session_agent or requested
+            return _AgentTargetResolution(
+                session_agent or requested,
+                requested is not None and not existing_agent_reference,
+            )
 
         if requested is not None:
-            return requested
+            return _AgentTargetResolution(requested, not existing_agent_reference)
 
         if session_key:
             scope_target = _resolve_scope_routing_target(session_key)
             if scope_target.agent_name:
-                return store.require_reference(scope_target.agent_name)
+                return _AgentTargetResolution(
+                    store.require_reference(scope_target.agent_name),
+                    False,
+                )
 
-        return store.get_default_agent()
+        default_agent = store.get_default_agent()
+        return _AgentTargetResolution(default_agent, default_agent is not None)
     finally:
         store.close()
+
+
+def _resolve_agent_for_target(
+    *,
+    agent_name: Optional[str],
+    session_id: Optional[str],
+    session_key: str,
+    help_command: str,
+    existing_agent_reference: bool = False,
+):
+    return _resolve_agent_target(
+        agent_name=agent_name,
+        session_id=session_id,
+        session_key=session_key,
+        help_command=help_command,
+        existing_agent_reference=existing_agent_reference,
+    ).agent
 
 
 def _resolve_agent_for_session_reservation(
@@ -2918,15 +2947,18 @@ def cmd_task_add(args):
             scoped_session=_has_modern_scope_target(args),
             help_command="vibe task add --help",
         )
-        agent = _resolve_agent_for_target(
+        agent_resolution = _resolve_agent_target(
             agent_name=getattr(args, "agent", None),
             session_id=session_id,
             session_key=session_key or scope_key or "",
             help_command="vibe task add --help",
         )
+        agent = agent_resolution.agent
         agent_name = agent.name if agent else None
         expected_enabled_agent_id = (
-            agent.id if agent is not None and bool((getattr(args, "agent", None) or "").strip()) else None
+            agent.id
+            if agent is not None and agent_resolution.requires_enabled_write_guard
+            else None
         )
         if session_policy == "create_once":
             session_id = _reserve_definition_session(
@@ -3366,6 +3398,7 @@ def cmd_task_update(args):
                 hint="Pass --scope-id <scopes.id>, or run from an Avibe Agent Session and pass --same-scope.",
                 help_command="vibe task update --help",
             )
+        agent_resolution = _AgentTargetResolution(None, False)
         if follows_session_agent and not explicit_agent_requested:
             # Deliberately resolves NOTHING. Re-resolving here would write today's
             # scope/default Agent back onto a definition whose Agent authority now
@@ -3374,25 +3407,28 @@ def cmd_task_update(args):
             # future fire onto a different Agent.
             pass
         elif agent_name is None and session_policy != "existing":
-            agent = _resolve_agent_for_target(
+            agent_resolution = _resolve_agent_target(
                 agent_name=None,
                 session_id=None,
                 session_key=scope_key,
                 help_command="vibe task update --help",
             )
+            agent = agent_resolution.agent
             agent_name = agent.name if agent else None
         elif agent_name is not None or session_id or session_key:
-            agent = _resolve_agent_for_target(
+            agent_resolution = _resolve_agent_target(
                 agent_name=agent_name,
                 session_id=session_id,
                 session_key=session_key,
                 help_command="vibe task update --help",
                 existing_agent_reference=not explicit_agent_requested,
             )
+            agent = agent_resolution.agent
             agent_name = agent.name if agent else None
         expected_enabled_agent_id = (
-            _agent_store().require_enabled(agent_name).id
-            if explicit_agent_requested and agent_name
+            agent_resolution.agent.id
+            if agent_resolution.agent is not None
+            and agent_resolution.requires_enabled_write_guard
             else None
         )
         if session_policy == "create_once" and (
@@ -8425,15 +8461,18 @@ def cmd_watch_add(args):
             required=session_policy == "existing",
             help_command="vibe watch add --help",
         )
-        agent = _resolve_agent_for_target(
+        agent_resolution = _resolve_agent_target(
             agent_name=getattr(args, "agent", None),
             session_id=session_id,
             session_key=session_key or scope_key or "",
             help_command="vibe watch add --help",
         )
+        agent = agent_resolution.agent
         agent_name = agent.name if agent else None
         expected_enabled_agent_id = (
-            agent.id if agent is not None and bool((getattr(args, "agent", None) or "").strip()) else None
+            agent.id
+            if agent is not None and agent_resolution.requires_enabled_write_guard
+            else None
         )
         cwd = _resolve_watch_cwd(args.cwd, help_command="vibe watch add --help", default_to_invocation=True)
         session_workdir = (
@@ -8812,6 +8851,7 @@ def cmd_watch_update(args):
                 hint="Pass --scope-id <scopes.id>, or run from an Avibe Agent Session and pass --same-scope.",
                 help_command="vibe watch update --help",
             )
+        agent_resolution = _AgentTargetResolution(None, False)
         if follows_session_agent and not explicit_agent_requested:
             # Deliberately resolves NOTHING. Re-resolving here would write today's
             # scope/default Agent back onto a definition whose Agent authority now
@@ -8820,25 +8860,28 @@ def cmd_watch_update(args):
             # future watch hook onto a different Agent.
             pass
         elif agent_name is None and session_policy != "existing":
-            agent = _resolve_agent_for_target(
+            agent_resolution = _resolve_agent_target(
                 agent_name=None,
                 session_id=None,
                 session_key=scope_key,
                 help_command="vibe watch update --help",
             )
+            agent = agent_resolution.agent
             agent_name = agent.name if agent else None
         elif agent_name is not None or session_id or session_key:
-            agent = _resolve_agent_for_target(
+            agent_resolution = _resolve_agent_target(
                 agent_name=agent_name,
                 session_id=session_id,
                 session_key=session_key,
                 help_command="vibe watch update --help",
                 existing_agent_reference=not explicit_agent_requested,
             )
+            agent = agent_resolution.agent
             agent_name = agent.name if agent else None
         expected_enabled_agent_id = (
-            _agent_store().require_enabled(agent_name).id
-            if explicit_agent_requested and agent_name
+            agent_resolution.agent.id
+            if agent_resolution.agent is not None
+            and agent_resolution.requires_enabled_write_guard
             else None
         )
         if session_policy == "create_once" and (

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -3570,6 +3570,9 @@ def cmd_hook_send(args):
             agent_name=agent.name if agent else None,
             run_type="agent_run",
             source_kind="cli",
+            expected_enabled_agent_id=(
+                agent.id if agent is not None and bool(getattr(args, "agent", None)) else None
+            ),
         )
         warnings = _collect_target_warnings(session_target, delivery_target)
         _print_cli_payload(

--- a/vibe/i18n/en.json
+++ b/vibe/i18n/en.json
@@ -165,6 +165,10 @@
       "message": "Agent routing changed while these settings were open.",
       "hint": "Reload the settings and apply your change again."
     },
+    "scopeAgentUnavailable": {
+      "message": "Agent `{agent}` is unavailable for this route.",
+      "hint": "Choose an enabled Agent and apply the setting again."
+    },
     "projectAgentConflict": {
       "message": "The project's Agent changed while Project Settings was open.",
       "hint": "Reload Project Settings and apply your change again."

--- a/vibe/i18n/en.json
+++ b/vibe/i18n/en.json
@@ -186,6 +186,10 @@
       "agent_archived_read_only": {
         "message": "Agent `{agent}` is archived and cannot be edited.",
         "hint": "Archived Agents are read-only and remain available only to existing durable references."
+      },
+      "agent_reference_metadata_invalid": {
+        "message": "Avibe cannot update Agent references because a task or watch contains invalid metadata.",
+        "hint": "Repair or remove the malformed task or watch metadata, then try again."
       }
     },
     "agentNameValidation": {

--- a/vibe/i18n/en.json
+++ b/vibe/i18n/en.json
@@ -176,6 +176,16 @@
         "hint": "Keep another enabled Agent available when archiving the current default."
       }
     },
+    "agentNameValidation": {
+      "agent_name_reserved": {
+        "message": "Agent names starting with `_` are reserved for Avibe.",
+        "hint": "Choose an Agent name that does not start with `_`."
+      },
+      "agent_name_path_separator": {
+        "message": "Agent names cannot contain `/` or `\\`.",
+        "hint": "Choose an Agent name without path separators."
+      }
+    },
     "channelNotEnabled": "This channel is not enabled. Please go to the control panel to enable it.",
     "unknownCommand": "Unknown command: `/{command}`\n\nPlease use `@avibe /start` to access all bot features.",
     "clearSession": "Error clearing session: {error}",

--- a/vibe/i18n/en.json
+++ b/vibe/i18n/en.json
@@ -173,6 +173,10 @@
       "message": "The project's Agent changed while Project Settings was open.",
       "hint": "Reload Project Settings and apply your change again."
     },
+    "projectAgentUnavailable": {
+      "message": "Agent `{agent}` is unavailable for this project.",
+      "hint": "Choose an enabled Agent and apply the project setting again."
+    },
     "sessionFork": {
       "agentUnavailable": {
         "message": "The source session's Agent is no longer available for a new fork.",

--- a/vibe/i18n/en.json
+++ b/vibe/i18n/en.json
@@ -162,6 +162,20 @@
   },
   "error": {
     "sessionArchived": "This session is archived and can no longer be changed.",
+    "agentArchive": {
+      "agent_builtin": {
+        "message": "Agent `{agent}` is built in and cannot be deleted.",
+        "hint": "Built-in default Agents are created from enabled Backends and cannot be deleted."
+      },
+      "agent_already_archived": {
+        "message": "Agent `{agent}` is already archived.",
+        "hint": "Use the archived Agent's internal name only for existing durable references."
+      },
+      "agent_no_default_replacement": {
+        "message": "The default Agent `{agent}` cannot be archived without another enabled Agent.",
+        "hint": "Keep another enabled Agent available when archiving the current default."
+      }
+    },
     "channelNotEnabled": "This channel is not enabled. Please go to the control panel to enable it.",
     "unknownCommand": "Unknown command: `/{command}`\n\nPlease use `@avibe /start` to access all bot features.",
     "clearSession": "Error clearing session: {error}",

--- a/vibe/i18n/en.json
+++ b/vibe/i18n/en.json
@@ -182,6 +182,12 @@
         "hint": "Keep another enabled Agent available when archiving the current default."
       }
     },
+    "agentLifecycle": {
+      "agent_archived_read_only": {
+        "message": "Agent `{agent}` is archived and cannot be edited.",
+        "hint": "Archived Agents are read-only and remain available only to existing durable references."
+      }
+    },
     "agentNameValidation": {
       "agent_name_reserved": {
         "message": "Agent names starting with `_` are reserved for Avibe.",

--- a/vibe/i18n/en.json
+++ b/vibe/i18n/en.json
@@ -161,6 +161,12 @@
     }
   },
   "error": {
+    "sessionFork": {
+      "agentUnavailable": {
+        "message": "The source session's Agent is no longer available for a new fork.",
+        "hint": "Choose an enabled Agent override that uses the same backend."
+      }
+    },
     "sessionArchived": "This session is archived and can no longer be changed.",
     "agentArchive": {
       "agent_builtin": {

--- a/vibe/i18n/en.json
+++ b/vibe/i18n/en.json
@@ -161,6 +161,14 @@
     }
   },
   "error": {
+    "settingsConflict": {
+      "message": "Agent routing changed while these settings were open.",
+      "hint": "Reload the settings and apply your change again."
+    },
+    "projectAgentConflict": {
+      "message": "The project's Agent changed while Project Settings was open.",
+      "hint": "Reload Project Settings and apply your change again."
+    },
     "sessionFork": {
       "agentUnavailable": {
         "message": "The source session's Agent is no longer available for a new fork.",

--- a/vibe/i18n/zh.json
+++ b/vibe/i18n/zh.json
@@ -173,6 +173,10 @@
       "message": "项目设置打开后，该项目的 Agent 已发生变化。",
       "hint": "请重新加载项目设置后再次修改。"
     },
+    "projectAgentUnavailable": {
+      "message": "Agent `{agent}` 无法用于此项目。",
+      "hint": "请选择一个已启用的 Agent 后重新保存项目设置。"
+    },
     "sessionFork": {
       "agentUnavailable": {
         "message": "源会话的 Agent 已无法用于创建新的复刻会话。",

--- a/vibe/i18n/zh.json
+++ b/vibe/i18n/zh.json
@@ -161,6 +161,14 @@
     }
   },
   "error": {
+    "settingsConflict": {
+      "message": "这些设置打开后，Agent 路由已发生变化。",
+      "hint": "请重新加载设置后再次修改。"
+    },
+    "projectAgentConflict": {
+      "message": "项目设置打开后，该项目的 Agent 已发生变化。",
+      "hint": "请重新加载项目设置后再次修改。"
+    },
     "sessionFork": {
       "agentUnavailable": {
         "message": "源会话的 Agent 已无法用于创建新的复刻会话。",

--- a/vibe/i18n/zh.json
+++ b/vibe/i18n/zh.json
@@ -182,6 +182,12 @@
         "hint": "归档当前默认 Agent 前，请保留另一个已启用 Agent。"
       }
     },
+    "agentLifecycle": {
+      "agent_archived_read_only": {
+        "message": "Agent `{agent}` 已归档，无法编辑。",
+        "hint": "已归档 Agent 为只读状态，仅供现有持久引用继续使用。"
+      }
+    },
     "agentNameValidation": {
       "agent_name_reserved": {
         "message": "Agent 名称不能以下划线 `_` 开头；该命名空间由 Avibe 保留。",

--- a/vibe/i18n/zh.json
+++ b/vibe/i18n/zh.json
@@ -161,6 +161,12 @@
     }
   },
   "error": {
+    "sessionFork": {
+      "agentUnavailable": {
+        "message": "源会话的 Agent 已无法用于创建新的复刻会话。",
+        "hint": "请选择使用相同 backend 的已启用 Agent 作为覆盖项。"
+      }
+    },
     "sessionArchived": "该会话已归档，无法再修改。",
     "agentArchive": {
       "agent_builtin": {

--- a/vibe/i18n/zh.json
+++ b/vibe/i18n/zh.json
@@ -186,6 +186,10 @@
       "agent_archived_read_only": {
         "message": "Agent `{agent}` 已归档，无法编辑。",
         "hint": "已归档 Agent 为只读状态，仅供现有持久引用继续使用。"
+      },
+      "agent_reference_metadata_invalid": {
+        "message": "任务或监控包含无效元数据，Avibe 无法更新 Agent 引用。",
+        "hint": "请修复或删除元数据异常的任务或监控，然后重试。"
       }
     },
     "agentNameValidation": {

--- a/vibe/i18n/zh.json
+++ b/vibe/i18n/zh.json
@@ -165,6 +165,10 @@
       "message": "这些设置打开后，Agent 路由已发生变化。",
       "hint": "请重新加载设置后再次修改。"
     },
+    "scopeAgentUnavailable": {
+      "message": "Agent `{agent}` 无法用于此路由。",
+      "hint": "请选择一个已启用的 Agent 后重新保存。"
+    },
     "projectAgentConflict": {
       "message": "项目设置打开后，该项目的 Agent 已发生变化。",
       "hint": "请重新加载项目设置后再次修改。"

--- a/vibe/i18n/zh.json
+++ b/vibe/i18n/zh.json
@@ -176,6 +176,16 @@
         "hint": "归档当前默认 Agent 前，请保留另一个已启用 Agent。"
       }
     },
+    "agentNameValidation": {
+      "agent_name_reserved": {
+        "message": "Agent 名称不能以下划线 `_` 开头；该命名空间由 Avibe 保留。",
+        "hint": "请选择不以下划线 `_` 开头的 Agent 名称。"
+      },
+      "agent_name_path_separator": {
+        "message": "Agent 名称不能包含 `/` 或 `\\`。",
+        "hint": "请选择不含路径分隔符的 Agent 名称。"
+      }
+    },
     "channelNotEnabled": "此频道未启用。请前往控制面板启用它。",
     "unknownCommand": "未知命令：`/{command}`\n\n请使用 `@avibe /start` 访问所有机器人功能。",
     "clearSession": "清除会话时出错：{error}",

--- a/vibe/i18n/zh.json
+++ b/vibe/i18n/zh.json
@@ -162,6 +162,20 @@
   },
   "error": {
     "sessionArchived": "该会话已归档，无法再修改。",
+    "agentArchive": {
+      "agent_builtin": {
+        "message": "Agent `{agent}` 是内置 Agent，无法删除。",
+        "hint": "内置默认 Agent 由已启用的 Backend 创建，无法删除。"
+      },
+      "agent_already_archived": {
+        "message": "Agent `{agent}` 已归档。",
+        "hint": "已归档 Agent 的内部名称仅供现有持久引用继续使用。"
+      },
+      "agent_no_default_replacement": {
+        "message": "没有其他已启用 Agent 时，无法归档默认 Agent `{agent}`。",
+        "hint": "归档当前默认 Agent 前，请保留另一个已启用 Agent。"
+      }
+    },
     "channelNotEnabled": "此频道未启用。请前往控制面板启用它。",
     "unknownCommand": "未知命令：`/{command}`\n\n请使用 `@avibe /start` 访问所有机器人功能。",
     "clearSession": "清除会话时出错：{error}",

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -5018,19 +5018,27 @@ def ui_reload():
 @app.route("/api/settings", methods=["POST"])
 def settings_post():
     from vibe import api
+    from storage.settings_service import StaleScopeAgentBindingError
 
     payload = request.json or {}
-    return jsonify(api.save_settings(payload))
+    try:
+        return jsonify(api.save_settings(payload))
+    except StaleScopeAgentBindingError as exc:
+        return _coded_error_response("settings_conflict", str(exc), 409)
 
 
 @app.post("/api/settings/thread", include_in_schema=False)
 async def thread_settings_post(starlette_request: FastAPIRequest):
     async def handler():
         from vibe import api
+        from storage.settings_service import StaleScopeAgentBindingError
 
         body = await starlette_request.body()
         payload = await starlette_request.json() if body else {}
-        return api.save_thread_settings(payload if isinstance(payload, dict) else {})
+        try:
+            return api.save_thread_settings(payload if isinstance(payload, dict) else {})
+        except StaleScopeAgentBindingError as exc:
+            return _coded_error_response("settings_conflict", str(exc), 409)
 
     return await _dispatch_native_ui_request(starlette_request, handler)
 
@@ -8990,9 +8998,13 @@ def users_get():
 @app.route("/api/users", methods=["POST"])
 def users_post():
     from vibe import api
+    from storage.settings_service import StaleScopeAgentBindingError
 
     payload = request.json or {}
-    return jsonify(api.save_users(payload))
+    try:
+        return jsonify(api.save_users(payload))
+    except StaleScopeAgentBindingError as exc:
+        return _coded_error_response("settings_conflict", str(exc), 409)
 
 
 @app.route("/api/users/<user_id>/admin", methods=["POST"])

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -4124,6 +4124,20 @@ def _project_agent_conflict_response(exc):
     )
 
 
+def _project_agent_unavailable_response(exc):
+    from core.services import settings as settings_service
+
+    lang = settings_service.load_config_or_default().language
+    key = "error.projectAgentUnavailable"
+    return _coded_error_response(
+        exc.code,
+        t(f"{key}.message", lang, agent=exc.agent_name),
+        400,
+        hint=t(f"{key}.hint", lang),
+        details={"agent_name": exc.agent_name},
+    )
+
+
 def _show_page_error_response(exc):
     code = getattr(exc, "code", "invalid_show_page_request")
     # A conflict (not a malformed request) when the page is in the wrong state or
@@ -5976,6 +5990,8 @@ def projects_update(project_id: str):
             )
     except projects_service.StaleProjectAgentBindingError as err:
         return _project_agent_conflict_response(err)
+    except projects_service.ProjectAgentUnavailableError as err:
+        return _project_agent_unavailable_response(err)
     except LookupError as err:
         return jsonify({"error": str(err)}), 404
     except (FileNotFoundError, NotADirectoryError, ValueError) as err:

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -6787,7 +6787,10 @@ async def sessions_update(session_id: str):
     identity_requested = "agent_id" in updatable or "agent_name" in updatable
     if identity_requested and (updatable.get("agent_id") or updatable.get("agent_name")):
         try:
-            with engine.connect() as conn:
+            with engine.begin() as conn:
+                from storage.agent_session_rows import reserve_write_lock
+
+                reserve_write_lock(conn)
                 identity = workbench_sessions_service.require_enabled_agent_identity(
                     conn,
                     agent_id=updatable.get("agent_id"),

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -3522,7 +3522,7 @@ def _vibe_agent_result_response(result: dict):
     status = 200
     if not result.get("ok", True):
         code = result.get("code")
-        if code == "agent_in_use":
+        if code in {"agent_in_use", "agent_archived_read_only"}:
             status = 409
         elif code in {"agent_not_found", "agent_import_source_not_found"}:
             status = 404

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -6325,6 +6325,8 @@ def sessions_create():
     payload = request.json or {}
     project_id = (payload.get("project_id") or "").strip()
     agent_backend = (payload.get("agent_backend") or "").strip()
+    agent_id = payload.get("agent_id")
+    agent_name = payload.get("agent_name")
     if not project_id:
         return jsonify({"error": "project_id is required"}), 400
     # When the caller doesn't pin a backend/agent (a plain "new chat"), leave
@@ -6343,17 +6345,21 @@ def sessions_create():
             from storage.agent_session_rows import reserve_write_lock
 
             reserve_write_lock(conn)
-            if payload.get("agent_name"):
-                workbench_sessions_service.require_enabled_agent_backend(
+            if agent_id or agent_name:
+                identity = workbench_sessions_service.require_enabled_agent_identity(
                     conn,
-                    str(payload["agent_name"]),
+                    agent_id=agent_id,
+                    agent_name=agent_name,
                 )
+                agent_id = identity["id"]
+                agent_name = identity["name"]
+                agent_backend = identity["backend"]
             session = workbench_sessions_service.create_session(
                 conn,
                 scope_id=scope_id,
                 agent_backend=agent_backend,
-                agent_id=payload.get("agent_id"),
-                agent_name=payload.get("agent_name"),
+                agent_id=agent_id,
+                agent_name=agent_name,
                 agent_variant=payload.get("agent_variant"),
                 model=payload.get("model"),
                 reasoning_effort=payload.get("reasoning_effort"),
@@ -6778,13 +6784,16 @@ async def sessions_update(session_id: str):
             return _session_archived_response()
     should_check_backend_lock = "agent_backend" in updatable
     requested_backend = updatable.get("agent_backend")
-    if "agent_name" in updatable and "agent_backend" not in updatable:
+    identity_requested = "agent_id" in updatable or "agent_name" in updatable
+    if identity_requested and (updatable.get("agent_id") or updatable.get("agent_name")):
         try:
             with engine.connect() as conn:
-                requested_backend = workbench_sessions_service.require_enabled_agent_backend(
+                identity = workbench_sessions_service.require_enabled_agent_identity(
                     conn,
-                    str(updatable.get("agent_name") or ""),
+                    agent_id=updatable.get("agent_id"),
+                    agent_name=updatable.get("agent_name"),
                 )
+                requested_backend = identity["backend"]
             should_check_backend_lock = True
         except LookupError as err:
             return jsonify({"error": str(err)}), 404
@@ -6821,11 +6830,16 @@ async def sessions_update(session_id: str):
             from storage.agent_session_rows import reserve_write_lock
 
             reserve_write_lock(conn)
-            if updatable.get("agent_name"):
-                workbench_sessions_service.require_enabled_agent_backend(
+            if identity_requested and (updatable.get("agent_id") or updatable.get("agent_name")):
+                identity = workbench_sessions_service.require_enabled_agent_identity(
                     conn,
-                    str(updatable["agent_name"]),
+                    agent_id=updatable.get("agent_id"),
+                    agent_name=updatable.get("agent_name"),
                 )
+                updatable["agent_id"] = identity["id"]
+                updatable["agent_name"] = identity["name"]
+                updatable["agent_backend"] = identity["backend"]
+                updatable.setdefault("agent_variant", identity["backend"])
             previous_session = (
                 workbench_sessions_service.get_session(conn, session_id)
                 if {"visibility", "scope_id"}.intersection(updatable)

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -6384,7 +6384,23 @@ def _session_fork_error_response(err: Exception):
     permanent refusal. See ``_coded_error_response`` — every code here needs the same
     treatment, so the whole mapping goes through it rather than one patched branch.
     """
+    from core.services import settings as settings_service
+    from core.services.session_fork import (
+        SESSION_AGENT_UNAVAILABLE_CODE,
+        SESSION_AGENT_UNAVAILABLE_I18N_KEY,
+    )
+
     message = str(err)
+    if getattr(err, "code", None) == SESSION_AGENT_UNAVAILABLE_CODE:
+        lang = settings_service.load_config_or_default().language
+        key = SESSION_AGENT_UNAVAILABLE_I18N_KEY
+        return _coded_error_response(
+            SESSION_AGENT_UNAVAILABLE_CODE,
+            t(f"{key}.message", lang),
+            409,
+            hint=t(f"{key}.hint", lang),
+            **getattr(err, "details", {}),
+        )
     if "id not found" in message:
         return _coded_error_response("session_not_found", message, 404)
     if "is archived" in message:

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -5018,20 +5018,22 @@ def ui_reload():
 @app.route("/api/settings", methods=["POST"])
 def settings_post():
     from vibe import api
-    from storage.settings_service import StaleScopeAgentBindingError
+    from storage.settings_service import ScopeAgentUnavailableError, StaleScopeAgentBindingError
 
     payload = request.json or {}
     try:
         return jsonify(api.save_settings(payload))
     except StaleScopeAgentBindingError as exc:
         return _coded_error_response("settings_conflict", str(exc), 409)
+    except ScopeAgentUnavailableError as exc:
+        return _coded_error_response("agent_unavailable", str(exc), 400)
 
 
 @app.post("/api/settings/thread", include_in_schema=False)
 async def thread_settings_post(starlette_request: FastAPIRequest):
     async def handler():
         from vibe import api
-        from storage.settings_service import StaleScopeAgentBindingError
+        from storage.settings_service import ScopeAgentUnavailableError, StaleScopeAgentBindingError
 
         body = await starlette_request.body()
         payload = await starlette_request.json() if body else {}
@@ -5039,6 +5041,8 @@ async def thread_settings_post(starlette_request: FastAPIRequest):
             return api.save_thread_settings(payload if isinstance(payload, dict) else {})
         except StaleScopeAgentBindingError as exc:
             return _coded_error_response("settings_conflict", str(exc), 409)
+        except ScopeAgentUnavailableError as exc:
+            return _coded_error_response("agent_unavailable", str(exc), 400)
 
     return await _dispatch_native_ui_request(starlette_request, handler)
 
@@ -6336,6 +6340,9 @@ def sessions_create():
     engine = _projects_engine()
     try:
         with engine.begin() as conn:
+            from storage.agent_session_rows import reserve_write_lock
+
+            reserve_write_lock(conn)
             if payload.get("agent_name"):
                 workbench_sessions_service.require_enabled_agent_backend(
                     conn,
@@ -6811,6 +6818,9 @@ async def sessions_update(session_id: str):
 
     try:
         with engine.begin() as conn:
+            from storage.agent_session_rows import reserve_write_lock
+
+            reserve_write_lock(conn)
             if updatable.get("agent_name"):
                 workbench_sessions_service.require_enabled_agent_backend(
                     conn,
@@ -8998,13 +9008,15 @@ def users_get():
 @app.route("/api/users", methods=["POST"])
 def users_post():
     from vibe import api
-    from storage.settings_service import StaleScopeAgentBindingError
+    from storage.settings_service import ScopeAgentUnavailableError, StaleScopeAgentBindingError
 
     payload = request.json or {}
     try:
         return jsonify(api.save_users(payload))
     except StaleScopeAgentBindingError as exc:
         return _coded_error_response("settings_conflict", str(exc), 409)
+    except ScopeAgentUnavailableError as exc:
+        return _coded_error_response("agent_unavailable", str(exc), 400)
 
 
 @app.route("/api/users/<user_id>/admin", methods=["POST"])

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -6785,6 +6785,9 @@ async def sessions_update(session_id: str):
     should_check_backend_lock = "agent_backend" in updatable
     requested_backend = updatable.get("agent_backend")
     identity_requested = "agent_id" in updatable or "agent_name" in updatable
+    if identity_requested and not (updatable.get("agent_id") or updatable.get("agent_name")):
+        updatable["agent_id"] = None
+        updatable["agent_name"] = None
     if identity_requested and (updatable.get("agent_id") or updatable.get("agent_name")):
         try:
             with engine.begin() as conn:

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -5915,7 +5915,7 @@ def projects_update(project_id: str):
             )
     except LookupError as err:
         return jsonify({"error": str(err)}), 404
-    except (FileNotFoundError, NotADirectoryError) as err:
+    except (FileNotFoundError, NotADirectoryError, ValueError) as err:
         return jsonify({"error": str(err)}), 400
     return jsonify(project)
 

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -4082,6 +4082,34 @@ def _coded_error_response(code: str, message: str, status: int, **extra: Any):
     )
 
 
+def _settings_conflict_response(exc):
+    from core.services import settings as settings_service
+
+    lang = settings_service.load_config_or_default().language
+    key = "error.settingsConflict"
+    return _coded_error_response(
+        exc.code,
+        t(f"{key}.message", lang),
+        409,
+        hint=t(f"{key}.hint", lang),
+        details={"scope_id": exc.scope_id},
+    )
+
+
+def _project_agent_conflict_response(exc):
+    from core.services import settings as settings_service
+
+    lang = settings_service.load_config_or_default().language
+    key = "error.projectAgentConflict"
+    return _coded_error_response(
+        exc.code,
+        t(f"{key}.message", lang),
+        409,
+        hint=t(f"{key}.hint", lang),
+        details=exc.details,
+    )
+
+
 def _show_page_error_response(exc):
     code = getattr(exc, "code", "invalid_show_page_request")
     # A conflict (not a malformed request) when the page is in the wrong state or
@@ -5024,7 +5052,7 @@ def settings_post():
     try:
         return jsonify(api.save_settings(payload))
     except StaleScopeAgentBindingError as exc:
-        return _coded_error_response("settings_conflict", str(exc), 409)
+        return _settings_conflict_response(exc)
     except ScopeAgentUnavailableError as exc:
         return _coded_error_response("agent_unavailable", str(exc), 400)
 
@@ -5040,7 +5068,7 @@ async def thread_settings_post(starlette_request: FastAPIRequest):
         try:
             return api.save_thread_settings(payload if isinstance(payload, dict) else {})
         except StaleScopeAgentBindingError as exc:
-            return _coded_error_response("settings_conflict", str(exc), 409)
+            return _settings_conflict_response(exc)
         except ScopeAgentUnavailableError as exc:
             return _coded_error_response("agent_unavailable", str(exc), 400)
 
@@ -5910,7 +5938,14 @@ def projects_update(project_id: str):
     # (see ``projects_service.update_project`` and its ``_UNSET`` sentinel).
     agent_kwargs = {
         field: payload[field]
-        for field in ("agent_name", "agent_variant", "model", "reasoning_effort")
+        for field in (
+            "agent_id",
+            "expected_agent_id",
+            "agent_name",
+            "agent_variant",
+            "model",
+            "reasoning_effort",
+        )
         if field in payload
     }
     if display_name is None and folder_path is None and not agent_kwargs:
@@ -5925,6 +5960,8 @@ def projects_update(project_id: str):
                 folder_path=folder_path,
                 **agent_kwargs,
             )
+    except projects_service.StaleProjectAgentBindingError as err:
+        return _project_agent_conflict_response(err)
     except LookupError as err:
         return jsonify({"error": str(err)}), 404
     except (FileNotFoundError, NotADirectoryError, ValueError) as err:
@@ -9050,7 +9087,7 @@ def users_post():
     try:
         return jsonify(api.save_users(payload))
     except StaleScopeAgentBindingError as exc:
-        return _coded_error_response("settings_conflict", str(exc), 409)
+        return _settings_conflict_response(exc)
     except ScopeAgentUnavailableError as exc:
         return _coded_error_response("agent_unavailable", str(exc), 400)
 

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -3662,7 +3662,7 @@ def vibe_agents_post():
     from vibe import api
 
     try:
-        return jsonify(api.create_vibe_agent(request.json or {}))
+        return _vibe_agent_result_response(api.create_vibe_agent(request.json or {}))
     except ValueError as exc:
         return _vibe_agent_error_response(exc)
 
@@ -3693,7 +3693,7 @@ def vibe_agent_patch(name):
     from vibe import api
 
     try:
-        return jsonify(api.update_vibe_agent(name, request.json or {}))
+        return _vibe_agent_result_response(api.update_vibe_agent(name, request.json or {}))
     except ValueError as exc:
         return _vibe_agent_error_response(exc)
 

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -3546,7 +3546,18 @@ def vibe_agents_get():
             "true",
             "yes",
         }
-        return jsonify(api.get_vibe_agents(backend=request.args.get("backend") or None, include_disabled=include_disabled))
+        include_archived = str(request.args.get("include_archived") or "").lower() in {
+            "1",
+            "true",
+            "yes",
+        }
+        return jsonify(
+            api.get_vibe_agents(
+                backend=request.args.get("backend") or None,
+                include_disabled=include_disabled,
+                include_archived=include_archived,
+            )
+        )
     except ValueError as exc:
         return _vibe_agent_error_response(exc)
 
@@ -6532,7 +6543,7 @@ async def sessions_bootstrap(session_id: str):
         draft = messages_service.get_draft(conn, session_id)
 
     try:
-        agents_payload = vibe_api.get_vibe_agents(include_disabled=False)
+        agents_payload = vibe_api.get_vibe_agents(include_disabled=False, include_archived=True)
     except Exception:
         logger.exception("sessions_bootstrap: failed to load Vibe Agents")
         agents_payload = {"agents": [], "default_agent_name": None}

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -6328,6 +6328,11 @@ def sessions_create():
     engine = _projects_engine()
     try:
         with engine.begin() as conn:
+            if payload.get("agent_name"):
+                workbench_sessions_service.require_enabled_agent_backend(
+                    conn,
+                    str(payload["agent_name"]),
+                )
             session = workbench_sessions_service.create_session(
                 conn,
                 scope_id=scope_id,
@@ -6761,7 +6766,7 @@ async def sessions_update(session_id: str):
     if "agent_name" in updatable and "agent_backend" not in updatable:
         try:
             with engine.connect() as conn:
-                requested_backend = workbench_sessions_service.derive_backend_for_agent_name(
+                requested_backend = workbench_sessions_service.require_enabled_agent_backend(
                     conn,
                     str(updatable.get("agent_name") or ""),
                 )
@@ -6798,6 +6803,11 @@ async def sessions_update(session_id: str):
 
     try:
         with engine.begin() as conn:
+            if updatable.get("agent_name"):
+                workbench_sessions_service.require_enabled_agent_backend(
+                    conn,
+                    str(updatable["agent_name"]),
+                )
             previous_session = (
                 workbench_sessions_service.get_session(conn, session_id)
                 if {"visibility", "scope_id"}.intersection(updatable)

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -4096,6 +4096,20 @@ def _settings_conflict_response(exc):
     )
 
 
+def _scope_agent_unavailable_response(exc):
+    from core.services import settings as settings_service
+
+    lang = settings_service.load_config_or_default().language
+    key = "error.scopeAgentUnavailable"
+    return _coded_error_response(
+        exc.code,
+        t(f"{key}.message", lang, agent=exc.agent_name),
+        400,
+        hint=t(f"{key}.hint", lang),
+        details={"agent_name": exc.agent_name},
+    )
+
+
 def _project_agent_conflict_response(exc):
     from core.services import settings as settings_service
 
@@ -5054,7 +5068,7 @@ def settings_post():
     except StaleScopeAgentBindingError as exc:
         return _settings_conflict_response(exc)
     except ScopeAgentUnavailableError as exc:
-        return _coded_error_response("agent_unavailable", str(exc), 400)
+        return _scope_agent_unavailable_response(exc)
 
 
 @app.post("/api/settings/thread", include_in_schema=False)
@@ -5070,7 +5084,7 @@ async def thread_settings_post(starlette_request: FastAPIRequest):
         except StaleScopeAgentBindingError as exc:
             return _settings_conflict_response(exc)
         except ScopeAgentUnavailableError as exc:
-            return _coded_error_response("agent_unavailable", str(exc), 400)
+            return _scope_agent_unavailable_response(exc)
 
     return await _dispatch_native_ui_request(starlette_request, handler)
 
@@ -9089,7 +9103,7 @@ def users_post():
     except StaleScopeAgentBindingError as exc:
         return _settings_conflict_response(exc)
     except ScopeAgentUnavailableError as exc:
-        return _coded_error_response("agent_unavailable", str(exc), 400)
+        return _scope_agent_unavailable_response(exc)
 
 
 @app.route("/api/users/<user_id>/admin", methods=["POST"])


### PR DESCRIPTION
## Summary

- replace destructive Agent deletion with an atomic archive operation
- migrate scope, Session, nonterminal Agent Run, task, watch, queued Workbench provenance, and structured JSON references to a short internal Agent name
- migrate every normalized-equivalent Agent spelling while preserving stable Agent IDs through claimed and direct execution
- keep archived Agent configuration resolvable only by persisted references while hiding it from catalogs and selectors
- reserve underscore-prefixed Agent names for Avibe internals
- reject archived Agents for newly assigned Session, definition, Run, Project, and IM scope work
- serialize Agent edits, default selection, lifecycle changes, direct assignments, Project route saves, and IM scope saves before their state-dependent reads
- replace UI clone-then-delete rename with an atomic in-place rename using the same reference migration
- compact legacy long archive names through the same formal remove command
- refuse archival when malformed definition metadata cannot be migrated without data loss

## Capability and scenarios

Changed capability: Vibe Agent lifecycle management and persisted Agent routing.

Scenario catalog IDs: N/A. This capability has no existing scenario-catalog entries; focused lifecycle, API, CLI, scheduler, migration, and concurrency tests cover the behavior.

## Evidence

- Unit: archive visibility, reference resolution, disabled-state preservation, explicit and effective-default replacement, rollback, reserved names, short-name collision handling, legacy-name compaction, normalized-equivalent aliases, queued provenance, malformed metadata preservation, and rename identity
- Contract: DELETE API and `vibe agent remove` archive payloads; PATCH rename contract; archived catalog opt-in; explicit Session identity clears both ID and name; inherited archived Agents cannot seed a new fork without an enabled override
- Concurrency: deterministic competing writers prove Agent edit, default selection, archive, direct definition/Run/Session assignment, Session create/update, Project route saves, and IM scope saves hold SQLite's writer slot before validation; global-default task/watch materialization carries the stable Agent ID into the definition transaction while existing Session/scope references retain reference semantics
- Scenario: existing Session/scope/definition/queued-message references and claimed execution snapshots continue to resolve after archival; late native binds preserve the internal name by stable Agent ID; unrelated task/watch edits preserve archived bindings while explicit archived selections fail; stale definition, Project, Session, channel, thread, and user writes cannot restore or rebind the removed name
- Migration: full SQLite migration suite, including pre-3.35 downgrade compatibility
- UI: TypeScript and production Vite build pass; archived Agents are hidden from selectors and retain their original display label on graph, Show Page, Session, Harness run, channel, and user surfaces
- Installed-build probe: local service first ran `3.0.9rc6.dev1+g3d0c9b96b`; formal `vibe agent remove pm` archived `pm`, then a later installed build compacted it to `_pm-8dd7` through the same command
- Restarted-service probe: local service and UI were healthy on `3.0.9rc6.dev3+geb2a6e528`
- Live-state probe: 9 Session and 122 non-deleted task/watch references moved to `_pm-8dd7`; old-name live references, scopes, and active/queued runs were all zero; default Agent remained `codex`

## Validation

- `687 passed` across the affected Agent lifecycle, settings, scheduler, task/watch CLI, Session API, controller, and message-handler suites on head `9e6dd94b`
- `297 passed` across focused archive, CLI, Session API, and SQLite Session-store suites on head `bd28d2df`
- `37 passed` in the focused Harness UI suite on head `bd28d2df`
- `1,300 passed` across the complete UI suite on head `76ca4f91`
- `145 passed` across the complete fallback-fixture files and focused CI failures on head `10721c92`
- `293 passed` across Agent archive/default, task/watch definition, Session fork, UI fork, and CLI fork suites on head `9ed69280`
- `156 passed` across the focused Session fork, UI API, and Agent-run CLI suites on head `76ca4f91`
- `114 passed` across the complete task/watch CLI command suite on head `b280868b`
- `346 passed` across the complete Agent archive, message provenance, UI API/routes, and task/watch CLI suites on head `971a58c8`
- `1,303 passed` across the complete UI suite on head `971a58c8`
- `npm run build` and focused `ruff check` passed on head `971a58c8`
- `316 passed` across persisted-scope routing, normalized Agent bindings, Agent Run reservation cleanup, task/watch CLI, and archive suites on head `25dec01a`
- focused `ruff check` and `git diff --check` passed on head `25dec01a`
- `ruff check` and Python compile validation passed for all changed Python files
- `npm run build` passed on head `76ca4f91`
- exact-head GitHub Actions passed all 10 reported checks on `b280868b`, including four unit-test shards, aggregate unit gate, install/upgrade regression, and Windows smoke
- 445 passed across the complete scheduler, Agent archive, UI API, and task/Agent CLI suites on head `73d03d7f`
- `491 passed` across the complete scheduler plus focused Agent archive, message routing, CLI, and UI API suites on head `2f6df525`
- `1,304 passed` across the complete UI suite on head `2f6df525`
- `npm run build`, focused `ruff check`, and `git diff --check` passed on head `2f6df525`
- `617 passed` across the expanded Project/settings/archive/UI API/task/watch/scheduler regression set on head `6275cba0`
- `164 passed` across the complete task/watch CLI suites on head `6275cba0`
- `43 passed` across focused Chat archived-label and new-Session UI tests on head `6275cba0`
- `npm run build`, focused `ruff check`, and `git diff --check` passed on head `6275cba0`

- `299 passed` across the complete Agent archive, Project service, task/Agent CLI, message-handler, and UI API suites on head `6f92f8d6` (with Avibe caller metadata unset for hermetic CLI fixtures)

## Residual manual checks

- formal local `pm` archive and legacy-name compaction acceptance path is complete
- exact-head service reinstall was not repeated after review fixes through `6f92f8d6`; the remaining manual check is the normal release-regression reinstall covering guarded disabled-Agent reference writes, stable-ID project defaults in New Chat, stale full-scope forms, archived source labels, stale mounted Chat labels, stable-ID Project conflict handling, atomic definition snapshots, legacy normalized project defaults, localized lifecycle and scope-conflict responses, soft-deleted tombstones, stable-ID scope-derived task/watch/hook writes, canonical normalized Agent bindings, and stable-ID continuation for existing CLI and IM Sessions, localized Project Agent availability responses, normalized-equivalent global defaults, and failed task/watch or Agent Run Session reservation cleanup


