### PR TITLE
fix(auth): open org workbench apps remotely

### DIFF
--- a/docs/plans/2026-08-11-org-remote-apps-temporary-access.md
+++ b/docs/plans/2026-08-11-org-remote-apps-temporary-access.md
@@ -1,0 +1,36 @@
+# Temporary Organization Remote App Access
+
+## Decision
+
+Until the authorization model in [#1313](https://github.com/avibe-bot/avibe/issues/1313)
+ships, every authenticated active Organization member may use Apps, Files,
+Editor, Terminal, and Show Pages through remote access. This rollout rule is
+not projected as a capability and does not add an App ACL.
+
+## Open Surfaces
+
+- Apps launcher, Dock, Window Layer, and the complete built-in App Library
+- the explicit `/api/files/*` endpoints used by Files and Editor, plus Files favorites
+- Terminal WebSocket connections and subject-scoped session deletion
+- authenticated Show Page inventory, content, mutations, Dock pins, events,
+  annotations, icons, and HMR
+
+## Retained Boundaries
+
+- Organization management keeps its existing Cloud authorization boundary.
+- Config and service control, Harness, Vault, and unknown local-only routes
+  remain fail-closed.
+- Terminal requests still require an exact allowed Origin, a signed remote
+  session, active Organization membership, authorization refresh, and
+  subject-scoped session IDs.
+- Anonymous `/p/` sharing still serves only public pages.
+- `show_page_email` sessions remain confined to their signed page subtree
+  (`AUTH-SETUP-401`).
+- Persisted Project and Show Page ACL services remain intact; only qualifying
+  remote Organization requests receive a request-scoped temporary bypass.
+
+## Removal
+
+Replace the exact temporary HTTP/WebSocket policy and Show Page resource-context
+bypass when #1313 defines and implements per-App capabilities and resource ACLs.
+The replacement must preserve fail-closed handling for new or unknown endpoints.

--- a/tests/scenario_harness/show_page_email_access.py
+++ b/tests/scenario_harness/show_page_email_access.py
@@ -70,14 +70,25 @@ class ShowPageEmailAccessScenarioHarness:
 
     def begin_login(self, show_page_id: str) -> dict[str, str]:
         next_path = f"/show/{show_page_id}/__show/me"
-        response = self.client.get(
+        navigation = self.client.get(
             next_path,
             base_url=REMOTE_ORIGIN,
             environ_base=REMOTE_PEER,
+            headers={"Accept": "text/html"},
             follow_redirects=False,
         )
-        assert response.status_code == 302
-        authorize_params = httpx.URL(response.headers["Location"]).params
+        assert navigation.status_code == 302
+        authorize_url = navigation.headers["Location"]
+        if authorize_url.startswith("/auth/login?"):
+            response = self.client.get(
+                authorize_url,
+                base_url=REMOTE_ORIGIN,
+                environ_base=REMOTE_PEER,
+                follow_redirects=False,
+            )
+            assert response.status_code == 302
+            authorize_url = response.headers["Location"]
+        authorize_params = httpx.URL(authorize_url).params
         state = authorize_params["state"]
         state_payload = ui_server._read_oauth_state(
             self.config.remote_access.vibe_cloud.session_secret,

--- a/tests/test_dock_api.py
+++ b/tests/test_dock_api.py
@@ -68,6 +68,7 @@ def test_dock_default_is_builtins_only(monkeypatch, tmp_path):
 
     result = api.get_dock()
 
+    assert BUILTIN_DOCK_IDS == ("files", "terminal", "editor", "library")
     assert result["ok"] is True
     assert result["dock"]["order"] == list(BUILTIN_DOCK_IDS)
     assert result["dock"]["pins"] == []

--- a/tests/test_instance_authorization.py
+++ b/tests/test_instance_authorization.py
@@ -91,6 +91,25 @@ def test_temporary_org_app_access_is_not_projected_as_a_capability() -> None:
     ) is False
 
 
+def test_temporary_org_members_receive_show_events_at_viewer_instance_role() -> None:
+    member = AuthorizationContext(
+        instance_role="viewer",
+        organization_id="org-1",
+        organization_member_id="membership-1",
+        organization_role="member",
+        instance_access_source="organization_group",
+        is_remote=True,
+    )
+    non_member = AuthorizationContext(
+        instance_role="viewer",
+        instance_access_source="email",
+        is_remote=True,
+    )
+
+    assert can_receive_workbench_event(member, "show.event") is True
+    assert can_receive_workbench_event(non_member, "show.event") is False
+
+
 @pytest.mark.parametrize(
     ("role", "expected"),
     [
@@ -303,7 +322,7 @@ def test_remote_http_policy_defaults_local_machine_and_unknown_routes_to_local_o
         ("GET", "/api/backend/codex/runtime", REMOTE_HTTP_LOCAL_ONLY),
         ("GET", "/api/opencode/permission-status", REMOTE_HTTP_LOCAL_ONLY),
         ("GET", "/api/vault/audit", REMOTE_HTTP_ALLOWED),
-        ("GET", "/api/dock", REMOTE_HTTP_ALLOWED),
+        ("GET", "/api/dock", REMOTE_HTTP_ACTIVE_ORGANIZATION_MEMBER),
         ("POST", "/api/dock/pins", REMOTE_HTTP_ACTIVE_ORGANIZATION_MEMBER),
         ("PUT", "/api/dock/order", REMOTE_HTTP_ACTIVE_ORGANIZATION_MEMBER),
         # A push endpoint is caller-supplied and `send_web_push()` fetches it
@@ -369,6 +388,7 @@ def test_remote_http_policy_keeps_approved_management_and_read_surfaces(
     ("method", "path"),
     [
         ("POST", "/api/dock/pins"),
+        ("GET", "/api/dock"),
         ("DELETE", "/api/dock/pins/ses-1"),
         ("PUT", "/api/dock/order"),
         ("GET", "/api/files/list"),
@@ -508,7 +528,12 @@ def test_temporary_org_app_policy_does_not_open_adjacent_or_sensitive_endpoints(
         ("canAdministerMemory", "POST", "/api/memory/clear", REMOTE_HTTP_LOCAL_ONLY),
         # Dock is temporarily writable by active Organization members while
         # Workbench preferences remain a trusted-local control.
-        ("dockAndWorkbenchPrefs", "GET", "/api/dock", REMOTE_HTTP_ALLOWED),
+        (
+            "dockAndWorkbenchPrefs",
+            "GET",
+            "/api/dock",
+            REMOTE_HTTP_ACTIVE_ORGANIZATION_MEMBER,
+        ),
         ("dockAndWorkbenchPrefs", "GET", "/api/workbench/prefs", REMOTE_HTTP_ALLOWED),
         (
             "dockAndWorkbenchPrefs",

--- a/tests/test_instance_authorization.py
+++ b/tests/test_instance_authorization.py
@@ -3,11 +3,13 @@ import pytest
 from vibe.authorization import (
     AuthorizationContext,
     InstanceAuthorizationError,
+    REMOTE_HTTP_ACTIVE_ORGANIZATION_MEMBER,
     REMOTE_HTTP_ALLOWED,
     REMOTE_HTTP_LOCAL_ONLY,
     REMOTE_HTTP_PAYLOAD_FILTERED,
     can_receive_workbench_event,
     context_from_session_payload,
+    has_temporary_unrestricted_org_app_access,
     http_authorization_policy,
     require_instance_role,
     required_instance_role,
@@ -41,6 +43,52 @@ def test_remote_roles_allow_chat_without_enabling_local_machine_capabilities() -
     assert trusted_local_context().can_manage_instance is True
     assert trusted_local_context().can_chat is True
     assert trusted_local_context().can_use_cloud_asr is False
+
+
+def test_temporary_org_app_access_is_not_projected_as_a_capability() -> None:
+    member = AuthorizationContext(
+        instance_role="viewer",
+        subject="member-1",
+        organization_id="org-1",
+        organization_member_id="membership-1",
+        organization_role="member",
+        instance_access_source="organization_group",
+        is_remote=True,
+    )
+
+    assert has_temporary_unrestricted_org_app_access(member) is True
+    assert member.capability_projection() == {
+        "is_instance_owner": False,
+        "can_read_instance": True,
+        "can_chat": False,
+        "can_manage_projects": False,
+        "can_manage_agents": False,
+        "can_manage_instance": False,
+        "can_use_agents": False,
+        "can_use_skills": False,
+        "can_use_vault_secrets": False,
+        "can_use_show_pages": True,
+        "can_use_terminal_files": False,
+        "can_use_terminal": False,
+        "can_use_files": False,
+        "can_use_system": False,
+    }
+    assert has_temporary_unrestricted_org_app_access(
+        AuthorizationContext(
+            **{
+                **member.__dict__,
+                "organization_member_id": None,
+            }
+        )
+    ) is False
+    assert has_temporary_unrestricted_org_app_access(
+        AuthorizationContext(
+            **{
+                **member.__dict__,
+                "instance_access_source": "show_page_email",
+            }
+        )
+    ) is False
 
 
 @pytest.mark.parametrize(
@@ -171,9 +219,10 @@ def test_http_policy_defaults_unknown_api_to_owner() -> None:
     assert required_instance_role("POST", "/api/sessions/ses-1/fork") == "editor"
     assert required_instance_role("POST", "/api/projects") == "owner"
     assert required_instance_role("GET", "/api/new-management-surface") == "owner"
+    assert required_instance_role("GET", "/api/dock") == "viewer"
     assert required_instance_role("GET", "/status") is None
     assert required_instance_role("GET", "/show/ses-1/") == "viewer"
-    assert required_instance_role("POST", "/show/ses-1/api/action") == "editor"
+    assert required_instance_role("POST", "/show/ses-1/api/action") == "viewer"
     assert required_instance_role("GET", "/assets/app.js") is None
 
 
@@ -255,8 +304,8 @@ def test_remote_http_policy_defaults_local_machine_and_unknown_routes_to_local_o
         ("GET", "/api/opencode/permission-status", REMOTE_HTTP_LOCAL_ONLY),
         ("GET", "/api/vault/audit", REMOTE_HTTP_ALLOWED),
         ("GET", "/api/dock", REMOTE_HTTP_ALLOWED),
-        ("POST", "/api/dock/pins", REMOTE_HTTP_LOCAL_ONLY),
-        ("PUT", "/api/dock/order", REMOTE_HTTP_LOCAL_ONLY),
+        ("POST", "/api/dock/pins", REMOTE_HTTP_ACTIVE_ORGANIZATION_MEMBER),
+        ("PUT", "/api/dock/order", REMOTE_HTTP_ACTIVE_ORGANIZATION_MEMBER),
         # A push endpoint is caller-supplied and `send_web_push()` fetches it
         # from this host, so registering or testing one from across the tunnel
         # would let a remote caller aim an outbound request at loopback, a
@@ -305,7 +354,7 @@ def test_remote_http_policy_defaults_local_machine_and_unknown_routes_to_local_o
         ("GET", "/api/bind-codes", REMOTE_HTTP_LOCAL_ONLY),
         ("DELETE", "/api/projects/proj-1", REMOTE_HTTP_LOCAL_ONLY),
         ("POST", "/api/sessions/ses-1/fork", REMOTE_HTTP_LOCAL_ONLY),
-        ("POST", "/show/ses-1/api/action", REMOTE_HTTP_LOCAL_ONLY),
+        ("POST", "/show/ses-1/api/action", REMOTE_HTTP_ACTIVE_ORGANIZATION_MEMBER),
     ],
 )
 def test_remote_http_policy_keeps_approved_management_and_read_surfaces(
@@ -314,6 +363,71 @@ def test_remote_http_policy_keeps_approved_management_and_read_surfaces(
     expected,
 ) -> None:
     assert http_authorization_policy(method, path).remote_access == expected
+
+
+@pytest.mark.parametrize(
+    ("method", "path"),
+    [
+        ("POST", "/api/dock/pins"),
+        ("DELETE", "/api/dock/pins/ses-1"),
+        ("PUT", "/api/dock/order"),
+        ("GET", "/api/files/list"),
+        ("HEAD", "/api/files/meta"),
+        ("GET", "/api/files/content"),
+        ("GET", "/api/files/search"),
+        ("GET", "/api/files/search_names"),
+        ("POST", "/api/files/upload"),
+        ("POST", "/api/files/mkdir"),
+        ("POST", "/api/files/rename"),
+        ("POST", "/api/files/move"),
+        ("POST", "/api/files/copy"),
+        ("POST", "/api/files/delete"),
+        ("POST", "/api/files/delete/undo"),
+        ("POST", "/api/files/search/replace"),
+        ("POST", "/api/files/search/undo"),
+        ("PUT", "/api/files/write"),
+        ("GET", "/api/browse/favorites"),
+        ("DELETE", "/api/terminal/term-1"),
+        ("POST", "/api/show-pages/ses-1/icon"),
+        ("POST", "/show/ses-1/api/action"),
+        ("PUT", "/show/ses-1/api/settings"),
+        ("DELETE", "/show/ses-1/api/item"),
+    ],
+)
+def test_temporary_org_app_policy_covers_only_the_explicit_app_endpoints(
+    method: str,
+    path: str,
+) -> None:
+    policy = http_authorization_policy(method, path)
+
+    assert policy.minimum_role == "viewer"
+    assert policy.remote_access == REMOTE_HTTP_ACTIVE_ORGANIZATION_MEMBER
+
+
+@pytest.mark.parametrize(
+    ("method", "path"),
+    [
+        ("POST", "/api/files/list"),
+        ("GET", "/api/files/future-operation"),
+        ("POST", "/api/browse"),
+        ("POST", "/api/browse/mkdir"),
+        ("GET", "/api/terminal/term-1"),
+        ("POST", "/api/dock/order"),
+        ("POST", "/api/show-pages/ses-1/icon/extra"),
+        ("POST", "/api/config"),
+        ("POST", "/api/control"),
+        ("POST", "/api/vault/secrets"),
+        ("GET", "/api/future-local-app-like-route"),
+    ],
+)
+def test_temporary_org_app_policy_does_not_open_adjacent_or_sensitive_endpoints(
+    method: str,
+    path: str,
+) -> None:
+    assert (
+        http_authorization_policy(method, path).remote_access
+        != REMOTE_HTTP_ACTIVE_ORGANIZATION_MEMBER
+    )
 
 
 @pytest.mark.parametrize(
@@ -392,18 +506,28 @@ def test_remote_http_policy_keeps_approved_management_and_read_surfaces(
             REMOTE_HTTP_LOCAL_ONLY,
         ),
         ("canAdministerMemory", "POST", "/api/memory/clear", REMOTE_HTTP_LOCAL_ONLY),
-        # Dock/Workbench prefs: the read is remote, the process-global writes
-        # are local until the records are keyed by the authenticated subject.
+        # Dock is temporarily writable by active Organization members while
+        # Workbench preferences remain a trusted-local control.
         ("dockAndWorkbenchPrefs", "GET", "/api/dock", REMOTE_HTTP_ALLOWED),
         ("dockAndWorkbenchPrefs", "GET", "/api/workbench/prefs", REMOTE_HTTP_ALLOWED),
-        ("dockAndWorkbenchPrefs", "POST", "/api/dock/pins", REMOTE_HTTP_LOCAL_ONLY),
+        (
+            "dockAndWorkbenchPrefs",
+            "POST",
+            "/api/dock/pins",
+            REMOTE_HTTP_ACTIVE_ORGANIZATION_MEMBER,
+        ),
         (
             "dockAndWorkbenchPrefs",
             "DELETE",
             "/api/dock/pins/ses-1",
-            REMOTE_HTTP_LOCAL_ONLY,
+            REMOTE_HTTP_ACTIVE_ORGANIZATION_MEMBER,
         ),
-        ("dockAndWorkbenchPrefs", "PUT", "/api/dock/order", REMOTE_HTTP_LOCAL_ONLY),
+        (
+            "dockAndWorkbenchPrefs",
+            "PUT",
+            "/api/dock/order",
+            REMOTE_HTTP_ACTIVE_ORGANIZATION_MEMBER,
+        ),
         ("dockAndWorkbenchPrefs", "PUT", "/api/workbench/prefs", REMOTE_HTTP_LOCAL_ONLY),
         # canRegisterWebPush: status reads stay remote, but registering or
         # testing an endpoint this host will call does not.

--- a/tests/test_resource_acl_show_pages.py
+++ b/tests/test_resource_acl_show_pages.py
@@ -6,14 +6,14 @@ from sqlalchemy import select
 from config import paths
 from core.dock_store import BUILTIN_DOCK_IDS, DockError
 from core.show_pages import ShowPageError, ShowPageStore, public_url
-from storage import media_service, projects_service, resource_access_service
+from storage import media_service, project_access_service, projects_service, resource_access_service
 from storage import workbench_sessions_service as sessions_service
 from storage.db import create_sqlite_engine
 from storage.importer import ensure_sqlite_state
 from storage.models import agent_sessions, show_pages
 from tests.test_ui_remote_access_auth import _remote_peer, _save_config
 from tests.ui_server_test_helpers import csrf_headers
-from vibe import api, remote_access
+from vibe import api, remote_access, ui_server
 from vibe.ui_server import app
 
 
@@ -43,6 +43,7 @@ def _organization_cookie(
     subject: str,
     groups: list[str] | None = None,
     instance_role: str = "viewer",
+    organization_role: str = "member",
 ) -> str:
     claims = {
         "vibe_instance_id": "inst_123",
@@ -50,7 +51,7 @@ def _organization_cookie(
         "vibe_instance_access_source": "organization_group",
         "vibe_organization_id": "org-1",
         "vibe_organization_member_id": f"member-{subject}",
-        "vibe_organization_role": "member",
+        "vibe_organization_role": organization_role,
         "vibe_membership_version": "membership-v2",
     }
     if groups is not None:
@@ -184,19 +185,38 @@ def test_broader_instance_context_unions_its_signed_show_page_entitlement(
         store.close()
 
 
-def test_remote_show_page_list_and_direct_requests_enforce_policy(monkeypatch, tmp_path) -> None:
+@pytest.mark.parametrize(
+    ("subject", "instance_role", "organization_role"),
+    [
+        ("owner-2", "owner", "owner"),
+        ("member-1", "viewer", "member"),
+    ],
+)
+def test_remote_org_members_can_open_all_show_pages_temporarily(
+    monkeypatch,
+    tmp_path,
+    subject,
+    instance_role,
+    organization_role,
+) -> None:
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     config = _save_config(tmp_path)
     store = _seed_show_pages_with_policies()
     store.close()
+
+    async def _runtime_response(*args, **kwargs):
+        return ui_server.FastAPIResponse(content=b"Show Page", media_type="text/html")
+
+    monkeypatch.setattr(ui_server, "_show_page_runtime_response", _runtime_response)
     client = app.test_client()
     client.set_cookie(
         remote_access.SESSION_COOKIE_NAME,
         _organization_cookie(
             config,
-            subject="member-1",
+            subject=subject,
             groups=["group-engineering"],
-            instance_role="owner",
+            instance_role=instance_role,
+            organization_role=organization_role,
         ),
         domain="alex.avibe.bot",
     )
@@ -222,21 +242,15 @@ def test_remote_show_page_list_and_direct_requests_enforce_policy(monkeypatch, t
     )
 
     assert catalog.status_code == 200
-    assert {item["session_id"] for item in catalog.get_json()["pages"]} == {"ses-public", "ses-scope"}
+    assert {item["session_id"] for item in catalog.get_json()["pages"]} == {
+        "ses-private",
+        "ses-public",
+        "ses-scope",
+    }
     assert all("path" not in item for item in catalog.get_json()["pages"])
-    assert mutation.status_code == 403
-    assert mutation.get_json()["code"] == "resource_access_forbidden"
-    assert page.status_code == 302
-    assert "show_page_id=ses-private" in page.headers["Location"]
-
-    reauth_result = client.get(
-        "/show/ses-private/?__vibe_show_page_reauth=1",
-        base_url="https://alex.avibe.bot",
-        environ_base=_remote_peer(),
-        headers={"Accept": "text/html"},
-        follow_redirects=False,
-    )
-    assert reauth_result.status_code == 403
+    assert mutation.status_code == 200
+    assert mutation.get_json()["visibility"] == "offline"
+    assert page.status_code == 200
 
 
 def test_remote_show_page_creation_defaults_private_and_org_public_does_not_share(monkeypatch, tmp_path) -> None:
@@ -815,7 +829,7 @@ def test_show_page_email_grant_change_requires_authorization_revision(monkeypatc
         )
 
 
-def test_remote_dock_filters_private_pins_and_authorizes_mutations(monkeypatch, tmp_path) -> None:
+def test_remote_org_dock_temporarily_bypasses_show_page_acl(monkeypatch, tmp_path) -> None:
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     config = _save_config(tmp_path)
     store = _seed_show_pages_with_policies()
@@ -862,13 +876,11 @@ def test_remote_dock_filters_private_pins_and_authorizes_mutations(monkeypatch, 
         base_url="https://alex.avibe.bot",
         environ_base=_remote_peer(),
     )
-    assert response.status_code == 403
-    # The Dock record is process-global rather than keyed by the authenticated
-    # subject, so every remote mutation now stops at the transport boundary
-    # before the resource ACL is consulted - a stricter refusal than the
-    # per-page `resource_access_forbidden` this once returned. The ACL itself is
-    # unchanged and still enforced in-process, as the `api.*` calls above assert.
-    assert response.get_json()["code"] == "remote_execution_disabled"
+    assert response.status_code == 200
+    assert {pin["session_id"] for pin in response.get_json()["dock"]["pins"]} == {
+        "ses-private",
+        "ses-scope",
+    }
 
 
 def test_remote_admin_dock_order_preserves_hidden_private_pins(monkeypatch, tmp_path) -> None:
@@ -982,16 +994,10 @@ def test_remote_member_cannot_archive_session_with_another_owners_page(monkeypat
         engine.dispose()
 
 
-def test_remote_show_annotation_media_follows_the_page_acl(monkeypatch, tmp_path) -> None:
-    """A screenshot token does not outlive access to the page it was drawn on.
-
-    `/api/media/<token>` authorizes Project/session role and short-circuits for
-    the Instance owner, so without a page check a caller who once saw a private
-    Show Page keeps its annotation screenshot readable after the page policy
-    stops naming them - and a remote Instance owner reads one they were never
-    allowed to open. The caller below is exactly that: Instance owner, but not
-    the subject the private page's policy names.
-    """
+def test_remote_org_show_annotation_media_temporarily_follows_open_page_policy(
+    monkeypatch,
+    tmp_path,
+) -> None:
 
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     config = _save_config(tmp_path)
@@ -1010,6 +1016,15 @@ def test_remote_show_annotation_media_follows_the_page_acl(monkeypatch, tmp_path
                 )["id"]
                 for access_level in ("private", "public")
             }
+            project_access_service.apply_project_access_intent(
+                connection,
+                {
+                    "project_id": project["id"],
+                    "revision": 1,
+                    "mode": "restricted",
+                    "bindings": [],
+                },
+            )
 
         store = ShowPageStore()
         try:
@@ -1061,7 +1076,7 @@ def test_remote_show_annotation_media_follows_the_page_acl(monkeypatch, tmp_path
                 config,
                 subject="member-1",
                 groups=["group-engineering"],
-                instance_role="owner",
+                instance_role="viewer",
             ),
             domain="alex.avibe.bot",
         )
@@ -1073,13 +1088,13 @@ def test_remote_show_annotation_media_follows_the_page_acl(monkeypatch, tmp_path
                 environ_base=_remote_peer(),
             )
 
-        # The page ACL decides, not the Instance-owner shortcut.
-        assert _media(tokens["show_annotation:private"]).status_code == 404
+        # Show annotation screenshots are part of the temporarily open page.
+        assert _media(tokens["show_annotation:private"]).status_code == 200
         assert _media(tokens["show_annotation:public"]).status_code == 200
         # An annotation with no page to check against cannot be authorized.
         assert _media(orphan_token).status_code == 404
-        # Only Show annotations gained the page check; other media keeps the
-        # Project/session authorization it already had as its only gate.
-        assert _media(tokens["agent_reply:private"]).status_code == 200
+        # Unrelated media keeps Project/session authorization as its gate.
+        assert _media(tokens["agent_reply:private"]).status_code == 404
+        assert _media(tokens["agent_reply:public"]).status_code == 404
     finally:
         engine.dispose()

--- a/tests/test_terminal_backend.py
+++ b/tests/test_terminal_backend.py
@@ -1428,7 +1428,7 @@ def test_terminal_websocket_unsupported_accepts_before_policy_close(monkeypatch)
     assert websocket.calls == [("accept", None), ("close", 1008)]
 
 
-def test_remote_terminal_websocket_is_rejected_before_authorization_refresh(monkeypatch):
+def test_remote_terminal_websocket_closes_at_authorization_refresh(monkeypatch):
     from vibe import remote_access
 
     class BlockingTerminalService:
@@ -1455,7 +1455,10 @@ def test_remote_terminal_websocket_is_rejected_before_authorization_refresh(monk
 
     asyncio.run(ui_server.terminal_websocket(websocket, "test"))
 
-    assert websocket.calls == [("close", 1008)]
+    assert websocket.calls == [
+        ("accept", None),
+        ("close", ui_server._AUTHORIZATION_REFRESH_WEBSOCKET_CLOSE_CODE),
+    ]
 
 
 def test_terminal_websocket_rejects_forwarded_request(monkeypatch, tmp_path):
@@ -1641,25 +1644,36 @@ def test_terminal_delete_rejects_forwarded_origin_proxy_without_terminating(monk
     assert terminated == []
 
 
-def test_remote_terminal_delete_is_rejected_before_service_access(monkeypatch, tmp_path):
+def test_remote_org_terminal_delete_is_subject_scoped(monkeypatch, tmp_path):
     monkeypatch.setenv("VIBE_UI_ENABLE_TERMINAL", "1")
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     monkeypatch.setattr(ui_server, "TERMINAL_SUPPORTED", True)
     config = _save_remote_config(tmp_path)
     user_one_effective = ui_server._terminal_effective_session_id("shared-session", "user-1")
+    user_two_effective = ui_server._terminal_effective_session_id("shared-session", "user-2")
     terminated: list[str] = []
 
     class _FakeService:
         async def terminate(self, session_id: str) -> bool:
             terminated.append(session_id)
-            return session_id == user_one_effective
+            return session_id == user_two_effective
 
     monkeypatch.setattr(ui_server, "get_terminal_service", lambda: _FakeService())
 
     user_two_client = app.test_client()
     user_two_client.set_cookie(
         remote_access.SESSION_COOKIE_NAME,
-        remote_session_cookie(config, "user-2@example.com", "user-2"),
+        remote_session_cookie(
+            config,
+            "user-2@example.com",
+            "user-2",
+            role="viewer",
+            access_source="organization_group",
+            organization_id="org-1",
+            organization_member_id="member-user-2",
+            organization_role="member",
+            group_ids=[],
+        ),
         domain="alex.avibe.bot",
     )
     headers = csrf_headers(user_two_client, "https://alex.avibe.bot")
@@ -1676,11 +1690,13 @@ def test_remote_terminal_delete_is_rejected_before_service_access(monkeypatch, t
         environ_base={"REMOTE_ADDR": "203.0.113.10"},
     )
 
-    assert response.status_code == 403
-    assert response.get_json()["code"] == "remote_execution_disabled"
-    assert malicious_response.status_code == 403
-    assert malicious_response.get_json()["code"] == "remote_execution_disabled"
-    assert terminated == []
+    assert response.status_code == 204
+    assert malicious_response.status_code == 404
+    assert malicious_response.get_json()["error"] == "terminal_session_not_found"
+    assert terminated == [
+        user_two_effective,
+        ui_server._terminal_effective_session_id(user_one_effective, "user-2"),
+    ]
 
 
 def test_terminal_service_ignores_invalid_limit_env(monkeypatch):

--- a/tests/test_ui_project_access.py
+++ b/tests/test_ui_project_access.py
@@ -181,7 +181,7 @@ def test_remote_editor_project_access_filters_every_read_surface(monkeypatch, tm
     monkeypatch.setattr(
         api,
         "list_show_pages",
-        lambda: {
+        lambda **_kwargs: {
             "ok": True,
             "count": 3,
             "pages": [
@@ -381,7 +381,7 @@ def test_archived_project_invalidates_retained_remote_urls(monkeypatch, tmp_path
     monkeypatch.setattr(
         api,
         "list_show_pages",
-        lambda: {
+        lambda **_kwargs: {
             "ok": True,
             "count": 1,
             "pages": [{"session_id": ids["session_a"]}],

--- a/tests/test_ui_remote_access_auth.py
+++ b/tests/test_ui_remote_access_auth.py
@@ -1257,7 +1257,7 @@ def test_remote_session_info_includes_authenticated_subject(monkeypatch, tmp_pat
     }
 
 
-def test_remote_file_api_is_blocked_while_local_file_browsing_still_works(
+def test_non_org_remote_file_api_is_blocked_while_local_file_browsing_still_works(
     monkeypatch,
     tmp_path,
 ):
@@ -1287,6 +1287,118 @@ def test_remote_file_api_is_blocked_while_local_file_browsing_still_works(
     assert remote_response.get_json()["code"] == "remote_execution_disabled"
     assert local_response.status_code == 200
     assert local_response.get_json()["path"] == str(tmp_path.resolve())
+
+
+@pytest.mark.parametrize(
+    ("instance_role", "organization_role"),
+    [("owner", "owner"), ("viewer", "member")],
+)
+def test_remote_org_members_can_use_files_editor_and_builtin_apps(
+    monkeypatch,
+    tmp_path,
+    instance_role,
+    organization_role,
+):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    config = _save_config(tmp_path)
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    write_path = workspace / f"{organization_role}.txt"
+    client = app.test_client()
+    client.set_cookie(
+        remote_access.SESSION_COOKIE_NAME,
+        remote_session_cookie(
+            config,
+            f"{organization_role}@example.com",
+            f"user-{organization_role}",
+            role=instance_role,
+            access_source="organization_group",
+            organization_id="org-1",
+            organization_member_id=f"member-{organization_role}",
+            organization_role=organization_role,
+            group_ids=[],
+        ),
+        domain="alex.avibe.bot",
+    )
+
+    list_response = client.get(
+        "/api/files/list",
+        params={"path": str(workspace)},
+        base_url="https://alex.avibe.bot",
+        environ_base=_remote_peer(),
+    )
+    write_response = client.put(
+        "/api/files/write",
+        json={"path": str(write_path), "content": "remote editor write"},
+        headers=csrf_headers(client, "https://alex.avibe.bot"),
+        base_url="https://alex.avibe.bot",
+        environ_base=_remote_peer(),
+    )
+    dock_response = client.get(
+        "/api/dock",
+        base_url="https://alex.avibe.bot",
+        environ_base=_remote_peer(),
+    )
+
+    assert list_response.status_code == 200
+    assert list_response.get_json()["path"] == str(workspace.resolve())
+    assert write_response.status_code == 200
+    assert write_path.read_text(encoding="utf-8") == "remote editor write"
+    assert dock_response.status_code == 200
+    assert dock_response.get_json()["dock"]["order"] == [
+        "files",
+        "terminal",
+        "editor",
+        "library",
+    ]
+
+
+@pytest.mark.parametrize(
+    ("method", "path", "json_body"),
+    [
+        ("GET", "/api/harness/bootstrap", None),
+        ("POST", "/api/settings", {"platform": "slack", "channels": {}}),
+        ("POST", "/api/vault/secrets", {}),
+        ("POST", "/api/control", {"action": "restart"}),
+    ],
+)
+def test_temporary_org_app_access_does_not_open_sensitive_control_plane(
+    monkeypatch,
+    tmp_path,
+    method,
+    path,
+    json_body,
+):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    config = _save_config(tmp_path)
+    client = app.test_client()
+    client.set_cookie(
+        remote_access.SESSION_COOKIE_NAME,
+        remote_session_cookie(
+            config,
+            "owner@example.com",
+            "user-owner",
+            role="owner",
+            access_source="organization_group",
+            organization_id="org-1",
+            organization_member_id="member-owner",
+            organization_role="owner",
+            group_ids=[],
+        ),
+        domain="alex.avibe.bot",
+    )
+
+    response = client.request(
+        method,
+        path,
+        json=json_body,
+        headers=csrf_headers(client, "https://alex.avibe.bot") if method != "GET" else None,
+        base_url="https://alex.avibe.bot",
+        environ_base=_remote_peer(),
+    )
+
+    assert response.status_code == 403
+    assert response.get_json()["code"] == "remote_execution_disabled"
 
 
 @pytest.mark.parametrize(
@@ -2017,6 +2129,56 @@ def test_remote_show_page_icon_upload_is_blocked_before_filesystem_access(
 
 
 @pytest.mark.parametrize(
+    ("instance_role", "organization_role"),
+    [("owner", "owner"), ("viewer", "member")],
+)
+def test_remote_org_members_can_reach_show_page_icon_upload(
+    monkeypatch,
+    tmp_path,
+    instance_role,
+    organization_role,
+):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    config = _save_config(tmp_path)
+    calls = []
+
+    def upload_icon(*args, **kwargs):
+        calls.append((args, kwargs))
+        return {"ok": True, "session_id": "ses-remote", "icon_version": "v1"}
+
+    monkeypatch.setattr(api, "upload_show_page_icon", upload_icon)
+    client = app.test_client()
+    client.set_cookie(
+        remote_access.SESSION_COOKIE_NAME,
+        remote_session_cookie(
+            config,
+            f"{organization_role}@example.com",
+            f"user-{organization_role}",
+            role=instance_role,
+            access_source="organization_group",
+            organization_id="org-1",
+            organization_member_id=f"member-{organization_role}",
+            organization_role=organization_role,
+            group_ids=[],
+        ),
+        domain="alex.avibe.bot",
+    )
+
+    response = client.post(
+        "/api/show-pages/ses-remote/icon",
+        files={"file": ("icon.svg", b"<svg/>", "image/svg+xml")},
+        headers=csrf_headers(client, "https://alex.avibe.bot"),
+        base_url="https://alex.avibe.bot",
+        environ_base=_remote_peer(),
+    )
+
+    assert response.status_code == 200
+    assert len(calls) == 1
+    assert calls[0][0] == ("ses-remote", b"<svg/>")
+    assert calls[0][1]["user_context"].is_trusted_local is True
+
+
+@pytest.mark.parametrize(
     ("path", "json_body", "api_method", "expected_args"),
     [
         (
@@ -2066,7 +2228,11 @@ def test_remote_show_page_public_link_mutations_reach_resource_authorization(
     )
 
     assert response.status_code == 200
-    assert calls == [(expected_args, {})]
+    assert len(calls) == 1
+    args, kwargs = calls[0]
+    assert args == expected_args
+    assert kwargs["user_context"].is_remote is True
+    assert kwargs["user_context"].is_trusted_local is False
 
 
 @pytest.mark.parametrize(
@@ -5024,7 +5190,7 @@ def test_terminal_websocket_rejects_remote_same_host_different_origin(monkeypatc
 
 @pytest.mark.skipif(not ui_server.TERMINAL_SUPPORTED, reason="terminal requires a POSIX pty")
 @pytest.mark.parametrize("origin", ["https://alex.avibe.bot", "https://alex.avibe.bot:443"])
-def test_terminal_websocket_rejects_remote_exact_trusted_origin(monkeypatch, tmp_path, origin):
+def test_terminal_websocket_rejects_non_org_remote_exact_trusted_origin(monkeypatch, tmp_path, origin):
     monkeypatch.setenv("VIBE_UI_ENABLE_TERMINAL", "1")
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     config = _save_config(tmp_path)
@@ -5055,6 +5221,59 @@ def test_terminal_websocket_rejects_remote_exact_trusted_origin(monkeypatch, tmp
 
     assert exc.value.code == 1008
     assert accepted is False
+
+
+@pytest.mark.skipif(not ui_server.TERMINAL_SUPPORTED, reason="terminal requires a POSIX pty")
+@pytest.mark.parametrize(
+    ("instance_role", "organization_role"),
+    [("owner", "owner"), ("viewer", "member")],
+)
+def test_terminal_websocket_accepts_remote_org_owner_and_member(
+    monkeypatch,
+    tmp_path,
+    instance_role,
+    organization_role,
+):
+    monkeypatch.setenv("VIBE_UI_ENABLE_TERMINAL", "1")
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    config = _save_config(tmp_path)
+    handled_session_ids: list[str] = []
+
+    async def fake_handle_websocket(websocket, session_id, *, initial_cwd=None):
+        handled_session_ids.append(session_id)
+
+    monkeypatch.setattr(ui_server.get_terminal_service(), "handle_websocket", fake_handle_websocket)
+    subject = f"user-{organization_role}"
+    client = app.test_client()
+    client.set_cookie(
+        remote_access.SESSION_COOKIE_NAME,
+        remote_session_cookie(
+            config,
+            f"{organization_role}@example.com",
+            subject,
+            role=instance_role,
+            access_source="organization_group",
+            organization_id="org-1",
+            organization_member_id=f"member-{organization_role}",
+            organization_role=organization_role,
+            group_ids=[],
+        ),
+        domain="alex.avibe.bot",
+    )
+
+    with client.websocket_connect(
+        "wss://alex.avibe.bot/api/terminal/shared-session",
+        headers={
+            "host": "alex.avibe.bot",
+            "origin": "https://alex.avibe.bot",
+            "x-forwarded-for": "203.0.113.10",
+        },
+    ):
+        pass
+
+    assert handled_session_ids == [
+        ui_server._terminal_effective_session_id("shared-session", subject)
+    ]
 
 
 @pytest.mark.skipif(not ui_server.TERMINAL_SUPPORTED, reason="terminal requires a POSIX pty")

--- a/tests/test_ui_remote_access_auth.py
+++ b/tests/test_ui_remote_access_auth.py
@@ -1238,6 +1238,7 @@ def test_remote_session_info_includes_authenticated_subject(monkeypatch, tmp_pat
         "email": "alex@example.com",
         "sub": "user-1",
         "instance_role": "owner",
+        "temporary_unrestricted_org_app_access": False,
         "capabilities": {
             "is_instance_owner": True,
             "can_read_instance": True,
@@ -1351,6 +1352,12 @@ def test_remote_org_members_can_use_files_editor_and_builtin_apps(
         "editor",
         "library",
     ]
+    session_response = client.get(
+        "/api/session",
+        base_url="https://alex.avibe.bot",
+        environ_base=_remote_peer(),
+    )
+    assert session_response.get_json()["temporary_unrestricted_org_app_access"] is True
 
 
 @pytest.mark.parametrize(

--- a/tests/test_ui_server_fastapi.py
+++ b/tests/test_ui_server_fastapi.py
@@ -2315,6 +2315,50 @@ def test_workbench_events_filter_privileged_events_for_viewers(monkeypatch, tmp_
     assert "hidden-secret" not in body
 
 
+def test_workbench_events_allow_show_events_to_temporary_org_viewers() -> None:
+    from vibe.authorization import AuthorizationContext
+    from vibe.sse_broker import broker
+    from vibe.ui_compat import g
+
+    async def collect_show_event() -> str:
+        with app.test_request_context("/api/events"):
+            g.authorization_context = AuthorizationContext(
+                instance_role="viewer",
+                instance_access_source="organization_group",
+                organization_id="org-1",
+                organization_member_id="member-1",
+                organization_role="member",
+                is_remote=True,
+            )
+            response = await ui_server.workbench_events()
+            iterator = response.body_iterator.__aiter__()
+            try:
+                for _ in range(3):
+                    await iterator.__anext__()
+                broker.publish(
+                    "show.event",
+                    {
+                        "session_id": "show-session-1",
+                        "payload": {
+                            "screenshot": {
+                                "path": "/private/host/path.png",
+                                "attachmentId": "attachment-1",
+                            }
+                        },
+                    },
+                )
+                chunk = await asyncio.wait_for(iterator.__anext__(), timeout=1)
+            finally:
+                await iterator.aclose()
+        return chunk.decode("utf-8") if isinstance(chunk, bytes) else chunk
+
+    body = asyncio.run(collect_show_event())
+
+    assert "event: show.event" in body
+    assert "show-session-1" in body
+    assert "/private/host/path.png" not in body
+
+
 def test_workbench_events_end_at_authorization_refresh_deadline():
     from vibe.authorization import AuthorizationContext
     from vibe.ui_compat import g

--- a/tests/test_ui_show_pages.py
+++ b/tests/test_ui_show_pages.py
@@ -680,7 +680,7 @@ def test_remote_show_page_ensure_redacts_local_path(monkeypatch, tmp_path):
     config = _save_config(tmp_path)
     monkeypatch.setattr(
         "vibe.api.ensure_show_page",
-        lambda session_id: {
+        lambda session_id, **_kwargs: {
             "ok": True,
             "existed": False,
             "session_id": session_id,
@@ -3421,7 +3421,10 @@ def test_private_show_events_stream_ends_when_project_access_is_revoked(monkeypa
     assert len(asyncio.run(_collect_until_revoked())) == 1
 
 
-def test_private_show_events_stream_ends_when_resource_access_is_revoked(monkeypatch, tmp_path):
+def test_remote_org_show_events_stream_stays_open_when_resource_access_is_revoked(
+    monkeypatch,
+    tmp_path,
+):
     from storage.db import create_sqlite_engine
     from vibe.authorization import AuthorizationContext
     from vibe.sse_broker import broker
@@ -3454,7 +3457,7 @@ def test_private_show_events_stream_ends_when_resource_access_is_revoked(monkeyp
         )
     engine.dispose()
 
-    async def _collect_until_revoked() -> list[str | bytes]:
+    async def _collect_after_revocation() -> str:
         response = await _show_events_stream(
             "ses123",
             authorization_context=context,
@@ -3478,13 +3481,27 @@ def test_private_show_events_stream_ends_when_resource_access_is_revoked(monkeyp
                 "authorization.changed",
                 {"project_ids": [], "resource_kinds": ["show_page"]},
             )
-            with pytest.raises(StopAsyncIteration):
-                await asyncio.wait_for(iterator.__anext__(), timeout=1)
+            broker.publish(
+                "show.dispatch",
+                {
+                    "session_id": "ses123",
+                    "scope_id": "scope123",
+                    "show_event_id": "show_evt_after_acl_change",
+                    "event": "turn.chunk",
+                    "data": {"text": "still connected"},
+                },
+            )
+            chunks.append(await asyncio.wait_for(iterator.__anext__(), timeout=1))
         finally:
             await iterator.aclose()
-        return chunks
+        return "".join(
+            chunk.decode("utf-8") if isinstance(chunk, bytes) else chunk
+            for chunk in chunks
+        )
 
-    assert len(asyncio.run(_collect_until_revoked())) == 1
+    body = asyncio.run(_collect_after_revocation())
+    assert "event: show.dispatch" in body
+    assert "still connected" in body
 
 
 def test_public_show_events_stream_redacts_nested_dispatch_ids(monkeypatch, tmp_path):
@@ -5872,7 +5889,10 @@ def test_private_show_page_hmr_websocket_closes_at_authorization_refresh_deadlin
     assert proxy_calls == [("started", "ses123"), ("cancelled", "ses123")]
 
 
-def test_private_show_page_hmr_websocket_closes_when_resource_access_is_revoked(monkeypatch, tmp_path):
+def test_remote_org_show_page_hmr_stays_open_when_resource_access_is_revoked(
+    monkeypatch,
+    tmp_path,
+):
     from storage.db import create_sqlite_engine
     from vibe.sse_broker import broker
 
@@ -5947,7 +5967,7 @@ def test_private_show_page_hmr_websocket_closes_when_resource_access_is_revoked(
     monkeypatch.setattr(ui_server, "_proxy_show_runtime_websocket", blocking_proxy)
     websocket = RecordingWebSocket()
 
-    async def _run_until_revoked() -> None:
+    async def _run_after_revocation() -> None:
         task = asyncio.create_task(ui_server.show_runtime_hmr_websocket(websocket, "ses123"))
         await asyncio.wait_for(proxy_started.wait(), timeout=1)
         revoke_engine = create_sqlite_engine()
@@ -5967,14 +5987,15 @@ def test_private_show_page_hmr_websocket_closes_when_resource_access_is_revoked(
             "authorization.changed",
             {"project_ids": [], "resource_kinds": ["show_page"]},
         )
-        await asyncio.wait_for(task, timeout=1)
+        await asyncio.sleep(0.05)
+        assert task.done() is False
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
 
-    asyncio.run(_run_until_revoked())
+    asyncio.run(_run_after_revocation())
 
-    assert websocket.calls == [
-        ("accept", "vite-hmr"),
-        ("close", ui_server._AUTHORIZATION_REFRESH_WEBSOCKET_CLOSE_CODE),
-    ]
+    assert websocket.calls == [("accept", "vite-hmr")]
     assert proxy_calls == [("started", "ses123"), ("cancelled", "ses123")]
 
 

--- a/ui/src/apps/appLibrary.test.ts
+++ b/ui/src/apps/appLibrary.test.ts
@@ -1,11 +1,16 @@
 import { describe, expect, it } from 'vitest';
 
 import { deriveAppRows, filterShowPages, partitionByDock, type FilterablePage } from './appLibrary';
+import { APP_LIST } from './registry';
 
 const BUILTINS = ['files', 'terminal', 'editor', 'library'];
 const pin = (id: string) => ({ session_id: id });
 
 describe('deriveAppRows (installed set)', () => {
+  it('receives the complete built-in registry regardless of access capabilities', () => {
+    expect(APP_LIST.map((app) => app.id)).toEqual(BUILTINS);
+  });
+
   it('lists every built-in then every installed page, resolving kinds', () => {
     const rows = deriveAppRows(BUILTINS, [pin('s1'), pin('s2')], ['files', 'show:s1']);
     expect(rows.map((r) => r.dockId)).toEqual(['files', 'terminal', 'editor', 'library', 'show:s1', 'show:s2']);

--- a/ui/src/components/AppShell.test.tsx
+++ b/ui/src/components/AppShell.test.tsx
@@ -31,6 +31,7 @@ const status = vi.hoisted(() => ({ state: 'ready' as const }));
 const inbox = vi.hoisted(() => ({ totalUnread: 0 }));
 const instanceAuth = vi.hoisted(() => ({
   remote: true,
+  hasTemporaryUnrestrictedOrgAppAccess: true,
   capabilities: {
     can_manage_instance: true,
     can_use_system: false,
@@ -48,7 +49,9 @@ vi.mock('../context/StatusContext', () => ({ useStatus: () => ({ status }) }));
 vi.mock('../context/WorkbenchInboxContext', () => ({ useWorkbenchInbox: () => inbox }));
 vi.mock('../context/InstanceAuthorizationContext', () => ({ useInstanceAuthorization: () => instanceAuth }));
 vi.mock('../context/DockProvider', () => ({
-  DockProvider: ({ children }: { children: ReactNode }) => <div data-testid="dock-provider">{children}</div>,
+  DockProvider: ({ children, enabled = true }: { children: ReactNode; enabled?: boolean }) => (
+    <div data-testid="dock-provider" data-enabled={String(enabled)}>{children}</div>
+  ),
 }));
 vi.mock('../context/WindowManagerProvider', () => ({
   WindowManagerProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
@@ -69,6 +72,7 @@ vi.mock('react-i18next', () => ({
 
 beforeEach(() => {
   instanceAuth.capabilities.can_manage_instance = true;
+  instanceAuth.hasTemporaryUnrestrictedOrgAppAccess = true;
   api.getConfig.mockResolvedValue({ platforms: { enabled: [] } });
   api.getMemorySettings.mockResolvedValue({
     status: 'failed',
@@ -123,6 +127,28 @@ describe('AppShell remote Apps access', () => {
     expect(screen.getByTestId('apps-launcher')).toBeTruthy();
     expect(screen.getByTestId('mobile-dock-drawer')).toBeTruthy();
     expect(screen.getByTestId('window-layer')).toBeTruthy();
+  });
+
+  it('hides Apps surfaces and redirects App routes for non-Organization remote users', async () => {
+    instanceAuth.hasTemporaryUnrestrictedOrgAppAccess = false;
+
+    render(
+      <MemoryRouter initialEntries={['/apps/library']}>
+        <Routes>
+          <Route element={<AppShell />}>
+            <Route path="apps/library" element={<div data-testid="library-surface" />} />
+            <Route index element={<div data-testid="workbench-surface" />} />
+          </Route>
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByTestId('workbench-surface')).toBeTruthy();
+    expect(screen.queryByTestId('library-surface')).toBeNull();
+    expect(screen.queryByTestId('apps-launcher')).toBeNull();
+    expect(screen.queryByTestId('mobile-dock-drawer')).toBeNull();
+    expect(screen.queryByTestId('window-layer')).toBeNull();
+    expect(screen.getByTestId('dock-provider').getAttribute('data-enabled')).toBe('false');
   });
 
   it.each([

--- a/ui/src/components/AppShell.test.tsx
+++ b/ui/src/components/AppShell.test.tsx
@@ -3,6 +3,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { cleanup, render, screen } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import type { ReactNode } from 'react';
 
 import { AppShell } from './AppShell';
 
@@ -46,11 +47,28 @@ vi.mock('../context/ApiContext', () => ({ useApi: () => api }));
 vi.mock('../context/StatusContext', () => ({ useStatus: () => ({ status }) }));
 vi.mock('../context/WorkbenchInboxContext', () => ({ useWorkbenchInbox: () => inbox }));
 vi.mock('../context/InstanceAuthorizationContext', () => ({ useInstanceAuthorization: () => instanceAuth }));
+vi.mock('../context/DockProvider', () => ({
+  DockProvider: ({ children }: { children: ReactNode }) => <div data-testid="dock-provider">{children}</div>,
+}));
+vi.mock('../context/WindowManagerProvider', () => ({
+  WindowManagerProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+vi.mock('../context/ShowPageDragProvider', () => ({
+  ShowPageDragProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+vi.mock('./AppsLauncher', () => ({ AppsLauncher: () => <div data-testid="apps-launcher" /> }));
+vi.mock('./apps/MobileDockDrawer', () => ({
+  MobileDockDrawer: () => <div data-testid="mobile-dock-drawer" />,
+}));
+vi.mock('./apps/WindowLayer', () => ({ WindowLayer: () => <div data-testid="window-layer" /> }));
+vi.mock('./workbench/WorkbenchSidebar', () => ({ WorkbenchSidebar: () => <div /> }));
+vi.mock('./workbench/search/SearchPalette', () => ({ SearchPalette: () => null }));
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (key: string) => key }),
 }));
 
 beforeEach(() => {
+  instanceAuth.capabilities.can_manage_instance = true;
   api.getConfig.mockResolvedValue({ platforms: { enabled: [] } });
   api.getMemorySettings.mockResolvedValue({
     status: 'failed',
@@ -80,5 +98,75 @@ describe('AppShell setup recovery', () => {
       '/admin/settings/messaging',
     );
     expect(screen.queryByTestId('wizard')).toBeNull();
+  });
+});
+
+describe('AppShell remote Apps access', () => {
+  it.each([
+    ['owner', true],
+    ['member', false],
+  ])('mounts the Apps shell for an authenticated remote %s', async (_role, canManageInstance) => {
+    instanceAuth.capabilities.can_manage_instance = canManageInstance;
+
+    render(
+      <MemoryRouter initialEntries={['/']}>
+        <Routes>
+          <Route element={<AppShell />}>
+            <Route index element={<div data-testid="workbench-surface" />} />
+          </Route>
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByTestId('workbench-surface')).toBeTruthy();
+    expect(screen.getByTestId('dock-provider')).toBeTruthy();
+    expect(screen.getByTestId('apps-launcher')).toBeTruthy();
+    expect(screen.getByTestId('mobile-dock-drawer')).toBeTruthy();
+    expect(screen.getByTestId('window-layer')).toBeTruthy();
+  });
+
+  it.each([
+    ['owner', true],
+    ['member', false],
+  ])('keeps App Library available to a remote %s', async (_role, canManageInstance) => {
+    instanceAuth.capabilities.can_manage_instance = canManageInstance;
+
+    render(
+      <MemoryRouter initialEntries={['/apps/library']}>
+        <Routes>
+          <Route element={<AppShell />}>
+            <Route path="apps/library" element={<div data-testid="library-surface" />} />
+            <Route index element={<div data-testid="redirected-workbench" />} />
+          </Route>
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByTestId('library-surface')).toBeTruthy();
+    expect(screen.queryByTestId('redirected-workbench')).toBeNull();
+  });
+
+  it.each([
+    '/apps/files',
+    '/apps/editor',
+    '/apps/terminal',
+    '/apps/library',
+    '/apps/show/session-1',
+  ])('keeps the remote App route %s available when legacy capabilities are false', async (path) => {
+    instanceAuth.capabilities.can_manage_instance = false;
+
+    render(
+      <MemoryRouter initialEntries={[path]}>
+        <Routes>
+          <Route element={<AppShell />}>
+            <Route path={path.slice(1)} element={<div data-testid="app-surface" />} />
+            <Route index element={<div data-testid="redirected-workbench" />} />
+          </Route>
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByTestId('app-surface')).toBeTruthy();
+    expect(screen.queryByTestId('redirected-workbench')).toBeNull();
   });
 });

--- a/ui/src/components/AppShell.tsx
+++ b/ui/src/components/AppShell.tsx
@@ -366,7 +366,7 @@ export const AppShell: React.FC = () => {
   const ownerOnlyPath =
     location.pathname === '/setup' ||
     (location.pathname.startsWith('/admin') && !location.pathname.startsWith('/admin/organization')) ||
-    ['/agents', '/harness', '/apps/library'].some(
+    ['/agents', '/harness'].some(
       (path) => location.pathname === path || location.pathname.startsWith(`${path}/`),
     );
   // Owner is not enough for these: `can_manage_instance` stays true for a remote
@@ -377,15 +377,10 @@ export const AppShell: React.FC = () => {
   const resourceUseDenied =
     (location.pathname.startsWith('/skills') && !capabilities.can_use_skills) ||
     (location.pathname.startsWith('/vaults') && !capabilities.can_use_vault_secrets);
-  const fileOnlyPath =
-    location.pathname.startsWith('/apps/files') || location.pathname.startsWith('/apps/editor');
-  const terminalOnlyPath = location.pathname.startsWith('/apps/terminal');
   if (
     (ownerOnlyPath && !capabilities.can_manage_instance) ||
     (localSystemPath && !capabilities.can_use_system) ||
-    resourceUseDenied ||
-    (fileOnlyPath && !capabilities.can_use_files) ||
-    (terminalOnlyPath && !capabilities.can_use_terminal)
+    resourceUseDenied
   ) {
     return <Navigate to="/" replace />;
   }
@@ -528,9 +523,7 @@ export const AppShell: React.FC = () => {
     // Apps (§7.1b): replaces the old 更多 route tab. Tapping toggles the Dock
     // drawer (the mobile Dock) rather than navigating; `grid-2x2` distinguishes
     // it from Capabilities' `layout-grid`.
-    ...(capabilities.can_use_system
-      ? [{ label: t('nav.apps'), icon: Grid2x2, onClick: () => setAppsDrawerOpen((v) => !v), match: () => appsDrawerOpen }]
-      : []),
+    { label: t('nav.apps'), icon: Grid2x2, onClick: () => setAppsDrawerOpen((v) => !v), match: () => appsDrawerOpen },
   ];
 
   // Chat is a full-screen detail (own composer) and Search is a full-screen
@@ -554,7 +547,7 @@ export const AppShell: React.FC = () => {
     // Desktop: normal document flow.
     <WindowManagerProvider standalone={standaloneAppTab}>
     <StandaloneAppTabContext.Provider value={standaloneAppTab}>
-    <DockProvider enabled={capabilities.can_use_system}>
+    <DockProvider>
     <ShowPageDragProvider>
     {/* Chromeless (single-app tab): the locked full-viewport column applies on DESKTOP too —
         the app fills the browser area exactly, with nothing to scroll around it. */}
@@ -625,7 +618,7 @@ export const AppShell: React.FC = () => {
                 centered Chat composer. Workbench → Settings (control panel);
                 Control Panel → Back to Workbench, the mint counterpart. */}
             <div className="flex items-stretch gap-2">
-              {capabilities.can_use_system && <AppsLauncher />}
+              <AppsLauncher />
               {shellMode === 'workbench' && ORGANIZATION_NAV_ENABLED && (
                 <Link
                   to="/admin/organization/overview"
@@ -808,7 +801,7 @@ export const AppShell: React.FC = () => {
       {/* Mobile Dock drawer — the workbench Apps tab summons it (§7.1b). Mobile-only
           (md:hidden internally); mounted inside DockProvider so it reads the same
           docked tiles + order as the desktop Dock. */}
-      {shellMode === 'workbench' && capabilities.can_use_system && (
+      {shellMode === 'workbench' && (
         <MobileDockDrawer open={appsDrawerOpen} onClose={() => setAppsDrawerOpen(false)} />
       )}
 
@@ -831,7 +824,7 @@ export const AppShell: React.FC = () => {
           second launcher on top in full-screen anymore (product: avoid the fullscreen floating
           button; a Dock redesign comes later). Un-maximize via the window traffic-lights to reach
           the sidebar launcher. */}
-      {capabilities.can_use_system && <WindowLayer />}
+      <WindowLayer />
     </div>
     </ShowPageDragProvider>
     </DockProvider>

--- a/ui/src/components/AppShell.tsx
+++ b/ui/src/components/AppShell.tsx
@@ -232,7 +232,11 @@ export const AppShell: React.FC = () => {
   const { t } = useTranslation();
   const { status } = useStatus();
   const { totalUnread } = useWorkbenchInbox();
-  const { capabilities, remote } = useInstanceAuthorization();
+  const {
+    capabilities,
+    remote,
+    hasTemporaryUnrestrictedOrgAppAccess,
+  } = useInstanceAuthorization();
   const api = useApi();
   const location = useLocation();
   const [enabledPlatforms, setEnabledPlatforms] = useState<string[]>([]);
@@ -362,6 +366,7 @@ export const AppShell: React.FC = () => {
   const hasChannelPlatforms = enabledPlatforms.some((platform) => platformSupportsChannels(config, platform));
   const modelHubEnabled = modelHubEnabledFromConfig(config);
   const isRunning = status.state === 'running';
+  const canUseApps = !remote || hasTemporaryUnrestrictedOrgAppAccess === true;
 
   const ownerOnlyPath =
     location.pathname === '/setup' ||
@@ -377,10 +382,12 @@ export const AppShell: React.FC = () => {
   const resourceUseDenied =
     (location.pathname.startsWith('/skills') && !capabilities.can_use_skills) ||
     (location.pathname.startsWith('/vaults') && !capabilities.can_use_vault_secrets);
+  const appAccessDenied = location.pathname.startsWith('/apps/') && !canUseApps;
   if (
     (ownerOnlyPath && !capabilities.can_manage_instance) ||
     (localSystemPath && !capabilities.can_use_system) ||
-    resourceUseDenied
+    resourceUseDenied ||
+    appAccessDenied
   ) {
     return <Navigate to="/" replace />;
   }
@@ -407,10 +414,11 @@ export const AppShell: React.FC = () => {
           match: (p: string) => p.startsWith('/admin/organization'),
         }]
       : []),
-    // Permanent escape hatch to the App Library (a workbench app). Always present,
-    // so the Library is reachable from the control panel even when it is undocked
-    // (§7.1c #7). Matches any /apps/library path so it stays active on the route.
-    { to: '/apps/library', label: t('nav.appLibrary'), icon: LayoutGrid, match: (p) => p.startsWith('/apps/library') },
+    // Permanent escape hatch to the App Library (a workbench app) for principals
+    // covered by the current Apps policy. It stays reachable even when undocked.
+    ...(canUseApps
+      ? [{ to: '/apps/library', label: t('nav.appLibrary'), icon: LayoutGrid, match: (p: string) => p.startsWith('/apps/library') }]
+      : []),
     { to: '/admin/remote-access', label: t('nav.remoteAccess'), icon: Globe },
     {
       // 通讯平台: groups everything about connecting messaging platforms — the
@@ -523,7 +531,9 @@ export const AppShell: React.FC = () => {
     // Apps (§7.1b): replaces the old 更多 route tab. Tapping toggles the Dock
     // drawer (the mobile Dock) rather than navigating; `grid-2x2` distinguishes
     // it from Capabilities' `layout-grid`.
-    { label: t('nav.apps'), icon: Grid2x2, onClick: () => setAppsDrawerOpen((v) => !v), match: () => appsDrawerOpen },
+    ...(canUseApps
+      ? [{ label: t('nav.apps'), icon: Grid2x2, onClick: () => setAppsDrawerOpen((v) => !v), match: () => appsDrawerOpen }]
+      : []),
   ];
 
   // Chat is a full-screen detail (own composer) and Search is a full-screen
@@ -547,7 +557,7 @@ export const AppShell: React.FC = () => {
     // Desktop: normal document flow.
     <WindowManagerProvider standalone={standaloneAppTab}>
     <StandaloneAppTabContext.Provider value={standaloneAppTab}>
-    <DockProvider>
+    <DockProvider enabled={canUseApps}>
     <ShowPageDragProvider>
     {/* Chromeless (single-app tab): the locked full-viewport column applies on DESKTOP too —
         the app fills the browser area exactly, with nothing to scroll around it. */}
@@ -618,7 +628,7 @@ export const AppShell: React.FC = () => {
                 centered Chat composer. Workbench → Settings (control panel);
                 Control Panel → Back to Workbench, the mint counterpart. */}
             <div className="flex items-stretch gap-2">
-              <AppsLauncher />
+              {canUseApps && <AppsLauncher />}
               {shellMode === 'workbench' && ORGANIZATION_NAV_ENABLED && (
                 <Link
                   to="/admin/organization/overview"
@@ -801,7 +811,7 @@ export const AppShell: React.FC = () => {
       {/* Mobile Dock drawer — the workbench Apps tab summons it (§7.1b). Mobile-only
           (md:hidden internally); mounted inside DockProvider so it reads the same
           docked tiles + order as the desktop Dock. */}
-      {shellMode === 'workbench' && (
+      {shellMode === 'workbench' && canUseApps && (
         <MobileDockDrawer open={appsDrawerOpen} onClose={() => setAppsDrawerOpen(false)} />
       )}
 
@@ -824,7 +834,7 @@ export const AppShell: React.FC = () => {
           second launcher on top in full-screen anymore (product: avoid the fullscreen floating
           button; a Dock redesign comes later). Un-maximize via the window traffic-lights to reach
           the sidebar launcher. */}
-      <WindowLayer />
+      {canUseApps && <WindowLayer />}
     </div>
     </ShowPageDragProvider>
     </DockProvider>

--- a/ui/src/components/workbench/ChatPage.tsx
+++ b/ui/src/components/workbench/ChatPage.tsx
@@ -219,7 +219,10 @@ export const ChatPage: React.FC = () => {
   const { capabilities } = useInstanceAuthorization();
   const [sessionCanChat, setSessionCanChat] = useState(false);
   const canChat = capabilities.can_chat && sessionCanChat;
-  const canManageShowPageAsInstance = capabilities.can_manage_instance && capabilities.can_use_system;
+  // Show Page resource ACLs are temporarily disabled for remote Organization
+  // members (avibe#1313). The existing role-level Show Pages capability is
+  // sufficient here; Apps availability must never depend on can_use_system.
+  const canManageShowPageAsInstance = capabilities.can_use_show_pages;
   const [showPageAccessResult, setShowPageAccessResult] = useState<{
     sessionId: string;
     probe: ShowPageAccessProbe;

--- a/ui/src/components/workbench/WorkbenchSidebar.tsx
+++ b/ui/src/components/workbench/WorkbenchSidebar.tsx
@@ -928,7 +928,7 @@ export const WorkbenchSidebar: React.FC<{ onOpenSearch?: () => void }> = ({ onOp
                   canManageMetadata={project.capabilities.can_chat}
                   canManageProjects={capabilities.can_manage_projects}
                   canArchive={capabilities.can_manage_projects && canArchiveProjects({ remote })}
-                  canOpenInEditor={capabilities.can_use_files}
+                  canOpenInEditor
                   canEditAgentsMd={capabilities.can_manage_projects && canEditProjectInstructions({ remote })}
                   unreadBySession={unreadBySession}
                   onRename={(next) => renameProject(project.id, next)}

--- a/ui/src/context/DockProvider.tsx
+++ b/ui/src/context/DockProvider.tsx
@@ -20,7 +20,32 @@ import { useLatestRef } from '@/lib/useLatestRef';
 // server's fresh-instance seed; reconcileDock takes over once the GET resolves.
 const DEFAULT_DOC: DockDoc = seedDefaultDock();
 
-export const DockProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+const DISABLED_DOCK_VALUE: DockValue = {
+  order: DEFAULT_DOC.order,
+  pins: [],
+  isPinned: () => false,
+  isDocked: (dockId) => DEFAULT_DOC.order.includes(dockId),
+  pinFor: () => null,
+  pin: () => Promise.resolve(),
+  unpin: () => Promise.resolve(),
+  dock: () => Promise.resolve(),
+  undock: () => Promise.resolve(),
+  setOrder: () => Promise.resolve(),
+};
+
+export const DockProvider: React.FC<{ children: React.ReactNode; enabled?: boolean }> = ({
+  children,
+  enabled = true,
+}) => {
+  if (!enabled) {
+    return (
+      <DockContext.Provider value={DISABLED_DOCK_VALUE}>{children}</DockContext.Provider>
+    );
+  }
+  return <EnabledDockProvider>{children}</EnabledDockProvider>;
+};
+
+const EnabledDockProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const api = useApi();
   const [doc, setDoc] = useState<DockDoc>(DEFAULT_DOC);
   // Latest committed doc for the async actions' rollback (avoids stale closures).

--- a/ui/src/context/DockProvider.tsx
+++ b/ui/src/context/DockProvider.tsx
@@ -19,32 +19,8 @@ import { useLatestRef } from '@/lib/useLatestRef';
 // immediately (no flicker) before the server document loads. Matches the
 // server's fresh-instance seed; reconcileDock takes over once the GET resolves.
 const DEFAULT_DOC: DockDoc = seedDefaultDock();
-const DISABLED_DOCK_VALUE: DockValue = {
-  order: DEFAULT_DOC.order,
-  pins: [],
-  isPinned: () => false,
-  isDocked: (dockId) => DEFAULT_DOC.order.includes(dockId),
-  pinFor: () => null,
-  pin: () => Promise.resolve(),
-  unpin: () => Promise.resolve(),
-  dock: () => Promise.resolve(),
-  undock: () => Promise.resolve(),
-  setOrder: () => Promise.resolve(),
-};
 
-export const DockProvider: React.FC<{ children: React.ReactNode; enabled?: boolean }> = ({
-  children,
-  enabled = true,
-}) => {
-  if (!enabled) {
-    return (
-      <DockContext.Provider value={DISABLED_DOCK_VALUE}>{children}</DockContext.Provider>
-    );
-  }
-  return <EnabledDockProvider>{children}</EnabledDockProvider>;
-};
-
-const EnabledDockProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+export const DockProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const api = useApi();
   const [doc, setDoc] = useState<DockDoc>(DEFAULT_DOC);
   // Latest committed doc for the async actions' rollback (avoids stale closures).

--- a/ui/src/context/InstanceAuthorizationContext.ts
+++ b/ui/src/context/InstanceAuthorizationContext.ts
@@ -6,12 +6,15 @@ import { DENIED_INSTANCE_CAPABILITIES } from '../lib/sessionInfo';
 export interface InstanceAuthorizationValue {
   remote: boolean;
   instanceRole: 'owner' | 'editor' | 'viewer' | null;
+  /** Temporary rollout policy, derived from signed active-Organization-member claims. */
+  hasTemporaryUnrestrictedOrgAppAccess?: boolean;
   capabilities: InstanceCapabilities;
 }
 
 export const InstanceAuthorizationContext = createContext<InstanceAuthorizationValue>({
   remote: false,
   instanceRole: null,
+  hasTemporaryUnrestrictedOrgAppAccess: false,
   capabilities: DENIED_INSTANCE_CAPABILITIES,
 });
 

--- a/ui/src/context/InstanceAuthorizationProvider.tsx
+++ b/ui/src/context/InstanceAuthorizationProvider.tsx
@@ -22,15 +22,23 @@ export const InstanceAuthorizationProvider = ({
       return {
         remote: false,
         instanceRole: session.instance_role ?? 'owner',
+        hasTemporaryUnrestrictedOrgAppAccess: false,
         capabilities: session.capabilities ?? OWNER_INSTANCE_CAPABILITIES,
       };
     }
     if (!session.authenticated) {
-      return { remote: true, instanceRole: null, capabilities: DENIED_INSTANCE_CAPABILITIES };
+      return {
+        remote: true,
+        instanceRole: null,
+        hasTemporaryUnrestrictedOrgAppAccess: false,
+        capabilities: DENIED_INSTANCE_CAPABILITIES,
+      };
     }
     return {
       remote: true,
       instanceRole: session.instance_role,
+      hasTemporaryUnrestrictedOrgAppAccess:
+        session.temporary_unrestricted_org_app_access,
       capabilities: session.capabilities,
     };
   }, [session]);

--- a/ui/src/lib/adminNavigation.test.ts
+++ b/ui/src/lib/adminNavigation.test.ts
@@ -47,7 +47,6 @@ describe('isLocalSystemPath', () => {
     expect(isLocalSystemPath('/admin/settings/diagnostics')).toBe(true);
     expect(isLocalSystemPath('/admin/settings/logs')).toBe(true);
     expect(isLocalSystemPath('/harness')).toBe(true);
-    expect(isLocalSystemPath('/apps/library')).toBe(true);
   });
 
   it('matches nested paths under a gated destination', () => {
@@ -58,6 +57,11 @@ describe('isLocalSystemPath', () => {
   it('leaves remotely usable destinations open', () => {
     expect(isLocalSystemPath('/admin/settings/messaging')).toBe(false);
     expect(isLocalSystemPath('/admin/organization/overview')).toBe(false);
+    expect(isLocalSystemPath('/apps/files')).toBe(false);
+    expect(isLocalSystemPath('/apps/editor')).toBe(false);
+    expect(isLocalSystemPath('/apps/terminal')).toBe(false);
+    expect(isLocalSystemPath('/apps/library')).toBe(false);
+    expect(isLocalSystemPath('/apps/show/session-1')).toBe(false);
     expect(isLocalSystemPath('/')).toBe(false);
   });
 

--- a/ui/src/lib/adminNavigation.ts
+++ b/ui/src/lib/adminNavigation.ts
@@ -12,9 +12,9 @@ export const isMemorySettingsPath = (pathname: string): boolean =>
  * `/api/control`; Remote Access drives pair / start / stop / optimize / settings
  * / diagnose (only its status read is remote-permitted); the service, platform,
  * backend, Model Hub, dependency, diagnostics, logs and users pages save or
- * reveal protected local state; Harness opens on `/api/harness/bootstrap`; and
- * the Library's Show Page controls are local-only. They therefore need the
- * trusted-local `can_use_system` capability on top, otherwise a remote owner
+ * reveal protected local state; and Harness opens on `/api/harness/bootstrap`.
+ * They therefore need the trusted-local `can_use_system` capability on top,
+ * otherwise a remote owner
  * gets partial or empty state and every mutation ends in
  * `remote_execution_disabled`.
  *
@@ -38,7 +38,6 @@ export const LOCAL_SYSTEM_ROUTES = [
   '/admin/settings/diagnostics',
   '/admin/settings/logs',
   '/harness',
-  '/apps/library',
 ] as const;
 
 const LOCAL_ONLY_MESSAGING_FIELDS = new Set([

--- a/ui/src/lib/sessionInfo.test.ts
+++ b/ui/src/lib/sessionInfo.test.ts
@@ -34,6 +34,7 @@ describe('normalizeSessionInfo', () => {
       email: 'owner@example.com',
       sub: 'owner-1',
       instance_role: 'owner',
+      temporary_unrestricted_org_app_access: false,
       capabilities: OWNER_INSTANCE_CAPABILITIES,
     });
   });
@@ -44,6 +45,7 @@ describe('normalizeSessionInfo', () => {
       authenticated: true,
       email: 'viewer@example.com',
       instance_role: 'viewer',
+      temporary_unrestricted_org_app_access: false,
       capabilities: {
         can_read_instance: true,
         can_use_show_pages: true,
@@ -55,12 +57,27 @@ describe('normalizeSessionInfo', () => {
       authenticated: true,
       email: 'viewer@example.com',
       instance_role: 'viewer',
+      temporary_unrestricted_org_app_access: false,
       capabilities: {
         ...DENIED_INSTANCE_CAPABILITIES,
         can_read_instance: true,
         can_use_show_pages: true,
       },
     });
+  });
+
+  it('preserves the temporary Organization policy signal without projecting a capability', () => {
+    const session = normalizeSessionInfo({
+      remote: true,
+      authenticated: true,
+      email: 'member@example.com',
+      instance_role: 'viewer',
+      temporary_unrestricted_org_app_access: true,
+      capabilities: { can_read_instance: true },
+    });
+
+    expect(session.temporary_unrestricted_org_app_access).toBe(true);
+    expect(session.capabilities.can_use_system).toBe(false);
   });
 
   it('keeps local sessions owner-compatible when an older server omits capabilities', () => {

--- a/ui/src/lib/sessionInfo.ts
+++ b/ui/src/lib/sessionInfo.ts
@@ -24,6 +24,7 @@ export type SessionInfo =
       email: string;
       sub?: string;
       instance_role: 'owner' | 'editor' | 'viewer';
+      temporary_unrestricted_org_app_access: boolean;
       capabilities: InstanceCapabilities;
     };
 
@@ -101,6 +102,8 @@ export const normalizeSessionInfo = (value: unknown): SessionInfo => {
     email: typeof value.email === 'string' ? value.email : '',
     ...(typeof value.sub === 'string' ? { sub: value.sub } : {}),
     instance_role: instanceRole,
+    temporary_unrestricted_org_app_access:
+      value.temporary_unrestricted_org_app_access === true,
     capabilities,
   };
 };

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -1317,7 +1317,7 @@ def _apply_session_meta(payloads: list[dict]) -> list[dict]:
     return payloads
 
 
-def list_show_pages() -> dict:
+def list_show_pages(*, user_context: Any = None) -> dict:
     """All Show Pages, newest-first, each enriched with the session title.
 
     Reuses ``ShowPageStore.list_page`` (already ordered by ``updated_at`` desc)
@@ -1330,7 +1330,7 @@ def list_show_pages() -> dict:
     config = V2Config.load()
     store = ShowPageStore()
     try:
-        result = store.list_page(page_request=None)
+        result = store.list_page(page_request=None, user_context=user_context)
         pages = [show_page_payload(page, config=config) for page in result.items]
     finally:
         store.close()
@@ -1350,11 +1350,12 @@ def _show_page_mutation_response(
     *,
     config: V2Config,
     additional_payload: dict | None = None,
+    user_context: Any = None,
 ) -> dict:
     """Return mutation details only when the caller can use the page."""
     from storage import resource_access_service
 
-    context = resource_access_service.resolve_resource_access_context()
+    context = resource_access_service.resolve_resource_access_context(user_context)
     with store.engine.connect() as connection:
         can_use = resource_access_service.can_use_resource(
             context,
@@ -1379,7 +1380,12 @@ def _show_page_mutation_response(
     }
 
 
-def set_show_page_visibility(session_id: str, visibility: str) -> dict:
+def set_show_page_visibility(
+    session_id: str,
+    visibility: str,
+    *,
+    user_context: Any = None,
+) -> dict:
     """Switch a Show Page between private / public / offline.
 
     Raises ``ShowPageError`` (a ``ValueError``) for invalid input, which the
@@ -1390,13 +1396,22 @@ def set_show_page_visibility(session_id: str, visibility: str) -> dict:
     config = V2Config.load()
     store = ShowPageStore()
     try:
-        updated = store.update_visibility(session_id, visibility)
-        return _show_page_mutation_response(store, updated, config=config)
+        updated = store.update_visibility(
+            session_id,
+            visibility,
+            user_context=user_context,
+        )
+        return _show_page_mutation_response(
+            store,
+            updated,
+            config=config,
+            user_context=user_context,
+        )
     finally:
         store.close()
 
 
-def ensure_show_page(session_id: str) -> dict:
+def ensure_show_page(session_id: str, *, user_context: Any = None) -> dict:
     """Create the session's Show Page if it doesn't exist yet; report which.
 
     ``existed`` tells the caller whether the page was already initialized, so the
@@ -1412,20 +1427,20 @@ def ensure_show_page(session_id: str) -> dict:
         # whether IT created the row (so the UI only prompts the agent on a real
         # first creation, not a concurrent ensure). Raises ShowPageError for an
         # archived session — the route maps it to a 4xx.
-        page, created = store.ensure_active(session_id)
+        page, created = store.ensure_active(session_id, user_context=user_context)
         payload = show_page_payload(page, config=config)
     finally:
         store.close()
     return {"ok": True, "existed": not created, **_apply_session_meta([payload])[0]}
 
 
-def get_show_page_access(session_id: str) -> dict:
+def get_show_page_access(session_id: str, *, user_context: Any = None) -> dict:
     """Return the applied authenticated audience and sharing authority."""
 
     from core.show_pages import ShowPageError, ShowPageStore
     from storage import resource_access_service
 
-    context = resource_access_service.resolve_resource_access_context()
+    context = resource_access_service.resolve_resource_access_context(user_context)
     store = ShowPageStore()
     try:
         page = store.get(session_id)
@@ -1481,11 +1496,15 @@ def get_show_page_access(session_id: str) -> dict:
     }
 
 
-def _require_show_page_email_access_owner(session_id: str) -> None:
+def _require_show_page_email_access_owner(
+    session_id: str,
+    *,
+    user_context: Any = None,
+) -> None:
     from core.show_pages import ShowPageError, ShowPageStore
     from storage import resource_access_service
 
-    context = resource_access_service.resolve_resource_access_context()
+    context = resource_access_service.resolve_resource_access_context(user_context)
     store = ShowPageStore()
     try:
         page = store.get(session_id)
@@ -1535,12 +1554,16 @@ def _show_page_email_access_error(exc: Exception):
     return ShowPageError(code, code=code)
 
 
-def get_show_page_authorized_emails(session_id: str) -> dict:
+def get_show_page_authorized_emails(
+    session_id: str,
+    *,
+    user_context: Any = None,
+) -> dict:
     """Return exact email grants for one owner-managed Show Page."""
 
     from vibe import remote_access
 
-    _require_show_page_email_access_owner(session_id)
+    _require_show_page_email_access_owner(session_id, user_context=user_context)
     try:
         result = remote_access.get_show_page_authorized_emails(session_id)
     except Exception as exc:
@@ -1548,12 +1571,17 @@ def get_show_page_authorized_emails(session_id: str) -> dict:
     return {"ok": True, "emails": result["emails"]}
 
 
-def replace_show_page_authorized_emails(session_id: str, emails: list[str]) -> dict:
+def replace_show_page_authorized_emails(
+    session_id: str,
+    emails: list[str],
+    *,
+    user_context: Any = None,
+) -> dict:
     """Replace one Show Page's exact email grants through paired-device auth."""
 
     from vibe import remote_access
 
-    _require_show_page_email_access_owner(session_id)
+    _require_show_page_email_access_owner(session_id, user_context=user_context)
     normalized = sorted({str(email).strip().lower() for email in emails if str(email).strip()})
     try:
         result = remote_access.replace_show_page_authorized_emails(session_id, normalized)
@@ -1566,25 +1594,34 @@ def replace_show_page_authorized_emails(session_id: str, emails: list[str]) -> d
     }
 
 
-def rotate_show_page_share(session_id: str) -> dict:
+def rotate_show_page_share(session_id: str, *, user_context: Any = None) -> dict:
     """Revoke the current public link and issue a new one (public pages only)."""
     from core.show_pages import ShowPageStore
 
     config = V2Config.load()
     store = ShowPageStore()
     try:
-        updated, previous_share_id = store.rotate_share(session_id)
+        updated, previous_share_id = store.rotate_share(
+            session_id,
+            user_context=user_context,
+        )
         return _show_page_mutation_response(
             store,
             updated,
             config=config,
             additional_payload={"previous_share_id": previous_share_id},
+            user_context=user_context,
         )
     finally:
         store.close()
 
 
-def set_show_page_share_id(session_id: str, share_id: str) -> dict:
+def set_show_page_share_id(
+    session_id: str,
+    share_id: str,
+    *,
+    user_context: Any = None,
+) -> dict:
     """Set a custom public link suffix (public pages only).
 
     Like ``rotate_show_page_share`` but with a caller-chosen value; setting it
@@ -1596,19 +1633,29 @@ def set_show_page_share_id(session_id: str, share_id: str) -> dict:
     config = V2Config.load()
     store = ShowPageStore()
     try:
-        updated, previous_share_id = store.set_share_id(session_id, share_id)
+        updated, previous_share_id = store.set_share_id(
+            session_id,
+            share_id,
+            user_context=user_context,
+        )
         return _show_page_mutation_response(
             store,
             updated,
             config=config,
             additional_payload={"previous_share_id": previous_share_id},
+            user_context=user_context,
         )
     finally:
         store.close()
 
 
 def upload_show_page_icon(
-    session_id: str, data: bytes, *, filename: str | None, content_type: str | None
+    session_id: str,
+    data: bytes,
+    *,
+    filename: str | None,
+    content_type: str | None,
+    user_context: Any = None,
 ) -> dict:
     """Write an uploaded image as the page's workspace-root favicon; return the
     refreshed page payload so the Web UI merges it like any other show-page mutation
@@ -1625,7 +1672,7 @@ def upload_show_page_icon(
     config = V2Config.load()
     store = ShowPageStore()
     try:
-        page = store.require_management(session_id)
+        page = store.require_management(session_id, user_context=user_context)
         if store.is_archived(session_id):
             # Archiving leaves the page offline and terminal; the other mutators guard it
             # with session_archived, so a direct icon upload must not slip past that.

--- a/vibe/authorization.py
+++ b/vibe/authorization.py
@@ -47,6 +47,7 @@ _EDITOR_WORKBENCH_EVENTS = frozenset({"queue.updated", "show.event"})
 _REMOTE_LOCAL_ONLY_WORKBENCH_EVENTS = frozenset({RUNS_UPDATED_EVENT})
 
 REMOTE_HTTP_ALLOWED = "allowed"
+REMOTE_HTTP_ACTIVE_ORGANIZATION_MEMBER = "active_organization_member"
 REMOTE_HTTP_LOCAL_ONLY = "local_only"
 REMOTE_HTTP_PAYLOAD_FILTERED = "payload_filtered"
 
@@ -136,18 +137,30 @@ class AuthorizationContext:
 
     @property
     def can_use_terminal_files(self) -> bool:
+        """Legacy trusted-local control capability, not an Apps visibility gate."""
+
         return not self.is_remote and self.has_role("owner")
 
     @property
     def can_use_terminal(self) -> bool:
+        """Legacy trusted-local control capability, not Terminal App access."""
+
         return not self.is_remote and self.has_role("owner")
 
     @property
     def can_use_files(self) -> bool:
+        """Legacy local-project filesystem capability, not Files App access."""
+
         return not self.is_remote and self.has_role("owner")
 
     @property
     def can_use_system(self) -> bool:
+        """Return access to trusted-local control-plane surfaces.
+
+        Apps are not system administration and must not use this capability as
+        an availability gate.
+        """
+
         return not self.is_remote and self.has_role("owner")
 
     def capability_projection(self) -> dict[str, bool]:
@@ -167,6 +180,25 @@ class AuthorizationContext:
             "can_use_files": self.can_use_files,
             "can_use_system": self.can_use_system,
         }
+
+
+def has_temporary_unrestricted_org_app_access(
+    context: AuthorizationContext | None,
+) -> bool:
+    """Return whether the temporary Organization Apps policy applies.
+
+    This is an HTTP/product rollout rule, not a projected capability. Until the
+    per-App and Show Page authorization model tracked in avibe#1313 ships, every
+    authenticated Organization member may use the remote Apps surfaces. Exact
+    Show Page email grants remain confined to their signed page subtree.
+    """
+
+    return bool(
+        context is not None
+        and context.is_remote
+        and context.instance_access_source != "show_page_email"
+        and context.is_active_organization_member
+    )
 
 
 def _optional_string(value: Any, *, limit: int = 320) -> str | None:
@@ -325,6 +357,7 @@ _VIEWER_HTTP_RULES = tuple(
         r"^/api/projects(?:/[^/]+)?$",
         r"^/api/workbench/prefs$",
         r"^/api/workbench/projects-bootstrap$",
+        r"^/api/dock$",
         r"^/api/sessions$",
         r"^/api/sessions/[^/]+$",
         r"^/api/sessions/[^/]+/(?:bootstrap|messages|activity|turn-state)$",
@@ -426,6 +459,31 @@ _REMOTE_PAYLOAD_FILTERED_HTTP_RULES = tuple(
     )
 )
 
+# Temporary, exact remote App surface for authenticated Organization members.
+# Keep this list route-specific: unrelated control-plane and future unknown API
+# endpoints must continue to fall through to the local-only default. The
+# replacement capability/resource model is tracked in avibe#1313.
+_TEMPORARY_ORGANIZATION_APP_HTTP_RULES = tuple(
+    (methods, re.compile(pattern))
+    for methods, pattern in (
+        (frozenset({"POST"}), r"^/api/dock/pins$"),
+        (frozenset({"DELETE"}), r"^/api/dock/pins/[^/]+$"),
+        (frozenset({"PUT"}), r"^/api/dock/order$"),
+        (
+            frozenset({"GET", "HEAD"}),
+            r"^/api/files/(?:list|meta|content|search|search_names)$",
+        ),
+        (
+            frozenset({"POST"}),
+            r"^/api/files/(?:upload|mkdir|rename|move|copy|delete|delete/undo|search/replace|search/undo)$",
+        ),
+        (frozenset({"PUT"}), r"^/api/files/write$"),
+        (frozenset({"GET", "HEAD"}), r"^/api/browse/favorites$"),
+        (frozenset({"DELETE"}), r"^/api/terminal/[^/]+$"),
+        (frozenset({"POST"}), r"^/api/show-pages/[^/]+/icon$"),
+    )
+)
+
 # Positive allowlist for remote-safe owner surfaces. Any route that mutates
 # local Agent, IM, Vault, or other execution state must stay absent here and
 # therefore use the fail-closed local-only default below.
@@ -449,11 +507,9 @@ _REMOTE_OWNER_ALLOWED_HTTP_RULES = tuple(
             frozenset({"GET", "HEAD", "PUT"}),
             r"^/api/show-pages/[^/]+/authorized-emails$",
         ),
-        # Reading the Dock is safe, but its pins/order and the Workbench prefs
-        # are one process-global record shared by the local owner and every
-        # remote principal. Until they are keyed by the authenticated subject a
-        # remote write would reorder and re-pin everyone else's Dock and flip
-        # another principal's banner preference, so the mutations stay local.
+        # Reading the Dock remains generally remote-safe. Dock writes are not
+        # listed here: the temporary Organization Apps matrix above admits only
+        # active members, while Workbench preference writes remain local-only.
         (frozenset({"GET", "HEAD"}), r"^/api/dock$"),
         # Reading push status stays remote, and so does the `POST` form of it:
         # it reports this principal's own subscription count and can only
@@ -534,6 +590,13 @@ def _owner_http_rule_matches(method: str, path: str) -> bool:
     )
 
 
+def _temporary_organization_app_rule_matches(method: str, path: str) -> bool:
+    return any(
+        method in methods and pattern.fullmatch(path)
+        for methods, pattern in _TEMPORARY_ORGANIZATION_APP_HTTP_RULES
+    )
+
+
 def http_authorization_policy(method: str, path: str) -> HttpAuthorizationPolicy:
     """Return role and remote-exposure policy for one HTTP request.
 
@@ -556,17 +619,22 @@ def http_authorization_policy(method: str, path: str) -> HttpAuthorizationPolicy
             r"^/show/[^/]+/(?:__show/events|__events)$",
             path,
         )
-        minimum_role = "viewer" if is_read else "editor"
+        minimum_role = "viewer"
         remote_access = (
             REMOTE_HTTP_ALLOWED
             if is_read or is_safe_human_event
-            else REMOTE_HTTP_LOCAL_ONLY
+            else REMOTE_HTTP_ACTIVE_ORGANIZATION_MEMBER
         )
         return HttpAuthorizationPolicy(minimum_role, remote_access)
     if path == "/status":
         return HttpAuthorizationPolicy(None, REMOTE_HTTP_LOCAL_ONLY)
     if not path.startswith("/api/"):
         return HttpAuthorizationPolicy(None)
+    if _temporary_organization_app_rule_matches(normalized_method, path):
+        return HttpAuthorizationPolicy(
+            "viewer",
+            REMOTE_HTTP_ACTIVE_ORGANIZATION_MEMBER,
+        )
 
     minimum_role = "owner"
     if _http_rule_matches(normalized_method, path, _VIEWER_HTTP_MUTATION_RULES):

--- a/vibe/authorization.py
+++ b/vibe/authorization.py
@@ -183,7 +183,7 @@ class AuthorizationContext:
 
 
 def has_temporary_unrestricted_org_app_access(
-    context: AuthorizationContext | None,
+    context: AuthorizationContext | Mapping[str, Any] | None,
 ) -> bool:
     """Return whether the temporary Organization Apps policy applies.
 
@@ -193,11 +193,18 @@ def has_temporary_unrestricted_org_app_access(
     Show Page email grants remain confined to their signed page subtree.
     """
 
+    resolved = (
+        context
+        if isinstance(context, AuthorizationContext)
+        else context_from_session_payload(context)
+        if context is not None
+        else None
+    )
     return bool(
-        context is not None
-        and context.is_remote
-        and context.instance_access_source != "show_page_email"
-        and context.is_active_organization_member
+        resolved is not None
+        and resolved.is_remote
+        and resolved.instance_access_source != "show_page_email"
+        and resolved.is_active_organization_member
     )
 
 
@@ -337,6 +344,8 @@ def can_receive_workbench_event(
 ) -> bool:
     """Return whether an SSE subscriber may receive a workbench event."""
 
+    if event_type == "show.event" and has_temporary_unrestricted_org_app_access(context):
+        return True
     try:
         require_instance_role(context, required_workbench_event_role(event_type))
     except InstanceAuthorizationError:
@@ -357,7 +366,6 @@ _VIEWER_HTTP_RULES = tuple(
         r"^/api/projects(?:/[^/]+)?$",
         r"^/api/workbench/prefs$",
         r"^/api/workbench/projects-bootstrap$",
-        r"^/api/dock$",
         r"^/api/sessions$",
         r"^/api/sessions/[^/]+$",
         r"^/api/sessions/[^/]+/(?:bootstrap|messages|activity|turn-state)$",
@@ -466,6 +474,7 @@ _REMOTE_PAYLOAD_FILTERED_HTTP_RULES = tuple(
 _TEMPORARY_ORGANIZATION_APP_HTTP_RULES = tuple(
     (methods, re.compile(pattern))
     for methods, pattern in (
+        (frozenset({"GET", "HEAD"}), r"^/api/dock$"),
         (frozenset({"POST"}), r"^/api/dock/pins$"),
         (frozenset({"DELETE"}), r"^/api/dock/pins/[^/]+$"),
         (frozenset({"PUT"}), r"^/api/dock/order$"),
@@ -507,10 +516,8 @@ _REMOTE_OWNER_ALLOWED_HTTP_RULES = tuple(
             frozenset({"GET", "HEAD", "PUT"}),
             r"^/api/show-pages/[^/]+/authorized-emails$",
         ),
-        # Reading the Dock remains generally remote-safe. Dock writes are not
-        # listed here: the temporary Organization Apps matrix above admits only
-        # active members, while Workbench preference writes remain local-only.
-        (frozenset({"GET", "HEAD"}), r"^/api/dock$"),
+        # Dock reads and writes are admitted only by the temporary Organization
+        # Apps matrix above; Workbench preference writes remain local-only.
         # Reading push status stays remote, and so does the `POST` form of it:
         # it reports this principal's own subscription count and can only
         # re-attach a device id to an endpoint that is already stored and

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -6557,7 +6557,11 @@ def remote_access_auth_callback():
 @app.route("/api/session", methods=["GET"])
 def api_session():
     from vibe import remote_access
-    from vibe.authorization import context_from_session_payload, trusted_local_context
+    from vibe.authorization import (
+        context_from_session_payload,
+        has_temporary_unrestricted_org_app_access,
+        trusted_local_context,
+    )
 
     config = _load_remote_access_config()
     if config is None or not _is_remote_access_request(config):
@@ -6592,6 +6596,9 @@ def api_session():
                     "email": str(payload.get("email", "")),
                     "sub": str(payload.get("sub", "")),
                     "instance_role": context.instance_role,
+                    "temporary_unrestricted_org_app_access": (
+                        has_temporary_unrestricted_org_app_access(context)
+                    ),
                     "capabilities": context.capability_projection(),
                 }
             )

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -19,6 +19,7 @@ import threading
 import time
 from collections import OrderedDict, deque
 from contextlib import contextmanager
+from dataclasses import replace
 from datetime import datetime, timezone
 from enum import Enum
 from pathlib import Path
@@ -2303,9 +2304,13 @@ def enforce_remote_access_cookie():
         if request.method == "GET" and context.instance_access_source != "show_page_email":
             show_page_id = _show_page_id_from_private_route(request.path)
             if show_page_id is not None:
-                resource_allowed = context.can_use_show_page(
-                    show_page_id
-                ) or _show_page_resource_access_allowed(context, show_page_id)
+                from vibe.authorization import has_temporary_unrestricted_org_app_access
+
+                resource_allowed = (
+                    has_temporary_unrestricted_org_app_access(context)
+                    or context.can_use_show_page(show_page_id)
+                    or _show_page_resource_access_allowed(context, show_page_id)
+                )
                 reauth_attempted = request.args.get(REMOTE_SHOW_PAGE_REAUTH_PARAM) == "1"
                 wants_html = "text/html" in request.headers.get("Accept", "")
                 raw_next = request.full_path if request.query_string else request.path
@@ -2379,6 +2384,23 @@ def enforce_show_page_email_scope():
     if public_static or exact_show_page:
         return None
     return jsonify({"ok": False, "error": "show_page_access_forbidden"}), 403
+
+
+def _temporary_org_app_resource_context(context: Any = None):
+    """Return a request-scoped resource context for the temporary Org policy.
+
+    The real authorization context remains on ``g`` for downstream identity,
+    renewal, and audit behavior. Only resource-service calls receive this copy,
+    which preserves the remote subject/Organization claims while bypassing the
+    Show Page ACL until avibe#1313 replaces the temporary full-access policy.
+    """
+
+    from vibe.authorization import has_temporary_unrestricted_org_app_access
+
+    resolved = context if context is not None else getattr(g, "authorization_context", None)
+    if not has_temporary_unrestricted_org_app_access(resolved):
+        return resolved
+    return replace(resolved, is_trusted_local=True)
 
 
 @app.before_request
@@ -2551,14 +2573,20 @@ async def enforce_remote_local_execution_boundary():
     if context is None or not context.is_remote:
         return None
     from vibe.authorization import (
+        REMOTE_HTTP_ACTIVE_ORGANIZATION_MEMBER,
         REMOTE_HTTP_LOCAL_ONLY,
         REMOTE_HTTP_PAYLOAD_FILTERED,
+        has_temporary_unrestricted_org_app_access,
         http_authorization_policy,
     )
 
     policy = getattr(g, "http_authorization_policy", None)
     if policy is None:
         policy = http_authorization_policy(request.method, request.path)
+    if policy.remote_access == REMOTE_HTTP_ACTIVE_ORGANIZATION_MEMBER:
+        if has_temporary_unrestricted_org_app_access(context):
+            return None
+        return _remote_execution_disabled_response()
     if policy.remote_access == REMOTE_HTTP_LOCAL_ONLY:
         return _remote_execution_disabled_response()
     if policy.remote_access != REMOTE_HTTP_PAYLOAD_FILTERED:
@@ -2609,8 +2637,13 @@ def enforce_project_role_capabilities():
         return None
 
     kind, resource_id = resource
-    if kind == "show_page" and context.can_use_show_page(resource_id):
-        return None
+    if kind == "show_page":
+        from vibe.authorization import has_temporary_unrestricted_org_app_access
+
+        if has_temporary_unrestricted_org_app_access(context) or context.can_use_show_page(
+            resource_id
+        ):
+            return None
     engine = create_sqlite_engine()
     with engine.connect() as conn:
         role = (
@@ -3082,7 +3115,11 @@ async def terminal_websocket(websocket: WebSocket, session_id: str):
     if not _terminal_origin_allowed(websocket):
         await websocket.close(code=1008)
         return
-    if not _show_runtime_websocket_authorized(websocket, minimum_role="owner"):
+    if not _show_runtime_websocket_authorized(
+        websocket,
+        minimum_role="viewer",
+        require_unrestricted_org_apps=True,
+    ):
         await websocket.close(code=1008)
         return
 
@@ -3090,9 +3127,6 @@ async def terminal_websocket(websocket: WebSocket, session_id: str):
     remote_payload = _remote_access_websocket_session_claims(websocket, config)
     if remote_payload is None and not _websocket_is_local_request(websocket, config):
         await websocket.close(code=_AUTHORIZATION_REFRESH_WEBSOCKET_CLOSE_CODE)
-        return
-    if remote_payload is not None:
-        await websocket.close(code=1008)
         return
     await websocket.accept()
     remote_addr = _websocket_client_host(websocket) or "unknown"
@@ -3186,7 +3220,11 @@ async def terminal_session_delete(session_id: str):
     terminal_request = _terminal_http_request_adapter()
     if not _terminal_origin_allowed(terminal_request):
         return jsonify({"ok": False, "error": "terminal_origin_forbidden"}), 403
-    if not _show_runtime_websocket_authorized(terminal_request, minimum_role="owner"):
+    if not _show_runtime_websocket_authorized(
+        terminal_request,
+        minimum_role="viewer",
+        require_unrestricted_org_apps=True,
+    ):
         return jsonify({"ok": False, "error": "terminal_unauthorized"}), 403
 
     remote_subject = _remote_access_websocket_subject(terminal_request)
@@ -3215,6 +3253,7 @@ def _show_runtime_websocket_authorized(
     *,
     minimum_role: str = "viewer",
     project_session_id: str | None = None,
+    require_unrestricted_org_apps: bool = False,
 ) -> bool:
     config = _load_remote_access_config()
     if config is None:
@@ -3226,10 +3265,17 @@ def _show_runtime_websocket_authorized(
     payload = _remote_access_websocket_session_payload(websocket, config)
     if payload is None:
         return False
-    from vibe.authorization import context_from_session_payload
+    from vibe.authorization import (
+        context_from_session_payload,
+        has_temporary_unrestricted_org_app_access,
+    )
 
     context = context_from_session_payload(payload)
     if not context.has_role(minimum_role):
+        return False
+    if require_unrestricted_org_apps and not has_temporary_unrestricted_org_app_access(
+        context
+    ):
         return False
     if project_session_id is None or context.is_instance_owner:
         return True
@@ -3238,8 +3284,13 @@ def _show_runtime_websocket_authorized(
 
 def _project_session_access_allowed(context: Any, session_id: str, minimum_role: str) -> bool:
     from storage import project_access_service
+    from vibe.authorization import has_temporary_unrestricted_org_app_access
 
-    if context is None or context.is_instance_owner:
+    if (
+        context is None
+        or context.is_instance_owner
+        or has_temporary_unrestricted_org_app_access(context)
+    ):
         return True
     if not context.has_role(minimum_role):
         return False
@@ -3275,8 +3326,9 @@ async def _wait_for_project_session_access_loss(
 
 def _show_page_resource_access_allowed(context: Any, session_id: str) -> bool:
     from storage import resource_access_service
+    from vibe.authorization import has_temporary_unrestricted_org_app_access
 
-    if context is None:
+    if context is None or has_temporary_unrestricted_org_app_access(context):
         return True
     try:
         return resource_access_service.can_use_resource(
@@ -3309,10 +3361,12 @@ def _show_runtime_websocket_resource_context(websocket: Any):
     payload = _remote_access_websocket_session_payload(websocket, config)
     if payload is None:
         return resource_access_service.ResourceUserContext()
-    return resource_access_service.current_resource_context(
-        payload,
-        is_remote=True,
-        is_trusted_local=False,
+    return _temporary_org_app_resource_context(
+        resource_access_service.current_resource_context(
+            payload,
+            is_remote=True,
+            is_trusted_local=False,
+        )
     )
 
 
@@ -4905,8 +4959,9 @@ def show_pages_list_get():
     from storage import project_access_service
     from vibe import api
 
-    payload = api.list_show_pages()
     context = getattr(g, "authorization_context", None)
+    resource_context = _temporary_org_app_resource_context(context)
+    payload = api.list_show_pages(user_context=resource_context)
     if _is_remote_show_page_request():
         payload = {
             **payload,
@@ -4915,7 +4970,11 @@ def show_pages_list_get():
                 for page in payload.get("pages", [])
             ],
         }
-    if context is not None and not context.is_instance_owner:
+    if (
+        context is not None
+        and not context.is_instance_owner
+        and not getattr(resource_context, "is_trusted_local", False)
+    ):
         engine = _projects_engine()
         with engine.connect() as conn:
             payload["pages"] = [
@@ -4941,7 +5000,13 @@ def show_page_visibility_post(session_id):
 
     payload = request.json or {}
     try:
-        return jsonify(api.set_show_page_visibility(session_id, str(payload.get("visibility") or "")))
+        return jsonify(
+            api.set_show_page_visibility(
+                session_id,
+                str(payload.get("visibility") or ""),
+                user_context=_temporary_org_app_resource_context(),
+            )
+        )
     except ShowPageError as exc:
         return _show_page_error_response(exc)
 
@@ -4952,7 +5017,14 @@ def show_page_ensure_post(session_id):
     from vibe import api
 
     try:
-        return jsonify(_show_page_payload_for_request(api.ensure_show_page(session_id)))
+        return jsonify(
+            _show_page_payload_for_request(
+                api.ensure_show_page(
+                    session_id,
+                    user_context=_temporary_org_app_resource_context(),
+                )
+            )
+        )
     except ShowPageError as exc:
         return _show_page_error_response(exc)
 
@@ -4963,7 +5035,12 @@ def show_page_access_get(session_id):
     from vibe import api
 
     try:
-        response = jsonify(api.get_show_page_access(session_id))
+        response = jsonify(
+            api.get_show_page_access(
+                session_id,
+                user_context=_temporary_org_app_resource_context(),
+            )
+        )
         response.headers["Cache-Control"] = "no-store, private"
         response.headers["Vary"] = "Cookie"
         return response
@@ -4977,7 +5054,12 @@ def show_page_authorized_emails_get(session_id):
     from vibe import api
 
     try:
-        response = jsonify(api.get_show_page_authorized_emails(session_id))
+        response = jsonify(
+            api.get_show_page_authorized_emails(
+                session_id,
+                user_context=_temporary_org_app_resource_context(),
+            )
+        )
         response.headers["Cache-Control"] = "no-store, private"
         response.headers["Vary"] = "Cookie"
         return response
@@ -5001,7 +5083,13 @@ def show_page_authorized_emails_put(session_id):
             ShowPageError("Invalid Show Page email audience.", code="invalid_email")
         )
     try:
-        return jsonify(api.replace_show_page_authorized_emails(session_id, emails))
+        return jsonify(
+            api.replace_show_page_authorized_emails(
+                session_id,
+                emails,
+                user_context=_temporary_org_app_resource_context(),
+            )
+        )
     except ShowPageError as exc:
         return _show_page_error_response(exc)
 
@@ -5012,7 +5100,12 @@ def show_page_rotate_share_post(session_id):
     from vibe import api
 
     try:
-        return jsonify(api.rotate_show_page_share(session_id))
+        return jsonify(
+            api.rotate_show_page_share(
+                session_id,
+                user_context=_temporary_org_app_resource_context(),
+            )
+        )
     except ShowPageError as exc:
         return _show_page_error_response(exc)
 
@@ -5024,7 +5117,13 @@ def show_page_set_share_id_post(session_id):
 
     payload = request.json or {}
     try:
-        return jsonify(api.set_show_page_share_id(session_id, str(payload.get("share_id") or "")))
+        return jsonify(
+            api.set_show_page_share_id(
+                session_id,
+                str(payload.get("share_id") or ""),
+                user_context=_temporary_org_app_resource_context(),
+            )
+        )
     except ShowPageError as exc:
         return _show_page_error_response(exc)
 
@@ -5063,7 +5162,10 @@ def show_page_icon_get(session_id):
     try:
         store = ShowPageStore()
         try:
-            page = store.require_access(session_id)
+            page = store.require_access(
+                session_id,
+                user_context=_temporary_org_app_resource_context(),
+            )
             # Any of the user's own pages — private, public, OR offline — may serve
             # its static icon: the payload advertises an icon token for all of them
             # and the inventory lists them, so gating by visibility would strand
@@ -5121,7 +5223,7 @@ def _dock_error_response(exc):
 def dock_get():
     from vibe import api
 
-    return jsonify(api.get_dock())
+    return jsonify(api.get_dock(user_context=_temporary_org_app_resource_context()))
 
 
 @app.route("/api/dock/pins", methods=["POST"])
@@ -5132,7 +5234,12 @@ def dock_pin_post():
 
     payload = request.json or {}
     try:
-        return jsonify(api.pin_dock_show_page(str(payload.get("session_id") or "")))
+        return jsonify(
+            api.pin_dock_show_page(
+                str(payload.get("session_id") or ""),
+                user_context=_temporary_org_app_resource_context(),
+            )
+        )
     except (DockError, ShowPageError) as exc:
         return _dock_error_response(exc)
 
@@ -5144,7 +5251,12 @@ def dock_unpin_delete(session_id):
     from vibe import api
 
     try:
-        return jsonify(api.unpin_dock_show_page(session_id))
+        return jsonify(
+            api.unpin_dock_show_page(
+                session_id,
+                user_context=_temporary_org_app_resource_context(),
+            )
+        )
     except (DockError, ShowPageError) as exc:
         return _dock_error_response(exc)
 
@@ -5161,7 +5273,13 @@ def dock_order_put():
         # concurrency — set_dock_order rejects the write as stale when it no
         # longer matches the server's, so a stale tab can't silently undock a pin
         # another tab installed.
-        return jsonify(api.set_dock_order(payload.get("order"), known=payload.get("known")))
+        return jsonify(
+            api.set_dock_order(
+                payload.get("order"),
+                known=payload.get("known"),
+                user_context=_temporary_org_app_resource_context(),
+            )
+        )
     except (DockError, ShowPageError) as exc:
         return _dock_error_response(exc)
 
@@ -9528,6 +9646,7 @@ async def show_page_icon_upload(session_id: str, starlette_request: FastAPIReque
                     data,
                     filename=upload.filename,
                     content_type=upload.content_type,
+                    user_context=_temporary_org_app_resource_context(),
                 )
                 # Broadcast so EVERY already-mounted inventory (Dock, WindowLayer, mobile
                 # drawer, app search) reloads and picks up the new icon_version — the
@@ -9836,10 +9955,18 @@ def _media_row_show_page_access_allowed(context: Any, row: dict[str, Any]) -> bo
 
 def _request_can_read_media_row(conn, token: str, row: dict[str, Any]) -> bool:
     from storage import media_service, project_access_service
+    from vibe.authorization import has_temporary_unrestricted_org_app_access
 
     context = getattr(g, "authorization_context", None)
     if not _media_row_show_page_access_allowed(context, row):
         return False
+    if row.get("source") == "show_annotation" and has_temporary_unrestricted_org_app_access(
+        context
+    ):
+        # Annotation screenshots are part of the Show Page surface. During the
+        # temporary unrestricted Organization rollout they follow the page,
+        # while all unrelated media keeps its existing Project/session ACL.
+        return True
     if context is None or context.is_instance_owner:
         return True
     session_ids = media_service.referenced_session_ids(conn, token)
@@ -10919,6 +11046,12 @@ def _workbench_event_visible_to_context(context, event_type: str, payload: str) 
             return False
         if not _show_page_resource_access_allowed(context, session_id):
             return False
+        from vibe.authorization import has_temporary_unrestricted_org_app_access
+
+        if has_temporary_unrestricted_org_app_access(context):
+            # Show events are page content. Keep them aligned with the same
+            # temporary all-pages policy instead of reapplying Project ACL here.
+            return True
     if context.is_instance_owner:
         return True
     if event_type in {"authorization.changed", "workbench.events.bridge.status"}:
@@ -13680,7 +13813,10 @@ def redirect_private_show_page_to_canonical_path(session_id):
     store = ShowPageStore()
     try:
         try:
-            page = store.require_access(session_id)
+            page = store.require_access(
+                session_id,
+                user_context=_temporary_org_app_resource_context(),
+            )
         except ShowPageError as exc:
             if exc.code == "resource_access_forbidden":
                 return _show_page_access_forbidden_response()
@@ -13711,7 +13847,10 @@ async def serve_private_show_page(session_id, asset_path):
     store = ShowPageStore()
     try:
         try:
-            page = store.require_access(session_id)
+            page = store.require_access(
+                session_id,
+                user_context=_temporary_org_app_resource_context(),
+            )
         except ShowPageError as exc:
             if exc.code == "resource_access_forbidden":
                 return _show_page_access_forbidden_response()


### PR DESCRIPTION
## Architecture scope

No avibe-backend or control-plane change is required. Existing signed OIDC claims already carry instance role and Organization membership. This PR changes only the Avibe runtime/UI data-plane consumers of those claims; the control-plane/data-plane identity contract and claim schema remain unchanged.

## Summary

- Temporarily expose the Apps launcher, Dock, Window Layer, and full built-in App Library to authenticated active Organization owners and members.
- Allow the exact Files and Editor HTTP surface plus the Terminal HTTP/WebSocket surface remotely without using `can_use_files`, `can_use_terminal`, or `can_use_system` as App gates.
- Temporarily make authenticated Show Page inventory, content, mutation, icon, event, annotation, and HMR surfaces available to every active Organization member.
- Keep the existing capability projection unchanged. This PR does not add or fabricate an App capability or App ACL.

## Temporary policy and follow-up

This is an explicit temporary full-access policy. Follow-up capability and resource ACL design is tracked in [#1313](https://github.com/avibe-bot/avibe/issues/1313). The request-scoped Organization App policy and Show Page ACL bypass must be removed when that work ships.

## Security boundaries retained

- Active Organization membership and signed remote sessions remain mandatory.
- Organization management, config/settings writes outside the existing filtered preference contract, Vault, Harness, service control, and unknown local-only endpoints remain fail-closed.
- Files and Editor access is restricted to the explicit current `/api/files/*` App endpoint matrix plus favorites; adjacent browse and future unknown endpoints are not opened.
- Terminal keeps exact-Origin validation, authorization refresh, and subject-hashed session isolation.
- Anonymous `/p/` access still requires a public page.
- Exact-email Show Page sessions remain confined to their signed page subtree.
- The persistent Project and Show Page ACL services remain intact; qualifying Organization requests receive a request-scoped temporary bypass only.

## Scenario IDs

- `AUTH-SETUP-401`: exact-email Show Page login remains confined to its signed page while active Organization members receive the temporary broader App policy.

## Evidence

- Unit and policy contract: `854 passed` across focused instance authorization, remote HTTP, Terminal, Show Page ACL/runtime, Dock, and `AUTH-SETUP-401` tests.
- UI contract: `132 passed` across Apps registry/launch, Dock/window state, AppShell routes, Show Page inventory, and admin navigation tests.
- Python lint: Ruff passed for every changed Python file.
- Python syntax: focused `compileall` passed.
- UI lint: baseline lint passed for 604 TypeScript sources with no drift.
- UI typecheck/build: `npm run build` passed, including import validation and `tsc -b`.
- Formatting: `git diff --check` passed.

## Residual manual evidence

No live remote browser or Incus end-to-end run was performed, and the local Avibe service was not restarted. GitHub CI and exact-head Codex review remain the delivery gates.

## Known by design

- During this temporary policy, every active Organization member can access the host filesystem through Files/Editor, create subject-isolated terminal sessions, use every authenticated Show Page including management controls, and mutate the instance-global Dock.
- Show Page email-grant sessions and anonymous public links are deliberately excluded from the broad Organization bypass.
- These risks are accepted only for the temporary rollout and are explicitly tracked in #1313.
