### PR TITLE
feat(ui): render a standalone app tab full-bleed

### DIFF
--- a/ui/src/apps/appLaunch.test.ts
+++ b/ui/src/apps/appLaunch.test.ts
@@ -5,6 +5,7 @@ import {
   appTabHref,
   appTabHrefForDockId,
   isAppleContextClick,
+  isStandaloneAppRoutePath,
   isStandaloneAppTab,
   tabModifierLabel,
 } from './appLaunch';
@@ -143,6 +144,25 @@ describe('isStandaloneAppTab', () => {
     // The sidebar Apps launcher and a chat's "open in editor" land on /apps/editor
     // WITHOUT the flag; those must keep the workbench windows they navigated from.
     expect(isStandaloneAppTab(new URL('http://x/apps/editor').search)).toBe(false);
+  });
+});
+
+describe('isStandaloneAppRoutePath', () => {
+  it('matches exactly the built-ins that own a standalone route', () => {
+    expect(isStandaloneAppRoutePath('/apps/terminal')).toBe(true);
+    expect(isStandaloneAppRoutePath('/apps/files')).toBe(true);
+    expect(isStandaloneAppRoutePath('/apps/editor')).toBe(true);
+    // The Library opens a WINDOW (and redirects the tab), so it never goes chromeless.
+    expect(isStandaloneAppRoutePath('/apps/library')).toBe(false);
+    expect(isStandaloneAppRoutePath('/apps/show/sess42')).toBe(false);
+  });
+
+  it('is false off the app routes', () => {
+    // A standalone tab that navigates away is an ordinary page again — chrome comes back.
+    expect(isStandaloneAppRoutePath('/')).toBe(false);
+    expect(isStandaloneAppRoutePath('/chat/sess42')).toBe(false);
+    expect(isStandaloneAppRoutePath('/apps')).toBe(false);
+    expect(isStandaloneAppRoutePath('/apps/terminal/extra')).toBe(false);
   });
 });
 

--- a/ui/src/apps/appLaunch.test.ts
+++ b/ui/src/apps/appLaunch.test.ts
@@ -157,6 +157,12 @@ describe('isStandaloneAppRoutePath', () => {
     expect(isStandaloneAppRoutePath('/apps/show/sess42')).toBe(false);
   });
 
+  it('accepts the trailing-slash variant React Router still renders', () => {
+    expect(isStandaloneAppRoutePath('/apps/terminal/')).toBe(true);
+    expect(isStandaloneAppRoutePath('/apps/files//')).toBe(true);
+    expect(isStandaloneAppRoutePath('/apps/library/')).toBe(false);
+  });
+
   it('is false off the app routes', () => {
     // A standalone tab that navigates away is an ordinary page again — chrome comes back.
     expect(isStandaloneAppRoutePath('/')).toBe(false);

--- a/ui/src/apps/appLaunch.test.ts
+++ b/ui/src/apps/appLaunch.test.ts
@@ -157,10 +157,15 @@ describe('isStandaloneAppRoutePath', () => {
     expect(isStandaloneAppRoutePath('/apps/show/sess42')).toBe(false);
   });
 
-  it('accepts the trailing-slash variant React Router still renders', () => {
+  it('accepts the route variants React Router still mounts', () => {
+    // Trailing slashes and casing are both matched loosely by the router, so the layout
+    // must agree with what mounted rather than with the literal URL.
     expect(isStandaloneAppRoutePath('/apps/terminal/')).toBe(true);
     expect(isStandaloneAppRoutePath('/apps/files//')).toBe(true);
+    expect(isStandaloneAppRoutePath('/Apps/Files')).toBe(true);
+    expect(isStandaloneAppRoutePath('/APPS/TERMINAL/')).toBe(true);
     expect(isStandaloneAppRoutePath('/apps/library/')).toBe(false);
+    expect(isStandaloneAppRoutePath('/Apps/Library')).toBe(false);
   });
 
   it('is false off the app routes', () => {

--- a/ui/src/apps/appLaunch.ts
+++ b/ui/src/apps/appLaunch.ts
@@ -170,10 +170,13 @@ export function isStandaloneAppTab(search: string): boolean {
  * standalone app opts into both behaviors in one place.
  *
  * Only the exact route matches: a standalone tab that navigates elsewhere (e.g. Files →
- * `/chat/<id>`) is an ordinary page again and gets the chrome back.
+ * `/chat/<id>`) is an ordinary page again and gets the chrome back. Trailing slashes are
+ * normalized away first, the same way `isApplicationRouteHref` does it: React Router
+ * renders `/apps/files/` as the Files route, so the layout must agree with what mounted.
  */
 export function isStandaloneAppRoutePath(pathname: string): boolean {
-  const id = pathname.startsWith('/apps/') ? pathname.slice('/apps/'.length) : '';
+  const normalized = pathname.replace(/\/+$/, '') || '/';
+  const id = normalized.startsWith('/apps/') ? normalized.slice('/apps/'.length) : '';
   return STANDALONE_BUILTIN_ROUTES.has(id);
 }
 

--- a/ui/src/apps/appLaunch.ts
+++ b/ui/src/apps/appLaunch.ts
@@ -170,12 +170,16 @@ export function isStandaloneAppTab(search: string): boolean {
  * standalone app opts into both behaviors in one place.
  *
  * Only the exact route matches: a standalone tab that navigates elsewhere (e.g. Files →
- * `/chat/<id>`) is an ordinary page again and gets the chrome back. Trailing slashes are
- * normalized away first, the same way `isApplicationRouteHref` does it: React Router
- * renders `/apps/files/` as the Files route, so the layout must agree with what mounted.
+ * `/chat/<id>`) is an ordinary page again and gets the chrome back.
+ *
+ * The pathname is normalized to what React Router actually MOUNTED first — trailing
+ * slashes stripped (as `isApplicationRouteHref` does) and case folded, since the router
+ * matches case-insensitively by default. `/Apps/Files/?standalone=1` mounts the Files
+ * page, so it must get the standalone layout too; disagreeing would leave the document
+ * half-standalone (windows suppressed, chrome restored).
  */
 export function isStandaloneAppRoutePath(pathname: string): boolean {
-  const normalized = pathname.replace(/\/+$/, '') || '/';
+  const normalized = pathname.replace(/\/+$/, '').toLowerCase() || '/';
   const id = normalized.startsWith('/apps/') ? normalized.slice('/apps/'.length) : '';
   return STANDALONE_BUILTIN_ROUTES.has(id);
 }

--- a/ui/src/apps/appLaunch.ts
+++ b/ui/src/apps/appLaunch.ts
@@ -162,6 +162,21 @@ export function isStandaloneAppTab(search: string): boolean {
   }
 }
 
+/**
+ * Whether a pathname is one of the built-in app routes a standalone tab can land on
+ * (`STANDALONE_BUILTIN_ROUTES`). Combined with `isStandaloneAppTab`, this is what tells
+ * the shell to drop ALL chrome — sidebar, mobile header/tab bar, page padding — so the
+ * app owns the whole viewport. Kept here, next to the allowlist it reads, so a new
+ * standalone app opts into both behaviors in one place.
+ *
+ * Only the exact route matches: a standalone tab that navigates elsewhere (e.g. Files →
+ * `/chat/<id>`) is an ordinary page again and gets the chrome back.
+ */
+export function isStandaloneAppRoutePath(pathname: string): boolean {
+  const id = pathname.startsWith('/apps/') ? pathname.slice('/apps/'.length) : '';
+  return STANDALONE_BUILTIN_ROUTES.has(id);
+}
+
 /** `appTabHref` for a persisted Dock id (`files` / `show:<session_id>`). */
 export function appTabHrefForDockId(
   dockId: string,

--- a/ui/src/components/AppShell.tsx
+++ b/ui/src/components/AppShell.tsx
@@ -4,7 +4,7 @@ import { ArrowLeft, Bot, Brain, ChevronDown, Cpu, FolderTree, Globe, Grid2x2, Ha
 import { useTranslation } from 'react-i18next';
 import clsx from 'clsx';
 
-import { isStandaloneAppRoutePath, isStandaloneAppTab } from '../apps/appLaunch';
+import { APP_TAB_PARAM, isStandaloneAppRoutePath, isStandaloneAppTab } from '../apps/appLaunch';
 import { StandaloneAppTabContext } from '../context/StandaloneAppTabContext';
 import { modelHubEnabledFromConfig } from './settings/models/featureFlags';
 import { memoryNavShouldBeVisible } from '../lib/memorySettings';
@@ -286,6 +286,33 @@ export const AppShell: React.FC = () => {
     setAppsDrawerOpen(false);
   }, [location.pathname]);
 
+  // A single-app tab sitting on the app's own route (⌘/Ctrl-clicked Terminal / Files /
+  // Editor, or that URL bookmarked): the tab exists to show ONE app, so it drops EVERY
+  // piece of shell chrome — sidebar, mobile brand header, bottom tab bar, page padding —
+  // and hands the whole viewport to the app. Both halves matter: the flag alone would
+  // strip the chrome off any page such a tab later navigates to, and the route alone
+  // would strip it inside the normal workbench. The app pages render their full-bleed
+  // body off the same signal (StandaloneAppTabContext).
+  const chromeless = standaloneAppTab && isStandaloneAppRoutePath(location.pathname);
+
+  // Keep the visible URL honest about standalone mode. An in-tab app-to-app navigation
+  // (Files → "Open in Editor" / "Open Terminal Here") lands on `/apps/editor` WITHOUT the
+  // marker, while the document is still the single-app tab — `standaloneAppTab` is frozen
+  // at mount by design. Reloading, bookmarking, or copying that URL would otherwise bring
+  // back the full workbench chrome and the restored window layout the tab exists to avoid.
+  //
+  // `history.replaceState` rather than a router navigate: this only corrects what the
+  // address bar shows, and leaving the router's own location (and `location.key`) untouched
+  // keeps launch effects keyed on it — the Terminal's "open one tab per launch" — from
+  // firing a second time for the same navigation.
+  useEffect(() => {
+    if (!chromeless) return;
+    const url = new URL(window.location.href);
+    if (url.searchParams.get(APP_TAB_PARAM) === '1') return;
+    url.searchParams.set(APP_TAB_PARAM, '1');
+    window.history.replaceState(window.history.state, '', `${url.pathname}${url.search}${url.hash}`);
+  }, [chromeless, location.pathname, location.search]);
+
   const hasChannelPlatforms = enabledPlatforms.some((platform) => platformSupportsChannels(config, platform));
   const modelHubEnabled = modelHubEnabledFromConfig(config);
   const isRunning = status.state === 'running';
@@ -409,14 +436,6 @@ export const AppShell: React.FC = () => {
   const isSearch = location.pathname === '/search';
   const isFullScreenMobile = isChat || isSearch;
 
-  // A single-app tab sitting on the app's own route (⌘/Ctrl-clicked Terminal / Files /
-  // Editor, or that URL bookmarked): the tab exists to show ONE app, so it drops EVERY
-  // piece of shell chrome — sidebar, mobile brand header, bottom tab bar, page padding —
-  // and hands the whole viewport to the app. Both halves matter: the flag alone would
-  // strip the chrome off any page such a tab later navigates to, and the route alone
-  // would strip it inside the normal workbench. The app pages render their full-bleed
-  // body off the same signal (StandaloneAppTabContext).
-  const chromeless = standaloneAppTab && isStandaloneAppRoutePath(location.pathname);
   const showBottomNav = !isFullScreenMobile && !chromeless && location.pathname !== '/setup';
 
   return (

--- a/ui/src/components/AppShell.tsx
+++ b/ui/src/components/AppShell.tsx
@@ -4,7 +4,8 @@ import { ArrowLeft, Bot, Brain, ChevronDown, Cpu, FolderTree, Globe, Grid2x2, Ha
 import { useTranslation } from 'react-i18next';
 import clsx from 'clsx';
 
-import { isStandaloneAppTab } from '../apps/appLaunch';
+import { isStandaloneAppRoutePath, isStandaloneAppTab } from '../apps/appLaunch';
+import { StandaloneAppTabContext } from '../context/StandaloneAppTabContext';
 import { modelHubEnabledFromConfig } from './settings/models/featureFlags';
 import { memoryNavShouldBeVisible } from '../lib/memorySettings';
 import { useApi } from '../context/ApiContext';
@@ -407,7 +408,16 @@ export const AppShell: React.FC = () => {
   const isChat = location.pathname.startsWith('/chat/');
   const isSearch = location.pathname === '/search';
   const isFullScreenMobile = isChat || isSearch;
-  const showBottomNav = !isFullScreenMobile && location.pathname !== '/setup';
+
+  // A single-app tab sitting on the app's own route (⌘/Ctrl-clicked Terminal / Files /
+  // Editor, or that URL bookmarked): the tab exists to show ONE app, so it drops EVERY
+  // piece of shell chrome — sidebar, mobile brand header, bottom tab bar, page padding —
+  // and hands the whole viewport to the app. Both halves matter: the flag alone would
+  // strip the chrome off any page such a tab later navigates to, and the route alone
+  // would strip it inside the normal workbench. The app pages render their full-bleed
+  // body off the same signal (StandaloneAppTabContext).
+  const chromeless = standaloneAppTab && isStandaloneAppRoutePath(location.pathname);
+  const showBottomNav = !isFullScreenMobile && !chromeless && location.pathname !== '/setup';
 
   return (
     // Mobile: a LOCKED, full-viewport flex column (overflow-hidden) so the
@@ -419,13 +429,22 @@ export const AppShell: React.FC = () => {
     // pans the locked page to lift the focused composer above the keyboard.
     // Desktop: normal document flow.
     <WindowManagerProvider standalone={standaloneAppTab}>
+    <StandaloneAppTabContext.Provider value={chromeless}>
     <DockProvider>
     <ShowPageDragProvider>
-    <div className="flex h-[var(--app-shell-h)] flex-col overflow-hidden bg-background text-foreground md:block md:h-auto md:min-h-screen md:overflow-visible">
+    {/* Chromeless (single-app tab): the locked full-viewport column applies on DESKTOP too —
+        the app fills the browser area exactly, with nothing to scroll around it. */}
+    <div
+      className={clsx(
+        'flex h-[var(--app-shell-h)] flex-col overflow-hidden bg-background text-foreground',
+        !chromeless && 'md:block md:h-auto md:min-h-screen md:overflow-visible'
+      )}
+    >
       {/* The sidebar forms its own stacking context BELOW the window layer (aside z-10 < window
           layer z-20), so a maximized window covers the WHOLE sidebar — including the Apps launcher.
           The Apps button no longer floats on top in full-screen (a Dock redesign comes later);
           un-maximize to reach it. */}
+      {!chromeless && (
       <aside className="fixed inset-y-0 left-0 z-10 hidden w-[240px] flex-col border-r border-border bg-surface md:flex">
         {/* Workbench packs more rows (search/inbox/capabilities/projects) into the
             sidebar, so it runs a tighter vertical rhythm than admin — less outer
@@ -540,11 +559,13 @@ export const AppShell: React.FC = () => {
           </div>
         </div>
       </aside>
+      )}
 
       {/* Chat and Search are fixed full-screen surfaces with their own header
           bars, so the brand header is hidden there (otherwise it would sit
-          behind them). */}
-      {!isFullScreenMobile && (
+          behind them). A chromeless single-app tab hides it for the same
+          reason: the app owns the viewport. */}
+      {!isFullScreenMobile && !chromeless && (
         <header className="sticky top-0 z-40 flex h-[calc(4rem+env(safe-area-inset-top))] shrink-0 items-center justify-between gap-2 border-b border-border bg-background/92 px-4 pt-[env(safe-area-inset-top)] backdrop-blur md:hidden">
           <div className="flex min-w-0 items-center gap-2">
             <img
@@ -566,12 +587,17 @@ export const AppShell: React.FC = () => {
           // Mobile: the internal scroll area of the locked flex-column shell, so
           // the document itself never scrolls. Desktop: normal flow (min-h-screen
           // + sidebar offset).
-          'flex-1 min-h-0 overflow-y-auto md:ml-[240px] md:min-h-screen md:flex-none md:overflow-visible md:pb-0',
-          showBottomNav ? 'pb-[calc(5.5rem+env(safe-area-inset-bottom))]' : 'pb-0',
-          location.pathname.startsWith('/admin/settings') ? 'page-glow-settings' : 'page-glow-console'
+          chromeless
+            // Single-app tab: no sidebar offset, no scroll, no page glow — the app body
+            // is the only thing in the viewport and sizes itself to this box (h-full).
+            ? 'min-h-0 flex-1 overflow-hidden'
+            : 'flex-1 min-h-0 overflow-y-auto md:ml-[240px] md:min-h-screen md:flex-none md:overflow-visible md:pb-0',
+          !chromeless && (showBottomNav ? 'pb-[calc(5.5rem+env(safe-area-inset-bottom))]' : 'pb-0'),
+          !chromeless &&
+            (location.pathname.startsWith('/admin/settings') ? 'page-glow-settings' : 'page-glow-console')
         )}
       >
-        <div className="mx-auto w-full px-4 py-5 md:px-10 md:py-8">
+        <div className={clsx('w-full', chromeless ? 'h-full' : 'mx-auto px-4 py-5 md:px-10 md:py-8')}>
           {/* A crashing page only replaces the content area — the sidebar + chrome stay usable, and
               navigating elsewhere clears the error without a manual retry. Key on location.key (not
               just pathname) so a query-only navigation (e.g. /search?q=…) also resets. */}
@@ -653,6 +679,7 @@ export const AppShell: React.FC = () => {
     </div>
     </ShowPageDragProvider>
     </DockProvider>
+    </StandaloneAppTabContext.Provider>
     </WindowManagerProvider>
   );
 };

--- a/ui/src/components/AppShell.tsx
+++ b/ui/src/components/AppShell.tsx
@@ -291,8 +291,13 @@ export const AppShell: React.FC = () => {
   // piece of shell chrome — sidebar, mobile brand header, bottom tab bar, page padding —
   // and hands the whole viewport to the app. Both halves matter: the flag alone would
   // strip the chrome off any page such a tab later navigates to, and the route alone
-  // would strip it inside the normal workbench. The app pages render their full-bleed
-  // body off the same signal (StandaloneAppTabContext).
+  // would strip it inside the normal workbench.
+  //
+  // Route-scoped, and therefore LOCAL to the layout: what `StandaloneAppTabContext`
+  // publishes is the mount-frozen document flag instead, because the window controls
+  // that read it must stay decided for the tab's whole life (see the context doc). The
+  // app pages read the same context and mount only on these routes, so for them the two
+  // agree anyway.
   const chromeless = standaloneAppTab && isStandaloneAppRoutePath(location.pathname);
 
   // Keep the visible URL honest about standalone mode. An in-tab app-to-app navigation
@@ -448,7 +453,7 @@ export const AppShell: React.FC = () => {
     // pans the locked page to lift the focused composer above the keyboard.
     // Desktop: normal document flow.
     <WindowManagerProvider standalone={standaloneAppTab}>
-    <StandaloneAppTabContext.Provider value={chromeless}>
+    <StandaloneAppTabContext.Provider value={standaloneAppTab}>
     <DockProvider>
     <ShowPageDragProvider>
     {/* Chromeless (single-app tab): the locked full-viewport column applies on DESKTOP too —

--- a/ui/src/components/apps/AppWindow.tsx
+++ b/ui/src/components/apps/AppWindow.tsx
@@ -9,6 +9,7 @@ import { APP_REGISTRY } from '../../apps/registry';
 import { showPageAvatar, showPageIconUrl } from '../../apps/showPageAvatar';
 import { ShowPageAvatarContent } from '../../apps/showPageAvatarTile';
 import { useWindowManager, type WindowInstance } from '../../context/WindowManagerContext';
+import { useStandaloneAppTab } from '../../context/StandaloneAppTabContext';
 import { useUnsavedChangesActionGuard } from '../../context/useUnsavedChangesActionGuard';
 import { clampToLayer, resizeBounds, type ResizeDir } from '../../lib/windowBounds';
 import { WindowBodyGestureShield } from './WindowBodyGestureShield';
@@ -165,6 +166,9 @@ export const AppWindow: React.FC<{
   const showpageSid = win.appId === 'showpage' ? (win.params?.sessionId as string | undefined) : undefined;
   const showpageAvatar = showpageSid ? showPageAvatar(showpageSid, win.title ?? '') : null;
   const focused = wm.focusedId === win.id;
+  // A chromeless single-app tab has no sidebar, hence no Dock/Apps launcher to restore
+  // a minimized window from — so this window doesn't offer minimize at all (see `lights`).
+  const chromeless = useStandaloneAppTab();
   // A standalone-surface app (v1: showpage) exposes an external URL for its own
   // browser tab; the title bar then shows an open-in-new-tab button.
   const externalHref = def.externalHref?.(win.params);
@@ -209,7 +213,14 @@ export const AppWindow: React.FC<{
     },
     // Minimize is a mounted hide (no exit animation): the body keeps running and
     // `inert` on the root pulls focus out, so nothing is trapped in a hidden window.
-    { key: 'min', color: '#febc2e', Glyph: Minus, onClick: () => wm.minimize(win.id), label: t('apps.window.minimize') },
+    // Withheld on a chromeless single-app tab: minimizing sends the window to the Dock,
+    // and that tab renders no sidebar — so the Apps launcher, the only surface that can
+    // restore an undocked window (a preview, a second Editor), isn't there. Without this
+    // the window would be hidden, inert, and unreachable, taking any unsaved buffer with
+    // it on reload (a standalone tab never persists its windows).
+    ...(chromeless
+      ? []
+      : [{ key: 'min', color: '#febc2e', Glyph: Minus, onClick: () => wm.minimize(win.id), label: t('apps.window.minimize') }]),
     { key: 'max', color: '#28c840', Glyph: Plus, onClick: () => wm.toggleMaximize(win.id), label: t('apps.window.maximize') },
   ];
 

--- a/ui/src/components/apps/AppWindow.tsx
+++ b/ui/src/components/apps/AppWindow.tsx
@@ -363,7 +363,11 @@ export const AppWindow: React.FC<{
                 // Jump to the owning session's chat and drop the window to the Dock
                 // (chat visible immediately; the Dock thumbnail brings the app back).
                 authorization.runNavigation(() => navigate(chatHref));
-                wm.minimize(win.id);
+                // Same reason the minimize light is withheld above: this tab's chrome —
+                // and with it the Dock — comes back only WHILE it sits on /chat. Going
+                // Back to the standalone app route hides the Dock again and would strand
+                // the window minimized and inert, so leave it shown instead.
+                if (!chromeless) wm.minimize(win.id);
               }}
               className="grid size-6 place-items-center rounded-md text-muted transition hover:bg-foreground/[0.06] hover:text-foreground"
             >

--- a/ui/src/components/apps/AppWindow.tsx
+++ b/ui/src/components/apps/AppWindow.tsx
@@ -166,9 +166,11 @@ export const AppWindow: React.FC<{
   const showpageSid = win.appId === 'showpage' ? (win.params?.sessionId as string | undefined) : undefined;
   const showpageAvatar = showpageSid ? showPageAvatar(showpageSid, win.title ?? '') : null;
   const focused = wm.focusedId === win.id;
-  // A chromeless single-app tab has no sidebar, hence no Dock/Apps launcher to restore
-  // a minimized window from — so this window doesn't offer minimize at all (see `lights`).
-  const chromeless = useStandaloneAppTab();
+  // A single-app tab has no sidebar, hence no Dock/Apps launcher to restore a minimized
+  // window from — so this window doesn't offer minimize at all (see `lights`). The whole
+  // TAB, not just its app route: stepping out to /chat lends the Dock back only until Back
+  // returns, which would leave anything minimized in between stranded and inert.
+  const standaloneTab = useStandaloneAppTab();
   // A standalone-surface app (v1: showpage) exposes an external URL for its own
   // browser tab; the title bar then shows an open-in-new-tab button.
   const externalHref = def.externalHref?.(win.params);
@@ -213,12 +215,12 @@ export const AppWindow: React.FC<{
     },
     // Minimize is a mounted hide (no exit animation): the body keeps running and
     // `inert` on the root pulls focus out, so nothing is trapped in a hidden window.
-    // Withheld on a chromeless single-app tab: minimizing sends the window to the Dock,
-    // and that tab renders no sidebar — so the Apps launcher, the only surface that can
-    // restore an undocked window (a preview, a second Editor), isn't there. Without this
-    // the window would be hidden, inert, and unreachable, taking any unsaved buffer with
-    // it on reload (a standalone tab never persists its windows).
-    ...(chromeless
+    // Withheld on a single-app tab: minimizing sends the window to the Dock, and that tab
+    // renders no sidebar — so the Apps launcher, the only surface that can restore an
+    // undocked window (a preview, a second Editor), isn't there. Without this the window
+    // would be hidden, inert, and unreachable, taking any unsaved buffer with it on reload
+    // (a standalone tab never persists its windows).
+    ...(standaloneTab
       ? []
       : [{ key: 'min', color: '#febc2e', Glyph: Minus, onClick: () => wm.minimize(win.id), label: t('apps.window.minimize') }]),
     { key: 'max', color: '#28c840', Glyph: Plus, onClick: () => wm.toggleMaximize(win.id), label: t('apps.window.maximize') },
@@ -367,7 +369,7 @@ export const AppWindow: React.FC<{
                 // and with it the Dock — comes back only WHILE it sits on /chat. Going
                 // Back to the standalone app route hides the Dock again and would strand
                 // the window minimized and inert, so leave it shown instead.
-                if (!chromeless) wm.minimize(win.id);
+                if (!standaloneTab) wm.minimize(win.id);
               }}
               className="grid size-6 place-items-center rounded-md text-muted transition hover:bg-foreground/[0.06] hover:text-foreground"
             >

--- a/ui/src/components/apps/WindowLayer.tsx
+++ b/ui/src/components/apps/WindowLayer.tsx
@@ -80,10 +80,12 @@ export const WindowLayer: React.FC = () => {
   // Any window open and NOT minimized — drives the layer's aria-hidden AND the
   // beforeunload guard (§7.1g).
   const anyShown = shouldGuardUnload(windows);
-  // A chromeless single-app tab renders no sidebar, so there is no Dock to restore a
-  // minimized window from — the titlebar drops its minimize light there, and ⌘/Ctrl+M
-  // goes with it rather than hiding a window the user can't get back.
-  const chromeless = useStandaloneAppTab();
+  // A single-app tab renders no sidebar, so there is no Dock to restore a minimized
+  // window from — the titlebar drops its minimize light there, and ⌘/Ctrl+M goes with it
+  // rather than hiding a window the user can't get back. Held for the whole tab, even
+  // while it steps onto a chrome-bearing route like /chat, since Back takes the Dock away
+  // again (the flag is the mount-frozen document one; see StandaloneAppTabContext).
+  const standaloneTab = useStandaloneAppTab();
   const ref = useRef<HTMLDivElement | null>(null);
   const [size, setSize] = useState({ w: 0, h: 0 });
   const [archivedSessionIds, setArchivedSessionIds] = useState<ReadonlySet<string>>(() => new Set());
@@ -127,14 +129,14 @@ export const WindowLayer: React.FC = () => {
       if (key === 'w') {
         e.preventDefault();
         if (confirmClose(targetId)) close(targetId);
-      } else if (key === 'm' && !chromeless) {
+      } else if (key === 'm' && !standaloneTab) {
         e.preventDefault();
         minimize(targetId);
       }
     };
     window.addEventListener('keydown', onKeyDown);
     return () => window.removeEventListener('keydown', onKeyDown);
-  }, [close, minimize, confirmClose, chromeless]);
+  }, [close, minimize, confirmClose, standaloneTab]);
 
   // ⌥W closes the focused in-app window — a browser-safe alternative to ⌘W, which
   // the browser reserves for tab-close (not interceptable). Uses `code` (macOS

--- a/ui/src/components/apps/WindowLayer.tsx
+++ b/ui/src/components/apps/WindowLayer.tsx
@@ -7,6 +7,7 @@ import { useDock } from '../../context/DockContext';
 import { dockIdToSession } from '../../context/dockDoc';
 import { useApi } from '../../context/ApiContext';
 import { useWindowManager, type WindowInstance } from '../../context/WindowManagerContext';
+import { useStandaloneAppTab } from '../../context/StandaloneAppTabContext';
 import { useShowPageInventory } from '../useShowPages';
 import { ShowPageAnnotationHost } from '../workbench/ShowPageAnnotationHost';
 import { AppWindow } from './AppWindow';
@@ -79,6 +80,10 @@ export const WindowLayer: React.FC = () => {
   // Any window open and NOT minimized — drives the layer's aria-hidden AND the
   // beforeunload guard (§7.1g).
   const anyShown = shouldGuardUnload(windows);
+  // A chromeless single-app tab renders no sidebar, so there is no Dock to restore a
+  // minimized window from — the titlebar drops its minimize light there, and ⌘/Ctrl+M
+  // goes with it rather than hiding a window the user can't get back.
+  const chromeless = useStandaloneAppTab();
   const ref = useRef<HTMLDivElement | null>(null);
   const [size, setSize] = useState({ w: 0, h: 0 });
   const [archivedSessionIds, setArchivedSessionIds] = useState<ReadonlySet<string>>(() => new Set());
@@ -122,14 +127,14 @@ export const WindowLayer: React.FC = () => {
       if (key === 'w') {
         e.preventDefault();
         if (confirmClose(targetId)) close(targetId);
-      } else if (key === 'm') {
+      } else if (key === 'm' && !chromeless) {
         e.preventDefault();
         minimize(targetId);
       }
     };
     window.addEventListener('keydown', onKeyDown);
     return () => window.removeEventListener('keydown', onKeyDown);
-  }, [close, minimize, confirmClose]);
+  }, [close, minimize, confirmClose, chromeless]);
 
   // ⌥W closes the focused in-app window — a browser-safe alternative to ⌘W, which
   // the browser reserves for tab-close (not interceptable). Uses `code` (macOS

--- a/ui/src/components/workbench/AppsEditorPage.tsx
+++ b/ui/src/components/workbench/AppsEditorPage.tsx
@@ -2,9 +2,11 @@ import { Suspense, lazy, useEffect, useMemo, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { CodeXml, FolderOpen } from 'lucide-react';
+import clsx from 'clsx';
 
 import { Button } from '../ui/button';
 import { useUnsavedChanges } from '../../context/useUnsavedChanges';
+import { useStandaloneAppTab } from '../../context/StandaloneAppTabContext';
 import { FileEditorPane } from './FileEditorPane';
 import { EditorFontSizePopover } from './EditorFontSizePopover';
 import { isDesktopViewport } from '../../lib/useIsDesktop';
@@ -77,19 +79,30 @@ export const AppsEditorPage: React.FC = () => {
   // Re-read whenever the router state changes (each navigation carries a fresh state object) so
   // opening another file while already on this route swaps the launch target.
   const launch = useMemo(() => readLaunch(location.state), [location.state]);
+  // A single-app browser tab (`?standalone=1`): the shell drops its chrome, so the editor
+  // fills the whole web area — no page header, no card border, no padding around it.
+  const fullBleed = useStandaloneAppTab();
   useUnsavedChanges(dirty ? t('apps.editor.confirmDiscardSwitch') : null);
   useUnloadWarning(dirty);
 
   return (
-    <div className="flex h-[calc(100dvh-7rem)] min-h-[460px] flex-col gap-3 md:h-[calc(100vh-8rem)]">
-      <div>
-        <h1 className="text-[18px] font-semibold text-foreground">{t('apps.editor.label')}</h1>
-        <p className="text-[12px] text-muted">{t('apps.editor.tagline')}</p>
-      </div>
+    <div
+      className={
+        fullBleed
+          ? 'flex h-full w-full flex-col bg-surface'
+          : 'flex h-[calc(100dvh-7rem)] min-h-[460px] flex-col gap-3 md:h-[calc(100vh-8rem)]'
+      }
+    >
+      {!fullBleed && (
+        <div>
+          <h1 className="text-[18px] font-semibold text-foreground">{t('apps.editor.label')}</h1>
+          <p className="text-[12px] text-muted">{t('apps.editor.tagline')}</p>
+        </div>
+      )}
       {desktop ? (
-        <DesktopEditor launch={launch} onDirtyChange={setDirty} />
+        <DesktopEditor launch={launch} onDirtyChange={setDirty} fullBleed={fullBleed} />
       ) : (
-        <MobileEditor launch={launch} onDirtyChange={setDirty} />
+        <MobileEditor launch={launch} onDirtyChange={setDirty} fullBleed={fullBleed} />
       )}
     </div>
   );
@@ -102,9 +115,13 @@ export const AppsEditorPage: React.FC = () => {
 const DesktopEditor: React.FC<{
   launch: LaunchFile | null;
   onDirtyChange: (dirty: boolean) => void;
-}> = ({ launch, onDirtyChange }) => {
+  fullBleed?: boolean;
+}> = ({ launch, onDirtyChange, fullBleed = false }) => {
   return (
-    <div data-theme="dark" className="flex min-h-0 flex-1 overflow-hidden rounded-xl border border-border bg-surface">
+    <div
+      data-theme="dark"
+      className={clsx('flex min-h-0 flex-1 overflow-hidden bg-surface', !fullBleed && 'rounded-xl border border-border')}
+    >
       <Suspense fallback={<PaneLoading />}>
         <EditorApp
           onDirtyChange={onDirtyChange}
@@ -122,7 +139,8 @@ const DesktopEditor: React.FC<{
 const MobileEditor: React.FC<{
   launch: LaunchFile | null;
   onDirtyChange: (dirty: boolean) => void;
-}> = ({ launch, onDirtyChange }) => {
+  fullBleed?: boolean;
+}> = ({ launch, onDirtyChange, fullBleed = false }) => {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const [file, setFile] = useState<LaunchFile | null>(launch);
@@ -140,7 +158,7 @@ const MobileEditor: React.FC<{
   const openAnother = () => navigate('/apps/files');
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-xl border border-border bg-surface">
+    <div className={clsx('flex min-h-0 flex-1 flex-col overflow-hidden bg-surface', !fullBleed && 'rounded-xl border border-border')}>
       {file ? (
         // Key by path so switching to a different file remounts the pane and reads it fresh —
         // FileEditorPane treats a live path change as a rename and skips the reread otherwise, which

--- a/ui/src/components/workbench/AppsFileBrowserPage.tsx
+++ b/ui/src/components/workbench/AppsFileBrowserPage.tsx
@@ -39,6 +39,7 @@ import clsx from 'clsx';
 
 import { useWorkbenchProjectsTree } from '../../context/WorkbenchProjectsContext';
 import { useWindowManager } from '../../context/WindowManagerContext';
+import { useStandaloneAppTab } from '../../context/StandaloneAppTabContext';
 import { isEditableFile, isEditableMeta, previewWindowKind } from '../../lib/filePreview';
 import {
   contentUrl,
@@ -206,6 +207,10 @@ export const AppsFileBrowserPage: React.FC<{ windowed?: boolean; windowId?: stri
   const { t } = useTranslation();
   const wm = useWindowManager();
   const routerNavigate = useNavigate();
+  // A single-app browser tab (`?standalone=1`) frames the app exactly like a window body —
+  // full-bleed, no page header or card border — since the shell drops its chrome there too.
+  const standalone = useStandaloneAppTab();
+  const fullBleed = windowed || standalone;
   const { projects } = useWorkbenchProjectsTree();
   const [cwd, setCwd] = useState('');
   const [listing, setListing] = useState<FsListing | null>(null);
@@ -1322,15 +1327,15 @@ export const AppsFileBrowserPage: React.FC<{ windowed?: boolean; windowId?: stri
     : 0;
 
   return (
-    <div className={windowed ? 'relative flex h-full w-full flex-col bg-surface' : 'relative flex h-[calc(100dvh-7rem)] min-h-[460px] flex-col gap-3 md:h-[calc(100vh-8rem)]'}>
-      {!windowed && (
+    <div className={fullBleed ? 'relative flex h-full w-full flex-col bg-surface' : 'relative flex h-[calc(100dvh-7rem)] min-h-[460px] flex-col gap-3 md:h-[calc(100vh-8rem)]'}>
+      {!fullBleed && (
         <div>
           <h1 className="text-[18px] font-semibold text-foreground">{t('apps.fileBrowser.label')}</h1>
           <p className="text-[12px] text-muted">{t('apps.fileBrowser.tagline')}</p>
         </div>
       )}
 
-      <div className={clsx('flex min-h-0 flex-1 flex-col overflow-hidden', !windowed && 'rounded-xl border border-border')}>
+      <div className={clsx('flex min-h-0 flex-1 flex-col overflow-hidden', !fullBleed && 'rounded-xl border border-border')}>
         {/* Toolbar: breadcrumb (left) + search + New File / New Folder (right) */}
         <div className="flex items-center gap-2 border-b border-border bg-surface-2/60 px-3 py-2">
           <div className="flex min-w-0 flex-1 items-center gap-0.5 overflow-x-auto">

--- a/ui/src/components/workbench/AppsTerminalPage.tsx
+++ b/ui/src/components/workbench/AppsTerminalPage.tsx
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 import { useLocation } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 
+import { useStandaloneAppTab } from '../../context/StandaloneAppTabContext';
 import { TerminalTabs } from './TerminalTabs';
 
 // A start directory handed to the terminal when navigating in from the File Browser on mobile
@@ -25,11 +26,24 @@ export const AppsTerminalPage: React.FC<{ windowed?: boolean; windowId?: string;
   // from `params.cwd` instead). location.key is unique per navigation, so TerminalTabs opens
   // exactly one tab per launch and leaves the persistent first tab as a reattach.
   const launchCwd = useMemo(() => readCwd(location.state), [location.state]);
+  // A single-app browser tab (`/apps/terminal?standalone=1`): the shell drops its chrome, so the
+  // terminal fills the whole web area — no page header, no card border, no padding around it.
+  // Still the ROUTE mount, so the first tab keeps its persistent reattachable session (unlike
+  // `windowed`, whose tabs are ephemeral).
+  const standalone = useStandaloneAppTab();
 
   if (windowed) {
     return (
       <div className="h-full w-full overflow-hidden bg-surface">
         <TerminalTabs windowed windowId={windowId} params={params} />
+      </div>
+    );
+  }
+
+  if (standalone) {
+    return (
+      <div className="flex h-full w-full overflow-hidden bg-surface">
+        <TerminalTabs launchCwd={launchCwd} launchKey={launchCwd ? location.key : undefined} />
       </div>
     );
   }

--- a/ui/src/context/StandaloneAppTabContext.ts
+++ b/ui/src/context/StandaloneAppTabContext.ts
@@ -6,6 +6,14 @@ import { createContext, useContext } from 'react';
  * the app pages under the route Outlet can render FULL-BLEED — no page header, no
  * rounded card, no shell chrome — instead of the padded workbench page layout.
  *
+ * The published value is the FROZEN document flag, not "is the tab currently on an app
+ * route". The window controls read it to withhold minimize (a chromeless tab renders no
+ * sidebar, so nothing can restore a minimized window), and that answer must hold for the
+ * tab's whole life: a standalone tab that steps out to `/chat/...` gets the Dock back
+ * only until Back returns it to the app route, which would strand anything minimized in
+ * between. The shell's own layout uses the route-scoped combination instead — it must
+ * put the chrome back on the pages a standalone tab navigates to.
+ *
  * Deliberately separate from the `windowed` prop an app body receives inside an
  * AppWindow: `windowed` also carries window semantics (ephemeral terminal sessions,
  * close guards, persisted window state), while a standalone tab is still the ROUTE

--- a/ui/src/context/StandaloneAppTabContext.ts
+++ b/ui/src/context/StandaloneAppTabContext.ts
@@ -1,0 +1,21 @@
+import { createContext, useContext } from 'react';
+
+/**
+ * Whether THIS document was opened as a single-app tab (`?standalone=1`, see
+ * `apps/appLaunch.ts`). The shell freezes the flag at mount and publishes it here so
+ * the app pages under the route Outlet can render FULL-BLEED — no page header, no
+ * rounded card, no shell chrome — instead of the padded workbench page layout.
+ *
+ * Deliberately separate from the `windowed` prop an app body receives inside an
+ * AppWindow: `windowed` also carries window semantics (ephemeral terminal sessions,
+ * close guards, persisted window state), while a standalone tab is still the ROUTE
+ * mount and keeps that route's behavior — it only drops the chrome.
+ *
+ * Defaults to false, so a page mounted outside the shell (tests, storybook-ish
+ * harnesses) keeps the normal padded layout.
+ */
+export const StandaloneAppTabContext = createContext(false);
+
+export function useStandaloneAppTab(): boolean {
+  return useContext(StandaloneAppTabContext);
+}


### PR DESCRIPTION
## Capability

Workbench → single-app browser tab (`appTabHref` / `?standalone=1`, the ⌘/Ctrl-click launch from the Dock, App Library, and ⌘K).

A standalone tab exists to show ONE app, but it still rendered the whole workbench frame around it — the 240px sidebar, the page header, the padded card — so a ⌘-clicked Terminal sat in a small box inside a mostly empty viewport. It now fills the web area edge to edge.

| | |
|---|---|
| Before | sidebar + "Terminal / A real shell, in your browser." header + `px-10 py-8` padding + rounded border around the shell |
| After | terminal owns the viewport; no sidebar, no header, no padding |

## Changes

- `apps/appLaunch.ts` — new `isStandaloneAppRoutePath()`, reading the existing `STANDALONE_BUILTIN_ROUTES` allowlist so a new standalone app opts into the URL and the chrome rule in one place.
- `context/StandaloneAppTabContext.ts` (new) — the shell's mount-frozen flag, published to the route pages under the Outlet. Deliberately separate from the `windowed` prop, which also carries window semantics (ephemeral terminal sessions, close guards, persisted window state): a standalone terminal tab is still the ROUTE mount and keeps its persistent reattachable first-tab session.
- `components/AppShell.tsx` — `chromeless = standaloneAppTab && isStandaloneAppRoutePath(pathname)` drops the sidebar, mobile brand header, bottom tab bar, `md:ml-[240px]` offset, and page padding/glow, and applies the locked full-viewport column on desktop as well as mobile. Both halves of the condition matter: the flag alone would strip the chrome off any page the tab later navigates to, and the route alone would strip it inside the normal workbench.
- `AppsTerminalPage` / `AppsFileBrowserPage` / `AppsEditorPage` — full-bleed body (no `h1` header, no rounded card border, `h-full`) on the same signal. Files and Editor are included because they share the mechanism and their `h-[calc(100vh-8rem)]` sizing assumes the header + padding the shell no longer renders.

Unchanged: `WindowLayer` still mounts in a standalone tab, per its existing contract that windows opened inside such a tab keep working.

## Evidence

- **Unit** — `ui/src/apps/appLaunch.test.ts`: 2 new cases for the route predicate (terminal/files/editor match; `/apps/library`, `/apps/show/:id`, `/apps`, `/chat/...` and a deeper path do not). 22 passed.
- **Contract / scenario** — no catalog scenario covers the single-app tab chrome; none updated.
- **Static** — `tsc -b` clean, `npm run lint` (baseline) no drift, `npm run build` clean.
- **Residual manual** — the rendered layout has not been eyeballed in a browser: the local checkout has no `jsdom` for DOM tests and no Playwright package for a screenshot. Worth a look at `/apps/terminal?standalone=1` on desktop and on a phone before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)