### PR TITLE
fix(harness): interlock idle eviction with durable session owners

### DIFF
--- a/core/handlers/session_handler.py
+++ b/core/handlers/session_handler.py
@@ -1655,8 +1655,11 @@ class SessionHandler(BaseHandler):
         The in-memory ``active`` flag is not the only owner of a session. Durable
         queued or in-flight work (a nonterminal Delivery, Turn, or
         execution-bearing Run) owns the session before the flag is ever set, so
-        both passes consult ``core/session_ownership.py`` and skip a session a
-        durable owner still holds. That pin is bounded by the same stuck-active
+        the selection pass consults ``core/session_ownership.py`` and the acting
+        pass re-resolves it immediately before each teardown — tearing one
+        candidate down awaits, and admission during that await is invisible to
+        both the clock and the flag. Either way a session a durable owner still
+        holds is skipped. That pin is bounded by the same stuck-active
         threshold and never refreshes ``last_activity``: repeated queued
         followers cannot extend it, so an interlocked session cannot become
         immortal. When the ownership union cannot be resolved the whole cycle is
@@ -1702,11 +1705,6 @@ class SessionHandler(BaseHandler):
         if not expired:
             return 0
 
-        # Recompute: work admitted between the two passes must pin the session.
-        ownership = await self._resolve_session_ownership()
-        if ownership.failed:
-            return 0
-
         evicted = 0
         for composite_key, idle_for in expired:
             current_last_activity = self.session_last_activity.get(composite_key)
@@ -1721,9 +1719,21 @@ class SessionHandler(BaseHandler):
             # touched or (de)activated between the two passes.
             recheck_idle = time.monotonic() - current_last_activity
             is_active = composite_key in self.active_sessions
-            pinned = False if is_active else self._ownership_pin(ownership, composite_key)
-            if pinned and self._pin_within_bound(recheck_idle, stuck_threshold):
-                continue
+            pinned = False
+            if not is_active:
+                if recheck_idle < idle_timeout:
+                    continue
+                # Re-resolve per candidate, not once per pass: tearing down an
+                # earlier candidate awaits, and work admitted during that await
+                # touches neither ``last_activity`` nor ``active_sessions``, so a
+                # snapshot taken before the loop would classify a later runtime
+                # from state that is already stale.
+                ownership = await self._resolve_session_ownership()
+                if ownership.failed:
+                    return evicted
+                pinned = self._ownership_pin(ownership, composite_key)
+                if pinned and self._pin_within_bound(recheck_idle, stuck_threshold):
+                    continue
             if is_active:
                 if stuck_threshold is None or recheck_idle < stuck_threshold:
                     continue
@@ -1738,8 +1748,6 @@ class SessionHandler(BaseHandler):
                     idle_timeout,
                 )
             else:
-                if recheck_idle < idle_timeout:
-                    continue
                 if pinned:
                     logger.warning(
                         "Force-evicting durably-owned Claude session %s after %.1fs idle "

--- a/core/handlers/session_handler.py
+++ b/core/handlers/session_handler.py
@@ -42,6 +42,7 @@ from core.agent_session_context import resolve_context_agent_session_target
 from core.caller_context import caller_env_for_platform_payload
 from core.message_context import build_thread_session_anchor, resolve_context_thread_id
 from core.resource_governance import governor_from_controller
+from core.session_ownership import SessionOwnershipSnapshot, resolve_ownership_snapshot
 from core.services.session_fork import pending_native_fork_source
 from core.system_prompt_injection import build_system_prompt_injection, get_enabled_agents_for_prompt
 from vibe import backend_model_catalog
@@ -1597,6 +1598,36 @@ class SessionHandler(BaseHandler):
         if exc is not None:
             logger.warning("Claude receiver ended with error during cleanup: %s", exc)
 
+    async def _resolve_session_ownership(self) -> SessionOwnershipSnapshot:
+        """Read the durable owner union, failing closed for this sweep."""
+
+        return await resolve_ownership_snapshot(self.controller)
+
+    @staticmethod
+    def _ownership_pin(ownership: SessionOwnershipSnapshot, composite_key: str) -> bool:
+        """Whether a durable owner holds this runtime right now (unbounded)."""
+
+        if not ownership.pins_runtime_key(composite_key):
+            return False
+        logger.debug(
+            "Idle Claude session %s is pinned by durable owners: %s",
+            composite_key,
+            ", ".join(ownership.reasons_for_runtime_key(composite_key)) or "unknown",
+        )
+        return True
+
+    @staticmethod
+    def _pin_within_bound(idle_for: float, stuck_threshold: Optional[float]) -> bool:
+        """Whether a durable pin is still inside the inactivity bound.
+
+        The pin borrows the stuck-active threshold rather than its own clock, and
+        a new owner never refreshes ``last_activity``, so a stream of queued
+        followers cannot extend the bound. Past it the pin is spent and the
+        session is torn down through the settling path.
+        """
+
+        return stuck_threshold is None or idle_for < stuck_threshold
+
     async def evict_idle_sessions(
         self,
         idle_timeout: float,
@@ -1620,6 +1651,16 @@ class SessionHandler(BaseHandler):
         backstop. Caveat: a real turn whose single tool call runs silently for
         longer than the cap is indistinguishable from a stuck session and would
         be force-evicted — see ``DEFAULT_STUCK_ACTIVE_IDLE_EVICTION_MULTIPLIER``.
+
+        The in-memory ``active`` flag is not the only owner of a session. Durable
+        queued or in-flight work (a nonterminal Delivery, Turn, or
+        execution-bearing Run) owns the session before the flag is ever set, so
+        both passes consult ``core/session_ownership.py`` and skip a session a
+        durable owner still holds. That pin is bounded by the same stuck-active
+        threshold and never refreshes ``last_activity``: repeated queued
+        followers cannot extend it, so an interlocked session cannot become
+        immortal. When the ownership union cannot be resolved the whole cycle is
+        skipped — missing safety data is not evidence that eviction is safe.
         """
         if idle_timeout <= 0:
             return 0
@@ -1630,6 +1671,10 @@ class SessionHandler(BaseHandler):
                 idle_timeout * stuck_active_multiplier,
                 max(0.0, stuck_active_floor_seconds),
             )
+
+        ownership = await self._resolve_session_ownership()
+        if ownership.failed:
+            return 0
 
         now = time.monotonic()
         expired: list[tuple[str, float]] = []
@@ -1646,8 +1691,21 @@ class SessionHandler(BaseHandler):
                 if stuck_threshold is not None and idle_for >= stuck_threshold:
                     expired.append((composite_key, idle_for))
                 continue
-            if idle_for >= idle_timeout:
-                expired.append((composite_key, idle_for))
+            if idle_for < idle_timeout:
+                continue
+            if self._ownership_pin(ownership, composite_key) and self._pin_within_bound(
+                idle_for, stuck_threshold
+            ):
+                continue
+            expired.append((composite_key, idle_for))
+
+        if not expired:
+            return 0
+
+        # Recompute: work admitted between the two passes must pin the session.
+        ownership = await self._resolve_session_ownership()
+        if ownership.failed:
+            return 0
 
         evicted = 0
         for composite_key, idle_for in expired:
@@ -1662,7 +1720,11 @@ class SessionHandler(BaseHandler):
             # Re-derive the decision from current state: a session may have been
             # touched or (de)activated between the two passes.
             recheck_idle = time.monotonic() - current_last_activity
-            if composite_key in self.active_sessions:
+            is_active = composite_key in self.active_sessions
+            pinned = False if is_active else self._ownership_pin(ownership, composite_key)
+            if pinned and self._pin_within_bound(recheck_idle, stuck_threshold):
+                continue
+            if is_active:
                 if stuck_threshold is None or recheck_idle < stuck_threshold:
                     continue
                 logger.warning(
@@ -1678,8 +1740,24 @@ class SessionHandler(BaseHandler):
             else:
                 if recheck_idle < idle_timeout:
                     continue
-                logger.info("Evicting idle Claude session %s after %.1fs idle", composite_key, recheck_idle)
-            if composite_key in self.active_sessions:
+                if pinned:
+                    logger.warning(
+                        "Force-evicting durably-owned Claude session %s after %.1fs idle "
+                        "(>= stuck-active threshold %.1fs; owners never settled: %s)",
+                        composite_key,
+                        recheck_idle,
+                        stuck_threshold,
+                        ", ".join(ownership.reasons_for_runtime_key(composite_key)) or "unknown",
+                    )
+                else:
+                    logger.info(
+                        "Evicting idle Claude session %s after %.1fs idle", composite_key, recheck_idle
+                    )
+            # A spent pin is torn down like a stuck-active turn, not like an idle
+            # session: its durable owner is still unsettled, so the settling path
+            # must retire the pending request and turn token before the runtime
+            # goes away, or a later result could adopt them.
+            if is_active or pinned:
                 agent_service = getattr(self.controller, "agent_service", None)
                 claude_agent = getattr(agent_service, "agents", {}).get("claude") if agent_service else None
                 force_cleanup = getattr(claude_agent, "force_cleanup_stuck_active_session", None)

--- a/core/handlers/session_handler.py
+++ b/core/handlers/session_handler.py
@@ -1533,12 +1533,57 @@ class SessionHandler(BaseHandler):
         finally:
             if not cleanup_from_receiver:
                 await self._stop_receiver_task(receiver_task, composite_key)
-            await reap_duplicate_claude_resume_processes(
+            await self._reap_duplicates_sparing_replacement(
+                composite_key,
                 native_session_id,
-                keep_pid=keep_pid if cleanup_from_receiver else None,
-                cli_path=self._get_claude_cli_path_override(),
-                logger=logger,
+                own_pid=keep_pid,
+                cleanup_from_receiver=cleanup_from_receiver,
             )
+
+    async def _reap_duplicates_sparing_replacement(
+        self,
+        composite_key: str,
+        native_session_id: Optional[str],
+        *,
+        own_pid: Optional[int],
+        cleanup_from_receiver: bool,
+    ) -> None:
+        """Reap leaked ``--resume`` duplicates without killing a replacement client.
+
+        ``cleanup_session`` pops the client before it awaits anything, which is what
+        makes a Delivery admitted mid-teardown survivable: the dispatch misses, and
+        ``get_or_create_claude_session`` builds a REPLACEMENT client that resumes the
+        same native session id. But resuming the same id means the replacement runs
+        with the same ``--resume`` argument this reap matches on, and with no PID to
+        keep the reaper treats every match as a leak and SIGTERMs it together with
+        its descendants. That would turn an eviction race whose cost should be a cold
+        start into work killed mid-turn.
+
+        So a live replacement is spared. If one is present but has not published a
+        PID yet, the reap is skipped outright rather than run blind: a duplicate that
+        survives one cycle is reaped by the next cleanup, whereas a SIGTERM into live
+        work is not recoverable. The replacement outranks ``own_pid`` because the
+        client this cleanup is retiring is being torn down by design.
+        """
+
+        keep_pid = own_pid if cleanup_from_receiver else None
+        replacement = self.claude_sessions.get(composite_key)
+        if replacement is not None:
+            replacement_pid = get_claude_client_pid(replacement)
+            if not replacement_pid:
+                logger.info(
+                    "Skipping duplicate Claude resume reap for %s: a replacement client is live "
+                    "without an observable PID",
+                    composite_key,
+                )
+                return
+            keep_pid = replacement_pid
+        await reap_duplicate_claude_resume_processes(
+            native_session_id,
+            keep_pid=keep_pid,
+            cli_path=self._get_claude_cli_path_override(),
+            logger=logger,
+        )
 
     async def _disconnect_client(self, client, composite_key: str) -> None:
         try:

--- a/core/handlers/session_handler.py
+++ b/core/handlers/session_handler.py
@@ -42,7 +42,6 @@ from core.agent_session_context import resolve_context_agent_session_target
 from core.caller_context import caller_env_for_platform_payload
 from core.message_context import build_thread_session_anchor, resolve_context_thread_id
 from core.resource_governance import governor_from_controller
-from core.session_ownership import SessionOwnershipSnapshot, resolve_ownership_snapshot
 from core.services.session_fork import pending_native_fork_source
 from core.system_prompt_injection import build_system_prompt_injection, get_enabled_agents_for_prompt
 from vibe import backend_model_catalog
@@ -53,6 +52,7 @@ logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from modules.agents.model_hub import ModelHubLaunch
+    from core.session_ownership import SessionOwnershipSnapshot
 
 CLAUDE_NO_CONVERSATION_RE = re.compile(r"No conversation found with session ID:\s*(\S+)")
 CLAUDE_REMOTE_DISALLOWED_TOOLS = ["AskUserQuestion", "EnterPlanMode", "ExitPlanMode"]
@@ -1598,13 +1598,22 @@ class SessionHandler(BaseHandler):
         if exc is not None:
             logger.warning("Claude receiver ended with error during cleanup: %s", exc)
 
-    async def _resolve_session_ownership(self) -> SessionOwnershipSnapshot:
-        """Read the durable owner union, failing closed for this sweep."""
+    async def _resolve_session_ownership(self) -> "SessionOwnershipSnapshot":
+        """Read the durable owner union, failing closed for this sweep.
+
+        Imported here, not at module scope: the owner union is read out of the
+        state database, so ``core.session_ownership`` pulls ``storage`` and with
+        it ``sqlite3``. This module is on the lightweight import path that
+        ``tests/test_native_session_providers.py`` guards against exactly that,
+        and eviction is the only caller -- nothing on the light path needs it.
+        """
+
+        from core.session_ownership import resolve_ownership_snapshot
 
         return await resolve_ownership_snapshot(self.controller)
 
     @staticmethod
-    def _ownership_pin(ownership: SessionOwnershipSnapshot, composite_key: str) -> bool:
+    def _ownership_pin(ownership: "SessionOwnershipSnapshot", composite_key: str) -> bool:
         """Whether a durable owner holds this runtime right now (unbounded).
 
         Scoped to ``claude``: this runtime key is only a projection of durable work

--- a/core/handlers/session_handler.py
+++ b/core/handlers/session_handler.py
@@ -1605,14 +1605,20 @@ class SessionHandler(BaseHandler):
 
     @staticmethod
     def _ownership_pin(ownership: SessionOwnershipSnapshot, composite_key: str) -> bool:
-        """Whether a durable owner holds this runtime right now (unbounded)."""
+        """Whether a durable owner holds this runtime right now (unbounded).
 
-        if not ownership.pins_runtime_key(composite_key):
+        Scoped to ``claude``: this runtime key is only a projection of durable work
+        that runs on this backend, and Claude and Codex sessions share the default
+        workdir, so an unscoped pin would keep a stale Claude client alive for a
+        session that has moved to Codex.
+        """
+
+        if not ownership.pins_runtime_key(composite_key, backend="claude"):
             return False
         logger.debug(
             "Idle Claude session %s is pinned by durable owners: %s",
             composite_key,
-            ", ".join(ownership.reasons_for_runtime_key(composite_key)) or "unknown",
+            ", ".join(ownership.reasons_for_runtime_key(composite_key, backend="claude")) or "unknown",
         )
         return True
 
@@ -1755,7 +1761,8 @@ class SessionHandler(BaseHandler):
                         composite_key,
                         recheck_idle,
                         stuck_threshold,
-                        ", ".join(ownership.reasons_for_runtime_key(composite_key)) or "unknown",
+                        ", ".join(ownership.reasons_for_runtime_key(composite_key, backend="claude"))
+                        or "unknown",
                     )
                 else:
                     logger.info(

--- a/core/session_ownership.py
+++ b/core/session_ownership.py
@@ -97,18 +97,65 @@ def normalize_workdir(value: Any) -> str:
     return os.path.abspath(os.path.expanduser(text))
 
 
-def split_runtime_key(runtime_key: str) -> tuple[str, str]:
-    """Split ``f"{base_session_id}:{workdir}"`` into its two parts.
+def runtime_key_matches_target(runtime_key: str, anchor: str, workdir: str) -> bool:
+    """Whether a backend would compose this runtime key for ``(anchor, workdir)``.
 
-    A subagent base itself contains a colon (``{platform}_{thread}:{agent}``) and
-    a workdir is an absolute path with none, so the split is on the LAST colon —
-    the same rule ``core/services/running_agents.py`` uses.
+    Matched anchor-first rather than by splitting the key. A Claude runtime key is
+    ``f"{base_session_id}:{workdir}"`` with neither part escaped, so a workdir that
+    itself contains a colon — ``C:\\repo`` on native Windows, or a POSIX directory
+    named ``a:b`` — cannot be recovered by splitting on the last colon: that reads
+    the drive letter as part of the base and yields a workdir of ``\\repo``, so
+    both halves mismatch and the pin is lost. It is lost exactly where nothing
+    compensates, because a queued Delivery or a pre-start Turn has no observed
+    ``session_turns.runtime_key`` to fall back on.
+
+    The anchor is known from the durable side, so the remainder after it is
+    unambiguously "optional subagent suffix + workdir" however many colons the
+    workdir holds.
     """
 
-    base, sep, workdir = str(runtime_key or "").rpartition(":")
-    if not sep:
-        return str(runtime_key or ""), ""
-    return base, workdir
+    key = str(runtime_key or "")
+    if not anchor or not key:
+        return False
+    if key == anchor:
+        # No workdir component at all: the anchor alone identifies the session.
+        return True
+    prefix = f"{anchor}:"
+    if not key.startswith(prefix):
+        return False
+    remainder = key[len(prefix) :]
+    if not workdir or not remainder:
+        # Nothing to disambiguate against, so an anchor match is the only
+        # evidence there is and it has to fail closed.
+        return True
+    if normalize_workdir(remainder) == workdir:
+        return True
+    # A subagent runs under its parent session's anchor as
+    # ``{anchor}:{agent_name}:{workdir}``, so a live parent turn pins it too.
+    _agent, sep, rest = remainder.partition(":")
+    return bool(sep) and bool(rest) and normalize_workdir(rest) == workdir
+
+
+def runtime_key_workdir_candidates(runtime_key: str) -> frozenset[str]:
+    """Every suffix of ``runtime_key`` that could be its workdir component.
+
+    Used for the reverse question — "does this key sit at this workdir?" — where
+    no anchor is in hand. Since the workdir is always the key's suffix, trying
+    every colon position is exact for a membership test: the real workdir is
+    among the candidates, and an extra candidate can only widen a pin, which is
+    the direction this provider must fail in.
+    """
+
+    key = str(runtime_key or "")
+    candidates: set[str] = set()
+    index = key.find(":")
+    while index != -1:
+        suffix = key[index + 1 :]
+        if suffix:
+            candidates.add(normalize_workdir(suffix))
+        index = key.find(":", index + 1)
+    candidates.discard("")
+    return frozenset(candidates)
 
 
 @dataclass(frozen=True)
@@ -172,14 +219,8 @@ class SessionOwnershipSnapshot:
         matched: set[str] = set()
         for session_id in self._runtime_key_owners.get(runtime_key, ()):
             matched.add(session_id)
-        base, workdir = split_runtime_key(runtime_key)
-        normalized = normalize_workdir(workdir)
         for anchor, session_workdir, session_id in self.pinned_targets:
-            if session_workdir and normalized and session_workdir != normalized:
-                continue
-            # A subagent runs under its parent session's anchor with an
-            # ``:{agent_name}`` suffix, so a live parent turn pins it too.
-            if base == anchor or base.startswith(f"{anchor}:"):
+            if runtime_key_matches_target(runtime_key, anchor, session_workdir):
                 matched.add(session_id)
         return frozenset(
             session_id for session_id in matched if self.backend_owns(session_id, backend)
@@ -207,7 +248,7 @@ class SessionOwnershipSnapshot:
             if session_workdir == normalized
         }
         for runtime_key, owners in self._runtime_key_owners.items():
-            if normalize_workdir(split_runtime_key(runtime_key)[1]) != normalized:
+            if normalized not in runtime_key_workdir_candidates(runtime_key):
                 continue
             matched |= set(owners)
         return frozenset(
@@ -232,8 +273,10 @@ class SessionOwnershipSnapshot:
         Only a POSITIVE mismatch drops the pin. A caller that names no backend, or
         a session whose backends cannot be established, keeps it: an
         unattributable runtime must still fail closed. The session's backends are
-        the union of ``agent_sessions.agent_backend`` and the backend of each of
-        its nonterminal Turns, so a session caught mid-switch pins both runtimes.
+        the union of ``agent_sessions.agent_backend``, the backend of each of its
+        nonterminal Turns, and the backend each nonterminal Run captured at
+        request time — so a session caught mid-switch pins both runtimes, and work
+        queued for the backend it is switching away from keeps its own pin.
         """
 
         requested = str(backend or "").strip().lower()
@@ -352,6 +395,7 @@ class DurableSessionOwnershipProvider:
                 agent_runs.c.run_type,
                 agent_runs.c.status,
                 agent_runs.c.delivery_id,
+                agent_runs.c.agent_backend,
             )
             .where(agent_runs.c.session_id.is_not(None))
             .where(agent_runs.c.status.notin_(TERMINAL_RUN_STATUS_VALUES))
@@ -360,6 +404,17 @@ class DurableSessionOwnershipProvider:
             if not self._run_bears_execution(run_type):
                 continue
             session_id = str(row["session_id"] or "")
+            # A Run captures its own routing identity, and ``MessageHandler`` gives
+            # that explicit request identity precedence over the session's stored
+            # target when it dispatches. So a Run queued before the user switched
+            # the session's backend still lands on the backend recorded here, and
+            # that is the runtime it has to pin -- the session row's new backend
+            # alone would pin the wrong one and leave the real one evictable.
+            # Recorded before the delivery-represented skip below: the Delivery
+            # standing in for this Run dispatches to the same captured backend.
+            run_backend = str(row["agent_backend"] or "").strip().lower()
+            if run_backend:
+                backends_by_session.setdefault(session_id, set()).add(run_backend)
             delivery_id = str(row["delivery_id"] or "").strip()
             # Exact ownership already represented by a Delivery in THIS snapshot
             # needs no second binding. Because both reads share one snapshot, a
@@ -396,9 +451,8 @@ class DurableSessionOwnershipProvider:
                 runtime_key_owners.setdefault(runtime_key, set()).add(session_id)
 
         pinned_workdirs = {workdir for _anchor, workdir, _session_id in pinned_targets if workdir}
-        pinned_workdirs |= {
-            normalize_workdir(split_runtime_key(key)[1]) for key in runtime_key_owners
-        }
+        for key in runtime_key_owners:
+            pinned_workdirs |= runtime_key_workdir_candidates(key)
         pinned_workdirs.discard("")
 
         session_backends: dict[str, frozenset[str]] = {}

--- a/core/session_ownership.py
+++ b/core/session_ownership.py
@@ -1,0 +1,428 @@
+"""Durable owners of an agent session, for backend idle-eviction interlocks.
+
+A backend runtime (a Claude SDK client, a Codex app-server transport) is a
+*projection* of a session, not its owner. The durable owners are the rows shipped
+by #1134: a nonterminal ``message_deliveries`` row owns submitted input, a
+nonterminal ``session_turns`` row owns native execution, and a nonterminal
+execution-bearing ``agent_runs`` row owns Harness work that has not yet reserved
+a Delivery. Idle eviction destroys the projection, so it must not run while one
+of those owners still legitimately holds the session.
+
+Two rules shape everything here:
+
+* **Waiting is not activity.** This provider only answers "does durable work own
+  this session right now?". It never touches ``session_last_activity``, so a
+  claim, a queue wait, or a provider lookup cannot keep a stuck session alive.
+  The caller keeps the real-progress inactivity clock and the stuck-active
+  threshold as the outer bound.
+* **Missing safety data is not evidence that eviction is safe.** A binding that
+  is *positively* dangling (its session row is gone) fails open for that binding
+  alone, so a deleted target cannot pin an unrelated runtime forever. Any other
+  failure marks the whole snapshot unresolved and the caller skips the cycle.
+
+The union is read inside ONE SQLite read transaction. All four tables live in the
+same state database and the same engine, so a single ``BEGIN DEFERRED`` snapshot
+is enough: an ownership handoff committed mid-read (bare Run to reserved
+Delivery, Delivery to Turn) is either wholly before or wholly after the snapshot,
+and can never fall between two reads.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Any, Callable, Iterable, Mapping
+
+from sqlalchemy import select
+from sqlalchemy.engine import Connection, Engine
+
+from storage.background import RUN_STATUS_ALIASES, TERMINAL_RUN_STATUSES, normalize_run_status
+from storage.db import get_cached_sqlite_engine
+from storage.delivery_states import DELIVERY_STATE_MATRIX
+from storage.models import agent_runs, agent_sessions, message_deliveries, session_turns
+
+logger = logging.getLogger(__name__)
+
+# The ordering roles that still own their input. Derived from the state policy
+# rather than spelled out, so a new Delivery state inherits the right answer:
+# terminal ``accepted`` / ``retired`` history does not pin a session, while an
+# unresolved fence or a turn-owned row does.
+PINNING_DELIVERY_ROLES = frozenset({"claimable", "fence", "turn_owned"})
+TERMINAL_DELIVERY_STATES = tuple(
+    state for state, policy in DELIVERY_STATE_MATRIX.items() if policy.ordering == "terminal"
+)
+PINNING_DELIVERY_STATES = tuple(
+    state for state, policy in DELIVERY_STATE_MATRIX.items() if policy.ordering in PINNING_DELIVERY_ROLES
+)
+# ``session_turns.state`` is constrained to these four values; only the last is
+# terminal. Queried as "not terminal" so an unrecognized state pins (fail closed)
+# instead of being silently skipped.
+TERMINAL_TURN_STATES = ("terminal",)
+PINNING_TURN_STATES = ("waiting", "starting", "active")
+
+# Run-type classification is explicit and closed on purpose. A watch supervisor
+# heartbeat is an ``agent_runs`` row that stays ``running`` for the whole life of
+# the waiter; treating it as execution would pin every watched session forever.
+# Anything not deliberately classified pins, so a future run type cannot silently
+# lose its interlock.
+SUPERVISOR_RUN_TYPES = frozenset({"watch_runtime"})
+EXECUTION_BEARING_RUN_TYPES = frozenset({"agent_run", "scheduled", "watch"})
+NONTERMINAL_RUN_STATUSES = tuple(
+    sorted({raw for raw, public in RUN_STATUS_ALIASES.items() if public not in TERMINAL_RUN_STATUSES})
+)
+
+_REQUIRED_TABLES = ("message_deliveries", "session_turns", "agent_sessions", "agent_runs")
+
+
+def normalize_workdir(value: Any) -> str:
+    """Match ``agent_run_target``'s stored form so both sides compare equal."""
+
+    text = str(value or "").strip()
+    if not text:
+        return ""
+    return os.path.abspath(os.path.expanduser(text))
+
+
+def split_runtime_key(runtime_key: str) -> tuple[str, str]:
+    """Split ``f"{base_session_id}:{workdir}"`` into its two parts.
+
+    A subagent base itself contains a colon (``{platform}_{thread}:{agent}``) and
+    a workdir is an absolute path with none, so the split is on the LAST colon —
+    the same rule ``core/services/running_agents.py`` uses.
+    """
+
+    base, sep, workdir = str(runtime_key or "").rpartition(":")
+    if not sep:
+        return str(runtime_key or ""), ""
+    return base, workdir
+
+
+@dataclass(frozen=True)
+class OwnerBinding:
+    """One durable row that owns a session, kept for loggable provenance."""
+
+    kind: str  # "delivery" | "turn" | "run"
+    row_id: str
+    session_id: str
+    detail: str
+
+    def describe(self) -> str:
+        return f"{self.kind}:{self.row_id}({self.detail})"
+
+
+@dataclass(frozen=True)
+class SessionOwnershipSnapshot:
+    """One consistent read of who owns which session.
+
+    ``resolved`` is the fail-closed switch: ``False`` means the union could not be
+    established and the caller must skip its eviction cycle rather than assume
+    nothing is owned.
+    """
+
+    resolved: bool
+    bindings: tuple[OwnerBinding, ...] = ()
+    pinned_session_ids: frozenset[str] = frozenset()
+    # Runtime keys observed by the runtime itself (``session_turns.runtime_key``),
+    # bound at native start. Authoritative when present.
+    observed_runtime_keys: frozenset[str] = frozenset()
+    # ``(session_anchor, normalized workdir, session_id)`` for pinned sessions, so
+    # a session whose turn never reached native start (or has no turn at all)
+    # still resolves to the runtime key the backend composes from the same two
+    # values.
+    pinned_targets: tuple[tuple[str, str, str], ...] = ()
+    pinned_workdirs: frozenset[str] = frozenset()
+    # Bindings whose session row is positively gone: recorded, never pinned.
+    dangling_session_ids: frozenset[str] = frozenset()
+
+    @property
+    def failed(self) -> bool:
+        return not self.resolved
+
+    def pins_runtime_key(self, runtime_key: str) -> bool:
+        """True when a durable owner holds the session behind this runtime key."""
+
+        return bool(runtime_key) and bool(self.session_ids_for_runtime_key(runtime_key))
+
+    def pins_workdir(self, workdir: str) -> bool:
+        """True for a runtime keyed only by working directory (Codex transports)."""
+
+        return bool(self.pinned_workdirs) and normalize_workdir(workdir) in self.pinned_workdirs
+
+    def session_ids_for_runtime_key(self, runtime_key: str) -> frozenset[str]:
+        """Which pinned sessions this backend runtime key projects."""
+
+        if not runtime_key or not self.pinned_session_ids:
+            return frozenset()
+        matched: set[str] = set()
+        for session_id in self._runtime_key_owners.get(runtime_key, ()):
+            matched.add(session_id)
+        base, workdir = split_runtime_key(runtime_key)
+        normalized = normalize_workdir(workdir)
+        for anchor, session_workdir, session_id in self.pinned_targets:
+            if session_workdir and normalized and session_workdir != normalized:
+                continue
+            # A subagent runs under its parent session's anchor with an
+            # ``:{agent_name}`` suffix, so a live parent turn pins it too.
+            if base == anchor or base.startswith(f"{anchor}:"):
+                matched.add(session_id)
+        return frozenset(matched)
+
+    def reasons_for_runtime_key(self, runtime_key: str) -> tuple[str, ...]:
+        """Loggable provenance: which durable rows pin this runtime key."""
+
+        owners = self.session_ids_for_runtime_key(runtime_key)
+        return tuple(binding.describe() for binding in self.bindings if binding.session_id in owners)
+
+    def session_ids_for_workdir(self, workdir: str) -> frozenset[str]:
+        """Which pinned sessions a workdir-keyed runtime projects."""
+
+        normalized = normalize_workdir(workdir)
+        if not normalized:
+            return frozenset()
+        return frozenset(
+            session_id
+            for _anchor, session_workdir, session_id in self.pinned_targets
+            if session_workdir == normalized
+        )
+
+    def reasons_for_workdir(self, workdir: str) -> tuple[str, ...]:
+        """Loggable provenance for a workdir-keyed runtime."""
+
+        owners = self.session_ids_for_workdir(workdir)
+        return tuple(binding.describe() for binding in self.bindings if binding.session_id in owners)
+
+    # Derived by the provider; carried so lookups stay O(1) per runtime key.
+    _runtime_key_owners: Mapping[str, frozenset[str]] = MappingProxyType({})
+
+
+UNRESOLVED_SNAPSHOT = SessionOwnershipSnapshot(resolved=False)
+EMPTY_SNAPSHOT = SessionOwnershipSnapshot(resolved=True)
+
+
+class DurableSessionOwnershipProvider:
+    """Resolves the durable owners of every session in one read snapshot."""
+
+    def __init__(self, engine_factory: Callable[[], Engine] = get_cached_sqlite_engine) -> None:
+        self._engine_factory = engine_factory
+        self._unknown_run_types_logged: set[str] = set()
+
+    def snapshot(self) -> SessionOwnershipSnapshot:
+        try:
+            engine = self._engine_factory()
+            with engine.connect() as conn:
+                if not self._schema_available(conn):
+                    # No durable tables means no durable owner can exist. That is
+                    # positive proof, not missing data.
+                    return EMPTY_SNAPSHOT
+                conn.exec_driver_sql("BEGIN DEFERRED")
+                try:
+                    return self._read(conn)
+                finally:
+                    conn.exec_driver_sql("ROLLBACK")
+        except Exception:
+            logger.warning("Durable session ownership lookup failed; skipping eviction", exc_info=True)
+            return UNRESOLVED_SNAPSHOT
+
+    @staticmethod
+    def _schema_available(conn: Connection) -> bool:
+        """Whether every owner table exists, asked of this exact handle.
+
+        Read from ``sqlite_master`` rather than through ``Dialect.has_table``,
+        which is documented as internal and rejects anything but a real
+        ``Connection`` — the probe has to work on whatever handle it is handed.
+        """
+
+        present = {
+            str(row[0])
+            for row in conn.exec_driver_sql(
+                "SELECT name FROM sqlite_master WHERE type = 'table'"
+            ).fetchall()
+        }
+        return all(table in present for table in _REQUIRED_TABLES)
+
+    def _read(self, conn: Connection) -> SessionOwnershipSnapshot:
+        bindings: list[OwnerBinding] = []
+        nonterminal_delivery_ids: set[str] = set()
+
+        for row in conn.execute(
+            select(
+                message_deliveries.c.id,
+                message_deliveries.c.session_id,
+                message_deliveries.c.state,
+            ).where(message_deliveries.c.state.notin_(TERMINAL_DELIVERY_STATES))
+        ).mappings():
+            delivery_id = str(row["id"])
+            nonterminal_delivery_ids.add(delivery_id)
+            bindings.append(
+                OwnerBinding(
+                    kind="delivery",
+                    row_id=delivery_id,
+                    session_id=str(row["session_id"] or ""),
+                    detail=str(row["state"] or ""),
+                )
+            )
+
+        runtime_keys_by_session: dict[str, set[str]] = {}
+        for row in conn.execute(
+            select(
+                session_turns.c.id,
+                session_turns.c.session_id,
+                session_turns.c.state,
+                session_turns.c.runtime_key,
+            ).where(session_turns.c.state.notin_(TERMINAL_TURN_STATES))
+        ).mappings():
+            session_id = str(row["session_id"] or "")
+            bindings.append(
+                OwnerBinding(
+                    kind="turn",
+                    row_id=str(row["id"]),
+                    session_id=session_id,
+                    detail=str(row["state"] or ""),
+                )
+            )
+            runtime_key = str(row["runtime_key"] or "").strip()
+            if runtime_key:
+                runtime_keys_by_session.setdefault(session_id, set()).add(runtime_key)
+
+        for row in conn.execute(
+            select(
+                agent_runs.c.id,
+                agent_runs.c.session_id,
+                agent_runs.c.run_type,
+                agent_runs.c.status,
+                agent_runs.c.delivery_id,
+            )
+            .where(agent_runs.c.session_id.is_not(None))
+            .where(agent_runs.c.status.in_(NONTERMINAL_RUN_STATUSES))
+        ).mappings():
+            run_type = str(row["run_type"] or "").strip()
+            if not self._run_bears_execution(run_type):
+                continue
+            session_id = str(row["session_id"] or "")
+            delivery_id = str(row["delivery_id"] or "").strip()
+            # Exact ownership already represented by a Delivery in THIS snapshot
+            # needs no second binding. Because both reads share one snapshot, a
+            # Run can never be dropped as "represented" by a row the snapshot
+            # omitted.
+            if delivery_id and delivery_id in nonterminal_delivery_ids:
+                continue
+            bindings.append(
+                OwnerBinding(
+                    kind="run",
+                    row_id=str(row["id"]),
+                    session_id=session_id,
+                    detail=f"{run_type or 'unknown'}/{normalize_run_status(row['status'])}",
+                )
+            )
+
+        candidate_session_ids = {binding.session_id for binding in bindings if binding.session_id}
+        session_rows = self._session_rows(conn, candidate_session_ids)
+        dangling = frozenset(candidate_session_ids - set(session_rows))
+        if dangling:
+            logger.debug("Ignoring dangling session ownership bindings: %s", sorted(dangling))
+
+        pinned_session_ids = frozenset(candidate_session_ids & set(session_rows))
+        pinned_targets = tuple(
+            (str(row["session_anchor"] or ""), normalize_workdir(row["workdir"]), session_id)
+            for session_id, row in sorted(session_rows.items())
+            if session_id in pinned_session_ids and str(row["session_anchor"] or "")
+        )
+        runtime_key_owners: dict[str, set[str]] = {}
+        for session_id, keys in runtime_keys_by_session.items():
+            if session_id not in pinned_session_ids:
+                continue
+            for runtime_key in keys:
+                runtime_key_owners.setdefault(runtime_key, set()).add(session_id)
+
+        pinned_workdirs = {workdir for _anchor, workdir, _session_id in pinned_targets if workdir}
+        pinned_workdirs |= {
+            normalize_workdir(split_runtime_key(key)[1]) for key in runtime_key_owners
+        }
+        pinned_workdirs.discard("")
+
+        return SessionOwnershipSnapshot(
+            resolved=True,
+            bindings=tuple(bindings),
+            pinned_session_ids=pinned_session_ids,
+            observed_runtime_keys=frozenset(runtime_key_owners),
+            pinned_targets=pinned_targets,
+            pinned_workdirs=frozenset(pinned_workdirs),
+            dangling_session_ids=dangling,
+            _runtime_key_owners=MappingProxyType(
+                {key: frozenset(owners) for key, owners in runtime_key_owners.items()}
+            ),
+        )
+
+    def _run_bears_execution(self, run_type: str) -> bool:
+        if run_type in SUPERVISOR_RUN_TYPES:
+            return False
+        if run_type in EXECUTION_BEARING_RUN_TYPES:
+            return True
+        if run_type not in self._unknown_run_types_logged:
+            self._unknown_run_types_logged.add(run_type)
+            logger.warning(
+                "Unclassified agent_runs.run_type=%r pins its session for eviction; classify it in "
+                "core/session_ownership.py",
+                run_type,
+            )
+        return True
+
+    @staticmethod
+    def _session_rows(conn: Connection, session_ids: Iterable[str]) -> dict[str, Mapping[str, Any]]:
+        ids = [session_id for session_id in session_ids if session_id]
+        if not ids:
+            return {}
+        rows: dict[str, Mapping[str, Any]] = {}
+        # SQLite caps bound parameters per statement; chunk like storage does.
+        chunk = 400
+        for start in range(0, len(ids), chunk):
+            batch = ids[start : start + chunk]
+            for row in conn.execute(
+                select(
+                    agent_sessions.c.id,
+                    agent_sessions.c.session_anchor,
+                    agent_sessions.c.workdir,
+                ).where(agent_sessions.c.id.in_(batch))
+            ).mappings():
+                rows[str(row["id"])] = dict(row)
+        return rows
+
+
+async def resolve_ownership_snapshot(controller: Any) -> SessionOwnershipSnapshot:
+    """Read the owner union off the event loop, failing closed for the caller.
+
+    The snapshot is a synchronous SQLite read, so it runs in a worker thread: an
+    idle-sweep loop must never wait on a database lock to decide eviction.
+    """
+
+    provider = ownership_provider(controller)
+    try:
+        snapshot = await asyncio.to_thread(provider.snapshot)
+    except Exception as exc:
+        logger.warning("Durable session ownership lookup raised; skipping eviction cycle: %s", exc)
+        return UNRESOLVED_SNAPSHOT
+    if snapshot is None or snapshot.failed:
+        logger.warning("Durable session ownership unresolved; skipping eviction cycle")
+        return UNRESOLVED_SNAPSHOT
+    return snapshot
+
+
+def ownership_provider(controller: Any) -> DurableSessionOwnershipProvider:
+    """One provider per controller, created on first use.
+
+    Tests (and any future backend) can pre-set ``controller.session_ownership``
+    to inject a stub; the attribute is the single wiring point.
+    """
+
+    provider = getattr(controller, "session_ownership", None)
+    if provider is not None:
+        return provider
+    provider = DurableSessionOwnershipProvider()
+    try:
+        controller.session_ownership = provider
+    except Exception:  # pragma: no cover - exotic controller stubs
+        logger.debug("Controller rejected session_ownership attribute", exc_info=True)
+    return provider

--- a/core/session_ownership.py
+++ b/core/session_ownership.py
@@ -34,7 +34,7 @@ import logging
 import os
 from dataclasses import dataclass
 from types import MappingProxyType
-from typing import Any, Callable, Iterable, Mapping
+from typing import Any, Callable, Iterable, Mapping, Optional
 
 from sqlalchemy import select
 from sqlalchemy.engine import Connection, Engine
@@ -70,6 +70,17 @@ PINNING_TURN_STATES = ("waiting", "starting", "active")
 # lose its interlock.
 SUPERVISOR_RUN_TYPES = frozenset({"watch_runtime"})
 EXECUTION_BEARING_RUN_TYPES = frozenset({"agent_run", "scheduled", "watch"})
+# ``agent_runs.status`` has no CHECK constraint and ``normalize_run_status`` keeps
+# an unrecognized string as-is, so an imported or newly introduced in-progress
+# status (``retrying``, say) must not fall outside an allowlist of the statuses we
+# happen to know are live. Queried as "not terminal", like Deliveries and Turns,
+# so an unknown status pins its session instead of silently losing its interlock.
+TERMINAL_RUN_STATUS_VALUES = tuple(
+    sorted(
+        {raw for raw, public in RUN_STATUS_ALIASES.items() if public in TERMINAL_RUN_STATUSES}
+        | set(TERMINAL_RUN_STATUSES)
+    )
+)
 NONTERMINAL_RUN_STATUSES = tuple(
     sorted({raw for raw, public in RUN_STATUS_ALIASES.items() if public not in TERMINAL_RUN_STATUSES})
 )
@@ -141,17 +152,19 @@ class SessionOwnershipSnapshot:
     def failed(self) -> bool:
         return not self.resolved
 
-    def pins_runtime_key(self, runtime_key: str) -> bool:
+    def pins_runtime_key(self, runtime_key: str, backend: Optional[str] = None) -> bool:
         """True when a durable owner holds the session behind this runtime key."""
 
-        return bool(runtime_key) and bool(self.session_ids_for_runtime_key(runtime_key))
+        return bool(runtime_key) and bool(self.session_ids_for_runtime_key(runtime_key, backend))
 
-    def pins_workdir(self, workdir: str) -> bool:
+    def pins_workdir(self, workdir: str, backend: Optional[str] = None) -> bool:
         """True for a runtime keyed only by working directory (Codex transports)."""
 
-        return bool(self.pinned_workdirs) and normalize_workdir(workdir) in self.pinned_workdirs
+        return bool(self.session_ids_for_workdir(workdir, backend))
 
-    def session_ids_for_runtime_key(self, runtime_key: str) -> frozenset[str]:
+    def session_ids_for_runtime_key(
+        self, runtime_key: str, backend: Optional[str] = None
+    ) -> frozenset[str]:
         """Which pinned sessions this backend runtime key projects."""
 
         if not runtime_key or not self.pinned_session_ids:
@@ -168,34 +181,74 @@ class SessionOwnershipSnapshot:
             # ``:{agent_name}`` suffix, so a live parent turn pins it too.
             if base == anchor or base.startswith(f"{anchor}:"):
                 matched.add(session_id)
-        return frozenset(matched)
+        return frozenset(
+            session_id for session_id in matched if self.backend_owns(session_id, backend)
+        )
 
-    def reasons_for_runtime_key(self, runtime_key: str) -> tuple[str, ...]:
+    def reasons_for_runtime_key(
+        self, runtime_key: str, backend: Optional[str] = None
+    ) -> tuple[str, ...]:
         """Loggable provenance: which durable rows pin this runtime key."""
 
-        owners = self.session_ids_for_runtime_key(runtime_key)
+        owners = self.session_ids_for_runtime_key(runtime_key, backend)
         return tuple(binding.describe() for binding in self.bindings if binding.session_id in owners)
 
-    def session_ids_for_workdir(self, workdir: str) -> frozenset[str]:
+    def session_ids_for_workdir(
+        self, workdir: str, backend: Optional[str] = None
+    ) -> frozenset[str]:
         """Which pinned sessions a workdir-keyed runtime projects."""
 
         normalized = normalize_workdir(workdir)
         if not normalized:
             return frozenset()
-        return frozenset(
+        matched = {
             session_id
             for _anchor, session_workdir, session_id in self.pinned_targets
             if session_workdir == normalized
+        }
+        for runtime_key, owners in self._runtime_key_owners.items():
+            if normalize_workdir(split_runtime_key(runtime_key)[1]) != normalized:
+                continue
+            matched |= set(owners)
+        return frozenset(
+            session_id for session_id in matched if self.backend_owns(session_id, backend)
         )
 
-    def reasons_for_workdir(self, workdir: str) -> tuple[str, ...]:
+    def reasons_for_workdir(self, workdir: str, backend: Optional[str] = None) -> tuple[str, ...]:
         """Loggable provenance for a workdir-keyed runtime."""
 
-        owners = self.session_ids_for_workdir(workdir)
+        owners = self.session_ids_for_workdir(workdir, backend)
         return tuple(binding.describe() for binding in self.bindings if binding.session_id in owners)
+
+    def backend_owns(self, session_id: str, backend: Optional[str]) -> bool:
+        """Whether this session's durable work runs on the backend that is asking.
+
+        A runtime key alone does not identify a backend: Claude and Codex sessions
+        share the default workdir, and a Codex transport is keyed by that workdir
+        alone — so without this filter a queued Claude Delivery would pin an
+        unrelated Codex app-server (and a session switched to Codex would pin the
+        obsolete Claude runtime) until the stuck-active cap expired.
+
+        Only a POSITIVE mismatch drops the pin. A caller that names no backend, or
+        a session whose backends cannot be established, keeps it: an
+        unattributable runtime must still fail closed. The session's backends are
+        the union of ``agent_sessions.agent_backend`` and the backend of each of
+        its nonterminal Turns, so a session caught mid-switch pins both runtimes.
+        """
+
+        requested = str(backend or "").strip().lower()
+        if not requested:
+            return True
+        backends = self._session_backends.get(session_id)
+        if not backends:
+            return True
+        return requested in backends
 
     # Derived by the provider; carried so lookups stay O(1) per runtime key.
     _runtime_key_owners: Mapping[str, frozenset[str]] = MappingProxyType({})
+    # ``session_id -> {backend}``: which backend runtimes this session's durable
+    # work actually projects onto.
+    _session_backends: Mapping[str, frozenset[str]] = MappingProxyType({})
 
 
 UNRESOLVED_SNAPSHOT = SessionOwnershipSnapshot(resolved=False)
@@ -266,15 +319,20 @@ class DurableSessionOwnershipProvider:
             )
 
         runtime_keys_by_session: dict[str, set[str]] = {}
+        backends_by_session: dict[str, set[str]] = {}
         for row in conn.execute(
             select(
                 session_turns.c.id,
                 session_turns.c.session_id,
                 session_turns.c.state,
                 session_turns.c.runtime_key,
+                session_turns.c.backend,
             ).where(session_turns.c.state.notin_(TERMINAL_TURN_STATES))
         ).mappings():
             session_id = str(row["session_id"] or "")
+            turn_backend = str(row["backend"] or "").strip().lower()
+            if turn_backend:
+                backends_by_session.setdefault(session_id, set()).add(turn_backend)
             bindings.append(
                 OwnerBinding(
                     kind="turn",
@@ -296,7 +354,7 @@ class DurableSessionOwnershipProvider:
                 agent_runs.c.delivery_id,
             )
             .where(agent_runs.c.session_id.is_not(None))
-            .where(agent_runs.c.status.in_(NONTERMINAL_RUN_STATUSES))
+            .where(agent_runs.c.status.notin_(TERMINAL_RUN_STATUS_VALUES))
         ).mappings():
             run_type = str(row["run_type"] or "").strip()
             if not self._run_bears_execution(run_type):
@@ -343,6 +401,15 @@ class DurableSessionOwnershipProvider:
         }
         pinned_workdirs.discard("")
 
+        session_backends: dict[str, frozenset[str]] = {}
+        for session_id in pinned_session_ids:
+            backends = set(backends_by_session.get(session_id, ()))
+            session_backend = str(session_rows[session_id].get("agent_backend") or "").strip().lower()
+            if session_backend:
+                backends.add(session_backend)
+            if backends:
+                session_backends[session_id] = frozenset(backends)
+
         return SessionOwnershipSnapshot(
             resolved=True,
             bindings=tuple(bindings),
@@ -354,6 +421,7 @@ class DurableSessionOwnershipProvider:
             _runtime_key_owners=MappingProxyType(
                 {key: frozenset(owners) for key, owners in runtime_key_owners.items()}
             ),
+            _session_backends=MappingProxyType(session_backends),
         )
 
     def _run_bears_execution(self, run_type: str) -> bool:
@@ -385,6 +453,7 @@ class DurableSessionOwnershipProvider:
                     agent_sessions.c.id,
                     agent_sessions.c.session_anchor,
                     agent_sessions.c.workdir,
+                    agent_sessions.c.agent_backend,
                 ).where(agent_sessions.c.id.in_(batch))
             ).mappings():
                 rows[str(row["id"])] = dict(row)

--- a/core/session_ownership.py
+++ b/core/session_ownership.py
@@ -309,10 +309,25 @@ class DurableSessionOwnershipProvider:
         try:
             engine = self._engine_factory()
             with engine.connect() as conn:
-                if not self._schema_available(conn):
-                    # No durable tables means no durable owner can exist. That is
-                    # positive proof, not missing data.
+                present = self._present_owner_tables(conn)
+                if not present:
+                    # NO durable table exists, so no durable owner can exist. That
+                    # is positive proof, not missing data.
                     return EMPTY_SNAPSHOT
+                missing = sorted(set(_REQUIRED_TABLES) - present)
+                if missing:
+                    # A PARTIAL schema is the opposite case, and conflating the two
+                    # is how the interlock gets lost on a half-migrated or damaged
+                    # state DB: the tables that survived say nothing about the owners
+                    # recorded in the ones that did not, so an execution-bearing Run
+                    # in a database missing its Delivery table would read as "nothing
+                    # owns anything" and eviction would proceed.
+                    logger.warning(
+                        "Durable owner schema is only partially present (missing %s); "
+                        "skipping eviction",
+                        missing,
+                    )
+                    return UNRESOLVED_SNAPSHOT
                 conn.exec_driver_sql("BEGIN DEFERRED")
                 try:
                     return self._read(conn)
@@ -323,8 +338,12 @@ class DurableSessionOwnershipProvider:
             return UNRESOLVED_SNAPSHOT
 
     @staticmethod
-    def _schema_available(conn: Connection) -> bool:
-        """Whether every owner table exists, asked of this exact handle.
+    def _present_owner_tables(conn: Connection) -> frozenset[str]:
+        """Which owner tables exist, asked of this exact handle.
+
+        Returns the set rather than a boolean so the caller can tell an entirely
+        absent schema (positive proof that no owner exists) from a partial one
+        (missing safety data, which must fail closed).
 
         Read from ``sqlite_master`` rather than through ``Dialect.has_table``,
         which is documented as internal and rejects anything but a real
@@ -337,7 +356,7 @@ class DurableSessionOwnershipProvider:
                 "SELECT name FROM sqlite_master WHERE type = 'table'"
             ).fetchall()
         }
-        return all(table in present for table in _REQUIRED_TABLES)
+        return frozenset(table for table in _REQUIRED_TABLES if table in present)
 
     def _read(self, conn: Connection) -> SessionOwnershipSnapshot:
         bindings: list[OwnerBinding] = []

--- a/docs/plans/harness-run-reliability.md
+++ b/docs/plans/harness-run-reliability.md
@@ -172,6 +172,25 @@ it. Do not let broken bindings or fake activity create immortal sessions.
 Exit criterion: no queued work is lost or misclassified, no productive turn is
 timed out, and the interlock cannot make a stuck session immortal.
 
+### Accepted residual — admission is not serialized with teardown
+
+The final ownership read cannot be atomic with teardown, and deliberately is
+not: admission is a durable commit that takes no backend runtime lock, because
+input acceptance must never block on a backend. So a Delivery can be admitted
+after an approved candidate's last re-resolution, while its teardown is already
+awaiting. This is bounded by the last evidence bullet above rather than closed by
+a lock: teardown removes the runtime from its registry before it can be observed
+half-torn-down (Codex holds `_transport_locks[cwd]` across both the recheck and
+the stop, and `_get_or_create_transport` takes the same lock; Claude's
+`cleanup_session` pops the client synchronously before its first await), so the
+next dispatch misses, rebuilds, and resumes — a cold start, not a lost turn. The
+persisted resume state (native session id, Codex thread mapping) is what makes
+the rebuild a resume, so eviction must never clear it. Covered by HFR-150/151.
+
+Serializing admission through eviction per runtime would put a backend lock on
+the acceptance path and is out of scope here; if a future change makes a cold
+start unacceptable (a costly warm-up, say), that is the point to revisit.
+
 ## 5. PR4 — Bound and supervise shared drains
 
 ### Goal

--- a/docs/plans/harness-run-reliability.md
+++ b/docs/plans/harness-run-reliability.md
@@ -187,6 +187,20 @@ next dispatch misses, rebuilds, and resumes — a cold start, not a lost turn. T
 persisted resume state (native session id, Codex thread mapping) is what makes
 the rebuild a resume, so eviction must never clear it. Covered by HFR-150/151.
 
+"A cold start, not a lost turn" is a property of the whole teardown path, not
+just of popping the registry entry, and PR3's fifth review head found the place
+it did not yet hold. On Claude, the *same* thing that makes the rebuild a resume
+— the replacement client running with the same `--resume <native_session_id>` —
+also makes it indistinguishable from a leaked duplicate to the reaper
+`cleanup_session` runs in its `finally`, and the idle-eviction path passed
+`keep_pid=None`, which SIGTERMs every match plus its descendants. The losing
+dispatch's replacement could therefore be killed mid-turn. So any teardown step
+that acts on the *native session id* rather than on the object being retired has
+to be written to spare a replacement: the reap now keeps a live replacement's
+PID, and skips entirely when a replacement exists but has not published one yet,
+since a duplicate surviving one cycle is reaped by the next while a SIGTERM into
+live work is not recoverable. Covered by HFR-431.
+
 Serializing admission through eviction per runtime would put a backend lock on
 the acceptance path and is out of scope here; if a future change makes a cold
 start unacceptable (a costly warm-up, say), that is the point to revisit.
@@ -446,6 +460,11 @@ Scenario ranges reserved by the original plan remain available on current
 Check the catalog again immediately before coding. If a range has been occupied,
 allocate a fresh contiguous block above the highest merged ID; never reuse a
 closed branch's overflow table.
+
+PR3 filled `HFR-130…154` and then needed one more ID for a late review finding,
+so by that rule it overflowed to `HFR-431` (the catalog's highest allocated ID
+was 430). PR4 and PR7 keep their reserved ranges intact; the next overflow starts
+at `HFR-432`.
 
 ## 8. Validation and non-goals
 

--- a/modules/agents/codex/agent.py
+++ b/modules/agents/codex/agent.py
@@ -852,14 +852,19 @@ class CodexAgent(BaseAgent):
         return idle_for >= idle_timeout
 
     def _durably_owned_cwd(self, ownership: SessionOwnershipSnapshot, cwd: str) -> bool:
-        """Whether durable rows still own a session rooted at this cwd."""
+        """Whether durable Codex work still owns a session rooted at this cwd.
 
-        if not ownership.pins_workdir(cwd):
+        Scoped to this backend: a transport is keyed by working directory alone and
+        Claude/OpenCode sessions share the default one, so an unscoped pin would
+        hold an app-server open for work that will never be dispatched into it.
+        """
+
+        if not ownership.pins_workdir(cwd, backend="codex"):
             return False
         logger.debug(
             "Codex transport for cwd=%s is pinned by durable owners: %s",
             cwd,
-            ", ".join(ownership.reasons_for_workdir(cwd)) or "unknown",
+            ", ".join(ownership.reasons_for_workdir(cwd, backend="codex")) or "unknown",
         )
         return True
 

--- a/modules/agents/codex/agent.py
+++ b/modules/agents/codex/agent.py
@@ -34,6 +34,7 @@ from core.system_prompt_injection import (
     get_enabled_agents_for_prompt,
 )
 from core.resource_governance import governor_from_controller
+from core.session_ownership import SessionOwnershipSnapshot, resolve_ownership_snapshot
 from modules.agents.base import AgentRequest, BaseAgent
 from modules.agents.subagent_router import SubagentDefinition, load_codex_subagent
 from modules.agents.codex.event_handler import CodexEventHandler
@@ -623,7 +624,15 @@ class CodexAgent(BaseAgent):
         logger.info("Stopped Codex runtime across %d transport(s)", len(transports))
 
     async def evict_idle_transports(self, idle_timeout: float) -> int:
-        """Stop idle Codex transports and invalidate stale thread mappings."""
+        """Stop idle Codex transports and invalidate stale thread mappings.
+
+        A transport is keyed by working directory, so the durable-ownership
+        interlock is consulted per cwd: while a nonterminal Delivery, Turn, or
+        execution-bearing Run still owns a session rooted there, the transport
+        stays up even though no in-memory turn is active yet. The pin is bounded
+        by the same stuck-active cap as an active turn, and an unresolved owner
+        union aborts the cycle rather than guessing.
+        """
         if idle_timeout <= 0:
             return 0
         if not hasattr(self, "_transport_last_activity"):
@@ -640,6 +649,10 @@ class CodexAgent(BaseAgent):
         # has been idle past this cap, force-evict it despite the active turn.
         stuck_active_cap = self._stuck_active_idle_eviction_cap(idle_timeout)
 
+        ownership = await resolve_ownership_snapshot(getattr(self, "controller", None))
+        if ownership.failed:
+            return 0
+
         now = time.monotonic()
         evicted = 0
 
@@ -655,6 +668,7 @@ class CodexAgent(BaseAgent):
                 idle_for=idle_for,
                 idle_timeout=idle_timeout,
                 stuck_active_cap=stuck_active_cap,
+                durably_owned=self._durably_owned_cwd(ownership, cwd),
             ):
                 continue
 
@@ -670,11 +684,19 @@ class CodexAgent(BaseAgent):
                 # active-turn flag) may have changed between the two passes.
                 idle_for = time.monotonic() - current_last_activity
                 has_active = self._has_active_turns_for_cwd(cwd)
+                # Re-read the durable owner union too: work accepted between the
+                # two passes owns this session and must defeat the eviction that
+                # the first pass already approved.
+                recheck_ownership = await resolve_ownership_snapshot(getattr(self, "controller", None))
+                if recheck_ownership.failed:
+                    return evicted
+                durably_owned = self._durably_owned_cwd(recheck_ownership, cwd)
                 if not self._is_transport_evictable(
                     has_active=has_active,
                     idle_for=idle_for,
                     idle_timeout=idle_timeout,
                     stuck_active_cap=stuck_active_cap,
+                    durably_owned=durably_owned,
                 ):
                     continue
 
@@ -685,6 +707,15 @@ class CodexAgent(BaseAgent):
                         cwd,
                         idle_for,
                         stuck_active_cap,
+                    )
+                elif durably_owned:
+                    logger.warning(
+                        "Force-evicting durably-owned Codex transport for cwd=%s after %.1fs idle "
+                        "(owners exceeded the stuck-active cap of %.1fs without settling: %s)",
+                        cwd,
+                        idle_for,
+                        stuck_active_cap,
+                        ", ".join(recheck_ownership.reasons_for_workdir(cwd)) or "unknown",
                     )
                 else:
                     logger.info("Evicting idle Codex transport for cwd=%s after %.1fs idle", cwd, idle_for)
@@ -799,21 +830,38 @@ class CodexAgent(BaseAgent):
         idle_for: float,
         idle_timeout: float,
         stuck_active_cap: Optional[float],
+        durably_owned: bool = False,
     ) -> bool:
         """Decide whether an idle transport is eligible for eviction.
 
-        Pure decision (no lookups), so callers evaluate the active-turn flag
-        exactly once. An idle transport with no active turn is evictable once it
-        crosses the normal ``idle_timeout``. A transport with an active turn is
-        normally vetoed, but is force-evictable once it crosses
-        ``stuck_active_cap`` (the absolute-time backstop) — the only path that
-        reaps a wedged app-server whose ``turn/completed`` never arrived.
+        Pure decision (no lookups), so callers evaluate the active-turn flag and
+        the durable-ownership flag exactly once. An idle transport that nothing
+        owns is evictable once it crosses the normal ``idle_timeout``.
+
+        An active in-memory turn and a durable owner are the same kind of veto:
+        both mean real work holds the transport, and both are bounded by
+        ``stuck_active_cap`` (the absolute-time backstop) so a wedged app-server
+        or a permanently unsettled owner still gets reaped instead of leaking the
+        process until restart. ``durably_owned`` defaults to False so a caller
+        that has no owner union to consult keeps the pre-interlock behavior.
         """
-        if has_active:
+        if has_active or durably_owned:
             if stuck_active_cap is None:
                 return False
             return idle_for >= stuck_active_cap
         return idle_for >= idle_timeout
+
+    def _durably_owned_cwd(self, ownership: SessionOwnershipSnapshot, cwd: str) -> bool:
+        """Whether durable rows still own a session rooted at this cwd."""
+
+        if not ownership.pins_workdir(cwd):
+            return False
+        logger.debug(
+            "Codex transport for cwd=%s is pinned by durable owners: %s",
+            cwd,
+            ", ".join(ownership.reasons_for_workdir(cwd)) or "unknown",
+        )
+        return True
 
     # ------------------------------------------------------------------
     # Transport management

--- a/tests/scenarios/INDEX.yaml
+++ b/tests/scenarios/INDEX.yaml
@@ -39,6 +39,7 @@ capabilities:
       - tests/test_agent_run_target.py
       - tests/test_watches.py
       - tests/test_cli_watch_command.py
+      - tests/test_session_eviction_interlock.py
   - id: auth_setup
     name: IM-driven backend auth recovery
     status: active

--- a/tests/scenarios/harness_failure_recovery/catalog.yaml
+++ b/tests/scenarios/harness_failure_recovery/catalog.yaml
@@ -2613,6 +2613,39 @@ scenarios:
     # disconnect commits the follower -- and asserts the teardown and the commit
     # both really happened, so it cannot pass by failing to race.
     test: tests/test_session_eviction_interlock.py::test_ownership_admitted_during_an_earlier_teardown_vetoes_the_later_eviction
+  - id: HFR-148
+    name: a durable pin does not cross backends at a shared working directory
+    status: covered
+    kind: safety
+    layer: contract
+    backend: shared
+    # Found by review on PR #1150's second head. Both eviction keyspaces collapse
+    # across backends at the default working directory: a Codex transport is keyed by
+    # cwd alone, and a Claude runtime key is anchor:workdir. An unscoped pin therefore
+    # lets one backend's queue hold another backend's runtime open forever -- the exact
+    # inverse of the leak this PR prevents, and unbounded because the neighbour's work
+    # will never be dispatched there to settle it. FIX: the snapshot retains each
+    # session's backends (agent_sessions.agent_backend UNION its nonterminal Turns'
+    # backend, so a session caught mid-switch pins both) and only a POSITIVE mismatch
+    # drops the pin -- a caller naming no backend, or a session whose backend cannot be
+    # established, still pins. Both directions are covered, plus the positive case that
+    # the matching backend does pin.
+    test: tests/test_session_eviction_interlock.py::test_a_pin_does_not_cross_backends_at_a_shared_workdir
+  - id: HFR-149
+    name: an unrecognized Run status still pins its session
+    status: covered
+    kind: safety
+    layer: contract
+    backend: claude
+    # Found by review on PR #1150's second head, and the same fail-closed rule the
+    # Delivery and Turn queries already followed. agent_runs.status has no CHECK
+    # constraint and normalize_run_status passes an unrecognized string through
+    # untouched, so a status introduced later -- or written by another producer --
+    # reaches this query. Selecting the known in-progress statuses would silently drop
+    # that Run's interlock, which is the one failure mode the provider exists to
+    # prevent. FIX: query NOT IN the terminal statuses (raw aliases plus public names),
+    # so an unknown status pins instead of vanishing.
+    test: tests/test_session_eviction_interlock.py::test_an_unrecognized_run_status_still_pins
   - id: HFR-240
     name: the backend-wide clear does not delete a superseded row
     status: covered

--- a/tests/scenarios/harness_failure_recovery/catalog.yaml
+++ b/tests/scenarios/harness_failure_recovery/catalog.yaml
@@ -2646,6 +2646,40 @@ scenarios:
     # prevent. FIX: query NOT IN the terminal statuses (raw aliases plus public names),
     # so an unknown status pins instead of vanishing.
     test: tests/test_session_eviction_interlock.py::test_an_unrecognized_run_status_still_pins
+  - id: HFR-150
+    name: a Codex Delivery admitted while the transport stops costs a restart, not the work
+    status: covered
+    kind: recovery
+    layer: contract
+    backend: codex
+    # Found by review on PR #1150's third head. The final ownership read cannot be
+    # atomic with teardown, and deliberately is not: admission is a durable commit
+    # that takes no runtime lock, because input acceptance must never block on a
+    # backend. So a Delivery can land after the in-lock recheck approved the eviction,
+    # while transport.stop() is still awaiting. The plan's governing requirement for
+    # that window is loss-free resumption, not atomicity, so this encodes it: the
+    # eviction holds _transport_locks[cwd] across BOTH the recheck and the stop and
+    # _get_or_create_transport takes the same lock, so the dispatch cannot observe a
+    # half-torn-down transport -- it misses, builds a fresh app-server, and resumes
+    # via the persisted thread mapping, which eviction must therefore never clear.
+    # Asserts the queued row survives untouched, no turn was invented, no stale handle
+    # or activity entry is left behind, and the lock is free for the rebuild.
+    test: tests/test_session_eviction_interlock.py::test_codex_admission_during_teardown_costs_a_restart_not_the_work
+  - id: HFR-151
+    name: a Claude Delivery admitted during its own candidate's disconnect is not lost
+    status: covered
+    kind: recovery
+    layer: contract
+    backend: claude
+    # The Claude half of HFR-150, and the irreducible remainder of HFR-147: there the
+    # admission is visible in time to veto a LATER candidate, here it lands during this
+    # candidate's own disconnect, after its own re-resolution. Survivable because
+    # cleanup_session pops the client out of claude_sessions synchronously, before it
+    # awaits anything, so a dispatch arriving afterwards never sees the disconnecting
+    # client -- it misses and get_or_create_claude_session builds a fresh one that
+    # resumes the same native session id. Asserts the queued row is untouched, no turn
+    # was created, and neither the client nor its activity clock is left behind.
+    test: tests/test_session_eviction_interlock.py::test_claude_admission_during_teardown_costs_a_restart_not_the_work
   - id: HFR-240
     name: the backend-wide clear does not delete a superseded row
     status: covered

--- a/tests/scenarios/harness_failure_recovery/catalog.yaml
+++ b/tests/scenarios/harness_failure_recovery/catalog.yaml
@@ -2716,6 +2716,23 @@ scenarios:
     # the per-session backend union, recorded before the delivery-represented skip
     # because the Delivery standing in for a Run dispatches to the same backend.
     test: tests/test_session_eviction_interlock.py::test_a_run_pins_the_backend_it_captured_not_the_switched_session_backend
+  - id: HFR-154
+    name: a partially migrated owner schema fails closed
+    status: covered
+    kind: safety
+    layer: contract
+    backend: shared
+    # Found by review on PR #1150's fifth head. The provider treated "an owner table
+    # is missing" as a single case and returned a RESOLVED empty snapshot for it,
+    # which conflates two opposite situations. An entirely absent schema is positive
+    # proof that no durable owner can exist. A PARTIAL schema -- half-migrated,
+    # damaged, or mid-upgrade -- is missing safety data: the tables that survived say
+    # nothing about the owners recorded in the ones that did not, so an
+    # execution-bearing Run in a database that lost its Delivery table read as
+    # "nothing owns anything" and eviction proceeded. Fixed by returning WHICH owner
+    # tables are present: none -> empty snapshot, some -> unresolved, which skips the
+    # cycle and names the missing tables in a warning.
+    test: tests/test_session_eviction_interlock.py::test_a_partially_migrated_owner_schema_fails_closed
   - id: HFR-240
     name: the backend-wide clear does not delete a superseded row
     status: covered
@@ -3761,6 +3778,26 @@ scenarios:
     # A refused Stop leaves both owners intact, and an idle backlog starts directly
     # without a post-submit call racing and interrupting the newly started head.
     test: tests/test_internal_server.py::test_agent_run_send_now_interrupts_then_dispatches_the_fifo_head
+  - id: HFR-431
+    name: the duplicate Claude resume reap spares a replacement client
+    status: covered
+    kind: safety
+    layer: contract
+    backend: claude
+    # Found by review on PR #1150's fifth head. PR3's reserved block ends at HFR-154,
+    # so this takes a fresh ID above the highest allocated one instead of borrowing
+    # PR4's range. What makes a Delivery admitted mid-teardown survivable is that
+    # cleanup_session pops the client before it awaits: the dispatch misses and
+    # get_or_create_claude_session builds a REPLACEMENT client resuming the same
+    # native session id. But resuming the same id means the replacement carries the
+    # same --resume argument the duplicate reaper matches on, and the idle-eviction
+    # path passed keep_pid=None, whose branch SIGTERMs every match plus its
+    # descendants. That turned the documented cold-start cost into work killed
+    # mid-turn. Fixed by sparing a live replacement's PID, and skipping the reap
+    # entirely when a replacement is live but has not published a PID yet -- a
+    # duplicate surviving one cycle is reaped by the next, a SIGTERM into live work
+    # is not recoverable. With no replacement, leak reaping is unchanged.
+    test: tests/test_session_eviction_interlock.py::test_the_duplicate_reap_spares_a_replacement_claude_client
 manual_evidence:
   - local Incus backend process death after prompt acceptance
   - local Incus controller restart with persisted queued successor

--- a/tests/scenarios/harness_failure_recovery/catalog.yaml
+++ b/tests/scenarios/harness_failure_recovery/catalog.yaml
@@ -2680,6 +2680,42 @@ scenarios:
     # resumes the same native session id. Asserts the queued row is untouched, no turn
     # was created, and neither the client nor its activity clock is left behind.
     test: tests/test_session_eviction_interlock.py::test_claude_admission_during_teardown_costs_a_restart_not_the_work
+  - id: HFR-152
+    name: a workdir containing a colon still pins its Claude runtime
+    status: covered
+    kind: safety
+    layer: contract
+    backend: claude
+    # Found by review on PR #1150's fourth head. The Claude runtime key is
+    # f"{base_session_id}:{workdir}" with neither part escaped, so recovering the
+    # workdir by splitting on the LAST colon is wrong for any workdir containing one
+    # -- C:\repo on native Windows, or a POSIX directory named proj:v2. The split
+    # reads part of the path as the base and the tail as the whole workdir, so both
+    # halves mismatch the durable target and the pin disappears. It disappears
+    # exactly where nothing compensates, because a queued Delivery or a pre-start
+    # Turn has no observed session_turns.runtime_key to match exactly. Fixed by
+    # matching anchor-first (runtime_key_matches_target): the anchor is known from
+    # the durable side, so the remainder after it is unambiguous however many colons
+    # the workdir holds. The reverse question -- "is this key at this workdir?" --
+    # tries every colon position, which is exact for a membership test and can only
+    # widen a pin.
+    test: tests/test_session_eviction_interlock.py::test_a_workdir_containing_a_colon_still_pins_its_claude_runtime
+  - id: HFR-153
+    name: a Run pins the backend it captured, not the session's switched backend
+    status: covered
+    kind: safety
+    layer: contract
+    backend: shared
+    # Found by review on PR #1150's fourth head, and the remainder of HFR-148's
+    # backend scoping. A Run captures its own routing identity (agent_runs.agent_backend)
+    # and MessageHandler gives that explicit request identity precedence over the
+    # session's stored target when it dispatches. So a Run still queued when the user
+    # switches the session's backend lands on the backend it captured, and attributing
+    # it only through the session row's NEW backend pins the wrong runtime while
+    # leaving the real one evictable. Fixed by folding the Run's captured backend into
+    # the per-session backend union, recorded before the delivery-represented skip
+    # because the Delivery standing in for a Run dispatches to the same backend.
+    test: tests/test_session_eviction_interlock.py::test_a_run_pins_the_backend_it_captured_not_the_switched_session_backend
   - id: HFR-240
     name: the backend-wide clear does not delete a superseded row
     status: covered

--- a/tests/scenarios/harness_failure_recovery/catalog.yaml
+++ b/tests/scenarios/harness_failure_recovery/catalog.yaml
@@ -2365,6 +2365,234 @@ scenarios:
     layer: scenario
     backend: shared
     test: tests/test_scheduled_tasks.py::test_service_stop_preserves_non_durable_user_stop_cause
+  - id: HFR-130
+    name: durable queued input pins its own idle backend runtime and no other
+    status: covered
+    kind: safety
+    layer: contract
+    backend: claude
+    # The interlock's root scenario. Idle eviction is keyed by an in-memory runtime key
+    # and gated by an in-memory activity clock plus the `active` flag, which only exists
+    # once a turn has reached native start. Every durable owner predates that flag, so a
+    # `queued` Delivery -- input already accepted from the user, not yet dispatched --
+    # sits behind a runtime that looks perfectly idle. Eviction then destroys the SDK
+    # client the row is about to be dispatched into.
+    # FIX: one provider (core/session_ownership.py) resolves the current durable owners
+    # of every session from ONE SQLite read snapshot, and both passes of
+    # evict_idle_sessions consult it. The join between the two keyspaces is the
+    # authoritative session_turns.runtime_key where a turn reached native start, plus
+    # composition from (session_anchor, normalized workdir) for the window where it has
+    # not -- otherwise the pin would be missing exactly when it matters most.
+    # The regression asserts BOTH halves in one sweep: the owned runtime survives and
+    # an unrelated idle runtime sharing the same workdir is still evicted, so a pin
+    # cannot silently immunize the whole process. It also asserts the pin did not
+    # refresh session_last_activity -- waiting is not activity.
+    test: tests/test_session_eviction_interlock.py::test_queued_delivery_pins_its_own_idle_claude_session
+  - id: HFR-131
+    name: the eviction pin is read from the Delivery state policy, not a hard-coded list
+    status: covered
+    kind: safety
+    layer: contract
+    backend: shared
+    # Which Delivery states own their input is already decided, once, by
+    # DELIVERY_STATE_MATRIX: `claimable`, `fence`, and `turn_owned` rows still own it,
+    # `terminal` rows are history. Restating that list inside the eviction path is how
+    # the two drift -- a new state would inherit whichever answer the copy happened to
+    # spell out. The provider derives the pinning set from the matrix and queries
+    # "NOT IN terminal", so an unrecognized state pins (fail closed) instead of being
+    # silently skipped. Asserted state by state across all nine, including that
+    # accepted/retired history cannot make a session immortal. Each row is seeded in
+    # its real constraint-satisfying shape (turn membership, steer attempt,
+    # materialized Message) so no assertion rests on a state production cannot produce.
+    test: tests/test_session_eviction_interlock.py::test_delivery_pin_follows_the_state_policy
+  - id: HFR-132
+    name: a Turn with no runtime_key yet still pins the runtime it is starting into
+    status: covered
+    kind: safety
+    layer: contract
+    backend: claude
+    # runtime_key is bound at bind_native_start, so a `waiting` or `starting` Turn
+    # carries NULL -- the same window in which the in-memory `active` flag is unset.
+    # A join that required the authoritative column would therefore fail open in
+    # precisely the pre-start window this PR exists to protect. Composition from
+    # (session_anchor, normalized workdir) covers it; the workdir is normalized the way
+    # agent_run_target stores it so both sides compare equal.
+    test: tests/test_session_eviction_interlock.py::test_nonterminal_turn_pins_through_anchor_and_workdir
+  - id: HFR-133
+    name: a watch supervisor heartbeat Run does not pin its session
+    status: covered
+    kind: safety
+    layer: contract
+    backend: shared
+    # The opposite failure from HFR-130, and the reason run types are classified rather
+    # than treated uniformly: a `watch_runtime` Run stays `running` for the entire life
+    # of the waiter -- hours or days. Counting it as execution would make every watched
+    # session permanently unevictable and leak a backend process per watch until
+    # restart. Only supervisor types are exempted, by name.
+    test: tests/test_session_eviction_interlock.py::test_watch_runtime_heartbeat_run_does_not_pin
+  - id: HFR-134
+    name: execution-bearing Runs pin, and an unclassified run type fails closed
+    status: covered
+    kind: safety
+    layer: contract
+    backend: shared
+    # The bare-Run window is durable ownership with no Delivery yet: a Run is created,
+    # resolves its target session, and only then reserves one. In between, the Run row
+    # is the only thing pointing at the session. A Run whose reserved Delivery is
+    # already in the same snapshot is not counted twice -- and because both reads share
+    # ONE snapshot, a Run can never be dropped as "represented" by a row the snapshot
+    # omitted. An unrecognized run_type pins and logs once, so a future run type cannot
+    # silently lose its interlock. Terminal Runs own nothing:
+    # tests/test_session_eviction_interlock.py::test_terminal_run_history_does_not_pin
+    test: tests/test_session_eviction_interlock.py::test_execution_bearing_and_unclassified_runs_pin
+  - id: HFR-135
+    name: work admitted between the two eviction passes defeats the decided eviction
+    status: covered
+    kind: safety
+    layer: contract
+    backend: claude
+    # The losing race. evict_idle_sessions decides in one pass and acts in another, and
+    # the second pass already re-derives activity and the active flag from current
+    # state -- durable ownership belongs in that same recheck. Input admitted in the
+    # window is durable and unstarted, so a first-pass verdict is stale by the time it
+    # is executed. The provider is re-read, not cached across the passes.
+    test: tests/test_session_eviction_interlock.py::test_work_admitted_between_the_two_passes_wins
+  - id: HFR-136
+    name: an unresolved owner union skips the whole eviction cycle
+    status: covered
+    kind: safety
+    layer: contract
+    backend: claude
+    # Missing safety data is not evidence that eviction is safe. A provider-wide failure
+    # -- an unreadable DB, a raising lookup -- says nothing about who owns what, so no
+    # session is evicted, including ones no owner would have pinned. The cost is one
+    # deferred sweep; the alternative is tearing down a runtime mid-dispatch on the
+    # strength of a failed read. Both failure shapes are pinned: an explicitly
+    # unresolved snapshot and a raising provider.
+    test: tests/test_session_eviction_interlock.py::test_unresolved_ownership_skips_the_whole_cycle
+  - id: HFR-137
+    name: a positively-dangling binding fails open for itself alone
+    status: covered
+    kind: safety
+    layer: contract
+    backend: claude
+    # The one place fail-closed is wrong. HFR-136's rule applies to a lookup that could
+    # not read; a binding whose session row is positively GONE is a read that succeeded,
+    # and treating it as unknown would veto eviction of an unrelated runtime forever.
+    # The two halves are asserted in one sweep -- the dangling row's runtime is evicted,
+    # the live owner's is not -- so neither rule can be widened into the other's
+    # territory. The dangling row is built by suspending foreign keys for one write,
+    # because enforcement is ON for every pooled connection.
+    test: tests/test_session_eviction_interlock.py::test_a_dangling_binding_fails_open_for_itself_alone
+  - id: HFR-138
+    name: the pin is bounded by the inactivity clock and settles through the teardown path
+    status: covered
+    kind: safety
+    layer: contract
+    backend: claude
+    # An interlock with no bound is a leak: an owner that never settles would pin its
+    # runtime until service restart. The pin borrows the EXISTING inactivity clock and
+    # stuck-active threshold rather than adding a second one, and a new owner never
+    # restarts that clock -- so a stream of queued followers cannot extend it.
+    # Past the bound the runtime is torn down through the #1140 settling path
+    # (force_cleanup_stuck_active_session), not the plain idle disconnect: the durable
+    # owner is still unsettled at that point, so the pending request and turn token must
+    # be retired first or a later result can adopt them.
+    test: tests/test_session_eviction_interlock.py::test_the_pin_is_bounded_by_the_stuck_active_threshold
+  - id: HFR-139
+    name: a live parent Turn pins its subagent runtime
+    status: covered
+    kind: safety
+    layer: contract
+    backend: claude
+    # A subagent's base session id is `{parent_anchor}:{agent_name}`, so its composite
+    # runtime key contains two colons and splits on the LAST one. The subagent runtime
+    # is a projection of the parent's session and has no durable rows of its own;
+    # matching the parent anchor as a prefix is what keeps a live parent turn from
+    # having its subagent evicted mid-flight underneath it.
+    test: tests/test_session_eviction_interlock.py::test_a_parent_turn_pins_its_subagent_runtime
+  - id: HFR-140
+    name: an ownership handoff committed mid-read cannot fall between two reads
+    status: covered
+    kind: safety
+    layer: contract
+    backend: shared
+    # The failure mode is not a lost update, it is a lost OWNER. Read Deliveries (only
+    # terminal history), then a commit lands that settles the running Turn and admits a
+    # follower, then read Turns (now terminal): two independent reads see NO owner and
+    # evict a session with queued input. The union is therefore resolved inside one
+    # BEGIN DEFERRED snapshot -- all four tables live in the same DB and engine, so the
+    # handoff is either wholly before or wholly after it.
+    # The regression drives the real interleaving: an engine proxy lands the competing
+    # commit from another connection immediately after the Deliveries read is
+    # materialized, and asserts both that the snapshot's Turn still pins AND that the
+    # handoff really did commit -- so the test cannot pass by failing to race.
+    test: tests/test_session_eviction_interlock.py::test_a_handoff_committed_mid_read_cannot_fall_between_two_reads
+  - id: HFR-141
+    name: a settled Turn is history and does not veto eviction
+    status: covered
+    kind: safety
+    layer: contract
+    backend: claude
+    # The negative control for HFR-132. An interlock that pinned on any Turn row would
+    # read as "safe" while quietly disabling idle eviction for every session that ever
+    # ran a turn, leaking a backend process each time.
+    test: tests/test_session_eviction_interlock.py::test_terminal_turn_history_does_not_pin
+  - id: HFR-142
+    name: a Codex transport is pinned by a durable owner rooted at its working directory
+    status: covered
+    kind: safety
+    layer: contract
+    backend: codex
+    # Same defect, different keyspace: a Codex app-server transport is keyed by cwd,
+    # shared across the sessions rooted there, and reaped on the same idle clock with
+    # the same pre-`active` window. The interlock is consulted per cwd, so the fix lives
+    # at the owner boundary both backends share rather than in one adapter.
+    test: tests/test_session_eviction_interlock.py::test_codex_transport_is_pinned_by_a_durable_owner
+  - id: HFR-143
+    name: the Codex sweep fails closed on an unresolved owner union
+    status: covered
+    kind: safety
+    layer: contract
+    backend: codex
+    # HFR-136 for the second consumer. Fail-closed has to be a property of the shared
+    # provider boundary, not of whichever caller remembered to check.
+    test: tests/test_session_eviction_interlock.py::test_codex_unresolved_ownership_skips_the_cycle
+  - id: HFR-144
+    name: ownership admitted while the Codex sweep waited for the lock vetoes eviction
+    status: covered
+    kind: safety
+    layer: contract
+    backend: codex
+    # HFR-135 for the second consumer, and the window is wider here: the per-cwd
+    # transport lock serializes eviction against transport start-up, so the sweep can
+    # wait inside it. The recheck that lock guards already re-derived activity and the
+    # active-turn flag from current state; the owner union is re-read there too.
+    test: tests/test_session_eviction_interlock.py::test_codex_ownership_admitted_inside_the_lock_vetoes_eviction
+  - id: HFR-145
+    name: a spent Codex pin force-evicts the transport but keeps the resume mapping
+    status: covered
+    kind: recovery
+    layer: contract
+    backend: codex
+    # HFR-138's bound for Codex, and the reason eviction past it is loss-free rather
+    # than destructive: invalidate_thread drops only the in-memory binding, so the
+    # PERSISTED thread mapping survives and the next dispatch resumes the same Codex
+    # conversation. That is what makes the bound safe to have at all.
+    test: tests/test_session_eviction_interlock.py::test_a_spent_codex_pin_force_evicts_but_keeps_the_thread_mapping
+  - id: HFR-146
+    name: every backend idle-eviction path is inventoried against the owner union
+    status: covered
+    kind: safety
+    layer: contract
+    backend: shared
+    # The inventory is the contract, not a comment. Idle eviction lives in exactly two
+    # places today (SessionHandler.evict_idle_sessions, CodexAgent.evict_idle_transports)
+    # and both consult the provider; OpenCode has no idle-eviction consumer at all, so
+    # its runtime is restart-safe by construction. A third path added later would
+    # otherwise ship with no interlock and no one noticing -- this test fails until the
+    # new path is classified here.
+    test: tests/test_session_eviction_interlock.py::test_every_backend_eviction_consumer_is_inventoried
   - id: HFR-240
     name: the backend-wide clear does not delete a superseded row
     status: covered
@@ -3417,3 +3645,4 @@ plan: docs/plans/harness-session-failure-recovery.md
 plans:
   - docs/plans/harness-session-failure-recovery.md
   - docs/plans/agent-run-zombie-settlement.md
+  - docs/plans/harness-run-reliability.md

--- a/tests/scenarios/harness_failure_recovery/catalog.yaml
+++ b/tests/scenarios/harness_failure_recovery/catalog.yaml
@@ -2593,6 +2593,26 @@ scenarios:
     # otherwise ship with no interlock and no one noticing -- this test fails until the
     # new path is classified here.
     test: tests/test_session_eviction_interlock.py::test_every_backend_eviction_consumer_is_inventoried
+  - id: HFR-147
+    name: ownership admitted during an earlier teardown vetoes the later eviction
+    status: covered
+    kind: safety
+    layer: contract
+    backend: claude
+    # Found by review on PR #1150's first head. HFR-135's per-pass re-read is
+    # necessary but not sufficient: the acting pass walks a LIST of candidates and
+    # every teardown awaits, so a Delivery committed while an earlier candidate is
+    # being cleaned up lands after a once-per-pass snapshot was taken. Queued work
+    # deliberately touches neither session_last_activity nor active_sessions -- the
+    # two things the per-candidate recheck already re-derives -- so nothing else in
+    # the loop can notice it, and the later runtime is destroyed with input already
+    # accepted. FIX: the acting pass re-resolves the union immediately before each
+    # teardown (only for candidates that are not stuck-active, which ignore the pin
+    # anyway), so the read is bounded by the number of sessions actually evicted.
+    # The regression drives the real interleaving -- the first candidate's own
+    # disconnect commits the follower -- and asserts the teardown and the commit
+    # both really happened, so it cannot pass by failing to race.
+    test: tests/test_session_eviction_interlock.py::test_ownership_admitted_during_an_earlier_teardown_vetoes_the_later_eviction
   - id: HFR-240
     name: the backend-wide clear does not delete a superseded row
     status: covered

--- a/tests/test_session_eviction_interlock.py
+++ b/tests/test_session_eviction_interlock.py
@@ -13,7 +13,7 @@ These tests drive the two real eviction entry points --
 -- against REAL durable rows in the isolated state database, so what is asserted
 is the join between the two keyspaces, not a stub's opinion of it.
 
-Scenarios: HFR-130 … HFR-147 (tests/scenarios/harness_failure_recovery/catalog.yaml).
+Scenarios: HFR-130 … HFR-149 (tests/scenarios/harness_failure_recovery/catalog.yaml).
 """
 
 from __future__ import annotations
@@ -1030,3 +1030,81 @@ def test_every_backend_eviction_consumer_is_inventoried() -> None:
         "OpenCode grew an idle-eviction path: it must consume core/session_ownership.py "
         f"or prove restart-safety here -- found {opencode_evictors}"
     )
+
+
+# ---------------------------------------------------------------------------
+# HFR-148 … HFR-149: a pin must be scoped, and must not depend on an allowlist
+# ---------------------------------------------------------------------------
+
+
+def test_a_pin_does_not_cross_backends_at_a_shared_workdir(monkeypatch, tmp_path: Path) -> None:
+    """HFR-148: durable work pins the runtime it will actually run in, only.
+
+    Both keyspaces collapse across backends at the default working directory: a
+    Codex transport is keyed by cwd alone, and a Claude runtime key is
+    ``anchor:workdir``. So an unscoped pin lets a Claude-backed session hold a
+    Codex app-server open for work that will never be dispatched into it, and
+    vice versa -- an idle runtime kept alive forever by a neighbour's queue.
+    Ownership is only evidence for the backend the durable work names.
+    """
+
+    _state_db()
+    workdir = str(tmp_path)
+
+    # A Claude-backed owner at this cwd is not evidence for the Codex transport.
+    _seed_session("sesclaude001", anchor="slack_C888", workdir=workdir, backend="claude")
+    _seed_delivery("sesclaude001", "queued")
+
+    agent, calls = _codex_agent(workdir)
+    assert _codex_sweep(agent, monkeypatch) == 1, "a foreign-backend owner must not pin Codex"
+    assert calls.stopped == [workdir]
+
+    # ... and the same owner on the matching backend still pins it.
+    _state_db()
+    _seed_session("sescodex0001", anchor="slack_C777", workdir=workdir, backend="codex")
+    _seed_delivery("sescodex0001", "queued")
+
+    agent, calls = _codex_agent(workdir)
+    assert _codex_sweep(agent, monkeypatch) == 0
+    assert calls.stopped == []
+
+
+def test_a_codex_owner_does_not_pin_the_claude_runtime_at_the_same_key(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """HFR-148: the mirror direction, on the Claude consumer.
+
+    A session that has switched backends keeps its anchor and its workdir, so its
+    Claude runtime key is unchanged. Queued Codex work must not keep the stale
+    SDK client from a previous backend alive.
+    """
+
+    _state_db()
+    handler, controller, composite_key, captured = _claude_handler(monkeypatch, tmp_path)
+    _seed_session(BASE_SESSION_ID, anchor=ANCHOR, workdir=str(tmp_path), backend="codex")
+    _seed_delivery(BASE_SESSION_ID, "queued")
+
+    assert _sweep(handler) == 1, "Codex-backed work must not pin the Claude runtime"
+    assert composite_key not in controller.claude_sessions
+    assert captured["disconnects"] == 1
+
+
+def test_an_unrecognized_run_status_still_pins(monkeypatch, tmp_path: Path) -> None:
+    """HFR-149: nonterminal is 'not terminal', never 'on the list we know about'.
+
+    ``agent_runs.status`` carries no CHECK constraint and ``normalize_run_status``
+    passes an unrecognized string through untouched, so a status introduced later
+    -- or imported from another writer -- reaches this query. Selecting the known
+    in-progress statuses would silently drop such a Run's interlock, which is the
+    one failure mode this whole provider exists to prevent. It is queried as NOT
+    IN the terminal set, exactly like Deliveries and Turns.
+    """
+
+    _state_db()
+    handler, controller, composite_key, captured = _claude_handler(monkeypatch, tmp_path)
+    _seed_session(BASE_SESSION_ID, anchor=ANCHOR, workdir=str(tmp_path))
+    _seed_run(BASE_SESSION_ID, run_type="agent_run", status="retrying")
+
+    assert _sweep(handler) == 0, "an unknown Run status must fail closed and pin"
+    assert composite_key in controller.claude_sessions
+    assert captured["disconnects"] == 0

--- a/tests/test_session_eviction_interlock.py
+++ b/tests/test_session_eviction_interlock.py
@@ -13,7 +13,10 @@ These tests drive the two real eviction entry points --
 -- against REAL durable rows in the isolated state database, so what is asserted
 is the join between the two keyspaces, not a stub's opinion of it.
 
-Scenarios: HFR-130 … HFR-153 (tests/scenarios/harness_failure_recovery/catalog.yaml).
+Scenarios: HFR-130 … HFR-154 plus HFR-431
+(tests/scenarios/harness_failure_recovery/catalog.yaml). PR3's reserved block ends
+at HFR-154, so the last review-driven addition takes a fresh ID above the highest
+allocated one rather than borrowing PR4's range.
 """
 
 from __future__ import annotations
@@ -1294,3 +1297,139 @@ def test_a_run_pins_the_backend_it_captured_not_the_switched_session_backend(
     assert _sweep(handler) == 0
     assert composite_key in handler.claude_sessions
     assert captured["disconnects"] == 0
+
+
+# ---------------------------------------------------------------------------
+# HFR-154 + HFR-431: partial safety data, and the reap that must spare a
+# replacement client
+# ---------------------------------------------------------------------------
+
+
+def _drop_table(table: str) -> None:
+    """Drop one owner table to build a PARTIALLY migrated state database.
+
+    Foreign keys are suspended for the drop only: the point is a database whose
+    surviving tables still hold owners, which is exactly what FK enforcement
+    would otherwise refuse to leave behind.
+    """
+
+    raw = _engine().raw_connection()
+    try:
+        cursor = raw.cursor()
+        cursor.execute("PRAGMA foreign_keys = OFF")
+        cursor.execute(f"DROP TABLE IF EXISTS {table}")
+        raw.commit()
+        cursor.execute("PRAGMA foreign_keys = ON")
+        cursor.close()
+    finally:
+        raw.close()
+
+
+def test_a_partially_migrated_owner_schema_fails_closed(monkeypatch, tmp_path: Path) -> None:
+    """HFR-154: a half-present schema is missing data, not proof of no owner.
+
+    An ENTIRELY absent schema is positive proof -- no durable table can hold an
+    owner, so eviction may proceed. A PARTIAL one is the opposite: the tables that
+    survived say nothing about the owners recorded in the ones that did not. Here a
+    live execution-bearing Run sits in ``agent_runs`` while ``message_deliveries``
+    is gone, so treating the two cases alike reads as "nothing owns anything" and
+    evicts the runtime that Run is about to be dispatched into.
+
+    RED against the previous head: both cases returned a resolved EMPTY snapshot,
+    and the sweep evicted (``evicted == 1``).
+    """
+
+    from sqlalchemy import create_engine
+
+    _state_db()
+    handler, _controller, composite_key, captured = _claude_handler(monkeypatch, tmp_path)
+    _seed_session(BASE_SESSION_ID, anchor=ANCHOR, workdir=str(tmp_path))
+    _seed_run(BASE_SESSION_ID)
+
+    _drop_table("message_deliveries")
+
+    snapshot = DurableSessionOwnershipProvider().snapshot()
+    assert snapshot.failed, "a partial owner schema must not resolve"
+    assert _sweep(handler) == 0
+    assert composite_key in handler.claude_sessions
+    assert captured["disconnects"] == 0
+
+    # The positive control, so this cannot pass by refusing to resolve anything:
+    # with NO owner table at all there is nothing to be missing.
+    empty = DurableSessionOwnershipProvider(engine_factory=lambda: create_engine("sqlite://")).snapshot()
+    assert empty.resolved and not empty.bindings
+
+
+def test_the_duplicate_reap_spares_a_replacement_claude_client(monkeypatch, tmp_path: Path) -> None:
+    """HFR-431: teardown must not SIGTERM the client that replaced it.
+
+    This is the sharp edge of the residual HFR-151 documents. ``cleanup_session``
+    pops the client before it awaits, so a Delivery admitted mid-teardown starts a
+    REPLACEMENT client -- which resumes the same native session id and therefore
+    runs with the same ``--resume`` argument the duplicate reap matches on. With no
+    PID to keep, the reaper treats every match as a leak and SIGTERMs it along with
+    its descendants, so the race would cost work killed mid-turn rather than a cold
+    start.
+
+    Three cases: a replacement with an observable PID is spared; a replacement
+    without one skips the reap entirely (an unreaped duplicate is recoverable, a
+    SIGTERM into live work is not); and with no replacement the reap-everything
+    behaviour is unchanged, so genuine leaks are still collected.
+
+    RED against the previous head: ``keep_pid`` was ``None`` in all three.
+    """
+
+    calls: list[dict[str, Any]] = []
+
+    async def _fake_reap(native_session_id, *, keep_pid=None, cli_path=None, logger=None):
+        calls.append({"native_session_id": native_session_id, "keep_pid": keep_pid})
+        return 0
+
+    monkeypatch.setattr(session_handler_module, "reap_duplicate_claude_resume_processes", _fake_reap)
+
+    def _client_with_pid(pid: Optional[int]):
+        process = SimpleNamespace(pid=pid) if pid is not None else SimpleNamespace()
+        return SimpleNamespace(
+            _transport=SimpleNamespace(_process=process),
+            _vibe_native_session_id="native-resume-id",
+            disconnect=_noop_disconnect,
+        )
+
+    async def _noop_disconnect() -> None:
+        return None
+
+    handler, _controller, composite_key, _captured = _claude_handler(monkeypatch, tmp_path)
+
+    # 1. A replacement lands during the retiring client's own disconnect.
+    replacement = _client_with_pid(4242)
+
+    class _AdmitsReplacement:
+        _vibe_native_session_id = "native-resume-id"
+
+        async def disconnect(self) -> None:
+            handler.claude_sessions[composite_key] = replacement
+
+    handler.claude_sessions[composite_key] = _AdmitsReplacement()
+    asyncio.run(handler.cleanup_session(composite_key))
+    assert calls[-1] == {"native_session_id": "native-resume-id", "keep_pid": 4242}
+
+    # 2. A replacement is live but has not published a PID yet: reap nothing.
+    handler.claude_sessions.pop(composite_key, None)
+    before = len(calls)
+    blind_replacement = _client_with_pid(None)
+
+    class _AdmitsPidlessReplacement:
+        _vibe_native_session_id = "native-resume-id"
+
+        async def disconnect(self) -> None:
+            handler.claude_sessions[composite_key] = blind_replacement
+
+    handler.claude_sessions[composite_key] = _AdmitsPidlessReplacement()
+    asyncio.run(handler.cleanup_session(composite_key))
+    assert len(calls) == before, "a blind reap may not run while a replacement is live"
+
+    # 3. No replacement: unchanged, so a genuinely leaked duplicate is still reaped.
+    handler.claude_sessions.pop(composite_key, None)
+    handler.claude_sessions[composite_key] = _client_with_pid(999)
+    asyncio.run(handler.cleanup_session(composite_key))
+    assert calls[-1] == {"native_session_id": "native-resume-id", "keep_pid": None}

--- a/tests/test_session_eviction_interlock.py
+++ b/tests/test_session_eviction_interlock.py
@@ -13,7 +13,7 @@ These tests drive the two real eviction entry points --
 -- against REAL durable rows in the isolated state database, so what is asserted
 is the join between the two keyspaces, not a stub's opinion of it.
 
-Scenarios: HFR-130 … HFR-151 (tests/scenarios/harness_failure_recovery/catalog.yaml).
+Scenarios: HFR-130 … HFR-153 (tests/scenarios/harness_failure_recovery/catalog.yaml).
 """
 
 from __future__ import annotations
@@ -300,6 +300,7 @@ def _seed_run(
     status: str = "running",
     delivery_id: Optional[str] = None,
     run_id: Optional[str] = None,
+    agent_backend: Optional[str] = None,
 ) -> str:
     from storage.models import agent_runs
 
@@ -311,6 +312,7 @@ def _seed_run(
                 run_type=run_type,
                 status=status,
                 session_id=session_id,
+                agent_backend=agent_backend,
                 delivery_id=delivery_id,
                 cancel_requested=0,
                 created_at=NOW,
@@ -1223,3 +1225,72 @@ def test_claude_admission_during_teardown_costs_a_restart_not_the_work(
     assert composite_key not in handler.claude_sessions
     assert composite_key not in controller.claude_sessions
     assert composite_key not in handler.session_last_activity
+
+
+# ---------------------------------------------------------------------------
+# HFR-152 … HFR-153: the keyspace join must survive real-world identifiers
+# ---------------------------------------------------------------------------
+
+
+def test_a_workdir_containing_a_colon_still_pins_its_claude_runtime(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """HFR-152: a colon inside the workdir must not dissolve the pin.
+
+    The Claude runtime key is ``f"{base_session_id}:{workdir}"`` with neither part
+    escaped, so recovering the workdir by splitting on the LAST colon is wrong for
+    any workdir that contains one -- ``C:\\repo`` on native Windows, or the POSIX
+    directory used here. The split then reads part of the path as the base and the
+    tail as the whole workdir, both halves mismatch the durable target, and the pin
+    vanishes. It vanishes exactly where nothing compensates: this session has a
+    ``queued`` Delivery and no turn, so there is no observed
+    ``session_turns.runtime_key`` to match exactly.
+
+    RED against the previous head: the colon-workdir runtime is torn down too
+    (``evicted == 2``).
+    """
+
+    _state_db()
+    handler, _controller, composite_key, captured = _claude_handler(monkeypatch, tmp_path)
+
+    colon_workdir = tmp_path / "proj:v2"
+    colon_workdir.mkdir()
+    owned_session_id = "sescolonwd001"
+    owned_anchor = "slack_C555"
+    _seed_session(owned_session_id, anchor=owned_anchor, workdir=str(colon_workdir))
+    _seed_delivery(owned_session_id, "queued", delivery_id="dlv-colon-workdir")
+    colon_key = f"{owned_anchor}:{colon_workdir}"
+    _add_second_runtime(handler, colon_key, captured)
+
+    # Only the runtime at ``tmp_path`` is unowned, so only it may be evicted.
+    assert _sweep(handler) == 1
+    assert colon_key in handler.claude_sessions
+    assert captured.get(colon_key) is None
+    assert composite_key not in handler.claude_sessions
+
+
+def test_a_run_pins_the_backend_it_captured_not_the_switched_session_backend(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """HFR-153: a Run queued before a backend switch pins the backend it recorded.
+
+    A Run captures its own routing identity (``agent_backend``), and
+    ``MessageHandler`` gives that explicit request identity precedence over the
+    session's stored target when it dispatches. So when the user switches a
+    session's backend while a Run is still queued, that Run will land on the
+    backend it captured -- and attributing it only through the session row's NEW
+    backend pins the wrong runtime while leaving the real one evictable.
+
+    RED against the previous head: the session's backends resolve to ``{codex}``
+    alone, the Claude pin is dropped as a cross-backend match, and the runtime the
+    Run is about to be dispatched into is torn down (``evicted == 1``).
+    """
+
+    _state_db()
+    handler, _controller, composite_key, captured = _claude_handler(monkeypatch, tmp_path)
+    _seed_session(BASE_SESSION_ID, anchor=ANCHOR, workdir=str(tmp_path), backend="codex")
+    _seed_run(BASE_SESSION_ID, agent_backend="claude")
+
+    assert _sweep(handler) == 0
+    assert composite_key in handler.claude_sessions
+    assert captured["disconnects"] == 0

--- a/tests/test_session_eviction_interlock.py
+++ b/tests/test_session_eviction_interlock.py
@@ -1,0 +1,986 @@
+"""Idle eviction must not destroy a runtime a durable owner still holds.
+
+Backend idle eviction is keyed by an in-memory runtime key (Claude's
+``{base_session_id}:{workdir}``, a Codex transport's cwd) and gated by an
+in-memory activity clock plus an ``active`` flag that only exists once a turn has
+reached native start. Every durable owner shipped by #1134 predates that flag: a
+``queued`` Delivery, a ``starting`` Turn, an execution-bearing Run that has not
+reserved a Delivery yet. Evicting under one of those tears down the runtime the
+owner is about to be dispatched into.
+
+These tests drive the two real eviction entry points --
+``SessionHandler.evict_idle_sessions`` and ``CodexAgent.evict_idle_transports``
+-- against REAL durable rows in the isolated state database, so what is asserted
+is the join between the two keyspaces, not a stub's opinion of it.
+
+Scenarios: HFR-130 … HFR-146 (tests/scenarios/harness_failure_recovery/catalog.yaml).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sqlite3
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, Optional
+from unittest.mock import Mock
+
+import pytest
+from sqlalchemy import Select, text as sa_text
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import core.handlers.session_handler as session_handler_module
+import modules.agents.codex.agent as codex_agent_module
+from core.handlers.session_handler import SessionHandler
+from core.session_ownership import (
+    UNRESOLVED_SNAPSHOT,
+    DurableSessionOwnershipProvider,
+)
+from modules.agents.codex.agent import CodexAgent
+from modules.im import MessageContext
+from tests.test_claude_cli_path import (
+    _Controller,
+    _StubClaudeAgentOptions,
+    _run_session,
+)
+
+NOW = "2026-07-01T00:00:00+00:00"
+ANCHOR = "slack_C123"
+BASE_SESSION_ID = "sesinterlock01"
+
+# ``evict_idle_sessions(600)`` with the shipped multiplier/floor.
+IDLE_TIMEOUT = 600.0
+STUCK_THRESHOLD = 1800.0
+
+
+# ---------------------------------------------------------------------------
+# Durable seeding: the real schema, the real tables, the isolated home's DB.
+# ---------------------------------------------------------------------------
+
+
+def _state_db() -> Path:
+    """The isolated home's state DB with the real migrated schema applied.
+
+    The provider answers ``EMPTY_SNAPSHOT`` (positive proof: no durable table can
+    hold an owner) when the schema is absent, so a test that forgets this would
+    pass for the wrong reason -- eviction would proceed because nothing could
+    pin, not because the interlock decided so.
+    """
+
+    from config import paths
+    from storage.importer import ensure_sqlite_state, resolve_primary_platform_from_config
+    from storage.migrations import run_migrations
+
+    path = paths.get_sqlite_state_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    run_migrations(path)
+    ensure_sqlite_state(primary_platform=resolve_primary_platform_from_config(paths.get_state_dir()))
+    return path
+
+
+def _engine():
+    from storage.db import get_cached_sqlite_engine
+
+    return get_cached_sqlite_engine()
+
+
+def _seed_session(
+    session_id: str,
+    *,
+    anchor: str,
+    workdir: str,
+    backend: str = "claude",
+) -> str:
+    from storage.models import agent_sessions
+
+    with _engine().begin() as conn:
+        conn.execute(
+            agent_sessions.insert().values(
+                id=session_id,
+                scope_id=None,
+                agent_backend=backend,
+                agent_name=backend,
+                agent_variant="default",
+                session_anchor=anchor,
+                workdir=workdir,
+                native_session_id=f"native-{session_id}",
+                status="active",
+                visibility="foreground",
+                agent_status="idle",
+                metadata_json="{}",
+                created_at=NOW,
+                updated_at=NOW,
+                last_active_at=NOW,
+            )
+        )
+    return session_id
+
+
+def _seed_delivery(session_id: str, state: str, *, delivery_id: Optional[str] = None) -> str:
+    """One Delivery row in ``state``, shaped the way the CHECK constraints demand.
+
+    The per-state shape is not decoration: ``claimed`` requires turn membership,
+    the steer states require a live attempt, and ``accepted`` requires a
+    materialized Message. Seeding a row the schema would reject is how a test
+    ends up asserting against a state production can never produce.
+    """
+
+    from storage.models import message_deliveries
+
+    delivery_id = delivery_id or f"dlv-{state}-{session_id}"
+    values: dict[str, Any] = dict(
+        id=delivery_id,
+        session_id=session_id,
+        priority="p1",
+        state=state,
+        snapshot_json="{}",
+        snapshot_sha256="0" * 64,
+        dispatch_text="hello",
+        dispatch_sha256="1" * 64,
+        submitted_at=NOW,
+        updated_at=NOW,
+    )
+
+    if state in ("claimed", "interrupt_waiting", "accepted"):
+        values.update(
+            turn_id=_seed_settled_turn(session_id, f"turn-for-{delivery_id}"),
+            turn_role="initial",
+            turn_position=0,
+        )
+    if state in ("pending_steer", "steering", "reconciling_steer"):
+        values.update(
+            current_attempt_id=f"att-{delivery_id}",
+            current_attempt_kind="steer",
+            current_target_turn_id=_seed_settled_turn(session_id, f"turn-for-{delivery_id}"),
+            current_attempt_opened_at=NOW,
+        )
+    if state in ("steering", "reconciling_steer"):
+        values["current_expected_native_turn_id"] = f"native-{delivery_id}"
+    if state == "reconciling_steer":
+        values["current_receipt_outcome"] = "unknown"
+    if state == "accepted":
+        values.update(
+            message_id=_seed_message(session_id, f"msg-{delivery_id}"),
+            materialized_at=NOW,
+            snapshot_json=None,
+            dispatch_text=None,
+        )
+    if state == "retired":
+        values["retired_at"] = NOW
+
+    with _engine().begin() as conn:
+        conn.execute(message_deliveries.insert().values(**values))
+    return delivery_id
+
+
+def _seed_message(session_id: str, message_id: str) -> str:
+    from storage.models import messages
+
+    with _engine().begin() as conn:
+        conn.execute(
+            messages.insert().values(
+                id=message_id,
+                session_id=session_id,
+                platform="slack",
+                author="user",
+                content_text="hello",
+                content_json="{}",
+                metadata_json="{}",
+                type="user",
+                created_at=NOW,
+                updated_at=NOW,
+            )
+        )
+    return message_id
+
+
+def _seed_settled_turn(session_id: str, turn_id: str) -> str:
+    """A terminal Turn to hang turn-membership references on.
+
+    Terminal history contributes no pin of its own, so a Delivery whose shape
+    requires a Turn reference still tests exactly the Delivery's own pin.
+    """
+
+    from storage.models import session_turns
+
+    with _engine().begin() as conn:
+        existing = conn.execute(
+            sa_text("SELECT id FROM session_turns WHERE id = :id"), {"id": turn_id}
+        ).scalar()
+        if existing:
+            return turn_id
+        initial_delivery_id = f"dlv-initial-{turn_id}"
+        conn.execute(
+            sa_text(
+                "INSERT INTO message_deliveries "
+                "(id, session_id, priority, state, snapshot_json, snapshot_sha256, "
+                " dispatch_text, dispatch_sha256, submitted_at, updated_at, retired_at) "
+                "VALUES (:id, :session_id, 'p1', 'retired', '{}', :sha, 'hello', :sha, "
+                " :now, :now, :now)"
+            ),
+            {"id": initial_delivery_id, "session_id": session_id, "sha": "0" * 64, "now": NOW},
+        )
+        conn.execute(
+            session_turns.insert().values(
+                id=turn_id,
+                session_id=session_id,
+                initial_delivery_id=initial_delivery_id,
+                state="terminal",
+                backend="claude",
+                terminal_outcome="not_written",
+                terminal_at=NOW,
+                start_receipt_json="{}",
+                terminal_evidence_json="{}",
+                control_receipt_json="{}",
+                created_at=NOW,
+                updated_at=NOW,
+            )
+        )
+    return turn_id
+
+
+def _seed_turn(
+    session_id: str,
+    state: str,
+    *,
+    runtime_key: Optional[str] = None,
+    turn_id: Optional[str] = None,
+    backend: str = "claude",
+) -> str:
+    """A Turn in ``state`` plus the terminal Delivery it was started from.
+
+    ``initial_delivery_id`` carries a real foreign key, and the seeded parent is
+    terminal so it contributes no pin of its own -- what is asserted is the
+    Turn's pin. The start-shape columns follow ``ck_session_turns_start_shape``:
+    a ``waiting`` Turn has no dispatch yet, ``starting`` has one with no receipt,
+    ``active`` has an accepted receipt, ``terminal`` carries its outcome.
+    """
+
+    from storage.models import session_turns
+
+    turn_id = turn_id or f"turn-{state}-{session_id}"
+    initial_delivery_id = _seed_delivery(
+        session_id, "retired", delivery_id=f"dlv-initial-{turn_id}"
+    )
+    values: dict[str, Any] = dict(
+        id=turn_id,
+        session_id=session_id,
+        initial_delivery_id=initial_delivery_id,
+        state=state,
+        backend=backend,
+        runtime_key=runtime_key,
+        start_receipt_json="{}",
+        terminal_evidence_json="{}",
+        control_receipt_json="{}",
+        created_at=NOW,
+        updated_at=NOW,
+    )
+    if state != "waiting":
+        values.update(
+            start_attempt_id=f"start-{turn_id}",
+            dispatch_text="hello",
+            dispatch_sha256="1" * 64,
+        )
+    if state in ("active", "terminal"):
+        values["start_receipt_outcome"] = "accepted"
+    if state == "terminal":
+        values.update(terminal_outcome="completed", terminal_at=NOW)
+
+    with _engine().begin() as conn:
+        conn.execute(session_turns.insert().values(**values))
+    return turn_id
+
+
+def _seed_run(
+    session_id: str,
+    *,
+    run_type: str = "agent_run",
+    status: str = "running",
+    delivery_id: Optional[str] = None,
+    run_id: Optional[str] = None,
+) -> str:
+    from storage.models import agent_runs
+
+    run_id = run_id or f"run-{run_type}-{status}-{session_id}"
+    with _engine().begin() as conn:
+        conn.execute(
+            agent_runs.insert().values(
+                id=run_id,
+                run_type=run_type,
+                status=status,
+                session_id=session_id,
+                delivery_id=delivery_id,
+                cancel_requested=0,
+                created_at=NOW,
+                updated_at=NOW,
+                metadata_json="{}",
+            )
+        )
+    return run_id
+
+
+def _set_delivery_state(delivery_id: str, state: str) -> None:
+    with _engine().begin() as conn:
+        conn.execute(
+            sa_text("UPDATE message_deliveries SET state = :state WHERE id = :id"),
+            {"state": state, "id": delivery_id},
+        )
+
+
+def _drop_session_row(session_id: str) -> None:
+    """Delete a session row while its Delivery still points at it.
+
+    Foreign keys are ON for every pooled connection, so the only way to build a
+    *positively* dangling binding -- the failure the provider must fail OPEN for
+    -- is to suspend enforcement for this one write.
+    """
+
+    raw = _engine().raw_connection()
+    try:
+        cursor = raw.cursor()
+        cursor.execute("PRAGMA foreign_keys = OFF")
+        cursor.execute("DELETE FROM agent_sessions WHERE id = ?", (session_id,))
+        raw.commit()
+        cursor.execute("PRAGMA foreign_keys = ON")
+        cursor.close()
+    finally:
+        raw.close()
+
+
+# ---------------------------------------------------------------------------
+# Claude harness
+# ---------------------------------------------------------------------------
+
+
+def _claude_handler(monkeypatch, tmp_path: Path, *, now: float = 1000.0):
+    """One live Claude runtime for ``slack_C123`` at ``tmp_path``, frozen clock."""
+
+    captured: dict[str, Any] = {"disconnects": 0}
+
+    class _StubClaudeSDKClient:
+        def __init__(self, options):
+            captured["options"] = options
+
+        async def connect(self) -> None:
+            return None
+
+        async def disconnect(self) -> None:
+            captured["disconnects"] += 1
+
+    monkeypatch.setattr(session_handler_module, "ClaudeAgentOptions", _StubClaudeAgentOptions)
+    monkeypatch.setattr(session_handler_module, "ClaudeSDKClient", _StubClaudeSDKClient)
+    monkeypatch.setattr(session_handler_module.time, "monotonic", lambda: now)
+
+    controller = _Controller(tmp_path)
+    handler = SessionHandler(controller)
+    _run_session(handler, MessageContext(user_id="U123", channel_id="C123"))
+    composite_key = f"{ANCHOR}:{tmp_path}"
+    handler.session_last_activity[composite_key] = 0.0
+    return handler, controller, composite_key, captured
+
+
+def _add_second_runtime(handler, composite_key: str, captured: dict[str, Any]) -> None:
+    """A second, unrelated Claude runtime sharing the workdir."""
+
+    class _Client:
+        async def disconnect(self) -> None:
+            captured[composite_key] = captured.get(composite_key, 0) + 1
+
+    handler.claude_sessions[composite_key] = _Client()
+    handler.session_last_activity[composite_key] = 0.0
+
+
+def _sweep(handler, idle_timeout: float = IDLE_TIMEOUT) -> int:
+    return asyncio.run(handler.evict_idle_sessions(idle_timeout))
+
+
+# ---------------------------------------------------------------------------
+# HFR-130 … HFR-141: the Claude interlock
+# ---------------------------------------------------------------------------
+
+
+def test_queued_delivery_pins_its_own_idle_claude_session(monkeypatch, tmp_path: Path) -> None:
+    """HFR-130: durable queued input outranks the idle clock, for that session only.
+
+    The baseline defect: ``queued`` is the state a Delivery sits in *before* any
+    turn starts, so the ``active`` flag is unset and the runtime looks perfectly
+    idle. Evicting it destroys the SDK client the queued row is about to be
+    dispatched into. RED against master (both runtimes evicted, ``evicted == 2``).
+    """
+
+    _state_db()
+    handler, controller, pinned_key, captured = _claude_handler(monkeypatch, tmp_path)
+    unrelated_key = f"slack_C999:{tmp_path}"
+    _add_second_runtime(handler, unrelated_key, captured)
+
+    _seed_session(BASE_SESSION_ID, anchor=ANCHOR, workdir=str(tmp_path))
+    _seed_delivery(BASE_SESSION_ID, "queued")
+
+    evicted = _sweep(handler)
+
+    assert evicted == 1, "only the unpinned runtime may be evicted"
+    assert pinned_key in controller.claude_sessions, "queued durable input must pin its runtime"
+    assert captured["disconnects"] == 0
+    assert unrelated_key not in controller.claude_sessions, (
+        "a pin on one session must not immunize every idle runtime"
+    )
+    # Waiting is not activity: the pin must not have refreshed the clock, or a
+    # stream of queued followers could keep a dead runtime alive forever.
+    assert handler.session_last_activity[pinned_key] == 0.0
+
+
+@pytest.mark.parametrize(
+    "state, pins",
+    [
+        ("reserved", True),
+        ("queued", True),
+        ("claimed", True),
+        ("pending_steer", True),
+        ("steering", True),
+        ("interrupt_waiting", True),
+        ("reconciling_steer", True),
+        ("accepted", False),
+        ("retired", False),
+    ],
+)
+def test_delivery_pin_follows_the_state_policy(
+    monkeypatch, tmp_path: Path, state: str, pins: bool
+) -> None:
+    """HFR-131: the pin is read from ``DELIVERY_STATE_MATRIX``, not a hard-coded list.
+
+    Every ``claimable`` / ``fence`` / ``turn_owned`` row still owns its input and
+    pins; only ``terminal`` history does not. Asserted state by state so a future
+    Delivery state cannot be added with the wrong eviction answer, and so
+    accepted/retired history cannot make a session immortal.
+    """
+
+    _state_db()
+    handler, controller, composite_key, captured = _claude_handler(monkeypatch, tmp_path)
+    _seed_session(BASE_SESSION_ID, anchor=ANCHOR, workdir=str(tmp_path))
+    _seed_delivery(BASE_SESSION_ID, state)
+
+    evicted = _sweep(handler)
+
+    if pins:
+        assert evicted == 0 and composite_key in controller.claude_sessions
+        assert captured["disconnects"] == 0
+    else:
+        assert evicted == 1 and composite_key not in controller.claude_sessions
+        assert captured["disconnects"] == 1
+
+
+@pytest.mark.parametrize("state", ["waiting", "starting", "active"])
+def test_nonterminal_turn_pins_through_anchor_and_workdir(
+    monkeypatch, tmp_path: Path, state: str
+) -> None:
+    """HFR-132: a Turn with no ``runtime_key`` yet still pins its runtime.
+
+    ``runtime_key`` is only bound at ``bind_native_start``, so a ``waiting`` or
+    ``starting`` Turn carries NULL -- exactly the window where the in-memory
+    ``active`` flag is also unset. The join therefore composes the same key from
+    ``session_anchor`` + normalized ``workdir`` rather than requiring the
+    authoritative column.
+    """
+
+    _state_db()
+    handler, controller, composite_key, captured = _claude_handler(monkeypatch, tmp_path)
+    _seed_session(BASE_SESSION_ID, anchor=ANCHOR, workdir=str(tmp_path))
+    _seed_turn(BASE_SESSION_ID, state)
+
+    assert _sweep(handler) == 0
+    assert composite_key in controller.claude_sessions
+    assert captured["disconnects"] == 0
+
+
+def test_terminal_turn_history_does_not_pin(monkeypatch, tmp_path: Path) -> None:
+    """HFR-141: a settled Turn is history and must not veto eviction."""
+
+    _state_db()
+    handler, controller, composite_key, captured = _claude_handler(monkeypatch, tmp_path)
+    _seed_session(BASE_SESSION_ID, anchor=ANCHOR, workdir=str(tmp_path))
+    _seed_turn(BASE_SESSION_ID, "terminal")
+
+    assert _sweep(handler) == 1
+    assert composite_key not in controller.claude_sessions
+    assert captured["disconnects"] == 1
+
+
+def test_watch_runtime_heartbeat_run_does_not_pin(monkeypatch, tmp_path: Path) -> None:
+    """HFR-133: a supervisor heartbeat is not execution.
+
+    A ``watch_runtime`` Run stays ``running`` for the entire life of the waiter --
+    hours or days. Counting it as an owner would make every watched session
+    permanently unevictable, which is the opposite failure from the one this PR
+    fixes, so the classification is explicit.
+    """
+
+    _state_db()
+    handler, controller, composite_key, captured = _claude_handler(monkeypatch, tmp_path)
+    _seed_session(BASE_SESSION_ID, anchor=ANCHOR, workdir=str(tmp_path))
+    _seed_run(BASE_SESSION_ID, run_type="watch_runtime", status="running")
+
+    assert _sweep(handler) == 1, "a heartbeat Run must not pin a runtime"
+    assert composite_key not in controller.claude_sessions
+    assert captured["disconnects"] == 1
+
+
+@pytest.mark.parametrize("run_type", ["agent_run", "scheduled", "watch", "some_future_run_type"])
+def test_execution_bearing_and_unclassified_runs_pin(
+    monkeypatch, tmp_path: Path, run_type: str
+) -> None:
+    """HFR-134: execution-bearing Runs pin, and an unknown run type fails closed.
+
+    The bare-Run window is real: a Run is created, resolves its target session,
+    and only then reserves a Delivery. Nothing durable but the Run itself points
+    at the session in between. An unrecognized ``run_type`` takes the same
+    answer -- a new run type may not silently lose its interlock.
+    """
+
+    _state_db()
+    handler, controller, composite_key, captured = _claude_handler(monkeypatch, tmp_path)
+    _seed_session(BASE_SESSION_ID, anchor=ANCHOR, workdir=str(tmp_path))
+    _seed_run(BASE_SESSION_ID, run_type=run_type, status="running")
+
+    assert _sweep(handler) == 0
+    assert composite_key in controller.claude_sessions
+    assert captured["disconnects"] == 0
+
+
+def test_terminal_run_history_does_not_pin(monkeypatch, tmp_path: Path) -> None:
+    """HFR-134: a completed Run owns nothing."""
+
+    _state_db()
+    handler, controller, composite_key, captured = _claude_handler(monkeypatch, tmp_path)
+    _seed_session(BASE_SESSION_ID, anchor=ANCHOR, workdir=str(tmp_path))
+    _seed_run(BASE_SESSION_ID, run_type="agent_run", status="succeeded")
+
+    assert _sweep(handler) == 1
+    assert composite_key not in controller.claude_sessions
+
+
+def test_work_admitted_between_the_two_passes_wins(monkeypatch, tmp_path: Path) -> None:
+    """HFR-135: the losing race -- a pin that appears after pass 1 still holds.
+
+    ``evict_idle_sessions`` decides in one pass and acts in another. Input
+    admitted in that window is durable and unstarted, so the second pass must
+    re-read the owner union instead of trusting the first pass's verdict.
+    """
+
+    _state_db()
+    handler, controller, composite_key, captured = _claude_handler(monkeypatch, tmp_path)
+    _seed_session(BASE_SESSION_ID, anchor=ANCHOR, workdir=str(tmp_path))
+
+    provider = DurableSessionOwnershipProvider()
+    reads = {"count": 0}
+
+    class _AdmitsBetweenPasses:
+        def snapshot(self):
+            reads["count"] += 1
+            if reads["count"] == 2:
+                _seed_delivery(BASE_SESSION_ID, "queued")
+            return provider.snapshot()
+
+    controller.session_ownership = _AdmitsBetweenPasses()
+
+    evicted = _sweep(handler)
+
+    assert reads["count"] == 2, "both passes must consult the owner union"
+    assert evicted == 0, "work admitted between the passes must defeat the decided eviction"
+    assert composite_key in controller.claude_sessions
+    assert captured["disconnects"] == 0
+
+
+def test_unresolved_ownership_skips_the_whole_cycle(monkeypatch, tmp_path: Path) -> None:
+    """HFR-136: missing safety data is not evidence that eviction is safe.
+
+    A provider-wide failure (an unreadable DB, a raising lookup) says nothing
+    about who owns what, so no session is evicted -- including ones no owner
+    would have pinned. The cost is one deferred sweep; the alternative is
+    destroying a runtime mid-dispatch on the basis of a failed read.
+    """
+
+    _state_db()
+    handler, controller, composite_key, captured = _claude_handler(monkeypatch, tmp_path)
+    _seed_session(BASE_SESSION_ID, anchor=ANCHOR, workdir=str(tmp_path))
+
+    controller.session_ownership = SimpleNamespace(snapshot=lambda: UNRESOLVED_SNAPSHOT)
+    assert _sweep(handler) == 0
+    assert composite_key in controller.claude_sessions
+
+    def _raise():
+        raise sqlite3.OperationalError("database is locked")
+
+    controller.session_ownership = SimpleNamespace(snapshot=_raise)
+    assert _sweep(handler) == 0
+    assert composite_key in controller.claude_sessions
+    assert captured["disconnects"] == 0
+
+
+def test_a_dangling_binding_fails_open_for_itself_alone(monkeypatch, tmp_path: Path) -> None:
+    """HFR-137: a deleted target cannot pin, and cannot poison the live pin.
+
+    Fail-closed is right for a lookup that *could not read*; it is wrong for a
+    binding whose session row is positively gone, which would otherwise veto
+    eviction of an unrelated runtime forever. Both halves are asserted in one
+    sweep: the dangling row's runtime is evicted, the live owner's is not.
+    """
+
+    _state_db()
+    handler, controller, live_key, captured = _claude_handler(monkeypatch, tmp_path)
+    dangling_key = f"slack_C999:{tmp_path}"
+    _add_second_runtime(handler, dangling_key, captured)
+
+    _seed_session(BASE_SESSION_ID, anchor=ANCHOR, workdir=str(tmp_path))
+    _seed_delivery(BASE_SESSION_ID, "queued")
+    _seed_session("sesdangling01", anchor="slack_C999", workdir=str(tmp_path))
+    _seed_delivery("sesdangling01", "queued", delivery_id="dlv-dangling")
+    _drop_session_row("sesdangling01")
+
+    evicted = _sweep(handler)
+
+    assert evicted == 1
+    assert live_key in controller.claude_sessions, "the live owner still pins"
+    assert dangling_key not in controller.claude_sessions, (
+        "a binding whose session row is gone must fail open for itself"
+    )
+
+
+def test_the_pin_is_bounded_by_the_stuck_active_threshold(monkeypatch, tmp_path: Path) -> None:
+    """HFR-138: an owner that never settles cannot make a runtime immortal.
+
+    The pin borrows the existing inactivity clock and stuck-active threshold
+    rather than adding one, and a new owner never restarts that clock. Past the
+    bound the runtime is torn down through the settling path (#1140), which
+    retires the pending request and turn token, instead of the plain idle
+    disconnect -- the durable owner is still unsettled at that point.
+    """
+
+    _state_db()
+    _seed_session(BASE_SESSION_ID, anchor=ANCHOR, workdir=str(tmp_path))
+    _seed_delivery(BASE_SESSION_ID, "claimed")
+
+    # Just inside the bound: pinned, and the clock is untouched.
+    handler, controller, composite_key, captured = _claude_handler(
+        monkeypatch, tmp_path, now=STUCK_THRESHOLD - 1.0
+    )
+    assert _sweep(handler) == 0
+    assert handler.session_last_activity[composite_key] == 0.0
+
+    # Past it: force-evicted, through the settling teardown.
+    handler, controller, composite_key, captured = _claude_handler(
+        monkeypatch, tmp_path, now=STUCK_THRESHOLD + 1.0
+    )
+    settled: list[str] = []
+    controller.agent_service = SimpleNamespace(
+        agents={
+            "claude": SimpleNamespace(
+                force_cleanup_stuck_active_session=lambda key: _record(settled, key)
+            )
+        }
+    )
+
+    assert _sweep(handler) == 1
+    assert settled == [composite_key], (
+        "a spent pin must settle its unsettled owner, not just disconnect the client"
+    )
+
+
+async def _record_async(sink: list[str], key: str) -> None:
+    sink.append(key)
+
+
+def _record(sink: list[str], key: str):
+    return _record_async(sink, key)
+
+
+def test_a_parent_turn_pins_its_subagent_runtime(monkeypatch, tmp_path: Path) -> None:
+    """HFR-139: a subagent runtime is projected from its parent's session.
+
+    A subagent's base session id is ``{parent_anchor}:{agent_name}``, so its
+    composite key contains two colons and splits on the LAST one. A live parent
+    Turn owns that runtime too; evicting it kills the subagent mid-flight.
+    """
+
+    _state_db()
+    handler, controller, _parent_key, captured = _claude_handler(monkeypatch, tmp_path)
+    subagent_key = f"{ANCHOR}:reviewer:{tmp_path}"
+    _add_second_runtime(handler, subagent_key, captured)
+
+    _seed_session(BASE_SESSION_ID, anchor=ANCHOR, workdir=str(tmp_path))
+    _seed_turn(BASE_SESSION_ID, "active", runtime_key=f"{ANCHOR}:{tmp_path}")
+
+    assert _sweep(handler) == 0
+    assert subagent_key in controller.claude_sessions
+    assert captured["disconnects"] == 0
+
+
+def test_a_handoff_committed_mid_read_cannot_fall_between_two_reads(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """HFR-140: the union is ONE snapshot, so an ownership handoff is atomic to it.
+
+    The dangerous interleaving is not a lost update, it is a lost OWNER: read
+    Deliveries (only terminal history), then a commit lands that settles the
+    running Turn and admits a follower, then read Turns (now terminal). Two
+    independent reads see no owner at all and evict a session with queued input.
+    One ``BEGIN DEFERRED`` snapshot sees the pre-handoff world consistently, so
+    the Turn still pins -- and the next sweep sees the follower.
+    """
+
+    _state_db()
+    handler, controller, composite_key, captured = _claude_handler(monkeypatch, tmp_path)
+    _seed_session(BASE_SESSION_ID, anchor=ANCHOR, workdir=str(tmp_path))
+    turn_id = _seed_turn(BASE_SESSION_ID, "active")
+
+    def _commit_handoff() -> None:
+        """Settle the Turn and admit a follower, from another connection."""
+
+        with _engine().begin() as conn:
+            conn.execute(
+                sa_text(
+                    "UPDATE session_turns SET state = 'terminal', "
+                    "terminal_outcome = 'completed', terminal_at = :now WHERE id = :id"
+                ),
+                {"id": turn_id, "now": NOW},
+            )
+        _seed_delivery(BASE_SESSION_ID, "queued", delivery_id="dlv-follower")
+
+    controller.session_ownership = DurableSessionOwnershipProvider(
+        engine_factory=lambda: _CommitBetweenReads(_engine(), _commit_handoff)
+    )
+
+    assert _sweep(handler) == 0, "the snapshot's Turn must still pin the runtime"
+    assert composite_key in controller.claude_sessions
+    assert captured["disconnects"] == 0
+    with _engine().connect() as conn:
+        state = conn.execute(
+            sa_text("SELECT state FROM session_turns WHERE id = :id"), {"id": turn_id}
+        ).scalar()
+    assert state == "terminal", "the competing handoff really did commit mid-read"
+
+
+class _CommitBetweenReads:
+    """Engine proxy that lands a competing commit after the Deliveries read."""
+
+    def __init__(self, engine, on_delivery_read) -> None:
+        self._engine = engine
+        self._on_delivery_read = on_delivery_read
+
+    def connect(self):
+        return _ConnectionProxy(self._engine.connect(), self._on_delivery_read)
+
+
+class _ConnectionProxy:
+    def __init__(self, conn, on_delivery_read) -> None:
+        self._conn = conn
+        self._on_delivery_read = on_delivery_read
+        self._fired = False
+
+    def execute(self, statement, *args, **kwargs):
+        result = self._conn.execute(statement, *args, **kwargs)
+        if (
+            not self._fired
+            and isinstance(statement, Select)
+            and "message_deliveries" in str(statement)
+        ):
+            self._fired = True
+            # Materialize the read before the competing write, exactly as the
+            # provider does: the snapshot is established, not merely requested.
+            result = _Rows(list(result.mappings()))
+            self._on_delivery_read()
+        return result
+
+    def __getattr__(self, name):
+        return getattr(self._conn, name)
+
+    def __enter__(self):
+        self._conn.__enter__()
+        return self
+
+    def __exit__(self, *exc_info):
+        return self._conn.__exit__(*exc_info)
+
+
+class _Rows:
+    def __init__(self, rows) -> None:
+        self._rows = rows
+
+    def mappings(self):
+        return self._rows
+
+
+# ---------------------------------------------------------------------------
+# HFR-142 … HFR-146: the Codex and OpenCode consumers
+# ---------------------------------------------------------------------------
+
+
+def _codex_agent(workdir: str, *, ownership=None):
+    """A Codex agent with one live transport keyed by ``workdir``."""
+
+    agent = object.__new__(CodexAgent)
+    stopped: list[str] = []
+    invalidated: list[str] = []
+    cleared: list[str] = []
+
+    async def stop_transport() -> None:
+        stopped.append(workdir)
+
+    agent._transports = {workdir: SimpleNamespace(stop=stop_transport)}
+    agent._transport_last_activity = {workdir: 0.0}
+    agent._transport_locks = {workdir: asyncio.Lock()}
+    agent._session_mgr = SimpleNamespace(
+        sessions_for_cwd=lambda cwd: ["codex-session-1"] if cwd == workdir else [],
+        invalidate_thread=lambda base_session_id: invalidated.append(base_session_id),
+    )
+    agent._turn_registry = SimpleNamespace(
+        get_active_turn=lambda base_session_id: None,
+        clear_session=lambda base_session_id: cleared.append(base_session_id),
+    )
+    agent._session_locks = {"codex-session-1": asyncio.Lock()}
+    agent.sessions = SimpleNamespace(clear_agent_session_mapping=Mock())
+    agent.controller = SimpleNamespace(
+        model_hub_runtime=SimpleNamespace(retire_process_scope=Mock()),
+        session_ownership=ownership,
+    )
+    return agent, SimpleNamespace(stopped=stopped, invalidated=invalidated, cleared=cleared)
+
+
+def _codex_sweep(agent, monkeypatch, *, now: float = 1000.0) -> int:
+    monkeypatch.setattr(codex_agent_module.time, "monotonic", lambda: now)
+    return asyncio.run(agent.evict_idle_transports(IDLE_TIMEOUT))
+
+
+def test_codex_transport_is_pinned_by_a_durable_owner(monkeypatch, tmp_path: Path) -> None:
+    """HFR-142: a Codex transport is a projection too, keyed by working directory.
+
+    Same defect, different keyspace: the app-server process is shared per cwd and
+    evicted on the same idle clock, with the same pre-``active`` window. RED
+    against master (the transport is stopped while a queued Delivery waits).
+    """
+
+    _state_db()
+    workdir = str(tmp_path)
+    _seed_session("sescodex0001", anchor="slack_C777", workdir=workdir, backend="codex")
+    _seed_delivery("sescodex0001", "queued")
+
+    agent, calls = _codex_agent(workdir)
+
+    assert _codex_sweep(agent, monkeypatch) == 0
+    assert calls.stopped == [], "a durably-owned transport must stay up"
+    assert workdir in agent._transports
+    assert agent._transport_last_activity[workdir] == 0.0, "the pin must not touch the clock"
+
+
+def test_codex_unresolved_ownership_skips_the_cycle(monkeypatch, tmp_path: Path) -> None:
+    """HFR-143: the Codex sweep fails closed on an unresolved union, like Claude's."""
+
+    _state_db()
+    workdir = str(tmp_path)
+    agent, calls = _codex_agent(
+        workdir, ownership=SimpleNamespace(snapshot=lambda: UNRESOLVED_SNAPSHOT)
+    )
+
+    assert _codex_sweep(agent, monkeypatch) == 0
+    assert calls.stopped == []
+    assert workdir in agent._transports
+
+
+def test_codex_ownership_admitted_inside_the_lock_vetoes_eviction(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """HFR-144: the Codex recheck inside the per-cwd lock re-reads the union.
+
+    The transport lock serializes eviction against start-up, and the recheck it
+    guards already re-derived activity and the active-turn flag from current
+    state. Durable ownership belongs in that same recheck, or work admitted while
+    the sweep waited for the lock loses its runtime.
+    """
+
+    _state_db()
+    workdir = str(tmp_path)
+    _seed_session("sescodex0001", anchor="slack_C777", workdir=workdir, backend="codex")
+
+    provider = DurableSessionOwnershipProvider()
+    reads = {"count": 0}
+
+    class _AdmitsInsideTheLock:
+        def snapshot(self):
+            reads["count"] += 1
+            if reads["count"] == 2:
+                _seed_delivery("sescodex0001", "queued")
+            return provider.snapshot()
+
+    agent, calls = _codex_agent(workdir, ownership=_AdmitsInsideTheLock())
+
+    assert _codex_sweep(agent, monkeypatch) == 0
+    assert reads["count"] == 2, "the in-lock recheck must consult the union again"
+    assert calls.stopped == []
+    assert workdir in agent._transports
+
+
+def test_a_spent_codex_pin_force_evicts_but_keeps_the_thread_mapping(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """HFR-145: past the cap the transport goes, the resume path stays.
+
+    The Codex bound is ``max(idle_timeout * 3, 1800s)``, the same backstop that
+    reaps a wedged app-server. Eviction stays loss-free because
+    ``invalidate_thread`` drops only the in-memory binding: the persisted thread
+    mapping survives, so the next dispatch resumes the same Codex conversation.
+    """
+
+    _state_db()
+    workdir = str(tmp_path)
+    _seed_session("sescodex0001", anchor="slack_C777", workdir=workdir, backend="codex")
+    _seed_delivery("sescodex0001", "claimed")
+
+    agent, calls = _codex_agent(workdir)
+    agent._settle_stuck_active_request = _settle_recorder(calls)
+
+    assert _codex_sweep(agent, monkeypatch, now=STUCK_THRESHOLD + 1.0) == 1
+    assert calls.stopped == [workdir]
+    assert calls.invalidated == ["codex-session-1"]
+    agent.sessions.clear_agent_session_mapping.assert_not_called()
+    assert workdir not in agent._transports
+
+
+def _settle_recorder(calls):
+    async def _settle(base_session_id: str) -> None:
+        calls.cleared.append(f"settled:{base_session_id}")
+
+    return _settle
+
+
+def test_every_backend_eviction_consumer_is_inventoried() -> None:
+    """HFR-146: a new eviction path may not ship without an ownership decision.
+
+    The inventory is the contract, not a comment: idle eviction lives in exactly
+    two places today, and both consult the interlock. OpenCode has no eviction
+    consumer at all -- its runtime is not reaped on an idle clock -- so it is
+    restart-safe by construction. If that changes, this test fails and the new
+    path has to be classified here.
+    """
+
+    import inspect
+
+    from modules.agents.opencode import agent as opencode_agent_module
+
+    interlocked = {
+        SessionHandler.evict_idle_sessions: session_handler_module,
+        CodexAgent.evict_idle_transports: codex_agent_module,
+    }
+    for function in interlocked:
+        source = inspect.getsource(function)
+        assert "ownership" in source, f"{function.__qualname__} must consult the owner union"
+
+    opencode_evictors = [
+        name
+        for name, _member in inspect.getmembers(opencode_agent_module.OpenCodeAgent, callable)
+        if name.startswith("evict") or name.startswith("reap_idle")
+    ]
+    assert opencode_evictors == [], (
+        "OpenCode grew an idle-eviction path: it must consume core/session_ownership.py "
+        f"or prove restart-safety here -- found {opencode_evictors}"
+    )

--- a/tests/test_session_eviction_interlock.py
+++ b/tests/test_session_eviction_interlock.py
@@ -13,7 +13,7 @@ These tests drive the two real eviction entry points --
 -- against REAL durable rows in the isolated state database, so what is asserted
 is the join between the two keyspaces, not a stub's opinion of it.
 
-Scenarios: HFR-130 … HFR-146 (tests/scenarios/harness_failure_recovery/catalog.yaml).
+Scenarios: HFR-130 … HFR-147 (tests/scenarios/harness_failure_recovery/catalog.yaml).
 """
 
 from __future__ import annotations
@@ -397,7 +397,7 @@ def _sweep(handler, idle_timeout: float = IDLE_TIMEOUT) -> int:
 
 
 # ---------------------------------------------------------------------------
-# HFR-130 … HFR-141: the Claude interlock
+# HFR-130 … HFR-141 + HFR-147: the Claude interlock
 # ---------------------------------------------------------------------------
 
 
@@ -590,6 +590,52 @@ def test_work_admitted_between_the_two_passes_wins(monkeypatch, tmp_path: Path) 
     assert evicted == 0, "work admitted between the passes must defeat the decided eviction"
     assert composite_key in controller.claude_sessions
     assert captured["disconnects"] == 0
+
+
+def test_ownership_admitted_during_an_earlier_teardown_vetoes_the_later_eviction(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """HFR-147: the acting pass re-resolves per candidate, not once per pass.
+
+    HFR-135's re-read is necessary but not sufficient. The acting pass walks a
+    LIST of candidates and every teardown awaits, so a Delivery committed while
+    an earlier candidate is being cleaned up lands after a once-per-pass
+    snapshot was taken. Queued work deliberately touches neither
+    ``session_last_activity`` nor ``active_sessions`` -- the two things the
+    per-candidate recheck already re-derives -- so nothing else in the loop can
+    notice it, and the later runtime is torn down with input already accepted.
+    """
+
+    _state_db()
+    handler, controller, first_key, captured = _claude_handler(monkeypatch, tmp_path)
+    _seed_session(BASE_SESSION_ID, anchor=ANCHOR, workdir=str(tmp_path))
+
+    second_anchor = "slack_C999"
+    second_base = "sesinterlock02"
+    _seed_session(second_base, anchor=second_anchor, workdir=str(tmp_path))
+    second_key = f"{second_anchor}:{tmp_path}"
+    _add_second_runtime(handler, second_key, captured)
+
+    class _AdmitsDuringTeardown:
+        """The first candidate's disconnect is when the follower is accepted."""
+
+        async def disconnect(self) -> None:
+            captured["disconnects"] += 1
+            _seed_delivery(second_base, "queued", delivery_id="dlv-admitted-mid-teardown")
+
+    handler.claude_sessions[first_key] = _AdmitsDuringTeardown()
+
+    evicted = _sweep(handler)
+
+    assert captured["disconnects"] == 1, "the first candidate must really have been torn down"
+    with _engine().connect() as conn:
+        admitted = conn.execute(
+            sa_text("SELECT state FROM message_deliveries WHERE id = 'dlv-admitted-mid-teardown'")
+        ).fetchone()
+    assert admitted is not None and admitted[0] == "queued", "the race must really have happened"
+    assert evicted == 1, "only the first candidate may be evicted"
+    assert second_key in handler.claude_sessions
+    assert captured.get(second_key, 0) == 0, "the newly owned runtime must survive"
 
 
 def test_unresolved_ownership_skips_the_whole_cycle(monkeypatch, tmp_path: Path) -> None:

--- a/tests/test_session_eviction_interlock.py
+++ b/tests/test_session_eviction_interlock.py
@@ -13,7 +13,7 @@ These tests drive the two real eviction entry points --
 -- against REAL durable rows in the isolated state database, so what is asserted
 is the join between the two keyspaces, not a stub's opinion of it.
 
-Scenarios: HFR-130 … HFR-149 (tests/scenarios/harness_failure_recovery/catalog.yaml).
+Scenarios: HFR-130 … HFR-151 (tests/scenarios/harness_failure_recovery/catalog.yaml).
 """
 
 from __future__ import annotations
@@ -326,6 +326,27 @@ def _set_delivery_state(delivery_id: str, state: str) -> None:
         conn.execute(
             sa_text("UPDATE message_deliveries SET state = :state WHERE id = :id"),
             {"state": state, "id": delivery_id},
+        )
+
+
+def _delivery_state(delivery_id: str) -> Optional[str]:
+    """The row's current state, or ``None`` if eviction destroyed the row."""
+
+    with _engine().begin() as conn:
+        row = conn.execute(
+            sa_text("SELECT state FROM message_deliveries WHERE id = :id"),
+            {"id": delivery_id},
+        ).fetchone()
+    return None if row is None else row[0]
+
+
+def _turn_count(session_id: str) -> int:
+    with _engine().begin() as conn:
+        return int(
+            conn.execute(
+                sa_text("SELECT count(*) FROM session_turns WHERE session_id = :sid"),
+                {"sid": session_id},
+            ).scalar_one()
         )
 
 
@@ -1108,3 +1129,97 @@ def test_an_unrecognized_run_status_still_pins(monkeypatch, tmp_path: Path) -> N
     assert _sweep(handler) == 0, "an unknown Run status must fail closed and pin"
     assert composite_key in controller.claude_sessions
     assert captured["disconnects"] == 0
+
+
+# ---------------------------------------------------------------------------
+# HFR-150 … HFR-151: the residual admission window is loss-free
+# ---------------------------------------------------------------------------
+#
+# The final ownership read is NOT atomic with teardown: admission is a durable
+# commit that deliberately takes no runtime lock (input acceptance must never
+# block on a backend), so work can be accepted while an approved teardown is
+# already awaiting. Plan section 4's evidence bullet is what governs that window
+# -- "every enabled backend eviction path either honors the provider or proves
+# queued work resumes without loss or replay" -- not atomicity. These two tests
+# are that proof: when eviction loses the race, the durable input survives
+# untouched and the runtime registry is left in a state the next dispatch can
+# rebuild from, so the cost is a cold start rather than a lost turn.
+
+
+def test_codex_admission_during_teardown_costs_a_restart_not_the_work(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """HFR-150: a Delivery committed while ``transport.stop()`` awaits is not lost.
+
+    Admission here commits inside the stop, i.e. after the in-lock ownership
+    recheck has already approved the eviction -- the exact window a snapshot
+    cannot close. What makes it survivable is that the eviction holds
+    ``_transport_locks[cwd]`` across both the recheck and the stop, and
+    ``_get_or_create_transport`` acquires that same lock: the dispatch cannot
+    observe the half-torn-down transport, and once the lock is free it finds no
+    transport and builds a fresh one. The persisted thread mapping is what makes
+    that rebuild a resume instead of a new conversation, so it must survive.
+    """
+
+    _state_db()
+    workdir = str(tmp_path)
+    _seed_session("sescodex0001", anchor="slack_C777", workdir=workdir, backend="codex")
+
+    agent, calls = _codex_agent(workdir)
+
+    async def _stop_then_admit() -> None:
+        calls.stopped.append(workdir)
+        _seed_delivery("sescodex0001", "queued", delivery_id="dlv-admitted-mid-stop")
+
+    agent._transports[workdir] = SimpleNamespace(stop=_stop_then_admit)
+
+    assert _codex_sweep(agent, monkeypatch) == 1
+
+    # The work itself is untouched: still claimable, no turn invented for it.
+    assert _delivery_state("dlv-admitted-mid-stop") == "queued"
+    assert _turn_count("sescodex0001") == 0
+    # No stale handle survives, so the next dispatch cannot reuse a stopped
+    # app-server -- it has to create one.
+    assert workdir not in agent._transports
+    assert workdir not in agent._transport_last_activity
+    # ... and it can: the lock is released and the resume mapping is intact.
+    assert not agent._transport_locks[workdir].locked()
+    agent.sessions.clear_agent_session_mapping.assert_not_called()
+
+
+def test_claude_admission_during_teardown_costs_a_restart_not_the_work(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """HFR-151: the same proof for the Claude consumer.
+
+    HFR-147 covers the case where the admission is visible in time to veto a
+    LATER candidate. This is the irreducible remainder: the admission lands
+    during this candidate's own disconnect, after its own re-resolution. It is
+    survivable because ``cleanup_session`` pops the client out of
+    ``claude_sessions`` synchronously, before it awaits anything, so a dispatch
+    arriving afterwards never sees the disconnecting client -- it misses, and
+    ``get_or_create_claude_session`` builds a fresh client that resumes the same
+    native session id.
+    """
+
+    _state_db()
+    handler, controller, composite_key, captured = _claude_handler(monkeypatch, tmp_path)
+    _seed_session(BASE_SESSION_ID, anchor=ANCHOR, workdir=str(tmp_path))
+
+    class _AdmitsDuringOwnDisconnect:
+        async def disconnect(self) -> None:
+            captured["disconnects"] += 1
+            _seed_delivery(BASE_SESSION_ID, "queued", delivery_id="dlv-admitted-mid-disconnect")
+
+    handler.claude_sessions[composite_key] = _AdmitsDuringOwnDisconnect()
+
+    assert _sweep(handler) == 1
+    assert captured["disconnects"] == 1
+
+    assert _delivery_state("dlv-admitted-mid-disconnect") == "queued"
+    assert _turn_count(BASE_SESSION_ID) == 0
+    # The stale client is gone rather than left half-disconnected in the map, and
+    # nothing resurrected the activity clock on the way out.
+    assert composite_key not in handler.claude_sessions
+    assert composite_key not in controller.claude_sessions
+    assert composite_key not in handler.session_last_activity


### PR DESCRIPTION
## Capability

Idle backend-runtime eviction may not destroy a runtime that a durable row still owns. PR3 of `docs/plans/harness-run-reliability.md`.

## Defect (reproduces on current master)

Idle eviction is gated entirely by in-memory state: an in-memory runtime key, an in-memory activity clock, and an `active` flag that only exists once a turn has reached native start. Every durable owner from #1134/#1139/#1140 predates that flag — a `queued` Delivery, a `waiting`/`starting` Turn, a Run that has resolved its session but not yet reserved input. Each of those is a session whose input the user has already had accepted, sitting behind a runtime that looks perfectly idle. The sweep then disconnects the SDK client or reaps the Codex transport the row is about to be dispatched into.

Classification per plan §3: **reproduces**, not fixed by #1134/#1139/#1140 and not superseded. RED baseline against master (both consumers reverted, provider module kept so imports resolve): **25 of 31 failures**; the 6 that pass are the negative controls. With the fix: 31/31.

## Change

- `core/session_ownership.py` (new) — one provider resolving the current durable owners of every session. Deliveries pin by their `DELIVERY_STATE_MATRIX` ordering role (`claimable`/`fence`/`turn_owned`), read as `NOT IN terminal` so an unrecognized state pins rather than being silently skipped; Turns pin in `waiting`/`starting`/`active`; execution-bearing Runs pin when their status is `NOT IN terminal` (same rule — `agent_runs.status` has no CHECK and unknown values pass through `normalize_run_status`, so an allowlist would drop the interlock) and not already represented, `watch_runtime` heartbeats never pin, and an unknown `run_type` pins with a one-time warning. The whole union is read inside ONE `BEGIN DEFERRED` snapshot, off the event loop, so an ownership handoff committed mid-read cannot fall between two reads.
- Pins are backend-scoped. Both keyspaces collapse across backends at the default workdir, so the snapshot retains each session's backends (`agent_sessions.agent_backend` ∪ its nonterminal Turns' `backend` ∪ the backend each nonterminal Run captured at request time, so a mid-switch session pins both) and each consumer asks with its own. Only a *positive* mismatch drops a pin — an unnamed backend, or a session whose backend cannot be established, still pins.
- Keyspace join: eviction is keyed by in-memory runtime keys, durable rows by `agent_sessions.id`. Resolved via the authoritative `session_turns.runtime_key` where a turn reached native start, plus composition from `(session_anchor, normalized workdir)` for the pre-start window — otherwise the pin would be absent exactly where it is needed. Matched anchor-first rather than by splitting the key, since neither half is escaped and a workdir may contain a colon; a subagent runs under its parent's anchor, so a live parent turn pins it too.
- `core/handlers/session_handler.py` — the selection pass of `evict_idle_sessions` consults the provider and the acting pass re-resolves it immediately before each teardown, so work admitted between the passes — or while an earlier candidate is being torn down — wins. `cleanup_session`'s duplicate-process reap now goes through `_reap_duplicates_sparing_replacement`, so the client that replaced this one mid-teardown is never mistaken for a leak.
- `modules/agents/codex/agent.py` — same interlock per cwd, re-read inside the per-cwd transport lock where the sweep can wait.
- Failure modes: a provider-wide failure skips the cycle (missing safety data is not evidence that eviction is safe); a binding whose session row is positively gone fails open for that binding alone. An *entirely* absent owner schema is the one exception — it is positive proof no owner exists — while a *partial* one is missing safety data and skips the cycle.
- Bound: the pin borrows the existing inactivity clock and stuck-active threshold, a new owner never restarts the clock, and past the bound teardown goes through the #1140 settling path (`force_cleanup_stuck_active_session` / `_settle_stuck_active_request`) rather than the plain idle disconnect — the owner is still unsettled at that point. The Codex force path keeps the persisted thread mapping, so eviction stays loss-free.
- No path touches `session_last_activity`: waiting is not activity.

## Accepted residual: admission is not serialized with teardown

The final ownership read is deliberately *not* atomic with teardown. Admission is a durable commit that takes no backend runtime lock, because input acceptance must never block on a backend — that is the coupling #1134 exists to remove, and putting `_transport_locks[cwd]` on the enqueue path would reintroduce it on the hot path. So a Delivery can be admitted after an approved candidate's last re-resolution, while its teardown is already awaiting.

What bounds it is not a lock but the property plan §4 actually asks of an eviction path — *"proves queued work resumes without loss or replay."* Teardown removes the runtime from its registry before anything can observe it half-torn-down: Codex holds the per-cwd lock across both the recheck and `await transport.stop()` and pops `_transports[cwd]` before releasing it, while `_get_or_create_transport` takes the same lock and is the only path handing a transport to a dispatch; Claude's `cleanup_session` pops the client synchronously before its first await. A losing dispatch therefore misses, rebuilds, and *resumes* — the persisted resume state (native session id, Codex thread mapping) is never cleared — so the cost is a cold start, not a lost turn. Proven by HFR-150/151 and recorded as a named residual in plan §4, with the condition to revisit: a rebuild ceasing to be cheap.

That property belongs to the whole teardown path, not just to popping the registry, and the fifth review head found the one place it did not yet hold: the very thing that makes the rebuild a resume — the replacement running with the same `--resume <native_session_id>` — also made it indistinguishable from a leaked duplicate to the reaper in `cleanup_session`'s `finally`, which on this path had no PID to keep. So any teardown step keyed on the *native session id* rather than on the object being retired now spares a replacement (HFR-431).

## Backend inventory

Claude and Codex both consume the provider. OpenCode has no idle-eviction consumer at all, so it is restart-safe by construction. Encoded as a guard test (HFR-146) that fails if a third eviction path appears without an ownership decision.

## Scenario IDs

`HFR-130` … `HFR-154` plus `HFR-431` (26), added to `tests/scenarios/harness_failure_recovery/catalog.yaml`; each ID is named in its test docstring. PR3's reserved block ends at `HFR-154`, so the last review-driven addition follows the plan's own rule — a fresh ID above the highest allocated one (430) — rather than borrowing PR4's `HFR-155…179`.

- HFR-130 queued input pins its own runtime and no other, clock untouched
- HFR-131 the pin is derived from the state policy, asserted across all nine Delivery states
- HFR-132 a Turn with no `runtime_key` yet still pins · HFR-141 a settled Turn does not
- HFR-133 a `watch_runtime` heartbeat does not pin · HFR-134 execution-bearing and unclassified Runs do
- HFR-135 work admitted between the two passes wins · HFR-144 the same for the Codex in-lock recheck
- HFR-136 / HFR-143 unresolved union skips the cycle (Claude / Codex)
- HFR-137 a positively-dangling binding fails open for itself alone
- HFR-138 / HFR-145 the pin is bounded and settles through the teardown path (Claude / Codex)
- HFR-139 a live parent Turn pins its subagent runtime
- HFR-140 an ownership handoff committed mid-read cannot fall between two reads
- HFR-142 a Codex transport is pinned by an owner rooted at its cwd
- HFR-146 backend eviction-path inventory guard
- HFR-147 ownership admitted during an earlier teardown vetoes the later eviction (review finding on the first head: the acting pass re-resolves per candidate, not once per pass)
- HFR-148 a pin does not cross backends at a shared workdir, both directions (review finding on the second head)
- HFR-149 an unrecognized `agent_runs.status` still pins (review finding on the second head)
- HFR-150 / HFR-151 a Delivery admitted *during* teardown costs a restart, not the work — the queued row survives untouched, no turn is invented, no stale runtime or activity entry is left, and the resume state is intact (Codex / Claude; review finding on the third head)
- HFR-152 a workdir containing a colon still pins its Claude runtime — `C:\repo` on Windows, a POSIX `proj:v2`; the last-colon split read the drive letter as part of the base and lost the pin exactly where a queued Delivery has no observed key to compensate (review finding on the fourth head)
- HFR-153 a Run pins the backend it captured, not the session's switched backend — a Run carries its own routing identity and `MessageHandler` gives that precedence, so a Run queued across a backend switch lands where it was recorded (review finding on the fourth head)
- HFR-154 a partially migrated owner schema fails closed — an absent schema and a half-present one are opposite cases, and collapsing them let an execution-bearing Run in a database missing its Delivery table read as "nothing owns anything"; includes the positive control that a fully empty schema still resolves (review finding on the fifth head)
- HFR-431 the duplicate Claude resume reap spares a replacement client — the replacement resumes the same native session id and so matches the reaper's own `--resume` filter; with no PID to keep, teardown could SIGTERM the client that was carrying the work it handed off (review finding on the fifth head)

## Evidence layers

- **Contract/unit**: `tests/test_session_eviction_interlock.py`, 41 tests at the real owner boundary — real migrated SQLite, rows seeded in their real constraint-satisfying shapes, real `evict_idle_sessions` / `evict_idle_transports` call paths. HFR-140 drives the actual interleaving with an engine proxy that lands a competing commit right after the Deliveries read and asserts both that the pin holds and that the handoff really committed, so it cannot pass by failing to race. Hermetic: state redirected to `tmp_path`, no writes to a real `~/.avibe`.
- **Scenario catalog**: `tests/scenarios/harness_failure_recovery/catalog.yaml` (+ `INDEX.yaml`, plan reference).
- **Adjacent regression**: `tests/test_session_eviction_interlock.py tests/test_harness_failure_visibility.py tests/test_claude_cli_path.py tests/test_codex_agent.py tests/test_codex_transport.py tests/test_session_delivery_fsm.py tests/test_agent_service.py tests/test_watches.py` → 580 passed (includes the import-weight guard). `ruff check` clean on changed files.
- **Import weight**: the provider reads the state DB, so it pulls `storage` and with it `sqlite3`. `core.handlers.session_handler` is on the lightweight import path guarded by `tests/test_native_session_providers.py::test_native_session_lightweight_imports_do_not_require_sqlite` (caught by CI shard 3/4), so the import is deferred into `_resolve_session_ownership` — eviction is the only caller — with the snapshot type kept for annotations via `TYPE_CHECKING`.
- **Residual manual**: local Incus cross-platform verification of a long-idle session receiving queued input after the idle window — not yet run.

No UI change, no new user-facing copy (log-only), so no i18n or `ui` build needed.

## Non-goals honored

No new Run status, no second output ledger, no backend-level exactly-once execution, no absolute turn-duration timeout, no widening into unrelated process lifecycle cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
