### PR TITLE
fix(auth): probe backends through Agent transports

### DIFF
--- a/config/v2_compat.py
+++ b/config/v2_compat.py
@@ -70,6 +70,7 @@ class AppCompatConfig:
     log_level: str
     ack_mode: str
     language: str
+    default_cwd: str
     platforms: dict = field(default_factory=lambda: {"enabled": ["slack"], "primary": "slack"})
     discord: Optional[DiscordConfig] = None
     telegram: Optional[TelegramConfig] = None
@@ -158,6 +159,7 @@ def to_app_config(v2: V2Config) -> AppCompatConfig:
         log_level=v2.runtime.log_level,
         ack_mode=v2.ack_mode,
         language=v2.language,
+        default_cwd=v2.runtime.default_cwd,
         show_duration=v2.show_duration,
         include_time_info=v2.include_time_info,
         include_user_info=v2.include_user_info,

--- a/core/agent_auth_service.py
+++ b/core/agent_auth_service.py
@@ -505,8 +505,8 @@ class AgentAuthService:
         cli_path = getattr(backend_cfg, "cli_path", None) or getattr(backend_cfg, "binary", None)
         return cli_path or backend
 
-    def _resolve_backend_probe_cwd(self, backend: str) -> str:
-        """Return the default runtime cwd for an isolated backend Agent probe."""
+    def _resolve_backend_probe_cwd(self, backend: str, *, prepare: bool = False) -> str:
+        """Resolve the configured runtime cwd without mutating it by default."""
         config = getattr(getattr(self, "controller", None), "config", None)
         candidates = (
             getattr(self._resolve_backend_config(backend), "cwd", None),
@@ -516,6 +516,8 @@ class AgentAuthService:
         for raw in candidates:
             if isinstance(raw, str) and raw.strip():
                 path = os.path.abspath(os.path.expanduser(raw.strip()))
+                if not prepare:
+                    return path
                 try:
                     os.makedirs(path, exist_ok=True)
                     return path
@@ -2248,7 +2250,10 @@ class AgentAuthService:
             return {"ok": False, "error": "unsupported_backend"}
 
         binary = self._get_cli_binary(backend)
-        probe_cwd = self._resolve_backend_probe_cwd(backend)
+        probe_cwd = self._resolve_backend_probe_cwd(
+            backend,
+            prepare=backend == "claude",
+        )
         auth_mode = None
         if backend == "claude":
             backend_cfg = self._resolve_backend_config("claude")
@@ -2452,9 +2457,13 @@ class AgentAuthService:
         on_diagnostic: Callable[[str], None] | None = None,
     ) -> str:
         """Reuse a matching direct runtime, or own a temporary direct runtime."""
+        from config import paths
         from config.v2_compat import CodexCompatConfig
         from config.v2_config import DEFAULT_AGENT_IDLE_TIMEOUT_SECONDS
-        from modules.agents.codex import CodexConnectionProbeRuntimeMismatchError
+        from modules.agents.codex import (
+            CODEX_CONNECTION_PROBE_DIR,
+            CodexConnectionProbeRuntimeMismatchError,
+        )
 
         backend_cfg = self._resolve_backend_config("codex")
         runtime_config = CodexCompatConfig(
@@ -2495,9 +2504,10 @@ class AgentAuthService:
                 pass
 
         probe_agent = self._create_codex_probe_agent(runtime_config)
+        isolated_cwd = str(paths.get_runtime_dir() / CODEX_CONNECTION_PROBE_DIR)
         try:
             return await probe_agent.probe_connection(
-                cwd,
+                isolated_cwd,
                 model=model,
                 on_diagnostic=on_diagnostic,
             )

--- a/core/agent_auth_service.py
+++ b/core/agent_auth_service.py
@@ -23,6 +23,7 @@ from modules.claude_sdk_compat import (
 from modules.agents.claude_process_reaper import (
     AVIBE_CLAUDE_AUTH_OWNER,
     AVIBE_CLAUDE_PROCESS_OWNER_ENV,
+    _reap_pid_set,
     get_claude_client_pid,
     register_claude_owned_process,
 )
@@ -53,10 +54,11 @@ OPENCODE_API_KEY_PROMPT_RE = re.compile(r"enteryourapikey", re.IGNORECASE)
 OPENCODE_CREDENTIAL_COUNT_RE = re.compile(r"\b(\d+)\s+credential(?:s)?\b", re.IGNORECASE)
 CLAUDE_LOGIN_METHODS = {"claudeai", "console"}
 OPENCODE_DIRECT_SETUP_URLS = {"opencode": "https://opencode.ai/auth"}
+CLAUDE_PROBE_DISCONNECT_TIMEOUT_SECONDS = 3.0
 
 
 def _pick_probe_response_excerpt(stdout_text: str) -> str:
-    """Return the first content-bearing line from Codex/Claude probe stdout.
+    """Return the first content-bearing line from a backend probe response.
 
     The CLIs emit decorations the user doesn't care about: warnings
     (``warning:``, ``ERROR:``, bubblewrap notices), session
@@ -110,7 +112,7 @@ def _classify_test_failure(
     *,
     auth_mode: str | None = None,
 ) -> str:
-    """Map a backend CLI's failure output to a specific UI error code.
+    """Map a backend runtime's failure output to a specific UI error code.
 
     The Settings → Backends "Test connection" panel routes the returned
     ``error`` string into an i18n key (``settings.backends.testFailure*``),
@@ -491,17 +493,11 @@ class AgentAuthService:
         cli_path = getattr(backend_cfg, "cli_path", None) or getattr(backend_cfg, "binary", None)
         return cli_path or backend
 
-    def _resolve_claude_probe_cwd(self) -> str:
-        """Return the cwd that a Settings Claude probe should execute in.
-
-        Plain ``claude -p`` loads project hooks, MCP config, and CLAUDE.md from
-        the process cwd. Use the same default runtime cwd as live Agent turns so
-        the Settings test reflects the actual Claude runtime instead of the UI
-        server launch directory.
-        """
+    def _resolve_backend_probe_cwd(self, backend: str) -> str:
+        """Return the default runtime cwd for an isolated backend Agent probe."""
         config = getattr(getattr(self, "controller", None), "config", None)
         candidates = (
-            getattr(self._resolve_backend_config("claude"), "cwd", None),
+            getattr(self._resolve_backend_config(backend), "cwd", None),
             getattr(getattr(config, "runtime", None), "default_cwd", None),
         )
         for raw in candidates:
@@ -511,7 +507,7 @@ class AgentAuthService:
                     os.makedirs(path, exist_ok=True)
                     return path
                 except OSError as exc:
-                    logger.warning("Failed to prepare Claude Settings probe cwd=%s: %s", path, exc)
+                    logger.warning("Failed to prepare %s Settings probe cwd=%s: %s", backend, path, exc)
         return os.getcwd()
 
     def _build_claude_full_subprocess_env(self, *, force_oauth: bool = False) -> dict[str, str]:
@@ -2229,45 +2225,19 @@ class AgentAuthService:
         timeout: float = 45.0,
         model: str | None = None,
     ) -> dict[str, Any]:
-        """Send a 1-token probe ("Hi") through the backend CLI.
+        """Send ``Hi`` through the backend's production Agent transport.
 
-        Validates both the credentials and the endpoint (when ``base_url``
-        is configured) by running ``claude --print "Hi"`` /
-        ``codex exec "Hi"``. Returns elapsed milliseconds + a short
-        response excerpt on success; surfaces stderr on failure.
-
-        ``model`` overrides the CLI's configured default — useful for
-        users whose ``config.toml`` selects a slow reasoning model
-        (e.g. ``gpt-5.4`` with ``model_reasoning_effort=xhigh``) where
-        even "Hi" can take minutes to round-trip. The frontend's Test
-        panel exposes a small select pre-filled from the routing
-        catalog so the user can probe a specific model.
+        Claude uses the Agent SDK stream and Codex uses app-server JSON-RPC,
+        matching normal Avibe turns. OpenCode keeps its provider-scoped probe
+        because it already uses the live ``opencode serve`` session API.
         """
-        # remove_web_auth and test_web_auth are claude / codex specific
-        # (single-backend subprocess invocations). OpenCode uses the
-        # per-provider DELETE / dedicated probe endpoints elsewhere.
         if backend not in {"claude", "codex"}:
             return {"ok": False, "error": "unsupported_backend"}
 
         binary = self._get_cli_binary(backend)
-        prompt = "Hi"
-        probe_cwd = None
+        probe_cwd = self._resolve_backend_probe_cwd(backend)
         auth_mode = None
         if backend == "claude":
-            probe_cwd = self._resolve_claude_probe_cwd()
-            # ``-p`` switches Claude Code into non-interactive print mode
-            # and exits after the first complete reply. Deliberately do
-            # not pass ``--bare`` here: recent Claude Code builds document
-            # that bare mode skips OAuth/keychain reads and only accepts
-            # API-key auth. This Settings probe should answer the user's
-            # real question: whether the current Avibe Claude setup can
-            # run an Agent turn. It follows the normal print-mode launch
-            # path used by live Claude sessions.
-            cmd = [binary]
-            cmd.append("-p")
-            if isinstance(model, str) and model.strip():
-                cmd.extend(["--model", model.strip()])
-            cmd.append(prompt)
             backend_cfg = self._resolve_backend_config("claude")
             auth_mode = getattr(backend_cfg, "auth_mode", None)
             auth_mode_set = bool(getattr(backend_cfg, "auth_mode_set", False))
@@ -2276,124 +2246,254 @@ class AgentAuthService:
                     await self._clear_claude_settings_env_for_oauth()
                 except Exception as err:  # noqa: BLE001
                     return {"ok": False, "error": "settings_cleanup_failed", "detail": str(err)}
-            try:
-                env_override = self._build_claude_full_subprocess_env()
-            except Exception as err:  # noqa: BLE001
-                if auth_mode == "oauth" and auth_mode_set:
-                    return {"ok": False, "error": "spawn_failed", "detail": str(err)}
-                env_override = dict(os.environ)
-        else:
-            # Codex single-shot mode. ``--skip-git-repo-check`` bypasses
-            # Codex's per-project trust gate. We also force
-            # ``model_reasoning_effort=low`` so a config.toml that
-            # selects ``xhigh`` reasoning (deep thinking + 30 s+ for any
-            # prompt) doesn't blow past our 45 s test timeout — the
-            # probe is "auth + endpoint reachable", not "exercise the
-            # reasoning chain". ``-c key=value`` overrides config.toml
-            # entries per invocation.
-            #
-            # NOT ``minimal``: OpenAI's Responses API rejects ``minimal``
-            # reasoning when ``image_gen`` / ``web_search`` tools are
-            # attached (which Codex auto-attaches for chat models with
-            # no override flag to disable). The 400 reads ``"The
-            # following tools cannot be used with reasoning.effort
-            # 'minimal'"``. ``low`` is described in the model catalog
-            # as "Fast responses with lighter reasoning" — still fast
-            # enough for a probe, compatible with all tool sets.
-            cmd = [
-                binary,
-                "exec",
-                "--skip-git-repo-check",
-                "-c",
-                "model_reasoning_effort=low",
-            ]
-            if isinstance(model, str) and model.strip():
-                cmd.extend(["-c", f"model={model.strip()}"])
-            cmd.append(prompt)
-            env_override = dict(os.environ)
 
         started = time.monotonic()
         try:
-            process = await asyncio.create_subprocess_exec(
-                *cmd,
-                # Close stdin explicitly — Codex's ``exec`` mode reads a
-                # second prompt from stdin when the parent's stdin is
-                # open (e.g. ``codex exec "Hi" < /dev/null`` works fine,
-                # but inheriting an open stdin makes it block forever).
-                stdin=asyncio.subprocess.DEVNULL,
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE,
-                env=env_override,
-                cwd=probe_cwd,
+            run_probe = (
+                self._run_claude_agent_probe
+                if backend == "claude"
+                else self._run_codex_agent_probe
             )
-            try:
-                stdout, stderr = await asyncio.wait_for(process.communicate(), timeout=timeout)
-            except asyncio.TimeoutError:
-                # Drain whatever the CLI managed to emit before we kill it
-                # so we can still classify the failure. Codex in particular
-                # retries 401 / network errors several times before exit;
-                # the killed-mid-retry case loses the real error code if we
-                # just report ``timed_out``. Read with a tight wait so the
-                # kill path stays fast.
-                process.kill()
-                partial_stdout = b""
-                partial_stderr = b""
-                try:
-                    partial_stdout, partial_stderr = await asyncio.wait_for(
-                        process.communicate(), timeout=3.0
-                    )
-                except (asyncio.TimeoutError, Exception):  # noqa: BLE001
-                    pass
-                stdout_partial = (partial_stdout or b"").decode("utf-8", errors="replace").strip()
-                stderr_partial = (partial_stderr or b"").decode("utf-8", errors="replace").strip()
-                classified = _classify_test_failure(
-                    stdout_partial,
-                    stderr_partial,
-                    auth_mode=auth_mode,
-                )
-                result = {
-                    "ok": False,
-                    "error": classified if classified != "cli_failed" else "timed_out",
-                    "duration_ms": int((time.monotonic() - started) * 1000),
-                }
-                if stderr_partial or stdout_partial:
-                    result["detail"] = (stderr_partial or stdout_partial)[:600]
-                return result
+            response_text = await asyncio.wait_for(
+                run_probe(binary=binary, cwd=probe_cwd, model=model),
+                timeout=timeout,
+            )
+        except asyncio.TimeoutError:
+            return {
+                "ok": False,
+                "error": "timed_out",
+                "duration_ms": int((time.monotonic() - started) * 1000),
+            }
         except FileNotFoundError:
             return {"ok": False, "error": "cli_not_found", "detail": binary}
         except Exception as err:  # noqa: BLE001
-            return {"ok": False, "error": "spawn_failed", "detail": str(err)}
-
-        duration_ms = int((time.monotonic() - started) * 1000)
-        stdout_text = (stdout or b"").decode("utf-8", errors="replace").strip()
-        stderr_text = (stderr or b"").decode("utf-8", errors="replace").strip()
-
-        if process.returncode != 0:
-            classified = _classify_test_failure(
-                stdout_text,
-                stderr_text,
-                auth_mode=auth_mode,
-            )
+            detail = str(err).strip()
+            if "no such file or directory" in detail.lower() or "claude code not found" in detail.lower():
+                error = "cli_not_found"
+            else:
+                error = _classify_test_failure("", detail, auth_mode=auth_mode)
             return {
                 "ok": False,
-                "error": classified,
-                "exit_code": process.returncode,
-                "detail": (stderr_text or stdout_text)[:600],
-                "duration_ms": duration_ms,
+                "error": error,
+                "detail": detail[:600],
+                "duration_ms": int((time.monotonic() - started) * 1000),
             }
 
-        # Pick the model's actual response out of chatty CLI output.
-        # Codex in particular prepends a session header, a "codex"
-        # label line, "tokens used" footer, ``Reconnecting...`` retry
-        # warnings, and bubblewrap notices — the first non-blank line
-        # would always be a warning or label. Skip known non-content
-        # lines and take the first remaining one as the excerpt.
-        excerpt = _pick_probe_response_excerpt(stdout_text)
         return {
             "ok": True,
-            "duration_ms": duration_ms,
-            "excerpt": excerpt,
+            "duration_ms": int((time.monotonic() - started) * 1000),
+            "excerpt": _pick_probe_response_excerpt(response_text),
         }
+
+    async def _run_claude_agent_probe(
+        self,
+        *,
+        binary: str,
+        cwd: str,
+        model: str | None,
+    ) -> str:
+        """Run an isolated turn through the same Claude Agent SDK transport."""
+        from modules.agents.model_hub import claude_setting_sources_for_launch
+        from vibe.claude_config import build_claude_subprocess_env
+
+        stderr_lines: list[str] = []
+
+        def capture_stderr(line: str) -> None:
+            text = (line or "").strip()
+            if text:
+                stderr_lines.append(text)
+                del stderr_lines[:-40]
+
+        claude_env = build_claude_subprocess_env(self._resolve_backend_config("claude"))
+        claude_env[AVIBE_CLAUDE_PROCESS_OWNER_ENV] = AVIBE_CLAUDE_AUTH_OWNER
+        option_kwargs: dict[str, Any] = {
+            "permission_mode": "bypassPermissions",
+            "cwd": cwd,
+            "setting_sources": claude_setting_sources_for_launch(None),
+            "sandbox": {"enabled": False},
+            "tools": [],
+            "max_turns": 1,
+            "env": claude_env,
+            "stderr": capture_stderr,
+            "max_buffer_size": CLAUDE_SDK_MAX_BUFFER_SIZE,
+        }
+        if binary and binary != "claude":
+            option_kwargs["cli_path"] = os.path.expanduser(binary)
+        if isinstance(model, str) and model.strip():
+            option_kwargs["extra_args"] = {"model": model.strip()}
+
+        client = ClaudeSDKClient(options=ClaudeAgentOptions(**option_kwargs))
+        assistant_text = ""
+        assistant_error = ""
+        terminal_text = ""
+        try:
+            await client.connect()
+            register_claude_owned_process(client, owner=AVIBE_CLAUDE_AUTH_OWNER)
+            governor_from_controller(self.controller).apply_to_pid(
+                get_claude_client_pid(client),
+                label="claude connection probe",
+            )
+            await client.query("Hi")
+            async for message in client.receive_response():
+                content = getattr(message, "content", None)
+                if isinstance(content, list):
+                    text_parts = [
+                        str(getattr(block, "text", "")).strip()
+                        for block in content
+                        if str(getattr(block, "text", "")).strip()
+                    ]
+                    if text_parts:
+                        assistant_text = "\n".join(text_parts)
+                message_error = getattr(message, "error", None)
+                if message_error:
+                    assistant_error = str(message_error)
+                if hasattr(message, "is_error"):
+                    result_text = str(getattr(message, "result", "") or "").strip()
+                    if bool(getattr(message, "is_error", False)):
+                        errors = getattr(message, "errors", None)
+                        detail_parts = [result_text, assistant_error]
+                        if isinstance(errors, list):
+                            detail_parts.extend(str(item) for item in errors if item)
+                        detail = "; ".join(part for part in detail_parts if part)
+                        raise RuntimeError(detail or "Claude Agent turn failed")
+                    if result_text:
+                        terminal_text = result_text
+            if terminal_text:
+                return terminal_text
+            if assistant_error:
+                raise RuntimeError(assistant_error)
+            if assistant_text:
+                return assistant_text
+            raise RuntimeError("Claude Agent turn returned no response")
+        except Exception as err:
+            detail = str(err).strip()
+            stderr = "\n".join(stderr_lines).strip()
+            if stderr and stderr not in detail:
+                raise RuntimeError(f"{detail}\n{stderr}".strip()) from err
+            raise
+        finally:
+            await self._disconnect_claude_probe_client(client)
+
+    async def _disconnect_claude_probe_client(self, client: ClaudeSDKClient) -> None:
+        """Bound probe cleanup so a wedged SDK disconnect cannot defeat its timeout."""
+        pid = get_claude_client_pid(client)
+        try:
+            await asyncio.wait_for(
+                self._disconnect_claude_client(client),
+                timeout=CLAUDE_PROBE_DISCONNECT_TIMEOUT_SECONDS,
+            )
+        except asyncio.TimeoutError:
+            logger.warning("Claude connection probe did not disconnect within the cleanup timeout")
+            if pid:
+                await _reap_pid_set({pid}, terminate_timeout=2.0, logger=logger)
+
+    async def _run_codex_agent_probe(
+        self,
+        *,
+        binary: str,
+        cwd: str,
+        model: str | None,
+    ) -> str:
+        """Run an isolated turn through the normal Codex app-server protocol."""
+        from modules.agents.codex.transport import CodexTransport
+
+        backend_cfg = self._resolve_backend_config("codex")
+        transport = CodexTransport(
+            binary=binary,
+            cwd=cwd,
+            extra_args=list(getattr(backend_cfg, "extra_args", None) or []),
+        )
+        terminal: asyncio.Future[tuple[str, str]] = asyncio.get_running_loop().create_future()
+        response_text = ""
+
+        async def on_notification(method: str, params: dict[str, Any]) -> None:
+            nonlocal response_text
+            if method == "item/completed":
+                item = params.get("item") if isinstance(params, dict) else None
+                if isinstance(item, dict) and item.get("type") == "agentMessage":
+                    text = str(item.get("text") or "").strip()
+                    if text:
+                        response_text = text
+                return
+            if method == "error":
+                if params.get("willRetry") is True:
+                    return
+                error = params.get("error") if isinstance(params, dict) else params
+                detail = error.get("message") if isinstance(error, dict) else str(error or "Codex error")
+                if not terminal.done():
+                    terminal.set_result(("error", detail))
+                return
+            if method != "turn/completed":
+                return
+            turn = params.get("turn") if isinstance(params, dict) else None
+            status = turn.get("status") if isinstance(turn, dict) else None
+            if status == "failed":
+                error = turn.get("error") if isinstance(turn, dict) else None
+                detail = error.get("message") if isinstance(error, dict) else str(error or "Codex turn failed")
+                if not terminal.done():
+                    terminal.set_result(("error", detail))
+            elif status == "interrupted":
+                if not terminal.done():
+                    terminal.set_result(("error", "Codex turn was interrupted"))
+            elif status == "completed":
+                if not terminal.done():
+                    terminal.set_result(("success", response_text))
+            elif not terminal.done():
+                terminal.set_result(("error", f"Codex turn ended with status: {status or 'unknown'}"))
+
+        async def on_server_request(
+            _request_id: int | str,
+            _method: str,
+            _params: dict[str, Any],
+        ) -> dict[str, Any]:
+            return {"approved": True}
+
+        transport.on_notification(on_notification)
+        transport.on_server_request(on_server_request)
+        try:
+            await transport.start()
+            governor_from_controller(self.controller).apply_to_pid(
+                transport.pid,
+                label="codex connection probe",
+            )
+            thread_response = await transport.send_request(
+                "thread/start",
+                {
+                    "cwd": cwd,
+                    "approvalPolicy": "never",
+                    "sandbox": "danger-full-access",
+                },
+            )
+            thread = thread_response.get("thread")
+            thread_id = thread_response.get("id") or (
+                thread.get("id") if isinstance(thread, dict) else None
+            )
+            if not thread_id:
+                raise RuntimeError("Codex thread/start returned no thread id")
+            turn_params: dict[str, Any] = {
+                "threadId": thread_id,
+                "input": [{"type": "text", "text": "Hi"}],
+                "approvalPolicy": "never",
+                "sandboxPolicy": {"type": "dangerFullAccess"},
+                "effort": "low",
+            }
+            if isinstance(model, str) and model.strip():
+                turn_params["model"] = model.strip()
+            turn_response = await transport.send_request("turn/start", turn_params)
+            turn = turn_response.get("turn")
+            turn_id = turn_response.get("id") or (
+                turn.get("id") if isinstance(turn, dict) else None
+            )
+            if not turn_id:
+                raise RuntimeError("Codex turn/start returned no turn id")
+            outcome, result = await terminal
+            if outcome == "error":
+                raise RuntimeError(result)
+            if not result.strip():
+                raise RuntimeError("Codex Agent turn returned no response")
+            return result
+        finally:
+            await transport.stop()
 
     async def test_opencode_provider(
         self,

--- a/core/agent_auth_service.py
+++ b/core/agent_auth_service.py
@@ -55,6 +55,7 @@ OPENCODE_CREDENTIAL_COUNT_RE = re.compile(r"\b(\d+)\s+credential(?:s)?\b", re.IG
 CLAUDE_LOGIN_METHODS = {"claudeai", "console"}
 OPENCODE_DIRECT_SETUP_URLS = {"opencode": "https://opencode.ai/auth"}
 CLAUDE_PROBE_DISCONNECT_TIMEOUT_SECONDS = 3.0
+CLAUDE_PROBE_PROCESS_EXIT_GRACE_SECONDS = 0.2
 
 
 def _pick_probe_response_excerpt(stdout_text: str) -> str:
@@ -2249,15 +2250,15 @@ class AgentAuthService:
 
         started = time.monotonic()
         try:
-            run_probe = (
-                self._run_claude_agent_probe
-                if backend == "claude"
-                else self._run_codex_agent_probe
-            )
-            response_text = await asyncio.wait_for(
-                run_probe(binary=binary, cwd=probe_cwd, model=model),
-                timeout=timeout,
-            )
+            if backend == "claude":
+                probe = self._run_claude_agent_probe(
+                    binary=binary,
+                    cwd=probe_cwd,
+                    model=model,
+                )
+            else:
+                probe = self._run_codex_agent_probe(cwd=probe_cwd, model=model)
+            response_text = await asyncio.wait_for(probe, timeout=timeout)
         except asyncio.TimeoutError:
             return {
                 "ok": False,
@@ -2384,116 +2385,42 @@ class AgentAuthService:
             )
         except asyncio.TimeoutError:
             logger.warning("Claude connection probe did not disconnect within the cleanup timeout")
-            if pid:
-                await _reap_pid_set({pid}, terminate_timeout=2.0, logger=logger)
+        if not pid:
+            return
+
+        transport = getattr(client, "_transport", None)
+        process = getattr(transport, "_process", None)
+        wait = getattr(process, "wait", None)
+        if callable(wait):
+            try:
+                await asyncio.wait_for(
+                    wait(),
+                    timeout=CLAUDE_PROBE_PROCESS_EXIT_GRACE_SECONDS,
+                )
+                return
+            except asyncio.TimeoutError:
+                pass
+            except Exception:  # noqa: BLE001
+                logger.debug(
+                    "Claude connection probe process wait failed; reaping by pid",
+                    exc_info=True,
+                )
+        await _reap_pid_set({pid}, terminate_timeout=2.0, logger=logger)
 
     async def _run_codex_agent_probe(
         self,
         *,
-        binary: str,
         cwd: str,
         model: str | None,
     ) -> str:
-        """Run an isolated turn through the normal Codex app-server protocol."""
-        from modules.agents.codex.transport import CodexTransport
-
-        backend_cfg = self._resolve_backend_config("codex")
-        transport = CodexTransport(
-            binary=binary,
-            cwd=cwd,
-            extra_args=list(getattr(backend_cfg, "extra_args", None) or []),
-        )
-        terminal: asyncio.Future[tuple[str, str]] = asyncio.get_running_loop().create_future()
-        response_text = ""
-
-        async def on_notification(method: str, params: dict[str, Any]) -> None:
-            nonlocal response_text
-            if method == "item/completed":
-                item = params.get("item") if isinstance(params, dict) else None
-                if isinstance(item, dict) and item.get("type") == "agentMessage":
-                    text = str(item.get("text") or "").strip()
-                    if text:
-                        response_text = text
-                return
-            if method == "error":
-                if params.get("willRetry") is True:
-                    return
-                error = params.get("error") if isinstance(params, dict) else params
-                detail = error.get("message") if isinstance(error, dict) else str(error or "Codex error")
-                if not terminal.done():
-                    terminal.set_result(("error", detail))
-                return
-            if method != "turn/completed":
-                return
-            turn = params.get("turn") if isinstance(params, dict) else None
-            status = turn.get("status") if isinstance(turn, dict) else None
-            if status == "failed":
-                error = turn.get("error") if isinstance(turn, dict) else None
-                detail = error.get("message") if isinstance(error, dict) else str(error or "Codex turn failed")
-                if not terminal.done():
-                    terminal.set_result(("error", detail))
-            elif status == "interrupted":
-                if not terminal.done():
-                    terminal.set_result(("error", "Codex turn was interrupted"))
-            elif status == "completed":
-                if not terminal.done():
-                    terminal.set_result(("success", response_text))
-            elif not terminal.done():
-                terminal.set_result(("error", f"Codex turn ended with status: {status or 'unknown'}"))
-
-        async def on_server_request(
-            _request_id: int | str,
-            _method: str,
-            _params: dict[str, Any],
-        ) -> dict[str, Any]:
-            return {"approved": True}
-
-        transport.on_notification(on_notification)
-        transport.on_server_request(on_server_request)
-        try:
-            await transport.start()
-            governor_from_controller(self.controller).apply_to_pid(
-                transport.pid,
-                label="codex connection probe",
-            )
-            thread_response = await transport.send_request(
-                "thread/start",
-                {
-                    "cwd": cwd,
-                    "approvalPolicy": "never",
-                    "sandbox": "danger-full-access",
-                },
-            )
-            thread = thread_response.get("thread")
-            thread_id = thread_response.get("id") or (
-                thread.get("id") if isinstance(thread, dict) else None
-            )
-            if not thread_id:
-                raise RuntimeError("Codex thread/start returned no thread id")
-            turn_params: dict[str, Any] = {
-                "threadId": thread_id,
-                "input": [{"type": "text", "text": "Hi"}],
-                "approvalPolicy": "never",
-                "sandboxPolicy": {"type": "dangerFullAccess"},
-                "effort": "low",
-            }
-            if isinstance(model, str) and model.strip():
-                turn_params["model"] = model.strip()
-            turn_response = await transport.send_request("turn/start", turn_params)
-            turn = turn_response.get("turn")
-            turn_id = turn_response.get("id") or (
-                turn.get("id") if isinstance(turn, dict) else None
-            )
-            if not turn_id:
-                raise RuntimeError("Codex turn/start returned no turn id")
-            outcome, result = await terminal
-            if outcome == "error":
-                raise RuntimeError(result)
-            if not result.strip():
-                raise RuntimeError("Codex Agent turn returned no response")
-            return result
-        finally:
-            await transport.stop()
+        """Run through the controller-owned CodexAgent transport pool."""
+        agent_service = getattr(self.controller, "agent_service", None)
+        agents = getattr(agent_service, "agents", None)
+        agent = agents.get("codex") if isinstance(agents, dict) else None
+        probe = getattr(agent, "probe_connection", None)
+        if not callable(probe):
+            raise RuntimeError("Codex Agent runtime is unavailable")
+        return await probe(cwd, model=model)
 
     async def test_opencode_provider(
         self,

--- a/core/agent_auth_service.py
+++ b/core/agent_auth_service.py
@@ -491,6 +491,17 @@ class AgentAuthService:
         # flows ignore a non-default cli_path and fall through to
         # ``$PATH``, breaking installs that pin a specific binary.
         backend_cfg = self._resolve_backend_config(backend)
+        if backend_cfg is None:
+            try:
+                from config.v2_config import V2Config
+
+                backend_cfg = getattr(V2Config.load().agents, backend, None)
+            except Exception:  # noqa: BLE001
+                logger.debug(
+                    "Failed to load persisted %s config for Settings probe",
+                    backend,
+                    exc_info=True,
+                )
         cli_path = getattr(backend_cfg, "cli_path", None) or getattr(backend_cfg, "binary", None)
         return cli_path or backend
 
@@ -500,6 +511,7 @@ class AgentAuthService:
         candidates = (
             getattr(self._resolve_backend_config(backend), "cwd", None),
             getattr(getattr(config, "runtime", None), "default_cwd", None),
+            getattr(config, "default_cwd", None),
         )
         for raw in candidates:
             if isinstance(raw, str) and raw.strip():
@@ -2249,22 +2261,41 @@ class AgentAuthService:
                     return {"ok": False, "error": "settings_cleanup_failed", "detail": str(err)}
 
         started = time.monotonic()
+        diagnostics: list[str] = []
+
+        def record_diagnostic(detail: str) -> None:
+            text = str(detail or "").strip()
+            if text:
+                diagnostics.append(text)
+                del diagnostics[:-40]
+
         try:
             if backend == "claude":
                 probe = self._run_claude_agent_probe(
                     binary=binary,
                     cwd=probe_cwd,
                     model=model,
+                    on_diagnostic=record_diagnostic,
                 )
             else:
-                probe = self._run_codex_agent_probe(cwd=probe_cwd, model=model)
+                probe = self._run_codex_agent_probe(
+                    binary=binary,
+                    cwd=probe_cwd,
+                    model=model,
+                    on_diagnostic=record_diagnostic,
+                )
             response_text = await asyncio.wait_for(probe, timeout=timeout)
         except asyncio.TimeoutError:
-            return {
+            detail = "\n".join(diagnostics).strip()
+            classified = _classify_test_failure("", detail, auth_mode=auth_mode)
+            result: dict[str, Any] = {
                 "ok": False,
-                "error": "timed_out",
+                "error": classified if classified != "cli_failed" else "timed_out",
                 "duration_ms": int((time.monotonic() - started) * 1000),
             }
+            if detail:
+                result["detail"] = detail[:600]
+            return result
         except FileNotFoundError:
             return {"ok": False, "error": "cli_not_found", "detail": binary}
         except Exception as err:  # noqa: BLE001
@@ -2292,6 +2323,7 @@ class AgentAuthService:
         binary: str,
         cwd: str,
         model: str | None,
+        on_diagnostic: Callable[[str], None] | None = None,
     ) -> str:
         """Run an isolated turn through the same Claude Agent SDK transport."""
         from modules.agents.model_hub import claude_setting_sources_for_launch
@@ -2304,6 +2336,8 @@ class AgentAuthService:
             if text:
                 stderr_lines.append(text)
                 del stderr_lines[:-40]
+                if on_diagnostic is not None:
+                    on_diagnostic(text)
 
         claude_env = build_claude_subprocess_env(self._resolve_backend_config("claude"))
         claude_env[AVIBE_CLAUDE_PROCESS_OWNER_ENV] = AVIBE_CLAUDE_AUTH_OWNER
@@ -2348,6 +2382,8 @@ class AgentAuthService:
                 message_error = getattr(message, "error", None)
                 if message_error:
                     assistant_error = str(message_error)
+                    if on_diagnostic is not None:
+                        on_diagnostic(assistant_error)
                 if hasattr(message, "is_error"):
                     result_text = str(getattr(message, "result", "") or "").strip()
                     if bool(getattr(message, "is_error", False)):
@@ -2410,17 +2446,79 @@ class AgentAuthService:
     async def _run_codex_agent_probe(
         self,
         *,
+        binary: str,
         cwd: str,
         model: str | None,
+        on_diagnostic: Callable[[str], None] | None = None,
     ) -> str:
-        """Run through the controller-owned CodexAgent transport pool."""
+        """Reuse a matching direct runtime, or own a temporary direct runtime."""
+        from config.v2_compat import CodexCompatConfig
+        from config.v2_config import DEFAULT_AGENT_IDLE_TIMEOUT_SECONDS
+        from modules.agents.codex import CodexConnectionProbeRuntimeMismatchError
+
+        backend_cfg = self._resolve_backend_config("codex")
+        runtime_config = CodexCompatConfig(
+            enabled=bool(getattr(backend_cfg, "enabled", True)),
+            binary=binary,
+            extra_args=list(getattr(backend_cfg, "extra_args", None) or []),
+            idle_timeout_seconds=int(
+                getattr(
+                    backend_cfg,
+                    "idle_timeout_seconds",
+                    DEFAULT_AGENT_IDLE_TIMEOUT_SECONDS,
+                )
+            ),
+            auth_mode=str(getattr(backend_cfg, "auth_mode", "oauth") or "oauth"),
+        )
         agent_service = getattr(self.controller, "agent_service", None)
         agents = getattr(agent_service, "agents", None)
         agent = agents.get("codex") if isinstance(agents, dict) else None
         probe = getattr(agent, "probe_connection", None)
-        if not callable(probe):
-            raise RuntimeError("Codex Agent runtime is unavailable")
-        return await probe(cwd, model=model)
+        can_reuse = getattr(agent, "can_reuse_direct_connection_probe", None)
+        live_config = getattr(agent, "codex_config", None)
+        live_matches = live_config is None or (
+            str(getattr(live_config, "binary", "")) == runtime_config.binary
+            and list(getattr(live_config, "extra_args", None) or [])
+            == runtime_config.extra_args
+            and str(getattr(live_config, "auth_mode", "oauth") or "oauth")
+            == runtime_config.auth_mode
+        )
+        direct_runtime = not callable(can_reuse) or bool(can_reuse(cwd))
+        if callable(probe) and live_matches and direct_runtime:
+            try:
+                return await probe(
+                    cwd,
+                    model=model,
+                    on_diagnostic=on_diagnostic,
+                )
+            except CodexConnectionProbeRuntimeMismatchError:
+                pass
+
+        probe_agent = self._create_codex_probe_agent(runtime_config)
+        try:
+            return await probe_agent.probe_connection(
+                cwd,
+                model=model,
+                on_diagnostic=on_diagnostic,
+            )
+        finally:
+            try:
+                await probe_agent.shutdown_runtime()
+            except Exception:  # noqa: BLE001
+                logger.warning(
+                    "Failed to stop controller-owned Codex probe runtime",
+                    exc_info=True,
+                )
+
+    def _create_codex_probe_agent(self, runtime_config: Any) -> Any:
+        """Create an unregistered CodexAgent whose runtime this service owns."""
+        from modules.agents.codex import CodexAgent
+
+        return CodexAgent(
+            self.controller,
+            runtime_config,
+            registered_runtime=False,
+        )
 
     async def test_opencode_provider(
         self,

--- a/core/internal_server.py
+++ b/core/internal_server.py
@@ -709,6 +709,39 @@ def create_app(controller: "Controller") -> FastAPI:
             logger.exception("internal Agent backend reconcile failed")
             return JSONResponse(status_code=500, content={"ok": False, "error": str(exc)})
 
+    @app.post("/internal/backend-auth/test")
+    async def _test_backend_auth(request: Request) -> Any:
+        """Probe credentials through the controller-owned Agent runtime."""
+        payload = await _safe_json(request)
+        backend = payload.get("backend")
+        model = payload.get("model")
+        if not isinstance(backend, str) or not backend.strip():
+            return JSONResponse(
+                status_code=400,
+                content={"ok": False, "error": "backend must be a non-empty string"},
+            )
+        if model is not None and not isinstance(model, str):
+            return JSONResponse(
+                status_code=400,
+                content={"ok": False, "error": "model must be a string"},
+            )
+        service = getattr(controller, "agent_auth_service", None)
+        test = getattr(service, "test_web_auth", None)
+        if not callable(test):
+            return JSONResponse(
+                status_code=503,
+                content={"ok": False, "error": "backend_runtime_unavailable"},
+            )
+        try:
+            result = await test(
+                backend.strip().lower(),
+                model=model.strip() if isinstance(model, str) and model.strip() else None,
+            )
+            return JSONResponse(status_code=200, content=result)
+        except Exception as exc:
+            logger.exception("internal backend auth test failed")
+            return JSONResponse(status_code=500, content={"ok": False, "error": str(exc)})
+
     @app.post("/internal/model-hub")
     async def _model_hub(request: Request) -> Any:
         """Dispatch UI operations to the controller-owned Model Hub aggregate."""

--- a/modules/agents/codex/__init__.py
+++ b/modules/agents/codex/__init__.py
@@ -1,5 +1,13 @@
 """Codex agent package — persistent app-server mode."""
 
-from .agent import CodexAgent, CodexConnectionProbeRuntimeMismatchError
+from .agent import (
+    CODEX_CONNECTION_PROBE_DIR,
+    CodexAgent,
+    CodexConnectionProbeRuntimeMismatchError,
+)
 
-__all__ = ["CodexAgent", "CodexConnectionProbeRuntimeMismatchError"]
+__all__ = [
+    "CODEX_CONNECTION_PROBE_DIR",
+    "CodexAgent",
+    "CodexConnectionProbeRuntimeMismatchError",
+]

--- a/modules/agents/codex/__init__.py
+++ b/modules/agents/codex/__init__.py
@@ -1,5 +1,5 @@
 """Codex agent package — persistent app-server mode."""
 
-from .agent import CodexAgent
+from .agent import CodexAgent, CodexConnectionProbeRuntimeMismatchError
 
-__all__ = ["CodexAgent"]
+__all__ = ["CodexAgent", "CodexConnectionProbeRuntimeMismatchError"]

--- a/modules/agents/codex/agent.py
+++ b/modules/agents/codex/agent.py
@@ -62,6 +62,16 @@ _CODEX_REBINDABLE_SAME_ID_PROVIDERS = _CODEX_MANAGED_PROVIDER_IDS | frozenset(
     (_CODEX_MODEL_HUB_PROVIDER_ID,)
 )
 CODEX_CALLER_ENV_DIR = "codex-caller-env"
+CODEX_CONNECTION_PROBE_DIR = "codex-connection-probe"
+
+
+class _CodexConnectionProbeState:
+    def __init__(self) -> None:
+        self.terminal: asyncio.Future[tuple[str, str]] = (
+            asyncio.get_running_loop().create_future()
+        )
+        self.response_text = ""
+        self.turn_id = ""
 
 
 class CodexResumeUnavailableError(RuntimeError):
@@ -120,6 +130,8 @@ class CodexAgent(BaseAgent):
         # base_session_id → (thread_id, effective Git PATH, PATH override persisted)
         self._thread_git_path_configs: Dict[str, tuple[str, str, bool]] = {}
         self._fork_correction_pending_base_sessions: set[str] = set()
+        self._connection_probes: Dict[str, _CodexConnectionProbeState] = {}
+        self._connection_probe_turns: Dict[str, str] = {}
 
     # ------------------------------------------------------------------
     # BaseAgent interface
@@ -166,6 +178,85 @@ class CodexAgent(BaseAgent):
         if transport is None:
             return lambda: None
         return lambda: self._transport_alive(transport)
+
+    async def probe_connection(self, cwd: str, *, model: str | None = None) -> str:
+        """Run a read-only ephemeral turn on the normal persistent app-server."""
+
+        probe_cwd = paths.get_runtime_dir() / CODEX_CONNECTION_PROBE_DIR
+        probe_cwd.mkdir(parents=True, exist_ok=True)
+
+        transport = self._transports.get(cwd)
+        if transport is None or not transport.is_initialized:
+            transport = await self._get_or_create_transport(cwd)
+        else:
+            self._touch_transport_activity(cwd)
+
+        thread_response = await transport.send_request(
+            "thread/start",
+            {
+                "cwd": str(probe_cwd),
+                "approvalPolicy": "never",
+                "sandbox": "read-only",
+                "ephemeral": True,
+                "developerInstructions": (
+                    "This is a connection probe. Do not use tools. "
+                    "Reply with a short greeting."
+                ),
+            },
+        )
+        thread = thread_response.get("thread")
+        thread_id = thread_response.get("id") or (
+            thread.get("id") if isinstance(thread, dict) else None
+        )
+        if not thread_id:
+            raise RuntimeError("Codex thread/start returned no thread id")
+
+        state = _CodexConnectionProbeState()
+        self._connection_probes[thread_id] = state
+        closed_task: asyncio.Task[None] | None = None
+        try:
+            turn_params: Dict[str, Any] = {
+                "threadId": thread_id,
+                "input": [{"type": "text", "text": "Hi"}],
+                "approvalPolicy": "never",
+                "sandboxPolicy": {"type": "readOnly", "networkAccess": False},
+                "effort": "low",
+            }
+            if isinstance(model, str) and model.strip():
+                turn_params["model"] = model.strip()
+            turn_response = await transport.send_request("turn/start", turn_params)
+            turn = turn_response.get("turn")
+            turn_id = turn_response.get("id") or (
+                turn.get("id") if isinstance(turn, dict) else None
+            )
+            if not turn_id:
+                raise RuntimeError("Codex turn/start returned no turn id")
+            state.turn_id = str(turn_id)
+            self._connection_probe_turns[state.turn_id] = thread_id
+
+            closed_task = asyncio.create_task(transport.wait_closed())
+            done, _ = await asyncio.wait(
+                {state.terminal, closed_task},
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+            if state.terminal not in done:
+                raise ConnectionError("Codex app-server exited during the connection probe")
+            outcome, result = state.terminal.result()
+            if outcome == "error":
+                raise RuntimeError(result)
+            if not result.strip():
+                raise RuntimeError("Codex Agent turn returned no response")
+            self._touch_transport_activity(cwd)
+            return result
+        finally:
+            self._connection_probes.pop(thread_id, None)
+            if state.turn_id:
+                self._connection_probe_turns.pop(state.turn_id, None)
+            if not state.terminal.done():
+                state.terminal.cancel()
+            if closed_task is not None:
+                closed_task.cancel()
+                await asyncio.gather(closed_task, return_exceptions=True)
 
     async def _record_model_hub_native_failure(self, context: Any, diagnostic: str) -> bool:
         router = getattr(self.controller, "model_hub_runtime", None)
@@ -2287,6 +2378,8 @@ class CodexAgent(BaseAgent):
 
     async def _on_notification(self, method: str, params: Dict[str, Any]) -> None:
         """Route a server notification to the event handler."""
+        if self._handle_connection_probe_notification(method, params):
+            return
         request = self._find_request_for_notification(method, params)
         if not request:
             thread_id = self._extract_thread_id(params)
@@ -2303,6 +2396,65 @@ class CodexAgent(BaseAgent):
             self._touch_transport_activity(request.working_path)
             self._touch_session_activity(request.base_session_id)
         await self._event_handler.handle_notification(method, params, request)
+
+    def _handle_connection_probe_notification(
+        self,
+        method: str,
+        params: Dict[str, Any],
+    ) -> bool:
+        thread_id = self._extract_thread_id(params)
+        turn_id = self._extract_turn_id(params)
+        probe_turns = getattr(self, "_connection_probe_turns", {})
+        if not thread_id and turn_id:
+            thread_id = probe_turns.get(turn_id, "")
+        state = getattr(self, "_connection_probes", {}).get(thread_id)
+        if state is None:
+            return False
+        if turn_id:
+            state.turn_id = turn_id
+            probe_turns[turn_id] = thread_id
+
+        if method == "item/completed":
+            item = params.get("item") if isinstance(params, dict) else None
+            if isinstance(item, dict) and item.get("type") == "agentMessage":
+                text = str(item.get("text") or "").strip()
+                if text:
+                    state.response_text = text
+            return True
+        if method == "error":
+            if params.get("willRetry") is True:
+                return True
+            error = params.get("error") if isinstance(params, dict) else params
+            detail = (
+                error.get("message")
+                if isinstance(error, dict)
+                else str(error or "Codex error")
+            )
+            if not state.terminal.done():
+                state.terminal.set_result(("error", str(detail or "Codex error")))
+            return True
+        if method != "turn/completed":
+            return True
+
+        turn = params.get("turn") if isinstance(params, dict) else None
+        status = turn.get("status") if isinstance(turn, dict) else None
+        if status == "completed":
+            outcome = ("success", state.response_text)
+        elif status == "interrupted":
+            outcome = ("error", "Codex turn was interrupted")
+        elif status == "failed":
+            error = turn.get("error") if isinstance(turn, dict) else None
+            detail = (
+                error.get("message")
+                if isinstance(error, dict)
+                else str(error or "Codex turn failed")
+            )
+            outcome = ("error", str(detail or "Codex turn failed"))
+        else:
+            outcome = ("error", f"Codex turn ended with status: {status or 'unknown'}")
+        if not state.terminal.done():
+            state.terminal.set_result(outcome)
+        return True
 
     async def _on_server_request(
         self,

--- a/modules/agents/codex/agent.py
+++ b/modules/agents/codex/agent.py
@@ -66,12 +66,26 @@ CODEX_CONNECTION_PROBE_DIR = "codex-connection-probe"
 
 
 class _CodexConnectionProbeState:
-    def __init__(self) -> None:
+    def __init__(self, on_diagnostic: Callable[[str], None] | None = None) -> None:
         self.terminal: asyncio.Future[tuple[str, str]] = (
             asyncio.get_running_loop().create_future()
         )
         self.response_text = ""
         self.turn_id = ""
+        self.on_diagnostic = on_diagnostic
+
+    def record_diagnostic(self, detail: str) -> None:
+        text = str(detail or "").strip()
+        if not text or self.on_diagnostic is None:
+            return
+        try:
+            self.on_diagnostic(text)
+        except Exception:
+            logger.debug("Codex probe diagnostic callback failed", exc_info=True)
+
+
+class CodexConnectionProbeRuntimeMismatchError(RuntimeError):
+    """The cached transport does not represent direct Codex credentials."""
 
 
 class CodexResumeUnavailableError(RuntimeError):
@@ -100,9 +114,16 @@ class CodexAgent(BaseAgent):
 
     name = "codex"
 
-    def __init__(self, controller: Any, codex_config: Any) -> None:
+    def __init__(
+        self,
+        controller: Any,
+        codex_config: Any,
+        *,
+        registered_runtime: bool = True,
+    ) -> None:
         super().__init__(controller)
         self.codex_config = codex_config
+        self._registered_runtime = registered_runtime
 
         # cwd → CodexTransport (one persistent process per working dir)
         self._transports: Dict[str, CodexTransport] = {}
@@ -132,6 +153,7 @@ class CodexAgent(BaseAgent):
         self._fork_correction_pending_base_sessions: set[str] = set()
         self._connection_probes: Dict[str, _CodexConnectionProbeState] = {}
         self._connection_probe_turns: Dict[str, str] = {}
+        self._connection_probe_cwds: Dict[str, int] = {}
 
     # ------------------------------------------------------------------
     # BaseAgent interface
@@ -179,42 +201,70 @@ class CodexAgent(BaseAgent):
             return lambda: None
         return lambda: self._transport_alive(transport)
 
-    async def probe_connection(self, cwd: str, *, model: str | None = None) -> str:
+    def can_reuse_direct_connection_probe(self, cwd: str) -> bool:
+        """Return whether a live transport is suitable for direct-auth testing."""
+
+        transport = self._transports.get(cwd)
+        return not (
+            transport is not None
+            and getattr(transport, "runtime_fingerprint", "direct") != "direct"
+        )
+
+    async def probe_connection(
+        self,
+        cwd: str,
+        *,
+        model: str | None = None,
+        on_diagnostic: Callable[[str], None] | None = None,
+    ) -> str:
         """Run a read-only ephemeral turn on the normal persistent app-server."""
 
         probe_cwd = paths.get_runtime_dir() / CODEX_CONNECTION_PROBE_DIR
         probe_cwd.mkdir(parents=True, exist_ok=True)
-
-        transport = self._transports.get(cwd)
-        if transport is None or not transport.is_initialized:
-            transport = await self._get_or_create_transport(cwd)
-        else:
-            self._touch_transport_activity(cwd)
-
-        thread_response = await transport.send_request(
-            "thread/start",
-            {
-                "cwd": str(probe_cwd),
-                "approvalPolicy": "never",
-                "sandbox": "read-only",
-                "ephemeral": True,
-                "developerInstructions": (
-                    "This is a connection probe. Do not use tools. "
-                    "Reply with a short greeting."
-                ),
-            },
-        )
-        thread = thread_response.get("thread")
-        thread_id = thread_response.get("id") or (
-            thread.get("id") if isinstance(thread, dict) else None
-        )
-        if not thread_id:
-            raise RuntimeError("Codex thread/start returned no thread id")
-
-        state = _CodexConnectionProbeState()
-        self._connection_probes[thread_id] = state
+        transport: CodexTransport | None = None
+        state: _CodexConnectionProbeState | None = None
+        thread_id = ""
         closed_task: asyncio.Task[None] | None = None
+        probe_cwds = self._connection_probe_cwds
+        probe_cwds[cwd] = probe_cwds.get(cwd, 0) + 1
         try:
+            transport = self._transports.get(cwd)
+            if (
+                transport is not None
+                and getattr(transport, "runtime_fingerprint", "direct") != "direct"
+            ):
+                raise CodexConnectionProbeRuntimeMismatchError(
+                    "The cached Codex transport does not use direct credentials"
+                )
+            if transport is None or not transport.is_initialized:
+                transport = await self._get_or_create_transport(cwd)
+            else:
+                self._touch_transport_activity(cwd)
+
+            thread_response = await transport.send_request(
+                "thread/start",
+                {
+                    "cwd": str(probe_cwd),
+                    "approvalPolicy": "never",
+                    "sandbox": "read-only",
+                    "ephemeral": True,
+                    "developerInstructions": (
+                        "This is a connection probe. Do not use tools. "
+                        "Reply with a short greeting."
+                    ),
+                },
+            )
+            thread = thread_response.get("thread")
+            thread_id = str(
+                thread_response.get("id")
+                or (thread.get("id") if isinstance(thread, dict) else "")
+                or ""
+            )
+            if not thread_id:
+                raise RuntimeError("Codex thread/start returned no thread id")
+
+            state = _CodexConnectionProbeState(on_diagnostic)
+            self._connection_probes[thread_id] = state
             turn_params: Dict[str, Any] = {
                 "threadId": thread_id,
                 "input": [{"type": "text", "text": "Hi"}],
@@ -249,14 +299,42 @@ class CodexAgent(BaseAgent):
             self._touch_transport_activity(cwd)
             return result
         finally:
-            self._connection_probes.pop(thread_id, None)
-            if state.turn_id:
-                self._connection_probe_turns.pop(state.turn_id, None)
-            if not state.terminal.done():
-                state.terminal.cancel()
-            if closed_task is not None:
-                closed_task.cancel()
-                await asyncio.gather(closed_task, return_exceptions=True)
+            try:
+                if (
+                    transport is not None
+                    and state is not None
+                    and state.turn_id
+                    and not state.terminal.done()
+                    and transport.is_initialized
+                ):
+                    try:
+                        await asyncio.wait_for(
+                            transport.send_request(
+                                "turn/interrupt",
+                                {"threadId": thread_id, "turnId": state.turn_id},
+                            ),
+                            timeout=2.0,
+                        )
+                    except Exception:
+                        logger.warning(
+                            "Failed to interrupt cancelled Codex connection probe",
+                            exc_info=True,
+                        )
+            finally:
+                if thread_id:
+                    self._connection_probes.pop(thread_id, None)
+                if state is not None and state.turn_id:
+                    self._connection_probe_turns.pop(state.turn_id, None)
+                if state is not None and not state.terminal.done():
+                    state.terminal.cancel()
+                if closed_task is not None:
+                    closed_task.cancel()
+                    await asyncio.gather(closed_task, return_exceptions=True)
+                remaining = probe_cwds.get(cwd, 0) - 1
+                if remaining > 0:
+                    probe_cwds[cwd] = remaining
+                else:
+                    probe_cwds.pop(cwd, None)
 
     async def _record_model_hub_native_failure(self, context: Any, diagnostic: str) -> bool:
         router = getattr(self.controller, "model_hub_runtime", None)
@@ -895,6 +973,8 @@ class CodexAgent(BaseAgent):
         cwd: str,
         transport: CodexTransport,
     ) -> RuntimeActivationIdentity | None:
+        if not getattr(self, "_registered_runtime", True):
+            return None
         registry = getattr(getattr(self, "controller", None), "runtime_activation", None)
         if registry is None:
             return None
@@ -912,6 +992,8 @@ class CodexAgent(BaseAgent):
     ) -> tuple[Any, Any] | None:
         if self._transports.get(cwd) is not transport:
             return None
+        if not getattr(self, "_registered_runtime", True):
+            return (None, None)
         registry = getattr(getattr(self, "controller", None), "runtime_activation", None)
         if registry is None:
             return (None, None)
@@ -1214,6 +1296,8 @@ class CodexAgent(BaseAgent):
         return evicted
 
     def _retire_model_hub_process_scope(self, cwd: str) -> None:
+        if not getattr(self, "_registered_runtime", True):
+            return
         controller = getattr(self, "controller", None)
         router = getattr(controller, "model_hub_runtime", None)
         retire = getattr(router, "retire_process_scope", None)
@@ -2422,14 +2506,15 @@ class CodexAgent(BaseAgent):
                     state.response_text = text
             return True
         if method == "error":
-            if params.get("willRetry") is True:
-                return True
             error = params.get("error") if isinstance(params, dict) else params
             detail = (
                 error.get("message")
                 if isinstance(error, dict)
                 else str(error or "Codex error")
             )
+            state.record_diagnostic(str(detail or "Codex error"))
+            if params.get("willRetry") is True:
+                return True
             if not state.terminal.done():
                 state.terminal.set_result(("error", str(detail or "Codex error")))
             return True
@@ -2449,6 +2534,7 @@ class CodexAgent(BaseAgent):
                 if isinstance(error, dict)
                 else str(error or "Codex turn failed")
             )
+            state.record_diagnostic(str(detail or "Codex turn failed"))
             outcome = ("error", str(detail or "Codex turn failed"))
         else:
             outcome = ("error", f"Codex turn ended with status: {status or 'unknown'}")
@@ -2581,6 +2667,8 @@ class CodexAgent(BaseAgent):
         }
 
     def _has_active_turns_for_cwd(self, cwd: str) -> bool:
+        if cwd in getattr(self, "_connection_probe_cwds", set()):
+            return True
         for base_session_id in self._session_mgr.sessions_for_cwd(cwd):
             if self._turn_registry.get_active_turn(base_session_id):
                 return True

--- a/modules/agents/codex/agent.py
+++ b/modules/agents/codex/agent.py
@@ -202,12 +202,13 @@ class CodexAgent(BaseAgent):
         return lambda: self._transport_alive(transport)
 
     def can_reuse_direct_connection_probe(self, cwd: str) -> bool:
-        """Return whether a live transport is suitable for direct-auth testing."""
+        """Return whether a cached transport can test direct credentials."""
 
         transport = self._transports.get(cwd)
-        return not (
+        return bool(
             transport is not None
-            and getattr(transport, "runtime_fingerprint", "direct") != "direct"
+            and getattr(transport, "runtime_fingerprint", "direct") == "direct"
+            and os.path.isdir(cwd)
         )
 
     async def probe_connection(
@@ -226,20 +227,21 @@ class CodexAgent(BaseAgent):
         thread_id = ""
         closed_task: asyncio.Task[None] | None = None
         probe_cwds = self._connection_probe_cwds
-        probe_cwds[cwd] = probe_cwds.get(cwd, 0) + 1
+        owns_probe_cwd = False
         try:
-            transport = self._transports.get(cwd)
             if (
-                transport is not None
-                and getattr(transport, "runtime_fingerprint", "direct") != "direct"
+                getattr(self, "_registered_runtime", True)
+                and not self.can_reuse_direct_connection_probe(cwd)
             ):
                 raise CodexConnectionProbeRuntimeMismatchError(
-                    "The cached Codex transport does not use direct credentials"
+                    "No cached direct Codex transport is available for the probe"
                 )
-            if transport is None or not transport.is_initialized:
-                transport = await self._get_or_create_transport(cwd)
-            else:
-                self._touch_transport_activity(cwd)
+            transport = await self._get_or_create_transport(
+                cwd,
+                allow_runtime_replacement=False,
+            )
+            probe_cwds[cwd] = probe_cwds.get(cwd, 0) + 1
+            owns_probe_cwd = True
 
             thread_response = await transport.send_request(
                 "thread/start",
@@ -330,11 +332,12 @@ class CodexAgent(BaseAgent):
                 if closed_task is not None:
                     closed_task.cancel()
                     await asyncio.gather(closed_task, return_exceptions=True)
-                remaining = probe_cwds.get(cwd, 0) - 1
-                if remaining > 0:
-                    probe_cwds[cwd] = remaining
-                else:
-                    probe_cwds.pop(cwd, None)
+                if owns_probe_cwd:
+                    remaining = probe_cwds.get(cwd, 0) - 1
+                    if remaining > 0:
+                        probe_cwds[cwd] = remaining
+                    else:
+                        probe_cwds.pop(cwd, None)
 
     async def _record_model_hub_native_failure(self, context: Any, diagnostic: str) -> bool:
         router = getattr(self.controller, "model_hub_runtime", None)
@@ -1503,6 +1506,8 @@ class CodexAgent(BaseAgent):
         self,
         cwd: str,
         launch: "ModelHubLaunch | None" = None,
+        *,
+        allow_runtime_replacement: bool = True,
     ) -> CodexTransport:
         """Return an initialized transport for the given working directory."""
         # Serialize creation per cwd
@@ -1517,6 +1522,10 @@ class CodexAgent(BaseAgent):
                 desired_fingerprint = launch.fingerprint if launch is not None else "direct"
                 existing_fingerprint = getattr(existing, "runtime_fingerprint", "direct")
                 runtime_changed = existing_fingerprint != desired_fingerprint
+                if existing is not None and runtime_changed and not allow_runtime_replacement:
+                    raise CodexConnectionProbeRuntimeMismatchError(
+                        "The cached Codex transport does not use direct credentials"
+                    )
                 if existing and existing.is_initialized:
                     # Reuse only while the directory the app-server was spawned in
                     # is still the SAME directory (#561): after a delete (+ possible

--- a/modules/agents/codex/transport.py
+++ b/modules/agents/codex/transport.py
@@ -120,9 +120,15 @@ class CodexTransport:
             logger.info("Codex app-server initialized: %s", resp)
             await self.send_notification("initialized")
             self._initialized = True
-        except Exception:
-            logger.exception("Codex app-server handshake failed, cleaning up")
-            await self.stop()
+        except BaseException as exc:
+            if isinstance(exc, asyncio.CancelledError):
+                logger.info("Codex app-server handshake cancelled, cleaning up")
+            else:
+                logger.exception("Codex app-server handshake failed, cleaning up")
+            try:
+                await self.stop()
+            except Exception:
+                logger.exception("Failed to clean up Codex app-server after handshake failure")
             raise
 
     async def stop(self) -> None:

--- a/modules/agents/codex/transport.py
+++ b/modules/agents/codex/transport.py
@@ -255,6 +255,11 @@ class CodexTransport:
 
         try:
             return await asyncio.wait_for(fut, timeout=120.0)
+        except asyncio.CancelledError:
+            self._pending.pop(req_id, None)
+            if not fut.done():
+                fut.cancel()
+            raise
         except asyncio.TimeoutError:
             self._pending.pop(req_id, None)
             self._initialized = False

--- a/modules/agents/codex/transport.py
+++ b/modules/agents/codex/transport.py
@@ -56,6 +56,7 @@ class CodexTransport:
         self._notify_queue: asyncio.Queue[tuple[str, dict[str, Any]]] = asyncio.Queue()
         self._notify_task: Optional[asyncio.Task[None]] = None
         self._notify_inflight = 0
+        self._closed_event = asyncio.Event()
 
     # ------------------------------------------------------------------
     # Lifecycle
@@ -67,6 +68,7 @@ class CodexTransport:
             logger.warning("CodexTransport.start() called but process is already running")
             return
 
+        self._closed_event.clear()
         cmd = (
             [self._binary, "--dangerously-bypass-approvals-and-sandbox"]
             + ["app-server"]
@@ -128,6 +130,7 @@ class CodexTransport:
         self._initialized = False
         proc = self._process
         if not proc or proc.returncode is not None:
+            self._closed_event.set()
             self._cleanup_tasks()
             return
 
@@ -152,6 +155,7 @@ class CodexTransport:
                     pass
 
         self._cleanup_tasks()
+        self._closed_event.set()
         # Fail all pending futures
         for fut in self._pending.values():
             if not fut.done():
@@ -186,6 +190,15 @@ class CodexTransport:
         """Whether an already-read notification can still deliver a terminal."""
 
         return self._notify_inflight > 0 or not self._notify_queue.empty()
+
+    async def wait_closed(self) -> None:
+        """Wait until the app-server exits and already-read notifications drain."""
+
+        await self._closed_event.wait()
+        for _ in range(50):
+            if not self.has_pending_notifications:
+                return
+            await asyncio.sleep(0.01)
 
     @property
     def pid(self) -> Optional[int]:
@@ -297,6 +310,7 @@ class CodexTransport:
             logger.exception("Codex reader loop crashed")
         finally:
             self._initialized = False
+            self._closed_event.set()
             # Process ended — fail pending futures
             for fut in self._pending.values():
                 if not fut.done():

--- a/tests/scenarios/auth_setup/catalog.yaml
+++ b/tests/scenarios/auth_setup/catalog.yaml
@@ -177,11 +177,11 @@ scenarios:
     backend: claude
     test: tests/scenarios/auth_setup/test_auth_setup_scenarios.py::test_claude_oauth_to_api_key_probe_drops_stale_auth_token
   - id: AUTH-SETUP-906
-    name: Codex connection probe uses an app-server Agent turn
+    name: Codex connection probe reuses the persistent app-server with an ephemeral turn
     status: covered
     kind: historical_regression
     layer: scenario
     backend: codex
-    test: tests/scenarios/auth_setup/test_auth_setup_scenarios.py::test_codex_connection_probe_uses_app_server_turn
+    test: tests/scenarios/auth_setup/test_auth_setup_scenarios.py::test_codex_connection_probe_reuses_persistent_app_server
 next_priority:
   - AUTH-SETUP-301

--- a/tests/scenarios/auth_setup/catalog.yaml
+++ b/tests/scenarios/auth_setup/catalog.yaml
@@ -170,11 +170,18 @@ scenarios:
     backend: claude
     test: tests/scenarios/auth_setup/test_auth_setup_scenarios.py::test_claude_oauth_to_explicit_auth_token_reaches_next_turn
   - id: AUTH-SETUP-905
-    name: Claude API key probe drops a stale inherited auth token after switching from OAuth
+    name: Claude SDK probe drops a stale inherited auth token after switching from OAuth
     status: covered
     kind: historical_regression
     layer: scenario
     backend: claude
     test: tests/scenarios/auth_setup/test_auth_setup_scenarios.py::test_claude_oauth_to_api_key_probe_drops_stale_auth_token
+  - id: AUTH-SETUP-906
+    name: Codex connection probe uses an app-server Agent turn
+    status: covered
+    kind: historical_regression
+    layer: scenario
+    backend: codex
+    test: tests/scenarios/auth_setup/test_auth_setup_scenarios.py::test_codex_connection_probe_uses_app_server_turn
 next_priority:
   - AUTH-SETUP-301

--- a/tests/scenarios/auth_setup/test_auth_setup_scenarios.py
+++ b/tests/scenarios/auth_setup/test_auth_setup_scenarios.py
@@ -400,6 +400,9 @@ class AgentAuthSetupScenarioTests(unittest.IsolatedAsyncioTestCase):
         agent._connection_probes = {}
         agent._connection_probe_turns = {}
         agent._connection_probe_cwds = {}
+        agent._get_or_create_transport = AsyncMock(
+            return_value=agent._transports[str(home)]
+        )
         controller.agent_service = SimpleNamespace(agents={"codex": agent})
         service = AgentAuthService(controller)
 
@@ -426,6 +429,10 @@ class AgentAuthSetupScenarioTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertTrue(harness.test_result["ok"])
         self.assertEqual(harness.test_result["excerpt"], "codex-probe-ok")
+        agent._get_or_create_transport.assert_awaited_once_with(
+            str(home),
+            allow_runtime_replacement=False,
+        )
         self.assertEqual(
             requests,
             [

--- a/tests/scenarios/auth_setup/test_auth_setup_scenarios.py
+++ b/tests/scenarios/auth_setup/test_auth_setup_scenarios.py
@@ -356,51 +356,51 @@ class AgentAuthSetupScenarioTests(unittest.IsolatedAsyncioTestCase):
             ["confirm_oauth_is_active", "save_api_key", "test_connection"],
         )
 
-    async def test_codex_connection_probe_uses_app_server_turn(self):
+    async def test_codex_connection_probe_reuses_persistent_app_server(self):
         """Scenario: AUTH-SETUP-906"""
         state_dir = tempfile.TemporaryDirectory()
         self.addCleanup(state_dir.cleanup)
         home = Path(state_dir.name)
         harness = AuthSetupScenarioHarness()
         runner = ScenarioRunner(harness)
-        service = AgentAuthService(_ReloadingV2ConfigController())
         requests = []
 
         class FakeCodexTransport:
-            pid = None
-
-            def __init__(self, **kwargs):
-                harness.transport_init = kwargs
-                self.notification = None
-
-            def on_notification(self, callback):
-                self.notification = callback
-
-            def on_server_request(self, callback):
-                harness.server_request = callback
-
-            async def start(self):
-                harness.transport_started = True
-
-            async def stop(self):
-                harness.transport_stopped = True
+            is_initialized = True
 
             async def send_request(self, method, params):
                 requests.append((method, params))
                 if method == "thread/start":
                     return {"thread": {"id": "thread-probe"}}
-                await self.notification(
+                await agent._on_notification(
                     "item/completed",
                     {
+                        "threadId": "thread-probe",
                         "turnId": "turn-probe",
                         "item": {"type": "agentMessage", "text": "codex-probe-ok"},
                     },
                 )
-                await self.notification(
+                await agent._on_notification(
                     "turn/completed",
-                    {"turn": {"id": "turn-probe", "status": "completed"}},
+                    {
+                        "threadId": "thread-probe",
+                        "turn": {"id": "turn-probe", "status": "completed"},
+                    },
                 )
                 return {"turn": {"id": "turn-probe"}}
+
+            async def wait_closed(self):
+                await asyncio.Event().wait()
+
+        controller = _ReloadingV2ConfigController()
+        agent = object.__new__(CodexAgent)
+        agent.controller = controller
+        agent._transports = {str(home): FakeCodexTransport()}
+        agent._transport_last_activity = {}
+        agent._connection_probes = {}
+        agent._connection_probe_turns = {}
+        controller.agent_service = SimpleNamespace(agents={"codex": agent})
+        service = AgentAuthService(controller)
 
         async def run_connection_probe(current):
             current.test_result = await probe_backend_auth_async(
@@ -411,7 +411,6 @@ class AgentAuthSetupScenarioTests(unittest.IsolatedAsyncioTestCase):
         with (
             patch.dict(os.environ, {"AVIBE_HOME": str(home / ".avibe")}),
             patch("vibe.api._get_oauth_service", return_value=service),
-            patch("modules.agents.codex.transport.CodexTransport", FakeCodexTransport),
         ):
             config = V2Config(
                 mode="self_host",
@@ -426,18 +425,22 @@ class AgentAuthSetupScenarioTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertTrue(harness.test_result["ok"])
         self.assertEqual(harness.test_result["excerpt"], "codex-probe-ok")
-        self.assertTrue(harness.transport_started)
-        self.assertTrue(harness.transport_stopped)
-        self.assertEqual(harness.transport_init["binary"], "codex-probe")
         self.assertEqual(
             requests,
             [
                 (
                     "thread/start",
                     {
-                        "cwd": str(home),
+                        "cwd": str(
+                            (home / ".avibe" / "runtime" / "codex-connection-probe").resolve()
+                        ),
                         "approvalPolicy": "never",
-                        "sandbox": "danger-full-access",
+                        "sandbox": "read-only",
+                        "ephemeral": True,
+                        "developerInstructions": (
+                            "This is a connection probe. Do not use tools. "
+                            "Reply with a short greeting."
+                        ),
                     },
                 ),
                 (
@@ -446,7 +449,7 @@ class AgentAuthSetupScenarioTests(unittest.IsolatedAsyncioTestCase):
                         "threadId": "thread-probe",
                         "input": [{"type": "text", "text": "Hi"}],
                         "approvalPolicy": "never",
-                        "sandboxPolicy": {"type": "dangerFullAccess"},
+                        "sandboxPolicy": {"type": "readOnly", "networkAccess": False},
                         "effort": "low",
                         "model": "gpt-5.4-mini",
                     },

--- a/tests/scenarios/auth_setup/test_auth_setup_scenarios.py
+++ b/tests/scenarios/auth_setup/test_auth_setup_scenarios.py
@@ -222,26 +222,6 @@ class AgentAuthSetupScenarioTests(unittest.IsolatedAsyncioTestCase):
             ),
             encoding="utf-8",
         )
-        probe_cli = home / "claude-probe"
-        probe_cli.write_text(
-            f"""#!{sys.executable}
-import os
-import sys
-
-expected = (
-    sys.argv[1:] == ["-p", "Hi"]
-    and os.environ.get("ANTHROPIC_API_KEY") == "relay-api-key"
-    and "ANTHROPIC_AUTH_TOKEN" not in os.environ
-    and os.environ.get("ANTHROPIC_BASE_URL") == "https://ai.coinsummer.com"
-)
-if not expected:
-    print("unexpected Claude probe environment")
-    raise SystemExit(7)
-print("relay-probe-ok")
-""",
-            encoding="utf-8",
-        )
-        probe_cli.chmod(0o755)
 
         harness = AuthSetupScenarioHarness()
         runner = ScenarioRunner(harness)
@@ -274,6 +254,27 @@ print("relay-probe-ok")
         async def run_connection_probe(current):
             current.test_result = await probe_backend_auth_async("claude")
 
+        class FakeClaudeSDKClient:
+            def __init__(self, *, options):
+                harness.probe_options = options
+
+            async def connect(self):
+                return None
+
+            async def query(self, text):
+                harness.probe_query = text
+
+            async def receive_response(self):
+                yield SimpleNamespace(
+                    is_error=False,
+                    result="relay-probe-ok",
+                    content=[],
+                    error=None,
+                )
+
+            async def disconnect(self):
+                return None
+
         with (
             patch.dict(
                 os.environ,
@@ -292,6 +293,7 @@ print("relay-probe-ok")
             ),
             patch("vibe.api.restart_backend", side_effect=restart_backend),
             patch("vibe.api._read_claude_cli_oauth_signed_in", return_value=None),
+            patch("core.agent_auth_service.ClaudeSDKClient", FakeClaudeSDKClient),
         ):
             config = V2Config(
                 mode="self_host",
@@ -302,7 +304,7 @@ print("relay-probe-ok")
             )
             config.agents.claude.auth_mode = "oauth"
             config.agents.claude.auth_mode_set = True
-            config.agents.claude.cli_path = str(probe_cli)
+            config.agents.claude.cli_path = "claude-probe"
             config.save()
 
             await runner.run(
@@ -328,6 +330,17 @@ print("relay-probe-ok")
         )
         self.assertTrue(harness.test_result["ok"])
         self.assertEqual(harness.test_result["excerpt"], "relay-probe-ok")
+        self.assertEqual(harness.probe_query, "Hi")
+        self.assertEqual(harness.probe_options.cli_path, "claude-probe")
+        self.assertEqual(
+            harness.probe_options.env["ANTHROPIC_API_KEY"],
+            "relay-api-key",
+        )
+        self.assertEqual(harness.probe_options.env["ANTHROPIC_AUTH_TOKEN"], "")
+        self.assertEqual(
+            harness.probe_options.env["ANTHROPIC_BASE_URL"],
+            "https://ai.coinsummer.com",
+        )
         self.assertEqual(cleanup_calls, [service])
         self.assertEqual(
             restart_calls,
@@ -342,6 +355,105 @@ print("relay-probe-ok")
             runner,
             ["confirm_oauth_is_active", "save_api_key", "test_connection"],
         )
+
+    async def test_codex_connection_probe_uses_app_server_turn(self):
+        """Scenario: AUTH-SETUP-906"""
+        state_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(state_dir.cleanup)
+        home = Path(state_dir.name)
+        harness = AuthSetupScenarioHarness()
+        runner = ScenarioRunner(harness)
+        service = AgentAuthService(_ReloadingV2ConfigController())
+        requests = []
+
+        class FakeCodexTransport:
+            pid = None
+
+            def __init__(self, **kwargs):
+                harness.transport_init = kwargs
+                self.notification = None
+
+            def on_notification(self, callback):
+                self.notification = callback
+
+            def on_server_request(self, callback):
+                harness.server_request = callback
+
+            async def start(self):
+                harness.transport_started = True
+
+            async def stop(self):
+                harness.transport_stopped = True
+
+            async def send_request(self, method, params):
+                requests.append((method, params))
+                if method == "thread/start":
+                    return {"thread": {"id": "thread-probe"}}
+                await self.notification(
+                    "item/completed",
+                    {
+                        "turnId": "turn-probe",
+                        "item": {"type": "agentMessage", "text": "codex-probe-ok"},
+                    },
+                )
+                await self.notification(
+                    "turn/completed",
+                    {"turn": {"id": "turn-probe", "status": "completed"}},
+                )
+                return {"turn": {"id": "turn-probe"}}
+
+        async def run_connection_probe(current):
+            current.test_result = await probe_backend_auth_async(
+                "codex",
+                model="gpt-5.4-mini",
+            )
+
+        with (
+            patch.dict(os.environ, {"AVIBE_HOME": str(home / ".avibe")}),
+            patch("vibe.api._get_oauth_service", return_value=service),
+            patch("modules.agents.codex.transport.CodexTransport", FakeCodexTransport),
+        ):
+            config = V2Config(
+                mode="self_host",
+                version="v2",
+                slack=SlackConfig(bot_token=""),
+                runtime=RuntimeConfig(default_cwd=str(home)),
+                agents=AgentsConfig(),
+            )
+            config.agents.codex.cli_path = "codex-probe"
+            config.save()
+            await runner.run(ScenarioStep("test_connection", run_connection_probe))
+
+        self.assertTrue(harness.test_result["ok"])
+        self.assertEqual(harness.test_result["excerpt"], "codex-probe-ok")
+        self.assertTrue(harness.transport_started)
+        self.assertTrue(harness.transport_stopped)
+        self.assertEqual(harness.transport_init["binary"], "codex-probe")
+        self.assertEqual(
+            requests,
+            [
+                (
+                    "thread/start",
+                    {
+                        "cwd": str(home),
+                        "approvalPolicy": "never",
+                        "sandbox": "danger-full-access",
+                    },
+                ),
+                (
+                    "turn/start",
+                    {
+                        "threadId": "thread-probe",
+                        "input": [{"type": "text", "text": "Hi"}],
+                        "approvalPolicy": "never",
+                        "sandboxPolicy": {"type": "dangerFullAccess"},
+                        "effort": "low",
+                        "model": "gpt-5.4-mini",
+                    },
+                ),
+            ],
+        )
+        ScenarioExpect.step_history(runner, ["test_connection"])
 
     async def test_legacy_codex_thread_rebinds_once_after_api_key_endpoint_switch(self):
         """Scenario: AUTH-SETUP-903"""

--- a/tests/scenarios/auth_setup/test_auth_setup_scenarios.py
+++ b/tests/scenarios/auth_setup/test_auth_setup_scenarios.py
@@ -399,6 +399,7 @@ class AgentAuthSetupScenarioTests(unittest.IsolatedAsyncioTestCase):
         agent._transport_last_activity = {}
         agent._connection_probes = {}
         agent._connection_probe_turns = {}
+        agent._connection_probe_cwds = {}
         controller.agent_service = SimpleNamespace(agents={"codex": agent})
         service = AgentAuthService(controller)
 

--- a/tests/test_codex_agent.py
+++ b/tests/test_codex_agent.py
@@ -264,6 +264,132 @@ class CodexAgentNotificationRoutingTests(unittest.TestCase):
         self.assertIsNone(resolved)
 
 
+class CodexAgentConnectionProbeTests(unittest.IsolatedAsyncioTestCase):
+    def _agent(self, cwd: str, transport):
+        agent = object.__new__(CodexAgent)
+        agent._transports = {cwd: transport}
+        agent._transport_last_activity = {}
+        agent._connection_probes = {}
+        agent._connection_probe_turns = {}
+        return agent
+
+    async def test_reuses_existing_transport_with_isolated_ephemeral_thread(self):
+        requests = []
+        cwd = "/tmp/user-project"
+        runtime_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(runtime_dir.cleanup)
+
+        class _Transport:
+            is_initialized = True
+
+            async def send_request(inner_self, method, params):
+                requests.append((method, params))
+                if method == "thread/start":
+                    return {"thread": {"id": "thread-probe"}}
+                await agent._on_notification(
+                    "item/completed",
+                    {
+                        "threadId": "thread-probe",
+                        "turnId": "turn-probe",
+                        "item": {"type": "agentMessage", "text": "hello"},
+                    },
+                )
+                await agent._on_notification(
+                    "turn/completed",
+                    {
+                        "threadId": "thread-probe",
+                        "turn": {"id": "turn-probe", "status": "completed"},
+                    },
+                )
+                return {"turn": {"id": "turn-probe"}}
+
+            async def wait_closed(inner_self):
+                await asyncio.Event().wait()
+
+        transport = _Transport()
+        agent = self._agent(cwd, transport)
+        agent._get_or_create_transport = AsyncMock(
+            side_effect=AssertionError("existing transport should be reused")
+        )
+
+        with patch.object(
+            _MODULE.paths,
+            "get_runtime_dir",
+            return_value=Path(runtime_dir.name),
+        ):
+            result = await agent.probe_connection(cwd, model="gpt-5.4-mini")
+
+        self.assertEqual(result, "hello")
+        agent._get_or_create_transport.assert_not_awaited()
+        self.assertEqual(requests[0][0], "thread/start")
+        self.assertEqual(
+            requests[0][1],
+            {
+                "cwd": str(Path(runtime_dir.name) / "codex-connection-probe"),
+                "approvalPolicy": "never",
+                "sandbox": "read-only",
+                "ephemeral": True,
+                "developerInstructions": (
+                    "This is a connection probe. Do not use tools. "
+                    "Reply with a short greeting."
+                ),
+            },
+        )
+        self.assertEqual(
+            requests[1],
+            (
+                "turn/start",
+                {
+                    "threadId": "thread-probe",
+                    "input": [{"type": "text", "text": "Hi"}],
+                    "approvalPolicy": "never",
+                    "sandboxPolicy": {
+                        "type": "readOnly",
+                        "networkAccess": False,
+                    },
+                    "effort": "low",
+                    "model": "gpt-5.4-mini",
+                },
+            ),
+        )
+        self.assertEqual(agent._connection_probes, {})
+        self.assertEqual(agent._connection_probe_turns, {})
+
+    async def test_transport_exit_settles_probe_without_outer_timeout(self):
+        cwd = "/tmp/user-project"
+        runtime_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(runtime_dir.cleanup)
+
+        class _Transport:
+            is_initialized = True
+
+            async def send_request(inner_self, method, _params):
+                if method == "thread/start":
+                    return {"thread": {"id": "thread-probe"}}
+                return {"turn": {"id": "turn-probe"}}
+
+            async def wait_closed(inner_self):
+                return None
+
+        agent = self._agent(cwd, _Transport())
+
+        with (
+            patch.object(
+                _MODULE.paths,
+                "get_runtime_dir",
+                return_value=Path(runtime_dir.name),
+            ),
+            self.assertRaisesRegex(
+                ConnectionError,
+                "app-server exited during the connection probe",
+            ),
+        ):
+            await agent.probe_connection(cwd)
+
+        self.assertEqual(agent._connection_probes, {})
+        self.assertEqual(agent._connection_probe_turns, {})
+
+
 class CodexAgentStopTests(unittest.IsolatedAsyncioTestCase):
     async def asyncSetUp(self):
         ownership = SimpleNamespace(

--- a/tests/test_codex_agent.py
+++ b/tests/test_codex_agent.py
@@ -141,6 +141,9 @@ assert _SPEC is not None and _SPEC.loader is not None
 _MODULE = importlib.util.module_from_spec(_SPEC)
 _SPEC.loader.exec_module(_MODULE)
 CodexAgent = _MODULE.CodexAgent
+CodexConnectionProbeRuntimeMismatchError = (
+    _MODULE.CodexConnectionProbeRuntimeMismatchError
+)
 CodexResumeUnavailableError = _MODULE.CodexResumeUnavailableError
 
 for name, module in _saved_modules.items():
@@ -271,6 +274,7 @@ class CodexAgentConnectionProbeTests(unittest.IsolatedAsyncioTestCase):
         agent._transport_last_activity = {}
         agent._connection_probes = {}
         agent._connection_probe_turns = {}
+        agent._connection_probe_cwds = {}
         return agent
 
     async def test_reuses_existing_transport_with_isolated_ephemeral_thread(self):
@@ -308,6 +312,7 @@ class CodexAgentConnectionProbeTests(unittest.IsolatedAsyncioTestCase):
 
         transport = _Transport()
         agent = self._agent(cwd, transport)
+        diagnostics = []
         agent._get_or_create_transport = AsyncMock(
             side_effect=AssertionError("existing transport should be reused")
         )
@@ -317,7 +322,11 @@ class CodexAgentConnectionProbeTests(unittest.IsolatedAsyncioTestCase):
             "get_runtime_dir",
             return_value=Path(runtime_dir.name),
         ):
-            result = await agent.probe_connection(cwd, model="gpt-5.4-mini")
+            result = await agent.probe_connection(
+                cwd,
+                model="gpt-5.4-mini",
+                on_diagnostic=diagnostics.append,
+            )
 
         self.assertEqual(result, "hello")
         agent._get_or_create_transport.assert_not_awaited()
@@ -354,6 +363,8 @@ class CodexAgentConnectionProbeTests(unittest.IsolatedAsyncioTestCase):
         )
         self.assertEqual(agent._connection_probes, {})
         self.assertEqual(agent._connection_probe_turns, {})
+        self.assertEqual(agent._connection_probe_cwds, {})
+        self.assertEqual(diagnostics, [])
 
     async def test_transport_exit_settles_probe_without_outer_timeout(self):
         cwd = "/tmp/user-project"
@@ -388,6 +399,144 @@ class CodexAgentConnectionProbeTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(agent._connection_probes, {})
         self.assertEqual(agent._connection_probe_turns, {})
+        self.assertEqual(agent._connection_probe_cwds, {})
+
+    async def test_cancellation_interrupts_started_probe_and_clears_ownership(self):
+        cwd = "/tmp/user-project"
+        runtime_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(runtime_dir.cleanup)
+        turn_started = asyncio.Event()
+        requests = []
+
+        class _Transport:
+            is_initialized = True
+
+            async def send_request(inner_self, method, params):
+                requests.append((method, params))
+                if method == "thread/start":
+                    return {"thread": {"id": "thread-probe"}}
+                if method == "turn/start":
+                    turn_started.set()
+                    return {"turn": {"id": "turn-probe"}}
+                if method == "turn/interrupt":
+                    return {}
+                raise AssertionError(method)
+
+            async def wait_closed(inner_self):
+                await asyncio.Event().wait()
+
+        agent = self._agent(cwd, _Transport())
+        with patch.object(
+            _MODULE.paths,
+            "get_runtime_dir",
+            return_value=Path(runtime_dir.name),
+        ):
+            task = asyncio.create_task(agent.probe_connection(cwd))
+            await turn_started.wait()
+            await asyncio.sleep(0)
+            task.cancel()
+            with self.assertRaises(asyncio.CancelledError):
+                await task
+
+        self.assertIn(
+            (
+                "turn/interrupt",
+                {"threadId": "thread-probe", "turnId": "turn-probe"},
+            ),
+            requests,
+        )
+        self.assertEqual(agent._connection_probes, {})
+        self.assertEqual(agent._connection_probe_turns, {})
+        self.assertEqual(agent._connection_probe_cwds, {})
+
+    async def test_retriable_errors_are_preserved_as_diagnostics(self):
+        cwd = "/tmp/user-project"
+        runtime_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(runtime_dir.cleanup)
+        diagnostics = []
+
+        class _Transport:
+            is_initialized = True
+
+            async def send_request(inner_self, method, _params):
+                if method == "thread/start":
+                    return {"thread": {"id": "thread-probe"}}
+                await agent._on_notification(
+                    "error",
+                    {
+                        "threadId": "thread-probe",
+                        "turnId": "turn-probe",
+                        "willRetry": True,
+                        "error": {"message": "401 Unauthorized"},
+                    },
+                )
+                await agent._on_notification(
+                    "turn/completed",
+                    {
+                        "threadId": "thread-probe",
+                        "turn": {"id": "turn-probe", "status": "completed"},
+                    },
+                )
+                return {"turn": {"id": "turn-probe"}}
+
+            async def wait_closed(inner_self):
+                await asyncio.Event().wait()
+
+        agent = self._agent(cwd, _Transport())
+        with patch.object(
+            _MODULE.paths,
+            "get_runtime_dir",
+            return_value=Path(runtime_dir.name),
+        ):
+            with self.assertRaisesRegex(RuntimeError, "returned no response"):
+                await agent.probe_connection(
+                    cwd,
+                    on_diagnostic=diagnostics.append,
+                )
+
+        self.assertEqual(diagnostics, ["401 Unauthorized"])
+
+    async def test_rejects_initialized_model_hub_transport(self):
+        cwd = "/tmp/user-project"
+        transport = SimpleNamespace(
+            is_initialized=True,
+            runtime_fingerprint="hub:openai/gpt-5.4-mini",
+        )
+        agent = self._agent(cwd, transport)
+
+        with self.assertRaises(CodexConnectionProbeRuntimeMismatchError):
+            await agent.probe_connection(cwd)
+
+        self.assertEqual(agent._connection_probe_cwds, {})
+
+    async def test_unregistered_probe_runtime_preserves_live_activation(self):
+        cwd = "/tmp/user-project"
+        activation = RuntimeActivationRegistry()
+        live_identity = activation.attach("codex", cwd)
+        retire_scope = Mock()
+        transport = SimpleNamespace(stop=AsyncMock())
+        agent = object.__new__(CodexAgent)
+        agent._registered_runtime = False
+        agent._transports = {cwd: transport}
+        agent._transport_last_activity = {cwd: 1.0}
+        agent._transport_locks = {cwd: asyncio.Lock()}
+        agent._transport_cwd_inodes = {cwd: 1}
+        agent._session_last_activity = {}
+        agent._session_locks = {}
+        agent._session_mgr = SimpleNamespace(all_base_sessions=lambda: [])
+        agent._turn_registry = SimpleNamespace()
+        agent.sessions = SimpleNamespace()
+        agent.controller = SimpleNamespace(
+            runtime_activation=activation,
+            model_hub_runtime=SimpleNamespace(retire_process_scope=retire_scope),
+        )
+
+        self.assertIsNone(agent._attach_transport_activation(cwd, transport))
+        await agent.shutdown_runtime()
+
+        transport.stop.assert_awaited_once_with()
+        self.assertIs(activation.current("codex", cwd), live_identity)
+        retire_scope.assert_not_called()
 
 
 class CodexAgentStopTests(unittest.IsolatedAsyncioTestCase):

--- a/tests/test_codex_agent.py
+++ b/tests/test_codex_agent.py
@@ -275,7 +275,27 @@ class CodexAgentConnectionProbeTests(unittest.IsolatedAsyncioTestCase):
         agent._connection_probes = {}
         agent._connection_probe_turns = {}
         agent._connection_probe_cwds = {}
+        agent.can_reuse_direct_connection_probe = Mock(
+            return_value=getattr(transport, "runtime_fingerprint", "direct") == "direct"
+        )
+        agent._get_or_create_transport = AsyncMock(return_value=transport)
         return agent
+
+    def test_live_probe_requires_a_cached_direct_transport_and_existing_cwd(self):
+        agent = object.__new__(CodexAgent)
+        agent._transports = {}
+        with tempfile.TemporaryDirectory() as cwd:
+            self.assertFalse(agent.can_reuse_direct_connection_probe(cwd))
+
+            direct = SimpleNamespace(runtime_fingerprint="direct")
+            agent._transports[cwd] = direct
+            self.assertTrue(agent.can_reuse_direct_connection_probe(cwd))
+
+            direct.runtime_fingerprint = "hub:openai/gpt-5.4-mini"
+            self.assertFalse(agent.can_reuse_direct_connection_probe(cwd))
+
+            direct.runtime_fingerprint = "direct"
+        self.assertFalse(agent.can_reuse_direct_connection_probe(cwd))
 
     async def test_reuses_existing_transport_with_isolated_ephemeral_thread(self):
         requests = []
@@ -313,9 +333,13 @@ class CodexAgentConnectionProbeTests(unittest.IsolatedAsyncioTestCase):
         transport = _Transport()
         agent = self._agent(cwd, transport)
         diagnostics = []
-        agent._get_or_create_transport = AsyncMock(
-            side_effect=AssertionError("existing transport should be reused")
-        )
+
+        async def acquire_transport(_cwd, *, allow_runtime_replacement):
+            self.assertEqual(agent._connection_probe_cwds, {})
+            self.assertFalse(allow_runtime_replacement)
+            return transport
+
+        agent._get_or_create_transport = AsyncMock(side_effect=acquire_transport)
 
         with patch.object(
             _MODULE.paths,
@@ -329,7 +353,10 @@ class CodexAgentConnectionProbeTests(unittest.IsolatedAsyncioTestCase):
             )
 
         self.assertEqual(result, "hello")
-        agent._get_or_create_transport.assert_not_awaited()
+        agent._get_or_create_transport.assert_awaited_once_with(
+            cwd,
+            allow_runtime_replacement=False,
+        )
         self.assertEqual(requests[0][0], "thread/start")
         self.assertEqual(
             requests[0][1],
@@ -507,6 +534,23 @@ class CodexAgentConnectionProbeTests(unittest.IsolatedAsyncioTestCase):
         with self.assertRaises(CodexConnectionProbeRuntimeMismatchError):
             await agent.probe_connection(cwd)
 
+        self.assertEqual(agent._connection_probe_cwds, {})
+
+    async def test_runtime_fingerprint_race_does_not_replace_model_hub_transport(self):
+        cwd = "/tmp/user-project"
+        transport = SimpleNamespace(is_initialized=True, runtime_fingerprint="direct")
+        agent = self._agent(cwd, transport)
+        agent._get_or_create_transport = AsyncMock(
+            side_effect=CodexConnectionProbeRuntimeMismatchError("runtime changed")
+        )
+
+        with self.assertRaises(CodexConnectionProbeRuntimeMismatchError):
+            await agent.probe_connection(cwd)
+
+        agent._get_or_create_transport.assert_awaited_once_with(
+            cwd,
+            allow_runtime_replacement=False,
+        )
         self.assertEqual(agent._connection_probe_cwds, {})
 
     async def test_unregistered_probe_runtime_preserves_live_activation(self):
@@ -3850,6 +3894,28 @@ class CodexTransportCwdStalenessTests(unittest.IsolatedAsyncioTestCase):
             self.assertIs(result, cached)
             cached.stop.assert_not_awaited()
             ctor.assert_not_called()
+
+    async def test_probe_validation_does_not_replace_incompatible_runtime(self):
+        import tempfile
+
+        agent = self._agent()
+        with tempfile.TemporaryDirectory() as cwd:
+            cached = SimpleNamespace(
+                is_initialized=True,
+                runtime_fingerprint="hub:openai/gpt-5.4-mini",
+                stop=AsyncMock(),
+            )
+            agent._transports[cwd] = cached
+            agent._transport_cwd_inodes[cwd] = os.stat(cwd).st_ino
+
+            with self.assertRaises(CodexConnectionProbeRuntimeMismatchError):
+                await agent._get_or_create_transport(
+                    cwd,
+                    allow_runtime_replacement=False,
+                )
+
+            cached.stop.assert_not_awaited()
+            self.assertIs(agent._transports[cwd], cached)
 
     async def test_untracked_legacy_entry_reuses_without_inode(self):
         import tempfile

--- a/tests/test_codex_transport.py
+++ b/tests/test_codex_transport.py
@@ -54,6 +54,30 @@ class CodexTransportHealthTests(unittest.IsolatedAsyncioTestCase):
         with self.assertRaises(ConnectionError):
             await transport.send_notification("initialized")
 
+    async def test_cancelled_request_does_not_leave_pending_rpc(self):
+        request_written = asyncio.Event()
+
+        class _Stdin:
+            def is_closing(self):
+                return False
+
+            def write(self, _payload):
+                return None
+
+            async def drain(self):
+                request_written.set()
+
+        transport = CodexTransport(binary="codex", cwd="/tmp")
+        transport._process = SimpleNamespace(returncode=None, stdin=_Stdin())
+
+        task = asyncio.create_task(transport.send_request("turn/interrupt", {}))
+        await request_written.wait()
+        task.cancel()
+        with self.assertRaises(asyncio.CancelledError):
+            await task
+
+        self.assertEqual(transport._pending, {})
+
     async def test_pending_notification_keeps_terminal_pipeline_alive(self):
         transport = CodexTransport(binary="codex", cwd="/tmp")
         started = asyncio.Event()

--- a/tests/test_codex_transport.py
+++ b/tests/test_codex_transport.py
@@ -78,6 +78,30 @@ class CodexTransportHealthTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertFalse(transport.has_pending_notifications)
 
+    async def test_wait_closed_waits_for_already_read_notifications(self):
+        transport = CodexTransport(binary="codex", cwd="/tmp")
+        started = asyncio.Event()
+        release = asyncio.Event()
+
+        async def handle(_method, _params):
+            started.set()
+            await release.wait()
+
+        transport._notification_cb = handle
+        transport._notify_task = asyncio.create_task(transport._notify_worker())
+        transport._notify_queue.put_nowait(("turn/completed", {}))
+        await started.wait()
+        transport._closed_event.set()
+        waiter = asyncio.create_task(transport.wait_closed())
+        await asyncio.sleep(0)
+        self.assertFalse(waiter.done())
+
+        release.set()
+        await waiter
+        await asyncio.sleep(0)
+        transport._notify_task.cancel()
+        await transport._notify_task
+
     def test_stream_buffer_limit_allows_large_codex_thread_responses(self):
         self.assertGreaterEqual(STREAM_BUFFER_LIMIT, 128 * 1024 * 1024)
 

--- a/tests/test_codex_transport.py
+++ b/tests/test_codex_transport.py
@@ -3,6 +3,7 @@ import sys
 import unittest
 from pathlib import Path
 from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
@@ -10,6 +11,48 @@ from modules.agents.codex.transport import CodexTransport, STREAM_BUFFER_LIMIT
 
 
 class CodexTransportHealthTests(unittest.IsolatedAsyncioTestCase):
+    async def test_cancelled_initialize_stops_unpublished_transport(self):
+        initialize_started = asyncio.Event()
+
+        class _Stream:
+            async def readline(self):
+                await asyncio.Event().wait()
+
+        process = SimpleNamespace(
+            pid=123,
+            returncode=None,
+            stdin=None,
+            stdout=_Stream(),
+            stderr=_Stream(),
+        )
+        transport = CodexTransport(binary="codex", cwd="/tmp")
+
+        async def wait_for_initialize(_method, _params):
+            initialize_started.set()
+            await asyncio.Event().wait()
+
+        async def stop_transport():
+            transport._cleanup_tasks()
+
+        transport.send_request = AsyncMock(side_effect=wait_for_initialize)
+        transport.stop = AsyncMock(side_effect=stop_transport)
+
+        with (
+            patch(
+                "modules.agents.codex.transport.asyncio.create_subprocess_exec",
+                new=AsyncMock(return_value=process),
+            ),
+            patch("modules.agents.codex.transport.process_identity", return_value={}),
+            patch("modules.agents.codex.transport.log_process_snapshot"),
+        ):
+            task = asyncio.create_task(transport.start())
+            await initialize_started.wait()
+            task.cancel()
+            with self.assertRaises(asyncio.CancelledError):
+                await task
+
+        transport.stop.assert_awaited_once_with()
+
     async def test_reader_task_failure_marks_transport_not_alive(self):
         transport = CodexTransport(binary="codex", cwd="/tmp")
         transport._process = SimpleNamespace(returncode=None)

--- a/tests/test_internal_client.py
+++ b/tests/test_internal_client.py
@@ -199,6 +199,46 @@ def test_reconcile_agent_backends_missing_socket_raises_unavailable(tmp_path):
         )
 
 
+def test_backend_auth_round_trip(tmp_path):
+    app = FastAPI()
+    captured: dict = {}
+
+    @app.post("/internal/backend-auth/test")
+    async def _test(payload: dict):
+        captured["payload"] = payload
+        return {"ok": True, "excerpt": "hello"}
+
+    sock = tmp_path / "dispatch.sock"
+    sock.touch()
+
+    async def _go():
+        fake_transport = httpx.ASGITransport(app=app)
+        with patch("vibe.internal_client.httpx.AsyncHTTPTransport", return_value=fake_transport):
+            return await internal_client.test_backend_auth(
+                "codex",
+                model="gpt-5.4-mini",
+                socket_path=sock,
+            )
+
+    result = asyncio.run(_go())
+
+    assert captured["payload"] == {"backend": "codex", "model": "gpt-5.4-mini"}
+    assert result == {
+        "status_code": 200,
+        "body": {"ok": True, "excerpt": "hello"},
+    }
+
+
+def test_backend_auth_missing_socket_raises_unavailable(tmp_path):
+    with pytest.raises(internal_client.InternalServerUnavailable):
+        asyncio.run(
+            internal_client.test_backend_auth(
+                "claude",
+                socket_path=tmp_path / "missing.sock",
+            )
+        )
+
+
 def test_notify_vault_request_created_round_trip(tmp_path):
     app = FastAPI()
     captured: dict = {}

--- a/tests/test_internal_server.py
+++ b/tests/test_internal_server.py
@@ -573,6 +573,44 @@ def test_reconcile_agent_backends_endpoint_rejects_invalid_shape():
     }
 
 
+def test_backend_auth_endpoint_uses_controller_owned_service():
+    controller = _build_controller_double()
+    test_web_auth = AsyncMock(return_value={"ok": True, "excerpt": "hello"})
+    controller.agent_auth_service = SimpleNamespace(test_web_auth=test_web_auth)
+    app = internal_server.create_app(controller)
+
+    async def _go():
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+            return await client.post(
+                "/internal/backend-auth/test",
+                json={"backend": "Codex", "model": "gpt-5.4-mini"},
+            )
+
+    resp = asyncio.run(_go())
+
+    assert resp.status_code == 200
+    assert resp.json() == {"ok": True, "excerpt": "hello"}
+    test_web_auth.assert_awaited_once_with("codex", model="gpt-5.4-mini")
+
+
+def test_backend_auth_endpoint_rejects_invalid_shape():
+    app = internal_server.create_app(_build_controller_double())
+
+    async def _go():
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+            return await client.post(
+                "/internal/backend-auth/test",
+                json={"backend": "codex", "model": ["gpt-5.4-mini"]},
+            )
+
+    resp = asyncio.run(_go())
+
+    assert resp.status_code == 400
+    assert resp.json() == {"ok": False, "error": "model must be a string"}
+
+
 async def _dispatch_round_trip(body: dict) -> httpx.Response:
     app = internal_server.create_app(_build_controller_double())
     transport = httpx.ASGITransport(app=app)

--- a/tests/test_ui_server_fastapi.py
+++ b/tests/test_ui_server_fastapi.py
@@ -120,6 +120,32 @@ def test_fastapi_schema_routes_are_not_exposed():
     assert client.get("/openapi.json").status_code != 200
 
 
+def test_backend_auth_test_routes_through_controller_runtime(monkeypatch):
+    from vibe import internal_client
+
+    calls = []
+
+    async def _test_backend_auth(backend, *, model=None):
+        calls.append((backend, model))
+        return {
+            "status_code": 200,
+            "body": {"ok": True, "excerpt": "hello"},
+        }
+
+    monkeypatch.setattr(internal_client, "test_backend_auth", _test_backend_auth)
+    client = app.test_client()
+
+    response = client.post(
+        "/api/backend/codex/auth/test",
+        json={"model": "gpt-5.4-mini"},
+        headers=csrf_headers(client),
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": True, "excerpt": "hello"}
+    assert calls == [("codex", "gpt-5.4-mini")]
+
+
 def test_thread_settings_routes_use_native_fastapi(monkeypatch):
     from vibe import api
 

--- a/tests/test_v2_compat_platforms.py
+++ b/tests/test_v2_compat_platforms.py
@@ -50,6 +50,7 @@ def test_to_app_config_preserves_enabled_platforms():
     assert compat.platform == "discord"
     assert compat.platforms == {"enabled": ["slack", "discord"], "primary": "discord"}
     assert compat.enabled_platforms() == ["slack", "discord"]
+    assert compat.default_cwd == config.runtime.default_cwd
 
 
 def test_to_app_config_preserves_telegram_config():

--- a/tests/test_web_oauth_flow.py
+++ b/tests/test_web_oauth_flow.py
@@ -16,7 +16,7 @@ import json
 import os
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import ANY, AsyncMock
 
 import pytest
 
@@ -1318,34 +1318,120 @@ def test_test_web_auth_rejects_unsupported_backend(service: AgentAuthService) ->
 def test_test_web_auth_surfaces_cli_not_found(
     service: AgentAuthService, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    async def _spawn(*_args, **_kwargs):
-        raise FileNotFoundError("no such cli")
-
-    monkeypatch.setattr(asyncio, "create_subprocess_exec", _spawn)
+    monkeypatch.setattr(
+        service,
+        "_run_codex_agent_probe",
+        AsyncMock(side_effect=FileNotFoundError("no such cli")),
+    )
     result = _run(service.test_web_auth("codex"))
     assert result["ok"] is False
     assert result["error"] == "cli_not_found"
 
 
+def test_claude_probe_timeout_bounds_disconnect_and_reaps_process(
+    service: AgentAuthService, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    class _WedgedClaudeClient:
+        async def disconnect(self):
+            await asyncio.Event().wait()
+
+    reap = AsyncMock(return_value=1)
+    monkeypatch.setattr(
+        "core.agent_auth_service.CLAUDE_PROBE_DISCONNECT_TIMEOUT_SECONDS",
+        0.01,
+    )
+    monkeypatch.setattr("core.agent_auth_service.get_claude_client_pid", lambda _client: 4321)
+    monkeypatch.setattr("core.agent_auth_service._reap_pid_set", reap)
+
+    _run(service._disconnect_claude_probe_client(_WedgedClaudeClient()))
+
+    reap.assert_awaited_once_with(
+        {4321},
+        terminate_timeout=2.0,
+        logger=ANY,
+    )
+
+
 def test_test_web_auth_happy_path_returns_excerpt(
     service: AgentAuthService, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """A passing probe surfaces the first non-blank stdout line + duration."""
+    """Codex probes use app-server thread/turn requests, not ``codex exec``."""
+    captured: dict[str, object] = {"requests": []}
 
-    class _FakeProcess:
-        returncode = 0
+    class _FakeTransport:
+        pid = None
 
-        async def communicate(self):
-            return (b"\nHello from the model\nmore text", b"")
+        def __init__(self, **kwargs):
+            captured["init"] = kwargs
+            self.notification = None
 
-    async def _spawn(*_args, **_kwargs):
-        return _FakeProcess()
+        def on_notification(self, callback):
+            self.notification = callback
 
-    monkeypatch.setattr(asyncio, "create_subprocess_exec", _spawn)
-    result = _run(service.test_web_auth("codex"))
+        def on_server_request(self, callback):
+            captured["server_request"] = callback
+
+        async def start(self):
+            captured["started"] = True
+
+        async def stop(self):
+            captured["stopped"] = True
+
+        async def send_request(self, method, params):
+            captured["requests"].append((method, params))
+            if method == "thread/start":
+                return {"thread": {"id": "thread-probe"}}
+            assert self.notification is not None
+            await self.notification(
+                "error",
+                {
+                    "turnId": "turn-probe",
+                    "willRetry": True,
+                    "error": {"message": "temporary upstream disconnect"},
+                },
+            )
+            await self.notification(
+                "item/completed",
+                {
+                    "turnId": "turn-probe",
+                    "item": {"type": "agentMessage", "text": "Hello from the model\nmore text"},
+                },
+            )
+            await self.notification(
+                "turn/completed",
+                {"turn": {"id": "turn-probe", "status": "completed"}},
+            )
+            return {"turn": {"id": "turn-probe"}}
+
+    monkeypatch.setattr("modules.agents.codex.transport.CodexTransport", _FakeTransport)
+    result = _run(service.test_web_auth("codex", model="gpt-5.4-mini"))
+
     assert result["ok"] is True
     assert result["excerpt"] == "Hello from the model"
     assert isinstance(result["duration_ms"], int)
+    assert captured["started"] is True
+    assert captured["stopped"] is True
+    assert captured["requests"] == [
+        (
+            "thread/start",
+            {
+                "cwd": os.getcwd(),
+                "approvalPolicy": "never",
+                "sandbox": "danger-full-access",
+            },
+        ),
+        (
+            "turn/start",
+            {
+                "threadId": "thread-probe",
+                "input": [{"type": "text", "text": "Hi"}],
+                "approvalPolicy": "never",
+                "sandboxPolicy": {"type": "dangerFullAccess"},
+                "effort": "low",
+                "model": "gpt-5.4-mini",
+            },
+        ),
+    ]
 
 
 def test_verify_web_login_claude_forces_oauth_env(
@@ -1424,38 +1510,52 @@ def test_verify_web_login_claude_forces_oauth_env(
 def test_test_web_auth_claude_oauth_env_removes_stale_anthropic_vars(
     service: AgentAuthService, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """The Settings Test button runs a real Claude subprocess; when OAuth is
-    explicitly selected it must use the same env cleanup as live sessions.
-    """
+    """The Claude probe uses the SDK with the same filtered launch env."""
 
     captured: dict = {}
 
-    class _FakeProcess:
-        returncode = 0
+    class _FakeClaudeClient:
+        def __init__(self, *, options):
+            captured["options"] = options
 
-        async def communicate(self):
-            return (b"Hello from Claude", b"")
+        async def connect(self):
+            captured["connected"] = True
 
-    async def _spawn(*args, **kwargs):
-        captured["args"] = args
-        captured["env"] = kwargs.get("env") or {}
-        return _FakeProcess()
+        async def query(self, text):
+            captured["query"] = text
+
+        async def receive_response(self):
+            yield SimpleNamespace(
+                is_error=False,
+                result="Hello from Claude",
+                content=[],
+                error=None,
+            )
+
+        async def disconnect(self):
+            captured["disconnected"] = True
 
     monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-stale-shell")
     monkeypatch.setenv("ANTHROPIC_AUTH_TOKEN", "bearer-stale-shell")
     monkeypatch.setenv("ANTHROPIC_BASE_URL", "https://stale-relay.example")
     monkeypatch.setattr(_Backend, "auth_mode", "oauth", raising=False)
     monkeypatch.setattr(_Backend, "auth_mode_set", True, raising=False)
-    monkeypatch.setattr(asyncio, "create_subprocess_exec", _spawn)
+    monkeypatch.setattr("core.agent_auth_service.ClaudeSDKClient", _FakeClaudeClient)
 
     result = _run(service.test_web_auth("claude"))
 
     assert result["ok"] is True
-    assert captured["args"][:2] == ("/usr/bin/echo", "-p")
-    assert "--bare" not in captured["args"]
-    assert "ANTHROPIC_API_KEY" not in captured["env"]
-    assert "ANTHROPIC_AUTH_TOKEN" not in captured["env"]
-    assert "ANTHROPIC_BASE_URL" not in captured["env"]
+    options = captured["options"]
+    assert options.cli_path == "/usr/bin/echo"
+    assert options.permission_mode == "bypassPermissions"
+    assert options.setting_sources == ["user", "project", "local"]
+    assert options.tools == []
+    assert options.env["ANTHROPIC_API_KEY"] == ""
+    assert options.env["ANTHROPIC_AUTH_TOKEN"] == ""
+    assert options.env["ANTHROPIC_BASE_URL"] == ""
+    assert captured["query"] == "Hi"
+    assert captured["connected"] is True
+    assert captured["disconnected"] is True
 
 
 def test_test_web_auth_claude_runs_in_runtime_cwd(
@@ -1463,116 +1563,90 @@ def test_test_web_auth_claude_runs_in_runtime_cwd(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Plain Claude print mode reads project config from cwd; the Settings
-    probe must use the same runtime cwd as live Agent turns.
-    """
+    """The isolated SDK probe uses the same default cwd as live Agent turns."""
 
     runtime_cwd = tmp_path / "agent-workdir"
-    captured: dict = {}
 
     class _Runtime:
         default_cwd = str(runtime_cwd)
 
-    class _FakeProcess:
-        returncode = 0
-
-        async def communicate(self):
-            return (b"Hello from Claude", b"")
-
-    async def _spawn(*_args, **kwargs):
-        captured["cwd"] = kwargs.get("cwd")
-        return _FakeProcess()
-
+    probe = AsyncMock(return_value="Hello from Claude")
     monkeypatch.setattr(_Config, "runtime", _Runtime(), raising=False)
-    monkeypatch.setattr(asyncio, "create_subprocess_exec", _spawn)
+    monkeypatch.setattr(service, "_run_claude_agent_probe", probe)
 
     result = _run(service.test_web_auth("claude"))
 
     assert result["ok"] is True
-    assert captured["cwd"] == str(runtime_cwd)
+    probe.assert_awaited_once_with(
+        binary="/usr/bin/echo",
+        cwd=str(runtime_cwd),
+        model=None,
+    )
     assert runtime_cwd.is_dir()
 
 
 def test_test_web_auth_claude_oauth_reports_settings_cleanup_failure(
     service: AgentAuthService, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    async def _spawn(*_args, **_kwargs):
-        raise AssertionError("Claude probe must not spawn when cleanup fails")
-
     def fail_cleanup(**_kwargs):
         raise OSError("settings locked")
 
+    probe = AsyncMock(side_effect=AssertionError("Claude probe must not start"))
     monkeypatch.setattr(_Backend, "auth_mode", "oauth", raising=False)
     monkeypatch.setattr(_Backend, "auth_mode_set", True, raising=False)
     monkeypatch.setattr("vibe.claude_config.apply_claude_auth", fail_cleanup)
-    monkeypatch.setattr(asyncio, "create_subprocess_exec", _spawn)
+    monkeypatch.setattr(service, "_run_claude_agent_probe", probe)
 
     result = _run(service.test_web_auth("claude"))
 
     assert result["ok"] is False
     assert result["error"] == "settings_cleanup_failed"
     assert "Failed to clear Claude Code settings env" in result["detail"]
+    probe.assert_not_awaited()
 
 
 def test_test_web_auth_failure_surfaces_stderr(
     service: AgentAuthService, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    class _FakeProcess:
-        returncode = 7
-
-        async def communicate(self):
-            return (b"", b"Authentication failed: no credentials configured")
-
-    async def _spawn(*_args, **_kwargs):
-        return _FakeProcess()
-
-    monkeypatch.setattr(asyncio, "create_subprocess_exec", _spawn)
+    monkeypatch.setattr(
+        service,
+        "_run_claude_agent_probe",
+        AsyncMock(side_effect=RuntimeError("Authentication failed: no credentials configured")),
+    )
     result = _run(service.test_web_auth("claude"))
     assert result["ok"] is False
     # The classifier turns "Authentication failed" stderr into the
     # specific ``invalid_credentials`` code so the UI can render the
     # actionable "Replace your API key or re-authenticate" sentence.
     assert result["error"] == "invalid_credentials"
-    assert result["exit_code"] == 7
     assert "Authentication failed" in (result.get("detail") or "")
 
 
 def test_test_web_auth_not_logged_in_has_specific_error_code(
     service: AgentAuthService, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    class _FakeProcess:
-        returncode = 1
-
-        async def communicate(self):
-            return (b"Not logged in \xc2\xb7 Please run /login", b"")
-
-    async def _spawn(*_args, **_kwargs):
-        return _FakeProcess()
-
-    monkeypatch.setattr(asyncio, "create_subprocess_exec", _spawn)
+    monkeypatch.setattr(
+        service,
+        "_run_claude_agent_probe",
+        AsyncMock(side_effect=RuntimeError("Not logged in · Please run /login")),
+    )
     monkeypatch.setattr(_Backend, "auth_mode", "oauth", raising=False)
 
     result = _run(service.test_web_auth("claude"))
 
     assert result["ok"] is False
     assert result["error"] == "not_logged_in"
-    assert result["exit_code"] == 1
     assert "Not logged in" in (result.get("detail") or "")
 
 
 def test_test_web_auth_api_key_mode_does_not_prompt_for_oauth_login(
     service: AgentAuthService, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    class _FakeProcess:
-        returncode = 1
-
-        async def communicate(self):
-            return (b"Not logged in \xc2\xb7 Please run /login", b"")
-
-    async def _spawn(*_args, **_kwargs):
-        return _FakeProcess()
-
-    monkeypatch.setattr(asyncio, "create_subprocess_exec", _spawn)
+    monkeypatch.setattr(
+        service,
+        "_run_claude_agent_probe",
+        AsyncMock(side_effect=RuntimeError("Not logged in · Please run /login")),
+    )
     monkeypatch.setattr(_Backend, "auth_mode", "api_key", raising=False)
     monkeypatch.setattr(_Backend, "auth_mode_set", True, raising=False)
 
@@ -1580,4 +1654,3 @@ def test_test_web_auth_api_key_mode_does_not_prompt_for_oauth_login(
 
     assert result["ok"] is False
     assert result["error"] == "invalid_credentials"
-    assert result["exit_code"] == 1

--- a/tests/test_web_oauth_flow.py
+++ b/tests/test_web_oauth_flow.py
@@ -1416,6 +1416,7 @@ def test_test_web_auth_happy_path_returns_excerpt(
 
 def test_test_web_auth_codex_uses_owned_runtime_when_backend_is_disabled(
     service: AgentAuthService,
+    tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     probe = AsyncMock(return_value="Hello from temporary Codex")
@@ -1425,7 +1426,16 @@ def test_test_web_auth_codex_uses_owned_runtime_when_backend_is_disabled(
         shutdown_runtime=shutdown,
     )
     captured = []
+    configured_cwd = tmp_path / "user-runtime"
+    probe_runtime = tmp_path / "avibe-runtime"
     service.controller.agent_service = SimpleNamespace(agents={})
+    monkeypatch.setattr(
+        _Config,
+        "runtime",
+        SimpleNamespace(default_cwd=str(configured_cwd)),
+        raising=False,
+    )
+    monkeypatch.setattr("config.paths.get_runtime_dir", lambda: probe_runtime)
     monkeypatch.setattr(service, "_get_cli_binary", lambda _backend: "codex-custom")
     monkeypatch.setattr(
         service,
@@ -1438,11 +1448,12 @@ def test_test_web_auth_codex_uses_owned_runtime_when_backend_is_disabled(
     assert result["ok"] is True
     assert captured[0].binary == "codex-custom"
     probe.assert_awaited_once_with(
-        os.getcwd(),
+        str(probe_runtime / "codex-connection-probe"),
         model=None,
         on_diagnostic=ANY,
     )
     shutdown.assert_awaited_once_with()
+    assert not configured_cwd.exists()
 
 
 def test_disabled_backend_probe_uses_persisted_codex_binary(
@@ -1462,6 +1473,7 @@ def test_disabled_backend_probe_uses_persisted_codex_binary(
 
 def test_test_web_auth_codex_does_not_probe_model_hub_transport(
     service: AgentAuthService,
+    tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     live_probe = AsyncMock(
@@ -1477,6 +1489,8 @@ def test_test_web_auth_codex_does_not_probe_model_hub_transport(
         shutdown_runtime=AsyncMock(),
     )
     service.controller.agent_service = SimpleNamespace(agents={"codex": live_agent})
+    probe_runtime = tmp_path / "avibe-runtime"
+    monkeypatch.setattr("config.paths.get_runtime_dir", lambda: probe_runtime)
     monkeypatch.setattr(
         service,
         "_create_codex_probe_agent",
@@ -1488,7 +1502,7 @@ def test_test_web_auth_codex_does_not_probe_model_hub_transport(
     assert result["ok"] is True
     live_probe.assert_not_awaited()
     temp_probe.assert_awaited_once_with(
-        os.getcwd(),
+        str(probe_runtime / "codex-connection-probe"),
         model=None,
         on_diagnostic=ANY,
     )

--- a/tests/test_web_oauth_flow.py
+++ b/tests/test_web_oauth_flow.py
@@ -1352,86 +1352,62 @@ def test_claude_probe_timeout_bounds_disconnect_and_reaps_process(
     )
 
 
-def test_test_web_auth_happy_path_returns_excerpt(
+def test_claude_probe_reaps_process_when_disconnect_raises(
     service: AgentAuthService, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Codex probes use app-server thread/turn requests, not ``codex exec``."""
-    captured: dict[str, object] = {"requests": []}
+    class _BrokenClaudeClient:
+        async def disconnect(self):
+            raise RuntimeError("disconnect failed")
 
-    class _FakeTransport:
-        pid = None
+    reap = AsyncMock(return_value=1)
+    monkeypatch.setattr("core.agent_auth_service.get_claude_client_pid", lambda _client: 4321)
+    monkeypatch.setattr("core.agent_auth_service._reap_pid_set", reap)
 
-        def __init__(self, **kwargs):
-            captured["init"] = kwargs
-            self.notification = None
+    _run(service._disconnect_claude_probe_client(_BrokenClaudeClient()))
 
-        def on_notification(self, callback):
-            self.notification = callback
+    reap.assert_awaited_once_with(
+        {4321},
+        terminate_timeout=2.0,
+        logger=ANY,
+    )
 
-        def on_server_request(self, callback):
-            captured["server_request"] = callback
 
-        async def start(self):
-            captured["started"] = True
+def test_claude_probe_does_not_reap_process_that_exited_after_disconnect_error(
+    service: AgentAuthService, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    process_wait = AsyncMock(return_value=0)
 
-        async def stop(self):
-            captured["stopped"] = True
+    class _BrokenClaudeClient:
+        _transport = SimpleNamespace(_process=SimpleNamespace(wait=process_wait))
 
-        async def send_request(self, method, params):
-            captured["requests"].append((method, params))
-            if method == "thread/start":
-                return {"thread": {"id": "thread-probe"}}
-            assert self.notification is not None
-            await self.notification(
-                "error",
-                {
-                    "turnId": "turn-probe",
-                    "willRetry": True,
-                    "error": {"message": "temporary upstream disconnect"},
-                },
-            )
-            await self.notification(
-                "item/completed",
-                {
-                    "turnId": "turn-probe",
-                    "item": {"type": "agentMessage", "text": "Hello from the model\nmore text"},
-                },
-            )
-            await self.notification(
-                "turn/completed",
-                {"turn": {"id": "turn-probe", "status": "completed"}},
-            )
-            return {"turn": {"id": "turn-probe"}}
+        async def disconnect(self):
+            raise RuntimeError("disconnect failed")
 
-    monkeypatch.setattr("modules.agents.codex.transport.CodexTransport", _FakeTransport)
+    reap = AsyncMock(return_value=1)
+    monkeypatch.setattr("core.agent_auth_service.get_claude_client_pid", lambda _client: 4321)
+    monkeypatch.setattr("core.agent_auth_service._reap_pid_set", reap)
+
+    _run(service._disconnect_claude_probe_client(_BrokenClaudeClient()))
+
+    process_wait.assert_awaited_once_with()
+    reap.assert_not_awaited()
+
+
+def test_test_web_auth_happy_path_returns_excerpt(
+    service: AgentAuthService,
+) -> None:
+    """AgentAuthService delegates Codex probes to the live Agent runtime."""
+    probe = AsyncMock(return_value="Hello from the model\nmore text")
+    service.controller.agent_service = SimpleNamespace(
+        agents={"codex": SimpleNamespace(probe_connection=probe)}
+    )
+
     result = _run(service.test_web_auth("codex", model="gpt-5.4-mini"))
 
     assert result["ok"] is True
     assert result["excerpt"] == "Hello from the model"
     assert isinstance(result["duration_ms"], int)
-    assert captured["started"] is True
-    assert captured["stopped"] is True
-    assert captured["requests"] == [
-        (
-            "thread/start",
-            {
-                "cwd": os.getcwd(),
-                "approvalPolicy": "never",
-                "sandbox": "danger-full-access",
-            },
-        ),
-        (
-            "turn/start",
-            {
-                "threadId": "thread-probe",
-                "input": [{"type": "text", "text": "Hi"}],
-                "approvalPolicy": "never",
-                "sandboxPolicy": {"type": "dangerFullAccess"},
-                "effort": "low",
-                "model": "gpt-5.4-mini",
-            },
-        ),
-    ]
+    probe.assert_awaited_once_with(os.getcwd(), model="gpt-5.4-mini")
 
 
 def test_verify_web_login_claude_forces_oauth_env(

--- a/tests/test_web_oauth_flow.py
+++ b/tests/test_web_oauth_flow.py
@@ -1407,7 +1407,92 @@ def test_test_web_auth_happy_path_returns_excerpt(
     assert result["ok"] is True
     assert result["excerpt"] == "Hello from the model"
     assert isinstance(result["duration_ms"], int)
-    probe.assert_awaited_once_with(os.getcwd(), model="gpt-5.4-mini")
+    probe.assert_awaited_once_with(
+        os.getcwd(),
+        model="gpt-5.4-mini",
+        on_diagnostic=ANY,
+    )
+
+
+def test_test_web_auth_codex_uses_owned_runtime_when_backend_is_disabled(
+    service: AgentAuthService,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    probe = AsyncMock(return_value="Hello from temporary Codex")
+    shutdown = AsyncMock()
+    temp_agent = SimpleNamespace(
+        probe_connection=probe,
+        shutdown_runtime=shutdown,
+    )
+    captured = []
+    service.controller.agent_service = SimpleNamespace(agents={})
+    monkeypatch.setattr(service, "_get_cli_binary", lambda _backend: "codex-custom")
+    monkeypatch.setattr(
+        service,
+        "_create_codex_probe_agent",
+        lambda runtime_config: captured.append(runtime_config) or temp_agent,
+    )
+
+    result = _run(service.test_web_auth("codex"))
+
+    assert result["ok"] is True
+    assert captured[0].binary == "codex-custom"
+    probe.assert_awaited_once_with(
+        os.getcwd(),
+        model=None,
+        on_diagnostic=ANY,
+    )
+    shutdown.assert_awaited_once_with()
+
+
+def test_disabled_backend_probe_uses_persisted_codex_binary(
+    service: AgentAuthService,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from config.v2_config import V2Config
+
+    persisted = SimpleNamespace(
+        agents=SimpleNamespace(codex=SimpleNamespace(cli_path="/opt/codex/bin/codex"))
+    )
+    monkeypatch.setattr(service, "_resolve_backend_config", lambda _backend: None)
+    monkeypatch.setattr(V2Config, "load", classmethod(lambda _cls: persisted))
+
+    assert service._get_cli_binary("codex") == "/opt/codex/bin/codex"
+
+
+def test_test_web_auth_codex_does_not_probe_model_hub_transport(
+    service: AgentAuthService,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    live_probe = AsyncMock(
+        side_effect=AssertionError("Model Hub transport must not test direct credentials")
+    )
+    live_agent = SimpleNamespace(
+        probe_connection=live_probe,
+        can_reuse_direct_connection_probe=lambda _cwd: False,
+    )
+    temp_probe = AsyncMock(return_value="Hello from direct Codex")
+    temp_agent = SimpleNamespace(
+        probe_connection=temp_probe,
+        shutdown_runtime=AsyncMock(),
+    )
+    service.controller.agent_service = SimpleNamespace(agents={"codex": live_agent})
+    monkeypatch.setattr(
+        service,
+        "_create_codex_probe_agent",
+        lambda _runtime_config: temp_agent,
+    )
+
+    result = _run(service.test_web_auth("codex"))
+
+    assert result["ok"] is True
+    live_probe.assert_not_awaited()
+    temp_probe.assert_awaited_once_with(
+        os.getcwd(),
+        model=None,
+        on_diagnostic=ANY,
+    )
+    temp_agent.shutdown_runtime.assert_awaited_once_with()
 
 
 def test_verify_web_login_claude_forces_oauth_env(
@@ -1557,6 +1642,7 @@ def test_test_web_auth_claude_runs_in_runtime_cwd(
         binary="/usr/bin/echo",
         cwd=str(runtime_cwd),
         model=None,
+        on_diagnostic=ANY,
     )
     assert runtime_cwd.is_dir()
 
@@ -1596,6 +1682,25 @@ def test_test_web_auth_failure_surfaces_stderr(
     # actionable "Replace your API key or re-authenticate" sentence.
     assert result["error"] == "invalid_credentials"
     assert "Authentication failed" in (result.get("detail") or "")
+
+
+def test_test_web_auth_timeout_preserves_retry_diagnostic(
+    service: AgentAuthService,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def retrying_probe(*, on_diagnostic, **_kwargs):
+        on_diagnostic("401 Unauthorized while retrying")
+        await asyncio.Event().wait()
+
+    monkeypatch.setattr(service, "_run_claude_agent_probe", retrying_probe)
+    monkeypatch.setattr(_Backend, "auth_mode", "api_key", raising=False)
+    monkeypatch.setattr(_Backend, "auth_mode_set", True, raising=False)
+
+    result = _run(service.test_web_auth("claude", timeout=0.01))
+
+    assert result["ok"] is False
+    assert result["error"] == "invalid_credentials"
+    assert result["detail"] == "401 Unauthorized while retrying"
 
 
 def test_test_web_auth_not_logged_in_has_specific_error_code(

--- a/ui/src/components/settings/BackendTestPanel.tsx
+++ b/ui/src/components/settings/BackendTestPanel.tsx
@@ -19,16 +19,14 @@ export type BackendTestPanelProps = {
 /**
  * Settings → Backends connectivity probe. Mirrors the ``cdTest2`` /
  * ``cxTest`` panels in ``design.pen``: sends a single ``Hi`` prompt
- * through the backend CLI so the user can confirm both the credentials
- * and the endpoint (Base URL) round-trip end-to-end. Works in both
- * OAuth and API-Key modes — the underlying CLI uses whichever auth
- * source is configured at launch.
+ * through the backend's production Agent transport so the user can
+ * confirm both the credentials and the endpoint (Base URL) round-trip
+ * end-to-end. Works in both OAuth and API-Key modes.
  *
  * The model dropdown lets the user override the backend's default
- * (important for Codex users whose ``config.toml`` selects
- * ``model_reasoning_effort=xhigh``; with the override the probe stays
- * fast). On success we echo the first content line of the model's
- * response so the user sees real output, not just a duration.
+ * (important when the configured default is unavailable or slow). On
+ * success we echo the first content line of the model's response so the
+ * user sees real output, not just a duration.
  */
 export const BackendTestPanel: React.FC<BackendTestPanelProps> = ({ backend }) => {
   const { t } = useTranslation();

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -8899,11 +8899,11 @@ def test_backend_auth(backend: str, model: Optional[str] = None) -> dict:
 
 
 async def test_backend_auth_async(backend: str, model: Optional[str] = None) -> dict:
-    """Send a single-token ``Hi`` probe through the backend CLI.
+    """Send a ``Hi`` probe through the backend's production Agent transport.
 
-    ``model`` lets the caller override the CLI's configured default —
-    important for Codex users whose ``config.toml`` selects a slow
-    reasoning model, where even "Hi" can blow past the test timeout.
+    Claude uses the Agent SDK and Codex uses app-server, matching normal
+    Avibe turns rather than a separate single-shot CLI mode. ``model`` lets
+    the caller select the model used by that isolated turn.
     """
     backend = (backend or "").strip().lower()
     if not supports_web_oauth(backend):

--- a/vibe/internal_client.py
+++ b/vibe/internal_client.py
@@ -263,6 +263,36 @@ async def reconcile_agent_backends(
     return {"status_code": resp.status_code, "body": resp.json() if resp.content else {}}
 
 
+async def test_backend_auth(
+    backend: str,
+    *,
+    model: str | None = None,
+    socket_path: Optional[Path] = None,
+    timeout: float = 60.0,
+) -> dict[str, Any]:
+    """Run a Settings connection probe on the controller-owned Agent runtime."""
+
+    target = (socket_path or default_socket_path()).expanduser().resolve()
+    if not target.exists():
+        raise InternalServerUnavailable(f"dispatch socket missing at {target}")
+    transport = httpx.AsyncHTTPTransport(uds=str(target))
+    payload: dict[str, Any] = {"backend": backend}
+    if model:
+        payload["model"] = model
+    try:
+        async with httpx.AsyncClient(
+            transport=transport,
+            base_url="http://localhost",
+            timeout=httpx.Timeout(timeout, connect=5.0),
+        ) as client:
+            resp = await client.post("/internal/backend-auth/test", json=payload)
+    except _SOCKET_CONNECT_ERRORS as exc:
+        raise InternalServerUnavailable(str(exc)) from exc
+    except httpx.TimeoutException as exc:
+        raise InternalServerTimeout(str(exc)) from exc
+    return {"status_code": resp.status_code, "body": resp.json() if resp.content else {}}
+
+
 async def notify_vault_request_created(
     request_payload: dict[str, Any],
     *,

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -5706,12 +5706,16 @@ def backend_auth_api_key_remove(backend: str):
 @app.route("/api/backend/<backend>/auth/test", methods=["POST"])
 async def backend_auth_test(backend: str):
     """Send an isolated turn through the backend's production Agent transport."""
-    from vibe import api
+    from vibe import internal_client
 
     payload = request.json or {}
     raw_model = payload.get("model")
     model = raw_model.strip() if isinstance(raw_model, str) and raw_model.strip() else None
-    return jsonify(await api.test_backend_auth_async(backend, model=model))
+    try:
+        result = await internal_client.test_backend_auth(backend, model=model)
+    except (internal_client.InternalServerUnavailable, internal_client.InternalServerTimeout) as exc:
+        return jsonify({"ok": False, "error": "spawn_failed", "detail": str(exc)})
+    return jsonify(result.get("body") or {"ok": False, "error": "test_failed"})
 
 
 @app.route("/api/backend/opencode/providers", methods=["GET"])

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -5705,7 +5705,7 @@ def backend_auth_api_key_remove(backend: str):
 
 @app.route("/api/backend/<backend>/auth/test", methods=["POST"])
 async def backend_auth_test(backend: str):
-    """Send a single-token probe through the backend CLI to verify auth."""
+    """Send an isolated turn through the backend's production Agent transport."""
     from vibe import api
 
     payload = request.json or {}


### PR DESCRIPTION
## Summary

- run the Claude Settings connection test through an isolated Claude Agent SDK turn instead of `claude -p`
- route Settings probes into the controller-owned Agent runtime instead of constructing backend transports in the UI process
- reuse a matching direct Codex app-server; use an unregistered Controller-owned direct probe only when Codex is disabled, its live config differs, no direct transport is cached, or the cwd is occupied by Model Hub
- keep OpenCode on its existing live `opencode serve` HTTP session probe because it already matches normal Agent traffic
- interrupt cancelled Codex probe turns, reap Claude/Codex probe children, and preserve retry diagnostics for typed UI errors

## Changed capability

Settings backend connection tests now validate the same transport family used by normal Agent turns. Codex resolves the configured runtime cwd and reuses its persistent direct app-server only when that runtime represents the credentials shown in Settings. A Model Hub runtime is never used to validate direct Codex credentials; the fallback probe is explicitly unregistered so it cannot replace the live runtime activation or retire its Model Hub process scope. The probe thread is ephemeral, read-only, and isolated from the configured project.

The second findings-bearing head triggered the first review-loop circuit breaker. The scope decision was to make runtime ownership explicit rather than continue patching individual branches: live matching direct runtimes are borrowed, incompatible or disabled runtimes get one Controller-owned temporary direct runtime, and cancellation/diagnostic cleanup belongs to the probe lifecycle.

The post-breaker `5f2242ad` head then received four more findings, making it the third findings-bearing head after the lifecycle rewrite and forcing a second full stop. The inventory exposed one remaining boundary rather than four independent defects: a probe was claiming cwd ownership before transport validation, initialized reuse bypassed that validation, temporary runtime creation still inherited the configured user cwd, and `CodexTransport.start()` did not own cancellation cleanup until publication. The scope decision is to close that boundary at its owners: all live probes validate through `_get_or_create_transport()` before claiming cwd ownership; incompatible runtime replacement is forbidden on the probe path; temporary probes launch only from Avibe-owned state; and `CodexTransport.start()` reaps every process that fails or is cancelled before registration. This is contract-preserving and does not change normal Agent turn routing.

## Scenarios

- `AUTH-SETUP-905`: Claude SDK probe drops a stale inherited auth token after switching from OAuth
- `AUTH-SETUP-906`: Codex connection probe reuses the persistent app-server with an ephemeral turn

## Evidence

- Unit: focused Agent, transport, auth-service, compat-config, internal-controller, and UI-route suites pass (`400 passed`)
- Contract: tests assert configured-cwd resolution, direct transport reuse, Model Hub isolation, disabled/no-cache fallback, runtime-activation preservation, pre-ownership transport validation, cwd inode recovery, initialization cancellation cleanup, turn cancellation interrupt, pending-RPC cleanup, transport-exit settlement, and timeout diagnostic classification
- Scenario: auth setup catalog and executable scenario harness cover `AUTH-SETUP-905` and `AUTH-SETUP-906`
- Lint: the CI-pinned Ruff `0.4.9` passes all changed Python files
- UI: production build succeeded on the previous exact head; this review fix does not change UI code

## Residual checks

- Re-run the three Settings connection entries in local Incus once the existing shared Lima VM is responsive. No non-regression service was restarted.
