### PR TITLE
fix(agents): disable native auto memory for Avibe runs

### DIFF
--- a/core/agent_auth_service.py
+++ b/core/agent_auth_service.py
@@ -1144,7 +1144,10 @@ class AgentAuthService:
         # api_key / base_url overrides apply uniformly. Without this, an
         # OAuth-mode user with ``ANTHROPIC_API_KEY`` in their shell would
         # still get the key into the control-channel SDK client.
-        from vibe.claude_config import build_claude_subprocess_env
+        from vibe.claude_config import (
+            CLAUDE_MEMORY_DISABLED_SETTINGS,
+            build_claude_subprocess_env,
+        )
 
         # ``force_oauth=True`` because this code path IS the OAuth
         # setup flow — the control-channel SDK client must run with
@@ -1166,6 +1169,7 @@ class AgentAuthService:
         option_kwargs = {
             "cwd": working_path,
             "env": claude_env,
+            "settings": CLAUDE_MEMORY_DISABLED_SETTINGS,
             "setting_sources": ["user", "project", "local"],
             "max_buffer_size": CLAUDE_SDK_MAX_BUFFER_SIZE,
         }
@@ -2332,7 +2336,10 @@ class AgentAuthService:
     ) -> str:
         """Run an isolated turn through the same Claude Agent SDK transport."""
         from modules.agents.model_hub import claude_setting_sources_for_launch
-        from vibe.claude_config import build_claude_subprocess_env
+        from vibe.claude_config import (
+            CLAUDE_MEMORY_DISABLED_SETTINGS,
+            build_claude_subprocess_env,
+        )
 
         stderr_lines: list[str] = []
 
@@ -2354,6 +2361,7 @@ class AgentAuthService:
             "tools": [],
             "max_turns": 1,
             "env": claude_env,
+            "settings": CLAUDE_MEMORY_DISABLED_SETTINGS,
             "stderr": capture_stderr,
             "max_buffer_size": CLAUDE_SDK_MAX_BUFFER_SIZE,
         }

--- a/core/handlers/session_handler.py
+++ b/core/handlers/session_handler.py
@@ -1461,7 +1461,10 @@ class SessionHandler(BaseHandler):
         # V2Config-driven Anthropic env composition, centralised so the
         # control-channel client (``agent_auth_service``) cannot drift
         # away from this site's auth_mode handling.
-        from vibe.claude_config import build_claude_subprocess_env
+        from vibe.claude_config import (
+            CLAUDE_MEMORY_DISABLED_SETTINGS,
+            build_claude_subprocess_env,
+        )
         from core.git_runtime import prepend_vendored_git_to_path
 
         claude_env = build_claude_subprocess_env(getattr(self.config, "claude", None))
@@ -1488,6 +1491,7 @@ class SessionHandler(BaseHandler):
             "resume": stored_claude_session_id if stored_claude_session_id else None,
             "fork_session": bool(fork_session and stored_claude_session_id),
             "extra_args": extra_args,
+            "settings": CLAUDE_MEMORY_DISABLED_SETTINGS,
             "setting_sources": claude_setting_sources_for_launch(model_hub_launch),
             "sandbox": CLAUDE_REMOTE_SANDBOX,
             # Disable interactive-only Claude Code tools that remote IM sessions

--- a/modules/agents/codex/transport.py
+++ b/modules/agents/codex/transport.py
@@ -74,6 +74,10 @@ class CodexTransport:
             + ["app-server"]
             + self._runtime_args
             + self._extra_args
+            # Keep this process-local policy last so user args cannot re-enable
+            # memory. Older Codex builds ignore unknown config keys, while an
+            # unknown ``--disable`` feature would abort startup.
+            + ["-c", "features.memories=false"]
         )
         logger.info("Launching Codex app-server: %s (cwd=%s)", " ".join(cmd), self._cwd)
 

--- a/tests/test_agent_auth_service.py
+++ b/tests/test_agent_auth_service.py
@@ -1968,6 +1968,7 @@ class AgentAuthServiceTests(_IsolatedClaudeConfigDirMixin, unittest.IsolatedAsyn
         self.assertTrue(captured["connected"])
         self.assertEqual(captured["options"].max_buffer_size, CLAUDE_SDK_MAX_BUFFER_SIZE)
         self.assertEqual(captured["options"].env["AVIBE_CLAUDE_PROCESS_OWNER"], "auth")
+        self.assertEqual(captured["options"].settings, '{"autoMemoryEnabled":false}')
 
     async def test_claude_control_flow_start_in_flight_disables_unknown_pid_guard(self):
         controller = _StubController()

--- a/tests/test_claude_cli_path.py
+++ b/tests/test_claude_cli_path.py
@@ -315,6 +315,7 @@ def test_session_handler_sets_claude_fork_session_for_pending_native_fork(monkey
     assert captured["options"].resume == "claude-source"
     assert captured["options"].fork_session is True
     assert captured["options"].extra_args == {"model": "claude-sonnet-4-5"}
+    assert captured["options"].settings == '{"autoMemoryEnabled":false}'
     assert captured["options"].effort == "high"
     assert not hasattr(client, "_vibe_native_session_id")
     prompt_value = captured["options"].system_prompt

--- a/tests/test_codex_agent.py
+++ b/tests/test_codex_agent.py
@@ -3662,13 +3662,21 @@ class CodexTransportCommandTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(
             created_cmds,
             [
-                ["codex", "--dangerously-bypass-approvals-and-sandbox", "app-server"],
+                [
+                    "codex",
+                    "--dangerously-bypass-approvals-and-sandbox",
+                    "app-server",
+                    "-c",
+                    "features.memories=false",
+                ],
                 [
                     "codex",
                     "--dangerously-bypass-approvals-and-sandbox",
                     "app-server",
                     "-c",
                     'model_provider="avibe_model_hub"',
+                    "-c",
+                    "features.memories=false",
                 ],
             ],
         )

--- a/tests/test_codex_transport.py
+++ b/tests/test_codex_transport.py
@@ -25,7 +25,12 @@ class CodexTransportHealthTests(unittest.IsolatedAsyncioTestCase):
             stdout=_Stream(),
             stderr=_Stream(),
         )
-        transport = CodexTransport(binary="codex", cwd="/tmp")
+        transport = CodexTransport(
+            binary="codex",
+            cwd="/tmp",
+            runtime_args=["-c", 'model_provider="avibe"'],
+            extra_args=["-c", "features.memories=true"],
+        )
 
         async def wait_for_initialize(_method, _params):
             initialize_started.set()
@@ -36,11 +41,12 @@ class CodexTransportHealthTests(unittest.IsolatedAsyncioTestCase):
 
         transport.send_request = AsyncMock(side_effect=wait_for_initialize)
         transport.stop = AsyncMock(side_effect=stop_transport)
+        spawn = AsyncMock(return_value=process)
 
         with (
             patch(
                 "modules.agents.codex.transport.asyncio.create_subprocess_exec",
-                new=AsyncMock(return_value=process),
+                new=spawn,
             ),
             patch("modules.agents.codex.transport.process_identity", return_value={}),
             patch("modules.agents.codex.transport.log_process_snapshot"),
@@ -52,6 +58,20 @@ class CodexTransportHealthTests(unittest.IsolatedAsyncioTestCase):
                 await task
 
         transport.stop.assert_awaited_once_with()
+        self.assertEqual(
+            spawn.await_args.args,
+            (
+                "codex",
+                "--dangerously-bypass-approvals-and-sandbox",
+                "app-server",
+                "-c",
+                'model_provider="avibe"',
+                "-c",
+                "features.memories=true",
+                "-c",
+                "features.memories=false",
+            ),
+        )
 
     async def test_reader_task_failure_marks_transport_not_alive(self):
         transport = CodexTransport(binary="codex", cwd="/tmp")

--- a/vibe/claude_config.py
+++ b/vibe/claude_config.py
@@ -37,6 +37,11 @@ MANAGED_ENV_VALUES = {
     "CLAUDE_CODE_ATTRIBUTION_HEADER": "0",
 }
 
+# Passed through the SDK as a process-local ``--settings`` override. Keeping it
+# out of ``MANAGED_ENV_VALUES`` ensures Avibe never persists this policy into
+# the user's Claude Code settings.
+CLAUDE_MEMORY_DISABLED_SETTINGS = '{"autoMemoryEnabled":false}'
+
 # Keys we recognise inside ``~/.claude/settings.json``'s ``env`` block.
 # Claude Code assigns header semantics from the selected variable, independently
 # from ``ANTHROPIC_BASE_URL``. Avibe preserves that native distinction instead


### PR DESCRIPTION
## Summary

- disable Codex Memories in every Avibe-owned `codex app-server` with a process-local config override that remains authoritative after Model Hub and user extra args
- disable Claude Code auto memory in Avibe-owned Agent SDK launches with an inline `--settings` override, without changing user or project settings files
- leave OpenCode unchanged because its current CLI and config schema expose no native auto-memory feature; `--pure` would disable all external plugins and break unrelated capabilities

## Scenarios

- No cataloged scenario IDs apply to backend process launch policy.

## Evidence

- Unit: 150 focused Claude/Codex tests passed, including subprocess argv and SDK settings assertions
- Contract: Codex disable override is asserted after runtime and user-provided args; Claude inline settings are asserted on session and control-client launches
- Scenario: not applicable; no user-facing scenario catalog entry covers native backend memory
- Residual manual: current installed Codex and Claude CLIs accepted the exact process-local overrides; OpenCode 1.18.5 and the official config schema expose no native memory toggle

## Known By Design

- Existing Avibe-owned backend processes need to be recycled after this change is deployed before the launch policy takes effect.
- OpenCode plugins are preserved. Avibe does not use `--pure` as a proxy for memory disablement because OpenCode has no corresponding built-in memory capability.
