### PR TITLE
refactor(memory): type Processing Record reads

### DIFF
--- a/core/memory/processing_record.py
+++ b/core/memory/processing_record.py
@@ -22,7 +22,6 @@ from core.memory.types import MemoryFailureLogEntry
 
 
 SourceStatus = Literal["available", "partial", "stale", "unknown", "unavailable"]
-ProcessingRecordKind = Literal["record", "status", "failures", "maintenance"]
 
 # One composite read performs an opaque operator lookup, then reads both
 # maintenance journals, then fans out over provider health, four local source
@@ -50,7 +49,7 @@ PROCESSING_RECORD_TRANSPORT_TIMEOUT_SECONDS = (
 )
 
 
-_Projection = TypeVar("_Projection")
+_AwaitResult = TypeVar("_AwaitResult")
 
 
 @dataclass(frozen=True, slots=True)
@@ -141,52 +140,93 @@ class MemoryProcessingRecord:
         self._recorder_episode_observed_at: str | None = None
         self._recorder_episode_id: str | None = None
 
-    async def read(
+    async def read_record(
         self,
-        kind: ProcessingRecordKind,
         *,
         verified_user_key: str | None = None,
         operator_ref: str | None = None,
         deadline: float | None = None,
-    ) -> (
-        ProcessingRecordSummary
-        | RuntimeHealthProjection
-        | tuple[AnomalyProjection, MaintenanceProjection]
-        | MaintenanceProjection
-    ):
-        """Project one Memory read under a single absolute work deadline."""
+    ) -> ProcessingRecordSummary:
+        """Read the complete Processing Record projection."""
 
-        if deadline is None:
-            work_timeout = (
-                PROVIDER_READ_TIMEOUT_SECONDS
-                if kind == "status"
-                else PROCESSING_RECORD_WORK_TIMEOUT_SECONDS
-            )
-            deadline = time.monotonic() + work_timeout
-        if kind == "status":
-            runtime, _recorder_anomaly = await self._read_runtime(None, deadline)
-            return runtime
+        operator_ref, deadline = await self._prepare_authorized_read(
+            verified_user_key=verified_user_key,
+            operator_ref=operator_ref,
+            deadline=deadline,
+        )
+        return await self._read_record(operator_ref, deadline)
 
+    async def read_status(
+        self,
+        *,
+        deadline: float | None = None,
+    ) -> RuntimeHealthProjection:
+        """Read the narrow provider-only runtime status projection."""
+
+        deadline = self._projection_deadline(
+            deadline,
+            timeout=PROVIDER_READ_TIMEOUT_SECONDS,
+        )
+        runtime, _recorder_anomaly = await self._read_runtime(None, deadline)
+        return runtime
+
+    async def read_failures(
+        self,
+        *,
+        verified_user_key: str | None = None,
+        operator_ref: str | None = None,
+        deadline: float | None = None,
+    ) -> tuple[AnomalyProjection, MaintenanceProjection]:
+        """Read failure entries and their owner-scoped recovery capability."""
+
+        operator_ref, deadline = await self._prepare_authorized_read(
+            verified_user_key=verified_user_key,
+            operator_ref=operator_ref,
+            deadline=deadline,
+        )
+        return await self._read_failures(operator_ref, deadline)
+
+    async def read_maintenance(
+        self,
+        *,
+        verified_user_key: str | None = None,
+        operator_ref: str | None = None,
+        deadline: float | None = None,
+    ) -> MaintenanceProjection:
+        """Read owner-scoped maintenance facts."""
+
+        operator_ref, deadline = await self._prepare_authorized_read(
+            verified_user_key=verified_user_key,
+            operator_ref=operator_ref,
+            deadline=deadline,
+        )
+        return await self._read_maintenance_projection(operator_ref, deadline)
+
+    async def _prepare_authorized_read(
+        self,
+        *,
+        verified_user_key: str | None,
+        operator_ref: str | None,
+        deadline: float | None,
+    ) -> tuple[str | None, float]:
+        deadline = self._projection_deadline(
+            deadline,
+            timeout=PROCESSING_RECORD_WORK_TIMEOUT_SECONDS,
+        )
         operator_ref = await self._resolve_operator(
             verified_user_key,
             operator_ref,
             deadline,
         )
-        if kind == "record":
-            return await self._read_record(operator_ref, deadline)
-        if kind == "failures":
-            return await self._read_failures(operator_ref, deadline)
-        if kind == "maintenance":
-            observation = await self._read_maintenance_observation(
-                operator_ref,
-                deadline,
-            )
-            return await self._read_maintenance(
-                operator_ref,
-                observation,
-                deadline,
-            )
-        raise ValueError(f"unknown Processing Record projection: {kind}")
+        return operator_ref, deadline
+
+    @staticmethod
+    def _projection_deadline(
+        deadline: float | None,
+        *,
+        timeout: float,
+    ) -> float:
+        return time.monotonic() + timeout if deadline is None else deadline
 
     async def _resolve_operator(
         self,
@@ -275,6 +315,21 @@ class MemoryProcessingRecord:
         return (
             self._merge_recorder_anomaly(anomalies, recorder_anomaly),
             maintenance,
+        )
+
+    async def _read_maintenance_projection(
+        self,
+        operator_ref: str | None,
+        deadline: float,
+    ) -> MaintenanceProjection:
+        observation = await self._read_maintenance_observation(
+            operator_ref,
+            deadline,
+        )
+        return await self._read_maintenance(
+            operator_ref,
+            observation,
+            deadline,
         )
 
     async def _read_maintenance_observation(
@@ -483,8 +538,8 @@ def _utc_observed_at() -> str:
 
 async def _await_before(
     deadline: float,
-    operation: Callable[[], Awaitable[_Projection]],
-) -> _Projection:
+    operation: Callable[[], Awaitable[_AwaitResult]],
+) -> _AwaitResult:
     remaining = deadline - time.monotonic()
     if remaining <= 0:
         raise asyncio.TimeoutError

--- a/core/memory/runtime.py
+++ b/core/memory/runtime.py
@@ -1025,19 +1025,14 @@ class MemoryRuntime:
         operator_ref: str | None = None,
         verified_user_key: str | None = None,
     ) -> dict[str, Any]:
-        summary = await self._processing_record.read(
-            "record",
+        summary = await self._processing_record.read_record(
             verified_user_key=verified_user_key,
             operator_ref=operator_ref,
         )
-        if not isinstance(summary, ProcessingRecordSummary):
-            raise RuntimeError("invalid Processing Record projection")
         return _processing_record_payload(summary)
 
     async def status_payload(self) -> dict[str, Any]:
-        runtime = await self._processing_record.read("status")
-        if not isinstance(runtime, RuntimeHealthProjection):
-            raise RuntimeError("invalid Memory status projection")
+        runtime = await self._processing_record.read_status()
         return _runtime_health_payload(runtime)
 
     async def failure_log_payload(
@@ -1046,13 +1041,10 @@ class MemoryRuntime:
         operator_ref: str | None = None,
         verified_user_key: str | None = None,
     ) -> dict[str, Any]:
-        projection = await self._processing_record.read(
-            "failures",
+        projection = await self._processing_record.read_failures(
             verified_user_key=verified_user_key,
             operator_ref=operator_ref,
         )
-        if not isinstance(projection, tuple):
-            raise RuntimeError("invalid Memory failures projection")
         anomalies, maintenance = projection
         if anomalies.source.status == "unavailable":
             raise self._unavailable()
@@ -1070,13 +1062,10 @@ class MemoryRuntime:
     ) -> dict[str, Any]:
         """Return cheap local maintenance facts without probing or scanning EverOS."""
 
-        result = await self._processing_record.read(
-            "maintenance",
+        result = await self._processing_record.read_maintenance(
             verified_user_key=verified_user_key,
             operator_ref=operator_ref,
         )
-        if not isinstance(result, MaintenanceProjection):
-            raise RuntimeError("invalid Memory maintenance projection")
         return {
             "status": "ok",
             "data_exists": result.data_exists,

--- a/tests/test_memory_processing_record.py
+++ b/tests/test_memory_processing_record.py
@@ -7,6 +7,7 @@ from dataclasses import replace
 from datetime import UTC, datetime
 from pathlib import Path
 from types import SimpleNamespace
+from typing import get_type_hints
 
 import pytest
 
@@ -14,13 +15,21 @@ import core.memory.processing_record as processing_record_module
 import core.memory.snapshot as snapshot_module
 from config.v2_config import MemoryConfig
 from core.memory.everos import ProviderHealthSnapshot
-from core.memory.maintenance import MaintenanceObservation, MaintenanceResult
+from core.memory.maintenance import (
+    ClearRecoveryResult,
+    MaintenanceObservation,
+    MaintenanceResult,
+)
 from core.memory.processing_record import (
+    AnomalyProjection,
     FailureLogObservation,
+    MaintenanceProjection,
     MemoryProcessingRecord,
     MemoryProcessingRecordPort,
+    ProcessingRecordSummary,
     ProcessingSourceObservations,
     RuntimeHealthObservation,
+    RuntimeHealthProjection,
     SourceObservation,
 )
 from core.memory.runtime import MemoryRuntime
@@ -213,6 +222,23 @@ class _OverlappingRecorderObservations(_RuntimeObservations):
         return await super().failure_log(maintenance_reason)
 
 
+def test_processing_record_exposes_only_exact_typed_read_entry_points() -> None:
+    assert get_type_hints(MemoryProcessingRecord.read_record)["return"] is (
+        ProcessingRecordSummary
+    )
+    assert get_type_hints(MemoryProcessingRecord.read_status)["return"] is (
+        RuntimeHealthProjection
+    )
+    assert get_type_hints(MemoryProcessingRecord.read_failures)["return"] == tuple[
+        AnomalyProjection,
+        MaintenanceProjection,
+    ]
+    assert get_type_hints(MemoryProcessingRecord.read_maintenance)["return"] is (
+        MaintenanceProjection
+    )
+    assert not hasattr(MemoryProcessingRecord, "read")
+
+
 @pytest.mark.asyncio
 async def test_health_snapshot_falls_back_only_to_its_own_stale_observation(
     monkeypatch: pytest.MonkeyPatch,
@@ -228,12 +254,12 @@ async def test_health_snapshot_falls_back_only_to_its_own_stale_observation(
         lambda: next(times),
     )
 
-    current = await record.read("record")
+    current = await record.read_record()
     observations.health = RuntimeHealthObservation(
         snapshot=None,
         unavailable_reason="memory_provider_timeout",
     )
-    stale = await record.read("record")
+    stale = await record.read_record()
 
     assert current.runtime.source == SourceObservation("available", "current")
     assert stale.runtime.source == SourceObservation(
@@ -279,14 +305,14 @@ async def test_recorder_episode_is_stable_and_rotates_after_recovery_or_reason_c
     )
 
     observations.recorder = {"state": "degraded", "reason": "writer_failures"}
-    first = await record.read("record")
-    second = await record.read("record")
+    first = await record.read_record()
+    second = await record.read_record()
     observations.recorder = {"state": "active", "reason": None}
-    recovered = await record.read("record")
+    recovered = await record.read_record()
     observations.recorder = {"state": "degraded", "reason": "writer_failures"}
-    next_episode = await record.read("record")
+    next_episode = await record.read_record()
     observations.recorder = {"state": "degraded", "reason": "call_log_corrupt"}
-    changed_reason = await record.read("record")
+    changed_reason = await record.read_record()
 
     assert [item.id for item in first.anomalies.items] == [
         "ma_episode_1",
@@ -312,8 +338,7 @@ async def test_sources_anomalies_and_maintenance_degrade_independently() -> None
     observations.maintenance_error = OSError("private maintenance detail")
     observations.recorder = {"state": "degraded", "reason": "writer_failures"}
 
-    summary = await MemoryProcessingRecord(observations.port()).read(
-        "record",
+    summary = await MemoryProcessingRecord(observations.port()).read_record(
         operator_ref="u-operator",
     )
 
@@ -350,8 +375,7 @@ async def test_verified_identity_lookup_is_inside_deadline_and_fails_closed() ->
     deadline = asyncio.get_running_loop().time() + 0.01
 
     summary = await asyncio.wait_for(
-        MemoryProcessingRecord(port).read(
-            "record",
+        MemoryProcessingRecord(port).read_record(
             verified_user_key="avibe:remote:subject",
             deadline=deadline,
         ),
@@ -372,7 +396,7 @@ async def test_fenced_anomaly_read_reports_maintenance_reason() -> None:
         False,
     )
 
-    summary = await MemoryProcessingRecord(observations.port()).read("record")
+    summary = await MemoryProcessingRecord(observations.port()).read_record()
 
     assert summary.anomalies.source == SourceObservation(
         "unavailable",
@@ -388,7 +412,7 @@ async def test_maintenance_observation_failure_marks_only_maintenance_unavailabl
     observations.maintenance_observation_error = OSError("journal unavailable")
     observations.maintenance = MaintenanceResult(False, False, None)
 
-    summary = await MemoryProcessingRecord(observations.port()).read("record")
+    summary = await MemoryProcessingRecord(observations.port()).read_record()
 
     assert summary.runtime.source.reason == "memory_store_unavailable"
     assert summary.sources.everos.reason == "memory_store_unavailable"
@@ -406,9 +430,9 @@ async def test_overlapping_composite_reads_keep_their_own_recorder_episode() -> 
     observations = _OverlappingRecorderObservations()
     record = MemoryProcessingRecord(observations.port())
 
-    first_reading = asyncio.create_task(record.read("record"))
+    first_reading = asyncio.create_task(record.read_record())
     await asyncio.wait_for(observations.first_health_read.wait(), timeout=0.2)
-    second = await asyncio.wait_for(record.read("record"), timeout=0.2)
+    second = await asyncio.wait_for(record.read_record(), timeout=0.2)
     observations.release_first_failure_read.set()
     first = await asyncio.wait_for(first_reading, timeout=0.2)
 
@@ -427,7 +451,7 @@ async def test_composite_reads_sources_concurrently_then_merges_recorder_episode
     observations = _ConcurrentRuntimeObservations()
     record = MemoryProcessingRecord(observations.port())
 
-    summary = await asyncio.wait_for(record.read("record"), timeout=0.2)
+    summary = await asyncio.wait_for(record.read_record(), timeout=0.2)
 
     assert summary.runtime.health is not None
     assert summary.runtime.health.recorder == {
@@ -440,6 +464,57 @@ async def test_composite_reads_sources_concurrently_then_merges_recorder_episode
 
 
 @pytest.mark.asyncio
+async def test_typed_failure_and_maintenance_reads_preserve_owner_recovery_and_recorder_merge(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    observations = _RuntimeObservations()
+    recovery = ClearRecoveryResult(
+        state="recovery_needed",
+        operation_id="clear-owner",
+        occurred_at="recovery-at",
+        error_code="memory_clear_failed",
+        can_resume=True,
+        can_abort=True,
+    )
+    observations.maintenance_observation = MaintenanceObservation(
+        None,
+        recovery,
+        True,
+    )
+    observations.maintenance = MaintenanceResult(True, True, recovery)
+    observations.failures = (
+        MemoryFailureLogEntry(
+            id="ma_durable",
+            kind="delivery_abandoned",
+            occurred_at="durable-at",
+        ),
+    )
+    observations.recorder = {"state": "degraded", "reason": "writer_failures"}
+    monkeypatch.setattr(
+        processing_record_module,
+        "_new_recorder_episode_id",
+        lambda: "ma_recorder",
+    )
+    monkeypatch.setattr(
+        processing_record_module,
+        "_utc_observed_at",
+        lambda: "recorder-at",
+    )
+    record = MemoryProcessingRecord(observations.port())
+
+    anomalies, failure_maintenance = await record.read_failures(
+        verified_user_key="owner",
+    )
+    maintenance = await record.read_maintenance(verified_user_key="owner")
+
+    assert [item.id for item in anomalies.items] == ["ma_recorder", "ma_durable"]
+    assert failure_maintenance.clear_recovery is recovery
+    assert maintenance.clear_recovery is recovery
+    assert maintenance.can_clear is True
+    assert observations.operator_refs == ["u-owner", "u-owner"]
+
+
+@pytest.mark.asyncio
 async def test_runtime_serializes_one_composite_and_compatibility_projections(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -447,11 +522,33 @@ async def test_runtime_serializes_one_composite_and_compatibility_projections(
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     runtime = MemoryRuntime(MemoryConfig(), effective_home=tmp_path)
 
+    typed_composite = await runtime._processing_record.read_record(
+        operator_ref="u-operator"
+    )
+    typed_status = await runtime._processing_record.read_status()
+    typed_failures = await runtime._processing_record.read_failures(
+        operator_ref="u-operator"
+    )
+    typed_maintenance = await runtime._processing_record.read_maintenance(
+        operator_ref="u-operator"
+    )
     composite = await runtime.processing_record_payload(operator_ref="u-operator")
     status = await runtime.status_payload()
     failures = await runtime.failure_log_payload(operator_ref="u-operator")
     maintenance = await runtime.maintenance_payload(operator_ref="u-operator")
 
+    assert typed_status == typed_composite.runtime
+    assert typed_failures[0].items == typed_composite.anomalies.items
+    assert (
+        typed_failures[1].clear_recovery
+        == typed_composite.maintenance.clear_recovery
+    )
+    assert typed_maintenance.data_exists == typed_composite.maintenance.data_exists
+    assert typed_maintenance.can_clear == typed_composite.maintenance.can_clear
+    assert (
+        typed_maintenance.clear_recovery
+        == typed_composite.maintenance.clear_recovery
+    )
     assert set(composite) == {
         "status",
         "runtime",
@@ -886,6 +983,49 @@ async def test_status_projection_never_reads_maintenance_journals(
 
     assert payload["source"]["reason"] == "memory_disabled"
     await runtime.close()
+
+
+@pytest.mark.asyncio
+async def test_typed_status_uses_provider_budget_without_identity_or_composite_reads(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    observations = _RuntimeObservations()
+
+    async def blocked_health(_maintenance_reason: str | None) -> RuntimeHealthObservation:
+        await asyncio.Event().wait()
+        raise AssertionError("unreachable")
+
+    async def unexpected_read(*_args: object) -> object:
+        raise AssertionError("status reads must stay runtime-only")
+
+    port = replace(
+        observations.port(),
+        resolve_operator=unexpected_read,
+        observe_maintenance=unexpected_read,
+        observe_health=blocked_health,
+        failure_log=unexpected_read,
+        observe_sources=unexpected_read,
+        maintenance=unexpected_read,
+    )
+    monkeypatch.setattr(
+        processing_record_module,
+        "PROVIDER_READ_TIMEOUT_SECONDS",
+        0.01,
+    )
+
+    status = await asyncio.wait_for(
+        MemoryProcessingRecord(port).read_status(),
+        timeout=0.2,
+    )
+
+    assert status == RuntimeHealthProjection(
+        source=SourceObservation(
+            "unavailable",
+            reason="memory_sidecar_unavailable",
+        ),
+        health=None,
+    )
+    assert observations.operator_refs == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- replace the public `read(kind)` union with exact `read_record`, `read_status`, `read_failures`, and `read_maintenance` entry points
- retain shared deadline, identity, maintenance observation, recorder merge, and source-local fallback ownership
- migrate Runtime and remove obsolete result-shape guards without changing payload, timeout, freshness, or authorization behavior

This is an internal typed-interface cleanup. Scenario IDs: none; no cataloged product scenario changes.

## Evidence

- Unit: `pytest -q tests/test_memory_processing_record.py tests/test_internal_client_timeouts.py` (40 passed)
- Contract: exact typed returns/no string-kind seam; typed projection-to-route parity; narrow status budget/no identity; owner-scoped recovery; failure recorder merge; composite deadline/concurrency coverage
- Route/integration: `pytest -q tests/test_memory_processing_record.py tests/test_internal_server.py tests/test_internal_client.py tests/test_internal_client_timeouts.py tests/test_ui_memory_routes.py tests/test_memory_maintenance.py` (252 passed)
- Runtime: `pytest -q tests/test_memory_runtime.py -k "processing_record or status_payload or failure_log_payload or maintenance_payload"` (1 passed, 144 deselected)
- Static: `ruff check core/memory/processing_record.py core/memory/runtime.py tests/test_memory_processing_record.py`; `git diff --check`; legacy call/guard search clean
- Scenario: no scenario harness change; public transport envelopes are unchanged
- Residual manual checks: none required for this internal interface-only change
