### PR TITLE
refactor(memory): generation-fence processing faults

### DIFF
--- a/core/memory/coordinator.py
+++ b/core/memory/coordinator.py
@@ -35,6 +35,8 @@ from core.memory.store import (
     FlushLease,
     MemoryStore,
     MessageFailure,
+    ProcessingHealthProbe,
+    ProcessingNotification,
     QueueRow,
     SystemOutage,
 )
@@ -51,6 +53,7 @@ ADD_TIMEOUT_SECONDS = 30.0
 FLUSH_TIMEOUT_SECONDS = 300.0
 MAX_CONCURRENT_PROVIDER_WRITES = 4
 SYSTEM_OUTAGE_RETRY_SECONDS = 5.0
+MAX_PROCESSING_ACTIONS_PER_PASS = 3
 
 AttachmentRelease = Callable[[str], Awaitable[None] | None]
 ProcessingFaultKind = Literal["credential", "engine"]
@@ -95,6 +98,7 @@ class SessionFlushCoordinator:
         self._write_slots = asyncio.Semaphore(max(1, int(max_concurrent_writes)))
         self._processing_event = processing_event
         self._processing_fault_lock = asyncio.Lock()
+        self._processing_notification_lock = asyncio.Lock()
         self._session_locks: weakref.WeakValueDictionary[str, asyncio.Lock] = (
             weakref.WeakValueDictionary()
         )
@@ -597,16 +601,17 @@ class SessionFlushCoordinator:
                 ),
             )
             return False
-        settled = await self._store_call(
-            self._store.settle_add_ack,
-            row,
-            ack,
-            lease_owner=lease_owner,
-            now=self._current_time(),
-            idle_timeout=IDLE_FLUSH_TIMEOUT,
-            max_unflushed_age=MAX_UNFLUSHED_AGE,
-            message_bound=MAX_UNFLUSHED_MESSAGES,
-        )
+        async with self._processing_notification_lock:
+            settled = await self._store_call(
+                self._store.settle_add_ack,
+                row,
+                ack,
+                lease_owner=lease_owner,
+                now=self._current_time(),
+                idle_timeout=IDLE_FLUSH_TIMEOUT,
+                max_unflushed_age=MAX_UNFLUSHED_AGE,
+                message_bound=MAX_UNFLUSHED_MESSAGES,
+            )
         if settled.attachment_release_id is not None:
             await self._release_bundle(settled.attachment_release_id)
         if settled.settled:
@@ -653,12 +658,13 @@ class SessionFlushCoordinator:
     ) -> bool:
         """Persist the exact outcome and its fault edge under the same local phase."""
 
-        settled = await self._store_call(
-            self._store.settle_flush,
-            lease,
-            result,
-            now=_iso(self._current_time()),
-        )
+        async with self._processing_notification_lock:
+            settled = await self._store_call(
+                self._store.settle_flush,
+                lease,
+                result,
+                now=_iso(self._current_time()),
+            )
         return settled.settled
 
     async def _return_unsubmitted_claim(
@@ -685,6 +691,9 @@ class SessionFlushCoordinator:
     ) -> None:
         opens_processing_fault = isinstance(outcome, AmbiguousAdd) or (
             isinstance(outcome, AddRejected) and outcome.server_fault
+        ) or (
+            isinstance(outcome, SystemOutage)
+            and outcome.error == "memory_processing_failed"
         )
         if opens_processing_fault:
             async with self._processing_fault_lock:
@@ -698,6 +707,10 @@ class SessionFlushCoordinator:
                 )
                 if settled.settled:
                     await self._reconcile_processing_events_locked()
+                    if isinstance(outcome, SystemOutage):
+                        self._add_outage_until = self._current_time() + timedelta(
+                            seconds=SYSTEM_OUTAGE_RETRY_SECONDS
+                        )
             if settled.attachment_release_id is not None:
                 await self._release_bundle(settled.attachment_release_id)
             return
@@ -715,73 +728,47 @@ class SessionFlushCoordinator:
             self._add_outage_until = self._current_time() + timedelta(
                 seconds=SYSTEM_OUTAGE_RETRY_SECONDS
             )
-            if outcome.error == "memory_processing_failed":
-                await self._open_processing_fault()
-
-    async def _open_processing_fault(self) -> None:
-        async with self._processing_fault_lock:
-            occurred_at = _iso(self._current_time())
-            await self._store_call(self._store.open_processing_fault, now=occurred_at)
-            await self._reconcile_processing_events_locked()
 
     async def _reconcile_processing_events(self) -> None:
         async with self._processing_fault_lock:
             await self._reconcile_processing_events_locked()
 
     async def _reconcile_processing_events_locked(self) -> None:
-        meta = await self._store_call(self._store.get_meta)
-        if meta is None:
-            return
-        if meta.processing_recovery_pending_at is not None:
-            recovered_at = meta.processing_recovery_pending_at
-            if not await self._emit_processing_event(
-                "recovered",
-                None,
-                recovered_at,
-            ):
+        for _ in range(MAX_PROCESSING_ACTIONS_PER_PASS):
+            action = await self._store_call(self._store.next_processing_action)
+            if action is None:
                 return
-            await self._store_call(
-                self._store.mark_processing_recovery_notified,
-                occurred_at=recovered_at,
-            )
-            meta = await self._store_call(self._store.get_meta)
-            if meta is None:
+            if isinstance(action, ProcessingHealthProbe):
+                try:
+                    healthy = bool(await self._provider.processing_healthy())
+                except Exception:
+                    return
+                committed = await self._store_call(
+                    self._store.record_processing_health,
+                    action,
+                    healthy=healthy,
+                )
+                if not committed.committed:
+                    return
+                continue
+            if not isinstance(action, ProcessingNotification):
                 return
-        if meta.processing_fault_since is not None and (
-            meta.processing_fault_kind is None or not meta.processing_alert_active
-        ):
-            await self._classify_processing_fault_locked(meta.processing_fault_since)
-
-    async def _classify_processing_fault(self, occurred_at: str) -> None:
-        async with self._processing_fault_lock:
-            await self._classify_processing_fault_locked(occurred_at)
-
-    async def _classify_processing_fault_locked(self, occurred_at: str) -> None:
-        kind: ProcessingFaultKind = (
-            "engine" if await self._provider_processing_healthy() else "credential"
-        )
-        should_alert = await self._store_call(
-            self._store.classify_processing_fault,
-            kind,
-        )
-        if should_alert and await self._emit_processing_event(
-            "fault",
-            kind,
-            occurred_at,
-        ):
-            await self._store_call(self._store.mark_processing_alert_active)
-
-    async def _close_processing_fault(self) -> None:
-        async with self._processing_fault_lock:
-            now = _iso(self._current_time())
-            if await self._store_call(self._store.close_processing_fault, now=now):
-                await self._reconcile_processing_events_locked()
-
-    async def _provider_processing_healthy(self) -> bool:
-        try:
-            return bool(await self._provider.processing_healthy())
-        except Exception:
-            return False
+            async with self._processing_notification_lock:
+                current = await self._store_call(self._store.next_processing_action)
+                if current != action:
+                    return
+                if not await self._emit_processing_event(
+                    action.event,
+                    action.kind,
+                    action.occurred_at,
+                ):
+                    return
+                acknowledged = await self._store_call(
+                    self._store.acknowledge_processing_notification,
+                    action,
+                )
+                if not acknowledged:
+                    return
 
     async def _emit_processing_event(
         self,

--- a/core/memory/coordinator.py
+++ b/core/memory/coordinator.py
@@ -53,6 +53,7 @@ ADD_TIMEOUT_SECONDS = 30.0
 FLUSH_TIMEOUT_SECONDS = 300.0
 MAX_CONCURRENT_PROVIDER_WRITES = 4
 SYSTEM_OUTAGE_RETRY_SECONDS = 5.0
+PROCESSING_ACTION_RETRY_SECONDS = 5.0
 MAX_PROCESSING_ACTIONS_PER_PASS = 3
 
 AttachmentRelease = Callable[[str], Awaitable[None] | None]
@@ -104,6 +105,7 @@ class SessionFlushCoordinator:
         )
         self._flush_tasks: dict[str, asyncio.Task[None]] = {}
         self._add_outage_until: datetime | None = None
+        self._processing_retry_at: datetime | None = None
         self._paused = False
 
     def replace_provider(self, provider: MemoryProviderPort) -> None:
@@ -205,7 +207,13 @@ class SessionFlushCoordinator:
         self._prune_tasks()
         if self._paused or not self._enabled():
             return 0
-        now = _iso(self._current_time())
+        current_time = self._current_time()
+        if (
+            self._processing_retry_at is not None
+            and current_time >= self._processing_retry_at
+        ):
+            await self._reconcile_processing_events()
+        now = _iso(current_time)
         refs = await self._store_call(
             self._store.list_flush_candidates,
             now=now,
@@ -734,6 +742,7 @@ class SessionFlushCoordinator:
             await self._reconcile_processing_events_locked()
 
     async def _reconcile_processing_events_locked(self) -> None:
+        self._processing_retry_at = None
         for _ in range(MAX_PROCESSING_ACTIONS_PER_PASS):
             action = await self._store_call(self._store.next_processing_action)
             if action is None:
@@ -742,6 +751,7 @@ class SessionFlushCoordinator:
                 try:
                     healthy = bool(await self._provider.processing_healthy())
                 except Exception:
+                    self._defer_processing_retry()
                     return
                 committed = await self._store_call(
                     self._store.record_processing_health,
@@ -762,6 +772,7 @@ class SessionFlushCoordinator:
                     action.kind,
                     action.occurred_at,
                 ):
+                    self._defer_processing_retry()
                     return
                 acknowledged = await self._store_call(
                     self._store.acknowledge_processing_notification,
@@ -769,6 +780,11 @@ class SessionFlushCoordinator:
                 )
                 if not acknowledged:
                     return
+
+    def _defer_processing_retry(self) -> None:
+        self._processing_retry_at = self._current_time() + timedelta(
+            seconds=PROCESSING_ACTION_RETRY_SECONDS
+        )
 
     async def _emit_processing_event(
         self,

--- a/core/memory/coordinator.py
+++ b/core/memory/coordinator.py
@@ -208,10 +208,7 @@ class SessionFlushCoordinator:
         if self._paused or not self._enabled():
             return 0
         current_time = self._current_time()
-        if (
-            self._processing_retry_at is not None
-            and current_time >= self._processing_retry_at
-        ):
+        if self._processing_retry_at is not None:
             await self._reconcile_processing_events()
         now = _iso(current_time)
         refs = await self._store_call(
@@ -742,7 +739,10 @@ class SessionFlushCoordinator:
             await self._reconcile_processing_events_locked()
 
     async def _reconcile_processing_events_locked(self) -> None:
-        self._processing_retry_at = None
+        if self._processing_retry_at is not None:
+            if self._current_time() < self._processing_retry_at:
+                return
+            self._processing_retry_at = None
         for _ in range(MAX_PROCESSING_ACTIONS_PER_PASS):
             action = await self._store_call(self._store.next_processing_action)
             if action is None:

--- a/core/memory/schema.sql
+++ b/core/memory/schema.sql
@@ -20,6 +20,9 @@ CREATE TABLE IF NOT EXISTS memory_meta (
         )
     ),
     last_error_at TEXT,
+    processing_fault_generation INTEGER NOT NULL DEFAULT 0 CHECK (
+        processing_fault_generation >= 0
+    ),
     processing_fault_kind TEXT CHECK (
         processing_fault_kind IS NULL OR processing_fault_kind IN ('credential', 'engine')
     ),
@@ -28,7 +31,17 @@ CREATE TABLE IF NOT EXISTS memory_meta (
         processing_alert_active IN (0, 1)
     ),
     processing_recovery_pending_at TEXT,
-    updated_at TEXT NOT NULL
+    processing_recovery_generation INTEGER CHECK (
+        processing_recovery_generation IS NULL OR processing_recovery_generation >= 0
+    ),
+    updated_at TEXT NOT NULL,
+    CHECK (
+        (processing_recovery_pending_at IS NULL
+            AND processing_recovery_generation IS NULL)
+        OR
+        (processing_recovery_pending_at IS NOT NULL
+            AND processing_recovery_generation IS NOT NULL)
+    )
 );
 
 CREATE TABLE IF NOT EXISTS memory_attachment_bundle (

--- a/core/memory/store.py
+++ b/core/memory/store.py
@@ -157,6 +157,56 @@ def _install_clean_schema(
         conn.execute("PRAGMA foreign_keys = ON")
 
 
+def _migrate_v1_to_v2(conn: sqlite3.Connection) -> None:
+    """Add generation fencing without rebuilding or dropping existing v1 data."""
+
+    # SQLite ADD COLUMN cannot retrofit the clean-v2 cross-column pair CHECK.
+    # The backfill and every Store transition update the recovery pair together.
+    conn.execute("BEGIN IMMEDIATE")
+    try:
+        conn.execute(
+            """
+            ALTER TABLE memory_meta
+            ADD COLUMN processing_fault_generation INTEGER NOT NULL DEFAULT 0
+                CHECK (processing_fault_generation >= 0)
+            """
+        )
+        conn.execute(
+            """
+            ALTER TABLE memory_meta
+            ADD COLUMN processing_recovery_generation INTEGER
+                CHECK (
+                    processing_recovery_generation IS NULL
+                    OR processing_recovery_generation >= 0
+                )
+            """
+        )
+        conn.execute(
+            """
+            UPDATE memory_meta
+            SET processing_fault_generation = CASE
+                    WHEN processing_fault_since IS NOT NULL
+                         AND processing_recovery_pending_at IS NOT NULL THEN 2
+                    WHEN processing_fault_since IS NOT NULL
+                         OR processing_recovery_pending_at IS NOT NULL THEN 1
+                    ELSE 0
+                END,
+                processing_recovery_generation = CASE
+                    WHEN processing_recovery_pending_at IS NOT NULL THEN 1
+                    ELSE NULL
+                END
+            WHERE singleton = 1
+            """
+        )
+        conn.execute(f"PRAGMA user_version = {MEMORY_STORE_SCHEMA_VERSION}")
+        _verify_current_schema(conn)
+    except BaseException:
+        conn.execute("ROLLBACK")
+        raise
+    else:
+        conn.execute("COMMIT")
+
+
 def _verify_current_schema(conn: sqlite3.Connection) -> None:
     application_tables = _application_tables(conn)
     if application_tables != _MEMORY_STORE_TABLES:
@@ -2836,9 +2886,11 @@ class MemoryStore:
         with self._connection() as conn:
             version = int(conn.execute("PRAGMA user_version").fetchone()[0])
             application_tables = _application_tables(conn)
-            if version not in {0, MEMORY_STORE_SCHEMA_VERSION}:
+            if version == 1:
+                _migrate_v1_to_v2(conn)
+            elif version not in {0, MEMORY_STORE_SCHEMA_VERSION}:
                 raise RuntimeError(f"Unsupported Memory store schema version: {version}")
-            if version == 0:
+            elif version == 0:
                 _install_clean_schema(conn, schema_sql, application_tables)
             _verify_current_schema(conn)
 

--- a/core/memory/store.py
+++ b/core/memory/store.py
@@ -35,7 +35,7 @@ from core.memory.types import (
 
 MEMORY_STORE_FILENAME = "memory.sqlite"
 MEMORY_STORE_DIRNAME = "memory"
-MEMORY_STORE_SCHEMA_VERSION = 1
+MEMORY_STORE_SCHEMA_VERSION = 2
 MAX_NONTERMINAL_QUEUE_ROWS = 500
 MAX_MESSAGE_ATTEMPTS = 3
 TERMINAL_TOMBSTONE_LIMIT = 100_000
@@ -54,9 +54,11 @@ _MEMORY_STORE_REQUIRED_COLUMNS = {
     "memory_meta": frozenset(
         {
             "singleton",
+            "processing_fault_generation",
             "processing_fault_kind",
             "processing_fault_since",
             "processing_alert_active",
+            "processing_recovery_generation",
             "processing_recovery_pending_at",
         }
     ),
@@ -224,9 +226,11 @@ class MemoryMeta:
     last_success_at: str | None
     last_error: MemoryErrorCode | None
     last_error_at: str | None
+    processing_fault_generation: int
     processing_fault_kind: Literal["credential", "engine"] | None
     processing_fault_since: str | None
     processing_alert_active: bool
+    processing_recovery_generation: int | None
     processing_recovery_pending_at: str | None
     updated_at: str
 
@@ -395,6 +399,34 @@ class BootRecovery:
     reclaimed: int
     interrupted_flushes: int
     due_flushes: int = 0
+
+
+@dataclass(frozen=True)
+class ProcessingHealthProbe:
+    """A provider-health read fenced to one exact open fault cycle."""
+
+    generation: int
+    occurred_at: str
+
+
+@dataclass(frozen=True)
+class ProcessingNotification:
+    """One stable durable processing event awaiting external delivery."""
+
+    event: Literal["fault", "recovered"]
+    generation: int
+    kind: Literal["credential", "engine"] | None
+    occurred_at: str
+
+
+ProcessingAction = ProcessingHealthProbe | ProcessingNotification
+
+
+@dataclass(frozen=True)
+class ProcessingHealthCommit:
+    """Whether a health result classified the exact probe generation."""
+
+    committed: bool
 
 
 class MemoryStore:
@@ -1905,6 +1937,8 @@ class MemoryStore:
             if result.rowcount != 1:
                 return False
             self._set_last_error_in_connection(conn, error, now)
+            if error == "memory_processing_failed":
+                self._open_processing_fault_in_connection(conn, now=now)
             return True
 
     def _record_message_failure(
@@ -2414,7 +2448,8 @@ class MemoryStore:
                     last_success_at = NULL, last_error = NULL, last_error_at = NULL,
                     processing_fault_kind = NULL, processing_fault_since = NULL,
                     processing_alert_active = 0,
-                    processing_recovery_pending_at = NULL, updated_at = ?
+                    processing_recovery_pending_at = NULL,
+                    processing_recovery_generation = NULL, updated_at = ?
                 WHERE singleton = 1
                 """,
                 (epoch, now),
@@ -2429,9 +2464,11 @@ class MemoryStore:
                 last_success_at=None,
                 last_error=None,
                 last_error_at=None,
+                processing_fault_generation=meta.processing_fault_generation,
                 processing_fault_kind=None,
                 processing_fault_since=None,
                 processing_alert_active=False,
+                processing_recovery_generation=None,
                 processing_recovery_pending_at=None,
                 updated_at=now,
             )
@@ -2503,9 +2540,11 @@ class MemoryStore:
                 last_success_at=meta.last_success_at,
                 last_error=None,
                 last_error_at=None,
+                processing_fault_generation=meta.processing_fault_generation,
                 processing_fault_kind=meta.processing_fault_kind,
                 processing_fault_since=meta.processing_fault_since,
                 processing_alert_active=meta.processing_alert_active,
+                processing_recovery_generation=meta.processing_recovery_generation,
                 processing_recovery_pending_at=meta.processing_recovery_pending_at,
                 updated_at=now,
             )
@@ -2544,7 +2583,8 @@ class MemoryStore:
                     last_success_at = NULL, last_error = NULL, last_error_at = NULL,
                     processing_fault_kind = NULL, processing_fault_since = NULL,
                     processing_alert_active = 0,
-                    processing_recovery_pending_at = NULL, updated_at = ?
+                    processing_recovery_pending_at = NULL,
+                    processing_recovery_generation = NULL, updated_at = ?
                 WHERE singleton = 1
                 """,
                 (epoch, now),
@@ -2566,12 +2606,6 @@ class MemoryStore:
                 now,
             )
 
-    def open_processing_fault(self, *, now: str) -> bool:
-        """Persist one OPEN cycle and return whether it starts a new outage."""
-
-        with self._transaction() as conn:
-            return self._open_processing_fault_in_connection(conn, now=now)
-
     def _open_processing_fault_in_connection(
         self,
         conn: sqlite3.Connection,
@@ -2583,11 +2617,19 @@ class MemoryStore:
         conn.execute(
             """
             UPDATE memory_meta
-            SET processing_fault_kind = CASE
+            SET processing_fault_generation = CASE
+                    WHEN processing_fault_since IS NULL
+                    THEN processing_fault_generation + 1
+                    ELSE processing_fault_generation
+                END,
+                processing_fault_kind = CASE
                     WHEN processing_fault_since IS NULL THEN NULL
                     ELSE processing_fault_kind
                 END,
-                processing_fault_since = ?,
+                processing_fault_since = CASE
+                    WHEN processing_fault_since IS NULL THEN ?
+                    ELSE processing_fault_since
+                END,
                 last_error = 'memory_processing_failed', last_error_at = ?,
                 updated_at = ?
             WHERE singleton = 1
@@ -2596,48 +2638,106 @@ class MemoryStore:
         )
         return newly_open
 
-    def classify_processing_fault(self, kind: Literal["credential", "engine"]) -> bool:
-        """Store display classification and report whether its alert is pending."""
+    def next_processing_action(self) -> ProcessingAction | None:
+        """Return the next stable external action in durable event order."""
 
-        if kind not in {"credential", "engine"}:
-            raise ValueError("invalid processing fault kind")
-        now = utc_now_iso()
-        with self._transaction() as conn:
+        with self._connection() as conn:
             meta = self._meta_in_connection(conn)
-            if meta is None or meta.processing_fault_since is None:
-                return False
-            should_alert = not meta.processing_alert_active
-            conn.execute(
-                """
-                UPDATE memory_meta
-                SET processing_fault_kind = ?, updated_at = ?
-                WHERE singleton = 1
-                """,
-                (kind, now),
+        if meta is None:
+            return None
+        if (
+            meta.processing_recovery_pending_at is not None
+            and meta.processing_recovery_generation is not None
+        ):
+            return ProcessingNotification(
+                event="recovered",
+                generation=meta.processing_recovery_generation,
+                kind=None,
+                occurred_at=meta.processing_recovery_pending_at,
             )
-            return should_alert
+        if meta.processing_fault_since is None:
+            return None
+        if meta.processing_fault_kind is None:
+            return ProcessingHealthProbe(
+                generation=meta.processing_fault_generation,
+                occurred_at=meta.processing_fault_since,
+            )
+        if not meta.processing_alert_active:
+            return ProcessingNotification(
+                event="fault",
+                generation=meta.processing_fault_generation,
+                kind=meta.processing_fault_kind,
+                occurred_at=meta.processing_fault_since,
+            )
+        return None
 
-    def mark_processing_alert_active(self) -> bool:
-        """Persist that the current outage notification was delivered."""
+    def record_processing_health(
+        self,
+        probe: ProcessingHealthProbe,
+        *,
+        healthy: bool,
+    ) -> ProcessingHealthCommit:
+        """Classify only the still-open fault identified by ``probe``."""
 
+        kind: Literal["credential", "engine"] = "engine" if healthy else "credential"
         now = utc_now_iso()
         with self._transaction() as conn:
             result = conn.execute(
                 """
                 UPDATE memory_meta
+                SET processing_fault_kind = ?, updated_at = ?
+                WHERE singleton = 1 AND processing_fault_generation = ?
+                  AND processing_fault_since = ?
+                  AND processing_fault_kind IS NULL
+                """,
+                (kind, now, probe.generation, probe.occurred_at),
+            )
+            return ProcessingHealthCommit(committed=result.rowcount == 1)
+
+    def acknowledge_processing_notification(
+        self,
+        notification: ProcessingNotification,
+    ) -> bool:
+        """Acknowledge one exact durable event after at-least-once delivery."""
+
+        now = utc_now_iso()
+        with self._transaction() as conn:
+            if notification.event == "recovered":
+                if notification.kind is not None:
+                    return False
+                result = conn.execute(
+                    """
+                    UPDATE memory_meta
+                    SET processing_recovery_pending_at = NULL,
+                        processing_recovery_generation = NULL, updated_at = ?
+                    WHERE singleton = 1
+                      AND processing_recovery_generation = ?
+                      AND processing_recovery_pending_at = ?
+                    """,
+                    (now, notification.generation, notification.occurred_at),
+                )
+                return result.rowcount == 1
+            if notification.event != "fault" or notification.kind not in {
+                "credential",
+                "engine",
+            }:
+                return False
+            result = conn.execute(
+                """
+                UPDATE memory_meta
                 SET processing_alert_active = 1, updated_at = ?
-                WHERE singleton = 1 AND processing_fault_since IS NOT NULL
+                WHERE singleton = 1 AND processing_fault_generation = ?
+                  AND processing_fault_since = ? AND processing_fault_kind = ?
                   AND processing_alert_active = 0
                 """,
-                (now,),
+                (
+                    now,
+                    notification.generation,
+                    notification.occurred_at,
+                    notification.kind,
+                ),
             )
-            return bool(result.rowcount)
-
-    def close_processing_fault(self, *, now: str) -> bool:
-        """Close an active breaker and retain any owed recovery notification."""
-
-        with self._transaction() as conn:
-            return self._close_processing_fault_in_connection(conn, now=now)
+            return result.rowcount == 1
 
     def _close_processing_fault_in_connection(
         self,
@@ -2658,6 +2758,14 @@ class MemoryStore:
                     THEN COALESCE(processing_recovery_pending_at, ?)
                     ELSE processing_recovery_pending_at
                 END,
+                processing_recovery_generation = CASE
+                    WHEN processing_alert_active = 1
+                    THEN COALESCE(
+                        processing_recovery_generation,
+                        processing_fault_generation
+                    )
+                    ELSE processing_recovery_generation
+                END,
                 last_error = CASE
                     WHEN last_error = 'memory_processing_failed' THEN NULL
                     ELSE last_error
@@ -2672,21 +2780,6 @@ class MemoryStore:
             (now, now),
         )
         return True
-
-    def mark_processing_recovery_notified(self, *, occurred_at: str) -> bool:
-        """Acknowledge the exact durable recovery edge after it was delivered."""
-
-        now = utc_now_iso()
-        with self._transaction() as conn:
-            result = conn.execute(
-                """
-                UPDATE memory_meta
-                SET processing_recovery_pending_at = NULL, updated_at = ?
-                WHERE singleton = 1 AND processing_recovery_pending_at = ?
-                """,
-                (now, occurred_at),
-            )
-            return bool(result.rowcount)
 
     def clear_system_outage_error(self) -> None:
         """Clear only the availability categories resolved by a fresh health probe."""
@@ -2805,6 +2898,8 @@ class MemoryStore:
             processing_fault_kind=None,
             processing_fault_since=None,
             processing_alert_active=False,
+            processing_fault_generation=0,
+            processing_recovery_generation=None,
             processing_recovery_pending_at=None,
             updated_at=now,
         )
@@ -3003,6 +3098,7 @@ def _meta_from_row(row: sqlite3.Row) -> MemoryMeta:
             if row["last_error_at"] is not None
             else None
         ),
+        processing_fault_generation=int(row["processing_fault_generation"]),
         processing_fault_kind=(
             str(row["processing_fault_kind"])
             if row["processing_fault_kind"] in {"credential", "engine"}
@@ -3014,6 +3110,11 @@ def _meta_from_row(row: sqlite3.Row) -> MemoryMeta:
             else None
         ),
         processing_alert_active=bool(row["processing_alert_active"]),
+        processing_recovery_generation=(
+            int(row["processing_recovery_generation"])
+            if row["processing_recovery_generation"] is not None
+            else None
+        ),
         processing_recovery_pending_at=(
             str(row["processing_recovery_pending_at"])
             if row["processing_recovery_pending_at"] is not None

--- a/tests/fixtures/memory_foundation_v1.sql
+++ b/tests/fixtures/memory_foundation_v1.sql
@@ -1,0 +1,179 @@
+-- Exact v1 Memory schema from dev at 63eb6efc.
+CREATE TABLE IF NOT EXISTS memory_meta (
+    singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+    epoch INTEGER NOT NULL,
+    clear_in_progress INTEGER NOT NULL DEFAULT 0 CHECK (clear_in_progress IN (0, 1)),
+    scope_key BLOB NOT NULL,
+    provider_root_id TEXT NOT NULL,
+    last_provider_timestamp_ms INTEGER NOT NULL DEFAULT 0,
+    missed_count INTEGER NOT NULL DEFAULT 0 CHECK (missed_count >= 0),
+    last_success_at TEXT,
+    last_error TEXT CHECK (
+        last_error IS NULL OR last_error IN (
+            'memory_disabled', 'memory_invalid_input', 'memory_input_too_large',
+            'memory_queue_full', 'memory_low_disk_space', 'memory_store_unavailable',
+            'memory_runtime_missing', 'memory_runtime_unsupported',
+            'memory_runtime_install_failed', 'memory_sidecar_unavailable',
+            'memory_provider_timeout', 'memory_provider_response_invalid',
+            'memory_processing_failed', 'memory_clear_failed',
+            'memory_capability_unavailable'
+        )
+    ),
+    last_error_at TEXT,
+    processing_fault_kind TEXT CHECK (
+        processing_fault_kind IS NULL OR processing_fault_kind IN ('credential', 'engine')
+    ),
+    processing_fault_since TEXT,
+    processing_alert_active INTEGER NOT NULL DEFAULT 0 CHECK (
+        processing_alert_active IN (0, 1)
+    ),
+    processing_recovery_pending_at TEXT,
+    updated_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS memory_attachment_bundle (
+    bundle_id TEXT PRIMARY KEY CHECK (
+        length(bundle_id) = 32
+        AND bundle_id NOT GLOB '*[^0-9a-f]*'
+    ),
+    relative_path TEXT NOT NULL UNIQUE,
+    state TEXT NOT NULL CHECK (state IN ('pinned', 'releasing')),
+    file_count INTEGER NOT NULL CHECK (file_count BETWEEN 1 AND 8),
+    total_bytes INTEGER NOT NULL CHECK (total_bytes >= 0),
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS memory_session_flush_state (
+    provider_session_ref TEXT PRIMARY KEY,
+    epoch INTEGER NOT NULL CHECK (epoch >= 0),
+    open_generation INTEGER NOT NULL DEFAULT 1 CHECK (open_generation >= 1),
+    target_generation INTEGER CHECK (target_generation IS NULL OR target_generation >= 1),
+    state TEXT NOT NULL DEFAULT 'idle' CHECK (
+        state IN ('idle', 'due', 'in_flight', 'manual_required')
+    ),
+    first_unflushed_at TEXT,
+    last_add_ack_at TEXT,
+    confirmed_add_watermark_ms INTEGER,
+    unflushed_count INTEGER NOT NULL DEFAULT 0 CHECK (unflushed_count >= 0),
+    due_at TEXT,
+    next_attempt_at TEXT,
+    retry_count INTEGER NOT NULL DEFAULT 0 CHECK (retry_count >= 0),
+    operation_epoch INTEGER NOT NULL DEFAULT 0 CHECK (operation_epoch >= 0),
+    fence_token TEXT,
+    submission_started_at TEXT,
+    updated_at TEXT NOT NULL,
+    CHECK (
+        (state = 'idle' AND target_generation IS NULL AND fence_token IS NULL
+            AND submission_started_at IS NULL)
+        OR
+        (state IN ('due', 'in_flight', 'manual_required')
+            AND target_generation IS NOT NULL AND fence_token IS NOT NULL)
+    ),
+    CHECK (state IN ('in_flight', 'manual_required') OR submission_started_at IS NULL)
+);
+
+CREATE TABLE IF NOT EXISTS memory_capture_queue (
+    source_message_digest TEXT PRIMARY KEY,
+    epoch INTEGER NOT NULL,
+    session_id TEXT NOT NULL,
+    provider_session_ref TEXT NOT NULL,
+    generation INTEGER NOT NULL CHECK (generation >= 1),
+    principal_id TEXT NOT NULL CHECK (
+        length(principal_id) = 34
+        AND substr(principal_id, 1, 2) = 'u-'
+        AND substr(principal_id, 3) NOT GLOB '*[^0-9a-f]*'
+    ),
+    project_ref TEXT NOT NULL CHECK (
+        length(project_ref) = 34
+        AND substr(project_ref, 1, 2) = 'p-'
+        AND substr(project_ref, 3) NOT GLOB '*[^0-9a-f]*'
+    ),
+    provenance TEXT NOT NULL CHECK (provenance IN ('user_input', 'agent')),
+    payload_text TEXT,
+    payload_attachments TEXT,
+    attachment_bundle_id TEXT REFERENCES memory_attachment_bundle(bundle_id) ON DELETE RESTRICT,
+    occurred_at_ms INTEGER NOT NULL,
+    provider_timestamp_ms INTEGER NOT NULL,
+    state TEXT NOT NULL CHECK (
+        state IN ('pending', 'processing', 'delivered', 'dead', 'manual_required')
+    ),
+    attempts INTEGER NOT NULL DEFAULT 0 CHECK (attempts >= 0),
+    next_retry_at TEXT,
+    lease_owner TEXT,
+    lease_at TEXT,
+    lease_token INTEGER NOT NULL DEFAULT 0 CHECK (lease_token >= 0),
+    last_error TEXT CHECK (
+        last_error IS NULL OR last_error IN (
+            'memory_disabled', 'memory_invalid_input', 'memory_input_too_large',
+            'memory_queue_full', 'memory_low_disk_space', 'memory_store_unavailable',
+            'memory_runtime_missing', 'memory_runtime_unsupported',
+            'memory_runtime_install_failed', 'memory_sidecar_unavailable',
+            'memory_provider_timeout', 'memory_provider_response_invalid',
+            'memory_processing_failed', 'memory_clear_failed'
+        )
+    ),
+    add_request_id TEXT,
+    add_status TEXT CHECK (add_status IS NULL OR add_status IN ('accumulated', 'extracted')),
+    created_at TEXT NOT NULL,
+    completed_at TEXT,
+    CHECK (
+        (state IN ('pending', 'processing', 'manual_required') AND payload_text IS NOT NULL)
+        OR (state IN ('delivered', 'dead') AND payload_text IS NULL)
+    )
+);
+
+CREATE INDEX IF NOT EXISTS ix_memory_capture_due
+    ON memory_capture_queue (epoch, state, next_retry_at);
+
+CREATE INDEX IF NOT EXISTS ix_memory_capture_session_generation
+    ON memory_capture_queue (provider_session_ref, epoch, generation, state);
+
+CREATE INDEX IF NOT EXISTS ix_memory_session_flush_due
+    ON memory_session_flush_state (epoch, state, due_at, next_attempt_at);
+
+CREATE TABLE IF NOT EXISTS memory_flush_settlements (
+    settlement_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    provider_session_ref TEXT NOT NULL,
+    epoch INTEGER NOT NULL CHECK (epoch >= 0),
+    generation INTEGER NOT NULL CHECK (generation >= 1),
+    operation_kind TEXT NOT NULL CHECK (operation_kind IN ('add', 'flush')),
+    operation_token TEXT NOT NULL,
+    observation TEXT NOT NULL CHECK (
+        observation IN ('settled', 'rejected', 'manual_required')
+    ),
+    request_id TEXT,
+    confirmed_watermark_ms INTEGER,
+    observed_at TEXT NOT NULL,
+    error_code TEXT,
+    recovery_origin TEXT CHECK (recovery_origin IS NULL OR recovery_origin = 'boot'),
+    attempts INTEGER NOT NULL DEFAULT 0 CHECK (attempts >= 0),
+    CHECK (
+        (operation_kind = 'add' AND observation = 'rejected' AND attempts >= 1)
+        OR
+        (NOT (operation_kind = 'add' AND observation = 'rejected') AND attempts = 0)
+    ),
+    UNIQUE (
+        provider_session_ref, epoch, generation, operation_kind, operation_token
+    )
+);
+
+CREATE INDEX IF NOT EXISTS ix_memory_flush_settlements_recent
+    ON memory_flush_settlements (epoch, observed_at DESC, settlement_id DESC);
+
+CREATE TRIGGER IF NOT EXISTS trg_memory_flush_settlements_immutable
+BEFORE UPDATE ON memory_flush_settlements
+BEGIN
+    SELECT RAISE(ABORT, 'memory flush settlements are immutable');
+END;
+
+CREATE TRIGGER IF NOT EXISTS trg_memory_flush_settlements_no_delete
+BEFORE DELETE ON memory_flush_settlements
+WHEN COALESCE(
+    (SELECT clear_in_progress FROM memory_meta WHERE singleton = 1),
+    0
+) != 1
+BEGIN
+    SELECT RAISE(ABORT, 'memory flush settlements are immutable');
+END;
+PRAGMA user_version = 1;

--- a/tests/test_memory_flush_coordinator.py
+++ b/tests/test_memory_flush_coordinator.py
@@ -194,10 +194,8 @@ async def test_accumulated_add_waits_for_idle_flush(tmp_path: Path) -> None:
     assert state.open_generation == 2
 
 
-@pytest.mark.parametrize("failure", [RuntimeError("health failed"), asyncio.CancelledError()])
-async def test_processing_probe_error_or_cancellation_leaves_action_pending(
+async def test_processing_probe_error_retries_on_tick_after_backoff(
     tmp_path: Path,
-    failure: BaseException,
 ) -> None:
     store = _store(tmp_path)
     _open_store_processing_fault(
@@ -206,29 +204,84 @@ async def test_processing_probe_error_or_cancellation_leaves_action_pending(
         at=datetime(2026, 1, 1, tzinfo=UTC),
     )
     expected = store.next_processing_action()
+    current = [datetime(2026, 1, 1, tzinfo=UTC)]
+    health_attempts = 0
+    events: list[str] = []
 
     class Provider(FakeMemoryProvider):
         async def processing_healthy(self) -> bool:
-            raise failure
+            nonlocal health_attempts
+            health_attempts += 1
+            if health_attempts == 1:
+                raise RuntimeError("health failed")
+            return True
+
+    async def notify(event, _kind, _occurred_at, _queued) -> bool:
+        events.append(event)
+        return True
 
     coordinator = SessionFlushCoordinator(
         store=store,
         provider=Provider(),
         enabled=lambda: True,
+        now=lambda: current[0],
+        processing_event=notify,
     )
-    if isinstance(failure, asyncio.CancelledError):
-        with pytest.raises(asyncio.CancelledError):
-            await coordinator.recover(lease_owner="next-boot")
-    else:
+    await coordinator.recover(lease_owner="next-boot")
+
+    assert health_attempts == 1
+    assert store.next_processing_action() == expected
+    assert await coordinator.run_due() == 0
+    current[0] += timedelta(seconds=4)
+    assert await coordinator.run_due() == 0
+    assert health_attempts == 1
+    assert events == []
+
+    current[0] += timedelta(seconds=1)
+    assert await coordinator.run_due() == 0
+    assert health_attempts == 2
+    assert events == ["fault"]
+    assert store.next_processing_action() is None
+
+
+async def test_processing_probe_cancellation_does_not_schedule_retry(
+    tmp_path: Path,
+) -> None:
+    store = _store(tmp_path)
+    _open_store_processing_fault(
+        store,
+        "probe-cancelled",
+        at=datetime(2026, 1, 1, tzinfo=UTC),
+    )
+    expected = store.next_processing_action()
+    current = [datetime(2026, 1, 1, tzinfo=UTC)]
+    health_attempts = 0
+
+    class Provider(FakeMemoryProvider):
+        async def processing_healthy(self) -> bool:
+            nonlocal health_attempts
+            health_attempts += 1
+            raise asyncio.CancelledError
+
+    coordinator = SessionFlushCoordinator(
+        store=store,
+        provider=Provider(),
+        enabled=lambda: True,
+        now=lambda: current[0],
+    )
+    with pytest.raises(asyncio.CancelledError):
         await coordinator.recover(lease_owner="next-boot")
 
+    current[0] += timedelta(minutes=1)
+    assert await coordinator.run_due() == 0
+    assert health_attempts == 1
     assert store.next_processing_action() == expected
 
 
-@pytest.mark.parametrize("result", [False, RuntimeError("notify failed")])
-async def test_processing_notification_failure_stops_without_immediate_retry(
+@pytest.mark.parametrize("failure", ["false", "error"])
+async def test_processing_notification_failure_retries_on_tick_after_backoff(
     tmp_path: Path,
-    result: bool | Exception,
+    failure: str,
 ) -> None:
     store = _store(tmp_path)
     _open_store_processing_fault(
@@ -240,25 +293,74 @@ async def test_processing_notification_failure_stops_without_immediate_retry(
     assert isinstance(probe, ProcessingHealthProbe)
     assert store.record_processing_health(probe, healthy=True).committed
     expected = store.next_processing_action()
+    current = [datetime(2026, 1, 1, tzinfo=UTC)]
     attempts = 0
 
     async def notify(*_args) -> bool:
         nonlocal attempts
         attempts += 1
-        if isinstance(result, Exception):
-            raise result
-        return result
+        if attempts > 1:
+            return True
+        if failure == "error":
+            raise RuntimeError("notify failed")
+        return False
 
     coordinator = SessionFlushCoordinator(
         store=store,
         provider=FakeMemoryProvider(),
         enabled=lambda: True,
+        now=lambda: current[0],
         processing_event=notify,
     )
     await coordinator.recover(lease_owner="next-boot")
 
     assert attempts == 1
     assert store.next_processing_action() == expected
+    assert await coordinator.run_due() == 0
+    assert attempts == 1
+
+    current[0] += timedelta(seconds=5)
+    assert await coordinator.run_due() == 0
+    assert attempts == 2
+    assert store.next_processing_action() is None
+
+
+@pytest.mark.parametrize("stop", ["pause", "shutdown"])
+async def test_processing_retry_does_not_run_while_paused_or_shutdown(
+    tmp_path: Path,
+    stop: str,
+) -> None:
+    store = _store(tmp_path)
+    _open_store_processing_fault(
+        store,
+        f"retry-{stop}",
+        at=datetime(2026, 1, 1, tzinfo=UTC),
+    )
+    current = [datetime(2026, 1, 1, tzinfo=UTC)]
+    health_attempts = 0
+
+    class Provider(FakeMemoryProvider):
+        async def processing_healthy(self) -> bool:
+            nonlocal health_attempts
+            health_attempts += 1
+            raise RuntimeError("health failed")
+
+    coordinator = SessionFlushCoordinator(
+        store=store,
+        provider=Provider(),
+        enabled=lambda: True,
+        now=lambda: current[0],
+    )
+    await coordinator.recover(lease_owner="next-boot")
+    if stop == "pause":
+        coordinator.pause()
+    else:
+        await coordinator.prepare_shutdown()
+
+    current[0] += timedelta(minutes=1)
+    assert await coordinator.run_due() == 0
+    assert health_attempts == 1
+    assert isinstance(store.next_processing_action(), ProcessingHealthProbe)
 
 
 async def test_processing_notification_cancellation_leaves_action_pending(
@@ -275,8 +377,14 @@ async def test_processing_notification_cancellation_leaves_action_pending(
     assert store.record_processing_health(probe, healthy=True).committed
     expected = store.next_processing_action()
     entered = asyncio.Event()
+    current = [datetime(2026, 1, 1, tzinfo=UTC)]
+    attempts = 0
 
     async def notify(*_args) -> bool:
+        nonlocal attempts
+        attempts += 1
+        if attempts > 1:
+            return True
         entered.set()
         await asyncio.Event().wait()
         return True
@@ -285,6 +393,7 @@ async def test_processing_notification_cancellation_leaves_action_pending(
         store=store,
         provider=FakeMemoryProvider(),
         enabled=lambda: True,
+        now=lambda: current[0],
         processing_event=notify,
     )
     recovery = asyncio.create_task(coordinator.recover(lease_owner="next-boot"))
@@ -293,6 +402,9 @@ async def test_processing_notification_cancellation_leaves_action_pending(
     with pytest.raises(asyncio.CancelledError):
         await recovery
 
+    current[0] += timedelta(minutes=1)
+    assert await coordinator.run_due() == 0
+    assert attempts == 1
     assert store.next_processing_action() == expected
 
 

--- a/tests/test_memory_flush_coordinator.py
+++ b/tests/test_memory_flush_coordinator.py
@@ -29,7 +29,16 @@ from core.memory.observations import (
     FlushSucceeded,
     FlushUnknown,
 )
-from core.memory.store import MemoryStore, MessageFailure, QueueRow
+from core.memory.store import (
+    Delivered,
+    MemoryStore,
+    MessageFailure,
+    ProcessingHealthCommit,
+    ProcessingHealthProbe,
+    ProcessingNotification,
+    QueueRow,
+    SystemOutage,
+)
 from core.memory.types import CaptureAttachment, ProviderSessionRef
 from core.memory.worker import MemoryWorker
 
@@ -56,6 +65,44 @@ def _enqueue(store: MemoryStore, source: str, *, session: str = "session"):
     )
     assert result.row is not None
     return result.row
+
+
+def _open_store_processing_fault(
+    store: MemoryStore,
+    source: str,
+    *,
+    at: datetime,
+) -> QueueRow:
+    _enqueue(store, source, session=source)
+    claimed = store.claim_due(lease_owner="setup", now=at.isoformat())
+    assert claimed is not None
+    assert store.settle(
+        claimed,
+        SystemOutage(error="memory_processing_failed"),
+        lease_owner="setup",
+        now=at,
+    ).settled
+    return claimed
+
+
+def _classify_and_ack_store_processing_fault(store: MemoryStore) -> None:
+    probe = store.next_processing_action()
+    assert isinstance(probe, ProcessingHealthProbe)
+    assert store.record_processing_health(probe, healthy=True).committed
+    notification = store.next_processing_action()
+    assert isinstance(notification, ProcessingNotification)
+    assert store.acknowledge_processing_notification(notification)
+
+
+def _close_store_processing_fault(store: MemoryStore, *, at: datetime) -> None:
+    claimed = store.claim_due(lease_owner="setup", now=at.isoformat())
+    assert claimed is not None
+    assert store.settle(
+        claimed,
+        Delivered(add_request_id="setup-success"),
+        lease_owner="setup",
+        now=at,
+    ).settled
 
 
 def _pin_attachment_bundle() -> tuple[AttachmentPinStore, PinnedBundle, Path]:
@@ -145,6 +192,480 @@ async def test_accumulated_add_waits_for_idle_flush(tmp_path: Path) -> None:
     state = store.get_session_flush_state(row.provider_session_ref)
     assert state is not None and state.state == "idle"
     assert state.open_generation == 2
+
+
+@pytest.mark.parametrize("failure", [RuntimeError("health failed"), asyncio.CancelledError()])
+async def test_processing_probe_error_or_cancellation_leaves_action_pending(
+    tmp_path: Path,
+    failure: BaseException,
+) -> None:
+    store = _store(tmp_path)
+    _open_store_processing_fault(
+        store,
+        "probe-pending",
+        at=datetime(2026, 1, 1, tzinfo=UTC),
+    )
+    expected = store.next_processing_action()
+
+    class Provider(FakeMemoryProvider):
+        async def processing_healthy(self) -> bool:
+            raise failure
+
+    coordinator = SessionFlushCoordinator(
+        store=store,
+        provider=Provider(),
+        enabled=lambda: True,
+    )
+    if isinstance(failure, asyncio.CancelledError):
+        with pytest.raises(asyncio.CancelledError):
+            await coordinator.recover(lease_owner="next-boot")
+    else:
+        await coordinator.recover(lease_owner="next-boot")
+
+    assert store.next_processing_action() == expected
+
+
+@pytest.mark.parametrize("result", [False, RuntimeError("notify failed")])
+async def test_processing_notification_failure_stops_without_immediate_retry(
+    tmp_path: Path,
+    result: bool | Exception,
+) -> None:
+    store = _store(tmp_path)
+    _open_store_processing_fault(
+        store,
+        "notify-pending",
+        at=datetime(2026, 1, 1, tzinfo=UTC),
+    )
+    probe = store.next_processing_action()
+    assert isinstance(probe, ProcessingHealthProbe)
+    assert store.record_processing_health(probe, healthy=True).committed
+    expected = store.next_processing_action()
+    attempts = 0
+
+    async def notify(*_args) -> bool:
+        nonlocal attempts
+        attempts += 1
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+    coordinator = SessionFlushCoordinator(
+        store=store,
+        provider=FakeMemoryProvider(),
+        enabled=lambda: True,
+        processing_event=notify,
+    )
+    await coordinator.recover(lease_owner="next-boot")
+
+    assert attempts == 1
+    assert store.next_processing_action() == expected
+
+
+async def test_processing_notification_cancellation_leaves_action_pending(
+    tmp_path: Path,
+) -> None:
+    store = _store(tmp_path)
+    _open_store_processing_fault(
+        store,
+        "notify-cancelled",
+        at=datetime(2026, 1, 1, tzinfo=UTC),
+    )
+    probe = store.next_processing_action()
+    assert isinstance(probe, ProcessingHealthProbe)
+    assert store.record_processing_health(probe, healthy=True).committed
+    expected = store.next_processing_action()
+    entered = asyncio.Event()
+
+    async def notify(*_args) -> bool:
+        entered.set()
+        await asyncio.Event().wait()
+        return True
+
+    coordinator = SessionFlushCoordinator(
+        store=store,
+        provider=FakeMemoryProvider(),
+        enabled=lambda: True,
+        processing_event=notify,
+    )
+    recovery = asyncio.create_task(coordinator.recover(lease_owner="next-boot"))
+    await asyncio.wait_for(entered.wait(), timeout=1)
+    recovery.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await recovery
+
+    assert store.next_processing_action() == expected
+
+
+async def test_processing_notification_is_at_least_once_when_ack_is_missing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = _store(tmp_path)
+    _open_store_processing_fault(
+        store,
+        "at-least-once",
+        at=datetime(2026, 1, 1, tzinfo=UTC),
+    )
+    probe = store.next_processing_action()
+    assert isinstance(probe, ProcessingHealthProbe)
+    assert store.record_processing_health(probe, healthy=True).committed
+    events: list[tuple[str, str | None, str, int]] = []
+
+    async def notify(event, kind, occurred_at, queued) -> bool:
+        events.append((event, kind, occurred_at, queued))
+        return True
+
+    original_ack = store.acknowledge_processing_notification
+
+    def fail_ack(_notification: ProcessingNotification) -> bool:
+        raise OSError("ack unavailable")
+
+    monkeypatch.setattr(store, "acknowledge_processing_notification", fail_ack)
+    first = SessionFlushCoordinator(
+        store=store,
+        provider=FakeMemoryProvider(),
+        enabled=lambda: True,
+        processing_event=notify,
+    )
+    with pytest.raises(OSError, match="ack unavailable"):
+        await first.recover(lease_owner="first-boot")
+
+    monkeypatch.setattr(store, "acknowledge_processing_notification", original_ack)
+    restarted = SessionFlushCoordinator(
+        store=MemoryStore(store.path),
+        provider=FakeMemoryProvider(),
+        enabled=lambda: True,
+        processing_event=notify,
+    )
+    await restarted.recover(lease_owner="second-boot")
+
+    assert len(events) == 2
+    assert events[0] == events[1]
+
+
+async def test_processing_notification_ack_suppresses_later_replays(
+    tmp_path: Path,
+) -> None:
+    store = _store(tmp_path)
+    _open_store_processing_fault(
+        store,
+        "ack-suppresses-replay",
+        at=datetime(2026, 1, 1, tzinfo=UTC),
+    )
+    events: list[tuple[str, str | None, str, int]] = []
+
+    async def notify(event, kind, occurred_at, queued) -> bool:
+        events.append((event, kind, occurred_at, queued))
+        return True
+
+    coordinator = SessionFlushCoordinator(
+        store=store,
+        provider=FakeMemoryProvider(processing_healthy_flag=True),
+        enabled=lambda: True,
+        processing_event=notify,
+    )
+    await coordinator.recover(lease_owner="first-boot")
+    await coordinator.recover(lease_owner="second-boot")
+
+    assert len(events) == 1
+
+
+async def test_successful_add_waits_for_blocked_fault_notification_ack(
+    tmp_path: Path,
+) -> None:
+    store = _store(tmp_path)
+    _open_store_processing_fault(
+        store,
+        "blocked-fault-close",
+        at=datetime(2026, 1, 1, tzinfo=UTC),
+    )
+    probe = store.next_processing_action()
+    assert isinstance(probe, ProcessingHealthProbe)
+    assert store.record_processing_health(probe, healthy=True).committed
+    claimed = store.claim_due(
+        lease_owner="worker",
+        now="2026-01-01T00:00:01.000Z",
+    )
+    assert claimed is not None
+    callback_entered = asyncio.Event()
+    release_callback = asyncio.Event()
+    events: list[str] = []
+
+    async def notify(event, _kind, _occurred_at, _queued) -> bool:
+        events.append(event)
+        if event == "fault":
+            callback_entered.set()
+            await release_callback.wait()
+        return True
+
+    provider = FakeMemoryProvider()
+    coordinator = SessionFlushCoordinator(
+        store=store,
+        provider=provider,
+        enabled=lambda: True,
+        processing_event=notify,
+    )
+    reconciliation = asyncio.create_task(coordinator._reconcile_processing_events())
+    await asyncio.wait_for(callback_entered.wait(), timeout=1)
+    success = asyncio.create_task(
+        coordinator.deliver(claimed, lease_owner="worker")
+    )
+
+    async def wait_for_provider_add() -> None:
+        while not provider.captures:
+            await asyncio.sleep(0)
+
+    await asyncio.wait_for(wait_for_provider_add(), timeout=1)
+    await asyncio.sleep(0)
+    assert not success.done()
+    assert store.ensure_meta().processing_fault_since is not None
+
+    release_callback.set()
+    await asyncio.wait_for(reconciliation, timeout=1)
+    assert await asyncio.wait_for(success, timeout=1)
+
+    assert events == ["fault", "recovered"]
+    assert store.next_processing_action() is None
+
+
+async def test_successful_flush_waits_for_blocked_fault_notification_ack(
+    tmp_path: Path,
+) -> None:
+    store = _store(tmp_path)
+    row = _enqueue(store, "blocked-flush-close")
+    claimed = store.claim_due(
+        lease_owner="worker",
+        now="2026-01-01T00:00:00.000Z",
+    )
+    assert claimed is not None
+    assert store.settle_add_ack(
+        claimed,
+        AddAck("before-flush", "accumulated"),
+        lease_owner="worker",
+        now=datetime(2026, 1, 1, tzinfo=UTC),
+    ).settled
+    lease = store.begin_flush_attempt(
+        now="2026-01-01T00:00:01.000Z",
+        provider_session_ref=row.provider_session_ref,
+        force=True,
+    )
+    assert lease is not None
+    assert store.begin_flush_submission(
+        lease,
+        now="2026-01-01T00:00:02.000Z",
+    )
+    _open_store_processing_fault(
+        store,
+        "blocked-flush-fault",
+        at=datetime(2026, 1, 1, 0, 0, 3, tzinfo=UTC),
+    )
+    probe = store.next_processing_action()
+    assert isinstance(probe, ProcessingHealthProbe)
+    assert store.record_processing_health(probe, healthy=True).committed
+    callback_entered = asyncio.Event()
+    release_callback = asyncio.Event()
+    events: list[str] = []
+
+    async def notify(event, _kind, _occurred_at, _queued) -> bool:
+        events.append(event)
+        if event == "fault":
+            callback_entered.set()
+            await release_callback.wait()
+        return True
+
+    coordinator = SessionFlushCoordinator(
+        store=store,
+        provider=FakeMemoryProvider(),
+        enabled=lambda: True,
+        processing_event=notify,
+    )
+    reconciliation = asyncio.create_task(coordinator._reconcile_processing_events())
+    await asyncio.wait_for(callback_entered.wait(), timeout=1)
+    success = asyncio.create_task(
+        coordinator._finalize_flush_outcome(
+            lease,
+            FlushSucceeded("flush-success", "extracted"),
+        )
+    )
+    await asyncio.sleep(0)
+    assert not success.done()
+    state = store.get_session_flush_state(row.provider_session_ref)
+    assert state is not None and state.state == "in_flight"
+    assert store.ensure_meta().processing_fault_since is not None
+
+    release_callback.set()
+    await asyncio.wait_for(reconciliation, timeout=1)
+    await asyncio.wait_for(success, timeout=1)
+
+    assert events == ["fault", "recovered"]
+    assert store.next_processing_action() is None
+
+
+async def test_processing_action_loop_orders_recovery_probe_and_fault(
+    tmp_path: Path,
+) -> None:
+    store = _store(tmp_path)
+    _open_store_processing_fault(
+        store,
+        "ordered-cycle-1",
+        at=datetime(2026, 1, 1, tzinfo=UTC),
+    )
+    _classify_and_ack_store_processing_fault(store)
+    _close_store_processing_fault(store, at=datetime(2026, 1, 1, 0, 0, 1, tzinfo=UTC))
+    _open_store_processing_fault(
+        store,
+        "ordered-cycle-2",
+        at=datetime(2026, 1, 1, 0, 0, 2, tzinfo=UTC),
+    )
+    events: list[tuple[str, str | None]] = []
+
+    async def notify(event, kind, _occurred_at, _queued) -> bool:
+        events.append((event, kind))
+        return True
+
+    provider = FakeMemoryProvider(processing_healthy_flag=True)
+    coordinator = SessionFlushCoordinator(
+        store=store,
+        provider=provider,
+        enabled=lambda: True,
+        processing_event=notify,
+    )
+    await coordinator.recover(lease_owner="next-boot")
+
+    assert events == [("recovered", None), ("fault", "engine")]
+    assert store.next_processing_action() is None
+    meta = store.ensure_meta()
+    assert meta.processing_fault_generation == 2
+    assert meta.processing_alert_active is True
+
+
+async def test_notification_queue_count_is_live_and_not_durable_identity(
+    tmp_path: Path,
+) -> None:
+    store = _store(tmp_path)
+    _open_store_processing_fault(
+        store,
+        "live-queued-1",
+        at=datetime(2026, 1, 1, tzinfo=UTC),
+    )
+    probe = store.next_processing_action()
+    assert isinstance(probe, ProcessingHealthProbe)
+    assert store.record_processing_health(probe, healthy=True).committed
+    durable_event = store.next_processing_action()
+    queued_values: list[int] = []
+
+    async def notify(_event, _kind, _occurred_at, queued) -> bool:
+        queued_values.append(queued)
+        return len(queued_values) > 1
+
+    coordinator = SessionFlushCoordinator(
+        store=store,
+        provider=FakeMemoryProvider(),
+        enabled=lambda: True,
+        processing_event=notify,
+    )
+    await coordinator.recover(lease_owner="first-boot")
+    _enqueue(store, "live-queued-2", session="live-queued-2")
+    assert store.next_processing_action() == durable_event
+    await coordinator.recover(lease_owner="second-boot")
+
+    assert queued_values == [1, 2]
+    assert store.next_processing_action() is None
+
+
+async def test_stale_processing_commit_stops_without_hot_loop(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = _store(tmp_path)
+    _open_store_processing_fault(
+        store,
+        "stale-commit",
+        at=datetime(2026, 1, 1, tzinfo=UTC),
+    )
+    commits = 0
+
+    def stale_commit(_probe: ProcessingHealthProbe, *, healthy: bool) -> ProcessingHealthCommit:
+        nonlocal commits
+        del healthy
+        commits += 1
+        return ProcessingHealthCommit(committed=False)
+
+    monkeypatch.setattr(store, "record_processing_health", stale_commit)
+    coordinator = SessionFlushCoordinator(
+        store=store,
+        provider=FakeMemoryProvider(processing_healthy_flag=True),
+        enabled=lambda: True,
+    )
+    await coordinator.recover(lease_owner="next-boot")
+
+    assert commits == 1
+
+
+@pytest.mark.parametrize("operation", ["health", "ack"])
+async def test_processing_action_cancellation_drains_started_store_commit(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    operation: str,
+) -> None:
+    store = _store(tmp_path)
+    _open_store_processing_fault(
+        store,
+        f"cancel-{operation}",
+        at=datetime(2026, 1, 1, tzinfo=UTC),
+    )
+    entered = threading.Event()
+    release = threading.Event()
+    events: list[str] = []
+
+    if operation == "health":
+        original = store.record_processing_health
+
+        def blocking_commit(probe: ProcessingHealthProbe, *, healthy: bool):
+            entered.set()
+            release.wait(timeout=2)
+            return original(probe, healthy=healthy)
+
+        monkeypatch.setattr(store, "record_processing_health", blocking_commit)
+    else:
+        probe = store.next_processing_action()
+        assert isinstance(probe, ProcessingHealthProbe)
+        assert store.record_processing_health(probe, healthy=True).committed
+        original = store.acknowledge_processing_notification
+
+        def blocking_ack(notification: ProcessingNotification) -> bool:
+            entered.set()
+            release.wait(timeout=2)
+            return original(notification)
+
+        monkeypatch.setattr(store, "acknowledge_processing_notification", blocking_ack)
+
+    async def notify(event, _kind, _occurred_at, _queued) -> bool:
+        events.append(event)
+        return True
+
+    coordinator = SessionFlushCoordinator(
+        store=store,
+        provider=FakeMemoryProvider(processing_healthy_flag=True),
+        enabled=lambda: True,
+        processing_event=notify,
+    )
+    recovery = asyncio.create_task(coordinator.recover(lease_owner="next-boot"))
+    assert await asyncio.to_thread(entered.wait, 1)
+    recovery.cancel()
+    await asyncio.sleep(0)
+    assert not recovery.done()
+    release.set()
+    with pytest.raises(asyncio.CancelledError):
+        await recovery
+
+    action = store.next_processing_action()
+    if operation == "health":
+        assert isinstance(action, ProcessingNotification)
+        assert events == []
+    else:
+        assert action is None
+        assert events == ["fault"]
 
 
 
@@ -485,14 +1006,11 @@ async def test_restart_finishes_ambiguous_add_fault_after_classification_interru
     )
     assert claimed is not None
 
-    async def interrupt_classification(_occurred_at: str) -> None:
+    async def interrupt_classification() -> bool:
         raise asyncio.CancelledError
 
-    monkeypatch.setattr(
-        coordinator,
-        "_classify_processing_fault_locked",
-        interrupt_classification,
-    )
+    original_health = provider.processing_healthy
+    monkeypatch.setattr(provider, "processing_healthy", interrupt_classification)
     with pytest.raises(asyncio.CancelledError):
         await coordinator.deliver(claimed, lease_owner="old-boot")
 
@@ -503,6 +1021,7 @@ async def test_restart_finishes_ambiguous_add_fault_after_classification_interru
     assert pending_fault.processing_fault_kind is None
     assert pending_fault.processing_alert_active is False
     assert len(provider.captures) == 1
+    monkeypatch.setattr(provider, "processing_healthy", original_health)
 
     events: list[tuple[str, str | None, str, int]] = []
 
@@ -806,7 +1325,6 @@ def test_stale_flush_settlement_cannot_clear_newer_generation(tmp_path: Path) ->
 
 async def test_stale_flush_finalization_does_not_open_processing_fault(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     store = _store(tmp_path)
     current = datetime(2026, 1, 1, tzinfo=UTC)
@@ -838,15 +1356,6 @@ async def test_stale_flush_finalization_does_not_open_processing_fault(
         now="2026-01-01T00:00:02.000Z",
     ).settled
 
-    fault_opens = 0
-    original_open = store.open_processing_fault
-
-    def count_open(*, now: str) -> bool:
-        nonlocal fault_opens
-        fault_opens += 1
-        return original_open(now=now)
-
-    monkeypatch.setattr(store, "open_processing_fault", count_open)
     coordinator = SessionFlushCoordinator(
         store=store,
         provider=FakeMemoryProvider(),
@@ -857,9 +1366,10 @@ async def test_stale_flush_finalization_does_not_open_processing_fault(
         FlushUnknown(reason="transport"),
     )
 
-    assert fault_opens == 0
     meta = store.get_meta()
-    assert meta is not None and meta.processing_fault_since is None
+    assert meta is not None
+    assert meta.processing_fault_generation == 0
+    assert meta.processing_fault_since is None
 
 
 
@@ -1092,10 +1602,6 @@ async def test_restart_finishes_atomic_processing_recovery_notification_once(
 ) -> None:
     store = _store(tmp_path)
     provider = FakeMemoryProvider(processing_healthy_flag=True)
-    if success.startswith("add-"):
-        assert store.open_processing_fault(now="2026-01-01T00:00:00.000Z")
-        assert store.classify_processing_fault("engine")
-        assert store.mark_processing_alert_active()
 
     row = _enqueue(store, f"recovery-{success}")
     claimed = store.claim_due(
@@ -1104,6 +1610,12 @@ async def test_restart_finishes_atomic_processing_recovery_notification_once(
     )
     assert claimed is not None
     if success.startswith("add-"):
+        _open_store_processing_fault(
+            store,
+            f"recovery-fault-{success}",
+            at=datetime(2026, 1, 1, tzinfo=UTC),
+        )
+        _classify_and_ack_store_processing_fault(store)
         status = success.removeprefix("add-")
         assert store.settle_add_ack(
             claimed,
@@ -1118,9 +1630,12 @@ async def test_restart_finishes_atomic_processing_recovery_notification_once(
             lease_owner="old-boot",
             now=datetime(2026, 1, 1, 0, 0, 2, tzinfo=UTC),
         ).settled
-        assert store.open_processing_fault(now="2026-01-01T00:00:02.500Z")
-        assert store.classify_processing_fault("engine")
-        assert store.mark_processing_alert_active()
+        _open_store_processing_fault(
+            store,
+            "recovery-fault-flush",
+            at=datetime(2026, 1, 1, 0, 0, 2, 500000, tzinfo=UTC),
+        )
+        _classify_and_ack_store_processing_fault(store)
         lease = store.begin_flush_attempt(
             now="2026-01-01T00:00:03.000Z",
             provider_session_ref=row.provider_session_ref,
@@ -1998,7 +2513,12 @@ async def test_shutdown_local_flush_phase_does_not_wait_for_classification_lock(
     row = _enqueue(store, "shutdown-lock-boundary")
     assert await worker.drain_once() == 1
 
-    old_classification = asyncio.create_task(coordinator._open_processing_fault())
+    _open_store_processing_fault(
+        store,
+        "shutdown-lock-fault",
+        at=datetime(2026, 1, 1, tzinfo=UTC),
+    )
+    old_classification = asyncio.create_task(coordinator._reconcile_processing_events())
     await asyncio.wait_for(old_health_entered.wait(), timeout=1)
     flush_task = coordinator._schedule(row.provider_session_ref, force=True)
     assert flush_task is not None

--- a/tests/test_memory_flush_coordinator.py
+++ b/tests/test_memory_flush_coordinator.py
@@ -244,6 +244,62 @@ async def test_processing_probe_error_retries_on_tick_after_backoff(
     assert store.next_processing_action() is None
 
 
+async def test_add_settlement_does_not_bypass_processing_probe_backoff(
+    tmp_path: Path,
+) -> None:
+    store = _store(tmp_path)
+    _open_store_processing_fault(
+        store,
+        "probe-before-add",
+        at=datetime(2026, 1, 1, tzinfo=UTC),
+    )
+    current = [datetime(2026, 1, 1, tzinfo=UTC)]
+    health_attempts = 0
+    events: list[str] = []
+
+    class Provider(FakeMemoryProvider):
+        async def processing_healthy(self) -> bool:
+            nonlocal health_attempts
+            health_attempts += 1
+            if health_attempts == 1:
+                raise RuntimeError("health failed")
+            return True
+
+        async def add(self, capture):
+            self.captures.append(capture)
+            raise MemoryProviderFailure("memory_processing_failed", retryable=True)
+
+    async def notify(event, _kind, _occurred_at, _queued) -> bool:
+        events.append(event)
+        return True
+
+    coordinator = SessionFlushCoordinator(
+        store=store,
+        provider=Provider(),
+        enabled=lambda: True,
+        now=lambda: current[0],
+        processing_event=notify,
+    )
+    await coordinator.recover(lease_owner="next-boot")
+    _enqueue(store, "activity-before-probe-retry", session="activity")
+    claimed = store.claim_due(
+        lease_owner="worker",
+        now="2026-01-01T00:00:01.000Z",
+    )
+    assert claimed is not None
+
+    assert not await coordinator.deliver(claimed, lease_owner="worker")
+    assert health_attempts == 1
+    assert events == []
+    assert isinstance(store.next_processing_action(), ProcessingHealthProbe)
+
+    current[0] += timedelta(seconds=5)
+    assert await coordinator.run_due() == 0
+    assert health_attempts == 2
+    assert events == ["fault"]
+    assert store.next_processing_action() is None
+
+
 async def test_processing_probe_cancellation_does_not_schedule_retry(
     tmp_path: Path,
 ) -> None:
@@ -322,6 +378,70 @@ async def test_processing_notification_failure_retries_on_tick_after_backoff(
     current[0] += timedelta(seconds=5)
     assert await coordinator.run_due() == 0
     assert attempts == 2
+    assert store.next_processing_action() is None
+
+
+async def test_flush_settlement_does_not_bypass_processing_notification_backoff(
+    tmp_path: Path,
+) -> None:
+    store = _store(tmp_path)
+    row = _enqueue(store, "flush-before-notification-retry")
+    claimed = store.claim_due(
+        lease_owner="worker",
+        now="2026-01-01T00:00:00.000Z",
+    )
+    assert claimed is not None
+    assert store.settle_add_ack(
+        claimed,
+        AddAck("before-flush", "accumulated"),
+        lease_owner="worker",
+        now=datetime(2026, 1, 1, tzinfo=UTC),
+    ).settled
+    lease = store.begin_flush_attempt(
+        now="2026-01-01T00:00:01.000Z",
+        provider_session_ref=row.provider_session_ref,
+        force=True,
+    )
+    assert lease is not None
+    assert store.begin_flush_submission(
+        lease,
+        now="2026-01-01T00:00:02.000Z",
+    )
+    _open_store_processing_fault(
+        store,
+        "notification-before-flush",
+        at=datetime(2026, 1, 1, 0, 0, 3, tzinfo=UTC),
+    )
+    probe = store.next_processing_action()
+    assert isinstance(probe, ProcessingHealthProbe)
+    assert store.record_processing_health(probe, healthy=True).committed
+    current = [datetime(2026, 1, 1, 0, 0, 3, tzinfo=UTC)]
+    notification_attempts = 0
+
+    async def notify(*_args) -> bool:
+        nonlocal notification_attempts
+        notification_attempts += 1
+        return notification_attempts > 1
+
+    coordinator = SessionFlushCoordinator(
+        store=store,
+        provider=FakeMemoryProvider(),
+        enabled=lambda: True,
+        now=lambda: current[0],
+        processing_event=notify,
+    )
+    await coordinator._reconcile_processing_events()
+
+    await coordinator._finalize_flush_outcome(
+        lease,
+        FlushUnknown(reason="transport"),
+    )
+    assert notification_attempts == 1
+    assert isinstance(store.next_processing_action(), ProcessingNotification)
+
+    current[0] += timedelta(seconds=5)
+    assert await coordinator.run_due() == 0
+    assert notification_attempts == 2
     assert store.next_processing_action() is None
 
 
@@ -670,16 +790,22 @@ async def test_notification_queue_count_is_live_and_not_durable_identity(
         queued_values.append(queued)
         return len(queued_values) > 1
 
+    current = [datetime(2026, 1, 1, tzinfo=UTC)]
     coordinator = SessionFlushCoordinator(
         store=store,
         provider=FakeMemoryProvider(),
         enabled=lambda: True,
+        now=lambda: current[0],
         processing_event=notify,
     )
     await coordinator.recover(lease_owner="first-boot")
     _enqueue(store, "live-queued-2", session="live-queued-2")
     assert store.next_processing_action() == durable_event
     await coordinator.recover(lease_owner="second-boot")
+    assert queued_values == [1]
+
+    current[0] += timedelta(seconds=5)
+    assert await coordinator.run_due() == 0
 
     assert queued_values == [1, 2]
     assert store.next_processing_action() is None

--- a/tests/test_memory_store.py
+++ b/tests/test_memory_store.py
@@ -20,6 +20,8 @@ from core.memory.store import (
     Delivered,
     MemoryStore,
     MessageFailure,
+    ProcessingHealthProbe,
+    ProcessingNotification,
     SettleResult,
     SystemOutage,
     TERMINAL_TOMBSTONE_RETENTION,
@@ -113,8 +115,59 @@ def _deliver(
     return result.row.provider_session_ref
 
 
+def _open_processing_fault(
+    store: MemoryStore,
+    source_message_id: str,
+    *,
+    at: str,
+):
+    result = _enqueue(store, source_message_id)
+    assert result.row is not None
+    claimed = store.claim_due(lease_owner="worker", now=at)
+    assert claimed is not None
+    settled = store.settle(
+        claimed,
+        SystemOutage(error="memory_processing_failed"),
+        lease_owner="worker",
+        now=_dt(at),
+    )
+    assert settled == SettleResult(settled=True, state="pending")
+    return claimed
+
+
+def _classify_and_ack_processing_fault(
+    store: MemoryStore,
+    *,
+    healthy: bool = True,
+) -> ProcessingNotification:
+    probe = store.next_processing_action()
+    assert isinstance(probe, ProcessingHealthProbe)
+    assert store.record_processing_health(probe, healthy=healthy).committed
+    notification = store.next_processing_action()
+    assert isinstance(notification, ProcessingNotification)
+    assert notification.event == "fault"
+    assert store.acknowledge_processing_notification(notification)
+    return notification
+
+
+def _close_processing_fault_with_add(
+    store: MemoryStore,
+    *,
+    at: str,
+) -> None:
+    claimed = store.claim_due(lease_owner="worker", now=at)
+    assert claimed is not None
+    assert store.settle(
+        claimed,
+        Delivered(add_request_id=f"success-{claimed.source_message_digest[:8]}"),
+        lease_owner="worker",
+        now=_dt(at),
+    ).settled
+
+
 def test_store_creates_exact_memory_tables_and_due_index(tmp_path: Path) -> None:
     store = MemoryStore(_store_path(tmp_path))
+    store.ensure_meta()
 
     with sqlite3.connect(store.path) as conn:
         tables = {
@@ -158,13 +211,31 @@ def test_store_creates_exact_memory_tables_and_due_index(tmp_path: Path) -> None
             "flush_observed_at",
         }.intersection(queue_columns)
         assert {
+            "processing_fault_generation",
             "processing_fault_kind",
             "processing_fault_since",
             "processing_alert_active",
+            "processing_recovery_generation",
             "processing_recovery_pending_at",
             "last_error_at",
         }.issubset(meta_columns)
         assert {"attempts", "recovery_origin"}.issubset(settlement_columns)
+        with pytest.raises(sqlite3.IntegrityError):
+            conn.execute(
+                """
+                UPDATE memory_meta
+                SET processing_recovery_pending_at = 'now'
+                WHERE singleton = 1
+                """
+            )
+        with pytest.raises(sqlite3.IntegrityError):
+            conn.execute(
+                """
+                UPDATE memory_meta
+                SET processing_recovery_generation = 1
+                WHERE singleton = 1
+                """
+            )
         with pytest.raises(sqlite3.IntegrityError):
             conn.execute(
                 """
@@ -262,24 +333,27 @@ def test_store_initializes_an_empty_v0_database(tmp_path: Path) -> None:
         assert conn.execute("SELECT COUNT(*) FROM memory_capture_queue").fetchone()[0] == 0
 
 
-def test_store_rejects_unknown_nonzero_schema_without_rebuilding(tmp_path: Path) -> None:
-    database = _store_path(tmp_path / "future-schema")
-    future_version = MEMORY_STORE_SCHEMA_VERSION + 1
+@pytest.mark.parametrize("version", [1, 3], ids=("prior-v1", "future-v3"))
+def test_store_rejects_nonzero_noncurrent_schema_without_rebuilding(
+    tmp_path: Path,
+    version: int,
+) -> None:
+    database = _store_path(tmp_path / f"schema-v{version}")
     database.parent.mkdir(parents=True)
     with sqlite3.connect(database) as conn:
-        conn.execute("CREATE TABLE future_memory_state (value TEXT NOT NULL)")
-        conn.execute("INSERT INTO future_memory_state VALUES ('preserve')")
-        conn.execute(f"PRAGMA user_version = {future_version}")
+        conn.execute("CREATE TABLE versioned_memory_state (value TEXT NOT NULL)")
+        conn.execute("INSERT INTO versioned_memory_state VALUES ('preserve')")
+        conn.execute(f"PRAGMA user_version = {version}")
 
     with pytest.raises(
         RuntimeError,
-        match=f"Unsupported Memory store schema version: {future_version}",
+        match=f"Unsupported Memory store schema version: {version}",
     ):
         MemoryStore(database)
 
     with sqlite3.connect(database) as conn:
-        assert conn.execute("PRAGMA user_version").fetchone()[0] == future_version
-        assert conn.execute("SELECT value FROM future_memory_state").fetchone()[0] == "preserve"
+        assert conn.execute("PRAGMA user_version").fetchone()[0] == version
+        assert conn.execute("SELECT value FROM versioned_memory_state").fetchone()[0] == "preserve"
 
 
 def test_session_scope_recovery_survives_store_reopen_and_separates_sessions(tmp_path: Path) -> None:
@@ -511,6 +585,165 @@ def test_server_rejected_add_and_processing_fault_are_one_transaction(
     assert store.failure_log() == ()
 
 
+def test_processing_system_outage_return_and_fault_open_are_one_transaction(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = MemoryStore(_store_path(tmp_path))
+    _enqueue(store, "atomic-processing-outage")
+    claimed = store.claim_due(
+        lease_owner="worker",
+        now="2026-01-01T00:00:00.000Z",
+    )
+    assert claimed is not None
+
+    def fail_fault_open(_conn, *, now: str) -> bool:
+        del now
+        raise OSError("injected processing fault write failure")
+
+    monkeypatch.setattr(
+        store,
+        "_open_processing_fault_in_connection",
+        fail_fault_open,
+    )
+    with pytest.raises(OSError, match="injected processing fault write failure"):
+        store.settle(
+            claimed,
+            SystemOutage(error="memory_processing_failed"),
+            lease_owner="worker",
+            now=_dt("2026-01-01T00:00:01.000Z"),
+        )
+
+    queued = _row_for_source(store, "atomic-processing-outage")
+    assert queued is not None and queued.state == "processing"
+    meta = store.ensure_meta()
+    assert meta.processing_fault_generation == 0
+    assert meta.processing_fault_since is None
+
+
+def test_repeated_processing_fault_open_preserves_cycle_generation_and_time(
+    tmp_path: Path,
+) -> None:
+    store = MemoryStore(_store_path(tmp_path))
+    _open_processing_fault(
+        store,
+        "same-cycle",
+        at="2026-01-01T00:00:00.000Z",
+    )
+    _open_processing_fault(
+        store,
+        "same-cycle",
+        at="2026-01-01T00:05:00.000Z",
+    )
+
+    meta = store.ensure_meta()
+    assert meta.processing_fault_generation == 1
+    assert meta.processing_fault_since == "2026-01-01T00:00:00.000Z"
+
+
+def test_stale_processing_probe_cannot_classify_reopened_cycle(tmp_path: Path) -> None:
+    store = MemoryStore(_store_path(tmp_path))
+    _open_processing_fault(store, "probe-cycle-1", at="2026-01-01T00:00:00.000Z")
+    old_probe = store.next_processing_action()
+    assert isinstance(old_probe, ProcessingHealthProbe)
+    _close_processing_fault_with_add(store, at="2026-01-01T00:00:01.000Z")
+    _open_processing_fault(store, "probe-cycle-2", at="2026-01-01T00:00:02.000Z")
+
+    assert not store.record_processing_health(old_probe, healthy=True).committed
+    current = store.next_processing_action()
+    assert isinstance(current, ProcessingHealthProbe)
+    assert current.generation == 2
+    assert store.ensure_meta().processing_fault_kind is None
+
+
+def test_stale_fault_notification_cannot_acknowledge_reopened_cycle(tmp_path: Path) -> None:
+    store = MemoryStore(_store_path(tmp_path))
+    _open_processing_fault(store, "alert-cycle-1", at="2026-01-01T00:00:00.000Z")
+    old_probe = store.next_processing_action()
+    assert isinstance(old_probe, ProcessingHealthProbe)
+    assert store.record_processing_health(old_probe, healthy=True).committed
+    old_notification = store.next_processing_action()
+    assert isinstance(old_notification, ProcessingNotification)
+    _close_processing_fault_with_add(store, at="2026-01-01T00:00:01.000Z")
+    _open_processing_fault(store, "alert-cycle-2", at="2026-01-01T00:00:02.000Z")
+
+    assert not store.acknowledge_processing_notification(old_notification)
+    meta = store.ensure_meta()
+    assert meta.processing_fault_generation == 2
+    assert meta.processing_alert_active is False
+
+
+def test_stale_recovery_notification_cannot_clear_newer_recovery(tmp_path: Path) -> None:
+    store = MemoryStore(_store_path(tmp_path))
+    _open_processing_fault(store, "recovery-cycle-1", at="2026-01-01T00:00:00.000Z")
+    _classify_and_ack_processing_fault(store)
+    _close_processing_fault_with_add(store, at="2026-01-01T00:00:01.000Z")
+    old_recovery = store.next_processing_action()
+    assert isinstance(old_recovery, ProcessingNotification)
+    assert old_recovery.event == "recovered"
+    invalid_recovery = ProcessingNotification(
+        event="recovered",
+        generation=old_recovery.generation,
+        kind="engine",
+        occurred_at=old_recovery.occurred_at,
+    )
+    assert not store.acknowledge_processing_notification(invalid_recovery)
+    assert store.next_processing_action() == old_recovery
+    assert store.acknowledge_processing_notification(old_recovery)
+
+    _open_processing_fault(store, "recovery-cycle-2", at="2026-01-01T00:00:02.000Z")
+    _classify_and_ack_processing_fault(store)
+    _close_processing_fault_with_add(store, at="2026-01-01T00:00:03.000Z")
+
+    assert not store.acknowledge_processing_notification(old_recovery)
+    current = store.next_processing_action()
+    assert isinstance(current, ProcessingNotification)
+    assert (current.event, current.generation) == ("recovered", 2)
+
+
+def test_recovery_for_generation_one_coexists_with_open_generation_two(
+    tmp_path: Path,
+) -> None:
+    store = MemoryStore(_store_path(tmp_path))
+    _open_processing_fault(store, "coexist-cycle-1", at="2026-01-01T00:00:00.000Z")
+    _classify_and_ack_processing_fault(store)
+    _close_processing_fault_with_add(store, at="2026-01-01T00:00:01.000Z")
+    _open_processing_fault(store, "coexist-cycle-2", at="2026-01-01T00:00:02.000Z")
+
+    recovery = store.next_processing_action()
+    assert isinstance(recovery, ProcessingNotification)
+    assert (recovery.event, recovery.generation) == ("recovered", 1)
+    assert store.acknowledge_processing_notification(recovery)
+    current = store.next_processing_action()
+    assert isinstance(current, ProcessingHealthProbe)
+    assert current.generation == 2
+
+
+@pytest.mark.parametrize("clear_path", ["begin-finish", "reset"])
+def test_processing_fault_generation_survives_clear(
+    tmp_path: Path,
+    clear_path: str,
+) -> None:
+    store = MemoryStore(_store_path(tmp_path))
+    _open_processing_fault(store, "before-clear", at="2026-01-01T00:00:00.000Z")
+    pre_clear_probe = store.next_processing_action()
+    assert isinstance(pre_clear_probe, ProcessingHealthProbe)
+
+    epoch = store.ensure_meta().epoch
+    if clear_path == "begin-finish":
+        store.begin_clear()
+        cleared = store.finish_clear()
+    else:
+        cleared = store.reset_for_clear(target_epoch=epoch + 1)
+    assert cleared.processing_fault_generation == 1
+    _open_processing_fault(store, "after-clear", at="2026-01-01T00:00:01.000Z")
+
+    assert not store.record_processing_health(pre_clear_probe, healthy=True).committed
+    post_clear_probe = store.next_processing_action()
+    assert isinstance(post_clear_probe, ProcessingHealthProbe)
+    assert post_clear_probe.generation == 2
+
+
 def test_exhausted_flush_retry_and_processing_fault_are_one_transaction(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -618,9 +851,12 @@ def test_successful_add_and_processing_fault_close_are_one_transaction(
         now="2026-01-01T00:00:00.000Z",
     )
     assert claimed is not None
-    assert store.open_processing_fault(now="2026-01-01T00:00:00.100Z")
-    assert store.classify_processing_fault("engine")
-    assert store.mark_processing_alert_active()
+    _open_processing_fault(
+        store,
+        f"atomic-add-close-fault-{status}",
+        at="2026-01-01T00:00:00.100Z",
+    )
+    _classify_and_ack_processing_fault(store)
 
     def fail_fault_close(_conn, *, now: str) -> bool:
         del now
@@ -664,9 +900,12 @@ def test_successful_flush_and_processing_fault_close_are_one_transaction(
         lease,
         now="2026-01-01T00:00:03.000Z",
     )
-    assert store.open_processing_fault(now="2026-01-01T00:00:03.100Z")
-    assert store.classify_processing_fault("engine")
-    assert store.mark_processing_alert_active()
+    _open_processing_fault(
+        store,
+        "atomic-flush-close-fault",
+        at="2026-01-01T00:00:03.100Z",
+    )
+    _classify_and_ack_processing_fault(store)
 
     def fail_fault_close(_conn, *, now: str) -> bool:
         del now
@@ -1334,38 +1573,38 @@ def test_boot_recovery_samples_its_clock_after_reclaiming_leases(tmp_path: Path)
     assert observed_at == "2026-01-01T00:00:09.000Z"
 
 
-def test_store_persists_refreshes_and_closes_processing_fault(tmp_path: Path) -> None:
+def test_store_persists_and_closes_processing_fault_protocol(tmp_path: Path) -> None:
     database = _store_path(tmp_path)
     store = MemoryStore(database)
 
-    assert store.open_processing_fault(now="2026-01-01T00:00:00.000Z") is True
-    assert store.classify_processing_fault("credential") is True
-    assert store.mark_processing_alert_active() is True
+    _open_processing_fault(store, "persisted-fault", at="2026-01-01T00:00:00.000Z")
+    notification = _classify_and_ack_processing_fault(store, healthy=False)
     reopened = MemoryStore(database).ensure_meta()
+    assert reopened.processing_fault_generation == 1
     assert reopened.processing_fault_since == "2026-01-01T00:00:00.000Z"
     assert reopened.processing_fault_kind == "credential"
     assert reopened.processing_alert_active is True
     assert reopened.last_error == "memory_processing_failed"
 
-    assert store.open_processing_fault(now="2026-01-01T00:05:00.000Z") is False
-    assert store.classify_processing_fault("engine") is False
+    _open_processing_fault(store, "persisted-fault", at="2026-01-01T00:05:00.000Z")
     refreshed = store.ensure_meta()
-    assert refreshed.processing_fault_since == "2026-01-01T00:05:00.000Z"
-    assert refreshed.processing_fault_kind == "engine"
+    assert refreshed.processing_fault_generation == 1
+    assert refreshed.processing_fault_since == "2026-01-01T00:00:00.000Z"
+    assert refreshed.processing_fault_kind == "credential"
+    assert store.acknowledge_processing_notification(notification) is False
 
-    assert store.close_processing_fault(now="2026-01-01T00:05:01.000Z") is True
+    _close_processing_fault_with_add(store, at="2026-01-01T00:05:01.000Z")
     closed = store.ensure_meta()
     assert closed.processing_fault_since is None
     assert closed.processing_fault_kind is None
     assert closed.processing_alert_active is False
     assert closed.processing_recovery_pending_at == "2026-01-01T00:05:01.000Z"
+    assert closed.processing_recovery_generation == 1
     assert closed.last_error is None
-    assert store.mark_processing_recovery_notified(
-        occurred_at="2026-01-01T00:05:01.000Z"
-    )
-    assert not store.mark_processing_recovery_notified(
-        occurred_at="2026-01-01T00:05:01.000Z"
-    )
+    recovery = store.next_processing_action()
+    assert isinstance(recovery, ProcessingNotification)
+    assert store.acknowledge_processing_notification(recovery)
+    assert not store.acknowledge_processing_notification(recovery)
 
 
 def test_duplicate_enqueue_is_atomic_and_does_not_advance_provider_clock(tmp_path: Path) -> None:

--- a/tests/test_memory_store.py
+++ b/tests/test_memory_store.py
@@ -37,6 +37,7 @@ FOUNDATION_SCHEMAS = (
     Path(__file__).with_name("fixtures") / "memory_initial_foundation_v0.sql",
     Path(__file__).with_name("fixtures") / "memory_foundation_v0.sql",
 )
+V1_SCHEMA = Path(__file__).with_name("fixtures") / "memory_foundation_v1.sql"
 
 
 def _dt(value: str) -> datetime:
@@ -333,11 +334,113 @@ def test_store_initializes_an_empty_v0_database(tmp_path: Path) -> None:
         assert conn.execute("SELECT COUNT(*) FROM memory_capture_queue").fetchone()[0] == 0
 
 
-@pytest.mark.parametrize("version", [1, 3], ids=("prior-v1", "future-v3"))
-def test_store_rejects_nonzero_noncurrent_schema_without_rebuilding(
+def _install_representative_v1_database(database: Path) -> None:
+    database.parent.mkdir(parents=True)
+    with sqlite3.connect(database) as conn:
+        conn.executescript(V1_SCHEMA.read_text(encoding="utf-8"))
+        conn.execute(
+            """
+            INSERT INTO memory_meta (
+                singleton, epoch, clear_in_progress, scope_key, provider_root_id,
+                last_provider_timestamp_ms, missed_count, last_success_at,
+                last_error, last_error_at, processing_fault_kind,
+                processing_fault_since, processing_alert_active,
+                processing_recovery_pending_at, updated_at
+            ) VALUES (
+                1, 4, 0, ?, 'preserved-root', 1234, 2,
+                '2026-01-01T00:00:00.000Z', 'memory_processing_failed',
+                '2026-01-01T00:02:00.000Z', 'engine',
+                '2026-01-01T00:02:00.000Z', 1,
+                '2026-01-01T00:01:00.000Z', '2026-01-01T00:02:00.000Z'
+            )
+            """,
+            (bytes.fromhex("11" * 32),),
+        )
+        conn.execute(
+            """
+            INSERT INTO memory_capture_queue (
+                source_message_digest, epoch, session_id, provider_session_ref,
+                generation, principal_id, project_ref, provenance, payload_text,
+                occurred_at_ms, provider_timestamp_ms, state, attempts, created_at
+            ) VALUES (
+                'preserved-digest', 4, 'preserved-session', ?,
+                2, 'u-11111111111111111111111111111111', ?, 'user_input',
+                'preserved payload', 1000, 1000, 'pending', 0,
+                '2026-01-01T00:00:00.000Z'
+            )
+            """,
+            (
+                ProviderSessionRef(
+                    principal_id="u-11111111111111111111111111111111",
+                    epoch=4,
+                    project_ref=PROJECT,
+                    session_id="preserved-provider-session",
+                ).serialize(),
+                PROJECT,
+            ),
+        )
+
+
+def test_store_migrates_v1_metadata_and_preserves_existing_data(tmp_path: Path) -> None:
+    database = _store_path(tmp_path / "schema-v1")
+    _install_representative_v1_database(database)
+
+    store = MemoryStore(database)
+
+    with sqlite3.connect(database) as conn:
+        assert conn.execute("PRAGMA user_version").fetchone()[0] == 2
+        columns = {row[1] for row in conn.execute("PRAGMA table_info('memory_meta')")}
+        assert {
+            "processing_fault_generation",
+            "processing_recovery_generation",
+        }.issubset(columns)
+    meta = store.ensure_meta()
+    assert meta.provider_root_id == "preserved-root"
+    assert meta.processing_fault_generation == 2
+    assert meta.processing_recovery_generation == 1
+    assert meta.processing_fault_since == "2026-01-01T00:02:00.000Z"
+    assert meta.processing_recovery_pending_at == "2026-01-01T00:01:00.000Z"
+    rows = store.list_queue_rows()
+    assert len(rows) == 1
+    assert rows[0].payload_text == "preserved payload"
+
+
+def test_store_rolls_back_failed_v1_migration_without_changing_data(
     tmp_path: Path,
-    version: int,
 ) -> None:
+    database = _store_path(tmp_path / "schema-v1-failure")
+    _install_representative_v1_database(database)
+    with sqlite3.connect(database) as conn:
+        conn.execute(
+            """
+            CREATE TRIGGER fail_v1_migration
+            BEFORE UPDATE ON memory_meta
+            BEGIN
+                SELECT RAISE(ABORT, 'injected v1 migration failure');
+            END
+            """
+        )
+
+    with pytest.raises(sqlite3.IntegrityError, match="injected v1 migration failure"):
+        MemoryStore(database)
+
+    with sqlite3.connect(database) as conn:
+        assert conn.execute("PRAGMA user_version").fetchone()[0] == 1
+        columns = {row[1] for row in conn.execute("PRAGMA table_info('memory_meta')")}
+        assert "processing_fault_generation" not in columns
+        assert "processing_recovery_generation" not in columns
+        assert conn.execute(
+            "SELECT provider_root_id FROM memory_meta WHERE singleton = 1"
+        ).fetchone()[0] == "preserved-root"
+        assert conn.execute(
+            "SELECT payload_text FROM memory_capture_queue"
+        ).fetchone()[0] == "preserved payload"
+
+
+def test_store_rejects_unknown_nonzero_schema_without_rebuilding(
+    tmp_path: Path,
+) -> None:
+    version = 3
     database = _store_path(tmp_path / f"schema-v{version}")
     database.parent.mkdir(parents=True)
     with sqlite3.connect(database) as conn:

--- a/tests/test_memory_worker.py
+++ b/tests/test_memory_worker.py
@@ -16,7 +16,7 @@ def test_new_lease_activation_recovers_before_claiming() -> None:
             calls.append(("recover", lease_owner))
             return BootRecovery(reclaimed=0, interrupted_flushes=0)
 
-        def get_meta(self):
+        def next_processing_action(self):
             return None
 
         def list_flush_candidates(self, *, now: str, limit: int):


### PR DESCRIPTION
Closes #1279

## Capability

Moves durable Memory processing-fault ownership into `MemoryStore` through generation-fenced health probes and notification actions. Queue/flush/boot settlements now open or close the exact fault edge atomically, while the coordinator performs only bounded external actions and generation-CAS commits.

External notification delivery is explicitly **at-least-once**. If delivery succeeds but the SQLite acknowledgement does not commit, restart may deliver the same stable event again. Durable identity is event, generation, kind, and occurred-at; `queued` remains a live value recomputed for each attempt.

The notification delivery gate serializes successful add/flush closure against callback+ack, preventing an externally emitted fault from closing without its recovery edge. It does not block local settlement on a provider health probe. Transient probe and notification failures retry through the existing periodic `run_due` tick after a bounded backoff, without a permanent scheduler task.

Schema v2 performs a transactional, data-preserving v1 metadata migration. The historical v0 fixtures remain immutable and v0 retains its clean-rebuild behavior.

## Evidence

- Unit: clean schema v2 bootstrap; exact v1 data-preserving migration and injected-failure rollback; paired recovery fields; monotonic generations through both Clear paths; stale health/fault/recovery CAS rejection; atomic SystemOutage return/open and successful close/recovery evidence.
- Contract: bounded recovery-before-probe-before-fault action loop; clock-controlled probe and notification false/error retries; cancellation/pause/shutdown suppression; at-least-once replay before ack and suppression after ack; live queue projection; cancellation-safe local commits; blocked-callback add/flush close races.
- Scenario: existing boot recovery, shutdown, final-flush, clear, maintenance, and runtime recovery suites remain green. No dedicated Memory scenario catalog exists.
- Residual manual: none; no user-facing workflow or UI behavior changed.

## Validation

- `pytest -q tests/test_memory_store.py tests/test_memory_flush_coordinator.py tests/test_memory_worker.py` - 145 passed
- `pytest -q tests/test_memory_*.py` - 836 passed, 1 skipped (implementation head before the focused review-fix rerun)
- `pytest -q tests/test_runtime_recovery.py` - 8 passed
- `ruff check` on every changed Python file - passed
- `git diff --check` - passed
- removed low-level transition symbol search - clean
- historical v0 fixture diff against `origin/dev` - clean
