### PR TITLE
refactor(memory): own private SQLite transactions

### DIFF
--- a/core/memory/backup_restore_journal.py
+++ b/core/memory/backup_restore_journal.py
@@ -7,6 +7,7 @@ import os
 import re
 import secrets
 import sqlite3
+from contextlib import AbstractContextManager
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -106,45 +107,36 @@ class MemoryBackupRestoreJournal:
         operation_id = secrets.token_hex(16)
         token = secrets.token_hex(16)
         now = _utc_now()
-        connection = self._connect()
         try:
-            connection.execute("BEGIN IMMEDIATE")
-            connection.execute(
-                """
-                INSERT INTO backup_restore_operation (
-                    operation_id, backup_id, manifest_sha256, surface_digests_json,
-                    state, started_at, updated_at, attempt_count, open_slot,
-                    revision, execution_token
-                ) VALUES (?, ?, ?, ?, 'restoring', ?, ?, 1, 1, 1, ?)
-                """,
-                (
+            with self._transaction() as connection:
+                connection.execute(
+                    """
+                    INSERT INTO backup_restore_operation (
+                        operation_id, backup_id, manifest_sha256, surface_digests_json,
+                        state, started_at, updated_at, attempt_count, open_slot,
+                        revision, execution_token
+                    ) VALUES (?, ?, ?, ?, 'restoring', ?, ?, 1, 1, 1, ?)
+                    """,
+                    (
+                        operation_id,
+                        backup_id,
+                        manifest,
+                        _encode_digests(digests),
+                        now,
+                        now,
+                        token,
+                    ),
+                )
+                self._append_event(
+                    connection,
                     operation_id,
-                    backup_id,
-                    manifest,
-                    _encode_digests(digests),
-                    now,
-                    now,
-                    token,
-                ),
-            )
-            self._append_event(
-                connection,
-                operation_id,
-                "started",
-                "system:runtime",
-                occurred_at=now,
-                resulting_revision=1,
-            )
-            connection.commit()
+                    "started",
+                    "system:runtime",
+                    occurred_at=now,
+                    resulting_revision=1,
+                )
         except sqlite3.IntegrityError as error:
-            connection.rollback()
             raise BackupRestoreConflict("a Memory backup restore is already open") from error
-        except Exception:
-            connection.rollback()
-            raise
-        finally:
-            connection.close()
-            self._harden_database_files()
         return self._require_operation(operation_id)
 
     def get_operation(self, operation_id: str) -> BackupRestoreOperation | None:
@@ -193,14 +185,11 @@ class MemoryBackupRestoreJournal:
     def mark_boot_recovery_needed(self) -> BackupRestoreOperation | None:
         """Release a dead process claim while retaining the restore fence."""
 
-        connection = self._connect()
-        try:
-            connection.execute("BEGIN IMMEDIATE")
+        with self._transaction() as connection:
             row = connection.execute(
                 "SELECT * FROM backup_restore_operation WHERE open_slot = 1"
             ).fetchone()
             if row is None:
-                connection.commit()
                 return None
             now = _utc_now()
             revision = row["revision"] + 1
@@ -222,14 +211,7 @@ class MemoryBackupRestoreJournal:
                 resulting_revision=revision,
                 error_code="memory_clear_failed",
             )
-            connection.commit()
             identifier = row["operation_id"]
-        except Exception:
-            connection.rollback()
-            raise
-        finally:
-            connection.close()
-            self._harden_database_files()
         return self._require_operation(identifier)
 
     def claim_retry(
@@ -241,9 +223,7 @@ class MemoryBackupRestoreJournal:
     ) -> BackupRestoreOperation:
         identifier = _validated_operation_id(operation_id)
         actor = _validated_actor(actor_ref)
-        connection = self._connect()
-        try:
-            connection.execute("BEGIN IMMEDIATE")
+        with self._transaction() as connection:
             row = self._require_row(
                 connection,
                 identifier,
@@ -271,13 +251,6 @@ class MemoryBackupRestoreJournal:
                 occurred_at=now,
                 resulting_revision=revision,
             )
-            connection.commit()
-        except Exception:
-            connection.rollback()
-            raise
-        finally:
-            connection.close()
-            self._harden_database_files()
         return self._require_operation(identifier)
 
     def mark_recovery_needed(
@@ -332,9 +305,7 @@ class MemoryBackupRestoreJournal:
         identifier = _validated_operation_id(operation_id)
         token = _validated_token(execution_token)
         actor = _validated_actor(actor_ref)
-        connection = self._connect()
-        try:
-            connection.execute("BEGIN IMMEDIATE")
+        with self._transaction() as connection:
             row = self._require_row(
                 connection,
                 identifier,
@@ -371,13 +342,6 @@ class MemoryBackupRestoreJournal:
                 resulting_revision=revision,
                 error_code=error_code,
             )
-            connection.commit()
-        except Exception:
-            connection.rollback()
-            raise
-        finally:
-            connection.close()
-            self._harden_database_files()
         return self._require_operation(identifier)
 
     @staticmethod
@@ -488,6 +452,16 @@ class MemoryBackupRestoreJournal:
             raise MemoryBackupRestoreJournalError(
                 "Memory backup restore journal is unsafe"
             ) from error
+
+    def _transaction(self) -> AbstractContextManager[sqlite3.Connection]:
+        return self._database.transaction(
+            translate_connect_error=lambda _error: MemoryBackupRestoreJournalError(
+                "Memory backup restore journal is unsafe"
+            ),
+            translate_harden_error=lambda _error: MemoryBackupRestoreJournalError(
+                "Memory backup restore journal files could not be hardened safely"
+            ),
+        )
 
     def _harden_database_files(self, *, sync_parent: bool = False) -> None:
         try:

--- a/core/memory/clear_journal.py
+++ b/core/memory/clear_journal.py
@@ -11,6 +11,7 @@ import os
 import re
 import secrets
 import sqlite3
+from contextlib import AbstractContextManager
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path, PurePosixPath
@@ -206,50 +207,41 @@ class MemoryClearJournal:
         _validated_epoch_pair(pre_epoch, target_epoch)
         now = _utc_now()
         token = secrets.token_hex(16)
-        connection = self._connect()
         try:
-            connection.execute("BEGIN IMMEDIATE")
-            connection.execute(
-                """
-                INSERT INTO clear_operation (
-                    operation_id, operator_ref, state, started_at, updated_at,
-                    pre_epoch, target_epoch, destructive_started, open_slot,
-                    revision, execution_token
-                ) VALUES (?, ?, 'preparing', ?, ?, ?, ?, 0, 1, 1, ?)
-                """,
-                (identifier, actor, now, now, pre_epoch, target_epoch, token),
-            )
-            connection.executemany(
-                """
-                INSERT INTO clear_surface (
-                    operation_id, surface, relative_path, state, updated_at
-                ) VALUES (?, ?, ?, 'pending', ?)
-                """,
-                [
-                    (identifier, surface.name, surface.relative_path, now)
-                    for surface in self._surfaces
-                ],
-            )
-            self._append_event(
-                connection,
-                identifier,
-                "started",
-                actor,
-                occurred_at=now,
-                resulting_revision=1,
-            )
-            connection.commit()
+            with self._transaction() as connection:
+                connection.execute(
+                    """
+                    INSERT INTO clear_operation (
+                        operation_id, operator_ref, state, started_at, updated_at,
+                        pre_epoch, target_epoch, destructive_started, open_slot,
+                        revision, execution_token
+                    ) VALUES (?, ?, 'preparing', ?, ?, ?, ?, 0, 1, 1, ?)
+                    """,
+                    (identifier, actor, now, now, pre_epoch, target_epoch, token),
+                )
+                connection.executemany(
+                    """
+                    INSERT INTO clear_surface (
+                        operation_id, surface, relative_path, state, updated_at
+                    ) VALUES (?, ?, ?, 'pending', ?)
+                    """,
+                    [
+                        (identifier, surface.name, surface.relative_path, now)
+                        for surface in self._surfaces
+                    ],
+                )
+                self._append_event(
+                    connection,
+                    identifier,
+                    "started",
+                    actor,
+                    occurred_at=now,
+                    resulting_revision=1,
+                )
         except sqlite3.IntegrityError as error:
-            connection.rollback()
             if self.get_open_operation() is not None:
                 raise ClearOperationConflict("a Memory clear operation is already open") from error
             raise MemoryClearJournalError("Memory clear journal rejected the operation") from error
-        except Exception:
-            connection.rollback()
-            raise
-        finally:
-            connection.close()
-            self._harden_database_files()
         return self._require_operation(identifier)
 
     def get_operation(self, operation_id: str) -> ClearOperation | None:
@@ -405,9 +397,7 @@ class MemoryClearJournal:
         if set(receipts) != expected_paths or len(receipts) != len(snapshot.surface_receipts):
             raise ValueError("Memory snapshot receipt must cover exactly four surfaces")
 
-        connection = self._connect()
-        try:
-            connection.execute("BEGIN IMMEDIATE")
+        with self._transaction() as connection:
             row = self._cas_row(
                 connection,
                 identifier,
@@ -467,13 +457,6 @@ class MemoryClearJournal:
                 """,
                 (relative_snapshot, manifest_digest, now, revision, identifier),
             )
-            connection.commit()
-        except Exception:
-            connection.rollback()
-            raise
-        finally:
-            connection.close()
-            self._harden_database_files()
         return self._require_operation(identifier)
 
     def mark_prepared(
@@ -486,9 +469,7 @@ class MemoryClearJournal:
         """Seal the independently verified snapshot before destructive work."""
 
         identifier = _validated_operation_id(operation_id)
-        connection = self._connect()
-        try:
-            connection.execute("BEGIN IMMEDIATE")
+        with self._transaction() as connection:
             row = self._cas_row(
                 connection,
                 identifier,
@@ -531,13 +512,6 @@ class MemoryClearJournal:
                 occurred_at=now,
                 resulting_revision=revision,
             )
-            connection.commit()
-        except Exception:
-            connection.rollback()
-            raise
-        finally:
-            connection.close()
-            self._harden_database_files()
         return self._require_operation(identifier)
 
     def begin_deleting(
@@ -590,9 +564,7 @@ class MemoryClearJournal:
         """Close a clear only after all four deletion receipts are durable."""
 
         identifier = _validated_operation_id(operation_id)
-        connection = self._connect()
-        try:
-            connection.execute("BEGIN IMMEDIATE")
+        with self._transaction() as connection:
             row = self._cas_row(
                 connection,
                 identifier,
@@ -628,13 +600,6 @@ class MemoryClearJournal:
                 occurred_at=now,
                 resulting_revision=revision,
             )
-            connection.commit()
-        except Exception:
-            connection.rollback()
-            raise
-        finally:
-            connection.close()
-            self._harden_database_files()
         return self._require_operation(identifier)
 
     def mark_recovery_needed(
@@ -649,9 +614,7 @@ class MemoryClearJournal:
 
         identifier = _validated_operation_id(operation_id)
         error = _validated_error(closed_error)
-        connection = self._connect()
-        try:
-            connection.execute("BEGIN IMMEDIATE")
+        with self._transaction() as connection:
             row = self._cas_row(
                 connection,
                 identifier,
@@ -680,13 +643,6 @@ class MemoryClearJournal:
                 closed_error=error,
                 resulting_revision=revision,
             )
-            connection.commit()
-        except Exception:
-            connection.rollback()
-            raise
-        finally:
-            connection.close()
-            self._harden_database_files()
         return self._require_operation(identifier)
 
     def mark_boot_recovery_needed(
@@ -702,14 +658,11 @@ class MemoryClearJournal:
         """
 
         error = _validated_error(closed_error)
-        connection = self._connect()
-        try:
-            connection.execute("BEGIN IMMEDIATE")
+        with self._transaction() as connection:
             row = connection.execute(
                 "SELECT * FROM clear_operation WHERE open_slot = 1"
             ).fetchone()
             if row is None:
-                connection.commit()
                 return None
             now = _utc_now()
             revision = row["revision"] + 1
@@ -737,13 +690,6 @@ class MemoryClearJournal:
                 closed_error=error,
                 resulting_revision=revision,
             )
-            connection.commit()
-        except Exception:
-            connection.rollback()
-            raise
-        finally:
-            connection.close()
-            self._harden_database_files()
         return self._require_operation(row["operation_id"])
 
     def claim_resume(
@@ -757,9 +703,7 @@ class MemoryClearJournal:
 
         identifier = _validated_operation_id(operation_id)
         actor = _validated_actor(operator_ref)
-        connection = self._connect()
-        try:
-            connection.execute("BEGIN IMMEDIATE")
+        with self._transaction() as connection:
             row = self._recovery_claim_row(connection, identifier, actor, expected_revision)
             if row["resolution"] == "abort":
                 raise ClearTransitionError("an abort decision cannot be changed to resume")
@@ -786,13 +730,6 @@ class MemoryClearJournal:
                 occurred_at=now,
                 resulting_revision=revision,
             )
-            connection.commit()
-        except Exception:
-            connection.rollback()
-            raise
-        finally:
-            connection.close()
-            self._harden_database_files()
         return self._require_operation(identifier)
 
     def claim_abort(
@@ -806,9 +743,7 @@ class MemoryClearJournal:
 
         identifier = _validated_operation_id(operation_id)
         actor = _validated_actor(operator_ref)
-        connection = self._connect()
-        try:
-            connection.execute("BEGIN IMMEDIATE")
+        with self._transaction() as connection:
             row = self._recovery_claim_row(connection, identifier, actor, expected_revision)
             if row["resolution"] == "resume":
                 raise ClearTransitionError("a resume decision cannot be changed to abort")
@@ -834,13 +769,6 @@ class MemoryClearJournal:
                 occurred_at=now,
                 resulting_revision=revision,
             )
-            connection.commit()
-        except Exception:
-            connection.rollback()
-            raise
-        finally:
-            connection.close()
-            self._harden_database_files()
         return self._require_operation(identifier)
 
     def release_recovery_claim(
@@ -855,9 +783,7 @@ class MemoryClearJournal:
 
         identifier = _validated_operation_id(operation_id)
         error = _validated_error(closed_error)
-        connection = self._connect()
-        try:
-            connection.execute("BEGIN IMMEDIATE")
+        with self._transaction() as connection:
             row = self._cas_row(
                 connection,
                 identifier,
@@ -887,13 +813,6 @@ class MemoryClearJournal:
                 closed_error=error,
                 resulting_revision=revision,
             )
-            connection.commit()
-        except Exception:
-            connection.rollback()
-            raise
-        finally:
-            connection.close()
-            self._harden_database_files()
         return self._require_operation(identifier)
 
     def record_surface_restored(
@@ -930,9 +849,7 @@ class MemoryClearJournal:
 
         identifier = _validated_operation_id(operation_id)
         error = _validated_optional_error(closed_error)
-        connection = self._connect()
-        try:
-            connection.execute("BEGIN IMMEDIATE")
+        with self._transaction() as connection:
             row = self._cas_row(
                 connection,
                 identifier,
@@ -971,13 +888,6 @@ class MemoryClearJournal:
                 closed_error=error,
                 resulting_revision=revision,
             )
-            connection.commit()
-        except Exception:
-            connection.rollback()
-            raise
-        finally:
-            connection.close()
-            self._harden_database_files()
         return self._require_operation(identifier)
 
     def _initialize(self) -> None:
@@ -1020,6 +930,16 @@ class MemoryClearJournal:
             return self._database.connect()
         except ConfinedFilesystemError as error:
             raise MemoryClearJournalError("Memory clear journal is unsafe") from error
+
+    def _transaction(self) -> AbstractContextManager[sqlite3.Connection]:
+        return self._database.transaction(
+            translate_connect_error=lambda _error: MemoryClearJournalError(
+                "Memory clear journal is unsafe"
+            ),
+            translate_harden_error=lambda _error: MemoryClearJournalError(
+                "Memory clear journal files could not be hardened safely"
+            ),
+        )
 
     def _validate_surfaces(self) -> None:
         if len(self._surfaces) != len(_SURFACE_NAMES):
@@ -1162,9 +1082,7 @@ class MemoryClearJournal:
         values = dict(assignments or {})
         if not set(values).issubset(allowed_assignments):
             raise ValueError("unsupported Memory clear journal assignment")
-        connection = self._connect()
-        try:
-            connection.execute("BEGIN IMMEDIATE")
+        with self._transaction() as connection:
             row = self._cas_row(
                 connection,
                 identifier,
@@ -1192,13 +1110,6 @@ class MemoryClearJournal:
                 occurred_at=now,
                 resulting_revision=revision,
             )
-            connection.commit()
-        except Exception:
-            connection.rollback()
-            raise
-        finally:
-            connection.close()
-            self._harden_database_files()
         return self._require_operation(identifier)
 
     def _surface_transition(
@@ -1223,9 +1134,7 @@ class MemoryClearJournal:
         values = dict(assignments or {})
         if not set(values).issubset(allowed_assignments):
             raise ValueError("unsupported Memory clear surface assignment")
-        connection = self._connect()
-        try:
-            connection.execute("BEGIN IMMEDIATE")
+        with self._transaction() as connection:
             row = self._cas_row(
                 connection,
                 operation_id,
@@ -1277,13 +1186,6 @@ class MemoryClearJournal:
                 occurred_at=now,
                 resulting_revision=revision,
             )
-            connection.commit()
-        except Exception:
-            connection.rollback()
-            raise
-        finally:
-            connection.close()
-            self._harden_database_files()
         return self._require_operation(operation_id)
 
     @staticmethod

--- a/core/memory/clear_snapshot_storage.py
+++ b/core/memory/clear_snapshot_storage.py
@@ -46,9 +46,7 @@ class MemoryClearSnapshotStorage:
         """Discard one exact unrecorded preparing snapshot and journal the result."""
 
         identifier = _validated_operation_id(operation_id)
-        connection = self._journal._connect()
-        try:
-            connection.execute("BEGIN IMMEDIATE")
+        with self._journal._transaction() as connection:
             row = self._journal._cas_row(
                 connection,
                 identifier,
@@ -108,13 +106,6 @@ class MemoryClearSnapshotStorage:
                 occurred_at=now,
                 resulting_revision=revision,
             )
-            connection.commit()
-        except BaseException:
-            connection.rollback()
-            raise
-        finally:
-            connection.close()
-            self._journal._harden_database_files()
         return self._journal._require_operation(identifier)
 
     def eligible_terminal_snapshot_ids(self) -> tuple[str, ...]:

--- a/core/memory/confined_filesystem.py
+++ b/core/memory/confined_filesystem.py
@@ -6,6 +6,8 @@ import os
 import sqlite3
 import stat
 from collections import OrderedDict
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Sequence
@@ -66,14 +68,76 @@ class PrivateSqliteDatabase:
             self._path,
             timeout=PRIVATE_SQLITE_BUSY_TIMEOUT_SECONDS,
         )
-        connection.row_factory = sqlite3.Row
-        connection.execute("PRAGMA foreign_keys=ON")
-        connection.execute(
-            f"PRAGMA busy_timeout={int(PRIVATE_SQLITE_BUSY_TIMEOUT_SECONDS * 1000)}"
-        )
-        connection.execute("PRAGMA journal_mode=WAL")
-        connection.execute("PRAGMA synchronous=FULL")
+        try:
+            connection.row_factory = sqlite3.Row
+            connection.execute("PRAGMA foreign_keys=ON")
+            connection.execute(
+                f"PRAGMA busy_timeout={int(PRIVATE_SQLITE_BUSY_TIMEOUT_SECONDS * 1000)}"
+            )
+            connection.execute("PRAGMA journal_mode=WAL")
+            connection.execute("PRAGMA synchronous=FULL")
+        except BaseException:
+            try:
+                connection.close()
+            except BaseException:
+                pass
+            raise
         return connection
+
+    @contextmanager
+    def transaction(
+        self,
+        *,
+        translate_connect_error: Callable[[ConfinedFilesystemError], Exception]
+        | None = None,
+        translate_harden_error: Callable[[ConfinedFilesystemError], Exception]
+        | None = None,
+    ) -> Iterator[sqlite3.Connection]:
+        """Own one immediate transaction through commit and file hardening.
+
+        Translation callbacks preserve an owner's public errors without moving
+        domain-specific exception types into this filesystem module.
+        """
+
+        try:
+            connection = self.connect()
+        except ConfinedFilesystemError as error:
+            if translate_connect_error is None:
+                raise
+            raise translate_connect_error(error) from error
+        try:
+            connection.execute("BEGIN IMMEDIATE")
+            yield connection
+            connection.commit()
+        except BaseException:
+            # Cleanup is bounded and cannot replace the transaction failure.
+            try:
+                connection.rollback()
+            except BaseException:
+                pass
+            try:
+                connection.close()
+            except BaseException:
+                pass
+            try:
+                self.harden()
+            except BaseException:
+                pass
+            raise
+        try:
+            connection.close()
+        except BaseException:
+            try:
+                self.harden()
+            except BaseException:
+                pass
+            raise
+        try:
+            self.harden()
+        except ConfinedFilesystemError as error:
+            if translate_harden_error is None:
+                raise
+            raise translate_harden_error(error) from error
 
     def harden(self, *, sync_parent: bool = False) -> None:
         """Set owner-only modes after SQLite may have created sidecar files."""

--- a/core/memory/store.py
+++ b/core/memory/store.py
@@ -2883,6 +2883,7 @@ class MemoryStore:
 
     def _initialize(self) -> None:
         schema_sql = Path(__file__).with_name("schema.sql").read_text(encoding="utf-8")
+        # Store migrations deliberately compose on this already-open connection.
         with self._connection() as conn:
             version = int(conn.execute("PRAGMA user_version").fetchone()[0])
             application_tables = _application_tables(conn)
@@ -2910,6 +2911,12 @@ class MemoryStore:
 
     @contextmanager
     def _transaction(self) -> Iterator[sqlite3.Connection]:
+        """Transact on the Store's already-open connection.
+
+        Store migrations and composed writes intentionally retain this path;
+        ``PrivateSqliteDatabase.transaction`` owns newly opened connections.
+        """
+
         with self._connection() as conn:
             conn.execute("BEGIN IMMEDIATE")
             try:

--- a/tests/test_memory_backup_restore_journal.py
+++ b/tests/test_memory_backup_restore_journal.py
@@ -8,6 +8,7 @@ from core.memory.backup_restore_journal import (
     BackupRestoreCASMismatch,
     BackupRestoreConflict,
     MemoryBackupRestoreJournal,
+    MemoryBackupRestoreJournalError,
 )
 from core.memory.snapshot import MemorySnapshotManager
 
@@ -91,3 +92,32 @@ def test_restore_journal_keeps_one_open_operation_until_completion(tmp_path: Pat
             expected_revision=operation.revision,
             actor_ref="system:runtime",
         )
+
+
+def test_restore_journal_translates_hardening_failure_after_durable_commit(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home, snapshot = _snapshot(tmp_path)
+    journal = MemoryBackupRestoreJournal(home)
+
+    from core.memory import confined_filesystem
+
+    real_chmod = confined_filesystem.os.chmod
+
+    def fail_journal_hardening(target, mode: int) -> None:
+        if Path(target) == journal.database_path and mode == 0o600:
+            raise confined_filesystem.ConfinedFilesystemError("unsafe journal")
+        real_chmod(target, mode)
+
+    monkeypatch.setattr(confined_filesystem.os, "chmod", fail_journal_hardening)
+
+    with pytest.raises(
+        MemoryBackupRestoreJournalError,
+        match="Memory backup restore journal files could not be hardened safely",
+    ):
+        journal.start(snapshot)
+
+    committed = journal.get_open_operation()
+    assert committed is not None
+    assert committed.backup_id == snapshot.snapshot_id

--- a/tests/test_memory_clear_journal.py
+++ b/tests/test_memory_clear_journal.py
@@ -484,6 +484,101 @@ def test_concurrent_starts_create_exactly_one_open_operation(tmp_path: Path) -> 
     assert journal.get_open_operation() == winners[0]
 
 
+def test_clear_journal_preserves_commit_failure_when_close_cleanup_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    journal = _journal(tmp_path)
+    commit_error = sqlite3.OperationalError("commit failed")
+    real_connect = sqlite3.connect
+
+    class FailingConnection(sqlite3.Connection):
+        def commit(self) -> None:
+            raise commit_error
+
+        def close(self) -> None:
+            super().close()
+            raise OSError("close cleanup failed")
+
+    def connect(*args, **kwargs):
+        return real_connect(*args, **kwargs, factory=FailingConnection)
+
+    from core.memory import confined_filesystem
+
+    monkeypatch.setattr(confined_filesystem.sqlite3, "connect", connect)
+
+    with pytest.raises(sqlite3.OperationalError) as raised:
+        journal.start(
+            operation_id="commit-failure",
+            operator_ref="user:owner",
+            pre_epoch=0,
+            target_epoch=1,
+        )
+
+    assert raised.value is commit_error
+
+
+def test_clear_journal_translates_hardening_failure_after_durable_commit(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    journal = _journal(tmp_path)
+
+    from core.memory import confined_filesystem
+
+    real_chmod = confined_filesystem.os.chmod
+
+    def fail_journal_hardening(target, mode: int) -> None:
+        if Path(target) == journal.database_path and mode == 0o600:
+            raise confined_filesystem.ConfinedFilesystemError("unsafe journal")
+        real_chmod(target, mode)
+
+    monkeypatch.setattr(confined_filesystem.os, "chmod", fail_journal_hardening)
+
+    with pytest.raises(
+        MemoryClearJournalError,
+        match="Memory clear journal files could not be hardened safely",
+    ):
+        journal.start(
+            operation_id="harden-failure",
+            operator_ref="user:owner",
+            pre_epoch=0,
+            target_epoch=1,
+        )
+
+    committed = journal.get_operation("harden-failure")
+    assert committed is not None
+    assert committed.state == "preparing"
+
+
+def test_clear_journal_keeps_sqlite_busy_failure_public(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    journal = _journal(tmp_path)
+    blocker = sqlite3.connect(journal.database_path)
+    blocker.execute("BEGIN IMMEDIATE")
+
+    from core.memory import confined_filesystem
+
+    monkeypatch.setattr(
+        confined_filesystem,
+        "PRIVATE_SQLITE_BUSY_TIMEOUT_SECONDS",
+        0.001,
+    )
+    try:
+        with pytest.raises(sqlite3.OperationalError, match="locked"):
+            journal.start(
+                operation_id="busy-failure",
+                operator_ref="user:owner",
+                pre_epoch=0,
+                target_epoch=1,
+            )
+    finally:
+        blocker.rollback()
+        blocker.close()
+
+
 def test_terminal_headers_and_events_are_immutable_in_sqlite(tmp_path: Path) -> None:
     journal = _journal(tmp_path)
     operation = journal.start(

--- a/tests/test_memory_confined_filesystem.py
+++ b/tests/test_memory_confined_filesystem.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import sqlite3
 import stat
 from pathlib import Path
 
@@ -72,6 +73,331 @@ def test_private_sqlite_database_prepares_and_hardens_owned_files(tmp_path: Path
     assert path.stat().st_mode & 0o777 == 0o600
     assert path.parent.stat().st_mode & 0o777 == 0o700
     assert home.stat().st_mode & 0o777 == 0o700
+
+
+def test_private_sqlite_transaction_commits_before_hardening(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home = tmp_path / "home"
+    path = home / "state" / "journal.sqlite"
+    database = PrivateSqliteDatabase(home, path)
+    database.prepare()
+    events: list[str] = []
+
+    real_connect = sqlite3.connect
+
+    class TrackingConnection(sqlite3.Connection):
+        def execute(self, sql: str, parameters=(), /):
+            if sql == "BEGIN IMMEDIATE":
+                events.append("begin")
+            return super().execute(sql, parameters)
+
+        def commit(self) -> None:
+            events.append("commit")
+            super().commit()
+
+        def close(self) -> None:
+            events.append("close")
+            super().close()
+
+    def connect(*args, **kwargs):
+        return real_connect(*args, **kwargs, factory=TrackingConnection)
+
+    from core.memory import confined_filesystem
+
+    real_chmod = confined_filesystem.os.chmod
+
+    def chmod(target, mode: int) -> None:
+        if Path(target) == path and mode == 0o600:
+            events.append("harden")
+        real_chmod(target, mode)
+
+    monkeypatch.setattr(confined_filesystem.sqlite3, "connect", connect)
+    monkeypatch.setattr(confined_filesystem.os, "chmod", chmod)
+
+    with database.transaction() as connection:
+        connection.execute("CREATE TABLE item (value TEXT NOT NULL)")
+        connection.execute("INSERT INTO item VALUES ('committed')")
+
+    with real_connect(path) as connection:
+        assert connection.execute("SELECT value FROM item").fetchone() == (
+            "committed",
+        )
+    assert events == ["begin", "commit", "close", "harden"]
+
+
+def test_private_sqlite_transaction_body_failure_remains_primary_during_cleanup(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home = tmp_path / "home"
+    path = home / "state" / "journal.sqlite"
+    database = PrivateSqliteDatabase(home, path)
+    database.prepare()
+    events: list[str] = []
+    body_error = RuntimeError("body failed")
+
+    real_connect = sqlite3.connect
+
+    class FailingCleanupConnection(sqlite3.Connection):
+        def execute(self, sql: str, parameters=(), /):
+            if sql == "BEGIN IMMEDIATE":
+                events.append("begin")
+            return super().execute(sql, parameters)
+
+        def rollback(self) -> None:
+            events.append("rollback")
+            super().rollback()
+            raise OSError("rollback cleanup failed")
+
+        def close(self) -> None:
+            events.append("close")
+            super().close()
+            raise OSError("close cleanup failed")
+
+    def connect(*args, **kwargs):
+        return real_connect(*args, **kwargs, factory=FailingCleanupConnection)
+
+    from core.memory import confined_filesystem
+
+    real_chmod = confined_filesystem.os.chmod
+
+    def chmod(target, mode: int) -> None:
+        if Path(target) == path and mode == 0o600:
+            events.append("harden")
+        real_chmod(target, mode)
+
+    monkeypatch.setattr(confined_filesystem.sqlite3, "connect", connect)
+    monkeypatch.setattr(confined_filesystem.os, "chmod", chmod)
+
+    with pytest.raises(RuntimeError) as raised:
+        with database.transaction() as connection:
+            connection.execute("CREATE TABLE item (value TEXT NOT NULL)")
+            raise body_error
+
+    with real_connect(path) as connection:
+        assert connection.execute(
+            "SELECT name FROM sqlite_master WHERE name = 'item'"
+        ).fetchone() is None
+    assert raised.value is body_error
+    assert events == ["begin", "rollback", "close", "harden"]
+
+
+def test_private_sqlite_transaction_commit_failure_remains_primary_during_cleanup(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home = tmp_path / "home"
+    path = home / "state" / "journal.sqlite"
+    database = PrivateSqliteDatabase(home, path)
+    database.prepare()
+    events: list[str] = []
+    commit_error = sqlite3.OperationalError("commit failed")
+
+    real_connect = sqlite3.connect
+
+    class FailingCommitConnection(sqlite3.Connection):
+        def execute(self, sql: str, parameters=(), /):
+            if sql == "BEGIN IMMEDIATE":
+                events.append("begin")
+            return super().execute(sql, parameters)
+
+        def commit(self) -> None:
+            events.append("commit")
+            raise commit_error
+
+        def rollback(self) -> None:
+            events.append("rollback")
+            super().rollback()
+            raise OSError("rollback cleanup failed")
+
+        def close(self) -> None:
+            events.append("close")
+            super().close()
+            raise OSError("close cleanup failed")
+
+    def connect(*args, **kwargs):
+        return real_connect(*args, **kwargs, factory=FailingCommitConnection)
+
+    from core.memory import confined_filesystem
+
+    real_chmod = confined_filesystem.os.chmod
+
+    def chmod(target, mode: int) -> None:
+        if Path(target) == path and mode == 0o600:
+            events.append("harden")
+        real_chmod(target, mode)
+
+    monkeypatch.setattr(confined_filesystem.sqlite3, "connect", connect)
+    monkeypatch.setattr(confined_filesystem.os, "chmod", chmod)
+
+    with pytest.raises(sqlite3.OperationalError) as raised:
+        with database.transaction() as connection:
+            connection.execute("CREATE TABLE item (value TEXT NOT NULL)")
+
+    with real_connect(path) as connection:
+        assert connection.execute(
+            "SELECT name FROM sqlite_master WHERE name = 'item'"
+        ).fetchone() is None
+    assert raised.value is commit_error
+    assert events == ["begin", "commit", "rollback", "close", "harden"]
+
+
+def test_private_sqlite_transaction_rolls_back_cancellation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class InjectedCancellation(BaseException):
+        pass
+
+    home = tmp_path / "home"
+    path = home / "state" / "journal.sqlite"
+    database = PrivateSqliteDatabase(home, path)
+    database.prepare()
+    with sqlite3.connect(path) as connection:
+        connection.execute("CREATE TABLE item (value TEXT NOT NULL)")
+    events: list[str] = []
+    cancellation = InjectedCancellation()
+
+    real_connect = sqlite3.connect
+
+    class TrackingConnection(sqlite3.Connection):
+        def execute(self, sql: str, parameters=(), /):
+            if sql == "BEGIN IMMEDIATE":
+                events.append("begin")
+            return super().execute(sql, parameters)
+
+        def rollback(self) -> None:
+            events.append("rollback")
+            super().rollback()
+
+        def close(self) -> None:
+            events.append("close")
+            super().close()
+
+    def connect(*args, **kwargs):
+        return real_connect(*args, **kwargs, factory=TrackingConnection)
+
+    from core.memory import confined_filesystem
+
+    real_chmod = confined_filesystem.os.chmod
+
+    def chmod(target, mode: int) -> None:
+        if Path(target) == path and mode == 0o600:
+            events.append("harden")
+        real_chmod(target, mode)
+
+    monkeypatch.setattr(confined_filesystem.sqlite3, "connect", connect)
+    monkeypatch.setattr(confined_filesystem.os, "chmod", chmod)
+
+    with pytest.raises(InjectedCancellation) as raised:
+        with database.transaction() as connection:
+            connection.execute("INSERT INTO item VALUES ('rolled back')")
+            raise cancellation
+
+    with real_connect(path) as connection:
+        assert connection.execute("SELECT value FROM item").fetchall() == []
+    assert raised.value is cancellation
+    assert events == ["begin", "rollback", "close", "harden"]
+
+
+def test_private_sqlite_transaction_translates_hardening_failure_after_commit(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class JournalHardeningError(RuntimeError):
+        pass
+
+    home = tmp_path / "home"
+    path = home / "state" / "journal.sqlite"
+    database = PrivateSqliteDatabase(home, path)
+    database.prepare()
+    events: list[str] = []
+    translated = JournalHardeningError("journal files could not be hardened safely")
+
+    real_connect = sqlite3.connect
+
+    class TrackingConnection(sqlite3.Connection):
+        def execute(self, sql: str, parameters=(), /):
+            if sql == "BEGIN IMMEDIATE":
+                events.append("begin")
+            return super().execute(sql, parameters)
+
+        def commit(self) -> None:
+            events.append("commit")
+            super().commit()
+
+        def close(self) -> None:
+            events.append("close")
+            super().close()
+
+    def connect(*args, **kwargs):
+        return real_connect(*args, **kwargs, factory=TrackingConnection)
+
+    from core.memory import confined_filesystem
+
+    real_chmod = confined_filesystem.os.chmod
+    harden_error = ConfinedFilesystemError("unsafe SQLite sidecar")
+
+    def chmod(target, mode: int) -> None:
+        if Path(target) == path and mode == 0o600:
+            events.append("harden")
+            raise harden_error
+        real_chmod(target, mode)
+
+    monkeypatch.setattr(confined_filesystem.sqlite3, "connect", connect)
+    monkeypatch.setattr(confined_filesystem.os, "chmod", chmod)
+
+    with pytest.raises(JournalHardeningError) as raised:
+        with database.transaction(
+            translate_harden_error=lambda _error: translated,
+        ) as connection:
+            connection.execute("CREATE TABLE item (value TEXT NOT NULL)")
+            connection.execute("INSERT INTO item VALUES ('durable')")
+
+    with real_connect(path) as connection:
+        assert connection.execute("SELECT value FROM item").fetchone() == ("durable",)
+    assert raised.value is translated
+    assert raised.value.__cause__ is harden_error
+    assert events == ["begin", "commit", "close", "harden"]
+
+
+def test_private_sqlite_transaction_closes_setup_failure_without_translation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home = tmp_path / "home"
+    path = home / "state" / "journal.sqlite"
+    database = PrivateSqliteDatabase(home, path)
+    database.prepare()
+    setup_error = sqlite3.OperationalError("SQLite setup failed")
+    events: list[str] = []
+    real_connect = sqlite3.connect
+
+    class FailingSetupConnection(sqlite3.Connection):
+        def execute(self, sql: str, parameters=(), /):
+            if sql == "PRAGMA synchronous=FULL":
+                raise setup_error
+            return super().execute(sql, parameters)
+
+        def close(self) -> None:
+            events.append("close")
+            super().close()
+
+    def connect(*args, **kwargs):
+        return real_connect(*args, **kwargs, factory=FailingSetupConnection)
+
+    from core.memory import confined_filesystem
+
+    monkeypatch.setattr(confined_filesystem.sqlite3, "connect", connect)
+
+    with pytest.raises(sqlite3.OperationalError) as raised:
+        with database.transaction():
+            pytest.fail("transaction body must not run after setup failure")
+
+    assert raised.value is setup_error
+    assert events == ["close"]
 
 
 def test_private_sqlite_database_rejects_an_unsafe_sidecar(tmp_path: Path) -> None:


### PR DESCRIPTION
## Changed capability

- Deepen `PrivateSqliteDatabase` with a typed immediate-transaction context manager that owns connection setup, commit/rollback ordering, bounded cleanup, close, error translation, and post-commit hardening.
- Migrate lifecycle-identical clear, clear-snapshot, and backup/restore journal mutations while preserving domain SQL, CAS predicates, event ordering, and public error types.
- Keep `MemoryStore` migrations and composed writes on their documented already-open connection path.

## Evidence

- Unit: owner lifecycle tests cover commit-before-harden, rollback/close, commit failure cleanup, BaseException cancellation, setup failure cleanup, hardening translation, and raw SQLite failure behavior.
- Contract/runtime: `88 passed` across confined filesystem, clear journal, backup/restore journal, clear snapshot storage, maintenance recovery, and targeted runtime clear-recovery tests.
- Static: Ruff passed on every changed Python file; `git diff --check` passed; transaction search leaves only intentional journal schema commits and documented Store/migration transactions.
- Scenario: no scenario catalog IDs apply to this internal refactor.
- Residual manual checks: none required for this internal refactor.

## Deferred

Filesystem traversal and no-follow hardening are intentionally deferred to the separate security PR.