### PR TITLE
test(watches): make lifetime expiry control deterministic

### DIFF
--- a/tests/test_watches.py
+++ b/tests/test_watches.py
@@ -3918,9 +3918,38 @@ def test_run_watch_enqueues_the_branch_hook_when_the_result_stamp_lands(tmp_path
     reached at all. Here the same wiring, minus the reclaim, must enqueue exactly one
     hook carrying that branch's own text.
     """
-    _store, service, watch, request_store, _session_id, calls = _hook_branch_service(tmp_path, branch)
+    store, service, watch, request_store, _session_id, calls = _hook_branch_service(tmp_path, branch)
 
-    asyncio.run(service._run_watch(watch.id))
+    async def _run() -> None:
+        if branch != "lifetime_expiry":
+            await service._run_watch(watch.id)
+            return
+
+        # The lifetime now begins when the Watch is created, so a tiny real-time
+        # deadline can expire during fixture setup on a busy CI runner. Hold a wide
+        # deadline until the retry result has landed, then expire it from the exact
+        # monotonic origin that _run_watch is using.
+        watch.lifetime_timeout_seconds = 60
+        store.upsert_watch(watch)
+        cycle_completed = asyncio.Event()
+        release_cycle = asyncio.Event()
+
+        async def _expire_after_completed_cycle(watch_arg, *, lifetime_started):  # noqa: ANN001
+            cycle_completed.set()
+            await release_cycle.wait()
+            watch_arg.lifetime_timeout_seconds = max(
+                asyncio.get_running_loop().time() - lifetime_started,
+                sys.float_info.min,
+            )
+            store.upsert_watch(watch_arg)
+
+        service._sleep_before_retry = _expire_after_completed_cycle  # type: ignore[method-assign]
+        task = asyncio.create_task(service._run_watch(watch.id))
+        await asyncio.wait_for(cycle_completed.wait(), timeout=2)
+        release_cycle.set()
+        await asyncio.wait_for(task, timeout=2)
+
+    asyncio.run(_run())
 
     _assert_branch_was_reached(branch, calls)
     pending = request_store.list_pending()


### PR DESCRIPTION
## Summary

- make the HFR-267 lifetime-expiry control wait until its retry cycle has completed
- expire the Watch from the exact monotonic lifetime origin instead of relying on a 20 ms scheduler window
- keep production behavior and the existing hook assertions unchanged

## Root Cause

#1304 made Watch lifetime start at the durable definition creation time. The control test still assumed lifetime began when `_run_watch` started, so a busy CI shard could consume its 20 ms lifetime during setup and retire the Watch before the first cycle.

## Evidence

- Unit: reproduced before the fix with 50 target invocations under 25-way local load; the same assertion failed multiple times
- Unit: target case passed 50/50 with `pytest-repeat` after the fix
- Unit: `tests/test_watches.py` passed 120/120
- Contract: the exact-one-hook and branch-reached assertions are unchanged
- Scenario: HFR-267
- Residual manual checks: none; this is test-only and changes no product behavior

## Dependencies

None.
