### PR TITLE
feat(voice): enable realtime input by default

### DIFF
--- a/.env.regression.example
+++ b/.env.regression.example
@@ -43,9 +43,6 @@ REGRESSION_DEFAULT_CWD=/home/avibe/.avibe/workdir
 REGRESSION_DEFAULT_BACKEND=opencode
 REGRESSION_LOG_LEVEL=INFO
 REGRESSION_LANGUAGE=en
-# Build-time gray rollout for realtime ASR. Changing this forces a UI rebuild.
-REGRESSION_VOICE_REALTIME_ENABLED=false
-
 # Master/worktree regression does not necessarily carry a packaged release
 # manifest, so the regression script prepares Show Runtime from source by
 # default. Release/pre-release installs should use the packaged manifest path.

--- a/docs/voice-realtime-prototype.md
+++ b/docs/voice-realtime-prototype.md
@@ -1,14 +1,8 @@
-# Realtime Voice Prototype
+# Realtime Voice
 
-The browser Realtime path is opt-in and preserves the existing HTTP dictation
-queue as its fallback. Enable `VITE_VOICE_REALTIME_ENABLED=true` in the UI
-build and `VOICE_REALTIME_ENABLED=true` in the cloud service only after both
-halves are deployed together. The default model is
+The browser Realtime path is enabled by default and preserves the existing HTTP
+dictation queue as its fallback. The default model is
 `qwen3-asr-flash-realtime`.
-
-For Incus regression builds, set `REGRESSION_VOICE_REALTIME_ENABLED=true` in
-`.env.regression`. The runner maps it to the Vite build flag and includes it in
-the UI fingerprint, so changing the flag forces a rebuild.
 
 The browser sends `start`, 250 ms PCM16 `audio`, and `finish` frames over the
 `avibe-asr-v1.<cloud-token>` subprotocol. The cloud route authenticates the

--- a/scripts/incus_regression.py
+++ b/scripts/incus_regression.py
@@ -151,13 +151,6 @@ def regression_env(suffix: str, default: str = "") -> str:
     return value.strip()
 
 
-def voice_realtime_build_env() -> str:
-    value = regression_env("VOICE_REALTIME_ENABLED", "false").lower()
-    if value not in {"true", "false"}:
-        raise RegressionError("REGRESSION_VOICE_REALTIME_ENABLED must be true or false.")
-    return value
-
-
 def host_bind_env(default: str = "127.0.0.1") -> str:
     return (
         regression_env("PORT_BIND_HOST")
@@ -863,7 +856,6 @@ def compute_fingerprints(repo_root: Path) -> dict:
                 "ui/tsconfig.node.json",
             ],
         ),
-        f"voice_realtime={voice_realtime_build_env()}",
     ]
     return {
         "python": file_hash(repo_root, ["pyproject.toml", "uv.lock"]),
@@ -927,10 +919,9 @@ def runtime_env_payload(repo_root: Path | None = None) -> bytes:
         "OPENAI_API_KEY": os.environ.get("OPENAI_API_KEY", ""),
         "OPENAI_BASE_URL": os.environ.get("OPENAI_BASE_URL", ""),
         "OPENAI_API_BASE": os.environ.get("OPENAI_API_BASE", ""),
-        "VITE_VOICE_REALTIME_ENABLED": voice_realtime_build_env(),
     }
     for key, value in os.environ.items():
-        if key == "REGRESSION_UI_HOST":
+        if key in {"REGRESSION_UI_HOST", "REGRESSION_VOICE_REALTIME_ENABLED"}:
             continue
         if key.startswith(ENV_PREFIX):
             mappings[key] = value
@@ -1222,11 +1213,10 @@ def update_dependencies_and_build(
             or ui_deps_changed
             or previous_fingerprints.get("ui_source") != next_fingerprints.get("ui_source")
         ):
-            realtime_enabled = voice_realtime_build_env()
             runner.run(
                 tenant_exec(
                     target,
-                    f"cd ui && VITE_VOICE_REALTIME_ENABLED={shlex.quote(realtime_enabled)} npm run build",
+                    "cd ui && npm run build",
                     remote=remote,
                 )
             )
@@ -1424,7 +1414,6 @@ def cmd_build_base(args: argparse.Namespace) -> int:
 def cmd_up(args: argparse.Namespace) -> int:
     repo_root = current_repo_root()
     loaded_env_file = load_env_file(repo_root, args.env_file)
-    voice_realtime_build_env()
     if not args.dry_run:
         require_incus()
     preflight_during_target_resolution = args.remote is None and args.target != MASTER_TARGET

--- a/tests/test_incus_regression.py
+++ b/tests/test_incus_regression.py
@@ -535,7 +535,7 @@ def test_ui_public_assets_are_part_of_source_fingerprint(tmp_path: Path) -> None
     assert before != after
 
 
-def test_voice_realtime_build_flag_is_part_of_ui_fingerprint(
+def test_legacy_voice_realtime_build_flag_does_not_change_ui_fingerprint(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -545,13 +545,13 @@ def test_voice_realtime_build_flag_is_part_of_ui_fingerprint(
     monkeypatch.setenv("REGRESSION_VOICE_REALTIME_ENABLED", "true")
     after = incus_regression.compute_fingerprints(tmp_path)["ui_source"]
 
-    assert before != after
+    assert before == after
 
 
 def test_runtime_env_payload_maps_show_runtime_and_llm_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("REGRESSION_SHOW_RUNTIME_GITHUB_REF", "main")
     monkeypatch.setenv("REGRESSION_SLACK_CHANNEL", "C123")
-    monkeypatch.setenv("REGRESSION_VOICE_REALTIME_ENABLED", "true")
+    monkeypatch.setenv("REGRESSION_VOICE_REALTIME_ENABLED", "false")
     monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
 
     payload = incus_regression.runtime_env_payload().decode()
@@ -562,39 +562,9 @@ def test_runtime_env_payload_maps_show_runtime_and_llm_env(monkeypatch: pytest.M
     assert "VIBE_SHOW_RUNTIME_SOURCE=github-source" in payload
     assert "VIBE_SHOW_RUNTIME_GITHUB_REF=main" in payload
     assert "REGRESSION_SLACK_CHANNEL=C123" in payload
-    assert "VITE_VOICE_REALTIME_ENABLED=true" in payload
+    assert "VITE_VOICE_REALTIME_ENABLED" not in payload
+    assert "REGRESSION_VOICE_REALTIME_ENABLED" not in payload
     assert "OPENAI_API_KEY=sk-test" in payload
-
-
-def test_runtime_env_payload_rejects_invalid_voice_realtime_flag(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setenv("REGRESSION_VOICE_REALTIME_ENABLED", "enabled")
-
-    with pytest.raises(
-        incus_regression.RegressionError,
-        match="REGRESSION_VOICE_REALTIME_ENABLED must be true or false",
-    ):
-        incus_regression.runtime_env_payload()
-
-
-def test_up_rejects_invalid_voice_realtime_flag_before_preflight(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    calls = []
-    monkeypatch.setenv("REGRESSION_VOICE_REALTIME_ENABLED", "enabled")
-    monkeypatch.setattr(incus_regression, "current_repo_root", lambda: tmp_path)
-    monkeypatch.setattr(incus_regression, "load_env_file", lambda repo_root, env_file: None)
-    monkeypatch.setattr(incus_regression, "require_incus", lambda: calls.append("require_incus"))
-
-    with pytest.raises(
-        incus_regression.RegressionError,
-        match="REGRESSION_VOICE_REALTIME_ENABLED must be true or false",
-    ):
-        incus_regression.cmd_up(argparse.Namespace(env_file=None, dry_run=False))
-
-    assert calls == []
 
 
 def test_runtime_env_payload_ignores_legacy_regression_env(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -2040,11 +2010,8 @@ def test_update_builds_ui_before_editable_install() -> None:
     assert build_index < install_index
 
 
-def test_force_ui_rebuilds_with_exported_voice_realtime_flag(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def test_force_ui_rebuilds_with_realtime_enabled_by_default() -> None:
     commands = []
-    monkeypatch.setenv("REGRESSION_VOICE_REALTIME_ENABLED", "true")
 
     class RecordingRunner:
         def run(self, command, **kwargs):
@@ -2074,7 +2041,7 @@ def test_force_ui_rebuilds_with_exported_voice_realtime_flag(
 
     joined = "\n".join(commands)
     assert "cd ui && npm ci" in joined
-    assert "cd ui && VITE_VOICE_REALTIME_ENABLED=true npm run build" in joined
+    assert "cd ui && npm run build" in joined
     assert "pip install -e ." not in joined
 
 
@@ -2150,7 +2117,7 @@ def test_missing_ui_dist_rebuilds_even_when_python_is_unchanged() -> None:
 
     joined = "\n".join(commands)
     assert "test -d ui/dist && test -f ui/dist/index.html" in joined
-    assert "VITE_VOICE_REALTIME_ENABLED=false npm run build" in joined
+    assert "cd ui && npm run build" in joined
     assert "pip install -e ." not in joined
 
 

--- a/ui/src/components/workbench/Composer.tsx
+++ b/ui/src/components/workbench/Composer.tsx
@@ -41,7 +41,6 @@ import {
   VoiceRecordingPipeline,
 } from '../../lib/voiceRecording';
 import {
-  isVoiceRealtimeEnabled,
   VoiceRealtimeSession,
   type VoiceRealtimeFinal,
 } from '../../lib/voiceRealtime';
@@ -970,32 +969,30 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
           dictationId,
         }),
       };
-      if (isVoiceRealtimeEnabled()) {
-        session.realtimeState = 'connecting';
-        session.realtime = new VoiceRealtimeSession({
-          before: insertion.before,
-          after: insertion.after,
-          signal: abortController.signal,
-          onPreview: (preview) => {
-            if (recordingSessionRef.current !== session || unmountedRef.current) return;
-            session.realtimeFirstPreviewAt ??= Date.now();
-            showRealtimePreview(session, `${preview.text}${preview.stash}`.trim());
-          },
-          onError: () => {
-            if (abortController.signal.aborted) return;
-            session.realtimeState = 'failed';
-            activateHttpFallback(session);
-          },
-        });
-        void session.realtime.start().then(() => {
-          if (abortController.signal.aborted) return;
-          session.realtimeState = 'active';
-        }).catch(() => {
+      session.realtimeState = 'connecting';
+      session.realtime = new VoiceRealtimeSession({
+        before: insertion.before,
+        after: insertion.after,
+        signal: abortController.signal,
+        onPreview: (preview) => {
+          if (recordingSessionRef.current !== session || unmountedRef.current) return;
+          session.realtimeFirstPreviewAt ??= Date.now();
+          showRealtimePreview(session, `${preview.text}${preview.stash}`.trim());
+        },
+        onError: () => {
           if (abortController.signal.aborted) return;
           session.realtimeState = 'failed';
           activateHttpFallback(session);
-        });
-      }
+        },
+      });
+      void session.realtime.start().then(() => {
+        if (abortController.signal.aborted) return;
+        session.realtimeState = 'active';
+      }).catch(() => {
+        if (abortController.signal.aborted) return;
+        session.realtimeState = 'failed';
+        activateHttpFallback(session);
+      });
       startingSession = session;
       const pipeline = new VoiceRecordingPipeline({
         stream,

--- a/ui/src/lib/voiceRealtime.ts
+++ b/ui/src/lib/voiceRealtime.ts
@@ -296,9 +296,6 @@ export class VoiceRealtimeSession {
   }
 }
 
-export const isVoiceRealtimeEnabled = (): boolean =>
-  import.meta.env.VITE_VOICE_REALTIME_ENABLED === 'true';
-
 export const voiceRealtimeError = (error: unknown): Error => {
   if (error instanceof CloudUnavailableError) return error;
   return error instanceof Error ? error : asError('realtime_failed');


### PR DESCRIPTION
## Summary

- make browser realtime voice the permanent default path
- remove the Vite and Incus regression rollout flags
- preserve the existing HTTP dictation fallback when realtime connection or protocol handling fails
- update regression contracts and operator documentation for the permanent default

## Scenarios

- No cataloged scenario IDs apply to this rollout-policy change.

## Evidence

- Unit: 84 focused voice tests passed across realtime protocol, recording, transcription, cleanup, telemetry, and inline preview.
- Contract: 4 focused Incus runner tests passed, including proof that the legacy rollout variable cannot alter fingerprints or deployed runtime environment.
- Scenario: prior public regression acceptance passed the complete realtime voice flow; this change removes only the rollout gate.
- Build: UI production build passed and the generated bundle contains the realtime endpoint with no legacy flag reference.
- Residual manual: repeat public microphone acceptance after merge/deployment.

## Notes

- The full Incus runner test file had 71 passes and one environment-dependent failure because local port 15200 was already occupied and the runner correctly selected 15201. The failing assertion is outside this change.
