### PR TITLE
docs(memory): simplify sidecar force-restart plan

### DIFF
--- a/docs/plans/memory-sidecar-force-restart-button.md
+++ b/docs/plans/memory-sidecar-force-restart-button.md
@@ -1,13 +1,15 @@
-# Add a forced sidecar restart action to Memory settings (rev10)
+# Add a forced sidecar restart action to Memory settings (rev11)
 
-> Rev10 keeps one public recovery action and a focused set of internal fixes:
+> Rev11 keeps one public recovery action and a focused set of internal fixes:
 > replayable configuration, config-wide write serialization, restart-specific
 > and Clear-intent admission, generation-fenced ready activation, complete
 > supervisor quiescing, bounded orphan recovery, disk/live replay convergence,
-> store-thread settlement, worker lease rotation, and locked clear-marker
-> recovery. Timed-out work remains owned until it is either joined or proven
-> unable to mutate state. It does not add a lifecycle coordinator, explicit
-> state machine, provider/store port, or frontend DOM test framework.
+> marker-free replay promotion, store-thread settlement, worker lease rotation,
+> locked clear-marker recovery, bounded readiness, supervisor callback rebinding,
+> and authoritative UI settings refresh. Timed-out work remains owned until it
+> is either joined or proven unable to mutate state. It does not add a lifecycle
+> coordinator, explicit state machine, provider/store port, or frontend DOM test
+> framework.
 
 ## Background and goals
 
@@ -105,6 +107,14 @@ Add private `_restart_config` and `_persisted_memory_snapshot` values to
   marker-free disk block and refreshes the snapshot before any later reconcile
   phase can return or fail. A failed/aborted transaction leaves the previous
   snapshot unchanged.
+- Marker settlement also replaces the in-flight reconcile candidate with a deep
+  copy of that exact committed marker-free block before live application
+  continues. If the remaining reconcile succeeds, commit that marker-free
+  candidate to both `self._config` and `_restart_config`; never reconstruct it
+  from the original marker-bearing request object. If a later reconcile phase
+  fails, keep the previous last-good `_restart_config` while retaining the exact
+  marker-free `_persisted_memory_snapshot` for conditional disk convergence on a
+  later restart.
 
 These snapshots answer which configuration an explicit restart replays and
 which exact Memory block it may conditionally replace on disk. They do not
@@ -302,6 +312,12 @@ an abandoned restart, and a user retry can enqueue a second one.
   start failure. The start budget uses that single outer reap cap, readiness
   wait, and another full stop budget for cleanup after a spawned replacement
   fails to become ready; it never assumes only one internal reap round.
+- Put one outer `asyncio.timeout(_STARTUP_TIMEOUT_SECONDS)` around the complete
+  `_wait_for_ready()` operation, not only a deadline check at the top of its
+  polling loop. The cap includes socket security, the final `/health` request,
+  its response body, and polling sleeps. A readiness timeout enters the existing
+  separately budgeted failed-start cleanup; no individual health request may
+  extend the readiness phase beyond the exported start budget.
 - Expose a process-owner settlement budget that includes watcher/monitor
   cancellation joins and one complete TERM/KILL cleanup round. Set
   `MEMORY_RESTART_TIMEOUT_SECONDS` strictly above the sum of two clear cleanup
@@ -380,8 +396,11 @@ The locked sequence is fixed:
    first and clear the marker in the replay block. The transaction must replace
    only the expected persisted Memory block with replay C0, preserving every
    unrelated field, and return the exact committed block. Refresh
-   `_persisted_memory_snapshot` from that return value and restore `self._config`
-   only after convergence succeeds.
+   `_persisted_memory_snapshot` from that return value, use the returned block as
+   the marker-free replay object, and restore `self._config` only after
+   convergence succeeds. Ordinary persisted reconcile follows the same rule:
+   settlement rebases its private in-flight candidate from the committed block,
+   so successful live and `_restart_config` state cannot retain the old marker.
 9. Stop the old process. Do not discard its supervisor or start another child
    until its process tree is confirmed reaped.
 10. Create a process from `_restart_config` bound to the lifecycle generation
@@ -443,14 +462,18 @@ Every exit after claims are fenced must end in one of these states:
   recovery, rotate the lease, or touch process ownership until the thread has
   returned and its terminal result has been consumed.
 - **Failure before `old_process.stop()` is invoked:** the old supervisor still
-  owns its child but is quiesced. Re-arm supervision and ready callbacks. If its
-  child is still running, reactivate with the new lease owner, resume claims and
-  the worker, and return the specific failure. If the child exited during the
-  handoff, keep claims fenced and let the re-armed supervisor start a child;
-  only a current-generation activation task may resume the worker after taking
-  both lifecycle locks. This branch applies only after the previous worker,
-  store, and process-owner tasks are confirmed done; it never attempts
-  reactivation beside a retained task.
+  owns its child but is quiesced. While both runtime lifecycle locks remain
+  owned, re-arm supervision and replace its ready callback with one bound to the
+  current supervisor object and the lifecycle generation that owns this failure
+  recovery; when invoked, that callback captures the child identity that actually
+  reached ready. Never reuse the generation captured when the supervisor object
+  was originally created. If its child is still running, reactivate with the new
+  lease owner, resume claims and the worker, and return the specific failure. If
+  the child exited during the handoff, keep claims fenced and let the re-armed
+  supervisor start a child; only the newly bound current-generation activation
+  task may resume the worker after taking both lifecycle locks. This branch
+  applies only after the previous worker, store, and process-owner tasks are
+  confirmed done; it never attempts reactivation beside a retained task.
 - **`old_process.stop()` was invoked:** `EverOSProcess.stop()` sets
   `_desired_running=false` before termination and cancels scheduled restart.
   If stop raises, retain the supervisor reference but keep claims and the worker
@@ -508,10 +531,11 @@ exceptions use the transport-only `memory_restart_failed`.
    `_persisted_memory_snapshot`, `_explicit_restart_active`,
    `_clear_pending_count`, lifecycle generation and a retained ready activation
    task, and fail-fast `restart()`; refresh the persisted snapshot after every
-   successful runtime-owned V2 mutation; conditionally converge disk to replay
-   before launch; retain worker/store tasks that outlive cancellation; reject
-   restart while artifact installation is active; make only restart/Clear
-   contention fail fast.
+   successful runtime-owned V2 mutation and rebase a successfully reconciled
+   live/replay candidate from marker settlement's exact return; conditionally
+   converge disk to replay before launch; retain worker/store tasks that outlive
+   cancellation; reject restart while artifact installation is active; make only
+   restart/Clear contention fail fast.
    `Controller.reconcile_memory()` marks only its persisted candidate explicitly;
    post-Clear and artifact-internal reconciles cannot change the disk snapshot.
 3. `core/memory/module.py`: extract locked clear recovery while retaining the
@@ -522,8 +546,9 @@ exceptions use the transport-only `memory_restart_failed`.
 5. `core/memory/process.py`: expose complete stop/start and process-owner
    settlement budget helpers, put one cap around all orphan-reap rounds, add the
    explicit-handoff supervisor fence, distinguish idle watcher/monitor tasks
-   from active cleanup owners with narrow phase flags, and support
-   callback-suppressed explicit start.
+   from active cleanup owners with narrow phase flags, hard-cap the complete
+   readiness operation, rebind re-armed ready callbacks to the current
+   generation, and support callback-suppressed explicit start.
 6. `core/internal_server.py`: add `POST /internal/memory/restart`. Missing runtime
    returns `memory_runtime_missing`; unhandled exceptions map to
    `memory_restart_failed`, not `memory_reconcile_failed`.
@@ -544,17 +569,27 @@ exceptions use the transport-only `memory_restart_failed`.
    closed on malformed bodies.
 2. `ApiContext.tsx`: import that type and normalizer. `restartMemoryRuntime()`
    returns only the normalized result and does not create a reverse import.
-3. `SettingsMemoryPage.tsx`: when `settings?.enabled === true` and the page is not
+3. `useMemoryResource.ts`: expose a narrow `invalidate()` transition that drops
+   the last accepted payload without changing sticky forbidden state. Restart
+   success uses it before the authoritative settings reload; existing resources
+   otherwise keep their current retry policy.
+4. `SettingsMemoryPage.tsx`: when `settings?.enabled === true` and the page is not
    cross-origin forbidden, render a page-level Status action row before the
    `remoteUnavailable` / `memorySetupStage()` branch. Use the existing secondary
    `xs` button with `RotateCw` / `Loader2`; disable it while restarting. Runtime
    required, setup loading, and status loading/error states share this action.
-   Await the result. Show completion copy on success and a localized reason plus
-   literal error code on failure, with a generic fallback when no code exists.
-4. `MemoryStatusPanel.tsx`: remove the old engine-fault restart action and its
+   Await the result. On success, invalidate the pre-restart Memory settings
+   payload, keep its form unavailable, and await an authoritative
+   `getMemorySettings()` reload before ending the restart state; a failed reload
+   must expose the settings read error without restoring an editable stale C1
+   payload. Refresh dependency/status state as well. Show completion copy only
+   after the settings reload settles successfully. On restart failure, keep the
+   existing settings payload and show a localized reason plus literal error code,
+   with a generic fallback when no code exists.
+5. `MemoryStatusPanel.tsx`: remove the old engine-fault restart action and its
    props so the normal Status body cannot render a duplicate. Keep the credential
    fault's settings action.
-5. `en.json` / `zh.json`: add button, completion, failure,
+6. `en.json` / `zh.json`: add button, completion, failure,
    `memory_restart_failed`, and `memory_restart_busy` copy in both locales;
    remove the unused engine-banner action key.
 
@@ -594,7 +629,9 @@ exceptions use the transport-only `memory_restart_failed`.
   - If the old child exits during the five-second drain grace, its supervisor is
     already quiesced: no automatic restart can schedule ready activation, resume
     claims, or replace `_worker_task`. Pre-stop failure re-arms that supervisor
-    and resumes work only after a live/ready child is established.
+    with a callback bound to the current lifecycle generation and resumes work
+    only after a live/ready child is established; the callback from the
+    supervisor's construction generation is never reused.
   - An automatic restart already inside `_start_locked()` is retained while
     claims are paused. It either settles within the complete start bound and its
     transient child is stopped, or restart returns fail-closed without lease or
@@ -612,8 +649,11 @@ exceptions use the transport-only `memory_restart_failed`.
     recovery failure launches no child.
   - A startup snapshot with the embedding marker rejects existing vectors and
     settles an empty root before launch. A successful ordinary persisted
-    reconcile that clears the marker refreshes `_persisted_memory_snapshot` to
-    the exact marker-free disk block, so a later restart accepts it.
+    reconcile that clears the marker refreshes `_persisted_memory_snapshot`, the
+    successful live config, and `_restart_config` to the exact marker-free disk
+    block. After vectors are created, a later restart must replay that block
+    without rerunning the stale-marker root guard or returning
+    `memory_clear_failed`.
   - Disabled, `start() is False`, factory exception, explicit activation
     exception, automatic activation exception, failed-start cleanup, and stop
     exception cases assert error codes, supervisor ownership, claims/worker
@@ -655,6 +695,9 @@ exceptions use the transport-only `memory_restart_failed`.
   the record and prevents child launch. Idle watcher/monitor tasks cancel and
   join during handoff; active cleanup owners are retained and settle under the
   exported owner budget. Explicit start suppresses automatic ready notification.
+  A socket that appears just before the readiness deadline with a stalled health
+  response cannot extend `_wait_for_ready()` beyond its outer cap, and the
+  separately budgeted failed-start cleanup still runs.
 
 ### TypeScript
 
@@ -665,7 +708,11 @@ exceptions use the transport-only `memory_restart_failed`.
   the setup prompt and exactly one restart action coexist. Also cover status
   loading/error and the disabled restarting state. `MemoryStatusPanel` tests
   assert no engine restart action and retain the credential action.
-- Keep click/toast behavior in the single manual scenario below.
+- Extend the existing Memory resource/state tests with the restart-success
+  transition: invalidate displayed C1, settle the authoritative settings reload
+  with C0, and expose only C0 to the form. The reload-failure case keeps no
+  editable C1 payload. Keep click/toast behavior in the single manual scenario
+  below.
 
 ## Validation
 
@@ -698,14 +745,16 @@ runtime-owned mutation refreshes the exact persisted snapshot; explicit restart
 and destructive Clear cannot queue behind or leapfrog each other while ordinary
 reads retain their existing serialization; artifact installation excludes
 launch; orphan recovery has one complete cap; every active process lifecycle
-owner is settled and budgeted before stop; delayed automatic activation is
-fenced by lifecycle generation and both runtime locks; pending embeddings cannot
-bypass the root guard; claimed rows require a new lease only after the old
-worker and every shielded store thread exit; activation success is observable;
-and clear markers serialize with root/child lifecycle. The implementation adds
-two private snapshots, two narrow admission fields, focused helpers, and two
-precise transport-only error codes while reusing existing locks, guards,
-recovery SQL, supervision, and UI primitives.
+owner is settled and budgeted before stop; readiness, including the final health
+request, has one hard cap; delayed automatic activation and re-armed supervision
+are bound to the current lifecycle generation and both runtime locks; pending
+embeddings cannot bypass the root guard or remain in a successful replay
+snapshot; claimed rows require a new lease only after the old worker and every
+shielded store thread exit; activation success is observable; UI settings reload
+from the converged disk block; and clear markers serialize with root/child
+lifecycle. The implementation adds two private snapshots, two narrow admission
+fields, focused helpers, and two precise transport-only error codes while reusing
+existing locks, guards, recovery SQL, supervision, and UI primitives.
 
 Do not introduce a general coordinator, explicit restart state machine, new
 port, database field, automatic restart policy, or frontend test framework. If
@@ -714,7 +763,7 @@ implementation appears to require one, revise this plan before expanding scope.
 ## Todo
 
 - [ ] Replay/disk snapshots, conditional C1-to-C0 convergence, focused tests
-- [ ] Marker-settlement snapshot refresh and later-restart regression
+- [ ] Marker-settlement persisted/live/replay refresh and later-restart regression
 - [ ] Settings/restart serialization and stale-C0 overwrite regression
 - [ ] Path-aware token-bound config mutation and custom-target regression
 - [ ] File-lock-first order, async writers off-thread, inline-reader responsiveness
@@ -724,10 +773,10 @@ implementation appears to require one, revise this plan before expanding scope.
 - [ ] Shielded store-thread registry, bounded settlement, and retry
 - [ ] Locked clear recovery and race regression
 - [ ] Restart/Clear intent admission, queued-Clear handoff, artifact admission
-- [ ] Supervisor handoff fence, lifecycle-owner settlement, and deadline contract
+- [ ] Supervisor handoff/rebind, lifecycle-owner settlement, readiness/deadline contract
 - [ ] Lifecycle-generation ready activation and Clear/reconcile race regression
 - [ ] Complete orphan/start budgets, explicit activation, failed-start cleanup
 - [ ] Internal server/client, closed/busy errors, bounded timeout tests
 - [ ] UI route and response normalizer
-- [ ] Page-level action, deduplicated banner, runtime-missing render, toast/i18n
+- [ ] Page action, deduplicated banner, settings invalidation/reload, toast/i18n
 - [ ] Focused Python/TypeScript validation and Incus `SIGSTOP` scenario

--- a/docs/plans/memory-sidecar-force-restart-button.md
+++ b/docs/plans/memory-sidecar-force-restart-button.md
@@ -1,8 +1,8 @@
-# Memory 设置页增加 sidecar 强制重启按钮（rev3）
+# Memory 设置页增加 sidecar 强制重启按钮（rev4）
 
-> rev3 根据整体 review 收敛为一个公开入口和三个很小的内部修正：重启配置快照、
-> worker lease 轮换、clear marker 的锁内恢复。不新增 lifecycle coordinator、状态机、
-> provider/store port 或前端 DOM 测试框架。
+> rev4 根据整体 review 收敛为一个公开入口和四个很小的内部修正：重启配置快照、
+> lifecycle busy 快速失败、worker lease 轮换、clear marker 的锁内恢复。不新增
+> lifecycle coordinator、状态机、provider/store port 或前端 DOM 测试框架。
 
 ## 背景与目标
 
@@ -10,7 +10,7 @@
 
 本需求只做两件事：
 
-1. Memory 已启用时，在 Status 标题区始终提供“重启引擎”按钮。
+1. Memory 已启用时，在 setup-stage 分支之外的 Status 动作区始终提供“重启引擎”按钮；即使依赖 API 报告 runtime 未安装、status 尚未加载或读取失败，也不能隐藏入口。
 2. 点击后由 controller 强制停止旧 sidecar 并等待新 sidecar `ready`，不重启 Avibe 主进程、不重装 runtime、不从磁盘重新选择 restart 目标配置，也不做 processing 预探测。若启动快照仍带 durable embedding-change marker，则必须先完成既有 root 兼容性检查，并允许 settlement 为核对/清除 marker 读取持久化配置。
 
 非目标：自动健康重启、重做全部 Memory lifecycle、改变 provider/store 协议、重试历史 `unknown` flush、四平台全量回归。
@@ -58,7 +58,18 @@ UI
 
 这只是消除现有 check/use 窗口，不新建通用 lifecycle coordinator。
 
-### 3. 强制替换与 lease 交接
+### 3. 不排队的 restart 入口与有界 deadline
+
+显式 restart 不能排在另一个 lifecycle 操作后面静默等待。否则 transport 可能先超时，controller 随后仍执行已经失去调用方的 restart，用户重试还会再排入一次。
+
+- `restart()` 在任何 await 之前检查 `_reconcile_lock` 和 `module._lifecycle_lock`；任一已占用就立即返回 `{ok: false, error: 'memory_restart_busy'}`，不进入 lock waiter 队列，也不修改 process、claims 或 worker。
+- 两把锁都空闲时，在同一 event-loop turn 内按 `_reconcile_lock -> module._lifecycle_lock` 立即取得它们，中间不执行其他 await。这样并发 restart、Settings PATCH、artifact activation 和 clear 只有一个 owner；已有 reconcile/clear 保持原语义，只有人工 restart 使用 fail-fast 契约。
+- interrupted-clear recovery 和条件性的 embedding/root guard 复用 `CLEAR_CLEANUP_TIMEOUT_SECONDS` 作为上界。restart transport deadline 必须严格大于 `clear recovery/guard bound + 5s worker grace + process stop 的 TERM/KILL 两轮上界 + process startup bound`；测试直接从这些源常量计算，不复制注释里的数字。
+- lock-busy 是一个已完成、可重试的业务响应，不是 `memory_restart_failed`，也不能启动后台 task。前端显示本地化 busy 原因并结束 spinner。
+
+这不增加独立 restart lock 或队列；现有两把 lifecycle lock 就是 single-flight 所有权边界。
+
+### 4. 强制替换与 lease 交接
 
 `MemoryWorker._boot_id` 当前在对象创建后不变，而 `recover_after_boot()` 只回收“其他 lease owner”的 `processing` 行。若 restart cancel 了已经 claim add 的同一个 worker，再用原 owner 激活，该行会永久停在 `processing`。
 
@@ -76,7 +87,7 @@ UI
 
 `restart()` 不调用 `_probe_processing`。条件性的 embedding/root guard 是防止混用向量空间的持久化安全约束，不是 processing 健康预探测；其余真实 processing 故障继续由 worker 的既有分类路径报告。
 
-### 4. 失败后置条件
+### 5. 失败后置条件
 
 claims 被 fence 后的每条退出路径必须明确恢复到以下二者之一：
 
@@ -87,7 +98,7 @@ claims 被 fence 后的每条退出路径必须明确恢复到以下二者之一
 
 `start()` 正常返回 `False` 时沿用更具体的 `memory_sidecar_unavailable`；stop、factory 或其他 restart orchestration 异常使用新的 transport-only `memory_restart_failed`。
 
-### 5. 队列语义
+### 6. 队列语义
 
 - cancel 发生在 add 已 claim 之后：新 lease owner 的 activation 会把旧 owner 的行退回 `pending`，按既有 at-least-once 语义重投。若 provider 在取消前已接收但本地未观察到 ack，可能产生重复副作用；强制重启不能承诺 exactly-once。
 - cancel 发生在 flush `in_flight`：activation 会把它永久标记为 `unknown` 并打开 processing fault。历史 `unknown` 不会在 5 分钟后自动重试或消失；以后新的 pending work 成功 flush 可以关闭 fault，但不会改写该历史记录。
@@ -96,21 +107,21 @@ claims 被 fence 后的每条退出路径必须明确恢复到以下二者之一
 
 ### 后端与 transport
 
-1. `core/memory/runtime.py`：增加 `_restart_config` 和 `restart()`；成功 reconcile 提交快照；修正 `_stop_worker()` 对调用方取消的识别。
+1. `core/memory/runtime.py`：增加 `_restart_config` 和 fail-fast `restart()`；成功 reconcile 提交快照；修正 `_stop_worker()` 对调用方取消的识别。
 2. `core/memory/module.py`：抽出锁内 clear recovery helper；现有 wrapper 继续服务其他调用方。
 3. `core/memory/worker.py`：增加 replacement activation 时的 lease owner 轮换。
 4. `core/internal_server.py`：增加 `POST /internal/memory/restart`。runtime 缺失返回 `memory_runtime_missing`；未处理异常映射为 `memory_restart_failed`，不能复用语义错误的 `memory_reconcile_failed`。
-5. `vibe/internal_client.py`：增加 `memory_restart()` 和独立 timeout。timeout 必须大于 `5s grace + process stop bound + process startup bound`。
+5. `vibe/internal_client.py`：增加 `memory_restart()` 和独立 timeout。timeout 按上面的完整 restart lifecycle budget 计算，lock busy 不计入预算，因为它不等待。
 6. `vibe/ui_memory_routes.py`：现有 `/api/memory/runtime/restart` 改调 `memory_restart()`，保持同源校验和外部路径不变。
-7. `core/memory/types.py` 与前端 en/zh `errors`：加入 transport-only `memory_restart_failed`；不加入 SQLite 持久化 schema。
+7. `core/memory/types.py` 与前端 en/zh `errors`：加入 transport-only `memory_restart_failed` 和 `memory_restart_busy`；不加入 SQLite 持久化 schema。
 
 ### 前端
 
 1. `memoryRead.ts`：在现有 Memory response classifier 附近定义并导出 `MemoryRuntimeRestartResult` 及纯函数 normalizer。接受 `{ok:true}`；把 `{ok:false,error}` 和 `{status:'failed',error}` 统一为失败；malformed body 也必须 fail closed。
 2. `ApiContext.tsx`：导入该类型和 normalizer，`restartMemoryRuntime()` 只返回归一化结果，避免反向 import 形成循环依赖。
-3. `MemoryStatusPanel.tsx`：Status 标题右侧常驻 secondary `xs` 重启按钮，使用 `RotateCw` / `Loader2`；`restarting` 时 disabled。动作区放在依赖 `status` 的 body 分支之外，因此首次 status 尚在 loading 或请求失败时也不会消失。engine fault 横幅删除重复按钮，credential fault 的“打开设置”保持不变。
-4. `SettingsMemoryPage.tsx`：请求同步等待结果。成功 toast 使用完成式文案；失败 toast 显示本地化原因和字面 error code，无 code 时显示通用失败。
-5. `en.json` / `zh.json`：同步增加按钮、完成、失败、`memory_restart_failed` 文案，删除不再使用的 engine 横幅 action 文案。
+3. `SettingsMemoryPage.tsx`：当 `settings?.enabled === true` 且页面不是 cross-origin forbidden 状态时，在 `remoteUnavailable` / `memorySetupStage()` 条件树之前渲染 page-level Status 动作行。secondary `xs` 重启按钮使用 `RotateCw` / `Loader2`，`restarting` 时 disabled；因此 `runtime-required`、setup loading、status loading/error 都共享同一个入口。请求同步等待结果；成功 toast 使用完成式文案，失败 toast 显示本地化原因和字面 error code，无 code 时显示通用失败。
+4. `MemoryStatusPanel.tsx`：删除 engine fault 横幅中的旧重启按钮和相关 props，避免正常 Status body 出现第二个入口；credential fault 的“打开设置”保持不变。
+5. `en.json` / `zh.json`：同步增加按钮、完成、失败、`memory_restart_failed`、`memory_restart_busy` 文案，删除不再使用的 engine 横幅 action 文案。
 
 ## 最小充分测试
 
@@ -118,20 +129,21 @@ claims 被 fence 后的每条退出路径必须明确恢复到以下二者之一
 
 - `tests/test_memory_runtime.py`
   - 成功 restart：旧 process 确认 stop，新 process 启动并 ready，worker 恢复。
-  - C1 reconcile 失败且 rollback 也失败后，restart 重放最后成功的 C0；并发 restart/reconcile 由 `_reconcile_lock` 串行，终态使用最后成功配置。
+  - C1 reconcile 失败且 rollback 也失败后，restart 重放最后成功的 C0；无竞争时的 restart 仍在两把 lifecycle lock 内完成。
+  - 分别预占 `_reconcile_lock` 和 `module._lifecycle_lock`，以及同时发起两个 restart，验证竞争者立即返回 `memory_restart_busy`、不进入 waiter 队列且不修改 process/claims/worker。
   - 分别挂起 add 和 flush，使用缩短的 grace 验证有界完成；add 可由新 owner 再 claim，flush 变 `unknown` 并打开 fault。
   - durable clear marker 恢复与 replacement 位于同一 lifecycle 临界区；恢复失败不启动 child。
   - 初始 `_restart_config.embedding_change_pending=true` 时：有旧向量数据必须拒绝启动；空 root 完成 marker settlement 后才允许启动。
   - disabled 不 spawn；`start() is False`、factory exception、stop exception 分别验证错误码、`_process`/claims/worker 后置条件和无双 child。
   - lifecycle task 分别在 worker 停止期间、以及 new `start()` 已创建 child 后被 cancel：完成最小 cleanup，验证 child 被回收或仍由唯一 supervisor 持有、claims 后置条件正确，并重新抛出 `CancelledError`。
 - `tests/test_internal_server.py`：成功透传、runtime missing、未处理异常映射。
-- `tests/test_internal_client.py` / `tests/test_internal_client_timeouts.py`：POST 路径、响应透传、timeout 覆盖完整有界预算。
+- `tests/test_internal_client.py` / `tests/test_internal_client_timeouts.py`：POST 路径、busy 响应透传、timeout 从 clear/worker/process 源常量覆盖完整有界预算。
 - `tests/test_ui_memory_routes.py`：切到新 client、internal unavailable、既有 cross-origin 拒绝。
 
 ### TypeScript
 
 - 给纯 normalizer 做表驱动测试：`ok:true`、`ok:false`、`status:'failed'`、malformed。
-- 沿用 `renderToStaticMarkup` 的 `MemoryStatusPanel` 测试：down/no-fault 也有按钮，`status=null` 的 loading/error 状态仍有按钮，restarting 时 disabled，engine fault 全页只有一个重启入口，credential action 仍存在。
+- 沿用 React SSR / `renderToStaticMarkup`，不引入 DOM 框架：给 `SettingsMemoryPage` 注入 enabled + runtime-missing fixture，断言 setup prompt 与唯一重启按钮同时存在；另覆盖 status loading/error、restarting disabled。`MemoryStatusPanel` 测试断言 engine fault 不再渲染重启入口、credential action 仍存在。
 - 不为 click/toast 新引入 DOM 测试框架；由下面的单一手工场景覆盖。
 
 ## 验证
@@ -139,23 +151,23 @@ claims 被 fence 后的每条退出路径必须明确恢复到以下二者之一
 1. `pytest tests/test_memory_runtime.py -k restart`
 2. `pytest tests/test_internal_server.py tests/test_internal_client.py tests/test_internal_client_timeouts.py tests/test_ui_memory_routes.py -k 'memory and restart'`
 3. `ruff check` 所有改动的 Python 文件。
-4. `cd ui && npx vitest run` 相关 normalizer / `MemoryStatusPanel` 测试，然后 `npm run build`。
+4. `cd ui && npx vitest run` 相关 normalizer / `SettingsMemoryPage` / `MemoryStatusPanel` 测试，然后 `npm run build`。
 5. 只使用本地 Incus `master` 回归环境：先运行 `./scripts/run_regression.sh` 更新代码和检查服务健康，不重置配置。
 6. 通过 `python3 scripts/incus_regression.py shell --target master` 在容器内确认受管 sidecar PID 后发送 `SIGSTOP`，制造“进程存活但不可达”；在 Web UI 确认状态 down、按钮常驻、spinner/toast 正确，并验证点击后 PID 被替换且状态恢复 ready。若 replacement 未完成，清理时对原 PID 发送 `SIGCONT`。
 7. 再用 runner 检查 Avibe service health。不要重启本机 `vibe`，也不要用 `kill -9`（它只覆盖已有的 child-exit supervision，不是本需求场景）。
 
 ## 整体 review 结论
 
-方案的必要复杂度来自四个已有安全/并发契约：成功配置不能被失败候选覆盖、pending embedding 不能绕过 root guard、已 claim 行必须换 lease 才能恢复、clear marker 必须与 root/child lifecycle 串行。实现只增加一个私有快照、两个窄 helper 和一个准确的错误码，并复用现有 lock、guard、recovery SQL、supervisor 和 UI primitives。
+方案的必要复杂度来自五个已有安全/并发契约：成功配置不能被失败候选覆盖、人工 restart 不能在 transport 背后排队、pending embedding 不能绕过 root guard、已 claim 行必须换 lease 才能恢复、clear marker 必须与 root/child lifecycle 串行。实现只增加一个私有快照、两个窄 helper 和两个准确的 transport-only 错误码，并复用现有 lock、guard、recovery SQL、supervisor 和 UI primitives。
 
 本方案明确不引入通用 coordinator、显式 restart 状态机、新 port、新数据库字段、自动重启策略或新前端测试框架。实现中若需要这些内容，应先回到本计划重新论证，而不是顺手扩 scope。
 
 ## Todo
 
-- [ ] runtime snapshot + pending-embedding guard + force restart + focused tests
+- [ ] runtime snapshot + pending-embedding guard + fail-fast force restart + focused tests
 - [ ] worker lease rotation + add/flush recovery tests
 - [ ] locked clear recovery + race regression test
-- [ ] internal server/client + closed error + timeout tests
+- [ ] internal server/client + closed/busy errors + bounded timeout tests
 - [ ] UI route + response normalizer
-- [ ] status button + deduplicated banner + toast/i18n
+- [ ] page-level status action + deduplicated banner + runtime-missing render test + toast/i18n
 - [ ] focused Python/TypeScript validation + Incus `SIGSTOP` scenario

--- a/docs/plans/memory-sidecar-force-restart-button.md
+++ b/docs/plans/memory-sidecar-force-restart-button.md
@@ -1,6 +1,6 @@
-# Add a forced sidecar restart action to Memory settings (rev18)
+# Add a forced sidecar restart action to Memory settings (rev19)
 
-> Rev18 keeps one public recovery action and a focused set of internal fixes:
+> Rev19 keeps one public recovery action and a focused set of internal fixes:
 > replayable configuration, config-wide write serialization, restart-specific
 > and lifecycle-intent admission, generation-fenced ready activation, complete
 > supervisor quiescing, bounded orphan recovery, disk/live replay convergence,
@@ -10,8 +10,9 @@
 > disabled/fail-closed replay handling, explicit worker activation, post-lock
 > retained-owner admission, complete root/installer/probe ownership, lifecycle
 > abort reactivation, under-lock generation changes, retained config writers,
-> store-unavailable retry, shutdown joining, and durable retry eligibility
-> alongside processing-probe/module-store ownership.
+> store-unavailable retry, disabled no-store convergence, durable ownership-record
+> recovery, controller config rebasing, shutdown joining, and durable retry
+> eligibility alongside processing-probe/module-store ownership.
 > Timed-out work remains owned until it is either joined or proven unable to
 > mutate state. It does not add a lifecycle coordinator, explicit state machine,
 > provider/store port, or frontend DOM test framework.
@@ -142,6 +143,14 @@ Add private `_restart_config` and `_persisted_memory_snapshot` values to
   candidate into `Controller.config.memory` before exposing only the transport
   result. Thus disk, Runtime, and Controller remain authoritative independently
   of the later lifecycle outcome.
+- A controller reconciler that awaited while Memory convergence completed must
+  not publish its earlier full-config snapshot afterward. Immediately before
+  `reconcile_platforms()` calls `_sync_config_references()`, deep-copy its incoming
+  config and replace only that copy's Memory block with the then-current
+  `Controller.config.memory`, with no intervening await before publication. The
+  platform operation still publishes all fields it owns from its saved candidate,
+  while reverse ordering cannot restore stale C1 over the C0 installed by
+  `restart_memory()` or `reconcile_memory()`.
 
 These snapshots answer which configuration an explicit restart replays and
 which exact Memory block it may conditionally replace on disk. They do not
@@ -321,12 +330,15 @@ an abandoned restart, and a user retry can enqueue a second one.
   `{ok: false, error: 'memory_restart_busy'}` without changing the process,
   claims, or worker.
 - Order that admission so Runtime-only counters and locks are checked before any
-  module member is read. If the store is unavailable and no conflicting Runtime
-  intent owns admission, synchronously retry `_open_store()` before accessing
-  `module.lifecycle_busy` or `module._lifecycle_lock`; a second failed open returns
-  `memory_store_unavailable` without process/config mutation. This preserves the
-  existing transient-store recovery behavior and never treats
-  `_UnavailableMemoryModule` as a full lifecycle module.
+  module member is read. Once those checks prove no competing reconcile intent,
+  synchronously snapshot `_restart_config` before store admission. If that replay
+  is enabled, retry `_open_store()` before accessing `module.lifecycle_busy` or
+  `module._lifecycle_lock`; a second failed open returns
+  `memory_store_unavailable` without process/config mutation. If the replay is
+  disabled, do not require or reopen the store and do not touch
+  `_UnavailableMemoryModule`: enter the narrow no-module disabled lane below.
+  This preserves transient-store recovery for enabled launch while allowing an
+  authoritative disabled C0 to repair a persisted C1 and reap old ownership.
 - Add a narrow `_retained_ownership_active` gate to `MemoryRuntime`. Any worker,
   worker/module store task, processing probe, supervisor start, watcher/monitor,
   or process cleanup owner that outlives its bound sets this gate synchronously
@@ -512,11 +524,17 @@ finished.
 
 The locked sequence is fixed:
 
-1. Snapshot the last-good `_restart_config` and recover an interrupted clear.
-   Validate store and artifact availability only when that replay is enabled.
+1. Snapshot the last-good `_restart_config` before module admission and recover
+   an interrupted clear only when a real module is available. Validate store and
+   artifact availability only when that replay is enabled.
    Do not reject solely because the persisted candidate is enabled while the
    replay is disabled; the replay state is authoritative after step 9
-   convergence and needs no launch prerequisites.
+   convergence and needs no launch prerequisites. When disabled replay is paired
+   with an unavailable store, acquire only the Runtime reconcile lock, revalidate
+   that the replay is still disabled, and run a no-module path containing config
+   convergence plus recorded/supervised sidecar cleanup. It performs no clear
+   recovery, provider-root access, worker/store operation, artifact resolution,
+   lease rotation, replacement construction, or module lifecycle access.
 2. Before touching the worker, call a non-awaiting, idempotent supervisor handoff
    fence on the old `EverOSProcess`. It sets `_desired_running=false`, marks ready
    callbacks quiesced, and captures the exact restart, watcher, and monitor task
@@ -692,8 +710,15 @@ Every exit after claims are fenced must end in one of these states:
   The user can retry the explicit restart, which first retries owned-tree stop.
   If replay already committed disabled config, return
   `restart_recovery_required=true` and expose the same fact through pure status
-  projection until the retained supervisor/child is reaped. This keeps explicit
-  cleanup retry reachable without making disabled Memory launch a replacement.
+  projection until the retained supervisor/child is reaped. Persisted ownership
+  evidence is equally authoritative: on startup, a retained sidecar ownership
+  record whose bounded reap fails sets the same recovery projection even when no
+  supervisor object survived and the store/module is unavailable. Pure status
+  reports that flag beside the ordinary disabled or store-unavailable state.
+  Explicit disabled restart, including the no-module lane, retries the recorded
+  reap and clears eligibility only after the record is retired or ownership is
+  otherwise proven absent. This keeps cleanup retry reachable across controller
+  restarts without making disabled Memory launch a replacement.
 - **The old child stopped but replacement startup failed:** retain the new
   supervisor, if one was created, and keep claims and the worker fenced. If its
   bounded supervisor later reaches ready, its generation-fenced activation task
@@ -779,7 +804,11 @@ exceptions use the transport-only `memory_restart_failed`.
    restart admission fail fast. Make `restart()` return its transport
    result plus the exact applied replay config whenever convergence committed,
    including later lifecycle failure, and no config before convergence or on
-   busy. Retry unavailable-store creation before module admission; compensate
+   busy. Snapshot replay before module admission, retry unavailable-store
+   creation only for enabled replay, and give disabled replay a no-module
+   convergence/ownership-cleanup lane. Reconstruct
+   `restart_recovery_required` from a failed startup reap of the durable ownership
+   record as well as retained in-memory owners; compensate
    failed lifecycle generation invalidation by activating an unchanged current
    ready supervisor under both locks. Project `restart_recovery_required` in
    restart/status results while a
@@ -821,6 +850,10 @@ exceptions use the transport-only `memory_restart_failed`.
    not `memory_reconcile_failed`. Make synchronous cleanup accept a per-resource
    allowance; Memory cancels/joins active restart ownership and receives its full
    Runtime-exported shutdown allowance rather than the generic five seconds.
+   Before platform reconciliation publishes an awaited full-config candidate,
+   rebase that candidate's Memory block from current `Controller.config.memory`
+   and publish without another await, so a stale platform snapshot cannot undo a
+   completed Memory convergence.
 7. `vibe/internal_client.py`: add `memory_restart()` with a deadline above the
    complete restart lifecycle budget; retain and join the shielded request task
    after a reporting timeout.
@@ -899,6 +932,11 @@ exceptions use the transport-only `memory_restart_failed`.
     `restart_recovery_required=true`; retry remains visible, settles the child,
     and never launches while disabled. A post-Clear internal reconcile cannot
     overwrite the persisted snapshot contract.
+    Restart a fresh controller after disabled convergence left an ownership
+    record and make startup reap fail. Status must reconstruct
+    `restart_recovery_required=true` without an in-memory supervisor; the one
+    recovery action remains available until explicit disabled restart reaps the
+    record, then status clears the flag.
   - Pre-held reconcile/module locks and concurrent restart calls immediately
     return `memory_restart_busy`, create no waiters, and change no ownership.
     An installer paused inside unlocked `ensure(force=True)` also returns busy
@@ -910,7 +948,11 @@ exceptions use the transport-only `memory_restart_failed`.
     With a startup store-open failure, restart retries `_open_store()` before
     reading module lifecycle state: a recovered store proceeds normally, while a
     second failure returns `memory_store_unavailable` without touching the
-    unavailable module adapter, process, or config.
+    unavailable module adapter, process, or config when replay is enabled. With a
+    disabled last-good replay, the same unavailable store is not an admission
+    failure: conditionally converge persisted enabled C1 to disabled C0, reap the
+    recorded or supervised child, and never access the module, provider root,
+    worker, artifact manager, lease, or process factory.
     Hold one search/profile request in the module lock and queue a second; across
     the owner's release/waiter-wakeup gap, `lifecycle_busy` remains true and
     restart returns busy without joining the read queue. After both reads finish,
@@ -1036,6 +1078,12 @@ exceptions use the transport-only `memory_restart_failed`.
   `Controller.config.memory`. Disk, controller, runtime live state, and replay
   state must match; the original marker-bearing request object is not installed.
   Failure returns no candidate and preserves the prior controller config.
+- `tests/test_controller_platform_reconcile.py`: pause a platform reconcile after
+  it captured marker-bearing or enabled C1, let Memory restart converge and
+  install C0 into `Controller.config.memory`, then release the platform operation.
+  Its publication retains its platform changes but rebases Memory from current
+  controller state, so handlers and controller still reference C0. Cover the
+  inverse completion order as well.
 - `tests/test_internal_server.py`: success, missing runtime, exception mapping,
   and post-convergence failure propagation without serializing the config object.
 - `tests/test_internal_client.py` / `tests/test_internal_client_timeouts.py`:
@@ -1160,7 +1208,9 @@ explicit restart cannot queue behind or leapfrog any active or queued module
 lifecycle operation, while reads and destructive Clear retain their existing
 serialization and recheck retained ownership after acquiring their locks;
 artifact installation and every root metadata thread remain explicitly owned
-through cancellation; unavailable-store retry precedes module admission;
+through cancellation; enabled unavailable-store retry follows replay snapshotting,
+while disabled replay can converge and clean durable ownership without a
+store/module;
 artifact installation excludes launch; orphan
 recovery has one complete cap; every active process lifecycle
 owner is settled and budgeted before stop; readiness, including the final health
@@ -1174,10 +1224,12 @@ shielded worker/module store thread exit; activation success is observable and
 its shared future is shielded from reporting timeout; post-convergence failure
 still propagates the committed block to Controller and UI; retained ownership
 excludes every other mutating lifecycle; replacement cleanup fences supervision
-before awaiting; disabled retained cleanup keeps its explicit recovery action;
+before awaiting; disabled retained cleanup and failed durable-record reap keep
+their explicit recovery action across controller restart;
 Runtime retains throwaway preflight supervisors; shutdown joins active restart
 ownership beyond the generic five-second close; enabled retry eligibility survives
-settings invalidation/read failure; and clear markers serialize with root/child
+settings invalidation/read failure; delayed platform config publication rebases
+the authoritative Memory block; and clear markers serialize with root/child
 lifecycle. The
 implementation adds two private snapshots, focused intent counters, one narrow
 retained-owner gate, focused helpers, and two precise transport-only error codes
@@ -1209,6 +1261,7 @@ implementation appears to require one, revise this plan before expanding scope.
 - [ ] Under-lock retained-owner recheck for every queued lifecycle operation
 - [ ] Cancelled artifact installer ownership and restart exclusion
 - [ ] Unavailable-store restart bootstrap before module admission
+- [ ] Disabled no-store replay convergence and durable-record cleanup retry
 - [ ] Runtime-owned preflight-probe supervisors and cancellation settlement
 - [ ] Supervisor handoff/rebind, lifecycle-owner settlement, readiness/deadline contract
 - [ ] Lifecycle-generation ready activation and Clear/reconcile race regression
@@ -1220,6 +1273,7 @@ implementation appears to require one, revise this plan before expanding scope.
 - [ ] UI route and response normalizer
 - [ ] Page action, deduplicated banner, success/failure settings reload, toast/i18n
 - [ ] Disabled retained-cleanup recovery projection and persistent retry action
+- [ ] Platform reconcile publication rebased against authoritative Memory config
 - [ ] Known-enabled retry eligibility across authoritative reload failure
 - [ ] Memory-specific shutdown allowance and active-restart ownership join
 - [ ] Focused Python/TypeScript validation and Incus `SIGSTOP` scenario

--- a/docs/plans/memory-sidecar-force-restart-button.md
+++ b/docs/plans/memory-sidecar-force-restart-button.md
@@ -1,11 +1,12 @@
-# Add a forced sidecar restart action to Memory settings (rev6)
+# Add a forced sidecar restart action to Memory settings (rev7)
 
-> Rev6 keeps one public recovery action and a small set of internal fixes:
-> replayable configuration, settings transaction serialization, fail-fast
-> lifecycle admission, bounded orphan recovery, worker lease rotation, and locked
-> clear-marker recovery. Timed-out work remains owned until it is either joined
-> or proven unable to mutate state. It does not add a lifecycle coordinator,
-> explicit state machine, provider/store port, or frontend DOM test framework.
+> Rev7 keeps one public recovery action and a focused set of internal fixes:
+> replayable configuration, config-wide write serialization, restart-specific
+> lifecycle admission, supervisor quiescing, bounded orphan recovery, worker
+> lease rotation, and locked clear-marker recovery. Timed-out work remains owned
+> until it is either joined or proven unable to mutate state. It does not add a
+> lifecycle coordinator, explicit state machine, provider/store port, or
+> frontend DOM test framework.
 
 ## Background and goals
 
@@ -102,12 +103,12 @@ Make the following narrow change:
 This closes the existing check/use window without creating a general lifecycle
 coordinator.
 
-### 3. Serialize settlement with Memory settings writes
+### 3. Serialize settlement with every V2 config writer
 
 `CONFIG_LOCK` is process-local: the controller's compare-and-save cannot, by
-itself, exclude a Memory PATCH running in the UI process. The public restart
-route must therefore participate in the UI process's existing settings
-transaction.
+itself, exclude a Memory PATCH or an unrelated `/api/config` save running in the
+UI process. Because every `V2Config.save()` replaces the complete JSON document,
+Memory-only serialization is insufficient.
 
 - Before calling `internal_client.memory_restart()`, the restart route checks
   `_memory_settings_write_lock()`. If it is already held, return
@@ -116,9 +117,26 @@ transaction.
   restart request and response. Every Memory PATCH already holds this same lock
   across load, save, controller reconcile, and rollback, so a PATCH cannot write
   C1 between the controller's C0 comparison and marker-clear save.
-- Controller settlement still performs load, full Memory configuration compare,
-  marker-only mutation, and atomic file replacement while its local
-  `CONFIG_LOCK` is held. A mismatch fails closed with `memory_clear_failed`.
+- Add one reentrant config-write transaction in `config/v2_config.py`. Its
+  outermost entry acquires `CONFIG_LOCK` and then a config-specific cross-process
+  file lock, using the existing `storage.lock.MigrationFileLock` primitive with
+  a dedicated lock path and bounded acquisition. Nested calls in the same thread
+  reuse the outer ownership rather than opening a second file-lock handle.
+- Every whole-file V2 writer must enter that transaction before loading the
+  current config and hold it through `V2Config.save()`. Migrate the generic and
+  Memory save paths in `vibe/api.py`, direct writers in `vibe/ui_server.py` and
+  `vibe/remote_access.py`, startup/default writers, and every other audited
+  `V2Config.save()` call path. `V2Config.save()` asserts transaction ownership so
+  a future writer cannot silently bypass the contract.
+- The transaction remains synchronous. Async UI/server routes offload the whole
+  load/merge/save transaction to one `asyncio.to_thread()` call, as the current
+  config route already does, so bounded file-lock waiting never blocks the ASGI
+  event loop.
+- Controller settlement enters the same config-wide transaction, freshly loads
+  the document, compares the complete expected Memory block, mutates only
+  `embedding_change_pending`, and atomically saves. A mismatch or bounded lock
+  timeout fails closed with `memory_clear_failed`. Unrelated config writers wait
+  before their load, so none can publish a stale whole-file snapshot afterward.
 - Settlement runs in one retained `asyncio.to_thread()` task. A deadline uses
   `wait_for(shield(task))`, never cancellation of the thread as proof that its
   work stopped. If the deadline or caller cancellation fires, cleanup continues
@@ -137,12 +155,13 @@ transaction.
   user-facing writer is the UI route that owns the cross-process transaction
   boundary.
 
-Add route concurrency tests that pause restart settlement, start a PATCH from a
-second task, and verify the PATCH cannot save until restart releases the UI
-lock. Cover both ordinary completion and an expired settlement deadline. In the
-expired case, prove the request and settings locks remain owned until the
-retained thread finishes. The PATCH must then read the settled configuration as
-its baseline and persist C1 without being overwritten by a stale C0 save.
+Add route concurrency tests that pause restart settlement and start both a
+Memory PATCH and an unrelated `/api/config` save. The Memory PATCH must wait on
+the UI lock; the generic save must wait on the cross-process config transaction
+before loading its baseline. Cover ordinary completion and an expired settlement
+deadline. In the expired case, prove the request and transaction locks remain
+owned until the retained thread finishes. Both writers must then preserve the
+settled marker and their own C1 fields without either side restoring stale C0.
 
 ### 4. Nonqueued admission and complete deadlines
 
@@ -160,19 +179,25 @@ an abandoned restart, and a user retry can enqueue a second one.
   release the lock and return `memory_restart_busy` before resolving an artifact
   or touching worker/process state. This check covers `install_artifact()`'s
   deliberate unlocked `ensure(force=True)` interval.
-- Make destructive Clear symmetric at the module lock. `MemoryModule.clear()`
-  checks `_lifecycle_lock` before its first await and acquires it immediately in
-  the same event-loop turn; when the lock is held it returns
-  `memory_clear_failed` without starting or queueing `begin_clear()`. Once Clear
-  owns the lock, restart observes it and returns `memory_restart_busy`. Clear's
-  existing post-receipt reconcile may still run after the module lock is
-  released, but no destructive wipe can remain queued behind restart.
+- Track a narrow `_explicit_restart_active` boolean in `MemoryRuntime`. Set it
+  after restart has acquired both lifecycle locks, before the first lifecycle
+  await, and clear it only in the final ownership cleanup. `MemoryRuntime.clear()`
+  checks this flag before awaiting `module.clear()` and returns
+  `memory_clear_failed` without starting or queueing `begin_clear()` only when an
+  explicit restart owns the lifecycle. `MemoryModule.clear()` retains its
+  existing queued lock behavior, so search/profile/read contention still
+  serializes instead of becoming a spurious Clear failure. If Clear reaches the
+  module lock first, restart observes that lock and returns `memory_restart_busy`.
 - Bound interrupted-clear recovery and embedding guard/settlement separately by
   `CLEAR_CLEANUP_TIMEOUT_SECONDS`, because both phases can run in one request.
   Settlement timeout is a reporting threshold, not permission to abandon its
   thread; the mandatory join above retains transaction ownership.
 - Give graceful worker drain five seconds. Bound forced worker-task cancellation
   separately so cancellation cleanup cannot make the lifecycle unbounded.
+- Bound settlement of any automatic supervisor restart already in progress by
+  the same all-inclusive process-start budget. The client deadline includes this
+  predecessor explicitly; the handoff fence prevents it from invoking
+  `on_ready` while claims are paused.
 - Expose pure budget helpers from `core/memory/process.py` for the production
   defaults. The stop budget includes both TERM and KILL wait rounds. Put one
   outer `asyncio.timeout()` around the complete `SidecarOwnership.reap()` call,
@@ -182,19 +207,19 @@ an abandoned restart, and a user retry can enqueue a second one.
   wait, and another full stop budget for cleanup after a spawned replacement
   fails to become ready; it never assumes only one internal reap round.
 - Set `MEMORY_RESTART_TIMEOUT_SECONDS` strictly above the sum of two clear
-  cleanup bounds, worker grace, worker cancellation cleanup, old-process stop,
-  and the all-inclusive replacement-start budget. The contract test imports the
-  source constants/helpers instead of copying numbers from comments. A deadline
-  cannot release either transaction while a non-cancellable settlement write is
-  still live; its mandatory join is an ownership cleanup tail rather than
-  detached restart work.
+  cleanup bounds, automatic-supervisor settlement, worker grace, worker
+  cancellation cleanup, old-process stop, and the all-inclusive replacement-start
+  budget. The contract test imports the source constants/helpers instead of
+  copying numbers from comments. A deadline cannot release either transaction
+  while a non-cancellable settlement write is still live; its mandatory join is
+  an ownership cleanup tail rather than detached restart work.
 - A busy result is a completed, retryable business response. It is not
   `memory_restart_failed`, starts no background task, ends the UI spinner, and
   displays a localized reason.
 
 No additional restart lock or queue is needed. The existing UI settings lock,
-installer flag, and controller/module lifecycle locks define single-flight
-ownership.
+config-wide write transaction, installer flag, restart-ownership boolean, and
+controller/module lifecycle locks define single-flight ownership.
 
 ### 5. Forced replacement and lease handoff
 
@@ -210,21 +235,33 @@ change MemoryStore or its recovery SQL.
 The locked sequence is fixed:
 
 1. Validate store, artifact, and enabled state; recover an interrupted clear.
-2. Pause claims and allow at most five seconds for the current drain. Timeout or
+2. Before touching the worker, call a non-awaiting, idempotent supervisor handoff
+   fence on the old `EverOSProcess`. It sets `_desired_running=false`, marks ready
+   callbacks quiesced, and returns the exact `_restart_task`. It cancels that task
+   only when `_starting` proves it has not entered `_start_locked()`; an active
+   start is retained rather than unsafely cancelled. Both `_watch_child()` and
+   `_notify_ready()` honor the fence, so a child exit or already-starting
+   replacement cannot resume claims or create a worker during explicit handoff.
+3. Immediately pause new claims, then await the retained supervisor task under
+   the complete process-start bound. It may finish launching a transient child,
+   but the ready fence prevents callback activation and step 8 will stop that
+   child. If the task outlives the bound, retain it, keep claims fenced, and
+   return fail-closed without rotating the lease or touching process ownership.
+4. Allow at most five seconds for the current worker drain. Timeout or
    an ordinary drain error enters the forced phase; task cancellation enters
    the cancellation cleanup path.
-3. Cancel and await the old worker task within its explicit cancellation bound.
+5. Cancel and await the old worker task within its explicit cancellation bound.
    Do not clear `_worker_task` until the exact task is done. If it outlives the
    bound, retain the task reference, keep claims fenced, and enter the
    fail-closed state below; do not rotate the lease or touch the process.
-4. Rotate the lease owner only after the old task is confirmed done and before
-   any new activation.
-5. Only when the snapshot has `embedding_change_pending`, run the root guard and
+6. Rotate the lease owner only after both retained tasks are confirmed done and
+   before any new activation.
+7. Only when the snapshot has `embedding_change_pending`, run the root guard and
    marker settlement while claims are fenced and the old worker is stopped.
    Restore `self._config` only after they pass.
-6. Stop the old process. Do not discard its supervisor or start another child
+8. Stop the old process. Do not discard its supervisor or start another child
    until its process tree is confirmed reaped.
-7. Create a process from `_restart_config` and call `start()`. Make ready-callback
+9. Create a process from `_restart_config` and call `start()`. Make ready-callback
    failure observable: `_notify_ready()` must propagate the callback exception
    into `_start_locked()`'s existing failed-start cleanup instead of logging and
    returning success. Restore claims and the worker only after `start()` and
@@ -240,19 +277,27 @@ worker classification path.
 
 Every exit after claims are fenced must end in one of these states:
 
+- **An automatic supervisor task outlives handoff settlement:** retain that
+  exact task, keep the old supervisor quiesced and claims fenced, retain the old
+  worker and lease, and return `memory_restart_failed` without touching process
+  ownership. A retry first rejoins the same task; it cannot continue while that
+  task is live.
 - **The old worker task outlives forced cancellation:** retain that exact task
   in `_worker_task`, retain the original lease, keep claims fenced, leave the
-  old process and supervisor untouched, set the visible runtime error, and
-  return `memory_restart_failed`. A retry cancels and waits on the retained task
-  for another bounded interval. It can continue only after the task is done and
-  its outcome has been consumed; while it remains live the retry returns the
-  same fail-closed response and creates no replacement worker or child.
+  old process untouched and its supervisor quiesced, set the visible runtime
+  error, and return `memory_restart_failed`. A retry reuses that quiesced
+  supervisor, cancels and waits on the retained task for another bounded
+  interval. It can continue only after the task is done and its outcome has been
+  consumed; while it remains live the retry returns the same fail-closed
+  response and creates no replacement worker or child.
 - **Failure before `old_process.stop()` is invoked:** the old supervisor still
-  has its original desired-running state. Reactivate with the new lease owner,
-  resume claims and the worker, and return the specific failure. The runtime is
-  genuinely restored to its pre-restart state. This branch applies only after
-  the previous worker task is confirmed done; it never attempts reactivation
-  beside a retained task.
+  owns its child but is quiesced. Re-arm supervision and ready callbacks. If its
+  child is still running, reactivate with the new lease owner, resume claims and
+  the worker, and return the specific failure. If the child exited during the
+  handoff, keep claims fenced and let the re-armed supervisor start a child;
+  only its successful observable `on_ready` may resume the worker. This branch
+  applies only after the previous worker task is confirmed done; it never
+  attempts reactivation beside a retained task.
 - **`old_process.stop()` was invoked:** `EverOSProcess.stop()` sets
   `_desired_running=false` before termination and cancels scheduled restart.
   If stop raises, retain the supervisor reference but keep claims and the worker
@@ -296,26 +341,30 @@ exceptions use the transport-only `memory_restart_failed`.
 
 ### Backend and transport
 
-1. `core/memory/runtime.py`: add `_restart_config` and fail-fast `restart()`;
-   commit snapshots after successful reconcile; retain worker tasks that outlive
-   cancellation; reject restart while artifact installation is active.
-2. `core/memory/module.py`: extract locked clear recovery while retaining the
-   wrapper for read paths; make destructive Clear acquire its lifecycle lock
-   without queueing behind restart.
-3. `core/memory/worker.py`: rotate the lease owner for replacement activation.
-4. `core/memory/process.py`: expose complete stop/start budget helpers, put one
-   cap around all orphan-reap rounds, and propagate ready-callback failure into
-   startup cleanup.
-5. `core/internal_server.py`: add `POST /internal/memory/restart`. Missing runtime
+1. `config/v2_config.py`, `vibe/api.py`, and every audited whole-file writer:
+   add the reentrant cross-process config write transaction, enter it before
+   load/merge, and enforce transaction ownership at `V2Config.save()`.
+2. `core/memory/runtime.py`: add `_restart_config`,
+   `_explicit_restart_active`, and fail-fast `restart()`; commit snapshots after
+   successful reconcile; retain worker tasks that outlive cancellation; reject
+   restart while artifact installation is active; make only restart-owned Clear
+   contention fail fast.
+3. `core/memory/module.py`: extract locked clear recovery while retaining the
+   wrapper and existing queued lifecycle-lock behavior for read/Clear paths.
+4. `core/memory/worker.py`: rotate the lease owner for replacement activation.
+5. `core/memory/process.py`: expose complete stop/start budget helpers, put one
+   cap around all orphan-reap rounds, add the explicit-handoff supervisor fence,
+   and propagate ready-callback failure into startup cleanup.
+6. `core/internal_server.py`: add `POST /internal/memory/restart`. Missing runtime
    returns `memory_runtime_missing`; unhandled exceptions map to
    `memory_restart_failed`, not `memory_reconcile_failed`.
-6. `vibe/internal_client.py`: add `memory_restart()` with a deadline above the
+7. `vibe/internal_client.py`: add `memory_restart()` with a deadline above the
    complete restart lifecycle budget; retain and join the shielded request task
    after a reporting timeout.
-7. `vibe/ui_memory_routes.py`: keep `/api/memory/runtime/restart`, acquire the
+8. `vibe/ui_memory_routes.py`: keep `/api/memory/runtime/restart`, acquire the
    Memory settings write lock across the internal call, and preserve same-origin
    validation.
-8. `core/memory/types.py` and frontend `errors` translations: add transport-only
+9. `core/memory/types.py` and frontend `errors` translations: add transport-only
    `memory_restart_failed` and `memory_restart_busy`; add no SQLite schema field.
 
 ### Frontend
@@ -352,14 +401,23 @@ exceptions use the transport-only `memory_restart_failed`.
     return `memory_restart_busy`, create no waiters, and change no ownership.
     An installer paused inside unlocked `ensure(force=True)` also returns busy
     before artifact resolution, worker fencing, or process replacement.
-  - Clear started while restart owns the module lifecycle lock returns before
+  - Clear started while `_explicit_restart_active` is true returns before
     `begin_clear()` and leaves no waiter or durable marker; the inverse ordering
-    makes restart return busy.
+    makes restart return busy. A search/profile call holding the same module lock
+    still makes Clear wait and then complete, preserving existing behavior.
   - Hung add and flush cases use shortened bounds; add can be reclaimed by the
     new owner, while flush becomes `unknown` and opens the fault.
   - A worker task that ignores its first cancellation is retained with the old
     lease and fenced claims. No child/process action occurs; retry stays closed
     until the exact task terminates, then completes replacement normally.
+  - If the old child exits during the five-second drain grace, its supervisor is
+    already quiesced: no automatic restart can invoke `on_ready`, resume claims,
+    or replace `_worker_task`. Pre-stop failure re-arms that supervisor and
+    resumes work only after a live/ready child is established.
+  - An automatic restart already inside `_start_locked()` is retained while
+    claims are paused. It either settles within the complete start bound and its
+    transient child is stopped, or restart returns fail-closed without lease or
+    process mutation; retry rejoins the same task.
   - Clear-marker recovery and replacement share one lifecycle critical section;
     recovery failure launches no child.
   - A startup snapshot with the embedding marker rejects existing vectors and
@@ -374,13 +432,18 @@ exceptions use the transport-only `memory_restart_failed`.
 - `tests/test_internal_server.py`: success, missing runtime, and exception mapping.
 - `tests/test_internal_client.py` / `tests/test_internal_client_timeouts.py`:
   POST and busy response passthrough; deadline computed from both clear phases,
-  worker bounds, old stop, the outer all-round orphan-reap cap, readiness, and
-  failed-start cleanup. On reporting timeout or caller cancellation, the
-  retained request is joined before its caller can release transaction
-  ownership.
+  automatic-supervisor settlement, worker bounds, old stop, the outer all-round
+  orphan-reap cap, readiness, and failed-start cleanup. On reporting timeout or
+  caller cancellation, the retained request is joined before its caller can
+  release transaction ownership.
 - `tests/test_ui_memory_routes.py`: new client path, internal unavailable,
   cross-origin rejection, restart/settings serialization, timed-out settlement
   ownership, and final C1 retention.
+- `tests/test_v2_config.py` / config route tests: a generic non-Memory save in a
+  second process waits before loading while settlement owns the config
+  transaction, then preserves both its C1 change and the cleared marker. Saving
+  without transaction ownership is rejected, and nested same-thread writes do
+  not deadlock.
 - `tests/test_memory_process.py`: stale recorded leader plus late helper and
   multiple unusable-record anchors share one outer reap deadline. Timeout keeps
   the record and prevents child launch. Ready-callback failure is returned as a
@@ -400,7 +463,7 @@ exceptions use the transport-only `memory_restart_failed`.
 ## Validation
 
 1. `pytest tests/test_memory_runtime.py -k restart`
-2. `pytest tests/test_internal_server.py tests/test_internal_client.py tests/test_internal_client_timeouts.py tests/test_ui_memory_routes.py -k 'memory and restart'`
+2. `pytest tests/test_internal_server.py tests/test_internal_client.py tests/test_internal_client_timeouts.py tests/test_ui_memory_routes.py tests/test_v2_config.py -k 'memory or config or restart'`
 3. Run `ruff check` on every changed Python file.
 4. In `ui/`, run the relevant normalizer, `SettingsMemoryPage`, and
    `MemoryStatusPanel` Vitest files, then `npm run build`.
@@ -419,11 +482,13 @@ exceptions use the transport-only `memory_restart_failed`.
 
 The necessary complexity comes from existing safety and concurrency contracts:
 failed candidates cannot replace last-good config; marker settlement cannot
-outlive its settings transaction; explicit restart and destructive Clear cannot
-queue behind each other; artifact installation excludes launch; orphan recovery
-has one complete cap; pending embeddings cannot bypass the root guard; claimed
-rows require a new lease only after the old worker exits; ready-callback success
-must be observable; and clear markers serialize with root/child lifecycle. The
+race any whole-file V2 writer or outlive its transaction; explicit restart and
+destructive Clear cannot queue behind each other while ordinary reads retain
+their existing serialization; artifact installation excludes launch; orphan
+recovery has one complete cap; automatic supervision is quiesced before worker
+handoff; pending embeddings cannot bypass the root guard; claimed rows require a
+new lease only after the old worker exits; ready-callback success must be
+observable; and clear markers serialize with root/child lifecycle. The
 implementation adds one private snapshot, narrow helpers, and two precise
 transport-only error codes while reusing existing locks, guards, recovery SQL,
 supervision, and UI primitives.
@@ -436,11 +501,13 @@ implementation appears to require one, revise this plan before expanding scope.
 
 - [ ] Runtime snapshot, pending-embedding guard, fail-fast restart, focused tests
 - [ ] Settings/restart serialization and stale-C0 overwrite regression
+- [ ] Config-wide transaction and concurrent non-Memory writer regression
 - [ ] Timed-out settlement ownership and retained-request regression
 - [ ] Worker lease rotation and add/flush recovery tests
 - [ ] Retained worker cancellation fail-closed state and retry
 - [ ] Locked clear recovery and race regression
-- [ ] Nonqueued destructive Clear and artifact-install admission
+- [ ] Restart-specific Clear admission and artifact-install admission
+- [ ] Supervisor handoff fence and child-exit-during-drain regression
 - [ ] Complete orphan/start budgets, observable ready callback, failed-start cleanup
 - [ ] Internal server/client, closed/busy errors, bounded timeout tests
 - [ ] UI route and response normalizer

--- a/docs/plans/memory-sidecar-force-restart-button.md
+++ b/docs/plans/memory-sidecar-force-restart-button.md
@@ -1,15 +1,15 @@
-# Add a forced sidecar restart action to Memory settings (rev11)
+# Add a forced sidecar restart action to Memory settings (rev12)
 
-> Rev11 keeps one public recovery action and a focused set of internal fixes:
+> Rev12 keeps one public recovery action and a focused set of internal fixes:
 > replayable configuration, config-wide write serialization, restart-specific
-> and Clear-intent admission, generation-fenced ready activation, complete
+> and lifecycle-intent admission, generation-fenced ready activation, complete
 > supervisor quiescing, bounded orphan recovery, disk/live replay convergence,
 > marker-free replay promotion, store-thread settlement, worker lease rotation,
 > locked clear-marker recovery, bounded readiness, supervisor callback rebinding,
-> and authoritative UI settings refresh. Timed-out work remains owned until it
-> is either joined or proven unable to mutate state. It does not add a lifecycle
-> coordinator, explicit state machine, provider/store port, or frontend DOM test
-> framework.
+> authoritative controller/UI settings refresh, and queued-read exclusion.
+> Timed-out work remains owned until it is either joined or proven unable to
+> mutate state. It does not add a lifecycle coordinator, explicit state machine,
+> provider/store port, or frontend DOM test framework.
 
 ## Background and goals
 
@@ -67,10 +67,12 @@ Add private `_restart_config` and `_persisted_memory_snapshot` values to
   a first-start failure can still be retried with the same configuration.
 - Update `_restart_config` with another deep copy only when enabled or disabled
   reconcile has completed successfully, while `_reconcile_lock` is held.
-- Initialize `_persisted_memory_snapshot` from the startup config. At the start
-  of `Controller.reconcile_memory()`, pass an explicit `persisted=True` contract
-  into `MemoryRuntime.reconcile()`: that controller entry point hot-applies a
-  freshly loaded, successfully saved V2 config. After acquiring
+- Initialize `_persisted_memory_snapshot` from the startup config. Add a narrow
+  `MemoryRuntime.reconcile_persisted()` entry point used only by
+  `Controller.reconcile_memory()`: it hot-applies a freshly loaded, successfully
+  saved V2 config and returns both the transport result and a deep copy of the
+  exact applied `MemoryConfig` on success. The ordinary `reconcile()` keeps its
+  current dict return for runtime-internal callers. After acquiring
   `_reconcile_lock`, a persisted reconcile replaces the snapshot with a deep
   copy of its candidate before live application, so the complete expected disk
   block is retained even if reconciliation later fails. Runtime-internal calls
@@ -115,6 +117,13 @@ Add private `_restart_config` and `_persisted_memory_snapshot` values to
   fails, keep the previous last-good `_restart_config` while retaining the exact
   marker-free `_persisted_memory_snapshot` for conditional disk convergence on a
   later restart.
+- `Controller.reconcile_memory()` installs only the successful applied config
+  returned by `reconcile_persisted()` into `Controller.config.memory`; it never
+  reuses its original marker-bearing argument. The returned candidate is already
+  the exact settled block, so controller shared state, runtime live/replay state,
+  and disk converge without mutating an object from the settlement thread. A
+  failed reconcile returns no applied candidate and leaves controller config at
+  its previous value.
 
 These snapshots answer which configuration an explicit restart replays and
 which exact Memory block it may conditionally replace on disk. They do not
@@ -251,8 +260,17 @@ An explicit restart must not wait silently behind another lifecycle operation.
 Otherwise the transport can time out first while the controller later performs
 an abandoned restart, and a user retry can enqueue a second one.
 
-- Before any await, `restart()` checks `_clear_pending_count`, `_reconcile_lock`,
-  and `module._lifecycle_lock`. If a destructive Clear is pending/active or
+- Add a synchronous, read-only `MemoryModule.lifecycle_busy` admission property
+  backed by a private `_lifecycle_pending_count`. Search, profile, Clear, and the
+  interrupted-clear wrapper enter a synchronous intent scope after input
+  validation but before their first lifecycle await, and leave it in `finally`
+  only after their complete lifecycle-lock path exits. The scope covers both the
+  current owner and every queued operation, including the interval between clear
+  recovery and a search/profile provider call. Nested locked helpers reuse the
+  outer intent; no code reads private `asyncio.Lock` waiter state.
+- Before any await, `restart()` checks `_clear_pending_count`,
+  `module.lifecycle_busy`, `_reconcile_lock`, and `module._lifecycle_lock`. If a
+  complete Runtime Clear or any module lifecycle operation is active/queued, or
   either lock is held, return
   `{ok: false, error: 'memory_restart_busy'}` without changing the process,
   claims, or worker.
@@ -267,19 +285,23 @@ an abandoned restart, and a user retry can enqueue a second one.
   acquiring both lifecycle locks, before the first lifecycle await, and clears
   it only in final ownership cleanup. `MemoryRuntime.clear()` checks the restart
   boolean and, if false, increments the Clear counter in the same event-loop turn
-  before its first await. Keep the counter owned across `module.clear()` and the
+  before its first await. Keep that counter owned across `module.clear()` and the
   subsequent reconcile, then decrement it in `finally` on every completion or
-  cancellation path. Multiple queued Clears each own one count.
+  cancellation path. `MemoryModule.clear()` also owns its module lifecycle
+  intent only for its direct lifecycle-lock path. Multiple queued Runtime Clears
+  and module operations retain independent counts.
 - `MemoryRuntime.clear()` still returns `memory_clear_failed` without starting
   or queueing `begin_clear()` when an explicit restart already owns admission.
   `MemoryModule.clear()` retains its existing queued lifecycle-lock behavior, so
   search/profile/read contention still serializes. While a Clear waits behind
-  such a reader, the nonzero counter makes restart return
+  such a reader, the nonzero lifecycle counter makes restart return
   `memory_restart_busy`; restart cannot exploit the brief unlocked handoff while
-  `asyncio.Lock` wakes the queued Clear. Conversely, once restart admission has
-  started, the active boolean rejects Clear before it increments the counter.
-  Both updates and admission checks contain no intervening await, so one side
-  wins deterministically without inspecting private lock waiters.
+  `asyncio.Lock` wakes any queued Clear, search, or profile request. Conversely,
+  once restart admission has started, the active boolean rejects Clear before it
+  enters module lifecycle intent; reads keep their existing queued behavior
+  behind restart. Intent updates and admission checks contain no intervening
+  await, so one side wins deterministically without inspecting private lock
+  waiters or adding an unbudgeted predecessor to restart.
 - Bound interrupted-clear recovery and the embedding guard/config convergence
   separately by `CLEAR_CLEANUP_TIMEOUT_SECONDS`, because both phases can run in
   one request. Transaction timeout is a reporting threshold, not permission to
@@ -334,8 +356,8 @@ an abandoned restart, and a user retry can enqueue a second one.
 
 No additional restart lock or queue is needed. The existing UI settings lock,
 config-wide write transaction, installer flag, restart-ownership boolean,
-Clear-intent counter, and controller/module lifecycle locks define single-flight
-ownership.
+Clear-intent counter, module lifecycle-intent counter, and controller/module
+lifecycle locks define single-flight ownership.
 
 ### 5. Forced replacement and lease handoff
 
@@ -535,11 +557,16 @@ exceptions use the transport-only `memory_restart_failed`.
    live/replay candidate from marker settlement's exact return; conditionally
    converge disk to replay before launch; retain worker/store tasks that outlive
    cancellation; reject restart while artifact installation is active; make only
-   restart/Clear contention fail fast.
-   `Controller.reconcile_memory()` marks only its persisted candidate explicitly;
-   post-Clear and artifact-internal reconciles cannot change the disk snapshot.
+   explicit restart admission fail fast. Add `reconcile_persisted()` to return
+   the exact successful candidate alongside the transport result while ordinary
+   `reconcile()` preserves its dict contract.
+   `Controller.reconcile_memory()` installs that returned candidate into
+   `Controller.config.memory`; post-Clear and artifact-internal reconciles cannot
+   claim a persisted snapshot or change controller shared config.
 3. `core/memory/module.py`: extract locked clear recovery while retaining the
-   wrapper and existing queued lifecycle-lock behavior for read/Clear paths.
+   wrapper and existing queued lifecycle-lock behavior for read/Clear paths. Add
+   the synchronous lifecycle-intent scope and `lifecycle_busy` property covering
+   active and queued search, profile, Clear, and recovery operations.
 4. `core/memory/worker.py`: retain and shield explicit store-thread tasks, expose
    bounded settlement, and rotate the lease owner only after their registry is
    empty.
@@ -609,6 +636,10 @@ exceptions use the transport-only `memory_restart_failed`.
     return `memory_restart_busy`, create no waiters, and change no ownership.
     An installer paused inside unlocked `ensure(force=True)` also returns busy
     before artifact resolution, worker fencing, or process replacement.
+    Hold one search/profile request in the module lock and queue a second; across
+    the owner's release/waiter-wakeup gap, `lifecycle_busy` remains true and
+    restart returns busy without joining the read queue. After both reads finish,
+    restart can acquire admission normally.
   - Clear started while `_explicit_restart_active` is true returns before
     `begin_clear()` and leaves no waiter or durable marker; the inverse ordering
     makes restart return busy. A search/profile call holding the same module lock
@@ -662,6 +693,12 @@ exceptions use the transport-only `memory_restart_failed`.
     restored claims.
   - Cancellation while stopping the worker and after a new child is spawned
     reaches the documented cleanup state and re-raises `CancelledError`.
+- `tests/test_memory_slice3.py`: a successful persisted reconcile that settles
+  the embedding marker returns the exact marker-free applied config to
+  `Controller.reconcile_memory()`, which installs a deep copy into
+  `Controller.config.memory`. Disk, controller, runtime live state, and replay
+  state must match; the original marker-bearing request object is not installed.
+  Failure returns no candidate and preserves the prior controller config.
 - `tests/test_internal_server.py`: success, missing runtime, and exception mapping.
 - `tests/test_internal_client.py` / `tests/test_internal_client_timeouts.py`:
   POST and busy response passthrough; deadline computed from both clear phases,
@@ -741,10 +778,12 @@ conditionally converge the known persisted Memory block to that same config;
 config mutation cannot race any whole-file V2 writer, start from an unlocked
 baseline, lose a custom target path, hold `CONFIG_LOCK` during a file-lock wait,
 block an async event loop, or outlive its transaction; every successful
-runtime-owned mutation refreshes the exact persisted snapshot; explicit restart
-and destructive Clear cannot queue behind or leapfrog each other while ordinary
-reads retain their existing serialization; artifact installation excludes
-launch; orphan recovery has one complete cap; every active process lifecycle
+runtime-owned mutation refreshes the exact persisted snapshot and successful
+settlement propagates the same exact block into controller shared config;
+explicit restart cannot queue behind or leapfrog any active or queued module
+lifecycle operation, while reads and destructive Clear retain their existing
+serialization; artifact installation excludes launch; orphan recovery has one
+complete cap; every active process lifecycle
 owner is settled and budgeted before stop; readiness, including the final health
 request, has one hard cap; delayed automatic activation and re-armed supervision
 are bound to the current lifecycle generation and both runtime locks; pending
@@ -752,7 +791,7 @@ embeddings cannot bypass the root guard or remain in a successful replay
 snapshot; claimed rows require a new lease only after the old worker and every
 shielded store thread exit; activation success is observable; UI settings reload
 from the converged disk block; and clear markers serialize with root/child
-lifecycle. The implementation adds two private snapshots, two narrow admission
+lifecycle. The implementation adds two private snapshots, three narrow admission
 fields, focused helpers, and two precise transport-only error codes while reusing
 existing locks, guards, recovery SQL, supervision, and UI primitives.
 
@@ -764,6 +803,7 @@ implementation appears to require one, revise this plan before expanding scope.
 
 - [ ] Replay/disk snapshots, conditional C1-to-C0 convergence, focused tests
 - [ ] Marker-settlement persisted/live/replay refresh and later-restart regression
+- [ ] Persisted reconcile propagation into Controller.config
 - [ ] Settings/restart serialization and stale-C0 overwrite regression
 - [ ] Path-aware token-bound config mutation and custom-target regression
 - [ ] File-lock-first order, async writers off-thread, inline-reader responsiveness
@@ -773,6 +813,7 @@ implementation appears to require one, revise this plan before expanding scope.
 - [ ] Shielded store-thread registry, bounded settlement, and retry
 - [ ] Locked clear recovery and race regression
 - [ ] Restart/Clear intent admission, queued-Clear handoff, artifact admission
+- [ ] Queued read intent admission and waiter-handoff regression
 - [ ] Supervisor handoff/rebind, lifecycle-owner settlement, readiness/deadline contract
 - [ ] Lifecycle-generation ready activation and Clear/reconcile race regression
 - [ ] Complete orphan/start budgets, explicit activation, failed-start cleanup

--- a/docs/plans/memory-sidecar-force-restart-button.md
+++ b/docs/plans/memory-sidecar-force-restart-button.md
@@ -1,13 +1,13 @@
-# Add a forced sidecar restart action to Memory settings (rev9)
+# Add a forced sidecar restart action to Memory settings (rev10)
 
-> Rev9 keeps one public recovery action and a focused set of internal fixes:
+> Rev10 keeps one public recovery action and a focused set of internal fixes:
 > replayable configuration, config-wide write serialization, restart-specific
-> lifecycle admission, generation-fenced ready activation, complete supervisor
-> quiescing, bounded orphan recovery, disk/live replay convergence, store-thread
-> settlement, worker lease rotation, and locked clear-marker recovery. Timed-out
-> work remains owned until it is either joined or proven unable to mutate state.
-> It does not add a lifecycle coordinator, explicit state machine,
-> provider/store port, or frontend DOM test framework.
+> and Clear-intent admission, generation-fenced ready activation, complete
+> supervisor quiescing, bounded orphan recovery, disk/live replay convergence,
+> store-thread settlement, worker lease rotation, and locked clear-marker
+> recovery. Timed-out work remains owned until it is either joined or proven
+> unable to mutate state. It does not add a lifecycle coordinator, explicit
+> state machine, provider/store port, or frontend DOM test framework.
 
 ## Background and goals
 
@@ -97,6 +97,14 @@ Add private `_restart_config` and `_persisted_memory_snapshot` values to
   `_restart_config`, `_persisted_memory_snapshot`, and the later restored
   `self._config`, without changing any other Memory field. It does not run the
   processing probe.
+- Every successful runtime-owned V2 Memory mutation returns the exact committed
+  `MemoryConfig` from `mutate_v2_config()`. While `_reconcile_lock` is still
+  owned, install that returned value into `_persisted_memory_snapshot`
+  immediately. In particular, ordinary persisted reconcile captures the
+  marker-bearing candidate first, then marker settlement returns the
+  marker-free disk block and refreshes the snapshot before any later reconcile
+  phase can return or fail. A failed/aborted transaction leaves the previous
+  snapshot unchanged.
 
 These snapshots answer which configuration an explicit restart replays and
 which exact Memory block it may conditionally replace on disk. They do not
@@ -139,9 +147,14 @@ Memory-only serialization is insufficient.
   restart request and response. Every Memory PATCH already holds this same lock
   across load, save, controller reconcile, and rollback, so a PATCH cannot write
   C1 between the controller's C0 comparison and marker-clear save.
-- Add one synchronous `mutate_v2_config(mutator, *, initializer=None)` write API
-  in `config/v2_config.py`. Its outermost call first acquires a config-specific
-  cross-process file lock, using the existing
+- Add one synchronous
+  `mutate_v2_config(mutator, *, config_path=None, initializer=None)` write API in
+  `config/v2_config.py`. Normalize the selected default or custom target to one
+  absolute path without resolving away its existing symlink/replace semantics.
+  Preserve `V2Config.save(config_path)`'s parent-creation behavior before lock
+  acquisition, then derive a deterministic per-target sibling lock path from
+  that normalized config path. Its outermost call first acquires this
+  path-specific cross-process file lock, using the existing
   `storage.lock.MigrationFileLock` primitive with a dedicated lock path and
   bounded acquisition, without owning `CONFIG_LOCK`. Only after the file lock is
   held does it acquire `CONFIG_LOCK`, load the current document, invoke a
@@ -153,14 +166,18 @@ Memory-only serialization is insufficient.
   without freezing their async event loop behind that writer's bounded wait.
   The API never accepts a caller-supplied or preloaded `V2Config` instance.
   First-install/default paths may supply an initializer factory, which is also
-  invoked only under both locks when the document is absent.
+  invoked only under both locks when the selected document is absent. Loading,
+  initializing, token validation, and the final atomic replace all use that same
+  normalized target; custom-path callers never fall back to the default config.
 - Make the raw save primitive private to that API. Bind its opaque write token
-  to both the transaction session and the exact config object loaded inside it;
-  a missing token, a token from another session, or a config object loaded
-  before lock acquisition is rejected. Reentrant same-thread mutation calls
-  reuse the outer session and its one working object, and only the outermost call
-  publishes one final document, rather than reloading or saving a nested stale
-  baseline.
+  to the normalized target path, transaction session, and exact config object
+  loaded inside it; a missing token, a token for another path/session, or a
+  config object loaded before lock acquisition is rejected. Reentrant
+  same-thread mutation calls for the same target reuse the outer session and its
+  one working object, and only the outermost call publishes one final document.
+  Reject a nested request for a different target before acquiring another lock;
+  callers split it into a separate outer operation so lock ordering remains
+  explicit.
 - Migrate every whole-file V2 writer to the mutation API: the generic and Memory
   paths in `vibe/api.py`, direct writers in `vibe/ui_server.py` and
   `vibe/remote_access.py`, `SettingsHandler`, `ModelHubService`, controller and
@@ -224,8 +241,9 @@ An explicit restart must not wait silently behind another lifecycle operation.
 Otherwise the transport can time out first while the controller later performs
 an abandoned restart, and a user retry can enqueue a second one.
 
-- Before any await, `restart()` checks `_reconcile_lock` and
-  `module._lifecycle_lock`. If either is held, return
+- Before any await, `restart()` checks `_clear_pending_count`, `_reconcile_lock`,
+  and `module._lifecycle_lock`. If a destructive Clear is pending/active or
+  either lock is held, return
   `{ok: false, error: 'memory_restart_busy'}` without changing the process,
   claims, or worker.
 - When both are free, acquire them in the established order in the same event
@@ -234,15 +252,24 @@ an abandoned restart, and a user retry can enqueue a second one.
   release the lock and return `memory_restart_busy` before resolving an artifact
   or touching worker/process state. This check covers `install_artifact()`'s
   deliberate unlocked `ensure(force=True)` interval.
-- Track a narrow `_explicit_restart_active` boolean in `MemoryRuntime`. Set it
-  after restart has acquired both lifecycle locks, before the first lifecycle
-  await, and clear it only in the final ownership cleanup. `MemoryRuntime.clear()`
-  checks this flag before awaiting `module.clear()` and returns
-  `memory_clear_failed` without starting or queueing `begin_clear()` only when an
-  explicit restart owns the lifecycle. `MemoryModule.clear()` retains its
-  existing queued lock behavior, so search/profile/read contention still
-  serializes instead of becoming a spurious Clear failure. If Clear reaches the
-  module lock first, restart observes that lock and returns `memory_restart_busy`.
+- Track a narrow `_explicit_restart_active` boolean and
+  `_clear_pending_count` in `MemoryRuntime`. Restart sets its boolean after
+  acquiring both lifecycle locks, before the first lifecycle await, and clears
+  it only in final ownership cleanup. `MemoryRuntime.clear()` checks the restart
+  boolean and, if false, increments the Clear counter in the same event-loop turn
+  before its first await. Keep the counter owned across `module.clear()` and the
+  subsequent reconcile, then decrement it in `finally` on every completion or
+  cancellation path. Multiple queued Clears each own one count.
+- `MemoryRuntime.clear()` still returns `memory_clear_failed` without starting
+  or queueing `begin_clear()` when an explicit restart already owns admission.
+  `MemoryModule.clear()` retains its existing queued lifecycle-lock behavior, so
+  search/profile/read contention still serializes. While a Clear waits behind
+  such a reader, the nonzero counter makes restart return
+  `memory_restart_busy`; restart cannot exploit the brief unlocked handoff while
+  `asyncio.Lock` wakes the queued Clear. Conversely, once restart admission has
+  started, the active boolean rejects Clear before it increments the counter.
+  Both updates and admission checks contain no intervening await, so one side
+  wins deterministically without inspecting private lock waiters.
 - Bound interrupted-clear recovery and the embedding guard/config convergence
   separately by `CLEAR_CLEANUP_TIMEOUT_SECONDS`, because both phases can run in
   one request. Transaction timeout is a reporting threshold, not permission to
@@ -290,8 +317,9 @@ an abandoned restart, and a user retry can enqueue a second one.
   displays a localized reason.
 
 No additional restart lock or queue is needed. The existing UI settings lock,
-config-wide write transaction, installer flag, restart-ownership boolean, and
-controller/module lifecycle locks define single-flight ownership.
+config-wide write transaction, installer flag, restart-ownership boolean,
+Clear-intent counter, and controller/module lifecycle locks define single-flight
+ownership.
 
 ### 5. Forced replacement and lease handoff
 
@@ -351,7 +379,9 @@ The locked sequence is fixed:
    When `_restart_config` has `embedding_change_pending`, run the root guard
    first and clear the marker in the replay block. The transaction must replace
    only the expected persisted Memory block with replay C0, preserving every
-   unrelated field. Restore `self._config` only after convergence succeeds.
+   unrelated field, and return the exact committed block. Refresh
+   `_persisted_memory_snapshot` from that return value and restore `self._config`
+   only after convergence succeeds.
 9. Stop the old process. Do not discard its supervisor or start another child
    until its process tree is confirmed reaped.
 10. Create a process from `_restart_config` bound to the lifecycle generation
@@ -470,15 +500,18 @@ exceptions use the transport-only `memory_restart_failed`.
 
 1. `config/v2_config.py`, `vibe/api.py`, and every audited whole-file writer:
    add the cross-process `mutate_v2_config()` API, make raw save private, bind
-   the working object to an opaque session token, always acquire the file lock
-   before `CONFIG_LOCK`, and offload the complete mutation from every
-   asynchronous caller.
+   the target path and working object to an opaque session token, derive one
+   lock per normalized default/custom path, always acquire that file lock before
+   `CONFIG_LOCK`, and offload the complete mutation from every asynchronous
+   caller.
 2. `core/memory/runtime.py`: add `_restart_config`,
-   `_persisted_memory_snapshot`, `_explicit_restart_active`, lifecycle generation
-   and a retained ready activation task, and fail-fast `restart()`; conditionally
-   converge disk to replay before launch; retain worker/store tasks that outlive
-   cancellation; reject restart while artifact installation is active; make
-   only restart-owned Clear contention fail fast.
+   `_persisted_memory_snapshot`, `_explicit_restart_active`,
+   `_clear_pending_count`, lifecycle generation and a retained ready activation
+   task, and fail-fast `restart()`; refresh the persisted snapshot after every
+   successful runtime-owned V2 mutation; conditionally converge disk to replay
+   before launch; retain worker/store tasks that outlive cancellation; reject
+   restart while artifact installation is active; make only restart/Clear
+   contention fail fast.
    `Controller.reconcile_memory()` marks only its persisted candidate explicitly;
    post-Clear and artifact-internal reconciles cannot change the disk snapshot.
 3. `core/memory/module.py`: extract locked clear recovery while retaining the
@@ -545,6 +578,9 @@ exceptions use the transport-only `memory_restart_failed`.
     `begin_clear()` and leaves no waiter or durable marker; the inverse ordering
     makes restart return busy. A search/profile call holding the same module lock
     still makes Clear wait and then complete, preserving existing behavior.
+    While that Clear is queued, `_clear_pending_count` also makes restart return
+    busy through the lock-release/waiter-wakeup gap. Concurrent Clear requests
+    retain independent counts until their complete Clear/reconcile paths exit.
   - Hung add and flush cases use shortened bounds; add can be reclaimed by the
     new owner, while flush becomes `unknown` and opens the fault.
   - A worker task that ignores its first cancellation is retained with the old
@@ -575,7 +611,9 @@ exceptions use the transport-only `memory_restart_failed`.
   - Clear-marker recovery and replacement share one lifecycle critical section;
     recovery failure launches no child.
   - A startup snapshot with the embedding marker rejects existing vectors and
-    settles an empty root before launch.
+    settles an empty root before launch. A successful ordinary persisted
+    reconcile that clears the marker refreshes `_persisted_memory_snapshot` to
+    the exact marker-free disk block, so a later restart accepts it.
   - Disabled, `start() is False`, factory exception, explicit activation
     exception, automatic activation exception, failed-start cleanup, and stop
     exception cases assert error codes, supervisor ownership, claims/worker
@@ -604,6 +642,10 @@ exceptions use the transport-only `memory_restart_failed`.
   and publish once without deadlock. While a second process holds the file lock,
   writers wait without owning `CONFIG_LOCK`, representative inline async UI and
   controller reads complete, and event-loop probes continue to run.
+  A custom-path initializer and mutation update only that selected target and
+  its sibling lock, leaving the default config untouched. Tokens cannot cross
+  paths, same-target nested mutation reuses its session, and nested
+  different-target mutation is rejected before acquiring another lock.
 - `tests/test_memory_worker.py`: `_store_call()` shields and retains its explicit
   thread task across drain cancellation. `settle_store_calls()` times out without
   cancelling the thread, retains it for retry, consumes its terminal result, and
@@ -650,17 +692,19 @@ The necessary complexity comes from existing safety and concurrency contracts:
 failed candidates cannot replace last-good config, and successful replay must
 conditionally converge the known persisted Memory block to that same config;
 config mutation cannot race any whole-file V2 writer, start from an unlocked
-baseline, hold `CONFIG_LOCK` during a file-lock wait, block an async event loop,
-or outlive its transaction; explicit restart and destructive Clear cannot queue
-behind each other while ordinary reads retain their existing serialization;
-artifact installation excludes launch; orphan recovery has one complete cap;
-every active process lifecycle owner is settled and budgeted before stop;
-delayed automatic activation is fenced by lifecycle generation and both runtime
-locks; pending embeddings cannot bypass the root guard; claimed rows require a
-new lease only after the old worker and every shielded store thread exit;
-activation success is observable; and clear markers serialize with root/child
-lifecycle. The implementation adds two private snapshots, narrow helpers, and
-two precise transport-only error codes while reusing existing locks, guards,
+baseline, lose a custom target path, hold `CONFIG_LOCK` during a file-lock wait,
+block an async event loop, or outlive its transaction; every successful
+runtime-owned mutation refreshes the exact persisted snapshot; explicit restart
+and destructive Clear cannot queue behind or leapfrog each other while ordinary
+reads retain their existing serialization; artifact installation excludes
+launch; orphan recovery has one complete cap; every active process lifecycle
+owner is settled and budgeted before stop; delayed automatic activation is
+fenced by lifecycle generation and both runtime locks; pending embeddings cannot
+bypass the root guard; claimed rows require a new lease only after the old
+worker and every shielded store thread exit; activation success is observable;
+and clear markers serialize with root/child lifecycle. The implementation adds
+two private snapshots, two narrow admission fields, focused helpers, and two
+precise transport-only error codes while reusing existing locks, guards,
 recovery SQL, supervision, and UI primitives.
 
 Do not introduce a general coordinator, explicit restart state machine, new
@@ -670,15 +714,16 @@ implementation appears to require one, revise this plan before expanding scope.
 ## Todo
 
 - [ ] Replay/disk snapshots, conditional C1-to-C0 convergence, focused tests
+- [ ] Marker-settlement snapshot refresh and later-restart regression
 - [ ] Settings/restart serialization and stale-C0 overwrite regression
-- [ ] Token-bound config mutation API and concurrent non-Memory writer regression
+- [ ] Path-aware token-bound config mutation and custom-target regression
 - [ ] File-lock-first order, async writers off-thread, inline-reader responsiveness
 - [ ] Timed-out settlement ownership and retained-request regression
 - [ ] Worker lease rotation and add/flush recovery tests
 - [ ] Retained worker cancellation fail-closed state and retry
 - [ ] Shielded store-thread registry, bounded settlement, and retry
 - [ ] Locked clear recovery and race regression
-- [ ] Restart-specific Clear admission and artifact-install admission
+- [ ] Restart/Clear intent admission, queued-Clear handoff, artifact admission
 - [ ] Supervisor handoff fence, lifecycle-owner settlement, and deadline contract
 - [ ] Lifecycle-generation ready activation and Clear/reconcile race regression
 - [ ] Complete orphan/start budgets, explicit activation, failed-start cleanup

--- a/docs/plans/memory-sidecar-force-restart-button.md
+++ b/docs/plans/memory-sidecar-force-restart-button.md
@@ -1,12 +1,12 @@
-# Add a forced sidecar restart action to Memory settings (rev7)
+# Add a forced sidecar restart action to Memory settings (rev8)
 
-> Rev7 keeps one public recovery action and a focused set of internal fixes:
+> Rev8 keeps one public recovery action and a focused set of internal fixes:
 > replayable configuration, config-wide write serialization, restart-specific
-> lifecycle admission, supervisor quiescing, bounded orphan recovery, worker
-> lease rotation, and locked clear-marker recovery. Timed-out work remains owned
-> until it is either joined or proven unable to mutate state. It does not add a
-> lifecycle coordinator, explicit state machine, provider/store port, or
-> frontend DOM test framework.
+> lifecycle admission, generation-fenced ready activation, complete supervisor
+> quiescing, bounded orphan recovery, worker lease rotation, and locked
+> clear-marker recovery. Timed-out work remains owned until it is either joined
+> or proven unable to mutate state. It does not add a lifecycle coordinator,
+> explicit state machine, provider/store port, or frontend DOM test framework.
 
 ## Background and goals
 
@@ -117,23 +117,37 @@ Memory-only serialization is insufficient.
   restart request and response. Every Memory PATCH already holds this same lock
   across load, save, controller reconcile, and rollback, so a PATCH cannot write
   C1 between the controller's C0 comparison and marker-clear save.
-- Add one reentrant config-write transaction in `config/v2_config.py`. Its
-  outermost entry acquires `CONFIG_LOCK` and then a config-specific cross-process
-  file lock, using the existing `storage.lock.MigrationFileLock` primitive with
-  a dedicated lock path and bounded acquisition. Nested calls in the same thread
-  reuse the outer ownership rather than opening a second file-lock handle.
-- Every whole-file V2 writer must enter that transaction before loading the
-  current config and hold it through `V2Config.save()`. Migrate the generic and
-  Memory save paths in `vibe/api.py`, direct writers in `vibe/ui_server.py` and
-  `vibe/remote_access.py`, startup/default writers, and every other audited
-  `V2Config.save()` call path. `V2Config.save()` asserts transaction ownership so
-  a future writer cannot silently bypass the contract.
-- The transaction remains synchronous. Async UI/server routes offload the whole
-  load/merge/save transaction to one `asyncio.to_thread()` call, as the current
-  config route already does, so bounded file-lock waiting never blocks the ASGI
-  event loop.
-- Controller settlement enters the same config-wide transaction, freshly loads
-  the document, compares the complete expected Memory block, mutates only
+- Add one synchronous `mutate_v2_config(mutator, *, initializer=None)` write API
+  in `config/v2_config.py`. Its outermost call acquires `CONFIG_LOCK` and then a
+  config-specific cross-process file lock, using the existing
+  `storage.lock.MigrationFileLock` primitive with a dedicated lock path and
+  bounded acquisition. Only after both locks are owned does it load the current
+  document, invoke a synchronous mutator on that fresh working object, validate
+  it, and atomically save it before releasing either lock. It never accepts a
+  caller-supplied or preloaded `V2Config` instance. First-install/default paths
+  may supply an initializer factory, which is also invoked only under both locks
+  when the document is absent.
+- Make the raw save primitive private to that API. Bind its opaque write token
+  to both the transaction session and the exact config object loaded inside it;
+  a missing token, a token from another session, or a config object loaded
+  before lock acquisition is rejected. Reentrant same-thread mutation calls
+  reuse the outer session and its one working object, and only the outermost call
+  publishes one final document, rather than reloading or saving a nested stale
+  baseline.
+- Migrate every whole-file V2 writer to the mutation API: the generic and Memory
+  paths in `vibe/api.py`, direct writers in `vibe/ui_server.py` and
+  `vibe/remote_access.py`, `SettingsHandler`, `ModelHubService`, controller and
+  agent-auth flows, startup/default writers, runtime settlement, and every other
+  audited former `V2Config.save()` call path. Each mutator merges only its owned
+  fields into the transaction's freshly loaded working object.
+- Every asynchronous caller, including controller-side IM settings, model-hub,
+  agent-auth, startup/runtime, and UI/server paths, offloads the complete
+  `mutate_v2_config()` call to one `asyncio.to_thread()` invocation. No async
+  caller may acquire the synchronous file lock or run load/merge/save inline on
+  its event loop. Awaited external I/O happens before the transaction; the
+  synchronous mutator then revalidates against the freshly loaded state.
+- Controller settlement uses that mutation API, compares the complete expected
+  Memory block on the fresh working object, mutates only
   `embedding_change_pending`, and atomically saves. A mismatch or bounded lock
   timeout fails closed with `memory_clear_failed`. Unrelated config writers wait
   before their load, so none can publish a stale whole-file snapshot afterward.
@@ -162,6 +176,11 @@ before loading its baseline. Cover ordinary completion and an expired settlement
 deadline. In the expired case, prove the request and transaction locks remain
 owned until the retained thread finishes. Both writers must then preserve the
 settled marker and their own C1 fields without either side restoring stale C0.
+Also load a stale C0 before another process publishes C1 and prove it cannot be
+passed into the mutation API or saved with a later transaction token; the
+accepted mutator must observe C1. Hold the file lock from a second process and
+prove representative async UI and controller writers keep their event loops
+responsive while their complete mutation waits in a worker thread.
 
 ### 4. Nonqueued admission and complete deadlines
 
@@ -196,8 +215,19 @@ an abandoned restart, and a user retry can enqueue a second one.
   separately so cancellation cleanup cannot make the lifecycle unbounded.
 - Bound settlement of any automatic supervisor restart already in progress by
   the same all-inclusive process-start budget. The client deadline includes this
-  predecessor explicitly; the handoff fence prevents it from invoking
-  `on_ready` while claims are paused.
+  predecessor explicitly. A generation fence, described below, prevents its
+  delayed ready activation from crossing a later Clear or reconcile boundary.
+- Add an async process handoff operation that settles every active lifecycle
+  owner, not only `_restart_task`. It first applies the non-awaiting supervisor
+  fence. A watcher or monitor that is still only waiting/polling is cancelled
+  and joined before `stop()`; one that has already entered child-tree cleanup is
+  retained and awaited under a process-owner settlement cap. Cleanup tasks are
+  never cancelled in the middle of termination. `_watch_cleanup_active` and
+  `_monitor_cleanup_active` flip synchronously before their tasks await the
+  process lifecycle lock or termination; handoff checks the phase and issues any
+  idle-task cancellation in the same event-loop turn, with no intervening await.
+  After this operation returns, no predecessor watcher, monitor, or restart task
+  can still own or be queued on the process lifecycle lock.
 - Expose pure budget helpers from `core/memory/process.py` for the production
   defaults. The stop budget includes both TERM and KILL wait rounds. Put one
   outer `asyncio.timeout()` around the complete `SidecarOwnership.reap()` call,
@@ -206,13 +236,16 @@ an abandoned restart, and a user retry can enqueue a second one.
   start failure. The start budget uses that single outer reap cap, readiness
   wait, and another full stop budget for cleanup after a spawned replacement
   fails to become ready; it never assumes only one internal reap round.
-- Set `MEMORY_RESTART_TIMEOUT_SECONDS` strictly above the sum of two clear
-  cleanup bounds, automatic-supervisor settlement, worker grace, worker
-  cancellation cleanup, old-process stop, and the all-inclusive replacement-start
-  budget. The contract test imports the source constants/helpers instead of
-  copying numbers from comments. A deadline cannot release either transaction
-  while a non-cancellable settlement write is still live; its mandatory join is
-  an ownership cleanup tail rather than detached restart work.
+- Expose a process-owner settlement budget that includes watcher/monitor
+  cancellation joins and one complete TERM/KILL cleanup round. Set
+  `MEMORY_RESTART_TIMEOUT_SECONDS` strictly above the sum of two clear cleanup
+  bounds, automatic-supervisor start settlement, process-owner settlement,
+  worker grace, worker cancellation cleanup, a separate old-process stop retry,
+  and the all-inclusive replacement-start budget. The contract test imports the
+  source constants/helpers instead of copying numbers from comments. A deadline
+  cannot release either transaction while a non-cancellable settlement write is
+  still live; its mandatory join is an ownership cleanup tail rather than
+  detached restart work.
 - A busy result is a completed, retryable business response. It is not
   `memory_restart_failed`, starts no background task, ends the UI spinner, and
   displays a localized reason.
@@ -237,16 +270,19 @@ The locked sequence is fixed:
 1. Validate store, artifact, and enabled state; recover an interrupted clear.
 2. Before touching the worker, call a non-awaiting, idempotent supervisor handoff
    fence on the old `EverOSProcess`. It sets `_desired_running=false`, marks ready
-   callbacks quiesced, and returns the exact `_restart_task`. It cancels that task
-   only when `_starting` proves it has not entered `_start_locked()`; an active
-   start is retained rather than unsafely cancelled. Both `_watch_child()` and
-   `_notify_ready()` honor the fence, so a child exit or already-starting
-   replacement cannot resume claims or create a worker during explicit handoff.
-3. Immediately pause new claims, then await the retained supervisor task under
-   the complete process-start bound. It may finish launching a transient child,
-   but the ready fence prevents callback activation and step 8 will stop that
-   child. If the task outlives the bound, retain it, keep claims fenced, and
-   return fail-closed without rotating the lease or touching process ownership.
+   callbacks quiesced, and captures the exact restart, watcher, and monitor task
+   references. It cancels a restart only when `_starting` proves it has not
+   entered `_start_locked()`; an active start is retained rather than unsafely
+   cancelled. A child exit cannot schedule another start after this fence.
+3. Immediately pause new claims. Await an active restart under the complete
+   process-start bound, then run the process handoff operation under the
+   process-owner settlement bound: cancel and join idle watcher/monitor tasks,
+   or retain and join the one already performing child cleanup. An active start
+   may finish launching a transient child, but generation-fenced activation
+   cannot resume claims and step 8 will stop it. If either retained start or
+   lifecycle owner outlives its bound, keep its exact references and claims
+   fenced, then return fail-closed without rotating the lease or invoking
+   `stop()` beside it. A retry rejoins those same tasks first.
 4. Allow at most five seconds for the current worker drain. Timeout or
    an ordinary drain error enters the forced phase; task cancellation enters
    the cancellation cleanup path.
@@ -261,12 +297,30 @@ The locked sequence is fixed:
    Restore `self._config` only after they pass.
 8. Stop the old process. Do not discard its supervisor or start another child
    until its process tree is confirmed reaped.
-9. Create a process from `_restart_config` and call `start()`. Make ready-callback
-   failure observable: `_notify_ready()` must propagate the callback exception
-   into `_start_locked()`'s existing failed-start cleanup instead of logging and
-   returning success. Restore claims and the worker only after `start()` and
-   `on_ready` succeed, then verify `_worker_task` exists and is not done before
-   returning `{ok: true, state: 'ready'}` synchronously.
+9. Create a process from `_restart_config` bound to the lifecycle generation
+   captured when restart entered its critical section. Its explicit initial
+   `start()` suppresses the automatic ready callback: while restart still owns
+   `_reconcile_lock -> module._lifecycle_lock`, runtime itself resumes claims,
+   starts the worker, and verifies `_worker_task` exists and is not done. An
+   activation exception runs bounded replacement cleanup, keeps claims fenced,
+   and cannot report ready. Return `{ok: true, state: 'ready'}` only after this
+   explicit activation succeeds.
+
+Automatic retries use a separate nonblocking ready notification. The callback
+captures process identity and lifecycle generation, schedules one retained
+runtime activation task, and returns without taking runtime locks, so it cannot
+deadlock `_start_locked()` with a caller already holding them. The activation
+task acquires `_reconcile_lock -> module._lifecycle_lock`, then verifies that the
+runtime is enabled, the process is still current and ready, the generation is
+unchanged, and no explicit restart or artifact installation owns admission.
+Every Clear, reconcile, artifact activation, restart, and close operation bumps
+the generation at its serialized lifecycle entry, before its first lifecycle
+await, and uses that value for any process it creates. Consequently an
+activation delayed behind later lifecycle work observes a stale token and exits
+without resuming claims or creating a worker. Current-generation activation
+failures set the visible runtime error and leave claims fenced; task completion
+is consumed and the task is retained/cancelled during later lifecycle cleanup
+rather than becoming an unobserved exception.
 
 `restart()` does not call `_probe_processing`. The conditional embedding/root
 guard protects persistent vector-space compatibility; it is not a processing
@@ -282,6 +336,11 @@ Every exit after claims are fenced must end in one of these states:
   worker and lease, and return `memory_restart_failed` without touching process
   ownership. A retry first rejoins the same task; it cannot continue while that
   task is live.
+- **A watcher or monitor owns cleanup beyond process handoff settlement:** retain
+  every captured task and the old supervisor, keep claims fenced, and return
+  `memory_restart_failed` without calling `stop()` concurrently or starting a
+  replacement. A retry rejoins the same owners under another bounded interval;
+  only after they finish may the distinct old-process stop retry begin.
 - **The old worker task outlives forced cancellation:** retain that exact task
   in `_worker_task`, retain the original lease, keep claims fenced, leave the
   old process untouched and its supervisor quiesced, set the visible runtime
@@ -295,9 +354,10 @@ Every exit after claims are fenced must end in one of these states:
   child is still running, reactivate with the new lease owner, resume claims and
   the worker, and return the specific failure. If the child exited during the
   handoff, keep claims fenced and let the re-armed supervisor start a child;
-  only its successful observable `on_ready` may resume the worker. This branch
-  applies only after the previous worker task is confirmed done; it never
-  attempts reactivation beside a retained task.
+  only a current-generation activation task may resume the worker after taking
+  both lifecycle locks. This branch applies only after the previous worker and
+  process-owner tasks are confirmed done; it never attempts reactivation beside
+  a retained task.
 - **`old_process.stop()` was invoked:** `EverOSProcess.stop()` sets
   `_desired_running=false` before termination and cancels scheduled restart.
   If stop raises, retain the supervisor reference but keep claims and the worker
@@ -306,12 +366,14 @@ Every exit after claims are fenced must end in one of these states:
   The user can retry the explicit restart, which first retries owned-tree stop.
 - **The old child stopped but replacement startup failed:** retain the new
   supervisor, if one was created, and keep claims and the worker fenced. If its
-  bounded supervisor later reaches `on_ready`, the existing callback resumes
-  them. With no supervisor, the user can click restart again.
-- **The replacement reaches health but `on_ready` fails:** treat this as startup
-  failure. The callback exception is visible to `_start_locked()`, which runs
-  the same bounded child cleanup and returns `False`; restart keeps claims
-  fenced and cannot report `ready`.
+  bounded supervisor later reaches ready, its generation-fenced activation task
+  may resume them only after coordinating with both lifecycle locks and proving
+  it is still current. With no supervisor, the user can click restart again.
+- **The replacement reaches health but explicit activation fails:** treat this
+  as startup failure. Restart directly observes the exception, runs the same
+  bounded child cleanup, keeps claims fenced, and cannot report `ready`. A later
+  automatic ready activation that fails records the visible runtime error and
+  likewise leaves claims fenced.
 
 `CancelledError` is re-raised after ownership and claims cleanup; it is never
 reported as a business failure. Fix `_stop_worker()` so it swallows only the
@@ -342,19 +404,23 @@ exceptions use the transport-only `memory_restart_failed`.
 ### Backend and transport
 
 1. `config/v2_config.py`, `vibe/api.py`, and every audited whole-file writer:
-   add the reentrant cross-process config write transaction, enter it before
-   load/merge, and enforce transaction ownership at `V2Config.save()`.
+   add the cross-process `mutate_v2_config()` API, make raw save private, bind
+   the working object to an opaque session token, and offload the complete
+   mutation from every asynchronous caller.
 2. `core/memory/runtime.py`: add `_restart_config`,
-   `_explicit_restart_active`, and fail-fast `restart()`; commit snapshots after
-   successful reconcile; retain worker tasks that outlive cancellation; reject
-   restart while artifact installation is active; make only restart-owned Clear
+   `_explicit_restart_active`, lifecycle generation and a retained ready
+   activation task, and fail-fast `restart()`; commit snapshots after successful
+   reconcile; retain worker tasks that outlive cancellation; reject restart
+   while artifact installation is active; make only restart-owned Clear
    contention fail fast.
 3. `core/memory/module.py`: extract locked clear recovery while retaining the
    wrapper and existing queued lifecycle-lock behavior for read/Clear paths.
 4. `core/memory/worker.py`: rotate the lease owner for replacement activation.
-5. `core/memory/process.py`: expose complete stop/start budget helpers, put one
-   cap around all orphan-reap rounds, add the explicit-handoff supervisor fence,
-   and propagate ready-callback failure into startup cleanup.
+5. `core/memory/process.py`: expose complete stop/start and process-owner
+   settlement budget helpers, put one cap around all orphan-reap rounds, add the
+   explicit-handoff supervisor fence, distinguish idle watcher/monitor tasks
+   from active cleanup owners with narrow phase flags, and support
+   callback-suppressed explicit start.
 6. `core/internal_server.py`: add `POST /internal/memory/restart`. Missing runtime
    returns `memory_runtime_missing`; unhandled exceptions map to
    `memory_restart_failed`, not `memory_reconcile_failed`.
@@ -411,43 +477,59 @@ exceptions use the transport-only `memory_restart_failed`.
     lease and fenced claims. No child/process action occurs; retry stays closed
     until the exact task terminates, then completes replacement normally.
   - If the old child exits during the five-second drain grace, its supervisor is
-    already quiesced: no automatic restart can invoke `on_ready`, resume claims,
-    or replace `_worker_task`. Pre-stop failure re-arms that supervisor and
-    resumes work only after a live/ready child is established.
+    already quiesced: no automatic restart can schedule ready activation, resume
+    claims, or replace `_worker_task`. Pre-stop failure re-arms that supervisor
+    and resumes work only after a live/ready child is established.
   - An automatic restart already inside `_start_locked()` is retained while
     claims are paused. It either settles within the complete start bound and its
     transient child is stopped, or restart returns fail-closed without lease or
     process mutation; retry rejoins the same task.
+  - An automatic retry reaches ready while Clear or reconcile owns the module
+    lifecycle lock. Its activation task waits, then observes the bumped
+    lifecycle generation and exits without resuming claims or replacing the
+    worker. The equivalent no-intervening-lifecycle case activates only after
+    taking both locks.
+  - The old watcher or safety monitor enters child-tree cleanup immediately
+    before restart. Handoff joins that exact owner under the process-owner bound
+    before calling `stop()`; timeout stays fail-closed, and the successful case
+    still has a separately budgeted complete stop retry.
   - Clear-marker recovery and replacement share one lifecycle critical section;
     recovery failure launches no child.
   - A startup snapshot with the embedding marker rejects existing vectors and
     settles an empty root before launch.
-  - Disabled, `start() is False`, factory exception, ready-callback exception,
-    failed-start cleanup, and stop exception cases assert error codes,
-    supervisor ownership, claims/worker fencing, and no double child. A callback
-    exception cannot report ready; a stop exception followed by child exit must
-    not auto-restart or report restored claims.
+  - Disabled, `start() is False`, factory exception, explicit activation
+    exception, automatic activation exception, failed-start cleanup, and stop
+    exception cases assert error codes, supervisor ownership, claims/worker
+    fencing, and no double child. An activation exception cannot report ready; a
+    stop exception followed by child exit must not auto-restart or report
+    restored claims.
   - Cancellation while stopping the worker and after a new child is spawned
     reaches the documented cleanup state and re-raises `CancelledError`.
 - `tests/test_internal_server.py`: success, missing runtime, and exception mapping.
 - `tests/test_internal_client.py` / `tests/test_internal_client_timeouts.py`:
   POST and busy response passthrough; deadline computed from both clear phases,
-  automatic-supervisor settlement, worker bounds, old stop, the outer all-round
-  orphan-reap cap, readiness, and failed-start cleanup. On reporting timeout or
-  caller cancellation, the retained request is joined before its caller can
-  release transaction ownership.
+  automatic-supervisor start settlement, watcher/monitor owner settlement,
+  worker bounds, a distinct old stop retry, the outer all-round orphan-reap cap,
+  readiness, and failed-start cleanup. On reporting timeout or caller
+  cancellation, the retained request is joined before its caller can release
+  transaction ownership.
 - `tests/test_ui_memory_routes.py`: new client path, internal unavailable,
   cross-origin rejection, restart/settings serialization, timed-out settlement
   ownership, and final C1 retention.
 - `tests/test_v2_config.py` / config route tests: a generic non-Memory save in a
   second process waits before loading while settlement owns the config
   transaction, then preserves both its C1 change and the cleared marker. Saving
-  without transaction ownership is rejected, and nested same-thread writes do
-  not deadlock.
+  without a valid session/object token is rejected; a stale C0 loaded before a
+  later transaction cannot be saved, and an accepted mutator observes the
+  intervening C1. Nested same-thread mutations share one fresh working object
+  and publish once without deadlock. While a second process holds the file lock,
+  representative async UI and controller writers wait off-thread and event-loop
+  probes continue to run.
 - `tests/test_memory_process.py`: stale recorded leader plus late helper and
   multiple unusable-record anchors share one outer reap deadline. Timeout keeps
-  the record and prevents child launch. Ready-callback failure is returned as a
-  failed start after bounded cleanup.
+  the record and prevents child launch. Idle watcher/monitor tasks cancel and
+  join during handoff; active cleanup owners are retained and settle under the
+  exported owner budget. Explicit start suppresses automatic ready notification.
 
 ### TypeScript
 
@@ -482,12 +564,14 @@ exceptions use the transport-only `memory_restart_failed`.
 
 The necessary complexity comes from existing safety and concurrency contracts:
 failed candidates cannot replace last-good config; marker settlement cannot
-race any whole-file V2 writer or outlive its transaction; explicit restart and
-destructive Clear cannot queue behind each other while ordinary reads retain
-their existing serialization; artifact installation excludes launch; orphan
-recovery has one complete cap; automatic supervision is quiesced before worker
-handoff; pending embeddings cannot bypass the root guard; claimed rows require a
-new lease only after the old worker exits; ready-callback success must be
+race any whole-file V2 writer, start from an unlocked baseline, block an async
+event loop, or outlive its transaction; explicit restart and destructive Clear
+cannot queue behind each other while ordinary reads retain their existing
+serialization; artifact installation excludes launch; orphan recovery has one
+complete cap; every active process lifecycle owner is settled and budgeted
+before stop; delayed automatic activation is fenced by lifecycle generation and
+both runtime locks; pending embeddings cannot bypass the root guard; claimed
+rows require a new lease only after the old worker exits; activation success is
 observable; and clear markers serialize with root/child lifecycle. The
 implementation adds one private snapshot, narrow helpers, and two precise
 transport-only error codes while reusing existing locks, guards, recovery SQL,
@@ -501,14 +585,16 @@ implementation appears to require one, revise this plan before expanding scope.
 
 - [ ] Runtime snapshot, pending-embedding guard, fail-fast restart, focused tests
 - [ ] Settings/restart serialization and stale-C0 overwrite regression
-- [ ] Config-wide transaction and concurrent non-Memory writer regression
+- [ ] Token-bound config mutation API and concurrent non-Memory writer regression
+- [ ] Async UI/controller config writers off-thread and event-loop responsiveness
 - [ ] Timed-out settlement ownership and retained-request regression
 - [ ] Worker lease rotation and add/flush recovery tests
 - [ ] Retained worker cancellation fail-closed state and retry
 - [ ] Locked clear recovery and race regression
 - [ ] Restart-specific Clear admission and artifact-install admission
-- [ ] Supervisor handoff fence and child-exit-during-drain regression
-- [ ] Complete orphan/start budgets, observable ready callback, failed-start cleanup
+- [ ] Supervisor handoff fence, lifecycle-owner settlement, and deadline contract
+- [ ] Lifecycle-generation ready activation and Clear/reconcile race regression
+- [ ] Complete orphan/start budgets, explicit activation, failed-start cleanup
 - [ ] Internal server/client, closed/busy errors, bounded timeout tests
 - [ ] UI route and response normalizer
 - [ ] Page-level action, deduplicated banner, runtime-missing render, toast/i18n

--- a/docs/plans/memory-sidecar-force-restart-button.md
+++ b/docs/plans/memory-sidecar-force-restart-button.md
@@ -1,6 +1,6 @@
-# Add a forced sidecar restart action to Memory settings (rev14)
+# Add a forced sidecar restart action to Memory settings (rev15)
 
-> Rev14 keeps one public recovery action and a focused set of internal fixes:
+> Rev15 keeps one public recovery action and a focused set of internal fixes:
 > replayable configuration, config-wide write serialization, restart-specific
 > and lifecycle-intent admission, generation-fenced ready activation, complete
 > supervisor quiescing, bounded orphan recovery, disk/live replay convergence,
@@ -8,7 +8,7 @@
 > locked clear-marker recovery, bounded readiness, supervisor callback rebinding,
 > authoritative controller/UI settings refresh, queued-operation exclusion, and
 > disabled/fail-closed replay handling, explicit worker activation, and retained
-> processing-probe ownership.
+> processing-probe/module-store ownership with cross-lifecycle admission.
 > Timed-out work remains owned until it is either joined or proven unable to
 > mutate state. It does not add a lifecycle coordinator, explicit state machine,
 > provider/store port, or frontend DOM test framework.
@@ -126,6 +126,19 @@ Add private `_restart_config` and `_persisted_memory_snapshot` values to
   and disk converge without mutating an object from the settlement thread. A
   failed reconcile returns no applied candidate and leaves controller config at
   its previous value.
+- Explicit restart keeps the exact config returned by its convergence
+  transaction as an applied candidate even if old-process stop, replacement
+  start, worker activation, or their cleanup later fails. Its internal result
+  includes that candidate plus `config_committed=true`; pre-convergence failures
+  and busy results return no candidate and `config_committed=false`.
+  Runtime converts every ordinary post-convergence orchestration exception into
+  this structured failure pair rather than letting internal-server exception
+  mapping discard the candidate. `CancelledError` still propagates after
+  ownership cleanup because there is no response consumer to refresh.
+  `Controller.restart_memory()` installs a deep copy of every non-null applied
+  candidate into `Controller.config.memory` before exposing only the transport
+  result. Thus disk, Runtime, and Controller remain authoritative independently
+  of the later lifecycle outcome.
 
 These snapshots answer which configuration an explicit restart replays and
 which exact Memory block it may conditionally replace on disk. They do not
@@ -287,6 +300,17 @@ an abandoned restart, and a user retry can enqueue a second one.
   held, return
   `{ok: false, error: 'memory_restart_busy'}` without changing the process,
   claims, or worker.
+- Add a narrow `_retained_ownership_active` gate to `MemoryRuntime`. Any worker,
+  worker/module store task, processing probe, supervisor start, watcher/monitor,
+  or process cleanup owner that outlives its bound sets this gate synchronously
+  before lifecycle locks or `_explicit_restart_active` can be released. Clear,
+  reconcile, artifact activation, search/profile and interrupted-clear recovery,
+  and automatic ready activation check it before their first await and reject
+  without entering lifecycle queues or mutating state. Pure status projection
+  may report the retained error but cannot run recovery. `close()` joins retained
+  ownership; only an explicit restart retry may enter the locked settlement path
+  while the gate is set. That retry clears the sticky gate atomically only after
+  every retained registry is empty and before normal replacement continues.
 - When both are free, acquire them in the established order in the same event
   loop turn, with no intervening await. After acquiring `_reconcile_lock`, check
   `_artifact_installing` while that lock is owned. If installation is active,
@@ -324,6 +348,13 @@ an abandoned restart, and a user retry can enqueue a second one.
 - Bound worker store-task settlement separately. Cancelling an asyncio drain
   owner does not stop a write-capable `asyncio.to_thread()` call, so worker-task
   completion alone is not proof that lease ownership is quiescent.
+- Give `MemoryModule._store_call()` the same explicit shielded-task registry and
+  bounded `settle_store_calls()` contract as the worker. Clear, interrupted-clear
+  recovery, and failure recording retain SQLite-writing threads after coroutine
+  timeout/cancellation. Their reporting timeout enters bounded settlement; if an
+  exact task still outlives that bound, retain it and set the cross-lifecycle gate
+  before releasing locks. Include module-store settlement as its own restart
+  deadline component.
 - Bound settlement of processing-probe trees separately. Cancelling the drain
   task can make it terminal while probe termination is still incomplete; every
   retained probe owner must prove its process tree reaped before lease rotation
@@ -361,16 +392,18 @@ an abandoned restart, and a user retry can enqueue a second one.
   cancellation joins and one complete TERM/KILL cleanup round. Set
   `MEMORY_RESTART_TIMEOUT_SECONDS` strictly above the sum of two clear cleanup
   bounds, automatic-supervisor start settlement, process-owner settlement,
-  worker grace, worker cancellation cleanup, worker store-task settlement,
-  processing-probe settlement, a separate old-process stop retry, and the
-  all-inclusive replacement-start budget. Add a worker-activation bound after
-  replacement health plus a distinct replacement-activation cleanup allowance
-  containing another worker cancellation, store-task settlement, probe
-  settlement, and complete TERM/KILL stop round. The contract test imports the
-  source constants/helpers instead of copying numbers from comments. A deadline
-  cannot release either transaction while a non-cancellable config/store write
-  or owned probe tree is still live; its mandatory join is an ownership cleanup
-  tail rather than detached restart work.
+  worker grace, worker cancellation cleanup, worker and module store-task
+  settlement, processing-probe settlement, a separate old-process stop retry,
+  and the all-inclusive replacement-start budget. Add a worker-activation bound
+  after replacement health plus a distinct replacement-activation cleanup
+  allowance containing a non-awaiting supervisor fence, captured automatic-start
+  and watcher/monitor settlement, another worker cancellation, worker/module
+  store-task settlement, probe settlement, and complete TERM/KILL stop round.
+  The contract test imports the source constants/helpers instead of copying
+  numbers from comments. A deadline cannot release either transaction while a
+  non-cancellable config/store write or owned probe/process tree is still live;
+  its mandatory join is an ownership cleanup tail rather than detached restart
+  work.
 - A busy result is a completed, retryable business response. It is not
   `memory_restart_failed`, starts no background task, ends the UI spinner, and
   displays a localized reason.
@@ -402,8 +435,11 @@ cannot emit an unobserved-future warning. `_ensure_worker()` accepts and reuses 
 prepared activation future, creating one only for ordinary callers, and returns
 the exact future associated with the worker task instead of using task existence
 or liveness as success evidence. Explicit restart and automatic ready activation
-keep claims paused, await their exact future under the worker activation bound,
-and resume claims only after it resolves successfully.
+keep claims paused and use
+`wait_for(shield(activation_future), WORKER_ACTIVATION_TIMEOUT_SECONDS)` so the
+reporting timeout cannot cancel the shared handshake. Only explicit cancellation
+and joining of the worker may reject that generation. Resume claims only after
+the exact future resolves successfully.
 
 Make `_store_call()` create an explicit task for `asyncio.to_thread()` and await
 it under `shield()`. Keep every unfinished task in a private worker registry;
@@ -444,10 +480,11 @@ The locked sequence is fixed:
    Do not clear `_worker_task` until the exact task is done. If it outlives the
    bound, retain the task reference, keep claims fenced, and enter the
    fail-closed state below; do not rotate the lease or touch the process.
-6. After the exact drain task is terminal, call `settle_store_calls()` under its
-   own bound. If any shielded store thread remains live, retain its registry
-   entry, the old lease, and every existing process reference; keep claims
-   fenced and return fail-closed. A retry rejoins the same store task before it
+6. After the exact drain task is terminal, call `settle_store_calls()` on both
+   `MemoryWorker` and `MemoryModule` under their distinct bounds. If any shielded
+   store thread remains live, retain its registry entry, the old lease, and every
+   existing process reference; set the retained-ownership gate, keep claims
+   fenced, and return fail-closed. A retry rejoins the same store task before it
    can proceed.
 7. Ask the old supervisor to settle every retained processing-probe tree under
    the probe-settlement bound. `processing_healthy()` registers the exact probe,
@@ -487,10 +524,13 @@ The locked sequence is fixed:
    `start()` suppresses the automatic ready callback. While restart still owns
    `_reconcile_lock -> module._lifecycle_lock`, keep claims paused, call
    `begin_replacement_activation()`, start the worker, and await that exact
-   activation-generation future under the worker-activation bound. Only after
-   it resolves may runtime resume claims. Rejection or timeout cancels and joins
-   the new worker, settles its store calls and processing probes, then stops the
-   replacement under the distinct replacement-activation cleanup allowance.
+   activation-generation future with the shielded worker-activation wait. Only
+   after it resolves may runtime resume claims. On rejection or timeout, apply
+   the replacement supervisor's non-awaiting handoff fence before the first
+   cleanup await, capture its restart/watcher/monitor owners, then cancel and
+   join the new worker, settle module/worker store calls and processing probes,
+   settle captured process owners, and stop the replacement under the distinct
+   replacement-activation cleanup allowance.
    Any cleanup owner that outlives its bound is retained fail-closed. Return
    `{ok: true, state: 'ready'}` only after real activation succeeds.
 
@@ -623,8 +663,9 @@ exceptions use the transport-only `memory_restart_failed`.
    caller.
 2. `core/memory/runtime.py`: add `_restart_config`,
    `_persisted_memory_snapshot`, `_explicit_restart_active`,
-   `_clear_pending_count`, `_reconcile_pending_count`, lifecycle generation and
-   a retained ready activation task, and fail-fast `restart()`; refresh the
+   `_clear_pending_count`, `_reconcile_pending_count`,
+   `_retained_ownership_active`, lifecycle generation and a retained ready
+   activation task, and fail-fast `restart()`; refresh the
    persisted snapshot after every successful runtime-owned V2 mutation and
    rebase a successfully reconciled
    live/replay candidate from marker settlement's exact return; conditionally
@@ -632,8 +673,9 @@ exceptions use the transport-only `memory_restart_failed`.
    generation and retain worker/store/probe owners that outlive cancellation;
    reject restart while artifact installation is active; make only explicit
    restart admission fail fast. Make `restart()` return its transport
-   result plus the exact applied replay config on ready/disabled success and no
-   config on busy/failure. Add `reconcile_persisted()` to return the exact
+   result plus the exact applied replay config whenever convergence committed,
+   including later lifecycle failure, and no config before convergence or on
+   busy. Add `reconcile_persisted()` to return the exact
    successful candidate alongside the transport result while ordinary
    `reconcile()` preserves its dict contract.
    `Controller.reconcile_memory()` installs that returned candidate into
@@ -642,7 +684,10 @@ exceptions use the transport-only `memory_restart_failed`.
 3. `core/memory/module.py`: extract locked clear recovery while retaining the
    wrapper and existing queued lifecycle-lock behavior for read/Clear paths. Add
    the synchronous lifecycle-intent scope and `lifecycle_busy` property covering
-   active and queued search, profile, Clear, and recovery operations.
+   active and queued search, profile, Clear, and recovery operations. Shield and
+   retain explicit module store tasks and expose their bounded settlement. A
+   narrow Runtime-supplied admission predicate prevents search/profile recovery
+   and Clear from entering while retained ownership is fenced.
 4. `core/memory/worker.py`: retain and shield explicit store-thread tasks, expose
    bounded settlement, make activation return a generation-specific completion
    future, and rotate the lease owner only after prior ownership registries are
@@ -656,11 +701,12 @@ exceptions use the transport-only `memory_restart_failed`.
    cleanup budget, rebind re-armed ready callbacks to the current generation,
    and support callback-suppressed explicit start.
 6. `core/controller.py` / `core/internal_server.py`: add a controller-owned
-   restart wrapper and `POST /internal/memory/restart`. On ready or disabled
-   success, install a deep copy of the exact applied config returned by Runtime
-   into `Controller.config.memory`, then expose only the transport response.
-   Missing runtime returns `memory_runtime_missing`; unhandled exceptions map to
-   `memory_restart_failed`, not `memory_reconcile_failed`.
+   restart wrapper and `POST /internal/memory/restart`. Whenever Runtime returns
+   an applied config, including a post-convergence failure, install a deep copy
+   into `Controller.config.memory`, then expose only the transport response with
+   its `config_committed` flag. Missing runtime returns
+   `memory_runtime_missing`; unhandled exceptions map to `memory_restart_failed`,
+   not `memory_reconcile_failed`.
 7. `vibe/internal_client.py`: add `memory_restart()` with a deadline above the
    complete restart lifecycle budget; retain and join the shielded request task
    after a reporting timeout.
@@ -676,26 +722,28 @@ exceptions use the transport-only `memory_restart_failed`.
 1. `memoryRead.ts`: define and export `MemoryRuntimeRestartResult` and a pure
    normalizer near the current Memory response classifier. Accept `{ok:true}`;
    normalize `{ok:false,error}` and `{status:'failed',error}` as failures; fail
-   closed on malformed bodies.
+   closed on malformed bodies, and preserve a strict boolean `config_committed`.
 2. `ApiContext.tsx`: import that type and normalizer. `restartMemoryRuntime()`
    returns only the normalized result and does not create a reverse import.
 3. `useMemoryResource.ts`: expose a narrow `invalidate()` transition that drops
-   the last accepted payload without changing sticky forbidden state. Restart
-   success uses it before the authoritative settings reload; existing resources
-   otherwise keep their current retry policy.
+   the last accepted payload without changing sticky forbidden state. Any restart
+   response with `config_committed=true` uses it before the authoritative
+   settings reload; existing resources otherwise keep their current retry policy.
 4. `SettingsMemoryPage.tsx`: when `settings?.enabled === true` and the page is not
    cross-origin forbidden, render a page-level Status action row before the
    `remoteUnavailable` / `memorySetupStage()` branch. Use the existing secondary
    `xs` button with `RotateCw` / `Loader2`; disable it while restarting. Runtime
    required, setup loading, and status loading/error states share this action.
-   Await the result. On success, invalidate the pre-restart Memory settings
-   payload, keep its form unavailable, and await an authoritative
-   `getMemorySettings()` reload before ending the restart state; a failed reload
-   must expose the settings read error without restoring an editable stale C1
-   payload. Refresh dependency/status state as well. Show completion copy only
-   after the settings reload settles successfully. On restart failure, keep the
-   existing settings payload and show a localized reason plus literal error code,
-   with a generic fallback when no code exists.
+   Await the result. When `config_committed=true`, including a later lifecycle
+   failure, invalidate the pre-restart Memory settings payload, keep its form
+   unavailable, and await an authoritative `getMemorySettings()` reload before
+   ending the restart state. A failed reload exposes the settings read error
+   without restoring an editable stale C1 payload. Refresh dependency/status
+   state as well. Show completion copy only after a successful operation and
+   settings reload. After a failed operation, show its localized reason plus
+   literal error code only after the required reload settles; when no config was
+   committed, keep the existing settings payload and use the generic fallback
+   when no code exists.
 5. `MemoryStatusPanel.tsx`: remove the old engine-fault restart action and its
    props so the normal Status body cannot render a duplicate. Keep the credential
    fault's settings action.
@@ -740,6 +788,12 @@ exceptions use the transport-only `memory_restart_failed`.
     While that Clear is queued, `_clear_pending_count` also makes restart return
     busy through the lock-release/waiter-wakeup gap. Concurrent Clear requests
     retain independent counts until their complete Clear/reconcile paths exit.
+  - Force each retained-owner class past its settlement bound and prove the
+    retained-ownership gate remains set after `_explicit_restart_active` clears.
+    Clear, search/profile recovery, persisted/internal reconcile, artifact
+    activation, and automatic ready activation must reject before their first
+    lifecycle await. An explicit restart retry may enter, joins the exact owners,
+    and clears the gate only after every registry is empty.
   - Hung add and flush cases use shortened bounds; add can be reclaimed by the
     new owner, while flush becomes `unknown` and opens the fault.
   - A worker task that ignores its first cancellation is retained with the old
@@ -755,6 +809,11 @@ exceptions use the transport-only `memory_restart_failed`.
     restart admission: the exact probe-tree record remains on the supervisor,
     claims and lease stay fenced, and no process replacement occurs. A retry
     reaps that same record before continuing.
+  - Timeout interrupted-clear recovery while `MemoryModule._store_call()` owns a
+    blocked `get_meta`, `begin_clear`, `finish_clear`, or failure-recording
+    thread. Cancellation leaves the exact task shielded and registered, keeps
+    lifecycle/retained admission owned until it returns, and prevents a late
+    marker or epoch write from crossing a later operation.
   - If the old child exits during the five-second drain grace, its supervisor is
     already quiesced: no automatic restart can schedule ready activation, resume
     claims, or replace `_worker_task`. Pre-stop failure beside an alive but
@@ -793,6 +852,18 @@ exceptions use the transport-only `memory_restart_failed`.
     and replacement worker/store/probe settlement plus a complete process stop
     fit the distinct cleanup allowance. A stop exception followed by child exit
     must not auto-restart or report restored claims.
+  - Let the healthy replacement exit immediately after activation failure. The
+    non-awaiting replacement fence runs before worker/store/probe cleanup, so no
+    watcher can schedule a new start; if a start/process owner already entered,
+    cleanup captures and settles it inside the advertised allowance.
+  - Delay the real activation generation beyond its reporting bound and prove
+    `wait_for(shield(future))` leaves the handshake pending. Only subsequent
+    worker cancellation rejects it, without `InvalidStateError` or loss of the
+    real activation outcome.
+  - After convergence commits C0, fail old stop, replacement start, and explicit
+    activation in separate cases. Each failure returns the exact applied C0 and
+    `config_committed=true`; `Controller.config.memory`, Runtime, and disk all
+    remain C0. Pre-convergence failure returns no candidate and false.
   - Cancellation while stopping the worker and after a new child is spawned
     reaches the documented cleanup state and re-raises `CancelledError`.
 - `tests/test_memory_slice3.py`: a successful persisted reconcile that settles
@@ -801,7 +872,8 @@ exceptions use the transport-only `memory_restart_failed`.
   `Controller.config.memory`. Disk, controller, runtime live state, and replay
   state must match; the original marker-bearing request object is not installed.
   Failure returns no candidate and preserves the prior controller config.
-- `tests/test_internal_server.py`: success, missing runtime, and exception mapping.
+- `tests/test_internal_server.py`: success, missing runtime, exception mapping,
+  and post-convergence failure propagation without serializing the config object.
 - `tests/test_internal_client.py` / `tests/test_internal_client_timeouts.py`:
   POST and busy response passthrough; deadline computed from both clear phases,
   automatic-supervisor start settlement, watcher/monitor owner settlement,
@@ -816,7 +888,8 @@ exceptions use the transport-only `memory_restart_failed`.
   Hold one settings writer and queue a second; through the owner's
   release/waiter-wakeup gap, the synchronous pending count makes restart return
   busy without acquiring the lock. After every writer exits, restart may acquire
-  admission normally.
+  admission normally. A `config_committed=true` failure invalidates C1 and reloads
+  C0 before showing the lifecycle error; a pre-convergence failure keeps C1.
 - `tests/test_v2_config.py` / config route tests: a generic non-Memory save in a
   second process waits before loading while settlement owns the config
   transaction, then preserves both its C1 change and the cleared marker. Saving
@@ -836,14 +909,20 @@ exceptions use the transport-only `memory_restart_failed`.
   reports quiescence only after the registry is empty. Activation generations
   resolve only after full recovery, reject with the real recovery error before
   retry creates a new generation, and reject on cancellation.
+- `tests/test_memory_module.py`: clear/recovery store calls use explicit shielded
+  tasks; timeout and caller cancellation retain each SQLite-writing task through
+  terminal result, and settlement reports quiescence only when the registry is
+  empty.
 - `tests/test_memory_process.py`: stale recorded leader plus late helper and
   multiple unusable-record anchors share one outer reap deadline. Timeout keeps
   the record and prevents child launch. Idle watcher/monitor tasks cancel and
   join during handoff; active cleanup owners are retained and settle under the
   exported owner budget. A cancelled processing probe whose termination fails
   retains its exact tree and cleanup owner; settlement retries that record and
-  reports quiescence only after reap. Explicit start suppresses automatic ready
-  notification.
+  reports quiescence only after reap. A replacement handoff fence applied before
+  activation cleanup prevents an exit from scheduling restart, while an already
+  active start is captured and settled. Explicit start suppresses automatic
+  ready notification.
   A socket that appears just before the readiness deadline with a stalled health
   response cannot extend `_wait_for_ready()` beyond its outer cap, and the
   separately budgeted failed-start cleanup still runs.
@@ -851,7 +930,7 @@ exceptions use the transport-only `memory_restart_failed`.
 ### TypeScript
 
 - Table-test the pure normalizer with `ok:true`, `ok:false`, `status:'failed'`,
-  and malformed responses.
+  strict `config_committed` values, and malformed responses.
 - Reuse React SSR / `renderToStaticMarkup`, without a new DOM framework. Inject
   enabled plus runtime-missing state into `SettingsMemoryPage` and assert that
   the setup prompt and exactly one restart action coexist. Also cover status
@@ -860,13 +939,14 @@ exceptions use the transport-only `memory_restart_failed`.
 - Extend the existing Memory resource/state tests with the restart-success
   transition: invalidate displayed C1, settle the authoritative settings reload
   with C0, and expose only C0 to the form. The reload-failure case keeps no
-  editable C1 payload. Keep click/toast behavior in the single manual scenario
-  below.
+  editable C1 payload. Add the equivalent `config_committed=true` failure
+  transition: reload C0 before displaying the lifecycle error. A false flag
+  preserves C1. Keep click/toast behavior in the single manual scenario below.
 
 ## Validation
 
 1. `pytest tests/test_memory_runtime.py -k restart`
-2. `pytest tests/test_memory_worker.py -k 'store or cancel or activation'`
+2. `pytest tests/test_memory_worker.py tests/test_memory_module.py -k 'store or cancel or activation or clear'`
 3. `pytest tests/test_internal_server.py tests/test_internal_client.py tests/test_internal_client_timeouts.py tests/test_ui_memory_routes.py tests/test_v2_config.py -k 'memory or config or restart'`
 4. Run `ruff check` on every changed Python file.
 5. In `ui/`, run the relevant normalizer, `SettingsMemoryPage`, and
@@ -901,11 +981,15 @@ request, has one hard cap; delayed automatic activation and re-armed supervision
 are bound to the current lifecycle generation and both runtime locks; pending
 embeddings cannot bypass the root guard or remain in a successful replay
 snapshot; claimed rows require a new lease only after the old worker and every
-shielded store thread exit; activation success is observable; UI settings reload
-from the converged disk block; and clear markers serialize with root/child
-lifecycle. The implementation adds two private snapshots, three narrow admission
-fields, focused helpers, and two precise transport-only error codes while reusing
-existing locks, guards, recovery SQL, supervision, and UI primitives.
+shielded worker/module store thread exit; activation success is observable and
+its shared future is shielded from reporting timeout; post-convergence failure
+still propagates the committed block to Controller and UI; retained ownership
+excludes every other mutating lifecycle; replacement cleanup fences supervision
+before awaiting; and clear markers serialize with root/child lifecycle. The
+implementation adds two private snapshots, focused intent counters, one narrow
+retained-owner gate, focused helpers, and two precise transport-only error codes
+while reusing existing locks, guards, recovery SQL, supervision, and UI
+primitives.
 
 Do not introduce a general coordinator, explicit restart state machine, new
 port, database field, automatic restart policy, or frontend test framework. If
@@ -923,13 +1007,15 @@ implementation appears to require one, revise this plan before expanding scope.
 - [ ] Worker lease rotation and add/flush recovery tests
 - [ ] Retained worker cancellation fail-closed state and retry
 - [ ] Shielded store-thread registry, bounded settlement, and retry
+- [ ] Module clear/recovery store-task retention and cross-lifecycle owner gate
 - [ ] Locked clear recovery and race regression
 - [ ] Restart/Clear intent admission, queued-Clear handoff, artifact admission
 - [ ] Queued read intent admission and waiter-handoff regression
 - [ ] Supervisor handoff/rebind, lifecycle-owner settlement, readiness/deadline contract
 - [ ] Lifecycle-generation ready activation and Clear/reconcile race regression
 - [ ] Complete orphan/start budgets, explicit activation, failed-start cleanup
+- [ ] Shielded activation handshake and fenced replacement-activation cleanup
 - [ ] Internal server/client, closed/busy errors, bounded timeout tests
 - [ ] UI route and response normalizer
-- [ ] Page action, deduplicated banner, settings invalidation/reload, toast/i18n
+- [ ] Page action, deduplicated banner, success/failure settings reload, toast/i18n
 - [ ] Focused Python/TypeScript validation and Incus `SIGSTOP` scenario

--- a/docs/plans/memory-sidecar-force-restart-button.md
+++ b/docs/plans/memory-sidecar-force-restart-button.md
@@ -1,12 +1,13 @@
-# Add a forced sidecar restart action to Memory settings (rev12)
+# Add a forced sidecar restart action to Memory settings (rev13)
 
-> Rev12 keeps one public recovery action and a focused set of internal fixes:
+> Rev13 keeps one public recovery action and a focused set of internal fixes:
 > replayable configuration, config-wide write serialization, restart-specific
 > and lifecycle-intent admission, generation-fenced ready activation, complete
 > supervisor quiescing, bounded orphan recovery, disk/live replay convergence,
 > marker-free replay promotion, store-thread settlement, worker lease rotation,
 > locked clear-marker recovery, bounded readiness, supervisor callback rebinding,
-> authoritative controller/UI settings refresh, and queued-read exclusion.
+> authoritative controller/UI settings refresh, queued-operation exclusion, and
+> disabled/fail-closed replay handling.
 > Timed-out work remains owned until it is either joined or proven unable to
 > mutate state. It does not add a lifecycle coordinator, explicit state machine,
 > provider/store port, or frontend DOM test framework.
@@ -159,8 +160,12 @@ itself, exclude a Memory PATCH or an unrelated `/api/config` save running in the
 UI process. Because every `V2Config.save()` replaces the complete JSON document,
 Memory-only serialization is insufficient.
 
-- Before calling `internal_client.memory_restart()`, the restart route checks
-  `_memory_settings_write_lock()`. If it is already held, return
+- Before calling `internal_client.memory_restart()`, the restart route checks a
+  synchronous `_memory_settings_write_pending_count` and
+  `_memory_settings_write_lock()`. Every Memory PATCH increments the counter
+  before its first await and decrements it in `finally` only after its complete
+  lock/save/reconcile/rollback path exits, so it covers the current owner and
+  every queued writer. If the count is nonzero or the lock is held, return
   `memory_restart_busy` immediately rather than joining its waiter queue.
 - If it is free, acquire it immediately and hold it across the complete internal
   restart request and response. Every Memory PATCH already holds this same lock
@@ -268,10 +273,17 @@ an abandoned restart, and a user retry can enqueue a second one.
   current owner and every queued operation, including the interval between clear
   recovery and a search/profile provider call. Nested locked helpers reuse the
   outer intent; no code reads private `asyncio.Lock` waiter state.
+- Add a synchronous `_reconcile_pending_count` to `MemoryRuntime`. Every
+  non-restart operation that can acquire `_reconcile_lock`, including persisted
+  and runtime-internal reconcile and artifact activation, increments it before
+  its first await and decrements it in `finally` only after its entire public
+  operation exits, including artifact installation's unlocked `ensure()`
+  interval. Nested locked helpers reuse the outer intent.
 - Before any await, `restart()` checks `_clear_pending_count`,
-  `module.lifecycle_busy`, `_reconcile_lock`, and `module._lifecycle_lock`. If a
-  complete Runtime Clear or any module lifecycle operation is active/queued, or
-  either lock is held, return
+  `_reconcile_pending_count`, `module.lifecycle_busy`, `_reconcile_lock`, and
+  `module._lifecycle_lock`. If a complete Runtime Clear, reconcile, artifact
+  activation, or module lifecycle operation is active/queued, or either lock is
+  held, return
   `{ok: false, error: 'memory_restart_busy'}` without changing the process,
   claims, or worker.
 - When both are free, acquire them in the established order in the same event
@@ -354,10 +366,10 @@ an abandoned restart, and a user retry can enqueue a second one.
   `memory_restart_failed`, starts no background task, ends the UI spinner, and
   displays a localized reason.
 
-No additional restart lock or queue is needed. The existing UI settings lock,
-config-wide write transaction, installer flag, restart-ownership boolean,
-Clear-intent counter, module lifecycle-intent counter, and controller/module
-lifecycle locks define single-flight ownership.
+No additional restart lock or queue is needed. The UI settings-writer intent
+counter and lock, config-wide write transaction, installer flag,
+restart-ownership boolean, Clear/reconcile/module lifecycle-intent counters, and
+controller/module lifecycle locks define single-flight ownership.
 
 ### 5. Forced replacement and lease handoff
 
@@ -382,7 +394,11 @@ finished.
 
 The locked sequence is fixed:
 
-1. Validate store, artifact, and enabled state; recover an interrupted clear.
+1. Snapshot the last-good `_restart_config` and recover an interrupted clear.
+   Validate store and artifact availability only when that replay is enabled.
+   Do not reject solely because the persisted candidate is enabled while the
+   replay is disabled; the replay state is authoritative after step 8
+   convergence and needs no launch prerequisites.
 2. Before touching the worker, call a non-awaiting, idempotent supervisor handoff
    fence on the old `EverOSProcess`. It sets `_desired_running=false`, marks ready
    callbacks quiesced, and captures the exact restart, watcher, and monitor task
@@ -423,9 +439,18 @@ The locked sequence is fixed:
    convergence succeeds. Ordinary persisted reconcile follows the same rule:
    settlement rebases its private in-flight candidate from the committed block,
    so successful live and `_restart_config` state cannot retain the old marker.
+   If the exact converged replay block is disabled, install that disabled block
+   into runtime state, proceed through bounded old-process stop, and record the
+   successful terminal state `{ok: true, state: 'disabled'}`. The controller
+   wrapper installs the same exact committed block into
+   `Controller.config.memory`, and the UI's mandatory success reload switches to
+   the authoritative disabled settings. A stop error remains fail-closed and
+   cannot report disabled success.
 9. Stop the old process. Do not discard its supervisor or start another child
    until its process tree is confirmed reaped.
-10. Create a process from `_restart_config` bound to the lifecycle generation
+10. If the converged replay is disabled, return the recorded disabled state
+   without creating a replacement child, activation task, or worker. Otherwise,
+   create a process from `_restart_config` bound to the lifecycle generation
    captured when restart entered its critical section. Its explicit initial
    `start()` suppresses the automatic ready callback: while restart still owns
    `_reconcile_lock -> module._lifecycle_lock`, runtime itself resumes claims,
@@ -484,17 +509,16 @@ Every exit after claims are fenced must end in one of these states:
   recovery, rotate the lease, or touch process ownership until the thread has
   returned and its terminal result has been consumed.
 - **Failure before `old_process.stop()` is invoked:** the old supervisor still
-  owns its child but is quiesced. While both runtime lifecycle locks remain
-  owned, re-arm supervision and replace its ready callback with one bound to the
-  current supervisor object and the lifecycle generation that owns this failure
-  recovery; when invoked, that callback captures the child identity that actually
-  reached ready. Never reuse the generation captured when the supervisor object
-  was originally created. If its child is still running, reactivate with the new
-  lease owner, resume claims and the worker, and return the specific failure. If
-  the child exited during the handoff, keep claims fenced and let the re-armed
-  supervisor start a child; only the newly bound current-generation activation
-  task may resume the worker after taking both lifecycle locks. This branch
-  applies only after the previous worker, store, and process-owner tasks are
+  owns its child but is quiesced. A live PID is not evidence that the UDS health
+  endpoint is ready, so never resume claims or the worker from `running` alone.
+  If it remains running, retain the quiesced supervisor, keep claims and the
+  worker fenced, and return the specific failure; a retry rejoins ownership and
+  attempts replacement again. Never reuse the supervisor's
+  construction-generation callback. If the child exited, it may be re-armed for
+  automatic start with a callback rebound to the current supervisor object and
+  lifecycle generation, but claims stay fenced until that newly bound activation
+  task takes both lifecycle locks and proves the replacement ready. This branch
+  applies only after all previous worker, store, and process-owner tasks are
   confirmed done; it never attempts reactivation beside a retained task.
 - **`old_process.stop()` was invoked:** `EverOSProcess.stop()` sets
   `_desired_running=false` before termination and cancels scheduled restart.
@@ -551,14 +575,17 @@ exceptions use the transport-only `memory_restart_failed`.
    caller.
 2. `core/memory/runtime.py`: add `_restart_config`,
    `_persisted_memory_snapshot`, `_explicit_restart_active`,
-   `_clear_pending_count`, lifecycle generation and a retained ready activation
-   task, and fail-fast `restart()`; refresh the persisted snapshot after every
-   successful runtime-owned V2 mutation and rebase a successfully reconciled
+   `_clear_pending_count`, `_reconcile_pending_count`, lifecycle generation and
+   a retained ready activation task, and fail-fast `restart()`; refresh the
+   persisted snapshot after every successful runtime-owned V2 mutation and
+   rebase a successfully reconciled
    live/replay candidate from marker settlement's exact return; conditionally
    converge disk to replay before launch; retain worker/store tasks that outlive
    cancellation; reject restart while artifact installation is active; make only
-   explicit restart admission fail fast. Add `reconcile_persisted()` to return
-   the exact successful candidate alongside the transport result while ordinary
+   explicit restart admission fail fast. Make `restart()` return its transport
+   result plus the exact applied replay config on ready/disabled success and no
+   config on busy/failure. Add `reconcile_persisted()` to return the exact
+   successful candidate alongside the transport result while ordinary
    `reconcile()` preserves its dict contract.
    `Controller.reconcile_memory()` installs that returned candidate into
    `Controller.config.memory`; post-Clear and artifact-internal reconciles cannot
@@ -576,15 +603,19 @@ exceptions use the transport-only `memory_restart_failed`.
    from active cleanup owners with narrow phase flags, hard-cap the complete
    readiness operation, rebind re-armed ready callbacks to the current
    generation, and support callback-suppressed explicit start.
-6. `core/internal_server.py`: add `POST /internal/memory/restart`. Missing runtime
-   returns `memory_runtime_missing`; unhandled exceptions map to
+6. `core/controller.py` / `core/internal_server.py`: add a controller-owned
+   restart wrapper and `POST /internal/memory/restart`. On ready or disabled
+   success, install a deep copy of the exact applied config returned by Runtime
+   into `Controller.config.memory`, then expose only the transport response.
+   Missing runtime returns `memory_runtime_missing`; unhandled exceptions map to
    `memory_restart_failed`, not `memory_reconcile_failed`.
 7. `vibe/internal_client.py`: add `memory_restart()` with a deadline above the
    complete restart lifecycle budget; retain and join the shielded request task
    after a reporting timeout.
 8. `vibe/ui_memory_routes.py`: keep `/api/memory/runtime/restart`, acquire the
-   Memory settings write lock across the internal call, and preserve same-origin
-   validation.
+   Memory settings write lock across the internal call, use a synchronous
+   pending-writer count to reject restart behind active or queued settings
+   saves, and preserve same-origin validation.
 9. `core/memory/types.py` and frontend `errors` translations: add transport-only
    `memory_restart_failed` and `memory_restart_busy`; add no SQLite schema field.
 
@@ -630,8 +661,11 @@ exceptions use the transport-only `memory_restart_failed`.
     the uncontended operation remains inside both lifecycle locks and
     conditionally replaces the expected persisted C1 Memory block with C0 while
     preserving unrelated fields. A fresh disk load must equal the live runtime;
-    an unexpected Memory C2 fails before process mutation. A post-Clear internal
-    reconcile cannot overwrite the persisted snapshot contract.
+    an unexpected Memory C2 fails before process mutation. If C0 is disabled,
+    convergence stops any retained old child without invoking the process
+    factory, start, activation, or worker; Runtime, Controller, disk, and the UI
+    reload all observe disabled. A post-Clear internal reconcile cannot
+    overwrite the persisted snapshot contract.
   - Pre-held reconcile/module locks and concurrent restart calls immediately
     return `memory_restart_busy`, create no waiters, and change no ownership.
     An installer paused inside unlocked `ensure(force=True)` also returns busy
@@ -640,6 +674,10 @@ exceptions use the transport-only `memory_restart_failed`.
     the owner's release/waiter-wakeup gap, `lifecycle_busy` remains true and
     restart returns busy without joining the read queue. After both reads finish,
     restart can acquire admission normally.
+    Hold one reconcile owner and queue a second non-restart reconcile; across
+    the owner's release/waiter-wakeup gap, `_reconcile_pending_count` remains
+    nonzero and restart returns busy without joining the queue. Each intent is
+    released on success, failure, and cancellation.
   - Clear started while `_explicit_restart_active` is true returns before
     `begin_clear()` and leaves no waiter or durable marker; the inverse ordering
     makes restart return busy. A search/profile call holding the same module lock
@@ -659,9 +697,11 @@ exceptions use the transport-only `memory_restart_failed`.
     and recovers.
   - If the old child exits during the five-second drain grace, its supervisor is
     already quiesced: no automatic restart can schedule ready activation, resume
-    claims, or replace `_worker_task`. Pre-stop failure re-arms that supervisor
-    with a callback bound to the current lifecycle generation and resumes work
-    only after a live/ready child is established; the callback from the
+    claims, or replace `_worker_task`. Pre-stop failure beside an alive but
+    unhealthy child retains the quiesced supervisor and keeps claims and the
+    worker fenced; `.running` alone never reactivates it. A child that exited may
+    re-arm with a callback bound to the current lifecycle generation and resume
+    work only after a replacement proves ready; the callback from the
     supervisor's construction generation is never reused.
   - An automatic restart already inside `_start_locked()` is retained while
     claims are paused. It either settles within the complete start bound and its
@@ -710,6 +750,10 @@ exceptions use the transport-only `memory_restart_failed`.
 - `tests/test_ui_memory_routes.py`: new client path, internal unavailable,
   cross-origin rejection, restart/settings serialization, timed-out settlement
   ownership, unrelated-field retention, and failed-Memory-C1 convergence to C0.
+  Hold one settings writer and queue a second; through the owner's
+  release/waiter-wakeup gap, the synchronous pending count makes restart return
+  busy without acquiring the lock. After every writer exits, restart may acquire
+  admission normally.
 - `tests/test_v2_config.py` / config route tests: a generic non-Memory save in a
   second process waits before loading while settlement owns the config
   transaction, then preserves both its C1 change and the cleared marker. Saving

--- a/docs/plans/memory-sidecar-force-restart-button.md
+++ b/docs/plans/memory-sidecar-force-restart-button.md
@@ -1,0 +1,161 @@
+# Memory 设置页增加 sidecar 强制重启按钮（rev3）
+
+> rev3 根据整体 review 收敛为一个公开入口和三个很小的内部修正：重启配置快照、
+> worker lease 轮换、clear marker 的锁内恢复。不新增 lifecycle coordinator、状态机、
+> provider/store port 或前端 DOM 测试框架。
+
+## 背景与目标
+
+当 Memory 状态为 `down` / `memory_sidecar_unavailable` 时，Web UI 没有恢复入口：当前重启按钮只出现在 `processing_fault_kind === 'engine'` 的横幅中。与此同时，`EverOSProcess` 只会在子进程退出或启动失败后自动拉起；“进程仍存活但 UDS/health 不可达”不会自动替换进程。
+
+本需求只做两件事：
+
+1. Memory 已启用时，在 Status 标题区始终提供“重启引擎”按钮。
+2. 点击后由 controller 强制停止旧 sidecar 并等待新 sidecar `ready`，不重启 Avibe 主进程、不重装 runtime、不从磁盘重新选择 restart 目标配置，也不做 processing 预探测。若启动快照仍带 durable embedding-change marker，则必须先完成既有 root 兼容性检查，并允许 settlement 为核对/清除 marker 读取持久化配置。
+
+非目标：自动健康重启、重做全部 Memory lifecycle、改变 provider/store 协议、重试历史 `unknown` flush、四平台全量回归。
+
+## 为什么不能继续复用 reconcile
+
+- Settings PATCH 与旧 restart 路径分别加载配置，存在 C0/C1 交错，可能把磁盘和 live 配置拆开。
+- reconcile 会先等待最长 30 秒的 worker drain，再做 processing probe；长 flush 最长 300 秒，因此它既不满足“5 秒后强制”的产品语义，也可能因无关的 probe 故障拒绝重启。
+- `self._config` 不是可靠的“最后成功配置”：enabled reconcile 会在 root 校验和新进程启动完成前写入候选；候选及 UI rollback 都失败后，它可能仍指向失败的 C1。
+
+因此保留现有 UI 路径 `/api/memory/runtime/restart`，但后端改走专用的 `MemoryRuntime.restart()`。
+
+```text
+UI
+  -> POST /api/memory/runtime/restart
+  -> internal_client.memory_restart()
+  -> POST /internal/memory/restart
+  -> MemoryRuntime.restart()
+```
+
+## 最小后端设计
+
+### 1. 可重放配置快照
+
+在 `MemoryRuntime` 增加私有 `_restart_config`：
+
+- 初始化为启动时 `MemoryConfig` 的深拷贝，使首次启动失败后仍可人工重试同一份配置。
+- 只在 enabled 或 disabled reconcile **成功结束**时，在 `_reconcile_lock` 内更新为深拷贝。
+- 失败候选不能更新它。之所以必须深拷贝，是因为 `MemoryConfig` 及其嵌套配置可变，`embedding_change_pending` 也会在运行时被修改。
+- `restart()` 在 `_reconcile_lock` 内读取其深拷贝，并在 safety guard 通过后、替换进程前同步恢复 `self._config`；这样 worker 的 `enabled` callback 和新 child settings 都不会继续使用失败候选。
+- 启动时的初始快照可能带 `embedding_change_pending=true`。restart 必须复用 reconcile 的 embedding/root safety guard，并只在 guard 成功且 marker settlement 成功后继续；有旧向量数据或 root 状态不可判定时返回 `memory_clear_failed`，不得强行启动。settlement 核对持久化配置仍与快照相同后，将磁盘、`_restart_config` 和随后恢复的 `self._config` 三处 marker 同步为 `false`，不改变其他配置；这里不运行 processing probe。
+
+这个字段只回答“人工 restart 应重放哪份配置”，不重新定义现有 `_config`，也不引入配置版本模型。
+
+### 2. clear marker 与进程替换原子化
+
+现有 `_recover_interrupted_clear()` 在取得 module lifecycle lock 前检查 `_clear_active`。并发 clear 若在这个间隙失败并留下 durable marker，restart/reconcile 可能随后启动 child 而不再检查 marker。
+
+最小修正：
+
+- 从现有方法抽出 `_recover_interrupted_clear_locked()`；调用方必须已持有 `module._lifecycle_lock`，方法内部再按现有顺序取得 root lifecycle lock 并重新读取 durable marker。
+- 原 `_recover_interrupted_clear()` 保留为 wrapper，供 search/profile/status 等调用；它继续保留 active clear 时的快速返回，维持 read 路径现有的立即失败/`clearing` 行为。
+- `reconcile()`、artifact activation 和新 `restart()` 都按 `_reconcile_lock -> module._lifecycle_lock -> root lifecycle lock` 的既有顺序，在同一 lifecycle 临界区内完成 marker 恢复和 child replacement。
+- 新的 locked helper 自身不做 `_clear_active` 快速返回；持有 lifecycle lock 时不会与 active clear 并行，因此必须重新读取并处理 durable marker。
+
+这只是消除现有 check/use 窗口，不新建通用 lifecycle coordinator。
+
+### 3. 强制替换与 lease 交接
+
+`MemoryWorker._boot_id` 当前在对象创建后不变，而 `recover_after_boot()` 只回收“其他 lease owner”的 `processing` 行。若 restart cancel 了已经 claim add 的同一个 worker，再用原 owner 激活，该行会永久停在 `processing`。
+
+给 `MemoryWorker` 增加一个私有语义的 helper，例如 `begin_replacement_activation()`：生成新的 UUID lease owner，然后复用现有 `begin_activation()`。MemoryStore 和 recovery SQL 不改。
+
+锁内执行顺序固定为：
+
+1. 校验 store、artifact、enabled 状态，并完成 interrupted-clear recovery。
+2. `pause_claims()`，给当前 drain 最多 5 秒优雅结束；超时或普通 drain 错误只记录并进入强制阶段，不作为失败返回。仅 task cancellation 进入下面定义的取消清理。
+3. cancel 并等待旧 worker task 结束。
+4. 轮换 lease owner。该动作必须发生在旧 task 结束之后、任何新 worker activation 之前。
+5. 仅当快照带 `embedding_change_pending` 时，在 claims 已 fence、旧 worker 已停止的状态下执行既有 embedding/root guard 和 marker settlement；通过后才恢复 `self._config`。
+6. 停止旧 process；只有 `stop()` 成功后才能丢弃旧 supervisor，禁止在旧进程未确认回收时启动第二个 child。
+7. 用 `_restart_config` 创建并启动新 process。`start()` / `on_ready` 成功后再恢复 claims 和 worker；同步返回 `{ok: true, state: 'ready'}`。
+
+`restart()` 不调用 `_probe_processing`。条件性的 embedding/root guard 是防止混用向量空间的持久化安全约束，不是 processing 健康预探测；其余真实 processing 故障继续由 worker 的既有分类路径报告。
+
+### 4. 失败后置条件
+
+claims 被 fence 后的每条退出路径必须明确恢复到以下二者之一：
+
+- **旧 child 仍由原 supervisor 持有且 `running`**：保留该 supervisor，使用新 lease owner 重新 activation，恢复 claims/worker，返回 `memory_restart_failed`。系统退回重启前状态，且不会出现双 child。
+- **旧 child 已停或新 child 启动失败**：保留新 supervisor（如果 factory/start 已创建）；claims 和 worker 保持暂停，设置可见 runtime error。若 supervisor 后续 supervised `on_ready`，它会按既有路径恢复 claims/worker；没有 supervisor 时，用户可再次点击 restart。
+
+`CancelledError` 在完成所有权和 claims 清理后继续抛出，不伪装成业务失败。为此要修正现有 `_stop_worker()`：只吞掉被 cancel 的 drain task 所产生的 `CancelledError`；若当前 lifecycle task 自身处于 cancelling 状态则继续抛出。restart 在 orchestration 边界以 shielded cleanup 收敛到上面的单-child/claims 后置条件，再重新抛出取消。若取消发生在新 `start()` 已创建 child、但 watcher/monitor 尚未建立的窗口，cleanup 必须 shield `new_process.stop()`：回收成功才置 `_process=None`，回收失败则保留 supervisor 引用并继续 fence claims，绝不遗留无所有权引用的 child。
+
+`start()` 正常返回 `False` 时沿用更具体的 `memory_sidecar_unavailable`；stop、factory 或其他 restart orchestration 异常使用新的 transport-only `memory_restart_failed`。
+
+### 5. 队列语义
+
+- cancel 发生在 add 已 claim 之后：新 lease owner 的 activation 会把旧 owner 的行退回 `pending`，按既有 at-least-once 语义重投。若 provider 在取消前已接收但本地未观察到 ack，可能产生重复副作用；强制重启不能承诺 exactly-once。
+- cancel 发生在 flush `in_flight`：activation 会把它永久标记为 `unknown` 并打开 processing fault。历史 `unknown` 不会在 5 分钟后自动重试或消失；以后新的 pending work 成功 flush 可以关闭 fault，但不会改写该历史记录。
+
+## 接口与 UI 改动
+
+### 后端与 transport
+
+1. `core/memory/runtime.py`：增加 `_restart_config` 和 `restart()`；成功 reconcile 提交快照；修正 `_stop_worker()` 对调用方取消的识别。
+2. `core/memory/module.py`：抽出锁内 clear recovery helper；现有 wrapper 继续服务其他调用方。
+3. `core/memory/worker.py`：增加 replacement activation 时的 lease owner 轮换。
+4. `core/internal_server.py`：增加 `POST /internal/memory/restart`。runtime 缺失返回 `memory_runtime_missing`；未处理异常映射为 `memory_restart_failed`，不能复用语义错误的 `memory_reconcile_failed`。
+5. `vibe/internal_client.py`：增加 `memory_restart()` 和独立 timeout。timeout 必须大于 `5s grace + process stop bound + process startup bound`。
+6. `vibe/ui_memory_routes.py`：现有 `/api/memory/runtime/restart` 改调 `memory_restart()`，保持同源校验和外部路径不变。
+7. `core/memory/types.py` 与前端 en/zh `errors`：加入 transport-only `memory_restart_failed`；不加入 SQLite 持久化 schema。
+
+### 前端
+
+1. `memoryRead.ts`：在现有 Memory response classifier 附近定义并导出 `MemoryRuntimeRestartResult` 及纯函数 normalizer。接受 `{ok:true}`；把 `{ok:false,error}` 和 `{status:'failed',error}` 统一为失败；malformed body 也必须 fail closed。
+2. `ApiContext.tsx`：导入该类型和 normalizer，`restartMemoryRuntime()` 只返回归一化结果，避免反向 import 形成循环依赖。
+3. `MemoryStatusPanel.tsx`：Status 标题右侧常驻 secondary `xs` 重启按钮，使用 `RotateCw` / `Loader2`；`restarting` 时 disabled。动作区放在依赖 `status` 的 body 分支之外，因此首次 status 尚在 loading 或请求失败时也不会消失。engine fault 横幅删除重复按钮，credential fault 的“打开设置”保持不变。
+4. `SettingsMemoryPage.tsx`：请求同步等待结果。成功 toast 使用完成式文案；失败 toast 显示本地化原因和字面 error code，无 code 时显示通用失败。
+5. `en.json` / `zh.json`：同步增加按钮、完成、失败、`memory_restart_failed` 文案，删除不再使用的 engine 横幅 action 文案。
+
+## 最小充分测试
+
+### Python
+
+- `tests/test_memory_runtime.py`
+  - 成功 restart：旧 process 确认 stop，新 process 启动并 ready，worker 恢复。
+  - C1 reconcile 失败且 rollback 也失败后，restart 重放最后成功的 C0；并发 restart/reconcile 由 `_reconcile_lock` 串行，终态使用最后成功配置。
+  - 分别挂起 add 和 flush，使用缩短的 grace 验证有界完成；add 可由新 owner 再 claim，flush 变 `unknown` 并打开 fault。
+  - durable clear marker 恢复与 replacement 位于同一 lifecycle 临界区；恢复失败不启动 child。
+  - 初始 `_restart_config.embedding_change_pending=true` 时：有旧向量数据必须拒绝启动；空 root 完成 marker settlement 后才允许启动。
+  - disabled 不 spawn；`start() is False`、factory exception、stop exception 分别验证错误码、`_process`/claims/worker 后置条件和无双 child。
+  - lifecycle task 分别在 worker 停止期间、以及 new `start()` 已创建 child 后被 cancel：完成最小 cleanup，验证 child 被回收或仍由唯一 supervisor 持有、claims 后置条件正确，并重新抛出 `CancelledError`。
+- `tests/test_internal_server.py`：成功透传、runtime missing、未处理异常映射。
+- `tests/test_internal_client.py` / `tests/test_internal_client_timeouts.py`：POST 路径、响应透传、timeout 覆盖完整有界预算。
+- `tests/test_ui_memory_routes.py`：切到新 client、internal unavailable、既有 cross-origin 拒绝。
+
+### TypeScript
+
+- 给纯 normalizer 做表驱动测试：`ok:true`、`ok:false`、`status:'failed'`、malformed。
+- 沿用 `renderToStaticMarkup` 的 `MemoryStatusPanel` 测试：down/no-fault 也有按钮，`status=null` 的 loading/error 状态仍有按钮，restarting 时 disabled，engine fault 全页只有一个重启入口，credential action 仍存在。
+- 不为 click/toast 新引入 DOM 测试框架；由下面的单一手工场景覆盖。
+
+## 验证
+
+1. `pytest tests/test_memory_runtime.py -k restart`
+2. `pytest tests/test_internal_server.py tests/test_internal_client.py tests/test_internal_client_timeouts.py tests/test_ui_memory_routes.py -k 'memory and restart'`
+3. `ruff check` 所有改动的 Python 文件。
+4. `cd ui && npx vitest run` 相关 normalizer / `MemoryStatusPanel` 测试，然后 `npm run build`。
+5. 只使用本地 Incus `master` 回归环境：先运行 `./scripts/run_regression.sh` 更新代码和检查服务健康，不重置配置。
+6. 通过 `python3 scripts/incus_regression.py shell --target master` 在容器内确认受管 sidecar PID 后发送 `SIGSTOP`，制造“进程存活但不可达”；在 Web UI 确认状态 down、按钮常驻、spinner/toast 正确，并验证点击后 PID 被替换且状态恢复 ready。若 replacement 未完成，清理时对原 PID 发送 `SIGCONT`。
+7. 再用 runner 检查 Avibe service health。不要重启本机 `vibe`，也不要用 `kill -9`（它只覆盖已有的 child-exit supervision，不是本需求场景）。
+
+## 整体 review 结论
+
+方案的必要复杂度来自四个已有安全/并发契约：成功配置不能被失败候选覆盖、pending embedding 不能绕过 root guard、已 claim 行必须换 lease 才能恢复、clear marker 必须与 root/child lifecycle 串行。实现只增加一个私有快照、两个窄 helper 和一个准确的错误码，并复用现有 lock、guard、recovery SQL、supervisor 和 UI primitives。
+
+本方案明确不引入通用 coordinator、显式 restart 状态机、新 port、新数据库字段、自动重启策略或新前端测试框架。实现中若需要这些内容，应先回到本计划重新论证，而不是顺手扩 scope。
+
+## Todo
+
+- [ ] runtime snapshot + pending-embedding guard + force restart + focused tests
+- [ ] worker lease rotation + add/flush recovery tests
+- [ ] locked clear recovery + race regression test
+- [ ] internal server/client + closed error + timeout tests
+- [ ] UI route + response normalizer
+- [ ] status button + deduplicated banner + toast/i18n
+- [ ] focused Python/TypeScript validation + Incus `SIGSTOP` scenario

--- a/docs/plans/memory-sidecar-force-restart-button.md
+++ b/docs/plans/memory-sidecar-force-restart-button.md
@@ -1,12 +1,13 @@
-# Add a forced sidecar restart action to Memory settings (rev8)
+# Add a forced sidecar restart action to Memory settings (rev9)
 
-> Rev8 keeps one public recovery action and a focused set of internal fixes:
+> Rev9 keeps one public recovery action and a focused set of internal fixes:
 > replayable configuration, config-wide write serialization, restart-specific
 > lifecycle admission, generation-fenced ready activation, complete supervisor
-> quiescing, bounded orphan recovery, worker lease rotation, and locked
-> clear-marker recovery. Timed-out work remains owned until it is either joined
-> or proven unable to mutate state. It does not add a lifecycle coordinator,
-> explicit state machine, provider/store port, or frontend DOM test framework.
+> quiescing, bounded orphan recovery, disk/live replay convergence, store-thread
+> settlement, worker lease rotation, and locked clear-marker recovery. Timed-out
+> work remains owned until it is either joined or proven unable to mutate state.
+> It does not add a lifecycle coordinator, explicit state machine,
+> provider/store port, or frontend DOM test framework.
 
 ## Background and goals
 
@@ -57,28 +58,49 @@ UI
 
 ### 1. Replayable configuration snapshot
 
-Add a private `_restart_config` to `MemoryRuntime`:
+Add private `_restart_config` and `_persisted_memory_snapshot` values to
+`MemoryRuntime`:
 
-- Initialize it as a deep copy of the startup `MemoryConfig`, so a first-start
-  failure can still be retried with the same configuration.
-- Update it with another deep copy only when enabled or disabled reconcile has
-  completed successfully, while `_reconcile_lock` is held.
+- Initialize `_restart_config` as a deep copy of the startup `MemoryConfig`, so
+  a first-start failure can still be retried with the same configuration.
+- Update `_restart_config` with another deep copy only when enabled or disabled
+  reconcile has completed successfully, while `_reconcile_lock` is held.
+- Initialize `_persisted_memory_snapshot` from the startup config. At the start
+  of `Controller.reconcile_memory()`, pass an explicit `persisted=True` contract
+  into `MemoryRuntime.reconcile()`: that controller entry point hot-applies a
+  freshly loaded, successfully saved V2 config. After acquiring
+  `_reconcile_lock`, a persisted reconcile replaces the snapshot with a deep
+  copy of its candidate before live application, so the complete expected disk
+  block is retained even if reconciliation later fails. Runtime-internal calls
+  such as post-Clear reconcile use the default `persisted=False`; artifact
+  activation uses `_reconcile_locked()`. Neither may claim a new disk snapshot.
 - Never commit a failed candidate. A deep copy is required because
   `MemoryConfig`, its nested settings, and `embedding_change_pending` are
   mutable.
 - `restart()` reads a deep copy while holding `_reconcile_lock`. After all
   safety checks pass and before process replacement, it restores `self._config`
   from that copy so worker callbacks and child settings cannot keep using C1.
+- Before replacing the process, restart always runs one config transaction that
+  freshly loads V2, requires its complete Memory block to equal
+  `_persisted_memory_snapshot`, and conditionally replaces only that Memory
+  block with `_restart_config`. Thus a failed persisted C1 converges to replayed
+  C0 while unrelated platform/runtime fields from later generic saves remain
+  intact. If disk already equals C0, the operation is an idempotent no-op. Any
+  other Memory block is an unknown/newer writer; fail closed without launching a
+  child rather than overwrite it. After commit, update
+  `_persisted_memory_snapshot` to the exact replay block.
 - A startup snapshot may have `embedding_change_pending=true`. Restart reuses
   the reconcile embedding/root guard and proceeds only after both the guard and
-  marker settlement succeed. Existing vectors or an indeterminate root return
-  `memory_clear_failed` without launching a child. Successful settlement clears
-  the marker in persisted config, `_restart_config`, and the later restored
+  the same disk-convergence transaction succeed. Existing vectors or an
+  indeterminate root return `memory_clear_failed` without launching a child.
+  Successful convergence clears the marker in persisted config,
+  `_restart_config`, `_persisted_memory_snapshot`, and the later restored
   `self._config`, without changing any other Memory field. It does not run the
   processing probe.
 
-This field answers only which configuration an explicit restart replays. It
-does not redefine `_config` or introduce configuration versioning.
+These snapshots answer which configuration an explicit restart replays and
+which exact Memory block it may conditionally replace on disk. They do not
+redefine `_config` or introduce general configuration versioning.
 
 ### 2. Clear-marker and replacement atomicity
 
@@ -118,15 +140,20 @@ Memory-only serialization is insufficient.
   across load, save, controller reconcile, and rollback, so a PATCH cannot write
   C1 between the controller's C0 comparison and marker-clear save.
 - Add one synchronous `mutate_v2_config(mutator, *, initializer=None)` write API
-  in `config/v2_config.py`. Its outermost call acquires `CONFIG_LOCK` and then a
-  config-specific cross-process file lock, using the existing
+  in `config/v2_config.py`. Its outermost call first acquires a config-specific
+  cross-process file lock, using the existing
   `storage.lock.MigrationFileLock` primitive with a dedicated lock path and
-  bounded acquisition. Only after both locks are owned does it load the current
-  document, invoke a synchronous mutator on that fresh working object, validate
-  it, and atomically save it before releasing either lock. It never accepts a
-  caller-supplied or preloaded `V2Config` instance. First-install/default paths
-  may supply an initializer factory, which is also invoked only under both locks
-  when the document is absent.
+  bounded acquisition, without owning `CONFIG_LOCK`. Only after the file lock is
+  held does it acquire `CONFIG_LOCK`, load the current document, invoke a
+  synchronous mutator on that fresh working object, validate it, and atomically
+  save it before releasing both locks. This fixed file-lock-then-`CONFIG_LOCK`
+  order applies to every writer; migrate any caller that currently enters
+  `CONFIG_LOCK` before invoking the helper. Inline readers can therefore take
+  the process-local lock briefly while another process owns the file lock,
+  without freezing their async event loop behind that writer's bounded wait.
+  The API never accepts a caller-supplied or preloaded `V2Config` instance.
+  First-install/default paths may supply an initializer factory, which is also
+  invoked only under both locks when the document is absent.
 - Make the raw save primitive private to that API. Bind its opaque write token
   to both the transaction session and the exact config object loaded inside it;
   a missing token, a token from another session, or a config object loaded
@@ -146,11 +173,13 @@ Memory-only serialization is insufficient.
   caller may acquire the synchronous file lock or run load/merge/save inline on
   its event loop. Awaited external I/O happens before the transaction; the
   synchronous mutator then revalidates against the freshly loaded state.
-- Controller settlement uses that mutation API, compares the complete expected
-  Memory block on the fresh working object, mutates only
-  `embedding_change_pending`, and atomically saves. A mismatch or bounded lock
-  timeout fails closed with `memory_clear_failed`. Unrelated config writers wait
-  before their load, so none can publish a stale whole-file snapshot afterward.
+- Controller convergence uses that mutation API, compares the fresh working
+  object's complete Memory block with `_persisted_memory_snapshot`, then replaces
+  only that block with `_restart_config` and clears its marker when the root
+  guard permits. A mismatch or bounded lock timeout fails closed with
+  `memory_clear_failed`. Unrelated config writers wait before their load, so
+  none can publish a stale whole-file snapshot afterward, and their non-Memory
+  fields are preserved.
 - Settlement runs in one retained `asyncio.to_thread()` task. A deadline uses
   `wait_for(shield(task))`, never cancellation of the thread as proof that its
   work stopped. If the deadline or caller cancellation fires, cleanup continues
@@ -169,18 +198,25 @@ Memory-only serialization is insufficient.
   user-facing writer is the UI route that owns the cross-process transaction
   boundary.
 
-Add route concurrency tests that pause restart settlement and start both a
+Add route concurrency tests that pause restart convergence and start both a
 Memory PATCH and an unrelated `/api/config` save. The Memory PATCH must wait on
 the UI lock; the generic save must wait on the cross-process config transaction
 before loading its baseline. Cover ordinary completion and an expired settlement
 deadline. In the expired case, prove the request and transaction locks remain
 owned until the retained thread finishes. Both writers must then preserve the
-settled marker and their own C1 fields without either side restoring stale C0.
+settled marker and the generic writer's unrelated C1 fields without either side
+publishing a stale whole-document snapshot.
+For a failed Memory C1 plus failed UI rollback, prove restart conditionally
+replaces only the expected C1 Memory block with replay C0 before reporting ready;
+settings reads and a fresh `V2Config.load()` must match the live runtime. An
+unexpected C2 Memory block must reject restart without any disk or process
+mutation.
 Also load a stale C0 before another process publishes C1 and prove it cannot be
 passed into the mutation API or saved with a later transaction token; the
 accepted mutator must observe C1. Hold the file lock from a second process and
-prove representative async UI and controller writers keep their event loops
-responsive while their complete mutation waits in a worker thread.
+prove `CONFIG_LOCK` remains available to representative inline async UI and
+controller readers while off-thread writers wait on that file lock; after file
+lock acquisition, complete mutations still serialize and preserve both changes.
 
 ### 4. Nonqueued admission and complete deadlines
 
@@ -207,12 +243,15 @@ an abandoned restart, and a user retry can enqueue a second one.
   existing queued lock behavior, so search/profile/read contention still
   serializes instead of becoming a spurious Clear failure. If Clear reaches the
   module lock first, restart observes that lock and returns `memory_restart_busy`.
-- Bound interrupted-clear recovery and embedding guard/settlement separately by
-  `CLEAR_CLEANUP_TIMEOUT_SECONDS`, because both phases can run in one request.
-  Settlement timeout is a reporting threshold, not permission to abandon its
-  thread; the mandatory join above retains transaction ownership.
+- Bound interrupted-clear recovery and the embedding guard/config convergence
+  separately by `CLEAR_CLEANUP_TIMEOUT_SECONDS`, because both phases can run in
+  one request. Transaction timeout is a reporting threshold, not permission to
+  abandon its thread; the mandatory join above retains transaction ownership.
 - Give graceful worker drain five seconds. Bound forced worker-task cancellation
   separately so cancellation cleanup cannot make the lifecycle unbounded.
+- Bound worker store-task settlement separately. Cancelling an asyncio drain
+  owner does not stop a write-capable `asyncio.to_thread()` call, so worker-task
+  completion alone is not proof that lease ownership is quiescent.
 - Bound settlement of any automatic supervisor restart already in progress by
   the same all-inclusive process-start budget. The client deadline includes this
   predecessor explicitly. A generation fence, described below, prevents its
@@ -240,12 +279,12 @@ an abandoned restart, and a user retry can enqueue a second one.
   cancellation joins and one complete TERM/KILL cleanup round. Set
   `MEMORY_RESTART_TIMEOUT_SECONDS` strictly above the sum of two clear cleanup
   bounds, automatic-supervisor start settlement, process-owner settlement,
-  worker grace, worker cancellation cleanup, a separate old-process stop retry,
-  and the all-inclusive replacement-start budget. The contract test imports the
-  source constants/helpers instead of copying numbers from comments. A deadline
-  cannot release either transaction while a non-cancellable settlement write is
-  still live; its mandatory join is an ownership cleanup tail rather than
-  detached restart work.
+  worker grace, worker cancellation cleanup, worker store-task settlement, a
+  separate old-process stop retry, and the all-inclusive replacement-start
+  budget. The contract test imports the source constants/helpers instead of
+  copying numbers from comments. A deadline cannot release either transaction
+  while a non-cancellable config or store write is still live; its mandatory
+  join is an ownership cleanup tail rather than detached restart work.
 - A busy result is a completed, retryable business response. It is not
   `memory_restart_failed`, starts no background task, ends the UI spinner, and
   displays a localized reason.
@@ -265,6 +304,16 @@ Add a private semantic helper such as `begin_replacement_activation()` that
 creates a new UUID lease owner and then reuses `begin_activation()`. Do not
 change MemoryStore or its recovery SQL.
 
+Make `_store_call()` create an explicit task for `asyncio.to_thread()` and await
+it under `shield()`. Keep every unfinished task in a private worker registry;
+task cancellation must leave the underlying store task live and discoverable.
+A done callback consumes its terminal result and removes it only after the
+thread has actually returned. Add `settle_store_calls()` to snapshot and await
+all registered tasks without cancelling them. Once the drain task is terminal,
+no new store calls can enter the registry, so an empty registry proves every old
+lease `claim_due`, `settle`, flush transition, recovery, and metadata write is
+finished.
+
 The locked sequence is fixed:
 
 1. Validate store, artifact, and enabled state; recover an interrupted clear.
@@ -279,7 +328,7 @@ The locked sequence is fixed:
    process-owner settlement bound: cancel and join idle watcher/monitor tasks,
    or retain and join the one already performing child cleanup. An active start
    may finish launching a transient child, but generation-fenced activation
-   cannot resume claims and step 8 will stop it. If either retained start or
+   cannot resume claims and step 9 will stop it. If either retained start or
    lifecycle owner outlives its bound, keep its exact references and claims
    fenced, then return fail-closed without rotating the lease or invoking
    `stop()` beside it. A retry rejoins those same tasks first.
@@ -290,14 +339,22 @@ The locked sequence is fixed:
    Do not clear `_worker_task` until the exact task is done. If it outlives the
    bound, retain the task reference, keep claims fenced, and enter the
    fail-closed state below; do not rotate the lease or touch the process.
-6. Rotate the lease owner only after both retained tasks are confirmed done and
-   before any new activation.
-7. Only when the snapshot has `embedding_change_pending`, run the root guard and
-   marker settlement while claims are fenced and the old worker is stopped.
-   Restore `self._config` only after they pass.
-8. Stop the old process. Do not discard its supervisor or start another child
+6. After the exact drain task is terminal, call `settle_store_calls()` under its
+   own bound. If any shielded store thread remains live, retain its registry
+   entry, the old lease, and every existing process reference; keep claims
+   fenced and return fail-closed. A retry rejoins the same store task before it
+   can proceed.
+7. Rotate the lease owner only after the supervisor, process owners, drain task,
+   and store-task registry are all confirmed quiescent, and before any new
+   activation.
+8. Run config convergence while claims are fenced and the old worker is stopped.
+   When `_restart_config` has `embedding_change_pending`, run the root guard
+   first and clear the marker in the replay block. The transaction must replace
+   only the expected persisted Memory block with replay C0, preserving every
+   unrelated field. Restore `self._config` only after convergence succeeds.
+9. Stop the old process. Do not discard its supervisor or start another child
    until its process tree is confirmed reaped.
-9. Create a process from `_restart_config` bound to the lifecycle generation
+10. Create a process from `_restart_config` bound to the lifecycle generation
    captured when restart entered its critical section. Its explicit initial
    `start()` suppresses the automatic ready callback: while restart still owns
    `_reconcile_lock -> module._lifecycle_lock`, runtime itself resumes claims,
@@ -349,15 +406,21 @@ Every exit after claims are fenced must end in one of these states:
   interval. It can continue only after the task is done and its outcome has been
   consumed; while it remains live the retry returns the same fail-closed
   response and creates no replacement worker or child.
+- **A shielded worker store task outlives settlement:** retain its exact registry
+  entry and the original lease after the drain task terminates, keep claims
+  fenced, leave the old process untouched, and return `memory_restart_failed`.
+  A retry awaits the same task under another bounded interval. It cannot run
+  recovery, rotate the lease, or touch process ownership until the thread has
+  returned and its terminal result has been consumed.
 - **Failure before `old_process.stop()` is invoked:** the old supervisor still
   owns its child but is quiesced. Re-arm supervision and ready callbacks. If its
   child is still running, reactivate with the new lease owner, resume claims and
   the worker, and return the specific failure. If the child exited during the
   handoff, keep claims fenced and let the re-armed supervisor start a child;
   only a current-generation activation task may resume the worker after taking
-  both lifecycle locks. This branch applies only after the previous worker and
-  process-owner tasks are confirmed done; it never attempts reactivation beside
-  a retained task.
+  both lifecycle locks. This branch applies only after the previous worker,
+  store, and process-owner tasks are confirmed done; it never attempts
+  reactivation beside a retained task.
 - **`old_process.stop()` was invoked:** `EverOSProcess.stop()` sets
   `_desired_running=false` before termination and cancels scheduled restart.
   If stop raises, retain the supervisor reference but keep claims and the worker
@@ -378,11 +441,11 @@ Every exit after claims are fenced must end in one of these states:
 `CancelledError` is re-raised after ownership and claims cleanup; it is never
 reported as a business failure. Fix `_stop_worker()` so it swallows only the
 cancelled drain task's `CancelledError`, while cancellation of the lifecycle
-task itself propagates. Restart uses shielded cleanup to reach one of the states
-above. If cancellation lands after a new child is spawned but before its watcher
-or monitor exists, shield `new_process.stop()`: clear `_process` only after
-successful reap; otherwise retain the supervisor reference and keep claims
-fenced.
+task itself propagates. Restart uses shielded cleanup to settle the worker store
+registry and reach one of the states above. If cancellation lands after a new
+child is spawned but before its watcher or monitor exists, shield
+`new_process.stop()`: clear `_process` only after successful reap; otherwise
+retain the supervisor reference and keep claims fenced.
 
 `start()` returning `False` keeps the specific
 `memory_sidecar_unavailable`. Stop, factory, and other restart orchestration
@@ -393,7 +456,9 @@ exceptions use the transport-only `memory_restart_failed`.
 - If cancellation occurs after an add is claimed, activation under the new lease
   returns the old owner's row to `pending`, preserving at-least-once behavior.
   The provider may have accepted the request before local acknowledgement, so
-  forced restart cannot promise exactly-once side effects.
+  forced restart cannot promise exactly-once side effects. Store-thread
+  settlement guarantees no old-lease claim or acknowledgement can commit after
+  that recovery begins.
 - If cancellation occurs while a flush is `in_flight`, activation permanently
   marks it `unknown` and opens a processing fault. Historical `unknown` entries
   do not retry or disappear after five minutes. A later successful flush can
@@ -405,17 +470,22 @@ exceptions use the transport-only `memory_restart_failed`.
 
 1. `config/v2_config.py`, `vibe/api.py`, and every audited whole-file writer:
    add the cross-process `mutate_v2_config()` API, make raw save private, bind
-   the working object to an opaque session token, and offload the complete
-   mutation from every asynchronous caller.
+   the working object to an opaque session token, always acquire the file lock
+   before `CONFIG_LOCK`, and offload the complete mutation from every
+   asynchronous caller.
 2. `core/memory/runtime.py`: add `_restart_config`,
-   `_explicit_restart_active`, lifecycle generation and a retained ready
-   activation task, and fail-fast `restart()`; commit snapshots after successful
-   reconcile; retain worker tasks that outlive cancellation; reject restart
-   while artifact installation is active; make only restart-owned Clear
-   contention fail fast.
+   `_persisted_memory_snapshot`, `_explicit_restart_active`, lifecycle generation
+   and a retained ready activation task, and fail-fast `restart()`; conditionally
+   converge disk to replay before launch; retain worker/store tasks that outlive
+   cancellation; reject restart while artifact installation is active; make
+   only restart-owned Clear contention fail fast.
+   `Controller.reconcile_memory()` marks only its persisted candidate explicitly;
+   post-Clear and artifact-internal reconciles cannot change the disk snapshot.
 3. `core/memory/module.py`: extract locked clear recovery while retaining the
    wrapper and existing queued lifecycle-lock behavior for read/Clear paths.
-4. `core/memory/worker.py`: rotate the lease owner for replacement activation.
+4. `core/memory/worker.py`: retain and shield explicit store-thread tasks, expose
+   bounded settlement, and rotate the lease owner only after their registry is
+   empty.
 5. `core/memory/process.py`: expose complete stop/start and process-owner
    settlement budget helpers, put one cap around all orphan-reap rounds, add the
    explicit-handoff supervisor fence, distinguish idle watcher/monitor tasks
@@ -462,7 +532,11 @@ exceptions use the transport-only `memory_restart_failed`.
 - `tests/test_memory_runtime.py`
   - Successful restart confirms old stop, new ready child, and worker recovery.
   - After failed C1 reconcile and failed rollback, restart replays last-good C0;
-    the uncontended operation remains inside both lifecycle locks.
+    the uncontended operation remains inside both lifecycle locks and
+    conditionally replaces the expected persisted C1 Memory block with C0 while
+    preserving unrelated fields. A fresh disk load must equal the live runtime;
+    an unexpected Memory C2 fails before process mutation. A post-Clear internal
+    reconcile cannot overwrite the persisted snapshot contract.
   - Pre-held reconcile/module locks and concurrent restart calls immediately
     return `memory_restart_busy`, create no waiters, and change no ownership.
     An installer paused inside unlocked `ensure(force=True)` also returns busy
@@ -476,6 +550,11 @@ exceptions use the transport-only `memory_restart_failed`.
   - A worker task that ignores its first cancellation is retained with the old
     lease and fenced claims. No child/process action occurs; retry stays closed
     until the exact task terminates, then completes replacement normally.
+  - A drain task cancelled while awaiting a blocked store `claim_due`, `settle`,
+    or `mark_flush_in_flight` can become done while its shielded thread remains
+    registered. Restart retains the old lease and process without running
+    recovery; after the thread is released, retry joins it and only then rotates
+    and recovers.
   - If the old child exits during the five-second drain grace, its supervisor is
     already quiesced: no automatic restart can schedule ready activation, resume
     claims, or replace `_worker_task`. Pre-stop failure re-arms that supervisor
@@ -509,13 +588,13 @@ exceptions use the transport-only `memory_restart_failed`.
 - `tests/test_internal_client.py` / `tests/test_internal_client_timeouts.py`:
   POST and busy response passthrough; deadline computed from both clear phases,
   automatic-supervisor start settlement, watcher/monitor owner settlement,
-  worker bounds, a distinct old stop retry, the outer all-round orphan-reap cap,
-  readiness, and failed-start cleanup. On reporting timeout or caller
-  cancellation, the retained request is joined before its caller can release
-  transaction ownership.
+  worker and store-task bounds, a distinct old stop retry, the outer all-round
+  orphan-reap cap, readiness, and failed-start cleanup. On reporting timeout or
+  caller cancellation, the retained request is joined before its caller can
+  release transaction ownership.
 - `tests/test_ui_memory_routes.py`: new client path, internal unavailable,
   cross-origin rejection, restart/settings serialization, timed-out settlement
-  ownership, and final C1 retention.
+  ownership, unrelated-field retention, and failed-Memory-C1 convergence to C0.
 - `tests/test_v2_config.py` / config route tests: a generic non-Memory save in a
   second process waits before loading while settlement owns the config
   transaction, then preserves both its C1 change and the cleared marker. Saving
@@ -523,8 +602,12 @@ exceptions use the transport-only `memory_restart_failed`.
   later transaction cannot be saved, and an accepted mutator observes the
   intervening C1. Nested same-thread mutations share one fresh working object
   and publish once without deadlock. While a second process holds the file lock,
-  representative async UI and controller writers wait off-thread and event-loop
-  probes continue to run.
+  writers wait without owning `CONFIG_LOCK`, representative inline async UI and
+  controller reads complete, and event-loop probes continue to run.
+- `tests/test_memory_worker.py`: `_store_call()` shields and retains its explicit
+  thread task across drain cancellation. `settle_store_calls()` times out without
+  cancelling the thread, retains it for retry, consumes its terminal result, and
+  reports quiescence only after the registry is empty.
 - `tests/test_memory_process.py`: stale recorded leader plus late helper and
   multiple unusable-record anchors share one outer reap deadline. Timeout keeps
   the record and prevents child launch. Idle watcher/monitor tasks cancel and
@@ -545,37 +628,40 @@ exceptions use the transport-only `memory_restart_failed`.
 ## Validation
 
 1. `pytest tests/test_memory_runtime.py -k restart`
-2. `pytest tests/test_internal_server.py tests/test_internal_client.py tests/test_internal_client_timeouts.py tests/test_ui_memory_routes.py tests/test_v2_config.py -k 'memory or config or restart'`
-3. Run `ruff check` on every changed Python file.
-4. In `ui/`, run the relevant normalizer, `SettingsMemoryPage`, and
+2. `pytest tests/test_memory_worker.py -k 'store or cancel or activation'`
+3. `pytest tests/test_internal_server.py tests/test_internal_client.py tests/test_internal_client_timeouts.py tests/test_ui_memory_routes.py tests/test_v2_config.py -k 'memory or config or restart'`
+4. Run `ruff check` on every changed Python file.
+5. In `ui/`, run the relevant normalizer, `SettingsMemoryPage`, and
    `MemoryStatusPanel` Vitest files, then `npm run build`.
-5. Update only the local Incus `master` regression environment with
+6. Update only the local Incus `master` regression environment with
    `./scripts/run_regression.sh`; preserve configuration and verify service health.
-6. Through `python3 scripts/incus_regression.py shell --target master`, identify
+7. Through `python3 scripts/incus_regression.py shell --target master`, identify
    the managed sidecar PID and send `SIGSTOP` to create an alive-but-unreachable
    process. In the Web UI, verify the persistent action, spinner, toast, PID
    replacement, and return to `ready`. If replacement does not complete, send
    `SIGCONT` to the original PID during cleanup.
-7. Check Avibe service health again through the runner. Do not restart the local
+8. Check Avibe service health again through the runner. Do not restart the local
    `vibe` service and do not use `kill -9`; that only covers existing child-exit
    supervision, not this scenario.
 
 ## Review conclusion
 
 The necessary complexity comes from existing safety and concurrency contracts:
-failed candidates cannot replace last-good config; marker settlement cannot
-race any whole-file V2 writer, start from an unlocked baseline, block an async
-event loop, or outlive its transaction; explicit restart and destructive Clear
-cannot queue behind each other while ordinary reads retain their existing
-serialization; artifact installation excludes launch; orphan recovery has one
-complete cap; every active process lifecycle owner is settled and budgeted
-before stop; delayed automatic activation is fenced by lifecycle generation and
-both runtime locks; pending embeddings cannot bypass the root guard; claimed
-rows require a new lease only after the old worker exits; activation success is
-observable; and clear markers serialize with root/child lifecycle. The
-implementation adds one private snapshot, narrow helpers, and two precise
-transport-only error codes while reusing existing locks, guards, recovery SQL,
-supervision, and UI primitives.
+failed candidates cannot replace last-good config, and successful replay must
+conditionally converge the known persisted Memory block to that same config;
+config mutation cannot race any whole-file V2 writer, start from an unlocked
+baseline, hold `CONFIG_LOCK` during a file-lock wait, block an async event loop,
+or outlive its transaction; explicit restart and destructive Clear cannot queue
+behind each other while ordinary reads retain their existing serialization;
+artifact installation excludes launch; orphan recovery has one complete cap;
+every active process lifecycle owner is settled and budgeted before stop;
+delayed automatic activation is fenced by lifecycle generation and both runtime
+locks; pending embeddings cannot bypass the root guard; claimed rows require a
+new lease only after the old worker and every shielded store thread exit;
+activation success is observable; and clear markers serialize with root/child
+lifecycle. The implementation adds two private snapshots, narrow helpers, and
+two precise transport-only error codes while reusing existing locks, guards,
+recovery SQL, supervision, and UI primitives.
 
 Do not introduce a general coordinator, explicit restart state machine, new
 port, database field, automatic restart policy, or frontend test framework. If
@@ -583,13 +669,14 @@ implementation appears to require one, revise this plan before expanding scope.
 
 ## Todo
 
-- [ ] Runtime snapshot, pending-embedding guard, fail-fast restart, focused tests
+- [ ] Replay/disk snapshots, conditional C1-to-C0 convergence, focused tests
 - [ ] Settings/restart serialization and stale-C0 overwrite regression
 - [ ] Token-bound config mutation API and concurrent non-Memory writer regression
-- [ ] Async UI/controller config writers off-thread and event-loop responsiveness
+- [ ] File-lock-first order, async writers off-thread, inline-reader responsiveness
 - [ ] Timed-out settlement ownership and retained-request regression
 - [ ] Worker lease rotation and add/flush recovery tests
 - [ ] Retained worker cancellation fail-closed state and retry
+- [ ] Shielded store-thread registry, bounded settlement, and retry
 - [ ] Locked clear recovery and race regression
 - [ ] Restart-specific Clear admission and artifact-install admission
 - [ ] Supervisor handoff fence, lifecycle-owner settlement, and deadline contract

--- a/docs/plans/memory-sidecar-force-restart-button.md
+++ b/docs/plans/memory-sidecar-force-restart-button.md
@@ -1,6 +1,6 @@
-# Add a forced sidecar restart action to Memory settings (rev16)
+# Add a forced sidecar restart action to Memory settings (rev17)
 
-> Rev16 keeps one public recovery action and a focused set of internal fixes:
+> Rev17 keeps one public recovery action and a focused set of internal fixes:
 > replayable configuration, config-wide write serialization, restart-specific
 > and lifecycle-intent admission, generation-fenced ready activation, complete
 > supervisor quiescing, bounded orphan recovery, disk/live replay convergence,
@@ -8,8 +8,9 @@
 > locked clear-marker recovery, bounded readiness, supervisor callback rebinding,
 > authoritative controller/UI settings refresh, queued-operation exclusion, and
 > disabled/fail-closed replay handling, explicit worker activation, post-lock
-> retained-owner admission, root/installer task retention, and disabled recovery
-> projection alongside processing-probe/module-store ownership.
+> retained-owner admission, complete root/installer/probe ownership, lifecycle
+> abort reactivation, store-unavailable retry, shutdown joining, and disabled
+> recovery projection alongside processing-probe/module-store ownership.
 > Timed-out work remains owned until it is either joined or proven unable to
 > mutate state. It does not add a lifecycle coordinator, explicit state machine,
 > provider/store port, or frontend DOM test framework.
@@ -301,6 +302,13 @@ an abandoned restart, and a user retry can enqueue a second one.
   held, return
   `{ok: false, error: 'memory_restart_busy'}` without changing the process,
   claims, or worker.
+- Order that admission so Runtime-only counters and locks are checked before any
+  module member is read. If the store is unavailable and no conflicting Runtime
+  intent owns admission, synchronously retry `_open_store()` before accessing
+  `module.lifecycle_busy` or `module._lifecycle_lock`; a second failed open returns
+  `memory_store_unavailable` without process/config mutation. This preserves the
+  existing transient-store recovery behavior and never treats
+  `_UnavailableMemoryModule` as a full lifecycle module.
 - Add a narrow `_retained_ownership_active` gate to `MemoryRuntime`. Any worker,
   worker/module store task, processing probe, supervisor start, watcher/monitor,
   or process cleanup owner that outlives its bound sets this gate synchronously
@@ -370,18 +378,28 @@ an abandoned restart, and a user retry can enqueue a second one.
   exact task still outlives that bound, retain it and set the cross-lifecycle gate
   before releasing locks. Include module-store settlement as its own restart
   deadline component.
-- Give the bare root verification and recreation `to_thread()` calls in
-  `_clear_provider_data_or_fail()` explicit shielded task records keyed by the
-  provider root. Keep them distinct from `_ROOT_CLEANUP_TASKS`, which owns the
-  provider cleanup callback. Clear and interrupted-clear recovery consume or
-  retain the exact verification/recreation tasks; restart settles all three root
-  owner classes under the root cleanup allowance. If any task outlives the bound,
-  set the cross-lifecycle gate before releasing locks and prevent a retry from
-  resolving or launching EverOS until that exact filesystem task terminates.
+- Give every root verification or mutation reached through `to_thread()` an
+  explicit shielded task record keyed by provider root. This includes Clear and
+  interrupted-clear verification/recreation plus artifact activation's format
+  rewrite, rollback sentinel restore, and post-restore verification. Keep these
+  records distinct from `_ROOT_CLEANUP_TASKS`, which owns the provider cleanup
+  callback. Clear, recovery, activation, and rollback consume or retain their
+  exact tasks; restart settles every root owner under the root cleanup allowance.
+  If any task outlives the bound or cancellation recurs during rollback, set the
+  cross-lifecycle gate before releasing locks and prevent reconcile, rollback,
+  or restart from touching root metadata or launching EverOS until that exact
+  filesystem task terminates.
 - Bound settlement of processing-probe trees separately. Cancelling the drain
   task can make it terminal while probe termination is still incomplete; every
   retained probe owner must prove its process tree reaped before lease rotation
   or sidecar replacement.
+- Register each throwaway supervisor created by `_probe_processing()` in a
+  Runtime-owned preflight-probe registry before invoking `processing_healthy()`.
+  Remove it only after its supervisor probe registry proves the credential-bearing
+  tree fully reaped. Reconcile cancellation/failure transfers the exact temporary
+  supervisor to retained ownership and sets the cross-lifecycle gate if bounded
+  settlement cannot finish; restart and close settle both the supervised child
+  and every Runtime-level preflight supervisor before releasing lifecycle state.
 - Bound settlement of any automatic supervisor restart already in progress by
   the same all-inclusive process-start budget. The client deadline includes this
   predecessor explicitly. A generation fence, described below, prevents its
@@ -504,20 +522,22 @@ The locked sequence is fixed:
    bound, retain the task reference, keep claims fenced, and enter the
    fail-closed state below; do not rotate the lease or touch the process.
 6. After the exact drain task is terminal, call `settle_store_calls()` on both
-   `MemoryWorker` and `MemoryModule` under their distinct bounds. If any shielded
-   store thread remains live, retain its registry entry, the old lease, and every
-   existing process reference; set the retained-ownership gate, keep claims
-   fenced, and return fail-closed. A retry rejoins the same store task before it
-   can proceed.
-7. Ask the old supervisor to settle every retained processing-probe tree under
-   the probe-settlement bound. `processing_healthy()` registers the exact probe,
+   `MemoryWorker` and `MemoryModule` under their distinct bounds, then settle the
+   module's root verification/mutation registry under the root cleanup allowance.
+   If any shielded store or root thread remains live, retain its registry entry,
+   the old lease, and every existing process reference; set the retained-ownership
+   gate, keep claims fenced, and return fail-closed. A retry rejoins the same task
+   before it can proceed.
+7. Ask the old supervisor and every Runtime-retained throwaway preflight
+   supervisor to settle their processing-probe trees under the probe-settlement
+   bound. `processing_healthy()` registers the exact probe,
    process group, and owned-process snapshot immediately after spawn returns and
    before awaiting probe completion; any cleanup task is recorded before its
    first cleanup await. It removes that record only after complete reap.
    Cancellation or failed cleanup keeps the record on the supervisor. If
-   settlement cannot prove every tree reaped, retain those records and the old
-   supervisor, keep claims fenced, and return fail-closed. A retry settles the
-   same owners first.
+   settlement cannot prove every tree reaped, retain those records and their
+   supervisor objects, keep claims fenced, and return fail-closed. A retry
+   settles the same owners first.
 8. Rotate the lease owner only after the supervisor, process owners, drain task,
    store-task registry, and probe registry are all confirmed quiescent, and
    before any new activation.
@@ -574,6 +594,18 @@ without resuming claims or creating a worker. Current-generation activation
 failures set the visible runtime error and leave claims fenced; task completion
 is consumed and the task is retained/cancelled during later lifecycle cleanup
 rather than becoming an unobserved exception.
+
+Generation invalidation also has an abort compensation. If a lifecycle operation
+returns before committing to a replacement/disable/Clear state and leaves the
+same enabled supervisor current and ready, it must not merely discard the queued
+old-generation callback. While still owning both lifecycle locks, verify that no
+retained owner or newer operation superseded that supervisor, rebind it to the
+current generation, and directly run the same locked activation handshake before
+releasing claims. This path is required for failed persisted reconcile preflight
+and equivalent early aborts. If the supervisor is no longer ready/current, or
+reactivation fails, keep claims fenced and expose the specific runtime error; do
+not resume from `running` alone. Operations that committed disable, Clear, root
+mutation, or replacement ownership never restore the prior activation.
 
 `restart()` does not call `_probe_processing`. The conditional embedding/root
 guard protects persistent vector-space compatibility; it is not a processing
@@ -666,6 +698,19 @@ retain the supervisor reference and keep claims fenced. The same shielded cleanu
 retains incomplete processing-probe owners rather than dropping their local
 references when cancellation is re-raised.
 
+Shutdown is an ownership handoff, not the generic five-second best-effort close.
+Runtime records the exact task executing explicit restart. `close()` first fences
+new lifecycle admission, cancels and joins that task through its shielded cleanup,
+then acquires the lifecycle locks and settles worker/module stores, every root
+task, Runtime preflight supervisors, automatic activation, process owners, and
+the final child stop. Expose a Memory-specific complete shutdown allowance equal
+to the advertised restart-cancellation and owner-cleanup components plus a small
+scheduling margin. `Controller.cleanup_sync()` passes that allowance to a
+timeout-parameterized loop helper instead of the fixed five seconds. Expiry is
+not success: the controller keeps the Memory close future and event loop alive
+until its terminal ownership result is observed, rather than abandoning it and
+continuing loop teardown beside a non-cancellable thread or live sidecar.
+
 `start()` returning `False` keeps the specific
 `memory_sidecar_unavailable`. Stop, factory, and other restart orchestration
 exceptions use the transport-only `memory_restart_failed`.
@@ -696,8 +741,9 @@ exceptions use the transport-only `memory_restart_failed`.
 2. `core/memory/runtime.py`: add `_restart_config`,
    `_persisted_memory_snapshot`, `_explicit_restart_active`,
    `_clear_pending_count`, `_reconcile_pending_count`,
-   `_retained_ownership_active`, a retained artifact-install task, lifecycle
-   generation and a retained ready activation task, and fail-fast `restart()`;
+   `_retained_ownership_active`, a retained artifact-install task, a Runtime
+   preflight-supervisor registry, lifecycle generation, the active explicit
+   restart task, and a retained ready activation task, and fail-fast `restart()`;
    recheck retained ownership under acquired lifecycle locks; refresh the
    persisted snapshot after every successful runtime-owned V2 mutation and
    rebase a successfully reconciled
@@ -708,7 +754,10 @@ exceptions use the transport-only `memory_restart_failed`.
    restart admission fail fast. Make `restart()` return its transport
    result plus the exact applied replay config whenever convergence committed,
    including later lifecycle failure, and no config before convergence or on
-   busy. Project `restart_recovery_required` in restart/status results while a
+   busy. Retry unavailable-store creation before module admission; compensate
+   failed lifecycle generation invalidation by activating an unchanged current
+   ready supervisor under both locks. Project `restart_recovery_required` in
+   restart/status results while a
    disabled replay still owns failed cleanup. Add `reconcile_persisted()` to
    return the exact
    successful candidate alongside the transport result while ordinary
@@ -720,8 +769,9 @@ exceptions use the transport-only `memory_restart_failed`.
    wrapper and existing queued lifecycle-lock behavior for read/Clear paths. Add
    the synchronous lifecycle-intent scope and `lifecycle_busy` property covering
    active and queued search, profile, Clear, and recovery operations. Shield and
-   retain explicit module store tasks plus root verification/recreation tasks and
-   expose their bounded settlement. A narrow Runtime-supplied admission predicate
+   retain explicit module store tasks plus every Clear/recovery/artifact root
+   verification or mutation task and expose their bounded settlement. A narrow
+   Runtime-supplied admission predicate
    prevents search/profile recovery and Clear from entering while retained
    ownership is fenced and is rechecked after a queued caller acquires the module
    lifecycle lock.
@@ -743,7 +793,9 @@ exceptions use the transport-only `memory_restart_failed`.
    into `Controller.config.memory`, then expose only the transport response with
    its `config_committed` flag. Missing runtime returns
    `memory_runtime_missing`; unhandled exceptions map to `memory_restart_failed`,
-   not `memory_reconcile_failed`.
+   not `memory_reconcile_failed`. Make synchronous cleanup accept a per-resource
+   allowance; Memory cancels/joins active restart ownership and receives its full
+   Runtime-exported shutdown allowance rather than the generic five seconds.
 7. `vibe/internal_client.py`: add `memory_restart()` with a deadline above the
    complete restart lifecycle budget; retain and join the shielded request task
    after a reporting timeout.
@@ -824,6 +876,10 @@ exceptions use the transport-only `memory_restart_failed`.
     task record, `_artifact_installing`, and reconcile intent remain owned;
     restart stays busy until the exact thread ends, after which cancellation is
     re-raised and all three ownership signals clear.
+    With a startup store-open failure, restart retries `_open_store()` before
+    reading module lifecycle state: a recovered store proceeds normally, while a
+    second failure returns `memory_store_unavailable` without touching the
+    unavailable module adapter, process, or config.
     Hold one search/profile request in the module lock and queue a second; across
     the owner's release/waiter-wakeup gap, `lifecycle_busy` remains true and
     restart returns busy without joining the read queue. After both reads finish,
@@ -860,17 +916,23 @@ exceptions use the transport-only `memory_restart_failed`.
     registered. Restart retains the old lease and process without running
     recovery; after the thread is released, retry joins it and only then rotates
     and recovers.
-  - Block the actual root verification and recreation `to_thread()` calls during
-    Clear and interrupted-clear recovery. Cancellation or reporting timeout must
-    leave the exact root task registered and the retained-owner gate set; restart
-    retry cannot resolve an artifact or launch a child until that thread exits
-    and the root-task registry is consumed. Cover the cleanup callback registry
-    in the same settlement assertion without conflating the three owners.
+  - Block the actual root verification/recreation `to_thread()` calls during
+    Clear and interrupted-clear recovery, then separately block artifact format
+    rewrite and rollback sentinel restore/verification. Cancellation or reporting
+    timeout must leave each exact root task registered and the retained-owner gate
+    set; restart/reconcile cannot touch root metadata, resolve an artifact, or
+    launch a child until that thread exits and the root-task registry is consumed.
+    Cover the cleanup callback registry in the same settlement assertion without
+    conflating the owner classes.
   - Cancel a drain task inside a real supervised processing probe and make its
     first termination round fail. The terminal worker task is insufficient for
     restart admission: the exact probe-tree record remains on the supervisor,
     claims and lease stay fenced, and no process replacement occurs. A retry
     reaps that same record before continuing.
+    Also cancel persisted reconcile inside `_probe_processing()` and fail the
+    throwaway supervisor's first termination round. Runtime must retain that exact
+    supervisor in its preflight registry, set cross-lifecycle admission, and make
+    restart/close settle it before any root, lease, or child action.
   - Timeout interrupted-clear recovery while `MemoryModule._store_call()` owns a
     blocked `get_meta`, `begin_clear`, `finish_clear`, or failure-recording
     thread. Cancellation leaves the exact task shielded and registered, keeps
@@ -893,6 +955,11 @@ exceptions use the transport-only `memory_restart_failed`.
     lifecycle generation and exits without resuming claims or replacing the
     worker. The equivalent no-intervening-lifecycle case activates only after
     taking both locks.
+    If persisted reconcile then aborts before committing replacement ownership,
+    such as on processing preflight failure, and the same supervisor is current
+    and ready, its abort compensation rebinds current generation and completes
+    locked worker activation before releasing claims. A stale callback alone
+    cannot strand draining; a changed/unready supervisor remains fenced.
   - The old watcher or safety monitor enters child-tree cleanup immediately
     before restart. Handoff joins that exact owner under the process-owner bound
     before calling `stop()`; timeout stays fail-closed, and the successful case
@@ -939,11 +1006,18 @@ exceptions use the transport-only `memory_restart_failed`.
 - `tests/test_internal_client.py` / `tests/test_internal_client_timeouts.py`:
   POST and busy response passthrough; deadline computed from both clear phases,
   automatic-supervisor start settlement, watcher/monitor owner settlement,
-  worker, store-task, and processing-probe bounds, a distinct old stop retry, the
+  worker, store/root-task, and supervised plus preflight processing-probe bounds,
+  a distinct old stop retry, the
   outer all-round orphan-reap cap, readiness, failed-start cleanup, explicit
   worker activation, and a separate complete replacement-activation cleanup
   allowance. On reporting timeout or caller cancellation, the retained request
   is joined before its caller can release transaction ownership.
+- Controller cleanup tests: start explicit restart inside retained store/root or
+  preflight cleanup, call `cleanup_sync()`, and prove it cancels and joins the
+  exact restart plus Runtime ownership before loop teardown. The Memory close
+  uses the exported complete shutdown allowance rather than five seconds; an
+  allowance expiry keeps the future/loop owned until terminal instead of silently
+  continuing shutdown.
 - `tests/test_ui_memory_routes.py`: new client path, internal unavailable,
   cross-origin rejection, restart/settings serialization, timed-out settlement
   ownership, unrelated-field retention, and failed-Memory-C1 convergence to C0.
@@ -974,7 +1048,8 @@ exceptions use the transport-only `memory_restart_failed`.
 - `tests/test_memory_module.py`: clear/recovery store calls use explicit shielded
   tasks; timeout and caller cancellation retain each SQLite-writing task through
   terminal result, and settlement reports quiescence only when the registry is
-  empty.
+  empty. Root task coverage includes Clear/recovery verification/recreation and
+  artifact activation/rollback metadata writes.
 - `tests/test_memory_process.py`: stale recorded leader plus late helper and
   multiple unusable-record anchors share one outer reap deadline. Timeout keeps
   the record and prevents child launch. Idle watcher/monitor tasks cancel and
@@ -1042,12 +1117,14 @@ settlement propagates the same exact block into controller shared config;
 explicit restart cannot queue behind or leapfrog any active or queued module
 lifecycle operation, while reads and destructive Clear retain their existing
 serialization and recheck retained ownership after acquiring their locks;
-artifact installation and root verification/recreation threads remain explicitly
-owned through cancellation; artifact installation excludes launch; orphan
+artifact installation and every root metadata thread remain explicitly owned
+through cancellation; unavailable-store retry precedes module admission;
+artifact installation excludes launch; orphan
 recovery has one complete cap; every active process lifecycle
 owner is settled and budgeted before stop; readiness, including the final health
 request, has one hard cap; delayed automatic activation and re-armed supervision
-are bound to the current lifecycle generation and both runtime locks; pending
+are bound to the current lifecycle generation and both runtime locks, with locked
+abort compensation for an unchanged ready supervisor; pending
 embeddings cannot bypass the root guard or remain in a successful replay
 snapshot; claimed rows require a new lease only after the old worker and every
 shielded worker/module store thread exit; activation success is observable and
@@ -1055,7 +1132,9 @@ its shared future is shielded from reporting timeout; post-convergence failure
 still propagates the committed block to Controller and UI; retained ownership
 excludes every other mutating lifecycle; replacement cleanup fences supervision
 before awaiting; disabled retained cleanup keeps its explicit recovery action;
-and clear markers serialize with root/child lifecycle. The
+Runtime retains throwaway preflight supervisors; shutdown joins active restart
+ownership beyond the generic five-second close; and clear markers serialize with
+root/child lifecycle. The
 implementation adds two private snapshots, focused intent counters, one narrow
 retained-owner gate, focused helpers, and two precise transport-only error codes
 while reusing existing locks, guards, recovery SQL, supervision, and UI
@@ -1078,18 +1157,22 @@ implementation appears to require one, revise this plan before expanding scope.
 - [ ] Retained worker cancellation fail-closed state and retry
 - [ ] Shielded store-thread registry, bounded settlement, and retry
 - [ ] Module clear/recovery store-task retention and cross-lifecycle owner gate
-- [ ] Root verification/recreation task retention and retry settlement
+- [ ] Clear/recovery/activation root-task retention and retry settlement
 - [ ] Locked clear recovery and race regression
 - [ ] Restart/Clear intent admission, queued-Clear handoff, artifact admission
 - [ ] Queued read intent admission and waiter-handoff regression
 - [ ] Under-lock retained-owner recheck for every queued lifecycle operation
 - [ ] Cancelled artifact installer ownership and restart exclusion
+- [ ] Unavailable-store restart bootstrap before module admission
+- [ ] Runtime-owned preflight-probe supervisors and cancellation settlement
 - [ ] Supervisor handoff/rebind, lifecycle-owner settlement, readiness/deadline contract
 - [ ] Lifecycle-generation ready activation and Clear/reconcile race regression
+- [ ] Lifecycle-abort compensation for unchanged ready supervisor activation
 - [ ] Complete orphan/start budgets, explicit activation, failed-start cleanup
 - [ ] Shielded activation handshake and fenced replacement-activation cleanup
 - [ ] Internal server/client, closed/busy errors, bounded timeout tests
 - [ ] UI route and response normalizer
 - [ ] Page action, deduplicated banner, success/failure settings reload, toast/i18n
 - [ ] Disabled retained-cleanup recovery projection and persistent retry action
+- [ ] Memory-specific shutdown allowance and active-restart ownership join
 - [ ] Focused Python/TypeScript validation and Incus `SIGSTOP` scenario

--- a/docs/plans/memory-sidecar-force-restart-button.md
+++ b/docs/plans/memory-sidecar-force-restart-button.md
@@ -1,13 +1,14 @@
-# Add a forced sidecar restart action to Memory settings (rev13)
+# Add a forced sidecar restart action to Memory settings (rev14)
 
-> Rev13 keeps one public recovery action and a focused set of internal fixes:
+> Rev14 keeps one public recovery action and a focused set of internal fixes:
 > replayable configuration, config-wide write serialization, restart-specific
 > and lifecycle-intent admission, generation-fenced ready activation, complete
 > supervisor quiescing, bounded orphan recovery, disk/live replay convergence,
 > marker-free replay promotion, store-thread settlement, worker lease rotation,
 > locked clear-marker recovery, bounded readiness, supervisor callback rebinding,
 > authoritative controller/UI settings refresh, queued-operation exclusion, and
-> disabled/fail-closed replay handling.
+> disabled/fail-closed replay handling, explicit worker activation, and retained
+> processing-probe ownership.
 > Timed-out work remains owned until it is either joined or proven unable to
 > mutate state. It does not add a lifecycle coordinator, explicit state machine,
 > provider/store port, or frontend DOM test framework.
@@ -323,6 +324,10 @@ an abandoned restart, and a user retry can enqueue a second one.
 - Bound worker store-task settlement separately. Cancelling an asyncio drain
   owner does not stop a write-capable `asyncio.to_thread()` call, so worker-task
   completion alone is not proof that lease ownership is quiescent.
+- Bound settlement of processing-probe trees separately. Cancelling the drain
+  task can make it terminal while probe termination is still incomplete; every
+  retained probe owner must prove its process tree reaped before lease rotation
+  or sidecar replacement.
 - Bound settlement of any automatic supervisor restart already in progress by
   the same all-inclusive process-start budget. The client deadline includes this
   predecessor explicitly. A generation fence, described below, prevents its
@@ -356,12 +361,16 @@ an abandoned restart, and a user retry can enqueue a second one.
   cancellation joins and one complete TERM/KILL cleanup round. Set
   `MEMORY_RESTART_TIMEOUT_SECONDS` strictly above the sum of two clear cleanup
   bounds, automatic-supervisor start settlement, process-owner settlement,
-  worker grace, worker cancellation cleanup, worker store-task settlement, a
-  separate old-process stop retry, and the all-inclusive replacement-start
-  budget. The contract test imports the source constants/helpers instead of
-  copying numbers from comments. A deadline cannot release either transaction
-  while a non-cancellable config or store write is still live; its mandatory
-  join is an ownership cleanup tail rather than detached restart work.
+  worker grace, worker cancellation cleanup, worker store-task settlement,
+  processing-probe settlement, a separate old-process stop retry, and the
+  all-inclusive replacement-start budget. Add a worker-activation bound after
+  replacement health plus a distinct replacement-activation cleanup allowance
+  containing another worker cancellation, store-task settlement, probe
+  settlement, and complete TERM/KILL stop round. The contract test imports the
+  source constants/helpers instead of copying numbers from comments. A deadline
+  cannot release either transaction while a non-cancellable config/store write
+  or owned probe tree is still live; its mandatory join is an ownership cleanup
+  tail rather than detached restart work.
 - A busy result is a completed, retryable business response. It is not
   `memory_restart_failed`, starts no background task, ends the UI spinner, and
   displays a localized reason.
@@ -382,6 +391,20 @@ Add a private semantic helper such as `begin_replacement_activation()` that
 creates a new UUID lease owner and then reuses `begin_activation()`. Do not
 change MemoryStore or its recovery SQL.
 
+Make `begin_activation()` create and return a generation-specific completion
+future. `_recover_activation()` resolves that exact future only after
+`recover_after_boot()`, interrupted-flush handling, metadata reads, and fault
+classification all finish. Before the drain loop retries a failed activation,
+it rejects the failed generation's future with the original exception and then
+creates the next generation; cancellation rejects it as well. A done callback
+consumes every terminal exception so an ordinary retry generation with no waiter
+cannot emit an unobserved-future warning. `_ensure_worker()` accepts and reuses a
+prepared activation future, creating one only for ordinary callers, and returns
+the exact future associated with the worker task instead of using task existence
+or liveness as success evidence. Explicit restart and automatic ready activation
+keep claims paused, await their exact future under the worker activation bound,
+and resume claims only after it resolves successfully.
+
 Make `_store_call()` create an explicit task for `asyncio.to_thread()` and await
 it under `shield()`. Keep every unfinished task in a private worker registry;
 task cancellation must leave the underlying store task live and discoverable.
@@ -397,7 +420,7 @@ The locked sequence is fixed:
 1. Snapshot the last-good `_restart_config` and recover an interrupted clear.
    Validate store and artifact availability only when that replay is enabled.
    Do not reject solely because the persisted candidate is enabled while the
-   replay is disabled; the replay state is authoritative after step 8
+   replay is disabled; the replay state is authoritative after step 9
    convergence and needs no launch prerequisites.
 2. Before touching the worker, call a non-awaiting, idempotent supervisor handoff
    fence on the old `EverOSProcess`. It sets `_desired_running=false`, marks ready
@@ -410,7 +433,7 @@ The locked sequence is fixed:
    process-owner settlement bound: cancel and join idle watcher/monitor tasks,
    or retain and join the one already performing child cleanup. An active start
    may finish launching a transient child, but generation-fenced activation
-   cannot resume claims and step 9 will stop it. If either retained start or
+   cannot resume claims and step 10 will stop it. If either retained start or
    lifecycle owner outlives its bound, keep its exact references and claims
    fenced, then return fail-closed without rotating the lease or invoking
    `stop()` beside it. A retry rejoins those same tasks first.
@@ -426,10 +449,19 @@ The locked sequence is fixed:
    entry, the old lease, and every existing process reference; keep claims
    fenced and return fail-closed. A retry rejoins the same store task before it
    can proceed.
-7. Rotate the lease owner only after the supervisor, process owners, drain task,
-   and store-task registry are all confirmed quiescent, and before any new
-   activation.
-8. Run config convergence while claims are fenced and the old worker is stopped.
+7. Ask the old supervisor to settle every retained processing-probe tree under
+   the probe-settlement bound. `processing_healthy()` registers the exact probe,
+   process group, and owned-process snapshot immediately after spawn returns and
+   before awaiting probe completion; any cleanup task is recorded before its
+   first cleanup await. It removes that record only after complete reap.
+   Cancellation or failed cleanup keeps the record on the supervisor. If
+   settlement cannot prove every tree reaped, retain those records and the old
+   supervisor, keep claims fenced, and return fail-closed. A retry settles the
+   same owners first.
+8. Rotate the lease owner only after the supervisor, process owners, drain task,
+   store-task registry, and probe registry are all confirmed quiescent, and
+   before any new activation.
+9. Run config convergence while claims are fenced and the old worker is stopped.
    When `_restart_config` has `embedding_change_pending`, run the root guard
    first and clear the marker in the replay block. The transaction must replace
    only the expected persisted Memory block with replay C0, preserving every
@@ -446,18 +478,21 @@ The locked sequence is fixed:
    `Controller.config.memory`, and the UI's mandatory success reload switches to
    the authoritative disabled settings. A stop error remains fail-closed and
    cannot report disabled success.
-9. Stop the old process. Do not discard its supervisor or start another child
+10. Stop the old process. Do not discard its supervisor or start another child
    until its process tree is confirmed reaped.
-10. If the converged replay is disabled, return the recorded disabled state
+11. If the converged replay is disabled, return the recorded disabled state
    without creating a replacement child, activation task, or worker. Otherwise,
    create a process from `_restart_config` bound to the lifecycle generation
    captured when restart entered its critical section. Its explicit initial
-   `start()` suppresses the automatic ready callback: while restart still owns
-   `_reconcile_lock -> module._lifecycle_lock`, runtime itself resumes claims,
-   starts the worker, and verifies `_worker_task` exists and is not done. An
-   activation exception runs bounded replacement cleanup, keeps claims fenced,
-   and cannot report ready. Return `{ok: true, state: 'ready'}` only after this
-   explicit activation succeeds.
+   `start()` suppresses the automatic ready callback. While restart still owns
+   `_reconcile_lock -> module._lifecycle_lock`, keep claims paused, call
+   `begin_replacement_activation()`, start the worker, and await that exact
+   activation-generation future under the worker-activation bound. Only after
+   it resolves may runtime resume claims. Rejection or timeout cancels and joins
+   the new worker, settles its store calls and processing probes, then stops the
+   replacement under the distinct replacement-activation cleanup allowance.
+   Any cleanup owner that outlives its bound is retained fail-closed. Return
+   `{ok: true, state: 'ready'}` only after real activation succeeds.
 
 Automatic retries use a separate nonblocking ready notification. The callback
 captures process identity and lifecycle generation, schedules one retained
@@ -465,7 +500,9 @@ runtime activation task, and returns without taking runtime locks, so it cannot
 deadlock `_start_locked()` with a caller already holding them. The activation
 task acquires `_reconcile_lock -> module._lifecycle_lock`, then verifies that the
 runtime is enabled, the process is still current and ready, the generation is
-unchanged, and no explicit restart or artifact installation owns admission.
+unchanged, and no explicit restart or artifact installation owns admission. It
+then keeps claims paused and awaits the worker's exact activation-generation
+future under the same worker-activation bound before resuming them.
 Every Clear, reconcile, artifact activation, restart, and close operation bumps
 the generation at its serialized lifecycle entry, before its first lifecycle
 await, and uses that value for any process it creates. Consequently an
@@ -508,6 +545,12 @@ Every exit after claims are fenced must end in one of these states:
   A retry awaits the same task under another bounded interval. It cannot run
   recovery, rotate the lease, or touch process ownership until the thread has
   returned and its terminal result has been consumed.
+- **A processing-probe tree outlives cancellation or cleanup:** retain its exact
+  probe/process-group/owned-process record and cleanup owner on the supervisor,
+  retain the current lease, and keep claims fenced. Restart returns
+  `memory_restart_failed` without stopping or replacing the supervised child
+  beside that credential-bearing tree. A retry reapplies the bounded settlement
+  to the same record and cannot proceed until the registry is empty.
 - **Failure before `old_process.stop()` is invoked:** the old supervisor still
   owns its child but is quiesced. A live PID is not evidence that the UDS health
   endpoint is ready, so never resume claims or the worker from `running` alone.
@@ -532,10 +575,13 @@ Every exit after claims are fenced must end in one of these states:
   may resume them only after coordinating with both lifecycle locks and proving
   it is still current. With no supervisor, the user can click restart again.
 - **The replacement reaches health but explicit activation fails:** treat this
-  as startup failure. Restart directly observes the exception, runs the same
-  bounded child cleanup, keeps claims fenced, and cannot report `ready`. A later
-  automatic ready activation that fails records the visible runtime error and
-  likewise leaves claims fenced.
+  as startup failure. Restart directly observes rejection of the exact
+  activation-generation future, keeps claims fenced, cancels and joins the new
+  worker, settles its store calls and probe trees, then stops the replacement
+  under the separate replacement-activation cleanup allowance. Retain any owner
+  that outlives its bound and never report `ready`. A later automatic ready
+  activation that fails records the visible runtime error and likewise leaves
+  claims fenced.
 
 `CancelledError` is re-raised after ownership and claims cleanup; it is never
 reported as a business failure. Fix `_stop_worker()` so it swallows only the
@@ -544,7 +590,9 @@ task itself propagates. Restart uses shielded cleanup to settle the worker store
 registry and reach one of the states above. If cancellation lands after a new
 child is spawned but before its watcher or monitor exists, shield
 `new_process.stop()`: clear `_process` only after successful reap; otherwise
-retain the supervisor reference and keep claims fenced.
+retain the supervisor reference and keep claims fenced. The same shielded cleanup
+retains incomplete processing-probe owners rather than dropping their local
+references when cancellation is re-raised.
 
 `start()` returning `False` keeps the specific
 `memory_sidecar_unavailable`. Stop, factory, and other restart orchestration
@@ -580,9 +628,10 @@ exceptions use the transport-only `memory_restart_failed`.
    persisted snapshot after every successful runtime-owned V2 mutation and
    rebase a successfully reconciled
    live/replay candidate from marker settlement's exact return; conditionally
-   converge disk to replay before launch; retain worker/store tasks that outlive
-   cancellation; reject restart while artifact installation is active; make only
-   explicit restart admission fail fast. Make `restart()` return its transport
+   converge disk to replay before launch; await the exact worker-activation
+   generation and retain worker/store/probe owners that outlive cancellation;
+   reject restart while artifact installation is active; make only explicit
+   restart admission fail fast. Make `restart()` return its transport
    result plus the exact applied replay config on ready/disabled success and no
    config on busy/failure. Add `reconcile_persisted()` to return the exact
    successful candidate alongside the transport result while ordinary
@@ -595,14 +644,17 @@ exceptions use the transport-only `memory_restart_failed`.
    the synchronous lifecycle-intent scope and `lifecycle_busy` property covering
    active and queued search, profile, Clear, and recovery operations.
 4. `core/memory/worker.py`: retain and shield explicit store-thread tasks, expose
-   bounded settlement, and rotate the lease owner only after their registry is
+   bounded settlement, make activation return a generation-specific completion
+   future, and rotate the lease owner only after prior ownership registries are
    empty.
 5. `core/memory/process.py`: expose complete stop/start and process-owner
    settlement budget helpers, put one cap around all orphan-reap rounds, add the
    explicit-handoff supervisor fence, distinguish idle watcher/monitor tasks
    from active cleanup owners with narrow phase flags, hard-cap the complete
-   readiness operation, rebind re-armed ready callbacks to the current
-   generation, and support callback-suppressed explicit start.
+   readiness operation, retain processing-probe trees and cleanup owners until
+   reaped, expose their settlement and the separate replacement-activation
+   cleanup budget, rebind re-armed ready callbacks to the current generation,
+   and support callback-suppressed explicit start.
 6. `core/controller.py` / `core/internal_server.py`: add a controller-owned
    restart wrapper and `POST /internal/memory/restart`. On ready or disabled
    success, install a deep copy of the exact applied config returned by Runtime
@@ -657,6 +709,9 @@ exceptions use the transport-only `memory_restart_failed`.
 
 - `tests/test_memory_runtime.py`
   - Successful restart confirms old stop, new ready child, and worker recovery.
+    Pause real `recover_after_boot()` after worker task creation and prove restart
+    retains both lifecycle locks, keeps claims paused, and cannot report ready
+    until the exact activation-generation future resolves.
   - After failed C1 reconcile and failed rollback, restart replays last-good C0;
     the uncontended operation remains inside both lifecycle locks and
     conditionally replaces the expected persisted C1 Memory block with C0 while
@@ -695,6 +750,11 @@ exceptions use the transport-only `memory_restart_failed`.
     registered. Restart retains the old lease and process without running
     recovery; after the thread is released, retry joins it and only then rotates
     and recovers.
+  - Cancel a drain task inside a real supervised processing probe and make its
+    first termination round fail. The terminal worker task is insufficient for
+    restart admission: the exact probe-tree record remains on the supervisor,
+    claims and lease stay fenced, and no process replacement occurs. A retry
+    reaps that same record before continuing.
   - If the old child exits during the five-second drain grace, its supervisor is
     already quiesced: no automatic restart can schedule ready activation, resume
     claims, or replace `_worker_task`. Pre-stop failure beside an alive but
@@ -728,9 +788,11 @@ exceptions use the transport-only `memory_restart_failed`.
   - Disabled, `start() is False`, factory exception, explicit activation
     exception, automatic activation exception, failed-start cleanup, and stop
     exception cases assert error codes, supervisor ownership, claims/worker
-    fencing, and no double child. An activation exception cannot report ready; a
-    stop exception followed by child exit must not auto-restart or report
-    restored claims.
+    fencing, and no double child. Drive explicit activation failure through real
+    worker recovery after task creation; its rejected future cannot report ready,
+    and replacement worker/store/probe settlement plus a complete process stop
+    fit the distinct cleanup allowance. A stop exception followed by child exit
+    must not auto-restart or report restored claims.
   - Cancellation while stopping the worker and after a new child is spawned
     reaches the documented cleanup state and re-raises `CancelledError`.
 - `tests/test_memory_slice3.py`: a successful persisted reconcile that settles
@@ -743,10 +805,11 @@ exceptions use the transport-only `memory_restart_failed`.
 - `tests/test_internal_client.py` / `tests/test_internal_client_timeouts.py`:
   POST and busy response passthrough; deadline computed from both clear phases,
   automatic-supervisor start settlement, watcher/monitor owner settlement,
-  worker and store-task bounds, a distinct old stop retry, the outer all-round
-  orphan-reap cap, readiness, and failed-start cleanup. On reporting timeout or
-  caller cancellation, the retained request is joined before its caller can
-  release transaction ownership.
+  worker, store-task, and processing-probe bounds, a distinct old stop retry, the
+  outer all-round orphan-reap cap, readiness, failed-start cleanup, explicit
+  worker activation, and a separate complete replacement-activation cleanup
+  allowance. On reporting timeout or caller cancellation, the retained request
+  is joined before its caller can release transaction ownership.
 - `tests/test_ui_memory_routes.py`: new client path, internal unavailable,
   cross-origin rejection, restart/settings serialization, timed-out settlement
   ownership, unrelated-field retention, and failed-Memory-C1 convergence to C0.
@@ -770,12 +833,17 @@ exceptions use the transport-only `memory_restart_failed`.
 - `tests/test_memory_worker.py`: `_store_call()` shields and retains its explicit
   thread task across drain cancellation. `settle_store_calls()` times out without
   cancelling the thread, retains it for retry, consumes its terminal result, and
-  reports quiescence only after the registry is empty.
+  reports quiescence only after the registry is empty. Activation generations
+  resolve only after full recovery, reject with the real recovery error before
+  retry creates a new generation, and reject on cancellation.
 - `tests/test_memory_process.py`: stale recorded leader plus late helper and
   multiple unusable-record anchors share one outer reap deadline. Timeout keeps
   the record and prevents child launch. Idle watcher/monitor tasks cancel and
   join during handoff; active cleanup owners are retained and settle under the
-  exported owner budget. Explicit start suppresses automatic ready notification.
+  exported owner budget. A cancelled processing probe whose termination fails
+  retains its exact tree and cleanup owner; settlement retries that record and
+  reports quiescence only after reap. Explicit start suppresses automatic ready
+  notification.
   A socket that appears just before the readiness deadline with a stalled health
   response cannot extend `_wait_for_ready()` beyond its outer cap, and the
   separately budgeted failed-start cleanup still runs.

--- a/docs/plans/memory-sidecar-force-restart-button.md
+++ b/docs/plans/memory-sidecar-force-restart-button.md
@@ -1,6 +1,6 @@
-# Add a forced sidecar restart action to Memory settings (rev17)
+# Add a forced sidecar restart action to Memory settings (rev18)
 
-> Rev17 keeps one public recovery action and a focused set of internal fixes:
+> Rev18 keeps one public recovery action and a focused set of internal fixes:
 > replayable configuration, config-wide write serialization, restart-specific
 > and lifecycle-intent admission, generation-fenced ready activation, complete
 > supervisor quiescing, bounded orphan recovery, disk/live replay convergence,
@@ -9,8 +9,9 @@
 > authoritative controller/UI settings refresh, queued-operation exclusion, and
 > disabled/fail-closed replay handling, explicit worker activation, post-lock
 > retained-owner admission, complete root/installer/probe ownership, lifecycle
-> abort reactivation, store-unavailable retry, shutdown joining, and disabled
-> recovery projection alongside processing-probe/module-store ownership.
+> abort reactivation, under-lock generation changes, retained config writers,
+> store-unavailable retry, shutdown joining, and durable retry eligibility
+> alongside processing-probe/module-store ownership.
 > Timed-out work remains owned until it is either joined or proven unable to
 > mutate state. It does not add a lifecycle coordinator, explicit state machine,
 > provider/store port, or frontend DOM test framework.
@@ -226,10 +227,21 @@ Memory-only serialization is insufficient.
   fields into the transaction's freshly loaded working object.
 - Every asynchronous caller, including controller-side IM settings, model-hub,
   agent-auth, startup/runtime, and UI/server paths, offloads the complete
-  `mutate_v2_config()` call to one `asyncio.to_thread()` invocation. No async
-  caller may acquire the synchronous file lock or run load/merge/save inline on
-  its event loop. Awaited external I/O happens before the transaction; the
-  synchronous mutator then revalidates against the freshly loaded state.
+  `mutate_v2_config()` call to one named `asyncio.to_thread()` task and awaits it
+  through `shield()`. No async caller may acquire the synchronous file lock or
+  run load/merge/save inline on its event loop. Caller cancellation retains and
+  joins that exact task before releasing the caller's route/service intent or
+  lock, then re-raises only after any required post-commit work finishes. Awaited
+  external I/O happens before the transaction; the synchronous mutator then
+  revalidates against the freshly loaded state.
+- In particular, Memory PATCH keeps `_memory_settings_write_pending_count` and
+  `_memory_settings_write_lock()` owned across the shielded writer task and, if
+  the thread committed, its complete controller reconcile or rollback even when
+  the HTTP request was cancelled. Cancellation is remembered, not allowed to
+  skip live convergence: after disk/live state reaches the same terminal result,
+  re-raise `CancelledError` and only then decrement/release admission. A failed
+  writer that committed nothing needs no reconcile but is still joined before
+  ownership is released.
 - Controller convergence uses that mutation API, compares the fresh working
   object's complete Memory block with `_persisted_memory_snapshot`, then replaces
   only that block with `_restart_config` and clears its marker when the root
@@ -263,6 +275,12 @@ deadline. In the expired case, prove the request and transaction locks remain
 owned until the retained thread finishes. Both writers must then preserve the
 settled marker and the generic writer's unrelated C1 fields without either side
 publishing a stale whole-document snapshot.
+Cancel a Memory PATCH while its real config mutation thread is blocked before
+commit, then release it. Prove the pending count and settings lock stay owned,
+restart remains busy, and a committed C1 still completes controller reconcile or
+rollback before cancellation is re-raised; disk and live Runtime cannot split.
+Apply the same shield/join assertion to a representative non-Memory async writer,
+which may release its service intent only after the exact mutation task ends.
 For a failed Memory C1 plus failed UI rollback, prove restart conditionally
 replaces only the expected C1 Memory block with replay C0 before reporting ready;
 settings reads and a fresh `V2Config.load()` must match the live runtime. An
@@ -586,9 +604,12 @@ runtime is enabled, the process is still current and ready, the generation is
 unchanged, and no explicit restart or artifact installation owns admission. It
 then keeps claims paused and awaits the worker's exact activation-generation
 future under the same worker-activation bound before resuming them.
-Every Clear, reconcile, artifact activation, restart, and close operation bumps
-the generation at its serialized lifecycle entry, before its first lifecycle
-await, and uses that value for any process it creates. Consequently an
+Every Clear, reconcile, artifact activation, restart, and close operation first
+registers its synchronous pending intent, then acquires the established
+`_reconcile_lock -> module._lifecycle_lock` order. Only after both locks are held,
+with no intervening await before the update, does it bump the generation and use
+that value for any process it creates. A waiter cancelled before lock ownership
+therefore cannot invalidate the active lifecycle. Consequently an
 activation delayed behind later lifecycle work observes a stale token and exits
 without resuming claims or creating a worker. Current-generation activation
 failures set the visible runtime error and leave claims fenced; task completion
@@ -737,14 +758,18 @@ exceptions use the transport-only `memory_restart_failed`.
    the target path and working object to an opaque session token, derive one
    lock per normalized default/custom path, always acquire that file lock before
    `CONFIG_LOCK`, and offload the complete mutation from every asynchronous
-   caller.
+   caller through a shared shielded task helper that joins cancellation before
+   releasing caller intent. Memory PATCH additionally finishes reconcile or
+   rollback after a committed cancelled write while its route lock/count remain
+   owned.
 2. `core/memory/runtime.py`: add `_restart_config`,
    `_persisted_memory_snapshot`, `_explicit_restart_active`,
    `_clear_pending_count`, `_reconcile_pending_count`,
    `_retained_ownership_active`, a retained artifact-install task, a Runtime
    preflight-supervisor registry, lifecycle generation, the active explicit
    restart task, and a retained ready activation task, and fail-fast `restart()`;
-   recheck retained ownership under acquired lifecycle locks; refresh the
+   recheck retained ownership and bump lifecycle generation only under acquired
+   lifecycle locks; refresh the
    persisted snapshot after every successful runtime-owned V2 mutation and
    rebase a successfully reconciled
    live/replay candidate from marker settlement's exact return; conditionally
@@ -833,8 +858,14 @@ exceptions use the transport-only `memory_restart_failed`.
    settings reload. After a failed operation, show its localized reason plus
    literal error code only after the required reload settles; when no config was
    committed, keep the existing settings payload and use the generic fallback
-   when no code exists. Also render the same single recovery action when either
-   the latest restart response or pure runtime status reports
+   when no code exists. Before invalidating an enabled settings payload, preserve
+   a separate non-editable `restartRetryEligible` bit. Keep it through a failed
+   authoritative settings reload so a `config_committed=true` lifecycle failure
+   cannot remove the only retry action. Clear it only when a successful settings
+   reload, together with status/restart recovery projection, proves Memory is
+   disabled with no retained owner; a read error or absent payload is not proof
+   of disablement. Also render the same single recovery action when this bit is
+   set, or when the latest restart response or pure runtime status reports
    `restart_recovery_required=true`, even if the authoritative settings reload
    now says disabled. Retain that local flag across the required settings/status
    refresh and clear it only when a successful retry or a later status proves no
@@ -960,6 +991,10 @@ exceptions use the transport-only `memory_restart_failed`.
     and ready, its abort compensation rebinds current generation and completes
     locked worker activation before releasing claims. A stale callback alone
     cannot strand draining; a changed/unready supervisor remains fenced.
+    Start a second lifecycle operation while the first owns both locks, then
+    cancel the waiter before acquisition. The generation must remain unchanged;
+    the first operation's supervisor callback stays current and activates
+    normally, and abort compensation is never invoked for the non-owner.
   - The old watcher or safety monitor enters child-tree cleanup immediately
     before restart. Handoff joins that exact owner under the process-owner bound
     before calling `stop()`; timeout stays fail-closed, and the successful case
@@ -1026,6 +1061,9 @@ exceptions use the transport-only `memory_restart_failed`.
   busy without acquiring the lock. After every writer exits, restart may acquire
   admission normally. A `config_committed=true` failure invalidates C1 and reloads
   C0 before showing the lifecycle error; a pre-convergence failure keeps C1.
+  Cancellation during the off-thread Memory mutation retains the pending count
+  and route lock through writer completion plus reconcile/rollback, then
+  re-raises without leaving disk and Runtime split.
 - `tests/test_v2_config.py` / config route tests: a generic non-Memory save in a
   second process waits before loading while settlement owns the config
   transaction, then preserves both its C1 change and the cleared marker. Saving
@@ -1082,8 +1120,11 @@ exceptions use the transport-only `memory_restart_failed`.
   preserves C1. When that C0 is disabled but cleanup is retained, prove the one
   recovery action remains after settings/status reload and disappears only after
   a successful retry or status clears the recovery flag. Ordinary disabled state
-  still renders no action. Keep click/toast behavior in the single manual
-  scenario below.
+  still renders no action. For an enabled `config_committed=true` lifecycle
+  failure followed by settings reload failure, the editable payload remains
+  absent but `restartRetryEligible` keeps exactly one retry action until a later
+  authoritative disabled/no-owner result clears it. Keep click/toast behavior in
+  the single manual scenario below.
 
 ## Validation
 
@@ -1111,8 +1152,9 @@ failed candidates cannot replace last-good config, and successful replay must
 conditionally converge the known persisted Memory block to that same config;
 config mutation cannot race any whole-file V2 writer, start from an unlocked
 baseline, lose a custom target path, hold `CONFIG_LOCK` during a file-lock wait,
-block an async event loop, or outlive its transaction; every successful
-runtime-owned mutation refreshes the exact persisted snapshot and successful
+block an async event loop, or outlive its caller intent; cancelled Memory writers
+finish required live reconcile/rollback before route ownership ends; every
+successful runtime-owned mutation refreshes the exact persisted snapshot and successful
 settlement propagates the same exact block into controller shared config;
 explicit restart cannot queue behind or leapfrog any active or queued module
 lifecycle operation, while reads and destructive Clear retain their existing
@@ -1124,7 +1166,8 @@ recovery has one complete cap; every active process lifecycle
 owner is settled and budgeted before stop; readiness, including the final health
 request, has one hard cap; delayed automatic activation and re-armed supervision
 are bound to the current lifecycle generation and both runtime locks, with locked
-abort compensation for an unchanged ready supervisor; pending
+generation updates that exclude cancelled waiters and abort compensation for an
+unchanged ready supervisor; pending
 embeddings cannot bypass the root guard or remain in a successful replay
 snapshot; claimed rows require a new lease only after the old worker and every
 shielded worker/module store thread exit; activation success is observable and
@@ -1133,8 +1176,9 @@ still propagates the committed block to Controller and UI; retained ownership
 excludes every other mutating lifecycle; replacement cleanup fences supervision
 before awaiting; disabled retained cleanup keeps its explicit recovery action;
 Runtime retains throwaway preflight supervisors; shutdown joins active restart
-ownership beyond the generic five-second close; and clear markers serialize with
-root/child lifecycle. The
+ownership beyond the generic five-second close; enabled retry eligibility survives
+settings invalidation/read failure; and clear markers serialize with root/child
+lifecycle. The
 implementation adds two private snapshots, focused intent counters, one narrow
 retained-owner gate, focused helpers, and two precise transport-only error codes
 while reusing existing locks, guards, recovery SQL, supervision, and UI
@@ -1152,6 +1196,7 @@ implementation appears to require one, revise this plan before expanding scope.
 - [ ] Settings/restart serialization and stale-C0 overwrite regression
 - [ ] Path-aware token-bound config mutation and custom-target regression
 - [ ] File-lock-first order, async writers off-thread, inline-reader responsiveness
+- [ ] Shielded async config-writer cancellation and Memory live convergence
 - [ ] Timed-out settlement ownership and retained-request regression
 - [ ] Worker lease rotation and add/flush recovery tests
 - [ ] Retained worker cancellation fail-closed state and retry
@@ -1167,6 +1212,7 @@ implementation appears to require one, revise this plan before expanding scope.
 - [ ] Runtime-owned preflight-probe supervisors and cancellation settlement
 - [ ] Supervisor handoff/rebind, lifecycle-owner settlement, readiness/deadline contract
 - [ ] Lifecycle-generation ready activation and Clear/reconcile race regression
+- [ ] Under-lock generation bump and cancelled-waiter regression
 - [ ] Lifecycle-abort compensation for unchanged ready supervisor activation
 - [ ] Complete orphan/start budgets, explicit activation, failed-start cleanup
 - [ ] Shielded activation handshake and fenced replacement-activation cleanup
@@ -1174,5 +1220,6 @@ implementation appears to require one, revise this plan before expanding scope.
 - [ ] UI route and response normalizer
 - [ ] Page action, deduplicated banner, success/failure settings reload, toast/i18n
 - [ ] Disabled retained-cleanup recovery projection and persistent retry action
+- [ ] Known-enabled retry eligibility across authoritative reload failure
 - [ ] Memory-specific shutdown allowance and active-restart ownership join
 - [ ] Focused Python/TypeScript validation and Incus `SIGSTOP` scenario

--- a/docs/plans/memory-sidecar-force-restart-button.md
+++ b/docs/plans/memory-sidecar-force-restart-button.md
@@ -1,27 +1,47 @@
-# Memory 设置页增加 sidecar 强制重启按钮（rev4）
+# Add a forced sidecar restart action to Memory settings (rev5)
 
-> rev4 根据整体 review 收敛为一个公开入口和四个很小的内部修正：重启配置快照、
-> lifecycle busy 快速失败、worker lease 轮换、clear marker 的锁内恢复。不新增
-> lifecycle coordinator、状态机、provider/store port 或前端 DOM 测试框架。
+> Rev5 keeps one public recovery action and a small set of internal fixes:
+> replayable configuration, settings transaction serialization, fail-fast
+> lifecycle admission, worker lease rotation, and locked clear-marker recovery.
+> It does not add a lifecycle coordinator, explicit state machine, provider/store
+> port, or frontend DOM test framework.
 
-## 背景与目标
+## Background and goals
 
-当 Memory 状态为 `down` / `memory_sidecar_unavailable` 时，Web UI 没有恢复入口：当前重启按钮只出现在 `processing_fault_kind === 'engine'` 的横幅中。与此同时，`EverOSProcess` 只会在子进程退出或启动失败后自动拉起；“进程仍存活但 UDS/health 不可达”不会自动替换进程。
+When Memory reports `down` or `memory_sidecar_unavailable`, the Web UI has no
+general recovery action. The current restart button appears only in the
+`processing_fault_kind === 'engine'` banner. `EverOSProcess` also restarts only
+after a child exits or fails to start; it does not replace a process that is
+still alive while its UDS or health endpoint is unreachable.
 
-本需求只做两件事：
+This change has two goals:
 
-1. Memory 已启用时，在 setup-stage 分支之外的 Status 动作区始终提供“重启引擎”按钮；即使依赖 API 报告 runtime 未安装、status 尚未加载或读取失败，也不能隐藏入口。
-2. 点击后由 controller 强制停止旧 sidecar 并等待新 sidecar `ready`，不重启 Avibe 主进程、不重装 runtime、不从磁盘重新选择 restart 目标配置，也不做 processing 预探测。若启动快照仍带 durable embedding-change marker，则必须先完成既有 root 兼容性检查，并允许 settlement 为核对/清除 marker 读取持久化配置。
+1. When Memory is enabled, always show a "Restart engine" action outside the
+   setup-stage branch. A missing runtime dependency, an unloaded status, or a
+   failed status read must not hide it.
+2. Make the controller stop the old sidecar and wait for a replacement to reach
+   `ready`. Do not restart Avibe, reinstall the runtime, reload a restart target
+   from disk, or run a processing preflight probe. If the replay snapshot still
+   carries the durable embedding-change marker, run the existing root safety
+   check and allow settlement to verify and clear that marker before launch.
 
-非目标：自动健康重启、重做全部 Memory lifecycle、改变 provider/store 协议、重试历史 `unknown` flush、四平台全量回归。
+Non-goals: automatic health-based restart, a complete Memory lifecycle rewrite,
+provider/store protocol changes, retries for historical `unknown` flushes, and
+a full four-platform regression.
 
-## 为什么不能继续复用 reconcile
+## Why reconcile is not sufficient
 
-- Settings PATCH 与旧 restart 路径分别加载配置，存在 C0/C1 交错，可能把磁盘和 live 配置拆开。
-- reconcile 会先等待最长 30 秒的 worker drain，再做 processing probe；长 flush 最长 300 秒，因此它既不满足“5 秒后强制”的产品语义，也可能因无关的 probe 故障拒绝重启。
-- `self._config` 不是可靠的“最后成功配置”：enabled reconcile 会在 root 校验和新进程启动完成前写入候选；候选及 UI rollback 都失败后，它可能仍指向失败的 C1。
+- Settings PATCH and the old restart route load configuration separately. A
+  C0/C1 interleaving can split persisted and live configuration.
+- Reconcile can wait up to 30 seconds for worker drain and then run a processing
+  probe. A long flush can take up to 300 seconds. That does not provide the
+  requested "force after five seconds" behavior, and an unrelated probe failure
+  can reject the recovery.
+- `self._config` is not the last known-good configuration. Enabled reconcile
+  assigns a candidate before root validation and replacement startup complete.
+  If both the candidate and UI rollback fail, it can still point at failed C1.
 
-因此保留现有 UI 路径 `/api/memory/runtime/restart`，但后端改走专用的 `MemoryRuntime.restart()`。
+Keep the existing public route, but make it call a dedicated runtime operation:
 
 ```text
 UI
@@ -31,143 +51,317 @@ UI
   -> MemoryRuntime.restart()
 ```
 
-## 最小后端设计
+## Minimal backend design
 
-### 1. 可重放配置快照
+### 1. Replayable configuration snapshot
 
-在 `MemoryRuntime` 增加私有 `_restart_config`：
+Add a private `_restart_config` to `MemoryRuntime`:
 
-- 初始化为启动时 `MemoryConfig` 的深拷贝，使首次启动失败后仍可人工重试同一份配置。
-- 只在 enabled 或 disabled reconcile **成功结束**时，在 `_reconcile_lock` 内更新为深拷贝。
-- 失败候选不能更新它。之所以必须深拷贝，是因为 `MemoryConfig` 及其嵌套配置可变，`embedding_change_pending` 也会在运行时被修改。
-- `restart()` 在 `_reconcile_lock` 内读取其深拷贝，并在 safety guard 通过后、替换进程前同步恢复 `self._config`；这样 worker 的 `enabled` callback 和新 child settings 都不会继续使用失败候选。
-- 启动时的初始快照可能带 `embedding_change_pending=true`。restart 必须复用 reconcile 的 embedding/root safety guard，并只在 guard 成功且 marker settlement 成功后继续；有旧向量数据或 root 状态不可判定时返回 `memory_clear_failed`，不得强行启动。settlement 核对持久化配置仍与快照相同后，将磁盘、`_restart_config` 和随后恢复的 `self._config` 三处 marker 同步为 `false`，不改变其他配置；这里不运行 processing probe。
+- Initialize it as a deep copy of the startup `MemoryConfig`, so a first-start
+  failure can still be retried with the same configuration.
+- Update it with another deep copy only when enabled or disabled reconcile has
+  completed successfully, while `_reconcile_lock` is held.
+- Never commit a failed candidate. A deep copy is required because
+  `MemoryConfig`, its nested settings, and `embedding_change_pending` are
+  mutable.
+- `restart()` reads a deep copy while holding `_reconcile_lock`. After all
+  safety checks pass and before process replacement, it restores `self._config`
+  from that copy so worker callbacks and child settings cannot keep using C1.
+- A startup snapshot may have `embedding_change_pending=true`. Restart reuses
+  the reconcile embedding/root guard and proceeds only after both the guard and
+  marker settlement succeed. Existing vectors or an indeterminate root return
+  `memory_clear_failed` without launching a child. Successful settlement clears
+  the marker in persisted config, `_restart_config`, and the later restored
+  `self._config`, without changing any other Memory field. It does not run the
+  processing probe.
 
-这个字段只回答“人工 restart 应重放哪份配置”，不重新定义现有 `_config`，也不引入配置版本模型。
+This field answers only which configuration an explicit restart replays. It
+does not redefine `_config` or introduce configuration versioning.
 
-### 2. clear marker 与进程替换原子化
+### 2. Clear-marker and replacement atomicity
 
-现有 `_recover_interrupted_clear()` 在取得 module lifecycle lock 前检查 `_clear_active`。并发 clear 若在这个间隙失败并留下 durable marker，restart/reconcile 可能随后启动 child 而不再检查 marker。
+`_recover_interrupted_clear()` currently checks `_clear_active` before taking
+the module lifecycle lock. A concurrent clear can fail in that gap, leave a
+durable marker, and let restart or reconcile launch a child without rechecking.
 
-最小修正：
+Make the following narrow change:
 
-- 从现有方法抽出 `_recover_interrupted_clear_locked()`；调用方必须已持有 `module._lifecycle_lock`，方法内部再按现有顺序取得 root lifecycle lock 并重新读取 durable marker。
-- 原 `_recover_interrupted_clear()` 保留为 wrapper，供 search/profile/status 等调用；它继续保留 active clear 时的快速返回，维持 read 路径现有的立即失败/`clearing` 行为。
-- `reconcile()`、artifact activation 和新 `restart()` 都按 `_reconcile_lock -> module._lifecycle_lock -> root lifecycle lock` 的既有顺序，在同一 lifecycle 临界区内完成 marker 恢复和 child replacement。
-- 新的 locked helper 自身不做 `_clear_active` 快速返回；持有 lifecycle lock 时不会与 active clear 并行，因此必须重新读取并处理 durable marker。
+- Extract `_recover_interrupted_clear_locked()`. Its caller must already hold
+  `module._lifecycle_lock`; it then takes the root lifecycle lock in the existing
+  order and rereads the durable marker.
+- Keep `_recover_interrupted_clear()` as the wrapper used by search, profile,
+  and status. It retains the active-clear fast return and the existing immediate
+  failure or `clearing` behavior on read paths.
+- Reconcile, artifact activation, and restart use the existing order
+  `_reconcile_lock -> module._lifecycle_lock -> root lifecycle lock` and perform
+  marker recovery and child replacement in one lifecycle critical section.
+- The locked helper has no `_clear_active` fast return. Once the lifecycle lock
+  is held, it cannot overlap an active clear and must reread the marker.
 
-这只是消除现有 check/use 窗口，不新建通用 lifecycle coordinator。
+This closes the existing check/use window without creating a general lifecycle
+coordinator.
 
-### 3. 不排队的 restart 入口与有界 deadline
+### 3. Serialize settlement with Memory settings writes
 
-显式 restart 不能排在另一个 lifecycle 操作后面静默等待。否则 transport 可能先超时，controller 随后仍执行已经失去调用方的 restart，用户重试还会再排入一次。
+`CONFIG_LOCK` is process-local: the controller's compare-and-save cannot, by
+itself, exclude a Memory PATCH running in the UI process. The public restart
+route must therefore participate in the UI process's existing settings
+transaction.
 
-- `restart()` 在任何 await 之前检查 `_reconcile_lock` 和 `module._lifecycle_lock`；任一已占用就立即返回 `{ok: false, error: 'memory_restart_busy'}`，不进入 lock waiter 队列，也不修改 process、claims 或 worker。
-- 两把锁都空闲时，在同一 event-loop turn 内按 `_reconcile_lock -> module._lifecycle_lock` 立即取得它们，中间不执行其他 await。这样并发 restart、Settings PATCH、artifact activation 和 clear 只有一个 owner；已有 reconcile/clear 保持原语义，只有人工 restart 使用 fail-fast 契约。
-- interrupted-clear recovery 和条件性的 embedding/root guard 复用 `CLEAR_CLEANUP_TIMEOUT_SECONDS` 作为上界。restart transport deadline 必须严格大于 `clear recovery/guard bound + 5s worker grace + process stop 的 TERM/KILL 两轮上界 + process startup bound`；测试直接从这些源常量计算，不复制注释里的数字。
-- lock-busy 是一个已完成、可重试的业务响应，不是 `memory_restart_failed`，也不能启动后台 task。前端显示本地化 busy 原因并结束 spinner。
+- Before calling `internal_client.memory_restart()`, the restart route checks
+  `_memory_settings_write_lock()`. If it is already held, return
+  `memory_restart_busy` immediately rather than joining its waiter queue.
+- If it is free, acquire it immediately and hold it across the complete internal
+  restart request and response. Every Memory PATCH already holds this same lock
+  across load, save, controller reconcile, and rollback, so a PATCH cannot write
+  C1 between the controller's C0 comparison and marker-clear save.
+- Controller settlement still performs load, full Memory configuration compare,
+  marker-only mutation, and atomic file replacement while its local
+  `CONFIG_LOCK` is held. A mismatch fails closed with `memory_clear_failed`.
+- The internal UDS endpoint remains controller-private. The supported
+  user-facing writer is the UI route that owns the cross-process transaction
+  boundary.
 
-这不增加独立 restart lock 或队列；现有两把 lifecycle lock 就是 single-flight 所有权边界。
+Add a route concurrency test that pauses restart settlement, starts a PATCH from
+a second task, and verifies the PATCH cannot save until restart releases the UI
+lock. It must then read the settled configuration as its baseline and persist
+C1 without being overwritten by a stale C0 save.
 
-### 4. 强制替换与 lease 交接
+### 4. Nonqueued admission and complete deadlines
 
-`MemoryWorker._boot_id` 当前在对象创建后不变，而 `recover_after_boot()` 只回收“其他 lease owner”的 `processing` 行。若 restart cancel 了已经 claim add 的同一个 worker，再用原 owner 激活，该行会永久停在 `processing`。
+An explicit restart must not wait silently behind another lifecycle operation.
+Otherwise the transport can time out first while the controller later performs
+an abandoned restart, and a user retry can enqueue a second one.
 
-给 `MemoryWorker` 增加一个私有语义的 helper，例如 `begin_replacement_activation()`：生成新的 UUID lease owner，然后复用现有 `begin_activation()`。MemoryStore 和 recovery SQL 不改。
+- Before any await, `restart()` checks `_reconcile_lock` and
+  `module._lifecycle_lock`. If either is held, return
+  `{ok: false, error: 'memory_restart_busy'}` without changing the process,
+  claims, or worker.
+- When both are free, acquire them in the established order in the same event
+  loop turn, with no intervening await. Concurrent restart, Settings PATCH,
+  artifact activation, and clear therefore have one owner. Existing reconcile
+  and clear behavior is unchanged; only explicit restart is fail-fast.
+- Bound interrupted-clear recovery and embedding guard/settlement separately by
+  `CLEAR_CLEANUP_TIMEOUT_SECONDS`, because both phases can run in one request.
+- Give graceful worker drain five seconds. Bound forced worker-task cancellation
+  separately so cancellation cleanup cannot make the lifecycle unbounded.
+- Expose pure budget helpers from `core/memory/process.py` for the production
+  defaults. The stop budget includes both TERM and KILL wait rounds. The start
+  budget includes recorded-orphan reap, readiness wait, and another full stop
+  budget for cleanup after a spawned replacement fails to become ready.
+- Set `MEMORY_RESTART_TIMEOUT_SECONDS` strictly above the sum of two clear
+  cleanup bounds, worker grace, worker cancellation cleanup, old-process stop,
+  and the all-inclusive replacement-start budget. The contract test imports the
+  source constants/helpers instead of copying numbers from comments.
+- A busy result is a completed, retryable business response. It is not
+  `memory_restart_failed`, starts no background task, ends the UI spinner, and
+  displays a localized reason.
 
-锁内执行顺序固定为：
+No additional restart lock or queue is needed. The existing UI settings lock
+and controller lifecycle locks define single-flight ownership.
 
-1. 校验 store、artifact、enabled 状态，并完成 interrupted-clear recovery。
-2. `pause_claims()`，给当前 drain 最多 5 秒优雅结束；超时或普通 drain 错误只记录并进入强制阶段，不作为失败返回。仅 task cancellation 进入下面定义的取消清理。
-3. cancel 并等待旧 worker task 结束。
-4. 轮换 lease owner。该动作必须发生在旧 task 结束之后、任何新 worker activation 之前。
-5. 仅当快照带 `embedding_change_pending` 时，在 claims 已 fence、旧 worker 已停止的状态下执行既有 embedding/root guard 和 marker settlement；通过后才恢复 `self._config`。
-6. 停止旧 process；只有 `stop()` 成功后才能丢弃旧 supervisor，禁止在旧进程未确认回收时启动第二个 child。
-7. 用 `_restart_config` 创建并启动新 process。`start()` / `on_ready` 成功后再恢复 claims 和 worker；同步返回 `{ok: true, state: 'ready'}`。
+### 5. Forced replacement and lease handoff
 
-`restart()` 不调用 `_probe_processing`。条件性的 embedding/root guard 是防止混用向量空间的持久化安全约束，不是 processing 健康预探测；其余真实 processing 故障继续由 worker 的既有分类路径报告。
+`MemoryWorker._boot_id` currently remains stable for the object's lifetime,
+while `recover_after_boot()` recovers only `processing` rows owned by another
+lease. If restart cancels an already claimed add and reactivates the same worker
+owner, that row remains `processing` forever.
 
-### 5. 失败后置条件
+Add a private semantic helper such as `begin_replacement_activation()` that
+creates a new UUID lease owner and then reuses `begin_activation()`. Do not
+change MemoryStore or its recovery SQL.
 
-claims 被 fence 后的每条退出路径必须明确恢复到以下二者之一：
+The locked sequence is fixed:
 
-- **旧 child 仍由原 supervisor 持有且 `running`**：保留该 supervisor，使用新 lease owner 重新 activation，恢复 claims/worker，返回 `memory_restart_failed`。系统退回重启前状态，且不会出现双 child。
-- **旧 child 已停或新 child 启动失败**：保留新 supervisor（如果 factory/start 已创建）；claims 和 worker 保持暂停，设置可见 runtime error。若 supervisor 后续 supervised `on_ready`，它会按既有路径恢复 claims/worker；没有 supervisor 时，用户可再次点击 restart。
+1. Validate store, artifact, and enabled state; recover an interrupted clear.
+2. Pause claims and allow at most five seconds for the current drain. Timeout or
+   an ordinary drain error enters the forced phase; task cancellation enters
+   the cancellation cleanup path.
+3. Cancel and await the old worker task within its explicit cancellation bound.
+4. Rotate the lease owner after the old task ends and before any new activation.
+5. Only when the snapshot has `embedding_change_pending`, run the root guard and
+   marker settlement while claims are fenced and the old worker is stopped.
+   Restore `self._config` only after they pass.
+6. Stop the old process. Do not discard its supervisor or start another child
+   until its process tree is confirmed reaped.
+7. Create a process from `_restart_config` and call `start()`. Restore claims and
+   the worker only after `start()` and `on_ready` succeed. Return
+   `{ok: true, state: 'ready'}` synchronously.
 
-`CancelledError` 在完成所有权和 claims 清理后继续抛出，不伪装成业务失败。为此要修正现有 `_stop_worker()`：只吞掉被 cancel 的 drain task 所产生的 `CancelledError`；若当前 lifecycle task 自身处于 cancelling 状态则继续抛出。restart 在 orchestration 边界以 shielded cleanup 收敛到上面的单-child/claims 后置条件，再重新抛出取消。若取消发生在新 `start()` 已创建 child、但 watcher/monitor 尚未建立的窗口，cleanup 必须 shield `new_process.stop()`：回收成功才置 `_process=None`，回收失败则保留 supervisor 引用并继续 fence claims，绝不遗留无所有权引用的 child。
+`restart()` does not call `_probe_processing`. The conditional embedding/root
+guard protects persistent vector-space compatibility; it is not a processing
+health preflight. Other processing failures continue through the existing
+worker classification path.
 
-`start()` 正常返回 `False` 时沿用更具体的 `memory_sidecar_unavailable`；stop、factory 或其他 restart orchestration 异常使用新的 transport-only `memory_restart_failed`。
+### 6. Failure and cancellation postconditions
 
-### 6. 队列语义
+Every exit after claims are fenced must end in one of these states:
 
-- cancel 发生在 add 已 claim 之后：新 lease owner 的 activation 会把旧 owner 的行退回 `pending`，按既有 at-least-once 语义重投。若 provider 在取消前已接收但本地未观察到 ack，可能产生重复副作用；强制重启不能承诺 exactly-once。
-- cancel 发生在 flush `in_flight`：activation 会把它永久标记为 `unknown` 并打开 processing fault。历史 `unknown` 不会在 5 分钟后自动重试或消失；以后新的 pending work 成功 flush 可以关闭 fault，但不会改写该历史记录。
+- **Failure before `old_process.stop()` is invoked:** the old supervisor still
+  has its original desired-running state. Reactivate with the new lease owner,
+  resume claims and the worker, and return the specific failure. The runtime is
+  genuinely restored to its pre-restart state.
+- **`old_process.stop()` was invoked:** `EverOSProcess.stop()` sets
+  `_desired_running=false` before termination and cancels scheduled restart.
+  If stop raises, retain the supervisor reference but keep claims and the worker
+  fenced, set the visible runtime error, and return `memory_restart_failed`.
+  Do not claim that the old runtime was restored and do not start a second child.
+  The user can retry the explicit restart, which first retries owned-tree stop.
+- **The old child stopped but replacement startup failed:** retain the new
+  supervisor, if one was created, and keep claims and the worker fenced. If its
+  bounded supervisor later reaches `on_ready`, the existing callback resumes
+  them. With no supervisor, the user can click restart again.
 
-## 接口与 UI 改动
+`CancelledError` is re-raised after ownership and claims cleanup; it is never
+reported as a business failure. Fix `_stop_worker()` so it swallows only the
+cancelled drain task's `CancelledError`, while cancellation of the lifecycle
+task itself propagates. Restart uses shielded cleanup to reach one of the states
+above. If cancellation lands after a new child is spawned but before its watcher
+or monitor exists, shield `new_process.stop()`: clear `_process` only after
+successful reap; otherwise retain the supervisor reference and keep claims
+fenced.
 
-### 后端与 transport
+`start()` returning `False` keeps the specific
+`memory_sidecar_unavailable`. Stop, factory, and other restart orchestration
+exceptions use the transport-only `memory_restart_failed`.
 
-1. `core/memory/runtime.py`：增加 `_restart_config` 和 fail-fast `restart()`；成功 reconcile 提交快照；修正 `_stop_worker()` 对调用方取消的识别。
-2. `core/memory/module.py`：抽出锁内 clear recovery helper；现有 wrapper 继续服务其他调用方。
-3. `core/memory/worker.py`：增加 replacement activation 时的 lease owner 轮换。
-4. `core/internal_server.py`：增加 `POST /internal/memory/restart`。runtime 缺失返回 `memory_runtime_missing`；未处理异常映射为 `memory_restart_failed`，不能复用语义错误的 `memory_reconcile_failed`。
-5. `vibe/internal_client.py`：增加 `memory_restart()` 和独立 timeout。timeout 按上面的完整 restart lifecycle budget 计算，lock busy 不计入预算，因为它不等待。
-6. `vibe/ui_memory_routes.py`：现有 `/api/memory/runtime/restart` 改调 `memory_restart()`，保持同源校验和外部路径不变。
-7. `core/memory/types.py` 与前端 en/zh `errors`：加入 transport-only `memory_restart_failed` 和 `memory_restart_busy`；不加入 SQLite 持久化 schema。
+### 7. Queue semantics
 
-### 前端
+- If cancellation occurs after an add is claimed, activation under the new lease
+  returns the old owner's row to `pending`, preserving at-least-once behavior.
+  The provider may have accepted the request before local acknowledgement, so
+  forced restart cannot promise exactly-once side effects.
+- If cancellation occurs while a flush is `in_flight`, activation permanently
+  marks it `unknown` and opens a processing fault. Historical `unknown` entries
+  do not retry or disappear after five minutes. A later successful flush can
+  close the fault but does not rewrite the historical record.
 
-1. `memoryRead.ts`：在现有 Memory response classifier 附近定义并导出 `MemoryRuntimeRestartResult` 及纯函数 normalizer。接受 `{ok:true}`；把 `{ok:false,error}` 和 `{status:'failed',error}` 统一为失败；malformed body 也必须 fail closed。
-2. `ApiContext.tsx`：导入该类型和 normalizer，`restartMemoryRuntime()` 只返回归一化结果，避免反向 import 形成循环依赖。
-3. `SettingsMemoryPage.tsx`：当 `settings?.enabled === true` 且页面不是 cross-origin forbidden 状态时，在 `remoteUnavailable` / `memorySetupStage()` 条件树之前渲染 page-level Status 动作行。secondary `xs` 重启按钮使用 `RotateCw` / `Loader2`，`restarting` 时 disabled；因此 `runtime-required`、setup loading、status loading/error 都共享同一个入口。请求同步等待结果；成功 toast 使用完成式文案，失败 toast 显示本地化原因和字面 error code，无 code 时显示通用失败。
-4. `MemoryStatusPanel.tsx`：删除 engine fault 横幅中的旧重启按钮和相关 props，避免正常 Status body 出现第二个入口；credential fault 的“打开设置”保持不变。
-5. `en.json` / `zh.json`：同步增加按钮、完成、失败、`memory_restart_failed`、`memory_restart_busy` 文案，删除不再使用的 engine 横幅 action 文案。
+## Interface and UI changes
 
-## 最小充分测试
+### Backend and transport
+
+1. `core/memory/runtime.py`: add `_restart_config` and fail-fast `restart()`;
+   commit snapshots after successful reconcile; fix caller cancellation handling
+   in `_stop_worker()`.
+2. `core/memory/module.py`: extract locked clear recovery while retaining the
+   wrapper for read paths.
+3. `core/memory/worker.py`: rotate the lease owner for replacement activation.
+4. `core/memory/process.py`: expose complete stop/start budget helpers, including
+   startup-failure cleanup.
+5. `core/internal_server.py`: add `POST /internal/memory/restart`. Missing runtime
+   returns `memory_runtime_missing`; unhandled exceptions map to
+   `memory_restart_failed`, not `memory_reconcile_failed`.
+6. `vibe/internal_client.py`: add `memory_restart()` with a deadline above the
+   complete restart lifecycle budget.
+7. `vibe/ui_memory_routes.py`: keep `/api/memory/runtime/restart`, acquire the
+   Memory settings write lock across the internal call, and preserve same-origin
+   validation.
+8. `core/memory/types.py` and frontend `errors` translations: add transport-only
+   `memory_restart_failed` and `memory_restart_busy`; add no SQLite schema field.
+
+### Frontend
+
+1. `memoryRead.ts`: define and export `MemoryRuntimeRestartResult` and a pure
+   normalizer near the current Memory response classifier. Accept `{ok:true}`;
+   normalize `{ok:false,error}` and `{status:'failed',error}` as failures; fail
+   closed on malformed bodies.
+2. `ApiContext.tsx`: import that type and normalizer. `restartMemoryRuntime()`
+   returns only the normalized result and does not create a reverse import.
+3. `SettingsMemoryPage.tsx`: when `settings?.enabled === true` and the page is not
+   cross-origin forbidden, render a page-level Status action row before the
+   `remoteUnavailable` / `memorySetupStage()` branch. Use the existing secondary
+   `xs` button with `RotateCw` / `Loader2`; disable it while restarting. Runtime
+   required, setup loading, and status loading/error states share this action.
+   Await the result. Show completion copy on success and a localized reason plus
+   literal error code on failure, with a generic fallback when no code exists.
+4. `MemoryStatusPanel.tsx`: remove the old engine-fault restart action and its
+   props so the normal Status body cannot render a duplicate. Keep the credential
+   fault's settings action.
+5. `en.json` / `zh.json`: add button, completion, failure,
+   `memory_restart_failed`, and `memory_restart_busy` copy in both locales;
+   remove the unused engine-banner action key.
+
+## Minimum sufficient tests
 
 ### Python
 
 - `tests/test_memory_runtime.py`
-  - 成功 restart：旧 process 确认 stop，新 process 启动并 ready，worker 恢复。
-  - C1 reconcile 失败且 rollback 也失败后，restart 重放最后成功的 C0；无竞争时的 restart 仍在两把 lifecycle lock 内完成。
-  - 分别预占 `_reconcile_lock` 和 `module._lifecycle_lock`，以及同时发起两个 restart，验证竞争者立即返回 `memory_restart_busy`、不进入 waiter 队列且不修改 process/claims/worker。
-  - 分别挂起 add 和 flush，使用缩短的 grace 验证有界完成；add 可由新 owner 再 claim，flush 变 `unknown` 并打开 fault。
-  - durable clear marker 恢复与 replacement 位于同一 lifecycle 临界区；恢复失败不启动 child。
-  - 初始 `_restart_config.embedding_change_pending=true` 时：有旧向量数据必须拒绝启动；空 root 完成 marker settlement 后才允许启动。
-  - disabled 不 spawn；`start() is False`、factory exception、stop exception 分别验证错误码、`_process`/claims/worker 后置条件和无双 child。
-  - lifecycle task 分别在 worker 停止期间、以及 new `start()` 已创建 child 后被 cancel：完成最小 cleanup，验证 child 被回收或仍由唯一 supervisor 持有、claims 后置条件正确，并重新抛出 `CancelledError`。
-- `tests/test_internal_server.py`：成功透传、runtime missing、未处理异常映射。
-- `tests/test_internal_client.py` / `tests/test_internal_client_timeouts.py`：POST 路径、busy 响应透传、timeout 从 clear/worker/process 源常量覆盖完整有界预算。
-- `tests/test_ui_memory_routes.py`：切到新 client、internal unavailable、既有 cross-origin 拒绝。
+  - Successful restart confirms old stop, new ready child, and worker recovery.
+  - After failed C1 reconcile and failed rollback, restart replays last-good C0;
+    the uncontended operation remains inside both lifecycle locks.
+  - Pre-held reconcile/module locks and concurrent restart calls immediately
+    return `memory_restart_busy`, create no waiters, and change no ownership.
+  - Hung add and flush cases use shortened bounds; add can be reclaimed by the
+    new owner, while flush becomes `unknown` and opens the fault.
+  - Clear-marker recovery and replacement share one lifecycle critical section;
+    recovery failure launches no child.
+  - A startup snapshot with the embedding marker rejects existing vectors and
+    settles an empty root before launch.
+  - Disabled, `start() is False`, factory exception, failed-start cleanup, and
+    stop exception cases assert error codes, supervisor ownership, claims/worker
+    fencing, and no double child. A stop exception followed by child exit must
+    not auto-restart or report restored claims.
+  - Cancellation while stopping the worker and after a new child is spawned
+    reaches the documented cleanup state and re-raises `CancelledError`.
+- `tests/test_internal_server.py`: success, missing runtime, and exception mapping.
+- `tests/test_internal_client.py` / `tests/test_internal_client_timeouts.py`:
+  POST and busy response passthrough; deadline computed from both clear phases,
+  worker bounds, old stop, readiness, and failed-start cleanup.
+- `tests/test_ui_memory_routes.py`: new client path, internal unavailable,
+  cross-origin rejection, restart/settings serialization, and final C1 retention.
 
 ### TypeScript
 
-- 给纯 normalizer 做表驱动测试：`ok:true`、`ok:false`、`status:'failed'`、malformed。
-- 沿用 React SSR / `renderToStaticMarkup`，不引入 DOM 框架：给 `SettingsMemoryPage` 注入 enabled + runtime-missing fixture，断言 setup prompt 与唯一重启按钮同时存在；另覆盖 status loading/error、restarting disabled。`MemoryStatusPanel` 测试断言 engine fault 不再渲染重启入口、credential action 仍存在。
-- 不为 click/toast 新引入 DOM 测试框架；由下面的单一手工场景覆盖。
+- Table-test the pure normalizer with `ok:true`, `ok:false`, `status:'failed'`,
+  and malformed responses.
+- Reuse React SSR / `renderToStaticMarkup`, without a new DOM framework. Inject
+  enabled plus runtime-missing state into `SettingsMemoryPage` and assert that
+  the setup prompt and exactly one restart action coexist. Also cover status
+  loading/error and the disabled restarting state. `MemoryStatusPanel` tests
+  assert no engine restart action and retain the credential action.
+- Keep click/toast behavior in the single manual scenario below.
 
-## 验证
+## Validation
 
 1. `pytest tests/test_memory_runtime.py -k restart`
 2. `pytest tests/test_internal_server.py tests/test_internal_client.py tests/test_internal_client_timeouts.py tests/test_ui_memory_routes.py -k 'memory and restart'`
-3. `ruff check` 所有改动的 Python 文件。
-4. `cd ui && npx vitest run` 相关 normalizer / `SettingsMemoryPage` / `MemoryStatusPanel` 测试，然后 `npm run build`。
-5. 只使用本地 Incus `master` 回归环境：先运行 `./scripts/run_regression.sh` 更新代码和检查服务健康，不重置配置。
-6. 通过 `python3 scripts/incus_regression.py shell --target master` 在容器内确认受管 sidecar PID 后发送 `SIGSTOP`，制造“进程存活但不可达”；在 Web UI 确认状态 down、按钮常驻、spinner/toast 正确，并验证点击后 PID 被替换且状态恢复 ready。若 replacement 未完成，清理时对原 PID 发送 `SIGCONT`。
-7. 再用 runner 检查 Avibe service health。不要重启本机 `vibe`，也不要用 `kill -9`（它只覆盖已有的 child-exit supervision，不是本需求场景）。
+3. Run `ruff check` on every changed Python file.
+4. In `ui/`, run the relevant normalizer, `SettingsMemoryPage`, and
+   `MemoryStatusPanel` Vitest files, then `npm run build`.
+5. Update only the local Incus `master` regression environment with
+   `./scripts/run_regression.sh`; preserve configuration and verify service health.
+6. Through `python3 scripts/incus_regression.py shell --target master`, identify
+   the managed sidecar PID and send `SIGSTOP` to create an alive-but-unreachable
+   process. In the Web UI, verify the persistent action, spinner, toast, PID
+   replacement, and return to `ready`. If replacement does not complete, send
+   `SIGCONT` to the original PID during cleanup.
+7. Check Avibe service health again through the runner. Do not restart the local
+   `vibe` service and do not use `kill -9`; that only covers existing child-exit
+   supervision, not this scenario.
 
-## 整体 review 结论
+## Review conclusion
 
-方案的必要复杂度来自五个已有安全/并发契约：成功配置不能被失败候选覆盖、人工 restart 不能在 transport 背后排队、pending embedding 不能绕过 root guard、已 claim 行必须换 lease 才能恢复、clear marker 必须与 root/child lifecycle 串行。实现只增加一个私有快照、两个窄 helper 和两个准确的 transport-only 错误码，并复用现有 lock、guard、recovery SQL、supervisor 和 UI primitives。
+The necessary complexity comes from six existing safety and concurrency
+contracts: failed candidates cannot replace last-good config; marker settlement
+cannot overwrite a concurrent settings save; explicit restart cannot queue
+behind the transport; pending embeddings cannot bypass the root guard; claimed
+rows require a new lease; and clear markers must serialize with root/child
+lifecycle. The implementation adds one private snapshot, narrow helpers, and
+two precise transport-only error codes while reusing existing locks, guards,
+recovery SQL, supervision, and UI primitives.
 
-本方案明确不引入通用 coordinator、显式 restart 状态机、新 port、新数据库字段、自动重启策略或新前端测试框架。实现中若需要这些内容，应先回到本计划重新论证，而不是顺手扩 scope。
+Do not introduce a general coordinator, explicit restart state machine, new
+port, database field, automatic restart policy, or frontend test framework. If
+implementation appears to require one, revise this plan before expanding scope.
 
 ## Todo
 
-- [ ] runtime snapshot + pending-embedding guard + fail-fast force restart + focused tests
-- [ ] worker lease rotation + add/flush recovery tests
-- [ ] locked clear recovery + race regression test
-- [ ] internal server/client + closed/busy errors + bounded timeout tests
-- [ ] UI route + response normalizer
-- [ ] page-level status action + deduplicated banner + runtime-missing render test + toast/i18n
-- [ ] focused Python/TypeScript validation + Incus `SIGSTOP` scenario
+- [ ] Runtime snapshot, pending-embedding guard, fail-fast restart, focused tests
+- [ ] Settings/restart serialization and stale-C0 overwrite regression
+- [ ] Worker lease rotation and add/flush recovery tests
+- [ ] Locked clear recovery and race regression
+- [ ] Complete process budgets and failed-start cleanup timeout contract
+- [ ] Internal server/client, closed/busy errors, bounded timeout tests
+- [ ] UI route and response normalizer
+- [ ] Page-level action, deduplicated banner, runtime-missing render, toast/i18n
+- [ ] Focused Python/TypeScript validation and Incus `SIGSTOP` scenario

--- a/docs/plans/memory-sidecar-force-restart-button.md
+++ b/docs/plans/memory-sidecar-force-restart-button.md
@@ -1,10 +1,11 @@
-# Add a forced sidecar restart action to Memory settings (rev5)
+# Add a forced sidecar restart action to Memory settings (rev6)
 
-> Rev5 keeps one public recovery action and a small set of internal fixes:
+> Rev6 keeps one public recovery action and a small set of internal fixes:
 > replayable configuration, settings transaction serialization, fail-fast
-> lifecycle admission, worker lease rotation, and locked clear-marker recovery.
-> It does not add a lifecycle coordinator, explicit state machine, provider/store
-> port, or frontend DOM test framework.
+> lifecycle admission, bounded orphan recovery, worker lease rotation, and locked
+> clear-marker recovery. Timed-out work remains owned until it is either joined
+> or proven unable to mutate state. It does not add a lifecycle coordinator,
+> explicit state machine, provider/store port, or frontend DOM test framework.
 
 ## Background and goals
 
@@ -118,14 +119,30 @@ transaction.
 - Controller settlement still performs load, full Memory configuration compare,
   marker-only mutation, and atomic file replacement while its local
   `CONFIG_LOCK` is held. A mismatch fails closed with `memory_clear_failed`.
+- Settlement runs in one retained `asyncio.to_thread()` task. A deadline uses
+  `wait_for(shield(task))`, never cancellation of the thread as proof that its
+  work stopped. If the deadline or caller cancellation fires, cleanup continues
+  to await that exact task under `shield()` while the controller lifecycle locks
+  and the UI settings transaction remain owned. Only after the task reaches a
+  terminal result may either process release its transaction boundary or return
+  a response. The thread works on a private config copy and performs no mutation
+  outside its final compare-and-save operation.
+- `internal_client.memory_restart()` owns one request task with no shorter HTTP
+  read timeout. Its reporting deadline and caller-cancellation path both use
+  `shield()`; after either one fires, cleanup joins the retained request before
+  returning its terminal result or re-raising `CancelledError`. This prevents a
+  disconnected UDS request from continuing settlement after the UI route has
+  released `_memory_settings_write_lock()`.
 - The internal UDS endpoint remains controller-private. The supported
   user-facing writer is the UI route that owns the cross-process transaction
   boundary.
 
-Add a route concurrency test that pauses restart settlement, starts a PATCH from
-a second task, and verifies the PATCH cannot save until restart releases the UI
-lock. It must then read the settled configuration as its baseline and persist
-C1 without being overwritten by a stale C0 save.
+Add route concurrency tests that pause restart settlement, start a PATCH from a
+second task, and verify the PATCH cannot save until restart releases the UI
+lock. Cover both ordinary completion and an expired settlement deadline. In the
+expired case, prove the request and settings locks remain owned until the
+retained thread finishes. The PATCH must then read the settled configuration as
+its baseline and persist C1 without being overwritten by a stale C0 save.
 
 ### 4. Nonqueued admission and complete deadlines
 
@@ -138,27 +155,46 @@ an abandoned restart, and a user retry can enqueue a second one.
   `{ok: false, error: 'memory_restart_busy'}` without changing the process,
   claims, or worker.
 - When both are free, acquire them in the established order in the same event
-  loop turn, with no intervening await. Concurrent restart, Settings PATCH,
-  artifact activation, and clear therefore have one owner. Existing reconcile
-  and clear behavior is unchanged; only explicit restart is fail-fast.
+  loop turn, with no intervening await. After acquiring `_reconcile_lock`, check
+  `_artifact_installing` while that lock is owned. If installation is active,
+  release the lock and return `memory_restart_busy` before resolving an artifact
+  or touching worker/process state. This check covers `install_artifact()`'s
+  deliberate unlocked `ensure(force=True)` interval.
+- Make destructive Clear symmetric at the module lock. `MemoryModule.clear()`
+  checks `_lifecycle_lock` before its first await and acquires it immediately in
+  the same event-loop turn; when the lock is held it returns
+  `memory_clear_failed` without starting or queueing `begin_clear()`. Once Clear
+  owns the lock, restart observes it and returns `memory_restart_busy`. Clear's
+  existing post-receipt reconcile may still run after the module lock is
+  released, but no destructive wipe can remain queued behind restart.
 - Bound interrupted-clear recovery and embedding guard/settlement separately by
   `CLEAR_CLEANUP_TIMEOUT_SECONDS`, because both phases can run in one request.
+  Settlement timeout is a reporting threshold, not permission to abandon its
+  thread; the mandatory join above retains transaction ownership.
 - Give graceful worker drain five seconds. Bound forced worker-task cancellation
   separately so cancellation cleanup cannot make the lifecycle unbounded.
 - Expose pure budget helpers from `core/memory/process.py` for the production
-  defaults. The stop budget includes both TERM and KILL wait rounds. The start
-  budget includes recorded-orphan reap, readiness wait, and another full stop
-  budget for cleanup after a spawned replacement fails to become ready.
+  defaults. The stop budget includes both TERM and KILL wait rounds. Put one
+  outer `asyncio.timeout()` around the complete `SidecarOwnership.reap()` call,
+  including leader termination, the late group sweep, and every unusable-record
+  anchor. Timeout retains the ownership record, launches no child, and returns a
+  start failure. The start budget uses that single outer reap cap, readiness
+  wait, and another full stop budget for cleanup after a spawned replacement
+  fails to become ready; it never assumes only one internal reap round.
 - Set `MEMORY_RESTART_TIMEOUT_SECONDS` strictly above the sum of two clear
   cleanup bounds, worker grace, worker cancellation cleanup, old-process stop,
   and the all-inclusive replacement-start budget. The contract test imports the
-  source constants/helpers instead of copying numbers from comments.
+  source constants/helpers instead of copying numbers from comments. A deadline
+  cannot release either transaction while a non-cancellable settlement write is
+  still live; its mandatory join is an ownership cleanup tail rather than
+  detached restart work.
 - A busy result is a completed, retryable business response. It is not
   `memory_restart_failed`, starts no background task, ends the UI spinner, and
   displays a localized reason.
 
-No additional restart lock or queue is needed. The existing UI settings lock
-and controller lifecycle locks define single-flight ownership.
+No additional restart lock or queue is needed. The existing UI settings lock,
+installer flag, and controller/module lifecycle locks define single-flight
+ownership.
 
 ### 5. Forced replacement and lease handoff
 
@@ -178,15 +214,22 @@ The locked sequence is fixed:
    an ordinary drain error enters the forced phase; task cancellation enters
    the cancellation cleanup path.
 3. Cancel and await the old worker task within its explicit cancellation bound.
-4. Rotate the lease owner after the old task ends and before any new activation.
+   Do not clear `_worker_task` until the exact task is done. If it outlives the
+   bound, retain the task reference, keep claims fenced, and enter the
+   fail-closed state below; do not rotate the lease or touch the process.
+4. Rotate the lease owner only after the old task is confirmed done and before
+   any new activation.
 5. Only when the snapshot has `embedding_change_pending`, run the root guard and
    marker settlement while claims are fenced and the old worker is stopped.
    Restore `self._config` only after they pass.
 6. Stop the old process. Do not discard its supervisor or start another child
    until its process tree is confirmed reaped.
-7. Create a process from `_restart_config` and call `start()`. Restore claims and
-   the worker only after `start()` and `on_ready` succeed. Return
-   `{ok: true, state: 'ready'}` synchronously.
+7. Create a process from `_restart_config` and call `start()`. Make ready-callback
+   failure observable: `_notify_ready()` must propagate the callback exception
+   into `_start_locked()`'s existing failed-start cleanup instead of logging and
+   returning success. Restore claims and the worker only after `start()` and
+   `on_ready` succeed, then verify `_worker_task` exists and is not done before
+   returning `{ok: true, state: 'ready'}` synchronously.
 
 `restart()` does not call `_probe_processing`. The conditional embedding/root
 guard protects persistent vector-space compatibility; it is not a processing
@@ -197,10 +240,19 @@ worker classification path.
 
 Every exit after claims are fenced must end in one of these states:
 
+- **The old worker task outlives forced cancellation:** retain that exact task
+  in `_worker_task`, retain the original lease, keep claims fenced, leave the
+  old process and supervisor untouched, set the visible runtime error, and
+  return `memory_restart_failed`. A retry cancels and waits on the retained task
+  for another bounded interval. It can continue only after the task is done and
+  its outcome has been consumed; while it remains live the retry returns the
+  same fail-closed response and creates no replacement worker or child.
 - **Failure before `old_process.stop()` is invoked:** the old supervisor still
   has its original desired-running state. Reactivate with the new lease owner,
   resume claims and the worker, and return the specific failure. The runtime is
-  genuinely restored to its pre-restart state.
+  genuinely restored to its pre-restart state. This branch applies only after
+  the previous worker task is confirmed done; it never attempts reactivation
+  beside a retained task.
 - **`old_process.stop()` was invoked:** `EverOSProcess.stop()` sets
   `_desired_running=false` before termination and cancels scheduled restart.
   If stop raises, retain the supervisor reference but keep claims and the worker
@@ -211,6 +263,10 @@ Every exit after claims are fenced must end in one of these states:
   supervisor, if one was created, and keep claims and the worker fenced. If its
   bounded supervisor later reaches `on_ready`, the existing callback resumes
   them. With no supervisor, the user can click restart again.
+- **The replacement reaches health but `on_ready` fails:** treat this as startup
+  failure. The callback exception is visible to `_start_locked()`, which runs
+  the same bounded child cleanup and returns `False`; restart keeps claims
+  fenced and cannot report `ready`.
 
 `CancelledError` is re-raised after ownership and claims cleanup; it is never
 reported as a business failure. Fix `_stop_worker()` so it swallows only the
@@ -241,18 +297,21 @@ exceptions use the transport-only `memory_restart_failed`.
 ### Backend and transport
 
 1. `core/memory/runtime.py`: add `_restart_config` and fail-fast `restart()`;
-   commit snapshots after successful reconcile; fix caller cancellation handling
-   in `_stop_worker()`.
+   commit snapshots after successful reconcile; retain worker tasks that outlive
+   cancellation; reject restart while artifact installation is active.
 2. `core/memory/module.py`: extract locked clear recovery while retaining the
-   wrapper for read paths.
+   wrapper for read paths; make destructive Clear acquire its lifecycle lock
+   without queueing behind restart.
 3. `core/memory/worker.py`: rotate the lease owner for replacement activation.
-4. `core/memory/process.py`: expose complete stop/start budget helpers, including
-   startup-failure cleanup.
+4. `core/memory/process.py`: expose complete stop/start budget helpers, put one
+   cap around all orphan-reap rounds, and propagate ready-callback failure into
+   startup cleanup.
 5. `core/internal_server.py`: add `POST /internal/memory/restart`. Missing runtime
    returns `memory_runtime_missing`; unhandled exceptions map to
    `memory_restart_failed`, not `memory_reconcile_failed`.
 6. `vibe/internal_client.py`: add `memory_restart()` with a deadline above the
-   complete restart lifecycle budget.
+   complete restart lifecycle budget; retain and join the shielded request task
+   after a reporting timeout.
 7. `vibe/ui_memory_routes.py`: keep `/api/memory/runtime/restart`, acquire the
    Memory settings write lock across the internal call, and preserve same-origin
    validation.
@@ -291,24 +350,41 @@ exceptions use the transport-only `memory_restart_failed`.
     the uncontended operation remains inside both lifecycle locks.
   - Pre-held reconcile/module locks and concurrent restart calls immediately
     return `memory_restart_busy`, create no waiters, and change no ownership.
+    An installer paused inside unlocked `ensure(force=True)` also returns busy
+    before artifact resolution, worker fencing, or process replacement.
+  - Clear started while restart owns the module lifecycle lock returns before
+    `begin_clear()` and leaves no waiter or durable marker; the inverse ordering
+    makes restart return busy.
   - Hung add and flush cases use shortened bounds; add can be reclaimed by the
     new owner, while flush becomes `unknown` and opens the fault.
+  - A worker task that ignores its first cancellation is retained with the old
+    lease and fenced claims. No child/process action occurs; retry stays closed
+    until the exact task terminates, then completes replacement normally.
   - Clear-marker recovery and replacement share one lifecycle critical section;
     recovery failure launches no child.
   - A startup snapshot with the embedding marker rejects existing vectors and
     settles an empty root before launch.
-  - Disabled, `start() is False`, factory exception, failed-start cleanup, and
-    stop exception cases assert error codes, supervisor ownership, claims/worker
-    fencing, and no double child. A stop exception followed by child exit must
+  - Disabled, `start() is False`, factory exception, ready-callback exception,
+    failed-start cleanup, and stop exception cases assert error codes,
+    supervisor ownership, claims/worker fencing, and no double child. A callback
+    exception cannot report ready; a stop exception followed by child exit must
     not auto-restart or report restored claims.
   - Cancellation while stopping the worker and after a new child is spawned
     reaches the documented cleanup state and re-raises `CancelledError`.
 - `tests/test_internal_server.py`: success, missing runtime, and exception mapping.
 - `tests/test_internal_client.py` / `tests/test_internal_client_timeouts.py`:
   POST and busy response passthrough; deadline computed from both clear phases,
-  worker bounds, old stop, readiness, and failed-start cleanup.
+  worker bounds, old stop, the outer all-round orphan-reap cap, readiness, and
+  failed-start cleanup. On reporting timeout or caller cancellation, the
+  retained request is joined before its caller can release transaction
+  ownership.
 - `tests/test_ui_memory_routes.py`: new client path, internal unavailable,
-  cross-origin rejection, restart/settings serialization, and final C1 retention.
+  cross-origin rejection, restart/settings serialization, timed-out settlement
+  ownership, and final C1 retention.
+- `tests/test_memory_process.py`: stale recorded leader plus late helper and
+  multiple unusable-record anchors share one outer reap deadline. Timeout keeps
+  the record and prevents child launch. Ready-callback failure is returned as a
+  failed start after bounded cleanup.
 
 ### TypeScript
 
@@ -341,14 +417,16 @@ exceptions use the transport-only `memory_restart_failed`.
 
 ## Review conclusion
 
-The necessary complexity comes from six existing safety and concurrency
-contracts: failed candidates cannot replace last-good config; marker settlement
-cannot overwrite a concurrent settings save; explicit restart cannot queue
-behind the transport; pending embeddings cannot bypass the root guard; claimed
-rows require a new lease; and clear markers must serialize with root/child
-lifecycle. The implementation adds one private snapshot, narrow helpers, and
-two precise transport-only error codes while reusing existing locks, guards,
-recovery SQL, supervision, and UI primitives.
+The necessary complexity comes from existing safety and concurrency contracts:
+failed candidates cannot replace last-good config; marker settlement cannot
+outlive its settings transaction; explicit restart and destructive Clear cannot
+queue behind each other; artifact installation excludes launch; orphan recovery
+has one complete cap; pending embeddings cannot bypass the root guard; claimed
+rows require a new lease only after the old worker exits; ready-callback success
+must be observable; and clear markers serialize with root/child lifecycle. The
+implementation adds one private snapshot, narrow helpers, and two precise
+transport-only error codes while reusing existing locks, guards, recovery SQL,
+supervision, and UI primitives.
 
 Do not introduce a general coordinator, explicit restart state machine, new
 port, database field, automatic restart policy, or frontend test framework. If
@@ -358,9 +436,12 @@ implementation appears to require one, revise this plan before expanding scope.
 
 - [ ] Runtime snapshot, pending-embedding guard, fail-fast restart, focused tests
 - [ ] Settings/restart serialization and stale-C0 overwrite regression
+- [ ] Timed-out settlement ownership and retained-request regression
 - [ ] Worker lease rotation and add/flush recovery tests
+- [ ] Retained worker cancellation fail-closed state and retry
 - [ ] Locked clear recovery and race regression
-- [ ] Complete process budgets and failed-start cleanup timeout contract
+- [ ] Nonqueued destructive Clear and artifact-install admission
+- [ ] Complete orphan/start budgets, observable ready callback, failed-start cleanup
 - [ ] Internal server/client, closed/busy errors, bounded timeout tests
 - [ ] UI route and response normalizer
 - [ ] Page-level action, deduplicated banner, runtime-missing render, toast/i18n

--- a/docs/plans/memory-sidecar-force-restart-button.md
+++ b/docs/plans/memory-sidecar-force-restart-button.md
@@ -1,14 +1,15 @@
-# Add a forced sidecar restart action to Memory settings (rev15)
+# Add a forced sidecar restart action to Memory settings (rev16)
 
-> Rev15 keeps one public recovery action and a focused set of internal fixes:
+> Rev16 keeps one public recovery action and a focused set of internal fixes:
 > replayable configuration, config-wide write serialization, restart-specific
 > and lifecycle-intent admission, generation-fenced ready activation, complete
 > supervisor quiescing, bounded orphan recovery, disk/live replay convergence,
 > marker-free replay promotion, store-thread settlement, worker lease rotation,
 > locked clear-marker recovery, bounded readiness, supervisor callback rebinding,
 > authoritative controller/UI settings refresh, queued-operation exclusion, and
-> disabled/fail-closed replay handling, explicit worker activation, and retained
-> processing-probe/module-store ownership with cross-lifecycle admission.
+> disabled/fail-closed replay handling, explicit worker activation, post-lock
+> retained-owner admission, root/installer task retention, and disabled recovery
+> projection alongside processing-probe/module-store ownership.
 > Timed-out work remains owned until it is either joined or proven unable to
 > mutate state. It does not add a lifecycle coordinator, explicit state machine,
 > provider/store port, or frontend DOM test framework.
@@ -306,17 +307,31 @@ an abandoned restart, and a user retry can enqueue a second one.
   before lifecycle locks or `_explicit_restart_active` can be released. Clear,
   reconcile, artifact activation, search/profile and interrupted-clear recovery,
   and automatic ready activation check it before their first await and reject
-  without entering lifecycle queues or mutating state. Pure status projection
-  may report the retained error but cannot run recovery. `close()` joins retained
-  ownership; only an explicit restart retry may enter the locked settlement path
-  while the gate is set. That retry clears the sticky gate atomically only after
-  every retained registry is empty and before normal replacement continues.
+  without entering lifecycle queues or mutating state. Every operation that was
+  admitted while the gate was false must also recheck it after acquiring its
+  outermost Runtime/module lifecycle locks and before marker recovery, config or
+  store mutation, provider access, artifact activation, or worker/process action.
+  Thus a reconcile, installer, Clear, or read already queued behind restart
+  cannot resume beside an owner that restart retained before releasing its locks.
+  Pure status projection may report the retained error but cannot run recovery.
+  `close()` joins retained ownership; only an explicit restart retry may enter
+  the locked settlement path while the gate is set. That retry clears the sticky
+  gate atomically only after every retained registry is empty and before normal
+  replacement continues.
 - When both are free, acquire them in the established order in the same event
   loop turn, with no intervening await. After acquiring `_reconcile_lock`, check
   `_artifact_installing` while that lock is owned. If installation is active,
   release the lock and return `memory_restart_busy` before resolving an artifact
   or touching worker/process state. This check covers `install_artifact()`'s
   deliberate unlocked `ensure(force=True)` interval.
+- Replace artifact installation's bare `to_thread(ensure)` await with one named,
+  shielded task retained by Runtime. `_artifact_installing`, its reconcile intent,
+  and the exact task record remain owned until that thread actually terminates;
+  cancellation joins the same task under `shield()` before clearing them under
+  `_reconcile_lock` and re-raising `CancelledError`. A cancelled request therefore
+  cannot release restart admission while its installer still deletes or replaces
+  artifacts. Ordinary failure consumes the same task result before releasing the
+  intent, and no second installer may replace its record.
 - Track a narrow `_explicit_restart_active` boolean and
   `_clear_pending_count` in `MemoryRuntime`. Restart sets its boolean after
   acquiring both lifecycle locks, before the first lifecycle await, and clears
@@ -355,6 +370,14 @@ an abandoned restart, and a user retry can enqueue a second one.
   exact task still outlives that bound, retain it and set the cross-lifecycle gate
   before releasing locks. Include module-store settlement as its own restart
   deadline component.
+- Give the bare root verification and recreation `to_thread()` calls in
+  `_clear_provider_data_or_fail()` explicit shielded task records keyed by the
+  provider root. Keep them distinct from `_ROOT_CLEANUP_TASKS`, which owns the
+  provider cleanup callback. Clear and interrupted-clear recovery consume or
+  retain the exact verification/recreation tasks; restart settles all three root
+  owner classes under the root cleanup allowance. If any task outlives the bound,
+  set the cross-lifecycle gate before releasing locks and prevent a retry from
+  resolving or launching EverOS until that exact filesystem task terminates.
 - Bound settlement of processing-probe trees separately. Cancelling the drain
   task can make it terminal while probe termination is still incomplete; every
   retained probe owner must prove its process tree reaped before lease rotation
@@ -585,6 +608,11 @@ Every exit after claims are fenced must end in one of these states:
   A retry awaits the same task under another bounded interval. It cannot run
   recovery, rotate the lease, or touch process ownership until the thread has
   returned and its terminal result has been consumed.
+- **A module store or root filesystem task outlives settlement:** retain its exact
+  store, verification, cleanup-callback, or recreation record, keep claims and
+  the root lifecycle fenced, and return `memory_restart_failed`. A retry settles
+  those records before marker recovery or artifact/process resolution; a
+  terminal coroutine is not proof that its underlying filesystem thread ended.
 - **A processing-probe tree outlives cancellation or cleanup:** retain its exact
   probe/process-group/owned-process record and cleanup owner on the supervisor,
   retain the current lease, and keep claims fenced. Restart returns
@@ -609,6 +637,10 @@ Every exit after claims are fenced must end in one of these states:
   fenced, set the visible runtime error, and return `memory_restart_failed`.
   Do not claim that the old runtime was restored and do not start a second child.
   The user can retry the explicit restart, which first retries owned-tree stop.
+  If replay already committed disabled config, return
+  `restart_recovery_required=true` and expose the same fact through pure status
+  projection until the retained supervisor/child is reaped. This keeps explicit
+  cleanup retry reachable without making disabled Memory launch a replacement.
 - **The old child stopped but replacement startup failed:** retain the new
   supervisor, if one was created, and keep claims and the worker fenced. If its
   bounded supervisor later reaches ready, its generation-fenced activation task
@@ -664,8 +696,9 @@ exceptions use the transport-only `memory_restart_failed`.
 2. `core/memory/runtime.py`: add `_restart_config`,
    `_persisted_memory_snapshot`, `_explicit_restart_active`,
    `_clear_pending_count`, `_reconcile_pending_count`,
-   `_retained_ownership_active`, lifecycle generation and a retained ready
-   activation task, and fail-fast `restart()`; refresh the
+   `_retained_ownership_active`, a retained artifact-install task, lifecycle
+   generation and a retained ready activation task, and fail-fast `restart()`;
+   recheck retained ownership under acquired lifecycle locks; refresh the
    persisted snapshot after every successful runtime-owned V2 mutation and
    rebase a successfully reconciled
    live/replay candidate from marker settlement's exact return; conditionally
@@ -675,7 +708,9 @@ exceptions use the transport-only `memory_restart_failed`.
    restart admission fail fast. Make `restart()` return its transport
    result plus the exact applied replay config whenever convergence committed,
    including later lifecycle failure, and no config before convergence or on
-   busy. Add `reconcile_persisted()` to return the exact
+   busy. Project `restart_recovery_required` in restart/status results while a
+   disabled replay still owns failed cleanup. Add `reconcile_persisted()` to
+   return the exact
    successful candidate alongside the transport result while ordinary
    `reconcile()` preserves its dict contract.
    `Controller.reconcile_memory()` installs that returned candidate into
@@ -685,9 +720,11 @@ exceptions use the transport-only `memory_restart_failed`.
    wrapper and existing queued lifecycle-lock behavior for read/Clear paths. Add
    the synchronous lifecycle-intent scope and `lifecycle_busy` property covering
    active and queued search, profile, Clear, and recovery operations. Shield and
-   retain explicit module store tasks and expose their bounded settlement. A
-   narrow Runtime-supplied admission predicate prevents search/profile recovery
-   and Clear from entering while retained ownership is fenced.
+   retain explicit module store tasks plus root verification/recreation tasks and
+   expose their bounded settlement. A narrow Runtime-supplied admission predicate
+   prevents search/profile recovery and Clear from entering while retained
+   ownership is fenced and is rechecked after a queued caller acquires the module
+   lifecycle lock.
 4. `core/memory/worker.py`: retain and shield explicit store-thread tasks, expose
    bounded settlement, make activation return a generation-specific completion
    future, and rotate the lease owner only after prior ownership registries are
@@ -722,7 +759,8 @@ exceptions use the transport-only `memory_restart_failed`.
 1. `memoryRead.ts`: define and export `MemoryRuntimeRestartResult` and a pure
    normalizer near the current Memory response classifier. Accept `{ok:true}`;
    normalize `{ok:false,error}` and `{status:'failed',error}` as failures; fail
-   closed on malformed bodies, and preserve a strict boolean `config_committed`.
+   closed on malformed bodies, and preserve strict boolean `config_committed`
+   and `restart_recovery_required` fields.
 2. `ApiContext.tsx`: import that type and normalizer. `restartMemoryRuntime()`
    returns only the normalized result and does not create a reverse import.
 3. `useMemoryResource.ts`: expose a narrow `invalidate()` transition that drops
@@ -743,7 +781,13 @@ exceptions use the transport-only `memory_restart_failed`.
    settings reload. After a failed operation, show its localized reason plus
    literal error code only after the required reload settles; when no config was
    committed, keep the existing settings payload and use the generic fallback
-   when no code exists.
+   when no code exists. Also render the same single recovery action when either
+   the latest restart response or pure runtime status reports
+   `restart_recovery_required=true`, even if the authoritative settings reload
+   now says disabled. Retain that local flag across the required settings/status
+   refresh and clear it only when a successful retry or a later status proves no
+   retained cleanup owner remains; ordinary disabled Memory still has no restart
+   action.
 5. `MemoryStatusPanel.tsx`: remove the old engine-fault restart action and its
    props so the normal Status body cannot render a duplicate. Keep the credential
    fault's settings action.
@@ -767,12 +811,19 @@ exceptions use the transport-only `memory_restart_failed`.
     an unexpected Memory C2 fails before process mutation. If C0 is disabled,
     convergence stops any retained old child without invoking the process
     factory, start, activation, or worker; Runtime, Controller, disk, and the UI
-    reload all observe disabled. A post-Clear internal reconcile cannot
+    reload all observe disabled. If stopping the retained old child fails after
+    that commit, restart and status both report
+    `restart_recovery_required=true`; retry remains visible, settles the child,
+    and never launches while disabled. A post-Clear internal reconcile cannot
     overwrite the persisted snapshot contract.
   - Pre-held reconcile/module locks and concurrent restart calls immediately
     return `memory_restart_busy`, create no waiters, and change no ownership.
     An installer paused inside unlocked `ensure(force=True)` also returns busy
-    before artifact resolution, worker fencing, or process replacement.
+    before artifact resolution, worker fencing, or process replacement. Cancel
+    that installer while its real `ensure()` thread remains blocked and prove its
+    task record, `_artifact_installing`, and reconcile intent remain owned;
+    restart stays busy until the exact thread ends, after which cancellation is
+    re-raised and all three ownership signals clear.
     Hold one search/profile request in the module lock and queue a second; across
     the owner's release/waiter-wakeup gap, `lifecycle_busy` remains true and
     restart returns busy without joining the read queue. After both reads finish,
@@ -794,6 +845,11 @@ exceptions use the transport-only `memory_restart_failed`.
     activation, and automatic ready activation must reject before their first
     lifecycle await. An explicit restart retry may enter, joins the exact owners,
     and clears the gate only after every registry is empty.
+    Also admit reconcile, artifact activation, Clear, and search/profile while
+    the gate is false but restart owns their lifecycle locks; after restart sets
+    the gate and releases the locks, each queued operation must fail its
+    under-lock recheck before marker recovery, config/store/provider mutation, or
+    installation.
   - Hung add and flush cases use shortened bounds; add can be reclaimed by the
     new owner, while flush becomes `unknown` and opens the fault.
   - A worker task that ignores its first cancellation is retained with the old
@@ -804,6 +860,12 @@ exceptions use the transport-only `memory_restart_failed`.
     registered. Restart retains the old lease and process without running
     recovery; after the thread is released, retry joins it and only then rotates
     and recovers.
+  - Block the actual root verification and recreation `to_thread()` calls during
+    Clear and interrupted-clear recovery. Cancellation or reporting timeout must
+    leave the exact root task registered and the retained-owner gate set; restart
+    retry cannot resolve an artifact or launch a child until that thread exits
+    and the root-task registry is consumed. Cover the cleanup callback registry
+    in the same settlement assertion without conflating the three owners.
   - Cancel a drain task inside a real supervised processing probe and make its
     first termination round fail. The terminal worker task is insufficient for
     restart admission: the exact probe-tree record remains on the supervisor,
@@ -930,7 +992,8 @@ exceptions use the transport-only `memory_restart_failed`.
 ### TypeScript
 
 - Table-test the pure normalizer with `ok:true`, `ok:false`, `status:'failed'`,
-  strict `config_committed` values, and malformed responses.
+  strict `config_committed` / `restart_recovery_required` values, and malformed
+  responses.
 - Reuse React SSR / `renderToStaticMarkup`, without a new DOM framework. Inject
   enabled plus runtime-missing state into `SettingsMemoryPage` and assert that
   the setup prompt and exactly one restart action coexist. Also cover status
@@ -941,7 +1004,11 @@ exceptions use the transport-only `memory_restart_failed`.
   with C0, and expose only C0 to the form. The reload-failure case keeps no
   editable C1 payload. Add the equivalent `config_committed=true` failure
   transition: reload C0 before displaying the lifecycle error. A false flag
-  preserves C1. Keep click/toast behavior in the single manual scenario below.
+  preserves C1. When that C0 is disabled but cleanup is retained, prove the one
+  recovery action remains after settings/status reload and disappears only after
+  a successful retry or status clears the recovery flag. Ordinary disabled state
+  still renders no action. Keep click/toast behavior in the single manual
+  scenario below.
 
 ## Validation
 
@@ -974,8 +1041,10 @@ runtime-owned mutation refreshes the exact persisted snapshot and successful
 settlement propagates the same exact block into controller shared config;
 explicit restart cannot queue behind or leapfrog any active or queued module
 lifecycle operation, while reads and destructive Clear retain their existing
-serialization; artifact installation excludes launch; orphan recovery has one
-complete cap; every active process lifecycle
+serialization and recheck retained ownership after acquiring their locks;
+artifact installation and root verification/recreation threads remain explicitly
+owned through cancellation; artifact installation excludes launch; orphan
+recovery has one complete cap; every active process lifecycle
 owner is settled and budgeted before stop; readiness, including the final health
 request, has one hard cap; delayed automatic activation and re-armed supervision
 are bound to the current lifecycle generation and both runtime locks; pending
@@ -985,7 +1054,8 @@ shielded worker/module store thread exit; activation success is observable and
 its shared future is shielded from reporting timeout; post-convergence failure
 still propagates the committed block to Controller and UI; retained ownership
 excludes every other mutating lifecycle; replacement cleanup fences supervision
-before awaiting; and clear markers serialize with root/child lifecycle. The
+before awaiting; disabled retained cleanup keeps its explicit recovery action;
+and clear markers serialize with root/child lifecycle. The
 implementation adds two private snapshots, focused intent counters, one narrow
 retained-owner gate, focused helpers, and two precise transport-only error codes
 while reusing existing locks, guards, recovery SQL, supervision, and UI
@@ -1008,9 +1078,12 @@ implementation appears to require one, revise this plan before expanding scope.
 - [ ] Retained worker cancellation fail-closed state and retry
 - [ ] Shielded store-thread registry, bounded settlement, and retry
 - [ ] Module clear/recovery store-task retention and cross-lifecycle owner gate
+- [ ] Root verification/recreation task retention and retry settlement
 - [ ] Locked clear recovery and race regression
 - [ ] Restart/Clear intent admission, queued-Clear handoff, artifact admission
 - [ ] Queued read intent admission and waiter-handoff regression
+- [ ] Under-lock retained-owner recheck for every queued lifecycle operation
+- [ ] Cancelled artifact installer ownership and restart exclusion
 - [ ] Supervisor handoff/rebind, lifecycle-owner settlement, readiness/deadline contract
 - [ ] Lifecycle-generation ready activation and Clear/reconcile race regression
 - [ ] Complete orphan/start budgets, explicit activation, failed-start cleanup
@@ -1018,4 +1091,5 @@ implementation appears to require one, revise this plan before expanding scope.
 - [ ] Internal server/client, closed/busy errors, bounded timeout tests
 - [ ] UI route and response normalizer
 - [ ] Page action, deduplicated banner, success/failure settings reload, toast/i18n
+- [ ] Disabled retained-cleanup recovery projection and persistent retry action
 - [ ] Focused Python/TypeScript validation and Incus `SIGSTOP` scenario


### PR DESCRIPTION
## Summary

- capability: Memory sidecar force-restart recovery plan
- user-visible change: documents an always-available restart action for enabled Memory and its synchronous success/failure contract
- motivation: replace the rev2 reconcile-based assumptions with the smallest design that preserves applied config, queue leases, clear recovery, and single-child ownership

## Scenario Coverage

- scenario IDs: N/A (planning-only change; no matching catalog entry is implemented yet)
- unit / contract coverage: defines focused runtime, internal server/client, timeout, UI route, response normalizer, and SSR test obligations
- scenario coverage: defines one local Incus master scenario using SIGSTOP to reproduce a live-but-unreachable sidecar
- residual manual checks: button visibility, spinner/toast, PID replacement, ready recovery, and service health remain implementation-time checks

## Validation

- commands run: git diff --cached --check; independent two-pass plan review
- result: clean whitespace check; final review found no P1/P2 issues and no overdesign

## Risks / Follow-ups

- risk: documentation only; runtime behavior is unchanged until the plan is implemented
- follow-up: implement the rev3 Todo list without adding a lifecycle coordinator, state machine, new port, database field, or frontend test framework