### PR TITLE
fix(ui): allow denying Vault provision requests

### DIFF
--- a/ui/src/components/ui/vault-request-card.test.tsx
+++ b/ui/src/components/ui/vault-request-card.test.tsx
@@ -14,14 +14,17 @@ vi.mock('./vault-secret-dialog', () => ({
     open,
     onOpenChange,
     onCancel,
+    onDeny,
   }: {
     open: boolean;
     onOpenChange: (open: boolean) => void;
     onCancel?: () => void;
+    onDeny?: () => void;
   }) => open ? (
     <div role="dialog">
       <button type="button" aria-label="close dialog" onClick={() => onOpenChange(false)}>Close</button>
       <button type="button" onClick={onCancel}>Ignore</button>
+      {onDeny ? <button type="button" onClick={onDeny}>Deny</button> : null}
     </div>
   ) : null,
 }));
@@ -48,12 +51,13 @@ const request = {
   card: { request_type: 'provision' },
 } satisfies VaultRequest;
 
-const renderProvisionCard = (onProvisionRequestHidden = vi.fn()) => render(
+const renderProvisionCard = (onProvisionRequestHidden = vi.fn(), onProvisionRequestDenied = vi.fn()) => render(
   <I18nextProvider i18n={i18n}>
     <VaultProvisionDialogProvider
       requests={[request]}
       onResolved={vi.fn()}
       onProvisionRequestHidden={onProvisionRequestHidden}
+      onProvisionRequestDenied={onProvisionRequestDenied}
     >
       <VaultRequestCard request={request} onResolved={vi.fn()} />
     </VaultProvisionDialogProvider>
@@ -75,5 +79,15 @@ describe('VaultRequestCard provision dialog dismissal', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Ignore' }));
     expect(screen.queryByText(request.secret_name)).toBeNull();
     expect(onProvisionRequestHidden).toHaveBeenCalledWith(request.id);
+  });
+
+  it('offers a terminal Deny action alongside the chat-only dismissal', () => {
+    const onProvisionRequestDenied = vi.fn(() => true);
+    renderProvisionCard(vi.fn(), onProvisionRequestDenied);
+
+    fireEvent.click(screen.getByRole('button', { name: /provide/i }));
+    fireEvent.click(screen.getByRole('button', { name: 'Deny' }));
+
+    expect(onProvisionRequestDenied).toHaveBeenCalledWith(request.id);
   });
 });

--- a/ui/src/components/ui/vault-request-card.tsx
+++ b/ui/src/components/ui/vault-request-card.tsx
@@ -30,9 +30,10 @@ export const VaultProvisionDialogProvider: React.FC<{
   requests: VaultRequest[];
   onResolved: () => void;
   onProvisionRequestHidden?: (requestId: string) => void;
+  onProvisionRequestDenied?: (requestId: string) => Promise<boolean | void> | boolean | void;
   disabled?: boolean;
   children: ReactNode;
-}> = ({ requests, onResolved, onProvisionRequestHidden, disabled = false, children }) => {
+}> = ({ requests, onResolved, onProvisionRequestHidden, onProvisionRequestDenied, disabled = false, children }) => {
   const [activeRequestId, setActiveRequestId] = useState<string | null>(null);
   const [dismissedRequestIds, setDismissedRequestIds] = useState<Set<string>>(() => new Set());
   const openProvisionDialog = useCallback((request: VaultRequest) => {
@@ -46,6 +47,19 @@ export const VaultProvisionDialogProvider: React.FC<{
       return new Set(current).add(requestId);
     });
   }, [onProvisionRequestHidden]);
+  const denyProvisionDialog = useCallback(async (requestId: string) => {
+    if (!onProvisionRequestDenied) return false;
+    const result = await onProvisionRequestDenied(requestId);
+    if (result === false) return false;
+    setActiveRequestId(null);
+    onProvisionRequestHidden?.(requestId);
+    setDismissedRequestIds((current) => {
+      if (current.has(requestId)) return current;
+      return new Set(current).add(requestId);
+    });
+    onResolved();
+    return true;
+  }, [onProvisionRequestDenied, onProvisionRequestHidden, onResolved]);
   const activeRequest = useMemo(
     () => requests.find((request) => request.id === activeRequestId && requestType(request) === 'provision'),
     [activeRequestId, requests],
@@ -64,6 +78,7 @@ export const VaultProvisionDialogProvider: React.FC<{
           }}
           request={activeRequest}
           onCancel={() => dismissProvisionDialog(activeRequest.id)}
+          onDeny={onProvisionRequestDenied ? () => denyProvisionDialog(activeRequest.id) : undefined}
           onCreated={() => {
             onProvisionRequestHidden?.(activeRequest.id);
             setActiveRequestId(null);

--- a/ui/src/components/ui/vault-secret-dialog.test.tsx
+++ b/ui/src/components/ui/vault-secret-dialog.test.tsx
@@ -1,0 +1,92 @@
+/* @vitest-environment jsdom */
+
+import type { ReactNode } from 'react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { createInstance } from 'i18next';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { I18nextProvider, initReactI18next } from 'react-i18next';
+
+import en from '@/i18n/en.json';
+import type { VaultRequest } from '@/context/ApiContext';
+import { VaultSecretDialog } from './vault-secret-dialog';
+
+vi.mock('./dialog', () => ({
+  Dialog: ({ children, open = true }: { children: ReactNode; open?: boolean }) => open ? <div>{children}</div> : null,
+  DialogContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DialogDescription: ({ children }: { children: ReactNode }) => <p>{children}</p>,
+  DialogFooter: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DialogHeader: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DialogTitle: ({ children }: { children: ReactNode }) => <h1>{children}</h1>,
+}));
+
+vi.mock('./vault-secret-form', () => ({
+  VaultSecretForm: ({ onDeny }: { onDeny?: () => void }) => (
+    <button type="button" onClick={onDeny}>deny-in-form</button>
+  ),
+}));
+
+const i18n = createInstance();
+void i18n.use(initReactI18next).init({
+  lng: 'en',
+  fallbackLng: 'en',
+  resources: { en: { translation: en } },
+  interpolation: { escapeValue: false },
+});
+
+const request = {
+  id: 'vrq_test',
+  request_type: 'provision',
+  secret_name: 'CHAT_SECRET',
+  status: 'pending',
+  card: { request_type: 'provision' },
+} as VaultRequest;
+
+const renderDialog = (onDeny: () => boolean) => render(
+  <I18nextProvider i18n={i18n}>
+    <VaultSecretDialog
+      open
+      onOpenChange={vi.fn()}
+      request={request}
+      onDeny={onDeny}
+      onCreated={vi.fn()}
+    />
+  </I18nextProvider>,
+);
+
+describe('VaultSecretDialog provision denial', () => {
+  afterEach(() => cleanup());
+
+  it('confirms before invoking the terminal denial callback', async () => {
+    const onDeny = vi.fn(() => true);
+    const onOpenChange = vi.fn();
+    render(
+      <I18nextProvider i18n={i18n}>
+        <VaultSecretDialog
+          open
+          onOpenChange={onOpenChange}
+          request={request}
+          onDeny={onDeny}
+          onCreated={vi.fn()}
+        />
+      </I18nextProvider>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'deny-in-form' }));
+    expect(onDeny).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByRole('button', { name: 'Deny' }));
+
+    await waitFor(() => expect(onDeny).toHaveBeenCalledTimes(1));
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it('keeps the confirmation open when denial fails', async () => {
+    const onDeny = vi.fn(() => false);
+    renderDialog(onDeny);
+
+    fireEvent.click(screen.getByRole('button', { name: 'deny-in-form' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Deny' }));
+
+    await waitFor(() => expect(onDeny).toHaveBeenCalledTimes(1));
+    expect(screen.getByRole('button', { name: 'Deny' })).toBeTruthy();
+  });
+});

--- a/ui/src/components/ui/vault-secret-dialog.tsx
+++ b/ui/src/components/ui/vault-secret-dialog.tsx
@@ -1,8 +1,10 @@
 import { KeyRound, Pencil } from 'lucide-react';
+import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import type { VaultRequest, VaultRequestSpec, VaultSecret } from '@/context/ApiContext';
 import { Dialog, DialogContent, DialogTitle } from './dialog';
+import { ConfirmDialog } from './confirm-dialog';
 import { VaultSecretForm } from './vault-secret-form';
 
 /**
@@ -27,11 +29,28 @@ export const VaultSecretDialog: React.FC<{
   notice?: React.ReactNode;
   onCancel?: () => void;
   cancelLabel?: string;
+  /** Terminally reject a pending provision request after user confirmation. */
+  onDeny?: () => Promise<boolean | void> | boolean | void;
+  denyLabel?: string;
   onCreated: (name: string, reason?: 'created' | 'already_exists') => void;
   /** Called after a successful metadata edit (edit mode only). */
   onSaved?: (name: string) => void;
-}> = ({ open, onOpenChange, name, request, editSecret, notice, onCancel, cancelLabel, onCreated, onSaved }) => {
+}> = ({
+  open,
+  onOpenChange,
+  name,
+  request,
+  editSecret,
+  notice,
+  onCancel,
+  cancelLabel,
+  onDeny,
+  denyLabel,
+  onCreated,
+  onSaved,
+}) => {
   const { t } = useTranslation();
+  const [denyConfirmationOpen, setDenyConfirmationOpen] = useState(false);
   const card = (request?.card ?? null) as { default_protection?: unknown; spec?: VaultRequestSpec } | null;
   const requestSpec = (card?.spec ?? null) as VaultRequestSpec | null;
   const defaultProtection =
@@ -42,36 +61,61 @@ export const VaultSecretDialog: React.FC<{
   const title = isEdit ? t('vaults.edit.title') : isProvide ? t('vaults.request.title') : t('vaults.dialog.title');
   const subtitle = isEdit ? t('vaults.edit.subtitle') : isProvide ? t('vaults.request.help') : t('vaults.dialog.subtitle');
   const HeaderIcon = isEdit ? Pencil : KeyRound;
+  const canDeny = Boolean(onDeny && request);
+
+  const confirmDeny = async () => {
+    if (!onDeny) return;
+    const result = await onDeny();
+    if (result === false) return;
+    setDenyConfirmationOpen(false);
+    onOpenChange(false);
+  };
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent>
-        {/* Accessible name; the visible heading is the branded header below. */}
-        <DialogTitle className="sr-only">{title}</DialogTitle>
-        <div className="flex items-start gap-3 pr-6">
-          <span className="flex size-10 shrink-0 items-center justify-center rounded-xl bg-accent/15 text-accent">
-            <HeaderIcon className="size-5" />
-          </span>
-          <div className="flex flex-col gap-0.5">
-            <span className="text-[15px] font-semibold text-foreground">{title}</span>
-            <span className="text-xs text-muted-foreground">{subtitle}</span>
+    <>
+      <Dialog open={open} onOpenChange={onOpenChange}>
+        <DialogContent>
+          {/* Accessible name; the visible heading is the branded header below. */}
+          <DialogTitle className="sr-only">{title}</DialogTitle>
+          <div className="flex items-start gap-3 pr-6">
+            <span className="flex size-10 shrink-0 items-center justify-center rounded-xl bg-accent/15 text-accent">
+              <HeaderIcon className="size-5" />
+            </span>
+            <div className="flex flex-col gap-0.5">
+              <span className="text-[15px] font-semibold text-foreground">{title}</span>
+              <span className="text-xs text-muted-foreground">{subtitle}</span>
+            </div>
           </div>
-        </div>
-        {notice ?? (
-          <VaultSecretForm
-            fixedName={fixedName}
-            editSecret={editSecret}
-            provisionRequestId={request?.id ?? null}
-            requestSpec={requestSpec}
-            defaultProtection={defaultProtection}
-            onCancel={onCancel ?? (() => onOpenChange(false))}
-            cancelLabel={cancelLabel}
-            onCreated={onCreated}
-            onSaved={onSaved}
-            treatExistingAsFulfilled={isProvide}
-          />
-        )}
-      </DialogContent>
-    </Dialog>
+          {notice ?? (
+            <VaultSecretForm
+              fixedName={fixedName}
+              editSecret={editSecret}
+              provisionRequestId={request?.id ?? null}
+              requestSpec={requestSpec}
+              defaultProtection={defaultProtection}
+              onCancel={onCancel ?? (() => onOpenChange(false))}
+              cancelLabel={cancelLabel}
+              onDeny={canDeny ? () => setDenyConfirmationOpen(true) : undefined}
+              denyLabel={denyLabel}
+              onCreated={onCreated}
+              onSaved={onSaved}
+              treatExistingAsFulfilled={isProvide}
+            />
+          )}
+        </DialogContent>
+      </Dialog>
+      {canDeny ? (
+        <ConfirmDialog
+          open={denyConfirmationOpen}
+          onOpenChange={setDenyConfirmationOpen}
+          title={t('vaults.request.denyTitle')}
+          description={t('vaults.request.denyDescription')}
+          cancelLabel={t('vaults.approval.close')}
+          confirmLabel={denyLabel ?? t('vaults.approval.deny')}
+          destructive
+          onConfirm={confirmDeny}
+        />
+      ) : null}
+    </>
   );
 };

--- a/ui/src/components/ui/vault-secret-form.tsx
+++ b/ui/src/components/ui/vault-secret-form.tsx
@@ -124,6 +124,9 @@ export const VaultSecretForm: React.FC<{
   onCreated: (name: string, reason?: 'created' | 'already_exists') => void;
   className?: string;
   cancelLabel?: string;
+  /** Terminally reject a pending provision request after confirmation in the dialog. */
+  onDeny?: () => void;
+  denyLabel?: string;
   defaultProtection?: VaultProtection;
   provisionRequestId?: string | null;
   requestSpec?: VaultRequestSpec | null;
@@ -138,6 +141,8 @@ export const VaultSecretForm: React.FC<{
   onCreated,
   className,
   cancelLabel,
+  onDeny,
+  denyLabel,
   defaultProtection = 'standard',
   provisionRequestId,
   requestSpec,
@@ -1086,11 +1091,17 @@ export const VaultSecretForm: React.FC<{
 
         {gatingNotices}
 
-        <div className="mt-1 flex justify-end gap-2">
-          <Button type="button" variant="ghost" onClick={onCancel} disabled={submitting}>
+        <div className="mt-1 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-end">
+          {onDeny ? (
+            <Button type="button" variant="destructive-soft" className="w-full sm:mr-auto sm:w-auto" onClick={onDeny} disabled={submitting}>
+              <X className="size-3.5" />
+              {denyLabel ?? t('vaults.approval.deny')}
+            </Button>
+          ) : null}
+          <Button type="button" variant="ghost" className="w-full sm:w-auto" onClick={onCancel} disabled={submitting}>
             {cancelLabel ?? t('vaults.request.dismiss')}
           </Button>
-          <Button type="submit" disabled={!canSubmit}>
+          <Button type="submit" className="w-full sm:w-auto" disabled={!canSubmit}>
             {submitting ? <Loader2 className="size-4 animate-spin" /> : <Check className="size-4" />}
             {t('vaults.request.saveAndWake')}
           </Button>

--- a/ui/src/components/workbench/ChatPage.tsx
+++ b/ui/src/components/workbench/ChatPage.tsx
@@ -473,6 +473,20 @@ export const ChatPage: React.FC = () => {
     // that makes the deferred request eligible for its next anchor attempt.
     setVaultAnchorCycle((cycle) => cycle + 1);
   }, []);
+  const denyVaultProvisionRequest = useCallback(
+    async (requestId: string) => {
+      try {
+        const result = await api.denyVaultRequest(requestId);
+        if (!result?.ok) return false;
+        showToast(t('vaults.requests.denied'), 'warning');
+        return true;
+      } catch {
+        showToast(t('vaults.approval.errors.failed'), 'warning');
+        return false;
+      }
+    },
+    [api, showToast, t],
+  );
   const [olderCursor, setOlderCursor] = useState<string | null>(null);
   const [loadingOlder, setLoadingOlder] = useState(false);
   const loadingOlderRef = useRef(false);
@@ -2478,6 +2492,7 @@ export const ChatPage: React.FC = () => {
         requests={vaultRequests}
         onResolved={refreshVaultRequests}
         onProvisionRequestHidden={markVaultRequestHidden}
+        onProvisionRequestDenied={denyVaultProvisionRequest}
         disabled={readOnly}
       >
       {/* Mobile: a FIXED full-screen flex column (the AppShell brand header is

--- a/ui/src/components/workbench/VaultsPage.tsx
+++ b/ui/src/components/workbench/VaultsPage.tsx
@@ -403,14 +403,17 @@ const PendingRequestsSection: React.FC<{
   const denyProvisionRequest = useCallback(
     async (request: VaultRequest) => {
       try {
-        await api.denyVaultRequest(request.id);
+        const result = await api.denyVaultRequest(request.id);
+        if (!result?.ok) return false;
         setProvisioning(null);
         setRequests((prev) => prev.filter((r) => r.id !== request.id));
         showToast(t('vaults.requests.denied'), 'warning');
         load();
         onResolved();
+        return true;
       } catch (err: unknown) {
         showToast(messageFromError(err), 'warning');
+        return false;
       }
     },
     [api, showToast, t, load, onResolved],
@@ -441,10 +444,9 @@ const PendingRequestsSection: React.FC<{
             if (!o) setProvisioning(null);
           }}
           request={provisioning}
-          onCancel={() => {
-            void denyProvisionRequest(provisioning);
-          }}
-          cancelLabel={t('vaults.approval.deny')}
+          onCancel={() => setProvisioning(null)}
+          cancelLabel={t('vaults.approval.close')}
+          onDeny={() => denyProvisionRequest(provisioning)}
           onCreated={(name, reason) => {
             setProvisioning(null);
             if (reason !== 'already_exists') {

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -3561,6 +3561,8 @@
       "help": "Provide the value — it goes to the vault, never to the chat or model.",
       "notSetYet": "not set yet",
       "dismiss": "Dismiss",
+      "denyTitle": "Reject this secret request?",
+      "denyDescription": "The agent will be notified that this request was rejected and stop waiting. This can't be undone.",
       "saveAndWake": "Save & let the agent continue",
       "ambiguousProvision": "Multiple pending requests need this secret. Open the request-specific Provide secret row in Vaults so the requested details are preserved.",
       "saveFailed": "Couldn't save the secret. Please try again."

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -3561,6 +3561,8 @@
       "help": "提供这个值——它会进入保险库,绝不会进入聊天或模型。",
       "notSetYet": "尚未设置",
       "dismiss": "忽略",
+      "denyTitle": "拒绝这次填写请求？",
+      "denyDescription": "Agent 会收到拒绝结果并停止等待，这个操作无法撤销。",
       "saveAndWake": "保存并让 AI 继续",
       "ambiguousProvision": "有多个待处理请求都需要这个密钥。请在 Vaults 里打开对应请求的填写行，这样才能保留请求里的详细设置。",
       "saveFailed": "保存失败，请重试。"


### PR DESCRIPTION
## What
Add a terminal Reject request action to the shared Vault provision dialog. Chat keeps a non-terminal Dismiss action, while Reject uses the existing deny API after confirmation and refreshes the pending request state. Vaults uses the same confirmed flow.

## Evidence
- Unit: vault-request-card and vault-secret-dialog component tests
- Contract: reuses the existing denyVaultRequest API contract
- Scenario: no catalog scenario applies; pending Vault provision request flow covered by component tests
- Residual manual: regression Chat and Vaults flows should verify Dismiss, close, Reject confirmation, and successful provision

## Risk
Scoped to pending provision dialog actions; create and edit forms do not receive the Reject action.