### PR TITLE
fix(regression): preserve realtime voice rollout flag

### DIFF
--- a/.env.regression.example
+++ b/.env.regression.example
@@ -43,6 +43,8 @@ REGRESSION_DEFAULT_CWD=/home/avibe/.avibe/workdir
 REGRESSION_DEFAULT_BACKEND=opencode
 REGRESSION_LOG_LEVEL=INFO
 REGRESSION_LANGUAGE=en
+# Build-time gray rollout for realtime ASR. Changing this forces a UI rebuild.
+REGRESSION_VOICE_REALTIME_ENABLED=false
 
 # Master/worktree regression does not necessarily carry a packaged release
 # manifest, so the regression script prepares Show Runtime from source by

--- a/docs/voice-realtime-prototype.md
+++ b/docs/voice-realtime-prototype.md
@@ -6,11 +6,15 @@ build and `VOICE_REALTIME_ENABLED=true` in the cloud service only after both
 halves are deployed together. The default model is
 `qwen3-asr-flash-realtime`.
 
+For Incus regression builds, set `REGRESSION_VOICE_REALTIME_ENABLED=true` in
+`.env.regression`. The runner maps it to the Vite build flag and includes it in
+the UI fingerprint, so changing the flag forces a rebuild.
+
 The browser sends `start`, 250 ms PCM16 `audio`, and `finish` frames over the
 `avibe-asr-v1.<cloud-token>` subprotocol. The cloud route authenticates the
 existing `asr` capability, forwards audio to the configured DashScope realtime
 endpoint, and returns non-authoritative previews followed by one final text.
-The preview never changes the draft; only the server-cleaned final result is
-inserted. Provider credentials remain server-side. Handshake, transport,
-protocol, timeout, and upstream failures activate the existing HTTP recording
-fallback without changing legacy or dictation endpoint contracts.
+The preview is transient editor state; only the server-cleaned final result is
+committed to the draft. Provider credentials remain server-side. Handshake,
+transport, protocol, timeout, and upstream failures activate the existing HTTP
+recording fallback without changing legacy or dictation endpoint contracts.

--- a/scripts/incus_regression.py
+++ b/scripts/incus_regression.py
@@ -1222,7 +1222,14 @@ def update_dependencies_and_build(
             or ui_deps_changed
             or previous_fingerprints.get("ui_source") != next_fingerprints.get("ui_source")
         ):
-            runner.run(tenant_exec(target, "cd ui && npm run build", remote=remote))
+            realtime_enabled = voice_realtime_build_env()
+            runner.run(
+                tenant_exec(
+                    target,
+                    f"cd ui && VITE_VOICE_REALTIME_ENABLED={shlex.quote(realtime_enabled)} npm run build",
+                    remote=remote,
+                )
+            )
         else:
             print("UI source fingerprint unchanged; skipping npm run build.")
     if python_changed:
@@ -1417,6 +1424,7 @@ def cmd_build_base(args: argparse.Namespace) -> int:
 def cmd_up(args: argparse.Namespace) -> int:
     repo_root = current_repo_root()
     loaded_env_file = load_env_file(repo_root, args.env_file)
+    voice_realtime_build_env()
     if not args.dry_run:
         require_incus()
     preflight_during_target_resolution = args.remote is None and args.target != MASTER_TARGET

--- a/scripts/incus_regression.py
+++ b/scripts/incus_regression.py
@@ -151,6 +151,13 @@ def regression_env(suffix: str, default: str = "") -> str:
     return value.strip()
 
 
+def voice_realtime_build_env() -> str:
+    value = regression_env("VOICE_REALTIME_ENABLED", "false").lower()
+    if value not in {"true", "false"}:
+        raise RegressionError("REGRESSION_VOICE_REALTIME_ENABLED must be true or false.")
+    return value
+
+
 def host_bind_env(default: str = "127.0.0.1") -> str:
     return (
         regression_env("PORT_BIND_HOST")
@@ -856,6 +863,7 @@ def compute_fingerprints(repo_root: Path) -> dict:
                 "ui/tsconfig.node.json",
             ],
         ),
+        f"voice_realtime={voice_realtime_build_env()}",
     ]
     return {
         "python": file_hash(repo_root, ["pyproject.toml", "uv.lock"]),
@@ -919,6 +927,7 @@ def runtime_env_payload(repo_root: Path | None = None) -> bytes:
         "OPENAI_API_KEY": os.environ.get("OPENAI_API_KEY", ""),
         "OPENAI_BASE_URL": os.environ.get("OPENAI_BASE_URL", ""),
         "OPENAI_API_BASE": os.environ.get("OPENAI_API_BASE", ""),
+        "VITE_VOICE_REALTIME_ENABLED": voice_realtime_build_env(),
     }
     for key, value in os.environ.items():
         if key == "REGRESSION_UI_HOST":

--- a/tests/test_incus_regression.py
+++ b/tests/test_incus_regression.py
@@ -535,9 +535,23 @@ def test_ui_public_assets_are_part_of_source_fingerprint(tmp_path: Path) -> None
     assert before != after
 
 
+def test_voice_realtime_build_flag_is_part_of_ui_fingerprint(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("REGRESSION_VOICE_REALTIME_ENABLED", "false")
+    before = incus_regression.compute_fingerprints(tmp_path)["ui_source"]
+
+    monkeypatch.setenv("REGRESSION_VOICE_REALTIME_ENABLED", "true")
+    after = incus_regression.compute_fingerprints(tmp_path)["ui_source"]
+
+    assert before != after
+
+
 def test_runtime_env_payload_maps_show_runtime_and_llm_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("REGRESSION_SHOW_RUNTIME_GITHUB_REF", "main")
     monkeypatch.setenv("REGRESSION_SLACK_CHANNEL", "C123")
+    monkeypatch.setenv("REGRESSION_VOICE_REALTIME_ENABLED", "true")
     monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
 
     payload = incus_regression.runtime_env_payload().decode()
@@ -548,7 +562,20 @@ def test_runtime_env_payload_maps_show_runtime_and_llm_env(monkeypatch: pytest.M
     assert "VIBE_SHOW_RUNTIME_SOURCE=github-source" in payload
     assert "VIBE_SHOW_RUNTIME_GITHUB_REF=main" in payload
     assert "REGRESSION_SLACK_CHANNEL=C123" in payload
+    assert "VITE_VOICE_REALTIME_ENABLED=true" in payload
     assert "OPENAI_API_KEY=sk-test" in payload
+
+
+def test_runtime_env_payload_rejects_invalid_voice_realtime_flag(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("REGRESSION_VOICE_REALTIME_ENABLED", "enabled")
+
+    with pytest.raises(
+        incus_regression.RegressionError,
+        match="REGRESSION_VOICE_REALTIME_ENABLED must be true or false",
+    ):
+        incus_regression.runtime_env_payload()
 
 
 def test_runtime_env_payload_ignores_legacy_regression_env(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_incus_regression.py
+++ b/tests/test_incus_regression.py
@@ -578,6 +578,25 @@ def test_runtime_env_payload_rejects_invalid_voice_realtime_flag(
         incus_regression.runtime_env_payload()
 
 
+def test_up_rejects_invalid_voice_realtime_flag_before_preflight(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = []
+    monkeypatch.setenv("REGRESSION_VOICE_REALTIME_ENABLED", "enabled")
+    monkeypatch.setattr(incus_regression, "current_repo_root", lambda: tmp_path)
+    monkeypatch.setattr(incus_regression, "load_env_file", lambda repo_root, env_file: None)
+    monkeypatch.setattr(incus_regression, "require_incus", lambda: calls.append("require_incus"))
+
+    with pytest.raises(
+        incus_regression.RegressionError,
+        match="REGRESSION_VOICE_REALTIME_ENABLED must be true or false",
+    ):
+        incus_regression.cmd_up(argparse.Namespace(env_file=None, dry_run=False))
+
+    assert calls == []
+
+
 def test_runtime_env_payload_ignores_legacy_regression_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("REGRESSION_SHOW_RUNTIME_GITHUB_REF", raising=False)
     monkeypatch.delenv("REGRESSION_SLACK_CHANNEL", raising=False)
@@ -2021,8 +2040,11 @@ def test_update_builds_ui_before_editable_install() -> None:
     assert build_index < install_index
 
 
-def test_force_ui_rebuilds_even_when_fingerprints_match() -> None:
+def test_force_ui_rebuilds_with_exported_voice_realtime_flag(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     commands = []
+    monkeypatch.setenv("REGRESSION_VOICE_REALTIME_ENABLED", "true")
 
     class RecordingRunner:
         def run(self, command, **kwargs):
@@ -2052,7 +2074,7 @@ def test_force_ui_rebuilds_even_when_fingerprints_match() -> None:
 
     joined = "\n".join(commands)
     assert "cd ui && npm ci" in joined
-    assert "cd ui && npm run build" in joined
+    assert "cd ui && VITE_VOICE_REALTIME_ENABLED=true npm run build" in joined
     assert "pip install -e ." not in joined
 
 
@@ -2128,7 +2150,7 @@ def test_missing_ui_dist_rebuilds_even_when_python_is_unchanged() -> None:
 
     joined = "\n".join(commands)
     assert "test -d ui/dist && test -f ui/dist/index.html" in joined
-    assert "cd ui && npm run build" in joined
+    assert "VITE_VOICE_REALTIME_ENABLED=false npm run build" in joined
     assert "pip install -e ." not in joined
 
 


### PR DESCRIPTION
## Summary
- map the regression realtime rollout setting into the Vite build environment
- include that setting in the UI fingerprint so toggling it forces a rebuild
- document the regression setting and reject invalid values before deployment

## Evidence
- Unit: focused realtime/runtime-env tests passed
- Contract: regression runtime-env mapping and UI fingerprint behavior are covered
- Scenario: no catalog scenario IDs apply
- Manual: reproduced a standard deployment compiling realtime off, then rebuilt the regression UI with the flag and verified the compiled gate, service health, and public asset

## Validation
- `ruff check scripts/incus_regression.py tests/test_incus_regression.py`
- `pytest -q tests/test_incus_regression.py -k 'voice_realtime or runtime_env_payload'` (5 passed)
- `pytest -q tests/test_incus_regression.py -k 'not test_up_reserves_worktree_port_under_mapping_lock'` (72 passed; the excluded pre-existing test requires host port 15200, currently occupied by an existing Lima listener)
