### PR TITLE
fix(memory): close post-merge lifecycle gaps

### DIFF
--- a/core/memory/runtime.py
+++ b/core/memory/runtime.py
@@ -992,7 +992,9 @@ class MemoryRuntime:
             )
         ):
             raise ValueError("invalid canonical Memory session scopes")
-        if not self.available or not self._config.enabled or self._maintenance_open():
+        if not self.available or not self._config.enabled:
+            return await operation()
+        if self._maintenance_open():
             raise MemorySessionLifecycleBusyError("memory session lifecycle is unavailable")
 
         timeout = _final_flush_timeout(deadline_seconds)

--- a/tests/test_memory_slice3.py
+++ b/tests/test_memory_slice3.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import gc
 import json
+import sys
 import weakref
 from pathlib import Path
 from types import SimpleNamespace
@@ -15,6 +16,9 @@ from config.v2_config import MemoryConfig, MemoryEndpointConfig, MemoryProcessin
 from core.controller import Controller
 from core.handlers.message_handler import MessageHandler
 from core.memory import CaptureAccepted, CaptureDuplicate
+from core.memory.artifact import FakeMemoryArtifactManager
+from core.memory.runtime import MemoryRuntime
+from core.memory.store import MemoryStore
 from modules.im.base import FileAttachment, MessageContext
 from modules.im.message_facts import (
     is_ordinary_discord_text,
@@ -677,6 +681,84 @@ def test_archive_memory_cli_session_flushes_every_cwd_scope_deterministically(
             "deadline_seconds": 3.0,
         }
     ]
+
+
+def test_archive_memory_cli_session_skips_flush_when_memory_is_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from core.session_turns import SessionTurnManager
+    from storage import workbench_sessions_service
+    from storage.db import create_sqlite_engine
+    from storage.importer import ensure_sqlite_state
+    from storage.projects_service import create_project
+
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    ensure_sqlite_state()
+    engine = create_sqlite_engine()
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    with engine.begin() as conn:
+        project = create_project(conn, str(project_dir), display_name="Project")
+        session_id = workbench_sessions_service.create_session(
+            conn,
+            scope_id=project["scope_id"],
+            agent_backend="claude",
+            title="Archive with Memory disabled",
+        )["id"]
+
+    principal_id = "u-" + ("2" * 32)
+    store = MemoryStore(tmp_path / "memory.sqlite")
+    accepted = store.enqueue_request(
+        source_message_id="persisted-scope",
+        session_id=session_id,
+        principal_id=principal_id,
+        project_ref=PROJECT,
+        provenance="user_input",
+        payload_text="persist this scope",
+        occurred_at_ms=1_725_000_001_234,
+        max_provider_timestamp_ms=4_102_444_800_000,
+    )
+    assert accepted.row is not None
+
+    disabled = MemoryConfig(enabled=False)
+    runtime = MemoryRuntime(
+        disabled,
+        store=store,
+        artifact_manager=FakeMemoryArtifactManager(python=Path(sys.executable)),
+        effective_home=tmp_path / "runtime",
+    )
+    assert runtime.available is True
+    assert runtime._maintenance_open() is False
+
+    async def flush_must_not_run(**_kwargs) -> bool:
+        raise AssertionError("disabled Memory must not flush during archive")
+
+    monkeypatch.setattr(runtime, "_final_flush_under_admission", flush_must_not_run)
+    controller = _controller()
+    controller.config.memory = disabled
+    controller.memory_runtime = runtime
+    controller.memory_module = runtime.module
+    controller.session_turns = SessionTurnManager(controller)
+    controller._memory_scopes_by_session = {}
+    controller._memory_cli_facts_by_session = {}
+
+    async def run() -> dict[str, object]:
+        try:
+            return await controller.archive_memory_cli_session(session_id)
+        finally:
+            await runtime.close()
+
+    try:
+        result = asyncio.run(run())
+        assert result["status"] == "archived"
+        assert store.resolve_current_session_scopes(session_id) == (
+            (principal_id, PROJECT),
+        )
+        with engine.connect() as conn:
+            assert workbench_sessions_service.get_session(conn, session_id)["status"] == "archived"
+    finally:
+        engine.dispose()
 
 
 def test_workbench_capture_requires_resolved_identity_and_uses_row_id() -> None:

--- a/tests/test_scheduled_tasks.py
+++ b/tests/test_scheduled_tasks.py
@@ -10648,7 +10648,11 @@ def test_dead_accepted_owner_converges_run_session_and_persisted_fifo(
 
     from core.internal_server import create_app
     from core.message_output import terminal_output_for
-    from core.session_turns import SessionTurnManager, emit_matches_active_turn
+    from core.session_turns import (
+        TURN_LIFECYCLE_ADMISSION_KEY,
+        SessionTurnManager,
+        emit_matches_active_turn,
+    )
     from modules.agents.base import AgentRequest
     from modules.agents.service import AgentService
 
@@ -10788,18 +10792,26 @@ def test_dead_accepted_owner_converges_run_session_and_persisted_fifo(
 
     async def _handle_scheduled_message(context, message, parsed_session_key=None):
         del parsed_session_key
-        await controller.agent_service.handle_message(
-            "claude",
-            AgentRequest(
-                context=context,
-                message=message,
-                user_message=message,
-                working_path=str(tmp_path),
-                base_session_id=session_id,
-                composite_session_id=f"{session_id}:{tmp_path}",
-                session_key=controller._get_session_key(context),
-            ),
+        lifecycle_admission = (context.platform_specific or {}).pop(
+            TURN_LIFECYCLE_ADMISSION_KEY,
+            None,
         )
+        try:
+            await controller.agent_service.handle_message(
+                "claude",
+                AgentRequest(
+                    context=context,
+                    message=message,
+                    user_message=message,
+                    working_path=str(tmp_path),
+                    base_session_id=session_id,
+                    composite_session_id=f"{session_id}:{tmp_path}",
+                    session_key=controller._get_session_key(context),
+                ),
+            )
+        finally:
+            if lifecycle_admission is not None:
+                lifecycle_admission.release()
 
     controller.message_handler = SimpleNamespace(
         handle_scheduled_message=_handle_scheduled_message,


### PR DESCRIPTION
## Summary

Post-review cleanup for #1231 against `dev`:

- archive Workbench sessions without flushing when Memory is disabled, even when the session has persisted Memory scopes;
- align direct scheduled-turn and internal-server test fixtures with the lifecycle-admission ownership introduced by #1231, eliminating deterministic FIFO stalls after merge.

## Evidence

- Review finding: https://github.com/avibe-bot/avibe/pull/1231#discussion_r3744303405
- Failed merged-head job: https://github.com/avibe-bot/avibe/actions/runs/31320965262/job/93263770128
- Unit: disabled-Memory archive regression uses a real `MemoryStore` and `MemoryRuntime(enabled=False)`; Memory slice 41/41; lifecycle subset 6/6.
- Scenario: HFR-002 failed locally before the fixture fix, then passed 10 consecutive runs after lifecycle-admission release matched the production `MessageHandler` owner.
- CI parity: shard 3 reproduced the held-admission failure in `tests/test_internal_server.py`; after the shared controller double adopted the production owner, all 106 tests in that file passed.
- Contract: no contract changes.
- Residual manual checks: none.

## Root Cause

The multi-scope lifecycle path treated disabled Memory as busy instead of executing the terminal archive without a flush. Separately, #1231 added a Session lifecycle admission that production releases in `MessageHandler`; direct AgentService and internal-server fixtures bypassed that owner and left the admission held, so persisted FIFO successors could never start.
