### PR TITLE
fix(desktop): surface startup dependency reconciliation

### DIFF
--- a/core/show_runtime.py
+++ b/core/show_runtime.py
@@ -426,6 +426,11 @@ class ShowRuntimeManager:
                 return command
         command = self._install_managed_runtime()
         if command:
+            # A successful prepare is already the installation attempt for the
+            # request-time resolver. This is especially important for archive
+            # providers, where re-entering the installer would download and
+            # unpack the same runtime a second time during prewarm.
+            self._install_attempted = True
             self._managed_command = command
         return command
 

--- a/core/show_runtime.py
+++ b/core/show_runtime.py
@@ -143,8 +143,7 @@ class ShowRuntimeManager:
         # `prepare()` runs in a worker thread while serving requests calls
         # `ensure()` on the event loop. Both paths can reach the provider
         # installer, so protect the filesystem-mutating section across threads.
-        self._install_lock = threading.RLock()
-        self._install_generation = 0
+        self._install_lock = threading.Lock()
 
     async def ensure(self) -> ShowRuntimeResult:
         if self._base_url and await self._healthy(self._base_url):
@@ -152,49 +151,53 @@ class ShowRuntimeManager:
         async with self._lock:
             if self._base_url and await self._healthy(self._base_url):
                 return ShowRuntimeResult(True, self._base_url)
-            self.stop()
-            command = _resolve_command(self.command) if self._command_explicit else None
-            if not command:
-                command = await self._resolve_managed_command()
-            if not command:
-                return ShowRuntimeResult(False, reason=self._install_reason or "runtime_command_missing")
-            self.runtime_dir.mkdir(parents=True, exist_ok=True)
-            self.workspace_root.mkdir(parents=True, exist_ok=True)
-            self.cache_root.mkdir(parents=True, exist_ok=True)
-            # Reap any orphaned runtime server still bound to this workspace root before
-            # spawning ours, so there is a single writer (avibe#813). self.stop() above
-            # already released our own tracked child; anything left is a stray from a
-            # prior avibe instance that died without reaping it (SIGKILL / crash). Run it
-            # off the event loop: the psutil scan + terminate/kill can block for seconds.
-            await asyncio.to_thread(self._sweep_orphan_runtime_servers)
-            with self.stdout_path.open("w", encoding="utf-8") as stdout, self.stderr_path.open(
-                "w", encoding="utf-8"
-            ) as stderr:
-                self._process = subprocess.Popen(
-                    [
-                        *command,
-                        "--workspace-root",
-                        str(self.workspace_root),
-                        "--cache-root",
-                        str(self.cache_root),
-                        "--host",
-                        "127.0.0.1",
-                        "--port",
-                        "0",
-                        "--fallback-delay-seconds",
-                        str(SHOW_RUNTIME_RECOVERY_LOADING_DELAY_SECONDS),
-                    ],
-                    stdout=stdout,
-                    stderr=stderr,
-                    text=True,
-                    **isolated_subprocess_kwargs(),
-                )
-            base_url = await self._read_startup_url()
-            if not base_url:
+            await asyncio.to_thread(self._install_lock.acquire)
+            try:
                 self.stop()
-                return ShowRuntimeResult(False, reason="runtime_start_failed")
-            self._base_url = base_url
-            return ShowRuntimeResult(True, base_url)
+                command = _resolve_command(self.command) if self._command_explicit else None
+                if not command:
+                    command = await self._resolve_managed_command_locked()
+                if not command:
+                    return ShowRuntimeResult(False, reason=self._install_reason or "runtime_command_missing")
+                self.runtime_dir.mkdir(parents=True, exist_ok=True)
+                self.workspace_root.mkdir(parents=True, exist_ok=True)
+                self.cache_root.mkdir(parents=True, exist_ok=True)
+                # Reap any orphaned runtime server still bound to this workspace root before
+                # spawning ours, so there is a single writer (avibe#813). self.stop() above
+                # already released our own tracked child; anything left is a stray from a
+                # prior avibe instance that died without reaping it (SIGKILL / crash). Run it
+                # off the event loop: the psutil scan + terminate/kill can block for seconds.
+                await asyncio.to_thread(self._sweep_orphan_runtime_servers)
+                with self.stdout_path.open("w", encoding="utf-8") as stdout, self.stderr_path.open(
+                    "w", encoding="utf-8"
+                ) as stderr:
+                    self._process = subprocess.Popen(
+                        [
+                            *command,
+                            "--workspace-root",
+                            str(self.workspace_root),
+                            "--cache-root",
+                            str(self.cache_root),
+                            "--host",
+                            "127.0.0.1",
+                            "--port",
+                            "0",
+                            "--fallback-delay-seconds",
+                            str(SHOW_RUNTIME_RECOVERY_LOADING_DELAY_SECONDS),
+                        ],
+                        stdout=stdout,
+                        stderr=stderr,
+                        text=True,
+                        **isolated_subprocess_kwargs(),
+                    )
+                base_url = await self._read_startup_url()
+                if not base_url:
+                    self.stop()
+                    return ShowRuntimeResult(False, reason="runtime_start_failed")
+                self._base_url = base_url
+                return ShowRuntimeResult(True, base_url)
+            finally:
+                self._install_lock.release()
 
     async def request(
         self,
@@ -326,6 +329,15 @@ class ShowRuntimeManager:
             logger.debug("Orphan show runtime sweep skipped", exc_info=True)
 
     async def _resolve_managed_command(self) -> list[str] | None:
+        """Resolve a managed runtime while excluding concurrent preparation."""
+        await asyncio.to_thread(self._install_lock.acquire)
+        try:
+            return await self._resolve_managed_command_locked()
+        finally:
+            self._install_lock.release()
+
+    async def _resolve_managed_command_locked(self) -> list[str] | None:
+        """Resolve a managed runtime while the installation lock is held."""
         if self._command_explicit and self.command != _RUNTIME_BIN:
             self._install_reason = "runtime_command_missing"
             return None
@@ -336,8 +348,7 @@ class ShowRuntimeManager:
                 return command
             if self.auto_install and not self._install_attempted:
                 self._install_attempted = True
-                generation = self._install_generation
-                command = await asyncio.to_thread(self._install_managed_runtime_serialized, generation)
+                command = await asyncio.to_thread(self._install_managed_runtime)
                 if command:
                     self._managed_command = command
                     return command
@@ -351,8 +362,7 @@ class ShowRuntimeManager:
         if self.runtime_source == _RUNTIME_SOURCE_ARCHIVE:
             if self.auto_install and not self._install_attempted:
                 self._install_attempted = True
-                generation = self._install_generation
-                command = await asyncio.to_thread(self._install_managed_runtime_serialized, generation)
+                command = await asyncio.to_thread(self._install_managed_runtime)
                 if command:
                     self._managed_command = command
                     return command
@@ -380,38 +390,34 @@ class ShowRuntimeManager:
         if self._install_attempted:
             return None
         self._install_attempted = True
-        generation = self._install_generation
-        command = await asyncio.to_thread(self._install_managed_runtime_serialized, generation)
+        command = await asyncio.to_thread(self._install_managed_runtime)
         if command:
             self._managed_command = command
         return command
 
-    def _install_managed_runtime_serialized(self, expected_generation: int | None = None) -> list[str] | None:
-        """Perform one provider install without racing a serving request."""
+    def _install_managed_runtime_serialized(self) -> list[str] | None:
+        """Compatibility wrapper for callers that need a serialized install."""
         with self._install_lock:
-            if expected_generation is not None and expected_generation != self._install_generation:
-                status = self.status()
-                command = status.get("command")
-                if status.get("installed") and isinstance(command, list) and command:
-                    self._install_reason = None
-                    self._managed_command = command
-                    return command
-            command = self._install_managed_runtime()
-            if command:
-                self._install_generation += 1
-            return command
+            return self._install_managed_runtime()
+
+    def _prepare_managed_runtime_locked(self) -> list[str] | None:
+        """Reuse a verified install, or install it while the shared lock is held."""
+        if not self.force_install:
+            status = self.status()
+            command = status.get("command")
+            if status.get("installed") and isinstance(command, list) and command:
+                self._install_reason = None
+                self._managed_command = command
+                return command
+        command = self._install_managed_runtime()
+        if command:
+            self._managed_command = command
+        return command
 
     def _prepare_managed_runtime_serialized(self) -> list[str] | None:
-        """Reuse a verified install, or install it while holding the shared lock."""
+        """Compatibility wrapper for callers that need a serialized preparation."""
         with self._install_lock:
-            if not self.force_install:
-                status = self.status()
-                command = status.get("command")
-                if status.get("installed") and isinstance(command, list) and command:
-                    self._install_reason = None
-                    self._managed_command = command
-                    return command
-            return self._install_managed_runtime_serialized()
+            return self._prepare_managed_runtime_locked()
 
     def _install_managed_runtime(self) -> list[str] | None:
         command: list[str] | None
@@ -711,29 +717,30 @@ class ShowRuntimeManager:
                 path.rmdir()
 
     def prepare(self, *, force: bool | None = None, offline: bool | None = None) -> dict[str, Any]:
-        previous_force = self.force_install
-        previous_offline = self.offline
-        if force is not None:
-            self.force_install = force
-        if offline is not None:
-            self.offline = offline
-        try:
-            if self._command_explicit:
-                command = _resolve_command(self.command)
-                self._install_reason = None if command else "runtime_command_missing"
-            else:
-                command = self._prepare_managed_runtime_serialized()
-            return {
-                "ok": command is not None,
-                "provider": self.runtime_source,
-                "platform": _runtime_platform_tag(),
-                "command": command,
-                "reason": None if command else self._install_reason,
-                "status": self.status(),
-            }
-        finally:
-            self.force_install = previous_force
-            self.offline = previous_offline
+        with self._install_lock:
+            previous_force = self.force_install
+            previous_offline = self.offline
+            if force is not None:
+                self.force_install = force
+            if offline is not None:
+                self.offline = offline
+            try:
+                if self._command_explicit:
+                    command = _resolve_command(self.command)
+                    self._install_reason = None if command else "runtime_command_missing"
+                else:
+                    command = self._prepare_managed_runtime_locked()
+                return {
+                    "ok": command is not None,
+                    "provider": self.runtime_source,
+                    "platform": _runtime_platform_tag(),
+                    "command": command,
+                    "reason": None if command else self._install_reason,
+                    "status": self.status(),
+                }
+            finally:
+                self.force_install = previous_force
+                self.offline = previous_offline
 
     def _installed_manifest_runtime_command(self) -> list[str] | None:
         node = _resolve_node_command()

--- a/core/show_runtime.py
+++ b/core/show_runtime.py
@@ -15,6 +15,7 @@ import signal
 import subprocess
 import tarfile
 import tempfile
+import threading
 import urllib.parse
 import urllib.request
 from dataclasses import dataclass
@@ -139,6 +140,11 @@ class ShowRuntimeManager:
         self._process: subprocess.Popen[str] | None = None
         self._base_url: str | None = None
         self._lock = asyncio.Lock()
+        # `prepare()` runs in a worker thread while serving requests calls
+        # `ensure()` on the event loop. Both paths can reach the provider
+        # installer, so protect the filesystem-mutating section across threads.
+        self._install_lock = threading.RLock()
+        self._install_generation = 0
 
     async def ensure(self) -> ShowRuntimeResult:
         if self._base_url and await self._healthy(self._base_url):
@@ -330,7 +336,8 @@ class ShowRuntimeManager:
                 return command
             if self.auto_install and not self._install_attempted:
                 self._install_attempted = True
-                command = await asyncio.to_thread(self._install_managed_runtime)
+                generation = self._install_generation
+                command = await asyncio.to_thread(self._install_managed_runtime_serialized, generation)
                 if command:
                     self._managed_command = command
                     return command
@@ -344,7 +351,8 @@ class ShowRuntimeManager:
         if self.runtime_source == _RUNTIME_SOURCE_ARCHIVE:
             if self.auto_install and not self._install_attempted:
                 self._install_attempted = True
-                command = await asyncio.to_thread(self._install_managed_runtime)
+                generation = self._install_generation
+                command = await asyncio.to_thread(self._install_managed_runtime_serialized, generation)
                 if command:
                     self._managed_command = command
                     return command
@@ -372,10 +380,38 @@ class ShowRuntimeManager:
         if self._install_attempted:
             return None
         self._install_attempted = True
-        command = await asyncio.to_thread(self._install_managed_runtime)
+        generation = self._install_generation
+        command = await asyncio.to_thread(self._install_managed_runtime_serialized, generation)
         if command:
             self._managed_command = command
         return command
+
+    def _install_managed_runtime_serialized(self, expected_generation: int | None = None) -> list[str] | None:
+        """Perform one provider install without racing a serving request."""
+        with self._install_lock:
+            if expected_generation is not None and expected_generation != self._install_generation:
+                status = self.status()
+                command = status.get("command")
+                if status.get("installed") and isinstance(command, list) and command:
+                    self._install_reason = None
+                    self._managed_command = command
+                    return command
+            command = self._install_managed_runtime()
+            if command:
+                self._install_generation += 1
+            return command
+
+    def _prepare_managed_runtime_serialized(self) -> list[str] | None:
+        """Reuse a verified install, or install it while holding the shared lock."""
+        with self._install_lock:
+            if not self.force_install:
+                status = self.status()
+                command = status.get("command")
+                if status.get("installed") and isinstance(command, list) and command:
+                    self._install_reason = None
+                    self._managed_command = command
+                    return command
+            return self._install_managed_runtime_serialized()
 
     def _install_managed_runtime(self) -> list[str] | None:
         command: list[str] | None
@@ -686,7 +722,7 @@ class ShowRuntimeManager:
                 command = _resolve_command(self.command)
                 self._install_reason = None if command else "runtime_command_missing"
             else:
-                command = self._install_managed_runtime()
+                command = self._prepare_managed_runtime_serialized()
             return {
                 "ok": command is not None,
                 "provider": self.runtime_source,

--- a/core/show_runtime.py
+++ b/core/show_runtime.py
@@ -151,7 +151,7 @@ class ShowRuntimeManager:
         async with self._lock:
             if self._base_url and await self._healthy(self._base_url):
                 return ShowRuntimeResult(True, self._base_url)
-            await asyncio.to_thread(self._install_lock.acquire)
+            await self._acquire_install_lock()
             try:
                 self.stop()
                 command = _resolve_command(self.command) if self._command_explicit else None
@@ -330,11 +330,26 @@ class ShowRuntimeManager:
 
     async def _resolve_managed_command(self) -> list[str] | None:
         """Resolve a managed runtime while excluding concurrent preparation."""
-        await asyncio.to_thread(self._install_lock.acquire)
+        await self._acquire_install_lock()
         try:
             return await self._resolve_managed_command_locked()
         finally:
             self._install_lock.release()
+
+    async def _acquire_install_lock(self) -> None:
+        """Acquire the cross-thread lock without leaking it on task cancellation."""
+        acquisition = asyncio.create_task(asyncio.to_thread(self._install_lock.acquire))
+        try:
+            await asyncio.shield(acquisition)
+        except asyncio.CancelledError:
+            def release_after_acquisition(task: asyncio.Task[bool]) -> None:
+                if task.cancelled() or task.exception() is not None:
+                    return
+                if task.result():
+                    self._install_lock.release()
+
+            acquisition.add_done_callback(release_after_acquisition)
+            raise
 
     async def _resolve_managed_command_locked(self) -> list[str] | None:
         """Resolve a managed runtime while the installation lock is held."""
@@ -400,9 +415,9 @@ class ShowRuntimeManager:
         with self._install_lock:
             return self._install_managed_runtime()
 
-    def _prepare_managed_runtime_locked(self) -> list[str] | None:
+    def _prepare_managed_runtime_locked(self, *, startup: bool = False) -> list[str] | None:
         """Reuse a verified install, or install it while the shared lock is held."""
-        if not self.force_install:
+        if startup and not self.force_install:
             status = self.status()
             command = status.get("command")
             if status.get("installed") and isinstance(command, list) and command:
@@ -414,10 +429,10 @@ class ShowRuntimeManager:
             self._managed_command = command
         return command
 
-    def _prepare_managed_runtime_serialized(self) -> list[str] | None:
+    def _prepare_managed_runtime_serialized(self, *, startup: bool = False) -> list[str] | None:
         """Compatibility wrapper for callers that need a serialized preparation."""
         with self._install_lock:
-            return self._prepare_managed_runtime_locked()
+            return self._prepare_managed_runtime_locked(startup=startup)
 
     def _install_managed_runtime(self) -> list[str] | None:
         command: list[str] | None
@@ -716,7 +731,13 @@ class ShowRuntimeManager:
             if path.is_dir() and not any(path.iterdir()):
                 path.rmdir()
 
-    def prepare(self, *, force: bool | None = None, offline: bool | None = None) -> dict[str, Any]:
+    def prepare(
+        self,
+        *,
+        force: bool | None = None,
+        offline: bool | None = None,
+        startup: bool = False,
+    ) -> dict[str, Any]:
         with self._install_lock:
             previous_force = self.force_install
             previous_offline = self.offline
@@ -729,7 +750,7 @@ class ShowRuntimeManager:
                     command = _resolve_command(self.command)
                     self._install_reason = None if command else "runtime_command_missing"
                 else:
-                    command = self._prepare_managed_runtime_locked()
+                    command = self._prepare_managed_runtime_locked(startup=startup)
                 return {
                     "ok": command is not None,
                     "provider": self.runtime_source,
@@ -1272,18 +1293,23 @@ class ShowRuntimeManager:
 
 
 _manager: ShowRuntimeManager | None = None
+_manager_lock = threading.Lock()
 
 
 def get_show_runtime_manager() -> ShowRuntimeManager:
     global _manager
     if _manager is None:
-        _manager = ShowRuntimeManager()
+        with _manager_lock:
+            if _manager is None:
+                _manager = ShowRuntimeManager()
     return _manager
 
 
 def stop_show_runtime_manager() -> None:
-    if _manager is not None:
-        _manager.stop()
+    with _manager_lock:
+        manager = _manager
+    if manager is not None:
+        manager.stop()
 
 
 def _is_runtime_server_cmdline(cmdline: list[str], workspace_root: str) -> bool:
@@ -1379,7 +1405,9 @@ async def prewarm_show_page_session(session_id: str, *, base_path: str | None = 
 
 def set_show_runtime_manager_for_tests(manager: ShowRuntimeManager | None) -> None:
     global _manager
-    previous = _manager
+    with _manager_lock:
+        previous = _manager
+        _manager = manager
     # Stop the manager we are replacing before dropping the reference. Serving-path
     # tests that never install a fake cause get_show_runtime_manager() to lazily
     # create the real manager, which spawns a Node cli.js + esbuild subprocess tree
@@ -1391,7 +1419,6 @@ def set_show_runtime_manager_for_tests(manager: ShowRuntimeManager | None) -> No
             previous.stop()
         except Exception:  # pragma: no cover - defensive cleanup
             logger.debug("failed to stop previous show runtime manager", exc_info=True)
-    _manager = manager
 
 
 def _show_runtime_prewarm_import_paths(

--- a/tests/test_local_deps.py
+++ b/tests/test_local_deps.py
@@ -868,6 +868,7 @@ def test_dependencies_status_shape(monkeypatch):
     monkeypatch.setattr(memory_artifact, "get_memory_artifact_manager", lambda: _MemoryMgr())
     out = api.dependencies_status()
     assert out["ok"]
+    assert out["reconciling"] is False
     by = {d["id"]: d for d in out["deps"]}
     assert list(by) == ["askill", "avault", "show-runtime", "memory-runtime", "tmux", "node"]
     assert "tmux" in by and by["tmux"]["required"] is False  # tmux is the optional terminal backend
@@ -968,7 +969,7 @@ def test_dependencies_status_node_unsupported_not_ready(monkeypatch):
     assert by["node"]["installed"] is False and by["node"]["status"] == "missing"
 
 
-def test_reconcile_startup_dependencies_installs_askill_and_defers_runtime_prepare(monkeypatch):
+def test_reconcile_startup_dependencies_installs_required_runtime_dependencies(monkeypatch):
     askill_calls = []
     avault_calls = []
 
@@ -1011,9 +1012,9 @@ def test_reconcile_startup_dependencies_installs_askill_and_defers_runtime_prepa
     assert out["ok"] is True
     assert askill_calls == [False]
     assert avault_calls == [False]
-    assert manager.prepared == []
+    assert manager.prepared == [False]
     assert out["node"]["status"] == "ready"
-    assert out["show_runtime"] == {"ok": True, "status": "pending_prewarm", "reason": None}
+    assert out["show_runtime"] == {"ok": True, "status": "ready", "reason": None}
 
 
 def test_reconcile_startup_dependencies_does_not_prepare_runtime_without_node(monkeypatch):

--- a/tests/test_local_deps.py
+++ b/tests/test_local_deps.py
@@ -990,6 +990,7 @@ def test_reconcile_startup_dependencies_installs_required_runtime_dependencies(m
     class _Mgr:
         def __init__(self):
             self.prepared = []
+            self.auto_install = True
 
         def status(self):
             return {
@@ -1014,6 +1015,64 @@ def test_reconcile_startup_dependencies_installs_required_runtime_dependencies(m
     assert avault_calls == [False]
     assert manager.prepared == [False]
     assert out["node"]["status"] == "ready"
+    assert out["show_runtime"] == {"ok": True, "status": "ready", "reason": None}
+
+
+def test_reconcile_startup_dependencies_respects_show_runtime_auto_install_opt_out(monkeypatch):
+    monkeypatch.setattr(api, "ensure_askill_installed", lambda force=False: {"ok": True, "installed": True})
+    monkeypatch.setattr(api, "ensure_avault_installed", lambda force=False: {"ok": True, "installed": True})
+
+    import core.show_runtime as srt_mod
+
+    class _Mgr:
+        auto_install = False
+
+        def status(self):
+            return {
+                "installed": False,
+                "node_available": True,
+                "node_supported": True,
+                "node_version": "22.12.0",
+            }
+
+        def prepare(self, *, force=False):
+            raise AssertionError("startup reconcile must honor the auto-install opt-out")
+
+    monkeypatch.setattr(srt_mod, "get_show_runtime_manager", lambda: _Mgr())
+
+    out = api.reconcile_startup_dependencies()
+
+    assert out["show_runtime"] == {
+        "ok": False,
+        "status": "failed",
+        "reason": "runtime_auto_install_disabled",
+    }
+
+
+def test_reconcile_startup_dependencies_does_not_reinstall_ready_show_runtime(monkeypatch):
+    monkeypatch.setattr(api, "ensure_askill_installed", lambda force=False: {"ok": True, "installed": True})
+    monkeypatch.setattr(api, "ensure_avault_installed", lambda force=False: {"ok": True, "installed": True})
+
+    import core.show_runtime as srt_mod
+
+    class _Mgr:
+        auto_install = True
+
+        def status(self):
+            return {
+                "installed": True,
+                "node_available": True,
+                "node_supported": True,
+                "node_version": "22.12.0",
+            }
+
+        def prepare(self, *, force=False):
+            raise AssertionError("ready runtime must not invoke its provider installer")
+
+    monkeypatch.setattr(srt_mod, "get_show_runtime_manager", lambda: _Mgr())
+
+    out = api.reconcile_startup_dependencies()
+
     assert out["show_runtime"] == {"ok": True, "status": "ready", "reason": None}
 
 

--- a/tests/test_local_deps.py
+++ b/tests/test_local_deps.py
@@ -891,6 +891,34 @@ def test_dependencies_status_shape(monkeypatch):
     assert by["node"]["installed"] and by["node"]["version"] == "20.11"
 
 
+def test_dependencies_status_preserves_reconciliation_seen_before_probes(monkeypatch):
+    monkeypatch.setattr(
+        api,
+        "askill_update_status",
+        lambda **_: {"installed": True, "version": "0.1.13", "status": "ready"},
+    )
+    monkeypatch.setattr(api, "avault_status", lambda: {"installed": True, "version": "0.0.1", "status": "ready"})
+    import core.show_runtime as srt_mod
+
+    class _ShowRuntime:
+        def status(self):
+            return {"installed": True, "node_available": True, "node_version": "22.0"}
+
+    monkeypatch.setattr(srt_mod, "get_show_runtime_manager", lambda: _ShowRuntime())
+
+    class _LockSnapshot:
+        def __init__(self):
+            self._calls = 0
+
+        def locked(self):
+            self._calls += 1
+            return self._calls == 1
+
+    monkeypatch.setattr(api, "_STARTUP_DEPENDENCY_RECONCILE_LOCK", _LockSnapshot())
+
+    assert api.dependencies_status(offline=True)["reconciling"] is True
+
+
 @pytest.mark.parametrize(
     ("runtime", "expected"),
     [

--- a/tests/test_local_deps.py
+++ b/tests/test_local_deps.py
@@ -869,6 +869,7 @@ def test_dependencies_status_shape(monkeypatch):
     out = api.dependencies_status()
     assert out["ok"]
     assert out["reconciling"] is False
+    assert out["reconciling_dependencies"] == []
     by = {d["id"]: d for d in out["deps"]}
     assert list(by) == ["askill", "avault", "show-runtime", "memory-runtime", "tmux", "node"]
     assert "tmux" in by and by["tmux"]["required"] is False  # tmux is the optional terminal backend
@@ -917,6 +918,39 @@ def test_dependencies_status_preserves_reconciliation_seen_before_probes(monkeyp
     monkeypatch.setattr(api, "_STARTUP_DEPENDENCY_RECONCILE_LOCK", _LockSnapshot())
 
     assert api.dependencies_status(offline=True)["reconciling"] is True
+
+
+def test_dependencies_status_detects_reconciliation_during_probes(monkeypatch):
+    monkeypatch.setattr(
+        api,
+        "askill_update_status",
+        lambda **_: {"installed": True, "version": "0.1.13", "status": "ready"},
+    )
+    monkeypatch.setattr(api, "avault_status", lambda: {"installed": True, "version": "0.0.1", "status": "ready"})
+    monkeypatch.setattr(api.V2Config, "load", classmethod(lambda _cls: SimpleNamespace(memory=SimpleNamespace(enabled=False))))
+
+    import core.show_runtime as srt_mod
+
+    class _ShowRuntime:
+        def status(self):
+            return {"installed": True, "node_available": True, "node_version": "22.0"}
+
+    monkeypatch.setattr(srt_mod, "get_show_runtime_manager", lambda: _ShowRuntime())
+
+    import core.tmux_runtime as tmux_mod
+
+    monkeypatch.setattr(tmux_mod, "tmux_status", lambda: {"installed": False, "version": None, "status": "missing"})
+    monkeypatch.setattr(api, "_startup_dependency_state_snapshot", iter([(7, set()), (8, set())]).__next__)
+
+    class _Unlocked:
+        def locked(self):
+            return False
+
+    monkeypatch.setattr(api, "_STARTUP_DEPENDENCY_RECONCILE_LOCK", _Unlocked())
+    result = api.dependencies_status()
+
+    assert result["reconciling"] is True
+    assert result["reconciling_dependencies"] == []
 
 
 @pytest.mark.parametrize(

--- a/tests/test_local_deps.py
+++ b/tests/test_local_deps.py
@@ -1029,8 +1029,8 @@ def test_reconcile_startup_dependencies_installs_required_runtime_dependencies(m
                 "node_version": "22.12.0",
             }
 
-        def prepare(self, *, force=False):
-            self.prepared.append(force)
+        def prepare(self, *, force=False, startup=False):
+            self.prepared.append((force, startup))
             return {"ok": True, "reason": None}
 
     manager = _Mgr()
@@ -1041,7 +1041,7 @@ def test_reconcile_startup_dependencies_installs_required_runtime_dependencies(m
     assert out["ok"] is True
     assert askill_calls == [False]
     assert avault_calls == [False]
-    assert manager.prepared == [False]
+    assert manager.prepared == [(False, True)]
     assert out["node"]["status"] == "ready"
     assert out["show_runtime"] == {"ok": True, "status": "ready", "reason": None}
 
@@ -1063,7 +1063,7 @@ def test_reconcile_startup_dependencies_respects_show_runtime_auto_install_opt_o
                 "node_version": "22.12.0",
             }
 
-        def prepare(self, *, force=False):
+        def prepare(self, *, force=False, startup=False):
             raise AssertionError("startup reconcile must honor the auto-install opt-out")
 
     monkeypatch.setattr(srt_mod, "get_show_runtime_manager", lambda: _Mgr())
@@ -1094,7 +1094,7 @@ def test_reconcile_startup_dependencies_does_not_reinstall_ready_show_runtime(mo
                 "node_version": "22.12.0",
             }
 
-        def prepare(self, *, force=False):
+        def prepare(self, *, force=False, startup=False):
             raise AssertionError("ready runtime must not invoke its provider installer")
 
     monkeypatch.setattr(srt_mod, "get_show_runtime_manager", lambda: _Mgr())
@@ -1114,7 +1114,7 @@ def test_reconcile_startup_dependencies_does_not_prepare_runtime_without_node(mo
         def status(self):
             return {"installed": False, "node_available": False, "node_version": None}
 
-        def prepare(self, *, force=False):
+        def prepare(self, *, force=False, startup=False):
             raise AssertionError("runtime must not prepare without Node")
 
     monkeypatch.setattr(srt_mod, "get_show_runtime_manager", lambda: _Mgr())

--- a/tests/test_ui_show_pages.py
+++ b/tests/test_ui_show_pages.py
@@ -4937,14 +4937,15 @@ def test_show_runtime_manager_installs_without_blocking_event_loop(monkeypatch, 
     monkeypatch.setattr(manager, "_install_managed_runtime", fake_install)
     calls = []
 
-    async def fake_to_thread(func):
+    async def fake_to_thread(func, *args):
         calls.append(func)
-        return func()
+        return func(*args)
 
     monkeypatch.setattr("core.show_runtime.asyncio.to_thread", fake_to_thread)
 
     assert asyncio.run(manager._resolve_managed_command()) == [str(manager._managed_bin_path())]
-    assert calls == [fake_install]
+    assert len(calls) == 1
+    assert calls[0].__name__ == "_install_managed_runtime_serialized"
 
 
 def test_show_runtime_manager_fails_closed_when_manifest_is_absent(tmp_path):
@@ -5125,6 +5126,62 @@ def test_show_runtime_manager_reuses_cached_managed_command_after_install_attemp
     monkeypatch.setattr("core.show_runtime._resolve_command", lambda command: None)
 
     assert asyncio.run(manager._resolve_managed_command()) == ["/bin/node", "/tmp/runtime/cli.js"]
+
+
+def test_show_runtime_prepare_and_request_install_are_serialized(monkeypatch, tmp_path):
+    manager = ShowRuntimeManager(
+        workspace_root=tmp_path / "show",
+        runtime_dir=tmp_path / "runtime",
+        runtime_source="npm",
+    )
+    command = ["/bin/node", str(tmp_path / "runtime.js")]
+    state = {"installed": False}
+    entered = threading.Event()
+    release = threading.Event()
+    request_done = threading.Event()
+    install_calls = 0
+
+    monkeypatch.setattr("core.show_runtime._resolve_executable_path", lambda _path: None)
+
+    def fake_status():
+        return {"installed": state["installed"], "command": command if state["installed"] else None}
+
+    def fake_install():
+        nonlocal install_calls
+        install_calls += 1
+        entered.set()
+        assert release.wait(timeout=2)
+        state["installed"] = True
+        return command
+
+    monkeypatch.setattr(manager, "status", fake_status)
+    monkeypatch.setattr(manager, "_install_managed_runtime", fake_install)
+    prepare_result = {}
+    request_result = {}
+
+    prepare_thread = threading.Thread(target=lambda: prepare_result.update(manager.prepare()))
+
+    def resolve_request():
+        try:
+            request_result["command"] = asyncio.run(manager._resolve_managed_command())
+        finally:
+            request_done.set()
+
+    request_thread = threading.Thread(target=resolve_request)
+    prepare_thread.start()
+    assert entered.wait(timeout=2)
+    request_thread.start()
+    assert not request_done.wait(timeout=0.1)
+    release.set()
+    prepare_thread.join(timeout=2)
+    request_thread.join(timeout=2)
+
+    assert not prepare_thread.is_alive()
+    assert not request_thread.is_alive()
+    assert install_calls == 1
+    assert prepare_result["ok"] is True
+    assert request_result["command"] == command
+    assert manager._managed_command == command
 
 
 def test_show_runtime_manager_can_use_npm_source(monkeypatch, tmp_path):

--- a/tests/test_ui_show_pages.py
+++ b/tests/test_ui_show_pages.py
@@ -4964,6 +4964,23 @@ def test_show_runtime_startup_reuses_github_install_but_explicit_prepare_refresh
     assert installs == [True]
 
 
+def test_show_runtime_prepare_marks_archive_install_attempted(monkeypatch, tmp_path):
+    manager = ShowRuntimeManager(
+        workspace_root=tmp_path / "show",
+        runtime_dir=tmp_path / "runtime",
+        runtime_source="archive",
+    )
+    command = ["/bin/node", str(tmp_path / "runtime.js")]
+    installs = []
+    monkeypatch.setattr(manager, "_install_managed_runtime", lambda: installs.append(True) or command)
+    monkeypatch.setattr(manager, "_installed_archive_runtime_command", lambda: command)
+
+    assert manager.prepare()["command"] == command
+    assert manager._install_attempted is True
+    assert asyncio.run(manager._resolve_managed_command()) == command
+    assert installs == [True]
+
+
 def test_show_runtime_manager_can_disable_auto_install(tmp_path):
     manager = ShowRuntimeManager(
         workspace_root=tmp_path / "show",

--- a/tests/test_ui_show_pages.py
+++ b/tests/test_ui_show_pages.py
@@ -112,6 +112,43 @@ def test_set_show_runtime_manager_stops_previous_manager():
     assert second.stopped is True
 
 
+def test_get_show_runtime_manager_initializes_once_across_threads(monkeypatch):
+    import core.show_runtime as srt
+
+    srt.set_show_runtime_manager_for_tests(None)
+    constructor_entered = threading.Event()
+    release_constructor = threading.Event()
+    constructor_calls = 0
+
+    class _Manager:
+        def __init__(self):
+            nonlocal constructor_calls
+            constructor_calls += 1
+            constructor_entered.set()
+            assert release_constructor.wait(timeout=2)
+
+        def stop(self):
+            return None
+
+    monkeypatch.setattr(srt, "ShowRuntimeManager", _Manager)
+    managers = []
+    threads = [threading.Thread(target=lambda: managers.append(srt.get_show_runtime_manager())) for _ in range(2)]
+    for thread in threads:
+        thread.start()
+    assert constructor_entered.wait(timeout=2)
+    release_constructor.set()
+    for thread in threads:
+        thread.join(timeout=2)
+
+    try:
+        assert all(not thread.is_alive() for thread in threads)
+        assert constructor_calls == 1
+        assert len(managers) == 2
+        assert managers[0] is managers[1]
+    finally:
+        srt.set_show_runtime_manager_for_tests(None)
+
+
 def _create_show_page(session_id: str, visibility: str) -> str | None:
     page_dir = ensure_show_page_dir(session_id)
     (page_dir / "index.html").write_text("<!doctype html><title>Show</title><h1>Show Page</h1>", encoding="utf-8")
@@ -4909,6 +4946,24 @@ def test_show_runtime_manager_status_does_not_read_manifest_for_legacy_sources(t
     assert status["reason"] is None
 
 
+def test_show_runtime_startup_reuses_github_install_but_explicit_prepare_refreshes(monkeypatch, tmp_path):
+    manager = ShowRuntimeManager(
+        workspace_root=tmp_path / "show",
+        runtime_dir=tmp_path / "runtime",
+        runtime_source="github",
+    )
+    command = ["/bin/node", str(tmp_path / "runtime.js")]
+    installs = []
+    monkeypatch.setattr(manager, "status", lambda: {"installed": True, "command": command})
+    monkeypatch.setattr(manager, "_install_managed_runtime", lambda: installs.append(True) or command)
+
+    assert manager.prepare(force=False, startup=True)["command"] == command
+    assert installs == []
+
+    assert manager.prepare(force=False)["command"] == command
+    assert installs == [True]
+
+
 def test_show_runtime_manager_can_disable_auto_install(tmp_path):
     manager = ShowRuntimeManager(
         workspace_root=tmp_path / "show",
@@ -5183,6 +5238,32 @@ def test_show_runtime_prepare_and_request_install_are_serialized(monkeypatch, tm
     assert prepare_result["ok"] is True
     assert request_result["command"] == command
     assert manager._managed_command == command
+
+
+def test_show_runtime_cancelled_lock_wait_releases_late_acquisition(tmp_path):
+    manager = ShowRuntimeManager(
+        workspace_root=tmp_path / "show",
+        runtime_dir=tmp_path / "runtime",
+        runtime_source="npm",
+        auto_install=False,
+    )
+    manager._install_lock.acquire()
+
+    async def exercise_cancelled_wait():
+        waiter = asyncio.create_task(manager._resolve_managed_command())
+        await asyncio.sleep(0)
+        waiter.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await waiter
+
+        manager._install_lock.release()
+        assert await asyncio.wait_for(manager._resolve_managed_command(), timeout=2) is None
+
+    try:
+        asyncio.run(exercise_cancelled_wait())
+    finally:
+        if manager._install_lock.locked():
+            manager._install_lock.release()
 
 
 def test_show_runtime_manager_can_use_npm_source(monkeypatch, tmp_path):

--- a/tests/test_ui_show_pages.py
+++ b/tests/test_ui_show_pages.py
@@ -4944,8 +4944,9 @@ def test_show_runtime_manager_installs_without_blocking_event_loop(monkeypatch, 
     monkeypatch.setattr("core.show_runtime.asyncio.to_thread", fake_to_thread)
 
     assert asyncio.run(manager._resolve_managed_command()) == [str(manager._managed_bin_path())]
-    assert len(calls) == 1
-    assert calls[0].__name__ == "_install_managed_runtime_serialized"
+    assert len(calls) == 2
+    assert calls[0].__name__ == "acquire"
+    assert calls[1].__name__ == "fake_install"
 
 
 def test_show_runtime_manager_fails_closed_when_manifest_is_absent(tmp_path):

--- a/ui/src/components/settings/SettingsDependenciesPage.logic.ts
+++ b/ui/src/components/settings/SettingsDependenciesPage.logic.ts
@@ -10,9 +10,15 @@ export const dependencyHasInstallAction = (
 export const dependencyIsStartupManaged = (dependency: Pick<DependencyItem, 'id'>): boolean =>
   STARTUP_MANAGED_DEPENDENCIES.has(dependency.id);
 
+export const dependencyIsStartupRepairing = (
+  dependency: Pick<DependencyItem, 'id' | 'installed' | 'status'>,
+): boolean =>
+  dependencyIsStartupManaged(dependency) &&
+  (!dependency.installed || dependency.status === 'upgrade_required' || dependency.status === 'error');
+
 export const dependenciesNeedAutomaticRefresh = (
   result: DependenciesResult,
   allowInitialRetry = false,
 ): boolean =>
   Boolean(result.reconciling) ||
-  (allowInitialRetry && result.deps.some((dependency) => dependencyIsStartupManaged(dependency) && !dependency.installed));
+  (allowInitialRetry && result.deps.some((dependency) => dependencyIsStartupRepairing(dependency)));

--- a/ui/src/components/settings/SettingsDependenciesPage.logic.ts
+++ b/ui/src/components/settings/SettingsDependenciesPage.logic.ts
@@ -10,6 +10,9 @@ export const dependencyHasInstallAction = (
 export const dependencyIsStartupManaged = (dependency: Pick<DependencyItem, 'id'>): boolean =>
   STARTUP_MANAGED_DEPENDENCIES.has(dependency.id);
 
-export const dependenciesNeedAutomaticRefresh = (result: DependenciesResult): boolean =>
+export const dependenciesNeedAutomaticRefresh = (
+  result: DependenciesResult,
+  allowInitialRetry = false,
+): boolean =>
   Boolean(result.reconciling) ||
-  result.deps.some((dependency) => dependencyIsStartupManaged(dependency) && !dependency.installed);
+  (allowInitialRetry && result.deps.some((dependency) => dependencyIsStartupManaged(dependency) && !dependency.installed));

--- a/ui/src/components/settings/SettingsDependenciesPage.logic.ts
+++ b/ui/src/components/settings/SettingsDependenciesPage.logic.ts
@@ -1,7 +1,15 @@
-import type { DependencyItem } from '@/context/ApiContext';
+import type { DependenciesResult, DependencyItem } from '@/context/ApiContext';
 
 const INSTALLABLE_DEPENDENCIES = new Set(['askill', 'avault', 'show-runtime', 'memory-runtime', 'tmux']);
+const STARTUP_MANAGED_DEPENDENCIES = new Set(['askill', 'avault', 'show-runtime', 'tmux', 'node']);
 
 export const dependencyHasInstallAction = (
   dependency: Pick<DependencyItem, 'id' | 'status'>,
 ): boolean => dependency.status !== 'unsupported' && INSTALLABLE_DEPENDENCIES.has(dependency.id);
+
+export const dependencyIsStartupManaged = (dependency: Pick<DependencyItem, 'id'>): boolean =>
+  STARTUP_MANAGED_DEPENDENCIES.has(dependency.id);
+
+export const dependenciesNeedAutomaticRefresh = (result: DependenciesResult): boolean =>
+  Boolean(result.reconciling) ||
+  result.deps.some((dependency) => dependencyIsStartupManaged(dependency) && !dependency.installed);

--- a/ui/src/components/settings/SettingsDependenciesPage.logic.ts
+++ b/ui/src/components/settings/SettingsDependenciesPage.logic.ts
@@ -12,13 +12,19 @@ export const dependencyIsStartupManaged = (dependency: Pick<DependencyItem, 'id'
 
 export const dependencyIsStartupRepairing = (
   dependency: Pick<DependencyItem, 'id' | 'installed' | 'status'>,
+  activeIds?: ReadonlySet<string>,
 ): boolean =>
   dependencyIsStartupManaged(dependency) &&
+  (activeIds === undefined || activeIds.has(dependency.id)) &&
   (!dependency.installed || dependency.status === 'upgrade_required' || dependency.status === 'error');
 
 export const dependenciesNeedAutomaticRefresh = (
   result: DependenciesResult,
   allowInitialRetry = false,
-): boolean =>
-  Boolean(result.reconciling) ||
-  (allowInitialRetry && result.deps.some((dependency) => dependencyIsStartupRepairing(dependency)));
+): boolean => {
+  const activeIds = Array.isArray(result.reconciling_dependencies)
+    ? new Set(result.reconciling_dependencies)
+    : undefined;
+  return Boolean(result.reconciling) ||
+    (allowInitialRetry && result.deps.some((dependency) => dependencyIsStartupRepairing(dependency, activeIds)));
+};

--- a/ui/src/components/settings/SettingsDependenciesPage.logic.ts
+++ b/ui/src/components/settings/SettingsDependenciesPage.logic.ts
@@ -1,7 +1,7 @@
 import type { DependenciesResult, DependencyItem } from '@/context/ApiContext';
 
 const INSTALLABLE_DEPENDENCIES = new Set(['askill', 'avault', 'show-runtime', 'memory-runtime', 'tmux']);
-const STARTUP_MANAGED_DEPENDENCIES = new Set(['askill', 'avault', 'show-runtime', 'tmux', 'node']);
+const STARTUP_MANAGED_DEPENDENCIES = new Set(['askill', 'avault', 'show-runtime', 'tmux']);
 
 export const dependencyHasInstallAction = (
   dependency: Pick<DependencyItem, 'id' | 'status'>,

--- a/ui/src/components/settings/SettingsDependenciesPage.test.ts
+++ b/ui/src/components/settings/SettingsDependenciesPage.test.ts
@@ -35,14 +35,24 @@ describe('startup dependency refresh', () => {
     expect(dependencyIsStartupManaged({ id: 'memory-runtime' })).toBe(false);
   });
 
-  it('keeps polling until startup-managed dependencies settle', () => {
+  it('allows one initial retry when startup reconciliation has not acquired its lock yet', () => {
+    expect(
+      dependenciesNeedAutomaticRefresh({
+        ok: true,
+        reconciling: false,
+        deps: [dependency('show-runtime', false)],
+      }, true),
+    ).toBe(true);
     expect(
       dependenciesNeedAutomaticRefresh({
         ok: true,
         reconciling: false,
         deps: [dependency('show-runtime', false)],
       }),
-    ).toBe(true);
+    ).toBe(false);
+  });
+
+  it('keeps polling while startup reconciliation is active', () => {
     expect(
       dependenciesNeedAutomaticRefresh({
         ok: true,

--- a/ui/src/components/settings/SettingsDependenciesPage.test.ts
+++ b/ui/src/components/settings/SettingsDependenciesPage.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
-import { dependencyHasInstallAction } from './SettingsDependenciesPage.logic';
+import {
+  dependenciesNeedAutomaticRefresh,
+  dependencyHasInstallAction,
+  dependencyIsStartupManaged,
+} from './SettingsDependenciesPage.logic';
 
 describe('dependencyHasInstallAction', () => {
   it('hides install and repair actions for unsupported dependencies', () => {
@@ -11,5 +15,47 @@ describe('dependencyHasInstallAction', () => {
     expect(dependencyHasInstallAction({ id: 'memory-runtime', status: 'missing' })).toBe(true);
     expect(dependencyHasInstallAction({ id: 'show-runtime', status: 'ready' })).toBe(true);
     expect(dependencyHasInstallAction({ id: 'node', status: 'missing' })).toBe(false);
+  });
+});
+
+describe('startup dependency refresh', () => {
+  const dependency = (id: string, installed: boolean) => ({
+    id,
+    kind: 'tool' as const,
+    required: true,
+    installed,
+    version: null,
+    status: installed ? ('ready' as const) : ('missing' as const),
+  });
+
+  it('tracks every dependency repaired by the startup reconciler', () => {
+    for (const id of ['askill', 'avault', 'show-runtime', 'tmux', 'node']) {
+      expect(dependencyIsStartupManaged({ id })).toBe(true);
+    }
+    expect(dependencyIsStartupManaged({ id: 'memory-runtime' })).toBe(false);
+  });
+
+  it('keeps polling until startup-managed dependencies settle', () => {
+    expect(
+      dependenciesNeedAutomaticRefresh({
+        ok: true,
+        reconciling: false,
+        deps: [dependency('show-runtime', false)],
+      }),
+    ).toBe(true);
+    expect(
+      dependenciesNeedAutomaticRefresh({
+        ok: true,
+        reconciling: true,
+        deps: [dependency('show-runtime', true)],
+      }),
+    ).toBe(true);
+    expect(
+      dependenciesNeedAutomaticRefresh({
+        ok: true,
+        reconciling: false,
+        deps: [dependency('show-runtime', true), dependency('memory-runtime', false)],
+      }),
+    ).toBe(false);
   });
 });

--- a/ui/src/components/settings/SettingsDependenciesPage.test.ts
+++ b/ui/src/components/settings/SettingsDependenciesPage.test.ts
@@ -83,4 +83,18 @@ describe('startup dependency refresh', () => {
       }, true),
     ).toBe(true);
   });
+
+  it('limits startup repair status to dependencies currently active in the backend', () => {
+    const showRuntime = dependency('show-runtime', false);
+    expect(dependencyIsStartupRepairing(showRuntime, new Set(['tmux']))).toBe(false);
+    expect(dependencyIsStartupRepairing(showRuntime, new Set(['show-runtime']))).toBe(true);
+    expect(
+      dependenciesNeedAutomaticRefresh({
+        ok: true,
+        reconciling: false,
+        reconciling_dependencies: [],
+        deps: [showRuntime],
+      }, true),
+    ).toBe(false);
+  });
 });

--- a/ui/src/components/settings/SettingsDependenciesPage.test.ts
+++ b/ui/src/components/settings/SettingsDependenciesPage.test.ts
@@ -4,6 +4,7 @@ import {
   dependenciesNeedAutomaticRefresh,
   dependencyHasInstallAction,
   dependencyIsStartupManaged,
+  dependencyIsStartupRepairing,
 } from './SettingsDependenciesPage.logic';
 
 describe('dependencyHasInstallAction', () => {
@@ -68,5 +69,18 @@ describe('startup dependency refresh', () => {
         deps: [dependency('show-runtime', true), dependency('memory-runtime', false)],
       }),
     ).toBe(false);
+  });
+
+  it('treats installed dependencies requiring an upgrade as startup repairs', () => {
+    expect(
+      dependencyIsStartupRepairing({ id: 'avault', installed: true, status: 'upgrade_required' }),
+    ).toBe(true);
+    expect(
+      dependenciesNeedAutomaticRefresh({
+        ok: true,
+        reconciling: false,
+        deps: [{ ...dependency('avault', true), status: 'upgrade_required' }],
+      }, true),
+    ).toBe(true);
   });
 });

--- a/ui/src/components/settings/SettingsDependenciesPage.test.ts
+++ b/ui/src/components/settings/SettingsDependenciesPage.test.ts
@@ -29,9 +29,10 @@ describe('startup dependency refresh', () => {
   });
 
   it('tracks every dependency repaired by the startup reconciler', () => {
-    for (const id of ['askill', 'avault', 'show-runtime', 'tmux', 'node']) {
+    for (const id of ['askill', 'avault', 'show-runtime', 'tmux']) {
       expect(dependencyIsStartupManaged({ id })).toBe(true);
     }
+    expect(dependencyIsStartupManaged({ id: 'node' })).toBe(false);
     expect(dependencyIsStartupManaged({ id: 'memory-runtime' })).toBe(false);
   });
 

--- a/ui/src/components/settings/SettingsDependenciesPage.tsx
+++ b/ui/src/components/settings/SettingsDependenciesPage.tsx
@@ -41,7 +41,6 @@ import { errorMessage } from '@/lib/errorMessage';
 type DepMeta = { icon: LucideIcon; tileCls: string; iconCls: string };
 
 const STARTUP_REFRESH_INTERVAL_MS = 1_500;
-const STARTUP_REFRESH_WINDOW_MS = 120_000;
 
 const DEP_META: Record<string, DepMeta> = {
   askill: { icon: WandSparkles, tileCls: 'bg-mint-soft', iconCls: 'text-mint' },
@@ -83,15 +82,19 @@ export const SettingsDependenciesPage: React.FC = () => {
   useEffect(() => {
     let cancelled = false;
     let timer: number | undefined;
-    const deadline = Date.now() + STARTUP_REFRESH_WINDOW_MS;
+    let allowInitialRetry = true;
 
     const pollUntilSettled = async () => {
       const result = await refresh();
-      if (
+      const shouldRetry =
         !cancelled &&
         result !== null &&
-        dependenciesNeedAutomaticRefresh(result) &&
-        Date.now() < deadline
+        dependenciesNeedAutomaticRefresh(result, allowInitialRetry);
+      // A single delayed retry catches the startup lock acquisition race. After
+      // that first response, only an active backend reconciliation can poll.
+      allowInitialRetry = false;
+      if (
+        shouldRetry
       ) {
         timer = window.setTimeout(() => void pollUntilSettled(), STARTUP_REFRESH_INTERVAL_MS);
       }

--- a/ui/src/components/settings/SettingsDependenciesPage.tsx
+++ b/ui/src/components/settings/SettingsDependenciesPage.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import {
@@ -24,17 +24,24 @@ import { SettingsResourceRow } from './SettingsPrimitives';
 import { useApi } from '@/context/ApiContext';
 import type { DependencyItem, InstallResult } from '@/context/ApiContext';
 import { useToast } from '@/context/ToastContext';
-import { dependencyHasInstallAction } from './SettingsDependenciesPage.logic';
+import {
+  dependenciesNeedAutomaticRefresh,
+  dependencyHasInstallAction,
+  dependencyIsStartupManaged,
+} from './SettingsDependenciesPage.logic';
 import { errorMessage } from '@/lib/errorMessage';
 
 // Mirrors design.pen "vibe-remote — Settings · Dependencies": one card per
 // required local runtime (icon tile + name/REQUIRED + detail + status pill +
-// action), reusing the Backends-page card shape. askill + the Show Page
-// runtime auto-install during `vibe runtime prepare`; this page surfaces their
-// status and offers manual re-check / install / repair. Backend CLIs are
+// action), reusing the Backends-page card shape. Startup reconciliation and
+// `vibe runtime prepare` auto-install askill + the Show Page runtime; this page
+// surfaces their status and offers manual re-check / install / repair. Backend CLIs are
 // managed on the Backends tab — linked, not duplicated.
 
 type DepMeta = { icon: LucideIcon; tileCls: string; iconCls: string };
+
+const STARTUP_REFRESH_INTERVAL_MS = 1_500;
+const STARTUP_REFRESH_WINDOW_MS = 120_000;
 
 const DEP_META: Record<string, DepMeta> = {
   askill: { icon: WandSparkles, tileCls: 'bg-mint-soft', iconCls: 'text-mint' },
@@ -52,18 +59,49 @@ export const SettingsDependenciesPage: React.FC = () => {
 
   const [deps, setDeps] = useState<DependencyItem[] | null>(null);
   const [busy, setBusy] = useState<string | null>(null);
+  const [reconciling, setReconciling] = useState(false);
+  const refreshSequence = useRef(0);
 
   const refresh = useCallback(async () => {
+    const sequence = ++refreshSequence.current;
     try {
       const res = await api.listDependencies();
-      setDeps(res.deps ?? []);
+      if (sequence === refreshSequence.current) {
+        setDeps(res.deps ?? []);
+        setReconciling(Boolean(res.reconciling));
+      }
+      return res;
     } catch {
-      setDeps([]);
+      if (sequence === refreshSequence.current) {
+        setDeps([]);
+        setReconciling(false);
+      }
+      return null;
     }
   }, [api]);
 
   useEffect(() => {
-    void refresh();
+    let cancelled = false;
+    let timer: number | undefined;
+    const deadline = Date.now() + STARTUP_REFRESH_WINDOW_MS;
+
+    const pollUntilSettled = async () => {
+      const result = await refresh();
+      if (
+        !cancelled &&
+        result !== null &&
+        dependenciesNeedAutomaticRefresh(result) &&
+        Date.now() < deadline
+      ) {
+        timer = window.setTimeout(() => void pollUntilSettled(), STARTUP_REFRESH_INTERVAL_MS);
+      }
+    };
+
+    void pollUntilSettled();
+    return () => {
+      cancelled = true;
+      if (timer !== undefined) window.clearTimeout(timer);
+    };
   }, [refresh]);
 
   // A closed backend reason/message is often a snake_case token (e.g.
@@ -97,6 +135,9 @@ export const SettingsDependenciesPage: React.FC = () => {
   };
 
   const statusText = (d: DependencyItem) => {
+    if (reconciling && dependencyIsStartupManaged(d) && !d.installed) {
+      return t('settings.dependencies.installing');
+    }
     // Closed non-installed failure states render distinctly, ahead
     // of the generic "not installed" fallback.
     if (d.status === 'unsupported') return t('settings.dependencies.statusUnsupported');
@@ -108,6 +149,7 @@ export const SettingsDependenciesPage: React.FC = () => {
   };
 
   const statusVariant = (d: DependencyItem): 'success' | 'warning' | 'destructive' => {
+    if (reconciling && dependencyIsStartupManaged(d) && !d.installed) return 'warning';
     if (d.status === 'error') return 'destructive';
     if (d.status === 'unsupported' || d.status === 'upgrade_required') return 'warning';
     return d.installed ? 'success' : 'destructive';
@@ -137,6 +179,7 @@ export const SettingsDependenciesPage: React.FC = () => {
           {deps.map((d) => {
             const meta = DEP_META[d.id] ?? DEP_META.node;
             const installing = busy === d.id;
+            const startupInstalling = reconciling && dependencyIsStartupManaged(d) && !d.installed;
             const showAction = dependencyHasInstallAction(d);
             return (
               <SettingsResourceRow
@@ -167,15 +210,20 @@ export const SettingsDependenciesPage: React.FC = () => {
                       </Button>
                     )}
                     {showAction && (
-                      <Button variant={d.installed ? 'secondary' : 'brand'} size="xs" disabled={installing} onClick={() => void install(d)}>
-                        {installing ? (
+                      <Button
+                        variant={d.installed ? 'secondary' : 'brand'}
+                        size="xs"
+                        disabled={installing || startupInstalling}
+                        onClick={() => void install(d)}
+                      >
+                        {installing || startupInstalling ? (
                           <Loader2 className="size-3.5 animate-spin" />
                         ) : d.installed ? (
                           <RefreshCw className="size-3.5" />
                         ) : (
                           <Download className="size-3.5" />
                         )}
-                        {installing
+                        {installing || startupInstalling
                           ? t('settings.dependencies.installing')
                           : d.installed
                             ? d.id === 'show-runtime' || d.id === 'memory-runtime'

--- a/ui/src/components/settings/SettingsDependenciesPage.tsx
+++ b/ui/src/components/settings/SettingsDependenciesPage.tsx
@@ -59,6 +59,7 @@ export const SettingsDependenciesPage: React.FC = () => {
   const [deps, setDeps] = useState<DependencyItem[] | null>(null);
   const [busy, setBusy] = useState<string | null>(null);
   const [reconciling, setReconciling] = useState(false);
+  const [startupRepairingIds, setStartupRepairingIds] = useState<Set<string> | undefined>(undefined);
   const refreshSequence = useRef(0);
 
   const refresh = useCallback(async () => {
@@ -68,12 +69,16 @@ export const SettingsDependenciesPage: React.FC = () => {
       if (sequence === refreshSequence.current) {
         setDeps(res.deps ?? []);
         setReconciling(Boolean(res.reconciling));
+        setStartupRepairingIds(
+          Array.isArray(res.reconciling_dependencies) ? new Set(res.reconciling_dependencies) : undefined,
+        );
       }
       return res;
     } catch {
       if (sequence === refreshSequence.current) {
         setDeps([]);
         setReconciling(false);
+        setStartupRepairingIds(undefined);
       }
       return null;
     }
@@ -138,7 +143,7 @@ export const SettingsDependenciesPage: React.FC = () => {
   };
 
   const statusText = (d: DependencyItem) => {
-    if (reconciling && dependencyIsStartupRepairing(d)) {
+    if (reconciling && dependencyIsStartupRepairing(d, startupRepairingIds)) {
       return t('settings.dependencies.installing');
     }
     // Closed non-installed failure states render distinctly, ahead
@@ -152,7 +157,7 @@ export const SettingsDependenciesPage: React.FC = () => {
   };
 
   const statusVariant = (d: DependencyItem): 'success' | 'warning' | 'destructive' => {
-    if (reconciling && dependencyIsStartupRepairing(d)) return 'warning';
+    if (reconciling && dependencyIsStartupRepairing(d, startupRepairingIds)) return 'warning';
     if (d.status === 'error') return 'destructive';
     if (d.status === 'unsupported' || d.status === 'upgrade_required') return 'warning';
     return d.installed ? 'success' : 'destructive';
@@ -182,7 +187,7 @@ export const SettingsDependenciesPage: React.FC = () => {
           {deps.map((d) => {
             const meta = DEP_META[d.id] ?? DEP_META.node;
             const installing = busy === d.id;
-            const startupInstalling = reconciling && dependencyIsStartupRepairing(d);
+            const startupInstalling = reconciling && dependencyIsStartupRepairing(d, startupRepairingIds);
             const showAction = dependencyHasInstallAction(d);
             return (
               <SettingsResourceRow

--- a/ui/src/components/settings/SettingsDependenciesPage.tsx
+++ b/ui/src/components/settings/SettingsDependenciesPage.tsx
@@ -27,7 +27,7 @@ import { useToast } from '@/context/ToastContext';
 import {
   dependenciesNeedAutomaticRefresh,
   dependencyHasInstallAction,
-  dependencyIsStartupManaged,
+  dependencyIsStartupRepairing,
 } from './SettingsDependenciesPage.logic';
 import { errorMessage } from '@/lib/errorMessage';
 
@@ -138,7 +138,7 @@ export const SettingsDependenciesPage: React.FC = () => {
   };
 
   const statusText = (d: DependencyItem) => {
-    if (reconciling && dependencyIsStartupManaged(d) && !d.installed) {
+    if (reconciling && dependencyIsStartupRepairing(d)) {
       return t('settings.dependencies.installing');
     }
     // Closed non-installed failure states render distinctly, ahead
@@ -152,7 +152,7 @@ export const SettingsDependenciesPage: React.FC = () => {
   };
 
   const statusVariant = (d: DependencyItem): 'success' | 'warning' | 'destructive' => {
-    if (reconciling && dependencyIsStartupManaged(d) && !d.installed) return 'warning';
+    if (reconciling && dependencyIsStartupRepairing(d)) return 'warning';
     if (d.status === 'error') return 'destructive';
     if (d.status === 'unsupported' || d.status === 'upgrade_required') return 'warning';
     return d.installed ? 'success' : 'destructive';
@@ -182,7 +182,7 @@ export const SettingsDependenciesPage: React.FC = () => {
           {deps.map((d) => {
             const meta = DEP_META[d.id] ?? DEP_META.node;
             const installing = busy === d.id;
-            const startupInstalling = reconciling && dependencyIsStartupManaged(d) && !d.installed;
+            const startupInstalling = reconciling && dependencyIsStartupRepairing(d);
             const showAction = dependencyHasInstallAction(d);
             return (
               <SettingsResourceRow

--- a/ui/src/context/ApiContext.tsx
+++ b/ui/src/context/ApiContext.tsx
@@ -1717,7 +1717,7 @@ export type DependencyItem = {
   download_error?: DependencyDownloadError | null;
 };
 
-export type DependenciesResult = { ok: boolean; deps: DependencyItem[] };
+export type DependenciesResult = { ok: boolean; deps: DependencyItem[]; reconciling?: boolean };
 
 // Memory plugin contract: docs/plans/memory-plugin-system.md.
 // Keys are write-only: GET never returns a usable `api_key`, only `has_api_key`.

--- a/ui/src/context/ApiContext.tsx
+++ b/ui/src/context/ApiContext.tsx
@@ -1717,7 +1717,12 @@ export type DependencyItem = {
   download_error?: DependencyDownloadError | null;
 };
 
-export type DependenciesResult = { ok: boolean; deps: DependencyItem[]; reconciling?: boolean };
+export type DependenciesResult = {
+  ok: boolean;
+  deps: DependencyItem[];
+  reconciling?: boolean;
+  reconciling_dependencies?: string[];
+};
 
 // Memory plugin contract: docs/plans/memory-plugin-system.md.
 // Keys are write-only: GET never returns a usable `api_key`, only `has_api_key`.

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -7646,7 +7646,11 @@ def dependencies_status(*, offline: bool = False) -> dict:
         }
     )
 
-    return {"ok": True, "deps": deps}
+    return {
+        "ok": True,
+        "deps": deps,
+        "reconciling": _STARTUP_DEPENDENCY_RECONCILE_LOCK.locked(),
+    }
 
 
 def _memory_runtime_dependency_status(memory_runtime: dict) -> str:
@@ -7862,10 +7866,12 @@ def reconcile_startup_dependencies() -> dict:
             }
 
             if node_ok:
+                prepared = manager.prepare(force=False)
+                runtime_ok = bool(prepared.get("ok"))
                 result["show_runtime"] = {
-                    "ok": True,
-                    "status": "pending_prewarm",
-                    "reason": None,
+                    "ok": runtime_ok,
+                    "status": "ready" if runtime_ok else "failed",
+                    "reason": prepared.get("reason"),
                 }
             else:
                 result["show_runtime"] = {

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -7866,7 +7866,16 @@ def reconcile_startup_dependencies() -> dict:
             }
 
             if node_ok:
-                prepared = manager.prepare(force=False)
+                if status.get("installed"):
+                    # Status verification already found a usable runtime. Do not
+                    # re-enter a provider installer on every service startup.
+                    prepared = {"ok": True, "reason": None}
+                elif not getattr(manager, "auto_install", True):
+                    # Respect the documented opt-out. The explicit install action
+                    # remains available from the Dependencies page.
+                    prepared = {"ok": False, "reason": "runtime_auto_install_disabled"}
+                else:
+                    prepared = manager.prepare(force=False)
                 runtime_ok = bool(prepared.get("ok"))
                 result["show_runtime"] = {
                     "ok": runtime_ok,

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -7878,7 +7878,7 @@ def reconcile_startup_dependencies() -> dict:
                     # remains available from the Dependencies page.
                     prepared = {"ok": False, "reason": "runtime_auto_install_disabled"}
                 else:
-                    prepared = manager.prepare(force=False)
+                    prepared = manager.prepare(force=False, startup=True)
                 runtime_ok = bool(prepared.get("ok"))
                 result["show_runtime"] = {
                     "ok": runtime_ok,

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -7517,8 +7517,24 @@ def reconcile_askill_auto_update() -> dict:
 
 _ALLOWED_DEP_INSTALLS = {"askill", "avault", "show-runtime", "memory-runtime", "tmux"}
 _STARTUP_DEPENDENCY_RECONCILE_LOCK = threading.Lock()
+_STARTUP_DEPENDENCY_STATE_LOCK = threading.Lock()
+_STARTUP_DEPENDENCY_RECONCILING: set[str] = set()
+_STARTUP_DEPENDENCY_RECONCILE_GENERATION = 0
 _DEFAULT_STARTUP_SHOW_PAGE_PREWARM_LIMIT = 3
 _MAX_STARTUP_SHOW_PAGE_PREWARM_LIMIT = 10
+
+
+def _startup_dependency_state_snapshot() -> tuple[int, set[str]]:
+    with _STARTUP_DEPENDENCY_STATE_LOCK:
+        return _STARTUP_DEPENDENCY_RECONCILE_GENERATION, set(_STARTUP_DEPENDENCY_RECONCILING)
+
+
+def _set_startup_dependency_reconciling(dependency: str, active: bool) -> None:
+    with _STARTUP_DEPENDENCY_STATE_LOCK:
+        if active:
+            _STARTUP_DEPENDENCY_RECONCILING.add(dependency)
+        else:
+            _STARTUP_DEPENDENCY_RECONCILING.discard(dependency)
 
 
 def dependencies_status(*, offline: bool = False) -> dict:
@@ -7531,6 +7547,7 @@ def dependencies_status(*, offline: bool = False) -> dict:
     """
     # Probes below can outlive a short reconciliation, so preserve either edge of
     # the lock window instead of reporting a stale idle snapshot.
+    generation_before, active_before = _startup_dependency_state_snapshot()
     reconciling_before = _STARTUP_DEPENDENCY_RECONCILE_LOCK.locked()
     deps: list[dict] = []
 
@@ -7649,10 +7666,16 @@ def dependencies_status(*, offline: bool = False) -> dict:
         }
     )
 
+    generation_after, active_after = _startup_dependency_state_snapshot()
     return {
         "ok": True,
         "deps": deps,
-        "reconciling": reconciling_before or _STARTUP_DEPENDENCY_RECONCILE_LOCK.locked(),
+        "reconciling": (
+            reconciling_before
+            or _STARTUP_DEPENDENCY_RECONCILE_LOCK.locked()
+            or generation_before != generation_after
+        ),
+        "reconciling_dependencies": sorted(active_before | active_after),
     }
 
 
@@ -7827,6 +7850,12 @@ def reconcile_startup_dependencies() -> dict:
     if not _STARTUP_DEPENDENCY_RECONCILE_LOCK.acquire(blocking=False):
         return {"ok": True, "skipped": True, "reason": "already_running"}
 
+    global _STARTUP_DEPENDENCY_RECONCILE_GENERATION
+
+    with _STARTUP_DEPENDENCY_STATE_LOCK:
+        _STARTUP_DEPENDENCY_RECONCILE_GENERATION += 1
+        _STARTUP_DEPENDENCY_RECONCILING.clear()
+
     started_at = time.monotonic()
     result: dict[str, Any] = {
         "ok": True,
@@ -7837,18 +7866,24 @@ def reconcile_startup_dependencies() -> dict:
         "tmux": {"ok": False, "status": "unknown"},
     }
     try:
+        _set_startup_dependency_reconciling("askill", True)
         try:
             askill = ensure_askill_installed(force=False)
         except Exception as exc:  # noqa: BLE001
             logger.warning("Startup dependency reconcile failed to ensure askill: %s", exc, exc_info=True)
             askill = {"ok": False, "message": str(exc)}
+        finally:
+            _set_startup_dependency_reconciling("askill", False)
         result["askill"] = askill
 
+        _set_startup_dependency_reconciling("avault", True)
         try:
             avault = ensure_avault_installed(force=False)
         except Exception as exc:  # noqa: BLE001
             logger.warning("Startup dependency reconcile failed to ensure avault: %s", exc, exc_info=True)
             avault = {"ok": False, "message": str(exc)}
+        finally:
+            _set_startup_dependency_reconciling("avault", False)
         result["avault"] = avault
 
         try:
@@ -7878,7 +7913,11 @@ def reconcile_startup_dependencies() -> dict:
                     # remains available from the Dependencies page.
                     prepared = {"ok": False, "reason": "runtime_auto_install_disabled"}
                 else:
-                    prepared = manager.prepare(force=False, startup=True)
+                    _set_startup_dependency_reconciling("show-runtime", True)
+                    try:
+                        prepared = manager.prepare(force=False, startup=True)
+                    finally:
+                        _set_startup_dependency_reconciling("show-runtime", False)
                 runtime_ok = bool(prepared.get("ok"))
                 result["show_runtime"] = {
                     "ok": runtime_ok,
@@ -7901,6 +7940,7 @@ def reconcile_startup_dependencies() -> dict:
         elif os.environ.get("VIBE_INSTALL_SKIP_TMUX", "").strip().lower() in _TRUTHY_ENV_VALUES:
             result["tmux"] = {"ok": True, "skipped": True, "reason": "VIBE_INSTALL_SKIP_TMUX"}
         else:
+            _set_startup_dependency_reconciling("tmux", True)
             try:
                 from core.tmux_runtime import ensure_tmux_installed
 
@@ -7908,6 +7948,8 @@ def reconcile_startup_dependencies() -> dict:
             except Exception as exc:  # noqa: BLE001
                 logger.warning("Startup dependency reconcile failed to ensure tmux runtime: %s", exc, exc_info=True)
                 result["tmux"] = {"ok": False, "status": "failed", "reason": str(exc)}
+            finally:
+                _set_startup_dependency_reconciling("tmux", False)
 
         result["duration_ms"] = int((time.monotonic() - started_at) * 1000)
         result["ok"] = (
@@ -7917,6 +7959,9 @@ def reconcile_startup_dependencies() -> dict:
         )
         return result
     finally:
+        with _STARTUP_DEPENDENCY_STATE_LOCK:
+            _STARTUP_DEPENDENCY_RECONCILING.clear()
+            _STARTUP_DEPENDENCY_RECONCILE_GENERATION += 1
         _STARTUP_DEPENDENCY_RECONCILE_LOCK.release()
 
 

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -7529,6 +7529,9 @@ def dependencies_status(*, offline: bool = False) -> dict:
     Returns stable ids + machine-readable status only — display copy (label /
     detail) is localized in the React page, not sent from here.
     """
+    # Probes below can outlive a short reconciliation, so preserve either edge of
+    # the lock window instead of reporting a stale idle snapshot.
+    reconciling_before = _STARTUP_DEPENDENCY_RECONCILE_LOCK.locked()
     deps: list[dict] = []
 
     a = askill_update_status(include_latest=False)
@@ -7649,7 +7652,7 @@ def dependencies_status(*, offline: bool = False) -> dict:
     return {
         "ok": True,
         "deps": deps,
-        "reconciling": _STARTUP_DEPENDENCY_RECONCILE_LOCK.locked(),
+        "reconciling": reconciling_before or _STARTUP_DEPENDENCY_RECONCILE_LOCK.locked(),
     }
 
 


### PR DESCRIPTION
## What changed

Make first-launch dependency provisioning observable and self-refreshing in the desktop Workbench.

The Python startup reconciler now prepares the Show Page runtime while it owns the startup dependency lock and exposes a `reconciling` status on the dependency endpoint. The Dependencies page polls for a bounded first-launch window, shows startup-managed items as installing while reconciliation is active, and ignores stale responses from older refresh requests.

This closes the race where the desktop shell completed startup while askill, Show Runtime, or tmux were still downloading, then the Dependencies page kept the first `not installed` snapshot forever.

## Scenarios

- D11 clean install: bundled Node remains detected and managed dependencies converge without manual clicks.
- D04 Show Page: Show Runtime is prepared before the first Show Page prewarm.
- D07 terminal: tmux startup installation remains automatic and visible while it runs.

## Evidence

- Unit: `tests/test_local_deps.py` (74 passed), including startup preparation and dependency status shape.
- UI unit: `SettingsDependenciesPage.test.ts` (4 passed).
- Static: Ruff passed on changed Python files; `git diff --check` passed.
- Build: `npm run build` passed.
- Manual: isolated macOS arm64 package reproduction confirmed the original race and showed all managed dependencies converging after startup.

## Scope and dependencies

- Base is `desktop`; no dependency on another open PR.
- Changed files are limited to the dependency API, startup reconciliation, dependency page polling, and focused tests.

## Known by design

The DMG embeds CPython, the Avibe wheel, Node, and npm. tmux, Git, askill, and the Show Runtime are Avibe-managed dependency artifacts installed under the user's Avibe runtime data; they are not part of the embedded Python/Node archive. Agent backends remain lazy-installed separately.
