### PR TITLE
docs(memory): define EverOS recovery contract

### DIFF
--- a/docs/memory-everos-reuse-audit.md
+++ b/docs/memory-everos-reuse-audit.md
@@ -1,0 +1,234 @@
+# Memory x EverOS reuse audit
+
+This audit compares Avibe's Memory integration with the capabilities in the
+pinned EverOS 1.2.3 artifact. It is the decision record behind
+`docs/plans/memory-rebuild-and-recovery-ladder.md`, not a mandate to replace
+working Avibe guarantees with superficially similar EverOS internals.
+
+Evidence baseline: Avibe `d6c7cf2d`; EverOS `560fb80`, whose source tree matches
+the 1.2.3 release commit `48fc908` (the release commit adds only the changelog).
+
+Verdicts use five terms:
+
+- **Reuse now**: a supported EverOS capability directly removes Avibe code in
+  the current recovery work.
+- **Keep**: Avibe owns a real gateway, durability, security, or product gap.
+- **Defer**: the idea lacks a prerequisite or measured payoff and should not
+  produce an implementation PR now.
+- **Investigate separately**: promising overlap whose storage/process contract
+  is not yet safe enough to change.
+- **Upstream**: EverOS needs a stable seam before Avibe should shrink.
+
+## Executive decision
+
+The recovery implementation reuses `cascade rebuild` and the existing EverOS
+health block. It does not add a replacement indexer, parse CLI output, or invent
+a second durable rebuild journal. The persisted candidate configuration plus
+`embedding_change_pending` is the crash fence; EverOS's reset-queue-first rebuild
+is the retry mechanism.
+
+The original audit overstated F2, F3, F4, and F5. Their corrected contracts are
+recorded below. The recovery plan is the priority workstream and may itself land
+as Rebuild-and-Apply followed by Factory reset. The findings here are separate
+optimization PRs or upstream work, not bundled recovery scope.
+
+| Finding | Validated verdict | Delivery |
+|---|---|---|
+| F1 message batching | Defer | Blocked on durable receipts |
+| F2 smaller snapshots | Defer | Research only after measured cost |
+| F3 ambiguous resend | Keep; upstream receipt | Upstream prerequisite |
+| F4 `cascade sync` / `fix` | Reuse `sync`; defer `fix` | Projection-repair PR / upstream contract |
+| F5 count flush | Keep | No change |
+| F6 provider recording | Keep; harden admission | Artifact-hardening PR + upstream |
+| F7 modality drift | Add pinned contract | Same artifact-hardening PR |
+| F8 idle/max-age flush | Keep; upstream seam | No local simplification yet |
+
+## Recovery reuse selected now
+
+EverOS markdown is authoritative for its business LanceDB projections, and
+`cascade rebuild` is its supported destructive repair. Avibe should invoke that
+command with the pinned artifact rather than delete or reconstruct EverOS tables
+itself. The exact command is:
+
+```text
+<artifact-python> -I -m everos.entrypoints.cli.main cascade rebuild --yes
+```
+
+The command resets `md_change_state` before dropping/recreating the business
+tables, then scans and drains. It preserves markdown and `unprocessed_buffer`.
+`system.db` in its entirety is not a rebuildable projection. EverOS's pinned
+runbook still lists the older drop/recreate/reset order, but the 1.2.3 command
+source deliberately resets first to make every crash window converge.
+
+A configured embedding outage can still fail markdown rows before any keyword
+row is written, while the CLI exits 0 after handling the batch. Avibe therefore
+settles vector-space identity after command completion but reports the existing
+`/health.cascade` fields after sidecar startup. EverOS's `healthy`/`reasons`
+describe operational health, while failed-row counts are informational; Avibe
+presents the latter as a separate data-quality warning. It does not promise
+keyword completeness or an exact pending-vector count. The
+post-rebuild start path must not run Avibe's ordinary endpoint preflight, which
+exists to protect a still-healthy old sidecar; after the old index has been
+dropped it would only turn an endpoint outage into a self-inflicted start block.
+A momentary `pending` count alone is normal queue telemetry.
+
+## F1. Batch captured messages - defer until durable receipts
+
+EverOS accepts multiple messages per `/add`, while Avibe currently delivers one
+outbox row per call. Batching may reduce boundary-detection calls, but EverOS
+message IDs include the payload position. A retry must resend the identical batch
+or the overlap can receive different IDs.
+
+Any change therefore needs a persisted batch composition/fence and explicit
+tests for partial delivery, lease expiry, process death, and session ordering.
+That is an outbox protocol change, not recovery cleanup.
+
+## F2. Snapshot less rebuildable data - defer until measured
+
+The earlier claim that a short authoritative-file allowlist could replace the
+whole provider-root snapshot was unsafe. The root also includes
+`.index/sqlite/ome.aps.db`, SQLite WAL/SHM state, Avibe's root-control file, and
+`system.db` state beyond `unprocessed_buffer` (audit/task/LSN and other system
+tables). A restore followed by rebuild also adds a new recoverable failure phase;
+the journal's correctness model would change.
+
+Do not change Clear/backup snapshots in the recovery PR. A later design may
+prove that selected LanceDB directories can be excluded, but it must first define
+SQLite-consistent capture, a versioned manifest, restore-plus-rebuild recovery,
+and compatibility with existing snapshots. Prefer excluding proven projections
+from a whole-root policy over maintaining an easy-to-miss authoritative-file
+whitelist.
+
+## F3. Retry before `manual_required` - keep; upstream receipt
+
+EverOS deduplicates deterministic message IDs only while those messages remain
+in `unprocessed_buffer`. If the first ambiguous request already extracted and
+replaced/cleared the buffer, an identical resend has no durable receipt or
+tombstone and can be accepted and extracted again.
+
+Avibe must retain the current ambiguous-add -> `manual_required` fence. Flush
+ambiguity remains fenced as well. The safe way to shrink this behavior is an
+EverOS-supported durable idempotency/receipt or reconciliation API; bounded
+blind resend is not equivalent.
+
+## F4. Reuse `cascade sync`; defer `cascade fix --apply`
+
+These are useful native projection-repair commands, but the original description
+overstated their behavior:
+
+- pathless `cascade sync` performs a full markdown scan and drains the queue;
+  only the optional positional path explicitly force-enqueues one path;
+- `cascade fix --apply` resets retryable failed rows' retry counts and drains,
+  which can intentionally repeat embedding calls and cost;
+- both commands may invoke embedding and both can exit 0 while rows still fail;
+  exit 0 is command completion, not semantic repair;
+- `sync` is explicitly documented live-safe. `fix --apply` uses the same atomic
+  claim path, but the pinned docs do not give it the same online-safety promise;
+  its retry-budget reset is also a user decision, not automatic remediation.
+
+The pinned implementation and its prose disagree here: the CLI help/runbook says
+pathless `sync` only drains, while `CascadeOrchestrator.sync_once()` actually
+calls `scan_once()` before draining. Treat the source behavior as verified for
+1.2.3, but require a contract test or upstream documentation fix before exposing
+it as a stable product promise.
+
+An eventual UI should expose projection repair in product language, not raw
+EverOS command names. The follow-up must decide separately when live-safe
+scan/drain is enough and when resetting retry budgets deserves cost confirmation
+and sidecar quiescence; it should not blindly chain both commands. Each command
+runs through the bounded, allowlisted one-shot child capability introduced for
+rebuild and reads `/health.cascade` afterwards. A live `sync` child needs an
+auxiliary ownership slot that cannot overwrite the sidecar record; this is a
+role-aware extension of the same process owner, not a second supervisor.
+
+## F5. Message-count flush - keep
+
+The original audit used EverOS's agent-mode primitive defaults (8,192 tokens / 50
+messages). Avibe does not ship that mode: it generates `memorize.mode = "chat"`.
+The pinned chat path passes EverOS's configured defaults of 65,536 tokens / 500
+messages to boundary detection. Avibe's `MAX_UNFLUSHED_MESSAGES = 100` therefore
+fires earlier and is not dead code.
+
+Keep the count, idle, and max-age triggers. Making the timer thresholds product
+configuration is a separate feature decision and has no recovery payoff by
+itself.
+
+## F6. Provider-call recording - keep; upstream stable seams
+
+EverOS has no equivalent payload recorder with Avibe's scrubbing and retention
+contract. Its usage recorder captures token counts, and its content capture does
+not provide the request/response audit surface Avibe needs. The feature remains
+justified.
+
+The current integration does patch version-sensitive EverOS symbols and reads
+private SQLite schemas. A pinned-wheel CI contract already checks the patch
+targets and signatures, so recreating that test would add no protection. The
+near-term gap is artifact admission: run a lightweight compatibility probe before
+activation. Recorder installation may disable/degrade recording without taking
+Memory down. Error-scrubber installation is different: it prevents provider URLs
+and API keys from reaching EverOS diagnostic persistence, so incompatibility must
+reject the artifact/sidecar unless another proven path disables or scrubs that
+persistence. Long-term, request an upstream `LLMClient.chat` wrapper injection
+point and a supported provenance/read API.
+
+## F7. Modality allowlist drift - add a pinned contract
+
+Avibe's modality extension table currently equals the pinned everalgo set minus
+intentional office-document and SVG exclusions. Add one exact pinned-artifact
+contract at admission/CI so an upstream change fails visibly. Do not dynamically
+import provider internals as runtime policy. Deliver this with F6 hardening.
+
+## F8. Idle/max-age flush - keep until an upstream seam exists
+
+EverOS contains idle-trigger and conversation timestamp machinery but no
+supported idle-session flush behavior. Avibe's timers remain necessary because a
+session that receives no more messages is never revisited by EverOS.
+
+An upstream idle/max-age strategy could eventually let Avibe reduce coordinator
+scheduling. Until that exists as a supported capability, keep the current
+outbox-owned timers.
+
+## Justified Avibe ownership
+
+The audit confirms that these modules are not duplicate EverOS implementations:
+
+- process supervision, UDS confinement, environment allowlisting, ownership
+  recovery, and no-TCP enforcement;
+- real processing probes (EverOS capability flags only prove configuration is
+  present);
+- attachment pinning for durable retry;
+- the local outbox and conservative ambiguity fence;
+- payload scrubbing, retention, and the user-facing processing record;
+- confined filesystem operations, admission policy, authentication, and UI
+  access control.
+
+## Follow-up order
+
+The verified implementation work is four focused PRs after this documentation
+change:
+
+1. **Rebuild-and-Apply (priority):** role-aware rebuild child, Runtime cutover,
+   Controller operation, settings/API/UI, health presentation, and user docs.
+2. **Artifact compatibility (parallel with 1):** CLI/scrubber/recorder admission
+   and the pinned modality contract for F6/F7, without duplicating the existing
+   real-wheel CI contract.
+3. **Factory reset (after 1):** fresh-Runtime replacement and confined mutable
+   root deletion as the final recovery rung.
+4. **Projection repair (after 1):** reuse the child capability for an explicit
+   `cascade sync` action after pinning its observed behavior. Keep `fix --apply`
+   out until EverOS documents its online-safety contract; any later retry-budget
+   reset remains separately confirmed and may require quiescence.
+
+External follow-up remains:
+
+5. Ask EverOS for durable delivery receipts and recorder/provenance seams before
+   revisiting F3/F1/F6.
+6. Research a versioned projection-excluding snapshot format for F2 only after
+   measurements justify it; do not ship a file whitelist without a complete
+   restore proof.
+7. Track F8 upstream. Revisit local coordinator simplification only after the
+   capability is released and pinned.
+
+There is no implementation PR for F1, F2, F3, F5, or F8 in this workstream.
+Those items are respectively blocked, speculative, a required safety fence,
+already correct, or waiting on an upstream capability.

--- a/docs/plans/memory-rebuild-and-recovery-ladder.md
+++ b/docs/plans/memory-rebuild-and-recovery-ladder.md
@@ -1,0 +1,412 @@
+# Memory: EverOS-native rebuild and recovery ladder
+
+## Background
+
+Changing `processing.embedding.base_url` or `processing.embedding.model` can
+currently leave Memory in a durable dead end. Avibe saves an
+`embedding_change_pending` marker, but `MemoryRuntime.reconcile()` only settles
+that marker when every vector-bearing surface is empty. Existing data therefore
+causes the save to fail, the UI rolls the candidate configuration back, and
+Restart engine remains fenced. The only documented escape is Clear all, which
+deletes the user's memory.
+
+This priority plan replaces that dead end with EverOS's supported index rebuild
+and adds one destructive recovery floor. It is the implementation contract for
+the first recovery workstream and incorporates the validated conclusions from
+`docs/memory-everos-reuse-audit.md`.
+
+The plan is intentionally deliverable as more than one PR. Rebuild-and-Apply is
+the first priority; Factory reset follows as a separate recovery-floor PR. The
+reuse audit is a backlog of independently justified optimizations, not extra
+scope to fold into either recovery PR.
+
+## Verified EverOS 1.2.3 contract
+
+Avibe pins EverOS 1.2.3. The following details are load-bearing:
+
+- Markdown under the EverOS root is the source of truth for the business
+  LanceDB projections. `system.db` as a whole is **not** a rebuildable
+  projection: it also contains `unprocessed_buffer` and other system state.
+- `cascade rebuild` resets `md_change_state` first, then drops and recreates the
+  business LanceDB tables, scans markdown, and drains the queue. That ordering
+  makes an interrupted rebuild retryable and avoids an empty index paired with
+  a completed queue. It preserves markdown and `unprocessed_buffer`. The pinned
+  runbook still lists the older drop-before-reset order; the command source and
+  this plan use reset-before-drop.
+- A configured but unavailable embedding endpoint is not a keyword-only success
+  mode. The embedding exception fails the markdown queue row before its
+  LanceDB/BM25 row is written. `cascade rebuild` can still exit 0 because its
+  drain result counts handled rows rather than proving every row succeeded.
+- Consequently, CLI exit 0 means only that the rebuild command completed. After
+  the sidecar starts, Avibe must use the existing `/health.cascade` projection.
+  EverOS's `healthy` flag and `reasons` report operational health; retryable and
+  permanent failed-row counts are informational and deliberately do not make
+  that flag false. Avibe presents those failed rows as a separate data-quality
+  warning. A nonzero `pending` count alone is normal queue telemetry. It must not
+  promise keyword completeness or parse stdout for an exact "pending embeddings"
+  count.
+- EverOS checks that the OME lock appears free before destructive work and exits
+  3 when it observes a busy root. That check is explicitly best effort and has
+  a TOCTOU window. Avibe can guarantee exclusion of its own managed children;
+  independently launched EverOS processes using Avibe's private root are outside
+  that guarantee unless EverOS later holds an exclusive root lock for the whole
+  rebuild.
+- The packaged Memory artifact intentionally removes `bin/everos`. The supported
+  invocation is the embedded interpreter:
+
+  ```text
+  <artifact-python> -I -m everos.entrypoints.cli.main cascade rebuild --yes
+  ```
+
+  `EVEROS_ROOT` selects the provider root, and the target embedding settings are
+  supplied through the existing allowlisted child environment.
+
+Evidence baseline: Avibe `d6c7cf2d` pins `everos==1.2.3`. EverOS source commit
+`560fb80` matches release commit `48fc908` for the source tree; the release
+commit adds only `CHANGELOG.md`. Where EverOS prose and implementation disagree,
+this plan records the pinned implementation and calls out the documentation gap.
+
+The checked-in source manifest intentionally has `release_state: unavailable`
+and placeholder archive digests, so a source checkout cannot install a managed
+runtime from it. Implementation and hermetic tests can use test/dev artifacts.
+For a packaged release, the existing release workflow must build the three
+supported artifacts (`darwin-arm64`, `linux-arm64`, and `linux-x64`), generate the
+published manifest, and embed that manifest in the package; the placeholder is
+not manually replaced in source. Its availability contract is ordering at
+publication: runtime assets must be downloadable before the manifest-bearing
+package becomes downloadable. Artifact admission must also prove the pinned
+CLI/rebuild module exists; the current smoke test only imports the API
+application.
+
+## Goals
+
+1. An embedding identity change preserves markdown content and never mixes old
+   and new vector spaces.
+2. A confirmed candidate configuration is durable before destructive work and
+   remains the sole configuration to retry after a crash or failure.
+3. Rebuild and reset reuse the existing lifecycle locks, claim fencing, artifact
+   runtime, child environment, process-group termination, and health projection.
+4. The UI always offers a truthful next action without a force path that bypasses
+   unfinished in-process work.
+5. The implementation remains one Memory-specific operation slot, not a generic
+   job framework or a second process supervisor.
+
+## Non-goals
+
+- No EverOS source changes.
+- No `cascade backfill` workflow or promise of complete keyword recall while the
+  embedding endpoint is unavailable.
+- No automatic rebuild, repair, or reset based on health.
+- No Force restart. A failed claim quiesce means Avibe work may still be using
+  the root; killing only the sidecar cannot make destructive work safe.
+- No snapshot format change. Reducing Clear/backup payloads requires a separate
+  migration and recovery design.
+- No change to ambiguous delivery fencing, message batching, flush thresholds,
+  recorder patching, or modality policy.
+- No generic operation IDs, history table, progress journal, or stdout parsing.
+
+## Recovery model
+
+```text
+Rung 1  Supervisor backoff       Existing automatic process recovery
+Rung 2  Restart engine           Replace the managed sidecar only
+Rung 3  Rebuild index            Recreate business projections from markdown
+Rung 4  Factory reset            Delete all mutable Memory state and start fresh
+```
+
+Rungs 1-3 preserve source content. Rung 4 intentionally deletes it. A rebuild
+failure retries rung 3; it never silently escalates to reset.
+
+EverOS also provides `cascade sync` and `cascade fix --apply` for projection
+repair. They are useful but are not process-recovery rungs:
+
+- pathless `sync` scans the markdown tree and drains; it does not force-enqueue
+  every completed row;
+- `fix --apply` resets retryable failures' retry budgets and can repeat external
+  embedding calls and cost;
+- either command can exit 0 while failed rows remain, so health must be read
+  afterwards;
+- a live `sync` child must coexist with the sidecar and therefore needs its own
+  role-aware ownership slot rather than overwriting `everos.sidecar.json`;
+- `fix --apply` remains deferred until EverOS documents its online-safety
+  contract; a later confirmed retry-budget reset may require sidecar quiescence.
+
+That explicit "Repair index" operation is a focused follow-up. The recovery PRs
+do not pre-build a second child manager or expose the two CLI commands as UI
+buttons. EverOS's CLI help/runbook currently describes pathless `sync` as only a
+drain even though the pinned `CascadeOrchestrator.sync_once()` implementation
+scans and drains; the follow-up must pin or upstream-clarify that contract before
+depending on it as product behavior. It must not ship `fix --apply` as a live
+operation based only on implementation similarity.
+
+## Confirmed embedding change
+
+`PATCH /api/memory/settings` remains the sole candidate-configuration write
+interface for this UI flow. It accepts an optional exact boolean
+`confirm_rebuild` field in addition to the existing settings patch.
+
+1. If `base_url` or `model` changes and confirmation is absent, return
+   `409 memory_embedding_rebuild_required`. Do not save any part of the
+   candidate. Requiring confirmation even for an apparently empty root avoids a
+   cross-process check-then-save race in which an old-config capture arrives
+   after the check. The strict-empty fast path below means an empty root does not
+   actually launch a rebuild child.
+2. The UI retains the draft, explains that the index will be recreated and that
+   embedding calls may take time/cost money, then resends the same patch with
+   `confirm_rebuild: true`.
+3. Under the existing settings write lock, save the candidate and
+   `embedding_change_pending=true` before scheduling rebuild. This persisted
+   candidate is the rebuild input and the crash-retry source of truth. Before
+   launching the CLI for a non-empty root, require a complete embedding endpoint
+   even when the candidate is disabled; an unconfigured disabled EverOS runtime
+   can otherwise mark rows complete with no vectors. A strictly empty root needs
+   no CLI and may settle an incomplete disabled candidate while fenced.
+4. Once confirmed, a rebuild failure must not roll the configuration back and
+   the UI must not reload over the draft. The marker remains set and exposes a
+   Retry rebuild action after restart.
+5. An `api_key`-only change with no pending rebuild retains the ordinary
+   save/reconcile/rollback behavior; it does not require rebuild because it does
+   not change vector identity. While a rebuild marker is pending, credential
+   corrections update the same candidate and remain behind that marker so Retry
+   rebuild can use them. This path returns a saved-but-`rebuild_required`
+   projection and does not call ordinary reconcile, roll back the candidate,
+   automatically launch rebuild, or reactivate the old vector space.
+6. The settings projection exposes a read-only `rebuild_required` boolean derived
+   from the internal marker. It never exposes the marker as writable input.
+7. While rebuild or reset is running, other Memory settings writes return
+   `memory_operation_in_progress` rather than racing the candidate.
+
+There is no candidate configuration in the rebuild RPC and no post-rebuild save
+replay. Those would create two competing sources of truth.
+
+## One retained operation
+
+The Controller owns at most one retained Memory operation task with the minimal
+projection `{kind: rebuild|factory_reset, state: running|failed, error}`.
+
+- A mutating request validates and records durable intent before starting the
+  retained task, then returns 202.
+- A duplicate request for the same operation joins/returns the current state only
+  while that task is running.
+- A different Memory mutation while it is active returns
+  `memory_operation_in_progress`.
+- Request cancellation does not cancel the retained work. Service shutdown does
+  join or cancel it and waits for managed child cleanup.
+- Success removes the ephemeral operation state. Failure retains only a generic
+  error for status display; the persisted marker is the durable retry signal
+  after a crash. The next explicit Retry atomically replaces a failed projection
+  with a new running task. A failed projection is not an active-operation lock.
+- The existing Memory status response carries this small projection. There is no
+  separate job endpoint, operation ID, progress percentage, or operation history.
+
+## Rebuild index
+
+Both confirmed embedding changes and the manual Rebuild index action call the
+same no-argument Controller operation. The Controller reloads the persisted
+configuration; request bodies never carry provider credentials. The manual path
+also persists the marker before scheduling so a service crash has the same Retry
+rebuild fence as a settings-driven operation.
+
+Under the existing reconcile lock and `MemoryModule.destructive_lifecycle()`:
+
+1. Fence new claims and definitively join in-process Memory work. If quiescence
+   cannot be proven, fail without touching the provider root. There is no force
+   bypass.
+2. Stop the supervised sidecar and prove the Avibe-owned process group is gone.
+3. Evaluate the existing strict data-state check. If it proves the state empty,
+   return the synthetic result `completed_empty`, skip the rebuild child, and stay
+   on the new destructive-cutover path. Do not call ordinary reconcile: its
+   endpoint preflight and rollback semantics protect a still-healthy old sidecar,
+   which is no longer the authority after confirmation. If the check is
+   indeterminate because a root or queue surface is unsafe/unreadable, fail
+   closed without launching destructive work.
+4. Only when the strict check positively reports data, launch the exact
+   pinned-artifact command above with a bounded timeout. Do not persist or parse
+   stdout/stderr.
+5. Extend the existing managed-child ownership record with a role:
+   `sidecar|cascade_rebuild`. A missing role means a legacy sidecar and uses the
+   existing legacy argv/socket/root/uid classifier without requiring a role
+   environment variable. New role-bearing children require an exact role-specific
+   argv predicate plus same uid, `EVEROS_ROOT`, and
+   `AVIBE_MEMORY_CHILD_ROLE`. Unknown or unverifiable roles fail closed. This is
+   one role-aware owner, not a parallel supervisor.
+6. Interpret child results as `completed` (0), `root_busy` (3), `interrupted`
+   (130/cancellation), `timed_out`, or `failed`. Together with the no-child
+   `completed_empty` result, this is a closed result set. Every
+   timeout/cancellation path terminates and reaps the owned process group before
+   releasing ownership.
+7. Only `completed` or `completed_empty` proves enough to settle
+   `embedding_change_pending`. Clear the marker durably before attempting
+   candidate activation. Start the candidate
+   sidecar and resume claims when Memory is enabled, without reusing
+   the ordinary healthy-replacement endpoint probe: after destructive cutover
+   there is no old sidecar to preserve, and that probe would prevent the
+   documented degraded startup during an endpoint outage. Structural
+   config/artifact validation still happens before destructive work. When the
+   persisted candidate is disabled, complete the rebuild and settle the marker
+   but leave claims and the sidecar disabled. Read normal health after an enabled
+   startup. A false cascade health verdict or non-empty reasons produce an
+   operational degradation; failed-row counts produce a separate data-quality
+   warning. Neither is a rebuild failure or a fabricated vector count, and a
+   transient `pending` count remains telemetry rather than an immediate alert.
+   If sidecar startup then fails, the rebuild remains settled and ordinary
+   supervisor backoff/Restart engine is the next rung; do not recreate the marker
+   or destroy the new projections again.
+8. On every other result keep the marker, claims fence, and sidecar-down state.
+   Exit 3 is reported as root busy and never points directly to Factory reset.
+
+The ownership guarantee covers Avibe-managed children. The provider root is
+private and mode 0700, but Avibe cannot exclude a separately launched same-root
+EverOS process across EverOS's lock-probe race.
+
+### Boot and retry semantics
+
+- A pending marker is a vector-space fence whether Memory is enabled or disabled.
+  Boot must reconcile managed child ownership before returning, keep claims
+  fenced, and never start the ordinary sidecar while the marker remains. For an
+  absent or corrupt record, process discovery recognizes a rebuild child only by
+  same uid, exact rebuild argv, exact `EVEROS_ROOT`, and the exact role
+  environment, then reconstructs ownership and reaps its entire group. Ambiguous
+  or unverifiable candidates fail closed.
+- If boot cannot prove the recorded or discovered child group dead, it retains
+  the record where available and the marker, starts neither worker nor sidecar,
+  and exposes `memory_rebuild_failed` plus `rebuild_required` for a later retry.
+- Boot does not start destructive work automatically. It exposes
+  `rebuild_required`; an explicit Retry rebuild or a newly confirmed settings
+  save schedules the retained operation from the persisted candidate.
+- A disabled candidate may be rebuilt explicitly so the marker can settle, but
+  successful completion remains disabled and starts no sidecar.
+- Failure, cancellation, timeout, or root-busy leaves the same candidate and
+  marker intact. A later retry reruns EverOS's convergent rebuild command.
+
+## Factory reset
+
+Factory reset is a Controller-owned replacement of the whole mutable Memory
+aggregate, not a method on possibly corrupt stores or maintenance journals.
+
+1. Reuse Clear's CSRF/user identity and signed internal user-key chain. Accept
+   only the exact body `{"confirm": true}`.
+2. Validate the active pinned artifact before any data deletion. If it is
+   invalid, fail without deletion and direct the user to the existing Repair
+   runtime action. Do not combine artifact installation and data reset into one
+   opaque operation.
+3. Persist `embedding_change_pending=true`, then retire the old Runtime: stop and
+   join workers, maintenance tasks, the sidecar/rebuild child, and any recorded
+   orphan. If owned-tree death cannot be proved, fail with `data_deleted=false`.
+4. Through the confined filesystem boundary, delete exactly
+   `<effective_home>/memory` and `<effective_home>/state/memory`. This includes
+   provider markdown/index/system state, queue, attachments, call log, ownership
+   record, clear/restore journals, snapshots, and backups. The artifact under
+   `<effective_home>/runtime/memory` and persisted settings are retained.
+5. Construct a fresh `MemoryRuntime` and publish it atomically through the
+   Controller, but do not call ordinary reconcile while the marker is set. Use a
+   dedicated factory-reset cutover under the Controller operation gate: the empty
+   new roots are already the authority, so an enabled candidate starts and waits
+   for ordinary readiness while the marker and claims fence remain closed; a
+   disabled candidate starts no sidecar and settles as disabled.
+6. Clear the durable marker and open claims only after that fresh cutover settles.
+   If activation fails after deletion, return `data_deleted=true`, keep the
+   marker and claims fence, and expose Retry/repair rather than claiming the reset
+   preserved data.
+
+All mutating Controller entry points must use the same operation gate or resolve
+the current runtime only after acquiring it, so a stale operation cannot write
+through an object retired by reset.
+
+The guarantee is intentionally bounded: Factory reset can recover from any
+state Avibe wrote inside the two mutable roots, provided the OS permits deletion,
+the artifact is valid/installable, configured providers satisfy ordinary startup
+requirements, and no external same-root process is racing Avibe.
+
+## API and UI
+
+- New error codes: `memory_embedding_rebuild_required`,
+  `memory_rebuild_failed`, `memory_factory_reset_failed`, and
+  `memory_operation_in_progress`.
+- `POST /api/memory/runtime/rebuild` accepts exact `{"confirm": true}` and uses
+  signed user proof internally. It has no config or force fields.
+- `POST /api/memory/runtime/factory-reset` has the same exact confirmation and
+  authentication shape.
+- Memory settings removes the data-exists edit lock from embedding identity
+  fields. The first identity-changing save always prompts; confirmation resends
+  the unchanged draft. Settings GET exposes `rebuild_required` for crash retry.
+- Memory settings adds one Rebuild index action beside Clear all. Rebuild failure
+  offers Retry; there is no Force restart.
+- The Dependencies Memory runtime action keeps artifact Repair as its default and
+  exposes Factory reset as a separately confirmed destructive action.
+- Existing status/processing-record UI distinguishes an operational warning
+  (`cascade.healthy=false` or reasons present) from a data-quality warning
+  (`failed_retryable` or `failed_permanent` is nonzero), even when the top-level
+  health status is `ok`. A transient `pending` count alone does not turn the
+  badge red.
+- All copy lives in the existing English/Chinese i18n catalogs.
+
+## Tests
+
+Required focused coverage:
+
+1. Unconfirmed identity change does not save; confirmation saves candidate and
+   marker before scheduling; failure keeps both. API-key-only behavior remains
+   ordinary without a marker, while a pending marker accepts the credential into
+   the candidate without reconciling or clearing the fence.
+2. Empty fast path launches no child. Non-empty rebuild fences claims, stops the
+   sidecar first, launches the exact argv/env, and never overlaps owned children.
+3. Exit 0/3/130/nonzero/timeout/cancellation map to typed results; cleanup proves
+   the process group is gone. Only exit 0 or a strictly proven empty state settles
+   the marker; an indeterminate state launches no CLI and remains fenced.
+4. Ownership compatibility covers a legacy no-role record with a legacy no-role
+   child environment, exact rebuild roles, absent/corrupt records with process
+   discovery, wrong argv/root/uid/role, orphan reaping, ambiguous discovery, and
+   surviving groups.
+5. Rebuild exit 0 followed by operational cascade failure versus failed-row
+   backlog surfaces the two distinct warnings; tests do not assert keyword
+   completeness or parse CLI output. A post-settlement sidecar start failure
+   leaves the marker clear and enters ordinary restart recovery.
+6. Boot with a pending marker reaps a sidecar or rebuild orphan, starts neither
+   worker nor sidecar, and exposes Retry. Enabled and disabled retries both rebuild;
+   only the enabled case starts a sidecar after completion.
+7. Reset corruption matrix covers a corrupt queue DB, mangled provider root,
+   unreadable clear/restore journal, sticky marker, and supervisor-down state.
+   It verifies both mutable roots are removed and a fresh Runtime is published.
+8. Reset refuses deletion when retirement/artifact validation fails and reports
+   whether data was deleted when later activation fails.
+9. Internal/UI routes enforce CSRF, signed user proof, exact confirmation bodies,
+   running-operation conflicts, retained-task cancellation behavior, failed-state
+   replacement on Retry, and no secret fields in operation payloads.
+10. UI tests cover draft retention, confirmation replay of the same patch,
+   operation polling, disabled concurrent actions, retry, cascade degradation,
+   and the destructive reset disclosure.
+
+All process and filesystem tests use test-owned homes, fake artifact interpreters,
+and no network or local Avibe service.
+
+## Delivery sequence
+
+### PR A - Rebuild-and-Apply (first priority)
+
+- [ ] Correct the settings transaction and durable candidate semantics.
+- [ ] Add the role-aware one-shot EverOS rebuild child.
+- [ ] Require a complete embedding target for destructive work and verify the
+      pinned CLI module at artifact admission.
+- [ ] Add the Controller-owned retained rebuild operation and status projection.
+- [ ] Add authenticated rebuild routes, Memory UI confirmation/Retry, and i18n.
+- [ ] Add focused settings, Runtime, ownership, route, degraded-health, and UI
+      tests.
+- [ ] Update `docs/MEMORY.md` and `docs/MEMORY_ZH.md` for rebuild behavior.
+- [ ] Before release, verify the existing workflow makes all three managed-runtime
+      artifacts downloadable before it publishes the generated-manifest-bearing
+      package; this is a release gate, not a unit-test prerequisite or a manual
+      source-manifest edit.
+
+### PR B - Factory reset recovery floor
+
+- [ ] Extend the same Controller operation slot with Factory reset.
+- [ ] Serialize mutating Memory entry points across fresh-Runtime replacement.
+- [ ] Confined-delete the two mutable roots and publish/reconcile a fresh Runtime.
+- [ ] Add authenticated reset routes, Dependencies UI disclosure, and i18n.
+- [ ] Add the corruption matrix, pre/post-deletion result tests, route/UI tests,
+      and Factory reset user documentation.
+
+Later PRs are tracked in the reuse audit: explicit live projection repair,
+snapshot-payload research, durable EverOS delivery receipts/batching, recorder
+seams, modality drift checks, and upstream idle flush.


### PR DESCRIPTION
## Summary
- verify the Memory recovery ladder against the pinned EverOS 1.2.3 implementation
- define the Rebuild-and-Apply, Factory reset, artifact compatibility, and projection-repair delivery sequence
- classify F1-F8 so deferred or justified Avibe behavior is not reimplemented

## Evidence
- Unit: not applicable (documentation-only)
- Contract: static verification against Avibe `d6c7cf2d` and the locked EverOS 1.2.3 wheel/source
- Scenario: no existing Memory scenario catalog applies
- Manual: three independent read-only reviews of CLI/process, recovery state, and reuse claims; all P1/P2 findings resolved

## Notes
The checked-in managed-runtime manifest remains intentionally unavailable; the release workflow publishes runtime assets before the generated-manifest-bearing package becomes downloadable.