### PR TITLE
docs: record harness Run invariants in AGENTS.md, archive the plan

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,6 +75,11 @@ Invariants every change must preserve:
    Run in the same session must not keep stuck work alive.
 7. **No turn-duration timeout.** A healthy turn may run for hours. Bounds may
    apply to inactivity and post-turn delivery, never to productive execution.
+   Known exception, not yet resolved: `OpenCodePollLoop` fixes a deadline from
+   `active_turn_timeout_seconds` (default 90 min) at turn start and
+   `_settle_active_turn_timeout` aborts the native session when it expires,
+   regardless of progress. Treat that as a defect to remove, not as precedent —
+   do not add a second one, and do not assume OpenCode already allows long turns.
 8. **Failures remain visible.** Reconcile paths must use #1072's durable notice
    path; a terminal row alone is not the exit criterion.
 9. **One output batch has one receipt.** Preserve #1139's stable receipt,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,62 @@ Decision checklist before writing code:
 3. **Call path**: is the code called from controller/handlers/common flow?
 4. **Future-proofing**: would a new platform/backend inherit the correct behavior automatically?
 
+### Harness Run Ownership (load-bearing)
+
+Read this before touching any Run, Delivery, Turn, or Activity path. These rules
+were paid for by #1063, #1064, #1072, #1134, #1139, #1140, #1155, and #1173; the
+full derivation lives in `docs/plans/harness-run-reliability.md`.
+
+Durable owners — one per phase, no side maps and no parallel output ledger:
+
+| Owner | Owns |
+|---|---|
+| `message_deliveries` | submitted input, FIFO position, acceptance, attempts, receipts, retirement |
+| `session_turns` | native execution and terminal Turn evidence |
+| `messages` | accepted communication history — **not** a queue |
+| durable Activity snapshots | pending output payload, ordered batch membership, the linked Run union, the stable output receipt identity |
+| `agent_runs` | the Harness projection and the callback/notice anchor |
+
+Invariants every change must preserve:
+
+1. **One durable owner per phase.** Delivery owns input before native
+   acceptance; Turn owns accepted execution; the Activity batch owns pending
+   terminal output; Run reflects the outcome.
+2. **No silent replay after execution starts.** Infrastructure interruption is
+   `failed` with a structured cause and an actionable notice. User Stop is
+   `canceled` and does not generate an infrastructure-failure notice.
+3. **Unstarted work remains retryable.** A bare claim or queued Delivery must not
+   be mislabeled as an interrupted execution.
+4. **Terminal writes are guarded.** A natural terminal result, user Stop, and
+   infrastructure teardown may race; the exact compare-and-set winner controls
+   projections and notices.
+5. **Absence of a receipt is not proof of non-delivery.** Any timeout around an
+   outbound send must use durable delivery evidence before retrying.
+6. **Waiting is not activity.** A real inbound message may establish a session
+   baseline, and every exact Turn start establishes a fresh one even when the
+   work came from a long-idle scheduled/watch queue; after that only observable
+   assistant/tool progress refreshes it. Run inactivity is stricter and re-arms
+   only from its exact owning Turn. A claim, queue wait, gate wait, or unrelated
+   Run in the same session must not keep stuck work alive.
+7. **No turn-duration timeout.** A healthy turn may run for hours. Bounds may
+   apply to inactivity and post-turn delivery, never to productive execution.
+8. **Failures remain visible.** Reconcile paths must use #1072's durable notice
+   path; a terminal row alone is not the exit criterion.
+9. **One output batch has one receipt.** Preserve #1139's stable receipt,
+   persisted ordered Activity membership, complete linked Run union, and
+   transport-free local-settlement retry. Incomplete or conflicting recovered
+   membership fails closed; it never emits a partial batch or invents a second
+   receipt.
+
+Two consequences that are easy to get wrong:
+
+- A batch reconcile path is still bound by rule 2. Sweeping accumulated Runs to
+  `failed` without a structured cause and a user-visible notice violates it even
+  though the terminal row itself looks correct.
+- Do not add a generic inactivity timeout unless every backend and lane can
+  attribute observable progress to the exact Turn. Session-wide activity is
+  never an acceptable substitute (rule 6).
+
 ### Codebase Map
 
 - `main.py` - entry point wiring `config.V2Config` into `core/controller.py`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,9 +85,12 @@ Invariants every change must preserve:
 
 Two consequences that are easy to get wrong:
 
-- A batch reconcile path is still bound by rule 2. Sweeping accumulated Runs to
-  `failed` without a structured cause and a user-visible notice violates it even
-  though the terminal row itself looks correct.
+- A batch reconcile path is still bound by rule 2, and sending the notice is
+  only half of it. A sweep that settles Runs to `failed` and dispatches a notice
+  carrying no `interrupt_reason` and no `error` still violates the rule: the
+  terminal row looks correct and the notice was delivered, but nothing tells the
+  user what happened. Supply the cause to the notice writer, not just the
+  terminal status.
 - Do not add a generic inactivity timeout unless every backend and lane can
   attribute observable progress to the exact Turn. Session-wide activity is
   never an acceptable substitute (rule 6).

--- a/docs/plans/harness-run-reliability.md
+++ b/docs/plans/harness-run-reliability.md
@@ -41,7 +41,9 @@ numbers or old ownership assumptions.
 | Activity output batch receipt and local settlement | **#1139 merged**; supersedes #1121 |
 | Idle-eviction interlock for queued work | **#1155 merged** (PR3); scenarios `HFR-130…154` |
 | Bounded and supervised shared drains | **#1173 merged** (PR4); scenarios `HFR-155…179`; PR4B unopened — its crash-matrix gate was never run |
-| Scheduled/watch terminal-time truth and cron liveness | **Closed 2026-08-07 — not reproduced.** See §7 |
+| Cron liveness | **Closed 2026-08-07 — not reproduced.** See §7 |
+| Terminal-time truth, Turn-bound Runs | **Closed 2026-08-07 — disproven.** See §7 |
+| Terminal-order truth, non-Turn Runs (`watch`, `scheduled`, command) | **Open.** No durable second row exists to check settlement against; carried as a residual in §7 |
 
 The post-plan architecture is load-bearing (now also recorded in `AGENTS.md`):
 
@@ -1242,10 +1244,18 @@ the same invariant.
   therefore measured too — `completed_at - created_at` over every settled Run:
 
   ```text
-  succeeded  n=1482  avg 12.2 min  max 1035.0 min   29 over 2h
+  succeeded  n=1484  avg 12.2 min  max 1035.0 min   29 over 2h
   failed     n=  52  avg 21.4 min  max  150.9 min    1 over 2h
   canceled   n=  19  avg 15.0 min  max   65.7 min    0 over 2h
   ```
+
+  Snapshot 2026-08-07T08:21Z, so the totals differ from the 07:57Z block above
+  by 24 minutes of growth: `succeeded` 1489 of which 1484 carry a
+  `completed_at`, `failed` 52 of 52, `canceled` 19 of 19, 1 live. The five
+  successes without a `completed_at` are the same five noted under the coverage
+  limit below; they are excluded from the durations because there is nothing to
+  subtract, which is exactly why the timed count is five short of the status
+  count at any instant.
 
   Thirty Runs did exceed two hours, and every one is accounted for. 29 are
   `watch_runtime` Runs — a waiter that blocks for nine hours is doing its job,
@@ -1286,6 +1296,23 @@ still in flight (run running, turn active)  1
 total                                    387
 Runs terminal while their Turn was not     0
 ```
+
+Ordering is only half the claim: a Run marked `succeeded` after its Turn
+*failed* would sit in these buckets and satisfy every predicate above. So the
+two statuses were cross-tabulated directly:
+
+```text
+run.status   x  session_turns.terminal_outcome      n
+succeeded    x  completed                         355
+failed       x  failed                             23
+canceled     x  canceled                           12
+running      x  (null, still active)                1
+                                                 ----
+off-diagonal                                        0
+```
+
+A perfect diagonal, all-time: no Run has ever carried a status its Turn did not
+produce. That is the semantic half; the buckets below are the ordering half.
 
 The buckets are exhaustive over the join — they sum to the full 387, with the
 one live row named rather than filtered away. The last line is checked against
@@ -1346,12 +1373,12 @@ Watch-Run duration for context: `succeeded` averages 2.0 min (n=840),
 `failed_with_cause` 7.4 min (n=18), `failed_blank` 58.3 min with a 150.9 min max
 (n=18).
 
-**The user was told.** All 18 carry `metadata.owed_failure_notice` with
-`state = "sent"`, `attempts = 1`, and `ack_evidence = "receipt"`. Empty
+**The user was mostly told.** 14 of the 18 carry
+`metadata.owed_failure_notice` with `state = "sent"`, `attempts = 1`, and
+`ack_evidence = "receipt"`; the remaining 4 carry `state = "skipped"`. Empty
 `message_ids_json` and null `callback_status` prove nothing here: the
 failure-notice lane does not populate `message_ids_json`, and a null callback
-status can simply mean no callback was owed. Invariant 8 is satisfied and any
-fix must not re-notify these Runs.
+status can simply mean no callback was owed. Any fix must not re-notify the 14.
 
 What the notice carried is the defect. Every one of those 18 stamps
 `"interrupt_reason": null, "error": null` — a notice went out with no cause in
@@ -1361,13 +1388,38 @@ control group: same shape, but it recorded
 `backend_runtime_exited_before_terminal`. Two settlement paths exist and only
 one supplies a reason to the notice writer.
 
-**This is an ordinary bug, tracked outside this plan.** It needs no evidence
-gate, no contract amendment, and no new owner — invariant 2 already specifies
-the required behavior, and the notice lane already works. The fix is to hand the
-sweep's reason to the notice writer instead of stamping `null`; it must not
-re-notify Runs whose `owed_failure_notice.state` is already `sent`. The
-58-minute hold before the sweep is the root cause behind that and is worth a
-separate look; supplying the cause is triage.
+**The writer is unidentified, and that is the first step — not "pass the
+reason".** An earlier revision of this section prescribed handing the sweep's
+reason to the notice writer. That prescription was wrong: the two obvious
+candidates on `master` already do it, and neither can have written these rows.
+
+- `SQLiteBackgroundTaskStore.sweep_stale_runs` settles through
+  `settle_run_terminal` with both `error=error_texts.get(reason)` and
+  `metadata={"interrupt_reason": reason}`. It also excludes `watch_runtime`
+  outright and restricts its `running` class to `run_type == "agent_run"`.
+- `recover_processing_runs` writes `error` and `interrupt_reason` atomically,
+  and requires `delivery_id IS NULL`.
+- All three `settle_without_result` call sites pass an `interrupt_reason` or a
+  delivery outcome.
+
+Every one of the 18 rows is `run_type = "watch"`, `source_kind = "watch"`,
+`delivery_id` **set**, `pid` set, and carries no `interrupt_reason`,
+`failure_code`, or `ok` anywhere in `metadata_json` — not merely a null inside
+the notice. Each named writer's own predicate excludes that shape, so none of
+them produced these rows.
+
+Timing narrows it further, and may close it: the 18 settle on 2026-08-04 (12)
+and 2026-08-05 (6) — the exact days PR3 (#1155) and PR4 (#1173) merged and
+replaced this machinery. These rows are plausibly artifacts of the writer those
+PRs removed.
+
+**So the follow-up is an ordinary bug whose first task is identification, not a
+fix.** Determine whether any path on current `master` can still settle a
+Turn-bound `watch` Run to `failed` with no cause in `metadata_json`. If none
+can, close it as already fixed and record that. If one can, then invariant 2
+already specifies the behavior and the fix is to supply the cause — without
+re-notifying the 14 rows whose notice is already `sent`. The 58-minute hold
+before the sweep is worth a separate look either way.
 
 ### Why PR7R was dropped
 

--- a/docs/plans/harness-run-reliability.md
+++ b/docs/plans/harness-run-reliability.md
@@ -1208,38 +1208,77 @@ Thirty days of production Runs, plus an all-time check for stuck rows:
   text because a command task is silent on success; the remainder are `<silent>`
   agent replies.
 
-The old premature-success claim is therefore **disproven**, not merely unproven:
-Runs stay nonterminal too long, never too short. Per this plan's own rule, a
-disproven claim closes without code.
+Absence of stuck rows alone does not settle premature success — a Run marked
+`succeeded` before its Turn finished would also be sitting in that terminal set.
+So the settlement order was compared directly, joining `agent_runs` →
+`message_deliveries` → `session_turns` and measuring
+`agent_runs.completed_at - session_turns.terminal_at`:
+
+```text
+run settles <50ms before its Turn       84
+run settles 50-1000ms before             1
+run settles 1-60s before                 1     (worst case -1.05s)
+run settles >1s after                    9
+Turn still non-terminal when Run settled 0
+```
+
+Every one of those Turns carries `terminal_evidence_kind = terminal_result`, so
+the Turn had a real natural completion in hand. The worst case is 1.05 s of
+write ordering inside one settlement sequence, not a Run claiming success ahead
+of its execution.
+
+Coverage limit, stated plainly: 104 of 1373 Runs in the window link all the way
+through to a `session_turns` row (387 bind a Delivery at all; `watch_runtime`
+Runs are waiter commands with no agent Turn and never do). The check is
+therefore exact for Turn-bound Runs and silent about the rest.
+
+On that evidence the old premature-success claim is **disproven** for Turn-bound
+Runs rather than merely unproven — they settle late, not early. Per this plan's
+own rule, a disproven claim closes without code.
 
 ### What the same data did find
 
 18 `failed` Runs in thirty days carry no cause at all — empty `error`, `stderr`,
-`exit_code`, and `result_text`; empty `message_ids_json`, so the user was never
-told; null `callback_status`. `delivery_id` is set, so a Delivery was reserved
-and then silently abandoned. They arrive in batch sweeps:
+`exit_code`, and `result_text`. They arrive in batch sweeps, 17 in three
+multi-Run sweeps plus one settled alone:
 
 ```text
 settled_at            n   blank_cause   oldest_created      held
 2026-08-04T12:36:56   7      7/7        08-04T10:05:59     151 min
 2026-08-05T04:29:03   6      6/6        08-05T03:07:04      82 min
 2026-08-04T12:30:16   4      4/4        08-04T11:31:32      59 min
+2026-08-04T06:43:44   1      1/1        —                    —
 2026-08-04T05:59:30   3      0/3        08-04T05:52:06       7 min
+                     ──
+        blank total  18
 ```
 
 Watch-Run duration for context: `succeeded` averages 2.0 min (n=840),
 `failed_with_cause` 7.4 min (n=18), `failed_blank` 58.3 min with a 150.9 min max
 (n=18).
 
-This violates invariant 2 — infrastructure interruption owes a structured cause
-and an actionable notice. The last sweep is the control group: it wrote
+**The user was told.** All 18 carry `metadata.owed_failure_notice` with
+`state = "sent"`, `attempts = 1`, and `ack_evidence = "receipt"`. Empty
+`message_ids_json` and null `callback_status` prove nothing here: the
+failure-notice lane does not populate `message_ids_json`, and a null callback
+status can simply mean no callback was owed. Invariant 8 is satisfied and any
+fix must not re-notify these Runs.
+
+What the notice carried is the defect. Every one of those 18 stamps
+`"interrupt_reason": null, "error": null` — a notice went out with no cause in
+it. Invariant 2 owes *a structured cause and* an actionable notice; the notice
+half held and the cause half did not. The `2026-08-04T05:59:30` sweep is the
+control group: same shape, but it recorded
 `backend_runtime_exited_before_terminal`. Two settlement paths exist and only
-one records a cause.
+one supplies a reason to the notice writer.
 
 **This is an ordinary bug, tracked outside this plan.** It needs no evidence
 gate, no contract amendment, and no new owner — invariant 2 already specifies
-the required behavior. The 58-minute hold before the sweep is the root cause and
-is worth a separate look; writing a cause is triage.
+the required behavior, and the notice lane already works. The fix is to hand the
+sweep's reason to the notice writer instead of stamping `null`; it must not
+re-notify Runs whose `owed_failure_notice.state` is already `sent`. The
+58-minute hold before the sweep is the root cause behind that and is worth a
+separate look; supplying the cause is triage.
 
 ### Why PR7R was dropped
 

--- a/docs/plans/harness-run-reliability.md
+++ b/docs/plans/harness-run-reliability.md
@@ -1218,10 +1218,22 @@ matrix, and the answer closes both claims.
 
 ### What was checked
 
-Thirty days of production Runs, plus an all-time check for stuck rows:
+Thirty days of production Runs, plus an all-time check for stuck rows. These are
+counts of live tables, taken while the system was serving traffic, so each block
+below carries its own timestamp and the totals do not agree across blocks by
+design — `agent_runs` grew by four rows during this investigation. The
+invariants are the claim; the counts are only what supported them at that
+instant. Re-running any of these later will give larger totals and should give
+the same invariant.
 
-- **No Run has ever been left nonterminal.** All 1553 rows are `succeeded`,
-  `failed`, or `canceled`. Zero rows sit nonterminal past two hours, all-time.
+- **No Run has ever been left nonterminal.** Snapshot 2026-08-07T07:57Z: 1557
+  rows — `succeeded` 1485, `failed` 52, `canceled` 19, and 1 `running` created
+  36 s earlier and still executing. A live row is expected and is not a
+  counterexample, which is why the claim is not "every row is terminal". The
+  time-independent form, and the one to re-check, is `select count(*) from
+  agent_runs where status not in ('succeeded','failed','canceled') and
+  julianday('now')-julianday(created_at) > 0.0833` → **0**, all-time. No Run has
+  ever aged past two hours without reaching a terminal status.
 - **No cron occurrence has been missed.** A single recent fire per definition
   would only prove the scheduler is alive today, so every expected occurrence was
   enumerated from each definition's own `created_at` and stored `timezone` and
@@ -1243,6 +1255,7 @@ So the settlement order was compared directly, joining `agent_runs` →
 `agent_runs.completed_at - session_turns.terminal_at`:
 
 ```text
+snapshot 2026-08-07T07:53Z
 run terminal 1-60s before its Turn        12     (worst case -1.054s)
 run terminal 50ms-1s before              211
 run terminal <50ms before                139
@@ -1261,11 +1274,12 @@ a real completion (`terminal_result` 382, `runner_release` 3, `service_shutdown`
 1). The worst case is 1.054 s of write ordering inside one settlement sequence,
 not a Run claiming success ahead of its execution.
 
-Coverage limit, stated plainly: 387 of 1553 Runs link all the way through to a
-`session_turns` row, which is every Run that binds a Delivery but one currently
-open. `watch_runtime` Runs are waiter commands with no agent Turn and never
-bind one. The check is therefore exact for Turn-bound Runs and silent about the
-rest.
+Coverage limit, stated plainly: at the settlement snapshot, 387 Runs linked all
+the way through to a `session_turns` row — every Run that bound a Delivery.
+`watch_runtime` Runs are waiter commands with no agent Turn and never bind one.
+The `still in flight` line is the same live Run the status block reports; four
+minutes later the join returned 389, which is the growth, not a discrepancy. The
+check is therefore exact for Turn-bound Runs and silent about the rest.
 
 On that evidence the old premature-success claim is **disproven** for Turn-bound
 Runs rather than merely unproven — they settle late, not early. Per this plan's

--- a/docs/plans/harness-run-reliability.md
+++ b/docs/plans/harness-run-reliability.md
@@ -3,9 +3,12 @@
 Status (2026-08-07): **ARCHIVED — complete through PR4.** PR1, PR2, PR5, PR6,
 #1139's Activity-output settlement closure, PR3 (#1155), and PR4 (#1173) all
 merged. PR7/PR7R is dropped and #1212 is closed; see §7. No further unit opens
-from this plan. PR4B stays unopened: it was always gated on a reproducer, and
-nothing has requested it — but that is not the same as disproven, because the
-crash matrix it was gated on was never run. See the delta note in §6.
+from this plan **except PR4B**, which stays conditional rather than closed: it
+was always gated on a reproducer and nothing has requested it, but that is not
+the same as disproven, because the crash matrix it was gated on was never run.
+The gate in §6 still stands and still requires its contract review if the matrix
+reproduces something or the symptom appears in the field. Everything else —
+PR7/PR7R included — is closed.
 
 **The Run/Delivery/Turn/Activity ownership rules and invariants now live in
 `AGENTS.md` §2 "Harness Run Ownership (load-bearing)".** Read those there before
@@ -1232,8 +1235,26 @@ the same invariant.
   counterexample, which is why the claim is not "every row is terminal". The
   time-independent form, and the one to re-check, is `select count(*) from
   agent_runs where status not in ('succeeded','failed','canceled') and
-  julianday('now')-julianday(created_at) > 0.0833` → **0**, all-time. No Run has
-  ever aged past two hours without reaching a terminal status.
+  julianday('now')-julianday(created_at) > 0.0833` → **0**, all-time.
+
+  That query only sees Runs nonterminal *now*, so on its own it cannot rule out a
+  Run that sat nonterminal for hours and then settled. Terminal lifetimes were
+  therefore measured too — `completed_at - created_at` over every settled Run:
+
+  ```text
+  succeeded  n=1482  avg 12.2 min  max 1035.0 min   29 over 2h
+  failed     n=  52  avg 21.4 min  max  150.9 min    1 over 2h
+  canceled   n=  19  avg 15.0 min  max   65.7 min    0 over 2h
+  ```
+
+  Thirty Runs did exceed two hours, and every one is accounted for. 29 are
+  `watch_runtime` Runs — a waiter that blocks for nine hours is doing its job,
+  not stuck, and each has `started_at == created_at` with execution filling the
+  whole lifetime. The 30th is the 150.9-minute `failed` Run below, which is the
+  blank-cause sweep this section reports as a real defect. So the claim is not
+  "no Run ran long" — long Runs are expected under invariant 7. It is that no
+  Run was ever *stranded*: every long lifetime is either a waiter waiting or the
+  one already-recorded defect.
 - **No cron occurrence has been missed.** A single recent fire per definition
   would only prove the scheduler is alive today, so every expected occurrence was
   enumerated from each definition's own `created_at` and stored `timezone` and
@@ -1284,6 +1305,25 @@ check is therefore exact for Turn-bound Runs and silent about the rest.
 On that evidence the old premature-success claim is **disproven** for Turn-bound
 Runs rather than merely unproven — they settle late, not early. Per this plan's
 own rule, a disproven claim closes without code.
+
+Scope of that closure, stated so it is not read wider than it is: it covers
+Turn-bound Runs only. The other 1168 terminal Runs — `watch`, `watch_runtime`,
+`scheduled`, and background `agent_run` — bind no Delivery and therefore no
+Turn, so there is no second durable row to compare their settlement against.
+`exit_code` cannot substitute: it is populated on 6 of those 1168. Their
+timestamps are unremarkable (16 rows have an absent or inverted `started_at` /
+`completed_at` pair; 7 are watch Runs settled in the same second they were
+created without ever starting, 5 are successes with no `completed_at`, and 4 are
+`agent_run` cancellations of unstarted work, which invariant 3 permits), but
+"unremarkable" is not ordering evidence.
+
+**Residual, carried past this plan:** command and watch execution paths have no
+durable record proving the Run settled only after the owning process reached its
+outcome. Nothing observed suggests they do not — but nothing here proves they
+do, and classifying their empty `result_text` as intentional (below) says
+something about output, not about ordering. Anyone adding a durable terminal
+marker to those paths closes this; until then invariant 1 is enforced by review
+rather than by evidence for non-Turn Runs.
 
 ### What the same data did find
 

--- a/docs/plans/harness-run-reliability.md
+++ b/docs/plans/harness-run-reliability.md
@@ -1,10 +1,15 @@
 # Harness Run Reliability
 
-Status (2026-08-06): **Every implementation unit through PR4 is merged. PR1,
-PR2, PR5, PR6, #1139's Activity-output settlement closure, PR3 (#1155), and
-PR4 (#1173) are complete. Only PR7R remains as the next unit, and it is
-evidence-only. PR4's conditional transport-attempt delta (PR4B) opens only if a
-current-master reproducer proves a missing durable fact.**
+Status (2026-08-07): **ARCHIVED — complete through PR4.** PR1, PR2, PR5, PR6,
+#1139's Activity-output settlement closure, PR3 (#1155), and PR4 (#1173) all
+merged. PR7/PR7R is dropped and #1212 is closed; see §7. No further unit opens
+from this plan. PR4B is likewise dropped — it was gated on a current-master
+reproducer that thirty days of production data did not produce.
+
+**The still-binding rules now live in `AGENTS.md` §2 "Harness Run Ownership
+(load-bearing)".** Read that, not this file, before changing a Run, Delivery,
+Turn, or Activity path. This document is retained as the derivation and the
+historical record.
 
 This is the execution plan, not the investigation log. The original detailed
 diagnosis and its review history remain available in Git before `fe821905`.
@@ -22,10 +27,10 @@ numbers or old ownership assumptions.
 | Teardown-interrupted Run settlement | **#1140 merged**; supersedes closed #1131 |
 | Activity output batch receipt and local settlement | **#1139 merged**; supersedes #1121 |
 | Idle-eviction interlock for queued work | **#1155 merged** (PR3); scenarios `HFR-130…154` |
-| Bounded and supervised shared drains | **#1173 merged** (PR4); scenarios `HFR-155…179`; attempt-state delta (PR4B) still requires a current-master reproducer |
-| Scheduled/watch terminal-time truth and cron liveness | **Open — PR7R**, evidence-only; `HFR-180…219` reserved and unoccupied as of 2026-08-06 |
+| Bounded and supervised shared drains | **#1173 merged** (PR4); scenarios `HFR-155…179`; PR4B dropped — no reproducer surfaced |
+| Scheduled/watch terminal-time truth and cron liveness | **Closed 2026-08-07 — not reproduced.** See §7 |
 
-The post-plan architecture is load-bearing:
+The post-plan architecture is load-bearing (now also recorded in `AGENTS.md`):
 
 - `message_deliveries` owns submitted input, FIFO position, acceptance,
   attempts, receipts, and retirement.
@@ -654,10 +659,16 @@ CAS remains the only owner for teardown settlement.
 
 ## 4. Required pre-code baseline
 
-Before each remaining PR, write or run a current-master reproducer. Classify the
-old defect as `reproduces`, `fixed by #1134/#1139/#1140`, or `superseded by a
-new owner`. Do not preserve an old prescription merely because the symptom still
-has the same name.
+Historical, and worth keeping for the next plan of this kind. Before each PR,
+write or run a current-master reproducer, and classify the old defect as
+`reproduces`, `fixed by #1134/#1139/#1140`, or `superseded by a new owner`. Do
+not preserve an old prescription merely because the symptom still has the same
+name.
+
+Add a fourth outcome that this plan lacked and needed: **`no evidence of a
+problem`**. Without it, a plan whose root causes are already fixed cannot admit
+that nothing remains, and keeps generating units to prove its own completion
+(§7).
 
 Minimum baseline cases:
 
@@ -681,10 +692,10 @@ Minimum baseline cases:
 
 ## 5. PR3 — Session runtime ownership and activation
 
-**Merged as #1155 (2026-08-04).** Retained as the accepted contract: PR7R and
-any later implementation unit must consume the runtime ownership snapshot,
-activation interlock, and work-supervisor interfaces defined here rather than
-reintroducing side maps or adapter-local reclamation rules.
+**Merged as #1155 (2026-08-04).** Retained as the accepted contract: any later
+work must consume the runtime ownership snapshot, activation interlock, and
+work-supervisor interfaces defined here rather than reintroducing side maps or
+adapter-local reclamation rules.
 
 ### Goal
 
@@ -1046,6 +1057,10 @@ matrix against #1139. If the accepted Message, stable Activity receipt, and
 local-settlement-only marker already close the reproduced window, record that
 evidence and add no state.
 
+Superseded 2026-08-07: PR4B is dropped and this plan is archived. The paragraph
+below states the bar a future PR4B-shaped change would have had to clear; it no
+longer authorizes one.
+
 Only a remaining concrete ambiguity may open a separate PR4B contract review.
 That review must name the missing fact, prove the existing Activity owner cannot
 express it, and keep any attempt metadata inside the existing Activity aggregate
@@ -1172,97 +1187,91 @@ lane cannot block another lane or the controller event loop, lifecycle teardown
 leaves no old-generation worker, and Activity/Delivery/Turn/Run ownership is
 unchanged.
 
-## 7. PR7 — Evidence gate before any new timeout model
+## 7. PR7 — Dropped; claims closed by production evidence
 
-**Open. This is the next unit of work.** PR3 and PR4 removed the serial-drain
-and reclamation causes; whether any terminal-truth or scheduler-liveness defect
-survives them is now an open question that only evidence may answer.
+**Closed 2026-08-07. Not reproduced.** PR3 and PR4 removed the serial-drain and
+reclamation causes. Whether any terminal-truth or scheduler-liveness defect
+survived them was the last open question in this plan. It has now been answered
+against live `agent_runs` / `run_definitions` state rather than by an offline
+matrix, and the answer closes both claims.
 
-Do **not** implement the old PR7 prescription. #1134 added
-`complete_on_return`, durable Delivery ownership, immutable Turn terminal
-evidence, and restart recovery; #1139 added exact Activity output batch receipts,
-Run-union settlement, anti-redelivery evidence, and transport-free local
-settlement retry; #1140 closed teardown-interrupted Run settlement. The previous
-plan guessed at the remaining timeout model before proving which gaps still
-exist. PR7 starts with evidence, not a schema or writer.
+### What was checked
 
-### PR7R — Current-master evidence
+Thirty days of production Runs, plus an all-time check for stuck rows:
 
-PR7R changes tests and the plan only. It must publish one executable matrix for:
+- **No Run has ever been left nonterminal.** All 1551 rows are `succeeded`,
+  `failed`, or `canceled`. Zero rows sit nonterminal past two hours, all-time.
+- **Cron liveness is healthy.** All three enabled cron definitions fired on
+  schedule: `7 9 * * *` at 08-07T01:10Z, `0 11 * * *` at 08-07T03:00Z, and
+  `30 9 * * wed` at 08-05T03:39Z. No silent scheduler death.
+- **Result-less successes are by design.** 6/6 command tasks return no result
+  text because a command task is silent on success; the remainder are `<silent>`
+  agent replies.
 
-- Claude, Codex, and OpenCode;
-- direct IM and durable Workbench execution lanes;
-- scheduler cron fires, one-shot `at` fires, manual CLI/API task runs, and watch
-  Runs;
-- success, failure, result-less termination, user Stop, terminal persistence
-  failure, pending output delivery, and post-delivery local settlement failure.
+The old premature-success claim is therefore **disproven**, not merely unproven:
+Runs stay nonterminal too long, never too short. Per this plan's own rule, a
+disproven claim closes without code.
 
-For every cell, trace the exact durable facts from Run enqueue through request /
-Delivery reservation, Turn start, terminal-result latch, Turn terminal evidence,
-Activity output batch, accepted Message receipt, Run settlement, and definition
-health projection. The matrix must answer these questions with a consuming test,
-not prose inference:
+### What the same data did find
 
-1. Does the Run remain nonterminal until its actual terminal Turn/result or
-   Activity output batch settles it? If yes, close the old premature-success
-   claim with regression evidence instead of adding another writer.
-2. Which observable assistant/tool events can be attributed to the exact Turn
-   and participating Runs? Prove this separately for every backend and both
-   lanes. A backend/lane without an exact signal blocks a generic inactivity
-   timeout; session-wide activity is never an acceptable substitute.
-3. Can scheduler and manual Runs with different source semantics or effective
-   deadlines enter the same Turn? Record the current merge key and every Run in
-   the batch. Cancellation is Turn-level, so no per-Run policy may be specified
-   until this cardinality is explicit.
-4. Which evidence exists before the Turn becomes terminal? A terminal-result
-   latch, durable pending-output fact, accepted Message, or Activity
-   local-settlement-only marker proves that natural completion has started and
-   must outrank a later inactivity decision.
-5. Are `health`, `consecutive_failures`, `recent_failures`, `last_run_at`, and
-   `last_error` already monotonic projections of bounded terminal Run history?
-   Dispatch or Delivery acceptance is never task success.
+18 `failed` Runs in thirty days carry no cause at all — empty `error`, `stderr`,
+`exit_code`, and `result_text`; empty `message_ids_json`, so the user was never
+told; null `callback_status`. `delivery_id` is set, so a Delivery was reserved
+and then silently abandoned. They arrive in batch sweeps:
 
-Exit criterion: the checked-in matrix and tests identify each remaining defect
-and its current owner. PR7R adds no status, timeout field, terminal writer,
-health cursor, or cancellation path.
+```text
+settled_at            n   blank_cause   oldest_created      held
+2026-08-04T12:36:56   7      7/7        08-04T10:05:59     151 min
+2026-08-05T04:29:03   6      6/6        08-05T03:07:04      82 min
+2026-08-04T12:30:16   4      4/4        08-04T11:31:32      59 min
+2026-08-04T05:59:30   3      0/3        08-04T05:52:06       7 min
+```
 
-### After PR7R — close the claim or review the contract
+Watch-Run duration for context: `succeeded` averages 2.0 min (n=840),
+`failed_with_cause` 7.4 min (n=18), `failed_blank` 58.3 min with a 150.9 min max
+(n=18).
 
-PR7R does not authorize implementation. If its executable evidence disproves an
-old claim, close that claim without adding code. For every reproduced defect,
-amend this plan in a separate documentation-only review before opening an
-implementation PR. Do not reserve PR7A / PR7B as implementation units until that
-contract review passes.
+This violates invariant 2 — infrastructure interruption owes a structured cause
+and an actionable notice. The last sweep is the control group: it wrote
+`backend_runtime_exited_before_terminal`. Two settlement paths exist and only
+one records a cause.
 
-The amendment must define one complete model, not another list of local patches:
+**This is an ordinary bug, tracked outside this plan.** It needs no evidence
+gate, no contract amendment, and no new owner — invariant 2 already specifies
+the required behavior. The 58-minute hold before the sweep is the root cause and
+is worth a separate look; writing a cause is triage.
 
-1. Name the durable owner and guarded terminal transition at every phase,
-   including a bare Run before Delivery reservation, each nonterminal Delivery
-   role, a starting or active Turn, terminal-result and pending-output evidence,
-   Activity receipt, and post-delivery local settlement. It must define
-   request/coalescing cleanup and the durable user notice for every terminal
-   cause.
-2. State whether exact-Turn progress must survive restart. If it must, define the
-   persisted owner, timestamp/update CAS, recovery read, and restart-after-progress
-   evidence. If no backend-independent durable signal exists for every backend
-   and lane, do not implement a generic inactivity timeout.
-3. Define one policy owner for coalesced Runs. Either prove all participants have
-   the same snapshotted policy or keep incompatible Runs in separate Turns.
-   Specify natural completion, user Stop, and timeout precedence before adding a
-   timeout writer.
-4. If the model includes a user-configurable task inactivity override, specify
-   its V2 config key, concrete default, normalization, persistence, CLI/API/Web
-   inputs, English and Chinese documentation, and unchanged watch semantics. If
-   those supported surfaces are not part of the implementation, remove the
-   override from the model rather than supporting it only through fixtures.
-5. Reuse the exact Run, Delivery, Turn, Message, and Activity owners already on
-   `master`. Any new state, schema, terminal writer, retry, or replay rule needs
-   evidence that those owners cannot express the reproduced behavior.
+### Why PR7R was dropped
 
-Terminal-truth and scheduler-liveness defects remain separate implementation
-reviews even when PR7R reproduces both. Each implementation PR starts with red
-tests for the approved contract and must not infer missing policy from this
-evidence plan.
+PR7R (#1212, closed) tried to answer these questions by enumerating a
+3 × 2 × 4 × 7 backend/lane/trigger/outcome product and demanding one end-to-end
+probe per cell. It shipped 168 cells all marked `unproven` and reproduced
+nothing. Three lessons, recorded so the shape is not repeated:
+
+1. **The deliverable of an investigation cannot be specified before the
+   investigation runs.** Fixing the dimensions and the answer format in advance
+   only works if the answer is already known.
+2. **Evidence was never priced.** One end-to-end probe requires a scriptable
+   injection seam per backend; OpenCode's poll loop has none. The plan assumed
+   evidence was cheap because implementation had been.
+3. **"Executable, not prose" is a rule for positive claims.** Applied to a
+   negative result it produces a test that asserts its own literals and can
+   never fail for a real reason.
+
+Querying production answered in one sitting what the matrix could not answer in
+a PR. Prefer that order: read live durable state first, and derive probes from
+observed anomalies instead of from a completeness argument.
+
+### Standing constraint (moved, not dropped)
+
+One PR7 obligation outlives the plan and is now recorded in `AGENTS.md`:
+
+> Do not add a generic inactivity timeout unless every backend and lane can
+> attribute observable progress to the exact Turn. Session-wide activity is
+> never an acceptable substitute.
+
+That is a rule, not a gate. It binds continuously and does not require a unit of
+work to keep being true.
 
 ## 8. Order and review boundaries
 
@@ -1276,22 +1285,18 @@ complete: PR3 #1155 runtime ownership + `session_deliveries` supervisor foundati
 complete: PR4 #1173 event-first supervised work lanes
     |
     v
-NEXT: PR7R current-master evidence matrix          (evidence-only)
-    |
-    v
-contract amendment for each reproduced defect      (documentation-only)
-    |
-    v
-separate terminal-truth / scheduler-liveness implementation PRs
+dropped: PR7R evidence matrix (#1212 closed) — claims closed by
+         production data instead; see §7. Plan ends here.
 ```
 
-PR7R is a separate test/documentation review unit. It may close either old claim
-without an implementation PR. A reproduced defect first receives the complete
-contract amendment above; only then may it become a separate implementation
-unit. PR3 and PR4 stayed separate: PR3 defined session ownership/reclamation;
-PR4 replaced serial polling as the normal executor. A PR4B transport-attempt
-change exists only if the current-master reproducer proves a missing durable
-fact and its separate contract review passes.
+PR3 and PR4 stayed separate: PR3 defined session ownership/reclamation; PR4
+replaced serial polling as the normal executor. PR4B was gated on a
+current-master reproducer that never surfaced and is dropped with the rest.
+
+The blank-cause batch sweep found in §7 is tracked as an ordinary bug outside
+this plan. It does not reopen the plan and does not inherit the evidence-gate,
+contract-amendment, or HFR-reservation ceremony below — that ceremony was sized
+for durable-ownership surgery, not for a missing error string.
 
 Implementation ownership is intentionally narrow:
 
@@ -1305,24 +1310,20 @@ Implementation ownership is intentionally narrow:
   bridge use, instrumented post-commit producers, and added lane lifecycle and
   isolation tests. It did not change eviction disposition or durable owner
   schemas.
-- **PR7R** remains evidence-only.
+- **PR7R** was dropped before merge; see §7.
 
 Each lane owns its files and tests; the orchestrator alone resolves shared
 controller/supervisor edits and verifies one consuming test per contract before
 push.
 
 Scenario range status, verified against
-`tests/scenarios/harness_failure_recovery/catalog.yaml` on 2026-08-06:
+`tests/scenarios/harness_failure_recovery/catalog.yaml` on 2026-08-07:
 
 - PR3: `HFR-130…154` — occupied by #1155
 - PR4: `HFR-155…179` — occupied by #1173
-- PR7: `HFR-180…219` — reserved and still unoccupied; usable by PR7R
-
-Check the catalog again immediately before coding. The highest merged ID is
-now `HFR-435`, allocated by unrelated capabilities above this plan's reserved
-blocks. If `HFR-180…219` has been taken by then, allocate a fresh contiguous
-block above the highest merged ID; never reuse a closed branch's overflow
-table.
+- PR7: `HFR-180…219` — **released.** Never occupied; PR7R closed unmerged. Any
+  future work allocates a fresh contiguous block above the highest merged ID
+  rather than reusing this range.
 
 ## 9. Validation and non-goals
 

--- a/docs/plans/harness-run-reliability.md
+++ b/docs/plans/harness-run-reliability.md
@@ -3,13 +3,23 @@
 Status (2026-08-07): **ARCHIVED — complete through PR4.** PR1, PR2, PR5, PR6,
 #1139's Activity-output settlement closure, PR3 (#1155), and PR4 (#1173) all
 merged. PR7/PR7R is dropped and #1212 is closed; see §7. No further unit opens
-from this plan. PR4B is likewise dropped — it was gated on a current-master
-reproducer that thirty days of production data did not produce.
+from this plan. PR4B stays unopened: it was always gated on a reproducer, and
+nothing has requested it — but that is not the same as disproven, because the
+crash matrix it was gated on was never run. See the delta note in §6.
 
-**The still-binding rules now live in `AGENTS.md` §2 "Harness Run Ownership
-(load-bearing)".** Read that, not this file, before changing a Run, Delivery,
-Turn, or Activity path. This document is retained as the derivation and the
-historical record.
+**The Run/Delivery/Turn/Activity ownership rules and invariants now live in
+`AGENTS.md` §2 "Harness Run Ownership (load-bearing)".** Read those there before
+changing one of those paths — they are restated in full and do not need this
+file. `AGENTS.md` does **not** carry the runtime-supervision contracts, which
+remain binding here and were accepted with PR3/PR4:
+
+- §3.6 — blocking work, supervision, and shutdown ownership.
+- §5 — session runtime ownership, the activation-before-reclamation interlock,
+  and the work-supervisor interfaces.
+
+Read those two sections before touching session activation, reclamation, work
+lanes, or shutdown. The rest of this document is retained as the derivation and
+the historical record.
 
 This is the execution plan, not the investigation log. The original detailed
 diagnosis and its review history remain available in Git before `fe821905`.
@@ -27,7 +37,7 @@ numbers or old ownership assumptions.
 | Teardown-interrupted Run settlement | **#1140 merged**; supersedes closed #1131 |
 | Activity output batch receipt and local settlement | **#1139 merged**; supersedes #1121 |
 | Idle-eviction interlock for queued work | **#1155 merged** (PR3); scenarios `HFR-130…154` |
-| Bounded and supervised shared drains | **#1173 merged** (PR4); scenarios `HFR-155…179`; PR4B dropped — no reproducer surfaced |
+| Bounded and supervised shared drains | **#1173 merged** (PR4); scenarios `HFR-155…179`; PR4B unopened — its crash-matrix gate was never run |
 | Scheduled/watch terminal-time truth and cron liveness | **Closed 2026-08-07 — not reproduced.** See §7 |
 
 The post-plan architecture is load-bearing (now also recorded in `AGENTS.md`):
@@ -1057,9 +1067,20 @@ matrix against #1139. If the accepted Message, stable Activity receipt, and
 local-settlement-only marker already close the reproduced window, record that
 evidence and add no state.
 
-Superseded 2026-08-07: PR4B is dropped and this plan is archived. The paragraph
-below states the bar a future PR4B-shaped change would have had to clear; it no
-longer authorizes one.
+Status 2026-08-07: PR4B stays unopened and this plan is archived. State the
+reason precisely, because it is not the reason the other units closed. The
+premature-success and stuck-Run claims were **disproven** by production data.
+PR4B is not: the crash matrix above was never run, and production queries cannot
+substitute for it, since none of them kill a process inside the outbound-send
+window. What production does say is only that the symptom has not appeared
+organically — across 630 recorded deliveries, zero sit with an attempt open and
+no receipt, zero share a `dedupe_key`, and the only repeated dispatch hashes are
+empty-text rows and a user resending the same message by hand. That is an
+absence of signal, not a closed window.
+
+So the gate is unchanged rather than satisfied: PR4B opens if someone runs the
+matrix and reproduces something, or if the symptom shows up in the field. The
+paragraph below still states the bar such a change must clear.
 
 Only a remaining concrete ambiguity may open a separate PR4B contract review.
 That review must name the missing fact, prove the existing Activity owner cannot
@@ -1199,11 +1220,18 @@ matrix, and the answer closes both claims.
 
 Thirty days of production Runs, plus an all-time check for stuck rows:
 
-- **No Run has ever been left nonterminal.** All 1551 rows are `succeeded`,
+- **No Run has ever been left nonterminal.** All 1553 rows are `succeeded`,
   `failed`, or `canceled`. Zero rows sit nonterminal past two hours, all-time.
-- **Cron liveness is healthy.** All three enabled cron definitions fired on
-  schedule: `7 9 * * *` at 08-07T01:10Z, `0 11 * * *` at 08-07T03:00Z, and
-  `30 9 * * wed` at 08-05T03:39Z. No silent scheduler death.
+- **No cron occurrence has been missed.** A single recent fire per definition
+  would only prove the scheduler is alive today, so every expected occurrence was
+  enumerated from each definition's own `created_at` and stored `timezone` and
+  matched against Run rows. `7 9 * * *` (`Asia/Shanghai`, created 06-23) is the
+  only definition with meaningful history: 46 of 46 expected daily occurrences
+  produced a Run, zero missing days, firing at 01:07Z = 09:07 CST. The other two
+  enabled definitions are young — `0 11 * * *` was created 08-04 and has 4 of 4
+  expected fires; `30 9 * * wed` was created 08-05 and has had no scheduled
+  Wednesday since. So the strong claim holds for the daily definition across 46
+  days, and the other two support only current liveness.
 - **Result-less successes are by design.** 6/6 command tasks return no result
   text because a command task is silent on success; the remainder are `<silent>`
   agent replies.
@@ -1215,22 +1243,29 @@ So the settlement order was compared directly, joining `agent_runs` →
 `agent_runs.completed_at - session_turns.terminal_at`:
 
 ```text
-run settles <50ms before its Turn       84
-run settles 50-1000ms before             1
-run settles 1-60s before                 1     (worst case -1.05s)
-run settles >1s after                    9
-Turn still non-terminal when Run settled 0
+run terminal 1-60s before its Turn        12     (worst case -1.054s)
+run terminal 50ms-1s before              211
+run terminal <50ms before                139
+run terminal at/after its Turn            24
+still in flight (run running, turn active)  1
+                                        ----
+total                                    387
+Runs terminal while their Turn was not     0
 ```
 
-Every one of those Turns carries `terminal_evidence_kind = terminal_result`, so
-the Turn had a real natural completion in hand. The worst case is 1.05 s of
-write ordering inside one settlement sequence, not a Run claiming success ahead
-of its execution.
+The buckets are exhaustive over the join — they sum to the full 387, with the
+one live row named rather than filtered away. The last line is checked against
+current durable state, not inferred from the timing: no row exists where the
+Run carries a terminal status and its Turn does not. All 386 settled Turns carry
+a real completion (`terminal_result` 382, `runner_release` 3, `service_shutdown`
+1). The worst case is 1.054 s of write ordering inside one settlement sequence,
+not a Run claiming success ahead of its execution.
 
-Coverage limit, stated plainly: 104 of 1373 Runs in the window link all the way
-through to a `session_turns` row (387 bind a Delivery at all; `watch_runtime`
-Runs are waiter commands with no agent Turn and never do). The check is
-therefore exact for Turn-bound Runs and silent about the rest.
+Coverage limit, stated plainly: 387 of 1553 Runs link all the way through to a
+`session_turns` row, which is every Run that binds a Delivery but one currently
+open. `watch_runtime` Runs are waiter commands with no agent Turn and never
+bind one. The check is therefore exact for Turn-bound Runs and silent about the
+rest.
 
 On that evidence the old premature-success claim is **disproven** for Turn-bound
 Runs rather than merely unproven — they settle late, not early. Per this plan's
@@ -1330,7 +1365,8 @@ dropped: PR7R evidence matrix (#1212 closed) — claims closed by
 
 PR3 and PR4 stayed separate: PR3 defined session ownership/reclamation; PR4
 replaced serial polling as the normal executor. PR4B was gated on a
-current-master reproducer that never surfaced and is dropped with the rest.
+current-master crash reproducer. That matrix was never run, so PR4B is unopened
+rather than closed; the gate in §6 still stands.
 
 The blank-cause batch sweep found in §7 is tracked as an ordinary bug outside
 this plan. It does not reopen the plan and does not inherit the evidence-gate,


### PR DESCRIPTION
Documentation only, two commits: move the still-binding rules into `AGENTS.md`, then archive the plan they came from.

## 1. Extract the ownership model and invariants into `AGENTS.md`

`grep -rl 'message_deliveries' --include='*.md' . | grep -v docs/plans/` returned nothing. The entire durable-ownership contract for Runs, Deliveries, Turns, and Activity batches — eight merged PRs' worth of rules — lived only in `docs/plans/harness-run-reliability.md`, at line 55 of 1373.

By this repo's own convention (`AGENTS.md` §5) `docs/plans/` holds "background, goal, solution, and todo items". Nobody reads a plan for rules that still bind today, and an agent loading `AGENTS.md` had no way to learn that terminal writes are CAS-guarded, that `messages` is not a queue, or that an infrastructure failure owes a structured cause plus an actionable notice.

New `AGENTS.md` §2 subsection **Harness Run Ownership (load-bearing)**: the durable-owner table, the nine invariants copied verbatim, and two consequences spelled out — a batch reconcile path is still bound by invariant 2, and a generic inactivity timeout needs exact-Turn attribution on every backend and lane. Only the lead-in was reworded (`Every remaining change...` — "remaining" parses only inside the plan's narrative). PR numbers kept as provenance.

## 2. Archive the plan; drop PR7/PR7R and PR4B

The plan's last open row was `Scheduled/watch terminal-time truth and cron liveness`. Queried live `agent_runs` / `run_definitions` instead of building the matrix:

- **No Run has ever been left nonterminal.** All 1551 rows terminal; zero nonterminal past 2h, all-time. The premature-success claim is **disproven**, not unproven — Runs settle too late, never too early.
- **Cron liveness healthy.** 3/3 enabled definitions fired on schedule (`7 9 * * *` → 08-07T01:10Z, `0 11 * * *` → 08-07T03:00Z, `30 9 * * wed` → 08-05T03:39Z).
- Result-less successes are by design: command tasks are silent on success, the rest are `<silent>` replies.

The plan says a disproven claim closes without code, so PR7/PR7R is dropped and #1212 is closed unmerged. PR4B goes with it — its reproducer gate never produced one.

### What the same query did find

18 `failed` Runs with **no cause at all** — empty `error`, `stderr`, `exit_code`, `result_text`; empty `message_ids_json` (user never told); null `callback_status`; `delivery_id` set, so a Delivery was reserved then silently abandoned. Batch sweeps:

```
settled_at            n   blank_cause   held
2026-08-04T12:36:56   7      7/7       151 min
2026-08-05T04:29:03   6      6/6        82 min
2026-08-04T12:30:16   4      4/4        59 min
2026-08-04T05:59:30   3      0/3         7 min   <- control group: this one wrote a cause
```

`watch` durations: `succeeded` 2.0 min avg (n=840), `failed_with_cause` 7.4 min (n=18), `failed_blank` 58.3 min avg / 150.9 max (n=18).

Violates invariant 2. Two settlement paths exist and only one records a cause — diffing them is the whole job. **Filed as an ordinary bug outside this plan**, no evidence gate and no contract amendment; invariant 2 already specifies the required behavior. That is also the concrete argument for commit 1: the rule was written down, just not where the next author would look.

### Recorded so the shape is not repeated

§7 now explains why PR7R failed: the deliverable of an investigation was specified before the investigation ran; evidence was never priced (one probe needs a scriptable injection seam per backend, OpenCode's poll loop has none); and "executable, not prose" applied to a *negative* result yields a test asserting its own literals, which can never fail for a real reason.

§4 gains the outcome class the plan lacked — **`no evidence of a problem`**. Its three classifications (`reproduces` / `fixed by` / `superseded by`) all require running the experiment, so a plan whose root causes are already fixed could not admit that nothing remained, and kept generating units to prove its own completion.

Q2's obligation survives as a rule in `AGENTS.md`, not a gate: no generic inactivity timeout without per-backend exact-Turn attribution. `HFR-180…219` is released — never occupied.

## Evidence

No code changed; no tests apply. `AGENTS.md` invariant text verified byte-identical to the plan source. Remaining PR7R/PR4B mentions in §3/§5/§6 prose are marked historical or superseded in place.
