### PR TITLE
test(watch-worker): tolerate descendant cleanup race

### DIFF
--- a/tests/test_watch_worker.py
+++ b/tests/test_watch_worker.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from contextlib import suppress
 import logging
 import os
 import signal
@@ -225,7 +226,8 @@ def test_posix_watch_worker_waits_for_descendant_after_command_root_exits() -> N
             os.killpg(process.pid, signal.SIGKILL)
             process.wait(timeout=10)
         if psutil.pid_exists(descendant_pid):
-            psutil.Process(descendant_pid).kill()
+            with suppress(psutil.NoSuchProcess):
+                psutil.Process(descendant_pid).kill()
 
 
 @pytest.mark.skipif(os.name == "nt", reason="POSIX process group identity contract")


### PR DESCRIPTION
## Summary

- preserve the POSIX watch-worker descendant behavior assertions
- suppress only `psutil.NoSuchProcess` in redundant descendant cleanup
- leave production watch-worker behavior unchanged

Closes #1261

## Evidence

- Unit: `PYTHONPATH=. .venv/bin/pytest -q tests/test_watch_worker.py` (8 passed, 2 skipped)
- Focused stress: 16 independent affected-node runs at concurrency 4 (16/16 passed)
- Contract: existing watch-worker behavioral assertions retained unchanged
- Scenario: no scenario catalog entry applies to this test-cleanup-only change
- Static: `uvx ruff check tests/test_watch_worker.py`; `git diff --check`
- Residual manual: none; no user-facing or production behavior changed