### PR TITLE
fix(chat): restore realtime tool-call activity

### DIFF
--- a/ui/src/lib/agentActivity.test.ts
+++ b/ui/src/lib/agentActivity.test.ts
@@ -247,9 +247,9 @@ describe('shouldShowRunningCard', () => {
 });
 
 describe('isActivityMessageType', () => {
-  it('recognizes only Message-backed assistant activity', () => {
+  it('recognizes Message-backed assistant rows and synthetic tool events', () => {
     expect(isActivityMessageType('assistant')).toBe(true);
-    expect(isActivityMessageType('tool_call')).toBe(false);
+    expect(isActivityMessageType('tool_call')).toBe(true);
     expect(isActivityMessageType('result')).toBe(false);
     expect(isActivityMessageType('user')).toBe(false);
   });

--- a/ui/src/lib/agentActivity.ts
+++ b/ui/src/lib/agentActivity.ts
@@ -150,9 +150,11 @@ export const liveActivityReducer = (
   }
 };
 
-// Process-log rows for the Activity panel — the catalog's ``activity`` render kind.
+// Process-log rows for the Activity panel. Assistant rows are real Messages and
+// therefore use the catalog. Tool calls are synthetic live envelopes backed by
+// ``agent_events``; they intentionally do not exist in the Message catalog.
 export const isActivityMessageType = (type: string): boolean =>
-  specFor(type).render === 'activity';
+  type === 'tool_call' || specFor(type).render === 'activity';
 
 // ``format_toolcall`` stores "🔧 `ToolName` `{json params}`" (one string, backend
 // formatter output). Parse the tool name (first backtick token, else first word

--- a/ui/src/lib/messageTypes.test.ts
+++ b/ui/src/lib/messageTypes.test.ts
@@ -101,9 +101,9 @@ describe('catalog-derived predicates match the communication-record boundary', (
     }
   });
 
-  it('activity-step identity (isActivityMessageType)', () => {
+  it('activity-step identity includes synthetic tool events', () => {
     for (const type of PROBE_TYPES) {
-      expect(isActivityMessageType(type), type).toBe(wasActivity(type));
+      expect(isActivityMessageType(type), type).toBe(type === 'tool_call' || wasActivity(type));
     }
   });
 


### PR DESCRIPTION
## Summary

- restore live Chat activity rendering for synthetic `tool_call` SSE envelopes
- keep `tool_call` out of the Message type catalog and the accepted communication ledger
- update the catalog-boundary test to cover the separate agent-event activity path

## Root Cause

PR #1134 correctly removed `tool_call` from the Message catalog because tool calls are stored in `agent_events`. The Chat live-event filter still derived all activity eligibility from that catalog, so it discarded the synthetic `tool_call` envelope even though the backend published it in real time. The settled activity endpoint later reloaded the same event, making tool calls appear only after the Turn finished.

## Evidence

- Unit: red-first `isActivityMessageType('tool_call')` regression, then 44 focused tests passed
- Contract: Message catalog boundary still rejects `tool_call` as a Message while the synthetic activity predicate accepts it
- Scenario: local Incus regression produced a real Codex tool call and terminal result; Activity persisted the execution group
- Full UI: 1,307 tests passed
- Static/build: changed-file ESLint, theme validation, import validation, TypeScript, and production Vite build passed

## Scenario IDs

- N/A: regression in the existing live Chat activity path

## Residual Manual Check

- The local regression instance is running this branch at `http://127.0.0.1:15130`; browser-visible timing remains available for a final manual smoke check.
