### PR TITLE
fix(runtime): key the turn sink per thread, not per channel

### DIFF
--- a/core/controller.py
+++ b/core/controller.py
@@ -1147,6 +1147,18 @@ class Controller:
         settings_key = resolve_context_settings_key(context)
         return build_context_session_key(context, platform=platform, settings_key=settings_key)
 
+    def _get_turn_sink_key(self, context: MessageContext) -> str:
+        """Get the live turn sink's key for ``context``.
+
+        Thread-scoped, unlike ``_get_session_key``: the sink is one agent
+        session's turn-concurrency slot, so sharing it across a channel's
+        threads made ``dispatch_turn`` refuse unrelated sessions' turns. See
+        ``core.message_context.build_context_turn_sink_key``.
+        """
+        from core.message_context import build_context_turn_sink_key
+
+        return build_context_turn_sink_key(context, session_key=self._get_session_key(context))
+
     def backend_alive(self, context: MessageContext) -> Optional[bool]:
         """Best-effort backend liveness for the concise status bubble's footer.
 
@@ -1281,7 +1293,7 @@ class Controller:
         when an agent turn is genuinely in flight (the result emit releases it)."""
         if context is None:
             return
-        sink = self.get_turn_sink(self._get_session_key(context))
+        sink = self.get_turn_sink(self._get_turn_sink_key(context))
         if sink is None:
             return
         # Turn-token guard (mirrors ``_stream_chunk`` / ``_is_active_turn``): a

--- a/core/message_context.py
+++ b/core/message_context.py
@@ -146,3 +146,25 @@ def build_context_turn_sink_key(
     if not thread_id:
         return base
     return f"{base}::thread::{thread_id}"
+
+
+def resolve_turn_sink_key(controller: object, context: MessageContext) -> str:
+    """Resolve ``context``'s turn-sink key, preferring ``controller``'s own accessor.
+
+    Falls back to ``_get_session_key`` and then to the context alone, applying the
+    same thread-scoping rule at every step. Never degrades to the bare channel key:
+    that scope is what made one busy thread refuse its siblings' turns, so a
+    controller without the accessor must still land on a thread-scoped key rather
+    than silently reintroduce the collision.
+
+    Always returns a key. A key with no sink registered simply misses in
+    ``get_turn_sink``, which is what every caller already handles.
+    """
+
+    getter = getattr(controller, "_get_turn_sink_key", None)
+    if callable(getter):
+        return getter(context)
+    base_getter = getattr(controller, "_get_session_key", None)
+    if callable(base_getter):
+        return build_context_turn_sink_key(context, session_key=base_getter(context))
+    return build_context_turn_sink_key(context)

--- a/core/message_context.py
+++ b/core/message_context.py
@@ -109,3 +109,40 @@ def build_context_session_key(
     if requires_typed_user_session_key(context):
         return f"{resolved_platform}::user::{resolved_settings_key}"
     return f"{resolved_platform}::{resolved_settings_key}"
+
+
+def build_context_turn_sink_key(
+    context: MessageContext,
+    *,
+    session_key: Optional[str] = None,
+) -> str:
+    """Build the key that identifies ONE agent session's live turn sink.
+
+    Distinct from ``build_context_session_key`` on purpose. That key is
+    channel-scoped (``resolve_context_settings_key`` deliberately drops the
+    thread), which is right for polls, settings lookup, and message
+    consolidation — they are channel-wide concerns. The turn sink is not: it
+    is the concurrency slot for a SINGLE agent session, and
+    ``dispatch_turn_with_outcome`` refuses any turn that finds the slot taken.
+
+    Keying the sink at channel scope therefore made the refusal channel-wide:
+    a long-running Telegram forum topic held the only slot for its whole group,
+    so every OTHER topic's turn was refused with ``refused_concurrent_turn``
+    before reaching a backend, silently, until that unrelated topic finished.
+
+    The thread scope is resolved the same way every session-anchor caller
+    resolves it (``resolve_context_thread_id(context) or context.thread_id``),
+    so the key is derived purely from context fields that are already pinned
+    before dispatch and carried by every context in a turn's lifetime — the
+    dispatch context, the backend receiver's stale per-turn context, and an
+    external stop's rebuilt context all land on the same key.
+    """
+
+    base = session_key if session_key is not None else build_context_session_key(context)
+    # ``getattr`` because this is reached from every turn-lifecycle context, including
+    # the lookalike namespaces the workbench/stop paths build. A context without the
+    # attribute has no thread, which is the unthreaded case — not an error.
+    thread_id = resolve_context_thread_id(context) or getattr(context, "thread_id", None)
+    if not thread_id:
+        return base
+    return f"{base}::thread::{thread_id}"

--- a/core/message_dispatcher.py
+++ b/core/message_dispatcher.py
@@ -167,16 +167,16 @@ async def _stream_chunk(
     ``controller.active_turn_sinks`` (see ``core.services.dispatch.dispatch_turn``)
     so the SSE response stream sees notify + result emits as they happen —
     even though the agent's receiver runs on a background task carrying a
-    stale per-turn context. We resolve the sink by *session key* (stable
-    across a session's turns) rather than off the context, so reused agent
-    sessions stream correctly too. A terminal ``result`` emit also marks the
+    stale per-turn context. We resolve the sink by its *thread-scoped sink key*
+    (stable across a session's turns) rather than off the context, so reused
+    agent sessions stream correctly too. A terminal ``result`` emit also marks the
     turn complete so ``dispatch_turn`` can close the stream right after it;
     multi-output callers explicitly pass ``completes_turn=False``. No
     sink (IM / CLI turns) => no-op, byte-identical to master.
     """
 
     get_sink = getattr(controller, "get_turn_sink", None)
-    get_key = getattr(controller, "_get_session_key", None)
+    get_key = getattr(controller, "_get_turn_sink_key", None)
     if not callable(get_sink) or not callable(get_key):
         # Controller has no streaming turn-sink registry (IM/CLI stubs, older
         # controllers) => nothing to stream to; stay a no-op.

--- a/core/message_dispatcher.py
+++ b/core/message_dispatcher.py
@@ -22,6 +22,7 @@ from config.v2_config import DEFAULT_AGENT_PROGRESS_STYLE
 from modules.im import MessageContext
 from modules.im.formatters.base_formatter import to_status_label
 from core.delivery_evidence import STAGE_PERSIST, STAGE_SEND, STAGE_STREAM, DeliveryEvidence
+from core.message_context import resolve_turn_sink_key
 from core.message_mirror import (
     agent_message_exists,
     persist_agent_message,
@@ -176,12 +177,11 @@ async def _stream_chunk(
     """
 
     get_sink = getattr(controller, "get_turn_sink", None)
-    get_key = getattr(controller, "_get_turn_sink_key", None)
-    if not callable(get_sink) or not callable(get_key):
+    if not callable(get_sink):
         # Controller has no streaming turn-sink registry (IM/CLI stubs, older
         # controllers) => nothing to stream to; stay a no-op.
         return
-    sink = get_sink(get_key(context))
+    sink = get_sink(resolve_turn_sink_key(controller, context))
     if sink is None:
         return
     # NB: we deliberately do NOT gate forwarding on a per-turn token here.

--- a/core/services/dispatch.py
+++ b/core/services/dispatch.py
@@ -141,7 +141,10 @@ async def dispatch_turn_with_outcome(
             backend_dispatch_attempted=backend_dispatch_attempted(context),
         )
 
-    session_key = controller._get_session_key(context)
+    # Thread-scoped, NOT ``_get_session_key`` (channel-scoped): this gate refuses
+    # a turn when the slot is taken, so a channel-wide key made one busy Telegram
+    # forum topic / Slack thread refuse every sibling thread's turn.
+    session_key = controller._get_turn_sink_key(context)
     if controller.get_turn_sink(session_key) is not None:
         # Serialize per session. A streaming turn is already in flight for
         # this session (a second browser tab, or a resend before the first

--- a/core/services/dispatch.py
+++ b/core/services/dispatch.py
@@ -36,6 +36,7 @@ from core.run_settlement import (
     SETTLED_BY_NO_TERMINAL_RESULT,
     SETTLED_BY_REFUSED_CONCURRENT_TURN,
 )
+from core.message_context import resolve_turn_sink_key
 from core.native_dispatch_phase import backend_dispatch_attempted
 from modules.im import MessageContext
 
@@ -144,7 +145,7 @@ async def dispatch_turn_with_outcome(
     # Thread-scoped, NOT ``_get_session_key`` (channel-scoped): this gate refuses
     # a turn when the slot is taken, so a channel-wide key made one busy Telegram
     # forum topic / Slack thread refuse every sibling thread's turn.
-    session_key = controller._get_turn_sink_key(context)
+    session_key = resolve_turn_sink_key(controller, context)
     if controller.get_turn_sink(session_key) is not None:
         # Serialize per session. A streaming turn is already in flight for
         # this session (a second browser tab, or a resend before the first

--- a/core/services/running_agents.py
+++ b/core/services/running_agents.py
@@ -851,7 +851,8 @@ def _build_session_row_stop_context(
     ``avibe::<session_id>``, which can stop the backend when backend ids are
     patched in, but cannot find the dispatch sink registered under the original
     scope key. Rebuild the same scope context that ``_execute_agent_run`` used so
-    ``controller._get_session_key`` resolves to the live sink.
+    ``controller._get_turn_sink_key`` resolves to the live sink — including the
+    row's ``thread_id``, which that key is scoped by.
     """
     if not session_id:
         return None

--- a/core/session_turns.py
+++ b/core/session_turns.py
@@ -28,6 +28,7 @@ from sqlalchemy.engine import Connection, Engine
 from sqlalchemy.exc import IntegrityError
 
 from core.web_push_notifications import WEB_PUSH_USER_KEY_METADATA, WEB_PUSH_USER_KEYS_METADATA
+from core.message_context import resolve_turn_sink_key
 from core.native_dispatch_phase import backend_dispatch_attempted
 from core.run_settlement import (
     SETTLEMENTS_WITHOUT_RESULT,
@@ -4154,10 +4155,9 @@ class SessionTurnManager:
             return None
         if outcome == "terminal":
             get_sink = getattr(self.controller, "get_turn_sink", None)
-            get_key = getattr(self.controller, "_get_turn_sink_key", None)
-            if callable(get_sink) and callable(get_key):
+            if callable(get_sink):
                 try:
-                    sink = get_sink(get_key(context))
+                    sink = get_sink(resolve_turn_sink_key(self.controller, context))
                 except Exception:
                     logger.debug("failed to inspect native terminal Turn sink", exc_info=True)
                 else:
@@ -6416,10 +6416,9 @@ class SessionTurnManager:
         if not callable(runtime_started) or runtime_started(context) is not True:
             return False
         session_id = self.controller._session_id_from_context(context)
-        get_key = getattr(self.controller, "_get_turn_sink_key", None)
-        if not session_id or not callable(get_key):
+        if not session_id:
             return False
-        session_key = get_key(context)
+        session_key = resolve_turn_sink_key(self.controller, context)
         return session_id not in self.in_flight and self.get_turn_sink(session_key) is None
 
     def on_running(self, context: "MessageContext") -> None:
@@ -6512,12 +6511,10 @@ class SessionTurnManager:
             if current is not None and current.logical_turn_id == logical_turn_id:
                 current.terminal_is_error = current.terminal_is_error or is_error
             sink = None
-            get_key = getattr(self.controller, "_get_turn_sink_key", None)
-            if callable(get_key):
-                try:
-                    sink = self.get_turn_sink(get_key(context))
-                except Exception:
-                    logger.debug("failed to inspect terminal Turn sink", exc_info=True)
+            try:
+                sink = self.get_turn_sink(resolve_turn_sink_key(self.controller, context))
+            except Exception:
+                logger.debug("failed to inspect terminal Turn sink", exc_info=True)
             if isinstance(sink, dict):
                 sink["terminal_evidence"] = dict(terminal_evidence or {})
         payload = dict(getattr(context, "platform_specific", None) or {})
@@ -6565,12 +6562,10 @@ class SessionTurnManager:
             return
         current = self.in_flight.get(session_id)
         sink = None
-        get_key = getattr(self.controller, "_get_turn_sink_key", None)
-        if callable(get_key):
-            try:
-                sink = self.get_turn_sink(get_key(context))
-            except Exception:
-                logger.debug("failed to inspect delivered terminal Turn sink", exc_info=True)
+        try:
+            sink = self.get_turn_sink(resolve_turn_sink_key(self.controller, context))
+        except Exception:
+            logger.debug("failed to inspect delivered terminal Turn sink", exc_info=True)
         self._finish_durable_terminal_result(
             session_id,
             logical_turn_id,
@@ -6612,10 +6607,7 @@ class SessionTurnManager:
         session_id = self.controller._session_id_from_context(context)
         if not session_id:
             return False
-        get_key = getattr(self.controller, "_get_turn_sink_key", None)
-        if not callable(get_key):
-            return False
-        session_key = get_key(context)
+        session_key = resolve_turn_sink_key(self.controller, context)
         # Defensive: ``begin_agent_initiated_turn`` only opens on a free gate, so a
         # turn shouldn't already be tracked/streaming — but never clobber one.
         if session_id in self.in_flight or self.get_turn_sink(session_key) is not None:
@@ -6862,11 +6854,10 @@ class SessionTurnManager:
         settle), else apply the one token rule. Centralizes the old
         ``ConsolidatedMessageDispatcher._is_active_turn``."""
         get_sink = getattr(self.controller, "get_turn_sink", None)
-        get_key = getattr(self.controller, "_get_turn_sink_key", None)
-        if not callable(get_sink) or not callable(get_key):
+        if not callable(get_sink):
             return True
         try:
-            sink = get_sink(get_key(context))
+            sink = get_sink(resolve_turn_sink_key(self.controller, context))
         except Exception:
             return True
         if sink is None:
@@ -6967,11 +6958,8 @@ class SessionTurnManager:
         """
         if self.controller is None:
             return None
-        get_key = getattr(self.controller, "_get_turn_sink_key", None)
-        if not callable(get_key):
-            return None
         try:
-            session_key = get_key(context)
+            session_key = resolve_turn_sink_key(self.controller, context)
         except Exception:
             logger.debug("turn sink bind: failed to derive session key", exc_info=True)
             return None

--- a/core/session_turns.py
+++ b/core/session_turns.py
@@ -396,10 +396,11 @@ class Turn:
     Queue policy is deliberately absent. The durable Session hold and Turn control
     slot decide whether backlog may drain across both process lifetime and restart.
 
-    The streaming SINK is deliberately NOT held here: it is keyed by ``session_key``
-    (platform-prefixed ``avibe::<id>``) not ``session_id``, is registered from the
-    dispatcher on the emit path, and is platform-agnostic (a future IM stream has a
-    sink but no avibe ``session_id``). See ``SessionTurnManager.active_turn_sinks``.
+    The streaming SINK is deliberately NOT held here: it is keyed by the
+    thread-scoped turn-sink key (platform-prefixed, e.g. ``avibe::<id>``) not
+    ``session_id``, is registered from the dispatcher on the emit path, and is
+    platform-agnostic (an IM stream has a sink but no avibe ``session_id``). See
+    ``SessionTurnManager.active_turn_sinks``.
     """
 
     task: asyncio.Task
@@ -486,7 +487,7 @@ class SessionTurnManager:
 
     - ``in_flight``: ``session_id -> Turn`` for the active turn — the Stop target
       (``/internal/cancel``) and the ``/turn-state`` projection.
-    - ``active_turn_sinks``: the live streaming sink per ``session_key`` — the
+    - ``active_turn_sinks``: the live streaming sink per turn-sink key — the
       streaming half, kept separate on purpose (see ``Turn``).
 
     ``controller`` reaches the backends + the outbound chokepoint
@@ -508,11 +509,18 @@ class SessionTurnManager:
         self._draining_backends: set[str] = set()
         self._deferred_restart_sessions: dict[str, set[str]] = {}
         self._queue_recovery_locks: dict[str, asyncio.Lock] = {}
-        # The live streaming turn sink per SESSION KEY (avibe/web-Chat only; IM/CLI
-        # turns register none). Each is ``{on_chunk, done_event, turn_token}`` — the
-        # turn's stream callback + completion event + correlation token. Keyed by
-        # session_key (stable across a session's turns) so a reused agent receiver
-        # carrying a stale per-turn context still resolves the current turn's sink.
+        # The live turn sink per TURN SINK KEY. Each is
+        # ``{on_chunk, done_event, turn_token}`` — the turn's stream callback +
+        # completion event + correlation token. Every dispatched turn registers one,
+        # IM/CLI included (``_run`` always passes ``_noop_chunk`` so the turn stays
+        # open until the backend's terminal result), which makes this map the
+        # turn-concurrency slot for ALL surfaces, not just web Chat.
+        #
+        # Keyed by ``controller._get_turn_sink_key`` — the THREAD-scoped key, not the
+        # channel-scoped ``_get_session_key``. Stable across a session's turns, so a
+        # reused agent receiver carrying a stale per-turn context still resolves the
+        # current turn's sink; distinct per thread, so a busy forum topic no longer
+        # occupies its siblings' slots.
         self.active_turn_sinks: dict[str, dict] = {}
 
     def _sqlite_engine(self) -> Engine:
@@ -4146,7 +4154,7 @@ class SessionTurnManager:
             return None
         if outcome == "terminal":
             get_sink = getattr(self.controller, "get_turn_sink", None)
-            get_key = getattr(self.controller, "_get_session_key", None)
+            get_key = getattr(self.controller, "_get_turn_sink_key", None)
             if callable(get_sink) and callable(get_key):
                 try:
                     sink = get_sink(get_key(context))
@@ -6408,7 +6416,7 @@ class SessionTurnManager:
         if not callable(runtime_started) or runtime_started(context) is not True:
             return False
         session_id = self.controller._session_id_from_context(context)
-        get_key = getattr(self.controller, "_get_session_key", None)
+        get_key = getattr(self.controller, "_get_turn_sink_key", None)
         if not session_id or not callable(get_key):
             return False
         session_key = get_key(context)
@@ -6504,7 +6512,7 @@ class SessionTurnManager:
             if current is not None and current.logical_turn_id == logical_turn_id:
                 current.terminal_is_error = current.terminal_is_error or is_error
             sink = None
-            get_key = getattr(self.controller, "_get_session_key", None)
+            get_key = getattr(self.controller, "_get_turn_sink_key", None)
             if callable(get_key):
                 try:
                     sink = self.get_turn_sink(get_key(context))
@@ -6557,7 +6565,7 @@ class SessionTurnManager:
             return
         current = self.in_flight.get(session_id)
         sink = None
-        get_key = getattr(self.controller, "_get_session_key", None)
+        get_key = getattr(self.controller, "_get_turn_sink_key", None)
         if callable(get_key):
             try:
                 sink = self.get_turn_sink(get_key(context))
@@ -6604,7 +6612,7 @@ class SessionTurnManager:
         session_id = self.controller._session_id_from_context(context)
         if not session_id:
             return False
-        get_key = getattr(self.controller, "_get_session_key", None)
+        get_key = getattr(self.controller, "_get_turn_sink_key", None)
         if not callable(get_key):
             return False
         session_key = get_key(context)
@@ -6854,7 +6862,7 @@ class SessionTurnManager:
         settle), else apply the one token rule. Centralizes the old
         ``ConsolidatedMessageDispatcher._is_active_turn``."""
         get_sink = getattr(self.controller, "get_turn_sink", None)
-        get_key = getattr(self.controller, "_get_session_key", None)
+        get_key = getattr(self.controller, "_get_turn_sink_key", None)
         if not callable(get_sink) or not callable(get_key):
             return True
         try:
@@ -6959,7 +6967,7 @@ class SessionTurnManager:
         """
         if self.controller is None:
             return None
-        get_key = getattr(self.controller, "_get_session_key", None)
+        get_key = getattr(self.controller, "_get_turn_sink_key", None)
         if not callable(get_key):
             return None
         try:

--- a/tests/scenarios/INDEX.yaml
+++ b/tests/scenarios/INDEX.yaml
@@ -89,6 +89,8 @@ capabilities:
       - tests/test_ui_api.py
       - tests/test_auth_pipeline.py
       - tests/test_agent_run_target.py
+      - tests/test_core_services_dispatch.py
     unit_or_contract_tests:
       - tests/test_sqlite_settings_store.py
+      - tests/test_message_context_helpers.py
       - tests/test_chat_discovery.py

--- a/tests/scenarios/telegram_topic_routing/catalog.yaml
+++ b/tests/scenarios/telegram_topic_routing/catalog.yaml
@@ -6,6 +6,8 @@ capability:
     - tests/test_ui_api.py
     - tests/test_auth_pipeline.py
     - tests/test_agent_run_target.py
+    - tests/test_core_services_dispatch.py
+    - tests/test_message_context_helpers.py
 status_legend:
   covered: automated scenario or contract coverage exists
   manual: currently validated by human regression
@@ -34,3 +36,9 @@ scenarios:
     kind: ui
     layer: manual
     evidence: output/playwright/telegram-topic-settings.png
+  - id: TELEGRAM-TOPIC-005
+    name: A topic running a long turn does not block a sibling topic's turn
+    status: covered
+    kind: concurrency
+    layer: contract
+    test: tests/test_core_services_dispatch.py::test_busy_sibling_thread_does_not_refuse_this_threads_turn

--- a/tests/scenarios/telegram_topic_routing/observations.yaml
+++ b/tests/scenarios/telegram_topic_routing/observations.yaml
@@ -20,3 +20,17 @@ observations:
     required_updates:
       - resolve settings from thread then channel
       - preserve the existing group session key and Telegram reply anchor
+  - id: OBS-TELEGRAM-TOPIC-003
+    source: field_incident
+    related_scenarios:
+      - TELEGRAM-TOPIC-005
+    summary: >-
+      The group-level session key must not be reused for per-turn runtime slots.
+      A topic that ran a 15-minute agent held the only turn sink for its whole
+      group, so three sibling topics' first turns were settled
+      refused_concurrent_turn before reaching a backend, silently, until that
+      unrelated topic finished.
+    required_updates:
+      - key the turn sink at thread scope, not channel scope
+      - keep the group session key unchanged for settings, polls, and consolidation
+      - assert sibling-topic turn independence at the dispatch contract layer

--- a/tests/test_agent_initiated_turn_fsm.py
+++ b/tests/test_agent_initiated_turn_fsm.py
@@ -21,6 +21,7 @@ from unittest.mock import AsyncMock, patch
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from core import session_turns
+from core.message_context import build_context_turn_sink_key
 
 
 def _ctx(session_id: str = "s1"):
@@ -36,6 +37,10 @@ def _manager():
     controller = SimpleNamespace(
         _session_id_from_context=lambda ctx: (getattr(ctx, "platform_specific", None) or {}).get("agent_session_id"),
         _get_session_key=lambda ctx: f"avibe::{(getattr(ctx, 'platform_specific', None) or {}).get('agent_session_id')}",
+        _get_turn_sink_key=lambda ctx: build_context_turn_sink_key(
+            ctx,
+            session_key=f"avibe::{(getattr(ctx, 'platform_specific', None) or {}).get('agent_session_id')}",
+        ),
         set_agent_status=lambda sid, status: None,
         command_handler=SimpleNamespace(handle_stop=AsyncMock(return_value=True)),
     )

--- a/tests/test_core_services_dispatch.py
+++ b/tests/test_core_services_dispatch.py
@@ -30,6 +30,7 @@ from core.run_settlement import (
     SETTLED_BY_REFUSED_CONCURRENT_TURN,
     SETTLED_BY_TERMINAL_RESULT,
 )
+from core.message_context import build_context_turn_sink_key
 from core.services.dispatch import (
     SOURCE_HUMAN,
     SOURCE_SCHEDULED,
@@ -110,6 +111,7 @@ def test_streaming_registers_turn_sink_and_waits_for_result():
         done_event.set()
 
     controller._get_session_key = MagicMock(return_value="slack::C")
+    controller._get_turn_sink_key = MagicMock(return_value="slack::C")
     controller.get_turn_sink = MagicMock(return_value=None)  # no turn in flight => not rejected
     controller.register_turn_sink = MagicMock(side_effect=_register)
     controller.pop_turn_sink = MagicMock()
@@ -139,12 +141,20 @@ def test_on_chunk_absent_keeps_platform_specific_untouched():
     )
 
 
-def _streaming_controller(*, sink_settled_by: str | None, in_flight: bool = False) -> MagicMock:
+def _streaming_controller(
+    *,
+    sink_settled_by: str | None,
+    in_flight: bool = False,
+    in_flight_key: str = "slack::C",
+) -> MagicMock:
     """A controller double whose registered sink is released like the real one.
 
     ``sink_settled_by`` is the stamp the release site would have written:
     ``terminal_result`` for a real backend result, ``None`` for a release that left
     no trace (``mark_turn_complete`` on a no-dispatch turn).
+
+    ``in_flight_key`` is the sink key the pre-registered turn occupies, so a test can
+    park a busy turn on a SIBLING thread's key rather than the one under dispatch.
     """
 
     controller = _build_controller_double()
@@ -158,12 +168,17 @@ def _streaming_controller(*, sink_settled_by: str | None, in_flight: bool = Fals
         done_event.set()
 
     controller._get_session_key = MagicMock(return_value="slack::C")
+    # The real controller derives the sink key from the session key by appending the
+    # THREAD scope; the double keeps that so a threaded context lands on its own key.
+    controller._get_turn_sink_key = MagicMock(
+        side_effect=lambda ctx: build_context_turn_sink_key(ctx, session_key="slack::C")
+    )
     controller.get_turn_sink = MagicMock(side_effect=lambda key: sinks.get(key))
     controller.register_turn_sink = MagicMock(side_effect=_register)
     controller.pop_turn_sink = MagicMock(side_effect=lambda key, done=None: sinks.pop(key, None))
     if in_flight:
         # Pre-register a live sink for the same session: a turn is already streaming.
-        sinks["slack::C"] = {"on_chunk": AsyncMock(), "done_event": asyncio.Event()}
+        sinks[in_flight_key] = {"on_chunk": AsyncMock(), "done_event": asyncio.Event()}
     return controller
 
 
@@ -219,6 +234,53 @@ def test_outcome_reports_refused_concurrent_turn():
     assert outcome.error is None
     on_chunk.assert_awaited_once()
     controller.register_turn_sink.assert_not_called()
+    controller.message_handler.handle_user_message.assert_not_called()
+
+
+def test_busy_sibling_thread_does_not_refuse_this_threads_turn():
+    """A turn in flight on ANOTHER thread of the same channel must not block this one.
+
+    The field bug: ``dispatch_turn_with_outcome`` keyed its concurrency slot off the
+    channel-scoped ``_get_session_key``, because
+    ``resolve_context_settings_key`` deliberately drops the thread. One Telegram forum
+    topic running a 15-minute agent therefore held the ONLY slot for its whole group,
+    and every sibling topic's first turn was settled ``refused_concurrent_turn``
+    before reaching a backend — silently, since IM turns dispatch with the discarding
+    ``_noop_chunk`` — until the unrelated topic finished.
+    """
+
+    busy_sibling = MessageContext(
+        user_id="U", channel_id="C", platform="telegram", thread_id="843", message_id="m0"
+    )
+    controller = _streaming_controller(
+        sink_settled_by=SETTLED_BY_TERMINAL_RESULT,
+        in_flight=True,
+        in_flight_key=build_context_turn_sink_key(busy_sibling, session_key="slack::C"),
+    )
+    new_topic = MessageContext(
+        user_id="U", channel_id="C", platform="telegram", thread_id="847", message_id="m1"
+    )
+    outcome = asyncio.run(
+        dispatch_turn_with_outcome(controller, new_topic, "create a directory", on_chunk=AsyncMock())
+    )
+    assert outcome.settled_by == SETTLED_BY_TERMINAL_RESULT
+    controller.message_handler.handle_user_message.assert_awaited_once()
+
+
+def test_same_thread_turn_is_still_refused():
+    """The slot is still exactly one turn per THREAD — the guard must stay real."""
+
+    ctx = MessageContext(
+        user_id="U", channel_id="C", platform="telegram", thread_id="843", message_id="m1"
+    )
+    controller = _streaming_controller(
+        sink_settled_by=None,
+        in_flight=True,
+        in_flight_key=build_context_turn_sink_key(ctx, session_key="slack::C"),
+    )
+    controller._t = MagicMock(return_value="already streaming")
+    outcome = asyncio.run(dispatch_turn_with_outcome(controller, ctx, "hi", on_chunk=AsyncMock()))
+    assert outcome.settled_by == SETTLED_BY_REFUSED_CONCURRENT_TURN
     controller.message_handler.handle_user_message.assert_not_called()
 
 

--- a/tests/test_dispatcher_stream_chunk.py
+++ b/tests/test_dispatcher_stream_chunk.py
@@ -19,6 +19,7 @@ from unittest.mock import AsyncMock
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
+from core.message_context import build_context_turn_sink_key
 from core.message_dispatcher import _stream_chunk
 from core.run_settlement import SETTLED_BY_STOPPED, SETTLED_BY_TERMINAL_RESULT
 from modules.im import MessageContext
@@ -32,6 +33,9 @@ class _ControllerDouble:
 
     def _get_session_key(self, ctx):
         return f"{ctx.platform}::{ctx.channel_id}"
+
+    def _get_turn_sink_key(self, ctx):
+        return build_context_turn_sink_key(ctx, session_key=self._get_session_key(ctx))
 
     def register_turn_sink(self, session_key, *, on_chunk, done_event, turn_token=None, context=None):
         self.active_turn_sinks[session_key] = {

--- a/tests/test_internal_server.py
+++ b/tests/test_internal_server.py
@@ -32,6 +32,7 @@ from sqlalchemy import select
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from core import internal_server, session_turns
+from core.message_context import build_context_turn_sink_key
 from core.run_settlement import SETTLED_BY_STOPPED, SETTLED_BY_TERMINAL_RESULT
 from core.services.dispatch import (
     SOURCE_HUMAN,
@@ -236,6 +237,12 @@ def _build_controller_double(handler=None):
     sinks: dict = {}
     controller.active_turn_sinks = sinks
     controller._get_session_key = lambda ctx: f"{getattr(ctx, 'platform', None)}::{getattr(ctx, 'channel_id', None)}"
+    # MUST be set explicitly: a MagicMock would auto-generate this attribute and hand
+    # dispatch_turn a bogus key, so every sink lookup would miss and a refused-turn
+    # test would hang in ``done.wait()`` instead of failing.
+    controller._get_turn_sink_key = lambda ctx: build_context_turn_sink_key(
+        ctx, session_key=controller._get_session_key(ctx)
+    )
 
     def _register(session_key, *, on_chunk, done_event, turn_token=None, context=None):
         sinks[session_key] = {"on_chunk": on_chunk, "done_event": done_event, "turn_token": turn_token}

--- a/tests/test_message_context_helpers.py
+++ b/tests/test_message_context_helpers.py
@@ -1,5 +1,6 @@
 from core.message_context import (
     build_context_session_key,
+    build_context_turn_sink_key,
     build_thread_session_anchor,
     build_thread_session_anchor_candidates,
     resolve_context_settings_key,
@@ -49,6 +50,63 @@ def test_telegram_thread_anchor_candidates_include_legacy_shape():
     assert build_thread_session_anchor_candidates("slack", "C123", "171717.999") == (
         "slack_171717.999",
     )
+
+
+def _telegram_topic(thread_id):
+    return MessageContext(
+        user_id="U1",
+        channel_id="-1004266799216",
+        platform="telegram",
+        thread_id=thread_id,
+        platform_specific={"platform": "telegram", "is_forum": True},
+    )
+
+
+def test_turn_sink_key_separates_forum_topics_that_share_a_session_key():
+    """Two topics of one group share a session key but must NOT share a sink slot.
+
+    The sink is a turn-concurrency slot: whoever holds it makes every other turn on
+    the same key settle ``refused_concurrent_turn`` before reaching a backend. The
+    channel-scoped session key made that refusal group-wide.
+    """
+    topic_843 = _telegram_topic("843")
+    topic_847 = _telegram_topic("847")
+
+    assert build_context_session_key(topic_843) == build_context_session_key(topic_847)
+    assert build_context_turn_sink_key(topic_843) != build_context_turn_sink_key(topic_847)
+    assert build_context_turn_sink_key(topic_847) == "telegram::-1004266799216::thread::847"
+
+
+def test_turn_sink_key_is_stable_across_a_threads_turns():
+    """The backend receiver resolves the sink from a stale per-turn context, so the
+    key must depend only on the routing scope — never on per-turn state."""
+    first = _telegram_topic("847")
+    first.platform_specific = {**(first.platform_specific or {}), "turn_token": "tok-1"}
+    second = _telegram_topic("847")
+    second.platform_specific = {**(second.platform_specific or {}), "turn_token": "tok-2"}
+
+    assert build_context_turn_sink_key(first) == build_context_turn_sink_key(second)
+
+
+def test_turn_sink_key_scopes_non_telegram_threads_too():
+    """``resolve_context_thread_id`` returns None off Telegram, so the fallback to
+    ``context.thread_id`` is what keeps Slack/Discord threads independent."""
+    thread_a = MessageContext(
+        user_id="U1", channel_id="C1", platform="slack", thread_id="171717.111"
+    )
+    thread_b = MessageContext(
+        user_id="U1", channel_id="C1", platform="slack", thread_id="171717.222"
+    )
+
+    assert build_context_turn_sink_key(thread_a) == "slack::C1::thread::171717.111"
+    assert build_context_turn_sink_key(thread_a) != build_context_turn_sink_key(thread_b)
+
+
+def test_turn_sink_key_falls_back_to_session_key_without_a_thread():
+    """A channel-level (unthreaded) context keeps today's key verbatim."""
+    context = MessageContext(user_id="U1", channel_id="C1", platform="slack")
+
+    assert build_context_turn_sink_key(context) == build_context_session_key(context)
 
 
 def test_thread_id_from_session_anchor_accepts_canonical_and_legacy_shapes():

--- a/tests/test_running_agents_service.py
+++ b/tests/test_running_agents_service.py
@@ -12,6 +12,7 @@ import types
 
 import pytest
 
+from core.message_context import build_context_turn_sink_key
 from core.services import running_agents
 
 
@@ -947,6 +948,9 @@ def test_end_active_agent_run_binds_stop_context_to_matching_turn_sink(monkeypat
         def _get_session_key(self, context):
             return f"{context.platform}::{context.channel_id}"
 
+        def _get_turn_sink_key(self, context):
+            return build_context_turn_sink_key(context, session_key=self._get_session_key(context))
+
         def bind_context_to_turn_sink(self, context, *, agent_session_id=None, backend_base_session_id=None):
             return self.session_turns.bind_context_to_turn_sink(
                 context,
@@ -975,8 +979,11 @@ def test_end_active_agent_run_binds_stop_context_to_matching_turn_sink(monkeypat
             },
         },
     )
+    # Register under the key real dispatch would use, derived from the same context. A
+    # hardcoded literal here would stop proving that the REBUILT stop context lands on
+    # the dispatcher's key, which is the whole point of this test.
     controller.session_turns.register_turn_sink(
-        "slack::private-agent-run-scope",
+        controller._get_turn_sink_key(dispatch_context),
         on_chunk=lambda _envelope: None,
         done_event=sink_done,
         turn_token="sink-token",
@@ -998,6 +1005,11 @@ def test_end_active_agent_run_binds_stop_context_to_matching_turn_sink(monkeypat
     assert sink_done.is_set()
     stopped_context = seen["context"]
     assert controller._get_session_key(stopped_context) == "slack::private-agent-run-scope"
+    # The rebuilt stop context must carry the row's thread too, or it lands on a
+    # different sink key than the dispatch that registered the sink.
+    assert controller._get_turn_sink_key(stopped_context) == controller._get_turn_sink_key(
+        dispatch_context
+    )
     assert stopped_context.platform_specific["turn_token"] == "sink-token"
     assert stopped_context.platform_specific["task_trigger_kind"] == "agent_run"
     assert stopped_context.platform_specific["task_execution_id"] == "run-primary"
@@ -1049,6 +1061,9 @@ def test_end_active_agent_run_does_not_settle_mismatched_turn_sink(monkeypatch):
         def _get_session_key(self, context):
             return f"{context.platform}::{context.channel_id}"
 
+        def _get_turn_sink_key(self, context):
+            return build_context_turn_sink_key(context, session_key=self._get_session_key(context))
+
         def bind_context_to_turn_sink(self, context, *, agent_session_id=None, backend_base_session_id=None):
             return self.session_turns.bind_context_to_turn_sink(
                 context,
@@ -1076,7 +1091,7 @@ def test_end_active_agent_run_does_not_settle_mismatched_turn_sink(monkeypatch):
         },
     )
     controller.session_turns.register_turn_sink(
-        "slack::private-agent-run-scope",
+        controller._get_turn_sink_key(newer_context),
         on_chunk=lambda _envelope: None,
         done_event=sink_done,
         turn_token="new-token",

--- a/tests/test_show_git_turn_entrypoints.py
+++ b/tests/test_show_git_turn_entrypoints.py
@@ -12,6 +12,7 @@ from config import paths
 from core import inbox_events, internal_server, show_git
 from core.git_binary import ResolvedGit
 from core.inbox_events import InboxEventBus
+from core.message_context import build_context_turn_sink_key
 from core.message_dispatcher import ConsolidatedMessageDispatcher
 from core.message_output import MessageOutput
 from core.scheduled_tasks import ScheduledTaskService, ScheduledTaskStore, TaskExecutionStore
@@ -139,6 +140,9 @@ class _Controller:
     @staticmethod
     def _get_session_key(context) -> str:
         return f"{context.platform}::{context.channel_id}"
+
+    def _get_turn_sink_key(self, context) -> str:
+        return build_context_turn_sink_key(context, session_key=self._get_session_key(context))
 
     def register_turn_sink(self, session_key: str, **kwargs) -> None:
         self.session_turns.register_turn_sink(session_key, **kwargs)


### PR DESCRIPTION
## Capability

**Turn concurrency isolation across threads of one channel** — Telegram forum topics, Slack/Discord threads.

A Telegram forum topic running a long agent turn silently blocked every other topic in the same group. Field trace from `~/.avibe/state/vibe.sqlite`:

| time (UTC+8) | topic | outcome |
|---|---|---|
| 12:31:56 → **12:47:36** | 843 (15m40s agent turn) | held the slot |
| 12:41:23 | **847** "create a directory…" | `refused_concurrent_turn` ×15, retried every 30s |
| 12:44:20 | 851 | `refused_concurrent_turn` ×13 |
| 12:46:32 | 854 | `refused_concurrent_turn` ×11 |
| 12:48:01 | 847 | accepted — 6m40s late, only because 843 had just released |
| 12:49:31 | 851 | accepted — only because 847 had just released |

Every refused row: `state=terminal`, `settled_by=refused_concurrent_turn`, `terminal_evidence_kind=definitive_prewrite_failure`, `runtime_key=''` — no backend was ever reached.

## Root cause

`dispatch_turn_with_outcome` guards turn concurrency on the presence of a registered turn sink, and the sink was keyed by `_get_session_key`. That key is **channel-scoped**: `resolve_context_settings_key` deliberately drops the thread (correct for settings, polls, and message consolidation). Every topic in a group therefore shared one concurrency slot.

`in_flight` and `runtime_key` were already per-session, so only the sink map was wrong. The sink's own `agent_session_id` identity fields and `_sink_identity_matches` show the key was always meant to be session-unique.

The refusal was **invisible**: IM turns dispatch with `_noop_chunk`, so the refusal's error chunk was discarded. Nothing reached the user — the topic just sat there.

## Change

- `build_context_turn_sink_key` — session key plus thread scope, resolved the same way every session-anchor caller resolves it (`resolve_context_thread_id(context) or context.thread_id`), so it depends only on routing fields pinned before dispatch. The dispatch context, the backend receiver's stale per-turn context, and an external stop's rebuilt context all land on the same key.
- `resolve_turn_sink_key` — funnels all 9 sink-key derivations through one rule. Prefers `Controller._get_turn_sink_key`, then `_get_session_key`, then the context alone; never degrades to the bare channel key, so no path can silently reintroduce the collision.
- `_get_session_key` is **unchanged** — settings, polls, and message consolidation keep their channel scope, per `OBS-TELEGRAM-TOPIC-002` ("preserve the existing group session key").
- Slack and Discord threads shared the same collision and are fixed by the same key.

Stale comments corrected along the way: `active_turn_sinks` was documented as "avibe/web-Chat only; IM/CLI turns register none", but `_run` always passes `_noop_chunk`, so **every** dispatched turn registers a sink. That staleness is what hid the bug.

## Scenario IDs

- `TELEGRAM-TOPIC-005` (new, covered) — a topic running a long turn does not block a sibling topic's turn
- `OBS-TELEGRAM-TOPIC-003` (new) — the group-level session key must not be reused for per-turn runtime slots

## Evidence layers

**Unit** (`tests/test_message_context_helpers.py`) — topic separation under a shared session key; key stability across a thread's turns; non-Telegram thread scoping; unthreaded fallback.

**Contract** (`tests/test_core_services_dispatch.py`) — a busy sibling thread no longer refuses this thread's turn (`TELEGRAM-TOPIC-005`); a same-thread turn is **still** refused, so the guard stays real.

**Scenario** — `tests/scenarios/telegram_topic_routing/{catalog,observations}.yaml` and `INDEX.yaml` updated.

**Test doubles** — updated to mirror the real controller's key derivation. Two were actively misleading:
- `test_internal_server`'s MagicMock controller auto-generated the new accessor and returned a key matching no registered sink, so the concurrent-turn refusal test **hung in `done.wait()`** instead of failing. Now stubbed explicitly, with a comment saying why.
- `test_running_agents_service` registered its sink under a hardcoded literal; it now derives the key from the same context, so it keeps proving that the *rebuilt* stop context resolves the dispatcher's sink.

**Residual manual checks** — none required for this change; no user-visible copy or UI surface is touched.

## Validation

| check | result |
|---|---|
| full suite, e2e excluded (7924 tests) | 7902 passed, 19 failed |
| those same 19 on unmodified `upstream/master` | identically fail — pre-existing (`test_ui_show_pages`, `test_ui_remote_access_auth`, `test_vault_rest`), unrelated to turn sinks; verified in a clean throwaway worktree |
| sink-touching files (14 files, 531 tests) | all pass |
| `ruff check core/ tests/` | clean |

e2e was excluded locally because `tests/e2e/test_api.py` needs port 15123, held by the running local `vibe`.

## Known gap, deliberately out of scope

A refusal is still invisible on IM: with this fix it can only happen within one thread, where the durable queue retries it (the trace above shows the message did eventually run, so nothing is lost), but the refusal's error chunk still goes to `_noop_chunk`. Surfacing it is a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)