### PR TITLE
feat(harness): add hidden agent session provenance

### DIFF
--- a/core/handlers/message_handler.py
+++ b/core/handlers/message_handler.py
@@ -18,7 +18,10 @@ from core.message_output import (
     terminal_output_for,
     terminal_turn_output,
 )
-from core.message_context import resolve_context_thread_id
+from core.message_context import (
+    SCHEDULED_DISPATCH_METADATA_APPLIED_KEY,
+    resolve_context_thread_id,
+)
 from core.native_dispatch_phase import (
     DISPATCH_PHASE_PREWRITE,
     set_dispatch_phase,
@@ -754,7 +757,13 @@ class MessageHandler(BaseHandler):
                 user_message = append_audio_transcripts_to_message(user_message, audio_transcripts)
                 await self._echo_audio_transcripts_if_enabled(context, audio_transcripts)
 
-            if not (is_human and durable_delivery_owned):
+            scheduled_metadata_applied = bool(
+                source == self.TURN_SOURCE_SCHEDULED
+                and (context.platform_specific or {}).get(
+                    SCHEDULED_DISPATCH_METADATA_APPLIED_KEY
+                )
+            )
+            if not (is_human and durable_delivery_owned) and not scheduled_metadata_applied:
                 message = await self._prepend_message_metadata(
                     context,
                     message,

--- a/core/handlers/message_handler.py
+++ b/core/handlers/message_handler.py
@@ -1294,12 +1294,26 @@ class MessageHandler(BaseHandler):
         metadata_lines: list[str] = []
         if getattr(self.config, "include_time_info", True):
             metadata_lines.append(self._build_current_time_line())
+        source_session_id = self._source_session_id(context)
+        if source_session_id:
+            metadata_lines.append(f"From: #{self._sanitize_identity(source_session_id)}")
         if include_user_info and getattr(self.config, "include_user_info", True):
             metadata_lines.append(await self._build_user_info_line(context))
 
         if not metadata_lines:
             return message
         return "\n".join([*metadata_lines, message])
+
+    @staticmethod
+    def _source_session_id(context: MessageContext) -> str:
+        """Return the Agent Session that authored this Harness input, if known."""
+        payload = context.platform_specific or {}
+        source_session_id = str(payload.get("source_session_id") or "").strip()
+        if source_session_id:
+            return source_session_id
+        if str(payload.get("source_kind") or "").strip() == "agent":
+            return str(payload.get("source_actor") or "").strip()
+        return ""
 
     @staticmethod
     def _build_current_time_line(now: datetime | None = None) -> str:

--- a/core/internal_server.py
+++ b/core/internal_server.py
@@ -217,8 +217,6 @@ def create_app(
             submission = await manager.submit(None, context, text, source=SOURCE_SCHEDULED)
             return submission.route
 
-        dispatch_text = await manager.prepare_scheduled_dispatch(context, text)
-
         from core.message_mirror import _scope_id_for_session
         from core.session_turns import (
             DeliveryRequest,
@@ -410,7 +408,7 @@ def create_app(
                         },
                         native_message_id=native_message_id or None,
                     ),
-                    dispatch_text=dispatch_text,
+                    dispatch_text=text,
                     dedupe_key=dedupe_key,
                     history_event={
                         "kind": "admission",
@@ -455,7 +453,7 @@ def create_app(
                     if delivery_intent == "send_now"
                     else priority_for_delivery_intent(delivery_intent)
                 ),
-                content=dispatch_text,
+                content=text,
                 delivery_id=delivery_id,
                 scope_id=scope_id,
                 platform=submission_platform,

--- a/core/internal_server.py
+++ b/core/internal_server.py
@@ -217,6 +217,8 @@ def create_app(
             submission = await manager.submit(None, context, text, source=SOURCE_SCHEDULED)
             return submission.route
 
+        dispatch_text = await manager.prepare_scheduled_dispatch(context, text)
+
         from core.message_mirror import _scope_id_for_session
         from core.session_turns import (
             DeliveryRequest,
@@ -408,7 +410,7 @@ def create_app(
                         },
                         native_message_id=native_message_id or None,
                     ),
-                    dispatch_text=text,
+                    dispatch_text=dispatch_text,
                     dedupe_key=dedupe_key,
                     history_event={
                         "kind": "admission",
@@ -453,7 +455,7 @@ def create_app(
                     if delivery_intent == "send_now"
                     else priority_for_delivery_intent(delivery_intent)
                 ),
-                content=text,
+                content=dispatch_text,
                 delivery_id=delivery_id,
                 scope_id=scope_id,
                 platform=submission_platform,

--- a/core/message_context.py
+++ b/core/message_context.py
@@ -8,6 +8,12 @@ from config.v2_settings import make_thread_settings_key
 from modules.im import MessageContext
 
 
+# Internal-only marker persisted with scheduled Delivery provenance. It keeps
+# durable turns from applying the backend-only metadata a second time when the
+# stored dispatch text is finally handed to MessageHandler.
+SCHEDULED_DISPATCH_METADATA_APPLIED_KEY = "scheduled_dispatch_metadata_applied"
+
+
 def resolve_context_platform(
     context: Optional[MessageContext],
     *,

--- a/core/scheduled_tasks.py
+++ b/core/scheduled_tasks.py
@@ -920,6 +920,7 @@ def enqueue_session_callback(
     session_id: str,
     message: str,
     source_actor: str,
+    source_session_id: Optional[str] = None,
     parent_run_id: Optional[str] = None,
     metadata: Optional[dict[str, Any]] = None,
 ) -> Optional["TaskExecutionRequest"]:
@@ -934,6 +935,10 @@ def enqueue_session_callback(
         return None
     target = resolve_session_id_target(session_id)
     from core.message_priority import delivery_intent_for_trigger
+
+    callback_metadata = dict(metadata or {})
+    if source_session_id:
+        callback_metadata["source_session_id"] = str(source_session_id)
 
     return request_store.enqueue_agent_run(
         session_id=session_id,
@@ -950,7 +955,7 @@ def enqueue_session_callback(
         parent_run_id=parent_run_id,
         delivery_intent=delivery_intent_for_trigger("callback"),
         metadata={
-            **(metadata or {}),
+            **callback_metadata,
             **({"callback_parent_run_id": parent_run_id} if parent_run_id else {}),
         },
         callback_parent_to_arm=parent_run_id,
@@ -7209,6 +7214,7 @@ class ScheduledTaskService:
                 session_id=callback_session_id,
                 message=terminal_message,
                 source_actor=f"{run_id}:terminal:{status}",
+                source_session_id=str(run.get("session_id") or "").strip() or None,
                 parent_run_id=run_id or None,
             )
             if terminal_callback is not None:
@@ -7218,6 +7224,7 @@ class ScheduledTaskService:
             session_id=callback_session_id,
             message=self._build_callback_message(run),
             source_actor=run_id,
+            source_session_id=str(run.get("session_id") or "").strip() or None,
             parent_run_id=run_id or None,
         )
 
@@ -10140,6 +10147,7 @@ class ScheduledTaskService:
                 "vibe_agent_id": agent_id,
                 "source_kind": (metadata or {}).get("source_kind"),
                 "source_actor": (metadata or {}).get("source_actor"),
+                "source_session_id": (metadata or {}).get("source_session_id"),
                 "vault_request_type": (metadata or {}).get("vault_request_type"),
                 "vault_request_status": (metadata or {}).get("vault_request_status"),
                 "parent_run_id": (metadata or {}).get("parent_run_id"),

--- a/core/session_turns.py
+++ b/core/session_turns.py
@@ -978,8 +978,28 @@ class SessionTurnManager:
         self,
         context: "MessageContext",
         text: str,
+        *,
+        delivery: Optional[dict[str, Any]] = None,
     ) -> str:
-        """Decorate scheduled backend text before it enters durable Delivery."""
+        """Decorate scheduled backend text immediately before native dispatch."""
+        if delivery is not None:
+            payload = delivery_store.delivery_payload(delivery)
+            provenance = (payload.get("metadata") or {}).get(SCHEDULED_PROVENANCE_KEY)
+            preserved = (
+                provenance.get("platform_specific")
+                if isinstance(provenance, dict)
+                else None
+            )
+            if isinstance(preserved, dict):
+                spec = dict(getattr(context, "platform_specific", None) or {})
+                spec.update(
+                    {
+                        key: value
+                        for key, value in preserved.items()
+                        if key not in _EXECUTION_ROUTING_KEYS
+                    }
+                )
+                context.platform_specific = spec
         spec = dict(getattr(context, "platform_specific", None) or {})
         if spec.get(SCHEDULED_DISPATCH_METADATA_APPLIED_KEY):
             return text
@@ -2530,13 +2550,22 @@ class SessionTurnManager:
                 attempted_turn_id=turn_id,
             )
         elif delivery["state"] == "steering" and turn_id and attempt_id and native_id:
+            raw_steer_text = str(delivery.get("dispatch_text") or "")
+            if request.source == "harness" or _scheduled_provenance(delivery) is not None:
+                steer_text = await self.prepare_scheduled_dispatch(
+                    context,
+                    raw_steer_text,
+                    delivery=delivery,
+                )
+            else:
+                steer_text = raw_steer_text
             receipt = await self._attempt_steer(
                 steer_backend,
                 SteerRequest(
                     target_session_id=request.session_id,
                     expected_logical_turn_id=turn_id,
                     expected_native_turn_id=native_id,
-                    text=str(delivery.get("dispatch_text") or ""),
+                    text=steer_text,
                     attempt_id=attempt_id,
                 ),
             )
@@ -2702,13 +2731,18 @@ class SessionTurnManager:
                 attempted_turn_id=turn_id,
             )
         elif leader["state"] == "steering" and turn_id and attempt_id and native_id:
+            steer_text = await self.prepare_scheduled_dispatch(
+                context,
+                dispatch_text,
+                delivery=leader,
+            ) if _scheduled_provenance(leader) is not None else dispatch_text
             receipt = await self._attempt_steer(
                 steer_backend,
                 SteerRequest(
                     target_session_id=session_id,
                     expected_logical_turn_id=turn_id,
                     expected_native_turn_id=native_id,
-                    text=dispatch_text,
+                    text=steer_text,
                     attempt_id=attempt_id,
                 ),
             )
@@ -4568,6 +4602,11 @@ class SessionTurnManager:
                 )
                 backend = str(turn["backend"])
                 delivery_id = str(claimed_batch[0]["id"])
+            steer_text = await self.prepare_scheduled_dispatch(
+                context,
+                steer_text,
+                delivery=claimed_batch[0],
+            ) if _scheduled_provenance(claimed_batch[0]) is not None else steer_text
             receipt = await self._attempt_steer(
                 backend,
                 SteerRequest(
@@ -6050,7 +6089,6 @@ class SessionTurnManager:
             else {}
         )
         if source == SOURCE_SCHEDULED:
-            dispatch_text = await self.prepare_scheduled_dispatch(context, text)
             scheduled_metadata[SCHEDULED_PROVENANCE_KEY] = capture_scheduled_provenance(
                 context
             )

--- a/core/session_turns.py
+++ b/core/session_turns.py
@@ -15,6 +15,7 @@ owners for live tasks and streaming only.
 from __future__ import annotations
 
 import asyncio
+import inspect
 import json
 import logging
 import uuid
@@ -984,7 +985,7 @@ class SessionTurnManager:
             return text
         handler = getattr(self.controller, "message_handler", None)
         decorator = getattr(handler, "_prepend_message_metadata", None)
-        if not callable(decorator):
+        if not callable(decorator) or not inspect.iscoroutinefunction(decorator):
             return text
         decorated = await decorator(context, text, include_user_info=False)
         spec[SCHEDULED_DISPATCH_METADATA_APPLIED_KEY] = True

--- a/core/session_turns.py
+++ b/core/session_turns.py
@@ -28,7 +28,10 @@ from sqlalchemy.engine import Connection, Engine
 from sqlalchemy.exc import IntegrityError
 
 from core.web_push_notifications import WEB_PUSH_USER_KEY_METADATA, WEB_PUSH_USER_KEYS_METADATA
-from core.message_context import resolve_turn_sink_key
+from core.message_context import (
+    SCHEDULED_DISPATCH_METADATA_APPLIED_KEY,
+    resolve_turn_sink_key,
+)
 from core.native_dispatch_phase import backend_dispatch_attempted
 from core.run_settlement import (
     NON_COMPLETING_TURN_SETTLEMENTS,
@@ -297,10 +300,14 @@ def _scheduled_merge_key(row: dict[str, Any]) -> Optional[tuple[str, ...]]:
             or spec.get(SCHEDULED_TARGET_AGENT_KEY)
             or ""
         )
+    source_session_id = str(spec.get("source_session_id") or "").strip()
+    if not source_session_id and str(spec.get("source_kind") or "").strip() == "agent":
+        source_session_id = str(spec.get("source_actor") or "").strip()
     return (
         trigger_kind,
         definition_id,
         stable_agent_key,
+        source_session_id,
         str(spec.get("delivery_key_external") or ""),
         str(spec.get("delivery_scope_session_key") or ""),
         str(delivery_override.get("platform") or ""),
@@ -965,6 +972,24 @@ class SessionTurnManager:
         if self._build_context is None:
             raise RuntimeError("Session delivery context builder is not bound")
         return self._build_context(session_id)
+
+    async def prepare_scheduled_dispatch(
+        self,
+        context: "MessageContext",
+        text: str,
+    ) -> str:
+        """Decorate scheduled backend text before it enters durable Delivery."""
+        spec = dict(getattr(context, "platform_specific", None) or {})
+        if spec.get(SCHEDULED_DISPATCH_METADATA_APPLIED_KEY):
+            return text
+        handler = getattr(self.controller, "message_handler", None)
+        decorator = getattr(handler, "_prepend_message_metadata", None)
+        if not callable(decorator):
+            return text
+        decorated = await decorator(context, text, include_user_info=False)
+        spec[SCHEDULED_DISPATCH_METADATA_APPLIED_KEY] = True
+        context.platform_specific = spec
+        return decorated
 
     @staticmethod
     def _apply_delivery_binding_provenance(
@@ -6017,6 +6042,17 @@ class SessionTurnManager:
             )
 
         spec = dict(getattr(context, "platform_specific", None) or {})
+        dispatch_text = text
+        scheduled_metadata = (
+            dict(spec.get("message_metadata") or {})
+            if isinstance(spec.get("message_metadata"), dict)
+            else {}
+        )
+        if source == SOURCE_SCHEDULED:
+            dispatch_text = await self.prepare_scheduled_dispatch(context, text)
+            scheduled_metadata[SCHEDULED_PROVENANCE_KEY] = capture_scheduled_provenance(
+                context
+            )
         with self._sqlite_engine().connect() as conn:
             busy = delivery_store.active_turn(conn, session_id) is not None
         source_value = "harness" if source == SOURCE_SCHEDULED else "user"
@@ -6031,7 +6067,7 @@ class SessionTurnManager:
         request = DeliveryRequest(
             session_id=session_id,
             priority=priority,
-            content=text,
+            content=dispatch_text,
             has_content=delivery_store.has_substantive_input(
                 text,
                 has_attachments=bool(getattr(context, "files", None)),
@@ -6044,7 +6080,7 @@ class SessionTurnManager:
             message_type="harness" if source == SOURCE_SCHEDULED else "user",
             display_text=str(spec.get("display_text") or text),
             content_json=spec.get("message_content") if isinstance(spec.get("message_content"), dict) else None,
-            metadata=spec.get("message_metadata") if isinstance(spec.get("message_metadata"), dict) else {},
+            metadata=scheduled_metadata,
             author_id=str(
                 spec.get("author_id")
                 or (spec.get("task_definition_id") if source == SOURCE_SCHEDULED else "")

--- a/core/session_turns.py
+++ b/core/session_turns.py
@@ -1007,10 +1007,7 @@ class SessionTurnManager:
         decorator = getattr(handler, "_prepend_message_metadata", None)
         if not callable(decorator) or not inspect.iscoroutinefunction(decorator):
             return text
-        decorated = await decorator(context, text, include_user_info=False)
-        spec[SCHEDULED_DISPATCH_METADATA_APPLIED_KEY] = True
-        context.platform_specific = spec
-        return decorated
+        return await decorator(context, text, include_user_info=False)
 
     @staticmethod
     def _apply_delivery_binding_provenance(

--- a/tests/test_message_handler_harness_echo.py
+++ b/tests/test_message_handler_harness_echo.py
@@ -17,6 +17,7 @@ ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
 from core.message_output import HARNESS_PROMPT_ECHO_SPEC_KEY
+from core.message_context import SCHEDULED_DISPATCH_METADATA_APPLIED_KEY
 from modules.im import MessageContext
 
 # Reuses the isolated module loader (and controller/session stubs) from the
@@ -74,6 +75,18 @@ class MessageHandlerHarnessEchoTests(unittest.IsolatedAsyncioTestCase):
         # And nothing is posted from here: the send waits for the runtime gate in
         # ``AgentService._begin_turn_status``, so a queued turn stays quiet.
         controller.message_dispatcher.emit_harness_prompt.assert_not_awaited()
+
+    async def test_durable_scheduled_text_with_metadata_marker_is_not_decorated_twice(self):
+        controller, handler = _build_handler()
+        context = _scheduled_context(
+            **{SCHEDULED_DISPATCH_METADATA_APPLIED_KEY: True}
+        )
+
+        await handler.handle_scheduled_message(context, "[Current Time: ...]\nFrom: #source\nwork")
+
+        handler._prepend_message_metadata.assert_not_awaited()
+        _agent_name, request = controller.agent_service.requests[0]
+        self.assertEqual(request.message, "[Current Time: ...]\nFrom: #source\nwork")
 
     async def test_subagent_prefixed_prompt_is_staged_unstripped(self):
         """Scenario: MESSAGE-DELIVERY-018

--- a/tests/test_message_handler_user_info.py
+++ b/tests/test_message_handler_user_info.py
@@ -117,6 +117,43 @@ class MessageHandlerUserInfoTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(result, "[Current Time: 2026-05-13 11:42:08 UTC+08:00]\nscheduled work")
 
+    async def test_prepend_message_metadata_places_source_session_after_time(self):
+        handler = MessageHandler(_StubController({"display_name": "", "real_name": "Alex", "name": "cyh"}))
+        handler.config.include_time_info = True
+        handler._build_current_time_line = lambda: "[Current Time: 2026-05-13 11:42:08 UTC+08:00]"  # type: ignore[method-assign]
+        context = MessageContext(
+            user_id="caller",
+            channel_id="C1",
+            platform_specific={
+                "source_kind": "callback",
+                "source_session_id": "ses_sender123",
+            },
+        )
+
+        result = await handler._prepend_message_metadata(context, "callback result", include_user_info=False)
+
+        self.assertEqual(
+            result,
+            "[Current Time: 2026-05-13 11:42:08 UTC+08:00]\n"
+            "From: #ses_sender123\ncallback result",
+        )
+
+    async def test_prepend_message_metadata_uses_agent_source_actor_as_session(self):
+        handler = MessageHandler(_StubController({"display_name": "", "real_name": "Alex", "name": "cyh"}))
+        handler.config.include_time_info = False
+        context = MessageContext(
+            user_id="caller",
+            channel_id="C1",
+            platform_specific={
+                "source_kind": "agent",
+                "source_actor": "ses_sender456",
+            },
+        )
+
+        result = await handler._prepend_message_metadata(context, "delegated work", include_user_info=False)
+
+        self.assertEqual(result, "From: #ses_sender456\ndelegated work")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_scheduled_tasks.py
+++ b/tests/test_scheduled_tasks.py
@@ -1154,6 +1154,34 @@ def test_build_context_forwards_vault_callback_outcome_metadata() -> None:
     assert context.platform_specific["vault_request_status"] == "denied"
 
 
+def test_build_context_forwards_callback_source_session_id() -> None:
+    settings_manager = SimpleNamespace(get_store=lambda: SimpleNamespace(get_user=lambda *_args, **_kwargs: None))
+    controller = SimpleNamespace(
+        platform_settings_managers={"slack": settings_manager},
+        get_im_client_for_context=lambda _context: SimpleNamespace(
+            should_use_thread_for_reply=lambda: True,
+            should_use_thread_for_dm_session=lambda: False,
+        ),
+    )
+    service = ScheduledTaskService(controller=controller, store=ScheduledTaskStore(Path("/tmp/nonexistent-scheduled.json")))
+    target = parse_session_key("slack::channel::C123")
+
+    context = asyncio.run(
+        service._build_context(
+            target,
+            execution_id="exec-callback-source",
+            trigger_kind="agent_run",
+            metadata={
+                "source_kind": "callback",
+                "source_actor": "run-parent",
+                "source_session_id": "ses-source",
+            },
+        )
+    )
+
+    assert context.platform_specific["source_session_id"] == "ses-source"
+
+
 def test_build_context_carries_the_definition_name_for_display() -> None:
     """The prompt echo names what fired, so the label cannot be an opaque id."""
 
@@ -6697,6 +6725,7 @@ def test_agent_run_callback_enqueues_only_result_to_caller_session(tmp_path: Pat
     assert callback_run["source_kind"] == "callback"
     assert callback_run["parent_run_id"] == request.id
     assert callback_run["message"] == "complete delegated result"
+    assert callback_run["metadata"]["source_session_id"] == "target-session"
 
 
 def test_one_terminal_turn_fans_out_each_accepted_run_callback_once(
@@ -7738,6 +7767,7 @@ def test_agent_run_callbacks_only_terminal_status_after_partial_output(
     ]
     assert [run["message"] for run in callback_runs] == [expected_message]
     assert callback_runs[0]["source_actor"] == f"{request.id}:terminal:{terminal_status}"
+    assert callback_runs[0]["metadata"]["source_session_id"] == "target-session"
     assert original["callback_run_id"] == callback_runs[0]["id"]
 
 

--- a/tests/test_session_delivery_fsm.py
+++ b/tests/test_session_delivery_fsm.py
@@ -1209,6 +1209,55 @@ def test_late_steer_acceptance_upgrades_the_queued_admission_receipt(managers) -
     assert acks == [("slack", "slack-msg-99", "accepted", "steered")]
 
 
+@pytest.mark.anyio
+async def test_pending_scheduled_batches_each_get_dispatch_metadata(managers) -> None:
+    manager, _other, _engine, _engine_b, _starts = managers
+    decorator = AsyncMock(side_effect=lambda _context, text, **_kwargs: f"decorated: {text}")
+    manager.controller.message_handler = SimpleNamespace(
+        _prepend_message_metadata=decorator,
+    )
+    context = _context()
+    deliveries = []
+    for index, text in enumerate(("first callback", "second callback")):
+        deliveries.append(
+            {
+                "id": f"delivery-{index}",
+                "dispatch_text": text,
+                "snapshot_json": json.dumps(
+                    delivery_store.message_snapshot(
+                        scope_id=None,
+                        session_id="ses_fsm",
+                        platform="avibe",
+                        author="harness",
+                        source="harness",
+                        message_type="harness",
+                        text=text,
+                        metadata={
+                            SCHEDULED_PROVENANCE_KEY: {
+                                "platform_specific": {
+                                    "task_trigger_kind": "agent_run",
+                                    "source_session_id": f"source-{index}",
+                                }
+                            }
+                        },
+                    )
+                ),
+            }
+        )
+
+    assert await manager.prepare_scheduled_dispatch(
+        context, "first callback", delivery=deliveries[0]
+    ) == "decorated: first callback"
+    assert await manager.prepare_scheduled_dispatch(
+        context, "second callback", delivery=deliveries[1]
+    ) == "decorated: second callback"
+    assert decorator.await_count == 2
+    assert [call.args[1] for call in decorator.await_args_list] == [
+        "first callback",
+        "second callback",
+    ]
+
+
 def test_workbench_delivery_reports_no_reaction_receipt(managers) -> None:
     """Only an IM input has a native message to react on."""
 

--- a/tests/test_session_delivery_fsm.py
+++ b/tests/test_session_delivery_fsm.py
@@ -640,7 +640,7 @@ def test_fifo_scheduled_segment_does_not_merge_different_source_sessions(manager
 
 @pytest.mark.anyio
 async def test_scheduled_submit_decorates_before_native_steering(managers) -> None:
-    manager, _other, _engine, _engine_b, _starts = managers
+    manager, _other, engine, _engine_b, _starts = managers
     decorator = AsyncMock(side_effect=lambda _context, text, **_kwargs: f"decorated: {text}")
     manager.controller.message_handler = SimpleNamespace(
         _prepend_message_metadata=decorator,
@@ -655,15 +655,27 @@ async def test_scheduled_submit_decorates_before_native_steering(managers) -> No
             "source_session_id": "source-session",
         }
     )
-    result = await manager.submit(
-        "ses_fsm",
-        context,
-        "callback result",
-        source=SOURCE_SCHEDULED,
-        delivery_intent="steer",
+    result = await manager.deliver(
+        DeliveryRequest(
+            session_id="ses_fsm",
+            priority="p1",
+            content="callback result",
+            source="harness",
+            author="harness",
+            message_type="harness",
+            metadata={
+                SCHEDULED_PROVENANCE_KEY: {
+                    "platform_specific": {
+                        "task_trigger_kind": "agent_run",
+                        "source_session_id": "source-session",
+                    }
+                }
+            },
+        ),
+        context=context,
     )
 
-    assert result.route == "ran"
+    assert result.state == "accepted"
     decorator.assert_awaited_once_with(context, "callback result", include_user_info=False)
     manager._steer.assert_awaited_once()
     assert manager._steer.await_args.args[1].text == "decorated: callback result"

--- a/tests/test_session_delivery_fsm.py
+++ b/tests/test_session_delivery_fsm.py
@@ -35,6 +35,7 @@ from core.session_turns import (
     DeliveryRequest,
     SessionTurnManager,
     Turn,
+    _scheduled_merge_key,
 )
 from core.handlers.message_handler import MessageHandler
 from modules.im import MessageContext
@@ -572,6 +573,100 @@ def test_fifo_segment_does_not_merge_different_message_authors(managers) -> None
     assert alice["state"] == "claimed"
     assert bob["turn_id"] is None
     assert bob["state"] == "queued"
+
+
+def test_scheduled_segment_key_keeps_source_sessions_separate() -> None:
+    def row(source_session_id: str) -> dict:
+        return {
+            "metadata": {
+                SCHEDULED_PROVENANCE_KEY: {
+                    "platform_specific": {
+                        "task_trigger_kind": "agent_run",
+                        "source_session_id": source_session_id,
+                    }
+                }
+            }
+        }
+
+    assert _scheduled_merge_key(row("source-a")) != _scheduled_merge_key(row("source-b"))
+    assert _scheduled_merge_key(row("source-a")) == _scheduled_merge_key(row("source-a"))
+
+    agent_row = row("")
+    agent_row["metadata"][SCHEDULED_PROVENANCE_KEY]["platform_specific"].update(
+        {"source_kind": "agent", "source_actor": "source-agent-a"}
+    )
+    other_agent_row = row("")
+    other_agent_row["metadata"][SCHEDULED_PROVENANCE_KEY]["platform_specific"].update(
+        {"source_kind": "agent", "source_actor": "source-agent-b"}
+    )
+    assert _scheduled_merge_key(agent_row) != _scheduled_merge_key(other_agent_row)
+
+
+def test_fifo_scheduled_segment_does_not_merge_different_source_sessions(managers) -> None:
+    manager, _other, engine, _engine_b, starts = managers
+    active_turn_id, _ = asyncio.run(_activate(manager, text="active"))
+
+    def scheduled_request(text: str, source_session_id: str) -> DeliveryRequest:
+        return DeliveryRequest(
+            session_id="ses_fsm",
+            priority="p3",
+            content=text,
+            source="harness",
+            author="harness",
+            message_type="harness",
+            metadata={
+                SCHEDULED_PROVENANCE_KEY: {
+                    "platform_specific": {
+                        "task_trigger_kind": "agent_run",
+                        "source_session_id": source_session_id,
+                    }
+                }
+            },
+        )
+
+    queued = [
+        asyncio.run(manager.deliver(scheduled_request(text, source), context=_context()))
+        for text, source in (("callback A", "source-a"), ("callback B", "source-b"))
+    ]
+
+    assert asyncio.run(manager.terminalize_turn(active_turn_id))
+    queued_starts = [(turn_id, text) for turn_id, text in starts if turn_id != active_turn_id]
+    assert len(queued_starts) == 1
+    first_turn_id, dispatch_text = queued_starts[0]
+    assert dispatch_text == "callback A"
+    assert _row(engine, str(queued[0].delivery_id))["turn_id"] == first_turn_id
+    assert _row(engine, str(queued[1].delivery_id))["turn_id"] is None
+
+
+@pytest.mark.anyio
+async def test_scheduled_submit_decorates_before_native_steering(managers) -> None:
+    manager, _other, _engine, _engine_b, _starts = managers
+    decorator = AsyncMock(side_effect=lambda _context, text, **_kwargs: f"decorated: {text}")
+    manager.controller.message_handler = SimpleNamespace(
+        _prepend_message_metadata=decorator,
+    )
+    await _activate(manager, text="active")
+    manager._steer = AsyncMock(return_value=steer_result(SteerOutcome.ACCEPTED))
+
+    context = _context()
+    context.platform_specific.update(
+        {
+            "task_trigger_kind": "agent_run",
+            "source_session_id": "source-session",
+        }
+    )
+    result = await manager.submit(
+        "ses_fsm",
+        context,
+        "callback result",
+        source=SOURCE_SCHEDULED,
+        delivery_intent="steer",
+    )
+
+    assert result.route == "ran"
+    decorator.assert_awaited_once_with(context, "callback result", include_user_info=False)
+    manager._steer.assert_awaited_once()
+    assert manager._steer.await_args.args[1].text == "decorated: callback result"
 
 
 def test_persisted_start_attempt_reaches_dispatch_context(managers) -> None:


### PR DESCRIPTION
## Summary

Add an internal `From: #<session-id>` prefix to Agent-originated Harness inputs.

The prefix is inserted by the shared metadata decorator after the current-time line and before the prompt body. Normal Agent delegation resolves the sender from the Agent source actor; normal, failed, and canceled callbacks carry the parent Run's sender Session ID explicitly. Harness mirrors and IM prompt echoes continue to use the raw display prompt, so users never see the internal line.

## Scenarios

- MESSAGE-DELIVERY-008: Agent Run callback delivery and terminal callback fan-out.
- MESSAGE-DELIVERY-018: Harness prompt echo remains the raw user-visible prompt.

## Evidence

- Unit: metadata ordering and Agent source-actor fallback tests.
- Contract: callback context forwards `source_session_id`.
- Scenario: 451 `tests/test_scheduled_tasks.py` tests plus focused callback and echo suites pass.
- Residual manual check: live backend/IM rendering was not run; the existing raw mirror/echo boundary is covered by the turn-pipeline tests.

## Validation

- `ruff check` passed on changed Python files.
- Focused message-handler, callback, and echo tests passed.
- Full `tests/test_scheduled_tasks.py`: 451 passed.
