### PR TITLE
fix(chat): restore result metrics hover behavior

### DIFF
--- a/ui/src/components/workbench/ChatArchivedReadOnly.test.tsx
+++ b/ui/src/components/workbench/ChatArchivedReadOnly.test.tsx
@@ -756,6 +756,7 @@ describe('read-only transcript locks the secret-request cards', () => {
 
 describe('Agent result metrics tail', () => {
   const footer = '✅ ⏱️ 5s · 🪙 1.2k tok';
+  const displayedFooter = '⏱️ 5s · 🪙 1.2k tok';
 
   it('renders structured duration and token usage once, after the timestamp', () => {
     const markup = render(
@@ -766,9 +767,12 @@ describe('Agent result metrics tail', () => {
       />,
     );
 
-    expect(markup.split(footer)).toHaveLength(2);
-    expect(markup.indexOf('2026-07-27')).toBeLessThan(markup.indexOf(footer));
-    expect(markup).toContain('opacity-100');
+    expect(markup).not.toContain(footer);
+    expect(markup.split(displayedFooter)).toHaveLength(2);
+    expect(markup.indexOf('2026-07-27')).toBeLessThan(markup.indexOf(displayedFooter));
+    expect(markup).toContain(
+      'opacity-0 transition-opacity duration-150 group-hover/message:opacity-100 group-focus-within/message:opacity-100 pointer-coarse:opacity-100',
+    );
     expect(markup).toContain('flex-wrap');
   });
 
@@ -783,8 +787,9 @@ describe('Agent result metrics tail', () => {
     );
 
     expect(markup).toContain('Answer body');
-    expect(markup.split(footer)).toHaveLength(2);
-    expect(markup.indexOf('2026-07-27')).toBeLessThan(markup.indexOf(footer));
+    expect(markup).not.toContain(footer);
+    expect(markup.split(displayedFooter)).toHaveLength(2);
+    expect(markup.indexOf('2026-07-27')).toBeLessThan(markup.indexOf(displayedFooter));
   });
 
   it('renders a footer-only completion in metadata without an empty bubble', () => {
@@ -797,8 +802,9 @@ describe('Agent result metrics tail', () => {
       <MessageRow message={footerOnly} session={session()} messageFontSize={13} />,
     );
 
-    expect(markup.split(footer)).toHaveLength(2);
-    expect(markup.indexOf('2026-07-27')).toBeLessThan(markup.indexOf(footer));
+    expect(markup).not.toContain(footer);
+    expect(markup.split(displayedFooter)).toHaveLength(2);
+    expect(markup.indexOf('2026-07-27')).toBeLessThan(markup.indexOf(displayedFooter));
     expect(markup).not.toContain('vr-markdown--inherit-size');
   });
 
@@ -814,8 +820,9 @@ describe('Agent result metrics tail', () => {
     );
 
     expect(markup).toContain('Failed to finish');
-    expect(markup.split(footer)).toHaveLength(2);
-    expect(markup.indexOf('2026-07-27')).toBeLessThan(markup.indexOf(footer));
+    expect(markup).not.toContain(footer);
+    expect(markup.split(displayedFooter)).toHaveLength(2);
+    expect(markup.indexOf('2026-07-27')).toBeLessThan(markup.indexOf(displayedFooter));
   });
 });
 

--- a/ui/src/components/workbench/ChatPage.tsx
+++ b/ui/src/components/workbench/ChatPage.tsx
@@ -3608,12 +3608,7 @@ export const MessageRow = memo(function MessageRow({
   // Coarse pointers (touch) have no hover, so keep it always visible there.
   const time = (
     <span
-      className={clsx(
-        'inline-flex max-w-full flex-wrap items-center gap-x-1.5 gap-y-0.5 px-1 font-mono text-[10px] text-muted transition-opacity duration-150',
-        resultPresentation.footer
-          ? 'opacity-100'
-          : 'opacity-0 group-hover/message:opacity-100 group-focus-within/message:opacity-100 pointer-coarse:opacity-100',
-      )}
+      className="inline-flex max-w-full flex-wrap items-center gap-x-1.5 gap-y-0.5 px-1 font-mono text-[10px] text-muted opacity-0 transition-opacity duration-150 group-hover/message:opacity-100 group-focus-within/message:opacity-100 pointer-coarse:opacity-100"
     >
       <span className="whitespace-nowrap">{formatLocalDateTime(message.created_at)}</span>
       {resultPresentation.footer ? <span className="min-w-0 break-words">{resultPresentation.footer}</span> : null}

--- a/ui/src/lib/resultFooter.test.ts
+++ b/ui/src/lib/resultFooter.test.ts
@@ -20,7 +20,7 @@ describe('resultFooterParts', () => {
     const footer = '✅ ⏱️ 5s · 🪙 1.2k tok';
     expect(resultFooterParts(message(`Answer\n\n${footer}`, { result_footer: footer }))).toEqual({
       body: 'Answer',
-      footer,
+      footer: '⏱️ 5s · 🪙 1.2k tok',
     });
   });
 
@@ -28,24 +28,30 @@ describe('resultFooterParts', () => {
     const footer = '✅ ⏱️ 2m 24s';
     expect(resultFooterParts(message('Answer', { result_footer: footer }))).toEqual({
       body: 'Answer',
-      footer,
+      footer: '⏱️ 2m 24s',
     });
   });
 
   it('recognizes legacy duration and token footer shapes', () => {
-    for (const footer of [
-      '✅ ⏱️ 0s',
-      '⚠️ ⏱️ 2m 4s · 🪙 240k tok',
-      '❌ 🪙 12.3k tok',
-      '✅ 🪙 1.4M tok',
+    for (const [footer, displayedFooter] of [
+      ['✅ ⏱️ 0s', '⏱️ 0s'],
+      ['⚠️ ⏱️ 2m 4s · 🪙 240k tok', '⚠️ ⏱️ 2m 4s · 🪙 240k tok'],
+      ['❌ 🪙 12.3k tok', '❌ 🪙 12.3k tok'],
+      ['✅ 🪙 1.4M tok', '🪙 1.4M tok'],
     ]) {
-      expect(resultFooterParts(message(`Answer\n\n${footer}`))).toEqual({ body: 'Answer', footer });
+      expect(resultFooterParts(message(`Answer\n\n${footer}`))).toEqual({
+        body: 'Answer',
+        footer: displayedFooter,
+      });
     }
   });
 
   it('moves a standalone generated footer out of a footer-only completion body', () => {
     const footer = '✅ ⏱️ 5s · 🪙 1.2k tok';
-    expect(resultFooterParts(message(footer))).toEqual({ body: '', footer });
+    expect(resultFooterParts(message(footer))).toEqual({
+      body: '',
+      footer: '⏱️ 5s · 🪙 1.2k tok',
+    });
   });
 
   it('does not move authored text or non-Agent result content', () => {

--- a/ui/src/lib/resultFooter.ts
+++ b/ui/src/lib/resultFooter.ts
@@ -8,6 +8,10 @@ export type ResultFooterParts = {
   footer: string | null;
 };
 
+function webResultFooter(footer: string): string {
+  return footer.replace(/^✅\s+/u, '');
+}
+
 /** Separate Avibe's generated duration/token summary from an Agent reply body. */
 export function resultFooterParts(
   message: Pick<WorkbenchMessage, 'author' | 'type' | 'text' | 'content'>,
@@ -22,12 +26,12 @@ export function resultFooterParts(
     const suffix = `\n\n${footer}`;
     return {
       body: message.text.endsWith(suffix) ? message.text.slice(0, -suffix.length) : message.text,
-      footer,
+      footer: webResultFooter(footer),
     };
   }
 
   if (LEGACY_RESULT_FOOTER_RE.test(message.text)) {
-    return { body: '', footer: message.text };
+    return { body: '', footer: webResultFooter(message.text) };
   }
 
   // Rows created before result_footer became structured still contain the exact
@@ -37,5 +41,5 @@ export function resultFooterParts(
   if (splitAt < 0) return { body: message.text, footer: null };
   const candidate = message.text.slice(splitAt + 2);
   if (!LEGACY_RESULT_FOOTER_RE.test(candidate)) return { body: message.text, footer: null };
-  return { body: message.text.slice(0, splitAt), footer: candidate };
+  return { body: message.text.slice(0, splitAt), footer: webResultFooter(candidate) };
 }


### PR DESCRIPTION
## What

- Hide the Web result metadata row until its message is hovered or focused, matching the existing timestamp behavior.
- Remove the success-only `✅` prefix from the Web metrics tail while preserving the stored/IM footer unchanged.
- Keep warning and error status prefixes intact.

## Why

PR #1128 moved duration and token metrics beside the timestamp, but metrics-bearing rows accidentally became permanently visible. The success marker is useful in IM result text but redundant in the Web metadata presentation.

## Evidence

- Unit: `resultFooter.test.ts` covers structured, legacy, and footer-only success-prefix removal while retaining warning/error prefixes.
- Contract: `ChatArchivedReadOnly.test.tsx` asserts timestamp-first rendering and the existing hover/focus/coarse-pointer visibility classes.
- Scenario: no catalog scenario ID applies to this presentation-only correction.
- Build: focused Vitest suite, UI lint baseline, and production UI build pass.

## Residual checks

- Manual pointer-hover verification in a live transcript remains for integration acceptance.

## Risk

Low. The change is confined to Web presentation; backend and IM result footer payloads are unchanged.
