### PR TITLE
fix(remote): allow authorized workbench messages

### DIFF
--- a/core/internal_server.py
+++ b/core/internal_server.py
@@ -679,26 +679,6 @@ def create_app(
                 if delivery is not None and delivery["session_id"] == session_id
                 else None
             )
-            if (
-                delivery is not None
-                and delivery_payload is not None
-                and message_deliveries.delivery_has_remote_resource_context(delivery)
-            ):
-                message_deliveries.retire_not_written(
-                    conn,
-                    session_id,
-                    delivery_id,
-                    reason="remote_execution_disabled",
-                )
-                return JSONResponse(
-                    status_code=403,
-                    content={
-                        "ok": False,
-                        "code": "remote_execution_disabled",
-                        "session_id": session_id,
-                        "delivery_id": delivery_id,
-                    },
-                )
             attachment_specs: list[dict[str, Any]] = []
             if delivery_payload is not None:
                 from core.workbench_media import resolve_attachment_specs

--- a/core/session_turns.py
+++ b/core/session_turns.py
@@ -1627,6 +1627,27 @@ class SessionTurnManager:
                     raise RuntimeError("runtime-rejected Delivery queue fallback lost")
             return None
 
+        denied_remote = [
+            (delivery, reason)
+            for delivery in deliveries
+            if (reason := cls._remote_delivery_execution_denial(conn, delivery)) is not None
+        ]
+        if denied_remote:
+            for delivery, reason in denied_remote:
+                if not cls._retire_delivery_not_written(
+                    conn,
+                    session_id,
+                    str(delivery["id"]),
+                    reason=reason,
+                ):
+                    raise RuntimeError("remote Delivery authorization retirement lost")
+                logger.warning(
+                    "retired remote-origin Delivery=%s before Agent dispatch: %s",
+                    delivery["id"],
+                    reason,
+                )
+            return None
+
         unstartable = [
             delivery
             for delivery in deliveries
@@ -1663,6 +1684,49 @@ class SessionTurnManager:
             dispatch_text=dispatch_text,
             attempt_id=attempt_id,
         )
+
+    @staticmethod
+    def _remote_delivery_execution_denial(
+        conn: Connection,
+        delivery: dict[str, Any],
+    ) -> str | None:
+        """Recheck deferred remote chat authority immediately before execution."""
+
+        if not delivery_store.delivery_has_remote_resource_context(delivery):
+            return None
+
+        from core.services import sessions as workbench_sessions_service
+        from core.vibe_agents import ensure_session_agent_access
+        from storage import project_access_service, resource_access_service
+
+        metadata = delivery_store.delivery_payload(delivery).get("metadata")
+        try:
+            context = resource_access_service.resource_user_context_from_metadata(metadata)
+        except resource_access_service.ResourceAccessError as error:
+            return error.code
+        if context is None or not context.can_chat:
+            return "remote_chat_access_forbidden"
+        if not project_access_service.role_allows(
+            project_access_service.get_effective_session_role(
+                conn,
+                context,
+                str(delivery["session_id"]),
+            ),
+            "editor",
+        ):
+            return "remote_project_access_forbidden"
+        try:
+            session = workbench_sessions_service.get_session(
+                conn,
+                str(delivery["session_id"]),
+                authorization_context=context,
+            )
+            ensure_session_agent_access(conn, session, user_context=context)
+        except LookupError:
+            return "remote_session_or_agent_not_found"
+        except PermissionError:
+            return "remote_agent_access_forbidden"
+        return None
 
     @staticmethod
     def _delivery_agent_runs_can_start(
@@ -1825,25 +1889,6 @@ class SessionTurnManager:
             if not segment or any(row is None for row in segment):
                 return None
             delivery_rows = [row for row in segment if row is not None]
-            remote_rows = [
-                row
-                for row in delivery_rows
-                if delivery_store.delivery_has_remote_resource_context(row)
-            ]
-            if remote_rows:
-                for row in remote_rows:
-                    if not self._retire_delivery_not_written(
-                        conn,
-                        session_id,
-                        str(row["id"]),
-                        reason="remote_execution_disabled",
-                    ):
-                        raise RuntimeError("remote FIFO Delivery retirement lost")
-                    logger.warning(
-                        "retired remote-origin queued Delivery=%s before Agent dispatch",
-                        row["id"],
-                    )
-                continue
             invalid_rows = [
                 row
                 for row in delivery_rows
@@ -3543,7 +3588,7 @@ class SessionTurnManager:
         archived_before_dispatch = False
         run_terminal_before_dispatch = False
         invalid_delivery_ids: set[str] = set()
-        remote_delivery_ids: set[str] = set()
+        remote_authorization_denials: dict[str, str] = {}
         with self._sqlite_engine().begin() as conn:
             reserve_write_lock(conn)
             latest = delivery_store.get_turn(conn, turn_id)
@@ -3577,10 +3622,10 @@ class SessionTurnManager:
                 for row in deliveries
                 if not self._has_resolvable_delivery_input(conn, row)
             }
-            remote_delivery_ids = {
-                str(row["id"])
+            remote_authorization_denials = {
+                str(row["id"]): reason
                 for row in deliveries
-                if delivery_store.delivery_has_remote_resource_context(row)
+                if (reason := self._remote_delivery_execution_denial(conn, row)) is not None
             }
             run_ids = list(
                 dict.fromkeys(
@@ -3629,16 +3674,18 @@ class SessionTurnManager:
             if terminal.get("changed"):
                 await self._resume_post_terminal(str(turn["session_id"]))
             return False
-        if remote_delivery_ids:
+        if remote_authorization_denials:
             logger.warning(
-                "durable Turn=%s was blocked because it contains remote-origin input",
+                "durable Turn=%s failed remote authorization before Agent dispatch: %s",
                 turn_id,
+                remote_authorization_denials,
             )
             terminal = self._terminalize_durable_turn(
                 turn_id,
                 "not_written",
-                settled_by="remote_execution_disabled",
-                evidence_kind="remote_origin_before_native_dispatch",
+                settled_by="remote_authorization_denied",
+                evidence_kind="remote_authorization_before_native_dispatch",
+                evidence={"denials": remote_authorization_denials},
                 retire_unwritten_delivery_ids={
                     str(row["id"])
                     for row in deliveries

--- a/tests/test_instance_authorization.py
+++ b/tests/test_instance_authorization.py
@@ -19,7 +19,7 @@ def _remote_context(role: str) -> AuthorizationContext:
     return AuthorizationContext(instance_role=role, is_remote=True)
 
 
-def test_remote_roles_keep_management_monotonic_but_execution_disabled() -> None:
+def test_remote_roles_allow_chat_without_enabling_local_machine_capabilities() -> None:
     viewer = AuthorizationContext(instance_role="viewer", is_remote=True)
     editor = AuthorizationContext(instance_role="editor", is_remote=True)
     owner = AuthorizationContext(instance_role="owner", is_remote=True)
@@ -28,10 +28,10 @@ def test_remote_roles_keep_management_monotonic_but_execution_disabled() -> None
     assert viewer.can_chat is False
     assert viewer.can_use_cloud_asr is False
     assert editor.can_read_instance is True
-    assert editor.can_chat is False
+    assert editor.can_chat is True
     assert editor.can_use_cloud_asr is True
     assert editor.can_manage_projects is False
-    assert owner.can_chat is False
+    assert owner.can_chat is True
     assert owner.can_use_cloud_asr is True
     assert owner.can_manage_projects is True
     assert owner.can_manage_agents is True
@@ -81,7 +81,7 @@ def test_context_uses_role_not_diagnostic_source_for_owner() -> None:
     )
 
     assert context.is_instance_owner is False
-    assert context.can_chat is False
+    assert context.can_chat is True
     assert context.can_manage_instance is False
     assert context.authorization_revision == 0
 
@@ -170,6 +170,7 @@ def test_remote_http_policy_defaults_local_machine_and_unknown_routes_to_local_o
     ("method", "path", "expected"),
     [
         ("GET", "/api/projects", REMOTE_HTTP_ALLOWED),
+        ("POST", "/api/sessions/ses-1/messages", REMOTE_HTTP_ALLOWED),
         ("PUT", "/api/workbench/prefs", REMOTE_HTTP_ALLOWED),
         ("PUT", "/api/resource-policies/agent/agent-1", REMOTE_HTTP_ALLOWED),
         ("GET", "/api/models/runtime/status", REMOTE_HTTP_ALLOWED),

--- a/tests/test_internal_server.py
+++ b/tests/test_internal_server.py
@@ -24,6 +24,7 @@ import socket
 import stat
 import sys
 import tempfile
+import time
 import types
 from pathlib import Path
 from types import SimpleNamespace
@@ -38,6 +39,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from config import paths
 from core import internal_server, session_turns
 from core.message_context import build_context_turn_sink_key
+from core.vibe_agents import VibeAgentStore
 from core.run_settlement import SETTLED_BY_STOPPED, SETTLED_BY_TERMINAL_RESULT
 from core.services.agent_steering import SteerOutcome, result as steer_result
 from core.services.dispatch import (
@@ -47,7 +49,8 @@ from core.services.dispatch import (
     dispatch_turn,
 )
 from modules.im import MessageContext
-from storage import message_deliveries
+from storage import message_deliveries, resource_access_service
+from vibe.authorization import AuthorizationContext
 
 
 # ---------------------------------------------------------------------
@@ -75,6 +78,29 @@ def _seed_project_workdir(conn, scope_id: str, workdir: Path, *, now: str = "202
             created_at=now,
             updated_at=now,
         )
+    )
+
+
+def _seed_remote_worker(*, backend: str = "claude") -> None:
+    store = VibeAgentStore()
+    try:
+        if store.get("worker") is None:
+            store.create(name="worker", backend=backend)
+    finally:
+        store.close()
+
+
+def _authorized_remote_message_metadata() -> dict:
+    return resource_access_service.metadata_with_resource_user_context(
+        {},
+        AuthorizationContext(
+            subject="remote-user",
+            email="remote-user@example.com",
+            instance_role="owner",
+            instance_access_source="owner",
+            claims_issued_at=int(time.time()),
+            is_remote=True,
+        ),
     )
 
 
@@ -1723,7 +1749,7 @@ def test_dispatch_async_replay_of_queued_delivery_is_idempotent(monkeypatch, tmp
     assert transcript == []
 
 
-def test_dispatch_async_retires_remote_reservation_before_turn_start(
+def test_dispatch_async_starts_authorized_remote_reservation(
     monkeypatch,
     tmp_path,
 ):
@@ -1732,16 +1758,22 @@ def test_dispatch_async_retires_remote_reservation_before_turn_start(
         tmp_path,
         native_id="proj_remote_dispatch_reservation",
     )
+    _seed_remote_worker()
     with engine.begin() as conn:
         remote = _reserve_submission(
             conn,
             scope_id=session["scope_id"],
             session_id=session["id"],
             text="remote reserved input",
-            metadata={"resource_user_context": {"sub": "remote-user"}},
+            metadata=_authorized_remote_message_metadata(),
         )
 
-    controller = _build_controller_double()
+    controller = None
+
+    async def handler(context, _text):
+        controller.mark_turn_complete(context)
+
+    controller = _build_controller_double(handler)
     app = internal_server.create_app(controller)
     transport = httpx.ASGITransport(app=app)
 
@@ -1761,13 +1793,13 @@ def test_dispatch_async_retires_remote_reservation_before_turn_start(
 
     response = asyncio.run(_go())
 
-    assert response.status_code == 403
-    assert response.json()["code"] == "remote_execution_disabled"
-    controller.message_handler.handle_user_message.assert_not_awaited()
+    assert response.status_code == 202
+    assert response.json()["ok"] is True
+    controller.message_handler.handle_user_message.assert_awaited_once()
     with engine.connect() as conn:
         stored = message_deliveries.get_delivery(conn, remote["id"])
     assert stored is not None
-    assert stored["state"] == "retired"
+    assert stored["state"] == "accepted"
 
 
 def test_dispatch_async_persists_acceptance_before_a_lost_response_replay(
@@ -5489,7 +5521,7 @@ def _manager_accepting_runs():
     return manager, runs
 
 
-def test_flush_retires_remote_head_and_runs_later_local_delivery(
+def test_flush_runs_authorized_remote_fifo_head(
     tmp_path,
     monkeypatch,
 ):
@@ -5498,13 +5530,14 @@ def test_flush_retires_remote_head_and_runs_later_local_delivery(
         tmp_path,
         native_id="proj_remote_queue_retirement",
     )
+    _seed_remote_worker()
     with engine.begin() as conn:
         remote = message_deliveries.enqueue_queued(
             conn,
             scope_id=session["scope_id"],
             session_id=session["id"],
             text="remote queued input",
-            metadata={"resource_user_context": {"sub": "remote-user"}},
+            metadata=_authorized_remote_message_metadata(),
         )
         local = message_deliveries.enqueue_queued(
             conn,
@@ -5521,18 +5554,18 @@ def test_flush_retires_remote_head_and_runs_later_local_delivery(
     assert asyncio.run(manager.flush_queue(session["id"])) is True
 
     assert [(text, source) for text, source, _context in runs] == [
-        ("local queued input", SOURCE_HUMAN)
+        ("remote queued input", SOURCE_HUMAN),
     ]
     with engine.connect() as conn:
         remote_saved = message_deliveries.get_delivery(conn, remote["id"])
         local_saved = message_deliveries.get_delivery(conn, local["id"])
     assert remote_saved is not None
-    assert remote_saved["state"] == "retired"
+    assert remote_saved["state"] == "accepted"
     assert local_saved is not None
-    assert local_saved["state"] == "accepted"
+    assert local_saved["state"] == "claimed"
 
 
-def test_claimed_remote_turn_is_terminalized_before_native_dispatch(
+def test_claimed_authorized_remote_turn_reaches_native_dispatch(
     tmp_path,
     monkeypatch,
 ):
@@ -5541,6 +5574,7 @@ def test_claimed_remote_turn_is_terminalized_before_native_dispatch(
         tmp_path,
         native_id="proj_remote_claimed_turn",
     )
+    _seed_remote_worker()
     turn_id = message_deliveries.new_turn_id()
     with engine.begin() as conn:
         queued = message_deliveries.enqueue_queued(
@@ -5548,7 +5582,7 @@ def test_claimed_remote_turn_is_terminalized_before_native_dispatch(
             scope_id=session["scope_id"],
             session_id=session["id"],
             text="claimed remote input",
-            metadata={"resource_user_context": {"sub": "remote-user"}},
+            metadata=_authorized_remote_message_metadata(),
         )
         row = message_deliveries.get_delivery(conn, queued["id"])
         assert row is not None
@@ -5571,21 +5605,22 @@ def test_claimed_remote_turn_is_terminalized_before_native_dispatch(
         ),
     )
 
-    async def unexpected_run(*_args, **_kwargs):
-        raise AssertionError("remote-origin turn must not reach native dispatch")
+    runs = []
 
-    manager._run = unexpected_run
-    assert asyncio.run(manager._start_persisted_turn(turn_id)) is False
+    async def capture_run(_session_id, _context, text, **_kwargs):
+        runs.append(text)
+
+    manager._run = capture_run
+    assert asyncio.run(manager._start_persisted_turn(turn_id)) is True
+    assert runs == ["claimed remote input"]
 
     with engine.connect() as conn:
         saved_turn = message_deliveries.get_turn(conn, turn_id)
         saved_delivery = message_deliveries.get_delivery(conn, queued["id"])
     assert saved_turn is not None
-    assert saved_turn["state"] == "terminal"
-    assert saved_turn["terminal_outcome"] == "not_written"
-    assert saved_turn["settled_by"] == "remote_execution_disabled"
+    assert saved_turn["state"] == "starting"
     assert saved_delivery is not None
-    assert saved_delivery["state"] == "retired"
+    assert saved_delivery["state"] == "claimed"
 
 
 def test_flush_runs_scheduled_row_as_scheduled_with_provenance(tmp_path, monkeypatch):

--- a/tests/test_resource_acl_agents.py
+++ b/tests/test_resource_acl_agents.py
@@ -414,7 +414,7 @@ def test_remote_agent_request_and_selection_reject_inaccessible_agent(monkeypatc
         environ_base=_remote_peer(),
     )
     assert blocked_legacy_turn.status_code == 403
-    assert blocked_legacy_turn.get_json()["code"] == "remote_execution_disabled"
+    assert blocked_legacy_turn.get_json()["code"] == "agent_access_forbidden"
     assert dispatch_calls == []
 
     with engine.begin() as connection:
@@ -435,7 +435,7 @@ def test_remote_agent_request_and_selection_reject_inaccessible_agent(monkeypatc
         environ_base=_remote_peer(),
     )
     assert revoked_turn.status_code == 403
-    assert revoked_turn.get_json()["code"] == "remote_execution_disabled"
+    assert revoked_turn.get_json()["code"] == "agent_access_forbidden"
     assert dispatch_calls == []
 
     with pytest.raises(

--- a/tests/test_ui_project_access.py
+++ b/tests/test_ui_project_access.py
@@ -12,16 +12,18 @@ from config.v2_config import (
     UiConfig,
     V2Config,
 )
+from core.vibe_agents import VibeAgentStore
 from storage import (
     media_service,
     message_deliveries,
     messages_service,
     project_access_service,
     projects_service,
+    resource_access_service,
 )
 from storage.db import create_sqlite_engine
 from storage.importer import ensure_sqlite_state
-from storage.models import media_object_references, media_objects, scopes
+from storage.models import agent_sessions, media_object_references, media_objects, scopes
 from storage.workbench_sessions_service import create_session
 from tests.ui_server_test_helpers import csrf_headers, remote_session_cookie
 from vibe import api, internal_client, remote_access, ui_server
@@ -457,7 +459,7 @@ def test_legacy_media_token_uses_all_migrated_session_references(monkeypatch, tm
     assert _get(beta, f"/api/media/{token}").status_code == 200
 
 
-def test_remote_message_is_blocked_before_persistence_or_dispatch(
+def test_remote_editor_message_persists_authoritative_identity_and_dispatches(
     monkeypatch,
     tmp_path,
 ) -> None:
@@ -465,6 +467,26 @@ def test_remote_message_is_blocked_before_persistence_or_dispatch(
     config, ids = _setup_state(tmp_path)
     engine = create_sqlite_engine()
     client = _remote_client(config, role="editor", email="alice@example.com")
+    store = VibeAgentStore()
+    try:
+        agent = store.create(name="remote-editor-agent", backend="codex")
+        with store.engine.begin() as conn:
+            resource_access_service.ensure_resource_policy(
+                conn,
+                resource_kind="agent",
+                resource_id=agent.id,
+                organization_id=None,
+                owner_user_id="user-editor-alice@example.com",
+                access_level="private",
+            )
+    finally:
+        store.close()
+    with engine.begin() as conn:
+        conn.execute(
+            agent_sessions.update()
+            .where(agent_sessions.c.id == ids["session_a"])
+            .values(agent_id=agent.id, agent_name=agent.name)
+        )
 
     with engine.connect() as conn:
         before_ids = {
@@ -476,8 +498,11 @@ def test_remote_message_is_blocked_before_persistence_or_dispatch(
             )["messages"]
         }
 
+    dispatch_calls = []
+
     async def dispatch_async(payload):
-        raise AssertionError("remote message reached the local controller")
+        dispatch_calls.append(payload)
+        return {"status_code": 202, "body": {"delivery_state": "queued"}}
 
     monkeypatch.setattr(internal_client, "dispatch_async", dispatch_async)
     response = client.post(
@@ -500,9 +525,11 @@ def test_remote_message_is_blocked_before_persistence_or_dispatch(
         },
     )
 
-    assert response.status_code == 403
-    assert response.get_json()["code"] == "remote_execution_disabled"
+    assert response.status_code == 202
+    assert len(dispatch_calls) == 1
+    assert dispatch_calls[0]["text"] == "Run it"
     with engine.connect() as conn:
+        stored = message_deliveries.get_delivery(conn, response.get_json()["id"])
         after_ids = {
             row["id"]
             for row in messages_service.list_session_messages(
@@ -511,6 +538,14 @@ def test_remote_message_is_blocked_before_persistence_or_dispatch(
                 limit=500,
             )["messages"]
         }
+    assert stored is not None
+    stored_metadata = message_deliveries.delivery_payload(stored)["metadata"]
+    assert stored_metadata["resource_user_context"]["sub"] == "user-editor-alice@example.com"
+    assert stored_metadata["resource_user_context"]["vibe_instance_role"] == "editor"
+    assert stored_metadata["_web_push_authorization_contexts"][0]["sub"] == (
+        "user-editor-alice@example.com"
+    )
+    assert "spoofed" not in json.dumps(stored_metadata)
     assert after_ids == before_ids
 
 

--- a/tests/test_ui_remote_access_auth.py
+++ b/tests/test_ui_remote_access_auth.py
@@ -860,7 +860,7 @@ def test_remote_session_info_includes_authenticated_subject(monkeypatch, tmp_pat
         "capabilities": {
             "is_instance_owner": True,
             "can_read_instance": True,
-            "can_chat": False,
+            "can_chat": True,
             "can_manage_projects": True,
             "can_manage_agents": True,
             "can_manage_instance": True,

--- a/vibe/authorization.py
+++ b/vibe/authorization.py
@@ -87,7 +87,7 @@ class AuthorizationContext:
 
     @property
     def can_chat(self) -> bool:
-        return not self.is_remote and self.has_role("editor")
+        return self.has_role("editor")
 
     @property
     def can_use_cloud_asr(self) -> bool:
@@ -347,7 +347,7 @@ _REMOTE_LOCAL_ONLY_HTTP_RULES = tuple(
         ("POST", r"^/api/sessions/[^/]+/fork$"),
         (
             "POST",
-            r"^/api/sessions/[^/]+/(?:messages|attachments|cancel|queue/[^/]+/send-now)$",
+            r"^/api/sessions/[^/]+/(?:attachments|cancel|queue/[^/]+/send-now)$",
         ),
         ("POST", r"^/api/asr/transcribe$"),
         ("POST", r"^/api/show/sessions/[^/]+/(?:events|prewarm)$"),


### PR DESCRIPTION
## Summary

- allow authenticated remote owners and editors to send Workbench messages without treating remote transport as globally read-only
- preserve instance-role, Project editor, Agent ACL, signed-context expiry, CSRF, and fail-closed unknown-route checks
- revalidate persisted remote authorization before immediate, queued, and restart-replayed Agent dispatch
- keep terminal, files, attachments, cancel, Harness mutations, service controls, and unknown APIs local-only

## Root cause

Remote transport was hard-coded as non-chat-capable and the same remote-origin Delivery was rejected again in the internal controller and durable queue paths, even when the caller had a valid owner/editor role and resource authorization.

## Validation

- focused pytest coverage for authorization, Project ACL, Agent ACL, direct dispatch, FIFO queue dispatch, and persisted-turn replay (71 tests/assertions passed across the selected targets)
- `uvx ruff check` on all changed Python files
- `git diff --check`

## Residual boundary

This PR only enables user-initiated Workbench messages. Other remote execution and local-machine mutation surfaces remain disabled.