### PR TITLE
fix(config): serialize config read modify writes

### DIFF
--- a/config/v2_config.py
+++ b/config/v2_config.py
@@ -1639,7 +1639,7 @@ class V2Config:
         self,
         config_path: Optional[Path] = None,
         *,
-        preserve_memory: bool = True,
+        preserve_memory: bool = False,
     ) -> None:
         paths.ensure_data_dirs()
         path = config_path or paths.get_config_path()

--- a/config/v2_config.py
+++ b/config/v2_config.py
@@ -5,10 +5,11 @@ import os
 import re
 import tempfile
 import threading
+from contextlib import contextmanager
 from dataclasses import dataclass, field, fields
 from datetime import datetime
 from pathlib import Path
-from typing import List, Literal, Mapping, Optional, Union
+from typing import Iterator, List, Literal, Mapping, Optional, Union
 from urllib.parse import urlsplit, urlunsplit
 
 from config import paths
@@ -28,6 +29,47 @@ from vibe.i18n import normalize_language
 logger = logging.getLogger(__name__)
 
 CONFIG_LOCK = threading.RLock()
+_CONFIG_WRITE_TRANSACTION = threading.local()
+CONFIG_WRITE_LOCK_TIMEOUT_SECONDS = 30.0
+
+
+@contextmanager
+def config_write_transaction(
+    config_path: Optional[Path] = None,
+) -> Iterator[Path]:
+    """Serialize config RMW with process-first ordering and bounded file locking.
+
+    Same-path nesting reuses the outer file lock; different-path nesting is
+    rejected so callers cannot introduce a cross-file lock-order inversion.
+    """
+
+    paths.ensure_data_dirs()
+    path = config_path or paths.get_config_path()
+    transaction_key = path.resolve(strict=False)
+    lock_path = transaction_key.with_name(f".{transaction_key.name}.lock")
+
+    with CONFIG_LOCK:
+        active_key = getattr(_CONFIG_WRITE_TRANSACTION, "key", None)
+        if active_key is not None:
+            if active_key != transaction_key:
+                raise RuntimeError(
+                    "Cannot nest config write transactions for different paths: "
+                    f"{active_key} and {transaction_key}"
+                )
+            yield path
+            return
+
+        from storage.lock import MigrationFileLock
+
+        with MigrationFileLock(
+            lock_path,
+            timeout_seconds=CONFIG_WRITE_LOCK_TIMEOUT_SECONDS,
+        ):
+            _CONFIG_WRITE_TRANSACTION.key = transaction_key
+            try:
+                yield path
+            finally:
+                del _CONFIG_WRITE_TRANSACTION.key
 
 DEFAULT_AGENT_IDLE_TIMEOUT_SECONDS = 600
 
@@ -1593,7 +1635,12 @@ class V2Config:
 
         return config
 
-    def save(self, config_path: Optional[Path] = None) -> None:
+    def save(
+        self,
+        config_path: Optional[Path] = None,
+        *,
+        preserve_memory: bool = True,
+    ) -> None:
         paths.ensure_data_dirs()
         path = config_path or paths.get_config_path()
         self.platforms.validate()
@@ -1659,9 +1706,19 @@ class V2Config:
             "agent_status_no_output_ms": self.agent_status_no_output_ms,
             "setup_completed": self.setup_completed,
         }
-        content = json.dumps(payload, indent=2)
         path.parent.mkdir(parents=True, exist_ok=True)
-        with CONFIG_LOCK:
+        with config_write_transaction(path):
+            if preserve_memory and path.exists():
+                current_payload = json.loads(path.read_text(encoding="utf-8"))
+                current_memory = (
+                    current_payload.get("memory")
+                    if isinstance(current_payload, dict)
+                    else None
+                )
+                if isinstance(current_memory, dict):
+                    payload["memory"] = current_memory
+                    self.memory = V2Config.from_payload(current_payload).memory
+            content = json.dumps(payload, indent=2)
             with tempfile.NamedTemporaryFile("w", encoding="utf-8", dir=path.parent, delete=False) as tmp:
                 tmp.write(content)
                 tmp.flush()

--- a/config/v2_config.py
+++ b/config/v2_config.py
@@ -48,23 +48,23 @@ def config_write_transaction(
     transaction_key = path.resolve(strict=False)
     lock_path = transaction_key.with_name(f".{transaction_key.name}.lock")
 
-    with CONFIG_LOCK:
-        active_key = getattr(_CONFIG_WRITE_TRANSACTION, "key", None)
-        if active_key is not None:
-            if active_key != transaction_key:
-                raise RuntimeError(
-                    "Cannot nest config write transactions for different paths: "
-                    f"{active_key} and {transaction_key}"
-                )
-            yield path
-            return
+    active_key = getattr(_CONFIG_WRITE_TRANSACTION, "key", None)
+    if active_key is not None:
+        if active_key != transaction_key:
+            raise RuntimeError(
+                "Cannot nest config write transactions for different paths: "
+                f"{active_key} and {transaction_key}"
+            )
+        yield path
+        return
 
-        from storage.lock import MigrationFileLock
+    from storage.lock import MigrationFileLock
 
-        with MigrationFileLock(
-            lock_path,
-            timeout_seconds=CONFIG_WRITE_LOCK_TIMEOUT_SECONDS,
-        ):
+    with MigrationFileLock(
+        lock_path,
+        timeout_seconds=CONFIG_WRITE_LOCK_TIMEOUT_SECONDS,
+    ):
+        with CONFIG_LOCK:
             _CONFIG_WRITE_TRANSACTION.key = transaction_key
             try:
                 yield path

--- a/core/agent_auth_service.py
+++ b/core/agent_auth_service.py
@@ -1285,11 +1285,27 @@ class AgentAuthService:
         doesn't lie about a partial sign-out. ``prepare_start`` persists
         pre-command state and may return a spawn-failure restoration.
         """
-        restore_on_spawn_failure = (
-            await run_blocking(prepare_start)
-            if prepare_start is not None
-            else None
-        )
+        restore_on_spawn_failure = None
+        if prepare_start is not None:
+            prepare_task = asyncio.create_task(asyncio.to_thread(prepare_start))
+            try:
+                restore_on_spawn_failure = await asyncio.shield(prepare_task)
+            except asyncio.CancelledError as cancellation:
+                while not prepare_task.done():
+                    try:
+                        await asyncio.shield(prepare_task)
+                    except asyncio.CancelledError:
+                        continue
+                    except Exception:
+                        break
+                if not prepare_task.cancelled() and prepare_task.exception() is None:
+                    restore = prepare_task.result()
+                    if restore is not None:
+                        try:
+                            await run_blocking(restore)
+                        except asyncio.CancelledError:
+                            pass
+                raise cancellation
         try:
             process = await asyncio.create_subprocess_exec(
                 *cmd,

--- a/core/agent_auth_service.py
+++ b/core/agent_auth_service.py
@@ -38,7 +38,7 @@ from modules.agents.opencode.utils import (
     resolve_opencode_reasoning_effort,
 )
 from modules.im import InlineButton, InlineKeyboard, MessageContext
-from core.memory.blocking import run_blocking
+from core.blocking import CancellationSettlement, run_blocking
 from core.resource_governance import governor_from_controller
 from core.message_output import MessageOutput, terminal_turn_output
 from vibe.i18n import t as i18n_t
@@ -1472,9 +1472,15 @@ class AgentAuthService:
             await flow.reader_task
             ok, detail = await self._verify_login(flow)
             if ok:
+                settlement = CancellationSettlement()
                 if flow.backend == "codex":
-                    await self._persist_backend_auth_mode(flow.backend, "oauth")
-                await self._refresh_backend_runtime(flow.backend)
+                    await self._persist_backend_auth_mode(
+                        flow.backend,
+                        "oauth",
+                        settlement=settlement,
+                    )
+                await settlement.wait(self._refresh_backend_runtime(flow.backend))
+                settlement.raise_if_cancelled()
                 await self._send_message(
                     flow.context,
                     f"✅ {self._t('command.setup.success', backend=flow.backend)}",
@@ -1524,9 +1530,20 @@ class AgentAuthService:
             flow.force_oauth = True
             ok, detail = await self._verify_login(flow)
             if ok:
-                await self._persist_backend_auth_mode(flow.backend, "oauth")
-                await self._finish_claude_oauth_attempt(flow.claude_oauth_attempt, succeeded=True)
-                await self._refresh_backend_runtime(flow.backend)
+                settlement = CancellationSettlement()
+                await self._persist_backend_auth_mode(
+                    flow.backend,
+                    "oauth",
+                    settlement=settlement,
+                )
+                await settlement.wait(
+                    self._finish_claude_oauth_attempt(
+                        flow.claude_oauth_attempt,
+                        succeeded=True,
+                    )
+                )
+                await settlement.wait(self._refresh_backend_runtime(flow.backend))
+                settlement.raise_if_cancelled()
                 await self._send_message(
                     flow.context,
                     f"✅ {self._t('command.setup.success', backend=flow.backend)}",
@@ -2180,12 +2197,14 @@ class AgentAuthService:
                     env=self._build_claude_full_subprocess_env(force_oauth=True),
                 )
 
+        settlement = CancellationSettlement()
         try:
             await self._save_backend_auth_fields(
                 backend,
                 "oauth",
                 clear_credentials=True,
                 mark_mode_explicit=backend == "claude",
+                settlement=settlement,
             )
         except Exception as err:  # noqa: BLE001
             # Disk state has already been cleared; surface the V2Config
@@ -2199,9 +2218,10 @@ class AgentAuthService:
         hook = self._post_web_success_hook
         if callable(hook):
             try:
-                await asyncio.to_thread(hook, backend)
+                await settlement.run_blocking(hook, backend)
             except Exception as err:  # noqa: BLE001
                 logger.warning("post_web_success_hook failed after remove for %s: %s", backend, err)
+        settlement.raise_if_cancelled()
         # Surface logout failures even though V2Config was cleared. The
         # on-disk credentials may still be intact (e.g. ``codex logout``
         # missing, exited non-zero, or timed out), and the user needs
@@ -3117,8 +3137,13 @@ class AgentAuthService:
             flow.state = "verifying"
             ok, detail = await self._verify_web_login(flow.backend, force_oauth=flow.backend == "claude")
             if ok:
-                await self._invoke_post_web_success_hook(flow.backend)
-                await self._refresh_backend_runtime(flow.backend)
+                settlement = CancellationSettlement()
+                await self._invoke_post_web_success_hook(
+                    flow.backend,
+                    settlement=settlement,
+                )
+                await settlement.wait(self._refresh_backend_runtime(flow.backend))
+                settlement.raise_if_cancelled()
                 flow.state = "success"
             else:
                 flow.state = "failed"
@@ -3151,9 +3176,19 @@ class AgentAuthService:
                 claude_oauth_attempt=flow.claude_oauth_attempt,
             )
             if ok:
-                await self._invoke_post_web_success_hook(flow.backend)
-                await self._finish_claude_oauth_attempt(flow.claude_oauth_attempt, succeeded=True)
-                await self._refresh_backend_runtime(flow.backend)
+                settlement = CancellationSettlement()
+                await self._invoke_post_web_success_hook(
+                    flow.backend,
+                    settlement=settlement,
+                )
+                await settlement.wait(
+                    self._finish_claude_oauth_attempt(
+                        flow.claude_oauth_attempt,
+                        succeeded=True,
+                    )
+                )
+                await settlement.wait(self._refresh_backend_runtime(flow.backend))
+                settlement.raise_if_cancelled()
                 flow.state = "success"
             else:
                 await self._finish_claude_oauth_attempt(flow.claude_oauth_attempt, succeeded=False)
@@ -3209,7 +3244,12 @@ class AgentAuthService:
                 if task and not task.done():
                     task.cancel()
 
-    async def _invoke_post_web_success_hook(self, backend: str) -> None:
+    async def _invoke_post_web_success_hook(
+        self,
+        backend: str,
+        *,
+        settlement: CancellationSettlement | None = None,
+    ) -> None:
         # OAuth completed via the web UI implies the user wants
         # ``auth_mode = "oauth"``. Persist it before the controller-refresh
         # hook fires so the live agent reloads with the right mode rather
@@ -3222,15 +3262,25 @@ class AgentAuthService:
         # Skipped for opencode: ``OpenCodeConfig`` has no ``auth_mode``
         # field (auth is per-provider, not global), so persisting one
         # would add a stray attribute and could mislead future readers.
+        owns_settlement = settlement is None
+        settlement = settlement or CancellationSettlement()
         if backend != "opencode":
-            await self._persist_backend_auth_mode(backend, "oauth")
+            await self._persist_backend_auth_mode(
+                backend,
+                "oauth",
+                settlement=settlement,
+            )
         hook = self._post_web_success_hook
         if not callable(hook):
+            if owns_settlement:
+                settlement.raise_if_cancelled()
             return
         try:
-            await asyncio.to_thread(hook, backend)
+            await settlement.run_blocking(hook, backend)
         except Exception as err:  # noqa: BLE001
             logger.warning("post_web_success_hook failed for %s: %s", backend, err)
+        if owns_settlement:
+            settlement.raise_if_cancelled()
 
     async def _clear_claude_settings_env_for_oauth(self) -> None:
         try:
@@ -3533,24 +3583,35 @@ class AgentAuthService:
         """Backward-compatible name for API-key save cleanup."""
         return await self.clear_claude_oauth_credentials_only()
 
-    async def _persist_backend_auth_mode(self, backend: str, auth_mode: str) -> None:
+    async def _persist_backend_auth_mode(
+        self,
+        backend: str,
+        auth_mode: str,
+        *,
+        settlement: CancellationSettlement | None = None,
+    ) -> None:
         """Persist V2Config.agents.<backend>.auth_mode for web and IM flows."""
+        owns_settlement = settlement is None
+        settlement = settlement or CancellationSettlement()
         if backend == "claude" and auth_mode == "oauth":
-            await self._clear_claude_settings_env_for_oauth()
+            await settlement.wait(self._clear_claude_settings_env_for_oauth())
         if backend == "codex" and auth_mode == "oauth":
-            await self._clear_codex_api_key_for_oauth()
+            await settlement.wait(self._clear_codex_api_key_for_oauth())
         try:
             await self._save_backend_auth_fields(
                 backend,
                 auth_mode,
                 clear_credentials=backend == "codex" and auth_mode == "oauth",
                 mark_mode_explicit=backend == "claude",
+                settlement=settlement,
             )
         except Exception as err:  # noqa: BLE001
             logger.warning(
                 "Failed to persist auth_mode=%s after web flow for %s: %s",
                 auth_mode, backend, err,
             )
+        if owns_settlement:
+            settlement.raise_if_cancelled()
 
     async def _save_backend_auth_fields(
         self,
@@ -3559,6 +3620,7 @@ class AgentAuthService:
         *,
         clear_credentials: bool,
         mark_mode_explicit: bool,
+        settlement: CancellationSettlement | None = None,
     ) -> None:
         """Fresh-load and persist backend auth fields without blocking the loop."""
 
@@ -3584,21 +3646,26 @@ class AgentAuthService:
         def persist() -> dict[str, Any] | None:
             from config.v2_config import V2Config, config_write_transaction
 
-            if isinstance(controller_config, V2Config):
-                with config_write_transaction():
-                    try:
-                        config = V2Config.load()
-                    except FileNotFoundError:
-                        config = controller_config
+            with config_write_transaction():
+                try:
+                    config = V2Config.load()
+                except FileNotFoundError:
+                    config = controller_config if isinstance(controller_config, V2Config) else None
+
+                if config is not None:
                     target = getattr(config.agents, backend, None)
-                    if target is None:
-                        return None
-                    if update_target(target):
-                        config.save()
-            else:
-                config = controller_config
-                target = getattr(getattr(config, "agents", None), backend, None)
-                saver = getattr(config, "save", None) if config is not None else None
+                    saver = config.save
+                else:
+                    target = getattr(
+                        getattr(controller_config, "agents", None),
+                        backend,
+                        None,
+                    ) or getattr(controller_config, backend, None)
+                    saver = (
+                        getattr(controller_config, "save", None)
+                        if controller_config is not None
+                        else None
+                    )
                 if target is None or not callable(saver):
                     return None
                 if update_target(target):
@@ -3610,17 +3677,28 @@ class AgentAuthService:
                 "auth_mode_set": getattr(target, "auth_mode_set", None),
             }
 
-        persisted = await run_blocking(persist)
+        owns_settlement = settlement is None
+        settlement = settlement or CancellationSettlement()
+        try:
+            persisted = await settlement.run_blocking(persist)
+        except Exception:
+            if owns_settlement:
+                settlement.raise_if_cancelled()
+            raise
         live_target = getattr(
             getattr(controller_config, "agents", None),
             backend,
             None,
-        )
+        ) or getattr(controller_config, backend, None)
         if persisted is None or live_target is None:
+            if owns_settlement:
+                settlement.raise_if_cancelled()
             return
         for field, value in persisted.items():
             if field != "auth_mode_set" or value is not None:
                 setattr(live_target, field, value)
+        if owns_settlement:
+            settlement.raise_if_cancelled()
 
     async def _terminate_web_flow(
         self,

--- a/core/agent_auth_service.py
+++ b/core/agent_auth_service.py
@@ -297,6 +297,10 @@ def verify_opencode_auth_list_output(text: str, provider: str | None = None) -> 
     return "credential" in normalized and "0 credentials" not in normalized and "no credentials" not in normalized
 
 
+class BackendAuthConfigSaveError(RuntimeError):
+    """V2 auth persistence failed after external auth cleanup succeeded."""
+
+
 @dataclass
 class AgentAuthFlow:
     flow_id: str
@@ -1473,18 +1477,26 @@ class AgentAuthService:
             ok, detail = await self._verify_login(flow)
             if ok:
                 settlement = CancellationSettlement()
+                persist_error: Exception | None = None
                 if flow.backend == "codex":
-                    await self._persist_backend_auth_mode(
-                        flow.backend,
-                        "oauth",
-                        settlement=settlement,
-                    )
+                    try:
+                        await self._persist_backend_auth_mode(
+                            flow.backend,
+                            "oauth",
+                            settlement=settlement,
+                        )
+                    except BackendAuthConfigSaveError as error:
+                        persist_error = error
                 try:
                     await settlement.wait(self._refresh_backend_runtime(flow.backend))
                 except (Exception, asyncio.CancelledError) as error:
-                    settlement.raise_if_cancelled(error)
+                    settlement.raise_if_cancelled(persist_error or error)
+                    if persist_error is not None:
+                        raise persist_error
                     raise
-                settlement.raise_if_cancelled()
+                settlement.raise_if_cancelled(persist_error)
+                if persist_error is not None:
+                    raise persist_error
                 await self._send_message(
                     flow.context,
                     f"✅ {self._t('command.setup.success', backend=flow.backend)}",
@@ -1535,11 +1547,15 @@ class AgentAuthService:
             ok, detail = await self._verify_login(flow)
             if ok:
                 settlement = CancellationSettlement()
-                await self._persist_backend_auth_mode(
-                    flow.backend,
-                    "oauth",
-                    settlement=settlement,
-                )
+                persist_error: Exception | None = None
+                try:
+                    await self._persist_backend_auth_mode(
+                        flow.backend,
+                        "oauth",
+                        settlement=settlement,
+                    )
+                except BackendAuthConfigSaveError as error:
+                    persist_error = error
                 try:
                     await settlement.wait(
                         self._finish_claude_oauth_attempt(
@@ -1549,9 +1565,13 @@ class AgentAuthService:
                     )
                     await settlement.wait(self._refresh_backend_runtime(flow.backend))
                 except (Exception, asyncio.CancelledError) as error:
-                    settlement.raise_if_cancelled(error)
+                    settlement.raise_if_cancelled(persist_error or error)
+                    if persist_error is not None:
+                        raise persist_error
                     raise
-                settlement.raise_if_cancelled()
+                settlement.raise_if_cancelled(persist_error)
+                if persist_error is not None:
+                    raise persist_error
                 await self._send_message(
                     flow.context,
                     f"✅ {self._t('command.setup.success', backend=flow.backend)}",
@@ -2201,8 +2221,15 @@ class AgentAuthService:
                     self._clear_claude_settings_env_for_logout()
                 )
                 if settings_cleanup_error:
-                    logout_ok = False
-                    logout_error = settings_cleanup_error
+                    settlement.raise_if_cancelled(
+                        RuntimeError(settings_cleanup_error)
+                    )
+                    return {
+                        "ok": True,
+                        "partial": True,
+                        "warning": "settings_cleanup_failed",
+                        "detail": settings_cleanup_error,
+                    }
                 else:
                     logout_ok, logout_error = await settlement.wait(
                         self._run_utility_command(
@@ -2251,13 +2278,6 @@ class AgentAuthService:
         # missing, exited non-zero, or timed out), and the user needs
         # to know about that partial sign-out rather than seeing a
         # green toast and assuming the backend is fully signed out.
-        if backend == "claude" and settings_cleanup_error:
-            return {
-                "ok": True,
-                "partial": True,
-                "warning": "settings_cleanup_failed",
-                "detail": settings_cleanup_error,
-            }
         if not logout_ok:
             return {
                 "ok": True,
@@ -3162,16 +3182,20 @@ class AgentAuthService:
             ok, detail = await self._verify_web_login(flow.backend, force_oauth=flow.backend == "claude")
             if ok:
                 settlement = CancellationSettlement()
-                await self._invoke_post_web_success_hook(
+                persist_error = await self._invoke_post_web_success_hook(
                     flow.backend,
                     settlement=settlement,
                 )
                 try:
                     await settlement.wait(self._refresh_backend_runtime(flow.backend))
                 except (Exception, asyncio.CancelledError) as error:
-                    settlement.raise_if_cancelled(error)
+                    settlement.raise_if_cancelled(persist_error or error)
+                    if persist_error is not None:
+                        raise persist_error
                     raise
-                settlement.raise_if_cancelled()
+                settlement.raise_if_cancelled(persist_error)
+                if persist_error is not None:
+                    raise persist_error
                 flow.state = "success"
             else:
                 flow.state = "failed"
@@ -3205,7 +3229,7 @@ class AgentAuthService:
             )
             if ok:
                 settlement = CancellationSettlement()
-                await self._invoke_post_web_success_hook(
+                persist_error = await self._invoke_post_web_success_hook(
                     flow.backend,
                     settlement=settlement,
                 )
@@ -3218,9 +3242,13 @@ class AgentAuthService:
                     )
                     await settlement.wait(self._refresh_backend_runtime(flow.backend))
                 except (Exception, asyncio.CancelledError) as error:
-                    settlement.raise_if_cancelled(error)
+                    settlement.raise_if_cancelled(persist_error or error)
+                    if persist_error is not None:
+                        raise persist_error
                     raise
-                settlement.raise_if_cancelled()
+                settlement.raise_if_cancelled(persist_error)
+                if persist_error is not None:
+                    raise persist_error
                 flow.state = "success"
             else:
                 await self._finish_claude_oauth_attempt(flow.claude_oauth_attempt, succeeded=False)
@@ -3281,7 +3309,7 @@ class AgentAuthService:
         backend: str,
         *,
         settlement: CancellationSettlement | None = None,
-    ) -> None:
+    ) -> Exception | None:
         # OAuth completed via the web UI implies the user wants
         # ``auth_mode = "oauth"``. Persist it before the controller-refresh
         # hook fires so the live agent reloads with the right mode rather
@@ -3296,17 +3324,23 @@ class AgentAuthService:
         # would add a stray attribute and could mislead future readers.
         owns_settlement = settlement is None
         settlement = settlement or CancellationSettlement()
+        persist_error: Exception | None = None
         if backend != "opencode":
-            await self._persist_backend_auth_mode(
-                backend,
-                "oauth",
-                settlement=settlement,
-            )
+            try:
+                await self._persist_backend_auth_mode(
+                    backend,
+                    "oauth",
+                    settlement=settlement,
+                )
+            except BackendAuthConfigSaveError as error:
+                persist_error = error
         hook = self._post_web_success_hook
         if not callable(hook):
             if owns_settlement:
-                settlement.raise_if_cancelled()
-            return
+                settlement.raise_if_cancelled(persist_error)
+                if persist_error is not None:
+                    raise persist_error
+            return persist_error
         try:
             await settlement.run_blocking(hook, backend)
         except asyncio.CancelledError as error:
@@ -3315,7 +3349,10 @@ class AgentAuthService:
         except Exception as err:  # noqa: BLE001
             logger.warning("post_web_success_hook failed for %s: %s", backend, err)
         if owns_settlement:
-            settlement.raise_if_cancelled()
+            settlement.raise_if_cancelled(persist_error)
+            if persist_error is not None:
+                raise persist_error
+        return persist_error
 
     async def _clear_claude_settings_env_for_oauth(self) -> None:
         try:
@@ -3644,11 +3681,25 @@ class AgentAuthService:
                 mark_mode_explicit=backend == "claude",
                 settlement=settlement,
             )
-        except Exception as err:  # noqa: BLE001
+        except asyncio.CancelledError as err:
             logger.warning(
                 "Failed to persist auth_mode=%s after web flow for %s: %s",
                 auth_mode, backend, err,
             )
+            if owns_settlement:
+                settlement.raise_if_cancelled(err)
+            raise
+        except Exception as err:  # noqa: BLE001
+            logger.warning(
+                "Failed to persist auth_mode=%s after web flow for %s: %s",
+                auth_mode,
+                backend,
+                err,
+            )
+            error = BackendAuthConfigSaveError(str(err))
+            if owns_settlement:
+                settlement.raise_if_cancelled(error)
+            raise error from err
         if owns_settlement:
             settlement.raise_if_cancelled()
 

--- a/core/agent_auth_service.py
+++ b/core/agent_auth_service.py
@@ -38,6 +38,7 @@ from modules.agents.opencode.utils import (
     resolve_opencode_reasoning_effort,
 )
 from modules.im import InlineButton, InlineKeyboard, MessageContext
+from core.memory.blocking import run_blocking
 from core.resource_governance import governor_from_controller
 from core.message_output import MessageOutput, terminal_turn_output
 from vibe.i18n import t as i18n_t
@@ -1285,7 +1286,7 @@ class AgentAuthService:
         pre-command state and may return a spawn-failure restoration.
         """
         restore_on_spawn_failure = (
-            prepare_start()
+            await run_blocking(prepare_start)
             if prepare_start is not None
             else None
         )
@@ -1298,7 +1299,7 @@ class AgentAuthService:
             )
         except Exception as err:  # noqa: BLE001
             if restore_on_spawn_failure is not None:
-                restore_on_spawn_failure()
+                await run_blocking(restore_on_spawn_failure)
             if prepare_start is not None:
                 raise
             logger.info("Utility command raised for %s: %s", " ".join(cmd), err)

--- a/core/agent_auth_service.py
+++ b/core/agent_auth_service.py
@@ -1479,7 +1479,11 @@ class AgentAuthService:
                         "oauth",
                         settlement=settlement,
                     )
-                await settlement.wait(self._refresh_backend_runtime(flow.backend))
+                try:
+                    await settlement.wait(self._refresh_backend_runtime(flow.backend))
+                except (Exception, asyncio.CancelledError) as error:
+                    settlement.raise_if_cancelled(error)
+                    raise
                 settlement.raise_if_cancelled()
                 await self._send_message(
                     flow.context,
@@ -1536,13 +1540,17 @@ class AgentAuthService:
                     "oauth",
                     settlement=settlement,
                 )
-                await settlement.wait(
-                    self._finish_claude_oauth_attempt(
-                        flow.claude_oauth_attempt,
-                        succeeded=True,
+                try:
+                    await settlement.wait(
+                        self._finish_claude_oauth_attempt(
+                            flow.claude_oauth_attempt,
+                            succeeded=True,
+                        )
                     )
-                )
-                await settlement.wait(self._refresh_backend_runtime(flow.backend))
+                    await settlement.wait(self._refresh_backend_runtime(flow.backend))
+                except (Exception, asyncio.CancelledError) as error:
+                    settlement.raise_if_cancelled(error)
+                    raise
                 settlement.raise_if_cancelled()
                 await self._send_message(
                     flow.context,
@@ -2181,23 +2189,34 @@ class AgentAuthService:
             return {"ok": False, "error": "unsupported_backend"}
 
         binary = self._get_cli_binary(backend)
-        settings_cleanup_error: str | None = None
-        if backend == "codex":
-            logout_ok, logout_error = await self._run_utility_command(binary, "logout")
-        else:
-            settings_cleanup_error = await self._clear_claude_settings_env_for_logout()
-            if settings_cleanup_error:
-                logout_ok = False
-                logout_error = settings_cleanup_error
-            else:
-                logout_ok, logout_error = await self._run_utility_command(
-                    binary,
-                    "auth",
-                    "logout",
-                    env=self._build_claude_full_subprocess_env(force_oauth=True),
-                )
-
         settlement = CancellationSettlement()
+        settings_cleanup_error: str | None = None
+        try:
+            if backend == "codex":
+                logout_ok, logout_error = await settlement.wait(
+                    self._run_utility_command(binary, "logout")
+                )
+            else:
+                settings_cleanup_error = await settlement.wait(
+                    self._clear_claude_settings_env_for_logout()
+                )
+                if settings_cleanup_error:
+                    logout_ok = False
+                    logout_error = settings_cleanup_error
+                else:
+                    logout_ok, logout_error = await settlement.wait(
+                        self._run_utility_command(
+                            binary,
+                            "auth",
+                            "logout",
+                            env=self._build_claude_full_subprocess_env(force_oauth=True),
+                        )
+                    )
+        except (Exception, asyncio.CancelledError) as error:
+            settlement.raise_if_cancelled(error)
+            raise
+
+        settlement_cause: BaseException | None = None
         try:
             await self._save_backend_auth_fields(
                 backend,
@@ -2207,6 +2226,7 @@ class AgentAuthService:
                 settlement=settlement,
             )
         except Exception as err:  # noqa: BLE001
+            settlement_cause = err
             # Disk state has already been cleared; surface the V2Config
             # write failure but report partial success so the UI shows
             # the auth as removed (which is the user-visible truth).
@@ -2219,9 +2239,13 @@ class AgentAuthService:
         if callable(hook):
             try:
                 await settlement.run_blocking(hook, backend)
+            except asyncio.CancelledError as error:
+                settlement.raise_if_cancelled(error)
+                raise
             except Exception as err:  # noqa: BLE001
+                settlement_cause = settlement_cause or err
                 logger.warning("post_web_success_hook failed after remove for %s: %s", backend, err)
-        settlement.raise_if_cancelled()
+        settlement.raise_if_cancelled(settlement_cause)
         # Surface logout failures even though V2Config was cleared. The
         # on-disk credentials may still be intact (e.g. ``codex logout``
         # missing, exited non-zero, or timed out), and the user needs
@@ -3142,7 +3166,11 @@ class AgentAuthService:
                     flow.backend,
                     settlement=settlement,
                 )
-                await settlement.wait(self._refresh_backend_runtime(flow.backend))
+                try:
+                    await settlement.wait(self._refresh_backend_runtime(flow.backend))
+                except (Exception, asyncio.CancelledError) as error:
+                    settlement.raise_if_cancelled(error)
+                    raise
                 settlement.raise_if_cancelled()
                 flow.state = "success"
             else:
@@ -3181,13 +3209,17 @@ class AgentAuthService:
                     flow.backend,
                     settlement=settlement,
                 )
-                await settlement.wait(
-                    self._finish_claude_oauth_attempt(
-                        flow.claude_oauth_attempt,
-                        succeeded=True,
+                try:
+                    await settlement.wait(
+                        self._finish_claude_oauth_attempt(
+                            flow.claude_oauth_attempt,
+                            succeeded=True,
+                        )
                     )
-                )
-                await settlement.wait(self._refresh_backend_runtime(flow.backend))
+                    await settlement.wait(self._refresh_backend_runtime(flow.backend))
+                except (Exception, asyncio.CancelledError) as error:
+                    settlement.raise_if_cancelled(error)
+                    raise
                 settlement.raise_if_cancelled()
                 flow.state = "success"
             else:
@@ -3277,6 +3309,9 @@ class AgentAuthService:
             return
         try:
             await settlement.run_blocking(hook, backend)
+        except asyncio.CancelledError as error:
+            settlement.raise_if_cancelled(error)
+            raise
         except Exception as err:  # noqa: BLE001
             logger.warning("post_web_success_hook failed for %s: %s", backend, err)
         if owns_settlement:
@@ -3593,10 +3628,14 @@ class AgentAuthService:
         """Persist V2Config.agents.<backend>.auth_mode for web and IM flows."""
         owns_settlement = settlement is None
         settlement = settlement or CancellationSettlement()
-        if backend == "claude" and auth_mode == "oauth":
-            await settlement.wait(self._clear_claude_settings_env_for_oauth())
-        if backend == "codex" and auth_mode == "oauth":
-            await settlement.wait(self._clear_codex_api_key_for_oauth())
+        try:
+            if backend == "claude" and auth_mode == "oauth":
+                await settlement.wait(self._clear_claude_settings_env_for_oauth())
+            if backend == "codex" and auth_mode == "oauth":
+                await settlement.wait(self._clear_codex_api_key_for_oauth())
+        except (Exception, asyncio.CancelledError) as error:
+            settlement.raise_if_cancelled(error)
+            raise
         try:
             await self._save_backend_auth_fields(
                 backend,
@@ -3681,9 +3720,9 @@ class AgentAuthService:
         settlement = settlement or CancellationSettlement()
         try:
             persisted = await settlement.run_blocking(persist)
-        except Exception:
+        except (Exception, asyncio.CancelledError) as error:
             if owns_settlement:
-                settlement.raise_if_cancelled()
+                settlement.raise_if_cancelled(error)
             raise
         live_target = getattr(
             getattr(controller_config, "agents", None),

--- a/core/agent_auth_service.py
+++ b/core/agent_auth_service.py
@@ -2165,39 +2165,12 @@ class AgentAuthService:
                 )
 
         try:
-            config = getattr(self.controller, "config", None)
-            target = getattr(getattr(config, "agents", None), backend, None)
-            saver = getattr(config, "save", None) if config is not None else None
-            if target is not None and callable(saver):
-                try:
-                    from config.v2_config import CONFIG_LOCK
-
-                    with CONFIG_LOCK:
-                        target.auth_mode = "oauth"
-                        target.api_key = None
-                        # Drop the relay base_url too: if the user
-                        # signed in via OAuth after this, the stored
-                        # base_url would still get injected as
-                        # ``ANTHROPIC_BASE_URL`` / Codex provider
-                        # override, sending OAuth requests to a relay
-                        # that only accepts API keys (401).
-                        target.base_url = None
-                        # Sign out is an explicit user choice — flip
-                        # the marker so ``build_claude_subprocess_env``
-                        # honors ``auth_mode == "oauth"`` strictly
-                        # and strips inherited ``ANTHROPIC_*`` env vars
-                        # (Codex-only field; setattr is a no-op for
-                        # other backends).
-                        if backend == "claude":
-                            target.auth_mode_set = True
-                        saver()
-                except ImportError:
-                    target.auth_mode = "oauth"
-                    target.api_key = None
-                    target.base_url = None
-                    if backend == "claude":
-                        target.auth_mode_set = True
-                    saver()
+            await self._save_backend_auth_fields(
+                backend,
+                "oauth",
+                clear_credentials=True,
+                mark_mode_explicit=backend == "claude",
+            )
         except Exception as err:  # noqa: BLE001
             # Disk state has already been cleared; surface the V2Config
             # write failure but report partial success so the UI shows
@@ -3551,75 +3524,87 @@ class AgentAuthService:
         if backend == "codex" and auth_mode == "oauth":
             await self._clear_codex_api_key_for_oauth()
         try:
-            config = getattr(self.controller, "config", None)
-            target = getattr(getattr(config, "agents", None), backend, None)
-            saver = getattr(config, "save", None) if config is not None else None
-            loaded_config = None
-            if target is None or not callable(saver):
-                from config.v2_config import V2Config
-
-                loaded_config = V2Config.load()
-                target = getattr(getattr(loaded_config, "agents", None), backend, None)
-                saver = getattr(loaded_config, "save", None)
-            if target is None or not callable(saver):
-                return
-            # An explicit OAuth save must also flip ``auth_mode_set``
-            # for Claude — otherwise a successful OAuth flow on a
-            # legacy install never trips the marker (auth_mode was
-            # already "oauth" from the schema default), so
-            # ``build_claude_subprocess_env`` keeps preserving env-var
-            # auth and the OAuth credentials are ignored at launch.
-            needs_mode_write = getattr(target, "auth_mode", None) != auth_mode
-            needs_marker_write = (
-                backend == "claude"
-                and not bool(getattr(target, "auth_mode_set", False))
+            await self._save_backend_auth_fields(
+                backend,
+                auth_mode,
+                clear_credentials=backend == "codex" and auth_mode == "oauth",
+                mark_mode_explicit=backend == "claude",
             )
-            needs_codex_oauth_cleanup = (
-                backend == "codex"
-                and auth_mode == "oauth"
-                and (
-                    bool(getattr(target, "api_key", None))
-                    or bool(getattr(target, "base_url", None))
-                )
-            )
-            if not needs_mode_write and not needs_marker_write and not needs_codex_oauth_cleanup:
-                return
-            try:
-                from config.v2_config import CONFIG_LOCK
-
-                with CONFIG_LOCK:
-                    if needs_mode_write:
-                        target.auth_mode = auth_mode
-                    if needs_marker_write:
-                        target.auth_mode_set = True
-                    if needs_codex_oauth_cleanup:
-                        target.api_key = None
-                        target.base_url = None
-                    saver()
-            except ImportError:
-                if needs_mode_write:
-                    target.auth_mode = auth_mode
-                if needs_marker_write:
-                    target.auth_mode_set = True
-                if needs_codex_oauth_cleanup:
-                    target.api_key = None
-                    target.base_url = None
-                saver()
-            if loaded_config is not None and config is not None:
-                compat_target = getattr(config, backend, None)
-                if compat_target is not None:
-                    if needs_mode_write:
-                        setattr(compat_target, "auth_mode", auth_mode)
-                    if needs_marker_write:
-                        setattr(compat_target, "auth_mode_set", True)
-                    if needs_codex_oauth_cleanup:
-                        setattr(compat_target, "api_key", None)
-                        setattr(compat_target, "base_url", None)
         except Exception as err:  # noqa: BLE001
             logger.warning(
                 "Failed to persist auth_mode=%s after web flow for %s: %s",
                 auth_mode, backend, err,
             )
+
+    async def _save_backend_auth_fields(
+        self,
+        backend: str,
+        auth_mode: str,
+        *,
+        clear_credentials: bool,
+        mark_mode_explicit: bool,
+    ) -> None:
+        """Fresh-load and persist backend auth fields without blocking the loop."""
+
+        controller_config = getattr(self.controller, "config", None)
+
+        def update_target(target: Any) -> bool:
+            changed = getattr(target, "auth_mode", None) != auth_mode
+            target.auth_mode = auth_mode
+            if clear_credentials:
+                changed = changed or bool(
+                    getattr(target, "api_key", None)
+                    or getattr(target, "base_url", None)
+                )
+                target.api_key = None
+                target.base_url = None
+            if mark_mode_explicit:
+                changed = changed or not bool(
+                    getattr(target, "auth_mode_set", False)
+                )
+                target.auth_mode_set = True
+            return changed
+
+        def persist() -> dict[str, Any] | None:
+            from config.v2_config import V2Config, config_write_transaction
+
+            if isinstance(controller_config, V2Config):
+                with config_write_transaction():
+                    try:
+                        config = V2Config.load()
+                    except FileNotFoundError:
+                        config = controller_config
+                    target = getattr(config.agents, backend, None)
+                    if target is None:
+                        return None
+                    if update_target(target):
+                        config.save()
+            else:
+                config = controller_config
+                target = getattr(getattr(config, "agents", None), backend, None)
+                saver = getattr(config, "save", None) if config is not None else None
+                if target is None or not callable(saver):
+                    return None
+                if update_target(target):
+                    saver()
+            return {
+                "auth_mode": getattr(target, "auth_mode", None),
+                "api_key": getattr(target, "api_key", None),
+                "base_url": getattr(target, "base_url", None),
+                "auth_mode_set": getattr(target, "auth_mode_set", None),
+            }
+
+        persisted = await run_blocking(persist)
+        live_target = getattr(
+            getattr(controller_config, "agents", None),
+            backend,
+            None,
+        )
+        if persisted is None or live_target is None:
+            return
+        for field, value in persisted.items():
+            if field != "auth_mode_set" or value is not None:
+                setattr(live_target, field, value)
 
     async def _terminate_web_flow(
         self,

--- a/core/agent_auth_service.py
+++ b/core/agent_auth_service.py
@@ -12,7 +12,7 @@ import signal
 import time
 import uuid
 from dataclasses import dataclass, field
-from typing import Any, Callable, Optional
+from typing import Any, Awaitable, Callable, Optional
 
 from modules.claude_sdk_compat import (
     CLAUDE_SDK_AVAILABLE,
@@ -1487,16 +1487,11 @@ class AgentAuthService:
                         )
                     except BackendAuthConfigSaveError as error:
                         persist_error = error
-                try:
-                    await settlement.wait(self._refresh_backend_runtime(flow.backend))
-                except (Exception, asyncio.CancelledError) as error:
-                    settlement.raise_if_cancelled(persist_error or error)
-                    if persist_error is not None:
-                        raise persist_error
-                    raise
-                settlement.raise_if_cancelled(persist_error)
-                if persist_error is not None:
-                    raise persist_error
+                await self._settle_auth_completion(
+                    flow.backend,
+                    settlement,
+                    persist_error=persist_error,
+                )
                 await self._send_message(
                     flow.context,
                     f"✅ {self._t('command.setup.success', backend=flow.backend)}",
@@ -1556,22 +1551,15 @@ class AgentAuthService:
                     )
                 except BackendAuthConfigSaveError as error:
                     persist_error = error
-                try:
-                    await settlement.wait(
-                        self._finish_claude_oauth_attempt(
-                            flow.claude_oauth_attempt,
-                            succeeded=True,
-                        )
-                    )
-                    await settlement.wait(self._refresh_backend_runtime(flow.backend))
-                except (Exception, asyncio.CancelledError) as error:
-                    settlement.raise_if_cancelled(persist_error or error)
-                    if persist_error is not None:
-                        raise persist_error
-                    raise
-                settlement.raise_if_cancelled(persist_error)
-                if persist_error is not None:
-                    raise persist_error
+                await self._settle_auth_completion(
+                    flow.backend,
+                    settlement,
+                    persist_error=persist_error,
+                    finalize=self._finish_claude_oauth_attempt(
+                        flow.claude_oauth_attempt,
+                        succeeded=True,
+                    ),
+                )
                 await self._send_message(
                     flow.context,
                     f"✅ {self._t('command.setup.success', backend=flow.backend)}",
@@ -2244,6 +2232,7 @@ class AgentAuthService:
             raise
 
         settlement_cause: BaseException | None = None
+        config_save_error: Exception | None = None
         try:
             await self._save_backend_auth_fields(
                 backend,
@@ -2254,6 +2243,7 @@ class AgentAuthService:
             )
         except Exception as err:  # noqa: BLE001
             settlement_cause = err
+            config_save_error = err
             # Disk state has already been cleared; surface the V2Config
             # write failure but report partial success so the UI shows
             # the auth as removed (which is the user-visible truth).
@@ -2273,6 +2263,13 @@ class AgentAuthService:
                 settlement_cause = settlement_cause or err
                 logger.warning("post_web_success_hook failed after remove for %s: %s", backend, err)
         settlement.raise_if_cancelled(settlement_cause)
+        if config_save_error is not None:
+            return {
+                "ok": True,
+                "partial": True,
+                "warning": "config_save_failed",
+                "detail": str(config_save_error),
+            }
         # Surface logout failures even though V2Config was cleared. The
         # on-disk credentials may still be intact (e.g. ``codex logout``
         # missing, exited non-zero, or timed out), and the user needs
@@ -3186,16 +3183,11 @@ class AgentAuthService:
                     flow.backend,
                     settlement=settlement,
                 )
-                try:
-                    await settlement.wait(self._refresh_backend_runtime(flow.backend))
-                except (Exception, asyncio.CancelledError) as error:
-                    settlement.raise_if_cancelled(persist_error or error)
-                    if persist_error is not None:
-                        raise persist_error
-                    raise
-                settlement.raise_if_cancelled(persist_error)
-                if persist_error is not None:
-                    raise persist_error
+                await self._settle_auth_completion(
+                    flow.backend,
+                    settlement,
+                    persist_error=persist_error,
+                )
                 flow.state = "success"
             else:
                 flow.state = "failed"
@@ -3233,22 +3225,15 @@ class AgentAuthService:
                     flow.backend,
                     settlement=settlement,
                 )
-                try:
-                    await settlement.wait(
-                        self._finish_claude_oauth_attempt(
-                            flow.claude_oauth_attempt,
-                            succeeded=True,
-                        )
-                    )
-                    await settlement.wait(self._refresh_backend_runtime(flow.backend))
-                except (Exception, asyncio.CancelledError) as error:
-                    settlement.raise_if_cancelled(persist_error or error)
-                    if persist_error is not None:
-                        raise persist_error
-                    raise
-                settlement.raise_if_cancelled(persist_error)
-                if persist_error is not None:
-                    raise persist_error
+                await self._settle_auth_completion(
+                    flow.backend,
+                    settlement,
+                    persist_error=persist_error,
+                    finalize=self._finish_claude_oauth_attempt(
+                        flow.claude_oauth_attempt,
+                        succeeded=True,
+                    ),
+                )
                 flow.state = "success"
             else:
                 await self._finish_claude_oauth_attempt(flow.claude_oauth_attempt, succeeded=False)
@@ -3353,6 +3338,41 @@ class AgentAuthService:
             if persist_error is not None:
                 raise persist_error
         return persist_error
+
+    async def _settle_auth_completion(
+        self,
+        backend: str,
+        settlement: CancellationSettlement,
+        *,
+        persist_error: BaseException | None = None,
+        finalize: Awaitable[None] | None = None,
+    ) -> None:
+        """Finish every required live stage before surfacing the primary error."""
+
+        primary_error = persist_error
+
+        async def settle_stage(awaitable: Awaitable[None], stage: str) -> None:
+            nonlocal primary_error
+            try:
+                await settlement.wait(awaitable)
+            except (Exception, asyncio.CancelledError) as error:
+                if primary_error is None:
+                    primary_error = error
+                else:
+                    logger.warning(
+                        "Agent auth %s failed after an earlier %s failure: %s",
+                        stage,
+                        backend,
+                        error,
+                        exc_info=True,
+                    )
+
+        if finalize is not None:
+            await settle_stage(finalize, "finalization")
+        await settle_stage(self._refresh_backend_runtime(backend), "runtime refresh")
+        settlement.raise_if_cancelled(primary_error)
+        if primary_error is not None:
+            raise primary_error
 
     async def _clear_claude_settings_env_for_oauth(self) -> None:
         try:

--- a/core/agent_auth_service.py
+++ b/core/agent_auth_service.py
@@ -301,6 +301,10 @@ class BackendAuthConfigSaveError(RuntimeError):
     """V2 auth persistence failed after external auth cleanup succeeded."""
 
 
+class BackendAuthCredentialCleanupError(RuntimeError):
+    """OAuth activation could not clear conflicting API-key state."""
+
+
 @dataclass
 class AgentAuthFlow:
     flow_id: str
@@ -3375,36 +3379,44 @@ class AgentAuthService:
             raise primary_error
 
     async def _clear_claude_settings_env_for_oauth(self) -> None:
-        try:
-            from vibe.claude_config import apply_claude_auth
-
-            await asyncio.to_thread(
-                apply_claude_auth,
-                auth_mode="oauth",
-                api_key=None,
-                base_url=None,
-            )
-        except Exception as err:  # noqa: BLE001
-            raise RuntimeError(
-                "Failed to clear Claude Code settings env after OAuth flow; "
-                "stale ANTHROPIC_* values may still override OAuth."
-            ) from err
+        await asyncio.to_thread(self._clear_backend_api_key_for_oauth, "claude")
 
     async def _clear_codex_api_key_for_oauth(self) -> None:
-        try:
-            from vibe.codex_config import apply_codex_auth
+        await asyncio.to_thread(self._clear_backend_api_key_for_oauth, "codex")
 
-            await asyncio.to_thread(
-                apply_codex_auth,
-                auth_mode="oauth",
-                api_key=None,
-                base_url=None,
-            )
+    def _clear_backend_api_key_for_oauth(self, backend: str) -> None:
+        try:
+            if backend == "claude":
+                from vibe.claude_config import apply_claude_auth
+
+                apply_claude_auth(
+                    auth_mode="oauth",
+                    api_key=None,
+                    base_url=None,
+                )
+                return
+            if backend == "codex":
+                from vibe.codex_config import apply_codex_auth
+
+                apply_codex_auth(
+                    auth_mode="oauth",
+                    api_key=None,
+                    base_url=None,
+                )
+                return
+            raise ValueError(f"Unsupported backend for OAuth cleanup: {backend}")
         except Exception as err:  # noqa: BLE001
-            raise RuntimeError(
-                "Failed to clear Codex API-key state after OAuth flow; "
-                "stale OPENAI_API_KEY or base_url values may still override OAuth."
-            ) from err
+            if backend == "claude":
+                message = (
+                    "Failed to clear Claude Code settings env after OAuth flow; "
+                    "stale ANTHROPIC_* values may still override OAuth."
+                )
+            else:
+                message = (
+                    "Failed to clear Codex API-key state after OAuth flow; "
+                    "stale OPENAI_API_KEY or base_url values may still override OAuth."
+                )
+            raise BackendAuthCredentialCleanupError(message) from err
 
     async def _read_pending_claude_oauth_settings_backup(
         self,
@@ -3686,21 +3698,20 @@ class AgentAuthService:
         owns_settlement = settlement is None
         settlement = settlement or CancellationSettlement()
         try:
-            if backend == "claude" and auth_mode == "oauth":
-                await settlement.wait(self._clear_claude_settings_env_for_oauth())
-            if backend == "codex" and auth_mode == "oauth":
-                await settlement.wait(self._clear_codex_api_key_for_oauth())
-        except (Exception, asyncio.CancelledError) as error:
-            settlement.raise_if_cancelled(error)
-            raise
-        try:
             await self._save_backend_auth_fields(
                 backend,
                 auth_mode,
                 clear_credentials=backend == "codex" and auth_mode == "oauth",
                 mark_mode_explicit=backend == "claude",
+                cleanup_oauth_credentials=(
+                    auth_mode == "oauth" and backend in {"claude", "codex"}
+                ),
                 settlement=settlement,
             )
+        except BackendAuthCredentialCleanupError as err:
+            if owns_settlement:
+                settlement.raise_if_cancelled(err)
+            raise
         except asyncio.CancelledError as err:
             logger.warning(
                 "Failed to persist auth_mode=%s after web flow for %s: %s",
@@ -3730,6 +3741,7 @@ class AgentAuthService:
         *,
         clear_credentials: bool,
         mark_mode_explicit: bool,
+        cleanup_oauth_credentials: bool = False,
         settlement: CancellationSettlement | None = None,
     ) -> None:
         """Fresh-load and persist backend auth fields without blocking the loop."""
@@ -3757,6 +3769,8 @@ class AgentAuthService:
             from config.v2_config import V2Config, config_write_transaction
 
             with config_write_transaction():
+                if cleanup_oauth_credentials:
+                    self._clear_backend_api_key_for_oauth(backend)
                 try:
                     config = V2Config.load()
                 except FileNotFoundError:

--- a/core/agent_auth_service.py
+++ b/core/agent_auth_service.py
@@ -1477,7 +1477,7 @@ class AgentAuthService:
             ok, detail = await self._verify_login(flow)
             if ok:
                 settlement = CancellationSettlement()
-                persist_error: Exception | None = None
+                persist_error: BaseException | None = None
                 if flow.backend == "codex":
                     try:
                         await self._persist_backend_auth_mode(
@@ -1485,7 +1485,7 @@ class AgentAuthService:
                             "oauth",
                             settlement=settlement,
                         )
-                    except BackendAuthConfigSaveError as error:
+                    except (Exception, asyncio.CancelledError) as error:
                         persist_error = error
                 await self._settle_auth_completion(
                     flow.backend,
@@ -1542,14 +1542,14 @@ class AgentAuthService:
             ok, detail = await self._verify_login(flow)
             if ok:
                 settlement = CancellationSettlement()
-                persist_error: Exception | None = None
+                persist_error: BaseException | None = None
                 try:
                     await self._persist_backend_auth_mode(
                         flow.backend,
                         "oauth",
                         settlement=settlement,
                     )
-                except BackendAuthConfigSaveError as error:
+                except (Exception, asyncio.CancelledError) as error:
                     persist_error = error
                 await self._settle_auth_completion(
                     flow.backend,
@@ -3294,7 +3294,7 @@ class AgentAuthService:
         backend: str,
         *,
         settlement: CancellationSettlement | None = None,
-    ) -> Exception | None:
+    ) -> BaseException | None:
         # OAuth completed via the web UI implies the user wants
         # ``auth_mode = "oauth"``. Persist it before the controller-refresh
         # hook fires so the live agent reloads with the right mode rather
@@ -3309,7 +3309,7 @@ class AgentAuthService:
         # would add a stray attribute and could mislead future readers.
         owns_settlement = settlement is None
         settlement = settlement or CancellationSettlement()
-        persist_error: Exception | None = None
+        persist_error: BaseException | None = None
         if backend != "opencode":
             try:
                 await self._persist_backend_auth_mode(
@@ -3317,7 +3317,7 @@ class AgentAuthService:
                     "oauth",
                     settlement=settlement,
                 )
-            except BackendAuthConfigSaveError as error:
+            except (Exception, asyncio.CancelledError) as error:
                 persist_error = error
         hook = self._post_web_success_hook
         if not callable(hook):

--- a/core/blocking.py
+++ b/core/blocking.py
@@ -1,0 +1,69 @@
+"""Cancellation-safe coordination for blocking and multi-stage operations."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from typing import Any, TypeVar
+
+
+_Result = TypeVar("_Result")
+
+
+class CancellationSettlement:
+    """Retain caller cancellation across an irreversible multi-stage sequence.
+
+    Callers run every required commit/reconcile stage through this instance,
+    then call ``raise_if_cancelled`` at the consistency boundary.
+    """
+
+    def __init__(self) -> None:
+        self._cancellation: asyncio.CancelledError | None = None
+
+    @property
+    def cancelled(self) -> bool:
+        return self._cancellation is not None
+
+    async def wait(self, awaitable: Awaitable[_Result]) -> _Result:
+        task = asyncio.ensure_future(awaitable)
+        while not task.done():
+            try:
+                await asyncio.shield(task)
+            except asyncio.CancelledError as error:
+                if task.cancelled():
+                    return task.result()
+                self._cancellation = self._cancellation or error
+            except Exception:
+                break
+        return task.result()
+
+    async def run_blocking(
+        self,
+        operation: Callable[..., _Result],
+        /,
+        *args: Any,
+        **kwargs: Any,
+    ) -> _Result:
+        return await self.wait(asyncio.to_thread(operation, *args, **kwargs))
+
+    def raise_if_cancelled(self) -> None:
+        if self._cancellation is not None:
+            raise self._cancellation
+
+
+async def run_blocking(
+    operation: Callable[..., _Result],
+    /,
+    *args: Any,
+    **kwargs: Any,
+) -> _Result:
+    """Settle one blocking operation before propagating caller cancellation."""
+
+    settlement = CancellationSettlement()
+    try:
+        result = await settlement.run_blocking(operation, *args, **kwargs)
+    except Exception:
+        settlement.raise_if_cancelled()
+        raise
+    settlement.raise_if_cancelled()
+    return result

--- a/core/blocking.py
+++ b/core/blocking.py
@@ -46,8 +46,10 @@ class CancellationSettlement:
     ) -> _Result:
         return await self.wait(asyncio.to_thread(operation, *args, **kwargs))
 
-    def raise_if_cancelled(self) -> None:
+    def raise_if_cancelled(self, cause: BaseException | None = None) -> None:
         if self._cancellation is not None:
+            if cause is not None:
+                raise self._cancellation from cause
             raise self._cancellation
 
 
@@ -62,8 +64,8 @@ async def run_blocking(
     settlement = CancellationSettlement()
     try:
         result = await settlement.run_blocking(operation, *args, **kwargs)
-    except Exception:
-        settlement.raise_if_cancelled()
+    except (Exception, asyncio.CancelledError) as error:
+        settlement.raise_if_cancelled(error)
         raise
     settlement.raise_if_cancelled()
     return result

--- a/core/blocking.py
+++ b/core/blocking.py
@@ -31,6 +31,12 @@ class CancellationSettlement:
                 await asyncio.shield(task)
             except asyncio.CancelledError as error:
                 if task.cancelled():
+                    if asyncio.current_task().cancelling():
+                        self._cancellation = self._cancellation or error
+                        try:
+                            return task.result()
+                        except asyncio.CancelledError as child_error:
+                            self.raise_if_cancelled(child_error)
                     return task.result()
                 self._cancellation = self._cancellation or error
             except Exception:
@@ -48,7 +54,7 @@ class CancellationSettlement:
 
     def raise_if_cancelled(self, cause: BaseException | None = None) -> None:
         if self._cancellation is not None:
-            if cause is not None:
+            if cause is not None and cause is not self._cancellation:
                 raise self._cancellation from cause
             raise self._cancellation
 
@@ -64,8 +70,8 @@ async def run_blocking(
     settlement = CancellationSettlement()
     try:
         result = await settlement.run_blocking(operation, *args, **kwargs)
-    except (Exception, asyncio.CancelledError) as error:
-        settlement.raise_if_cancelled(error)
+    except (Exception, asyncio.CancelledError):
+        settlement.raise_if_cancelled()
         raise
     settlement.raise_if_cancelled()
     return result

--- a/core/controller.py
+++ b/core/controller.py
@@ -49,7 +49,7 @@ from core.watches import ManagedWatchService
 from core.vibe_agents import VibeAgent, VibeAgentStore
 from core.memory import CaptureRequest
 from core.memory.admission import CaptureAdmission, InboundTurnFacts
-from core.memory.blocking import run_blocking
+from core.blocking import run_blocking
 from vibe.i18n import get_supported_languages, t as i18n_t
 
 logger = logging.getLogger(__name__)

--- a/core/controller.py
+++ b/core/controller.py
@@ -15,6 +15,7 @@ from config.v2_config import (
     DEFAULT_AGENT_IDLE_TIMEOUT_SECONDS,
     DEFAULT_AGENT_PROGRESS_STYLE,
     MemoryConfig,
+    config_write_transaction,
 )
 from modules.im import BaseIMClient, MessageContext, IMFactory
 from modules.im.multi import MultiIMClient
@@ -778,9 +779,10 @@ class Controller:
 
             from config.v2_config import V2Config
 
-            v2_config = V2Config.load()
-            v2_config.language = chosen
-            v2_config.save()
+            with config_write_transaction():
+                v2_config = V2Config.load()
+                v2_config.language = chosen
+                v2_config.save()
             self.config.language = chosen
             logger.info("Migrated legacy per-channel language to global config: %s", chosen)
         except Exception as err:

--- a/core/controller.py
+++ b/core/controller.py
@@ -779,12 +779,19 @@ class Controller:
 
             from config.v2_config import V2Config
 
+            migrated = False
             with config_write_transaction():
+                latest_payload = json.loads(config_path.read_text(encoding="utf-8"))
                 v2_config = V2Config.load()
-                v2_config.language = chosen
-                v2_config.save()
+                if isinstance(latest_payload, dict) and "language" in latest_payload:
+                    chosen = v2_config.language
+                else:
+                    v2_config.language = chosen
+                    v2_config.save()
+                    migrated = True
             self.config.language = chosen
-            logger.info("Migrated legacy per-channel language to global config: %s", chosen)
+            if migrated:
+                logger.info("Migrated legacy per-channel language to global config: %s", chosen)
         except Exception as err:
             logger.warning("Failed to migrate legacy language setting: %s", err)
 

--- a/core/handlers/model_hub/service.py
+++ b/core/handlers/model_hub/service.py
@@ -15,7 +15,6 @@ from sqlalchemy import func, select
 
 from config import paths
 from config.v2_config import (
-    CONFIG_LOCK,
     MODEL_HUB_BACKENDS,
     ModelHubAgentSupplyConfig,
     ModelHubConfig,
@@ -26,6 +25,7 @@ from config.v2_config import (
     ModelHubSourceStateConfig,
     ModelHubSourceUsageConfig,
     V2Config,
+    config_write_transaction,
 )
 from core.services.settings import default_config
 from storage.db import get_cached_sqlite_engine
@@ -148,7 +148,7 @@ class V2ModelHubConfigStore:
             return default_config().model_hub
 
     def save(self, model_hub: ModelHubConfig) -> None:
-        with CONFIG_LOCK:
+        with config_write_transaction():
             try:
                 config = V2Config.load()
             except FileNotFoundError:

--- a/core/handlers/model_hub/service.py
+++ b/core/handlers/model_hub/service.py
@@ -135,6 +135,10 @@ class EngineUnavailableError(RuntimeError):
     pass
 
 
+class ModelHubConfigConflictError(RuntimeError):
+    pass
+
+
 class ModelHubConfigStore(Protocol):
     def load(self) -> ModelHubConfig: ...
 
@@ -144,18 +148,44 @@ class ModelHubConfigStore(Protocol):
 class V2ModelHubConfigStore:
     def load(self) -> ModelHubConfig:
         try:
-            return V2Config.load().model_hub
+            config = V2Config.load().model_hub
         except FileNotFoundError:
-            return default_config().model_hub
+            config = default_config().model_hub
+        _set_model_hub_store_snapshot(config, config.to_payload())
+        return config
 
     def save(self, model_hub: ModelHubConfig) -> None:
+        expected = _model_hub_store_snapshot(model_hub)
         with config_write_transaction():
             try:
                 config = V2Config.load()
             except FileNotFoundError:
                 config = default_config()
+            if (
+                expected is not None
+                and config.model_hub.to_payload() != expected
+            ):
+                raise ModelHubConfigConflictError
             config.model_hub = model_hub
             config.save()
+            _set_model_hub_store_snapshot(model_hub, model_hub.to_payload())
+
+
+# Store-only revision metadata follows cloned configs without entering config.json.
+_MODEL_HUB_STORE_SNAPSHOT_ATTR = "_v2_store_snapshot"
+
+
+def _model_hub_store_snapshot(config: ModelHubConfig) -> dict | None:
+    snapshot = getattr(config, _MODEL_HUB_STORE_SNAPSHOT_ATTR, None)
+    return snapshot if isinstance(snapshot, dict) else None
+
+
+def _set_model_hub_store_snapshot(config: ModelHubConfig, snapshot: dict) -> None:
+    setattr(
+        config,
+        _MODEL_HUB_STORE_SNAPSHOT_ATTR,
+        ModelHubConfig.from_payload(snapshot).to_payload(),
+    )
 
 class UnavailableEngineAdapter:
     """Explicit fail-closed adapter for isolated callers and tests."""
@@ -512,7 +542,11 @@ class ModelHubService:
 
     @staticmethod
     def _clone_config(config: ModelHubConfig) -> ModelHubConfig:
-        return ModelHubConfig.from_payload(config.to_payload())
+        cloned = ModelHubConfig.from_payload(config.to_payload())
+        snapshot = _model_hub_store_snapshot(config)
+        if snapshot is not None:
+            _set_model_hub_store_snapshot(cloned, snapshot)
+        return cloned
 
     async def _save_store(
         self,
@@ -520,10 +554,13 @@ class ModelHubService:
         *,
         settlement: CancellationSettlement | None = None,
     ) -> None:
-        if settlement is None:
-            await run_blocking(self.store.save, config)
-        else:
-            await settlement.run_blocking(self.store.save, config)
+        try:
+            if settlement is None:
+                await run_blocking(self.store.save, config)
+            else:
+                await settlement.run_blocking(self.store.save, config)
+        except ModelHubConfigConflictError:
+            raise ModelHubError("config_conflict", status=409) from None
 
     async def _sync_sources(self, config: ModelHubConfig, *, force_empty: bool = False) -> None:
         bindings = self._bindings(config)
@@ -554,6 +591,9 @@ class ModelHubService:
             )
         except (Exception, asyncio.CancelledError) as sync_error:
             rollback_save_error: BaseException | None = None
+            updated_snapshot = _model_hub_store_snapshot(updated)
+            if updated_snapshot is not None:
+                _set_model_hub_store_snapshot(previous, updated_snapshot)
             try:
                 await self._save_store(previous, settlement=settlement)
             except (Exception, asyncio.CancelledError) as rollback_error:
@@ -2880,6 +2920,9 @@ class ModelHubService:
                         detail_key="models.source.needs_action.oauth_expired",
                     )
                 self.store.save(config)
+                updated_snapshot = _model_hub_store_snapshot(config)
+                if updated_snapshot is not None:
+                    _set_model_hub_store_snapshot(previous, updated_snapshot)
 
                 def restore_after_spawn_failure() -> None:
                     self.store.save(previous)

--- a/core/handlers/model_hub/service.py
+++ b/core/handlers/model_hub/service.py
@@ -28,6 +28,7 @@ from config.v2_config import (
     config_write_transaction,
 )
 from core.services.settings import default_config
+from core.memory.blocking import run_blocking
 from storage.db import get_cached_sqlite_engine
 from storage.models import agent_sessions, messages
 from vibe.backend_model_catalog import backend_model_entries, load_bundled_catalog
@@ -513,6 +514,9 @@ class ModelHubService:
     def _clone_config(config: ModelHubConfig) -> ModelHubConfig:
         return ModelHubConfig.from_payload(config.to_payload())
 
+    async def _save_store(self, config: ModelHubConfig) -> None:
+        await run_blocking(self.store.save, config)
+
     async def _sync_sources(self, config: ModelHubConfig, *, force_empty: bool = False) -> None:
         bindings = self._bindings(config)
         has_hub_sources = any(
@@ -530,11 +534,11 @@ class ModelHubService:
         self._engine_synced = False
         previous_bindings = self._bindings(previous)
         updated_bindings = self._bindings(updated)
-        self.store.save(updated)
+        await self._save_store(updated)
         try:
             await self._sync_sources(updated, force_empty=bool(previous_bindings))
         except Exception:
-            self.store.save(previous)
+            await self._save_store(previous)
             try:
                 await self._sync_sources(previous, force_empty=bool(updated_bindings))
             except ModelHubError:
@@ -759,7 +763,7 @@ class ModelHubService:
             except OSError:
                 pass
 
-    def _mark_same_handle_reauth_needs_action(self, source_id: str) -> None:
+    async def _mark_same_handle_reauth_needs_action(self, source_id: str) -> None:
         # The engine may replace OAuth material behind the same opaque ref.
         # Without an old snapshot, fail closed instead of restoring stale supply.
         config = self._clone_config(self.store.load())
@@ -771,7 +775,7 @@ class ModelHubService:
             status="needs_action",
             detail_key="models.source.needs_action.oauth_expired",
         )
-        self.store.save(config)
+        await self._save_store(config)
 
     async def _discard_unbound_hub_flow(self, flow: OAuthFlowState) -> None:
         if flow.credential_ref:
@@ -1079,7 +1083,7 @@ class ModelHubService:
                     else "models.source.error.unclassified"
                 ),
             )
-            self.store.save(config)
+            await self._save_store(config)
             return self._would_interrupt(config)
 
     async def _materialize_reauth(
@@ -1137,7 +1141,7 @@ class ModelHubService:
                         status="error",
                         detail_key="models.source.error.unclassified",
                     )
-                    self.store.save(config)
+                    await self._save_store(config)
                     interrupted_pairs = self._would_interrupt(config)
                     raise ModelHubError(
                         "discovery_failed",
@@ -1145,7 +1149,7 @@ class ModelHubService:
                         data={"interrupted_pairs": interrupted_pairs},
                     )
                 self._apply_discovered_models(source, manual, discovered)
-                self.store.save(config)
+                await self._save_store(config)
                 interrupted_pairs = self._would_interrupt(config)
                 self._complete_reauth_flow(
                     flow_id,
@@ -1209,7 +1213,7 @@ class ModelHubService:
                                 replacement_ref,
                             )
                         elif replacement_ref == old_credential_ref:
-                            self._mark_same_handle_reauth_needs_action(source.id)
+                            await self._mark_same_handle_reauth_needs_action(source.id)
                         else:
                             await self._rollback_replacement(
                                 source.id,
@@ -1276,7 +1280,7 @@ class ModelHubService:
         except OSError:
             pass
 
-    def _fail_closed_hub_reauth(
+    async def _fail_closed_hub_reauth(
         self,
         binding: OAuthFlowBinding,
         *,
@@ -1297,7 +1301,7 @@ class ModelHubService:
             status="needs_action",
             detail_key="models.source.needs_action.oauth_expired",
         )
-        self.store.save(config)
+        await self._save_store(config)
         return config
 
     async def _materialize_failed_hub_reauth(
@@ -1317,7 +1321,7 @@ class ModelHubService:
             RetainedMaterialDisposition.FLOW_SOURCE_REF,
             RetainedMaterialDisposition.UNKNOWN,
         }:
-            return self._fail_closed_hub_reauth(
+            return await self._fail_closed_hub_reauth(
                 binding,
                 config=config,
             )
@@ -1693,7 +1697,7 @@ class ModelHubService:
             if "base_url" in payload:
                 await self._commit_synced(previous, config)
             else:
-                self.store.save(config)
+                await self._save_store(config)
             return source.to_payload()
 
     @staticmethod
@@ -1829,7 +1833,7 @@ class ModelHubService:
             except ModelHubError:
                 restored = False
                 try:
-                    self.store.save(previous)
+                    await self._save_store(previous)
                     restored = True
                     self._engine_synced = False
                     await self._sync_sources(previous)
@@ -1866,7 +1870,7 @@ class ModelHubService:
                     status="error",
                     detail_key="models.source.error.unclassified",
                 )
-                self.store.save(config)
+                await self._save_store(config)
                 self._record_event(
                     agent="system",
                     kind="needs_action",
@@ -1973,7 +1977,7 @@ class ModelHubService:
                     seen.add(source_id)
                 agent.sources.policy = "custom"
                 agent.sources.order = list(order)
-            self.store.save(config)
+            await self._save_store(config)
             return self._agent_payload(config, agent)
 
     def get_agent_sources(self, backend: str) -> dict:
@@ -2189,7 +2193,7 @@ class ModelHubService:
             config = self.store.load()
             agent = self._agent(config, backend)
             agent.mode = mode
-            self.store.save(config)
+            await self._save_store(config)
             return self._agent_payload(config, agent)
 
     async def set_mappings(self, backend: str, mappings: object) -> dict:
@@ -2222,7 +2226,7 @@ class ModelHubService:
                 ],
             )
             agent.mappings = parsed
-            self.store.save(config)
+            await self._save_store(config)
             return self._agent_payload(config, agent)
 
     async def set_opencode_menu(self, menu: object) -> dict:
@@ -2251,7 +2255,7 @@ class ModelHubService:
                 ],
             )
             agent.menu = parsed
-            self.store.save(config)
+            await self._save_store(config)
             return self._agent_payload(config, agent)
 
     async def add_custom_model(self, payload: dict) -> dict:
@@ -2509,7 +2513,7 @@ class ModelHubService:
                 status=status,
                 detail_key=detail_key,
             )
-            self.store.save(config)
+            await self._save_store(config)
             if not unchanged:
                 self._record_event(
                     agent=cast(EventAgent, backend),
@@ -2922,7 +2926,7 @@ class ModelHubService:
             async with self._mutation_lock:
                 config = self.store.load()
                 config.subscription_hub_experimental = True
-                self.store.save(config)
+                await self._save_store(config)
         return {"flow": _oauth_payload(flow, channel=channel)}
 
     def _oauth_result(
@@ -3137,7 +3141,7 @@ class ModelHubService:
                     now=self.now(),
                 )
             if config_changed:
-                self.store.save(config)
+                await self._save_store(config)
 
     async def _cooldown(
         self,
@@ -3160,7 +3164,7 @@ class ModelHubService:
                 retry_at=(self.now() + timedelta(seconds=decision.cooldown_seconds)).isoformat(),
                 detail_key=detail_key or f"models.source.cooldown.{decision.reason}",
             )
-            self.store.save(config)
+            await self._save_store(config)
             if not already_cooling:
                 self._record_event(
                     agent=agent,

--- a/core/handlers/model_hub/service.py
+++ b/core/handlers/model_hub/service.py
@@ -571,8 +571,6 @@ class ModelHubService:
                 self._engine_synced = False
                 failure = rollback_error.__cause__ or rollback_error
                 logger.error("Model Hub rollback sync failed: %s", failure)
-                if rollback_save_error is None:
-                    settlement.raise_if_cancelled(rollback_error)
             else:
                 self._engine_synced = rollback_save_error is None
             if rollback_save_error is not None:

--- a/core/handlers/model_hub/service.py
+++ b/core/handlers/model_hub/service.py
@@ -545,25 +545,38 @@ class ModelHubService:
         settlement = CancellationSettlement()
         try:
             await self._save_store(updated, settlement=settlement)
-        except Exception:
-            settlement.raise_if_cancelled()
+        except (Exception, asyncio.CancelledError) as error:
+            settlement.raise_if_cancelled(error)
             raise
         try:
             await settlement.wait(
                 self._sync_sources(updated, force_empty=bool(previous_bindings))
             )
-        except (Exception, asyncio.CancelledError):
-            await self._save_store(previous, settlement=settlement)
+        except (Exception, asyncio.CancelledError) as sync_error:
+            try:
+                await self._save_store(previous, settlement=settlement)
+            except (Exception, asyncio.CancelledError) as rollback_error:
+                self._engine_synced = False
+                failure = rollback_error.__cause__ or rollback_error
+                logger.error("Model Hub rollback save failed: %s", failure)
+                settlement.raise_if_cancelled(rollback_error)
+                raise rollback_error from sync_error
             try:
                 await settlement.wait(
-                    self._sync_sources(previous, force_empty=bool(updated_bindings))
+                    self._sync_sources(
+                        previous,
+                        force_empty=bool(updated_bindings),
+                    )
                 )
-            except ModelHubError:
+            except (Exception, asyncio.CancelledError) as rollback_error:
                 self._engine_synced = False
+                failure = rollback_error.__cause__ or rollback_error
+                logger.error("Model Hub rollback sync failed: %s", failure)
+                settlement.raise_if_cancelled(rollback_error)
             else:
                 self._engine_synced = True
-            settlement.raise_if_cancelled()
-            raise
+            settlement.raise_if_cancelled(sync_error)
+            raise sync_error
         self._engine_synced = True
         settlement.raise_if_cancelled()
 

--- a/core/handlers/model_hub/service.py
+++ b/core/handlers/model_hub/service.py
@@ -28,7 +28,7 @@ from config.v2_config import (
     config_write_transaction,
 )
 from core.services.settings import default_config
-from core.memory.blocking import run_blocking
+from core.blocking import CancellationSettlement, run_blocking
 from storage.db import get_cached_sqlite_engine
 from storage.models import agent_sessions, messages
 from vibe.backend_model_catalog import backend_model_entries, load_bundled_catalog
@@ -514,8 +514,16 @@ class ModelHubService:
     def _clone_config(config: ModelHubConfig) -> ModelHubConfig:
         return ModelHubConfig.from_payload(config.to_payload())
 
-    async def _save_store(self, config: ModelHubConfig) -> None:
-        await run_blocking(self.store.save, config)
+    async def _save_store(
+        self,
+        config: ModelHubConfig,
+        *,
+        settlement: CancellationSettlement | None = None,
+    ) -> None:
+        if settlement is None:
+            await run_blocking(self.store.save, config)
+        else:
+            await settlement.run_blocking(self.store.save, config)
 
     async def _sync_sources(self, config: ModelHubConfig, *, force_empty: bool = False) -> None:
         bindings = self._bindings(config)
@@ -534,19 +542,30 @@ class ModelHubService:
         self._engine_synced = False
         previous_bindings = self._bindings(previous)
         updated_bindings = self._bindings(updated)
-        await self._save_store(updated)
+        settlement = CancellationSettlement()
         try:
-            await self._sync_sources(updated, force_empty=bool(previous_bindings))
+            await self._save_store(updated, settlement=settlement)
         except Exception:
-            await self._save_store(previous)
+            settlement.raise_if_cancelled()
+            raise
+        try:
+            await settlement.wait(
+                self._sync_sources(updated, force_empty=bool(previous_bindings))
+            )
+        except (Exception, asyncio.CancelledError):
+            await self._save_store(previous, settlement=settlement)
             try:
-                await self._sync_sources(previous, force_empty=bool(updated_bindings))
+                await settlement.wait(
+                    self._sync_sources(previous, force_empty=bool(updated_bindings))
+                )
             except ModelHubError:
                 self._engine_synced = False
             else:
                 self._engine_synced = True
+            settlement.raise_if_cancelled()
             raise
         self._engine_synced = True
+        settlement.raise_if_cancelled()
 
     async def _ensure_engine_synced(self) -> None:
         pending_revocations = self.revocations.list()

--- a/core/handlers/model_hub/service.py
+++ b/core/handlers/model_hub/service.py
@@ -553,14 +553,13 @@ class ModelHubService:
                 self._sync_sources(updated, force_empty=bool(previous_bindings))
             )
         except (Exception, asyncio.CancelledError) as sync_error:
+            rollback_save_error: BaseException | None = None
             try:
                 await self._save_store(previous, settlement=settlement)
             except (Exception, asyncio.CancelledError) as rollback_error:
                 self._engine_synced = False
-                failure = rollback_error.__cause__ or rollback_error
-                logger.error("Model Hub rollback save failed: %s", failure)
-                settlement.raise_if_cancelled(rollback_error)
-                raise rollback_error from sync_error
+                rollback_save_error = rollback_error
+                logger.error("Model Hub rollback save failed: %s", rollback_error)
             try:
                 await settlement.wait(
                     self._sync_sources(
@@ -572,9 +571,13 @@ class ModelHubService:
                 self._engine_synced = False
                 failure = rollback_error.__cause__ or rollback_error
                 logger.error("Model Hub rollback sync failed: %s", failure)
-                settlement.raise_if_cancelled(rollback_error)
+                if rollback_save_error is None:
+                    settlement.raise_if_cancelled(rollback_error)
             else:
-                self._engine_synced = True
+                self._engine_synced = rollback_save_error is None
+            if rollback_save_error is not None:
+                settlement.raise_if_cancelled(rollback_save_error)
+                raise rollback_save_error from sync_error
             settlement.raise_if_cancelled(sync_error)
             raise sync_error
         self._engine_synced = True

--- a/core/handlers/settings_handler.py
+++ b/core/handlers/settings_handler.py
@@ -6,6 +6,7 @@ from typing import Optional
 
 from modules.agents import get_agent_display_name
 from modules.im import MessageContext, InlineKeyboard, InlineButton
+from core.memory.blocking import run_blocking
 from core.modals import RoutingModalData, RoutingModalSelection
 from vibe import backend_model_catalog
 
@@ -708,10 +709,13 @@ class SettingsHandler(BaseHandler):
                 try:
                     from config.v2_config import V2Config, config_write_transaction
 
-                    with config_write_transaction():
-                        v2_config = V2Config.load()
-                        v2_config.language = language
-                        v2_config.save()
+                    def persist_language() -> None:
+                        with config_write_transaction():
+                            v2_config = V2Config.load()
+                            v2_config.language = language
+                            v2_config.save()
+
+                    await run_blocking(persist_language)
                     self.config.language = language
                 except Exception as err:
                     language_saved = False

--- a/core/handlers/settings_handler.py
+++ b/core/handlers/settings_handler.py
@@ -719,10 +719,13 @@ class SettingsHandler(BaseHandler):
                     await settlement.run_blocking(persist_language)
                     self.config.language = language
                     settlement.raise_if_cancelled()
+                except asyncio.CancelledError as error:
+                    settlement.raise_if_cancelled(error)
+                    raise
                 except Exception as err:
                     language_saved = False
                     logger.error(f"Failed to persist language setting: {err}")
-                    settlement.raise_if_cancelled()
+                    settlement.raise_if_cancelled(err)
 
             logger.info(
                 f"Updated settings for {settings_key}: show types = {show_message_types}, "

--- a/core/handlers/settings_handler.py
+++ b/core/handlers/settings_handler.py
@@ -718,14 +718,14 @@ class SettingsHandler(BaseHandler):
 
                     await settlement.run_blocking(persist_language)
                     self.config.language = language
-                    settlement.raise_if_cancelled()
-                except asyncio.CancelledError as error:
-                    settlement.raise_if_cancelled(error)
+                except asyncio.CancelledError:
                     raise
                 except Exception as err:
                     language_saved = False
                     logger.error(f"Failed to persist language setting: {err}")
                     settlement.raise_if_cancelled(err)
+                else:
+                    settlement.raise_if_cancelled()
 
             logger.info(
                 f"Updated settings for {settings_key}: show types = {show_message_types}, "

--- a/core/handlers/settings_handler.py
+++ b/core/handlers/settings_handler.py
@@ -6,7 +6,7 @@ from typing import Optional
 
 from modules.agents import get_agent_display_name
 from modules.im import MessageContext, InlineKeyboard, InlineButton
-from core.memory.blocking import run_blocking
+from core.blocking import CancellationSettlement
 from core.modals import RoutingModalData, RoutingModalSelection
 from vibe import backend_model_catalog
 
@@ -706,6 +706,7 @@ class SettingsHandler(BaseHandler):
 
             language_saved = True
             if language is not None and language != self.config.language:
+                settlement = CancellationSettlement()
                 try:
                     from config.v2_config import V2Config, config_write_transaction
 
@@ -715,11 +716,13 @@ class SettingsHandler(BaseHandler):
                             v2_config.language = language
                             v2_config.save()
 
-                    await run_blocking(persist_language)
+                    await settlement.run_blocking(persist_language)
                     self.config.language = language
+                    settlement.raise_if_cancelled()
                 except Exception as err:
                     language_saved = False
                     logger.error(f"Failed to persist language setting: {err}")
+                    settlement.raise_if_cancelled()
 
             logger.info(
                 f"Updated settings for {settings_key}: show types = {show_message_types}, "

--- a/core/handlers/settings_handler.py
+++ b/core/handlers/settings_handler.py
@@ -706,11 +706,12 @@ class SettingsHandler(BaseHandler):
             language_saved = True
             if language is not None and language != self.config.language:
                 try:
-                    from config.v2_config import V2Config
+                    from config.v2_config import V2Config, config_write_transaction
 
-                    v2_config = V2Config.load()
-                    v2_config.language = language
-                    v2_config.save()
+                    with config_write_transaction():
+                        v2_config = V2Config.load()
+                        v2_config.language = language
+                        v2_config.save()
                     self.config.language = language
                 except Exception as err:
                     language_saved = False

--- a/core/internal_server.py
+++ b/core/internal_server.py
@@ -48,7 +48,7 @@ from fastapi.responses import JSONResponse, StreamingResponse
 from sqlalchemy.exc import IntegrityError
 
 from config import paths
-from core.memory.blocking import run_blocking
+from core.blocking import run_blocking
 from core.services.dispatch import SOURCE_HUMAN, SOURCE_SCHEDULED
 from modules.im.base import MessageContext
 from storage.db import get_cached_sqlite_engine

--- a/core/memory/blocking.py
+++ b/core/memory/blocking.py
@@ -1,36 +1,7 @@
-"""Cancellation-safe execution for blocking Memory operations."""
+"""Compatibility imports for cancellation-safe Memory operations."""
 
 from __future__ import annotations
 
-import asyncio
-from collections.abc import Callable
-from typing import Any, TypeVar
+from core.blocking import CancellationSettlement, run_blocking
 
-
-_Result = TypeVar("_Result")
-
-
-async def run_blocking(
-    operation: Callable[..., _Result],
-    /,
-    *args: Any,
-    **kwargs: Any,
-) -> _Result:
-    """Settle one synchronous Memory operation before propagating cancellation."""
-
-    task = asyncio.create_task(asyncio.to_thread(operation, *args, **kwargs))
-    cancellation: asyncio.CancelledError | None = None
-    while not task.done():
-        try:
-            await asyncio.shield(task)
-        except asyncio.CancelledError as error:
-            cancellation = cancellation or error
-        except Exception:
-            break
-    if cancellation is not None:
-        try:
-            task.result()
-        except (Exception, asyncio.CancelledError):
-            pass
-        raise cancellation
-    return task.result()
+__all__ = ["CancellationSettlement", "run_blocking"]

--- a/core/memory/runtime.py
+++ b/core/memory/runtime.py
@@ -17,7 +17,7 @@ from pathlib import Path
 from typing import Any, TypeVar
 
 from config import paths
-from config.v2_config import CONFIG_LOCK, MemoryConfig, V2Config
+from config.v2_config import MemoryConfig, V2Config, config_write_transaction
 from core.memory.artifact import (
     EVEROS_VERSION,
     MemoryArtifactCandidate,
@@ -2057,13 +2057,13 @@ class MemoryRuntime:
         """Clear a persisted candidate marker only when its full config still matches."""
 
         try:
-            with CONFIG_LOCK:
+            with config_write_transaction():
                 persisted = V2Config.load()
                 if not _same_memory_configuration(persisted.memory, config):
                     return False
                 if persisted.memory.embedding_change_pending:
                     persisted.memory.embedding_change_pending = False
-                    persisted.save()
+                    persisted.save(preserve_memory=False)
                 config.embedding_change_pending = False
             return True
         except Exception:

--- a/tests/scenarios/auth_setup/catalog.yaml
+++ b/tests/scenarios/auth_setup/catalog.yaml
@@ -183,5 +183,12 @@ scenarios:
     layer: scenario
     backend: codex
     test: tests/scenarios/auth_setup/test_auth_setup_scenarios.py::test_codex_connection_probe_reuses_persistent_app_server
+  - id: AUTH-SETUP-907
+    name: Codex auth persistence failure refreshes runtime before reporting failure
+    status: covered
+    kind: historical_regression
+    layer: scenario
+    backend: codex
+    test: tests/scenarios/auth_setup/test_auth_setup_scenarios.py::test_codex_persist_failure_refreshes_runtime_before_reporting_failure
 next_priority:
   - AUTH-SETUP-301

--- a/tests/scenarios/auth_setup/catalog.yaml
+++ b/tests/scenarios/auth_setup/catalog.yaml
@@ -190,5 +190,12 @@ scenarios:
     layer: scenario
     backend: codex
     test: tests/scenarios/auth_setup/test_auth_setup_scenarios.py::test_codex_persist_failure_refreshes_runtime_before_reporting_failure
+  - id: AUTH-SETUP-908
+    name: Claude finalization failure still refreshes runtime before reporting failure
+    status: covered
+    kind: historical_regression
+    layer: scenario
+    backend: claude
+    test: tests/scenarios/auth_setup/test_auth_setup_scenarios.py::test_claude_finish_failure_refreshes_runtime_before_reporting_failure
 next_priority:
   - AUTH-SETUP-301

--- a/tests/scenarios/auth_setup/catalog.yaml
+++ b/tests/scenarios/auth_setup/catalog.yaml
@@ -197,5 +197,12 @@ scenarios:
     layer: scenario
     backend: claude
     test: tests/scenarios/auth_setup/test_auth_setup_scenarios.py::test_claude_finish_failure_refreshes_runtime_before_reporting_failure
+  - id: AUTH-SETUP-909
+    name: Claude cleanup failure still finalizes and refreshes live runtime
+    status: covered
+    kind: historical_regression
+    layer: scenario
+    backend: claude
+    test: tests/scenarios/auth_setup/test_auth_setup_scenarios.py::test_claude_cleanup_failure_still_finalizes_and_refreshes_runtime
 next_priority:
   - AUTH-SETUP-301

--- a/tests/scenarios/auth_setup/test_auth_setup_scenarios.py
+++ b/tests/scenarios/auth_setup/test_auth_setup_scenarios.py
@@ -24,6 +24,7 @@ from core.agent_auth_service import (
     AgentAuthFlow,
     AgentAuthService,
     BackendAuthConfigSaveError,
+    BackendAuthCredentialCleanupError,
 )
 from core.handlers.model_hub.service import ModelHubError
 from modules.agents.codex.agent import CodexAgent
@@ -908,17 +909,16 @@ class AgentAuthSetupScenarioTests(unittest.IsolatedAsyncioTestCase):
         )
         harness.service._send_claude_control_request = AsyncMock()
         harness.service._verify_login = AsyncMock(return_value=(True, "Logged in"))
-        harness.service._clear_claude_settings_env_for_oauth = AsyncMock(
-            side_effect=RuntimeError("credential cleanup failed")
+        harness.service._save_backend_auth_fields = AsyncMock(
+            side_effect=BackendAuthCredentialCleanupError("credential cleanup failed")
         )
-        harness.service._save_backend_auth_fields = AsyncMock()
         harness.service._finish_claude_oauth_attempt = AsyncMock()
         harness.service._refresh_backend_runtime = AsyncMock()
         harness.service._disconnect_claude_client = AsyncMock()
 
         await harness.service._wait_for_claude_completion(flow)
 
-        harness.service._save_backend_auth_fields.assert_not_awaited()
+        harness.service._save_backend_auth_fields.assert_awaited_once()
         harness.service._finish_claude_oauth_attempt.assert_any_await(
             None,
             succeeded=True,

--- a/tests/scenarios/auth_setup/test_auth_setup_scenarios.py
+++ b/tests/scenarios/auth_setup/test_auth_setup_scenarios.py
@@ -20,7 +20,7 @@ from config.v2_config import (
     SlackConfig,
     V2Config,
 )
-from core.agent_auth_service import AgentAuthService
+from core.agent_auth_service import AgentAuthService, BackendAuthConfigSaveError
 from core.handlers.model_hub.service import ModelHubError
 from modules.agents.codex.agent import CodexAgent
 from tests.scenario_harness.auth_setup import AuthSetupScenarioHarness, FakeProcess
@@ -830,6 +830,30 @@ class AgentAuthSetupScenarioTests(unittest.IsolatedAsyncioTestCase):
         ScenarioExpect.text_contains(harness, "T74L-XU61D", index=1)
         ScenarioExpect.text_contains(harness, "codex login is active again")
         ScenarioExpect.flow_missing(harness, "C1:codex")
+
+    async def test_codex_persist_failure_refreshes_runtime_before_reporting_failure(self):
+        """Scenario: AUTH-SETUP-907"""
+        harness = AuthSetupScenarioHarness()
+        fake_process = FakeProcess()
+        harness.service._start_codex_process = AsyncMock(return_value=fake_process)
+        harness.service._read_codex_output = AsyncMock(return_value=None)
+        harness.service._verify_login = AsyncMock(return_value=(True, "Logged in"))
+        harness.service._persist_backend_auth_mode = AsyncMock(
+            side_effect=BackendAuthConfigSaveError("config save failed")
+        )
+        harness.service._refresh_backend_runtime = AsyncMock()
+
+        await harness.service.start_setup(
+            harness.context,
+            backend="codex",
+            force_reset=True,
+        )
+        flow = harness.flow("codex")
+        fake_process.finish(0)
+        await flow.waiter_task
+
+        harness.service._refresh_backend_runtime.assert_awaited_once_with("codex")
+        ScenarioExpect.text_contains(harness, "config save failed")
 
     async def test_codex_successful_setup_refreshes_runtime_before_the_next_turn(self):
         """Scenario: AUTH-SETUP-901"""

--- a/tests/scenarios/auth_setup/test_auth_setup_scenarios.py
+++ b/tests/scenarios/auth_setup/test_auth_setup_scenarios.py
@@ -892,6 +892,40 @@ class AgentAuthSetupScenarioTests(unittest.IsolatedAsyncioTestCase):
         harness.service._refresh_backend_runtime.assert_awaited_once_with("claude")
         ScenarioExpect.text_contains(harness, "attempt finish failed")
 
+    async def test_claude_cleanup_failure_still_finalizes_and_refreshes_runtime(self):
+        """Scenario: AUTH-SETUP-909"""
+        harness = AuthSetupScenarioHarness()
+        flow = AgentAuthFlow(
+            flow_id="claude-cleanup-failure",
+            backend="claude",
+            settings_key="C1",
+            initiator_user_id="U1",
+            context=harness.context,
+            process=None,
+            reader_task=None,
+            waiter_task=None,
+            claude_client=SimpleNamespace(),
+        )
+        harness.service._send_claude_control_request = AsyncMock()
+        harness.service._verify_login = AsyncMock(return_value=(True, "Logged in"))
+        harness.service._clear_claude_settings_env_for_oauth = AsyncMock(
+            side_effect=RuntimeError("credential cleanup failed")
+        )
+        harness.service._save_backend_auth_fields = AsyncMock()
+        harness.service._finish_claude_oauth_attempt = AsyncMock()
+        harness.service._refresh_backend_runtime = AsyncMock()
+        harness.service._disconnect_claude_client = AsyncMock()
+
+        await harness.service._wait_for_claude_completion(flow)
+
+        harness.service._save_backend_auth_fields.assert_not_awaited()
+        harness.service._finish_claude_oauth_attempt.assert_any_await(
+            None,
+            succeeded=True,
+        )
+        harness.service._refresh_backend_runtime.assert_awaited_once_with("claude")
+        ScenarioExpect.text_contains(harness, "credential cleanup failed")
+
     async def test_codex_successful_setup_refreshes_runtime_before_the_next_turn(self):
         """Scenario: AUTH-SETUP-901"""
         harness = AuthSetupScenarioHarness()

--- a/tests/scenarios/auth_setup/test_auth_setup_scenarios.py
+++ b/tests/scenarios/auth_setup/test_auth_setup_scenarios.py
@@ -6,7 +6,7 @@ import tempfile
 import unittest
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, patch
+from unittest.mock import ANY, AsyncMock, patch
 
 ROOT = Path(__file__).resolve().parents[3]
 sys.path.insert(0, str(ROOT))
@@ -818,7 +818,11 @@ class AgentAuthSetupScenarioTests(unittest.IsolatedAsyncioTestCase):
         fake_process.finish(0)
         await flow.waiter_task
 
-        harness.service._persist_backend_auth_mode.assert_awaited_once_with("codex", "oauth")
+        harness.service._persist_backend_auth_mode.assert_awaited_once_with(
+            "codex",
+            "oauth",
+            settlement=ANY,
+        )
         harness.service._refresh_backend_runtime.assert_awaited_once_with("codex")
         ScenarioExpect.step_history(runner, ["start_setup", "emit_device_url", "emit_device_code"])
         ScenarioExpect.text_contains(harness, "starting codex", index=0)

--- a/tests/scenarios/auth_setup/test_auth_setup_scenarios.py
+++ b/tests/scenarios/auth_setup/test_auth_setup_scenarios.py
@@ -20,7 +20,11 @@ from config.v2_config import (
     SlackConfig,
     V2Config,
 )
-from core.agent_auth_service import AgentAuthService, BackendAuthConfigSaveError
+from core.agent_auth_service import (
+    AgentAuthFlow,
+    AgentAuthService,
+    BackendAuthConfigSaveError,
+)
 from core.handlers.model_hub.service import ModelHubError
 from modules.agents.codex.agent import CodexAgent
 from tests.scenario_harness.auth_setup import AuthSetupScenarioHarness, FakeProcess
@@ -854,6 +858,39 @@ class AgentAuthSetupScenarioTests(unittest.IsolatedAsyncioTestCase):
 
         harness.service._refresh_backend_runtime.assert_awaited_once_with("codex")
         ScenarioExpect.text_contains(harness, "config save failed")
+
+    async def test_claude_finish_failure_refreshes_runtime_before_reporting_failure(self):
+        """Scenario: AUTH-SETUP-908"""
+        harness = AuthSetupScenarioHarness()
+        flow = AgentAuthFlow(
+            flow_id="claude-finish-failure",
+            backend="claude",
+            settings_key="C1",
+            initiator_user_id="U1",
+            context=harness.context,
+            process=None,
+            reader_task=None,
+            waiter_task=None,
+            claude_client=SimpleNamespace(),
+        )
+        harness.service._send_claude_control_request = AsyncMock()
+        harness.service._verify_login = AsyncMock(return_value=(True, "Logged in"))
+        harness.service._persist_backend_auth_mode = AsyncMock()
+
+        async def finish_attempt(_attempt, *, succeeded):
+            if succeeded:
+                raise RuntimeError("attempt finish failed")
+
+        harness.service._finish_claude_oauth_attempt = AsyncMock(
+            side_effect=finish_attempt
+        )
+        harness.service._refresh_backend_runtime = AsyncMock()
+        harness.service._disconnect_claude_client = AsyncMock()
+
+        await harness.service._wait_for_claude_completion(flow)
+
+        harness.service._refresh_backend_runtime.assert_awaited_once_with("claude")
+        ScenarioExpect.text_contains(harness, "attempt finish failed")
 
     async def test_codex_successful_setup_refreshes_runtime_before_the_next_turn(self):
         """Scenario: AUTH-SETUP-901"""

--- a/tests/test_agent_auth_service.py
+++ b/tests/test_agent_auth_service.py
@@ -1251,7 +1251,7 @@ class AgentAuthServiceTests(_IsolatedClaudeConfigDirMixin, unittest.IsolatedAsyn
         ):
             await service._wait_for_claude_completion(flow)
 
-        service._refresh_backend_runtime.assert_not_awaited()
+        service._refresh_backend_runtime.assert_awaited_once_with("claude")
         service._disconnect_claude_client.assert_awaited_once_with(fake_client)
         self.assertIn("failed", controller.im_client.sent_button_messages[0][1].lower())
         self.assertIn("Failed to clear Claude Code settings env", controller.im_client.sent_button_messages[0][1])

--- a/tests/test_codex_api_auth.py
+++ b/tests/test_codex_api_auth.py
@@ -233,6 +233,69 @@ def test_save_codex_auth_preserved_fields_share_final_config_transaction(
     assert api.load_config().agents.codex.base_url == "https://new.example.test/v1"
 
 
+def test_save_codex_auth_reads_preserved_disk_key_inside_transaction(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    from core.services.settings import default_config
+    from storage.lock import MigrationFileLock
+    from vibe import codex_config
+
+    codex_home = tmp_path / ".codex"
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    monkeypatch.setenv("CODEX_HOME", str(codex_home))
+    config = default_config()
+    config.agents.codex.auth_mode = "api_key"
+    config.agents.codex.api_key = "sk-old"
+    config.agents.codex.base_url = "https://old.example.test/v1"
+    config.save()
+    codex_config.apply_codex_auth(
+        auth_mode="api_key",
+        api_key="sk-old",
+        base_url="https://old.example.test/v1",
+    )
+    context = multiprocessing.get_context("spawn")
+    attempting = context.Event()
+    finished = context.Event()
+    concurrent = context.Process(
+        target=_save_codex_api_key,
+        args=(str(tmp_path), str(codex_home), "sk-new", attempting, finished),
+    )
+    original_acquire = MigrationFileLock.acquire
+    interleaved = False
+
+    def rotate_before_parent_acquires(lock) -> None:
+        nonlocal interleaved
+        if not interleaved:
+            interleaved = True
+            concurrent.start()
+            assert attempting.wait(timeout=5)
+            assert finished.wait(timeout=5)
+        original_acquire(lock)
+
+    monkeypatch.setattr(MigrationFileLock, "acquire", rotate_before_parent_acquires)
+    monkeypatch.setattr(api, "restart_backend", lambda name, **kwargs: {"ok": True})
+    try:
+        result = api.save_codex_auth(
+            {
+                "auth_mode": "api_key",
+                "base_url": "https://parent.example.test/v1",
+            }
+        )
+    finally:
+        concurrent.join(timeout=5)
+        if concurrent.is_alive():
+            concurrent.terminate()
+            concurrent.join(timeout=5)
+
+    assert result["ok"] is True
+    assert concurrent.exitcode == 0
+    assert codex_config.read_codex_api_key() == "sk-new"
+    persisted = api.load_config().agents.codex
+    assert persisted.api_key == "sk-new"
+    assert persisted.base_url == "https://parent.example.test/v1"
+
+
 def test_remove_codex_api_key_serializes_credential_and_config_mutations(
     monkeypatch,
     tmp_path: Path,

--- a/tests/test_codex_api_auth.py
+++ b/tests/test_codex_api_auth.py
@@ -48,6 +48,36 @@ def _save_codex_base_url(
     finished.set()
 
 
+def _save_codex_api_key(
+    avibe_home: str,
+    codex_home: str,
+    api_key: str,
+    attempting,
+    finished,
+) -> None:
+    os.environ["AVIBE_HOME"] = avibe_home
+    os.environ["CODEX_HOME"] = codex_home
+    from storage.lock import MigrationFileLock
+    from vibe import api as child_api
+
+    original_acquire = MigrationFileLock.acquire
+
+    def signal_acquire(lock) -> None:
+        attempting.set()
+        original_acquire(lock)
+
+    MigrationFileLock.acquire = signal_acquire
+    child_api.restart_backend = lambda name, **kwargs: {"ok": True}
+    child_api.save_codex_auth(
+        {
+            "auth_mode": "api_key",
+            "api_key": api_key,
+            "base_url": "https://new.example.test/v1",
+        }
+    )
+    finished.set()
+
+
 def _seed_disk(home: Path, *, api_key: str | None, store: str | None) -> None:
     codex_home = home / ".codex"
     codex_home.mkdir(parents=True, exist_ok=True)
@@ -201,3 +231,69 @@ def test_save_codex_auth_preserved_fields_share_final_config_transaction(
     assert concurrent.exitcode == 0
     assert observed_base_urls == ["https://old.example.test/v1"]
     assert api.load_config().agents.codex.base_url == "https://new.example.test/v1"
+
+
+def test_remove_codex_api_key_serializes_credential_and_config_mutations(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    from core.services.settings import default_config
+    from storage.lock import MigrationFileLock
+    from vibe import codex_config
+
+    codex_home = tmp_path / ".codex"
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    monkeypatch.setenv("CODEX_HOME", str(codex_home))
+    config = default_config()
+    config.agents.codex.auth_mode = "api_key"
+    config.agents.codex.api_key = "sk-old"
+    config.agents.codex.base_url = "https://old.example.test/v1"
+    config.save()
+    codex_config.apply_codex_auth(
+        auth_mode="api_key",
+        api_key="sk-old",
+        base_url="https://old.example.test/v1",
+    )
+    context = multiprocessing.get_context("spawn")
+    attempting = context.Event()
+    finished = context.Event()
+    concurrent = context.Process(
+        target=_save_codex_api_key,
+        args=(str(tmp_path), str(codex_home), "sk-new", attempting, finished),
+    )
+    original_apply = codex_config.apply_codex_auth
+    original_acquire = MigrationFileLock.acquire
+    interleaved = False
+
+    def remove_then_interleave(**kwargs):
+        nonlocal interleaved
+        result = original_apply(**kwargs)
+        interleaved = True
+        concurrent.start()
+        assert attempting.wait(timeout=5)
+        return result
+
+    def wait_for_concurrent_writer(lock) -> None:
+        if interleaved:
+            assert finished.wait(timeout=5)
+        original_acquire(lock)
+
+    monkeypatch.setattr(codex_config, "apply_codex_auth", remove_then_interleave)
+    monkeypatch.setattr(MigrationFileLock, "acquire", wait_for_concurrent_writer)
+    monkeypatch.setattr(api, "restart_backend", lambda name, **kwargs: {"ok": True})
+    try:
+        result = api.remove_backend_api_key("codex")
+        assert finished.wait(timeout=5)
+    finally:
+        concurrent.join(timeout=5)
+        if concurrent.is_alive():
+            concurrent.terminate()
+            concurrent.join(timeout=5)
+
+    persisted = api.load_config()
+    assert result["ok"] is True
+    assert concurrent.exitcode == 0
+    assert codex_config.read_codex_api_key() == "sk-new"
+    assert persisted.agents.codex.auth_mode == "api_key"
+    assert persisted.agents.codex.api_key == "sk-new"
+    assert persisted.agents.codex.base_url == "https://new.example.test/v1"

--- a/tests/test_codex_api_auth.py
+++ b/tests/test_codex_api_auth.py
@@ -13,6 +13,8 @@ Pins two contracts:
 from __future__ import annotations
 
 import json
+import multiprocessing
+import os
 import sys
 import types
 from pathlib import Path
@@ -20,6 +22,30 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from vibe import api  # noqa: E402
+
+
+def _save_codex_base_url(
+    avibe_home: str,
+    base_url: str,
+    attempting,
+    finished,
+) -> None:
+    os.environ["AVIBE_HOME"] = avibe_home
+    from storage.lock import MigrationFileLock
+    from vibe import api as child_api
+    from vibe import codex_config
+
+    original_acquire = MigrationFileLock.acquire
+
+    def signal_acquire(lock) -> None:
+        attempting.set()
+        original_acquire(lock)
+
+    MigrationFileLock.acquire = signal_acquire
+    codex_config.apply_codex_auth = lambda **kwargs: {}
+    child_api.restart_backend = lambda name, **kwargs: {"ok": True}
+    child_api.save_codex_auth({"auth_mode": "oauth", "base_url": base_url})
+    finished.set()
 
 
 def _seed_disk(home: Path, *, api_key: str | None, store: str | None) -> None:
@@ -113,3 +139,65 @@ def test_save_codex_auth_falls_back_to_v2config_when_disk_empty(
 
     auth = json.loads((tmp_path / ".codex" / "auth.json").read_text(encoding="utf-8"))
     assert auth["OPENAI_API_KEY"] == "sk-from-cache"
+
+
+def test_save_codex_auth_preserved_fields_share_final_config_transaction(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    from core.services.settings import default_config
+    from storage.lock import MigrationFileLock
+    from vibe import codex_config
+
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path / ".codex"))
+    config = default_config()
+    config.agents.codex.auth_mode = "oauth"
+    config.agents.codex.base_url = "https://old.example.test/v1"
+    config.save()
+    context = multiprocessing.get_context("spawn")
+    attempting = context.Event()
+    finished = context.Event()
+    concurrent = context.Process(
+        target=_save_codex_base_url,
+        args=(
+            str(tmp_path),
+            "https://new.example.test/v1",
+            attempting,
+            finished,
+        ),
+    )
+    apply_entered = False
+    observed_base_urls: list[str | None] = []
+
+    def apply_codex_auth(**kwargs):
+        nonlocal apply_entered
+        apply_entered = True
+        observed_base_urls.append(kwargs["base_url"])
+        concurrent.start()
+        assert attempting.wait(timeout=5)
+        return {}
+
+    original_acquire = MigrationFileLock.acquire
+
+    def wait_for_concurrent_writer(lock) -> None:
+        if apply_entered:
+            assert finished.wait(timeout=5)
+        original_acquire(lock)
+
+    monkeypatch.setattr(codex_config, "apply_codex_auth", apply_codex_auth)
+    monkeypatch.setattr(MigrationFileLock, "acquire", wait_for_concurrent_writer)
+    monkeypatch.setattr(api, "restart_backend", lambda name, **kwargs: {"ok": True})
+    try:
+        result = api.save_codex_auth({"auth_mode": "oauth"})
+        assert finished.wait(timeout=5)
+    finally:
+        concurrent.join(timeout=5)
+        if concurrent.is_alive():
+            concurrent.terminate()
+            concurrent.join(timeout=5)
+
+    assert result["ok"] is True
+    assert concurrent.exitcode == 0
+    assert observed_base_urls == ["https://old.example.test/v1"]
+    assert api.load_config().agents.codex.base_url == "https://new.example.test/v1"

--- a/tests/test_controller_config_reload.py
+++ b/tests/test_controller_config_reload.py
@@ -1,6 +1,10 @@
+import contextlib
+import json
 from types import SimpleNamespace
 
+from config import paths
 from config.v2_config import DiscordConfig, TelegramConfig, V2Config
+import core.controller as controller_module
 from core.controller import Controller
 
 
@@ -164,3 +168,47 @@ def test_progress_style_getter_self_refreshes_from_disk(tmp_path, monkeypatch) -
     # No prior _refresh_config_from_disk call; the getter itself must pick it up.
     assert controller.get_progress_style_for_context(None) == "concise"
     assert controller.get_heartbeat_interval_ms_for_context(None) == 8000
+
+
+def test_language_migration_preserves_concurrent_global_choice(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    config = V2Config.from_payload(_config_payload({"bot_token": "discord-token"}))
+    config.save()
+    config_path = paths.get_config_path()
+    config_payload = json.loads(config_path.read_text(encoding="utf-8"))
+    config_payload.pop("language")
+    config_path.write_text(json.dumps(config_payload), encoding="utf-8")
+    settings_path = paths.get_settings_path()
+    settings_path.parent.mkdir(parents=True, exist_ok=True)
+    settings_path.write_text(
+        json.dumps({"channels": {"legacy": {"language": "zh"}}}),
+        encoding="utf-8",
+    )
+
+    controller = Controller.__new__(Controller)
+    controller.config = V2Config.load()
+    original_transaction = controller_module.config_write_transaction
+    injected = False
+
+    @contextlib.contextmanager
+    def transaction_with_concurrent_choice(*args, **kwargs):
+        nonlocal injected
+        with original_transaction(*args, **kwargs):
+            if not injected:
+                injected = True
+                latest = json.loads(config_path.read_text(encoding="utf-8"))
+                latest["language"] = "en"
+                config_path.write_text(json.dumps(latest), encoding="utf-8")
+            yield
+
+    monkeypatch.setattr(
+        controller_module,
+        "config_write_transaction",
+        transaction_with_concurrent_choice,
+    )
+
+    controller._migrate_language_from_settings()
+
+    persisted = json.loads(config_path.read_text(encoding="utf-8"))
+    assert persisted["language"] == "en"
+    assert controller.config.language == "en"

--- a/tests/test_memory_blocking.py
+++ b/tests/test_memory_blocking.py
@@ -67,6 +67,7 @@ def test_run_blocking_cancellation_precedes_later_operation_failure() -> None:
         with pytest.raises(asyncio.CancelledError) as raised:
             await call
         assert raised.value.args == ("caller stopped",)
+        assert raised.value.__cause__ is None
 
     asyncio.run(run())
 
@@ -172,6 +173,31 @@ def test_cancellation_settlement_propagates_child_cancellation_without_retaining
             await settlement.wait(child())
         assert raised.value.args == ("child stopped",)
         assert not settlement.cancelled
+
+    asyncio.run(run())
+
+
+def test_cancellation_settlement_caller_cancel_precedes_child_cancellation() -> None:
+    child_entered = asyncio.Event()
+    release_child = asyncio.Event()
+
+    async def child() -> None:
+        child_entered.set()
+        await release_child.wait()
+        raise asyncio.CancelledError("child stopped")
+
+    async def run() -> None:
+        settlement = CancellationSettlement()
+        call = asyncio.create_task(settlement.wait(child()))
+        await child_entered.wait()
+        call.cancel("caller stopped")
+        await asyncio.sleep(0)
+        release_child.set()
+        with pytest.raises(asyncio.CancelledError) as raised:
+            await call
+        assert raised.value.args == ("caller stopped",)
+        assert isinstance(raised.value.__cause__, asyncio.CancelledError)
+        assert raised.value.__cause__.args == ("child stopped",)
 
     asyncio.run(run())
 

--- a/tests/test_memory_blocking.py
+++ b/tests/test_memory_blocking.py
@@ -174,3 +174,70 @@ def test_cancellation_settlement_propagates_child_cancellation_without_retaining
         assert not settlement.cancelled
 
     asyncio.run(run())
+
+
+def test_cancellation_settlement_caller_cancel_precedes_later_stage_failure() -> None:
+    entered = threading.Event()
+    release = threading.Event()
+    dependent_ran = False
+
+    def failing_cleanup() -> None:
+        entered.set()
+        assert release.wait(timeout=2)
+        raise RuntimeError("cleanup failed")
+
+    async def run() -> None:
+        nonlocal dependent_ran
+
+        async def operation() -> None:
+            settlement = CancellationSettlement()
+            try:
+                await settlement.run_blocking(failing_cleanup)
+            except RuntimeError as error:
+                settlement.raise_if_cancelled(error)
+                raise
+            dependent_ran = True
+
+        call = asyncio.create_task(operation())
+        assert await asyncio.to_thread(entered.wait, 1)
+        call.cancel("caller stopped")
+        await asyncio.sleep(0)
+        release.set()
+        with pytest.raises(asyncio.CancelledError) as raised:
+            await call
+        assert raised.value.args == ("caller stopped",)
+        assert isinstance(raised.value.__cause__, RuntimeError)
+        assert str(raised.value.__cause__) == "cleanup failed"
+
+    asyncio.run(run())
+    assert not dependent_ran
+
+
+def test_cancellation_settlement_wait_preserves_failure_until_boundary() -> None:
+    entered = threading.Event()
+    release = threading.Event()
+
+    def failing_operation() -> None:
+        entered.set()
+        assert release.wait(timeout=2)
+        raise RuntimeError("underlying failure")
+
+    async def run() -> None:
+        async def operation() -> tuple[RuntimeError, bool]:
+            settlement = CancellationSettlement()
+            try:
+                await settlement.run_blocking(failing_operation)
+            except RuntimeError as error:
+                return error, settlement.cancelled
+            raise AssertionError("expected the underlying failure")
+
+        call = asyncio.create_task(operation())
+        assert await asyncio.to_thread(entered.wait, 1)
+        call.cancel("caller stopped")
+        await asyncio.sleep(0)
+        release.set()
+        error, cancellation_retained = await call
+        assert str(error) == "underlying failure"
+        assert cancellation_retained
+
+    asyncio.run(run())

--- a/tests/test_memory_blocking.py
+++ b/tests/test_memory_blocking.py
@@ -6,6 +6,7 @@ from concurrent.futures import ThreadPoolExecutor
 
 import pytest
 
+from core.blocking import CancellationSettlement
 from core.memory.blocking import run_blocking
 
 
@@ -121,5 +122,55 @@ def test_run_blocking_completed_result_is_not_changed_by_late_cancellation() -> 
         assert await call == "settled"
         assert call.cancel("too late") is False
         assert call.result() == "settled"
+
+    asyncio.run(run())
+
+
+def test_cancellation_settlement_runs_followup_before_rethrowing_first_cancel() -> None:
+    entered = threading.Event()
+    release = threading.Event()
+    events: list[str] = []
+
+    def commit() -> str:
+        entered.set()
+        assert release.wait(timeout=2)
+        events.append("commit")
+        return "committed"
+
+    async def reconcile(value: str) -> None:
+        events.append(f"reconcile:{value}")
+
+    async def run() -> None:
+        async def operation() -> None:
+            settlement = CancellationSettlement()
+            committed = await settlement.run_blocking(commit)
+            await settlement.wait(reconcile(committed))
+            settlement.raise_if_cancelled()
+
+        call = asyncio.create_task(operation())
+        assert await asyncio.to_thread(entered.wait, 1)
+        call.cancel("first")
+        await asyncio.sleep(0)
+        call.cancel("second")
+        await asyncio.sleep(0)
+        release.set()
+        with pytest.raises(asyncio.CancelledError) as raised:
+            await call
+        assert raised.value.args == ("first",)
+
+    asyncio.run(run())
+    assert events == ["commit", "reconcile:committed"]
+
+
+def test_cancellation_settlement_propagates_child_cancellation_without_retaining_it() -> None:
+    async def child() -> None:
+        raise asyncio.CancelledError("child stopped")
+
+    async def run() -> None:
+        settlement = CancellationSettlement()
+        with pytest.raises(asyncio.CancelledError) as raised:
+            await settlement.wait(child())
+        assert raised.value.args == ("child stopped",)
+        assert not settlement.cancelled
 
     asyncio.run(run())

--- a/tests/test_memory_config.py
+++ b/tests/test_memory_config.py
@@ -1,12 +1,83 @@
 from __future__ import annotations
 
 import json
+import multiprocessing
+import os
 
 import pytest
 
-from config.v2_config import AgentsConfig, MemoryConfig, MemoryEndpointConfig, RuntimeConfig, SlackConfig, V2Config
+from config.v2_config import (
+    AgentsConfig,
+    MemoryConfig,
+    MemoryEndpointConfig,
+    RuntimeConfig,
+    SlackConfig,
+    V2Config,
+    config_write_transaction,
+)
 from vibe import api
 from vibe.api import config_to_payload
+
+
+def _save_stale_general_config(
+    avibe_home: str,
+    loaded,
+    release,
+) -> None:
+    os.environ["AVIBE_HOME"] = avibe_home
+    stale = V2Config.load()
+    loaded.set()
+    if not release.wait(timeout=5):
+        raise TimeoutError("test did not release stale general config writer")
+    stale.runtime.log_level = "DEBUG"
+    stale.save()
+
+
+def _save_memory_candidate(avibe_home: str) -> None:
+    os.environ["AVIBE_HOME"] = avibe_home
+    api.save_memory_config(
+        {
+            "enabled": False,
+            "processing": {
+                "llm": {
+                    "base_url": "https://llm.example.test/v1",
+                    "model": "chat",
+                    "api_key": "llm-key",
+                },
+                "embedding": {
+                    "base_url": "https://embed.example.test/v1",
+                    "model": "embed-v2",
+                    "api_key": "embed-key",
+                },
+            },
+        },
+        embedding_change_pending=True,
+    )
+
+
+def _save_paused_memory_candidate(
+    avibe_home: str,
+    about_to_lock,
+    release,
+) -> None:
+    os.environ["AVIBE_HOME"] = avibe_home
+    from storage.lock import MigrationFileLock
+
+    original_acquire = MigrationFileLock.acquire
+
+    def acquire_after_release(lock) -> None:
+        about_to_lock.set()
+        if not release.wait(timeout=5):
+            raise TimeoutError("test did not release stale Memory config writer")
+        original_acquire(lock)
+
+    MigrationFileLock.acquire = acquire_after_release
+    _save_memory_candidate(avibe_home)
+
+
+def _save_general_config(avibe_home: str) -> None:
+    os.environ["AVIBE_HOME"] = avibe_home
+    api.save_config({"runtime": {"log_level": "DEBUG"}})
 
 
 def _payload(memory: dict) -> dict:
@@ -186,6 +257,131 @@ def test_generic_config_save_preserves_memory_keys(monkeypatch, tmp_path) -> Non
     assert saved.memory.processing.llm.api_key == "llm-key"
     assert saved.memory.processing.embedding.api_key == "embed-key"
     assert saved.memory.embedding_change_pending is True
+
+
+def test_config_write_transaction_reuses_same_path_lock(monkeypatch, tmp_path) -> None:
+    from storage.lock import MigrationFileLock
+
+    acquire_count = 0
+    original_acquire = MigrationFileLock.acquire
+
+    def counted_acquire(lock) -> None:
+        nonlocal acquire_count
+        acquire_count += 1
+        original_acquire(lock)
+
+    monkeypatch.setattr(MigrationFileLock, "acquire", counted_acquire)
+    config_path = tmp_path / "config.json"
+    config = V2Config.from_payload(_payload({"enabled": False, "processing": {}}))
+
+    with config_write_transaction(config_path):
+        config.save(config_path, preserve_memory=False)
+
+    assert acquire_count == 1
+
+
+def test_config_write_transaction_rejects_nested_different_path(tmp_path) -> None:
+    first_path = tmp_path / "first" / "config.json"
+    second_path = tmp_path / "second" / "config.json"
+
+    with config_write_transaction(first_path):
+        with pytest.raises(RuntimeError, match="different paths"):
+            with config_write_transaction(second_path):
+                pass
+
+
+def test_stale_general_writer_cannot_overwrite_memory_candidate_across_processes(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    V2Config.from_payload(
+        _payload(
+            {
+                "enabled": False,
+                "processing": _complete_processing(),
+            }
+        )
+    ).save()
+    context = multiprocessing.get_context("spawn")
+    loaded = context.Event()
+    release = context.Event()
+    general = context.Process(
+        target=_save_stale_general_config,
+        args=(str(tmp_path), loaded, release),
+    )
+    memory = context.Process(
+        target=_save_memory_candidate,
+        args=(str(tmp_path),),
+    )
+
+    general.start()
+    try:
+        assert loaded.wait(timeout=5)
+        memory.start()
+        memory.join(timeout=5)
+        assert memory.exitcode == 0
+        release.set()
+        general.join(timeout=5)
+        assert general.exitcode == 0
+    finally:
+        release.set()
+        for process in (memory, general):
+            if process.is_alive():
+                process.terminate()
+            process.join(timeout=5)
+
+    persisted = V2Config.load()
+    assert persisted.runtime.log_level == "DEBUG"
+    assert persisted.memory.processing.embedding.model == "embed-v2"
+    assert persisted.memory.embedding_change_pending is True
+
+
+def test_stale_memory_writer_cannot_overwrite_general_config_across_processes(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    V2Config.from_payload(
+        _payload(
+            {
+                "enabled": False,
+                "processing": _complete_processing(),
+            }
+        )
+    ).save()
+    context = multiprocessing.get_context("spawn")
+    about_to_lock = context.Event()
+    release = context.Event()
+    memory = context.Process(
+        target=_save_paused_memory_candidate,
+        args=(str(tmp_path), about_to_lock, release),
+    )
+    general = context.Process(
+        target=_save_general_config,
+        args=(str(tmp_path),),
+    )
+
+    memory.start()
+    try:
+        assert about_to_lock.wait(timeout=5)
+        general.start()
+        general.join(timeout=5)
+        assert general.exitcode == 0
+        release.set()
+        memory.join(timeout=5)
+        assert memory.exitcode == 0
+    finally:
+        release.set()
+        for process in (general, memory):
+            if process.is_alive():
+                process.terminate()
+            process.join(timeout=5)
+
+    persisted = V2Config.load()
+    assert persisted.runtime.log_level == "DEBUG"
+    assert persisted.memory.processing.embedding.model == "embed-v2"
+    assert persisted.memory.embedding_change_pending is True
 
 
 def test_memory_save_uses_dedicated_config_writer(monkeypatch, tmp_path) -> None:

--- a/tests/test_memory_config.py
+++ b/tests/test_memory_config.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import multiprocessing
 import os
+import threading
 
 import pytest
 
@@ -17,6 +18,19 @@ from config.v2_config import (
 )
 from vibe import api
 from vibe.api import config_to_payload
+
+
+def _hold_config_file_lock(avibe_home: str, acquired, release) -> None:
+    os.environ["AVIBE_HOME"] = avibe_home
+    from config import paths
+    from storage.lock import MigrationFileLock
+
+    config_path = paths.get_config_path().resolve(strict=False)
+    lock_path = config_path.with_name(f".{config_path.name}.lock")
+    with MigrationFileLock(lock_path):
+        acquired.set()
+        if not release.wait(timeout=5):
+            raise TimeoutError("test did not release config file lock")
 
 
 def _save_stale_general_config(
@@ -331,6 +345,67 @@ def test_config_write_transaction_rejects_nested_different_path(tmp_path) -> Non
         with pytest.raises(RuntimeError, match="different paths"):
             with config_write_transaction(second_path):
                 pass
+
+
+def test_config_writer_waiting_for_file_lock_does_not_block_config_reads(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    from storage.lock import MigrationFileLock
+
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    V2Config.from_payload(_payload({"enabled": False, "processing": {}})).save()
+    context = multiprocessing.get_context("spawn")
+    acquired = context.Event()
+    release = context.Event()
+    lock_owner = context.Process(
+        target=_hold_config_file_lock,
+        args=(str(tmp_path), acquired, release),
+    )
+    writer_attempting = threading.Event()
+    writer_finished = threading.Event()
+    reader_finished = threading.Event()
+    original_acquire = MigrationFileLock.acquire
+
+    def signal_writer_attempt(lock) -> None:
+        writer_attempting.set()
+        original_acquire(lock)
+
+    monkeypatch.setattr(MigrationFileLock, "acquire", signal_writer_attempt)
+
+    def writer() -> None:
+        with config_write_transaction():
+            pass
+        writer_finished.set()
+
+    def reader() -> None:
+        V2Config.load()
+        reader_finished.set()
+
+    lock_owner.start()
+    writer_thread = threading.Thread(target=writer)
+    reader_thread = threading.Thread(target=reader)
+    try:
+        assert acquired.wait(timeout=5)
+        writer_thread.start()
+        assert writer_attempting.wait(timeout=5)
+        reader_thread.start()
+        assert reader_finished.wait(timeout=0.5)
+        assert not writer_finished.is_set()
+        release.set()
+        writer_thread.join(timeout=5)
+        lock_owner.join(timeout=5)
+    finally:
+        release.set()
+        for thread in (reader_thread, writer_thread):
+            if thread.ident is not None:
+                thread.join(timeout=5)
+        if lock_owner.is_alive():
+            lock_owner.terminate()
+        lock_owner.join(timeout=5)
+
+    assert writer_finished.is_set()
+    assert lock_owner.exitcode == 0
 
 
 def test_stale_general_writer_cannot_overwrite_memory_candidate_across_processes(

--- a/tests/test_memory_config.py
+++ b/tests/test_memory_config.py
@@ -30,7 +30,7 @@ def _save_stale_general_config(
     if not release.wait(timeout=5):
         raise TimeoutError("test did not release stale general config writer")
     stale.runtime.log_level = "DEBUG"
-    stale.save()
+    stale.save(preserve_memory=True)
 
 
 def _save_memory_candidate(avibe_home: str) -> None:
@@ -78,6 +78,30 @@ def _save_paused_memory_candidate(
 def _save_general_config(avibe_home: str) -> None:
     os.environ["AVIBE_HOME"] = avibe_home
     api.save_config({"runtime": {"log_level": "DEBUG"}})
+
+
+def _save_paused_model_hub_config(
+    avibe_home: str,
+    about_to_lock,
+    release,
+) -> None:
+    os.environ["AVIBE_HOME"] = avibe_home
+    from config.v2_config import ModelHubConfig
+    from core.handlers.model_hub.service import V2ModelHubConfigStore
+    from storage.lock import MigrationFileLock
+
+    original_acquire = MigrationFileLock.acquire
+
+    def acquire_after_release(lock) -> None:
+        about_to_lock.set()
+        if not release.wait(timeout=5):
+            raise TimeoutError("test did not release Model Hub config writer")
+        original_acquire(lock)
+
+    MigrationFileLock.acquire = acquire_after_release
+    V2ModelHubConfigStore().save(
+        ModelHubConfig(subscription_hub_experimental=True)
+    )
 
 
 def _payload(memory: dict) -> dict:
@@ -259,6 +283,25 @@ def test_generic_config_save_preserves_memory_keys(monkeypatch, tmp_path) -> Non
     assert saved.memory.embedding_change_pending is True
 
 
+def test_v2_config_save_persists_intentional_memory_mutation(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    V2Config.from_payload(
+        _payload({"enabled": False, "processing": {}})
+    ).save()
+    config = V2Config.load()
+    config.memory = MemoryConfig(
+        enabled=False,
+        embedding_change_pending=True,
+    )
+
+    config.save()
+
+    assert V2Config.load().memory.embedding_change_pending is True
+
+
 def test_config_write_transaction_reuses_same_path_lock(monkeypatch, tmp_path) -> None:
     from storage.lock import MigrationFileLock
 
@@ -382,6 +425,52 @@ def test_stale_memory_writer_cannot_overwrite_general_config_across_processes(
     assert persisted.runtime.log_level == "DEBUG"
     assert persisted.memory.processing.embedding.model == "embed-v2"
     assert persisted.memory.embedding_change_pending is True
+
+
+def test_model_hub_writer_preserves_concurrent_general_config_across_processes(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    V2Config.from_payload(
+        _payload(
+            {
+                "enabled": False,
+                "processing": _complete_processing(),
+            }
+        )
+    ).save()
+    context = multiprocessing.get_context("spawn")
+    about_to_lock = context.Event()
+    release = context.Event()
+    model_hub = context.Process(
+        target=_save_paused_model_hub_config,
+        args=(str(tmp_path), about_to_lock, release),
+    )
+    general = context.Process(
+        target=_save_general_config,
+        args=(str(tmp_path),),
+    )
+
+    model_hub.start()
+    try:
+        assert about_to_lock.wait(timeout=5)
+        general.start()
+        general.join(timeout=5)
+        assert general.exitcode == 0
+        release.set()
+        model_hub.join(timeout=5)
+        assert model_hub.exitcode == 0
+    finally:
+        release.set()
+        for process in (general, model_hub):
+            if process.is_alive():
+                process.terminate()
+            process.join(timeout=5)
+
+    persisted = V2Config.load()
+    assert persisted.runtime.log_level == "DEBUG"
+    assert persisted.model_hub.subscription_hub_experimental is True
 
 
 def test_memory_save_uses_dedicated_config_writer(monkeypatch, tmp_path) -> None:

--- a/tests/test_model_hub_resolution.py
+++ b/tests/test_model_hub_resolution.py
@@ -1596,6 +1596,49 @@ def test_synced_mutation_rollback_self_cancel_preserves_sync_failure(tmp_path):
     assert service._engine_synced is False
 
 
+def test_synced_mutation_caller_cancel_chains_primary_not_rollback_sync_failure(
+    tmp_path,
+    caplog,
+):
+    rollback_entered = asyncio.Event()
+    release_rollback = asyncio.Event()
+
+    class FailingRollbackAdapter(FakeAdapter):
+        async def sync_sources(self, bindings):
+            self.synced.append(tuple(bindings))
+            if len(self.synced) == 1:
+                raise ModelHubError("updated_primary", status=503)
+            rollback_entered.set()
+            await release_rollback.wait()
+            raise ModelHubError("rollback_secondary", status=503)
+
+    adapter = FailingRollbackAdapter([])
+    service = _service(tmp_path, adapter)
+
+    async def exercise() -> None:
+        task = asyncio.create_task(
+            service.patch_source(
+                "src_primary01",
+                {"base_url": "https://new.example.test"},
+            )
+        )
+        await rollback_entered.wait()
+        task.cancel("mutation cancelled")
+        await asyncio.sleep(0)
+        release_rollback.set()
+        with pytest.raises(asyncio.CancelledError) as raised:
+            await task
+        assert raised.value.args == ("mutation cancelled",)
+        assert isinstance(raised.value.__cause__, ModelHubError)
+        assert raised.value.__cause__.code == "updated_primary"
+
+    asyncio.run(exercise())
+
+    assert "modelHub.errors.rollback_secondary" in caplog.text
+    assert service.store.load().sources[0].base_url is None
+    assert service._engine_synced is False
+
+
 def test_synced_mutation_double_sync_failure_preserves_original(tmp_path):
     adapter = FakeAdapter([])
     adapter.fail_sync = True

--- a/tests/test_model_hub_resolution.py
+++ b/tests/test_model_hub_resolution.py
@@ -1420,6 +1420,73 @@ def test_async_mutation_settles_config_save_before_propagating_cancellation(tmp_
     assert service.store.load().agents["claude"].mode == "direct"
 
 
+def test_synced_mutation_settles_engine_projection_before_cancellation(tmp_path):
+    adapter = FakeAdapter([])
+    service = _service(tmp_path, adapter)
+    original_save = service.store.save
+    save_entered = threading.Event()
+    release_save = threading.Event()
+
+    def blocking_save(config):
+        save_entered.set()
+        assert release_save.wait(timeout=5)
+        original_save(config)
+
+    service.store.save = blocking_save
+
+    async def exercise() -> None:
+        task = asyncio.create_task(
+            service.create_source(
+                {
+                    "kind": "api_key",
+                    "vendor": "anthropic",
+                    "display_name": "Cancellation-safe source",
+                    "key": "sk-test-settlement-only",
+                }
+            )
+        )
+        assert await asyncio.to_thread(save_entered.wait, 5)
+        task.cancel()
+        await asyncio.sleep(0)
+        task.cancel()
+        await asyncio.sleep(0)
+        assert not task.done()
+        release_save.set()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    asyncio.run(exercise())
+
+    persisted = service.store.load()
+    assert persisted.sources[-1].display_name == "Cancellation-safe source"
+    assert adapter.synced
+    assert adapter.synced[-1][-1].source_id == persisted.sources[-1].id
+
+
+def test_synced_mutation_rolls_back_when_engine_awaitable_cancels_itself(tmp_path):
+    class SelfCancellingAdapter(FakeAdapter):
+        async def sync_sources(self, bindings):
+            self.synced.append(tuple(bindings))
+            if len(self.synced) == 1:
+                raise asyncio.CancelledError("engine sync stopped")
+
+    adapter = SelfCancellingAdapter([])
+    service = _service(tmp_path, adapter)
+
+    async def exercise() -> None:
+        with pytest.raises(asyncio.CancelledError) as raised:
+            await service.patch_source(
+                "src_primary01",
+                {"base_url": "https://new.example.test"},
+            )
+        assert raised.value.args == ("engine sync stopped",)
+
+    asyncio.run(exercise())
+
+    assert service.store.load().sources[0].base_url is None
+    assert len(adapter.synced) == 2
+
+
 def test_source_creation_revokes_credential_when_persist_fails(tmp_path):
     adapter = FakeAdapter([])
     service = _service(tmp_path, adapter)

--- a/tests/test_model_hub_resolution.py
+++ b/tests/test_model_hub_resolution.py
@@ -16,6 +16,7 @@ from config.v2_config import (
     ModelHubModelConfig,
     ModelHubSourceConfig,
     ModelHubSourceStateConfig,
+    V2Config,
 )
 from core.handlers.model_hub.adapter import (
     EngineHealth,
@@ -28,7 +29,13 @@ from core.handlers.model_hub.errors import ModelDiscoveryError
 from core.handlers.model_hub.events import BoundedEventLog, build_resolution_event
 from core.handlers.model_hub.resolver import resolve_model_hub_turn
 from core.handlers.model_hub.revocations import CredentialRevocationJournal
-from core.handlers.model_hub.service import ModelHubError, ModelHubService, _mask_credential
+from core.handlers.model_hub.service import (
+    ModelHubError,
+    ModelHubService,
+    V2ModelHubConfigStore,
+    _mask_credential,
+)
+from core.services.settings import default_config
 from vibe.i18n import t as i18n_t
 from vibe.model_hub_runtime.client import _SAFE_ERROR_CODES
 from vibe.model_hub_runtime.state import EngineStateError
@@ -1387,6 +1394,51 @@ def test_async_mutation_offloads_config_store_save(tmp_path):
 
     assert save_threads
     assert all(thread_id != event_loop_thread for thread_id in save_threads)
+
+
+def test_v2_store_rejects_stale_patch_without_overwriting_concurrent_edit(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path / "avibe-home"))
+    initial = _service(tmp_path, FakeAdapter([])).store.load()
+    persisted = default_config()
+    persisted.model_hub = ModelHubConfig.from_payload(initial.to_payload())
+    persisted.save()
+
+    store = V2ModelHubConfigStore()
+    original_save = store.save
+    interleaved = False
+
+    def save_after_concurrent_edit(config: ModelHubConfig) -> None:
+        nonlocal interleaved
+        if not interleaved:
+            interleaved = True
+            concurrent = V2Config.load()
+            concurrent.model_hub.sources[1].display_name = "Concurrent backup"
+            concurrent.save()
+        original_save(config)
+
+    store.save = save_after_concurrent_edit  # type: ignore[method-assign]
+    service = ModelHubService(
+        store=store,
+        adapter=FakeAdapter([]),
+        events=BoundedEventLog(tmp_path / "v2-events.json", max_entries=5),
+    )
+
+    with pytest.raises(ModelHubError) as raised:
+        asyncio.run(
+            service.patch_source(
+                "src_primary01",
+                {"display_name": "Requested primary"},
+            )
+        )
+
+    assert raised.value.code == "config_conflict"
+    assert raised.value.status == 409
+    current = V2Config.load().model_hub
+    assert current.sources[0].display_name == "Primary"
+    assert current.sources[1].display_name == "Concurrent backup"
 
 
 def test_async_mutation_settles_config_save_before_propagating_cancellation(tmp_path):

--- a/tests/test_model_hub_resolution.py
+++ b/tests/test_model_hub_resolution.py
@@ -1488,8 +1488,13 @@ def test_synced_mutation_rolls_back_when_engine_awaitable_cancels_itself(tmp_pat
 
 
 def test_synced_mutation_caller_cancel_precedes_rollback_save_failure(tmp_path):
-    adapter = FakeAdapter([])
-    adapter.fail_sync = True
+    class FailFirstSyncAdapter(FakeAdapter):
+        async def sync_sources(self, bindings):
+            self.synced.append(tuple(bindings))
+            if len(self.synced) == 1:
+                raise RuntimeError("updated sync failed")
+
+    adapter = FailFirstSyncAdapter([])
     service = _service(tmp_path, adapter)
     original_save = service.store.save
     save_entered = threading.Event()
@@ -1528,11 +1533,17 @@ def test_synced_mutation_caller_cancel_precedes_rollback_save_failure(tmp_path):
     asyncio.run(exercise())
 
     assert service._engine_synced is False
+    assert len(adapter.synced) == 2
 
 
 def test_synced_mutation_rollback_save_failure_chains_sync_failure(tmp_path):
-    adapter = FakeAdapter([])
-    adapter.fail_sync = True
+    class FailFirstSyncAdapter(FakeAdapter):
+        async def sync_sources(self, bindings):
+            self.synced.append(tuple(bindings))
+            if len(self.synced) == 1:
+                raise RuntimeError("updated sync failed")
+
+    adapter = FailFirstSyncAdapter([])
     service = _service(tmp_path, adapter)
     original_save = service.store.save
     save_count = 0
@@ -1557,6 +1568,7 @@ def test_synced_mutation_rollback_save_failure_chains_sync_failure(tmp_path):
 
     assert isinstance(raised.value.__cause__, ModelHubError)
     assert service._engine_synced is False
+    assert len(adapter.synced) == 2
 
 
 def test_synced_mutation_rollback_self_cancel_preserves_sync_failure(tmp_path):

--- a/tests/test_model_hub_resolution.py
+++ b/tests/test_model_hub_resolution.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import threading
 from collections import deque
 from datetime import datetime, timedelta, timezone
 
@@ -1364,6 +1365,59 @@ def test_source_creation_persists_before_engine_sync(tmp_path):
 
     assert order == ["persist", "sync"]
     assert service.store.load().sources[-1].id == created["source"]["id"]
+
+
+def test_async_mutation_offloads_config_store_save(tmp_path):
+    service = _service(tmp_path, FakeAdapter([]))
+    original_save = service.store.save
+    save_threads: list[int] = []
+
+    def blocking_save(config):
+        save_threads.append(threading.get_ident())
+        original_save(config)
+
+    service.store.save = blocking_save
+
+    async def exercise() -> int:
+        event_loop_thread = threading.get_ident()
+        await service.set_agent_mode("claude", "direct")
+        return event_loop_thread
+
+    event_loop_thread = asyncio.run(exercise())
+
+    assert save_threads
+    assert all(thread_id != event_loop_thread for thread_id in save_threads)
+
+
+def test_async_mutation_settles_config_save_before_propagating_cancellation(tmp_path):
+    service = _service(tmp_path, FakeAdapter([]))
+    original_save = service.store.save
+    save_entered = threading.Event()
+    release_save = threading.Event()
+    save_finished = threading.Event()
+
+    def blocking_save(config):
+        save_entered.set()
+        assert release_save.wait(timeout=5)
+        original_save(config)
+        save_finished.set()
+
+    service.store.save = blocking_save
+
+    async def exercise() -> None:
+        task = asyncio.create_task(service.set_agent_mode("claude", "direct"))
+        assert await asyncio.to_thread(save_entered.wait, 5)
+        task.cancel()
+        await asyncio.sleep(0)
+        assert not task.done()
+        release_save.set()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    asyncio.run(exercise())
+
+    assert save_finished.is_set()
+    assert service.store.load().agents["claude"].mode == "direct"
 
 
 def test_source_creation_revokes_credential_when_persist_fails(tmp_path):

--- a/tests/test_model_hub_resolution.py
+++ b/tests/test_model_hub_resolution.py
@@ -1487,6 +1487,122 @@ def test_synced_mutation_rolls_back_when_engine_awaitable_cancels_itself(tmp_pat
     assert len(adapter.synced) == 2
 
 
+def test_synced_mutation_caller_cancel_precedes_rollback_save_failure(tmp_path):
+    adapter = FakeAdapter([])
+    adapter.fail_sync = True
+    service = _service(tmp_path, adapter)
+    original_save = service.store.save
+    save_entered = threading.Event()
+    release_save = threading.Event()
+    save_count = 0
+
+    def fail_rollback_save(config):
+        nonlocal save_count
+        save_count += 1
+        if save_count == 1:
+            save_entered.set()
+            assert release_save.wait(timeout=5)
+            original_save(config)
+            return
+        raise OSError("rollback save failed")
+
+    service.store.save = fail_rollback_save
+
+    async def exercise() -> None:
+        task = asyncio.create_task(
+            service.patch_source(
+                "src_primary01",
+                {"base_url": "https://new.example.test"},
+            )
+        )
+        assert await asyncio.to_thread(save_entered.wait, 5)
+        task.cancel("mutation cancelled")
+        await asyncio.sleep(0)
+        release_save.set()
+        with pytest.raises(asyncio.CancelledError) as raised:
+            await task
+        assert raised.value.args == ("mutation cancelled",)
+        assert isinstance(raised.value.__cause__, OSError)
+        assert str(raised.value.__cause__) == "rollback save failed"
+
+    asyncio.run(exercise())
+
+    assert service._engine_synced is False
+
+
+def test_synced_mutation_rollback_save_failure_chains_sync_failure(tmp_path):
+    adapter = FakeAdapter([])
+    adapter.fail_sync = True
+    service = _service(tmp_path, adapter)
+    original_save = service.store.save
+    save_count = 0
+
+    def fail_rollback_save(config):
+        nonlocal save_count
+        save_count += 1
+        if save_count == 1:
+            original_save(config)
+            return
+        raise OSError("rollback save failed")
+
+    service.store.save = fail_rollback_save
+
+    with pytest.raises(OSError, match="rollback save failed") as raised:
+        asyncio.run(
+            service.patch_source(
+                "src_primary01",
+                {"base_url": "https://new.example.test"},
+            )
+        )
+
+    assert isinstance(raised.value.__cause__, ModelHubError)
+    assert service._engine_synced is False
+
+
+def test_synced_mutation_rollback_self_cancel_preserves_sync_failure(tmp_path):
+    class FailingThenCancellingAdapter(FakeAdapter):
+        async def sync_sources(self, bindings):
+            self.synced.append(tuple(bindings))
+            if len(self.synced) == 1:
+                raise RuntimeError("updated sync failed")
+            raise asyncio.CancelledError("rollback sync stopped")
+
+    adapter = FailingThenCancellingAdapter([])
+    service = _service(tmp_path, adapter)
+
+    with pytest.raises(ModelHubError) as raised:
+        asyncio.run(
+            service.patch_source(
+                "src_primary01",
+                {"base_url": "https://new.example.test"},
+            )
+        )
+
+    assert raised.value.code == "engine_down"
+    assert raised.value.__cause__ is None
+    assert service.store.load().sources[0].base_url is None
+    assert service._engine_synced is False
+
+
+def test_synced_mutation_double_sync_failure_preserves_original(tmp_path):
+    adapter = FakeAdapter([])
+    adapter.fail_sync = True
+    service = _service(tmp_path, adapter)
+
+    with pytest.raises(ModelHubError) as raised:
+        asyncio.run(
+            service.patch_source(
+                "src_primary01",
+                {"base_url": "https://new.example.test"},
+            )
+        )
+
+    assert raised.value.code == "engine_down"
+    assert raised.value.__cause__ is None
+    assert service.store.load().sources[0].base_url is None
+    assert service._engine_synced is False
+
+
 def test_source_creation_revokes_credential_when_persist_fails(tmp_path):
     adapter = FakeAdapter([])
     service = _service(tmp_path, adapter)

--- a/tests/test_save_opencode_provider_auth.py
+++ b/tests/test_save_opencode_provider_auth.py
@@ -112,6 +112,80 @@ class _FakeModelServer:
         pass
 
 
+@pytest.mark.parametrize(
+    ("server_factory", "expected"),
+    [
+        (
+            lambda _tmp_path: None,
+            {
+                "ok": False,
+                "message": "OpenCode is disabled in V2Config",
+                "mutation_attempted": False,
+                "removed": False,
+            },
+        ),
+        (
+            lambda tmp_path: _FakeServer(tmp_path),
+            {
+                "ok": False,
+                "message": "remove failed",
+                "mutation_attempted": True,
+                "removed": None,
+            },
+        ),
+        (
+            lambda tmp_path: _FakeServer(tmp_path),
+            {
+                "ok": False,
+                "message": "close failed",
+                "mutation_attempted": True,
+                "removed": True,
+            },
+        ),
+    ],
+)
+def test_private_delete_provider_auth_reports_exact_mutation_facts(
+    monkeypatch,
+    tmp_path,
+    server_factory,
+    expected,
+) -> None:
+    server = server_factory(tmp_path)
+
+    async def get_server():
+        return server
+
+    monkeypatch.setattr(api, "_opencode_get_server", get_server)
+    if isinstance(server, _FakeServer) and expected["removed"] is None:
+        server.remove_error = RuntimeError("remove failed")
+    if isinstance(server, _FakeServer) and expected["removed"] is True:
+        async def fail_close(*_args, **_kwargs) -> None:
+            raise RuntimeError("close failed")
+
+        monkeypatch.setattr(server, "close_http_session", fail_close)
+
+    result = asyncio.run(api._delete_opencode_provider_auth_async("deepseek"))
+
+    assert result == expected
+
+
+def test_private_delete_provider_auth_reports_full_success(monkeypatch, tmp_path) -> None:
+    server = _FakeServer(tmp_path)
+
+    async def get_server():
+        return server
+
+    monkeypatch.setattr(api, "_opencode_get_server", get_server)
+
+    result = asyncio.run(api._delete_opencode_provider_auth_async("deepseek"))
+
+    assert result == {
+        "ok": True,
+        "mutation_attempted": True,
+        "removed": True,
+    }
+
+
 @pytest.fixture()
 def fake_save_env(monkeypatch, tmp_path):
     """Wire ``save_opencode_provider_auth`` to a temp HOME + fake server."""
@@ -414,6 +488,42 @@ def test_delete_custom_provider_settles_after_auth_delete_then_custom_failure(
     assert api._OPENCODE_OPTIONS_CACHE == {}
 
 
+def test_save_provider_auth_marks_write_exception_as_uncertain_without_leaking_key(
+    monkeypatch,
+    fake_save_env,
+) -> None:
+    _server, _home = fake_save_env
+
+    def fail_write(*_args, **_kwargs) -> None:
+        raise RuntimeError("write failed after possible commit")
+
+    monkeypatch.setattr(
+        "vibe.opencode_config.upsert_opencode_provider_api_key",
+        fail_write,
+    )
+
+    result = _save("deepseek", {"api_key": "sk-top-secret"})
+
+    assert result["ok"] is False
+    assert result["partial"] is True
+    assert result["mutation_attempted"] is True
+    assert result["saved"] is None
+    assert "sk-top-secret" not in repr(result)
+
+
+def test_save_provider_auth_marks_validation_failure_as_not_saved(fake_save_env) -> None:
+    result = _save(
+        "deepseek",
+        {"api_key": "sk-top-secret", "base_url": "ftp://invalid.example"},
+    )
+
+    assert result == {
+        "ok": False,
+        "saved": False,
+        "message": "base_url must start with http:// or https://",
+    }
+
+
 def test_delete_provider_normalizes_daemon_failure_after_local_key_removed(
     monkeypatch,
 ) -> None:
@@ -509,7 +619,7 @@ def test_delete_provider_settles_when_auth_delete_commits_then_close_fails(
     assert result["message"] == "session close failed"
     assert result["partial"] is True
     assert result["mutation_attempted"] is True
-    assert result["removed"] is None
+    assert result["removed"] is (None if custom else True)
     assert result["provider_id"] == provider_id
     assert server._read_auth() == {}
     assert clear_calls == [provider_id]
@@ -541,6 +651,7 @@ def test_save_provider_auth_partial_cleanup_clears_prefilled_cache(
     assert result["ok"] is False
     assert result["partial"] is True
     assert result["mutation_attempted"] is True
+    assert result["saved"] is True
     assert result["provider_id"] == "deepseek"
     assert result["message"] == "API key saved, but stale OpenCode auth cleanup failed: session close failed"
     assert result["restart"] == {"ok": True}
@@ -1095,6 +1206,57 @@ def test_save_custom_provider_exposes_partial_auth_write_after_config_saved(
     assert saved_providers == ["my-relay"]
 
 
+def test_save_custom_provider_marks_config_write_exception_as_uncertain(
+    monkeypatch,
+) -> None:
+    restart_calls: list[str] = []
+
+    async def provider_catalog() -> dict:
+        return {"ok": True, "providers": []}
+
+    def fail_write(*_args, **_kwargs) -> None:
+        raise RuntimeError("custom write failed after possible commit")
+
+    monkeypatch.setattr(api, "_get_opencode_providers_async", provider_catalog)
+    monkeypatch.setattr(
+        "vibe.opencode_config.is_reserved_opencode_provider_id",
+        lambda _provider_id: False,
+    )
+    monkeypatch.setattr(
+        "vibe.opencode_config.upsert_opencode_custom_provider",
+        fail_write,
+    )
+    monkeypatch.setattr(
+        api,
+        "restart_backend",
+        lambda backend: restart_calls.append(backend) or {"ok": True},
+    )
+    monkeypatch.setattr(api, "_OPENCODE_OPTIONS_CACHE", {"stale": object()})
+
+    result = _save_custom(
+        {
+            "provider_id": "my-relay",
+            "name": "My Relay",
+            "adapter": "openai-compatible",
+            "base_url": "https://relay.example/v1",
+            "api_key": "sk-top-secret",
+        }
+    )
+
+    assert result == {
+        "ok": False,
+        "partial": True,
+        "saved": None,
+        "mutation_attempted": True,
+        "provider_id": "my-relay",
+        "message": "custom write failed after possible commit",
+        "restart": {"ok": True},
+    }
+    assert "sk-top-secret" not in repr(result)
+    assert restart_calls == ["opencode"]
+    assert api._OPENCODE_OPTIONS_CACHE == {}
+
+
 def test_save_custom_provider_rejects_clearing_base_url(fake_save_env) -> None:
     from vibe.opencode_config import (
         read_opencode_provider_base_url,
@@ -1112,7 +1274,11 @@ def test_save_custom_provider_rejects_clearing_base_url(fake_save_env) -> None:
 
     result = _save("my-relay", {"base_url": ""})
 
-    assert result == {"ok": False, "message": "base_url is required for custom providers"}
+    assert result == {
+        "ok": False,
+        "saved": False,
+        "message": "base_url is required for custom providers",
+    }
     assert server.set_calls == []
     assert read_opencode_provider_base_url("my-relay", home=home) == "https://relay.example/v1"
 

--- a/tests/test_save_opencode_provider_auth.py
+++ b/tests/test_save_opencode_provider_auth.py
@@ -471,12 +471,15 @@ def test_delete_provider_settles_when_auth_delete_commits_then_close_fails(
     assert api._OPENCODE_OPTIONS_CACHE == {}
 
 
+@pytest.mark.parametrize("custom", [False, True])
 def test_delete_provider_reports_default_clear_failure_after_restart(
     monkeypatch,
     tmp_path,
+    custom: bool,
 ) -> None:
+    provider_id = "custom" if custom else "deepseek"
     server = _FakeServer(tmp_path)
-    server._write_auth({"deepseek": {"type": "api", "key": "sk-old"}})
+    server._write_auth({provider_id: {"type": "api", "key": "sk-old"}})
     restart_calls: list[str] = []
 
     async def get_server():
@@ -488,12 +491,20 @@ def test_delete_provider_reports_default_clear_failure_after_restart(
     monkeypatch.setattr(api, "_opencode_get_server", get_server)
     monkeypatch.setattr(
         "vibe.opencode_config.read_opencode_provider_auth_entries",
-        lambda **_kwargs: {"deepseek": {"type": "api", "key": "sk-old"}},
+        lambda **_kwargs: {provider_id: {"type": "api", "key": "sk-old"}},
     )
     monkeypatch.setattr(
         api,
         "_read_opencode_config_api_key_provider_ids",
         no_config_keys,
+    )
+    monkeypatch.setattr(
+        "vibe.opencode_config.is_opencode_custom_provider",
+        lambda *_args, **_kwargs: custom,
+    )
+    monkeypatch.setattr(
+        "vibe.opencode_config.remove_opencode_custom_provider",
+        lambda *_args, **_kwargs: None,
     )
     monkeypatch.setattr(
         api,
@@ -506,15 +517,74 @@ def test_delete_provider_reports_default_clear_failure_after_restart(
         lambda backend: restart_calls.append(backend) or {"ok": True},
     )
 
-    result = asyncio.run(api.delete_opencode_provider_auth_async("deepseek"))
+    if custom:
+        result = asyncio.run(api.delete_opencode_custom_provider_async(provider_id))
+    else:
+        result = asyncio.run(api.delete_opencode_provider_auth_async(provider_id))
 
-    assert result["ok"] is True
+    assert result["ok"] is False
+    assert result["partial"] is True
+    assert result["removed"] is True
+    assert result["provider_id"] == provider_id
+    assert result["message"] == "default clear failed"
     assert result["restart"] == {
         "ok": False,
         "message": "default clear failed",
         "runtime_refresh": {"ok": True},
     }
     assert restart_calls == ["opencode"]
+
+
+@pytest.mark.parametrize("custom", [False, True])
+def test_delete_provider_reports_restart_failure_at_top_level(
+    monkeypatch,
+    tmp_path,
+    custom: bool,
+) -> None:
+    provider_id = "custom" if custom else "deepseek"
+    server = _FakeServer(tmp_path)
+    server._write_auth({provider_id: {"type": "api", "key": "sk-old"}})
+
+    async def get_server():
+        return server
+
+    async def no_config_keys():
+        return set()
+
+    monkeypatch.setattr(api, "_opencode_get_server", get_server)
+    monkeypatch.setattr(
+        "vibe.opencode_config.read_opencode_provider_auth_entries",
+        lambda **_kwargs: {provider_id: {"type": "api", "key": "sk-old"}},
+    )
+    monkeypatch.setattr(api, "_read_opencode_config_api_key_provider_ids", no_config_keys)
+    monkeypatch.setattr(
+        "vibe.opencode_config.is_opencode_custom_provider",
+        lambda *_args, **_kwargs: custom,
+    )
+    monkeypatch.setattr(
+        "vibe.opencode_config.remove_opencode_custom_provider",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(api, "_clear_opencode_default_provider_if", lambda _pid: None)
+    monkeypatch.setattr(
+        api,
+        "restart_backend",
+        lambda _backend: {"ok": False, "message": "restart failed"},
+    )
+
+    if custom:
+        result = asyncio.run(api.delete_opencode_custom_provider_async(provider_id))
+    else:
+        result = asyncio.run(api.delete_opencode_provider_auth_async(provider_id))
+
+    assert result == {
+        "ok": False,
+        "partial": True,
+        "removed": True,
+        "provider_id": provider_id,
+        "message": "restart failed",
+        "restart": {"ok": False, "message": "restart failed"},
+    }
 
 
 def test_base_url_absent_leaves_existing_value_untouched(fake_save_env) -> None:

--- a/tests/test_save_opencode_provider_auth.py
+++ b/tests/test_save_opencode_provider_auth.py
@@ -168,7 +168,7 @@ def _delete_custom(provider_id: str) -> dict:
     return asyncio.run(api.delete_opencode_custom_provider_async(provider_id))
 
 
-def test_delete_provider_auth_settles_default_clear_on_cancellation(
+def test_delete_provider_auth_settles_main_delete_and_live_state_on_cancellation(
     monkeypatch,
     tmp_path,
 ) -> None:
@@ -181,18 +181,27 @@ def test_delete_provider_auth_settles_default_clear_on_cancellation(
     async def no_config_keys():
         return set()
 
-    clear_entered = threading.Event()
-    release_clear = threading.Event()
+    delete_entered = threading.Event()
+    release_delete = threading.Event()
     clear_finished = threading.Event()
     restart_calls: list[str] = []
 
+    async def blocking_remove(provider_id: str) -> None:
+        def remove_after_release() -> None:
+            delete_entered.set()
+            assert release_delete.wait(timeout=5)
+            server.remove_calls.append(provider_id)
+            server._write_auth({})
+
+        await asyncio.to_thread(remove_after_release)
+
     def blocking_clear(provider_id: str) -> None:
         assert provider_id == "deepseek"
-        clear_entered.set()
-        assert release_clear.wait(timeout=5)
         clear_finished.set()
+        raise RuntimeError("default clear failed")
 
     monkeypatch.setattr(api, "_opencode_get_server", get_server)
+    monkeypatch.setattr(server, "remove_provider_auth", blocking_remove)
     monkeypatch.setattr(
         "vibe.opencode_config.read_opencode_provider_auth_entries",
         lambda **_kwargs: {"deepseek": {"type": "api", "key": "sk-old"}},
@@ -208,35 +217,44 @@ def test_delete_provider_auth_settles_default_clear_on_cancellation(
 
     async def exercise() -> None:
         task = asyncio.create_task(api.delete_opencode_provider_auth_async("deepseek"))
-        assert await asyncio.to_thread(clear_entered.wait, 5)
-        task.cancel()
+        assert await asyncio.to_thread(delete_entered.wait, 5)
+        task.cancel("delete cancelled")
         await asyncio.sleep(0)
-        assert not task.done()
-        task.cancel()
+        task.cancel("repeated cancellation")
         await asyncio.sleep(0)
-        assert not task.done()
-        release_clear.set()
-        with pytest.raises(asyncio.CancelledError):
+        release_delete.set()
+        with pytest.raises(asyncio.CancelledError) as raised:
             await task
+        assert raised.value.args == ("delete cancelled",)
+        assert isinstance(raised.value.__cause__, RuntimeError)
+        assert str(raised.value.__cause__) == "default clear failed"
 
     asyncio.run(exercise())
 
     assert clear_finished.is_set()
     assert restart_calls == ["opencode"]
     assert api._OPENCODE_OPTIONS_CACHE == {}
+    assert server._read_auth() == {}
 
 
-def test_delete_custom_provider_settles_live_restart_on_cancellation(
+def test_delete_custom_provider_settles_main_delete_and_live_state_on_cancellation(
     monkeypatch,
 ) -> None:
-    clear_entered = threading.Event()
-    release_clear = threading.Event()
+    delete_entered = threading.Event()
+    release_delete = threading.Event()
+    delete_finished = threading.Event()
     restart_calls: list[str] = []
 
-    def blocking_clear(provider_id: str) -> None:
+    def blocking_delete(provider_id: str, *_args, **_kwargs) -> None:
         assert provider_id == "custom"
-        clear_entered.set()
-        assert release_clear.wait(timeout=5)
+        delete_entered.set()
+        assert release_delete.wait(timeout=5)
+        delete_finished.set()
+
+    clear_calls: list[str] = []
+
+    def clear_default(provider_id: str) -> None:
+        clear_calls.append(provider_id)
 
     monkeypatch.setattr(
         "vibe.opencode_config.is_opencode_custom_provider",
@@ -248,9 +266,9 @@ def test_delete_custom_provider_settles_live_restart_on_cancellation(
     )
     monkeypatch.setattr(
         "vibe.opencode_config.remove_opencode_custom_provider",
-        lambda *_args, **_kwargs: None,
+        blocking_delete,
     )
-    monkeypatch.setattr(api, "_clear_opencode_default_provider_if", blocking_clear)
+    monkeypatch.setattr(api, "_clear_opencode_default_provider_if", clear_default)
     monkeypatch.setattr(
         api,
         "restart_backend",
@@ -262,18 +280,20 @@ def test_delete_custom_provider_settles_live_restart_on_cancellation(
         task = asyncio.create_task(
             api.delete_opencode_custom_provider_async("custom")
         )
-        assert await asyncio.to_thread(clear_entered.wait, 5)
-        task.cancel()
+        assert await asyncio.to_thread(delete_entered.wait, 5)
+        task.cancel("delete cancelled")
         await asyncio.sleep(0)
-        task.cancel()
+        task.cancel("repeated cancellation")
         await asyncio.sleep(0)
-        assert not task.done()
-        release_clear.set()
-        with pytest.raises(asyncio.CancelledError):
+        release_delete.set()
+        with pytest.raises(asyncio.CancelledError) as raised:
             await task
+        assert raised.value.args == ("delete cancelled",)
 
     asyncio.run(exercise())
 
+    assert delete_finished.wait(timeout=5)
+    assert clear_calls == ["custom"]
     assert restart_calls == ["opencode"]
     assert api._OPENCODE_OPTIONS_CACHE == {}
 

--- a/tests/test_save_opencode_provider_auth.py
+++ b/tests/test_save_opencode_provider_auth.py
@@ -404,6 +404,10 @@ def test_delete_custom_provider_settles_after_auth_delete_then_custom_failure(
 
     assert result["ok"] is False
     assert result["message"] == "custom provider delete failed"
+    assert result["partial"] is True
+    assert result["mutation_attempted"] is True
+    assert result["removed"] is None
+    assert result["provider_id"] == "custom"
     assert result["restart"] == {"ok": True}
     assert clear_calls == ["custom"]
     assert restart_calls == ["opencode"]
@@ -465,8 +469,43 @@ def test_delete_provider_settles_when_auth_delete_commits_then_close_fails(
 
     assert result["ok"] is False
     assert result["message"] == "session close failed"
+    assert result["partial"] is True
+    assert result["mutation_attempted"] is True
+    assert result["removed"] is None
+    assert result["provider_id"] == provider_id
     assert server._read_auth() == {}
     assert clear_calls == [provider_id]
+    assert restart_calls == ["opencode"]
+    assert api._OPENCODE_OPTIONS_CACHE == {}
+
+
+def test_save_provider_auth_partial_cleanup_clears_prefilled_cache(
+    monkeypatch,
+    fake_save_env,
+) -> None:
+    server, _home = fake_save_env
+    server._write_auth({"deepseek": {"type": "api", "key": "sk-old"}})
+
+    async def fail_close(*_args, **_kwargs) -> None:
+        raise RuntimeError("session close failed")
+
+    monkeypatch.setattr(server, "close_http_session", fail_close)
+    monkeypatch.setattr(api, "_OPENCODE_OPTIONS_CACHE", {"stale": object()})
+    restart_calls: list[str] = []
+    monkeypatch.setattr(
+        api,
+        "restart_backend",
+        lambda backend: restart_calls.append(backend) or {"ok": True},
+    )
+
+    result = _save("deepseek", {"api_key": "sk-new"})
+
+    assert result["ok"] is False
+    assert result["partial"] is True
+    assert result["mutation_attempted"] is True
+    assert result["provider_id"] == "deepseek"
+    assert result["message"] == "API key saved, but stale OpenCode auth cleanup failed: session close failed"
+    assert result["restart"] == {"ok": True}
     assert restart_calls == ["opencode"]
     assert api._OPENCODE_OPTIONS_CACHE == {}
 
@@ -581,6 +620,7 @@ def test_delete_provider_reports_restart_failure_at_top_level(
         "ok": False,
         "partial": True,
         "removed": True,
+        "mutation_attempted": True,
         "provider_id": provider_id,
         "message": "restart failed",
         "restart": {"ok": False, "message": "restart failed"},

--- a/tests/test_save_opencode_provider_auth.py
+++ b/tests/test_save_opencode_provider_auth.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import threading
 from pathlib import Path
 from typing import Any, List, Tuple
 
@@ -165,6 +166,52 @@ def _save_custom(payload: dict) -> dict:
 
 def _delete_custom(provider_id: str) -> dict:
     return asyncio.run(api.delete_opencode_custom_provider_async(provider_id))
+
+
+def test_delete_provider_auth_settles_default_clear_on_cancellation(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    server = _FakeServer(tmp_path)
+    server._write_auth({"deepseek": {"type": "api", "key": "sk-old"}})
+
+    async def get_server():
+        return server
+
+    async def no_config_keys():
+        return set()
+
+    clear_entered = threading.Event()
+    release_clear = threading.Event()
+    clear_finished = threading.Event()
+
+    def blocking_clear(provider_id: str) -> None:
+        assert provider_id == "deepseek"
+        clear_entered.set()
+        assert release_clear.wait(timeout=5)
+        clear_finished.set()
+
+    monkeypatch.setattr(api, "_opencode_get_server", get_server)
+    monkeypatch.setattr(
+        "vibe.opencode_config.read_opencode_provider_auth_entries",
+        lambda **_kwargs: {"deepseek": {"type": "api", "key": "sk-old"}},
+    )
+    monkeypatch.setattr(api, "_read_opencode_config_api_key_provider_ids", no_config_keys)
+    monkeypatch.setattr(api, "_clear_opencode_default_provider_if", blocking_clear)
+
+    async def exercise() -> None:
+        task = asyncio.create_task(api.delete_opencode_provider_auth_async("deepseek"))
+        assert await asyncio.to_thread(clear_entered.wait, 5)
+        task.cancel()
+        await asyncio.sleep(0)
+        assert not task.done()
+        release_clear.set()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    asyncio.run(exercise())
+
+    assert clear_finished.is_set()
 
 
 def test_base_url_absent_leaves_existing_value_untouched(fake_save_env) -> None:

--- a/tests/test_save_opencode_provider_auth.py
+++ b/tests/test_save_opencode_provider_auth.py
@@ -414,6 +414,44 @@ def test_delete_custom_provider_settles_after_auth_delete_then_custom_failure(
     assert api._OPENCODE_OPTIONS_CACHE == {}
 
 
+def test_delete_provider_normalizes_daemon_failure_after_local_key_removed(
+    monkeypatch,
+) -> None:
+    removed_keys: list[str] = []
+
+    async def daemon_delete_failed(_provider_id: str) -> dict:
+        return {"ok": False, "message": "daemon auth delete failed"}
+
+    async def config_key_ids() -> set[str]:
+        return {"deepseek"}
+
+    monkeypatch.setattr(
+        "vibe.opencode_config.read_opencode_provider_auth_entries",
+        lambda **_kwargs: {"deepseek": {"type": "api", "key": "sk-old"}},
+    )
+    monkeypatch.setattr(api, "_read_opencode_config_api_key_provider_ids", config_key_ids)
+    monkeypatch.setattr(api, "_delete_opencode_provider_auth_async", daemon_delete_failed)
+    monkeypatch.setattr(
+        "vibe.opencode_config.remove_opencode_provider_api_key",
+        lambda provider_id, **_kwargs: removed_keys.append(provider_id),
+    )
+    monkeypatch.setattr(api, "_clear_opencode_default_provider_if", lambda _pid: None)
+    monkeypatch.setattr(api, "restart_backend", lambda _backend: {"ok": True})
+
+    result = asyncio.run(api.delete_opencode_provider_auth_async("deepseek"))
+
+    assert result == {
+        "ok": False,
+        "partial": True,
+        "mutation_attempted": True,
+        "removed": True,
+        "provider_id": "deepseek",
+        "message": "daemon auth delete failed",
+        "restart": {"ok": True},
+    }
+    assert removed_keys == ["deepseek"]
+
+
 @pytest.mark.parametrize("custom", [False, True])
 def test_delete_provider_settles_when_auth_delete_commits_then_close_fails(
     monkeypatch,
@@ -1005,6 +1043,56 @@ def test_save_custom_provider_persists_config_and_key(fake_save_env) -> None:
     assert "my-relay" in read_opencode_custom_providers(home=home)
     config = _read_opencode_config(home)
     assert config["provider"]["my-relay"]["options"]["apiKey"] == "sk-relay"
+
+
+def test_save_custom_provider_exposes_partial_auth_write_after_config_saved(
+    monkeypatch,
+) -> None:
+    saved_providers: list[str] = []
+
+    async def provider_catalog() -> dict:
+        return {"ok": True, "providers": []}
+
+    async def partial_auth_save(*_args, **_kwargs) -> dict:
+        return {
+            "ok": False,
+            "partial": True,
+            "mutation_attempted": True,
+            "message": "API key write failed after commit",
+        }
+
+    monkeypatch.setattr(api, "_get_opencode_providers_async", provider_catalog)
+    monkeypatch.setattr(
+        "vibe.opencode_config.is_reserved_opencode_provider_id",
+        lambda _provider_id: False,
+    )
+    monkeypatch.setattr(
+        "vibe.opencode_config.upsert_opencode_custom_provider",
+        lambda provider_id, *_args, **_kwargs: saved_providers.append(provider_id),
+    )
+    monkeypatch.setattr(api, "_save_opencode_provider_auth_async", partial_auth_save)
+    monkeypatch.setattr(api, "restart_backend", lambda _backend: {"ok": True})
+
+    result = _save_custom(
+        {
+            "provider_id": "my-relay",
+            "name": "My Relay",
+            "adapter": "openai-compatible",
+            "base_url": "https://relay.example/v1",
+            "api_key": "sk-relay",
+        }
+    )
+
+    assert result == {
+        "ok": False,
+        "partial": True,
+        "saved": True,
+        "mutation_attempted": True,
+        "provider_id": "my-relay",
+        "message": "API key write failed after commit",
+        "restart": {"ok": True},
+    }
+    assert saved_providers == ["my-relay"]
 
 
 def test_save_custom_provider_rejects_clearing_base_url(fake_save_env) -> None:

--- a/tests/test_save_opencode_provider_auth.py
+++ b/tests/test_save_opencode_provider_auth.py
@@ -184,6 +184,7 @@ def test_delete_provider_auth_settles_default_clear_on_cancellation(
     clear_entered = threading.Event()
     release_clear = threading.Event()
     clear_finished = threading.Event()
+    restart_calls: list[str] = []
 
     def blocking_clear(provider_id: str) -> None:
         assert provider_id == "deepseek"
@@ -198,10 +199,19 @@ def test_delete_provider_auth_settles_default_clear_on_cancellation(
     )
     monkeypatch.setattr(api, "_read_opencode_config_api_key_provider_ids", no_config_keys)
     monkeypatch.setattr(api, "_clear_opencode_default_provider_if", blocking_clear)
+    monkeypatch.setattr(
+        api,
+        "restart_backend",
+        lambda backend: restart_calls.append(backend) or {"ok": True},
+    )
+    monkeypatch.setattr(api, "_OPENCODE_OPTIONS_CACHE", {"stale": object()})
 
     async def exercise() -> None:
         task = asyncio.create_task(api.delete_opencode_provider_auth_async("deepseek"))
         assert await asyncio.to_thread(clear_entered.wait, 5)
+        task.cancel()
+        await asyncio.sleep(0)
+        assert not task.done()
         task.cancel()
         await asyncio.sleep(0)
         assert not task.done()
@@ -212,6 +222,60 @@ def test_delete_provider_auth_settles_default_clear_on_cancellation(
     asyncio.run(exercise())
 
     assert clear_finished.is_set()
+    assert restart_calls == ["opencode"]
+    assert api._OPENCODE_OPTIONS_CACHE == {}
+
+
+def test_delete_custom_provider_settles_live_restart_on_cancellation(
+    monkeypatch,
+) -> None:
+    clear_entered = threading.Event()
+    release_clear = threading.Event()
+    restart_calls: list[str] = []
+
+    def blocking_clear(provider_id: str) -> None:
+        assert provider_id == "custom"
+        clear_entered.set()
+        assert release_clear.wait(timeout=5)
+
+    monkeypatch.setattr(
+        "vibe.opencode_config.is_opencode_custom_provider",
+        lambda *_args, **_kwargs: True,
+    )
+    monkeypatch.setattr(
+        "vibe.opencode_config.read_opencode_provider_auth_entries",
+        lambda **_kwargs: {},
+    )
+    monkeypatch.setattr(
+        "vibe.opencode_config.remove_opencode_custom_provider",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(api, "_clear_opencode_default_provider_if", blocking_clear)
+    monkeypatch.setattr(
+        api,
+        "restart_backend",
+        lambda backend: restart_calls.append(backend) or {"ok": True},
+    )
+    monkeypatch.setattr(api, "_OPENCODE_OPTIONS_CACHE", {"stale": object()})
+
+    async def exercise() -> None:
+        task = asyncio.create_task(
+            api.delete_opencode_custom_provider_async("custom")
+        )
+        assert await asyncio.to_thread(clear_entered.wait, 5)
+        task.cancel()
+        await asyncio.sleep(0)
+        task.cancel()
+        await asyncio.sleep(0)
+        assert not task.done()
+        release_clear.set()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    asyncio.run(exercise())
+
+    assert restart_calls == ["opencode"]
+    assert api._OPENCODE_OPTIONS_CACHE == {}
 
 
 def test_base_url_absent_leaves_existing_value_untouched(fake_save_env) -> None:

--- a/tests/test_save_opencode_provider_auth.py
+++ b/tests/test_save_opencode_provider_auth.py
@@ -444,7 +444,11 @@ def test_delete_custom_provider_settles_after_auth_delete_then_custom_failure(
     restart_calls: list[str] = []
 
     async def committed_auth_delete(_provider_id: str) -> dict:
-        return {"ok": True}
+        return {
+            "ok": True,
+            "mutation_attempted": True,
+            "removed": True,
+        }
 
     def failing_custom_delete(*_args, **_kwargs) -> None:
         raise RuntimeError("custom provider delete failed")
@@ -480,7 +484,7 @@ def test_delete_custom_provider_settles_after_auth_delete_then_custom_failure(
     assert result["message"] == "custom provider delete failed"
     assert result["partial"] is True
     assert result["mutation_attempted"] is True
-    assert result["removed"] is None
+    assert result["removed"] is True
     assert result["provider_id"] == "custom"
     assert result["restart"] == {"ok": True}
     assert clear_calls == ["custom"]
@@ -619,7 +623,7 @@ def test_delete_provider_settles_when_auth_delete_commits_then_close_fails(
     assert result["message"] == "session close failed"
     assert result["partial"] is True
     assert result["mutation_attempted"] is True
-    assert result["removed"] is (None if custom else True)
+    assert result["removed"] is True
     assert result["provider_id"] == provider_id
     assert server._read_auth() == {}
     assert clear_calls == [provider_id]
@@ -653,7 +657,8 @@ def test_save_provider_auth_partial_cleanup_clears_prefilled_cache(
     assert result["mutation_attempted"] is True
     assert result["saved"] is True
     assert result["provider_id"] == "deepseek"
-    assert result["message"] == "API key saved, but stale OpenCode auth cleanup failed: session close failed"
+    assert result["error_code"] == "opencode_stale_auth_cleanup_failed"
+    assert "message" not in result
     assert result["restart"] == {"ok": True}
     assert restart_calls == ["opencode"]
     assert api._OPENCODE_OPTIONS_CACHE == {}
@@ -1333,7 +1338,13 @@ def test_delete_custom_provider_removes_config_and_auth(fake_save_env) -> None:
 
     result = _delete_custom("my-relay")
 
-    assert result["ok"] is True
+    assert result == {
+        "ok": True,
+        "provider_id": "my-relay",
+        "mutation_attempted": True,
+        "removed": True,
+        "restart": {"ok": True},
+    }
     assert server.remove_calls == []
     assert read_opencode_custom_providers(home=home) == {}
 

--- a/tests/test_save_opencode_provider_auth.py
+++ b/tests/test_save_opencode_provider_auth.py
@@ -298,6 +298,118 @@ def test_delete_custom_provider_settles_main_delete_and_live_state_on_cancellati
     assert api._OPENCODE_OPTIONS_CACHE == {}
 
 
+def test_delete_provider_auth_settles_after_config_delete_failure_and_cancellation(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    server = _FakeServer(tmp_path)
+    server._write_auth({"deepseek": {"type": "api", "key": "sk-old"}})
+    delete_entered = threading.Event()
+    release_delete = threading.Event()
+    clear_calls: list[str] = []
+    restart_calls: list[str] = []
+
+    async def get_server():
+        return server
+
+    async def config_keys():
+        return {"deepseek"}
+
+    def failing_config_delete(provider_id: str, *_args, **_kwargs) -> None:
+        assert provider_id == "deepseek"
+        delete_entered.set()
+        assert release_delete.wait(timeout=5)
+        raise RuntimeError("config key delete failed")
+
+    monkeypatch.setattr(api, "_opencode_get_server", get_server)
+    monkeypatch.setattr(
+        "vibe.opencode_config.read_opencode_provider_auth_entries",
+        lambda **_kwargs: {"deepseek": {"type": "api", "key": "sk-old"}},
+    )
+    monkeypatch.setattr(api, "_read_opencode_config_api_key_provider_ids", config_keys)
+    monkeypatch.setattr(
+        "vibe.opencode_config.remove_opencode_provider_api_key",
+        failing_config_delete,
+    )
+    monkeypatch.setattr(
+        api,
+        "_clear_opencode_default_provider_if",
+        lambda provider_id: clear_calls.append(provider_id),
+    )
+    monkeypatch.setattr(
+        api,
+        "restart_backend",
+        lambda backend: restart_calls.append(backend) or {"ok": True},
+    )
+    monkeypatch.setattr(api, "_OPENCODE_OPTIONS_CACHE", {"stale": object()})
+
+    async def exercise() -> None:
+        task = asyncio.create_task(api.delete_opencode_provider_auth_async("deepseek"))
+        assert await asyncio.to_thread(delete_entered.wait, 5)
+        task.cancel("delete cancelled")
+        await asyncio.sleep(0)
+        release_delete.set()
+        with pytest.raises(asyncio.CancelledError) as raised:
+            await task
+        assert raised.value.args == ("delete cancelled",)
+        assert isinstance(raised.value.__cause__, RuntimeError)
+        assert str(raised.value.__cause__) == "config key delete failed"
+
+    asyncio.run(exercise())
+
+    assert server._read_auth() == {}
+    assert clear_calls == ["deepseek"]
+    assert restart_calls == ["opencode"]
+    assert api._OPENCODE_OPTIONS_CACHE == {}
+
+
+def test_delete_custom_provider_settles_after_auth_delete_then_custom_failure(
+    monkeypatch,
+) -> None:
+    clear_calls: list[str] = []
+    restart_calls: list[str] = []
+
+    async def committed_auth_delete(_provider_id: str) -> dict:
+        return {"ok": True}
+
+    def failing_custom_delete(*_args, **_kwargs) -> None:
+        raise RuntimeError("custom provider delete failed")
+
+    monkeypatch.setattr(
+        "vibe.opencode_config.is_opencode_custom_provider",
+        lambda *_args, **_kwargs: True,
+    )
+    monkeypatch.setattr(
+        "vibe.opencode_config.read_opencode_provider_auth_entries",
+        lambda **_kwargs: {"custom": {"type": "api", "key": "sk-old"}},
+    )
+    monkeypatch.setattr(api, "_delete_opencode_provider_auth_async", committed_auth_delete)
+    monkeypatch.setattr(
+        "vibe.opencode_config.remove_opencode_custom_provider",
+        failing_custom_delete,
+    )
+    monkeypatch.setattr(
+        api,
+        "_clear_opencode_default_provider_if",
+        lambda provider_id: clear_calls.append(provider_id),
+    )
+    monkeypatch.setattr(
+        api,
+        "restart_backend",
+        lambda backend: restart_calls.append(backend) or {"ok": True},
+    )
+    monkeypatch.setattr(api, "_OPENCODE_OPTIONS_CACHE", {"stale": object()})
+
+    result = asyncio.run(api.delete_opencode_custom_provider_async("custom"))
+
+    assert result["ok"] is False
+    assert result["message"] == "custom provider delete failed"
+    assert result["restart"] == {"ok": True}
+    assert clear_calls == ["custom"]
+    assert restart_calls == ["opencode"]
+    assert api._OPENCODE_OPTIONS_CACHE == {}
+
+
 def test_base_url_absent_leaves_existing_value_untouched(fake_save_env) -> None:
     from vibe.opencode_config import (
         read_opencode_provider_base_url,

--- a/tests/test_save_opencode_provider_auth.py
+++ b/tests/test_save_opencode_provider_auth.py
@@ -372,6 +372,146 @@ def test_delete_custom_provider_settles_main_delete_and_live_state_on_cancellati
     assert api._OPENCODE_OPTIONS_CACHE == {}
 
 
+def test_save_provider_auth_settles_disk_and_live_state_before_cancellation(
+    monkeypatch,
+) -> None:
+    write_entered = threading.Event()
+    release_write = threading.Event()
+    write_finished = threading.Event()
+    restart_calls: list[str] = []
+    catalog_calls: list[str] = []
+
+    def blocking_write(provider_id: str, api_key: str, **_kwargs) -> None:
+        assert provider_id == "deepseek"
+        assert api_key == "sk-new"
+        write_entered.set()
+        assert release_write.wait(timeout=5)
+        write_finished.set()
+
+    async def refresh_catalog(provider_id: str) -> dict:
+        catalog_calls.append(provider_id)
+        return {"ok": True, "catalog": {"ok": True, "providers": []}}
+
+    monkeypatch.setattr(
+        "vibe.opencode_config.upsert_opencode_provider_api_key",
+        blocking_write,
+    )
+    monkeypatch.setattr(
+        "vibe.opencode_config.read_opencode_provider_auth_entries",
+        lambda **_kwargs: {},
+    )
+    monkeypatch.setattr(
+        api,
+        "restart_backend",
+        lambda backend: restart_calls.append(backend) or {"ok": True},
+    )
+    monkeypatch.setattr(
+        api,
+        "_refresh_opencode_provider_catalog_async",
+        refresh_catalog,
+    )
+    monkeypatch.setattr(api, "_OPENCODE_OPTIONS_CACHE", {"stale": object()})
+
+    async def exercise() -> None:
+        task = asyncio.create_task(
+            api.save_opencode_provider_auth_async(
+                "deepseek",
+                {"api_key": "sk-new"},
+            )
+        )
+        assert await asyncio.to_thread(write_entered.wait, 5)
+        task.cancel("save cancelled")
+        await asyncio.sleep(0)
+        task.cancel("repeated cancellation")
+        await asyncio.sleep(0)
+        completed_before_release = task.done()
+        release_write.set()
+        with pytest.raises(asyncio.CancelledError) as raised:
+            await task
+        assert raised.value.args == ("save cancelled",)
+        assert not completed_before_release
+
+    asyncio.run(exercise())
+
+    assert write_finished.wait(timeout=5)
+    assert api._OPENCODE_OPTIONS_CACHE == {}
+    assert restart_calls == ["opencode"]
+    assert catalog_calls == ["deepseek"]
+
+
+def test_save_custom_provider_settles_nested_auth_before_cancellation(
+    monkeypatch,
+) -> None:
+    write_entered = threading.Event()
+    release_write = threading.Event()
+    write_finished = threading.Event()
+    restart_calls: list[str] = []
+
+    async def provider_catalog() -> dict:
+        return {"ok": True, "providers": []}
+
+    def blocking_key_write(*_args, **_kwargs) -> None:
+        write_entered.set()
+        assert release_write.wait(timeout=5)
+        write_finished.set()
+
+    async def refresh_catalog(*_args, **_kwargs) -> dict:
+        return {"ok": True, "catalog": {"ok": True, "providers": []}}
+
+    monkeypatch.setattr(api, "_get_opencode_providers_async", provider_catalog)
+    monkeypatch.setattr(
+        "vibe.opencode_config.is_reserved_opencode_provider_id",
+        lambda _provider_id: False,
+    )
+    monkeypatch.setattr(
+        "vibe.opencode_config.upsert_opencode_custom_provider",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        "vibe.opencode_config.upsert_opencode_provider_api_key",
+        blocking_key_write,
+    )
+    monkeypatch.setattr(
+        "vibe.opencode_config.read_opencode_provider_auth_entries",
+        lambda **_kwargs: {},
+    )
+    monkeypatch.setattr(
+        api,
+        "restart_backend",
+        lambda backend: restart_calls.append(backend) or {"ok": True},
+    )
+    monkeypatch.setattr(
+        api,
+        "_refresh_opencode_provider_catalog_async",
+        refresh_catalog,
+    )
+
+    async def exercise() -> None:
+        task = asyncio.create_task(
+            api.save_opencode_custom_provider_async(
+                {
+                    "provider_id": "my-relay",
+                    "name": "My Relay",
+                    "adapter": "openai-compatible",
+                    "base_url": "https://relay.example/v1",
+                    "api_key": "sk-new",
+                }
+            )
+        )
+        assert await asyncio.to_thread(write_entered.wait, 5)
+        task.cancel("save cancelled")
+        await asyncio.sleep(0)
+        release_write.set()
+        with pytest.raises(asyncio.CancelledError) as raised:
+            await task
+        assert raised.value.args == ("save cancelled",)
+
+    asyncio.run(exercise())
+
+    assert write_finished.wait(timeout=5)
+    assert restart_calls == ["opencode", "opencode"]
+
+
 def test_delete_provider_auth_settles_after_config_delete_failure_and_cancellation(
     monkeypatch,
     tmp_path,

--- a/tests/test_save_opencode_provider_auth.py
+++ b/tests/test_save_opencode_provider_auth.py
@@ -410,6 +410,113 @@ def test_delete_custom_provider_settles_after_auth_delete_then_custom_failure(
     assert api._OPENCODE_OPTIONS_CACHE == {}
 
 
+@pytest.mark.parametrize("custom", [False, True])
+def test_delete_provider_settles_when_auth_delete_commits_then_close_fails(
+    monkeypatch,
+    tmp_path,
+    custom: bool,
+) -> None:
+    provider_id = "custom" if custom else "deepseek"
+    server = _FakeServer(tmp_path)
+    server._write_auth({provider_id: {"type": "api", "key": "sk-old"}})
+    clear_calls: list[str] = []
+    restart_calls: list[str] = []
+
+    async def get_server():
+        return server
+
+    async def no_config_keys():
+        return set()
+
+    async def fail_close(*_args, **_kwargs) -> None:
+        raise RuntimeError("session close failed")
+
+    monkeypatch.setattr(api, "_opencode_get_server", get_server)
+    monkeypatch.setattr(server, "close_http_session", fail_close)
+    monkeypatch.setattr(
+        "vibe.opencode_config.read_opencode_provider_auth_entries",
+        lambda **_kwargs: {provider_id: {"type": "api", "key": "sk-old"}},
+    )
+    monkeypatch.setattr(
+        api,
+        "_read_opencode_config_api_key_provider_ids",
+        no_config_keys,
+    )
+    monkeypatch.setattr(
+        "vibe.opencode_config.is_opencode_custom_provider",
+        lambda *_args, **_kwargs: custom,
+    )
+    monkeypatch.setattr(
+        api,
+        "_clear_opencode_default_provider_if",
+        lambda pid: clear_calls.append(pid),
+    )
+    monkeypatch.setattr(
+        api,
+        "restart_backend",
+        lambda backend: restart_calls.append(backend) or {"ok": True},
+    )
+    monkeypatch.setattr(api, "_OPENCODE_OPTIONS_CACHE", {"stale": object()})
+
+    if custom:
+        result = asyncio.run(api.delete_opencode_custom_provider_async(provider_id))
+    else:
+        result = asyncio.run(api.delete_opencode_provider_auth_async(provider_id))
+
+    assert result["ok"] is False
+    assert result["message"] == "session close failed"
+    assert server._read_auth() == {}
+    assert clear_calls == [provider_id]
+    assert restart_calls == ["opencode"]
+    assert api._OPENCODE_OPTIONS_CACHE == {}
+
+
+def test_delete_provider_reports_default_clear_failure_after_restart(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    server = _FakeServer(tmp_path)
+    server._write_auth({"deepseek": {"type": "api", "key": "sk-old"}})
+    restart_calls: list[str] = []
+
+    async def get_server():
+        return server
+
+    async def no_config_keys():
+        return set()
+
+    monkeypatch.setattr(api, "_opencode_get_server", get_server)
+    monkeypatch.setattr(
+        "vibe.opencode_config.read_opencode_provider_auth_entries",
+        lambda **_kwargs: {"deepseek": {"type": "api", "key": "sk-old"}},
+    )
+    monkeypatch.setattr(
+        api,
+        "_read_opencode_config_api_key_provider_ids",
+        no_config_keys,
+    )
+    monkeypatch.setattr(
+        api,
+        "_clear_opencode_default_provider_if",
+        lambda _pid: (_ for _ in ()).throw(RuntimeError("default clear failed")),
+    )
+    monkeypatch.setattr(
+        api,
+        "restart_backend",
+        lambda backend: restart_calls.append(backend) or {"ok": True},
+    )
+
+    result = asyncio.run(api.delete_opencode_provider_auth_async("deepseek"))
+
+    assert result["ok"] is True
+    assert result["restart"] == {
+        "ok": False,
+        "message": "default clear failed",
+        "runtime_refresh": {"ok": True},
+    }
+    assert restart_calls == ["opencode"]
+
+
 def test_base_url_absent_leaves_existing_value_untouched(fake_save_env) -> None:
     from vibe.opencode_config import (
         read_opencode_provider_base_url,

--- a/tests/test_settings_disk_fallback.py
+++ b/tests/test_settings_disk_fallback.py
@@ -958,6 +958,13 @@ def test_save_claude_auth_preserved_fields_share_final_config_transaction(
     monkeypatch.setenv("AVIBE_HOME", str(avibe_home))
     monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(claude_home))
     monkeypatch.setattr("config.paths._home", lambda: tmp_path, raising=False)
+    _write_claude_settings(
+        tmp_path,
+        {
+            "ANTHROPIC_API_KEY": "sk-old-settings",
+            "ANTHROPIC_BASE_URL": "https://old.example.invalid",
+        },
+    )
 
     from config.v2_config import CONFIG_LOCK, AgentsConfig, RuntimeConfig, SlackConfig, V2Config
     from storage.lock import MigrationFileLock

--- a/tests/test_settings_disk_fallback.py
+++ b/tests/test_settings_disk_fallback.py
@@ -22,6 +22,8 @@ The fixes:
 from __future__ import annotations
 
 import json
+import multiprocessing
+import os
 import subprocess
 import threading
 from pathlib import Path
@@ -29,6 +31,39 @@ from pathlib import Path
 import pytest
 
 from vibe.codex_config import read_codex_auth_state
+
+
+def _save_claude_base_url(
+    avibe_home: str,
+    claude_home: str,
+    base_url: str,
+    attempting,
+    finished,
+) -> None:
+    os.environ["AVIBE_HOME"] = avibe_home
+    os.environ["CLAUDE_CONFIG_DIR"] = claude_home
+    from storage.lock import MigrationFileLock
+    from vibe import api
+
+    original_acquire = MigrationFileLock.acquire
+
+    def signal_acquire(lock) -> None:
+        attempting.set()
+        original_acquire(lock)
+
+    MigrationFileLock.acquire = signal_acquire
+    api.restart_backend = lambda name, **kwargs: {"ok": True}
+    api._clear_claude_oauth_credentials_after_api_key_save = (
+        lambda _service=None: {"ok": True}
+    )
+    api.save_claude_auth(
+        {
+            "auth_mode": "api_key",
+            "api_key": "sk-concurrent",
+            "base_url": base_url,
+        }
+    )
+    finished.set()
 
 
 def test_codex_reads_base_url_from_user_titlecase_provider(tmp_path: Path) -> None:
@@ -911,6 +946,78 @@ def test_save_claude_auth_keeps_settings_token_over_legacy_v2_key(
     assert "ANTHROPIC_API_KEY" not in settings["env"]
     assert settings["env"]["ANTHROPIC_BASE_URL"] == "https://new-relay.example.invalid"
     _assert_claude_managed_env(settings["env"])
+
+
+def test_save_claude_auth_preserved_fields_share_final_config_transaction(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    claude_restart_calls: list[dict],
+) -> None:
+    avibe_home = tmp_path / ".vibe_remote"
+    claude_home = tmp_path / ".claude"
+    monkeypatch.setenv("AVIBE_HOME", str(avibe_home))
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(claude_home))
+    monkeypatch.setattr("config.paths._home", lambda: tmp_path, raising=False)
+
+    from config.v2_config import CONFIG_LOCK, AgentsConfig, RuntimeConfig, SlackConfig, V2Config
+    from storage.lock import MigrationFileLock
+    from vibe import claude_config
+    from vibe.api import save_claude_auth
+
+    config = V2Config(
+        mode="self_host",
+        version="v2",
+        slack=SlackConfig(bot_token=""),
+        runtime=RuntimeConfig(default_cwd="."),
+        agents=AgentsConfig(),
+    )
+    config.agents.claude.auth_mode = "api_key"
+    config.agents.claude.api_key = "sk-legacy"
+    config.agents.claude.base_url = "https://old.example.invalid"
+    config.save()
+    context = multiprocessing.get_context("spawn")
+    attempting = context.Event()
+    finished = context.Event()
+    concurrent = context.Process(
+        target=_save_claude_base_url,
+        args=(
+            str(avibe_home),
+            str(claude_home),
+            "https://new.example.invalid",
+            attempting,
+            finished,
+        ),
+    )
+    original_apply = claude_config.apply_claude_auth
+    original_acquire = MigrationFileLock.acquire
+
+    def interleaved_apply(**kwargs):
+        concurrent.start()
+        assert attempting.wait(timeout=5)
+        if not CONFIG_LOCK._is_owned():
+            assert finished.wait(timeout=5)
+        return original_apply(**kwargs)
+
+    def wait_for_concurrent_writer(lock) -> None:
+        if concurrent.pid is not None and not CONFIG_LOCK._is_owned():
+            assert finished.wait(timeout=5)
+        original_acquire(lock)
+
+    monkeypatch.setattr(claude_config, "apply_claude_auth", interleaved_apply)
+    monkeypatch.setattr(MigrationFileLock, "acquire", wait_for_concurrent_writer)
+    try:
+        result = save_claude_auth({"auth_mode": "api_key", "api_key": ""})
+        assert finished.wait(timeout=5)
+    finally:
+        concurrent.join(timeout=5)
+        if concurrent.is_alive():
+            concurrent.terminate()
+            concurrent.join(timeout=5)
+
+    settings = json.loads((claude_home / "settings.json").read_text(encoding="utf-8"))
+    assert result["ok"] is True
+    assert concurrent.exitcode == 0
+    assert settings["env"]["ANTHROPIC_BASE_URL"] == "https://new.example.invalid"
 
 
 def test_remove_claude_api_key_refreshes_cached_runtime(

--- a/tests/test_settings_handler.py
+++ b/tests/test_settings_handler.py
@@ -139,8 +139,9 @@ def test_settings_language_save_stays_responsive_and_settles_on_cancellation(
         await asyncio.sleep(0)
         assert not task.done()
         release_lock.set()
-        with pytest.raises(asyncio.CancelledError):
+        with pytest.raises(asyncio.CancelledError) as raised:
             await task
+        assert raised.value.__cause__ is None
 
     asyncio.run(exercise())
     assert V2Config.load().language == "zh"

--- a/tests/test_settings_handler.py
+++ b/tests/test_settings_handler.py
@@ -135,12 +135,16 @@ def test_settings_language_save_stays_responsive_and_settles_on_cancellation(
         task.cancel()
         await asyncio.sleep(0)
         assert not task.done()
+        task.cancel()
+        await asyncio.sleep(0)
+        assert not task.done()
         release_lock.set()
         with pytest.raises(asyncio.CancelledError):
             await task
 
     asyncio.run(exercise())
     assert V2Config.load().language == "zh"
+    assert handler.config.language == "zh"
 
 
 class _FlatScopeSessions:

--- a/tests/test_settings_handler.py
+++ b/tests/test_settings_handler.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
 import asyncio
+import threading
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 from unittest.mock import patch
+
+import pytest
 
 from config.v2_settings import RoutingSettings
 from core.handlers.settings_handler import SettingsHandler
@@ -82,6 +85,62 @@ def test_settings_update_materializes_topic_mention_before_saving_other_fields()
     )
 
     assert calls == ["mention", "read", "save"]
+
+
+def test_settings_language_save_stays_responsive_and_settles_on_cancellation(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    from core.services.settings import default_config
+    from storage.lock import MigrationFileLock
+    from config.v2_config import V2Config
+
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    config = default_config()
+    config.language = "en"
+    config.save()
+    lock_entered = threading.Event()
+    release_lock = threading.Event()
+    original_acquire = MigrationFileLock.acquire
+
+    def blocking_acquire(lock) -> None:
+        lock_entered.set()
+        assert release_lock.wait(timeout=5)
+        original_acquire(lock)
+
+    monkeypatch.setattr(MigrationFileLock, "acquire", blocking_acquire)
+    user_settings = SimpleNamespace(show_message_types=[])
+    settings_manager = SimpleNamespace(
+        set_require_mention=lambda *_args: None,
+        get_user_settings=lambda _key: user_settings,
+        update_user_settings=lambda *_args: None,
+    )
+    handler, _ = _make_handler(settings_manager)
+
+    async def exercise() -> None:
+        task = asyncio.create_task(
+            handler.handle_settings_update(
+                user_id="42",
+                channel_id="-100123",
+                show_message_types=["assistant"],
+                language="zh",
+                notify_user=False,
+                platform="telegram",
+            )
+        )
+        assert await asyncio.to_thread(lock_entered.wait, 5)
+        loop_progressed = asyncio.Event()
+        asyncio.get_running_loop().call_soon(loop_progressed.set)
+        await asyncio.wait_for(loop_progressed.wait(), timeout=0.2)
+        task.cancel()
+        await asyncio.sleep(0)
+        assert not task.done()
+        release_lock.set()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    asyncio.run(exercise())
+    assert V2Config.load().language == "zh"
 
 
 class _FlatScopeSessions:

--- a/tests/test_tunnel_recovery.py
+++ b/tests/test_tunnel_recovery.py
@@ -26,6 +26,33 @@ def _save_remote_transport(avibe_home: str, transport_protocol: str) -> None:
     )
 
 
+def _save_remote_enabled(avibe_home: str, enabled: bool) -> None:
+    os.environ["AVIBE_HOME"] = avibe_home
+    from vibe import api
+
+    api.save_config({"remote_access": {"vibe_cloud": {"enabled": enabled}}})
+
+
+def _save_remote_transport_with_signal(
+    avibe_home: str,
+    transport_protocol: str,
+    attempting,
+    finished,
+) -> None:
+    os.environ["AVIBE_HOME"] = avibe_home
+    from storage.lock import MigrationFileLock
+
+    original_acquire = MigrationFileLock.acquire
+
+    def signal_acquire(lock) -> None:
+        attempting.set()
+        original_acquire(lock)
+
+    MigrationFileLock.acquire = signal_acquire
+    _save_remote_transport(avibe_home, transport_protocol)
+    finished.set()
+
+
 def _setup_settings_candidate(monkeypatch, tmp_path) -> list[tuple[str, object]]:
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     config = _config()
@@ -236,7 +263,7 @@ def test_ra_tq_028_settings_promote_before_draining_previous_connector(monkeypat
     monkeypatch.setattr(remote_access, "_wait_candidate_ready", lambda pid, metrics: True)
 
     def promote(pid, **kwargs):
-        assert not CONFIG_LOCK._is_owned()
+        assert CONFIG_LOCK._is_owned()
         events.append(("promote", kwargs["runtime_signature"]["transport_protocol"]))
         return {"pid": 111}
 
@@ -255,6 +282,43 @@ def test_ra_tq_028_settings_promote_before_draining_previous_connector(monkeypat
     assert result["connector_replaced"] is True
     assert V2Config.load().remote_access.vibe_cloud.transport_protocol == "http2"
     assert events == [("start", "http2"), ("promote", "http2"), ("drain", 111)]
+
+
+def test_ra_tq_028_settings_holds_config_transaction_through_promotion(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    events = _setup_settings_candidate(monkeypatch, tmp_path)
+    context = multiprocessing.get_context("spawn")
+    attempting = context.Event()
+    finished = context.Event()
+    concurrent = context.Process(
+        target=_save_remote_transport_with_signal,
+        args=(str(tmp_path), "quic", attempting, finished),
+    )
+
+    def promote(pid, **kwargs):
+        concurrent.start()
+        assert attempting.wait(timeout=5)
+        assert not finished.wait(timeout=0.2)
+        events.append(("promote", kwargs["runtime_signature"]["transport_protocol"]))
+        return {"pid": 111}
+
+    monkeypatch.setattr(remote_access, "_promote_candidate_connector", promote)
+    monkeypatch.setattr(remote_access, "_drain_tracked_connector", lambda connector: True)
+    try:
+        result = remote_access.apply_settings({"transport_protocol": "http2"})
+        assert finished.wait(timeout=5)
+    finally:
+        concurrent.join(timeout=5)
+        if concurrent.is_alive():
+            concurrent.terminate()
+            concurrent.join(timeout=5)
+
+    assert result["ok"] is True
+    assert concurrent.exitcode == 0
+    assert events == [("start", "http2"), ("promote", "http2")]
+    assert V2Config.load().remote_access.vibe_cloud.transport_protocol == "quic"
 
 
 def test_ra_tq_028_settings_compare_and_save_reject_concurrent_config_write(
@@ -302,6 +366,48 @@ def test_ra_tq_028_settings_compare_and_save_reject_concurrent_config_write(
     assert events == [("start", "http2"), ("discard", 222)]
 
 
+def test_config_runtime_decision_compares_snapshot_from_same_transaction(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    from storage.lock import MigrationFileLock
+    from vibe import ui_server
+
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    config = _config()
+    config.remote_access.vibe_cloud.enabled = False
+    config.save()
+    context = multiprocessing.get_context("spawn")
+    concurrent = context.Process(
+        target=_save_remote_enabled,
+        args=(str(tmp_path), True),
+    )
+    original_acquire = MigrationFileLock.acquire
+    interleaved = False
+
+    def acquire_after_concurrent_write(lock) -> None:
+        nonlocal interleaved
+        if not interleaved:
+            interleaved = True
+            concurrent.start()
+            concurrent.join(timeout=5)
+            assert concurrent.exitcode == 0
+        original_acquire(lock)
+
+    monkeypatch.setattr(MigrationFileLock, "acquire", acquire_after_concurrent_write)
+    try:
+        saved, should_reconcile, _, _ = ui_server._save_config_and_runtime_decisions(
+            {"remote_access": {"vibe_cloud": {"enabled": False}}}
+        )
+    finally:
+        if concurrent.is_alive():
+            concurrent.terminate()
+        concurrent.join(timeout=5)
+
+    assert should_reconcile is True
+    assert saved.remote_access.vibe_cloud.enabled is False
+
+
 def test_ra_tq_028_settings_rollback_preserves_concurrent_config_write(
     monkeypatch,
     tmp_path,
@@ -309,26 +415,31 @@ def test_ra_tq_028_settings_rollback_preserves_concurrent_config_write(
     events = _setup_settings_candidate(monkeypatch, tmp_path)
 
     context = multiprocessing.get_context("spawn")
+    attempting = context.Event()
+    finished = context.Event()
     concurrent = context.Process(
-        target=_save_remote_transport,
-        args=(str(tmp_path), "quic"),
+        target=_save_remote_transport_with_signal,
+        args=(str(tmp_path), "quic", attempting, finished),
     )
 
     def fail_promotion(*args, **kwargs):
         concurrent.start()
-        concurrent.join(timeout=5)
-        assert concurrent.exitcode == 0
+        assert attempting.wait(timeout=5)
+        assert not finished.wait(timeout=0.2)
         raise RuntimeError("promotion_failed")
 
     monkeypatch.setattr(remote_access, "_promote_candidate_connector", fail_promotion)
     try:
         result = remote_access.apply_settings({"transport_protocol": "http2"})
+        assert finished.wait(timeout=5)
     finally:
+        concurrent.join(timeout=5)
         if concurrent.is_alive():
             concurrent.terminate()
-        concurrent.join(timeout=5)
+            concurrent.join(timeout=5)
 
     assert result["ok"] is False
+    assert concurrent.exitcode == 0
     assert result["error"] == "remote_access_settings_apply_failed"
     assert result["detail"] == "promotion_failed"
     assert V2Config.load().remote_access.vibe_cloud.transport_protocol == "quic"

--- a/tests/test_tunnel_recovery.py
+++ b/tests/test_tunnel_recovery.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import json
+import multiprocessing
+import os
 import threading
 import time
 
@@ -9,6 +11,44 @@ import pytest
 from config.v2_config import V2Config
 from tests.test_remote_access_vibe_cloud import _config
 from vibe import remote_access, runtime
+
+
+def _save_remote_transport(avibe_home: str, transport_protocol: str) -> None:
+    os.environ["AVIBE_HOME"] = avibe_home
+    from vibe import api
+
+    api.save_config(
+        {
+            "remote_access": {
+                "vibe_cloud": {"transport_protocol": transport_protocol}
+            }
+        }
+    )
+
+
+def _setup_settings_candidate(monkeypatch, tmp_path) -> list[tuple[str, object]]:
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    config = _config()
+    config.remote_access.vibe_cloud.tunnel_token = "tunnel-token"
+    config.save()
+    events: list[tuple[str, object]] = []
+    monkeypatch.setattr(remote_access, "status", lambda loaded=None: {"running": True})
+    monkeypatch.setattr(remote_access, "_resolve_binary", lambda loaded: "/usr/bin/cloudflared")
+    monkeypatch.setattr(
+        remote_access,
+        "_start_candidate_connector",
+        lambda loaded, binary, protocol: events.append(("start", protocol))
+        or (222, "http://metrics"),
+    )
+    monkeypatch.setattr(remote_access, "_wait_candidate_ready", lambda pid, metrics: True)
+    monkeypatch.setattr(
+        remote_access,
+        "_discard_candidate_connector",
+        lambda pid: events.append(("discard", pid)),
+    )
+    with remote_access._RECOVERY_LOCK:
+        remote_access._RECOVERY_THREAD = None
+    return events
 
 
 def _quality(median: float) -> dict:
@@ -179,6 +219,8 @@ def test_ra_tq_028_settings_candidate_failure_keeps_active_config(monkeypatch, t
 
 
 def test_ra_tq_028_settings_promote_before_draining_previous_connector(monkeypatch, tmp_path) -> None:
+    from config.v2_config import CONFIG_LOCK
+
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     config = _config()
     config.remote_access.vibe_cloud.tunnel_token = "tunnel-token"
@@ -194,7 +236,7 @@ def test_ra_tq_028_settings_promote_before_draining_previous_connector(monkeypat
     monkeypatch.setattr(remote_access, "_wait_candidate_ready", lambda pid, metrics: True)
 
     def promote(pid, **kwargs):
-        assert not remote_access.CONFIG_LOCK._is_owned()
+        assert not CONFIG_LOCK._is_owned()
         events.append(("promote", kwargs["runtime_signature"]["transport_protocol"]))
         return {"pid": 111}
 
@@ -213,6 +255,84 @@ def test_ra_tq_028_settings_promote_before_draining_previous_connector(monkeypat
     assert result["connector_replaced"] is True
     assert V2Config.load().remote_access.vibe_cloud.transport_protocol == "http2"
     assert events == [("start", "http2"), ("promote", "http2"), ("drain", 111)]
+
+
+def test_ra_tq_028_settings_compare_and_save_reject_concurrent_config_write(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    from storage.lock import MigrationFileLock
+
+    events = _setup_settings_candidate(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        remote_access,
+        "_promote_candidate_connector",
+        lambda *args, **kwargs: pytest.fail("concurrent settings must block promotion"),
+    )
+
+    context = multiprocessing.get_context("spawn")
+    concurrent = context.Process(
+        target=_save_remote_transport,
+        args=(str(tmp_path), "quic"),
+    )
+    original_acquire = MigrationFileLock.acquire
+    interleaved = False
+
+    def acquire_after_concurrent_write(lock) -> None:
+        nonlocal interleaved
+        if events and not interleaved:
+            interleaved = True
+            concurrent.start()
+            concurrent.join(timeout=5)
+            assert concurrent.exitcode == 0
+        original_acquire(lock)
+
+    monkeypatch.setattr(MigrationFileLock, "acquire", acquire_after_concurrent_write)
+    try:
+        result = remote_access.apply_settings({"transport_protocol": "http2"})
+    finally:
+        if concurrent.is_alive():
+            concurrent.terminate()
+        concurrent.join(timeout=5)
+
+    assert result["ok"] is False
+    assert result["error"] == "remote_access_settings_apply_failed"
+    assert result["detail"] == "remote_access_settings_changed"
+    assert V2Config.load().remote_access.vibe_cloud.transport_protocol == "quic"
+    assert events == [("start", "http2"), ("discard", 222)]
+
+
+def test_ra_tq_028_settings_rollback_preserves_concurrent_config_write(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    events = _setup_settings_candidate(monkeypatch, tmp_path)
+
+    context = multiprocessing.get_context("spawn")
+    concurrent = context.Process(
+        target=_save_remote_transport,
+        args=(str(tmp_path), "quic"),
+    )
+
+    def fail_promotion(*args, **kwargs):
+        concurrent.start()
+        concurrent.join(timeout=5)
+        assert concurrent.exitcode == 0
+        raise RuntimeError("promotion_failed")
+
+    monkeypatch.setattr(remote_access, "_promote_candidate_connector", fail_promotion)
+    try:
+        result = remote_access.apply_settings({"transport_protocol": "http2"})
+    finally:
+        if concurrent.is_alive():
+            concurrent.terminate()
+        concurrent.join(timeout=5)
+
+    assert result["ok"] is False
+    assert result["error"] == "remote_access_settings_apply_failed"
+    assert result["detail"] == "promotion_failed"
+    assert V2Config.load().remote_access.vibe_cloud.transport_protocol == "quic"
+    assert events == [("start", "http2"), ("discard", 222)]
 
 
 @pytest.mark.parametrize(

--- a/tests/test_ui_server_fastapi.py
+++ b/tests/test_ui_server_fastapi.py
@@ -2054,6 +2054,82 @@ def test_config_post_non_platform_change_does_not_reconcile_platforms(monkeypatc
     assert "agent_backend_runtime" not in response.get_json()
 
 
+def test_config_post_settles_runtime_reconciliation_after_cancelled_save(
+    monkeypatch,
+    tmp_path,
+):
+    from config.v2_config import V2Config
+    from vibe import internal_client, remote_access, runtime
+
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    config = V2Config.from_payload(_full_config_payload())
+    save_entered = threading.Event()
+    release_save = threading.Event()
+    settled: list[str] = []
+
+    def blocking_save(_payload):
+        save_entered.set()
+        assert release_save.wait(timeout=5)
+        config.show_duration = True
+        config.save()
+        settled.append("save")
+        return config, True, True, ["codex"]
+
+    def reconcile_remote_access():
+        settled.append("remote")
+        return {"ok": True}
+
+    async def reconcile_platforms():
+        settled.append("platform")
+        return {"status_code": 500, "body": {"ok": False}}
+
+    async def reconcile_agent_backends(backends):
+        assert backends == ["codex"]
+        settled.append("agent")
+        return {"status_code": 500, "body": {"ok": False}}
+
+    def schedule_restart():
+        settled.append("restart")
+        return {"ok": True, "restart": {"job_id": "fallback-1"}}
+
+    monkeypatch.setattr(ui_server, "_save_config_and_runtime_decisions", blocking_save)
+    monkeypatch.setattr(remote_access, "reconcile", reconcile_remote_access)
+    monkeypatch.setattr(
+        ui_server,
+        "_ensure_remote_access_monitoring",
+        lambda _config: settled.append("monitor"),
+    )
+    monkeypatch.setattr(internal_client, "reconcile_platforms", reconcile_platforms)
+    monkeypatch.setattr(
+        internal_client,
+        "reconcile_agent_backends",
+        reconcile_agent_backends,
+    )
+    monkeypatch.setattr(runtime, "service_process_running", lambda: True)
+    monkeypatch.setattr(
+        ui_server,
+        "_schedule_service_restart_for_config_fallback",
+        schedule_restart,
+    )
+
+    async def exercise() -> None:
+        task = asyncio.create_task(ui_server.config_post())
+        assert await asyncio.to_thread(save_entered.wait, 5)
+        task.cancel("config request cancelled")
+        await asyncio.sleep(0)
+        task.cancel("repeated cancellation")
+        release_save.set()
+        with pytest.raises(asyncio.CancelledError) as raised:
+            await task
+        assert raised.value.args == ("config request cancelled",)
+
+    with app.test_request_context("/api/config", method="POST", json={"agents": {}}):
+        asyncio.run(exercise())
+
+    assert V2Config.load().show_duration is True
+    assert settled == ["save", "remote", "monitor", "platform", "restart", "agent"]
+
+
 def test_config_post_schedules_service_restart_when_hot_reconcile_unavailable(monkeypatch, tmp_path):
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     from vibe import api
@@ -2516,6 +2592,96 @@ def test_wechat_qr_poll_marks_bind_hint_and_schedules_managed_restart(monkeypatc
     ]
     assert bound_users == ["wx-user"]
     assert restart_calls == [True]
+
+
+def test_wechat_qr_poll_persists_credentials_off_event_loop(monkeypatch):
+    from vibe import runtime
+
+    loop_threads: list[int] = []
+    persist_threads: list[int] = []
+
+    class _Auth:
+        async def poll_status(self, session_key, verify_code=None):
+            loop_threads.append(threading.get_ident())
+            return {
+                "status": "confirmed",
+                "bot_token": "wechat-token",
+                "base_url": "https://wechat.example.com",
+                "user_id": "wx-user",
+            }
+
+    runtime.ensure_config()
+    monkeypatch.setattr(ui_server, "_get_wechat_auth", lambda: _Auth())
+    monkeypatch.setattr(
+        ui_server,
+        "_persist_wechat_qr_credentials",
+        lambda _result: persist_threads.append(threading.get_ident()),
+    )
+    monkeypatch.setattr(
+        ui_server,
+        "_schedule_wechat_qr_login_restart",
+        lambda: {"job_id": "restart-1"},
+    )
+    monkeypatch.setattr("vibe.api.auto_bind_wechat_user", lambda _user_id: {"ok": True})
+
+    client = app.test_client()
+    response = client.post(
+        "/api/wechat/qr_login/poll",
+        json={"session_key": "qr-session"},
+        headers=csrf_headers(client),
+    )
+
+    assert response.status_code == 200
+    assert loop_threads and persist_threads
+    assert persist_threads[0] != loop_threads[0]
+
+
+def test_wechat_qr_poll_settles_persistence_before_cancellation(monkeypatch):
+    from vibe import runtime
+
+    persist_entered = threading.Event()
+    release_persist = threading.Event()
+    persist_finished = threading.Event()
+
+    class _Auth:
+        async def poll_status(self, session_key, verify_code=None):
+            return {
+                "status": "confirmed",
+                "bot_token": "wechat-token",
+                "base_url": "https://wechat.example.com",
+                "user_id": "wx-user",
+            }
+
+    def blocking_persist(_result):
+        persist_entered.set()
+        assert release_persist.wait(timeout=5)
+        persist_finished.set()
+
+    runtime.ensure_config()
+    monkeypatch.setattr(ui_server, "_get_wechat_auth", lambda: _Auth())
+    monkeypatch.setattr(ui_server, "_persist_wechat_qr_credentials", blocking_persist)
+
+    async def exercise() -> None:
+        task = asyncio.create_task(ui_server.wechat_qr_login_poll())
+        assert await asyncio.to_thread(persist_entered.wait, 5)
+        task.cancel("wechat request cancelled")
+        await asyncio.sleep(0)
+        task.cancel("repeated cancellation")
+        await asyncio.sleep(0)
+        assert not task.done()
+        release_persist.set()
+        with pytest.raises(asyncio.CancelledError) as raised:
+            await task
+        assert raised.value.args == ("wechat request cancelled",)
+
+    with app.test_request_context(
+        "/api/wechat/qr_login/poll",
+        method="POST",
+        json={"session_key": "qr-session"},
+    ):
+        asyncio.run(exercise())
+
+    assert persist_finished.is_set()
 
 
 def test_wechat_qr_poll_passes_verify_code(monkeypatch):

--- a/tests/test_ui_server_fastapi.py
+++ b/tests/test_ui_server_fastapi.py
@@ -2642,6 +2642,8 @@ def test_wechat_qr_poll_settles_persistence_before_cancellation(monkeypatch):
     persist_entered = threading.Event()
     release_persist = threading.Event()
     persist_finished = threading.Event()
+    bound_users: list[str] = []
+    restart_calls: list[bool] = []
 
     class _Auth:
         async def poll_status(self, session_key, verify_code=None):
@@ -2660,6 +2662,15 @@ def test_wechat_qr_poll_settles_persistence_before_cancellation(monkeypatch):
     runtime.ensure_config()
     monkeypatch.setattr(ui_server, "_get_wechat_auth", lambda: _Auth())
     monkeypatch.setattr(ui_server, "_persist_wechat_qr_credentials", blocking_persist)
+    monkeypatch.setattr(
+        "vibe.api.auto_bind_wechat_user",
+        lambda user_id: bound_users.append(user_id) or {"ok": True},
+    )
+    monkeypatch.setattr(
+        ui_server,
+        "_schedule_wechat_qr_login_restart",
+        lambda: restart_calls.append(True) or {"job_id": "restart-1"},
+    )
 
     async def exercise() -> None:
         task = asyncio.create_task(ui_server.wechat_qr_login_poll())
@@ -2682,6 +2693,8 @@ def test_wechat_qr_poll_settles_persistence_before_cancellation(monkeypatch):
         asyncio.run(exercise())
 
     assert persist_finished.is_set()
+    assert bound_users == ["wx-user"]
+    assert restart_calls == [True]
 
 
 def test_wechat_qr_poll_passes_verify_code(monkeypatch):

--- a/tests/test_web_oauth_flow.py
+++ b/tests/test_web_oauth_flow.py
@@ -303,6 +303,59 @@ def test_web_codex_persist_failure_reconciles_hook_and_runtime_before_failure(
     service._refresh_backend_runtime.assert_awaited_once_with("codex")
 
 
+def test_web_codex_persist_failure_logs_secondary_refresh_failure(
+    service: AgentAuthService,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    flow = WebAuthFlow(
+        flow_id="codex-double-failure",
+        backend="codex",
+        state="verifying",
+        process=SimpleNamespace(wait=AsyncMock(return_value=0)),
+    )
+    service._verify_web_login = AsyncMock(return_value=(True, None))
+    service._persist_backend_auth_mode = AsyncMock(
+        side_effect=BackendAuthConfigSaveError("config save failed")
+    )
+    service._refresh_backend_runtime = AsyncMock(
+        side_effect=RuntimeError("runtime refresh failed")
+    )
+
+    _run(service._wait_for_codex_completion_web(flow))
+
+    assert flow.state == "failed"
+    assert flow.error == "config save failed"
+    assert "runtime refresh failed" in caplog.text
+
+
+def test_web_claude_finish_failure_still_attempts_runtime_refresh(
+    service: AgentAuthService,
+) -> None:
+    flow = WebAuthFlow(
+        flow_id="claude-finish-failure",
+        backend="claude",
+        state="verifying",
+        claude_client=SimpleNamespace(),
+    )
+    service._send_claude_control_request = AsyncMock()
+    service._verify_web_login = AsyncMock(return_value=(True, None))
+    service._invoke_post_web_success_hook = AsyncMock(return_value=None)
+
+    async def finish_attempt(_attempt, *, succeeded):
+        if succeeded:
+            raise RuntimeError("attempt finish failed")
+
+    service._finish_claude_oauth_attempt = AsyncMock(side_effect=finish_attempt)
+    service._refresh_backend_runtime = AsyncMock()
+    service._disconnect_claude_client = AsyncMock()
+
+    _run(service._wait_for_claude_completion_web(flow))
+
+    service._refresh_backend_runtime.assert_awaited_once_with("claude")
+    assert flow.state == "failed"
+    assert flow.error == "attempt finish failed"
+
+
 def test_web_codex_persist_failure_reconciles_before_cancellation(
     service: AgentAuthService,
     monkeypatch: pytest.MonkeyPatch,
@@ -1516,6 +1569,72 @@ def test_remove_web_auth_reconciles_hook_before_cancel_after_save_failure(
 
     _run(exercise())
     assert hook_calls == ["codex"]
+
+
+def test_remove_web_auth_surfaces_config_save_failure_after_hook(
+    service: AgentAuthService,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from config.v2_config import V2Config
+    from core.services.settings import default_config
+
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    config = default_config()
+    config.agents.codex.auth_mode = "api_key"
+    config.agents.codex.api_key = "sk-stale"
+    config.save()
+    service.controller.config = V2Config.load()
+    service._run_utility_command = AsyncMock(return_value=(True, None))
+    hook_calls: list[str] = []
+    service._post_web_success_hook = hook_calls.append
+
+    monkeypatch.setattr(
+        V2Config,
+        "save",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            RuntimeError("config save failed")
+        ),
+    )
+
+    result = _run(service.remove_web_auth("codex"))
+
+    assert result == {
+        "ok": True,
+        "partial": True,
+        "warning": "config_save_failed",
+        "detail": "config save failed",
+    }
+    assert hook_calls == ["codex"]
+
+
+def test_remove_web_auth_caller_cancel_precedes_child_cancel(
+    service: AgentAuthService,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    child_entered = asyncio.Event()
+    release_child = asyncio.Event()
+
+    async def child_cancel(*_args, **_kwargs):
+        child_entered.set()
+        await release_child.wait()
+        raise asyncio.CancelledError("logout child stopped")
+
+    monkeypatch.setattr(service, "_run_utility_command", child_cancel)
+
+    async def exercise() -> None:
+        task = asyncio.create_task(service.remove_web_auth("codex"))
+        await child_entered.wait()
+        task.cancel("remove caller stopped")
+        await asyncio.sleep(0)
+        release_child.set()
+        with pytest.raises(asyncio.CancelledError) as raised:
+            await task
+        assert raised.value.args == ("remove caller stopped",)
+        assert isinstance(raised.value.__cause__, asyncio.CancelledError)
+        assert raised.value.__cause__.args == ("logout child stopped",)
+
+    _run(exercise())
 
 
 def test_remove_web_auth_surfaces_logout_failure(

--- a/tests/test_web_oauth_flow.py
+++ b/tests/test_web_oauth_flow.py
@@ -24,6 +24,7 @@ import pytest
 from core.agent_auth_service import (
     AgentAuthService,
     BackendAuthConfigSaveError,
+    BackendAuthCredentialCleanupError,
     ClaudeOAuthAttempt,
     ClaudeOAuthBatch,
     WebAuthFlow,
@@ -314,10 +315,9 @@ def test_web_codex_cleanup_failure_still_runs_hook_and_runtime(
         process=SimpleNamespace(wait=AsyncMock(return_value=0)),
     )
     service._verify_web_login = AsyncMock(return_value=(True, None))
-    service._clear_codex_api_key_for_oauth = AsyncMock(
-        side_effect=RuntimeError("credential cleanup failed")
+    service._save_backend_auth_fields = AsyncMock(
+        side_effect=BackendAuthCredentialCleanupError("credential cleanup failed")
     )
-    service._save_backend_auth_fields = AsyncMock()
     service._refresh_backend_runtime = AsyncMock()
     service._post_web_success_hook = hook_calls.append
 
@@ -326,7 +326,7 @@ def test_web_codex_cleanup_failure_still_runs_hook_and_runtime(
     assert flow.state == "failed"
     assert flow.error == "credential cleanup failed"
     assert hook_calls == ["codex"]
-    service._save_backend_auth_fields.assert_not_awaited()
+    service._save_backend_auth_fields.assert_awaited_once()
     service._refresh_backend_runtime.assert_awaited_once_with("codex")
 
 
@@ -1686,21 +1686,27 @@ def test_remove_web_auth_surfaces_logout_failure(
 def test_persist_auth_cancel_precedes_cleanup_failure_and_skips_config_save(
     service: AgentAuthService,
     monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
+    from config.v2_config import V2Config
+    from core.services.settings import default_config
+
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    config = default_config()
+    config.agents.codex.auth_mode = "api_key"
+    config.agents.codex.api_key = "sk-stale"
+    config.save()
+    service.controller.config = V2Config.load()
     cleanup_entered = threading.Event()
     release_cleanup = threading.Event()
-    save_fields = AsyncMock()
 
-    def failing_cleanup() -> None:
+    def failing_cleanup(backend: str) -> None:
+        assert backend == "codex"
         cleanup_entered.set()
         assert release_cleanup.wait(timeout=5)
-        raise RuntimeError("credential cleanup failed")
+        raise BackendAuthCredentialCleanupError("credential cleanup failed")
 
-    async def clear_codex() -> None:
-        await asyncio.to_thread(failing_cleanup)
-
-    monkeypatch.setattr(service, "_clear_codex_api_key_for_oauth", clear_codex)
-    monkeypatch.setattr(service, "_save_backend_auth_fields", save_fields)
+    monkeypatch.setattr(service, "_clear_backend_api_key_for_oauth", failing_cleanup)
 
     async def exercise() -> None:
         task = asyncio.create_task(
@@ -1717,7 +1723,52 @@ def test_persist_auth_cancel_precedes_cleanup_failure_and_skips_config_save(
         assert str(raised.value.__cause__) == "credential cleanup failed"
 
     _run(exercise())
-    save_fields.assert_not_awaited()
+    persisted = V2Config.load().agents.codex
+    assert persisted.auth_mode == "api_key"
+    assert persisted.api_key == "sk-stale"
+
+
+@pytest.mark.parametrize("backend", ["claude", "codex"])
+def test_oauth_cleanup_runs_inside_backend_config_transaction(
+    service: AgentAuthService,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    backend: str,
+) -> None:
+    import config.v2_config as config_module
+    from core.services.settings import default_config
+
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    config = default_config()
+    target = getattr(config.agents, backend)
+    target.auth_mode = "api_key"
+    target.api_key = "sk-stale"
+    config.save()
+    service.controller.config = config_module.V2Config.load()
+
+    transaction_depth = threading.local()
+    cleanup_depths: list[int] = []
+    original_transaction = config_module.config_write_transaction
+
+    @contextlib.contextmanager
+    def tracked_transaction(*args, **kwargs):
+        with original_transaction(*args, **kwargs):
+            transaction_depth.value = getattr(transaction_depth, "value", 0) + 1
+            try:
+                yield
+            finally:
+                transaction_depth.value -= 1
+
+    def record_cleanup(**_kwargs) -> None:
+        cleanup_depths.append(getattr(transaction_depth, "value", 0))
+
+    monkeypatch.setattr(config_module, "config_write_transaction", tracked_transaction)
+    monkeypatch.setattr(f"vibe.{backend}_config.apply_{backend}_auth", record_cleanup)
+
+    _run(service._persist_backend_auth_mode(backend, "oauth"))
+
+    assert cleanup_depths == [1]
+    assert getattr(config_module.V2Config.load().agents, backend).auth_mode == "oauth"
 
 
 def test_persist_backend_auth_mode_propagates_config_save_failure(

--- a/tests/test_web_oauth_flow.py
+++ b/tests/test_web_oauth_flow.py
@@ -1340,6 +1340,104 @@ def test_remove_web_auth_settles_live_state_and_hook_before_cancellation(
     assert hook_calls == ["codex"]
 
 
+def test_remove_web_auth_settles_logout_before_config_and_live_state(
+    service: AgentAuthService,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from config.v2_config import V2Config
+    from core.services.settings import default_config
+
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    config = default_config()
+    config.agents.codex.auth_mode = "api_key"
+    config.agents.codex.api_key = "sk-stale"
+    config.save()
+    service.controller.config = V2Config.load()
+    logout_entered = threading.Event()
+    release_logout = threading.Event()
+    logout_finished = threading.Event()
+    hook_calls: list[str] = []
+
+    def blocking_logout() -> None:
+        logout_entered.set()
+        assert release_logout.wait(timeout=5)
+        logout_finished.set()
+
+    async def run_utility(*_args, **_kwargs):
+        await asyncio.to_thread(blocking_logout)
+        return True, None
+
+    monkeypatch.setattr(service, "_run_utility_command", run_utility)
+    service._post_web_success_hook = hook_calls.append
+
+    async def exercise() -> None:
+        task = asyncio.create_task(service.remove_web_auth("codex"))
+        assert await asyncio.to_thread(logout_entered.wait, 5)
+        task.cancel("remove cancelled")
+        await asyncio.sleep(0)
+        task.cancel("repeated cancellation")
+        await asyncio.sleep(0)
+        release_logout.set()
+        with pytest.raises(asyncio.CancelledError) as raised:
+            await task
+        assert raised.value.args == ("remove cancelled",)
+
+    _run(exercise())
+
+    assert logout_finished.wait(timeout=5)
+    persisted = V2Config.load().agents.codex
+    live = service.controller.config.agents.codex
+    assert persisted.auth_mode == "oauth"
+    assert persisted.api_key is None
+    assert live.auth_mode == "oauth"
+    assert live.api_key is None
+    assert hook_calls == ["codex"]
+
+
+def test_remove_web_auth_reconciles_hook_before_cancel_after_save_failure(
+    service: AgentAuthService,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from config.v2_config import V2Config
+    from core.services.settings import default_config
+
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    config = default_config()
+    config.agents.codex.auth_mode = "api_key"
+    config.agents.codex.api_key = "sk-stale"
+    config.save()
+    service.controller.config = V2Config.load()
+    service._run_utility_command = AsyncMock(return_value=(True, None))
+    save_entered = threading.Event()
+    release_save = threading.Event()
+    hook_calls: list[str] = []
+
+    def failing_save(*_args, **_kwargs) -> None:
+        save_entered.set()
+        assert release_save.wait(timeout=5)
+        raise RuntimeError("config save failed")
+
+    monkeypatch.setattr(V2Config, "save", failing_save)
+    service._post_web_success_hook = hook_calls.append
+
+    async def exercise() -> None:
+        task = asyncio.create_task(service.remove_web_auth("codex"))
+        assert await asyncio.to_thread(save_entered.wait, 5)
+        task.cancel("remove cancelled")
+        await asyncio.sleep(0)
+        release_save.set()
+        with pytest.raises(asyncio.CancelledError) as raised:
+            await task
+        assert raised.value.args == ("remove cancelled",)
+        assert isinstance(raised.value.__cause__, RuntimeError)
+        assert str(raised.value.__cause__) == "config save failed"
+
+    _run(exercise())
+    assert hook_calls == ["codex"]
+
+
 def test_remove_web_auth_surfaces_logout_failure(
     service: AgentAuthService, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -1357,6 +1455,89 @@ def test_remove_web_auth_surfaces_logout_failure(
     assert result["partial"] is True
     assert result["warning"] == "logout_failed"
     assert "exit 1" in result["detail"]
+
+
+def test_persist_auth_cancel_precedes_cleanup_failure_and_skips_config_save(
+    service: AgentAuthService,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cleanup_entered = threading.Event()
+    release_cleanup = threading.Event()
+    save_fields = AsyncMock()
+
+    def failing_cleanup() -> None:
+        cleanup_entered.set()
+        assert release_cleanup.wait(timeout=5)
+        raise RuntimeError("credential cleanup failed")
+
+    async def clear_codex() -> None:
+        await asyncio.to_thread(failing_cleanup)
+
+    monkeypatch.setattr(service, "_clear_codex_api_key_for_oauth", clear_codex)
+    monkeypatch.setattr(service, "_save_backend_auth_fields", save_fields)
+
+    async def exercise() -> None:
+        task = asyncio.create_task(
+            service._persist_backend_auth_mode("codex", "oauth")
+        )
+        assert await asyncio.to_thread(cleanup_entered.wait, 5)
+        task.cancel("auth cancelled")
+        await asyncio.sleep(0)
+        release_cleanup.set()
+        with pytest.raises(asyncio.CancelledError) as raised:
+            await task
+        assert raised.value.args == ("auth cancelled",)
+        assert isinstance(raised.value.__cause__, RuntimeError)
+        assert str(raised.value.__cause__) == "credential cleanup failed"
+
+    _run(exercise())
+    save_fields.assert_not_awaited()
+
+
+def test_save_backend_auth_fields_owned_cancel_precedes_save_failure(
+    service: AgentAuthService,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from config.v2_config import V2Config
+    from core.services.settings import default_config
+
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    config = default_config()
+    config.agents.codex.auth_mode = "api_key"
+    config.agents.codex.api_key = "sk-stale"
+    config.save()
+    service.controller.config = V2Config.load()
+    save_entered = threading.Event()
+    release_save = threading.Event()
+
+    def failing_save(*_args, **_kwargs) -> None:
+        save_entered.set()
+        assert release_save.wait(timeout=5)
+        raise RuntimeError("config save failed")
+
+    monkeypatch.setattr(V2Config, "save", failing_save)
+
+    async def exercise() -> None:
+        task = asyncio.create_task(
+            service._save_backend_auth_fields(
+                "codex",
+                "oauth",
+                clear_credentials=True,
+                mark_mode_explicit=False,
+            )
+        )
+        assert await asyncio.to_thread(save_entered.wait, 5)
+        task.cancel("save cancelled")
+        await asyncio.sleep(0)
+        release_save.set()
+        with pytest.raises(asyncio.CancelledError) as raised:
+            await task
+        assert raised.value.args == ("save cancelled",)
+        assert isinstance(raised.value.__cause__, RuntimeError)
+        assert str(raised.value.__cause__) == "config save failed"
+
+    _run(exercise())
 
 
 def test_remove_web_auth_surfaces_claude_settings_cleanup_failure(

--- a/tests/test_web_oauth_flow.py
+++ b/tests/test_web_oauth_flow.py
@@ -303,6 +303,33 @@ def test_web_codex_persist_failure_reconciles_hook_and_runtime_before_failure(
     service._refresh_backend_runtime.assert_awaited_once_with("codex")
 
 
+def test_web_codex_cleanup_failure_still_runs_hook_and_runtime(
+    service: AgentAuthService,
+) -> None:
+    hook_calls: list[str] = []
+    flow = WebAuthFlow(
+        flow_id="codex-cleanup-failure",
+        backend="codex",
+        state="verifying",
+        process=SimpleNamespace(wait=AsyncMock(return_value=0)),
+    )
+    service._verify_web_login = AsyncMock(return_value=(True, None))
+    service._clear_codex_api_key_for_oauth = AsyncMock(
+        side_effect=RuntimeError("credential cleanup failed")
+    )
+    service._save_backend_auth_fields = AsyncMock()
+    service._refresh_backend_runtime = AsyncMock()
+    service._post_web_success_hook = hook_calls.append
+
+    _run(service._wait_for_codex_completion_web(flow))
+
+    assert flow.state == "failed"
+    assert flow.error == "credential cleanup failed"
+    assert hook_calls == ["codex"]
+    service._save_backend_auth_fields.assert_not_awaited()
+    service._refresh_backend_runtime.assert_awaited_once_with("codex")
+
+
 def test_web_codex_persist_failure_logs_secondary_refresh_failure(
     service: AgentAuthService,
     caplog: pytest.LogCaptureFixture,

--- a/tests/test_web_oauth_flow.py
+++ b/tests/test_web_oauth_flow.py
@@ -272,7 +272,7 @@ def test_post_web_success_hook_invocation_when_set(
     monkeypatch.setattr(service, "_persist_backend_auth_mode", persist)
     service._post_web_success_hook = hook
     _run(service._invoke_post_web_success_hook("codex"))
-    persist.assert_awaited_once_with("codex", "oauth")
+    persist.assert_awaited_once_with("codex", "oauth", settlement=ANY)
     assert calls == ["codex"]
 
 
@@ -1284,6 +1284,60 @@ def test_remove_web_auth_fresh_loads_config_and_saves_off_loop(
     assert save_threads and all(
         thread_id != event_loop_thread for thread_id in save_threads
     )
+
+
+def test_remove_web_auth_settles_live_state_and_hook_before_cancellation(
+    service: AgentAuthService,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from config.v2_config import V2Config
+    from core.services.settings import default_config
+
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    config = default_config()
+    config.agents.codex.auth_mode = "api_key"
+    config.agents.codex.api_key = "sk-stale"
+    config.agents.codex.base_url = "https://old.example.test/v1"
+    config.save()
+    service.controller.config = V2Config.load()
+    service._run_utility_command = AsyncMock(return_value=(True, None))
+    save_entered = threading.Event()
+    release_save = threading.Event()
+    hook_calls: list[str] = []
+    original_save = V2Config.save
+
+    def blocking_save(config, *args, **kwargs):
+        save_entered.set()
+        assert release_save.wait(timeout=5)
+        return original_save(config, *args, **kwargs)
+
+    monkeypatch.setattr(V2Config, "save", blocking_save)
+    service._post_web_success_hook = hook_calls.append
+
+    async def exercise() -> None:
+        task = asyncio.create_task(service.remove_web_auth("codex"))
+        assert await asyncio.to_thread(save_entered.wait, 5)
+        task.cancel()
+        await asyncio.sleep(0)
+        task.cancel()
+        await asyncio.sleep(0)
+        assert not task.done()
+        release_save.set()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    _run(exercise())
+
+    persisted = V2Config.load().agents.codex
+    live = service.controller.config.agents.codex
+    assert persisted.auth_mode == "oauth"
+    assert persisted.api_key is None
+    assert persisted.base_url is None
+    assert live.auth_mode == "oauth"
+    assert live.api_key is None
+    assert live.base_url is None
+    assert hook_calls == ["codex"]
 
 
 def test_remove_web_auth_surfaces_logout_failure(

--- a/tests/test_web_oauth_flow.py
+++ b/tests/test_web_oauth_flow.py
@@ -1196,6 +1196,53 @@ def test_remove_web_auth_codex_uses_logout_subcommand(
     assert "logout" in args and "auth" not in args
 
 
+def test_remove_web_auth_fresh_loads_config_and_saves_off_loop(
+    service: AgentAuthService,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from core.services.settings import default_config
+    from config.v2_config import V2Config
+
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    config = default_config()
+    config.agents.codex.auth_mode = "api_key"
+    config.agents.codex.api_key = "sk-stale"
+    config.agents.codex.base_url = "https://old.example.test/v1"
+    config.save()
+    service.controller.config = V2Config.load()
+    concurrent = V2Config.load()
+    concurrent.runtime.log_level = "DEBUG"
+    concurrent.save()
+    service._run_utility_command = AsyncMock(return_value=(True, None))
+    service._post_web_success_hook = None
+    original_save = V2Config.save
+    save_threads: list[int] = []
+
+    def record_save(config, *args, **kwargs):
+        save_threads.append(threading.get_ident())
+        return original_save(config, *args, **kwargs)
+
+    monkeypatch.setattr(V2Config, "save", record_save)
+
+    async def exercise():
+        event_loop_thread = threading.get_ident()
+        result = await service.remove_web_auth("codex")
+        return result, event_loop_thread
+
+    result, event_loop_thread = _run(exercise())
+    persisted = V2Config.load()
+
+    assert result == {"ok": True}
+    assert persisted.runtime.log_level == "DEBUG"
+    assert persisted.agents.codex.auth_mode == "oauth"
+    assert persisted.agents.codex.api_key is None
+    assert persisted.agents.codex.base_url is None
+    assert save_threads and all(
+        thread_id != event_loop_thread for thread_id in save_threads
+    )
+
+
 def test_remove_web_auth_surfaces_logout_failure(
     service: AgentAuthService, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -1232,6 +1279,51 @@ def test_remove_web_auth_surfaces_claude_settings_cleanup_failure(
     assert result["partial"] is True
     assert result["warning"] == "settings_cleanup_failed"
     assert "Failed to clear Claude Code settings env" in result["detail"]
+
+
+def test_persist_backend_auth_mode_fresh_loads_config_and_saves_off_loop(
+    service: AgentAuthService,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from core.services.settings import default_config
+    from config.v2_config import V2Config
+
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    config = default_config()
+    config.agents.codex.auth_mode = "api_key"
+    config.agents.codex.api_key = "sk-stale"
+    config.agents.codex.base_url = "https://old.example.test/v1"
+    config.save()
+    service.controller.config = V2Config.load()
+    concurrent = V2Config.load()
+    concurrent.runtime.log_level = "DEBUG"
+    concurrent.save()
+    service._clear_codex_api_key_for_oauth = AsyncMock()
+    original_save = V2Config.save
+    save_threads: list[int] = []
+
+    def record_save(config, *args, **kwargs):
+        save_threads.append(threading.get_ident())
+        return original_save(config, *args, **kwargs)
+
+    monkeypatch.setattr(V2Config, "save", record_save)
+
+    async def exercise():
+        event_loop_thread = threading.get_ident()
+        await service._persist_backend_auth_mode("codex", "oauth")
+        return event_loop_thread
+
+    event_loop_thread = _run(exercise())
+    persisted = V2Config.load()
+
+    assert persisted.runtime.log_level == "DEBUG"
+    assert persisted.agents.codex.auth_mode == "oauth"
+    assert persisted.agents.codex.api_key is None
+    assert persisted.agents.codex.base_url is None
+    assert save_threads and all(
+        thread_id != event_loop_thread for thread_id in save_threads
+    )
 
 
 def test_clear_claude_oauth_for_api_key_mode_restores_key_settings(

--- a/tests/test_web_oauth_flow.py
+++ b/tests/test_web_oauth_flow.py
@@ -14,6 +14,7 @@ import asyncio
 import contextlib
 import json
 import os
+import threading
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import ANY, AsyncMock
@@ -424,6 +425,7 @@ def test_utility_start_callback_runs_before_subprocess_creation(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     events = []
+    callback_threads: list[int] = []
 
     class FakeProcess:
         returncode = 0
@@ -436,18 +438,27 @@ def test_utility_start_callback_runs_before_subprocess_creation(
         events.append("spawn")
         return FakeProcess()
 
+    def prepare_start():
+        events.append("callback")
+        callback_threads.append(threading.get_ident())
+
     monkeypatch.setattr(asyncio, "create_subprocess_exec", spawn)
 
-    result = _run(
-        service._run_utility_command(
+    async def exercise():
+        event_loop_thread = threading.get_ident()
+        result = await service._run_utility_command(
             "codex",
             "logout",
-            prepare_start=lambda: events.append("callback"),
+            prepare_start=prepare_start,
         )
-    )
+        return result, event_loop_thread
+
+    result, event_loop_thread = _run(exercise())
 
     assert result == (True, None)
     assert events == ["callback", "spawn", "communicate"]
+    assert len(callback_threads) == 1
+    assert callback_threads[0] != event_loop_thread
 
 
 def test_claude_web_oauth_failures_restore_settings_after_batch_finishes(

--- a/tests/test_web_oauth_flow.py
+++ b/tests/test_web_oauth_flow.py
@@ -461,6 +461,49 @@ def test_utility_start_callback_runs_before_subprocess_creation(
     assert callback_threads[0] != event_loop_thread
 
 
+def test_utility_start_cancellation_restores_prepared_state_before_spawn(
+    service: AgentAuthService,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    prepare_entered = threading.Event()
+    release_prepare = threading.Event()
+    events: list[str] = []
+
+    def prepare_start():
+        prepare_entered.set()
+        assert release_prepare.wait(timeout=5)
+        events.append("prepared")
+
+        def restore():
+            events.append("restored")
+
+        return restore
+
+    async def unexpected_spawn(*_args, **_kwargs):
+        events.append("spawn")
+        raise AssertionError("cancelled preparation must not spawn")
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", unexpected_spawn)
+
+    async def exercise():
+        task = asyncio.create_task(
+            service._run_utility_command(
+                "codex",
+                "logout",
+                prepare_start=prepare_start,
+            )
+        )
+        assert await asyncio.to_thread(prepare_entered.wait, 5)
+        task.cancel()
+        release_prepare.set()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    _run(exercise())
+
+    assert events == ["prepared", "restored"]
+
+
 def test_claude_web_oauth_failures_restore_settings_after_batch_finishes(
     service: AgentAuthService,
 ) -> None:

--- a/tests/test_web_oauth_flow.py
+++ b/tests/test_web_oauth_flow.py
@@ -23,6 +23,7 @@ import pytest
 
 from core.agent_auth_service import (
     AgentAuthService,
+    BackendAuthConfigSaveError,
     ClaudeOAuthAttempt,
     ClaudeOAuthBatch,
     WebAuthFlow,
@@ -274,6 +275,85 @@ def test_post_web_success_hook_invocation_when_set(
     _run(service._invoke_post_web_success_hook("codex"))
     persist.assert_awaited_once_with("codex", "oauth", settlement=ANY)
     assert calls == ["codex"]
+
+
+def test_web_codex_persist_failure_reconciles_hook_and_runtime_before_failure(
+    service: AgentAuthService,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    hook_calls: list[str] = []
+    flow = WebAuthFlow(
+        flow_id="codex-persist-failure",
+        backend="codex",
+        state="verifying",
+        process=SimpleNamespace(wait=AsyncMock(return_value=0)),
+    )
+    service._verify_web_login = AsyncMock(return_value=(True, None))
+    service._persist_backend_auth_mode = AsyncMock(
+        side_effect=BackendAuthConfigSaveError("config save failed")
+    )
+    service._refresh_backend_runtime = AsyncMock()
+    service._post_web_success_hook = hook_calls.append
+
+    _run(service._wait_for_codex_completion_web(flow))
+
+    assert flow.state == "failed"
+    assert flow.error == "config save failed"
+    assert hook_calls == ["codex"]
+    service._refresh_backend_runtime.assert_awaited_once_with("codex")
+
+
+def test_web_codex_persist_failure_reconciles_before_cancellation(
+    service: AgentAuthService,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from config.v2_config import V2Config
+    from core.services.settings import default_config
+
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    config = default_config()
+    config.agents.codex.auth_mode = "api_key"
+    config.agents.codex.api_key = "sk-stale"
+    config.save()
+    service.controller.config = V2Config.load()
+    flow = WebAuthFlow(
+        flow_id="codex-cancelled-persist-failure",
+        backend="codex",
+        state="verifying",
+        process=SimpleNamespace(wait=AsyncMock(return_value=0)),
+    )
+    service._verify_web_login = AsyncMock(return_value=(True, None))
+    service._clear_codex_api_key_for_oauth = AsyncMock()
+    service._refresh_backend_runtime = AsyncMock()
+    hook_calls: list[str] = []
+    service._post_web_success_hook = hook_calls.append
+    save_entered = threading.Event()
+    release_save = threading.Event()
+
+    def failing_save(*_args, **_kwargs) -> None:
+        save_entered.set()
+        assert release_save.wait(timeout=5)
+        raise RuntimeError("config save failed")
+
+    monkeypatch.setattr(V2Config, "save", failing_save)
+
+    async def exercise() -> None:
+        task = asyncio.create_task(service._wait_for_codex_completion_web(flow))
+        assert await asyncio.to_thread(save_entered.wait, 5)
+        task.cancel("web auth cancelled")
+        await asyncio.sleep(0)
+        release_save.set()
+        with pytest.raises(asyncio.CancelledError) as raised:
+            await task
+        assert raised.value.args == ("web auth cancelled",)
+        assert isinstance(raised.value.__cause__, RuntimeError)
+        assert str(raised.value.__cause__) == "config save failed"
+
+    _run(exercise())
+
+    assert hook_calls == ["codex"]
+    service._refresh_backend_runtime.assert_awaited_once_with("codex")
 
 
 def test_codex_oauth_success_clears_api_key_state(
@@ -1494,6 +1574,33 @@ def test_persist_auth_cancel_precedes_cleanup_failure_and_skips_config_save(
     save_fields.assert_not_awaited()
 
 
+def test_persist_backend_auth_mode_propagates_config_save_failure(
+    service: AgentAuthService,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from config.v2_config import V2Config
+    from core.services.settings import default_config
+
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    config = default_config()
+    config.agents.codex.auth_mode = "api_key"
+    config.agents.codex.api_key = "sk-stale"
+    config.save()
+    service.controller.config = V2Config.load()
+    service._clear_codex_api_key_for_oauth = AsyncMock()
+
+    def failing_save(*_args, **_kwargs) -> None:
+        raise RuntimeError("config save failed")
+
+    monkeypatch.setattr(V2Config, "save", failing_save)
+
+    with pytest.raises(BackendAuthConfigSaveError, match="config save failed") as raised:
+        _run(service._persist_backend_auth_mode("codex", "oauth"))
+
+    assert isinstance(raised.value.__cause__, RuntimeError)
+
+
 def test_save_backend_auth_fields_owned_cancel_precedes_save_failure(
     service: AgentAuthService,
     monkeypatch: pytest.MonkeyPatch,
@@ -1541,10 +1648,23 @@ def test_save_backend_auth_fields_owned_cancel_precedes_save_failure(
 
 
 def test_remove_web_auth_surfaces_claude_settings_cleanup_failure(
-    service: AgentAuthService, monkeypatch: pytest.MonkeyPatch
+    service: AgentAuthService,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
 ) -> None:
+    from config.v2_config import V2Config
+    from core.services.settings import default_config
+
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    config = default_config()
+    config.agents.claude.auth_mode = "api_key"
+    config.agents.claude.api_key = "sk-stale"
+    config.save()
+    service.controller.config = V2Config.load()
     run_cmd = AsyncMock(return_value=(True, None))
     monkeypatch.setattr(service, "_run_utility_command", run_cmd)
+    hook_calls: list[str] = []
+    service._post_web_success_hook = hook_calls.append
 
     def fail_cleanup(**_kwargs):
         raise OSError("settings locked")
@@ -1557,6 +1677,12 @@ def test_remove_web_auth_surfaces_claude_settings_cleanup_failure(
     assert result["partial"] is True
     assert result["warning"] == "settings_cleanup_failed"
     assert "Failed to clear Claude Code settings env" in result["detail"]
+    assert V2Config.load().agents.claude.auth_mode == "api_key"
+    assert V2Config.load().agents.claude.api_key == "sk-stale"
+    assert service.controller.config.agents.claude.auth_mode == "api_key"
+    assert service.controller.config.agents.claude.api_key == "sk-stale"
+    assert hook_calls == []
+    run_cmd.assert_not_awaited()
 
 
 def test_persist_backend_auth_mode_fresh_loads_config_and_saves_off_loop(

--- a/ui/src/components/settings/providers/OpencodeProviderConfig.partial.test.tsx
+++ b/ui/src/components/settings/providers/OpencodeProviderConfig.partial.test.tsx
@@ -8,6 +8,8 @@ import type { OpencodeProvider } from '@/context/ApiContext';
 import { OpencodeProviderConfig } from './OpencodeProviderConfig';
 
 const api = vi.hoisted(() => ({
+  deleteOpencodeCustomProvider: vi.fn(),
+  deleteOpencodeProviderAuth: vi.fn(),
   getOpencodeProviders: vi.fn(),
   saveOpencodeCustomProvider: vi.fn(),
   setOpencodeProviderAuth: vi.fn(),
@@ -65,6 +67,8 @@ const provider = (overrides: Partial<OpencodeProvider> = {}): OpencodeProvider =
 });
 
 beforeEach(() => {
+  api.deleteOpencodeCustomProvider.mockReset();
+  api.deleteOpencodeProviderAuth.mockReset();
   api.getOpencodeProviders.mockReset();
   api.saveOpencodeCustomProvider.mockReset();
   api.setOpencodeProviderAuth.mockReset();
@@ -73,6 +77,7 @@ beforeEach(() => {
 
 afterEach(() => {
   cleanup();
+  vi.restoreAllMocks();
 });
 
 describe('OpencodeProviderConfig partial save settlement', () => {
@@ -241,6 +246,65 @@ describe('OpencodeProviderConfig partial save settlement', () => {
     await waitFor(() => expect(api.getOpencodeProviders).toHaveBeenCalledTimes(2));
     expect(screen.queryByDisplayValue('sk-top-secret')).toBeNull();
     expect(screen.queryByLabelText('settings.backends.opencodeProviderApiKey')).toBeNull();
+    expect(modelOptionsChanged).toHaveBeenCalledOnce();
+    expect(showToast).toHaveBeenCalledWith('transport interrupted', 'warning');
+    window.removeEventListener('avibe:opencode-model-options-changed', modelOptionsChanged);
+  });
+
+  it('reconciles an uncertain custom-provider delete when the request rejects', async () => {
+    const custom = provider({
+      id: 'my-relay',
+      name: 'My Relay',
+      configured: true,
+      custom: true,
+    });
+    api.getOpencodeProviders
+      .mockResolvedValueOnce({ ok: true, providers: [custom] })
+      .mockResolvedValue({ ok: true, providers: [] });
+    api.deleteOpencodeCustomProvider.mockRejectedValue(new Error('transport interrupted'));
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
+    const modelOptionsChanged = vi.fn();
+    window.addEventListener('avibe:opencode-model-options-changed', modelOptionsChanged);
+    const user = userEvent.setup();
+
+    render(<OpencodeProviderConfig hideEnableToggle />);
+    await user.click(await screen.findByRole('button', { name: /My Relay/ }));
+    await user.click(
+      screen.getByRole('button', { name: 'settings.backends.opencodeCustomProviderRemove' }),
+    );
+
+    await waitFor(() => expect(api.deleteOpencodeCustomProvider).toHaveBeenCalledOnce());
+    await waitFor(() => expect(api.getOpencodeProviders).toHaveBeenCalledTimes(2));
+    expect(screen.queryByText('My Relay')).toBeNull();
+    expect(modelOptionsChanged).toHaveBeenCalledOnce();
+    expect(showToast).toHaveBeenCalledWith('transport interrupted', 'warning');
+    window.removeEventListener('avibe:opencode-model-options-changed', modelOptionsChanged);
+  });
+
+  it('reconciles an uncertain provider-auth delete when the request rejects', async () => {
+    const configured = provider({
+      configured: true,
+      has_auth: true,
+      api_key_masked: 'sk-•••old',
+    });
+    api.getOpencodeProviders
+      .mockResolvedValueOnce({ ok: true, providers: [configured] })
+      .mockResolvedValue({ ok: true, providers: [] });
+    api.deleteOpencodeProviderAuth.mockRejectedValue(new Error('transport interrupted'));
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
+    const modelOptionsChanged = vi.fn();
+    window.addEventListener('avibe:opencode-model-options-changed', modelOptionsChanged);
+    const user = userEvent.setup();
+
+    render(<OpencodeProviderConfig hideEnableToggle />);
+    await user.click(await screen.findByRole('button', { name: /DeepSeek/ }));
+    await user.click(
+      screen.getByRole('button', { name: 'settings.backends.opencodeProviderRemove' }),
+    );
+
+    await waitFor(() => expect(api.deleteOpencodeProviderAuth).toHaveBeenCalledOnce());
+    await waitFor(() => expect(api.getOpencodeProviders).toHaveBeenCalledTimes(2));
+    expect(screen.queryByText('DeepSeek')).toBeNull();
     expect(modelOptionsChanged).toHaveBeenCalledOnce();
     expect(showToast).toHaveBeenCalledWith('transport interrupted', 'warning');
     window.removeEventListener('avibe:opencode-model-options-changed', modelOptionsChanged);

--- a/ui/src/components/settings/providers/OpencodeProviderConfig.partial.test.tsx
+++ b/ui/src/components/settings/providers/OpencodeProviderConfig.partial.test.tsx
@@ -1,0 +1,172 @@
+/* @vitest-environment jsdom */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import type { OpencodeProvider } from '@/context/ApiContext';
+import { OpencodeProviderConfig } from './OpencodeProviderConfig';
+
+const api = vi.hoisted(() => ({
+  getOpencodeProviders: vi.fn(),
+  saveOpencodeCustomProvider: vi.fn(),
+  setOpencodeProviderAuth: vi.fn(),
+}));
+const showToast = vi.hoisted(() => vi.fn());
+
+vi.mock('@/context/ApiContext', async (loadOriginal) => {
+  const original = await loadOriginal<typeof import('@/context/ApiContext')>();
+  return { ...original, useApi: () => api };
+});
+
+vi.mock('@/context/ToastContext', () => ({
+  useToast: () => ({ showToast }),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+vi.mock('../shared/useBackendRuntime', () => ({
+  useBackendRuntime: () => ({
+    loaded: true,
+    enabled: true,
+    cliStatus: 'ok',
+    configError: null,
+  }),
+}));
+
+vi.mock('../shared/useOpencodePermission', () => ({
+  useOpencodePermission: () => ({
+    permissionAllowed: true,
+    state: 'idle',
+    message: null,
+    setupPermission: vi.fn(),
+    setPermissionAllowed: vi.fn(),
+  }),
+}));
+
+vi.mock('../models/useModelHubCapability', () => ({ useModelHubCapability: () => false }));
+vi.mock('../shared/BackendRuntimeCard', () => ({ BackendRuntimeCard: () => null }));
+vi.mock('../shared/OpencodePermissionSetup', () => ({ OpencodePermissionSetup: () => null }));
+vi.mock('../BackendOAuthPanel', () => ({ BackendOAuthPanel: () => null }));
+vi.mock('../OpencodeProviderTestPanel', () => ({ OpencodeProviderTestPanel: () => null }));
+
+const provider = (overrides: Partial<OpencodeProvider> = {}): OpencodeProvider => ({
+  id: 'deepseek',
+  name: 'DeepSeek',
+  description: 'DeepSeek provider',
+  configured: false,
+  oauth_available: false,
+  local: false,
+  models: [],
+  default_model: null,
+  ...overrides,
+});
+
+beforeEach(() => {
+  api.getOpencodeProviders.mockReset();
+  api.saveOpencodeCustomProvider.mockReset();
+  api.setOpencodeProviderAuth.mockReset();
+  showToast.mockReset();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('OpencodeProviderConfig partial save settlement', () => {
+  it('moves a committed custom provider into the catalog and clears its secret', async () => {
+    const committed = provider({
+      id: 'my-relay',
+      name: 'My Relay',
+      configured: true,
+      custom: true,
+      has_auth: true,
+      api_key_masked: 'sk-•••elay',
+      base_url: 'https://relay.example/v1',
+    });
+    api.getOpencodeProviders
+      .mockResolvedValueOnce({ ok: true, providers: [] })
+      .mockResolvedValue({ ok: true, providers: [committed] });
+    api.saveOpencodeCustomProvider.mockResolvedValue({
+      ok: false,
+      partial: true,
+      saved: true,
+      mutation_attempted: true,
+      provider_id: 'my-relay',
+      message: 'provider saved, key cleanup failed',
+    });
+    const modelOptionsChanged = vi.fn();
+    window.addEventListener('avibe:opencode-model-options-changed', modelOptionsChanged);
+    const user = userEvent.setup();
+
+    render(<OpencodeProviderConfig hideEnableToggle />);
+    await screen.findByText('settings.backends.opencodeProvidersEmpty');
+    await user.click(screen.getByRole('button', { name: 'settings.backends.opencodeCustomProviderAdd' }));
+    await user.type(
+      screen.getByPlaceholderText('settings.backends.opencodeCustomProviderNamePlaceholder'),
+      'My Relay',
+    );
+    await user.type(
+      screen.getByPlaceholderText('settings.backends.opencodeProviderBaseUrlPlaceholder'),
+      'https://relay.example/v1',
+    );
+    await user.type(
+      screen.getByPlaceholderText('settings.backends.opencodeProviderApiKeyPlaceholder'),
+      'sk-top-secret',
+    );
+    await user.click(screen.getByRole('button', { name: 'settings.backends.opencodeCustomProviderSave' }));
+
+    await waitFor(() => expect(api.saveOpencodeCustomProvider).toHaveBeenCalledOnce());
+    await screen.findByText('sk-•••elay');
+    expect(screen.queryByDisplayValue('sk-top-secret')).toBeNull();
+    expect(screen.getByRole('button', { name: 'settings.backends.opencodeProviderCollapse' })).toBeTruthy();
+    expect(api.getOpencodeProviders).toHaveBeenCalledTimes(2);
+    expect(modelOptionsChanged).toHaveBeenCalledOnce();
+    expect(showToast).toHaveBeenCalledWith('provider saved, key cleanup failed', 'warning');
+    window.removeEventListener('avibe:opencode-model-options-changed', modelOptionsChanged);
+  });
+
+  it('clears and collapses a direct auth secret after a partial save', async () => {
+    const initial = provider({
+      configured: true,
+      has_auth: true,
+      api_key_masked: 'sk-•••old',
+    });
+    const committed = provider({
+      configured: true,
+      has_auth: true,
+      api_key_masked: 'sk-•••cret',
+    });
+    api.getOpencodeProviders
+      .mockResolvedValueOnce({ ok: true, providers: [initial] })
+      .mockResolvedValue({ ok: true, providers: [committed] });
+    api.setOpencodeProviderAuth.mockResolvedValue({
+      ok: false,
+      partial: true,
+      saved: true,
+      mutation_attempted: true,
+      provider_id: 'deepseek',
+      message: 'saved, cleanup failed',
+    });
+    const modelOptionsChanged = vi.fn();
+    window.addEventListener('avibe:opencode-model-options-changed', modelOptionsChanged);
+    const user = userEvent.setup();
+
+    render(<OpencodeProviderConfig hideEnableToggle />);
+    await user.click(await screen.findByRole('button', { name: /DeepSeek/ }));
+    await user.click(screen.getByRole('button', { name: 'settings.backends.replaceApiKey' }));
+    const secret = screen.getByLabelText('settings.backends.opencodeProviderApiKey');
+    await user.type(secret, 'sk-top-secret');
+    await user.click(screen.getByRole('button', { name: 'settings.backends.opencodeProviderSave' }));
+
+    await waitFor(() => expect(api.setOpencodeProviderAuth).toHaveBeenCalledOnce());
+    await screen.findByText('sk-•••cret');
+    expect(screen.queryByDisplayValue('sk-top-secret')).toBeNull();
+    expect(screen.queryByLabelText('settings.backends.opencodeProviderApiKey')).toBeNull();
+    expect(api.getOpencodeProviders).toHaveBeenCalledTimes(2);
+    expect(modelOptionsChanged).toHaveBeenCalledOnce();
+    window.removeEventListener('avibe:opencode-model-options-changed', modelOptionsChanged);
+  });
+});

--- a/ui/src/components/settings/providers/OpencodeProviderConfig.partial.test.tsx
+++ b/ui/src/components/settings/providers/OpencodeProviderConfig.partial.test.tsx
@@ -148,7 +148,7 @@ describe('OpencodeProviderConfig partial save settlement', () => {
       saved: true,
       mutation_attempted: true,
       provider_id: 'deepseek',
-      message: 'saved, cleanup failed',
+      error_code: 'opencode_stale_auth_cleanup_failed',
     });
     const modelOptionsChanged = vi.fn();
     window.addEventListener('avibe:opencode-model-options-changed', modelOptionsChanged);
@@ -167,6 +167,82 @@ describe('OpencodeProviderConfig partial save settlement', () => {
     expect(screen.queryByLabelText('settings.backends.opencodeProviderApiKey')).toBeNull();
     expect(api.getOpencodeProviders).toHaveBeenCalledTimes(2);
     expect(modelOptionsChanged).toHaveBeenCalledOnce();
+    expect(showToast).toHaveBeenCalledWith(
+      'settings.backends.opencodeProviderAuthCleanupFailed',
+      'warning',
+    );
+    window.removeEventListener('avibe:opencode-model-options-changed', modelOptionsChanged);
+  });
+
+  it('clears and reconciles a custom secret when the submitted request rejects', async () => {
+    const maybeCommitted = provider({
+      id: 'my-relay',
+      name: 'My Relay',
+      configured: true,
+      custom: true,
+      has_auth: true,
+      api_key_masked: 'sk-•••elay',
+    });
+    api.getOpencodeProviders
+      .mockResolvedValueOnce({ ok: true, providers: [] })
+      .mockResolvedValue({ ok: true, providers: [maybeCommitted] });
+    api.saveOpencodeCustomProvider.mockRejectedValue(new Error('transport interrupted'));
+    const modelOptionsChanged = vi.fn();
+    window.addEventListener('avibe:opencode-model-options-changed', modelOptionsChanged);
+    const user = userEvent.setup();
+
+    render(<OpencodeProviderConfig hideEnableToggle />);
+    await screen.findByText('settings.backends.opencodeProvidersEmpty');
+    await user.click(screen.getByRole('button', { name: 'settings.backends.opencodeCustomProviderAdd' }));
+    await user.type(
+      screen.getByPlaceholderText('settings.backends.opencodeCustomProviderNamePlaceholder'),
+      'My Relay',
+    );
+    await user.type(
+      screen.getByPlaceholderText('settings.backends.opencodeProviderBaseUrlPlaceholder'),
+      'https://relay.example/v1',
+    );
+    await user.type(
+      screen.getByPlaceholderText('settings.backends.opencodeProviderApiKeyPlaceholder'),
+      'sk-top-secret',
+    );
+    await user.click(screen.getByRole('button', { name: 'settings.backends.opencodeCustomProviderSave' }));
+
+    await waitFor(() => expect(api.saveOpencodeCustomProvider).toHaveBeenCalledOnce());
+    await waitFor(() => expect(api.getOpencodeProviders).toHaveBeenCalledTimes(2));
+    expect(screen.queryByDisplayValue('sk-top-secret')).toBeNull();
+    expect(modelOptionsChanged).toHaveBeenCalledOnce();
+    expect(showToast).toHaveBeenCalledWith('transport interrupted', 'warning');
+    window.removeEventListener('avibe:opencode-model-options-changed', modelOptionsChanged);
+  });
+
+  it('clears and reconciles a replaced secret when the submitted auth request rejects', async () => {
+    const configured = provider({
+      configured: true,
+      has_auth: true,
+      api_key_masked: 'sk-•••old',
+    });
+    api.getOpencodeProviders.mockResolvedValue({ ok: true, providers: [configured] });
+    api.setOpencodeProviderAuth.mockRejectedValue(new Error('transport interrupted'));
+    const modelOptionsChanged = vi.fn();
+    window.addEventListener('avibe:opencode-model-options-changed', modelOptionsChanged);
+    const user = userEvent.setup();
+
+    render(<OpencodeProviderConfig hideEnableToggle />);
+    await user.click(await screen.findByRole('button', { name: /DeepSeek/ }));
+    await user.click(screen.getByRole('button', { name: 'settings.backends.replaceApiKey' }));
+    await user.type(
+      screen.getByLabelText('settings.backends.opencodeProviderApiKey'),
+      'sk-top-secret',
+    );
+    await user.click(screen.getByRole('button', { name: 'settings.backends.opencodeProviderSave' }));
+
+    await waitFor(() => expect(api.setOpencodeProviderAuth).toHaveBeenCalledOnce());
+    await waitFor(() => expect(api.getOpencodeProviders).toHaveBeenCalledTimes(2));
+    expect(screen.queryByDisplayValue('sk-top-secret')).toBeNull();
+    expect(screen.queryByLabelText('settings.backends.opencodeProviderApiKey')).toBeNull();
+    expect(modelOptionsChanged).toHaveBeenCalledOnce();
+    expect(showToast).toHaveBeenCalledWith('transport interrupted', 'warning');
     window.removeEventListener('avibe:opencode-model-options-changed', modelOptionsChanged);
   });
 });

--- a/ui/src/components/settings/providers/OpencodeProviderConfig.tsx
+++ b/ui/src/components/settings/providers/OpencodeProviderConfig.tsx
@@ -527,10 +527,23 @@ export const OpencodeProviderConfig: React.FC<{
       if (expandedId === provider.id) setExpandedId(null);
       await loadProviders();
     } catch (e) {
+      const message = errorMessage(e) || (t('settings.backends.opencodeCustomProviderRemoveFailed') as string);
       updateEdit(provider.id, {
         deletingProvider: false,
-        error: errorMessage(e) || (t('settings.backends.opencodeCustomProviderRemoveFailed') as string),
+        error: message,
       });
+      await settlePartialMutation(
+        {
+          ok: false,
+          partial: true,
+          mutation_attempted: true,
+          removed: null,
+          provider_id: provider.id,
+        },
+        provider.id,
+        message,
+        true,
+      );
     }
   };
 
@@ -631,10 +644,23 @@ export const OpencodeProviderConfig: React.FC<{
       notifyOpenCodeModelOptionsChanged();
       await loadProviders();
     } catch (e) {
+      const message = errorMessage(e) || (t('settings.backends.opencodeProviderRemoveFailed') as string);
       updateEdit(provider.id, {
         removing: false,
-        error: errorMessage(e) || (t('settings.backends.opencodeProviderRemoveFailed') as string),
+        error: message,
       });
+      await settlePartialMutation(
+        {
+          ok: false,
+          partial: true,
+          mutation_attempted: true,
+          removed: null,
+          provider_id: provider.id,
+        },
+        provider.id,
+        message,
+        true,
+      );
     }
   };
 

--- a/ui/src/components/settings/providers/OpencodeProviderConfig.tsx
+++ b/ui/src/components/settings/providers/OpencodeProviderConfig.tsx
@@ -435,10 +435,34 @@ export const OpencodeProviderConfig: React.FC<{
         ...(apiKey ? { api_key: apiKey } : {}),
       });
       if (!result.ok) {
-        updateCustomProviderDraft({
-          saving: false,
-          error: result.message || (t('settings.backends.opencodeCustomProviderSaveFailed') as string),
-        });
+        const message = result.message || (t('settings.backends.opencodeCustomProviderSaveFailed') as string);
+        if (result.partial) {
+          if (result.saved === true) {
+            const nextId = result.provider_id || providerId;
+            setCustomProviderDraft(emptyCustomProviderDraft());
+            setShowCustomProviderForm(false);
+            setExpandedId(nextId);
+            setEditByProvider((prev) => ({
+              ...prev,
+              [nextId]: {
+                ...(prev[nextId] || emptyEdit()),
+                apiKey: '',
+                editingKey: false,
+                baseUrl,
+                error: message,
+              },
+            }));
+          } else {
+            updateCustomProviderDraft({
+              saving: false,
+              apiKey: '',
+              error: message,
+            });
+          }
+          await settlePartialMutation(result, result.provider_id || providerId, message, false);
+          return;
+        }
+        updateCustomProviderDraft({ saving: false, error: message });
         return;
       }
       setCustomProviderDraft(emptyCustomProviderDraft());
@@ -528,6 +552,7 @@ export const OpencodeProviderConfig: React.FC<{
         const message = result.message || (t('settings.backends.opencodeProviderSaveFailed') as string);
         updateEdit(provider.id, {
           saving: false,
+          ...(result.partial ? { apiKey: '', editingKey: false } : {}),
           error: message,
         });
         await settlePartialMutation(result, provider.id, message, false);

--- a/ui/src/components/settings/providers/OpencodeProviderConfig.tsx
+++ b/ui/src/components/settings/providers/OpencodeProviderConfig.tsx
@@ -450,10 +450,17 @@ export const OpencodeProviderConfig: React.FC<{
     try {
       const result = await api.deleteOpencodeCustomProvider(provider.id);
       if (!result.ok) {
+        const message = result.message || (t('settings.backends.opencodeCustomProviderRemoveFailed') as string);
         updateEdit(provider.id, {
           deletingProvider: false,
-          error: result.message || (t('settings.backends.opencodeCustomProviderRemoveFailed') as string),
+          error: message,
         });
+        if (result.partial) {
+          showToast(message, 'warning');
+          notifyOpenCodeModelOptionsChanged();
+          if (expandedId === provider.id) setExpandedId(null);
+          await loadProviders();
+        }
         return;
       }
       updateEdit(provider.id, { deletingProvider: false, error: null });
@@ -541,10 +548,17 @@ export const OpencodeProviderConfig: React.FC<{
     try {
       const result = await api.deleteOpencodeProviderAuth(provider.id);
       if (!result.ok) {
+        const message = result.message || (t('settings.backends.opencodeProviderRemoveFailed') as string);
         updateEdit(provider.id, {
           removing: false,
-          error: result.message || (t('settings.backends.opencodeProviderRemoveFailed') as string),
+          error: message,
         });
+        if (result.partial) {
+          showToast(message, 'warning');
+          notifyOpenCodeModelOptionsChanged();
+          if (expandedId === provider.id) setExpandedId(null);
+          await loadProviders();
+        }
         return;
       }
       updateEdit(provider.id, { removing: false, error: null });

--- a/ui/src/components/settings/providers/OpencodeProviderConfig.tsx
+++ b/ui/src/components/settings/providers/OpencodeProviderConfig.tsx
@@ -291,6 +291,16 @@ export const OpencodeProviderConfig: React.FC<{
     [expandedId, loadProviders, showToast],
   );
 
+  const saveErrorMessage = useCallback(
+    (result: OpencodeMutationResult, fallbackKey: string): string => {
+      if (result.error_code === 'opencode_stale_auth_cleanup_failed') {
+        return t('settings.backends.opencodeProviderAuthCleanupFailed') as string;
+      }
+      return result.message || (t(fallbackKey) as string);
+    },
+    [t],
+  );
+
   useEffect(() => {
     loadProvidersRef.current = loadProviders;
   }, [loadProviders]);
@@ -435,7 +445,7 @@ export const OpencodeProviderConfig: React.FC<{
         ...(apiKey ? { api_key: apiKey } : {}),
       });
       if (!result.ok) {
-        const message = result.message || (t('settings.backends.opencodeCustomProviderSaveFailed') as string);
+        const message = saveErrorMessage(result, 'settings.backends.opencodeCustomProviderSaveFailed');
         if (result.partial) {
           if (result.saved === true) {
             const nextId = result.provider_id || providerId;
@@ -479,10 +489,18 @@ export const OpencodeProviderConfig: React.FC<{
         [nextId]: { ...(prev[nextId] || emptyEdit()), baseUrl },
       }));
     } catch (e) {
+      const message = errorMessage(e) || (t('settings.backends.opencodeCustomProviderSaveFailed') as string);
       updateCustomProviderDraft({
         saving: false,
-        error: errorMessage(e) || (t('settings.backends.opencodeCustomProviderSaveFailed') as string),
+        apiKey: '',
+        error: message,
       });
+      await settlePartialMutation(
+        { ok: false, partial: true },
+        providerId,
+        message,
+        false,
+      );
     }
   };
 
@@ -549,7 +567,7 @@ export const OpencodeProviderConfig: React.FC<{
     try {
       const result = await api.setOpencodeProviderAuth(provider.id, key, baseUrl);
       if (!result.ok) {
-        const message = result.message || (t('settings.backends.opencodeProviderSaveFailed') as string);
+        const message = saveErrorMessage(result, 'settings.backends.opencodeProviderSaveFailed');
         updateEdit(provider.id, {
           saving: false,
           ...(result.partial ? { apiKey: '', editingKey: false } : {}),
@@ -570,10 +588,19 @@ export const OpencodeProviderConfig: React.FC<{
         await loadProviders();
       }
     } catch (e) {
+      const message = errorMessage(e) || (t('settings.backends.opencodeProviderSaveFailed') as string);
       updateEdit(provider.id, {
         saving: false,
-        error: errorMessage(e) || (t('settings.backends.opencodeProviderSaveFailed') as string),
+        apiKey: '',
+        editingKey: false,
+        error: message,
       });
+      await settlePartialMutation(
+        { ok: false, partial: true },
+        provider.id,
+        message,
+        false,
+      );
     }
   };
 

--- a/ui/src/components/settings/providers/OpencodeProviderConfig.tsx
+++ b/ui/src/components/settings/providers/OpencodeProviderConfig.tsx
@@ -45,6 +45,7 @@ import type {
 } from '@/context/ApiContext';
 import { useToast } from '@/context/ToastContext';
 import { errorMessage } from '@/lib/errorMessage';
+import { reconcileOpencodePartialMutation } from './opencodePartialMutation';
 
 type FilterMode = 'all' | 'configured' | 'oauth' | 'local';
 type CustomProviderAdapter = 'openai-compatible' | 'anthropic-compatible';
@@ -270,6 +271,26 @@ export const OpencodeProviderConfig: React.FC<{
     [applyProvidersResult, showToast, t],
   );
 
+  const settlePartialMutation = useCallback(
+    async (
+      result: OpencodeMutationResult,
+      providerId: string,
+      message: string,
+      clearExpanded: boolean,
+    ): Promise<boolean> =>
+      reconcileOpencodePartialMutation(result, {
+        message,
+        warn: (warning) => showToast(warning, 'warning'),
+        notify: notifyOpenCodeModelOptionsChanged,
+        reload: loadProviders,
+        clearExpanded:
+          clearExpanded && expandedId === providerId
+            ? () => setExpandedId(null)
+            : undefined,
+      }),
+    [expandedId, loadProviders, showToast],
+  );
+
   useEffect(() => {
     loadProvidersRef.current = loadProviders;
   }, [loadProviders]);
@@ -455,12 +476,7 @@ export const OpencodeProviderConfig: React.FC<{
           deletingProvider: false,
           error: message,
         });
-        if (result.partial) {
-          showToast(message, 'warning');
-          notifyOpenCodeModelOptionsChanged();
-          if (expandedId === provider.id) setExpandedId(null);
-          await loadProviders();
-        }
+        await settlePartialMutation(result, provider.id, message, true);
         return;
       }
       updateEdit(provider.id, { deletingProvider: false, error: null });
@@ -509,10 +525,12 @@ export const OpencodeProviderConfig: React.FC<{
     try {
       const result = await api.setOpencodeProviderAuth(provider.id, key, baseUrl);
       if (!result.ok) {
+        const message = result.message || (t('settings.backends.opencodeProviderSaveFailed') as string);
         updateEdit(provider.id, {
           saving: false,
-          error: result.message || (t('settings.backends.opencodeProviderSaveFailed') as string),
+          error: message,
         });
+        await settlePartialMutation(result, provider.id, message, false);
         return;
       }
       updateEdit(provider.id, {
@@ -553,12 +571,7 @@ export const OpencodeProviderConfig: React.FC<{
           removing: false,
           error: message,
         });
-        if (result.partial) {
-          showToast(message, 'warning');
-          notifyOpenCodeModelOptionsChanged();
-          if (expandedId === provider.id) setExpandedId(null);
-          await loadProviders();
-        }
+        await settlePartialMutation(result, provider.id, message, true);
         return;
       }
       updateEdit(provider.id, { removing: false, error: null });

--- a/ui/src/components/settings/providers/opencodePartialMutation.test.ts
+++ b/ui/src/components/settings/providers/opencodePartialMutation.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { reconcileOpencodePartialMutation } from './opencodePartialMutation';
+
+describe('reconcileOpencodePartialMutation', () => {
+  it('reconciles a partial provider-auth save without clearing the editor', async () => {
+    const warn = vi.fn();
+    const notify = vi.fn();
+    const reload = vi.fn(async () => undefined);
+
+    const reconciled = await reconcileOpencodePartialMutation(
+      { ok: false, partial: true, saved: true },
+      { message: 'saved partially', warn, notify, reload },
+    );
+
+    expect(reconciled).toBe(true);
+    expect(warn).toHaveBeenCalledWith('saved partially');
+    expect(notify).toHaveBeenCalledOnce();
+    expect(reload).toHaveBeenCalledOnce();
+  });
+
+  it('reconciles a partial delete and clears its expanded row', async () => {
+    const warn = vi.fn();
+    const notify = vi.fn();
+    const reload = vi.fn(async () => undefined);
+    const clearExpanded = vi.fn();
+
+    const reconciled = await reconcileOpencodePartialMutation(
+      { ok: false, partial: true, removed: null },
+      { message: 'delete outcome uncertain', warn, notify, reload, clearExpanded },
+    );
+
+    expect(reconciled).toBe(true);
+    expect(warn).toHaveBeenCalledWith('delete outcome uncertain');
+    expect(notify).toHaveBeenCalledOnce();
+    expect(reload).toHaveBeenCalledOnce();
+    expect(clearExpanded).toHaveBeenCalledOnce();
+  });
+
+  it('leaves an ordinary failure untouched', async () => {
+    const reload = vi.fn(async () => undefined);
+
+    const reconciled = await reconcileOpencodePartialMutation(
+      { ok: false },
+      { message: 'failed', warn: vi.fn(), notify: vi.fn(), reload },
+    );
+
+    expect(reconciled).toBe(false);
+    expect(reload).not.toHaveBeenCalled();
+  });
+});

--- a/ui/src/components/settings/providers/opencodePartialMutation.ts
+++ b/ui/src/components/settings/providers/opencodePartialMutation.ts
@@ -1,0 +1,25 @@
+type PartialMutationResult = {
+  ok: boolean;
+  partial?: boolean;
+};
+
+type PartialMutationSettlement = {
+  message: string;
+  warn: (message: string) => void;
+  notify: () => void;
+  reload: () => Promise<void>;
+  clearExpanded?: () => void;
+};
+
+export const reconcileOpencodePartialMutation = async (
+  result: PartialMutationResult,
+  settlement: PartialMutationSettlement,
+): Promise<boolean> => {
+  if (result.ok || !result.partial) return false;
+
+  settlement.warn(settlement.message);
+  settlement.notify();
+  settlement.clearExpanded?.();
+  await settlement.reload();
+  return true;
+};

--- a/ui/src/context/ApiContext.tsx
+++ b/ui/src/context/ApiContext.tsx
@@ -2271,7 +2271,8 @@ export type OpencodeProviderListResult = {
 export type OpencodeMutationResult = {
   ok: boolean;
   partial?: boolean;
-  removed?: boolean;
+  removed?: boolean | null;
+  mutation_attempted?: boolean;
   message?: string;
   default_provider?: string;
   provider_id?: string;

--- a/ui/src/context/ApiContext.tsx
+++ b/ui/src/context/ApiContext.tsx
@@ -2274,6 +2274,7 @@ export type OpencodeMutationResult = {
   removed?: boolean | null;
   saved?: boolean | null;
   mutation_attempted?: boolean;
+  error_code?: string;
   message?: string;
   default_provider?: string;
   provider_id?: string;

--- a/ui/src/context/ApiContext.tsx
+++ b/ui/src/context/ApiContext.tsx
@@ -2272,6 +2272,7 @@ export type OpencodeMutationResult = {
   ok: boolean;
   partial?: boolean;
   removed?: boolean | null;
+  saved?: boolean;
   mutation_attempted?: boolean;
   message?: string;
   default_provider?: string;

--- a/ui/src/context/ApiContext.tsx
+++ b/ui/src/context/ApiContext.tsx
@@ -2270,6 +2270,8 @@ export type OpencodeProviderListResult = {
 
 export type OpencodeMutationResult = {
   ok: boolean;
+  partial?: boolean;
+  removed?: boolean;
   message?: string;
   default_provider?: string;
   provider_id?: string;
@@ -2278,6 +2280,11 @@ export type OpencodeMutationResult = {
     ok: boolean;
     message?: string;
     catalog?: OpencodeProviderListResult | null;
+  };
+  restart?: {
+    ok: boolean;
+    message?: string;
+    runtime_refresh?: { ok: boolean; message?: string };
   };
 };
 

--- a/ui/src/context/ApiContext.tsx
+++ b/ui/src/context/ApiContext.tsx
@@ -2272,7 +2272,7 @@ export type OpencodeMutationResult = {
   ok: boolean;
   partial?: boolean;
   removed?: boolean | null;
-  saved?: boolean;
+  saved?: boolean | null;
   mutation_attempted?: boolean;
   message?: string;
   default_provider?: string;

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -575,6 +575,7 @@
       "opencodeProviderSaved": "Provider credentials saved.",
       "opencodeProviderCatalogRefreshPending": "Provider saved. Refreshing the model list…",
       "opencodeProviderSaveFailed": "Could not save provider credentials.",
+      "opencodeProviderAuthCleanupFailed": "The API key was saved, but stale OpenCode credentials could not be cleared.",
       "opencodeProviderRemove": "Remove key",
       "opencodeProviderRemoveOauth": "Sign out",
       "opencodeProviderRemoveConfirm": "Remove the saved key for {{name}}?",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -575,6 +575,7 @@
       "opencodeProviderSaved": "服务商凭据已保存。",
       "opencodeProviderCatalogRefreshPending": "服务商已保存，正在刷新模型列表…",
       "opencodeProviderSaveFailed": "保存服务商凭据失败。",
+      "opencodeProviderAuthCleanupFailed": "API 密钥已保存，但无法清理旧的 OpenCode 凭据。",
       "opencodeProviderRemove": "移除 Key",
       "opencodeProviderRemoveOauth": "退出登录",
       "opencodeProviderRemoveConfirm": "确定要删除 {{name}} 的已保存 Key 吗？",

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -10457,10 +10457,11 @@ async def save_opencode_custom_provider_async(payload: dict) -> dict:
             if existing_name and existing_name == normalized_name and existing_id != normalized_id:
                 return {"ok": False, "message": "provider name already exists"}
 
+    settlement = CancellationSettlement()
     try:
         from vibe.opencode_config import upsert_opencode_custom_provider
 
-        await asyncio.to_thread(
+        await settlement.run_blocking(
             upsert_opencode_custom_provider,
             provider_id,
             name,
@@ -10468,14 +10469,19 @@ async def save_opencode_custom_provider_async(payload: dict) -> dict:
             base_url,
             logger_instance=logger,
         )
-    except Exception as exc:
+    except (Exception, asyncio.CancelledError) as exc:
+        if isinstance(exc, asyncio.CancelledError) and not settlement.cancelled:
+            raise
         logger.warning("OpenCode custom provider save failed for %s: %s", provider_id, exc, exc_info=True)
         _OPENCODE_OPTIONS_CACHE.clear()
         try:
-            restart = restart_backend("opencode")
-        except Exception as restart_exc:
+            restart = await settlement.run_blocking(restart_backend, "opencode")
+        except (Exception, asyncio.CancelledError) as restart_exc:
+            if isinstance(restart_exc, asyncio.CancelledError) and not settlement.cancelled:
+                raise
             restart = {"ok": False, "message": str(restart_exc)}
         _OPENCODE_OPTIONS_CACHE.clear()
+        settlement.raise_if_cancelled(exc)
         return {
             "ok": False,
             "partial": True,
@@ -10488,8 +10494,10 @@ async def save_opencode_custom_provider_async(payload: dict) -> dict:
 
     _OPENCODE_OPTIONS_CACHE.clear()
     try:
-        restart = restart_backend("opencode")
-    except Exception as exc:
+        restart = await settlement.run_blocking(restart_backend, "opencode")
+    except (Exception, asyncio.CancelledError) as exc:
+        if isinstance(exc, asyncio.CancelledError) and not settlement.cancelled:
+            raise
         restart = {"ok": False, "message": str(exc)}
     _OPENCODE_OPTIONS_CACHE.clear()
 
@@ -10499,11 +10507,14 @@ async def save_opencode_custom_provider_async(payload: dict) -> dict:
             None,
             _BASE_URL_UNCHANGED,
             config_api_key=api_key,
+            settlement=settlement,
         )
         _OPENCODE_OPTIONS_CACHE.clear()
         try:
-            restart = restart_backend("opencode")
-        except Exception as exc:
+            restart = await settlement.run_blocking(restart_backend, "opencode")
+        except (Exception, asyncio.CancelledError) as exc:
+            if isinstance(exc, asyncio.CancelledError) and not settlement.cancelled:
+                raise
             restart = {"ok": False, "message": str(exc)}
         _OPENCODE_OPTIONS_CACHE.clear()
         if not auth_result.get("ok"):
@@ -10521,12 +10532,16 @@ async def save_opencode_custom_provider_async(payload: dict) -> dict:
                 failure["error_code"] = error_code
             elif isinstance(message, str) and message:
                 failure["message"] = message
+            settlement.raise_if_cancelled()
             return failure
 
-    catalog_refresh = await _refresh_opencode_provider_catalog_async(
-        provider_id.strip().lower(),
-        require_models=False,
+    catalog_refresh = await settlement.wait(
+        _refresh_opencode_provider_catalog_async(
+            provider_id.strip().lower(),
+            require_models=False,
+        )
     )
+    settlement.raise_if_cancelled()
     return {
         "ok": True,
         "provider_id": provider_id.strip().lower(),
@@ -10795,6 +10810,7 @@ async def _save_opencode_provider_auth_async(
     base_url: Any = _BASE_URL_UNCHANGED,
     *,
     config_api_key: str | None = None,
+    settlement: CancellationSettlement | None = None,
 ) -> dict:
     from vibe.opencode_config import (
         remove_opencode_provider_base_url,
@@ -10802,6 +10818,14 @@ async def _save_opencode_provider_auth_async(
         upsert_opencode_provider_api_key,
         upsert_opencode_provider_base_url,
     )
+
+    owns_settlement = settlement is None
+    settlement = settlement or CancellationSettlement()
+
+    def finish(result: dict, cause: BaseException | None = None) -> dict:
+        if owns_settlement:
+            settlement.raise_if_cancelled(cause)
+        return result
 
     # Treat API keys entered through avibe's Settings UI as OpenCode
     # config provider options, not OpenCode daemon auth entries. The
@@ -10816,7 +10840,7 @@ async def _save_opencode_provider_auth_async(
             # The write may commit before raising, so this is possibly
             # irreversible from the moment the operation starts.
             mutation_attempted = True
-            await asyncio.to_thread(
+            await settlement.run_blocking(
                 upsert_opencode_provider_api_key,
                 provider_id,
                 config_key,
@@ -10829,7 +10853,7 @@ async def _save_opencode_provider_auth_async(
                 exc,
                 exc_info=True,
             )
-            return {
+            return finish({
                 "ok": False,
                 "mutation_attempted": mutation_attempted,
                 "saved": None,
@@ -10837,23 +10861,25 @@ async def _save_opencode_provider_auth_async(
                     "Provider credential persistence failed: "
                     f"{exc}"
                 ),
-            }
+            }, exc)
         saved = True
 
         try:
-            auth_entries = await asyncio.to_thread(
+            auth_entries = await settlement.run_blocking(
                 read_opencode_provider_auth_entries,
                 logger_instance=logger,
             )
             if provider_id in auth_entries:
-                auth_cleanup = await _delete_opencode_provider_auth_async(provider_id)
+                auth_cleanup = await settlement.wait(
+                    _delete_opencode_provider_auth_async(provider_id)
+                )
                 if not auth_cleanup.get("ok"):
-                    return {
+                    return finish({
                         "ok": False,
                         "mutation_attempted": mutation_attempted,
                         "saved": saved,
                         "error_code": "opencode_stale_auth_cleanup_failed",
-                    }
+                    })
         except Exception as exc:
             logger.warning(
                 "OpenCode stale auth cleanup failed for %s: %s",
@@ -10861,12 +10887,12 @@ async def _save_opencode_provider_auth_async(
                 exc,
                 exc_info=True,
             )
-            return {
+            return finish({
                 "ok": False,
                 "mutation_attempted": mutation_attempted,
                 "saved": saved,
                 "error_code": "opencode_stale_auth_cleanup_failed",
-            }
+            }, exc)
 
     # ``baseURL`` is different: OpenCode's auth endpoint has no field for
     # it, so this write is the *only* place it gets persisted. A silent
@@ -10874,19 +10900,19 @@ async def _save_opencode_provider_auth_async(
     # exact UX bug Codex flagged. Surface those errors to the caller so
     # the UI can show a useful message.
     if base_url is _BASE_URL_UNCHANGED:
-        return {"ok": True}
+        return finish({"ok": True})
 
     try:
         mutation_attempted = True
         if base_url:
-            await asyncio.to_thread(
+            await settlement.run_blocking(
                 upsert_opencode_provider_base_url,
                 provider_id,
                 base_url,
                 logger_instance=logger,
             )
         else:
-            await asyncio.to_thread(
+            await settlement.run_blocking(
                 remove_opencode_provider_base_url,
                 provider_id,
                 logger_instance=logger,
@@ -10895,7 +10921,7 @@ async def _save_opencode_provider_auth_async(
         logger.warning(
             "OpenCode base_url persist failed for %s: %s", provider_id, exc, exc_info=True
         )
-        return {
+        return finish({
             "ok": False,
             "mutation_attempted": mutation_attempted,
             "saved": saved if saved else None,
@@ -10903,8 +10929,8 @@ async def _save_opencode_provider_auth_async(
                 "API key saved, but base URL persistence failed: "
                 f"{exc}"
             ),
-        }
-    return {"ok": True}
+        }, exc)
+    return finish({"ok": True})
 
 
 def save_opencode_provider_auth(provider_id: str, payload: dict) -> dict:
@@ -11001,14 +11027,19 @@ async def save_opencode_provider_auth_async(provider_id: str, payload: dict) -> 
                     "message": "base_url is required for custom providers",
                 }
 
+    settlement = CancellationSettlement()
     try:
         result = await _save_opencode_provider_auth_async(
             provider_id.strip(),
             None,
             base_url,
             config_api_key=api_key or existing_api_key,
+            settlement=settlement,
         )
-    except Exception as exc:
+    except (Exception, asyncio.CancelledError) as exc:
+        settlement.raise_if_cancelled(exc)
+        if isinstance(exc, asyncio.CancelledError):
+            raise
         logger.warning("OpenCode set-auth failed for %s: %s", provider_id, exc, exc_info=True)
         return {"ok": False, "message": str(exc)}
 
@@ -11032,12 +11063,20 @@ async def save_opencode_provider_auth_async(provider_id: str, payload: dict) -> 
     # separate ``restart`` key so the UI can show "saved, but daemon
     # refresh failed" when applicable.
     try:
-        result["restart"] = restart_backend("opencode")
-    except Exception as exc:
+        result["restart"] = await settlement.run_blocking(
+            restart_backend,
+            "opencode",
+        )
+    except (Exception, asyncio.CancelledError) as exc:
+        if isinstance(exc, asyncio.CancelledError) and not settlement.cancelled:
+            raise
         logger.warning("OpenCode auto-restart after save failed for %s: %s", provider_id, exc)
         result["restart"] = {"ok": False, "message": str(exc)}
     if result.get("ok"):
-        result["catalog_refresh"] = await _refresh_opencode_provider_catalog_async(provider_id.strip())
+        result["catalog_refresh"] = await settlement.wait(
+            _refresh_opencode_provider_catalog_async(provider_id.strip())
+        )
+    settlement.raise_if_cancelled()
     return result
 
 

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -42,6 +42,7 @@ from config.v2_settings import (
 )
 from config.v2_sessions import SessionsStore
 from config.platform_registry import get_platform_descriptor
+from core.memory.blocking import run_blocking
 from vibe.opencode_config import (
     get_opencode_config_paths,
     load_first_opencode_user_config,
@@ -8974,34 +8975,49 @@ def remove_backend_api_key(backend: str) -> dict:
         return {"ok": False, "error": "unsupported_backend"}
 
     notices: list = []
-    if backend == "codex":
-        from vibe.codex_config import apply_codex_auth
+    with config_write_transaction():
+        if backend == "codex":
+            from vibe.codex_config import apply_codex_auth
 
+            try:
+                result = apply_codex_auth(
+                    auth_mode="oauth",
+                    api_key=None,
+                    base_url=None,
+                )
+                if isinstance(result, dict):
+                    raw_notices = result.get("notices")
+                    if isinstance(raw_notices, list):
+                        notices = raw_notices
+            except Exception as exc:  # noqa: BLE001
+                logger.error(
+                    "apply_codex_auth(oauth) during remove-key failed: %s",
+                    exc,
+                    exc_info=True,
+                )
+                return {"ok": False, "error": "remove_failed", "detail": str(exc)}
+        else:
+            from vibe.claude_config import apply_claude_auth
+
+            try:
+                apply_claude_auth(auth_mode="oauth", api_key=None, base_url=None)
+            except Exception as exc:  # noqa: BLE001
+                logger.error(
+                    "apply_claude_auth(oauth) during remove-key failed: %s",
+                    exc,
+                    exc_info=True,
+                )
+                return {"ok": False, "error": "remove_failed", "detail": str(exc)}
+
+        # Clear V2Config api_key for both backends while the credential-file
+        # mutation remains serialized with concurrent auth saves.
         try:
-            result = apply_codex_auth(auth_mode="oauth", api_key=None, base_url=None)
-            if isinstance(result, dict):
-                raw_notices = result.get("notices")
-                if isinstance(raw_notices, list):
-                    notices = raw_notices
-        except Exception as exc:  # noqa: BLE001
-            logger.error("apply_codex_auth(oauth) during remove-key failed: %s", exc, exc_info=True)
-            return {"ok": False, "error": "remove_failed", "detail": str(exc)}
-    elif backend == "claude":
-        from vibe.claude_config import apply_claude_auth
-
-        try:
-            apply_claude_auth(auth_mode="oauth", api_key=None, base_url=None)
-        except Exception as exc:  # noqa: BLE001
-            logger.error("apply_claude_auth(oauth) during remove-key failed: %s", exc, exc_info=True)
-            return {"ok": False, "error": "remove_failed", "detail": str(exc)}
-
-    # Clear V2Config api_key for both backends.
-    try:
-        with config_write_transaction():
             try:
                 config = load_config()
             except FileNotFoundError:
-                config = V2Config()
+                from core.services.settings import default_config
+
+                config = default_config()
             target = getattr(getattr(config, "agents", None), backend, None)
             if target is not None:
                 target.auth_mode = "oauth"
@@ -9021,8 +9037,12 @@ def remove_backend_api_key(backend: str) -> dict:
                 if backend == "claude":
                     target.auth_mode_set = True
                 config.save()
-    except Exception as exc:  # noqa: BLE001
-        logger.warning("V2Config clear during remove-key failed for %s: %s", backend, exc)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "V2Config clear during remove-key failed for %s: %s",
+                backend,
+                exc,
+            )
 
     # Both backends keep runtime state in the controller. Codex owns a
     # persistent app-server; Claude owns cached SDK sessions and a loaded
@@ -10538,7 +10558,7 @@ async def delete_opencode_custom_provider_async(provider_id: str) -> dict:
         return {"ok": False, "message": str(exc)}
 
     try:
-        _clear_opencode_default_provider_if(pid)
+        await run_blocking(_clear_opencode_default_provider_if, pid)
     except Exception as exc:
         logger.warning(
             "Failed to revalidate opencode.default_provider after custom provider delete for %s: %s",
@@ -11018,7 +11038,7 @@ async def delete_opencode_provider_auth_async(provider_id: str) -> dict:
     if removed_auth:
         _OPENCODE_OPTIONS_CACHE.clear()
         try:
-            _clear_opencode_default_provider_if(pid)
+            await run_blocking(_clear_opencode_default_provider_if, pid)
         except Exception as exc:  # noqa: BLE001
             logger.warning(
                 "Failed to revalidate opencode.default_provider after delete for %s: %s",
@@ -11053,7 +11073,9 @@ def set_opencode_default_provider(payload: dict) -> dict:
         try:
             config = load_config()
         except FileNotFoundError:
-            config = V2Config()
+            from core.services.settings import default_config
+
+            config = default_config()
         config.agents.opencode.default_provider = provider_id
         config.save()
     return {"ok": True, "default_provider": provider_id}

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -10522,6 +10522,7 @@ async def delete_opencode_custom_provider_async(provider_id: str) -> dict:
     if not isinstance(provider_id, str) or not provider_id.strip():
         return {"ok": False, "message": "provider_id is required"}
     pid = provider_id.strip().lower()
+    settlement: CancellationSettlement | None = None
     try:
         from vibe.opencode_config import (
             is_opencode_custom_provider,
@@ -10540,24 +10541,37 @@ async def delete_opencode_custom_provider_async(provider_id: str) -> dict:
             read_opencode_provider_auth_entries,
             logger_instance=logger,
         )
+        settlement = CancellationSettlement()
         if pid in auth_entries:
-            auth_result = await _delete_opencode_provider_auth_async(pid)
+            auth_result = await settlement.wait(
+                _delete_opencode_provider_auth_async(pid)
+            )
             if not auth_result.get("ok"):
+                settlement.raise_if_cancelled()
                 return {
                     "ok": False,
                     "provider_id": pid,
                     "message": auth_result.get("message") or "Provider auth removal failed",
                 }
-        await asyncio.to_thread(
+        await settlement.run_blocking(
             remove_opencode_custom_provider,
             pid,
             logger_instance=logger,
         )
-    except Exception as exc:
+    except (Exception, asyncio.CancelledError) as exc:
+        if settlement is not None:
+            settlement.raise_if_cancelled(exc)
+        if isinstance(exc, asyncio.CancelledError):
+            raise
         logger.warning("OpenCode custom provider delete failed for %s: %s", pid, exc, exc_info=True)
         return {"ok": False, "message": str(exc)}
 
-    restart = await _settle_opencode_delete_runtime(pid, clear_default=True)
+    restart = await _settle_opencode_delete_runtime(
+        pid,
+        clear_default=True,
+        settlement=settlement,
+    )
+    settlement.raise_if_cancelled()
     return {"ok": True, "provider_id": pid, "restart": restart}
 
 
@@ -10969,17 +10983,22 @@ async def _settle_opencode_delete_runtime(
     provider_id: str,
     *,
     clear_default: bool,
+    settlement: CancellationSettlement | None = None,
 ) -> dict:
     """Settle persisted delete state into the live OpenCode projection."""
 
-    settlement = CancellationSettlement()
+    settlement = settlement or CancellationSettlement()
+    cancellation_cause: BaseException | None = None
     if clear_default:
         try:
             await settlement.run_blocking(
                 _clear_opencode_default_provider_if,
                 provider_id,
             )
-        except Exception as exc:  # noqa: BLE001
+        except (Exception, asyncio.CancelledError) as exc:
+            if isinstance(exc, asyncio.CancelledError) and not settlement.cancelled:
+                raise
+            cancellation_cause = exc
             logger.warning(
                 "Failed to revalidate opencode.default_provider after delete for %s: %s",
                 provider_id,
@@ -10989,10 +11008,13 @@ async def _settle_opencode_delete_runtime(
     _OPENCODE_OPTIONS_CACHE.clear()
     try:
         restart = await settlement.run_blocking(restart_backend, "opencode")
-    except Exception as exc:  # noqa: BLE001
+    except (Exception, asyncio.CancelledError) as exc:
+        if isinstance(exc, asyncio.CancelledError) and not settlement.cancelled:
+            raise
+        cancellation_cause = exc
         restart = {"ok": False, "message": str(exc)}
     _OPENCODE_OPTIONS_CACHE.clear()
-    settlement.raise_if_cancelled()
+    settlement.raise_if_cancelled(cancellation_cause)
     return restart
 
 
@@ -11021,6 +11043,7 @@ async def delete_opencode_provider_auth_async(provider_id: str) -> dict:
     if not isinstance(provider_id, str) or not provider_id.strip():
         return {"ok": False, "message": "provider_id is required"}
     pid = provider_id.strip()
+    settlement: CancellationSettlement | None = None
     try:
         from vibe.opencode_config import (
             read_opencode_provider_auth_entries,
@@ -11034,17 +11057,24 @@ async def delete_opencode_provider_auth_async(provider_id: str) -> dict:
         config_api_key_provider_ids = await _read_opencode_config_api_key_provider_ids()
         result = {"ok": True}
         removed_auth = False
+        settlement = CancellationSettlement()
         if pid in auth_entries:
-            result = await _delete_opencode_provider_auth_async(pid)
+            result = await settlement.wait(
+                _delete_opencode_provider_auth_async(pid)
+            )
             removed_auth = bool(result.get("ok"))
         if pid in config_api_key_provider_ids:
-            await asyncio.to_thread(
+            await settlement.run_blocking(
                 remove_opencode_provider_api_key,
                 pid,
                 logger_instance=logger,
             )
             removed_auth = True
-    except Exception as exc:
+    except (Exception, asyncio.CancelledError) as exc:
+        if settlement is not None:
+            settlement.raise_if_cancelled(exc)
+        if isinstance(exc, asyncio.CancelledError):
+            raise
         logger.warning("OpenCode delete-auth failed for %s: %s", provider_id, exc, exc_info=True)
         return {"ok": False, "message": str(exc)}
 
@@ -11056,12 +11086,15 @@ async def delete_opencode_provider_auth_async(provider_id: str) -> dict:
         result["restart"] = await _settle_opencode_delete_runtime(
             pid,
             clear_default=True,
+            settlement=settlement,
         )
     else:
         result["restart"] = await _settle_opencode_delete_runtime(
             pid,
             clear_default=False,
+            settlement=settlement,
         )
+    settlement.raise_if_cancelled()
     return result
 
 

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -42,7 +42,7 @@ from config.v2_settings import (
 )
 from config.v2_sessions import SessionsStore
 from config.platform_registry import get_platform_descriptor
-from core.memory.blocking import run_blocking
+from core.blocking import CancellationSettlement, run_blocking
 from vibe.opencode_config import (
     get_opencode_config_paths,
     load_first_opencode_user_config,
@@ -10557,21 +10557,7 @@ async def delete_opencode_custom_provider_async(provider_id: str) -> dict:
         logger.warning("OpenCode custom provider delete failed for %s: %s", pid, exc, exc_info=True)
         return {"ok": False, "message": str(exc)}
 
-    try:
-        await run_blocking(_clear_opencode_default_provider_if, pid)
-    except Exception as exc:
-        logger.warning(
-            "Failed to revalidate opencode.default_provider after custom provider delete for %s: %s",
-            pid,
-            exc,
-        )
-
-    _OPENCODE_OPTIONS_CACHE.clear()
-    try:
-        restart = restart_backend("opencode")
-    except Exception as exc:
-        restart = {"ok": False, "message": str(exc)}
-    _OPENCODE_OPTIONS_CACHE.clear()
+    restart = await _settle_opencode_delete_runtime(pid, clear_default=True)
     return {"ok": True, "provider_id": pid, "restart": restart}
 
 
@@ -10979,6 +10965,37 @@ def _clear_opencode_default_provider_if(provider_id: str) -> None:
             )
 
 
+async def _settle_opencode_delete_runtime(
+    provider_id: str,
+    *,
+    clear_default: bool,
+) -> dict:
+    """Settle persisted delete state into the live OpenCode projection."""
+
+    settlement = CancellationSettlement()
+    if clear_default:
+        try:
+            await settlement.run_blocking(
+                _clear_opencode_default_provider_if,
+                provider_id,
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "Failed to revalidate opencode.default_provider after delete for %s: %s",
+                provider_id,
+                exc,
+            )
+
+    _OPENCODE_OPTIONS_CACHE.clear()
+    try:
+        restart = await settlement.run_blocking(restart_backend, "opencode")
+    except Exception as exc:  # noqa: BLE001
+        restart = {"ok": False, "message": str(exc)}
+    _OPENCODE_OPTIONS_CACHE.clear()
+    settlement.raise_if_cancelled()
+    return restart
+
+
 def delete_opencode_provider_auth(provider_id: str) -> dict:
     from vibe.async_bridge import run_coroutine_blocking
 
@@ -11036,21 +11053,15 @@ async def delete_opencode_provider_auth_async(provider_id: str) -> dict:
     # credential, but log it so the user can investigate if the
     # default sticks around after a "Remove key" click.
     if removed_auth:
-        _OPENCODE_OPTIONS_CACHE.clear()
-        try:
-            await run_blocking(_clear_opencode_default_provider_if, pid)
-        except Exception as exc:  # noqa: BLE001
-            logger.warning(
-                "Failed to revalidate opencode.default_provider after delete for %s: %s",
-                pid,
-                exc,
-            )
-
-    try:
-        result["restart"] = restart_backend("opencode")
-    except Exception as exc:
-        logger.warning("OpenCode auto-restart after delete failed for %s: %s", provider_id, exc)
-        result["restart"] = {"ok": False, "message": str(exc)}
+        result["restart"] = await _settle_opencode_delete_runtime(
+            pid,
+            clear_default=True,
+        )
+    else:
+        result["restart"] = await _settle_opencode_delete_runtime(
+            pid,
+            clear_default=False,
+        )
     return result
 
 

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -27,7 +27,7 @@ from sqlalchemy import select
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 
 from config import paths
-from config.v2_config import CONFIG_LOCK, V2Config, config_write_transaction
+from config.v2_config import V2Config, config_write_transaction
 from config.v2_settings import (
     SettingsStore,
     ChannelSettings,
@@ -9252,7 +9252,9 @@ def save_codex_auth(payload: dict) -> dict:
         try:
             config = load_config()
         except FileNotFoundError:
-            config = V2Config()
+            from core.services.settings import default_config
+
+            config = default_config()
         stored_codex = getattr(getattr(config, "agents", None), "codex", None)
         if auth_mode == "api_key" and not api_key:
             api_key = getattr(stored_codex, "api_key", None) or None
@@ -9510,64 +9512,58 @@ def save_claude_auth(payload: dict) -> dict:
     if auth_mode == "api_key":
         credential_type = raw_credential_type or existing_credential_type or "api_key"
     credential = api_key or existing_credential
-
-    if auth_mode == "api_key" and not credential:
-        # Fall back to legacy V2Config only for older installs that have not
-        # yet migrated their credential into Claude Code settings.
-        with CONFIG_LOCK:
-            try:
-                existing = load_config()
-                stored = getattr(getattr(existing, "agents", None), "claude", None)
-                credential = getattr(stored, "api_key", None) or None
-            except Exception:
-                pass
-        if not credential:
-            return {"ok": False, "message": "api_key is required when auth_mode='api_key'"}
-
     effective_base_url = base_url_change if base_url_present else None
     if not base_url_present and auth_mode == "api_key":
         existing_base = settings_env.get("ANTHROPIC_BASE_URL")
         if isinstance(existing_base, str) and existing_base.strip():
             effective_base_url = existing_base.strip()
-        else:
-            with CONFIG_LOCK:
-                try:
-                    existing = load_config()
-                    stored = getattr(getattr(existing, "agents", None), "claude", None)
-                    effective_base_url = getattr(stored, "base_url", None) or None
-                except Exception:
-                    effective_base_url = None
 
     oauth_cleanup_service = _get_oauth_service() if auth_mode == "api_key" else None
 
     from vibe.claude_config import apply_claude_auth
 
-    try:
-        apply_claude_auth(
-            auth_mode=auth_mode,
-            api_key=(
-                credential
-                if auth_mode == "api_key" and credential_type == "api_key"
-                else None
-            ),
-            base_url=effective_base_url if auth_mode == "api_key" else None,
-            auth_token=(
-                credential
-                if auth_mode == "api_key" and credential_type == "auth_token"
-                else None
-            ),
-        )
-    except ValueError as exc:
-        return {"ok": False, "message": str(exc)}
-    except OSError as exc:
-        logger.error("Failed to write Claude settings.json: %s", exc, exc_info=True)
-        return {"ok": False, "message": f"Failed to write Claude settings: {exc}"}
-
     with config_write_transaction():
         try:
             config = load_config()
         except FileNotFoundError:
-            config = V2Config()
+            from core.services.settings import default_config
+
+            config = default_config()
+        stored_claude = getattr(getattr(config, "agents", None), "claude", None)
+        if auth_mode == "api_key" and not credential:
+            # Legacy installs may still have a credential cached in V2Config.
+            credential = getattr(stored_claude, "api_key", None) or None
+            if not credential:
+                return {
+                    "ok": False,
+                    "message": "api_key is required when auth_mode='api_key'",
+                }
+        if (
+            auth_mode == "api_key"
+            and not base_url_present
+            and effective_base_url is None
+        ):
+            effective_base_url = getattr(stored_claude, "base_url", None) or None
+        try:
+            apply_claude_auth(
+                auth_mode=auth_mode,
+                api_key=(
+                    credential
+                    if auth_mode == "api_key" and credential_type == "api_key"
+                    else None
+                ),
+                base_url=effective_base_url if auth_mode == "api_key" else None,
+                auth_token=(
+                    credential
+                    if auth_mode == "api_key" and credential_type == "auth_token"
+                    else None
+                ),
+            )
+        except ValueError as exc:
+            return {"ok": False, "message": str(exc)}
+        except OSError as exc:
+            logger.error("Failed to write Claude settings.json: %s", exc, exc_info=True)
+            return {"ok": False, "message": f"Failed to write Claude settings: {exc}"}
         config.agents.claude.auth_mode = auth_mode
         # Flip the explicit marker so ``build_claude_subprocess_env``
         # honors ``auth_mode`` strictly (strip inherited env in OAuth

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -6336,7 +6336,7 @@ def _run_install_command(
             # config entries, so they must not touch V2Config bookkeeping.
             if installed_path and is_agent_backend(name):
                 try:
-                    with CONFIG_LOCK:
+                    with config_write_transaction():
                         try:
                             cfg = load_config()
                         except FileNotFoundError:
@@ -6623,7 +6623,7 @@ def _persist_avault_cli_path(path: str) -> None:
             load_config()
         except FileNotFoundError:
             save_config({})
-        with CONFIG_LOCK:
+        with config_write_transaction():
             cfg = load_config()
             previous = getattr(cfg.agents.avault, "cli_path", "") or ""
             if previous != path:
@@ -8997,7 +8997,7 @@ def remove_backend_api_key(backend: str) -> dict:
 
     # Clear V2Config api_key for both backends.
     try:
-        with CONFIG_LOCK:
+        with config_write_transaction():
             try:
                 config = load_config()
             except FileNotFoundError:
@@ -9286,7 +9286,7 @@ def save_codex_auth(payload: dict) -> dict:
         logger.error("Failed to write Codex auth files: %s", exc, exc_info=True)
         return {"ok": False, "message": f"Failed to write Codex config: {exc}"}
 
-    with CONFIG_LOCK:
+    with config_write_transaction():
         try:
             config = load_config()
         except FileNotFoundError:
@@ -9573,7 +9573,7 @@ def save_claude_auth(payload: dict) -> dict:
         logger.error("Failed to write Claude settings.json: %s", exc, exc_info=True)
         return {"ok": False, "message": f"Failed to write Claude settings: {exc}"}
 
-    with CONFIG_LOCK:
+    with config_write_transaction():
         try:
             config = load_config()
         except FileNotFoundError:
@@ -10958,7 +10958,7 @@ async def _delete_opencode_provider_auth_async(provider_id: str) -> dict:
 def _clear_opencode_default_provider_if(provider_id: str) -> None:
     """Clear the saved OpenCode default if it points at ``provider_id``."""
 
-    with CONFIG_LOCK:
+    with config_write_transaction():
         try:
             cfg = load_config()
         except FileNotFoundError:
@@ -11064,7 +11064,7 @@ def set_opencode_default_provider(payload: dict) -> dict:
         return {"ok": False, "message": "provider_id is required"}
     provider_id = raw.strip()
 
-    with CONFIG_LOCK:
+    with config_write_transaction():
         try:
             config = load_config()
         except FileNotFoundError:

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -10470,7 +10470,21 @@ async def save_opencode_custom_provider_async(payload: dict) -> dict:
         )
     except Exception as exc:
         logger.warning("OpenCode custom provider save failed for %s: %s", provider_id, exc, exc_info=True)
-        return {"ok": False, "message": str(exc)}
+        _OPENCODE_OPTIONS_CACHE.clear()
+        try:
+            restart = restart_backend("opencode")
+        except Exception as restart_exc:
+            restart = {"ok": False, "message": str(restart_exc)}
+        _OPENCODE_OPTIONS_CACHE.clear()
+        return {
+            "ok": False,
+            "partial": True,
+            "saved": None,
+            "mutation_attempted": True,
+            "provider_id": provider_id.strip().lower(),
+            "message": str(exc),
+            "restart": restart,
+        }
 
     _OPENCODE_OPTIONS_CACHE.clear()
     try:
@@ -10547,18 +10561,25 @@ async def delete_opencode_custom_provider_async(provider_id: str) -> dict:
         )
         settlement = CancellationSettlement()
         if pid in auth_entries:
-            mutation_started = True
             auth_result = await settlement.wait(
                 _delete_opencode_provider_auth_async(pid)
             )
+            mutation_started = bool(auth_result.get("mutation_attempted"))
             if not auth_result.get("ok"):
+                restart = None
+                if mutation_started:
+                    restart = await _settle_opencode_delete_runtime(
+                        pid,
+                        clear_default=True,
+                        settlement=settlement,
+                    )
                 settlement.raise_if_cancelled()
-                return {
-                    "ok": False,
-                    "provider_id": pid,
-                    "message": auth_result.get("message") or "Provider auth removal failed",
-                }
-            mutation_started = True
+                return _opencode_delete_failure_result(
+                    pid,
+                    str(auth_result.get("message") or "Provider auth removal failed"),
+                    restart,
+                    mutation_attempted=mutation_started,
+                )
         mutation_started = True
         await settlement.run_blocking(
             remove_opencode_custom_provider,
@@ -10770,6 +10791,7 @@ async def _save_opencode_provider_auth_async(
     # providers consistently use at invocation time.
     config_key = config_api_key or api_key
     mutation_attempted = False
+    saved: bool | None = False
     if config_key:
         try:
             # The write may commit before raising, so this is possibly
@@ -10791,11 +10813,13 @@ async def _save_opencode_provider_auth_async(
             return {
                 "ok": False,
                 "mutation_attempted": mutation_attempted,
+                "saved": None,
                 "message": (
                     "Provider credential persistence failed: "
                     f"{exc}"
                 ),
             }
+        saved = True
 
         try:
             auth_entries = await asyncio.to_thread(
@@ -10805,11 +10829,15 @@ async def _save_opencode_provider_auth_async(
             if provider_id in auth_entries:
                 auth_cleanup = await _delete_opencode_provider_auth_async(provider_id)
                 if not auth_cleanup.get("ok"):
+                    cleanup_message = auth_cleanup.get("message")
                     return {
                         "ok": False,
                         "mutation_attempted": mutation_attempted,
-                        "message": auth_cleanup.get("message")
-                        or "API key saved, but stale OpenCode auth cleanup failed",
+                        "saved": saved,
+                        "message": (
+                            "API key saved, but stale OpenCode auth cleanup failed"
+                            + (f": {cleanup_message}" if cleanup_message else "")
+                        ),
                     }
         except Exception as exc:
             logger.warning(
@@ -10821,6 +10849,7 @@ async def _save_opencode_provider_auth_async(
             return {
                 "ok": False,
                 "mutation_attempted": mutation_attempted,
+                "saved": saved,
                 "message": (
                     "API key saved, but stale OpenCode auth cleanup failed: "
                     f"{exc}"
@@ -10857,6 +10886,7 @@ async def _save_opencode_provider_auth_async(
         return {
             "ok": False,
             "mutation_attempted": mutation_attempted,
+            "saved": saved if saved else None,
             "message": (
                 "API key saved, but base URL persistence failed: "
                 f"{exc}"
@@ -10886,9 +10916,9 @@ async def save_opencode_provider_auth_async(provider_id: str, payload: dict) -> 
       * non-empty string    → upsert (must start with http:// or https://)
     """
     if not isinstance(provider_id, str) or not provider_id.strip():
-        return {"ok": False, "message": "provider_id is required"}
+        return {"ok": False, "saved": False, "message": "provider_id is required"}
     if not isinstance(payload, dict):
-        return {"ok": False, "message": "Payload must be an object"}
+        return {"ok": False, "saved": False, "message": "Payload must be an object"}
     raw_key = payload.get("api_key")
     # ``api_key`` is optional when the provider is already configured: the
     # UI's "Replace" flow hides the plaintext and only sends ``base_url``
@@ -10929,7 +10959,7 @@ async def save_opencode_provider_auth_async(provider_id: str, payload: dict) -> 
             )
             has_existing_key = False
         if not has_existing_key:
-            return {"ok": False, "message": "api_key is required"}
+            return {"ok": False, "saved": False, "message": "api_key is required"}
 
     base_url: Any = _BASE_URL_UNCHANGED
     if "base_url" in payload:
@@ -10944,15 +10974,20 @@ async def save_opencode_provider_auth_async(provider_id: str, payload: dict) -> 
                 if not candidate.lower().startswith(("http://", "https://")):
                     return {
                         "ok": False,
+                        "saved": False,
                         "message": "base_url must start with http:// or https://",
                     }
                 base_url = candidate
         else:
-            return {"ok": False, "message": "base_url must be a string"}
+            return {"ok": False, "saved": False, "message": "base_url must be a string"}
         if base_url is None:
             custom_provider_ids = await _read_opencode_custom_provider_ids()
             if provider_id.strip() in custom_provider_ids:
-                return {"ok": False, "message": "base_url is required for custom providers"}
+                return {
+                    "ok": False,
+                    "saved": False,
+                    "message": "base_url is required for custom providers",
+                }
 
     try:
         result = await _save_opencode_provider_auth_async(
@@ -10997,13 +11032,57 @@ async def save_opencode_provider_auth_async(provider_id: str, payload: dict) -> 
 async def _delete_opencode_provider_auth_async(provider_id: str) -> dict:
     server = await _opencode_get_server()
     if server is None:
-        return {"ok": False, "message": "OpenCode is disabled in V2Config"}
+        return {
+            "ok": False,
+            "message": "OpenCode is disabled in V2Config",
+            "mutation_attempted": False,
+            "removed": False,
+        }
     request_loop = asyncio.get_running_loop()
+    remove_error: Exception | None = None
+    remove_cancelled: asyncio.CancelledError | None = None
     try:
         await server.remove_provider_auth(provider_id)
-    finally:
+    except asyncio.CancelledError as exc:
+        remove_cancelled = exc
+    except Exception as exc:
+        remove_error = exc
+
+    close_error: Exception | None = None
+    try:
         await server.close_http_session(loop=request_loop)
-    return {"ok": True}
+    except Exception as exc:
+        close_error = exc
+
+    if remove_cancelled is not None:
+        if close_error is not None:
+            logger.warning(
+                "OpenCode auth session close also failed for %s after cancellation: %s",
+                provider_id,
+                close_error,
+            )
+        raise remove_cancelled
+    if remove_error is not None:
+        if close_error is not None:
+            logger.warning(
+                "OpenCode auth session close also failed for %s after remove failure: %s",
+                provider_id,
+                close_error,
+            )
+        return {
+            "ok": False,
+            "message": str(remove_error),
+            "mutation_attempted": True,
+            "removed": None,
+        }
+    if close_error is not None:
+        return {
+            "ok": False,
+            "message": str(close_error),
+            "mutation_attempted": True,
+            "removed": True,
+        }
+    return {"ok": True, "mutation_attempted": True, "removed": True}
 
 
 def _clear_opencode_default_provider_if(provider_id: str) -> None:
@@ -11164,11 +11243,11 @@ async def delete_opencode_provider_auth_async(provider_id: str) -> dict:
         removed_auth = False
         settlement = CancellationSettlement()
         if pid in auth_entries:
-            mutation_started = True
             result = await settlement.wait(
                 _delete_opencode_provider_auth_async(pid)
             )
-            removed_auth = bool(result.get("ok"))
+            mutation_started = bool(result.get("mutation_attempted"))
+            removed_auth = result.get("removed") is True
         if pid in config_api_key_provider_ids:
             mutation_started = True
             await settlement.run_blocking(

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -9491,36 +9491,13 @@ def save_claude_auth(payload: dict) -> dict:
         if base_url_change == "":
             base_url_change = None
 
-    settings_env: dict[str, str] = {}
-    existing_credential_type: str | None = None
-    existing_credential: str | None = None
-    if auth_mode == "api_key":
-        try:
-            from vibe.claude_config import (
-                read_claude_credential_from_settings,
-                read_claude_settings_env,
-            )
-
-            settings_env = read_claude_settings_env()
-            existing_credential_type, existing_credential = (
-                read_claude_credential_from_settings()
-            )
-        except Exception:
-            settings_env = {}
-
-    credential_type = None
-    if auth_mode == "api_key":
-        credential_type = raw_credential_type or existing_credential_type or "api_key"
-    credential = api_key or existing_credential
-    effective_base_url = base_url_change if base_url_present else None
-    if not base_url_present and auth_mode == "api_key":
-        existing_base = settings_env.get("ANTHROPIC_BASE_URL")
-        if isinstance(existing_base, str) and existing_base.strip():
-            effective_base_url = existing_base.strip()
-
     oauth_cleanup_service = _get_oauth_service() if auth_mode == "api_key" else None
 
-    from vibe.claude_config import apply_claude_auth
+    from vibe.claude_config import (
+        apply_claude_auth,
+        read_claude_credential_from_settings,
+        read_claude_settings_env,
+    )
 
     with config_write_transaction():
         try:
@@ -9530,6 +9507,23 @@ def save_claude_auth(payload: dict) -> dict:
 
             config = default_config()
         stored_claude = getattr(getattr(config, "agents", None), "claude", None)
+        settings_env: dict[str, str] = {}
+        existing_credential_type: str | None = None
+        existing_credential: str | None = None
+        if auth_mode == "api_key":
+            try:
+                settings_env = read_claude_settings_env()
+                existing_credential_type, existing_credential = (
+                    read_claude_credential_from_settings()
+                )
+            except Exception:
+                settings_env = {}
+        credential_type = (
+            raw_credential_type or existing_credential_type or "api_key"
+            if auth_mode == "api_key"
+            else None
+        )
+        credential = api_key or existing_credential
         if auth_mode == "api_key" and not credential:
             # Legacy installs may still have a credential cached in V2Config.
             credential = getattr(stored_claude, "api_key", None) or None
@@ -9538,12 +9532,17 @@ def save_claude_auth(payload: dict) -> dict:
                     "ok": False,
                     "message": "api_key is required when auth_mode='api_key'",
                 }
+        effective_base_url = base_url_change if base_url_present else None
         if (
             auth_mode == "api_key"
             and not base_url_present
-            and effective_base_url is None
         ):
-            effective_base_url = getattr(stored_claude, "base_url", None) or None
+            existing_base = settings_env.get("ANTHROPIC_BASE_URL")
+            effective_base_url = (
+                existing_base.strip()
+                if isinstance(existing_base, str) and existing_base.strip()
+                else getattr(stored_claude, "base_url", None) or None
+            )
         try:
             apply_claude_auth(
                 auth_mode=auth_mode,

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -10523,6 +10523,7 @@ async def delete_opencode_custom_provider_async(provider_id: str) -> dict:
         return {"ok": False, "message": "provider_id is required"}
     pid = provider_id.strip().lower()
     settlement: CancellationSettlement | None = None
+    mutation_started = False
     try:
         from vibe.opencode_config import (
             is_opencode_custom_provider,
@@ -10553,18 +10554,28 @@ async def delete_opencode_custom_provider_async(provider_id: str) -> dict:
                     "provider_id": pid,
                     "message": auth_result.get("message") or "Provider auth removal failed",
                 }
+            mutation_started = True
+        mutation_started = True
         await settlement.run_blocking(
             remove_opencode_custom_provider,
             pid,
             logger_instance=logger,
         )
     except (Exception, asyncio.CancelledError) as exc:
-        if settlement is not None:
+        restart = None
+        if settlement is not None and mutation_started:
+            restart = await _settle_opencode_delete_runtime(
+                pid,
+                clear_default=True,
+                settlement=settlement,
+                cancellation_cause=exc,
+            )
+        elif settlement is not None:
             settlement.raise_if_cancelled(exc)
         if isinstance(exc, asyncio.CancelledError):
             raise
         logger.warning("OpenCode custom provider delete failed for %s: %s", pid, exc, exc_info=True)
-        return {"ok": False, "message": str(exc)}
+        return {"ok": False, "message": str(exc), "restart": restart}
 
     restart = await _settle_opencode_delete_runtime(
         pid,
@@ -10984,11 +10995,12 @@ async def _settle_opencode_delete_runtime(
     *,
     clear_default: bool,
     settlement: CancellationSettlement | None = None,
+    cancellation_cause: BaseException | None = None,
 ) -> dict:
     """Settle persisted delete state into the live OpenCode projection."""
 
     settlement = settlement or CancellationSettlement()
-    cancellation_cause: BaseException | None = None
+    boundary_cause = cancellation_cause
     if clear_default:
         try:
             await settlement.run_blocking(
@@ -10998,7 +11010,7 @@ async def _settle_opencode_delete_runtime(
         except (Exception, asyncio.CancelledError) as exc:
             if isinstance(exc, asyncio.CancelledError) and not settlement.cancelled:
                 raise
-            cancellation_cause = exc
+            boundary_cause = boundary_cause or exc
             logger.warning(
                 "Failed to revalidate opencode.default_provider after delete for %s: %s",
                 provider_id,
@@ -11011,10 +11023,10 @@ async def _settle_opencode_delete_runtime(
     except (Exception, asyncio.CancelledError) as exc:
         if isinstance(exc, asyncio.CancelledError) and not settlement.cancelled:
             raise
-        cancellation_cause = exc
+        boundary_cause = boundary_cause or exc
         restart = {"ok": False, "message": str(exc)}
     _OPENCODE_OPTIONS_CACHE.clear()
-    settlement.raise_if_cancelled(cancellation_cause)
+    settlement.raise_if_cancelled(boundary_cause)
     return restart
 
 
@@ -11044,6 +11056,7 @@ async def delete_opencode_provider_auth_async(provider_id: str) -> dict:
         return {"ok": False, "message": "provider_id is required"}
     pid = provider_id.strip()
     settlement: CancellationSettlement | None = None
+    mutation_started = False
     try:
         from vibe.opencode_config import (
             read_opencode_provider_auth_entries,
@@ -11063,7 +11076,9 @@ async def delete_opencode_provider_auth_async(provider_id: str) -> dict:
                 _delete_opencode_provider_auth_async(pid)
             )
             removed_auth = bool(result.get("ok"))
+            mutation_started = removed_auth
         if pid in config_api_key_provider_ids:
+            mutation_started = True
             await settlement.run_blocking(
                 remove_opencode_provider_api_key,
                 pid,
@@ -11071,12 +11086,20 @@ async def delete_opencode_provider_auth_async(provider_id: str) -> dict:
             )
             removed_auth = True
     except (Exception, asyncio.CancelledError) as exc:
-        if settlement is not None:
+        restart = None
+        if settlement is not None and mutation_started:
+            restart = await _settle_opencode_delete_runtime(
+                pid,
+                clear_default=True,
+                settlement=settlement,
+                cancellation_cause=exc,
+            )
+        elif settlement is not None:
             settlement.raise_if_cancelled(exc)
         if isinstance(exc, asyncio.CancelledError):
             raise
         logger.warning("OpenCode delete-auth failed for %s: %s", provider_id, exc, exc_info=True)
-        return {"ok": False, "message": str(exc)}
+        return {"ok": False, "message": str(exc), "restart": restart}
 
     # Revalidate the saved default. Best-effort: a V2Config write
     # failure here is non-fatal because the daemon already dropped the

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -9250,25 +9250,18 @@ def save_codex_auth(payload: dict) -> dict:
         if base_url_change == "":
             base_url_change = None
 
-    if auth_mode == "api_key" and not api_key:
-        # Allow callers to PATCH base_url alone by reusing the stored key.
-        # ``auth.json`` is the live source Codex reads at launch, and it
-        # captures keys rotated outside this flow (e.g. ``codex login
-        # --with-api-key``). The V2Config cache can be stale relative to
-        # disk, so trusting it first would silently revert a freshly
-        # rotated key when we re-write ``auth.json`` below. Prefer disk;
-        # fall back to V2Config only if disk has nothing (legacy installs
-        # that never wrote ``auth.json``).
-        try:
-            from vibe.codex_config import read_codex_api_key
-
-            api_key = read_codex_api_key()
-        except Exception:
-            api_key = None
-    from vibe.codex_config import apply_codex_auth
+    from vibe.codex_config import apply_codex_auth, read_codex_api_key
 
     notices: list = []
     with config_write_transaction():
+        if auth_mode == "api_key" and not api_key:
+            # ``auth.json`` is the live source Codex reads at launch. Keep
+            # this preservation read in the same transaction as its rewrite
+            # so a concurrent key rotation cannot be replaced with stale data.
+            try:
+                api_key = read_codex_api_key()
+            except Exception:
+                api_key = None
         try:
             config = load_config()
         except FileNotFoundError:

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -10544,6 +10544,7 @@ async def delete_opencode_custom_provider_async(provider_id: str) -> dict:
         )
         settlement = CancellationSettlement()
         if pid in auth_entries:
+            mutation_started = True
             auth_result = await settlement.wait(
                 _delete_opencode_provider_auth_async(pid)
             )
@@ -11001,6 +11002,7 @@ async def _settle_opencode_delete_runtime(
 
     settlement = settlement or CancellationSettlement()
     boundary_cause = cancellation_cause
+    default_clear_error: BaseException | None = None
     if clear_default:
         try:
             await settlement.run_blocking(
@@ -11011,6 +11013,7 @@ async def _settle_opencode_delete_runtime(
             if isinstance(exc, asyncio.CancelledError) and not settlement.cancelled:
                 raise
             boundary_cause = boundary_cause or exc
+            default_clear_error = exc
             logger.warning(
                 "Failed to revalidate opencode.default_provider after delete for %s: %s",
                 provider_id,
@@ -11027,6 +11030,12 @@ async def _settle_opencode_delete_runtime(
         restart = {"ok": False, "message": str(exc)}
     _OPENCODE_OPTIONS_CACHE.clear()
     settlement.raise_if_cancelled(boundary_cause)
+    if default_clear_error is not None:
+        return {
+            "ok": False,
+            "message": str(default_clear_error),
+            "runtime_refresh": restart,
+        }
     return restart
 
 
@@ -11072,6 +11081,7 @@ async def delete_opencode_provider_auth_async(provider_id: str) -> dict:
         removed_auth = False
         settlement = CancellationSettlement()
         if pid in auth_entries:
+            mutation_started = True
             result = await settlement.wait(
                 _delete_opencode_provider_auth_async(pid)
             )

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -10576,7 +10576,12 @@ async def delete_opencode_custom_provider_async(provider_id: str) -> dict:
         if isinstance(exc, asyncio.CancelledError):
             raise
         logger.warning("OpenCode custom provider delete failed for %s: %s", pid, exc, exc_info=True)
-        return {"ok": False, "message": str(exc), "restart": restart}
+        return _opencode_delete_failure_result(
+            pid,
+            str(exc),
+            restart,
+            mutation_attempted=mutation_started,
+        )
 
     restart = await _settle_opencode_delete_runtime(
         pid,
@@ -10584,7 +10589,12 @@ async def delete_opencode_custom_provider_async(provider_id: str) -> dict:
         settlement=settlement,
     )
     settlement.raise_if_cancelled()
-    partial = _opencode_delete_partial_result(pid, restart, removed=True)
+    partial = _opencode_delete_partial_result(
+        pid,
+        restart,
+        removed=True,
+        mutation_attempted=True,
+    )
     if partial is not None:
         return partial
     return {"ok": True, "provider_id": pid, "restart": restart}
@@ -10756,8 +10766,12 @@ async def _save_opencode_provider_auth_async(
     # flow, but provider options are the source OpenCode-compatible
     # providers consistently use at invocation time.
     config_key = config_api_key or api_key
+    mutation_attempted = False
     if config_key:
         try:
+            # The write may commit before raising, so this is possibly
+            # irreversible from the moment the operation starts.
+            mutation_attempted = True
             await asyncio.to_thread(
                 upsert_opencode_provider_api_key,
                 provider_id,
@@ -10773,6 +10787,7 @@ async def _save_opencode_provider_auth_async(
             )
             return {
                 "ok": False,
+                "mutation_attempted": mutation_attempted,
                 "message": (
                     "Provider credential persistence failed: "
                     f"{exc}"
@@ -10789,6 +10804,7 @@ async def _save_opencode_provider_auth_async(
                 if not auth_cleanup.get("ok"):
                     return {
                         "ok": False,
+                        "mutation_attempted": mutation_attempted,
                         "message": auth_cleanup.get("message")
                         or "API key saved, but stale OpenCode auth cleanup failed",
                     }
@@ -10801,6 +10817,7 @@ async def _save_opencode_provider_auth_async(
             )
             return {
                 "ok": False,
+                "mutation_attempted": mutation_attempted,
                 "message": (
                     "API key saved, but stale OpenCode auth cleanup failed: "
                     f"{exc}"
@@ -10816,6 +10833,7 @@ async def _save_opencode_provider_auth_async(
         return {"ok": True}
 
     try:
+        mutation_attempted = True
         if base_url:
             await asyncio.to_thread(
                 upsert_opencode_provider_base_url,
@@ -10835,6 +10853,7 @@ async def _save_opencode_provider_auth_async(
         )
         return {
             "ok": False,
+            "mutation_attempted": mutation_attempted,
             "message": (
                 "API key saved, but base URL persistence failed: "
                 f"{exc}"
@@ -10943,8 +10962,17 @@ async def save_opencode_provider_auth_async(provider_id: str, payload: dict) -> 
         logger.warning("OpenCode set-auth failed for %s: %s", provider_id, exc, exc_info=True)
         return {"ok": False, "message": str(exc)}
 
-    if result.get("ok"):
+    mutation_attempted = bool(result.get("mutation_attempted"))
+    if mutation_attempted or result.get("ok"):
         _OPENCODE_OPTIONS_CACHE.clear()
+
+    if not result.get("ok") and mutation_attempted:
+        result.update(
+            {
+                "partial": True,
+                "provider_id": provider_id.strip(),
+            }
+        )
 
     # Ask the live controller to refresh the OpenCode server so the
     # daemon's in-memory ``connected`` cache picks up the new auth.
@@ -11046,7 +11074,8 @@ def _opencode_delete_partial_result(
     provider_id: str,
     restart: dict,
     *,
-    removed: bool,
+    removed: bool | None,
+    mutation_attempted: bool,
 ) -> dict | None:
     """Expose a committed delete whose required runtime settlement failed."""
 
@@ -11056,12 +11085,36 @@ def _opencode_delete_partial_result(
         "ok": False,
         "partial": True,
         "removed": removed,
+        "mutation_attempted": mutation_attempted,
         "provider_id": provider_id,
         "restart": restart,
     }
     message = restart.get("message")
     if isinstance(message, str) and message:
         result["message"] = message
+    return result
+
+
+def _opencode_delete_failure_result(
+    provider_id: str,
+    message: str,
+    restart: dict | None,
+    *,
+    mutation_attempted: bool,
+) -> dict:
+    """Return one closed response shape for an uncertain delete outcome."""
+
+    result: dict[str, Any] = {
+        "ok": False,
+        "partial": mutation_attempted,
+        "mutation_attempted": mutation_attempted,
+        "provider_id": provider_id,
+        "removed": None if mutation_attempted else False,
+    }
+    if message:
+        result["message"] = message
+    if restart is not None:
+        result["restart"] = restart
     return result
 
 
@@ -11112,7 +11165,6 @@ async def delete_opencode_provider_auth_async(provider_id: str) -> dict:
                 _delete_opencode_provider_auth_async(pid)
             )
             removed_auth = bool(result.get("ok"))
-            mutation_started = removed_auth
         if pid in config_api_key_provider_ids:
             mutation_started = True
             await settlement.run_blocking(
@@ -11135,7 +11187,12 @@ async def delete_opencode_provider_auth_async(provider_id: str) -> dict:
         if isinstance(exc, asyncio.CancelledError):
             raise
         logger.warning("OpenCode delete-auth failed for %s: %s", provider_id, exc, exc_info=True)
-        return {"ok": False, "message": str(exc), "restart": restart}
+        return _opencode_delete_failure_result(
+            pid,
+            str(exc),
+            restart,
+            mutation_attempted=mutation_started,
+        )
 
     # Revalidate the saved default after the credential mutation. A
     # failure is partial because the credential is already gone, but it
@@ -11157,6 +11214,7 @@ async def delete_opencode_provider_auth_async(provider_id: str) -> dict:
         pid,
         result["restart"],
         removed=removed_auth,
+        mutation_attempted=mutation_started,
     )
     if partial is not None:
         return partial

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -10584,6 +10584,9 @@ async def delete_opencode_custom_provider_async(provider_id: str) -> dict:
         settlement=settlement,
     )
     settlement.raise_if_cancelled()
+    partial = _opencode_delete_partial_result(pid, restart, removed=True)
+    if partial is not None:
+        return partial
     return {"ok": True, "provider_id": pid, "restart": restart}
 
 
@@ -11039,6 +11042,29 @@ async def _settle_opencode_delete_runtime(
     return restart
 
 
+def _opencode_delete_partial_result(
+    provider_id: str,
+    restart: dict,
+    *,
+    removed: bool,
+) -> dict | None:
+    """Expose a committed delete whose required runtime settlement failed."""
+
+    if restart.get("ok") is not False:
+        return None
+    result = {
+        "ok": False,
+        "partial": True,
+        "removed": removed,
+        "provider_id": provider_id,
+        "restart": restart,
+    }
+    message = restart.get("message")
+    if isinstance(message, str) and message:
+        result["message"] = message
+    return result
+
+
 def delete_opencode_provider_auth(provider_id: str) -> dict:
     from vibe.async_bridge import run_coroutine_blocking
 
@@ -11111,10 +11137,9 @@ async def delete_opencode_provider_auth_async(provider_id: str) -> dict:
         logger.warning("OpenCode delete-auth failed for %s: %s", provider_id, exc, exc_info=True)
         return {"ok": False, "message": str(exc), "restart": restart}
 
-    # Revalidate the saved default. Best-effort: a V2Config write
-    # failure here is non-fatal because the daemon already dropped the
-    # credential, but log it so the user can investigate if the
-    # default sticks around after a "Remove key" click.
+    # Revalidate the saved default after the credential mutation. A
+    # failure is partial because the credential is already gone, but it
+    # must remain visible to the caller instead of looking fully successful.
     if removed_auth:
         result["restart"] = await _settle_opencode_delete_runtime(
             pid,
@@ -11128,6 +11153,13 @@ async def delete_opencode_provider_auth_async(provider_id: str) -> dict:
             settlement=settlement,
         )
     settlement.raise_if_cancelled()
+    partial = _opencode_delete_partial_result(
+        pid,
+        result["restart"],
+        removed=removed_auth,
+    )
+    if partial is not None:
+        return partial
     return result
 
 

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -27,7 +27,7 @@ from sqlalchemy import select
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 
 from config import paths
-from config.v2_config import CONFIG_LOCK, V2Config
+from config.v2_config import CONFIG_LOCK, V2Config, config_write_transaction
 from config.v2_settings import (
     SettingsStore,
     ChannelSettings,
@@ -929,7 +929,7 @@ def save_config(
     payload = _strip_preserved_config_secrets(payload)
     payload = _mark_explicit_audio_asr_enabled(payload)
 
-    with CONFIG_LOCK:
+    with config_write_transaction():
         base_payload: dict = {}
         base_config: Optional[V2Config] = None
         try:
@@ -995,7 +995,7 @@ def save_config(
                 existing_update = _discord_guild_scope_from_config(base_config)
                 if existing_update is not None:
                     _save_discord_guild_scope_update(*existing_update, store=store)
-        config.save()
+        config.save(preserve_memory=not allow_memory)
         # The activity-streaming gate (ui.show_agent_activity) is cached in-process
         # by the message mirror; a save that flips it must take effect immediately,
         # not after the cache TTL. Reset it here (same process) — best-effort.

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -10495,6 +10495,9 @@ async def save_opencode_custom_provider_async(payload: dict) -> dict:
         if not auth_result.get("ok"):
             return {
                 "ok": False,
+                "partial": True,
+                "saved": True,
+                "mutation_attempted": True,
                 "provider_id": provider_id.strip().lower(),
                 "message": auth_result.get("message") or "Provider saved, but API key save failed",
                 "restart": restart,
@@ -11101,6 +11104,7 @@ def _opencode_delete_failure_result(
     restart: dict | None,
     *,
     mutation_attempted: bool,
+    removed: bool | None = None,
 ) -> dict:
     """Return one closed response shape for an uncertain delete outcome."""
 
@@ -11109,7 +11113,7 @@ def _opencode_delete_failure_result(
         "partial": mutation_attempted,
         "mutation_attempted": mutation_attempted,
         "provider_id": provider_id,
-        "removed": None if mutation_attempted else False,
+        "removed": removed if removed is not None else (None if mutation_attempted else False),
     }
     if message:
         result["message"] = message
@@ -11210,6 +11214,14 @@ async def delete_opencode_provider_auth_async(provider_id: str) -> dict:
             settlement=settlement,
         )
     settlement.raise_if_cancelled()
+    if not result.get("ok"):
+        return _opencode_delete_failure_result(
+            pid,
+            str(result.get("message") or "Provider auth removal failed"),
+            result["restart"],
+            mutation_attempted=mutation_started,
+            removed=True if removed_auth else None,
+        )
     partial = _opencode_delete_partial_result(
         pid,
         result["restart"],

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -9245,52 +9245,42 @@ def save_codex_auth(payload: dict) -> dict:
             api_key = read_codex_api_key()
         except Exception:
             api_key = None
-        if not api_key:
-            with CONFIG_LOCK:
-                try:
-                    existing = load_config()
-                    stored = getattr(getattr(existing, "agents", None), "codex", None)
-                    api_key = getattr(stored, "api_key", None) or None
-                except Exception:
-                    api_key = None
-        if not api_key:
-            return {"ok": False, "message": "api_key is required when auth_mode='api_key'"}
-
-    # Resolve the effective base_url: explicit payload wins, otherwise
-    # preserve whatever V2Config currently has.
-    if base_url_present:
-        effective_base_url = base_url_change
-    else:
-        with CONFIG_LOCK:
-            try:
-                existing_cfg = load_config()
-                stored_codex = getattr(getattr(existing_cfg, "agents", None), "codex", None)
-                effective_base_url = getattr(stored_codex, "base_url", None) or None
-            except Exception:
-                effective_base_url = None
-
     from vibe.codex_config import apply_codex_auth
 
     notices: list = []
-    try:
-        result = apply_codex_auth(
-            auth_mode=auth_mode, api_key=api_key, base_url=effective_base_url
-        )
-        if isinstance(result, dict):
-            raw_notices = result.get("notices")
-            if isinstance(raw_notices, list):
-                notices = raw_notices
-    except ValueError as exc:
-        return {"ok": False, "message": str(exc)}
-    except OSError as exc:
-        logger.error("Failed to write Codex auth files: %s", exc, exc_info=True)
-        return {"ok": False, "message": f"Failed to write Codex config: {exc}"}
-
     with config_write_transaction():
         try:
             config = load_config()
         except FileNotFoundError:
             config = V2Config()
+        stored_codex = getattr(getattr(config, "agents", None), "codex", None)
+        if auth_mode == "api_key" and not api_key:
+            api_key = getattr(stored_codex, "api_key", None) or None
+            if not api_key:
+                return {
+                    "ok": False,
+                    "message": "api_key is required when auth_mode='api_key'",
+                }
+        effective_base_url = (
+            base_url_change
+            if base_url_present
+            else getattr(stored_codex, "base_url", None) or None
+        )
+        try:
+            result = apply_codex_auth(
+                auth_mode=auth_mode,
+                api_key=api_key,
+                base_url=effective_base_url,
+            )
+            if isinstance(result, dict):
+                raw_notices = result.get("notices")
+                if isinstance(raw_notices, list):
+                    notices = raw_notices
+        except ValueError as exc:
+            return {"ok": False, "message": str(exc)}
+        except OSError as exc:
+            logger.error("Failed to write Codex auth files: %s", exc, exc_info=True)
+            return {"ok": False, "message": f"Failed to write Codex config: {exc}"}
         config.agents.codex.auth_mode = auth_mode
         config.agents.codex.api_key = api_key if auth_mode == "api_key" else None
         config.agents.codex.base_url = effective_base_url

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -10507,15 +10507,21 @@ async def save_opencode_custom_provider_async(payload: dict) -> dict:
             restart = {"ok": False, "message": str(exc)}
         _OPENCODE_OPTIONS_CACHE.clear()
         if not auth_result.get("ok"):
-            return {
+            failure = {
                 "ok": False,
                 "partial": True,
                 "saved": True,
                 "mutation_attempted": True,
                 "provider_id": provider_id.strip().lower(),
-                "message": auth_result.get("message") or "Provider saved, but API key save failed",
                 "restart": restart,
             }
+            error_code = auth_result.get("error_code")
+            message = auth_result.get("message")
+            if isinstance(error_code, str) and error_code:
+                failure["error_code"] = error_code
+            elif isinstance(message, str) and message:
+                failure["message"] = message
+            return failure
 
     catalog_refresh = await _refresh_opencode_provider_catalog_async(
         provider_id.strip().lower(),
@@ -10541,6 +10547,7 @@ async def delete_opencode_custom_provider_async(provider_id: str) -> dict:
     pid = provider_id.strip().lower()
     settlement: CancellationSettlement | None = None
     mutation_started = False
+    removed_fact: bool | None = False
     try:
         from vibe.opencode_config import (
             is_opencode_custom_provider,
@@ -10565,6 +10572,7 @@ async def delete_opencode_custom_provider_async(provider_id: str) -> dict:
                 _delete_opencode_provider_auth_async(pid)
             )
             mutation_started = bool(auth_result.get("mutation_attempted"))
+            removed_fact = auth_result.get("removed")
             if not auth_result.get("ok"):
                 restart = None
                 if mutation_started:
@@ -10579,13 +10587,17 @@ async def delete_opencode_custom_provider_async(provider_id: str) -> dict:
                     str(auth_result.get("message") or "Provider auth removal failed"),
                     restart,
                     mutation_attempted=mutation_started,
+                    removed=removed_fact,
                 )
+        if removed_fact is not True:
+            removed_fact = None
         mutation_started = True
         await settlement.run_blocking(
             remove_opencode_custom_provider,
             pid,
             logger_instance=logger,
         )
+        removed_fact = True
     except (Exception, asyncio.CancelledError) as exc:
         restart = None
         if settlement is not None and mutation_started:
@@ -10605,6 +10617,7 @@ async def delete_opencode_custom_provider_async(provider_id: str) -> dict:
             str(exc),
             restart,
             mutation_attempted=mutation_started,
+            removed=removed_fact,
         )
 
     restart = await _settle_opencode_delete_runtime(
@@ -10621,7 +10634,13 @@ async def delete_opencode_custom_provider_async(provider_id: str) -> dict:
     )
     if partial is not None:
         return partial
-    return {"ok": True, "provider_id": pid, "restart": restart}
+    return {
+        "ok": True,
+        "provider_id": pid,
+        "mutation_attempted": True,
+        "removed": True,
+        "restart": restart,
+    }
 
 
 def delete_opencode_custom_provider(provider_id: str) -> dict:
@@ -10829,15 +10848,11 @@ async def _save_opencode_provider_auth_async(
             if provider_id in auth_entries:
                 auth_cleanup = await _delete_opencode_provider_auth_async(provider_id)
                 if not auth_cleanup.get("ok"):
-                    cleanup_message = auth_cleanup.get("message")
                     return {
                         "ok": False,
                         "mutation_attempted": mutation_attempted,
                         "saved": saved,
-                        "message": (
-                            "API key saved, but stale OpenCode auth cleanup failed"
-                            + (f": {cleanup_message}" if cleanup_message else "")
-                        ),
+                        "error_code": "opencode_stale_auth_cleanup_failed",
                     }
         except Exception as exc:
             logger.warning(
@@ -10850,10 +10865,7 @@ async def _save_opencode_provider_auth_async(
                 "ok": False,
                 "mutation_attempted": mutation_attempted,
                 "saved": saved,
-                "message": (
-                    "API key saved, but stale OpenCode auth cleanup failed: "
-                    f"{exc}"
-                ),
+                "error_code": "opencode_stale_auth_cleanup_failed",
             }
 
     # ``baseURL`` is different: OpenCode's auth endpoint has no field for

--- a/vibe/i18n/en.json
+++ b/vibe/i18n/en.json
@@ -746,6 +746,7 @@
       "mode_switch_blocked": "This operation is blocked by the current supply mode or selection.",
       "engine_down": "The local Model Hub runtime is unavailable.",
       "consent_required": "Explicit consent is required for experimental subscription routing.",
+      "config_conflict": "Model Hub settings changed while this update was in progress. Reload and try again.",
       "migration_item_conflict": "This migration item conflicts with current Model Hub state.",
       "stream_interrupted": "The upstream stream was interrupted.",
       "upstream_protocol_error": "The upstream response did not match the expected protocol.",

--- a/vibe/i18n/zh.json
+++ b/vibe/i18n/zh.json
@@ -746,6 +746,7 @@
       "mode_switch_blocked": "当前供给模式或选择阻止了此操作。",
       "engine_down": "本地模型中枢运行时不可用。",
       "consent_required": "实验性订阅路由需要明确同意。",
+      "config_conflict": "更新期间模型中枢设置发生了变化。请重新加载后重试。",
       "migration_item_conflict": "此迁移项与当前模型中枢状态冲突。",
       "stream_interrupted": "上游流已中断。",
       "upstream_protocol_error": "上游响应不符合预期协议。",

--- a/vibe/remote_access.py
+++ b/vibe/remote_access.py
@@ -37,7 +37,7 @@ import requests
 from jwt import PyJWKClient
 
 from config import paths
-from config.v2_config import CONFIG_LOCK, V2Config
+from config.v2_config import CONFIG_LOCK, V2Config, config_write_transaction
 from vibe import api, cloudflare_network, runtime
 from vibe import tunnel_quality
 
@@ -2551,8 +2551,12 @@ def stop(config: V2Config | None = None) -> dict[str, Any]:
 
 
 def rotate_session_secret(config: V2Config) -> None:
-    config.remote_access.vibe_cloud.session_secret = secrets.token_urlsafe(32)
-    config.save()
+    session_secret = secrets.token_urlsafe(32)
+    with config_write_transaction():
+        persisted = V2Config.load()
+        persisted.remote_access.vibe_cloud.session_secret = session_secret
+        persisted.save()
+    config.remote_access.vibe_cloud.session_secret = session_secret
 
 
 def start(config: V2Config | None = None) -> dict[str, Any]:

--- a/vibe/remote_access.py
+++ b/vibe/remote_access.py
@@ -1025,21 +1025,19 @@ def apply_settings(payload: dict[str, Any]) -> dict[str, Any]:
                 candidate_config = api.save_config(
                     {"remote_access": {"vibe_cloud": payload}}
                 )
-            try:
-                replaced = _promote_candidate_connector(
-                    candidate_pid,
-                    runtime_signature=_runtime_signature(candidate_config, binary),
-                )
-            except Exception:
-                with config_write_transaction():
+                try:
+                    replaced = _promote_candidate_connector(
+                        candidate_pid,
+                        runtime_signature=_runtime_signature(candidate_config, binary),
+                    )
+                except Exception:
                     persisted = V2Config.load()
-                    # Never roll an older candidate over a newer settings writer.
                     if _remote_access_settings(persisted) == candidate_settings:
                         api.save_config(
                             {"remote_access": {"vibe_cloud": previous_settings}},
                             validate_remote_access_network=False,
                         )
-                raise
+                    raise
     except Exception as exc:
         if candidate_pid is not None:
             _discard_candidate_connector(candidate_pid)

--- a/vibe/remote_access.py
+++ b/vibe/remote_access.py
@@ -37,7 +37,7 @@ import requests
 from jwt import PyJWKClient
 
 from config import paths
-from config.v2_config import CONFIG_LOCK, V2Config, config_write_transaction
+from config.v2_config import V2Config, config_write_transaction
 from vibe import api, cloudflare_network, runtime
 from vibe import tunnel_quality
 
@@ -939,27 +939,28 @@ def apply_settings(payload: dict[str, Any]) -> dict[str, Any]:
                 "error": "remote_access_settings_unavailable",
             }
         with _CONNECTOR_LOCK:
-            live_config = V2Config.load()
-            live_status = status(live_config)
-            if (
-                live_status.get("pid_state") == "unknown"
-                or _remote_access_settings(live_config) != previous_settings
-            ):
-                return {
-                    **live_status,
-                    "ok": False,
-                    "error": "remote_access_settings_unavailable",
-                }
-            if not live_status.get("running"):
-                candidate_config = api.save_config(
-                    {"remote_access": {"vibe_cloud": payload}}
-                )
-                return {
-                    **status(candidate_config),
-                    "ok": True,
-                    "settings_applied": True,
-                    "connector_replaced": False,
-                }
+            with config_write_transaction():
+                live_config = V2Config.load()
+                live_status = status(live_config)
+                if (
+                    live_status.get("pid_state") == "unknown"
+                    or _remote_access_settings(live_config) != previous_settings
+                ):
+                    return {
+                        **live_status,
+                        "ok": False,
+                        "error": "remote_access_settings_unavailable",
+                    }
+                if not live_status.get("running"):
+                    candidate_config = api.save_config(
+                        {"remote_access": {"vibe_cloud": payload}}
+                    )
+                    return {
+                        **status(candidate_config),
+                        "ok": True,
+                        "settings_applied": True,
+                        "connector_replaced": False,
+                    }
 
     current_status = live_status
 
@@ -1010,7 +1011,7 @@ def apply_settings(payload: dict[str, Any]) -> dict[str, Any]:
             if not _wait_candidate_ready(candidate_pid, metrics_url):
                 raise RuntimeError("candidate_not_ready")
         with _CONNECTOR_LOCK:
-            with CONFIG_LOCK:
+            with config_write_transaction():
                 live_config = V2Config.load()
                 live_binary = _resolve_binary(live_config)
                 if (
@@ -1030,11 +1031,14 @@ def apply_settings(payload: dict[str, Any]) -> dict[str, Any]:
                     runtime_signature=_runtime_signature(candidate_config, binary),
                 )
             except Exception:
-                with CONFIG_LOCK:
-                    api.save_config(
-                        {"remote_access": {"vibe_cloud": previous_settings}},
-                        validate_remote_access_network=False,
-                    )
+                with config_write_transaction():
+                    persisted = V2Config.load()
+                    # Never roll an older candidate over a newer settings writer.
+                    if _remote_access_settings(persisted) == candidate_settings:
+                        api.save_config(
+                            {"remote_access": {"vibe_cloud": previous_settings}},
+                            validate_remote_access_network=False,
+                        )
                 raise
     except Exception as exc:
         if candidate_pid is not None:

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -38,6 +38,7 @@ from vibe.ui_compat import CompatApp, Response, TEST_REMOTE_ADDR_HEADER, g, json
 
 from config import paths
 from config.v2_config import V2Config, config_write_transaction
+from core.blocking import CancellationSettlement, run_blocking
 from core.show_pages import (
     SHOW_CLI_EVENT_TOKEN_HEADER,
     SHOW_EVENT_WRITE_TOKEN_COOKIE,
@@ -4688,80 +4689,98 @@ async def config_post():
 
     payload = request.json or {}
     remote_access_runtime = None
+    settlement = CancellationSettlement()
     try:
         (
             config,
             should_reconcile_remote_access,
             should_reconcile_platforms,
             changed_agent_backends,
-        ) = await asyncio.to_thread(
+        ) = await settlement.run_blocking(
             _save_config_and_runtime_decisions,
             payload,
         )
     except ValueError as exc:
+        settlement.raise_if_cancelled(exc)
         message = str(exc)
         return jsonify({"ok": False, "error": message, "message": message}), 400
-    if should_reconcile_remote_access:
-        remote_access_runtime = await asyncio.to_thread(remote_access.reconcile)
-    await asyncio.to_thread(_ensure_remote_access_monitoring, config)
-    platform_runtime = None
-    if should_reconcile_platforms:
-        try:
-            result = await internal_client.reconcile_platforms()
-            platform_runtime = {
-                "ok": result.get("status_code") == 200 and bool((result.get("body") or {}).get("ok")),
-                "hot_reconciled": result.get("status_code") == 200 and bool((result.get("body") or {}).get("ok")),
-                "body": result.get("body") or {},
-            }
-        except internal_client.InternalServerUnavailable as exc:
-            platform_runtime = {"ok": False, "hot_reconciled": False, "error": str(exc)}
-        if not platform_runtime.get("ok"):
-            restart_result = await asyncio.to_thread(_schedule_service_restart_for_config_fallback)
-            platform_runtime["restart_scheduled"] = bool(restart_result.get("ok"))
-            if restart_result.get("ok"):
-                platform_runtime["restart"] = restart_result.get("restart")
-            else:
-                platform_runtime["restart_error"] = restart_result.get("error")
-                platform_runtime["restart_code"] = restart_result.get("code")
-    agent_backend_runtime = None
-    if changed_agent_backends:
-        try:
-            result = await internal_client.reconcile_agent_backends(changed_agent_backends)
-            body = result.get("body") or {}
-            hot_reconciled = result.get("status_code") == 200 and bool(body.get("ok"))
-            agent_backend_runtime = {
-                "ok": hot_reconciled,
-                "hot_reconciled": hot_reconciled,
-                "backends": changed_agent_backends,
-                "body": body,
-            }
-        except internal_client.InternalServerUnavailable as exc:
-            agent_backend_runtime = {
-                "ok": False,
-                "hot_reconciled": False,
-                "backends": changed_agent_backends,
-                "error": str(exc),
-            }
+    except (Exception, asyncio.CancelledError) as exc:
+        settlement.raise_if_cancelled(exc)
+        raise
 
-        if not agent_backend_runtime.get("ok"):
-            from vibe import runtime
-
-            service_running = await asyncio.to_thread(runtime.service_process_running)
-            if service_running:
-                if platform_runtime and platform_runtime.get("restart_scheduled"):
-                    agent_backend_runtime["restart_scheduled"] = True
-                    if platform_runtime.get("restart"):
-                        agent_backend_runtime["restart"] = platform_runtime["restart"]
+    try:
+        if should_reconcile_remote_access:
+            remote_access_runtime = await settlement.run_blocking(remote_access.reconcile)
+        await settlement.run_blocking(_ensure_remote_access_monitoring, config)
+        platform_runtime = None
+        if should_reconcile_platforms:
+            try:
+                result = await settlement.wait(internal_client.reconcile_platforms())
+                platform_runtime = {
+                    "ok": result.get("status_code") == 200 and bool((result.get("body") or {}).get("ok")),
+                    "hot_reconciled": result.get("status_code") == 200
+                    and bool((result.get("body") or {}).get("ok")),
+                    "body": result.get("body") or {},
+                }
+            except internal_client.InternalServerUnavailable as exc:
+                platform_runtime = {"ok": False, "hot_reconciled": False, "error": str(exc)}
+            if not platform_runtime.get("ok"):
+                restart_result = await settlement.run_blocking(
+                    _schedule_service_restart_for_config_fallback
+                )
+                platform_runtime["restart_scheduled"] = bool(restart_result.get("ok"))
+                if restart_result.get("ok"):
+                    platform_runtime["restart"] = restart_result.get("restart")
                 else:
-                    restart_result = await asyncio.to_thread(_schedule_service_restart_for_config_fallback)
-                    agent_backend_runtime["restart_scheduled"] = bool(restart_result.get("ok"))
-                    if restart_result.get("ok"):
-                        agent_backend_runtime["restart"] = restart_result.get("restart")
+                    platform_runtime["restart_error"] = restart_result.get("error")
+                    platform_runtime["restart_code"] = restart_result.get("code")
+        agent_backend_runtime = None
+        if changed_agent_backends:
+            try:
+                result = await settlement.wait(
+                    internal_client.reconcile_agent_backends(changed_agent_backends)
+                )
+                body = result.get("body") or {}
+                hot_reconciled = result.get("status_code") == 200 and bool(body.get("ok"))
+                agent_backend_runtime = {
+                    "ok": hot_reconciled,
+                    "hot_reconciled": hot_reconciled,
+                    "backends": changed_agent_backends,
+                    "body": body,
+                }
+            except internal_client.InternalServerUnavailable as exc:
+                agent_backend_runtime = {
+                    "ok": False,
+                    "hot_reconciled": False,
+                    "backends": changed_agent_backends,
+                    "error": str(exc),
+                }
+
+            if not agent_backend_runtime.get("ok"):
+                from vibe import runtime
+
+                service_running = await settlement.run_blocking(runtime.service_process_running)
+                if service_running:
+                    if platform_runtime and platform_runtime.get("restart_scheduled"):
+                        agent_backend_runtime["restart_scheduled"] = True
+                        if platform_runtime.get("restart"):
+                            agent_backend_runtime["restart"] = platform_runtime["restart"]
                     else:
-                        agent_backend_runtime["restart_error"] = restart_result.get("error")
-                        agent_backend_runtime["restart_code"] = restart_result.get("code")
-            else:
-                agent_backend_runtime["apply_on_next_start"] = True
+                        restart_result = await settlement.run_blocking(
+                            _schedule_service_restart_for_config_fallback
+                        )
+                        agent_backend_runtime["restart_scheduled"] = bool(restart_result.get("ok"))
+                        if restart_result.get("ok"):
+                            agent_backend_runtime["restart"] = restart_result.get("restart")
+                        else:
+                            agent_backend_runtime["restart_error"] = restart_result.get("error")
+                            agent_backend_runtime["restart_code"] = restart_result.get("code")
+                else:
+                    agent_backend_runtime["apply_on_next_start"] = True
+    except (Exception, asyncio.CancelledError) as exc:
+        settlement.raise_if_cancelled(exc)
+        raise
+    settlement.raise_if_cancelled()
     response_payload = api.client_config_payload(config)
     if remote_access_runtime is not None:
         response_payload["remote_access_runtime"] = remote_access_runtime
@@ -5404,7 +5423,7 @@ async def wechat_qr_login_poll():
         user_id = result["user_id"]
 
         try:
-            _persist_wechat_qr_credentials(result)
+            await run_blocking(_persist_wechat_qr_credentials, result)
         except Exception as exc:
             logger.error("Failed to persist WeChat QR credentials: %s", exc)
             return jsonify({"ok": False, "error": "failed_to_persist_wechat_credentials"}), 500

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -37,7 +37,7 @@ from starlette.formparsers import MultiPartException, MultiPartParser
 from vibe.ui_compat import CompatApp, Response, TEST_REMOTE_ADDR_HEADER, g, jsonify, redirect, request, send_file
 
 from config import paths
-from config.v2_config import CONFIG_LOCK, V2Config
+from config.v2_config import V2Config, config_write_transaction
 from core.show_pages import (
     SHOW_CLI_EVENT_TOKEN_HEADER,
     SHOW_EVENT_WRITE_TOKEN_COOKIE,
@@ -4602,7 +4602,7 @@ def _save_config_and_runtime_decisions(payload: dict) -> tuple[V2Config, bool, b
     from vibe import api
     from vibe import remote_access
 
-    with CONFIG_LOCK:
+    with config_write_transaction():
         previous_config = _load_remote_access_config()
         config = api.save_config(payload, generic_remote_access=True)
         should_reconcile_remote_access = False

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -5421,26 +5421,38 @@ async def wechat_qr_login_poll():
     # If confirmed, auto-bind the WeChat user
     if result.get("status") == "confirmed" and result.get("bot_token") and result.get("user_id"):
         user_id = result["user_id"]
+        settlement = CancellationSettlement()
 
         try:
-            await run_blocking(_persist_wechat_qr_credentials, result)
-        except Exception as exc:
+            await settlement.run_blocking(_persist_wechat_qr_credentials, result)
+        except (Exception, asyncio.CancelledError) as exc:
+            settlement.raise_if_cancelled(exc)
+            if isinstance(exc, asyncio.CancelledError):
+                raise
             logger.error("Failed to persist WeChat QR credentials: %s", exc)
             return jsonify({"ok": False, "error": "failed_to_persist_wechat_credentials"}), 500
 
         # Auto-bind user
+        settlement_cause: BaseException | None = None
         try:
             from vibe import api as vibe_api
 
-            vibe_api.auto_bind_wechat_user(user_id)
-        except Exception as e:
+            await settlement.run_blocking(vibe_api.auto_bind_wechat_user, user_id)
+        except (Exception, asyncio.CancelledError) as e:
+            if isinstance(e, asyncio.CancelledError) and not settlement.cancelled:
+                raise
+            settlement_cause = e
             logger.warning("Failed to auto-bind WeChat user: %s", e)
 
         try:
-            restart = _schedule_wechat_qr_login_restart()
+            restart = await settlement.run_blocking(_schedule_wechat_qr_login_restart)
             logger.info("Scheduled service restart after WeChat QR login: %s", restart.get("job_id"))
-        except Exception as exc:
+        except (Exception, asyncio.CancelledError) as exc:
+            if isinstance(exc, asyncio.CancelledError) and not settlement.cancelled:
+                raise
+            settlement_cause = settlement_cause or exc
             logger.warning("Failed to schedule service restart after WeChat QR login: %s", exc)
+        settlement.raise_if_cancelled(settlement_cause)
 
     return jsonify(result)
 


### PR DESCRIPTION
## Capability

Make config persistence an atomic cross-process read/merge/write transaction so independent configuration owners cannot overwrite each other from stale snapshots. `V2Config.save()` retains its complete-object write contract; preservation of the persisted Memory block is explicit for generic/stale writers.

## Scope

- add a bounded, same-path-reentrant config transaction using the existing `MigrationFileLock`
- acquire the cross-process lock before `CONFIG_LOCK` so contended writers do not block same-process readers
- serialize `save_config()` from its initial read through its final atomic replace
- keep direct `V2Config.save()` mutations, including intentional Memory changes, complete-object writes
- wrap production read-modify-write owners including Model Hub, Claude/Codex auth and credential files, OpenCode default-provider and CLI-path updates, language persistence, remote session-secret rotation, UI runtime decisions, and Memory marker settlement
- offload Model Hub, backend OAuth, Telegram language, and async OpenCode config persistence from event loops with cancellation settlement through a shared core seam
- keep Remote Access compare/save/promotion/rollback under `_CONNECTOR_LOCK -> config transaction` ordering
- keep dedicated Memory writes authorized and exact-checked

## Evidence

- Config/API/Auth/Settings/Tunnel shared-lock suite: 287 passed
- Model Hub: 436 passed; off-loop, repeated-cancellation live reconciliation, child-cancellation rollback, and pre-spawn restoration contracts included
- Changed cancellation-settlement files: 190 passed; AgentAuth cancellation focus: 15 passed; prior CI regressions: 2 passed
- Runtime: `tests/test_memory_runtime.py` 110 passed
- Lock ordering: deterministic spawned-process/thread test proves a writer waiting on the file lock does not block `V2Config.load()`
- Contract: deterministic stale general, stale Memory, Model Hub/general-config, Claude/Codex preserved auth, API-key remove-vs-save, backend-auth stale-controller, Remote Access promotion, Telegram disk/live settlement, OpenCode disk/cache/restart settlement, and UI A-to-B-to-A runtime-decision interleavings
- Static: Ruff on all changed Python files, Python compile, and `git diff --check`
- Scenario IDs: `RA-TQ-028`
- Residual manual checks: none; persistence probes are hermetic and use test-owned `AVIBE_HOME` paths

The broad `tests/test_remote_access_vibe_cloud.py` run passed 102 tests; two unrelated macOS system-proxy isolation tests attempted real TLS and timed out locally.
