### PR TITLE
fix(settings): keep memory nav independently active

### DIFF
--- a/ui/src/components/AppShell.tsx
+++ b/ui/src/components/AppShell.tsx
@@ -28,7 +28,7 @@ import { InstallHint } from './InstallHint';
 import logoImg from '../assets/logo.png';
 import { getEnabledPlatforms, platformSupportsChannels } from '../lib/platforms';
 import { useViewportHeightVar } from '../lib/useViewportHeightVar';
-import { isAdvancedSettingsPath } from '../lib/adminNavigation';
+import { isAdvancedSettingsPath, isMemorySettingsPath } from '../lib/adminNavigation';
 
 type ShellNavItem = {
   // Optional: a parent that only groups children (no page of its own) omits `to`
@@ -333,7 +333,7 @@ export const AppShell: React.FC = () => {
       match: (p) => p.startsWith('/admin/settings/backends'),
     },
     ...(memoryNavVisible
-      ? [{ to: '/admin/settings/memory', label: t('memory.betaTitle'), icon: Brain }]
+      ? [{ to: '/admin/settings/memory', label: t('memory.betaTitle'), icon: Brain, match: isMemorySettingsPath }]
       : []),
     {
       // 高级设置: the remaining Settings tabs (messaging leads). Platforms,
@@ -342,7 +342,7 @@ export const AppShell: React.FC = () => {
       to: '/admin/settings/messaging',
       label: t('nav.advancedSettings'),
       icon: Settings,
-      match: isAdvancedSettingsPath,
+      match: (pathname) => isAdvancedSettingsPath(pathname, memoryNavVisible),
     },
   ];
 
@@ -361,7 +361,7 @@ export const AppShell: React.FC = () => {
       to: '/admin/settings/messaging',
       label: t('nav.advancedSettings'),
       icon: Settings,
-      match: isAdvancedSettingsPath,
+      match: (pathname) => isAdvancedSettingsPath(pathname, memoryNavVisible),
     },
   ];
   // The 更多 sheet shows the OVERFLOW — admin sections not already on the bottom

--- a/ui/src/components/AppShell.tsx
+++ b/ui/src/components/AppShell.tsx
@@ -28,6 +28,7 @@ import { InstallHint } from './InstallHint';
 import logoImg from '../assets/logo.png';
 import { getEnabledPlatforms, platformSupportsChannels } from '../lib/platforms';
 import { useViewportHeightVar } from '../lib/useViewportHeightVar';
+import { isAdvancedSettingsPath } from '../lib/adminNavigation';
 
 type ShellNavItem = {
   // Optional: a parent that only groups children (no page of its own) omits `to`
@@ -335,17 +336,13 @@ export const AppShell: React.FC = () => {
       ? [{ to: '/admin/settings/memory', label: t('memory.betaTitle'), icon: Brain }]
       : []),
     {
-      // 高级设置: the remaining Settings tabs (messaging leads). Platforms +
-      // backends moved out to their own sidebar destinations above, so exclude
-      // their routes from the active match.
+      // 高级设置: the remaining Settings tabs (messaging leads). Platforms,
+      // backends, models, and Memory have their own sidebar destinations, so
+      // exclude those routes from the active match.
       to: '/admin/settings/messaging',
       label: t('nav.advancedSettings'),
       icon: Settings,
-      match: (p) =>
-        p.startsWith('/admin/settings') &&
-        !p.startsWith('/admin/settings/platforms') &&
-        !p.startsWith('/admin/settings/backends') &&
-        !p.startsWith('/admin/settings/models'),
+      match: isAdvancedSettingsPath,
     },
   ];
 
@@ -364,11 +361,7 @@ export const AppShell: React.FC = () => {
       to: '/admin/settings/messaging',
       label: t('nav.advancedSettings'),
       icon: Settings,
-      match: (p) =>
-        p.startsWith('/admin/settings') &&
-        !p.startsWith('/admin/settings/platforms') &&
-        !p.startsWith('/admin/settings/backends') &&
-        !p.startsWith('/admin/settings/models'),
+      match: isAdvancedSettingsPath,
     },
   ];
   // The 更多 sheet shows the OVERFLOW — admin sections not already on the bottom

--- a/ui/src/lib/adminNavigation.test.ts
+++ b/ui/src/lib/adminNavigation.test.ts
@@ -1,22 +1,40 @@
 import { describe, expect, it } from 'vitest';
 
-import { isAdvancedSettingsPath } from './adminNavigation';
+import { isAdvancedSettingsPath, isMemorySettingsPath } from './adminNavigation';
 
 describe('isAdvancedSettingsPath', () => {
-  it('does not activate Advanced Settings on the standalone Memory page', () => {
-    expect(isAdvancedSettingsPath('/admin/settings/memory')).toBe(false);
+  it('defers to the standalone Memory item when that item is visible', () => {
+    expect(isAdvancedSettingsPath('/admin/settings/memory', true)).toBe(false);
+    expect(isAdvancedSettingsPath('/admin/settings/memory/', true)).toBe(false);
+  });
+
+  it('keeps Memory setup under Advanced Settings when the standalone item is hidden', () => {
+    expect(isAdvancedSettingsPath('/admin/settings/memory', false)).toBe(true);
+    expect(isAdvancedSettingsPath('/admin/settings/memory/', false)).toBe(true);
   });
 
   it('keeps the remaining settings pages grouped under Advanced Settings', () => {
-    expect(isAdvancedSettingsPath('/admin/settings/messaging')).toBe(true);
-    expect(isAdvancedSettingsPath('/admin/settings/service')).toBe(true);
-    expect(isAdvancedSettingsPath('/admin/settings/dependencies')).toBe(true);
-    expect(isAdvancedSettingsPath('/admin/settings/diagnostics')).toBe(true);
+    expect(isAdvancedSettingsPath('/admin/settings/messaging', true)).toBe(true);
+    expect(isAdvancedSettingsPath('/admin/settings/service', true)).toBe(true);
+    expect(isAdvancedSettingsPath('/admin/settings/dependencies', true)).toBe(true);
+    expect(isAdvancedSettingsPath('/admin/settings/diagnostics', true)).toBe(true);
   });
 
   it('leaves other standalone settings destinations inactive', () => {
-    expect(isAdvancedSettingsPath('/admin/settings/platforms')).toBe(false);
-    expect(isAdvancedSettingsPath('/admin/settings/backends')).toBe(false);
-    expect(isAdvancedSettingsPath('/admin/settings/models')).toBe(false);
+    expect(isAdvancedSettingsPath('/admin/settings/platforms', true)).toBe(false);
+    expect(isAdvancedSettingsPath('/admin/settings/backends', true)).toBe(false);
+    expect(isAdvancedSettingsPath('/admin/settings/models', true)).toBe(false);
+  });
+});
+
+describe('isMemorySettingsPath', () => {
+  it('matches the Memory route and nested path boundaries', () => {
+    expect(isMemorySettingsPath('/admin/settings/memory')).toBe(true);
+    expect(isMemorySettingsPath('/admin/settings/memory/')).toBe(true);
+    expect(isMemorySettingsPath('/admin/settings/memory/details')).toBe(true);
+  });
+
+  it('does not match a route that only shares the Memory prefix', () => {
+    expect(isMemorySettingsPath('/admin/settings/memory-tools')).toBe(false);
   });
 });

--- a/ui/src/lib/adminNavigation.test.ts
+++ b/ui/src/lib/adminNavigation.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+
+import { isAdvancedSettingsPath } from './adminNavigation';
+
+describe('isAdvancedSettingsPath', () => {
+  it('does not activate Advanced Settings on the standalone Memory page', () => {
+    expect(isAdvancedSettingsPath('/admin/settings/memory')).toBe(false);
+  });
+
+  it('keeps the remaining settings pages grouped under Advanced Settings', () => {
+    expect(isAdvancedSettingsPath('/admin/settings/messaging')).toBe(true);
+    expect(isAdvancedSettingsPath('/admin/settings/service')).toBe(true);
+    expect(isAdvancedSettingsPath('/admin/settings/dependencies')).toBe(true);
+    expect(isAdvancedSettingsPath('/admin/settings/diagnostics')).toBe(true);
+  });
+
+  it('leaves other standalone settings destinations inactive', () => {
+    expect(isAdvancedSettingsPath('/admin/settings/platforms')).toBe(false);
+    expect(isAdvancedSettingsPath('/admin/settings/backends')).toBe(false);
+    expect(isAdvancedSettingsPath('/admin/settings/models')).toBe(false);
+  });
+});

--- a/ui/src/lib/adminNavigation.ts
+++ b/ui/src/lib/adminNavigation.ts
@@ -1,6 +1,15 @@
-export const isAdvancedSettingsPath = (pathname: string): boolean =>
+const matchesRoute = (pathname: string, route: string): boolean =>
+  pathname === route || pathname.startsWith(`${route}/`);
+
+export const isMemorySettingsPath = (pathname: string): boolean =>
+  matchesRoute(pathname, '/admin/settings/memory');
+
+export const isAdvancedSettingsPath = (
+  pathname: string,
+  memoryNavVisible: boolean,
+): boolean =>
   pathname.startsWith('/admin/settings') &&
   !pathname.startsWith('/admin/settings/platforms') &&
   !pathname.startsWith('/admin/settings/backends') &&
   !pathname.startsWith('/admin/settings/models') &&
-  !pathname.startsWith('/admin/settings/memory');
+  (!memoryNavVisible || !isMemorySettingsPath(pathname));

--- a/ui/src/lib/adminNavigation.ts
+++ b/ui/src/lib/adminNavigation.ts
@@ -1,0 +1,6 @@
+export const isAdvancedSettingsPath = (pathname: string): boolean =>
+  pathname.startsWith('/admin/settings') &&
+  !pathname.startsWith('/admin/settings/platforms') &&
+  !pathname.startsWith('/admin/settings/backends') &&
+  !pathname.startsWith('/admin/settings/models') &&
+  !pathname.startsWith('/admin/settings/memory');


### PR DESCRIPTION
## Summary
- exclude the standalone Memory route from the Advanced Settings active matcher
- share the matcher between desktop and mobile navigation
- add regression coverage for standalone and grouped settings routes

## Evidence
- Unit: `cd ui && npm test -- --run src/lib/adminNavigation.test.ts`
- Contract: not applicable; no API contract changed
- Scenario: not applicable; no matching scenario catalog entry
- Build: `cd ui && npm run build`
- Residual manual check: local Vite rendering could not pass the loading shell without attaching a backend; no local `vibe` service was restarted or production state accessed
