### PR TITLE
fix(remote-access): simplify quality summary

### DIFF
--- a/ui/src/components/RemoteAccess.tsx
+++ b/ui/src/components/RemoteAccess.tsx
@@ -466,38 +466,15 @@ export const RemoteAccess: React.FC = () => {
           <div className="mt-1 flex min-h-5 items-center gap-2">
             <Badge variant={qualityVariant}>{qualityLabel}</Badge>
             {qualityFresh && (requestLatency || quality?.rtt_ms) && (
-              <span className="font-mono text-[11px] text-foreground">
-                {requestLatency
-                  ? `P95 ${formatLatency(requestLatency.p95)}`
-                  : formatLatency(quality!.rtt_ms!.median)}
+              <span className="text-[11px] font-medium tabular-nums text-foreground">
+                {t('remoteAccess.qualityLatency', {
+                  latency: requestLatency
+                    ? formatLatency(requestLatency.p95)
+                    : formatLatency(quality!.rtt_ms!.median),
+                })}
               </span>
             )}
           </div>
-          {qualityFresh && quality ? (
-            <div className="mt-1 space-y-0.5 text-[10px] leading-4 text-muted">
-              <div className="break-words" title={quality.edge_locations?.join(', ')}>
-                {connectorPathLabel}
-              </div>
-              {requestPathUnavailable ? (
-                <div className="truncate font-medium text-destructive">
-                  {t('remoteAccess.requestPathUnavailable', {
-                    success: requestPath?.success_count || 0,
-                    count: requestPath?.sample_count || 0,
-                  })}
-                </div>
-              ) : requestLatency ? (
-                <div className="truncate font-mono text-foreground/80">
-                  {t('remoteAccess.requestPath', {
-                    p95: formatLatency(requestLatency.p95),
-                    p99: formatLatency(requestLatency.p99),
-                    slow: Math.round((requestPath?.slow_request_rate.over_1000_ms || 0) * 100),
-                  })}
-                </div>
-              ) : requestPath ? (
-                <div>{t('remoteAccess.requestPathMeasuring', { count: requestPath.sample_count })}</div>
-              ) : null}
-            </div>
-          ) : null}
         </div>
       </div>
 
@@ -563,6 +540,34 @@ export const RemoteAccess: React.FC = () => {
                   )) : <div>{t('remoteAccess.networkIpUnavailable')}</div>}
                 </div>
               </div>
+              {qualityFresh && quality && (
+                <div className="min-w-0 border-t border-border/60 pt-3 sm:col-span-2">
+                  <div className="font-medium text-muted">{t('remoteAccess.quality')}</div>
+                  <div className="mt-1 space-y-1 text-foreground/85">
+                    <div className="break-words" title={quality.edge_locations?.join(', ')}>
+                      {connectorPathLabel}
+                    </div>
+                    {requestPathUnavailable ? (
+                      <div className="break-words font-medium text-destructive">
+                        {t('remoteAccess.requestPathUnavailable', {
+                          success: requestPath?.success_count || 0,
+                          count: requestPath?.sample_count || 0,
+                        })}
+                      </div>
+                    ) : requestLatency ? (
+                      <div className="break-words font-mono text-foreground/80">
+                        {t('remoteAccess.requestPath', {
+                          p95: formatLatency(requestLatency.p95),
+                          p99: formatLatency(requestLatency.p99),
+                          slow: Math.round((requestPath?.slow_request_rate.over_1000_ms || 0) * 100),
+                        })}
+                      </div>
+                    ) : requestPath ? (
+                      <div>{t('remoteAccess.requestPathMeasuring', { count: requestPath.sample_count })}</div>
+                    ) : null}
+                  </div>
+                </div>
+              )}
             </div>
           </details>
         </div>

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -1132,6 +1132,7 @@
     "qualityUnknown": "Measuring",
     "qualityRecovering": "Optimizing",
     "qualityDegraded": "Degraded",
+    "qualityLatency": "Latency {{latency}}",
     "protocolAutomatic": "{{protocol}} (Auto)",
     "protocolUnknown": "Detecting",
     "connectorConnectionsHealthy": "Cloudflare connections healthy",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -1132,6 +1132,7 @@
     "qualityUnknown": "测量中",
     "qualityRecovering": "正在优化",
     "qualityDegraded": "异常",
+    "qualityLatency": "延迟 {{latency}}",
     "protocolAutomatic": "{{protocol}}（自动）",
     "protocolUnknown": "检测中",
     "connectorConnectionsHealthy": "Cloudflare 连接正常",


### PR DESCRIPTION
## Summary

- Replace the raw `P95` label in the connection-quality summary with the user-facing `Latency` / `延迟` label while retaining the same evidence-gated value.
- Move connector-path and detailed request-path metrics into the existing Technical details disclosure so the default status view stays concise.

Affected scenario: `RA-TQ-031`.

## Evidence

- Unit: `npm test` (1,498 tests passed).
- Contract: English and Chinese copy updated together; no API or runtime payload changes.
- Scenario: `npm run build` and `npm run lint` pass; the development route is served against the Incus regression backend.
- Residual manual: verify the disclosure layout at desktop and mobile widths; browser automation was unavailable in this session.

## Risk

Low. This is presentation-only and preserves the underlying quality and request-path measurements.
