### PR TITLE
fix(workbench): prevent false missing-session flash

### DIFF
--- a/ui/src/components/workbench/ChatPage.tsx
+++ b/ui/src/components/workbench/ChatPage.tsx
@@ -94,6 +94,7 @@ import {
   type SessionReadOnlyReason,
 } from './sessionArchived';
 import { createSessionRowRefreshGate } from './sessionRowRefresh';
+import { chatSessionViewState } from './chatSessionViewState';
 import { InstallHint } from '../InstallHint';
 import { Badge } from '../ui/badge';
 import { Button } from '../ui/button';
@@ -2463,15 +2464,16 @@ export const ChatPage: React.FC = () => {
     return <ChatMissing onBack={goBack} />;
   }
 
-  // A direct session→session switch re-renders this SAME ChatPage instance with
-  // the new :sessionId while every piece of state still belongs to the PREVIOUS
-  // session — the reset effect only clears it after this render commits.
-  // Rendering the chat body in those mismatch frames leaks the old session under
-  // the new route: the composer remounts (key change) seeded with the OLD
-  // session's draft and its seed-change would be persisted under the NEW
-  // session id. Treat the mismatch as loading so nothing of the old session
-  // ever mounts under the new route.
-  if ((loading && !session) || (session && session.id !== sessionId)) {
+  // A direct session→session switch reuses this ChatPage instance. Until the
+  // current row arrives, the state can still hold the previous row or be empty
+  // while a newer recovery read supersedes bootstrap. Neither means not-found.
+  const viewState = chatSessionViewState({
+    routeSessionId: sessionId,
+    loadedSessionId: session?.id ?? null,
+    loading,
+    error,
+  });
+  if (viewState === 'loading') {
     return (
       <div className="flex h-[60vh] flex-col items-center justify-center gap-2 text-muted">
         <Loader2 className="size-5 animate-spin" />
@@ -2480,7 +2482,7 @@ export const ChatPage: React.FC = () => {
     );
   }
 
-  if (!session) {
+  if (viewState === 'failed' || !session) {
     return (
       <div className="mx-auto flex w-full max-w-3xl flex-col gap-4 py-8">
         <button

--- a/ui/src/components/workbench/ChatPage.tsx
+++ b/ui/src/components/workbench/ChatPage.tsx
@@ -93,7 +93,10 @@ import {
   transcriptSelectionActions,
   type SessionReadOnlyReason,
 } from './sessionArchived';
-import { createSessionRowRefreshGate } from './sessionRowRefresh';
+import {
+  createSessionRowRefreshGate,
+  sessionRowWithBootstrapFallback,
+} from './sessionRowRefresh';
 import { chatSessionViewState } from './chatSessionViewState';
 import { InstallHint } from '../InstallHint';
 import { Badge } from '../ui/badge';
@@ -1383,8 +1386,14 @@ export const ChatPage: React.FC = () => {
       if (bootstrapIsCurrent()) {
         setSession(bootstrap.session);
       } else {
-        // A newer turn-end/activity read won the row race. Keep its route-bearing
-        // snapshot and repair a cold page if that read has not hydrated it yet.
+        // A newer turn-end/activity read won the row race. Preserve its row if
+        // it landed, but keep this successful bootstrap as the fallback while a
+        // cold-page recovery is pending or if both bounded attempts fail.
+        setSession((current) => sessionRowWithBootstrapFallback(
+          current,
+          sessionId,
+          bootstrap.session,
+        ));
         void refreshSessionRow();
       }
       setAgents(bootstrap.agents);

--- a/ui/src/components/workbench/chatSessionViewState.test.ts
+++ b/ui/src/components/workbench/chatSessionViewState.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+
+import { chatSessionViewState } from './chatSessionViewState';
+
+describe('chatSessionViewState', () => {
+  it.each([true, false])(
+    'keeps an empty error-free session in loading state when loading=%s',
+    (loading) => {
+      expect(chatSessionViewState({
+        routeSessionId: 'session-new',
+        loadedSessionId: null,
+        loading,
+        error: null,
+      })).toBe('loading');
+    },
+  );
+
+  it('keeps a row from the previous route out of the new chat', () => {
+    expect(chatSessionViewState({
+      routeSessionId: 'session-new',
+      loadedSessionId: 'session-old',
+      loading: false,
+      error: null,
+    })).toBe('loading');
+  });
+
+  it('shows content only for the current route and failure only for an explicit error', () => {
+    expect(chatSessionViewState({
+      routeSessionId: 'session-new',
+      loadedSessionId: 'session-new',
+      loading: true,
+      error: null,
+    })).toBe('ready');
+    expect(chatSessionViewState({
+      routeSessionId: 'session-new',
+      loadedSessionId: null,
+      loading: false,
+      error: 'Session unavailable',
+    })).toBe('failed');
+  });
+});

--- a/ui/src/components/workbench/chatSessionViewState.ts
+++ b/ui/src/components/workbench/chatSessionViewState.ts
@@ -1,0 +1,24 @@
+export type ChatSessionViewState = 'loading' | 'ready' | 'failed';
+
+type ChatSessionViewStateInput = {
+  routeSessionId: string;
+  loadedSessionId: string | null;
+  loading: boolean;
+  error: string | null;
+};
+
+export function chatSessionViewState({
+  routeSessionId,
+  loadedSessionId,
+  loading,
+  error,
+}: ChatSessionViewStateInput): ChatSessionViewState {
+  if (loadedSessionId === routeSessionId) return 'ready';
+
+  // A row from the previous route and an empty row awaiting a newer refresh are
+  // both pending states. Absence becomes a failure only after a request records
+  // an explicit error; it is never evidence that the session does not exist.
+  if (loadedSessionId !== null || loading || error === null) return 'loading';
+
+  return 'failed';
+}

--- a/ui/src/components/workbench/sessionRowRefresh.test.ts
+++ b/ui/src/components/workbench/sessionRowRefresh.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
-import { createSessionRowRefreshGate } from './sessionRowRefresh';
+import {
+  createSessionRowRefreshGate,
+  sessionRowWithBootstrapFallback,
+} from './sessionRowRefresh';
 
 describe('Session-row refresh ordering', () => {
   it('accepts only the newest overlapping read', async () => {
@@ -42,5 +45,25 @@ describe('Session-row refresh ordering', () => {
     finishSecond();
     await read;
     expect(readStarted).toBe(true);
+  });
+
+  it('uses bootstrap as a fallback when a superseding recovery produces no row', () => {
+    const bootstrap = { id: 'session-a', title: 'Bootstrap' };
+
+    expect(sessionRowWithBootstrapFallback(null, 'session-a', bootstrap)).toBe(bootstrap);
+  });
+
+  it('preserves a newer row for the current route over the bootstrap fallback', () => {
+    const bootstrap = { id: 'session-a', title: 'Bootstrap' };
+    const recovered = { id: 'session-a', title: 'Recovered' };
+
+    expect(sessionRowWithBootstrapFallback(recovered, 'session-a', bootstrap)).toBe(recovered);
+  });
+
+  it('replaces a stale row from the previous route with the bootstrap fallback', () => {
+    const bootstrap = { id: 'session-b', title: 'Bootstrap' };
+    const previous = { id: 'session-a', title: 'Previous' };
+
+    expect(sessionRowWithBootstrapFallback(previous, 'session-b', bootstrap)).toBe(bootstrap);
   });
 });

--- a/ui/src/components/workbench/sessionRowRefresh.ts
+++ b/ui/src/components/workbench/sessionRowRefresh.ts
@@ -7,6 +7,12 @@ export type SessionRowRefreshGate = {
   invalidate: () => void;
 };
 
+export const sessionRowWithBootstrapFallback = <T extends { id: string }>(
+  current: T | null,
+  routeSessionId: string,
+  bootstrap: T,
+): T => (current?.id === routeSessionId ? current : bootstrap);
+
 export const createSessionRowRefreshGate = (): SessionRowRefreshGate => {
   let generation = 0;
   let activeMutations = 0;


### PR DESCRIPTION
## Summary

- keep Workbench Chat in a loading state while the current route's session row is still pending
- distinguish a superseded bootstrap read from a confirmed session-load failure
- preserve a successful bootstrap session row when bounded recovery reads are exhausted
- prevent the fallback `chat.notFound` banner from flashing during ordinary session switches or recovery reads

## Capability

Reliable Workbench session switching when bootstrap and session-row recovery reads overlap, the connection is temporarily slow, or recovery attempts are exhausted.

Scenario catalog: N/A (no session-switching scenario IDs exist).

## Evidence

- Unit: explicit loading / ready / failed state contract, including previous-session, empty-but-error-free, and explicit-error transitions
- Contract: a missing session row is not treated as not-found until the load records an explicit error; a successful bootstrap is retained if newer best-effort recovery fails
- Scenario: the route-switch race from previous row -> empty pending row -> current row, plus recovery success/failure fallback branches, is covered by the state tests
- CI: lint workflow attempt 2 for c5eb4d30 passed all 13 checks; the first attempt's unrelated watch timeout timing test passed on rerun
- Residual manual checks: browser-level session switching over a degraded network was not run; production UI build and complete Vitest suite passed

## Validation

- `npm test -- src/components/workbench/chatSessionViewState.test.ts src/components/workbench/sessionRowRefresh.test.ts` (10 passed)
- `npm test -- --run` (1,666 passed)
- `npm run lint`
- `npm run build`
- `git diff --check`

Dependencies: none.
