### PR TITLE
fix(harness): deduplicate empty Turn failure notices

### DIFF
--- a/core/agent_auth_service.py
+++ b/core/agent_auth_service.py
@@ -14,6 +14,10 @@ import uuid
 from dataclasses import dataclass, field
 from typing import Any, Callable, Optional
 
+from core.backend_failure import terminal_backend_failure_output
+from core.delivery_evidence import DeliveryEvidence, STAGE_PERSIST, STAGE_SEND
+from core.message_output import MessageOutput, terminal_turn_output
+from core.resource_governance import governor_from_controller
 from modules.claude_sdk_compat import (
     CLAUDE_SDK_AVAILABLE,
     CLAUDE_SDK_MAX_BUFFER_SIZE,
@@ -38,8 +42,6 @@ from modules.agents.opencode.utils import (
     resolve_opencode_reasoning_effort,
 )
 from modules.im import InlineButton, InlineKeyboard, MessageContext
-from core.resource_governance import governor_from_controller
-from core.message_output import MessageOutput, terminal_turn_output
 from vibe.i18n import t as i18n_t
 from vibe.opencode_config import remove_opencode_provider_api_key
 
@@ -938,17 +940,25 @@ class AgentAuthService:
             backend == "codex"
             and getattr(backend_config, "auth_mode", None) == "api_key"
         )
-        if uses_codex_api_key:
-            recovery_text = f"{error_text}\n\n{self._t('command.setup.apiKeyRecoveryPrompt', backend=backend)}"
-            await self._send_message(context, recovery_text)
-        else:
-            recovery_text = f"{error_text}\n\n{self._t('command.setup.resetPrompt', backend=backend)}"
-            await self._send_message_with_button(
-                context,
-                recovery_text,
-                button_text=self._t("button.resetOAuth"),
-                callback_data=f"auth_setup:{backend}",
-            )
+        delivery = DeliveryEvidence()
+        try:
+            if uses_codex_api_key:
+                recovery_text = f"{error_text}\n\n{self._t('command.setup.apiKeyRecoveryPrompt', backend=backend)}"
+                delivered_id = await self._send_message(context, recovery_text)
+            else:
+                recovery_text = f"{error_text}\n\n{self._t('command.setup.resetPrompt', backend=backend)}"
+                delivered_id = await self._send_message_with_button(
+                    context,
+                    recovery_text,
+                    button_text=self._t("button.resetOAuth"),
+                    callback_data=f"auth_setup:{backend}",
+                )
+        except Exception as err:
+            delivery.error = err
+            delivery.error_stage = STAGE_SEND
+            raise
+        delivery.send_returned = True
+        delivery.delivered_id = str(delivered_id) if delivered_id is not None else None
         # Transport sends are not durable ``messages`` rows, and the web Chat
         # renders only durable rows. Persist the recovery text here, the single
         # home for it, rather than letting each backend store an error-only copy
@@ -966,12 +976,23 @@ class AgentAuthService:
             else self._t("command.setup.resetPromptPlain", backend=backend)
         )
         durable_text = f"{error_text}\n\n{durable_prompt}"
+        persist_errors: list[BaseException] = []
         try:
             from core.message_mirror import persist_agent_message
 
-            persist_agent_message(context, "notify", durable_text)
-        except Exception:
+            delivery.persisted_row = persist_agent_message(
+                context,
+                "notify",
+                durable_text,
+                error_sink=persist_errors,
+            )
+        except Exception as err:
+            delivery.error = err
+            delivery.error_stage = STAGE_PERSIST
             logger.debug("auth recovery: failed to persist durable notify", exc_info=True)
+        if delivery.persisted_row is None and persist_errors:
+            delivery.error = persist_errors[0]
+            delivery.error_stage = STAGE_PERSIST
         # Settle the failed turn through the outbound status chokepoint: a silent
         # terminal failure turns the dot red and releases the SSE waiter
         # without adding a second visible message (the recovery button above is the
@@ -983,7 +1004,11 @@ class AgentAuthService:
                 "",
                 is_error=True,
                 level="silent",
-                output=output or terminal_turn_output(),
+                output=terminal_backend_failure_output(
+                    context,
+                    output=output or terminal_turn_output(),
+                    delivery=delivery,
+                ),
                 terminal_error=terminal_error or error_text,
             )
         except Exception:

--- a/core/agent_auth_service.py
+++ b/core/agent_auth_service.py
@@ -16,6 +16,7 @@ from typing import Any, Callable, Optional
 
 from core.backend_failure import terminal_backend_failure_output
 from core.delivery_evidence import DeliveryEvidence, STAGE_PERSIST, STAGE_SEND
+from core.delivery_target import routed_delivery_context
 from core.message_output import MessageOutput, terminal_turn_output
 from core.resource_governance import governor_from_controller
 from modules.claude_sdk_compat import (
@@ -940,15 +941,19 @@ class AgentAuthService:
             backend == "codex"
             and getattr(backend_config, "auth_mode", None) == "api_key"
         )
+        delivery_context = routed_delivery_context(context)
         delivery = DeliveryEvidence()
         try:
             if uses_codex_api_key:
                 recovery_text = f"{error_text}\n\n{self._t('command.setup.apiKeyRecoveryPrompt', backend=backend)}"
-                delivered_id = await self._send_message(context, recovery_text)
+                delivered_id = await self._send_message(
+                    delivery_context,
+                    recovery_text,
+                )
             else:
                 recovery_text = f"{error_text}\n\n{self._t('command.setup.resetPrompt', backend=backend)}"
                 delivered_id = await self._send_message_with_button(
-                    context,
+                    delivery_context,
                     recovery_text,
                     button_text=self._t("button.resetOAuth"),
                     callback_data=f"auth_setup:{backend}",
@@ -981,7 +986,7 @@ class AgentAuthService:
             from core.message_mirror import persist_agent_message
 
             delivery.persisted_row = persist_agent_message(
-                context,
+                delivery_context,
                 "notify",
                 durable_text,
                 error_sink=persist_errors,

--- a/core/agent_auth_service.py
+++ b/core/agent_auth_service.py
@@ -982,22 +982,24 @@ class AgentAuthService:
         )
         durable_text = f"{error_text}\n\n{durable_prompt}"
         persist_errors: list[BaseException] = []
-        try:
-            from core.message_mirror import persist_agent_message
+        target_platform = str(delivery_context.platform or "").strip()
+        if target_platform == "avibe" or delivery.delivered_id is not None:
+            try:
+                from core.message_mirror import persist_agent_message
 
-            delivery.persisted_row = persist_agent_message(
-                delivery_context,
-                "notify",
-                durable_text,
-                error_sink=persist_errors,
-            )
-        except Exception as err:
-            delivery.error = err
-            delivery.error_stage = STAGE_PERSIST
-            logger.debug("auth recovery: failed to persist durable notify", exc_info=True)
-        if delivery.persisted_row is None and persist_errors:
-            delivery.error = persist_errors[0]
-            delivery.error_stage = STAGE_PERSIST
+                delivery.persisted_row = persist_agent_message(
+                    delivery_context,
+                    "notify",
+                    durable_text,
+                    error_sink=persist_errors,
+                )
+            except Exception as err:
+                delivery.error = err
+                delivery.error_stage = STAGE_PERSIST
+                logger.debug("auth recovery: failed to persist durable notify", exc_info=True)
+            if delivery.persisted_row is None and persist_errors:
+                delivery.error = persist_errors[0]
+                delivery.error_stage = STAGE_PERSIST
         # Settle the failed turn through the outbound status chokepoint: a silent
         # terminal failure turns the dot red and releases the SSE waiter
         # without adding a second visible message (the recovery button above is the

--- a/core/backend_failure.py
+++ b/core/backend_failure.py
@@ -12,6 +12,7 @@ from core.delivery_evidence import (
     ACK_EVIDENCE_RECEIPT,
     DeliveryEvidence,
 )
+from core.delivery_target import routed_delivery_context
 from core.message_output import MessageOutput, terminal_output_for, terminal_turn_output
 from vibe.message_types import spec_for
 
@@ -164,24 +165,6 @@ def backend_failure_notification_output(
     )
 
 
-def _target_delivery_platform(context: Any) -> str:
-    platform_specific = getattr(context, "platform_specific", None) or {}
-    delivery_override = (
-        platform_specific.get("delivery_override")
-        if isinstance(platform_specific, dict)
-        else None
-    )
-    return str(
-        (
-            delivery_override.get("platform")
-            if isinstance(delivery_override, dict)
-            else None
-        )
-        or getattr(context, "platform", "")
-        or ""
-    ).strip()
-
-
 def _acknowledges_target(
     context: Any,
     evidence: str | None,
@@ -190,7 +173,7 @@ def _acknowledges_target(
         return True
     return (
         evidence == ACK_EVIDENCE_DELIVERY_ONLY
-        and _target_delivery_platform(context) != "avibe"
+        and routed_delivery_context(context).platform != "avibe"
     )
 
 

--- a/core/backend_failure.py
+++ b/core/backend_failure.py
@@ -164,6 +164,84 @@ def backend_failure_notification_output(
     )
 
 
+def _target_delivery_platform(context: Any) -> str:
+    platform_specific = getattr(context, "platform_specific", None) or {}
+    delivery_override = (
+        platform_specific.get("delivery_override")
+        if isinstance(platform_specific, dict)
+        else None
+    )
+    return str(
+        (
+            delivery_override.get("platform")
+            if isinstance(delivery_override, dict)
+            else None
+        )
+        or getattr(context, "platform", "")
+        or ""
+    ).strip()
+
+
+def _acknowledges_target(
+    context: Any,
+    evidence: str | None,
+) -> bool:
+    if evidence == ACK_EVIDENCE_RECEIPT:
+        return True
+    return (
+        evidence == ACK_EVIDENCE_DELIVERY_ONLY
+        and _target_delivery_platform(context) != "avibe"
+    )
+
+
+def terminal_backend_failure_output(
+    context: Any,
+    *,
+    request: Any = None,
+    output: MessageOutput | None = None,
+    failure_id: str | None = None,
+    delivery: DeliveryEvidence | None = None,
+) -> MessageOutput:
+    """Attach one monotonic Turn failure-delivery contract to a terminal output.
+
+    Some failures use the ordinary ``notify`` dispatcher while others need a
+    specialized visible path, such as an OAuth recovery button. Both must settle
+    with the same evidence contract or a later Harness Run cannot distinguish an
+    error the user already saw from an error that still needs a fallback notice.
+    """
+
+    terminal = _terminal_output(request, output)
+    if not (_turn_failure_identity(context, request) or _harness_run_identity(context, request)):
+        return terminal
+
+    metadata = dict(terminal.metadata)
+    existing = metadata.get("turn_failure_notification")
+    existing_notification = dict(existing) if isinstance(existing, dict) else {}
+    identity = str(existing_notification.get("failure_id") or "").strip()
+    if not identity:
+        identity = _failure_identity(context, request, failure_id)
+
+    incoming_ack = delivery.ack_evidence if delivery is not None else None
+    existing_ack = str(existing_notification.get("ack_evidence") or "").strip() or None
+    ack_priority = {None: 0, ACK_EVIDENCE_DELIVERY_ONLY: 1, ACK_EVIDENCE_RECEIPT: 2}
+    ack_evidence = (
+        incoming_ack
+        if ack_priority.get(incoming_ack, 1 if incoming_ack else 0)
+        > ack_priority.get(existing_ack, 1 if existing_ack else 0)
+        else existing_ack
+    )
+    existing_notification.update(
+        {
+            "failure_id": identity,
+            "ack_evidence": ack_evidence,
+            "delivered": bool(existing_notification.get("delivered"))
+            or _acknowledges_target(context, ack_evidence),
+        }
+    )
+    metadata["turn_failure_notification"] = existing_notification
+    return replace(terminal, metadata=metadata)
+
+
 async def emit_replayed_backend_failure(
     controller: Any,
     context: Any,
@@ -282,43 +360,14 @@ async def emit_backend_failure(
     if owns_failure_contract and live_delivery is None:
         live_delivery = DeliveryEvidence()
 
-    platform_specific = getattr(context, "platform_specific", None) or {}
-    delivery_override = (
-        platform_specific.get("delivery_override")
-        if isinstance(platform_specific, dict)
-        else None
-    )
-    target_platform = str(
-        (
-            delivery_override.get("platform")
-            if isinstance(delivery_override, dict)
-            else None
-        )
-        or getattr(context, "platform", "")
-        or ""
-    ).strip()
-
-    def notification_acknowledged() -> bool:
-        if live_delivery is None:
-            return False
-        evidence = live_delivery.ack_evidence
-        if evidence == ACK_EVIDENCE_RECEIPT:
-            return True
-        return (
-            evidence == ACK_EVIDENCE_DELIVERY_ONLY
-            and target_platform != "avibe"
-        )
-
     async def settle_terminal_failure() -> None:
-        terminal_output = terminal
-        if owns_failure_contract:
-            metadata = dict(terminal.metadata)
-            metadata["turn_failure_notification"] = {
-                "failure_id": notification_identity,
-                "ack_evidence": live_delivery.ack_evidence if live_delivery else None,
-                "delivered": notification_acknowledged(),
-            }
-            terminal_output = replace(terminal, metadata=metadata)
+        terminal_output = terminal_backend_failure_output(
+            context,
+            request=request,
+            output=terminal,
+            failure_id=notification_identity,
+            delivery=live_delivery,
+        )
         await controller.emit_agent_message(
             context,
             "result",

--- a/core/backend_failure.py
+++ b/core/backend_failure.py
@@ -258,16 +258,18 @@ async def emit_backend_failure(
     auth recovery supplied that immediate notification.
 
     ``delivery``, when supplied, is filled in with what the notify attempt actually
-    proved. Harness supplies an evidence object automatically because linked Runs
-    owe a durable fallback; other callers opt in when they need the same proof. A
-    clean return alone is not enough to distinguish a delivered message from a lost
-    one.
+    proved. A durable Turn or legacy Harness Run supplies an evidence object
+    automatically so Runs attached after settlement inherit the same proof. A clean
+    return alone is not enough to distinguish a delivered message from a lost one.
     """
 
     backend_name = str(backend or "backend").strip() or "backend"
     error, visible = _failure_texts(backend_name, diagnostic, display_text)
     terminal = _terminal_output(request, output)
     harness_run_id = _harness_run_identity(context, request)
+    owns_failure_contract = bool(
+        _turn_failure_identity(context, request) or harness_run_id
+    )
     notification = backend_failure_notification_output(
         context,
         backend_name,
@@ -277,7 +279,7 @@ async def emit_backend_failure(
     )
     notification_identity = str(notification.metadata.get("failure_id") or "").strip()
     live_delivery = delivery
-    if harness_run_id and live_delivery is None:
+    if owns_failure_contract and live_delivery is None:
         live_delivery = DeliveryEvidence()
 
     platform_specific = getattr(context, "platform_specific", None) or {}
@@ -309,7 +311,7 @@ async def emit_backend_failure(
 
     async def settle_terminal_failure() -> None:
         terminal_output = terminal
-        if harness_run_id:
+        if owns_failure_contract:
             metadata = dict(terminal.metadata)
             metadata["turn_failure_notification"] = {
                 "failure_id": notification_identity,
@@ -354,9 +356,9 @@ async def emit_backend_failure(
         if handled_auth:
             return True
 
-    # ``delivery`` is passed only when the emitter supports it. Harness creates the
-    # object automatically, but controller-like test and integration doubles with
-    # the legacy signature must keep working.
+    # ``delivery`` is passed only when the emitter supports it. Durable Turn and
+    # Harness contexts create the object automatically, but controller-like test
+    # and integration doubles with the legacy signature must keep working.
     notify_kwargs: dict[str, Any] = {"output": notification}
     if live_delivery is not None:
         emit = controller.emit_agent_message

--- a/core/backend_failure.py
+++ b/core/backend_failure.py
@@ -171,9 +171,11 @@ def _acknowledges_target(
 ) -> bool:
     if evidence == ACK_EVIDENCE_RECEIPT:
         return True
+    target_platform = getattr(routed_delivery_context(context), "platform", None)
     return (
         evidence == ACK_EVIDENCE_DELIVERY_ONLY
-        and routed_delivery_context(context).platform != "avibe"
+        and bool(target_platform)
+        and target_platform != "avibe"
     )
 
 

--- a/core/delivery_target.py
+++ b/core/delivery_target.py
@@ -1,0 +1,26 @@
+"""Resolve the concrete outbound destination carried by a message context."""
+
+from __future__ import annotations
+
+from modules.im import MessageContext
+
+
+def routed_delivery_context(context: MessageContext) -> MessageContext:
+    """Apply a scheduled/Harness delivery override without losing Turn lineage."""
+
+    payload = dict(context.platform_specific or {})
+    override = payload.get("delivery_override")
+    if not isinstance(override, dict):
+        return context
+
+    payload["is_dm"] = override.get("is_dm", payload.get("is_dm", False))
+    return MessageContext(
+        user_id=str(override.get("user_id") or context.user_id),
+        channel_id=str(override.get("channel_id") or context.channel_id),
+        platform=override.get("platform") or context.platform,
+        thread_id=override.get("thread_id"),
+        message_id=context.message_id,
+        platform_specific=payload,
+        files=context.files,
+        is_ordinary_text=context.is_ordinary_text,
+    )

--- a/core/handlers/message_handler.py
+++ b/core/handlers/message_handler.py
@@ -13,6 +13,7 @@ from core.audio_asr import (
     detect_audio_mime_from_sample,
     format_audio_transcript_echo,
 )
+from core.backend_failure import emit_backend_failure
 from core.message_output import (
     HARNESS_PROMPT_ECHO_SPEC_KEY,
     terminal_output_for,
@@ -845,17 +846,10 @@ class MessageHandler(BaseHandler):
                             session_id=str(bound_session_id),
                         )
             except KeyError:
-                await self._handle_missing_agent(context, agent_name)
-                # Synchronous terminal failure (no agent dispatched). Settle the
-                # turn through the OUTBOUND status chokepoint: an empty terminal
-                # error result turns the dot red + releases the SSE waiter (the
-                # missing-agent message was already shown above). No separate latch.
-                await self.controller.emit_agent_message(
+                await self._handle_missing_agent(
                     context,
-                    "result",
-                    "",
-                    is_error=True,
-                    output=terminal_output_for(request),
+                    agent_name,
+                    request=request,
                 )
                 # Clean up reaction on error
                 await self._remove_ack_reaction(context, request)
@@ -1612,14 +1606,30 @@ class MessageHandler(BaseHandler):
             logger.error(f"Error handling inline stop: {e}", exc_info=True)
             return False
 
-    async def _handle_missing_agent(self, context: MessageContext, agent_name: str):
-        """Notify user when a requested agent backend is unavailable."""
+    async def _handle_missing_agent(
+        self,
+        context: MessageContext,
+        agent_name: str,
+        *,
+        request: AgentRequest | None = None,
+    ) -> None:
+        """Notify and, for a dispatched Turn, settle a missing Agent failure."""
         target = agent_name or self.controller.agent_service.default_agent
         backend = self._missing_agent_backend(context, target)
         display_backend = display_name_for_backend(backend) if backend else str(target)
         hint_key = f"error.agentNotConfiguredHint.{backend}" if backend else "error.agentNotConfiguredHint.generic"
         hint = self._t(hint_key)
         msg = f"❌ {self._t('error.agentNotConfigured', agent=target, backend=display_backend, hint=hint)}"
+        if request is not None:
+            await emit_backend_failure(
+                self.controller,
+                context,
+                backend or str(target),
+                msg,
+                display_text=msg,
+                request=request,
+            )
+            return
         await self._get_im_client(context).send_message(context, msg)
         await self._stream_terminal_error(context, msg)
 

--- a/core/handlers/message_handler.py
+++ b/core/handlers/message_handler.py
@@ -815,6 +815,11 @@ class MessageHandler(BaseHandler):
                 processing_indicator=processing_indicator,
                 files=processed_files,
             )
+            request.failure_handler = lambda error: self._emit_agent_dispatch_failure(
+                context,
+                request,
+                error,
+            )
             if processing_indicator is not None:
                 self.controller.processing_indicator.apply_to_request(request, processing_indicator)
             try:
@@ -868,15 +873,8 @@ class MessageHandler(BaseHandler):
                     )
             except Exception as cleanup_err:
                 logger.debug(f"Failed to clean up reaction on error: {cleanup_err}")
-            error_text = self.formatter.format_error(self._t("error.processMessageFailed", error=str(e)))
-            await emit_backend_failure(
-                self.controller,
-                context,
-                str(getattr(request, "vibe_agent_backend", None) or "agent"),
-                error_text,
-                display_text=error_text,
-                request=request,
-            )
+            if not bool(getattr(request, "failure_handled", False)):
+                await self._emit_agent_dispatch_failure(context, request, e)
             return str(e)
         finally:
             if not agent_dispatched:
@@ -887,6 +885,26 @@ class MessageHandler(BaseHandler):
                 mark_complete = getattr(self.controller, "mark_turn_complete", None)
                 if callable(mark_complete):
                     mark_complete(context)
+
+    async def _emit_agent_dispatch_failure(
+        self,
+        context: MessageContext,
+        request: AgentRequest | None,
+        error: BaseException,
+    ) -> None:
+        """Report one backend dispatch failure through the shared live boundary."""
+
+        error_text = self.formatter.format_error(
+            self._t("error.processMessageFailed", error=str(error))
+        )
+        await emit_backend_failure(
+            self.controller,
+            context,
+            str(getattr(request, "vibe_agent_backend", None) or "agent"),
+            error_text,
+            display_text=error_text,
+            request=request,
+        )
 
     async def _admit_human_delivery(
         self,

--- a/core/handlers/message_handler.py
+++ b/core/handlers/message_handler.py
@@ -847,6 +847,8 @@ class MessageHandler(BaseHandler):
                             session_id=str(bound_session_id),
                         )
             except KeyError:
+                if request.failure_handled:
+                    raise
                 await self._handle_missing_agent(
                     context,
                     agent_name,

--- a/core/handlers/message_handler.py
+++ b/core/handlers/message_handler.py
@@ -13,13 +13,8 @@ from core.audio_asr import (
     detect_audio_mime_from_sample,
     format_audio_transcript_echo,
 )
-from core.backend_failure import emit_backend_failure, terminal_backend_failure_output
-from core.delivery_evidence import DeliveryEvidence, STAGE_PERSIST, STAGE_SEND, STAGE_STREAM
-from core.message_output import (
-    HARNESS_PROMPT_ECHO_SPEC_KEY,
-    terminal_output_for,
-    terminal_turn_output,
-)
+from core.backend_failure import emit_backend_failure
+from core.message_output import HARNESS_PROMPT_ECHO_SPEC_KEY
 from core.message_context import (
     SCHEDULED_DISPATCH_METADATA_APPLIED_KEY,
     resolve_context_thread_id,
@@ -874,46 +869,13 @@ class MessageHandler(BaseHandler):
             except Exception as cleanup_err:
                 logger.debug(f"Failed to clean up reaction on error: {cleanup_err}")
             error_text = self.formatter.format_error(self._t("error.processMessageFailed", error=str(e)))
-            delivery = DeliveryEvidence()
-            try:
-                delivered_id = await self._get_im_client(context).send_message(
-                    context,
-                    error_text,
-                )
-            except Exception as delivery_err:
-                delivery.error = delivery_err
-                delivery.error_stage = STAGE_SEND
-                raise
-            delivery.send_returned = True
-            delivery.delivered_id = (
-                str(delivered_id) if delivered_id is not None else None
-            )
-            # Surface the failure into the live web-Chat SSE stream first...
-            await self._stream_terminal_error(
+            await emit_backend_failure(
+                self.controller,
                 context,
+                str(getattr(request, "vibe_agent_backend", None) or "agent"),
                 error_text,
-                delivery=delivery,
-            )
-            # ...then settle the failed turn through the OUTBOUND status chokepoint:
-            # an empty terminal error result turns the dot red + releases the SSE
-            # waiter. The shared contract carries proof that the direct error path
-            # already delivered, so linked Runs cannot emit another fallback.
-            terminal_output = (
-                terminal_output_for(request)
-                if request is not None
-                else terminal_turn_output()
-            )
-            await self.controller.emit_agent_message(
-                context,
-                "result",
-                "",
-                is_error=True,
-                output=terminal_backend_failure_output(
-                    context,
-                    request=request,
-                    output=terminal_output,
-                    delivery=delivery,
-                ),
+                display_text=error_text,
+                request=request,
             )
             return str(e)
         finally:
@@ -1679,8 +1641,6 @@ class MessageHandler(BaseHandler):
         self,
         context: MessageContext,
         text: str,
-        *,
-        delivery: DeliveryEvidence | None = None,
     ) -> None:
         """Surface a synchronous, no-agent-dispatched failure (missing backend,
         a pre-dispatch exception) into the web Chat so the browser shows it
@@ -1696,32 +1656,14 @@ class MessageHandler(BaseHandler):
 
             # Persisted as ``notify`` → renders as a status box, not an answer;
             # publishes message.new so the async send path surfaces it.
-            persist_errors: list[BaseException] = []
-            persisted = persist_agent_message(
-                context,
-                "notify",
-                text,
-                native_message_id=(delivery.delivered_id if delivery else None),
-                error_sink=persist_errors,
-            )
-            if delivery is not None:
-                delivery.persisted_row = persisted
-                if persisted is None and persist_errors:
-                    delivery.error = persist_errors[0]
-                    delivery.error_stage = STAGE_PERSIST
-        except Exception as err:
-            if delivery is not None:
-                delivery.error = err
-                delivery.error_stage = STAGE_PERSIST
+            persist_agent_message(context, "notify", text)
+        except Exception:
             logger.debug("failed to persist terminal error row", exc_info=True)
         try:
             from core.message_dispatcher import _stream_chunk
 
             await _stream_chunk(self.controller, context, text=text, message_id=None, kind="error")
-        except Exception as err:
-            if delivery is not None:
-                delivery.error = err
-                delivery.error_stage = STAGE_STREAM
+        except Exception:
             logger.debug("failed to stream terminal error chunk", exc_info=True)
 
     async def _delete_ack(self, channel_id: str, request: AgentRequest):

--- a/core/handlers/message_handler.py
+++ b/core/handlers/message_handler.py
@@ -13,7 +13,8 @@ from core.audio_asr import (
     detect_audio_mime_from_sample,
     format_audio_transcript_echo,
 )
-from core.backend_failure import emit_backend_failure
+from core.backend_failure import emit_backend_failure, terminal_backend_failure_output
+from core.delivery_evidence import DeliveryEvidence, STAGE_PERSIST, STAGE_SEND, STAGE_STREAM
 from core.message_output import (
     HARNESS_PROMPT_ECHO_SPEC_KEY,
     terminal_output_for,
@@ -873,21 +874,45 @@ class MessageHandler(BaseHandler):
             except Exception as cleanup_err:
                 logger.debug(f"Failed to clean up reaction on error: {cleanup_err}")
             error_text = self.formatter.format_error(self._t("error.processMessageFailed", error=str(e)))
-            await self._get_im_client(context).send_message(context, error_text)
+            delivery = DeliveryEvidence()
+            try:
+                delivered_id = await self._get_im_client(context).send_message(
+                    context,
+                    error_text,
+                )
+            except Exception as delivery_err:
+                delivery.error = delivery_err
+                delivery.error_stage = STAGE_SEND
+                raise
+            delivery.send_returned = True
+            delivery.delivered_id = (
+                str(delivered_id) if delivered_id is not None else None
+            )
             # Surface the failure into the live web-Chat SSE stream first...
-            await self._stream_terminal_error(context, error_text)
+            await self._stream_terminal_error(
+                context,
+                error_text,
+                delivery=delivery,
+            )
             # ...then settle the failed turn through the OUTBOUND status chokepoint:
             # an empty terminal error result turns the dot red + releases the SSE
-            # waiter (the visible error was sent + streamed above). No separate latch.
+            # waiter. The shared contract carries proof that the direct error path
+            # already delivered, so linked Runs cannot emit another fallback.
+            terminal_output = (
+                terminal_output_for(request)
+                if request is not None
+                else terminal_turn_output()
+            )
             await self.controller.emit_agent_message(
                 context,
                 "result",
                 "",
                 is_error=True,
-                output=(
-                    terminal_output_for(request)
-                    if request is not None
-                    else terminal_turn_output()
+                output=terminal_backend_failure_output(
+                    context,
+                    request=request,
+                    output=terminal_output,
+                    delivery=delivery,
                 ),
             )
             return str(e)
@@ -1650,7 +1675,13 @@ class MessageHandler(BaseHandler):
         backend = getattr(agent, "backend", None)
         return str(backend) if is_agent_backend(str(backend)) else None
 
-    async def _stream_terminal_error(self, context: MessageContext, text: str) -> None:
+    async def _stream_terminal_error(
+        self,
+        context: MessageContext,
+        text: str,
+        *,
+        delivery: DeliveryEvidence | None = None,
+    ) -> None:
         """Surface a synchronous, no-agent-dispatched failure (missing backend,
         a pre-dispatch exception) into the web Chat so the browser shows it
         instead of silently ending the turn with only the user's prompt visible.
@@ -1665,14 +1696,32 @@ class MessageHandler(BaseHandler):
 
             # Persisted as ``notify`` → renders as a status box, not an answer;
             # publishes message.new so the async send path surfaces it.
-            persist_agent_message(context, "notify", text)
-        except Exception:
+            persist_errors: list[BaseException] = []
+            persisted = persist_agent_message(
+                context,
+                "notify",
+                text,
+                native_message_id=(delivery.delivered_id if delivery else None),
+                error_sink=persist_errors,
+            )
+            if delivery is not None:
+                delivery.persisted_row = persisted
+                if persisted is None and persist_errors:
+                    delivery.error = persist_errors[0]
+                    delivery.error_stage = STAGE_PERSIST
+        except Exception as err:
+            if delivery is not None:
+                delivery.error = err
+                delivery.error_stage = STAGE_PERSIST
             logger.debug("failed to persist terminal error row", exc_info=True)
         try:
             from core.message_dispatcher import _stream_chunk
 
             await _stream_chunk(self.controller, context, text=text, message_id=None, kind="error")
-        except Exception:
+        except Exception as err:
+            if delivery is not None:
+                delivery.error = err
+                delivery.error_stage = STAGE_STREAM
             logger.debug("failed to stream terminal error chunk", exc_info=True)
 
     async def _delete_ack(self, channel_id: str, request: AgentRequest):

--- a/core/message_dispatcher.py
+++ b/core/message_dispatcher.py
@@ -1377,7 +1377,7 @@ class ConsolidatedMessageDispatcher:
         if isinstance(notification, dict) and str(notification.get("failure_id") or "").strip():
             return output_semantics
         turn_id = str((context.platform_specific or {}).get("turn_token") or "").strip()
-        if not turn_id or not self._terminal_agent_run_ids(context, output_semantics):
+        if not turn_id:
             return output_semantics
         metadata = dict(output_semantics.metadata)
         metadata["turn_failure_notification"] = {

--- a/core/message_dispatcher.py
+++ b/core/message_dispatcher.py
@@ -1355,6 +1355,37 @@ class ConsolidatedMessageDispatcher:
         metadata["turn_failure_notification"] = notification
         return replace(output_semantics, metadata=metadata)
 
+    def _output_with_implicit_turn_failure_notification(
+        self,
+        context: MessageContext,
+        output_semantics: MessageOutput,
+        *,
+        is_error: bool,
+        has_visible_result: bool,
+        mutates_turn_lifecycle: bool,
+    ) -> MessageOutput:
+        """Give an invisible failed Harness Turn one shared fallback identity."""
+
+        if (
+            not is_error
+            or has_visible_result
+            or not mutates_turn_lifecycle
+            or not output_semantics.settles_run
+        ):
+            return output_semantics
+        notification = output_semantics.metadata.get("turn_failure_notification")
+        if isinstance(notification, dict) and str(notification.get("failure_id") or "").strip():
+            return output_semantics
+        turn_id = str((context.platform_specific or {}).get("turn_token") or "").strip()
+        if not turn_id or not self._terminal_agent_run_ids(context, output_semantics):
+            return output_semantics
+        metadata = dict(output_semantics.metadata)
+        metadata["turn_failure_notification"] = {
+            "failure_id": f"turn:{turn_id}",
+            "delivered": False,
+        }
+        return replace(output_semantics, metadata=metadata)
+
     def _run_has_blocking_activity(self, run_id: str) -> bool:
         service = getattr(self.controller, "agent_service", None)
         registry = getattr(service, "activities", None)
@@ -1999,11 +2030,6 @@ class ConsolidatedMessageDispatcher:
         canonical_type = settings_manager._canonicalize_message_type(message_type or "")
         settings_key = self._get_settings_key(context)
         output_semantics = output_for_message(canonical_type, output)
-        if canonical_type == "result" and output_semantics.completes_turn:
-            output_semantics = self._output_with_turn_fallback_owner(
-                context,
-                output_semantics,
-            )
         activity_batch_incomplete = bool(
             output_semantics.requires_delivery_for_run_settlement
             and output_semantics.metadata.get("activity_batch_complete") is False
@@ -2058,6 +2084,18 @@ class ConsolidatedMessageDispatcher:
             text = enhanced.visible_text
         else:
             text = strip_silent_blocks(raw_text)
+        if canonical_type == "result" and output_semantics.completes_turn:
+            output_semantics = self._output_with_implicit_turn_failure_notification(
+                context,
+                output_semantics,
+                is_error=is_error,
+                has_visible_result=level != "silent" and bool(text and text.strip()),
+                mutates_turn_lifecycle=mutates_turn_lifecycle,
+            )
+            output_semantics = self._output_with_turn_fallback_owner(
+                context,
+                output_semantics,
+            )
         # Persist the exact terminal body in the Turn snapshot before delivery.
         # A steer accepted after this Turn settles can then complete its Agent Run
         # without guessing from transcript order or requiring a live sink.

--- a/core/message_dispatcher.py
+++ b/core/message_dispatcher.py
@@ -22,6 +22,7 @@ from config.v2_config import DEFAULT_AGENT_PROGRESS_STYLE
 from modules.im import MessageContext
 from modules.im.formatters.base_formatter import to_status_label
 from core.delivery_evidence import STAGE_PERSIST, STAGE_SEND, STAGE_STREAM, DeliveryEvidence
+from core.delivery_target import routed_delivery_context
 from core import failure_notices
 from core.message_context import resolve_turn_sink_key
 from core.message_mirror import (
@@ -430,19 +431,9 @@ class ConsolidatedMessageDispatcher:
         return i18n_t(key, lang, **kwargs)
 
     def _get_target_context(self, context: MessageContext) -> MessageContext:
-        payload = dict(context.platform_specific or {})
-        delivery_override = payload.get("delivery_override")
-        if isinstance(delivery_override, dict):
-            next_payload = dict(payload)
-            next_payload["is_dm"] = delivery_override.get("is_dm", next_payload.get("is_dm", False))
-            return MessageContext(
-                user_id=str(delivery_override.get("user_id") or context.user_id),
-                channel_id=str(delivery_override.get("channel_id") or context.channel_id),
-                platform=delivery_override.get("platform") or context.platform,
-                thread_id=delivery_override.get("thread_id"),
-                message_id=context.message_id,
-                platform_specific=next_payload,
-            )
+        target = routed_delivery_context(context)
+        if target is not context:
+            return target
         if self._get_im_client(context).should_use_thread_for_reply() and context.thread_id:
             return MessageContext(
                 user_id=context.user_id,

--- a/docs/plans/harness-watch-run-failure-boundary.md
+++ b/docs/plans/harness-watch-run-failure-boundary.md
@@ -178,7 +178,8 @@ does not claim that an event was detected.
   contract before its immutable snapshot, even before the first participant is
   attached, so every accepted Run shares one fallback owner instead of emitting
   one notice per Run. A primary error already delivered through the shared
-  backend-failure path carries its acknowledgement into the same contract.
+  backend-failure path, the message-handler exception path, or auth recovery
+  carries its acknowledgement into the same monotonic contract.
 
 Residual manual check: trigger two one-shot Watches into one failing Turn and
 confirm that the conversation contains one backend error, both Runs are failed,

--- a/docs/plans/harness-watch-run-failure-boundary.md
+++ b/docs/plans/harness-watch-run-failure-boundary.md
@@ -175,8 +175,10 @@ does not claim that an event was detected.
 - `HFR-459`: independent Activity completions reserve the SQLite writer before
   reading deferred participants and electing their shared Turn fallback owner.
 - `HFR-472`: an empty failed Harness Turn synthesizes the existing Turn failure
-  contract before its immutable snapshot, so every accepted Run shares one
-  fallback owner instead of emitting one notice per Run.
+  contract before its immutable snapshot, even before the first participant is
+  attached, so every accepted Run shares one fallback owner instead of emitting
+  one notice per Run. A primary error already delivered through the shared
+  backend-failure path carries its acknowledgement into the same contract.
 
 Residual manual check: trigger two one-shot Watches into one failing Turn and
 confirm that the conversation contains one backend error, both Runs are failed,

--- a/docs/plans/harness-watch-run-failure-boundary.md
+++ b/docs/plans/harness-watch-run-failure-boundary.md
@@ -179,7 +179,9 @@ does not claim that an event was detected.
   attached, so every accepted Run shares one fallback owner instead of emitting
   one notice per Run. A primary error already delivered through the shared
   backend-failure path, the message-handler exception path, or auth recovery
-  carries its acknowledgement into the same monotonic contract.
+  carries its acknowledgement into the same monotonic contract. All visible
+  paths resolve the Harness delivery override before sending or persisting, so
+  acknowledgement can never be attributed to a different target.
 
 Residual manual check: trigger two one-shot Watches into one failing Turn and
 confirm that the conversation contains one backend error, both Runs are failed,

--- a/docs/plans/harness-watch-run-failure-boundary.md
+++ b/docs/plans/harness-watch-run-failure-boundary.md
@@ -140,8 +140,8 @@ does not claim that an event was detected.
   complete Turn fallback; pending callback delivery defers it.
 - `HFR-441`: persistence under `suppress_delivery` cannot satisfy or shadow a
   later outward receipt, including in a foreground callback target Session.
-- `HFR-442`: bare Turn provenance without a notification contract does not
-  bypass definition-level failure-notice suppression.
+- `HFR-442`: a visible direct error with bare Turn provenance does not bypass
+  definition-level failure-notice suppression.
 - `HFR-443`: a deferred participant's pending callback remains part of the Turn
   callback aggregate and blocks an immediate sibling fallback.
 - `HFR-444`: a Watch in its first in-flight waiter cycle reports unknown waiter
@@ -174,6 +174,9 @@ does not claim that an event was detected.
   receipt through the shared Turn output even when another Run owns the Message.
 - `HFR-459`: independent Activity completions reserve the SQLite writer before
   reading deferred participants and electing their shared Turn fallback owner.
+- `HFR-472`: an empty failed Harness Turn synthesizes the existing Turn failure
+  contract before its immutable snapshot, so every accepted Run shares one
+  fallback owner instead of emitting one notice per Run.
 
 Residual manual check: trigger two one-shot Watches into one failing Turn and
 confirm that the conversation contains one backend error, both Runs are failed,

--- a/modules/agents/base.py
+++ b/modules/agents/base.py
@@ -55,6 +55,11 @@ class AgentRequest:
     ack_reaction_emoji: Optional[str] = None
     typing_indicator_active: bool = False
     typing_indicator_task: Optional[Any] = None
+    # The caller that owns user-facing failure copy can provide its reporter here.
+    # AgentService invokes it before releasing the runtime Turn, so notification
+    # delivery evidence and terminal settlement remain one ordered operation.
+    failure_handler: Optional[Callable[[BaseException], Any]] = None
+    failure_handled: bool = False
     # File attachments (downloaded or with URLs for download)
     files: Optional[List[FileAttachment]] = None
     # Internal stop diagnostics. Backend adapters set this when ``handle_stop``

--- a/modules/agents/service.py
+++ b/modules/agents/service.py
@@ -411,28 +411,46 @@ class AgentService:
             if not scheduled:
                 self.release_runtime_turn(request.context)
             raise
-        except Exception:
-            # The message handler converts backend exceptions into a terminal
-            # error result using the same context. Try that shared terminal path
-            # here too; if delivery itself is broken, the finally below still
-            # releases this turn's token so later prompts cannot hang forever.
+        except Exception as error:
+            # The caller owns the user-facing failure copy. Invoke that shared
+            # reporter while this runtime Turn is still current, so its notify
+            # receipt is part of the terminal failure contract before the gate is
+            # released. Direct AgentService callers without a reporter retain the
+            # silent terminal fallback below.
             try:
-                emit = getattr(self.controller, "emit_agent_message", None)
-                if callable(emit):
+                failure_handler = getattr(request, "failure_handler", None)
+                if callable(failure_handler):
+                    request.failure_handled = True
                     try:
-                        await emit(
-                            request.context,
-                            "result",
-                            "",
-                            is_error=True,
-                            level="silent",
-                            output=terminal_output_for(request),
-                        )
+                        handled = failure_handler(error)
+                        if inspect.isawaitable(handled):
+                            await handled
                     except Exception:
-                        logger.debug("Failed to emit terminal result for backend exception", exc_info=True)
+                        logger.exception("Failed to report backend exception before Turn release")
+                        await self._emit_exception_terminal_fallback(request)
+                else:
+                    await self._emit_exception_terminal_fallback(request)
             finally:
                 self.release_runtime_turn(request.context)
             raise
+
+    async def _emit_exception_terminal_fallback(self, request: AgentRequest) -> None:
+        """Best-effort settlement for callers without a visible failure owner."""
+
+        emit = getattr(self.controller, "emit_agent_message", None)
+        if not callable(emit):
+            return
+        try:
+            await emit(
+                request.context,
+                "result",
+                "",
+                is_error=True,
+                level="silent",
+                output=terminal_output_for(request),
+            )
+        except Exception:
+            logger.debug("Failed to emit terminal result for backend exception", exc_info=True)
 
     async def clear_sessions(self, session_key: str) -> Dict[str, int]:
         cleared: Dict[str, int] = {}

--- a/tests/scenarios/harness_failure_recovery/catalog.yaml
+++ b/tests/scenarios/harness_failure_recovery/catalog.yaml
@@ -4235,6 +4235,15 @@ scenarios:
     # Exit 124 keeps a once Watch waiting only when listed, then the first event
     # queues one Run and retires normally.
     test: tests/test_watches.py::test_once_watch_retries_timeout_only_when_124_is_allowed
+  - id: HFR-472
+    name: empty failed Turn owns one fallback across all accepted Runs
+    status: covered
+    kind: failure_recovery
+    layer: contract
+    backend: shared
+    # The shared dispatcher stamps one Turn failure identity before the immutable
+    # terminal snapshot; the existing atomic settlement elects one Run owner.
+    test: tests/test_message_dispatcher_result_fallback.py::MessageDispatcherResultFallbackTests::test_hfr_472_empty_failed_turn_creates_one_shared_fallback_contract
 manual_evidence:
   - local Incus backend process death after prompt acceptance
   - local Incus controller restart with persisted queued successor

--- a/tests/scenarios/harness_failure_recovery/catalog.yaml
+++ b/tests/scenarios/harness_failure_recovery/catalog.yaml
@@ -4242,8 +4242,8 @@ scenarios:
     layer: contract
     backend: shared
     # The shared dispatcher stamps one Turn failure identity before participants
-    # arrive; an already shown primary keeps its acknowledgement, and the existing
-    # atomic settlement elects one Run owner only when participants exist.
+    # arrive; backend, handler, and auth-recovery delivery paths preserve an already
+    # shown primary, and atomic settlement elects one owner only when Runs exist.
     test: tests/test_message_dispatcher_result_fallback.py::MessageDispatcherResultFallbackTests::test_hfr_472_empty_failed_turn_creates_one_shared_fallback_contract
 manual_evidence:
   - local Incus backend process death after prompt acceptance

--- a/tests/scenarios/harness_failure_recovery/catalog.yaml
+++ b/tests/scenarios/harness_failure_recovery/catalog.yaml
@@ -4241,8 +4241,9 @@ scenarios:
     kind: failure_recovery
     layer: contract
     backend: shared
-    # The shared dispatcher stamps one Turn failure identity before the immutable
-    # terminal snapshot; the existing atomic settlement elects one Run owner.
+    # The shared dispatcher stamps one Turn failure identity before participants
+    # arrive; an already shown primary keeps its acknowledgement, and the existing
+    # atomic settlement elects one Run owner only when participants exist.
     test: tests/test_message_dispatcher_result_fallback.py::MessageDispatcherResultFallbackTests::test_hfr_472_empty_failed_turn_creates_one_shared_fallback_contract
 manual_evidence:
   - local Incus backend process death after prompt acceptance

--- a/tests/scenarios/harness_failure_recovery/catalog.yaml
+++ b/tests/scenarios/harness_failure_recovery/catalog.yaml
@@ -4243,7 +4243,8 @@ scenarios:
     backend: shared
     # The shared dispatcher stamps one Turn failure identity before participants
     # arrive; backend, handler, and auth-recovery delivery paths preserve an already
-    # shown primary, and atomic settlement elects one owner only when Runs exist.
+    # shown primary at its resolved delivery target, and atomic settlement elects
+    # one owner only when Runs exist.
     test: tests/test_message_dispatcher_result_fallback.py::MessageDispatcherResultFallbackTests::test_hfr_472_empty_failed_turn_creates_one_shared_fallback_contract
 manual_evidence:
   - local Incus backend process death after prompt acceptance

--- a/tests/test_agent_auth_service.py
+++ b/tests/test_agent_auth_service.py
@@ -274,6 +274,78 @@ class AgentAuthServiceTests(_IsolatedClaudeConfigDirMixin, unittest.IsolatedAsyn
             },
         )
 
+    async def test_auth_recovery_does_not_persist_an_undelivered_external_message(self):
+        controller = _StubController()
+        service = AgentAuthService(controller)
+        service._send_message_with_button = AsyncMock(return_value=None)
+        context = MessageContext(
+            user_id="U1",
+            channel_id="C1",
+            platform="slack",
+            platform_specific={
+                "turn_token": "turn-auth-undelivered",
+                "task_execution_id": "run-auth-undelivered",
+            },
+        )
+
+        with patch(
+            "core.message_mirror.persist_agent_message",
+            return_value={"id": "message-auth-undelivered"},
+        ) as persist:
+            handled = await service.maybe_emit_auth_recovery_message(
+                context,
+                "codex",
+                "Codex error: 401 Unauthorized",
+            )
+
+        self.assertTrue(handled)
+        persist.assert_not_called()
+        terminal_output = controller.emit_agent_message.await_args.kwargs["output"]
+        self.assertEqual(
+            terminal_output.metadata["turn_failure_notification"],
+            {
+                "failure_id": "turn:turn-auth-undelivered",
+                "ack_evidence": None,
+                "delivered": False,
+            },
+        )
+
+    async def test_auth_recovery_keeps_local_persistence_without_a_send_id(self):
+        controller = _StubController()
+        service = AgentAuthService(controller)
+        service._send_message_with_button = AsyncMock(return_value=None)
+        context = MessageContext(
+            user_id="U1",
+            channel_id="ses-local",
+            platform="avibe",
+            platform_specific={
+                "turn_token": "turn-auth-local",
+                "task_execution_id": "run-auth-local",
+            },
+        )
+
+        with patch(
+            "core.message_mirror.persist_agent_message",
+            return_value={"id": "message-auth-local"},
+        ) as persist:
+            handled = await service.maybe_emit_auth_recovery_message(
+                context,
+                "codex",
+                "Codex error: 401 Unauthorized",
+            )
+
+        self.assertTrue(handled)
+        persist.assert_called_once()
+        terminal_output = controller.emit_agent_message.await_args.kwargs["output"]
+        self.assertEqual(
+            terminal_output.metadata["turn_failure_notification"],
+            {
+                "failure_id": "turn:turn-auth-local",
+                "ack_evidence": "receipt",
+                "delivered": True,
+            },
+        )
+
     async def test_auth_recovery_sends_and_persists_to_delivery_override(self):
         controller = _StubController()
         source_client = controller.im_client

--- a/tests/test_agent_auth_service.py
+++ b/tests/test_agent_auth_service.py
@@ -240,6 +240,40 @@ class AgentAuthServiceTests(_IsolatedClaudeConfigDirMixin, unittest.IsolatedAsyn
             terminal_error="❌ Codex error: 401 Unauthorized",
         )
 
+    async def test_auth_recovery_carries_primary_receipt_into_turn_settlement(self):
+        controller = _StubController()
+        service = AgentAuthService(controller)
+        context = MessageContext(
+            user_id="U1",
+            channel_id="C1",
+            platform="slack",
+            platform_specific={
+                "turn_token": "turn-auth",
+                "task_execution_id": "run-auth",
+            },
+        )
+
+        with patch(
+            "core.message_mirror.persist_agent_message",
+            return_value={"id": "message-auth"},
+        ):
+            handled = await service.maybe_emit_auth_recovery_message(
+                context,
+                "codex",
+                "❌ Codex error: 401 Unauthorized",
+            )
+
+        self.assertTrue(handled)
+        terminal_output = controller.emit_agent_message.await_args.kwargs["output"]
+        self.assertEqual(
+            terminal_output.metadata["turn_failure_notification"],
+            {
+                "failure_id": "turn:turn-auth",
+                "ack_evidence": "receipt",
+                "delivered": True,
+            },
+        )
+
     async def test_codex_api_key_auth_error_points_to_key_settings_without_oauth_button(self):
         from config.v2_compat import to_app_config
         from config.v2_config import AgentsConfig, RuntimeConfig, SlackConfig, V2Config

--- a/tests/test_agent_auth_service.py
+++ b/tests/test_agent_auth_service.py
@@ -274,6 +274,58 @@ class AgentAuthServiceTests(_IsolatedClaudeConfigDirMixin, unittest.IsolatedAsyn
             },
         )
 
+    async def test_auth_recovery_sends_and_persists_to_delivery_override(self):
+        controller = _StubController()
+        source_client = controller.im_client
+        target_client = _StubIMClient()
+        controller.get_im_client_for_context = lambda context: (
+            target_client if context.platform == "telegram" else source_client
+        )
+        service = AgentAuthService(controller)
+        context = MessageContext(
+            user_id="U-source",
+            channel_id="C-source",
+            platform="slack",
+            platform_specific={
+                "turn_token": "turn-auth-routed",
+                "task_execution_id": "run-auth-routed",
+                "delivery_override": {
+                    "user_id": "U-target",
+                    "channel_id": "C-target",
+                    "platform": "telegram",
+                    "thread_id": "topic-target",
+                },
+            },
+        )
+
+        with patch(
+            "core.message_mirror.persist_agent_message",
+            return_value={"id": "message-auth-routed"},
+        ) as persist:
+            handled = await service.maybe_emit_auth_recovery_message(
+                context,
+                "codex",
+                "❌ Codex error: 401 Unauthorized",
+            )
+
+        self.assertTrue(handled)
+        self.assertEqual(source_client.sent_button_messages, [])
+        self.assertEqual(target_client.sent_button_messages[0][0], "C-target")
+        persisted_context = persist.call_args.args[0]
+        self.assertEqual(
+            (
+                persisted_context.platform,
+                persisted_context.channel_id,
+                persisted_context.thread_id,
+            ),
+            ("telegram", "C-target", "topic-target"),
+        )
+        terminal_call = controller.emit_agent_message.await_args
+        self.assertIs(terminal_call.args[0], context)
+        self.assertTrue(
+            terminal_call.kwargs["output"].metadata["turn_failure_notification"]["delivered"]
+        )
+
     async def test_codex_api_key_auth_error_points_to_key_settings_without_oauth_button(self):
         from config.v2_compat import to_app_config
         from config.v2_config import AgentsConfig, RuntimeConfig, SlackConfig, V2Config

--- a/tests/test_agent_service.py
+++ b/tests/test_agent_service.py
@@ -1425,6 +1425,68 @@ def test_agent_service_releases_gate_when_exception_terminal_emit_fails() -> Non
     asyncio.run(_run())
 
 
+def test_agent_service_reports_backend_failure_before_releasing_runtime_turn() -> None:
+    """A caller-owned failure receipt must reach settlement before Turn release."""
+
+    async def _run() -> None:
+        from core.backend_failure import emit_backend_failure
+
+        controller = _Controller()
+        service = AgentService(controller=controller)
+        controller.agent_service = service
+        service.register(_RaisingRuntimeAgent())
+        request = _request("boom")
+        request.context.platform = "slack"
+        request.context.platform_specific = {
+            "turn_token": "turn-backend-failure",
+            "task_execution_id": "run-backend-failure",
+            "task_trigger_kind": "watch",
+        }
+        emitted: list[tuple[str, object, str]] = []
+
+        async def _emit(_context, message_type, _text, **kwargs):
+            gate = service._turn_gates["session:/repo"]
+            emitted.append((message_type, kwargs.get("output"), gate.token))
+            delivery = kwargs.get("delivery")
+            if message_type == "notify" and delivery is not None:
+                delivery.send_returned = True
+                delivery.delivered_id = "slack-message-1"
+                return delivery.delivered_id
+            return None
+
+        async def _report(error: BaseException) -> None:
+            await emit_backend_failure(
+                controller,
+                request.context,
+                "claude",
+                str(error),
+                display_text=f"Error: {error}",
+                request=request,
+            )
+
+        controller.emit_agent_message = _emit
+        request.failure_handler = _report
+
+        with pytest.raises(RuntimeError, match="backend failed"):
+            await service.handle_message("claude", request)
+
+        assert [message_type for message_type, _output, _token in emitted] == [
+            "notify",
+            "result",
+        ]
+        terminal = emitted[-1][1]
+        assert terminal.metadata["turn_failure_notification"] == {
+            "failure_id": "turn:turn-backend-failure",
+            "ack_evidence": "delivery_only",
+            "delivered": True,
+        }
+        assert all(token for _message_type, _output, token in emitted)
+        assert request.failure_handled is True
+        assert not service._turn_gates["session:/repo"].lock.locked()
+
+    asyncio.run(_run())
+
+
 def test_agent_service_recovers_accepted_turn_when_owned_backend_dies() -> None:
     """A dead accepted backend must release the runtime FIFO without a timeout."""
 

--- a/tests/test_backend_failure.py
+++ b/tests/test_backend_failure.py
@@ -4,7 +4,9 @@ import unittest
 from types import SimpleNamespace
 from unittest.mock import ANY, AsyncMock, call
 
-from core.backend_failure import emit_backend_failure
+from core.backend_failure import emit_backend_failure, terminal_backend_failure_output
+from core.delivery_evidence import DeliveryEvidence
+from core.message_output import MessageOutput
 from modules.agents.base import AgentRequest
 from modules.im import MessageContext
 
@@ -28,6 +30,40 @@ def _request() -> AgentRequest:
 
 
 class BackendFailureTests(unittest.IsolatedAsyncioTestCase):
+    async def test_terminal_contract_never_downgrades_existing_delivery_evidence(
+        self,
+    ) -> None:
+        request = _request()
+        output = MessageOutput(
+            completes_turn=True,
+            completes_run=True,
+            metadata={
+                "turn_failure_notification": {
+                    "failure_id": "turn:turn-1",
+                    "ack_evidence": "receipt",
+                    "delivered": True,
+                    "fallback_run_id": "run-owner",
+                }
+            },
+        )
+
+        merged = terminal_backend_failure_output(
+            request.context,
+            request=request,
+            output=output,
+            delivery=DeliveryEvidence(),
+        )
+
+        self.assertEqual(
+            merged.metadata["turn_failure_notification"],
+            {
+                "failure_id": "turn:turn-1",
+                "ack_evidence": "receipt",
+                "delivered": True,
+                "fallback_run_id": "run-owner",
+            },
+        )
+
     async def test_turn_without_current_runs_preserves_primary_delivery_for_late_runs(
         self,
     ) -> None:

--- a/tests/test_backend_failure.py
+++ b/tests/test_backend_failure.py
@@ -28,6 +28,43 @@ def _request() -> AgentRequest:
 
 
 class BackendFailureTests(unittest.IsolatedAsyncioTestCase):
+    async def test_turn_without_current_runs_preserves_primary_delivery_for_late_runs(
+        self,
+    ) -> None:
+        request = _request()
+        emissions = []
+
+        async def emit(context, message_type, text, **kwargs):
+            emissions.append((message_type, text, kwargs))
+            evidence = kwargs.get("delivery")
+            if message_type == "notify" and evidence is not None:
+                evidence.persisted_row = {"id": "msg-primary"}
+                return "msg-primary"
+            return None
+
+        controller = SimpleNamespace(
+            agent_auth_service=SimpleNamespace(),
+            emit_agent_message=emit,
+        )
+
+        await emit_backend_failure(
+            controller,
+            request.context,
+            "codex",
+            "provider unavailable",
+            request=request,
+        )
+
+        terminal_output = emissions[1][2]["output"]
+        self.assertEqual(
+            terminal_output.metadata["turn_failure_notification"],
+            {
+                "failure_id": "turn-1",
+                "ack_evidence": "receipt",
+                "delivered": True,
+            },
+        )
+
     async def test_harness_turn_notifies_live_and_carries_delivery_evidence_to_settlement(
         self,
     ) -> None:
@@ -258,14 +295,18 @@ class BackendFailureTests(unittest.IsolatedAsyncioTestCase):
                 request=request,
             )
 
-        controller.emit_agent_message.assert_awaited_once_with(
-            request.context,
-            "result",
-            "",
-            is_error=True,
-            level="silent",
-            output=request.output,
-            terminal_error="401 Unauthorized",
+        terminal_call = controller.emit_agent_message.await_args
+        self.assertEqual(terminal_call.args, (request.context, "result", ""))
+        self.assertTrue(terminal_call.kwargs["is_error"])
+        self.assertEqual(terminal_call.kwargs["level"], "silent")
+        self.assertEqual(terminal_call.kwargs["terminal_error"], "401 Unauthorized")
+        self.assertEqual(
+            terminal_call.kwargs["output"].metadata["turn_failure_notification"],
+            {
+                "failure_id": "turn-1",
+                "ack_evidence": None,
+                "delivered": False,
+            },
         )
 
     async def test_separates_notify_from_terminal_settlement(self) -> None:
@@ -293,7 +334,6 @@ class BackendFailureTests(unittest.IsolatedAsyncioTestCase):
             (request.context, "codex", "Codex failed: provider unavailable"),
         )
         self.assertEqual(auth_call.kwargs["terminal_error"], "provider unavailable")
-        terminal_output = auth_call.kwargs["output"]
         notify_call, terminal_call = controller.emit_agent_message.await_args_list
         self.assertEqual(
             notify_call,
@@ -302,6 +342,7 @@ class BackendFailureTests(unittest.IsolatedAsyncioTestCase):
                 "notify",
                 "Codex failed: provider unavailable",
                 output=ANY,
+                delivery=ANY,
             ),
         )
         self.assertFalse(notify_call.kwargs["output"].settles_run)
@@ -325,9 +366,17 @@ class BackendFailureTests(unittest.IsolatedAsyncioTestCase):
                 "",
                 is_error=True,
                 level="silent",
-                output=terminal_output,
+                output=ANY,
                 terminal_error="provider unavailable",
             ),
+        )
+        self.assertEqual(
+            terminal_call.kwargs["output"].metadata["turn_failure_notification"],
+            {
+                "failure_id": "turn-1",
+                "ack_evidence": "delivery_only",
+                "delivered": False,
+            },
         )
 
     async def test_identity_is_stable_for_duplicate_terminal_events(self) -> None:
@@ -377,14 +426,15 @@ class BackendFailureTests(unittest.IsolatedAsyncioTestCase):
                 request=request,
             )
 
+        self.assertEqual(len(terminal_calls), 1)
+        self.assertTrue(terminal_calls[0]["is_error"])
+        self.assertEqual(terminal_calls[0]["level"], "silent")
+        self.assertEqual(terminal_calls[0]["terminal_error"], "transport failed")
         self.assertEqual(
-            terminal_calls,
-            [
-                {
-                    "is_error": True,
-                    "level": "silent",
-                    "output": request.output,
-                    "terminal_error": "transport failed",
-                }
-            ],
+            terminal_calls[0]["output"].metadata["turn_failure_notification"],
+            {
+                "failure_id": "turn-1",
+                "ack_evidence": None,
+                "delivered": False,
+            },
         )

--- a/tests/test_backend_failure.py
+++ b/tests/test_backend_failure.py
@@ -291,6 +291,42 @@ class BackendFailureTests(unittest.IsolatedAsyncioTestCase):
                 self.assertEqual(notification["ack_evidence"], "delivery_only")
                 self.assertIs(notification["delivered"], expected)
 
+    async def test_delivery_only_ack_fails_closed_without_target_platform(
+        self,
+    ) -> None:
+        request = _request()
+        request.context.platform = None
+        emissions = []
+
+        async def emit(_context, message_type, _text, **kwargs):
+            emissions.append((message_type, kwargs))
+            evidence = kwargs.get("delivery")
+            if message_type == "notify" and evidence is not None:
+                evidence.delivered_id = "synthetic-id"
+                evidence.send_returned = True
+            return None
+
+        controller = SimpleNamespace(
+            agent_auth_service=SimpleNamespace(
+                maybe_emit_auth_recovery_message=AsyncMock(return_value=False)
+            ),
+            emit_agent_message=emit,
+        )
+
+        await emit_backend_failure(
+            controller,
+            request.context,
+            "codex",
+            "stream disconnected",
+            request=request,
+        )
+
+        notification = emissions[1][1]["output"].metadata[
+            "turn_failure_notification"
+        ]
+        self.assertEqual(notification["ack_evidence"], "delivery_only")
+        self.assertFalse(notification["delivered"])
+
     async def test_auth_recovery_owns_the_only_terminal_settlement(self) -> None:
         request = _request()
         controller = SimpleNamespace(

--- a/tests/test_message_dispatcher_result_fallback.py
+++ b/tests/test_message_dispatcher_result_fallback.py
@@ -284,6 +284,41 @@ class MessageDispatcherResultFallbackTests(unittest.IsolatedAsyncioTestCase):
         )
         self.assertEqual(controller.im_client.sent_messages, [])
 
+    async def test_hfr_472_contract_is_snapshotted_before_the_first_run_arrives(self):
+        controller = self._terminal_lifecycle_controller()
+        dispatcher = ConsolidatedMessageDispatcher(controller)
+        dispatcher._collapse_status_bubble = mock.AsyncMock()
+        dispatcher._clear_consolidated_state = mock.AsyncMock()
+        context = MessageContext(
+            user_id="U1",
+            channel_id="C1",
+            platform="slack",
+            platform_specific={
+                "agent_runtime_turn_key": "runtime-1",
+                "agent_runtime_turn_token": "runtime-turn-1",
+                "turn_token": "turn-before-run",
+            },
+        )
+
+        await dispatcher.emit_agent_message(
+            context,
+            "result",
+            "",
+            is_error=True,
+            output=MessageOutput(completes_turn=True, completes_run=True),
+        )
+
+        evidence = controller.session_turns.on_terminal_result.call_args.kwargs[
+            "terminal_evidence"
+        ]
+        self.assertEqual(
+            evidence["output_provenance"]["turn_failure_notification"],
+            {
+                "failure_id": "turn:turn-before-run",
+                "delivered": False,
+            },
+        )
+
     def test_visible_direct_error_does_not_create_a_turn_fallback_contract(self):
         dispatcher = ConsolidatedMessageDispatcher(_StubController(platform="slack"))
         context = MessageContext(

--- a/tests/test_message_dispatcher_result_fallback.py
+++ b/tests/test_message_dispatcher_result_fallback.py
@@ -229,6 +229,85 @@ class MessageDispatcherResultFallbackTests(unittest.IsolatedAsyncioTestCase):
         )
         store.get_run.assert_not_called()
 
+    async def test_hfr_472_empty_failed_turn_creates_one_shared_fallback_contract(self):
+        controller = self._terminal_lifecycle_controller()
+        dispatcher = ConsolidatedMessageDispatcher(controller)
+        dispatcher._collapse_status_bubble = mock.AsyncMock()
+        dispatcher._clear_consolidated_state = mock.AsyncMock()
+        context = MessageContext(
+            user_id="U1",
+            channel_id="C1",
+            platform="slack",
+            platform_specific={
+                "agent_runtime_turn_key": "runtime-1",
+                "agent_runtime_turn_token": "runtime-turn-1",
+                "turn_token": "turn-empty-failure",
+                "accepted_agent_run_ids": ["run-b", "run-a"],
+            },
+        )
+        store = mock.Mock()
+        store.get_run.side_effect = lambda run_id: {
+            "run-a": {"id": "run-a", "status": "running"},
+            "run-b": {"id": "run-b", "status": "running"},
+        }.get(run_id)
+
+        with mock.patch(
+            "core.message_dispatcher.SQLiteBackgroundTaskStore",
+            return_value=store,
+        ):
+            await dispatcher.emit_agent_message(
+                context,
+                "result",
+                "",
+                is_error=True,
+                output=MessageOutput(completes_turn=True, completes_run=True),
+            )
+
+        evidence = controller.session_turns.on_terminal_result.call_args.kwargs[
+            "terminal_evidence"
+        ]
+        notification = evidence["output_provenance"]["turn_failure_notification"]
+        self.assertEqual(
+            notification,
+            {
+                "failure_id": "turn:turn-empty-failure",
+                "delivered": False,
+                "fallback_run_id": "run-a",
+            },
+        )
+        store.record_turn_run_outputs.assert_called_once()
+        record_call = store.record_turn_run_outputs.call_args
+        self.assertEqual(record_call.args[0], ["run-b", "run-a"])
+        self.assertEqual(
+            record_call.kwargs["provenance"]["turn_failure_notification"],
+            notification,
+        )
+        self.assertEqual(controller.im_client.sent_messages, [])
+
+    def test_visible_direct_error_does_not_create_a_turn_fallback_contract(self):
+        dispatcher = ConsolidatedMessageDispatcher(_StubController(platform="slack"))
+        context = MessageContext(
+            user_id="U1",
+            channel_id="C1",
+            platform="slack",
+            platform_specific={
+                "turn_token": "turn-visible-error",
+                "accepted_agent_run_ids": ["run-a", "run-b"],
+            },
+        )
+        output = MessageOutput(completes_turn=True, completes_run=True)
+
+        unchanged = dispatcher._output_with_implicit_turn_failure_notification(
+            context,
+            output,
+            is_error=True,
+            has_visible_result=True,
+            mutates_turn_lifecycle=True,
+        )
+
+        self.assertIs(unchanged, output)
+        self.assertNotIn("turn_failure_notification", unchanged.metadata)
+
     async def test_detached_stale_result_delivers_without_mutating_newer_turn(self):
         controller = _StubController(platform="slack")
         controller.agent_service = type(

--- a/tests/test_message_handler_missing_agent.py
+++ b/tests/test_message_handler_missing_agent.py
@@ -5,6 +5,7 @@ from types import SimpleNamespace
 import anyio
 
 from core.handlers.message_handler import MessageHandler
+from modules.agents.base import AgentRequest
 from modules.im import MessageContext
 
 
@@ -26,13 +27,23 @@ class _StubController:
         self.session_manager = SimpleNamespace()
         self.receiver_tasks = {}
         self.agent_service = SimpleNamespace(default_agent="claude", agents={})
+        self.agent_auth_service = SimpleNamespace()
         self.vibe_agent_store = SimpleNamespace(get=lambda _name: None)
+        self.emissions = []
 
     def get_im_client_for_context(self, context):
         return self.im_client
 
     def _get_lang(self) -> str:
         return "zh"
+
+    async def emit_agent_message(self, context, message_type, text, **kwargs):
+        self.emissions.append((message_type, text, kwargs))
+        evidence = kwargs.get("delivery")
+        if message_type == "notify" and evidence is not None:
+            evidence.persisted_row = {"id": "msg-primary"}
+            return "msg-primary"
+        return None
 
 
 def test_missing_opencode_agent_hint_does_not_mention_codex():
@@ -51,3 +62,48 @@ def test_missing_opencode_agent_hint_does_not_mention_codex():
     assert "OpenCode" in sent
     assert "OPENCODE_CLI_PATH" in sent
     assert "Codex" not in sent
+
+
+def test_dispatched_missing_agent_preserves_primary_delivery_in_terminal_contract():
+    controller = _StubController()
+    handler = MessageHandler(controller)
+    context = MessageContext(
+        user_id="U1",
+        channel_id="C1",
+        platform="avibe",
+        platform_specific={
+            "turn_token": "turn-missing-agent",
+            "task_execution_id": "run-missing-agent",
+            "task_trigger_kind": "scheduled",
+        },
+    )
+    request = AgentRequest(
+        context=context,
+        message="work",
+        user_message="work",
+        working_path="/tmp/work",
+        base_session_id="session-1",
+        composite_session_id="session-1:/tmp/work",
+        session_key="avibe::project::p1",
+    )
+
+    async def run() -> None:
+        await handler._handle_missing_agent(
+            context,
+            "opencode",
+            request=request,
+        )
+
+    anyio.run(run)
+
+    assert [message_type for message_type, _text, _kwargs in controller.emissions] == [
+        "notify",
+        "result",
+    ]
+    terminal = controller.emissions[1][2]["output"]
+    assert terminal.metadata["turn_failure_notification"] == {
+        "failure_id": "turn:turn-missing-agent",
+        "ack_evidence": "receipt",
+        "delivered": True,
+    }
+    assert controller.im_client.sent == []

--- a/tests/test_message_handler_typing.py
+++ b/tests/test_message_handler_typing.py
@@ -1568,6 +1568,47 @@ class MessageHandlerTypingTests(unittest.IsolatedAsyncioTestCase):
             },
         )
 
+    async def test_handled_backend_key_error_is_not_reclassified_as_missing_agent(self):
+        controller = _StubController(platform="slack", ack_mode="reaction", typing_result=True)
+
+        async def fail_after_dispatch(_agent_name, request):
+            error = KeyError("backend config")
+            request.failure_handled = True
+            await request.failure_handler(error)
+            raise error
+
+        controller.agent_service.handle_message = fail_after_dispatch
+
+        async def emit(context, message_type, text, **kwargs):
+            if message_type == "notify":
+                delivered_id = await controller.im_client.send_message(context, text)
+                delivery = kwargs["delivery"]
+                delivery.send_returned = True
+                delivery.delivered_id = delivered_id
+                return delivered_id
+            return None
+
+        controller.emit_agent_message = AsyncMock(side_effect=emit)
+        handler = MessageHandler(controller)
+        handler.set_session_handler(_StubSessionHandler())
+        context = MessageContext(
+            user_id="scheduled",
+            channel_id="C1",
+            message_id="scheduled:task-1:key-error",
+            platform="slack",
+            platform_specific={
+                "turn_token": "turn-scheduled-key-error",
+                "task_execution_id": "run-scheduled-key-error",
+            },
+        )
+
+        result = await handler.handle_scheduled_message(context, "hello")
+
+        self.assertEqual(result, "'backend config'")
+        self.assertEqual(controller.im_client.sent_messages, [("C1", "Error: 'backend config'")])
+        self.assertEqual(controller.emit_agent_message.await_count, 2)
+        self.assertNotIn("not available", controller.im_client.sent_messages[0][1])
+
     async def test_durable_scheduled_turn_does_not_mirror_before_acceptance(self):
         controller = _StubController(platform="slack", ack_mode="reaction", typing_result=True)
         handler = MessageHandler(controller)

--- a/tests/test_message_handler_typing.py
+++ b/tests/test_message_handler_typing.py
@@ -204,9 +204,20 @@ class _StubController:
         is_error=False,
         level="normal",
         output=None,
+        terminal_error=None,
+        delivery=None,
     ):
         # Terminal error results settle the dot + release the SSE waiter via the
         # outbound chokepoint; a no-op here (these are IM turns, no workbench dot).
+        if message_type == "notify":
+            delivered_id = await self.get_im_client_for_context(context).send_message(
+                context,
+                text,
+            )
+            if delivery is not None:
+                delivery.send_returned = True
+                delivery.delivered_id = delivered_id
+            return delivered_id
         return None
 
     def get_im_client_for_context(self, context):
@@ -491,8 +502,12 @@ class MessageHandlerTypingTests(unittest.IsolatedAsyncioTestCase):
         )
 
         self.assertEqual(error, "context preparation failed")
-        controller.emit_agent_message.assert_awaited_once()
-        call = controller.emit_agent_message.await_args
+        self.assertEqual(controller.emit_agent_message.await_count, 2)
+        notify_call, call = controller.emit_agent_message.await_args_list
+        self.assertEqual(
+            notify_call.args[:3],
+            (context, "notify", "Error: context preparation failed"),
+        )
         self.assertEqual(call.args[:3], (context, "result", ""))
         output = call.kwargs["output"]
         self.assertTrue(output.completes_turn)
@@ -1512,7 +1527,17 @@ class MessageHandlerTypingTests(unittest.IsolatedAsyncioTestCase):
     async def test_scheduled_turn_returns_error_string_after_notifying_im(self):
         controller = _StubController(platform="slack", ack_mode="reaction", typing_result=True)
         controller.agent_service.error = RuntimeError("boom")
-        controller.emit_agent_message = AsyncMock(return_value=None)
+
+        async def emit(context, message_type, text, **kwargs):
+            if message_type == "notify":
+                delivered_id = await controller.im_client.send_message(context, text)
+                delivery = kwargs["delivery"]
+                delivery.send_returned = True
+                delivery.delivered_id = delivered_id
+                return delivered_id
+            return None
+
+        controller.emit_agent_message = AsyncMock(side_effect=emit)
         handler = MessageHandler(controller)
         handler.set_session_handler(_StubSessionHandler())
         context = MessageContext(
@@ -1530,6 +1555,9 @@ class MessageHandlerTypingTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(result, "boom")
         self.assertEqual(controller.im_client.sent_messages, [("C1", "Error: boom")])
+        self.assertEqual(controller.emit_agent_message.await_count, 2)
+        notify_call, _terminal_call = controller.emit_agent_message.await_args_list
+        self.assertEqual(notify_call.args[:3], (context, "notify", "Error: boom"))
         terminal_output = controller.emit_agent_message.await_args.kwargs["output"]
         self.assertEqual(
             terminal_output.metadata["turn_failure_notification"],

--- a/tests/test_message_handler_typing.py
+++ b/tests/test_message_handler_typing.py
@@ -1512,6 +1512,7 @@ class MessageHandlerTypingTests(unittest.IsolatedAsyncioTestCase):
     async def test_scheduled_turn_returns_error_string_after_notifying_im(self):
         controller = _StubController(platform="slack", ack_mode="reaction", typing_result=True)
         controller.agent_service.error = RuntimeError("boom")
+        controller.emit_agent_message = AsyncMock(return_value=None)
         handler = MessageHandler(controller)
         handler.set_session_handler(_StubSessionHandler())
         context = MessageContext(
@@ -1519,12 +1520,25 @@ class MessageHandlerTypingTests(unittest.IsolatedAsyncioTestCase):
             channel_id="C1",
             message_id="scheduled:task-1:abc",
             platform="slack",
+            platform_specific={
+                "turn_token": "turn-scheduled-error",
+                "task_execution_id": "run-scheduled-error",
+            },
         )
 
         result = await handler.handle_scheduled_message(context, "hello")
 
         self.assertEqual(result, "boom")
         self.assertEqual(controller.im_client.sent_messages, [("C1", "Error: boom")])
+        terminal_output = controller.emit_agent_message.await_args.kwargs["output"]
+        self.assertEqual(
+            terminal_output.metadata["turn_failure_notification"],
+            {
+                "failure_id": "turn:turn-scheduled-error",
+                "ack_evidence": "delivery_only",
+                "delivered": True,
+            },
+        )
 
     async def test_durable_scheduled_turn_does_not_mirror_before_acceptance(self):
         controller = _StubController(platform="slack", ack_mode="reaction", typing_result=True)


### PR DESCRIPTION
## Capability

Deduplicate Harness failure notifications when one Agent Turn settles failed without returning a visible result.

## Root cause

A failed empty terminal result carried Turn provenance but no `turn_failure_notification` contract. Each Run accepted into that Turn therefore derived an independent Run-scoped owed notice, so one failed Turn could emit dozens of `[Avibe Harness]` notifications. Error delivery and Turn settlement also had separate owners in the generic handler and auth-recovery paths, so later settlement could erase evidence that the user had already received the primary error.

## Changes

- synthesize the existing Turn failure notification contract for an invisible failed terminal that owns Harness Runs
- stamp the contract before the immutable Turn snapshot even when participants have not arrived yet
- centralize terminal failure evidence composition in the shared backend-failure boundary
- route generic handler failures through the shared backend-failure dispatcher
- resolve dispatcher, auth-recovery, and acknowledgement policy through one delivery-target helper
- carry auth-recovery send/persist evidence into the same monotonic Turn contract
- route dispatched missing-Agent failures through the shared backend-failure emitter
- reuse the existing atomic fallback-owner election when participants are present
- keep visible direct errors, user stops, contained backend refreshes, detached outputs, and stale Turn outputs on their existing paths
- register scenario `HFR-472` and refine the `HFR-442` boundary wording

## Scenarios

- `HFR-472`: empty failed Turn owns one fallback across all accepted Runs
- `HFR-442`: visible direct errors with bare Turn provenance remain under definition-level policy
- `HFR-438`: a missing primary Turn notification still emits exactly one fallback

## Evidence

- Unit: backend failure, auth recovery, message handler, missing-Agent, scheduled dispatcher, and fallback suites, 281 tests plus 19 subtests passed
- Contract: `HFR-472` proves one shared failure identity, one atomic multi-Run write, pre-participant snapshot persistence, target-correct routing, and monotonic primary-delivery preservation
- Scenario: Harness failure visibility and scheduled task settlement suites, 670 tests passed; dispatcher routing, status, and mirror suites, 106 tests passed
- Static: Ruff and `git diff --check` passed
- Residual manual: reproduce an empty failed Turn with multiple accepted Runs in local Incus and confirm exactly one fallback notification
