### PR TITLE
refactor(memory): enforce strict confined traversal

### DIFF
--- a/core/memory/artifact.py
+++ b/core/memory/artifact.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import secrets
 import stat
 import subprocess
 from dataclasses import dataclass, field
@@ -27,9 +28,17 @@ from core.managed_runtime import (
     env_flag_enabled,
     file_sha256,
     runtime_platform_tag,
-    write_json_atomic,
 )
 from core.process_isolation import isolated_subprocess_kwargs
+from core.memory.confined_filesystem import (
+    ConfinedFilesystemError,
+    create_confined_file,
+    ensure_private_directory,
+    fsync_directory,
+    open_confined_regular_file,
+    remove_confined_path,
+    replace_confined,
+)
 from core.memory.provider_root import (
     PROVIDER_ROOT_CONTROL_FILES,
     ROOT_SENTINEL_FILENAME,
@@ -405,10 +414,9 @@ class MemoryArtifactManager(ManagedRuntimeManager):
         if not stat.S_ISREG(expected.st_mode) or expected.st_size > _MAX_CURRENT_POINTER_BYTES:
             return None, True
 
-        flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
         try:
-            descriptor = os.open(path, flags)
-        except OSError:
+            descriptor = open_confined_regular_file(self.runtime_dir, path)
+        except (ConfinedFilesystemError, OSError):
             return None, True
         try:
             actual = os.fstat(descriptor)
@@ -501,7 +509,8 @@ class MemoryArtifactManager(ManagedRuntimeManager):
         archive: ManagedRuntimeArchive,
         candidate: MemoryArtifactCandidate,
     ) -> None:
-        write_json_atomic(
+        _write_memory_pointer_atomic(
+            self.runtime_dir,
             self.runtime_dir / "current.json",
             {
                 "provider": "manifest",
@@ -521,9 +530,16 @@ class MemoryArtifactManager(ManagedRuntimeManager):
     def _restore_current_pointer(self, pointer: dict[str, Any] | None) -> None:
         current = self.runtime_dir / "current.json"
         if pointer is None:
-            current.unlink(missing_ok=True)
+            try:
+                remove_confined_path(self.runtime_dir, current)
+            except FileNotFoundError:
+                pass
+            except ConfinedFilesystemError as error:
+                raise MemoryRuntimeActivationError(
+                    "memory runtime pointer could not be removed safely"
+                ) from error
             return
-        write_json_atomic(current, pointer)
+        _write_memory_pointer_atomic(self.runtime_dir, current, pointer)
 
     def _binary_version(self, binary: Path | None) -> str | None:
         if binary is None or not binary.is_file():
@@ -564,6 +580,41 @@ class MemoryArtifactManager(ManagedRuntimeManager):
             "python_version": EMBEDDED_PYTHON_VERSION,
             "lock_sha256": PACKAGE_LOCK_SHA256,
         }
+
+
+def _write_memory_pointer_atomic(
+    runtime_root: Path,
+    path: Path,
+    payload: dict[str, Any],
+) -> None:
+    temporary = runtime_root / f".{path.name}.{secrets.token_hex(8)}.tmp"
+    descriptor: int | None = None
+    try:
+        ensure_private_directory(runtime_root, runtime_root)
+        descriptor = create_confined_file(runtime_root, temporary)
+        encoded = (json.dumps(payload, sort_keys=True) + "\n").encode("utf-8")
+        view = memoryview(encoded)
+        while view:
+            written = os.write(descriptor, view)
+            if written <= 0:
+                raise OSError("memory runtime pointer write made no progress")
+            view = view[written:]
+        os.fsync(descriptor)
+        os.close(descriptor)
+        descriptor = None
+        replace_confined(runtime_root, temporary, path)
+        fsync_directory(runtime_root)
+    except (ConfinedFilesystemError, OSError) as error:
+        raise MemoryRuntimeActivationError(
+            "memory runtime pointer could not be written safely"
+        ) from error
+    finally:
+        if descriptor is not None:
+            os.close(descriptor)
+        try:
+            remove_confined_path(runtime_root, temporary)
+        except (ConfinedFilesystemError, OSError):
+            pass
 
 
 @runtime_checkable

--- a/core/memory/artifact.py
+++ b/core/memory/artifact.py
@@ -35,6 +35,7 @@ from core.memory.confined_filesystem import (
     create_confined_file,
     ensure_private_directory,
     fsync_directory,
+    open_and_harden_confined_regular_file,
     open_confined_regular_file,
     remove_confined_path,
     replace_confined,
@@ -415,7 +416,8 @@ class MemoryArtifactManager(ManagedRuntimeManager):
             return None, True
 
         try:
-            descriptor = open_confined_regular_file(self.runtime_dir, path)
+            ensure_private_directory(self.runtime_dir, self.runtime_dir)
+            descriptor = open_and_harden_confined_regular_file(self.runtime_dir, path)
         except (ConfinedFilesystemError, OSError):
             return None, True
         try:

--- a/core/memory/attachments.py
+++ b/core/memory/attachments.py
@@ -16,6 +16,11 @@ from pathlib import Path, PurePosixPath
 from urllib.parse import unquote_to_bytes, urlsplit
 
 from config import paths
+from core.memory.confined_filesystem import (
+    ConfinedFilesystemError,
+    SpilledDirectoryOrder,
+    required_no_follow_flag,
+)
 from core.memory.modality import SUPPORTED_ATTACHMENT_EXTENSIONS
 from core.memory.types import (
     CaptureAttachment,
@@ -658,13 +663,13 @@ def _paths_overlap(left: Path, right: Path) -> bool:
 
 
 def _required_no_follow_flag() -> int:
-    no_follow = getattr(os, "O_NOFOLLOW", 0)
-    if not no_follow:
+    try:
+        return required_no_follow_flag()
+    except ConfinedFilesystemError as error:
         raise AttachmentPinError(
             "memory_store_unavailable",
             "durable attachments require no-follow filesystem support",
-        )
-    return int(no_follow)
+        ) from error
 
 
 def _directory_open_flags() -> int:
@@ -1153,7 +1158,10 @@ def _directory_entry_names(directory_fd: int) -> tuple[str, ...]:
 def _validate_private_bundle(parent_fd: int, name: str) -> tuple[str, ...]:
     bundle_fd = _open_private_directory_at(parent_fd, name, "attachment bundle")
     try:
-        filenames = sorted(_directory_entry_names(bundle_fd))
+        filenames = _bounded_ordered_directory_entry_names(
+            bundle_fd,
+            maximum=MAX_PINNED_ATTACHMENTS,
+        )
         if not 1 <= len(filenames) <= MAX_PINNED_ATTACHMENTS:
             raise AttachmentPinError(
                 "memory_store_unavailable",
@@ -1190,6 +1198,28 @@ def _validate_private_bundle(parent_fd: int, name: str) -> tuple[str, ...]:
         return tuple(filenames)
     finally:
         os.close(bundle_fd)
+
+
+def _bounded_ordered_directory_entry_names(
+    directory_fd: int,
+    *,
+    maximum: int,
+) -> tuple[str, ...]:
+    try:
+        with SpilledDirectoryOrder() as orders:
+            cursor = orders.scan(directory_fd)
+            names: list[str] = []
+            while len(names) <= maximum:
+                name = orders.next_name(cursor)
+                if name is None:
+                    break
+                names.append(name)
+            return tuple(names)
+    except ConfinedFilesystemError as error:
+        raise AttachmentPinError(
+            "memory_store_unavailable",
+            "attachment directory could not be ordered safely",
+        ) from error
 
 
 def _remove_private_bundle(parent_fd: int, name: str, *, strict_files: bool) -> None:

--- a/core/memory/confined_filesystem.py
+++ b/core/memory/confined_filesystem.py
@@ -334,7 +334,7 @@ def replace_confined(home: Path, source: Path, destination: Path) -> None:
                 dir_fd=destination_parent,
                 follow_symlinks=False,
             )
-            if (
+            source_changed = (
                 destination_info.st_dev,
                 destination_info.st_ino,
                 stat.S_IFMT(destination_info.st_mode),
@@ -342,7 +342,22 @@ def replace_confined(home: Path, source: Path, destination: Path) -> None:
                 source_info.st_dev,
                 source_info.st_ino,
                 stat.S_IFMT(source_info.st_mode),
-            ):
+            )
+            if not source_changed:
+                try:
+                    if stat.S_ISDIR(source_info.st_mode):
+                        _require_private_directory(
+                            destination_info,
+                            "atomic replacement destination",
+                        )
+                    else:
+                        _require_private_regular(
+                            destination_info,
+                            "atomic replacement destination",
+                        )
+                except ConfinedFilesystemError:
+                    source_changed = True
+            if source_changed:
                 remove_anchored_entry(
                     destination_parent,
                     destination_relative.parts[-1],
@@ -780,6 +795,21 @@ def _remove_entry_at(
     *,
     expected_identity: tuple[int, int] | None = None,
 ) -> None:
+    try:
+        initial = os.stat(name, dir_fd=parent_fd, follow_symlinks=False)
+    except FileNotFoundError:
+        return
+    if expected_identity is not None and (
+        initial.st_dev,
+        initial.st_ino,
+    ) != expected_identity:
+        raise ConfinedFilesystemError("confined entry changed during removal")
+    if stat.S_ISLNK(initial.st_mode) or stat.S_ISREG(initial.st_mode):
+        os.unlink(name, dir_fd=parent_fd)
+        return
+    if not stat.S_ISDIR(initial.st_mode):
+        raise ConfinedFilesystemError("confined removal refuses special files")
+
     root_node = _RelativeNode(None, name)
     stack: list[_RemovalFrame | _RelativeNode] = [root_node]
     with (
@@ -815,7 +845,13 @@ def _remove_entry_at(
                         raise ConfinedFilesystemError(
                             "confined removal refuses special files"
                         )
-                    _require_private_directory(before, "confined removal directory")
+                    if item is root_node and expected_identity is not None:
+                        _require_directory(before, "confined removal directory")
+                    else:
+                        _require_private_directory(
+                            before,
+                            "confined removal directory",
+                        )
                     child_fd = os.open(
                         item.name,
                         strict_directory_open_flags(),

--- a/core/memory/confined_filesystem.py
+++ b/core/memory/confined_filesystem.py
@@ -22,34 +22,331 @@ class ConfinedFilesystemError(RuntimeError):
     """A confined filesystem operation refused an unsafe path or entry."""
 
 
+def required_no_follow_flag() -> int:
+    """Return the host no-follow capability or disable Memory persistence."""
+
+    flag = getattr(os, "O_NOFOLLOW", None)
+    if not isinstance(flag, int) or isinstance(flag, bool) or flag == 0:
+        raise ConfinedFilesystemError(
+            "Memory persistence requires strict no-follow filesystem support"
+        )
+    return flag
+
+
+def strict_directory_open_flags() -> int:
+    """Flags for a directory descriptor that must not follow its final entry."""
+
+    return (
+        os.O_RDONLY
+        | required_no_follow_flag()
+        | int(getattr(os, "O_DIRECTORY", 0))
+        | int(getattr(os, "O_CLOEXEC", 0))
+    )
+
+
+def strict_file_read_flags(*, nonblocking: bool = False) -> int:
+    """Flags for a read descriptor that must not follow its final entry."""
+
+    flags = os.O_RDONLY | required_no_follow_flag() | int(getattr(os, "O_CLOEXEC", 0))
+    if nonblocking:
+        flags |= int(getattr(os, "O_NONBLOCK", 0))
+    return flags
+
+
+def strict_file_create_flags(*, read_write: bool = False) -> int:
+    """Flags for exclusive creation of a no-follow regular file."""
+
+    access = os.O_RDWR if read_write else os.O_WRONLY
+    return (
+        access
+        | os.O_CREAT
+        | os.O_EXCL
+        | required_no_follow_flag()
+        | int(getattr(os, "O_CLOEXEC", 0))
+    )
+
+
+def ensure_private_directory(home: Path, directory: Path) -> None:
+    """Create one owner-private directory chain through anchored descriptors."""
+
+    required_no_follow_flag()
+    relative = _relative_to_home(directory, home)
+    if not home.exists():
+        try:
+            home.mkdir(parents=True, mode=0o700)
+        except FileExistsError:
+            pass
+        except OSError as error:
+            raise ConfinedFilesystemError(
+                "confinement root cannot be created safely"
+            ) from error
+    try:
+        current = os.open(home, strict_directory_open_flags())
+    except OSError as error:
+        raise ConfinedFilesystemError(
+            "confinement root cannot be opened safely"
+        ) from error
+    try:
+        _harden_private_directory_fd(current, "confinement root")
+        for component in relative.parts:
+            try:
+                child = os.open(
+                    component,
+                    strict_directory_open_flags(),
+                    dir_fd=current,
+                )
+            except FileNotFoundError:
+                try:
+                    os.mkdir(component, mode=0o700, dir_fd=current)
+                    os.fsync(current)
+                except FileExistsError:
+                    pass
+                except OSError as error:
+                    raise ConfinedFilesystemError(
+                        "private directory cannot be created safely"
+                    ) from error
+                try:
+                    child = os.open(
+                        component,
+                        strict_directory_open_flags(),
+                        dir_fd=current,
+                    )
+                except OSError as error:
+                    raise ConfinedFilesystemError(
+                        "private directory cannot be opened safely"
+                    ) from error
+            except OSError as error:
+                raise ConfinedFilesystemError(
+                    "private directory cannot be opened safely"
+                ) from error
+            try:
+                _harden_private_directory_fd(child, "private directory")
+            except BaseException:
+                os.close(child)
+                raise
+            os.close(current)
+            current = child
+    finally:
+        os.close(current)
+
+
+def fsync_directory(path: Path) -> None:
+    """Synchronize one strict, owner-private directory descriptor."""
+
+    try:
+        descriptor = os.open(path, strict_directory_open_flags())
+    except OSError as error:
+        raise ConfinedFilesystemError("directory cannot be opened safely") from error
+    try:
+        _require_private_directory(os.fstat(descriptor), "directory")
+        os.fsync(descriptor)
+    except OSError as error:
+        raise ConfinedFilesystemError("directory cannot be synchronized safely") from error
+    finally:
+        os.close(descriptor)
+
+
+def create_confined_file(
+    home: Path,
+    path: Path,
+    *,
+    mode: int = 0o600,
+    read_write: bool = False,
+) -> int:
+    """Exclusively create one private regular file through its anchored parent."""
+
+    relative = _relative_to_home(path, home)
+    if not relative.parts:
+        raise ConfinedFilesystemError("confined file must be below the confinement root")
+    root = _open_confined_directory(home, ())
+    parent: int | None = None
+    descriptor: int | None = None
+    try:
+        parent = _open_descendant_directory(root, relative.parts[:-1])
+        try:
+            descriptor = os.open(
+                relative.parts[-1],
+                strict_file_create_flags(read_write=read_write),
+                mode,
+                dir_fd=parent,
+            )
+        except OSError as error:
+            raise ConfinedFilesystemError(
+                "confined file cannot be created safely"
+            ) from error
+        try:
+            _require_private_regular(
+                os.fstat(descriptor),
+                "confined file",
+                require_mode=False,
+            )
+            os.fchmod(descriptor, mode)
+            _require_private_regular(os.fstat(descriptor), "confined file")
+            os.fsync(descriptor)
+            os.fsync(parent)
+        except BaseException:
+            os.close(descriptor)
+            descriptor = None
+            try:
+                os.unlink(relative.parts[-1], dir_fd=parent)
+            except OSError:
+                pass
+            raise
+        result = descriptor
+        descriptor = None
+        return result
+    finally:
+        if descriptor is not None:
+            os.close(descriptor)
+        if parent is not None:
+            os.close(parent)
+        os.close(root)
+
+
+def open_confined_regular_file(home: Path, path: Path) -> int:
+    """Open one owner-private regular file through its anchored parent."""
+
+    relative = _relative_to_home(path, home)
+    if not relative.parts:
+        raise ConfinedFilesystemError("confined file must be below the confinement root")
+    root = _open_confined_directory(home, ())
+    parent: int | None = None
+    try:
+        parent = _open_descendant_directory(root, relative.parts[:-1])
+        try:
+            descriptor = os.open(
+                relative.parts[-1],
+                strict_file_read_flags(),
+                dir_fd=parent,
+            )
+        except OSError as error:
+            raise ConfinedFilesystemError(
+                "confined file cannot be opened safely"
+            ) from error
+        try:
+            _require_private_regular(os.fstat(descriptor), "confined file")
+        except BaseException:
+            os.close(descriptor)
+            raise
+        return descriptor
+    finally:
+        if parent is not None:
+            os.close(parent)
+        os.close(root)
+
+
+def open_confined_directory(home: Path, path: Path) -> int:
+    """Open one owner-private directory beneath a pinned confinement root."""
+
+    relative = _relative_to_home(path, home)
+    return _open_confined_directory(home, relative.parts)
+
+
+def replace_confined(home: Path, source: Path, destination: Path) -> None:
+    """Atomically replace two entries through confinement-anchored parents."""
+
+    required_no_follow_flag()
+    source_relative = _relative_to_home(source, home)
+    destination_relative = _relative_to_home(destination, home)
+    if not source_relative.parts or not destination_relative.parts:
+        raise ConfinedFilesystemError("atomic replacement cannot replace the confinement root")
+    root = _open_confined_directory(home, ())
+    source_parent: int | None = None
+    destination_parent: int | None = None
+    try:
+        source_parent = _open_descendant_directory(
+            root,
+            source_relative.parts[:-1],
+        )
+        destination_parent = _open_descendant_directory(
+            root,
+            destination_relative.parts[:-1],
+        )
+        try:
+            source_info = os.stat(
+                source_relative.parts[-1],
+                dir_fd=source_parent,
+                follow_symlinks=False,
+            )
+            if stat.S_ISDIR(source_info.st_mode):
+                _require_private_directory(source_info, "atomic replacement source")
+            else:
+                _require_private_regular(source_info, "atomic replacement source")
+            os.replace(
+                source_relative.parts[-1],
+                destination_relative.parts[-1],
+                src_dir_fd=source_parent,
+                dst_dir_fd=destination_parent,
+            )
+            destination_info = os.stat(
+                destination_relative.parts[-1],
+                dir_fd=destination_parent,
+                follow_symlinks=False,
+            )
+            if (
+                destination_info.st_dev,
+                destination_info.st_ino,
+                stat.S_IFMT(destination_info.st_mode),
+            ) != (
+                source_info.st_dev,
+                source_info.st_ino,
+                stat.S_IFMT(source_info.st_mode),
+            ):
+                remove_anchored_entry(
+                    destination_parent,
+                    destination_relative.parts[-1],
+                    expected_identity=(
+                        destination_info.st_dev,
+                        destination_info.st_ino,
+                    ),
+                )
+                raise ConfinedFilesystemError(
+                    "confined atomic replacement source changed"
+                )
+        except OSError as error:
+            raise ConfinedFilesystemError(
+                "confined atomic replacement failed safely"
+            ) from error
+    finally:
+        if destination_parent is not None:
+            os.close(destination_parent)
+        if source_parent is not None:
+            os.close(source_parent)
+        os.close(root)
+
+
 class PrivateSqliteDatabase:
     """Prepare and validate one owner-private SQLite database and its sidecars."""
 
     def __init__(self, home: Path, path: Path) -> None:
+        required_no_follow_flag()
         self._home = home
         self._path = path
 
     def prepare(self) -> None:
         """Create the private parent chain and database when they are absent."""
 
+        required_no_follow_flag()
         _ensure_private_parent(self._home, self._path.parent)
         try:
             info = os.lstat(self._path)
         except FileNotFoundError:
-            flags = os.O_RDWR | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0)
-            descriptor = os.open(self._path, flags, 0o600)
+            descriptor = create_confined_file(
+                self._home,
+                self._path,
+                read_write=True,
+            )
             try:
                 os.fsync(descriptor)
             finally:
                 os.close(descriptor)
-            os.chmod(self._path, 0o600)
-            _fsync_directory(self._path.parent)
             return
         _require_private_regular(info, "private SQLite database")
 
     def connect(self) -> sqlite3.Connection:
         """Open SQLite only after validating the database and owned sidecars."""
 
+        required_no_follow_flag()
         try:
             info = os.lstat(self._path)
         except FileNotFoundError as error:
@@ -167,20 +464,23 @@ class _RelativeNode:
 class _RemovalFrame:
     node: _RelativeNode
     before: tuple[int, int]
-    child_order: _DirectoryOrderCursor
+    child_order: DirectoryOrderCursor
 
 
 @dataclass(slots=True)
-class _DirectoryOrderCursor:
+class DirectoryOrderCursor:
     order_id: int
     last_name: bytes | None = None
     exhausted: bool = False
 
 
-class _SpilledDirectoryOrder:
+class SpilledDirectoryOrder:
     """Deterministically order directory names without retaining their width."""
 
-    def __init__(self) -> None:
+    def __init__(self, *, insert_batch_size: int = _DIRECTORY_ORDER_INSERT_BATCH_SIZE) -> None:
+        if not isinstance(insert_batch_size, int) or isinstance(insert_batch_size, bool) or insert_batch_size < 1:
+            raise ValueError("directory order insertion batch size must be positive")
+        self._insert_batch_size = insert_batch_size
         self._connection = sqlite3.connect("")
         self._next_order_id = 1
         try:
@@ -200,21 +500,31 @@ class _SpilledDirectoryOrder:
             self._connection.close()
             raise
 
-    def __enter__(self) -> _SpilledDirectoryOrder:
+    def __enter__(self) -> SpilledDirectoryOrder:
         return self
 
     def __exit__(self, *_exc_info: object) -> None:
+        self.close()
+
+    def close(self) -> None:
         self._connection.close()
 
-    def scan(self, descriptor: int) -> _DirectoryOrderCursor:
+    def scan(
+        self,
+        descriptor: int,
+        *,
+        include: Callable[[str], bool] | None = None,
+    ) -> DirectoryOrderCursor:
         order_id = self._next_order_id
         self._next_order_id += 1
         rows: list[tuple[int, bytes]] = []
         try:
             with os.scandir(descriptor) as iterator:
                 for entry in iterator:
+                    if include is not None and not include(entry.name):
+                        continue
                     rows.append((order_id, os.fsencode(entry.name)))
-                    if len(rows) >= _DIRECTORY_ORDER_INSERT_BATCH_SIZE:
+                    if len(rows) >= self._insert_batch_size:
                         self._insert(rows)
                         rows.clear()
             if rows:
@@ -223,9 +533,9 @@ class _SpilledDirectoryOrder:
             raise ConfinedFilesystemError(
                 "confined directory cannot be scanned safely"
             ) from error
-        return _DirectoryOrderCursor(order_id=order_id)
+        return DirectoryOrderCursor(order_id=order_id)
 
-    def next_name(self, cursor: _DirectoryOrderCursor) -> str | None:
+    def next_name(self, cursor: DirectoryOrderCursor) -> str | None:
         if cursor.exhausted:
             return None
         try:
@@ -254,10 +564,16 @@ class _SpilledDirectoryOrder:
             )
             cursor.exhausted = True
             return None
-        except sqlite3.Error as error:
+        except (sqlite3.Error, UnicodeError) as error:
             raise ConfinedFilesystemError(
                 "confined directory cannot be read safely"
             ) from error
+
+    def names(self, cursor: DirectoryOrderCursor) -> Iterator[str]:
+        """Yield one cursor in raw filename-byte order."""
+
+        while (name := self.next_name(cursor)) is not None:
+            yield name
 
     def _insert(self, rows: Sequence[tuple[int, bytes]]) -> None:
         self._connection.executemany(
@@ -300,7 +616,7 @@ class _DirectoryDescriptorCache:
                 try:
                     next_descriptor = os.open(
                         component_node.name,
-                        _directory_open_flags(),
+                        strict_directory_open_flags(),
                         dir_fd=current,
                     )
                 except OSError as error:
@@ -310,10 +626,7 @@ class _DirectoryDescriptorCache:
                 os.close(current)
                 current = next_descriptor
                 info = os.fstat(current)
-                if not stat.S_ISDIR(info.st_mode) or stat.S_ISLNK(info.st_mode):
-                    raise ConfinedFilesystemError(
-                        "confined removal parent is not a safe directory"
-                    )
+                _require_private_directory(info, "confined removal parent")
                 self._remember(component_node, current)
             return current
         except BaseException:
@@ -336,23 +649,26 @@ def remove_confined_path(
 ) -> None:
     """Remove one entry through anchored, no-follow directory handles."""
 
+    required_no_follow_flag()
     relative = _relative_to_home(path, home)
     if not relative.parts:
         raise ConfinedFilesystemError("refusing to remove the confinement root")
     current: int | None = None
     try:
-        current = os.open(home, _directory_open_flags())
+        current = os.open(home, strict_directory_open_flags())
+        _require_private_directory(os.fstat(current), "confinement root")
         for component in relative.parts[:-1]:
             try:
                 next_descriptor = os.open(
                     component,
-                    _directory_open_flags(),
+                    strict_directory_open_flags(),
                     dir_fd=current,
                 )
             except FileNotFoundError:
                 return
             os.close(current)
             current = next_descriptor
+            _require_private_directory(os.fstat(current), "confined directory")
         remove_anchored_entry(current, relative.parts[-1])
     finally:
         if current is not None:
@@ -392,7 +708,7 @@ def _remove_entry_at(
     stack: list[_RemovalFrame | _RelativeNode] = [root_node]
     with (
         _DirectoryDescriptorCache(parent_fd) as cache,
-        _SpilledDirectoryOrder() as orders,
+        SpilledDirectoryOrder() as orders,
     ):
         while stack:
             item = stack[-1]
@@ -426,9 +742,10 @@ def _remove_entry_at(
                         raise ConfinedFilesystemError(
                             "confined removal refuses special files"
                         )
+                    _require_private_directory(before, "confined removal directory")
                     child_fd = os.open(
                         item.name,
-                        _directory_open_flags(),
+                        strict_directory_open_flags(),
                         dir_fd=node_parent_fd,
                     )
                     try:
@@ -489,26 +806,7 @@ def _relative_to_home(path: Path, home: Path) -> Path:
 
 
 def _ensure_private_parent(home: Path, directory: Path) -> None:
-    relative = _relative_to_home(directory, home)
-    if not home.exists():
-        home.mkdir(parents=True, mode=0o700)
-    _require_directory(os.lstat(home), "confinement root")
-    os.chmod(home, 0o700)
-    _fsync_directory(home)
-    current = home
-    for component in relative.parts:
-        current /= component
-        try:
-            info = os.lstat(current)
-        except FileNotFoundError:
-            os.mkdir(current, mode=0o700)
-            _fsync_directory(current.parent)
-            info = os.lstat(current)
-        _require_directory(info, "private SQLite directory")
-        os.chmod(current, 0o700)
-        _fsync_directory(current)
-        if stat.S_IMODE(os.lstat(current).st_mode) != 0o700:
-            raise ConfinedFilesystemError("private SQLite directory is not private")
+    ensure_private_directory(home, directory)
 
 
 def _database_sidecars(path: Path) -> tuple[Path, Path, Path]:
@@ -545,13 +843,72 @@ def _require_directory(info: os.stat_result, label: str) -> None:
     _require_owned(info, label)
 
 
-def _fsync_directory(path: Path) -> None:
-    descriptor = os.open(path, _directory_open_flags())
+def _require_private_directory(info: os.stat_result, label: str) -> None:
+    _require_directory(info, label)
+    if stat.S_IMODE(info.st_mode) != 0o700:
+        raise ConfinedFilesystemError(f"{label} is not private")
+
+
+def _harden_private_directory_fd(descriptor: int, label: str) -> None:
+    _require_directory(os.fstat(descriptor), label)
     try:
+        os.fchmod(descriptor, 0o700)
         os.fsync(descriptor)
-    finally:
-        os.close(descriptor)
+    except OSError as error:
+        raise ConfinedFilesystemError(f"{label} cannot be hardened safely") from error
+    _require_private_directory(os.fstat(descriptor), label)
+
+
+def _open_confined_directory(home: Path, components: Sequence[str]) -> int:
+    try:
+        current = os.open(home, strict_directory_open_flags())
+    except OSError as error:
+        raise ConfinedFilesystemError(
+            "confinement root cannot be opened safely"
+        ) from error
+    try:
+        _require_private_directory(os.fstat(current), "confinement root")
+        descendant = _open_descendant_directory(current, components)
+        os.close(current)
+        return descendant
+    except BaseException:
+        os.close(current)
+        raise
+
+
+def _open_descendant_directory(
+    root_fd: int,
+    components: Sequence[str],
+) -> int:
+    current = os.dup(root_fd)
+    try:
+        for component in components:
+            try:
+                child = os.open(
+                    component,
+                    strict_directory_open_flags(),
+                    dir_fd=current,
+                )
+            except OSError as error:
+                raise ConfinedFilesystemError(
+                    "confined directory cannot be opened safely"
+                ) from error
+            try:
+                _require_private_directory(os.fstat(child), "confined directory")
+            except BaseException:
+                os.close(child)
+                raise
+            os.close(current)
+            current = child
+        return current
+    except BaseException:
+        os.close(current)
+        raise
+
+
+def _fsync_directory(path: Path) -> None:
+    fsync_directory(path)
 
 
 def _directory_open_flags() -> int:
-    return os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+    return strict_directory_open_flags()

--- a/core/memory/confined_filesystem.py
+++ b/core/memory/confined_filesystem.py
@@ -531,7 +531,12 @@ class SpilledDirectoryOrder:
         if not isinstance(insert_batch_size, int) or isinstance(insert_batch_size, bool) or insert_batch_size < 1:
             raise ValueError("directory order insertion batch size must be positive")
         self._insert_batch_size = insert_batch_size
-        self._connection = sqlite3.connect("")
+        try:
+            self._connection = sqlite3.connect("")
+        except sqlite3.Error as error:
+            raise ConfinedFilesystemError(
+                "confined directory ordering cannot be initialized safely"
+            ) from error
         self._next_order_id = 1
         try:
             self._connection.execute("PRAGMA temp_store=FILE")
@@ -546,8 +551,13 @@ class SpilledDirectoryOrder:
                 ) WITHOUT ROWID
                 """
             )
+        except sqlite3.Error as error:
+            self._close_after_failure()
+            raise ConfinedFilesystemError(
+                "confined directory ordering cannot be initialized safely"
+            ) from error
         except BaseException:
-            self._connection.close()
+            self._close_after_failure()
             raise
 
     def __enter__(self) -> SpilledDirectoryOrder:
@@ -558,6 +568,12 @@ class SpilledDirectoryOrder:
 
     def close(self) -> None:
         self._connection.close()
+
+    def _close_after_failure(self) -> None:
+        try:
+            self._connection.close()
+        except sqlite3.Error:
+            pass
 
     def scan(
         self,
@@ -579,7 +595,12 @@ class SpilledDirectoryOrder:
                         rows.clear()
             if rows:
                 self._insert(rows)
-        except (OSError, sqlite3.Error, UnicodeError) as error:
+        except sqlite3.Error as error:
+            self._close_after_failure()
+            raise ConfinedFilesystemError(
+                "confined directory cannot be scanned safely"
+            ) from error
+        except (OSError, UnicodeError) as error:
             raise ConfinedFilesystemError(
                 "confined directory cannot be scanned safely"
             ) from error
@@ -614,7 +635,12 @@ class SpilledDirectoryOrder:
             )
             cursor.exhausted = True
             return None
-        except (sqlite3.Error, UnicodeError) as error:
+        except sqlite3.Error as error:
+            self._close_after_failure()
+            raise ConfinedFilesystemError(
+                "confined directory cannot be read safely"
+            ) from error
+        except UnicodeError as error:
             raise ConfinedFilesystemError(
                 "confined directory cannot be read safely"
             ) from error

--- a/core/memory/confined_filesystem.py
+++ b/core/memory/confined_filesystem.py
@@ -235,6 +235,57 @@ def open_confined_regular_file(home: Path, path: Path) -> int:
         os.close(root)
 
 
+def open_and_harden_confined_regular_file(
+    home: Path,
+    path: Path,
+    *,
+    mode: int = 0o600,
+) -> int:
+    """Open and harden one owned, single-link regular file through its parent."""
+
+    relative = _relative_to_home(path, home)
+    if not relative.parts:
+        raise ConfinedFilesystemError("confined file must be below the confinement root")
+    root = _open_confined_directory(home, ())
+    parent: int | None = None
+    descriptor: int | None = None
+    try:
+        parent = _open_descendant_directory(root, relative.parts[:-1])
+        try:
+            descriptor = os.open(
+                relative.parts[-1],
+                strict_file_read_flags(),
+                dir_fd=parent,
+            )
+        except OSError as error:
+            raise ConfinedFilesystemError(
+                "confined file cannot be opened safely"
+            ) from error
+        try:
+            _require_private_regular(
+                os.fstat(descriptor),
+                "confined file",
+                require_mode=False,
+            )
+            os.fchmod(descriptor, mode)
+            os.fsync(descriptor)
+            _require_private_regular(os.fstat(descriptor), "confined file")
+            os.fsync(parent)
+        except OSError as error:
+            raise ConfinedFilesystemError(
+                "confined file cannot be hardened safely"
+            ) from error
+        result = descriptor
+        descriptor = None
+        return result
+    finally:
+        if descriptor is not None:
+            os.close(descriptor)
+        if parent is not None:
+            os.close(parent)
+        os.close(root)
+
+
 def open_confined_directory(home: Path, path: Path) -> int:
     """Open one owner-private directory beneath a pinned confinement root."""
 
@@ -319,7 +370,6 @@ class PrivateSqliteDatabase:
     """Prepare and validate one owner-private SQLite database and its sidecars."""
 
     def __init__(self, home: Path, path: Path) -> None:
-        required_no_follow_flag()
         self._home = home
         self._path = path
 
@@ -656,7 +706,7 @@ def remove_confined_path(
     current: int | None = None
     try:
         current = os.open(home, strict_directory_open_flags())
-        _require_private_directory(os.fstat(current), "confinement root")
+        _require_exact_private_directory(os.fstat(current), "confinement root")
         for component in relative.parts[:-1]:
             try:
                 next_descriptor = os.open(
@@ -727,10 +777,7 @@ def _remove_entry_at(
                     if (
                         item is root_node
                         and expected_identity is not None
-                        and (
-                            not stat.S_ISDIR(before.st_mode)
-                            or (before.st_dev, before.st_ino) != expected_identity
-                        )
+                        and (before.st_dev, before.st_ino) != expected_identity
                     ):
                         raise ConfinedFilesystemError(
                             "confined entry changed during removal"
@@ -757,6 +804,10 @@ def _remove_entry_at(
                             raise ConfinedFilesystemError(
                                 "confined directory changed during removal"
                             )
+                        _harden_private_directory_fd(
+                            child_fd,
+                            "confined removal directory",
+                        )
                         child_order = orders.scan(child_fd)
                     finally:
                         os.close(child_fd)
@@ -845,8 +896,14 @@ def _require_directory(info: os.stat_result, label: str) -> None:
 
 def _require_private_directory(info: os.stat_result, label: str) -> None:
     _require_directory(info, label)
-    if stat.S_IMODE(info.st_mode) != 0o700:
+    if stat.S_IMODE(info.st_mode) & 0o077:
         raise ConfinedFilesystemError(f"{label} is not private")
+
+
+def _require_exact_private_directory(info: os.stat_result, label: str) -> None:
+    _require_private_directory(info, label)
+    if stat.S_IMODE(info.st_mode) != 0o700:
+        raise ConfinedFilesystemError(f"{label} mode mismatch")
 
 
 def _harden_private_directory_fd(descriptor: int, label: str) -> None:
@@ -856,7 +913,7 @@ def _harden_private_directory_fd(descriptor: int, label: str) -> None:
         os.fsync(descriptor)
     except OSError as error:
         raise ConfinedFilesystemError(f"{label} cannot be hardened safely") from error
-    _require_private_directory(os.fstat(descriptor), label)
+    _require_exact_private_directory(os.fstat(descriptor), label)
 
 
 def _open_confined_directory(home: Path, components: Sequence[str]) -> int:
@@ -867,7 +924,7 @@ def _open_confined_directory(home: Path, components: Sequence[str]) -> int:
             "confinement root cannot be opened safely"
         ) from error
     try:
-        _require_private_directory(os.fstat(current), "confinement root")
+        _require_exact_private_directory(os.fstat(current), "confinement root")
         descendant = _open_descendant_directory(current, components)
         os.close(current)
         return descendant

--- a/core/memory/everos_insight/recorder.py
+++ b/core/memory/everos_insight/recorder.py
@@ -17,6 +17,12 @@ from pathlib import Path
 from typing import Literal, TypeAlias
 from urllib.parse import urlsplit, urlunsplit
 
+from core.memory.confined_filesystem import (
+    ConfinedFilesystemError,
+    required_no_follow_flag,
+    strict_file_create_flags,
+)
+
 JsonPrimitive: TypeAlias = None | bool | int | float | str
 JsonValue: TypeAlias = JsonPrimitive | list["JsonValue"] | dict[str, "JsonValue"]
 ProviderKind: TypeAlias = Literal["llm", "multimodal_llm", "embedding"]
@@ -1185,6 +1191,12 @@ def _encode_json(value: JsonValue) -> str:
 
 
 def _prepare_private_database_path(db_path: Path) -> None:
+    try:
+        required_no_follow_flag()
+    except ConfinedFilesystemError as error:
+        raise OSError(
+            "Call-log persistence requires no-follow filesystem support"
+        ) from error
     if not db_path.is_absolute() or ".." in db_path.parts:
         raise OSError("Call-log database path must be a lexical absolute path")
     _validate_directory_chain(db_path.parent)
@@ -1197,9 +1209,10 @@ def _prepare_private_database_path(db_path: Path) -> None:
     try:
         os.lstat(db_path)
     except FileNotFoundError:
-        flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
-        if hasattr(os, "O_NOFOLLOW"):
-            flags |= os.O_NOFOLLOW
+        try:
+            flags = strict_file_create_flags()
+        except ConfinedFilesystemError as error:  # pragma: no cover - guarded above
+            raise OSError("Call-log persistence is unavailable") from error
         fd = os.open(db_path, flags, 0o600)
         try:
             info = os.fstat(fd)

--- a/core/memory/provider_root.py
+++ b/core/memory/provider_root.py
@@ -12,7 +12,15 @@ from typing import Protocol
 
 from core.memory.confined_filesystem import (
     ConfinedFilesystemError,
+    SpilledDirectoryOrder,
+    create_confined_file,
+    fsync_directory,
+    open_confined_directory,
+    open_confined_regular_file,
+    remove_anchored_entry,
     remove_confined_path,
+    replace_confined,
+    required_no_follow_flag,
 )
 
 
@@ -74,6 +82,12 @@ class ProviderRoot:
     """Own all synchronous security, format, and transition policy for one root."""
 
     def __init__(self, path: Path | str, *, effective_home: Path | str) -> None:
+        try:
+            required_no_follow_flag()
+        except ConfinedFilesystemError as error:
+            raise ProviderRootError(
+                "memory provider root requires no-follow filesystem support"
+            ) from error
         self.path = Path(path)
         self._effective_home = Path(effective_home)
 
@@ -195,22 +209,23 @@ class ProviderRoot:
         """Remove provider children safely while preserving the owned root itself."""
 
         self._verify(meta, active_metadata, require_empty=False)
+        root_fd: int | None = None
         try:
-            with os.scandir(self.path) as entries:
-                children = [
-                    Path(entry.path)
-                    for entry in entries
-                    if entry.name != ROOT_SENTINEL_FILENAME
-                ]
-        except OSError as error:
-            raise ProviderRootError("memory provider root cannot be read") from error
-        for child in children:
-            try:
-                remove_confined_path(self._effective_home, child)
-            except (ConfinedFilesystemError, OSError, ValueError) as error:
-                raise ProviderRootError(
-                    "memory provider root child could not be removed"
-                ) from error
+            root_fd = open_confined_directory(self._effective_home, self.path)
+            with SpilledDirectoryOrder() as orders:
+                cursor = orders.scan(
+                    root_fd,
+                    include=lambda name: name != ROOT_SENTINEL_FILENAME,
+                )
+                for child_name in orders.names(cursor):
+                    remove_anchored_entry(root_fd, child_name)
+        except (ConfinedFilesystemError, OSError, ValueError) as error:
+            raise ProviderRootError(
+                "memory provider root child could not be removed"
+            ) from error
+        finally:
+            if root_fd is not None:
+                os.close(root_fd)
         self._write_sentinel(meta, active_metadata)
         self._verify(meta, active_metadata, require_empty=True)
 
@@ -267,10 +282,7 @@ class ProviderRoot:
 
         descriptor: int | None = None
         try:
-            descriptor = os.open(
-                path,
-                os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0),
-            )
+            descriptor = open_confined_regular_file(self._effective_home, path)
             actual = os.fstat(descriptor)
             if (
                 not stat.S_ISREG(actual.st_mode)
@@ -284,7 +296,7 @@ class ProviderRoot:
                 )
             self._require_owner(actual, "memory provider root sentinel")
             payload = os.read(descriptor, MAX_ROOT_SENTINEL_BYTES + 1)
-        except OSError as error:
+        except (ConfinedFilesystemError, OSError) as error:
             raise ProviderRootError(
                 "memory provider root sentinel is invalid"
             ) from error
@@ -348,16 +360,20 @@ class ProviderRoot:
         )
         descriptor: int | None = None
         try:
-            descriptor = os.open(
+            descriptor = create_confined_file(
+                self._effective_home,
                 temporary,
-                os.O_WRONLY | os.O_CREAT | os.O_EXCL,
-                0o600,
             )
             _write_all(descriptor, payload)
             os.fsync(descriptor)
             os.close(descriptor)
             descriptor = None
-            os.replace(temporary, self.path / ROOT_SENTINEL_FILENAME)
+            replace_confined(
+                self._effective_home,
+                temporary,
+                self.path / ROOT_SENTINEL_FILENAME,
+            )
+            fsync_directory(self.path)
             sentinel_info = self._lstat(
                 self.path / ROOT_SENTINEL_FILENAME,
                 "memory provider root sentinel",
@@ -367,7 +383,7 @@ class ProviderRoot:
                 "memory provider root sentinel",
                 private=True,
             )
-        except OSError as error:
+        except (ConfinedFilesystemError, OSError) as error:
             raise ProviderRootError(
                 "memory provider root sentinel could not be written"
             ) from error
@@ -375,25 +391,35 @@ class ProviderRoot:
             if descriptor is not None:
                 os.close(descriptor)
             try:
-                os.unlink(temporary)
-            except OSError:
+                remove_confined_path(self._effective_home, temporary)
+            except (ConfinedFilesystemError, OSError):
                 pass
 
     def _directory_is_empty(self) -> bool:
+        descriptor: int | None = None
         try:
-            with os.scandir(self.path) as entries:
+            descriptor = open_confined_directory(self._effective_home, self.path)
+            with os.scandir(descriptor) as entries:
                 return not any(True for _entry in entries)
-        except OSError as error:
+        except (ConfinedFilesystemError, OSError) as error:
             raise ProviderRootError("memory provider root cannot be read") from error
+        finally:
+            if descriptor is not None:
+                os.close(descriptor)
 
     def _is_empty(self) -> bool:
+        descriptor: int | None = None
         try:
-            with os.scandir(self.path) as entries:
+            descriptor = open_confined_directory(self._effective_home, self.path)
+            with os.scandir(descriptor) as entries:
                 return all(
                     entry.name in PROVIDER_ROOT_CONTROL_FILES for entry in entries
                 )
-        except OSError as error:
+        except (ConfinedFilesystemError, OSError) as error:
             raise ProviderRootError("memory provider root cannot be inspected") from error
+        finally:
+            if descriptor is not None:
+                os.close(descriptor)
 
     def _ensure_chain_safe(self) -> None:
         home = Path(os.path.abspath(os.fspath(self._effective_home)))

--- a/core/memory/provider_root.py
+++ b/core/memory/provider_root.py
@@ -82,12 +82,6 @@ class ProviderRoot:
     """Own all synchronous security, format, and transition policy for one root."""
 
     def __init__(self, path: Path | str, *, effective_home: Path | str) -> None:
-        try:
-            required_no_follow_flag()
-        except ConfinedFilesystemError as error:
-            raise ProviderRootError(
-                "memory provider root requires no-follow filesystem support"
-            ) from error
         self.path = Path(path)
         self._effective_home = Path(effective_home)
 
@@ -171,6 +165,7 @@ class ProviderRoot:
     ) -> ProviderRootRollback | None:
         """Rewrite an owned empty root for a candidate and return its rollback."""
 
+        self._require_no_follow()
         try:
             self.path.lstat()
         except FileNotFoundError:
@@ -266,6 +261,7 @@ class ProviderRoot:
             raise ProviderRootError("memory provider root still contains data")
 
     def _read_sentinel(self) -> dict[str, str | int]:
+        self._require_no_follow()
         path = self.path / ROOT_SENTINEL_FILENAME
         expected = self._lstat(path, "memory provider root sentinel")
         if (
@@ -338,6 +334,7 @@ class ProviderRoot:
         meta: ProviderRootMeta,
         metadata: ProviderRootMetadata,
     ) -> None:
+        self._require_no_follow()
         if not (
             _is_metadata_value(meta.provider_root_id)
             and _is_metadata_value(metadata.provider_root_format)
@@ -422,6 +419,7 @@ class ProviderRoot:
                 os.close(descriptor)
 
     def _ensure_chain_safe(self) -> None:
+        self._require_no_follow()
         home = Path(os.path.abspath(os.fspath(self._effective_home)))
         current = Path(os.path.abspath(os.fspath(self.path)))
         while True:
@@ -441,6 +439,15 @@ class ProviderRoot:
             if current == current.parent or current == home:
                 break
             current = current.parent
+
+    @staticmethod
+    def _require_no_follow() -> None:
+        try:
+            required_no_follow_flag()
+        except ConfinedFilesystemError as error:
+            raise ProviderRootError(
+                "memory provider root requires no-follow filesystem support"
+            ) from error
 
     @staticmethod
     def _lstat(path: Path, label: str) -> os.stat_result:

--- a/core/memory/provider_root.py
+++ b/core/memory/provider_root.py
@@ -14,6 +14,7 @@ from core.memory.confined_filesystem import (
     ConfinedFilesystemError,
     SpilledDirectoryOrder,
     create_confined_file,
+    ensure_private_directory,
     fsync_directory,
     open_confined_directory,
     open_confined_regular_file,
@@ -439,6 +440,12 @@ class ProviderRoot:
             if current == current.parent or current == home:
                 break
             current = current.parent
+        try:
+            ensure_private_directory(home, home)
+        except ConfinedFilesystemError as error:
+            raise ProviderRootError(
+                "memory provider root confinement home is unsafe or has an owner mismatch"
+            ) from error
 
     @staticmethod
     def _require_no_follow() -> None:

--- a/core/memory/runtime.py
+++ b/core/memory/runtime.py
@@ -28,6 +28,7 @@ from core.memory.artifact import (
 )
 from core.memory.blocking import run_blocking
 from core.memory.clear_journal import ClearSurface
+from core.memory.confined_filesystem import required_no_follow_flag
 from core.memory.everos import (
     EverOSPort,
     MemoryProviderFailure,
@@ -382,6 +383,7 @@ class MemoryRuntime:
         if self._module is not None:
             return True
         try:
+            required_no_follow_flag()
             opened = store or MemoryStore()
             self._artifact_manager.set_provider_root(self._provider_root)
             module = MemoryModule(

--- a/core/memory/snapshot.py
+++ b/core/memory/snapshot.py
@@ -92,10 +92,17 @@ class _MemorySQLiteCorruptionError(MemorySnapshotError):
     """A SQLite source is readable as a file but not as a valid database."""
 
 
-def _new_directory_order() -> SpilledDirectoryOrder:
-    return SpilledDirectoryOrder(
-        insert_batch_size=_directory_order_insert_batch_size()
-    )
+def _new_directory_order(
+    *,
+    error_type: type[MemorySnapshotError],
+    message: str,
+) -> SpilledDirectoryOrder:
+    try:
+        return SpilledDirectoryOrder(
+            insert_batch_size=_directory_order_insert_batch_size()
+        )
+    except ConfinedFilesystemError as error:
+        raise error_type(message) from error
 
 
 def _scan_directory_order(
@@ -745,7 +752,10 @@ class MemorySnapshotManager:
         removed: list[str] = []
         orders: SpilledDirectoryOrder | None = None
         try:
-            orders = _new_directory_order()
+            orders = _new_directory_order(
+                error_type=MemorySnapshotUnsafePathError,
+                message="Memory backup root cannot be scanned safely",
+            )
             candidates = _scan_directory_order(
                 orders,
                 root_fd,
@@ -1230,7 +1240,10 @@ class MemorySnapshotManager:
         destination_cache = _DirectoryDescriptorCache(destination_root_fd)
         orders: SpilledDirectoryOrder | None = None
         try:
-            orders = _new_directory_order()
+            orders = _new_directory_order(
+                error_type=MemorySnapshotError,
+                message="Memory tree surface could not be read",
+            )
             root_mode = stat.S_IMODE(info.st_mode)
             stack = [
                 _tree_copy_frame(
@@ -2203,7 +2216,10 @@ def _verify_payload_paths(
     entries: _ManifestIndex,
 ) -> None:
     root_info = os.fstat(payload_root_fd)
-    orders = _new_directory_order()
+    orders = _new_directory_order(
+        error_type=MemorySnapshotVerificationError,
+        message="Memory snapshot payload cannot be read",
+    )
     try:
         stack = [
             _DirectoryWalkFrame(

--- a/core/memory/snapshot.py
+++ b/core/memory/snapshot.py
@@ -626,12 +626,6 @@ class MemorySnapshotManager:
         surfaces: Sequence[SnapshotSurface] = DEFAULT_MEMORY_SNAPSHOT_SURFACES,
         operation_guard: Callable[[], None] | None = None,
     ) -> None:
-        try:
-            required_no_follow_flag()
-        except ConfinedFilesystemError as error:
-            raise MemorySnapshotUnsafePathError(
-                "Memory snapshots require no-follow filesystem support"
-            ) from error
         self._effective_home = _absolute_without_resolve(effective_home)
         root_value = Path(snapshot_root)
         if root_value.is_absolute():
@@ -803,6 +797,7 @@ class MemorySnapshotManager:
     ) -> MemorySnapshot:
         """Verify the manifest, every byte, every mode, and every tree digest."""
 
+        self._require_no_follow()
         identifier = _validated_snapshot_id(snapshot_id)
         directory = self.snapshot_path(identifier)
         with self._verified_directory(identifier, directory) as (snapshot, _index):
@@ -949,8 +944,18 @@ class MemorySnapshotManager:
             return snapshot
 
     def _assert_operation_allowed(self) -> None:
+        self._require_no_follow()
         if self._operation_guard is not None:
             self._operation_guard()
+
+    @staticmethod
+    def _require_no_follow() -> None:
+        try:
+            required_no_follow_flag()
+        except ConfinedFilesystemError as error:
+            raise MemorySnapshotUnsafePathError(
+                "Memory snapshots require no-follow filesystem support"
+            ) from error
 
     def _remove_clear_snapshot(
         self,
@@ -962,6 +967,7 @@ class MemorySnapshotManager:
     ) -> None:
         """Remove one journal-authorized clear snapshot."""
 
+        self._require_no_follow()
         identifier = _validated_snapshot_id(snapshot_id)
         directory = self.snapshot_path(identifier)
         tombstone = self._snapshot_root / f".{identifier}.gc"
@@ -1002,6 +1008,7 @@ class MemorySnapshotManager:
     ) -> None:
         """Discard one storage-authorized unrecorded clear snapshot."""
 
+        self._require_no_follow()
         identifier = _validated_snapshot_id(snapshot_id)
         expected_relative = (
             PurePosixPath(self._snapshot_root_relative) / identifier

--- a/core/memory/snapshot.py
+++ b/core/memory/snapshot.py
@@ -23,8 +23,17 @@ from typing import Callable, Iterator, Literal, Mapping, Protocol, Sequence
 
 from core.memory.confined_filesystem import (
     ConfinedFilesystemError,
+    DirectoryOrderCursor as _DirectoryOrderCursor,
+    SpilledDirectoryOrder,
+    ensure_private_directory as ensure_confined_private_directory,
+    fsync_directory as fsync_confined_directory,
     remove_anchored_entry,
     remove_confined_path,
+    replace_confined,
+    required_no_follow_flag,
+    strict_directory_open_flags,
+    strict_file_create_flags,
+    strict_file_read_flags,
 )
 
 
@@ -81,6 +90,39 @@ class MemorySnapshotVerificationError(MemorySnapshotError):
 
 class _MemorySQLiteCorruptionError(MemorySnapshotError):
     """A SQLite source is readable as a file but not as a valid database."""
+
+
+def _new_directory_order() -> SpilledDirectoryOrder:
+    return SpilledDirectoryOrder(
+        insert_batch_size=_directory_order_insert_batch_size()
+    )
+
+
+def _scan_directory_order(
+    orders: SpilledDirectoryOrder,
+    descriptor: int,
+    *,
+    error_type: type[MemorySnapshotError],
+    message: str,
+    include: Callable[[str], bool] | None = None,
+) -> _DirectoryOrderCursor:
+    try:
+        return orders.scan(descriptor, include=include)
+    except ConfinedFilesystemError as error:
+        raise error_type(message) from error
+
+
+def _next_directory_name(
+    orders: SpilledDirectoryOrder,
+    cursor: _DirectoryOrderCursor,
+    *,
+    error_type: type[MemorySnapshotError],
+    message: str,
+) -> str | None:
+    try:
+        return orders.next_name(cursor)
+    except ConfinedFilesystemError as error:
+        raise error_type(message) from error
 
 
 @dataclass(frozen=True, slots=True)
@@ -207,119 +249,6 @@ class _DirectoryWalkFrame:
     node: _RelativeNode | None
     before: tuple[int, int, int, int]
     child_order: _DirectoryOrderCursor
-
-
-@dataclass(slots=True)
-class _DirectoryOrderCursor:
-    order_id: int
-    last_name: bytes | None = None
-    exhausted: bool = False
-
-
-class _SpilledDirectoryOrder:
-    """Deterministically order directory names without retaining their width."""
-
-    def __init__(self) -> None:
-        # The unnamed SQLite database is disk-backed and deleted on close. One
-        # index is shared by every active DFS frame, so wide and deep trees do
-        # not multiply database handles or in-memory filename collections.
-        self._connection = sqlite3.connect("")
-        self._next_order_id = 1
-        try:
-            self._connection.execute("PRAGMA temp_store=FILE")
-            self._connection.execute("PRAGMA cache_size=-512")
-            self._connection.execute("PRAGMA journal_mode=OFF")
-            self._connection.execute(
-                """
-                CREATE TABLE directory_name (
-                    order_id INTEGER NOT NULL,
-                    name BLOB NOT NULL,
-                    PRIMARY KEY (order_id, name)
-                ) WITHOUT ROWID
-                """
-            )
-        except BaseException:
-            self._connection.close()
-            raise
-
-    def __enter__(self) -> _SpilledDirectoryOrder:
-        return self
-
-    def __exit__(self, *_exc_info: object) -> None:
-        self.close()
-
-    def close(self) -> None:
-        self._connection.close()
-
-    def scan(
-        self,
-        descriptor: int,
-        *,
-        error_type: type[MemorySnapshotError],
-        message: str,
-        include: Callable[[str], bool] | None = None,
-    ) -> _DirectoryOrderCursor:
-        order_id = self._next_order_id
-        self._next_order_id += 1
-        rows: list[tuple[int, bytes]] = []
-        try:
-            with os.scandir(descriptor) as iterator:
-                for entry in iterator:
-                    if include is not None and not include(entry.name):
-                        continue
-                    rows.append((order_id, os.fsencode(entry.name)))
-                    if len(rows) >= _directory_order_insert_batch_size():
-                        self._insert(rows)
-                        rows.clear()
-            if rows:
-                self._insert(rows)
-        except (OSError, sqlite3.Error, UnicodeError) as error:
-            raise error_type(message) from error
-        return _DirectoryOrderCursor(order_id=order_id)
-
-    def next_name(
-        self,
-        cursor: _DirectoryOrderCursor,
-        *,
-        error_type: type[MemorySnapshotError],
-        message: str,
-    ) -> str | None:
-        if cursor.exhausted:
-            return None
-        try:
-            if cursor.last_name is None:
-                row = self._connection.execute(
-                    """
-                    SELECT name FROM directory_name
-                    WHERE order_id = ? ORDER BY name LIMIT 1
-                    """,
-                    (cursor.order_id,),
-                ).fetchone()
-            else:
-                row = self._connection.execute(
-                    """
-                    SELECT name FROM directory_name
-                    WHERE order_id = ? AND name > ? ORDER BY name LIMIT 1
-                    """,
-                    (cursor.order_id, cursor.last_name),
-                ).fetchone()
-            if row is not None:
-                cursor.last_name = bytes(row[0])
-                return os.fsdecode(cursor.last_name)
-            self._connection.execute(
-                "DELETE FROM directory_name WHERE order_id = ?",
-                (cursor.order_id,),
-            )
-            cursor.exhausted = True
-            return None
-        except sqlite3.Error as error:
-            raise error_type(message) from error
-
-    def _insert(self, rows: Sequence[tuple[int, bytes]]) -> None:
-        self._connection.executemany(
-            "INSERT INTO directory_name (order_id, name) VALUES (?, ?)",
-            rows,
-        )
 
 
 class _DirectoryDescriptorCache:
@@ -467,7 +396,7 @@ class _ManifestWriter:
     """Write an authenticated manifest without retaining the full tree."""
 
     def __init__(self, path: Path) -> None:
-        flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0)
+        flags = strict_file_create_flags()
         self._descriptor = os.open(path, flags, 0o600)
         self._path = path
         self._buffer: list[bytes] = []
@@ -697,6 +626,12 @@ class MemorySnapshotManager:
         surfaces: Sequence[SnapshotSurface] = DEFAULT_MEMORY_SNAPSHOT_SURFACES,
         operation_guard: Callable[[], None] | None = None,
     ) -> None:
+        try:
+            required_no_follow_flag()
+        except ConfinedFilesystemError as error:
+            raise MemorySnapshotUnsafePathError(
+                "Memory snapshots require no-follow filesystem support"
+            ) from error
         self._effective_home = _absolute_without_resolve(effective_home)
         root_value = Path(snapshot_root)
         if root_value.is_absolute():
@@ -789,7 +724,7 @@ class MemorySnapshotManager:
             _fsync_directory(payload_root)
             _fsync_directory(stage)
             self._verify_directory(identifier, stage)
-            os.replace(stage, final)
+            _replace_safe_path(self._effective_home, stage, final)
             published = True
             _fsync_directory(self._snapshot_root)
             return self._verify_directory(identifier, final)
@@ -814,10 +749,11 @@ class MemorySnapshotManager:
         _require_directory_private(root_info, "Memory backup root")
         root_fd = _open_directory(self._snapshot_root, "Memory backup root")
         removed: list[str] = []
-        orders: _SpilledDirectoryOrder | None = None
+        orders: SpilledDirectoryOrder | None = None
         try:
-            orders = _SpilledDirectoryOrder()
-            candidates = orders.scan(
+            orders = _new_directory_order()
+            candidates = _scan_directory_order(
+                orders,
                 root_fd,
                 error_type=MemorySnapshotUnsafePathError,
                 message="Memory backup root cannot be scanned safely",
@@ -825,7 +761,8 @@ class MemorySnapshotManager:
                 is not None,
             )
             while True:
-                name = orders.next_name(
+                name = _next_directory_name(
+                    orders,
                     candidates,
                     error_type=MemorySnapshotUnsafePathError,
                     message="Memory backup root cannot be scanned safely",
@@ -987,12 +924,16 @@ class MemorySnapshotManager:
                             sidecar=candidate_index > 0,
                         )
                         if backup_info is None:
-                            os.replace(candidate, backup)
+                            _replace_safe_path(self._effective_home, candidate, backup)
                             plan.backups.append(_RestoreBackup(candidate, backup, True))
                         else:
                             _remove_safe_path(self._effective_home, candidate)
                     for staged_file, installed_target in plan.installs:
-                        os.replace(staged_file, installed_target)
+                        _replace_safe_path(
+                            self._effective_home,
+                            staged_file,
+                            installed_target,
+                        )
                         plan.installed_targets.append(installed_target)
                     _fsync_directory(plan.target.parent)
             except Exception:
@@ -1048,7 +989,7 @@ class MemorySnapshotManager:
             expected_manifest_sha256=expected_manifest_sha256,
             expected_surface_digests=expected_surface_digests,
         )
-        os.replace(directory, tombstone)
+        _replace_safe_path(self._effective_home, directory, tombstone)
         _fsync_directory(self._snapshot_root)
         _remove_safe_path(self._effective_home, tombstone)
         _fsync_directory(self._snapshot_root)
@@ -1280,9 +1221,9 @@ class MemorySnapshotManager:
         destination_root_fd = _open_directory(destination, "Memory snapshot destination")
         source_cache = _DirectoryDescriptorCache(source_root_fd)
         destination_cache = _DirectoryDescriptorCache(destination_root_fd)
-        orders: _SpilledDirectoryOrder | None = None
+        orders: SpilledDirectoryOrder | None = None
         try:
-            orders = _SpilledDirectoryOrder()
+            orders = _new_directory_order()
             root_mode = stat.S_IMODE(info.st_mode)
             stack = [
                 _tree_copy_frame(
@@ -1298,7 +1239,8 @@ class MemorySnapshotManager:
             root_entry: SnapshotEntry | None = None
             while stack:
                 frame = stack[-1]
-                child_name = orders.next_name(
+                child_name = _next_directory_name(
+                    orders,
                     frame.child_order,
                     error_type=MemorySnapshotError,
                     message="Memory tree surface could not be read",
@@ -1690,7 +1632,11 @@ class MemorySnapshotManager:
                     _remove_safe_path(self._effective_home, installed_target)
                 for backup in reversed(plan.backups):
                     if backup.created_this_run and backup.backup.exists():
-                        os.replace(backup.backup, backup.target)
+                        _replace_safe_path(
+                            self._effective_home,
+                            backup.backup,
+                            backup.target,
+                        )
                 if plan.staged is not None:
                     _remove_safe_path(self._effective_home, plan.staged)
                 _fsync_directory(plan.target.parent)
@@ -1737,29 +1683,12 @@ def _managed_source_info(home: Path, source: Path) -> os.stat_result | None:
 
 
 def _ensure_private_directory(home: Path, directory: Path) -> None:
-    if directory != home:
-        relative = _relative_to_home(directory, home)
-    else:
-        relative = Path()
-    if not home.exists():
-        home.mkdir(parents=True, mode=0o700)
-        _require_directory(os.lstat(home), "effective Memory home")
-        os.chmod(home, 0o700)
-        _fsync_directory(home)
-    current = home
-    for component in relative.parts:
-        current /= component
-        try:
-            info = os.lstat(current)
-        except FileNotFoundError:
-            os.mkdir(current, mode=0o700)
-            _fsync_directory(current.parent)
-            info = os.lstat(current)
-        _require_directory(info, "Memory private directory")
-        os.chmod(current, 0o700)
-        _fsync_directory(current)
-        if stat.S_IMODE(os.lstat(current).st_mode) != 0o700:
-            raise MemorySnapshotUnsafePathError("Memory directory is not owner-only")
+    try:
+        ensure_confined_private_directory(home, directory)
+    except ConfinedFilesystemError as error:
+        raise MemorySnapshotUnsafePathError(
+            "Memory directory cannot be prepared safely"
+        ) from error
 
 
 def _mkdir_private(path: Path) -> None:
@@ -1769,7 +1698,7 @@ def _mkdir_private(path: Path) -> None:
 
 
 def _directory_open_flags() -> int:
-    return os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+    return strict_directory_open_flags()
 
 
 def _open_directory(path: Path, label: str) -> int:
@@ -1836,7 +1765,7 @@ def _directory_identity(info: os.stat_result) -> tuple[int, int, int, int]:
 
 def _tree_copy_frame(
     source_cache: _DirectoryDescriptorCache,
-    orders: _SpilledDirectoryOrder,
+    orders: SpilledDirectoryOrder,
     node: _RelativeNode | None,
     *,
     base_path: str,
@@ -1865,7 +1794,8 @@ def _tree_copy_frame(
             entry_type=entry_type,
             mode=mode,
             before=_directory_identity(opened),
-            child_order=orders.scan(
+            child_order=_scan_directory_order(
+                orders,
                 descriptor,
                 error_type=MemorySnapshotError,
                 message="Memory tree surface could not be read",
@@ -1916,13 +1846,13 @@ def _missing_entry(path: str) -> SnapshotEntry:
 
 
 def _copy_regular_file(source: Path, destination: Path, *, mode: int) -> tuple[int, str]:
-    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+    flags = strict_file_read_flags()
     source_fd = os.open(source, flags)
     destination_fd: int | None = None
     try:
         before = os.fstat(source_fd)
         _require_regular_private(before, "Memory snapshot source file")
-        destination_flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0)
+        destination_flags = strict_file_create_flags()
         destination_fd = os.open(destination, destination_flags, 0o600)
         digest = hashlib.sha256()
         size = 0
@@ -1969,7 +1899,7 @@ def _copy_regular_file_at(
     target_name = source_name if destination_name is None else destination_name
     source_fd = os.open(
         source_name,
-        os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0),
+        strict_file_read_flags(),
         dir_fd=source_parent_fd,
     )
     destination_fd: int | None = None
@@ -1979,10 +1909,7 @@ def _copy_regular_file_at(
         _require_regular_private(before, "Memory snapshot source file")
         destination_fd = os.open(
             target_name,
-            os.O_WRONLY
-            | os.O_CREAT
-            | os.O_EXCL
-            | getattr(os, "O_NOFOLLOW", 0),
+            strict_file_create_flags(),
             0o600,
             dir_fd=destination_parent_fd,
         )
@@ -2084,7 +2011,7 @@ def _indexed_manifest(path: Path) -> Iterator[tuple[_ManifestIndex, str]]:
 
 
 def _read_manifest(path: Path, entries: _ManifestIndex) -> str:
-    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+    flags = strict_file_read_flags()
     try:
         descriptor = os.open(path, flags)
     except OSError as error:
@@ -2269,13 +2196,14 @@ def _verify_payload_paths(
     entries: _ManifestIndex,
 ) -> None:
     root_info = os.fstat(payload_root_fd)
-    orders = _SpilledDirectoryOrder()
+    orders = _new_directory_order()
     try:
         stack = [
             _DirectoryWalkFrame(
                 node=None,
                 before=_directory_identity(root_info),
-                child_order=orders.scan(
+                child_order=_scan_directory_order(
+                    orders,
                     payload_root_fd,
                     error_type=MemorySnapshotVerificationError,
                     message="Memory snapshot payload cannot be read",
@@ -2284,7 +2212,8 @@ def _verify_payload_paths(
         ]
         while stack:
             frame = stack[-1]
-            child_name = orders.next_name(
+            child_name = _next_directory_name(
+                orders,
                 frame.child_order,
                 error_type=MemorySnapshotVerificationError,
                 message="Memory snapshot payload cannot be read",
@@ -2358,7 +2287,8 @@ def _verify_payload_paths(
                         _DirectoryWalkFrame(
                             node=child_node,
                             before=_directory_identity(opened),
-                            child_order=orders.scan(
+                            child_order=_scan_directory_order(
+                                orders,
                                 descriptor,
                                 error_type=MemorySnapshotVerificationError,
                                 message="Memory snapshot payload cannot be read",
@@ -2390,7 +2320,7 @@ def _entry_from_row(row: Sequence[object]) -> SnapshotEntry:
 
 
 def _file_sha256(path: Path) -> str:
-    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+    flags = strict_file_read_flags()
     descriptor = os.open(path, flags)
     digest = hashlib.sha256()
     try:
@@ -2425,7 +2355,7 @@ def _file_sha256(path: Path) -> str:
 def _file_sha256_at(parent_fd: int, name: str) -> str:
     descriptor = os.open(
         name,
-        os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0),
+        strict_file_read_flags(),
         dir_fd=parent_fd,
     )
     digest = hashlib.sha256()
@@ -2543,7 +2473,7 @@ def _call_log_has_sqlite_header(home: Path, database: Path) -> bool:
     try:
         database_fd = os.open(
             database.name,
-            os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0),
+            strict_file_read_flags(),
             dir_fd=directory_fd,
         )
         before = os.fstat(database_fd)
@@ -2618,8 +2548,17 @@ def _remove_safe_entry(
         ) from error
 
 
+def _replace_safe_path(home: Path, source: Path, destination: Path) -> None:
+    try:
+        replace_confined(home, source, destination)
+    except ConfinedFilesystemError as error:
+        raise MemorySnapshotUnsafePathError(
+            "Memory snapshot entry could not be replaced safely"
+        ) from error
+
+
 def _fsync_file(path: Path) -> None:
-    flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+    flags = strict_file_read_flags()
     descriptor = os.open(path, flags)
     try:
         os.fsync(descriptor)
@@ -2628,9 +2567,9 @@ def _fsync_file(path: Path) -> None:
 
 
 def _fsync_directory(path: Path) -> None:
-    flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
-    descriptor = os.open(path, flags)
     try:
-        os.fsync(descriptor)
-    finally:
-        os.close(descriptor)
+        fsync_confined_directory(path)
+    except ConfinedFilesystemError as error:
+        raise MemorySnapshotUnsafePathError(
+            "Memory directory could not be synchronized safely"
+        ) from error

--- a/tests/test_memory_attachments.py
+++ b/tests/test_memory_attachments.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import errno
 import hashlib
 import os
+import sqlite3
 import stat
 from dataclasses import fields
 from pathlib import Path
@@ -12,6 +13,7 @@ from urllib.parse import quote
 import pytest
 
 import core.memory.attachments as attachment_module
+import core.memory.confined_filesystem as confined_filesystem_module
 from core.memory.attachments import (
     AttachmentPinError,
     AttachmentPinStore,
@@ -393,6 +395,40 @@ def test_reconcile_preserves_references_and_removes_releasing_orphans_and_stagin
     assert not stale.exists()
     assert unknown.read_text(encoding="utf-8") == "keep"
     assert store.reconcile({referenced.bundle_id}, {releasing.bundle_id}) == ()
+
+
+@pytest.mark.parametrize("operation", ["provider", "reconcile"])
+def test_attachment_reads_translate_temporary_ordering_database_failure(
+    attachment_roots,
+    monkeypatch: pytest.MonkeyPatch,
+    operation: str,
+) -> None:
+    _home, source_root = attachment_roots
+    store = AttachmentPinStore()
+    bundle = store.pin((_attachment(_source_file(source_root, "referenced.txt")),))
+    failure = sqlite3.OperationalError("temporary ordering unavailable")
+
+    def fail_connect(*_args, **_kwargs):
+        raise failure
+
+    monkeypatch.setattr(
+        confined_filesystem_module.sqlite3,
+        "connect",
+        fail_connect,
+    )
+
+    with pytest.raises(AttachmentPinError) as raised:
+        if operation == "provider":
+            store.provider_attachments(bundle)
+        else:
+            store.reconcile({bundle.bundle_id}, set())
+
+    _assert_pin_error(raised, "memory_store_unavailable")
+    assert isinstance(
+        raised.value.__cause__,
+        confined_filesystem_module.ConfinedFilesystemError,
+    )
+    assert raised.value.__cause__.__cause__ is failure
 
 
 def test_reconcile_reports_missing_reference(attachment_roots) -> None:

--- a/tests/test_memory_confined_filesystem.py
+++ b/tests/test_memory_confined_filesystem.py
@@ -28,6 +28,7 @@ import os
 import sys
 import asyncio
 from pathlib import Path
+from types import SimpleNamespace
 
 delattr(os, "O_NOFOLLOW")
 
@@ -39,6 +40,7 @@ from core.memory.confined_filesystem import ConfinedFilesystemError, PrivateSqli
 from config.v2_config import MemoryConfig
 from core.memory.artifact import MemoryArtifactManager
 from core.memory.runtime import create_memory_runtime
+from core.memory.provider_root import ProviderRoot, ProviderRootError, ProviderRootMetadata
 from core.memory.snapshot import MemorySnapshotManager, MemorySnapshotUnsafePathError
 
 home = Path(sys.argv[1])
@@ -61,6 +63,21 @@ except ConfinedFilesystemError as error:
     assert "no-follow" in str(error)
 else:
     raise AssertionError("Memory persistence accepted a host without O_NOFOLLOW")
+provider_root = ProviderRoot(home / "memory" / "everos-root", effective_home=home)
+try:
+    provider_root.ensure(
+        SimpleNamespace(provider_root_id="root-id"),
+        ProviderRootMetadata(
+            provider_root_format="everos-1.0",
+            compatible_provider_root_formats=frozenset({"everos-1.0"}),
+            artifact_fingerprint="artifact",
+        ),
+    )
+except ProviderRootError:
+    pass
+else:
+    raise AssertionError("Memory provider root accepted a host without O_NOFOLLOW")
+assert not home.exists()
 
 for enabled in (False, True):
     runtime_home = home / ("enabled" if enabled else "disabled")
@@ -129,6 +146,117 @@ def test_spilled_directory_order_preserves_raw_filename_order_across_batches(
     assert [os.fsencode(name) for name in actual] == sorted(
         os.fsencode(name) for name in names
     )
+
+
+def test_spilled_directory_order_translates_connect_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from core.memory import confined_filesystem
+
+    failure = sqlite3.OperationalError("temporary database unavailable")
+
+    def fail_connect(*_args, **_kwargs):
+        raise failure
+
+    monkeypatch.setattr(confined_filesystem.sqlite3, "connect", fail_connect)
+
+    with pytest.raises(ConfinedFilesystemError) as raised:
+        confined_filesystem.SpilledDirectoryOrder()
+
+    assert raised.value.__cause__ is failure
+
+
+def test_spilled_directory_order_closes_and_translates_schema_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from core.memory import confined_filesystem
+
+    real_connection = sqlite3.connect("")
+    failure = sqlite3.OperationalError("temporary schema unavailable")
+
+    class Connection:
+        closed = False
+
+        def execute(self, sql: str, parameters=()):
+            if "CREATE TABLE directory_name" in sql:
+                raise failure
+            return real_connection.execute(sql, parameters)
+
+        def close(self) -> None:
+            self.closed = True
+            real_connection.close()
+
+    connection = Connection()
+    monkeypatch.setattr(
+        confined_filesystem.sqlite3,
+        "connect",
+        lambda *_args, **_kwargs: connection,
+    )
+
+    with pytest.raises(ConfinedFilesystemError) as raised:
+        confined_filesystem.SpilledDirectoryOrder()
+
+    assert raised.value.__cause__ is failure
+    assert connection.closed is True
+    with pytest.raises(sqlite3.ProgrammingError, match="closed database"):
+        real_connection.execute("SELECT 1")
+
+
+@pytest.mark.parametrize("failure_stage", ["insert", "read"])
+def test_spilled_directory_order_closes_after_operation_database_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    failure_stage: str,
+) -> None:
+    from core.memory import confined_filesystem
+
+    class Entry:
+        name = "entry"
+
+    class Scandir:
+        def __enter__(self):
+            return iter((Entry(),))
+
+        def __exit__(self, *_exc_info: object) -> None:
+            return None
+
+    monkeypatch.setattr(confined_filesystem.os, "scandir", lambda _fd: Scandir())
+    order = confined_filesystem.SpilledDirectoryOrder(insert_batch_size=1)
+    real_connection = order._connection
+    failure = sqlite3.OperationalError(f"temporary {failure_stage} failed")
+
+    class Connection:
+        closed = False
+
+        def execute(self, sql: str, parameters=()):
+            if failure_stage == "read" and "SELECT name" in sql:
+                raise failure
+            return real_connection.execute(sql, parameters)
+
+        def executemany(self, sql: str, parameters):
+            if failure_stage == "insert":
+                raise failure
+            return real_connection.executemany(sql, parameters)
+
+        def close(self) -> None:
+            self.closed = True
+            real_connection.close()
+
+    connection = Connection()
+    if failure_stage == "read":
+        cursor = order.scan(-1)
+        order._connection = connection
+        operation = lambda: order.next_name(cursor)
+    else:
+        order._connection = connection
+        operation = lambda: order.scan(-1)
+
+    with pytest.raises(ConfinedFilesystemError) as raised:
+        operation()
+
+    assert raised.value.__cause__ is failure
+    assert connection.closed is True
+    with pytest.raises(sqlite3.ProgrammingError, match="closed database"):
+        real_connection.execute("SELECT 1")
 
 
 def test_spilled_directory_order_closes_temporary_database_on_base_exception() -> None:

--- a/tests/test_memory_confined_filesystem.py
+++ b/tests/test_memory_confined_filesystem.py
@@ -354,6 +354,32 @@ def test_remove_confined_path_refuses_to_follow_a_swapped_directory(
     assert victim.read_text(encoding="utf-8") == "outside must survive"
 
 
+def test_remove_confined_regular_file_does_not_initialize_directory_ordering(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home = tmp_path / "home"
+    home.mkdir(mode=0o700)
+    target = home / "current.json"
+    target.write_text("pointer", encoding="utf-8")
+    target.chmod(0o600)
+    connect_calls = 0
+
+    from core.memory import confined_filesystem
+
+    def fail_connect(*_args, **_kwargs):
+        nonlocal connect_calls
+        connect_calls += 1
+        raise sqlite3.OperationalError("temporary ordering unavailable")
+
+    monkeypatch.setattr(confined_filesystem.sqlite3, "connect", fail_connect)
+
+    remove_confined_path(home, target)
+
+    assert connect_calls == 0
+    assert not target.exists()
+
+
 def test_confined_atomic_replace_refuses_symlink_source_and_replaces_symlink_target(
     tmp_path: Path,
 ) -> None:
@@ -457,6 +483,68 @@ def test_confined_atomic_replace_cleans_a_source_replaced_during_rename(
     assert not target.is_symlink()
     assert held.read_text(encoding="utf-8") == "original"
     assert outside.read_text(encoding="utf-8") == "outside survives"
+
+
+def test_confined_atomic_replace_removes_a_source_made_public_during_rename(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home = tmp_path / "home"
+    home.mkdir(mode=0o700)
+    stage = home / "stage"
+    stage.mkdir(mode=0o700)
+    value = stage / "value.txt"
+    value.write_text("private", encoding="utf-8")
+    value.chmod(0o600)
+    target = home / "target"
+    outside = tmp_path / "outside.txt"
+    outside.write_text("outside survives", encoding="utf-8")
+
+    from core.memory import confined_filesystem
+
+    real_replace = confined_filesystem.os.replace
+
+    def expose_source_before_replace(source, destination, *args, **kwargs):
+        stage.chmod(0o755)
+        return real_replace(source, destination, *args, **kwargs)
+
+    monkeypatch.setattr(confined_filesystem.os, "replace", expose_source_before_replace)
+
+    with pytest.raises(ConfinedFilesystemError):
+        replace_confined(home, stage, target)
+
+    assert not target.exists()
+    assert outside.read_text(encoding="utf-8") == "outside survives"
+
+
+def test_confined_atomic_replace_removes_a_source_hardlinked_during_rename(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home = tmp_path / "home"
+    home.mkdir(mode=0o700)
+    stage = home / "stage"
+    stage.write_text("private", encoding="utf-8")
+    stage.chmod(0o600)
+    target = home / "target"
+    outside_link = tmp_path / "outside-link.txt"
+
+    from core.memory import confined_filesystem
+
+    real_replace = confined_filesystem.os.replace
+
+    def link_source_before_replace(source, destination, *args, **kwargs):
+        os.link(stage, outside_link)
+        return real_replace(source, destination, *args, **kwargs)
+
+    monkeypatch.setattr(confined_filesystem.os, "replace", link_source_before_replace)
+
+    with pytest.raises(ConfinedFilesystemError):
+        replace_confined(home, stage, target)
+
+    assert not target.exists()
+    assert outside_link.read_text(encoding="utf-8") == "private"
+    assert outside_link.stat().st_nlink == 1
 
 
 def test_confined_replace_and_cleanup_accept_owner_only_directory_modes(

--- a/tests/test_memory_confined_filesystem.py
+++ b/tests/test_memory_confined_filesystem.py
@@ -26,6 +26,7 @@ def test_memory_persistence_fails_closed_without_no_follow_before_touching_path(
     script = """
 import os
 import sys
+import asyncio
 from pathlib import Path
 
 delattr(os, "O_NOFOLLOW")
@@ -35,11 +36,15 @@ delattr(os, "O_NOFOLLOW")
 import core.controller  # noqa: F401
 from core.memory.attachments import AttachmentPinError, AttachmentPinStore
 from core.memory.confined_filesystem import ConfinedFilesystemError, PrivateSqliteDatabase
+from config.v2_config import MemoryConfig
+from core.memory.artifact import MemoryArtifactManager
+from core.memory.runtime import create_memory_runtime
 from core.memory.snapshot import MemorySnapshotManager, MemorySnapshotUnsafePathError
 
 home = Path(sys.argv[1])
+snapshot_manager = MemorySnapshotManager(home)
 try:
-    MemorySnapshotManager(home)
+    snapshot_manager.create("unsupported")
 except MemorySnapshotUnsafePathError:
     pass
 else:
@@ -56,6 +61,27 @@ except ConfinedFilesystemError as error:
     assert "no-follow" in str(error)
 else:
     raise AssertionError("Memory persistence accepted a host without O_NOFOLLOW")
+
+for enabled in (False, True):
+    runtime_home = home / ("enabled" if enabled else "disabled")
+    artifact = MemoryArtifactManager(
+        runtime_dir=runtime_home / "runtime" / "memory",
+        provider_root=runtime_home / "memory" / "everos-root",
+        offline=True,
+    )
+    runtime = create_memory_runtime(
+        MemoryConfig(enabled=enabled),
+        artifact_manager=artifact,
+        effective_home=runtime_home,
+    )
+    assert runtime.available is False
+    result = asyncio.run(runtime.reconcile(MemoryConfig(enabled=enabled)))
+    if enabled:
+        assert result == {"ok": False, "error": "memory_store_unavailable"}
+    else:
+        assert result == {"ok": True, "state": "disabled"}
+    asyncio.run(runtime.close())
+    assert not runtime_home.exists()
 assert not home.exists()
 """
 
@@ -263,6 +289,64 @@ def test_confined_atomic_replace_stays_on_pinned_parent_during_directory_swap(
     assert swapped
     assert (held / "target").read_text(encoding="utf-8") == "published"
     assert sentinel.read_text(encoding="utf-8") == "outside survives"
+
+
+@pytest.mark.parametrize("replacement_type", ["regular", "symlink"])
+def test_confined_atomic_replace_cleans_a_source_replaced_during_rename(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    replacement_type: str,
+) -> None:
+    home = tmp_path / "home"
+    home.mkdir(mode=0o700)
+    stage = home / "stage"
+    stage.write_text("original", encoding="utf-8")
+    stage.chmod(0o600)
+    target = home / "target"
+    held = home / "held"
+    outside = tmp_path / "outside.txt"
+    outside.write_text("outside survives", encoding="utf-8")
+
+    from core.memory import confined_filesystem
+
+    real_replace = confined_filesystem.os.replace
+
+    def swap_source_before_replace(source, destination, *args, **kwargs):
+        stage.rename(held)
+        if replacement_type == "regular":
+            stage.write_text("raced", encoding="utf-8")
+            stage.chmod(0o600)
+        else:
+            stage.symlink_to(outside)
+        return real_replace(source, destination, *args, **kwargs)
+
+    monkeypatch.setattr(confined_filesystem.os, "replace", swap_source_before_replace)
+
+    with pytest.raises(ConfinedFilesystemError):
+        replace_confined(home, stage, target)
+
+    assert not target.exists()
+    assert not target.is_symlink()
+    assert held.read_text(encoding="utf-8") == "original"
+    assert outside.read_text(encoding="utf-8") == "outside survives"
+
+
+def test_confined_replace_and_cleanup_accept_owner_only_directory_modes(
+    tmp_path: Path,
+) -> None:
+    home = tmp_path / "home"
+    home.mkdir(mode=0o700)
+    stage = home / "stage"
+    stage.mkdir(mode=0o700)
+    (stage / "value.txt").write_text("preserved", encoding="utf-8")
+    stage.chmod(0o500)
+    target = home / "target"
+
+    replace_confined(home, stage, target)
+
+    assert stat.S_IMODE(target.stat().st_mode) == 0o500
+    remove_confined_path(home, target)
+    assert not target.exists()
 
 
 def test_private_sqlite_database_prepares_and_hardens_owned_files(tmp_path: Path) -> None:

--- a/tests/test_memory_confined_filesystem.py
+++ b/tests/test_memory_confined_filesystem.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+import asyncio
 import os
 import sqlite3
 import stat
+import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -12,7 +15,150 @@ from core.memory.confined_filesystem import (
     PrivateSqliteDatabase,
     remove_anchored_entry,
     remove_confined_path,
+    replace_confined,
 )
+
+
+def test_memory_persistence_fails_closed_without_no_follow_before_touching_path(
+    tmp_path: Path,
+) -> None:
+    home = tmp_path / "must-not-exist"
+    script = """
+import os
+import sys
+from pathlib import Path
+
+delattr(os, "O_NOFOLLOW")
+
+# Importing ordinary application wiring must remain usable when only Memory
+# persistence is unsupported on the host.
+import core.controller  # noqa: F401
+from core.memory.attachments import AttachmentPinError, AttachmentPinStore
+from core.memory.confined_filesystem import ConfinedFilesystemError, PrivateSqliteDatabase
+from core.memory.snapshot import MemorySnapshotManager, MemorySnapshotUnsafePathError
+
+home = Path(sys.argv[1])
+try:
+    MemorySnapshotManager(home)
+except MemorySnapshotUnsafePathError:
+    pass
+else:
+    raise AssertionError("Memory snapshots accepted a host without O_NOFOLLOW")
+try:
+    AttachmentPinStore(effective_home=home, source_root=home / "source")
+except AttachmentPinError:
+    pass
+else:
+    raise AssertionError("Memory attachments accepted a host without O_NOFOLLOW")
+try:
+    PrivateSqliteDatabase(home, home / "state" / "journal.sqlite").prepare()
+except ConfinedFilesystemError as error:
+    assert "no-follow" in str(error)
+else:
+    raise AssertionError("Memory persistence accepted a host without O_NOFOLLOW")
+assert not home.exists()
+"""
+
+    completed = subprocess.run(
+        [sys.executable, "-c", script, os.fspath(home)],
+        cwd=Path(__file__).resolve().parents[1],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert not home.exists()
+
+
+def test_supported_host_exposes_strict_no_follow_capability() -> None:
+    from core.memory import confined_filesystem
+
+    assert confined_filesystem.required_no_follow_flag() == os.O_NOFOLLOW
+
+
+def test_spilled_directory_order_preserves_raw_filename_order_across_batches(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from core.memory import confined_filesystem
+
+    names = ["z", "a", "\udcff", "\udc80", "middle"]
+
+    class Entry:
+        def __init__(self, name: str) -> None:
+            self.name = name
+
+    class Scandir:
+        def __enter__(self):
+            return iter(Entry(name) for name in names)
+
+        def __exit__(self, *_exc_info: object) -> None:
+            return None
+
+    monkeypatch.setattr(confined_filesystem.os, "scandir", lambda _fd: Scandir())
+    with confined_filesystem.SpilledDirectoryOrder(insert_batch_size=2) as order:
+        cursor = order.scan(-1)
+        actual = list(order.names(cursor))
+
+    assert [os.fsencode(name) for name in actual] == sorted(
+        os.fsencode(name) for name in names
+    )
+
+
+def test_spilled_directory_order_closes_temporary_database_on_base_exception() -> None:
+    from core.memory import confined_filesystem
+
+    class InjectedCancellation(BaseException):
+        pass
+
+    order = confined_filesystem.SpilledDirectoryOrder(insert_batch_size=2)
+    connection = order._connection
+
+    with pytest.raises(InjectedCancellation):
+        with order:
+            raise InjectedCancellation()
+
+    with pytest.raises(sqlite3.ProgrammingError, match="closed database"):
+        connection.execute("SELECT 1")
+
+
+@pytest.mark.parametrize(
+    "failure",
+    [RuntimeError("failed"), asyncio.CancelledError(), KeyboardInterrupt()],
+)
+def test_spilled_directory_order_closes_on_scan_failure_and_cancellation(
+    monkeypatch: pytest.MonkeyPatch,
+    failure: BaseException,
+) -> None:
+    from core.memory import confined_filesystem
+
+    class FailingScandir:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_exc_info: object) -> None:
+            return None
+
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            raise failure
+
+    monkeypatch.setattr(
+        confined_filesystem.os,
+        "scandir",
+        lambda _fd: FailingScandir(),
+    )
+    order = confined_filesystem.SpilledDirectoryOrder(insert_batch_size=2)
+    connection = order._connection
+
+    with pytest.raises(type(failure)):
+        with order:
+            order.scan(-1)
+
+    with pytest.raises(sqlite3.ProgrammingError, match="closed database"):
+        connection.execute("SELECT 1")
 
 
 def test_remove_confined_path_refuses_to_follow_a_swapped_directory(
@@ -52,6 +198,71 @@ def test_remove_confined_path_refuses_to_follow_a_swapped_directory(
     assert swapped
     assert target.is_symlink()
     assert victim.read_text(encoding="utf-8") == "outside must survive"
+
+
+def test_confined_atomic_replace_refuses_symlink_source_and_replaces_symlink_target(
+    tmp_path: Path,
+) -> None:
+    home = tmp_path / "home"
+    home.mkdir(mode=0o700)
+    outside = tmp_path / "outside.txt"
+    outside.write_text("outside survives", encoding="utf-8")
+    stage = home / "stage"
+    target = home / "target"
+
+    stage.symlink_to(outside)
+    with pytest.raises(ConfinedFilesystemError):
+        replace_confined(home, stage, target)
+    assert stage.is_symlink()
+    assert not target.exists()
+
+    stage.unlink()
+    stage.write_text("published", encoding="utf-8")
+    stage.chmod(0o600)
+    target.symlink_to(outside)
+    replace_confined(home, stage, target)
+
+    assert target.read_text(encoding="utf-8") == "published"
+    assert not target.is_symlink()
+    assert outside.read_text(encoding="utf-8") == "outside survives"
+
+
+def test_confined_atomic_replace_stays_on_pinned_parent_during_directory_swap(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home = tmp_path / "home"
+    home.mkdir(mode=0o700)
+    managed = home / "managed"
+    managed.mkdir(mode=0o700)
+    stage = managed / "stage"
+    stage.write_text("published", encoding="utf-8")
+    stage.chmod(0o600)
+    outside = tmp_path / "outside"
+    outside.mkdir(mode=0o700)
+    sentinel = outside / "target"
+    sentinel.write_text("outside survives", encoding="utf-8")
+    held = home / "held-managed"
+
+    from core.memory import confined_filesystem
+
+    real_replace = confined_filesystem.os.replace
+    swapped = False
+
+    def swap_before_replace(source, destination, *args, **kwargs):
+        nonlocal swapped
+        if not swapped:
+            swapped = True
+            managed.rename(held)
+            managed.symlink_to(outside, target_is_directory=True)
+        return real_replace(source, destination, *args, **kwargs)
+
+    monkeypatch.setattr(confined_filesystem.os, "replace", swap_before_replace)
+    replace_confined(home, stage, managed / "target")
+
+    assert swapped
+    assert (held / "target").read_text(encoding="utf-8") == "published"
+    assert sentinel.read_text(encoding="utf-8") == "outside survives"
 
 
 def test_private_sqlite_database_prepares_and_hardens_owned_files(tmp_path: Path) -> None:

--- a/tests/test_memory_maintenance.py
+++ b/tests/test_memory_maintenance.py
@@ -2141,8 +2141,10 @@ async def test_backup_restore_crash_is_fenced_and_boot_converges_one_generation(
         nonlocal crashed, intent_visible_before_replace
         if (
             not crashed
-            and Path(destination) == target
+            and Path(destination).name == target.name
             and f".restore-{backup.snapshot_id}-" in Path(source).name
+            and kwargs.get("src_dir_fd") is not None
+            and kwargs.get("dst_dir_fd") is not None
         ):
             open_operation = _maintenance(runtime)._backup_restore_journal.get_open_operation()
             assert open_operation is not None

--- a/tests/test_memory_provider_root.py
+++ b/tests/test_memory_provider_root.py
@@ -236,6 +236,8 @@ def test_provider_root_recreate_empty_removes_children_but_preserves_root(
     identity = root.path.stat().st_ino
     nested = root.path / "vectors" / "nested"
     nested.mkdir(parents=True)
+    nested.parent.chmod(0o700)
+    nested.chmod(0o700)
     (nested / "data").write_bytes(b"provider data")
     (root.path / "everos.toml").write_text("generated", encoding="utf-8")
 

--- a/tests/test_memory_provider_root.py
+++ b/tests/test_memory_provider_root.py
@@ -2,11 +2,14 @@ from __future__ import annotations
 
 import json
 import os
+import sqlite3
+import stat
 from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
 
+import core.memory.confined_filesystem as confined_filesystem_module
 from core.memory.provider_root import (
     PROVIDER_ROOT_CONTROL_FILES,
     ROOT_SENTINEL_FILENAME,
@@ -73,6 +76,107 @@ def test_provider_root_ensure_creates_private_owned_root_and_sentinel(
         "provider_root_format": "everos-1.0",
         "created_by_artifact_fingerprint": "artifact-1.0",
     }
+
+
+def test_provider_root_ensure_creates_a_fresh_effective_home_privately(
+    tmp_path: Path,
+) -> None:
+    home = tmp_path / "fresh-home"
+    root = ProviderRoot(home / "memory" / "everos-root", effective_home=home)
+    meta = SimpleNamespace(provider_root_id="root-id")
+    previous_umask = os.umask(0o022)
+    try:
+        root.ensure(meta, _metadata())
+    finally:
+        os.umask(previous_umask)
+
+    assert stat.S_IMODE(home.stat().st_mode) == 0o700
+    assert root.inspect(_metadata()).exists is True
+
+
+def test_provider_root_ensure_hardens_an_owned_legacy_effective_home(
+    tmp_path: Path,
+) -> None:
+    home = tmp_path / "legacy-home"
+    home.mkdir(mode=0o755)
+    home.chmod(0o755)
+    root = ProviderRoot(home / "memory" / "everos-root", effective_home=home)
+    meta = SimpleNamespace(provider_root_id="root-id")
+
+    root.ensure(meta, _metadata())
+
+    assert stat.S_IMODE(home.stat().st_mode) == 0o700
+    assert root.inspect(_metadata()).exists is True
+
+
+def test_provider_root_refuses_to_harden_an_unowned_effective_home(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    getuid = getattr(os, "getuid", None)
+    if not callable(getuid):
+        pytest.skip("platform does not expose file ownership")
+    home = tmp_path / "foreign-home"
+    home.mkdir(mode=0o755)
+    home.chmod(0o755)
+    root = ProviderRoot(home / "memory" / "everos-root", effective_home=home)
+    meta = SimpleNamespace(provider_root_id="root-id")
+    monkeypatch.setattr(confined_filesystem_module.os, "getuid", lambda: getuid() + 1)
+
+    with pytest.raises(ProviderRootError, match="confinement home is unsafe"):
+        root.ensure(meta, _metadata())
+
+    assert stat.S_IMODE(home.stat().st_mode) == 0o755
+    assert not (home / "memory").exists()
+
+
+def test_provider_root_refuses_a_symlinked_effective_home_without_touching_target(
+    tmp_path: Path,
+) -> None:
+    outside = tmp_path / "outside"
+    outside.mkdir(mode=0o755)
+    outside.chmod(0o755)
+    home = tmp_path / "linked-home"
+    home.symlink_to(outside, target_is_directory=True)
+    root = ProviderRoot(home / "memory" / "everos-root", effective_home=home)
+    meta = SimpleNamespace(provider_root_id="root-id")
+
+    with pytest.raises(ProviderRootError, match="chain contains a symlink"):
+        root.ensure(meta, _metadata())
+
+    assert home.is_symlink()
+    assert stat.S_IMODE(outside.stat().st_mode) == 0o755
+    assert list(outside.iterdir()) == []
+
+
+def test_provider_root_translates_temporary_ordering_database_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    root, meta = _owner(tmp_path)
+    metadata = _metadata()
+    root.ensure(meta, metadata)
+    (root.path / "vectors").mkdir(mode=0o700)
+    failure = sqlite3.OperationalError("temporary ordering unavailable")
+
+    def fail_connect(*_args, **_kwargs):
+        raise failure
+
+    monkeypatch.setattr(
+        confined_filesystem_module.sqlite3,
+        "connect",
+        fail_connect,
+    )
+
+    with pytest.raises(ProviderRootError) as raised:
+        root.recreate_empty(meta, metadata)
+
+    assert isinstance(
+        raised.value.__cause__,
+        confined_filesystem_module.ConfinedFilesystemError,
+    )
+    assert raised.value.__cause__.__cause__ is failure
+    assert (root.path / "vectors").is_dir()
 
 
 @pytest.mark.parametrize(

--- a/tests/test_memory_runtime.py
+++ b/tests/test_memory_runtime.py
@@ -621,6 +621,7 @@ def test_memory_artifact_rejects_an_active_pointer_built_for_another_target(
 def test_memory_artifact_coordinator_rolls_back_the_active_pointer(tmp_path: Path) -> None:
     provider_root = tmp_path / "memory" / "everos-root"
     provider_root.mkdir(parents=True, mode=0o700)
+    provider_root.parent.chmod(0o700)
     sentinel = provider_root / ".avibe-memory-root.json"
     sentinel.write_text(
         json.dumps(
@@ -641,6 +642,7 @@ def test_memory_artifact_coordinator_rolls_back_the_active_pointer(tmp_path: Pat
         provider_root=provider_root,
     )
     manager.runtime_dir.mkdir(parents=True)
+    manager.runtime_dir.chmod(0o700)
     previous_pointer = {
         "provider": "manifest",
         "runtime_id": "memory-runtime",
@@ -654,7 +656,9 @@ def test_memory_artifact_coordinator_rolls_back_the_active_pointer(tmp_path: Pat
         "compatible_provider_root_formats": [],
         "artifact_fingerprint": "old-artifact",
     }
-    (manager.runtime_dir / "current.json").write_text(json.dumps(previous_pointer), encoding="utf-8")
+    current_pointer = manager.runtime_dir / "current.json"
+    current_pointer.write_text(json.dumps(previous_pointer), encoding="utf-8")
+    current_pointer.chmod(0o600)
     calls: list[tuple[str, object]] = []
 
     def coordinate(candidate, root_state, commit, rollback) -> None:

--- a/tests/test_memory_runtime.py
+++ b/tests/test_memory_runtime.py
@@ -6,6 +6,7 @@ import inspect
 import json
 import logging
 import os
+import sqlite3
 import stat
 import subprocess
 import sys
@@ -21,6 +22,7 @@ import pytest
 
 from core.managed_runtime import ManagedRuntimeArchive, ManagedRuntimeManifest
 import core.memory.artifact as memory_artifact
+import core.memory.confined_filesystem as confined_filesystem
 from core.memory.artifact import (
     FakeMemoryArtifactManager,
     MemoryArtifactCandidate,
@@ -714,6 +716,45 @@ def test_memory_artifact_coordinator_rolls_back_the_active_pointer(tmp_path: Pat
     ]
     assert json.loads((manager.runtime_dir / "current.json").read_text(encoding="utf-8")) == previous_pointer
     assert manager.provider_root_format() == "everos-1.0"
+
+
+def test_memory_artifact_first_activation_rollback_does_not_need_temp_sqlite(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    provider_root = tmp_path / "memory" / "everos-root"
+    manager = MemoryArtifactManager(
+        runtime_dir=tmp_path / "runtime",
+        offline=True,
+        provider_root=provider_root,
+    )
+    connect_calls = 0
+
+    def fail_connect(*_args, **_kwargs):
+        nonlocal connect_calls
+        connect_calls += 1
+        raise sqlite3.OperationalError("temporary ordering unavailable")
+
+    def reject_candidate(_candidate, root_state, commit, rollback) -> None:
+        assert root_state.exists is False
+        commit()
+        assert (manager.runtime_dir / "current.json").is_file()
+        rollback()
+        raise MemoryRuntimeActivationError("candidate rejected")
+
+    monkeypatch.setattr(confined_filesystem.sqlite3, "connect", fail_connect)
+    manager.set_activation_coordinator(reject_candidate)
+
+    with pytest.raises(MemoryRuntimeActivationError, match="candidate rejected"):
+        manager._write_current_pointer(
+            manager.runtime_dir / "versions" / "candidate",
+            _artifact_manifest("everos-2.0", compatible_formats=[]),
+            _artifact_archive(),
+        )
+
+    assert connect_calls == 0
+    assert not (manager.runtime_dir / "current.json").exists()
+    assert not provider_root.exists()
 
 
 async def test_memory_artifact_rollback_resolves_old_active_binary(

--- a/tests/test_memory_runtime.py
+++ b/tests/test_memory_runtime.py
@@ -6,6 +6,7 @@ import inspect
 import json
 import logging
 import os
+import stat
 import subprocess
 import sys
 import threading
@@ -527,6 +528,37 @@ def test_memory_artifact_status_marks_unreadable_active_pointer_as_error(tmp_pat
     assert status["installed"] is False
     assert status["status"] == "error"
     assert status["reason"] == "memory_runtime_install_failed"
+    assert stat.S_IMODE(manager.runtime_dir.stat().st_mode) == 0o700
+    assert stat.S_IMODE((manager.runtime_dir / "current.json").stat().st_mode) == 0o600
+
+
+def test_memory_artifact_hardens_a_valid_legacy_active_pointer(tmp_path: Path) -> None:
+    manager = MemoryArtifactManager(runtime_dir=tmp_path / "runtime", offline=True)
+    manager.runtime_dir.mkdir(parents=True, mode=0o755)
+    manager.runtime_dir.chmod(0o755)
+    current = manager.runtime_dir / "current.json"
+    current.write_text(json.dumps({"legacy": True}), encoding="utf-8")
+    current.chmod(0o644)
+
+    assert manager._read_active_pointer() == ({"legacy": True}, False)
+    assert stat.S_IMODE(manager.runtime_dir.stat().st_mode) == 0o700
+    assert stat.S_IMODE(current.stat().st_mode) == 0o600
+
+
+def test_memory_artifact_refuses_to_harden_a_hardlinked_legacy_pointer(
+    tmp_path: Path,
+) -> None:
+    manager = MemoryArtifactManager(runtime_dir=tmp_path / "runtime", offline=True)
+    manager.runtime_dir.mkdir(parents=True, mode=0o755)
+    manager.runtime_dir.chmod(0o755)
+    outside = tmp_path / "outside.json"
+    outside.write_text(json.dumps({"outside": True}), encoding="utf-8")
+    outside.chmod(0o644)
+    os.link(outside, manager.runtime_dir / "current.json")
+
+    assert manager._read_active_pointer() == (None, True)
+    assert stat.S_IMODE(outside.stat().st_mode) == 0o644
+    assert json.loads(outside.read_text(encoding="utf-8")) == {"outside": True}
 
 
 @pytest.mark.parametrize("binary_state", ["missing", "tampered"])

--- a/tests/test_memory_runtime_release_guard.py
+++ b/tests/test_memory_runtime_release_guard.py
@@ -13,7 +13,7 @@ from scripts import memory_runtime_release_guard as guard
 from scripts.build_memory_runtime import LOCK_SHA256 as RUNTIME_LOCK_SHA256
 
 
-def test_guard_platform_contract_excludes_darwin_x64() -> None:
+def test_guard_platform_contract_keeps_no_follow_capable_shipped_targets_enabled() -> None:
     assert guard.EXPECTED_PLATFORMS == frozenset({"darwin-arm64", "linux-arm64", "linux-x64"})
 
 

--- a/tests/test_memory_snapshot.py
+++ b/tests/test_memory_snapshot.py
@@ -24,6 +24,7 @@ from core.memory.snapshot import (
     MemorySnapshotManager,
     MemorySnapshotUnsafePathError,
     MemorySnapshotVerificationError,
+    SnapshotSurface,
 )
 
 
@@ -362,6 +363,37 @@ def test_snapshot_restore_relocates_and_restores_missing_as_absent(tmp_path: Pat
     assert not (relocated_home / "memory/call-log/call-log.db").exists()
     assert not (relocated_home / "memory/attachments").exists()
     assert source_home / "state/memory/memory.sqlite" != relocated_home / "state/memory/memory.sqlite"
+
+
+def test_snapshot_restore_preserves_and_cleans_owner_only_tree_modes(
+    tmp_path: Path,
+) -> None:
+    home = tmp_path / "home"
+    target = _private_directory(home / "memory/everos-root", home)
+    original = _private_file(target / "profile.json", b"before", home)
+    target.chmod(0o500)
+    manager = MemorySnapshotManager(
+        home,
+        surfaces=(SnapshotSurface("memory/everos-root", "tree"),),
+    )
+    snapshot = manager.create("owner-only-tree")
+
+    target.chmod(0o700)
+    original.write_bytes(b"after")
+    original.chmod(0o600)
+    target.chmod(0o500)
+
+    restored = manager.restore(
+        snapshot.snapshot_id,
+        expected_manifest_sha256=snapshot.manifest_sha256,
+        expected_surface_digests=snapshot.surface_digests(),
+    )
+
+    assert restored == snapshot
+    assert stat.S_IMODE(target.stat().st_mode) == 0o500
+    assert original.read_bytes() == b"before"
+    assert not list(home.rglob("*.before-restore-*"))
+    assert not list(home.rglob("*.restore-*"))
 
 
 def test_streaming_manifest_crosses_batches_and_restores_exact_tree(

--- a/tests/test_memory_snapshot.py
+++ b/tests/test_memory_snapshot.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 import pytest
 
+import core.memory.confined_filesystem as confined_filesystem_module
 import core.memory.snapshot as snapshot_module
 from core.memory.clear_journal import (
     ClearBackupBlocked,
@@ -655,41 +656,24 @@ def test_spilled_directory_order_is_exact_and_memory_bounded_for_wide_directorie
 
     sqlite_temp = _private_directory(tmp_path / "sqlite-temp", tmp_path)
     monkeypatch.setenv("SQLITE_TMPDIR", str(sqlite_temp))
-    monkeypatch.setattr(snapshot_module.os, "scandir", lambda _descriptor: ReverseScandir())
-    monkeypatch.setattr(snapshot_module, "_DIRECTORY_ORDER_INSERT_BATCH_SIZE", 11)
+    monkeypatch.setattr(
+        confined_filesystem_module.os,
+        "scandir",
+        lambda _descriptor: ReverseScandir(),
+    )
 
     connection: sqlite3.Connection | None = None
     tracemalloc.start()
     try:
-        with snapshot_module._SpilledDirectoryOrder() as orders:
+        with confined_filesystem_module.SpilledDirectoryOrder(
+            insert_batch_size=11
+        ) as orders:
             connection = orders._connection
-            cursor = orders.scan(
-                -1,
-                error_type=MemorySnapshotUnsafePathError,
-                message="injected wide directory cannot be scanned",
-            )
+            cursor = orders.scan(-1)
             for index in range(entry_count):
-                assert orders.next_name(
-                    cursor,
-                    error_type=MemorySnapshotUnsafePathError,
-                    message="injected wide directory cannot be scanned",
-                ) == f"entry-{index:05d}-{suffix}"
-            assert (
-                orders.next_name(
-                    cursor,
-                    error_type=MemorySnapshotUnsafePathError,
-                    message="injected wide directory cannot be scanned",
-                )
-                is None
-            )
-            assert (
-                orders.next_name(
-                    cursor,
-                    error_type=MemorySnapshotUnsafePathError,
-                    message="injected wide directory cannot be scanned",
-                )
-                is None
-            )
+                assert orders.next_name(cursor) == f"entry-{index:05d}-{suffix}"
+            assert orders.next_name(cursor) is None
+            assert orders.next_name(cursor) is None
             _current, peak = tracemalloc.get_traced_memory()
     finally:
         tracemalloc.stop()
@@ -1148,7 +1132,7 @@ def test_restore_retry_converges_after_crash_between_backup_and_install(
         real_replace(source, destination, *args, **kwargs)
         if (
             not crashed
-            and Path(source) == queue
+            and Path(source).name == queue.name
             and ".before-restore-crash-retry-0-0" in Path(destination).name
         ):
             crashed = True
@@ -1197,7 +1181,7 @@ def test_create_retry_reclaims_stage_left_by_process_death(
     real_replace = snapshot_module.os.replace
 
     def crash_before_publish(source, destination, *args, **kwargs):
-        if Path(destination) == manager.snapshot_path("stage-crash"):
+        if Path(destination).name == "stage-crash":
             raise SystemExit("injected snapshot process death")
         return real_replace(source, destination, *args, **kwargs)
 
@@ -1266,9 +1250,10 @@ def test_auto_id_backup_stage_reconcile_covers_copy_and_publish_crashes(
 
     def crash_at_publish(source, destination, *args, **kwargs):
         is_publish = (
-            Path(source).parent == manager.snapshot_root
-            and Path(source).name.endswith(".tmp")
-            and Path(destination).parent == manager.snapshot_root
+            Path(source).name.endswith(".tmp")
+            and not Path(destination).name.startswith(".")
+            and kwargs.get("src_dir_fd") is not None
+            and kwargs.get("dst_dir_fd") is not None
         )
         if is_publish and crash_boundary == "before-publish":
             raise SystemExit(crash_boundary)
@@ -1348,7 +1333,7 @@ def test_explicit_id_backup_retry_still_reclaims_its_deterministic_stage(
     real_replace = snapshot_module.os.replace
 
     def crash_before_publish(source, destination, *args, **kwargs):
-        if Path(destination) == manager.snapshot_path("explicit-retry"):
+        if Path(destination).name == "explicit-retry":
             raise SystemExit("injected backup process death")
         return real_replace(source, destination, *args, **kwargs)
 

--- a/tests/test_memory_snapshot.py
+++ b/tests/test_memory_snapshot.py
@@ -719,6 +719,32 @@ def test_spilled_directory_order_is_exact_and_memory_bounded_for_wide_directorie
     assert list(sqlite_temp.iterdir()) == []
 
 
+def test_snapshot_translates_temporary_directory_order_database_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home = tmp_path / "home"
+    _private_file(home / "memory/everos-root/profile.json", b"profile", home)
+    manager = MemorySnapshotManager(home)
+    failure = sqlite3.OperationalError("temporary ordering unavailable")
+
+    def fail_connect(*_args, **_kwargs):
+        raise failure
+
+    monkeypatch.setattr(
+        confined_filesystem_module.sqlite3,
+        "connect",
+        fail_connect,
+    )
+
+    with pytest.raises(MemorySnapshotError) as raised:
+        manager.create("ordering-failure")
+
+    assert isinstance(raised.value.__cause__, confined_filesystem_module.ConfinedFilesystemError)
+    assert raised.value.__cause__.__cause__ is failure
+    assert not manager.snapshot_path("ordering-failure").exists()
+
+
 def test_streaming_manifest_accepts_extended_unicode_path_record(tmp_path: Path) -> None:
     manifest_path = _private_directory(tmp_path / "snapshot", tmp_path) / "manifest.jsonl"
     relative_path = "memory/everos-root/" + "/".join(["\u754c" * 200] * 55)

--- a/tests/test_memory_snapshot.py
+++ b/tests/test_memory_snapshot.py
@@ -726,23 +726,74 @@ def test_snapshot_translates_temporary_directory_order_database_failure(
     home = tmp_path / "home"
     _private_file(home / "memory/everos-root/profile.json", b"profile", home)
     manager = MemorySnapshotManager(home)
-    failure = sqlite3.OperationalError("temporary ordering unavailable")
+    failure = confined_filesystem_module.ConfinedFilesystemError(
+        "temporary ordering unavailable"
+    )
 
-    def fail_connect(*_args, **_kwargs):
+    def fail_order(*_args, **_kwargs):
         raise failure
 
-    monkeypatch.setattr(
-        confined_filesystem_module.sqlite3,
-        "connect",
-        fail_connect,
-    )
+    monkeypatch.setattr(snapshot_module, "SpilledDirectoryOrder", fail_order)
 
     with pytest.raises(MemorySnapshotError) as raised:
         manager.create("ordering-failure")
 
-    assert isinstance(raised.value.__cause__, confined_filesystem_module.ConfinedFilesystemError)
-    assert raised.value.__cause__.__cause__ is failure
+    assert raised.value.__cause__ is failure
     assert not manager.snapshot_path("ordering-failure").exists()
+
+
+def test_snapshot_verify_translates_directory_order_construction_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home = tmp_path / "home"
+    _private_file(home / "memory/everos-root/profile.json", b"profile", home)
+    manager = MemorySnapshotManager(home)
+    snapshot = manager.create("verify-ordering-failure")
+    failure = confined_filesystem_module.ConfinedFilesystemError(
+        "temporary ordering unavailable"
+    )
+
+    def fail_order(*_args, **_kwargs):
+        raise failure
+
+    monkeypatch.setattr(snapshot_module, "SpilledDirectoryOrder", fail_order)
+
+    with pytest.raises(MemorySnapshotVerificationError) as raised:
+        manager.verify(
+            snapshot.snapshot_id,
+            expected_manifest_sha256=snapshot.manifest_sha256,
+            expected_surface_digests=snapshot.surface_digests(),
+        )
+
+    assert raised.value.__cause__ is failure
+
+
+def test_backup_reconcile_translates_directory_order_construction_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home = _private_directory(tmp_path / "home", tmp_path)
+    manager = MemorySnapshotManager(
+        home,
+        snapshot_root="state/memory/backups",
+        surfaces=(SnapshotSurface("memory/everos-root", "tree"),),
+        operation_guard=lambda: None,
+    )
+    _private_directory(manager.snapshot_root, home)
+    failure = confined_filesystem_module.ConfinedFilesystemError(
+        "temporary ordering unavailable"
+    )
+
+    def fail_order(*_args, **_kwargs):
+        raise failure
+
+    monkeypatch.setattr(snapshot_module, "SpilledDirectoryOrder", fail_order)
+
+    with pytest.raises(MemorySnapshotUnsafePathError) as raised:
+        manager.reconcile_unpublished_backup_stages()
+
+    assert raised.value.__cause__ is failure
 
 
 def test_streaming_manifest_accepts_extended_unicode_path_record(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- require `O_NOFOLLOW` lazily for every Memory persistence capability and fail closed without breaking Avibe imports or non-Memory startup
- centralize descriptor-anchored private directory/file operations, removal, fsync, atomic replacement, and disk-spilled raw filename ordering in the confined filesystem owner
- migrate snapshot, backup/restore, provider-root, artifact-pointer, call-log, SQLite, and attachment persistence while preserving their digest, manifest, receipt, transaction, bundle, recovery, and exception contracts

## Evidence

- Scenario IDs: N/A (filesystem security/refactor contract; no scenario catalog entry applies)
- Unit/security: `pytest -q tests/test_memory_confined_filesystem.py tests/test_memory_snapshot.py` (59 passed)
- Contract/runtime: attachment, provider-root, clear, backup, call-log, release guard (124 passed); full runtime suite (94 passed)
- Crash recovery: four surface restore crash cases passed; stage cleanup, publish retry, tombstone deletion, and directory fsync coverage passed in the snapshot/maintenance suites
- Broad Memory gate: 864 passed, 1 skipped; one unrelated timing-sensitive final-flush assertion failed in the broad run and passed on isolated rerun
- Static: Ruff passed for every changed Python file; `git diff --check` passed; production search found no zero-valued Memory `O_NOFOLLOW` fallback, duplicate spill-order implementation, or full-directory sorted scan
- Residual manual checks: none required; automated platform and recovery contracts cover this change

## Platform Boundary

The shipped `darwin-arm64`, `linux-arm64`, and `linux-x64` Memory Runtime targets remain enabled and covered by the release guard. Native Windows remains unavailable for Memory persistence until a proven reparse-point-safe adapter exists; no silent fallback is permitted.