### PR TITLE
feat(ui): remember the Agents tab and run-graph mode across visits

### DIFF
--- a/docs/plans/agents-run-graph-and-session-visibility.md
+++ b/docs/plans/agents-run-graph-and-session-visibility.md
@@ -79,7 +79,9 @@ standalone session" entry point (model support only); mobile canvas rendering
   widens 活跃 → 含历史 to surface an out-of-window node is transient, like the
   disabled-trigger reveal. Best-effort local storage
   (`ui/src/lib/agentsViewMemory.ts`); blocked storage falls back to the defaults.
-  Time window / project / `显示后台会话` are not remembered.
+  Time window / project / `显示后台会话` are not remembered. Only general
+  navigation resumes the memory: a contextual entry point passes
+  `/agents?tab=definitions` and that destination wins without being remembered.
 
 ### Graph semantics (all from existing columns)
 

--- a/docs/plans/agents-run-graph-and-session-visibility.md
+++ b/docs/plans/agents-run-graph-and-session-visibility.md
@@ -72,6 +72,14 @@ standalone session" entry point (model support only); mobile canvas rendering
 - Filters: 活跃 / 含历史 segmented; time window (default 24h) applies to
   history; project filter (including `独立` bucket); `显示后台会话` toggle
   (default on).
+- Cross-visit memory (added later): the Agents page remembers which tab it was
+  left on, and the 活跃/含历史 choice inside `运行`, so re-entering resumes that
+  view instead of resetting. 含历史 remains the fresh-browser default; only an
+  explicit segmented-control click is remembered — the search-locate path that
+  widens 活跃 → 含历史 to surface an out-of-window node is transient, like the
+  disabled-trigger reveal. Best-effort local storage
+  (`ui/src/lib/agentsViewMemory.ts`); blocked storage falls back to the defaults.
+  Time window / project / `显示后台会话` are not remembered.
 
 ### Graph semantics (all from existing columns)
 

--- a/docs/plans/running-agents-activity-tab.md
+++ b/docs/plans/running-agents-activity-tab.md
@@ -153,6 +153,11 @@ OpenCode 已是一等活后端（进程模型不同、无 pid）。
 `ui/src/lib/agentsViewMemory.ts`）。记忆是本地浏览器级的 best-effort：
 私密模式或存储被拦截时静默回落到首次默认。
 
+带明确意图的入口（如 Chat Agent 选择器的"新建 Agent"、Harness 详情的
+"Open in Agents"）用 `/agents?tab=definitions` 指定落地 Tab，优先于记忆——
+它是目的地而不是用户的选择，因此**不写回**记忆；只有用户真的点 Tab 才会改变
+下次裸进 `/agents` 的落点。
+
 ### 8-K. Running 子 Tab 计数 badge 口径（已定 K2）
 Running 子 Tab 的 badge **仅计 `active`（在途轮次）**；idle 实例仍在列表中可见但不计入 badge。须与 §6 口径统一：列表含 idle（D2），但所有"在跑计数"badge 一律只数 active。
 

--- a/docs/plans/running-agents-activity-tab.md
+++ b/docs/plans/running-agents-activity-tab.md
@@ -156,7 +156,8 @@ OpenCode 已是一等活后端（进程模型不同、无 pid）。
 带明确意图的入口（如 Chat Agent 选择器的"新建 Agent"、Harness 详情的
 "Open in Agents"）用 `/agents?tab=definitions` 指定落地 Tab，优先于记忆——
 它是目的地而不是用户的选择，因此**不写回**记忆；只有用户真的点 Tab 才会改变
-下次裸进 `/agents` 的落点。
+下次裸进 `/agents` 的落点。该参数消失（例如从带参 URL 再点侧边栏 Agents，
+路由只改 URL 不重挂组件）即视为回到裸导航，重新按记忆落地。
 
 ### 8-K. Running 子 Tab 计数 badge 口径（已定 K2）
 Running 子 Tab 的 badge **仅计 `active`（在途轮次）**；idle 实例仍在列表中可见但不计入 badge。须与 §6 口径统一：列表含 idle（D2），但所有"在跑计数"badge 一律只数 active。

--- a/docs/plans/running-agents-activity-tab.md
+++ b/docs/plans/running-agents-activity-tab.md
@@ -142,8 +142,16 @@ OpenCode 已是一等活后端（进程模型不同、无 pid）。
 - I2：显示上次已知 + 过期横幅。
 - I3：显示空。
 
-### 8-J. 子 Tab 默认落地（已定 J1）
-点 `/agents` 默认进 **`Definitions`**（保留现有肌肉记忆）；`Running` 为并列项。
+### 8-J. 子 Tab 默认落地（已定 J1；后续补充跨次记忆）
+首次进入（全新浏览器 / 存储被清空 / 存储不可用）点 `/agents` 默认进
+**`Definitions`**（保留现有肌肉记忆）；`Running` 为并列项。
+
+**后续补充**：J1 只定义"首次默认"，不再定义"每次重置"。之后再进 `/agents`
+（含侧边栏点击）会恢复上次离开时所在的子 Tab；停在 `Running` 时，其内部
+活跃/含历史 视图选择也一并恢复（详见
+`agents-run-graph-and-session-visibility.md` 的 Filters 段与
+`ui/src/lib/agentsViewMemory.ts`）。记忆是本地浏览器级的 best-effort：
+私密模式或存储被拦截时静默回落到首次默认。
 
 ### 8-K. Running 子 Tab 计数 badge 口径（已定 K2）
 Running 子 Tab 的 badge **仅计 `active`（在途轮次）**；idle 实例仍在列表中可见但不计入 badge。须与 §6 口径统一：列表含 idle（D2），但所有"在跑计数"badge 一律只数 active。

--- a/ui/src/components/workbench/AgentGraphTab.tsx
+++ b/ui/src/components/workbench/AgentGraphTab.tsx
@@ -24,6 +24,7 @@ import {
 } from '../../lib/agentGraph';
 import { searchGraph, type GraphSearchResult } from '../../lib/graphSearch';
 import { readGraphShowDisabled, writeGraphShowDisabled } from '../../lib/graphViewPrefs';
+import { readAgentGraphMode, writeAgentGraphMode } from '../../lib/agentsViewMemory';
 import { useIsDesktop } from '../../lib/useIsDesktop';
 import { AgentGraphCanvas } from './AgentGraphCanvas';
 import { AgentGraphMobileList } from './AgentGraphMobileList';
@@ -113,7 +114,16 @@ export const AgentGraphTab: React.FC = () => {
   const [projects, setProjects] = useState<{ id: string; display_name: string }[]>([]);
 
   // Filters (spec: 活跃/含历史 · time window · project incl. 独立 · 显示后台会话).
-  const [mode, setMode] = useState<'active' | 'history'>('history');
+  // The 活跃/含历史 choice is remembered across visits (含历史 by default) so
+  // re-entering the Runs tab resumes the view the user was actually watching.
+  // Only an explicit segmented-control click persists — the filter widening the
+  // search-locate path performs below is transient, same ruling as the
+  // disabled-trigger reveal.
+  const [mode, setMode] = useState<'active' | 'history'>(readAgentGraphMode);
+  const setModePersisted = useCallback((next: 'active' | 'history') => {
+    setMode(next);
+    writeAgentGraphMode(next);
+  }, []);
   const [windowSel, setWindowSel] = useState<GraphWindow>('24h');
   const [projectSel, setProjectSel] = useState<string>('all');
   const [showBackground, setShowBackground] = useState(true);
@@ -589,7 +599,7 @@ export const AgentGraphTab: React.FC = () => {
         />
         <SegmentedRadio
           value={mode}
-          onChange={setMode}
+          onChange={setModePersisted}
           ariaLabel={t('agents.graph.filters.modeLabel')}
           options={[
             { id: 'active', label: t('agents.graph.filters.active') },

--- a/ui/src/components/workbench/AgentRoutePicker.tsx
+++ b/ui/src/components/workbench/AgentRoutePicker.tsx
@@ -358,7 +358,9 @@ export const AgentRoutePicker: React.FC<AgentRoutePickerProps> = ({
               onClick={() => {
                 setOpen(false);
                 onNavigateAway?.(); // close the create sheet before leaving, if any
-                navigate('/agents');
+                // Creating an agent needs the Definitions controls, so ask for
+                // that tab explicitly instead of resuming the remembered one.
+                navigate('/agents?tab=definitions');
               }}
               className="mt-1 h-auto w-full justify-start gap-1.5 rounded px-2 py-1.5 text-[11px] font-medium text-cyan hover:bg-cyan/[0.08] hover:text-cyan"
             >

--- a/ui/src/components/workbench/AgentsPage.tsx
+++ b/ui/src/components/workbench/AgentsPage.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useSearchParams } from 'react-router-dom';
 import {
   Bot,
   ChevronDown,
@@ -52,7 +53,13 @@ import {
 import { errorMessage } from '@/lib/errorMessage';
 // Tab set + its cross-visit memory live together so the remembered value can
 // never name a tab this page no longer renders (see agentsViewMemory).
-import { AGENTS_TAB_ORDER, readAgentsTab, writeAgentsTab, type AgentsTabKey } from '../../lib/agentsViewMemory';
+import {
+  AGENTS_TAB_ORDER,
+  agentsTabFromParam,
+  readAgentsTab,
+  writeAgentsTab,
+  type AgentsTabKey,
+} from '../../lib/agentsViewMemory';
 
 function isSystemAgent(agent: { source: string }): boolean {
   return agent.source === 'builtin' || agent.source === 'system';
@@ -62,8 +69,22 @@ export const AgentsPage: React.FC = () => {
   const { t } = useTranslation();
   const api = useApi();
   const { showToast } = useToast();
-  // Resume the tab the user left the page on; a fresh browser opens Definitions.
-  const [agentsTab, setAgentsTab] = useState<AgentsTabKey>(readAgentsTab);
+  // General navigation (sidebar / nav / capability tabs) resumes the tab the user
+  // left the page on; a fresh browser opens Definitions. A contextual caller that
+  // needs a specific tab passes ``?tab=`` and wins over the memory — the tab it
+  // asked for is a destination, not a choice the user made, so it is deliberately
+  // NOT written back to the memory.
+  const [searchParams] = useSearchParams();
+  const tabParam = searchParams.get('tab');
+  const [agentsTab, setAgentsTab] = useState<AgentsTabKey>(
+    () => agentsTabFromParam(tabParam) ?? readAgentsTab(),
+  );
+  // One-way URL -> state, keyed on the param so a later user tab click isn't
+  // yanked back: a contextual link can arrive while this page is already mounted.
+  useEffect(() => {
+    const requested = agentsTabFromParam(tabParam);
+    if (requested) setAgentsTab(requested);
+  }, [tabParam]);
   const selectAgentsTab = useCallback((next: AgentsTabKey) => {
     setAgentsTab(next);
     writeAgentsTab(next);

--- a/ui/src/components/workbench/AgentsPage.tsx
+++ b/ui/src/components/workbench/AgentsPage.tsx
@@ -55,8 +55,7 @@ import { errorMessage } from '@/lib/errorMessage';
 // never name a tab this page no longer renders (see agentsViewMemory).
 import {
   AGENTS_TAB_ORDER,
-  agentsTabFromParam,
-  readAgentsTab,
+  resolveAgentsTab,
   writeAgentsTab,
   type AgentsTabKey,
 } from '../../lib/agentsViewMemory';
@@ -76,14 +75,14 @@ export const AgentsPage: React.FC = () => {
   // NOT written back to the memory.
   const [searchParams] = useSearchParams();
   const tabParam = searchParams.get('tab');
-  const [agentsTab, setAgentsTab] = useState<AgentsTabKey>(
-    () => agentsTabFromParam(tabParam) ?? readAgentsTab(),
-  );
+  const [agentsTab, setAgentsTab] = useState<AgentsTabKey>(() => resolveAgentsTab(tabParam));
   // One-way URL -> state, keyed on the param so a later user tab click isn't
-  // yanked back: a contextual link can arrive while this page is already mounted.
+  // yanked back: both a contextual link arriving while this page is already
+  // mounted, and that param going away again (the sidebar link from a pinned URL
+  // changes the URL without remounting) are param changes, and the second one is
+  // bare navigation — back to the remembered tab.
   useEffect(() => {
-    const requested = agentsTabFromParam(tabParam);
-    if (requested) setAgentsTab(requested);
+    setAgentsTab(resolveAgentsTab(tabParam));
   }, [tabParam]);
   const selectAgentsTab = useCallback((next: AgentsTabKey) => {
     setAgentsTab(next);

--- a/ui/src/components/workbench/AgentsPage.tsx
+++ b/ui/src/components/workbench/AgentsPage.tsx
@@ -50,9 +50,9 @@ import {
   type Backend,
 } from '../../lib/backendAccent';
 import { errorMessage } from '@/lib/errorMessage';
-
-type AgentsTabKey = 'definitions' | 'running';
-const AGENTS_TAB_ORDER: AgentsTabKey[] = ['definitions', 'running'];
+// Tab set + its cross-visit memory live together so the remembered value can
+// never name a tab this page no longer renders (see agentsViewMemory).
+import { AGENTS_TAB_ORDER, readAgentsTab, writeAgentsTab, type AgentsTabKey } from '../../lib/agentsViewMemory';
 
 function isSystemAgent(agent: { source: string }): boolean {
   return agent.source === 'builtin' || agent.source === 'system';
@@ -62,7 +62,12 @@ export const AgentsPage: React.FC = () => {
   const { t } = useTranslation();
   const api = useApi();
   const { showToast } = useToast();
-  const [agentsTab, setAgentsTab] = useState<AgentsTabKey>('definitions');
+  // Resume the tab the user left the page on; a fresh browser opens Definitions.
+  const [agentsTab, setAgentsTab] = useState<AgentsTabKey>(readAgentsTab);
+  const selectAgentsTab = useCallback((next: AgentsTabKey) => {
+    setAgentsTab(next);
+    writeAgentsTab(next);
+  }, []);
   const [runningActiveCount, setRunningActiveCount] = useState<number | null>(null);
   const [eventBridgeConnected, setEventBridgeConnected] = useState(false);
   const [agents, setAgents] = useState<VibeAgentBrief[]>([]);
@@ -365,7 +370,7 @@ export const AgentsPage: React.FC = () => {
             <button
               key={key}
               type="button"
-              onClick={() => setAgentsTab(key)}
+              onClick={() => selectAgentsTab(key)}
               className={clsx(
                 'flex shrink-0 items-center gap-2 whitespace-nowrap px-4 py-3 text-[13px] transition',
                 active

--- a/ui/src/components/workbench/HarnessPage.tsx
+++ b/ui/src/components/workbench/HarnessPage.tsx
@@ -2043,7 +2043,9 @@ const DetailAgent: React.FC<{ agentName: string | null; agent?: VibeAgentBrief }
       {meta && <span className="min-w-0 flex-1 truncate font-mono text-[10px] text-muted">{meta}</span>}
       {!agent?.archived && (
         <Link
-          to="/agents"
+          // This opens the agent's definition, so it asks for the Definitions tab
+          // explicitly rather than resuming whichever tab was left on.
+          to="/agents?tab=definitions"
           className="ml-auto inline-flex shrink-0 items-center gap-0.5 text-[11px] font-medium text-violet hover:underline"
         >
           {t('harness.detail.openInAgents')}

--- a/ui/src/lib/agentsViewMemory.test.ts
+++ b/ui/src/lib/agentsViewMemory.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  AGENTS_TAB_ORDER,
+  DEFAULT_AGENTS_TAB,
+  DEFAULT_AGENT_GRAPH_MODE,
+  readAgentGraphMode,
+  readAgentsTab,
+  writeAgentGraphMode,
+  writeAgentsTab,
+} from './agentsViewMemory';
+
+function memoryStorage(initial: Record<string, string> = {}) {
+  const values: Record<string, string> = { ...initial };
+  return {
+    storage: {
+      getItem: vi.fn((key: string) => values[key] ?? null),
+      setItem: vi.fn((key: string, next: string) => {
+        values[key] = next;
+      }),
+    },
+    values: () => values,
+  };
+}
+
+describe('agents view memory', () => {
+  it('defaults to Definitions and 含历史 on a fresh browser', () => {
+    const memory = memoryStorage();
+
+    expect(readAgentsTab(memory.storage)).toBe(DEFAULT_AGENTS_TAB);
+    expect(readAgentsTab(memory.storage)).toBe('definitions');
+    expect(readAgentGraphMode(memory.storage)).toBe(DEFAULT_AGENT_GRAPH_MODE);
+    expect(readAgentGraphMode(memory.storage)).toBe('history');
+  });
+
+  it('resumes the remembered tab and graph mode independently', () => {
+    const memory = memoryStorage();
+
+    writeAgentsTab('running', memory.storage);
+    expect(readAgentsTab(memory.storage)).toBe('running');
+    // Remembering Runs must not disturb the mode inside it.
+    expect(readAgentGraphMode(memory.storage)).toBe('history');
+
+    writeAgentGraphMode('active', memory.storage);
+    expect(readAgentGraphMode(memory.storage)).toBe('active');
+    expect(readAgentsTab(memory.storage)).toBe('running');
+
+    writeAgentsTab('definitions', memory.storage);
+    expect(readAgentsTab(memory.storage)).toBe('definitions');
+    expect(readAgentGraphMode(memory.storage)).toBe('active');
+  });
+
+  it('every tab in the rendered order round-trips', () => {
+    const memory = memoryStorage();
+    for (const tab of AGENTS_TAB_ORDER) {
+      writeAgentsTab(tab, memory.storage);
+      expect(readAgentsTab(memory.storage)).toBe(tab);
+    }
+  });
+
+  it('opens the default when the stored value is not a tab or mode', () => {
+    // A tab removed in a later build, or a hand-edited value, must not select
+    // nothing — it lands on the default.
+    const stale = memoryStorage({
+      'avibe.agents.tab.v1': 'webhooks',
+      'avibe.agents.graph-mode.v1': 'queued',
+    });
+
+    expect(readAgentsTab(stale.storage)).toBe('definitions');
+    expect(readAgentGraphMode(stale.storage)).toBe('history');
+  });
+
+  it('tolerates blocked storage', () => {
+    const blocked = {
+      getItem: () => {
+        throw new Error('blocked');
+      },
+      setItem: () => {
+        throw new Error('blocked');
+      },
+    };
+
+    expect(readAgentsTab(blocked)).toBe('definitions');
+    expect(readAgentGraphMode(blocked)).toBe('history');
+    expect(() => writeAgentsTab('running', blocked)).not.toThrow();
+    expect(() => writeAgentGraphMode('active', blocked)).not.toThrow();
+  });
+});

--- a/ui/src/lib/agentsViewMemory.test.ts
+++ b/ui/src/lib/agentsViewMemory.test.ts
@@ -4,6 +4,7 @@ import {
   AGENTS_TAB_ORDER,
   DEFAULT_AGENTS_TAB,
   DEFAULT_AGENT_GRAPH_MODE,
+  agentsTabFromParam,
   readAgentGraphMode,
   readAgentsTab,
   writeAgentGraphMode,
@@ -68,6 +69,27 @@ describe('agents view memory', () => {
 
     expect(readAgentsTab(stale.storage)).toBe('definitions');
     expect(readAgentGraphMode(stale.storage)).toBe('history');
+  });
+
+  it('reads a contextual ?tab= intent for every tab and nothing else', () => {
+    for (const tab of AGENTS_TAB_ORDER) {
+      expect(agentsTabFromParam(tab)).toBe(tab);
+    }
+    // No intent ⇒ null, so the caller resumes the remembered tab instead of
+    // being forced onto a default.
+    for (const absent of [null, undefined, '', 'webhooks', 'Definitions']) {
+      expect(agentsTabFromParam(absent)).toBeNull();
+    }
+  });
+
+  it('a contextual ?tab= destination never rewrites the remembered tab', () => {
+    const memory = memoryStorage();
+    writeAgentsTab('running', memory.storage);
+
+    // Resolving an explicit destination is a pure read — only an actual tab
+    // click (writeAgentsTab) may change what the next bare visit opens.
+    expect(agentsTabFromParam('definitions')).toBe('definitions');
+    expect(readAgentsTab(memory.storage)).toBe('running');
   });
 
   it('tolerates blocked storage', () => {

--- a/ui/src/lib/agentsViewMemory.test.ts
+++ b/ui/src/lib/agentsViewMemory.test.ts
@@ -7,6 +7,7 @@ import {
   agentsTabFromParam,
   readAgentGraphMode,
   readAgentsTab,
+  resolveAgentsTab,
   writeAgentGraphMode,
   writeAgentsTab,
 } from './agentsViewMemory';
@@ -89,7 +90,21 @@ describe('agents view memory', () => {
     // Resolving an explicit destination is a pure read — only an actual tab
     // click (writeAgentsTab) may change what the next bare visit opens.
     expect(agentsTabFromParam('definitions')).toBe('definitions');
+    expect(resolveAgentsTab('definitions', memory.storage)).toBe('definitions');
     expect(readAgentsTab(memory.storage)).toBe('running');
+  });
+
+  it('resolves ?tab= while present and the remembered tab the moment it is gone', () => {
+    const memory = memoryStorage();
+    writeAgentsTab('running', memory.storage);
+
+    // A pinned destination, then the same URL without it (the sidebar link from a
+    // pinned URL) — the second resolution is bare navigation again, so the
+    // remembered tab comes back instead of the destination sticking.
+    expect(resolveAgentsTab('definitions', memory.storage)).toBe('definitions');
+    expect(resolveAgentsTab(null, memory.storage)).toBe('running');
+    // An unknown value is no intent at all, so it resumes the memory too.
+    expect(resolveAgentsTab('webhooks', memory.storage)).toBe('running');
   });
 
   it('tolerates blocked storage', () => {

--- a/ui/src/lib/agentsViewMemory.ts
+++ b/ui/src/lib/agentsViewMemory.ts
@@ -45,6 +45,16 @@ export function readAgentsTab(storage?: ViewStorage): AgentsTabKey {
   return read(TAB_STORAGE_KEY, AGENTS_TAB_ORDER, DEFAULT_AGENTS_TAB, storage);
 }
 
+// A contextual link that needs a specific tab says so with ``?tab=`` — e.g.
+// "New agent" / "Open in Agents" both need the Definitions controls, not the run
+// graph, whichever tab the user happens to have left the page on. Unlike
+// harnessTabFromParam this returns null rather than the default for an absent or
+// unknown value, because here "no explicit intent" means *resume the remembered
+// tab*, which only the caller can fall back to.
+export function agentsTabFromParam(param: string | null | undefined): AgentsTabKey | null {
+  return (AGENTS_TAB_ORDER as string[]).includes(param ?? '') ? (param as AgentsTabKey) : null;
+}
+
 export function writeAgentsTab(tab: AgentsTabKey, storage?: ViewStorage): void {
   write(TAB_STORAGE_KEY, tab, storage);
 }

--- a/ui/src/lib/agentsViewMemory.ts
+++ b/ui/src/lib/agentsViewMemory.ts
@@ -55,6 +55,16 @@ export function agentsTabFromParam(param: string | null | undefined): AgentsTabK
   return (AGENTS_TAB_ORDER as string[]).includes(param ?? '') ? (param as AgentsTabKey) : null;
 }
 
+// Which tab the current URL should show: the ``?tab=`` destination while it is
+// there, the remembered tab otherwise. One function so the page resolves mount
+// and every later param change the same way — the param can disappear without a
+// remount (clicking the sidebar link from a pinned URL), and that is bare
+// navigation again, so it must go back to the remembered tab rather than keep
+// whatever the pinned one left on screen.
+export function resolveAgentsTab(param: string | null | undefined, storage?: ViewStorage): AgentsTabKey {
+  return agentsTabFromParam(param) ?? readAgentsTab(storage);
+}
+
 export function writeAgentsTab(tab: AgentsTabKey, storage?: ViewStorage): void {
   write(TAB_STORAGE_KEY, tab, storage);
 }

--- a/ui/src/lib/agentsViewMemory.ts
+++ b/ui/src/lib/agentsViewMemory.ts
@@ -1,0 +1,63 @@
+// Remembers which view the Agents surface was left on, so re-entering it from
+// the sidebar resumes where the user was instead of always reopening
+// Definitions. Two independent memories because they are nested: the page tab
+// (Definitions / Runs) and, inside Runs, the run-graph 活跃/含历史 mode.
+//
+// Storage conventions mirror chatViewMemory: versioned `avibe.*` key, injectable
+// storage for tests, best-effort try/catch so private mode / blocked storage
+// degrades to the defaults rather than throwing.
+export type AgentsTabKey = 'definitions' | 'running';
+export type AgentGraphMode = 'active' | 'history';
+
+export const AGENTS_TAB_ORDER: AgentsTabKey[] = ['definitions', 'running'];
+export const DEFAULT_AGENTS_TAB: AgentsTabKey = 'definitions';
+export const DEFAULT_AGENT_GRAPH_MODE: AgentGraphMode = 'history';
+
+const TAB_STORAGE_KEY = 'avibe.agents.tab.v1';
+const GRAPH_MODE_STORAGE_KEY = 'avibe.agents.graph-mode.v1';
+
+type ViewStorage = Pick<Storage, 'getItem' | 'setItem'>;
+
+function browserStorage(storage?: ViewStorage): ViewStorage | undefined {
+  return storage ?? (typeof window !== 'undefined' ? window.localStorage : undefined);
+}
+
+function read<T extends string>(key: string, allowed: readonly T[], fallback: T, storage?: ViewStorage): T {
+  try {
+    const raw = browserStorage(storage)?.getItem(key);
+    // An unknown value (older build, hand-edited storage, removed tab) opens the
+    // default rather than selecting nothing.
+    return (allowed as readonly string[]).includes(raw ?? '') ? (raw as T) : fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+function write(key: string, value: string, storage?: ViewStorage): void {
+  try {
+    browserStorage(storage)?.setItem(key, value);
+  } catch {
+    // View memory is best-effort in private browsing and restricted storage contexts.
+  }
+}
+
+export function readAgentsTab(storage?: ViewStorage): AgentsTabKey {
+  return read(TAB_STORAGE_KEY, AGENTS_TAB_ORDER, DEFAULT_AGENTS_TAB, storage);
+}
+
+export function writeAgentsTab(tab: AgentsTabKey, storage?: ViewStorage): void {
+  write(TAB_STORAGE_KEY, tab, storage);
+}
+
+export function readAgentGraphMode(storage?: ViewStorage): AgentGraphMode {
+  return read(
+    GRAPH_MODE_STORAGE_KEY,
+    ['active', 'history'] as const,
+    DEFAULT_AGENT_GRAPH_MODE,
+    storage,
+  );
+}
+
+export function writeAgentGraphMode(mode: AgentGraphMode, storage?: ViewStorage): void {
+  write(GRAPH_MODE_STORAGE_KEY, mode, storage);
+}


### PR DESCRIPTION
## Capability

Agents surface view memory: re-entering **Agents** from the sidebar resumes the tab it was left on (Definitions / Runs) instead of always reopening Definitions, and inside Runs the 活跃/含历史 segmented mode is remembered too.

Before: `AgentsPage` hardcoded `useState('definitions')` and `AgentGraphTab` hardcoded `useState('history')`, so every visit reset both. The sidebar link carries no `?tab=`, so a URL param alone cannot fix this.

## Changes

- `ui/src/lib/agentsViewMemory.ts` (new): versioned `avibe.agents.tab.v1` / `avibe.agents.graph-mode.v1` localStorage memory with injectable storage, following the `chatViewMemory` conventions. The tab set (`AGENTS_TAB_ORDER`) now lives next to its memory, so a remembered value can never name a tab the page no longer renders — an unknown/stale value opens the default.
- `AgentsPage.tsx`: initialize the tab from memory; persist on tab click.
- `AgentGraphTab.tsx`: initialize `mode` from memory; persist only on an explicit segmented-control click. The search-locate path that widens `active -> history` to surface an out-of-view node stays **transient** and does not overwrite the preference — the same ruling already applied to the disabled-trigger reveal.

Defaults for a fresh browser are unchanged: Definitions + 含历史.

## Evidence

- Unit: `ui/src/lib/agentsViewMemory.test.ts` — defaults, independent tab/mode round-trip, every tab in the rendered order, stale/unknown value falls back to the default, blocked storage tolerated. `npx vitest run src/lib/agentsViewMemory.test.ts` → 5 passed.
- Contract/scenario: no catalog covers this surface; no scenario IDs affected.
- Build/lint: `npm run build` (incl. `tsc -b`) and `npm run lint` pass in `ui/`.
- Residual manual check: Agents → Runs → 活跃, navigate away, click Agents again → lands on Runs / 活跃; a search-reveal that widens to 含历史 does not stick after leaving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)