### PR TITLE
feat(ui): add realtime voice preview fallback

### DIFF
--- a/docs/voice-realtime-prototype.md
+++ b/docs/voice-realtime-prototype.md
@@ -1,0 +1,16 @@
+# Realtime Voice Prototype
+
+The browser Realtime path is opt-in and preserves the existing HTTP dictation
+queue as its fallback. Enable `VITE_VOICE_REALTIME_ENABLED=true` in the UI
+build and `VOICE_REALTIME_ENABLED=true` in the cloud service only after both
+halves are deployed together. The default model is
+`qwen3-asr-flash-realtime`.
+
+The browser sends `start`, 250 ms PCM16 `audio`, and `finish` frames over the
+`avibe-asr-v1.<cloud-token>` subprotocol. The cloud route authenticates the
+existing `asr` capability, forwards audio to the configured DashScope realtime
+endpoint, and returns non-authoritative previews followed by one final text.
+The preview never changes the draft; only the server-cleaned final result is
+inserted. Provider credentials remain server-side. Handshake, transport,
+protocol, timeout, and upstream failures activate the existing HTTP recording
+fallback without changing legacy or dictation endpoint contracts.

--- a/tests/test_ui_server_voice_telemetry.py
+++ b/tests/test_ui_server_voice_telemetry.py
@@ -24,6 +24,9 @@ def test_voice_telemetry_logs_only_allowlisted_metadata(caplog):
                 "elapsedMs": 820,
                 "httpStatus": 200,
                 "attemptCount": 1,
+                "realtime": True,
+                "firstPreviewMs": 360,
+                "stopToFinalMs": 420,
                 "browserFamily": "chrome",
                 "transcript": "private words",
                 "audio": "private bytes",
@@ -39,6 +42,9 @@ def test_voice_telemetry_logs_only_allowlisted_metadata(caplog):
     assert metric["dictationId"] == "dictation-123"
     assert metric["sizeBytes"] == 240_000
     assert metric["httpStatus"] == 200
+    assert metric["realtime"] is True
+    assert metric["firstPreviewMs"] == 360
+    assert metric["stopToFinalMs"] == 420
     assert metric["release"]
     assert "transcript" not in metric
     assert "audio" not in metric

--- a/ui/src/components/workbench/Composer.tsx
+++ b/ui/src/components/workbench/Composer.tsx
@@ -920,6 +920,11 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
             session.realtimeFirstPreviewAt ??= Date.now();
             setRealtimePreview(`${preview.text}${preview.stash}`.trim());
           },
+          onError: () => {
+            if (abortController.signal.aborted) return;
+            session.realtimeState = 'failed';
+            activateHttpFallback(session);
+          },
         });
         void session.realtime.start().then(() => {
           if (abortController.signal.aborted) return;

--- a/ui/src/components/workbench/Composer.tsx
+++ b/ui/src/components/workbench/Composer.tsx
@@ -961,6 +961,11 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
         },
         onError: (error) => {
           session.captureError = error;
+          if (session.realtime) {
+            session.realtimeState = 'failed';
+            session.realtime.abort();
+            activateHttpFallback(session);
+          }
           if (!voiceSessionsById.has(session.sessionId)) {
             voiceSessionsById.set(session.sessionId, session);
           }

--- a/ui/src/components/workbench/Composer.tsx
+++ b/ui/src/components/workbench/Composer.tsx
@@ -41,6 +41,11 @@ import {
   isVoiceControlDisabled,
   VoiceRecordingPipeline,
 } from '../../lib/voiceRecording';
+import {
+  isVoiceRealtimeEnabled,
+  VoiceRealtimeSession,
+  type VoiceRealtimeFinal,
+} from '../../lib/voiceRealtime';
 import { Button } from '../ui/button';
 import {
   MentionEditor,
@@ -94,6 +99,7 @@ const newLocalId = () => `${Date.now()}-${Math.random().toString(36).slice(2, 8)
 
 type VoiceSegment = VoiceTranscriptionSegment & {
   task: Promise<void>;
+  transcriptionStarted?: boolean;
 };
 
 type VoiceRecordingSession = {
@@ -118,6 +124,10 @@ type VoiceRecordingSession = {
   insertion: VoiceInsertionSnapshot;
   cleanupOutcome?: VoiceCleanupOutcome;
   cleanupElapsedMs?: number;
+  realtime?: VoiceRealtimeSession;
+  realtimeState?: 'connecting' | 'active' | 'failed' | 'finalized';
+  realtimeFirstPreviewAt?: number;
+  realtimeFinalAt?: number;
 };
 
 // Composer remounts when the user switches chats. Keep pending or retryable
@@ -167,26 +177,28 @@ const settleVoiceSession = async (session: VoiceRecordingSession): Promise<void>
   }
 };
 
+const runVoiceFinalization = async (session: VoiceRecordingSession): Promise<void> => {
+  await Promise.all(session.segments.map((segment) => segment.task));
+  if (session.abortController.signal.aborted) {
+    deleteMapValueIfCurrent(voiceSessionsById, session.sessionId, session);
+    return;
+  }
+  if (session.captureError !== undefined) {
+    session.transcript = undefined;
+    session.error = session.captureError;
+    session.status = 'failed';
+    return;
+  }
+  await settleVoiceSession(session);
+  if (session.abortController.signal.aborted) {
+    deleteMapValueIfCurrent(voiceSessionsById, session.sessionId, session);
+  }
+};
+
 const finalizeVoiceSession = (session: VoiceRecordingSession): Promise<void> => {
   if (session.finalization) return session.finalization;
   session.status = 'transcribing';
-  session.finalization = (async () => {
-    await Promise.all(session.segments.map((segment) => segment.task));
-    if (session.abortController.signal.aborted) {
-      deleteMapValueIfCurrent(voiceSessionsById, session.sessionId, session);
-      return;
-    }
-    if (session.captureError !== undefined) {
-      session.transcript = undefined;
-      session.error = session.captureError;
-      session.status = 'failed';
-      return;
-    }
-    await settleVoiceSession(session);
-    if (session.abortController.signal.aborted) {
-      deleteMapValueIfCurrent(voiceSessionsById, session.sessionId, session);
-    }
-  })();
+  session.finalization = runVoiceFinalization(session);
   return session.finalization;
 };
 
@@ -254,6 +266,13 @@ const reportVoiceFinalization = (
     totalDurationMs: session.stoppedAt == null || session.startedAt == null
       ? undefined
       : session.stoppedAt - session.startedAt,
+    realtime: session.realtimeState !== undefined,
+    firstPreviewMs: session.realtimeFirstPreviewAt == null || session.startedAt == null
+      ? undefined
+      : session.realtimeFirstPreviewAt - session.startedAt,
+    stopToFinalMs: session.realtimeFinalAt == null || session.stoppedAt == null
+      ? undefined
+      : session.realtimeFinalAt - session.stoppedAt,
     retry: session.retryCount > 0,
   });
   session.reportedAttemptCount = attemptCount;
@@ -273,6 +292,13 @@ const reportVoiceInsertion = (session: VoiceRecordingSession): void => {
     totalDurationMs: session.stoppedAt == null || session.startedAt == null
       ? undefined
       : session.stoppedAt - session.startedAt,
+    realtime: session.realtimeState !== undefined,
+    firstPreviewMs: session.realtimeFirstPreviewAt == null || session.startedAt == null
+      ? undefined
+      : session.realtimeFirstPreviewAt - session.startedAt,
+    stopToFinalMs: session.realtimeFinalAt == null || session.stoppedAt == null
+      ? undefined
+      : session.realtimeFinalAt - session.stoppedAt,
     stopToInsertionMs: session.stoppedAt == null
       ? undefined
       : Date.now() - session.stoppedAt,
@@ -388,6 +414,7 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
     sessionId != null && voiceSessionLocksDraft(voiceSessionsById.get(sessionId))
   ));
   const [recordingSeconds, setRecordingSeconds] = useState(0);
+  const [realtimePreview, setRealtimePreview] = useState('');
   const [transcribing, setTranscribing] = useState(false);
   const [voiceRetainedSession, setVoiceRetainedSession] = useState<VoiceRecordingSession | null>(null);
   const transcribingRef = useRef(false);
@@ -512,6 +539,7 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
   // the composer by session.
   useEffect(() => {
     setAttachments([]);
+    setRealtimePreview('');
     setVoiceRetainedSession(null);
     setRestoringRecording(
       sessionId != null && voiceSessionLocksDraft(voiceSessionsById.get(sessionId)),
@@ -662,7 +690,22 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
       task: Promise.resolve(),
     };
     session.segments.push(segment);
+    if (session.realtimeState === 'connecting' || session.realtimeState === 'active') {
+      return;
+    }
+    segment.transcriptionStarted = true;
     segment.task = session.transcriptionQueue.enqueue(segment);
+  };
+
+  const activateHttpFallback = (session: VoiceRecordingSession): void => {
+    if (session.realtimeState === 'failed') {
+      for (const segment of session.segments) {
+        if (!segment.transcriptionStarted && segment.blob && !segment.final) {
+          segment.transcriptionStarted = true;
+          segment.task = session.transcriptionQueue.enqueue(segment);
+        }
+      }
+    }
   };
 
   const presentVoiceSession = useCallback((session: VoiceRecordingSession) => {
@@ -710,6 +753,58 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
       await finalizeVoiceSession(session);
       presentVoiceSession(session);
     } finally {
+      if (recordingSessionRef.current === session) recordingSessionRef.current = null;
+      if (activeHere) {
+        transcribingRef.current = false;
+        if (!unmountedRef.current) setTranscribing(false);
+      }
+    }
+  };
+
+  const finishRealtimeVoiceSession = async (session: VoiceRecordingSession) => {
+    const activeHere = !unmountedRef.current && sessionId === session.sessionId;
+    if (activeHere) {
+      transcribingRef.current = true;
+      setTranscribing(true);
+      setVoiceRetainedSession(session);
+    }
+    session.status = 'transcribing';
+    session.finalization = (async () => {
+      try {
+        if (session.captureError !== undefined || !session.realtime) {
+          throw session.captureError ?? new Error('realtime_unavailable');
+        }
+        const result: VoiceRealtimeFinal = await session.realtime.finish();
+        if (session.abortController.signal.aborted) return;
+        session.realtimeState = 'finalized';
+        session.realtimeFinalAt = Date.now();
+        session.cleanupOutcome = result.cleanup;
+        session.cleanupElapsedMs = session.realtimeFinalAt - (session.stoppedAt ?? session.realtimeFinalAt);
+        session.finalizedSegmentCount = session.segments.filter((segment) => segment.blob).length;
+        session.finalizedFailedSegmentCount = 0;
+        session.transcript = result.text;
+        if (!result.text.trim()) {
+          session.error = new VoiceTranscriptionError('empty');
+          session.status = 'failed';
+          return;
+        }
+        session.segments = [];
+        session.error = undefined;
+        session.status = 'ready';
+      } catch (_error) {
+        if (session.abortController.signal.aborted) return;
+        session.realtimeState = 'failed';
+        activateHttpFallback(session);
+        session.finalization = undefined;
+        session.status = 'transcribing';
+        await runVoiceFinalization(session);
+      }
+    })();
+    try {
+      await session.finalization;
+      presentVoiceSession(session);
+    } finally {
+      setRealtimePreview('');
       if (recordingSessionRef.current === session) recordingSessionRef.current = null;
       if (activeHere) {
         transcribingRef.current = false;
@@ -819,6 +914,27 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
           dictationId,
         }),
       };
+      if (isVoiceRealtimeEnabled()) {
+        session.realtimeState = 'connecting';
+        session.realtime = new VoiceRealtimeSession({
+          before: insertion.before,
+          after: insertion.after,
+          signal: abortController.signal,
+          onPreview: (preview) => {
+            if (recordingSessionRef.current !== session || unmountedRef.current) return;
+            session.realtimeFirstPreviewAt ??= Date.now();
+            setRealtimePreview(`${preview.text}${preview.stash}`.trim());
+          },
+        });
+        void session.realtime.start().then(() => {
+          if (abortController.signal.aborted) return;
+          session.realtimeState = 'active';
+        }).catch(() => {
+          if (abortController.signal.aborted) return;
+          session.realtimeState = 'failed';
+          activateHttpFallback(session);
+        });
+      }
       startingSession = session;
       const pipeline = new VoiceRecordingPipeline({
         stream,
@@ -831,6 +947,11 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
           metadata.overlapMs,
           metadata.final,
         ),
+        onPcm: (samples) => {
+          if (session.realtimeState === 'connecting' || session.realtimeState === 'active') {
+            session.realtime?.sendPcm(samples);
+          }
+        },
         onStopRequested: (reason, metadata) => {
           if (reason === 'abort') return;
           session.stoppedAt = metadata.requestedAt;
@@ -852,11 +973,15 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 
           if (reason === 'abort') {
             session.abortController.abort();
+            session.realtime?.abort();
+            setRealtimePreview('');
             deleteMapValueIfCurrent(voiceSessionsById, session.sessionId, session);
             return;
           }
           session.backlogAtStop = (session.backlogAtStop ?? 0) + metadata.pendingSegmentCount;
           if (!session.segments.length && session.captureError === undefined) {
+            session.realtime?.abort();
+            setRealtimePreview('');
             reportVoiceFinalization(session, 'empty');
             if (!unmountedRef.current && sessionId === session.sessionId) {
               showToast(t('chat.compose.voiceEmpty'), 'error');
@@ -873,7 +998,11 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
               task: Promise.resolve(),
             });
           }
-          void finishVoiceSession(session);
+          if (session.realtime && session.realtimeState !== 'failed') {
+            void finishRealtimeVoiceSession(session);
+          } else {
+            void finishVoiceSession(session);
+          }
         },
       });
       startingPipeline = pipeline;
@@ -1073,6 +1202,15 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
               </Button>
             </div>
           ))}
+        </div>
+      )}
+      {recording && realtimePreview && (
+        <div
+          className="truncate px-3 text-xs text-muted"
+          aria-live="polite"
+          aria-label={t('chat.compose.voicePreview')}
+        >
+          {realtimePreview}
         </div>
       )}
       <div

--- a/ui/src/components/workbench/Composer.tsx
+++ b/ui/src/components/workbench/Composer.tsx
@@ -776,6 +776,7 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
         }
         const result: VoiceRealtimeFinal = await session.realtime.finish();
         if (session.abortController.signal.aborted) return;
+        if (!result.text.trim()) throw new VoiceTranscriptionError('empty');
         session.realtimeState = 'finalized';
         session.realtimeFinalAt = Date.now();
         session.cleanupOutcome = result.cleanup;
@@ -783,11 +784,6 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
         session.finalizedSegmentCount = session.segments.filter((segment) => segment.blob).length;
         session.finalizedFailedSegmentCount = 0;
         session.transcript = result.text;
-        if (!result.text.trim()) {
-          session.error = new VoiceTranscriptionError('empty');
-          session.status = 'failed';
-          return;
-        }
         session.segments = [];
         session.error = undefined;
         session.status = 'ready';
@@ -795,7 +791,6 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
         if (session.abortController.signal.aborted) return;
         session.realtimeState = 'failed';
         activateHttpFallback(session);
-        session.finalization = undefined;
         session.status = 'transcribing';
         await runVoiceFinalization(session);
       }
@@ -1034,6 +1029,9 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
     } catch {
       // getUserMedia may have handed us a live stream before capture setup
       // threw. Release it so the mic does not stay on.
+      startingSession?.abortController.abort();
+      startingSession?.realtime?.abort();
+      setRealtimePreview('');
       if (recorderRef.current === startingPipeline) recorderRef.current = null;
       if (recordingSessionRef.current === startingSession) recordingSessionRef.current = null;
       clearRecordingTimers();

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -3201,6 +3201,7 @@
       "voice": "Voice input",
       "stopRecording": "Finish recording",
       "cancelRecording": "Cancel recording",
+      "voicePreview": "Live transcription preview",
       "voiceProcessing": "Processing recording",
       "voiceRetry": "Retry transcription",
       "voiceCopyTranscript": "Copy recovered transcript",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -3201,6 +3201,7 @@
       "voice": "语音输入",
       "stopRecording": "完成录音",
       "cancelRecording": "取消录音",
+      "voicePreview": "实时转写预览",
       "voiceProcessing": "正在处理录音",
       "voiceRetry": "重试转写",
       "voiceCopyTranscript": "复制已恢复的文字",

--- a/ui/src/lib/avibeFetch.ts
+++ b/ui/src/lib/avibeFetch.ts
@@ -16,6 +16,8 @@ import { apiFetch } from './apiFetch';
 
 export type CloudToken = { token: string; baseUrl: string; expiresAt: number };
 
+export type AvibeWebSocket = WebSocket;
+
 export type AvibeFetchAttemptEvent =
   | { phase: 'started'; attempt: number }
   | { phase: 'response'; attempt: number; status: number; elapsedMs: number };
@@ -127,6 +129,34 @@ const mint = (): Promise<CloudToken | null> => {
 
 const ensureToken = (): Promise<CloudToken | null> =>
   isFresh(current) ? Promise.resolve(current) : mint();
+
+export const openAvibeWebSocket = async (
+  path: string,
+  subprotocol: string,
+  signal?: AbortSignal,
+): Promise<AvibeWebSocket> => {
+  let token: CloudToken | null;
+  try {
+    token = await waitForSignal(ensureToken(), signal);
+  } catch (error) {
+    if (signal?.aborted) throw signal.reason ?? error;
+    throw new CloudUnavailableError();
+  }
+  if (!token) throw new CloudUnavailableError();
+
+  const websocketBaseUrl = token.baseUrl.replace(/^http/i, 'ws');
+  const socket = new WebSocket(
+    `${websocketBaseUrl}${path}`,
+    `${subprotocol}.${token.token}`,
+  );
+  if (signal) {
+    const abort = () => socket.close(1000, 'aborted');
+    if (signal.aborted) abort();
+    else signal.addEventListener('abort', abort, { once: true });
+    socket.addEventListener('close', () => signal.removeEventListener('abort', abort), { once: true });
+  }
+  return socket;
+};
 
 const waitForSignal = <Value>(promise: Promise<Value>, signal?: AbortSignal): Promise<Value> => {
   if (!signal) return promise;

--- a/ui/src/lib/voiceRealtime.test.ts
+++ b/ui/src/lib/voiceRealtime.test.ts
@@ -91,4 +91,21 @@ describe('voice realtime client protocol', () => {
       cleanup: 'success',
     });
   });
+
+  it('preserves a socket failure that happens before finish', async () => {
+    vi.stubGlobal('WebSocket', { OPEN: 1 });
+    const socket = new FakeSocket();
+    const session = new VoiceRealtimeSession({
+      before: '',
+      after: '',
+      openSocket: async () => socket as unknown as WebSocket,
+    });
+    const start = session.start();
+    socket.open();
+    await start;
+
+    socket.close();
+
+    await expect(session.finish()).rejects.toThrow('realtime_closed');
+  });
 });

--- a/ui/src/lib/voiceRealtime.test.ts
+++ b/ui/src/lib/voiceRealtime.test.ts
@@ -9,6 +9,8 @@ import {
 
 class FakeSocket {
   readyState = 0;
+  autoReady = true;
+  autoFinal = true;
   sent: string[] = [];
   private readonly listeners = new Map<string, Set<(event: unknown) => void>>();
 
@@ -25,10 +27,10 @@ class FakeSocket {
   send(value: string): void {
     this.sent.push(value);
     const message = JSON.parse(value) as { type?: string };
-    if (message.type === 'start') {
+    if (message.type === 'start' && this.autoReady) {
       this.emit('message', { data: JSON.stringify({ type: 'ready', protocol: VOICE_REALTIME_PROTOCOL }) });
     }
-    if (message.type === 'finish') {
+    if (message.type === 'finish' && this.autoFinal) {
       this.emit('message', {
         data: JSON.stringify({ type: 'final', text: '最终文本', cleanup: 'success' }),
       });
@@ -51,6 +53,7 @@ class FakeSocket {
 }
 
 afterEach(() => {
+  vi.useRealTimers();
   vi.unstubAllGlobals();
 });
 
@@ -107,5 +110,84 @@ describe('voice realtime client protocol', () => {
     socket.close();
 
     await expect(session.finish()).rejects.toThrow('realtime_closed');
+  });
+
+  it('closes a socket when the handshake deadline expires', async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal('WebSocket', { OPEN: 1, CLOSED: 3 });
+    const socket = new FakeSocket();
+    socket.autoReady = false;
+    const session = new VoiceRealtimeSession({
+      before: '',
+      after: '',
+      openSocket: async () => socket as unknown as WebSocket,
+    });
+    const start = session.start();
+    await Promise.resolve();
+    socket.open();
+    const expectation = expect(start).rejects.toThrow('realtime_timeout');
+    await vi.advanceTimersByTimeAsync(8_000);
+
+    await expectation;
+    expect(socket.readyState).toBe(3);
+  });
+
+  it('reports an active socket failure and stops accepting PCM', async () => {
+    vi.stubGlobal('WebSocket', { OPEN: 1, CLOSED: 3 });
+    const socket = new FakeSocket();
+    const onError = vi.fn();
+    const session = new VoiceRealtimeSession({
+      before: '',
+      after: '',
+      onError,
+      openSocket: async () => socket as unknown as WebSocket,
+    });
+    const start = session.start();
+    socket.open();
+    await start;
+
+    socket.close();
+
+    expect(onError).toHaveBeenCalledWith(expect.objectContaining({ message: 'realtime_closed' }));
+    expect(session.sendPcm(new Int16Array([1]))).toBe(false);
+  });
+
+  it('rejects the open phase when the socket fails before opening', async () => {
+    vi.stubGlobal('WebSocket', { OPEN: 1, CLOSED: 3 });
+    const socket = new FakeSocket();
+    const session = new VoiceRealtimeSession({
+      before: '',
+      after: '',
+      openSocket: async () => socket as unknown as WebSocket,
+    });
+    const start = session.start();
+    await Promise.resolve();
+    socket.emit('error', {});
+
+    await expect(start).rejects.toThrow('realtime_socket_error');
+    expect(socket.readyState).toBe(3);
+  });
+
+  it('closes the socket when finalization times out', async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal('WebSocket', { OPEN: 1, CLOSED: 3 });
+    const socket = new FakeSocket();
+    socket.autoFinal = false;
+    const session = new VoiceRealtimeSession({
+      before: '',
+      after: '',
+      openSocket: async () => socket as unknown as WebSocket,
+    });
+    const start = session.start();
+    await Promise.resolve();
+    socket.open();
+    await start;
+    const finish = session.finish();
+    const expectation = expect(finish).rejects.toThrow('realtime_timeout');
+
+    await vi.advanceTimersByTimeAsync(20_000);
+
+    await expectation;
+    expect(socket.readyState).toBe(3);
   });
 });

--- a/ui/src/lib/voiceRealtime.test.ts
+++ b/ui/src/lib/voiceRealtime.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  encodeVoiceRealtimePcm,
+  parseVoiceRealtimeMessage,
+  VoiceRealtimeSession,
+  VOICE_REALTIME_PROTOCOL,
+} from './voiceRealtime';
+
+class FakeSocket {
+  readyState = 0;
+  sent: string[] = [];
+  private readonly listeners = new Map<string, Set<(event: unknown) => void>>();
+
+  addEventListener(type: string, listener: (event: unknown) => void): void {
+    const listeners = this.listeners.get(type) ?? new Set();
+    listeners.add(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  removeEventListener(type: string, listener: (event: unknown) => void): void {
+    this.listeners.get(type)?.delete(listener);
+  }
+
+  send(value: string): void {
+    this.sent.push(value);
+    const message = JSON.parse(value) as { type?: string };
+    if (message.type === 'start') {
+      this.emit('message', { data: JSON.stringify({ type: 'ready', protocol: VOICE_REALTIME_PROTOCOL }) });
+    }
+    if (message.type === 'finish') {
+      this.emit('message', {
+        data: JSON.stringify({ type: 'final', text: '最终文本', cleanup: 'success' }),
+      });
+    }
+  }
+
+  close(): void {
+    this.readyState = 3;
+    this.emit('close', {});
+  }
+
+  open(): void {
+    this.readyState = 1;
+    this.emit('open', {});
+  }
+
+  emit(type: string, event: unknown): void {
+    for (const listener of this.listeners.get(type) ?? []) listener(event);
+  }
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('voice realtime client protocol', () => {
+  it('validates server events and keeps the final text distinct from preview', () => {
+    expect(parseVoiceRealtimeMessage(JSON.stringify({
+      type: 'preview',
+      text: '临时',
+      stash: '尾部',
+    }))).toEqual({ type: 'preview', text: '临时', stash: '尾部' });
+    expect(parseVoiceRealtimeMessage(JSON.stringify({
+      type: 'final',
+      text: '最终',
+      cleanup: 'success',
+    }))).toEqual({ type: 'final', text: '最终', cleanup: 'success' });
+    expect(parseVoiceRealtimeMessage(JSON.stringify({ type: 'ready', protocol: 'other' }))).toBeNull();
+  });
+
+  it('encodes little-endian PCM as base64', () => {
+    expect(encodeVoiceRealtimePcm(new Int16Array([0x0102, -2]))).toBe('AgH+/w==');
+  });
+
+  it('buffers the first PCM chunks until the upstream handshake is ready', async () => {
+    vi.stubGlobal('WebSocket', { OPEN: 1 });
+    const socket = new FakeSocket();
+    const session = new VoiceRealtimeSession({
+      before: '',
+      after: '',
+      openSocket: async () => socket as unknown as WebSocket,
+    });
+    const start = session.start();
+    expect(session.sendPcm(new Int16Array([1]))).toBe(true);
+    socket.open();
+    await start;
+    expect(socket.sent.some((frame) => JSON.parse(frame).type === 'audio')).toBe(true);
+    await expect(session.finish()).resolves.toEqual({
+      text: '最终文本',
+      cleanup: 'success',
+    });
+  });
+});

--- a/ui/src/lib/voiceRealtime.ts
+++ b/ui/src/lib/voiceRealtime.ts
@@ -1,0 +1,245 @@
+import {
+  CloudUnavailableError,
+  openAvibeWebSocket,
+  type AvibeWebSocket,
+} from './avibeFetch';
+
+export const VOICE_REALTIME_PATH = '/api/cloud/voice/realtime';
+export const VOICE_REALTIME_PROTOCOL = 'avibe-asr-v1';
+export const VOICE_REALTIME_HANDSHAKE_TIMEOUT_MS = 8_000;
+export const VOICE_REALTIME_FINISH_TIMEOUT_MS = 20_000;
+const MAX_PENDING_AUDIO_FRAMES = 128;
+
+export type VoiceRealtimePreview = { text: string; stash: string };
+export type VoiceRealtimeFinal = { text: string; cleanup: 'success' | 'fallback' };
+
+export type VoiceRealtimeOptions = {
+  before: string;
+  after: string;
+  language?: string;
+  signal?: AbortSignal;
+  openSocket?: (
+    path: string,
+    protocol: string,
+    signal?: AbortSignal,
+  ) => Promise<AvibeWebSocket>;
+  onReady?: () => void;
+  onPreview?: (preview: VoiceRealtimePreview) => void;
+};
+
+const asError = (code: string): Error => {
+  const error = new Error(code);
+  error.name = 'VoiceRealtimeError';
+  return error;
+};
+
+export const encodeVoiceRealtimePcm = (samples: Int16Array<ArrayBuffer>): string => {
+  const bytes = new Uint8Array(samples.buffer, samples.byteOffset, samples.byteLength);
+  let binary = '';
+  const blockSize = 0x8000;
+  for (let offset = 0; offset < bytes.length; offset += blockSize) {
+    const block = bytes.subarray(offset, offset + blockSize);
+    binary += String.fromCharCode(...block);
+  }
+  return btoa(binary);
+};
+
+export const parseVoiceRealtimeMessage = (value: unknown):
+  | { type: 'ready'; protocol: string }
+  | { type: 'preview'; text: string; stash: string }
+  | { type: 'final'; text: string; cleanup: 'success' | 'fallback' }
+  | { type: 'error'; code: string }
+  | { type: 'finished' }
+  | null => {
+  if (typeof value !== 'string') return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(value);
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return null;
+  const message = parsed as Record<string, unknown>;
+  if (message.type === 'ready' && message.protocol === VOICE_REALTIME_PROTOCOL) {
+    return { type: 'ready', protocol: VOICE_REALTIME_PROTOCOL };
+  }
+  if (
+    message.type === 'preview'
+    && typeof message.text === 'string'
+    && typeof message.stash === 'string'
+  ) {
+    return { type: 'preview', text: message.text, stash: message.stash };
+  }
+  if (
+    message.type === 'final'
+    && typeof message.text === 'string'
+    && (message.cleanup === 'success' || message.cleanup === 'fallback')
+  ) {
+    return { type: 'final', text: message.text, cleanup: message.cleanup };
+  }
+  if (message.type === 'error' && typeof message.code === 'string') {
+    return { type: 'error', code: message.code };
+  }
+  if (message.type === 'finished') return { type: 'finished' };
+  return null;
+};
+
+const waitWithTimeout = <T>(promise: Promise<T>, timeoutMs: number): Promise<T> => {
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  return new Promise<T>((resolve, reject) => {
+    timer = setTimeout(() => reject(asError('realtime_timeout')), timeoutMs);
+    promise.then(
+      (value) => {
+        if (timer != null) clearTimeout(timer);
+        resolve(value);
+      },
+      (error) => {
+        if (timer != null) clearTimeout(timer);
+        reject(error);
+      },
+    );
+  });
+};
+
+export class VoiceRealtimeSession {
+  private readonly options: VoiceRealtimeOptions;
+  private readonly openSocket: NonNullable<VoiceRealtimeOptions['openSocket']>;
+  private socket: AvibeWebSocket | null = null;
+  private ready = false;
+  private finished = false;
+  private aborted = false;
+  private startPromise: Promise<void> | null = null;
+  private finalPromise: Promise<VoiceRealtimeFinal> | null = null;
+  private finalResolve: ((value: VoiceRealtimeFinal) => void) | null = null;
+  private finalReject: ((error: unknown) => void) | null = null;
+  private pendingAudio: string[] = [];
+
+  constructor(options: VoiceRealtimeOptions) {
+    this.options = options;
+    this.openSocket = options.openSocket ?? openAvibeWebSocket;
+  }
+
+  async start(): Promise<void> {
+    if (this.startPromise) return this.startPromise;
+    this.startPromise = this.connect();
+    return this.startPromise;
+  }
+
+  private async connect(): Promise<void> {
+    const socket = await this.openSocket(
+      VOICE_REALTIME_PATH,
+      VOICE_REALTIME_PROTOCOL,
+      this.options.signal,
+    );
+    this.socket = socket;
+    const readyPromise = new Promise<void>((resolve, reject) => {
+      const onMessage = (event: MessageEvent) => {
+        const message = parseVoiceRealtimeMessage(event.data);
+        if (!message) return;
+        if (message.type === 'ready') {
+          this.ready = true;
+          socket.removeEventListener('message', onMessage);
+          this.options.onReady?.();
+          resolve();
+        }
+      };
+      socket.addEventListener('message', onMessage);
+      socket.addEventListener('error', () => reject(asError('realtime_socket_error')), { once: true });
+      socket.addEventListener('close', () => reject(asError('realtime_closed')), { once: true });
+    });
+    socket.addEventListener('message', (event) => this.handleMessage(event));
+    socket.addEventListener('error', () => this.rejectFinal(asError('realtime_socket_error')), { once: true });
+    socket.addEventListener('close', () => {
+      if (!this.finished && !this.aborted) this.rejectFinal(asError('realtime_closed'));
+    }, { once: true });
+    await waitWithTimeout(new Promise<void>((resolve, reject) => {
+      const sendStart = () => {
+        try {
+          socket.send(JSON.stringify({
+            type: 'start',
+            before: this.options.before,
+            after: this.options.after,
+            ...(this.options.language ? { language: this.options.language } : {}),
+          }));
+          resolve();
+        } catch (error) {
+          reject(error);
+        }
+      };
+      if (socket.readyState === WebSocket.OPEN) sendStart();
+      else socket.addEventListener('open', sendStart, { once: true });
+    }), VOICE_REALTIME_HANDSHAKE_TIMEOUT_MS);
+    await waitWithTimeout(readyPromise, VOICE_REALTIME_HANDSHAKE_TIMEOUT_MS);
+    while (this.pendingAudio.length > 0 && this.socket?.readyState === WebSocket.OPEN) {
+      this.socket.send(JSON.stringify({ type: 'audio', audio: this.pendingAudio.shift() }));
+    }
+  }
+
+  private handleMessage(event: MessageEvent): void {
+    const message = parseVoiceRealtimeMessage(event.data);
+    if (!message) return;
+    if (message.type === 'preview') {
+      this.options.onPreview?.(message);
+    } else if (message.type === 'final') {
+      this.finished = true;
+      this.finalResolve?.({ text: message.text, cleanup: message.cleanup });
+      this.finalResolve = null;
+      this.finalReject = null;
+    } else if (message.type === 'error') {
+      this.rejectFinal(asError(message.code));
+    }
+  }
+
+  sendPcm(samples: Int16Array<ArrayBuffer>): boolean {
+    if (this.finished || this.aborted) {
+      return false;
+    }
+    const audio = encodeVoiceRealtimePcm(samples);
+    if (!this.ready || this.socket?.readyState !== WebSocket.OPEN) {
+      if (this.pendingAudio.length >= MAX_PENDING_AUDIO_FRAMES) return false;
+      this.pendingAudio.push(audio);
+      return true;
+    }
+    try {
+      this.socket.send(JSON.stringify({ type: 'audio', audio }));
+      return true;
+    } catch {
+      this.rejectFinal(asError('realtime_socket_error'));
+      return false;
+    }
+  }
+
+  finish(): Promise<VoiceRealtimeFinal> {
+    if (this.finalPromise) return this.finalPromise;
+    this.finalPromise = new Promise<VoiceRealtimeFinal>((resolve, reject) => {
+      this.finalResolve = resolve;
+      this.finalReject = reject;
+      void this.start().then(() => {
+        if (this.aborted || this.finished || !this.socket) return;
+        this.socket.send(JSON.stringify({ type: 'finish' }));
+      }).catch(reject);
+    });
+    return waitWithTimeout(this.finalPromise, VOICE_REALTIME_FINISH_TIMEOUT_MS);
+  }
+
+  abort(): void {
+    this.aborted = true;
+    this.socket?.close(1000, 'aborted');
+    this.rejectFinal(asError('realtime_aborted'));
+  }
+
+  private rejectFinal(error: unknown): void {
+    if (this.finished || this.aborted) return;
+    this.finalReject?.(error);
+    this.finalResolve = null;
+    this.finalReject = null;
+  }
+}
+
+export const isVoiceRealtimeEnabled = (): boolean =>
+  import.meta.env.VITE_VOICE_REALTIME_ENABLED === 'true';
+
+export const voiceRealtimeError = (error: unknown): Error => {
+  if (error instanceof CloudUnavailableError) return error;
+  return error instanceof Error ? error : asError('realtime_failed');
+};

--- a/ui/src/lib/voiceRealtime.ts
+++ b/ui/src/lib/voiceRealtime.ts
@@ -112,6 +112,7 @@ export class VoiceRealtimeSession {
   private finalPromise: Promise<VoiceRealtimeFinal> | null = null;
   private finalResolve: ((value: VoiceRealtimeFinal) => void) | null = null;
   private finalReject: ((error: unknown) => void) | null = null;
+  private terminalError: unknown | null = null;
   private pendingAudio: string[] = [];
 
   constructor(options: VoiceRealtimeOptions) {
@@ -211,15 +212,22 @@ export class VoiceRealtimeSession {
 
   finish(): Promise<VoiceRealtimeFinal> {
     if (this.finalPromise) return this.finalPromise;
-    this.finalPromise = new Promise<VoiceRealtimeFinal>((resolve, reject) => {
+    const pending = new Promise<VoiceRealtimeFinal>((resolve, reject) => {
       this.finalResolve = resolve;
       this.finalReject = reject;
+      if (this.terminalError) {
+        reject(this.terminalError);
+        this.finalResolve = null;
+        this.finalReject = null;
+        return;
+      }
       void this.start().then(() => {
         if (this.aborted || this.finished || !this.socket) return;
         this.socket.send(JSON.stringify({ type: 'finish' }));
       }).catch(reject);
     });
-    return waitWithTimeout(this.finalPromise, VOICE_REALTIME_FINISH_TIMEOUT_MS);
+    this.finalPromise = waitWithTimeout(pending, VOICE_REALTIME_FINISH_TIMEOUT_MS);
+    return this.finalPromise;
   }
 
   abort(): void {
@@ -230,6 +238,7 @@ export class VoiceRealtimeSession {
 
   private rejectFinal(error: unknown): void {
     if (this.finished || this.aborted) return;
+    this.terminalError ??= error;
     this.finalReject?.(error);
     this.finalResolve = null;
     this.finalReject = null;

--- a/ui/src/lib/voiceRealtime.ts
+++ b/ui/src/lib/voiceRealtime.ts
@@ -25,6 +25,7 @@ export type VoiceRealtimeOptions = {
   ) => Promise<AvibeWebSocket>;
   onReady?: () => void;
   onPreview?: (preview: VoiceRealtimePreview) => void;
+  onError?: (error: Error) => void;
 };
 
 const asError = (code: string): Error => {
@@ -113,6 +114,7 @@ export class VoiceRealtimeSession {
   private finalResolve: ((value: VoiceRealtimeFinal) => void) | null = null;
   private finalReject: ((error: unknown) => void) | null = null;
   private terminalError: unknown | null = null;
+  private errorNotified = false;
   private pendingAudio: string[] = [];
 
   constructor(options: VoiceRealtimeOptions) {
@@ -133,46 +135,75 @@ export class VoiceRealtimeSession {
       this.options.signal,
     );
     this.socket = socket;
-    const readyPromise = new Promise<void>((resolve, reject) => {
-      const onMessage = (event: MessageEvent) => {
-        const message = parseVoiceRealtimeMessage(event.data);
-        if (!message) return;
-        if (message.type === 'ready') {
-          this.ready = true;
-          socket.removeEventListener('message', onMessage);
-          this.options.onReady?.();
-          resolve();
-        }
-      };
-      socket.addEventListener('message', onMessage);
-      socket.addEventListener('error', () => reject(asError('realtime_socket_error')), { once: true });
-      socket.addEventListener('close', () => reject(asError('realtime_closed')), { once: true });
-    });
+    let openReject: ((error: unknown) => void) | null = null;
+    let readyReject: ((error: unknown) => void) | null = null;
+    let openListener: ((event: unknown) => void) | null = null;
+    let readyListener: ((event: unknown) => void) | null = null;
+    const cleanupHandshakeListeners = (): void => {
+      if (openListener) socket.removeEventListener('open', openListener);
+      if (readyListener) socket.removeEventListener('message', readyListener);
+      openListener = null;
+      readyListener = null;
+      openReject = null;
+      readyReject = null;
+    };
+    const failHandshake = (error: unknown): void => {
+      const normalized = this.fail(error);
+      openReject?.(normalized);
+      readyReject?.(normalized);
+    };
+    const onSocketError = (): void => failHandshake(asError('realtime_socket_error'));
+    const onSocketClose = (): void => {
+      if (!this.finished && !this.aborted) failHandshake(asError('realtime_closed'));
+    };
+    socket.addEventListener('error', onSocketError);
+    socket.addEventListener('close', onSocketClose);
     socket.addEventListener('message', (event) => this.handleMessage(event));
-    socket.addEventListener('error', () => this.rejectFinal(asError('realtime_socket_error')), { once: true });
-    socket.addEventListener('close', () => {
-      if (!this.finished && !this.aborted) this.rejectFinal(asError('realtime_closed'));
-    }, { once: true });
-    await waitWithTimeout(new Promise<void>((resolve, reject) => {
-      const sendStart = () => {
-        try {
-          socket.send(JSON.stringify({
-            type: 'start',
-            before: this.options.before,
-            after: this.options.after,
-            ...(this.options.language ? { language: this.options.language } : {}),
-          }));
-          resolve();
-        } catch (error) {
-          reject(error);
-        }
+
+    const openPromise = new Promise<void>((resolve, reject) => {
+      openReject = reject;
+      openListener = () => {
+        if (openListener) socket.removeEventListener('open', openListener);
+        openListener = null;
+        resolve();
       };
-      if (socket.readyState === WebSocket.OPEN) sendStart();
-      else socket.addEventListener('open', sendStart, { once: true });
-    }), VOICE_REALTIME_HANDSHAKE_TIMEOUT_MS);
-    await waitWithTimeout(readyPromise, VOICE_REALTIME_HANDSHAKE_TIMEOUT_MS);
-    while (this.pendingAudio.length > 0 && this.socket?.readyState === WebSocket.OPEN) {
-      this.socket.send(JSON.stringify({ type: 'audio', audio: this.pendingAudio.shift() }));
+      if (socket.readyState === WebSocket.OPEN) resolve();
+      else if (socket.readyState === WebSocket.CLOSED) failHandshake(asError('realtime_closed'));
+      else socket.addEventListener('open', openListener);
+    });
+    const readyPromise = new Promise<void>((resolve, reject) => {
+      readyReject = reject;
+      readyListener = (event: unknown) => {
+        const message = parseVoiceRealtimeMessage((event as MessageEvent).data);
+        if (!message || message.type !== 'ready') return;
+        this.ready = true;
+        if (readyListener) socket.removeEventListener('message', readyListener);
+        readyListener = null;
+        this.options.onReady?.();
+        resolve();
+      };
+      socket.addEventListener('message', readyListener);
+    });
+    // The ready promise may reject while the open phase is still pending. Keep
+    // that rejection observed until the sequential handshake awaits it.
+    void readyPromise.catch(() => undefined);
+    try {
+      await waitWithTimeout(openPromise, VOICE_REALTIME_HANDSHAKE_TIMEOUT_MS);
+      socket.send(JSON.stringify({
+        type: 'start',
+        before: this.options.before,
+        after: this.options.after,
+        ...(this.options.language ? { language: this.options.language } : {}),
+      }));
+      await waitWithTimeout(readyPromise, VOICE_REALTIME_HANDSHAKE_TIMEOUT_MS);
+      while (this.pendingAudio.length > 0 && this.socket?.readyState === WebSocket.OPEN) {
+        this.socket.send(JSON.stringify({ type: 'audio', audio: this.pendingAudio.shift() }));
+      }
+    } catch (error) {
+      this.fail(error);
+      throw error;
+    } finally {
+      cleanupHandshakeListeners();
     }
   }
 
@@ -192,7 +223,7 @@ export class VoiceRealtimeSession {
   }
 
   sendPcm(samples: Int16Array<ArrayBuffer>): boolean {
-    if (this.finished || this.aborted) {
+    if (this.finished || this.aborted || this.terminalError) {
       return false;
     }
     const audio = encodeVoiceRealtimePcm(samples);
@@ -226,7 +257,10 @@ export class VoiceRealtimeSession {
         this.socket.send(JSON.stringify({ type: 'finish' }));
       }).catch(reject);
     });
-    this.finalPromise = waitWithTimeout(pending, VOICE_REALTIME_FINISH_TIMEOUT_MS);
+    this.finalPromise = waitWithTimeout(pending, VOICE_REALTIME_FINISH_TIMEOUT_MS).catch((error) => {
+      this.fail(error);
+      throw error;
+    });
     return this.finalPromise;
   }
 
@@ -237,11 +271,28 @@ export class VoiceRealtimeSession {
   }
 
   private rejectFinal(error: unknown): void {
-    if (this.finished || this.aborted) return;
-    this.terminalError ??= error;
-    this.finalReject?.(error);
+    this.fail(error);
+  }
+
+  private fail(error: unknown): Error {
+    const normalized = error instanceof Error ? error : asError('realtime_failed');
+    if (this.finished || this.aborted) return normalized;
+    const firstFailure = this.terminalError === null;
+    this.terminalError ??= normalized;
+    if (!firstFailure) {
+      return this.terminalError instanceof Error ? this.terminalError : normalized;
+    }
+    if (!this.errorNotified) {
+      this.errorNotified = true;
+      this.options.onError?.(normalized);
+    }
+    this.finalReject?.(normalized);
     this.finalResolve = null;
     this.finalReject = null;
+    if (this.socket && this.socket.readyState !== WebSocket.CLOSED) {
+      this.socket.close(4000, normalized.message.slice(0, 120));
+    }
+    return normalized;
   }
 }
 

--- a/ui/src/lib/voiceRecording.test.ts
+++ b/ui/src/lib/voiceRecording.test.ts
@@ -52,6 +52,7 @@ const setup = (options: {
     getTracks: () => [track],
   } as unknown as MediaStream;
   const onSegment = vi.fn<(blob: Blob, metadata: { durationMs: number }) => void>();
+  const onPcm = vi.fn<(samples: Int16Array) => void>();
   const onError = vi.fn();
   const onStopRequested = vi.fn();
   const onStopped = vi.fn();
@@ -63,6 +64,7 @@ const setup = (options: {
     maxFileBytes: options.maxFileBytes,
     overlapMs: options.overlapMs ?? 0,
     onSegment,
+    onPcm,
     onError,
     onStopRequested,
     onStopped,
@@ -82,6 +84,7 @@ const setup = (options: {
     capture: () => capture!,
     onError,
     onSegment,
+    onPcm,
     onStopRequested,
     onStopped,
     pipeline,
@@ -111,6 +114,16 @@ afterEach(() => {
 });
 
 describe('VoiceRecordingPipeline', () => {
+  it('delivers short PCM frames independently of WAV segmentation', async () => {
+    const { capture, onPcm, onSegment, pipeline } = setup();
+    await pipeline.start();
+    capture().emit(1, 2, 3);
+
+    expect(onPcm).toHaveBeenCalledTimes(1);
+    expect(Array.from(onPcm.mock.calls[0]?.[0] ?? [])).toEqual([1, 2, 3]);
+    expect(onSegment).not.toHaveBeenCalled();
+  });
+
   it('frames delayed PCM delivery into provider-safe segments by sample count', async () => {
     const { capture, onSegment, pipeline } = setup();
     await pipeline.start();

--- a/ui/src/lib/voiceRecording.ts
+++ b/ui/src/lib/voiceRecording.ts
@@ -349,6 +349,7 @@ export type VoiceRecordingPipelineOptions = {
   stream: MediaStream;
   segmentMs: number;
   onSegment: (blob: Blob, metadata: VoiceRecordingSegmentMetadata) => void;
+  onPcm?: (samples: Int16Array<ArrayBuffer>) => void;
   onStopRequested?: (
     reason: VoiceRecordingStopReason,
     metadata: VoiceRecordingStopMetadata,
@@ -525,6 +526,7 @@ export class VoiceRecordingPipeline {
 
   private handleSamples(samples: Int16Array<ArrayBuffer>): void {
     if (this.stopped || this.stopping === 'abort') return;
+    this.options.onPcm?.(samples);
     let offset = 0;
     while (offset < samples.length) {
       const available = this.segmentSamples - this.segmentSampleCount;

--- a/ui/src/lib/voiceTelemetry.ts
+++ b/ui/src/lib/voiceTelemetry.ts
@@ -27,6 +27,9 @@ export type VoiceTelemetryEvent = {
   backlogAtStop?: number;
   totalDurationMs?: number;
   stopToInsertionMs?: number;
+  realtime?: boolean;
+  firstPreviewMs?: number;
+  stopToFinalMs?: number;
   retry?: boolean;
 };
 

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -8201,6 +8201,8 @@ def asr_telemetry():
         "backlogAtStop",
         "totalDurationMs",
         "stopToInsertionMs",
+        "firstPreviewMs",
+        "stopToFinalMs",
     }
     for key in integer_fields:
         if key not in payload:
@@ -8224,6 +8226,11 @@ def asr_telemetry():
         if not isinstance(payload["retry"], bool):
             return jsonify({"error": "invalid_field", "field": "retry"}), 400
         sanitized["retry"] = payload["retry"]
+
+    if "realtime" in payload:
+        if not isinstance(payload["realtime"], bool):
+            return jsonify({"error": "invalid_field", "field": "realtime"}), 400
+        sanitized["realtime"] = payload["realtime"]
 
     logger.info(
         "voice_reliability %s",


### PR DESCRIPTION
## Capability

This PR adds an opt-in realtime voice recording path to the composer. It streams PCM worklet frames over the existing authenticated cloud connection, renders a muted live preview, and inserts only the server-cleaned final result when recording stops.

The existing HTTP transcription, receipt, retry, and UI control contracts remain intact. Realtime is disabled unless `VITE_VOICE_REALTIME_ENABLED=true`; handshake, transport, or finalization failures fall back to the existing HTTP queue without losing the recording.

## Rollout and contract

- Deploy the companion backend route first, then enable this client flag for a controlled regression cohort.
- Preview text is display-only and never mutates the composer draft.
- Stop inserts one final server-owned cleaned transcript atomically.
- Disable the flag to return immediately to the legacy HTTP flow.

The backend PR is the contract dependency for this client PR.

## Evidence

- Focused voice tests: `58 passed`.
- Full UI test suite: `1574 passed` across `126` test files.
- Lint passed for 550 sources.
- Vite production build passed.
- Python telemetry contract test: `8 passed`.
- `git diff --check` passed.
- Scenario coverage includes PCM framing, buffering before realtime readiness, preview/final parsing, cancellation, fallback to HTTP, telemetry sanitization, and the existing voice controls.
- Residual manual check: deploy both sides with the flag enabled and verify a real browser recording against the legacy path; no live upstream WebSocket smoke was run from this local worktree.

## Known-by-design ledger

- Feature flags default to off.
- Preview is non-authoritative.
- Existing HTTP fallback and retry behavior remains the compatibility path.
- This prototype does not remove the legacy recording flow.
- Review-loop circuit-breaker decision: socket failure handling is owned by one realtime
  session lifecycle. Open/ready/finalization timeouts, early closes, and active transport
  failures, including capture errors, close the socket and activate the same existing HTTP
  fallback queue.
