### PR TITLE
fix(workbench): compact sidebar session actions

### DIFF
--- a/ui/src/components/workbench/ProjectsPage.tsx
+++ b/ui/src/components/workbench/ProjectsPage.tsx
@@ -31,6 +31,7 @@ import { Popover, PopoverContent, PopoverTrigger } from '../ui/popover';
 import { NewProjectDialog } from './NewProjectDialog';
 import { ProjectAgentsMdDialog } from './ProjectAgentsMdDialog';
 import { ProjectSettingsDialog } from './ProjectSettingsDialog';
+import { mobileSessionActions } from './chatSessionActions';
 import { SessionActionMenuContent, SessionActionsTrigger } from './sessionActions';
 import { useSessionActions } from './useSessionActions';
 import { SessionPinIndicator } from './SessionPinIndicator';
@@ -341,7 +342,7 @@ const MobileSessionRow: React.FC<{
           />
         </PopoverTrigger>
         <SessionActionMenuContent
-          actions={actions}
+          actions={mobileSessionActions(actions)}
           label={t('workbench.sessionActions')}
           align="end"
           onClose={() => setMenuOpen(false)}

--- a/ui/src/components/workbench/SessionPinAction.test.tsx
+++ b/ui/src/components/workbench/SessionPinAction.test.tsx
@@ -3,7 +3,12 @@ import { renderToStaticMarkup } from 'react-dom/server';
 import { describe, expect, it, vi } from 'vitest';
 
 import { SessionPinAction } from './SessionPinAction';
-import { sessionRowActionPaddingClass } from './sessionRowLayout';
+import {
+  SESSION_ROW_ACTION_BUTTON_CLASS,
+  SESSION_ROW_MENU_POSITION_CLASS,
+  SESSION_ROW_PIN_POSITION_CLASS,
+  sessionRowActionPaddingClass,
+} from './sessionRowLayout';
 
 const renderAction = (pinned: boolean, pending = false) =>
   renderToStaticMarkup(
@@ -35,11 +40,15 @@ describe('SessionPinAction', () => {
     expect(onToggle).toHaveBeenCalledTimes(1);
   });
 
-  it('keeps the pin control beside the session action menu', () => {
+  it('uses the compact rounded rail geometry shared with the session action menu', () => {
     const html = renderAction(false);
 
-    expect(html).toContain('absolute inset-y-0 right-9 flex items-center');
-    expect(html).toContain('grid size-6');
+    expect(html).toContain('absolute inset-y-0 flex items-center right-6');
+    expect(html).toContain('grid shrink-0 place-items-center');
+    expect(html).toContain('size-5 rounded-md');
+    expect(SESSION_ROW_ACTION_BUTTON_CLASS).toBe('size-5 rounded-md');
+    expect(SESSION_ROW_PIN_POSITION_CLASS).toBe('right-6');
+    expect(SESSION_ROW_MENU_POSITION_CLASS).toBe('right-0.5');
   });
 
   it('reveals an unpinned action on row hover, keyboard focus, and coarse pointers', () => {
@@ -75,13 +84,13 @@ describe('sessionRowActionPaddingClass', () => {
     const className = sessionRowActionPaddingClass(false, false);
 
     expect(className).toContain('pr-2.5');
-    expect(className).toContain('hover:pr-16');
-    expect(className).toContain('focus-within:pr-16');
-    expect(className).toContain('pointer-coarse:pr-16');
+    expect(className).toContain('hover:pr-12');
+    expect(className).toContain('focus-within:pr-12');
+    expect(className).toContain('pointer-coarse:pr-12');
   });
 
   it('reserves the rail while the menu is open or the pin stays visible', () => {
-    expect(sessionRowActionPaddingClass(true, false)).toBe('pr-16');
-    expect(sessionRowActionPaddingClass(false, true)).toBe('pr-16');
+    expect(sessionRowActionPaddingClass(true, false)).toBe('pr-12');
+    expect(sessionRowActionPaddingClass(false, true)).toBe('pr-12');
   });
 });

--- a/ui/src/components/workbench/SessionPinAction.test.tsx
+++ b/ui/src/components/workbench/SessionPinAction.test.tsx
@@ -43,12 +43,12 @@ describe('SessionPinAction', () => {
   it('uses the compact rounded rail geometry shared with the session action menu', () => {
     const html = renderAction(false);
 
-    expect(html).toContain('absolute inset-y-0 flex items-center right-6');
+    expect(html).toContain('absolute inset-y-0 flex items-center right-5');
     expect(html).toContain('grid shrink-0 place-items-center');
     expect(html).toContain('size-5 rounded-md');
     expect(SESSION_ROW_ACTION_BUTTON_CLASS).toBe('size-5 rounded-md');
-    expect(SESSION_ROW_PIN_POSITION_CLASS).toBe('right-6');
-    expect(SESSION_ROW_MENU_POSITION_CLASS).toBe('right-0.5');
+    expect(SESSION_ROW_PIN_POSITION_CLASS).toBe('right-5');
+    expect(SESSION_ROW_MENU_POSITION_CLASS).toBe('right-0');
   });
 
   it('reveals an unpinned action on row hover, keyboard focus, and coarse pointers', () => {
@@ -84,13 +84,13 @@ describe('sessionRowActionPaddingClass', () => {
     const className = sessionRowActionPaddingClass(false, false);
 
     expect(className).toContain('pr-2.5');
-    expect(className).toContain('hover:pr-12');
-    expect(className).toContain('focus-within:pr-12');
-    expect(className).toContain('pointer-coarse:pr-12');
+    expect(className).toContain('hover:pr-11');
+    expect(className).toContain('focus-within:pr-11');
+    expect(className).toContain('pointer-coarse:pr-11');
   });
 
   it('reserves the rail while the menu is open or the pin stays visible', () => {
-    expect(sessionRowActionPaddingClass(true, false)).toBe('pr-12');
-    expect(sessionRowActionPaddingClass(false, true)).toBe('pr-12');
+    expect(sessionRowActionPaddingClass(true, false)).toBe('pr-11');
+    expect(sessionRowActionPaddingClass(false, true)).toBe('pr-11');
   });
 });

--- a/ui/src/components/workbench/SessionPinAction.tsx
+++ b/ui/src/components/workbench/SessionPinAction.tsx
@@ -2,6 +2,8 @@ import clsx from 'clsx';
 import { Loader2, Pin } from 'lucide-react';
 import type { MouseEventHandler } from 'react';
 
+import { SESSION_ROW_ACTION_BUTTON_CLASS, SESSION_ROW_PIN_POSITION_CLASS } from './sessionRowLayout';
+
 interface SessionPinActionProps {
   pinned: boolean;
   pending: boolean;
@@ -28,7 +30,7 @@ export const SessionPinAction: React.FC<SessionPinActionProps> = ({
   };
 
   return (
-    <span className={clsx('absolute inset-y-0 right-9 flex items-center', className)}>
+    <span className={clsx('absolute inset-y-0 flex items-center', SESSION_ROW_PIN_POSITION_CLASS, className)}>
       <button
         type="button"
         disabled={pending}
@@ -37,7 +39,8 @@ export const SessionPinAction: React.FC<SessionPinActionProps> = ({
         title={label}
         onClick={handleClick}
         className={clsx(
-          'group/pin grid size-6 shrink-0 place-items-center rounded-md transition-[opacity,transform,background-color,color,box-shadow] duration-150 ease-out',
+          'group/pin grid shrink-0 place-items-center transition-[opacity,transform,background-color,color,box-shadow] duration-150 ease-out',
+          SESSION_ROW_ACTION_BUTTON_CLASS,
           'hover:-translate-y-px hover:scale-105 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-cyan/60 motion-reduce:transform-none',
           pending
             ? 'cursor-wait text-muted opacity-100 hover:translate-y-0 hover:scale-100'

--- a/ui/src/components/workbench/WorkbenchSidebar.tsx
+++ b/ui/src/components/workbench/WorkbenchSidebar.tsx
@@ -32,7 +32,7 @@ import { useWindowManager } from '../../context/WindowManagerContext';
 import { useUnsavedChangesActionGuard } from '../../context/useUnsavedChangesActionGuard';
 import type { InboxSession, WorkbenchProject, WorkbenchSession } from '../../context/ApiContext';
 import { SessionPinAction } from './SessionPinAction';
-import { sessionRowActionPaddingClass } from './sessionRowLayout';
+import { SESSION_ROW_MENU_POSITION_CLASS, sessionRowActionPaddingClass } from './sessionRowLayout';
 import { SessionActionMenuContent, SessionActionsTrigger } from './sessionActions';
 import { useSessionActions } from './useSessionActions';
 import { formatRelativeTime } from '../../lib/relativeTime';
@@ -341,7 +341,7 @@ const SessionRow: React.FC<{
               onToggle={pinAction.onSelect}
             />
           )}
-          <span className="absolute inset-y-0 right-2 flex items-center">
+          <span className={clsx('absolute inset-y-0 flex items-center', SESSION_ROW_MENU_POSITION_CLASS)}>
             <PopoverTrigger asChild>
               <SessionActionsTrigger label={t('workbench.sessionActions')} open={menuOpen} />
             </PopoverTrigger>

--- a/ui/src/components/workbench/chatSessionActions.ts
+++ b/ui/src/components/workbench/chatSessionActions.ts
@@ -1,4 +1,9 @@
 import type { SessionActionDescriptor } from './sessionActions';
 
+// Touch surfaces do not advertise desktop keyboard chords. Keep the shared
+// descriptor model intact and adapt only the mobile presentation.
+export const mobileSessionActions = (actions: SessionActionDescriptor[]): SessionActionDescriptor[] =>
+  actions.map((action) => (action.id === 'archive' ? { ...action, hint: undefined } : action));
+
 export const mobileChatSessionActions = (actions: SessionActionDescriptor[]): SessionActionDescriptor[] =>
-  actions.filter((action) => action.id !== 'rename');
+  mobileSessionActions(actions).filter((action) => action.id !== 'rename');

--- a/ui/src/components/workbench/sessionActions.test.tsx
+++ b/ui/src/components/workbench/sessionActions.test.tsx
@@ -135,6 +135,9 @@ describe('SessionActionsTrigger', () => {
   it('hides the row variant until hover, keyboard focus, a coarse pointer, or an open menu', () => {
     const closed = renderToStaticMarkup(<SessionActionsTrigger label="Session actions" open={false} />);
 
+    expect(closed).toContain('size-5');
+    expect(closed).toContain('rounded-md');
+    expect(closed).not.toContain('rounded-lg');
     expect(closed).toContain('opacity-0');
     expect(closed).toContain('group-hover/sess:opacity-100');
     expect(closed).toContain('group-focus-within/sess:opacity-100');

--- a/ui/src/components/workbench/sessionActions.test.tsx
+++ b/ui/src/components/workbench/sessionActions.test.tsx
@@ -67,9 +67,9 @@ describe('SessionActionMenu', () => {
 
   // ── Codex review (sessionActions.tsx:93) ────────────────────────────────────
   // A natively ``disabled`` button cannot be focused, so the row uses aria-disabled.
-  // Its reason stays out of the visible menu while remaining available on hover and
-  // to assistive technology.
-  it('keeps an unforkable fork row gray and exposes its reason without visible menu copy', () => {
+  // Its reason stays out of the resting menu and appears through a hover/focus/tap
+  // disclosure that also supplies the accessible description.
+  it('keeps an unforkable fork row gray and discloses its reason without resting menu copy', () => {
     const reason = 'This session has no native agent session to fork yet.';
     const html = renderMenu([
       row({ id: 'fork', group: 'continue', label: 'Fork session', icon: GitFork, disabled: true, title: reason }),
@@ -77,9 +77,13 @@ describe('SessionActionMenu', () => {
 
     expect(html).toContain('aria-disabled="true"');
     expect(html).not.toContain('disabled=""');
-    expect(html).toContain(`title="${reason}"`);
     expect(html).toContain('aria-describedby=');
-    expect(html).toContain('class="sr-only"');
+    expect(html).toContain('role="tooltip"');
+    expect(html).toContain('opacity-0');
+    expect(html).toContain('group-hover/action:opacity-100');
+    expect(html).toContain('group-focus-within/action:opacity-100');
+    expect(html).not.toContain(`title="${reason}"`);
+    expect(html).not.toContain('class="sr-only"');
     expect(html).toContain('cursor-not-allowed text-muted');
     expect(html).not.toContain('text-[10.5px] leading-tight text-muted');
     expect(html).toContain('Fork session');

--- a/ui/src/components/workbench/sessionActions.test.tsx
+++ b/ui/src/components/workbench/sessionActions.test.tsx
@@ -9,7 +9,7 @@ import {
   SessionActionsTrigger,
   type SessionActionDescriptor,
 } from './sessionActions';
-import { mobileChatSessionActions } from './chatSessionActions';
+import { mobileChatSessionActions, mobileSessionActions } from './chatSessionActions';
 
 const row = (over: Partial<SessionActionDescriptor> & Pick<SessionActionDescriptor, 'id' | 'group' | 'label'>) =>
   ({ icon: Pin, onSelect: () => undefined, ...over }) as SessionActionDescriptor;
@@ -160,15 +160,13 @@ describe('SessionActionsTrigger', () => {
 });
 
 describe('MobileChatSessionActionMenu', () => {
-  it('removes rename from the Chat surface while preserving the remaining descriptors', () => {
+  it('removes rename and the archive shortcut hint from the mobile Chat surface', () => {
     const actions = fullMenu();
+    const visibleActions = mobileChatSessionActions(actions);
 
-    expect(mobileChatSessionActions(actions).map((action) => action.id)).toEqual([
-      'pin',
-      'fork',
-      'hide',
-      'archive',
-    ]);
+    expect(visibleActions.map((action) => action.id)).toEqual(['pin', 'fork', 'hide', 'archive']);
+    expect(visibleActions.find((action) => action.id === 'archive')?.hint).toBeUndefined();
+    expect(actions.find((action) => action.id === 'archive')?.hint).toBe('⇧⌘D');
   });
 
   it('renders the chat trigger only below the desktop breakpoint', () => {
@@ -182,5 +180,17 @@ describe('MobileChatSessionActionMenu', () => {
 
   it('withdraws the trigger when the surface offers no actions', () => {
     expect(renderToStaticMarkup(<MobileChatSessionActionMenu actions={[]} label="Session actions" />)).toBe('');
+  });
+});
+
+describe('mobileSessionActions', () => {
+  it('removes only the archive shortcut hint from mobile session menus', () => {
+    const actions = fullMenu();
+    const visibleActions = mobileSessionActions(actions);
+
+    expect(visibleActions.map((action) => action.id)).toEqual(actions.map((action) => action.id));
+    expect(visibleActions.find((action) => action.id === 'archive')?.hint).toBeUndefined();
+    expect(visibleActions.find((action) => action.id === 'fork')).toBe(actions.find((action) => action.id === 'fork'));
+    expect(actions.find((action) => action.id === 'archive')?.hint).toBe('⇧⌘D');
   });
 });

--- a/ui/src/components/workbench/sessionActions.test.tsx
+++ b/ui/src/components/workbench/sessionActions.test.tsx
@@ -66,20 +66,22 @@ describe('SessionActionMenu', () => {
   });
 
   // ── Codex review (sessionActions.tsx:93) ────────────────────────────────────
-  // A natively ``disabled`` button cannot be focused, so the only place the reason
-  // lived — the ``title`` tooltip — was unreachable by keyboard AND by touch. The
-  // row stays focusable via aria-disabled and states the reason on screen.
-  it('keeps an unforkable session’s fork row focusable and explains it on screen', () => {
+  // A natively ``disabled`` button cannot be focused, so the row uses aria-disabled.
+  // Its reason stays out of the visible menu while remaining available on hover and
+  // to assistive technology.
+  it('keeps an unforkable fork row gray and exposes its reason without visible menu copy', () => {
     const reason = 'This session has no native agent session to fork yet.';
     const html = renderMenu([
       row({ id: 'fork', group: 'continue', label: 'Fork session', icon: GitFork, disabled: true, title: reason }),
     ]);
 
     expect(html).toContain('aria-disabled="true"');
-    expect(html).not.toContain('disabled=""'); // focusable, so the reason is reachable
+    expect(html).not.toContain('disabled=""');
     expect(html).toContain(`title="${reason}"`);
-    // Visible text, not only the tooltip: touch pointers never get a tooltip.
-    expect(html).toContain(`>${reason}</span>`);
+    expect(html).toContain('aria-describedby=');
+    expect(html).toContain('class="sr-only"');
+    expect(html).toContain('cursor-not-allowed text-muted');
+    expect(html).not.toContain('text-[10.5px] leading-tight text-muted');
     expect(html).toContain('Fork session');
   });
 

--- a/ui/src/components/workbench/sessionActions.tsx
+++ b/ui/src/components/workbench/sessionActions.tsx
@@ -7,6 +7,7 @@ import type { LucideIcon } from 'lucide-react';
 import { Button } from '../ui/button';
 import { Popover, PopoverContent, PopoverTrigger } from '../ui/popover';
 import { mobileChatSessionActions } from './chatSessionActions';
+import { SESSION_ROW_ACTION_BUTTON_CLASS } from './sessionRowLayout';
 
 // Presentation half of the shared session action menu: the ⋯ trigger and the menu
 // body, used by the desktop sidebar row, the mobile projects row and the chat
@@ -65,7 +66,8 @@ export const SessionActionsTrigger = React.forwardRef<HTMLButtonElement, Session
         'shrink-0 text-muted transition hover:text-foreground',
         variant === 'row'
           ? [
-              'size-6 opacity-0 group-hover/sess:opacity-100 group-focus-within/sess:opacity-100 pointer-coarse:opacity-100',
+              SESSION_ROW_ACTION_BUTTON_CLASS,
+              'opacity-0 group-hover/sess:opacity-100 group-focus-within/sess:opacity-100 pointer-coarse:opacity-100',
               open && 'opacity-100',
             ]
           : 'size-7',

--- a/ui/src/components/workbench/sessionActions.tsx
+++ b/ui/src/components/workbench/sessionActions.tsx
@@ -26,8 +26,7 @@ export interface SessionActionDescriptor {
   label: string;
   /** Keyboard hint badge (e.g. ``⇧⌘D``), right-aligned in the menu row. */
   hint?: string;
-  /** Why this action is unavailable. Rendered as VISIBLE text under the label (a
-   *  touch user never sees a ``title`` tooltip) as well as the native tooltip. */
+  /** Why this action is unavailable. Exposed as a hover tooltip and an accessible description. */
   title?: string;
   disabled?: boolean;
   /** A write is in flight: the icon becomes a spinner and the row stops accepting clicks. */
@@ -103,6 +102,7 @@ export const SessionActionMenu: React.FC<{
   label?: string;
 }> = ({ actions, onAction, label }) => {
   const itemsRef = useRef<Array<HTMLButtonElement | null>>([]);
+  const menuId = React.useId();
 
   const focusItem = (index: number) => itemsRef.current[index]?.focus();
   const moveFocus = (from: number, delta: number) => {
@@ -118,6 +118,7 @@ export const SessionActionMenu: React.FC<{
         const newGroup =
           previous != null && GROUP_ORDER.indexOf(previous.group) !== GROUP_ORDER.indexOf(action.group);
         const reason = action.disabled ? action.title : undefined;
+        const reasonId = reason ? `${menuId}-${action.id}-reason` : undefined;
         return (
           <div key={action.id} className={clsx(newGroup && 'mt-1 border-t border-border pt-1')}>
             <button
@@ -126,6 +127,7 @@ export const SessionActionMenu: React.FC<{
               }}
               type="button"
               aria-disabled={action.disabled || undefined}
+              aria-describedby={reasonId}
               title={action.title}
               onClick={() => {
                 if (action.disabled) return;
@@ -165,16 +167,18 @@ export const SessionActionMenu: React.FC<{
                   aria-hidden="true"
                 />
               )}
-              <span className="flex flex-1 flex-col gap-0.5 overflow-hidden">
-                <span className="truncate">{action.label}</span>
-                {reason && <span className="text-[10.5px] leading-tight text-muted">{reason}</span>}
-              </span>
+              <span className="flex-1 truncate">{action.label}</span>
               {action.hint && (
                 <span className="shrink-0 font-mono text-[10px] text-muted" aria-hidden="true">
                   {action.hint}
                 </span>
               )}
             </button>
+            {reason && (
+              <span id={reasonId} className="sr-only">
+                {reason}
+              </span>
+            )}
           </div>
         );
       })}
@@ -203,7 +207,7 @@ export const SessionActionMenuContent: React.FC<{
   return (
     <PopoverContent
       align={align}
-      className={clsx('w-[196px] p-1', className)}
+      className={clsx('w-[176px] p-1', className)}
       onCloseAutoFocus={(event) => {
         if (!transferredFocus.current) return;
         transferredFocus.current = false;

--- a/ui/src/components/workbench/sessionActions.tsx
+++ b/ui/src/components/workbench/sessionActions.tsx
@@ -26,7 +26,7 @@ export interface SessionActionDescriptor {
   label: string;
   /** Keyboard hint badge (e.g. ``⇧⌘D``), right-aligned in the menu row. */
   hint?: string;
-  /** Why this action is unavailable. Exposed as a hover tooltip and an accessible description. */
+  /** Why this action is unavailable. Exposed through the disabled row's disclosure tooltip. */
   title?: string;
   disabled?: boolean;
   /** A write is in flight: the icon becomes a spinner and the row stops accepting clicks. */
@@ -103,6 +103,7 @@ export const SessionActionMenu: React.FC<{
 }> = ({ actions, onAction, label }) => {
   const itemsRef = useRef<Array<HTMLButtonElement | null>>([]);
   const menuId = React.useId();
+  const [disclosedReasonId, setDisclosedReasonId] = useState<SessionActionId | null>(null);
 
   const focusItem = (index: number) => itemsRef.current[index]?.focus();
   const moveFocus = (from: number, delta: number) => {
@@ -120,7 +121,10 @@ export const SessionActionMenu: React.FC<{
         const reason = action.disabled ? action.title : undefined;
         const reasonId = reason ? `${menuId}-${action.id}-reason` : undefined;
         return (
-          <div key={action.id} className={clsx(newGroup && 'mt-1 border-t border-border pt-1')}>
+          <div
+            key={action.id}
+            className={clsx('group/action relative', newGroup && 'mt-1 border-t border-border pt-1')}
+          >
             <button
               ref={(node) => {
                 itemsRef.current[index] = node;
@@ -128,11 +132,17 @@ export const SessionActionMenu: React.FC<{
               type="button"
               aria-disabled={action.disabled || undefined}
               aria-describedby={reasonId}
-              title={action.title}
               onClick={() => {
-                if (action.disabled) return;
+                if (action.disabled) {
+                  if (reason) setDisclosedReasonId((current) => (current === action.id ? null : action.id));
+                  return;
+                }
+                setDisclosedReasonId(null);
                 onAction?.(action.id);
                 action.onSelect();
+              }}
+              onBlur={() => {
+                setDisclosedReasonId((current) => (current === action.id ? null : current));
               }}
               onKeyDown={(event) => {
                 if (event.key === 'ArrowDown') {
@@ -175,7 +185,16 @@ export const SessionActionMenu: React.FC<{
               )}
             </button>
             {reason && (
-              <span id={reasonId} className="sr-only">
+              <span
+                id={reasonId}
+                role="tooltip"
+                className={clsx(
+                  'pointer-events-none absolute left-0 right-0 top-full z-50 mt-1 rounded-md bg-foreground px-2 py-1.5 text-[11px] leading-tight text-background shadow-md transition-opacity',
+                  disclosedReasonId === action.id
+                    ? 'opacity-100'
+                    : 'opacity-0 group-hover/action:opacity-100 group-focus-within/action:opacity-100',
+                )}
+              >
                 {reason}
               </span>
             )}

--- a/ui/src/components/workbench/sessionRowLayout.ts
+++ b/ui/src/components/workbench/sessionRowLayout.ts
@@ -1,11 +1,11 @@
 // Compact right-hand rail shared by the direct pin control and action menu.
 // Both controls use the same footprint/radius; the menu sits close to the row
-// edge and the pin follows with a narrow gap.
+// edge and the pin follows without a gap between their hit areas.
 export const SESSION_ROW_ACTION_BUTTON_CLASS = 'size-5 rounded-md';
-export const SESSION_ROW_PIN_POSITION_CLASS = 'right-6';
-export const SESSION_ROW_MENU_POSITION_CLASS = 'right-0.5';
+export const SESSION_ROW_PIN_POSITION_CLASS = 'right-5';
+export const SESSION_ROW_MENU_POSITION_CLASS = 'right-0';
 
 // Pinned rows reserve the rail at rest; unpinned rows expand it only while
 // either control is revealed through hover/focus or while the menu is open.
 export const sessionRowActionPaddingClass = (menuOpen: boolean, pinned: boolean) =>
-  menuOpen || pinned ? 'pr-12' : 'pr-2.5 hover:pr-12 focus-within:pr-12 pointer-coarse:pr-12';
+  menuOpen || pinned ? 'pr-11' : 'pr-2.5 hover:pr-11 focus-within:pr-11 pointer-coarse:pr-11';

--- a/ui/src/components/workbench/sessionRowLayout.ts
+++ b/ui/src/components/workbench/sessionRowLayout.ts
@@ -1,5 +1,11 @@
-// Right-hand rail for the direct pin control and the session action menu. Pinned
-// rows reserve it at rest; unpinned rows expand it only while either control is
-// revealed through hover/focus or while the menu is open.
+// Compact right-hand rail shared by the direct pin control and action menu.
+// Both controls use the same footprint/radius; the menu sits close to the row
+// edge and the pin follows with a narrow gap.
+export const SESSION_ROW_ACTION_BUTTON_CLASS = 'size-5 rounded-md';
+export const SESSION_ROW_PIN_POSITION_CLASS = 'right-6';
+export const SESSION_ROW_MENU_POSITION_CLASS = 'right-0.5';
+
+// Pinned rows reserve the rail at rest; unpinned rows expand it only while
+// either control is revealed through hover/focus or while the menu is open.
 export const sessionRowActionPaddingClass = (menuOpen: boolean, pinned: boolean) =>
-  menuOpen || pinned ? 'pr-16' : 'pr-2.5 hover:pr-16 focus-within:pr-16 pointer-coarse:pr-16';
+  menuOpen || pinned ? 'pr-12' : 'pr-2.5 hover:pr-12 focus-within:pr-12 pointer-coarse:pr-12';


### PR DESCRIPTION
## Capability

Compacts the desktop Workbench sidebar session action rail, restores the shared session menu's earlier compact width, and keeps unavailable fork actions unobtrusive.

- reduces both desktop sidebar controls from 24px to 20px
- moves the overflow control flush to the row edge
- removes the remaining gap between the two 20px hit areas
- reduces the revealed/pinned action rail reservation from 64px to 44px
- keeps unpinned titles at their existing maximum resting width
- uses `rounded-md` for both controls
- restores the shared session menu width from 196px to its pre-#1165 value of 176px
- keeps unforkable sessions' fork action gray and non-interactive
- moves the unavailable reason out of the resting menu and into a hover/focus/tap disclosure tooltip connected through `aria-describedby`
- hides the archive keyboard shortcut hint from mobile Chat and Projects session menus while retaining it on desktop

## Scenario IDs

None. This visual refinement has no cataloged scenario ID.

## Evidence

- Unit: `SessionPinAction.test.tsx` and `sessionActions.test.tsx` cover shared size/radius, zero-gap offsets, reveal behavior, 44px rail padding, mobile action filtering, and unavailable-fork disclosure; full UI suite passed (115 files, 1499 tests).
- Contract: the shared action menu test verifies that unavailable fork actions remain focusable with `aria-disabled`, expose a hover/focus disclosure, stay gray, and do not render persistent visible reason copy. Mobile presentation tests verify that the archive hint is removed without mutating the desktop descriptor.
- Scenario: no scenario harness changes; behavior remains within the existing session action interaction.
- Build/lint: UI lint baseline and production build passed.
- Browser: verified the live desktop Workbench at 1440x900. Pinned and unpinned hover rows measured 20px controls with a 0px inter-control gap and 0px right inset, without title overlap. Verified the live mobile Chat menu at 390x844 renders Pin, Fork, Hide, and Archive with neither Rename nor the archive shortcut hint.
- Residual manual: the loaded project had no unforkable session, so the real-data mobile tap disclosure remains a manual check; its markup and interaction contract are covered by the focused test.

## Dependencies

No unmerged dependency. This follows merged PR #1187.

## Known by design

- Mobile Chat and Projects action trigger sizes are unchanged; only the desktop sidebar row variant is compacted.
- The restored 176px menu body is shared by the desktop sidebar, mobile Projects, and mobile Chat surfaces.
- Unpinned rows still reserve the action rail only on hover/focus/coarse pointers, while pinned rows reserve it continuously.
