### PR TITLE
refactor(memory): hide snapshot cleanup authority

### DIFF
--- a/core/memory/clear_journal.py
+++ b/core/memory/clear_journal.py
@@ -11,25 +11,16 @@ import os
 import re
 import secrets
 import sqlite3
-from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path, PurePosixPath
-from typing import Iterator, Literal, Mapping, Sequence
+from typing import Literal, Mapping, Sequence
 
 from core.memory.confined_filesystem import (
     ConfinedFilesystemError,
     PrivateSqliteDatabase,
 )
-from core.memory.snapshot import (
-    MemorySnapshot,
-    _TerminalSnapshotPermit,
-    _issue_terminal_snapshot_permit,
-    _issue_preparing_snapshot_discard_permit,
-    _PreparingSnapshotDiscardPermit,
-    _preparing_snapshot_discard_succeeded,
-    _revoke_preparing_snapshot_discard_permit,
-)
+from core.memory.snapshot import MemorySnapshot
 from core.memory.types import CLOSED_MEMORY_ERROR_CODES, is_memory_error_code
 
 
@@ -392,52 +383,6 @@ class MemoryClearJournal:
         if operation is not None:
             raise ClearBackupBlocked(operation.operation_id, operation.state)
 
-    def terminal_snapshot_permit(self, operation_id: str) -> _TerminalSnapshotPermit:
-        """Issue snapshot-GC authority for a fully audited terminal clear."""
-
-        operation = self._require_operation(_validated_operation_id(operation_id))
-        required_surface_state = {
-            "completed": "deleted",
-            "aborted": "restored",
-        }.get(operation.state)
-        if required_surface_state is None:
-            raise ClearTransitionError("only a terminal Memory clear may remove its snapshot")
-        if operation.snapshot_path is None or operation.manifest_sha256 is None:
-            raise ClearTransitionError("terminal Memory clear snapshot metadata is missing")
-        surfaces = self.get_surfaces(operation.operation_id)
-        if len(surfaces) != len(_SURFACE_NAMES) or any(
-            surface.state != required_surface_state or surface.present is None
-            for surface in surfaces
-        ):
-            raise ClearTransitionError("terminal Memory clear surface audit is incomplete")
-        return _issue_terminal_snapshot_permit(
-            snapshot_id=operation.operation_id,
-            relative_path=operation.snapshot_path,
-            manifest_sha256=operation.manifest_sha256,
-            surface_digests=tuple(
-                (surface.relative_path, surface.snapshot_digest) for surface in surfaces
-            ),
-        )
-
-    def terminal_snapshot_permits(self) -> tuple[_TerminalSnapshotPermit, ...]:
-        """Return durable GC work left by every eligible terminal clear."""
-
-        connection = self._connect()
-        try:
-            rows = connection.execute(
-                """
-                SELECT operation_id FROM clear_operation
-                WHERE state IN ('completed', 'aborted')
-                ORDER BY terminal_at, operation_id
-                """
-            ).fetchall()
-        finally:
-            connection.close()
-        return tuple(
-            self.terminal_snapshot_permit(row["operation_id"])
-            for row in rows
-        )
-
     def record_snapshot(
         self,
         operation_id: str,
@@ -530,89 +475,6 @@ class MemoryClearJournal:
             connection.close()
             self._harden_database_files()
         return self._require_operation(identifier)
-
-    @contextmanager
-    def authorize_preparing_snapshot_discard(
-        self,
-        operation_id: str,
-        *,
-        expected_revision: int,
-        execution_token: str,
-    ) -> Iterator[_PreparingSnapshotDiscardPermit]:
-        """Lease removal of an unjournaled snapshot while holding the write lock."""
-
-        identifier = _validated_operation_id(operation_id)
-        connection = self._connect()
-        permit: _PreparingSnapshotDiscardPermit | None = None
-        try:
-            connection.execute("BEGIN IMMEDIATE")
-            row = self._cas_row(
-                connection,
-                identifier,
-                expected_revision,
-                execution_token,
-                allowed_states=("preparing",),
-            )
-            nonpending = connection.execute(
-                """
-                SELECT COUNT(*) FROM clear_surface
-                WHERE operation_id = ? AND state != 'pending'
-                """,
-                (identifier,),
-            ).fetchone()[0]
-            if (
-                nonpending
-                or row["snapshot_path"] is not None
-                or row["manifest_sha256"] is not None
-                or row["destructive_started"]
-            ):
-                raise ClearTransitionError(
-                    "only an unrecorded preparing snapshot may be discarded"
-                )
-            relative_path = f"state/memory/clear-snapshots/{identifier}"
-            permit = _issue_preparing_snapshot_discard_permit(
-                snapshot_id=identifier,
-                relative_path=relative_path,
-            )
-            yield permit
-            if not _preparing_snapshot_discard_succeeded(permit):
-                raise ClearTransitionError("Memory snapshot discard did not complete")
-            now = _utc_now()
-            revision = row["revision"] + 1
-            updated = connection.execute(
-                """
-                UPDATE clear_operation
-                SET updated_at = ?, revision = ?
-                WHERE operation_id = ? AND state = 'preparing'
-                    AND revision = ? AND execution_token = ?
-                """,
-                (
-                    now,
-                    revision,
-                    identifier,
-                    row["revision"],
-                    row["execution_token"],
-                ),
-            )
-            if updated.rowcount != 1:
-                raise ClearOperationCASMismatch("Memory clear discard claim is stale")
-            self._append_event(
-                connection,
-                identifier,
-                "snapshot_discarded",
-                row["operator_ref"],
-                occurred_at=now,
-                resulting_revision=revision,
-            )
-            connection.commit()
-        except BaseException:
-            connection.rollback()
-            raise
-        finally:
-            if permit is not None:
-                _revoke_preparing_snapshot_discard_permit(permit)
-            connection.close()
-            self._harden_database_files()
 
     def mark_prepared(
         self,

--- a/core/memory/clear_snapshot_storage.py
+++ b/core/memory/clear_snapshot_storage.py
@@ -1,0 +1,191 @@
+"""Durably authorized storage cleanup for Memory clear snapshots."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from core.memory.clear_journal import (
+    ClearOperation,
+    ClearOperationCASMismatch,
+    ClearTransitionError,
+    MemoryClearJournal,
+    _utc_now,
+    _validated_digest,
+    _validated_operation_id,
+    _validated_relative_path,
+)
+from core.memory.snapshot import MemorySnapshotManager
+
+
+@dataclass(frozen=True, slots=True)
+class _TerminalSnapshot:
+    operation_id: str
+    relative_path: str
+    manifest_sha256: str
+    surface_digests: dict[str, str | None]
+
+
+class MemoryClearSnapshotStorage:
+    """Own journal-authorized cleanup of clear snapshots."""
+
+    def __init__(
+        self,
+        journal: MemoryClearJournal,
+        snapshot_manager: MemorySnapshotManager,
+    ) -> None:
+        self._journal = journal
+        self._snapshot_manager = snapshot_manager
+
+    def discard_unrecorded_preparing_snapshot(
+        self,
+        operation_id: str,
+        *,
+        expected_revision: int,
+        execution_token: str,
+    ) -> ClearOperation:
+        """Discard one exact unrecorded preparing snapshot and journal the result."""
+
+        identifier = _validated_operation_id(operation_id)
+        connection = self._journal._connect()
+        try:
+            connection.execute("BEGIN IMMEDIATE")
+            row = self._journal._cas_row(
+                connection,
+                identifier,
+                expected_revision,
+                execution_token,
+                allowed_states=("preparing",),
+            )
+            nonpending = connection.execute(
+                """
+                SELECT COUNT(*) FROM clear_surface
+                WHERE operation_id = ? AND state != 'pending'
+                """,
+                (identifier,),
+            ).fetchone()[0]
+            if (
+                nonpending
+                or row["snapshot_path"] is not None
+                or row["manifest_sha256"] is not None
+                or row["destructive_started"]
+            ):
+                raise ClearTransitionError(
+                    "only an unrecorded preparing snapshot may be discarded"
+                )
+
+            relative_path = f"state/memory/clear-snapshots/{identifier}"
+            self._snapshot_manager._discard_unrecorded_clear_snapshot(
+                identifier,
+                expected_relative_path=relative_path,
+            )
+
+            now = _utc_now()
+            revision = row["revision"] + 1
+            updated = connection.execute(
+                """
+                UPDATE clear_operation
+                SET updated_at = ?, revision = ?
+                WHERE operation_id = ? AND state = 'preparing'
+                    AND revision = ? AND execution_token = ?
+                """,
+                (
+                    now,
+                    revision,
+                    identifier,
+                    row["revision"],
+                    row["execution_token"],
+                ),
+            )
+            if updated.rowcount != 1:
+                raise ClearOperationCASMismatch(
+                    "Memory clear discard claim is stale"
+                )
+            self._journal._append_event(
+                connection,
+                identifier,
+                "snapshot_discarded",
+                row["operator_ref"],
+                occurred_at=now,
+                resulting_revision=revision,
+            )
+            connection.commit()
+        except BaseException:
+            connection.rollback()
+            raise
+        finally:
+            connection.close()
+            self._journal._harden_database_files()
+        return self._journal._require_operation(identifier)
+
+    def eligible_terminal_snapshot_ids(self) -> tuple[str, ...]:
+        """Return durable terminal snapshot cleanup work in completion order."""
+
+        connection = self._journal._connect()
+        try:
+            rows = connection.execute(
+                """
+                SELECT operation_id FROM clear_operation
+                WHERE state IN ('completed', 'aborted')
+                ORDER BY terminal_at, operation_id
+                """
+            ).fetchall()
+        finally:
+            connection.close()
+        identifiers = tuple(str(row["operation_id"]) for row in rows)
+        for identifier in identifiers:
+            self._terminal_snapshot(identifier)
+        return identifiers
+
+    def remove_terminal_snapshot(self, operation_id: str) -> None:
+        """Remove one snapshot only when its durable clear audit is terminal."""
+
+        snapshot = self._terminal_snapshot(operation_id)
+        self._snapshot_manager._remove_clear_snapshot(
+            snapshot.operation_id,
+            expected_relative_path=snapshot.relative_path,
+            expected_manifest_sha256=snapshot.manifest_sha256,
+            expected_surface_digests=snapshot.surface_digests,
+        )
+
+    def _terminal_snapshot(self, operation_id: str) -> _TerminalSnapshot:
+        operation = self._journal._require_operation(
+            _validated_operation_id(operation_id)
+        )
+        required_surface_state = {
+            "completed": "deleted",
+            "aborted": "restored",
+        }.get(operation.state)
+        if required_surface_state is None:
+            raise ClearTransitionError(
+                "only a terminal Memory clear may remove its snapshot"
+            )
+        if operation.snapshot_path is None or operation.manifest_sha256 is None:
+            raise ClearTransitionError(
+                "terminal Memory clear snapshot metadata is missing"
+            )
+        relative_path = _validated_relative_path(operation.snapshot_path)
+        manifest_sha256 = _validated_digest(operation.manifest_sha256)
+        surfaces = self._journal.get_surfaces(operation.operation_id)
+        if len(surfaces) != len(self._journal.surfaces) or any(
+            surface.state != required_surface_state or surface.present is None
+            for surface in surfaces
+        ):
+            raise ClearTransitionError(
+                "terminal Memory clear surface audit is incomplete"
+            )
+        surface_digests: dict[str, str | None] = {}
+        for surface in surfaces:
+            relative_surface = _validated_relative_path(surface.relative_path)
+            if relative_surface in surface_digests:
+                raise ValueError("terminal Memory snapshot has duplicate surfaces")
+            surface_digests[relative_surface] = (
+                None
+                if surface.snapshot_digest is None
+                else _validated_digest(surface.snapshot_digest)
+            )
+        return _TerminalSnapshot(
+            operation_id=operation.operation_id,
+            relative_path=relative_path,
+            manifest_sha256=manifest_sha256,
+            surface_digests=surface_digests,
+        )

--- a/core/memory/maintenance.py
+++ b/core/memory/maintenance.py
@@ -16,6 +16,7 @@ from core.memory.backup_restore_journal import (
 )
 from core.memory.blocking import run_blocking
 from core.memory.clear_journal import ClearOperation, ClearSurface, MemoryClearJournal
+from core.memory.clear_snapshot_storage import MemoryClearSnapshotStorage
 from core.memory.snapshot import MemorySnapshot, MemorySnapshotManager
 from core.memory.store import MemoryStore
 
@@ -105,6 +106,7 @@ class MemoryMaintenance:
         self._backup_restore_journal: MemoryBackupRestoreJournal | None = None
         self._clear_journal: MemoryClearJournal | None = None
         self._snapshot_manager: MemorySnapshotManager | None = None
+        self._clear_snapshot_storage: MemoryClearSnapshotStorage | None = None
         self._backup_manager: MemorySnapshotManager | None = None
         self._initialization_error: Exception | None = None
         self._terminal_snapshot_gc_task: asyncio.Task[None] | None = None
@@ -114,6 +116,10 @@ class MemoryMaintenance:
             self._backup_restore_journal = MemoryBackupRestoreJournal(effective_home)
             self._clear_journal = MemoryClearJournal(effective_home)
             self._snapshot_manager = MemorySnapshotManager(effective_home)
+            self._clear_snapshot_storage = MemoryClearSnapshotStorage(
+                self._clear_journal,
+                self._snapshot_manager,
+            )
             self._backup_manager = MemorySnapshotManager._for_backup(
                 effective_home,
                 operation_guard=self._clear_journal.assert_backup_allowed,
@@ -133,6 +139,7 @@ class MemoryMaintenance:
             and self._backup_restore_journal is not None
             and self._clear_journal is not None
             and self._snapshot_manager is not None
+            and self._clear_snapshot_storage is not None
             and self._backup_manager is not None
             and self._initialization_error is None
         )
@@ -617,22 +624,18 @@ class MemoryMaintenance:
     ) -> ClearOperation:
         journal = self._require_clear_journal()
         manager = self._require_snapshot_manager()
+        snapshot_storage = self._require_clear_snapshot_storage()
         await self._runtime.quiesce(claims_already_paused)
         if operation.state == "preparing":
             if operation.snapshot_path is None or operation.manifest_sha256 is None:
                 if operation.resolution == "resume":
-                    with journal.authorize_preparing_snapshot_discard(
-                        operation.operation_id,
-                        expected_revision=operation.revision,
-                        execution_token=self._clear_execution_token(operation),
-                    ) as permit:
-                        await self._run_maintenance_io(
-                            lambda: manager.discard_unrecorded(permit)
+                    operation = await self._run_maintenance_io(
+                        lambda: snapshot_storage.discard_unrecorded_preparing_snapshot(
+                            operation.operation_id,
+                            expected_revision=operation.revision,
+                            execution_token=self._clear_execution_token(operation),
                         )
-                    refreshed = journal.get_operation(operation.operation_id)
-                    if refreshed is None:
-                        raise RuntimeError("Memory clear operation disappeared")
-                    operation = refreshed
+                    )
                 snapshot = await self._run_maintenance_io(
                     lambda: manager.create(operation.operation_id)
                 )
@@ -842,15 +845,14 @@ class MemoryMaintenance:
         )
 
     def _reconcile_terminal_clear_snapshots(self) -> None:
-        journal = self._require_clear_journal()
-        manager = self._require_snapshot_manager()
-        for permit in journal.terminal_snapshot_permits():
+        storage = self._require_clear_snapshot_storage()
+        for operation_id in storage.eligible_terminal_snapshot_ids():
             try:
-                manager.remove(permit)
+                storage.remove_terminal_snapshot(operation_id)
             except Exception:
                 logger.warning(
                     "Terminal Memory clear snapshot %s could not be removed",
-                    permit.snapshot_id,
+                    operation_id,
                     exc_info=True,
                 )
 
@@ -866,8 +868,7 @@ class MemoryMaintenance:
         if (
             self._closing
             or state.artifact_installing
-            or self._clear_journal is None
-            or self._snapshot_manager is None
+            or self._clear_snapshot_storage is None
             or self._initialization_error is not None
             or (task is not None and not task.done())
         ):
@@ -935,29 +936,32 @@ class MemoryMaintenance:
             )
 
     async def _run_terminal_snapshot_gc(self) -> None:
-        journal = self._require_clear_journal()
-        manager = self._require_snapshot_manager()
+        storage = self._require_clear_snapshot_storage()
         try:
-            permits = await self._run_maintenance_io(journal.terminal_snapshot_permits)
+            operation_ids = await self._run_maintenance_io(
+                storage.eligible_terminal_snapshot_ids
+            )
         except asyncio.CancelledError:
             raise
         except Exception:
             logger.warning(
-                "Terminal Memory clear snapshot permits could not be loaded",
+                "Terminal Memory clear snapshots could not be enumerated",
                 exc_info=True,
             )
             return
-        for permit in permits:
+        for operation_id in operation_ids:
             try:
                 await self._run_maintenance_io(
-                    lambda permit=permit: manager.remove(permit)
+                    lambda operation_id=operation_id: storage.remove_terminal_snapshot(
+                        operation_id
+                    )
                 )
             except asyncio.CancelledError:
                 raise
             except Exception:
                 logger.warning(
                     "Terminal Memory clear snapshot %s could not be removed",
-                    permit.snapshot_id,
+                    operation_id,
                     exc_info=True,
                 )
 
@@ -1044,6 +1048,16 @@ class MemoryMaintenance:
         if self._snapshot_manager is None or self._initialization_error is not None:
             raise MemoryStoreUnavailableError("Memory snapshot manager is unavailable")
         return self._snapshot_manager
+
+    def _require_clear_snapshot_storage(self) -> MemoryClearSnapshotStorage:
+        if (
+            self._clear_snapshot_storage is None
+            or self._initialization_error is not None
+        ):
+            raise MemoryStoreUnavailableError(
+                "Memory clear snapshot storage is unavailable"
+            )
+        return self._clear_snapshot_storage
 
     def _require_backup_manager(self) -> MemorySnapshotManager:
         if self._backup_manager is None or self._initialization_error is not None:

--- a/core/memory/snapshot.py
+++ b/core/memory/snapshot.py
@@ -47,10 +47,6 @@ _DIRECTORY_DESCRIPTOR_CACHE_SIZE = 48
 _SNAPSHOT_ID_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]{0,127}\Z")
 _AUTOMATIC_BACKUP_STAGE_RE = re.compile(r"\.([0-9a-f]{32})\.tmp\Z")
 _SHA256_RE = re.compile(r"[0-9a-f]{64}\Z")
-_TERMINAL_PERMIT_AUTHORITY = object()
-_PREPARING_DISCARD_PERMIT_AUTHORITY = object()
-_ACTIVE_PREPARING_DISCARD_LEASES: set[object] = set()
-_SUCCEEDED_PREPARING_DISCARD_LEASES: set[object] = set()
 _CALL_LOG_FILESET: tuple[tuple[str, str], ...] = (
     ("database", ""),
     ("journal", "-journal"),
@@ -171,88 +167,6 @@ class MemorySnapshot:
         """Return the journal-persisted snapshot digest for every surface."""
 
         return {receipt.path: receipt.snapshot_digest for receipt in self.surface_receipts}
-
-
-@dataclass(frozen=True, slots=True)
-class _TerminalSnapshotPermit:
-    """Journal-issued capability for garbage-collecting a terminal snapshot."""
-
-    snapshot_id: str
-    relative_path: str
-    manifest_sha256: str
-    surface_digests: tuple[tuple[str, str | None], ...]
-    _authority: object
-
-    def __post_init__(self) -> None:
-        if self._authority is not _TERMINAL_PERMIT_AUTHORITY:
-            raise TypeError("terminal Memory snapshot permits are journal-issued")
-        _validated_snapshot_id(self.snapshot_id)
-        object.__setattr__(self, "relative_path", _validated_relative_path(self.relative_path))
-        _validated_sha256(self.manifest_sha256)
-        normalized: list[tuple[str, str | None]] = []
-        for path, digest in self.surface_digests:
-            canonical = _validated_relative_path(path)
-            normalized.append((canonical, None if digest is None else _validated_sha256(digest)))
-        if len({path for path, _digest in normalized}) != len(normalized):
-            raise ValueError("terminal Memory snapshot permit has duplicate surfaces")
-        object.__setattr__(self, "surface_digests", tuple(normalized))
-
-
-def _issue_terminal_snapshot_permit(
-    *,
-    snapshot_id: str,
-    relative_path: str,
-    manifest_sha256: str,
-    surface_digests: tuple[tuple[str, str | None], ...],
-) -> _TerminalSnapshotPermit:
-    """Issue the opaque capability used by an eligible terminal journal row."""
-
-    return _TerminalSnapshotPermit(
-        snapshot_id=snapshot_id,
-        relative_path=relative_path,
-        manifest_sha256=manifest_sha256,
-        surface_digests=surface_digests,
-        _authority=_TERMINAL_PERMIT_AUTHORITY,
-    )
-
-
-@dataclass(frozen=True, slots=True)
-class _PreparingSnapshotDiscardPermit:
-    snapshot_id: str
-    relative_path: str
-    _lease: object
-    _authority: object
-
-    def __post_init__(self) -> None:
-        if self._authority is not _PREPARING_DISCARD_PERMIT_AUTHORITY:
-            raise TypeError("preparing Memory snapshot discard permits are journal-issued")
-        _validated_snapshot_id(self.snapshot_id)
-        object.__setattr__(self, "relative_path", _validated_relative_path(self.relative_path))
-
-
-def _issue_preparing_snapshot_discard_permit(
-    *,
-    snapshot_id: str,
-    relative_path: str,
-) -> _PreparingSnapshotDiscardPermit:
-    lease = object()
-    permit = _PreparingSnapshotDiscardPermit(
-        snapshot_id=snapshot_id,
-        relative_path=relative_path,
-        _lease=lease,
-        _authority=_PREPARING_DISCARD_PERMIT_AUTHORITY,
-    )
-    _ACTIVE_PREPARING_DISCARD_LEASES.add(lease)
-    return permit
-
-
-def _preparing_snapshot_discard_succeeded(permit: _PreparingSnapshotDiscardPermit) -> bool:
-    return permit._lease in _SUCCEEDED_PREPARING_DISCARD_LEASES
-
-
-def _revoke_preparing_snapshot_discard_permit(permit: _PreparingSnapshotDiscardPermit) -> None:
-    _ACTIVE_PREPARING_DISCARD_LEASES.discard(permit._lease)
-    _SUCCEEDED_PREPARING_DISCARD_LEASES.discard(permit._lease)
 
 
 @dataclass(slots=True)
@@ -1097,19 +1011,26 @@ class MemorySnapshotManager:
         if self._operation_guard is not None:
             self._operation_guard()
 
-    def remove(self, permit: _TerminalSnapshotPermit) -> None:
-        """Remove only a snapshot authorized by an eligible terminal journal row."""
+    def _remove_clear_snapshot(
+        self,
+        snapshot_id: str,
+        *,
+        expected_relative_path: str,
+        expected_manifest_sha256: str,
+        expected_surface_digests: Mapping[str, str | None],
+    ) -> None:
+        """Remove one journal-authorized clear snapshot."""
 
-        if (
-            not isinstance(permit, _TerminalSnapshotPermit)
-            or permit._authority is not _TERMINAL_PERMIT_AUTHORITY
-        ):
-            raise TypeError("Memory snapshot removal requires a terminal journal permit")
-        directory = self.snapshot_path(permit.snapshot_id)
-        tombstone = self._snapshot_root / f".{permit.snapshot_id}.gc"
-        expected_relative = (PurePosixPath(self._snapshot_root_relative) / permit.snapshot_id).as_posix()
-        if permit.relative_path != expected_relative:
-            raise MemorySnapshotVerificationError("Memory snapshot removal permit path is invalid")
+        identifier = _validated_snapshot_id(snapshot_id)
+        directory = self.snapshot_path(identifier)
+        tombstone = self._snapshot_root / f".{identifier}.gc"
+        expected_relative = (
+            PurePosixPath(self._snapshot_root_relative) / identifier
+        ).as_posix()
+        if expected_relative_path != expected_relative:
+            raise MemorySnapshotVerificationError(
+                "Memory snapshot removal path is invalid"
+            )
 
         # A prior removal may have crashed after the verified snapshot was
         # renamed.  The deterministic tombstone is already authorized by this
@@ -1123,37 +1044,37 @@ class MemorySnapshotManager:
             return
         _require_directory_private(info, "Memory snapshot directory")
         self.verify(
-            permit.snapshot_id,
-            expected_manifest_sha256=permit.manifest_sha256,
-            expected_surface_digests=dict(permit.surface_digests),
+            identifier,
+            expected_manifest_sha256=expected_manifest_sha256,
+            expected_surface_digests=expected_surface_digests,
         )
         os.replace(directory, tombstone)
         _fsync_directory(self._snapshot_root)
         _remove_safe_path(self._effective_home, tombstone)
         _fsync_directory(self._snapshot_root)
 
-    def discard_unrecorded(self, permit: _PreparingSnapshotDiscardPermit) -> None:
-        """Discard an untrusted published snapshot under a live journal lease."""
+    def _discard_unrecorded_clear_snapshot(
+        self,
+        snapshot_id: str,
+        *,
+        expected_relative_path: str,
+    ) -> None:
+        """Discard one storage-authorized unrecorded clear snapshot."""
 
-        if (
-            not isinstance(permit, _PreparingSnapshotDiscardPermit)
-            or permit._authority is not _PREPARING_DISCARD_PERMIT_AUTHORITY
-            or permit._lease not in _ACTIVE_PREPARING_DISCARD_LEASES
-        ):
-            raise TypeError("Memory snapshot discard requires an active preparing journal permit")
+        identifier = _validated_snapshot_id(snapshot_id)
         expected_relative = (
-            PurePosixPath(self._snapshot_root_relative) / permit.snapshot_id
+            PurePosixPath(self._snapshot_root_relative) / identifier
         ).as_posix()
-        if permit.relative_path != expected_relative:
-            raise MemorySnapshotVerificationError("Memory snapshot discard permit path is invalid")
-        _ACTIVE_PREPARING_DISCARD_LEASES.remove(permit._lease)
-        directory = self.snapshot_path(permit.snapshot_id)
+        if expected_relative_path != expected_relative:
+            raise MemorySnapshotVerificationError(
+                "Memory snapshot discard path is invalid"
+            )
+        directory = self.snapshot_path(identifier)
         _remove_safe_path(self._effective_home, directory)
         root_info = _managed_source_info(self._effective_home, self._snapshot_root)
         if root_info is not None:
             _require_directory_private(root_info, "Memory snapshot root")
             _fsync_directory(self._snapshot_root)
-        _SUCCEEDED_PREPARING_DISCARD_LEASES.add(permit._lease)
 
     def _validate_surface_layout(self) -> None:
         paths = [PurePosixPath(surface.path) for surface in self._surfaces]

--- a/tests/test_memory_clear_journal.py
+++ b/tests/test_memory_clear_journal.py
@@ -130,10 +130,6 @@ def test_clear_journal_happy_path_is_a_pure_durable_state_machine(tmp_path: Path
     assert operation.execution_token is None
     assert journal.get_open_operation() is None
     journal.assert_backup_allowed()
-    permit = journal.terminal_snapshot_permit(operation.operation_id)
-    assert permit.snapshot_id == operation.operation_id
-    assert permit.manifest_sha256 == _digest("manifest")
-    assert len(permit.surface_digests) == 4
     assert sentinel.read_text() == "must remain"
     assert [event.event for event in journal.get_events(operation.operation_id)] == [
         "started",
@@ -386,8 +382,6 @@ def test_abort_direction_survives_a_second_crash_and_requires_restore(tmp_path: 
         operator_ref="user:owner",
         expected_revision=recovery.revision,
     )
-    with pytest.raises(ClearTransitionError, match="only a terminal"):
-        journal.terminal_snapshot_permit(abort.operation_id)
     with pytest.raises(ClearTransitionError):
         assert abort.execution_token is not None
         journal.mark_aborted(
@@ -437,11 +431,6 @@ def test_abort_direction_survives_a_second_crash_and_requires_restore(tmp_path: 
     assert aborted.state == "aborted"
     assert aborted.resolution == "abort"
     assert aborted.closed_error == "memory_clear_failed"
-    permit = journal.terminal_snapshot_permit(aborted.operation_id)
-    assert permit.snapshot_id == aborted.operation_id
-    assert [item.snapshot_id for item in journal.terminal_snapshot_permits()] == [
-        aborted.operation_id
-    ]
     journal.assert_backup_allowed()
 
 

--- a/tests/test_memory_clear_snapshot_storage.py
+++ b/tests/test_memory_clear_snapshot_storage.py
@@ -1,0 +1,290 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import core.memory.snapshot as snapshot_module
+from core.memory.clear_journal import (
+    ClearOperation,
+    ClearOperationCASMismatch,
+    ClearTransitionError,
+    MemoryClearJournal,
+)
+from core.memory.clear_snapshot_storage import MemoryClearSnapshotStorage
+from core.memory.snapshot import (
+    MemorySnapshotManager,
+    MemorySnapshotUnsafePathError,
+    MemorySnapshotVerificationError,
+)
+
+
+def _storage(
+    tmp_path: Path,
+) -> tuple[MemoryClearJournal, MemorySnapshotManager, MemoryClearSnapshotStorage]:
+    home = tmp_path / "home"
+    home.mkdir(mode=0o700)
+    home.chmod(0o700)
+    journal = MemoryClearJournal(home)
+    manager = MemorySnapshotManager(home)
+    return journal, manager, MemoryClearSnapshotStorage(journal, manager)
+
+
+def _record_snapshot(
+    journal: MemoryClearJournal,
+    manager: MemorySnapshotManager,
+    operation_id: str,
+) -> ClearOperation:
+    operation = journal.start(
+        operation_id=operation_id,
+        operator_ref="user:owner",
+        pre_epoch=0,
+        target_epoch=1,
+    )
+    snapshot = manager.create(operation.operation_id)
+    assert operation.execution_token is not None
+    return journal.record_snapshot(
+        operation.operation_id,
+        expected_revision=operation.revision,
+        execution_token=operation.execution_token,
+        snapshot=snapshot,
+    )
+
+
+def _complete_clear(
+    journal: MemoryClearJournal,
+    manager: MemorySnapshotManager,
+    operation_id: str,
+) -> ClearOperation:
+    operation = _record_snapshot(journal, manager, operation_id)
+    assert operation.execution_token is not None
+    operation = journal.mark_prepared(
+        operation.operation_id,
+        expected_revision=operation.revision,
+        execution_token=operation.execution_token,
+    )
+    assert operation.execution_token is not None
+    operation = journal.begin_deleting(
+        operation.operation_id,
+        expected_revision=operation.revision,
+        execution_token=operation.execution_token,
+    )
+    for surface in journal.surfaces:
+        assert operation.execution_token is not None
+        operation = journal.record_surface_deleted(
+            operation.operation_id,
+            surface.name,
+            expected_revision=operation.revision,
+            execution_token=operation.execution_token,
+        )
+    assert operation.execution_token is not None
+    return journal.mark_completed(
+        operation.operation_id,
+        expected_revision=operation.revision,
+        execution_token=operation.execution_token,
+    )
+
+
+def _abort_clear(
+    journal: MemoryClearJournal,
+    manager: MemorySnapshotManager,
+    operation_id: str,
+) -> ClearOperation:
+    operation = _record_snapshot(journal, manager, operation_id)
+    assert operation.execution_token is not None
+    operation = journal.mark_prepared(
+        operation.operation_id,
+        expected_revision=operation.revision,
+        execution_token=operation.execution_token,
+    )
+    recovery = journal.mark_boot_recovery_needed()
+    assert recovery is not None
+    operation = journal.claim_abort(
+        operation.operation_id,
+        operator_ref="user:owner",
+        expected_revision=recovery.revision,
+    )
+    for surface in journal.surfaces:
+        assert operation.execution_token is not None
+        operation = journal.record_surface_restored(
+            operation.operation_id,
+            surface.name,
+            expected_revision=operation.revision,
+            execution_token=operation.execution_token,
+        )
+    assert operation.execution_token is not None
+    return journal.mark_aborted(
+        operation.operation_id,
+        expected_revision=operation.revision,
+        execution_token=operation.execution_token,
+    )
+
+
+def test_terminal_snapshot_removal_requires_a_complete_audit_and_verifies_bytes(
+    tmp_path: Path,
+) -> None:
+    journal, manager, storage = _storage(tmp_path)
+    operation = _record_snapshot(journal, manager, "remove-completed")
+    snapshot_path = manager.snapshot_path(operation.operation_id)
+
+    assert storage.eligible_terminal_snapshot_ids() == ()
+    with pytest.raises(ClearTransitionError, match="only a terminal"):
+        storage.remove_terminal_snapshot(operation.operation_id)
+    assert snapshot_path.is_dir()
+
+    assert operation.execution_token is not None
+    operation = journal.mark_prepared(
+        operation.operation_id,
+        expected_revision=operation.revision,
+        execution_token=operation.execution_token,
+    )
+    assert operation.execution_token is not None
+    operation = journal.begin_deleting(
+        operation.operation_id,
+        expected_revision=operation.revision,
+        execution_token=operation.execution_token,
+    )
+    for surface in journal.surfaces:
+        assert operation.execution_token is not None
+        operation = journal.record_surface_deleted(
+            operation.operation_id,
+            surface.name,
+            expected_revision=operation.revision,
+            execution_token=operation.execution_token,
+        )
+    assert operation.execution_token is not None
+    operation = journal.mark_completed(
+        operation.operation_id,
+        expected_revision=operation.revision,
+        execution_token=operation.execution_token,
+    )
+
+    assert storage.eligible_terminal_snapshot_ids() == (operation.operation_id,)
+    manifest_path = snapshot_path / "manifest.jsonl"
+    manifest = manifest_path.read_bytes()
+    manifest_path.write_bytes(b"corrupt")
+    with pytest.raises(MemorySnapshotVerificationError):
+        storage.remove_terminal_snapshot(operation.operation_id)
+    assert snapshot_path.is_dir()
+    manifest_path.write_bytes(manifest)
+
+    storage.remove_terminal_snapshot(operation.operation_id)
+    storage.remove_terminal_snapshot(operation.operation_id)
+    assert not snapshot_path.exists()
+
+
+def test_aborted_restored_snapshot_is_eligible_for_idempotent_removal(
+    tmp_path: Path,
+) -> None:
+    journal, manager, storage = _storage(tmp_path)
+    operation = _abort_clear(journal, manager, "remove-aborted")
+    snapshot_path = manager.snapshot_path(operation.operation_id)
+
+    assert storage.eligible_terminal_snapshot_ids() == (operation.operation_id,)
+    storage.remove_terminal_snapshot(operation.operation_id)
+    storage.remove_terminal_snapshot(operation.operation_id)
+
+    assert not snapshot_path.exists()
+
+
+def test_preparing_discard_requires_exact_cas_and_refuses_a_recorded_snapshot(
+    tmp_path: Path,
+) -> None:
+    journal, manager, storage = _storage(tmp_path)
+    operation = journal.start(
+        operation_id="publish-before-record",
+        operator_ref="user:owner",
+        pre_epoch=2,
+        target_epoch=3,
+    )
+    manager.create(operation.operation_id)
+    assert operation.execution_token is not None
+
+    with pytest.raises(ClearOperationCASMismatch):
+        storage.discard_unrecorded_preparing_snapshot(
+            operation.operation_id,
+            expected_revision=operation.revision + 1,
+            execution_token=operation.execution_token,
+        )
+    assert manager.snapshot_path(operation.operation_id).is_dir()
+
+    discarded = storage.discard_unrecorded_preparing_snapshot(
+        operation.operation_id,
+        expected_revision=operation.revision,
+        execution_token=operation.execution_token,
+    )
+    assert discarded.revision == operation.revision + 1
+    assert journal.get_events(operation.operation_id)[-1].event == "snapshot_discarded"
+    assert not manager.snapshot_path(operation.operation_id).exists()
+
+    rebuilt = manager.create(operation.operation_id)
+    assert discarded.execution_token is not None
+    recorded = journal.record_snapshot(
+        operation.operation_id,
+        expected_revision=discarded.revision,
+        execution_token=discarded.execution_token,
+        snapshot=rebuilt,
+    )
+    assert recorded.execution_token is not None
+    with pytest.raises(ClearTransitionError, match="only an unrecorded"):
+        storage.discard_unrecorded_preparing_snapshot(
+            recorded.operation_id,
+            expected_revision=recorded.revision,
+            execution_token=recorded.execution_token,
+        )
+    assert manager.snapshot_path(operation.operation_id).is_dir()
+
+
+def test_terminal_removal_retries_a_partially_deleted_tombstone(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    journal, manager, storage = _storage(tmp_path)
+    operation = _complete_clear(journal, manager, "remove-retry")
+    snapshot_path = manager.snapshot_path(operation.operation_id)
+    tombstone = manager.snapshot_root / f".{operation.operation_id}.gc"
+    real_unlink = snapshot_module.os.unlink
+    interrupted = False
+
+    def interrupt_after_unlink(path, *args, **kwargs):
+        nonlocal interrupted
+        real_unlink(path, *args, **kwargs)
+        if not interrupted:
+            interrupted = True
+            raise OSError("injected tombstone removal failure")
+
+    monkeypatch.setattr(snapshot_module.os, "unlink", interrupt_after_unlink)
+    with pytest.raises(OSError, match="injected tombstone removal failure"):
+        storage.remove_terminal_snapshot(operation.operation_id)
+
+    assert interrupted
+    assert not snapshot_path.exists()
+    assert tombstone.is_dir()
+
+    monkeypatch.setattr(snapshot_module.os, "unlink", real_unlink)
+    storage.remove_terminal_snapshot(operation.operation_id)
+
+    assert not tombstone.exists()
+    assert not snapshot_path.exists()
+
+
+def test_terminal_removal_refuses_a_symlinked_snapshot_directory(
+    tmp_path: Path,
+) -> None:
+    journal, manager, storage = _storage(tmp_path)
+    operation = _complete_clear(journal, manager, "remove-symlink")
+    snapshot_path = manager.snapshot_path(operation.operation_id)
+    displaced = manager.snapshot_root / ".displaced"
+    snapshot_path.rename(displaced)
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    sentinel = outside / "sentinel"
+    sentinel.write_text("must remain")
+    snapshot_path.symlink_to(outside, target_is_directory=True)
+
+    with pytest.raises(MemorySnapshotUnsafePathError):
+        storage.remove_terminal_snapshot(operation.operation_id)
+
+    assert snapshot_path.is_symlink()
+    assert displaced.is_dir()
+    assert sentinel.read_text() == "must remain"

--- a/tests/test_memory_maintenance.py
+++ b/tests/test_memory_maintenance.py
@@ -18,6 +18,7 @@ import core.memory.snapshot as snapshot_module
 from config.v2_config import MemoryConfig
 from core.memory.artifact import FakeMemoryArtifactManager
 from core.memory.clear_journal import MemoryClearJournal
+from core.memory.clear_snapshot_storage import MemoryClearSnapshotStorage
 from core.memory.process import SidecarOwnership
 from core.memory.maintenance import (
     ClearRecoveryResult,
@@ -1148,18 +1149,20 @@ async def test_completed_clear_snapshot_removal_retries_on_reconcile_and_restart
 ) -> None:
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     runtime = MemoryRuntime(MemoryConfig(), effective_home=tmp_path)
+    storage = _maintenance(runtime)._clear_snapshot_storage
     manager = _maintenance(runtime)._snapshot_manager
+    assert storage is not None
     assert manager is not None
-    original_remove = manager.remove
+    original_remove = storage.remove_terminal_snapshot
     removal_attempts: list[str] = []
 
-    def fail_removal(permit) -> None:
-        if manager.snapshot_path(permit.snapshot_id).exists():
-            removal_attempts.append(permit.snapshot_id)
+    def fail_removal(operation_id: str) -> None:
+        if manager.snapshot_path(operation_id).exists():
+            removal_attempts.append(operation_id)
             raise OSError("injected snapshot removal failure")
-        original_remove(permit)
+        original_remove(operation_id)
 
-    monkeypatch.setattr(manager, "remove", fail_removal)
+    monkeypatch.setattr(storage, "remove_terminal_snapshot", fail_removal)
     completed = await _clear(runtime, operator_ref="user:owner")
     snapshot_path = manager.snapshot_path(completed["operation_id"])
 
@@ -1167,14 +1170,14 @@ async def test_completed_clear_snapshot_removal_retries_on_reconcile_and_restart
     assert removal_attempts == [completed["operation_id"]]
     assert snapshot_path.is_dir()
 
-    monkeypatch.setattr(manager, "remove", original_remove)
+    monkeypatch.setattr(storage, "remove_terminal_snapshot", original_remove)
     assert await runtime.reconcile(MemoryConfig()) == {"ok": True, "state": "disabled"}
     reconcile_gc = _maintenance(runtime)._terminal_snapshot_gc_task
     assert reconcile_gc is not None
     await reconcile_gc
     assert not snapshot_path.exists()
 
-    monkeypatch.setattr(manager, "remove", fail_removal)
+    monkeypatch.setattr(storage, "remove_terminal_snapshot", fail_removal)
     completed_before_restart = await _clear(runtime, operator_ref="user:owner")
     restart_snapshot_path = manager.snapshot_path(completed_before_restart["operation_id"])
     assert restart_snapshot_path.is_dir()
@@ -1201,13 +1204,15 @@ async def _retain_terminal_clear_snapshot(
     home: Path,
 ) -> Path:
     runtime = MemoryRuntime(MemoryConfig(), effective_home=home)
+    storage = _maintenance(runtime)._clear_snapshot_storage
     manager = _maintenance(runtime)._snapshot_manager
+    assert storage is not None
     assert manager is not None
 
-    def retain(_permit) -> None:
+    def retain(_operation_id: str) -> None:
         raise OSError("retain terminal snapshot for startup GC")
 
-    monkeypatch.setattr(manager, "remove", retain)
+    monkeypatch.setattr(storage, "remove_terminal_snapshot", retain)
     completed = await _clear(runtime, operator_ref="user:owner")
     snapshot_path = manager.snapshot_path(completed["operation_id"])
     assert completed["status"] == "completed"
@@ -1222,15 +1227,22 @@ async def test_terminal_snapshot_gc_is_scheduled_after_lifecycle_returns(
 ) -> None:
     entered = threading.Event()
     release = threading.Event()
-    original_remove = MemorySnapshotManager.remove
+    original_remove = MemoryClearSnapshotStorage.remove_terminal_snapshot
     snapshot_path = await _retain_terminal_clear_snapshot(monkeypatch, tmp_path)
 
-    def blocking_remove(manager: MemorySnapshotManager, permit) -> None:
+    def blocking_remove(
+        storage: MemoryClearSnapshotStorage,
+        operation_id: str,
+    ) -> None:
         entered.set()
         assert release.wait(timeout=2)
-        original_remove(manager, permit)
+        original_remove(storage, operation_id)
 
-    monkeypatch.setattr(MemorySnapshotManager, "remove", blocking_remove)
+    monkeypatch.setattr(
+        MemoryClearSnapshotStorage,
+        "remove_terminal_snapshot",
+        blocking_remove,
+    )
     runtime = MemoryRuntime(MemoryConfig(), effective_home=tmp_path)
 
     assert await runtime.reconcile(MemoryConfig()) == {
@@ -1255,18 +1267,25 @@ async def test_terminal_snapshot_gc_shutdown_joins_cancelled_io(
     entered = threading.Event()
     release = threading.Event()
     finished = threading.Event()
-    original_remove = MemorySnapshotManager.remove
+    original_remove = MemoryClearSnapshotStorage.remove_terminal_snapshot
     snapshot_path = await _retain_terminal_clear_snapshot(monkeypatch, tmp_path)
 
-    def blocking_remove(manager: MemorySnapshotManager, permit) -> None:
+    def blocking_remove(
+        storage: MemoryClearSnapshotStorage,
+        operation_id: str,
+    ) -> None:
         entered.set()
         assert release.wait(timeout=2)
         try:
-            original_remove(manager, permit)
+            original_remove(storage, operation_id)
         finally:
             finished.set()
 
-    monkeypatch.setattr(MemorySnapshotManager, "remove", blocking_remove)
+    monkeypatch.setattr(
+        MemoryClearSnapshotStorage,
+        "remove_terminal_snapshot",
+        blocking_remove,
+    )
     runtime = MemoryRuntime(MemoryConfig(), effective_home=tmp_path)
     await runtime.reconcile(MemoryConfig())
     gc_task = _maintenance(runtime)._terminal_snapshot_gc_task
@@ -1295,11 +1314,13 @@ async def test_aborted_clear_snapshot_removal_retries_on_reconcile_and_restart(
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     runtime = MemoryRuntime(MemoryConfig(), effective_home=tmp_path)
     journal = _maintenance(runtime)._clear_journal
+    storage = _maintenance(runtime)._clear_snapshot_storage
     manager = _maintenance(runtime)._snapshot_manager
     assert journal is not None
+    assert storage is not None
     assert manager is not None
     original_delete = _maintenance(runtime)._runtime.delete_surface
-    original_remove = manager.remove
+    original_remove = storage.remove_terminal_snapshot
     removal_attempts: list[str] = []
 
     async def interrupt_provider(surface, target_epoch):
@@ -1307,11 +1328,11 @@ async def test_aborted_clear_snapshot_removal_retries_on_reconcile_and_restart(
             raise OSError("injected provider delete failure")
         await original_delete(surface, target_epoch)
 
-    def fail_removal(permit) -> None:
-        if manager.snapshot_path(permit.snapshot_id).exists():
-            removal_attempts.append(permit.snapshot_id)
+    def fail_removal(operation_id: str) -> None:
+        if manager.snapshot_path(operation_id).exists():
+            removal_attempts.append(operation_id)
             raise OSError("injected snapshot removal failure")
-        original_remove(permit)
+        original_remove(operation_id)
 
     async def abort_after_interrupted_clear() -> dict:
         _replace_runtime_port(runtime, delete_surface=interrupt_provider)
@@ -1325,7 +1346,7 @@ async def test_aborted_clear_snapshot_removal_retries_on_reconcile_and_restart(
             operator_ref="user:owner",
         )
 
-    monkeypatch.setattr(manager, "remove", fail_removal)
+    monkeypatch.setattr(storage, "remove_terminal_snapshot", fail_removal)
     aborted = await abort_after_interrupted_clear()
     snapshot_path = manager.snapshot_path(aborted["operation_id"])
 
@@ -1335,14 +1356,14 @@ async def test_aborted_clear_snapshot_removal_retries_on_reconcile_and_restart(
     terminal = journal.get_operation(aborted["operation_id"])
     assert terminal is not None and terminal.state == "aborted"
 
-    monkeypatch.setattr(manager, "remove", original_remove)
+    monkeypatch.setattr(storage, "remove_terminal_snapshot", original_remove)
     assert await runtime.reconcile(MemoryConfig()) == {"ok": True, "state": "disabled"}
     reconcile_gc = _maintenance(runtime)._terminal_snapshot_gc_task
     assert reconcile_gc is not None
     await reconcile_gc
     assert not snapshot_path.exists()
 
-    monkeypatch.setattr(manager, "remove", fail_removal)
+    monkeypatch.setattr(storage, "remove_terminal_snapshot", fail_removal)
     aborted_before_restart = await abort_after_interrupted_clear()
     restart_snapshot_path = manager.snapshot_path(aborted_before_restart["operation_id"])
     assert restart_snapshot_path.is_dir()
@@ -1419,19 +1440,29 @@ async def test_cancelled_clear_waits_for_snapshot_creation_before_releasing_fenc
     discard_started = threading.Event()
     discard_release = threading.Event()
     discard_finished = threading.Event()
-    original_discard = MemorySnapshotManager.discard_unrecorded
+    original_discard = (
+        MemoryClearSnapshotStorage.discard_unrecorded_preparing_snapshot
+    )
 
-    def blocking_discard(manager: MemorySnapshotManager, permit) -> None:
-        if manager is _maintenance(runtime)._snapshot_manager:
+    def blocking_discard(
+        storage: MemoryClearSnapshotStorage,
+        operation_id: str,
+        **kwargs,
+    ):
+        if storage is _maintenance(runtime)._clear_snapshot_storage:
             discard_started.set()
             assert discard_release.wait(2)
         try:
-            original_discard(manager, permit)
+            return original_discard(storage, operation_id, **kwargs)
         finally:
-            if manager is _maintenance(runtime)._snapshot_manager:
+            if storage is _maintenance(runtime)._clear_snapshot_storage:
                 discard_finished.set()
 
-    monkeypatch.setattr(MemorySnapshotManager, "discard_unrecorded", blocking_discard)
+    monkeypatch.setattr(
+        MemoryClearSnapshotStorage,
+        "discard_unrecorded_preparing_snapshot",
+        blocking_discard,
+    )
     resuming = asyncio.create_task(
         _resume_clear(runtime, recovery.operation_id, operator_ref="user:owner")
     )
@@ -1452,7 +1483,11 @@ async def test_cancelled_clear_waits_for_snapshot_creation_before_releasing_fenc
     assert pending.state == "recovery_needed"
     assert pending.resolution == "resume"
 
-    monkeypatch.setattr(MemorySnapshotManager, "discard_unrecorded", original_discard)
+    monkeypatch.setattr(
+        MemoryClearSnapshotStorage,
+        "discard_unrecorded_preparing_snapshot",
+        original_discard,
+    )
     completed = await _resume_clear(runtime, pending.operation_id, operator_ref="user:owner")
     assert completed["status"] == "completed"
     await runtime.close()
@@ -1790,25 +1825,25 @@ async def test_backup_stage_cleanup_waits_for_terminal_snapshot_gc(
 ) -> None:
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     runtime = MemoryRuntime(MemoryConfig(), effective_home=tmp_path)
-    journal = _maintenance(runtime)._clear_journal
+    storage = _maintenance(runtime)._clear_snapshot_storage
     manager = _maintenance(runtime)._backup_manager
-    assert journal is not None
+    assert storage is not None
     assert manager is not None
     terminal_entered = threading.Event()
     terminal_release = threading.Event()
     backup_entered = threading.Event()
-    original_permits = journal.terminal_snapshot_permits
+    original_ids = storage.eligible_terminal_snapshot_ids
 
-    def blocking_permits():
+    def blocking_ids():
         terminal_entered.set()
         assert terminal_release.wait(2)
-        return original_permits()
+        return original_ids()
 
     def observe_backup_cleanup() -> tuple[str, ...]:
         backup_entered.set()
         return ()
 
-    monkeypatch.setattr(journal, "terminal_snapshot_permits", blocking_permits)
+    monkeypatch.setattr(storage, "eligible_terminal_snapshot_ids", blocking_ids)
     monkeypatch.setattr(
         manager,
         "reconcile_unpublished_backup_stages",

--- a/tests/test_memory_snapshot.py
+++ b/tests/test_memory_snapshot.py
@@ -14,9 +14,9 @@ import pytest
 import core.memory.snapshot as snapshot_module
 from core.memory.clear_journal import (
     ClearBackupBlocked,
-    ClearTransitionError,
     MemoryClearJournal,
 )
+from core.memory.clear_snapshot_storage import MemoryClearSnapshotStorage
 from core.memory.confined_filesystem import remove_confined_path
 from core.memory.snapshot import (
     MemorySnapshotError,
@@ -568,7 +568,9 @@ def test_deep_tree_create_verify_restore_and_terminal_clear_gc_converge(
             expected_revision=operation.revision,
             execution_token=operation.execution_token,
         )
-        manager.remove(journal.terminal_snapshot_permit(operation.operation_id))
+        MemoryClearSnapshotStorage(journal, manager).remove_terminal_snapshot(
+            operation.operation_id
+        )
     finally:
         sys.setrecursionlimit(previous_recursion_limit)
 
@@ -801,7 +803,9 @@ def test_snapshot_accepts_path_record_beyond_256k_and_clear_gc(
         expected_revision=operation.revision,
         execution_token=operation.execution_token,
     )
-    manager.remove(journal.terminal_snapshot_permit(operation.operation_id))
+    MemoryClearSnapshotStorage(journal, manager).remove_terminal_snapshot(
+        operation.operation_id
+    )
     remove_confined_path(home, source_root)
     assert not manager.snapshot_path(snapshot.snapshot_id).exists()
 
@@ -968,8 +972,6 @@ def test_snapshot_verify_fails_before_restore_on_tampered_payload(tmp_path: Path
         )
     assert live_provider.read_bytes() == b"live sentinel"
 
-    with pytest.raises(TypeError):
-        manager.remove(snapshot)  # type: ignore[arg-type]
     assert manager.snapshot_path("tamper").exists()
 
 
@@ -1358,198 +1360,3 @@ def test_explicit_id_backup_retry_still_reclaims_its_deterministic_stage(
     backup = manager.create("explicit-retry")
     assert backup.snapshot_id == "explicit-retry"
     assert not (manager.snapshot_root / ".explicit-retry.tmp").exists()
-
-
-def test_only_completed_journal_operation_can_authorize_snapshot_removal(tmp_path: Path) -> None:
-    home = tmp_path / "home"
-    home.mkdir(mode=0o700)
-    home.chmod(0o700)
-    journal = MemoryClearJournal(home)
-    operation = journal.start(
-        operation_id="remove-completed",
-        operator_ref="user:owner",
-        pre_epoch=0,
-        target_epoch=1,
-    )
-    manager = MemorySnapshotManager(home)
-    snapshot = manager.create(operation.operation_id)
-    assert operation.execution_token is not None
-    operation = journal.record_snapshot(
-        operation.operation_id,
-        expected_revision=operation.revision,
-        execution_token=operation.execution_token,
-        snapshot=snapshot,
-    )
-    with pytest.raises(ClearTransitionError):
-        journal.terminal_snapshot_permit(operation.operation_id)
-    assert operation.execution_token is not None
-    operation = journal.mark_prepared(
-        operation.operation_id,
-        expected_revision=operation.revision,
-        execution_token=operation.execution_token,
-    )
-    assert operation.execution_token is not None
-    operation = journal.begin_deleting(
-        operation.operation_id,
-        expected_revision=operation.revision,
-        execution_token=operation.execution_token,
-    )
-    for surface in journal.surfaces:
-        assert operation.execution_token is not None
-        operation = journal.record_surface_deleted(
-            operation.operation_id,
-            surface.name,
-            expected_revision=operation.revision,
-            execution_token=operation.execution_token,
-        )
-    assert operation.execution_token is not None
-    operation = journal.mark_completed(
-        operation.operation_id,
-        expected_revision=operation.revision,
-        execution_token=operation.execution_token,
-    )
-
-    permit = journal.terminal_snapshot_permit(operation.operation_id)
-    snapshot_path = manager.snapshot_path(operation.operation_id)
-    tombstone = manager.snapshot_root / f".{operation.operation_id}.gc"
-    manifest_path = snapshot_path / "manifest.jsonl"
-    manifest = manifest_path.read_bytes()
-    manifest_path.write_bytes(b"corrupt")
-    with pytest.raises(MemorySnapshotVerificationError):
-        manager.remove(permit)
-    assert snapshot_path.is_dir()
-    assert not tombstone.exists()
-    manifest_path.write_bytes(manifest)
-
-    manager.remove(permit)
-    assert not snapshot_path.exists()
-    assert not tombstone.exists()
-    manager.remove(permit)
-
-
-def test_completed_snapshot_removal_retries_a_partially_deleted_tombstone(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    home = tmp_path / "home"
-    queue_connection = _build_all_surfaces(home)
-    journal = MemoryClearJournal(home)
-    manager = MemorySnapshotManager(home)
-    _complete_clear_audit(journal, manager, "remove-retry")
-    queue_connection.close()
-    permit = journal.terminal_snapshot_permit("remove-retry")
-    snapshot_path = manager.snapshot_path(permit.snapshot_id)
-    tombstone = manager.snapshot_root / f".{permit.snapshot_id}.gc"
-    real_unlink = snapshot_module.os.unlink
-    interrupted = False
-
-    def interrupt_after_unlink(path, *args, **kwargs):
-        nonlocal interrupted
-        real_unlink(path, *args, **kwargs)
-        if not interrupted:
-            interrupted = True
-            raise OSError("injected tombstone removal failure")
-
-    monkeypatch.setattr(snapshot_module.os, "unlink", interrupt_after_unlink)
-    with pytest.raises(OSError, match="injected tombstone removal failure"):
-        manager.remove(permit)
-
-    assert interrupted
-    assert not snapshot_path.exists()
-    assert tombstone.is_dir()
-
-    monkeypatch.setattr(snapshot_module.os, "unlink", real_unlink)
-    manager.remove(permit)
-
-    assert not tombstone.exists()
-    assert not snapshot_path.exists()
-
-
-def test_restored_aborted_journal_operation_authorizes_snapshot_removal(
-    tmp_path: Path,
-) -> None:
-    home = tmp_path / "home"
-    queue_connection = _build_all_surfaces(home)
-    journal = MemoryClearJournal(home)
-    manager = MemorySnapshotManager(home)
-    _abort_clear_audit(journal, manager, "remove-aborted")
-    queue_connection.close()
-
-    permit = journal.terminal_snapshot_permit("remove-aborted")
-    snapshot_path = manager.snapshot_path(permit.snapshot_id)
-    manager.remove(permit)
-
-    assert not snapshot_path.exists()
-    manager.remove(permit)
-
-
-def test_preparing_journal_discards_snapshot_published_before_record_and_rebuilds(
-    tmp_path: Path,
-) -> None:
-    home = tmp_path / "home"
-    queue_connection = _build_all_surfaces(home)
-    journal = MemoryClearJournal(home)
-    operation = journal.start(
-        operation_id="publish-before-record",
-        operator_ref="user:owner",
-        pre_epoch=2,
-        target_epoch=3,
-    )
-    manager = MemorySnapshotManager(home)
-    manager.create(operation.operation_id)
-    queue_connection.close()
-
-    # Simulate process death before journal.record_snapshot().  Construction
-    # itself must not change the open operation.
-    reopened = MemoryClearJournal(home)
-    assert reopened.get_open_operation() == operation
-    recovery = reopened.mark_boot_recovery_needed()
-    assert recovery is not None
-    resumed = reopened.claim_resume(
-        operation.operation_id,
-        operator_ref="user:owner",
-        expected_revision=recovery.revision,
-    )
-    assert resumed.state == "preparing"
-    with pytest.raises(MemorySnapshotUnsafePathError):
-        manager.create(operation.operation_id)
-
-    assert resumed.execution_token is not None
-    with reopened.authorize_preparing_snapshot_discard(
-        resumed.operation_id,
-        expected_revision=resumed.revision,
-        execution_token=resumed.execution_token,
-    ) as discard_permit:
-        manager.discard_unrecorded(discard_permit)
-
-    assert not manager.snapshot_path(operation.operation_id).exists()
-    after_discard = reopened.get_operation(operation.operation_id)
-    assert after_discard is not None
-    assert after_discard.revision == resumed.revision + 1
-    assert reopened.get_events(operation.operation_id)[-1].event == "snapshot_discarded"
-
-    rebuilt = manager.create(operation.operation_id)
-    with pytest.raises(TypeError):
-        manager.discard_unrecorded(discard_permit)
-    assert manager.snapshot_path(operation.operation_id).exists()
-    assert after_discard.execution_token is not None
-    recorded = reopened.record_snapshot(
-        operation.operation_id,
-        expected_revision=after_discard.revision,
-        execution_token=after_discard.execution_token,
-        snapshot=rebuilt,
-    )
-    assert recorded.snapshot_path == rebuilt.relative_path
-    assert all(
-        surface.state == "snapshotted"
-        for surface in reopened.get_surfaces(operation.operation_id)
-    )
-    assert recorded.execution_token is not None
-    with pytest.raises(ClearTransitionError):
-        with reopened.authorize_preparing_snapshot_discard(
-            recorded.operation_id,
-            expected_revision=recorded.revision,
-            execution_token=recorded.execution_token,
-        ):
-            pass
-    assert manager.snapshot_path(operation.operation_id).exists()


### PR DESCRIPTION
## Summary

- add the deep `MemoryClearSnapshotStorage` module with three cleanup use cases:
  - `discard_unrecorded_preparing_snapshot(...)`
  - `eligible_terminal_snapshot_ids()`
  - `remove_terminal_snapshot(operation_id)`
- move preparing CAS/event coordination and terminal journal validation behind that interface
- remove snapshot permit classes, authority sentinels, process-local lease sets, issue/revoke helpers, and journal permit methods
- migrate synchronous and background maintenance cleanup to operation IDs through the new module

## Invariants

- terminal removal still requires `completed + all deleted` or `aborted + all restored`
- preparing discard still requires an exact operation/revision/execution-token CAS, no recorded snapshot, and no destructive progress
- persisted paths and digests are validated before cleanup, including tombstone retries
- terminal cleanup retains manifest/surface verification followed by deterministic tombstone rename, directory fsync, confined idempotent deletion, and final fsync
- preparing discard retains private-mode/no-follow confined deletion and journals the revision/event while holding the journal write transaction
- cancellation-safe blocking execution still settles filesystem and journal work before maintenance releases lifecycle fences

## Evidence

- Unit: `pytest -q tests/test_memory_clear_snapshot_storage.py` (5 passed)
- Contract: `pytest -q tests/test_memory_snapshot.py tests/test_memory_clear_snapshot_storage.py` (40 passed)
- Contract: `pytest -q tests/test_memory_clear_journal.py tests/test_memory_maintenance.py` (60 passed)
- Runtime: `pytest -q tests/test_memory_runtime.py` (145 passed)
- Static: Ruff on all changed Python files; `git diff --check`; symbol/search gate for removed permit/sentinel/lease helpers
- Scenario IDs: none; this refactor does not change a cataloged user workflow
- Residual manual checks: none; no user-visible behavior changes

## Conflict Note

#1270 deepens the Store/coordinator flush transaction interface. It is based on the same `dev` anchor but has no expected production-file overlap with this snapshot/journal/maintenance cleanup refactor; shared runtime evidence may need ordinary test reconciliation if both branches evolve.

Closes #1269
