### PR TITLE
fix(codex): recover sessions after transport death

### DIFF
--- a/core/runtime_ownership.py
+++ b/core/runtime_ownership.py
@@ -154,6 +154,23 @@ class RuntimeTargetOwnershipSnapshot:
         )
 
     @property
+    def blocks_dead_transport_replacement(self) -> bool:
+        """Whether native effects can outlive a definitively dead transport.
+
+        Delivery, Turn, and Run ownership may remain active until shared
+        terminal convergence finishes, but none of those rows can keep a dead
+        backend process executing. Activities can own child effects beyond the
+        transport lifetime, and an unknown snapshot must still fail closed.
+        """
+
+        if self.disposition is SessionRuntimeDisposition.UNKNOWN:
+            return True
+        return bool(
+            self.sessionless_active_activity_ids
+            or any(session.active_activity_ids for session in self.sessions)
+        )
+
+    @property
     def has_runnable_deliveries(self) -> bool:
         return any(
             any(reason == "delivery:queued" for reason in session.reasons)

--- a/docs/plans/harness-watch-run-failure-boundary.md
+++ b/docs/plans/harness-watch-run-failure-boundary.md
@@ -66,6 +66,12 @@ snapshot plus the indexed Delivery-to-Turn ownership relation, not a Run-history
 scan. Canceled and cancel-requested parents are excluded only before a callback is
 armed; an accepted callback child remains delivery evidence after parent cancellation.
 
+After the shared liveness monitor terminalizes a Turn whose Codex app-server is
+definitively dead, the next request may retire that exact dead generation despite
+its stale process-local Turn fence. Unknown ownership and active Activities still
+block replacement because their native effects can outlive the transport; Delivery,
+Turn, and Run rows do not make a dead process reusable.
+
 Terminal output replay is idempotent for status and content but monotonic for
 delivery evidence. A later same-Turn notification acknowledgement upgrades the
 existing owed notice without resetting its attempts, state, or fallback owner, so
@@ -182,6 +188,9 @@ does not claim that an event was detected.
   carries its acknowledgement into the same monotonic contract. All visible
   paths resolve the Harness delivery override before sending or persisting, so
   acknowledgement can never be attributed to a different target.
+- `HFR-473`: a definitively dead Codex transport can be replaced for the next
+  request even while stale Turn ownership from that dead generation remains;
+  unknown ownership and active Activities continue to fail closed.
 
 Residual manual check: trigger two one-shot Watches into one failing Turn and
 confirm that the conversation contains one backend error, both Runs are failed,

--- a/modules/agents/codex/agent.py
+++ b/modules/agents/codex/agent.py
@@ -1561,6 +1561,10 @@ class CodexAgent(BaseAgent):
             async with self._transport_locks[cwd]:
                 # Double-check after acquiring lock
                 existing = self._transports.get(cwd)
+                existing_dead = bool(
+                    existing is not None
+                    and self._transport_alive(existing) is False
+                )
                 desired_fingerprint = launch.fingerprint if launch is not None else "direct"
                 existing_fingerprint = getattr(existing, "runtime_fingerprint", "direct")
                 runtime_changed = existing_fingerprint != desired_fingerprint
@@ -1599,14 +1603,22 @@ class CodexAgent(BaseAgent):
                             ownership = (
                                 await self._runtime_ownership_snapshot_for_cwd_async(cwd)
                             )
+                            replacement_blocked = getattr(
+                                ownership,
+                                (
+                                    "blocks_dead_transport_replacement"
+                                    if existing_dead
+                                    else "blocks_transport_replacement"
+                                ),
+                                True,
+                            )
                             return bool(
                                 ownership is not None
-                                and not getattr(
-                                    ownership,
-                                    "blocks_transport_replacement",
-                                    True,
+                                and not replacement_blocked
+                                and (
+                                    existing_dead
+                                    or not self._has_active_turns_for_cwd(cwd)
                                 )
-                                and not self._has_active_turns_for_cwd(cwd)
                             )
 
                         detached = await self._stop_and_detach_transport_generation(

--- a/tests/scenarios/harness_failure_recovery/catalog.yaml
+++ b/tests/scenarios/harness_failure_recovery/catalog.yaml
@@ -4246,6 +4246,15 @@ scenarios:
     # shown primary at its resolved delivery target, and atomic settlement elects
     # one owner only when Runs exist.
     test: tests/test_message_dispatcher_result_fallback.py::MessageDispatcherResultFallbackTests::test_hfr_472_empty_failed_turn_creates_one_shared_fallback_contract
+  - id: HFR-473
+    name: dead Codex transport releases its stale Turn fence for the next request
+    status: covered
+    kind: failure_recovery
+    layer: scenario
+    backend: codex
+    # A definitive process death makes the old local Turn fence non-authoritative;
+    # only unknown ownership or an active Activity can still veto replacement.
+    test: tests/test_codex_agent.py::CodexTransportCwdStalenessTests::test_hfr_473_dead_transport_restarts_past_stale_turn_ownership
 manual_evidence:
   - local Incus backend process death after prompt acceptance
   - local Incus controller restart with persisted queued successor

--- a/tests/test_codex_agent.py
+++ b/tests/test_codex_agent.py
@@ -3899,6 +3899,80 @@ class CodexTransportCwdStalenessTests(unittest.IsolatedAsyncioTestCase):
             stale.stop.assert_not_awaited()
             self.assertIs(agent._transports[cwd], stale)
 
+    async def test_hfr_473_dead_transport_restarts_past_stale_turn_ownership(self):
+        import tempfile
+
+        agent = self._agent()
+        with tempfile.TemporaryDirectory() as cwd:
+            dead = SimpleNamespace(
+                is_initialized=False,
+                is_alive=False,
+                has_pending_notifications=False,
+                runtime_fingerprint="direct",
+                stop=AsyncMock(),
+            )
+            agent._transports[cwd] = dead
+            agent._transport_cwd_inodes[cwd] = os.stat(cwd).st_ino
+            agent._runtime_ownership_snapshot_for_cwd = Mock(
+                return_value=SimpleNamespace(
+                    blocks_transport_replacement=True,
+                    blocks_dead_transport_replacement=False,
+                )
+            )
+            agent._session_mgr = SimpleNamespace(
+                sessions_for_cwd=Mock(return_value=["session-1"]),
+                invalidate_thread=Mock(),
+            )
+            agent._turn_registry = SimpleNamespace(
+                get_active_turn=Mock(return_value="turn-from-dead-generation"),
+                has_pending_turn_start=Mock(return_value=False),
+                clear_session=Mock(),
+            )
+            agent._clear_thread_developer_instructions = Mock()
+            fresh = SimpleNamespace(
+                is_initialized=True,
+                pid=2468,
+                start=AsyncMock(),
+                on_notification=Mock(),
+                on_server_request=Mock(),
+            )
+
+            with patch.object(_MODULE, "CodexTransport", return_value=fresh):
+                result = await agent._get_or_create_transport(cwd)
+
+            self.assertIs(result, fresh)
+            dead.stop.assert_awaited_once()
+            fresh.start.assert_awaited_once()
+            agent._session_mgr.invalidate_thread.assert_called_once_with("session-1")
+            agent._turn_registry.clear_session.assert_called_once_with("session-1")
+
+    async def test_dead_transport_preserves_generation_with_active_activity_owner(self):
+        import tempfile
+
+        agent = self._agent()
+        with tempfile.TemporaryDirectory() as cwd:
+            dead = SimpleNamespace(
+                is_initialized=False,
+                is_alive=False,
+                has_pending_notifications=False,
+                runtime_fingerprint="direct",
+                stop=AsyncMock(),
+            )
+            agent._transports[cwd] = dead
+            agent._transport_cwd_inodes[cwd] = os.stat(cwd).st_ino
+            agent._runtime_ownership_snapshot_for_cwd = Mock(
+                return_value=SimpleNamespace(
+                    blocks_transport_replacement=True,
+                    blocks_dead_transport_replacement=True,
+                )
+            )
+
+            with self.assertRaisesRegex(RuntimeError, "durable owner"):
+                await agent._get_or_create_transport(cwd)
+
+            dead.stop.assert_not_awaited()
+            self.assertIs(agent._transports[cwd], dead)
+
     async def test_runtime_change_preserves_transport_with_pid_run_owner(self):
         import tempfile
 

--- a/tests/test_runtime_ownership.py
+++ b/tests/test_runtime_ownership.py
@@ -606,7 +606,7 @@ def test_snapshot_many_reads_backend_owner_tables_once(tmp_path: Path) -> None:
 
 
 @pytest.mark.parametrize(
-    ("snapshot", "expected"),
+    ("snapshot", "expected", "dead_expected"),
     (
         (
             RuntimeTargetOwnershipSnapshot(
@@ -619,6 +619,7 @@ def test_snapshot_many_reads_backend_owner_tables_once(tmp_path: Path) -> None:
                 disposition=SessionRuntimeDisposition.UNKNOWN,
             ),
             True,
+            True,
         ),
         (
             RuntimeTargetOwnershipSnapshot(
@@ -630,6 +631,7 @@ def test_snapshot_many_reads_backend_owner_tables_once(tmp_path: Path) -> None:
                 sessionless_fallback_run_ids=(),
                 disposition=SessionRuntimeDisposition.ACTIVE,
             ),
+            True,
             True,
         ),
         (
@@ -644,6 +646,7 @@ def test_snapshot_many_reads_backend_owner_tables_once(tmp_path: Path) -> None:
                 reasons=("run:run-a:active",),
             ),
             True,
+            False,
         ),
         (
             RuntimeTargetOwnershipSnapshot(
@@ -665,6 +668,7 @@ def test_snapshot_many_reads_backend_owner_tables_once(tmp_path: Path) -> None:
                 sessionless_fallback_run_ids=(),
                 disposition=SessionRuntimeDisposition.ACTIVE,
             ),
+            False,
             False,
         ),
         (
@@ -688,14 +692,17 @@ def test_snapshot_many_reads_backend_owner_tables_once(tmp_path: Path) -> None:
                 disposition=SessionRuntimeDisposition.ACTIVE,
             ),
             True,
+            False,
         ),
     ),
 )
 def test_transport_replacement_gate_tracks_only_durable_native_effect_owners(
     snapshot: RuntimeTargetOwnershipSnapshot,
     expected: bool,
+    dead_expected: bool,
 ) -> None:
     assert snapshot.blocks_transport_replacement is expected
+    assert snapshot.blocks_dead_transport_replacement is dead_expected
 
 
 def _codex_reclaimer(engine, bindings: list[tuple[str, str, str, str]]):


### PR DESCRIPTION
## Capability

Recover an existing Codex Agent Session after its cached app-server process dies, without letting stale Turn or Run ownership veto replacement of a definitively dead transport.

Unknown runtime ownership and active Activities still block replacement because they may own native effects beyond the transport lifetime.

## Scenarios

- HFR-473: replace a definitively dead Codex transport past stale Turn ownership while preserving the Activity fail-closed boundary.
- HFR-472: retain one shared backend-failure notice when two Watch Runs share the failed Turn.

## Evidence

- Unit: `tests/test_codex_agent.py` and `tests/test_runtime_ownership.py` (155 passed).
- Contract: normal replacement continues to honor Delivery, Turn, Run, Activity, and unknown ownership; only the definitively-dead path narrows the blocker to Activity and unknown ownership.
- Scenario: local Incus worktree regression admitted two one-shot Watches into one Codex Turn, killed the exact app-server generation after `sleep 120` started, observed two failed Runs and exactly one failure notice, then successfully continued the same Session with `SESSION_RECOVERED`.
- Residual manual checks: none; this change has no UI surface.

## Risk

Replacement remains serialized under the per-working-directory transport lock and the exact runtime-activation retirement reservation. A failed ownership snapshot or active Activity continues to fail closed.
