### PR TITLE
refactor(memory): centralize cancellation-safe blocking work

### DIFF
--- a/core/controller.py
+++ b/core/controller.py
@@ -48,6 +48,7 @@ from core.watches import ManagedWatchService
 from core.vibe_agents import VibeAgent, VibeAgentStore
 from core.memory import CaptureRequest
 from core.memory.admission import CaptureAdmission, InboundTurnFacts
+from core.memory.blocking import run_blocking
 from vibe.i18n import get_supported_languages, t as i18n_t
 
 logger = logging.getLogger(__name__)
@@ -1733,17 +1734,7 @@ class Controller:
         async def archive_operation() -> dict[str, Any]:
             # Cancelling the socket request must not release Memory admission
             # while SQLite is still committing the terminal transition.
-            task = asyncio.create_task(asyncio.to_thread(archive_session))
-            cancellation: asyncio.CancelledError | None = None
-            while not task.done():
-                try:
-                    await asyncio.shield(task)
-                except asyncio.CancelledError as error:
-                    cancellation = cancellation or error
-            result = task.result()
-            if cancellation is not None:
-                raise cancellation
-            return result
+            return await run_blocking(archive_session)
 
         async def run_memory_lifecycle() -> dict[str, Any]:
             live_scope = self.memory_scope_for_cli_session(raw_session_id)

--- a/core/memory/blocking.py
+++ b/core/memory/blocking.py
@@ -1,0 +1,36 @@
+"""Cancellation-safe execution for blocking Memory operations."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable
+from typing import Any, TypeVar
+
+
+_Result = TypeVar("_Result")
+
+
+async def run_blocking(
+    operation: Callable[..., _Result],
+    /,
+    *args: Any,
+    **kwargs: Any,
+) -> _Result:
+    """Settle one synchronous Memory operation before propagating cancellation."""
+
+    task = asyncio.create_task(asyncio.to_thread(operation, *args, **kwargs))
+    cancellation: asyncio.CancelledError | None = None
+    while not task.done():
+        try:
+            await asyncio.shield(task)
+        except asyncio.CancelledError as error:
+            cancellation = cancellation or error
+        except Exception:
+            break
+    if cancellation is not None:
+        try:
+            task.result()
+        except (Exception, asyncio.CancelledError):
+            pass
+        raise cancellation
+    return task.result()

--- a/core/memory/coordinator.py
+++ b/core/memory/coordinator.py
@@ -16,6 +16,7 @@ from core.memory.attachments import (
     AttachmentPinStore,
     decode_pinned_bundle,
 )
+from core.memory.blocking import run_blocking
 from core.memory.everos import (
     AddAck,
     AddRejected,
@@ -885,20 +886,7 @@ class SessionFlushCoordinator:
         return value.astimezone(timezone.utc)
 
     async def _store_call(self, operation: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
-        task = asyncio.create_task(asyncio.to_thread(operation, *args, **kwargs))
-        cancellation: asyncio.CancelledError | None = None
-        while not task.done():
-            try:
-                await asyncio.shield(task)
-            except asyncio.CancelledError as error:
-                cancellation = cancellation or error
-        if cancellation is not None:
-            try:
-                task.result()
-            except (Exception, asyncio.CancelledError):
-                pass
-            raise cancellation
-        return task.result()
+        return await run_blocking(operation, *args, **kwargs)
 
 
 def _positive_timeout(value: float) -> float:

--- a/core/memory/module.py
+++ b/core/memory/module.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from typing import Any, Literal
 
 from config import paths
+from core.memory.blocking import run_blocking
 from core.memory.attachments import (
     AttachmentPinError,
     AttachmentPinStore,
@@ -290,7 +291,7 @@ class MemoryModule:
         pinned_bundle: PinnedBundle | None = None
         try:
             if request.attachments:
-                pinned_bundle = await self._thread_call(
+                pinned_bundle = await run_blocking(
                     self._attachment_store.pin,
                     request.attachments,
                 )
@@ -360,7 +361,7 @@ class MemoryModule:
 
     async def _release_unadmitted_bundle(self, bundle_id: str) -> None:
         try:
-            await self._thread_call(self._attachment_store.release, bundle_id)
+            await run_blocking(self._attachment_store.release, bundle_id)
         except Exception:
             # It has no DB reference and boot reconciliation removes the orphan.
             return
@@ -892,26 +893,7 @@ class MemoryModule:
             return
 
     async def _store_call(self, method: Callable[..., Any], /, *args: Any, **kwargs: Any) -> Any:
-        return await self._thread_call(method, *args, **kwargs)
-
-    @staticmethod
-    async def _thread_call(method: Callable[..., Any], /, *args: Any, **kwargs: Any) -> Any:
-        """Settle durable thread work before propagating caller cancellation."""
-
-        task = asyncio.create_task(asyncio.to_thread(method, *args, **kwargs))
-        cancellation: asyncio.CancelledError | None = None
-        while not task.done():
-            try:
-                await asyncio.shield(task)
-            except asyncio.CancelledError as error:
-                cancellation = cancellation or error
-        if cancellation is not None:
-            try:
-                task.result()
-            except (Exception, asyncio.CancelledError):
-                pass
-            raise cancellation
-        return task.result()
+        return await run_blocking(method, *args, **kwargs)
 
     def _default_free_disk_bytes(self) -> int:
         return int(shutil.disk_usage(self._store.path.parent).free)

--- a/core/memory/runtime.py
+++ b/core/memory/runtime.py
@@ -1727,6 +1727,7 @@ class MemoryRuntime:
         task = self._terminal_snapshot_gc_task
         if (
             self._closing
+            or self._artifact_installing
             or self._clear_journal is None
             or self._snapshot_manager is None
             or self._clear_journal_error is not None
@@ -1751,6 +1752,7 @@ class MemoryRuntime:
         task = self._backup_stage_reconcile_task
         if (
             self._closing
+            or self._artifact_installing
             or not self.available
             or self._backup_manager is None
             or self._clear_journal is None

--- a/core/memory/runtime.py
+++ b/core/memory/runtime.py
@@ -1787,6 +1787,8 @@ class MemoryRuntime:
         try:
             async with self._reconcile_lock, self.module._lifecycle_lock:
                 async with self.module._root_lifecycle_lock():
+                    if self._artifact_installing:
+                        return
                     journal.assert_backup_allowed()
                     restore_journal.assert_idle()
                     await self._run_maintenance_io(

--- a/core/memory/runtime.py
+++ b/core/memory/runtime.py
@@ -2118,6 +2118,8 @@ class MemoryRuntime:
                         self._artifact_installing = False
                 except asyncio.CancelledError as error:
                     cancellation = cancellation or error
+            self._ensure_terminal_snapshot_gc()
+            self._ensure_backup_stage_reconcile()
         if cancellation is not None:
             raise cancellation
         if ensure_failed:

--- a/core/memory/runtime.py
+++ b/core/memory/runtime.py
@@ -33,6 +33,7 @@ from core.memory.backup_restore_journal import (
     BackupRestoreOperation,
     MemoryBackupRestoreJournal,
 )
+from core.memory.blocking import run_blocking
 from core.memory.clear_journal import (
     ClearOperation,
     ClearSurface,
@@ -1158,15 +1159,7 @@ class MemoryRuntime:
         operation: Callable[[], dict[str, Any]],
     ) -> dict[str, Any]:
         async with self.module._lifecycle_lock:
-            task = asyncio.create_task(asyncio.to_thread(operation))
-            try:
-                return await asyncio.shield(task)
-            except asyncio.CancelledError:
-                try:
-                    await asyncio.shield(task)
-                except Exception:
-                    pass
-                raise
+            return await run_blocking(operation)
 
     async def create_backup(self, backup_id: str | None = None) -> MemorySnapshot:
         """Create one ordinary Memory backup under the full maintenance fence."""
@@ -1280,22 +1273,7 @@ class MemoryRuntime:
     ) -> _MaintenanceIOResult:
         """Keep the maintenance fence until a cancelled I/O thread settles."""
 
-        task = asyncio.create_task(asyncio.to_thread(operation))
-        cancellation: asyncio.CancelledError | None = None
-        while not task.done():
-            try:
-                await asyncio.shield(task)
-            except asyncio.CancelledError as error:
-                cancellation = cancellation or error
-            except Exception:
-                break
-        if cancellation is not None:
-            try:
-                task.result()
-            except (Exception, asyncio.CancelledError):
-                pass
-            raise cancellation
-        return task.result()
+        return await run_blocking(operation)
 
     async def clear(self, *, operator_ref: str) -> dict[str, Any]:
         if not self.available:
@@ -2711,17 +2689,8 @@ class MemoryRuntime:
                 return True, await self._run_call_log_maintenance()
 
     async def _run_call_log_maintenance(self) -> str | None:
-        task = asyncio.create_task(
-            asyncio.to_thread(maintain_call_log, self._call_log_db_path)
-        )
         try:
-            return await asyncio.shield(task)
-        except asyncio.CancelledError:
-            try:
-                await asyncio.shield(task)
-            except Exception:
-                pass
-            raise
+            return await run_blocking(maintain_call_log, self._call_log_db_path)
         except Exception:
             return "writer_failures"
 

--- a/core/memory/worker.py
+++ b/core/memory/worker.py
@@ -9,6 +9,7 @@ from datetime import datetime, timezone
 from typing import Any
 
 from core.memory.attachments import AttachmentPinStore
+from core.memory.blocking import run_blocking
 from core.memory.coordinator import ProcessingEvent, SessionFlushCoordinator
 from core.memory.everos import MemoryProviderPort
 from core.memory.store import MemoryStore, QueueRow
@@ -177,20 +178,7 @@ class MemoryWorker:
         raise cancellation
 
     async def _store_call(self, operation: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
-        task = asyncio.create_task(asyncio.to_thread(operation, *args, **kwargs))
-        cancellation: asyncio.CancelledError | None = None
-        while not task.done():
-            try:
-                await asyncio.shield(task)
-            except asyncio.CancelledError as error:
-                cancellation = cancellation or error
-        if cancellation is not None:
-            try:
-                task.result()
-            except (Exception, asyncio.CancelledError):
-                pass
-            raise cancellation
-        return task.result()
+        return await run_blocking(operation, *args, **kwargs)
 
 
 def _positive_timeout(value: float) -> float:

--- a/tests/test_memory_blocking.py
+++ b/tests/test_memory_blocking.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import asyncio
+import threading
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+
+from core.memory.blocking import run_blocking
+
+
+def test_run_blocking_returns_operation_result() -> None:
+    def operation(value: int, *, increment: int) -> int:
+        return value + increment
+
+    assert asyncio.run(run_blocking(operation, 40, increment=2)) == 42
+
+
+def test_run_blocking_settles_work_before_repeated_cancellation_propagates() -> None:
+    entered = threading.Event()
+    release = threading.Event()
+    finished = threading.Event()
+
+    def operation() -> None:
+        entered.set()
+        release.wait(timeout=2)
+        finished.set()
+
+    async def run() -> None:
+        call = asyncio.create_task(run_blocking(operation))
+        assert await asyncio.to_thread(entered.wait, 1)
+
+        call.cancel("first")
+        await asyncio.sleep(0)
+        assert not call.done()
+        call.cancel("second")
+        await asyncio.sleep(0)
+        assert not call.done()
+
+        release.set()
+        with pytest.raises(asyncio.CancelledError) as raised:
+            await call
+        assert raised.value.args == ("first",)
+        assert finished.is_set()
+
+    asyncio.run(run())
+
+
+def test_run_blocking_cancellation_precedes_later_operation_failure() -> None:
+    entered = threading.Event()
+    release = threading.Event()
+
+    def operation() -> None:
+        entered.set()
+        release.wait(timeout=2)
+        raise RuntimeError("blocking operation failed")
+
+    async def run() -> None:
+        call = asyncio.create_task(run_blocking(operation))
+        assert await asyncio.to_thread(entered.wait, 1)
+        call.cancel("caller stopped")
+        await asyncio.sleep(0)
+        assert not call.done()
+
+        release.set()
+        with pytest.raises(asyncio.CancelledError) as raised:
+            await call
+        assert raised.value.args == ("caller stopped",)
+
+    asyncio.run(run())
+
+
+def test_run_blocking_finishes_queued_work_before_cancellation_propagates() -> None:
+    executor_entered = threading.Event()
+    release_executor = threading.Event()
+    operation_finished = threading.Event()
+
+    def occupy_executor() -> None:
+        executor_entered.set()
+        release_executor.wait(timeout=2)
+
+    def operation() -> None:
+        operation_finished.set()
+
+    async def run() -> None:
+        loop = asyncio.get_running_loop()
+        loop.set_default_executor(ThreadPoolExecutor(max_workers=1))
+        occupying = asyncio.create_task(asyncio.to_thread(occupy_executor))
+        await asyncio.sleep(0)
+        assert executor_entered.wait(timeout=1)
+
+        call = asyncio.create_task(run_blocking(operation))
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        call.cancel("cancelled while queued")
+        await asyncio.sleep(0)
+        assert not call.done()
+        assert not operation_finished.is_set()
+
+        release_executor.set()
+        await occupying
+        with pytest.raises(asyncio.CancelledError) as raised:
+            await call
+        assert raised.value.args == ("cancelled while queued",)
+        assert operation_finished.is_set()
+
+    asyncio.run(run())
+
+
+def test_run_blocking_propagates_operation_failure_without_cancellation() -> None:
+    def operation() -> None:
+        raise RuntimeError("blocking operation failed")
+
+    with pytest.raises(RuntimeError, match="blocking operation failed"):
+        asyncio.run(run_blocking(operation))
+
+
+def test_run_blocking_completed_result_is_not_changed_by_late_cancellation() -> None:
+    async def run() -> None:
+        call = asyncio.create_task(run_blocking(lambda: "settled"))
+        assert await call == "settled"
+        assert call.cancel("too late") is False
+        assert call.result() == "settled"
+
+    asyncio.run(run())

--- a/tests/test_memory_runtime.py
+++ b/tests/test_memory_runtime.py
@@ -2612,6 +2612,7 @@ def test_runtime_install_artifact_uses_controller_owned_manager(tmp_path: Path) 
 
 
 def test_runtime_install_artifact_converts_background_ensure_exception(
+    monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
     artifact = _installed_artifact(ensure_failure=RuntimeError("install failed"))
@@ -2620,12 +2621,31 @@ def test_runtime_install_artifact_converts_background_ensure_exception(
         artifact_manager=artifact,
         effective_home=tmp_path,
     )
+    housekeeping_calls: list[tuple[str, bool]] = []
 
-    assert asyncio.run(runtime.install_artifact()) == {
-        "ok": False,
-        "reason": "memory_runtime_install_failed",
-        "download_error": None,
-    }
+    async def observe_terminal_gc() -> None:
+        housekeeping_calls.append(("terminal-gc", runtime._artifact_installing))
+
+    async def observe_backup_reconcile() -> None:
+        housekeeping_calls.append(("backup-reconcile", runtime._artifact_installing))
+
+    monkeypatch.setattr(runtime, "_run_terminal_snapshot_gc", observe_terminal_gc)
+    monkeypatch.setattr(runtime, "_run_backup_stage_reconcile", observe_backup_reconcile)
+
+    async def run() -> None:
+        assert await runtime.install_artifact() == {
+            "ok": False,
+            "reason": "memory_runtime_install_failed",
+            "download_error": None,
+        }
+        await asyncio.sleep(0)
+        assert sorted(housekeeping_calls) == [
+            ("backup-reconcile", False),
+            ("terminal-gc", False),
+        ]
+        await runtime.close()
+
+    asyncio.run(run())
 
 
 def test_distribution_metadata_bundles_only_the_memory_runtime_manifest() -> None:
@@ -4959,12 +4979,13 @@ def test_cancelled_artifact_install_owns_ensure_until_restart_can_enter(
         release.set()
         with pytest.raises(asyncio.CancelledError):
             await installing
-        assert await runtime.restart() == {"ok": True, "state": "ready"}
         await asyncio.sleep(0)
         assert sorted(housekeeping_calls) == [
             ("backup-reconcile", False),
             ("terminal-gc", False),
         ]
+        housekeeping_calls.clear()
+        assert await runtime.restart() == {"ok": True, "state": "ready"}
         assert activations == [None]
         await runtime.close()
 

--- a/tests/test_memory_runtime.py
+++ b/tests/test_memory_runtime.py
@@ -4918,6 +4918,16 @@ def test_cancelled_artifact_install_owns_ensure_until_restart_can_enter(
     )
     activations: list[None] = []
     monkeypatch.setattr(runtime, "_ensure_worker", lambda: activations.append(None))
+    housekeeping_calls: list[tuple[str, bool]] = []
+
+    async def observe_terminal_gc() -> None:
+        housekeeping_calls.append(("terminal-gc", runtime._artifact_installing))
+
+    async def observe_backup_reconcile() -> None:
+        housekeeping_calls.append(("backup-reconcile", runtime._artifact_installing))
+
+    monkeypatch.setattr(runtime, "_run_terminal_snapshot_gc", observe_terminal_gc)
+    monkeypatch.setattr(runtime, "_run_backup_stage_reconcile", observe_backup_reconcile)
 
     async def run() -> None:
         installing = asyncio.create_task(runtime.install_artifact())
@@ -4935,6 +4945,8 @@ def test_cancelled_artifact_install_owns_ensure_until_restart_can_enter(
             "ok": False,
             "error": "memory_restart_failed",
         }
+        await asyncio.sleep(0)
+        assert housekeeping_calls == []
         assert installing.done() is False
         installing.cancel()
         await asyncio.sleep(0)
@@ -4948,6 +4960,11 @@ def test_cancelled_artifact_install_owns_ensure_until_restart_can_enter(
         with pytest.raises(asyncio.CancelledError):
             await installing
         assert await runtime.restart() == {"ok": True, "state": "ready"}
+        await asyncio.sleep(0)
+        assert sorted(housekeeping_calls) == [
+            ("backup-reconcile", False),
+            ("terminal-gc", False),
+        ]
         assert activations == [None]
         await runtime.close()
 

--- a/tests/test_memory_runtime.py
+++ b/tests/test_memory_runtime.py
@@ -4992,6 +4992,67 @@ def test_cancelled_artifact_install_owns_ensure_until_restart_can_enter(
     asyncio.run(run())
 
 
+def test_queued_backup_stage_reconcile_rechecks_artifact_install(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    install_entered = threading.Event()
+    release_install = threading.Event()
+
+    class BlockingArtifact(FakeMemoryArtifactManager):
+        def ensure(self, *, force: bool = False) -> dict:
+            self.ensure_calls.append(force)
+            install_entered.set()
+            release_install.wait(timeout=2)
+            return dict(self.ensure_payload)
+
+    runtime = MemoryRuntime(
+        MemoryConfig(enabled=False),
+        artifact_manager=BlockingArtifact(python=Path(sys.executable)),
+        effective_home=tmp_path,
+    )
+    terminal_gc_entered = asyncio.Event()
+    release_terminal_gc = asyncio.Event()
+    cleanup_calls: list[bool] = []
+
+    async def blocked_terminal_gc() -> None:
+        terminal_gc_entered.set()
+        await release_terminal_gc.wait()
+
+    manager = runtime._backup_manager
+    assert manager is not None
+    monkeypatch.setattr(runtime, "_run_terminal_snapshot_gc", blocked_terminal_gc)
+    monkeypatch.setattr(
+        manager,
+        "reconcile_unpublished_backup_stages",
+        lambda: cleanup_calls.append(runtime._artifact_installing),
+    )
+
+    async def run() -> None:
+        runtime._ensure_terminal_snapshot_gc()
+        runtime._ensure_backup_stage_reconcile()
+        await terminal_gc_entered.wait()
+        queued_reconcile = runtime._backup_stage_reconcile_task
+        assert queued_reconcile is not None
+
+        installing = asyncio.create_task(runtime.install_artifact())
+        assert await asyncio.to_thread(install_entered.wait, 1)
+        release_terminal_gc.set()
+        await queued_reconcile
+        assert cleanup_calls == []
+
+        release_install.set()
+        assert (await installing)["ok"] is True
+        deferred_reconcile = runtime._backup_stage_reconcile_task
+        assert deferred_reconcile is not None
+        assert deferred_reconcile is not queued_reconcile
+        await deferred_reconcile
+        assert cleanup_calls == [False]
+        await runtime.close()
+
+    asyncio.run(run())
+
+
 class _BlockingProbeProcess:
     """A sidecar fake whose processing probe never finishes on its own.
 

--- a/tests/test_memory_worker.py
+++ b/tests/test_memory_worker.py
@@ -1,9 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import threading
-
-import pytest
 
 from core.memory.everos import FakeMemoryProvider
 from core.memory.store import BootRecovery
@@ -43,37 +40,3 @@ def test_new_lease_activation_recovers_before_claiming() -> None:
     assert [kind for kind, _lease in calls] == ["recover", "claim"]
     assert calls[0][1] == calls[1][1]
     assert calls[0][1] != "old-lease"
-
-
-def test_cancelled_worker_waits_for_exact_store_call() -> None:
-    entered = threading.Event()
-    release = threading.Event()
-
-    class Store:
-        def recover_after_boot(self, *, lease_owner: str, clock) -> BootRecovery:
-            del lease_owner, clock
-            entered.set()
-            release.wait(timeout=2.0)
-            return BootRecovery(reclaimed=0, interrupted_flushes=0)
-
-    worker = MemoryWorker(
-        store=Store(),
-        provider=FakeMemoryProvider(),
-        enabled=lambda: True,
-        boot_id="lease",
-    )
-
-    async def run() -> None:
-        draining = asyncio.create_task(worker.drain_once())
-        assert await asyncio.to_thread(entered.wait, 1.0)
-        draining.cancel()
-        await asyncio.sleep(0)
-        assert draining.done() is False
-        draining.cancel()
-        await asyncio.sleep(0)
-        assert draining.done() is False
-        release.set()
-        with pytest.raises(asyncio.CancelledError):
-            await draining
-
-    asyncio.run(run())


### PR DESCRIPTION
## Summary

- add one Memory-internal primitive that owns thread task creation, cancellation shielding, repeated cancellation, settlement, and cancellation precedence
- migrate identical Memory module, worker, coordinator, runtime, and archive-session blocking calls to the shared contract
- keep routine and fenced claim compensation local so acquired claims are returned through their exact compare-and-set path

## Evidence

- Unit: `tests/test_memory_blocking.py` covers normal results, queued and in-flight cancellation, repeated cancellation, late cancellation, and operation failures
- Contract: `pytest -q tests/test_memory_blocking.py tests/test_memory_worker.py tests/test_memory_module.py tests/test_memory_flush_coordinator.py tests/test_memory_runtime.py tests/test_memory_slice3.py` (285 passed)
- Scenario: no scenario catalog entries changed; this is a behavior-preserving internal refactor
- Residual manual checks: none; no user-visible payload or workflow changed
- Lint: `ruff check core/controller.py core/memory/blocking.py core/memory/coordinator.py core/memory/module.py core/memory/runtime.py core/memory/worker.py tests/test_memory_blocking.py tests/test_memory_worker.py`
- Diff hygiene: `git diff --check`

Closes #1242
