### PR TITLE
fix(show): require valid runtime manifests in wheels

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -177,6 +177,11 @@ jobs:
         run: |
           uv pip install --system dist/*.whl pytest
 
+      - name: Prepare Show Runtime manifest for fixture wheels
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: python scripts/prepare_local_show_runtime_manifest.py
+
       - name: Run install and upgrade regressions
         run: |
           docker info

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -58,8 +58,11 @@ jobs:
             uv.lock
 
       - name: Build package artifact
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           pip install build
+          python scripts/prepare_local_show_runtime_manifest.py
           python -m build --wheel
 
       - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4  # v5

--- a/.gitignore
+++ b/.gitignore
@@ -158,6 +158,7 @@ ui/node_modules/
 ui/dist/
 ui/.vite/
 vibe/show_runtime/*.tgz
+vibe/show_runtime_manifest.json
 tmp/
 .bot.pid
 user_settings.json

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,9 @@ Thanks for your interest in contributing!
 
 ## Development
 
-- Run locally: `python main.py`
+- Run locally: `python main.py`. A source checkout without a packaged Show
+  Runtime manifest uses the GitHub source provider for development; installed
+  wheels still require their pinned manifest.
 - Build an installable local wheel: build `ui/`, run
   `python scripts/prepare_local_show_runtime_manifest.py`, then run
   `uv build --wheel`. The preparation step inherits the latest official

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,11 @@ Thanks for your interest in contributing!
 ## Development
 
 - Run locally: `python main.py`
+- Build an installable local wheel: build `ui/`, run
+  `python scripts/prepare_local_show_runtime_manifest.py`, then run
+  `uv build --wheel`. The preparation step inherits the latest official
+  release's SHA256-verified Show Runtime manifest; packaging fails closed when
+  the manifest is missing or invalid.
 - Lint before PR: ruff is configured with a minimal safety rule set (E9,F63,F7,F82) and ignores E501. Install hooks with `pip install pre-commit` then `pre-commit install`. Run manually with `pre-commit run --all-files`.
 - Write clear commit messages
 - Agent-specific changes: install the relevant CLI (recommended: OpenCode `opencode`; also supported: Codex), then route one Slack channel via Slack **Agent Settings** to manually test the backend (`opencode` or `codex`).

--- a/core/show_runtime.py
+++ b/core/show_runtime.py
@@ -109,6 +109,14 @@ class ShowRuntimeManager:
         source_value = runtime_source or os.environ.get("VIBE_SHOW_RUNTIME_SOURCE")
         if source_value is None and (archive_path_value or archive_url is not None or archive_url_env):
             source_value = _RUNTIME_SOURCE_ARCHIVE
+        if (
+            source_value is None
+            and not self.manifest_path
+            and not self.manifest_url
+            and not _packaged_runtime_manifest_exists()
+            and _running_from_development_checkout()
+        ):
+            source_value = _RUNTIME_SOURCE_GITHUB
         self.auto_install = _auto_install_enabled() if auto_install is None else auto_install
         self.package_spec = package_spec or os.environ.get("VIBE_SHOW_RUNTIME_PACKAGE_SPEC") or _RUNTIME_PACKAGE
         self.runtime_source = _normalize_runtime_source(source_value)
@@ -1431,6 +1439,19 @@ def _env_flag_enabled(name: str, *, default: bool) -> bool:
     if value is None:
         return default
     return value.strip().lower() not in _FALSE_VALUES
+
+
+def _packaged_runtime_manifest_exists() -> bool:
+    try:
+        resource = package_resources.files("vibe").joinpath(_RUNTIME_MANIFEST_RESOURCE)
+    except Exception:
+        return False
+    return resource.is_file()
+
+
+def _running_from_development_checkout() -> bool:
+    source_root = Path(__file__).resolve().parents[1]
+    return (source_root / "pyproject.toml").is_file() and (source_root / "main.py").is_file()
 
 
 def _normalize_runtime_source(value: str | None) -> str:

--- a/core/show_runtime.py
+++ b/core/show_runtime.py
@@ -109,13 +109,6 @@ class ShowRuntimeManager:
         source_value = runtime_source or os.environ.get("VIBE_SHOW_RUNTIME_SOURCE")
         if source_value is None and (archive_path_value or archive_url is not None or archive_url_env):
             source_value = _RUNTIME_SOURCE_ARCHIVE
-        if (
-            source_value is None
-            and not self.manifest_path
-            and not self.manifest_url
-            and not _packaged_runtime_manifest_exists()
-        ):
-            source_value = _RUNTIME_SOURCE_ARCHIVE
         self.auto_install = _auto_install_enabled() if auto_install is None else auto_install
         self.package_spec = package_spec or os.environ.get("VIBE_SHOW_RUNTIME_PACKAGE_SPEC") or _RUNTIME_PACKAGE
         self.runtime_source = _normalize_runtime_source(source_value)
@@ -1438,14 +1431,6 @@ def _env_flag_enabled(name: str, *, default: bool) -> bool:
     if value is None:
         return default
     return value.strip().lower() not in _FALSE_VALUES
-
-
-def _packaged_runtime_manifest_exists() -> bool:
-    try:
-        resource = package_resources.files("vibe").joinpath(_RUNTIME_MANIFEST_RESOURCE)
-    except Exception:
-        return False
-    return resource.is_file()
 
 
 def _normalize_runtime_source(value: str | None) -> str:

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import zipfile
+from pathlib import Path
+from runpy import run_path
+
+from hatchling.builders.hooks.plugin.interface import BuildHookInterface
+
+MANIFEST_SOURCE = Path("vibe/show_runtime_manifest.json")
+MANIFEST_WHEEL_PATH = "vibe/show_runtime_manifest.json"
+_VALIDATION = run_path(str(Path(__file__).parent / "scripts" / "show_runtime_manifest_asset.py"))
+validate_manifest_bytes = _VALIDATION["validate_manifest_bytes"]
+validate_manifest_file = _VALIDATION["validate_manifest_file"]
+
+
+class CustomBuildHook(BuildHookInterface):
+    PLUGIN_NAME = "custom"
+
+    def initialize(self, version: str, build_data: dict) -> None:
+        if version == "editable":
+            return
+        validate_manifest_file(Path(self.root) / MANIFEST_SOURCE)
+
+    def finalize(self, version: str, build_data: dict, artifact_path: str) -> None:
+        if version == "editable" or self.target_name != "wheel":
+            return
+        with zipfile.ZipFile(artifact_path) as wheel:
+            try:
+                content = wheel.read(MANIFEST_WHEEL_PATH)
+            except KeyError as exc:
+                raise RuntimeError(f"Built wheel is missing {MANIFEST_WHEEL_PATH}") from exc
+        try:
+            validate_manifest_bytes(content)
+        except ValueError as exc:
+            raise RuntimeError(f"Built wheel contains an invalid {MANIFEST_WHEEL_PATH}: {exc}") from exc

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,6 +102,8 @@ artifacts = [
     "vibe/model_hub_runtime/cliproxyapi_manifest.json",
 ]
 
+[tool.hatch.build.hooks.custom]
+
 [tool.hatch.build.targets.wheel]
 packages = ["vibe", "config", "core", "modules", "storage"]
 
@@ -117,7 +119,10 @@ include = [
     "core/**",
     "modules/**",
     "storage/**",
+    "hatch_build.py",
     "main.py",
+    "scripts/prepare_local_show_runtime_manifest.py",
+    "scripts/show_runtime_manifest_asset.py",
     "ui/dist/**",
     "vibe/show_runtime_manifest.json",
     "vibe/tmux_runtime_manifest.json",

--- a/scripts/prepare_local_show_runtime_manifest.py
+++ b/scripts/prepare_local_show_runtime_manifest.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from show_runtime_manifest_asset import prepare_manifest
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Prepare a verified Show Runtime manifest for a local Avibe wheel build."
+    )
+    parser.add_argument(
+        "--release-tag",
+        help="Official avibe-bot/avibe release tag to inherit. Defaults to the latest stable release.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("vibe/show_runtime_manifest.json"),
+        help="Manifest destination used by the Avibe wheel build.",
+    )
+    args = parser.parse_args()
+    manifest = prepare_manifest(args.output, release_tag=args.release_tag)
+    print(
+        json.dumps(
+            {
+                "ok": True,
+                "output": str(args.output),
+                "runtime_version": manifest["runtime_version"],
+                "platforms": sorted(manifest["archives"]),
+            },
+            indent=2,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_install_audit.sh
+++ b/scripts/run_install_audit.sh
@@ -58,6 +58,17 @@ def build_wheel(dest: Path, version: str) -> Path:
     return wheel
 
 
+def prepare_show_runtime_manifest() -> None:
+    result = run(
+        [python_executable, str(repo_root / "scripts" / "prepare_local_show_runtime_manifest.py")],
+        cwd=repo_root,
+        env=os.environ.copy(),
+        timeout=120,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(result.stdout + result.stderr)
+
+
 def build_scenarios(current_name: str, old_name: str, new_name: str) -> list[tuple[str, str]]:
     return [
         (
@@ -224,6 +235,7 @@ def main() -> int:
     results: list[dict[str, str | int]] = []
 
     try:
+        prepare_show_runtime_manifest()
         with tempfile.TemporaryDirectory(prefix="vibe-install-audit-fixtures-") as tmpdir:
             fixtures = Path(tmpdir)
             current_wheel = build_wheel(fixtures, "9997.0.0")

--- a/scripts/show_runtime_manifest_asset.py
+++ b/scripts/show_runtime_manifest_asset.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Any, Callable
+
+
+REPOSITORY = "avibe-bot/avibe"
+RUNTIME_REPOSITORY = "avibe-bot/vibe-show-runtime"
+MANIFEST_ASSET_NAME = "show-runtime-manifest.json"
+EXPECTED_PLATFORMS = {
+    "darwin-arm64",
+    "darwin-x64",
+    "linux-arm64",
+    "linux-x64",
+    "win32-arm64",
+    "win32-x64",
+}
+_COMMIT_RE = re.compile(r"[0-9a-f]{40}")
+_SHA256_RE = re.compile(r"[0-9a-f]{64}")
+UrlOpener = Callable[..., Any]
+
+
+def validate_manifest_bytes(content: bytes, *, release_tag: str | None = None) -> dict[str, Any]:
+    try:
+        manifest = json.loads(content.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ValueError("Show Runtime manifest is not valid UTF-8 JSON") from exc
+    if not isinstance(manifest, dict):
+        raise ValueError("Show Runtime manifest must be a JSON object")
+    if manifest.get("schema_version") != 1:
+        raise ValueError("Show Runtime manifest schema_version must be 1")
+
+    runtime_version = manifest.get("runtime_version")
+    if not isinstance(runtime_version, str) or not _COMMIT_RE.fullmatch(runtime_version):
+        raise ValueError("Show Runtime manifest runtime_version must be a 40-character hex commit")
+    runtime_source = manifest.get("runtime_source")
+    if not isinstance(runtime_source, dict):
+        raise ValueError("Show Runtime manifest runtime_source must be an object")
+    if runtime_source.get("repo") != RUNTIME_REPOSITORY or runtime_source.get("ref") != runtime_version:
+        raise ValueError("Show Runtime manifest runtime_source must pin the declared runtime_version")
+    if not isinstance(manifest.get("minimum_node"), str) or not manifest["minimum_node"]:
+        raise ValueError("Show Runtime manifest minimum_node must be non-empty")
+
+    archives = manifest.get("archives")
+    if not isinstance(archives, dict) or set(archives) != EXPECTED_PLATFORMS:
+        missing = sorted(EXPECTED_PLATFORMS - set(archives or {}))
+        extra = sorted(set(archives or {}) - EXPECTED_PLATFORMS)
+        raise ValueError(f"Show Runtime manifest platforms mismatch; missing={missing}, extra={extra}")
+    for platform, archive in archives.items():
+        _validate_archive(platform, archive, release_tag=release_tag)
+    return manifest
+
+
+def validate_manifest_file(path: Path) -> dict[str, Any]:
+    if not path.is_file():
+        raise RuntimeError(
+            "Cannot build an installable Avibe artifact without vibe/show_runtime_manifest.json. "
+            "Run `python scripts/prepare_local_show_runtime_manifest.py` first."
+        )
+    try:
+        return validate_manifest_bytes(path.read_bytes())
+    except ValueError as exc:
+        raise RuntimeError(f"Invalid {path}: {exc}") from exc
+
+
+def prepare_manifest(
+    output: Path,
+    *,
+    release_tag: str | None = None,
+    opener: UrlOpener = urllib.request.urlopen,
+) -> dict[str, Any]:
+    release_url = _release_api_url(release_tag)
+    release = _read_json(release_url, opener=opener)
+    resolved_tag = release.get("tag_name")
+    if not isinstance(resolved_tag, str) or not resolved_tag:
+        raise RuntimeError("GitHub release response is missing tag_name")
+    assets = release.get("assets")
+    if not isinstance(assets, list):
+        raise RuntimeError(f"GitHub release {resolved_tag} has no assets")
+    matches = [asset for asset in assets if isinstance(asset, dict) and asset.get("name") == MANIFEST_ASSET_NAME]
+    if len(matches) != 1:
+        raise RuntimeError(f"GitHub release {resolved_tag} must contain exactly one {MANIFEST_ASSET_NAME}")
+
+    asset = matches[0]
+    download_url = asset.get("browser_download_url")
+    digest = asset.get("digest")
+    if not isinstance(download_url, str) or not download_url.startswith("https://github.com/"):
+        raise RuntimeError(f"GitHub release {resolved_tag} has an invalid manifest download URL")
+    if not isinstance(digest, str) or not digest.startswith("sha256:") or not _SHA256_RE.fullmatch(digest[7:]):
+        raise RuntimeError(f"GitHub release {resolved_tag} is missing the manifest SHA256 digest")
+
+    content = _read_bytes(download_url, opener=opener)
+    actual_digest = hashlib.sha256(content).hexdigest()
+    if actual_digest != digest[7:]:
+        raise RuntimeError(
+            f"Show Runtime manifest digest mismatch for {resolved_tag}: expected {digest[7:]}, got {actual_digest}"
+        )
+    manifest = validate_manifest_bytes(content, release_tag=resolved_tag)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_bytes(content)
+    return manifest
+
+
+def _validate_archive(platform: str, archive: object, *, release_tag: str | None) -> None:
+    if not isinstance(archive, dict):
+        raise ValueError(f"Show Runtime archive {platform} must be an object")
+    expected_name = f"vibe-show-runtime-node-{platform}.tgz"
+    if archive.get("name") != expected_name:
+        raise ValueError(f"Show Runtime archive {platform} must be named {expected_name}")
+    sha256 = archive.get("sha256")
+    if not isinstance(sha256, str) or not _SHA256_RE.fullmatch(sha256):
+        raise ValueError(f"Show Runtime archive {platform} has an invalid SHA256")
+    size = archive.get("size")
+    if not isinstance(size, int) or isinstance(size, bool) or size <= 0:
+        raise ValueError(f"Show Runtime archive {platform} has an invalid size")
+    url = archive.get("url")
+    if not isinstance(url, str):
+        raise ValueError(f"Show Runtime archive {platform} has no URL")
+    parsed = urllib.parse.urlparse(url)
+    parts = [urllib.parse.unquote(part) for part in parsed.path.split("/") if part]
+    expected_prefix = ["avibe-bot", "avibe", "releases", "download"]
+    if parsed.scheme != "https" or parsed.netloc != "github.com" or parts[:4] != expected_prefix:
+        raise ValueError(f"Show Runtime archive {platform} must use an immutable avibe-bot/avibe release URL")
+    if len(parts) != 6 or parts[-1] != expected_name:
+        raise ValueError(f"Show Runtime archive {platform} has an invalid release URL path")
+    if release_tag is not None and parts[4] != release_tag:
+        raise ValueError(f"Show Runtime archive {platform} does not belong to release {release_tag}")
+
+
+def _release_api_url(release_tag: str | None) -> str:
+    base = f"https://api.github.com/repos/{REPOSITORY}/releases"
+    if release_tag is None:
+        return f"{base}/latest"
+    return f"{base}/tags/{urllib.parse.quote(release_tag, safe='')}"
+
+
+def _read_json(url: str, *, opener: UrlOpener) -> dict[str, Any]:
+    content = _read_bytes(url, opener=opener, accept="application/vnd.github+json")
+    try:
+        value = json.loads(content.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise RuntimeError(f"GitHub returned invalid JSON from {url}") from exc
+    if not isinstance(value, dict):
+        raise RuntimeError(f"GitHub returned an invalid release payload from {url}")
+    return value
+
+
+def _read_bytes(url: str, *, opener: UrlOpener, accept: str = "application/octet-stream") -> bytes:
+    headers = {"Accept": accept, "User-Agent": "avibe-local-wheel-builder"}
+    token = os.environ.get("GITHUB_TOKEN")
+    if token and urllib.parse.urlparse(url).hostname in {"api.github.com", "github.com"}:
+        headers["Authorization"] = f"Bearer {token}"
+    request = urllib.request.Request(
+        url,
+        headers=headers,
+    )
+    with opener(request, timeout=30) as response:
+        return response.read()

--- a/scripts/show_runtime_manifest_asset.py
+++ b/scripts/show_runtime_manifest_asset.py
@@ -23,6 +23,7 @@ EXPECTED_PLATFORMS = {
 }
 _COMMIT_RE = re.compile(r"[0-9a-f]{40}")
 _SHA256_RE = re.compile(r"[0-9a-f]{64}")
+_NODE_REQUIREMENT_CLAUSE_RE = re.compile(r"(?:\^|>=)?\d+\.\d+\.\d+")
 UrlOpener = Callable[..., Any]
 
 
@@ -44,8 +45,14 @@ def validate_manifest_bytes(content: bytes, *, release_tag: str | None = None) -
         raise ValueError("Show Runtime manifest runtime_source must be an object")
     if runtime_source.get("repo") != RUNTIME_REPOSITORY or runtime_source.get("ref") != runtime_version:
         raise ValueError("Show Runtime manifest runtime_source must pin the declared runtime_version")
-    if not isinstance(manifest.get("minimum_node"), str) or not manifest["minimum_node"]:
-        raise ValueError("Show Runtime manifest minimum_node must be non-empty")
+    minimum_node = manifest.get("minimum_node")
+    if not isinstance(minimum_node, str):
+        raise ValueError("Show Runtime manifest minimum_node must be a string")
+    node_clauses = [clause.strip() for clause in minimum_node.split("||")]
+    if not node_clauses or any(
+        not clause or not _NODE_REQUIREMENT_CLAUSE_RE.fullmatch(clause) for clause in node_clauses
+    ):
+        raise ValueError("Show Runtime manifest minimum_node uses an unsupported Node requirement")
 
     archives = manifest.get("archives")
     if not isinstance(archives, dict) or set(archives) != EXPECTED_PLATFORMS:

--- a/tests/test_show_runtime_manifest_packaging.py
+++ b/tests/test_show_runtime_manifest_packaging.py
@@ -61,6 +61,18 @@ def test_validate_manifest_requires_the_complete_pinned_platform_set() -> None:
         validate_manifest_bytes(json.dumps(manifest).encode(), release_tag=RELEASE_TAG)
 
 
+@pytest.mark.parametrize(
+    "minimum_node",
+    ["", " ", "definitely-not-a-node-range", "^20", ">=22.12.0 <23.0.0", ">=22.12.0 ||"],
+)
+def test_validate_manifest_rejects_unsupported_node_requirements(minimum_node: str) -> None:
+    manifest = _manifest()
+    manifest["minimum_node"] = minimum_node
+
+    with pytest.raises(ValueError, match="unsupported Node requirement"):
+        validate_manifest_bytes(json.dumps(manifest).encode(), release_tag=RELEASE_TAG)
+
+
 def test_validate_manifest_file_rejects_an_uninstallable_wheel_source(tmp_path: Path) -> None:
     with pytest.raises(RuntimeError, match="Cannot build an installable Avibe artifact"):
         validate_manifest_file(tmp_path / "missing.json")

--- a/tests/test_show_runtime_manifest_packaging.py
+++ b/tests/test_show_runtime_manifest_packaging.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.show_runtime_manifest_asset import (
+    EXPECTED_PLATFORMS,
+    prepare_manifest,
+    validate_manifest_bytes,
+    validate_manifest_file,
+)
+
+
+RELEASE_TAG = "v3.0.8"
+RUNTIME_VERSION = "c2d5acc3a021cf62161919214a63a51ff313351b"
+
+
+class _Response:
+    def __init__(self, content: bytes):
+        self.content = content
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return None
+
+    def read(self) -> bytes:
+        return self.content
+
+
+def _manifest() -> dict:
+    return {
+        "schema_version": 1,
+        "runtime_version": RUNTIME_VERSION,
+        "runtime_source": {"repo": "avibe-bot/vibe-show-runtime", "ref": RUNTIME_VERSION},
+        "minimum_node": "^20.19.0 || >=22.12.0",
+        "archives": {
+            platform: {
+                "name": f"vibe-show-runtime-node-{platform}.tgz",
+                "url": (
+                    f"https://github.com/avibe-bot/avibe/releases/download/{RELEASE_TAG}/"
+                    f"vibe-show-runtime-node-{platform}.tgz"
+                ),
+                "sha256": hashlib.sha256(platform.encode()).hexdigest(),
+                "size": 100,
+            }
+            for platform in EXPECTED_PLATFORMS
+        },
+    }
+
+
+def test_validate_manifest_requires_the_complete_pinned_platform_set() -> None:
+    manifest = _manifest()
+    manifest["archives"].pop("linux-x64")
+
+    with pytest.raises(ValueError, match="platforms mismatch"):
+        validate_manifest_bytes(json.dumps(manifest).encode(), release_tag=RELEASE_TAG)
+
+
+def test_validate_manifest_file_rejects_an_uninstallable_wheel_source(tmp_path: Path) -> None:
+    with pytest.raises(RuntimeError, match="Cannot build an installable Avibe artifact"):
+        validate_manifest_file(tmp_path / "missing.json")
+
+
+def test_prepare_manifest_verifies_release_asset_digest_and_writes_output(tmp_path: Path) -> None:
+    manifest_content = (json.dumps(_manifest()) + "\n").encode()
+    asset_url = f"https://github.com/avibe-bot/avibe/releases/download/{RELEASE_TAG}/show-runtime-manifest.json"
+    release_content = json.dumps(
+        {
+            "tag_name": RELEASE_TAG,
+            "assets": [
+                {
+                    "name": "show-runtime-manifest.json",
+                    "browser_download_url": asset_url,
+                    "digest": f"sha256:{hashlib.sha256(manifest_content).hexdigest()}",
+                }
+            ],
+        }
+    ).encode()
+
+    def opener(request, timeout):
+        assert timeout == 30
+        return _Response(manifest_content if request.full_url == asset_url else release_content)
+
+    output = tmp_path / "vibe" / "show_runtime_manifest.json"
+    result = prepare_manifest(output, release_tag=RELEASE_TAG, opener=opener)
+
+    assert result["runtime_version"] == RUNTIME_VERSION
+    assert output.read_bytes() == manifest_content
+
+
+def test_prepare_manifest_rejects_a_release_asset_digest_mismatch(tmp_path: Path) -> None:
+    manifest_content = json.dumps(_manifest()).encode()
+    asset_url = f"https://github.com/avibe-bot/avibe/releases/download/{RELEASE_TAG}/show-runtime-manifest.json"
+    release_content = json.dumps(
+        {
+            "tag_name": RELEASE_TAG,
+            "assets": [
+                {
+                    "name": "show-runtime-manifest.json",
+                    "browser_download_url": asset_url,
+                    "digest": f"sha256:{'0' * 64}",
+                }
+            ],
+        }
+    ).encode()
+
+    def opener(request, timeout):
+        return _Response(manifest_content if request.full_url == asset_url else release_content)
+
+    with pytest.raises(RuntimeError, match="digest mismatch"):
+        prepare_manifest(tmp_path / "manifest.json", release_tag=RELEASE_TAG, opener=opener)

--- a/tests/test_ui_show_pages.py
+++ b/tests/test_ui_show_pages.py
@@ -4953,7 +4953,6 @@ def test_show_runtime_manager_can_disable_auto_install(tmp_path):
 
 
 def test_show_runtime_manager_installs_without_blocking_event_loop(monkeypatch, tmp_path):
-    monkeypatch.setattr("core.show_runtime._packaged_runtime_manifest_exists", lambda: True)
     manager = ShowRuntimeManager(
         workspace_root=tmp_path / "show",
         runtime_dir=tmp_path / "runtime",
@@ -4979,20 +4978,18 @@ def test_show_runtime_manager_installs_without_blocking_event_loop(monkeypatch, 
     assert calls == [fake_install]
 
 
-def test_show_runtime_manager_defaults_to_archive_when_package_manifest_is_absent(monkeypatch, tmp_path):
-    monkeypatch.setattr("core.show_runtime._packaged_runtime_manifest_exists", lambda: False)
-
+def test_show_runtime_manager_fails_closed_when_manifest_is_absent(tmp_path):
     manager = ShowRuntimeManager(
         workspace_root=tmp_path / "show",
         runtime_dir=tmp_path / "runtime",
+        manifest_path=tmp_path / "missing-manifest.json",
     )
 
-    assert manager.runtime_source == "archive"
+    assert manager.runtime_source == "manifest-cache"
+    assert manager.status()["reason"] == "runtime_manifest_missing"
 
 
-def test_show_runtime_manager_defaults_to_manifest_when_package_manifest_exists(monkeypatch, tmp_path):
-    monkeypatch.setattr("core.show_runtime._packaged_runtime_manifest_exists", lambda: True)
-
+def test_show_runtime_manager_defaults_to_manifest_provider(tmp_path):
     manager = ShowRuntimeManager(
         workspace_root=tmp_path / "show",
         runtime_dir=tmp_path / "runtime",

--- a/tests/test_ui_show_pages.py
+++ b/tests/test_ui_show_pages.py
@@ -4989,13 +4989,26 @@ def test_show_runtime_manager_fails_closed_when_manifest_is_absent(tmp_path):
     assert manager.status()["reason"] == "runtime_manifest_missing"
 
 
-def test_show_runtime_manager_defaults_to_manifest_provider(tmp_path):
+def test_show_runtime_manager_defaults_to_manifest_provider_outside_development_checkout(monkeypatch, tmp_path):
+    monkeypatch.setattr("core.show_runtime._packaged_runtime_manifest_exists", lambda: False)
+    monkeypatch.setattr("core.show_runtime._running_from_development_checkout", lambda: False)
     manager = ShowRuntimeManager(
         workspace_root=tmp_path / "show",
         runtime_dir=tmp_path / "runtime",
     )
 
     assert manager.runtime_source == "manifest-cache"
+
+
+def test_show_runtime_manager_uses_github_source_in_development_checkout_without_manifest(monkeypatch, tmp_path):
+    monkeypatch.setattr("core.show_runtime._packaged_runtime_manifest_exists", lambda: False)
+    monkeypatch.setattr("core.show_runtime._running_from_development_checkout", lambda: True)
+    manager = ShowRuntimeManager(
+        workspace_root=tmp_path / "show",
+        runtime_dir=tmp_path / "runtime",
+    )
+
+    assert manager.runtime_source == "github"
 
 
 def test_show_runtime_manager_installs_from_github_source(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary

- stop default Show Runtime resolution from silently falling back to the retired unpinned archive when a package manifest is absent
- add a local/CI preparation step that inherits the latest official release manifest and verifies GitHub's asset SHA256 plus the complete pinned runtime contract
- make Hatch reject source distributions and wheels with a missing or invalid Show Runtime manifest, and verify the manifest is present inside the built wheel

## Capability and scenarios

Changed capability: installable Avibe artifacts always carry a validated, manifest-pinned Show Runtime; malformed packages fail during build and at runtime instead of activating the legacy provider.

Scenario catalog: no existing scenario ID covers package metadata integrity. The install/upgrade artifact path remains covered by the existing CI install regressions.

## Evidence

- Unit: 227 Show Runtime/UI proxy tests passed; 15 manifest/CLI-focused tests passed
- Contract: missing-manifest wheel build fails; verified-manifest sdist and wheel builds pass; built wheel contains all six platform pins
- Scenario: existing install/upgrade and Windows wheel jobs consume the corrected CI artifact
- UI: `npm run build` passed
- Residual manual check: reinstall this exact wheel locally, restart Avibe, and reopen an old Show Page with a stale dependency link

## Known by design

- Development wheels inherit the latest stable official Avibe release's immutable Show Runtime manifest. They do not rebuild runtime archives or select an unpinned runtime branch.
