### PR TITLE
refactor(memory): own confined filesystem primitives

### DIFF
--- a/core/memory/backup_restore_journal.py
+++ b/core/memory/backup_restore_journal.py
@@ -8,17 +8,13 @@ import re
 import secrets
 import sqlite3
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Literal, Mapping
 
-from core.memory.clear_journal import (
-    _database_sidecars,
-    _ensure_private_parent,
-    _fsync_directory,
-    _prepare_database_path,
-    _require_private_database,
-    _require_private_regular,
-    _utc_now,
+from core.memory.confined_filesystem import (
+    ConfinedFilesystemError,
+    PrivateSqliteDatabase,
 )
 from core.memory.snapshot import MemorySnapshot
 
@@ -94,6 +90,7 @@ class MemoryBackupRestoreJournal:
             if database.as_posix().startswith("../") or database.as_posix().startswith("/"):
                 raise ValueError("invalid backup restore journal path")
             self._database_path = self._effective_home / database
+        self._database = PrivateSqliteDatabase(self._effective_home, self._database_path)
         self._initialize()
 
     @property
@@ -442,8 +439,12 @@ class MemoryBackupRestoreJournal:
         )
 
     def _initialize(self) -> None:
-        _ensure_private_parent(self._effective_home, self._database_path.parent)
-        _prepare_database_path(self._database_path)
+        try:
+            self._database.prepare()
+        except ConfinedFilesystemError as error:
+            raise MemoryBackupRestoreJournalError(
+                "Memory backup restore journal could not be prepared safely"
+            ) from error
         connection = self._connect()
         try:
             version = connection.execute("PRAGMA user_version").fetchone()[0]
@@ -478,37 +479,23 @@ class MemoryBackupRestoreJournal:
             ) from error
         finally:
             connection.close()
-            self._harden_database_files()
-            _fsync_directory(self._database_path.parent)
+            self._harden_database_files(sync_parent=True)
 
     def _connect(self) -> sqlite3.Connection:
-        _require_private_database(self._database_path)
-        for path in _database_sidecars(self._database_path):
-            try:
-                info = os.lstat(path)
-            except FileNotFoundError:
-                continue
-            _require_private_regular(info, "Memory backup restore journal sidecar")
-        connection = sqlite3.connect(self._database_path, timeout=5.0)
-        connection.row_factory = sqlite3.Row
-        connection.execute("PRAGMA foreign_keys=ON")
-        connection.execute("PRAGMA busy_timeout=5000")
-        connection.execute("PRAGMA journal_mode=WAL")
-        connection.execute("PRAGMA synchronous=FULL")
-        return connection
+        try:
+            return self._database.connect()
+        except ConfinedFilesystemError as error:
+            raise MemoryBackupRestoreJournalError(
+                "Memory backup restore journal is unsafe"
+            ) from error
 
-    def _harden_database_files(self) -> None:
-        for path in (self._database_path, *_database_sidecars(self._database_path)):
-            try:
-                info = os.lstat(path)
-            except FileNotFoundError:
-                continue
-            _require_private_regular(
-                info,
-                "Memory backup restore journal file",
-                require_mode=False,
-            )
-            os.chmod(path, 0o600)
+    def _harden_database_files(self, *, sync_parent: bool = False) -> None:
+        try:
+            self._database.harden(sync_parent=sync_parent)
+        except ConfinedFilesystemError as error:
+            raise MemoryBackupRestoreJournalError(
+                "Memory backup restore journal files could not be hardened safely"
+            ) from error
 
 
 def _schema_sql() -> str:
@@ -679,3 +666,7 @@ def _validated_actor(value: str) -> str:
     if not isinstance(value, str) or not value or "\x00" in value or len(value) > 256:
         raise ValueError("invalid backup restore actor")
     return value
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="milliseconds").replace("+00:00", "Z")

--- a/core/memory/clear_journal.py
+++ b/core/memory/clear_journal.py
@@ -11,13 +11,16 @@ import os
 import re
 import secrets
 import sqlite3
-import stat
 from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path, PurePosixPath
 from typing import Iterator, Literal, Mapping, Sequence
 
+from core.memory.confined_filesystem import (
+    ConfinedFilesystemError,
+    PrivateSqliteDatabase,
+)
 from core.memory.snapshot import (
     MemorySnapshot,
     _TerminalSnapshotPermit,
@@ -175,6 +178,7 @@ class MemoryClearJournal:
         else:
             relative = _validated_relative_path(database_value.as_posix())
             self._database_path = self._effective_home / relative
+        self._database = PrivateSqliteDatabase(self._effective_home, self._database_path)
         self._surfaces = tuple(surfaces)
         self._validate_surfaces()
         self._initialize()
@@ -1083,8 +1087,12 @@ class MemoryClearJournal:
         return self._require_operation(identifier)
 
     def _initialize(self) -> None:
-        _ensure_private_parent(self._effective_home, self._database_path.parent)
-        _prepare_database_path(self._database_path)
+        try:
+            self._database.prepare()
+        except ConfinedFilesystemError as error:
+            raise MemoryClearJournalError(
+                "Memory clear journal could not be prepared safely"
+            ) from error
         connection = self._connect()
         try:
             version = connection.execute("PRAGMA user_version").fetchone()[0]
@@ -1111,24 +1119,13 @@ class MemoryClearJournal:
             raise MemoryClearJournalError("Memory clear journal could not be initialized") from error
         finally:
             connection.close()
-            self._harden_database_files()
-            _fsync_directory(self._database_path.parent)
+            self._harden_database_files(sync_parent=True)
 
     def _connect(self) -> sqlite3.Connection:
-        _require_private_database(self._database_path)
-        for path in _database_sidecars(self._database_path):
-            try:
-                info = os.lstat(path)
-            except FileNotFoundError:
-                continue
-            _require_private_regular(info, "Memory clear journal sidecar")
-        connection = sqlite3.connect(self._database_path, timeout=5.0)
-        connection.row_factory = sqlite3.Row
-        connection.execute("PRAGMA foreign_keys=ON")
-        connection.execute("PRAGMA busy_timeout=5000")
-        connection.execute("PRAGMA journal_mode=WAL")
-        connection.execute("PRAGMA synchronous=FULL")
-        return connection
+        try:
+            return self._database.connect()
+        except ConfinedFilesystemError as error:
+            raise MemoryClearJournalError("Memory clear journal is unsafe") from error
 
     def _validate_surfaces(self) -> None:
         if len(self._surfaces) != len(_SURFACE_NAMES):
@@ -1403,17 +1400,13 @@ class MemoryClearJournal:
             ),
         )
 
-    def _harden_database_files(self) -> None:
-        for path in (
-            self._database_path,
-            *_database_sidecars(self._database_path),
-        ):
-            try:
-                info = os.lstat(path)
-            except FileNotFoundError:
-                continue
-            _require_private_regular(info, "Memory clear journal file", require_mode=False)
-            os.chmod(path, 0o600)
+    def _harden_database_files(self, *, sync_parent: bool = False) -> None:
+        try:
+            self._database.harden(sync_parent=sync_parent)
+        except ConfinedFilesystemError as error:
+            raise MemoryClearJournalError(
+                "Memory clear journal files could not be hardened safely"
+            ) from error
 
 
 def _schema_sql() -> str:
@@ -1696,96 +1689,6 @@ def _relative_to_home(path: Path, home: Path) -> Path:
         return path.relative_to(home)
     except ValueError as error:
         raise ValueError("Memory clear journal must stay within effective home") from error
-
-
-def _ensure_private_parent(home: Path, directory: Path) -> None:
-    relative = _relative_to_home(directory, home)
-    if not home.exists():
-        home.mkdir(parents=True, mode=0o700)
-    _require_directory(os.lstat(home), "effective Memory home")
-    os.chmod(home, 0o700)
-    _fsync_directory(home)
-    current = home
-    for component in relative.parts:
-        current /= component
-        try:
-            info = os.lstat(current)
-        except FileNotFoundError:
-            os.mkdir(current, mode=0o700)
-            _fsync_directory(current.parent)
-            info = os.lstat(current)
-        _require_directory(info, "Memory clear journal directory")
-        os.chmod(current, 0o700)
-        _fsync_directory(current)
-        if stat.S_IMODE(os.lstat(current).st_mode) != 0o700:
-            raise MemoryClearJournalError("Memory clear journal directory is not private")
-
-
-def _prepare_database_path(path: Path) -> None:
-    try:
-        info = os.lstat(path)
-    except FileNotFoundError:
-        flags = os.O_RDWR | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0)
-        descriptor = os.open(path, flags, 0o600)
-        try:
-            os.fsync(descriptor)
-        finally:
-            os.close(descriptor)
-        os.chmod(path, 0o600)
-        _fsync_directory(path.parent)
-        return
-    _require_private_regular(info, "Memory clear journal")
-
-
-def _require_private_database(path: Path) -> None:
-    try:
-        info = os.lstat(path)
-    except FileNotFoundError as error:
-        raise MemoryClearJournalError("Memory clear journal is missing") from error
-    _require_private_regular(info, "Memory clear journal")
-
-
-def _database_sidecars(path: Path) -> tuple[Path, Path, Path]:
-    return (
-        path.with_name(f"{path.name}-wal"),
-        path.with_name(f"{path.name}-shm"),
-        path.with_name(f"{path.name}-journal"),
-    )
-
-
-def _require_private_regular(
-    info: os.stat_result,
-    label: str,
-    *,
-    require_mode: bool = True,
-) -> None:
-    if stat.S_ISLNK(info.st_mode) or not stat.S_ISREG(info.st_mode):
-        raise MemoryClearJournalError(f"{label} is not a safe regular file")
-    _require_owned(info, label)
-    if info.st_nlink != 1:
-        raise MemoryClearJournalError(f"{label} has multiple hard links")
-    if require_mode and stat.S_IMODE(info.st_mode) & 0o077:
-        raise MemoryClearJournalError(f"{label} is not private")
-
-
-def _require_owned(info: os.stat_result, label: str) -> None:
-    if hasattr(os, "getuid") and info.st_uid != os.getuid():
-        raise MemoryClearJournalError(f"{label} is not owned by the current user")
-
-
-def _require_directory(info: os.stat_result, label: str) -> None:
-    if stat.S_ISLNK(info.st_mode) or not stat.S_ISDIR(info.st_mode):
-        raise MemoryClearJournalError(f"{label} is not a safe directory")
-    _require_owned(info, label)
-
-
-def _fsync_directory(path: Path) -> None:
-    flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
-    descriptor = os.open(path, flags)
-    try:
-        os.fsync(descriptor)
-    finally:
-        os.close(descriptor)
 
 
 def _utc_now() -> str:

--- a/core/memory/confined_filesystem.py
+++ b/core/memory/confined_filesystem.py
@@ -1,0 +1,487 @@
+"""Shared filesystem primitives confined to an effective Memory home."""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import stat
+from collections import OrderedDict
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Sequence
+
+
+_DIRECTORY_ORDER_INSERT_BATCH_SIZE = 256
+_DIRECTORY_DESCRIPTOR_CACHE_SIZE = 48
+
+
+class ConfinedFilesystemError(RuntimeError):
+    """A confined filesystem operation refused an unsafe path or entry."""
+
+
+class PrivateSqliteDatabase:
+    """Prepare and validate one owner-private SQLite database and its sidecars."""
+
+    def __init__(self, home: Path, path: Path) -> None:
+        self._home = home
+        self._path = path
+
+    def prepare(self) -> None:
+        """Create the private parent chain and database when they are absent."""
+
+        _ensure_private_parent(self._home, self._path.parent)
+        try:
+            info = os.lstat(self._path)
+        except FileNotFoundError:
+            flags = os.O_RDWR | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0)
+            descriptor = os.open(self._path, flags, 0o600)
+            try:
+                os.fsync(descriptor)
+            finally:
+                os.close(descriptor)
+            os.chmod(self._path, 0o600)
+            _fsync_directory(self._path.parent)
+            return
+        _require_private_regular(info, "private SQLite database")
+
+    def connect(self) -> sqlite3.Connection:
+        """Open SQLite only after validating the database and owned sidecars."""
+
+        try:
+            info = os.lstat(self._path)
+        except FileNotFoundError as error:
+            raise ConfinedFilesystemError(
+                "private SQLite database is missing"
+            ) from error
+        _require_private_regular(info, "private SQLite database")
+        for path in _database_sidecars(self._path):
+            try:
+                sidecar_info = os.lstat(path)
+            except FileNotFoundError:
+                continue
+            _require_private_regular(sidecar_info, "private SQLite sidecar")
+
+        connection = sqlite3.connect(self._path, timeout=5.0)
+        connection.row_factory = sqlite3.Row
+        connection.execute("PRAGMA foreign_keys=ON")
+        connection.execute("PRAGMA busy_timeout=5000")
+        connection.execute("PRAGMA journal_mode=WAL")
+        connection.execute("PRAGMA synchronous=FULL")
+        return connection
+
+    def harden(self, *, sync_parent: bool = False) -> None:
+        """Set owner-only modes after SQLite may have created sidecar files."""
+
+        for path in (self._path, *_database_sidecars(self._path)):
+            try:
+                info = os.lstat(path)
+            except FileNotFoundError:
+                continue
+            _require_private_regular(
+                info,
+                "private SQLite file",
+                require_mode=False,
+            )
+            os.chmod(path, 0o600)
+        if sync_parent:
+            _fsync_directory(self._path.parent)
+
+
+@dataclass(frozen=True, slots=True)
+class _RelativeNode:
+    parent: _RelativeNode | None
+    name: str
+
+
+@dataclass(slots=True)
+class _RemovalFrame:
+    node: _RelativeNode
+    before: tuple[int, int]
+    child_order: _DirectoryOrderCursor
+
+
+@dataclass(slots=True)
+class _DirectoryOrderCursor:
+    order_id: int
+    last_name: bytes | None = None
+    exhausted: bool = False
+
+
+class _SpilledDirectoryOrder:
+    """Deterministically order directory names without retaining their width."""
+
+    def __init__(self) -> None:
+        self._connection = sqlite3.connect("")
+        self._next_order_id = 1
+        try:
+            self._connection.execute("PRAGMA temp_store=FILE")
+            self._connection.execute("PRAGMA cache_size=-512")
+            self._connection.execute("PRAGMA journal_mode=OFF")
+            self._connection.execute(
+                """
+                CREATE TABLE directory_name (
+                    order_id INTEGER NOT NULL,
+                    name BLOB NOT NULL,
+                    PRIMARY KEY (order_id, name)
+                ) WITHOUT ROWID
+                """
+            )
+        except BaseException:
+            self._connection.close()
+            raise
+
+    def __enter__(self) -> _SpilledDirectoryOrder:
+        return self
+
+    def __exit__(self, *_exc_info: object) -> None:
+        self._connection.close()
+
+    def scan(self, descriptor: int) -> _DirectoryOrderCursor:
+        order_id = self._next_order_id
+        self._next_order_id += 1
+        rows: list[tuple[int, bytes]] = []
+        try:
+            with os.scandir(descriptor) as iterator:
+                for entry in iterator:
+                    rows.append((order_id, os.fsencode(entry.name)))
+                    if len(rows) >= _DIRECTORY_ORDER_INSERT_BATCH_SIZE:
+                        self._insert(rows)
+                        rows.clear()
+            if rows:
+                self._insert(rows)
+        except (OSError, sqlite3.Error, UnicodeError) as error:
+            raise ConfinedFilesystemError(
+                "confined directory cannot be scanned safely"
+            ) from error
+        return _DirectoryOrderCursor(order_id=order_id)
+
+    def next_name(self, cursor: _DirectoryOrderCursor) -> str | None:
+        if cursor.exhausted:
+            return None
+        try:
+            if cursor.last_name is None:
+                row = self._connection.execute(
+                    """
+                    SELECT name FROM directory_name
+                    WHERE order_id = ? ORDER BY name LIMIT 1
+                    """,
+                    (cursor.order_id,),
+                ).fetchone()
+            else:
+                row = self._connection.execute(
+                    """
+                    SELECT name FROM directory_name
+                    WHERE order_id = ? AND name > ? ORDER BY name LIMIT 1
+                    """,
+                    (cursor.order_id, cursor.last_name),
+                ).fetchone()
+            if row is not None:
+                cursor.last_name = bytes(row[0])
+                return os.fsdecode(cursor.last_name)
+            self._connection.execute(
+                "DELETE FROM directory_name WHERE order_id = ?",
+                (cursor.order_id,),
+            )
+            cursor.exhausted = True
+            return None
+        except sqlite3.Error as error:
+            raise ConfinedFilesystemError(
+                "confined directory cannot be read safely"
+            ) from error
+
+    def _insert(self, rows: Sequence[tuple[int, bytes]]) -> None:
+        self._connection.executemany(
+            "INSERT INTO directory_name (order_id, name) VALUES (?, ?)",
+            rows,
+        )
+
+
+class _DirectoryDescriptorCache:
+    """Reopen deep paths safely while keeping descriptor use constant."""
+
+    def __init__(self, root_fd: int) -> None:
+        self._root_fd = root_fd
+        self._descriptors: OrderedDict[int, tuple[_RelativeNode, int]] = OrderedDict()
+
+    def __enter__(self) -> _DirectoryDescriptorCache:
+        return self
+
+    def __exit__(self, *_exc_info: object) -> None:
+        for _node, descriptor in self._descriptors.values():
+            os.close(descriptor)
+        self._descriptors.clear()
+
+    def open(self, node: _RelativeNode | None) -> int:
+        if node is None:
+            return os.dup(self._root_fd)
+        trail: list[_RelativeNode] = []
+        ancestor = node
+        cached: tuple[_RelativeNode, int] | None = None
+        while ancestor is not None:
+            cached = self._descriptors.get(id(ancestor))
+            if cached is not None and cached[0] is ancestor:
+                self._descriptors.move_to_end(id(ancestor))
+                break
+            trail.append(ancestor)
+            ancestor = ancestor.parent
+        current = os.dup(self._root_fd if cached is None else cached[1])
+        try:
+            for component_node in reversed(trail):
+                try:
+                    next_descriptor = os.open(
+                        component_node.name,
+                        _directory_open_flags(),
+                        dir_fd=current,
+                    )
+                except OSError as error:
+                    raise ConfinedFilesystemError(
+                        "confined removal parent cannot be opened safely"
+                    ) from error
+                os.close(current)
+                current = next_descriptor
+                info = os.fstat(current)
+                if not stat.S_ISDIR(info.st_mode) or stat.S_ISLNK(info.st_mode):
+                    raise ConfinedFilesystemError(
+                        "confined removal parent is not a safe directory"
+                    )
+                self._remember(component_node, current)
+            return current
+        except BaseException:
+            os.close(current)
+            raise
+
+    def _remember(self, node: _RelativeNode, descriptor: int) -> None:
+        previous = self._descriptors.pop(id(node), None)
+        if previous is not None:
+            os.close(previous[1])
+        self._descriptors[id(node)] = (node, os.dup(descriptor))
+        while len(self._descriptors) > _DIRECTORY_DESCRIPTOR_CACHE_SIZE:
+            _key, (_old_node, old_descriptor) = self._descriptors.popitem(last=False)
+            os.close(old_descriptor)
+
+
+def remove_confined_path(
+    home: Path,
+    path: Path,
+) -> None:
+    """Remove one entry through anchored, no-follow directory handles."""
+
+    relative = _relative_to_home(path, home)
+    if not relative.parts:
+        raise ConfinedFilesystemError("refusing to remove the confinement root")
+    current: int | None = None
+    try:
+        current = os.open(home, _directory_open_flags())
+        for component in relative.parts[:-1]:
+            try:
+                next_descriptor = os.open(
+                    component,
+                    _directory_open_flags(),
+                    dir_fd=current,
+                )
+            except FileNotFoundError:
+                return
+            os.close(current)
+            current = next_descriptor
+        remove_anchored_entry(current, relative.parts[-1])
+    finally:
+        if current is not None:
+            os.close(current)
+
+
+def remove_anchored_entry(
+    parent_fd: int,
+    name: str,
+    *,
+    expected_identity: tuple[int, int] | None = None,
+) -> None:
+    """Remove one safe relative name beneath an already anchored directory."""
+
+    if (
+        not name
+        or name in {".", ".."}
+        or "\x00" in name
+        or os.sep in name
+        or (os.altsep is not None and os.altsep in name)
+    ):
+        raise ConfinedFilesystemError("anchored removal requires one safe entry name")
+    _remove_entry_at(
+        parent_fd,
+        name,
+        expected_identity=expected_identity,
+    )
+
+
+def _remove_entry_at(
+    parent_fd: int,
+    name: str,
+    *,
+    expected_identity: tuple[int, int] | None = None,
+) -> None:
+    root_node = _RelativeNode(None, name)
+    stack: list[_RemovalFrame | _RelativeNode] = [root_node]
+    with (
+        _DirectoryDescriptorCache(parent_fd) as cache,
+        _SpilledDirectoryOrder() as orders,
+    ):
+        while stack:
+            item = stack[-1]
+            if isinstance(item, _RelativeNode):
+                stack.pop()
+                node_parent_fd = cache.open(item.parent)
+                try:
+                    try:
+                        before = os.stat(
+                            item.name,
+                            dir_fd=node_parent_fd,
+                            follow_symlinks=False,
+                        )
+                    except FileNotFoundError:
+                        continue
+                    if (
+                        item is root_node
+                        and expected_identity is not None
+                        and (
+                            not stat.S_ISDIR(before.st_mode)
+                            or (before.st_dev, before.st_ino) != expected_identity
+                        )
+                    ):
+                        raise ConfinedFilesystemError(
+                            "confined entry changed during removal"
+                        )
+                    if stat.S_ISLNK(before.st_mode) or stat.S_ISREG(before.st_mode):
+                        os.unlink(item.name, dir_fd=node_parent_fd)
+                        continue
+                    if not stat.S_ISDIR(before.st_mode):
+                        raise ConfinedFilesystemError(
+                            "confined removal refuses special files"
+                        )
+                    child_fd = os.open(
+                        item.name,
+                        _directory_open_flags(),
+                        dir_fd=node_parent_fd,
+                    )
+                    try:
+                        opened = os.fstat(child_fd)
+                        if (opened.st_dev, opened.st_ino) != (
+                            before.st_dev,
+                            before.st_ino,
+                        ):
+                            raise ConfinedFilesystemError(
+                                "confined directory changed during removal"
+                            )
+                        child_order = orders.scan(child_fd)
+                    finally:
+                        os.close(child_fd)
+                finally:
+                    os.close(node_parent_fd)
+                stack.append(
+                    _RemovalFrame(
+                        node=item,
+                        before=(before.st_dev, before.st_ino),
+                        child_order=child_order,
+                    )
+                )
+                continue
+
+            child_name = orders.next_name(item.child_order)
+            if child_name is not None:
+                stack.append(_RelativeNode(item.node, child_name))
+                continue
+
+            stack.pop()
+            node_parent_fd = cache.open(item.node.parent)
+            try:
+                current = os.stat(
+                    item.node.name,
+                    dir_fd=node_parent_fd,
+                    follow_symlinks=False,
+                )
+                if (
+                    not stat.S_ISDIR(current.st_mode)
+                    or (current.st_dev, current.st_ino) != item.before
+                ):
+                    raise ConfinedFilesystemError(
+                        "confined directory changed during removal"
+                    )
+                os.rmdir(item.node.name, dir_fd=node_parent_fd)
+            finally:
+                os.close(node_parent_fd)
+
+
+def _relative_to_home(path: Path, home: Path) -> Path:
+    try:
+        return path.relative_to(home)
+    except ValueError as error:
+        raise ConfinedFilesystemError(
+            "confined path must stay within the confinement root"
+        ) from error
+
+
+def _ensure_private_parent(home: Path, directory: Path) -> None:
+    relative = _relative_to_home(directory, home)
+    if not home.exists():
+        home.mkdir(parents=True, mode=0o700)
+    _require_directory(os.lstat(home), "confinement root")
+    os.chmod(home, 0o700)
+    _fsync_directory(home)
+    current = home
+    for component in relative.parts:
+        current /= component
+        try:
+            info = os.lstat(current)
+        except FileNotFoundError:
+            os.mkdir(current, mode=0o700)
+            _fsync_directory(current.parent)
+            info = os.lstat(current)
+        _require_directory(info, "private SQLite directory")
+        os.chmod(current, 0o700)
+        _fsync_directory(current)
+        if stat.S_IMODE(os.lstat(current).st_mode) != 0o700:
+            raise ConfinedFilesystemError("private SQLite directory is not private")
+
+
+def _database_sidecars(path: Path) -> tuple[Path, Path, Path]:
+    return (
+        path.with_name(f"{path.name}-wal"),
+        path.with_name(f"{path.name}-shm"),
+        path.with_name(f"{path.name}-journal"),
+    )
+
+
+def _require_private_regular(
+    info: os.stat_result,
+    label: str,
+    *,
+    require_mode: bool = True,
+) -> None:
+    if stat.S_ISLNK(info.st_mode) or not stat.S_ISREG(info.st_mode):
+        raise ConfinedFilesystemError(f"{label} is not a safe regular file")
+    _require_owned(info, label)
+    if info.st_nlink != 1:
+        raise ConfinedFilesystemError(f"{label} has multiple hard links")
+    if require_mode and stat.S_IMODE(info.st_mode) & 0o077:
+        raise ConfinedFilesystemError(f"{label} is not private")
+
+
+def _require_owned(info: os.stat_result, label: str) -> None:
+    if hasattr(os, "getuid") and info.st_uid != os.getuid():
+        raise ConfinedFilesystemError(f"{label} is not owned by the current user")
+
+
+def _require_directory(info: os.stat_result, label: str) -> None:
+    if stat.S_ISLNK(info.st_mode) or not stat.S_ISDIR(info.st_mode):
+        raise ConfinedFilesystemError(f"{label} is not a safe directory")
+    _require_owned(info, label)
+
+
+def _fsync_directory(path: Path) -> None:
+    descriptor = os.open(path, _directory_open_flags())
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def _directory_open_flags() -> int:
+    return os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)

--- a/core/memory/module.py
+++ b/core/memory/module.py
@@ -24,8 +24,11 @@ from core.memory.attachments import (
     encode_pinned_bundle,
 )
 from core.memory.artifact import PROVIDER_ROOT_CONTROL_FILES
+from core.memory.confined_filesystem import (
+    ConfinedFilesystemError,
+    remove_confined_path,
+)
 from core.memory.everos import MemoryProviderFailure, MemoryProviderPort
-from core.memory.snapshot import MemorySnapshotError, _remove_safe_path
 from core.memory.store import (
     MAX_NONTERMINAL_QUEUE_ROWS,
     MemoryMeta,
@@ -1117,8 +1120,8 @@ def _read_root_sentinel(path: Path) -> object:
 
 def _remove_root_child_no_follow(path: Path, effective_home: Path) -> None:
     try:
-        _remove_safe_path(effective_home, path)
-    except (MemorySnapshotError, OSError, ValueError) as error:
+        remove_confined_path(effective_home, path)
+    except (ConfinedFilesystemError, OSError, ValueError) as error:
         raise _ClearStepFailure("provider root child could not be removed") from error
 
 

--- a/core/memory/snapshot.py
+++ b/core/memory/snapshot.py
@@ -21,6 +21,12 @@ from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
 from typing import Callable, Iterator, Literal, Mapping, Protocol, Sequence
 
+from core.memory.confined_filesystem import (
+    ConfinedFilesystemError,
+    remove_anchored_entry,
+    remove_confined_path,
+)
+
 
 SnapshotSurfaceKind = Literal["sqlite", "tree", "call_log"]
 SnapshotEntryType = Literal["sqlite", "tree", "directory", "file", "missing"]
@@ -286,13 +292,6 @@ class _TreeCopyFrame:
 class _DirectoryWalkFrame:
     node: _RelativeNode | None
     before: tuple[int, int, int, int]
-    child_order: _DirectoryOrderCursor
-
-
-@dataclass(slots=True)
-class _RemovalFrame:
-    node: _RelativeNode
-    before: tuple[int, int]
     child_order: _DirectoryOrderCursor
 
 
@@ -930,7 +929,7 @@ class MemorySnapshotManager:
                         "Memory backup stage is not a safe directory"
                     )
                 _require_directory_private(info, "Memory backup stage")
-                _remove_entry_at(
+                _remove_safe_entry(
                     root_fd,
                     name,
                     expected_identity=(info.st_dev, info.st_ino),
@@ -2668,138 +2667,34 @@ def _require_expected_target(info: os.stat_result, kind: SnapshotSurfaceKind, *,
         _require_directory_private(info, "Memory restore tree target")
 
 
-def _remove_safe_path(home: Path, path: Path) -> None:
-    """Remove a confined entry through anchored, no-follow directory handles."""
-
-    relative = _relative_to_home(path, home)
-    if not relative.parts:
-        raise MemorySnapshotUnsafePathError("refusing to remove the effective Memory home")
-    flags = _directory_open_flags()
-    current: int | None = None
+def _remove_safe_path(
+    home: Path,
+    path: Path,
+) -> None:
     try:
-        current = os.open(home, flags)
-        for component in relative.parts[:-1]:
-            try:
-                next_descriptor = os.open(component, flags, dir_fd=current)
-            except FileNotFoundError:
-                return
-            os.close(current)
-            current = next_descriptor
-        _remove_entry_at(current, relative.parts[-1])
-    finally:
-        if current is not None:
-            os.close(current)
+        remove_confined_path(home, path)
+    except ConfinedFilesystemError as error:
+        raise MemorySnapshotUnsafePathError(
+            "Memory snapshot path could not be removed safely"
+        ) from error
 
 
-def _remove_entry_at(
+def _remove_safe_entry(
     parent_fd: int,
     name: str,
     *,
-    expected_identity: tuple[int, int] | None = None,
+    expected_identity: tuple[int, int],
 ) -> None:
-    root_node = _RelativeNode(None, name)
-    stack: list[_RemovalFrame | _RelativeNode] = [root_node]
-    with (
-        _DirectoryDescriptorCache(parent_fd, require_private=False) as cache,
-        _SpilledDirectoryOrder() as orders,
-    ):
-        while stack:
-            item = stack[-1]
-            if isinstance(item, _RelativeNode):
-                stack.pop()
-                node_parent_fd = cache.open(
-                    item.parent,
-                    "Memory snapshot removal parent",
-                )
-                try:
-                    try:
-                        before = os.stat(
-                            item.name,
-                            dir_fd=node_parent_fd,
-                            follow_symlinks=False,
-                        )
-                    except FileNotFoundError:
-                        continue
-                    if (
-                        item is root_node
-                        and expected_identity is not None
-                        and (
-                            not stat.S_ISDIR(before.st_mode)
-                            or (before.st_dev, before.st_ino) != expected_identity
-                        )
-                    ):
-                        raise MemorySnapshotUnsafePathError(
-                            "Memory snapshot entry changed during removal"
-                        )
-                    if stat.S_ISLNK(before.st_mode) or stat.S_ISREG(before.st_mode):
-                        os.unlink(item.name, dir_fd=node_parent_fd)
-                        continue
-                    if not stat.S_ISDIR(before.st_mode):
-                        raise MemorySnapshotUnsafePathError(
-                            "Memory snapshot removal refuses special files"
-                        )
-                    child_fd = os.open(
-                        item.name,
-                        _directory_open_flags(),
-                        dir_fd=node_parent_fd,
-                    )
-                    try:
-                        opened = os.fstat(child_fd)
-                        if (opened.st_dev, opened.st_ino) != (
-                            before.st_dev,
-                            before.st_ino,
-                        ):
-                            raise MemorySnapshotUnsafePathError(
-                                "Memory snapshot directory changed during removal"
-                            )
-                        child_order = orders.scan(
-                            child_fd,
-                            error_type=MemorySnapshotUnsafePathError,
-                            message="Memory snapshot directory cannot be scanned safely",
-                        )
-                    finally:
-                        os.close(child_fd)
-                finally:
-                    os.close(node_parent_fd)
-                stack.append(
-                    _RemovalFrame(
-                        node=item,
-                        before=(before.st_dev, before.st_ino),
-                        child_order=child_order,
-                    )
-                )
-                continue
-
-            child_name = orders.next_name(
-                item.child_order,
-                error_type=MemorySnapshotUnsafePathError,
-                message="Memory snapshot directory cannot be scanned safely",
-            )
-            if child_name is not None:
-                stack.append(_RelativeNode(item.node, child_name))
-                continue
-
-            stack.pop()
-            node_parent_fd = cache.open(
-                item.node.parent,
-                "Memory snapshot removal parent",
-            )
-            try:
-                current = os.stat(
-                    item.node.name,
-                    dir_fd=node_parent_fd,
-                    follow_symlinks=False,
-                )
-                if (
-                    not stat.S_ISDIR(current.st_mode)
-                    or (current.st_dev, current.st_ino) != item.before
-                ):
-                    raise MemorySnapshotUnsafePathError(
-                        "Memory snapshot directory changed during removal"
-                    )
-                os.rmdir(item.node.name, dir_fd=node_parent_fd)
-            finally:
-                os.close(node_parent_fd)
+    try:
+        remove_anchored_entry(
+            parent_fd,
+            name,
+            expected_identity=expected_identity,
+        )
+    except ConfinedFilesystemError as error:
+        raise MemorySnapshotUnsafePathError(
+            "Memory snapshot entry could not be removed safely"
+        ) from error
 
 
 def _fsync_file(path: Path) -> None:

--- a/tests/test_memory_confined_filesystem.py
+++ b/tests/test_memory_confined_filesystem.py
@@ -1,0 +1,194 @@
+from __future__ import annotations
+
+import os
+import stat
+from pathlib import Path
+
+import pytest
+
+from core.memory.confined_filesystem import (
+    ConfinedFilesystemError,
+    PrivateSqliteDatabase,
+    remove_anchored_entry,
+    remove_confined_path,
+)
+
+
+def test_remove_confined_path_refuses_to_follow_a_swapped_directory(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home = tmp_path / "home"
+    home.mkdir(mode=0o700)
+    target = home / "managed"
+    target.mkdir(mode=0o700)
+    (target / "nested").mkdir(mode=0o700)
+    (target / "nested" / "owned.txt").write_text("owned", encoding="utf-8")
+
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    victim = outside / "victim.txt"
+    victim.write_text("outside must survive", encoding="utf-8")
+    moved = home / "held-managed"
+
+    from core.memory import confined_filesystem
+
+    real_scandir = confined_filesystem.os.scandir
+    swapped = False
+
+    def swap_directory_for_symlink(path):
+        nonlocal swapped
+        if isinstance(path, int) and not swapped:
+            swapped = True
+            target.rename(moved)
+            target.symlink_to(outside, target_is_directory=True)
+        return real_scandir(path)
+
+    monkeypatch.setattr(confined_filesystem.os, "scandir", swap_directory_for_symlink)
+    with pytest.raises(ConfinedFilesystemError):
+        remove_confined_path(home, target)
+
+    assert swapped
+    assert target.is_symlink()
+    assert victim.read_text(encoding="utf-8") == "outside must survive"
+
+
+def test_private_sqlite_database_prepares_and_hardens_owned_files(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    path = home / "state" / "journal.sqlite"
+    database = PrivateSqliteDatabase(home, path)
+
+    database.prepare()
+    connection = database.connect()
+    try:
+        connection.execute("CREATE TABLE item (value TEXT NOT NULL)")
+        connection.commit()
+    finally:
+        connection.close()
+    path.chmod(0o644)
+
+    database.harden(sync_parent=True)
+
+    assert path.stat().st_mode & 0o777 == 0o600
+    assert path.parent.stat().st_mode & 0o777 == 0o700
+    assert home.stat().st_mode & 0o777 == 0o700
+
+
+def test_private_sqlite_database_rejects_an_unsafe_sidecar(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    path = home / "journal.sqlite"
+    database = PrivateSqliteDatabase(home, path)
+    database.prepare()
+    outside = tmp_path / "outside"
+    outside.write_bytes(b"")
+    sidecar = path.with_name(f"{path.name}-wal")
+    sidecar.symlink_to(outside)
+
+    with pytest.raises(ConfinedFilesystemError):
+        database.connect()
+
+
+@pytest.mark.parametrize("unsafe_kind", ("hardlink", "fifo"))
+def test_private_sqlite_database_rejects_unsafe_database_entries(
+    tmp_path: Path,
+    unsafe_kind: str,
+) -> None:
+    home = tmp_path / "home"
+    home.mkdir(mode=0o700)
+    path = home / "journal.sqlite"
+    if unsafe_kind == "hardlink":
+        outside = tmp_path / "outside"
+        outside.write_bytes(b"")
+        outside.chmod(0o600)
+        os.link(outside, path)
+    else:
+        os.mkfifo(path, mode=0o600)
+
+    with pytest.raises(ConfinedFilesystemError):
+        PrivateSqliteDatabase(home, path).prepare()
+
+
+def test_private_sqlite_database_rejects_unowned_database(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home = tmp_path / "home"
+    path = home / "journal.sqlite"
+    database = PrivateSqliteDatabase(home, path)
+    database.prepare()
+    real_uid = os.getuid()
+
+    from core.memory import confined_filesystem
+
+    monkeypatch.setattr(confined_filesystem.os, "getuid", lambda: real_uid + 1)
+    with pytest.raises(ConfinedFilesystemError):
+        database.connect()
+
+
+def test_remove_confined_path_unlinks_links_without_touching_their_victims(
+    tmp_path: Path,
+) -> None:
+    home = tmp_path / "home"
+    home.mkdir(mode=0o700)
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    victim = outside / "victim.txt"
+    victim.write_text("outside must survive", encoding="utf-8")
+
+    symlink = home / "symlink"
+    symlink.symlink_to(victim)
+    hardlink = home / "hardlink"
+    os.link(victim, hardlink)
+
+    remove_confined_path(home, symlink)
+    remove_confined_path(home, hardlink)
+
+    assert not symlink.exists()
+    assert not hardlink.exists()
+    assert victim.read_text(encoding="utf-8") == "outside must survive"
+
+
+def test_remove_confined_path_rejects_root_outside_and_special_entries(
+    tmp_path: Path,
+) -> None:
+    home = tmp_path / "home"
+    home.mkdir(mode=0o700)
+    outside = tmp_path / "outside"
+    outside.write_text("outside must survive", encoding="utf-8")
+    fifo = home / "fifo"
+    os.mkfifo(fifo, mode=0o600)
+
+    with pytest.raises(ConfinedFilesystemError):
+        remove_confined_path(home, home)
+    with pytest.raises(ConfinedFilesystemError):
+        remove_confined_path(home, outside)
+    with pytest.raises(ConfinedFilesystemError):
+        remove_confined_path(home, fifo)
+
+    assert stat.S_ISFIFO(os.lstat(fifo).st_mode)
+    assert outside.read_text(encoding="utf-8") == "outside must survive"
+
+
+def test_remove_anchored_entry_requires_the_expected_directory_identity(
+    tmp_path: Path,
+) -> None:
+    home = tmp_path / "home"
+    home.mkdir(mode=0o700)
+    target = home / "target"
+    target.mkdir(mode=0o700)
+    identity = os.lstat(target)
+    target.rename(home / "moved")
+    target.mkdir(mode=0o700)
+    descriptor = os.open(home, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+    try:
+        with pytest.raises(ConfinedFilesystemError):
+            remove_anchored_entry(
+                descriptor,
+                target.name,
+                expected_identity=(identity.st_dev, identity.st_ino),
+            )
+    finally:
+        os.close(descriptor)
+
+    assert target.is_dir()
+    assert (home / "moved").is_dir()

--- a/tests/test_memory_snapshot.py
+++ b/tests/test_memory_snapshot.py
@@ -17,6 +17,7 @@ from core.memory.clear_journal import (
     ClearTransitionError,
     MemoryClearJournal,
 )
+from core.memory.confined_filesystem import remove_confined_path
 from core.memory.snapshot import (
     MemorySnapshotError,
     MemorySnapshotManager,
@@ -801,7 +802,7 @@ def test_snapshot_accepts_path_record_beyond_256k_and_clear_gc(
         execution_token=operation.execution_token,
     )
     manager.remove(journal.terminal_snapshot_permit(operation.operation_id))
-    snapshot_module._remove_safe_path(home, source_root)
+    remove_confined_path(home, source_root)
     assert not manager.snapshot_path(snapshot.snapshot_id).exists()
 
 
@@ -1357,83 +1358,6 @@ def test_explicit_id_backup_retry_still_reclaims_its_deterministic_stage(
     backup = manager.create("explicit-retry")
     assert backup.snapshot_id == "explicit-retry"
     assert not (manager.snapshot_root / ".explicit-retry.tmp").exists()
-
-
-def test_remove_uses_anchored_no_follow_walk_during_directory_swap(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    home = tmp_path / "home"
-    home.mkdir(mode=0o700)
-    home.chmod(0o700)
-    journal = MemoryClearJournal(home)
-    operation = journal.start(
-        operation_id="remove-race",
-        operator_ref="user:owner",
-        pre_epoch=0,
-        target_epoch=1,
-    )
-    manager = MemorySnapshotManager(home)
-    snapshot = manager.create("remove-race")
-    assert operation.execution_token is not None
-    operation = journal.record_snapshot(
-        operation.operation_id,
-        expected_revision=operation.revision,
-        execution_token=operation.execution_token,
-        snapshot=snapshot,
-    )
-    assert operation.execution_token is not None
-    operation = journal.mark_prepared(
-        operation.operation_id,
-        expected_revision=operation.revision,
-        execution_token=operation.execution_token,
-    )
-    assert operation.execution_token is not None
-    operation = journal.begin_deleting(
-        operation.operation_id,
-        expected_revision=operation.revision,
-        execution_token=operation.execution_token,
-    )
-    for surface in journal.surfaces:
-        assert operation.execution_token is not None
-        operation = journal.record_surface_deleted(
-            operation.operation_id,
-            surface.name,
-            expected_revision=operation.revision,
-            execution_token=operation.execution_token,
-        )
-    assert operation.execution_token is not None
-    operation = journal.mark_completed(
-        operation.operation_id,
-        expected_revision=operation.revision,
-        execution_token=operation.execution_token,
-    )
-    permit = journal.terminal_snapshot_permit(operation.operation_id)
-    outside = tmp_path / "outside"
-    outside.mkdir()
-    victim = outside / "victim.txt"
-    victim.write_text("outside must survive")
-    snapshot_dir = manager.snapshot_path(snapshot.snapshot_id)
-    tombstone = manager.snapshot_root / f".{snapshot.snapshot_id}.gc"
-    moved = manager.snapshot_root / "held-remove-race"
-    real_scandir = snapshot_module.os.scandir
-    swapped = False
-
-    def swap_directory_for_symlink(path):
-        nonlocal swapped
-        if isinstance(path, int) and not swapped and tombstone.exists():
-            swapped = True
-            tombstone.rename(moved)
-            tombstone.symlink_to(outside, target_is_directory=True)
-        return real_scandir(path)
-
-    monkeypatch.setattr(snapshot_module.os, "scandir", swap_directory_for_symlink)
-    with pytest.raises(MemorySnapshotUnsafePathError):
-        manager.remove(permit)
-
-    assert swapped
-    assert not snapshot_dir.exists()
-    assert victim.read_text() == "outside must survive"
 
 
 def test_only_completed_journal_operation_can_authorize_snapshot_removal(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- add a narrow Memory-owned confined filesystem module for private SQLite files and anchored no-follow removal
- rewire both journals, snapshot cleanup, and provider-root cleanup away from peer-domain private helpers
- move primitive race coverage to the shared owner while retaining domain contract coverage

## Evidence

- Unit: shared primitive tests cover symlink swaps, hardlinks, special files, ownership, modes, identity guards, confinement, and outside victims
- Contract: snapshot, clear journal, backup/restore journal, module, and runtime-clear suites pass
- Scenario: no scenario catalog IDs apply to this behavior-preserving internal refactor
- Residual manual checks: none; no user-visible workflow or filesystem layout changed

Closes #1244
