### PR TITLE
fix(opencode): preserve native message ordering

### DIFF
--- a/docs/plans/session-delivery-foundation.md
+++ b/docs/plans/session-delivery-foundation.md
@@ -92,10 +92,11 @@ that batch and releases the Session. OpenCode retains its stronger exact-attempt
 reconciliation. A definitive pre-write start failure requeues the entire claimed
 batch in its original order. A late event for T1 cannot mutate T2.
 
-OpenCode writes the persisted Delivery attempt ID as the native `messageID`.
-After restart, reconciliation reads that exact native Message without issuing a
-second prompt: exact presence accepts, while absence or transport uncertainty
-remains blocked.
+OpenCode generates every native `messageID` at the actual write and stores the
+persisted Delivery attempt ID as the exact ID of the user Message's text part.
+After restart, reconciliation lists that native Session's Messages without
+issuing a second prompt: an exact user-part match accepts and returns its native
+Message ID, while absence or transport uncertainty remains blocked.
 
 Terminal settlement, the next compatible FIFO claim, and the Session status
 projection share one writer transaction. Result evidence is committed only after

--- a/modules/agents/opencode/agent.py
+++ b/modules/agents/opencode/agent.py
@@ -56,7 +56,7 @@ from .poll_loop import OpenCodePollLoop, restored_platform_from_poll_info, resto
 from .server import (
     OpenCodePromptRejectedError,
     OpenCodeServerManager,
-    native_message_id_for_attempt,
+    native_part_id_for_attempt,
 )
 from .session import OpenCodeResumeUnavailableError, OpenCodeSessionManager
 from .utils import resolve_opencode_model_id, resolve_opencode_reasoning_effort
@@ -1078,8 +1078,8 @@ class OpenCodeAgent(OpenCodeMessageProcessorMixin, BaseAgent):
             await server.mark_run_active(session_id)
             run_registered = True
             # Persist the complete recovery address before the first native write.
-            # A crash after OpenCode accepts the exact message ID can now rebuild the
-            # poll and Turn owner even if no post-prompt Python statement ran.
+            # A crash after OpenCode accepts the exact attempt part can now rebuild
+            # the poll and Turn owner even if no post-prompt Python statement ran.
             self.sessions.add_active_poll(
                 opencode_session_id=session_id,
                 base_session_id=request.base_session_id,
@@ -1106,11 +1106,7 @@ class OpenCodeAgent(OpenCodeMessageProcessorMixin, BaseAgent):
                 session_id=session_id,
                 directory=request.working_path,
                 text=prompt_text,
-                message_id=(
-                    native_message_id_for_attempt(start_attempt_id)
-                    if start_attempt_id
-                    else None
-                ),
+                attempt_id=start_attempt_id or None,
                 agent=agent_to_use,
                 model=model_dict,
                 reasoning_effort=reasoning_effort,
@@ -1433,9 +1429,7 @@ class OpenCodeAgent(OpenCodeMessageProcessorMixin, BaseAgent):
                         "tools": {"question": False},
                     }
                     if request.attempt_id:
-                        prompt_kwargs["message_id"] = native_message_id_for_attempt(
-                            request.attempt_id
-                        )
+                        prompt_kwargs["attempt_id"] = request.attempt_id
                     await server.prompt_async(
                         **prompt_kwargs,
                     )
@@ -1540,7 +1534,7 @@ class OpenCodeAgent(OpenCodeMessageProcessorMixin, BaseAgent):
         request: SteerReconcileRequest,
         target: ActiveSteerTarget,
     ) -> SteerResult:
-        """Resolve one prior OpenCode write by its native message identity."""
+        """Resolve one prior OpenCode write by its exact native part identity."""
 
         if not request.attempt_id:
             return steer_result(
@@ -1575,11 +1569,10 @@ class OpenCodeAgent(OpenCodeMessageProcessorMixin, BaseAgent):
                 reason="runtime_unavailable",
                 backend=self.name,
             )
-        native_message_id = native_message_id_for_attempt(request.attempt_id)
+        native_part_id = native_part_id_for_attempt(request.attempt_id)
         try:
-            message = await server.get_message(
+            messages = await server.list_messages(
                 native_session_id,
-                native_message_id,
                 directory,
             )
         except Exception as exc:  # noqa: BLE001 - absence is not negative proof
@@ -1589,18 +1582,26 @@ class OpenCodeAgent(OpenCodeMessageProcessorMixin, BaseAgent):
                 backend=self.name,
                 diagnostic=str(exc),
             )
-        info = message.get("info") if isinstance(message, dict) else None
-        if (
-            isinstance(info, dict)
-            and str(info.get("id") or "") == native_message_id
-            and info.get("role") == "user"
-        ):
-            return steer_result(
-                SteerOutcome.ACCEPTED,
-                reason="native_message_found",
-                backend=self.name,
-                native_message_id=native_message_id,
-            )
+        for message in messages:
+            info = message.get("info") if isinstance(message, dict) else None
+            parts = message.get("parts") if isinstance(message, dict) else None
+            if (
+                isinstance(info, dict)
+                and info.get("role") == "user"
+                and isinstance(parts, list)
+                and any(
+                    isinstance(part, dict)
+                    and str(part.get("id") or "") == native_part_id
+                    for part in parts
+                )
+            ):
+                return steer_result(
+                    SteerOutcome.ACCEPTED,
+                    reason="native_attempt_part_found",
+                    backend=self.name,
+                    native_message_id=str(info.get("id") or ""),
+                    native_part_id=native_part_id,
+                )
         return steer_result(
             SteerOutcome.UNKNOWN,
             reason="untrusted_attempt_evidence",
@@ -1783,16 +1784,19 @@ class OpenCodeAgent(OpenCodeMessageProcessorMixin, BaseAgent):
                 verification_unknown = True
 
             baseline_message_ids = set(poll_info.baseline_message_ids)
-            start_attempt_message_id = (
-                native_message_id_for_attempt(start_attempt_id)
+            start_attempt_part_id = (
+                native_part_id_for_attempt(start_attempt_id)
                 if start_attempt_id
                 else ""
             )
             start_attempt_found = any(
-                start_attempt_message_id
+                start_attempt_part_id
                 and message.get("info", {}).get("role") == "user"
-                and str(message.get("info", {}).get("id") or "")
-                == start_attempt_message_id
+                and any(
+                    isinstance(part, dict)
+                    and str(part.get("id") or "") == start_attempt_part_id
+                    for part in (message.get("parts") or [])
+                )
                 for message in messages
             )
             has_in_progress = False

--- a/modules/agents/opencode/agent.py
+++ b/modules/agents/opencode/agent.py
@@ -67,6 +67,9 @@ _STATUS_RECONCILIATION_FAILURE_LIMIT = 3
 # OpenCode returns 204 after forking prompt work, before that worker necessarily
 # registers the session as busy.
 _ASYNC_PROMPT_START_CONFIRMATION_TIMEOUT_SECONDS = 5.0
+# OpenCode can report idle just before the completed assistant message becomes
+# visible through the message-list endpoint.
+_ASYNC_PROMPT_RESULT_CONFIRMATION_TIMEOUT_SECONDS = 5.0
 # A prompt accepted at the end of the previous native turn can race its final
 # status transition. Let that transition settle before trusting the write as a
 # same-turn steer.
@@ -99,6 +102,7 @@ class _OpenCodeSteerState:
     awaiting_user_text: str | None = None
     awaiting_start_confirmation_deadline: float | None = None
     awaiting_active_status_observed: bool = False
+    awaiting_result_confirmation_deadline: float | None = None
     idle_reconciliation_message: str = ""
     restored: bool = False
     reconcile_initial_status: bool = False
@@ -244,6 +248,7 @@ class _SteeringAwareOpenCodeServer:
         self._state.awaiting_user_text = None
         self._state.awaiting_start_confirmation_deadline = None
         self._state.awaiting_active_status_observed = False
+        self._state.awaiting_result_confirmation_deadline = None
 
     def _terminal_reconciliation_failure(
         self,
@@ -344,6 +349,7 @@ class _SteeringAwareOpenCodeServer:
                                 >= 0
                             ):
                                 self._state.awaiting_active_status_observed = True
+                                self._state.awaiting_result_confirmation_deadline = None
                             if reconcile_initial_status and awaiting is None:
                                 self._state.awaiting_after_message_ids = (
                                     self._completed_assistant_boundary(messages)
@@ -399,6 +405,26 @@ class _SteeringAwareOpenCodeServer:
                                     and time.monotonic() < start_deadline
                                 ):
                                     wait_for_insert = True
+                                elif self._state.awaiting_active_status_observed:
+                                    result_deadline = (
+                                        self._state.awaiting_result_confirmation_deadline
+                                    )
+                                    if result_deadline is None:
+                                        self._state.awaiting_result_confirmation_deadline = (
+                                            time.monotonic()
+                                            + _ASYNC_PROMPT_RESULT_CONFIRMATION_TIMEOUT_SECONDS
+                                        )
+                                        wait_for_insert = True
+                                    elif time.monotonic() < result_deadline:
+                                        wait_for_insert = True
+                                    else:
+                                        self._clear_awaiting_reconciliation()
+                                        return self._terminal_reconciliation_failure(
+                                            session_id,
+                                            messages,
+                                            name="NativeSessionEndedBeforeResult",
+                                            message=self._idle_reconciliation_error_text(),
+                                        )
                                 else:
                                     self._clear_awaiting_reconciliation()
                                     return self._terminal_reconciliation_failure(

--- a/modules/agents/opencode/agent.py
+++ b/modules/agents/opencode/agent.py
@@ -57,7 +57,6 @@ from .server import (
     OpenCodePromptRejectedError,
     OpenCodeServerManager,
     native_message_id_for_attempt,
-    native_message_ids_for_attempt,
 )
 from .session import OpenCodeResumeUnavailableError, OpenCodeSessionManager
 from .utils import resolve_opencode_model_id, resolve_opencode_reasoning_effort
@@ -1550,40 +1549,36 @@ class OpenCodeAgent(OpenCodeMessageProcessorMixin, BaseAgent):
                 reason="runtime_unavailable",
                 backend=self.name,
             )
-        diagnostics: list[str] = []
-        observed_evidence = False
-        for native_message_id in native_message_ids_for_attempt(request.attempt_id):
-            try:
-                message = await server.get_message(
-                    native_session_id,
-                    native_message_id,
-                    directory,
-                )
-            except Exception as exc:  # noqa: BLE001 - absence is not negative proof
-                diagnostics.append(str(exc))
-                continue
-            observed_evidence = True
-            info = message.get("info") if isinstance(message, dict) else None
-            if (
-                isinstance(info, dict)
-                and str(info.get("id") or "") == native_message_id
-                and info.get("role") == "user"
-            ):
-                return steer_result(
-                    SteerOutcome.ACCEPTED,
-                    reason="native_message_found",
-                    backend=self.name,
-                    native_message_id=native_message_id,
-                )
+        native_message_id = native_message_id_for_attempt(request.attempt_id)
+        try:
+            message = await server.get_message(
+                native_session_id,
+                native_message_id,
+                directory,
+            )
+        except Exception as exc:  # noqa: BLE001 - absence is not negative proof
+            return steer_result(
+                SteerOutcome.UNKNOWN,
+                reason="attempt_evidence_unavailable",
+                backend=self.name,
+                diagnostic=str(exc),
+            )
+        info = message.get("info") if isinstance(message, dict) else None
+        if (
+            isinstance(info, dict)
+            and str(info.get("id") or "") == native_message_id
+            and info.get("role") == "user"
+        ):
+            return steer_result(
+                SteerOutcome.ACCEPTED,
+                reason="native_message_found",
+                backend=self.name,
+                native_message_id=native_message_id,
+            )
         return steer_result(
             SteerOutcome.UNKNOWN,
-            reason=(
-                "untrusted_attempt_evidence"
-                if observed_evidence
-                else "attempt_evidence_unavailable"
-            ),
+            reason="untrusted_attempt_evidence",
             backend=self.name,
-            diagnostic="; ".join(diagnostics),
         )
 
     async def handle_stop(self, request: AgentRequest) -> bool:
@@ -1762,14 +1757,16 @@ class OpenCodeAgent(OpenCodeMessageProcessorMixin, BaseAgent):
                 verification_unknown = True
 
             baseline_message_ids = set(poll_info.baseline_message_ids)
-            start_attempt_message_ids = set(
-                native_message_ids_for_attempt(start_attempt_id)
+            start_attempt_message_id = (
+                native_message_id_for_attempt(start_attempt_id)
+                if start_attempt_id
+                else ""
             )
             start_attempt_found = any(
-                start_attempt_message_ids
+                start_attempt_message_id
                 and message.get("info", {}).get("role") == "user"
                 and str(message.get("info", {}).get("id") or "")
-                in start_attempt_message_ids
+                == start_attempt_message_id
                 for message in messages
             )
             has_in_progress = False

--- a/modules/agents/opencode/server.py
+++ b/modules/agents/opencode/server.py
@@ -47,6 +47,9 @@ MODEL_HUB_OVERLAY_DRAIN_TIMEOUT_SECONDS = 30.0
 _USE_CURRENT_CALLER_CONTEXT_PATH = object()
 _CURRENT_OWNER_PID = os.getpid()
 _DURABLE_ATTEMPT_ID_RE = re.compile(r"^atm_([0-9a-f]{26})$")
+_ORDERED_NATIVE_MESSAGE_ID_RE = re.compile(
+    r"^msg_([0-9a-f]{12})([0-9a-f]{11})[0-9a-f]{3}$"
+)
 
 
 def _percent_encode_path(path: str) -> str:
@@ -68,6 +71,20 @@ def native_message_id_for_attempt(attempt_id: str) -> str:
     if match is None:
         raise ValueError("OpenCode prompt attempt identity is not ordered")
     return f"msg_{match.group(1)}"
+
+
+def native_message_not_before_ms(message_id: str) -> int | None:
+    """Return the enforced write boundary encoded by an Avibe native ID."""
+
+    match = _ORDERED_NATIVE_MESSAGE_ID_RE.fullmatch(str(message_id or "").strip())
+    if match is None:
+        return None
+    order_key = int(match.group(1), 16)
+    not_before_ms = int(match.group(2), 16)
+    expected_order_key = (not_before_ms * 0x1000) & ((1 << 48) - 1)
+    if order_key != expected_order_key:
+        return None
+    return not_before_ms
 
 
 class OpenCodePromptRejectedError(RuntimeError):
@@ -1588,6 +1605,8 @@ class OpenCodeServerManager:
     ) -> None:
         """Start a prompt asynchronously without holding the HTTP request open."""
 
+        if message_id:
+            await self._wait_for_native_message_slot(message_id)
         started_at = time.time()
         async with self._request_scope():
             session = await self._get_http_session()
@@ -1619,6 +1638,15 @@ class OpenCodeServerManager:
                     error_text = await resp.text()
                     raise OpenCodePromptRejectedError(resp.status, error_text)
             self._last_prompt_started_at[session_id] = started_at
+
+    @staticmethod
+    async def _wait_for_native_message_slot(message_id: str) -> None:
+        not_before_ms = native_message_not_before_ms(message_id)
+        if not_before_ms is None:
+            return
+        delay_seconds = (not_before_ms - int(time.time() * 1_000)) / 1_000
+        if delay_seconds > 0:
+            await asyncio.sleep(delay_seconds)
 
     async def list_messages(self, session_id: str, directory: str) -> List[Dict[str, Any]]:
         async with self._request_scope():

--- a/modules/agents/opencode/server.py
+++ b/modules/agents/opencode/server.py
@@ -46,10 +46,7 @@ OPENCODE_LOG_TAIL_BYTES = 2_000_000
 MODEL_HUB_OVERLAY_DRAIN_TIMEOUT_SECONDS = 30.0
 _USE_CURRENT_CALLER_CONTEXT_PATH = object()
 _CURRENT_OWNER_PID = os.getpid()
-_DURABLE_ATTEMPT_ID_RE = re.compile(r"^atm_([0-9a-f]{26})$")
-_ORDERED_NATIVE_MESSAGE_ID_RE = re.compile(
-    r"^msg_([0-9a-f]{12})([0-9a-f]{11})[0-9a-f]{3}$"
-)
+_DURABLE_ATTEMPT_ID_RE = re.compile(r"^atm_([0-9a-f]{32})$")
 
 
 def _percent_encode_path(path: str) -> str:
@@ -63,28 +60,14 @@ def _percent_encode_path(path: str) -> str:
     return _url_quote(path, safe="/")
 
 
-def native_message_id_for_attempt(attempt_id: str) -> str:
-    """Map one ordered durable attempt into OpenCode's message namespace."""
+def native_part_id_for_attempt(attempt_id: str) -> str:
+    """Map one durable attempt into OpenCode's part namespace."""
 
     value = str(attempt_id or "").strip()
     match = _DURABLE_ATTEMPT_ID_RE.fullmatch(value)
     if match is None:
-        raise ValueError("OpenCode prompt attempt identity is not ordered")
-    return f"msg_{match.group(1)}"
-
-
-def native_message_not_before_ms(message_id: str) -> int | None:
-    """Return the enforced write boundary encoded by an Avibe native ID."""
-
-    match = _ORDERED_NATIVE_MESSAGE_ID_RE.fullmatch(str(message_id or "").strip())
-    if match is None:
-        return None
-    order_key = int(match.group(1), 16)
-    not_before_ms = int(match.group(2), 16)
-    expected_order_key = (not_before_ms * 0x1000) & ((1 << 48) - 1)
-    if order_key != expected_order_key:
-        return None
-    return not_before_ms
+        raise ValueError("OpenCode prompt attempt identity is not canonical")
+    return f"prt_{match.group(1)}"
 
 
 class OpenCodePromptRejectedError(RuntimeError):
@@ -1596,7 +1579,7 @@ class OpenCodeServerManager:
         session_id: str,
         directory: str,
         text: str,
-        message_id: Optional[str] = None,
+        attempt_id: Optional[str] = None,
         agent: Optional[str] = None,
         model: Optional[Dict[str, str]] = None,
         reasoning_effort: Optional[str] = None,
@@ -1605,17 +1588,16 @@ class OpenCodeServerManager:
     ) -> None:
         """Start a prompt asynchronously without holding the HTTP request open."""
 
-        if message_id:
-            await self._wait_for_native_message_slot(message_id)
         started_at = time.time()
         async with self._request_scope():
             session = await self._get_http_session()
 
+            text_part: Dict[str, Any] = {"type": "text", "text": text}
+            if attempt_id:
+                text_part["id"] = native_part_id_for_attempt(attempt_id)
             body: Dict[str, Any] = {
-                "parts": [{"type": "text", "text": text}],
+                "parts": [text_part],
             }
-            if message_id:
-                body["messageID"] = message_id
             if agent:
                 body["agent"] = agent
             if model:
@@ -1638,15 +1620,6 @@ class OpenCodeServerManager:
                     error_text = await resp.text()
                     raise OpenCodePromptRejectedError(resp.status, error_text)
             self._last_prompt_started_at[session_id] = started_at
-
-    @staticmethod
-    async def _wait_for_native_message_slot(message_id: str) -> None:
-        not_before_ms = native_message_not_before_ms(message_id)
-        if not_before_ms is None:
-            return
-        delay_seconds = (not_before_ms - int(time.time() * 1_000)) / 1_000
-        if delay_seconds > 0:
-            await asyncio.sleep(delay_seconds)
 
     async def list_messages(self, session_id: str, directory: str) -> List[Dict[str, Any]]:
         async with self._request_scope():

--- a/modules/agents/opencode/server.py
+++ b/modules/agents/opencode/server.py
@@ -46,6 +46,7 @@ OPENCODE_LOG_TAIL_BYTES = 2_000_000
 MODEL_HUB_OVERLAY_DRAIN_TIMEOUT_SECONDS = 30.0
 _USE_CURRENT_CALLER_CONTEXT_PATH = object()
 _CURRENT_OWNER_PID = os.getpid()
+_DURABLE_ATTEMPT_ID_RE = re.compile(r"^atm_([0-9a-f]{26})$")
 
 
 def _percent_encode_path(path: str) -> str:
@@ -60,25 +61,13 @@ def _percent_encode_path(path: str) -> str:
 
 
 def native_message_id_for_attempt(attempt_id: str) -> str:
-    """Map one durable attempt identity into OpenCode's message namespace."""
+    """Map one ordered durable attempt into OpenCode's message namespace."""
 
     value = str(attempt_id or "").strip()
-    if not value.startswith("atm") or len(value) == 3:
-        raise ValueError("OpenCode prompt attempt identity must start with 'atm'")
-    return f"msg{value[3:]}"
-
-
-def native_message_ids_for_attempt(attempt_id: str) -> tuple[str, ...]:
-    """Return current and legacy native identities for exact evidence reads."""
-
-    value = str(attempt_id or "").strip()
-    if not value:
-        return ()
-    try:
-        current = native_message_id_for_attempt(value)
-    except ValueError:
-        return (value,)
-    return (current, value) if current != value else (value,)
+    match = _DURABLE_ATTEMPT_ID_RE.fullmatch(value)
+    if match is None:
+        raise ValueError("OpenCode prompt attempt identity is not ordered")
+    return f"msg_{match.group(1)}"
 
 
 class OpenCodePromptRejectedError(RuntimeError):

--- a/storage/message_deliveries.py
+++ b/storage/message_deliveries.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import threading
 import time
 import uuid
 from datetime import datetime, timezone
@@ -29,6 +30,9 @@ from storage.models import (
 TURN_OWNER_STATES = ("starting", "active")
 WEB_PUSH_USER_KEY_METADATA = "_web_push_user_key"
 WEB_PUSH_USER_KEYS_METADATA = "_web_push_user_keys"
+_ATTEMPT_ID_LOCK = threading.Lock()
+_ATTEMPT_ID_WALL_MS = -1
+_ATTEMPT_ID_SLOT = -1
 
 
 def utc_now_iso() -> str:
@@ -50,10 +54,21 @@ def new_delivery_id() -> str:
 
 
 def new_attempt_id() -> str:
-    # Keep the leading order key compatible with timestamp-first native IDs.
-    # The zeroed low bits leave room for a native assistant created in the same
-    # millisecond to sort after this user-message attempt.
-    order_key = (int(time.time() * 1_000) * 0x1000) & ((1 << 48) - 1)
+    # Reserve the preceding millisecond for Avibe-authored user messages. This
+    # leaves the current native millisecond free for OpenCode's assistant ID,
+    # while the slot preserves FIFO order between rapid durable attempts.
+    global _ATTEMPT_ID_SLOT, _ATTEMPT_ID_WALL_MS
+
+    wall_ms = int(time.time() * 1_000)
+    with _ATTEMPT_ID_LOCK:
+        if wall_ms != _ATTEMPT_ID_WALL_MS:
+            _ATTEMPT_ID_WALL_MS = wall_ms
+            _ATTEMPT_ID_SLOT = 0
+        else:
+            _ATTEMPT_ID_SLOT += 1
+        if _ATTEMPT_ID_SLOT > 0xFFF:
+            raise RuntimeError("durable attempt ID slots exhausted for one millisecond")
+        order_key = (((wall_ms - 1) * 0x1000) + _ATTEMPT_ID_SLOT) & ((1 << 48) - 1)
     return f"atm_{order_key:012x}{uuid.uuid4().hex[:14]}"
 
 

--- a/storage/message_deliveries.py
+++ b/storage/message_deliveries.py
@@ -50,7 +50,11 @@ def new_delivery_id() -> str:
 
 
 def new_attempt_id() -> str:
-    return f"atm_{uuid.uuid4().hex}"
+    # Keep the leading order key compatible with timestamp-first native IDs.
+    # The zeroed low bits leave room for a native assistant created in the same
+    # millisecond to sort after this user-message attempt.
+    order_key = (int(time.time() * 1_000) * 0x1000) & ((1 << 48) - 1)
+    return f"atm_{order_key:012x}{uuid.uuid4().hex[:14]}"
 
 
 def _canonical_json(value: Any) -> str:

--- a/storage/message_deliveries.py
+++ b/storage/message_deliveries.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import hashlib
 import json
-import threading
 import time
 import uuid
 from datetime import datetime, timezone
@@ -30,8 +29,6 @@ from storage.models import (
 TURN_OWNER_STATES = ("starting", "active")
 WEB_PUSH_USER_KEY_METADATA = "_web_push_user_key"
 WEB_PUSH_USER_KEYS_METADATA = "_web_push_user_keys"
-_ATTEMPT_ID_LOCK = threading.Lock()
-_LAST_ATTEMPT_NOT_BEFORE_MS = -1
 
 
 def utc_now_iso() -> str:
@@ -53,17 +50,7 @@ def new_delivery_id() -> str:
 
 
 def new_attempt_id() -> str:
-    # Give every attempt its own future native millisecond. The backend waits
-    # for that boundary before writing, so an existing assistant is always
-    # earlier and OpenCode's following assistant is always later.
-    global _LAST_ATTEMPT_NOT_BEFORE_MS
-
-    wall_ms = int(time.time() * 1_000)
-    with _ATTEMPT_ID_LOCK:
-        not_before_ms = max(wall_ms + 1, _LAST_ATTEMPT_NOT_BEFORE_MS + 1)
-        _LAST_ATTEMPT_NOT_BEFORE_MS = not_before_ms
-    order_key = (not_before_ms * 0x1000) & ((1 << 48) - 1)
-    return f"atm_{order_key:012x}{not_before_ms:011x}{uuid.uuid4().hex[:3]}"
+    return f"atm_{uuid.uuid4().hex}"
 
 
 def _canonical_json(value: Any) -> str:

--- a/storage/message_deliveries.py
+++ b/storage/message_deliveries.py
@@ -31,8 +31,7 @@ TURN_OWNER_STATES = ("starting", "active")
 WEB_PUSH_USER_KEY_METADATA = "_web_push_user_key"
 WEB_PUSH_USER_KEYS_METADATA = "_web_push_user_keys"
 _ATTEMPT_ID_LOCK = threading.Lock()
-_ATTEMPT_ID_WALL_MS = -1
-_ATTEMPT_ID_SLOT = -1
+_LAST_ATTEMPT_NOT_BEFORE_MS = -1
 
 
 def utc_now_iso() -> str:
@@ -54,22 +53,17 @@ def new_delivery_id() -> str:
 
 
 def new_attempt_id() -> str:
-    # Reserve the preceding millisecond for Avibe-authored user messages. This
-    # leaves the current native millisecond free for OpenCode's assistant ID,
-    # while the slot preserves FIFO order between rapid durable attempts.
-    global _ATTEMPT_ID_SLOT, _ATTEMPT_ID_WALL_MS
+    # Give every attempt its own future native millisecond. The backend waits
+    # for that boundary before writing, so an existing assistant is always
+    # earlier and OpenCode's following assistant is always later.
+    global _LAST_ATTEMPT_NOT_BEFORE_MS
 
     wall_ms = int(time.time() * 1_000)
     with _ATTEMPT_ID_LOCK:
-        if wall_ms != _ATTEMPT_ID_WALL_MS:
-            _ATTEMPT_ID_WALL_MS = wall_ms
-            _ATTEMPT_ID_SLOT = 0
-        else:
-            _ATTEMPT_ID_SLOT += 1
-        if _ATTEMPT_ID_SLOT > 0xFFF:
-            raise RuntimeError("durable attempt ID slots exhausted for one millisecond")
-        order_key = (((wall_ms - 1) * 0x1000) + _ATTEMPT_ID_SLOT) & ((1 << 48) - 1)
-    return f"atm_{order_key:012x}{uuid.uuid4().hex[:14]}"
+        not_before_ms = max(wall_ms + 1, _LAST_ATTEMPT_NOT_BEFORE_MS + 1)
+        _LAST_ATTEMPT_NOT_BEFORE_MS = not_before_ms
+    order_key = (not_before_ms * 0x1000) & ((1 << 48) - 1)
+    return f"atm_{order_key:012x}{not_before_ms:011x}{uuid.uuid4().hex[:3]}"
 
 
 def _canonical_json(value: Any) -> str:

--- a/tests/scenarios/message_delivery/catalog.yaml
+++ b/tests/scenarios/message_delivery/catalog.yaml
@@ -139,7 +139,7 @@ scenarios:
     status: covered
     kind: recovery
     layer: contract
-    test: tests/test_opencode_server.py::OpenCodeServerTests::test_durable_attempt_maps_to_opencode_part_evidence
+    test: tests/test_agent_steering.py::test_message_delivery_021_opencode_preserves_native_order_and_recovers_exact_part
   - id: MESSAGE-DELIVERY-101
     name: Unresolved fallback-capable delivery fences only later FIFO submissions
     status: covered

--- a/tests/scenarios/message_delivery/catalog.yaml
+++ b/tests/scenarios/message_delivery/catalog.yaml
@@ -135,11 +135,11 @@ scenarios:
     layer: contract
     test: tests/test_session_delivery_fsm.py::test_permanent_start_rejection_retires_delivery_without_retry
   - id: MESSAGE-DELIVERY-021
-    name: Durable OpenCode attempts preserve native same-Session message order
+    name: Durable OpenCode attempts preserve native order through exact part evidence
     status: covered
     kind: recovery
     layer: contract
-    test: tests/test_opencode_server.py::OpenCodeServerTests::test_durable_attempt_maps_between_surrounding_native_messages
+    test: tests/test_opencode_server.py::OpenCodeServerTests::test_durable_attempt_maps_to_opencode_part_evidence
   - id: MESSAGE-DELIVERY-101
     name: Unresolved fallback-capable delivery fences only later FIFO submissions
     status: covered

--- a/tests/scenarios/message_delivery/catalog.yaml
+++ b/tests/scenarios/message_delivery/catalog.yaml
@@ -134,6 +134,12 @@ scenarios:
     kind: recovery
     layer: contract
     test: tests/test_session_delivery_fsm.py::test_permanent_start_rejection_retires_delivery_without_retry
+  - id: MESSAGE-DELIVERY-021
+    name: Durable OpenCode attempts preserve native same-Session message order
+    status: covered
+    kind: recovery
+    layer: contract
+    test: tests/test_opencode_server.py::OpenCodeServerTests::test_durable_attempt_maps_between_surrounding_native_messages
   - id: MESSAGE-DELIVERY-101
     name: Unresolved fallback-capable delivery fences only later FIFO submissions
     status: covered

--- a/tests/test_agent_steering.py
+++ b/tests/test_agent_steering.py
@@ -32,8 +32,7 @@ from modules.im import MessageContext
 
 
 STEER_TEXT = "补充：**不要改写**\n```python\nprint('λ')\n```"
-ORDERED_ATTEMPT_ID = "atm_1234567890000123456789abcd"
-ORDERED_NATIVE_MESSAGE_ID = "msg_1234567890000123456789abcd"
+ATTEMPT_ID = "atm_1234567890abcdef1234567890abcdef"
 
 
 def test_steer_outcomes_are_exhaustive() -> None:
@@ -151,13 +150,17 @@ class _OpenCodeServer:
             await self.release_prompt.wait()
         if self.error is not None:
             raise self.error
+        attempt_id = kwargs.get("attempt_id")
+        part = {"type": "text", "text": kwargs["text"]}
+        if attempt_id:
+            part["id"] = f"prt_{attempt_id.removeprefix('atm_')}"
         self.messages.append(
             {
                 "info": {
-                    "id": kwargs.get("message_id") or f"steer-user-{len(self.prompt_calls)}",
+                    "id": f"steer-user-{len(self.prompt_calls)}",
                     "role": "user",
                 },
-                "parts": [{"type": "text", "text": kwargs["text"]}],
+                "parts": [part],
             }
         )
 
@@ -661,7 +664,7 @@ async def test_opencode_reconciles_exact_native_attempt_without_resteering() -> 
     server = _OpenCodeServer()
     agent = _opencode_agent(primary, gate_task, server)
     controller = _controller_with_active_gate(agent, primary, gate_task)
-    attempt_id = ORDERED_ATTEMPT_ID
+    attempt_id = ATTEMPT_ID
     try:
         identity = active_steer_identity(controller, "opencode", "avibe-session")
         assert identity is not None
@@ -677,7 +680,8 @@ async def test_opencode_reconciles_exact_native_attempt_without_resteering() -> 
             ),
         )
         assert receipt.outcome is SteerOutcome.ACCEPTED
-        assert server.prompt_calls[0]["message_id"] == ORDERED_NATIVE_MESSAGE_ID
+        assert server.prompt_calls[0]["attempt_id"] == ATTEMPT_ID
+        assert "message_id" not in server.prompt_calls[0]
 
         reconciled = await reconcile_steer_attempt(
             controller,
@@ -691,7 +695,7 @@ async def test_opencode_reconciles_exact_native_attempt_without_resteering() -> 
         )
 
         assert reconciled.outcome is SteerOutcome.ACCEPTED
-        assert reconciled.details["native_message_id"] == ORDERED_NATIVE_MESSAGE_ID
+        assert reconciled.details["native_message_id"] == "steer-user-1"
         assert len(server.prompt_calls) == 1
     finally:
         await _cancel_tasks(gate_task)
@@ -965,7 +969,7 @@ async def test_opencode_definitive_start_rejection_reconciles_before_poll_cleanu
     reconciliation_fails: bool,
 ) -> None:
     primary = _primary_request(backend="opencode")
-    primary.context.platform_specific["delivery_start_attempt_id"] = ORDERED_ATTEMPT_ID
+    primary.context.platform_specific["delivery_start_attempt_id"] = ATTEMPT_ID
     events: list[str] = []
 
     class _Server:
@@ -1086,9 +1090,9 @@ async def test_opencode_definitive_start_rejection_reconciles_before_poll_cleanu
     await agent._process_message(primary)
 
     expected_reconciliation = (
-        f"invalid:logical-turn:{ORDERED_ATTEMPT_ID}:opencode"
+        f"invalid:logical-turn:{ATTEMPT_ID}:opencode"
         if status == 400
-        else f"reconcile:logical-turn:{ORDERED_ATTEMPT_ID}:opencode"
+        else f"reconcile:logical-turn:{ATTEMPT_ID}:opencode"
     )
     assert events[:3] == [
         "persist_poll",
@@ -1105,7 +1109,7 @@ async def test_opencode_ambiguous_start_failure_preserves_recovery_poll(
     monkeypatch,
 ) -> None:
     primary = _primary_request(backend="opencode")
-    primary.context.platform_specific["delivery_start_attempt_id"] = ORDERED_ATTEMPT_ID
+    primary.context.platform_specific["delivery_start_attempt_id"] = ATTEMPT_ID
     events: list[str] = []
 
     class _Server:

--- a/tests/test_agent_steering.py
+++ b/tests/test_agent_steering.py
@@ -32,6 +32,8 @@ from modules.im import MessageContext
 
 
 STEER_TEXT = "补充：**不要改写**\n```python\nprint('λ')\n```"
+ORDERED_ATTEMPT_ID = "atm_1234567890000123456789abcd"
+ORDERED_NATIVE_MESSAGE_ID = "msg_1234567890000123456789abcd"
 
 
 def test_steer_outcomes_are_exhaustive() -> None:
@@ -659,7 +661,7 @@ async def test_opencode_reconciles_exact_native_attempt_without_resteering() -> 
     server = _OpenCodeServer()
     agent = _opencode_agent(primary, gate_task, server)
     controller = _controller_with_active_gate(agent, primary, gate_task)
-    attempt_id = "atm_exact_restart_evidence"
+    attempt_id = ORDERED_ATTEMPT_ID
     try:
         identity = active_steer_identity(controller, "opencode", "avibe-session")
         assert identity is not None
@@ -675,7 +677,7 @@ async def test_opencode_reconciles_exact_native_attempt_without_resteering() -> 
             ),
         )
         assert receipt.outcome is SteerOutcome.ACCEPTED
-        assert server.prompt_calls[0]["message_id"] == "msg_exact_restart_evidence"
+        assert server.prompt_calls[0]["message_id"] == ORDERED_NATIVE_MESSAGE_ID
 
         reconciled = await reconcile_steer_attempt(
             controller,
@@ -689,41 +691,8 @@ async def test_opencode_reconciles_exact_native_attempt_without_resteering() -> 
         )
 
         assert reconciled.outcome is SteerOutcome.ACCEPTED
-        assert reconciled.details["native_message_id"] == "msg_exact_restart_evidence"
+        assert reconciled.details["native_message_id"] == ORDERED_NATIVE_MESSAGE_ID
         assert len(server.prompt_calls) == 1
-    finally:
-        await _cancel_tasks(gate_task)
-
-
-@pytest.mark.anyio
-async def test_opencode_reconciles_legacy_native_attempt_without_resteering() -> None:
-    primary = _primary_request(backend="opencode")
-    gate_task = await _held_task()
-    attempt_id = "atm_legacy_restart_evidence"
-    server = _OpenCodeServer(
-        messages=[
-            {"info": {"id": attempt_id, "role": "user"}, "parts": []},
-        ]
-    )
-    agent = _opencode_agent(primary, gate_task, server)
-    controller = _controller_with_active_gate(agent, primary, gate_task)
-    try:
-        identity = active_steer_identity(controller, "opencode", "avibe-session")
-        assert identity is not None
-        reconciled = await reconcile_steer_attempt(
-            controller,
-            "opencode",
-            SteerReconcileRequest(
-                target_session_id="avibe-session",
-                expected_logical_turn_id=identity[0],
-                expected_native_turn_id=identity[1],
-                attempt_id=attempt_id,
-            ),
-        )
-
-        assert reconciled.outcome is SteerOutcome.ACCEPTED
-        assert reconciled.details["native_message_id"] == attempt_id
-        assert server.prompt_calls == []
     finally:
         await _cancel_tasks(gate_task)
 
@@ -996,7 +965,7 @@ async def test_opencode_definitive_start_rejection_reconciles_before_poll_cleanu
     reconciliation_fails: bool,
 ) -> None:
     primary = _primary_request(backend="opencode")
-    primary.context.platform_specific["delivery_start_attempt_id"] = "atm-start"
+    primary.context.platform_specific["delivery_start_attempt_id"] = ORDERED_ATTEMPT_ID
     events: list[str] = []
 
     class _Server:
@@ -1117,9 +1086,9 @@ async def test_opencode_definitive_start_rejection_reconciles_before_poll_cleanu
     await agent._process_message(primary)
 
     expected_reconciliation = (
-        "invalid:logical-turn:atm-start:opencode"
+        f"invalid:logical-turn:{ORDERED_ATTEMPT_ID}:opencode"
         if status == 400
-        else "reconcile:logical-turn:atm-start:opencode"
+        else f"reconcile:logical-turn:{ORDERED_ATTEMPT_ID}:opencode"
     )
     assert events[:3] == [
         "persist_poll",
@@ -1136,7 +1105,7 @@ async def test_opencode_ambiguous_start_failure_preserves_recovery_poll(
     monkeypatch,
 ) -> None:
     primary = _primary_request(backend="opencode")
-    primary.context.platform_specific["delivery_start_attempt_id"] = "atm-start"
+    primary.context.platform_specific["delivery_start_attempt_id"] = ORDERED_ATTEMPT_ID
     events: list[str] = []
 
     class _Server:

--- a/tests/test_agent_steering.py
+++ b/tests/test_agent_steering.py
@@ -1496,6 +1496,57 @@ async def test_opencode_accepted_prompt_waits_for_delayed_busy_registration() ->
 
 
 @pytest.mark.anyio
+async def test_opencode_idle_waits_for_delayed_terminal_message_visibility() -> None:
+    primary = _primary_request(backend="opencode")
+    gate_task = await _held_task()
+
+    class _DelayedFinalServer(_OpenCodeServer):
+        async def list_messages(self, session_id: str, directory: str) -> list[dict]:
+            if self.list_calls == 2:
+                self.messages.append(
+                    {
+                        "info": {
+                            "id": "follow-up-assistant",
+                            "role": "assistant",
+                            "time": {"completed": 2},
+                            "finish": "stop",
+                        },
+                        "parts": [{"type": "text", "text": "answered"}],
+                    }
+                )
+            return await super().list_messages(session_id, directory)
+
+    server = _DelayedFinalServer(
+        messages=[
+            {
+                "info": {"id": "follow-up-user", "role": "user"},
+                "parts": [{"type": "text", "text": "follow-up"}],
+            }
+        ],
+        status_responses=[{"type": "busy"}, {"type": "idle"}, {"type": "idle"}],
+    )
+    agent = _opencode_agent(primary, gate_task, server)
+    state = agent._steering_states[primary.base_session_id]
+    state.awaiting_after_message_ids = set()
+    state.awaiting_user_text = "follow-up"
+    state.awaiting_start_confirmation_deadline = time.monotonic() - 1
+    poll_server = _SteeringAwareOpenCodeServer(server, state)
+    try:
+        messages = await asyncio.wait_for(
+            poll_server.list_messages("opencode-session", primary.working_path),
+            timeout=1,
+        )
+
+        assert messages[-1]["info"]["id"] == "follow-up-assistant"
+        assert state.terminal_status_failure_messages is None
+        assert state.awaiting_after_message_ids is None
+        assert state.closing is True
+        assert server.list_calls == 3
+    finally:
+        await _cancel_tasks(gate_task)
+
+
+@pytest.mark.anyio
 async def test_opencode_accepted_prompt_idle_start_timeout_is_terminal() -> None:
     primary = _primary_request(backend="opencode")
     gate_task = await _held_task()

--- a/tests/test_agent_steering.py
+++ b/tests/test_agent_steering.py
@@ -658,10 +658,28 @@ async def test_opencode_keeps_reconciliation_armed_after_post_write_idle() -> No
 
 
 @pytest.mark.anyio
-async def test_opencode_reconciles_exact_native_attempt_without_resteering() -> None:
+async def test_message_delivery_021_opencode_preserves_native_order_and_recovers_exact_part() -> None:
+    """Scenario: MESSAGE-DELIVERY-021."""
     primary = _primary_request(backend="opencode")
     gate_task = await _held_task()
-    server = _OpenCodeServer()
+    server = _OpenCodeServer(
+        messages=[
+            {
+                "info": {"id": "primary-user", "role": "user"},
+                "parts": [{"type": "text", "text": "primary"}],
+            },
+            {
+                "info": {
+                    "id": "primary-assistant",
+                    "role": "assistant",
+                    "parentID": "primary-user",
+                    "time": {"completed": 1},
+                    "finish": "stop",
+                },
+                "parts": [{"type": "text", "text": "primary result"}],
+            },
+        ]
+    )
     agent = _opencode_agent(primary, gate_task, server)
     controller = _controller_with_active_gate(agent, primary, gate_task)
     attempt_id = ATTEMPT_ID
@@ -682,6 +700,34 @@ async def test_opencode_reconciles_exact_native_attempt_without_resteering() -> 
         assert receipt.outcome is SteerOutcome.ACCEPTED
         assert server.prompt_calls[0]["attempt_id"] == ATTEMPT_ID
         assert "message_id" not in server.prompt_calls[0]
+        inserted_user = server.messages[-1]
+        server.messages.append(
+            {
+                "info": {
+                    "id": "steer-assistant-1",
+                    "role": "assistant",
+                    "parentID": inserted_user["info"]["id"],
+                    "time": {"completed": 2},
+                    "finish": "stop",
+                },
+                "parts": [{"type": "text", "text": "steer result"}],
+            }
+        )
+
+        assert [message["info"]["id"] for message in server.messages] == [
+            "primary-user",
+            "primary-assistant",
+            "steer-user-1",
+            "steer-assistant-1",
+        ]
+        assert inserted_user["parts"] == [
+            {
+                "type": "text",
+                "text": STEER_TEXT,
+                "id": "prt_1234567890abcdef1234567890abcdef",
+            }
+        ]
+        assert server.messages[-1]["info"]["parentID"] == "steer-user-1"
 
         reconciled = await reconcile_steer_attempt(
             controller,

--- a/tests/test_multi_platform_runtime.py
+++ b/tests/test_multi_platform_runtime.py
@@ -30,6 +30,10 @@ from modules.agents.opencode.poll_loop import OpenCodePollLoop
 from modules.agents.opencode.utils import resolve_opencode_reasoning_effort
 
 
+ORDERED_ATTEMPT_ID = "atm_1234567890000123456789abcd"
+ORDERED_NATIVE_MESSAGE_ID = "msg_1234567890000123456789abcd"
+
+
 @dataclass
 class _StubConfig(BaseIMConfig):
     def validate(self) -> None:
@@ -820,7 +824,7 @@ def test_opencode_prompt_disables_question_tool_for_all_platforms():
                 platform_specific={
                     "agent_session_id": "ses_test",
                     "turn_token": "logical-turn",
-                    "delivery_start_attempt_id": "atm_initial_start",
+                    "delivery_start_attempt_id": ORDERED_ATTEMPT_ID,
                 },
             ),
             message="hello",
@@ -838,7 +842,7 @@ def test_opencode_prompt_disables_question_tool_for_all_platforms():
     assert calls[0]["tools"] == {"question": False}
     assert calls[0]["model"] == {"providerID": "openai", "modelID": "gpt-5.4"}
     assert calls[0]["reasoning_effort"] == "high"
-    assert calls[0]["message_id"] == "msg_initial_start"
+    assert calls[0]["message_id"] == ORDERED_NATIVE_MESSAGE_ID
     assert recovery_order[:3] == ["poll", "prompt", "accepted"]
     assert active_poll_updates[0][0] == "oc-session"
     assert isinstance(active_poll_updates[0][1]["prompt_started_at"], float)

--- a/tests/test_multi_platform_runtime.py
+++ b/tests/test_multi_platform_runtime.py
@@ -30,8 +30,7 @@ from modules.agents.opencode.poll_loop import OpenCodePollLoop
 from modules.agents.opencode.utils import resolve_opencode_reasoning_effort
 
 
-ORDERED_ATTEMPT_ID = "atm_1234567890000123456789abcd"
-ORDERED_NATIVE_MESSAGE_ID = "msg_1234567890000123456789abcd"
+ATTEMPT_ID = "atm_1234567890abcdef1234567890abcdef"
 
 
 @dataclass
@@ -824,7 +823,7 @@ def test_opencode_prompt_disables_question_tool_for_all_platforms():
                 platform_specific={
                     "agent_session_id": "ses_test",
                     "turn_token": "logical-turn",
-                    "delivery_start_attempt_id": ORDERED_ATTEMPT_ID,
+                    "delivery_start_attempt_id": ATTEMPT_ID,
                 },
             ),
             message="hello",
@@ -842,7 +841,8 @@ def test_opencode_prompt_disables_question_tool_for_all_platforms():
     assert calls[0]["tools"] == {"question": False}
     assert calls[0]["model"] == {"providerID": "openai", "modelID": "gpt-5.4"}
     assert calls[0]["reasoning_effort"] == "high"
-    assert calls[0]["message_id"] == ORDERED_NATIVE_MESSAGE_ID
+    assert calls[0]["attempt_id"] == ATTEMPT_ID
+    assert "message_id" not in calls[0]
     assert recovery_order[:3] == ["poll", "prompt", "accepted"]
     assert active_poll_updates[0][0] == "oc-session"
     assert isinstance(active_poll_updates[0][1]["prompt_started_at"], float)

--- a/tests/test_opencode_restore_polls.py
+++ b/tests/test_opencode_restore_polls.py
@@ -26,8 +26,8 @@ from core.services.agent_steering import SteerOutcome, SteerRequest, active_stee
 from modules.agents.opencode.agent import OpenCodeAgent  # noqa: E402
 
 
-ORDERED_ATTEMPT_ID = "atm_1234567890000123456789abcd"
-ORDERED_NATIVE_MESSAGE_ID = "msg_1234567890000123456789abcd"
+ATTEMPT_ID = "atm_1234567890abcdef1234567890abcdef"
+NATIVE_PART_ID = "prt_1234567890abcdef1234567890abcdef"
 
 
 def _make_poll(*, platform: str, base_session_id: str, opencode_session_id: str) -> ActivePollInfo:
@@ -342,7 +342,7 @@ def test_restore_preserves_durable_poll_when_verification_is_temporarily_unavail
     )
     poll.processing_indicator = {
         "platform": "avibe",
-        "delivery_start_attempt_id": ORDERED_ATTEMPT_ID,
+        "delivery_start_attempt_id": ATTEMPT_ID,
         "opencode_native_steering": {
             "target_session_id": "ses_wb",
             "logical_turn_id": "turn-unknown",
@@ -377,7 +377,7 @@ def test_restore_rebuilds_completed_exact_start_attempt() -> None:
     )
     poll.processing_indicator = {
         "platform": "avibe",
-        "delivery_start_attempt_id": ORDERED_ATTEMPT_ID,
+        "delivery_start_attempt_id": ATTEMPT_ID,
         "opencode_native_steering": {
             "target_session_id": "ses_wb",
             "logical_turn_id": "logical-start",
@@ -385,7 +385,10 @@ def test_restore_rebuilds_completed_exact_start_attempt() -> None:
     }
     agent, _, removed, _ = _build_agent({"oc-1": poll})
     agent._test_server.messages = [
-        {"info": {"id": ORDERED_NATIVE_MESSAGE_ID, "role": "user", "time": {}}},
+        {
+            "info": {"id": "native-start-user", "role": "user", "time": {}},
+            "parts": [{"id": NATIVE_PART_ID, "type": "text", "text": "hello"}],
+        },
         {
             "info": {
                 "id": "assistant-done",
@@ -438,7 +441,7 @@ def test_restore_reconciles_definitive_missing_start_attempt() -> None:
     )
     poll.processing_indicator = {
         "platform": "avibe",
-        "delivery_start_attempt_id": ORDERED_ATTEMPT_ID,
+        "delivery_start_attempt_id": ATTEMPT_ID,
         "opencode_native_steering": {
             "target_session_id": "ses_wb",
             "logical_turn_id": "logical-missing",
@@ -456,7 +459,7 @@ def test_restore_reconciles_definitive_missing_start_attempt() -> None:
     agent.controller.session_turns.reconcile_start_attempt_not_written = _reconcile
 
     assert asyncio.run(agent.restore_active_polls()) == 0
-    assert reconciled == [("logical-missing", ORDERED_ATTEMPT_ID, "opencode")]
+    assert reconciled == [("logical-missing", ATTEMPT_ID, "opencode")]
     assert removed == ["oc-1"]
 
 

--- a/tests/test_opencode_restore_polls.py
+++ b/tests/test_opencode_restore_polls.py
@@ -26,6 +26,10 @@ from core.services.agent_steering import SteerOutcome, SteerRequest, active_stee
 from modules.agents.opencode.agent import OpenCodeAgent  # noqa: E402
 
 
+ORDERED_ATTEMPT_ID = "atm_1234567890000123456789abcd"
+ORDERED_NATIVE_MESSAGE_ID = "msg_1234567890000123456789abcd"
+
+
 def _make_poll(*, platform: str, base_session_id: str, opencode_session_id: str) -> ActivePollInfo:
     return ActivePollInfo(
         opencode_session_id=opencode_session_id,
@@ -338,7 +342,7 @@ def test_restore_preserves_durable_poll_when_verification_is_temporarily_unavail
     )
     poll.processing_indicator = {
         "platform": "avibe",
-        "delivery_start_attempt_id": "atm-unknown",
+        "delivery_start_attempt_id": ORDERED_ATTEMPT_ID,
         "opencode_native_steering": {
             "target_session_id": "ses_wb",
             "logical_turn_id": "turn-unknown",
@@ -365,18 +369,7 @@ def test_restore_preserves_durable_poll_when_verification_is_temporarily_unavail
     assert removed == []
 
 
-@pytest.mark.parametrize(
-    ("attempt_id", "native_message_id"),
-    [
-        ("atm-start", "msg-start"),
-        ("atm-start", "atm-start"),
-        ("legacy-start", "legacy-start"),
-    ],
-)
-def test_restore_rebuilds_completed_exact_start_attempt(
-    attempt_id: str,
-    native_message_id: str,
-) -> None:
+def test_restore_rebuilds_completed_exact_start_attempt() -> None:
     poll = _make_poll(
         platform="avibe",
         base_session_id="ses_wb",
@@ -384,7 +377,7 @@ def test_restore_rebuilds_completed_exact_start_attempt(
     )
     poll.processing_indicator = {
         "platform": "avibe",
-        "delivery_start_attempt_id": attempt_id,
+        "delivery_start_attempt_id": ORDERED_ATTEMPT_ID,
         "opencode_native_steering": {
             "target_session_id": "ses_wb",
             "logical_turn_id": "logical-start",
@@ -392,7 +385,7 @@ def test_restore_rebuilds_completed_exact_start_attempt(
     }
     agent, _, removed, _ = _build_agent({"oc-1": poll})
     agent._test_server.messages = [
-        {"info": {"id": native_message_id, "role": "user", "time": {}}},
+        {"info": {"id": ORDERED_NATIVE_MESSAGE_ID, "role": "user", "time": {}}},
         {
             "info": {
                 "id": "assistant-done",
@@ -445,7 +438,7 @@ def test_restore_reconciles_definitive_missing_start_attempt() -> None:
     )
     poll.processing_indicator = {
         "platform": "avibe",
-        "delivery_start_attempt_id": "atm-missing",
+        "delivery_start_attempt_id": ORDERED_ATTEMPT_ID,
         "opencode_native_steering": {
             "target_session_id": "ses_wb",
             "logical_turn_id": "logical-missing",
@@ -463,7 +456,7 @@ def test_restore_reconciles_definitive_missing_start_attempt() -> None:
     agent.controller.session_turns.reconcile_start_attempt_not_written = _reconcile
 
     assert asyncio.run(agent.restore_active_polls()) == 0
-    assert reconciled == [("logical-missing", "atm-missing", "opencode")]
+    assert reconciled == [("logical-missing", ORDERED_ATTEMPT_ID, "opencode")]
     assert removed == ["oc-1"]
 
 

--- a/tests/test_opencode_server.py
+++ b/tests/test_opencode_server.py
@@ -11,6 +11,8 @@ from unittest.mock import AsyncMock, Mock, patch
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
+from storage import message_deliveries as delivery_store
+
 MODULE_PATH = Path(__file__).resolve().parents[1] / "modules" / "agents" / "opencode" / "server.py"
 
 
@@ -490,21 +492,22 @@ class OpenCodeServerTests(unittest.IsolatedAsyncioTestCase):
             "msg_exact_evidence",
         )
 
-    def test_durable_attempt_maps_to_opencode_message_namespace(self):
-        self.assertEqual(
-            SERVER_MODULE.native_message_id_for_attempt("atm_exact_evidence"),
-            "msg_exact_evidence",
-        )
+    def test_durable_attempt_maps_between_surrounding_native_messages(self):
+        timestamp_ms = 1_775_630_400_000
+        with patch.object(delivery_store.time, "time", return_value=timestamp_ms / 1000):
+            attempt_id = delivery_store.new_attempt_id()
 
-    def test_attempt_evidence_accepts_current_and_legacy_native_ids(self):
-        self.assertEqual(
-            SERVER_MODULE.native_message_ids_for_attempt("atm_exact_evidence"),
-            ("msg_exact_evidence", "atm_exact_evidence"),
-        )
-        self.assertEqual(
-            SERVER_MODULE.native_message_ids_for_attempt("legacy-evidence"),
-            ("legacy-evidence",),
-        )
+        native_message_id = SERVER_MODULE.native_message_id_for_attempt(attempt_id)
+        previous_order = ((timestamp_ms - 1) * 0x1000) & ((1 << 48) - 1)
+        next_order = (timestamp_ms * 0x1000 + 1) & ((1 << 48) - 1)
+
+        self.assertRegex(native_message_id, r"^msg_[0-9a-f]{26}$")
+        self.assertLess(f"msg_{previous_order:012x}{'z' * 14}", native_message_id)
+        self.assertLess(native_message_id, f"msg_{next_order:012x}{'0' * 14}")
+
+    def test_legacy_random_attempt_identity_is_rejected(self):
+        with self.assertRaises(ValueError):
+            SERVER_MODULE.native_message_id_for_attempt("atm_exact_evidence")
 
     async def test_prompt_async_exposes_definitive_http_rejection(self):
         manager = OpenCodeServerManager(binary="opencode", port=4096)

--- a/tests/test_opencode_server.py
+++ b/tests/test_opencode_server.py
@@ -471,10 +471,9 @@ class OpenCodeServerTests(unittest.IsolatedAsyncioTestCase):
         body = fake_session.posts[0]["json"]
         self.assertEqual(body["tools"], {"question": False})
 
-    async def test_prompt_async_uses_opencode_native_message_id(self):
+    async def test_prompt_async_uses_opencode_native_attempt_part(self):
         manager = OpenCodeServerManager(binary="opencode", port=4096)
         fake_session = _FakeSession()
-        manager._wait_for_native_message_slot = AsyncMock()  # type: ignore[method-assign]
 
         async def _fake_get_http_session():
             return fake_session
@@ -485,59 +484,37 @@ class OpenCodeServerTests(unittest.IsolatedAsyncioTestCase):
             session_id="ses-1",
             directory="/tmp/work",
             text="hello",
-            message_id="msg_exact_evidence",
+            attempt_id="atm_1234567890abcdef1234567890abcdef",
         )
 
+        body = fake_session.posts[0]["json"]
+        self.assertNotIn("messageID", body)
         self.assertEqual(
-            fake_session.posts[0]["json"]["messageID"],
-            "msg_exact_evidence",
-        )
-        manager._wait_for_native_message_slot.assert_awaited_once_with(  # type: ignore[attr-defined]
-            "msg_exact_evidence"
-        )
-
-    def test_durable_attempt_maps_between_surrounding_native_messages(self):
-        """MESSAGE-DELIVERY-021: durable attempts preserve native message order."""
-        timestamp_ms = 1_775_630_400_000
-        with patch.object(delivery_store.time, "time", return_value=timestamp_ms / 1000):
-            first_attempt_id = delivery_store.new_attempt_id()
-            second_attempt_id = delivery_store.new_attempt_id()
-
-        first_native_message_id = SERVER_MODULE.native_message_id_for_attempt(
-            first_attempt_id
-        )
-        second_native_message_id = SERVER_MODULE.native_message_id_for_attempt(
-            second_attempt_id
-        )
-        previous_order = (timestamp_ms * 0x1000 + 0xFFF) & ((1 << 48) - 1)
-        first_assistant_order = ((timestamp_ms + 1) * 0x1000 + 1) & (
-            (1 << 48) - 1
+            body["parts"],
+            [
+                {
+                    "type": "text",
+                    "text": "hello",
+                    "id": "prt_1234567890abcdef1234567890abcdef",
+                }
+            ],
         )
 
-        self.assertRegex(first_native_message_id, r"^msg_[0-9a-f]{26}$")
-        self.assertLess(
-            f"msg_{previous_order:012x}{'z' * 14}", first_native_message_id
-        )
-        self.assertLess(
-            first_native_message_id,
-            f"msg_{first_assistant_order:012x}{'0' * 14}",
-        )
-        self.assertLess(
-            f"msg_{first_assistant_order:012x}{'z' * 14}",
-            second_native_message_id,
-        )
+    def test_durable_attempt_maps_to_opencode_part_evidence(self):
+        """MESSAGE-DELIVERY-021: OpenCode owns native message ordering."""
+        attempt_id = delivery_store.new_attempt_id()
+
+        self.assertRegex(attempt_id, r"^atm_[0-9a-f]{32}$")
         self.assertEqual(
-            SERVER_MODULE.native_message_not_before_ms(first_native_message_id),
-            timestamp_ms + 1,
-        )
-        self.assertEqual(
-            SERVER_MODULE.native_message_not_before_ms(second_native_message_id),
-            timestamp_ms + 2,
+            SERVER_MODULE.native_part_id_for_attempt(attempt_id),
+            f"prt_{attempt_id.removeprefix('atm_')}",
         )
 
-    def test_legacy_random_attempt_identity_is_rejected(self):
+    def test_unreleased_ordered_attempt_identity_is_rejected(self):
         with self.assertRaises(ValueError):
-            SERVER_MODULE.native_message_id_for_attempt("atm_exact_evidence")
+            SERVER_MODULE.native_part_id_for_attempt(
+                "atm_1234567890000123456789abcd"
+            )
 
     async def test_prompt_async_exposes_definitive_http_rejection(self):
         manager = OpenCodeServerManager(binary="opencode", port=4096)

--- a/tests/test_opencode_server.py
+++ b/tests/test_opencode_server.py
@@ -474,6 +474,7 @@ class OpenCodeServerTests(unittest.IsolatedAsyncioTestCase):
     async def test_prompt_async_uses_opencode_native_message_id(self):
         manager = OpenCodeServerManager(binary="opencode", port=4096)
         fake_session = _FakeSession()
+        manager._wait_for_native_message_slot = AsyncMock()  # type: ignore[method-assign]
 
         async def _fake_get_http_session():
             return fake_session
@@ -491,6 +492,9 @@ class OpenCodeServerTests(unittest.IsolatedAsyncioTestCase):
             fake_session.posts[0]["json"]["messageID"],
             "msg_exact_evidence",
         )
+        manager._wait_for_native_message_slot.assert_awaited_once_with(  # type: ignore[attr-defined]
+            "msg_exact_evidence"
+        )
 
     def test_durable_attempt_maps_between_surrounding_native_messages(self):
         """MESSAGE-DELIVERY-021: durable attempts preserve native message order."""
@@ -505,16 +509,30 @@ class OpenCodeServerTests(unittest.IsolatedAsyncioTestCase):
         second_native_message_id = SERVER_MODULE.native_message_id_for_attempt(
             second_attempt_id
         )
-        previous_order = ((timestamp_ms - 2) * 0x1000 + 0xFFF) & ((1 << 48) - 1)
-        next_order = (timestamp_ms * 0x1000) & ((1 << 48) - 1)
+        previous_order = (timestamp_ms * 0x1000 + 0xFFF) & ((1 << 48) - 1)
+        first_assistant_order = ((timestamp_ms + 1) * 0x1000 + 1) & (
+            (1 << 48) - 1
+        )
 
         self.assertRegex(first_native_message_id, r"^msg_[0-9a-f]{26}$")
         self.assertLess(
             f"msg_{previous_order:012x}{'z' * 14}", first_native_message_id
         )
-        self.assertLess(first_native_message_id, second_native_message_id)
         self.assertLess(
-            second_native_message_id, f"msg_{next_order:012x}{'0' * 14}"
+            first_native_message_id,
+            f"msg_{first_assistant_order:012x}{'0' * 14}",
+        )
+        self.assertLess(
+            f"msg_{first_assistant_order:012x}{'z' * 14}",
+            second_native_message_id,
+        )
+        self.assertEqual(
+            SERVER_MODULE.native_message_not_before_ms(first_native_message_id),
+            timestamp_ms + 1,
+        )
+        self.assertEqual(
+            SERVER_MODULE.native_message_not_before_ms(second_native_message_id),
+            timestamp_ms + 2,
         )
 
     def test_legacy_random_attempt_identity_is_rejected(self):

--- a/tests/test_opencode_server.py
+++ b/tests/test_opencode_server.py
@@ -501,7 +501,6 @@ class OpenCodeServerTests(unittest.IsolatedAsyncioTestCase):
         )
 
     def test_durable_attempt_maps_to_opencode_part_evidence(self):
-        """MESSAGE-DELIVERY-021: OpenCode owns native message ordering."""
         attempt_id = delivery_store.new_attempt_id()
 
         self.assertRegex(attempt_id, r"^atm_[0-9a-f]{32}$")

--- a/tests/test_opencode_server.py
+++ b/tests/test_opencode_server.py
@@ -493,17 +493,29 @@ class OpenCodeServerTests(unittest.IsolatedAsyncioTestCase):
         )
 
     def test_durable_attempt_maps_between_surrounding_native_messages(self):
+        """MESSAGE-DELIVERY-021: durable attempts preserve native message order."""
         timestamp_ms = 1_775_630_400_000
         with patch.object(delivery_store.time, "time", return_value=timestamp_ms / 1000):
-            attempt_id = delivery_store.new_attempt_id()
+            first_attempt_id = delivery_store.new_attempt_id()
+            second_attempt_id = delivery_store.new_attempt_id()
 
-        native_message_id = SERVER_MODULE.native_message_id_for_attempt(attempt_id)
-        previous_order = ((timestamp_ms - 1) * 0x1000) & ((1 << 48) - 1)
-        next_order = (timestamp_ms * 0x1000 + 1) & ((1 << 48) - 1)
+        first_native_message_id = SERVER_MODULE.native_message_id_for_attempt(
+            first_attempt_id
+        )
+        second_native_message_id = SERVER_MODULE.native_message_id_for_attempt(
+            second_attempt_id
+        )
+        previous_order = ((timestamp_ms - 2) * 0x1000 + 0xFFF) & ((1 << 48) - 1)
+        next_order = (timestamp_ms * 0x1000) & ((1 << 48) - 1)
 
-        self.assertRegex(native_message_id, r"^msg_[0-9a-f]{26}$")
-        self.assertLess(f"msg_{previous_order:012x}{'z' * 14}", native_message_id)
-        self.assertLess(native_message_id, f"msg_{next_order:012x}{'0' * 14}")
+        self.assertRegex(first_native_message_id, r"^msg_[0-9a-f]{26}$")
+        self.assertLess(
+            f"msg_{previous_order:012x}{'z' * 14}", first_native_message_id
+        )
+        self.assertLess(first_native_message_id, second_native_message_id)
+        self.assertLess(
+            second_native_message_id, f"msg_{next_order:012x}{'0' * 14}"
+        )
 
     def test_legacy_random_attempt_identity_is_rejected(self):
         with self.assertRaises(ValueError):


### PR DESCRIPTION
## Summary

- let OpenCode allocate every native message ID at the actual write, preserving its own same-Session chronological order
- map each backend-neutral durable attempt UUID to an exact user text-part ID, so start and steer reconciliation remain crash-safe without influencing native message order
- keep the bounded terminal-message visibility reconciliation when OpenCode reports idle just before its completed assistant row becomes visible
- reject the unreleased ordered-attempt format instead of retaining a compatibility or migration path

## Affected scenarios

- `MESSAGE-DELIVERY-020`: permanent native start rejection still retires only the rejected Delivery
- `MESSAGE-DELIVERY-021`: durable OpenCode attempts preserve native order through exact part evidence

## Evidence

- Unit and contract: prompt payload omits caller-supplied `messageID`, canonical attempt-to-part mapping, exact start/steer recovery, rejection/FIFO settlement, delayed terminal visibility, and backend-neutral attempt allocation
- Scenario: message-delivery catalog and scenario suite, with `MESSAGE-DELIVERY-021` named by its automated test
- Local validation: 1,249 focused tests plus 6 message-delivery scenarios passed for the runtime change; the review follow-up reran 135 OpenCode/steering tests and all 6 message-delivery scenarios; Ruff and `git diff --check` passed
- OpenCode contract: installed regression version `1.18.13` accepts caller-supplied part IDs while generating the message ID itself
- Review-loop circuit breaker: ordering findings appeared on `4880c405`, `b68da8fe`, and `fc5c99df`; `2ff33c3f` removes the shared wall-clock allocator and caller-supplied OpenCode message IDs instead of applying another bucket-level patch
- Exact-head Incus: deployed `9abe86aa11c36ad3c42aff4e0585b51c0aaddc70`, branch `fix/opencode-message-id-ordering`, dirty=false; service, `/health`, `/status`, and Show Runtime passed; existing regression state was preserved
- Real OpenCode E2E: fresh Avibe Session `sespzfjj9h62e`, native Session `ses_029785d12ffec9uTBHIJPMouvN`; Runs `d662aa507a6f` and `28bef04dc53a` succeeded with `OC-PART-9ABE-T1-OK` and `OC-PART-9ABE-T2-OK`
- Native E2E order: OpenCode-generated user `msg_fd687a3ef0014WtqCuBZ8GWq5g` -> assistant `msg_fd687a40e001oN5mY41k68E4y0` -> OpenCode-generated user `msg_fd6888695001CFp4gB0MzRU7eL` -> assistant `msg_fd688869c001ysFnpiiJqAlKYC`; the assistants parent their respective users and the two user text parts carried distinct durable IDs `prt_5dc551661e0d4ac18fc7aebab3dac03a` and `prt_9b4d2c7efd844189a2877139f8544577`

## Scope

- No compatibility layer or state migration is retained because the affected #1134/#1186 development line has not shipped in a release.
