### PR TITLE
refactor(memory): add fake provider timing hooks

### DIFF
--- a/core/memory/everos.py
+++ b/core/memory/everos.py
@@ -1110,17 +1110,24 @@ class FakeMemoryProvider:
             recorder={"state": "disabled", "reason": None},
         )
     )
+    add_hook: Callable[[ProviderCapture], Awaitable[None]] | None = None
+    flush_hook: Callable[[ProviderSessionRef], Awaitable[None]] | None = None
+    processing_healthy_hook: Callable[[], Awaitable[None]] | None = None
 
     async def add(self, capture: ProviderCapture) -> AddResult:
         if self.ingest_failures:
             raise self.ingest_failures.popleft()
         self.captures.append(capture)
+        if self.add_hook is not None:
+            await self.add_hook(capture)
         if self.add_results:
             return self.add_results.popleft()
         return AddAck(request_id=f"fake-add-{len(self.captures)}", status="accumulated")
 
     async def flush(self, session_ref: ProviderSessionRef) -> FlushResult:
         self.flushes.append(session_ref)
+        if self.flush_hook is not None:
+            await self.flush_hook(session_ref)
         if self.flush_results:
             return self.flush_results.popleft()
         return FlushSucceeded(request_id=f"fake-flush-{len(self.flushes)}", status="extracted")
@@ -1173,6 +1180,8 @@ class FakeMemoryProvider:
         real EverOS adapter performs bounded authenticated LLM+embedding
         probes.
         """
+        if self.processing_healthy_hook is not None:
+            await self.processing_healthy_hook()
         if self.processing_health_failure is not None:
             raise self.processing_health_failure
         return self.processing_healthy_flag

--- a/tests/test_fake_memory_provider.py
+++ b/tests/test_fake_memory_provider.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+import asyncio
+from collections import deque
+
+import pytest
+
+from core.memory.everos import (
+    AddAck,
+    FakeMemoryProvider,
+    FlushSucceeded,
+    MemoryProviderPort,
+    ProviderCapture,
+)
+from core.memory.types import ProviderSessionRef
+
+
+SESSION_REF = ProviderSessionRef(
+    principal_id="u-11111111111111111111111111111111",
+    epoch=1,
+    project_ref="p-22222222222222222222222222222222",
+    session_id="provider-session",
+)
+CAPTURE = ProviderCapture(
+    session_ref=SESSION_REF,
+    text="remember this",
+    provider_timestamp_ms=1_725_000_001_234,
+)
+
+
+async def test_add_hook_runs_after_failure_and_recording_but_before_results() -> None:
+    failure = RuntimeError("configured add failure")
+    configured = AddAck(request_id="configured-add", status="accumulated")
+    observations: list[tuple[int, int, int]] = []
+
+    async def observe(_capture: ProviderCapture) -> None:
+        observations.append(
+            (
+                len(provider.captures),
+                len(provider.ingest_failures),
+                len(provider.add_results),
+            )
+        )
+
+    provider = FakeMemoryProvider(
+        ingest_failures=deque((failure,)),
+        add_results=deque((configured,)),
+        add_hook=observe,
+    )
+
+    with pytest.raises(RuntimeError) as raised:
+        await provider.add(CAPTURE)
+    assert raised.value is failure
+    assert provider.captures == []
+
+    assert await provider.add(CAPTURE) is configured
+    default = await provider.add(CAPTURE)
+
+    assert default == AddAck(request_id="fake-add-2", status="accumulated")
+    assert provider.captures == [CAPTURE, CAPTURE]
+    assert observations == [(1, 0, 1), (2, 0, 0)]
+
+
+async def test_flush_hook_runs_after_recording_but_before_existing_results() -> None:
+    configured = FlushSucceeded(request_id="configured-flush", status="extracted")
+    observations: list[tuple[int, int]] = []
+
+    async def observe(_session_ref: ProviderSessionRef) -> None:
+        observations.append((len(provider.flushes), len(provider.flush_results)))
+
+    provider = FakeMemoryProvider(
+        flush_results=deque((configured,)),
+        flush_hook=observe,
+    )
+
+    assert await provider.flush(SESSION_REF) is configured
+    default = await provider.flush(SESSION_REF)
+
+    assert default == FlushSucceeded(
+        request_id="fake-flush-2",
+        status="extracted",
+    )
+    assert provider.flushes == [SESSION_REF, SESSION_REF]
+    assert observations == [(1, 1), (2, 0)]
+
+
+async def test_processing_healthy_hook_runs_before_failure_and_default() -> None:
+    failure = RuntimeError("configured processing health failure")
+    observed_failures: list[BaseException | None] = []
+
+    async def observe() -> None:
+        observed_failures.append(provider.processing_health_failure)
+
+    provider = FakeMemoryProvider(
+        processing_healthy_flag=False,
+        processing_health_failure=failure,
+        processing_healthy_hook=observe,
+    )
+
+    with pytest.raises(RuntimeError) as raised:
+        await provider.processing_healthy()
+    assert raised.value is failure
+
+    provider.processing_health_failure = None
+    assert await provider.processing_healthy() is False
+    assert observed_failures == [failure, None]
+
+
+async def test_hook_exception_propagates_after_recording_before_add_result() -> None:
+    hook_failure = RuntimeError("add hook failed")
+    configured_result = AddAck(request_id="configured-add", status="accumulated")
+
+    async def fail(_capture: ProviderCapture) -> None:
+        raise hook_failure
+
+    provider = FakeMemoryProvider(
+        add_results=deque((configured_result,)),
+        add_hook=fail,
+    )
+
+    with pytest.raises(RuntimeError) as raised:
+        await provider.add(CAPTURE)
+
+    assert raised.value is hook_failure
+    assert provider.captures == [CAPTURE]
+    assert tuple(provider.add_results) == (configured_result,)
+
+
+async def test_hook_cancellation_propagates_after_flush_recording() -> None:
+    configured = FlushSucceeded(request_id="configured-flush", status="extracted")
+
+    async def cancel(_session_ref: ProviderSessionRef) -> None:
+        raise asyncio.CancelledError
+
+    provider = FakeMemoryProvider(
+        flush_results=deque((configured,)),
+        flush_hook=cancel,
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        await provider.flush(SESSION_REF)
+
+    assert provider.flushes == [SESSION_REF]
+    assert tuple(provider.flush_results) == (configured,)
+
+
+async def test_absent_hooks_preserve_default_fake_behavior() -> None:
+    add_failure = RuntimeError("configured add failure")
+    processing_failure = RuntimeError("configured processing health failure")
+    configured_add = AddAck(request_id="configured-add", status="accumulated")
+    configured_flush = FlushSucceeded(
+        request_id="configured-flush",
+        status="extracted",
+    )
+    provider = FakeMemoryProvider(
+        processing_healthy_flag=False,
+        ingest_failures=deque((add_failure,)),
+        add_results=deque((configured_add,)),
+        flush_results=deque((configured_flush,)),
+        processing_health_failure=processing_failure,
+    )
+
+    with pytest.raises(RuntimeError) as raised:
+        await provider.add(CAPTURE)
+    assert raised.value is add_failure
+    assert provider.captures == []
+    assert await provider.add(CAPTURE) is configured_add
+    assert await provider.add(CAPTURE) == AddAck(
+        request_id="fake-add-2",
+        status="accumulated",
+    )
+
+    assert await provider.flush(SESSION_REF) is configured_flush
+    assert await provider.flush(SESSION_REF) == FlushSucceeded(
+        request_id="fake-flush-2",
+        status="extracted",
+    )
+
+    with pytest.raises(RuntimeError) as raised:
+        await provider.processing_healthy()
+    assert raised.value is processing_failure
+    provider.processing_health_failure = None
+    assert await provider.processing_healthy() is False
+
+
+def test_timing_hooks_are_fake_only() -> None:
+    provider = FakeMemoryProvider()
+
+    assert isinstance(provider, MemoryProviderPort)
+    assert not hasattr(MemoryProviderPort, "add_hook")
+    assert not hasattr(MemoryProviderPort, "flush_hook")
+    assert not hasattr(MemoryProviderPort, "processing_healthy_hook")

--- a/tests/test_memory_flush_coordinator.py
+++ b/tests/test_memory_flush_coordinator.py
@@ -48,6 +48,19 @@ PROJECT = "p-22222222222222222222222222222222"
 TEST_BUNDLE_ID = "a" * 32
 
 
+class _Gate:
+    def __init__(self) -> None:
+        self.entered = asyncio.Event()
+        self._release = asyncio.Event()
+
+    async def __call__(self, *_args: object) -> None:
+        self.entered.set()
+        await self._release.wait()
+
+    def open(self) -> None:
+        self._release.set()
+
+
 def _store(tmp_path: Path) -> MemoryStore:
     return MemoryStore(paths.get_state_dir() / "coordinator-tests" / tmp_path.name / "memory.sqlite")
 
@@ -1492,17 +1505,8 @@ async def test_cancelled_server_rejection_commit_is_completed_once_after_restart
 
 async def test_fence_routes_new_capture_to_next_generation(tmp_path: Path) -> None:
     store = _store(tmp_path)
-    entered = asyncio.Event()
-    release = asyncio.Event()
-
-    class Provider(FakeMemoryProvider):
-        async def flush(self, session_ref):
-            self.flushes.append(session_ref)
-            entered.set()
-            await release.wait()
-            return FlushSucceeded("flush", "extracted")
-
-    provider = Provider()
+    flush = _Gate()
+    provider = FakeMemoryProvider(flush_hook=flush)
     current = [datetime(2026, 1, 1, tzinfo=UTC)]
     worker = MemoryWorker(
         store=store,
@@ -1514,13 +1518,13 @@ async def test_fence_routes_new_capture_to_next_generation(tmp_path: Path) -> No
     assert await worker.drain_once() == 1
     current[0] += timedelta(minutes=5)
     assert await worker.coordinator.run_due() == 1
-    await asyncio.wait_for(entered.wait(), timeout=1)
+    await asyncio.wait_for(flush.entered.wait(), timeout=1)
 
     second = _enqueue(store, "second")
     assert second.generation == first.generation + 1
     assert store.claim_due(lease_owner="raced", now="2026-01-01T00:05:01.000Z") is None
 
-    release.set()
+    flush.open()
     await _wait_for_scheduled_flush(worker.coordinator, first.provider_session_ref)
     claimed = store.claim_due(lease_owner="next", now="2026-01-01T00:05:01.000Z")
     assert claimed is not None and claimed.source_message_digest == second.source_message_digest
@@ -2153,21 +2157,13 @@ async def test_message_bound_makes_generation_immediately_due(
 
 async def test_same_session_serializes_while_another_session_continues(tmp_path: Path) -> None:
     store = _store(tmp_path)
-    first_entered = asyncio.Event()
-    release_first = asyncio.Event()
+    first_add = _Gate()
 
-    class Provider(FakeMemoryProvider):
-        async def add(self, capture):
-            self.captures.append(capture)
-            if capture.text == "payload-same-first":
-                first_entered.set()
-                await release_first.wait()
-            return AddAck(
-                request_id=f"add-{capture.text}",
-                status="accumulated",
-            )
+    async def block_first(capture) -> None:
+        if capture.text == "payload-same-first":
+            await first_add(capture)
 
-    provider = Provider()
+    provider = FakeMemoryProvider(add_hook=block_first)
     coordinator = SessionFlushCoordinator(
         store=store,
         provider=provider,
@@ -2188,7 +2184,7 @@ async def test_same_session_serializes_while_another_session_continues(tmp_path:
             lease_owner="parallel",
         )
     )
-    await asyncio.wait_for(first_entered.wait(), timeout=1)
+    await asyncio.wait_for(first_add.entered.wait(), timeout=1)
     same_second = asyncio.create_task(
         coordinator.deliver(
             claimed["payload-same-second"],
@@ -2209,7 +2205,7 @@ async def test_same_session_serializes_while_another_session_continues(tmp_path:
         "payload-other",
     ]
 
-    release_first.set()
+    first_add.open()
     assert await asyncio.wait_for(first, timeout=1)
     assert await asyncio.wait_for(same_second, timeout=1)
     assert [capture.text for capture in provider.captures] == [
@@ -2524,16 +2520,15 @@ async def test_shutdown_joins_post_entry_flush_classification_and_boot_recovers(
             flush_entered.set()
             await asyncio.Event().wait()
 
-        async def processing_healthy(self) -> bool:
-            nonlocal health_calls
-            health_calls += 1
-            if health_calls == 1:
-                health_entered.set()
-                try:
-                    await release_health.wait()
-                finally:
-                    health_finished.set()
-            return True
+    async def block_first_health_probe() -> None:
+        nonlocal health_calls
+        health_calls += 1
+        if health_calls == 1:
+            health_entered.set()
+            try:
+                await release_health.wait()
+            finally:
+                health_finished.set()
 
     async def record_event(
         event: str,
@@ -2544,7 +2539,7 @@ async def test_shutdown_joins_post_entry_flush_classification_and_boot_recovers(
         events.append((event, kind, occurred_at, queued))
         return True
 
-    provider = Provider()
+    provider = Provider(processing_healthy_hook=block_first_health_probe)
     coordinator = SessionFlushCoordinator(
         store=store,
         provider=provider,
@@ -2624,10 +2619,9 @@ async def test_shutdown_drains_local_flush_commit_then_boot_alerts(
             flush_entered.set()
             await asyncio.Event().wait()
 
-        async def processing_healthy(self) -> bool:
-            nonlocal health_calls
-            health_calls += 1
-            return True
+    async def record_health_probe() -> None:
+        nonlocal health_calls
+        health_calls += 1
 
     async def record_event(
         event: str,
@@ -2646,7 +2640,7 @@ async def test_shutdown_drains_local_flush_commit_then_boot_alerts(
         return original_settle(lease, result, now=now)
 
     monkeypatch.setattr(store, "settle_flush", blocking_settle)
-    provider = Provider()
+    provider = Provider(processing_healthy_hook=record_health_probe)
     coordinator = SessionFlushCoordinator(
         store=store,
         provider=provider,
@@ -2718,13 +2712,12 @@ async def test_shutdown_local_flush_phase_does_not_wait_for_classification_lock(
             flush_entered.set()
             await asyncio.Event().wait()
 
-        async def processing_healthy(self) -> bool:
-            nonlocal health_calls
-            health_calls += 1
-            if health_calls == 1:
-                old_health_entered.set()
-                await release_old_health.wait()
-            return True
+    async def block_first_health_probe() -> None:
+        nonlocal health_calls
+        health_calls += 1
+        if health_calls == 1:
+            old_health_entered.set()
+            await release_old_health.wait()
 
     async def record_event(
         event: str,
@@ -2735,7 +2728,7 @@ async def test_shutdown_local_flush_phase_does_not_wait_for_classification_lock(
         events.append((event, kind, occurred_at, queued))
         return True
 
-    provider = Provider()
+    provider = Provider(processing_healthy_hook=block_first_health_probe)
     coordinator = SessionFlushCoordinator(
         store=store,
         provider=provider,
@@ -3236,18 +3229,8 @@ async def test_attachment_preflight_classifies_local_failures_without_ambiguity(
 
 async def test_stale_add_waiter_does_not_resubmit_after_flush_reclaims_it(tmp_path: Path) -> None:
     store = _store(tmp_path)
-    first_add_entered = asyncio.Event()
-    release_first_add = asyncio.Event()
-
-    class Provider(FakeMemoryProvider):
-        async def add(self, capture):
-            self.captures.append(capture)
-            if len(self.captures) == 1:
-                first_add_entered.set()
-                await release_first_add.wait()
-            return AddAck(f"add-{len(self.captures)}", "accumulated")
-
-    provider = Provider()
+    first_add = _Gate()
+    provider = FakeMemoryProvider(add_hook=first_add)
     coordinator = SessionFlushCoordinator(
         store=store,
         provider=provider,
@@ -3263,14 +3246,14 @@ async def test_stale_add_waiter_does_not_resubmit_after_flush_reclaims_it(tmp_pa
     flush_call = asyncio.create_task(
         coordinator.final_flush(row.provider_session_ref, deadline_seconds=2)
     )
-    await asyncio.wait_for(first_add_entered.wait(), timeout=1)
+    await asyncio.wait_for(first_add.entered.wait(), timeout=1)
     stale_call = asyncio.create_task(
         coordinator.deliver(stale_claim, lease_owner="ordinary-worker")
     )
     await asyncio.sleep(0)
     assert stale_call.done() is False
 
-    release_first_add.set()
+    first_add.open()
     assert await flush_call
     assert await stale_call is False
     assert [capture.text for capture in provider.captures] == [
@@ -3432,18 +3415,8 @@ async def test_cancelled_fenced_claim_acquisition_returns_exact_claim(
 
 async def test_session_lock_is_shared_with_waiters_then_reclaimed(tmp_path: Path) -> None:
     store = _store(tmp_path)
-    first_add_entered = asyncio.Event()
-    release_first_add = asyncio.Event()
-
-    class Provider(FakeMemoryProvider):
-        async def add(self, capture):
-            self.captures.append(capture)
-            if len(self.captures) == 1:
-                first_add_entered.set()
-                await release_first_add.wait()
-            return AddAck(f"add-{len(self.captures)}", "accumulated")
-
-    provider = Provider()
+    first_add = _Gate()
+    provider = FakeMemoryProvider(add_hook=first_add)
     coordinator = SessionFlushCoordinator(
         store=store,
         provider=provider,
@@ -3462,14 +3435,14 @@ async def test_session_lock_is_shared_with_waiters_then_reclaimed(tmp_path: Path
     key = claimed[0].provider_session_ref.serialize()
 
     owner = asyncio.create_task(coordinator.deliver(claimed[0], lease_owner="worker"))
-    await asyncio.wait_for(first_add_entered.wait(), timeout=1)
+    await asyncio.wait_for(first_add.entered.wait(), timeout=1)
     waiter = asyncio.create_task(coordinator.deliver(claimed[1], lease_owner="worker"))
     await asyncio.sleep(0)
     assert waiter.done() is False
     assert len(coordinator._session_locks) == 1
     shared_lock = coordinator._session_locks[key]
 
-    release_first_add.set()
+    first_add.open()
     assert await asyncio.wait_for(owner, timeout=1)
     assert await asyncio.wait_for(waiter, timeout=1)
     assert [capture.text for capture in provider.captures] == [

--- a/tests/test_memory_runtime.py
+++ b/tests/test_memory_runtime.py
@@ -192,15 +192,17 @@ async def test_memory_drain_recovery_waits_for_scheduled_flush_settlement(
     flush_finished = threading.Event()
     release_flush = asyncio.Event()
 
-    class BlockingProvider(FakeMemoryProvider):
-        async def flush(self, session_ref: ProviderSessionRef):
-            self.flushes.append(session_ref)
-            flush_entered.set()
-            await release_flush.wait()
-            flush_finished.set()
-            return FlushSucceeded(request_id="exact-flush", status="extracted")
+    async def block_flush(_session_ref: ProviderSessionRef) -> None:
+        flush_entered.set()
+        await release_flush.wait()
+        flush_finished.set()
 
-    provider = BlockingProvider()
+    provider = FakeMemoryProvider(
+        flush_results=deque(
+            (FlushSucceeded(request_id="exact-flush", status="extracted"),)
+        ),
+        flush_hook=block_flush,
+    )
     runtime._provider = provider
     runtime.module._replace_provider(provider)
     worker = runtime.module._worker
@@ -1476,17 +1478,19 @@ async def test_final_flush_fences_capture_before_queue_visibility(
         artifact_manager=_installed_artifact(),
         effective_home=runtime_home,
     )
-    flush_entered = threading.Event()
-    release_flush = threading.Event()
+    flush_entered = asyncio.Event()
+    release_flush = asyncio.Event()
 
-    class BlockingFlushProvider(FakeMemoryProvider):
-        async def flush(self, session_ref: ProviderSessionRef):
-            self.flushes.append(session_ref)
-            flush_entered.set()
-            assert await asyncio.to_thread(release_flush.wait, 2.0)
-            return FlushSucceeded(request_id="old-session-flush", status="extracted")
+    async def block_flush(_session_ref: ProviderSessionRef) -> None:
+        flush_entered.set()
+        await release_flush.wait()
 
-    provider = BlockingFlushProvider()
+    provider = FakeMemoryProvider(
+        flush_results=deque(
+            (FlushSucceeded(request_id="old-session-flush", status="extracted"),)
+        ),
+        flush_hook=block_flush,
+    )
     runtime._provider = provider
     runtime.module._replace_provider(provider)
 
@@ -1552,7 +1556,7 @@ async def test_final_flush_fences_capture_before_queue_visibility(
     assert isinstance(await old_capture, CaptureAccepted)
     drain = asyncio.create_task(runtime.module._worker.drain_once())
 
-    assert await asyncio.to_thread(flush_entered.wait, 1.0)
+    await asyncio.wait_for(flush_entered.wait(), timeout=1.0)
     assert [capture.text for capture in provider.captures] == [
         "old session message"
     ]
@@ -3735,11 +3739,9 @@ async def test_runtime_restart_preserves_drain_completed_inside_grace_window(
     release_add = asyncio.Event()
     pause_timeouts: list[float] = []
 
-    class BlockingProvider(FakeMemoryProvider):
-        async def add(self, capture):
-            add_entered.set()
-            await release_add.wait()
-            return await super().add(capture)
+    async def block_add(_capture: ProviderCapture) -> None:
+        add_entered.set()
+        await release_add.wait()
 
     factory = FakeEverOSProcessFactory()
     runtime = MemoryRuntime(
@@ -3750,7 +3752,7 @@ async def test_runtime_restart_preserves_drain_completed_inside_grace_window(
     )
     old = FakeEverOSProcess()
     runtime._process = old
-    provider = BlockingProvider()
+    provider = FakeMemoryProvider(add_hook=block_add)
     runtime._provider = provider
     runtime.module._replace_provider(provider)
     store = runtime._store


### PR DESCRIPTION
## Summary

- add deterministic, fake-only async hooks for `FakeMemoryProvider.add`, `flush`, and `processing_healthy`
- define hook ordering around existing call recording, configured failures/results, and defaults without changing absent-hook behavior
- replace timing-only provider subclasses with hooks and a small test-owned gate while preserving call counts, cancellation boundaries, and coordinator/store assertions
- keep `MemoryProviderPort`, real EverOS I/O, coordinator/store behavior, timeouts, retries, and error classification unchanged

Production lock observability was explicitly rejected: this adds no exclusion-state, lock-inspection, or lifecycle API.

## Retained Subclass Audit

- retained sequenced/distinct outcome providers for processing-probe retry/backoff and forced-flush generation behavior
- retained cancellation-boundary providers for queued/in-flight add and flush coverage
- retained malformed, timeout, disconnect, ambiguous-result, and multi-step providers
- no timing-only `FakeMemoryProvider` subclasses remain in `test_memory_runtime.py`; timing-only methods in retained coordinator cancellation providers now use hooks

## Evidence

- Unit: `pytest -q tests/test_fake_memory_provider.py tests/test_memory_flush_coordinator.py tests/test_memory_worker.py tests/test_memory_runtime.py` (`227 passed`)
- Contract: seven new fake tests cover ordering, hook exception/cancellation propagation, absent-hook compatibility, and fake-only protocol scope
- Collection: affected files increased from 220 tests on `origin/dev` to 227 on this branch
- Static: `ruff check core/memory/everos.py tests/test_fake_memory_provider.py tests/test_memory_flush_coordinator.py tests/test_memory_runtime.py`
- Diff hygiene: `git diff --check`
- Scenario IDs: none; no scenario catalog or product workflow changes
- Residual manual checks: none; this changes deterministic test substitution only, with no product/manual behavior change
