### PR TITLE
fix(runtime): bind default Agent before delivery start

### DIFF
--- a/core/session_turns.py
+++ b/core/session_turns.py
@@ -972,6 +972,71 @@ class SessionTurnManager:
         return {"agent_id": "", "agent_name": "", "agent_backend": ""}
 
     @staticmethod
+    def _binding_projection_is_stale(
+        context: "MessageContext",
+        binding: dict[str, Any],
+    ) -> bool:
+        spec = getattr(context, "platform_specific", None) or {}
+
+        def differs(
+            projection: dict[str, Any],
+            *,
+            identity_key: str,
+            require_backend: bool,
+        ) -> bool:
+            if str(projection.get(identity_key) or "").strip() != str(
+                binding.get("id") or ""
+            ).strip():
+                # A context without the durable Session identity may carry a
+                # deliberate per-run target (scheduled/CLI), not a stale Session
+                # projection. The delivery backend must respect that target.
+                return False
+            if require_backend and not str(projection.get("agent_backend") or "").strip():
+                return True
+            for key in (
+                "id",
+                "agent_id",
+                "agent_name",
+                "agent_backend",
+                "agent_variant",
+                "model",
+                "reasoning_effort",
+            ):
+                if key in projection and str(projection.get(key) or "").strip() != str(
+                    binding.get(key) or ""
+                ).strip():
+                    return True
+            return False
+
+        session_target = spec.get("agent_session_target")
+        if isinstance(session_target, dict) and differs(
+            session_target,
+            identity_key="id",
+            require_backend=True,
+        ):
+            return True
+        run_target = spec.get("agent_run_target")
+        if isinstance(run_target, dict) and differs(
+            run_target,
+            identity_key="agent_session_id",
+            require_backend=True,
+        ):
+            return True
+        if any(
+            isinstance(projection, dict)
+            and str(projection.get(identity_key) or "").strip()
+            == str(binding.get("id") or "").strip()
+            for projection, identity_key in (
+                (session_target, "id"),
+                (run_target, "agent_session_id"),
+            )
+        ):
+            for key in ("vibe_agent_id", "vibe_agent_name"):
+                if spec.get(key) and str(spec.get(key)).strip() != str(binding.get(key) or "").strip():
+                    return True
+        return False
+
+    @staticmethod
     def _apply_session_binding_to_context(
         context: "MessageContext",
         binding: dict[str, Any],
@@ -1036,6 +1101,8 @@ class SessionTurnManager:
             ).mappings().one_or_none()
         durable_backend = str((binding or {}).get("agent_backend") or "").strip()
         if durable_backend:
+            if self._binding_projection_is_stale(resolved, dict(binding)):
+                self._apply_session_binding_to_context(resolved, dict(binding))
             return durable_backend, resolved
 
         resolved_agent = self._context_vibe_agent_binding(resolved)

--- a/core/session_turns.py
+++ b/core/session_turns.py
@@ -978,6 +978,21 @@ class SessionTurnManager:
     ) -> bool:
         spec = getattr(context, "platform_specific", None) or {}
 
+        # Scheduled/CLI deliveries may intentionally run a Session through a
+        # different Agent for this one execution. Their top-level identity is the
+        # explicit request, not a stale copy of the Session row, so durable context
+        # refresh must not overwrite it.
+        if (
+            spec.get("task_trigger_kind")
+            or spec.get("turn_source") == SOURCE_SCHEDULED
+        ) and any(spec.get(key) for key in ("vibe_agent_id", "vibe_agent_name")):
+            if any(
+                str(spec.get(key) or "").strip()
+                != str(binding.get(key) or "").strip()
+                for key in ("vibe_agent_id", "vibe_agent_name")
+            ):
+                return False
+
         def differs(
             projection: dict[str, Any],
             *,

--- a/core/session_turns.py
+++ b/core/session_turns.py
@@ -21,7 +21,7 @@ import uuid
 from contextlib import contextmanager
 from dataclasses import dataclass, replace
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING, Any, Callable, Iterator, Literal, Optional
+from typing import TYPE_CHECKING, Any, Callable, ContextManager, Iterator, Literal, Optional
 
 from sqlalchemy import and_, exists, literal, or_, select, update
 from sqlalchemy.engine import Connection, Engine
@@ -933,16 +933,13 @@ class SessionTurnManager:
             raise RuntimeError("Session delivery context builder is not bound")
         return self._build_context(session_id)
 
-    def _delivery_context_for_binding(self, session_id: str) -> "MessageContext":
-        """Build binding context with the queued head's scheduled Agent identity."""
-        context = self._delivery_context(session_id)
-        with self._sqlite_engine().connect() as conn:
-            head = delivery_store.claimable_fifo_head(conn, session_id)
-        if head is None:
-            return context
-        provenance = (
-            delivery_store.delivery_payload(head).get("metadata") or {}
-        ).get(SCHEDULED_PROVENANCE_KEY)
+    @staticmethod
+    def _apply_delivery_binding_provenance(
+        context: "MessageContext",
+        delivery: dict[str, Any],
+    ) -> "MessageContext":
+        """Overlay only the exact queued Delivery's routing provenance."""
+        provenance = (delivery_store.delivery_payload(delivery).get("metadata") or {}).get(SCHEDULED_PROVENANCE_KEY)
         preserved = provenance.get("platform_specific") if isinstance(provenance, dict) else None
         if not isinstance(preserved, dict):
             return context
@@ -958,6 +955,15 @@ class SessionTurnManager:
                 spec[key] = preserved[key]
         context.platform_specific = spec
         return context
+
+    @staticmethod
+    def _binding_metadata(binding: dict[str, Any]) -> dict[str, Any]:
+        raw_metadata = binding.get("metadata_json")
+        try:
+            metadata = json.loads(raw_metadata) if raw_metadata else {}
+        except (TypeError, ValueError):
+            metadata = {}
+        return metadata if isinstance(metadata, dict) else {}
 
     def _context_vibe_agent_binding(self, context: "MessageContext") -> dict[str, str]:
         spec = getattr(context, "platform_specific", None) or {}
@@ -1014,18 +1020,31 @@ class SessionTurnManager:
         # different Agent for this one execution. Their top-level identity is the
         # explicit request, not a stale copy of the Session row, so durable context
         # refresh must not overwrite it.
-        if (
-            spec.get("task_trigger_kind")
-            or spec.get("turn_source") == SOURCE_SCHEDULED
-        ) and any(spec.get(key) for key in ("vibe_agent_id", "vibe_agent_name")):
-            if any(
-                str(spec.get(key) or "").strip()
-                != str(binding.get(binding_key) or "").strip()
-                for key, binding_key in (
-                    ("vibe_agent_id", "agent_id"),
-                    ("vibe_agent_name", "agent_name"),
-                )
+        if (spec.get("task_trigger_kind") or spec.get("turn_source") == SOURCE_SCHEDULED) and any(
+            spec.get(key) for key in ("vibe_agent_id", "vibe_agent_name")
+        ):
+            for key, binding_key in (
+                ("vibe_agent_id", "agent_id"),
+                ("vibe_agent_name", "agent_name"),
             ):
+                supplied = str(spec.get(key) or "").strip()
+                if supplied and supplied != str(binding.get(binding_key) or "").strip():
+                    return False
+            if (
+                spec.get(SCHEDULED_TARGET_AGENT_KEY)
+                and str(spec.get(SCHEDULED_TARGET_AGENT_KEY)).strip() != str(binding.get("agent_name") or "").strip()
+            ):
+                return False
+
+        durable_session_id = str(binding.get("id") or "").strip()
+        for projection, identity_key in (
+            (spec.get("agent_session_target"), "id"),
+            (spec.get("agent_run_target"), "agent_session_id"),
+        ):
+            if not isinstance(projection, dict):
+                continue
+            projection_id = str(projection.get(identity_key) or "").strip()
+            if projection_id and durable_session_id and projection_id != durable_session_id:
                 return False
 
         def differs(
@@ -1052,10 +1071,10 @@ class SessionTurnManager:
                 "model",
                 "reasoning_effort",
             ):
-                if key in projection and str(projection.get(key) or "").strip() != str(
-                    binding.get(key) or ""
-                ).strip():
+                if key in projection and str(projection.get(key) or "").strip() != str(binding.get(key) or "").strip():
                     return True
+            if "metadata" in projection and projection.get("metadata") != SessionTurnManager._binding_metadata(binding):
+                return True
             return False
 
         session_target = spec.get("agent_session_target")
@@ -1072,10 +1091,18 @@ class SessionTurnManager:
             require_backend=True,
         ):
             return True
+        resolved_agent = spec.get("resolved_vibe_agent")
+        if isinstance(resolved_agent, dict):
+            for key, binding_key in (
+                ("id", "agent_id"),
+                ("name", "agent_name"),
+                ("backend", "agent_backend"),
+            ):
+                if str(resolved_agent.get(key) or "").strip() != str(binding.get(binding_key) or "").strip():
+                    return True
         if any(
             isinstance(projection, dict)
-            and str(projection.get(identity_key) or "").strip()
-            == str(binding.get("id") or "").strip()
+            and str(projection.get(identity_key) or "").strip() == str(binding.get("id") or "").strip()
             for projection, identity_key in (
                 (session_target, "id"),
                 (run_target, "agent_session_id"),
@@ -1099,25 +1126,41 @@ class SessionTurnManager:
         spec = dict(getattr(context, "platform_specific", None) or {})
         target = spec.get("agent_session_target")
         target = dict(target) if isinstance(target, dict) else {}
-        target.update(
-            {
-                "id": binding.get("id"),
-                "agent_id": binding.get("agent_id"),
-                "agent_name": binding.get("agent_name"),
-                "agent_backend": binding.get("agent_backend"),
-                "agent_variant": binding.get("agent_variant"),
-                "model": binding.get("model"),
-                "reasoning_effort": binding.get("reasoning_effort"),
-            }
-        )
+        target_id = str(target.get("id") or "").strip()
+        if not target_id or target_id == str(binding.get("id") or "").strip():
+            target.update(
+                {
+                    "id": binding.get("id"),
+                    "agent_id": binding.get("agent_id"),
+                    "agent_name": binding.get("agent_name"),
+                    "agent_backend": binding.get("agent_backend"),
+                    "agent_variant": binding.get("agent_variant"),
+                    "model": binding.get("model"),
+                    "reasoning_effort": binding.get("reasoning_effort"),
+                    "metadata": SessionTurnManager._binding_metadata(binding),
+                }
+            )
         spec["agent_session_target"] = target
         # Keep every routing projection on the same durable winner. MessageHandler
         # and Controller prefer these cached fields over agent_session_target, so
         # leaving an old top-level value would route a newly bound turn elsewhere.
-        spec["vibe_agent_id"] = binding.get("agent_id")
-        spec["vibe_agent_name"] = binding.get("agent_name")
+        agent_id = str(binding.get("agent_id") or "").strip()
+        agent_name = str(binding.get("agent_name") or "").strip()
+        spec["vibe_agent_id"] = agent_id or None
+        spec["vibe_agent_name"] = agent_name or None
+        if agent_id or agent_name:
+            spec["resolved_vibe_agent"] = {
+                "id": agent_id or None,
+                "name": agent_name or None,
+                "backend": binding.get("agent_backend"),
+            }
+        else:
+            spec.pop("resolved_vibe_agent", None)
         run_target = spec.get("agent_run_target")
-        if isinstance(run_target, dict):
+        if (
+            isinstance(run_target, dict)
+            and str(run_target.get("agent_session_id") or "").strip() == str(binding.get("id") or "").strip()
+        ):
             run_target = dict(run_target)
             run_target.update(
                 {
@@ -1133,13 +1176,9 @@ class SessionTurnManager:
             spec["agent_run_target"] = run_target
         context.platform_specific = spec
 
-    def _delivery_backend(
-        self,
-        session_id: str,
-        context: Optional["MessageContext"],
-    ) -> tuple[str, "MessageContext"]:
-        resolved = context or self._delivery_context(session_id)
-        columns = (
+    @staticmethod
+    def _session_binding_columns() -> tuple[Any, ...]:
+        return (
             agent_sessions.c.id,
             agent_sessions.c.agent_id,
             agent_sessions.c.agent_name,
@@ -1150,10 +1189,86 @@ class SessionTurnManager:
             agent_sessions.c.metadata_json,
             agent_sessions.c.status,
         )
+
+    def _delivery_backend_in_transaction(
+        self,
+        conn: Connection,
+        session_id: str,
+        context: "MessageContext",
+        *,
+        resolved_agent: dict[str, str] | None = None,
+        requested_backend: str | None = None,
+    ) -> tuple[str, "MessageContext"]:
+        """Resolve and persist a Session route while the caller owns the writer lock."""
+        columns = self._session_binding_columns()
+        binding = conn.execute(select(*columns).where(agent_sessions.c.id == session_id)).mappings().one_or_none()
+        durable_backend = str((binding or {}).get("agent_backend") or "").strip()
+        if durable_backend:
+            if self._binding_projection_is_stale(context, dict(binding)):
+                self._apply_session_binding_to_context(context, dict(binding))
+            return durable_backend, context
+
+        if resolved_agent is None:
+            resolved_agent = self._context_vibe_agent_binding(context)
+        requested_backend = requested_backend or (resolved_agent["agent_backend"] or self._context_backend(context))
+        if not requested_backend:
+            raise RuntimeError(f"Session {session_id} has no resolved backend")
+
+        # An agentless Workbench Session is valid until its first turn resolves the
+        # global default Agent. Materialize that decision before crossing the runtime
+        # ownership gate; otherwise a queued Delivery is durable while its route is not.
+        if binding is not None and binding["status"] == "active" and not str(binding["agent_backend"] or "").strip():
+            values: dict[str, Any] = {
+                "agent_backend": requested_backend,
+                "updated_at": _utc_now_iso(),
+            }
+            if str(binding["agent_variant"] or "").strip() in {"", "default"}:
+                values["agent_variant"] = requested_backend
+            if resolved_agent["agent_id"] and not binding["agent_id"]:
+                values["agent_id"] = resolved_agent["agent_id"]
+            if resolved_agent["agent_name"] and not binding["agent_name"]:
+                values["agent_name"] = resolved_agent["agent_name"]
+            stored_metadata = self._binding_metadata(dict(binding))
+            reconciled_metadata = reconcile_explicit_overrides(stored_metadata)
+            if reconciled_metadata != stored_metadata:
+                values["metadata_json"] = json.dumps(
+                    reconciled_metadata,
+                    separators=(",", ":"),
+                    ensure_ascii=False,
+                )
+            conn.execute(
+                update(agent_sessions)
+                .where(agent_sessions.c.id == session_id)
+                .where(agent_sessions.c.status == "active")
+                .where(
+                    or_(
+                        agent_sessions.c.agent_backend == "",
+                        agent_sessions.c.agent_backend.is_(None),
+                    )
+                )
+                .values(**values)
+            )
+            binding = conn.execute(select(*columns).where(agent_sessions.c.id == session_id)).mappings().one_or_none()
+
+        if binding is not None:
+            binding_payload = dict(binding)
+            self._apply_session_binding_to_context(context, binding_payload)
+            durable_backend = str(binding_payload.get("agent_backend") or "").strip()
+            if durable_backend:
+                return durable_backend, context
+            if binding_payload.get("status") == "active":
+                raise RuntimeError(f"Session {session_id} has no durable backend binding")
+        return requested_backend, context
+
+    def _delivery_backend(
+        self,
+        session_id: str,
+        context: Optional["MessageContext"],
+    ) -> tuple[str, "MessageContext"]:
+        resolved = context or self._delivery_context(session_id)
+        columns = self._session_binding_columns()
         with self._sqlite_engine().connect() as conn:
-            binding = conn.execute(
-                select(*columns).where(agent_sessions.c.id == session_id)
-            ).mappings().one_or_none()
+            binding = conn.execute(select(*columns).where(agent_sessions.c.id == session_id)).mappings().one_or_none()
         durable_backend = str((binding or {}).get("agent_backend") or "").strip()
         if durable_backend:
             if self._binding_projection_is_stale(resolved, dict(binding)):
@@ -1168,93 +1283,31 @@ class SessionTurnManager:
         if not requested_backend:
             raise RuntimeError(f"Session {session_id} has no resolved backend")
 
-        # An agentless Workbench Session is valid until its first turn resolves the
-        # global default Agent. Materialize that decision before crossing the runtime
-        # ownership gate; otherwise a queued Delivery is durable while its route is not.
         with self._sqlite_engine().begin() as conn:
             reserve_write_lock(conn)
-            binding = conn.execute(
-                select(*columns).where(agent_sessions.c.id == session_id)
-            ).mappings().one_or_none()
-            if (
-                binding is not None
-                and binding["status"] == "active"
-                and not str(binding["agent_backend"] or "").strip()
-            ):
-                values: dict[str, Any] = {
-                    "agent_backend": requested_backend,
-                    "updated_at": _utc_now_iso(),
-                }
-                if str(binding["agent_variant"] or "").strip() in {"", "default"}:
-                    values["agent_variant"] = requested_backend
-                if resolved_agent["agent_id"] and not binding["agent_id"]:
-                    values["agent_id"] = resolved_agent["agent_id"]
-                if resolved_agent["agent_name"] and not binding["agent_name"]:
-                    values["agent_name"] = resolved_agent["agent_name"]
-                raw_metadata = binding.get("metadata_json")
-                try:
-                    stored_metadata = json.loads(raw_metadata) if raw_metadata else {}
-                except (TypeError, ValueError):
-                    stored_metadata = {}
-                if not isinstance(stored_metadata, dict):
-                    stored_metadata = {}
-                reconciled_metadata = reconcile_explicit_overrides(stored_metadata)
-                if reconciled_metadata != stored_metadata:
-                    values["metadata_json"] = json.dumps(
-                        reconciled_metadata,
-                        separators=(",", ":"),
-                        ensure_ascii=False,
-                    )
-                conn.execute(
-                    update(agent_sessions)
-                    .where(agent_sessions.c.id == session_id)
-                    .where(agent_sessions.c.status == "active")
-                    .where(
-                        or_(
-                            agent_sessions.c.agent_backend == "",
-                            agent_sessions.c.agent_backend.is_(None),
-                        )
-                    )
-                    .values(**values)
-                )
-                binding = conn.execute(
-                    select(*columns).where(agent_sessions.c.id == session_id)
-                ).mappings().one_or_none()
-
-        if binding is not None:
-            binding_payload = dict(binding)
-            self._apply_session_binding_to_context(resolved, binding_payload)
-            durable_backend = str(binding_payload.get("agent_backend") or "").strip()
-            if durable_backend:
-                return durable_backend, resolved
-            if binding_payload.get("status") == "active":
-                raise RuntimeError(f"Session {session_id} has no durable backend binding")
-        return requested_backend, resolved
+            return self._delivery_backend_in_transaction(
+                conn,
+                session_id,
+                resolved,
+                resolved_agent=resolved_agent,
+                requested_backend=requested_backend,
+            )
 
     @contextmanager
-    def _runtime_start_owner(
+    def _runtime_start_owner_for_binding(
         self,
         session_id: str,
         backend: str,
+        binding: dict[str, Any] | None,
     ) -> Iterator[_RuntimeStartOwner]:
         """Hold the exact runtime generation through the owning SQLite commit."""
-
-        with self._sqlite_engine().connect() as conn:
-            binding = conn.execute(
-                select(
-                    agent_sessions.c.agent_backend,
-                    agent_sessions.c.session_anchor,
-                    agent_sessions.c.workdir,
-                ).where(agent_sessions.c.id == session_id)
-            ).mappings().one_or_none()
         durable_backend = str((binding or {}).get("agent_backend") or "").strip()
         requested_backend = str(backend or "").strip()
         session_anchor = str((binding or {}).get("session_anchor") or "").strip()
         workdir = (binding or {}).get("workdir")
         if binding is None or not durable_backend or not session_anchor:
             logger.warning(
-                "Refusing runtime start with incomplete durable Session binding: "
-                "session=%s",
+                "Refusing runtime start with incomplete durable Session binding: session=%s",
                 session_id,
             )
             yield _RuntimeStartOwner(
@@ -1348,6 +1401,52 @@ class SessionTurnManager:
                 admitted=bool(admitted),
                 identity=identity,
             )
+
+    @contextmanager
+    def _runtime_start_owner(
+        self,
+        session_id: str,
+        backend: str,
+    ) -> Iterator[_RuntimeStartOwner]:
+        with self._sqlite_engine().connect() as conn:
+            binding = (
+                conn.execute(
+                    select(
+                        agent_sessions.c.agent_backend,
+                        agent_sessions.c.session_anchor,
+                        agent_sessions.c.workdir,
+                    ).where(agent_sessions.c.id == session_id)
+                )
+                .mappings()
+                .one_or_none()
+            )
+        with self._runtime_start_owner_for_binding(
+            session_id, backend, dict(binding) if binding is not None else None
+        ) as owner:
+            yield owner
+
+    @contextmanager
+    def _runtime_start_owner_in_transaction(
+        self,
+        conn: Connection,
+        session_id: str,
+        backend: str,
+    ) -> Iterator[_RuntimeStartOwner]:
+        binding = (
+            conn.execute(
+                select(
+                    agent_sessions.c.agent_backend,
+                    agent_sessions.c.session_anchor,
+                    agent_sessions.c.workdir,
+                ).where(agent_sessions.c.id == session_id)
+            )
+            .mappings()
+            .one_or_none()
+        )
+        with self._runtime_start_owner_for_binding(
+            session_id, backend, dict(binding) if binding is not None else None
+        ) as owner:
+            yield owner
 
     @staticmethod
     def _delivery_snapshot(request: DeliveryRequest) -> dict[str, Any]:
@@ -1638,13 +1737,17 @@ class SessionTurnManager:
         self,
         conn: Connection,
         *,
-        owner: _RuntimeStartOwner,
+        owner: _RuntimeStartOwner | None,
         session_id: str,
         backend: str,
         expected_head_id: str | None = None,
         expected_head_version: int | None = None,
+        owner_factory: Callable[[Connection, list[dict[str, Any]]], ContextManager[_RuntimeStartOwner]] | None = None,
     ) -> str | None:
         """Claim the exact open FIFO head while the caller owns SQLite's writer slot."""
+
+        if owner is None and owner_factory is None:
+            raise ValueError("FIFO claim requires a runtime owner or owner factory")
 
         if (
             delivery_store.active_turn(conn, session_id) is not None
@@ -1689,16 +1792,45 @@ class SessionTurnManager:
                         row["id"],
                     )
                 continue
+            unstartable_rows = [row for row in delivery_rows if not self._delivery_agent_runs_can_start(conn, row)]
+            if unstartable_rows:
+                self._retire_unstartable_deliveries(
+                    conn,
+                    session_id,
+                    unstartable_rows,
+                )
+                continue
             turn_id = delivery_store.new_turn_id()
-            claimed = self._claim_start_batch(
-                conn,
-                owner=owner,
-                turn_id=turn_id,
-                session_id=session_id,
-                backend=backend,
-                deliveries=delivery_rows,
-                dispatch_text=_segment_dispatch_text(segment_payloads),
-            )
+            dispatch_text = _segment_dispatch_text(segment_payloads)
+            if owner is not None:
+                claimed = self._claim_start_batch(
+                    conn,
+                    owner=owner,
+                    turn_id=turn_id,
+                    session_id=session_id,
+                    backend=backend,
+                    deliveries=delivery_rows,
+                    dispatch_text=dispatch_text,
+                )
+            else:
+                assert owner_factory is not None
+                with owner_factory(conn, delivery_rows) as prepared_owner:
+                    prepared_backend = prepared_owner.backend or backend
+                    if prepared_backend in self._draining_backends:
+                        self._deferred_restart_sessions.setdefault(
+                            prepared_backend,
+                            set(),
+                        ).add(session_id)
+                        return None
+                    claimed = self._claim_start_batch(
+                        conn,
+                        owner=prepared_owner,
+                        turn_id=turn_id,
+                        session_id=session_id,
+                        backend=prepared_backend,
+                        deliveries=delivery_rows,
+                        dispatch_text=dispatch_text,
+                    )
             if claimed is not None:
                 return turn_id
             if self._start_claim_retired_rows(conn, delivery_rows):
@@ -3491,6 +3623,65 @@ class SessionTurnManager:
                     )
             return False
 
+    def _delivery_runtime_owner_factory(
+        self,
+        session_id: str,
+        context: Optional["MessageContext"],
+    ) -> Callable[[Connection, list[dict[str, Any]]], ContextManager[_RuntimeStartOwner]]:
+        """Create a claim callback that binds the exact selected FIFO segment."""
+
+        @contextmanager
+        def prepare(
+            conn: Connection,
+            deliveries: list[dict[str, Any]],
+        ) -> Iterator[_RuntimeStartOwner]:
+            resolved = context
+            if resolved is None:
+                durable_backend = str(
+                    conn.execute(
+                        select(agent_sessions.c.agent_backend).where(agent_sessions.c.id == session_id)
+                    ).scalar_one_or_none()
+                    or ""
+                ).strip()
+                if durable_backend:
+                    with self._runtime_start_owner_in_transaction(
+                        conn,
+                        session_id,
+                        durable_backend,
+                    ) as owner:
+                        yield owner
+                    return
+                try:
+                    resolved = self._delivery_context(session_id)
+                except Exception:
+                    logger.exception(
+                        "durable queue drain could not rebuild Session context: session=%s",
+                        session_id,
+                    )
+                    yield _RuntimeStartOwner(
+                        session_id=session_id,
+                        backend="",
+                        session_anchor="",
+                        workdir=None,
+                        admitted=False,
+                    )
+                    return
+            if deliveries:
+                self._apply_delivery_binding_provenance(resolved, deliveries[0])
+            backend, _ = self._delivery_backend_in_transaction(
+                conn,
+                session_id,
+                resolved,
+            )
+            with self._runtime_start_owner_in_transaction(
+                conn,
+                session_id,
+                backend,
+            ) as owner:
+                yield owner
+
+        return prepare
+
     async def drain_delivery_queue(
         self,
         session_id: str,
@@ -3499,36 +3690,16 @@ class SessionTurnManager:
         expected_head_version: int | None = None,
     ) -> bool:
         turn_id: str | None = None
-        with self._sqlite_engine().connect() as conn:
-            backend = str(
-                conn.execute(
-                    select(agent_sessions.c.agent_backend).where(
-                        agent_sessions.c.id == session_id
-                    )
-                ).scalar_one_or_none()
-                or ""
-            ).strip()
-        if not backend:
-            binding_context = (
-                self._delivery_context_for_binding(session_id)
-                if self._build_context is not None
-                else None
-            )
-            backend, _context = self._delivery_backend(session_id, binding_context)
-        with self._runtime_start_owner(session_id, backend) as start_owner, self._sqlite_engine().begin() as conn:
+        with self._sqlite_engine().begin() as conn:
             reserve_write_lock(conn)
-            if backend in self._draining_backends:
-                self._deferred_restart_sessions.setdefault(backend, set()).add(
-                    session_id
-                )
-                return False
             turn_id = self._claim_fifo_batch_in_transaction(
                 conn,
-                owner=start_owner,
+                owner=None,
                 session_id=session_id,
-                backend=backend,
+                backend="",
                 expected_head_id=expected_head_id,
                 expected_head_version=expected_head_version,
+                owner_factory=self._delivery_runtime_owner_factory(session_id, None),
             )
             if turn_id is None:
                 return False

--- a/core/session_turns.py
+++ b/core/session_turns.py
@@ -932,22 +932,138 @@ class SessionTurnManager:
             raise RuntimeError("Session delivery context builder is not bound")
         return self._build_context(session_id)
 
-    def _delivery_backend(self, session_id: str, context: Optional["MessageContext"]) -> tuple[str, "MessageContext"]:
+    def _context_vibe_agent_binding(self, context: "MessageContext") -> dict[str, str]:
+        spec = getattr(context, "platform_specific", None) or {}
+        resolver = getattr(self.controller, "resolve_vibe_agent_for_context", None)
+        agent = None
+        if callable(resolver):
+            try:
+                agent = resolver(context, required=False)
+            except Exception:
+                logger.debug(
+                    "Failed to resolve inherited Vibe Agent before Session binding",
+                    exc_info=True,
+                )
+        if agent is not None:
+            return {
+                "agent_id": str(getattr(agent, "id", None) or "").strip(),
+                "agent_name": str(getattr(agent, "name", None) or "").strip(),
+                "agent_backend": str(getattr(agent, "backend", None) or "").strip(),
+            }
+        resolved = spec.get("resolved_vibe_agent")
+        if isinstance(resolved, dict):
+            return {
+                "agent_id": str(resolved.get("id") or "").strip(),
+                "agent_name": str(resolved.get("name") or "").strip(),
+                "agent_backend": str(resolved.get("backend") or "").strip(),
+            }
+        return {"agent_id": "", "agent_name": "", "agent_backend": ""}
+
+    @staticmethod
+    def _apply_session_binding_to_context(
+        context: "MessageContext",
+        binding: dict[str, Any],
+    ) -> None:
+        spec = dict(getattr(context, "platform_specific", None) or {})
+        target = spec.get("agent_session_target")
+        target = dict(target) if isinstance(target, dict) else {}
+        target.update(
+            {
+                "id": binding.get("id"),
+                "agent_id": binding.get("agent_id"),
+                "agent_name": binding.get("agent_name"),
+                "agent_backend": binding.get("agent_backend"),
+                "agent_variant": binding.get("agent_variant"),
+                "model": binding.get("model"),
+                "reasoning_effort": binding.get("reasoning_effort"),
+            }
+        )
+        spec["agent_session_target"] = target
+        if binding.get("agent_name"):
+            spec["vibe_agent_name"] = binding["agent_name"]
+        context.platform_specific = spec
+
+    def _delivery_backend(
+        self,
+        session_id: str,
+        context: Optional["MessageContext"],
+    ) -> tuple[str, "MessageContext"]:
         resolved = context or self._delivery_context(session_id)
+        columns = (
+            agent_sessions.c.id,
+            agent_sessions.c.agent_id,
+            agent_sessions.c.agent_name,
+            agent_sessions.c.agent_backend,
+            agent_sessions.c.agent_variant,
+            agent_sessions.c.model,
+            agent_sessions.c.reasoning_effort,
+            agent_sessions.c.status,
+        )
         with self._sqlite_engine().connect() as conn:
-            backend = str(
-                conn.execute(
-                    select(agent_sessions.c.agent_backend).where(
-                        agent_sessions.c.id == session_id
-                    )
-                ).scalar_one_or_none()
-                or ""
-            ).strip()
-        if not backend:
-            backend = self._context_backend(resolved)
-        if not backend:
+            binding = conn.execute(
+                select(*columns).where(agent_sessions.c.id == session_id)
+            ).mappings().one_or_none()
+        durable_backend = str((binding or {}).get("agent_backend") or "").strip()
+        if durable_backend:
+            self._apply_session_binding_to_context(resolved, dict(binding))
+            return durable_backend, resolved
+
+        resolved_agent = self._context_vibe_agent_binding(resolved)
+        requested_backend = (
+            resolved_agent["agent_backend"]
+            or self._context_backend(resolved)
+        )
+        if not requested_backend:
             raise RuntimeError(f"Session {session_id} has no resolved backend")
-        return backend, resolved
+
+        # An agentless Workbench Session is valid until its first turn resolves the
+        # global default Agent. Materialize that decision before crossing the runtime
+        # ownership gate; otherwise a queued Delivery is durable while its route is not.
+        with self._sqlite_engine().begin() as conn:
+            reserve_write_lock(conn)
+            binding = conn.execute(
+                select(*columns).where(agent_sessions.c.id == session_id)
+            ).mappings().one_or_none()
+            if (
+                binding is not None
+                and binding["status"] == "active"
+                and not str(binding["agent_backend"] or "").strip()
+            ):
+                values: dict[str, Any] = {
+                    "agent_backend": requested_backend,
+                    "updated_at": _utc_now_iso(),
+                }
+                if str(binding["agent_variant"] or "").strip() in {"", "default"}:
+                    values["agent_variant"] = requested_backend
+                if resolved_agent["agent_id"] and not binding["agent_id"]:
+                    values["agent_id"] = resolved_agent["agent_id"]
+                if resolved_agent["agent_name"] and not binding["agent_name"]:
+                    values["agent_name"] = resolved_agent["agent_name"]
+                conn.execute(
+                    update(agent_sessions)
+                    .where(agent_sessions.c.id == session_id)
+                    .where(agent_sessions.c.status == "active")
+                    .where(
+                        or_(
+                            agent_sessions.c.agent_backend == "",
+                            agent_sessions.c.agent_backend.is_(None),
+                        )
+                    )
+                    .values(**values)
+                )
+                binding = conn.execute(
+                    select(*columns).where(agent_sessions.c.id == session_id)
+                ).mappings().one_or_none()
+
+        if binding is not None:
+            binding_payload = dict(binding)
+            self._apply_session_binding_to_context(resolved, binding_payload)
+            durable_backend = str(binding_payload.get("agent_backend") or "").strip()
+            if durable_backend:
+                return durable_backend, resolved
+            if binding_payload.get("status") == "active":
+                raise RuntimeError(f"Session {session_id} has no durable backend binding")
+        return requested_backend, resolved
 
     @contextmanager
     def _runtime_start_owner(
@@ -1757,7 +1873,10 @@ class SessionTurnManager:
             request = replace(request, content=None)
         if request.priority == "p3" and not content_present:
             raise ValueError("P3 requires content")
-        backend, resolved_context = self._delivery_backend(request.session_id, context)
+        backend, resolved_context = self._delivery_backend(
+            request.session_id,
+            context,
+        )
         if request.priority == "p3":
             return await self._admit_p3(request, backend, resolved_context)
         if request.priority == "p1":
@@ -3224,7 +3343,7 @@ class SessionTurnManager:
                 or ""
             ).strip()
         if not backend:
-            raise RuntimeError(f"Session {session_id} has no resolved backend")
+            backend, _context = self._delivery_backend(session_id, None)
         with self._runtime_start_owner(session_id, backend) as start_owner, self._sqlite_engine().begin() as conn:
             reserve_write_lock(conn)
             if backend in self._draining_backends:

--- a/core/session_turns.py
+++ b/core/session_turns.py
@@ -938,8 +938,19 @@ class SessionTurnManager:
         resolver = getattr(self.controller, "resolve_vibe_agent_for_context", None)
         agent = None
         if callable(resolver):
+            override_agent_id = str(spec.get("vibe_agent_id") or "").strip()
+            override_agent_name = str(
+                spec.get("vibe_agent_name")
+                or spec.get(SCHEDULED_TARGET_AGENT_KEY)
+                or ""
+            ).strip()
+            resolve_kwargs: dict[str, Any] = {"required": False}
+            if override_agent_id:
+                resolve_kwargs["override_agent_id"] = override_agent_id
+            if override_agent_name:
+                resolve_kwargs["override_agent_name"] = override_agent_name
             try:
-                agent = resolver(context, required=False)
+                agent = resolver(context, **resolve_kwargs)
             except Exception:
                 logger.debug(
                     "Failed to resolve inherited Vibe Agent before Session binding",
@@ -980,8 +991,26 @@ class SessionTurnManager:
             }
         )
         spec["agent_session_target"] = target
-        if binding.get("agent_name"):
-            spec["vibe_agent_name"] = binding["agent_name"]
+        # Keep every routing projection on the same durable winner. MessageHandler
+        # and Controller prefer these cached fields over agent_session_target, so
+        # leaving an old top-level value would route a newly bound turn elsewhere.
+        spec["vibe_agent_id"] = binding.get("agent_id")
+        spec["vibe_agent_name"] = binding.get("agent_name")
+        run_target = spec.get("agent_run_target")
+        if isinstance(run_target, dict):
+            run_target = dict(run_target)
+            run_target.update(
+                {
+                    "agent_session_id": binding.get("id"),
+                    "agent_id": binding.get("agent_id"),
+                    "agent_name": binding.get("agent_name"),
+                    "agent_backend": binding.get("agent_backend"),
+                    "agent_variant": binding.get("agent_variant"),
+                    "model": binding.get("model"),
+                    "reasoning_effort": binding.get("reasoning_effort"),
+                }
+            )
+            spec["agent_run_target"] = run_target
         context.platform_specific = spec
 
     def _delivery_backend(

--- a/core/session_turns.py
+++ b/core/session_turns.py
@@ -53,6 +53,7 @@ from storage import message_deliveries as delivery_store
 from storage.agent_session_rows import reserve_write_lock
 from storage.db import get_cached_sqlite_engine
 from storage.background import normalize_run_status
+from storage.session_reclaim import reconcile_explicit_overrides
 from storage.models import (
     agent_runs,
     agent_sessions,
@@ -997,6 +998,7 @@ class SessionTurnManager:
             agent_sessions.c.agent_variant,
             agent_sessions.c.model,
             agent_sessions.c.reasoning_effort,
+            agent_sessions.c.metadata_json,
             agent_sessions.c.status,
         )
         with self._sqlite_engine().connect() as conn:
@@ -1005,7 +1007,6 @@ class SessionTurnManager:
             ).mappings().one_or_none()
         durable_backend = str((binding or {}).get("agent_backend") or "").strip()
         if durable_backend:
-            self._apply_session_binding_to_context(resolved, dict(binding))
             return durable_backend, resolved
 
         resolved_agent = self._context_vibe_agent_binding(resolved)
@@ -1039,6 +1040,20 @@ class SessionTurnManager:
                     values["agent_id"] = resolved_agent["agent_id"]
                 if resolved_agent["agent_name"] and not binding["agent_name"]:
                     values["agent_name"] = resolved_agent["agent_name"]
+                raw_metadata = binding.get("metadata_json")
+                try:
+                    stored_metadata = json.loads(raw_metadata) if raw_metadata else {}
+                except (TypeError, ValueError):
+                    stored_metadata = {}
+                if not isinstance(stored_metadata, dict):
+                    stored_metadata = {}
+                reconciled_metadata = reconcile_explicit_overrides(stored_metadata)
+                if reconciled_metadata != stored_metadata:
+                    values["metadata_json"] = json.dumps(
+                        reconciled_metadata,
+                        separators=(",", ":"),
+                        ensure_ascii=False,
+                    )
                 conn.execute(
                     update(agent_sessions)
                     .where(agent_sessions.c.id == session_id)

--- a/core/session_turns.py
+++ b/core/session_turns.py
@@ -933,10 +933,37 @@ class SessionTurnManager:
             raise RuntimeError("Session delivery context builder is not bound")
         return self._build_context(session_id)
 
+    def _delivery_context_for_binding(self, session_id: str) -> "MessageContext":
+        """Build binding context with the queued head's scheduled Agent identity."""
+        context = self._delivery_context(session_id)
+        with self._sqlite_engine().connect() as conn:
+            head = delivery_store.claimable_fifo_head(conn, session_id)
+        if head is None:
+            return context
+        provenance = (
+            delivery_store.delivery_payload(head).get("metadata") or {}
+        ).get(SCHEDULED_PROVENANCE_KEY)
+        preserved = provenance.get("platform_specific") if isinstance(provenance, dict) else None
+        if not isinstance(preserved, dict):
+            return context
+        spec = dict(getattr(context, "platform_specific", None) or {})
+        for key in (
+            "vibe_agent_id",
+            "vibe_agent_name",
+            SCHEDULED_TARGET_AGENT_KEY,
+            "resolved_vibe_agent",
+            "agent_run_target",
+        ):
+            if key in preserved:
+                spec[key] = preserved[key]
+        context.platform_specific = spec
+        return context
+
     def _context_vibe_agent_binding(self, context: "MessageContext") -> dict[str, str]:
         spec = getattr(context, "platform_specific", None) or {}
         resolver = getattr(self.controller, "resolve_vibe_agent_for_context", None)
         agent = None
+        has_explicit_override = False
         if callable(resolver):
             override_agent_id = str(spec.get("vibe_agent_id") or "").strip()
             override_agent_name = str(
@@ -944,7 +971,8 @@ class SessionTurnManager:
                 or spec.get(SCHEDULED_TARGET_AGENT_KEY)
                 or ""
             ).strip()
-            resolve_kwargs: dict[str, Any] = {"required": False}
+            has_explicit_override = bool(override_agent_id or override_agent_name)
+            resolve_kwargs: dict[str, Any] = {"required": has_explicit_override}
             if override_agent_id:
                 resolve_kwargs["override_agent_id"] = override_agent_id
             if override_agent_name:
@@ -952,10 +980,14 @@ class SessionTurnManager:
             try:
                 agent = resolver(context, **resolve_kwargs)
             except Exception:
+                if has_explicit_override:
+                    raise
                 logger.debug(
                     "Failed to resolve inherited Vibe Agent before Session binding",
                     exc_info=True,
                 )
+            if has_explicit_override and agent is None:
+                raise RuntimeError("Explicit Vibe Agent override could not be resolved")
         if agent is not None:
             return {
                 "agent_id": str(getattr(agent, "id", None) or "").strip(),
@@ -988,8 +1020,11 @@ class SessionTurnManager:
         ) and any(spec.get(key) for key in ("vibe_agent_id", "vibe_agent_name")):
             if any(
                 str(spec.get(key) or "").strip()
-                != str(binding.get(key) or "").strip()
-                for key in ("vibe_agent_id", "vibe_agent_name")
+                != str(binding.get(binding_key) or "").strip()
+                for key, binding_key in (
+                    ("vibe_agent_id", "agent_id"),
+                    ("vibe_agent_name", "agent_name"),
+                )
             ):
                 return False
 
@@ -1046,8 +1081,13 @@ class SessionTurnManager:
                 (run_target, "agent_session_id"),
             )
         ):
-            for key in ("vibe_agent_id", "vibe_agent_name"):
-                if spec.get(key) and str(spec.get(key)).strip() != str(binding.get(key) or "").strip():
+            for key, binding_key in (
+                ("vibe_agent_id", "agent_id"),
+                ("vibe_agent_name", "agent_name"),
+            ):
+                if spec.get(key) and str(spec.get(key)).strip() != str(
+                    binding.get(binding_key) or ""
+                ).strip():
                     return True
         return False
 
@@ -3469,7 +3509,12 @@ class SessionTurnManager:
                 or ""
             ).strip()
         if not backend:
-            backend, _context = self._delivery_backend(session_id, None)
+            binding_context = (
+                self._delivery_context_for_binding(session_id)
+                if self._build_context is not None
+                else None
+            )
+            backend, _context = self._delivery_backend(session_id, binding_context)
         with self._runtime_start_owner(session_id, backend) as start_owner, self._sqlite_engine().begin() as conn:
             reserve_write_lock(conn)
             if backend in self._draining_backends:

--- a/tests/test_session_delivery_fsm.py
+++ b/tests/test_session_delivery_fsm.py
@@ -795,6 +795,11 @@ def test_binding_refreshes_all_cached_route_projections(managers) -> None:
                 "reasoning_effort": "low",
                 "workdir": "/tmp",
             },
+            "resolved_vibe_agent": {
+                "id": "stale-agent",
+                "name": "stale",
+                "backend": "claude",
+            },
         }
     )
 
@@ -808,6 +813,7 @@ def test_binding_refreshes_all_cached_route_projections(managers) -> None:
             "agent_variant": "codex",
             "model": None,
             "reasoning_effort": None,
+            "metadata_json": '{"explicit_setting_overrides":["model"]}',
         },
     )
 
@@ -818,6 +824,134 @@ def test_binding_refreshes_all_cached_route_projections(managers) -> None:
     assert spec["agent_run_target"]["agent_backend"] == "codex"
     assert spec["agent_run_target"]["agent_name"] is None
     assert spec["agent_run_target"]["model"] is None
+    assert spec["agent_session_target"]["metadata"] == {"explicit_setting_overrides": ["model"]}
+    assert "resolved_vibe_agent" not in spec
+
+
+def test_name_only_scheduled_projection_refreshes_same_durable_agent(managers) -> None:
+    manager, _other, _engine, _engine_b, _starts = managers
+    context = _context()
+    context.platform_specific.update(
+        {
+            "turn_source": SOURCE_SCHEDULED,
+            "vibe_agent_name": "reviewer",
+            "agent_session_target": {
+                "id": "ses_fsm",
+                "agent_id": "agent-reviewer",
+                "agent_name": "reviewer",
+                "agent_backend": "claude",
+                "agent_variant": "claude",
+                "model": "old-model",
+                "reasoning_effort": "low",
+                "metadata": {},
+            },
+        }
+    )
+
+    assert manager._binding_projection_is_stale(
+        context,
+        {
+            "id": "ses_fsm",
+            "agent_id": "agent-reviewer",
+            "agent_name": "reviewer",
+            "agent_backend": "codex",
+            "agent_variant": "codex",
+            "model": "new-model",
+            "reasoning_effort": "high",
+            "metadata_json": '{"explicit_setting_overrides":["model"]}',
+        },
+    )
+
+
+def test_projection_refresh_preserves_explicit_run_target(managers) -> None:
+    manager, _other, _engine, _engine_b, _starts = managers
+    context = _context()
+    context.platform_specific.update(
+        {
+            "agent_run_target": {
+                "agent_session_id": "ses_scheduled_run",
+                "agent_id": "agent-writer",
+                "agent_name": "writer",
+                "agent_backend": "claude",
+            },
+            "resolved_vibe_agent": {
+                "id": "agent-writer",
+                "name": "writer",
+                "backend": "claude",
+            },
+        }
+    )
+
+    assert not manager._binding_projection_is_stale(
+        context,
+        {
+            "id": "ses_fsm",
+            "agent_id": "agent-reviewer",
+            "agent_name": "reviewer",
+            "agent_backend": "codex",
+            "metadata_json": "{}",
+        },
+    )
+
+
+def test_fifo_head_mismatch_does_not_bind_session_route(managers) -> None:
+    manager, _other, engine, _engine_b, starts = managers
+    delivery_id = delivery_store.new_delivery_id()
+    with engine.begin() as conn:
+        conn.execute(
+            update(agent_sessions)
+            .where(agent_sessions.c.id == "ses_fsm")
+            .values(
+                agent_id=None,
+                agent_name=None,
+                agent_backend="",
+                agent_variant="default",
+            )
+        )
+        delivery_store.insert_delivery(
+            conn,
+            delivery_id=delivery_id,
+            session_id="ses_fsm",
+            priority="p3",
+            state="queued",
+            snapshot=delivery_store.message_snapshot(
+                scope_id=None,
+                session_id="ses_fsm",
+                platform="avibe",
+                author="user",
+                source="scheduled",
+                text="exact head",
+                metadata={
+                    SCHEDULED_PROVENANCE_KEY: {
+                        "platform_specific": {
+                            "vibe_agent_name": "reviewer",
+                        }
+                    }
+                },
+            ),
+            dispatch_text="exact head",
+            now="2026-08-01T00:00:01Z",
+        )
+        head = delivery_store.get_delivery(conn, delivery_id)
+    assert head is not None
+
+    assert not asyncio.run(
+        manager.drain_delivery_queue(
+            "ses_fsm",
+            expected_head_id="different-head",
+            expected_head_version=int(head["version"]),
+        )
+    )
+    with engine.connect() as conn:
+        binding = conn.execute(
+            select(
+                agent_sessions.c.agent_id,
+                agent_sessions.c.agent_name,
+                agent_sessions.c.agent_backend,
+            ).where(agent_sessions.c.id == "ses_fsm")
+        ).one()
+    assert binding == (None, None, "")
+    assert starts == []
 
 
 def test_im_p1_materializes_only_after_exact_native_acceptance(managers) -> None:
@@ -1134,9 +1268,7 @@ def test_post_native_terminal_storage_failure_retains_owner_and_running_projecti
     with engine.connect() as conn:
         turn = delivery_store.get_turn(conn, turn_id)
         status = conn.execute(
-            select(agent_sessions.c.agent_status).where(
-                agent_sessions.c.id == "ses_fsm"
-            )
+            select(agent_sessions.c.agent_status).where(agent_sessions.c.id == "ses_fsm")
         ).scalar_one()
     assert turn is not None and turn["state"] == "active"
     assert status == "running"
@@ -3249,7 +3381,9 @@ def test_forced_backend_refresh_fails_unresolved_start_instead_of_blocking(
     with engine.connect() as conn:
         turn = delivery_store.get_turn(conn, turn_id)
         status = conn.execute(
-            select(agent_sessions.c.agent_status).where(agent_sessions.c.id == "ses_fsm")
+            select(agent_sessions.c.agent_status).where(
+                agent_sessions.c.id == "ses_fsm"
+            )
         ).scalar_one()
     assert turn is not None
     assert turn["state"] == "terminal"

--- a/tests/test_session_delivery_fsm.py
+++ b/tests/test_session_delivery_fsm.py
@@ -92,6 +92,25 @@ def _context(session_id: str = "ses_fsm") -> MessageContext:
     )
 
 
+def _agentless_context(session_id: str = "ses_fsm") -> MessageContext:
+    return MessageContext(
+        user_id="user",
+        channel_id=session_id,
+        platform="avibe",
+        platform_specific={
+            "workbench_session_id": session_id,
+            "agent_session_id": session_id,
+            "agent_session_target": {
+                "id": session_id,
+                "agent_id": None,
+                "agent_name": None,
+                "agent_backend": "",
+                "agent_variant": "default",
+            },
+        },
+    )
+
+
 def _seed_session(engine, session_id: str = "ses_fsm") -> None:
     now = "2026-08-01T00:00:00+00:00"
     with engine.begin() as conn:
@@ -567,6 +586,105 @@ def test_persisted_start_attempt_reaches_dispatch_context(managers) -> None:
         turn = delivery_store.get_turn(conn, admitted.turn_id)
     assert turn is not None
     assert captured["delivery_start_attempt_id"] == turn["start_attempt_id"]
+
+
+def test_first_delivery_binds_agentless_session_before_runtime_start(managers) -> None:
+    manager, _other, engine, _engine_b, starts = managers
+    with engine.begin() as conn:
+        conn.execute(
+            update(agent_sessions)
+            .where(agent_sessions.c.id == "ses_fsm")
+            .values(
+                agent_id=None,
+                agent_name=None,
+                agent_backend="",
+                agent_variant="default",
+            )
+        )
+    manager.controller.resolve_vibe_agent_for_context = lambda *_args, **_kwargs: SimpleNamespace(
+        id="agent-codex",
+        name="reviewer",
+        backend="codex",
+    )
+
+    result = asyncio.run(
+        manager.deliver(
+            DeliveryRequest(
+                session_id="ses_fsm",
+                priority="p3",
+                content="bind the default Agent",
+            ),
+            context=_agentless_context(),
+        )
+    )
+
+    assert result.state == "claimed"
+    assert [text for _turn_id, text in starts] == ["bind the default Agent"]
+    with engine.connect() as conn:
+        binding = conn.execute(
+            select(
+                agent_sessions.c.agent_id,
+                agent_sessions.c.agent_name,
+                agent_sessions.c.agent_backend,
+                agent_sessions.c.agent_variant,
+            ).where(agent_sessions.c.id == "ses_fsm")
+        ).one()
+    assert binding == ("agent-codex", "reviewer", "codex", "codex")
+
+
+def test_first_delivery_keeps_concurrent_session_binding_winner(managers) -> None:
+    manager, _other, engine, engine_b, _starts = managers
+    with engine.begin() as conn:
+        conn.execute(
+            update(agent_sessions)
+            .where(agent_sessions.c.id == "ses_fsm")
+            .values(
+                agent_id=None,
+                agent_name=None,
+                agent_backend="",
+                agent_variant="default",
+            )
+        )
+
+    def resolve_after_user_edit(*_args, **_kwargs):
+        with engine_b.begin() as conn:
+            conn.execute(
+                update(agent_sessions)
+                .where(agent_sessions.c.id == "ses_fsm")
+                .values(
+                    agent_id="agent-claude",
+                    agent_name="writer",
+                    agent_backend="claude",
+                    agent_variant="claude",
+                )
+            )
+        return SimpleNamespace(id="agent-codex", name="reviewer", backend="codex")
+
+    manager.controller.resolve_vibe_agent_for_context = resolve_after_user_edit
+
+    result = asyncio.run(
+        manager.deliver(
+            DeliveryRequest(
+                session_id="ses_fsm",
+                priority="p3",
+                content="keep the user's route",
+            ),
+            context=_agentless_context(),
+        )
+    )
+
+    assert result.state == "claimed"
+    with engine.connect() as conn:
+        binding = conn.execute(
+            select(
+                agent_sessions.c.agent_id,
+                agent_sessions.c.agent_name,
+                agent_sessions.c.agent_backend,
+            ).where(agent_sessions.c.id == "ses_fsm")
+        ).one()
+        turn = delivery_store.get_turn(conn, str(result.turn_id))
+    assert binding == ("agent-claude", "writer", "claude")
+    assert turn is not None and turn["backend"] == "claude"
 
 
 def test_im_p1_materializes_only_after_exact_native_acceptance(managers) -> None:
@@ -3557,6 +3675,62 @@ def test_recovery_survives_queued_delivery_whose_agent_run_settled(
 
     assert _row(engine, poisoned_id)["state"] == "retired"
     assert starts == []
+
+
+def test_recovery_binds_agentless_session_before_draining_queue(managers) -> None:
+    """Startup repairs the pre-fix queue state instead of crashing again."""
+
+    manager, _other, engine, _engine_b, starts = managers
+    delivery_id = delivery_store.new_delivery_id()
+    with engine.begin() as conn:
+        conn.execute(
+            update(agent_sessions)
+            .where(agent_sessions.c.id == "ses_fsm")
+            .values(
+                agent_id=None,
+                agent_name=None,
+                agent_backend="",
+                agent_variant="default",
+            )
+        )
+        delivery_store.insert_delivery(
+            conn,
+            delivery_id=delivery_id,
+            session_id="ses_fsm",
+            priority="p3",
+            state="queued",
+            snapshot=delivery_store.message_snapshot(
+                scope_id=None,
+                session_id="ses_fsm",
+                platform="avibe",
+                author="user",
+                source="user",
+                text="recover the queued turn",
+            ),
+            dispatch_text="recover the queued turn",
+        )
+    manager.bind_context(_agentless_context)
+    manager.controller.resolve_vibe_agent_for_context = lambda *_args, **_kwargs: SimpleNamespace(
+        id="agent-codex",
+        name="reviewer",
+        backend="codex",
+    )
+
+    assert asyncio.run(
+        manager.recover_durable_delivery_state(service_restart=True)
+    ) == []
+
+    assert _row(engine, delivery_id)["state"] == "claimed"
+    assert [text for _turn_id, text in starts] == ["recover the queued turn"]
+    with engine.connect() as conn:
+        binding = conn.execute(
+            select(
+                agent_sessions.c.agent_id,
+                agent_sessions.c.agent_name,
+                agent_sessions.c.agent_backend,
+            ).where(agent_sessions.c.id == "ses_fsm")
+        ).one()
+    assert binding == ("agent-codex", "reviewer", "codex")
 
 
 def test_fifo_claim_starts_head_whose_agent_run_is_still_queued(

--- a/tests/test_session_delivery_fsm.py
+++ b/tests/test_session_delivery_fsm.py
@@ -737,6 +737,47 @@ def test_first_delivery_honors_context_agent_override_when_binding(managers) -> 
     assert binding == ("agent-selected", "selected", "claude")
 
 
+def test_first_delivery_rejects_unresolvable_context_agent_override(managers) -> None:
+    manager, _other, engine, _engine_b, _starts = managers
+    with engine.begin() as conn:
+        conn.execute(
+            update(agent_sessions)
+            .where(agent_sessions.c.id == "ses_fsm")
+            .values(
+                agent_id=None,
+                agent_name=None,
+                agent_backend="",
+                agent_variant="default",
+            )
+        )
+    context = _agentless_context()
+    context.platform_specific["vibe_agent_name"] = "archived-agent"
+    resolved_kwargs: dict[str, object] = {}
+
+    def resolve(_context, **kwargs):
+        resolved_kwargs.update(kwargs)
+        return None
+
+    manager.controller.resolve_vibe_agent_for_context = resolve
+
+    with pytest.raises(RuntimeError, match="Explicit Vibe Agent override"):
+        asyncio.run(
+            manager.deliver(
+                DeliveryRequest(session_id="ses_fsm", priority="p3", content="reject"),
+                context=context,
+            )
+        )
+    assert resolved_kwargs["required"] is True
+    with engine.connect() as conn:
+        binding = conn.execute(
+            select(
+                agent_sessions.c.agent_name,
+                agent_sessions.c.agent_backend,
+            ).where(agent_sessions.c.id == "ses_fsm")
+        ).one()
+    assert binding == (None, "")
+
+
 def test_binding_refreshes_all_cached_route_projections(managers) -> None:
     manager, _other, _engine, _engine_b, _starts = managers
     context = _agentless_context()
@@ -3823,6 +3864,71 @@ def test_recovery_binds_agentless_session_before_draining_queue(managers) -> Non
             ).where(agent_sessions.c.id == "ses_fsm")
         ).one()
     assert binding == ("agent-codex", "reviewer", "codex")
+
+
+def test_recovery_binds_scheduled_head_from_delivery_provenance(managers) -> None:
+    manager, _other, engine, _engine_b, starts = managers
+    delivery_id = delivery_store.new_delivery_id()
+    with engine.begin() as conn:
+        conn.execute(
+            update(agent_sessions)
+            .where(agent_sessions.c.id == "ses_fsm")
+            .values(
+                agent_id=None,
+                agent_name=None,
+                agent_backend="",
+                agent_variant="default",
+            )
+        )
+        delivery_store.insert_delivery(
+            conn,
+            delivery_id=delivery_id,
+            session_id="ses_fsm",
+            priority="p3",
+            state="queued",
+            snapshot=delivery_store.message_snapshot(
+                scope_id=None,
+                session_id="ses_fsm",
+                platform="avibe",
+                author="harness",
+                source="harness",
+                text="recover scheduled turn",
+                metadata={
+                    SCHEDULED_PROVENANCE_KEY: {
+                        "platform_specific": {
+                            "task_trigger_kind": "agent_run",
+                            "vibe_agent_id": "agent-scheduled",
+                            "vibe_agent_name": "scheduled",
+                        }
+                    }
+                },
+            ),
+            dispatch_text="recover scheduled turn",
+        )
+    manager.bind_context(_agentless_context)
+    manager.controller.resolve_vibe_agent_for_context = lambda _context, **kwargs: (
+        SimpleNamespace(
+            id="agent-scheduled",
+            name="scheduled",
+            backend="claude",
+        )
+        if kwargs.get("override_agent_name") == "scheduled"
+        else None
+    )
+
+    assert asyncio.run(manager.recover_durable_delivery_state(service_restart=True)) == []
+
+    assert _row(engine, delivery_id)["state"] == "claimed"
+    assert [text for _turn_id, text in starts] == ["recover scheduled turn"]
+    with engine.connect() as conn:
+        binding = conn.execute(
+            select(
+                agent_sessions.c.agent_id,
+                agent_sessions.c.agent_name,
+                agent_sessions.c.agent_backend,
+            ).where(agent_sessions.c.id == "ses_fsm")
+        ).one()
+    assert binding == ("agent-scheduled", "scheduled", "claude")
 
 
 def test_fifo_claim_starts_head_whose_agent_run_is_still_queued(

--- a/tests/test_session_delivery_fsm.py
+++ b/tests/test_session_delivery_fsm.py
@@ -687,6 +687,98 @@ def test_first_delivery_keeps_concurrent_session_binding_winner(managers) -> Non
     assert turn is not None and turn["backend"] == "claude"
 
 
+def test_first_delivery_honors_context_agent_override_when_binding(managers) -> None:
+    manager, _other, engine, _engine_b, _starts = managers
+    with engine.begin() as conn:
+        conn.execute(
+            update(agent_sessions)
+            .where(agent_sessions.c.id == "ses_fsm")
+            .values(
+                agent_id=None,
+                agent_name=None,
+                agent_backend="",
+                agent_variant="default",
+            )
+        )
+    context = _agentless_context()
+    context.platform_specific.update(
+        {"vibe_agent_id": "agent-selected", "vibe_agent_name": "selected"}
+    )
+    resolved_kwargs: dict[str, object] = {}
+
+    def resolve(_context, **kwargs):
+        resolved_kwargs.update(kwargs)
+        return SimpleNamespace(
+            id="agent-selected",
+            name="selected",
+            backend="claude",
+        )
+
+    manager.controller.resolve_vibe_agent_for_context = resolve
+
+    result = asyncio.run(
+        manager.deliver(
+            DeliveryRequest(session_id="ses_fsm", priority="p3", content="use selected"),
+            context=context,
+        )
+    )
+
+    assert result.state == "claimed"
+    assert resolved_kwargs["override_agent_id"] == "agent-selected"
+    assert resolved_kwargs["override_agent_name"] == "selected"
+    with engine.connect() as conn:
+        binding = conn.execute(
+            select(
+                agent_sessions.c.agent_id,
+                agent_sessions.c.agent_name,
+                agent_sessions.c.agent_backend,
+            ).where(agent_sessions.c.id == "ses_fsm")
+        ).one()
+    assert binding == ("agent-selected", "selected", "claude")
+
+
+def test_binding_refreshes_all_cached_route_projections(managers) -> None:
+    manager, _other, _engine, _engine_b, _starts = managers
+    context = _agentless_context()
+    context.platform_specific.update(
+        {
+            "vibe_agent_id": "stale-agent",
+            "vibe_agent_name": "stale",
+            "agent_run_target": {
+                "agent_session_id": "ses_fsm",
+                "agent_id": "stale-agent",
+                "agent_name": "stale",
+                "agent_backend": "claude",
+                "agent_variant": "claude",
+                "model": "old-model",
+                "reasoning_effort": "low",
+                "workdir": "/tmp",
+            },
+        }
+    )
+
+    manager._apply_session_binding_to_context(
+        context,
+        {
+            "id": "ses_fsm",
+            "agent_id": None,
+            "agent_name": None,
+            "agent_backend": "codex",
+            "agent_variant": "codex",
+            "model": None,
+            "reasoning_effort": None,
+        },
+    )
+
+    spec = context.platform_specific
+    assert spec["vibe_agent_id"] is None
+    assert spec["vibe_agent_name"] is None
+    assert spec["agent_session_target"]["agent_backend"] == "codex"
+    assert spec["agent_run_target"]["agent_backend"] == "codex"
+    assert spec["agent_run_target"]["agent_name"] is None
+    assert spec["agent_run_target"]["model"] is None
+
+
 def test_im_p1_materializes_only_after_exact_native_acceptance(managers) -> None:
     manager, _other, engine, _engine_b, _starts = managers
 

--- a/tests/test_sqlite_sessions_store.py
+++ b/tests/test_sqlite_sessions_store.py
@@ -6246,6 +6246,9 @@ _MARKER_AWARE_SESSION_ROUTE_WRITERS = {
     # its bind moves an unbound row to another backend; the remaining sites here
     # write the route only as part of creating / importing / relabelling a row.
     "storage/sessions_service.py",
+    # First-turn binding materializes an inherited backend on an agentless row and
+    # normalizes its override marker without changing explicitly pinned settings.
+    "core/session_turns.py",
 }
 
 #: The reconciliation API a marker-aware writer has to reach for.


### PR DESCRIPTION
## Summary

- atomically resolve and persist the exact queued Delivery's Agent/backend route before runtime admission
- claim the validated FIFO head, bind the Session route, and acquire the runtime owner under one SQLite writer transaction
- rebuild cached Session routing projections from the durable row while preserving explicit alternate scheduled/run targets

## Root cause

PR #1155 correctly made runtime admission fail closed unless the Session already has a durable backend binding. Plain Workbench sessions intentionally remain agentless until first dispatch so the configured default Vibe Agent can supply its backend, model, and system prompt. The dispatch path resolved that route in memory before it owned the exact FIFO head, then crossed the runtime ownership gate without one durable source of truth. Recovery could therefore leave the Delivery queued, bind from the wrong head, or dispatch from stale cached Agent/model projections.

## Scenario coverage

- Scenario IDs: none; this is the Session Delivery FSM, outside the Harness Failure Recovery catalog
- first P3 delivery binds an agentless Session before runtime start
- FIFO head/version mismatch cannot mutate the Session route
- a concurrent explicit Session route wins over stale default resolution
- explicit context Agent overrides are materialized and invalid overrides are rejected
- name-only scheduled Agent identities refresh matching durable projections
- cached Session/run targets, model metadata, and resolved Agent identity refresh together without overwriting explicit alternate run targets
- startup recovery repairs agentless Sessions and binds scheduled heads from exact durable provenance

## Evidence

- Unit: `tests/test_session_delivery_fsm.py` (113 passed)
- Contract: `tests/test_workbench_session_defaults.py tests/test_sqlite_sessions_store.py tests/test_internal_server.py tests/test_scheduled_tasks.py` (658 passed)
- Scenario: focused first-dispatch, FIFO CAS, concurrent-winner, explicit-Agent, cached-projection, scheduled-provenance, and restart-recovery regressions are included in the FSM suite
- Static/build: Ruff, `git diff --check`, Python compile, and production UI build pass
- CI: all current-head GitHub checks pass
- Manual regression: local Incus master environment on commit `0fa15de6`; an agentless Workbench Session accepted its first Delivery, durably bound to the default Codex Agent, completed the native turn with `OK`, and was archived afterward
- Local hotfix: the same wheel is installed on the developer workstation; the existing process remains running until active foreground turns can be restarted without interruption
