### PR TITLE
fix(release): pin package version to release tag

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -216,6 +216,15 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Pin package version to release tag
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ needs.resolve-tag.outputs.tag }}
+        run: |
+          PACKAGE_VERSION="$(python scripts/release_package_version.py "$RELEASE_TAG")"
+          echo "SETUPTOOLS_SCM_PRETEND_VERSION=$PACKAGE_VERSION" >> "$GITHUB_ENV"
+          echo "SETUPTOOLS_SCM_PRETEND_VERSION_FOR_AVIBE_OS=$PACKAGE_VERSION" >> "$GITHUB_ENV"
+
       - name: Verify Show Runtime release assets
         run: |
           python - <<'PY'

--- a/.github/workflows/release_ai.yml
+++ b/.github/workflows/release_ai.yml
@@ -190,6 +190,15 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Pin package version to release tag
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ github.event.inputs.tag || github.ref_name }}
+        run: |
+          PACKAGE_VERSION="$(python scripts/release_package_version.py "$RELEASE_TAG")"
+          echo "SETUPTOOLS_SCM_PRETEND_VERSION=$PACKAGE_VERSION" >> "$GITHUB_ENV"
+          echo "SETUPTOOLS_SCM_PRETEND_VERSION_FOR_AVIBE_OS=$PACKAGE_VERSION" >> "$GITHUB_ENV"
+
       - name: Build Python package
         run: |
           pip install build

--- a/scripts/release_package_version.py
+++ b/scripts/release_package_version.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""Resolve an Avibe release tag to the package version used for builds."""
+
+from __future__ import annotations
+
+import argparse
+import re
+from collections.abc import Sequence
+
+
+_VERSION_PATTERN = re.compile(
+    r"^[0-9]+\.[0-9]+\.[0-9]+"
+    r"(?:(?:[.-]?(?:a|b|rc|dev))[0-9]+)?"
+    r"(?:\.post[0-9]+)?$"
+)
+
+
+def package_version_from_release_tag(tag: str) -> str:
+    normalized = tag.strip()
+    if normalized.startswith("gh-v"):
+        version = normalized.removeprefix("gh-v")
+    elif normalized.startswith("v"):
+        version = normalized.removeprefix("v")
+    else:
+        raise ValueError("release tag must start with 'v' or 'gh-v'")
+
+    if not _VERSION_PATTERN.fullmatch(version):
+        raise ValueError(f"release tag does not contain a supported package version: {tag!r}")
+    return version
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("tag", help="Release tag, for example gh-v3.0.10rc1")
+    args = parser.parse_args(argv)
+    try:
+        version = package_version_from_release_tag(args.tag)
+    except ValueError as exc:
+        parser.error(str(exc))
+    print(version)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_release_package_version.py
+++ b/tests/test_release_package_version.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scripts.release_package_version import package_version_from_release_tag
+
+
+@pytest.mark.parametrize(
+    ("tag", "expected"),
+    [
+        ("v3.0.9", "3.0.9"),
+        ("v3.0.10rc1", "3.0.10rc1"),
+        ("gh-v3.0.10rc1", "3.0.10rc1"),
+        ("gh-v4.1.0b2", "4.1.0b2"),
+    ],
+)
+def test_package_version_from_release_tag(tag: str, expected: str) -> None:
+    assert package_version_from_release_tag(tag) == expected
+
+
+@pytest.mark.parametrize("tag", ["", "3.0.10rc1", "release-v3.0.10", "gh-vnext"])
+def test_package_version_from_release_tag_rejects_unsupported_tags(tag: str) -> None:
+    with pytest.raises(ValueError):
+        package_version_from_release_tag(tag)
+
+
+def test_package_release_workflows_pin_scm_version_to_release_tag() -> None:
+    workflows = Path(__file__).resolve().parents[1] / ".github/workflows"
+
+    for name in ("release_ai.yml", "publish.yml"):
+        workflow = (workflows / name).read_text(encoding="utf-8")
+        assert "python scripts/release_package_version.py" in workflow
+        assert "SETUPTOOLS_SCM_PRETEND_VERSION=$PACKAGE_VERSION" in workflow
+        assert "SETUPTOOLS_SCM_PRETEND_VERSION_FOR_AVIBE_OS=$PACKAGE_VERSION" in workflow


### PR DESCRIPTION
## Summary

Pin Avibe package builds to the release tag version after generated runtime manifests make the checkout dirty. This keeps `gh-v...` prerelease wheels and `v...` builds aligned with their tags in both GitHub-only and PyPI workflows.

## Evidence

- Unit: `tests/test_release_package_version.py` covers tag normalization and rejection cases.
- Contract: the test asserts both release workflows export the package-specific and generic `SETUPTOOLS_SCM_PRETEND_VERSION` variables from the release tag.
- Scenario: release workflow package build; no scenario catalog changes.
- Residual manual check: rerun a `gh-v...` release and verify wheel metadata matches the tag; the existing `gh-v3.0.10rc1` release is intentionally not rebuilt because tags and assets are immutable.

## Dependencies

None.

## Known by design

- Generated runtime manifests can remain tracked and change during the build; the explicit VCS pretend version is the release tag's package version.
