### PR TITLE
test(turns): mirror lifecycle admission ownership

### DIFF
--- a/tests/test_internal_server.py
+++ b/tests/test_internal_server.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import inspect
 import socket
 import sys
 import tempfile
@@ -234,7 +235,25 @@ def _build_controller_double(handler=None):
 
     controller = MagicMock()
     controller.message_handler = MagicMock()
-    controller.message_handler.handle_user_message = AsyncMock(side_effect=handler or (lambda ctx, text: None))
+    callback = handler or (lambda ctx, text: None)
+
+    async def _handle_user_message(ctx, text):
+        lifecycle_admission = (ctx.platform_specific or {}).pop(
+            session_turns.TURN_LIFECYCLE_ADMISSION_KEY,
+            None,
+        )
+        try:
+            result = callback(ctx, text)
+            if inspect.isawaitable(result):
+                return await result
+            return result
+        finally:
+            if lifecycle_admission is not None:
+                lifecycle_admission.release()
+
+    controller.message_handler.handle_user_message = AsyncMock(
+        side_effect=_handle_user_message,
+    )
 
     sinks: dict = {}
     controller.active_turn_sinks = sinks


### PR DESCRIPTION
## Summary

Follow-up to #1247 after it merged while its final CI shard was still running:

- make the internal-server controller double release lifecycle admission through the same owner boundary as production `MessageHandler`;
- restore queued Show annotation and compatible FIFO segment dispatch after the active turn completes.

## Evidence

- Parent cleanup PR: #1247
- Affected CI job: https://github.com/avibe-bot/avibe/actions/runs/31322473499/job/93267475797
- Before: shard 3 reproduced three failed queued-turn assertions and then remained blocked in `tests/test_internal_server.py`.
- After: `tests/test_internal_server.py` passed 106/106 and the complete unit-test shard 3 passed all 57 files.
- Regression: `tests/test_scheduled_tasks.py::test_dead_accepted_owner_converges_run_session_and_persisted_fifo` remains green.
- Contract: no contract changes.
- Residual manual checks: none.

## Root Cause

#1231 introduced lifecycle admission before dispatch. Production pops and releases it in `MessageHandler`, but the internal-server test double invoked direct handlers without mirroring that ownership. The first turn therefore retained admission and blocked every queued successor.
