### PR TITLE
fix(ui): register the PWA catch-all route in the route inventory

### DIFF
--- a/ui/src/lib/applicationRoutes.ts
+++ b/ui/src/lib/applicationRoutes.ts
@@ -58,6 +58,8 @@ export const APPLICATION_ROUTE_PATHS = [
   '/remote-access',
   '/doctor',
   '/doctor/logs',
+  // PWA cold-launch fallback keeps stale extensionless paths inside AuthGuard.
+  '*',
 ] as const;
 
 export const APPLICATION_DYNAMIC_ROUTE_PATHS = [


### PR DESCRIPTION
## Summary

Register the intentional React Router catch-all route introduced by the PWA cold-launch fix in the shared application route inventory. The inventory test exists to make every App.tsx route declaration explicit, so this is a test-contract registration only; runtime behavior is unchanged.

#1238 (PWA cold-launch auth-sheet fix) added the `*` fallback route intentionally, and #1239 (realtime voice preview) carried the route inventory test from the prior base. Each PR was green independently; after both squash merges landed on master, the route declaration and inventory diverged and master turned red. This PR reconciles those two valid changes.

## Evidence

- Unit: `npm test` in `ui/` — 130 files passed, 1629 tests passed.
- Contract: `ui/src/lib/applicationRoutes.test.ts` now explicitly registers the `*` declaration from `App.tsx`.
- Scenario: no scenario catalog changes; #1238 cold-launch behavior remains covered by its existing auth/setup scenarios.
- Residual manual check: no browser/manual verification needed for this test-only inventory update.

## Dependencies

#1238 and #1239 are already merged into `master`; this PR has no unmerged dependency.

## Known by design

- `*` is a React Router catch-all declaration for stale extensionless paths and PWA cold-launch recovery. It is intentionally present in the route inventory even though it is not a navigable exact URL.
