### PR TITLE
fix(delivery): resume P0 successor after stop race

### DIFF
--- a/core/session_turns.py
+++ b/core/session_turns.py
@@ -4082,6 +4082,18 @@ class SessionTurnManager:
         elif owner["state"] == "starting":
             await self._start_persisted_turn(str(owner["id"]))
 
+    @staticmethod
+    def _should_resume_durable_owner(
+        terminal_result: dict[str, Any],
+        *,
+        settled_by: str,
+    ) -> bool:
+        """Re-read ownership when terminal settlement returned a successor or Stop
+        may already have activated one in a competing terminal path."""
+        return bool(terminal_result.get("successor_turn_id")) or (
+            settled_by == SETTLED_BY_STOPPED
+        )
+
     async def _resume_post_terminal(self, session_id: str) -> None:
         with self._sqlite_engine().begin() as conn:
             reserve_write_lock(conn)
@@ -4388,9 +4400,9 @@ class SessionTurnManager:
                             await self._resume_post_terminal(session_id)
                         else:
                             await self.flush_queue(session_id)
-                    elif durable_turn_registered and (
-                        durable_terminal_result.get("successor_turn_id")
-                        or settled_by == SETTLED_BY_STOPPED
+                    elif durable_turn_registered and self._should_resume_durable_owner(
+                        durable_terminal_result,
+                        settled_by=settled_by,
                     ):
                         # Stop may persist the old Turn's terminal snapshot before
                         # releasing this runner. In that ordering the terminal CAS
@@ -5366,6 +5378,9 @@ class SessionTurnManager:
             finally:
                 sink = self.get_turn_sink(session_key)
                 settled_by = str((sink or {}).get("settled_by") or "")
+                effective_settled_by = (
+                    SETTLED_BY_STOPPED if cancelled else settled_by
+                )
                 terminal_evidence = (sink or {}).get("terminal_evidence")
                 self.pop_turn_sink(session_key, done)
                 current = self.in_flight.get(session_id)
@@ -5386,16 +5401,10 @@ class SessionTurnManager:
                             turn_token,
                             self._durable_terminal_outcome(
                                 is_error=terminal_is_error,
-                                settled_by=(
-                                    SETTLED_BY_STOPPED
-                                    if cancelled
-                                    else settled_by or None
-                                ),
+                                settled_by=effective_settled_by or None,
                             ),
                             settled_by=(
-                                SETTLED_BY_STOPPED
-                                if cancelled
-                                else settled_by or SETTLED_BY_TERMINAL_RESULT
+                                effective_settled_by or SETTLED_BY_TERMINAL_RESULT
                             ),
                             evidence_kind="agent_initiated_terminal",
                             evidence=(
@@ -5423,8 +5432,9 @@ class SessionTurnManager:
                             await self.flush_queue(session_id)
                     except Exception:
                         logger.debug("agent-initiated turn: queue resume failed", exc_info=True)
-                elif durable_turn_registered and durable_terminal_result.get(
-                    "successor_turn_id"
+                elif durable_turn_registered and self._should_resume_durable_owner(
+                    durable_terminal_result,
+                    settled_by=effective_settled_by,
                 ):
                     await self._resume_durable_session(session_id)
 

--- a/core/session_turns.py
+++ b/core/session_turns.py
@@ -2632,6 +2632,11 @@ class SessionTurnManager:
                 logger.error("durable Turn has no exact start-attempt owner: %s", turn_id)
                 return False
             attempt_id = str(turn["start_attempt_id"])
+            # The row stays ``starting`` until native acceptance, so the live
+            # projection is the launch fence for concurrent resume callers.
+            projected = self.in_flight.get(str(turn["session_id"]))
+            if projected is not None and not projected.task.done():
+                return projected.logical_turn_id == turn_id
         try:
             resolved = (
                 self._delivery_context(str(turn["session_id"]))

--- a/core/session_turns.py
+++ b/core/session_turns.py
@@ -4388,9 +4388,16 @@ class SessionTurnManager:
                             await self._resume_post_terminal(session_id)
                         else:
                             await self.flush_queue(session_id)
-                    elif durable_turn_registered and durable_terminal_result.get(
-                        "successor_turn_id"
+                    elif durable_turn_registered and (
+                        durable_terminal_result.get("successor_turn_id")
+                        or settled_by == SETTLED_BY_STOPPED
                     ):
+                        # Stop may persist the old Turn's terminal snapshot before
+                        # releasing this runner. In that ordering the terminal CAS
+                        # already activated the P0 successor, so this runner sees an
+                        # idempotent no-op instead of the successor ID. Re-read the
+                        # durable owner after every Stop; an activated successor
+                        # starts, while a stop-only hold keeps backlog blocked.
                         await self._resume_durable_session(session_id)
 
         task = asyncio.create_task(_runner(), name="internal-dispatch-async")

--- a/core/session_turns.py
+++ b/core/session_turns.py
@@ -2594,9 +2594,10 @@ class SessionTurnManager:
                     "turn.end",
                     _turn_event_payload(session_id, logical_turn_id),
                 )
-            successor_turn_id = terminal.get("successor_turn_id")
-            if successor_turn_id:
-                await self._start_persisted_turn(str(successor_turn_id))
+            successor_turn_id = await self._resume_linked_control_successor(
+                session_id,
+                str(logical_turn_id),
+            )
             return {
                 "state": "claimed" if successor_turn_id else "settled",
                 "reason": "not_active",
@@ -4082,17 +4083,31 @@ class SessionTurnManager:
         elif owner["state"] == "starting":
             await self._start_persisted_turn(str(owner["id"]))
 
-    @staticmethod
-    def _should_resume_durable_owner(
-        terminal_result: dict[str, Any],
-        *,
-        settled_by: str,
-    ) -> bool:
-        """Re-read ownership when terminal settlement returned a successor or Stop
-        may already have activated one in a competing terminal path."""
-        return bool(terminal_result.get("successor_turn_id")) or (
-            settled_by == SETTLED_BY_STOPPED
-        )
+    async def _resume_linked_control_successor(
+        self,
+        session_id: str,
+        terminal_turn_id: str,
+    ) -> str | None:
+        """Start only the exact replacement linked from a settled control Turn."""
+        with self._sqlite_engine().connect() as conn:
+            terminal = delivery_store.get_turn(conn, terminal_turn_id)
+            successor_id = str(
+                (terminal or {}).get("control_successor_turn_id") or ""
+            )
+            owner = delivery_store.active_turn(conn, session_id)
+        if (
+            terminal is None
+            or terminal["state"] != "terminal"
+            or str(terminal["session_id"]) != session_id
+            or terminal.get("control_mode") != "replace"
+            or not successor_id
+            or owner is None
+            or str(owner["id"]) != successor_id
+            or owner["state"] != "starting"
+        ):
+            return None
+        await self._start_persisted_turn(successor_id)
+        return successor_id
 
     async def _resume_post_terminal(self, session_id: str) -> None:
         with self._sqlite_engine().begin() as conn:
@@ -4400,17 +4415,15 @@ class SessionTurnManager:
                             await self._resume_post_terminal(session_id)
                         else:
                             await self.flush_queue(session_id)
-                    elif durable_turn_registered and self._should_resume_durable_owner(
-                        durable_terminal_result,
-                        settled_by=settled_by,
-                    ):
+                    elif durable_turn_registered:
                         # Stop may persist the old Turn's terminal snapshot before
                         # releasing this runner. In that ordering the terminal CAS
-                        # already activated the P0 successor, so this runner sees an
-                        # idempotent no-op instead of the successor ID. Re-read the
-                        # durable owner after every Stop; an activated successor
-                        # starts, while a stop-only hold keeps backlog blocked.
-                        await self._resume_durable_session(session_id)
+                        # already activated the linked P0 successor, so this runner
+                        # sees an idempotent no-op instead of the successor ID.
+                        await self._resume_linked_control_successor(
+                            session_id,
+                            str(logical_turn_id or ""),
+                        )
 
         task = asyncio.create_task(_runner(), name="internal-dispatch-async")
         if isinstance(session_id, str) and session_id:
@@ -5432,11 +5445,11 @@ class SessionTurnManager:
                             await self.flush_queue(session_id)
                     except Exception:
                         logger.debug("agent-initiated turn: queue resume failed", exc_info=True)
-                elif durable_turn_registered and self._should_resume_durable_owner(
-                    durable_terminal_result,
-                    settled_by=effective_settled_by,
-                ):
-                    await self._resume_durable_session(session_id)
+                elif durable_turn_registered:
+                    await self._resume_linked_control_successor(
+                        session_id,
+                        turn_token,
+                    )
 
         try:
             task = asyncio.create_task(_holder(), name="agent-initiated-turn-holder")

--- a/tests/test_session_delivery_fsm.py
+++ b/tests/test_session_delivery_fsm.py
@@ -1695,6 +1695,109 @@ def test_stopped_agent_initiated_holder_starts_already_activated_successor(
     assert started == [successor_id]
 
 
+def test_unrelated_runner_cancellation_does_not_drain_queued_work(
+    managers, monkeypatch
+) -> None:
+    manager, _restarted, engine, _engine_b, starts = managers
+
+    async def run() -> str:
+        turn_id, context = await _activate(manager)
+        dispatch_started = asyncio.Event()
+
+        async def blocked_dispatch(*_args, **_kwargs):
+            dispatch_started.set()
+            await asyncio.Event().wait()
+
+        monkeypatch.setattr(
+            "core.session_turns.dispatch_turn_with_outcome",
+            blocked_dispatch,
+        )
+        await SessionTurnManager._run(
+            manager,
+            "ses_fsm",
+            context,
+            "primary",
+            logical_turn_id=turn_id,
+            durable_preallocated=True,
+        )
+        await dispatch_started.wait()
+
+        queued = await manager.deliver(
+            DeliveryRequest(session_id="ses_fsm", priority="p3", content="backlog"),
+            context=_context(),
+        )
+        current = manager.in_flight["ses_fsm"]
+        current.task.cancel()
+        await asyncio.gather(current.task, return_exceptions=True)
+        return str(queued.delivery_id)
+
+    delivery_id = asyncio.run(run())
+    assert _row(engine, delivery_id)["state"] == "queued"
+    assert [text for _turn, text in starts].count("backlog") == 0
+
+
+def test_adapter_not_active_race_resumes_exact_linked_successor(
+    managers, monkeypatch
+) -> None:
+    manager, _restarted, engine, _engine_b, _starts = managers
+
+    async def run() -> tuple[str, list[str], str]:
+        turn_id, context = await _activate(manager)
+        holder = asyncio.create_task(asyncio.Event().wait())
+        manager.in_flight["ses_fsm"] = Turn(
+            task=holder,
+            context=context,
+            logical_turn_id=turn_id,
+        )
+
+        async def not_active(stop_context):
+            stop_context.platform_specific["stop_failure_reason"] = "not_active"
+            return False
+
+        manager.controller.command_handler.handle_stop = not_active
+        original_terminalize = manager._terminalize_durable_turn
+        competing_terminal_written = False
+
+        def terminalize_with_competing_result(candidate, outcome, **kwargs):
+            nonlocal competing_terminal_written
+            if kwargs.get("settled_by") == "adapter_not_active":
+                assert competing_terminal_written is False
+                competing_terminal_written = True
+                won = original_terminalize(
+                    candidate,
+                    "canceled",
+                    settled_by=SETTLED_BY_STOPPED,
+                    evidence_kind="competing_terminal_result",
+                )
+                assert won["successor_turn_id"]
+            return original_terminalize(candidate, outcome, **kwargs)
+
+        monkeypatch.setattr(
+            manager,
+            "_terminalize_durable_turn",
+            terminalize_with_competing_result,
+        )
+        started: list[str] = []
+
+        async def record_start(candidate: str, **_kwargs) -> bool:
+            started.append(candidate)
+            return True
+
+        monkeypatch.setattr(manager, "_start_persisted_turn", record_start)
+        admitted = await manager.deliver(
+            DeliveryRequest(session_id="ses_fsm", priority="p0", content="successor"),
+            context=_context(),
+        )
+        with engine.connect() as conn:
+            old = delivery_store.get_turn(conn, turn_id)
+        assert old is not None
+        return str(old["control_successor_turn_id"]), started, admitted.state
+
+    successor_id, started, state = asyncio.run(run())
+    assert state == "claimed"
+    assert started == [successor_id]
+
+
 def test_empty_p0_supersedes_in_flight_content_replacement(managers) -> None:
     manager, _other, engine, _engine_b, _starts = managers
 

--- a/tests/test_session_delivery_fsm.py
+++ b/tests/test_session_delivery_fsm.py
@@ -1641,6 +1641,60 @@ def test_stopped_runner_starts_successor_already_activated_by_terminal_result(
     assert started == [successor_id]
 
 
+@pytest.mark.parametrize("cancel_holder", [False, True])
+def test_stopped_agent_initiated_holder_starts_already_activated_successor(
+    managers, monkeypatch, cancel_holder
+) -> None:
+    manager, _restarted, engine, _engine_b, _starts = managers
+
+    async def run() -> tuple[str, list[str]]:
+        context = _context()
+        assert manager.register_agent_initiated_turn(context) is True
+        await asyncio.sleep(0)
+        turn_id = str(context.platform_specific["turn_token"])
+
+        admitted = await manager.deliver(
+            DeliveryRequest(session_id="ses_fsm", priority="p0", content="successor"),
+            context=_context(),
+        )
+        assert admitted.state == "waiting_terminal"
+        with engine.connect() as conn:
+            old = delivery_store.get_turn(conn, turn_id)
+        assert old is not None
+        successor_id = str(old["control_successor_turn_id"])
+
+        manager._finish_durable_terminal_result(
+            "ses_fsm",
+            turn_id,
+            is_error=False,
+            settled_by=SETTLED_BY_STOPPED,
+        )
+        with engine.connect() as conn:
+            successor = delivery_store.get_turn(conn, successor_id)
+        assert successor is not None and successor["state"] == "starting"
+
+        started: list[str] = []
+
+        async def record_start(candidate: str, **_kwargs) -> bool:
+            started.append(candidate)
+            return True
+
+        monkeypatch.setattr(manager, "_start_persisted_turn", record_start)
+        holder = manager.in_flight["ses_fsm"].task
+        sink = manager.get_turn_sink(manager.controller._get_session_key(context))
+        assert sink is not None
+        if cancel_holder:
+            holder.cancel()
+        else:
+            sink["settled_by"] = SETTLED_BY_STOPPED
+            sink["done_event"].set()
+        await asyncio.gather(holder, return_exceptions=True)
+        return successor_id, started
+
+    successor_id, started = asyncio.run(run())
+    assert started == [successor_id]
+
+
 def test_empty_p0_supersedes_in_flight_content_replacement(managers) -> None:
     manager, _other, engine, _engine_b, _starts = managers
 

--- a/tests/test_session_delivery_fsm.py
+++ b/tests/test_session_delivery_fsm.py
@@ -1798,6 +1798,95 @@ def test_adapter_not_active_race_resumes_exact_linked_successor(
     assert started == [successor_id]
 
 
+def test_adapter_not_active_runner_cleanup_starts_linked_successor_once(
+    managers, monkeypatch
+) -> None:
+    manager, _restarted, engine, _engine_b, _starts = managers
+
+    async def run() -> tuple[str, list[str]]:
+        turn_id, context = await _activate(manager)
+        dispatch_started = asyncio.Event()
+
+        async def blocked_dispatch(*_args, **_kwargs):
+            dispatch_started.set()
+            await asyncio.Event().wait()
+
+        monkeypatch.setattr(
+            "core.session_turns.dispatch_turn_with_outcome",
+            blocked_dispatch,
+        )
+        await SessionTurnManager._run(
+            manager,
+            "ses_fsm",
+            context,
+            "primary",
+            logical_turn_id=turn_id,
+            durable_preallocated=True,
+        )
+        await dispatch_started.wait()
+
+        async def not_active(stop_context):
+            stop_context.platform_specific["stop_failure_reason"] = "not_active"
+            return False
+
+        manager.controller.command_handler.handle_stop = not_active
+        original_terminalize = manager._terminalize_durable_turn
+        competing_terminal_written = False
+
+        def terminalize_with_competing_result(candidate, outcome, **kwargs):
+            nonlocal competing_terminal_written
+            if kwargs.get("settled_by") == "adapter_not_active":
+                assert competing_terminal_written is False
+                competing_terminal_written = True
+                won = original_terminalize(
+                    candidate,
+                    "canceled",
+                    settled_by=SETTLED_BY_STOPPED,
+                    evidence_kind="competing_terminal_result",
+                )
+                assert won["successor_turn_id"]
+            return original_terminalize(candidate, outcome, **kwargs)
+
+        monkeypatch.setattr(
+            manager,
+            "_terminalize_durable_turn",
+            terminalize_with_competing_result,
+        )
+        started: list[str] = []
+        successor_holder: asyncio.Task | None = None
+
+        async def record_successor_start(
+            session_id, start_context, _text, *, logical_turn_id=None, **_kwargs
+        ):
+            nonlocal successor_holder
+            assert logical_turn_id is not None
+            started.append(logical_turn_id)
+            successor_holder = asyncio.create_task(asyncio.Event().wait())
+            manager.in_flight[session_id] = Turn(
+                task=successor_holder,
+                context=start_context,
+                logical_turn_id=logical_turn_id,
+            )
+
+        manager._run = record_successor_start
+        admitted = await manager.deliver(
+            DeliveryRequest(session_id="ses_fsm", priority="p0", content="successor"),
+            context=_context(),
+        )
+        with engine.connect() as conn:
+            old = delivery_store.get_turn(conn, turn_id)
+        assert old is not None
+        successor_id = str(old["control_successor_turn_id"])
+        assert admitted.state == "claimed"
+        if successor_holder is not None:
+            successor_holder.cancel()
+            await asyncio.gather(successor_holder, return_exceptions=True)
+        return successor_id, started
+
+    successor_id, started = asyncio.run(run())
+    assert started == [successor_id]
+
+
 def test_empty_p0_supersedes_in_flight_content_replacement(managers) -> None:
     manager, _other, engine, _engine_b, _starts = managers
 

--- a/tests/test_session_delivery_fsm.py
+++ b/tests/test_session_delivery_fsm.py
@@ -18,7 +18,7 @@ from core.native_dispatch_phase import (
     DISPATCH_PHASE_PREWRITE,
     set_dispatch_phase,
 )
-from core.run_settlement import SETTLED_BY_TERMINAL_RESULT
+from core.run_settlement import SETTLED_BY_STOPPED, SETTLED_BY_TERMINAL_RESULT
 from core.session_turns import (
     SCHEDULED_PROVENANCE_KEY,
     SOURCE_SCHEDULED,
@@ -1570,6 +1570,75 @@ def test_content_p0_preserves_open_hold_and_claims_successor_once(managers) -> N
     assert delivery["state"] == "claimed"
     with engine.connect() as conn:
         assert delivery_store.queue_is_held(conn, "ses_fsm") is False
+
+
+def test_stopped_runner_starts_successor_already_activated_by_terminal_result(
+    managers, monkeypatch
+) -> None:
+    manager, _restarted, engine, _engine_b, _starts = managers
+
+    async def run() -> tuple[str, list[str]]:
+        turn_id, context = await _activate(manager)
+        dispatch_started = asyncio.Event()
+        dispatch_blocked = asyncio.Event()
+
+        async def blocked_dispatch(*_args, **_kwargs):
+            dispatch_started.set()
+            await dispatch_blocked.wait()
+            return TurnDispatchOutcome(
+                error=None,
+                settled_by=SETTLED_BY_STOPPED,
+                backend_dispatch_attempted=True,
+            )
+
+        monkeypatch.setattr(
+            "core.session_turns.dispatch_turn_with_outcome",
+            blocked_dispatch,
+        )
+        await SessionTurnManager._run(
+            manager,
+            "ses_fsm",
+            context,
+            "primary",
+            logical_turn_id=turn_id,
+            durable_preallocated=True,
+        )
+        await dispatch_started.wait()
+
+        admitted = await manager.deliver(
+            DeliveryRequest(session_id="ses_fsm", priority="p0", content="successor"),
+            context=_context(),
+        )
+        assert admitted.state == "waiting_terminal"
+        with engine.connect() as conn:
+            old = delivery_store.get_turn(conn, turn_id)
+        assert old is not None
+        successor_id = str(old["control_successor_turn_id"])
+
+        manager._finish_durable_terminal_result(
+            "ses_fsm",
+            turn_id,
+            is_error=False,
+            settled_by=SETTLED_BY_STOPPED,
+        )
+        with engine.connect() as conn:
+            successor = delivery_store.get_turn(conn, successor_id)
+        assert successor is not None and successor["state"] == "starting"
+
+        started: list[str] = []
+
+        async def record_start(candidate: str, **_kwargs) -> bool:
+            started.append(candidate)
+            return True
+
+        monkeypatch.setattr(manager, "_start_persisted_turn", record_start)
+        current = manager.in_flight["ses_fsm"]
+        dispatch_blocked.set()
+        await current.task
+        return successor_id, started
+
+    successor_id, started = asyncio.run(run())
+    assert started == [successor_id]
 
 
 def test_empty_p0_supersedes_in_flight_content_replacement(managers) -> None:


### PR DESCRIPTION
## Capability

Resume a durable content-P0 successor when Stop terminalizes the old Turn before its runner or agent-initiated holder returns.

The Stop path may activate the persisted successor inside terminal settlement. The old runner or holder then observes an idempotent terminal CAS with no returned successor ID and previously skipped the already-starting Turn. Terminal cleanup now resumes work only when the settled Turn durably names that exact replacement as its control successor and that successor is still the Session's starting owner. It no longer infers replacement ownership from a generic cancellation reason. The single persisted-start entrypoint also treats an existing live projection for that same logical Turn as an idempotent success, preventing multiple cleanup callers from dispatching it twice while its durable row still reads `starting`.

## Scenarios

- Content-P0 `--send-now` interrupts an active Turn and starts its persisted replacement exactly once without requiring process restart.
- The same ordering is closed for agent-initiated Turns, whether their holder receives a stopped sink or is canceled.
- A competing terminal result during an adapter `not_active` response still starts the exact linked replacement.
- Runner cleanup and the adapter cancellation path may both request that start, but the shared start fence dispatches it once.
- Unrelated service or event-loop cancellation does not drain queued P3 work because no control successor is linked.
- Empty Stop remains compatible with the durable hold because it has no replacement link to resume.
- Catalog scenario IDs: none; this is regression coverage for the delivery cutover merged in #1135.

## Evidence

- Unit: `tests/test_session_delivery_fsm.py` covers dispatched and agent-initiated Stop races, unrelated cancellation, the adapter `not_active` competing-terminal ordering, and duplicate start requests from runner plus adapter cleanup.
- Adjacent contract: 103 tests passed across `test_session_delivery_fsm.py` and `test_message_priority_cutover.py`; the original 98-test patch also passed inside the Incus regression environment.
- Static: Ruff, compileall, and `git diff --check` passed.
- Scenario: on exact master the replacement remained `starting` until service restart; with this patch the old Run became `canceled` and the replacement completed in the same process with durable accepted Delivery and terminal Turn records.
- Residual manual: none for this bounded race fix; the broader #1135 migration, UI, P1, and P3 regression pass was completed before opening this PR.

## Dependencies

None. Based directly on current `origin/master` after #1135.
