### PR TITLE
fix(chat): avoid false interrupt failure banner

### DIFF
--- a/core/session_turns.py
+++ b/core/session_turns.py
@@ -5075,12 +5075,12 @@ class SessionTurnManager:
         )
         if result.state in {"waiting_terminal", "interrupt_waiting"}:
             return {"ok": True, "session_id": session_id, "status": "cancel_requested"}
-        if result.state == "settled" and result.reason == "not_active":
+        if result.state == "settled":
             return {
                 "ok": True,
                 "session_id": session_id,
                 "status": "stale_released",
-                "reason": "not_active",
+                "reason": result.reason or "already_terminal",
             }
         return {
             "ok": False,

--- a/tests/scenarios/harness_failure_recovery/catalog.yaml
+++ b/tests/scenarios/harness_failure_recovery/catalog.yaml
@@ -3430,6 +3430,18 @@ scenarios:
     # A refused Stop leaves both owners intact, and an idle backlog starts directly
     # without a post-submit call racing and interrupting the newly started head.
     test: tests/test_internal_server.py::test_agent_run_send_now_interrupts_then_dispatches_the_fifo_head
+  - id: HFR-431
+    name: a terminal Turn racing a successful Stop receipt remains a successful cancel
+    status: covered
+    kind: recovery
+    layer: contract
+    backend: shared
+    # A backend may emit its terminal result synchronously while handling Stop.
+    # The exact durable Turn can therefore settle before the interrupt owner
+    # records its accepted receipt. That terminal snapshot is stronger evidence
+    # than the late receipt and must clear stale UI working state, not surface a
+    # false transport failure banner. A genuinely unresolved Stop remains 409.
+    test: tests/test_internal_server.py::test_cancel_accepts_terminal_settlement_that_races_the_stop_receipt
 manual_evidence:
   - local Incus backend process death after prompt acceptance
   - local Incus controller restart with persisted queued successor

--- a/tests/test_internal_server.py
+++ b/tests/test_internal_server.py
@@ -32,7 +32,7 @@ from sqlalchemy import select
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from core import internal_server, session_turns
-from core.run_settlement import SETTLED_BY_TERMINAL_RESULT
+from core.run_settlement import SETTLED_BY_STOPPED, SETTLED_BY_TERMINAL_RESULT
 from core.services.dispatch import (
     SOURCE_HUMAN,
     SOURCE_SCHEDULED,
@@ -2370,6 +2370,68 @@ def test_cancel_releases_stale_turn_when_backend_not_active(tmp_path, monkeypatc
         ).scalar_one()
     assert status == "idle"
     assert notices == [True]
+
+
+def test_cancel_accepts_terminal_settlement_that_races_the_stop_receipt(
+    tmp_path,
+    monkeypatch,
+):
+    """HFR-431: a successful Stop may emit terminal proof before its receipt lands."""
+
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    _engine, session, turn_id = _create_active_test_turn(
+        tmp_path,
+        native_id="proj_terminal_stop_race",
+    )
+    session_id = session["id"]
+    controller = _build_controller_double()
+    app = internal_server.create_app(controller)
+    transport = httpx.ASGITransport(app=app)
+
+    async def _go():
+        task = asyncio.create_task(asyncio.sleep(60))
+        context = MessageContext(
+            user_id="U",
+            channel_id="C",
+            platform="avibe",
+            platform_specific={"agent_session_id": session_id},
+        )
+        app.state.in_flight_dispatches[session_id] = session_turns.Turn(
+            task=task,
+            context=context,
+            logical_turn_id=turn_id,
+        )
+
+        async def _stop_and_settle(_context):
+            terminal = controller.session_turns._terminalize_durable_turn(
+                turn_id,
+                "canceled",
+                settled_by=SETTLED_BY_STOPPED,
+                evidence_kind="test_stop_terminal",
+            )
+            assert terminal["changed"] is True
+            return True
+
+        controller.command_handler.handle_stop = AsyncMock(
+            side_effect=_stop_and_settle
+        )
+        async with httpx.AsyncClient(
+            transport=transport,
+            base_url="http://testserver",
+        ) as client:
+            response = await client.post(f"/internal/cancel/{session_id}")
+        task.cancel()
+        await asyncio.gather(task, return_exceptions=True)
+        return response
+
+    response = asyncio.run(_go())
+    assert response.status_code == 200
+    assert response.json() == {
+        "ok": True,
+        "session_id": session_id,
+        "status": "stale_released",
+        "reason": "already_terminal",
+    }
 
 
 def test_cancel_waits_for_stale_dispatch_cleanup_before_releasing(tmp_path, monkeypatch):


### PR DESCRIPTION
## What changed

Treat an exact durable Turn that terminalizes while its successful Stop receipt is being recorded as a successful cancel. The Chat page now clears its stale working state instead of showing a false "couldn't reach the agent" banner, while genuinely unresolved or failed interrupts remain HTTP 409 failures.

## Scenario

- HFR-431: terminal Turn settlement races a successful Stop receipt

## Evidence

- Unit: focused cancel success, stale-backend, and failed-interrupt cases pass
- Contract: HFR-431 reproduces the exact terminal-before-receipt race through the internal cancel endpoint
- Scenario: Harness failure-recovery catalog records the new contract
- Adjacent: full `test_internal_server.py` and `test_session_delivery_fsm.py` suites pass (178 tests)
- Static: Ruff, Python compile, YAML catalog validation, and `git diff --check` pass

## Residual manual checks

- None; the user-visible branch is fully determined by the internal cancel response and existing `stale_released` handling.
