### PR TITLE
fix(workbench): restore chat menu and pin interactions

### DIFF
--- a/ui/src/components/workbench/ChatPage.tsx
+++ b/ui/src/components/workbench/ChatPage.tsx
@@ -1,4 +1,4 @@
-import { Fragment, forwardRef, memo, useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState } from 'react';
+import { Fragment, memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link, useLocation, useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import { Activity, ArrowLeft, ArrowRight, ArrowUpRight, Bell, Bot, ChevronDown, ChevronRight, Clock, Eye, GitFork, Image as ImageIcon, Info, Loader2, MapPin, MessageSquare, MessageSquareQuote, Pencil, Terminal, Undo2, UploadCloud, X } from 'lucide-react';
@@ -60,8 +60,7 @@ import {
 } from './chatShortcuts';
 import { bindFrameChord } from '../apps/windowChords';
 import {
-  SessionActionMenuContent,
-  SessionActionsTrigger,
+  MobileChatSessionActionMenu,
   type SessionActionDescriptor,
 } from './sessionActions';
 import { useSessionActions } from './useSessionActions';
@@ -1899,13 +1898,12 @@ export const ChatPage: React.FC = () => {
     [api, session, t],
   );
 
-  // Session-level actions (pin / rename / fork / hide / archive) — the same model
-  // the sidebar rows and the mobile projects rows render, so the chat no longer
-  // sends the user back to the tree to act on the session they're reading. A
-  // read-only session yields no actions and an inert requestArchive: every one of
+  // Session-level actions share the sidebar/mobile row model. The chat header
+  // exposes them only on mobile and intentionally supplies no rename editor, so
+  // Rename is absent from this surface. A read-only session yields no actions and
+  // an inert requestArchive: every one of
   // them is refused server-side (409 archived / 403 reserved_session), so the
   // header withdraws the ⋯ rather than offering guaranteed failures.
-  const titleFieldRef = useRef<TitleFieldHandle | null>(null);
   const {
     actions: sessionActions,
     archiveDialog: sessionArchiveDialog,
@@ -1913,9 +1911,6 @@ export const ChatPage: React.FC = () => {
     canArchive,
   } = useSessionActions({
     session: readOnly ? null : session,
-    // Rename focuses the header's existing click-to-edit title instead of adding
-    // a second editor for the same field.
-    onRenameStart: () => titleFieldRef.current?.startEditing(),
     onOpenSession: (id) => navigate(`/chat/${encodeURIComponent(id)}`),
     onArchived: () => navigate('/inbox'),
     // The provider cache feeds the sidebar, not this page's own session copy. The
@@ -2147,7 +2142,6 @@ export const ChatPage: React.FC = () => {
           onAnnotateOpenChange={setAnnotateOpen}
           readOnlyReason={readOnlyReason}
           sessionActions={sessionActions}
-          titleFieldRef={titleFieldRef}
         />
 
       {showPageActive && showPageUrl && (
@@ -2694,12 +2688,6 @@ const Compose: React.FC<ComposeProps> = ({ composerRef, onSend, onStop, busy, se
   );
 };
 
-// Imperative handle on the header's click-to-edit title, so Rename can be one
-// menu row instead of a duplicate dialog.
-interface TitleFieldHandle {
-  startEditing: () => void;
-}
-
 interface ChatHeaderBarProps {
   session: WorkbenchSession;
   agents: VibeAgentBrief[];
@@ -2722,27 +2710,25 @@ interface ChatHeaderBarProps {
   // cluster is withdrawn entirely (see showPageControlActions). The REASON, not a
   // boolean, because it also picks the badge: a runtime-owned row is not "Archived".
   readOnlyReason: SessionReadOnlyReason | null;
-  // Shared session actions (pin / rename / fork / hide / archive), rendered behind
-  // the ⋯ at the far right. Empty (or absent) withdraws the trigger — which is what
-  // a read-only session yields, since every one of those writes is refused.
+  // Shared session actions, rendered behind the mobile-only ⋯ at the far right.
+  // Empty (or absent) withdraws the trigger — which is what a read-only session
+  // yields, since every one of those writes is refused.
   sessionActions?: SessionActionDescriptor[];
-  // Lets the menu's Rename row focus the title field that already lives here.
-  titleFieldRef?: React.Ref<TitleFieldHandle>;
 }
 
 // Exported for the read-only regression test (ChatArchivedReadOnly.test.tsx),
 // which renders the header alone rather than mounting the whole page. Note the
 // live (non-readOnly) header pulls in AgentRoutePicker → useApi, so only the
 // read-only rendering is reachable without an ApiProvider.
-export const ChatHeaderBar: React.FC<ChatHeaderBarProps> = ({ session, agents, defaultAgentName, onPatch, onBack, working, showPageMode, showPageBusy, onToggleShowPage, onPrepareShowPageLaunch, onShowPageVisibilityChange, onShareOpenChange, annotation, onAnnotateOpenChange, readOnlyReason, sessionActions, titleFieldRef }) => {
+export const ChatHeaderBar: React.FC<ChatHeaderBarProps> = ({ session, agents, defaultAgentName, onPatch, onBack, working, showPageMode, showPageBusy, onToggleShowPage, onPrepareShowPageLaunch, onShowPageVisibilityChange, onShareOpenChange, annotation, onAnnotateOpenChange, readOnlyReason, sessionActions }) => {
   const { t } = useTranslation();
   const readOnly = readOnlyReason !== null;
   const showPageActions = showPageControlActions(readOnly, showPageMode);
-  const [actionsOpen, setActionsOpen] = useState(false);
   // ``!readOnly`` twice over: useSessionActions already yields an empty list for a
   // read-only session, and the withdrawal is re-stated here so this header cannot
   // grow a ⋯ full of guaranteed-409 rows if a future caller passes actions anyway.
-  const hasSessionActions = !readOnly && (sessionActions?.length ?? 0) > 0;
+  const mobileSessionActions = sessionActions ?? [];
+  const hasMobileSessionActions = !readOnly && mobileSessionActions.length > 0;
   const defaultAgent = defaultAgentName ? agents.find((agent) => agent.name === defaultAgentName) : null;
   const sessionAgentLabel = sessionAgentDisplayName(session, agents);
   // Backend locks once a NATIVE conversation exists — a native can only be
@@ -2799,7 +2785,6 @@ export const ChatHeaderBar: React.FC<ChatHeaderBarProps> = ({ session, agents, d
         </Button>
         <TitleField
           key={session.id}
-          ref={titleFieldRef}
           title={session.title}
           onCommit={(title) => onPatch({ title })}
           readOnly={readOnly}
@@ -2860,7 +2845,7 @@ export const ChatHeaderBar: React.FC<ChatHeaderBarProps> = ({ session, agents, d
             the three can do anything but 409 or frame a dead page. There is no
             read-only page-serving path to offer instead; see
             showPageControlActions for the per-control reasoning. */}
-        {(showPageActions.visualize || hasSessionActions) && (
+        {(showPageActions.visualize || hasMobileSessionActions) && (
           <div className="ml-auto flex items-center gap-1.5">
             {showPageActions.annotate && (
               <ShowPageAnnotateControl
@@ -2888,25 +2873,14 @@ export const ChatHeaderBar: React.FC<ChatHeaderBarProps> = ({ session, agents, d
                 onOpenChange={onShareOpenChange}
               />
             )}
-            {/* Rightmost: the same session action menu the sidebar row uses, so
-                pin / rename / fork / hide / archive are reachable from the chat
-                without going back to the drawer. */}
-            {hasSessionActions && (
-              <Popover open={actionsOpen} onOpenChange={setActionsOpen}>
-                <PopoverTrigger asChild>
-                  <SessionActionsTrigger
-                    label={t('workbench.sessionActions')}
-                    open={actionsOpen}
-                    variant="bar"
-                  />
-                </PopoverTrigger>
-                <SessionActionMenuContent
-                  actions={sessionActions ?? []}
-                  label={t('workbench.sessionActions')}
-                  align="end"
-                  onClose={() => setActionsOpen(false)}
-                />
-              </Popover>
+            {/* The chat-level session menu is a compact-mobile affordance. Desktop
+                keeps these operations in the sidebar instead of duplicating a
+                second ⋯ in the page header. */}
+            {hasMobileSessionActions && (
+              <MobileChatSessionActionMenu
+                actions={mobileSessionActions}
+                label={t('workbench.sessionActions')}
+              />
             )}
           </div>
         )}
@@ -2922,7 +2896,7 @@ interface TitleFieldProps {
   readOnly?: boolean;
 }
 
-const TitleField = forwardRef<TitleFieldHandle, TitleFieldProps>(({ title, onCommit, readOnly }, ref) => {
+const TitleField: React.FC<TitleFieldProps> = ({ title, onCommit, readOnly }) => {
   const { t } = useTranslation();
   const [editing, setEditing] = useState(false);
   const [value, setValue] = useState(title ?? '');
@@ -2935,21 +2909,6 @@ const TitleField = forwardRef<TitleFieldHandle, TitleFieldProps>(({ title, onCom
   useEffect(() => {
     if (editing) inputRef.current?.focus();
   }, [editing]);
-
-  // The ⋯ menu's Rename row drives the header title the user already sees
-  // instead of opening a second dialog for the same field. Inert while
-  // read-only, where the title is static text with no input to focus.
-  useImperativeHandle(
-    ref,
-    () => ({
-      startEditing: () => {
-        if (readOnly) return;
-        setEditing(true);
-        inputRef.current?.focus();
-      },
-    }),
-    [readOnly],
-  );
 
   if (readOnly) {
     return (
@@ -2999,8 +2958,7 @@ const TitleField = forwardRef<TitleFieldHandle, TitleFieldProps>(({ title, onCom
       className="h-8 flex-1 px-2 text-[15px] font-bold"
     />
   );
-});
-TitleField.displayName = 'TitleField';
+};
 
 interface TranscriptProps {
   messages: WorkbenchMessage[];

--- a/ui/src/components/workbench/SessionPinAction.test.tsx
+++ b/ui/src/components/workbench/SessionPinAction.test.tsx
@@ -1,0 +1,87 @@
+import type { ReactElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it, vi } from 'vitest';
+
+import { SessionPinAction } from './SessionPinAction';
+import { sessionRowActionPaddingClass } from './sessionRowLayout';
+
+const renderAction = (pinned: boolean, pending = false) =>
+  renderToStaticMarkup(
+    <SessionPinAction
+      pinned={pinned}
+      pending={pending}
+      pinLabel="Pin to top"
+      unpinLabel="Unpin"
+      onToggle={() => undefined}
+    />,
+  );
+
+describe('SessionPinAction', () => {
+  it('stops the row click and invokes the shared pin action', () => {
+    const onToggle = vi.fn();
+    const event = { stopPropagation: vi.fn() };
+    const wrapper = SessionPinAction({
+      pinned: false,
+      pending: false,
+      pinLabel: 'Pin to top',
+      unpinLabel: 'Unpin',
+      onToggle,
+    }) as ReactElement<{ children: ReactElement<{ onClick: (event: typeof event) => void }> }>;
+    const button = wrapper.props.children;
+
+    button.props.onClick(event);
+
+    expect(event.stopPropagation).toHaveBeenCalledTimes(1);
+    expect(onToggle).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps the pin control beside the session action menu', () => {
+    const html = renderAction(false);
+
+    expect(html).toContain('absolute inset-y-0 right-9 flex items-center');
+    expect(html).toContain('grid size-6');
+  });
+
+  it('reveals an unpinned action on row hover, keyboard focus, and coarse pointers', () => {
+    const html = renderAction(false);
+
+    expect(html).toContain('aria-pressed="false"');
+    expect(html).toContain('opacity-0');
+    expect(html).toContain('group-hover/sess:opacity-100');
+    expect(html).toContain('group-focus-within/sess:opacity-100');
+    expect(html).toContain('pointer-coarse:opacity-100');
+  });
+
+  it('keeps a pinned action visible with unpin semantics', () => {
+    const html = renderAction(true);
+
+    expect(html).toContain('aria-pressed="true"');
+    expect(html).toContain('aria-label="Unpin"');
+    expect(html).toContain('opacity-100');
+    expect(html).toContain('hover:bg-cyan/[0.18]');
+  });
+
+  it('shows a disabled progress state while persistence is pending', () => {
+    const html = renderAction(false, true);
+
+    expect(html).toContain('disabled=""');
+    expect(html).toContain('animate-spin');
+    expect(html).toContain('cursor-wait');
+  });
+});
+
+describe('sessionRowActionPaddingClass', () => {
+  it('gives the title full width until the two-button rail is revealed', () => {
+    const className = sessionRowActionPaddingClass(false, false);
+
+    expect(className).toContain('pr-2.5');
+    expect(className).toContain('hover:pr-16');
+    expect(className).toContain('focus-within:pr-16');
+    expect(className).toContain('pointer-coarse:pr-16');
+  });
+
+  it('reserves the rail while the menu is open or the pin stays visible', () => {
+    expect(sessionRowActionPaddingClass(true, false)).toBe('pr-16');
+    expect(sessionRowActionPaddingClass(false, true)).toBe('pr-16');
+  });
+});

--- a/ui/src/components/workbench/SessionPinAction.tsx
+++ b/ui/src/components/workbench/SessionPinAction.tsx
@@ -1,0 +1,60 @@
+import clsx from 'clsx';
+import { Loader2, Pin } from 'lucide-react';
+import type { MouseEventHandler } from 'react';
+
+interface SessionPinActionProps {
+  pinned: boolean;
+  pending: boolean;
+  pinLabel: string;
+  unpinLabel: string;
+  onToggle: () => void;
+  className?: string;
+}
+
+// Direct pin control for desktop sidebar rows. The shared session action model
+// still owns persistence; this component only restores the compact row affordance.
+export const SessionPinAction: React.FC<SessionPinActionProps> = ({
+  pinned,
+  pending,
+  pinLabel,
+  unpinLabel,
+  onToggle,
+  className,
+}) => {
+  const label = pinned ? unpinLabel : pinLabel;
+  const handleClick: MouseEventHandler<HTMLButtonElement> = (event) => {
+    event.stopPropagation();
+    onToggle();
+  };
+
+  return (
+    <span className={clsx('absolute inset-y-0 right-9 flex items-center', className)}>
+      <button
+        type="button"
+        disabled={pending}
+        aria-label={label}
+        aria-pressed={pinned}
+        title={label}
+        onClick={handleClick}
+        className={clsx(
+          'group/pin grid size-6 shrink-0 place-items-center rounded-md transition-[opacity,transform,background-color,color,box-shadow] duration-150 ease-out',
+          'hover:-translate-y-px hover:scale-105 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-cyan/60 motion-reduce:transform-none',
+          pending
+            ? 'cursor-wait text-muted opacity-100 hover:translate-y-0 hover:scale-100'
+            : pinned
+              ? 'text-cyan opacity-100 hover:bg-cyan/[0.18] hover:ring-1 hover:ring-cyan/30'
+              : 'text-muted opacity-0 hover:bg-foreground/[0.08] hover:text-foreground group-hover/sess:opacity-100 group-focus-within/sess:opacity-100 pointer-coarse:opacity-100',
+        )}
+      >
+        {pending ? (
+          <Loader2 className="size-3 animate-spin" aria-hidden="true" />
+        ) : (
+          <Pin
+            className="size-3 transition-transform duration-150 group-hover/pin:-rotate-12 group-hover/pin:scale-110 motion-reduce:transform-none"
+            aria-hidden="true"
+          />
+        )}
+      </button>
+    </span>
+  );
+};

--- a/ui/src/components/workbench/SessionPinIndicator.test.tsx
+++ b/ui/src/components/workbench/SessionPinIndicator.test.tsx
@@ -2,7 +2,6 @@ import { renderToStaticMarkup } from 'react-dom/server';
 import { describe, expect, it } from 'vitest';
 
 import { SessionPinIndicator } from './SessionPinIndicator';
-import { sessionRowActionPaddingClass } from './sessionRowLayout';
 
 describe('SessionPinIndicator', () => {
   it('renders no passive status for an unpinned session', () => {
@@ -15,22 +14,6 @@ describe('SessionPinIndicator', () => {
     expect(html).toContain('role="img"');
     expect(html).toContain('aria-label="Pinned"');
     expect(html).toContain('text-cyan');
-    // Pin / unpin lives in the row's ⋯ menu now; this glyph must not look clickable.
     expect(html).not.toContain('<button');
-  });
-});
-
-describe('sessionRowActionPaddingClass', () => {
-  it('gives the title the full width until the ⋯ trigger is revealed', () => {
-    const className = sessionRowActionPaddingClass(false);
-
-    expect(className).toContain('pr-2.5');
-    expect(className).toContain('hover:pr-10');
-    expect(className).toContain('focus-within:pr-10');
-    expect(className).toContain('pointer-coarse:pr-10');
-  });
-
-  it('holds the rail open while the menu is open, so the row cannot shift under it', () => {
-    expect(sessionRowActionPaddingClass(true)).toBe('pr-10');
   });
 });

--- a/ui/src/components/workbench/SessionPinIndicator.tsx
+++ b/ui/src/components/workbench/SessionPinIndicator.tsx
@@ -7,9 +7,8 @@ interface SessionPinIndicatorProps {
   className?: string;
 }
 
-// Passive "this row is pinned" status. Not a button: pinning moved into the row's
-// ⋯ action menu (see sessionActions.tsx), so this glyph only has to keep the state
-// visible at a glance — including when the row is not hovered.
+// Passive pinned-state marker for mobile project rows, where the row action menu
+// remains the mutation surface.
 export const SessionPinIndicator: React.FC<SessionPinIndicatorProps> = ({ pinned, label, className }) => {
   if (!pinned) return null;
 

--- a/ui/src/components/workbench/WorkbenchSidebar.tsx
+++ b/ui/src/components/workbench/WorkbenchSidebar.tsx
@@ -31,7 +31,7 @@ import { useWorkbenchProjectsTree } from '../../context/WorkbenchProjectsContext
 import { useWindowManager } from '../../context/WindowManagerContext';
 import { useUnsavedChangesActionGuard } from '../../context/useUnsavedChangesActionGuard';
 import type { InboxSession, WorkbenchProject, WorkbenchSession } from '../../context/ApiContext';
-import { SessionPinIndicator } from './SessionPinIndicator';
+import { SessionPinAction } from './SessionPinAction';
 import { sessionRowActionPaddingClass } from './sessionRowLayout';
 import { SessionActionMenuContent, SessionActionsTrigger } from './sessionActions';
 import { useSessionActions } from './useSessionActions';
@@ -238,6 +238,7 @@ const SessionRow: React.FC<{
       if (active) navigate('/inbox');
     },
   });
+  const pinAction = actions.find((action) => action.id === 'pin');
 
   useEffect(() => {
     if (renaming) inputRef.current?.focus();
@@ -299,7 +300,7 @@ const SessionRow: React.FC<{
           }}
           className={clsx(
             'group/sess relative flex items-center gap-2 rounded-md py-1.5 pl-[26px] text-left transition-[background-color,padding-right] duration-150 ease-out motion-reduce:transition-none',
-            sessionRowActionPaddingClass(menuOpen),
+            sessionRowActionPaddingClass(menuOpen, session.pinned),
             active
               ? 'border-l-2 border-mint bg-mint-soft pl-[24px] font-semibold text-foreground'
               : 'hover:bg-foreground/[0.04]',
@@ -325,16 +326,21 @@ const SessionRow: React.FC<{
             >
               {displayName}
             </span>
-            {/* Pinned state is a passive glyph now that pin/unpin lives in the ⋯
-                menu — inline with the title so it stays visible unhovered and
-                nothing shifts when the trigger appears. */}
-            <SessionPinIndicator pinned={session.pinned} label={t('workbench.sessionPinned')} />
             {unread > 0 && (
               <span className="inline-flex min-w-[1.1rem] items-center justify-center rounded-full bg-mint px-1.5 font-mono text-[9px] font-bold text-[#080812]">
                 {unread > 99 ? '99+' : unread}
               </span>
             )}
           </button>
+          {pinAction && (
+            <SessionPinAction
+              pinned={session.pinned}
+              pending={Boolean(pinAction.pending)}
+              pinLabel={t('workbench.sessionPin')}
+              unpinLabel={t('workbench.sessionUnpin')}
+              onToggle={pinAction.onSelect}
+            />
+          )}
           <span className="absolute inset-y-0 right-2 flex items-center">
             <PopoverTrigger asChild>
               <SessionActionsTrigger label={t('workbench.sessionActions')} open={menuOpen} />

--- a/ui/src/components/workbench/chatSessionActions.ts
+++ b/ui/src/components/workbench/chatSessionActions.ts
@@ -1,0 +1,4 @@
+import type { SessionActionDescriptor } from './sessionActions';
+
+export const mobileChatSessionActions = (actions: SessionActionDescriptor[]): SessionActionDescriptor[] =>
+  actions.filter((action) => action.id !== 'rename');

--- a/ui/src/components/workbench/sessionActions.test.tsx
+++ b/ui/src/components/workbench/sessionActions.test.tsx
@@ -3,7 +3,13 @@ import { Archive, EyeOff, GitFork, Pencil, Pin } from 'lucide-react';
 import { describe, expect, it } from 'vitest';
 
 import { Popover, PopoverTrigger } from '../ui/popover';
-import { SessionActionMenu, SessionActionsTrigger, type SessionActionDescriptor } from './sessionActions';
+import {
+  MobileChatSessionActionMenu,
+  SessionActionMenu,
+  SessionActionsTrigger,
+  type SessionActionDescriptor,
+} from './sessionActions';
+import { mobileChatSessionActions } from './chatSessionActions';
 
 const row = (over: Partial<SessionActionDescriptor> & Pick<SessionActionDescriptor, 'id' | 'group' | 'label'>) =>
   ({ icon: Pin, onSelect: () => undefined, ...over }) as SessionActionDescriptor;
@@ -141,5 +147,31 @@ describe('SessionActionsTrigger', () => {
 
     expect(html).not.toContain('opacity-0');
     expect(html).toContain('size-7');
+  });
+});
+
+describe('MobileChatSessionActionMenu', () => {
+  it('removes rename from the Chat surface while preserving the remaining descriptors', () => {
+    const actions = fullMenu();
+
+    expect(mobileChatSessionActions(actions).map((action) => action.id)).toEqual([
+      'pin',
+      'fork',
+      'hide',
+      'archive',
+    ]);
+  });
+
+  it('renders the chat trigger only below the desktop breakpoint', () => {
+    const html = renderToStaticMarkup(
+      <MobileChatSessionActionMenu actions={fullMenu()} label="Session actions" />,
+    );
+
+    expect(html).toContain('md:hidden');
+    expect(html).toContain('aria-label="Session actions"');
+  });
+
+  it('withdraws the trigger when the surface offers no actions', () => {
+    expect(renderToStaticMarkup(<MobileChatSessionActionMenu actions={[]} label="Session actions" />)).toBe('');
   });
 });

--- a/ui/src/components/workbench/sessionActions.tsx
+++ b/ui/src/components/workbench/sessionActions.tsx
@@ -1,16 +1,17 @@
 import * as React from 'react';
-import { useRef } from 'react';
+import { useRef, useState } from 'react';
 import { Ellipsis, Loader2 } from 'lucide-react';
 import clsx from 'clsx';
 import type { LucideIcon } from 'lucide-react';
 
 import { Button } from '../ui/button';
-import { PopoverContent } from '../ui/popover';
+import { Popover, PopoverContent, PopoverTrigger } from '../ui/popover';
+import { mobileChatSessionActions } from './chatSessionActions';
 
 // Presentation half of the shared session action menu: the ⋯ trigger and the menu
 // body, used by the desktop sidebar row, the mobile projects row and the chat
 // header. The actions themselves (labels, writes, pending state) come from
-// useSessionActions.tsx — one model, so the surfaces cannot drift again.
+// useSessionActions.tsx; surfaces opt into only the capabilities they can render.
 
 export type SessionActionId = 'pin' | 'reference' | 'fork' | 'rename' | 'hide' | 'archive';
 
@@ -35,9 +36,9 @@ export interface SessionActionDescriptor {
 }
 
 // The ⋯ trigger. Rows reveal it on hover / keyboard focus and keep it visible on
-// coarse pointers (touch has no hover) and while its menu is open; the chat
-// header always shows it. forwardRef + prop spread so <PopoverTrigger asChild>
-// can attach its own ref and handlers.
+// coarse pointers (touch has no hover) and while its menu is open; a bar trigger
+// stays visible whenever its responsive wrapper is mounted. forwardRef + prop
+// spread lets <PopoverTrigger asChild> attach its own ref and handlers.
 //
 // It deliberately writes NO aria-haspopup / aria-expanded of its own: <PopoverTrigger
 // asChild> injects both (as `dialog`, which is what a Popover actually opens), and
@@ -216,5 +217,34 @@ export const SessionActionMenuContent: React.FC<{
         }}
       />
     </PopoverContent>
+  );
+};
+
+// Chat keeps this compact action entry point on mobile only. Owning the responsive
+// wrapper here makes the breakpoint part of the tested component contract instead
+// of an incidental class buried in the large ChatPage render tree. Rename is also
+// removed at this presentation boundary so future callers cannot reintroduce it.
+export const MobileChatSessionActionMenu: React.FC<{
+  actions: SessionActionDescriptor[];
+  label: string;
+}> = ({ actions, label }) => {
+  const [open, setOpen] = useState(false);
+  const visibleActions = mobileChatSessionActions(actions);
+  if (visibleActions.length === 0) return null;
+
+  return (
+    <div className="md:hidden">
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          <SessionActionsTrigger label={label} open={open} variant="bar" />
+        </PopoverTrigger>
+        <SessionActionMenuContent
+          actions={visibleActions}
+          label={label}
+          align="end"
+          onClose={() => setOpen(false)}
+        />
+      </Popover>
+    </div>
   );
 };

--- a/ui/src/components/workbench/sessionRowLayout.ts
+++ b/ui/src/components/workbench/sessionRowLayout.ts
@@ -1,7 +1,5 @@
-// Right-hand rail for a session row's ⋯ action trigger. The trigger is absolutely
-// positioned, so the row reserves the space only while it is revealed — on hover,
-// on keyboard focus, and always on coarse pointers (touch has no hover) or while
-// its menu is open. A pinned row no longer forces the rail open: its pin glyph is
-// inline with the title, so nothing shifts when the trigger appears.
-export const sessionRowActionPaddingClass = (menuOpen: boolean) =>
-  menuOpen ? 'pr-10' : 'pr-2.5 hover:pr-10 focus-within:pr-10 pointer-coarse:pr-10';
+// Right-hand rail for the direct pin control and the session action menu. Pinned
+// rows reserve it at rest; unpinned rows expand it only while either control is
+// revealed through hover/focus or while the menu is open.
+export const sessionRowActionPaddingClass = (menuOpen: boolean, pinned: boolean) =>
+  menuOpen || pinned ? 'pr-16' : 'pr-2.5 hover:pr-16 focus-within:pr-16 pointer-coarse:pr-16';

--- a/ui/src/components/workbench/useSessionActions.test.tsx
+++ b/ui/src/components/workbench/useSessionActions.test.tsx
@@ -108,6 +108,15 @@ beforeEach(() => {
   mocks.authorizeRouteAction.mockImplementation(grantedAuthorization);
 });
 
+describe('surface-specific actions', () => {
+  it('omits rename when the surface provides no rename editor', () => {
+    const h = mount(options({ onRenameStart: undefined }));
+
+    expect(h.actions.map((action) => action.id)).not.toContain('rename');
+    expect(h.actions.map((action) => action.id)).toContain('pin');
+  });
+});
+
 // ── Codex review (useSessionActions.tsx:81) ──────────────────────────────────
 // `project_id` is the `proj_*` suffix of the scope id, so it is NULL for every
 // session outside a project. The hook used to bail out of pin / fork when it was
@@ -126,6 +135,14 @@ describe('a session with no project (project_id: null)', () => {
       // surface may have navigated to another session by then.
       expect(onSessionPatched).toHaveBeenCalledWith({ pinned: true }, 'ses_standalone');
     });
+  });
+
+  it('unpins a currently pinned session', () => {
+    const h = mount(options({ session: session({ pinned: true }) }));
+
+    select(h, 'pin');
+
+    expect(mocks.setSessionPinned).toHaveBeenCalledWith(null, 'ses_standalone', false);
   });
 
   it('forks and opens the fork', async () => {

--- a/ui/src/components/workbench/useSessionActions.tsx
+++ b/ui/src/components/workbench/useSessionActions.tsx
@@ -16,12 +16,12 @@ import type { SessionActionDescriptor } from './sessionActions';
 
 // ── One session action model, four render sites ───────────────────────────────
 // The desktop sidebar row, its right-click menu, the mobile projects row and the
-// chat header all offer the SAME six actions. They used to be written out three
-// times (and had already drifted: fork was disabled-with-tooltip on desktop but
-// hidden on mobile, and "reference" existed only on desktop). This hook owns the
-// list, the writes and the pending state; each surface owns only where the
-// trigger sits and what "rename" / "open" / "archived" mean locally. The rows
-// themselves render through SessionActionMenu (sessionActions.tsx).
+// chat header share one action model. They used to be written out three times
+// (and had already drifted: fork was disabled-with-tooltip on desktop but hidden
+// on mobile, and "reference" existed only on desktop). This hook owns the list,
+// the writes and the pending state; each surface owns only where the trigger sits
+// and which local capabilities it supplies. The rows themselves render through
+// SessionActionMenu (sessionActions.tsx).
 
 export interface SessionActionsOptions {
   /** ``null`` (no session yet, or a read-only one) yields no actions and an inert
@@ -31,8 +31,9 @@ export interface SessionActionsOptions {
    *  Defaults to ``session.project_id``, which is ``null`` for a standalone session
    *  (no project-bound scope); the writes run either way. */
   projectId?: string | null;
-  /** Start the surface's own rename editor (inline input / chat header title). */
-  onRenameStart: () => void;
+  /** Start the surface's own rename editor. Omit when that surface intentionally
+   *  does not expose Rename, such as the compact Chat header menu. */
+  onRenameStart?: () => void;
   /** Navigate to a session (the fork target). Always called inside the
    *  unsaved-changes authorization's runner (see below). */
   onOpenSession: (sessionId: string) => void;
@@ -180,14 +181,16 @@ export const useSessionActions = ({
         disabled: pinning,
         onSelect: () => void togglePinned(),
       },
-      {
+    ];
+    if (onRenameStart) {
+      rows.push({
         id: 'rename',
         group: 'organize',
         icon: Pencil,
         label: t('workbench.sessionRename'),
         onSelect: onRenameStart,
-      },
-    ];
+      });
+    }
     if (canReference) {
       rows.push({
         id: 'reference',


### PR DESCRIPTION
## Capability

- hide the Chat session overflow menu at the desktop breakpoint while retaining it on mobile
- remove Rename from the Chat overflow action set on every breakpoint
- restore the desktop sidebar's direct pin/unpin button while keeping the shared session action menu

## Affected scenarios

- No cataloged scenario IDs apply to these responsive Workbench controls.

## Evidence layers

- Unit: added responsive-menu, action-policy, direct-click, pin, and unpin coverage; the complete UI suite passes (115 files, 1495 tests).
- Contract: the mobile Chat menu owns the `md:hidden` boundary and filters Rename at its presentation boundary; Chat also omits the rename capability at action construction.
- Scenario: production UI build and import validation pass.
- Residual manual checks: browser screenshot/interaction verification is deferred because no browser connection was available in the implementation session.

## Dependencies

- None.

## Known-by-design

- Chat titles remain directly editable; only the Chat overflow menu omits Rename.
- The desktop sidebar overflow menu remains available, including Rename; the restored pin button is an additional direct action.
- Mobile Projects rows keep their existing passive pin indicator and menu behavior.
