### PR TITLE
refactor(memory): extract maintenance state machine

### DIFF
--- a/core/memory/maintenance.py
+++ b/core/memory/maintenance.py
@@ -1,0 +1,922 @@
+"""Durable Clear, backup/restore, and housekeeping ownership for Memory."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Awaitable, Callable, Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import AsyncContextManager, Literal, TypeVar
+
+from core.memory.backup_restore_journal import (
+    BackupRestoreConflict,
+    BackupRestoreOperation,
+    MemoryBackupRestoreJournal,
+)
+from core.memory.blocking import run_blocking
+from core.memory.clear_journal import ClearOperation, ClearSurface, MemoryClearJournal
+from core.memory.snapshot import MemorySnapshot, MemorySnapshotManager
+from core.memory.store import MemoryStore
+
+
+logger = logging.getLogger(__name__)
+
+
+_MaintenanceIOResult = TypeVar("_MaintenanceIOResult")
+
+
+class MemoryStoreUnavailableError(RuntimeError):
+    """Raised when the controller cannot safely use the local Memory store."""
+
+
+@dataclass(frozen=True)
+class MaintenanceRuntimeState:
+    """Dynamic runtime gates needed by maintenance-owned jobs."""
+
+    artifact_installing: bool
+
+
+@dataclass(frozen=True)
+class ClearRecoveryResult:
+    state: str
+    operation_id: str
+    occurred_at: str
+    error_code: str | None
+    can_resume: bool
+    can_abort: bool
+
+
+@dataclass(frozen=True)
+class ClearResult:
+    status: Literal["completed", "aborted", "failed"]
+    operation_id: str | None = None
+    epoch: int | None = None
+    error: str | None = None
+    recovery: ClearRecoveryResult | None = None
+
+
+@dataclass(frozen=True)
+class MaintenanceResult:
+    data_exists: bool
+    can_clear: bool
+    clear_recovery: ClearRecoveryResult | None
+
+
+@dataclass(frozen=True)
+class MemoryMaintenanceRuntimePort:
+    """Capability-shaped access to lifecycle state retained by MemoryRuntime."""
+
+    exclusive_fence: Callable[[], AsyncContextManager[None]]
+    boot_recovery_fence: Callable[[], AsyncContextManager[None]]
+    state: Callable[[], MaintenanceRuntimeState]
+    enter_maintenance: Callable[[], None]
+    leave_maintenance: Callable[[], None]
+    pause_claims: Callable[[], Awaitable[None]]
+    resume_claims: Callable[[], None]
+    quiesce: Callable[[bool], Awaitable[None]]
+    resume: Callable[[], Awaitable[None]]
+    delete_surface: Callable[[ClearSurface, int], Awaitable[None]]
+
+
+class MemoryMaintenance:
+    """Own the complete durable maintenance state machine for one Memory store."""
+
+    def __init__(
+        self,
+        store: MemoryStore | None,
+        *,
+        effective_home: Path,
+        runtime: MemoryMaintenanceRuntimePort,
+    ) -> None:
+        self._store = store
+        self._runtime = runtime
+        self._backup_active = False
+        self._backup_restore_journal: MemoryBackupRestoreJournal | None = None
+        self._clear_journal: MemoryClearJournal | None = None
+        self._snapshot_manager: MemorySnapshotManager | None = None
+        self._backup_manager: MemorySnapshotManager | None = None
+        self._initialization_error: Exception | None = None
+        self._terminal_snapshot_gc_task: asyncio.Task[None] | None = None
+        self._backup_stage_reconcile_task: asyncio.Task[None] | None = None
+        self._closing = False
+        try:
+            self._backup_restore_journal = MemoryBackupRestoreJournal(effective_home)
+            self._clear_journal = MemoryClearJournal(effective_home)
+            self._snapshot_manager = MemorySnapshotManager(effective_home)
+            self._backup_manager = MemorySnapshotManager._for_backup(
+                effective_home,
+                operation_guard=self._clear_journal.assert_backup_allowed,
+            )
+            self._backup_restore_journal.mark_boot_recovery_needed()
+            self._clear_journal.mark_boot_recovery_needed()
+        except Exception as exc:
+            self._initialization_error = exc
+            logger.exception(
+                "Memory maintenance journal initialization failed; maintenance is fenced"
+            )
+
+    @property
+    def ready(self) -> bool:
+        return (
+            self._store is not None
+            and self._backup_restore_journal is not None
+            and self._clear_journal is not None
+            and self._snapshot_manager is not None
+            and self._backup_manager is not None
+            and self._initialization_error is None
+        )
+
+    def attach_store(self, store: MemoryStore) -> None:
+        """Attach the store after a transient boot-time open failure recovers."""
+
+        self._store = store
+
+    def is_open(self) -> bool:
+        """Fail closed unless every durable authority proves terminal."""
+
+        if self._backup_active:
+            return True
+        restore_journal = self._backup_restore_journal
+        if restore_journal is None:
+            return True
+        try:
+            if restore_journal.get_open_operation() is not None:
+                return True
+        except Exception:
+            return True
+        journal = self._clear_journal
+        if journal is None or self._initialization_error is not None:
+            return True
+        try:
+            return journal.get_open_operation() is not None
+        except Exception:
+            return True
+
+    def can_disable_without_authority(self) -> bool:
+        restore_journal = self._backup_restore_journal
+        clear_journal = self._clear_journal
+        if (
+            restore_journal is None
+            or clear_journal is None
+            or self._initialization_error is not None
+        ):
+            return True
+        try:
+            restore_journal.get_open_operation()
+            clear_journal.get_open_operation()
+        except Exception:
+            return True
+        return False
+
+    def has_open_restore(self) -> bool:
+        return self._open_backup_restore_operation() is not None
+
+    def recovery(self, *, operator_ref: str | None = None) -> ClearRecoveryResult | None:
+        operation = self._open_clear_operation()
+        if operation is None:
+            return None
+        can_resume = False
+        can_abort = False
+        try:
+            if operator_ref is not None and operation.operator_ref == operator_ref:
+                journal = self._require_clear_journal()
+                can_resume = journal.can_resume(operation.operation_id)
+                can_abort = journal.can_abort(operation.operation_id)
+        except Exception:
+            pass
+        return ClearRecoveryResult(
+            state=operation.state,
+            operation_id=operation.operation_id,
+            occurred_at=operation.updated_at,
+            error_code=operation.closed_error,
+            can_resume=can_resume,
+            can_abort=can_abort,
+        )
+
+    async def maintenance_payload(
+        self,
+        *,
+        operator_ref: str | None = None,
+    ) -> MaintenanceResult:
+        try:
+            meta, history, manual_required = await asyncio.gather(
+                asyncio.to_thread(self._store.get_meta),
+                asyncio.to_thread(self._store.has_provider_data_history),
+                asyncio.to_thread(self._store.has_manual_required_fence),
+            )
+        except Exception:
+            return MaintenanceResult(
+                data_exists=True,
+                can_clear=False,
+                clear_recovery=self.recovery(operator_ref=operator_ref),
+            )
+        recovery = self.recovery(operator_ref=operator_ref)
+        return MaintenanceResult(
+            data_exists=bool(history or (meta is not None and meta.last_success_at)),
+            can_clear=(
+                self.ready
+                and not self.is_open()
+                and not manual_required
+                and recovery is None
+            ),
+            clear_recovery=recovery,
+        )
+
+    async def create_backup(self, backup_id: str | None = None) -> MemorySnapshot:
+        return await self._run_backup_operation(lambda manager: manager.create(backup_id))
+
+    async def restore_backup(
+        self,
+        backup_id: str,
+        *,
+        expected_manifest_sha256: str,
+        expected_surface_digests: Mapping[str, str | None],
+    ) -> MemorySnapshot:
+        clear_journal = self._require_clear_journal()
+        restore_journal = self._require_backup_restore_journal()
+        manager = self._require_backup_manager()
+        async with self._runtime.exclusive_fence():
+            clear_journal.assert_backup_allowed()
+            operation = restore_journal.get_open_operation()
+            if operation is not None and (
+                operation.state != "recovery_needed"
+                or operation.backup_id != backup_id
+                or operation.manifest_sha256 != expected_manifest_sha256
+                or operation.digest_mapping() != dict(expected_surface_digests)
+            ):
+                raise BackupRestoreConflict(
+                    "a different Memory backup restore owns the recovery fence"
+                )
+            self._backup_active = True
+            self._runtime.enter_maintenance()
+            try:
+                await self._runtime.quiesce(False)
+                if operation is not None:
+                    operation = await self._run_maintenance_io(
+                        lambda: restore_journal.claim_retry(
+                            operation.operation_id,
+                            expected_revision=operation.revision,
+                            actor_ref="system:runtime",
+                        )
+                    )
+
+                def begin_restore(snapshot: MemorySnapshot) -> None:
+                    nonlocal operation
+                    operation = restore_journal.start(snapshot)
+
+                restored = await self._run_maintenance_io(
+                    lambda: manager.restore(
+                        backup_id,
+                        expected_manifest_sha256=expected_manifest_sha256,
+                        expected_surface_digests=expected_surface_digests,
+                        before_replace=None if operation is not None else begin_restore,
+                    )
+                )
+                if operation is None:
+                    raise RuntimeError("Memory backup restore intent was not recorded")
+                operation = await self._run_maintenance_io(
+                    lambda: restore_journal.mark_completed(
+                        operation.operation_id,
+                        expected_revision=operation.revision,
+                        execution_token=self._backup_restore_execution_token(operation),
+                    )
+                )
+                return restored
+            except BaseException:
+                await self._mark_backup_restore_recovery(operation)
+                raise
+            finally:
+                self._backup_active = False
+                try:
+                    if restore_journal.get_open_operation() is None:
+                        await self._runtime.resume()
+                finally:
+                    self._runtime.leave_maintenance()
+
+    async def _run_backup_operation(
+        self,
+        operation: Callable[[MemorySnapshotManager], MemorySnapshot],
+    ) -> MemorySnapshot:
+        journal = self._require_clear_journal()
+        restore_journal = self._require_backup_restore_journal()
+        manager = self._require_backup_manager()
+        async with self._runtime.exclusive_fence():
+            journal.assert_backup_allowed()
+            restore_journal.assert_idle()
+            self._backup_active = True
+            self._runtime.enter_maintenance()
+            try:
+                await self._runtime.quiesce(False)
+                return await self._run_maintenance_io(lambda: operation(manager))
+            finally:
+                self._backup_active = False
+                try:
+                    await self._runtime.resume()
+                finally:
+                    self._runtime.leave_maintenance()
+
+    async def clear(self, *, operator_ref: str) -> ClearResult:
+        journal = self._require_clear_journal()
+        async with self._runtime.exclusive_fence():
+            if journal.get_open_operation() is not None:
+                return self._blocked(operator_ref=operator_ref)
+            operation: ClearOperation | None = None
+            self._runtime.enter_maintenance()
+            try:
+                try:
+                    await self._runtime.pause_claims()
+                    manual_required = await self._run_maintenance_io(
+                        self._store.has_manual_required_fence
+                    )
+                except BaseException as error:
+                    self._runtime.leave_maintenance()
+                    self._runtime.resume_claims()
+                    if isinstance(error, asyncio.CancelledError):
+                        raise
+                    return self._blocked(operator_ref=operator_ref)
+                if manual_required:
+                    self._runtime.leave_maintenance()
+                    self._runtime.resume_claims()
+                    return self._blocked(operator_ref=operator_ref)
+                try:
+                    meta = await self._run_maintenance_io(self._store.ensure_meta)
+                    operation = await self._run_maintenance_io(
+                        lambda: journal.start(
+                            operator_ref=operator_ref,
+                            pre_epoch=meta.epoch,
+                            target_epoch=meta.epoch + 1,
+                        )
+                    )
+                    await self._run_maintenance_io(self._store.begin_clear_fence)
+                    operation = await self._prepare_clear(
+                        operation,
+                        claims_already_paused=True,
+                    )
+                    operation = await self._delete_clear_surfaces(operation)
+                except BaseException as error:
+                    current = await self._mark_clear_recovery(operation)
+                    if current is not None and current.state == "completed":
+                        self._runtime.leave_maintenance()
+                        await self._finish_clear(current)
+                    elif current is None:
+                        self._runtime.leave_maintenance()
+                        self._runtime.resume_claims()
+                    if isinstance(error, asyncio.CancelledError):
+                        raise
+                    return self._blocked(operator_ref=operator_ref)
+            finally:
+                self._runtime.leave_maintenance()
+            if operation is None:
+                raise RuntimeError("Memory clear operation did not start")
+            return await self._finish_clear(operation)
+
+    async def resume_clear(
+        self,
+        operation_id: str,
+        *,
+        operator_ref: str,
+    ) -> ClearResult:
+        journal = self._require_clear_journal()
+        async with self._runtime.exclusive_fence():
+            current = journal.get_open_operation()
+            if current is None or current.operation_id != operation_id:
+                return self._blocked(operator_ref=operator_ref)
+            try:
+                operation = await self._run_maintenance_io(
+                    lambda: journal.claim_resume(
+                        operation_id,
+                        operator_ref=operator_ref,
+                        expected_revision=current.revision,
+                    )
+                )
+                await self._run_maintenance_io(self._store.begin_clear_fence)
+                operation = await self._prepare_clear(operation)
+                operation = await self._delete_clear_surfaces(operation)
+            except BaseException as error:
+                recovered = await self._mark_clear_recovery(operation_id=operation_id)
+                if recovered is not None and recovered.state == "completed":
+                    await self._finish_clear(recovered)
+                if isinstance(error, asyncio.CancelledError):
+                    raise
+                return self._blocked(operator_ref=operator_ref)
+            return await self._finish_clear(operation)
+
+    async def abort_clear(
+        self,
+        operation_id: str,
+        *,
+        operator_ref: str,
+    ) -> ClearResult:
+        journal = self._require_clear_journal()
+        manager = self._require_snapshot_manager()
+        async with self._runtime.exclusive_fence():
+            current = journal.get_open_operation()
+            if current is None or current.operation_id != operation_id:
+                return self._blocked(operator_ref=operator_ref)
+            try:
+                operation = await self._run_maintenance_io(
+                    lambda: journal.claim_abort(
+                        operation_id,
+                        operator_ref=operator_ref,
+                        expected_revision=current.revision,
+                    )
+                )
+                await self._runtime.quiesce(False)
+                digests = self._journal_surface_digests(operation.operation_id)
+                if operation.manifest_sha256 is None or operation.snapshot_path is None:
+                    raise RuntimeError("clear snapshot is not sealed")
+                await self._run_maintenance_io(
+                    lambda: manager.restore(
+                        operation.operation_id,
+                        expected_manifest_sha256=operation.manifest_sha256,
+                        expected_surface_digests=digests,
+                    )
+                )
+                await self._run_maintenance_io(self._store.release_clear_fence)
+                for surface in journal.get_surfaces(operation.operation_id):
+                    if surface.state == "restored":
+                        continue
+                    operation = await self._run_maintenance_io(
+                        lambda: journal.record_surface_restored(
+                            operation.operation_id,
+                            surface.surface,
+                            expected_revision=operation.revision,
+                            execution_token=self._clear_execution_token(operation),
+                        )
+                    )
+                operation = await self._run_maintenance_io(
+                    lambda: journal.mark_aborted(
+                        operation.operation_id,
+                        expected_revision=operation.revision,
+                        execution_token=self._clear_execution_token(operation),
+                    )
+                )
+            except BaseException as error:
+                recovered = await self._mark_clear_recovery(operation_id=operation_id)
+                if recovered is not None and recovered.state == "aborted":
+                    await self._finish_aborted_clear(recovered)
+                if isinstance(error, asyncio.CancelledError):
+                    raise
+                return self._blocked(operator_ref=operator_ref)
+            return await self._finish_aborted_clear(operation)
+
+    async def _prepare_clear(
+        self,
+        operation: ClearOperation,
+        *,
+        claims_already_paused: bool = False,
+    ) -> ClearOperation:
+        journal = self._require_clear_journal()
+        manager = self._require_snapshot_manager()
+        await self._runtime.quiesce(claims_already_paused)
+        if operation.state == "preparing":
+            if operation.snapshot_path is None or operation.manifest_sha256 is None:
+                if operation.resolution == "resume":
+                    with journal.authorize_preparing_snapshot_discard(
+                        operation.operation_id,
+                        expected_revision=operation.revision,
+                        execution_token=self._clear_execution_token(operation),
+                    ) as permit:
+                        await self._run_maintenance_io(
+                            lambda: manager.discard_unrecorded(permit)
+                        )
+                    refreshed = journal.get_operation(operation.operation_id)
+                    if refreshed is None:
+                        raise RuntimeError("Memory clear operation disappeared")
+                    operation = refreshed
+                snapshot = await self._run_maintenance_io(
+                    lambda: manager.create(operation.operation_id)
+                )
+                operation = await self._run_maintenance_io(
+                    lambda: journal.record_snapshot(
+                        operation.operation_id,
+                        expected_revision=operation.revision,
+                        execution_token=self._clear_execution_token(operation),
+                        snapshot=snapshot,
+                    )
+                )
+            else:
+                await self._verify_clear_snapshot(operation)
+            operation = await self._run_maintenance_io(
+                lambda: journal.mark_prepared(
+                    operation.operation_id,
+                    expected_revision=operation.revision,
+                    execution_token=self._clear_execution_token(operation),
+                )
+            )
+        if operation.state == "prepared":
+            await self._verify_clear_snapshot(operation)
+        return operation
+
+    async def _delete_clear_surfaces(self, operation: ClearOperation) -> ClearOperation:
+        journal = self._require_clear_journal()
+        if operation.state == "prepared":
+            operation = await self._run_maintenance_io(
+                lambda: journal.begin_deleting(
+                    operation.operation_id,
+                    expected_revision=operation.revision,
+                    execution_token=self._clear_execution_token(operation),
+                )
+            )
+        if operation.state != "deleting":
+            raise RuntimeError("clear operation is not ready for deletion")
+        await self._verify_clear_snapshot(operation)
+        for surface in journal.get_surfaces(operation.operation_id):
+            if surface.state == "deleted":
+                continue
+            await self._runtime.delete_surface(surface, operation.target_epoch)
+            operation = await self._run_maintenance_io(
+                lambda: journal.record_surface_deleted(
+                    operation.operation_id,
+                    surface.surface,
+                    expected_revision=operation.revision,
+                    execution_token=self._clear_execution_token(operation),
+                )
+            )
+        return await self._run_maintenance_io(
+            lambda: journal.mark_completed(
+                operation.operation_id,
+                expected_revision=operation.revision,
+                execution_token=self._clear_execution_token(operation),
+            )
+        )
+
+    async def _verify_clear_snapshot(self, operation: ClearOperation) -> MemorySnapshot:
+        if operation.manifest_sha256 is None or operation.snapshot_path is None:
+            raise RuntimeError("clear snapshot is not sealed")
+        return await self._run_maintenance_io(
+            lambda: self._require_snapshot_manager().verify(
+                operation.operation_id,
+                expected_manifest_sha256=operation.manifest_sha256,
+                expected_surface_digests=self._journal_surface_digests(
+                    operation.operation_id
+                ),
+            )
+        )
+
+    async def recover_boot(self) -> bool:
+        """Converge an interrupted ordinary restore before activation."""
+
+        journal = self._require_backup_restore_journal()
+        operation = journal.get_open_operation()
+        if operation is None:
+            return True
+        if operation.state != "recovery_needed":
+            return False
+        manager = self._require_backup_manager()
+        self._backup_active = True
+        self._runtime.enter_maintenance()
+        try:
+            async with self._runtime.boot_recovery_fence():
+                await self._runtime.quiesce(False)
+                operation = await self._run_maintenance_io(
+                    lambda: journal.claim_retry(
+                        operation.operation_id,
+                        expected_revision=operation.revision,
+                        actor_ref="system:boot",
+                    )
+                )
+                await self._run_maintenance_io(
+                    lambda: manager.restore(
+                        operation.backup_id,
+                        expected_manifest_sha256=operation.manifest_sha256,
+                        expected_surface_digests=operation.digest_mapping(),
+                    )
+                )
+                await self._run_maintenance_io(
+                    lambda: journal.mark_completed(
+                        operation.operation_id,
+                        expected_revision=operation.revision,
+                        execution_token=self._backup_restore_execution_token(operation),
+                        actor_ref="system:boot",
+                    )
+                )
+            return True
+        except asyncio.CancelledError:
+            await self._mark_backup_restore_recovery(operation)
+            raise
+        except Exception:
+            await self._mark_backup_restore_recovery(operation)
+            return False
+        finally:
+            self._backup_active = False
+            self._runtime.leave_maintenance()
+
+    async def _mark_backup_restore_recovery(
+        self,
+        operation: BackupRestoreOperation | None,
+    ) -> BackupRestoreOperation | None:
+        journal = self._backup_restore_journal
+        if journal is None or operation is None:
+            return None
+        try:
+            current = journal.get_operation(operation.operation_id)
+            if current is None or current.state != "restoring":
+                return current
+            return await self._run_maintenance_io(
+                lambda: journal.mark_recovery_needed(
+                    current.operation_id,
+                    expected_revision=current.revision,
+                    execution_token=self._backup_restore_execution_token(current),
+                )
+            )
+        except Exception:
+            logger.exception("Memory backup restore failure could not be journaled")
+            return None
+
+    async def _mark_clear_recovery(
+        self,
+        operation: ClearOperation | None = None,
+        *,
+        operation_id: str | None = None,
+    ) -> ClearOperation | None:
+        journal = self._clear_journal
+        if journal is None:
+            return None
+
+        def mark_recovery() -> ClearOperation | None:
+            identifier = operation.operation_id if operation is not None else operation_id
+            current = (
+                journal.get_open_operation()
+                if identifier is None
+                else journal.get_operation(identifier)
+            )
+            if current is None:
+                return None
+            if current.state in {"preparing", "prepared", "deleting"}:
+                return journal.mark_recovery_needed(
+                    current.operation_id,
+                    expected_revision=current.revision,
+                    execution_token=self._clear_execution_token(current),
+                )
+            if current.state == "recovery_needed" and current.execution_token is not None:
+                return journal.release_recovery_claim(
+                    current.operation_id,
+                    expected_revision=current.revision,
+                    execution_token=self._clear_execution_token(current),
+                )
+            return current
+
+        try:
+            return await self._run_maintenance_io(mark_recovery)
+        except Exception:
+            logger.exception("Memory clear failure could not be journaled")
+            return None
+
+    async def _finish_clear(self, operation: ClearOperation) -> ClearResult:
+        try:
+            await self._run_maintenance_io(self._reconcile_terminal_clear_snapshots)
+        finally:
+            await self._runtime.resume()
+        return ClearResult(
+            status="completed",
+            operation_id=operation.operation_id,
+            epoch=operation.target_epoch,
+        )
+
+    async def _finish_aborted_clear(self, operation: ClearOperation) -> ClearResult:
+        try:
+            await self._run_maintenance_io(self._reconcile_terminal_clear_snapshots)
+        finally:
+            await self._runtime.resume()
+        return ClearResult(
+            status="aborted",
+            operation_id=operation.operation_id,
+            epoch=operation.pre_epoch,
+        )
+
+    def _blocked(self, *, operator_ref: str | None = None) -> ClearResult:
+        return ClearResult(
+            status="failed",
+            error="memory_clear_failed",
+            recovery=self.recovery(operator_ref=operator_ref),
+        )
+
+    def _reconcile_terminal_clear_snapshots(self) -> None:
+        journal = self._require_clear_journal()
+        manager = self._require_snapshot_manager()
+        for permit in journal.terminal_snapshot_permits():
+            try:
+                manager.remove(permit)
+            except Exception:
+                logger.warning(
+                    "Terminal Memory clear snapshot %s could not be removed",
+                    permit.snapshot_id,
+                    exc_info=True,
+                )
+
+    def ensure_housekeeping(self) -> None:
+        """Schedule terminal GC before backup-stage reconciliation."""
+
+        self._ensure_terminal_snapshot_gc()
+        self._ensure_backup_stage_reconcile()
+
+    def _ensure_terminal_snapshot_gc(self) -> None:
+        task = self._terminal_snapshot_gc_task
+        state = self._runtime.state()
+        if (
+            self._closing
+            or state.artifact_installing
+            or self._clear_journal is None
+            or self._snapshot_manager is None
+            or self._initialization_error is not None
+            or (task is not None and not task.done())
+        ):
+            return
+        task = asyncio.create_task(
+            self._run_terminal_snapshot_gc(),
+            name="memory-terminal-snapshot-gc",
+        )
+        self._terminal_snapshot_gc_task = task
+
+        def clear_gc(completed: asyncio.Task[None]) -> None:
+            if self._terminal_snapshot_gc_task is completed:
+                self._terminal_snapshot_gc_task = None
+
+        task.add_done_callback(clear_gc)
+
+    def _ensure_backup_stage_reconcile(self) -> None:
+        task = self._backup_stage_reconcile_task
+        state = self._runtime.state()
+        if (
+            self._closing
+            or state.artifact_installing
+            or self._backup_manager is None
+            or self._clear_journal is None
+            or self._backup_restore_journal is None
+            or self._initialization_error is not None
+            or (task is not None and not task.done())
+        ):
+            return
+        task = asyncio.create_task(
+            self._run_backup_stage_reconcile(),
+            name="memory-backup-stage-reconcile",
+        )
+        self._backup_stage_reconcile_task = task
+
+        def clear_reconcile(completed: asyncio.Task[None]) -> None:
+            if self._backup_stage_reconcile_task is completed:
+                self._backup_stage_reconcile_task = None
+
+        task.add_done_callback(clear_reconcile)
+
+    async def _run_backup_stage_reconcile(self) -> None:
+        terminal_gc = self._terminal_snapshot_gc_task
+        if terminal_gc is not None and terminal_gc is not asyncio.current_task():
+            await asyncio.shield(terminal_gc)
+        journal = self._require_clear_journal()
+        restore_journal = self._require_backup_restore_journal()
+        manager = self._require_backup_manager()
+        try:
+            async with self._runtime.exclusive_fence():
+                if self._runtime.state().artifact_installing:
+                    return
+                journal.assert_backup_allowed()
+                restore_journal.assert_idle()
+                await self._run_maintenance_io(
+                    manager.reconcile_unpublished_backup_stages
+                )
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.warning(
+                "Unpublished Memory backup stages could not be reconciled",
+                exc_info=True,
+            )
+
+    async def _run_terminal_snapshot_gc(self) -> None:
+        journal = self._require_clear_journal()
+        manager = self._require_snapshot_manager()
+        try:
+            permits = await self._run_maintenance_io(journal.terminal_snapshot_permits)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.warning(
+                "Terminal Memory clear snapshot permits could not be loaded",
+                exc_info=True,
+            )
+            return
+        for permit in permits:
+            try:
+                await self._run_maintenance_io(
+                    lambda permit=permit: manager.remove(permit)
+                )
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.warning(
+                    "Terminal Memory clear snapshot %s could not be removed",
+                    permit.snapshot_id,
+                    exc_info=True,
+                )
+
+    async def close(self) -> None:
+        self._closing = True
+        caller_cancellation: asyncio.CancelledError | None = None
+        for attribute in (
+            "_backup_stage_reconcile_task",
+            "_terminal_snapshot_gc_task",
+        ):
+            try:
+                await self._stop_task(attribute)
+            except asyncio.CancelledError as error:
+                caller_cancellation = caller_cancellation or error
+        if caller_cancellation is not None:
+            raise caller_cancellation
+
+    async def _stop_task(self, attribute: str) -> None:
+        task = getattr(self, attribute)
+        if task is None or task is asyncio.current_task():
+            return
+        task.cancel()
+        settlement = asyncio.gather(task, return_exceptions=True)
+        caller_cancellation: asyncio.CancelledError | None = None
+        while not settlement.done():
+            try:
+                await asyncio.shield(settlement)
+            except asyncio.CancelledError as error:
+                caller_cancellation = caller_cancellation or error
+        try:
+            result = settlement.result()[0]
+        finally:
+            if getattr(self, attribute) is task:
+                setattr(self, attribute, None)
+        if isinstance(result, BaseException) and not isinstance(
+            result,
+            asyncio.CancelledError,
+        ):
+            raise result
+        if caller_cancellation is not None:
+            raise caller_cancellation
+
+    def _open_backup_restore_operation(self) -> BackupRestoreOperation | None:
+        journal = self._backup_restore_journal
+        if journal is None:
+            return None
+        try:
+            return journal.get_open_operation()
+        except Exception:
+            return None
+
+    def _open_clear_operation(self) -> ClearOperation | None:
+        journal = self._clear_journal
+        if journal is None:
+            return None
+        try:
+            return journal.get_open_operation()
+        except Exception:
+            return None
+
+    def _journal_surface_digests(self, operation_id: str) -> dict[str, str | None]:
+        journal = self._require_clear_journal()
+        return {
+            surface.relative_path: surface.snapshot_digest
+            for surface in journal.get_surfaces(operation_id)
+        }
+
+    def _require_clear_journal(self) -> MemoryClearJournal:
+        if self._clear_journal is None or self._initialization_error is not None:
+            raise MemoryStoreUnavailableError("Memory clear journal is unavailable")
+        return self._clear_journal
+
+    def _require_backup_restore_journal(self) -> MemoryBackupRestoreJournal:
+        if (
+            self._backup_restore_journal is None
+            or self._initialization_error is not None
+        ):
+            raise MemoryStoreUnavailableError(
+                "Memory backup restore journal is unavailable"
+            )
+        return self._backup_restore_journal
+
+    def _require_snapshot_manager(self) -> MemorySnapshotManager:
+        if self._snapshot_manager is None or self._initialization_error is not None:
+            raise MemoryStoreUnavailableError("Memory snapshot manager is unavailable")
+        return self._snapshot_manager
+
+    def _require_backup_manager(self) -> MemorySnapshotManager:
+        if self._backup_manager is None or self._initialization_error is not None:
+            raise MemoryStoreUnavailableError("Memory backup manager is unavailable")
+        return self._backup_manager
+
+    @staticmethod
+    async def _run_maintenance_io(
+        operation: Callable[[], _MaintenanceIOResult],
+    ) -> _MaintenanceIOResult:
+        return await run_blocking(operation)
+
+    @staticmethod
+    def _backup_restore_execution_token(
+        operation: BackupRestoreOperation,
+    ) -> str:
+        if operation.execution_token is None:
+            raise RuntimeError("Memory backup restore execution claim is missing")
+        return operation.execution_token
+
+    @staticmethod
+    def _clear_execution_token(operation: ClearOperation) -> str:
+        if operation.execution_token is None:
+            raise RuntimeError("Memory clear operation is not claimed")
+        return operation.execution_token

--- a/core/memory/maintenance.py
+++ b/core/memory/maintenance.py
@@ -742,6 +742,7 @@ class MemoryMaintenance:
         if (
             self._closing
             or state.artifact_installing
+            or self._store is None
             or self._backup_manager is None
             or self._clear_journal is None
             or self._backup_restore_journal is None

--- a/core/memory/runtime.py
+++ b/core/memory/runtime.py
@@ -219,7 +219,7 @@ class MemoryRuntime:
         self._last_health_snapshot: ProviderHealthSnapshot | None = None
         self._last_health_observed_at: str | None = None
         self._maintenance = MemoryMaintenance(
-            store,
+            None,
             effective_home=self._effective_home,
             runtime=self._maintenance_runtime_port(),
         )

--- a/core/memory/runtime.py
+++ b/core/memory/runtime.py
@@ -11,7 +11,8 @@ import stat
 from concurrent.futures import CancelledError as FutureCancelledError
 from concurrent.futures import Future as ThreadFuture
 from concurrent.futures import TimeoutError as FutureTimeoutError
-from collections.abc import Awaitable, Callable, Mapping
+from collections.abc import AsyncIterator, Awaitable, Callable, Mapping
+from contextlib import asynccontextmanager
 from dataclasses import asdict, replace
 from datetime import datetime, timezone
 from pathlib import Path
@@ -27,17 +28,8 @@ from core.memory.artifact import (
     MemoryRuntimeActivationError,
     get_memory_artifact_manager,
 )
-from core.memory.backup_restore_journal import (
-    BackupRestoreConflict,
-    BackupRestoreOperation,
-    MemoryBackupRestoreJournal,
-)
 from core.memory.blocking import run_blocking
-from core.memory.clear_journal import (
-    ClearOperation,
-    ClearSurface,
-    MemoryClearJournal,
-)
+from core.memory.clear_journal import ClearSurface
 from core.memory.everos import (
     EverOSPort,
     MemoryProviderFailure,
@@ -46,6 +38,14 @@ from core.memory.everos import (
 from core.memory.everos_insight import MemoryInsightPaths, MemoryInsightReader
 from core.memory.everos_insight.recorder import clear_call_log, maintain_call_log
 from core.memory.module import MemoryModule
+from core.memory.maintenance import (
+    ClearRecoveryResult,
+    ClearResult,
+    MaintenanceRuntimeState,
+    MemoryMaintenance,
+    MemoryMaintenanceRuntimePort,
+    MemoryStoreUnavailableError,
+)
 from core.memory.process import (
     EverOSProcess,
     EverOSProcessFactory,
@@ -60,7 +60,7 @@ from core.memory.provider_root import (
     ProviderRootRollback,
 )
 from core.memory.store import MemoryStore, is_principal_id, is_project_id
-from core.memory.snapshot import MemorySnapshot, MemorySnapshotManager
+from core.memory.snapshot import MemorySnapshot
 from core.memory.types import (
     MemoryItems,
     MemoryResult,
@@ -76,7 +76,6 @@ from core.memory.worker import ProcessingEvent
 logger = logging.getLogger(__name__)
 
 
-_MaintenanceIOResult = TypeVar("_MaintenanceIOResult")
 _SessionLifecycleResult = TypeVar("_SessionLifecycleResult")
 
 
@@ -90,8 +89,33 @@ def _new_recorder_episode_id() -> str:
     return f"ma_{secrets.token_hex(32)}"
 
 
-class MemoryStoreUnavailableError(RuntimeError):
-    """Raised when the controller cannot safely open the local Memory store."""
+def _clear_recovery_payload(
+    recovery: ClearRecoveryResult | None,
+) -> dict[str, Any] | None:
+    if recovery is None:
+        return None
+    return {
+        "state": recovery.state,
+        "operation_id": recovery.operation_id,
+        "occurred_at": recovery.occurred_at,
+        "error_code": recovery.error_code,
+        "can_resume": recovery.can_resume,
+        "can_abort": recovery.can_abort,
+    }
+
+
+def _clear_result_payload(result: ClearResult) -> dict[str, Any]:
+    if result.status == "failed":
+        return {
+            "status": "failed",
+            "error": result.error,
+            "recovery": _clear_recovery_payload(result.recovery),
+        }
+    return {
+        "status": result.status,
+        "operation_id": result.operation_id,
+        "epoch": result.epoch,
+    }
 
 
 class MemorySessionLifecycleBusyError(RuntimeError):
@@ -156,29 +180,7 @@ class MemoryRuntime:
         self._config = config
         self._restart_config = deepcopy(config)
         self._effective_home = effective_home or paths.get_vibe_remote_dir()
-        self._backup_active = False
-        self._backup_restore_journal: MemoryBackupRestoreJournal | None = None
-        self._clear_journal: MemoryClearJournal | None = None
-        self._snapshot_manager: MemorySnapshotManager | None = None
-        self._backup_manager: MemorySnapshotManager | None = None
-        self._clear_journal_error: Exception | None = None
-        try:
-            self._backup_restore_journal = MemoryBackupRestoreJournal(
-                self._effective_home
-            )
-            self._clear_journal = MemoryClearJournal(self._effective_home)
-            self._snapshot_manager = MemorySnapshotManager(self._effective_home)
-            self._backup_manager = MemorySnapshotManager._for_backup(
-                self._effective_home,
-                operation_guard=self._clear_journal.assert_backup_allowed,
-            )
-            self._backup_restore_journal.mark_boot_recovery_needed()
-            self._clear_journal.mark_boot_recovery_needed()
-        except Exception as exc:
-            self._clear_journal_error = exc
-            logger.exception(
-                "Memory maintenance journal initialization failed; maintenance is fenced"
-            )
+        self._maintenance: MemoryMaintenance | None = None
         self._artifact_manager: MemoryArtifactPort = artifact_manager or get_memory_artifact_manager()
         self._provider_root_owner = ProviderRoot(
             self._provider_root,
@@ -194,8 +196,6 @@ class MemoryRuntime:
         self._reconcile_lock = asyncio.Lock()
         self._restart_task: asyncio.Task[dict[str, Any]] | None = None
         self._ready_activation_task: asyncio.Task[None] | None = None
-        self._terminal_snapshot_gc_task: asyncio.Task[None] | None = None
-        self._backup_stage_reconcile_task: asyncio.Task[None] | None = None
         self._closing = False
         self._ready_event: EverOSProcessPort | None = None
         # Single-flight state for the drain-side processing gate. Deliberately a
@@ -218,6 +218,11 @@ class MemoryRuntime:
         self._recorder_health_episode_id: str | None = None
         self._last_health_snapshot: ProviderHealthSnapshot | None = None
         self._last_health_observed_at: str | None = None
+        self._maintenance = MemoryMaintenance(
+            store,
+            effective_home=self._effective_home,
+            runtime=self._maintenance_runtime_port(),
+        )
         self._open_store(store)
 
     def _open_store(self, store: MemoryStore | None = None) -> bool:
@@ -252,6 +257,7 @@ class MemoryRuntime:
             return False
         self._store = opened
         self._module = module
+        self._require_maintenance().attach_store(opened)
         if self._maintenance_open():
             module._worker.pause_claims()
         self._store_error = None
@@ -295,56 +301,62 @@ class MemoryRuntime:
     def _maintenance_open(self) -> bool:
         """Fail closed when the independent clear authority cannot prove terminal."""
 
-        if self._backup_active:
-            return True
-        restore_journal = self._backup_restore_journal
-        if restore_journal is None:
-            return True
-        try:
-            if restore_journal.get_open_operation() is not None:
-                return True
-        except Exception:
-            return True
-        journal = self._clear_journal
-        if journal is None or self._clear_journal_error is not None:
-            return True
-        try:
-            return journal.get_open_operation() is not None
-        except Exception:
-            return True
+        maintenance = self._maintenance
+        return maintenance is None or maintenance.is_open()
 
     def _can_disable_without_maintenance_authority(self, config: MemoryConfig) -> bool:
         """Allow only a pure disable when the journal authority is unreadable."""
 
         if config.enabled or config != replace(self._config, enabled=False):
             return False
-        restore_journal = self._backup_restore_journal
-        clear_journal = self._clear_journal
-        if (
-            restore_journal is None
-            or clear_journal is None
-            or self._clear_journal_error is not None
-        ):
-            return True
-        try:
-            restore_journal.get_open_operation()
-            clear_journal.get_open_operation()
-        except Exception:
-            return True
-        return False
+        maintenance = self._maintenance
+        return maintenance is None or maintenance.can_disable_without_authority()
 
-    def _clear_capability_ready(self) -> bool:
-        """Whether every local dependency required by Clear initialized."""
-
-        return (
-            self._store is not None
-            and self._module is not None
-            and self._backup_restore_journal is not None
-            and self._clear_journal is not None
-            and self._snapshot_manager is not None
-            and self._backup_manager is not None
-            and self._clear_journal_error is None
+    def _maintenance_runtime_port(self) -> MemoryMaintenanceRuntimePort:
+        return MemoryMaintenanceRuntimePort(
+            exclusive_fence=self._maintenance_fence,
+            boot_recovery_fence=self._maintenance_boot_recovery_fence,
+            state=self._maintenance_runtime_state,
+            enter_maintenance=self._enter_maintenance,
+            leave_maintenance=self._leave_maintenance,
+            pause_claims=self._pause_clear_claims,
+            resume_claims=self._resume_maintenance_claims,
+            quiesce=self._quiesce_for_clear,
+            resume=self._resume_after_clear,
+            delete_surface=self._delete_clear_surface,
         )
+
+    @asynccontextmanager
+    async def _maintenance_fence(self) -> AsyncIterator[None]:
+        """Acquire destructive fences in their single permitted order."""
+
+        async with self._reconcile_lock, self.module._lifecycle_lock:
+            async with self.module._root_lifecycle_lock():
+                yield
+
+    @asynccontextmanager
+    async def _maintenance_boot_recovery_fence(self) -> AsyncIterator[None]:
+        """Add the root fence while reconcile and module fences are already held."""
+
+        async with self.module._root_lifecycle_lock():
+            yield
+
+    def _maintenance_runtime_state(self) -> MaintenanceRuntimeState:
+        return MaintenanceRuntimeState(
+            artifact_installing=self._artifact_installing,
+        )
+
+    def _enter_maintenance(self) -> None:
+        if self._module is not None:
+            self._module._clear_active = True
+
+    def _leave_maintenance(self) -> None:
+        if self._module is not None:
+            self._module._clear_active = False
+
+    def _resume_maintenance_claims(self) -> None:
+        if self._module is not None:
+            self._module._worker.resume_claims()
 
     def _configure_insight_reader(self, config: MemoryConfig) -> None:
         if self._insight_reader_override is not None:
@@ -438,8 +450,8 @@ class MemoryRuntime:
         try:
             return await self._reconcile(config)
         finally:
-            self._ensure_terminal_snapshot_gc()
-            self._ensure_backup_stage_reconcile()
+            if self._maintenance is not None:
+                self._maintenance.ensure_housekeeping()
 
     async def _reconcile(self, config: MemoryConfig) -> dict[str, Any]:
         """Run one reconciliation owned by the public lifecycle operation."""
@@ -474,17 +486,20 @@ class MemoryRuntime:
             # save cannot race a root wipe or replace sidecar credentials halfway
             # through an active provider call.
             async with self.module._lifecycle_lock:
-                restore_operation = self._open_backup_restore_operation()
+                restore_operation_open = (
+                    self._maintenance is not None
+                    and self._maintenance.has_open_restore()
+                )
                 maintenance_open = self._maintenance_open()
                 if (
                     maintenance_open
                     and self._can_disable_without_maintenance_authority(config)
                 ):
                     result = await self._disable_locked(config)
-                elif restore_operation is not None and not recorded_sidecar_reaped:
+                elif restore_operation_open and not recorded_sidecar_reaped:
                     self.module._worker.pause_claims()
                     return {"ok": False, "error": "memory_clear_failed"}
-                elif maintenance_open and restore_operation is None:
+                elif maintenance_open and not restore_operation_open:
                     self.module._worker.pause_claims()
                     return {"ok": False, "error": "memory_clear_failed"}
                 else:
@@ -523,8 +538,8 @@ class MemoryRuntime:
     ) -> dict[str, Any]:
         """Reconcile while both controller and module lifecycle locks are held."""
 
-        if self._open_backup_restore_operation() is not None:
-            recovered = await self._recover_backup_restore_locked()
+        if self._maintenance is not None and self._maintenance.has_open_restore():
+            recovered = await self._maintenance.recover_boot()
             if not recovered:
                 self.module._worker.pause_claims()
                 self._runtime_error = "memory_clear_failed"
@@ -845,32 +860,13 @@ class MemoryRuntime:
                     operator_ref=operator_ref
                 ),
             }
-        try:
-            meta, history, manual_required = await asyncio.gather(
-                asyncio.to_thread(self._store.get_meta),
-                asyncio.to_thread(self._store.has_provider_data_history),
-                asyncio.to_thread(self._store.has_manual_required_fence),
-            )
-        except Exception:
-            return {
-                "status": "ok",
-                "data_exists": True,
-                "can_clear": False,
-                "clear_recovery": self._clear_recovery_payload(
-                    operator_ref=operator_ref
-                ),
-            }
-        recovery = self._clear_recovery_payload(operator_ref=operator_ref)
+        maintenance = self._require_maintenance()
+        result = await maintenance.maintenance_payload(operator_ref=operator_ref)
         return {
             "status": "ok",
-            "data_exists": bool(history or (meta is not None and meta.last_success_at)),
-            "can_clear": (
-                self._clear_capability_ready()
-                and not self._maintenance_open()
-                and not manual_required
-                and recovery is None
-            ),
-            "clear_recovery": recovery,
+            "data_exists": result.data_exists,
+            "can_clear": result.can_clear,
+            "clear_recovery": _clear_recovery_payload(result.clear_recovery),
         }
 
     def principal_for_user_key(self, user_key: str) -> str:
@@ -1175,9 +1171,9 @@ class MemoryRuntime:
     async def create_backup(self, backup_id: str | None = None) -> MemorySnapshot:
         """Create one ordinary Memory backup under the full maintenance fence."""
 
-        return await self._run_backup_operation(
-            lambda manager: manager.create(backup_id),
-        )
+        if not self.available:
+            raise self._unavailable()
+        return await self._require_maintenance().create_backup(backup_id)
 
     async def restore_backup(
         self,
@@ -1190,346 +1186,72 @@ class MemoryRuntime:
 
         if not self.available:
             raise self._unavailable()
-        clear_journal = self._require_clear_journal()
-        restore_journal = self._require_backup_restore_journal()
-        manager = self._require_backup_manager()
-        async with self._reconcile_lock, self.module._lifecycle_lock:
-            async with self.module._root_lifecycle_lock():
-                clear_journal.assert_backup_allowed()
-                operation = restore_journal.get_open_operation()
-                if operation is not None:
-                    if (
-                        operation.state != "recovery_needed"
-                        or operation.backup_id != backup_id
-                        or operation.manifest_sha256 != expected_manifest_sha256
-                        or operation.digest_mapping() != dict(expected_surface_digests)
-                    ):
-                        raise BackupRestoreConflict(
-                            "a different Memory backup restore owns the recovery fence"
-                        )
-                self._backup_active = True
-                self.module._clear_active = True
-                try:
-                    await self._quiesce_for_clear()
-                    if operation is not None:
-                        operation = await self._run_maintenance_io(
-                            lambda: restore_journal.claim_retry(
-                                operation.operation_id,
-                                expected_revision=operation.revision,
-                                actor_ref="system:runtime",
-                            )
-                        )
-
-                    def begin_restore(snapshot: MemorySnapshot) -> None:
-                        nonlocal operation
-                        operation = restore_journal.start(snapshot)
-
-                    restored = await self._run_maintenance_io(
-                        lambda: manager.restore(
-                            backup_id,
-                            expected_manifest_sha256=expected_manifest_sha256,
-                            expected_surface_digests=expected_surface_digests,
-                            before_replace=None if operation is not None else begin_restore,
-                        )
-                    )
-                    if operation is None:
-                        raise RuntimeError("Memory backup restore intent was not recorded")
-                    operation = await self._run_maintenance_io(
-                        lambda: restore_journal.mark_completed(
-                            operation.operation_id,
-                            expected_revision=operation.revision,
-                            execution_token=self._backup_restore_execution_token(operation),
-                        )
-                    )
-                    return restored
-                except BaseException:
-                    await self._mark_backup_restore_recovery(operation)
-                    raise
-                finally:
-                    self._backup_active = False
-                    try:
-                        if restore_journal.get_open_operation() is None:
-                            await self._resume_after_clear()
-                    finally:
-                        self.module._clear_active = False
-
-    async def _run_backup_operation(
-        self,
-        operation: Callable[[MemorySnapshotManager], MemorySnapshot],
-    ) -> MemorySnapshot:
-        if not self.available:
-            raise self._unavailable()
-        journal = self._require_clear_journal()
-        restore_journal = self._require_backup_restore_journal()
-        manager = self._require_backup_manager()
-        async with self._reconcile_lock, self.module._lifecycle_lock:
-            async with self.module._root_lifecycle_lock():
-                journal.assert_backup_allowed()
-                restore_journal.assert_idle()
-                self._backup_active = True
-                self.module._clear_active = True
-                try:
-                    await self._quiesce_for_clear()
-                    return await self._run_maintenance_io(lambda: operation(manager))
-                finally:
-                    self._backup_active = False
-                    try:
-                        await self._resume_after_clear()
-                    finally:
-                        self.module._clear_active = False
-
-    @staticmethod
-    async def _run_maintenance_io(
-        operation: Callable[[], _MaintenanceIOResult],
-    ) -> _MaintenanceIOResult:
-        """Keep the maintenance fence until a cancelled I/O thread settles."""
-
-        return await run_blocking(operation)
+        return await self._require_maintenance().restore_backup(
+            backup_id,
+            expected_manifest_sha256=expected_manifest_sha256,
+            expected_surface_digests=expected_surface_digests,
+        )
 
     async def clear(self, *, operator_ref: str) -> dict[str, Any]:
         if not self.available:
             raise self._unavailable()
-        journal = self._require_clear_journal()
-        async with self._reconcile_lock, self.module._lifecycle_lock:
-            async with self.module._root_lifecycle_lock():
-                if journal.get_open_operation() is not None:
-                    return self._clear_blocked_payload(operator_ref=operator_ref)
-                operation: ClearOperation | None = None
-                self.module._clear_active = True
-                try:
-                    try:
-                        await self._pause_clear_claims()
-                        manual_required = await self._run_maintenance_io(
-                            self._store.has_manual_required_fence
-                        )
-                    except BaseException as error:
-                        self.module._clear_active = False
-                        self.module._worker.resume_claims()
-                        if isinstance(error, asyncio.CancelledError):
-                            raise
-                        return self._clear_blocked_payload(operator_ref=operator_ref)
-                    if manual_required:
-                        self.module._clear_active = False
-                        self.module._worker.resume_claims()
-                        return self._clear_blocked_payload(operator_ref=operator_ref)
-                    try:
-                        meta = await self._run_maintenance_io(self._store.ensure_meta)
-                        operation = await self._run_maintenance_io(
-                            lambda: journal.start(
-                                operator_ref=operator_ref,
-                                pre_epoch=meta.epoch,
-                                target_epoch=meta.epoch + 1,
-                            )
-                        )
-                        await self._run_maintenance_io(self._store.begin_clear_fence)
-                        operation = await self._prepare_clear(
-                            operation,
-                            claims_already_paused=True,
-                        )
-                        operation = await self._delete_clear_surfaces(operation)
-                    except BaseException as error:
-                        current = await self._mark_clear_recovery(operation)
-                        if current is not None and current.state == "completed":
-                            self.module._clear_active = False
-                            await self._finish_clear(current)
-                        elif current is None:
-                            self.module._clear_active = False
-                            self.module._worker.resume_claims()
-                        if isinstance(error, asyncio.CancelledError):
-                            raise
-                        return self._clear_blocked_payload(operator_ref=operator_ref)
-                finally:
-                    self.module._clear_active = False
-                if operation is None:
-                    raise RuntimeError("Memory clear operation did not start")
-                return await self._finish_clear(operation)
+        result = await self._require_maintenance().clear(operator_ref=operator_ref)
+        return _clear_result_payload(result)
 
-    async def resume_clear(self, operation_id: str, *, operator_ref: str) -> dict[str, Any]:
-        """Explicitly continue the exact clear stage recorded by the journal."""
-
-        if not self.available:
-            raise self._unavailable()
-        journal = self._require_clear_journal()
-        async with self._reconcile_lock, self.module._lifecycle_lock:
-            async with self.module._root_lifecycle_lock():
-                current = journal.get_open_operation()
-                if current is None or current.operation_id != operation_id:
-                    return self._clear_blocked_payload(operator_ref=operator_ref)
-                try:
-                    operation = await self._run_maintenance_io(
-                        lambda: journal.claim_resume(
-                            operation_id,
-                            operator_ref=operator_ref,
-                            expected_revision=current.revision,
-                        )
-                    )
-                    await self._run_maintenance_io(self._store.begin_clear_fence)
-                    operation = await self._prepare_clear(operation)
-                    operation = await self._delete_clear_surfaces(operation)
-                except BaseException as error:
-                    recovered = await self._mark_clear_recovery(
-                        operation_id=operation_id
-                    )
-                    if recovered is not None and recovered.state == "completed":
-                        await self._finish_clear(recovered)
-                    if isinstance(error, asyncio.CancelledError):
-                        raise
-                    return self._clear_blocked_payload(operator_ref=operator_ref)
-                return await self._finish_clear(operation)
-
-    async def abort_clear(self, operation_id: str, *, operator_ref: str) -> dict[str, Any]:
-        """Restore all four verified surfaces, then release the admission fence."""
-
-        if not self.available:
-            raise self._unavailable()
-        journal = self._require_clear_journal()
-        manager = self._require_snapshot_manager()
-        async with self._reconcile_lock, self.module._lifecycle_lock:
-            async with self.module._root_lifecycle_lock():
-                current = journal.get_open_operation()
-                if current is None or current.operation_id != operation_id:
-                    return self._clear_blocked_payload(operator_ref=operator_ref)
-                try:
-                    operation = await self._run_maintenance_io(
-                        lambda: journal.claim_abort(
-                            operation_id,
-                            operator_ref=operator_ref,
-                            expected_revision=current.revision,
-                        )
-                    )
-                    await self._quiesce_for_clear()
-                    digests = self._journal_surface_digests(operation.operation_id)
-                    if operation.manifest_sha256 is None or operation.snapshot_path is None:
-                        raise RuntimeError("clear snapshot is not sealed")
-                    await self._run_maintenance_io(
-                        lambda: manager.restore(
-                            operation.operation_id,
-                            expected_manifest_sha256=operation.manifest_sha256,
-                            expected_surface_digests=digests,
-                        )
-                    )
-                    await self._run_maintenance_io(self._store.release_clear_fence)
-                    for surface in journal.get_surfaces(operation.operation_id):
-                        if surface.state == "restored":
-                            continue
-                        operation = await self._run_maintenance_io(
-                            lambda: journal.record_surface_restored(
-                                operation.operation_id,
-                                surface.surface,
-                                expected_revision=operation.revision,
-                                execution_token=self._clear_execution_token(operation),
-                            )
-                        )
-                    operation = await self._run_maintenance_io(
-                        lambda: journal.mark_aborted(
-                            operation.operation_id,
-                            expected_revision=operation.revision,
-                            execution_token=self._clear_execution_token(operation),
-                        )
-                    )
-                except BaseException as error:
-                    recovered = await self._mark_clear_recovery(
-                        operation_id=operation_id
-                    )
-                    if recovered is not None and recovered.state == "aborted":
-                        await self._finish_aborted_clear(recovered)
-                    if isinstance(error, asyncio.CancelledError):
-                        raise
-                    return self._clear_blocked_payload(operator_ref=operator_ref)
-                return await self._finish_aborted_clear(operation)
-
-    async def _prepare_clear(
+    async def resume_clear(
         self,
-        operation: ClearOperation,
+        operation_id: str,
         *,
-        claims_already_paused: bool = False,
-    ) -> ClearOperation:
-        journal = self._require_clear_journal()
-        manager = self._require_snapshot_manager()
-        await self._quiesce_for_clear(
-            claims_already_paused=claims_already_paused,
+        operator_ref: str,
+    ) -> dict[str, Any]:
+        if not self.available:
+            raise self._unavailable()
+        result = await self._require_maintenance().resume_clear(
+            operation_id,
+            operator_ref=operator_ref,
         )
-        if operation.state == "preparing":
-            if operation.snapshot_path is None or operation.manifest_sha256 is None:
-                if operation.resolution == "resume":
-                    with journal.authorize_preparing_snapshot_discard(
-                        operation.operation_id,
-                        expected_revision=operation.revision,
-                        execution_token=self._clear_execution_token(operation),
-                    ) as permit:
-                        await self._run_maintenance_io(
-                            lambda: manager.discard_unrecorded(permit)
-                        )
-                    refreshed = journal.get_operation(operation.operation_id)
-                    if refreshed is None:
-                        raise RuntimeError("Memory clear operation disappeared")
-                    operation = refreshed
-                snapshot = await self._run_maintenance_io(
-                    lambda: manager.create(operation.operation_id)
-                )
-                operation = await self._run_maintenance_io(
-                    lambda: journal.record_snapshot(
-                        operation.operation_id,
-                        expected_revision=operation.revision,
-                        execution_token=self._clear_execution_token(operation),
-                        snapshot=snapshot,
-                    )
-                )
-            else:
-                await self._verify_clear_snapshot(operation)
-            operation = await self._run_maintenance_io(
-                lambda: journal.mark_prepared(
-                    operation.operation_id,
-                    expected_revision=operation.revision,
-                    execution_token=self._clear_execution_token(operation),
-                )
-            )
-        if operation.state == "prepared":
-            await self._verify_clear_snapshot(operation)
-        return operation
+        return _clear_result_payload(result)
 
-    async def _delete_clear_surfaces(self, operation: ClearOperation) -> ClearOperation:
-        journal = self._require_clear_journal()
-        if operation.state == "prepared":
-            operation = await self._run_maintenance_io(
-                lambda: journal.begin_deleting(
-                    operation.operation_id,
-                    expected_revision=operation.revision,
-                    execution_token=self._clear_execution_token(operation),
-                )
-            )
-        if operation.state != "deleting":
-            raise RuntimeError("clear operation is not ready for deletion")
-        await self._verify_clear_snapshot(operation)
-        for surface in journal.get_surfaces(operation.operation_id):
-            if surface.state == "deleted":
-                continue
-            await self._delete_clear_surface(surface, target_epoch=operation.target_epoch)
-            operation = await self._run_maintenance_io(
-                lambda: journal.record_surface_deleted(
-                    operation.operation_id,
-                    surface.surface,
-                    expected_revision=operation.revision,
-                    execution_token=self._clear_execution_token(operation),
-                )
-            )
-        return await self._run_maintenance_io(
-            lambda: journal.mark_completed(
-                operation.operation_id,
-                expected_revision=operation.revision,
-                execution_token=self._clear_execution_token(operation),
-            )
+    async def abort_clear(
+        self,
+        operation_id: str,
+        *,
+        operator_ref: str,
+    ) -> dict[str, Any]:
+        if not self.available:
+            raise self._unavailable()
+        result = await self._require_maintenance().abort_clear(
+            operation_id,
+            operator_ref=operator_ref,
         )
+        return _clear_result_payload(result)
+
+    async def _pause_clear_claims(self) -> None:
+        if not await self.module._worker.pause_and_wait(
+            timeout_seconds=self.module._clear_drain_timeout_seconds
+        ):
+            raise RuntimeError("Memory worker did not quiesce before clear")
+
+    async def _quiesce_for_clear(self, claims_already_paused: bool = False) -> None:
+        if not claims_already_paused:
+            await self._pause_clear_claims()
+        await self._stop_worker()
+        if self._process is not None:
+            await self._process.stop()
+            self._process = None
+        self._process_records_calls = False
+        await self._stop_call_log_retention()
+        self._set_recorder_health_disabled()
 
     async def _delete_clear_surface(
         self,
         surface: ClearSurface,
-        *,
         target_epoch: int,
     ) -> None:
         if surface.surface == "queue":
-            await self._run_maintenance_io(
-                lambda: self._store.reset_for_clear(target_epoch=target_epoch)
+            await run_blocking(
+                self._store.reset_for_clear,
+                target_epoch=target_epoch,
             )
             return
         if surface.surface == "provider":
@@ -1547,365 +1269,16 @@ class MemoryRuntime:
                         self._active_provider_root_metadata(),
                     )
 
-            await self._run_maintenance_io(reset_provider_root)
+            await run_blocking(reset_provider_root)
             return
         if surface.surface == "call_log":
-            await self._run_maintenance_io(
-                lambda: clear_call_log(self._call_log_db_path)
-            )
+            await run_blocking(clear_call_log, self._call_log_db_path)
             self._set_recorder_health_disabled()
             return
         if surface.surface == "attachments":
-            await self._run_maintenance_io(
-                self.module._attachment_store.clear_all
-            )
+            await run_blocking(self.module._attachment_store.clear_all)
             return
         raise RuntimeError("unknown Memory clear surface")
-
-    async def _verify_clear_snapshot(self, operation: ClearOperation) -> MemorySnapshot:
-        if operation.manifest_sha256 is None or operation.snapshot_path is None:
-            raise RuntimeError("clear snapshot is not sealed")
-        return await self._run_maintenance_io(
-            lambda: self._require_snapshot_manager().verify(
-                operation.operation_id,
-                expected_manifest_sha256=operation.manifest_sha256,
-                expected_surface_digests=self._journal_surface_digests(
-                    operation.operation_id
-                ),
-            )
-        )
-
-    async def _pause_clear_claims(self) -> None:
-        if not await self.module._worker.pause_and_wait(
-            timeout_seconds=self.module._clear_drain_timeout_seconds
-        ):
-            raise RuntimeError("Memory worker did not quiesce before clear")
-
-    async def _quiesce_for_clear(self, *, claims_already_paused: bool = False) -> None:
-        if not claims_already_paused:
-            await self._pause_clear_claims()
-        await self._stop_worker()
-        if self._process is not None:
-            await self._process.stop()
-            self._process = None
-        self._process_records_calls = False
-        await self._stop_call_log_retention()
-        self._set_recorder_health_disabled()
-
-    async def _recover_backup_restore_locked(self) -> bool:
-        """Converge an interrupted restore before any boot-time activation."""
-
-        journal = self._require_backup_restore_journal()
-        operation = journal.get_open_operation()
-        if operation is None:
-            return True
-        if operation.state != "recovery_needed":
-            return False
-        manager = self._require_backup_manager()
-        self._backup_active = True
-        self.module._clear_active = True
-        try:
-            async with self.module._root_lifecycle_lock():
-                await self._quiesce_for_clear()
-                operation = await self._run_maintenance_io(
-                    lambda: journal.claim_retry(
-                        operation.operation_id,
-                        expected_revision=operation.revision,
-                        actor_ref="system:boot",
-                    )
-                )
-                await self._run_maintenance_io(
-                    lambda: manager.restore(
-                        operation.backup_id,
-                        expected_manifest_sha256=operation.manifest_sha256,
-                        expected_surface_digests=operation.digest_mapping(),
-                    )
-                )
-                await self._run_maintenance_io(
-                    lambda: journal.mark_completed(
-                        operation.operation_id,
-                        expected_revision=operation.revision,
-                        execution_token=self._backup_restore_execution_token(operation),
-                        actor_ref="system:boot",
-                    )
-                )
-            return True
-        except asyncio.CancelledError:
-            await self._mark_backup_restore_recovery(operation)
-            raise
-        except Exception:
-            await self._mark_backup_restore_recovery(operation)
-            return False
-        finally:
-            self._backup_active = False
-            self.module._clear_active = False
-
-    async def _mark_backup_restore_recovery(
-        self,
-        operation: BackupRestoreOperation | None,
-    ) -> BackupRestoreOperation | None:
-        journal = self._backup_restore_journal
-        if journal is None or operation is None:
-            return None
-        try:
-            current = journal.get_operation(operation.operation_id)
-            if current is None or current.state != "restoring":
-                return current
-            return await self._run_maintenance_io(
-                lambda: journal.mark_recovery_needed(
-                    current.operation_id,
-                    expected_revision=current.revision,
-                    execution_token=self._backup_restore_execution_token(current),
-                )
-            )
-        except Exception:
-            logger.exception("Memory backup restore failure could not be journaled")
-            return None
-
-    async def _mark_clear_recovery(
-        self,
-        operation: ClearOperation | None = None,
-        *,
-        operation_id: str | None = None,
-    ) -> ClearOperation | None:
-        journal = self._clear_journal
-        if journal is None:
-            return None
-
-        def mark_recovery() -> ClearOperation | None:
-            identifier = operation.operation_id if operation is not None else operation_id
-            current = (
-                journal.get_open_operation()
-                if identifier is None
-                else journal.get_operation(identifier)
-            )
-            if current is None:
-                return None
-            if current.state in {"preparing", "prepared", "deleting"}:
-                return journal.mark_recovery_needed(
-                    current.operation_id,
-                    expected_revision=current.revision,
-                    execution_token=self._clear_execution_token(current),
-                )
-            if current.state == "recovery_needed" and current.execution_token is not None:
-                return journal.release_recovery_claim(
-                    current.operation_id,
-                    expected_revision=current.revision,
-                    execution_token=self._clear_execution_token(current),
-                )
-            return current
-
-        try:
-            return await self._run_maintenance_io(mark_recovery)
-        except Exception:
-            logger.exception("Memory clear failure could not be journaled")
-            return None
-
-    async def _finish_clear(self, operation: ClearOperation) -> dict[str, Any]:
-        try:
-            await self._run_maintenance_io(self._reconcile_terminal_clear_snapshots)
-        finally:
-            await self._resume_after_clear()
-        return {
-            "status": "completed",
-            "operation_id": operation.operation_id,
-            "epoch": operation.target_epoch,
-        }
-
-    async def _finish_aborted_clear(self, operation: ClearOperation) -> dict[str, Any]:
-        try:
-            await self._run_maintenance_io(self._reconcile_terminal_clear_snapshots)
-        finally:
-            await self._resume_after_clear()
-        return {
-            "status": "aborted",
-            "operation_id": operation.operation_id,
-            "epoch": operation.pre_epoch,
-        }
-
-    def _reconcile_terminal_clear_snapshots(self) -> None:
-        """Retry GC whose durable terminal transition preceded snapshot removal."""
-
-        journal = self._require_clear_journal()
-        manager = self._require_snapshot_manager()
-        for permit in journal.terminal_snapshot_permits():
-            try:
-                manager.remove(permit)
-            except Exception:
-                logger.warning(
-                    "Terminal Memory clear snapshot %s could not be removed",
-                    permit.snapshot_id,
-                    exc_info=True,
-                )
-
-    def _ensure_terminal_snapshot_gc(self) -> None:
-        """Schedule one runtime-owned retry after activation has returned."""
-
-        task = self._terminal_snapshot_gc_task
-        if (
-            self._closing
-            or self._artifact_installing
-            or self._clear_journal is None
-            or self._snapshot_manager is None
-            or self._clear_journal_error is not None
-            or (task is not None and not task.done())
-        ):
-            return
-        task = asyncio.create_task(
-            self._run_terminal_snapshot_gc(),
-            name="memory-terminal-snapshot-gc",
-        )
-        self._terminal_snapshot_gc_task = task
-
-        def clear_gc(completed: asyncio.Task[None]) -> None:
-            if self._terminal_snapshot_gc_task is completed:
-                self._terminal_snapshot_gc_task = None
-
-        task.add_done_callback(clear_gc)
-
-    def _ensure_backup_stage_reconcile(self) -> None:
-        """Schedule cleanup of auto-ID backup stages after lifecycle reconcile."""
-
-        task = self._backup_stage_reconcile_task
-        if (
-            self._closing
-            or self._artifact_installing
-            or not self.available
-            or self._backup_manager is None
-            or self._clear_journal is None
-            or self._backup_restore_journal is None
-            or self._clear_journal_error is not None
-            or (task is not None and not task.done())
-        ):
-            return
-        task = asyncio.create_task(
-            self._run_backup_stage_reconcile(),
-            name="memory-backup-stage-reconcile",
-        )
-        self._backup_stage_reconcile_task = task
-
-        def clear_reconcile(completed: asyncio.Task[None]) -> None:
-            if self._backup_stage_reconcile_task is completed:
-                self._backup_stage_reconcile_task = None
-
-        task.add_done_callback(clear_reconcile)
-
-    async def _run_backup_stage_reconcile(self) -> None:
-        """Remove abandoned unpublished stages under lifecycle serialization."""
-
-        # Both jobs reopen the clear journal, whose transient SQLite sidecars
-        # must not be inspected while the preceding terminal GC is settling.
-        terminal_gc = self._terminal_snapshot_gc_task
-        if terminal_gc is not None and terminal_gc is not asyncio.current_task():
-            await asyncio.shield(terminal_gc)
-        journal = self._require_clear_journal()
-        restore_journal = self._require_backup_restore_journal()
-        manager = self._require_backup_manager()
-        try:
-            async with self._reconcile_lock, self.module._lifecycle_lock:
-                async with self.module._root_lifecycle_lock():
-                    if self._artifact_installing:
-                        return
-                    journal.assert_backup_allowed()
-                    restore_journal.assert_idle()
-                    await self._run_maintenance_io(
-                        manager.reconcile_unpublished_backup_stages
-                    )
-        except asyncio.CancelledError:
-            raise
-        except Exception:
-            logger.warning(
-                "Unpublished Memory backup stages could not be reconciled",
-                exc_info=True,
-            )
-
-    async def _stop_backup_stage_reconcile(self) -> None:
-        """Cancel stage cleanup and wait until its current filesystem I/O settles."""
-
-        task = self._backup_stage_reconcile_task
-        if task is None or task is asyncio.current_task():
-            return
-        task.cancel()
-        settlement = asyncio.gather(task, return_exceptions=True)
-        caller_cancellation: asyncio.CancelledError | None = None
-        while not settlement.done():
-            try:
-                await asyncio.shield(settlement)
-            except asyncio.CancelledError as error:
-                caller_cancellation = caller_cancellation or error
-        try:
-            result = settlement.result()[0]
-        finally:
-            if self._backup_stage_reconcile_task is task:
-                self._backup_stage_reconcile_task = None
-        if isinstance(result, BaseException) and not isinstance(
-            result,
-            asyncio.CancelledError,
-        ):
-            raise result
-        if caller_cancellation is not None:
-            raise caller_cancellation
-
-    async def _run_terminal_snapshot_gc(self) -> None:
-        """Remove terminal snapshots without occupying the activation path."""
-
-        journal = self._require_clear_journal()
-        manager = self._require_snapshot_manager()
-        try:
-            permits = await self._run_maintenance_io(
-                journal.terminal_snapshot_permits
-            )
-        except asyncio.CancelledError:
-            raise
-        except Exception:
-            logger.warning(
-                "Terminal Memory clear snapshot permits could not be loaded",
-                exc_info=True,
-            )
-            return
-        for permit in permits:
-            try:
-                # A cancellation settles the current filesystem operation but
-                # stops before the next permit. Remaining permits stay durable
-                # for the next reconcile or restart.
-                await self._run_maintenance_io(
-                    lambda permit=permit: manager.remove(permit)
-                )
-            except asyncio.CancelledError:
-                raise
-            except Exception:
-                logger.warning(
-                    "Terminal Memory clear snapshot %s could not be removed",
-                    permit.snapshot_id,
-                    exc_info=True,
-                )
-
-    async def _stop_terminal_snapshot_gc(self) -> None:
-        """Cancel GC and retain ownership until its current I/O call settles."""
-
-        task = self._terminal_snapshot_gc_task
-        if task is None or task is asyncio.current_task():
-            return
-        task.cancel()
-        settlement = asyncio.gather(task, return_exceptions=True)
-        caller_cancellation: asyncio.CancelledError | None = None
-        while not settlement.done():
-            try:
-                await asyncio.shield(settlement)
-            except asyncio.CancelledError as error:
-                caller_cancellation = caller_cancellation or error
-        try:
-            result = settlement.result()[0]
-        finally:
-            if self._terminal_snapshot_gc_task is task:
-                self._terminal_snapshot_gc_task = None
-        if isinstance(result, BaseException) and not isinstance(
-            result,
-            asyncio.CancelledError,
-        ):
-            raise result
-        if caller_cancellation is not None:
-            raise caller_cancellation
 
     async def _resume_after_clear(self) -> None:
         """Keep lifecycle ownership until runtime reconciliation settles."""
@@ -1943,107 +1316,24 @@ class MemoryRuntime:
         else:
             self._runtime_error = "memory_sidecar_unavailable"
 
-    def _open_backup_restore_operation(self) -> BackupRestoreOperation | None:
-        journal = self._backup_restore_journal
-        if journal is None:
-            return None
-        try:
-            return journal.get_open_operation()
-        except Exception:
-            return None
-
-    def _open_clear_operation(self) -> ClearOperation | None:
-        journal = self._clear_journal
-        if journal is None:
-            return None
-        try:
-            return journal.get_open_operation()
-        except Exception:
-            return None
-
     def _clear_recovery_payload(
         self,
         *,
         operator_ref: str | None = None,
     ) -> dict[str, Any] | None:
-        operation = self._open_clear_operation()
-        if operation is None:
-            return None
-        can_resume = False
-        can_abort = False
-        try:
-            if operator_ref is not None and operation.operator_ref == operator_ref:
-                journal = self._require_clear_journal()
-                can_resume = journal.can_resume(operation.operation_id)
-                can_abort = journal.can_abort(operation.operation_id)
-        except Exception:
-            pass
-        return {
-            "state": operation.state,
-            "operation_id": operation.operation_id,
-            "occurred_at": operation.updated_at,
-            "error_code": operation.closed_error,
-            "can_resume": can_resume,
-            "can_abort": can_abort,
-        }
+        maintenance = self._maintenance
+        recovery = (
+            None
+            if maintenance is None
+            else maintenance.recovery(operator_ref=operator_ref)
+        )
+        return _clear_recovery_payload(recovery)
 
-    def _clear_blocked_payload(
-        self,
-        *,
-        operator_ref: str | None = None,
-    ) -> dict[str, Any]:
-        return {
-            "status": "failed",
-            "error": "memory_clear_failed",
-            "recovery": self._clear_recovery_payload(operator_ref=operator_ref),
-        }
-
-    def _journal_surface_digests(self, operation_id: str) -> dict[str, str | None]:
-        journal = self._require_clear_journal()
-        return {
-            surface.relative_path: surface.snapshot_digest
-            for surface in journal.get_surfaces(operation_id)
-        }
-
-    def _require_clear_journal(self) -> MemoryClearJournal:
-        if self._clear_journal is None or self._clear_journal_error is not None:
-            raise MemoryStoreUnavailableError("Memory clear journal is unavailable")
-        return self._clear_journal
-
-    def _require_backup_restore_journal(self) -> MemoryBackupRestoreJournal:
-        if (
-            self._backup_restore_journal is None
-            or self._clear_journal_error is not None
-        ):
-            raise MemoryStoreUnavailableError(
-                "Memory backup restore journal is unavailable"
-            )
-        return self._backup_restore_journal
-
-    def _require_snapshot_manager(self) -> MemorySnapshotManager:
-        if self._snapshot_manager is None or self._clear_journal_error is not None:
-            raise MemoryStoreUnavailableError("Memory snapshot manager is unavailable")
-        return self._snapshot_manager
-
-    def _require_backup_manager(self) -> MemorySnapshotManager:
-        if self._backup_manager is None or self._clear_journal_error is not None:
-            raise MemoryStoreUnavailableError("Memory backup manager is unavailable")
-        return self._backup_manager
-
-    @staticmethod
-    def _backup_restore_execution_token(
-        operation: BackupRestoreOperation,
-    ) -> str:
-        if operation.execution_token is None:
-            raise RuntimeError("Memory backup restore execution claim is missing")
-        return operation.execution_token
-
-    @staticmethod
-    def _clear_execution_token(operation: ClearOperation) -> str:
-        if operation.execution_token is None:
-            raise RuntimeError("Memory clear operation is not claimed")
-        return operation.execution_token
-
+    def _require_maintenance(self) -> MemoryMaintenance:
+        maintenance = self._maintenance
+        if maintenance is None:
+            raise self._unavailable()
+        return maintenance
     async def install_artifact(self) -> dict[str, Any]:
         """Install or repair EverOS through this controller-owned lifecycle."""
 
@@ -2137,8 +1427,8 @@ class MemoryRuntime:
                         self._artifact_installing = False
                 except asyncio.CancelledError as error:
                     cancellation = cancellation or error
-            self._ensure_terminal_snapshot_gc()
-            self._ensure_backup_stage_reconcile()
+            if self._maintenance is not None:
+                self._maintenance.ensure_housekeeping()
         if cancellation is not None:
             raise cancellation
         if ensure_failed:
@@ -2184,8 +1474,8 @@ class MemoryRuntime:
             logger.exception("Memory sidecar restart failed")
             return {"ok": False, "error": "memory_restart_failed"}
         finally:
-            self._ensure_terminal_snapshot_gc()
-            self._ensure_backup_stage_reconcile()
+            if self._maintenance is not None:
+                self._maintenance.ensure_housekeeping()
 
     async def _restart_locked(self) -> dict[str, Any]:
         """Replace the sidecar while ``_reconcile_lock`` is held."""
@@ -2320,7 +1610,8 @@ class MemoryRuntime:
 
     async def close(self) -> None:
         self._closing = True
-        await self._stop_backup_stage_reconcile()
+        if self._maintenance is not None:
+            await self._maintenance.close()
         restart_task = self._restart_task
         if restart_task is not None and restart_task is not asyncio.current_task():
             try:
@@ -2353,7 +1644,6 @@ class MemoryRuntime:
         self._process_records_calls = False
         await self._stop_call_log_retention()
         self._artifact_manager.set_activation_coordinator(None)
-        await self._stop_terminal_snapshot_gc()
 
     def _active_provider_root_metadata(self) -> ProviderRootMetadata:
         provider_root_format = (

--- a/tests/test_memory_maintenance.py
+++ b/tests/test_memory_maintenance.py
@@ -6,6 +6,7 @@ import os
 import sqlite3
 import stat
 import sys
+from dataclasses import replace
 from datetime import UTC, datetime
 from pathlib import Path
 import threading
@@ -14,7 +15,14 @@ import pytest
 
 import core.memory.snapshot as snapshot_module
 from config.v2_config import MemoryConfig
+from core.memory.artifact import FakeMemoryArtifactManager
+from core.memory.clear_journal import MemoryClearJournal
 from core.memory.process import SidecarOwnership
+from core.memory.maintenance import (
+    ClearRecoveryResult,
+    ClearResult,
+    MemoryMaintenance,
+)
 from core.memory.runtime import MemoryRuntime
 from core.memory.snapshot import MemorySnapshotManager
 from core.memory.store import AmbiguousAdd, Delivered
@@ -23,6 +31,126 @@ from core.memory.types import CaptureAccepted, CaptureRequest, CaptureSkipped
 
 PRINCIPAL = "u-11111111111111111111111111111111"
 PROJECT = "p-22222222222222222222222222222222"
+
+
+def _maintenance(runtime: MemoryRuntime) -> MemoryMaintenance:
+    maintenance = runtime._maintenance
+    assert maintenance is not None
+    return maintenance
+
+
+def _replace_runtime_port(runtime: MemoryRuntime, **changes) -> None:
+    maintenance = _maintenance(runtime)
+    maintenance._runtime = replace(maintenance._runtime, **changes)
+
+
+def _clear_payload(result: ClearResult) -> dict:
+    if result.status == "failed":
+        recovery = result.recovery
+        return {
+            "status": "failed",
+            "error": result.error,
+            "recovery": (
+                None
+                if recovery is None
+                else {
+                    "state": recovery.state,
+                    "operation_id": recovery.operation_id,
+                    "occurred_at": recovery.occurred_at,
+                    "error_code": recovery.error_code,
+                    "can_resume": recovery.can_resume,
+                    "can_abort": recovery.can_abort,
+                }
+            ),
+        }
+    return {
+        "status": result.status,
+        "operation_id": result.operation_id,
+        "epoch": result.epoch,
+    }
+
+
+async def _clear(runtime: MemoryRuntime, *, operator_ref: str) -> dict:
+    return _clear_payload(
+        await _maintenance(runtime).clear(operator_ref=operator_ref)
+    )
+
+
+async def _resume_clear(
+    runtime: MemoryRuntime,
+    operation_id: str,
+    *,
+    operator_ref: str,
+) -> dict:
+    return _clear_payload(
+        await _maintenance(runtime).resume_clear(
+            operation_id,
+            operator_ref=operator_ref,
+        )
+    )
+
+
+async def _abort_clear(
+    runtime: MemoryRuntime,
+    operation_id: str,
+    *,
+    operator_ref: str,
+) -> dict:
+    return _clear_payload(
+        await _maintenance(runtime).abort_clear(
+            operation_id,
+            operator_ref=operator_ref,
+        )
+    )
+
+
+async def test_runtime_preserves_public_clear_payloads_when_delegating(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    runtime = MemoryRuntime(MemoryConfig(), effective_home=tmp_path)
+    results = iter(
+        (
+            ClearResult(status="completed", operation_id="clear-1", epoch=3),
+            ClearResult(
+                status="failed",
+                error="memory_clear_failed",
+                recovery=ClearRecoveryResult(
+                    state="recovery_needed",
+                    operation_id="clear-2",
+                    occurred_at="2026-01-01T00:00:00.000Z",
+                    error_code="memory_clear_failed",
+                    can_resume=True,
+                    can_abort=False,
+                ),
+            ),
+        )
+    )
+
+    async def delegated_clear(*, operator_ref: str) -> ClearResult:
+        assert operator_ref == "user:owner"
+        return next(results)
+
+    monkeypatch.setattr(_maintenance(runtime), "clear", delegated_clear)
+
+    assert await runtime.clear(operator_ref="user:owner") == {
+        "status": "completed",
+        "operation_id": "clear-1",
+        "epoch": 3,
+    }
+    assert await runtime.clear(operator_ref="user:owner") == {
+        "status": "failed",
+        "error": "memory_clear_failed",
+        "recovery": {
+            "state": "recovery_needed",
+            "operation_id": "clear-2",
+            "occurred_at": "2026-01-01T00:00:00.000Z",
+            "error_code": "memory_clear_failed",
+            "can_resume": True,
+            "can_abort": False,
+        },
+    }
+    await runtime.close()
 
 
 @pytest.mark.parametrize(
@@ -40,7 +168,7 @@ async def test_maintenance_refuses_clear_when_a_journal_cannot_initialize(
         raise OSError("injected journal initialization failure")
 
     monkeypatch.setattr(
-        f"core.memory.runtime.{failed_dependency}",
+        f"core.memory.maintenance.{failed_dependency}",
         fail_initialization,
     )
     runtime = MemoryRuntime(MemoryConfig(), effective_home=tmp_path)
@@ -76,6 +204,38 @@ async def test_maintenance_refuses_clear_when_the_store_is_unavailable(
 
     assert runtime.available is False
     assert (await runtime.maintenance_payload())["can_clear"] is False
+    await runtime.close()
+
+
+async def test_unavailable_store_still_projects_durable_clear_recovery(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    operation = MemoryClearJournal(tmp_path).start(
+        operation_id="clear-before-store-failure",
+        operator_ref="user:owner",
+        pre_epoch=2,
+        target_epoch=3,
+    )
+
+    def fail_initialization(*_args, **_kwargs):
+        raise OSError("injected store initialization failure")
+
+    monkeypatch.setattr("core.memory.runtime.MemoryStore", fail_initialization)
+    runtime = MemoryRuntime(MemoryConfig(), effective_home=tmp_path)
+
+    payload = await runtime.maintenance_payload(operator_ref="user:owner")
+    assert payload["status"] == "ok"
+    assert payload["data_exists"] is True
+    assert payload["can_clear"] is False
+    assert payload["clear_recovery"] == {
+        "state": "recovery_needed",
+        "operation_id": operation.operation_id,
+        "occurred_at": payload["clear_recovery"]["occurred_at"],
+        "error_code": "memory_clear_failed",
+        "can_resume": True,
+        "can_abort": False,
+    }
     await runtime.close()
 
 
@@ -137,7 +297,7 @@ async def test_processing_record_does_not_compact_queue_during_clear_snapshot(
         "_compact_terminal_tombstones_in_connection",
         observed_compaction,
     )
-    clearing = asyncio.create_task(runtime.clear(operator_ref="user:owner"))
+    clearing = asyncio.create_task(_clear(runtime, operator_ref="user:owner"))
     assert await asyncio.to_thread(snapshot_copied.wait, 1)
     runtime._observe_recorder_health(
         {"state": "degraded", "reason": "call_log_corrupt"},
@@ -153,7 +313,7 @@ async def test_processing_record_does_not_compact_queue_during_clear_snapshot(
         "recorder_degraded"
     ]
     assert result["status"] == "completed"
-    assert runtime._clear_journal.get_open_operation() is None
+    assert _maintenance(runtime)._clear_journal.get_open_operation() is None
     await runtime.close()
 
 
@@ -177,7 +337,7 @@ async def test_clear_converges_for_provider_tree_deeper_than_recursion_limit(
 ) -> None:
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     runtime = MemoryRuntime(MemoryConfig(), effective_home=tmp_path)
-    manager = runtime._snapshot_manager
+    manager = _maintenance(runtime)._snapshot_manager
     assert manager is not None
     provider_root = tmp_path / "memory/everos-root"
     runtime._provider_root_owner.ensure(
@@ -209,16 +369,16 @@ async def test_clear_converges_for_provider_tree_deeper_than_recursion_limit(
     previous_recursion_limit = sys.getrecursionlimit()
     try:
         sys.setrecursionlimit(recursion_limit)
-        result = await runtime.clear(operator_ref="user:owner")
-        gc_task = runtime._terminal_snapshot_gc_task
+        result = await _clear(runtime, operator_ref="user:owner")
+        gc_task = _maintenance(runtime)._terminal_snapshot_gc_task
         if gc_task is not None:
             await gc_task
     finally:
         sys.setrecursionlimit(previous_recursion_limit)
 
     assert result["status"] == "completed"
-    assert runtime._clear_journal is not None
-    assert runtime._clear_journal.get_open_operation() is None
+    assert _maintenance(runtime)._clear_journal is not None
+    assert _maintenance(runtime)._clear_journal.get_open_operation() is None
     assert not leaf.exists()
     assert not manager.snapshot_path(result["operation_id"]).exists()
     await runtime.close()
@@ -271,8 +431,8 @@ async def test_clear_refuses_manual_required_fence_without_mutating_evidence(
                 """
             ).fetchall()
 
-    journal = runtime._clear_journal
-    manager = runtime._snapshot_manager
+    journal = _maintenance(runtime)._clear_journal
+    manager = _maintenance(runtime)._snapshot_manager
     assert journal is not None
     assert manager is not None
     with sqlite3.connect(journal.database_path) as connection:
@@ -340,7 +500,7 @@ async def test_clear_refuses_manual_required_fence_without_mutating_evidence(
     monkeypatch.setattr(runtime, "_stop_worker", observed_stop_worker)
     monkeypatch.setattr(journal, "start", observed_start)
 
-    result = await runtime.clear(operator_ref="user:owner")
+    result = await _clear(runtime, operator_ref="user:owner")
 
     assert result == {
         "status": "failed",
@@ -389,7 +549,7 @@ async def test_interrupted_queue_delete_requires_explicit_resume_at_target_epoch
     other_operator = runtime.principal_for_user_key("avibe:remote:other-subject")
     _enqueue(runtime, "resume-source")
     pre_epoch = runtime._store.ensure_meta().epoch
-    journal = runtime._clear_journal
+    journal = _maintenance(runtime)._clear_journal
     assert journal is not None
     original_record = journal.record_surface_deleted
     interrupted = False
@@ -403,7 +563,7 @@ async def test_interrupted_queue_delete_requires_explicit_resume_at_target_epoch
 
     monkeypatch.setattr(journal, "record_surface_deleted", interrupt_queue_receipt)
 
-    failed = await runtime.clear(operator_ref=owner)
+    failed = await _clear(runtime, operator_ref=owner)
 
     assert failed["status"] == "failed"
     recovery = journal.get_open_operation()
@@ -431,7 +591,7 @@ async def test_interrupted_queue_delete_requires_explicit_resume_at_target_epoch
     assert "operator_ref" not in owner_maintenance["clear_recovery"]
     assert owner not in repr(owner_maintenance)
 
-    rejected = await runtime.resume_clear(
+    rejected = await _resume_clear(runtime,
         recovery.operation_id,
         operator_ref=other_operator,
     )
@@ -440,7 +600,7 @@ async def test_interrupted_queue_delete_requires_explicit_resume_at_target_epoch
     assert journal.get_open_operation() == recovery
 
     monkeypatch.setattr(journal, "record_surface_deleted", original_record)
-    completed = await runtime.resume_clear(
+    completed = await _resume_clear(runtime,
         recovery.operation_id,
         operator_ref=owner,
     )
@@ -472,14 +632,14 @@ async def test_attachment_clear_failure_does_not_record_surface_deleted(
 
     monkeypatch.setattr(attachment_store, "clear_all", inject_unsafe_entry_then_clear)
 
-    failed = await runtime.clear(operator_ref="user:owner")
+    failed = await _clear(runtime, operator_ref="user:owner")
 
     assert failed["status"] == "failed"
-    recovery = runtime._clear_journal.get_open_operation()
+    recovery = _maintenance(runtime)._clear_journal.get_open_operation()
     assert recovery is not None and recovery.state == "recovery_needed"
     surfaces = {
         surface.surface: surface.state
-        for surface in runtime._clear_journal.get_surfaces(recovery.operation_id)
+        for surface in _maintenance(runtime)._clear_journal.get_surfaces(recovery.operation_id)
     }
     assert surfaces["attachments"] == "snapshotted"
     assert unsafe.is_symlink()
@@ -493,7 +653,7 @@ async def test_recovery_payload_disables_abort_before_initial_snapshot(
 ) -> None:
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     runtime = MemoryRuntime(MemoryConfig(), effective_home=tmp_path)
-    journal = runtime._clear_journal
+    journal = _maintenance(runtime)._clear_journal
     assert journal is not None
     operation = journal.start(
         operation_id="incomplete-snapshot",
@@ -522,7 +682,7 @@ async def test_cancelled_clear_start_and_resume_claim_settle_before_recovery(
 ) -> None:
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     runtime = MemoryRuntime(MemoryConfig(), effective_home=tmp_path)
-    journal = runtime._clear_journal
+    journal = _maintenance(runtime)._clear_journal
     assert journal is not None
     start_entered = threading.Event()
     start_release = threading.Event()
@@ -535,7 +695,7 @@ async def test_cancelled_clear_start_and_resume_claim_settle_before_recovery(
         return operation
 
     monkeypatch.setattr(journal, "start", blocking_start)
-    clearing = asyncio.create_task(runtime.clear(operator_ref="user:owner"))
+    clearing = asyncio.create_task(_clear(runtime, operator_ref="user:owner"))
     assert await asyncio.to_thread(start_entered.wait, 1)
 
     clearing.cancel()
@@ -568,7 +728,7 @@ async def test_cancelled_clear_start_and_resume_claim_settle_before_recovery(
 
     monkeypatch.setattr(journal, "claim_resume", blocking_claim_resume)
     resuming = asyncio.create_task(
-        runtime.resume_clear(recovery.operation_id, operator_ref="user:owner")
+        _resume_clear(runtime, recovery.operation_id, operator_ref="user:owner")
     )
     assert await asyncio.to_thread(claim_entered.wait, 1)
 
@@ -591,7 +751,7 @@ async def test_cancelled_clear_start_and_resume_claim_settle_before_recovery(
     assert claimed_recovery.execution_token is None
 
     monkeypatch.setattr(journal, "claim_resume", original_claim_resume)
-    completed = await runtime.resume_clear(
+    completed = await _resume_clear(runtime,
         claimed_recovery.operation_id,
         operator_ref="user:owner",
     )
@@ -606,7 +766,7 @@ async def test_cancelled_completed_clear_resumes_runtime_once(
 ) -> None:
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     runtime = MemoryRuntime(MemoryConfig(), effective_home=tmp_path)
-    journal = runtime._clear_journal
+    journal = _maintenance(runtime)._clear_journal
     assert journal is not None
     completed_entered = threading.Event()
     completed_release = threading.Event()
@@ -621,7 +781,7 @@ async def test_cancelled_completed_clear_resumes_runtime_once(
         return operation
 
     resume_calls = 0
-    original_resume = runtime._resume_after_clear
+    original_resume = _maintenance(runtime)._runtime.resume
 
     async def counted_resume() -> None:
         nonlocal resume_calls
@@ -629,8 +789,8 @@ async def test_cancelled_completed_clear_resumes_runtime_once(
         await original_resume()
 
     monkeypatch.setattr(journal, "mark_completed", blocking_mark_completed)
-    monkeypatch.setattr(runtime, "_resume_after_clear", counted_resume)
-    clearing = asyncio.create_task(runtime.clear(operator_ref="user:owner"))
+    _replace_runtime_port(runtime, resume=counted_resume)
+    clearing = asyncio.create_task(_clear(runtime, operator_ref="user:owner"))
     assert await asyncio.to_thread(completed_entered.wait, 1)
 
     clearing.cancel()
@@ -669,10 +829,10 @@ async def test_cancelled_post_terminal_resume_holds_lifecycle_fences(
         return {"ok": True, "state": "running"}
 
     monkeypatch.setattr(runtime, "_reconcile_locked", blocking_reconcile)
-    clearing = asyncio.create_task(runtime.clear(operator_ref="user:owner"))
+    clearing = asyncio.create_task(_clear(runtime, operator_ref="user:owner"))
     await asyncio.wait_for(resume_entered.wait(), timeout=1)
 
-    assert runtime._clear_journal.get_open_operation() is None
+    assert _maintenance(runtime)._clear_journal.get_open_operation() is None
     assert runtime.module._worker._claims_paused is True
     assert runtime.module._worker._coordinator._paused is True
     clearing.cancel()
@@ -702,23 +862,23 @@ async def test_abort_restores_all_surfaces_after_destructive_work(
     runtime = MemoryRuntime(MemoryConfig(), effective_home=tmp_path)
     _enqueue(runtime, "abort-source")
     pre_meta = runtime._store.ensure_meta()
-    original_delete = runtime._delete_clear_surface
+    original_delete = _maintenance(runtime)._runtime.delete_surface
 
-    async def interrupt_provider(surface, *, target_epoch):
+    async def interrupt_provider(surface, target_epoch):
         if surface.surface == "provider":
             raise OSError("injected provider delete failure")
-        await original_delete(surface, target_epoch=target_epoch)
+        await original_delete(surface, target_epoch)
 
-    monkeypatch.setattr(runtime, "_delete_clear_surface", interrupt_provider)
-    failed = await runtime.clear(operator_ref="user:owner")
-    recovery = runtime._clear_journal.get_open_operation()
+    _replace_runtime_port(runtime, delete_surface=interrupt_provider)
+    failed = await _clear(runtime, operator_ref="user:owner")
+    recovery = _maintenance(runtime)._clear_journal.get_open_operation()
 
     assert failed["status"] == "failed"
     assert recovery is not None and recovery.destructive_started
     assert runtime._store.list_queue_rows() == ()
 
-    monkeypatch.setattr(runtime, "_delete_clear_surface", original_delete)
-    aborted = await runtime.abort_clear(
+    _replace_runtime_port(runtime, delete_surface=original_delete)
+    aborted = await _abort_clear(runtime,
         recovery.operation_id,
         operator_ref="user:owner",
     )
@@ -728,11 +888,11 @@ async def test_abort_restores_all_surfaces_after_destructive_work(
     assert restored_meta.epoch == pre_meta.epoch
     assert restored_meta.clear_in_progress is False
     assert len(runtime._store.list_queue_rows()) == 1
-    assert runtime._clear_journal.get_open_operation() is None
-    operation = runtime._clear_journal.get_operation(recovery.operation_id)
+    assert _maintenance(runtime)._clear_journal.get_open_operation() is None
+    operation = _maintenance(runtime)._clear_journal.get_operation(recovery.operation_id)
     assert operation is not None and operation.state == "aborted"
-    assert runtime._snapshot_manager is not None
-    assert not runtime._snapshot_manager.snapshot_path(recovery.operation_id).exists()
+    assert _maintenance(runtime)._snapshot_manager is not None
+    assert not _maintenance(runtime)._snapshot_manager.snapshot_path(recovery.operation_id).exists()
     await runtime.close()
 
 
@@ -755,11 +915,11 @@ async def test_clear_accepts_corrupt_diagnostic_call_log(
         path.write_bytes(payload)
         path.chmod(0o600)
 
-    result = await runtime.clear(operator_ref="user:owner")
+    result = await _clear(runtime, operator_ref="user:owner")
 
     assert result["status"] == "completed"
     assert all(not path.exists() for path in files)
-    assert runtime._clear_journal.get_open_operation() is None
+    assert _maintenance(runtime)._clear_journal.get_open_operation() is None
     await runtime.close()
 
 
@@ -789,23 +949,23 @@ async def test_abort_restores_exact_corrupt_call_log_files_after_deletion(
         )
         for path in files
     }
-    original_delete = runtime._delete_clear_surface
+    original_delete = _maintenance(runtime)._runtime.delete_surface
 
-    async def fail_after_call_log(surface, *, target_epoch):
+    async def fail_after_call_log(surface, target_epoch):
         if surface.surface == "attachments":
             raise OSError("injected failure after call-log deletion")
-        await original_delete(surface, target_epoch=target_epoch)
+        await original_delete(surface, target_epoch)
 
-    monkeypatch.setattr(runtime, "_delete_clear_surface", fail_after_call_log)
-    failed = await runtime.clear(operator_ref="user:owner")
-    recovery = runtime._clear_journal.get_open_operation()
+    _replace_runtime_port(runtime, delete_surface=fail_after_call_log)
+    failed = await _clear(runtime, operator_ref="user:owner")
+    recovery = _maintenance(runtime)._clear_journal.get_open_operation()
 
     assert failed["status"] == "failed"
     assert recovery is not None and recovery.destructive_started
     assert all(not path.exists() for path in files)
 
-    monkeypatch.setattr(runtime, "_delete_clear_surface", original_delete)
-    aborted = await runtime.abort_clear(
+    _replace_runtime_port(runtime, delete_surface=original_delete)
+    aborted = await _abort_clear(runtime,
         recovery.operation_id,
         operator_ref="user:owner",
     )
@@ -816,7 +976,7 @@ async def test_abort_restores_exact_corrupt_call_log_files_after_deletion(
         assert restored_bytes == expected_bytes
         assert stat.S_IMODE(path.stat().st_mode) == expected_mode
         assert hashlib.sha256(restored_bytes).hexdigest() == expected_digest
-    assert runtime._clear_journal.get_open_operation() is None
+    assert _maintenance(runtime)._clear_journal.get_open_operation() is None
     await runtime.close()
 
 
@@ -826,7 +986,7 @@ async def test_completed_clear_snapshot_removal_retries_on_reconcile_and_restart
 ) -> None:
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     runtime = MemoryRuntime(MemoryConfig(), effective_home=tmp_path)
-    manager = runtime._snapshot_manager
+    manager = _maintenance(runtime)._snapshot_manager
     assert manager is not None
     original_remove = manager.remove
     removal_attempts: list[str] = []
@@ -838,7 +998,7 @@ async def test_completed_clear_snapshot_removal_retries_on_reconcile_and_restart
         original_remove(permit)
 
     monkeypatch.setattr(manager, "remove", fail_removal)
-    completed = await runtime.clear(operator_ref="user:owner")
+    completed = await _clear(runtime, operator_ref="user:owner")
     snapshot_path = manager.snapshot_path(completed["operation_id"])
 
     assert completed["status"] == "completed"
@@ -847,13 +1007,13 @@ async def test_completed_clear_snapshot_removal_retries_on_reconcile_and_restart
 
     monkeypatch.setattr(manager, "remove", original_remove)
     assert await runtime.reconcile(MemoryConfig()) == {"ok": True, "state": "disabled"}
-    reconcile_gc = runtime._terminal_snapshot_gc_task
+    reconcile_gc = _maintenance(runtime)._terminal_snapshot_gc_task
     assert reconcile_gc is not None
     await reconcile_gc
     assert not snapshot_path.exists()
 
     monkeypatch.setattr(manager, "remove", fail_removal)
-    completed_before_restart = await runtime.clear(operator_ref="user:owner")
+    completed_before_restart = await _clear(runtime, operator_ref="user:owner")
     restart_snapshot_path = manager.snapshot_path(completed_before_restart["operation_id"])
     assert restart_snapshot_path.is_dir()
     await runtime.close()
@@ -861,17 +1021,109 @@ async def test_completed_clear_snapshot_removal_retries_on_reconcile_and_restart
     restarted = MemoryRuntime(MemoryConfig(), effective_home=tmp_path)
 
     assert restart_snapshot_path.is_dir()
-    assert restarted._clear_journal is not None
-    assert restarted._clear_journal.get_open_operation() is None
+    assert _maintenance(restarted)._clear_journal is not None
+    assert _maintenance(restarted)._clear_journal.get_open_operation() is None
     assert await restarted.reconcile(MemoryConfig()) == {
         "ok": True,
         "state": "disabled",
     }
-    restart_gc = restarted._terminal_snapshot_gc_task
+    restart_gc = _maintenance(restarted)._terminal_snapshot_gc_task
     assert restart_gc is not None
     await restart_gc
     assert not restart_snapshot_path.exists()
     await restarted.close()
+
+
+async def _retain_terminal_clear_snapshot(
+    monkeypatch: pytest.MonkeyPatch,
+    home: Path,
+) -> Path:
+    runtime = MemoryRuntime(MemoryConfig(), effective_home=home)
+    manager = _maintenance(runtime)._snapshot_manager
+    assert manager is not None
+
+    def retain(_permit) -> None:
+        raise OSError("retain terminal snapshot for startup GC")
+
+    monkeypatch.setattr(manager, "remove", retain)
+    completed = await _clear(runtime, operator_ref="user:owner")
+    snapshot_path = manager.snapshot_path(completed["operation_id"])
+    assert completed["status"] == "completed"
+    assert snapshot_path.is_dir()
+    await runtime.close()
+    return snapshot_path
+
+
+async def test_terminal_snapshot_gc_is_scheduled_after_lifecycle_returns(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    entered = threading.Event()
+    release = threading.Event()
+    original_remove = MemorySnapshotManager.remove
+    snapshot_path = await _retain_terminal_clear_snapshot(monkeypatch, tmp_path)
+
+    def blocking_remove(manager: MemorySnapshotManager, permit) -> None:
+        entered.set()
+        assert release.wait(timeout=2)
+        original_remove(manager, permit)
+
+    monkeypatch.setattr(MemorySnapshotManager, "remove", blocking_remove)
+    runtime = MemoryRuntime(MemoryConfig(), effective_home=tmp_path)
+
+    assert await runtime.reconcile(MemoryConfig()) == {
+        "ok": True,
+        "state": "disabled",
+    }
+    assert entered.is_set() is False
+    gc_task = _maintenance(runtime)._terminal_snapshot_gc_task
+    assert gc_task is not None
+    assert await asyncio.to_thread(entered.wait, 1)
+
+    release.set()
+    await asyncio.wait_for(asyncio.shield(gc_task), timeout=1)
+    assert not snapshot_path.exists()
+    await runtime.close()
+
+
+async def test_terminal_snapshot_gc_shutdown_joins_cancelled_io(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    entered = threading.Event()
+    release = threading.Event()
+    finished = threading.Event()
+    original_remove = MemorySnapshotManager.remove
+    snapshot_path = await _retain_terminal_clear_snapshot(monkeypatch, tmp_path)
+
+    def blocking_remove(manager: MemorySnapshotManager, permit) -> None:
+        entered.set()
+        assert release.wait(timeout=2)
+        try:
+            original_remove(manager, permit)
+        finally:
+            finished.set()
+
+    monkeypatch.setattr(MemorySnapshotManager, "remove", blocking_remove)
+    runtime = MemoryRuntime(MemoryConfig(), effective_home=tmp_path)
+    await runtime.reconcile(MemoryConfig())
+    gc_task = _maintenance(runtime)._terminal_snapshot_gc_task
+    assert gc_task is not None
+    assert await asyncio.to_thread(entered.wait, 1)
+
+    closing = asyncio.create_task(_maintenance(runtime).close())
+    await asyncio.sleep(0)
+    closing.cancel()
+    await asyncio.sleep(0)
+    assert not closing.done()
+
+    release.set()
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.wait_for(closing, timeout=1)
+    assert finished.is_set()
+    assert gc_task.done()
+    assert _maintenance(runtime)._terminal_snapshot_gc_task is None
+    assert not snapshot_path.exists()
 
 
 async def test_aborted_clear_snapshot_removal_retries_on_reconcile_and_restart(
@@ -880,18 +1132,18 @@ async def test_aborted_clear_snapshot_removal_retries_on_reconcile_and_restart(
 ) -> None:
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     runtime = MemoryRuntime(MemoryConfig(), effective_home=tmp_path)
-    journal = runtime._clear_journal
-    manager = runtime._snapshot_manager
+    journal = _maintenance(runtime)._clear_journal
+    manager = _maintenance(runtime)._snapshot_manager
     assert journal is not None
     assert manager is not None
-    original_delete = runtime._delete_clear_surface
+    original_delete = _maintenance(runtime)._runtime.delete_surface
     original_remove = manager.remove
     removal_attempts: list[str] = []
 
-    async def interrupt_provider(surface, *, target_epoch):
+    async def interrupt_provider(surface, target_epoch):
         if surface.surface == "provider":
             raise OSError("injected provider delete failure")
-        await original_delete(surface, target_epoch=target_epoch)
+        await original_delete(surface, target_epoch)
 
     def fail_removal(permit) -> None:
         if manager.snapshot_path(permit.snapshot_id).exists():
@@ -900,13 +1152,13 @@ async def test_aborted_clear_snapshot_removal_retries_on_reconcile_and_restart(
         original_remove(permit)
 
     async def abort_after_interrupted_clear() -> dict:
-        monkeypatch.setattr(runtime, "_delete_clear_surface", interrupt_provider)
-        failed = await runtime.clear(operator_ref="user:owner")
+        _replace_runtime_port(runtime, delete_surface=interrupt_provider)
+        failed = await _clear(runtime, operator_ref="user:owner")
         recovery = journal.get_open_operation()
         assert failed["status"] == "failed"
         assert recovery is not None
-        monkeypatch.setattr(runtime, "_delete_clear_surface", original_delete)
-        return await runtime.abort_clear(
+        _replace_runtime_port(runtime, delete_surface=original_delete)
+        return await _abort_clear(runtime,
             recovery.operation_id,
             operator_ref="user:owner",
         )
@@ -923,7 +1175,7 @@ async def test_aborted_clear_snapshot_removal_retries_on_reconcile_and_restart(
 
     monkeypatch.setattr(manager, "remove", original_remove)
     assert await runtime.reconcile(MemoryConfig()) == {"ok": True, "state": "disabled"}
-    reconcile_gc = runtime._terminal_snapshot_gc_task
+    reconcile_gc = _maintenance(runtime)._terminal_snapshot_gc_task
     assert reconcile_gc is not None
     await reconcile_gc
     assert not snapshot_path.exists()
@@ -937,13 +1189,13 @@ async def test_aborted_clear_snapshot_removal_retries_on_reconcile_and_restart(
     restarted = MemoryRuntime(MemoryConfig(), effective_home=tmp_path)
 
     assert restart_snapshot_path.is_dir()
-    assert restarted._clear_journal is not None
-    assert restarted._clear_journal.get_open_operation() is None
+    assert _maintenance(restarted)._clear_journal is not None
+    assert _maintenance(restarted)._clear_journal.get_open_operation() is None
     assert await restarted.reconcile(MemoryConfig()) == {
         "ok": True,
         "state": "disabled",
     }
-    restart_gc = restarted._terminal_snapshot_gc_task
+    restart_gc = _maintenance(restarted)._terminal_snapshot_gc_task
     assert restart_gc is not None
     await restart_gc
     assert not restart_snapshot_path.exists()
@@ -962,19 +1214,19 @@ async def test_cancelled_clear_waits_for_snapshot_creation_before_releasing_fenc
     original_create = MemorySnapshotManager.create
 
     def blocking_create(manager: MemorySnapshotManager, snapshot_id: str | None = None):
-        if manager is runtime._snapshot_manager:
+        if manager is _maintenance(runtime)._snapshot_manager:
             started.set()
             assert release.wait(2)
         try:
             return original_create(manager, snapshot_id)
         finally:
-            if manager is runtime._snapshot_manager:
+            if manager is _maintenance(runtime)._snapshot_manager:
                 finished.set()
 
     monkeypatch.setattr(MemorySnapshotManager, "create", blocking_create)
-    clearing = asyncio.create_task(runtime.clear(operator_ref="user:owner"))
+    clearing = asyncio.create_task(_clear(runtime, operator_ref="user:owner"))
     assert await asyncio.to_thread(started.wait, 1)
-    operation = runtime._clear_journal.get_open_operation()
+    operation = _maintenance(runtime)._clear_journal.get_open_operation()
     assert operation is not None
 
     clearing.cancel()
@@ -984,7 +1236,7 @@ async def test_cancelled_clear_waits_for_snapshot_creation_before_releasing_fenc
     assert runtime._reconcile_lock.locked()
     assert runtime.module._lifecycle_lock.locked()
     resuming = asyncio.create_task(
-        runtime.resume_clear(operation.operation_id, operator_ref="user:owner")
+        _resume_clear(runtime, operation.operation_id, operator_ref="user:owner")
     )
     await asyncio.sleep(0)
     assert resuming.done() is False
@@ -997,7 +1249,7 @@ async def test_cancelled_clear_waits_for_snapshot_creation_before_releasing_fenc
         await clearing
 
     assert finished.is_set()
-    recovery = runtime._clear_journal.get_open_operation()
+    recovery = _maintenance(runtime)._clear_journal.get_open_operation()
     assert recovery is not None
     assert recovery.state == "recovery_needed"
     assert recovery.recovery_from_state == "preparing"
@@ -1008,18 +1260,18 @@ async def test_cancelled_clear_waits_for_snapshot_creation_before_releasing_fenc
     original_discard = MemorySnapshotManager.discard_unrecorded
 
     def blocking_discard(manager: MemorySnapshotManager, permit) -> None:
-        if manager is runtime._snapshot_manager:
+        if manager is _maintenance(runtime)._snapshot_manager:
             discard_started.set()
             assert discard_release.wait(2)
         try:
             original_discard(manager, permit)
         finally:
-            if manager is runtime._snapshot_manager:
+            if manager is _maintenance(runtime)._snapshot_manager:
                 discard_finished.set()
 
     monkeypatch.setattr(MemorySnapshotManager, "discard_unrecorded", blocking_discard)
     resuming = asyncio.create_task(
-        runtime.resume_clear(recovery.operation_id, operator_ref="user:owner")
+        _resume_clear(runtime, recovery.operation_id, operator_ref="user:owner")
     )
     assert await asyncio.to_thread(discard_started.wait, 1)
     resuming.cancel()
@@ -1033,13 +1285,13 @@ async def test_cancelled_clear_waits_for_snapshot_creation_before_releasing_fenc
         await resuming
 
     assert discard_finished.is_set()
-    pending = runtime._clear_journal.get_open_operation()
+    pending = _maintenance(runtime)._clear_journal.get_open_operation()
     assert pending is not None
     assert pending.state == "recovery_needed"
     assert pending.resolution == "resume"
 
     monkeypatch.setattr(MemorySnapshotManager, "discard_unrecorded", original_discard)
-    completed = await runtime.resume_clear(pending.operation_id, operator_ref="user:owner")
+    completed = await _resume_clear(runtime, pending.operation_id, operator_ref="user:owner")
     assert completed["status"] == "completed"
     await runtime.close()
 
@@ -1056,17 +1308,17 @@ async def test_cancelled_clear_waits_for_snapshot_verification_before_releasing_
     original_verify = MemorySnapshotManager.verify
 
     def blocking_verify(manager: MemorySnapshotManager, snapshot_id: str, **kwargs):
-        if manager is runtime._snapshot_manager:
+        if manager is _maintenance(runtime)._snapshot_manager:
             started.set()
             assert release.wait(2)
         try:
             return original_verify(manager, snapshot_id, **kwargs)
         finally:
-            if manager is runtime._snapshot_manager:
+            if manager is _maintenance(runtime)._snapshot_manager:
                 finished.set()
 
     monkeypatch.setattr(MemorySnapshotManager, "verify", blocking_verify)
-    clearing = asyncio.create_task(runtime.clear(operator_ref="user:owner"))
+    clearing = asyncio.create_task(_clear(runtime, operator_ref="user:owner"))
     assert await asyncio.to_thread(started.wait, 1)
 
     clearing.cancel()
@@ -1080,13 +1332,13 @@ async def test_cancelled_clear_waits_for_snapshot_verification_before_releasing_
         await clearing
 
     assert finished.is_set()
-    recovery = runtime._clear_journal.get_open_operation()
+    recovery = _maintenance(runtime)._clear_journal.get_open_operation()
     assert recovery is not None
     assert recovery.state == "recovery_needed"
     assert recovery.recovery_from_state == "prepared"
 
     monkeypatch.setattr(MemorySnapshotManager, "verify", original_verify)
-    completed = await runtime.resume_clear(recovery.operation_id, operator_ref="user:owner")
+    completed = await _resume_clear(runtime, recovery.operation_id, operator_ref="user:owner")
     assert completed["status"] == "completed"
     await runtime.close()
 
@@ -1119,7 +1371,7 @@ async def test_cancelled_clear_waits_for_provider_delete_before_releasing_fences
         "recreate_empty",
         blocking_recreate,
     )
-    clearing = asyncio.create_task(runtime.clear(operator_ref="user:owner"))
+    clearing = asyncio.create_task(_clear(runtime, operator_ref="user:owner"))
     assert await asyncio.to_thread(started.wait, 1)
 
     clearing.cancel()
@@ -1134,7 +1386,7 @@ async def test_cancelled_clear_waits_for_provider_delete_before_releasing_fences
         await clearing
 
     assert finished.is_set()
-    recovery = runtime._clear_journal.get_open_operation()
+    recovery = _maintenance(runtime)._clear_journal.get_open_operation()
     assert recovery is not None
     assert recovery.state == "recovery_needed"
     assert recovery.recovery_from_state == "deleting"
@@ -1144,7 +1396,7 @@ async def test_cancelled_clear_waits_for_provider_delete_before_releasing_fences
         "recreate_empty",
         original_recreate,
     )
-    completed = await runtime.resume_clear(
+    completed = await _resume_clear(runtime,
         recovery.operation_id,
         operator_ref="user:owner",
     )
@@ -1159,19 +1411,19 @@ async def test_cancelled_abort_waits_for_restore_before_releasing_fences(
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     runtime = MemoryRuntime(MemoryConfig(), effective_home=tmp_path)
     _enqueue(runtime, "cancel-abort-source")
-    original_delete = runtime._delete_clear_surface
+    original_delete = _maintenance(runtime)._runtime.delete_surface
 
-    async def interrupt_provider(surface, *, target_epoch):
+    async def interrupt_provider(surface, target_epoch):
         if surface.surface == "provider":
             raise OSError("injected provider delete failure")
-        await original_delete(surface, target_epoch=target_epoch)
+        await original_delete(surface, target_epoch)
 
-    monkeypatch.setattr(runtime, "_delete_clear_surface", interrupt_provider)
-    failed = await runtime.clear(operator_ref="user:owner")
-    recovery = runtime._clear_journal.get_open_operation()
+    _replace_runtime_port(runtime, delete_surface=interrupt_provider)
+    failed = await _clear(runtime, operator_ref="user:owner")
+    recovery = _maintenance(runtime)._clear_journal.get_open_operation()
     assert failed["status"] == "failed"
     assert recovery is not None
-    monkeypatch.setattr(runtime, "_delete_clear_surface", original_delete)
+    _replace_runtime_port(runtime, delete_surface=original_delete)
 
     started = threading.Event()
     release = threading.Event()
@@ -1179,18 +1431,18 @@ async def test_cancelled_abort_waits_for_restore_before_releasing_fences(
     original_restore = MemorySnapshotManager.restore
 
     def blocking_restore(manager: MemorySnapshotManager, snapshot_id: str, **kwargs):
-        if manager is runtime._snapshot_manager:
+        if manager is _maintenance(runtime)._snapshot_manager:
             started.set()
             assert release.wait(2)
         try:
             return original_restore(manager, snapshot_id, **kwargs)
         finally:
-            if manager is runtime._snapshot_manager:
+            if manager is _maintenance(runtime)._snapshot_manager:
                 finished.set()
 
     monkeypatch.setattr(MemorySnapshotManager, "restore", blocking_restore)
     aborting = asyncio.create_task(
-        runtime.abort_clear(recovery.operation_id, operator_ref="user:owner")
+        _abort_clear(runtime, recovery.operation_id, operator_ref="user:owner")
     )
     assert await asyncio.to_thread(started.wait, 1)
 
@@ -1205,15 +1457,15 @@ async def test_cancelled_abort_waits_for_restore_before_releasing_fences(
         await aborting
 
     assert finished.is_set()
-    pending = runtime._clear_journal.get_open_operation()
+    pending = _maintenance(runtime)._clear_journal.get_open_operation()
     assert pending is not None
     assert pending.state == "recovery_needed"
     assert pending.resolution == "abort"
     assert pending.execution_token is None
-    assert runtime._clear_recovery_payload()["can_resume"] is False
+    assert _maintenance(runtime).recovery().can_resume is False
 
     monkeypatch.setattr(MemorySnapshotManager, "restore", original_restore)
-    journal = runtime._clear_journal
+    journal = _maintenance(runtime)._clear_journal
     terminal_entered = threading.Event()
     terminal_release = threading.Event()
     original_mark_aborted = journal.mark_aborted
@@ -1225,7 +1477,7 @@ async def test_cancelled_abort_waits_for_restore_before_releasing_fences(
         return operation
 
     resume_calls = 0
-    original_resume = runtime._resume_after_clear
+    original_resume = _maintenance(runtime)._runtime.resume
 
     async def counted_resume() -> None:
         nonlocal resume_calls
@@ -1233,9 +1485,9 @@ async def test_cancelled_abort_waits_for_restore_before_releasing_fences(
         await original_resume()
 
     monkeypatch.setattr(journal, "mark_aborted", blocking_mark_aborted)
-    monkeypatch.setattr(runtime, "_resume_after_clear", counted_resume)
+    _replace_runtime_port(runtime, resume=counted_resume)
     aborting = asyncio.create_task(
-        runtime.abort_clear(pending.operation_id, operator_ref="user:owner")
+        _abort_clear(runtime, pending.operation_id, operator_ref="user:owner")
     )
     assert await asyncio.to_thread(terminal_entered.wait, 1)
 
@@ -1253,12 +1505,12 @@ async def test_cancelled_abort_waits_for_restore_before_releasing_fences(
     aborted = journal.get_operation(pending.operation_id)
     assert aborted is not None
     assert aborted.state == "aborted"
-    assert runtime._clear_journal.get_open_operation() is None
+    assert _maintenance(runtime)._clear_journal.get_open_operation() is None
     assert resume_calls == 1
     await runtime.close()
 
 
-async def test_runtime_backup_fences_capture_and_clear_for_the_full_copy(
+async def test_maintenance_backup_fences_capture_and_clear_for_the_full_copy(
     monkeypatch,
     tmp_path: Path,
 ) -> None:
@@ -1287,7 +1539,7 @@ async def test_runtime_backup_fences_capture_and_clear_for_the_full_copy(
 
     monkeypatch.setattr(MemorySnapshotManager, "create", blocking_create)
     monkeypatch.setattr(runtime._store, "enqueue_request", blocking_enqueue)
-    monkeypatch.setattr(runtime, "_resume_after_clear", resume_without_sidecar)
+    _replace_runtime_port(runtime, resume=resume_without_sidecar)
 
     capturing = asyncio.create_task(
         runtime.module.capture(
@@ -1303,13 +1555,13 @@ async def test_runtime_backup_fences_capture_and_clear_for_the_full_copy(
         )
     )
     assert await asyncio.to_thread(enqueue_entered.wait, 1)
-    creating = asyncio.create_task(runtime.create_backup("runtime-fence"))
+    creating = asyncio.create_task(_maintenance(runtime).create_backup("runtime-fence"))
     await asyncio.sleep(0)
     assert entered.is_set() is False
     release_enqueue.set()
     assert await capturing == CaptureAccepted()
     assert await asyncio.to_thread(entered.wait, 1)
-    assert runtime._maintenance_open() is True
+    assert _maintenance(runtime).is_open() is True
     receipt = await runtime.module.capture(
         CaptureRequest(
             source_message_id="blocked-capture",
@@ -1323,10 +1575,10 @@ async def test_runtime_backup_fences_capture_and_clear_for_the_full_copy(
     )
     assert receipt == CaptureSkipped(reason="memory_clear_failed")
 
-    clearing = asyncio.create_task(runtime.clear(operator_ref="user:owner"))
+    clearing = asyncio.create_task(_clear(runtime, operator_ref="user:owner"))
     await asyncio.sleep(0)
     assert clearing.done() is False
-    assert runtime._clear_journal.get_open_operation() is None
+    assert _maintenance(runtime)._clear_journal.get_open_operation() is None
 
     clearing.cancel()
     with pytest.raises(asyncio.CancelledError):
@@ -1334,12 +1586,12 @@ async def test_runtime_backup_fences_capture_and_clear_for_the_full_copy(
     creating.cancel()
     await asyncio.sleep(0)
     assert creating.done() is False
-    assert runtime._maintenance_open() is True
+    assert _maintenance(runtime).is_open() is True
     release.set()
     with pytest.raises(asyncio.CancelledError):
         await creating
     assert (tmp_path / "state" / "memory" / "backups" / "runtime-fence").is_dir()
-    assert runtime._maintenance_open() is False
+    assert _maintenance(runtime).is_open() is False
     await runtime.close()
 
 
@@ -1349,7 +1601,7 @@ async def test_reconcile_schedules_auto_id_backup_stage_cleanup(
 ) -> None:
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     runtime = MemoryRuntime(MemoryConfig(), effective_home=tmp_path)
-    manager = runtime._backup_manager
+    manager = _maintenance(runtime)._backup_manager
     assert manager is not None
     stage = manager.snapshot_root / f".{('a' * 32)}.tmp"
     stage.mkdir(parents=True, mode=0o700)
@@ -1362,7 +1614,7 @@ async def test_reconcile_schedules_auto_id_backup_stage_cleanup(
         "ok": True,
         "state": "disabled",
     }
-    task = runtime._backup_stage_reconcile_task
+    task = _maintenance(runtime)._backup_stage_reconcile_task
     if task is not None:
         await task
 
@@ -1376,8 +1628,8 @@ async def test_backup_stage_cleanup_waits_for_terminal_snapshot_gc(
 ) -> None:
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     runtime = MemoryRuntime(MemoryConfig(), effective_home=tmp_path)
-    journal = runtime._clear_journal
-    manager = runtime._backup_manager
+    journal = _maintenance(runtime)._clear_journal
+    manager = _maintenance(runtime)._backup_manager
     assert journal is not None
     assert manager is not None
     terminal_entered = threading.Event()
@@ -1410,8 +1662,8 @@ async def test_backup_stage_cleanup_waits_for_terminal_snapshot_gc(
     assert backup_entered.is_set() is False
 
     terminal_release.set()
-    terminal_gc = runtime._terminal_snapshot_gc_task
-    backup_reconcile = runtime._backup_stage_reconcile_task
+    terminal_gc = _maintenance(runtime)._terminal_snapshot_gc_task
+    backup_reconcile = _maintenance(runtime)._backup_stage_reconcile_task
     assert terminal_gc is not None
     assert backup_reconcile is not None
     await terminal_gc
@@ -1427,7 +1679,7 @@ async def test_backup_stage_cleanup_cancellation_joins_filesystem_io(
 ) -> None:
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     runtime = MemoryRuntime(MemoryConfig(), effective_home=tmp_path)
-    manager = runtime._backup_manager
+    manager = _maintenance(runtime)._backup_manager
     assert manager is not None
     entered = threading.Event()
     release = threading.Event()
@@ -1443,14 +1695,14 @@ async def test_backup_stage_cleanup_cancellation_joins_filesystem_io(
         "state": "disabled",
     }
     assert await asyncio.to_thread(entered.wait, 1)
-    assert runtime._maintenance_open() is False
+    assert _maintenance(runtime).is_open() is False
 
     closing = asyncio.create_task(runtime.close())
     await asyncio.sleep(0)
     assert closing.done() is False
     release.set()
     await closing
-    assert runtime._backup_stage_reconcile_task is None
+    assert _maintenance(runtime)._backup_stage_reconcile_task is None
 
 
 async def test_backup_stage_cleanup_queues_capture_without_global_maintenance_fence(
@@ -1459,7 +1711,7 @@ async def test_backup_stage_cleanup_queues_capture_without_global_maintenance_fe
 ) -> None:
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     runtime = MemoryRuntime(MemoryConfig(enabled=True), effective_home=tmp_path)
-    manager = runtime._backup_manager
+    manager = _maintenance(runtime)._backup_manager
     assert manager is not None
     entered = threading.Event()
     release = threading.Event()
@@ -1470,7 +1722,7 @@ async def test_backup_stage_cleanup_queues_capture_without_global_maintenance_fe
         return ()
 
     monkeypatch.setattr(manager, "reconcile_unpublished_backup_stages", blocking_reconcile)
-    cleanup = asyncio.create_task(runtime._run_backup_stage_reconcile())
+    cleanup = asyncio.create_task(_maintenance(runtime)._run_backup_stage_reconcile())
     assert await asyncio.to_thread(entered.wait, 1)
     assert runtime._reconcile_lock.locked()
     assert runtime.module._lifecycle_lock.locked()
@@ -1502,7 +1754,65 @@ async def test_backup_stage_cleanup_queues_capture_without_global_maintenance_fe
     await runtime.close()
 
 
-async def test_runtime_backup_restore_round_trips_queue_state(
+async def test_queued_backup_stage_reconcile_rechecks_artifact_install(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    install_entered = threading.Event()
+    release_install = threading.Event()
+
+    class BlockingArtifact(FakeMemoryArtifactManager):
+        def ensure(self, *, force: bool = False) -> dict:
+            self.ensure_calls.append(force)
+            install_entered.set()
+            release_install.wait(timeout=2)
+            return dict(self.ensure_payload)
+
+    runtime = MemoryRuntime(
+        MemoryConfig(enabled=False),
+        artifact_manager=BlockingArtifact(python=Path(sys.executable)),
+        effective_home=tmp_path,
+    )
+    terminal_gc_entered = asyncio.Event()
+    release_terminal_gc = asyncio.Event()
+    cleanup_calls: list[bool] = []
+    maintenance = _maintenance(runtime)
+
+    async def blocked_terminal_gc() -> None:
+        terminal_gc_entered.set()
+        await release_terminal_gc.wait()
+
+    manager = maintenance._backup_manager
+    assert manager is not None
+    monkeypatch.setattr(maintenance, "_run_terminal_snapshot_gc", blocked_terminal_gc)
+    monkeypatch.setattr(
+        manager,
+        "reconcile_unpublished_backup_stages",
+        lambda: cleanup_calls.append(runtime._artifact_installing),
+    )
+
+    maintenance.ensure_housekeeping()
+    await terminal_gc_entered.wait()
+    queued_reconcile = maintenance._backup_stage_reconcile_task
+    assert queued_reconcile is not None
+
+    installing = asyncio.create_task(runtime.install_artifact())
+    assert await asyncio.to_thread(install_entered.wait, 1)
+    release_terminal_gc.set()
+    await queued_reconcile
+    assert cleanup_calls == []
+
+    release_install.set()
+    assert (await installing)["ok"] is True
+    deferred_reconcile = maintenance._backup_stage_reconcile_task
+    assert deferred_reconcile is not None
+    assert deferred_reconcile is not queued_reconcile
+    await deferred_reconcile
+    assert cleanup_calls == [False]
+    await runtime.close()
+
+
+async def test_maintenance_backup_restore_round_trips_queue_state(
     monkeypatch,
     tmp_path: Path,
 ) -> None:
@@ -1510,12 +1820,12 @@ async def test_runtime_backup_restore_round_trips_queue_state(
     runtime = MemoryRuntime(MemoryConfig(), effective_home=tmp_path)
     _enqueue(runtime, "backup-source")
 
-    backup = await runtime.create_backup("runtime-round-trip")
+    backup = await _maintenance(runtime).create_backup("runtime-round-trip")
     meta = runtime._store.ensure_meta()
     runtime._store.reset_for_clear(target_epoch=meta.epoch + 1)
     assert runtime._store.list_queue_rows() == ()
 
-    restored = await runtime.restore_backup(
+    restored = await _maintenance(runtime).restore_backup(
         backup.snapshot_id,
         expected_manifest_sha256=backup.manifest_sha256,
         expected_surface_digests=backup.surface_digests(),
@@ -1562,7 +1872,7 @@ async def test_backup_restore_crash_is_fenced_and_boot_converges_one_generation(
         connection.execute("INSERT INTO generation VALUES ('backup')")
     call_log.chmod(0o600)
 
-    backup = await runtime.create_backup("crash-safe-restore")
+    backup = await _maintenance(runtime).create_backup("crash-safe-restore")
     _enqueue(runtime, "live-queue")
     provider_marker.write_text("live")
     attachment_marker.write_text("live")
@@ -1584,7 +1894,7 @@ async def test_backup_restore_crash_is_fenced_and_boot_converges_one_generation(
             and Path(destination) == target
             and f".restore-{backup.snapshot_id}-" in Path(source).name
         ):
-            open_operation = runtime._backup_restore_journal.get_open_operation()
+            open_operation = _maintenance(runtime)._backup_restore_journal.get_open_operation()
             assert open_operation is not None
             assert open_operation.state == "restoring"
             intent_visible_before_replace = True
@@ -1597,9 +1907,13 @@ async def test_backup_restore_crash_is_fenced_and_boot_converges_one_generation(
         return None
 
     monkeypatch.setattr(snapshot_module.os, "replace", crash_after_surface_install)
-    monkeypatch.setattr(runtime, "_mark_backup_restore_recovery", process_died_before_cleanup)
+    monkeypatch.setattr(
+        _maintenance(runtime),
+        "_mark_backup_restore_recovery",
+        process_died_before_cleanup,
+    )
     with pytest.raises(InjectedProcessDeath):
-        await runtime.restore_backup(
+        await _maintenance(runtime).restore_backup(
             backup.snapshot_id,
             expected_manifest_sha256=backup.manifest_sha256,
             expected_surface_digests=backup.surface_digests(),
@@ -1608,12 +1922,12 @@ async def test_backup_restore_crash_is_fenced_and_boot_converges_one_generation(
 
     assert crashed is True
     assert intent_visible_before_replace is True
-    interrupted = runtime._backup_restore_journal.get_open_operation()
+    interrupted = _maintenance(runtime)._backup_restore_journal.get_open_operation()
     assert interrupted is not None
     assert interrupted.state == "restoring"
     assert [
         event.event
-        for event in runtime._backup_restore_journal.get_events(
+        for event in _maintenance(runtime)._backup_restore_journal.get_events(
             interrupted.operation_id
         )
     ] == ["started"]
@@ -1622,10 +1936,10 @@ async def test_backup_restore_crash_is_fenced_and_boot_converges_one_generation(
         MemoryConfig(enabled=True),
         effective_home=tmp_path,
     )
-    recovery = restarted._backup_restore_journal.get_open_operation()
+    recovery = _maintenance(restarted)._backup_restore_journal.get_open_operation()
     assert recovery is not None
     assert recovery.state == "recovery_needed"
-    assert restarted._maintenance_open() is True
+    assert _maintenance(restarted).is_open() is True
     assert restarted.module._worker._claims_paused is True
     assert restarted._worker_task is None
     assert restarted._process is None
@@ -1653,7 +1967,7 @@ async def test_backup_restore_crash_is_fenced_and_boot_converges_one_generation(
             "ok": False,
             "error": "memory_clear_failed",
         }
-        still_fenced = restarted._backup_restore_journal.get_open_operation()
+        still_fenced = _maintenance(restarted)._backup_restore_journal.get_open_operation()
         assert still_fenced == recovery
         assert restarted.module._worker._claims_paused is True
         monkeypatch.setattr(SidecarOwnership, "reap", original_reap)
@@ -1670,20 +1984,20 @@ async def test_backup_restore_crash_is_fenced_and_boot_converges_one_generation(
             "backup",
         )
 
-    completed = restarted._backup_restore_journal.get_operation(
+    completed = _maintenance(restarted)._backup_restore_journal.get_operation(
         recovery.operation_id
     )
     assert completed is not None
     assert completed.state == "completed"
     assert completed.attempt_count == 2
-    assert restarted._backup_restore_journal.get_open_operation() is None
+    assert _maintenance(restarted)._backup_restore_journal.get_open_operation() is None
     assert [
         event.event
-        for event in restarted._backup_restore_journal.get_events(
+        for event in _maintenance(restarted)._backup_restore_journal.get_events(
             completed.operation_id
         )
     ] == ["started", "recovery_needed", "retry_started", "completed"]
-    assert restarted._maintenance_open() is False
+    assert _maintenance(restarted).is_open() is False
 
     await runtime.close()
     await restarted.close()

--- a/tests/test_memory_maintenance.py
+++ b/tests/test_memory_maintenance.py
@@ -6,6 +6,7 @@ import os
 import sqlite3
 import stat
 import sys
+from contextlib import asynccontextmanager
 from dataclasses import replace
 from datetime import UTC, datetime
 from pathlib import Path
@@ -224,18 +225,36 @@ async def test_unavailable_store_still_projects_durable_clear_recovery(
     monkeypatch.setattr("core.memory.runtime.MemoryStore", fail_initialization)
     runtime = MemoryRuntime(MemoryConfig(), effective_home=tmp_path)
 
-    payload = await runtime.maintenance_payload(operator_ref="user:owner")
-    assert payload["status"] == "ok"
-    assert payload["data_exists"] is True
-    assert payload["can_clear"] is False
-    assert payload["clear_recovery"] == {
+    fence_entered = False
+
+    @asynccontextmanager
+    async def observed_fence():
+        nonlocal fence_entered
+        fence_entered = True
+        yield
+
+    _replace_runtime_port(runtime, exclusive_fence=observed_fence)
+    before = await runtime.maintenance_payload(operator_ref="user:owner")
+    assert before["status"] == "ok"
+    assert before["data_exists"] is True
+    assert before["can_clear"] is False
+    assert before["clear_recovery"] == {
         "state": "recovery_needed",
         "operation_id": operation.operation_id,
-        "occurred_at": payload["clear_recovery"]["occurred_at"],
+        "occurred_at": before["clear_recovery"]["occurred_at"],
         "error_code": "memory_clear_failed",
         "can_resume": True,
         "can_abort": False,
     }
+
+    assert await runtime.reconcile(MemoryConfig()) == {
+        "ok": True,
+        "state": "disabled",
+    }
+    assert _maintenance(runtime)._backup_stage_reconcile_task is None
+    await asyncio.sleep(0)
+    assert fence_entered is False
+    assert await runtime.maintenance_payload(operator_ref="user:owner") == before
     await runtime.close()
 
 

--- a/tests/test_memory_maintenance.py
+++ b/tests/test_memory_maintenance.py
@@ -26,7 +26,7 @@ from core.memory.maintenance import (
 )
 from core.memory.runtime import MemoryRuntime
 from core.memory.snapshot import MemorySnapshotManager
-from core.memory.store import AmbiguousAdd, Delivered
+from core.memory.store import AmbiguousAdd, Delivered, MemoryStore
 from core.memory.types import CaptureAccepted, CaptureRequest, CaptureSkipped
 
 
@@ -252,6 +252,63 @@ async def test_unavailable_store_still_projects_durable_clear_recovery(
         "state": "disabled",
     }
     assert _maintenance(runtime)._backup_stage_reconcile_task is None
+    await asyncio.sleep(0)
+    assert fence_entered is False
+    assert await runtime.maintenance_payload(operator_ref="user:owner") == before
+    await runtime.close()
+
+
+@pytest.mark.parametrize("failure_point", ("provider_root", "module"))
+async def test_supplied_store_attaches_only_after_module_initialization(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    failure_point: str,
+) -> None:
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    operation = MemoryClearJournal(tmp_path).start(
+        operation_id=f"clear-before-{failure_point}-failure",
+        operator_ref="user:owner",
+        pre_epoch=4,
+        target_epoch=5,
+    )
+    store = MemoryStore(tmp_path / "state" / "memory" / "memory.sqlite")
+    artifact = FakeMemoryArtifactManager()
+
+    def fail_initialization(*_args, **_kwargs):
+        raise OSError(f"injected {failure_point} initialization failure")
+
+    if failure_point == "provider_root":
+        monkeypatch.setattr(artifact, "set_provider_root", fail_initialization)
+    else:
+        monkeypatch.setattr("core.memory.runtime.MemoryModule", fail_initialization)
+
+    runtime = MemoryRuntime(
+        MemoryConfig(),
+        store=store,
+        artifact_manager=artifact,
+        effective_home=tmp_path,
+    )
+    maintenance = _maintenance(runtime)
+    assert runtime.available is False
+    assert maintenance._store is None
+
+    fence_entered = False
+
+    @asynccontextmanager
+    async def observed_fence():
+        nonlocal fence_entered
+        fence_entered = True
+        yield
+
+    _replace_runtime_port(runtime, exclusive_fence=observed_fence)
+    before = await runtime.maintenance_payload(operator_ref="user:owner")
+    assert before["clear_recovery"]["operation_id"] == operation.operation_id
+
+    assert await runtime.reconcile(MemoryConfig()) == {
+        "ok": True,
+        "state": "disabled",
+    }
+    assert maintenance._backup_stage_reconcile_task is None
     await asyncio.sleep(0)
     assert fence_entered is False
     assert await runtime.maintenance_payload(operator_ref="user:owner") == before

--- a/tests/test_memory_runtime.py
+++ b/tests/test_memory_runtime.py
@@ -34,6 +34,7 @@ from core.memory.artifact import (
     MemoryRuntimeActivationError,
 )
 from core.memory.clear_journal import MemoryClearJournal
+from core.memory.maintenance import MemoryMaintenance
 from core.memory.attachments import AttachmentPinStore, attachment_pin_root
 from core.memory.everos import (
     AddAck,
@@ -93,6 +94,12 @@ from config.v2_config import (
 
 
 PROJECT = "p-22222222222222222222222222222222"
+
+
+def _maintenance(runtime: MemoryRuntime) -> MemoryMaintenance:
+    maintenance = runtime._maintenance
+    assert maintenance is not None
+    return maintenance
 
 
 def _installed_artifact(**overrides) -> FakeMemoryArtifactManager:
@@ -887,14 +894,14 @@ def test_disable_stops_live_runtime_when_maintenance_journal_is_unreadable(
         assert runtime._worker_task is not None
         assert runtime._process_records_calls is True
 
-        terminal_gc = runtime._terminal_snapshot_gc_task
-        backup_reconcile = runtime._backup_stage_reconcile_task
+        terminal_gc = _maintenance(runtime)._terminal_snapshot_gc_task
+        backup_reconcile = _maintenance(runtime)._backup_stage_reconcile_task
         if terminal_gc is not None:
             await terminal_gc
         if backup_reconcile is not None:
             await backup_reconcile
 
-        journal = getattr(runtime, journal_attribute)
+        journal = getattr(_maintenance(runtime), journal_attribute)
         assert journal is not None
 
         def unreadable_journal() -> None:
@@ -904,7 +911,7 @@ def test_disable_stops_live_runtime_when_maintenance_journal_is_unreadable(
             raise AssertionError("disable must not mutate an unreadable journal")
 
         monkeypatch.setattr(journal, "get_open_operation", unreadable_journal)
-        monkeypatch.setattr(runtime, "_recover_backup_restore_locked", recovery_must_not_run)
+        monkeypatch.setattr(_maintenance(runtime), "recover_boot", recovery_must_not_run)
 
         changed = replace(
             enabled,
@@ -1441,11 +1448,12 @@ def test_runtime_effective_home_owns_the_attachment_pipeline(
     assert runtime.module._attachment_store._effective_home == runtime_home
     assert runtime.module._attachment_store._root == expected_pin_root
     assert runtime.module._attachment_store._source_root == source_root
-    assert runtime._snapshot_manager is not None
-    assert runtime._snapshot_manager.effective_home == runtime_home
+    manager = _maintenance(runtime)._snapshot_manager
+    assert manager is not None
+    assert manager.effective_home == runtime_home
     assert any(
         surface.path == "memory/attachments"
-        for surface in runtime._snapshot_manager.surfaces
+        for surface in manager.surfaces
     )
 
     process = EverOSProcess(
@@ -2402,7 +2410,7 @@ def test_runtime_exposes_interrupted_clear_without_starting_sidecar(tmp_path: Pa
 
     asyncio.run(run())
     assert started == []
-    recovery = runtime._clear_journal.get_open_operation()
+    recovery = _maintenance(runtime)._clear_journal.get_open_operation()
     assert recovery is not None
     assert recovery.operation_id == "interrupted-clear"
     assert recovery.state == "recovery_needed"
@@ -2434,7 +2442,6 @@ def test_runtime_install_artifact_uses_controller_owned_manager(tmp_path: Path) 
 
 
 def test_runtime_install_artifact_converts_background_ensure_exception(
-    monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
     artifact = _installed_artifact(ensure_failure=RuntimeError("install failed"))
@@ -2443,28 +2450,12 @@ def test_runtime_install_artifact_converts_background_ensure_exception(
         artifact_manager=artifact,
         effective_home=tmp_path,
     )
-    housekeeping_calls: list[tuple[str, bool]] = []
-
-    async def observe_terminal_gc() -> None:
-        housekeeping_calls.append(("terminal-gc", runtime._artifact_installing))
-
-    async def observe_backup_reconcile() -> None:
-        housekeeping_calls.append(("backup-reconcile", runtime._artifact_installing))
-
-    monkeypatch.setattr(runtime, "_run_terminal_snapshot_gc", observe_terminal_gc)
-    monkeypatch.setattr(runtime, "_run_backup_stage_reconcile", observe_backup_reconcile)
-
     async def run() -> None:
         assert await runtime.install_artifact() == {
             "ok": False,
             "reason": "memory_runtime_install_failed",
             "download_error": None,
         }
-        await asyncio.sleep(0)
-        assert sorted(housekeeping_calls) == [
-            ("backup-reconcile", False),
-            ("terminal-gc", False),
-        ]
         await runtime.close()
 
     asyncio.run(run())
@@ -3773,141 +3764,6 @@ def _processing_config() -> MemoryProcessingConfig:
     )
 
 
-async def _retain_terminal_clear_snapshot(
-    monkeypatch: pytest.MonkeyPatch,
-    home: Path,
-) -> Path:
-    runtime = MemoryRuntime(MemoryConfig(), effective_home=home)
-    manager = runtime._snapshot_manager
-    assert manager is not None
-
-    def retain(_permit) -> None:
-        raise OSError("retain terminal snapshot for startup GC")
-
-    monkeypatch.setattr(manager, "remove", retain)
-    completed = await runtime.clear(operator_ref="user:owner")
-    snapshot_path = manager.snapshot_path(completed["operation_id"])
-    assert completed["status"] == "completed"
-    assert snapshot_path.is_dir()
-    await runtime.close()
-    return snapshot_path
-
-
-def test_terminal_snapshot_gc_does_not_block_construction_or_ready_activation(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
-) -> None:
-    entered = threading.Event()
-    release = threading.Event()
-    finished = threading.Event()
-    synchronous_calls: list[str] = []
-    original_remove = MemorySnapshotManager.remove
-
-    def blocking_remove(manager: MemorySnapshotManager, permit) -> None:
-        try:
-            asyncio.get_running_loop()
-        except RuntimeError:
-            pass
-        else:
-            synchronous_calls.append(permit.snapshot_id)
-            raise AssertionError("terminal snapshot GC ran on the activation loop")
-        entered.set()
-        assert release.wait(timeout=2)
-        try:
-            original_remove(manager, permit)
-        finally:
-            finished.set()
-
-    async def run() -> None:
-        snapshot_path = await _retain_terminal_clear_snapshot(monkeypatch, tmp_path)
-        monkeypatch.setattr(MemorySnapshotManager, "remove", blocking_remove)
-        factory = FakeEverOSProcessFactory()
-        runtime = MemoryRuntime(
-            MemoryConfig(enabled=True, processing=_processing_config()),
-            artifact_manager=_installed_artifact(),
-            process_factory=factory,
-            effective_home=tmp_path,
-        )
-
-        assert synchronous_calls == []
-        assert await runtime.reconcile(runtime._config) == {
-            "ok": True,
-            "state": "ready",
-        }
-        assert factory.supervised[0].running is True
-        assert entered.is_set() is False
-
-        gc_task = runtime._terminal_snapshot_gc_task
-        assert gc_task is not None
-        assert await asyncio.to_thread(entered.wait, 1)
-        assert not gc_task.done()
-        release.set()
-        await asyncio.wait_for(asyncio.shield(gc_task), timeout=1)
-
-        assert finished.is_set()
-        assert not snapshot_path.exists()
-        await runtime.close()
-
-    asyncio.run(run())
-
-
-def test_terminal_snapshot_gc_shutdown_owns_cancelled_io_until_it_settles(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
-) -> None:
-    entered = threading.Event()
-    release = threading.Event()
-    finished = threading.Event()
-    original_remove = MemorySnapshotManager.remove
-
-    def blocking_remove(manager: MemorySnapshotManager, permit) -> None:
-        entered.set()
-        assert release.wait(timeout=2)
-        try:
-            original_remove(manager, permit)
-        finally:
-            finished.set()
-
-    async def run() -> None:
-        snapshot_path = await _retain_terminal_clear_snapshot(monkeypatch, tmp_path)
-        monkeypatch.setattr(MemorySnapshotManager, "remove", blocking_remove)
-        runtime = MemoryRuntime(MemoryConfig(), effective_home=tmp_path)
-
-        assert await runtime.reconcile(MemoryConfig()) == {
-            "ok": True,
-            "state": "disabled",
-        }
-        gc_task = runtime._terminal_snapshot_gc_task
-        assert gc_task is not None
-        assert await asyncio.to_thread(entered.wait, 1)
-
-        stop_entered = asyncio.Event()
-        original_stop = runtime._stop_terminal_snapshot_gc
-
-        async def observed_stop() -> None:
-            stop_entered.set()
-            await original_stop()
-
-        monkeypatch.setattr(runtime, "_stop_terminal_snapshot_gc", observed_stop)
-        closing = asyncio.create_task(runtime.close())
-        await stop_entered.wait()
-        assert not closing.done()
-        closing.cancel()
-        await asyncio.sleep(0)
-        assert not closing.done()
-
-        release.set()
-        with pytest.raises(asyncio.CancelledError):
-            await asyncio.wait_for(closing, timeout=1)
-
-        assert finished.is_set()
-        assert gc_task.done()
-        assert runtime._terminal_snapshot_gc_task is None
-        assert not snapshot_path.exists()
-
-    asyncio.run(run())
-
-
 def test_runtime_restart_replaces_process_without_processing_preflight(tmp_path: Path) -> None:
     factory = FakeEverOSProcessFactory()
     runtime = MemoryRuntime(
@@ -4411,7 +4267,7 @@ def test_runtime_restart_fails_closed_before_launch_for_marker_or_clear_recovery
     )
 
     meta = recovering._store.ensure_meta()
-    recovering._clear_journal.start(
+    _maintenance(recovering)._clear_journal.start(
         operation_id="restart-recovery",
         operator_ref="user:owner",
         pre_epoch=meta.epoch,
@@ -4546,7 +4402,7 @@ def test_ready_callback_waits_for_runtime_lifecycle_and_revalidates_process(
                 await release.wait()
                 raise RuntimeError("injected clear pause")
 
-            monkeypatch.setattr(runtime, "_prepare_clear", blocked_prepare)
+            monkeypatch.setattr(_maintenance(runtime), "_prepare_clear", blocked_prepare)
             operation = asyncio.create_task(runtime.clear(operator_ref="user:owner"))
         elif lifecycle == "reconcile":
             async def blocked_reconcile(*_args, **_kwargs):
@@ -4663,17 +4519,6 @@ def test_cancelled_artifact_install_owns_ensure_until_restart_can_enter(
     )
     activations: list[None] = []
     monkeypatch.setattr(runtime, "_ensure_worker", lambda: activations.append(None))
-    housekeeping_calls: list[tuple[str, bool]] = []
-
-    async def observe_terminal_gc() -> None:
-        housekeeping_calls.append(("terminal-gc", runtime._artifact_installing))
-
-    async def observe_backup_reconcile() -> None:
-        housekeeping_calls.append(("backup-reconcile", runtime._artifact_installing))
-
-    monkeypatch.setattr(runtime, "_run_terminal_snapshot_gc", observe_terminal_gc)
-    monkeypatch.setattr(runtime, "_run_backup_stage_reconcile", observe_backup_reconcile)
-
     async def run() -> None:
         installing = asyncio.create_task(runtime.install_artifact())
         assert await asyncio.to_thread(entered.wait, 1.0)
@@ -4691,7 +4536,6 @@ def test_cancelled_artifact_install_owns_ensure_until_restart_can_enter(
             "error": "memory_restart_failed",
         }
         await asyncio.sleep(0)
-        assert housekeeping_calls == []
         assert installing.done() is False
         installing.cancel()
         await asyncio.sleep(0)
@@ -4704,75 +4548,8 @@ def test_cancelled_artifact_install_owns_ensure_until_restart_can_enter(
         release.set()
         with pytest.raises(asyncio.CancelledError):
             await installing
-        await asyncio.sleep(0)
-        assert sorted(housekeeping_calls) == [
-            ("backup-reconcile", False),
-            ("terminal-gc", False),
-        ]
-        housekeeping_calls.clear()
         assert await runtime.restart() == {"ok": True, "state": "ready"}
         assert activations == [None]
-        await runtime.close()
-
-    asyncio.run(run())
-
-
-def test_queued_backup_stage_reconcile_rechecks_artifact_install(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
-) -> None:
-    install_entered = threading.Event()
-    release_install = threading.Event()
-
-    class BlockingArtifact(FakeMemoryArtifactManager):
-        def ensure(self, *, force: bool = False) -> dict:
-            self.ensure_calls.append(force)
-            install_entered.set()
-            release_install.wait(timeout=2)
-            return dict(self.ensure_payload)
-
-    runtime = MemoryRuntime(
-        MemoryConfig(enabled=False),
-        artifact_manager=BlockingArtifact(python=Path(sys.executable)),
-        effective_home=tmp_path,
-    )
-    terminal_gc_entered = asyncio.Event()
-    release_terminal_gc = asyncio.Event()
-    cleanup_calls: list[bool] = []
-
-    async def blocked_terminal_gc() -> None:
-        terminal_gc_entered.set()
-        await release_terminal_gc.wait()
-
-    manager = runtime._backup_manager
-    assert manager is not None
-    monkeypatch.setattr(runtime, "_run_terminal_snapshot_gc", blocked_terminal_gc)
-    monkeypatch.setattr(
-        manager,
-        "reconcile_unpublished_backup_stages",
-        lambda: cleanup_calls.append(runtime._artifact_installing),
-    )
-
-    async def run() -> None:
-        runtime._ensure_terminal_snapshot_gc()
-        runtime._ensure_backup_stage_reconcile()
-        await terminal_gc_entered.wait()
-        queued_reconcile = runtime._backup_stage_reconcile_task
-        assert queued_reconcile is not None
-
-        installing = asyncio.create_task(runtime.install_artifact())
-        assert await asyncio.to_thread(install_entered.wait, 1)
-        release_terminal_gc.set()
-        await queued_reconcile
-        assert cleanup_calls == []
-
-        release_install.set()
-        assert (await installing)["ok"] is True
-        deferred_reconcile = runtime._backup_stage_reconcile_task
-        assert deferred_reconcile is not None
-        assert deferred_reconcile is not queued_reconcile
-        await deferred_reconcile
-        assert cleanup_calls == [False]
         await runtime.close()
 
     asyncio.run(run())


### PR DESCRIPTION
## Summary

- extract Clear, backup/restore, boot recovery, and housekeeping into the deep MemoryMaintenance owner
- keep MemoryRuntime as the provider lifecycle owner behind an ordered, capability-shaped maintenance port
- preserve public payloads while moving the maintenance contract suite and removing Runtime-private maintenance test seams

## Evidence

- Unit: 329 focused Memory tests passed across maintenance, Runtime, journals, snapshots, module, ProviderRoot, runtime release, and slice 3
- Contract: typed owner results are serialized by explicit Runtime delegation coverage; cancellation, durable recovery, receipts, lock fencing, and housekeeping ordering remain covered
- Scenario: no scenario catalog IDs apply to this internal ownership refactor
- Residual manual checks: none; no UI or user workflow changed
- Static: Ruff passed on every changed Python file; git diff --check passed

Closes #1243