### PR TITLE
refactor(memory): deepen flush store transactions

### DIFF
--- a/core/memory/coordinator.py
+++ b/core/memory/coordinator.py
@@ -338,14 +338,13 @@ class SessionFlushCoordinator:
             ):
                 return
             lease = await self._store_call(
-                self._store.acquire_flush,
+                self._store.begin_flush_attempt,
                 now=_iso(self._current_time()),
                 provider_session_ref=provider_session_ref,
                 force=force,
             )
             if lease is None:
                 return
-            await self._store_call(self._store.reclaim_fenced_generation_claims, lease)
             while not self._paused and self._enabled():
                 row = await self._claim_fenced_generation(
                     lease,
@@ -378,19 +377,13 @@ class SessionFlushCoordinator:
                     return
             if self._paused or not self._enabled():
                 return
-            pending, processing = await self._store_call(
-                self._store.target_generation_counts,
-                lease,
-            )
-            if pending or processing:
-                return
             result: FlushResult
             async with self._write_slots:
                 submission = _ProviderSubmissionAttempt()
                 try:
                     submitted_at = _iso(self._current_time())
                     if not await self._store_call(
-                        self._store.mark_flush_submission_started,
+                        self._store.begin_flush_submission,
                         lease,
                         now=submitted_at,
                     ):

--- a/core/memory/store.py
+++ b/core/memory/store.py
@@ -1457,47 +1457,31 @@ class MemoryStore:
             return "flush_required"
         return "complete"
 
-    def acquire_flush(
+    def begin_flush_attempt(
         self,
         *,
+        provider_session_ref: ProviderSessionRef,
         now: str,
-        provider_session_ref: ProviderSessionRef | None = None,
         force: bool = False,
     ) -> FlushLease | None:
-        """Acquire or resume one due generation, persisting the fence first."""
+        """Acquire or resume one exact session and reclaim its raced claims.
 
+        The caller must hold the exact session lock until the returned lease is
+        settled or returned.
+        """
+
+        serialized_ref = provider_session_ref.serialize()
         with self._transaction() as conn:
             meta = self._meta_in_connection(conn)
             if meta is None or meta.clear_in_progress:
                 return None
-            if provider_session_ref is not None:
-                serialized_ref = provider_session_ref.serialize()
-                row = conn.execute(
-                    """
-                    SELECT * FROM memory_session_flush_state
-                    WHERE provider_session_ref = ? AND epoch = ?
-                    """,
-                    (serialized_ref, meta.epoch),
-                ).fetchone()
-            else:
-                row = conn.execute(
-                    """
-                    SELECT * FROM memory_session_flush_state
-                    WHERE epoch = ? AND (
-                        (state = 'due' AND submission_started_at IS NULL
-                            AND (next_attempt_at IS NULL OR next_attempt_at <= ?))
-                        OR
-                        (state = 'idle' AND unflushed_count > 0
-                            AND due_at IS NOT NULL AND due_at <= ?)
-                    )
-                    ORDER BY
-                        CASE WHEN state = 'due' THEN 0 ELSE 1 END,
-                        COALESCE(next_attempt_at, due_at), provider_session_ref
-                    LIMIT 1
-                    """,
-                    (meta.epoch, now, now),
-                ).fetchone()
-                serialized_ref = str(row["provider_session_ref"]) if row is not None else ""
+            row = conn.execute(
+                """
+                SELECT * FROM memory_session_flush_state
+                WHERE provider_session_ref = ? AND epoch = ?
+                """,
+                (serialized_ref, meta.epoch),
+            ).fetchone()
             if row is None:
                 return None
 
@@ -1508,61 +1492,72 @@ class MemoryStore:
                 next_attempt_at = row["next_attempt_at"]
                 if next_attempt_at is not None and str(next_attempt_at) > now:
                     return None
-                return _flush_lease_from_row(row)
-            if state != "idle":
-                return None
-
-            if provider_session_ref is not None and force:
-                pending = conn.execute(
-                    """
-                    SELECT 1 FROM memory_capture_queue
-                    WHERE provider_session_ref = ? AND epoch = ?
-                      AND generation = ? AND state IN ('pending', 'processing')
-                    LIMIT 1
-                    """,
-                    (serialized_ref, meta.epoch, int(row["open_generation"])),
-                ).fetchone()
-                if int(row["unflushed_count"]) == 0 and pending is None:
+                lease = _flush_lease_from_row(row)
+            else:
+                if state != "idle":
                     return None
-            elif not (
-                int(row["unflushed_count"]) > 0
-                and row["due_at"] is not None
-                and str(row["due_at"]) <= now
-            ):
-                return None
+                if force:
+                    pending = conn.execute(
+                        """
+                        SELECT 1 FROM memory_capture_queue
+                        WHERE provider_session_ref = ? AND epoch = ?
+                          AND generation = ? AND state IN ('pending', 'processing')
+                        LIMIT 1
+                        """,
+                        (serialized_ref, meta.epoch, int(row["open_generation"])),
+                    ).fetchone()
+                    if int(row["unflushed_count"]) == 0 and pending is None:
+                        return None
+                elif not (
+                    int(row["unflushed_count"]) > 0
+                    and row["due_at"] is not None
+                    and str(row["due_at"]) <= now
+                ):
+                    return None
 
-            generation = int(row["open_generation"])
-            operation_epoch = int(row["operation_epoch"]) + 1
-            fence_token = f"flush-{operation_epoch}-{secrets.token_hex(16)}"
-            updated = conn.execute(
+                generation = int(row["open_generation"])
+                operation_epoch = int(row["operation_epoch"]) + 1
+                fence_token = f"flush-{operation_epoch}-{secrets.token_hex(16)}"
+                updated = conn.execute(
+                    """
+                    UPDATE memory_session_flush_state
+                    SET open_generation = open_generation + 1,
+                        target_generation = open_generation,
+                        state = 'due', operation_epoch = ?, fence_token = ?,
+                        next_attempt_at = NULL, retry_count = 0,
+                        submission_started_at = NULL, updated_at = ?
+                    WHERE provider_session_ref = ? AND epoch = ?
+                      AND state = 'idle' AND operation_epoch = ?
+                    """,
+                    (
+                        operation_epoch,
+                        fence_token,
+                        now,
+                        serialized_ref,
+                        meta.epoch,
+                        int(row["operation_epoch"]),
+                    ),
+                )
+                if updated.rowcount != 1:
+                    return None
+                lease = FlushLease(
+                    provider_session_ref=provider_session_ref,
+                    epoch=meta.epoch,
+                    generation=generation,
+                    operation_epoch=operation_epoch,
+                    fence_token=fence_token,
+                )
+
+            conn.execute(
                 """
-                UPDATE memory_session_flush_state
-                SET open_generation = open_generation + 1,
-                    target_generation = open_generation,
-                    state = 'due', operation_epoch = ?, fence_token = ?,
-                    next_attempt_at = NULL, retry_count = 0,
-                    submission_started_at = NULL, updated_at = ?
-                WHERE provider_session_ref = ? AND epoch = ?
-                  AND state = 'idle' AND operation_epoch = ?
+                UPDATE memory_capture_queue
+                SET state = 'pending', lease_owner = NULL, lease_at = NULL
+                WHERE provider_session_ref = ? AND epoch = ? AND generation = ?
+                  AND state = 'processing'
                 """,
-                (
-                    operation_epoch,
-                    fence_token,
-                    now,
-                    serialized_ref,
-                    meta.epoch,
-                    int(row["operation_epoch"]),
-                ),
+                (serialized_ref, lease.epoch, lease.generation),
             )
-            if updated.rowcount != 1:
-                return None
-            return FlushLease(
-                provider_session_ref=ProviderSessionRef.deserialize(serialized_ref),
-                epoch=meta.epoch,
-                generation=generation,
-                operation_epoch=operation_epoch,
-                fence_token=fence_token,
-            )
+            return lease
 
     def list_flush_candidates(self, *, now: str, limit: int = 16) -> tuple[ProviderSessionRef, ...]:
         """List independently acquirable session refs without changing state."""
@@ -1595,89 +1590,11 @@ class MemoryStore:
             for row in rows
         )
 
-    def target_generation_counts(self, lease: FlushLease) -> tuple[int, int]:
-        """Return pending/processing rows only after verifying the exact fence."""
-
-        serialized_ref = lease.provider_session_ref.serialize()
-        with self._connection() as conn:
-            authority = conn.execute(
-                """
-                SELECT 1 FROM memory_session_flush_state
-                WHERE provider_session_ref = ? AND epoch = ?
-                  AND target_generation = ? AND operation_epoch = ?
-                  AND fence_token = ? AND state = 'due'
-                """,
-                (
-                    serialized_ref,
-                    lease.epoch,
-                    lease.generation,
-                    lease.operation_epoch,
-                    lease.fence_token,
-                ),
-            ).fetchone()
-            if authority is None:
-                return (0, 0)
-            row = conn.execute(
-                """
-                SELECT
-                    SUM(CASE WHEN state = 'pending' THEN 1 ELSE 0 END) AS pending,
-                    SUM(CASE WHEN state = 'processing' THEN 1 ELSE 0 END) AS processing
-                FROM memory_capture_queue
-                WHERE provider_session_ref = ? AND epoch = ? AND generation = ?
-                """,
-                (serialized_ref, lease.epoch, lease.generation),
-            ).fetchone()
-        return (int(row["pending"] or 0), int(row["processing"] or 0))
-
-    def reclaim_fenced_generation_claims(self, lease: FlushLease) -> int:
-        """Return pre-call raced claims while the coordinator owns the session lock."""
+    def begin_flush_submission(self, lease: FlushLease, *, now: str) -> bool:
+        """Atomically prove generation emptiness and persist provider submission."""
 
         serialized_ref = lease.provider_session_ref.serialize()
         with self._transaction() as conn:
-            authority = conn.execute(
-                """
-                SELECT 1 FROM memory_session_flush_state
-                WHERE provider_session_ref = ? AND epoch = ?
-                  AND target_generation = ? AND operation_epoch = ?
-                  AND fence_token = ? AND state = 'due'
-                """,
-                (
-                    serialized_ref,
-                    lease.epoch,
-                    lease.generation,
-                    lease.operation_epoch,
-                    lease.fence_token,
-                ),
-            ).fetchone()
-            if authority is None:
-                return 0
-            updated = conn.execute(
-                """
-                UPDATE memory_capture_queue
-                SET state = 'pending', lease_owner = NULL, lease_at = NULL
-                WHERE provider_session_ref = ? AND epoch = ? AND generation = ?
-                  AND state = 'processing'
-                """,
-                (serialized_ref, lease.epoch, lease.generation),
-            )
-            return int(updated.rowcount)
-
-    def mark_flush_submission_started(self, lease: FlushLease, *, now: str) -> bool:
-        """Persist the ambiguity boundary only after the target generation drains."""
-
-        serialized_ref = lease.provider_session_ref.serialize()
-        with self._transaction() as conn:
-            remaining = conn.execute(
-                """
-                SELECT 1 FROM memory_capture_queue
-                WHERE provider_session_ref = ? AND epoch = ? AND generation = ?
-                  AND state IN ('pending', 'processing')
-                LIMIT 1
-                """,
-                (serialized_ref, lease.epoch, lease.generation),
-            ).fetchone()
-            if remaining is not None:
-                return False
             updated = conn.execute(
                 """
                 UPDATE memory_session_flush_state
@@ -1686,6 +1603,17 @@ class MemoryStore:
                   AND target_generation = ? AND operation_epoch = ?
                   AND fence_token = ? AND state = 'due'
                   AND submission_started_at IS NULL
+                  AND EXISTS (
+                      SELECT 1 FROM memory_meta AS meta
+                      WHERE meta.singleton = 1 AND meta.epoch = ?
+                        AND meta.clear_in_progress = 0
+                  )
+                  AND NOT EXISTS (
+                      SELECT 1 FROM memory_capture_queue AS queue
+                      WHERE queue.provider_session_ref = ? AND queue.epoch = ?
+                        AND queue.generation = ?
+                        AND queue.state IN ('pending', 'processing')
+                  )
                 """,
                 (
                     now,
@@ -1695,6 +1623,10 @@ class MemoryStore:
                     lease.generation,
                     lease.operation_epoch,
                     lease.fence_token,
+                    lease.epoch,
+                    serialized_ref,
+                    lease.epoch,
+                    lease.generation,
                 ),
             )
             return updated.rowcount == 1

--- a/tests/test_memory_flush_coordinator.py
+++ b/tests/test_memory_flush_coordinator.py
@@ -783,12 +783,12 @@ def test_stale_flush_settlement_cannot_clear_newer_generation(tmp_path: Path) ->
         now=current,
         idle_timeout=timedelta(0),
     ).settled
-    lease = store.acquire_flush(
+    lease = store.begin_flush_attempt(
         now="2026-01-01T00:00:00.000Z",
         provider_session_ref=row.provider_session_ref,
     )
     assert lease is not None
-    assert store.mark_flush_submission_started(lease, now="2026-01-01T00:00:01.000Z")
+    assert store.begin_flush_submission(lease, now="2026-01-01T00:00:01.000Z")
     assert store.settle_flush(
         lease,
         FlushSucceeded("first", "extracted"),
@@ -823,12 +823,12 @@ async def test_stale_flush_finalization_does_not_open_processing_fault(
         now=current,
         idle_timeout=timedelta(0),
     ).settled
-    lease = store.acquire_flush(
+    lease = store.begin_flush_attempt(
         now="2026-01-01T00:00:00.000Z",
         provider_session_ref=row.provider_session_ref,
     )
     assert lease is not None
-    assert store.mark_flush_submission_started(
+    assert store.begin_flush_submission(
         lease,
         now="2026-01-01T00:00:01.000Z",
     )
@@ -875,12 +875,12 @@ def test_boot_recovery_never_replays_submitted_flush(tmp_path: Path) -> None:
         now=datetime(2026, 1, 1, tzinfo=UTC),
         idle_timeout=timedelta(0),
     ).settled
-    lease = store.acquire_flush(
+    lease = store.begin_flush_attempt(
         now="2026-01-01T00:00:00.000Z",
         provider_session_ref=row.provider_session_ref,
     )
     assert lease is not None
-    assert store.mark_flush_submission_started(lease, now="2026-01-01T00:00:01.000Z")
+    assert store.begin_flush_submission(lease, now="2026-01-01T00:00:01.000Z")
 
     recovered = MemoryStore(store.path)
     evidence = recovered.recover_after_boot(
@@ -891,7 +891,7 @@ def test_boot_recovery_never_replays_submitted_flush(tmp_path: Path) -> None:
     assert evidence.interrupted_flushes == 1
     state = recovered.get_session_flush_state(row.provider_session_ref)
     assert state is not None and state.state == "manual_required"
-    assert recovered.acquire_flush(
+    assert recovered.begin_flush_attempt(
         now="2026-01-01T00:10:00.000Z",
         provider_session_ref=row.provider_session_ref,
         force=True,
@@ -919,12 +919,12 @@ async def test_boot_recovery_opens_and_emits_processing_fault_once(
             now=datetime(2026, 1, 1, tzinfo=UTC),
             idle_timeout=timedelta(0),
         ).settled
-        lease = store.acquire_flush(
+        lease = store.begin_flush_attempt(
             now="2026-01-01T00:00:01.000Z",
             provider_session_ref=row.provider_session_ref,
         )
         assert lease is not None
-        assert store.mark_flush_submission_started(
+        assert store.begin_flush_submission(
             lease,
             now="2026-01-01T00:00:02.000Z",
         )
@@ -1031,13 +1031,13 @@ async def test_restart_finishes_submitted_flush_fault_notification_once(
         lease_owner="old-boot",
         now=datetime(2026, 1, 1, tzinfo=UTC),
     ).settled
-    lease = store.acquire_flush(
+    lease = store.begin_flush_attempt(
         now="2026-01-01T00:00:01.000Z",
         provider_session_ref=row.provider_session_ref,
         force=True,
     )
     assert lease is not None
-    assert store.mark_flush_submission_started(
+    assert store.begin_flush_submission(
         lease,
         now="2026-01-01T00:00:02.000Z",
     )
@@ -1121,13 +1121,13 @@ async def test_restart_finishes_atomic_processing_recovery_notification_once(
         assert store.open_processing_fault(now="2026-01-01T00:00:02.500Z")
         assert store.classify_processing_fault("engine")
         assert store.mark_processing_alert_active()
-        lease = store.acquire_flush(
+        lease = store.begin_flush_attempt(
             now="2026-01-01T00:00:03.000Z",
             provider_session_ref=row.provider_session_ref,
             force=True,
         )
         assert lease is not None
-        assert store.mark_flush_submission_started(
+        assert store.begin_flush_submission(
             lease,
             now="2026-01-01T00:00:04.000Z",
         )
@@ -1584,7 +1584,7 @@ async def test_cancelled_flush_while_submission_marker_commits_remains_retryable
 
     marker_committed = threading.Event()
     release_marker = threading.Event()
-    original_mark = store.mark_flush_submission_started
+    original_mark = store.begin_flush_submission
 
     def blocking_mark(lease, *, now: str) -> bool:
         marked = original_mark(lease, now=now)
@@ -1592,7 +1592,7 @@ async def test_cancelled_flush_while_submission_marker_commits_remains_retryable
         release_marker.wait(timeout=2)
         return marked
 
-    monkeypatch.setattr(store, "mark_flush_submission_started", blocking_mark)
+    monkeypatch.setattr(store, "begin_flush_submission", blocking_mark)
     flush_call = asyncio.create_task(
         coordinator.final_flush(row.provider_session_ref, deadline_seconds=5)
     )

--- a/tests/test_memory_store.py
+++ b/tests/test_memory_store.py
@@ -517,7 +517,7 @@ def test_exhausted_flush_retry_and_processing_fault_are_one_transaction(
 ) -> None:
     store = MemoryStore(_store_path(tmp_path))
     session_ref = _deliver(store, "atomic-flush-retry")
-    lease = store.acquire_flush(
+    lease = store.begin_flush_attempt(
         now="2026-01-01T00:00:02.000Z",
         provider_session_ref=session_ref,
         force=True,
@@ -572,13 +572,13 @@ def test_submitted_flush_fault_and_settlement_are_one_transaction(
 ) -> None:
     store = MemoryStore(_store_path(tmp_path))
     session_ref = _deliver(store, "atomic-submitted-flush")
-    lease = store.acquire_flush(
+    lease = store.begin_flush_attempt(
         now="2026-01-01T00:00:02.000Z",
         provider_session_ref=session_ref,
         force=True,
     )
     assert lease is not None
-    assert store.mark_flush_submission_started(
+    assert store.begin_flush_submission(
         lease,
         now="2026-01-01T00:00:03.000Z",
     )
@@ -654,13 +654,13 @@ def test_successful_flush_and_processing_fault_close_are_one_transaction(
 ) -> None:
     store = MemoryStore(_store_path(tmp_path))
     session_ref = _deliver(store, "atomic-flush-close")
-    lease = store.acquire_flush(
+    lease = store.begin_flush_attempt(
         now="2026-01-01T00:00:02.000Z",
         provider_session_ref=session_ref,
         force=True,
     )
     assert lease is not None
-    assert store.mark_flush_submission_started(
+    assert store.begin_flush_submission(
         lease,
         now="2026-01-01T00:00:03.000Z",
     )
@@ -720,6 +720,302 @@ def test_project_derivation_is_stable_opaque_and_workdir_scoped() -> None:
         derive_project_id(scope_key, "/workspaces/../one")
 
 
+def test_begin_flush_attempt_reclaims_only_the_exact_new_session(
+    tmp_path: Path,
+) -> None:
+    store = MemoryStore(_store_path(tmp_path))
+    first = store.enqueue_request(
+        source_message_id="first-raced-claim",
+        session_id="first-session",
+        principal_id="u-11111111111111111111111111111111",
+        project_ref=PROJECT,
+        provenance="user_input",
+        payload_text="queued payload",
+        occurred_at_ms=1_000,
+        max_provider_timestamp_ms=4_102_444_800_000,
+    )
+    second = store.enqueue_request(
+        source_message_id="second-raced-claim",
+        session_id="second-session",
+        principal_id="u-11111111111111111111111111111111",
+        project_ref=PROJECT,
+        provenance="user_input",
+        payload_text="queued payload",
+        occurred_at_ms=1_001,
+        max_provider_timestamp_ms=4_102_444_800_000,
+    )
+    assert first.row is not None and second.row is not None
+    assert store.claim_due(lease_owner="first-worker", now="2026-01-01T00:00:00.000Z")
+    assert store.claim_due(lease_owner="second-worker", now="2026-01-01T00:00:00.000Z")
+
+    lease = store.begin_flush_attempt(
+        provider_session_ref=first.row.provider_session_ref,
+        now="2026-01-01T00:00:01.000Z",
+        force=True,
+    )
+
+    assert lease is not None
+    first_row = _row_for_source(store, "first-raced-claim")
+    second_row = _row_for_source(store, "second-raced-claim")
+    assert first_row is not None and first_row.state == "pending"
+    assert second_row is not None and second_row.state == "processing"
+
+
+def test_begin_flush_attempt_resumes_lease_and_reclaims_fenced_claim(
+    tmp_path: Path,
+) -> None:
+    store = MemoryStore(_store_path(tmp_path))
+    result = _enqueue(store, "resumed-raced-claim")
+    assert result.row is not None
+    lease = store.begin_flush_attempt(
+        provider_session_ref=result.row.provider_session_ref,
+        now="2026-01-01T00:00:01.000Z",
+        force=True,
+    )
+    assert lease is not None
+    claimed = store.claim_fenced_generation(
+        lease,
+        lease_owner=lease.fence_token,
+        now="2026-01-01T00:00:02.000Z",
+    )
+    assert claimed is not None and claimed.state == "processing"
+
+    resumed = store.begin_flush_attempt(
+        provider_session_ref=result.row.provider_session_ref,
+        now="2026-01-01T00:00:03.000Z",
+        force=True,
+    )
+
+    assert resumed == lease
+    reclaimed = _row_for_source(store, "resumed-raced-claim")
+    assert reclaimed is not None and reclaimed.state == "pending"
+
+
+def test_begin_flush_attempt_rolls_back_acquisition_when_reclaim_fails(
+    tmp_path: Path,
+) -> None:
+    store = MemoryStore(_store_path(tmp_path))
+    result = _enqueue(store, "rollback-raced-claim")
+    assert result.row is not None
+    assert store.claim_due(lease_owner="worker", now="2026-01-01T00:00:00.000Z")
+    with sqlite3.connect(store.path) as conn:
+        conn.execute(
+            """
+            CREATE TRIGGER fail_flush_reclaim
+            BEFORE UPDATE OF state ON memory_capture_queue
+            WHEN OLD.state = 'processing' AND NEW.state = 'pending'
+            BEGIN
+                SELECT RAISE(ABORT, 'injected reclaim failure');
+            END
+            """
+        )
+
+    with pytest.raises(sqlite3.IntegrityError, match="injected reclaim failure"):
+        store.begin_flush_attempt(
+            provider_session_ref=result.row.provider_session_ref,
+            now="2026-01-01T00:00:01.000Z",
+            force=True,
+        )
+
+    state = store.get_session_flush_state(result.row.provider_session_ref)
+    row = _row_for_source(store, "rollback-raced-claim")
+    assert state is not None
+    assert (state.state, state.open_generation, state.target_generation) == ("idle", 1, None)
+    assert row is not None and row.state == "processing"
+
+
+def test_begin_flush_attempt_force_preserves_resumed_retry_backoff(tmp_path: Path) -> None:
+    store = MemoryStore(_store_path(tmp_path))
+    session_ref = _deliver(store, "force-backoff")
+    lease = store.begin_flush_attempt(
+        provider_session_ref=session_ref,
+        now="2026-01-01T00:00:02.000Z",
+        force=True,
+    )
+    assert lease is not None
+    assert store.retry_unsubmitted_flush(
+        lease,
+        now=_dt("2026-01-01T00:00:03.000Z"),
+    ).settled
+
+    assert store.begin_flush_attempt(
+        provider_session_ref=session_ref,
+        now="2026-01-01T00:00:03.000Z",
+        force=True,
+    ) is None
+
+
+@pytest.mark.parametrize("remaining_state", ("pending", "processing"))
+def test_begin_flush_submission_refuses_nonempty_target_generation(
+    tmp_path: Path,
+    remaining_state: str,
+) -> None:
+    store = MemoryStore(_store_path(tmp_path))
+    result = _enqueue(store, f"submission-{remaining_state}")
+    assert result.row is not None
+    lease = store.begin_flush_attempt(
+        provider_session_ref=result.row.provider_session_ref,
+        now="2026-01-01T00:00:01.000Z",
+        force=True,
+    )
+    assert lease is not None
+    if remaining_state == "processing":
+        assert store.claim_fenced_generation(
+            lease,
+            lease_owner=lease.fence_token,
+            now="2026-01-01T00:00:02.000Z",
+        )
+
+    assert not store.begin_flush_submission(
+        lease,
+        now="2026-01-01T00:00:03.000Z",
+    )
+    state = store.get_session_flush_state(result.row.provider_session_ref)
+    assert state is not None and state.state == "due"
+
+
+def test_begin_flush_submission_commits_exact_generation_marker(tmp_path: Path) -> None:
+    store = MemoryStore(_store_path(tmp_path))
+    session_ref = _deliver(store, "submission-marker")
+    lease = store.begin_flush_attempt(
+        provider_session_ref=session_ref,
+        now="2026-01-01T00:00:02.000Z",
+        force=True,
+    )
+    assert lease is not None
+
+    assert store.begin_flush_submission(lease, now="2026-01-01T00:00:03.000Z")
+    state = store.get_session_flush_state(session_ref)
+    assert state is not None
+    assert (state.state, state.target_generation, state.submission_started_at) == (
+        "in_flight",
+        lease.generation,
+        "2026-01-01T00:00:03.000Z",
+    )
+
+
+def test_begin_flush_submission_refuses_a_stale_completed_lease(tmp_path: Path) -> None:
+    store = MemoryStore(_store_path(tmp_path))
+    session_ref = _deliver(store, "stale-submission-lease")
+    lease = store.begin_flush_attempt(
+        provider_session_ref=session_ref,
+        now="2026-01-01T00:00:02.000Z",
+        force=True,
+    )
+    assert lease is not None
+    assert store.begin_flush_submission(lease, now="2026-01-01T00:00:03.000Z")
+    assert store.settle_flush(
+        lease,
+        FlushSucceeded(request_id="stale-lease", status="extracted"),
+        now="2026-01-01T00:00:04.000Z",
+    ).settled
+
+    assert not store.begin_flush_submission(lease, now="2026-01-01T00:00:05.000Z")
+
+
+@pytest.mark.parametrize("advance_epoch", (False, True), ids=("same-epoch", "advanced-epoch"))
+def test_begin_flush_submission_refuses_clear_meta_cas(
+    tmp_path: Path,
+    advance_epoch: bool,
+) -> None:
+    store = MemoryStore(_store_path(tmp_path))
+    session_ref = _deliver(store, f"clear-cas-{advance_epoch}")
+    lease = store.begin_flush_attempt(
+        provider_session_ref=session_ref,
+        now="2026-01-01T00:00:02.000Z",
+        force=True,
+    )
+    assert lease is not None
+    if advance_epoch:
+        store.begin_clear()
+    else:
+        store.begin_clear_fence()
+
+    assert not store.begin_flush_submission(lease, now="2026-01-01T00:00:03.000Z")
+    state = store.get_session_flush_state(session_ref)
+    assert state is not None and state.state == "due"
+
+
+def test_begin_flush_submission_rolls_back_marker_failure(tmp_path: Path) -> None:
+    store = MemoryStore(_store_path(tmp_path))
+    session_ref = _deliver(store, "marker-rollback")
+    lease = store.begin_flush_attempt(
+        provider_session_ref=session_ref,
+        now="2026-01-01T00:00:02.000Z",
+        force=True,
+    )
+    assert lease is not None
+    with sqlite3.connect(store.path) as conn:
+        conn.execute(
+            """
+            CREATE TRIGGER fail_submission_marker
+            BEFORE UPDATE OF state ON memory_session_flush_state
+            WHEN NEW.state = 'in_flight'
+            BEGIN
+                SELECT RAISE(ABORT, 'injected marker failure');
+            END
+            """
+        )
+
+    with pytest.raises(sqlite3.IntegrityError, match="injected marker failure"):
+        store.begin_flush_submission(lease, now="2026-01-01T00:00:03.000Z")
+
+    state = store.get_session_flush_state(session_ref)
+    assert state is not None
+    assert (state.state, state.submission_started_at) == ("due", None)
+
+
+def test_manual_flush_authority_refuses_transactions_without_releasing_attachment(
+    tmp_path: Path,
+) -> None:
+    store = MemoryStore(_store_path(tmp_path))
+    bundle_id = "a" * 32
+    enqueued = store.enqueue_request(
+        source_message_id="manual-attachment",
+        session_id="manual-attachment-session",
+        principal_id="u-11111111111111111111111111111111",
+        project_ref=PROJECT,
+        provenance="user_input",
+        payload_text="queued payload",
+        payload_attachments="pinned attachment payload",
+        attachment_bundle_id=bundle_id,
+        attachment_bundle_relative_path=f"bundles/{bundle_id}",
+        attachment_file_count=1,
+        attachment_total_bytes=10,
+        occurred_at_ms=1_000,
+        max_provider_timestamp_ms=4_102_444_800_000,
+    )
+    assert enqueued.row is not None
+    assert store.claim_due(lease_owner="worker", now="2026-01-01T00:00:00.000Z")
+    lease = store.begin_flush_attempt(
+        provider_session_ref=enqueued.row.provider_session_ref,
+        now="2026-01-01T00:00:01.000Z",
+        force=True,
+    )
+    assert lease is not None
+    assert store.attachment_bundle_sets() == (frozenset({bundle_id}), frozenset())
+    claimed = store.claim_fenced_generation(
+        lease,
+        lease_owner=lease.fence_token,
+        now="2026-01-01T00:00:02.000Z",
+    )
+    assert claimed is not None
+    assert store.settle(
+        claimed,
+        AmbiguousAdd(),
+        lease_owner=lease.fence_token,
+        now=_dt("2026-01-01T00:00:03.000Z"),
+    ).settled
+
+    assert store.begin_flush_attempt(
+        provider_session_ref=enqueued.row.provider_session_ref,
+        now="2026-01-01T00:00:04.000Z",
+        force=True,
+    ) is None
+    assert not store.begin_flush_submission(lease, now="2026-01-01T00:00:04.000Z")
+    assert store.attachment_bundle_sets() == (frozenset({bundle_id}), frozenset())
+
+
 def test_reused_memory_session_anchor_is_namespaced_by_project(tmp_path: Path) -> None:
     store = MemoryStore(_store_path(tmp_path))
     first = _enqueue(store, "first")
@@ -748,14 +1044,14 @@ def test_store_settles_one_fenced_generation_not_individual_queue_rows(tmp_path:
     assert before is not None
     assert (before.state, before.open_generation, before.unflushed_count) == ("idle", 1, 2)
 
-    lease = store.acquire_flush(
+    lease = store.begin_flush_attempt(
         now="2026-01-01T00:00:02.000Z",
         provider_session_ref=session_ref,
         force=True,
     )
     assert lease is not None
     assert lease.generation == 1
-    assert store.mark_flush_submission_started(lease, now="2026-01-01T00:00:02.500Z")
+    assert store.begin_flush_submission(lease, now="2026-01-01T00:00:02.500Z")
     settled = store.settle_flush(
         lease,
         FlushSucceeded(request_id="flush-request", status="extracted"),
@@ -796,13 +1092,13 @@ def test_store_settles_one_fenced_generation_not_individual_queue_rows(tmp_path:
 def test_store_records_rejected_and_unknown_as_generation_settlements(tmp_path: Path) -> None:
     store = MemoryStore(_store_path(tmp_path))
     rejected_session = _deliver(store, "rejected", session_ref="rejected-session")
-    rejected_lease = store.acquire_flush(
+    rejected_lease = store.begin_flush_attempt(
         now="2026-01-01T00:00:02.000Z",
         provider_session_ref=rejected_session,
         force=True,
     )
     assert rejected_lease is not None
-    assert store.mark_flush_submission_started(
+    assert store.begin_flush_submission(
         rejected_lease,
         now="2026-01-01T00:00:02.500Z",
     )
@@ -818,13 +1114,13 @@ def test_store_records_rejected_and_unknown_as_generation_settlements(tmp_path: 
     assert (rejected.settled, rejected.state) == (True, "idle")
 
     unknown_session = _deliver(store, "unknown", session_ref="unknown-session")
-    unknown_lease = store.acquire_flush(
+    unknown_lease = store.begin_flush_attempt(
         now="2026-01-01T00:00:03.000Z",
         provider_session_ref=unknown_session,
         force=True,
     )
     assert unknown_lease is not None
-    assert store.mark_flush_submission_started(
+    assert store.begin_flush_submission(
         unknown_lease,
         now="2026-01-01T00:00:03.500Z",
     )
@@ -944,18 +1240,18 @@ def test_store_activation_recovery_fences_submitted_and_resumes_unsubmitted_flus
     store = MemoryStore(_store_path(tmp_path))
     submitted_ref = _deliver(store, "in-flight", session_ref="in-flight-session")
     resumable_ref = _deliver(store, "not-attempted", session_ref="not-attempted-session")
-    submitted_lease = store.acquire_flush(
+    submitted_lease = store.begin_flush_attempt(
         now="2026-01-01T00:00:02.000Z",
         provider_session_ref=submitted_ref,
         force=True,
     )
-    resumable_lease = store.acquire_flush(
+    resumable_lease = store.begin_flush_attempt(
         now="2026-01-01T00:00:02.000Z",
         provider_session_ref=resumable_ref,
         force=True,
     )
     assert submitted_lease is not None and resumable_lease is not None
-    assert store.mark_flush_submission_started(
+    assert store.begin_flush_submission(
         submitted_lease,
         now="2026-01-01T00:00:03.000Z",
     )
@@ -974,12 +1270,12 @@ def test_store_activation_recovery_fences_submitted_and_resumes_unsubmitted_flus
     assert store.list_flush_candidates(
         now="2026-01-01T00:00:05.000Z",
     ) == (resumable_ref,)
-    assert store.acquire_flush(
+    assert store.begin_flush_attempt(
         now="2026-01-01T00:00:05.000Z",
         provider_session_ref=submitted_ref,
         force=True,
     ) is None
-    assert store.acquire_flush(
+    assert store.begin_flush_attempt(
         now="2026-01-01T00:00:05.000Z",
         provider_session_ref=resumable_ref,
     ) == resumable_lease
@@ -997,13 +1293,13 @@ def test_boot_recovery_samples_its_clock_after_reclaiming_leases(tmp_path: Path)
 
     store = MemoryStore(_store_path(tmp_path / "recovery-clock-order"))
     in_flight_ref = _deliver(store, "in-flight", session_ref="in-flight-session")
-    lease = store.acquire_flush(
+    lease = store.begin_flush_attempt(
         now="2026-01-01T00:00:02.000Z",
         provider_session_ref=in_flight_ref,
         force=True,
     )
     assert lease is not None
-    assert store.mark_flush_submission_started(
+    assert store.begin_flush_submission(
         lease,
         now="2026-01-01T00:00:03.000Z",
     )
@@ -1178,13 +1474,13 @@ def test_reclaim_processing_and_clear_deletes_every_queue_row(tmp_path: Path) ->
 def test_clear_reset_replays_at_the_exact_target_epoch(tmp_path: Path) -> None:
     store = MemoryStore(_store_path(tmp_path))
     session_ref = _deliver(store, "queued")
-    lease = store.acquire_flush(
+    lease = store.begin_flush_attempt(
         now="2026-01-01T00:00:02.000Z",
         provider_session_ref=session_ref,
         force=True,
     )
     assert lease is not None
-    assert store.mark_flush_submission_started(lease, now="2026-01-01T00:00:02.500Z")
+    assert store.begin_flush_submission(lease, now="2026-01-01T00:00:02.500Z")
     assert store.settle_flush(
         lease,
         FlushSucceeded(request_id="flush-before-clear", status="extracted"),
@@ -1233,13 +1529,13 @@ def test_terminal_tombstones_compact_after_90_days_but_retain_settlement_evidenc
 ) -> None:
     store = MemoryStore(_store_path(tmp_path))
     session_ref = _deliver(store, "terminal")
-    lease = store.acquire_flush(
+    lease = store.begin_flush_attempt(
         now="2026-01-01T00:00:02.000Z",
         provider_session_ref=session_ref,
         force=True,
     )
     assert lease is not None
-    assert store.mark_flush_submission_started(lease, now="2026-01-01T00:00:02.500Z")
+    assert store.begin_flush_submission(lease, now="2026-01-01T00:00:02.500Z")
     assert store.settle_flush(
         lease,
         FlushSucceeded(request_id="flush-terminal", status="extracted"),
@@ -1337,13 +1633,13 @@ def test_terminal_tombstone_count_compaction_prunes_only_the_evicted_session(
         for index in range(2)
     ]
     for index, session_ref in enumerate(session_refs):
-        lease = store.acquire_flush(
+        lease = store.begin_flush_attempt(
             now="2026-01-01T00:00:02.000Z",
             provider_session_ref=session_ref,
             force=True,
         )
         assert lease is not None
-        assert store.mark_flush_submission_started(
+        assert store.begin_flush_submission(
             lease,
             now="2026-01-01T00:00:02.500Z",
         )
@@ -1366,7 +1662,7 @@ def test_session_state_pruning_preserves_active_and_retained_evidence(tmp_path: 
     store = MemoryStore(_store_path(tmp_path))
 
     due_ref = _deliver(store, "retained-due", session_ref="retained-due")
-    due_lease = store.acquire_flush(
+    due_lease = store.begin_flush_attempt(
         now="2026-01-01T00:00:02.000Z",
         provider_session_ref=due_ref,
         force=True,
@@ -1374,13 +1670,13 @@ def test_session_state_pruning_preserves_active_and_retained_evidence(tmp_path: 
     assert due_lease is not None
 
     in_flight_ref = _deliver(store, "retained-in-flight", session_ref="retained-in-flight")
-    in_flight_lease = store.acquire_flush(
+    in_flight_lease = store.begin_flush_attempt(
         now="2026-01-01T00:00:02.000Z",
         provider_session_ref=in_flight_ref,
         force=True,
     )
     assert in_flight_lease is not None
-    assert store.mark_flush_submission_started(
+    assert store.begin_flush_submission(
         in_flight_lease,
         now="2026-01-01T00:00:02.500Z",
     )


### PR DESCRIPTION
## Summary

- replace four caller-driven flush transitions with `begin_flush_attempt` and `begin_flush_submission`
- acquire or resume one required exact `ProviderSessionRef` and reclaim its fenced generation claims in one Store transaction
- prove target-generation emptiness and CAS the exact lease plus current Clear/meta state before marking provider submission
- preserve the coordinator cancellation compensation region and distinct unsubmitted, retry, and settlement outcomes

## Evidence

- Unit: `119 passed` across `test_memory_store.py`, `test_memory_flush_coordinator.py`, and `test_memory_worker.py`
- Contract: transaction coverage includes new/resumed reclamation, rollback, force/backoff, pending/processing refusal, exact marker commit, stale/manual refusal, both Clear CAS states, marker rollback, and attachment-reference preservation
- Contract: repository search confirms no coordinator or test callers remain for the four absorbed transitions
- Runtime: `4 passed` focused memory recovery/final-flush tests and `8 passed` runtime recovery tests
- Scenario: not applicable; no Memory flush-transaction scenario catalog entry exists
- Residual manual: none; this changes no user-visible or provider behavior
- Static: Ruff on all changed Python files and `git diff --check`

## Interface Notes

- result types remain `FlushLease | None` and `bool`; no refinement was needed
- the reviewed implementation brief's `begin_flush_submission` name is used for the submission transaction

Closes #1270
