### PR TITLE
fix(dispatcher): stop reporting a user-cancelled turn as done

### DIFF
--- a/core/message_dispatcher.py
+++ b/core/message_dispatcher.py
@@ -39,6 +39,7 @@ from core.run_settlement import (
     SETTLED_BY_STOPPED,
     SETTLED_BY_TERMINAL_RESULT,
     SETTLED_BY_TURN_ONLY_RESULT,
+    SETTLEMENTS_WITHOUT_RESULT,
 )
 from core.session_activities import SessionActivity
 from core.session_turns import emit_matches_active_turn
@@ -1892,7 +1893,17 @@ class ConsolidatedMessageDispatcher:
         # a clean turn is "done" (✅); a failure is "stopped" (⏹) when it was an
         # intentional silent stop (e.g. user stop), else "failed" (⏹). An explicit
         # diagnostic distinguishes a silent backend failure from a silent stop.
-        if not is_error:
+        #
+        # The settlement outranks ``is_error`` here, as it already does on every
+        # other terminal surface. A user Stop is not an error -- nobody's backend
+        # broke -- so it emits with the flag CLEAR, and reading the flag alone put
+        # a green ``✅ done`` on a turn the user called off before it answered.
+        # ``SETTLEMENTS_WITHOUT_RESULT`` is the existing "no terminal result will
+        # ever arrive for this run" set, which is exactly the condition that
+        # forbids the word ``done``; membership is tested rather than naming
+        # ``stopped``, so a future settlement in that set cannot regress to a
+        # green footer by being forgotten here.
+        if not is_error and output_semantics.settled_by not in SETTLEMENTS_WITHOUT_RESULT:
             terminal_reason = "done"
         elif level == "silent" and terminal_error is None:
             terminal_reason = "stopped"

--- a/tests/test_message_dispatcher_result_fallback.py
+++ b/tests/test_message_dispatcher_result_fallback.py
@@ -1103,6 +1103,56 @@ class MessageDispatcherStatusChokepointTests(unittest.IsolatedAsyncioTestCase):
             reason="failed",
         )
 
+    async def test_user_stop_collapses_status_as_stopped(self):
+        """A turn the user called off is not a turn that succeeded.
+
+        The footer word was derived from ``is_error`` alone, and a stop emits with
+        that flag CLEAR -- correctly, nobody's backend broke. So the last thing the
+        user saw after pressing Stop was a green ``✅ done`` on a turn that never
+        answered. The settlement is the fact that contradicts it, exactly as it does
+        on the Turn-outcome and sidebar surfaces.
+        """
+
+        controller = _AvibeStatusController()
+        dispatcher = ConsolidatedMessageDispatcher(controller)
+        dispatcher._collapse_status_bubble = mock.AsyncMock()
+        context = _avibe_ctx()
+        with mock.patch("core.message_dispatcher.persist_agent_message"):
+            await dispatcher.emit_agent_message(
+                context,
+                "result",
+                "",
+                level="silent",
+                output=stop_output_for(None),
+            )
+
+        dispatcher._collapse_status_bubble.assert_awaited_once_with(
+            context,
+            controller.im_client,
+            reason="stopped",
+        )
+
+    async def test_silent_success_still_collapses_as_done(self):
+        """The negative control, on the same call site the stop test asserts.
+
+        A silent turn that simply chose not to speak (a ``<silent>`` reply) carries
+        no settlement and no error, and must keep the green word. Only membership in
+        ``SETTLEMENTS_WITHOUT_RESULT`` takes it away.
+        """
+
+        controller = _AvibeStatusController()
+        dispatcher = ConsolidatedMessageDispatcher(controller)
+        dispatcher._collapse_status_bubble = mock.AsyncMock()
+        context = _avibe_ctx()
+        with mock.patch("core.message_dispatcher.persist_agent_message"):
+            await dispatcher.emit_agent_message(context, "result", "", level="silent")
+
+        dispatcher._collapse_status_bubble.assert_awaited_once_with(
+            context,
+            controller.im_client,
+            reason="done",
+        )
+
     async def test_notify_does_not_settle_dot(self):
         controller = _AvibeStatusController()
         dispatcher = ConsolidatedMessageDispatcher(controller)


### PR DESCRIPTION
## Problem

The terminal status-bubble footer word is derived from `is_error` alone:

```python
if not is_error:
    terminal_reason = "done"
elif level == "silent" and terminal_error is None:
    terminal_reason = "stopped"
else:
    terminal_reason = "failed"
```

A user Stop emits with that flag **clear** — correctly, nobody's backend broke. So the last thing a user sees after pressing Stop is a green `✅ done` on a turn that never answered. All three backends hit it: `handle_stop` in Claude, Codex, and OpenCode emit the same synthetic silent `result`, and `tests/test_agent_stop_settlement.py` exists precisely because that emit is shared by design.

## Fix

Let the settlement outrank the flag here too, as it already does on the durable Turn outcome, the IM silent-terminal trace, and the sidebar projection.

```python
if not is_error and output_semantics.settled_by not in SETTLEMENTS_WITHOUT_RESULT:
    terminal_reason = "done"
```

`SETTLEMENTS_WITHOUT_RESULT` already exists on `master` — it is the "no terminal result will ever arrive for this run" set, which is exactly the condition that forbids the word `done`. No new map. Membership is tested rather than naming `stopped`, so a future settlement added to that set cannot regress to a green footer by being forgotten here.

Nothing else moves: an output carrying no such settlement takes the same branch it always did.

## Tests

- `test_user_stop_collapses_status_as_stopped` — counter-checked by stashing only the production diff: without it the assertion fails with `reason='done'`, which is the bug verbatim.
- `test_silent_success_still_collapses_as_done` — negative control on the same call site: a silent turn that simply chose not to speak keeps the green word.
- Per-backend coverage already exists: the AST guard in `tests/test_agent_stop_settlement.py` requires every `handle_stop` terminal `result` emit to carry `stop_output_for`.

ruff clean; 387 tests pass across the dispatcher, stop-settlement, status-chokepoint, delivery-FSM and failure-visibility suites.

## Notes

`terminal_reason` also feeds `_finalize_status_message` and the orphan path, so a Stop now reads `stopped` on those surfaces too — intended, and the same word the settlement already records.