### PR TITLE
fix(harness): decorate initial agent run inputs

### DIFF
--- a/core/session_turns.py
+++ b/core/session_turns.py
@@ -980,26 +980,13 @@ class SessionTurnManager:
         text: str,
         *,
         delivery: Optional[dict[str, Any]] = None,
+        decorate: bool = True,
     ) -> str:
-        """Decorate scheduled backend text immediately before native dispatch."""
+        """Restore scheduled provenance and optionally decorate backend text."""
         if delivery is not None:
-            payload = delivery_store.delivery_payload(delivery)
-            provenance = (payload.get("metadata") or {}).get(SCHEDULED_PROVENANCE_KEY)
-            preserved = (
-                provenance.get("platform_specific")
-                if isinstance(provenance, dict)
-                else None
-            )
-            if isinstance(preserved, dict):
-                spec = dict(getattr(context, "platform_specific", None) or {})
-                spec.update(
-                    {
-                        key: value
-                        for key, value in preserved.items()
-                        if key not in _EXECUTION_ROUTING_KEYS
-                    }
-                )
-                context.platform_specific = spec
+            self._restore_scheduled_dispatch_context(context, delivery)
+        if not decorate:
+            return text
         spec = dict(getattr(context, "platform_specific", None) or {})
         if spec.get(SCHEDULED_DISPATCH_METADATA_APPLIED_KEY):
             return text
@@ -1008,6 +995,30 @@ class SessionTurnManager:
         if not callable(decorator) or not inspect.iscoroutinefunction(decorator):
             return text
         return await decorator(context, text, include_user_info=False)
+
+    @staticmethod
+    def _restore_scheduled_dispatch_context(
+        context: "MessageContext",
+        delivery: dict[str, Any],
+    ) -> None:
+        payload = delivery_store.delivery_payload(delivery)
+        provenance = (payload.get("metadata") or {}).get(SCHEDULED_PROVENANCE_KEY)
+        preserved = (
+            provenance.get("platform_specific")
+            if isinstance(provenance, dict)
+            else None
+        )
+        if not isinstance(preserved, dict):
+            return
+        spec = dict(getattr(context, "platform_specific", None) or {})
+        spec.update(
+            {
+                key: value
+                for key, value in preserved.items()
+                if key not in _EXECUTION_ROUTING_KEYS
+            }
+        )
+        context.platform_specific = spec
 
     @staticmethod
     def _apply_delivery_binding_provenance(
@@ -3632,12 +3643,16 @@ class SessionTurnManager:
                 )
             text = str(turn.get("dispatch_text") or "")
             if source == SOURCE_SCHEDULED:
-                text = await self.prepare_scheduled_dispatch(
+                # Keep the raw prompt until MessageHandler parses an explicit
+                # ``subagent: prompt`` prefix. The handler adds metadata to the
+                # final backend request after routing; decorating here would make
+                # the metadata line hide that prefix from the parser.
+                await self.prepare_scheduled_dispatch(
                     resolved,
                     text,
                     delivery=delivery,
+                    decorate=False,
                 )
-                resolved.platform_specific[SCHEDULED_DISPATCH_METADATA_APPLIED_KEY] = True
         except Exception:
             logger.exception(
                 "durable native start failed during pre-dispatch preparation for Turn=%s",

--- a/core/session_turns.py
+++ b/core/session_turns.py
@@ -3631,6 +3631,13 @@ class SessionTurnManager:
                     else str(delivery["id"])
                 )
             text = str(turn.get("dispatch_text") or "")
+            if source == SOURCE_SCHEDULED:
+                text = await self.prepare_scheduled_dispatch(
+                    resolved,
+                    text,
+                    delivery=delivery,
+                )
+                resolved.platform_specific[SCHEDULED_DISPATCH_METADATA_APPLIED_KEY] = True
         except Exception:
             logger.exception(
                 "durable native start failed during pre-dispatch preparation for Turn=%s",

--- a/tests/test_message_handler_harness_echo.py
+++ b/tests/test_message_handler_harness_echo.py
@@ -124,6 +124,44 @@ class MessageHandlerHarnessEchoTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(request.subagent_name, "echo-probe")
         self.assertEqual(request.message, "audit the queue")
 
+    async def test_scheduled_subagent_prefix_routes_before_hidden_provenance(self):
+        controller, handler = _build_handler()
+        del handler._prepend_message_metadata
+        context = _scheduled_context(
+            source_kind="agent",
+            source_actor="source-session",
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            project = Path(tmp)
+            agents_dir = project / ".codex" / "agents"
+            agents_dir.mkdir(parents=True)
+            (agents_dir / "echo-probe.toml").write_text(
+                "\n".join(
+                    [
+                        'name = "echo-probe"',
+                        'description = "probe agent"',
+                        'developer_instructions = "probe"',
+                    ]
+                ),
+                encoding="utf-8",
+            )
+            handler.session_handler.get_session_info = (
+                lambda context, source="human": (
+                    "base-session",
+                    str(project),
+                    f"base-session:{project}",
+                )
+            )
+
+            await handler.handle_scheduled_message(context, "echo-probe: audit the queue")
+
+        _agent_name, request = controller.agent_service.requests[0]
+        self.assertEqual(request.subagent_name, "echo-probe")
+        self.assertEqual(
+            request.message,
+            "From: #source-session\naudit the queue",
+        )
+
     async def test_human_turn_never_stages_a_prompt(self):
         controller, handler = _build_handler()
 

--- a/tests/test_session_delivery_fsm.py
+++ b/tests/test_session_delivery_fsm.py
@@ -704,12 +704,8 @@ def test_persisted_start_attempt_reaches_dispatch_context(managers) -> None:
 
 
 @pytest.mark.anyio
-async def test_persisted_scheduled_start_decorates_before_native_dispatch(managers) -> None:
+async def test_persisted_scheduled_start_preserves_raw_text_for_handler_routing(managers) -> None:
     manager, _other, engine, _engine_b, _starts = managers
-    decorator = AsyncMock(side_effect=lambda _context, text, **_kwargs: f"decorated: {text}")
-    manager.controller.message_handler = SimpleNamespace(
-        _prepend_message_metadata=decorator,
-    )
     captured: dict[str, object] = {}
 
     async def capture_run(_session_id, context, text, **_kwargs):
@@ -748,11 +744,10 @@ async def test_persisted_scheduled_start_decorates_before_native_dispatch(manage
     )
 
     assert admitted.state == "claimed"
-    assert captured["text"] == "decorated: callback result"
-    assert decorator.await_args.args[0] is captured["context"]
-    assert (
-        captured["context"].platform_specific[SCHEDULED_DISPATCH_METADATA_APPLIED_KEY]
-        is True
+    assert captured["text"] == "callback result"
+    assert captured["context"].platform_specific["source_actor"] == "source-session"
+    assert not captured["context"].platform_specific.get(
+        SCHEDULED_DISPATCH_METADATA_APPLIED_KEY
     )
 
 

--- a/tests/test_session_delivery_fsm.py
+++ b/tests/test_session_delivery_fsm.py
@@ -37,6 +37,7 @@ from core.session_turns import (
     Turn,
     _scheduled_merge_key,
 )
+from core.message_context import SCHEDULED_DISPATCH_METADATA_APPLIED_KEY
 from core.handlers.message_handler import MessageHandler
 from modules.im import MessageContext
 from modules.im.base import FileAttachment
@@ -700,6 +701,59 @@ def test_persisted_start_attempt_reaches_dispatch_context(managers) -> None:
         turn = delivery_store.get_turn(conn, admitted.turn_id)
     assert turn is not None
     assert captured["delivery_start_attempt_id"] == turn["start_attempt_id"]
+
+
+@pytest.mark.anyio
+async def test_persisted_scheduled_start_decorates_before_native_dispatch(managers) -> None:
+    manager, _other, engine, _engine_b, _starts = managers
+    decorator = AsyncMock(side_effect=lambda _context, text, **_kwargs: f"decorated: {text}")
+    manager.controller.message_handler = SimpleNamespace(
+        _prepend_message_metadata=decorator,
+    )
+    captured: dict[str, object] = {}
+
+    async def capture_run(_session_id, context, text, **_kwargs):
+        captured["context"] = context
+        captured["text"] = text
+
+    manager._run = capture_run
+    context = _context()
+    context.platform_specific.update(
+        {
+            "task_trigger_kind": "agent_run",
+            "source_kind": "agent",
+            "source_actor": "source-session",
+        }
+    )
+
+    admitted = await manager.deliver(
+        DeliveryRequest(
+            session_id="ses_fsm",
+            priority="p3",
+            content="callback result",
+            source="harness",
+            author="harness",
+            message_type="harness",
+            metadata={
+                SCHEDULED_PROVENANCE_KEY: {
+                    "platform_specific": {
+                        "task_trigger_kind": "agent_run",
+                        "source_kind": "agent",
+                        "source_actor": "source-session",
+                    }
+                }
+            },
+        ),
+        context=context,
+    )
+
+    assert admitted.state == "claimed"
+    assert captured["text"] == "decorated: callback result"
+    assert decorator.await_args.args[0] is captured["context"]
+    assert (
+        captured["context"].platform_specific[SCHEDULED_DISPATCH_METADATA_APPLIED_KEY]
+        is True
+    )
 
 
 def test_first_delivery_binds_agentless_session_before_runtime_start(managers) -> None:


### PR DESCRIPTION
## Capability

Ensure Agent-to-Agent inputs and Harness callbacks carry hidden session provenance before the first native turn starts.

## Affected scenarios

- `MESSAGE-DELIVERY-018`
- `MESSAGE-DELIVERY-019`

## Root cause

The persisted scheduled-start path restored provenance but did not consistently apply it before an idle/new target Agent's first native request. The first fix added decoration before the claimed native start, but that decoration could hide an explicit `subagent: prompt` prefix from `MessageHandler`, whose parser is anchored at the beginning of the raw control message.

## Change

- Restore scheduled provenance on the hydrated dispatch context before the claimed native start.
- Keep persisted scheduled dispatch text raw until `MessageHandler` parses an explicit `subagent: prompt` prefix.
- Apply hidden provenance to the final backend request and preserve the context marker so shared pipeline decoration is not duplicated.
- Add Harness echo and session-delivery FSM regressions covering the initial Agent-originated dispatch.

## Evidence

- Unit/contract: latest focused local validation passed with 139 tests; Ruff passed on all changed Python files. GitHub CI is fully green on head `23e89678`.
- Scenario: local Incus master regression verified real Agent-to-Agent input (`From: #seswg8adeu3u3`) and normal callback input (`From: #ses3xgq8ecfd5`).
- User-visible contract: persisted Harness message content remains the raw prompt without the hidden `From:` line, while the final backend request carries provenance.
- Residual manual check: stopped-run callback could not be exercised because this regression instance's cancel dispatch socket was unavailable; the run completed naturally and callback was skipped by the existing cancellation policy.
