### PR TITLE
fix(codex): identify Avibe in upstream client metadata

### DIFF
--- a/modules/agents/codex/transport.py
+++ b/modules/agents/codex/transport.py
@@ -110,7 +110,7 @@ class CodexTransport:
                 "initialize",
                 {
                     "clientInfo": {
-                        "name": "vibe-remote",
+                        "name": "avibe",
                         "version": "1.0.0",
                     },
                 },

--- a/tests/test_codex_agent.py
+++ b/tests/test_codex_agent.py
@@ -1,5 +1,6 @@
 import asyncio
 import importlib.util
+import json
 import os
 import sys
 import tempfile
@@ -3091,6 +3092,9 @@ class CodexTransportCommandTests(unittest.IsolatedAsyncioTestCase):
             transport = Transport(binary="codex", cwd="/tmp/work")
             await transport.start()
             await transport.stop()
+            initialize_request = json.loads(writes[0])
+            self.assertEqual(initialize_request["method"], "initialize")
+            self.assertEqual(initialize_request["params"]["clientInfo"]["name"], "avibe")
             transport = Transport(
                 binary="codex",
                 cwd="/tmp/work",


### PR DESCRIPTION
## What changed

Codex app-server initialization now identifies the embedding client as `avibe`, so Codex upstream requests no longer use the legacy `vibe-remote` client name.

## Evidence

- Unit: `tests/test_codex_agent.py` asserts the initialize JSON-RPC payload carries `clientInfo.name == "avibe"`.
- Contract: the Codex app-server initialize client metadata is the changed boundary.
- Scenario: no scenario catalog entry applies to this transport metadata-only change.
- Residual manual check: real upstream request capture is deferred; the local Codex CLI is `0.145.0` and the transport handshake test covers the source of the client label.

## Dependencies

None.
