### PR TITLE
fix(ui): wrap long Vault secret names

### DIFF
--- a/ui/src/components/ui/vault-secret-form.tsx
+++ b/ui/src/components/ui/vault-secret-form.tsx
@@ -1054,7 +1054,7 @@ export const VaultSecretForm: React.FC<{
           <Asterisk className="size-[18px] shrink-0 text-accent" />
           <div className="flex min-w-0 flex-1 flex-col gap-0.5">
             <span className="text-[10px] font-semibold uppercase tracking-wide text-muted">{t('vaults.dialog.nameUpper')}</span>
-            <span className="truncate font-mono text-[15px] font-semibold text-foreground">{secretName}</span>
+            <span className="whitespace-normal break-all font-mono text-[15px] font-semibold text-foreground">{secretName}</span>
           </div>
           <Badge variant="secondary" className="bg-surface">{t('vaults.request.notSetYet')}</Badge>
         </div>


### PR DESCRIPTION
## What
Long Vault secret names in the secure provision dialog no longer use ellipsis truncation. They wrap at any character so the complete requested name remains visible without widening the dialog.

## Validation
- Unit: `npm run test -- --run src/components/ui/vault-request-card.test.tsx` (1 passed)
- Lint: `npm run lint`
- Build: `npm run build`
- Residual manual check: regression Vault request cards remain the user-visible acceptance path.

## Risk
CSS-only change limited to the provision dialog's requested-name row.
