### PR TITLE
refactor(memory): extract status presentation policy

### DIFF
--- a/ui/src/components/settings/memory/MemoryStatusPanel.test.tsx
+++ b/ui/src/components/settings/memory/MemoryStatusPanel.test.tsx
@@ -85,127 +85,27 @@ describe('MemoryStatusPanel', () => {
     expect(screen.queryByText('memory.status.state.degraded')).toBeNull();
   });
 
-  it('does not present an unobserved source as available', () => {
-    render(
+  it('preserves the Processing Record structure and responsive class contract', () => {
+    const { container } = render(
       <MemoryStatusPanel
         {...baseProps}
-        logSections={{
-          ...baseProps.logSections!,
-          everos: { status: 'available', observed_at: null },
-        }}
+        failures={[MANUAL_FAILURE]}
+        recovery={{ operation_id: 'clear-dom', state: 'prepared', can_resume: true, can_abort: true }}
       />,
     );
 
-    expect(screen.getByText('memory.processingRecord.sourceState.unknown')).toBeTruthy();
-    expect(screen.getAllByText('memory.processingRecord.sourceNotObserved').length).toBeGreaterThan(0);
-  });
-
-  it('preserves a future runtime health status as diagnostic fallback text', () => {
-    render(
-      <MemoryStatusPanel
-        {...baseProps}
-        status={{
-          ...STATUS,
-          health: { ...STATUS.health!, status: 'future_health_state' },
-        }}
-      />,
+    expect(container.firstElementChild?.className).toBe('flex flex-col gap-5');
+    expect(Array.from(container.querySelectorAll('section')).map((section) => section.getAttribute('aria-labelledby'))).toEqual([
+      'memory-runtime-title',
+      'memory-sources-title',
+      'memory-anomalies-title',
+    ]);
+    expect(container.querySelector('#memory-sources-title')?.parentElement?.nextElementSibling?.className).toBe(
+      'grid gap-2 sm:grid-cols-2 xl:grid-cols-4',
     );
-
-    expect(screen.getByText('future_health_state')).toBeTruthy();
-  });
-
-  it('localizes closed runtime fact labels and enum values while preserving diagnostics', () => {
-    render(
-      <MemoryStatusPanel
-        {...baseProps}
-        status={{
-          ...STATUS,
-          health: {
-            ...STATUS.health!,
-            capabilities: { embed: false },
-            disabled_features: ['embed'],
-            cascade: {
-              healthy: false,
-              reasons: ['drain_failures'],
-              prune_stale_seconds: 45,
-            },
-            recorder: { state: 'degraded', reason: 'call_log_corrupt' },
-          },
-        }}
-      />,
+    expect(screen.getByTestId('memory-anomaly-result_unknown').className).toBe(
+      'flex min-w-0 flex-col gap-3 border-b border-border py-3 last:border-b-0 lg:flex-row lg:justify-between',
     );
-
-    expect(screen.getAllByText('memory.processingRecord.runtime.fact.capability.embed')).toHaveLength(2);
-    expect(screen.getAllByText('memory.processingRecord.runtime.fact.boolean.false')).toHaveLength(2);
-    expect(screen.getByText('memory.processingRecord.runtime.fact.cascade.pruneStaleSeconds')).toBeTruthy();
-    expect(screen.getByText('memory.processingRecord.runtime.fact.cascadeReason.drainFailures')).toBeTruthy();
-    expect(screen.getByText('memory.processingRecord.runtime.fact.recorder.state')).toBeTruthy();
-    expect(screen.getByText('memory.processingRecord.runtime.fact.recorderState.degraded')).toBeTruthy();
-    expect(screen.getByText('memory.processingRecord.runtime.fact.recorderReason.callLogCorrupt')).toBeTruthy();
-    expect(screen.getByText('45')).toBeTruthy();
-  });
-
-  it('leaves future runtime fact labels and values as raw fallback text', () => {
-    render(
-      <MemoryStatusPanel
-        {...baseProps}
-        status={{
-          ...STATUS,
-          health: {
-            ...STATUS.health!,
-            capabilities: { future_capability: true },
-            disabled_features: ['future_feature'],
-            cascade: { reasons: ['future_reason'], future_counter: 12 },
-            recorder: { state: 'future_state', future_field: 'future_value' },
-          },
-        }}
-      />,
-    );
-
-    expect(screen.getByText('future_capability')).toBeTruthy();
-    expect(screen.getByText('true')).toBeTruthy();
-    expect(screen.getByText('future_feature')).toBeTruthy();
-    expect(screen.getByText('future_reason')).toBeTruthy();
-    expect(screen.getByText('future_counter')).toBeTruthy();
-    expect(screen.getByText('12')).toBeTruthy();
-    expect(screen.getByText('future_state')).toBeTruthy();
-    expect(screen.getByText('future_field')).toBeTruthy();
-    expect(screen.getByText('future_value')).toBeTruthy();
-  });
-
-  it('localizes known runtime and log source reasons', () => {
-    render(
-      <MemoryStatusPanel
-        {...baseProps}
-        status={{
-          ...STATUS,
-          source: { status: 'unavailable', observed_at: null, reason: 'memory_sidecar_unavailable' },
-        }}
-        logSections={{
-          ...baseProps.logSections!,
-          everos: { status: 'unavailable', observed_at: null, reason: 'missing' },
-          capture: { status: 'stale', observed_at: null, reason: 'runs_busy' },
-        }}
-      />,
-    );
-
-    expect(screen.getByText('memory.processingRecord.sourceReason:errors.memory_sidecar_unavailable')).toBeTruthy();
-    expect(screen.getByText('memory.processingRecord.sourceReason:memory.log.reason.missing')).toBeTruthy();
-    expect(screen.getByText('memory.processingRecord.sourceReason:memory.log.reason.runsBusy')).toBeTruthy();
-  });
-
-  it('leaves a future source reason as inert fallback text', () => {
-    render(
-      <MemoryStatusPanel
-        {...baseProps}
-        status={{
-          ...STATUS,
-          source: { status: 'unavailable', observed_at: null, reason: 'future_source_reason' },
-        }}
-      />,
-    );
-
-    expect(screen.getByText('memory.processingRecord.sourceReason:future_source_reason')).toBeTruthy();
   });
 
   it('keeps source-independent anomalies visible when health cannot be read', () => {
@@ -260,36 +160,6 @@ describe('MemoryStatusPanel', () => {
     consoleError.mockRestore();
   });
 
-  it('localizes the boot recovery anomaly kind', () => {
-    render(
-      <MemoryStatusPanel
-        {...baseProps}
-        failures={[{ ...MANUAL_FAILURE, kind: 'boot_recovery' }]}
-      />,
-    );
-
-    expect(screen.getByText('memory.status.failureLog.kind.boot_recovery')).toBeTruthy();
-    expect(screen.queryByText('boot_recovery')).toBeNull();
-  });
-
-  it('leaves future anomaly enum values as inert fallback text', () => {
-    render(
-      <MemoryStatusPanel
-        {...baseProps}
-        failures={[{
-          ...MANUAL_FAILURE,
-          kind: 'future_kind',
-          state: 'future_state',
-          operation: 'future_operation',
-        }]}
-      />,
-    );
-
-    expect(screen.getByText('future_kind')).toBeTruthy();
-    expect(screen.getByText('future_state')).toBeTruthy();
-    expect(screen.getByText('future_operation')).toBeTruthy();
-  });
-
   it('offers distinct resume and abort commands for clear recovery', async () => {
     const onResumeClear = vi.fn();
     const onAbortClear = vi.fn();
@@ -308,34 +178,6 @@ describe('MemoryStatusPanel', () => {
 
     expect(onResumeClear).toHaveBeenCalledWith('clear-42');
     expect(onAbortClear).toHaveBeenCalledWith('clear-42');
-  });
-
-  it.each([
-    ['preparing', 'memory.processingRecord.clearRecovery.state.preparing'],
-    ['prepared', 'memory.processingRecord.clearRecovery.state.prepared'],
-    ['deleting', 'memory.processingRecord.clearRecovery.state.deleting'],
-    ['recovery_needed', 'memory.processingRecord.clearRecovery.state.recoveryNeeded'],
-  ])('localizes the known Clear recovery state %s', (state, label) => {
-    render(
-      <MemoryStatusPanel
-        {...baseProps}
-        recovery={{ operation_id: `clear-${state}`, state, can_resume: true, can_abort: false }}
-      />,
-    );
-
-    expect(screen.getByText(label)).toBeTruthy();
-    expect(screen.queryByText(state)).toBeNull();
-  });
-
-  it('leaves a future Clear recovery state as inert fallback text', () => {
-    render(
-      <MemoryStatusPanel
-        {...baseProps}
-        recovery={{ operation_id: 'clear-future', state: 'future_state', can_resume: false, can_abort: false }}
-      />,
-    );
-
-    expect(screen.getByText('future_state')).toBeTruthy();
   });
 
   it.each([

--- a/ui/src/components/settings/memory/MemoryStatusPanel.tsx
+++ b/ui/src/components/settings/memory/MemoryStatusPanel.tsx
@@ -1,5 +1,4 @@
 import { useTranslation } from 'react-i18next';
-import type { TFunction } from 'i18next';
 import {
   AlertTriangle,
   CheckCircle2,
@@ -23,176 +22,20 @@ import type {
   MemoryStatus,
 } from '../../../context/ApiContext';
 import { memoryErrorMessage } from '../../../lib/memoryRead';
-import { memoryLogEnumLabel } from './memoryLog';
-
-type SourceState = MemoryStatus['source']['status'] | MemoryLogSourceStatus['status'];
-type BadgeVariant = 'success' | 'warning' | 'destructive' | 'info' | 'secondary';
-
-const SOURCE_BADGE_VARIANT: Record<SourceState, BadgeVariant> = {
-  available: 'success',
-  partial: 'warning',
-  stale: 'warning',
-  unknown: 'secondary',
-  unavailable: 'destructive',
-};
-
-const ANOMALY_LABEL_KEYS = {
-  kind: {
-    boot_recovery: 'memory.status.failureLog.kind.boot_recovery',
-    delivery_abandoned: 'memory.status.failureLog.kind.delivery_abandoned',
-    distillation_rejected: 'memory.status.failureLog.kind.distillation_rejected',
-    recorder_degraded: 'memory.status.failureLog.kind.recorder_degraded',
-    result_unknown: 'memory.status.failureLog.kind.result_unknown',
-  },
-  state: {
-    dead: 'memory.processingRecord.anomalyState.dead',
-    degraded: 'memory.processingRecord.anomalyState.degraded',
-    manual_required: 'memory.processingRecord.anomalyState.manualRequired',
-    rejected: 'memory.processingRecord.anomalyState.rejected',
-  },
-  operation: {
-    add: 'memory.processingRecord.anomalyOperation.add',
-    flush: 'memory.processingRecord.anomalyOperation.flush',
-    record: 'memory.processingRecord.anomalyOperation.record',
-  },
-} as const;
-
-const CLEAR_RECOVERY_STATE_LABEL_KEYS = {
-  preparing: 'memory.processingRecord.clearRecovery.state.preparing',
-  prepared: 'memory.processingRecord.clearRecovery.state.prepared',
-  deleting: 'memory.processingRecord.clearRecovery.state.deleting',
-  recovery_needed: 'memory.processingRecord.clearRecovery.state.recoveryNeeded',
-} as const;
-
-const HEALTH_STATUS_LABEL_KEYS = {
-  ok: 'memory.processingRecord.runtime.healthStatus.ok',
-} as const;
-
-const MEMORY_SOURCE_ERROR_REASONS = new Set([
-  'memory_disabled',
-  'memory_runtime_missing',
-  'memory_runtime_unsupported',
-  'memory_runtime_install_failed',
-  'memory_sidecar_unavailable',
-  'memory_provider_timeout',
-  'memory_provider_response_invalid',
-  'memory_processing_failed',
-  'memory_clear_failed',
-  'memory_restart_failed',
-]);
-
-const RUNTIME_FACT_LABEL_KEYS = {
-  capability: {
-    llm: 'memory.processingRecord.runtime.fact.capability.llm',
-    embed: 'memory.processingRecord.runtime.fact.capability.embed',
-    rerank: 'memory.processingRecord.runtime.fact.capability.rerank',
-    multimodal_llm: 'memory.processingRecord.runtime.fact.capability.multimodalLlm',
-    parser: 'memory.processingRecord.runtime.fact.capability.parser',
-  },
-  cascade: {
-    healthy: 'memory.processingRecord.runtime.fact.cascade.healthy',
-    reasons: 'memory.processingRecord.runtime.fact.cascade.reasons',
-    pending: 'memory.processingRecord.runtime.fact.cascade.pending',
-    failed_permanent: 'memory.processingRecord.runtime.fact.cascade.failedPermanent',
-    failed_retryable: 'memory.processingRecord.runtime.fact.cascade.failedRetryable',
-    drain_consecutive_failures: 'memory.processingRecord.runtime.fact.cascade.drainConsecutiveFailures',
-    unrecoverable_total: 'memory.processingRecord.runtime.fact.cascade.unrecoverableTotal',
-    optimize_failure_streak: 'memory.processingRecord.runtime.fact.cascade.optimizeFailureStreak',
-    prune_stale_seconds: 'memory.processingRecord.runtime.fact.cascade.pruneStaleSeconds',
-  },
-  recorder: {
-    state: 'memory.processingRecord.runtime.fact.recorder.state',
-    reason: 'memory.processingRecord.runtime.fact.recorder.reason',
-  },
-} as const;
-
-const CASCADE_REASON_LABEL_KEYS = {
-  drain_failures: 'memory.processingRecord.runtime.fact.cascadeReason.drainFailures',
-  optimize_stuck: 'memory.processingRecord.runtime.fact.cascadeReason.optimizeStuck',
-  prune_stale: 'memory.processingRecord.runtime.fact.cascadeReason.pruneStale',
-  health_probe_failed: 'memory.processingRecord.runtime.fact.cascadeReason.healthProbeFailed',
-  unknown: 'memory.processingRecord.runtime.fact.cascadeReason.unknown',
-} as const;
-
-const RECORDER_STATE_LABEL_KEYS = {
-  active: 'memory.processingRecord.runtime.fact.recorderState.active',
-  degraded: 'memory.processingRecord.runtime.fact.recorderState.degraded',
-  disabled: 'memory.processingRecord.runtime.fact.recorderState.disabled',
-} as const;
-
-const RECORDER_REASON_LABEL_KEYS = {
-  writer_failures: 'memory.processingRecord.runtime.fact.recorderReason.writerFailures',
-  serialization_failed: 'memory.processingRecord.runtime.fact.recorderReason.serializationFailed',
-  call_log_corrupt: 'memory.processingRecord.runtime.fact.recorderReason.callLogCorrupt',
-} as const;
-
-type AnomalyLabelGroup = keyof typeof ANOMALY_LABEL_KEYS;
-type RuntimeFactGroup = keyof typeof RUNTIME_FACT_LABEL_KEYS;
-
-const anomalyLabel = (t: TFunction, group: AnomalyLabelGroup, value: string): string => {
-  const keys = ANOMALY_LABEL_KEYS[group] as Record<string, string>;
-  return keys[value] ? t(keys[value]) : value;
-};
-
-const clearRecoveryStateLabel = (t: TFunction, value: string): string => {
-  const keys = CLEAR_RECOVERY_STATE_LABEL_KEYS as Record<string, string>;
-  return keys[value] ? t(keys[value]) : value;
-};
-
-const sourceReasonLabel = (t: TFunction, value: string): string => (
-  MEMORY_SOURCE_ERROR_REASONS.has(value)
-    ? memoryErrorMessage(t, value)
-    : memoryLogEnumLabel(t, 'reason', value)
-);
-
-const formatTimestamp = (value: string | null | undefined): string => {
-  if (!value) return '-';
-  const timestamp = new Date(value);
-  return Number.isNaN(timestamp.getTime()) ? value : timestamp.toLocaleString();
-};
-
-const formatFact = (value: unknown): string => {
-  if (value === null || value === undefined) return '-';
-  if (typeof value === 'boolean') return value ? 'true' : 'false';
-  if (typeof value === 'string' || typeof value === 'number') return String(value);
-  try {
-    return JSON.stringify(value);
-  } catch {
-    return '-';
-  }
-};
-
-const knownLabel = (t: TFunction, keys: Record<string, string>, value: string): string => {
-  const key = Object.prototype.hasOwnProperty.call(keys, value) ? keys[value] : undefined;
-  return key ? t(key) : value;
-};
-
-const runtimeFactLabel = (t: TFunction, group: RuntimeFactGroup, value: string): string => (
-  knownLabel(t, RUNTIME_FACT_LABEL_KEYS[group] as Record<string, string>, value)
-);
-
-const formatRuntimeFact = (t: TFunction, group: RuntimeFactGroup, name: string, value: unknown): string => {
-  const knownField = Object.prototype.hasOwnProperty.call(RUNTIME_FACT_LABEL_KEYS[group], name);
-  if (!knownField) return formatFact(value);
-  if (typeof value === 'boolean') {
-    return t(`memory.processingRecord.runtime.fact.boolean.${value ? 'true' : 'false'}`);
-  }
-  if (group === 'cascade' && name === 'reasons' && Array.isArray(value)) {
-    if (value.length === 0) return formatFact(value);
-    return value
-      .map((reason) => typeof reason === 'string'
-        ? knownLabel(t, CASCADE_REASON_LABEL_KEYS, reason)
-        : formatFact(reason))
-      .join(', ');
-  }
-  if (group === 'recorder' && name === 'state' && typeof value === 'string') {
-    return knownLabel(t, RECORDER_STATE_LABEL_KEYS, value);
-  }
-  if (group === 'recorder' && name === 'reason' && typeof value === 'string') {
-    return knownLabel(t, RECORDER_REASON_LABEL_KEYS, value);
-  }
-  return formatFact(value);
-};
+import {
+  formatMemoryStatusRuntimeFact,
+  formatMemoryStatusTimestamp,
+  memoryStatusAnomalyLabel,
+  memoryStatusClearRecoveryStateLabel,
+  memoryStatusHealthLabel,
+  memoryStatusRuntimeFactLabel,
+  memoryStatusSourceBadgeVariant,
+  memoryStatusSourceDisplayState,
+  memoryStatusSourceReasonLabel,
+  memoryStatusSourceStateLabel,
+  type RuntimeFactGroup,
+  type SourceState,
+} from './memoryStatusPresentation';
 
 const FactList: React.FC<{
   facts: Record<string, unknown>;
@@ -206,9 +49,9 @@ const FactList: React.FC<{
     <dl className="grid min-w-0 gap-x-4 gap-y-2 text-[11.5px] sm:grid-cols-2">
       {entries.map(([name, value]) => (
         <div key={name} className="flex min-w-0 items-start justify-between gap-3">
-          <dt className="break-words text-muted">{runtimeFactLabel(t, group, name)}</dt>
+          <dt className="break-words text-muted">{memoryStatusRuntimeFactLabel(t, group, name)}</dt>
           <dd className="max-w-[65%] break-all text-right font-mono text-foreground">
-            {formatRuntimeFact(t, group, name, value)}
+            {formatMemoryStatusRuntimeFact(t, group, name, value)}
           </dd>
         </div>
       ))}
@@ -221,28 +64,26 @@ const SourceCard: React.FC<{
   source: { status: SourceState; observed_at: string | null; reason?: string | null };
 }> = ({ label, source }) => {
   const { t } = useTranslation();
-  const displayStatus = source.observed_at || source.status === 'unavailable'
-    ? source.status
-    : 'unknown';
+  const displayStatus = memoryStatusSourceDisplayState(source);
   return (
     <div className="flex min-w-0 flex-col gap-2 rounded-md border border-border bg-surface px-3 py-3">
       <div className="flex flex-wrap items-center justify-between gap-2">
         <span className="text-[12px] font-semibold text-foreground">{label}</span>
-        <Badge variant={SOURCE_BADGE_VARIANT[displayStatus]}>
-          {t(`memory.processingRecord.sourceState.${displayStatus}`)}
+        <Badge variant={memoryStatusSourceBadgeVariant(displayStatus)}>
+          {memoryStatusSourceStateLabel(t, displayStatus)}
         </Badge>
       </div>
       <div className="flex min-w-0 items-center gap-1.5 text-[10.5px] text-muted">
         <Clock3 className="size-3 shrink-0" />
         <span className="truncate">
           {source.observed_at
-            ? formatTimestamp(source.observed_at)
+            ? formatMemoryStatusTimestamp(source.observed_at)
             : t('memory.processingRecord.sourceNotObserved')}
         </span>
       </div>
       {source.reason ? (
         <div className="break-words text-[11px] text-muted">
-          {t('memory.processingRecord.sourceReason', { reason: sourceReasonLabel(t, source.reason) })}
+          {t('memory.processingRecord.sourceReason', { reason: memoryStatusSourceReasonLabel(t, source.reason) })}
         </div>
       ) : null}
     </div>
@@ -269,13 +110,13 @@ const FailureRow: React.FC<{ entry: MemoryFailureLogEntry }> = ({ entry }) => {
         <div className="min-w-0">
           <div className="flex flex-wrap items-center gap-2">
             <span className="break-words text-[12.5px] font-medium text-foreground">
-              {anomalyLabel(t, 'kind', entry.kind)}
+              {memoryStatusAnomalyLabel(t, 'kind', entry.kind)}
             </span>
             <Badge variant={manualRequired ? 'warning' : 'secondary'}>
-              {anomalyLabel(t, 'state', entry.state)}
+              {memoryStatusAnomalyLabel(t, 'state', entry.state)}
             </Badge>
           </div>
-          <div className="mt-1 font-mono text-[10.5px] text-muted">{formatTimestamp(entry.occurred_at)}</div>
+          <div className="mt-1 font-mono text-[10.5px] text-muted">{formatMemoryStatusTimestamp(entry.occurred_at)}</div>
           {manualRequired ? (
             <div className="mt-1.5 text-[11px] text-gold">{t('memory.processingRecord.manualRequiredReadOnly')}</div>
           ) : null}
@@ -284,7 +125,7 @@ const FailureRow: React.FC<{ entry: MemoryFailureLogEntry }> = ({ entry }) => {
       <div className="grid min-w-0 gap-1.5 text-[11px] sm:grid-cols-2 lg:min-w-[440px]">
         <Field
           label={t('memory.processingRecord.field.operation')}
-          value={anomalyLabel(t, 'operation', entry.operation)}
+          value={memoryStatusAnomalyLabel(t, 'operation', entry.operation)}
         />
         <Field
           label={t('memory.processingRecord.field.errorCode')}
@@ -320,10 +161,10 @@ const ClearRecoveryCard: React.FC<{
         <Field label={t('memory.processingRecord.field.operationId')} value={recovery.operation_id} />
         <Field
           label={t('memory.processingRecord.field.state')}
-          value={clearRecoveryStateLabel(t, recovery.state)}
+          value={memoryStatusClearRecoveryStateLabel(t, recovery.state)}
         />
         {recovery.occurred_at ? (
-          <Field label={t('memory.processingRecord.field.occurredAt')} value={formatTimestamp(recovery.occurred_at)} />
+          <Field label={t('memory.processingRecord.field.occurredAt')} value={formatMemoryStatusTimestamp(recovery.occurred_at)} />
         ) : null}
         {recovery.error_code ? (
           <Field
@@ -438,7 +279,7 @@ export const MemoryStatusPanel: React.FC<{
               <>
                 <div className="flex flex-wrap items-center gap-2">
                   <Badge variant={health.status === 'ok' ? 'success' : 'warning'}>
-                    {knownLabel(t, HEALTH_STATUS_LABEL_KEYS, health.status)}
+                    {memoryStatusHealthLabel(t, health.status)}
                   </Badge>
                   <span className="text-[11.5px] text-muted">
                     {t('memory.processingRecord.runtime.version')}: <code className="text-foreground">{health.version ?? '-'}</code>
@@ -464,7 +305,7 @@ export const MemoryStatusPanel: React.FC<{
                     ) : (
                       <div className="flex flex-wrap gap-1.5">
                         {health.disabled_features.map((feature) => (
-                          <Badge key={feature} variant="secondary">{runtimeFactLabel(t, 'capability', feature)}</Badge>
+                          <Badge key={feature} variant="secondary">{memoryStatusRuntimeFactLabel(t, 'capability', feature)}</Badge>
                         ))}
                       </div>
                     )}

--- a/ui/src/components/settings/memory/memoryStatusPresentation.test.ts
+++ b/ui/src/components/settings/memory/memoryStatusPresentation.test.ts
@@ -1,0 +1,142 @@
+import type { TFunction } from 'i18next';
+import { describe, expect, it } from 'vitest';
+
+import {
+  formatMemoryStatusFact,
+  formatMemoryStatusRuntimeFact,
+  formatMemoryStatusTimestamp,
+  memoryStatusAnomalyLabel,
+  memoryStatusClearRecoveryStateLabel,
+  memoryStatusHealthLabel,
+  memoryStatusRuntimeFactLabel,
+  memoryStatusSourceBadgeVariant,
+  memoryStatusSourceDisplayState,
+  memoryStatusSourceReasonLabel,
+  memoryStatusSourceStateLabel,
+  type SourceState,
+} from './memoryStatusPresentation';
+
+const t = ((key: string) => key) as TFunction;
+
+describe('memory status source presentation', () => {
+  it.each(['available', 'partial', 'stale'] as const)(
+    'downgrades unobserved %s evidence to unknown',
+    (status) => {
+      expect(memoryStatusSourceDisplayState({ status, observed_at: null })).toBe('unknown');
+    },
+  );
+
+  it('preserves observed and explicitly unavailable source states', () => {
+    expect(memoryStatusSourceDisplayState({ status: 'partial', observed_at: '2026-08-08T12:00:00Z' })).toBe('partial');
+    expect(memoryStatusSourceDisplayState({ status: 'unavailable', observed_at: null })).toBe('unavailable');
+    expect(memoryStatusSourceStateLabel(t, 'stale')).toBe('memory.processingRecord.sourceState.stale');
+  });
+
+  it.each<[SourceState, string]>([
+    ['available', 'success'],
+    ['partial', 'warning'],
+    ['stale', 'warning'],
+    ['unknown', 'secondary'],
+    ['unavailable', 'destructive'],
+  ])('uses the %s source badge variant %s', (status, variant) => {
+    expect(memoryStatusSourceBadgeVariant(status)).toBe(variant);
+  });
+
+  it.each([
+    ['memory_sidecar_unavailable', 'errors.memory_sidecar_unavailable'],
+    ['missing', 'memory.log.reason.missing'],
+    ['runs_busy', 'memory.log.reason.runsBusy'],
+    ['future_source_reason', 'future_source_reason'],
+  ])('maps source reason %s to %s', (reason, expected) => {
+    expect(memoryStatusSourceReasonLabel(t, reason)).toBe(expected);
+  });
+});
+
+describe('memory status enum labels', () => {
+  it.each([
+    ['kind', 'boot_recovery', 'memory.status.failureLog.kind.boot_recovery'],
+    ['state', 'manual_required', 'memory.processingRecord.anomalyState.manualRequired'],
+    ['operation', 'flush', 'memory.processingRecord.anomalyOperation.flush'],
+    ['kind', 'future_kind', 'future_kind'],
+    ['state', 'future_state', 'future_state'],
+    ['operation', 'future_operation', 'future_operation'],
+  ] as const)('maps anomaly %s value %s to %s', (group, value, expected) => {
+    expect(memoryStatusAnomalyLabel(t, group, value)).toBe(expected);
+  });
+
+  it.each([
+    ['preparing', 'memory.processingRecord.clearRecovery.state.preparing'],
+    ['prepared', 'memory.processingRecord.clearRecovery.state.prepared'],
+    ['deleting', 'memory.processingRecord.clearRecovery.state.deleting'],
+    ['recovery_needed', 'memory.processingRecord.clearRecovery.state.recoveryNeeded'],
+    ['future_state', 'future_state'],
+  ])('maps clear recovery state %s to %s', (state, expected) => {
+    expect(memoryStatusClearRecoveryStateLabel(t, state)).toBe(expected);
+  });
+
+  it.each([
+    ['ok', 'memory.processingRecord.runtime.healthStatus.ok'],
+    ['future_health_state', 'future_health_state'],
+  ])('maps provider health %s to %s', (health, expected) => {
+    expect(memoryStatusHealthLabel(t, health)).toBe(expected);
+  });
+});
+
+describe('memory status runtime facts', () => {
+  it.each([
+    ['capability', 'embed', 'memory.processingRecord.runtime.fact.capability.embed'],
+    ['cascade', 'prune_stale_seconds', 'memory.processingRecord.runtime.fact.cascade.pruneStaleSeconds'],
+    ['recorder', 'state', 'memory.processingRecord.runtime.fact.recorder.state'],
+    ['capability', 'future_capability', 'future_capability'],
+    ['cascade', 'future_counter', 'future_counter'],
+    ['recorder', 'future_field', 'future_field'],
+  ] as const)('maps %s fact label %s to %s', (group, name, expected) => {
+    expect(memoryStatusRuntimeFactLabel(t, group, name)).toBe(expected);
+  });
+
+  it('localizes known fact values and preserves future diagnostics', () => {
+    expect(formatMemoryStatusRuntimeFact(t, 'capability', 'embed', false)).toBe(
+      'memory.processingRecord.runtime.fact.boolean.false',
+    );
+    expect(formatMemoryStatusRuntimeFact(t, 'cascade', 'reasons', ['drain_failures', 'future_reason', 7])).toBe(
+      'memory.processingRecord.runtime.fact.cascadeReason.drainFailures, future_reason, 7',
+    );
+    expect(formatMemoryStatusRuntimeFact(t, 'recorder', 'state', 'degraded')).toBe(
+      'memory.processingRecord.runtime.fact.recorderState.degraded',
+    );
+    expect(formatMemoryStatusRuntimeFact(t, 'recorder', 'reason', 'call_log_corrupt')).toBe(
+      'memory.processingRecord.runtime.fact.recorderReason.callLogCorrupt',
+    );
+    expect(formatMemoryStatusRuntimeFact(t, 'recorder', 'state', 'future_state')).toBe('future_state');
+    expect(formatMemoryStatusRuntimeFact(t, 'cascade', 'future_counter', 12)).toBe('12');
+  });
+});
+
+describe('memory status formatting', () => {
+  it('formats null, invalid, and valid timestamps without inventing data', () => {
+    const valid = '2026-08-08T12:00:00Z';
+    expect(formatMemoryStatusTimestamp(null)).toBe('-');
+    expect(formatMemoryStatusTimestamp(undefined)).toBe('-');
+    expect(formatMemoryStatusTimestamp('not-a-timestamp')).toBe('not-a-timestamp');
+    expect(formatMemoryStatusTimestamp(valid)).toBe(new Date(valid).toLocaleString());
+  });
+
+  it.each([
+    [null, '-'],
+    [undefined, '-'],
+    [true, 'true'],
+    [false, 'false'],
+    ['diagnostic', 'diagnostic'],
+    [42, '42'],
+    [{ answer: 42 }, '{"answer":42}'],
+    [[1, 'two'], '[1,"two"]'],
+  ])('serializes fact value %j as %s', (value, expected) => {
+    expect(formatMemoryStatusFact(value)).toBe(expected);
+  });
+
+  it('falls back when a fact cannot be serialized', () => {
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+    expect(formatMemoryStatusFact(circular)).toBe('-');
+  });
+});

--- a/ui/src/components/settings/memory/memoryStatusPresentation.ts
+++ b/ui/src/components/settings/memory/memoryStatusPresentation.ts
@@ -1,0 +1,199 @@
+import type { TFunction } from 'i18next';
+
+import type { MemoryLogSourceStatus, MemoryStatus } from '../../../context/ApiContext';
+import { memoryErrorMessage } from '../../../lib/memoryRead';
+import { memoryLogEnumLabel } from './memoryLog';
+
+export type RuntimeFactGroup = keyof typeof RUNTIME_FACT_LABEL_KEYS;
+export type SourceState = MemoryStatus['source']['status'] | MemoryLogSourceStatus['status'];
+export type BadgeVariant = 'success' | 'warning' | 'destructive' | 'info' | 'secondary';
+
+type AnomalyLabelGroup = keyof typeof ANOMALY_LABEL_KEYS;
+
+const SOURCE_BADGE_VARIANT: Record<SourceState, BadgeVariant> = {
+  available: 'success',
+  partial: 'warning',
+  stale: 'warning',
+  unknown: 'secondary',
+  unavailable: 'destructive',
+};
+
+const ANOMALY_LABEL_KEYS = {
+  kind: {
+    boot_recovery: 'memory.status.failureLog.kind.boot_recovery',
+    delivery_abandoned: 'memory.status.failureLog.kind.delivery_abandoned',
+    distillation_rejected: 'memory.status.failureLog.kind.distillation_rejected',
+    recorder_degraded: 'memory.status.failureLog.kind.recorder_degraded',
+    result_unknown: 'memory.status.failureLog.kind.result_unknown',
+  },
+  state: {
+    dead: 'memory.processingRecord.anomalyState.dead',
+    degraded: 'memory.processingRecord.anomalyState.degraded',
+    manual_required: 'memory.processingRecord.anomalyState.manualRequired',
+    rejected: 'memory.processingRecord.anomalyState.rejected',
+  },
+  operation: {
+    add: 'memory.processingRecord.anomalyOperation.add',
+    flush: 'memory.processingRecord.anomalyOperation.flush',
+    record: 'memory.processingRecord.anomalyOperation.record',
+  },
+} as const;
+
+const CLEAR_RECOVERY_STATE_LABEL_KEYS = {
+  preparing: 'memory.processingRecord.clearRecovery.state.preparing',
+  prepared: 'memory.processingRecord.clearRecovery.state.prepared',
+  deleting: 'memory.processingRecord.clearRecovery.state.deleting',
+  recovery_needed: 'memory.processingRecord.clearRecovery.state.recoveryNeeded',
+} as const;
+
+const HEALTH_STATUS_LABEL_KEYS = {
+  ok: 'memory.processingRecord.runtime.healthStatus.ok',
+} as const;
+
+const MEMORY_SOURCE_ERROR_REASONS = new Set([
+  'memory_disabled',
+  'memory_runtime_missing',
+  'memory_runtime_unsupported',
+  'memory_runtime_install_failed',
+  'memory_sidecar_unavailable',
+  'memory_provider_timeout',
+  'memory_provider_response_invalid',
+  'memory_processing_failed',
+  'memory_clear_failed',
+  'memory_restart_failed',
+]);
+
+const RUNTIME_FACT_LABEL_KEYS = {
+  capability: {
+    llm: 'memory.processingRecord.runtime.fact.capability.llm',
+    embed: 'memory.processingRecord.runtime.fact.capability.embed',
+    rerank: 'memory.processingRecord.runtime.fact.capability.rerank',
+    multimodal_llm: 'memory.processingRecord.runtime.fact.capability.multimodalLlm',
+    parser: 'memory.processingRecord.runtime.fact.capability.parser',
+  },
+  cascade: {
+    healthy: 'memory.processingRecord.runtime.fact.cascade.healthy',
+    reasons: 'memory.processingRecord.runtime.fact.cascade.reasons',
+    pending: 'memory.processingRecord.runtime.fact.cascade.pending',
+    failed_permanent: 'memory.processingRecord.runtime.fact.cascade.failedPermanent',
+    failed_retryable: 'memory.processingRecord.runtime.fact.cascade.failedRetryable',
+    drain_consecutive_failures: 'memory.processingRecord.runtime.fact.cascade.drainConsecutiveFailures',
+    unrecoverable_total: 'memory.processingRecord.runtime.fact.cascade.unrecoverableTotal',
+    optimize_failure_streak: 'memory.processingRecord.runtime.fact.cascade.optimizeFailureStreak',
+    prune_stale_seconds: 'memory.processingRecord.runtime.fact.cascade.pruneStaleSeconds',
+  },
+  recorder: {
+    state: 'memory.processingRecord.runtime.fact.recorder.state',
+    reason: 'memory.processingRecord.runtime.fact.recorder.reason',
+  },
+} as const;
+
+const CASCADE_REASON_LABEL_KEYS = {
+  drain_failures: 'memory.processingRecord.runtime.fact.cascadeReason.drainFailures',
+  optimize_stuck: 'memory.processingRecord.runtime.fact.cascadeReason.optimizeStuck',
+  prune_stale: 'memory.processingRecord.runtime.fact.cascadeReason.pruneStale',
+  health_probe_failed: 'memory.processingRecord.runtime.fact.cascadeReason.healthProbeFailed',
+  unknown: 'memory.processingRecord.runtime.fact.cascadeReason.unknown',
+} as const;
+
+const RECORDER_STATE_LABEL_KEYS = {
+  active: 'memory.processingRecord.runtime.fact.recorderState.active',
+  degraded: 'memory.processingRecord.runtime.fact.recorderState.degraded',
+  disabled: 'memory.processingRecord.runtime.fact.recorderState.disabled',
+} as const;
+
+const RECORDER_REASON_LABEL_KEYS = {
+  writer_failures: 'memory.processingRecord.runtime.fact.recorderReason.writerFailures',
+  serialization_failed: 'memory.processingRecord.runtime.fact.recorderReason.serializationFailed',
+  call_log_corrupt: 'memory.processingRecord.runtime.fact.recorderReason.callLogCorrupt',
+} as const;
+
+const knownLabel = (t: TFunction, keys: Record<string, string>, value: string): string => {
+  const key = Object.prototype.hasOwnProperty.call(keys, value) ? keys[value] : undefined;
+  return key ? t(key) : value;
+};
+
+export function memoryStatusSourceDisplayState(
+  source: { status: SourceState; observed_at: string | null },
+): SourceState {
+  return source.observed_at || source.status === 'unavailable' ? source.status : 'unknown';
+}
+
+export const memoryStatusSourceBadgeVariant = (state: SourceState): BadgeVariant => (
+  SOURCE_BADGE_VARIANT[state]
+);
+
+export const memoryStatusSourceStateLabel = (t: TFunction, state: SourceState): string => (
+  t(`memory.processingRecord.sourceState.${state}`)
+);
+
+export const memoryStatusAnomalyLabel = (
+  t: TFunction,
+  group: AnomalyLabelGroup,
+  value: string,
+): string => knownLabel(t, ANOMALY_LABEL_KEYS[group] as Record<string, string>, value);
+
+export const memoryStatusClearRecoveryStateLabel = (t: TFunction, value: string): string => (
+  knownLabel(t, CLEAR_RECOVERY_STATE_LABEL_KEYS, value)
+);
+
+export const memoryStatusHealthLabel = (t: TFunction, value: string): string => (
+  knownLabel(t, HEALTH_STATUS_LABEL_KEYS, value)
+);
+
+export const memoryStatusSourceReasonLabel = (t: TFunction, value: string): string => (
+  MEMORY_SOURCE_ERROR_REASONS.has(value)
+    ? memoryErrorMessage(t, value)
+    : memoryLogEnumLabel(t, 'reason', value)
+);
+
+export const formatMemoryStatusTimestamp = (value: string | null | undefined): string => {
+  if (!value) return '-';
+  const timestamp = new Date(value);
+  return Number.isNaN(timestamp.getTime()) ? value : timestamp.toLocaleString();
+};
+
+export const formatMemoryStatusFact = (value: unknown): string => {
+  if (value === null || value === undefined) return '-';
+  if (typeof value === 'boolean') return value ? 'true' : 'false';
+  if (typeof value === 'string' || typeof value === 'number') return String(value);
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return '-';
+  }
+};
+
+export const memoryStatusRuntimeFactLabel = (
+  t: TFunction,
+  group: RuntimeFactGroup,
+  value: string,
+): string => knownLabel(t, RUNTIME_FACT_LABEL_KEYS[group] as Record<string, string>, value);
+
+export const formatMemoryStatusRuntimeFact = (
+  t: TFunction,
+  group: RuntimeFactGroup,
+  name: string,
+  value: unknown,
+): string => {
+  const knownField = Object.prototype.hasOwnProperty.call(RUNTIME_FACT_LABEL_KEYS[group], name);
+  if (!knownField) return formatMemoryStatusFact(value);
+  if (typeof value === 'boolean') {
+    return t(`memory.processingRecord.runtime.fact.boolean.${value ? 'true' : 'false'}`);
+  }
+  if (group === 'cascade' && name === 'reasons' && Array.isArray(value)) {
+    if (value.length === 0) return formatMemoryStatusFact(value);
+    return value
+      .map((reason) => typeof reason === 'string'
+        ? knownLabel(t, CASCADE_REASON_LABEL_KEYS, reason)
+        : formatMemoryStatusFact(reason))
+      .join(', ');
+  }
+  if (group === 'recorder' && name === 'state' && typeof value === 'string') {
+    return knownLabel(t, RECORDER_STATE_LABEL_KEYS, value);
+  }
+  if (group === 'recorder' && name === 'reason' && typeof value === 'string') {
+    return knownLabel(t, RECORDER_REASON_LABEL_KEYS, value);
+  }
+  return formatMemoryStatusFact(value);
+};


### PR DESCRIPTION
## Summary

- extract Memory Processing Record enum, localization, source-state, badge, timestamp, and fact-formatting policy into a focused pure module
- keep `MemoryStatusPanel` responsible for React structure, actions, loading/error states, accessibility, and callback wiring
- move pure mapping and formatting coverage out of the component suite while retaining DOM/class and real en/zh catalog integration evidence

Closes #1278

## Evidence layers

- Unit: updated with direct `memoryStatusPresentation` policy tests covering known/future values, source observation downgrade and badges, source reasons, timestamps, and fact serialization
- Contract: updated through the existing `MemoryStatusPanel` behavior suite, an explicit DOM/class contract assertion, and the unchanged real en/zh catalog integration suite
- Scenario: not applicable; this is a behavior-preserving presentation-policy extraction and no scenario catalog applies
- Residual manual: no live UI fixture or local `vibe` service was started; DOM structure/classes were compared through the component contract test

## Validation

- `npm test -- src/components/settings/memory/memoryStatusPresentation.test.ts src/components/settings/memory/MemoryStatusPanel.test.tsx src/components/settings/memory/MemoryStatusPanel.i18n.test.tsx` (3 files, 58 tests passed)
- `npm run lint`
- `npm run build`
- `git diff --check`

Rendered DOM, classes, visible copy, interactions, accessibility, callbacks, and backend API types are unchanged.