### PR TITLE
fix(ui): place attachment before voice control

### DIFF
--- a/ui/src/components/workbench/Composer.tsx
+++ b/ui/src/components/workbench/Composer.tsx
@@ -1081,9 +1081,9 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
           mediaEnabled ? 'pl-1.5' : 'pl-3.5',
         )}
       >
-        {/* Voice owns the first control slot so starting, finishing, processing,
-            retrying, and recovering all happen at the same left edge. Once a
-            voice flow starts, unrelated attachment controls withdraw. */}
+        {/* Attach stays in the first idle slot and voice starts in the second.
+            Once a voice flow starts, the unrelated attachment control withdraws
+            and the active voice action takes the left edge. */}
         {mediaEnabled && (
           <div className="flex items-end">
             <input
@@ -1097,6 +1097,21 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
                 e.target.value = '';
               }}
             />
+            {!voiceFlowActive && (
+              /* Attach uses a generic plus rather than a paperclip so it reads
+                 as the general "add anything" entry point. */
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                onClick={() => fileInputRef.current?.click()}
+                disabled={disabled}
+                aria-label={t('chat.compose.attach')}
+                className="h-9 w-7 shrink-0"
+              >
+                <Plus className="size-4" />
+              </Button>
+            )}
             {voiceControlMode === 'record' && (
               <Button
                 type="button"
@@ -1172,21 +1187,6 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
                 className="size-9 shrink-0"
               >
                 <Copy className="size-4" />
-              </Button>
-            )}
-            {!voiceFlowActive && (
-              /* Attach uses a generic plus rather than a paperclip: it reads as
-                 "add anything" while remaining secondary to voice input. */
-              <Button
-                type="button"
-                variant="ghost"
-                size="icon"
-                onClick={() => fileInputRef.current?.click()}
-                disabled={disabled}
-                aria-label={t('chat.compose.attach')}
-                className="h-9 w-7 shrink-0"
-              >
-                <Plus className="size-4" />
               </Button>
             )}
             {recording && (


### PR DESCRIPTION
## Summary

- Keep the attachment `+` as the leftmost idle composer control.
- Place the voice input button in the second slot.
- Preserve active voice behavior: attachment withdraws during the flow, Finish/loading/retry stay in the active left slot, and Trash remains at the opposite edge.

## Evidence

- Unit: `ChatArchivedReadOnly.test.tsx` (39 tests passed; existing voice lifecycle gating coverage).
- Contract: no API or i18n contract changes.
- Scenario: no cataloged scenario covers composer control ordering.
- Build: UI lint baseline and production build passed.
- Residual manual: deployed to an isolated Incus worktree environment; final visual acceptance remains for the integration pass.
