### PR TITLE
refactor(memory): extract sidecar lifecycle

### DIFF
--- a/core/memory/maintenance.py
+++ b/core/memory/maintenance.py
@@ -719,6 +719,7 @@ class MemoryMaintenance:
                         actor_ref="system:boot",
                     )
                 )
+                self._runtime.restore_completed()
             return True
         except asyncio.CancelledError:
             await self._mark_backup_restore_recovery(operation)

--- a/core/memory/maintenance.py
+++ b/core/memory/maintenance.py
@@ -88,6 +88,7 @@ class MemoryMaintenanceRuntimePort:
     quiesce: Callable[[bool], Awaitable[None]]
     resume: Callable[[], Awaitable[None]]
     delete_surface: Callable[[ClearSurface, int], Awaitable[None]]
+    restore_completed: Callable[[], None]
 
 
 class MemoryMaintenance:
@@ -411,6 +412,7 @@ class MemoryMaintenance:
                         execution_token=self._backup_restore_execution_token(operation),
                     )
                 )
+                self._runtime.restore_completed()
                 return restored
             except BaseException:
                 await self._mark_backup_restore_recovery(operation)

--- a/core/memory/runtime.py
+++ b/core/memory/runtime.py
@@ -55,6 +55,7 @@ from core.memory.process import (
     SidecarOwnership,
     sidecar_record_path,
 )
+from core.memory.sidecar_lifecycle import MemorySidecarLifecycle, SidecarSnapshot
 from core.memory.processing_record import (
     AnomalyProjection,
     FailureLogObservation,
@@ -327,7 +328,6 @@ class MemoryRuntime:
         )
         self._process_factory: EverOSProcessFactory = process_factory or EverOSProcess
         self._processing_event = processing_event
-        self._process: EverOSProcessPort | None = None
         # The controller-side port only talks to the private UDS. Credentials
         # enter an EverOSPort only inside the owned child probe/sidecar.
         self._provider = EverOSPort(self._socket_path)
@@ -339,12 +339,6 @@ class MemoryRuntime:
         self._restart_task: asyncio.Task[dict[str, Any]] | None = None
         self._ready_activation_task: asyncio.Task[None] | None = None
         self._closing = False
-        self._ready_event: EverOSProcessPort | None = None
-        # Single-flight state for the drain-side processing gate. Deliberately a
-        # flag and a cached verdict rather than a lock: the gate must answer
-        # without waiting, see ``_processing_healthy``.
-        self._processing_probe_active = False
-        self._processing_probe_healthy = False
         self._worker_task: asyncio.Task[None] | None = None
         self._activation_loop: asyncio.AbstractEventLoop | None = None
         self._artifact_installing = False
@@ -353,9 +347,17 @@ class MemoryRuntime:
         self._store_error: Exception | None = None
         self._insight_reader_override = insight_reader
         self._insight_reader: MemoryInsightReader | None = None
-        self._call_log_retention_task: asyncio.Task[None] | None = None
-        self._process_records_calls = False
         self._recorder_health: dict[str, str | None] = dict(_RECORDER_DISABLED)
+        self._sidecar = MemorySidecarLifecycle(
+            self._process_factory,
+            provider_root=self._provider_root,
+            effective_home=self._effective_home,
+            socket_path=self._socket_path,
+            call_log_db_path=self._call_log_db_path,
+            retain_call_log=self._maintain_call_log_once,
+            on_current_sidecar_ready=self._current_sidecar_ready,
+            on_recorder_health=self._update_recorder_health,
+        )
         self._maintenance = MemoryMaintenance(
             None,
             effective_home=self._effective_home,
@@ -436,6 +438,28 @@ class MemoryRuntime:
     @property
     def _call_log_db_path(self) -> Path:
         return self._memory_dir / "call-log" / "call-log.db"
+
+    # Remaining Runtime paths still read these projections while their own
+    # lifecycle work is migrated. Ownership remains in ``_sidecar``.
+    @property
+    def _process(self) -> EverOSProcessPort | None:
+        return self._sidecar.snapshot().process
+
+    @_process.setter
+    def _process(self, process: EverOSProcessPort | None) -> None:
+        self._sidecar._replace_for_runtime(process)
+
+    @property
+    def _process_records_calls(self) -> bool:
+        return self._sidecar.snapshot().records_calls
+
+    @_process_records_calls.setter
+    def _process_records_calls(self, value: bool) -> None:
+        self._sidecar._set_records_calls_for_runtime(value)
+
+    @property
+    def _call_log_retention_task(self) -> asyncio.Task[None] | None:
+        return self._sidecar.retention_task
 
     def _maintenance_open(self) -> bool:
         """Fail closed when the independent clear authority cannot prove terminal."""
@@ -812,10 +836,7 @@ class MemoryRuntime:
             self._runtime_error = "memory_clear_failed"
             return {"ok": False, "error": self._runtime_error}
         await self._stop_worker()
-        if self._process is not None:
-            await self._process.stop()
-            self._process = None
-        self._process_records_calls = False
+        await self._sidecar.stop()
 
         self._config = config
         self._configure_insight_reader(config)
@@ -834,53 +855,17 @@ class MemoryRuntime:
                 self.module.resume_claims()
             return {"ok": False, "error": self._runtime_error}
 
-        await self._stop_call_log_retention()
-        sidecar: EverOSProcessPort | None = None
-
-        async def before_recorder_start() -> None:
-            if sidecar is not self._process:
-                raise RuntimeError("stale EverOS recorder supervisor")
-            await self._stop_call_log_retention()
-
-        async def recorder_reaped() -> None:
-            if sidecar is not self._process:
-                return
-            self._process_records_calls = False
-            self._ensure_call_log_retention()
-
-        def sidecar_ready() -> None:
-            if sidecar is not None:
-                self._schedule_sidecar_ready(sidecar)
-
         settings = _process_settings(
             config,
             call_log_db_path=self._call_log_db_path,
         )
-        sidecar = self._process_factory(
-            python,
-            provider_root=self._provider_root,
-            effective_home=self._effective_home,
-            settings=settings,
-            socket_path=self._socket_path,
-            on_ready=sidecar_ready,
-            before_start=before_recorder_start,
-            on_reaped=recorder_reaped,
-        )
-        self._process = sidecar
-        self._process_records_calls = True
         try:
-            started = await self._process.start()
+            started = await self._sidecar.start(python, settings)
         except BaseException:
-            self._process_records_calls = False
-            self._ensure_call_log_retention()
             raise
         if not started:
-            self._process_records_calls = False
-            self._ensure_call_log_retention()
             self._runtime_error = "memory_sidecar_unavailable"
             return {"ok": False, "error": self._runtime_error}
-        if self._ready_event is sidecar:
-            self._ready_event = None
         self._update_recorder_health(_RECORDER_DEGRADED)
         self._runtime_error = None
         self.module.resume_claims()
@@ -1619,54 +1604,21 @@ class MemoryRuntime:
                 self._runtime_error = "memory_clear_failed"
                 return {"ok": False, "error": self._runtime_error}
 
-            await self._stop_call_log_retention()
-            sidecar: EverOSProcessPort | None = None
-
-            async def before_recorder_start() -> None:
-                if sidecar is not self._process:
-                    raise RuntimeError("stale EverOS recorder supervisor")
-                await self._stop_call_log_retention()
-
-            async def recorder_reaped() -> None:
-                if sidecar is not self._process:
-                    return
-                self._process_records_calls = False
-                self._ensure_call_log_retention()
-
-            def sidecar_ready() -> None:
-                if sidecar is not None:
-                    self._schedule_sidecar_ready(sidecar)
-
-            sidecar = self._process_factory(
-                python,
-                provider_root=self._provider_root,
-                effective_home=self._effective_home,
-                settings=_process_settings(
-                    self._config,
-                    call_log_db_path=self._call_log_db_path,
-                ),
-                socket_path=self._socket_path,
-                on_ready=sidecar_ready,
-                before_start=before_recorder_start,
-                on_reaped=recorder_reaped,
-            )
-            self._process = sidecar
-            self._process_records_calls = True
             self.module.begin_activation(new_lease=True)
             try:
-                started = await sidecar.start()
+                started = await self._sidecar.start(
+                    python,
+                    _process_settings(
+                        self._config,
+                        call_log_db_path=self._call_log_db_path,
+                    ),
+                )
             except Exception:
-                self._process_records_calls = False
-                self._ensure_call_log_retention()
                 self._runtime_error = "memory_restart_failed"
                 return {"ok": False, "error": self._runtime_error}
             if not started:
-                self._process_records_calls = False
-                self._ensure_call_log_retention()
                 self._runtime_error = "memory_sidecar_unavailable"
                 return {"ok": False, "error": self._runtime_error}
-            if self._ready_event is sidecar:
-                self._ready_event = None
 
             self._update_recorder_health(_RECORDER_DEGRADED)
             self._runtime_error = None
@@ -1676,6 +1628,7 @@ class MemoryRuntime:
 
     async def close(self) -> None:
         self._closing = True
+        self._sidecar.close_ready_admission()
         self._advance_processing_lifecycle()
         if self._maintenance is not None:
             await self._maintenance.close()
@@ -1687,29 +1640,13 @@ class MemoryRuntime:
                 raise
             except Exception:
                 pass
-        # Ready callbacks are synchronous schedulers. Close their admission
-        # before the first shutdown await so a late supervisor notification
-        # cannot create a new drain task behind this close operation.
-        self._activation_loop = None
-        self._ready_event = None
-        ready_task = self._ready_activation_task
-        if ready_task is not None and ready_task is not asyncio.current_task():
-            try:
-                await asyncio.shield(ready_task)
-            except asyncio.CancelledError:
-                raise
-            except Exception:
-                pass
         if self.available:
             try:
                 await self.module.prepare_shutdown()
             finally:
                 await self._stop_worker()
-        if self._process is not None:
-            await self._process.stop()
-            self._process = None
-        self._process_records_calls = False
         await self._stop_call_log_retention()
+        await self._sidecar.close()
         self._artifact_manager.set_activation_coordinator(None)
         self._advance_processing_lifecycle()
 
@@ -1874,58 +1811,44 @@ class MemoryRuntime:
 
         await self._quiesce_for_clear()
 
-    def _schedule_sidecar_ready(self, process: EverOSProcessPort) -> None:
-        """Coalesce a supervisor notification into Runtime-owned lock work."""
+    async def _current_sidecar_ready(self, generation: int) -> None:
+        """Accept the lifecycle module's semantic current-sidecar event."""
 
-        if self._activation_loop is None or process is not self._process:
+        async with self._reconcile_lock:
+            async with self.module.lifecycle():
+                snapshot = self._sidecar.snapshot()
+                if not self._sidecar_ready_is_current(snapshot, generation):
+                    return
+                if self._maintenance_open():
+                    self.module.pause_claims()
+                    return
+                if not self._sidecar_ready_is_current(self._sidecar.snapshot(), generation):
+                    return
+                self._runtime_error = None
+                self.module.resume_claims()
+                self._ensure_worker()
+
+    def _schedule_sidecar_ready(self, process: EverOSProcessPort) -> None:
+        """Compatibility bridge for legacy direct-supervisor test fixtures."""
+
+        if self._closing:
             return
-        self._ready_event = process
-        task = self._ready_activation_task
-        if task is not None and not task.done():
+        snapshot = self._sidecar.snapshot()
+        if process is not snapshot.process:
             return
-        task = asyncio.create_task(
-            self._activate_ready_events(),
+        self._ready_activation_task = asyncio.create_task(
+            self._current_sidecar_ready(snapshot.generation),
             name="memory-ready-activation",
         )
-        self._ready_activation_task = task
 
-        def clear_activation(completed: asyncio.Task[None]) -> None:
-            if self._ready_activation_task is completed:
-                self._ready_activation_task = None
-
-        task.add_done_callback(clear_activation)
-
-    async def _activate_ready_events(self) -> None:
-        while True:
-            async with self._reconcile_lock:
-                async with self.module.lifecycle():
-                    process = self._ready_event
-                    self._ready_event = None
-                    if process is None:
-                        return
-                    if not self._ready_event_is_current(process):
-                        continue
-                    if self._maintenance_open():
-                        self.module.pause_claims()
-                        continue
-                    if not self._ready_event_is_current(process):
-                        continue
-                    self._process_records_calls = True
-                    await self._stop_call_log_retention()
-                    if not self._ready_event_is_current(process):
-                        continue
-                    self._runtime_error = None
-                    self.module.resume_claims()
-                    self._ensure_worker()
-
-    def _ready_event_is_current(
+    def _sidecar_ready_is_current(
         self,
-        process: EverOSProcessPort,
+        snapshot: SidecarSnapshot,
+        generation: int,
     ) -> bool:
         return bool(
-            self._activation_loop is not None
-            and process is self._process
-            and process.running
+            snapshot.generation == generation
+            and snapshot.running
             and self._config.enabled
             and not self._config.embedding_change_pending
             and self._restart_config.enabled
@@ -1947,16 +1870,7 @@ class MemoryRuntime:
         published verdict instead of blocking.
         """
 
-        if self._processing_probe_active:
-            return self._processing_probe_healthy
-        self._processing_probe_active = True
-        try:
-            process = self._process
-            healthy = bool(process is not None and await process.processing_healthy())
-        finally:
-            self._processing_probe_active = False
-        self._processing_probe_healthy = healthy
-        return healthy
+        return await self._sidecar.processing_healthy()
 
     async def _probe_processing(self, python: Path, config: MemoryConfig) -> bool:
         """Probe a candidate configuration on a throwaway child.
@@ -1969,14 +1883,7 @@ class MemoryRuntime:
         lock every read and Clear needs.
         """
 
-        probe_process = self._process_factory(
-            python,
-            provider_root=self._provider_root,
-            effective_home=self._effective_home,
-            settings=_process_settings(config),
-            socket_path=self._socket_path,
-        )
-        return await probe_process.processing_healthy()
+        return await self._sidecar.probe(python, _process_settings(config))
 
     def _ensure_worker(self) -> None:
         if self._maintenance_open():
@@ -2015,61 +1922,18 @@ class MemoryRuntime:
             raise caller_cancellation
 
     def _ensure_call_log_retention(self) -> None:
-        task = self._call_log_retention_task
-        if (
-            self._process_records_calls
-            or self._recorder_health.get("reason") == "call_log_corrupt"
-            or not self._call_log_exists()
-        ):
-            return
-        if task is not None and not task.done():
-            return
-        self._call_log_retention_task = asyncio.create_task(
-            self._call_log_retention_loop(),
-            name="memory-call-log-retention",
-        )
+        if self._recorder_health.get("reason") != "call_log_corrupt":
+            self._sidecar.handoff_to_host_retention()
 
     async def _stop_call_log_retention(self) -> None:
-        task = self._call_log_retention_task
-        self._call_log_retention_task = None
-        if task is None or task is asyncio.current_task():
-            return
-        task.cancel()
-        try:
-            await task
-        except asyncio.CancelledError:
-            pass
-
-    async def _call_log_retention_loop(self) -> None:
-        current = asyncio.current_task()
-        try:
-            while True:
-                should_continue, reason = await self._maintain_call_log_once()
-                if not should_continue:
-                    return
-                if reason is not None:
-                    self._update_recorder_health(
-                        {"state": "degraded", "reason": reason}
-                    )
-                    if reason == "call_log_corrupt":
-                        return
-                elif self._recorder_health.get("reason") != "call_log_corrupt":
-                    self._set_recorder_health_disabled()
-                await asyncio.sleep(_CALL_LOG_RETENTION_INTERVAL_SECONDS)
-        finally:
-            if self._call_log_retention_task is current:
-                self._call_log_retention_task = None
+        await self._sidecar.stop_host_retention()
 
     async def _maintain_call_log_once(self) -> tuple[bool, str | None]:
         async with self._reconcile_lock:
-            if self._process_records_calls or not self._call_log_exists():
-                return False, None
             if self._module is None:
-                return True, await self._run_call_log_maintenance()
+                return await self._run_call_log_maintenance()
             async with self.module.lifecycle():
-                if self._process_records_calls or not self._call_log_exists():
-                    return False, None
-                return True, await self._run_call_log_maintenance()
+                return await self._run_call_log_maintenance()
 
     async def _run_call_log_maintenance(self) -> str | None:
         try:

--- a/core/memory/runtime.py
+++ b/core/memory/runtime.py
@@ -488,6 +488,7 @@ class MemoryRuntime:
             quiesce=self._quiesce_for_clear,
             resume=self._resume_after_clear,
             delete_surface=self._delete_clear_surface,
+            restore_completed=self._sidecar.reset_host_retention_after_clear,
         )
 
     def _processing_record_port(self) -> MemoryProcessingRecordPort:
@@ -986,6 +987,7 @@ class MemoryRuntime:
         observed_at: str | None = None,
     ) -> None:
         self._recorder_health = dict(health)
+        self._sidecar.observe_recorder_health(self._recorder_health)
         self._processing_record.observe_recorder(
             self._recorder_health,
             observed_at=observed_at,

--- a/core/memory/runtime.py
+++ b/core/memory/runtime.py
@@ -1339,6 +1339,7 @@ class MemoryRuntime:
             return
         if surface.surface == "call_log":
             await run_blocking(clear_call_log, self._call_log_db_path)
+            self._sidecar.reset_host_retention_after_clear()
             self._set_recorder_health_disabled()
             return
         if surface.surface == "attachments":

--- a/core/memory/runtime.py
+++ b/core/memory/runtime.py
@@ -338,6 +338,7 @@ class MemoryRuntime:
         )
         self._restart_task: asyncio.Task[dict[str, Any]] | None = None
         self._ready_activation_task: asyncio.Task[None] | None = None
+        self._artifact_activation_task: asyncio.Task[None] | None = None
         self._closing = False
         self._worker_task: asyncio.Task[None] | None = None
         self._activation_loop: asyncio.AbstractEventLoop | None = None
@@ -1629,6 +1630,7 @@ class MemoryRuntime:
     async def close(self) -> None:
         self._closing = True
         self._sidecar.close_ready_admission()
+        self._activation_loop = None
         self._advance_processing_lifecycle()
         if self._maintenance is not None:
             await self._maintenance.close()
@@ -1636,6 +1638,15 @@ class MemoryRuntime:
         if restart_task is not None and restart_task is not asyncio.current_task():
             try:
                 await asyncio.shield(restart_task)
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                pass
+        for task in (self._artifact_activation_task, self._ready_activation_task):
+            if task is None or task is asyncio.current_task():
+                continue
+            try:
+                await asyncio.shield(task)
             except asyncio.CancelledError:
                 raise
             except Exception:
@@ -1689,6 +1700,8 @@ class MemoryRuntime:
         task_result: ThreadFuture[None] = ThreadFuture()
 
         def settle_task(task: asyncio.Task[None]) -> None:
+            if self._artifact_activation_task is task:
+                self._artifact_activation_task = None
             if task.cancelled():
                 task_result.cancel()
                 return
@@ -1706,6 +1719,7 @@ class MemoryRuntime:
             except BaseException as exc:
                 task_ready.set_exception(exc)
                 return
+            self._artifact_activation_task = task
             task.add_done_callback(settle_task)
             task_ready.set_result(task)
 
@@ -1749,6 +1763,8 @@ class MemoryRuntime:
 
         async with self._reconcile_lock:
             async with self.module.lifecycle():
+                if self._closing:
+                    raise MemoryRuntimeActivationError("memory controller lifecycle is unavailable")
                 if self._maintenance_open():
                     self.module.pause_claims()
                     raise MemoryRuntimeActivationError("memory clear recovery is required")
@@ -1854,6 +1870,7 @@ class MemoryRuntime:
             and self._restart_config.enabled
             and not self._restart_config.embedding_change_pending
             and not self._artifact_installing
+            and not self._closing
         )
 
     async def _processing_healthy(self) -> bool:

--- a/core/memory/sidecar_lifecycle.py
+++ b/core/memory/sidecar_lifecycle.py
@@ -61,6 +61,7 @@ class MemorySidecarLifecycle:
         self._ready_generation: int | None = None
         self._ready_task: asyncio.Task[None] | None = None
         self._retention_task: asyncio.Task[None] | None = None
+        self._retention_blocked = False
         self._ready_admission_open = True
         self._closed = False
         self._processing_probe_active = False
@@ -202,6 +203,11 @@ class MemorySidecarLifecycle:
     async def stop_host_retention(self) -> None:
         await self._stop_retention()
 
+    def reset_host_retention_after_clear(self) -> None:
+        """Reopen retention only after Clear repaired its corrupt call-log surface."""
+
+        self._retention_blocked = False
+
     def _is_current(self, process: EverOSProcessPort | None, generation: int) -> bool:
         return process is not None and process is self._process and generation == self._generation
 
@@ -226,7 +232,12 @@ class MemorySidecarLifecycle:
                     await result
 
     def _ensure_retention(self) -> None:
-        if self._closed or self._records_calls or not self._call_log_exists():
+        if (
+            self._closed
+            or self._retention_blocked
+            or self._records_calls
+            or not self._call_log_exists()
+        ):
             return
         if self._retention_task is None or self._retention_task.done():
             self._retention_task = asyncio.create_task(
@@ -254,6 +265,7 @@ class MemorySidecarLifecycle:
                 if reason is not None:
                     self._on_recorder_health({"state": "degraded", "reason": reason})
                     if reason == "call_log_corrupt":
+                        self._retention_blocked = True
                         return
                 else:
                     self._on_recorder_health({"state": "disabled", "reason": None})

--- a/core/memory/sidecar_lifecycle.py
+++ b/core/memory/sidecar_lifecycle.py
@@ -1,0 +1,269 @@
+"""Deep lifecycle module for Memory's private EverOS sidecar."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from pathlib import Path
+
+from core.memory.process import EverOSProcessFactory, EverOSProcessPort, EverOSProcessSettings
+
+
+logger = logging.getLogger(__name__)
+_CALL_LOG_RETENTION_INTERVAL_SECONDS = 6 * 60 * 60
+
+
+@dataclass(frozen=True, slots=True)
+class SidecarSnapshot:
+    """The current sidecar ownership projection for its Runtime caller."""
+
+    generation: int
+    process: EverOSProcessPort | None
+    records_calls: bool
+
+    @property
+    def running(self) -> bool:
+        return bool(self.process and self.process.running)
+
+
+class MemorySidecarLifecycle:
+    """Own sidecar supervision, readiness admission, and recorder handoff.
+
+    Runtime supplies its existing lifecycle fence for retention work; this module
+    keeps the ownership state and all supervisor callbacks local.
+    """
+
+    def __init__(
+        self,
+        process_factory: EverOSProcessFactory,
+        *,
+        provider_root: Path,
+        effective_home: Path,
+        socket_path: Path,
+        call_log_db_path: Path,
+        retain_call_log: Callable[[], Awaitable[str | None]],
+        on_current_sidecar_ready: Callable[[int], Awaitable[None] | None],
+        on_recorder_health: Callable[[dict[str, str | None]], None],
+    ) -> None:
+        self._process_factory = process_factory
+        self._provider_root = provider_root
+        self._effective_home = effective_home
+        self._socket_path = socket_path
+        self._call_log_db_path = call_log_db_path
+        self._retain_call_log = retain_call_log
+        self._on_current_sidecar_ready = on_current_sidecar_ready
+        self._on_recorder_health = on_recorder_health
+        self._process: EverOSProcessPort | None = None
+        self._generation = 0
+        self._records_calls = False
+        self._ready_generation: int | None = None
+        self._ready_task: asyncio.Task[None] | None = None
+        self._retention_task: asyncio.Task[None] | None = None
+        self._ready_admission_open = True
+        self._processing_probe_active = False
+        self._processing_probe_healthy = False
+
+    def snapshot(self) -> SidecarSnapshot:
+        return SidecarSnapshot(self._generation, self._process, self._records_calls)
+
+    def _replace_for_runtime(self, process: EverOSProcessPort | None) -> None:
+        """Temporary Runtime compatibility for lifecycle paths not yet migrated."""
+
+        self._generation += 1
+        self._process = process
+
+    def _set_records_calls_for_runtime(self, value: bool) -> None:
+        self._records_calls = value
+
+    async def start(self, python: Path, settings: EverOSProcessSettings) -> bool:
+        """Replace the supervised sidecar, assigning ownership before start."""
+
+        await self.stop()
+        await self._stop_retention()
+        self._generation += 1
+        generation = self._generation
+        sidecar: EverOSProcessPort | None = None
+
+        async def before_start() -> None:
+            if not self._is_current(sidecar, generation):
+                raise RuntimeError("stale EverOS recorder supervisor")
+            self._records_calls = True
+            await self._stop_retention()
+
+        async def reaped() -> None:
+            if not self._is_current(sidecar, generation):
+                return
+            self._records_calls = False
+            self._ensure_retention()
+
+        def ready() -> None:
+            if self._is_current(sidecar, generation) and self._ready_admission_open:
+                self._schedule_ready(generation)
+
+        sidecar = self._process_factory(
+            python,
+            provider_root=self._provider_root,
+            effective_home=self._effective_home,
+            settings=settings,
+            socket_path=self._socket_path,
+            on_ready=ready,
+            before_start=before_start,
+            on_reaped=reaped,
+        )
+        self._process = sidecar
+        self._records_calls = True
+        try:
+            started = await sidecar.start()
+        except BaseException:
+            if self._is_current(sidecar, generation):
+                self._records_calls = False
+                self._ensure_retention()
+            raise
+        if not started:
+            if self._is_current(sidecar, generation):
+                self._records_calls = False
+                self._ensure_retention()
+            return False
+        # Runtime accepts the successful explicit start synchronously. The
+        # supervisor's same-turn ready notification is therefore redundant;
+        # later recovery notifications still emit the semantic event.
+        if self._ready_generation == generation:
+            self._ready_generation = None
+        return True
+
+    async def stop(self) -> None:
+        """Stop the current child; failed cleanup intentionally retains ownership."""
+
+        process = self._process
+        if process is None:
+            return
+        await process.stop()
+        if process is self._process:
+            self._process = None
+            self._generation += 1
+            self._records_calls = False
+            self._ensure_retention()
+
+    async def probe(self, python: Path, settings: EverOSProcessSettings) -> bool:
+        probe = self._process_factory(
+            python,
+            provider_root=self._provider_root,
+            effective_home=self._effective_home,
+            settings=settings,
+            socket_path=self._socket_path,
+        )
+        return await probe.processing_healthy()
+
+    async def processing_healthy(self) -> bool:
+        if self._processing_probe_active:
+            return self._processing_probe_healthy
+        self._processing_probe_active = True
+        try:
+            process = self._process
+            healthy = bool(process and await process.processing_healthy())
+        finally:
+            self._processing_probe_active = False
+        self._processing_probe_healthy = healthy
+        return healthy
+
+    async def close(self) -> None:
+        """Close ready admission, settle internal work, then stop ownership."""
+
+        self.close_ready_admission()
+        task = self._ready_task
+        if task is not None and task is not asyncio.current_task():
+            try:
+                await asyncio.shield(task)
+            except Exception:
+                pass
+        await self._stop_retention()
+        await self.stop()
+
+    def close_ready_admission(self) -> None:
+        """Synchronously reject late supervisor readiness before shutdown awaits."""
+
+        self._ready_admission_open = False
+        self._ready_generation = None
+
+    def handoff_to_host_retention(self) -> None:
+        """Start host maintenance after an external orphan handoff proved safe."""
+
+        self._ensure_retention()
+
+    @property
+    def retention_task(self) -> asyncio.Task[None] | None:
+        return self._retention_task
+
+    async def stop_host_retention(self) -> None:
+        await self._stop_retention()
+
+    def _is_current(self, process: EverOSProcessPort | None, generation: int) -> bool:
+        return process is not None and process is self._process and generation == self._generation
+
+    def _schedule_ready(self, generation: int) -> None:
+        self._ready_generation = generation
+        task = self._ready_task
+        if task is None or task.done():
+            self._ready_task = asyncio.create_task(self._emit_ready(), name="memory-ready-activation")
+
+    async def _emit_ready(self) -> None:
+        while self._ready_generation is not None:
+            generation = self._ready_generation
+            self._ready_generation = None
+            snapshot = self.snapshot()
+            if (
+                self._ready_admission_open
+                and snapshot.generation == generation
+                and snapshot.running
+            ):
+                result = self._on_current_sidecar_ready(generation)
+                if asyncio.iscoroutine(result):
+                    await result
+
+    def _ensure_retention(self) -> None:
+        if self._records_calls or not self._call_log_exists():
+            return
+        if self._retention_task is None or self._retention_task.done():
+            self._retention_task = asyncio.create_task(
+                self._retention_loop(), name="memory-call-log-retention"
+            )
+
+    async def _stop_retention(self) -> None:
+        task = self._retention_task
+        self._retention_task = None
+        if task is None or task is asyncio.current_task():
+            return
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    async def _retention_loop(self) -> None:
+        current = asyncio.current_task()
+        try:
+            while True:
+                if self._records_calls or not self._call_log_exists():
+                    return
+                reason = await self._retain_call_log()
+                if reason is not None:
+                    self._on_recorder_health({"state": "degraded", "reason": reason})
+                    if reason == "call_log_corrupt":
+                        return
+                else:
+                    self._on_recorder_health({"state": "disabled", "reason": None})
+                await asyncio.sleep(_CALL_LOG_RETENTION_INTERVAL_SECONDS)
+        finally:
+            if self._retention_task is current:
+                self._retention_task = None
+
+    def _call_log_exists(self) -> bool:
+        try:
+            self._call_log_db_path.lstat()
+        except FileNotFoundError:
+            return False
+        except OSError:
+            return True
+        return True

--- a/core/memory/sidecar_lifecycle.py
+++ b/core/memory/sidecar_lifecycle.py
@@ -203,6 +203,12 @@ class MemorySidecarLifecycle:
     async def stop_host_retention(self) -> None:
         await self._stop_retention()
 
+    def observe_recorder_health(self, health: dict[str, str | None]) -> None:
+        """Block host retention when the live recorder reports corruption."""
+
+        if health.get("reason") == "call_log_corrupt":
+            self._retention_blocked = True
+
     def reset_host_retention_after_clear(self) -> None:
         """Reopen retention only after Clear repaired its corrupt call-log surface."""
 

--- a/core/memory/sidecar_lifecycle.py
+++ b/core/memory/sidecar_lifecycle.py
@@ -62,6 +62,7 @@ class MemorySidecarLifecycle:
         self._ready_task: asyncio.Task[None] | None = None
         self._retention_task: asyncio.Task[None] | None = None
         self._ready_admission_open = True
+        self._closed = False
         self._processing_probe_active = False
         self._processing_probe_healthy = False
 
@@ -185,12 +186,14 @@ class MemorySidecarLifecycle:
         """Synchronously reject late supervisor readiness before shutdown awaits."""
 
         self._ready_admission_open = False
+        self._closed = True
         self._ready_generation = None
 
     def handoff_to_host_retention(self) -> None:
         """Start host maintenance after an external orphan handoff proved safe."""
 
-        self._ensure_retention()
+        if not self._closed:
+            self._ensure_retention()
 
     @property
     def retention_task(self) -> asyncio.Task[None] | None:
@@ -223,7 +226,7 @@ class MemorySidecarLifecycle:
                     await result
 
     def _ensure_retention(self) -> None:
-        if self._records_calls or not self._call_log_exists():
+        if self._closed or self._records_calls or not self._call_log_exists():
             return
         if self._retention_task is None or self._retention_task.done():
             self._retention_task = asyncio.create_task(

--- a/tests/test_memory_maintenance.py
+++ b/tests/test_memory_maintenance.py
@@ -2068,6 +2068,11 @@ async def test_maintenance_backup_restore_round_trips_queue_state(
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     runtime = memory_runtime_factory(MemoryConfig(), effective_home=tmp_path)
     _enqueue(runtime, "backup-source")
+    restored_call_log: list[None] = []
+    _replace_runtime_port(
+        runtime,
+        restore_completed=lambda: restored_call_log.append(None),
+    )
 
     backup = await _maintenance(runtime).create_backup("runtime-round-trip")
     meta = runtime._store.ensure_meta()
@@ -2081,6 +2086,7 @@ async def test_maintenance_backup_restore_round_trips_queue_state(
     )
 
     assert restored == backup
+    assert restored_call_log == [None]
     rows = runtime._store.list_queue_rows()
     assert len(rows) == 1
     assert rows[0].source_message_digest

--- a/tests/test_memory_maintenance.py
+++ b/tests/test_memory_maintenance.py
@@ -2194,6 +2194,11 @@ async def test_backup_restore_crash_is_fenced_and_boot_converges_one_generation(
         MemoryConfig(enabled=True),
         effective_home=tmp_path,
     )
+    restored_call_log: list[None] = []
+    _replace_runtime_port(
+        restarted,
+        restore_completed=lambda: restored_call_log.append(None),
+    )
     recovery = _maintenance(restarted)._backup_restore_journal.get_open_operation()
     assert recovery is not None
     assert recovery.state == "recovery_needed"
@@ -2228,6 +2233,7 @@ async def test_backup_restore_crash_is_fenced_and_boot_converges_one_generation(
         still_fenced = _maintenance(restarted)._backup_restore_journal.get_open_operation()
         assert still_fenced == recovery
         assert restarted.module._worker._claims_paused is True
+        assert restored_call_log == []
         monkeypatch.setattr(SidecarOwnership, "reap", original_reap)
 
     assert await restarted.reconcile(MemoryConfig()) == {
@@ -2256,6 +2262,7 @@ async def test_backup_restore_crash_is_fenced_and_boot_converges_one_generation(
         )
     ] == ["started", "recovery_needed", "retry_started", "completed"]
     assert _maintenance(restarted).is_open() is False
+    assert restored_call_log == [None]
 
     await memory_runtime_factory.close(runtime)
     await memory_runtime_factory.close(restarted)

--- a/tests/test_memory_sidecar_lifecycle.py
+++ b/tests/test_memory_sidecar_lifecycle.py
@@ -103,3 +103,44 @@ async def test_close_never_restarts_host_retention_after_stopping_sidecar(tmp_pa
 
     assert lifecycle.snapshot().process is None
     assert lifecycle.retention_task is None
+
+
+async def test_corrupt_host_log_stays_blocked_across_sidecar_reaps(tmp_path: Path) -> None:
+    factory = FakeEverOSProcessFactory()
+    call_log = tmp_path / "memory" / "call-log" / "call-log.db"
+    call_log.parent.mkdir(parents=True)
+    call_log.touch()
+    attempts = 0
+
+    async def retain() -> str | None:
+        nonlocal attempts
+        attempts += 1
+        return "call_log_corrupt"
+
+    lifecycle = MemorySidecarLifecycle(
+        factory,
+        provider_root=tmp_path / "memory" / "everos-root",
+        effective_home=tmp_path,
+        socket_path=tmp_path / "memory" / ".rt" / "everos.sock",
+        call_log_db_path=call_log,
+        retain_call_log=retain,
+        on_current_sidecar_ready=lambda _generation: None,
+        on_recorder_health=lambda _health: None,
+    )
+    lifecycle.handoff_to_host_retention()
+    task = lifecycle.retention_task
+    assert task is not None
+    await task
+    assert attempts == 1
+
+    assert await lifecycle.start(Path(sys.executable), _settings()) is True
+    await lifecycle.stop()
+    await asyncio.sleep(0)
+    assert attempts == 1
+
+    lifecycle.reset_host_retention_after_clear()
+    lifecycle.handoff_to_host_retention()
+    resumed = lifecycle.retention_task
+    assert resumed is not None
+    await resumed
+    assert attempts == 2

--- a/tests/test_memory_sidecar_lifecycle.py
+++ b/tests/test_memory_sidecar_lifecycle.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+import pytest
+
+from core.memory.process import EverOSProcessSettings, FakeEverOSProcess, FakeEverOSProcessFactory
+from core.memory.sidecar_lifecycle import MemorySidecarLifecycle
+
+
+def _settings() -> EverOSProcessSettings:
+    return EverOSProcessSettings(
+        llm_base_url="https://llm.example.test",
+        llm_model="model",
+        llm_api_key="key",
+        embedding_base_url="https://embedding.example.test",
+        embedding_model="embedding",
+        embedding_api_key="key",
+    )
+
+
+def _lifecycle(tmp_path: Path, factory: FakeEverOSProcessFactory, ready) -> MemorySidecarLifecycle:
+    async def retain() -> str | None:
+        return None
+
+    return MemorySidecarLifecycle(
+        factory,
+        provider_root=tmp_path / "memory" / "everos-root",
+        effective_home=tmp_path,
+        socket_path=tmp_path / "memory" / ".rt" / "everos.sock",
+        call_log_db_path=tmp_path / "memory" / "call-log" / "call-log.db",
+        retain_call_log=retain,
+        on_current_sidecar_ready=ready,
+        on_recorder_health=lambda _health: None,
+    )
+
+
+async def test_start_assigns_owner_before_sidecar_callbacks_and_ignores_stale_reap(tmp_path: Path) -> None:
+    factory = FakeEverOSProcessFactory()
+    ready: list[int] = []
+    lifecycle = _lifecycle(tmp_path, factory, lambda generation: ready.append(generation))
+
+    assert await lifecycle.start(Path(sys.executable), _settings()) is True
+    first = factory.supervised[0]
+    first_generation = lifecycle.snapshot().generation
+    await first.ready()
+    await asyncio.sleep(0)
+    assert ready == [first_generation]
+
+    assert await lifecycle.start(Path(sys.executable), _settings()) is True
+    second = factory.supervised[1]
+    assert first.stops == 1
+    stale_reap = first.on_reaped
+    assert stale_reap is not None
+    await stale_reap()
+    assert lifecycle.snapshot().process is second
+    assert lifecycle.snapshot().records_calls is True
+
+
+async def test_stop_failure_retains_current_supervisor(tmp_path: Path) -> None:
+    factory = FakeEverOSProcessFactory(template=lambda: FakeEverOSProcess(stop_failure=RuntimeError("stuck")))
+    lifecycle = _lifecycle(tmp_path, factory, lambda _generation: None)
+    assert await lifecycle.start(Path(sys.executable), _settings()) is True
+    process = lifecycle.snapshot().process
+
+    with pytest.raises(RuntimeError, match="stuck"):
+        await lifecycle.stop()
+    assert lifecycle.snapshot().process is process
+
+
+async def test_processing_health_is_single_flight_without_waiting(tmp_path: Path) -> None:
+    entered = asyncio.Event()
+    release = asyncio.Event()
+
+    class BlockingProcess(FakeEverOSProcess):
+        async def processing_healthy(self) -> bool:
+            entered.set()
+            await release.wait()
+            return True
+
+    factory = FakeEverOSProcessFactory(template=BlockingProcess)
+    lifecycle = _lifecycle(tmp_path, factory, lambda _generation: None)
+    assert await lifecycle.start(Path(sys.executable), _settings()) is True
+
+    first = asyncio.create_task(lifecycle.processing_healthy())
+    await entered.wait()
+    assert await asyncio.wait_for(lifecycle.processing_healthy(), timeout=1) is False
+    release.set()
+    assert await first is True

--- a/tests/test_memory_sidecar_lifecycle.py
+++ b/tests/test_memory_sidecar_lifecycle.py
@@ -144,3 +144,32 @@ async def test_corrupt_host_log_stays_blocked_across_sidecar_reaps(tmp_path: Pat
     assert resumed is not None
     await resumed
     assert attempts == 2
+
+
+async def test_recorder_corruption_blocks_host_retention_after_a_reap(tmp_path: Path) -> None:
+    factory = FakeEverOSProcessFactory()
+    call_log = tmp_path / "memory" / "call-log" / "call-log.db"
+    call_log.parent.mkdir(parents=True)
+    call_log.touch()
+    attempts = 0
+
+    async def retain() -> str | None:
+        nonlocal attempts
+        attempts += 1
+        return None
+
+    lifecycle = MemorySidecarLifecycle(
+        factory,
+        provider_root=tmp_path / "memory" / "everos-root",
+        effective_home=tmp_path,
+        socket_path=tmp_path / "memory" / ".rt" / "everos.sock",
+        call_log_db_path=call_log,
+        retain_call_log=retain,
+        on_current_sidecar_ready=lambda _generation: None,
+        on_recorder_health=lambda _health: None,
+    )
+    lifecycle.observe_recorder_health({"state": "degraded", "reason": "call_log_corrupt"})
+    assert await lifecycle.start(Path(sys.executable), _settings()) is True
+    await lifecycle.stop()
+    await asyncio.sleep(0)
+    assert attempts == 0

--- a/tests/test_memory_sidecar_lifecycle.py
+++ b/tests/test_memory_sidecar_lifecycle.py
@@ -89,3 +89,17 @@ async def test_processing_health_is_single_flight_without_waiting(tmp_path: Path
     assert await asyncio.wait_for(lifecycle.processing_healthy(), timeout=1) is False
     release.set()
     assert await first is True
+
+
+async def test_close_never_restarts_host_retention_after_stopping_sidecar(tmp_path: Path) -> None:
+    factory = FakeEverOSProcessFactory()
+    call_log = tmp_path / "memory" / "call-log" / "call-log.db"
+    call_log.parent.mkdir(parents=True)
+    call_log.touch()
+    lifecycle = _lifecycle(tmp_path, factory, lambda _generation: None)
+
+    assert await lifecycle.start(Path(sys.executable), _settings()) is True
+    await lifecycle.close()
+
+    assert lifecycle.snapshot().process is None
+    assert lifecycle.retention_task is None


### PR DESCRIPTION
## Memory sidecar lifecycle

Extracts `MemorySidecarLifecycle` as the deep owner of sidecar supervision, generation checks, readiness coalescing, recorder-to-host retention handoff, and processing-health single-flight. Runtime keeps provider/root reconciliation, configuration, maintenance fences, and worker activation.

Scenario IDs: none (internal lifecycle refactor; no matching catalog scenario).

Evidence: unit `tests/test_memory_sidecar_lifecycle.py`; contract `tests/test_memory_runtime.py`; runtime/factory/controller-adjacent `tests/test_memory_runtime_factory.py`, `tests/test_runtime_activation.py`, `tests/test_memory_module.py`, `tests/test_memory_process.py`.

Validation: focused pytest suite (228 passed); Ruff; `git diff --check`. Residual manual checks: none; no user-facing workflow changed.