### PR TITLE
fix(agents): use muted idle status dots

### DIFF
--- a/ui/src/lib/agentGraph.test.ts
+++ b/ui/src/lib/agentGraph.test.ts
@@ -100,6 +100,8 @@ describe('nodeDisplayTitle', () => {
 describe('statusMeta / isBackground', () => {
   it('maps status to tone + glyph', () => {
     expect(statusMeta('active').glyph).toBe('dot');
+    expect(statusMeta('active').dotClass).toBe('bg-mint');
+    expect(statusMeta('idle')).toMatchObject({ tone: 'muted', dotClass: 'bg-muted', glyph: 'dot' });
     expect(statusMeta('succeeded').glyph).toBe('check');
     expect(statusMeta('failed').glyph).toBe('cross');
     expect(statusMeta('failed').tone).toBe('destructive');

--- a/ui/src/lib/agentGraph.ts
+++ b/ui/src/lib/agentGraph.ts
@@ -191,7 +191,7 @@ export type StatusMeta = {
 const STATUS_META: Record<AgentGraphStatus, StatusMeta> = {
   active: { tone: 'mint', dotClass: 'bg-mint', labelKey: 'agents.graph.status.active', dim: false, glyph: 'dot' },
   queued: { tone: 'gold', dotClass: 'bg-gold', labelKey: 'agents.graph.status.queued', dim: false, glyph: 'dot' },
-  idle: { tone: 'cyan', dotClass: 'bg-cyan', labelKey: 'agents.graph.status.idle', dim: false, glyph: 'dot' },
+  idle: { tone: 'muted', dotClass: 'bg-muted', labelKey: 'agents.graph.status.idle', dim: false, glyph: 'dot' },
   orphan: { tone: 'gold', dotClass: 'bg-amber-500', labelKey: 'agents.graph.status.orphan', dim: false, glyph: 'dot' },
   succeeded: { tone: 'muted', dotClass: 'bg-muted', labelKey: 'agents.graph.status.succeeded', dim: true, glyph: 'check' },
   failed: { tone: 'destructive', dotClass: 'bg-destructive', labelKey: 'agents.graph.status.failed', dim: true, glyph: 'cross' },


### PR DESCRIPTION
## Summary
- align Agent Graph liveness indicators with the shared design contract: active sessions remain green and idle sessions use muted gray
- apply the change through the shared status mapping used by graph cards, mobile lists, search results, and detail views
- preserve queued and terminal outcome styling as separate status semantics

## Scenario coverage
- Scenario IDs: none; the repository scenario catalog does not cover this visual Agent Graph status-token mapping

## Evidence
- Unit: `npx vitest run src/lib/agentGraph.test.ts` (21 tests passed)
- Contract: shared `statusMeta` assertions pin active to mint and idle to muted
- Scenario: not applicable; no cataloged end-to-end scenario for this visual token mapping
- UI gate: `npm run lint` and `npm run build` passed
- Residual manual check: compare the Agent Graph active and idle indicators against the approved design preview

## Risk
Low. The change is limited to the shared idle color token and its regression assertion.
