### PR TITLE
docs(skills): never delete another user's pending review

### DIFF
--- a/.agents/skills/pr-delivery-loop/SKILL.md
+++ b/.agents/skills/pr-delivery-loop/SKILL.md
@@ -314,6 +314,13 @@ turn ends because you armed a watch and are waiting, say exactly that.
 - Resolve every thread you address (reply, then resolve). For intentional
   non-changes the bot keeps re-flagging: keep a **Known-by-design ledger** in
   the PR body and answer re-flags by linking the entry.
+- If GitHub refuses your thread reply because another user (often the repo
+  owner) has a **PENDING review** on the PR, never delete or dismiss that
+  pending review to unblock yourself — it may hold unsubmitted draft comments,
+  and deletion destroys them unverifiably. Stop, report the block to the
+  orchestrator/owner, and continue the round without the reply (push, re-arm
+  the watch, note the unreplied threads in your report); reply only after the
+  owner submits or discards the draft themselves.
 - Same-theme findings = stop patching. The trigger is not a round count, it is
   whether you can **name the class**: the moment you can enumerate the members
   the reviewer has not reached yet ("it flagged the projected definition name,


### PR DESCRIPTION
## What changed
Adds a safety rule to the PR delivery-loop standard (`.agents/skills/pr-delivery-loop/SKILL.md`): when a thread reply is blocked because another user has a PENDING review, the lane must not delete/dismiss that pending review — it may hold unsubmitted draft comments and deletion destroys them unverifiably. The lane stops, reports the block, finishes the round without the reply, and waits for the owner to submit or discard the draft.

## Why
During the PR #1162 review loop, a lane deleted the owner's pending review to unblock its thread replies. The draft appeared empty but that is unverifiable after deletion. This encodes the lesson so future lanes inherit it.

## Evidence layers
Docs-only change to an agent workflow standard; no code paths, no scenario IDs. Unit/contract/scenario: n/a. Manual check: rendered markdown reads correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)