### PR TITLE
refactor(memory): remove obsolete maintenance helpers

### DIFF
--- a/core/memory/maintenance.py
+++ b/core/memory/maintenance.py
@@ -170,32 +170,6 @@ class MemoryMaintenance:
         except Exception:
             return True
 
-    def observation_block_reason(self) -> str | None:
-        """Describe why read-only provider observations are currently fenced."""
-
-        if self._backup_active:
-            return "busy"
-        restore_journal = self._backup_restore_journal
-        if restore_journal is None or self._initialization_error is not None:
-            return "memory_store_unavailable"
-        try:
-            if restore_journal.get_open_operation() is not None:
-                return "busy"
-        except Exception:
-            return "memory_store_unavailable"
-        clear_journal = self._clear_journal
-        if clear_journal is None:
-            return "memory_store_unavailable"
-        try:
-            operation = clear_journal.get_open_operation()
-        except Exception:
-            return "memory_store_unavailable"
-        if operation is None:
-            return None
-        if operation.state == "recovery_needed":
-            return operation.closed_error or "memory_clear_failed"
-        return "busy"
-
     def can_disable_without_authority(self) -> bool:
         restore_journal = self._backup_restore_journal
         clear_journal = self._clear_journal
@@ -816,10 +790,7 @@ class MemoryMaintenance:
             return None
 
     async def _finish_clear(self, operation: ClearOperation) -> ClearResult:
-        try:
-            await self._run_maintenance_io(self._reconcile_terminal_clear_snapshots)
-        finally:
-            await self._runtime.resume()
+        await self._finalize_terminal_clear()
         return ClearResult(
             status="completed",
             operation_id=operation.operation_id,
@@ -827,15 +798,18 @@ class MemoryMaintenance:
         )
 
     async def _finish_aborted_clear(self, operation: ClearOperation) -> ClearResult:
-        try:
-            await self._run_maintenance_io(self._reconcile_terminal_clear_snapshots)
-        finally:
-            await self._runtime.resume()
+        await self._finalize_terminal_clear()
         return ClearResult(
             status="aborted",
             operation_id=operation.operation_id,
             epoch=operation.pre_epoch,
         )
+
+    async def _finalize_terminal_clear(self) -> None:
+        try:
+            await self._run_maintenance_io(self._reconcile_terminal_clear_snapshots)
+        finally:
+            await self._runtime.resume()
 
     def _blocked(self, *, operator_ref: str | None = None) -> ClearResult:
         return ClearResult(
@@ -1006,15 +980,6 @@ class MemoryMaintenance:
 
     def _open_backup_restore_operation(self) -> BackupRestoreOperation | None:
         journal = self._backup_restore_journal
-        if journal is None:
-            return None
-        try:
-            return journal.get_open_operation()
-        except Exception:
-            return None
-
-    def _open_clear_operation(self) -> ClearOperation | None:
-        journal = self._clear_journal
         if journal is None:
             return None
         try:

--- a/tests/test_memory_processing_record.py
+++ b/tests/test_memory_processing_record.py
@@ -950,12 +950,13 @@ async def test_processing_sources_distinguish_busy_clear_from_failed_recovery(
     journal = maintenance._clear_journal
     assert journal is not None
     maintenance._backup_active = True
-    assert maintenance.observation_block_reason() == "busy"
+    assert (await maintenance.observe()).block_reason == "busy"
     maintenance._backup_active = False
     restore_journal = maintenance._backup_restore_journal
     assert restore_journal is not None
 
-    def unavailable_clear_journal():
+    def unavailable_clear_journal(*, operator_ref: str | None):
+        del operator_ref
         raise OSError("clear journal unavailable")
 
     with monkeypatch.context() as restore_patch:
@@ -964,10 +965,10 @@ async def test_processing_sources_distinguish_busy_clear_from_failed_recovery(
             "get_open_operation",
             lambda: object(),
         )
-        assert maintenance.observation_block_reason() == "busy"
+        assert (await maintenance.observe()).block_reason == "busy"
         restore_patch.setattr(
             journal,
-            "get_open_operation",
+            "observe_open_operation",
             unavailable_clear_journal,
         )
         observation = await runtime._processing_record_maintenance_observation(None)


### PR DESCRIPTION
## Summary

- delete the uncalled _open_clear_operation helper
- migrate test-only observation_block_reason calls to the typed observe(...).block_reason contract, then delete the obsolete helper
- share only terminal snapshot reconciliation and runtime resume ordering in _finalize_terminal_clear while retaining distinct completed and aborted receipts and state transitions

## Scenario coverage

- Scenario IDs: none; no cataloged scenario is affected

## Evidence

- Unit: full memory maintenance, clear journal, clear snapshot storage, and processing-record suites
- Contract: targeted Runtime interrupted Clear, Clear quiesce, and restart recovery tests
- Scenario: existing completed/aborted terminal paths, cleanup retry, cancellation ownership, operator capability projection, and distinct block reasons retained in automated coverage
- Residual manual checks: none; no product behavior changed

## Validation

- pytest -q tests/test_memory_maintenance.py
- pytest -q tests/test_memory_clear_journal.py tests/test_memory_clear_snapshot_storage.py
- pytest -q tests/test_memory_processing_record.py
- pytest -q tests/test_memory_runtime.py -k "runtime_exposes_interrupted_clear_without_starting_sidecar or clear_quiesce_does_not_delete_call_log_files or runtime_restart_fails_closed_before_launch_for_marker_or_clear_recovery"
- ruff check core/memory/maintenance.py tests/test_memory_processing_record.py
- git diff --check
- removed-symbol searches for _open_clear_operation and observation_block_reason