### PR TITLE
fix(claude): recover sessions after CLI termination

### DIFF
--- a/core/agent_auth_service.py
+++ b/core/agent_auth_service.py
@@ -916,7 +916,10 @@ class AgentAuthService:
         through the outbound chokepoint with a silent terminal failure. No-op
         off-workbench (the outbound resolves no session id).
         """
-        if not classify_auth_error(backend, error_text):
+        auth_text = "\n".join(
+            text for text in (error_text, terminal_error) if str(text or "").strip()
+        )
+        if not classify_auth_error(backend, auth_text):
             return False
 
         backend_config = self._resolve_backend_config(backend)

--- a/core/handlers/session_handler.py
+++ b/core/handlers/session_handler.py
@@ -253,6 +253,32 @@ class SessionHandler(BaseHandler):
         )
         return env["PATH"] if "PATH" in env else os.environ.get("PATH", "")
 
+    async def _evict_terminated_cached_claude_session(
+        self,
+        composite_key: str,
+        client: ClaudeSDKClient,
+        *,
+        retire_model_hub_scope: bool,
+    ) -> bool:
+        returncode = get_claude_client_returncode(client)
+        if returncode is None:
+            return False
+
+        reason = claude_process_exit_reason(returncode)
+        stderr_tail = get_claude_client_stderr_tail(client)
+        diagnostic = f"\nClaude stderr tail:\n{stderr_tail}" if stderr_tail else ""
+        logger.warning(
+            "Recreating cached Claude SDK client for %s because its process terminated (%s)%s",
+            composite_key,
+            reason,
+            diagnostic,
+        )
+        await self._cleanup_session_locked(
+            composite_key,
+            retire_model_hub_scope=retire_model_hub_scope,
+        )
+        return True
+
     async def _reuse_cached_claude_session_if_available(
         self,
         *,
@@ -268,6 +294,12 @@ class SessionHandler(BaseHandler):
     ) -> ClaudeSDKClient | None:
         client = self.claude_sessions.get(composite_key)
         if client is None:
+            return None
+        if await self._evict_terminated_cached_claude_session(
+            composite_key,
+            client,
+            retire_model_hub_scope=model_hub_launch.channel == "direct",
+        ):
             return None
         if getattr(client, "_vibe_model_hub_fingerprint", "direct") != model_hub_launch.fingerprint:
             logger.info("Recreating cached Claude SDK client because Model Hub channel changed")
@@ -358,6 +390,12 @@ class SessionHandler(BaseHandler):
     ) -> ClaudeSDKClient | None:
         client = self.claude_sessions.get(composite_key)
         if client is None:
+            return None
+        if await self._evict_terminated_cached_claude_session(
+            composite_key,
+            client,
+            retire_model_hub_scope=model_hub_launch.channel == "direct",
+        ):
             return None
         if getattr(client, "_vibe_model_hub_fingerprint", "direct") != model_hub_launch.fingerprint:
             logger.info("Recreating cached Claude subagent SDK client because Model Hub channel changed")

--- a/core/handlers/session_handler.py
+++ b/core/handlers/session_handler.py
@@ -157,6 +157,26 @@ class SessionHandler(BaseHandler):
         while composite_key in self.active_sessions:
             await asyncio.sleep(0.05)
 
+    async def _wait_for_claude_receiver_cleanup(self, composite_key: str) -> None:
+        """Wait for the receiver task to finish its post-error cleanup."""
+        receiver_task = self.receiver_tasks.get(composite_key)
+        if receiver_task is None or receiver_task is asyncio.current_task():
+            return
+        try:
+            await asyncio.shield(receiver_task)
+        except asyncio.CancelledError:
+            if receiver_task.cancelled():
+                return
+            raise
+        except Exception:
+            # The receiver already reported its failure; cleanup must still retire
+            # the cached client and drain the task without masking that failure.
+            logger.debug(
+                "Claude receiver task ended with an error while waiting for cleanup: %s",
+                composite_key,
+                exc_info=True,
+            )
+
     def bind_claude_runtime_session(
         self,
         client: ClaudeSDKClient,
@@ -258,8 +278,6 @@ class SessionHandler(BaseHandler):
         self,
         composite_key: str,
         client: ClaudeSDKClient,
-        *,
-        retire_model_hub_scope: bool,
     ) -> bool:
         returncode = get_claude_client_returncode(client)
         if returncode is None:
@@ -274,10 +292,14 @@ class SessionHandler(BaseHandler):
             reason,
             diagnostic,
         )
+        await self._wait_for_claude_receiver_cleanup(composite_key)
         await self._wait_for_claude_session_idle(composite_key)
         await self._cleanup_session_locked(
             composite_key,
-            retire_model_hub_scope=retire_model_hub_scope,
+            # A dead cached client may have been launched through Model Hub even
+            # when the current turn resolves to a different channel. Retire the
+            # cached generation's process credential before recreating it.
+            retire_model_hub_scope=True,
         )
         return True
 
@@ -300,7 +322,6 @@ class SessionHandler(BaseHandler):
         if await self._evict_terminated_cached_claude_session(
             composite_key,
             client,
-            retire_model_hub_scope=model_hub_launch.channel == "direct",
         ):
             return None
         if getattr(client, "_vibe_model_hub_fingerprint", "direct") != model_hub_launch.fingerprint:
@@ -396,7 +417,6 @@ class SessionHandler(BaseHandler):
         if await self._evict_terminated_cached_claude_session(
             composite_key,
             client,
-            retire_model_hub_scope=model_hub_launch.channel == "direct",
         ):
             return None
         if getattr(client, "_vibe_model_hub_fingerprint", "direct") != model_hub_launch.fingerprint:
@@ -1250,6 +1270,7 @@ class SessionHandler(BaseHandler):
             claude_stderr_lines.append(text)
             if len(claude_stderr_lines) > 40:
                 del claude_stderr_lines[:-40]
+            logger.warning("Claude CLI stderr for %s: %s", composite_key, text)
 
         # V2Config-driven Anthropic env composition, centralised so the
         # control-channel client (``agent_auth_service``) cannot drift

--- a/core/handlers/session_handler.py
+++ b/core/handlers/session_handler.py
@@ -77,6 +77,14 @@ class ClaudeSessionNotFoundError(RuntimeError):
         )
 
 
+class _ClaudeReceiverCleanupRequired(RuntimeError):
+    """Signal that a dead generation must be retried after receiver cleanup."""
+
+    def __init__(self, composite_key: str):
+        self.composite_key = composite_key
+        super().__init__(f"Claude receiver cleanup is still pending for {composite_key}")
+
+
 class SessionHandler(BaseHandler):
     """Handles all session-related operations"""
 
@@ -292,6 +300,16 @@ class SessionHandler(BaseHandler):
             reason,
             diagnostic,
         )
+        receiver_task = self.receiver_tasks.get(composite_key)
+        if (
+            receiver_task is not None
+            and receiver_task is not asyncio.current_task()
+            and not receiver_task.done()
+        ):
+            # This method runs under the generation lock. Let the receiver
+            # release that lock through its normal error cleanup before waiting
+            # for the task, otherwise both sides wait on one another.
+            raise _ClaudeReceiverCleanupRequired(composite_key)
         await self._wait_for_claude_receiver_cleanup(composite_key)
         await self._wait_for_claude_session_idle(composite_key)
         await self._cleanup_session_locked(
@@ -978,14 +996,20 @@ class SessionHandler(BaseHandler):
         """Resolve or create one Claude runtime generation under its exact lock."""
 
         composite_key = self._claude_runtime_generation_key(context, subagent_name)
-        async with self._claude_runtime_generation_lock(composite_key):
-            return await self._get_or_create_claude_session_locked(
-                context,
-                subagent_name=subagent_name,
-                subagent_model=subagent_model,
-                subagent_reasoning_effort=subagent_reasoning_effort,
-                agent_system_prompt=agent_system_prompt,
-            )
+        while True:
+            try:
+                async with self._claude_runtime_generation_lock(composite_key):
+                    return await self._get_or_create_claude_session_locked(
+                        context,
+                        subagent_name=subagent_name,
+                        subagent_model=subagent_model,
+                        subagent_reasoning_effort=subagent_reasoning_effort,
+                        agent_system_prompt=agent_system_prompt,
+                    )
+            except _ClaudeReceiverCleanupRequired as retry:
+                # Receiver error handling may need the same generation lock. Wait
+                # only after the lock has been released, then retry resolution.
+                await self._wait_for_claude_receiver_cleanup(retry.composite_key)
 
     async def _get_or_create_claude_session_locked(
         self,

--- a/core/handlers/session_handler.py
+++ b/core/handlers/session_handler.py
@@ -26,6 +26,7 @@ from modules.agents.claude_process_reaper import (
     get_claude_client_returncode,
     get_claude_client_stderr_tail,
     claude_process_exit_reason,
+    claude_process_exit_reason_i18n,
     register_claude_owned_process,
     reap_duplicate_claude_resume_processes,
     reap_orphaned_claude_processes,
@@ -273,6 +274,7 @@ class SessionHandler(BaseHandler):
             reason,
             diagnostic,
         )
+        await self._wait_for_claude_session_idle(composite_key)
         await self._cleanup_session_locked(
             composite_key,
             retire_model_hub_scope=retire_model_hub_scope,
@@ -2265,7 +2267,8 @@ class SessionHandler(BaseHandler):
         client = self.claude_sessions.get(composite_key)
         returncode = get_claude_client_returncode(client)
         if returncode is not None:
-            reason = claude_process_exit_reason(returncode)
+            reason_key, reason_values = claude_process_exit_reason_i18n(returncode)
+            reason = self._t(reason_key, **reason_values)
             diagnostic = self.claude_error_diagnostic(composite_key, error)
             logger.error(
                 "Claude process for session %s terminated (%s): %s",

--- a/core/handlers/session_handler.py
+++ b/core/handlers/session_handler.py
@@ -23,6 +23,9 @@ from modules.agents.claude_process_reaper import (
     AVIBE_CLAUDE_PROCESS_OWNER_ENV,
     AVIBE_CLAUDE_SESSION_OWNER,
     get_claude_client_pid,
+    get_claude_client_returncode,
+    get_claude_client_stderr_tail,
+    claude_process_exit_reason,
     register_claude_owned_process,
     reap_duplicate_claude_resume_processes,
     reap_orphaned_claude_processes,
@@ -1284,6 +1287,7 @@ class SessionHandler(BaseHandler):
 
         # Create new Claude client
         client = ClaudeSDKClient(options=options)
+        setattr(client, "_vibe_stderr_lines", claude_stderr_lines)
         setattr(client, "_vibe_caller_env", self._caller_env_for_context(context))
         setattr(client, "_vibe_git_path_state", git_path_state)
         setattr(
@@ -2218,7 +2222,28 @@ class SessionHandler(BaseHandler):
                     )
                 ),
             )
-        elif "read() called while another coroutine" in error_msg:
+            return
+
+        client = self.claude_sessions.get(composite_key)
+        returncode = get_claude_client_returncode(client)
+        if returncode is not None:
+            reason = claude_process_exit_reason(returncode)
+            diagnostic = self.claude_error_diagnostic(composite_key, error)
+            logger.error(
+                "Claude process for session %s terminated (%s): %s",
+                composite_key,
+                reason,
+                diagnostic,
+            )
+            await self.cleanup_session(composite_key, current_receiver_task=asyncio.current_task())
+            await self._get_im_client(context).send_message(
+                context,
+                self._get_formatter(context).format_error(
+                    self._t("error.claudeProcessTerminated", reason=reason)
+                ),
+            )
+            return
+        if "read() called while another coroutine" in error_msg:
             logger.error(f"Session {composite_key} has concurrent read error - cleaning up")
             await self.cleanup_session(composite_key, current_receiver_task=asyncio.current_task())
 
@@ -2250,6 +2275,18 @@ class SessionHandler(BaseHandler):
                 context,
                 self._get_formatter(context).format_error(self._t("error.sessionGeneric", error=error_msg)),
             )
+
+    def claude_error_diagnostic(self, composite_key: str, error: Exception) -> str:
+        """Add process state and captured stderr to a Claude failure diagnostic."""
+        diagnostic = str(error)
+        client = self.claude_sessions.get(composite_key)
+        returncode = get_claude_client_returncode(client)
+        if returncode is not None:
+            diagnostic = f"{diagnostic}\nClaude process terminated: {claude_process_exit_reason(returncode)}"
+        stderr_tail = get_claude_client_stderr_tail(client)
+        if stderr_tail:
+            diagnostic = f"{diagnostic}\nClaude stderr tail:\n{stderr_tail}"
+        return diagnostic
 
     def capture_session_id(
         self,

--- a/modules/agents/claude_agent.py
+++ b/modules/agents/claude_agent.py
@@ -1850,6 +1850,43 @@ class ClaudeAgent(BaseAgent):
                 self._pending_requests.setdefault(composite_key, []).insert(0, pending_request)
                 return
         self._requeue_request_activity(pending_request)
+        terminal_error = "Claude receiver ended without a terminal result"
+        client = self.claude_sessions.get(composite_key)
+        returncode = get_claude_client_returncode(client)
+        cleanup_handled = False
+        if returncode is not None:
+            eof_error = RuntimeError(terminal_error)
+            error_notify = self._format_error_notify(eof_error, composite_key=composite_key)
+            diagnostic = self._claude_error_diagnostic(composite_key, eof_error)
+            handle_session_error = getattr(self.session_handler, "handle_session_error", None)
+            if callable(handle_session_error):
+                await handle_session_error(composite_key, context, eof_error)
+                cleanup_handled = True
+                try:
+                    from core.message_mirror import persist_agent_message
+
+                    notification = backend_failure_notification_output(
+                        context,
+                        "claude",
+                        request=pending_request,
+                        output=terminal_output_for(pending_request),
+                    )
+                    persist_agent_message(
+                        context,
+                        "notify",
+                        error_notify,
+                        metadata=notification.metadata,
+                        native_message_id=notification.idempotency_key,
+                    )
+                except Exception:
+                    logger.debug(
+                        "claude: failed to persist terminated EOF notification",
+                        exc_info=True,
+                    )
+            else:
+                diagnostic = terminal_error
+        else:
+            diagnostic = terminal_error
         logger.warning("Claude receiver ended without a result for session %s", composite_key)
         self._adopt_pending_turn_token(context, pending_request)
         await self._remove_specific_pending_reaction(composite_key, context, pending_request)
@@ -1858,11 +1895,12 @@ class ClaudeAgent(BaseAgent):
         self._pending_assistant_message.pop(composite_key, None)
         self._mark_session_idle_if_no_pending_requests(composite_key)
 
-        await self._cleanup_runtime_session(
-            composite_key,
-            current_receiver_task=asyncio.current_task(),
-            preserve_pending_request_state=True,
-        )
+        if not cleanup_handled:
+            await self._cleanup_runtime_session(
+                composite_key,
+                current_receiver_task=asyncio.current_task(),
+                preserve_pending_request_state=True,
+            )
         try:
             await self.controller.emit_agent_message(
                 context,
@@ -1871,7 +1909,7 @@ class ClaudeAgent(BaseAgent):
                 is_error=True,
                 level="silent",
                 output=terminal_output_for(pending_request),
-                terminal_error="Claude receiver ended without a terminal result",
+                terminal_error=diagnostic,
             )
         finally:
             self._release_service_runtime_turn(context)
@@ -1904,7 +1942,19 @@ class ClaudeAgent(BaseAgent):
                 output=terminal_output_for(pending_request),
                 terminal_error=diagnostic,
             )
-            if not handled:
+            if handled:
+                self._retire_failed_auth_turn(composite_key, context)
+                await self._cleanup_runtime_session(
+                    composite_key,
+                    current_receiver_task=asyncio.current_task(),
+                    preserve_pending_request_state=True,
+                )
+                if pending_request is not None:
+                    await self._remove_ack_reaction(pending_request)
+                self._discard_pending_reaction(composite_key)
+                await self._clear_pending_reactions(composite_key, context)
+                self._mark_session_idle_if_no_pending_requests(composite_key)
+            else:
                 await self.session_handler.handle_session_error(
                     composite_key,
                     context,

--- a/modules/agents/claude_agent.py
+++ b/modules/agents/claude_agent.py
@@ -245,6 +245,16 @@ class ClaudeAgent(BaseAgent):
                     output=terminal_output_for(request),
                     terminal_error=diagnostic,
                 )
+                if handled and get_claude_client_returncode(client) is not None:
+                    # Auth recovery owns the visible settlement, but a query can
+                    # fail after the cached CLI has already exited. Retire that
+                    # runtime here so its client and Model Hub credential cannot
+                    # survive until a later retry; preserve newer queued turns.
+                    self._requeue_request_activity(request)
+                    await self._cleanup_runtime_session(
+                        runtime_session_key,
+                        preserve_pending_request_state=True,
+                    )
                 if not handled:
                     await self.session_handler.handle_session_error(runtime_session_key, context, e)
                     # ``handle_session_error`` sends through the IM client, which doesn't
@@ -1849,53 +1859,82 @@ class ClaudeAgent(BaseAgent):
             if not pending_token:
                 self._pending_requests.setdefault(composite_key, []).insert(0, pending_request)
                 return
-        self._requeue_request_activity(pending_request)
+        # The receiver context may belong to an earlier turn. Adopt the FIFO
+        # owner's identity before any visible or durable failure output.
+        self._adopt_pending_turn_token(context, pending_request)
         terminal_error = "Claude receiver ended without a terminal result"
         client = self.claude_sessions.get(composite_key)
         returncode = get_claude_client_returncode(client)
-        cleanup_handled = False
+        auth_handled = False
         if returncode is not None:
             eof_error = RuntimeError(terminal_error)
             error_notify = self._format_error_notify(eof_error, composite_key=composite_key)
             diagnostic = self._claude_error_diagnostic(composite_key, eof_error)
-            handle_session_error = getattr(self.session_handler, "handle_session_error", None)
-            if callable(handle_session_error):
-                await handle_session_error(composite_key, context, eof_error)
-                cleanup_handled = True
-                try:
-                    from core.message_mirror import persist_agent_message
-
-                    notification = backend_failure_notification_output(
-                        context,
-                        "claude",
-                        request=pending_request,
-                        output=terminal_output_for(pending_request),
-                    )
-                    persist_agent_message(
-                        context,
-                        "notify",
-                        error_notify,
-                        metadata=notification.metadata,
-                        native_message_id=notification.idempotency_key,
-                    )
-                except Exception:
-                    logger.debug(
-                        "claude: failed to persist terminated EOF notification",
-                        exc_info=True,
-                    )
+            auth_handled = await self.controller.agent_auth_service.maybe_emit_auth_recovery_message(
+                context,
+                "claude",
+                error_notify,
+                output=terminal_output_for(pending_request),
+                terminal_error=diagnostic,
+            )
+            if auth_handled:
+                self._retire_failed_auth_turn(
+                    composite_key,
+                    context,
+                    failed_request=pending_request,
+                )
+                await self._cleanup_runtime_session(
+                    composite_key,
+                    current_receiver_task=asyncio.current_task(),
+                    preserve_pending_request_state=True,
+                )
+                if pending_request is not None:
+                    await self._remove_ack_reaction(pending_request)
+                self._discard_pending_reaction(composite_key)
+                await self._clear_pending_reactions(composite_key, context)
+                self._mark_session_idle_if_no_pending_requests(composite_key)
             else:
-                diagnostic = terminal_error
+                self._requeue_request_activity(pending_request)
+                handle_session_error = getattr(self.session_handler, "handle_session_error", None)
+                if callable(handle_session_error):
+                    await handle_session_error(composite_key, context, eof_error)
+                    try:
+                        from core.message_mirror import persist_agent_message
+
+                        notification = backend_failure_notification_output(
+                            context,
+                            "claude",
+                            request=pending_request,
+                            output=terminal_output_for(pending_request),
+                        )
+                        persist_agent_message(
+                            context,
+                            "notify",
+                            error_notify,
+                            metadata=notification.metadata,
+                            native_message_id=notification.idempotency_key,
+                        )
+                    except Exception:
+                        logger.debug(
+                            "claude: failed to persist terminated EOF notification",
+                            exc_info=True,
+                        )
+                else:
+                    diagnostic = terminal_error
         else:
+            self._requeue_request_activity(pending_request)
             diagnostic = terminal_error
+        if auth_handled:
+            self._release_service_runtime_turn(context)
+            return
         logger.warning("Claude receiver ended without a result for session %s", composite_key)
-        self._adopt_pending_turn_token(context, pending_request)
         await self._remove_specific_pending_reaction(composite_key, context, pending_request)
         await self._remove_ack_reaction(pending_request)
         self._last_assistant_text.pop(composite_key, None)
         self._pending_assistant_message.pop(composite_key, None)
         self._mark_session_idle_if_no_pending_requests(composite_key)
 
-        if not cleanup_handled:
+        if returncode is None or not callable(getattr(self.session_handler, "handle_session_error", None)):
             await self._cleanup_runtime_session(
                 composite_key,
                 current_receiver_task=asyncio.current_task(),
@@ -2227,7 +2266,13 @@ class ClaudeAgent(BaseAgent):
                     value["execution_ids"] = list(execution_ids)
             context.platform_specific[key] = value
 
-    def _retire_failed_auth_turn(self, composite_key: str, context: MessageContext) -> None:
+    def _retire_failed_auth_turn(
+        self,
+        composite_key: str,
+        context: MessageContext,
+        *,
+        failed_request: AgentRequest | None = None,
+    ) -> None:
         """Retire a terminal auth-failure turn from the pending FIFO.
 
         The auth error IS this turn's (failed) result, so pop its pending request:
@@ -2236,7 +2281,8 @@ class ClaudeAgent(BaseAgent):
         and Stop sticks until the safety timeout. Adopt the failed turn's own token
         and release its Chat stream now. Called from auth-failure terminal paths
         after the recovery notify has been persisted."""
-        failed_request = self._pop_pending_request(composite_key)
+        if failed_request is None:
+            failed_request = self._pop_pending_request(composite_key)
         self._requeue_request_activity(failed_request)
         self._adopt_pending_turn_token(context, failed_request)
         _mark = getattr(self.controller, "mark_turn_complete", None)

--- a/modules/agents/claude_agent.py
+++ b/modules/agents/claude_agent.py
@@ -29,6 +29,8 @@ from core.session_activities import SessionActivity, activity_completion_output
 from modules.claude_sdk_compat import TextBlock, ToolUseBlock, is_claude_sdk_buffer_error
 from modules.agents.claude_process_reaper import (
     AVIBE_CLAUDE_SESSION_OWNER,
+    claude_process_exit_reason,
+    get_claude_client_returncode,
     register_claude_owned_process,
 )
 
@@ -108,7 +110,16 @@ class ClaudeAgent(BaseAgent):
         # )
         self._question_handler = None
 
-    def _format_error_notify(self, error: Exception) -> str:
+    def _claude_error_diagnostic(self, composite_key: str, error: Exception) -> str:
+        diagnostic = getattr(self.session_handler, "claude_error_diagnostic", None)
+        if callable(diagnostic):
+            try:
+                return diagnostic(composite_key, error)
+            except Exception:
+                logger.debug("claude: failed to build error diagnostic", exc_info=True)
+        return str(error)
+
+    def _format_error_notify(self, error: Exception, *, composite_key: str | None = None) -> str:
         """Return the durable notify text for Claude terminal errors."""
         if is_claude_sdk_buffer_error(error):
             translator = getattr(self.session_handler, "_t", None) or getattr(self.controller, "_t", None)
@@ -118,6 +129,20 @@ class ClaudeAgent(BaseAgent):
                 except Exception:
                     logger.debug("claude: failed to translate buffer-error notify", exc_info=True)
             return "❌ Connection to Claude was lost. Please try your message again."
+        client = self.claude_sessions.get(composite_key) if composite_key else None
+        returncode = get_claude_client_returncode(client)
+        if returncode is not None:
+            reason = claude_process_exit_reason(returncode)
+            translator = getattr(self.session_handler, "_t", None) or getattr(self.controller, "_t", None)
+            if callable(translator):
+                try:
+                    return f"❌ {translator('error.claudeProcessTerminated', reason=reason)}"
+                except Exception:
+                    logger.debug("claude: failed to translate process-termination notify", exc_info=True)
+            return (
+                f"❌ Claude Code process terminated ({reason}); the session was reset. "
+                "Please try your message again."
+            )
         return f"❌ Claude error: {error}"
 
     async def handle_message(self, request: AgentRequest) -> None:
@@ -207,20 +232,21 @@ class ClaudeAgent(BaseAgent):
             raise
         except Exception as e:
             logger.error(f"Error processing Claude message: {e}", exc_info=True)
-            await self.record_model_hub_native_failure(context, str(e))
+            diagnostic = self._claude_error_diagnostic(runtime_session_key, e)
+            await self.record_model_hub_native_failure(context, diagnostic)
             # Clean up the specific reaction for this request (not FIFO)
             await self._remove_specific_pending_reaction(runtime_session_key, context, request)
             self._remove_pending_request(runtime_session_key, request)
             self._mark_session_idle_if_no_pending_requests(runtime_session_key)
             await self._remove_ack_reaction(request)
-            error_notify = self._format_error_notify(e)
+            error_notify = self._format_error_notify(e, composite_key=runtime_session_key)
             try:
                 handled = await self.controller.agent_auth_service.maybe_emit_auth_recovery_message(
                     context,
                     "claude",
                     error_notify,
                     output=terminal_output_for(request),
-                    terminal_error=str(e),
+                    terminal_error=diagnostic,
                 )
                 if not handled:
                     await self.session_handler.handle_session_error(runtime_session_key, context, e)
@@ -254,7 +280,7 @@ class ClaudeAgent(BaseAgent):
                         is_error=True,
                         level="silent",
                         output=terminal_output_for(request),
-                        terminal_error=str(e),
+                        terminal_error=diagnostic,
                     )
             finally:
                 self._release_service_runtime_turn(context)
@@ -1870,15 +1896,16 @@ class ClaudeAgent(BaseAgent):
             pending_request = pending[0] if pending else None
             self._adopt_pending_turn_token(context, pending_request)
             await self._clear_pending_reactions(composite_key, context)
-            error_notify = self._format_error_notify(error)
+            diagnostic = self._claude_error_diagnostic(composite_key, error)
+            error_notify = self._format_error_notify(error, composite_key=composite_key)
             failure_context = getattr(pending_request, "context", context)
-            await self.record_model_hub_native_failure(failure_context, str(error))
+            await self.record_model_hub_native_failure(failure_context, diagnostic)
             handled = await self.controller.agent_auth_service.maybe_emit_auth_recovery_message(
                 context,
                 "claude",
                 error_notify,
                 output=terminal_output_for(pending_request),
-                terminal_error=str(error),
+                terminal_error=diagnostic,
             )
             if not handled:
                 await self.session_handler.handle_session_error(
@@ -1914,7 +1941,7 @@ class ClaudeAgent(BaseAgent):
                     is_error=True,
                     level="silent",
                     output=terminal_output_for(pending_request),
-                    terminal_error=str(error),
+                    terminal_error=diagnostic,
                 )
             self._release_service_runtime_turn(context)
 

--- a/modules/agents/claude_agent.py
+++ b/modules/agents/claude_agent.py
@@ -29,7 +29,7 @@ from core.session_activities import SessionActivity, activity_completion_output
 from modules.claude_sdk_compat import TextBlock, ToolUseBlock, is_claude_sdk_buffer_error
 from modules.agents.claude_process_reaper import (
     AVIBE_CLAUDE_SESSION_OWNER,
-    claude_process_exit_reason,
+    claude_process_exit_reason_i18n,
     get_claude_client_returncode,
     register_claude_owned_process,
 )
@@ -137,7 +137,8 @@ class ClaudeAgent(BaseAgent):
         client = self.claude_sessions.get(composite_key) if composite_key else None
         returncode = get_claude_client_returncode(client)
         if returncode is not None:
-            reason = claude_process_exit_reason(returncode)
+            reason_key, reason_values = claude_process_exit_reason_i18n(returncode)
+            reason = self._translate_error(reason_key, **reason_values)
             return f"❌ {self._translate_error('error.claudeProcessTerminated', reason=reason)}"
         return f"❌ Claude error: {error}"
 

--- a/modules/agents/claude_agent.py
+++ b/modules/agents/claude_agent.py
@@ -147,6 +147,7 @@ class ClaudeAgent(BaseAgent):
         runtime_base_session_id = request.base_session_id
         runtime_session_key = request.composite_session_id
         turn_registered = False
+        client = None
 
         # Question callback handling (disabled - SDK doesn't support AskUserQuestion response)
         # if self.ENABLE_ASK_USER_QUESTION and request.message.startswith("claude_question:"):
@@ -245,7 +246,7 @@ class ClaudeAgent(BaseAgent):
                     output=terminal_output_for(request),
                     terminal_error=diagnostic,
                 )
-                if handled and get_claude_client_returncode(client) is not None:
+                if handled and client is not None and get_claude_client_returncode(client) is not None:
                     # Auth recovery owns the visible settlement, but a query can
                     # fail after the cached CLI has already exited. Retire that
                     # runtime here so its client and Model Hub credential cannot
@@ -1870,6 +1871,8 @@ class ClaudeAgent(BaseAgent):
             eof_error = RuntimeError(terminal_error)
             error_notify = self._format_error_notify(eof_error, composite_key=composite_key)
             diagnostic = self._claude_error_diagnostic(composite_key, eof_error)
+            failure_context = getattr(pending_request, "context", context)
+            await self.record_model_hub_native_failure(failure_context, diagnostic)
             auth_handled = await self.controller.agent_auth_service.maybe_emit_auth_recovery_message(
                 context,
                 "claude",

--- a/modules/agents/claude_agent.py
+++ b/modules/agents/claude_agent.py
@@ -33,6 +33,7 @@ from modules.agents.claude_process_reaper import (
     get_claude_client_returncode,
     register_claude_owned_process,
 )
+from vibe.i18n import t as i18n_t
 
 from modules.agents.base import (
     AGENT_RUNTIME_TURN_KEY,
@@ -119,30 +120,25 @@ class ClaudeAgent(BaseAgent):
                 logger.debug("claude: failed to build error diagnostic", exc_info=True)
         return str(error)
 
+    def _translate_error(self, key: str, **kwargs) -> str:
+        translator = getattr(self.session_handler, "_t", None) or getattr(self.controller, "_t", None)
+        if callable(translator):
+            try:
+                return str(translator(key, **kwargs))
+            except Exception:
+                logger.debug("claude: failed to translate error notify", exc_info=True)
+        lang = getattr(getattr(self.controller, "config", None), "language", "en")
+        return str(i18n_t(key, lang, **kwargs))
+
     def _format_error_notify(self, error: Exception, *, composite_key: str | None = None) -> str:
         """Return the durable notify text for Claude terminal errors."""
         if is_claude_sdk_buffer_error(error):
-            translator = getattr(self.session_handler, "_t", None) or getattr(self.controller, "_t", None)
-            if callable(translator):
-                try:
-                    return f"❌ {translator('error.sessionConnectionLost')}"
-                except Exception:
-                    logger.debug("claude: failed to translate buffer-error notify", exc_info=True)
-            return "❌ Connection to Claude was lost. Please try your message again."
+            return f"❌ {self._translate_error('error.sessionConnectionLost')}"
         client = self.claude_sessions.get(composite_key) if composite_key else None
         returncode = get_claude_client_returncode(client)
         if returncode is not None:
             reason = claude_process_exit_reason(returncode)
-            translator = getattr(self.session_handler, "_t", None) or getattr(self.controller, "_t", None)
-            if callable(translator):
-                try:
-                    return f"❌ {translator('error.claudeProcessTerminated', reason=reason)}"
-                except Exception:
-                    logger.debug("claude: failed to translate process-termination notify", exc_info=True)
-            return (
-                f"❌ Claude Code process terminated ({reason}); the session was reset. "
-                "Please try your message again."
-            )
+            return f"❌ {self._translate_error('error.claudeProcessTerminated', reason=reason)}"
         return f"❌ Claude error: {error}"
 
     async def handle_message(self, request: AgentRequest) -> None:

--- a/modules/agents/claude_process_reaper.py
+++ b/modules/agents/claude_process_reaper.py
@@ -64,6 +64,18 @@ def claude_process_exit_reason(returncode: int) -> str:
     return f"exit code {returncode}"
 
 
+def claude_process_exit_reason_i18n(returncode: int) -> tuple[str, dict[str, str | int]]:
+    """Return the i18n key and values for a user-facing exit reason."""
+    if returncode < 0:
+        signal_number = -returncode
+        try:
+            signal_name = signal.Signals(signal_number).name
+        except ValueError:
+            signal_name = f"SIG{signal_number}"
+        return "error.claudeProcessSignal", {"signal": signal_name, "number": signal_number}
+    return "error.claudeProcessExitCode", {"code": returncode}
+
+
 def get_claude_client_stderr_tail(client: object | None) -> str:
     """Return the stderr ring buffer captured for a Claude SDK client."""
     lines = getattr(client, "_vibe_stderr_lines", None)

--- a/modules/agents/claude_process_reaper.py
+++ b/modules/agents/claude_process_reaper.py
@@ -42,6 +42,36 @@ def get_claude_client_pid(client: object | None) -> int | None:
     return pid if isinstance(pid, int) and pid > 0 else None
 
 
+def get_claude_client_returncode(client: object | None) -> int | None:
+    """Return the Claude CLI exit code once its subprocess has terminated."""
+    transport = getattr(client, "_transport", None)
+    process = getattr(transport, "_process", None)
+    returncode = getattr(process, "returncode", None)
+    if isinstance(returncode, bool) or not isinstance(returncode, int):
+        return None
+    return returncode
+
+
+def claude_process_exit_reason(returncode: int) -> str:
+    """Format a subprocess exit code for logs and user-facing diagnostics."""
+    if returncode < 0:
+        signal_number = -returncode
+        try:
+            signal_name = signal.Signals(signal_number).name
+        except ValueError:
+            signal_name = f"signal {signal_number}"
+        return f"{signal_name} (signal {signal_number})"
+    return f"exit code {returncode}"
+
+
+def get_claude_client_stderr_tail(client: object | None) -> str:
+    """Return the stderr ring buffer captured for a Claude SDK client."""
+    lines = getattr(client, "_vibe_stderr_lines", None)
+    if not isinstance(lines, (list, tuple)):
+        return ""
+    return "\n".join(str(line).strip() for line in lines if str(line).strip())
+
+
 def _process_start_time(pid: int) -> float | None:
     try:
         result = subprocess.run(

--- a/tests/test_agent_auth_service.py
+++ b/tests/test_agent_auth_service.py
@@ -199,6 +199,22 @@ class AgentAuthServiceTests(_IsolatedClaudeConfigDirMixin, unittest.IsolatedAsyn
         self.assertIn("/setup codex", persisted_text)  # actionable without a button
         self.assertNotIn("button", persisted_text.lower())  # no dangling button reference
 
+    async def test_maybe_emit_auth_recovery_message_classifies_terminal_diagnostic(self):
+        controller = _StubController()
+        service = AgentAuthService(controller)
+        context = MessageContext(user_id="U1", channel_id="C1")
+
+        with patch("core.message_mirror.persist_agent_message"):
+            handled = await service.maybe_emit_auth_recovery_message(
+                context,
+                "claude",
+                "❌ Claude Code 进程已终止；会话已重置，请重试。",
+                terminal_error="Cannot write to terminated process after OAuth login failed",
+            )
+
+        self.assertTrue(handled)
+        self.assertEqual(len(controller.im_client.sent_button_messages), 1)
+
     async def test_maybe_emit_auth_recovery_message_settles_turn_for_auth_error(self):
         # An AUTH error is handled here (reset button + persisted notify). The
         # recovery message is a button row, not a result, so this settles the

--- a/tests/test_claude_agent_sessions.py
+++ b/tests/test_claude_agent_sessions.py
@@ -1388,9 +1388,20 @@ class ClaudeAgentSessionTests(unittest.IsolatedAsyncioTestCase):
         controller.agent_auth_service.maybe_emit_auth_recovery_message = AsyncMock(return_value=True)
         controller._get_session_key = lambda context: "telegram::user::U1"
         agent = ClaudeAgent(controller)
-        agent.session_handler = SimpleNamespace(handle_session_error=AsyncMock())
+        composite_key = "session-1:/tmp/work"
+        failed_request = SimpleNamespace(
+            context=SimpleNamespace(platform_specific={"turn_token": "auth-turn"}),
+        )
+        agent._pending_requests[composite_key] = [failed_request]
+        controller.receiver_tasks[composite_key] = asyncio.current_task()
+        controller.claude_sessions[composite_key] = _StubClient()
+        agent.session_handler = SimpleNamespace(
+            handle_session_error=AsyncMock(),
+            cleanup_session=AsyncMock(),
+            claude_error_diagnostic=lambda _key, _error: "Claude process terminated: SIGABRT",
+        )
         agent._clear_pending_reactions = AsyncMock()
-        context = SimpleNamespace()
+        context = SimpleNamespace(platform_specific={})
 
         class _FailingClient:
             def receive_messages(self):
@@ -1406,6 +1417,50 @@ class ClaudeAgentSessionTests(unittest.IsolatedAsyncioTestCase):
 
         controller.agent_auth_service.maybe_emit_auth_recovery_message.assert_awaited_once()
         agent.session_handler.handle_session_error.assert_not_awaited()
+        agent.session_handler.cleanup_session.assert_awaited_once_with(
+            composite_key,
+            current_receiver_task=asyncio.current_task(),
+            activation_retired=False,
+        )
+        self.assertFalse(agent._pending_requests.get(composite_key))
+
+    async def test_receiver_eof_with_terminated_process_reports_localized_failure(self):
+        controller = _StubController()
+        controller.emit_agent_message = AsyncMock()
+        controller._get_session_key = lambda context: "telegram::user::U1"
+        agent = ClaudeAgent(controller)
+        composite_key = "session-eof:/tmp/work"
+        pending_request = SimpleNamespace(
+            context=SimpleNamespace(
+                platform_specific={
+                    "turn_token": "eof-turn",
+                    "agent_runtime_turn_token": "eof-runtime",
+                }
+            ),
+        )
+        agent._pending_requests[composite_key] = [pending_request]
+        agent._remove_specific_pending_reaction = AsyncMock()
+        agent._remove_ack_reaction = AsyncMock()
+        agent.session_handler = SimpleNamespace(
+            handle_session_error=AsyncMock(),
+            cleanup_session=AsyncMock(),
+            claude_error_diagnostic=lambda _key, _error: "Claude process terminated: SIGABRT",
+        )
+        controller.claude_sessions[composite_key] = SimpleNamespace(
+            _transport=SimpleNamespace(_process=SimpleNamespace(returncode=-6)),
+        )
+        controller.receiver_tasks[composite_key] = asyncio.current_task()
+
+        with patch("core.message_mirror.persist_agent_message") as persist:
+            await agent._handle_receiver_eof(composite_key, pending_request.context)
+
+        agent.session_handler.handle_session_error.assert_awaited_once()
+        agent.session_handler.cleanup_session.assert_not_awaited()
+        persist.assert_called_once()
+        self.assertIn("Claude Code process terminated", persist.call_args.args[2])
+        terminal_call = controller.emit_agent_message.await_args
+        self.assertIn("SIGABRT", terminal_call.kwargs["terminal_error"])
+        self.assertFalse(agent._pending_requests.get(composite_key))
 
     async def test_receiver_non_auth_error_settles_dot_and_persists(self):
         # A non-auth receiver error (connection loss, concurrent read, …) is NOT

--- a/tests/test_claude_agent_sessions.py
+++ b/tests/test_claude_agent_sessions.py
@@ -1035,6 +1035,62 @@ class ClaudeAgentSessionTests(unittest.IsolatedAsyncioTestCase):
             persist.call_args.kwargs["native_message_id"].startswith("backend-failure:")
         )
 
+    async def test_handle_message_terminated_auth_failure_cleans_cached_runtime(self):
+        controller = _StubController()
+        controller.agent_auth_service.maybe_emit_auth_recovery_message = AsyncMock(return_value=True)
+        runtime_key = "wechat_o9:reviewer:/tmp/work"
+        queued_request = SimpleNamespace()
+        client = SimpleNamespace(
+            query=AsyncMock(
+                side_effect=RuntimeError(
+                    "Failed to authenticate: OAuth login required",
+                )
+            ),
+            _transport=SimpleNamespace(_process=SimpleNamespace(returncode=-6)),
+            _vibe_runtime_base_session_id="wechat_o9:reviewer",
+            _vibe_runtime_session_key=runtime_key,
+        )
+        controller.session_handler = SimpleNamespace(
+            get_or_create_claude_session=AsyncMock(return_value=client),
+            mark_session_active=lambda _composite_key: None,
+            mark_session_idle=lambda _composite_key: None,
+            handle_session_error=AsyncMock(),
+            cleanup_session=AsyncMock(),
+            capture_session_id=lambda *_: None,
+        )
+        agent = ClaudeAgent(controller)
+        agent._prepare_message_with_files = lambda request: request.message
+        agent._delete_ack = AsyncMock()
+        agent._remove_ack_reaction = AsyncMock()
+        agent._pending_requests[runtime_key] = [queued_request]
+
+        request = SimpleNamespace(
+            context=SimpleNamespace(platform_specific={}),
+            message="hello",
+            working_path="/tmp/work",
+            base_session_id="wechat_o9",
+            composite_session_id="wechat_o9:/tmp/work",
+            session_key="wechat-user",
+            subagent_name=None,
+            subagent_model=None,
+            subagent_reasoning_effort=None,
+            ack_message_id=None,
+            ack_reaction_message_id="m1",
+            ack_reaction_emoji="eyes",
+            files=None,
+        )
+
+        await agent.handle_message(request)
+
+        controller.agent_auth_service.maybe_emit_auth_recovery_message.assert_awaited_once()
+        controller.session_handler.cleanup_session.assert_awaited_once_with(
+            runtime_key,
+            current_receiver_task=None,
+            activation_retired=False,
+        )
+        self.assertEqual(agent._pending_requests[runtime_key], [queued_request])
+        controller.session_handler.handle_session_error.assert_not_awaited()
+
     async def test_clear_sessions_cancels_receiver_tasks_for_cleared_session(self):
         controller = _StubController()
         agent = ClaudeAgent(controller)
@@ -1460,6 +1516,68 @@ class ClaudeAgentSessionTests(unittest.IsolatedAsyncioTestCase):
         self.assertIn("Claude Code process terminated", persist.call_args.args[2])
         terminal_call = controller.emit_agent_message.await_args
         self.assertIn("SIGABRT", terminal_call.kwargs["terminal_error"])
+        self.assertFalse(agent._pending_requests.get(composite_key))
+
+    async def test_receiver_eof_terminated_auth_adopts_turn_before_recovery(self):
+        controller = _StubController()
+        controller._get_session_key = lambda context: "telegram::user::U1"
+        recovery_contexts = []
+
+        async def _recover(context, *_args, **_kwargs):
+            recovery_contexts.append(context)
+            self.assertEqual(context.platform_specific["turn_token"], "eof-auth-turn")
+            self.assertEqual(
+                context.platform_specific["agent_runtime_turn_token"],
+                "eof-auth-runtime",
+            )
+            return True
+
+        controller.agent_auth_service.maybe_emit_auth_recovery_message = AsyncMock(
+            side_effect=_recover,
+        )
+        agent = ClaudeAgent(controller)
+        composite_key = "session-eof-auth:/tmp/work"
+        stale_context = SimpleNamespace(
+            platform_specific={
+                "turn_token": "old-turn",
+                "agent_runtime_turn_token": "old-runtime",
+            }
+        )
+        pending_request = SimpleNamespace(
+            context=SimpleNamespace(
+                platform_specific={
+                    "turn_token": "eof-auth-turn",
+                    "agent_runtime_turn_token": "eof-auth-runtime",
+                }
+            ),
+            ack_reaction_message_id=None,
+            ack_reaction_emoji=None,
+        )
+        agent._pending_requests[composite_key] = [pending_request]
+        agent._pending_reactions[composite_key] = [("m1", "eyes")]
+        agent._remove_ack_reaction = AsyncMock()
+        agent._clear_pending_reactions = AsyncMock()
+        agent.session_handler = SimpleNamespace(
+            handle_session_error=AsyncMock(),
+            cleanup_session=AsyncMock(),
+            claude_error_diagnostic=lambda _key, _error: (
+                "OAuth login failed; Claude process terminated: SIGABRT"
+            ),
+        )
+        controller.claude_sessions[composite_key] = SimpleNamespace(
+            _transport=SimpleNamespace(_process=SimpleNamespace(returncode=-6)),
+        )
+        controller.receiver_tasks[composite_key] = asyncio.current_task()
+
+        await agent._handle_receiver_eof(composite_key, stale_context)
+
+        self.assertEqual(recovery_contexts, [stale_context])
+        agent.session_handler.handle_session_error.assert_not_awaited()
+        agent.session_handler.cleanup_session.assert_awaited_once_with(
+            composite_key,
+            current_receiver_task=asyncio.current_task(),
+            activation_retired=False,
+        )
         self.assertFalse(agent._pending_requests.get(composite_key))
 
     async def test_receiver_non_auth_error_settles_dot_and_persists(self):

--- a/tests/test_claude_agent_sessions.py
+++ b/tests/test_claude_agent_sessions.py
@@ -133,6 +133,8 @@ class ClaudeAgentSessionTests(unittest.IsolatedAsyncioTestCase):
             _t=lambda key, **kwargs: (
                 f"process terminated: {kwargs['reason']}"
                 if key == "error.claudeProcessTerminated"
+                else f"{kwargs['signal']} (signal {kwargs['number']})"
+                if key == "error.claudeProcessSignal"
                 else key
             ),
         )
@@ -156,7 +158,7 @@ class ClaudeAgentSessionTests(unittest.IsolatedAsyncioTestCase):
         assert agent._format_error_notify(
             RuntimeError("Cannot write to terminated process (exit code: -6)"),
             composite_key=runtime_key,
-        ) == "❌ Claude Code 进程已终止（SIGABRT (signal 6)）；会话已重置，请重试。"
+        ) == "❌ Claude Code 进程已终止（SIGABRT（信号 6））；会话已重置，请重试。"
 
     async def test_handle_message_serializes_queries_for_same_runtime_session(self):
         controller = _StubController()

--- a/tests/test_claude_agent_sessions.py
+++ b/tests/test_claude_agent_sessions.py
@@ -143,6 +143,21 @@ class ClaudeAgentSessionTests(unittest.IsolatedAsyncioTestCase):
             composite_key=runtime_key,
         ) == "❌ process terminated: SIGABRT (signal 6)"
 
+    def test_process_termination_notify_uses_shared_i18n_fallback(self):
+        controller = _StubController()
+        controller.config.language = "zh"
+        runtime_key = "wechat_o9:/tmp/work"
+        controller.claude_sessions[runtime_key] = SimpleNamespace(
+            _transport=SimpleNamespace(_process=SimpleNamespace(returncode=-6)),
+        )
+        controller.session_handler = SimpleNamespace()
+        agent = ClaudeAgent(controller)
+
+        assert agent._format_error_notify(
+            RuntimeError("Cannot write to terminated process (exit code: -6)"),
+            composite_key=runtime_key,
+        ) == "❌ Claude Code 进程已终止（SIGABRT (signal 6)）；会话已重置，请重试。"
+
     async def test_handle_message_serializes_queries_for_same_runtime_session(self):
         controller = _StubController()
         runtime_key = "wechat_o9:/tmp/work"

--- a/tests/test_claude_agent_sessions.py
+++ b/tests/test_claude_agent_sessions.py
@@ -796,6 +796,41 @@ class ClaudeAgentSessionTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(observed_gate_current, [True])
         self.assertFalse(service._turn_gates[runtime_key].lock.locked())
 
+    async def test_setup_auth_failure_without_client_does_not_raise_unbound_client(self):
+        controller = _StubController()
+        controller.agent_auth_service.maybe_emit_auth_recovery_message = AsyncMock(return_value=True)
+        controller.session_handler = SimpleNamespace(
+            get_or_create_claude_session=AsyncMock(
+                side_effect=RuntimeError("OAuth login required"),
+            ),
+            mark_session_idle=lambda _key: None,
+            handle_session_error=AsyncMock(),
+            capture_session_id=lambda *_args, **_kwargs: None,
+        )
+        agent = ClaudeAgent(controller)
+        agent._delete_ack = AsyncMock()
+
+        request = SimpleNamespace(
+            context=SimpleNamespace(platform_specific={}),
+            message="hello",
+            working_path="/tmp/work",
+            base_session_id="wechat_o9",
+            composite_session_id="wechat_o9:/tmp/work",
+            session_key="wechat-user",
+            subagent_name=None,
+            subagent_model=None,
+            subagent_reasoning_effort=None,
+            ack_message_id=None,
+            ack_reaction_message_id=None,
+            ack_reaction_emoji=None,
+            files=None,
+        )
+
+        await agent.handle_message(request)
+
+        controller.agent_auth_service.maybe_emit_auth_recovery_message.assert_awaited_once()
+        controller.session_handler.handle_session_error.assert_not_awaited()
+
     async def test_result_keeps_claude_session_active_when_requests_are_queued(self):
         controller = _StubController()
         mark_idle_calls = []
@@ -1485,6 +1520,10 @@ class ClaudeAgentSessionTests(unittest.IsolatedAsyncioTestCase):
         controller.emit_agent_message = AsyncMock()
         controller._get_session_key = lambda context: "telegram::user::U1"
         agent = ClaudeAgent(controller)
+        settlement_order = []
+        agent.record_model_hub_native_failure = AsyncMock(
+            side_effect=lambda *_args: settlement_order.append("record")
+        )
         composite_key = "session-eof:/tmp/work"
         pending_request = SimpleNamespace(
             context=SimpleNamespace(
@@ -1498,7 +1537,9 @@ class ClaudeAgentSessionTests(unittest.IsolatedAsyncioTestCase):
         agent._remove_specific_pending_reaction = AsyncMock()
         agent._remove_ack_reaction = AsyncMock()
         agent.session_handler = SimpleNamespace(
-            handle_session_error=AsyncMock(),
+            handle_session_error=AsyncMock(
+                side_effect=lambda *_args: settlement_order.append("handle")
+            ),
             cleanup_session=AsyncMock(),
             claude_error_diagnostic=lambda _key, _error: "Claude process terminated: SIGABRT",
         )
@@ -1511,6 +1552,11 @@ class ClaudeAgentSessionTests(unittest.IsolatedAsyncioTestCase):
             await agent._handle_receiver_eof(composite_key, pending_request.context)
 
         agent.session_handler.handle_session_error.assert_awaited_once()
+        agent.record_model_hub_native_failure.assert_awaited_once_with(
+            pending_request.context,
+            "Claude process terminated: SIGABRT",
+        )
+        self.assertEqual(settlement_order, ["record", "handle"])
         agent.session_handler.cleanup_session.assert_not_awaited()
         persist.assert_called_once()
         self.assertIn("Claude Code process terminated", persist.call_args.args[2])

--- a/tests/test_claude_agent_sessions.py
+++ b/tests/test_claude_agent_sessions.py
@@ -123,6 +123,26 @@ class ClaudeAgentSessionTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(terminal_call.kwargs["level"], "silent")
         self.assertEqual(terminal_call.kwargs["terminal_error"], diagnostic)
 
+    def test_process_termination_notify_is_localized(self):
+        controller = _StubController()
+        runtime_key = "wechat_o9:/tmp/work"
+        controller.claude_sessions[runtime_key] = SimpleNamespace(
+            _transport=SimpleNamespace(_process=SimpleNamespace(returncode=-6)),
+        )
+        controller.session_handler = SimpleNamespace(
+            _t=lambda key, **kwargs: (
+                f"process terminated: {kwargs['reason']}"
+                if key == "error.claudeProcessTerminated"
+                else key
+            ),
+        )
+        agent = ClaudeAgent(controller)
+
+        assert agent._format_error_notify(
+            RuntimeError("Cannot write to terminated process (exit code: -6)"),
+            composite_key=runtime_key,
+        ) == "❌ process terminated: SIGABRT (signal 6)"
+
     async def test_handle_message_serializes_queries_for_same_runtime_session(self):
         controller = _StubController()
         runtime_key = "wechat_o9:/tmp/work"

--- a/tests/test_claude_cli_path.py
+++ b/tests/test_claude_cli_path.py
@@ -565,6 +565,47 @@ def test_session_handler_reuses_cached_claude_client_when_system_prompt_is_uncha
     assert "slack/U456" not in first_client.options.system_prompt["append"]
 
 
+def test_session_handler_recreates_terminated_cached_client_before_dispatch(
+    monkeypatch,
+    tmp_path: Path,
+    caplog,
+) -> None:
+    captured: dict[str, Any] = {"clients": []}
+
+    class _StubClaudeSDKClient:
+        def __init__(self, options):
+            self.options = options
+            self.disconnects = 0
+            self._transport = SimpleNamespace(_process=SimpleNamespace(returncode=None))
+            captured["clients"].append(self)
+
+        async def connect(self) -> None:
+            return None
+
+        async def disconnect(self) -> None:
+            self.disconnects += 1
+
+    monkeypatch.setattr(session_handler_module, "ClaudeAgentOptions", _StubClaudeAgentOptions)
+    monkeypatch.setattr(session_handler_module, "ClaudeSDKClient", _StubClaudeSDKClient)
+
+    controller = _Controller(tmp_path)
+    handler = SessionHandler(controller)
+    context = MessageContext(user_id="U123", channel_id="C123")
+    composite_key = f"slack_C123:{tmp_path}"
+
+    first_client = _run_session(handler, context)
+    first_client._transport._process.returncode = -6
+    first_client._vibe_stderr_lines.extend(["fatal: Claude CLI aborted", "transport closed"])
+    second_client = _run_session(handler, context)
+
+    assert first_client is not second_client
+    assert first_client.disconnects == 1
+    assert controller.claude_sessions[composite_key] is second_client
+    assert len(captured["clients"]) == 2
+    assert "SIGABRT (signal 6)" in caplog.text
+    assert "Claude stderr tail:\nfatal: Claude CLI aborted\ntransport closed" in caplog.text
+
+
 def test_session_handler_marks_claude_sdk_session_process_owner(monkeypatch, tmp_path: Path) -> None:
     captured: dict[str, Any] = {}
     registered: list[dict[str, Any]] = []
@@ -1177,6 +1218,65 @@ def test_session_handler_reuses_cached_claude_subagent_after_ensuring_caller_env
     assert len(captured["clients"]) == 1
     assert first_client.options.env["AVIBE_SESSION_ID"] == "ses-subagent"
     assert second_context.platform_specific["agent_session_id"] == "ses-subagent"
+
+
+def test_session_handler_recreates_terminated_cached_subagent_before_dispatch(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    captured: dict[str, Any] = {"clients": []}
+
+    class _RoutingSessions(_Sessions):
+        @staticmethod
+        def get_agent_session_id(settings_key, base_session_id, agent_name):
+            return None
+
+        @staticmethod
+        def ensure_agent_session_id(settings_key, agent_name, base_session_id, **_kwargs):
+            return "ses-subagent"
+
+    class _RoutingSettingsManager(_SettingsManager):
+        def __init__(self) -> None:
+            super().__init__()
+            self.sessions = _RoutingSessions()
+
+        @staticmethod
+        def get_channel_routing(settings_key):
+            return type("Routing", (), {"claude_agent": "reviewer", "model": None, "reasoning_effort": None})()
+
+    class _StubClaudeSDKClient:
+        def __init__(self, options):
+            self.options = options
+            self.disconnects = 0
+            self._transport = SimpleNamespace(_process=SimpleNamespace(returncode=None))
+            captured["clients"].append(self)
+
+        async def connect(self) -> None:
+            return None
+
+        async def disconnect(self) -> None:
+            self.disconnects += 1
+
+    monkeypatch.setattr(session_handler_module, "ClaudeAgentOptions", _StubClaudeAgentOptions)
+    monkeypatch.setattr(session_handler_module, "ClaudeSDKClient", _StubClaudeSDKClient)
+
+    controller = _Controller(tmp_path)
+    controller.settings_manager = _RoutingSettingsManager()
+    controller.platform_settings_managers = {"slack": controller.settings_manager}
+    handler = SessionHandler(controller)
+    context = MessageContext(
+        user_id="U123",
+        channel_id="C123",
+        platform_specific={"routing_subagent": "reviewer", "task_trigger_kind": "agent_run"},
+    )
+
+    first_client = _run_session(handler, context)
+    first_client._transport._process.returncode = -6
+    second_client = _run_session(handler, context)
+
+    assert first_client is not second_client
+    assert first_client.disconnects == 1
+    assert len(captured["clients"]) == 2
 
 
 def test_session_handler_updates_cached_claude_model_only_when_changed(monkeypatch, tmp_path: Path) -> None:

--- a/tests/test_claude_cli_path.py
+++ b/tests/test_claude_cli_path.py
@@ -597,6 +597,7 @@ def test_session_handler_recreates_terminated_cached_client_before_dispatch(
     composite_key = f"slack_C123:{tmp_path}"
 
     first_client = _run_session(handler, context)
+    first_client.options.stderr("sandbox warning")
     first_client._transport._process.returncode = -6
     first_client._vibe_stderr_lines.extend(["fatal: Claude CLI aborted", "transport closed"])
     second_client = _run_session(handler, context)
@@ -607,7 +608,74 @@ def test_session_handler_recreates_terminated_cached_client_before_dispatch(
     assert len(captured["clients"]) == 2
     idle_wait.assert_awaited_once_with(composite_key)
     assert "SIGABRT (signal 6)" in caplog.text
-    assert "Claude stderr tail:\nfatal: Claude CLI aborted\ntransport closed" in caplog.text
+    assert "Claude CLI stderr for slack_C123:" in caplog.text
+    assert "Claude stderr tail:\nsandbox warning\nfatal: Claude CLI aborted\ntransport closed" in caplog.text
+
+
+def test_session_handler_waits_for_receiver_cleanup_before_evicting_dead_client(
+    tmp_path: Path,
+) -> None:
+    async def exercise() -> None:
+        controller = _Controller(tmp_path)
+        handler = SessionHandler(controller)
+        composite_key = f"slack_C123:{tmp_path}"
+        cleanup_started = asyncio.Event()
+        release_cleanup = asyncio.Event()
+
+        async def receiver() -> None:
+            cleanup_started.set()
+            await release_cleanup.wait()
+
+        receiver_task = asyncio.create_task(receiver())
+        await cleanup_started.wait()
+        handler.receiver_tasks[composite_key] = receiver_task
+        client = SimpleNamespace(
+            _transport=SimpleNamespace(_process=SimpleNamespace(returncode=-6)),
+        )
+        handler.claude_sessions[composite_key] = client
+        handler._cleanup_session_locked = AsyncMock()
+        handler._wait_for_claude_session_idle = AsyncMock()
+
+        eviction = asyncio.create_task(
+            handler._evict_terminated_cached_claude_session(composite_key, client)
+        )
+        await asyncio.sleep(0)
+        assert not eviction.done()
+        release_cleanup.set()
+        assert await eviction is True
+        handler._cleanup_session_locked.assert_awaited_once_with(
+            composite_key,
+            retire_model_hub_scope=True,
+        )
+        handler._wait_for_claude_session_idle.assert_awaited_once_with(composite_key)
+        await receiver_task
+
+    asyncio.run(exercise())
+
+
+def test_session_handler_retires_model_hub_scope_for_dead_cached_client(
+    tmp_path: Path,
+) -> None:
+    async def exercise() -> None:
+        controller = _Controller(tmp_path)
+        handler = SessionHandler(controller)
+        composite_key = f"slack_C123:{tmp_path}"
+        client = SimpleNamespace(
+            _transport=SimpleNamespace(_process=SimpleNamespace(returncode=1)),
+            _vibe_model_hub_fingerprint="hub:http://127.0.0.1:18443:token",
+        )
+        handler.claude_sessions[composite_key] = client
+        handler._wait_for_claude_receiver_cleanup = AsyncMock()
+        handler._wait_for_claude_session_idle = AsyncMock()
+        handler._cleanup_session_locked = AsyncMock()
+
+        assert await handler._evict_terminated_cached_claude_session(composite_key, client)
+        handler._cleanup_session_locked.assert_awaited_once_with(
+            composite_key,
+            retire_model_hub_scope=True,
+        )
+
+    asyncio.run(exercise())
 
 
 def test_session_handler_marks_claude_sdk_session_process_owner(monkeypatch, tmp_path: Path) -> None:

--- a/tests/test_claude_cli_path.py
+++ b/tests/test_claude_cli_path.py
@@ -7,6 +7,7 @@ import sys
 import threading
 from types import SimpleNamespace
 from typing import Any
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -590,6 +591,8 @@ def test_session_handler_recreates_terminated_cached_client_before_dispatch(
 
     controller = _Controller(tmp_path)
     handler = SessionHandler(controller)
+    idle_wait = AsyncMock()
+    handler._wait_for_claude_session_idle = idle_wait
     context = MessageContext(user_id="U123", channel_id="C123")
     composite_key = f"slack_C123:{tmp_path}"
 
@@ -602,6 +605,7 @@ def test_session_handler_recreates_terminated_cached_client_before_dispatch(
     assert first_client.disconnects == 1
     assert controller.claude_sessions[composite_key] is second_client
     assert len(captured["clients"]) == 2
+    idle_wait.assert_awaited_once_with(composite_key)
     assert "SIGABRT (signal 6)" in caplog.text
     assert "Claude stderr tail:\nfatal: Claude CLI aborted\ntransport closed" in caplog.text
 

--- a/tests/test_claude_cli_path.py
+++ b/tests/test_claude_cli_path.py
@@ -612,42 +612,57 @@ def test_session_handler_recreates_terminated_cached_client_before_dispatch(
     assert "Claude stderr tail:\nsandbox warning\nfatal: Claude CLI aborted\ntransport closed" in caplog.text
 
 
-def test_session_handler_waits_for_receiver_cleanup_before_evicting_dead_client(
+def test_session_handler_waits_for_receiver_cleanup_outside_generation_lock(
+    monkeypatch,
     tmp_path: Path,
 ) -> None:
+    captured: dict[str, Any] = {"clients": []}
+
     async def exercise() -> None:
         controller = _Controller(tmp_path)
         handler = SessionHandler(controller)
         composite_key = f"slack_C123:{tmp_path}"
-        cleanup_started = asyncio.Event()
         release_cleanup = asyncio.Event()
 
+        class _StubClaudeSDKClient:
+            def __init__(self, options):
+                self.options = options
+                self.disconnects = 0
+                self._transport = SimpleNamespace(_process=SimpleNamespace(returncode=None))
+                captured["clients"].append(self)
+
+            async def connect(self) -> None:
+                return None
+
+            async def disconnect(self) -> None:
+                self.disconnects += 1
+
+        monkeypatch.setattr(session_handler_module, "ClaudeAgentOptions", _StubClaudeAgentOptions)
+        monkeypatch.setattr(session_handler_module, "ClaudeSDKClient", _StubClaudeSDKClient)
+        context = MessageContext(user_id="U123", channel_id="C123")
+        first_client = await handler.get_or_create_claude_session(context)
+        first_client._transport._process.returncode = -6
+
         async def receiver() -> None:
-            cleanup_started.set()
             await release_cleanup.wait()
+            await handler.cleanup_session(
+                composite_key,
+                current_receiver_task=asyncio.current_task(),
+            )
 
         receiver_task = asyncio.create_task(receiver())
-        await cleanup_started.wait()
         handler.receiver_tasks[composite_key] = receiver_task
-        client = SimpleNamespace(
-            _transport=SimpleNamespace(_process=SimpleNamespace(returncode=-6)),
-        )
-        handler.claude_sessions[composite_key] = client
-        handler._cleanup_session_locked = AsyncMock()
-        handler._wait_for_claude_session_idle = AsyncMock()
 
         eviction = asyncio.create_task(
-            handler._evict_terminated_cached_claude_session(composite_key, client)
+            handler.get_or_create_claude_session(context)
         )
         await asyncio.sleep(0)
         assert not eviction.done()
         release_cleanup.set()
-        assert await eviction is True
-        handler._cleanup_session_locked.assert_awaited_once_with(
-            composite_key,
-            retire_model_hub_scope=True,
-        )
-        handler._wait_for_claude_session_idle.assert_awaited_once_with(composite_key)
+        second_client = await asyncio.wait_for(eviction, timeout=1)
+        assert second_client is not first_client
+        assert first_client.disconnects == 1
+        assert len(captured["clients"]) == 2
         await receiver_task
 
     asyncio.run(exercise())

--- a/tests/test_claude_process_reaper.py
+++ b/tests/test_claude_process_reaper.py
@@ -2,8 +2,28 @@ import asyncio
 import logging
 import os
 import signal
+from types import SimpleNamespace
 
 from modules.agents import claude_process_reaper
+
+
+def test_claude_process_state_helpers_report_signal_and_stderr_tail():
+    client = SimpleNamespace(
+        _transport=SimpleNamespace(_process=SimpleNamespace(returncode=-signal.SIGABRT)),
+        _vibe_stderr_lines=["first", "", "fatal Claude error"],
+    )
+
+    assert claude_process_reaper.get_claude_client_returncode(client) == -6
+    assert claude_process_reaper.claude_process_exit_reason(-6) == "SIGABRT (signal 6)"
+    assert claude_process_reaper.get_claude_client_stderr_tail(client) == "first\nfatal Claude error"
+
+
+def test_claude_process_state_helpers_ignore_running_process():
+    client = SimpleNamespace(
+        _transport=SimpleNamespace(_process=SimpleNamespace(returncode=None)),
+    )
+
+    assert claude_process_reaper.get_claude_client_returncode(client) is None
 
 
 def test_find_claude_resume_processes_matches_exact_resume_id(monkeypatch):

--- a/tests/test_claude_process_reaper.py
+++ b/tests/test_claude_process_reaper.py
@@ -15,6 +15,10 @@ def test_claude_process_state_helpers_report_signal_and_stderr_tail():
 
     assert claude_process_reaper.get_claude_client_returncode(client) == -6
     assert claude_process_reaper.claude_process_exit_reason(-6) == "SIGABRT (signal 6)"
+    assert claude_process_reaper.claude_process_exit_reason_i18n(-6) == (
+        "error.claudeProcessSignal",
+        {"signal": "SIGABRT", "number": 6},
+    )
     assert claude_process_reaper.get_claude_client_stderr_tail(client) == "first\nfatal Claude error"
 
 

--- a/tests/test_session_handler_base_id.py
+++ b/tests/test_session_handler_base_id.py
@@ -4,6 +4,7 @@ import asyncio
 from dataclasses import dataclass
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
@@ -404,3 +405,44 @@ def test_claude_sdk_buffer_error_cleans_up_broken_session() -> None:
     assert len(controller.im_client.sent_messages) == 1
     _, message = controller.im_client.sent_messages[0]
     assert message == "ERR:Connection to Claude was lost. Please try your message again."
+
+
+def test_claude_terminated_process_cleans_up_and_reports_signal_diagnostic() -> None:
+    controller = _Controller(platform="slack", dm_threads=False)
+    controller.im_client = _FakeIM()
+    handler = SessionHandler(controller)
+    composite_key = "slack_C123:/tmp/workdir"
+    controller.claude_sessions[composite_key] = SimpleNamespace(
+        _transport=SimpleNamespace(_process=SimpleNamespace(returncode=-6)),
+        _vibe_stderr_lines=["fatal: Claude CLI aborted", "transport closed"],
+    )
+    cleanup_calls = []
+
+    async def _cleanup_session(key: str, *, current_receiver_task=None) -> None:
+        cleanup_calls.append((key, current_receiver_task))
+
+    handler.cleanup_session = _cleanup_session
+    context = MessageContext(user_id="U123", channel_id="C123", platform="slack")
+
+    asyncio.run(
+        handler.handle_session_error(
+            composite_key,
+            context,
+            RuntimeError("Cannot write to terminated process (exit code: -6)"),
+        )
+    )
+
+    assert len(cleanup_calls) == 1
+    assert cleanup_calls[0][0] == composite_key
+    assert cleanup_calls[0][1] is not None
+    _, message = controller.im_client.sent_messages[0]
+    assert message == (
+        "ERR:Claude Code process terminated (SIGABRT (signal 6)); "
+        "the session was reset. Please try your message again."
+    )
+    diagnostic = handler.claude_error_diagnostic(
+        composite_key,
+        RuntimeError("Cannot write to terminated process (exit code: -6)"),
+    )
+    assert "Claude process terminated: SIGABRT (signal 6)" in diagnostic
+    assert "Claude stderr tail:\nfatal: Claude CLI aborted\ntransport closed" in diagnostic

--- a/vibe/i18n/en.json
+++ b/vibe/i18n/en.json
@@ -289,6 +289,8 @@
     "streamTurnInProgress": "⚠️ A reply is already streaming for this session — wait for it to finish, then try again.",
     "sessionReset": "Session error detected. Session has been reset. Please try your message again.",
     "sessionConnectionLost": "Connection to Claude was lost. Please try your message again.",
+    "claudeProcessSignal": "{signal} (signal {number})",
+    "claudeProcessExitCode": "exit code {code}",
     "claudeProcessTerminated": "Claude Code process terminated ({reason}); the session was reset. Please try your message again.",
     "claudeCredentialTypeInvalid": "Choose either API key or auth token for the Claude Code credential.",
     "claudeSessionNotFound": "Claude Code could not find the historical session `{sessionId}` in the current working directory:\n`{path}`\n\nClaude Code sessions are scoped to a working directory. This usually means the conversation was resumed after switching workdirs, or the local Claude Code session data changed. Switch back to the original working directory to continue that session, or start a new Claude Code session from the current directory.",

--- a/vibe/i18n/en.json
+++ b/vibe/i18n/en.json
@@ -289,6 +289,7 @@
     "streamTurnInProgress": "⚠️ A reply is already streaming for this session — wait for it to finish, then try again.",
     "sessionReset": "Session error detected. Session has been reset. Please try your message again.",
     "sessionConnectionLost": "Connection to Claude was lost. Please try your message again.",
+    "claudeProcessTerminated": "Claude Code process terminated ({reason}); the session was reset. Please try your message again.",
     "claudeCredentialTypeInvalid": "Choose either API key or auth token for the Claude Code credential.",
     "claudeSessionNotFound": "Claude Code could not find the historical session `{sessionId}` in the current working directory:\n`{path}`\n\nClaude Code sessions are scoped to a working directory. This usually means the conversation was resumed after switching workdirs, or the local Claude Code session data changed. Switch back to the original working directory to continue that session, or start a new Claude Code session from the current directory.",
     "sessionGeneric": "An error occurred: {error}",

--- a/vibe/i18n/zh.json
+++ b/vibe/i18n/zh.json
@@ -289,6 +289,7 @@
     "streamTurnInProgress": "⚠️ 这个会话已经有一条回复在生成中，请等它完成后再试。",
     "sessionReset": "检测到会话错误。会话已重置，请重试。",
     "sessionConnectionLost": "与 Claude 的连接已断开，请重试。",
+    "claudeProcessTerminated": "Claude Code 进程已终止（{reason}）；会话已重置，请重试。",
     "claudeCredentialTypeInvalid": "Claude Code 凭据类型只能选择 API Key 或 Auth Token。",
     "claudeSessionNotFound": "Claude Code 在当前工作目录下找不到历史会话 `{sessionId}`：\n`{path}`\n\nClaude Code 的会话和工作目录相关。通常是恢复会话后切换了工作目录，或本地 Claude Code 会话数据发生变化。请切回原来的工作目录继续该会话，或在当前目录开始一个新的 Claude Code 会话。",
     "sessionGeneric": "发生错误：{error}",

--- a/vibe/i18n/zh.json
+++ b/vibe/i18n/zh.json
@@ -289,6 +289,8 @@
     "streamTurnInProgress": "⚠️ 这个会话已经有一条回复在生成中，请等它完成后再试。",
     "sessionReset": "检测到会话错误。会话已重置，请重试。",
     "sessionConnectionLost": "与 Claude 的连接已断开，请重试。",
+    "claudeProcessSignal": "{signal}（信号 {number}）",
+    "claudeProcessExitCode": "退出码 {code}",
     "claudeProcessTerminated": "Claude Code 进程已终止（{reason}）；会话已重置，请重试。",
     "claudeCredentialTypeInvalid": "Claude Code 凭据类型只能选择 API Key 或 Auth Token。",
     "claudeSessionNotFound": "Claude Code 在当前工作目录下找不到历史会话 `{sessionId}`：\n`{path}`\n\nClaude Code 的会话和工作目录相关。通常是恢复会话后切换了工作目录，或本地 Claude Code 会话数据发生变化。请切回原来的工作目录继续该会话，或在当前目录开始一个新的 Claude Code 会话。",


### PR DESCRIPTION
## Capability
Recover Claude sessions after the Claude Code CLI subprocess exits during a turn.

## Root cause
A cached Claude SDK client could remain in claude_sessions after the CLI exited with a negative signal return code. The next query reused that dead client, while the captured stderr ring buffer was no longer available for diagnosis.

## Scenarios
No cataloged scenario ID applies to this backend transport failure. Regression coverage is added for SIGABRT detection, cached-session cleanup, stderr diagnostics, and localized durable notifications.

## Evidence
- Unit: process exit-code and stderr-tail helper tests.
- Contract: dead clients are evicted before the next retry; signal reason is localized and technical stderr remains in diagnostics.
- Scenario: focused Claude session, process reaper, and i18n parity tests pass.
- Residual manual: a live Incus/Claude SIGABRT replay was not run; the deterministic transport fixture covers the acceptance path.

## Dependencies
None.

## Known by design
The user-facing message exposes only the signal reason and reset guidance. The SDK error and stderr tail remain in terminal diagnostics and logs.
