### PR TITLE
fix(delivery): prevent accepted steering from blocking FIFO

### DIFF
--- a/storage/message_deliveries.py
+++ b/storage/message_deliveries.py
@@ -1327,6 +1327,7 @@ def materialize_steer_acceptance(
             )
         ).scalar_one()
     ) + 1
+    _insert_message(conn, message_id=message_id, snapshot=snapshot, accepted_at=now)
     accepted: list[dict[str, Any]] = []
     for offset, row in enumerate(rows):
         saved = cas_delivery(
@@ -1368,7 +1369,6 @@ def materialize_steer_acceptance(
             .where(show_session_events.c.message_id.is_(None))
             .values(message_id=message_id)
         )
-    _insert_message(conn, message_id=message_id, snapshot=snapshot, accepted_at=now)
     return accepted
 
 

--- a/tests/scenarios/message_delivery/catalog.yaml
+++ b/tests/scenarios/message_delivery/catalog.yaml
@@ -218,5 +218,11 @@ scenarios:
     kind: lifecycle
     layer: contract
     test: tests/test_delivery_ack_reaction.py::AdmissionAckTests::test_start_clears_every_receipt_merged_into_its_turn
+  - id: MESSAGE-DELIVERY-310
+    name: Steer acceptance creates its Message before linking a Show event
+    status: covered
+    kind: regression
+    layer: contract
+    test: tests/test_session_delivery_fsm.py::test_steer_acceptance_materializes_message_before_show_event_link
 next_priority:
-  - MESSAGE-DELIVERY-310
+  - MESSAGE-DELIVERY-311

--- a/tests/test_session_delivery_fsm.py
+++ b/tests/test_session_delivery_fsm.py
@@ -51,6 +51,7 @@ from storage.models import (
     messages,
     metadata,
     session_turns,
+    show_session_events,
 )
 
 
@@ -2145,6 +2146,76 @@ def test_p1_steer_uses_persisted_dispatch_text(managers, monkeypatch) -> None:
             select(messages.c.content_text).where(messages.c.id == delivery_id)
         ).scalar_one()
     assert materialized == "display content"
+
+
+def test_steer_acceptance_materializes_message_before_show_event_link(managers) -> None:
+    """MESSAGE-DELIVERY-310: acceptance satisfies the Show event Message FK."""
+
+    manager, _other, engine, _engine_b, _starts = managers
+    turn_id, _ = asyncio.run(_activate(manager))
+    delivery_id = delivery_store.new_delivery_id()
+    with engine.begin() as conn:
+        delivery_store.insert_delivery(
+            conn,
+            delivery_id=delivery_id,
+            session_id="ses_fsm",
+            priority="p1",
+            state="reserved",
+            snapshot=delivery_store.message_snapshot(
+                scope_id=None,
+                session_id="ses_fsm",
+                platform="avibe",
+                author="user",
+                source="show_annotation",
+                text="accepted annotation",
+            ),
+            dispatch_text="accepted annotation",
+        )
+        conn.execute(
+            show_session_events.insert().values(
+                id="show_evt_steer_acceptance",
+                session_id="ses_fsm",
+                event_type="human.annotation.created",
+                actor="human",
+                scope="page",
+                anchor_json="{}",
+                payload_json="{}",
+                transcript_text="accepted annotation",
+                message_id=None,
+                delivery_id=delivery_id,
+                created_at="2026-08-07T00:00:00+00:00",
+            )
+        )
+
+    manager._active_identity = lambda _b, _s, logical: (logical, f"native-{logical}")
+
+    async def accepted(_backend, _request):
+        return steer_result(SteerOutcome.ACCEPTED)
+
+    manager._steer = accepted
+    result = asyncio.run(
+        manager.deliver(
+            DeliveryRequest(
+                session_id="ses_fsm",
+                priority="p1",
+                content="ignored retry payload",
+                delivery_id=delivery_id,
+            ),
+            context=_context(),
+        )
+    )
+
+    assert result.state == "accepted"
+    assert result.turn_id == turn_id
+    with engine.connect() as conn:
+        assert conn.execute(
+            select(show_session_events.c.message_id).where(
+                show_session_events.c.id == "show_evt_steer_acceptance"
+            )
+        ).scalar_one() == delivery_id
+        assert conn.execute(
+            select(messages.c.id).where(messages.c.id == delivery_id)
+        ).scalar_one() == delivery_id
 
 
 def test_lost_accepted_receipt_materializes_from_exact_restart_evidence(


### PR DESCRIPTION
## Summary

- create the accepted Message before linking dependent Show events during P1 steering settlement
- keep the Message, Delivery batch, and Show-event links in one atomic transaction
- cover the production-shaped immediate foreign-key path as `MESSAGE-DELIVERY-310`

## Root cause

`materialize_steer_acceptance` updated `show_session_events.message_id` before inserting the referenced `messages` row. SQLite enforced the immediate Message foreign key, rolled back the accepted receipt, and recovery persisted the Delivery as `reconciling_steer`. That ordering fence then blocked every later FIFO submission even while the Session was idle.

## Scenario coverage

- `MESSAGE-DELIVERY-310`: Steer acceptance creates its Message before linking a Show event

## Evidence

- Unit: `tests/test_session_delivery_fsm.py` passed, 127 tests
- Contract: production-shaped Show event FK regression, lost-receipt recovery, unknown-receipt fence, and FIFO coverage passed
- Scenario: message-delivery catalog updated and validated through a structured YAML parser
- Static: Ruff and `git diff --check` passed

## Residual manual checks

- No host Avibe service restart or live database mutation was performed.
- Existing Deliveries already stranded by the old write order require an evidence-preserving operational repair after this code path is available; this PR prevents new occurrences and does not guess or resend ambiguous native input.
