### PR TITLE
fix(codex): keep visible result after silent follow-up

### DIFF
--- a/modules/agents/codex/event_handler.py
+++ b/modules/agents/codex/event_handler.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Any
 
 from vibe.i18n import t as i18n_t
 from core.backend_failure import emit_backend_failure
+from core.reply_enhancer import strip_silent_blocks
 
 if TYPE_CHECKING:
     from modules.agents.base import AgentRequest
@@ -242,9 +243,10 @@ class CodexEventHandler:
         if item_type == "agentMessage":
             text = item.get("text", "")
             if text:
-                # Emit previous pending message as assistant, buffer this one
                 prev = turn_state.pending_assistant if turn_state else None
-                if prev:
+                text_is_visible = bool(strip_silent_blocks(text).strip())
+                prev_is_visible = bool(prev and strip_silent_blocks(prev[0]).strip())
+                if text_is_visible and prev_is_visible:
                     prev_text, prev_pm = prev
                     await self._agent.controller.emit_agent_message(
                         request.context,
@@ -252,7 +254,9 @@ class CodexEventHandler:
                         prev_text,
                         parse_mode=prev_pm or "markdown",
                     )
-                if turn_state:
+                # A silent terminal response may settle the turn, but it must
+                # not displace an earlier visible result candidate.
+                if turn_state and (text_is_visible or not prev_is_visible):
                     turn_state.pending_assistant = (text, "markdown")
 
         elif item_type == "commandExecution":

--- a/tests/test_codex_event_handler.py
+++ b/tests/test_codex_event_handler.py
@@ -414,6 +414,121 @@ class CodexEventHandlerTests(unittest.IsolatedAsyncioTestCase):
 
         agent.controller.emit_agent_message.assert_not_awaited()
 
+    async def test_silent_followup_preserves_visible_result_candidate(self):
+        agent = _StubAgent()
+        handler = CodexEventHandler(agent)
+        request = SimpleNamespace(base_session_id="session-1", context=object(), started_at=0)
+        agent._turn_registry.register_turn("turn-1", request)
+
+        await handler._on_item_completed(
+            {
+                "turnId": "turn-1",
+                "item": {"type": "agentMessage", "text": "Regression report"},
+            },
+            request,
+        )
+        await handler._on_item_completed(
+            {
+                "turnId": "turn-1",
+                "item": {"type": "agentMessage", "text": "<silent>Watch acknowledged</silent>"},
+            },
+            request,
+        )
+        await handler._on_turn_completed(
+            {"turn": {"id": "turn-1", "status": "completed"}},
+            request,
+        )
+
+        agent.controller.emit_agent_message.assert_not_awaited()
+        agent.emit_result_message.assert_awaited_once()
+        assert agent.emit_result_message.await_args.args[1] == "Regression report"
+
+    async def test_visible_followup_replaces_silent_candidate_without_activity(self):
+        agent = _StubAgent()
+        handler = CodexEventHandler(agent)
+        request = SimpleNamespace(base_session_id="session-1", context=object(), started_at=0)
+        agent._turn_registry.register_turn("turn-1", request)
+
+        await handler._on_item_completed(
+            {
+                "turnId": "turn-1",
+                "item": {"type": "agentMessage", "text": "<silent>Waiting</silent>"},
+            },
+            request,
+        )
+        await handler._on_item_completed(
+            {
+                "turnId": "turn-1",
+                "item": {"type": "agentMessage", "text": "Final answer"},
+            },
+            request,
+        )
+        await handler._on_turn_completed(
+            {"turn": {"id": "turn-1", "status": "completed"}},
+            request,
+        )
+
+        agent.controller.emit_agent_message.assert_not_awaited()
+        agent.emit_result_message.assert_awaited_once()
+        assert agent.emit_result_message.await_args.args[1] == "Final answer"
+
+    async def test_silent_only_turn_still_emits_terminal_result(self):
+        agent = _StubAgent()
+        handler = CodexEventHandler(agent)
+        request = SimpleNamespace(base_session_id="session-1", context=object(), started_at=0)
+        agent._turn_registry.register_turn("turn-1", request)
+
+        silent_result = "<silent>No user-facing response needed</silent>"
+        await handler._on_item_completed(
+            {
+                "turnId": "turn-1",
+                "item": {"type": "agentMessage", "text": silent_result},
+            },
+            request,
+        )
+        await handler._on_turn_completed(
+            {"turn": {"id": "turn-1", "status": "completed"}},
+            request,
+        )
+
+        agent.controller.emit_agent_message.assert_not_awaited()
+        agent.emit_result_message.assert_awaited_once()
+        assert agent.emit_result_message.await_args.args[1] == silent_result
+
+    async def test_visible_followup_keeps_prior_visible_message_as_activity(self):
+        agent = _StubAgent()
+        handler = CodexEventHandler(agent)
+        request = SimpleNamespace(base_session_id="session-1", context=object(), started_at=0)
+        agent._turn_registry.register_turn("turn-1", request)
+
+        await handler._on_item_completed(
+            {
+                "turnId": "turn-1",
+                "item": {"type": "agentMessage", "text": "Progress update"},
+            },
+            request,
+        )
+        await handler._on_item_completed(
+            {
+                "turnId": "turn-1",
+                "item": {"type": "agentMessage", "text": "Final answer"},
+            },
+            request,
+        )
+        await handler._on_turn_completed(
+            {"turn": {"id": "turn-1", "status": "completed"}},
+            request,
+        )
+
+        agent.controller.emit_agent_message.assert_awaited_once_with(
+            request.context,
+            "assistant",
+            "Progress update",
+            parse_mode="markdown",
+        )
+        agent.emit_result_message.assert_awaited_once()
+        assert agent.emit_result_message.await_args.args[1] == "Final answer"
+
     async def test_empty_success_result_falls_back_to_new_thread_generated_images(self):
         agent = _StubAgent()
         handler = CodexEventHandler(agent)


### PR DESCRIPTION
## Summary

- Keep the latest visible Codex `agentMessage` as the terminal Result when a later all-silent message arrives in the same native turn.
- Preserve silent-only turn settlement and the existing visible-to-visible Activity/Result split.
- Reuse the shared Markdown-aware silent-block parser so literal control examples remain visible.

## Root cause

The Codex adapter assumed the newest `agentMessage` was always the final user-visible answer. A late P1 follow-up could produce an all-silent message in the same native turn, which demoted the earlier visible answer to Activity and then settled the durable Turn with an empty Result.

## Evidence

- Unit: 229 relevant tests passed, plus 7 subtests.
- Contract: added coverage for visible-to-silent, silent-to-visible, silent-only, and visible-to-visible result selection.
- Scenario IDs: none; the scenario catalog has no Codex adapter result-classification capability.
- Lint: Ruff passed for the changed production and test files.
- Residual manual: no live native P1-steer reproduction was run; host Avibe, regression state, and Cloud pairing were not touched.
