### PR TITLE
feat(memory): admit compatible runtime artifacts

### DIFF
--- a/core/memory/artifact.py
+++ b/core/memory/artifact.py
@@ -526,7 +526,10 @@ class MemoryArtifactManager(ManagedRuntimeManager):
             return None
         revision = pointer.get("admission_revision")
         if type(revision) is int and revision == ARTIFACT_ADMISSION_REVISION:
-            return binary
+            if pointer.get("admission_ok") is True:
+                return binary
+            self._install_reason = "memory_runtime_install_failed"
+            return None
         try:
             file_lock = self._acquire_mutation_lock()
         except Exception:  # noqa: BLE001
@@ -543,14 +546,19 @@ class MemoryArtifactManager(ManagedRuntimeManager):
                 return None
             revision = current.get("admission_revision")
             if type(revision) is int and revision == ARTIFACT_ADMISSION_REVISION:
-                return binary
-            preparation = self._prepare_binary(binary)
-            if preparation.get("ok") is not True:
+                if current.get("admission_ok") is True:
+                    return binary
                 self._install_reason = "memory_runtime_install_failed"
                 return None
+            preparation = self._prepare_binary(binary)
+            admission_ok = preparation.get("ok") is True
             admitted_pointer = dict(current)
             admitted_pointer["admission_revision"] = ARTIFACT_ADMISSION_REVISION
+            admitted_pointer["admission_ok"] = admission_ok
             self._restore_current_pointer(admitted_pointer)
+            if not admission_ok:
+                self._install_reason = "memory_runtime_install_failed"
+                return None
         except Exception:  # noqa: BLE001
             self._install_reason = "memory_runtime_install_failed"
             return None
@@ -579,6 +587,7 @@ class MemoryArtifactManager(ManagedRuntimeManager):
                 "archive_sha256": archive.sha256,
                 "bin_path": archive.bin_path,
                 "admission_revision": ARTIFACT_ADMISSION_REVISION,
+                "admission_ok": True,
                 "provider_root_format": candidate.provider_root_format,
                 "compatible_provider_root_formats": sorted(candidate.compatible_provider_root_formats - {candidate.provider_root_format}),
                 "artifact_fingerprint": candidate.artifact_fingerprint,

--- a/core/memory/artifact.py
+++ b/core/memory/artifact.py
@@ -364,6 +364,51 @@ class MemoryArtifactManager(ManagedRuntimeManager):
             return False
         return True
 
+    def _reuse_existing_install(
+        self,
+        binary: Path,
+        install_dir: Path,
+        manifest: ManagedRuntimeManifest,
+        archive: ManagedRuntimeArchive,
+        *,
+        reason: str | None = None,
+    ) -> dict[str, Any]:
+        """Re-admit an existing install before activating it under this contract."""
+
+        try:
+            admission_ok = self._prepare_binary(binary).get("ok") is True
+        except Exception:  # noqa: BLE001
+            logger.exception("Failed to admit existing Memory runtime binary")
+            admission_ok = False
+        if not admission_ok:
+            try:
+                self._persist_active_pointer_admission(binary, admitted=False)
+            except Exception:  # noqa: BLE001
+                logger.exception("Failed to persist rejected Memory runtime admission")
+            return self._failure(
+                "memory_runtime_install_failed",
+                manifest=manifest,
+                archive=archive,
+            )
+        return super()._reuse_existing_install(
+            binary,
+            install_dir,
+            manifest,
+            archive,
+            reason=reason,
+        )
+
+    def _persist_active_pointer_admission(self, binary: Path, *, admitted: bool) -> None:
+        current, invalid = self._read_active_pointer()
+        if invalid or current is None:
+            return
+        if self._verified_active_pointer_binary(current) != binary:
+            return
+        admitted_pointer = dict(current)
+        admitted_pointer["admission_revision"] = ARTIFACT_ADMISSION_REVISION
+        admitted_pointer["admission_ok"] = admitted
+        self._restore_current_pointer(admitted_pointer)
+
     def _write_current_pointer(
         self,
         install_dir: Path,

--- a/core/memory/artifact.py
+++ b/core/memory/artifact.py
@@ -587,7 +587,7 @@ class MemoryArtifactManager(ManagedRuntimeManager):
         if result.returncode != 0 or result.stdout.splitlines() != [EVEROS_VERSION, EMBEDDED_PYTHON_VERSION]:
             return {"ok": False, "reason": "memory_runtime_smoke_failed"}
         if not self._admit_error_scrubbers(binary):
-            return {"ok": False, "reason": "memory_runtime_prepare_failed"}
+            return {"ok": False, "reason": "memory_runtime_install_failed"}
         return {
             "ok": True,
             "everos_version": EVEROS_VERSION,

--- a/core/memory/artifact.py
+++ b/core/memory/artifact.py
@@ -13,6 +13,7 @@ import os
 import secrets
 import stat
 import subprocess
+import tempfile
 from dataclasses import dataclass, field
 from pathlib import Path
 from collections.abc import Callable, Iterable
@@ -48,6 +49,7 @@ from core.memory.provider_root import (
     ProviderRootMetadata,
     ProviderRootState,
 )
+from core.memory.modality import pinned_modality_contract_script
 
 
 EVEROS_VERSION = "1.2.3"
@@ -72,12 +74,20 @@ _SMOKE_SCRIPT = (
     "import everos\n"
     "import uvicorn\n"
     "from everos.entrypoints.api.app import create_app\n"
+    "import everos.entrypoints.cli.main\n"
+    "import everos.memory.cascade\n"
     f"assert version('everos') == '{EVEROS_VERSION}'\n"
     "assert platform.python_version() == '3.12.12'\n"
     "assert everos is not None and uvicorn is not None\n"
     "assert callable(create_app)\n"
+    + pinned_modality_contract_script()
+    +
     "print(version('everos'))\n"
     "print(platform.python_version())\n"
+)
+_SCRUBBER_ADMISSION_SCRIPT = (
+    "from core.memory.everos_insight import install_error_scrubbers\n"
+    "install_error_scrubbers()\n"
 )
 
 
@@ -576,12 +586,44 @@ class MemoryArtifactManager(ManagedRuntimeManager):
             return {"ok": False, "reason": "memory_runtime_smoke_failed"}
         if result.returncode != 0 or result.stdout.splitlines() != [EVEROS_VERSION, EMBEDDED_PYTHON_VERSION]:
             return {"ok": False, "reason": "memory_runtime_smoke_failed"}
+        if not self._admit_error_scrubbers(binary):
+            return {"ok": False, "reason": "memory_runtime_prepare_failed"}
         return {
             "ok": True,
             "everos_version": EVEROS_VERSION,
             "python_version": EMBEDDED_PYTHON_VERSION,
             "lock_sha256": PACKAGE_LOCK_SHA256,
         }
+
+    def _admit_error_scrubbers(self, binary: Path) -> bool:
+        """Prove the child can install mandatory diagnostic scrubbers before launch."""
+
+        source_root = Path(__file__).resolve().parents[2]
+        try:
+            with tempfile.TemporaryDirectory(prefix="avibe-memory-admission-") as home:
+                child_home = Path(home)
+                result = subprocess.run(
+                    [str(binary), "-c", _SCRUBBER_ADMISSION_SCRIPT],
+                    capture_output=True,
+                    text=True,
+                    timeout=30,
+                    check=False,
+                    cwd=str(source_root),
+                    env={
+                        "HOME": str(child_home),
+                        "PATH": os.defpath,
+                        "PYTHONNOUSERSITE": "1",
+                        "PYTHONPATH": str(source_root),
+                        "XDG_CACHE_HOME": str(child_home / ".cache"),
+                        "XDG_CONFIG_HOME": str(child_home / ".config"),
+                        "XDG_DATA_HOME": str(child_home / ".local" / "share"),
+                        "XDG_STATE_HOME": str(child_home / ".local" / "state"),
+                    },
+                    **isolated_subprocess_kwargs(),
+                )
+        except (OSError, subprocess.SubprocessError):
+            return False
+        return result.returncode == 0
 
 
 def _write_memory_pointer_atomic(

--- a/core/memory/artifact.py
+++ b/core/memory/artifact.py
@@ -56,6 +56,7 @@ EVEROS_VERSION = "1.2.3"
 EMBEDDED_PYTHON_VERSION = "3.12.12"
 PACKAGE_LOCK_SHA256 = "e6acc17e4c0969563d380326e90134965af0822259bb4a9adb4d54433e9737fe"
 RUNTIME_BUILDER_UV_VERSION = "0.9.18"
+ARTIFACT_ADMISSION_REVISION = 1
 _DEV_RUNTIME_ENV = "AVIBE_MEMORY_DEV_RUNTIME"
 _DEV_RUNTIME_FAILURE_REASON = "memory_runtime_install_failed"
 _DEV_PROVIDER_ROOT_FORMAT = f"everos-{EVEROS_VERSION}"
@@ -172,7 +173,7 @@ class MemoryArtifactManager(ManagedRuntimeManager):
         if pointer is None:
             return None
         try:
-            return self._verified_active_pointer_binary(pointer)
+            return self._admitted_active_pointer_binary(pointer)
         except Exception:  # noqa: BLE001
             return None
 
@@ -182,7 +183,7 @@ class MemoryArtifactManager(ManagedRuntimeManager):
         if self._dev_runtime_configured():
             return self._dev_runtime_status(self._dev_runtime_python())
         pointer, pointer_invalid = self._read_active_pointer()
-        if pointer is not None and self._verified_active_pointer_binary(pointer) is None:
+        if pointer is not None and self._admitted_active_pointer_binary(pointer) is None:
             pointer_invalid = True
         status_payload = super().status()
         if pointer_invalid:
@@ -514,6 +515,50 @@ class MemoryArtifactManager(ManagedRuntimeManager):
             return None
         return binary
 
+    def _admitted_active_pointer_binary(
+        self,
+        pointer: dict[str, Any],
+    ) -> Path | None:
+        """Re-admit artifacts accepted under an older compatibility contract."""
+
+        binary = self._verified_active_pointer_binary(pointer)
+        if binary is None:
+            return None
+        revision = pointer.get("admission_revision")
+        if type(revision) is int and revision == ARTIFACT_ADMISSION_REVISION:
+            return binary
+        try:
+            file_lock = self._acquire_mutation_lock()
+        except Exception:  # noqa: BLE001
+            self._install_reason = "memory_runtime_install_failed"
+            return None
+        if file_lock is None:
+            return None
+        try:
+            current, invalid = self._read_active_pointer()
+            if invalid or current is None:
+                return None
+            binary = self._verified_active_pointer_binary(current)
+            if binary is None:
+                return None
+            revision = current.get("admission_revision")
+            if type(revision) is int and revision == ARTIFACT_ADMISSION_REVISION:
+                return binary
+            preparation = self._prepare_binary(binary)
+            if preparation.get("ok") is not True:
+                self._install_reason = "memory_runtime_install_failed"
+                return None
+            admitted_pointer = dict(current)
+            admitted_pointer["admission_revision"] = ARTIFACT_ADMISSION_REVISION
+            self._restore_current_pointer(admitted_pointer)
+        except Exception:  # noqa: BLE001
+            self._install_reason = "memory_runtime_install_failed"
+            return None
+        finally:
+            self._release_mutation_lock(file_lock)
+        self._install_reason = None
+        return binary
+
     def _write_memory_current_pointer(
         self,
         install_dir: Path,
@@ -533,6 +578,7 @@ class MemoryArtifactManager(ManagedRuntimeManager):
                 "manifest_sha256": manifest.digest,
                 "archive_sha256": archive.sha256,
                 "bin_path": archive.bin_path,
+                "admission_revision": ARTIFACT_ADMISSION_REVISION,
                 "provider_root_format": candidate.provider_root_format,
                 "compatible_provider_root_formats": sorted(candidate.compatible_provider_root_formats - {candidate.provider_root_format}),
                 "artifact_fingerprint": candidate.artifact_fingerprint,
@@ -583,9 +629,9 @@ class MemoryArtifactManager(ManagedRuntimeManager):
                 **isolated_subprocess_kwargs(),
             )
         except (OSError, subprocess.SubprocessError):
-            return {"ok": False, "reason": "memory_runtime_smoke_failed"}
+            return {"ok": False, "reason": "memory_runtime_install_failed"}
         if result.returncode != 0 or result.stdout.splitlines() != [EVEROS_VERSION, EMBEDDED_PYTHON_VERSION]:
-            return {"ok": False, "reason": "memory_runtime_smoke_failed"}
+            return {"ok": False, "reason": "memory_runtime_install_failed"}
         if not self._admit_error_scrubbers(binary):
             return {"ok": False, "reason": "memory_runtime_install_failed"}
         return {

--- a/core/memory/modality.py
+++ b/core/memory/modality.py
@@ -97,7 +97,7 @@ def pinned_modality_contract_script() -> str:
     exclusions = repr(frozenset(PINNED_UPSTREAM_EXCLUDED_EXTENSIONS))
     return (
         "from everalgo.types.modality import SUPPORTED_EXTENSIONS\n"
-        "assert isinstance(SUPPORTED_EXTENSIONS, frozenset)\n"
+        "assert isinstance(SUPPORTED_EXTENSIONS, (set, frozenset))\n"
         "assert all(isinstance(extension, str) for extension in SUPPORTED_EXTENSIONS)\n"
-        f"assert SUPPORTED_EXTENSIONS - {exclusions} == {expected}\n"
+        f"assert frozenset(SUPPORTED_EXTENSIONS) - {exclusions} == {expected}\n"
     )

--- a/core/memory/modality.py
+++ b/core/memory/modality.py
@@ -54,3 +54,50 @@ SUPPORTED_ATTACHMENT_EXTENSIONS: frozenset[str] = frozenset(
         "eml",
     }
 )
+
+# These pinned upstream formats need unavailable local integrations.  They are
+# deliberately a static Avibe policy, not a provider import in request handling.
+PINNED_UPSTREAM_EXCLUDED_EXTENSIONS: frozenset[str] = frozenset(
+    {
+        "svg",
+        "docx",
+        "pptx",
+        "xlsx",
+        "doc",
+        "ppt",
+        "xls",
+        "pages",
+        "key",
+        "numbers",
+        "odt",
+        "ods",
+        "odp",
+        "rtf",
+    }
+)
+
+
+def pinned_modality_contract_matches(upstream_extensions: object) -> bool:
+    """Verify the pinned artifact's extension set without changing runtime policy."""
+
+    if not isinstance(upstream_extensions, (set, frozenset)) or not all(
+        isinstance(extension, str) for extension in upstream_extensions
+    ):
+        return False
+    return (
+        frozenset(upstream_extensions) - PINNED_UPSTREAM_EXCLUDED_EXTENSIONS
+        == SUPPORTED_ATTACHMENT_EXTENSIONS
+    )
+
+
+def pinned_modality_contract_script() -> str:
+    """Build the artifact-only check from Avibe's static modality policy."""
+
+    expected = repr(frozenset(SUPPORTED_ATTACHMENT_EXTENSIONS))
+    exclusions = repr(frozenset(PINNED_UPSTREAM_EXCLUDED_EXTENSIONS))
+    return (
+        "from everalgo.types.modality import SUPPORTED_EXTENSIONS\n"
+        "assert isinstance(SUPPORTED_EXTENSIONS, frozenset)\n"
+        "assert all(isinstance(extension, str) for extension in SUPPORTED_EXTENSIONS)\n"
+        f"assert SUPPORTED_EXTENSIONS - {exclusions} == {expected}\n"
+    )

--- a/core/memory/runtime.py
+++ b/core/memory/runtime.py
@@ -109,6 +109,7 @@ class _ProcessingRuntimeSnapshot:
     maintenance_active: bool
     closing: bool
     process: EverOSProcessPort | None
+    launch_token: int
     process_running: bool
     runtime_error: str | None
 
@@ -148,6 +149,7 @@ class _ProcessingRuntimeSnapshot:
             and self.maintenance_active == other.maintenance_active
             and self.closing == other.closing
             and self.process is other.process
+            and self.launch_token == other.launch_token
             and self.process_running == other.process_running
             and self.runtime_error == other.runtime_error
         )
@@ -512,7 +514,8 @@ class MemoryRuntime:
         self._processing_lifecycle_generation += 1
 
     def _processing_runtime_snapshot(self) -> _ProcessingRuntimeSnapshot:
-        process = self._process
+        sidecar = self._sidecar.snapshot()
+        process = sidecar.process
         module = self._module
         return _ProcessingRuntimeSnapshot(
             generation=self._processing_lifecycle_generation,
@@ -522,6 +525,7 @@ class MemoryRuntime:
             maintenance_active=bool(module and module.maintenance_active),
             closing=self._closing,
             process=process,
+            launch_token=sidecar.launch_token,
             process_running=bool(process and process.running),
             runtime_error=self._runtime_error,
         )

--- a/core/memory/runtime.py
+++ b/core/memory/runtime.py
@@ -1624,7 +1624,6 @@ class MemoryRuntime:
                 self._runtime_error = "memory_sidecar_unavailable"
                 return {"ok": False, "error": self._runtime_error}
 
-            self._update_recorder_health(_RECORDER_DEGRADED)
             self._runtime_error = None
             self.module.resume_claims()
             self._ensure_worker()

--- a/core/memory/runtime.py
+++ b/core/memory/runtime.py
@@ -358,6 +358,7 @@ class MemoryRuntime:
             retain_call_log=self._maintain_call_log_once,
             on_current_sidecar_ready=self._current_sidecar_ready,
             on_recorder_health=self._update_recorder_health,
+            read_recorder_health=self._provider.recorder_health,
         )
         self._maintenance = MemoryMaintenance(
             None,
@@ -868,7 +869,6 @@ class MemoryRuntime:
         if not started:
             self._runtime_error = "memory_sidecar_unavailable"
             return {"ok": False, "error": self._runtime_error}
-        self._update_recorder_health(_RECORDER_DEGRADED)
         self._runtime_error = None
         self.module.resume_claims()
         self._ensure_worker()

--- a/core/memory/sidecar_lifecycle.py
+++ b/core/memory/sidecar_lifecycle.py
@@ -28,6 +28,35 @@ class SidecarSnapshot:
         return bool(self.process and self.process.running)
 
 
+@dataclass(frozen=True, slots=True)
+class RecorderAdmission:
+    """Closed projection of the child's recorder compatibility handshake."""
+
+    state: str
+    reason: str | None
+
+    @classmethod
+    def from_health(cls, value: object) -> "RecorderAdmission":
+        if not isinstance(value, dict):
+            return cls("degraded", "writer_failures")
+        state = value.get("state")
+        reason = value.get("reason")
+        if state == "active" and reason is None:
+            return cls(state, reason)
+        if state == "degraded" and isinstance(reason, str):
+            return cls(state, reason)
+        if state == "disabled" and reason in {None, "writer_failures"}:
+            return cls(state, reason)
+        return cls("degraded", "writer_failures")
+
+    @property
+    def records_calls(self) -> bool:
+        return self.state != "disabled"
+
+    def health(self) -> dict[str, str | None]:
+        return {"state": self.state, "reason": self.reason}
+
+
 class MemorySidecarLifecycle:
     """Own sidecar supervision, readiness admission, and recorder handoff.
 
@@ -46,6 +75,7 @@ class MemorySidecarLifecycle:
         retain_call_log: Callable[[], Awaitable[str | None]],
         on_current_sidecar_ready: Callable[[int], Awaitable[None] | None],
         on_recorder_health: Callable[[dict[str, str | None]], None],
+        read_recorder_health: Callable[[], Awaitable[dict[str, str | None]]],
     ) -> None:
         self._process_factory = process_factory
         self._provider_root = provider_root
@@ -55,6 +85,7 @@ class MemorySidecarLifecycle:
         self._retain_call_log = retain_call_log
         self._on_current_sidecar_ready = on_current_sidecar_ready
         self._on_recorder_health = on_recorder_health
+        self._read_recorder_health = read_recorder_health
         self._process: EverOSProcessPort | None = None
         self._generation = 0
         self._records_calls = False
@@ -84,6 +115,7 @@ class MemorySidecarLifecycle:
 
         await self.stop()
         await self._stop_retention()
+        self._ready_admission_open = False
         self._generation += 1
         generation = self._generation
         sidecar: EverOSProcessPort | None = None
@@ -122,18 +154,43 @@ class MemorySidecarLifecycle:
             if self._is_current(sidecar, generation):
                 self._records_calls = False
                 self._ensure_retention()
+            self._ready_admission_open = True
             raise
         if not started:
             if self._is_current(sidecar, generation):
                 self._records_calls = False
                 self._ensure_retention()
+            self._ready_admission_open = True
             return False
+        try:
+            await self._admit_recorder_health(sidecar, generation)
+        finally:
+            self._ready_admission_open = True
         # Runtime accepts the successful explicit start synchronously. The
         # supervisor's same-turn ready notification is therefore redundant;
         # later recovery notifications still emit the semantic event.
         if self._ready_generation == generation:
             self._ready_generation = None
         return True
+
+    async def _admit_recorder_health(
+        self,
+        sidecar: EverOSProcessPort,
+        generation: int,
+    ) -> None:
+        """Make the child health projection, not file timing, own recorder state."""
+
+        try:
+            health = await self._read_recorder_health()
+        except Exception:
+            health = {"state": "degraded", "reason": "writer_failures"}
+        if not self._is_current(sidecar, generation):
+            return
+        admission = RecorderAdmission.from_health(health)
+        self._on_recorder_health(admission.health())
+        if not admission.records_calls:
+            self._records_calls = False
+            self._ensure_retention()
 
     async def stop(self) -> None:
         """Stop the current child; failed cleanup intentionally retains ownership."""

--- a/core/memory/sidecar_lifecycle.py
+++ b/core/memory/sidecar_lifecycle.py
@@ -167,8 +167,12 @@ class MemorySidecarLifecycle:
         launch_token = self._launch_token
         try:
             await self._admit_recorder_health(sidecar, generation, launch_token)
-        finally:
+        except BaseException:
             self._ready_admission_open = True
+            if self._ready_launch is not None and not self._closed:
+                self._ensure_ready_task()
+            raise
+        self._ready_admission_open = True
         launch_is_current = self._launch_is_current(
             sidecar,
             generation,

--- a/core/memory/sidecar_lifecycle.py
+++ b/core/memory/sidecar_lifecycle.py
@@ -20,6 +20,7 @@ class SidecarSnapshot:
     """The current sidecar ownership projection for its Runtime caller."""
 
     generation: int
+    launch_token: int
     process: EverOSProcessPort | None
     records_calls: bool
 
@@ -100,7 +101,12 @@ class MemorySidecarLifecycle:
         self._processing_probe_healthy = False
 
     def snapshot(self) -> SidecarSnapshot:
-        return SidecarSnapshot(self._generation, self._process, self._records_calls)
+        return SidecarSnapshot(
+            self._generation,
+            self._launch_token,
+            self._process,
+            self._records_calls,
+        )
 
     def _replace_for_runtime(self, process: EverOSProcessPort | None) -> None:
         """Temporary Runtime compatibility for lifecycle paths not yet migrated."""
@@ -156,23 +162,23 @@ class MemorySidecarLifecycle:
             if self._is_current(sidecar, generation):
                 self._records_calls = False
                 self._ensure_retention()
-            self._ready_admission_open = True
+            self._reopen_ready_admission()
             raise
         if not started:
             if self._is_current(sidecar, generation):
                 self._records_calls = False
                 self._ensure_retention()
-            self._ready_admission_open = True
+            self._reopen_ready_admission()
             return False
         launch_token = self._launch_token
         try:
             await self._admit_recorder_health(sidecar, generation, launch_token)
         except BaseException:
-            self._ready_admission_open = True
+            self._reopen_ready_admission()
             if self._ready_launch is not None and not self._closed:
                 self._ensure_ready_task()
             raise
-        self._ready_admission_open = True
+        self._reopen_ready_admission()
         launch_is_current = self._launch_is_current(
             sidecar,
             generation,
@@ -293,6 +299,10 @@ class MemorySidecarLifecycle:
 
     def _is_current(self, process: EverOSProcessPort | None, generation: int) -> bool:
         return process is not None and process is self._process and generation == self._generation
+
+    def _reopen_ready_admission(self) -> None:
+        if not self._closed:
+            self._ready_admission_open = True
 
     def _launch_is_current(
         self,

--- a/core/memory/sidecar_lifecycle.py
+++ b/core/memory/sidecar_lifecycle.py
@@ -290,6 +290,15 @@ class MemorySidecarLifecycle:
                 and snapshot.generation == generation
                 and snapshot.running
             ):
+                assert snapshot.process is not None
+                await self._admit_recorder_health(snapshot.process, generation)
+                snapshot = self.snapshot()
+                if (
+                    not self._ready_admission_open
+                    or snapshot.generation != generation
+                    or not snapshot.running
+                ):
+                    continue
                 result = self._on_current_sidecar_ready(generation)
                 if asyncio.iscoroutine(result):
                     await result

--- a/core/memory/sidecar_lifecycle.py
+++ b/core/memory/sidecar_lifecycle.py
@@ -88,8 +88,9 @@ class MemorySidecarLifecycle:
         self._read_recorder_health = read_recorder_health
         self._process: EverOSProcessPort | None = None
         self._generation = 0
+        self._launch_token = 0
         self._records_calls = False
-        self._ready_generation: int | None = None
+        self._ready_launch: tuple[int, int] | None = None
         self._ready_task: asyncio.Task[None] | None = None
         self._retention_task: asyncio.Task[None] | None = None
         self._retention_blocked = False
@@ -123,6 +124,7 @@ class MemorySidecarLifecycle:
         async def before_start() -> None:
             if not self._is_current(sidecar, generation):
                 raise RuntimeError("stale EverOS recorder supervisor")
+            self._launch_token += 1
             self._records_calls = True
             await self._stop_retention()
 
@@ -133,8 +135,8 @@ class MemorySidecarLifecycle:
             self._ensure_retention()
 
         def ready() -> None:
-            if self._is_current(sidecar, generation) and self._ready_admission_open:
-                self._schedule_ready(generation)
+            if self._is_current(sidecar, generation):
+                self._schedule_ready(generation, self._launch_token)
 
         sidecar = self._process_factory(
             python,
@@ -162,21 +164,25 @@ class MemorySidecarLifecycle:
                 self._ensure_retention()
             self._ready_admission_open = True
             return False
+        launch_token = self._launch_token
         try:
-            await self._admit_recorder_health(sidecar, generation)
+            await self._admit_recorder_health(sidecar, generation, launch_token)
         finally:
             self._ready_admission_open = True
         # Runtime accepts the successful explicit start synchronously. The
         # supervisor's same-turn ready notification is therefore redundant;
         # later recovery notifications still emit the semantic event.
-        if self._ready_generation == generation:
-            self._ready_generation = None
+        if self._ready_launch == (generation, launch_token):
+            self._ready_launch = None
+        elif self._ready_launch is not None:
+            self._ensure_ready_task()
         return True
 
     async def _admit_recorder_health(
         self,
         sidecar: EverOSProcessPort,
         generation: int,
+        launch_token: int,
     ) -> None:
         """Make the child health projection, not file timing, own recorder state."""
 
@@ -184,7 +190,10 @@ class MemorySidecarLifecycle:
             health = await self._read_recorder_health()
         except Exception:
             health = {"state": "degraded", "reason": "writer_failures"}
-        if not self._is_current(sidecar, generation):
+        if (
+            not self._is_current(sidecar, generation)
+            or launch_token != self._launch_token
+        ):
             return
         admission = RecorderAdmission.from_health(health)
         self._on_recorder_health(admission.health())
@@ -245,7 +254,7 @@ class MemorySidecarLifecycle:
 
         self._ready_admission_open = False
         self._closed = True
-        self._ready_generation = None
+        self._ready_launch = None
 
     def handoff_to_host_retention(self) -> None:
         """Start host maintenance after an external orphan handoff proved safe."""
@@ -274,28 +283,39 @@ class MemorySidecarLifecycle:
     def _is_current(self, process: EverOSProcessPort | None, generation: int) -> bool:
         return process is not None and process is self._process and generation == self._generation
 
-    def _schedule_ready(self, generation: int) -> None:
-        self._ready_generation = generation
+    def _schedule_ready(self, generation: int, launch_token: int) -> None:
+        self._ready_launch = (generation, launch_token)
+        if not self._ready_admission_open:
+            return
+        self._ensure_ready_task()
+
+    def _ensure_ready_task(self) -> None:
         task = self._ready_task
         if task is None or task.done():
             self._ready_task = asyncio.create_task(self._emit_ready(), name="memory-ready-activation")
 
     async def _emit_ready(self) -> None:
-        while self._ready_generation is not None:
-            generation = self._ready_generation
-            self._ready_generation = None
+        while self._ready_launch is not None:
+            generation, launch_token = self._ready_launch
+            self._ready_launch = None
             snapshot = self.snapshot()
             if (
                 self._ready_admission_open
                 and snapshot.generation == generation
+                and launch_token == self._launch_token
                 and snapshot.running
             ):
                 assert snapshot.process is not None
-                await self._admit_recorder_health(snapshot.process, generation)
+                await self._admit_recorder_health(
+                    snapshot.process,
+                    generation,
+                    launch_token,
+                )
                 snapshot = self.snapshot()
                 if (
                     not self._ready_admission_open
                     or snapshot.generation != generation
+                    or launch_token != self._launch_token
                     or not snapshot.running
                 ):
                     continue

--- a/core/memory/sidecar_lifecycle.py
+++ b/core/memory/sidecar_lifecycle.py
@@ -169,14 +169,19 @@ class MemorySidecarLifecycle:
             await self._admit_recorder_health(sidecar, generation, launch_token)
         finally:
             self._ready_admission_open = True
+        launch_is_current = self._launch_is_current(
+            sidecar,
+            generation,
+            launch_token,
+        )
         # Runtime accepts the successful explicit start synchronously. The
         # supervisor's same-turn ready notification is therefore redundant;
         # later recovery notifications still emit the semantic event.
-        if self._ready_launch == (generation, launch_token):
+        if launch_is_current and self._ready_launch == (generation, launch_token):
             self._ready_launch = None
         elif self._ready_launch is not None:
             self._ensure_ready_task()
-        return True
+        return launch_is_current
 
     async def _admit_recorder_health(
         self,
@@ -190,10 +195,7 @@ class MemorySidecarLifecycle:
             health = await self._read_recorder_health()
         except Exception:
             health = {"state": "degraded", "reason": "writer_failures"}
-        if (
-            not self._is_current(sidecar, generation)
-            or launch_token != self._launch_token
-        ):
+        if not self._launch_is_current(sidecar, generation, launch_token):
             return
         admission = RecorderAdmission.from_health(health)
         self._on_recorder_health(admission.health())
@@ -270,10 +272,15 @@ class MemorySidecarLifecycle:
         await self._stop_retention()
 
     def observe_recorder_health(self, health: dict[str, str | None]) -> None:
-        """Block host retention when the live recorder reports corruption."""
+        """Keep host retention aligned with the live recorder's ownership."""
 
         if health.get("reason") == "call_log_corrupt":
             self._retention_blocked = True
+            return
+        admission = RecorderAdmission.from_health(health)
+        if not admission.records_calls:
+            self._records_calls = False
+            self._ensure_retention()
 
     def reset_host_retention_after_clear(self) -> None:
         """Reopen retention only after Clear repaired its corrupt call-log surface."""
@@ -282,6 +289,19 @@ class MemorySidecarLifecycle:
 
     def _is_current(self, process: EverOSProcessPort | None, generation: int) -> bool:
         return process is not None and process is self._process and generation == self._generation
+
+    def _launch_is_current(
+        self,
+        process: EverOSProcessPort | None,
+        generation: int,
+        launch_token: int,
+    ) -> bool:
+        return bool(
+            self._is_current(process, generation)
+            and launch_token == self._launch_token
+            and process is not None
+            and process.running
+        )
 
     def _schedule_ready(self, generation: int, launch_token: int) -> None:
         self._ready_launch = (generation, launch_token)

--- a/tests/test_memory_modality.py
+++ b/tests/test_memory_modality.py
@@ -1,0 +1,24 @@
+from core.memory.modality import (
+    PINNED_UPSTREAM_EXCLUDED_EXTENSIONS,
+    SUPPORTED_ATTACHMENT_EXTENSIONS,
+    pinned_modality_contract_matches,
+    pinned_modality_contract_script,
+)
+
+
+def test_pinned_modality_contract_allows_exact_upstream_set_minus_exclusions() -> None:
+    upstream = SUPPORTED_ATTACHMENT_EXTENSIONS | PINNED_UPSTREAM_EXCLUDED_EXTENSIONS
+
+    assert pinned_modality_contract_matches(upstream) is True
+    assert pinned_modality_contract_matches(upstream | {"video"}) is False
+    assert pinned_modality_contract_matches(["txt"]) is False
+    assert pinned_modality_contract_matches(frozenset({"txt", 1})) is False
+
+
+def test_pinned_modality_admission_script_is_derived_from_static_policy() -> None:
+    script = pinned_modality_contract_script()
+
+    assert "from everalgo.types.modality import SUPPORTED_EXTENSIONS" in script
+    assert "isinstance(SUPPORTED_EXTENSIONS, frozenset)" in script
+    assert repr(SUPPORTED_ATTACHMENT_EXTENSIONS) in script
+    assert repr(PINNED_UPSTREAM_EXCLUDED_EXTENSIONS) in script

--- a/tests/test_memory_modality.py
+++ b/tests/test_memory_modality.py
@@ -1,3 +1,8 @@
+import sys
+from types import ModuleType
+
+import pytest
+
 from core.memory.modality import (
     PINNED_UPSTREAM_EXCLUDED_EXTENSIONS,
     SUPPORTED_ATTACHMENT_EXTENSIONS,
@@ -19,6 +24,27 @@ def test_pinned_modality_admission_script_is_derived_from_static_policy() -> Non
     script = pinned_modality_contract_script()
 
     assert "from everalgo.types.modality import SUPPORTED_EXTENSIONS" in script
-    assert "isinstance(SUPPORTED_EXTENSIONS, frozenset)" in script
+    assert "isinstance(SUPPORTED_EXTENSIONS, (set, frozenset))" in script
+    assert "frozenset(SUPPORTED_EXTENSIONS)" in script
     assert repr(SUPPORTED_ATTACHMENT_EXTENSIONS) in script
     assert repr(PINNED_UPSTREAM_EXCLUDED_EXTENSIONS) in script
+
+
+@pytest.mark.parametrize("container", [set, frozenset], ids=["set", "frozenset"])
+def test_pinned_modality_admission_script_accepts_supported_upstream_containers(
+    monkeypatch: pytest.MonkeyPatch,
+    container,
+) -> None:
+    everalgo = ModuleType("everalgo")
+    everalgo_types = ModuleType("everalgo.types")
+    modality = ModuleType("everalgo.types.modality")
+    modality.SUPPORTED_EXTENSIONS = container(
+        SUPPORTED_ATTACHMENT_EXTENSIONS | PINNED_UPSTREAM_EXCLUDED_EXTENSIONS
+    )
+    everalgo.types = everalgo_types
+    everalgo_types.modality = modality
+    monkeypatch.setitem(sys.modules, "everalgo", everalgo)
+    monkeypatch.setitem(sys.modules, "everalgo.types", everalgo_types)
+    monkeypatch.setitem(sys.modules, "everalgo.types.modality", modality)
+
+    exec(pinned_modality_contract_script(), {})

--- a/tests/test_memory_runtime.py
+++ b/tests/test_memory_runtime.py
@@ -434,8 +434,61 @@ def test_memory_artifact_uses_configured_dev_runtime_without_managed_archive(
     assert manager.provider_root_format() == "everos-1.2.3"
     assert manager.compatible_provider_root_formats() == frozenset({"everos-1.2.3"})
     assert manager.artifact_fingerprint() == "dev-everos-1.2.3"
-    assert len(calls) == 1
+    assert len(calls) == 2
     assert "DEV RUNTIME bypass active - not for production" in caplog.text
+
+
+def test_memory_artifact_smoke_requires_pinned_cli_cascade_module(
+    monkeypatch, tmp_path: Path
+) -> None:
+    dev_python = tmp_path / "dev-venv" / "bin" / "python"
+    dev_python.parent.mkdir(parents=True)
+    dev_python.write_text("#!/bin/sh\n", encoding="utf-8")
+    dev_python.chmod(0o755)
+    monkeypatch.setenv("AVIBE_MEMORY_DEV_RUNTIME", str(dev_python))
+    commands: list[list[str]] = []
+
+    def smoke_succeeds(command: list[str], **_kwargs) -> subprocess.CompletedProcess[str]:
+        commands.append(command)
+        return subprocess.CompletedProcess(
+            command,
+            0,
+            stdout="1.2.3\n3.12.12\n",
+            stderr="",
+        )
+
+    monkeypatch.setattr(memory_artifact.subprocess, "run", smoke_succeeds)
+
+    assert MemoryArtifactManager(runtime_dir=tmp_path / "runtime", offline=True).resolve_python() == dev_python
+    assert "everos.entrypoints.cli.main" in commands[0][-1]
+    assert "everos.memory.cascade" in commands[0][-1]
+    assert "everalgo.types.modality" in commands[0][-1]
+
+
+def test_memory_artifact_rejects_scrubber_incompatibility_as_repairable_dependency_failure(
+    monkeypatch, tmp_path: Path
+) -> None:
+    dev_python = tmp_path / "dev-venv" / "bin" / "python"
+    dev_python.parent.mkdir(parents=True)
+    dev_python.write_text("#!/bin/sh\n", encoding="utf-8")
+    dev_python.chmod(0o755)
+    monkeypatch.setenv("AVIBE_MEMORY_DEV_RUNTIME", str(dev_python))
+
+    def scrubber_fails(command: list[str], **_kwargs) -> subprocess.CompletedProcess[str]:
+        if "-I" in command:
+            return subprocess.CompletedProcess(
+                command,
+                0,
+                stdout="1.2.3\n3.12.12\n",
+                stderr="",
+            )
+        return subprocess.CompletedProcess(command, 1, stdout="", stderr="incompatible patch")
+
+    monkeypatch.setattr(memory_artifact.subprocess, "run", scrubber_fails)
+    manager = MemoryArtifactManager(runtime_dir=tmp_path / "runtime", offline=True)
+
+    assert manager.resolve_python() is None
+    assert manager.status()["reason"] == "memory_runtime_install_failed"
 
 
 def test_memory_artifact_refuses_dev_runtime_without_importable_everos(monkeypatch, caplog, tmp_path: Path) -> None:

--- a/tests/test_memory_runtime.py
+++ b/tests/test_memory_runtime.py
@@ -519,6 +519,38 @@ def test_memory_artifact_prepare_maps_scrubber_rejection_to_public_install_failu
     }
 
 
+@pytest.mark.parametrize(
+    "failure",
+    [
+        OSError("cannot execute"),
+        subprocess.CompletedProcess(["python"], 1, stdout="", stderr="incompatible"),
+    ],
+)
+def test_memory_artifact_prepare_maps_smoke_rejection_to_public_install_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    failure: BaseException | subprocess.CompletedProcess[str],
+) -> None:
+    binary = tmp_path / "python"
+    binary.write_text("#!/bin/sh\n", encoding="utf-8")
+    manager = MemoryArtifactManager(runtime_dir=tmp_path / "runtime", offline=True)
+
+    def reject_smoke(
+        _command: list[str],
+        **_kwargs,
+    ) -> subprocess.CompletedProcess[str]:
+        if isinstance(failure, BaseException):
+            raise failure
+        return failure
+
+    monkeypatch.setattr(memory_artifact.subprocess, "run", reject_smoke)
+
+    assert manager._prepare_binary(binary) == {
+        "ok": False,
+        "reason": "memory_runtime_install_failed",
+    }
+
+
 def test_memory_artifact_refuses_dev_runtime_without_importable_everos(monkeypatch, caplog, tmp_path: Path) -> None:
     dev_python = tmp_path / "dev-venv" / "bin" / "python"
     dev_python.parent.mkdir(parents=True)
@@ -741,6 +773,64 @@ def test_memory_artifact_rejects_an_active_pointer_built_for_another_target(
     assert manager.resolve_python() is None
 
 
+@pytest.mark.parametrize("admitted", [False, True])
+def test_memory_artifact_readmits_active_pointer_after_contract_revision(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    admitted: bool,
+) -> None:
+    manager = MemoryArtifactManager(runtime_dir=tmp_path / "runtime", offline=True)
+    install_dir = manager.runtime_dir / "versions" / "old"
+    binary = install_dir / "bin" / "python"
+    binary.parent.mkdir(parents=True)
+    binary.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    binary.chmod(0o755)
+    pointer = {
+        "provider": "manifest",
+        "runtime_id": "memory-runtime",
+        "runtime_version": memory_artifact.EVEROS_VERSION,
+        "platform": memory_artifact.runtime_platform_tag(),
+        "install_dir": str(install_dir),
+        "manifest_sha256": "a" * 64,
+        "archive_sha256": "b" * 64,
+        "bin_path": "bin/python",
+    }
+    (install_dir / manager.spec.metadata_filename).write_text(
+        json.dumps(
+            {
+                **pointer,
+                "binary_sha256": hashlib.sha256(binary.read_bytes()).hexdigest(),
+            }
+        ),
+        encoding="utf-8",
+    )
+    manager._restore_current_pointer(pointer)
+    admissions: list[Path] = []
+
+    def admit(candidate: Path) -> dict[str, object]:
+        admissions.append(candidate)
+        return {
+            "ok": admitted,
+            "reason": None if admitted else "memory_runtime_install_failed",
+        }
+
+    monkeypatch.setattr(manager, "_prepare_binary", admit)
+
+    resolved = manager.resolve_python()
+
+    assert resolved == (binary if admitted else None)
+    assert admissions == [binary]
+    active = manager._active_pointer()
+    assert active is not None
+    if admitted:
+        assert active["admission_revision"] == memory_artifact.ARTIFACT_ADMISSION_REVISION
+        assert manager.resolve_python() == binary
+        assert admissions == [binary]
+    else:
+        assert "admission_revision" not in active
+        assert manager.status()["reason"] == "memory_runtime_install_failed"
+
+
 def test_memory_artifact_coordinator_rolls_back_the_active_pointer(tmp_path: Path) -> None:
     provider_root = tmp_path / "memory" / "everos-root"
     provider_root.mkdir(parents=True, mode=0o700)
@@ -775,6 +865,7 @@ def test_memory_artifact_coordinator_rolls_back_the_active_pointer(tmp_path: Pat
         "manifest_sha256": "a" * 64,
         "archive_sha256": "b" * 64,
         "bin_path": "bin/python",
+        "admission_revision": memory_artifact.ARTIFACT_ADMISSION_REVISION,
         "provider_root_format": "everos-1.0",
         "compatible_provider_root_formats": [],
         "artifact_fingerprint": "old-artifact",
@@ -788,6 +879,10 @@ def test_memory_artifact_coordinator_rolls_back_the_active_pointer(tmp_path: Pat
         calls.append(("candidate", candidate.provider_root_format))
         calls.append(("root", (root_state.provider_root_format, root_state.empty)))
         commit()
+        assert (
+            manager._active_pointer()["admission_revision"]
+            == memory_artifact.ARTIFACT_ADMISSION_REVISION
+        )
         calls.append(("active", manager.provider_root_format()))
         rollback()
 
@@ -871,6 +966,7 @@ async def test_memory_artifact_rollback_resolves_old_active_binary(
         "manifest_sha256": "a" * 64,
         "archive_sha256": "b" * 64,
         "bin_path": "bin/python",
+        "admission_revision": memory_artifact.ARTIFACT_ADMISSION_REVISION,
         "provider_root_format": "everos-1.0",
         "compatible_provider_root_formats": [],
         "artifact_fingerprint": "old-artifact",

--- a/tests/test_memory_runtime.py
+++ b/tests/test_memory_runtime.py
@@ -3397,6 +3397,53 @@ async def test_runtime_restart_preserves_admitted_recorder_health(
     await memory_runtime_factory.close(runtime)
 
 
+async def test_runtime_discards_recorder_health_from_prior_launch_token(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    memory_runtime_factory,
+) -> None:
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    factory = FakeEverOSProcessFactory()
+    config = MemoryConfig(enabled=True, processing=_processing_config())
+    runtime = memory_runtime_factory(
+        config,
+        artifact_manager=_installed_artifact(),
+        process_factory=factory,
+        effective_home=tmp_path,
+    )
+    assert (await runtime.reconcile(config))["ok"] is True
+    supervised = factory.supervised[0]
+    assert supervised.before_start is not None
+    health = ProviderHealthSnapshot(
+        status="ok",
+        version="1.2.3",
+        capabilities={},
+        disabled_features=(),
+        cascade=None,
+        recorder={"state": "disabled", "reason": "writer_failures"},
+    )
+
+    async def stale_health() -> ProviderHealthSnapshot:
+        entered.set()
+        await release.wait()
+        return health
+
+    monkeypatch.setattr(runtime._provider, "health_snapshot", stale_health)
+    observation = asyncio.create_task(runtime._processing_record_health(None))
+    await asyncio.wait_for(entered.wait(), timeout=1.0)
+
+    await supervised.before_start()
+    release.set()
+    result = await observation
+
+    assert result.snapshot is None
+    assert result.unavailable_reason == "memory_sidecar_unavailable"
+    assert runtime._process_records_calls is True
+    assert runtime._call_log_retention_task is None
+    await memory_runtime_factory.close(runtime)
+
+
 @pytest.mark.parametrize("force_pending_assertion_failure", [False, True])
 async def test_runtime_restart_is_retained_when_one_caller_is_cancelled(
     tmp_path: Path,

--- a/tests/test_memory_runtime.py
+++ b/tests/test_memory_runtime.py
@@ -491,6 +491,34 @@ def test_memory_artifact_rejects_scrubber_incompatibility_as_repairable_dependen
     assert manager.status()["reason"] == "memory_runtime_install_failed"
 
 
+def test_memory_artifact_prepare_maps_scrubber_rejection_to_public_install_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    binary = tmp_path / "python"
+    binary.write_text("#!/bin/sh\n", encoding="utf-8")
+    manager = MemoryArtifactManager(runtime_dir=tmp_path / "runtime", offline=True)
+
+    def smoke_succeeds(
+        command: list[str],
+        **_kwargs,
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(
+            command,
+            0,
+            stdout="1.2.3\n3.12.12\n",
+            stderr="",
+        )
+
+    monkeypatch.setattr(memory_artifact.subprocess, "run", smoke_succeeds)
+    monkeypatch.setattr(manager, "_admit_error_scrubbers", lambda _binary: False)
+
+    assert manager._prepare_binary(binary) == {
+        "ok": False,
+        "reason": "memory_runtime_install_failed",
+    }
+
+
 def test_memory_artifact_refuses_dev_runtime_without_importable_everos(monkeypatch, caplog, tmp_path: Path) -> None:
     dev_python = tmp_path / "dev-venv" / "bin" / "python"
     dev_python.parent.mkdir(parents=True)
@@ -3145,6 +3173,38 @@ async def test_runtime_restart_replaces_process_without_processing_preflight(
     assert old.stops == 1
     assert len(factory.created) == 1
     assert factory.supervised[0].starts == 1
+    await memory_runtime_factory.close(runtime)
+
+
+async def test_runtime_restart_preserves_admitted_recorder_health(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    memory_runtime_factory,
+) -> None:
+    factory = FakeEverOSProcessFactory()
+    runtime = memory_runtime_factory(
+        MemoryConfig(enabled=True, processing=_processing_config()),
+        artifact_manager=_installed_artifact(),
+        process_factory=factory,
+        effective_home=tmp_path,
+    )
+    runtime._process = FakeEverOSProcess()
+
+    async def disabled_recorder_health() -> dict[str, str | None]:
+        return {"state": "disabled", "reason": "writer_failures"}
+
+    monkeypatch.setattr(
+        runtime._sidecar,
+        "_read_recorder_health",
+        disabled_recorder_health,
+    )
+
+    assert await runtime.restart() == {"ok": True, "state": "ready"}
+    assert runtime._recorder_health == {
+        "state": "disabled",
+        "reason": "writer_failures",
+    }
+    assert runtime._sidecar.snapshot().records_calls is False
     await memory_runtime_factory.close(runtime)
 
 

--- a/tests/test_memory_runtime.py
+++ b/tests/test_memory_runtime.py
@@ -835,6 +835,92 @@ def test_memory_artifact_readmits_active_pointer_after_contract_revision(
         assert admissions == [binary]
 
 
+@pytest.mark.parametrize("admitted", [False, True])
+def test_memory_artifact_readmits_existing_install_before_reuse(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    admitted: bool,
+) -> None:
+    manager = MemoryArtifactManager(runtime_dir=tmp_path / "runtime", offline=True)
+    binary_contents = b"#!/bin/sh\nexit 0\n"
+    binary_sha256 = hashlib.sha256(binary_contents).hexdigest()
+    archive = ManagedRuntimeArchive(
+        platform=memory_artifact.runtime_platform_tag(),
+        name="memory-runtime.tar.gz",
+        url="file:///memory-runtime.tar.gz",
+        sha256="d" * 64,
+        binary_sha256=binary_sha256,
+        size=1,
+        bin_path="bin/python",
+    )
+    manifest = ManagedRuntimeManifest(
+        schema_version=1,
+        runtime_version=memory_artifact.EVEROS_VERSION,
+        source="test",
+        source_url=None,
+        archives={archive.platform: archive},
+        digest="c" * 64,
+        loaded_from="test",
+        payload={
+            "release_state": "published",
+            "python_version": memory_artifact.EMBEDDED_PYTHON_VERSION,
+            "lock_sha256": memory_artifact.PACKAGE_LOCK_SHA256,
+            "lock_id": f"uv-lock-sha256:{memory_artifact.PACKAGE_LOCK_SHA256}",
+            "uv_version": memory_artifact.RUNTIME_BUILDER_UV_VERSION,
+            "provider_root_format": "everos-1.2.3",
+            "compatible_provider_root_formats": [],
+        },
+    )
+    install_dir = manager._manifest_install_dir(manifest, archive)
+    binary = install_dir / archive.bin_path
+    binary.parent.mkdir(parents=True)
+    binary.write_bytes(binary_contents)
+    binary.chmod(0o755)
+    manager._write_manifest_install_metadata(
+        install_dir,
+        manifest,
+        archive,
+        binary_sha256=binary_sha256,
+    )
+    manager._restore_current_pointer(
+        {
+            "provider": "manifest",
+            "runtime_id": manager.spec.runtime_id,
+            "runtime_version": manifest.runtime_version,
+            "platform": archive.platform,
+            "install_dir": str(install_dir),
+            "manifest_sha256": manifest.digest,
+            "archive_sha256": archive.sha256,
+            "bin_path": archive.bin_path,
+        }
+    )
+    monkeypatch.setattr(manager, "_load_manifest", lambda *, allow_network: manifest)
+    admissions: list[Path] = []
+
+    def admit(candidate: Path) -> dict[str, object]:
+        admissions.append(candidate)
+        return {
+            "ok": admitted,
+            "reason": None if admitted else "memory_runtime_install_failed",
+        }
+
+    monkeypatch.setattr(manager, "_prepare_binary", admit)
+
+    result = manager.ensure(force=False)
+
+    assert result["ok"] is admitted
+    assert result.get("reason") is (None if admitted else "memory_runtime_install_failed")
+    assert admissions == [binary]
+    active = manager._active_pointer()
+    assert active is not None
+    assert active["admission_revision"] == memory_artifact.ARTIFACT_ADMISSION_REVISION
+    assert active["admission_ok"] is admitted
+    assert manager.resolve_python() == (binary if admitted else None)
+    if not admitted:
+        assert manager.status()["reason"] == "memory_runtime_install_failed"
+    assert admissions == [binary]
+
+
 def test_memory_artifact_coordinator_rolls_back_the_active_pointer(tmp_path: Path) -> None:
     provider_root = tmp_path / "memory" / "everos-root"
     provider_root.mkdir(parents=True, mode=0o700)

--- a/tests/test_memory_runtime.py
+++ b/tests/test_memory_runtime.py
@@ -824,11 +824,15 @@ def test_memory_artifact_readmits_active_pointer_after_contract_revision(
     assert active is not None
     if admitted:
         assert active["admission_revision"] == memory_artifact.ARTIFACT_ADMISSION_REVISION
+        assert active["admission_ok"] is True
         assert manager.resolve_python() == binary
         assert admissions == [binary]
     else:
-        assert "admission_revision" not in active
+        assert active["admission_revision"] == memory_artifact.ARTIFACT_ADMISSION_REVISION
+        assert active["admission_ok"] is False
+        assert manager.resolve_python() is None
         assert manager.status()["reason"] == "memory_runtime_install_failed"
+        assert admissions == [binary]
 
 
 def test_memory_artifact_coordinator_rolls_back_the_active_pointer(tmp_path: Path) -> None:
@@ -866,6 +870,7 @@ def test_memory_artifact_coordinator_rolls_back_the_active_pointer(tmp_path: Pat
         "archive_sha256": "b" * 64,
         "bin_path": "bin/python",
         "admission_revision": memory_artifact.ARTIFACT_ADMISSION_REVISION,
+        "admission_ok": True,
         "provider_root_format": "everos-1.0",
         "compatible_provider_root_formats": [],
         "artifact_fingerprint": "old-artifact",
@@ -883,6 +888,7 @@ def test_memory_artifact_coordinator_rolls_back_the_active_pointer(tmp_path: Pat
             manager._active_pointer()["admission_revision"]
             == memory_artifact.ARTIFACT_ADMISSION_REVISION
         )
+        assert manager._active_pointer()["admission_ok"] is True
         calls.append(("active", manager.provider_root_format()))
         rollback()
 
@@ -967,6 +973,7 @@ async def test_memory_artifact_rollback_resolves_old_active_binary(
         "archive_sha256": "b" * 64,
         "bin_path": "bin/python",
         "admission_revision": memory_artifact.ARTIFACT_ADMISSION_REVISION,
+        "admission_ok": True,
         "provider_root_format": "everos-1.0",
         "compatible_provider_root_formats": [],
         "artifact_fingerprint": "old-artifact",

--- a/tests/test_memory_sidecar.py
+++ b/tests/test_memory_sidecar.py
@@ -6,6 +6,8 @@ from contextlib import asynccontextmanager, contextmanager
 from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
+
 from core.memory import everos
 from core.memory import sidecar
 from core.memory.sidecar import (
@@ -55,6 +57,30 @@ def test_sidecar_server_bounds_graceful_shutdown(monkeypatch, tmp_path: Path) ->
     sidecar.serve(tmp_path / "everos.sock")
 
     assert captured["timeout_graceful_shutdown"] == 1
+
+
+def test_sidecar_rejects_artifact_before_everos_can_persist_diagnostics(
+    monkeypatch, tmp_path: Path
+) -> None:
+    imported = False
+
+    def scrubbers_fail() -> None:
+        raise RuntimeError("incompatible scrubber")
+
+    def import_app(_module: str):
+        nonlocal imported
+        imported = True
+        raise AssertionError("EverOS app must not load after scrubber rejection")
+
+    monkeypatch.setattr(sidecar, "version", lambda _package: "1.2.3")
+    monkeypatch.setattr(sidecar, "install_error_scrubbers", scrubbers_fail)
+    monkeypatch.setattr(sidecar.importlib, "import_module", import_app)
+    monkeypatch.setenv("AVIBE_MEMORY_ATTACHMENTS_ROOT", str(tmp_path / "attachments"))
+
+    with pytest.raises(RuntimeError, match="incompatible scrubber"):
+        sidecar.serve(tmp_path / "everos.sock")
+
+    assert imported is False
 
 
 def test_sidecar_prepares_recorder_before_import_and_wraps_existing_lifespan(

--- a/tests/test_memory_sidecar_lifecycle.py
+++ b/tests/test_memory_sidecar_lifecycle.py
@@ -198,13 +198,53 @@ async def test_recovery_during_initial_admission_discards_stale_health_and_queue
 
     assert await supervised.start() is True
     release_initial_health.set()
-    assert await initial_start is True
+    assert await initial_start is False
     await asyncio.wait_for(recovery_ready.wait(), timeout=1.0)
 
     assert health_reads == 2
     assert seen == [{"state": "disabled", "reason": "writer_failures"}]
     assert ready_health == [{"state": "disabled", "reason": "writer_failures"}]
     assert lifecycle.snapshot().records_calls is False
+
+
+async def test_runtime_disabled_recorder_hands_call_log_to_host_retention(
+    tmp_path: Path,
+) -> None:
+    factory = FakeEverOSProcessFactory()
+    call_log = tmp_path / "memory" / "call-log" / "call-log.db"
+    call_log.parent.mkdir(parents=True)
+    call_log.touch()
+    retained = asyncio.Event()
+
+    async def retain() -> str | None:
+        retained.set()
+        return None
+
+    lifecycle = MemorySidecarLifecycle(
+        factory,
+        provider_root=tmp_path / "memory" / "everos-root",
+        effective_home=tmp_path,
+        socket_path=tmp_path / "memory" / ".rt" / "everos.sock",
+        call_log_db_path=call_log,
+        retain_call_log=retain,
+        on_current_sidecar_ready=lambda _generation: None,
+        on_recorder_health=lambda _health: None,
+        read_recorder_health=lambda: asyncio.sleep(
+            0, result={"state": "active", "reason": None}
+        ),
+    )
+    assert await lifecycle.start(Path(sys.executable), _settings()) is True
+    assert lifecycle.snapshot().records_calls is True
+
+    lifecycle.observe_recorder_health(
+        {"state": "disabled", "reason": "writer_failures"}
+    )
+    await asyncio.wait_for(retained.wait(), timeout=1.0)
+
+    assert lifecycle.snapshot().records_calls is False
+    assert lifecycle.snapshot().running is True
+    assert lifecycle.retention_task is not None
+    await lifecycle.close()
 
 
 async def test_stop_failure_retains_current_supervisor(tmp_path: Path) -> None:

--- a/tests/test_memory_sidecar_lifecycle.py
+++ b/tests/test_memory_sidecar_lifecycle.py
@@ -251,6 +251,46 @@ async def test_cancelled_initial_admission_schedules_queued_ready(
         await lifecycle.close()
 
 
+async def test_close_during_initial_admission_never_reopens_ready_admission(
+    tmp_path: Path,
+) -> None:
+    factory = FakeEverOSProcessFactory()
+    health_entered = asyncio.Event()
+    release_health = asyncio.Event()
+    ready = asyncio.Event()
+    health_reads = 0
+
+    async def recorder_health() -> dict[str, str | None]:
+        nonlocal health_reads
+        health_reads += 1
+        if health_reads == 1:
+            health_entered.set()
+            await release_health.wait()
+        return {"state": "active", "reason": None}
+
+    lifecycle = _lifecycle(
+        tmp_path,
+        factory,
+        lambda _generation: ready.set(),
+        recorder_health,
+    )
+    initial_start = asyncio.create_task(
+        lifecycle.start(Path(sys.executable), _settings())
+    )
+    await asyncio.wait_for(health_entered.wait(), timeout=1.0)
+    supervised = factory.supervised[0]
+
+    lifecycle.close_ready_admission()
+    await supervised.ready()
+    release_health.set()
+    assert await initial_start is True
+
+    assert health_reads == 1
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(ready.wait(), timeout=0.05)
+    await lifecycle.close()
+
+
 async def test_runtime_disabled_recorder_hands_call_log_to_host_retention(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_memory_sidecar_lifecycle.py
+++ b/tests/test_memory_sidecar_lifecycle.py
@@ -21,9 +21,18 @@ def _settings() -> EverOSProcessSettings:
     )
 
 
-def _lifecycle(tmp_path: Path, factory: FakeEverOSProcessFactory, ready) -> MemorySidecarLifecycle:
+def _lifecycle(
+    tmp_path: Path,
+    factory: FakeEverOSProcessFactory,
+    ready,
+    recorder_health=None,
+    on_recorder_health=None,
+) -> MemorySidecarLifecycle:
     async def retain() -> str | None:
         return None
+
+    async def read_recorder_health() -> dict[str, str | None]:
+        return {"state": "active", "reason": None}
 
     return MemorySidecarLifecycle(
         factory,
@@ -33,7 +42,8 @@ def _lifecycle(tmp_path: Path, factory: FakeEverOSProcessFactory, ready) -> Memo
         call_log_db_path=tmp_path / "memory" / "call-log" / "call-log.db",
         retain_call_log=retain,
         on_current_sidecar_ready=ready,
-        on_recorder_health=lambda _health: None,
+        on_recorder_health=on_recorder_health or (lambda _health: None),
+        read_recorder_health=recorder_health or read_recorder_health,
     )
 
 
@@ -56,6 +66,50 @@ async def test_start_assigns_owner_before_sidecar_callbacks_and_ignores_stale_re
     assert stale_reap is not None
     await stale_reap()
     assert lifecycle.snapshot().process is second
+    assert lifecycle.snapshot().records_calls is True
+
+
+async def test_start_handoffs_disabled_recorder_from_child_health_without_file_inference(
+    tmp_path: Path,
+) -> None:
+    factory = FakeEverOSProcessFactory()
+    seen: list[dict[str, str | None]] = []
+
+    async def disabled() -> dict[str, str | None]:
+        return {"state": "disabled", "reason": "writer_failures"}
+
+    lifecycle = _lifecycle(
+        tmp_path,
+        factory,
+        lambda _generation: None,
+        disabled,
+        seen.append,
+    )
+
+    assert await lifecycle.start(Path(sys.executable), _settings()) is True
+    assert seen == [{"state": "disabled", "reason": "writer_failures"}]
+    assert lifecycle.snapshot().records_calls is False
+
+
+async def test_start_keeps_recorder_ownership_when_child_health_is_malformed(
+    tmp_path: Path,
+) -> None:
+    factory = FakeEverOSProcessFactory()
+    seen: list[dict[str, str | None]] = []
+
+    async def malformed() -> dict[str, str | None]:
+        return {"state": "disabled", "reason": "unexpected"}
+
+    lifecycle = _lifecycle(
+        tmp_path,
+        factory,
+        lambda _generation: None,
+        malformed,
+        seen.append,
+    )
+
+    assert await lifecycle.start(Path(sys.executable), _settings()) is True
+    assert seen == [{"state": "degraded", "reason": "writer_failures"}]
     assert lifecycle.snapshot().records_calls is True
 
 
@@ -126,6 +180,7 @@ async def test_corrupt_host_log_stays_blocked_across_sidecar_reaps(tmp_path: Pat
         retain_call_log=retain,
         on_current_sidecar_ready=lambda _generation: None,
         on_recorder_health=lambda _health: None,
+        read_recorder_health=lambda: asyncio.sleep(0, result={"state": "active", "reason": None}),
     )
     lifecycle.handoff_to_host_retention()
     task = lifecycle.retention_task
@@ -167,6 +222,7 @@ async def test_recorder_corruption_blocks_host_retention_after_a_reap(tmp_path: 
         retain_call_log=retain,
         on_current_sidecar_ready=lambda _generation: None,
         on_recorder_health=lambda _health: None,
+        read_recorder_health=lambda: asyncio.sleep(0, result={"state": "active", "reason": None}),
     )
     lifecycle.observe_recorder_health({"state": "degraded", "reason": "call_log_corrupt"})
     assert await lifecycle.start(Path(sys.executable), _settings()) is True

--- a/tests/test_memory_sidecar_lifecycle.py
+++ b/tests/test_memory_sidecar_lifecycle.py
@@ -207,6 +207,50 @@ async def test_recovery_during_initial_admission_discards_stale_health_and_queue
     assert lifecycle.snapshot().records_calls is False
 
 
+async def test_cancelled_initial_admission_schedules_queued_ready(
+    tmp_path: Path,
+) -> None:
+    factory = FakeEverOSProcessFactory()
+    initial_health_entered = asyncio.Event()
+    block_initial_health = asyncio.Event()
+    ready = asyncio.Event()
+    seen: list[dict[str, str | None]] = []
+    health_reads = 0
+
+    async def recorder_health() -> dict[str, str | None]:
+        nonlocal health_reads
+        health_reads += 1
+        if health_reads == 1:
+            initial_health_entered.set()
+            await block_initial_health.wait()
+        return {"state": "disabled", "reason": "writer_failures"}
+
+    lifecycle = _lifecycle(
+        tmp_path,
+        factory,
+        lambda _generation: ready.set(),
+        recorder_health,
+        seen.append,
+    )
+    start = asyncio.create_task(lifecycle.start(Path(sys.executable), _settings()))
+    try:
+        await asyncio.wait_for(initial_health_entered.wait(), timeout=1.0)
+        start.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await start
+
+        await asyncio.wait_for(ready.wait(), timeout=1.0)
+        assert health_reads == 2
+        assert seen == [{"state": "disabled", "reason": "writer_failures"}]
+        assert lifecycle.snapshot().records_calls is False
+    finally:
+        block_initial_health.set()
+        if not start.done():
+            start.cancel()
+            await asyncio.gather(start, return_exceptions=True)
+        await lifecycle.close()
+
+
 async def test_runtime_disabled_recorder_hands_call_log_to_host_retention(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_memory_sidecar_lifecycle.py
+++ b/tests/test_memory_sidecar_lifecycle.py
@@ -113,6 +113,51 @@ async def test_start_keeps_recorder_ownership_when_child_health_is_malformed(
     assert lifecycle.snapshot().records_calls is True
 
 
+async def test_supervised_restart_readmits_recorder_health_before_ready(
+    tmp_path: Path,
+) -> None:
+    factory = FakeEverOSProcessFactory()
+    health = iter(
+        (
+            {"state": "active", "reason": None},
+            {"state": "disabled", "reason": "writer_failures"},
+        )
+    )
+    seen: list[dict[str, str | None]] = []
+    ready_health: list[dict[str, str | None]] = []
+    ready = asyncio.Event()
+
+    async def recorder_health() -> dict[str, str | None]:
+        return next(health)
+
+    def observe_recorder_health(value: dict[str, str | None]) -> None:
+        seen.append(value)
+
+    def observe_ready(_generation: int) -> None:
+        ready_health.append(seen[-1])
+        ready.set()
+
+    lifecycle = _lifecycle(
+        tmp_path,
+        factory,
+        observe_ready,
+        recorder_health,
+        observe_recorder_health,
+    )
+
+    assert await lifecycle.start(Path(sys.executable), _settings()) is True
+    supervised = factory.supervised[0]
+    await supervised.start()
+    await asyncio.wait_for(ready.wait(), timeout=1.0)
+
+    assert seen == [
+        {"state": "active", "reason": None},
+        {"state": "disabled", "reason": "writer_failures"},
+    ]
+    assert ready_health == [{"state": "disabled", "reason": "writer_failures"}]
+    assert lifecycle.snapshot().records_calls is False
+
+
 async def test_stop_failure_retains_current_supervisor(tmp_path: Path) -> None:
     factory = FakeEverOSProcessFactory(template=lambda: FakeEverOSProcess(stop_failure=RuntimeError("stuck")))
     lifecycle = _lifecycle(tmp_path, factory, lambda _generation: None)

--- a/tests/test_memory_sidecar_lifecycle.py
+++ b/tests/test_memory_sidecar_lifecycle.py
@@ -158,6 +158,55 @@ async def test_supervised_restart_readmits_recorder_health_before_ready(
     assert lifecycle.snapshot().records_calls is False
 
 
+async def test_recovery_during_initial_admission_discards_stale_health_and_queues_ready(
+    tmp_path: Path,
+) -> None:
+    factory = FakeEverOSProcessFactory()
+    initial_health_entered = asyncio.Event()
+    release_initial_health = asyncio.Event()
+    recovery_ready = asyncio.Event()
+    seen: list[dict[str, str | None]] = []
+    ready_health: list[dict[str, str | None]] = []
+    health_reads = 0
+
+    async def recorder_health() -> dict[str, str | None]:
+        nonlocal health_reads
+        health_reads += 1
+        if health_reads == 1:
+            initial_health_entered.set()
+            await release_initial_health.wait()
+            return {"state": "degraded", "reason": "writer_failures"}
+        return {"state": "disabled", "reason": "writer_failures"}
+
+    def observe_ready(_generation: int) -> None:
+        ready_health.append(seen[-1])
+        recovery_ready.set()
+
+    lifecycle = _lifecycle(
+        tmp_path,
+        factory,
+        observe_ready,
+        recorder_health,
+        seen.append,
+    )
+
+    initial_start = asyncio.create_task(
+        lifecycle.start(Path(sys.executable), _settings())
+    )
+    await asyncio.wait_for(initial_health_entered.wait(), timeout=1.0)
+    supervised = factory.supervised[0]
+
+    assert await supervised.start() is True
+    release_initial_health.set()
+    assert await initial_start is True
+    await asyncio.wait_for(recovery_ready.wait(), timeout=1.0)
+
+    assert health_reads == 2
+    assert seen == [{"state": "disabled", "reason": "writer_failures"}]
+    assert ready_health == [{"state": "disabled", "reason": "writer_failures"}]
+    assert lifecycle.snapshot().records_calls is False
+
+
 async def test_stop_failure_retains_current_supervisor(tmp_path: Path) -> None:
     factory = FakeEverOSProcessFactory(template=lambda: FakeEverOSProcess(stop_failure=RuntimeError("stuck")))
     lifecycle = _lifecycle(tmp_path, factory, lambda _generation: None)


### PR DESCRIPTION
## Capability

Adds bounded Memory artifact admission for the pinned EverOS runtime: CLI/cascade and pinned modality checks, mandatory hermetic error-scrubber admission, and a deterministic recorder-health handoff that degrades recorder capture without taking Memory offline.

## Evidence

- Unit: artifact admission, scrubber rejection, malformed recorder health, and modality policy tests
- Contract: existing pinned real-wheel patch contract reused; no duplicate patch probe added
- Scenario: no applicable scenario catalog entry
- Manual residual: packaged pinned-wheel admission remains covered by CI; no local service or user state was touched
