### PR TITLE
feat(memory): add durable capture foundation

### DIFF
--- a/core/memory/__init__.py
+++ b/core/memory/__init__.py
@@ -20,6 +20,7 @@ from core.memory.types import (
     MemoryResult,
     MemoryStatus,
     OperationFailed,
+    ProviderSessionRef,
 )
 
 __all__ = [
@@ -42,4 +43,5 @@ __all__ = [
     "MemoryResult",
     "MemoryStatus",
     "OperationFailed",
+    "ProviderSessionRef",
 ]

--- a/core/memory/everos.py
+++ b/core/memory/everos.py
@@ -274,6 +274,9 @@ class EverOSPort:
                     except MemoryProviderFailure:
                         raw = None
                     status_code = response.status_code
+        except httpx.ConnectTimeout as exc:
+            logger.warning("EverOS sidecar connection timeout route=%s latency_ms=%s", route, _elapsed_ms(started))
+            raise MemoryProviderSystemFailure() from exc
         except httpx.TimeoutException as exc:
             logger.warning("EverOS sidecar timeout route=%s latency_ms=%s", route, _elapsed_ms(started))
             raise MemoryProviderFailure("memory_provider_timeout") from exc

--- a/core/memory/everos.py
+++ b/core/memory/everos.py
@@ -277,7 +277,12 @@ class EverOSPort:
         except httpx.TimeoutException as exc:
             logger.warning("EverOS sidecar timeout route=%s latency_ms=%s", route, _elapsed_ms(started))
             raise MemoryProviderFailure("memory_provider_timeout") from exc
-        except (httpx.ReadError, httpx.RemoteProtocolError) as exc:
+        except (
+            httpx.ReadError,
+            httpx.RemoteProtocolError,
+            httpx.WriteError,
+            httpx.CloseError,
+        ) as exc:
             logger.warning(
                 "EverOS sidecar response lost route=%s latency_ms=%s",
                 route,

--- a/core/memory/everos.py
+++ b/core/memory/everos.py
@@ -881,7 +881,7 @@ class FakeMemoryProvider:
         if self.ingest_failures:
             raise self.ingest_failures.popleft()
         self.captures.append(capture)
-        return AddAck(request_id=None, status="accumulated")
+        return AddAck(request_id=f"fake-add-{len(self.captures)}", status="accumulated")
 
     async def flush(self, session_ref: str, project_id: str) -> FlushResult:
         self.flushes.append(session_ref)

--- a/core/memory/everos.py
+++ b/core/memory/everos.py
@@ -75,6 +75,7 @@ class MemoryProviderFailure(RuntimeError):
         error: MemoryErrorCode = "memory_processing_failed",
         *,
         retryable: bool = True,
+        ambiguous: bool = False,
     ) -> None:
         closed_error: MemoryErrorCode = (
             error if is_memory_error_code(error) else "memory_processing_failed"
@@ -82,6 +83,7 @@ class MemoryProviderFailure(RuntimeError):
         super().__init__(closed_error)
         self.error = closed_error
         self.retryable = bool(retryable)
+        self.ambiguous = bool(ambiguous)
 
 
 class MemoryProviderSystemFailure(MemoryProviderFailure):
@@ -90,11 +92,13 @@ class MemoryProviderSystemFailure(MemoryProviderFailure):
     def __init__(
         self,
         error: MemoryErrorCode = "memory_sidecar_unavailable",
+        *,
+        ambiguous: bool = False,
     ) -> None:
         closed_error: MemoryErrorCode = (
             error if is_memory_error_code(error) else "memory_sidecar_unavailable"
         )
-        super().__init__(closed_error, retryable=True)
+        super().__init__(closed_error, retryable=True, ambiguous=ambiguous)
 
 
 class EverOSPort:
@@ -198,7 +202,7 @@ class EverOSPort:
         elif status is not None and status not in {"accumulated", "extracted"}:
             logger.warning("EverOS add returned an unsupported status value")
         return AddAck(
-            request_id=_bounded_opaque_string(envelope.get("request_id") if envelope else None),
+            request_id=_strict_receipt_id(envelope.get("request_id") if envelope else None),
             status=status if status in {"accumulated", "extracted"} else None,
         )
 
@@ -273,6 +277,13 @@ class EverOSPort:
         except httpx.TimeoutException as exc:
             logger.warning("EverOS sidecar timeout route=%s latency_ms=%s", route, _elapsed_ms(started))
             raise MemoryProviderFailure("memory_provider_timeout") from exc
+        except (httpx.ReadError, httpx.RemoteProtocolError) as exc:
+            logger.warning(
+                "EverOS sidecar response lost route=%s latency_ms=%s",
+                route,
+                _elapsed_ms(started),
+            )
+            raise MemoryProviderSystemFailure(ambiguous=True) from exc
         except (httpx.HTTPError, OSError) as exc:
             logger.warning("EverOS sidecar unavailable route=%s latency_ms=%s", route, _elapsed_ms(started))
             raise MemoryProviderSystemFailure() from exc
@@ -802,6 +813,12 @@ def _bounded_opaque_string(value: object, *, max_bytes: int = 128) -> str | None
     if len(raw) <= max_bytes:
         return value
     return raw[:max_bytes].decode("utf-8", errors="ignore")
+
+
+def _strict_receipt_id(value: object, *, max_bytes: int = 128) -> str | None:
+    if not isinstance(value, str):
+        return None
+    return value if len(value.encode("utf-8")) <= max_bytes else None
 
 
 def _optional_json_object(raw: bytes | None) -> dict[str, Any] | None:

--- a/core/memory/module.py
+++ b/core/memory/module.py
@@ -353,6 +353,7 @@ class MemoryModule:
         try:
             meta = await self._store_call(self._store.get_meta)
             stats = await self._store_call(self._store.queue_stats)
+            manual_required = await self._store_call(self._store.has_manual_required_fence)
         except Exception:
             return MemoryStatus(state="error", error="memory_store_unavailable")
 
@@ -412,6 +413,13 @@ class MemoryModule:
                 meta=meta,
                 stats=stats,
                 error="memory_low_disk_space",
+            )
+        if manual_required:
+            return await self._status(
+                "degraded",
+                meta=meta,
+                stats=stats,
+                error="memory_processing_failed",
             )
         if active_error is not None:
             return await self._status("degraded", meta=meta, stats=stats, error=active_error)

--- a/core/memory/runtime.py
+++ b/core/memory/runtime.py
@@ -1401,7 +1401,7 @@ class MemoryRuntime:
                 raise
             except Exception:
                 logger.warning("Memory drain activation failed; retrying recovery")
-                self.module._worker.begin_activation()
+                self.module._worker.begin_new_lease_activation()
             await asyncio.sleep(1.0)
 
     def _data_exists(self) -> bool:

--- a/core/memory/schema.sql
+++ b/core/memory/schema.sql
@@ -33,6 +33,7 @@ CREATE TABLE IF NOT EXISTS memory_capture_queue (
     source_message_digest TEXT PRIMARY KEY,
     epoch INTEGER NOT NULL,
     session_id TEXT NOT NULL,
+    provider_session_ref TEXT NOT NULL,
     principal_id TEXT NOT NULL CHECK (
         length(principal_id) = 34
         AND substr(principal_id, 1, 2) = 'u-'
@@ -48,7 +49,10 @@ CREATE TABLE IF NOT EXISTS memory_capture_queue (
     payload_attachments TEXT,
     occurred_at_ms INTEGER NOT NULL,
     provider_timestamp_ms INTEGER NOT NULL,
-    state TEXT NOT NULL CHECK (state IN ('pending', 'processing', 'delivered', 'dead')),
+    flush_generation INTEGER NOT NULL DEFAULT 0 CHECK (flush_generation >= 0),
+    state TEXT NOT NULL CHECK (
+        state IN ('pending', 'processing', 'delivered', 'dead', 'manual_required')
+    ),
     attempts INTEGER NOT NULL DEFAULT 0 CHECK (attempts >= 0),
     next_retry_at TEXT,
     lease_owner TEXT,
@@ -78,10 +82,88 @@ CREATE TABLE IF NOT EXISTS memory_capture_queue (
     created_at TEXT NOT NULL,
     completed_at TEXT,
     CHECK (
-        (state IN ('pending', 'processing') AND payload_text IS NOT NULL)
+        (state IN ('pending', 'processing', 'manual_required') AND payload_text IS NOT NULL)
         OR (state IN ('delivered', 'dead') AND payload_text IS NULL)
     )
 );
 
 CREATE INDEX IF NOT EXISTS ix_memory_capture_due
     ON memory_capture_queue (epoch, state, next_retry_at);
+
+CREATE INDEX IF NOT EXISTS ix_memory_capture_session_flush
+    ON memory_capture_queue (
+        epoch, provider_session_ref, flush_generation, state, flush_observation
+    );
+
+-- Version 2 coordination state for the later session flush coordinator.
+CREATE TABLE IF NOT EXISTS memory_session_flush_state (
+    provider_session_ref TEXT PRIMARY KEY,
+    principal_id TEXT NOT NULL CHECK (
+        length(principal_id) = 34
+        AND substr(principal_id, 1, 2) = 'u-'
+        AND substr(principal_id, 3) NOT GLOB '*[^0-9a-f]*'
+    ),
+    epoch INTEGER NOT NULL CHECK (epoch >= 0),
+    project_ref TEXT NOT NULL CHECK (
+        length(project_ref) = 34
+        AND substr(project_ref, 1, 2) = 'p-'
+        AND substr(project_ref, 3) NOT GLOB '*[^0-9a-f]*'
+    ),
+    session_id TEXT NOT NULL,
+    generation INTEGER NOT NULL DEFAULT 0 CHECK (generation >= 0),
+    first_unflushed_at TEXT,
+    last_add_ack_at TEXT,
+    due_at TEXT,
+    next_attempt_at TEXT,
+    flush_state TEXT NOT NULL DEFAULT 'not_due' CHECK (
+        flush_state IN ('not_due', 'due', 'in_flight', 'manual_required')
+    ),
+    watermark_ms INTEGER NOT NULL DEFAULT 0 CHECK (watermark_ms >= 0),
+    fence_epoch INTEGER NOT NULL DEFAULT 0 CHECK (fence_epoch >= 0),
+    fence_owner TEXT,
+    fence_acquired_at TEXT,
+    updated_at TEXT NOT NULL,
+    UNIQUE (principal_id, epoch, project_ref, session_id)
+);
+
+CREATE INDEX IF NOT EXISTS ix_memory_session_flush_due
+    ON memory_session_flush_state (flush_state, due_at, next_attempt_at);
+
+-- Settlement history is append-only. A later coordinator can project the
+-- latest generation without treating a mutable live row as historical proof.
+CREATE TABLE IF NOT EXISTS memory_flush_settlements (
+    settlement_id TEXT PRIMARY KEY,
+    provider_session_ref TEXT NOT NULL,
+    generation INTEGER NOT NULL CHECK (generation >= 0),
+    fence_epoch INTEGER NOT NULL CHECK (fence_epoch >= 0),
+    operation_id TEXT NOT NULL,
+    operation_kind TEXT NOT NULL CHECK (operation_kind IN ('add', 'flush')),
+    outcome TEXT NOT NULL CHECK (
+        outcome IN ('succeeded', 'rejected', 'unknown', 'manual_required')
+    ),
+    last_known_state TEXT,
+    last_observed_outcome TEXT CHECK (
+        last_observed_outcome IS NULL OR last_observed_outcome IN (
+            'succeeded', 'rejected', 'unknown', 'manual_required', 'in_flight'
+        )
+    ),
+    request_id TEXT,
+    error_code TEXT,
+    watermark_before INTEGER CHECK (watermark_before IS NULL OR watermark_before >= 0),
+    watermark_after INTEGER CHECK (watermark_after IS NULL OR watermark_after >= 0),
+    confirmed_watermark_ms INTEGER CHECK (
+        confirmed_watermark_ms IS NULL OR confirmed_watermark_ms >= 0
+    ),
+    flush_state TEXT CHECK (
+        flush_state IS NULL OR flush_state IN ('not_due', 'due', 'in_flight', 'manual_required')
+    ),
+    source TEXT CHECK (source IS NULL OR source IN ('add', 'flush')),
+    observed_at TEXT NOT NULL,
+    settled_at TEXT NOT NULL,
+    UNIQUE (provider_session_ref, generation, operation_id)
+);
+
+CREATE INDEX IF NOT EXISTS ix_memory_flush_settlements_session
+    ON memory_flush_settlements (provider_session_ref, generation, observed_at);
+
+PRAGMA user_version = 2;

--- a/core/memory/schema.sql
+++ b/core/memory/schema.sql
@@ -155,9 +155,13 @@ CREATE TABLE IF NOT EXISTS memory_flush_settlements (
         confirmed_watermark_ms IS NULL OR confirmed_watermark_ms >= 0
     ),
     flush_state TEXT CHECK (
-        flush_state IS NULL OR flush_state IN ('not_due', 'due', 'in_flight', 'manual_required')
+        flush_state IS NULL OR flush_state IN (
+            'not_due', 'due', 'in_flight', 'manual_required', 'settled'
+        )
     ),
-    source TEXT CHECK (source IS NULL OR source IN ('add', 'flush')),
+    source TEXT CHECK (
+        source IS NULL OR source IN ('add', 'flush', 'natural_boundary')
+    ),
     observed_at TEXT NOT NULL,
     settled_at TEXT NOT NULL,
     UNIQUE (provider_session_ref, generation, operation_id)

--- a/core/memory/schema.sql
+++ b/core/memory/schema.sql
@@ -49,7 +49,6 @@ CREATE TABLE IF NOT EXISTS memory_capture_queue (
     payload_attachments TEXT,
     occurred_at_ms INTEGER NOT NULL,
     provider_timestamp_ms INTEGER NOT NULL,
-    flush_generation INTEGER NOT NULL DEFAULT 0 CHECK (flush_generation >= 0),
     state TEXT NOT NULL CHECK (
         state IN ('pending', 'processing', 'delivered', 'dead', 'manual_required')
     ),
@@ -89,85 +88,3 @@ CREATE TABLE IF NOT EXISTS memory_capture_queue (
 
 CREATE INDEX IF NOT EXISTS ix_memory_capture_due
     ON memory_capture_queue (epoch, state, next_retry_at);
-
-CREATE INDEX IF NOT EXISTS ix_memory_capture_session_flush
-    ON memory_capture_queue (
-        epoch, provider_session_ref, flush_generation, state, flush_observation
-    );
-
--- Version 2 coordination state for the later session flush coordinator.
-CREATE TABLE IF NOT EXISTS memory_session_flush_state (
-    provider_session_ref TEXT PRIMARY KEY,
-    principal_id TEXT NOT NULL CHECK (
-        length(principal_id) = 34
-        AND substr(principal_id, 1, 2) = 'u-'
-        AND substr(principal_id, 3) NOT GLOB '*[^0-9a-f]*'
-    ),
-    epoch INTEGER NOT NULL CHECK (epoch >= 0),
-    project_ref TEXT NOT NULL CHECK (
-        length(project_ref) = 34
-        AND substr(project_ref, 1, 2) = 'p-'
-        AND substr(project_ref, 3) NOT GLOB '*[^0-9a-f]*'
-    ),
-    session_id TEXT NOT NULL,
-    generation INTEGER NOT NULL DEFAULT 0 CHECK (generation >= 0),
-    first_unflushed_at TEXT,
-    last_add_ack_at TEXT,
-    due_at TEXT,
-    next_attempt_at TEXT,
-    flush_state TEXT NOT NULL DEFAULT 'not_due' CHECK (
-        flush_state IN ('not_due', 'due', 'in_flight', 'manual_required')
-    ),
-    watermark_ms INTEGER NOT NULL DEFAULT 0 CHECK (watermark_ms >= 0),
-    fence_epoch INTEGER NOT NULL DEFAULT 0 CHECK (fence_epoch >= 0),
-    fence_owner TEXT,
-    fence_acquired_at TEXT,
-    updated_at TEXT NOT NULL,
-    UNIQUE (principal_id, epoch, project_ref, session_id)
-);
-
-CREATE INDEX IF NOT EXISTS ix_memory_session_flush_due
-    ON memory_session_flush_state (flush_state, due_at, next_attempt_at);
-
--- Settlement history is append-only. A later coordinator can project the
--- latest generation without treating a mutable live row as historical proof.
-CREATE TABLE IF NOT EXISTS memory_flush_settlements (
-    settlement_id TEXT PRIMARY KEY,
-    provider_session_ref TEXT NOT NULL,
-    generation INTEGER NOT NULL CHECK (generation >= 0),
-    fence_epoch INTEGER NOT NULL CHECK (fence_epoch >= 0),
-    operation_id TEXT NOT NULL,
-    operation_kind TEXT NOT NULL CHECK (operation_kind IN ('add', 'flush')),
-    outcome TEXT NOT NULL CHECK (
-        outcome IN ('succeeded', 'rejected', 'unknown', 'manual_required')
-    ),
-    last_known_state TEXT,
-    last_observed_outcome TEXT CHECK (
-        last_observed_outcome IS NULL OR last_observed_outcome IN (
-            'succeeded', 'rejected', 'unknown', 'manual_required', 'in_flight'
-        )
-    ),
-    request_id TEXT,
-    error_code TEXT,
-    watermark_before INTEGER CHECK (watermark_before IS NULL OR watermark_before >= 0),
-    watermark_after INTEGER CHECK (watermark_after IS NULL OR watermark_after >= 0),
-    confirmed_watermark_ms INTEGER CHECK (
-        confirmed_watermark_ms IS NULL OR confirmed_watermark_ms >= 0
-    ),
-    flush_state TEXT CHECK (
-        flush_state IS NULL OR flush_state IN (
-            'not_due', 'due', 'in_flight', 'manual_required', 'settled'
-        )
-    ),
-    source TEXT CHECK (
-        source IS NULL OR source IN ('add', 'flush', 'natural_boundary')
-    ),
-    observed_at TEXT NOT NULL,
-    settled_at TEXT NOT NULL,
-    UNIQUE (provider_session_ref, generation, operation_id)
-);
-
-CREATE INDEX IF NOT EXISTS ix_memory_flush_settlements_session
-    ON memory_flush_settlements (provider_session_ref, generation, observed_at);
-
-PRAGMA user_version = 2;

--- a/core/memory/store.py
+++ b/core/memory/store.py
@@ -954,8 +954,9 @@ class MemoryStore:
                         ('not_attempted', 'in_flight') THEN 1 ELSE 0 END) AS awaiting_receipt,
                     SUM(CASE WHEN state = 'delivered' AND flush_observation = 'succeeded'
                         THEN 1 ELSE 0 END) AS succeeded,
-                    SUM(CASE WHEN state = 'delivered' AND
-                        (flush_observation = 'unknown' OR flush_observation IS NULL)
+                    SUM(CASE WHEN state = 'manual_required'
+                        OR (state = 'delivered' AND
+                        (flush_observation = 'unknown' OR flush_observation IS NULL))
                         THEN 1 ELSE 0 END) AS receipt_unknown,
                     SUM(CASE WHEN state = 'delivered' AND flush_observation = 'rejected'
                         THEN 1 ELSE 0 END) AS distill_failed,

--- a/core/memory/store.py
+++ b/core/memory/store.py
@@ -18,7 +18,12 @@ from typing import Literal
 
 from config import paths
 from core.memory.observations import FlushRejected, FlushResult, FlushSucceeded, FlushUnknown
-from core.memory.types import MemoryErrorCode, MemoryFailureLogEntry, is_memory_error_code
+from core.memory.types import (
+    MemoryErrorCode,
+    MemoryFailureLogEntry,
+    ProviderSessionRef,
+    is_memory_error_code,
+)
 
 
 MEMORY_STORE_FILENAME = "memory.sqlite"
@@ -89,13 +94,15 @@ class QueueRow:
     source_message_digest: str
     epoch: int
     session_id: str
+    provider_session_ref: ProviderSessionRef
     principal_id: str
     project_ref: str
     provenance: Literal["user_input", "agent"]
     payload_text: str | None
     occurred_at_ms: int
     provider_timestamp_ms: int
-    state: Literal["pending", "processing", "delivered", "dead"]
+    flush_generation: int
+    state: Literal["pending", "processing", "delivered", "dead", "manual_required"]
     attempts: int
     next_retry_at: str | None
     lease_owner: str | None
@@ -149,6 +156,14 @@ class Delivered:
 
 
 @dataclass(frozen=True)
+class AmbiguousAdd:
+    """The provider response cannot prove whether this add was accepted."""
+
+    add_request_id: str | None = None
+    error: MemoryErrorCode = "memory_provider_response_invalid"
+
+
+@dataclass(frozen=True)
 class SystemOutage:
     """Infrastructure failed, not this row. Release it without spending an attempt."""
 
@@ -164,7 +179,7 @@ class MessageFailure:
 
 
 #: Every way a claimed row can leave the ``processing`` state.
-DeliveryOutcome = Delivered | SystemOutage | MessageFailure
+DeliveryOutcome = Delivered | AmbiguousAdd | SystemOutage | MessageFailure
 
 
 @dataclass(frozen=True)
@@ -173,7 +188,7 @@ class SettleResult:
 
     #: False when the fenced update matched no row — a lost or stolen lease.
     settled: bool
-    state: Literal["delivered", "pending", "dead"] | None = None
+    state: Literal["delivered", "pending", "dead", "manual_required"] | None = None
     #: Attempts consumed so far; only a MessageFailure spends one.
     attempts: int | None = None
 
@@ -299,12 +314,18 @@ class MemoryStore:
                 self._record_capture_skip_in_connection(conn, None, now)
                 return EnqueueResult(outcome="timestamp_invalid")
 
-            session_ref = _provider_session_ref(
+            session_id_ref = _provider_session_ref(
                 meta.scope_key,
                 principal_id,
                 project_ref,
                 session_id,
                 meta.epoch,
+            )
+            provider_session_ref = ProviderSessionRef(
+                principal_id=principal_id,
+                epoch=meta.epoch,
+                project_ref=project_ref,
+                session_id=session_id_ref,
             )
             conn.execute(
                 """
@@ -326,18 +347,21 @@ class MemoryStore:
             conn.execute(
                 """
                 INSERT INTO memory_capture_queue (
-                    source_message_digest, epoch, session_id, principal_id,
+                    source_message_digest, epoch, session_id, provider_session_ref,
+                    principal_id,
                     project_ref, provenance, payload_text,
-                    payload_attachments,
-                    occurred_at_ms, provider_timestamp_ms, state, attempts,
+                    payload_attachments, occurred_at_ms, provider_timestamp_ms,
+                    flush_generation, state, attempts,
                     next_retry_at, lease_owner, lease_at, last_error,
                     created_at, completed_at
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'pending', 0, NULL, NULL, NULL, NULL, ?, NULL)
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, 'pending', 0,
+                          NULL, NULL, NULL, NULL, ?, NULL)
                 """,
                 (
                     source_message_digest,
                     meta.epoch,
-                    session_ref,
+                    session_id_ref,
+                    provider_session_ref.serialize(),
                     principal_id,
                     project_ref,
                     provenance,
@@ -353,13 +377,15 @@ class MemoryStore:
                 row=QueueRow(
                     source_message_digest=source_message_digest,
                     epoch=meta.epoch,
-                    session_id=session_ref,
+                    session_id=session_id_ref,
+                    provider_session_ref=provider_session_ref,
                     principal_id=principal_id,
                     project_ref=project_ref,
                     provenance=provenance,
                     payload_text=payload_text,
                     occurred_at_ms=occurred_at_ms,
                     provider_timestamp_ms=provider_timestamp_ms,
+                    flush_generation=0,
                     state="pending",
                     attempts=0,
                     next_retry_at=None,
@@ -381,11 +407,18 @@ class MemoryStore:
                 return None
             row = conn.execute(
                 """
-                SELECT * FROM memory_capture_queue
-                WHERE epoch = ?
-                  AND state = 'pending'
-                  AND (next_retry_at IS NULL OR next_retry_at <= ?)
-                ORDER BY created_at, source_message_digest
+                SELECT q.* FROM memory_capture_queue AS q
+                WHERE q.epoch = ?
+                  AND q.state = 'pending'
+                  AND (q.next_retry_at IS NULL OR q.next_retry_at <= ?)
+                  AND NOT EXISTS (
+                      SELECT 1
+                      FROM memory_session_flush_state AS fence
+                      WHERE fence.provider_session_ref = q.provider_session_ref
+                        AND fence.epoch = q.epoch
+                        AND fence.flush_state = 'manual_required'
+                  )
+                ORDER BY q.created_at, q.source_message_digest
                 LIMIT 1
                 """,
                 (meta.epoch, now),
@@ -434,6 +467,18 @@ class MemoryStore:
                 add_request_id=outcome.add_request_id,
             )
             return SettleResult(settled=settled, state="delivered" if settled else None)
+        if isinstance(outcome, AmbiguousAdd):
+            settled = self._settle_ambiguous_add(
+                row,
+                lease_owner=lease_owner,
+                now=now_iso,
+                add_request_id=outcome.add_request_id,
+                error=outcome.error,
+            )
+            return SettleResult(
+                settled=settled,
+                state="manual_required" if settled else None,
+            )
         if isinstance(outcome, SystemOutage):
             settled = self._return_system_failure(
                 row,
@@ -514,6 +559,102 @@ class MemoryStore:
                 return False
             self._compact_terminal_tombstones_in_connection(conn, _datetime_from_iso(now))
             return True
+
+    def _settle_ambiguous_add(
+        self,
+        row: QueueRow,
+        *,
+        lease_owner: str,
+        now: str,
+        add_request_id: str | None,
+        error: MemoryErrorCode,
+    ) -> bool:
+        """Retain an uncertain add and fence its session against auto-replay."""
+
+        safe_error = _closed_error_or(error, "memory_provider_response_invalid")
+        with self._transaction() as conn:
+            result = conn.execute(
+                """
+                UPDATE memory_capture_queue
+                SET state = 'manual_required', next_retry_at = NULL,
+                    lease_owner = NULL, lease_at = NULL,
+                    last_error = ?, add_request_id = ?
+                WHERE source_message_digest = ? AND epoch = ?
+                  AND state = 'processing' AND lease_owner = ?
+                """,
+                (
+                    safe_error,
+                    _bounded_opaque_text(add_request_id),
+                    row.source_message_digest,
+                    row.epoch,
+                    lease_owner,
+                ),
+            )
+            if result.rowcount != 1:
+                return False
+            self._set_manual_required_fence_in_connection(
+                conn,
+                row.provider_session_ref,
+                now=now,
+            )
+            self._set_last_error_in_connection(conn, safe_error, now)
+            return True
+
+    def _set_manual_required_fence_in_connection(
+        self,
+        conn: sqlite3.Connection,
+        provider_session_ref: ProviderSessionRef,
+        *,
+        now: str,
+    ) -> None:
+        """Persist a session-scoped terminal fence for an uncertain add."""
+
+        key = provider_session_ref.serialize()
+        conn.execute(
+            """
+            INSERT INTO memory_session_flush_state (
+                provider_session_ref, principal_id, epoch, project_ref, session_id,
+                generation, first_unflushed_at, last_add_ack_at, due_at,
+                next_attempt_at, flush_state, watermark_ms, fence_epoch,
+                fence_owner, fence_acquired_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, 0, NULL, NULL, NULL, NULL,
+                      'manual_required', 0, 1, 'manual-required', ?, ?)
+            ON CONFLICT(provider_session_ref) DO UPDATE SET
+                fence_epoch = memory_session_flush_state.fence_epoch + 1,
+                flush_state = 'manual_required',
+                due_at = NULL,
+                next_attempt_at = NULL,
+                fence_owner = 'manual-required',
+                fence_acquired_at = excluded.fence_acquired_at,
+                updated_at = excluded.updated_at
+            """,
+            (
+                key,
+                provider_session_ref.principal_id,
+                provider_session_ref.epoch,
+                provider_session_ref.project_ref,
+                provider_session_ref.session_id,
+                now,
+                now,
+            ),
+        )
+
+    def has_manual_required_fence(self) -> bool:
+        """Return whether the active epoch contains a terminal session fence."""
+
+        with self._connection() as conn:
+            meta = self._meta_in_connection(conn)
+            if meta is None:
+                return False
+            row = conn.execute(
+                """
+                SELECT 1 FROM memory_session_flush_state
+                WHERE epoch = ? AND flush_state = 'manual_required'
+                LIMIT 1
+                """,
+                (meta.epoch,),
+            ).fetchone()
+        return row is not None
 
     def mark_flush_in_flight(self, session_id: str, project_ref: str) -> int:
         """Freeze the delivered rows consumed by one imminent session flush."""
@@ -758,20 +899,42 @@ class MemoryStore:
             return MessageFailureResult(state=state, attempts=attempts)
 
     def _reclaim_processing(self, *, lease_owner: str) -> int:
-        """Return rows leased by prior boots to pending for at-least-once delivery."""
+        """Fence rows whose provider add outcome was ambiguous at boot."""
 
+        now = utc_now_iso()
         with self._transaction() as conn:
-            result = conn.execute(
+            rows = conn.execute(
                 """
-                UPDATE memory_capture_queue
-                SET state = 'pending', lease_owner = NULL, lease_at = NULL,
-                    next_retry_at = NULL
+                SELECT * FROM memory_capture_queue
                 WHERE state = 'processing'
                   AND (lease_owner IS NULL OR lease_owner != ?)
                 """,
                 (lease_owner,),
-            )
-            return int(result.rowcount)
+            ).fetchall()
+            for row in rows:
+                updated = conn.execute(
+                    """
+                    UPDATE memory_capture_queue
+                    SET state = 'manual_required', lease_owner = NULL, lease_at = NULL,
+                        next_retry_at = NULL,
+                        last_error = 'memory_provider_response_invalid'
+                    WHERE source_message_digest = ? AND state = 'processing'
+                    """,
+                    (row["source_message_digest"],),
+                )
+                if updated.rowcount:
+                    self._set_manual_required_fence_in_connection(
+                        conn,
+                        _provider_ref_from_row(row),
+                        now=now,
+                    )
+            if rows:
+                self._set_last_error_in_connection(
+                    conn,
+                    "memory_provider_response_invalid",
+                    now,
+                )
+            return len(rows)
 
     def queue_stats(self) -> QueueStats:
         """Return aggregate counts and retained plaintext bytes for the active epoch."""
@@ -1001,6 +1164,8 @@ class MemoryStore:
         with self._transaction() as conn:
             meta = self._ensure_meta_in_connection(conn)
             conn.execute("DELETE FROM memory_capture_queue")
+            conn.execute("DELETE FROM memory_session_flush_state")
+            conn.execute("DELETE FROM memory_flush_settlements")
             conn.execute(
                 """
                 UPDATE memory_meta
@@ -1404,6 +1569,10 @@ def _meta_from_row(row: sqlite3.Row) -> MemoryMeta:
     )
 
 
+def _provider_ref_from_row(row: sqlite3.Row | dict[str, object]) -> ProviderSessionRef:
+    return ProviderSessionRef.deserialize(str(row["provider_session_ref"]))
+
+
 def _queue_from_row(row: sqlite3.Row | dict[str, object]) -> QueueRow:
     last_error = (
         _closed_error_or(row["last_error"], "memory_store_unavailable")
@@ -1414,6 +1583,9 @@ def _queue_from_row(row: sqlite3.Row | dict[str, object]) -> QueueRow:
         source_message_digest=str(row["source_message_digest"]),
         epoch=int(row["epoch"]),
         session_id=str(row["session_id"]),
+        provider_session_ref=ProviderSessionRef.deserialize(
+            str(row["provider_session_ref"])
+        ),
         principal_id=str(row["principal_id"]),
         project_ref=str(row["project_ref"]),
         provenance=str(row["provenance"]),
@@ -1425,6 +1597,7 @@ def _queue_from_row(row: sqlite3.Row | dict[str, object]) -> QueueRow:
         ),
         occurred_at_ms=int(row["occurred_at_ms"]),
         provider_timestamp_ms=int(row["provider_timestamp_ms"]),
+        flush_generation=int(row["flush_generation"]),
         state=str(row["state"]),
         attempts=int(row["attempts"]),
         next_retry_at=str(row["next_retry_at"]) if row["next_retry_at"] is not None else None,

--- a/core/memory/store.py
+++ b/core/memory/store.py
@@ -300,7 +300,8 @@ class MemoryStore:
                 conn.execute(
                     """
                     SELECT COUNT(*) FROM memory_capture_queue
-                    WHERE epoch = ? AND state IN ('pending', 'processing')
+                    WHERE epoch = ?
+                      AND state IN ('pending', 'processing', 'manual_required')
                     """,
                     (meta.epoch,),
                 ).fetchone()[0]
@@ -959,7 +960,7 @@ class MemoryStore:
                     SUM(CASE WHEN state = 'delivered' AND flush_observation = 'rejected'
                         THEN 1 ELSE 0 END) AS distill_failed,
                     COALESCE(SUM(
-                        CASE WHEN state IN ('pending', 'processing')
+                        CASE WHEN state IN ('pending', 'processing', 'manual_required')
                         THEN length(CAST(payload_text AS BLOB))
                            + length(CAST(COALESCE(payload_attachments, '') AS BLOB))
                         ELSE 0 END

--- a/core/memory/store.py
+++ b/core/memory/store.py
@@ -101,7 +101,6 @@ class QueueRow:
     payload_text: str | None
     occurred_at_ms: int
     provider_timestamp_ms: int
-    flush_generation: int
     state: Literal["pending", "processing", "delivered", "dead", "manual_required"]
     attempts: int
     next_retry_at: str | None
@@ -352,10 +351,10 @@ class MemoryStore:
                     principal_id,
                     project_ref, provenance, payload_text,
                     payload_attachments, occurred_at_ms, provider_timestamp_ms,
-                    flush_generation, state, attempts,
+                    state, attempts,
                     next_retry_at, lease_owner, lease_at, last_error,
                     created_at, completed_at
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, 'pending', 0,
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'pending', 0,
                           NULL, NULL, NULL, NULL, ?, NULL)
                 """,
                 (
@@ -386,7 +385,6 @@ class MemoryStore:
                     payload_text=payload_text,
                     occurred_at_ms=occurred_at_ms,
                     provider_timestamp_ms=provider_timestamp_ms,
-                    flush_generation=0,
                     state="pending",
                     attempts=0,
                     next_retry_at=None,
@@ -414,10 +412,10 @@ class MemoryStore:
                   AND (q.next_retry_at IS NULL OR q.next_retry_at <= ?)
                   AND NOT EXISTS (
                       SELECT 1
-                      FROM memory_session_flush_state AS fence
+                      FROM memory_capture_queue AS fence
                       WHERE fence.provider_session_ref = q.provider_session_ref
                         AND fence.epoch = q.epoch
-                        AND fence.flush_state = 'manual_required'
+                        AND fence.state = 'manual_required'
                   )
                 ORDER BY q.created_at, q.source_message_digest
                 LIMIT 1
@@ -594,52 +592,8 @@ class MemoryStore:
             )
             if result.rowcount != 1:
                 return False
-            self._set_manual_required_fence_in_connection(
-                conn,
-                row.provider_session_ref,
-                now=now,
-            )
             self._set_last_error_in_connection(conn, safe_error, now)
             return True
-
-    def _set_manual_required_fence_in_connection(
-        self,
-        conn: sqlite3.Connection,
-        provider_session_ref: ProviderSessionRef,
-        *,
-        now: str,
-    ) -> None:
-        """Persist a session-scoped terminal fence for an uncertain add."""
-
-        key = provider_session_ref.serialize()
-        conn.execute(
-            """
-            INSERT INTO memory_session_flush_state (
-                provider_session_ref, principal_id, epoch, project_ref, session_id,
-                generation, first_unflushed_at, last_add_ack_at, due_at,
-                next_attempt_at, flush_state, watermark_ms, fence_epoch,
-                fence_owner, fence_acquired_at, updated_at
-            ) VALUES (?, ?, ?, ?, ?, 0, NULL, NULL, NULL, NULL,
-                      'manual_required', 0, 1, 'manual-required', ?, ?)
-            ON CONFLICT(provider_session_ref) DO UPDATE SET
-                fence_epoch = memory_session_flush_state.fence_epoch + 1,
-                flush_state = 'manual_required',
-                due_at = NULL,
-                next_attempt_at = NULL,
-                fence_owner = 'manual-required',
-                fence_acquired_at = excluded.fence_acquired_at,
-                updated_at = excluded.updated_at
-            """,
-            (
-                key,
-                provider_session_ref.principal_id,
-                provider_session_ref.epoch,
-                provider_session_ref.project_ref,
-                provider_session_ref.session_id,
-                now,
-                now,
-            ),
-        )
 
     def has_manual_required_fence(self) -> bool:
         """Return whether the active epoch contains a terminal session fence."""
@@ -650,8 +604,8 @@ class MemoryStore:
                 return False
             row = conn.execute(
                 """
-                SELECT 1 FROM memory_session_flush_state
-                WHERE epoch = ? AND flush_state = 'manual_required'
+                SELECT 1 FROM memory_capture_queue
+                WHERE epoch = ? AND state = 'manual_required'
                 LIMIT 1
                 """,
                 (meta.epoch,),
@@ -914,7 +868,7 @@ class MemoryStore:
                 (lease_owner,),
             ).fetchall()
             for row in rows:
-                updated = conn.execute(
+                conn.execute(
                     """
                     UPDATE memory_capture_queue
                     SET state = 'manual_required', lease_owner = NULL, lease_at = NULL,
@@ -924,12 +878,6 @@ class MemoryStore:
                     """,
                     (now, row["source_message_digest"]),
                 )
-                if updated.rowcount:
-                    self._set_manual_required_fence_in_connection(
-                        conn,
-                        _provider_ref_from_row(row),
-                        now=now,
-                    )
             if rows:
                 self._set_last_error_in_connection(
                     conn,
@@ -1170,8 +1118,6 @@ class MemoryStore:
         with self._transaction() as conn:
             meta = self._ensure_meta_in_connection(conn)
             conn.execute("DELETE FROM memory_capture_queue")
-            conn.execute("DELETE FROM memory_session_flush_state")
-            conn.execute("DELETE FROM memory_flush_settlements")
             conn.execute(
                 """
                 UPDATE memory_meta
@@ -1575,10 +1521,6 @@ def _meta_from_row(row: sqlite3.Row) -> MemoryMeta:
     )
 
 
-def _provider_ref_from_row(row: sqlite3.Row | dict[str, object]) -> ProviderSessionRef:
-    return ProviderSessionRef.deserialize(str(row["provider_session_ref"]))
-
-
 def _queue_from_row(row: sqlite3.Row | dict[str, object]) -> QueueRow:
     last_error = (
         _closed_error_or(row["last_error"], "memory_store_unavailable")
@@ -1603,7 +1545,6 @@ def _queue_from_row(row: sqlite3.Row | dict[str, object]) -> QueueRow:
         ),
         occurred_at_ms=int(row["occurred_at_ms"]),
         provider_timestamp_ms=int(row["provider_timestamp_ms"]),
-        flush_generation=int(row["flush_generation"]),
         state=str(row["state"]),
         attempts=int(row["attempts"]),
         next_retry_at=str(row["next_retry_at"]) if row["next_retry_at"] is not None else None,

--- a/core/memory/store.py
+++ b/core/memory/store.py
@@ -579,13 +579,14 @@ class MemoryStore:
                 UPDATE memory_capture_queue
                 SET state = 'manual_required', next_retry_at = NULL,
                     lease_owner = NULL, lease_at = NULL,
-                    last_error = ?, add_request_id = ?
+                    last_error = ?, add_request_id = ?, completed_at = ?
                 WHERE source_message_digest = ? AND epoch = ?
                   AND state = 'processing' AND lease_owner = ?
                 """,
                 (
                     safe_error,
                     _bounded_opaque_text(add_request_id),
+                    now,
                     row.source_message_digest,
                     row.epoch,
                     lease_owner,
@@ -918,10 +919,10 @@ class MemoryStore:
                     UPDATE memory_capture_queue
                     SET state = 'manual_required', lease_owner = NULL, lease_at = NULL,
                         next_retry_at = NULL,
-                        last_error = 'memory_provider_response_invalid'
+                        last_error = 'memory_provider_response_invalid', completed_at = ?
                     WHERE source_message_digest = ? AND state = 'processing'
                     """,
-                    (row["source_message_digest"],),
+                    (now, row["source_message_digest"]),
                 )
                 if updated.rowcount:
                     self._set_manual_required_fence_in_connection(
@@ -1038,14 +1039,17 @@ class MemoryStore:
                 SELECT kind, occurred_at, error_code, request_id, attempts
                 FROM (
                     SELECT
-                        'delivery_abandoned' AS kind,
+                        CASE
+                            WHEN state = 'dead' THEN 'delivery_abandoned'
+                            ELSE 'result_unknown'
+                        END AS kind,
                         COALESCE(completed_at, created_at) AS occurred_at,
                         last_error AS error_code,
                         add_request_id AS request_id,
                         attempts,
                         source_message_digest AS sort_key
                     FROM memory_capture_queue
-                    WHERE epoch = ? AND state = 'dead'
+                    WHERE epoch = ? AND state IN ('dead', 'manual_required')
 
                     UNION ALL
 

--- a/core/memory/types.py
+++ b/core/memory/types.py
@@ -69,6 +69,73 @@ def is_memory_error_code(value: object) -> bool:
 
 
 @dataclass(frozen=True)
+class ProviderSessionRef:
+    """Canonical provider identity persisted by Avibe's Memory outbox."""
+
+    principal_id: str
+    epoch: int
+    project_ref: str
+    session_id: str
+
+    def __post_init__(self) -> None:
+        for name, value in (
+            ("principal_id", self.principal_id),
+            ("project_ref", self.project_ref),
+            ("session_id", self.session_id),
+        ):
+            if not isinstance(value, str) or not value:
+                raise ValueError(f"provider session {name} must be non-empty")
+        if isinstance(self.epoch, bool) or not isinstance(self.epoch, int) or self.epoch < 0:
+            raise ValueError("provider session epoch must be a non-negative integer")
+
+    def as_tuple(self) -> tuple[str, int, str, str]:
+        """Return the canonical identity ordering."""
+
+        return (self.principal_id, self.epoch, self.project_ref, self.session_id)
+
+    def serialize(self) -> str:
+        """Serialize deterministically for Avibe-owned SQLite state."""
+
+        return json.dumps(
+            {
+                "principal_id": self.principal_id,
+                "epoch": self.epoch,
+                "project_ref": self.project_ref,
+                "session_id": self.session_id,
+            },
+            ensure_ascii=True,
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+
+    to_json = serialize
+
+    @classmethod
+    def deserialize(cls, value: str) -> "ProviderSessionRef":
+        """Deserialize only the canonical four-field identity shape."""
+
+        try:
+            payload = json.loads(value)
+        except (TypeError, ValueError):
+            raise ValueError("invalid provider session reference") from None
+        if not isinstance(payload, dict) or set(payload) != {
+            "principal_id",
+            "epoch",
+            "project_ref",
+            "session_id",
+        }:
+            raise ValueError("invalid provider session reference")
+        return cls(
+            principal_id=payload["principal_id"],
+            epoch=payload["epoch"],
+            project_ref=payload["project_ref"],
+            session_id=payload["session_id"],
+        )
+
+    from_serialized = deserialize
+
+
+@dataclass(frozen=True)
 class CaptureAttachment:
     """One Workbench-owned local file forwarded unchanged to the provider."""
 

--- a/core/memory/worker.py
+++ b/core/memory/worker.py
@@ -269,6 +269,9 @@ class MemoryWorker:
             if error == "memory_provider_timeout":
                 await self._manual_required(row, error)
                 return False
+            if not failure.retryable:
+                await self._record_message_failure(row, error, retryable=False)
+                return False
             await self._ambiguous_failure_is_system_outage(
                 row,
                 error,

--- a/core/memory/worker.py
+++ b/core/memory/worker.py
@@ -20,6 +20,7 @@ from core.memory.everos import (
     ProviderCapture,
 )
 from core.memory.store import (
+    AmbiguousAdd,
     Delivered,
     MemoryStore,
     MessageFailure,
@@ -273,8 +274,13 @@ class MemoryWorker:
             await self._ambiguous_failure_is_system_outage(row, "memory_processing_failed")
             return False
 
-        if not isinstance(ack, AddAck):
-            ack = AddAck(request_id=None, status=None)
+        if not isinstance(ack, AddAck) or ack.status not in {"accumulated", "extracted"}:
+            await self._manual_required(
+                row,
+                "memory_provider_response_invalid",
+                request_id=ack.request_id if isinstance(ack, AddAck) else None,
+            )
+            return False
         settled = await self._store_call(
             self._store.settle,
             row,
@@ -430,6 +436,21 @@ class MemoryWorker:
             self._store.settle,
             row,
             MessageFailure(error=error, retryable=retryable),
+            lease_owner=self._boot_id,
+            now=self._current_time(),
+        )
+
+    async def _manual_required(
+        self,
+        row: QueueRow,
+        error: MemoryErrorCode,
+        *,
+        request_id: str | None = None,
+    ) -> None:
+        await self._store_call(
+            self._store.settle,
+            row,
+            AmbiguousAdd(add_request_id=request_id, error=error),
             lease_owner=self._boot_id,
             now=self._current_time(),
         )

--- a/core/memory/worker.py
+++ b/core/memory/worker.py
@@ -261,9 +261,13 @@ class MemoryWorker:
             )
             return False
         except MemoryProviderFailure as failure:
+            error = _provider_error_code(failure, "memory_processing_failed")
+            if error == "memory_provider_timeout":
+                await self._manual_required(row, error)
+                return False
             await self._ambiguous_failure_is_system_outage(
                 row,
-                _provider_error_code(failure, "memory_processing_failed"),
+                error,
                 retryable=failure.retryable,
             )
             return False
@@ -271,7 +275,11 @@ class MemoryWorker:
             await self._ambiguous_failure_is_system_outage(row, "memory_processing_failed")
             return False
 
-        if not isinstance(ack, AddAck) or ack.status not in {"accumulated", "extracted"}:
+        if (
+            not isinstance(ack, AddAck)
+            or ack.status not in {"accumulated", "extracted"}
+            or not _valid_add_receipt_id(ack.request_id)
+        ):
             await self._manual_required(
                 row,
                 "memory_provider_response_invalid",
@@ -506,6 +514,10 @@ def _opens_breaker(result: FlushResult) -> bool:
 
 def _provider_error_code(error: MemoryProviderFailure, fallback: MemoryErrorCode) -> MemoryErrorCode:
     return error.error if is_memory_error_code(error.error) else fallback
+
+
+def _valid_add_receipt_id(value: object) -> bool:
+    return isinstance(value, str) and bool(value) and len(value.encode("utf-8")) <= 128
 
 
 def _positive_timeout(value: float) -> float:

--- a/core/memory/worker.py
+++ b/core/memory/worker.py
@@ -252,10 +252,7 @@ class MemoryWorker:
                 timeout=self._add_timeout_seconds,
             )
         except asyncio.TimeoutError:
-            await self._ambiguous_failure_is_system_outage(
-                row,
-                "memory_provider_timeout",
-            )
+            await self._manual_required(row, "memory_provider_timeout")
             return False
         except MemoryProviderSystemFailure as failure:
             await self._return_system_failure(

--- a/core/memory/worker.py
+++ b/core/memory/worker.py
@@ -255,9 +255,13 @@ class MemoryWorker:
             await self._manual_required(row, "memory_provider_timeout")
             return False
         except MemoryProviderSystemFailure as failure:
+            error = _provider_error_code(failure, "memory_sidecar_unavailable")
+            if failure.ambiguous:
+                await self._manual_required(row, error)
+                return False
             await self._return_system_failure(
                 row,
-                _provider_error_code(failure, "memory_sidecar_unavailable"),
+                error,
             )
             return False
         except MemoryProviderFailure as failure:

--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -52,3 +52,19 @@ and retained provider-call diagnostics owned by this installation. It does not
 remove original Avibe chats, copies already sent to a provider, user-created
 snapshots, general logs, crash reports, backups, or data outside the dedicated
 Memory directory. It is not a secure wipe of the storage device.
+
+## Capture outbox foundation
+
+Each captured row stores the canonical provider session reference
+`(principal_id, epoch, project_ref, session_id)` alongside the durable capture
+queue state. Duplicate source identities remain idempotent within the active
+epoch, and a claimed row is either settled successfully or retained with its
+payload for recovery.
+
+An incomplete, malformed, or otherwise ambiguous provider add is terminal for
+automatic delivery: the row is retained and its provider session is fenced as
+`manual_required`. Boot recovery applies the same fence to any abandoned
+`processing` row, so it never silently replays an add whose provider outcome is
+unknown. The status surface reports an active manual fence as degraded. Flush
+coordination, generation routing, and per-generation settlement projection are
+owned by the later flush coordinator.

--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -61,6 +61,10 @@ queue state. Duplicate source identities remain idempotent within the active
 epoch, and a claimed row is either settled successfully or retained with its
 payload for recovery.
 
+This phase initializes a clean Avibe-owned schema; legacy Memory databases and
+schema migration are intentionally not supported for the currently unused
+feature.
+
 An incomplete, malformed, or otherwise ambiguous provider add is terminal for
 automatic delivery: the row is retained and its provider session is fenced as
 `manual_required`. Boot recovery applies the same fence to any abandoned

--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -65,10 +65,10 @@ This phase initializes a clean Avibe-owned schema; legacy Memory databases and
 schema migration are intentionally not supported for the currently unused
 feature.
 
-An incomplete, malformed, or otherwise ambiguous provider add is terminal for
-automatic delivery: the row is retained and its provider session is fenced as
-`manual_required`. Boot recovery applies the same fence to any abandoned
-`processing` row, so it never silently replays an add whose provider outcome is
-unknown. The status surface reports an active manual fence as degraded. Flush
-coordination, generation routing, and per-generation settlement projection are
-owned by the later flush coordinator.
+An incomplete, malformed, overlong-receipt, timed-out, or response-disconnected
+provider add is terminal for automatic delivery: the row is retained and its
+provider session is fenced as `manual_required`. Boot recovery applies the same
+fence to any abandoned `processing` row, so it never silently replays an add
+whose provider outcome is unknown. The status surface reports an active manual
+fence as degraded. Flush coordination, generation routing, and per-generation
+settlement projection are owned by the later flush coordinator.

--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -70,5 +70,5 @@ provider add is terminal for automatic delivery: the row is retained and its
 provider session is fenced as `manual_required`. Boot recovery applies the same
 fence to any abandoned `processing` row, so it never silently replays an add
 whose provider outcome is unknown. The status surface reports an active manual
-fence as degraded. Flush coordination, generation routing, and per-generation
-settlement projection are owned by the later flush coordinator.
+fence as degraded. Flush scheduling and generation coordination are intentionally
+deferred to the later flush coordinator.

--- a/tests/test_memory_everos.py
+++ b/tests/test_memory_everos.py
@@ -15,6 +15,7 @@ from core.memory.everos import (
     FlushSucceeded,
     FlushUnknown,
     MemoryProviderFailure,
+    MemoryProviderSystemFailure,
     ProviderAttachment,
     ProviderCapture,
 )
@@ -85,6 +86,39 @@ def test_add_and_flush_are_separate_and_parse_provider_envelopes() -> None:
             {"session_id": "src--one--e1", "app_id": "avibe", "project_id": PROJECT},
         ),
     ]
+
+
+def test_add_marks_response_disconnect_as_ambiguous() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ReadError("response lost", request=request)
+
+    async def run() -> None:
+        provider = EverOSPort(Path("/tmp/everos.sock"))
+        await provider.add(ProviderCapture("owner", "session", "capture", 1, PROJECT))
+
+    with _sidecar_transport(handler):
+        with pytest.raises(MemoryProviderSystemFailure) as raised:
+            asyncio.run(run())
+
+    assert raised.value.ambiguous is True
+
+
+def test_add_rejects_overlong_receipt_without_truncating() -> None:
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={"request_id": "x" * 129, "data": {"status": "accumulated"}},
+        )
+
+    async def run() -> AddAck:
+        return await EverOSPort(Path("/tmp/everos.sock")).add(
+            ProviderCapture("owner", "session", "capture", 1, PROJECT)
+        )
+
+    with _sidecar_transport(handler):
+        ack = asyncio.run(run())
+
+    assert ack == AddAck(request_id=None, status="accumulated")
 
 
 @pytest.mark.parametrize(

--- a/tests/test_memory_everos.py
+++ b/tests/test_memory_everos.py
@@ -103,6 +103,22 @@ def test_add_marks_response_disconnect_as_ambiguous() -> None:
     assert raised.value.ambiguous is True
 
 
+def test_add_keeps_connect_timeout_on_retryable_system_outage_path() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectTimeout("connection stalled", request=request)
+
+    async def run() -> None:
+        provider = EverOSPort(Path("/tmp/everos.sock"))
+        await provider.add(ProviderCapture("owner", "session", "capture", 1, PROJECT))
+
+    with _sidecar_transport(handler):
+        with pytest.raises(MemoryProviderSystemFailure) as raised:
+            asyncio.run(run())
+
+    assert raised.value.error == "memory_sidecar_unavailable"
+    assert raised.value.ambiguous is False
+
+
 @pytest.mark.parametrize("failure_type", [httpx.WriteError, httpx.CloseError])
 def test_add_marks_post_submission_transport_failures_as_ambiguous(
     failure_type: type[httpx.TransportError],

--- a/tests/test_memory_everos.py
+++ b/tests/test_memory_everos.py
@@ -103,6 +103,24 @@ def test_add_marks_response_disconnect_as_ambiguous() -> None:
     assert raised.value.ambiguous is True
 
 
+@pytest.mark.parametrize("failure_type", [httpx.WriteError, httpx.CloseError])
+def test_add_marks_post_submission_transport_failures_as_ambiguous(
+    failure_type: type[httpx.TransportError],
+) -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise failure_type("response lost", request=request)
+
+    async def run() -> None:
+        provider = EverOSPort(Path("/tmp/everos.sock"))
+        await provider.add(ProviderCapture("owner", "session", "capture", 1, PROJECT))
+
+    with _sidecar_transport(handler):
+        with pytest.raises(MemoryProviderSystemFailure) as raised:
+            asyncio.run(run())
+
+    assert raised.value.ambiguous is True
+
+
 def test_add_rejects_overlong_receipt_without_truncating() -> None:
     def handler(_request: httpx.Request) -> httpx.Response:
         return httpx.Response(

--- a/tests/test_memory_module.py
+++ b/tests/test_memory_module.py
@@ -788,6 +788,24 @@ async def test_adapter_classified_timeout_is_manual_required_without_replay(tmp_
     assert store.has_manual_required_fence() is True
 
 
+async def test_ambiguous_transport_failure_is_manual_required_without_replay(
+    tmp_path: Path,
+) -> None:
+    module, store, provider = _module(tmp_path)
+    assert await module.capture(_request()) == CaptureAccepted()
+    provider.ingest_failures.append(MemoryProviderSystemFailure(ambiguous=True))
+    worker = MemoryWorker(store=store, provider=provider, enabled=lambda: True, boot_id="boot")
+
+    assert await worker.drain_once() == 1
+    row = store.list_queue_rows()[0]
+    assert row.state == "manual_required"
+    assert row.attempts == 0
+    assert row.payload_text == "remember this"
+    assert row.last_error == "memory_sidecar_unavailable"
+    assert len(provider.captures) == 0
+    assert store.has_manual_required_fence() is True
+
+
 async def test_search_and_profile_enforce_bounds_and_return_closed_errors(tmp_path: Path) -> None:
     provider = FakeMemoryProvider(
         search_items=(MemoryItem(kind="fact", text="bounded fact", date="2026-01-01"),),

--- a/tests/test_memory_module.py
+++ b/tests/test_memory_module.py
@@ -744,7 +744,10 @@ async def test_malformed_add_ack_becomes_manual_required_without_replay(
     assert row.payload_text == "remember this"
     assert row.add_request_id == "ambiguous-ack"
     assert store.has_manual_required_fence() is True
-    assert (await module.status()).error == "memory_processing_failed"
+    status = await module.status()
+    assert status.error == "memory_processing_failed"
+    assert status.receipt_unknown == 1
+    assert status.buckets.unknown == 1
 
 
 @pytest.mark.parametrize("request_id", [None, "", "x" * 129])

--- a/tests/test_memory_module.py
+++ b/tests/test_memory_module.py
@@ -14,6 +14,7 @@ import pytest
 
 from config import paths
 from core.memory.everos import (
+    AddAck,
     FakeMemoryProvider,
     FlushRejected,
     FlushSucceeded,
@@ -708,17 +709,42 @@ async def test_message_failure_when_endpoints_healthy_consumes_attempt(tmp_path:
     assert row.last_error == "memory_processing_failed"
 
 
-async def test_old_boot_processing_row_is_reclaimed_for_at_least_once_delivery(tmp_path: Path) -> None:
+async def test_old_boot_processing_row_becomes_manual_required_without_replay(tmp_path: Path) -> None:
     module, store, provider = _module(tmp_path)
     assert await module.capture(_request()) == CaptureAccepted()
     claimed = store.claim_due(lease_owner="old-boot", now="2026-01-01T00:00:00.000Z")
     assert claimed is not None and claimed.state == "processing"
     worker = MemoryWorker(store=store, provider=provider, enabled=lambda: True, boot_id="new-boot")
 
+    assert await worker.drain_once() == 0
+    row = store.list_queue_rows()[0]
+    assert row.state == "manual_required"
+    assert row.payload_text == "remember this"
+    assert row.last_error == "memory_provider_response_invalid"
+    assert len(provider.captures) == 0
+    assert store.has_manual_required_fence() is True
+
+
+async def test_malformed_add_ack_becomes_manual_required_without_replay(
+    tmp_path: Path,
+) -> None:
+    class MalformedAckProvider(FakeMemoryProvider):
+        async def add(self, capture):
+            self.captures.append(capture)
+            return AddAck(request_id="ambiguous-ack", status=None)
+
+    provider = MalformedAckProvider()
+    module, store, _provider = _module(tmp_path, provider=provider)
+    assert await module.capture(_request()) == CaptureAccepted()
+    worker = MemoryWorker(store=store, provider=provider, enabled=lambda: True, boot_id="boot")
+
     assert await worker.drain_once() == 1
     row = store.list_queue_rows()[0]
-    assert row.state == "delivered"
-    assert len(provider.captures) == 1
+    assert row.state == "manual_required"
+    assert row.payload_text == "remember this"
+    assert row.add_request_id == "ambiguous-ack"
+    assert store.has_manual_required_fence() is True
+    assert (await module.status()).error == "memory_processing_failed"
 
 
 async def test_search_and_profile_enforce_bounds_and_return_closed_errors(tmp_path: Path) -> None:

--- a/tests/test_memory_module.py
+++ b/tests/test_memory_module.py
@@ -709,6 +709,25 @@ async def test_message_failure_when_endpoints_healthy_consumes_attempt(tmp_path:
     assert row.last_error == "memory_processing_failed"
 
 
+async def test_non_retryable_add_rejection_is_terminal_even_when_processing_is_down(
+    tmp_path: Path,
+) -> None:
+    module, store, provider = _module(tmp_path)
+    assert await module.capture(_request(source="poison")) == CaptureAccepted()
+    provider.ingest_failures.append(
+        MemoryProviderFailure("memory_processing_failed", retryable=False)
+    )
+    provider.processing_healthy_flag = False
+    worker = MemoryWorker(store=store, provider=provider, enabled=lambda: True, boot_id="boot")
+
+    assert await worker.drain_once() == 1
+    row = store.list_queue_rows()[0]
+    assert (row.state, row.attempts, row.payload_text) == ("dead", 1, None)
+    assert row.last_error == "memory_processing_failed"
+    assert await worker.drain_once() == 0
+    assert len(provider.captures) == 0
+
+
 async def test_old_boot_processing_row_becomes_manual_required_without_replay(tmp_path: Path) -> None:
     module, store, provider = _module(tmp_path)
     assert await module.capture(_request()) == CaptureAccepted()

--- a/tests/test_memory_module.py
+++ b/tests/test_memory_module.py
@@ -748,6 +748,16 @@ async def test_malformed_add_ack_becomes_manual_required_without_replay(
     assert status.error == "memory_processing_failed"
     assert status.receipt_unknown == 1
     assert status.buckets.unknown == 1
+    assert row.completed_at is not None
+    assert await module.failure_log() == (
+        MemoryFailureLogEntry(
+            kind="result_unknown",
+            occurred_at=row.completed_at,
+            error_code="memory_provider_response_invalid",
+            request_id="ambiguous-ack",
+            attempts=0,
+        ),
+    )
 
 
 @pytest.mark.parametrize("request_id", [None, "", "x" * 129])

--- a/tests/test_memory_module.py
+++ b/tests/test_memory_module.py
@@ -1598,7 +1598,7 @@ def test_provider_port_is_not_part_of_the_public_memory_package() -> None:
     assert "ProviderCapture" not in memory.__all__
 
 
-async def test_healthy_timeout_poison_row_spends_attempts_then_unblocks_later_work(tmp_path: Path) -> None:
+async def test_ambiguous_timeout_is_manual_required_and_unblocks_later_work(tmp_path: Path) -> None:
     class PoisonProvider(FakeMemoryProvider):
         async def add(self, capture):
             if capture.text == "poison":
@@ -1608,7 +1608,9 @@ async def test_healthy_timeout_poison_row_spends_attempts_then_unblocks_later_wo
     provider = PoisonProvider()
     module, store, _provider = _module(tmp_path, provider=provider)
     assert await module.capture(_request(source="poison", text="poison")) == CaptureAccepted()
-    assert await module.capture(_request(source="later", text="later")) == CaptureAccepted()
+    assert await module.capture(
+        _request(source="later", session="later-session", text="later")
+    ) == CaptureAccepted()
     current = datetime(2026, 1, 1, tzinfo=UTC)
     worker = MemoryWorker(
         store=store,
@@ -1620,14 +1622,13 @@ async def test_healthy_timeout_poison_row_spends_attempts_then_unblocks_later_wo
     )
 
     assert await worker.drain_once() == 1
-    assert store.list_queue_rows()[0].attempts == 1
-    current += timedelta(seconds=31)
-    assert await worker.drain_once() == 1
-    assert store.list_queue_rows()[0].attempts == 2
-    current += timedelta(minutes=2, seconds=1)
-    assert await worker.drain_once() == 1
     poison = store.list_queue_rows()[0]
-    assert (poison.state, poison.attempts, poison.payload_text) == ("dead", 3, None)
+    assert (poison.state, poison.attempts, poison.payload_text) == (
+        "manual_required",
+        0,
+        "poison",
+    )
+    assert store.has_manual_required_fence() is True
 
     assert await worker.drain_once() == 1
     later = store.list_queue_rows()[1]

--- a/tests/test_memory_module.py
+++ b/tests/test_memory_module.py
@@ -747,6 +747,47 @@ async def test_malformed_add_ack_becomes_manual_required_without_replay(
     assert (await module.status()).error == "memory_processing_failed"
 
 
+@pytest.mark.parametrize("request_id", [None, "", "x" * 129])
+async def test_add_ack_without_bounded_receipt_is_manual_required_without_replay(
+    tmp_path: Path,
+    request_id: str | None,
+) -> None:
+    class MissingReceiptProvider(FakeMemoryProvider):
+        async def add(self, capture):
+            self.captures.append(capture)
+            return AddAck(request_id=request_id, status="accumulated")
+
+    provider = MissingReceiptProvider()
+    module, store, _provider = _module(tmp_path, provider=provider)
+    assert await module.capture(_request()) == CaptureAccepted()
+    worker = MemoryWorker(store=store, provider=provider, enabled=lambda: True, boot_id="boot")
+
+    assert await worker.drain_once() == 1
+    row = store.list_queue_rows()[0]
+    assert row.state == "manual_required"
+    assert row.payload_text == "remember this"
+    if request_id is None or len(request_id.encode("utf-8")) <= 128:
+        assert row.add_request_id == request_id
+    else:
+        assert row.add_request_id == request_id[:128]
+    assert store.has_manual_required_fence() is True
+
+
+async def test_adapter_classified_timeout_is_manual_required_without_replay(tmp_path: Path) -> None:
+    module, store, provider = _module(tmp_path)
+    assert await module.capture(_request()) == CaptureAccepted()
+    provider.ingest_failures.append(MemoryProviderFailure("memory_provider_timeout"))
+    worker = MemoryWorker(store=store, provider=provider, enabled=lambda: True, boot_id="boot")
+
+    assert await worker.drain_once() == 1
+    row = store.list_queue_rows()[0]
+    assert row.state == "manual_required"
+    assert row.attempts == 0
+    assert row.payload_text == "remember this"
+    assert len(provider.captures) == 0
+    assert store.has_manual_required_fence() is True
+
+
 async def test_search_and_profile_enforce_bounds_and_return_closed_errors(tmp_path: Path) -> None:
     provider = FakeMemoryProvider(
         search_items=(MemoryItem(kind="fact", text="bounded fact", date="2026-01-01"),),
@@ -940,14 +981,16 @@ async def test_status_precedence(tmp_path: Path) -> None:
     assert (await clearing.status()).state == "clearing"
 
 
-async def test_latest_flush_success_closes_stale_timeout_but_keeps_dead_history(tmp_path: Path) -> None:
+async def test_latest_flush_success_closes_stale_delivery_failure_but_keeps_dead_history(
+    tmp_path: Path,
+) -> None:
     module, store, provider = _module(tmp_path)
     assert await module.capture(_request(source="failed", text="failed delivery")) == CaptureAccepted()
     provider.ingest_failures.extend(
         [
-            MemoryProviderFailure("memory_provider_timeout"),
-            MemoryProviderFailure("memory_provider_timeout"),
-            MemoryProviderFailure("memory_provider_timeout"),
+            MemoryProviderFailure("memory_processing_failed"),
+            MemoryProviderFailure("memory_processing_failed"),
+            MemoryProviderFailure("memory_processing_failed"),
         ]
     )
     current = datetime(2026, 1, 1, tzinfo=UTC)
@@ -1033,7 +1076,7 @@ async def test_latest_flush_observation_supersedes_stale_timeout_after_delivery(
     module, store, provider = _module(tmp_path)
     assert await module.capture(_request(source="failed")) == CaptureAccepted()
     provider.ingest_failures.extend(
-        [MemoryProviderFailure("memory_provider_timeout")] * 3
+        [MemoryProviderFailure("memory_processing_failed")] * 3
     )
     current = datetime.now(UTC).replace(microsecond=0)
     worker = MemoryWorker(store=store, provider=provider, enabled=lambda: True, now=lambda: current)
@@ -1054,7 +1097,7 @@ async def test_latest_flush_observation_supersedes_stale_timeout_after_delivery(
     ).settled
     delivered_status = await module.status()
     assert delivered_status.state == "degraded"
-    assert delivered_status.error == "memory_provider_timeout"
+    assert delivered_status.error == "memory_processing_failed"
 
     assert store.mark_flush_in_flight(row.session_id, row.project_ref) == 1
     assert store.record_flush_verdict(
@@ -1074,9 +1117,9 @@ async def test_failure_log_keeps_sanitized_delivery_failures(tmp_path: Path) -> 
     assert await module.capture(_request(source="failed", session="private-session", text="private text")) == CaptureAccepted()
     provider.ingest_failures.extend(
         [
-            MemoryProviderFailure("memory_provider_timeout"),
-            MemoryProviderFailure("memory_provider_timeout"),
-            MemoryProviderFailure("memory_provider_timeout"),
+            MemoryProviderFailure("memory_processing_failed"),
+            MemoryProviderFailure("memory_processing_failed"),
+            MemoryProviderFailure("memory_processing_failed"),
         ]
     )
     current = datetime.now(UTC).replace(microsecond=0)
@@ -1099,7 +1142,7 @@ async def test_failure_log_keeps_sanitized_delivery_failures(tmp_path: Path) -> 
         MemoryFailureLogEntry(
             kind="delivery_abandoned",
             occurred_at=expected_at,
-            error_code="memory_provider_timeout",
+            error_code="memory_processing_failed",
             request_id=None,
             attempts=3,
         ),

--- a/tests/test_memory_runtime.py
+++ b/tests/test_memory_runtime.py
@@ -3294,11 +3294,11 @@ def test_restart_waits_for_cancelled_worker_store_call_before_process_handoff(
         assert worker._boot_id != old_lease
         assert store.list_queue_rows()[0].state == "processing"
 
-        # The first tick under the replacement lease must reclaim old claimed
+        # The first tick under the replacement lease must fence old claimed
         # work before claims can resume.
         worker.pause_claims()
         assert await worker.drain_once() == 0
-        assert store.list_queue_rows()[0].state == "pending"
+        assert store.list_queue_rows()[0].state == "manual_required"
         await runtime.close()
 
     asyncio.run(run())

--- a/tests/test_memory_runtime.py
+++ b/tests/test_memory_runtime.py
@@ -98,12 +98,7 @@ def test_memory_drain_task_reactivates_recovery_after_an_unexpected_failure(
         artifact_manager=MemoryArtifactManager(runtime_dir=tmp_path / "runtime", offline=True),
         effective_home=tmp_path,
     )
-    activation_calls = 0
     drain_calls = 0
-
-    def begin_activation() -> None:
-        nonlocal activation_calls
-        activation_calls += 1
 
     async def drain() -> int:
         nonlocal drain_calls
@@ -116,7 +111,7 @@ def test_memory_drain_task_reactivates_recovery_after_an_unexpected_failure(
     async def no_wait(_seconds: float) -> None:
         return None
 
-    monkeypatch.setattr(runtime.module._worker, "begin_activation", begin_activation)
+    initial_boot_id = runtime.module._worker._boot_id
     monkeypatch.setattr(runtime.module._worker, "drain", drain)
     monkeypatch.setattr("core.memory.runtime.asyncio.sleep", no_wait)
 
@@ -127,7 +122,7 @@ def test_memory_drain_task_reactivates_recovery_after_an_unexpected_failure(
 
     asyncio.run(run())
     assert drain_calls == 2
-    assert activation_calls == 2
+    assert runtime.module._worker._boot_id != initial_boot_id
 
 
 def _settings() -> EverOSProcessSettings:

--- a/tests/test_memory_store.py
+++ b/tests/test_memory_store.py
@@ -204,6 +204,50 @@ def test_ambiguous_add_is_terminal_and_never_claimed_again(tmp_path: Path) -> No
     assert store.has_manual_required_fence() is True
     assert store.claim_due(lease_owner="worker-2", now="2026-01-01T00:00:02.000Z") is None
     assert store.ensure_meta().last_error == "memory_provider_response_invalid"
+    assert store.queue_stats().queue_plaintext_bytes == len("queued payload")
+    assert (
+        store.enqueue_request(
+            source_message_id="bounded-after-manual",
+            session_id="other-session",
+            principal_id="u-11111111111111111111111111111111",
+            project_ref=PROJECT,
+            provenance="user_input",
+            payload_text="another payload",
+            occurred_at_ms=2_000,
+            max_provider_timestamp_ms=4_102_444_800_000,
+            nonterminal_limit=1,
+        ).outcome
+        == "queue_full"
+    )
+
+
+def test_settlement_schema_accepts_settled_natural_boundary_records(tmp_path: Path) -> None:
+    store = MemoryStore(_store_path(tmp_path))
+    result = _enqueue(store, "settlement")
+    assert result.row is not None
+    reference = result.row.provider_session_ref.serialize()
+
+    with sqlite3.connect(store.path) as conn:
+        conn.execute(
+            """
+            INSERT INTO memory_flush_settlements (
+                settlement_id, provider_session_ref, generation, fence_epoch,
+                operation_id, operation_kind, outcome, flush_state, source,
+                observed_at, settled_at
+            ) VALUES (?, ?, 0, 0, ?, 'flush', 'succeeded', 'settled',
+                      'natural_boundary', '2026-01-01T00:00:00.000Z',
+                      '2026-01-01T00:00:00.000Z')
+            """,
+            ("settlement-1", reference, "operation-1"),
+        )
+        persisted = conn.execute(
+            """
+            SELECT flush_state, source
+            FROM memory_flush_settlements
+            WHERE settlement_id = 'settlement-1'
+            """
+        ).fetchone()
+    assert persisted == ("settled", "natural_boundary")
 
 
 def test_principal_derivation_is_stable_opaque_and_user_scoped() -> None:

--- a/tests/test_memory_store.py
+++ b/tests/test_memory_store.py
@@ -12,6 +12,7 @@ import pytest
 from config import paths
 from core.memory.everos import FlushRejected, FlushSucceeded, FlushUnknown
 from core.memory.store import (
+    AmbiguousAdd,
     MAX_MESSAGE_ATTEMPTS,
     MAX_NONTERMINAL_QUEUE_ROWS,
     Delivered,
@@ -24,6 +25,7 @@ from core.memory.store import (
     derive_principal_id,
     _keyed_digest,
 )
+from core.memory.types import ProviderSessionRef
 
 
 PROJECT = "p-22222222222222222222222222222222"
@@ -92,13 +94,20 @@ def test_store_creates_exact_memory_tables_and_due_index(tmp_path: Path) -> None
             row[1]
             for row in conn.execute("PRAGMA index_list('memory_capture_queue')")
         }
-        assert {"memory_meta", "memory_capture_queue"}.issubset(tables)
+        assert {
+            "memory_meta",
+            "memory_capture_queue",
+            "memory_session_flush_state",
+            "memory_flush_settlements",
+        }.issubset(tables)
         assert "ix_memory_capture_due" in indexes
         queue_columns = {row[1] for row in conn.execute("PRAGMA table_info('memory_capture_queue')")}
         meta_columns = {row[1] for row in conn.execute("PRAGMA table_info('memory_meta')")}
         assert {
             "principal_id",
             "project_ref",
+            "provider_session_ref",
+            "flush_generation",
             "provenance",
             "payload_attachments",
             "add_request_id",
@@ -114,6 +123,28 @@ def test_store_creates_exact_memory_tables_and_due_index(tmp_path: Path) -> None
             "processing_alert_active",
             "last_error_at",
         }.issubset(meta_columns)
+        session_state_columns = {
+            row[1]
+            for row in conn.execute("PRAGMA table_info('memory_session_flush_state')")
+        }
+        assert {
+            "provider_session_ref",
+            "epoch",
+            "generation",
+            "watermark_ms",
+            "fence_epoch",
+        }.issubset(session_state_columns)
+        settlement_columns = {
+            row[1]
+            for row in conn.execute("PRAGMA table_info('memory_flush_settlements')")
+        }
+        assert {
+            "provider_session_ref",
+            "generation",
+            "fence_epoch",
+            "operation_id",
+            "outcome",
+        }.issubset(settlement_columns)
         with pytest.raises(sqlite3.IntegrityError):
             conn.execute(
                 """
@@ -123,6 +154,56 @@ def test_store_creates_exact_memory_tables_and_due_index(tmp_path: Path) -> None
                 ) VALUES ('invalid', 0, 'src', 'payload', 1, 1, 'delivered', 'now')
                 """
             )
+
+
+def test_provider_session_ref_preserves_the_canonical_identity(tmp_path: Path) -> None:
+    store = MemoryStore(_store_path(tmp_path))
+
+    first = _enqueue(store, "identity")
+    duplicate = _enqueue(store, "identity", occurred_at_ms=2_000)
+
+    assert first.row is not None and duplicate.row is not None
+    reference = first.row.provider_session_ref
+    assert reference.as_tuple() == (
+        "u-11111111111111111111111111111111",
+        0,
+        PROJECT,
+        first.row.session_id,
+    )
+    assert ProviderSessionRef.deserialize(reference.serialize()) == reference
+    assert duplicate.row.provider_session_ref == reference
+    with sqlite3.connect(store.path) as conn:
+        persisted = conn.execute(
+            "SELECT provider_session_ref FROM memory_capture_queue"
+        ).fetchone()[0]
+    assert persisted == reference.serialize()
+
+
+def test_ambiguous_add_is_terminal_and_never_claimed_again(tmp_path: Path) -> None:
+    store = MemoryStore(_store_path(tmp_path))
+    _enqueue(store, "ambiguous")
+    claimed = store.claim_due(lease_owner="worker", now="2026-01-01T00:00:00.000Z")
+    assert claimed is not None
+
+    result = store.settle(
+        claimed,
+        AmbiguousAdd(add_request_id="provider-request"),
+        lease_owner="worker",
+        now=_dt("2026-01-01T00:00:01.000Z"),
+    )
+
+    assert result == SettleResult(settled=True, state="manual_required")
+    row = _row_for_source(store, "ambiguous")
+    assert row is not None
+    assert (row.state, row.payload_text, row.last_error, row.add_request_id) == (
+        "manual_required",
+        "queued payload",
+        "memory_provider_response_invalid",
+        "provider-request",
+    )
+    assert store.has_manual_required_fence() is True
+    assert store.claim_due(lease_owner="worker-2", now="2026-01-01T00:00:02.000Z") is None
+    assert store.ensure_meta().last_error == "memory_provider_response_invalid"
 
 
 def test_principal_derivation_is_stable_opaque_and_user_scoped() -> None:
@@ -358,7 +439,7 @@ def test_boot_recovery_samples_its_clock_after_reclaiming_leases(tmp_path: Path)
     )
 
     assert recovery.reclaimed == 1
-    assert observed_states == ["pending"], "the clock was sampled before leases were reclaimed"
+    assert observed_states == ["manual_required"], "the clock was sampled before leases were reclaimed"
     assert _row_for_source(store, "in-flight").flush_observed_at == "2026-01-01T00:00:09.000Z"
 
 
@@ -465,8 +546,11 @@ def test_reclaim_processing_and_clear_deletes_every_queue_row(tmp_path: Path) ->
     assert recovery.reclaimed == 1
     reclaimed = _row_for_source(store, "queued")
     assert reclaimed is not None
-    assert reclaimed.state == "pending"
+    assert reclaimed.state == "manual_required"
     assert reclaimed.attempts == 0
+    assert reclaimed.payload_text == "queued payload"
+    assert reclaimed.last_error == "memory_provider_response_invalid"
+    assert store.has_manual_required_fence() is True
 
     before = store.ensure_meta()
     clearing = store.begin_clear()

--- a/tests/test_memory_store.py
+++ b/tests/test_memory_store.py
@@ -204,7 +204,9 @@ def test_ambiguous_add_is_terminal_and_never_claimed_again(tmp_path: Path) -> No
     assert store.has_manual_required_fence() is True
     assert store.claim_due(lease_owner="worker-2", now="2026-01-01T00:00:02.000Z") is None
     assert store.ensure_meta().last_error == "memory_provider_response_invalid"
-    assert store.queue_stats().queue_plaintext_bytes == len("queued payload")
+    stats = store.queue_stats()
+    assert stats.receipt_unknown == 1
+    assert stats.queue_plaintext_bytes == len("queued payload")
     assert (
         store.enqueue_request(
             source_message_id="bounded-after-manual",

--- a/tests/test_memory_store.py
+++ b/tests/test_memory_store.py
@@ -97,9 +97,11 @@ def test_store_creates_exact_memory_tables_and_due_index(tmp_path: Path) -> None
         assert {
             "memory_meta",
             "memory_capture_queue",
+        }.issubset(tables)
+        assert not {
             "memory_session_flush_state",
             "memory_flush_settlements",
-        }.issubset(tables)
+        }.intersection(tables)
         assert "ix_memory_capture_due" in indexes
         queue_columns = {row[1] for row in conn.execute("PRAGMA table_info('memory_capture_queue')")}
         meta_columns = {row[1] for row in conn.execute("PRAGMA table_info('memory_meta')")}
@@ -107,7 +109,6 @@ def test_store_creates_exact_memory_tables_and_due_index(tmp_path: Path) -> None
             "principal_id",
             "project_ref",
             "provider_session_ref",
-            "flush_generation",
             "provenance",
             "payload_attachments",
             "add_request_id",
@@ -123,28 +124,6 @@ def test_store_creates_exact_memory_tables_and_due_index(tmp_path: Path) -> None
             "processing_alert_active",
             "last_error_at",
         }.issubset(meta_columns)
-        session_state_columns = {
-            row[1]
-            for row in conn.execute("PRAGMA table_info('memory_session_flush_state')")
-        }
-        assert {
-            "provider_session_ref",
-            "epoch",
-            "generation",
-            "watermark_ms",
-            "fence_epoch",
-        }.issubset(session_state_columns)
-        settlement_columns = {
-            row[1]
-            for row in conn.execute("PRAGMA table_info('memory_flush_settlements')")
-        }
-        assert {
-            "provider_session_ref",
-            "generation",
-            "fence_epoch",
-            "operation_id",
-            "outcome",
-        }.issubset(settlement_columns)
         with pytest.raises(sqlite3.IntegrityError):
             conn.execute(
                 """
@@ -221,35 +200,21 @@ def test_ambiguous_add_is_terminal_and_never_claimed_again(tmp_path: Path) -> No
         ).outcome
         == "queue_full"
     )
-
-
-def test_settlement_schema_accepts_settled_natural_boundary_records(tmp_path: Path) -> None:
-    store = MemoryStore(_store_path(tmp_path))
-    result = _enqueue(store, "settlement")
-    assert result.row is not None
-    reference = result.row.provider_session_ref.serialize()
-
-    with sqlite3.connect(store.path) as conn:
-        conn.execute(
-            """
-            INSERT INTO memory_flush_settlements (
-                settlement_id, provider_session_ref, generation, fence_epoch,
-                operation_id, operation_kind, outcome, flush_state, source,
-                observed_at, settled_at
-            ) VALUES (?, ?, 0, 0, ?, 'flush', 'succeeded', 'settled',
-                      'natural_boundary', '2026-01-01T00:00:00.000Z',
-                      '2026-01-01T00:00:00.000Z')
-            """,
-            ("settlement-1", reference, "operation-1"),
-        )
-        persisted = conn.execute(
-            """
-            SELECT flush_state, source
-            FROM memory_flush_settlements
-            WHERE settlement_id = 'settlement-1'
-            """
-        ).fetchone()
-    assert persisted == ("settled", "natural_boundary")
+    follow_up = store.enqueue_request(
+        source_message_id="same-session-after-manual",
+        session_id="session",
+        principal_id="u-11111111111111111111111111111111",
+        project_ref=PROJECT,
+        provenance="user_input",
+        payload_text="follow-up payload",
+        occurred_at_ms=2_000,
+        max_provider_timestamp_ms=4_102_444_800_000,
+        nonterminal_limit=2,
+    )
+    assert follow_up.outcome == "accepted"
+    assert follow_up.row is not None
+    assert follow_up.row.provider_session_ref == row.provider_session_ref
+    assert store.claim_due(lease_owner="worker-3", now="2026-01-01T00:00:02.000Z") is None
 
 
 def test_principal_derivation_is_stable_opaque_and_user_scoped() -> None:


### PR DESCRIPTION
## Capability

Establish the clean-schema Memory foundation for the later flush coordinator:
- Persist canonical provider session identity `(principal_id, epoch, project_ref, session_id)` on each capture.
- Keep durable enqueue, idempotency, claim, successful settlement, and boot recovery for the capture outbox.
- Convert malformed, ambiguous, disconnected, and timed-out provider add outcomes to terminal `manual_required` without automatic replay.
- Keep deterministic non-retryable provider rejections terminal and preserve existing status, data-exists, CLI, and capture contracts.

This PR intentionally contains no old-schema migration or compatibility layer, no flush coordinator tables, generation routing, in-flight serialization, watermark/fence settlement projection, natural-boundary settlement, retry coordination, operator UI/API, search, rotation, or release changes. Existing per-message flush behavior is unchanged.

## Evidence
- Unit: provider-session serialization, clean schema shape, idempotent enqueue, claim/settlement, manual fence, boot recovery, and provider transport classification tests.
- Contract: terminal manual-required rows retain payloads, fence the same canonical session, appear in status/failure diagnostics, and are never claimed again; deterministic rejections become terminal dead rows even when processing health is down.
- Scenario: focused Memory module, worker, EverOS adapter, store, presentation, and runtime suites.
- Manual residual: no UI/API or operator-resolution flow is included; no user-visible flush timing changes are introduced.

Tests: `283 passed` across the focused Memory suites; Ruff passes on all changed Python files.