### PR TITLE
fix(chat): show queued delegated Agent messages correctly

### DIFF
--- a/docs/plans/unified-background-work-banner.md
+++ b/docs/plans/unified-background-work-banner.md
@@ -20,8 +20,9 @@ The banner's source of truth is a **union assembled at runtime-state build time*
    keeps the banner correct-by-construction after a restart):
    - enabled watches whose callback session is this session;
    - pending/scheduled tasks targeting this session;
-   - running/queued delegated agent runs whose callback returns to this session (work this
-     session dispatched and is waiting on).
+   - active delegated agent runs whose callback returns to this session (work this session
+     dispatched and is waiting on). A linked Delivery still in the FIFO `queued` state is
+     presented as queued even when its executor Run has already moved to `running`.
 
 Each unified item carries: `kind` (`backend_activity` | `watch` | `task` | `agent_run`),
 `label` (watch name / task summary / target agent + short message head / activity description),
@@ -46,8 +47,9 @@ run detail.
   state payload (search `background_activities` producers in core/vibe; ChatPage consumes
   `runtimeState.background_activities` at ui/src/components/workbench/ChatPage.tsx ~1632).
 - Registry: `core/session_activities.py` (`SessionActivity`, `SessionActivityRegistry`).
-- Harness state: `run_definitions` (watches), scheduled tasks store, `agent_runs`
-  (status running/queued, callback lineage) — read-only queries.
+- Harness state: `run_definitions` (watches), scheduled tasks store, `agent_runs` (executor
+  status and callback lineage), and linked `message_deliveries` (FIFO queue status) — read-only
+  queries.
 - Banner UI: ChatPage banner block (~1626-1670) + `chat.activities.*` i18n keys.
 
 ## Owner design review (2026-07-16 21:15) — five requirements folded in

--- a/storage/workbench_sessions_service.py
+++ b/storage/workbench_sessions_service.py
@@ -1046,6 +1046,14 @@ def derive_session_harness_activities(conn: Connection, session_id: str) -> list
                 agent_runs.c.created_at,
                 agent_runs.c.started_at,
                 agent_runs.c.updated_at,
+                message_deliveries.c.state.label("delivery_state"),
+                message_deliveries.c.submitted_at.label("delivery_submitted_at"),
+            )
+            .select_from(
+                agent_runs.outerjoin(
+                    message_deliveries,
+                    message_deliveries.c.id == agent_runs.c.delivery_id,
+                )
             )
             .where(agent_runs.c.callback_session_id == session_id)
             .where(agent_runs.c.run_type == "agent_run")
@@ -1069,13 +1077,22 @@ def derive_session_harness_activities(conn: Connection, session_id: str) -> list
             label = _banner_label(f"{agent_name}: {head}")
         else:
             label = agent_name or head
-        since = str(row["started_at"] or row["created_at"] or "")
+        # A delegated executor can own a Run before its target Session accepts
+        # the queued Delivery. The banner describes that user-visible wait.
+        delivery_is_queued = row["delivery_state"] == "queued"
+        status = "queued" if delivery_is_queued else str(row["status"] or "running")
+        since = str(
+            (row["delivery_submitted_at"] if delivery_is_queued else None)
+            or row["started_at"]
+            or row["created_at"]
+            or ""
+        )
         items.append(
             _harness_banner_item(
                 item_id=f"agent_run:{row['id']}",
                 item_kind="agent_run",
                 session_id=session_id,
-                status=str(row["status"] or "running"),
+                status=status,
                 label=label,
                 since=since,
                 updated_at=str(row["updated_at"] or since),

--- a/tests/test_background_work_banner.py
+++ b/tests/test_background_work_banner.py
@@ -18,6 +18,8 @@ from sqlalchemy import insert
 
 from core.session_activities import SessionActivityRegistry
 from core.session_turns import SessionTurnManager
+from storage import message_deliveries as delivery_store
+from storage.agent_session_rows import create_agent_session_row
 from storage.background import SQLiteBackgroundTaskStore
 from storage.db import create_sqlite_engine
 from storage.importer import ensure_sqlite_state
@@ -78,6 +80,36 @@ def _insert_run(engine, **overrides) -> str:
     return values["id"]
 
 
+def _insert_queued_delivery(engine, *, delivery_id: str, session_id: str, now: str) -> None:
+    with engine.begin() as conn:
+        create_agent_session_row(
+            conn,
+            scope_id=None,
+            session_id=session_id,
+            session_anchor=session_id,
+            agent_backend="codex",
+            workdir="/tmp",
+            now=now,
+        )
+        delivery_store.insert_delivery(
+            conn,
+            delivery_id=delivery_id,
+            session_id=session_id,
+            priority="p3",
+            state="queued",
+            snapshot=delivery_store.message_snapshot(
+                scope_id=None,
+                session_id=session_id,
+                platform="avibe",
+                author="user",
+                source="harness",
+                text="audit the contract",
+            ),
+            dispatch_text="audit the contract",
+            now=now,
+        )
+
+
 def test_each_harness_source_contributes_one_row(tmp_path: Path):
     engine, _ = _make_engine(tmp_path)
     _insert_definition(
@@ -117,10 +149,40 @@ def test_each_harness_source_contributes_one_row(tmp_path: Path):
     assert by_kind["task"]["schedule_type"] == "cron"
     assert by_kind["agent_run"]["id"] == "agent_run:run-1"
     assert by_kind["agent_run"]["label"] == "worker: audit the contract"
+    assert by_kind["agent_run"]["status"] == "running"
     assert by_kind["agent_run"]["schedule_type"] is None
     # ``since`` and a stable id are present on every unified item.
     assert all(item["since"] == _NOW for item in items)
     assert all(item["id"] for item in items)
+
+
+def test_queued_delivery_projects_delegated_run_as_queued(tmp_path: Path):
+    engine, _ = _make_engine(tmp_path)
+    queued_at = "2026-07-16T00:00:01Z"
+    _insert_queued_delivery(
+        engine,
+        delivery_id="delivery-queued",
+        session_id="ses-delegate",
+        now=queued_at,
+    )
+    _insert_run(
+        engine,
+        id="run-queued-delivery",
+        agent_name="worker",
+        message="audit the contract",
+        session_id="ses-delegate",
+        callback_session_id="ses-caller",
+        delivery_id="delivery-queued",
+        status="running",
+        started_at="2026-07-16T00:00:02Z",
+    )
+
+    with engine.connect() as conn:
+        items = derive_session_harness_activities(conn, "ses-caller")
+
+    assert len(items) == 1
+    assert items[0]["status"] == "queued"
+    assert items[0]["since"] == queued_at
 
 
 def test_task_schedule_type_comes_from_the_durable_definition(tmp_path: Path):


### PR DESCRIPTION
## Summary

- capability: derive the Chat background-work banner state from both delegated Agent Run execution and linked Delivery queue ownership
- user-visible change: delegated messages still waiting in the target Session FIFO now show as queued instead of Agent running
- motivation: the Delivery/Turn ownership migration intentionally keeps the executor Run running while its Delivery may remain queued, but the banner projection only read the Run status

## Scenario Coverage

- scenario IDs: none; the unified background-work banner has no cataloged scenario ID
- unit / contract coverage: added a cross-table regression for `Run=running + Delivery=queued`, preserved the legacy no-Delivery fallback, and updated the banner projection contract
- scenario coverage: related Chat turn-state, Workbench-only runtime, and banner projection suites pass
- residual manual checks: no live service restart or mutation of existing Sessions/queues; browser rendering remains covered by the existing status-to-label UI tests

## Validation

- commands run: focused pytest suites for banner, Codex turn state, and Workbench-only runtime; Ruff on changed Python files; `git diff --check`
- result: 22 tests passed; Ruff and diff checks passed

## Risks / Follow-ups

- risk: low; this is a read-only outer join and presentation projection, with no Run or Delivery lifecycle mutation
- follow-up: none
