### PR TITLE
feat(ui): ⌘/Ctrl-click an app icon opens it in a browser tab

### DIFF
--- a/docs/plans/dock-pinned-show-page-apps.md
+++ b/docs/plans/dock-pinned-show-page-apps.md
@@ -811,12 +811,15 @@ behaves identically instead of re-deriving it):
     `shortcut` slot on the shared `ContextMenuItem`; the Dock menu widens to 268px only
     when that row is present).
   - **hover tooltips** spell the chord on the surfaces where a click is the only
-    affordance: the Dock tile (appended after the existing `⌥{n}` switch hint, and only
-    when the app HAS a tab surface), the App Library rows, and the Show Pages row's
-    open cluster.
+    affordance: the Dock tile (appended after the existing `⌥{n}` switch hint), the App
+    Library rows, and the Show Pages row's open cluster.
   - the **⌘K palette footer** gains a `⌘↵ New Tab` hint that appears **only while an app
     result is highlighted** — a message hit has no tab equivalent, so the hint travels
     with the target it applies to instead of always occupying the footer.
+  - EVERY hint is gated on `appTabHref` resolving for that exact target, not merely on
+    "this is an app": the Library falls back to a workbench window, so promising it a
+    tab would be a lie the click then breaks (Codex bot review on PR #1168, two P2s —
+    the Library row tooltip and the palette footer hint).
   - the chord text is one interpolated string, `apps.dock.newTabChord` = `{{key}}-click →
     new tab`, with `tabModifierLabel()` supplying `⌘`/`Ctrl` from the SAME `IS_APPLE`
     used by `appLaunchIntent` (a test asserts the labelled key is the one that actually

--- a/docs/plans/dock-pinned-show-page-apps.md
+++ b/docs/plans/dock-pinned-show-page-apps.md
@@ -759,6 +759,73 @@ Fix (structural):
   shared store. ShowPageShareControl's separate usage joins the same store.
 - No backend changes; icon endpoint caching unchanged.
 
+### 7.1m ⌘/Ctrl-click an app icon opens a browser tab (owner 2026-08-04)
+
+Owner request: clicking an app icon opens a workbench window; a **⌘/Ctrl-held click
+should open that app in a new BROWSER TAB** instead — the universal web convention.
+Modifier-click only; the plain click keeps opening a window.
+
+Rule (one shared, pure mapping in `ui/src/apps/appLaunch.ts`, so every launch surface
+behaves identically instead of re-deriving it):
+
+- `appLaunchIntent(modifiers)`: **the platform tab modifier → `newTab`**,
+  **Alt/Shift → `newWindow`**, otherwise `activate`. The tab modifier is **⌘ (without
+  Ctrl) on Apple, Ctrl (without ⌘) elsewhere** — the same `IS_APPLE` idiom the Editor
+  and Terminal chords use, because **macOS Ctrl+click is the right-click gesture** and
+  must not mean "new tab" there. The tab modifier wins when combined with Alt/Shift, so
+  a stray extra modifier still yields the requested tab. This RE-ASSIGNS the
+  pre-existing Dock behavior where ⌘/Ctrl/Alt all meant "another window": the tab
+  modifier now means the tab, and Alt keeps the window (Shift joins it as the browser's
+  own new-window modifier). New Window stays reachable from the tile's ＋ and its
+  right-click menu, so nothing is lost.
+- `isAppleContextClick(modifiers)`: a **mouse-only** guard — a Ctrl-held click on Apple
+  belongs to the context menu, so every mouse handler bails instead of also launching
+  (browsers differ on whether that click event fires at all). Deliberately NOT folded
+  into the intent: a **Ctrl+Enter keypress** is a normal launch, so only click paths ask.
+  It also requires `detail > 0`: Enter/Space on a `<button>` dispatches a synthetic
+  **click with `detail === 0`**, and without that check the guard would swallow the very
+  keyboard launch it is not meant to cover (Codex review 2026-08-04, Medium).
+- `IS_APPLE` was duplicated in `TerminalView` + `EditorApp`; this third consumer
+  promotes it to `ui/src/lib/platform.ts` (reuse ladder: extract on the third repeat).
+- `appTabHref(target)`: the app's own standalone browser surface — a Show Page →
+  `/show/<sid>/` (the SAME target as the tile's "Open in New Tab" menu item and the
+  window titlebar's external-open button, i.e. `registry.externalHref`), a built-in →
+  its in-shell `/apps/<id>` route. An app with **no** standalone surface returns null and
+  the click falls back to a window rather than doing nothing.
+  - That built-in mapping is an **allowlist** (`files` / `terminal` / `editor`), not
+    "every id has a route": `/apps/library` deliberately opens a Library WINDOW and
+    redirects the tab to `/` on desktop (it also serves the retired
+    `/admin/show-pages` bookmark), so treating it as a tab surface spawned a second
+    whole workbench instead of the app — and `preview` has no route at all. Both now
+    fall back to a window, and the Library tile's menu drops "Open in New Tab"
+    accordingly (Codex review 2026-08-04, High). A new app opts in there once its
+    standalone route exists.
+- Applies to every app-icon surface: the desktop **Dock** tiles, the **App Library**
+  rows (Apps + AI tabs), and the **⌘K / Search** app results — where ⌘/Ctrl+**Enter**
+  works too, since the intent reads modifiers off mouse AND keyboard events alike.
+- Discoverability (owner Q 2026-08-04 "do you show a hint for that shortcut?" — the
+  gesture was implemented with NO hint anywhere; these were added in answer):
+  - the Dock's **Open in New Tab** context item is no longer Show-Page-only — a built-in
+    has an `/apps/<id>` surface too, so every tile offers it as the visible twin of the
+    modifier-click — and it now carries a trailing **shortcut hint** (new optional
+    `shortcut` slot on the shared `ContextMenuItem`; the Dock menu widens to 268px only
+    when that row is present).
+  - **hover tooltips** spell the chord on the surfaces where a click is the only
+    affordance: the Dock tile (appended after the existing `⌥{n}` switch hint, and only
+    when the app HAS a tab surface), the App Library rows, and the Show Pages row's
+    open cluster.
+  - the **⌘K palette footer** gains a `⌘↵ New Tab` hint that appears **only while an app
+    result is highlighted** — a message hit has no tab equivalent, so the hint travels
+    with the target it applies to instead of always occupying the footer.
+  - the chord text is one interpolated string, `apps.dock.newTabChord` = `{{key}}-click →
+    new tab`, with `tabModifierLabel()` supplying `⌘`/`Ctrl` from the SAME `IS_APPLE`
+    used by `appLaunchIntent` (a test asserts the labelled key is the one that actually
+    opens a tab, so hint and behavior cannot drift). It replaces the orphan
+    `apps.dock.newInstanceHint` ("⌘-click for a new window"), which no code referenced
+    and which this change made false.
+- Mobile is untouched: no modifier keys there, and the tap paths (`/apps/*`,
+  `/apps/show/:sessionId`, §7.1b) keep the AppShell chrome as before.
+
 ### 7.2 Becoming an app: the ladder (owner Q&A 2026-07-13)
 
 Pinning **is** installing — no separate ceremony. Two entrances, one action:

--- a/docs/plans/dock-pinned-show-page-apps.md
+++ b/docs/plans/dock-pinned-show-page-apps.md
@@ -800,6 +800,25 @@ behaves identically instead of re-deriving it):
     fall back to a window, and the Library tile's menu drops "Open in New Tab"
     accordingly (Codex review 2026-08-04, High). A new app opts in there once its
     standalone route exists.
+  - The built-in href carries **`?standalone=1`** (`APP_TAB_PARAM`), and `AppShell`
+    freezes `isStandaloneAppTab(location.search)` **at mount** into
+    `<WindowManagerProvider standalone>`. Without it the tab was not standalone at all:
+    `/apps/*` live INSIDE `AppShell`, which restores `avibe.workbench.windows.v1` on
+    every desktop mount and always renders the higher-z `WindowLayer` — so a ⌘-clicked
+    Files tab came up underneath a restored Library window, and a persisted **maximized**
+    window hid it completely (Codex bot review on PR #1168, P2).
+    - Restore and persist are ONE predicate, `sharesWorkbenchLayout(standalone,
+      isDesktop)` in `workbenchPersistence`: a shell that skips the restore starts with
+      an empty list, so letting it save would clobber the real layout with `[]` in every
+      other tab. It also expresses the pre-existing below-md opt-out, unchanged.
+    - The flag is read from the LANDING url and frozen, never tracked off `location`:
+      navigating deeper inside the tab must not suddenly restore the layout the tab
+      exists to stay out of, nor re-enable that clobbering save.
+    - `WindowLayer` stays mounted (empty) in such a tab, so a window opened later from
+      inside it still renders — it just lives and dies with the tab.
+    - In-shell navigations to the same routes (the sidebar Apps launcher, a chat's
+      "open in editor", the mobile `/apps/*` tap paths) carry no flag and keep the
+      workbench layout exactly as before.
 - Applies to every app-icon surface: the desktop **Dock** tiles, the **App Library**
   rows (Apps + AI tabs), and the **⌘K / Search** app results — where ⌘/Ctrl+**Enter**
   works too, since the intent reads modifiers off mouse AND keyboard events alike.

--- a/ui/src/apps/LibraryApp.tsx
+++ b/ui/src/apps/LibraryApp.tsx
@@ -5,6 +5,13 @@ import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import clsx from 'clsx';
 
+import {
+  appLaunchIntent,
+  appTabHref,
+  isAppleContextClick,
+  tabModifierLabel,
+  type LaunchModifiers,
+} from './appLaunch';
 import { APP_LIST, APP_REGISTRY, type AppDefinition, type AppId } from './registry';
 import { deriveAppRows, partitionByDock, type AppRow } from './appLibrary';
 import { SHARED_ACTION_ZONE } from './rowLayout';
@@ -40,12 +47,24 @@ type LibraryTab = 'apps' | 'showpages';
  * navigate to their in-shell `/apps/*` route and a Show Page navigates to the
  * full-screen `/apps/show/:sessionId` route (§7.1b) — both keep the AppShell
  * chrome instead of dropping the user onto the raw page or a new browser tab.
+ *
+ * `launch` carries the opening event's modifiers so this surface honors the same
+ * rule as the Dock (§7.1m): the platform tab modifier (⌘ on Apple, Ctrl elsewhere)
+ * hands the app to the browser as a real tab. Otherwise — plain click, or an app
+ * with no standalone surface — the behavior above is unchanged.
  */
 function useOpenApp() {
   const wm = useWindowManager();
   const navigate = useNavigate();
   return useCallback(
-    (appId: AppId, opts?: { title?: string; sessionId?: string }) => {
+    (appId: AppId, opts?: { title?: string; sessionId?: string }, launch?: LaunchModifiers | null) => {
+      if (launch && appLaunchIntent(launch) === 'newTab') {
+        const href = appTabHref({ appId, sessionId: opts?.sessionId });
+        if (href) {
+          window.open(href, '_blank', 'noopener,noreferrer');
+          return;
+        }
+      }
       const desktop = typeof window !== 'undefined' && !!window.matchMedia?.('(min-width: 768px)').matches;
       if (desktop) {
         wm.openApp(appId, {
@@ -104,7 +123,10 @@ export const LibraryApp: React.FC<{ windowId?: string; params?: Record<string, u
         {tab === 'apps' ? (
           <AppsView pages={controller.pages} openApp={openApp} />
         ) : (
-          <ShowPagesView {...controller} onOpenApp={(sessionId, title) => openApp('showpage', { sessionId, title })} />
+          <ShowPagesView
+            {...controller}
+            onOpenApp={(sessionId, title, launch) => openApp('showpage', { sessionId, title }, launch)}
+          />
         )}
       </div>
     </div>
@@ -171,7 +193,8 @@ interface AppLibraryRowProps {
   leading?: React.ReactNode;
   /** The last row overall carries no bottom divider (single-list look). */
   last?: boolean;
-  onOpen: () => void;
+  /** Receives the opening event so a ⌘/Ctrl-click can open a browser tab (§7.1m). */
+  onOpen: (launch?: LaunchModifiers) => void;
   onDockToggle: () => void;
   onRemove?: () => void;
 }
@@ -190,11 +213,14 @@ const AppLibraryRow: React.FC<AppLibraryRowProps> = ({ item, leading, last, onOp
     <div
       role="button"
       tabIndex={0}
-      onClick={onOpen}
+      // Hover hint for the otherwise invisible modifier gesture (§7.1m).
+      title={t('apps.dock.newTabChord', { key: tabModifierLabel() })}
+      // A macOS Ctrl-click is the right-click gesture: leave it to the context menu.
+      onClick={(e) => !isAppleContextClick(e) && onOpen(e)}
       onKeyDown={(e) => {
         if (e.target === e.currentTarget && (e.key === 'Enter' || e.key === ' ')) {
           e.preventDefault();
-          onOpen();
+          onOpen(e);
         }
       }}
       className={clsx(
@@ -276,7 +302,7 @@ const AppLibraryRow: React.FC<AppLibraryRowProps> = ({ item, leading, last, onOp
 const DockedReorderRow: React.FC<{
   item: ResolvedRow;
   last?: boolean;
-  onOpen: () => void;
+  onOpen: (launch?: LaunchModifiers) => void;
   onDockToggle: () => void;
   onRemove?: () => void;
   onCommit: () => void;
@@ -305,12 +331,12 @@ const DockedReorderRow: React.FC<{
         item={item}
         last={last}
         leading={<GripHandle controls={controls} />}
-        onOpen={() => {
+        onOpen={(launch) => {
           if (draggedRef.current) {
             draggedRef.current = false;
             return;
           }
-          onOpen();
+          onOpen(launch);
         }}
         onDockToggle={onDockToggle}
         onRemove={onRemove}
@@ -389,15 +415,19 @@ const AppsView: React.FC<{ pages: ShowPage[]; openApp: ReturnType<typeof useOpen
     void setOrder(next);
   };
 
-  const openRow = (row: AppRow) =>
+  const openRow = (row: AppRow, launch?: LaunchModifiers) =>
     row.kind === 'builtin'
-      ? openApp(row.builtinId as AppId)
-      : openApp('showpage', {
-          sessionId: row.sessionId ?? '',
-          title: pageBySession.get(row.sessionId ?? '')?.title ?? undefined,
-        });
+      ? openApp(row.builtinId as AppId, undefined, launch)
+      : openApp(
+          'showpage',
+          {
+            sessionId: row.sessionId ?? '',
+            title: pageBySession.get(row.sessionId ?? '')?.title ?? undefined,
+          },
+          launch,
+        );
   const handlers = (item: ResolvedRow) => ({
-    onOpen: () => openRow(item.row),
+    onOpen: (launch?: LaunchModifiers) => openRow(item.row, launch),
     onDockToggle: () => void (item.row.docked ? undock(item.row.dockId) : dock(item.row.dockId)),
     onRemove: item.row.kind === 'showpage' && item.row.sessionId ? () => void unpin(item.row.sessionId!) : undefined,
   });

--- a/ui/src/apps/LibraryApp.tsx
+++ b/ui/src/apps/LibraryApp.tsx
@@ -8,6 +8,7 @@ import clsx from 'clsx';
 import {
   appLaunchIntent,
   appTabHref,
+  appTabHrefForDockId,
   isAppleContextClick,
   tabModifierLabel,
   type LaunchModifiers,
@@ -213,8 +214,14 @@ const AppLibraryRow: React.FC<AppLibraryRowProps> = ({ item, leading, last, onOp
     <div
       role="button"
       tabIndex={0}
-      // Hover hint for the otherwise invisible modifier gesture (§7.1m).
-      title={t('apps.dock.newTabChord', { key: tabModifierLabel() })}
+      // Hover hint for the otherwise invisible modifier gesture (§7.1m) — but only on a
+      // row that HAS a tab surface, or it would promise a tab where the Library (and
+      // any other window-only app) falls back to a workbench window.
+      title={
+        appTabHrefForDockId(row.dockId)
+          ? t('apps.dock.newTabChord', { key: tabModifierLabel() })
+          : undefined
+      }
       // A macOS Ctrl-click is the right-click gesture: leave it to the context menu.
       onClick={(e) => !isAppleContextClick(e) && onOpen(e)}
       onKeyDown={(e) => {

--- a/ui/src/apps/appLaunch.test.ts
+++ b/ui/src/apps/appLaunch.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  appLaunchIntent,
+  appTabHref,
+  appTabHrefForDockId,
+  isAppleContextClick,
+  tabModifierLabel,
+} from './appLaunch';
+import { showDockId } from '../context/dockDoc';
+
+const mods = (overrides: Partial<Record<'metaKey' | 'ctrlKey' | 'altKey' | 'shiftKey', boolean>> = {}) => ({
+  metaKey: false,
+  ctrlKey: false,
+  altKey: false,
+  shiftKey: false,
+  ...overrides,
+});
+
+const APPLE = true;
+const NON_APPLE = false;
+
+describe('appLaunchIntent', () => {
+  it('opens a browser tab on the platform tab modifier: ⌘ on Apple, Ctrl elsewhere', () => {
+    expect(appLaunchIntent(mods({ metaKey: true }), APPLE)).toBe('newTab');
+    expect(appLaunchIntent(mods({ ctrlKey: true }), NON_APPLE)).toBe('newTab');
+  });
+
+  it('does not treat the other platform’s modifier as the tab modifier', () => {
+    // macOS Ctrl+click is the right-click gesture, not a new tab.
+    expect(appLaunchIntent(mods({ ctrlKey: true }), APPLE)).not.toBe('newTab');
+    expect(appLaunchIntent(mods({ metaKey: true }), NON_APPLE)).not.toBe('newTab');
+    // Both held is ambiguous — neither platform claims it as the tab modifier.
+    expect(appLaunchIntent(mods({ metaKey: true, ctrlKey: true }), APPLE)).not.toBe('newTab');
+    expect(appLaunchIntent(mods({ metaKey: true, ctrlKey: true }), NON_APPLE)).not.toBe('newTab');
+  });
+
+  it('keeps Alt (and Shift) on a new workbench window', () => {
+    expect(appLaunchIntent(mods({ altKey: true }), APPLE)).toBe('newWindow');
+    expect(appLaunchIntent(mods({ shiftKey: true }), NON_APPLE)).toBe('newWindow');
+  });
+
+  it('prefers the tab when the tab modifier is combined with Alt/Shift', () => {
+    expect(appLaunchIntent(mods({ metaKey: true, altKey: true }), APPLE)).toBe('newTab');
+    expect(appLaunchIntent(mods({ ctrlKey: true, shiftKey: true }), NON_APPLE)).toBe('newTab');
+  });
+
+  it('activates on a plain click, and on a Ctrl+Enter keypress on Apple', () => {
+    expect(appLaunchIntent(mods(), APPLE)).toBe('activate');
+    expect(appLaunchIntent(mods({ ctrlKey: true }), APPLE)).toBe('activate');
+  });
+});
+
+describe('isAppleContextClick', () => {
+  it('flags a Ctrl-held mouse click on Apple only', () => {
+    expect(isAppleContextClick(mods({ ctrlKey: true }), APPLE)).toBe(true);
+    expect(isAppleContextClick(mods({ ctrlKey: true }), NON_APPLE)).toBe(false);
+    expect(isAppleContextClick(mods({ metaKey: true }), APPLE)).toBe(false);
+    expect(isAppleContextClick(mods(), APPLE)).toBe(false);
+  });
+
+  it('ignores a KEYBOARD-synthesized click (detail 0) — Ctrl+Enter must still launch', () => {
+    // Enter/Space on a <button> fires a click with detail 0; a real mouse click is ≥1.
+    expect(isAppleContextClick({ ...mods({ ctrlKey: true }), detail: 0 }, APPLE)).toBe(false);
+    expect(isAppleContextClick({ ...mods({ ctrlKey: true }), detail: 1 }, APPLE)).toBe(true);
+  });
+});
+
+describe('tabModifierLabel', () => {
+  it('names the key the hint should show, per platform', () => {
+    expect(tabModifierLabel(APPLE)).toBe('⌘');
+    expect(tabModifierLabel(NON_APPLE)).toBe('Ctrl');
+  });
+
+  it('agrees with the intent rule: the labelled key is the one that opens a tab', () => {
+    for (const isApple of [APPLE, NON_APPLE]) {
+      const held = tabModifierLabel(isApple) === '⌘' ? { metaKey: true } : { ctrlKey: true };
+      expect(appLaunchIntent(mods(held), isApple)).toBe('newTab');
+    }
+  });
+});
+
+describe('appTabHref', () => {
+  it('maps a built-in that stands alone to its /apps/<id> route', () => {
+    expect(appTabHref({ appId: 'files' })).toBe('/apps/files');
+    expect(appTabHref({ appId: 'terminal' })).toBe('/apps/terminal');
+    expect(appTabHref({ appId: 'editor' })).toBe('/apps/editor');
+  });
+
+  it('has no tab surface for a built-in whose route is not standalone on desktop', () => {
+    // /apps/library opens a Library WINDOW and redirects the tab to `/`; preview has
+    // no route at all. Both must fall back to a workbench window.
+    expect(appTabHref({ appId: 'library' })).toBeNull();
+    expect(appTabHref({ appId: 'preview' })).toBeNull();
+    expect(appTabHref({ appId: 'not-an-app' })).toBeNull();
+  });
+
+  it('maps a Show Page to its private /show/<sid>/ page', () => {
+    expect(appTabHref({ appId: 'showpage', sessionId: 'abc123' })).toBe('/show/abc123/');
+  });
+
+  it('encodes an unsafe session id', () => {
+    expect(appTabHref({ appId: 'showpage', sessionId: 'a b/c' })).toBe('/show/a%20b%2Fc/');
+  });
+
+  it('has no tab surface for a Show Page without a session id', () => {
+    expect(appTabHref({ appId: 'showpage' })).toBeNull();
+    expect(appTabHref({ appId: 'showpage', sessionId: '  ' })).toBeNull();
+    expect(appTabHref({ appId: '' })).toBeNull();
+  });
+});
+
+describe('appTabHrefForDockId', () => {
+  it('resolves both Dock id kinds', () => {
+    expect(appTabHrefForDockId('terminal')).toBe('/apps/terminal');
+    expect(appTabHrefForDockId(showDockId('sess42'))).toBe('/show/sess42/');
+    expect(appTabHrefForDockId('library')).toBeNull();
+  });
+});

--- a/ui/src/apps/appLaunch.test.ts
+++ b/ui/src/apps/appLaunch.test.ts
@@ -5,6 +5,7 @@ import {
   appTabHref,
   appTabHrefForDockId,
   isAppleContextClick,
+  isStandaloneAppTab,
   tabModifierLabel,
 } from './appLaunch';
 import { showDockId } from '../context/dockDoc';
@@ -81,10 +82,19 @@ describe('tabModifierLabel', () => {
 });
 
 describe('appTabHref', () => {
-  it('maps a built-in that stands alone to its /apps/<id> route', () => {
-    expect(appTabHref({ appId: 'files' })).toBe('/apps/files');
-    expect(appTabHref({ appId: 'terminal' })).toBe('/apps/terminal');
-    expect(appTabHref({ appId: 'editor' })).toBe('/apps/editor');
+  it('maps a built-in that stands alone to its /apps/<id> route, flagged as a single-app tab', () => {
+    expect(appTabHref({ appId: 'files' })).toBe('/apps/files?standalone=1');
+    expect(appTabHref({ appId: 'terminal' })).toBe('/apps/terminal?standalone=1');
+    expect(appTabHref({ appId: 'editor' })).toBe('/apps/editor?standalone=1');
+  });
+
+  it('emits a flag the shell actually recognizes', () => {
+    // The href and the shell-side reader must not drift: a silently-unread param
+    // would restore the saved windows over the very app the tab was opened for.
+    for (const appId of ['files', 'terminal', 'editor']) {
+      const href = appTabHref({ appId })!;
+      expect(isStandaloneAppTab(href.slice(href.indexOf('?')))).toBe(true);
+    }
   });
 
   it('has no tab surface for a built-in whose route is not standalone on desktop', () => {
@@ -110,9 +120,26 @@ describe('appTabHref', () => {
   });
 });
 
+describe('isStandaloneAppTab', () => {
+  it('recognizes only the tab flag', () => {
+    expect(isStandaloneAppTab('?standalone=1')).toBe(true);
+    expect(isStandaloneAppTab('?view=pages&standalone=1')).toBe(true);
+    expect(isStandaloneAppTab('?standalone=0')).toBe(false);
+    expect(isStandaloneAppTab('?standalone')).toBe(false);
+    expect(isStandaloneAppTab('?view=pages')).toBe(false);
+    expect(isStandaloneAppTab('')).toBe(false);
+  });
+
+  it('is false for an in-shell navigation to the same route', () => {
+    // The sidebar Apps launcher and a chat's "open in editor" land on /apps/editor
+    // WITHOUT the flag; those must keep the workbench windows they navigated from.
+    expect(isStandaloneAppTab(new URL('http://x/apps/editor').search)).toBe(false);
+  });
+});
+
 describe('appTabHrefForDockId', () => {
   it('resolves both Dock id kinds', () => {
-    expect(appTabHrefForDockId('terminal')).toBe('/apps/terminal');
+    expect(appTabHrefForDockId('terminal')).toBe('/apps/terminal?standalone=1');
     expect(appTabHrefForDockId(showDockId('sess42'))).toBe('/show/sess42/');
     expect(appTabHrefForDockId('library')).toBeNull();
   });

--- a/ui/src/apps/appLaunch.ts
+++ b/ui/src/apps/appLaunch.ts
@@ -92,14 +92,28 @@ export interface AppTabTarget {
 const STANDALONE_BUILTIN_ROUTES = new Set(['files', 'terminal', 'editor']);
 
 /**
+ * Marks a tab that was opened to show ONE app, so `AppShell` mounts without the
+ * persisted workbench window layout (`WindowManagerProvider` otherwise restores
+ * `avibe.workbench.windows.v1` on every desktop mount, and `WindowLayer` floats those
+ * windows above the route outlet — a ⌘-clicked Files tab would open underneath a
+ * restored Library window, and a maximized one would hide it outright).
+ *
+ * A URL param rather than shell state, so the mode survives a reload/bookmark of the
+ * tab and stays invisible to the in-shell navigations (the sidebar Apps launcher, a
+ * chat's "open in editor") that legitimately WANT the workbench layout.
+ */
+export const APP_TAB_PARAM = 'standalone';
+
+/**
  * The URL that shows an app on its OWN browser tab, or null when it has no
  * standalone surface (so the caller can fall back to a window).
  *
  *  - a Show Page → its private `/show/<sid>/` page, the SAME target as the tile's
  *    "Open in New Tab" menu item and the window titlebar's external-open button
  *    (`registry.externalHref`): the page itself, full viewport, no workbench chrome.
- *  - a built-in → its in-shell `/apps/<id>` route, but only the ones that stand alone
- *    on desktop (see `STANDALONE_BUILTIN_ROUTES`).
+ *  - a built-in → its in-shell `/apps/<id>` route — only the ones that stand alone on
+ *    desktop (see `STANDALONE_BUILTIN_ROUTES`) — flagged with `APP_TAB_PARAM` so the
+ *    shell suppresses the restored window layer over it.
  *
  * Pure.
  */
@@ -109,7 +123,24 @@ export function appTabHref(target: AppTabTarget): string | null {
     return sessionId ? showPagePrivatePath(sessionId) : null;
   }
   const appId = target.appId.trim();
-  return STANDALONE_BUILTIN_ROUTES.has(appId) ? `/apps/${appId}` : null;
+  return STANDALONE_BUILTIN_ROUTES.has(appId) ? `/apps/${appId}?${APP_TAB_PARAM}=1` : null;
+}
+
+/**
+ * Whether THIS document was opened as a standalone app tab (`appTabHref` above).
+ * Read once at shell mount: the answer must not flip while the tab lives, or a later
+ * in-tab navigation would re-restore the layout the tab was opened to avoid — and,
+ * worse, a suppressed-then-enabled save would clobber the real layout with `[]`.
+ *
+ * Takes the raw `location.search` so it stays pure and testable.
+ */
+export function isStandaloneAppTab(search: string): boolean {
+  if (!search) return false;
+  try {
+    return new URLSearchParams(search).get(APP_TAB_PARAM) === '1';
+  } catch {
+    return false;
+  }
 }
 
 /** `appTabHref` for a persisted Dock id (`files` / `show:<session_id>`). Pure. */

--- a/ui/src/apps/appLaunch.ts
+++ b/ui/src/apps/appLaunch.ts
@@ -1,0 +1,119 @@
+// How a modifier-held click/Enter on an app icon launches the app, plus the
+// standalone browser URL a "new tab" launch needs. Kept pure (no React, no DOM)
+// so EVERY launch surface — the desktop Dock, the App Library rows, the ⌘K
+// results — shares ONE rule and one testable mapping instead of re-deriving it.
+
+import { dockIdToSession } from '../context/dockDoc';
+import { IS_APPLE } from '../lib/platform';
+import { showPagePrivatePath } from './showPageAvatar';
+
+/**
+ * What a click (or Enter) on an app icon should do:
+ *  - `newTab`    — the platform's tab modifier (⌘ on Apple, Ctrl elsewhere): hand the
+ *                  app to the browser as a real tab, matching the universal web
+ *                  convention for a modifier-click.
+ *  - `newWindow` — Alt or Shift held: another workbench window for the same app (Alt
+ *                  kept the pre-⌘ behavior; Shift is the browser's own new-window
+ *                  modifier, so both read naturally).
+ *  - `activate`  — plain click: focus / un-minimize / launch (surface-defined).
+ */
+export type AppLaunchIntent = 'newTab' | 'newWindow' | 'activate';
+
+/** The modifier flags a launch intent is read from — satisfied by React's mouse
+ *  AND keyboard synthetic events, so ⌘-click and ⌘+Enter map identically. */
+export interface LaunchModifiers {
+  metaKey: boolean;
+  ctrlKey: boolean;
+  altKey: boolean;
+  shiftKey: boolean;
+}
+
+/**
+ * Map held modifiers to a launch intent. The tab modifier is platform-aware — ⌘
+ * (without Ctrl) on Apple, Ctrl (without ⌘) elsewhere — the same idiom the Editor and
+ * Terminal chords use: on macOS Ctrl+click is the right-click gesture, so it must not
+ * mean "new tab" there (see `isAppleContextClick`). `isApple` is injectable so the
+ * rule is testable on both platforms.
+ */
+export function appLaunchIntent(event: LaunchModifiers, isApple: boolean = IS_APPLE): AppLaunchIntent {
+  if (isApple ? event.metaKey && !event.ctrlKey : event.ctrlKey && !event.metaKey) return 'newTab';
+  if (event.altKey || event.shiftKey) return 'newWindow';
+  return 'activate';
+}
+
+/**
+ * Whether a MOUSE click is really macOS's right-click gesture (Ctrl held on an Apple
+ * platform). Such a click belongs to the context menu — the surface must do nothing,
+ * or the gesture would open the menu AND launch the app in browsers that still emit
+ * the click. Only mouse handlers ask this; a Ctrl+Enter keypress is a normal launch,
+ * which is why the check is separate from `appLaunchIntent`.
+ */
+export function isAppleContextClick(
+  event: Pick<LaunchModifiers, 'ctrlKey'> & { detail?: number },
+  isApple: boolean = IS_APPLE,
+): boolean {
+  if (!isApple || !event.ctrlKey) return false;
+  // Enter/Space on a <button> (or a role="button") dispatches a synthetic CLICK whose
+  // `detail` is 0, unlike a real mouse click (≥1). Without this check a Ctrl+Enter
+  // keypress on Apple would be swallowed as a right-click and launch nothing — the
+  // keyboard path this guard is explicitly not meant to cover.
+  return (event.detail ?? 1) > 0;
+}
+
+/**
+ * How the tab modifier is WRITTEN in a hint — the ⌘ glyph on Apple, the word `Ctrl`
+ * elsewhere (Apple users read glyphs, everyone else reads names). Not translated: it
+ * names a physical key. Interpolate it into `apps.dock.newTabChord` rather than
+ * hard-coding a chord in any locale string, so the hint can never disagree with
+ * `appLaunchIntent`.
+ */
+export function tabModifierLabel(isApple: boolean = IS_APPLE): string {
+  return isApple ? '⌘' : 'Ctrl';
+}
+
+/** An app to resolve a standalone browser URL for: a built-in by id, or a
+ *  Show Page by session id (`appId: 'showpage'`). */
+export interface AppTabTarget {
+  appId: string;
+  sessionId?: string | null;
+}
+
+/**
+ * Built-ins whose `/apps/<id>` route really renders the app STANDALONE on desktop
+ * (App.tsx: `AppsFileBrowserPage` / `AppsTerminalPage` / `AppsEditorPage`).
+ *
+ * An allowlist, not a denylist, because the route is NOT a given: `/apps/library`
+ * deliberately opens a Library WINDOW and redirects the tab to `/` on desktop (it also
+ * serves the retired `/admin/show-pages` bookmark), so handing it to a new tab would
+ * spawn a second whole workbench instead of the app — and `preview` has no route at
+ * all. Both must fall back to a window. A new app therefore opts in HERE once its
+ * standalone route exists, and until then degrades to the plain-click behavior.
+ */
+const STANDALONE_BUILTIN_ROUTES = new Set(['files', 'terminal', 'editor']);
+
+/**
+ * The URL that shows an app on its OWN browser tab, or null when it has no
+ * standalone surface (so the caller can fall back to a window).
+ *
+ *  - a Show Page → its private `/show/<sid>/` page, the SAME target as the tile's
+ *    "Open in New Tab" menu item and the window titlebar's external-open button
+ *    (`registry.externalHref`): the page itself, full viewport, no workbench chrome.
+ *  - a built-in → its in-shell `/apps/<id>` route, but only the ones that stand alone
+ *    on desktop (see `STANDALONE_BUILTIN_ROUTES`).
+ *
+ * Pure.
+ */
+export function appTabHref(target: AppTabTarget): string | null {
+  if (target.appId === 'showpage') {
+    const sessionId = (target.sessionId ?? '').trim();
+    return sessionId ? showPagePrivatePath(sessionId) : null;
+  }
+  const appId = target.appId.trim();
+  return STANDALONE_BUILTIN_ROUTES.has(appId) ? `/apps/${appId}` : null;
+}
+
+/** `appTabHref` for a persisted Dock id (`files` / `show:<session_id>`). Pure. */
+export function appTabHrefForDockId(dockId: string): string | null {
+  const sessionId = dockIdToSession(dockId);
+  return sessionId !== null ? appTabHref({ appId: 'showpage', sessionId }) : appTabHref({ appId: dockId });
+}

--- a/ui/src/components/AppShell.tsx
+++ b/ui/src/components/AppShell.tsx
@@ -4,6 +4,7 @@ import { ArrowLeft, Bot, ChevronDown, Cpu, FolderTree, Globe, Grid2x2, Hash, Inb
 import { useTranslation } from 'react-i18next';
 import clsx from 'clsx';
 
+import { isStandaloneAppTab } from '../apps/appLaunch';
 import { modelHubEnabledFromConfig } from './settings/models/featureFlags';
 import { useApi } from '../context/ApiContext';
 import { useStatus } from '../context/StatusContext';
@@ -228,6 +229,13 @@ export const AppShell: React.FC = () => {
   // The mobile Dock drawer (opened from the workbench Apps tab). Like the admin
   // sheet it closes on any route change — tapping a tile navigates + dismisses.
   const [appsDrawerOpen, setAppsDrawerOpen] = useState(false);
+  // Whether this DOCUMENT was opened as a single-app tab (⌘/Ctrl-click on an app icon,
+  // §7.1m). Frozen at mount from the landing URL rather than tracked off `location`, so
+  // navigating deeper inside the tab can't suddenly restore the workbench window layout
+  // this tab exists to stay out of — nor re-enable the save that would clobber it.
+  const [standaloneAppTab] = useState(() =>
+    typeof window === 'undefined' ? false : isStandaloneAppTab(window.location.search),
+  );
   // Mirror the iOS visual-viewport height into --app-vvh. The MOBILE shell is a
   // static locked column that does NOT read it (resizing the shell mid-focus
   // fought iOS's scroll-into-view and flung the input off-screen); only the md+
@@ -401,7 +409,7 @@ export const AppShell: React.FC = () => {
     // fought iOS's own scroll-into-view and threw the input off-screen. iOS instead
     // pans the locked page to lift the focused composer above the keyboard.
     // Desktop: normal document flow.
-    <WindowManagerProvider>
+    <WindowManagerProvider standalone={standaloneAppTab}>
     <DockProvider>
     <ShowPageDragProvider>
     <div className="flex h-[var(--app-shell-h)] flex-col overflow-hidden bg-background text-foreground md:block md:h-auto md:min-h-screen md:overflow-visible">

--- a/ui/src/components/ShowPagesPage.tsx
+++ b/ui/src/components/ShowPagesPage.tsx
@@ -25,7 +25,7 @@ import { useWindowManager } from '../context/WindowManagerContext';
 import { copyTextToClipboard } from '../lib/utils';
 import { copyHref, displayLink, type ShowPageLinkInfo } from '../lib/showPageLinks';
 import { type ShowPage, type ShowPagesController, type Visibility } from './useShowPages';
-import { isAppleContextClick, tabModifierLabel, type LaunchModifiers } from '../apps/appLaunch';
+import { appTabHref, isAppleContextClick, tabModifierLabel, type LaunchModifiers } from '../apps/appLaunch';
 import { filterShowPages, type ShowPageFilter } from '../apps/appLibrary';
 import { SHARED_ACTION_ZONE } from '../apps/rowLayout';
 import { ShowPageAvatarTile } from '../apps/showPageAvatarTile';
@@ -130,8 +130,16 @@ function ShowPageRow({
             type="button"
             // A macOS Ctrl-click is the right-click gesture: leave it to the context menu.
             onClick={(e) => !isAppleContextClick(e) && onOpen(e)}
-            // …plus the modifier gesture, which has no other tell here (§7.1m).
-            title={`${t('showPages.openApp')} · ${t('apps.dock.newTabChord', { key: tabModifierLabel() })}`}
+            // …plus the modifier gesture, which has no other tell here — appended only
+            // when this page really resolves to a tab surface (§7.1m).
+            title={[
+              t('showPages.openApp'),
+              appTabHref({ appId: 'showpage', sessionId: page.session_id })
+                ? t('apps.dock.newTabChord', { key: tabModifierLabel() })
+                : null,
+            ]
+              .filter(Boolean)
+              .join(' · ')}
             className="group flex min-w-0 cursor-pointer items-center gap-3 rounded-lg text-left transition-colors hover:bg-foreground/[0.03]"
           >
             <ShowPageAvatarTile sessionId={page.session_id} title={page.title || ''} iconVersion={page.icon_version} />

--- a/ui/src/components/ShowPagesPage.tsx
+++ b/ui/src/components/ShowPagesPage.tsx
@@ -25,6 +25,7 @@ import { useWindowManager } from '../context/WindowManagerContext';
 import { copyTextToClipboard } from '../lib/utils';
 import { copyHref, displayLink, type ShowPageLinkInfo } from '../lib/showPageLinks';
 import { type ShowPage, type ShowPagesController, type Visibility } from './useShowPages';
+import { isAppleContextClick, tabModifierLabel, type LaunchModifiers } from '../apps/appLaunch';
 import { filterShowPages, type ShowPageFilter } from '../apps/appLibrary';
 import { SHARED_ACTION_ZONE } from '../apps/rowLayout';
 import { ShowPageAvatarTile } from '../apps/showPageAvatarTile';
@@ -53,7 +54,8 @@ interface RowProps {
   busy: boolean;
   copied: boolean;
   installed: boolean;
-  onOpen: () => void;
+  /** Receives the opening event so a ⌘/Ctrl-click can open a browser tab (§7.1m). */
+  onOpen: (launch?: LaunchModifiers) => void;
   onToggleExpand: () => void;
   onToggleInstall: (next: boolean) => void;
   onRename: (title: string | null) => Promise<void>;
@@ -126,8 +128,10 @@ function ShowPageRow({
         <div className="flex min-w-0 flex-1">
           <button
             type="button"
-            onClick={onOpen}
-            title={t('showPages.openApp')}
+            // A macOS Ctrl-click is the right-click gesture: leave it to the context menu.
+            onClick={(e) => !isAppleContextClick(e) && onOpen(e)}
+            // …plus the modifier gesture, which has no other tell here (§7.1m).
+            title={`${t('showPages.openApp')} · ${t('apps.dock.newTabChord', { key: tabModifierLabel() })}`}
             className="group flex min-w-0 cursor-pointer items-center gap-3 rounded-lg text-left transition-colors hover:bg-foreground/[0.03]"
           >
             <ShowPageAvatarTile sessionId={page.session_id} title={page.title || ''} iconVersion={page.icon_version} />
@@ -472,7 +476,9 @@ export function ShowPagesView({
   onShareIdSaved,
   reload,
   onOpenApp,
-}: ShowPagesController & { onOpenApp?: (sessionId: string, title?: string) => void }) {
+}: ShowPagesController & {
+  onOpenApp?: (sessionId: string, title?: string, launch?: LaunchModifiers) => void;
+}) {
   const { t } = useTranslation();
   const { isPinned, pin, unpin } = useDock();
   const { windows, setParams, setTitle } = useWindowManager();
@@ -561,7 +567,7 @@ export function ShowPagesView({
               busy={busyId === page.session_id}
               copied={copiedId === page.session_id}
               installed={isPinned(page.session_id)}
-              onOpen={() => onOpenApp?.(page.session_id, page.title ?? undefined)}
+              onOpen={(launch) => onOpenApp?.(page.session_id, page.title ?? undefined, launch)}
               onToggleExpand={() => setExpandedId((id) => (id === page.session_id ? null : page.session_id))}
               onToggleInstall={(next) => (next ? pin(page.session_id) : unpin(page.session_id))}
               onRename={(title) => rename(page, title)}

--- a/ui/src/components/apps/Dock.tsx
+++ b/ui/src/components/apps/Dock.tsx
@@ -4,8 +4,9 @@ import { Copy, ExternalLink, LayoutGrid, PinOff, Plus, SquarePlus } from 'lucide
 import { useTranslation } from 'react-i18next';
 import clsx from 'clsx';
 
+import { appLaunchIntent, appTabHref, isAppleContextClick, tabModifierLabel } from '../../apps/appLaunch';
 import { APP_REGISTRY, type AppDefinition, type AppId } from '../../apps/registry';
-import { showPageAvatar, showPageIconUrl, showPagePrivatePath } from '../../apps/showPageAvatar';
+import { showPageAvatar, showPageIconUrl } from '../../apps/showPageAvatar';
 import { ShowPageAvatarContent } from '../../apps/showPageAvatarTile';
 import { useDock } from '../../context/DockContext';
 import { dockIdToSession } from '../../context/dockDoc';
@@ -25,9 +26,10 @@ type ResidentItem =
 // order); a running app's tile reveals a ＋ (and a right-click menu) to open
 // another window. EVERY tile — built-ins included (§7.1c) — can be unpinned from
 // the Dock via the right-click menu (it stays installed, so the Apps view can
-// re-dock it); pinned Show Pages additionally offer Open in New Tab. When the Dock
-// is empty it shows an App Library shortcut rather than a dead surface. The
-// minimized-window strip trails the row and is not reorderable.
+// re-dock it), and every tile offers Open in New Tab, which a ⌘/Ctrl-click on the
+// icon also performs (§7.1m). When the Dock is empty it shows an App Library
+// shortcut rather than a dead surface. The minimized-window strip trails the row
+// and is not reorderable.
 export const Dock: React.FC = () => {
   const { t } = useTranslation();
   const wm = useWindowManager();
@@ -134,9 +136,23 @@ export const Dock: React.FC = () => {
     setMenu(null);
   };
 
-  const openExternal = (sessionId: string) => {
-    window.open(showPagePrivatePath(sessionId), '_blank', 'noopener,noreferrer');
+  // The app's own standalone browser surface: a Show Page's `/show/<sid>/` page,
+  // a built-in's `/apps/<id>` route (§7.1m, shared pure mapping).
+  const tabHrefFor = (item: ResidentItem) =>
+    item.kind === 'builtin' ? appTabHref({ appId: item.id }) : appTabHref({ appId: 'showpage', sessionId: item.sessionId });
+
+  // The gesture is invisible otherwise, so it is spelled out in the two places a user
+  // already looks: the tile's hover tooltip and the right-click menu row it mirrors.
+  const tabChord = t('apps.dock.newTabChord', { key: tabModifierLabel() });
+
+  // Hand the app to the browser as a real tab. Returns false when the app has no
+  // standalone surface, so a ⌘-click can fall back to a workbench window.
+  const openInTab = (item: ResidentItem) => {
+    const href = tabHrefFor(item);
     setMenu(null);
+    if (!href) return false;
+    window.open(href, '_blank', 'noopener,noreferrer');
+    return true;
   };
 
   // Unpin from the Dock = undock (remove from `order`) for ANY tile, built-ins
@@ -157,9 +173,9 @@ export const Dock: React.FC = () => {
 
   const menuItemCount = (item: ResidentItem) => {
     const running = windowsFor(item).length > 0;
-    // New Window (+ Show All Windows if running) + [Open in New Tab for a
-    // Show Page] + Unpin from Dock (every tile).
-    return 1 + (running ? 1 : 0) + (item.kind === 'showpage' ? 1 : 0) + 1;
+    // New Window (+ Show All Windows if running) + Open in New Tab (any tile with
+    // a standalone surface) + Unpin from Dock (every tile).
+    return 1 + (running ? 1 : 0) + (tabHrefFor(item) ? 1 : 0) + 1;
   };
 
   return (
@@ -191,9 +207,13 @@ export const Dock: React.FC = () => {
                 <div className="relative">
                   <button
                     type="button"
-                    title={
-                      index < 9 ? `${label} · ${t('apps.dock.switchShortcut', { number: index + 1 })}` : label
-                    }
+                    title={[
+                      label,
+                      index < 9 ? t('apps.dock.switchShortcut', { number: index + 1 }) : null,
+                      tabHrefFor(item) ? tabChord : null,
+                    ]
+                      .filter(Boolean)
+                      .join(' · ')}
                     aria-label={label}
                     onPointerDown={(e) => {
                       pressPtRef.current = { x: e.clientX, y: e.clientY };
@@ -207,8 +227,16 @@ export const Dock: React.FC = () => {
                       const press = pressPtRef.current;
                       pressPtRef.current = null;
                       if (e.detail !== 0 && isDragRelease(press, { x: e.clientX, y: e.clientY })) return;
-                      if (e.metaKey || e.ctrlKey || e.altKey) openNew(item);
-                      else activate(item);
+                      // Modifier click (§7.1m): the platform tab modifier (⌘ on Apple,
+                      // Ctrl elsewhere) → a real browser tab, Alt/Shift → another
+                      // workbench window. An app with no standalone surface falls back
+                      // to a window rather than doing nothing. A macOS Ctrl-click is the
+                      // right-click gesture — onContextMenu owns it, so do nothing here.
+                      if (isAppleContextClick(e)) return;
+                      const intent = appLaunchIntent(e);
+                      if (intent === 'newTab' && openInTab(item)) return;
+                      if (intent === 'activate') activate(item);
+                      else openNew(item);
                     }}
                     onContextMenu={(e) => {
                       e.preventDefault();
@@ -365,9 +393,9 @@ export const Dock: React.FC = () => {
           // survives into the item onClick closures (a mutable `menu.item` would
           // widen back to ResidentItem inside them).
           const item = menu.item;
-          const showpage = item.kind === 'showpage' ? item : null;
+          const hasTab = !!tabHrefFor(item);
           return (
-            <ContextMenu x={menu.x} y={menu.y} onClose={() => setMenu(null)} width={196} itemCount={menuItemCount(item)}>
+            <ContextMenu x={menu.x} y={menu.y} onClose={() => setMenu(null)} width={hasTab ? 268 : 196} itemCount={menuItemCount(item)}>
               <ContextMenuItem
                 icon={<SquarePlus className="size-[15px] text-cyan" />}
                 label={t('apps.dock.newWindow')}
@@ -380,11 +408,15 @@ export const Dock: React.FC = () => {
                   onClick={() => showAll(item)}
                 />
               )}
-              {showpage && (
+              {/* Open in New Tab is no longer Show-Page-only: a built-in has an
+                  `/apps/<id>` surface too, and this is the discoverable twin of the
+                  ⌘/Ctrl-click on the icon (§7.1m). */}
+              {hasTab && (
                 <ContextMenuItem
                   icon={<ExternalLink className="size-[15px]" />}
                   label={t('apps.dock.openInNewTab')}
-                  onClick={() => openExternal(showpage.sessionId)}
+                  shortcut={tabChord}
+                  onClick={() => openInTab(item)}
                 />
               )}
               {/* Unpin (undock) is available on EVERY tile now, built-ins included. */}

--- a/ui/src/components/ui/context-menu.tsx
+++ b/ui/src/components/ui/context-menu.tsx
@@ -9,9 +9,13 @@ import clsx from 'clsx';
 export const ContextMenuItem: React.FC<{
   icon?: React.ReactNode;
   label: string;
+  /** Trailing, muted key/gesture hint (e.g. `⌘-click → new tab`) — the discoverable
+   *  twin of an item that also has a modifier gesture. Grows the menu's needed width,
+   *  so pass `width` on the parent `ContextMenu` accordingly. */
+  shortcut?: string;
   danger?: boolean;
   onClick: () => void;
-}> = ({ icon, label, danger, onClick }) => (
+}> = ({ icon, label, shortcut, danger, onClick }) => (
   <button
     type="button"
     role="menuitem"
@@ -22,7 +26,10 @@ export const ContextMenuItem: React.FC<{
     )}
   >
     {icon !== undefined && <span className="grid size-4 shrink-0 place-items-center">{icon}</span>}
-    {label}
+    <span className="min-w-0 truncate">{label}</span>
+    {shortcut && (
+      <span className="ml-auto shrink-0 pl-2 font-mono text-[10px] leading-none text-muted">{shortcut}</span>
+    )}
   </button>
 );
 

--- a/ui/src/components/workbench/EditorApp.tsx
+++ b/ui/src/components/workbench/EditorApp.tsx
@@ -8,6 +8,7 @@ import { MAX_RESTORED_TABS, WINDOW_RESTORE_PARAM } from '../../lib/workbenchPers
 import { FilesApiError, contentUrl, downloadFile, fileMeta, joinPath, parentDir, writeFile, type FsEntry } from '../../lib/filesApi';
 import { isEditableFile, isEditableMeta, previewOverlayKind, previewRenderKind } from '../../lib/filePreview';
 import { adjustEditorFontSize, resetEditorFontSize } from '../../lib/editorFontSize';
+import { IS_APPLE } from '../../lib/platform';
 import { forgetRecentFile, loadEditorRecents, recentPathLabel, rememberRecentFile, rememberRecentFolder, removeRecentFile, type EditorRecents, type RecentFile } from '../../lib/editorRecents';
 import { FileTree } from './FileTree';
 import { FilePreview } from '../ui/file-preview';
@@ -76,10 +77,6 @@ type RecentOpenResult = 'opened' | 'gone' | 'unavailable';
 // (Monaco's detected insertSpaces / tabSize). Stored per tab so switching tabs shows the target
 // file's real values immediately, without waiting for its cursor to move.
 type PaneStatus = { line: number; col: number; insertSpaces: boolean; tabSize: number };
-
-const IS_APPLE =
-  typeof navigator !== 'undefined' &&
-  /Mac|iP(hone|ad|od)/i.test(navigator.platform || navigator.userAgent || '');
 
 type FontZoom = 'in' | 'out' | 'reset';
 function fontZoomIntent(e: KeyboardEvent): FontZoom | null {

--- a/ui/src/components/workbench/TerminalView.tsx
+++ b/ui/src/components/workbench/TerminalView.tsx
@@ -15,6 +15,7 @@ import {
   resetTerminalFontSize,
   subscribeTerminalFontSize,
 } from '../../lib/terminalFontSize';
+import { IS_APPLE } from '../../lib/platform';
 import { useLatestRef } from '@/lib/useLatestRef';
 
 // xterm.js wired to the /api/terminal/{id} WebSocket. Protocol (locked with the
@@ -75,12 +76,8 @@ function buildWsUrl(sessionId: string, cwd?: string | null): string {
   return cwd ? `${base}?cwd=${encodeURIComponent(cwd)}` : base;
 }
 
-// Apple vs. non-Apple decides the Find chord below. Detected once (navigator.platform is deprecated but
-// remains the most reliable signal, with userAgent as a fallback).
-const IS_APPLE =
-  typeof navigator !== 'undefined' &&
-  /Mac|iP(hone|ad|od)/i.test(navigator.platform || navigator.userAgent || '');
-
+// Apple vs. non-Apple decides the Find chord below (shared detection in lib/platform).
+//
 // The chord that opens Find: ⌘F on Apple platforms, Ctrl+Shift+F everywhere else. Plain Ctrl+F is a live
 // terminal key on BOTH macOS and Linux (readline forward-char, less/vim page-forward), so it must keep
 // reaching the PTY — hence ⌘ on Apple (a free modifier) and the Shift-qualified chord elsewhere, which is

--- a/ui/src/components/workbench/search/AppSearchResults.tsx
+++ b/ui/src/components/workbench/search/AppSearchResults.tsx
@@ -2,6 +2,7 @@ import { useTranslation } from 'react-i18next';
 import { LayoutGrid } from 'lucide-react';
 import clsx from 'clsx';
 
+import { isAppleContextClick, type LaunchModifiers } from '../../../apps/appLaunch';
 import { APP_REGISTRY } from '../../../apps/registry';
 import { ShowPageAvatarTile } from '../../../apps/showPageAvatarTile';
 import { Button } from '../../ui/button';
@@ -10,7 +11,8 @@ import type { AppSearchResult } from './appSearch';
 type AppSearchResultSectionProps = {
   results: AppSearchResult[];
   selectedKey?: string;
-  onSelect: (result: AppSearchResult) => void;
+  /** Receives the activating event so a ⌘/Ctrl-click can open a browser tab (§7.1m). */
+  onSelect: (result: AppSearchResult, launch?: LaunchModifiers) => void;
 };
 
 export const AppSearchResultSection: React.FC<AppSearchResultSectionProps> = ({
@@ -40,7 +42,8 @@ export const AppSearchResultSection: React.FC<AppSearchResultSectionProps> = ({
               key={result.key}
               type="button"
               variant="ghost"
-              onClick={() => onSelect(result)}
+              // A macOS Ctrl-click is the right-click gesture: leave it to the context menu.
+              onClick={(e) => !isAppleContextClick(e) && onSelect(result, e)}
               aria-current={selected ? 'true' : undefined}
               className={clsx(
                 'h-auto w-full justify-start gap-2.5 px-2.5 py-2 text-left font-normal',

--- a/ui/src/components/workbench/search/SearchPalette.tsx
+++ b/ui/src/components/workbench/search/SearchPalette.tsx
@@ -4,7 +4,7 @@ import { useNavigate } from 'react-router-dom';
 import * as DialogPrimitive from '@radix-ui/react-dialog';
 import { AlertCircle, Loader2, Search } from 'lucide-react';
 
-import { tabModifierLabel, type LaunchModifiers } from '../../../apps/appLaunch';
+import { appTabHref, tabModifierLabel, type LaunchModifiers } from '../../../apps/appLaunch';
 import { useMessageSearch } from '../../../lib/useMessageSearch';
 import { Dialog, DialogOverlay, DialogPortal, DialogTitle } from '../../ui/dialog';
 import { Input } from '../../ui/input';
@@ -71,6 +71,16 @@ export const SearchPalette: React.FC<SearchPaletteProps> = ({ open, onClose }) =
   // A changed result set falls back to its first row without a state-sync
   // effect. Arrow navigation only stores an explicit key while it stays valid.
   const selectedTarget = flatTargets.find((target) => target.key === selectedKey) ?? flatTargets[0];
+  // Whether the highlighted row actually HAS a browser-tab surface: the ⌘↵ hint below
+  // must not promise a tab for a message hit, nor for a window-only app such as the
+  // Library, where `openSearchApp` falls back to a workbench window (§7.1m).
+  const selectedTabHref =
+    selectedTarget?.kind === 'app'
+      ? appTabHref({
+          appId: selectedTarget.result.appId,
+          sessionId: selectedTarget.result.kind === 'showpage' ? selectedTarget.result.sessionId : null,
+        })
+      : null;
 
   const handleSelect = (sessionId: string, messageId: string) => {
     navigate(`/chat/${encodeURIComponent(sessionId)}?msg=${encodeURIComponent(messageId)}`);
@@ -222,10 +232,11 @@ export const SearchPalette: React.FC<SearchPaletteProps> = ({ open, onClose }) =
           <div className="flex shrink-0 items-center gap-4 border-t border-border bg-foreground/[0.02] px-4 py-[11px]">
             <FooterHint keyLabel="↑↓" label={t('workbench.search.kbdNavigate')} />
             <FooterHint keyLabel="↵" label={t('workbench.search.kbdOpen')} />
-            {/* Only while an APP is highlighted: ⌘↵ opens it as a browser tab (§7.1m),
-                which a message hit has no equivalent of — so the hint appears with the
-                target it applies to instead of always sitting in the footer. */}
-            {selectedTarget?.kind === 'app' && (
+            {/* Only while an app WITH a tab surface is highlighted: ⌘↵ opens it as a
+                browser tab (§7.1m), which a message hit has no equivalent of — so the
+                hint appears with the target it applies to instead of always sitting in
+                the footer. */}
+            {selectedTabHref && (
               <FooterHint
                 keyLabel={`${tabModifierLabel()}↵`}
                 label={t('workbench.search.kbdNewTab')}

--- a/ui/src/components/workbench/search/SearchPalette.tsx
+++ b/ui/src/components/workbench/search/SearchPalette.tsx
@@ -4,6 +4,7 @@ import { useNavigate } from 'react-router-dom';
 import * as DialogPrimitive from '@radix-ui/react-dialog';
 import { AlertCircle, Loader2, Search } from 'lucide-react';
 
+import { tabModifierLabel, type LaunchModifiers } from '../../../apps/appLaunch';
 import { useMessageSearch } from '../../../lib/useMessageSearch';
 import { Dialog, DialogOverlay, DialogPortal, DialogTitle } from '../../ui/dialog';
 import { Input } from '../../ui/input';
@@ -76,8 +77,10 @@ export const SearchPalette: React.FC<SearchPaletteProps> = ({ open, onClose }) =
     onClose();
   };
 
-  const handleAppSelect = (result: (typeof appResults)[number]) => {
-    openSearchApp(result);
+  // `launch` carries the activating event's modifiers, so ⌘/Ctrl+click AND
+  // ⌘/Ctrl+Enter open the app in a browser tab (§7.1m).
+  const handleAppSelect = (result: (typeof appResults)[number], launch?: LaunchModifiers) => {
+    openSearchApp(result, launch);
     onClose();
   };
 
@@ -108,7 +111,7 @@ export const SearchPalette: React.FC<SearchPaletteProps> = ({ open, onClose }) =
       // row activates instead of the (possibly different) arrow-selected one.
       if (document.activeElement !== inputRef.current) return;
       e.preventDefault();
-      if (selectedTarget?.kind === 'app') handleAppSelect(selectedTarget.result);
+      if (selectedTarget?.kind === 'app') handleAppSelect(selectedTarget.result, e);
       else if (selectedTarget) handleSelect(selectedTarget.sessionId, selectedTarget.messageId);
     }
   };
@@ -219,6 +222,15 @@ export const SearchPalette: React.FC<SearchPaletteProps> = ({ open, onClose }) =
           <div className="flex shrink-0 items-center gap-4 border-t border-border bg-foreground/[0.02] px-4 py-[11px]">
             <FooterHint keyLabel="↑↓" label={t('workbench.search.kbdNavigate')} />
             <FooterHint keyLabel="↵" label={t('workbench.search.kbdOpen')} />
+            {/* Only while an APP is highlighted: ⌘↵ opens it as a browser tab (§7.1m),
+                which a message hit has no equivalent of — so the hint appears with the
+                target it applies to instead of always sitting in the footer. */}
+            {selectedTarget?.kind === 'app' && (
+              <FooterHint
+                keyLabel={`${tabModifierLabel()}↵`}
+                label={t('workbench.search.kbdNewTab')}
+              />
+            )}
             <FooterHint keyLabel={t('workbench.search.kbdEsc')} label={t('workbench.search.kbdClose')} />
             {/* Archived opt-in — off on every open; archived hits open read-only. */}
             <label className="flex items-center gap-1.5 text-[11px] text-muted">

--- a/ui/src/components/workbench/search/useAppSearch.ts
+++ b/ui/src/components/workbench/search/useAppSearch.ts
@@ -2,6 +2,7 @@ import { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useLocation, useNavigate } from 'react-router-dom';
 
+import { appLaunchIntent, appTabHref, type LaunchModifiers } from '../../../apps/appLaunch';
 import { APP_LIST } from '../../../apps/registry';
 import { showAppRoutePath } from '../../apps/mobileDock';
 import { useShowPageInventory } from '../../useShowPages';
@@ -49,7 +50,16 @@ export function useOpenSearchApp() {
   const location = useLocation();
 
   return useCallback(
-    (result: AppSearchResult) => {
+    (result: AppSearchResult, launch?: LaunchModifiers | null) => {
+      // Tab modifier held (click OR Enter) → hand the app to the browser as a real
+      // tab, the same rule the Dock and the App Library rows follow (§7.1m).
+      if (launch && appLaunchIntent(launch) === 'newTab') {
+        const href = appTabHref({ appId: result.appId, sessionId: result.kind === 'showpage' ? result.sessionId : null });
+        if (href) {
+          window.open(href, '_blank', 'noopener,noreferrer');
+          return;
+        }
+      }
       const desktop = typeof window !== 'undefined' && !!window.matchMedia?.('(min-width: 768px)').matches;
       if (desktop) {
         wm.openApp(result.appId, {

--- a/ui/src/context/WindowManagerProvider.tsx
+++ b/ui/src/context/WindowManagerProvider.tsx
@@ -5,6 +5,7 @@ import {
   WINDOW_RESTORE_PARAM,
   loadWorkbenchWindows,
   saveWorkbenchWindows,
+  sharesWorkbenchLayout,
   stripRestoreParam,
   type PersistedWindow,
 } from '../lib/workbenchPersistence';
@@ -31,7 +32,18 @@ function isDesktopViewport(): boolean {
     : false;
 }
 
-export const WindowManagerProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+/**
+ * `standalone`: this document is a single-app tab (`appTabHref` + `isStandaloneAppTab`).
+ * Such a tab neither RESTORES the saved layout — the app it was opened for must not
+ * come up underneath a restored window — nor SAVES: its window list starts empty, so a
+ * save would clobber the real workbench layout with `[]` in every other tab. Windows
+ * opened later inside that tab still work (WindowLayer stays mounted); they just live
+ * and die with it. The flag is frozen by the shell at mount, so it never flips mid-life.
+ */
+export const WindowManagerProvider: React.FC<{ children: React.ReactNode; standalone?: boolean }> = ({
+  children,
+  standalone = false,
+}) => {
   const idSeq = useRef(0);
   const zSeq = useRef(0);
   const openCount = useRef(0);
@@ -62,7 +74,13 @@ export const WindowManagerProvider: React.FC<{ children: React.ReactNode }> = ({
   // in a position to wipe the stored layout.
   // eslint-disable-next-line react-hooks/refs -- Mount-time bootstrap; see above.
   const [windows, setWindows] = useState<WindowInstance[]>(() => {
-    if (!isDesktopViewport()) return [];
+    if (!sharesWorkbenchLayout(standalone, isDesktopViewport())) {
+      // A standalone tab marks itself restored so the after-widen path below stays inert
+      // too: "no restore" must hold for its whole life, not just at mount. A narrow shell
+      // leaves the flag clear, so widening to desktop still restores (unchanged).
+      if (standalone) restoredRef.current = true;
+      return [];
+    }
     restoredRef.current = true;
     return loadAndSeed();
   });
@@ -122,17 +140,17 @@ export const WindowManagerProvider: React.FC<{ children: React.ReactNode }> = ({
       clearTimeout(saveTimer.current);
       saveTimer.current = null;
     }
-    if (!isDesktopViewport()) return; // never persist (incl. clobber with []) from a non-desktop viewport
+    if (!sharesWorkbenchLayout(standalone, isDesktopViewport())) return;
     saveWorkbenchWindows(buildSnapshot());
-  }, [buildSnapshot]);
+  }, [buildSnapshot, standalone]);
   const scheduleSave = useCallback(() => {
-    if (!isDesktopViewport()) return;
+    if (!sharesWorkbenchLayout(standalone, isDesktopViewport())) return;
     if (saveTimer.current !== null) clearTimeout(saveTimer.current);
     saveTimer.current = window.setTimeout(() => {
       saveTimer.current = null;
       saveWorkbenchWindows(buildSnapshot());
     }, 400);
-  }, [buildSnapshot]);
+  }, [buildSnapshot, standalone]);
 
   const confirmClose = useCallback((id: string): boolean => {
     const message = closeGuards.current.get(id)?.();

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -1298,7 +1298,7 @@
       }
     },
     "dock": {
-      "newInstanceHint": "⌘-click for a new window",
+      "newTabChord": "{{key}}-click → new tab",
       "switchShortcut": "⌥{{number}}",
       "newWindow": "New Window",
       "showAllWindows": "Show All Windows",
@@ -1597,6 +1597,7 @@
       "kbdEsc": "Esc",
       "kbdNavigate": "Navigate",
       "kbdOpen": "Open",
+      "kbdNewTab": "New Tab",
       "kbdClose": "Close",
       "footerNote": "Apps and message content · all sessions",
       "scopeAll": "all sessions"

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -1298,7 +1298,7 @@
       }
     },
     "dock": {
-      "newInstanceHint": "⌘ 点击可新建窗口",
+      "newTabChord": "{{key}} 点击 → 新标签页",
       "switchShortcut": "⌥{{number}}",
       "newWindow": "新建窗口",
       "showAllWindows": "显示所有窗口",
@@ -1597,6 +1597,7 @@
       "kbdEsc": "Esc",
       "kbdNavigate": "切换",
       "kbdOpen": "打开",
+      "kbdNewTab": "新标签页",
       "kbdClose": "关闭",
       "footerNote": "应用与消息内容 · 全部会话",
       "scopeAll": "全部会话"

--- a/ui/src/lib/platform.ts
+++ b/ui/src/lib/platform.ts
@@ -6,6 +6,14 @@
 // place so the detection can't drift between the InstallHint nudge and the
 // media-download helper.
 
+// Apple vs. non-Apple platform — the signal every "⌘ here, Ctrl there" chord or
+// gesture depends on (Editor/Terminal chords, app-icon modifier clicks). Detected
+// once at module load: ``navigator.platform`` is deprecated but remains the most
+// reliable signal, with userAgent as a fallback.
+export const IS_APPLE =
+  typeof navigator !== 'undefined' &&
+  /Mac|iP(hone|ad|od)/i.test(navigator.platform || navigator.userAgent || '');
+
 // iPhone / iPad / iPod, plus iPadOS 13+ which reports as desktop "MacIntel"
 // while still exposing multi-touch.
 export function isIosDevice(): boolean {

--- a/ui/src/lib/workbenchPersistence.test.ts
+++ b/ui/src/lib/workbenchPersistence.test.ts
@@ -4,6 +4,7 @@ import {
   MAX_RESTORED_WINDOWS,
   WINDOW_RESTORE_PARAM,
   parseWorkbenchWindows,
+  sharesWorkbenchLayout,
   serializeWorkbenchWindows,
   stripRestoreParam,
   type PersistedWindow,
@@ -171,5 +172,23 @@ describe('stripRestoreParam', () => {
     const p = { path: '/a.ts' };
     expect(stripRestoreParam(p)).toBe(p);
     expect(stripRestoreParam(undefined)).toBeUndefined();
+  });
+});
+
+describe('sharesWorkbenchLayout', () => {
+  it('restores + persists only for a desktop shell that is not a standalone app tab', () => {
+    expect(sharesWorkbenchLayout(false, true)).toBe(true);
+  });
+
+  it('opts a standalone app tab out entirely', () => {
+    // Restoring would float the saved windows over the one app the tab was opened for
+    // (a maximized one would hide it); persisting from that empty list would then wipe
+    // the real layout for every other tab. Both must be off, on any viewport.
+    expect(sharesWorkbenchLayout(true, true)).toBe(false);
+    expect(sharesWorkbenchLayout(true, false)).toBe(false);
+  });
+
+  it('keeps the pre-existing below-md opt-out', () => {
+    expect(sharesWorkbenchLayout(false, false)).toBe(false);
   });
 });

--- a/ui/src/lib/workbenchPersistence.ts
+++ b/ui/src/lib/workbenchPersistence.ts
@@ -171,6 +171,23 @@ export function stripRestoreParam(
   return Object.keys(rest).length ? rest : undefined;
 }
 
+/**
+ * Whether THIS shell mount takes part in the shared saved layout — restoring it at
+ * mount AND writing it back. Restore and persist are deliberately the same predicate:
+ * a shell that skips the restore starts with an empty window list, so letting it save
+ * would clobber the real layout with `[]` for every other tab.
+ *
+ *  - below md: the window layer is `hidden md:block` and windowed apps open only from
+ *    the desktop-only launcher/Dock, so a phone would restore invisible bodies and its
+ *    empty save would wipe a real desktop layout.
+ *  - a standalone app tab (⌘/Ctrl-click on an app icon, §7.1m): it exists to show ONE
+ *    app, which restored windows would float above — and hide entirely if one of them
+ *    was persisted maximized.
+ */
+export function sharesWorkbenchLayout(standalone: boolean, isDesktop: boolean): boolean {
+  return !standalone && isDesktop;
+}
+
 // Read + parse the persisted layout. Returns [] when storage is unavailable or empty.
 export function loadWorkbenchWindows(): WindowInstance[] {
   try {


### PR DESCRIPTION
## Capability

**Launching an app from its icon.** A plain click still opens a workbench window; a **⌘ (macOS) / Ctrl (elsewhere) held click now opens that app in a new browser tab** — the universal web convention. Owner request; the hint surfaces below were added in answer to the follow-up "do you show a hint for that shortcut?".

## Rule (one shared pure module: `ui/src/apps/appLaunch.ts`)

- `appLaunchIntent()` — platform tab modifier (**⌘ without Ctrl** on Apple, **Ctrl without ⌘** elsewhere) → `newTab`; **Alt/Shift** → `newWindow`; otherwise `activate`. macOS Ctrl+click *is* the right-click gesture, so it must not mean "new tab" there. This **re-assigns** the Dock's old ⌘/Ctrl/Alt = "another window": the tab modifier means the tab, Alt keeps the window, and New Window stays reachable from the tile's ＋ and its context menu.
- `isAppleContextClick()` — mouse-only guard (requires `detail > 0`), so a Ctrl-held real click belongs to the context menu while **Ctrl+Enter still launches**.
- `appTabHref()` — Show Page → `/show/<sid>/`; built-in → `/apps/<id>` for the built-ins that actually stand alone on desktop (`files` / `terminal` / `editor`). `/apps/library` deliberately opens a Library *window* and redirects the tab to `/`, and `preview` has no route, so both fall back to a workbench window.
- `IS_APPLE` promoted from `TerminalView` + `EditorApp` to `ui/src/lib/platform.ts` (third consumer).

**Surfaces:** Dock tiles, App Library rows (Apps + AI), ⌘K/Search app results — including **⌘/Ctrl+Enter**, since the intent reads modifiers off mouse and keyboard events alike. **Mobile is untouched** (no modifiers on touch; the `/apps/*` tap paths are unchanged).

## Discoverability

- `ContextMenuItem` gains an optional trailing **`shortcut`** hint; the Dock's **Open in New Tab** item (now offered on every tile that has a tab surface, not just Show Pages) shows `⌘-click → new tab`.
- Hover tooltips spell the chord on the Dock tile (after the existing `⌥{n}` hint), the App Library rows, and the Show Pages row's open cluster.
- The ⌘K palette footer gains a `⌘↵ New Tab` hint **only while an app result is highlighted** (a message hit has no tab equivalent).
- One interpolated string, `apps.dock.newTabChord` (en + zh), fed by `tabModifierLabel()` off the same `IS_APPLE` the intent uses — a test asserts the labelled key is the one that opens a tab, so hint and behavior cannot drift. It replaces the orphan `apps.dock.newInstanceHint` ("⌘-click for a new window"), which no code referenced and which this change made false.

## Evidence

- **Unit:** `ui/src/apps/appLaunch.test.ts` — intent per platform (both platforms' modifiers, both-held, Alt/Shift, tab-wins-over-Alt), the keyboard-vs-mouse guard (`detail === 0`), the href allowlist and encoding, hint/behavior agreement. `829` UI tests pass; `npm run build` and the lint baseline are clean.
- **Contract / scenario:** none — Web-UI-only behavior with no backend or IM-platform surface; no scenario catalog IDs apply.
- **Independent review:** a Codex (gpt-5.6, high) pass over the diff raised the `/apps/library` tab target (High) and the `detail === 0` keyboard-click suppression (Medium); **both are fixed in this branch**, each with a regression test.
- **Residual manual checks:** the hover tooltips are native `title` attributes, so they cannot be captured by an automated screenshot — worth one eyeball in the regression environment, along with the ⌘K footer hint and the Dock menu width with the shortcut row present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
