### PR TITLE
fix(ui): keep realtime voice preview visible

### DIFF
--- a/ui/src/components/workbench/MentionEditor.tsx
+++ b/ui/src/components/workbench/MentionEditor.tsx
@@ -470,6 +470,7 @@ function BootstrapPlugin({
         text: string,
         tag?: string | string[],
         insertion: VoiceInsertionSnapshot = replacement,
+        keepEndVisible = false,
       ): VoiceInsertionSnapshot | null => {
         let inserted: VoiceInsertionSnapshot | null = null;
         editor.update(() => {
@@ -490,7 +491,14 @@ function BootstrapPlugin({
           $setSelection(selection);
           selection.insertText(result.insertion);
           inserted = result.snapshot;
-        }, tag ? { tag } : undefined);
+        }, {
+          tag,
+          onUpdate: () => {
+            if (!keepEndVisible || inserted === null || inserted.end !== inserted.text.length) return;
+            const root = editor.getRootElement();
+            if (root !== null) root.scrollTop = root.scrollHeight;
+          },
+        });
         return inserted;
       };
 
@@ -547,6 +555,7 @@ function BootstrapPlugin({
             text,
             [VOICE_PREVIEW_TAG, HISTORIC_TAG],
             snapshot,
+            true,
           );
           if (insertion === null) {
             voicePreviewRef.current = null;
@@ -562,6 +571,7 @@ function BootstrapPlugin({
             text,
             HISTORY_PUSH_TAG,
             snapshot,
+            true,
           );
           if (inserted !== null) voicePreviewRef.current = null;
           return inserted !== null;

--- a/ui/src/components/workbench/MentionEditor.voicePreview.test.tsx
+++ b/ui/src/components/workbench/MentionEditor.voicePreview.test.tsx
@@ -66,6 +66,48 @@ describe('MentionEditor voice preview', () => {
     expect(onChange.mock.calls.at(-1)?.[3]).toBe(false);
   });
 
+  it('keeps an appended realtime preview visible after the editor starts scrolling', async () => {
+    const { ref } = renderEditor('Existing draft');
+    const editor = screen.getByLabelText('Message');
+    await waitFor(() => expect(editor.textContent).toBe('Existing draft'));
+    let scrollHeight = 240;
+    Object.defineProperty(editor, 'scrollHeight', {
+      configurable: true,
+      get: () => scrollHeight,
+    });
+    editor.scrollTop = 0;
+    const snapshot = voiceInsertionSnapshot('Existing draft', 14, 14);
+
+    act(() => {
+      expect(ref.current?.showVoicePreview(snapshot, 'first realtime words')).toBe(true);
+    });
+    await waitFor(() => expect(editor.scrollTop).toBe(240));
+
+    scrollHeight = 360;
+    editor.scrollTop = 80;
+    act(() => {
+      expect(ref.current?.showVoicePreview(snapshot, 'first realtime words and more')).toBe(true);
+    });
+    await waitFor(() => expect(editor.scrollTop).toBe(360));
+  });
+
+  it('does not move the scroll position for a sentence insertion away from the end', async () => {
+    const { ref } = renderEditor('Plan today');
+    const editor = screen.getByLabelText('Message');
+    await waitFor(() => expect(editor.textContent).toBe('Plan today'));
+    Object.defineProperty(editor, 'scrollHeight', { configurable: true, value: 320 });
+    editor.scrollTop = 40;
+
+    act(() => {
+      expect(ref.current?.showVoicePreview(
+        voiceInsertionSnapshot('Plan today', 5, 5),
+        'the launch',
+      )).toBe(true);
+    });
+    await waitFor(() => expect(editor.textContent).toBe('Plan the launch today'));
+    expect(editor.scrollTop).toBe(40);
+  });
+
   it('restores the original rich editor state when recording is discarded', async () => {
     const { ref } = renderEditor();
     const editor = screen.getByLabelText('Message');


### PR DESCRIPTION
## Summary

- keep append-only realtime voice previews pinned to the bottom of the capped composer editor
- preserve the current scroll position for sentence insertions that occur away from the end
- cover successive preview growth and middle-insertion behavior with focused Lexical tests

## Evidence

- Unit: `MentionEditor.voicePreview.test.tsx` (6 passing tests)
- Contract: appended previews follow `scrollHeight`; non-terminal insertions do not move `scrollTop`
- Scenario: no voice-input scenario ID exists in the current catalog
- Build: UI production build and lint baseline pass
- Residual manual check: authenticated microphone behavior after regression deployment

