### PR TITLE
fix(harness): stop deleting a definition's own Session on first delivery

### DIFF
--- a/core/handlers/session_handler.py
+++ b/core/handlers/session_handler.py
@@ -667,6 +667,35 @@ class SessionHandler(BaseHandler):
             cleared = self.sessions.clear_session_base(resolved_source_key, source_base_session_id)
         return bool(changed or cleared)
 
+    @staticmethod
+    def _is_reserved_session_anchor(context: MessageContext, base_session_id: str) -> bool:
+        """True when this anchor names a reserved, durable Agent Session row.
+
+        ``clear_source`` is decided upstream by ``_build_delivery_alias_strategy`` from
+        ``session_target.thread_id is None``. That is a proxy for "this is a throwaway
+        channel-level anchor that the delivered message should replace". A durable
+        ``--create-session`` definition anchor satisfies the same proxy:
+        ``thread_id_from_session_anchor`` splits the anchor at ``:``, so
+        ``<platform>_<channel_id>:definition_<uuid>`` reduces to ``<platform>_<channel_id>``
+        and the derived thread id equals the channel id, which the function reports as
+        ``None``. The proxy therefore cannot tell a provisional anchor from a durable one.
+
+        The clear is a HARD delete of the ``agent_sessions`` row, while the definition keeps
+        its now-dangling ``run_definitions.session_id``. Every later fire then dies at
+        dispatch with ``agent session id not found``, silently, at ``last_status=failed``
+        with no result text, and the definition never recovers on its own.
+
+        Decide from the same authority ``get_base_session_id`` used to mint the anchor: a
+        context bound to a reserved Agent Session row is never provisional. Reading the
+        reserved row keeps this a fact check rather than a second anchor-format parser that
+        would drift from the minting side in ``_session_anchor_with_suffix``.
+        """
+        reserved = resolve_context_agent_session_target(context)
+        if not reserved:
+            return False
+        reserved_anchor = str(reserved.get("session_anchor") or "").strip()
+        return bool(reserved_anchor) and reserved_anchor == str(base_session_id or "").strip()
+
     def finalize_scheduled_delivery(self, context: MessageContext, sent_message_id: Optional[str]) -> None:
         payload = context.platform_specific or {}
         if payload.get("turn_source") != "scheduled":
@@ -688,7 +717,9 @@ class SessionHandler(BaseHandler):
             return
 
         target_session_key = strategy.get("session_key") or self._get_session_key(context)
-        clear_source = bool(strategy.get("clear_source", False))
+        clear_source = bool(strategy.get("clear_source", False)) and not self._is_reserved_session_anchor(
+            context, source_base_session_id
+        )
         self.alias_session_base(
             context,
             source_base_session_id=source_base_session_id,

--- a/tests/test_session_handler_base_id.py
+++ b/tests/test_session_handler_base_id.py
@@ -324,6 +324,108 @@ def test_finalize_scheduled_delivery_can_alias_into_delivery_scope() -> None:
     assert controller.sessions.thread_marks == [("scheduled", "C999", "181818.456")]
 
 
+def test_finalize_scheduled_delivery_never_clears_a_reserved_definition_anchor() -> None:
+    """A ``--create-session`` definition Session survives its first visible delivery.
+
+    Regression for the orphaning bug: ``clear_source`` is decided upstream from
+    ``session_target.thread_id is None``, which a durable definition anchor also
+    satisfies, and the clear is a HARD delete. Deleting the row leaves
+    ``run_definitions.session_id`` dangling, so every later fire dies at dispatch.
+    The alias must still happen; only the delete is refused.
+    """
+    controller = _Controller(platform="discord", dm_threads=False)
+    handler = SessionHandler(controller)
+    definition_anchor = "discord_C123:definition_ab12cd34ef56"
+    context = MessageContext(
+        user_id="scheduled",
+        channel_id="C123",
+        platform="discord",
+        platform_specific={
+            "is_dm": False,
+            "turn_source": "scheduled",
+            "turn_base_session_id": definition_anchor,
+            "agent_session_target": {
+                "id": "sess-durable-1",
+                "session_anchor": definition_anchor,
+            },
+            "delivery_override": {"channel_id": "C123"},
+            "scheduled_delivery_alias": {
+                "mode": "sent_message",
+                "session_key": "discord::C123",
+                "clear_source": True,
+            },
+        },
+    )
+
+    handler.finalize_scheduled_delivery(context, "919191.777")
+
+    assert controller.sessions.alias_calls == [
+        ("discord::C123", definition_anchor, "discord_919191.777")
+    ]
+    assert controller.sessions.clear_calls == []
+
+
+def test_finalize_scheduled_delivery_still_clears_a_throwaway_provisional_anchor() -> None:
+    """The guard is not a blanket disable: an unbound provisional anchor still clears."""
+    controller = _Controller(platform="discord", dm_threads=False)
+    handler = SessionHandler(controller)
+    context = MessageContext(
+        user_id="scheduled",
+        channel_id="C123",
+        platform="discord",
+        platform_specific={
+            "is_dm": False,
+            "turn_source": "scheduled",
+            "turn_base_session_id": "discord_scheduled-8f2c",
+            "delivery_override": {"channel_id": "C123"},
+            "scheduled_delivery_alias": {
+                "mode": "sent_message",
+                "session_key": "discord::C123",
+                "clear_source": True,
+            },
+        },
+    )
+
+    handler.finalize_scheduled_delivery(context, "929292.888")
+
+    assert controller.sessions.clear_calls == [("discord::C123", "discord_scheduled-8f2c")]
+
+
+def test_finalize_scheduled_delivery_clears_when_reserved_row_is_a_different_anchor() -> None:
+    """Only the reserved row's own anchor is protected.
+
+    A context may carry a reserved Session while the turn ran off a separate provisional
+    anchor. Protecting that unrelated anchor would leak throwaway rows, so the guard
+    compares anchors rather than merely observing that a reserved row exists.
+    """
+    controller = _Controller(platform="discord", dm_threads=False)
+    handler = SessionHandler(controller)
+    context = MessageContext(
+        user_id="scheduled",
+        channel_id="C123",
+        platform="discord",
+        platform_specific={
+            "is_dm": False,
+            "turn_source": "scheduled",
+            "turn_base_session_id": "discord_scheduled-7a1b",
+            "agent_session_target": {
+                "id": "sess-durable-2",
+                "session_anchor": "discord_C123:definition_ffeeddccbbaa",
+            },
+            "delivery_override": {"channel_id": "C123"},
+            "scheduled_delivery_alias": {
+                "mode": "sent_message",
+                "session_key": "discord::C123",
+                "clear_source": True,
+            },
+        },
+    )
+
+    handler.finalize_scheduled_delivery(context, "939393.999")
+
+    assert controller.sessions.clear_calls == [("discord::C123", "discord_scheduled-7a1b")]
+
+
 def test_alias_session_base_clears_source_even_when_alias_already_exists() -> None:
     controller = _Controller(platform="slack", dm_threads=False)
     controller.sessions.alias_result = False


### PR DESCRIPTION
Fixes #1079.

## The defect

A `--create-session` definition reserves its own durable Agent Session and stores
the anchor `<platform>_<channel_id>:definition_<uuid>`. On the definition's **first
successful delivery**, `finalize_scheduled_delivery` hard-deletes that very row.

`clear_source` is decided upstream in `_build_delivery_alias_strategy` from
`session_target.thread_id is None` — a proxy for "this is a throwaway channel-level
anchor that the delivered message should replace". A durable definition anchor
satisfies the same proxy by accident: `thread_id_from_session_anchor` splits the
anchor at `:`, so `<platform>_<channel_id>:definition_<uuid>` reduces to
`<platform>_<channel_id>`, the derived thread id equals the channel id, and the
function reports `None`. The proxy cannot tell a provisional anchor from a durable
one.

The definition keeps its now-dangling `run_definitions.session_id`. Every later
fire dies at dispatch with `agent session id not found`.

## The fix

Decide from the same authority that minted the anchor. `get_base_session_id`
(`session_handler.py:531`) returns the reserved anchor verbatim when the context is
bound to a reserved Agent Session row — so `source_base_session_id` in
`finalize_scheduled_delivery` **is** the durable anchor. A new
`_is_reserved_session_anchor` reads that reserved row and suppresses `clear_source`
when it matches.

Reading the row keeps this a fact check rather than a second anchor-format parser
that would drift from the minting side in `_session_anchor_with_suffix`.

Guarded at the decision point rather than in `delete_agent_sessions`, because
intentional deletion of a definition Session must keep working.

## Symptom description in the issue is partly outdated

`storage/session_reclaim.py` landed 2026-07-29 in #1064, one day after this issue
was filed. On current master `clear_session_base` -> `delete_agent_sessions` runs
with the default `RECLAIM_PAUSE`, so the bound definition is now paused with
`last_error` and a `session_settings_snapshot` instead of being left `enabled=1`
with a dangling id. The root cause is unchanged; the failure is visible and
recoverable rather than silent and permanent.

## Existing data

No migration. `_recover_pinned_session_binding` already repairs a dangling binding
at the next fire: a `create_once` definition rebinds from the settings snapshot and
retries in the same tick; an `existing` pin auto-pauses after 3 strikes with one
notice. Reclaim-paused definitions need `vibe task resume <id>` to reach that path.
An audit of this machine's store found 0 orphaned definitions out of 52.

## Not fixed here

`delete_agent_sessions` matches `session_anchor LIKE 'prefix:%'`, so any future
caller passing a bare `<platform>_<channel_id>` would sweep every `:definition_` /
`:run_` sub-anchor under it. `include_superseded=False` is the existing precedent
for such an exclusion. Worth a separate issue rather than widening this change.

## Tests

Three cases in `tests/test_session_handler_base_id.py`: a reserved definition
anchor is never cleared; a throwaway provisional anchor still is; a reserved row
naming a *different* anchor does not shield the provisional one.

`19 + 314 + 451 passed`, `ruff` clean.
