### PR TITLE
refactor(memory): own lifecycle claims in module

### DIFF
--- a/core/memory/module.py
+++ b/core/memory/module.py
@@ -1,16 +1,18 @@
-"""The five-method, provider-independent MemoryModule interface."""
+"""The provider-independent MemoryModule interface."""
 
 from __future__ import annotations
 
 import asyncio
+import logging
 import os
 import shutil
 import unicodedata
 import weakref
 from collections.abc import Awaitable, Callable
+from contextlib import asynccontextmanager
 from datetime import date, datetime, timezone
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any, AsyncIterator, Literal, TypeVar
 
 from config import paths
 from core.memory.blocking import run_blocking
@@ -68,7 +70,17 @@ PROVIDER_READ_TIMEOUT_SECONDS = 20.0
 CLEAR_DRAIN_TIMEOUT_SECONDS = 5.0
 
 
+logger = logging.getLogger(__name__)
+_SessionLifecycleResult = TypeVar("_SessionLifecycleResult")
+
+
 _ROOT_LIFECYCLE_LOCKS: dict[str, asyncio.Lock] = {}
+
+
+class MemorySessionLifecycleBusyError(RuntimeError):
+    """Raised when a destructive session transition cannot acquire its fence."""
+
+    code = "memory_session_lifecycle_busy"
 
 
 class MemoryModule:
@@ -125,10 +137,286 @@ class MemoryModule:
             attachment_admission_lock=self._root_lifecycle_lock(),
         )
 
-    def _replace_provider(self, provider: MemoryProviderPort) -> None:
-        """Swap the private provider shared by direct reads and the worker.
+    @property
+    def maintenance_active(self) -> bool:
+        """Whether Runtime-owned maintenance currently fences module work."""
 
-        ``MemoryRuntime`` holds the module lifecycle lock before invoking this,
+        return self._clear_active
+
+    def enter_maintenance(self) -> None:
+        """Fence capture and reads before a maintenance transition begins."""
+
+        self._clear_active = True
+
+    def leave_maintenance(self) -> None:
+        """Reopen capture and reads after maintenance ownership is released."""
+
+        self._clear_active = False
+
+    @asynccontextmanager
+    async def lifecycle(self) -> AsyncIterator[None]:
+        """Serialize an ordinary module lifecycle transition."""
+
+        async with self._lifecycle_lock:
+            yield
+
+    @asynccontextmanager
+    async def destructive_lifecycle(self) -> AsyncIterator[None]:
+        """Acquire module and provider-root ownership in their required order."""
+
+        async with self._lifecycle_lock:
+            async with self._root_lifecycle_lock():
+                yield
+
+    @asynccontextmanager
+    async def provider_root_lifecycle(self) -> AsyncIterator[None]:
+        """Fence provider-root work when module lifecycle ownership is already held."""
+
+        async with self._root_lifecycle_lock():
+            yield
+
+    @asynccontextmanager
+    async def observe_provider_root(self) -> AsyncIterator[bool]:
+        """Acquire provider-root observation only when it is immediately available."""
+
+        lock = self._root_lifecycle_lock()
+        if lock.locked():
+            yield False
+            return
+        # An uncontended asyncio.Lock acquisition completes without yielding.
+        await lock.acquire()
+        try:
+            yield True
+        finally:
+            lock.release()
+
+    def pause_claims(self) -> None:
+        """Synchronously fence new add and flush claims."""
+
+        self._worker.pause_claims()
+
+    async def quiesce_claims(self, *, timeout_seconds: float | None = None) -> bool:
+        """Fence claims and join in-flight add and flush work under one deadline."""
+
+        if timeout_seconds is None:
+            return await self._worker.pause_and_wait()
+        return await self._worker.pause_and_wait(timeout_seconds=timeout_seconds)
+
+    async def quiesce_claims_for_clear(self) -> bool:
+        """Fence claims using the module's configured destructive-work budget."""
+
+        return await self._worker.pause_and_wait(
+            timeout_seconds=self._clear_drain_timeout_seconds
+        )
+
+    def resume_claims(self) -> None:
+        """Permit add and flush claims after lifecycle recovery succeeds."""
+
+        self._worker.resume_claims()
+
+    def begin_activation(self, *, new_lease: bool = False) -> None:
+        """Require recovery before the next drain, optionally rotating lease ownership."""
+
+        if new_lease:
+            self._worker.begin_new_lease_activation()
+            return
+        self._worker.begin_activation()
+
+    async def drain(self) -> int:
+        """Run one bounded worker drain through the module interface."""
+
+        return await self._worker.drain()
+
+    async def prepare_shutdown(self) -> None:
+        """Settle in-process flush work without initiating provider writes."""
+
+        await self._worker.prepare_shutdown()
+
+    async def clear_attachments(self) -> None:
+        """Remove every module-owned pinned attachment during destructive clear."""
+
+        await run_blocking(self._attachment_store.clear_all)
+
+    async def final_flush(
+        self,
+        *,
+        principal_id: str,
+        project_id: str,
+        raw_session_id: str,
+        deadline_seconds: float = 5.0,
+    ) -> bool:
+        """Fence capture and flush one trusted canonical session by deadline."""
+
+        if not self._is_enabled() or self.maintenance_active or self._is_maintenance_open():
+            return False
+        timeout = _positive_timeout(deadline_seconds)
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + timeout
+        admission_lock = self._capture_admission_lock(
+            principal_id=principal_id,
+            project_id=project_id,
+            session_id=raw_session_id,
+        )
+        acquired = False
+        try:
+            await asyncio.wait_for(admission_lock.acquire(), timeout=timeout)
+            acquired = True
+            return await self._final_flush_under_admission(
+                principal_id=principal_id,
+                project_id=project_id,
+                raw_session_id=raw_session_id,
+                deadline=deadline,
+            )
+        except asyncio.TimeoutError:
+            return False
+        finally:
+            if acquired:
+                admission_lock.release()
+
+    async def run_session_lifecycle(
+        self,
+        *,
+        principal_id: str,
+        project_id: str,
+        raw_session_id: str,
+        operation: Callable[[], Awaitable[_SessionLifecycleResult]],
+        deadline_seconds: float = 5.0,
+    ) -> _SessionLifecycleResult:
+        """Flush and run one destructive session transition under one fence."""
+
+        if not self._is_enabled() or self.maintenance_active or self._is_maintenance_open():
+            return await operation()
+        timeout = _positive_timeout(deadline_seconds)
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + timeout
+        admission_lock = self._capture_admission_lock(
+            principal_id=principal_id,
+            project_id=project_id,
+            session_id=raw_session_id,
+        )
+        try:
+            await asyncio.wait_for(admission_lock.acquire(), timeout=timeout)
+        except asyncio.TimeoutError as error:
+            raise MemorySessionLifecycleBusyError(
+                "memory capture admission did not quiesce before the deadline"
+            ) from error
+
+        try:
+            await self._final_flush_under_admission(
+                principal_id=principal_id,
+                project_id=project_id,
+                raw_session_id=raw_session_id,
+                deadline=deadline,
+            )
+            return await operation()
+        finally:
+            admission_lock.release()
+
+    async def run_session_scopes_lifecycle(
+        self,
+        *,
+        scopes: tuple[tuple[str, str], ...],
+        raw_session_id: str,
+        operation: Callable[[], Awaitable[_SessionLifecycleResult]],
+        deadline_seconds: float = 5.0,
+    ) -> _SessionLifecycleResult:
+        """Flush all session scopes and run one transition under every fence."""
+
+        canonical_scopes = tuple(sorted(set(scopes)))
+        if (
+            not canonical_scopes
+            or not isinstance(raw_session_id, str)
+            or not raw_session_id
+            or any(
+                not is_principal_id(principal_id) or not is_project_id(project_id)
+                for principal_id, project_id in canonical_scopes
+            )
+        ):
+            raise ValueError("invalid canonical Memory session scopes")
+        if not self._is_enabled():
+            return await operation()
+        if self.maintenance_active or self._is_maintenance_open():
+            raise MemorySessionLifecycleBusyError("memory session lifecycle is unavailable")
+
+        timeout = _positive_timeout(deadline_seconds)
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + timeout
+        locks = [
+            self._capture_admission_lock(
+                principal_id=principal_id,
+                project_id=project_id,
+                session_id=raw_session_id,
+            )
+            for principal_id, project_id in canonical_scopes
+        ]
+        acquired: list[asyncio.Lock] = []
+        try:
+            for admission_lock in locks:
+                remaining = deadline - loop.time()
+                if remaining <= 0:
+                    raise asyncio.TimeoutError
+                await asyncio.wait_for(admission_lock.acquire(), timeout=remaining)
+                acquired.append(admission_lock)
+        except asyncio.TimeoutError as error:
+            for admission_lock in reversed(acquired):
+                admission_lock.release()
+            raise MemorySessionLifecycleBusyError(
+                "memory capture admission did not quiesce before the deadline"
+            ) from error
+        except asyncio.CancelledError:
+            for admission_lock in reversed(acquired):
+                admission_lock.release()
+            raise
+
+        try:
+            for principal_id, project_id in canonical_scopes:
+                await self._final_flush_under_admission(
+                    principal_id=principal_id,
+                    project_id=project_id,
+                    raw_session_id=raw_session_id,
+                    deadline=deadline,
+                )
+            return await operation()
+        finally:
+            for admission_lock in reversed(acquired):
+                admission_lock.release()
+
+    async def _final_flush_under_admission(
+        self,
+        *,
+        principal_id: str,
+        project_id: str,
+        raw_session_id: str,
+        deadline: float,
+    ) -> bool:
+        if not self._is_enabled() or self.maintenance_active or self._is_maintenance_open():
+            return False
+        try:
+            session_ref = await self._store_call(
+                self._store.provider_session_ref,
+                principal_id=principal_id,
+                project_ref=project_id,
+                session_id=raw_session_id,
+            )
+            remaining = deadline - asyncio.get_running_loop().time()
+            if remaining <= 0:
+                return False
+            return await self._worker.coordinator.final_flush(
+                session_ref,
+                deadline_seconds=remaining,
+            )
+        except asyncio.TimeoutError:
+            return False
+        except (TypeError, ValueError):
+            return False
+        except Exception:
+            logger.warning("Memory final flush failed")
+            return False
+
+    def replace_provider(self, provider: MemoryProviderPort) -> None:
+        """Swap the provider shared by direct reads and claim delivery.
+
+        The caller holds module lifecycle ownership before invoking this,
         so a sidecar credential/runtime replacement cannot split these two
         consumers across provider instances.
         """

--- a/core/memory/runtime.py
+++ b/core/memory/runtime.py
@@ -35,7 +35,7 @@ from core.memory.everos import (
 )
 from core.memory.everos_insight import MemoryInsightPaths, MemoryInsightReader
 from core.memory.everos_insight.recorder import clear_call_log, maintain_call_log
-from core.memory.module import MemoryModule
+from core.memory.module import MemoryModule, MemorySessionLifecycleBusyError
 from core.memory.maintenance import (
     ClearRecoveryResult,
     ClearResult,
@@ -262,17 +262,11 @@ def _processing_record_payload(summary: ProcessingRecordSummary) -> dict[str, An
     }
 
 
-class MemorySessionLifecycleBusyError(RuntimeError):
-    """Raised when a destructive session transition cannot acquire its fence."""
-
-    code = "memory_session_lifecycle_busy"
-
-
 class _UnavailableMemoryModule:
     """Capture sink for a runtime whose store could not be opened.
 
     ``MemoryRuntime.module`` is only ever used to capture, so this narrow adapter
-    is the whole seam — not a stand-in for ``MemoryModule``'s six methods.
+    is the whole seam, not a stand-in for the complete ``MemoryModule`` interface.
     """
 
     async def capture(self, _request: Any) -> OperationFailed:
@@ -402,7 +396,7 @@ class MemoryRuntime:
         self._module = module
         self._require_maintenance().attach_store(opened)
         if self._maintenance_open():
-            module._worker.pause_claims()
+            module.pause_claims()
         self._store_error = None
         self._configure_insight_reader(self._config)
         self._artifact_manager.set_activation_coordinator(self._coordinate_artifact_activation)
@@ -496,7 +490,7 @@ class MemoryRuntime:
             transition_active=self._reconcile_lock.locked(),
             enabled=self._config.enabled,
             store_available=module is not None,
-            maintenance_active=bool(module and module._clear_active),
+            maintenance_active=bool(module and module.maintenance_active),
             closing=self._closing,
             process=process,
             process_running=bool(process and process.running),
@@ -507,15 +501,14 @@ class MemoryRuntime:
     async def _maintenance_fence(self) -> AsyncIterator[None]:
         """Acquire destructive fences in their single permitted order."""
 
-        async with self._reconcile_lock, self.module._lifecycle_lock:
-            async with self.module._root_lifecycle_lock():
-                yield
+        async with self._reconcile_lock, self.module.destructive_lifecycle():
+            yield
 
     @asynccontextmanager
     async def _maintenance_boot_recovery_fence(self) -> AsyncIterator[None]:
         """Add the root fence while reconcile and module fences are already held."""
 
-        async with self.module._root_lifecycle_lock():
+        async with self.module.provider_root_lifecycle():
             yield
 
     def _maintenance_runtime_state(self) -> MaintenanceRuntimeState:
@@ -525,17 +518,17 @@ class MemoryRuntime:
 
     def _enter_maintenance(self) -> None:
         if self._module is not None:
-            self._module._clear_active = True
+            self._module.enter_maintenance()
         self._advance_processing_lifecycle()
 
     def _leave_maintenance(self) -> None:
         if self._module is not None:
-            self._module._clear_active = False
+            self._module.leave_maintenance()
         self._advance_processing_lifecycle()
 
     def _resume_maintenance_claims(self) -> None:
         if self._module is not None:
-            self._module._worker.resume_claims()
+            self._module.resume_claims()
 
     def _configure_insight_reader(self, config: MemoryConfig) -> None:
         if self._insight_reader_override is not None:
@@ -664,7 +657,7 @@ class MemoryRuntime:
             # This is deliberately the same lifecycle lock Clear uses. A settings
             # save cannot race a root wipe or replace sidecar credentials halfway
             # through an active provider call.
-            async with self.module._lifecycle_lock:
+            async with self.module.lifecycle():
                 restore_operation_open = (
                     self._maintenance is not None
                     and self._maintenance.has_open_restore()
@@ -676,10 +669,10 @@ class MemoryRuntime:
                 ):
                     result = await self._disable_locked(config)
                 elif restore_operation_open and not recorded_sidecar_reaped:
-                    self.module._worker.pause_claims()
+                    self.module.pause_claims()
                     return {"ok": False, "error": "memory_clear_failed"}
                 elif maintenance_open and not restore_operation_open:
-                    self.module._worker.pause_claims()
+                    self.module.pause_claims()
                     return {"ok": False, "error": "memory_clear_failed"}
                 else:
                     result = await self._reconcile_locked(config)
@@ -690,11 +683,11 @@ class MemoryRuntime:
     async def _disable_locked(self, config: MemoryConfig) -> dict[str, Any]:
         """Stop every active Memory component without consulting maintenance state."""
 
-        self.module._worker.pause_claims()
+        self.module.pause_claims()
         self._config = config
         self._configure_insight_reader(config)
         self._provider = EverOSPort(self._socket_path)
-        self.module._replace_provider(self._provider)
+        self.module.replace_provider(self._provider)
         await self._stop_worker()
         stopped_process = self._process is not None
         if stopped_process:
@@ -720,12 +713,12 @@ class MemoryRuntime:
         if self._maintenance is not None and self._maintenance.has_open_restore():
             recovered = await self._maintenance.recover_boot()
             if not recovered:
-                self.module._worker.pause_claims()
+                self.module.pause_claims()
                 self._runtime_error = "memory_clear_failed"
                 return {"ok": False, "error": self._runtime_error}
 
         if self._maintenance_open():
-            self.module._worker.pause_claims()
+            self.module.pause_claims()
             if self._can_disable_without_maintenance_authority(config):
                 return await self._disable_locked(config)
             return {"ok": False, "error": "memory_clear_failed"}
@@ -738,12 +731,12 @@ class MemoryRuntime:
             # Stop the worker before inspecting provider state. A capture may
             # still enqueue while settings are being reconciled, but no
             # old-embedding drain can cross this boundary.
-            if not await self.module._worker.pause_and_wait():
+            if not await self.module.quiesce_claims():
                 # ``pause_and_wait`` fences claims before waiting, so a timeout
                 # leaves them fenced. Releasing here is what keeps a failed
                 # settings save from silently stopping the drain loop forever.
                 if resume_claims_on_failure:
-                    self.module._worker.resume_claims()
+                    self.module.resume_claims()
                 self._runtime_error = "memory_clear_failed"
                 return {"ok": False, "error": self._runtime_error}
             claims_paused = True
@@ -761,7 +754,7 @@ class MemoryRuntime:
                 return {"ok": False, "error": self._runtime_error}
             finally:
                 if embedding_guard_rejected and resume_claims_on_failure:
-                    self.module._worker.resume_claims()
+                    self.module.resume_claims()
                     claims_paused = False
 
         if config.embedding_change_pending:
@@ -774,7 +767,7 @@ class MemoryRuntime:
                 if not (self._process and self._process.running):
                     self._runtime_error = error
                 if claims_paused and resume_claims_on_failure:
-                    self.module._worker.resume_claims()
+                    self.module.resume_claims()
                 return {"ok": False, "error": error}
             # Settlement is independently durable even when later candidate
             # activation fails. Mirror only that fact into the replay snapshot.
@@ -796,24 +789,24 @@ class MemoryRuntime:
             if not (self._process and self._process.running):
                 self._runtime_error = error
             if claims_paused and resume_claims_on_failure:
-                self.module._worker.resume_claims()
+                self.module.resume_claims()
             return {"ok": False, "error": error}
         if not await self._probe_processing(python, config):
             error = "memory_processing_failed"
             if not (self._process and self._process.running):
                 self._runtime_error = error
             if claims_paused and resume_claims_on_failure:
-                self.module._worker.resume_claims()
+                self.module.resume_claims()
             return {"ok": False, "error": error}
 
         # Every enabled reconciliation receives a fresh process. Endpoint,
         # model, and key changes belong exclusively in its allowlisted child
         # environment and must never leave an old sidecar running.
-        if not claims_paused and not await self.module._worker.pause_and_wait():
+        if not claims_paused and not await self.module.quiesce_claims():
             # Same fence release as the embedding guard above: a timed-out pause
             # must not leave the worker permanently unable to claim.
             if resume_claims_on_failure:
-                self.module._worker.resume_claims()
+                self.module.resume_claims()
             self._runtime_error = "memory_clear_failed"
             return {"ok": False, "error": self._runtime_error}
         await self._stop_worker()
@@ -825,7 +818,7 @@ class MemoryRuntime:
         self._config = config
         self._configure_insight_reader(config)
         self._provider = candidate_provider
-        self.module._replace_provider(self._provider)
+        self.module.replace_provider(self._provider)
         try:
             meta = await asyncio.to_thread(self._store.ensure_meta)
             await run_blocking(
@@ -836,7 +829,7 @@ class MemoryRuntime:
         except Exception:
             self._runtime_error = "memory_clear_failed"
             if resume_claims_on_failure:
-                self.module._worker.resume_claims()
+                self.module.resume_claims()
             return {"ok": False, "error": self._runtime_error}
 
         await self._stop_call_log_retention()
@@ -888,7 +881,7 @@ class MemoryRuntime:
             self._ready_event = None
         self._update_recorder_health(_RECORDER_DEGRADED)
         self._runtime_error = None
-        self.module._worker.resume_claims()
+        self.module.resume_claims()
         self._ensure_worker()
         return {"ok": True, "state": "ready"}
 
@@ -940,13 +933,9 @@ class MemoryRuntime:
         reason = before.local_observation_reason(maintenance_reason)
         if reason is not None:
             return FailureLogObservation((), reason)
-        root_lock = self.module._root_lifecycle_lock()
-        if root_lock.locked():
-            return FailureLogObservation((), "busy")
-        # asyncio.Lock's uncontended acquire completes synchronously, so no
-        # lifecycle owner can enter between this check and acquisition.
-        await root_lock.acquire()
-        try:
+        async with self.module.observe_provider_root() as root_available:
+            if not root_available:
+                return FailureLogObservation((), "busy")
             acquired = self._processing_runtime_snapshot()
             reason = acquired.local_observation_reason(maintenance_reason)
             if acquired.generation != before.generation or reason is not None:
@@ -957,8 +946,6 @@ class MemoryRuntime:
             if after.generation != before.generation or reason is not None:
                 return FailureLogObservation((), reason or "busy")
             return FailureLogObservation(entries)
-        finally:
-            root_lock.release()
 
     async def _processing_record_sources(
         self,
@@ -1113,31 +1100,14 @@ class MemoryRuntime:
     ) -> bool:
         """Fence one trusted canonical session at a centralized lifecycle boundary."""
 
-        if not self.available or not self._config.enabled or self._maintenance_open():
+        if not self.available:
             return False
-        timeout = _final_flush_timeout(deadline_seconds)
-        loop = asyncio.get_running_loop()
-        deadline = loop.time() + timeout
-        admission_lock = self.module._capture_admission_lock(
+        return await self.module.final_flush(
             principal_id=principal_id,
             project_id=project_id,
-            session_id=raw_session_id,
+            raw_session_id=raw_session_id,
+            deadline_seconds=deadline_seconds,
         )
-        acquired = False
-        try:
-            await asyncio.wait_for(admission_lock.acquire(), timeout=timeout)
-            acquired = True
-            return await self._final_flush_under_admission(
-                principal_id=principal_id,
-                project_id=project_id,
-                raw_session_id=raw_session_id,
-                deadline=deadline,
-            )
-        except asyncio.TimeoutError:
-            return False
-        finally:
-            if acquired:
-                admission_lock.release()
 
     async def run_session_lifecycle(
         self,
@@ -1150,33 +1120,15 @@ class MemoryRuntime:
     ) -> _SessionLifecycleResult:
         """Flush and run one destructive session transition under one fence."""
 
-        if not self.available or not self._config.enabled or self._maintenance_open():
+        if not self.available:
             return await operation()
-        timeout = _final_flush_timeout(deadline_seconds)
-        loop = asyncio.get_running_loop()
-        deadline = loop.time() + timeout
-        admission_lock = self.module._capture_admission_lock(
+        return await self.module.run_session_lifecycle(
             principal_id=principal_id,
             project_id=project_id,
-            session_id=raw_session_id,
+            raw_session_id=raw_session_id,
+            operation=operation,
+            deadline_seconds=deadline_seconds,
         )
-        try:
-            await asyncio.wait_for(admission_lock.acquire(), timeout=timeout)
-        except asyncio.TimeoutError as error:
-            raise MemorySessionLifecycleBusyError(
-                "memory capture admission did not quiesce before the deadline"
-            ) from error
-
-        try:
-            await self._final_flush_under_admission(
-                principal_id=principal_id,
-                project_id=project_id,
-                raw_session_id=raw_session_id,
-                deadline=deadline,
-            )
-            return await operation()
-        finally:
-            admission_lock.release()
 
     async def run_session_scopes_lifecycle(
         self,
@@ -1199,87 +1151,14 @@ class MemoryRuntime:
             )
         ):
             raise ValueError("invalid canonical Memory session scopes")
-        if not self.available or not self._config.enabled:
+        if not self.available:
             return await operation()
-        if self._maintenance_open():
-            raise MemorySessionLifecycleBusyError("memory session lifecycle is unavailable")
-
-        timeout = _final_flush_timeout(deadline_seconds)
-        loop = asyncio.get_running_loop()
-        deadline = loop.time() + timeout
-        locks = [
-            self.module._capture_admission_lock(
-                principal_id=principal_id,
-                project_id=project_id,
-                session_id=raw_session_id,
-            )
-            for principal_id, project_id in canonical_scopes
-        ]
-        acquired: list[asyncio.Lock] = []
-        try:
-            for admission_lock in locks:
-                remaining = deadline - loop.time()
-                if remaining <= 0:
-                    raise asyncio.TimeoutError
-                await asyncio.wait_for(admission_lock.acquire(), timeout=remaining)
-                acquired.append(admission_lock)
-        except asyncio.TimeoutError as error:
-            for admission_lock in reversed(acquired):
-                admission_lock.release()
-            raise MemorySessionLifecycleBusyError(
-                "memory capture admission did not quiesce before the deadline"
-            ) from error
-        except asyncio.CancelledError:
-            for admission_lock in reversed(acquired):
-                admission_lock.release()
-            raise
-
-        try:
-            for principal_id, project_id in canonical_scopes:
-                await self._final_flush_under_admission(
-                    principal_id=principal_id,
-                    project_id=project_id,
-                    raw_session_id=raw_session_id,
-                    deadline=deadline,
-                )
-            return await operation()
-        finally:
-            for admission_lock in reversed(acquired):
-                admission_lock.release()
-
-    async def _final_flush_under_admission(
-        self,
-        *,
-        principal_id: str,
-        project_id: str,
-        raw_session_id: str,
-        deadline: float,
-    ) -> bool:
-        """Flush one session while its capture admission lock is already held."""
-
-        if not self.available or not self._config.enabled or self._maintenance_open():
-            return False
-        try:
-            session_ref = await asyncio.to_thread(
-                self._store.provider_session_ref,
-                principal_id=principal_id,
-                project_ref=project_id,
-                session_id=raw_session_id,
-            )
-            remaining = deadline - asyncio.get_running_loop().time()
-            if remaining <= 0:
-                return False
-            return await self.module._worker.coordinator.final_flush(
-                session_ref,
-                deadline_seconds=remaining,
-            )
-        except asyncio.TimeoutError:
-            return False
-        except (TypeError, ValueError):
-            return False
-        except Exception:
-            logger.warning("Memory final flush failed")
-            return False
+        return await self.module.run_session_scopes_lifecycle(
+            scopes=canonical_scopes,
+            raw_session_id=raw_session_id,
+            operation=operation,
+            deadline_seconds=deadline_seconds,
+        )
 
     async def profile_payload(self, principal_id: str, project_id: str) -> dict[str, Any]:
         if not self.available:
@@ -1366,7 +1245,7 @@ class MemoryRuntime:
         self,
         operation: Callable[[], dict[str, Any]],
     ) -> dict[str, Any]:
-        async with self.module._lifecycle_lock:
+        async with self.module.lifecycle():
             return await run_blocking(operation)
 
     async def create_backup(self, backup_id: str | None = None) -> MemorySnapshot:
@@ -1428,9 +1307,7 @@ class MemoryRuntime:
         return _clear_result_payload(result)
 
     async def _pause_clear_claims(self) -> None:
-        if not await self.module._worker.pause_and_wait(
-            timeout_seconds=self.module._clear_drain_timeout_seconds
-        ):
+        if not await self.module.quiesce_claims_for_clear():
             raise RuntimeError("Memory worker did not quiesce before clear")
 
     async def _quiesce_for_clear(self, claims_already_paused: bool = False) -> None:
@@ -1477,7 +1354,7 @@ class MemoryRuntime:
             self._set_recorder_health_disabled()
             return
         if surface.surface == "attachments":
-            await run_blocking(self.module._attachment_store.clear_all)
+            await self.module.clear_attachments()
             return
         raise RuntimeError("unknown Memory clear surface")
 
@@ -1503,7 +1380,7 @@ class MemoryRuntime:
 
     async def _resume_after_clear_once(self) -> None:
         if not self._config.enabled:
-            self.module._worker.resume_claims()
+            self.module.resume_claims()
             return
         try:
             reconciled = await self._reconcile_locked(
@@ -1557,9 +1434,9 @@ class MemoryRuntime:
                     "download_error": None,
                 }
             if supervisor is not None:
-                async with self.module._lifecycle_lock:
+                async with self.module.lifecycle():
                     try:
-                        claims_paused = await self.module._worker.pause_and_wait()
+                        claims_paused = await self.module.quiesce_claims()
                     except Exception:
                         claims_paused = False
                     if not claims_paused:
@@ -1684,28 +1561,27 @@ class MemoryRuntime:
         if python is None:
             return {"ok": False, "error": "memory_restart_failed"}
 
-        async with self.module._lifecycle_lock:
+        async with self.module.lifecycle():
             if self._maintenance_open():
-                self.module._worker.pause_claims()
+                self.module.pause_claims()
                 return {"ok": False, "error": "memory_clear_failed"}
 
             # Recovery may resume claims. Reinstate the fence synchronously,
             # before a drain task can run another claim.
-            worker = self.module._worker
-            worker.pause_claims()
+            self.module.pause_claims()
             old_process = self._process
             try:
                 # The grace budget applies only to the current drain tick. A
                 # timeout leaves the current process/provider ownership intact.
-                if not await worker.pause_and_wait(timeout_seconds=5.0):
+                if not await self.module.quiesce_claims(timeout_seconds=5.0):
                     if old_process is not None and old_process.running:
-                        worker.resume_claims()
+                        self.module.resume_claims()
                         self._ensure_worker()
                     return {"ok": False, "error": "memory_restart_failed"}
                 await self._stop_worker()
             except Exception:
                 if old_process is not None and old_process.running:
-                    worker.resume_claims()
+                    self.module.resume_claims()
                     self._ensure_worker()
                 return {"ok": False, "error": "memory_restart_failed"}
 
@@ -1729,7 +1605,7 @@ class MemoryRuntime:
                 self._socket_path,
                 processing_health_check=self._processing_healthy,
             )
-            self.module._replace_provider(self._provider)
+            self.module.replace_provider(self._provider)
             try:
                 meta = await asyncio.to_thread(self._store.ensure_meta)
                 await run_blocking(
@@ -1774,7 +1650,7 @@ class MemoryRuntime:
             )
             self._process = sidecar
             self._process_records_calls = True
-            worker.begin_new_lease_activation()
+            self.module.begin_activation(new_lease=True)
             try:
                 started = await sidecar.start()
             except Exception:
@@ -1792,7 +1668,7 @@ class MemoryRuntime:
 
             self._update_recorder_health(_RECORDER_DEGRADED)
             self._runtime_error = None
-            worker.resume_claims()
+            self.module.resume_claims()
             self._ensure_worker()
             return {"ok": True, "state": "ready"}
 
@@ -1824,7 +1700,7 @@ class MemoryRuntime:
                 pass
         if self.available:
             try:
-                await self.module._worker.prepare_shutdown()
+                await self.module.prepare_shutdown()
             finally:
                 await self._stop_worker()
         if self._process is not None:
@@ -1933,14 +1809,14 @@ class MemoryRuntime:
         """Cut over a verified pointer while preserving the prior runtime on failure."""
 
         async with self._reconcile_lock:
-            async with self.module._lifecycle_lock:
+            async with self.module.lifecycle():
                 if self._maintenance_open():
-                    self.module._worker.pause_claims()
+                    self.module.pause_claims()
                     raise MemoryRuntimeActivationError("memory clear recovery is required")
-                if not await self.module._worker.pause_and_wait():
-                    self.module._worker.resume_claims()
+                if not await self.module.quiesce_claims():
+                    self.module.resume_claims()
                     raise MemoryRuntimeActivationError("memory worker could not pause")
-                async with self.module._root_lifecycle_lock():
+                async with self.module.provider_root_lifecycle():
                     meta = None
                     root_rollback: ProviderRootRollback | None = None
                     try:
@@ -2020,7 +1896,7 @@ class MemoryRuntime:
     async def _activate_ready_events(self) -> None:
         while True:
             async with self._reconcile_lock:
-                async with self.module._lifecycle_lock:
+                async with self.module.lifecycle():
                     process = self._ready_event
                     self._ready_event = None
                     if process is None:
@@ -2028,7 +1904,7 @@ class MemoryRuntime:
                     if not self._ready_event_is_current(process):
                         continue
                     if self._maintenance_open():
-                        self.module._worker.pause_claims()
+                        self.module.pause_claims()
                         continue
                     if not self._ready_event_is_current(process):
                         continue
@@ -2037,7 +1913,7 @@ class MemoryRuntime:
                     if not self._ready_event_is_current(process):
                         continue
                     self._runtime_error = None
-                    self.module._worker.resume_claims()
+                    self.module.resume_claims()
                     self._ensure_worker()
 
     def _ready_event_is_current(
@@ -2102,10 +1978,10 @@ class MemoryRuntime:
 
     def _ensure_worker(self) -> None:
         if self._maintenance_open():
-            self.module._worker.pause_claims()
+            self.module.pause_claims()
             return
         if self._worker_task is None or self._worker_task.done():
-            self.module._worker.begin_activation()
+            self.module.begin_activation()
             self._worker_task = asyncio.create_task(self._drain_loop(), name="memory-drain")
 
     async def _stop_worker(self) -> None:
@@ -2188,7 +2064,7 @@ class MemoryRuntime:
                 return False, None
             if self._module is None:
                 return True, await self._run_call_log_maintenance()
-            async with self.module._lifecycle_lock:
+            async with self.module.lifecycle():
                 if self._process_records_calls or not self._call_log_exists():
                     return False, None
                 return True, await self._run_call_log_maintenance()
@@ -2218,7 +2094,7 @@ class MemoryRuntime:
     async def _drain_loop(self) -> None:
         while self._config.enabled:
             try:
-                await self.module._worker.drain()
+                await self.module.drain()
             except asyncio.CancelledError:
                 raise
             except Exception:
@@ -2229,10 +2105,9 @@ class MemoryRuntime:
     async def _recover_failed_drain(self) -> None:
         """Quiesce detached session work before rotating the worker lease."""
 
-        worker = self.module._worker
         while self._config.enabled:
             try:
-                if await worker.pause_and_wait():
+                if await self.module.quiesce_claims():
                     break
             except asyncio.CancelledError:
                 raise
@@ -2249,7 +2124,7 @@ class MemoryRuntime:
             # waited for lifecycle ownership. Fence and join that newer work.
             while self._config.enabled:
                 try:
-                    if await worker.pause_and_wait():
+                    if await self.module.quiesce_claims():
                         break
                 except asyncio.CancelledError:
                     raise
@@ -2259,11 +2134,11 @@ class MemoryRuntime:
             else:
                 return
 
-            worker.begin_new_lease_activation()
+            self.module.begin_activation(new_lease=True)
             while self._config.enabled:
                 try:
                     # Claims remain paused, so this pass can only run boot recovery.
-                    await worker.drain()
+                    await self.module.drain()
                 except asyncio.CancelledError:
                     raise
                 except Exception:
@@ -2271,7 +2146,7 @@ class MemoryRuntime:
                     await asyncio.sleep(1.0)
                     continue
                 if not self._maintenance_open():
-                    worker.resume_claims()
+                    self.module.resume_claims()
                 return
 
     def _data_exists(self) -> bool:
@@ -2315,13 +2190,6 @@ def _provider_kwargs(config: MemoryConfig) -> dict[str, str | None]:
         "embedding_model": config.processing.embedding.model,
         "embedding_api_key": config.processing.embedding.api_key,
     }
-
-
-def _final_flush_timeout(value: float) -> float:
-    try:
-        return max(float(value), 0.001)
-    except (TypeError, ValueError):
-        return 0.001
 
 
 def _active_compatible_root_formats(artifact_manager: MemoryArtifactPort) -> tuple[str, ...]:

--- a/tests/test_memory_module.py
+++ b/tests/test_memory_module.py
@@ -192,6 +192,163 @@ async def test_maintenance_fence_closes_capture_and_reads(tmp_path: Path) -> Non
     assert provider.search_scopes == []
 
 
+async def test_module_maintenance_state_fences_capture_until_closed(tmp_path: Path) -> None:
+    module, store, _provider = _module(tmp_path)
+
+    module.enter_maintenance()
+    assert module.maintenance_active
+    assert await module.capture(_request()) == CaptureSkipped(reason="memory_clear_failed")
+    assert store.list_queue_rows() == ()
+
+    module.leave_maintenance()
+    assert not module.maintenance_active
+    assert await module.capture(_request()) == CaptureAccepted()
+
+
+async def test_destructive_lifecycle_owns_root_and_blocks_ordinary_lifecycle(
+    tmp_path: Path,
+) -> None:
+    module, _store, _provider = _module(tmp_path)
+    entered = asyncio.Event()
+    release = asyncio.Event()
+
+    async def destructive_operation() -> None:
+        async with module.destructive_lifecycle():
+            entered.set()
+            async with module.observe_provider_root() as root_available:
+                assert root_available is False
+            await release.wait()
+
+    destructive = asyncio.create_task(destructive_operation())
+    ordinary: asyncio.Task[None] | None = None
+    try:
+        await asyncio.wait_for(entered.wait(), timeout=1.0)
+
+        ordinary_entered = False
+
+        async def ordinary_operation() -> None:
+            nonlocal ordinary_entered
+            async with module.lifecycle():
+                ordinary_entered = True
+
+        ordinary = asyncio.create_task(ordinary_operation())
+        await asyncio.sleep(0)
+        assert ordinary_entered is False
+
+        release.set()
+        await destructive
+        await ordinary
+        assert ordinary_entered is True
+    finally:
+        release.set()
+        await asyncio.gather(
+            destructive,
+            *((ordinary,) if ordinary is not None else ()),
+            return_exceptions=True,
+        )
+
+
+async def test_claim_quiescence_fences_delivery_until_resumed(tmp_path: Path) -> None:
+    module, _store, provider = _module(tmp_path)
+    assert await module.capture(_request()) == CaptureAccepted()
+
+    assert await module.quiesce_claims()
+    assert await module.drain() == 0
+    assert provider.captures == []
+
+    module.resume_claims()
+    assert await module.drain() == 1
+    assert [capture.text for capture in provider.captures] == ["remember this"]
+
+
+async def test_timed_out_quiescence_remains_fenced_until_resumed(tmp_path: Path) -> None:
+    add_entered = asyncio.Event()
+    release_add = asyncio.Event()
+
+    async def block_add(_capture) -> None:
+        add_entered.set()
+        await release_add.wait()
+
+    provider = FakeMemoryProvider(add_hook=block_add)
+    module, _store, _provider = _module(tmp_path, provider=provider)
+    assert await module.capture(_request()) == CaptureAccepted()
+
+    draining = asyncio.create_task(module.drain())
+    try:
+        await asyncio.wait_for(add_entered.wait(), timeout=1.0)
+        assert not await module.quiesce_claims(timeout_seconds=0.01)
+
+        release_add.set()
+        assert await draining == 1
+        assert await module.capture(_request(source="still-paused")) == CaptureAccepted()
+        assert await module.drain() == 0
+
+        module.resume_claims()
+        assert await module.drain() == 1
+    finally:
+        release_add.set()
+        await asyncio.gather(draining, return_exceptions=True)
+
+
+async def test_provider_replacement_updates_reads_and_claim_delivery(tmp_path: Path) -> None:
+    original = FakeMemoryProvider()
+    replacement = FakeMemoryProvider(
+        search_items=(MemoryItem(kind="fact", text="replacement result"),),
+    )
+    module, _store, _provider = _module(tmp_path, provider=original)
+
+    module.replace_provider(replacement)
+    assert await module.search(
+        "query",
+        principal_id=PRINCIPAL,
+        project_id=PROJECT,
+    ) == MemoryItems(items=replacement.search_items)
+    assert await module.capture(_request()) == CaptureAccepted()
+    assert await module.drain() == 1
+    assert original.captures == []
+    assert [capture.text for capture in replacement.captures] == ["remember this"]
+
+
+async def test_session_lifecycle_fences_capture_through_operation(tmp_path: Path) -> None:
+    module, store, _provider = _module(tmp_path)
+    operation_entered = asyncio.Event()
+    release_operation = asyncio.Event()
+
+    async def reset_session() -> str:
+        operation_entered.set()
+        await release_operation.wait()
+        return "reset-complete"
+
+    lifecycle = asyncio.create_task(
+        module.run_session_lifecycle(
+            principal_id=PRINCIPAL,
+            project_id=PROJECT,
+            raw_session_id="conversation-1",
+            operation=reset_session,
+            deadline_seconds=2.0,
+        )
+    )
+    capture: asyncio.Task[object] | None = None
+    try:
+        await asyncio.wait_for(operation_entered.wait(), timeout=1.0)
+        capture = asyncio.create_task(module.capture(_request(source="after-reset")))
+        await asyncio.sleep(0)
+
+        assert not capture.done()
+        assert store.list_queue_rows() == ()
+
+        release_operation.set()
+        assert await lifecycle == "reset-complete"
+        assert await capture == CaptureAccepted()
+    finally:
+        release_operation.set()
+        await asyncio.gather(
+            lifecycle,
+            *((capture,) if capture is not None else ()),
+            return_exceptions=True,
+        )
+
+
 async def test_capture_normalizes_deduplicates_and_never_persists_raw_ids(tmp_path: Path) -> None:
     module, store, _provider = _module(tmp_path)
     request = _request(
@@ -232,7 +389,7 @@ async def test_capture_pins_a_real_attachment_and_forwards_the_private_copy(tmp_
     assert attachment.uri not in queued.payload_attachments
 
     source_path.unlink()
-    assert await module._worker.drain_once() == 1
+    assert await module.drain() == 1
     forwarded = provider.captures[0].attachments[0]
     assert forwarded.name == attachment.name
     assert forwarded.uri != attachment.uri
@@ -273,9 +430,9 @@ async def test_boot_reconcile_waits_for_attachment_admission_and_preserves_accep
     )
     try:
         assert await asyncio.to_thread(published.wait, 1)
-        recovery = asyncio.create_task(
-            module._worker.coordinator.recover(lease_owner="activation-boot")
-        )
+        module.pause_claims()
+        module.begin_activation(new_lease=True)
+        recovery = asyncio.create_task(module.drain())
         assert await asyncio.to_thread(recovery_started.wait, 1)
 
         completed, _pending = await asyncio.wait({recovery}, timeout=0.1)
@@ -299,7 +456,9 @@ async def test_boot_reconcile_waits_for_attachment_admission_and_preserves_accep
         enabled=True,
         attachment_store=restarted_attachments,
     )
-    await restarted._worker.coordinator.recover(lease_owner="restart-boot")
+    restarted.pause_claims()
+    restarted.begin_activation(new_lease=True)
+    await restarted.drain()
 
     assert restarted_attachments.provider_attachments(bundle)[0].name == attachment.name
     assert restarted_store.list_queue_rows()[0].attachment_bundle_id == bundle.bundle_id

--- a/tests/test_memory_runtime.py
+++ b/tests/test_memory_runtime.py
@@ -121,15 +121,22 @@ async def test_memory_drain_task_reactivates_recovery_after_an_unexpected_failur
     async def no_wait(_seconds: float) -> None:
         return None
 
-    initial_boot_id = runtime.module._worker._boot_id
-    monkeypatch.setattr(runtime.module._worker, "drain", drain)
+    activations: list[bool] = []
+    begin_activation = runtime.module.begin_activation
+
+    def track_activation(*, new_lease: bool = False) -> None:
+        activations.append(new_lease)
+        begin_activation(new_lease=new_lease)
+
+    monkeypatch.setattr(runtime.module, "begin_activation", track_activation)
+    monkeypatch.setattr(runtime.module, "drain", drain)
     monkeypatch.setattr("core.memory.runtime.asyncio.sleep", no_wait)
 
     runtime._ensure_worker()
     assert runtime._worker_task is not None
     await runtime._worker_task
     assert drain_calls == 2
-    assert runtime.module._worker._boot_id != initial_boot_id
+    assert activations == [False, True]
 
 
 async def test_memory_drain_recovery_waits_for_scheduled_flush_settlement(
@@ -187,7 +194,7 @@ async def test_memory_drain_recovery_waits_for_scheduled_flush_settlement(
         flush_hook=block_flush,
     )
     runtime._provider = provider
-    runtime.module._replace_provider(provider)
+    runtime.module.replace_provider(provider)
     worker = runtime.module._worker
     coordinator = worker.coordinator
 
@@ -1248,7 +1255,7 @@ async def test_final_flush_fences_capture_before_queue_visibility(
         flush_hook=block_flush,
     )
     runtime._provider = provider
-    runtime.module._replace_provider(provider)
+    runtime.module.replace_provider(provider)
 
     source_root = runtime_home / "attachments" / "avibe"
     source_root.mkdir(parents=True, mode=0o700)
@@ -1310,7 +1317,7 @@ async def test_final_flush_fences_capture_before_queue_visibility(
 
     release_pin.set()
     assert isinstance(await old_capture, CaptureAccepted)
-    drain = asyncio.create_task(runtime.module._worker.drain_once())
+    drain = asyncio.create_task(runtime.module.drain())
 
     await asyncio.wait_for(flush_entered.wait(), timeout=1.0)
     assert [capture.text for capture in provider.captures] == [
@@ -1354,20 +1361,9 @@ async def test_session_lifecycle_fences_capture_through_reset(
     )
     provider = FakeMemoryProvider()
     runtime._provider = provider
-    runtime.module._replace_provider(provider)
+    runtime.module.replace_provider(provider)
     principal_id = "u-11111111111111111111111111111111"
     session_id = "lifecycle-session"
-    admission_lock = runtime.module._capture_admission_lock(
-        principal_id=principal_id,
-        project_id=PROJECT,
-        session_id=session_id,
-    )
-
-    async def failed_flush(**_kwargs) -> bool:
-        assert admission_lock.locked()
-        return False
-
-    monkeypatch.setattr(runtime, "_final_flush_under_admission", failed_flush)
     request = CaptureRequest(
         source_message_id="after-reset-source",
         session_id=session_id,
@@ -1442,36 +1438,56 @@ async def test_multi_scope_session_lifecycle_holds_every_fence_through_operation
         "p-22222222222222222222222222222222",
     )
     session_id = "multi-scope-lifecycle-session"
-    locks = [
-        runtime.module._capture_admission_lock(
-            principal_id=principal_id,
-            project_id=project_id,
-            session_id=session_id,
-        )
-        for principal_id, project_id in (first_scope, second_scope)
-    ]
-    flushes: list[tuple[str, str]] = []
-
-    async def flush_under_fence(*, principal_id, project_id, **_kwargs) -> bool:
-        assert all(lock.locked() for lock in locks)
-        flushes.append((principal_id, project_id))
-        return True
-
-    monkeypatch.setattr(runtime, "_final_flush_under_admission", flush_under_fence)
+    operation_entered = asyncio.Event()
+    release_operation = asyncio.Event()
 
     async def archive_session() -> str:
-        assert all(lock.locked() for lock in locks)
+        operation_entered.set()
+        await release_operation.wait()
         return "archived"
 
-    assert await runtime.run_session_scopes_lifecycle(
-        scopes=(second_scope, first_scope, second_scope),
-        raw_session_id=session_id,
-        operation=archive_session,
-        deadline_seconds=2.0,
-    ) == "archived"
-    assert flushes == [first_scope, second_scope]
-    assert all(not lock.locked() for lock in locks)
-    await memory_runtime_factory.close(runtime)
+    lifecycle = asyncio.create_task(
+        runtime.run_session_scopes_lifecycle(
+            scopes=(second_scope, first_scope, second_scope),
+            raw_session_id=session_id,
+            operation=archive_session,
+            deadline_seconds=2.0,
+        )
+    )
+    captures: list[asyncio.Task[object]] = []
+    try:
+        await asyncio.wait_for(operation_entered.wait(), timeout=1.0)
+        captures = [
+            asyncio.create_task(
+                runtime.module.capture(
+                    CaptureRequest(
+                        source_message_id=f"multi-scope-{index}",
+                        session_id=session_id,
+                        principal_id=principal_id,
+                        project_id=project_id,
+                        provenance="user_input",
+                        text=f"scope {index} after lifecycle",
+                        occurred_at_ms=1_725_000_001_234 + index,
+                        attachments=(),
+                    )
+                )
+            )
+            for index, (principal_id, project_id) in enumerate(
+                (first_scope, second_scope),
+                start=1,
+            )
+        ]
+        await asyncio.sleep(0)
+        assert all(not capture.done() for capture in captures)
+
+        release_operation.set()
+        assert await lifecycle == "archived"
+        capture_results = await asyncio.gather(*captures)
+        assert all(isinstance(result, CaptureAccepted) for result in capture_results)
+    finally:
+        release_operation.set()
+        await asyncio.gather(lifecycle, *captures, return_exceptions=True)
+        await memory_runtime_factory.close(runtime)
 
 
 async def test_cancelled_multi_scope_lifecycle_releases_partially_acquired_fences(
@@ -1599,7 +1615,7 @@ async def test_session_lifecycle_releases_capture_fence_after_aborted_reset(
     )
     provider = FakeMemoryProvider()
     runtime._provider = provider
-    runtime.module._replace_provider(provider)
+    runtime.module.replace_provider(provider)
     principal_id = "u-11111111111111111111111111111111"
     session_id = f"aborted-{outcome}-session"
     request = CaptureRequest(
@@ -1835,7 +1851,7 @@ async def test_runtime_repair_stops_retained_down_supervisor_before_replacing_ar
         events.append("pause")
         return True
 
-    monkeypatch.setattr(runtime.module._worker, "pause_and_wait", pause_and_wait)
+    monkeypatch.setattr(runtime.module, "quiesce_claims", pause_and_wait)
 
     assert await runtime.install_artifact() == {
         "ok": True,
@@ -3228,7 +3244,7 @@ async def test_runtime_restart_preserves_drain_completed_inside_grace_window(
     runtime._process = old
     provider = FakeMemoryProvider(add_hook=block_add)
     runtime._provider = provider
-    runtime.module._replace_provider(provider)
+    runtime.module.replace_provider(provider)
     store = runtime._store
     assert store is not None
     accepted = store.enqueue_request(

--- a/tests/test_memory_slice3.py
+++ b/tests/test_memory_slice3.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import ast
 import asyncio
 import gc
 import json
@@ -17,6 +18,7 @@ from core.controller import Controller
 from core.handlers.message_handler import MessageHandler
 from core.memory import CaptureAccepted, CaptureDuplicate
 from core.memory.artifact import FakeMemoryArtifactManager
+from core.memory.everos import FakeMemoryProvider
 from core.memory.runtime import MemoryRuntime
 from core.memory.store import MemoryStore
 from modules.im.base import FileAttachment, MessageContext
@@ -30,6 +32,7 @@ from modules.im.message_facts import (
 
 
 PROJECT = "p-22222222222222222222222222222222"
+REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
 class _Store:
@@ -730,11 +733,8 @@ def test_archive_memory_cli_session_skips_flush_when_memory_is_disabled(
     )
     assert runtime.available is True
     assert runtime._maintenance_open() is False
-
-    async def flush_must_not_run(**_kwargs) -> bool:
-        raise AssertionError("disabled Memory must not flush during archive")
-
-    monkeypatch.setattr(runtime, "_final_flush_under_admission", flush_must_not_run)
+    provider = FakeMemoryProvider()
+    runtime.module.replace_provider(provider)
     controller = _controller()
     controller.config.memory = disabled
     controller.memory_runtime = runtime
@@ -755,10 +755,44 @@ def test_archive_memory_cli_session_skips_flush_when_memory_is_disabled(
         assert store.resolve_current_session_scopes(session_id) == (
             (principal_id, PROJECT),
         )
+        assert provider.flushes == []
+        assert store.list_queue_rows()[0].state == "pending"
         with engine.connect() as conn:
             assert workbench_sessions_service.get_session(conn, session_id)["status"] == "archived"
     finally:
         engine.dispose()
+
+
+def test_removed_memory_runtime_lifecycle_symbols_have_no_callers() -> None:
+    """Keep callers on MemoryModule after lifecycle ownership moves there."""
+
+    module_internal = "_final_flush_" + "under_admission"
+    removed = {
+        module_internal,
+        "_final_flush_" + "timeout",
+        "_replace_" + "provider",
+    }
+    module_path = REPO_ROOT / "core" / "memory" / "module.py"
+    offenders: list[str] = []
+    for source_path in sorted(REPO_ROOT.rglob("*.py")):
+        if any(part in {".git", ".runtime", ".venv"} for part in source_path.parts):
+            continue
+        tree = ast.parse(source_path.read_text(encoding="utf-8"), filename=str(source_path))
+        for node in ast.walk(tree):
+            symbol: str | None = None
+            if isinstance(node, ast.Attribute):
+                symbol = node.attr
+            elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Name)):
+                symbol = node.name if hasattr(node, "name") else node.id
+            elif isinstance(node, ast.Constant) and isinstance(node.value, str):
+                symbol = node.value
+            if symbol not in removed:
+                continue
+            if source_path == module_path and symbol == module_internal:
+                continue
+            offenders.append(f"{source_path.relative_to(REPO_ROOT)}:{node.lineno}: {symbol}")
+
+    assert offenders == []
 
 
 def test_workbench_capture_requires_resolved_identity_and_uses_row_id() -> None:


### PR DESCRIPTION
## Summary
- add a behavior-shaped MemoryModule lifecycle and claim interface for maintenance fencing, provider replacement, activation, drain, shutdown, and attachment cleanup
- move exact-session and multi-scope admission fencing/final flush ownership into MemoryModule while preserving MemoryRuntime public contracts
- remove all production MemoryRuntime reach-through into private MemoryModule, MemoryWorker, and SessionFlushCoordinator state

## Evidence
- Unit: `pytest -q tests/test_memory_slice3.py tests/test_memory_module.py tests/test_memory_runtime.py tests/test_memory_maintenance.py tests/test_memory_processing_record.py tests/test_memory_worker.py tests/test_memory_flush_coordinator.py` (318 passed)
- Contract: module lifecycle ordering/root observation, maintenance admission fencing, quiesce timeout fail-closed behavior, provider replacement, lease activation routing, session lifecycle capture fencing, and disabled archive behavior
- Scenario IDs: none; no Memory scenario catalog entry applies to this behavior-preserving refactor
- Static: Ruff on all changed Python files; `git diff --check`; zero production Runtime private module/worker/coordinator crossings; repo-wide removed-symbol AST gate
- Residual manual checks: none required; no user-visible behavior or external Runtime/API contract changed
