### PR TITLE
feat(memory): ship confirmed embedding rebuild recovery

### DIFF
--- a/config/v2_config.py
+++ b/config/v2_config.py
@@ -1676,81 +1676,105 @@ class V2Config:
 
         return config
 
-    def save(self, config_path: Optional[Path] = None) -> None:
+    def save(
+        self,
+        config_path: Optional[Path] = None,
+        *,
+        persist_memory: bool = False,
+    ) -> None:
+        """Persist this config.
+
+        Direct writers (language, Model Hub, agent auth, remote access, …) must
+        not re-arm or clobber a Memory candidate/marker settled by another
+        process. Every save therefore takes the Memory config transaction; when
+        *persist_memory* is false the on-disk Memory unit is re-read under that
+        lock so a stale in-memory snapshot cannot overwrite it. Memory-owning
+        writers (``save_config(allow_memory=True)``, Controller settlement) pass
+        ``persist_memory=True``.
+        """
+
         paths.ensure_data_dirs()
         path = config_path or paths.get_config_path()
-        self.platforms.validate()
-        self.memory.validate()
-        self.platform = self.platforms.primary
-        platform_payload = {}
-        for descriptor in platform_descriptors():
-            descriptor_config = descriptor.get_config(self)
-            config_payload = descriptor_config.__dict__.copy() if descriptor_config else None
-            if descriptor.id == "discord" and isinstance(config_payload, dict):
-                if not config_payload.get("guild_allowlist") and not config_payload.get("guild_denylist"):
-                    config_payload.pop("guild_allowlist", None)
-                    config_payload.pop("guild_denylist", None)
-            platform_payload[descriptor.config_key] = config_payload
-        payload = {
-            "platform": self.platform,
-            "platforms": {
-                "enabled": self.platforms.enabled,
-                "primary": self.platforms.primary,
-            },
-            "mode": self.mode,
-            "version": self.version,
-            **platform_payload,
-            "runtime": {
-                "default_cwd": self.runtime.default_cwd,
-                "log_level": self.runtime.log_level,
-                "resource_governance": self.runtime.resource_governance,
-                "harness_run_sweep_interval_seconds": self.runtime.harness_run_sweep_interval_seconds,
-                "harness_run_orphan_grace_seconds": self.runtime.harness_run_orphan_grace_seconds,
-                "harness_run_queued_ttl_seconds": self.runtime.harness_run_queued_ttl_seconds,
-                "harness_run_hold_ttl_seconds": self.runtime.harness_run_hold_ttl_seconds,
-                "harness_prompt_echo": self.runtime.harness_prompt_echo,
-            },
-            "agents": {
-                "opencode": self.agents.opencode.__dict__,
-                "claude": self.agents.claude.__dict__,
-                "codex": self.agents.codex.__dict__,
-                "avault": self.agents.avault.__dict__,
-            },
-            "memory": memory_config_to_payload(
-                self.memory,
-                include_secrets=True,
-                include_internal=True,
-            ),
-            "model_hub": self.model_hub.to_payload(),
-            "gateway": self.gateway.__dict__ if self.gateway else None,
-            "ui": self.ui.__dict__,
-            "remote_access": {
-                "provider": self.remote_access.provider,
-                "vibe_cloud": self.remote_access.vibe_cloud.__dict__,
-            },
-            "audio_asr": self.audio_asr.__dict__,
-            "update": self.update.__dict__,
-            "ack_mode": self.ack_mode,
-            "show_duration": self.show_duration,
-            "include_time_info": self.include_time_info,
-            "include_user_info": self.include_user_info,
-            "reply_enhancements": self.reply_enhancements,
-            "show_pages_prompt": self.show_pages_prompt,
-            "language": self.language,
-            "agent_progress_style": self.agent_progress_style,
-            "agent_status_heartbeat_ms": self.agent_status_heartbeat_ms,
-            "agent_status_no_output_ms": self.agent_status_no_output_ms,
-            "setup_completed": self.setup_completed,
-        }
-        content = json.dumps(payload, indent=2)
-        path.parent.mkdir(parents=True, exist_ok=True)
-        with CONFIG_LOCK:
-            with tempfile.NamedTemporaryFile("w", encoding="utf-8", dir=path.parent, delete=False) as tmp:
-                tmp.write(content)
-                tmp.flush()
-                os.fsync(tmp.fileno())
-                temp_name = tmp.name
-            os.replace(temp_name, path)
+        with memory_config_transaction():
+            if not persist_memory:
+                try:
+                    # Re-read under the shared lock so a concurrent settlement
+                    # that cleared the marker is the value this write keeps.
+                    self.memory = type(self).load(path).memory
+                except FileNotFoundError:
+                    pass
+            self.platforms.validate()
+            self.memory.validate()
+            self.platform = self.platforms.primary
+            platform_payload = {}
+            for descriptor in platform_descriptors():
+                descriptor_config = descriptor.get_config(self)
+                config_payload = descriptor_config.__dict__.copy() if descriptor_config else None
+                if descriptor.id == "discord" and isinstance(config_payload, dict):
+                    if not config_payload.get("guild_allowlist") and not config_payload.get("guild_denylist"):
+                        config_payload.pop("guild_allowlist", None)
+                        config_payload.pop("guild_denylist", None)
+                platform_payload[descriptor.config_key] = config_payload
+            payload = {
+                "platform": self.platform,
+                "platforms": {
+                    "enabled": self.platforms.enabled,
+                    "primary": self.platforms.primary,
+                },
+                "mode": self.mode,
+                "version": self.version,
+                **platform_payload,
+                "runtime": {
+                    "default_cwd": self.runtime.default_cwd,
+                    "log_level": self.runtime.log_level,
+                    "resource_governance": self.runtime.resource_governance,
+                    "harness_run_sweep_interval_seconds": self.runtime.harness_run_sweep_interval_seconds,
+                    "harness_run_orphan_grace_seconds": self.runtime.harness_run_orphan_grace_seconds,
+                    "harness_run_queued_ttl_seconds": self.runtime.harness_run_queued_ttl_seconds,
+                    "harness_run_hold_ttl_seconds": self.runtime.harness_run_hold_ttl_seconds,
+                    "harness_prompt_echo": self.runtime.harness_prompt_echo,
+                },
+                "agents": {
+                    "opencode": self.agents.opencode.__dict__,
+                    "claude": self.agents.claude.__dict__,
+                    "codex": self.agents.codex.__dict__,
+                    "avault": self.agents.avault.__dict__,
+                },
+                "memory": memory_config_to_payload(
+                    self.memory,
+                    include_secrets=True,
+                    include_internal=True,
+                ),
+                "model_hub": self.model_hub.to_payload(),
+                "gateway": self.gateway.__dict__ if self.gateway else None,
+                "ui": self.ui.__dict__,
+                "remote_access": {
+                    "provider": self.remote_access.provider,
+                    "vibe_cloud": self.remote_access.vibe_cloud.__dict__,
+                },
+                "audio_asr": self.audio_asr.__dict__,
+                "update": self.update.__dict__,
+                "ack_mode": self.ack_mode,
+                "show_duration": self.show_duration,
+                "include_time_info": self.include_time_info,
+                "include_user_info": self.include_user_info,
+                "reply_enhancements": self.reply_enhancements,
+                "show_pages_prompt": self.show_pages_prompt,
+                "language": self.language,
+                "agent_progress_style": self.agent_progress_style,
+                "agent_status_heartbeat_ms": self.agent_status_heartbeat_ms,
+                "agent_status_no_output_ms": self.agent_status_no_output_ms,
+                "setup_completed": self.setup_completed,
+            }
+            content = json.dumps(payload, indent=2)
+            path.parent.mkdir(parents=True, exist_ok=True)
+            with CONFIG_LOCK:
+                with tempfile.NamedTemporaryFile("w", encoding="utf-8", dir=path.parent, delete=False) as tmp:
+                    tmp.write(content)
+                    tmp.flush()
+                    os.fsync(tmp.fileno())
+                    temp_name = tmp.name
+                os.replace(temp_name, path)
 
     def enabled_platforms(self) -> list[str]:
         return list(self.platforms.enabled)

--- a/config/v2_config.py
+++ b/config/v2_config.py
@@ -32,6 +32,43 @@ CONFIG_LOCK = threading.RLock()
 _memory_config_tx_state = threading.local()
 
 
+def _acquire_memory_config_file_lock(descriptor: int) -> None:
+    """Acquire a cross-process exclusive lock with a platform-supported API."""
+
+    if os.name == "nt":
+        import msvcrt
+
+        # Lock one byte of the file; Windows keeps the range until unlocked.
+        os.lseek(descriptor, 0, os.SEEK_SET)
+        try:
+            os.write(descriptor, b"\0")
+        except OSError:
+            pass
+        os.lseek(descriptor, 0, os.SEEK_SET)
+        msvcrt.locking(descriptor, msvcrt.LK_LOCK, 1)
+        return
+    import fcntl
+
+    fcntl.flock(descriptor, fcntl.LOCK_EX)
+
+
+def _release_memory_config_file_lock(descriptor: int) -> None:
+    """Release the cross-process exclusive lock acquired by the helper above."""
+
+    try:
+        if os.name == "nt":
+            import msvcrt
+
+            os.lseek(descriptor, 0, os.SEEK_SET)
+            msvcrt.locking(descriptor, msvcrt.LK_UNLCK, 1)
+        else:
+            import fcntl
+
+            fcntl.flock(descriptor, fcntl.LOCK_UN)
+    except Exception:
+        pass
+
+
 @contextmanager
 def memory_config_transaction() -> Iterator[None]:
     """Narrow cross-process exclusive section for Memory candidate+marker writes.
@@ -40,8 +77,9 @@ def memory_config_transaction() -> Iterator[None]:
     so settlement and a concurrent settings save need a shared file lock around
     the durable Memory unit. This is not a general multi-writer config service.
 
-    Nested acquisitions in the same thread only re-enter ``CONFIG_LOCK`` so
-    ``save_memory_config`` can call ``save_config`` without deadlocking the flock.
+    Lock order is always ``CONFIG_LOCK`` then the file lock, matching existing
+    callers that already hold ``CONFIG_LOCK`` when they enter ``save_config``.
+    Nested acquisitions only re-enter the process lock.
     """
 
     depth = getattr(_memory_config_tx_state, "depth", 0)
@@ -59,21 +97,19 @@ def memory_config_transaction() -> Iterator[None]:
         0o600,
     )
     _memory_config_tx_state.depth = 1
-    try:
-        import fcntl
-
-        fcntl.flock(descriptor, fcntl.LOCK_EX)
-        with CONFIG_LOCK:
-            yield
-    finally:
-        _memory_config_tx_state.depth = 0
+    # CONFIG_LOCK first so threads that already hold it (remote_access/settings
+    # helpers) never wait on the file lock while another waiter holds the file
+    # lock and waits for CONFIG_LOCK.
+    with CONFIG_LOCK:
         try:
-            import fcntl
-
-            fcntl.flock(descriptor, fcntl.LOCK_UN)
-        except Exception:
-            pass
-        os.close(descriptor)
+            _acquire_memory_config_file_lock(descriptor)
+            try:
+                yield
+            finally:
+                _release_memory_config_file_lock(descriptor)
+        finally:
+            _memory_config_tx_state.depth = 0
+            os.close(descriptor)
 
 
 DEFAULT_AGENT_IDLE_TIMEOUT_SECONDS = 600

--- a/config/v2_config.py
+++ b/config/v2_config.py
@@ -29,6 +29,7 @@ from vibe.i18n import normalize_language
 logger = logging.getLogger(__name__)
 
 CONFIG_LOCK = threading.RLock()
+_memory_config_tx_state = threading.local()
 
 
 @contextmanager
@@ -38,7 +39,16 @@ def memory_config_transaction() -> Iterator[None]:
     UI and Controller run in different processes. ``CONFIG_LOCK`` is process-local,
     so settlement and a concurrent settings save need a shared file lock around
     the durable Memory unit. This is not a general multi-writer config service.
+
+    Nested acquisitions in the same thread only re-enter ``CONFIG_LOCK`` so
+    ``save_memory_config`` can call ``save_config`` without deadlocking the flock.
     """
+
+    depth = getattr(_memory_config_tx_state, "depth", 0)
+    if depth > 0:
+        with CONFIG_LOCK:
+            yield
+        return
 
     paths.ensure_data_dirs()
     lock_path = paths.get_config_dir() / "memory-config.tx.lock"
@@ -48,6 +58,7 @@ def memory_config_transaction() -> Iterator[None]:
         os.O_RDWR | os.O_CREAT | getattr(os, "O_CLOEXEC", 0),
         0o600,
     )
+    _memory_config_tx_state.depth = 1
     try:
         import fcntl
 
@@ -55,6 +66,7 @@ def memory_config_transaction() -> Iterator[None]:
         with CONFIG_LOCK:
             yield
     finally:
+        _memory_config_tx_state.depth = 0
         try:
             import fcntl
 

--- a/config/v2_config.py
+++ b/config/v2_config.py
@@ -5,10 +5,11 @@ import os
 import re
 import tempfile
 import threading
+from contextlib import contextmanager
 from dataclasses import dataclass, field, fields
 from datetime import datetime
 from pathlib import Path
-from typing import List, Literal, Mapping, Optional, Union
+from typing import Iterator, List, Literal, Mapping, Optional, Union
 from urllib.parse import urlsplit, urlunsplit
 
 from config import paths
@@ -28,6 +29,40 @@ from vibe.i18n import normalize_language
 logger = logging.getLogger(__name__)
 
 CONFIG_LOCK = threading.RLock()
+
+
+@contextmanager
+def memory_config_transaction() -> Iterator[None]:
+    """Narrow cross-process exclusive section for Memory candidate+marker writes.
+
+    UI and Controller run in different processes. ``CONFIG_LOCK`` is process-local,
+    so settlement and a concurrent settings save need a shared file lock around
+    the durable Memory unit. This is not a general multi-writer config service.
+    """
+
+    paths.ensure_data_dirs()
+    lock_path = paths.get_config_dir() / "memory-config.tx.lock"
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor = os.open(
+        lock_path,
+        os.O_RDWR | os.O_CREAT | getattr(os, "O_CLOEXEC", 0),
+        0o600,
+    )
+    try:
+        import fcntl
+
+        fcntl.flock(descriptor, fcntl.LOCK_EX)
+        with CONFIG_LOCK:
+            yield
+    finally:
+        try:
+            import fcntl
+
+            fcntl.flock(descriptor, fcntl.LOCK_UN)
+        except Exception:
+            pass
+        os.close(descriptor)
+
 
 DEFAULT_AGENT_IDLE_TIMEOUT_SECONDS = 600
 

--- a/core/internal_server.py
+++ b/core/internal_server.py
@@ -908,6 +908,27 @@ def create_app(
                 content={"ok": False, "error": "memory_restart_failed"},
             )
 
+    @app.post("/internal/memory/rebuild")
+    async def _memory_rebuild() -> Any:
+        """Run one retained Memory rebuild and wait for the closed result."""
+
+        runtime = _memory_runtime()
+        if runtime is None:
+            return JSONResponse(
+                status_code=503,
+                content={"ok": False, "error": "memory_runtime_missing", "result": "failed"},
+            )
+        try:
+            result = await runtime.rebuild()
+            status_code = 200 if result.get("ok") is True else 409
+            return JSONResponse(status_code=status_code, content=result)
+        except Exception:
+            logger.exception("internal memory rebuild failed")
+            return JSONResponse(
+                status_code=503,
+                content={"ok": False, "error": "memory_rebuild_failed", "result": "failed"},
+            )
+
     @app.post("/internal/memory/install-runtime")
     async def _memory_install_runtime() -> Any:
         """Install or repair the managed runtime on the controller lifecycle."""

--- a/core/memory/runtime.py
+++ b/core/memory/runtime.py
@@ -17,7 +17,7 @@ from pathlib import Path
 from typing import Any, TypeVar
 
 from config import paths
-from config.v2_config import CONFIG_LOCK, MemoryConfig, V2Config
+from config.v2_config import CONFIG_LOCK, MemoryConfig, V2Config, memory_config_transaction
 from core.memory.artifact import (
     EVEROS_VERSION,
     MemoryArtifactCandidate,
@@ -53,6 +53,7 @@ from core.memory.process import (
     EverOSProcessPort,
     EverOSRebuildProcess,
     EverOSProcessSettings,
+    RebuildProcessResult,
 )
 from core.memory.sidecar_lifecycle import MemorySidecarLifecycle, SidecarSnapshot
 from core.memory.processing_record import (
@@ -338,6 +339,7 @@ class MemoryRuntime:
             self._advance_processing_lifecycle
         )
         self._restart_task: asyncio.Task[dict[str, Any]] | None = None
+        self._rebuild_task: asyncio.Task[dict[str, Any]] | None = None
         self._ready_activation_task: asyncio.Task[None] | None = None
         self._artifact_activation_task: asyncio.Task[None] | None = None
         self._closing = False
@@ -661,6 +663,9 @@ class MemoryRuntime:
     async def _reconcile(self, config: MemoryConfig) -> dict[str, Any]:
         """Run one reconciliation owned by the public lifecycle operation."""
 
+        if self._rebuild_running() and asyncio.current_task() is not self._rebuild_task:
+            return {"ok": False, "error": "memory_operation_in_progress"}
+
         # Before every early return below, because a boot that never launches a
         # sidecar is exactly the boot that may face one from the run before it.
         # Takes and releases the reconcile lock itself; the lock this method
@@ -773,28 +778,45 @@ class MemoryRuntime:
                 self._runtime_error = "memory_clear_failed"
                 return {"ok": False, "error": self._runtime_error}
             claims_paused = True
-            embedding_guard_rejected = False
-            try:
-                if await asyncio.to_thread(self._provider_data_exists_strict):
+            # A durable pending marker means the user confirmed rebuild; non-empty
+            # roots stay fenced for an explicit rebuild rather than failing as a
+            # clear-style rejection. Only unmarked identity drift still fails
+            # closed when data exists.
+            if not config.embedding_change_pending:
+                embedding_guard_rejected = False
+                try:
+                    if await asyncio.to_thread(self._provider_data_exists_strict):
+                        embedding_guard_rejected = True
+                        self._runtime_error = "memory_clear_failed"
+                        return {"ok": False, "error": self._runtime_error}
+                except Exception:
+                    # An indeterminate root/queue state cannot safely accept an
+                    # embedding change because it could mix vector spaces.
                     embedding_guard_rejected = True
                     self._runtime_error = "memory_clear_failed"
                     return {"ok": False, "error": self._runtime_error}
-            except Exception:
-                # An indeterminate root/queue state cannot safely accept an
-                # embedding change because it could mix vector spaces.
-                embedding_guard_rejected = True
-                self._runtime_error = "memory_clear_failed"
-                return {"ok": False, "error": self._runtime_error}
-            finally:
-                if embedding_guard_rejected and resume_claims_on_failure:
-                    self.module.resume_claims()
-                    claims_paused = False
+                finally:
+                    if embedding_guard_rejected and resume_claims_on_failure:
+                        self.module.resume_claims()
+                        claims_paused = False
 
         if config.embedding_change_pending:
             # A durable candidate marker prevents a post-save crash from
-            # comparing the candidate against itself on next startup. Clear it
-            # only after the guarded inspection succeeds, while claims remain
-            # paused, so no capture can resume against an unverified config.
+            # comparing the candidate against itself on next startup. Empty
+            # roots may settle here. Non-empty (or indeterminate) roots keep
+            # claims fenced and the sidecar down until an explicit rebuild.
+            try:
+                has_data = await asyncio.to_thread(self._provider_data_exists_strict)
+            except Exception:
+                has_data = True
+            if has_data:
+                self.module.pause_claims()
+                await self._stop_worker()
+                await self._sidecar.stop()
+                self._config = config
+                self._restart_config = deepcopy(config)
+                self._runtime_error = "memory_embedding_rebuild_required"
+                return {"ok": False, "error": "memory_embedding_rebuild_required"}
             if not await asyncio.to_thread(self._settle_embedding_change_pending, config):
                 error = "memory_runtime_install_failed"
                 if not (self._process and self._process.running):
@@ -1269,6 +1291,8 @@ class MemoryRuntime:
     async def clear(self, *, operator_ref: str) -> dict[str, Any]:
         if not self.available:
             raise self._unavailable()
+        if self._rebuild_running():
+            return {"status": "failed", "error": "memory_operation_in_progress"}
         result = await self._require_maintenance().clear(operator_ref=operator_ref)
         return _clear_result_payload(result)
 
@@ -1280,6 +1304,8 @@ class MemoryRuntime:
     ) -> dict[str, Any]:
         if not self.available:
             raise self._unavailable()
+        if self._rebuild_running():
+            return {"status": "failed", "error": "memory_operation_in_progress"}
         result = await self._require_maintenance().resume_clear(
             operation_id,
             operator_ref=operator_ref,
@@ -1294,6 +1320,8 @@ class MemoryRuntime:
     ) -> dict[str, Any]:
         if not self.available:
             raise self._unavailable()
+        if self._rebuild_running():
+            return {"status": "failed", "error": "memory_operation_in_progress"}
         result = await self._require_maintenance().abort_clear(
             operation_id,
             operator_ref=operator_ref,
@@ -1514,6 +1542,8 @@ class MemoryRuntime:
     async def restart(self) -> dict[str, Any]:
         """Join or start one process-only replacement of the Memory sidecar."""
 
+        if self._rebuild_running():
+            return {"ok": False, "error": "memory_operation_in_progress"}
         task = self._restart_task
         if task is None or task.done():
             task = asyncio.create_task(self._restart_once(), name="memory-restart")
@@ -1526,6 +1556,25 @@ class MemoryRuntime:
             task.add_done_callback(clear_restart)
         return await asyncio.shield(task)
 
+    async def rebuild(self) -> dict[str, Any]:
+        """Join or start one retained embedding-index rebuild over the cascade child."""
+
+        task = self._rebuild_task
+        if task is None or task.done():
+            task = asyncio.create_task(self._rebuild_once(), name="memory-rebuild")
+            self._rebuild_task = task
+
+            def clear_rebuild(completed: asyncio.Task[dict[str, Any]]) -> None:
+                if self._rebuild_task is completed:
+                    self._rebuild_task = None
+
+            task.add_done_callback(clear_rebuild)
+        return await asyncio.shield(task)
+
+    def _rebuild_running(self) -> bool:
+        task = self._rebuild_task
+        return task is not None and not task.done()
+
     async def _restart_once(self) -> dict[str, Any]:
         try:
             async with self._reconcile_lock:
@@ -1533,6 +1582,21 @@ class MemoryRuntime:
         except Exception:
             logger.exception("Memory sidecar restart failed")
             return {"ok": False, "error": "memory_restart_failed"}
+        finally:
+            if self._maintenance is not None:
+                self._maintenance.ensure_housekeeping()
+
+    async def _rebuild_once(self) -> dict[str, Any]:
+        try:
+            async with self._reconcile_lock:
+                return await self._rebuild_locked()
+        except Exception:
+            logger.exception("Memory embedding rebuild failed")
+            return {
+                "ok": False,
+                "error": "memory_rebuild_failed",
+                "result": "failed",
+            }
         finally:
             if self._maintenance is not None:
                 self._maintenance.ensure_housekeeping()
@@ -1545,12 +1609,14 @@ class MemoryRuntime:
             return {"ok": False, "error": "memory_store_unavailable"}
         if self._artifact_installing:
             return {"ok": False, "error": "memory_restart_failed"}
+        if self._rebuild_running() and asyncio.current_task() is not self._rebuild_task:
+            return {"ok": False, "error": "memory_operation_in_progress"}
 
         replay = deepcopy(self._restart_config)
         if not replay.enabled:
             return {"ok": False, "error": "memory_disabled"}
         if replay.embedding_change_pending:
-            return {"ok": False, "error": "memory_clear_failed"}
+            return {"ok": False, "error": "memory_embedding_rebuild_required"}
 
         python = await asyncio.to_thread(self._artifact_manager.resolve_python)
         if python is None:
@@ -1633,6 +1699,192 @@ class MemoryRuntime:
             self._ensure_worker()
             return {"ok": True, "state": "ready"}
 
+    async def _rebuild_locked(self) -> dict[str, Any]:
+        """Rebuild the vector index while ``_reconcile_lock`` is held."""
+
+        self._activation_loop = asyncio.get_running_loop()
+        if not self.available or self._store is None or self._module is None:
+            return {
+                "ok": False,
+                "error": "memory_store_unavailable",
+                "result": "failed",
+            }
+        if self._artifact_installing:
+            return {
+                "ok": False,
+                "error": "memory_rebuild_failed",
+                "result": "failed",
+            }
+
+        # Prefer the durable on-disk candidate so a concurrent settings write
+        # that already landed is the unit we rebuild against.
+        try:
+            candidate = await asyncio.to_thread(lambda: V2Config.load().memory)
+        except Exception:
+            candidate = deepcopy(self._restart_config)
+        if not candidate.embedding_change_pending:
+            return {
+                "ok": False,
+                "error": "memory_invalid_input",
+                "result": "failed",
+            }
+
+        # Fail closed before any destructive stop when the pinned artifact or
+        # embedding endpoint cannot rebuild a non-empty root.
+        python = await asyncio.to_thread(self._artifact_manager.resolve_python)
+        if python is None:
+            error = _runtime_error_for_status(
+                await asyncio.to_thread(self._artifact_manager.status)
+            )
+            self._runtime_error = error
+            return {"ok": False, "error": error, "result": "failed"}
+        rebuild_settings = _process_settings(
+            candidate,
+            call_log_db_path=self._call_log_db_path,
+        )
+        if not _rebuild_settings_usable(rebuild_settings):
+            self._runtime_error = "memory_rebuild_failed"
+            return {
+                "ok": False,
+                "error": "memory_rebuild_failed",
+                "result": "failed",
+            }
+
+        async with self.module.lifecycle():
+            if self._maintenance_open():
+                self.module.pause_claims()
+                return {
+                    "ok": False,
+                    "error": "memory_operation_in_progress",
+                    "result": "failed",
+                }
+
+            if not await self.module.quiesce_claims():
+                self._runtime_error = "memory_rebuild_failed"
+                return {
+                    "ok": False,
+                    "error": "memory_rebuild_failed",
+                    "result": "failed",
+                }
+            await self._stop_worker()
+            await self._sidecar.stop()
+
+            self._config = deepcopy(candidate)
+            self._restart_config = deepcopy(candidate)
+            self._configure_insight_reader(self._config)
+            self._provider = EverOSPort(
+                self._socket_path,
+                processing_health_check=self._processing_healthy,
+            )
+            self.module.replace_provider(self._provider)
+
+            try:
+                has_data = await asyncio.to_thread(self._provider_data_exists_strict)
+            except Exception:
+                self._runtime_error = "memory_rebuild_failed"
+                return {
+                    "ok": False,
+                    "error": "memory_rebuild_failed",
+                    "result": "failed",
+                }
+
+            child_result = RebuildProcessResult.COMPLETED
+            if has_data:
+                rebuild_process = EverOSRebuildProcess(
+                    python,
+                    effective_home=self._effective_home,
+                    provider_root=self._provider_root,
+                    settings=rebuild_settings,
+                )
+                child_result = await rebuild_process.run()
+                mapped = _rebuild_public_result(child_result)
+                if mapped["result"] not in {"completed", "completed_empty"}:
+                    self._runtime_error = mapped["error"]
+                    return mapped
+            else:
+                child_result = RebuildProcessResult.COMPLETED
+                mapped = {
+                    "ok": True,
+                    "result": "completed_empty",
+                }
+
+            if not await asyncio.to_thread(
+                self._settle_embedding_change_pending,
+                candidate,
+            ):
+                self._runtime_error = "memory_rebuild_failed"
+                return {
+                    "ok": False,
+                    "error": "memory_rebuild_failed",
+                    "result": "failed",
+                }
+
+            # Marker is clear. Refresh Controller/restart snapshot before any
+            # sidecar activation so activation uses the settled candidate.
+            settled = deepcopy(candidate)
+            settled.embedding_change_pending = False
+            self._config = settled
+            self._restart_config = deepcopy(settled)
+            self._configure_insight_reader(self._config)
+
+            if not settled.enabled:
+                self._runtime_error = None
+                return {
+                    "ok": True,
+                    "result": mapped["result"],
+                    "state": "disabled",
+                }
+
+            try:
+                meta = await asyncio.to_thread(self._store.ensure_meta)
+                await run_blocking(
+                    self._provider_root_owner.ensure,
+                    meta,
+                    self._active_provider_root_metadata(),
+                )
+            except Exception:
+                self._runtime_error = "memory_rebuild_failed"
+                return {
+                    "ok": False,
+                    "error": "memory_rebuild_failed",
+                    "result": "failed",
+                }
+
+            self.module.begin_activation(new_lease=True)
+            try:
+                # Destructive cutover: skip ordinary healthy-replacement endpoint
+                # preflight; the rebuild child already exercised the candidate.
+                started = await self._sidecar.start(
+                    python,
+                    _process_settings(
+                        self._config,
+                        call_log_db_path=self._call_log_db_path,
+                    ),
+                )
+            except Exception:
+                self._runtime_error = "memory_rebuild_failed"
+                return {
+                    "ok": False,
+                    "error": "memory_rebuild_failed",
+                    "result": "failed",
+                }
+            if not started:
+                self._runtime_error = "memory_sidecar_unavailable"
+                return {
+                    "ok": False,
+                    "error": "memory_sidecar_unavailable",
+                    "result": "failed",
+                }
+
+            self._runtime_error = None
+            self.module.resume_claims()
+            self._ensure_worker()
+            return {
+                "ok": True,
+                "result": mapped["result"],
+                "state": "ready",
+            }
+
     async def close(self) -> None:
         self._closing = True
         self._sidecar.close_ready_admission()
@@ -1640,14 +1892,14 @@ class MemoryRuntime:
         self._advance_processing_lifecycle()
         if self._maintenance is not None:
             await self._maintenance.close()
-        restart_task = self._restart_task
-        if restart_task is not None and restart_task is not asyncio.current_task():
-            try:
-                await asyncio.shield(restart_task)
-            except asyncio.CancelledError:
-                raise
-            except Exception:
-                pass
+        for retained in (self._rebuild_task, self._restart_task):
+            if retained is not None and retained is not asyncio.current_task():
+                try:
+                    await asyncio.shield(retained)
+                except asyncio.CancelledError:
+                    raise
+                except Exception:
+                    pass
         for task in (self._artifact_activation_task, self._ready_activation_task):
             if task is None or task is asyncio.current_task():
                 continue
@@ -2054,10 +2306,15 @@ class MemoryRuntime:
         return bool(root_has_data or stats.pending or stats.processing or stats.dead or self._store.has_provider_data_history())
 
     def _settle_embedding_change_pending(self, config: MemoryConfig) -> bool:
-        """Clear a persisted candidate marker only when its full config still matches."""
+        """Clear a persisted candidate marker only when its full config still matches.
+
+        Compare-and-swap under the cross-process Memory config transaction so a
+        newer confirmed candidate from the UI process cannot be clobbered by a
+        stale Controller snapshot.
+        """
 
         try:
-            with CONFIG_LOCK:
+            with memory_config_transaction():
                 persisted = V2Config.load()
                 if not _same_memory_configuration(persisted.memory, config):
                     return False
@@ -2132,6 +2389,49 @@ def _process_settings(
         **_provider_kwargs(config),
         call_log_db_path=call_log_db_path,
     )
+
+
+def _rebuild_settings_usable(settings: EverOSProcessSettings) -> bool:
+    """Return whether the candidate embedding endpoint is complete enough to rebuild."""
+
+    return all(
+        isinstance(value, str) and bool(value.strip())
+        for value in (
+            settings.embedding_base_url,
+            settings.embedding_model,
+            settings.embedding_api_key,
+        )
+    )
+
+
+def _rebuild_public_result(result: RebuildProcessResult) -> dict[str, Any]:
+    """Map a closed child result to the public rebuild response shape."""
+
+    if result is RebuildProcessResult.COMPLETED:
+        return {"ok": True, "result": "completed"}
+    if result is RebuildProcessResult.ROOT_BUSY:
+        return {
+            "ok": False,
+            "error": "memory_rebuild_root_busy",
+            "result": "root_busy",
+        }
+    if result is RebuildProcessResult.INTERRUPTED:
+        return {
+            "ok": False,
+            "error": "memory_rebuild_failed",
+            "result": "interrupted",
+        }
+    if result is RebuildProcessResult.TIMED_OUT:
+        return {
+            "ok": False,
+            "error": "memory_rebuild_failed",
+            "result": "timed_out",
+        }
+    return {
+        "ok": False,
+        "error": "memory_rebuild_failed",
+        "result": "failed",
+    }
 
 
 def _runtime_error_for_status(status: dict[str, Any]) -> str:

--- a/core/memory/runtime.py
+++ b/core/memory/runtime.py
@@ -689,6 +689,21 @@ class MemoryRuntime:
                 logger.warning("Memory store remains unavailable during reconciliation")
                 return {"ok": False, "error": "memory_store_unavailable"}
         async with self._reconcile_lock:
+            # A rebuild may have finished while this call reaped an orphan.
+            # Recheck ownership and prefer the durable unit so a stale pending
+            # snapshot cannot stop a just-activated sidecar.
+            if self._rebuild_running() and asyncio.current_task() is not self._rebuild_task:
+                return {"ok": False, "error": "memory_operation_in_progress"}
+            try:
+                durable = await asyncio.to_thread(lambda: V2Config.load().memory)
+            except Exception:
+                durable = None
+            if durable is not None and (
+                bool(config.embedding_change_pending)
+                != bool(durable.embedding_change_pending)
+                or not _same_memory_configuration(config, durable)
+            ):
+                config = deepcopy(durable)
             self._activation_loop = asyncio.get_running_loop()
             if self._artifact_installing:
                 return {"ok": False, "error": "memory_runtime_install_failed"}
@@ -1729,8 +1744,9 @@ class MemoryRuntime:
                 "result": "failed",
             }
 
-        # Fail closed before any destructive stop when the pinned artifact or
-        # embedding endpoint cannot rebuild a non-empty root.
+        # Fail closed before any destructive stop when the pinned artifact is
+        # unusable. Endpoint completeness is required only when a rebuild child
+        # will run against non-empty vector-bearing state.
         python = await asyncio.to_thread(self._artifact_manager.resolve_python)
         if python is None:
             error = _runtime_error_for_status(
@@ -1742,13 +1758,6 @@ class MemoryRuntime:
             candidate,
             call_log_db_path=self._call_log_db_path,
         )
-        if not _rebuild_settings_usable(rebuild_settings):
-            self._runtime_error = "memory_rebuild_failed"
-            return {
-                "ok": False,
-                "error": "memory_rebuild_failed",
-                "result": "failed",
-            }
 
         async with self.module.lifecycle():
             if self._maintenance_open():
@@ -1788,8 +1797,14 @@ class MemoryRuntime:
                     "result": "failed",
                 }
 
-            child_result = RebuildProcessResult.COMPLETED
             if has_data:
+                if not _rebuild_settings_usable(rebuild_settings):
+                    self._runtime_error = "memory_rebuild_failed"
+                    return {
+                        "ok": False,
+                        "error": "memory_rebuild_failed",
+                        "result": "failed",
+                    }
                 rebuild_process = EverOSRebuildProcess(
                     python,
                     effective_home=self._effective_home,
@@ -1802,7 +1817,6 @@ class MemoryRuntime:
                     self._runtime_error = mapped["error"]
                     return mapped
             else:
-                child_result = RebuildProcessResult.COMPLETED
                 mapped = {
                     "ok": True,
                     "result": "completed_empty",
@@ -1819,11 +1833,16 @@ class MemoryRuntime:
                     "result": "failed",
                 }
 
-            # Marker is clear. Refresh Controller/restart snapshot before any
-            # sidecar activation so activation uses the settled candidate.
-            settled = deepcopy(candidate)
+            # Marker is clear. Activate the latest durable candidate so a
+            # concurrent non-identity credential/LLM fix under the marker is not
+            # discarded by the pre-rebuild snapshot.
+            try:
+                settled = await asyncio.to_thread(lambda: V2Config.load().memory)
+            except Exception:
+                settled = deepcopy(candidate)
+                settled.embedding_change_pending = False
             settled.embedding_change_pending = False
-            self._config = settled
+            self._config = deepcopy(settled)
             self._restart_config = deepcopy(settled)
             self._configure_insight_reader(self._config)
 
@@ -2306,17 +2325,18 @@ class MemoryRuntime:
         return bool(root_has_data or stats.pending or stats.processing or stats.dead or self._store.has_provider_data_history())
 
     def _settle_embedding_change_pending(self, config: MemoryConfig) -> bool:
-        """Clear a persisted candidate marker only when its full config still matches.
+        """Clear a persisted candidate marker when the vector-space identity still matches.
 
         Compare-and-swap under the cross-process Memory config transaction so a
         newer confirmed candidate from the UI process cannot be clobbered by a
-        stale Controller snapshot.
+        stale Controller snapshot. Non-identity fields (API keys, LLM settings)
+        may change under the marker without invalidating a completed rebuild.
         """
 
         try:
             with memory_config_transaction():
                 persisted = V2Config.load()
-                if not _same_memory_configuration(persisted.memory, config):
+                if not _same_embedding_identity(persisted.memory, config):
                     return False
                 if persisted.memory.embedding_change_pending:
                     persisted.memory.embedding_change_pending = False
@@ -2363,6 +2383,12 @@ def _embedding_configuration_changed(current: MemoryConfig, candidate: MemoryCon
         current_embedding.base_url != candidate_embedding.base_url
         or current_embedding.model != candidate_embedding.model
     )
+
+
+def _same_embedding_identity(current: MemoryConfig, candidate: MemoryConfig) -> bool:
+    """Return whether two configs share the same embedding vector-space identity."""
+
+    return not _embedding_configuration_changed(current, candidate)
 
 
 _SETTLEMENT_IRRELEVANT_FIELDS = {

--- a/core/memory/runtime.py
+++ b/core/memory/runtime.py
@@ -2340,7 +2340,8 @@ class MemoryRuntime:
                     return False
                 if persisted.memory.embedding_change_pending:
                     persisted.memory.embedding_change_pending = False
-                    persisted.save()
+                    # Settlement owns the Memory unit; do not re-read it.
+                    persisted.save(persist_memory=True)
                 config.embedding_change_pending = False
             return True
         except Exception:

--- a/core/memory/types.py
+++ b/core/memory/types.py
@@ -36,6 +36,10 @@ MemoryErrorCode = Literal[
     "memory_capability_unavailable",
     "memory_processing_failed",
     "memory_clear_failed",
+    "memory_embedding_rebuild_required",
+    "memory_rebuild_failed",
+    "memory_rebuild_root_busy",
+    "memory_operation_in_progress",
 ]
 
 # Transport vocabulary, wider than the persistable one: errors such as
@@ -61,6 +65,10 @@ CLOSED_MEMORY_ERROR_CODES = frozenset(
         "memory_capability_unavailable",
         "memory_processing_failed",
         "memory_clear_failed",
+        "memory_embedding_rebuild_required",
+        "memory_rebuild_failed",
+        "memory_rebuild_root_busy",
+        "memory_operation_in_progress",
     }
 )
 

--- a/tests/test_memory_config.py
+++ b/tests/test_memory_config.py
@@ -38,7 +38,7 @@ def test_memory_config_round_trips_and_hides_keys(tmp_path) -> None:
             }
         )
     )
-    config.save(tmp_path / "config.json")
+    config.save(tmp_path / "config.json", persist_memory=True)
 
     stored = json.loads((tmp_path / "config.json").read_text(encoding="utf-8"))
     projected = config_to_payload(config)
@@ -69,7 +69,7 @@ def test_memory_config_drops_retired_proactive_capture_flag(tmp_path) -> None:
             }
         )
     )
-    upgraded.save(tmp_path / "config.json")
+    upgraded.save(tmp_path / "config.json", persist_memory=True)
 
     stored = json.loads((tmp_path / "config.json").read_text(encoding="utf-8"))
     assert "proactive_capture" not in stored["memory"]
@@ -178,7 +178,7 @@ def test_generic_config_save_preserves_memory_keys(monkeypatch, tmp_path) -> Non
             }
         )
     )
-    original.save()
+    original.save(persist_memory=True)
 
     saved = api.save_config({"runtime": {"log_level": "DEBUG"}})
 
@@ -190,9 +190,45 @@ def test_generic_config_save_preserves_memory_keys(monkeypatch, tmp_path) -> Non
 
 def test_memory_save_uses_dedicated_config_writer(monkeypatch, tmp_path) -> None:
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
-    V2Config.from_payload(_payload({"enabled": False, "processing": {}})).save()
+    V2Config.from_payload(_payload({"enabled": False, "processing": {}})).save(
+        persist_memory=True
+    )
 
     saved = api.save_memory_config({"enabled": True, "processing": _complete_processing()})
 
     assert saved.memory.enabled is True
     assert saved.memory.processing.llm.api_key == "llm-key"
+
+
+def test_direct_v2config_writer_preserves_settled_memory_marker(monkeypatch, tmp_path) -> None:
+    """Language/Model Hub style writers must not re-arm a cleared rebuild marker."""
+
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    original = V2Config.from_payload(
+        _payload(
+            {
+                "enabled": True,
+                "processing": _complete_processing(),
+                "embedding_change_pending": True,
+            }
+        )
+    )
+    original.save(persist_memory=True)
+
+    # Stale writer loaded while the marker was still set.
+    stale = V2Config.load()
+    assert stale.memory.embedding_change_pending is True
+
+    # Controller settlement clears the marker under the shared transaction.
+    settled = V2Config.load()
+    settled.memory.embedding_change_pending = False
+    settled.save(persist_memory=True)
+
+    # Direct non-Memory writer (language/model-hub pattern) must keep settlement.
+    stale.language = "zh"
+    stale.save()
+
+    persisted = V2Config.load()
+    assert persisted.language == "zh"
+    assert persisted.memory.embedding_change_pending is False
+    assert persisted.memory.processing.embedding.api_key == "embed-key"

--- a/tests/test_memory_runtime.py
+++ b/tests/test_memory_runtime.py
@@ -47,6 +47,7 @@ from core.memory.process import (
     EverOSProcessSettings,
     FakeEverOSProcess,
     FakeEverOSProcessFactory,
+    RebuildProcessResult,
 )
 from core.memory.runtime import (
     MemoryRuntime,
@@ -2509,12 +2510,15 @@ async def test_runtime_restart_rechecks_persisted_embedding_candidate(
         return True
 
     monkeypatch.setattr(runtime, "_provider_data_exists_strict", existing_vectors, raising=False)
-    assert await runtime.reconcile(restarted) == {"ok": False, "error": "memory_clear_failed"}
+    assert await runtime.reconcile(restarted) == {
+        "ok": False,
+        "error": "memory_embedding_rebuild_required",
+    }
     assert runtime._config is restarted
-    assert runtime.module._worker._claims_paused is False
+    assert runtime.module._worker._claims_paused is True
     await memory_runtime_factory.close(runtime)
     assert inspected == [True]
-    # The rejection must land before any child is launched.
+    # The pending marker must fence without launching any child.
     assert factory.created == []
 
 
@@ -4018,7 +4022,7 @@ async def test_runtime_restart_fails_closed_before_launch_for_marker_or_clear_re
 
     assert await marked.restart() == {
         "ok": False,
-        "error": "memory_clear_failed",
+        "error": "memory_embedding_rebuild_required",
     }
     assert await recovering.restart() == {
         "ok": False,
@@ -4566,3 +4570,185 @@ async def test_runtime_effective_home_owns_the_attachment_pipeline(
     assert len(pinned_files) == 1
     assert pinned_files[0].read_bytes() == b"runtime-owned attachment"
     assert not attachment_pin_root(global_home).exists()
+
+
+async def test_runtime_rebuild_validates_before_destructive_stop(
+    monkeypatch,
+    tmp_path,
+    memory_runtime_factory,
+) -> None:
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    processing = _processing_config()
+    V2Config(
+        mode="self_host",
+        version="v2",
+        slack=SlackConfig(bot_token=""),
+        runtime=RuntimeConfig(default_cwd="."),
+        agents=AgentsConfig(),
+        memory=MemoryConfig(
+            enabled=True,
+            processing=processing,
+            embedding_change_pending=True,
+        ),
+    ).save()
+    factory = FakeEverOSProcessFactory()
+    runtime = memory_runtime_factory(
+        V2Config.load().memory,
+        artifact_manager=_installed_artifact(
+            python=None,
+            status_payload={"reason": "missing"},
+        ),
+        process_factory=factory,
+        effective_home=tmp_path,
+    )
+    old = FakeEverOSProcess(settings=_settings())
+    runtime._process = old
+    runtime.module.resume_claims()
+    result = await runtime.rebuild()
+    assert result["ok"] is False
+    assert result["result"] == "failed"
+    assert old.stopped is False
+    assert factory.created == []
+    assert V2Config.load().memory.embedding_change_pending is True
+    await memory_runtime_factory.close(runtime)
+
+async def test_runtime_rebuild_empty_root_settles_without_child(
+    monkeypatch,
+    tmp_path,
+    memory_runtime_factory,
+) -> None:
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    processing = _processing_config()
+    V2Config(
+        mode="self_host",
+        version="v2",
+        slack=SlackConfig(bot_token=""),
+        runtime=RuntimeConfig(default_cwd="."),
+        agents=AgentsConfig(),
+        memory=MemoryConfig(
+            enabled=True,
+            processing=processing,
+            embedding_change_pending=True,
+        ),
+    ).save()
+    factory = FakeEverOSProcessFactory()
+    runtime = memory_runtime_factory(
+        V2Config.load().memory,
+        artifact_manager=_installed_artifact(),
+        process_factory=factory,
+        effective_home=tmp_path,
+    )
+    monkeypatch.setattr(runtime, "_provider_data_exists_strict", lambda: False, raising=False)
+    rebuild_calls = []
+
+    class _NoChild:
+        def __init__(self, *args, **kwargs):
+            rebuild_calls.append(True)
+
+        async def run(self):
+            raise AssertionError("empty root must not launch cascade rebuild")
+
+    monkeypatch.setattr("core.memory.runtime.EverOSRebuildProcess", _NoChild)
+    result = await runtime.rebuild()
+    assert result == {"ok": True, "result": "completed_empty", "state": "ready"}
+    assert rebuild_calls == []
+    assert V2Config.load().memory.embedding_change_pending is False
+    assert runtime._restart_config.embedding_change_pending is False
+    await memory_runtime_factory.close(runtime)
+
+
+async def test_runtime_rebuild_maps_root_busy_without_settling(
+    monkeypatch,
+    tmp_path,
+    memory_runtime_factory,
+) -> None:
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    processing = _processing_config()
+    V2Config(
+        mode="self_host",
+        version="v2",
+        slack=SlackConfig(bot_token=""),
+        runtime=RuntimeConfig(default_cwd="."),
+        agents=AgentsConfig(),
+        memory=MemoryConfig(
+            enabled=True,
+            processing=processing,
+            embedding_change_pending=True,
+        ),
+    ).save()
+    factory = FakeEverOSProcessFactory()
+    runtime = memory_runtime_factory(
+        V2Config.load().memory,
+        artifact_manager=_installed_artifact(),
+        process_factory=factory,
+        effective_home=tmp_path,
+    )
+    monkeypatch.setattr(runtime, "_provider_data_exists_strict", lambda: True, raising=False)
+
+    class _BusyRebuild:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def run(self):
+            return RebuildProcessResult.ROOT_BUSY
+
+    monkeypatch.setattr("core.memory.runtime.EverOSRebuildProcess", _BusyRebuild)
+    result = await runtime.rebuild()
+    assert result == {"ok": False, "error": "memory_rebuild_root_busy", "result": "root_busy"}
+    assert "factory" not in str(result).lower()
+    assert V2Config.load().memory.embedding_change_pending is True
+    assert runtime.module._worker._claims_paused is True
+    await memory_runtime_factory.close(runtime)
+
+async def test_runtime_rebuild_refreshes_restart_snapshot_before_activation(
+    monkeypatch,
+    tmp_path,
+    memory_runtime_factory,
+) -> None:
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    processing = _processing_config()
+    V2Config(
+        mode="self_host",
+        version="v2",
+        slack=SlackConfig(bot_token=""),
+        runtime=RuntimeConfig(default_cwd="."),
+        agents=AgentsConfig(),
+        memory=MemoryConfig(
+            enabled=True,
+            processing=processing,
+            embedding_change_pending=True,
+        ),
+    ).save()
+    observed = []
+
+    class _CompletedRebuild:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        async def run(self):
+            return RebuildProcessResult.COMPLETED
+
+    class _Process(FakeEverOSProcess):
+        async def start(self) -> bool:
+            observed.append(
+                (
+                    runtime._restart_config.embedding_change_pending,
+                    V2Config.load().memory.embedding_change_pending,
+                )
+            )
+            return await super().start()
+
+    factory = FakeEverOSProcessFactory(template=_Process)
+    runtime = memory_runtime_factory(
+        V2Config.load().memory,
+        artifact_manager=_installed_artifact(),
+        process_factory=factory,
+        effective_home=tmp_path,
+    )
+    monkeypatch.setattr(runtime, "_provider_data_exists_strict", lambda: True, raising=False)
+    monkeypatch.setattr("core.memory.runtime.EverOSRebuildProcess", _CompletedRebuild)
+    result = await runtime.rebuild()
+    assert result == {"ok": True, "result": "completed", "state": "ready"}
+    assert observed == [(False, False)]
+    assert runtime._restart_config.embedding_change_pending is False
+    await memory_runtime_factory.close(runtime)

--- a/tests/test_memory_runtime.py
+++ b/tests/test_memory_runtime.py
@@ -2493,7 +2493,7 @@ async def test_runtime_restart_rechecks_persisted_embedding_candidate(
             processing=processing,
             embedding_change_pending=True,
         ),
-    ).save()
+    ).save(persist_memory=True)
     restarted = V2Config.load().memory
     inspected: list[bool] = []
     factory = FakeEverOSProcessFactory()
@@ -2565,7 +2565,7 @@ async def test_runtime_settles_embedding_candidate_before_resuming_claims(
             processing=processing,
             embedding_change_pending=True,
         ),
-    ).save()
+    ).save(persist_memory=True)
     restarted = V2Config.load().memory
 
     runtime = memory_runtime_factory(
@@ -3934,7 +3934,7 @@ async def test_marker_settlement_updates_only_replay_marker_after_candidate_fail
         runtime=RuntimeConfig(default_cwd="."),
         agents=AgentsConfig(),
         memory=candidate,
-    ).save()
+    ).save(persist_memory=True)
     factory = FakeEverOSProcessFactory(template=ConfigAwareProcess)
     runtime = memory_runtime_factory(
         startup,
@@ -4590,7 +4590,7 @@ async def test_runtime_rebuild_validates_before_destructive_stop(
             processing=processing,
             embedding_change_pending=True,
         ),
-    ).save()
+    ).save(persist_memory=True)
     factory = FakeEverOSProcessFactory()
     runtime = memory_runtime_factory(
         V2Config.load().memory,
@@ -4630,7 +4630,7 @@ async def test_runtime_rebuild_empty_root_settles_without_child(
             processing=processing,
             embedding_change_pending=True,
         ),
-    ).save()
+    ).save(persist_memory=True)
     factory = FakeEverOSProcessFactory()
     runtime = memory_runtime_factory(
         V2Config.load().memory,
@@ -4675,7 +4675,7 @@ async def test_runtime_rebuild_maps_root_busy_without_settling(
             processing=processing,
             embedding_change_pending=True,
         ),
-    ).save()
+    ).save(persist_memory=True)
     factory = FakeEverOSProcessFactory()
     runtime = memory_runtime_factory(
         V2Config.load().memory,
@@ -4718,7 +4718,7 @@ async def test_runtime_rebuild_refreshes_restart_snapshot_before_activation(
             processing=processing,
             embedding_change_pending=True,
         ),
-    ).save()
+    ).save(persist_memory=True)
     observed = []
 
     class _CompletedRebuild:

--- a/tests/test_ui_memory_routes.py
+++ b/tests/test_ui_memory_routes.py
@@ -722,7 +722,10 @@ def test_memory_enable_rolls_back_when_live_sidecar_reconciliation_fails(monkeyp
     assert V2Config.load().memory.enabled is False
 
 
-def test_memory_embedding_change_rolls_back_when_controller_rejects_it(monkeypatch, tmp_path) -> None:
+def test_memory_embedding_identity_change_requires_confirm_and_saves_nothing(
+    monkeypatch,
+    tmp_path,
+) -> None:
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)
     current = V2Config.load()
@@ -736,13 +739,11 @@ def test_memory_embedding_change_rolls_back_when_controller_rejects_it(monkeypat
     current.save()
     calls: list[bool] = []
 
-    async def reconcile():
+    async def rebuild():
         calls.append(True)
-        if len(calls) == 1:
-            return {"status_code": 200, "body": {"ok": False, "error": "memory_clear_failed"}}
-        return {"status_code": 200, "body": {"ok": True, "state": "disabled"}}
+        return {"status_code": 200, "body": {"ok": True, "result": "completed_empty"}}
 
-    monkeypatch.setattr(internal_client, "reconcile_memory", reconcile)
+    monkeypatch.setattr(internal_client, "memory_rebuild", rebuild)
     client = app.test_client()
     response = client.patch(
         "/api/memory/settings",
@@ -753,12 +754,19 @@ def test_memory_embedding_change_rolls_back_when_controller_rejects_it(monkeypat
     )
 
     assert response.status_code == 409
-    assert response.get_json() == {"status": "failed", "error": "memory_clear_failed"}
-    assert calls == [True, True]
+    assert response.get_json() == {
+        "status": "failed",
+        "error": "memory_embedding_rebuild_required",
+    }
+    assert calls == []
     assert V2Config.load().memory.processing.embedding.model == "embed-v1"
+    assert V2Config.load().memory.embedding_change_pending is False
 
 
-def test_memory_embedding_change_delegates_marker_settlement_to_controller(monkeypatch, tmp_path) -> None:
+def test_memory_confirmed_embedding_change_persists_marker_and_awaits_rebuild(
+    monkeypatch,
+    tmp_path,
+) -> None:
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)
     current = V2Config.load()
@@ -772,30 +780,218 @@ def test_memory_embedding_change_delegates_marker_settlement_to_controller(monke
     current.save()
     observed: list[tuple[str | None, bool]] = []
 
-    async def reconcile():
+    async def rebuild():
         persisted = V2Config.load().memory
         observed.append((persisted.processing.embedding.model, persisted.embedding_change_pending))
         persisted.embedding_change_pending = False
         controller_config = V2Config.load()
         controller_config.memory = persisted
         controller_config.save()
-        return {"status_code": 200, "body": {"ok": True, "state": "disabled"}}
+        return {
+            "status_code": 200,
+            "body": {"ok": True, "result": "completed_empty", "state": "disabled"},
+        }
 
-    monkeypatch.setattr(internal_client, "reconcile_memory", reconcile)
+    monkeypatch.setattr(internal_client, "memory_rebuild", rebuild)
     client = app.test_client()
     response = client.patch(
         "/api/memory/settings",
-        json={"processing": {"embedding": {"model": "embed-v2"}}},
+        json={
+            "processing": {"embedding": {"model": "embed-v2"}},
+            "confirm_rebuild": True,
+        },
         headers=csrf_headers(client, "http://127.0.0.1:15131"),
         base_url="http://127.0.0.1:15131",
         environ_base={"REMOTE_ADDR": "127.0.0.1"},
     )
 
     assert response.status_code == 200
+    body = response.get_json()
+    assert body["status"] == "ok"
+    assert body["rebuild_required"] is False
     assert observed == [("embed-v2", True)]
     persisted = V2Config.load().memory
     assert persisted.processing.embedding.model == "embed-v2"
     assert persisted.embedding_change_pending is False
+
+
+def test_memory_confirmed_rebuild_failure_keeps_candidate(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    _save_config(tmp_path)
+    current = V2Config.load()
+    current.memory = MemoryConfig(
+        enabled=False,
+        processing=MemoryProcessingConfig(
+            llm=MemoryEndpointConfig("https://llm.example.test/v1", "chat", "llm-key"),
+            embedding=MemoryEndpointConfig("https://embed.example.test/v1", "embed-v1", "embed-key"),
+        ),
+    )
+    current.save()
+
+    async def rebuild():
+        return {
+            "status_code": 409,
+            "body": {
+                "ok": False,
+                "error": "memory_rebuild_root_busy",
+                "result": "root_busy",
+            },
+        }
+
+    monkeypatch.setattr(internal_client, "memory_rebuild", rebuild)
+    client = app.test_client()
+    response = client.patch(
+        "/api/memory/settings",
+        json={
+            "processing": {"embedding": {"model": "embed-v2"}},
+            "confirm_rebuild": True,
+        },
+        headers=csrf_headers(client, "http://127.0.0.1:15131"),
+        base_url="http://127.0.0.1:15131",
+        environ_base={"REMOTE_ADDR": "127.0.0.1"},
+    )
+
+    assert response.status_code == 409
+    body = response.get_json()
+    assert body["error"] == "memory_rebuild_root_busy"
+    assert body["rebuild_required"] is True
+    persisted = V2Config.load().memory
+    assert persisted.processing.embedding.model == "embed-v2"
+    assert persisted.embedding_change_pending is True
+
+
+def test_memory_api_key_only_under_pending_marker_does_not_reconcile(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    _save_config(tmp_path)
+    current = V2Config.load()
+    current.memory = MemoryConfig(
+        enabled=False,
+        embedding_change_pending=True,
+        processing=MemoryProcessingConfig(
+            llm=MemoryEndpointConfig("https://llm.example.test/v1", "chat", "llm-key"),
+            embedding=MemoryEndpointConfig("https://embed.example.test/v1", "embed-v1", "embed-key"),
+        ),
+    )
+    current.save()
+    rebuild_calls: list[bool] = []
+    reconcile_calls: list[bool] = []
+
+    async def rebuild():
+        rebuild_calls.append(True)
+        return {"status_code": 200, "body": {"ok": True, "result": "completed"}}
+
+    async def reconcile():
+        reconcile_calls.append(True)
+        return {"status_code": 200, "body": {"ok": True, "state": "disabled"}}
+
+    monkeypatch.setattr(internal_client, "memory_rebuild", rebuild)
+    monkeypatch.setattr(internal_client, "reconcile_memory", reconcile)
+    client = app.test_client()
+    response = client.patch(
+        "/api/memory/settings",
+        json={"processing": {"embedding": {"api_key": "embed-key-2"}}},
+        headers=csrf_headers(client, "http://127.0.0.1:15131"),
+        base_url="http://127.0.0.1:15131",
+        environ_base={"REMOTE_ADDR": "127.0.0.1"},
+    )
+
+    assert response.status_code == 200
+    body = response.get_json()
+    assert body["status"] == "ok"
+    assert body["rebuild_required"] is True
+    assert rebuild_calls == []
+    assert reconcile_calls == []
+    persisted = V2Config.load().memory
+    assert persisted.processing.embedding.api_key == "embed-key-2"
+    assert persisted.embedding_change_pending is True
+
+
+def test_memory_runtime_rebuild_requires_exact_confirm(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    _save_config(tmp_path)
+    calls: list[bool] = []
+
+    async def rebuild():
+        calls.append(True)
+        return {"status_code": 200, "body": {"ok": True, "result": "completed"}}
+
+    monkeypatch.setattr(internal_client, "memory_rebuild", rebuild)
+    client = app.test_client()
+    response = client.post(
+        "/api/memory/runtime/rebuild",
+        json={},
+        headers=csrf_headers(client, "http://127.0.0.1:15131"),
+        base_url="http://127.0.0.1:15131",
+        environ_base={"REMOTE_ADDR": "127.0.0.1"},
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {"status": "failed", "error": "memory_invalid_input"}
+    assert calls == []
+
+    ok = client.post(
+        "/api/memory/runtime/rebuild",
+        json={"confirm": True},
+        headers=csrf_headers(client, "http://127.0.0.1:15131"),
+        base_url="http://127.0.0.1:15131",
+        environ_base={"REMOTE_ADDR": "127.0.0.1"},
+    )
+    assert ok.status_code == 200
+    assert ok.get_json() == {"ok": True, "result": "completed"}
+    assert calls == [True]
+
+
+def test_memory_config_stale_controller_settlement_cannot_clobber_newer_candidate(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    """Cross-process CAS: a stale settlement loses to a newer confirmed write."""
+
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    _save_config(tmp_path)
+    baseline = V2Config.load()
+    baseline.memory = MemoryConfig(
+        enabled=False,
+        processing=MemoryProcessingConfig(
+            llm=MemoryEndpointConfig("https://llm.example.test/v1", "chat", "llm-key"),
+            embedding=MemoryEndpointConfig("https://embed.example.test/v1", "embed-v1", "embed-key"),
+        ),
+    )
+    baseline.save()
+
+    # UI confirms a new candidate+marker.
+    from config.v2_config import memory_config_to_payload
+
+    stale_snapshot = V2Config.load().memory
+    confirmed = MemoryConfig(
+        enabled=False,
+        embedding_change_pending=True,
+        processing=MemoryProcessingConfig(
+            llm=MemoryEndpointConfig("https://llm.example.test/v1", "chat", "llm-key"),
+            embedding=MemoryEndpointConfig("https://embed.example.test/v1", "embed-v2", "embed-key"),
+        ),
+    )
+    api.save_memory_config(
+        memory_config_to_payload(confirmed, include_secrets=True),
+        embedding_change_pending=True,
+        expected=stale_snapshot,
+    )
+
+    # A Controller settlement that still holds the pre-confirm snapshot must not
+    # clear the newer marker or restore the old model.
+    with pytest.raises(api.MemoryConfigStaleWrite):
+        api.save_memory_config(
+            memory_config_to_payload(stale_snapshot, include_secrets=True),
+            embedding_change_pending=False,
+            expected=stale_snapshot,
+        )
+
+    persisted = V2Config.load().memory
+    assert persisted.processing.embedding.model == "embed-v2"
+    assert persisted.embedding_change_pending is True
 
 
 def test_overlapping_memory_settings_patches_never_interleave_save_and_rollback(monkeypatch, tmp_path) -> None:
@@ -818,17 +1014,17 @@ def test_overlapping_memory_settings_patches_never_interleave_save_and_rollback(
 
     def save(memory_payload, **kwargs):
         saved = save_memory_config(memory_payload, **kwargs)
-        if saved.memory.processing.embedding.model == "embed-accepted":
+        if saved.memory.processing.llm.model == "chat-accepted":
             accepted_persisted.set()
         return saved
 
     async def reconcile():
-        model = V2Config.load().memory.processing.embedding.model
+        model = V2Config.load().memory.processing.llm.model
         observed.append(model)
         if not first_reconcile_entered.is_set():
             first_reconcile_entered.set()
             await release_first_reconcile.wait()
-        if model == "embed-rejected":
+        if model == "chat-rejected":
             return {"status_code": 200, "body": {"ok": False, "error": "memory_clear_failed"}}
         return {"status_code": 200, "body": {"ok": True, "state": "disabled"}}
 
@@ -838,13 +1034,13 @@ def test_overlapping_memory_settings_patches_never_interleave_save_and_rollback(
     async def scenario():
         rejected = asyncio.create_task(
             ui_memory_routes._apply_memory_settings_patch(
-                {"processing": {"embedding": {"model": "embed-rejected"}}}
+                {"processing": {"llm": {"model": "chat-rejected"}}}
             )
         )
         await first_reconcile_entered.wait()
         accepted = asyncio.create_task(
             ui_memory_routes._apply_memory_settings_patch(
-                {"processing": {"embedding": {"model": "embed-accepted"}}}
+                {"processing": {"llm": {"model": "chat-accepted"}}}
             )
         )
         # Give the second request every chance to persist while the first is
@@ -865,8 +1061,8 @@ def test_overlapping_memory_settings_patches_never_interleave_save_and_rollback(
     # The rejected request rolls its own candidate back and the accepted request
     # then starts from that restored baseline; neither observes the other's
     # half-applied state.
-    assert observed == ["embed-rejected", "embed-v1", "embed-accepted"]
-    assert V2Config.load().memory.processing.embedding.model == "embed-accepted"
+    assert observed == ["chat-rejected", "chat", "chat-accepted"]
+    assert V2Config.load().memory.processing.llm.model == "chat-accepted"
 
 
 def test_memory_clear_requires_the_global_csrf_proof(monkeypatch, tmp_path) -> None:

--- a/tests/test_ui_memory_routes.py
+++ b/tests/test_ui_memory_routes.py
@@ -736,7 +736,7 @@ def test_memory_embedding_identity_change_requires_confirm_and_saves_nothing(
             embedding=MemoryEndpointConfig("https://embed.example.test/v1", "embed-v1", "embed-key"),
         ),
     )
-    current.save()
+    current.save(persist_memory=True)
     calls: list[bool] = []
 
     async def rebuild():
@@ -777,7 +777,7 @@ def test_memory_confirmed_embedding_change_persists_marker_and_awaits_rebuild(
             embedding=MemoryEndpointConfig("https://embed.example.test/v1", "embed-v1", "embed-key"),
         ),
     )
-    current.save()
+    current.save(persist_memory=True)
     observed: list[tuple[str | None, bool]] = []
 
     async def rebuild():
@@ -786,7 +786,7 @@ def test_memory_confirmed_embedding_change_persists_marker_and_awaits_rebuild(
         persisted.embedding_change_pending = False
         controller_config = V2Config.load()
         controller_config.memory = persisted
-        controller_config.save()
+        controller_config.save(persist_memory=True)
         return {
             "status_code": 200,
             "body": {"ok": True, "result": "completed_empty", "state": "disabled"},
@@ -826,7 +826,7 @@ def test_memory_confirmed_rebuild_failure_keeps_candidate(monkeypatch, tmp_path)
             embedding=MemoryEndpointConfig("https://embed.example.test/v1", "embed-v1", "embed-key"),
         ),
     )
-    current.save()
+    current.save(persist_memory=True)
 
     async def rebuild():
         return {
@@ -875,7 +875,7 @@ def test_memory_api_key_only_under_pending_marker_does_not_reconcile(
             embedding=MemoryEndpointConfig("https://embed.example.test/v1", "embed-v1", "embed-key"),
         ),
     )
-    current.save()
+    current.save(persist_memory=True)
     rebuild_calls: list[bool] = []
     reconcile_calls: list[bool] = []
 
@@ -960,7 +960,7 @@ def test_memory_config_stale_controller_settlement_cannot_clobber_newer_candidat
             embedding=MemoryEndpointConfig("https://embed.example.test/v1", "embed-v1", "embed-key"),
         ),
     )
-    baseline.save()
+    baseline.save(persist_memory=True)
 
     # UI confirms a new candidate+marker.
     from config.v2_config import memory_config_to_payload
@@ -1005,7 +1005,7 @@ def test_overlapping_memory_settings_patches_never_interleave_save_and_rollback(
             embedding=MemoryEndpointConfig("https://embed.example.test/v1", "embed-v1", "embed-key"),
         ),
     )
-    baseline.save()
+    baseline.save(persist_memory=True)
     observed: list[str] = []
     first_reconcile_entered = asyncio.Event()
     release_first_reconcile = asyncio.Event()
@@ -1411,7 +1411,7 @@ def test_memory_disable_under_pending_marker_still_reconciles(monkeypatch, tmp_p
             embedding=MemoryEndpointConfig("https://embed.example.test/v1", "embed-v1", "embed-key"),
         ),
     )
-    current.save()
+    current.save(persist_memory=True)
     reconcile_calls = []
 
     async def reconcile():
@@ -1433,3 +1433,51 @@ def test_memory_disable_under_pending_marker_still_reconciles(monkeypatch, tmp_p
     persisted = V2Config.load().memory
     assert persisted.enabled is False
     assert persisted.embedding_change_pending is True
+
+
+def test_memory_enabled_save_succeeds_when_settlement_clears_marker(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    """Concurrent Retry settlement must not report a successful enable as 409."""
+
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    _save_config(tmp_path)
+    current = V2Config.load()
+    current.memory = MemoryConfig(
+        enabled=False,
+        embedding_change_pending=True,
+        processing=MemoryProcessingConfig(
+            llm=MemoryEndpointConfig("https://llm.example.test/v1", "chat", "llm-key"),
+            embedding=MemoryEndpointConfig("https://embed.example.test/v1", "embed-v1", "embed-key"),
+        ),
+    )
+    current.save(persist_memory=True)
+
+    async def reconcile():
+        # Another tab's Retry settles the marker after this save persisted enabled.
+        settled = V2Config.load()
+        settled.memory.embedding_change_pending = False
+        settled.save(persist_memory=True)
+        return {
+            "status_code": 409,
+            "body": {"ok": False, "error": "memory_operation_in_progress"},
+        }
+
+    monkeypatch.setattr(internal_client, "reconcile_memory", reconcile)
+    client = app.test_client()
+    response = client.patch(
+        "/api/memory/settings",
+        json={"enabled": True},
+        headers=csrf_headers(client, "http://127.0.0.1:15131"),
+        base_url="http://127.0.0.1:15131",
+        environ_base={"REMOTE_ADDR": "127.0.0.1"},
+    )
+
+    assert response.status_code == 200
+    body = response.get_json()
+    assert body["status"] == "ok"
+    assert body["enabled"] is True
+    persisted = V2Config.load().memory
+    assert persisted.enabled is True
+    assert persisted.embedding_change_pending is False

--- a/tests/test_ui_memory_routes.py
+++ b/tests/test_ui_memory_routes.py
@@ -1397,3 +1397,39 @@ def test_memory_restart_route_isolates_remote_session_cookie_renewal(
     assert second_response.status_code == 200
     assert renewed_subject(first_response) == "user-1"
     assert renewed_subject(second_response) == "user-2"
+
+
+def test_memory_disable_under_pending_marker_still_reconciles(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    _save_config(tmp_path)
+    current = V2Config.load()
+    current.memory = MemoryConfig(
+        enabled=True,
+        embedding_change_pending=True,
+        processing=MemoryProcessingConfig(
+            llm=MemoryEndpointConfig("https://llm.example.test/v1", "chat", "llm-key"),
+            embedding=MemoryEndpointConfig("https://embed.example.test/v1", "embed-v1", "embed-key"),
+        ),
+    )
+    current.save()
+    reconcile_calls = []
+
+    async def reconcile():
+        reconcile_calls.append(True)
+        return {"status_code": 200, "body": {"ok": True, "state": "disabled"}}
+
+    monkeypatch.setattr(internal_client, "reconcile_memory", reconcile)
+    client = app.test_client()
+    response = client.patch(
+        "/api/memory/settings",
+        json={"enabled": False},
+        headers=csrf_headers(client, "http://127.0.0.1:15131"),
+        base_url="http://127.0.0.1:15131",
+        environ_base={"REMOTE_ADDR": "127.0.0.1"},
+    )
+
+    assert response.status_code == 200
+    assert reconcile_calls == [True]
+    persisted = V2Config.load().memory
+    assert persisted.enabled is False
+    assert persisted.embedding_change_pending is True

--- a/ui/src/components/settings/SettingsMemoryPage.tsx
+++ b/ui/src/components/settings/SettingsMemoryPage.tsx
@@ -40,6 +40,7 @@ export const SettingsMemoryPage: React.FC = () => {
   const [dependencyReady, setDependencyReady] = useState(true);
   const [runtimeInstalled, setRuntimeInstalled] = useState<boolean | null>(null);
   const [restarting, setRestarting] = useState(false);
+  const [rebuildBusy, setRebuildBusy] = useState(false);
   const [logGeneration, setLogGeneration] = useState(0);
   const [logRefreshToken, setLogRefreshToken] = useState(0);
   const [recoveryAction, setRecoveryAction] = useState<'resume' | 'abort' | null>(null);
@@ -187,12 +188,15 @@ export const SettingsMemoryPage: React.FC = () => {
     [t],
   );
 
+  const rebuildRequired = settings?.rebuild_required === true;
   const settingsPanel = settings ? (
     <MemorySettingsPanel
       settings={settings}
       maintenance={maintenanceRead.data}
       maintenanceError={maintenanceRead.error}
       dependencyReady={dependencyReady}
+      rebuildBusy={rebuildBusy}
+      onRebuildBusyChange={setRebuildBusy}
       onSaved={(next) => {
         setSettings(next);
         window.dispatchEvent(new Event('avibe:memory-settings-changed'));
@@ -224,7 +228,7 @@ export const SettingsMemoryPage: React.FC = () => {
             variant="secondary"
             size="xs"
             onClick={() => void restartEngine()}
-            disabled={restarting}
+            disabled={restarting || rebuildRequired || rebuildBusy}
           >
             {restarting ? <Loader2 className="animate-spin" /> : <RotateCw />}
             {t('memory.status.restartEngine')}

--- a/ui/src/components/settings/memory/MemorySettingsPanel.test.tsx
+++ b/ui/src/components/settings/memory/MemorySettingsPanel.test.tsx
@@ -184,4 +184,73 @@ describe('MemorySettingsPanel', () => {
     expect(onClearAll).not.toHaveBeenCalled();
   });
 
+  it('does not announce rebuild completion for ordinary reconcile results', async () => {
+    api.saveMemorySettings.mockResolvedValue({
+      ...legacySettings,
+      processing: {
+        ...legacySettings.processing,
+        llm: endpoint('https://new.example.test/v1'),
+      },
+      runtime: { ok: true, state: 'ready' },
+    });
+    const user = userEvent.setup();
+    render(
+      <MemorySettingsPanel
+        settings={legacySettings}
+        maintenance={null}
+        maintenanceError={null}
+        dependencyReady
+        onSaved={() => undefined}
+        onReloadSettings={() => undefined}
+        onReloadMaintenance={() => undefined}
+        onClearAll={() => undefined}
+        clearing={false}
+      />,
+    );
+
+    const llmBaseUrl = screen.getAllByPlaceholderText('memory.settings.baseUrlPlaceholder')[0];
+    await user.clear(llmBaseUrl);
+    await user.type(llmBaseUrl, 'https://new.example.test/v1');
+    await user.click(screen.getByRole('button', { name: 'memory.settings.save' }));
+
+    await waitFor(() => expect(showToast).toHaveBeenCalledWith('memory.settings.saved', 'success'));
+    expect(showToast).not.toHaveBeenCalledWith('memory.settings.rebuildCompleted', 'success');
+  });
+
+  it('announces rebuild completion only for confirmed rebuild saves', async () => {
+    api.saveMemorySettings.mockResolvedValue({
+      ...legacySettings,
+      rebuild_required: false,
+      processing: {
+        ...legacySettings.processing,
+        embedding: endpoint('https://new-embedding.example.test/v1'),
+      },
+      runtime: { ok: true, result: 'completed' },
+    });
+    const user = userEvent.setup();
+    render(
+      <MemorySettingsPanel
+        settings={legacySettings}
+        maintenance={{ status: 'ok', data_exists: true, can_clear: true, clear_recovery: null }}
+        maintenanceError={null}
+        dependencyReady
+        onSaved={() => undefined}
+        onReloadSettings={() => undefined}
+        onReloadMaintenance={() => undefined}
+        onClearAll={() => undefined}
+        clearing={false}
+      />,
+    );
+
+    const embeddingBaseUrl = screen.getAllByPlaceholderText('memory.settings.baseUrlPlaceholder')[1];
+    await user.clear(embeddingBaseUrl);
+    await user.type(embeddingBaseUrl, 'https://new-embedding.example.test/v1');
+    await user.click(screen.getByRole('button', { name: 'memory.settings.save' }));
+    await user.click(await screen.findByRole('button', { name: 'confirm-rebuild' }));
+
+    await waitFor(() =>
+      expect(showToast).toHaveBeenCalledWith('memory.settings.rebuildCompleted', 'success'),
+    );
+  });
+
 });

--- a/ui/src/components/settings/memory/MemorySettingsPanel.test.tsx
+++ b/ui/src/components/settings/memory/MemorySettingsPanel.test.tsx
@@ -7,7 +7,10 @@ import userEvent from '@testing-library/user-event';
 import type { MemorySettings } from '../../../context/ApiContext';
 import { MemorySettingsPanel } from './MemorySettingsPanel';
 
-const api = vi.hoisted(() => ({ saveMemorySettings: vi.fn() }));
+const api = vi.hoisted(() => ({
+  saveMemorySettings: vi.fn(),
+  rebuildMemoryRuntime: vi.fn(),
+}));
 const showToast = vi.hoisted(() => vi.fn());
 
 vi.mock('../../../context/ApiContext', async (loadOriginal) => {
@@ -17,6 +20,16 @@ vi.mock('../../../context/ApiContext', async (loadOriginal) => {
 
 vi.mock('../../../context/ToastContext', () => ({
   useToast: () => ({ showToast }),
+}));
+
+vi.mock('../../ui/confirm-dialog', () => ({
+  ConfirmDialog: ({
+    open,
+    onConfirm,
+  }: {
+    open: boolean;
+    onConfirm: () => void | Promise<void>;
+  }) => (open ? <button type="button" onClick={() => void onConfirm()}>confirm-rebuild</button> : null),
 }));
 
 vi.mock('react-i18next', () => ({
@@ -86,49 +99,10 @@ describe('MemorySettingsPanel', () => {
     expect(onSaved).toHaveBeenCalledWith(saved);
   });
 
-  it('locks embedding identity until the separate maintenance fact is known', () => {
-    render(
-      <MemorySettingsPanel
-        settings={legacySettings}
-        maintenance={null}
-        maintenanceError={null}
-        dependencyReady
-        onSaved={() => undefined}
-        onReloadSettings={() => undefined}
-        onReloadMaintenance={() => undefined}
-        onClearAll={() => undefined}
-        clearing={false}
-      />,
-    );
-
-    const embeddingBaseUrl = screen.getAllByPlaceholderText('memory.settings.baseUrlPlaceholder')[1] as HTMLInputElement;
-    expect(embeddingBaseUrl.disabled).toBe(true);
-    expect(screen.getByText('memory.settings.embeddingStatusPending')).toBeTruthy();
-  });
-
-  it('keeps the embedding identity locked and reports a maintenance read failure', () => {
-    render(
-      <MemorySettingsPanel
-        settings={legacySettings}
-        maintenance={null}
-        maintenanceError="maintenance unavailable"
-        dependencyReady
-        onSaved={() => undefined}
-        onReloadSettings={() => undefined}
-        onReloadMaintenance={() => undefined}
-        onClearAll={() => undefined}
-        clearing={false}
-      />,
-    );
-
-    const embeddingBaseUrl = screen.getAllByPlaceholderText('memory.settings.baseUrlPlaceholder')[1] as HTMLInputElement;
-    expect(embeddingBaseUrl.disabled).toBe(true);
-    expect(screen.getByText('maintenance unavailable')).toBeTruthy();
-  });
-
-  it('unlocks embedding identity only when maintenance reports no data', async () => {
+  it('keeps embedding identity editable when data exists and confirms rebuild on save', async () => {
     api.saveMemorySettings.mockResolvedValue({
       ...legacySettings,
+      rebuild_required: true,
       processing: {
         ...legacySettings.processing,
         embedding: endpoint('https://new-embedding.example.test/v1'),
@@ -138,7 +112,7 @@ describe('MemorySettingsPanel', () => {
     render(
       <MemorySettingsPanel
         settings={legacySettings}
-        maintenance={{ status: 'ok', data_exists: false, can_clear: true, clear_recovery: null }}
+        maintenance={{ status: 'ok', data_exists: true, can_clear: true, clear_recovery: null }}
         maintenanceError={null}
         dependencyReady
         onSaved={() => undefined}
@@ -154,10 +128,37 @@ describe('MemorySettingsPanel', () => {
     await user.clear(embeddingBaseUrl);
     await user.type(embeddingBaseUrl, 'https://new-embedding.example.test/v1');
     await user.click(screen.getByRole('button', { name: 'memory.settings.save' }));
+    expect(api.saveMemorySettings).not.toHaveBeenCalled();
+    await user.click(await screen.findByRole('button', { name: 'confirm-rebuild' }));
 
     await waitFor(() => expect(api.saveMemorySettings).toHaveBeenCalledWith({
       processing: { embedding: { base_url: 'https://new-embedding.example.test/v1' } },
+      confirm_rebuild: true,
     }));
+  });
+
+  it('shows Retry rebuild under a pending marker', async () => {
+    api.rebuildMemoryRuntime.mockResolvedValue({ ok: true, result: 'completed' });
+    const onReloadSettings = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <MemorySettingsPanel
+        settings={{ ...legacySettings, rebuild_required: true }}
+        maintenance={{ status: 'ok', data_exists: true, can_clear: true, clear_recovery: null }}
+        maintenanceError={null}
+        dependencyReady
+        onSaved={() => undefined}
+        onReloadSettings={onReloadSettings}
+        onReloadMaintenance={() => undefined}
+        onClearAll={() => undefined}
+        clearing={false}
+      />,
+    );
+
+    expect(screen.getByText('memory.settings.rebuildRequiredTitle')).toBeTruthy();
+    await user.click(screen.getByRole('button', { name: 'memory.settings.retryRebuild' }));
+    await waitFor(() => expect(api.rebuildMemoryRuntime).toHaveBeenCalled());
+    expect(onReloadSettings).toHaveBeenCalled();
   });
 
   it.each([false, true])('disables Clear when authoritative maintenance refuses it with data_exists=%s', async (dataExists) => {

--- a/ui/src/components/settings/memory/MemorySettingsPanel.tsx
+++ b/ui/src/components/settings/memory/MemorySettingsPanel.tsx
@@ -1,11 +1,12 @@
 import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import { ArrowUpRight, Loader2, Lock, ShieldAlert, Trash2 } from 'lucide-react';
+import { ArrowUpRight, Loader2, RefreshCw, ShieldAlert, Trash2 } from 'lucide-react';
 
 import { Badge } from '../../ui/badge';
 import { Button } from '../../ui/button';
 import { Checkbox } from '../../ui/checkbox';
+import { ConfirmDialog } from '../../ui/confirm-dialog';
 import { Input } from '../../ui/input';
 import { Label } from '../../ui/label';
 import { Switch } from '../../ui/switch';
@@ -24,20 +25,16 @@ import { isMemoryOk, memoryErrorMessage } from '../../../lib/memoryRead';
 
 type MemorySettingsOk = Extract<MemorySettingsResult, { status: 'ok' }>;
 
-// One LLM/embedding endpoint's fields. `locked` disables base_url/model edits — used for the
-// embedding endpoint once memory data exists, because changing it would mix vector spaces.
 const EndpointFields: React.FC<{
   title: string;
   draft: EndpointDraft;
   original: MemoryEndpointConfig;
   onChange: (next: EndpointDraft) => void;
   disabled: boolean;
-  locked: boolean;
-  lockedHint?: string;
+  identityHint?: string;
   canClearKey: boolean;
-}> = ({ title, draft, original, onChange, disabled, locked, lockedHint, canClearKey }) => {
+}> = ({ title, draft, original, onChange, disabled, identityHint, canClearKey }) => {
   const { t } = useTranslation();
-  const identityFieldsDisabled = disabled || locked;
   return (
     <div className="flex flex-col gap-3 rounded-xl border border-border bg-surface p-4">
       <div className="flex items-center gap-2">
@@ -47,20 +44,14 @@ const EndpointFields: React.FC<{
         ) : (
           <Badge variant="secondary">{t('memory.settings.apiKeyNotSet')}</Badge>
         )}
-        {locked ? (
-          <Badge variant="warning" className="gap-1">
-            <Lock className="size-3" />
-            {t('common.locked')}
-          </Badge>
-        ) : null}
       </div>
-      {lockedHint ? <p className="text-[11.5px] leading-snug text-muted">{lockedHint}</p> : null}
+      {identityHint ? <p className="text-[11.5px] leading-snug text-muted">{identityHint}</p> : null}
       <div className="grid gap-3 sm:grid-cols-2">
         <div className="flex flex-col gap-1.5">
           <Label className="text-[12px] text-muted">{t('memory.settings.baseUrl')}</Label>
           <Input
             value={draft.baseUrl}
-            disabled={identityFieldsDisabled}
+            disabled={disabled}
             placeholder={t('memory.settings.baseUrlPlaceholder')}
             onChange={(e) => onChange({ ...draft, baseUrl: e.target.value })}
             className="text-[13px]"
@@ -70,7 +61,7 @@ const EndpointFields: React.FC<{
           <Label className="text-[12px] text-muted">{t('memory.settings.model')}</Label>
           <Input
             value={draft.model}
-            disabled={identityFieldsDisabled}
+            disabled={disabled}
             placeholder={t('memory.settings.modelPlaceholder')}
             onChange={(e) => onChange({ ...draft, model: e.target.value })}
             className="text-[13px]"
@@ -113,11 +104,19 @@ const EndpointFields: React.FC<{
   );
 };
 
+const identityChanged = (draft: EndpointDraft, original: MemoryEndpointConfig): boolean => {
+  const baseUrl = draft.baseUrl.trim() || null;
+  const model = draft.model.trim() || null;
+  return baseUrl !== (original.base_url ?? null) || model !== (original.model ?? null);
+};
+
 export const MemorySettingsPanel: React.FC<{
   settings: MemorySettings;
   maintenance: MemoryMaintenance | null;
   maintenanceError: string | null;
   dependencyReady: boolean;
+  rebuildBusy?: boolean;
+  onRebuildBusyChange?: (busy: boolean) => void;
   onSaved: (next: MemorySettingsOk) => void;
   onReloadSettings: () => void;
   onReloadMaintenance: () => void;
@@ -128,6 +127,8 @@ export const MemorySettingsPanel: React.FC<{
   maintenance,
   maintenanceError,
   dependencyReady,
+  rebuildBusy = false,
+  onRebuildBusyChange,
   onSaved,
   onReloadSettings,
   onReloadMaintenance,
@@ -142,6 +143,8 @@ export const MemorySettingsPanel: React.FC<{
   const [embeddingDraft, setEmbeddingDraft] = useState<EndpointDraft>(() => draftFromConfig(settings.processing.embedding));
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [confirmRebuildOpen, setConfirmRebuildOpen] = useState(false);
+  const [pendingPatch, setPendingPatch] = useState<MemorySettingsPatch | null>(null);
 
   // Reset drafts whenever a fresh settings snapshot lands (initial load or after a save).
   useEffect(() => {
@@ -150,67 +153,57 @@ export const MemorySettingsPanel: React.FC<{
     setEmbeddingDraft(draftFromConfig(settings.processing.embedding));
   }, [settings]);
 
-  // `data_exists` is only known once the cheap local maintenance read resolves. Settings can render
-  // first, so until maintenance is known we must NOT let the embedding endpoint be edited: a
-  // change made in that window would be silently discarded once the lock activates yet still report
-  // success. Fail closed until the maintenance fact explicitly reports data_exists=false.
-  const maintenanceKnown = maintenance != null;
-  // Data already exists in the local Memory root: changing the embedding endpoint/model would mix
-  // vector spaces, so the backend rejects it; lock those fields here too, proactively.
-  const embeddingDataLock = !!maintenance?.data_exists;
-  const embeddingLocked = !maintenanceKnown || embeddingDataLock;
-  const embeddingLockedHint = embeddingDataLock
-    ? t('memory.settings.embeddingLocked')
-    : maintenanceError ?? (!maintenanceKnown ? t('memory.settings.embeddingStatusPending') : undefined);
+  const rebuildRequired = settings.rebuild_required === true;
   const canClearKeys = !enabledDraft;
   const canClearMemory = maintenance?.can_clear === true;
+  const busy = saving || rebuildBusy;
 
-  // If data_exists transitions to true while the user has an unsaved embedding draft
-  // (e.g. they edited it while data_exists was false, then a refreshed maintenance read reports
-  // true), discard that draft back to the persisted settings. Otherwise save() would
-  // drop the embedding patch (locked) yet report success — a silent discard.
-  useEffect(() => {
-    if (embeddingDataLock) {
-      setEmbeddingDraft((draft) => ({
-        ...draftFromConfig(settings.processing.embedding),
-        apiKey: draft.apiKey,
-        clearKey: draft.clearKey,
-      }));
+  const buildPatch = (): MemorySettingsPatch => {
+    const patch: MemorySettingsPatch = {};
+    if (enabledDraft !== settings.enabled) patch.enabled = enabledDraft;
+    // A key clear is accepted only while the resulting state stays disabled.
+    const allowClear = !enabledDraft;
+    const llmPatch = buildEndpointPatch(llmDraft, settings.processing.llm, allowClear);
+    // Identity fields stay editable even when data exists; rebuild confirmation
+    // is the safety gate instead of a silent lock.
+    const embeddingPatch = buildEndpointPatch(
+      embeddingDraft,
+      settings.processing.embedding,
+      allowClear,
+      false,
+    );
+    if (llmPatch || embeddingPatch) {
+      patch.processing = {};
+      if (llmPatch) patch.processing.llm = llmPatch;
+      if (embeddingPatch) patch.processing.embedding = embeddingPatch;
     }
-  }, [embeddingDataLock, settings]);
+    return patch;
+  };
 
-  const save = async () => {
+  const submitPatch = async (patch: MemorySettingsPatch) => {
     setSaving(true);
     setError(null);
+    const needsRebuild = Boolean(patch.confirm_rebuild);
+    if (needsRebuild) onRebuildBusyChange?.(true);
     try {
-      const patch: MemorySettingsPatch = {};
-      if (enabledDraft !== settings.enabled) patch.enabled = enabledDraft;
-      // A key clear is accepted only while the resulting state stays disabled.
-      const allowClear = !enabledDraft;
-      const llmPatch = buildEndpointPatch(llmDraft, settings.processing.llm, allowClear);
-      const embeddingPatch = buildEndpointPatch(
-        embeddingDraft,
-        settings.processing.embedding,
-        allowClear,
-        embeddingLocked,
-      );
-      if (llmPatch || embeddingPatch) {
-        patch.processing = {};
-        if (llmPatch) patch.processing.llm = llmPatch;
-        if (embeddingPatch) patch.processing.embedding = embeddingPatch;
-      }
-      if (Object.keys(patch).length === 0) {
-        showToast(t('memory.settings.saved'), 'success');
-        return;
-      }
       const res = await api.saveMemorySettings(patch);
       if (isMemoryOk(res)) {
         onSaved(res);
-        showToast(t('memory.settings.saved'), 'success');
+        if (res.rebuild_required) {
+          const runtimeOk = (res.runtime as { ok?: boolean } | undefined)?.ok;
+          showToast(
+            runtimeOk === false ? t('memory.settings.rebuildFailed') : t('memory.settings.rebuildCompleted'),
+            runtimeOk === false ? 'error' : 'success',
+          );
+        } else {
+          showToast(t('memory.settings.saved'), 'success');
+        }
+        setConfirmRebuildOpen(false);
+        setPendingPatch(null);
       } else {
         setError(memoryErrorMessage(t, (res as { error?: string })?.error));
-        // Reconciliation may roll back endpoint fields. Reload both resources
-        // instead of restoring drafts from the stale pre-save snapshot.
+        // Confirmed rebuild keeps the candidate on failure; reload both resources
+        // so Retry / rebuild_required reflect the durable marker.
         onReloadSettings();
         onReloadMaintenance();
       }
@@ -220,11 +213,63 @@ export const MemorySettingsPanel: React.FC<{
       onReloadMaintenance();
     } finally {
       setSaving(false);
+      if (needsRebuild) onRebuildBusyChange?.(false);
+    }
+  };
+
+  const save = async () => {
+    const patch = buildPatch();
+    if (Object.keys(patch).length === 0) {
+      showToast(t('memory.settings.saved'), 'success');
+      return;
+    }
+    if (identityChanged(embeddingDraft, settings.processing.embedding)) {
+      // Retain the draft and open confirmation; the same patch is replayed with
+      // confirm_rebuild: true after the user accepts the cost/duration disclosure.
+      setPendingPatch(patch);
+      setConfirmRebuildOpen(true);
+      return;
+    }
+    await submitPatch(patch);
+  };
+
+  const confirmRebuild = async () => {
+    if (!pendingPatch) return;
+    await submitPatch({ ...pendingPatch, confirm_rebuild: true });
+  };
+
+  const retryRebuild = async () => {
+    onRebuildBusyChange?.(true);
+    setError(null);
+    try {
+      const res = await api.rebuildMemoryRuntime();
+      if (res.ok) {
+        showToast(t('memory.settings.rebuildCompleted'), 'success');
+        onReloadSettings();
+        onReloadMaintenance();
+      } else {
+        setError(memoryErrorMessage(t, res.error));
+        onReloadSettings();
+        onReloadMaintenance();
+      }
+    } catch {
+      setError(t('memory.settings.rebuildFailed'));
+      onReloadSettings();
+      onReloadMaintenance();
+    } finally {
+      onRebuildBusyChange?.(false);
     }
   };
 
   return (
     <div className="flex flex-col gap-4">
+      {rebuildRequired ? (
+        <div className="flex flex-col gap-1 rounded-xl border border-warning/40 bg-warning/10 px-4 py-3">
+          <span className="text-[13px] font-semibold text-foreground">{t('memory.settings.rebuildRequiredTitle')}</span>
+          <span className="text-[12px] leading-snug text-muted">{t('memory.settings.rebuildRequiredDescription')}</span>
+        </div>
+      ) : null}
+
       <div className="flex items-start justify-between gap-4 rounded-xl border border-border bg-surface px-4 py-3.5">
         <div className="flex min-w-0 flex-col gap-1">
           <span className="text-[13px] font-semibold text-foreground">{t('memory.settings.enableLabel')}</span>
@@ -245,7 +290,7 @@ export const MemorySettingsPanel: React.FC<{
         <Switch
           checked={enabledDraft}
           onCheckedChange={setEnabledDraft}
-          disabled={saving || (!enabledDraft && !dependencyReady)}
+          disabled={busy || (!enabledDraft && !dependencyReady)}
           label={t('memory.settings.enableLabel')}
         />
       </div>
@@ -255,8 +300,7 @@ export const MemorySettingsPanel: React.FC<{
         draft={llmDraft}
         original={settings.processing.llm}
         onChange={setLlmDraft}
-        disabled={saving}
-        locked={false}
+        disabled={busy}
         canClearKey={canClearKeys}
       />
 
@@ -265,11 +309,8 @@ export const MemorySettingsPanel: React.FC<{
         draft={embeddingDraft}
         original={settings.processing.embedding}
         onChange={setEmbeddingDraft}
-        disabled={saving}
-        locked={embeddingLocked}
-        // Distinguish the two lock reasons: data-exists (permanent until Clear all) vs maintenance
-        // not yet resolved (transient — re-enables once the local fact confirms no data exists).
-        lockedHint={embeddingLockedHint}
+        disabled={busy}
+        identityHint={t('memory.settings.embeddingIdentityHint')}
         canClearKey={canClearKeys}
       />
 
@@ -277,16 +318,28 @@ export const MemorySettingsPanel: React.FC<{
         <div className="rounded-xl border border-destructive/40 bg-destructive/10 px-4 py-3 text-sm text-destructive">{error}</div>
       ) : null}
 
-      <div className="flex items-center justify-between gap-3">
-        <Button onClick={() => void save()} disabled={saving}>
-          {saving ? <Loader2 className="size-3.5 animate-spin" /> : null}
-          {saving ? t('memory.settings.saving') : t('memory.settings.save')}
-        </Button>
+      {maintenanceError ? (
+        <div className="rounded-xl border border-border bg-surface px-4 py-3 text-[12px] text-muted">{maintenanceError}</div>
+      ) : null}
+
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex flex-wrap items-center gap-2">
+          <Button onClick={() => void save()} disabled={busy}>
+            {saving ? <Loader2 className="size-3.5 animate-spin" /> : null}
+            {saving ? t('memory.settings.saving') : t('memory.settings.save')}
+          </Button>
+          {rebuildRequired ? (
+            <Button variant="secondary" onClick={() => void retryRebuild()} disabled={busy}>
+              {rebuildBusy ? <Loader2 className="size-3.5 animate-spin" /> : <RefreshCw className="size-3.5" />}
+              {rebuildBusy ? t('memory.settings.retryingRebuild') : t('memory.settings.retryRebuild')}
+            </Button>
+          ) : null}
+        </div>
         <Button
           variant="destructive"
           size="sm"
           onClick={onClearAll}
-          disabled={clearing || !canClearMemory}
+          disabled={clearing || !canClearMemory || busy}
         >
           <Trash2 className="size-3.5" />
           {t('memory.clear.button')}
@@ -304,6 +357,18 @@ export const MemorySettingsPanel: React.FC<{
           ))}
         </ul>
       </div>
+
+      <ConfirmDialog
+        open={confirmRebuildOpen}
+        onOpenChange={(open) => {
+          setConfirmRebuildOpen(open);
+          if (!open) setPendingPatch(null);
+        }}
+        title={t('memory.settings.rebuildConfirmTitle')}
+        description={t('memory.settings.rebuildConfirmDescription')}
+        confirmLabel={t('memory.settings.rebuildConfirmLabel')}
+        onConfirm={confirmRebuild}
+      />
     </div>
   );
 };

--- a/ui/src/components/settings/memory/MemorySettingsPanel.tsx
+++ b/ui/src/components/settings/memory/MemorySettingsPanel.tsx
@@ -189,11 +189,12 @@ export const MemorySettingsPanel: React.FC<{
       const res = await api.saveMemorySettings(patch);
       if (isMemoryOk(res)) {
         onSaved(res);
-        if (res.rebuild_required) {
-          const runtimeOk = (res.runtime as { ok?: boolean } | undefined)?.ok;
+        const runtime = res.runtime as { ok?: boolean } | undefined;
+        if (runtime && typeof runtime.ok === 'boolean') {
+          // Only announce rebuild outcomes when the backend actually ran rebuild.
           showToast(
-            runtimeOk === false ? t('memory.settings.rebuildFailed') : t('memory.settings.rebuildCompleted'),
-            runtimeOk === false ? 'error' : 'success',
+            runtime.ok ? t('memory.settings.rebuildCompleted') : t('memory.settings.rebuildFailed'),
+            runtime.ok ? 'success' : 'error',
           );
         } else {
           showToast(t('memory.settings.saved'), 'success');
@@ -202,13 +203,18 @@ export const MemorySettingsPanel: React.FC<{
         setPendingPatch(null);
       } else {
         setError(memoryErrorMessage(t, (res as { error?: string })?.error));
-        // Confirmed rebuild keeps the candidate on failure; reload both resources
-        // so Retry / rebuild_required reflect the durable marker.
+        // Confirmed rebuild keeps the candidate on failure. Exit the confirm
+        // modal so a second click cannot re-submit a now-non-identity patch;
+        // Retry rebuild is the recovery control under the pending marker.
+        setConfirmRebuildOpen(false);
+        setPendingPatch(null);
         onReloadSettings();
         onReloadMaintenance();
       }
     } catch {
       setError(t('memory.settings.saveFailed'));
+      setConfirmRebuildOpen(false);
+      setPendingPatch(null);
       onReloadSettings();
       onReloadMaintenance();
     } finally {

--- a/ui/src/components/settings/memory/MemorySettingsPanel.tsx
+++ b/ui/src/components/settings/memory/MemorySettingsPanel.tsx
@@ -105,6 +105,13 @@ const EndpointFields: React.FC<{
 };
 
 const identityChanged = (draft: EndpointDraft, original: MemoryEndpointConfig): boolean => {
+  // Match the backend: first-time setup from empty identity is ordinary save,
+  // not a rebuild-confirming identity change.
+  const originalBase = (original.base_url ?? '').trim();
+  const originalModel = (original.model ?? '').trim();
+  if (!originalBase && !originalModel) {
+    return false;
+  }
   const baseUrl = draft.baseUrl.trim() || null;
   const model = draft.model.trim() || null;
   return baseUrl !== (original.base_url ?? null) || model !== (original.model ?? null);

--- a/ui/src/components/settings/memory/MemorySettingsPanel.tsx
+++ b/ui/src/components/settings/memory/MemorySettingsPanel.tsx
@@ -197,8 +197,9 @@ export const MemorySettingsPanel: React.FC<{
       if (isMemoryOk(res)) {
         onSaved(res);
         const runtime = res.runtime as { ok?: boolean } | undefined;
-        if (runtime && typeof runtime.ok === 'boolean') {
-          // Only announce rebuild outcomes when the backend actually ran rebuild.
+        // Ordinary reconcile also returns runtime.ok; only a confirmed rebuild
+        // (needsRebuild) or Retry path should announce rebuild outcomes.
+        if (needsRebuild && runtime && typeof runtime.ok === 'boolean') {
           showToast(
             runtime.ok ? t('memory.settings.rebuildCompleted') : t('memory.settings.rebuildFailed'),
             runtime.ok ? 'success' : 'error',

--- a/ui/src/context/ApiContext.tsx
+++ b/ui/src/context/ApiContext.tsx
@@ -540,6 +540,7 @@ export type ApiContextType = {
   resumeMemoryClear: (operationId: string) => Promise<MemoryClearRecoveryResult>;
   abortMemoryClear: (operationId: string) => Promise<MemoryClearRecoveryResult>;
   restartMemoryRuntime: () => Promise<MemoryRuntimeRestartResult>;
+  rebuildMemoryRuntime: () => Promise<MemoryRuntimeRebuildResult>;
   getBackendRuntime: (name: string) => Promise<BackendRuntimeInfo>;
   restartBackend: (name: string) => Promise<BackendRestartResult>;
   getCodexAuth: () => Promise<CodexAuthState>;
@@ -1740,6 +1741,7 @@ export type MemorySettings = {
   status: 'ok';
   enabled: boolean;
   processing: MemoryProcessingConfig;
+  rebuild_required?: boolean;
 };
 
 // Omitting a field keeps its current value; an explicit `api_key: null` clears it
@@ -1756,6 +1758,7 @@ export type MemorySettingsPatch = {
     llm?: MemoryEndpointPatch;
     embedding?: MemoryEndpointPatch;
   };
+  confirm_rebuild?: boolean;
 };
 
 export type MemoryFailure = { status: 'failed'; error: string };
@@ -2001,6 +2004,10 @@ export type MemoryClearRecoveryResult =
 // Reconciliation answers the controller's ok/error shape rather than the
 // status/error one the read routes use.
 export type MemoryRuntimeRestartResult = { ok: true; state?: string } | { ok: false; error?: string };
+
+export type MemoryRuntimeRebuildResult =
+  | { ok: true; result?: string; state?: string }
+  | { ok: false; error?: string; result?: string };
 
 export type BackendRuntimeInfo = {
   ok: boolean;
@@ -3008,6 +3015,8 @@ export const ApiProvider: React.FC<{ children: React.ReactNode }> = ({ children 
     abortMemoryClear: (operationId) =>
       postJson('/api/memory/clear/abort', { operation_id: operationId }, { handleError: false }),
     restartMemoryRuntime: () => postJson('/api/memory/runtime/restart', {}, { handleError: false }),
+    rebuildMemoryRuntime: () =>
+      postJson('/api/memory/runtime/rebuild', { confirm: true }, { handleError: false }),
     getBackendRuntime: (name) => getJson(`/api/backend/${encodeURIComponent(name)}/runtime`),
     restartBackend: (name) => postJson(`/api/backend/${encodeURIComponent(name)}/restart`, {}),
     getCodexAuth: () => getJson('/api/backend/codex/auth'),

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -1312,7 +1312,11 @@
     "memory_runtime_unpublished": "This Avibe version hasn't published a memory runtime yet.",
     "memory_runtime_manifest_missing": "The memory runtime manifest is missing.",
     "memory_runtime_manifest_unavailable": "The memory runtime manifest couldn't be downloaded.",
-    "memory_runtime_archive_unavailable": "The memory runtime download isn't available right now."
+    "memory_runtime_archive_unavailable": "The memory runtime download isn't available right now.",
+    "memory_rebuild_failed": "Rebuilding the Memory index failed. Retry when ready; your markdown memory is still kept.",
+    "memory_rebuild_root_busy": "Another process is using the Memory root. Wait and retry the rebuild.",
+    "memory_operation_in_progress": "A Memory operation is already in progress. Wait for it to finish.",
+    "memory_embedding_rebuild_required": "Changing the embedding endpoint or model rebuilds the Memory index. Confirm to continue."
   },
   "apps": {
     "title": "Apps",
@@ -3913,7 +3917,6 @@
       "apiKeyNotSet": "No key set.",
       "apiKeyPlaceholder": "sk-…",
       "apiKeyClearHint": "Keys are write-only — Avibe never shows a saved key back to you.",
-      "embeddingLocked": "Changing the embedding endpoint or model is disabled while memory data exists. Run Clear all first.",
       "embeddingStatusPending": "Reading local maintenance state… the embedding endpoint unlocks once it's confirmed no data exists.",
       "maintenanceLoadFailed": "Couldn't load local Memory maintenance state.",
       "save": "Save settings",
@@ -3935,7 +3938,17 @@
         "Delivery to the Memory endpoints is at-least-once — a rare duplicate derived memory is possible after a timeout or crash.",
         "Each platform user has a separate memory scope; identities are not linked across platforms."
       ],
-      "clearKeyLabel": "Clear the saved key"
+      "clearKeyLabel": "Clear the saved key",
+      "rebuildRequiredTitle": "Memory index rebuild required",
+      "rebuildRequiredDescription": "The confirmed embedding change is saved. Restart engine stays blocked until rebuild finishes successfully.",
+      "rebuildConfirmTitle": "Rebuild Memory index?",
+      "rebuildConfirmDescription": "Changing the embedding endpoint or model rebuilds the local vector index. Markdown memory is preserved, but the rebuild can take time and may use embedding API quota.",
+      "rebuildConfirmLabel": "Save and rebuild",
+      "retryRebuild": "Retry rebuild",
+      "retryingRebuild": "Rebuilding…",
+      "rebuildCompleted": "Memory index rebuild completed.",
+      "rebuildFailed": "Memory index rebuild failed.",
+      "embeddingIdentityHint": "Changing the embedding endpoint or model rebuilds the local vector index. Markdown memory is preserved."
     },
     "clear": {
       "button": "Clear all",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -1312,7 +1312,11 @@
     "memory_runtime_unpublished": "当前 Avibe 版本尚未发布记忆运行时。",
     "memory_runtime_manifest_missing": "记忆运行时的清单缺失。",
     "memory_runtime_manifest_unavailable": "无法下载记忆运行时的清单。",
-    "memory_runtime_archive_unavailable": "记忆运行时的下载包当前不可用。"
+    "memory_runtime_archive_unavailable": "记忆运行时的下载包当前不可用。",
+    "memory_rebuild_failed": "重建记忆索引失败。可稍后重试；Markdown 记忆内容仍会保留。",
+    "memory_rebuild_root_busy": "另一个进程正在使用记忆根目录。请稍后重试重建。",
+    "memory_operation_in_progress": "记忆操作正在进行中，请等待完成。",
+    "memory_embedding_rebuild_required": "更改 Embedding 端点或模型会重建记忆索引。请确认后继续。"
   },
   "apps": {
     "title": "应用",
@@ -3913,7 +3917,6 @@
       "apiKeyNotSet": "尚未设置密钥。",
       "apiKeyPlaceholder": "sk-…",
       "apiKeyClearHint": "密钥仅可写入——Avibe 不会把已保存的密钥回显给你。",
-      "embeddingLocked": "已有记忆数据时无法更改 Embedding 端点或模型，请先执行「清除全部」。",
       "embeddingStatusPending": "正在读取本地维护状态……确认没有数据后，Embedding 端点将解锁。",
       "maintenanceLoadFailed": "无法加载本地记忆维护状态。",
       "save": "保存设置",
@@ -3935,7 +3938,17 @@
         "发往记忆端点的投递是至少一次——超时或崩溃后偶尔可能出现重复的派生记忆。",
         "每个平台用户拥有独立的记忆范围；不同平台之间不会自动关联身份。"
       ],
-      "clearKeyLabel": "清除已保存的密钥"
+      "clearKeyLabel": "清除已保存的密钥",
+      "rebuildRequiredTitle": "需要重建记忆索引",
+      "rebuildRequiredDescription": "已确认的 Embedding 更改已保存。重建成功前，重启引擎会保持禁用。",
+      "rebuildConfirmTitle": "重建记忆索引？",
+      "rebuildConfirmDescription": "更改 Embedding 端点或模型会重建本地向量索引。Markdown 记忆会保留，但重建可能较久，并可能消耗 Embedding API 配额。",
+      "rebuildConfirmLabel": "保存并重建",
+      "retryRebuild": "重试重建",
+      "retryingRebuild": "正在重建…",
+      "rebuildCompleted": "记忆索引重建完成。",
+      "rebuildFailed": "记忆索引重建失败。",
+      "embeddingIdentityHint": "更改 Embedding 端点或模型会重建本地向量索引。Markdown 记忆会保留。"
     },
     "clear": {
       "button": "清除全部",

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -1011,7 +1011,9 @@ def save_config(
                 existing_update = _discord_guild_scope_from_config(base_config)
                 if existing_update is not None:
                     _save_discord_guild_scope_update(*existing_update, store=store)
-        config.save()
+        # Memory-owning path: candidate/marker already resolved under the shared
+        # transaction above; do not re-read Memory on the final write.
+        config.save(persist_memory=True)
         # The activity-streaming gate (ui.show_agent_activity) is cached in-process
         # by the message mirror; a save that flips it must take effect immediately,
         # not after the cache TTL. Reset it here (same process) — best-effort.
@@ -1036,6 +1038,26 @@ def _memory_transaction_unit(memory) -> tuple:
     return (
         bool(memory.enabled),
         bool(memory.embedding_change_pending),
+        processing.llm.base_url,
+        processing.llm.model,
+        processing.llm.api_key,
+        processing.embedding.base_url,
+        processing.embedding.model,
+        processing.embedding.api_key,
+        bool(memory.diagnostics.log_provider_calls),
+    )
+
+
+def memory_operational_unit(memory) -> tuple:
+    """Project operational Memory fields, ignoring the rebuild marker.
+
+    Used when a concurrent rebuild settles the marker while another tab's
+    enabled/settings save still holds the requested operational values.
+    """
+
+    processing = memory.processing
+    return (
+        bool(memory.enabled),
         processing.llm.base_url,
         processing.llm.model,
         processing.llm.api_key,

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -27,7 +27,7 @@ from sqlalchemy import select
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 
 from config import paths
-from config.v2_config import CONFIG_LOCK, V2Config
+from config.v2_config import CONFIG_LOCK, V2Config, memory_config_transaction
 from config.v2_settings import (
     SettingsStore,
     ChannelSettings,
@@ -1009,12 +1009,40 @@ def save_config(
         return config
 
 
+class MemoryConfigStaleWrite(RuntimeError):
+    """The on-disk Memory candidate/marker no longer matches this writer's snapshot."""
+
+
+def _memory_transaction_unit(memory) -> tuple:
+    """Project the durable Memory candidate + marker unit for compare-and-swap."""
+
+    processing = memory.processing
+    return (
+        bool(memory.enabled),
+        bool(memory.embedding_change_pending),
+        processing.llm.base_url,
+        processing.llm.model,
+        processing.llm.api_key,
+        processing.embedding.base_url,
+        processing.embedding.model,
+        processing.embedding.api_key,
+        bool(memory.diagnostics.log_provider_calls),
+    )
+
+
 def save_memory_config(
     memory_payload: dict,
     *,
     embedding_change_pending: bool = False,
+    expected: object | None = None,
 ) -> V2Config:
-    """Persist Memory settings only from the direct-loopback Memory route."""
+    """Persist Memory settings only from the direct-loopback Memory route.
+
+    When *expected* is provided, the write is a narrow cross-process transaction:
+    the on-disk Memory candidate+marker unit must still match *expected* or the
+    save raises ``MemoryConfigStaleWrite`` without changing the file. Process-local
+    locks alone cannot protect UI saves from Controller settlement write-back.
+    """
 
     if not isinstance(memory_payload, dict):
         raise ValueError("Memory config payload must be an object")
@@ -1022,7 +1050,15 @@ def save_memory_config(
         raise ValueError("Memory embedding compatibility state must be a boolean")
     payload = dict(memory_payload)
     payload["embedding_change_pending"] = embedding_change_pending
-    return save_config({"memory": payload}, allow_memory=True)
+    with memory_config_transaction():
+        if expected is not None:
+            try:
+                current = load_config()
+            except FileNotFoundError as exc:
+                raise MemoryConfigStaleWrite("memory config missing") from exc
+            if _memory_transaction_unit(current.memory) != _memory_transaction_unit(expected):
+                raise MemoryConfigStaleWrite("memory candidate changed")
+        return save_config({"memory": payload}, allow_memory=True)
 
 
 def _vibe_cloud_payload(config: V2Config, include_secrets: bool) -> dict:

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -929,7 +929,9 @@ def save_config(
     payload = _strip_preserved_config_secrets(payload)
     payload = _mark_explicit_audio_asr_enabled(payload)
 
-    with CONFIG_LOCK:
+    # Share the Memory candidate+marker transaction with Controller settlement so
+    # a whole-config writer cannot re-persist a stale embedding marker over it.
+    with memory_config_transaction():
         base_payload: dict = {}
         base_config: Optional[V2Config] = None
         try:
@@ -961,6 +963,20 @@ def save_config(
         merged_payload = _deep_merge_dicts(base_payload, payload) if base_payload else payload
         merged_payload = _merge_legacy_discord_guild_scope_fields(merged_payload, payload, base_config)
         sanitized_payload, guild_scope_update = _extract_settings_scopes_from_config_payload(merged_payload)
+        if not allow_memory:
+            # Re-read the Memory unit immediately before the final write so a
+            # Controller settlement that cleared the marker after the initial
+            # load is not overwritten by a stale whole-config snapshot.
+            try:
+                from config.v2_config import memory_config_to_payload
+
+                sanitized_payload["memory"] = memory_config_to_payload(
+                    load_config().memory,
+                    include_secrets=True,
+                    include_internal=True,
+                )
+            except Exception:
+                pass
         config = V2Config.from_payload(sanitized_payload)
         connector_controls_changed = (
             base_config is not None

--- a/vibe/internal_client.py
+++ b/vibe/internal_client.py
@@ -367,6 +367,20 @@ async def memory_restart(
     )
 
 
+async def memory_rebuild(
+    *,
+    socket_path: Optional[Path] = None,
+) -> dict[str, Any]:
+    """Wait without a reporting deadline for the retained Runtime rebuild."""
+
+    return await _memory_request(
+        "POST",
+        "/internal/memory/rebuild",
+        socket_path=socket_path,
+        timeout=None,
+    )
+
+
 async def memory_final_flush(
     session_id: str,
     *,

--- a/vibe/ui_memory_routes.py
+++ b/vibe/ui_memory_routes.py
@@ -117,20 +117,29 @@ def _memory_settings_projection(memory: object) -> dict:
 def _memory_settings_payload() -> dict:
     # Tag the response, not `memory_config_to_payload` itself: the same helper
     # feeds the persisted config, which must stay free of result envelopes.
-    return {
-        **_memory_settings_projection(V2Config.load().memory),
-        "status": "ok",
-    }
+    memory = V2Config.load().memory
+    payload = _memory_settings_projection(memory)
+    payload["status"] = "ok"
+    # Read-only projection while a durable rebuild marker is pending.
+    payload["rebuild_required"] = bool(memory.embedding_change_pending)
+    return payload
 
 
-def _memory_settings_patch(current: V2Config, patch_payload: object) -> dict:
-    """Merge one write-only Memory settings PATCH."""
+def _memory_settings_patch(current: V2Config, patch_payload: object) -> tuple[dict, bool]:
+    """Merge one write-only Memory settings PATCH.
+
+    Returns ``(target_payload, confirm_rebuild)``. ``confirm_rebuild`` is accepted
+    only as an exact boolean and never becomes part of the persisted candidate.
+    """
 
     from config.v2_config import memory_config_to_payload
 
     if not isinstance(patch_payload, dict) or not set(patch_payload).issubset(
-        {"enabled", "processing"}
+        {"enabled", "processing", "confirm_rebuild"}
     ):
+        raise ValueError("invalid_memory_patch")
+    confirm_rebuild = patch_payload.get("confirm_rebuild", False)
+    if not isinstance(confirm_rebuild, bool):
         raise ValueError("invalid_memory_patch")
     target = memory_config_to_payload(current.memory, include_secrets=True)
     for endpoint in ("llm", "embedding"):
@@ -158,7 +167,7 @@ def _memory_settings_patch(current: V2Config, patch_payload: object) -> dict:
     )
     if explicit_key_clear and target["enabled"]:
         raise ValueError("memory_key_clear_while_enabled")
-    return target
+    return target, confirm_rebuild
 
 
 def _memory_candidate_config(current: V2Config, memory_payload: dict) -> V2Config:
@@ -170,13 +179,22 @@ def _memory_candidate_config(current: V2Config, memory_payload: dict) -> V2Confi
 
 
 def _memory_embedding_configuration_changed(current: V2Config, candidate: V2Config) -> bool:
-    """Return whether the persisted vector-space identity would change."""
+    """Return whether an already-established vector-space identity would change.
+
+    First-time configuration of empty embedding fields is ordinary setup, not a
+    rebuild. Only a change away from a previously set base_url/model requires
+    confirm_rebuild.
+    """
 
     current_embedding = current.memory.processing.embedding
     candidate_embedding = candidate.memory.processing.embedding
+    current_base = (current_embedding.base_url or "").strip()
+    current_model = (current_embedding.model or "").strip()
+    if not current_base and not current_model:
+        return False
     return (
-        current_embedding.base_url != candidate_embedding.base_url
-        or current_embedding.model != candidate_embedding.model
+        current_base != (candidate_embedding.base_url or "").strip()
+        or current_model != (candidate_embedding.model or "").strip()
     )
 
 
@@ -191,6 +209,8 @@ _settings_write_lock: asyncio.Lock | None = None
 _settings_write_lock_loop: asyncio.AbstractEventLoop | None = None
 _restart_request_task: asyncio.Task[tuple[dict, int]] | None = None
 _restart_request_task_loop: asyncio.AbstractEventLoop | None = None
+_rebuild_request_task: asyncio.Task[tuple[dict, int]] | None = None
+_rebuild_request_task_loop: asyncio.AbstractEventLoop | None = None
 
 
 def _memory_settings_write_lock() -> asyncio.Lock:
@@ -241,6 +261,47 @@ def _memory_restart_request_task() -> asyncio.Task[tuple[dict, int]]:
     return _restart_request_task
 
 
+async def _run_memory_rebuild_request() -> tuple[dict, int]:
+    # Intentionally not under the settings write lock: confirmed settings saves
+    # already hold that lock and then join this retained task. Controller-side
+    # rebuild ownership serializes the destructive work.
+    from vibe import internal_client
+
+    return await _memory_internal_result(internal_client.memory_rebuild)
+
+
+def _memory_rebuild_request_task() -> asyncio.Task[tuple[dict, int]]:
+    """Create or join the UI process' loop-scoped rebuild request owner."""
+
+    global _rebuild_request_task, _rebuild_request_task_loop
+
+    loop = asyncio.get_running_loop()
+    if _rebuild_request_task_loop is not loop:
+        _rebuild_request_task = None
+        _rebuild_request_task_loop = loop
+    if _rebuild_request_task is None:
+        task = loop.create_task(_run_memory_rebuild_request())
+        _rebuild_request_task = task
+
+        def clear_finished(finished: asyncio.Task[tuple[dict, int]]) -> None:
+            global _rebuild_request_task
+
+            if _rebuild_request_task is finished:
+                _rebuild_request_task = None
+
+        task.add_done_callback(clear_finished)
+    return _rebuild_request_task
+
+
+def _settings_ok_payload(memory, runtime_payload: dict | None = None) -> dict:
+    payload = _memory_settings_projection(memory)
+    payload["status"] = "ok"
+    payload["rebuild_required"] = bool(getattr(memory, "embedding_change_pending", False))
+    if runtime_payload is not None:
+        payload["runtime"] = runtime_payload
+    return payload
+
+
 async def _apply_memory_settings_patch(
     patch_payload: object,
 ) -> Response:
@@ -261,15 +322,46 @@ async def _apply_memory_settings_patch(
     async with _memory_settings_write_lock():
         try:
             current = await asyncio.to_thread(V2Config.load)
-            target_payload = _memory_settings_patch(current, patch_payload)
+            target_payload, confirm_rebuild = _memory_settings_patch(current, patch_payload)
             candidate = _memory_candidate_config(current, target_payload)
-            embedding_change_pending = (
-                current.memory.embedding_change_pending
-                or _memory_embedding_configuration_changed(current, candidate)
-            )
+            identity_changed = _memory_embedding_configuration_changed(current, candidate)
+            pending_marker = bool(current.memory.embedding_change_pending)
         except (TypeError, ValueError):
             return _memory_response({"status": "failed", "error": "memory_invalid_input"}, status_code=400)
 
+        # Unconfirmed identity change never writes — including on empty roots —
+        # so a check-then-save race cannot quietly accept a new vector space.
+        if identity_changed and not confirm_rebuild:
+            return _memory_response(
+                {
+                    "status": "failed",
+                    "error": "memory_embedding_rebuild_required",
+                },
+                status_code=409,
+            )
+
+        # API-key (or other non-identity) updates under an existing marker update
+        # the candidate only. They do not reconcile, clear the fence, or roll back.
+        if pending_marker and not identity_changed:
+            try:
+                saved = await asyncio.to_thread(
+                    api.save_memory_config,
+                    target_payload,
+                    embedding_change_pending=True,
+                    expected=current.memory,
+                )
+            except api.MemoryConfigStaleWrite:
+                return _memory_response(
+                    {"status": "failed", "error": "memory_operation_in_progress"},
+                    status_code=409,
+                )
+            except ValueError:
+                return _memory_response({"status": "failed", "error": "memory_invalid_input"}, status_code=400)
+            except Exception:
+                return _memory_response({"status": "failed", "error": "memory_store_unavailable"}, status_code=503)
+            return _memory_response(_settings_ok_payload(saved.memory))
+
+        embedding_change_pending = pending_marker or identity_changed
         try:
             # Persist a durable marker before asking the controller to inspect
             # the root. If Avibe exits in this interval, startup must re-run
@@ -279,15 +371,50 @@ async def _apply_memory_settings_patch(
                 api.save_memory_config,
                 target_payload,
                 embedding_change_pending=embedding_change_pending,
+                expected=current.memory,
+            )
+        except api.MemoryConfigStaleWrite:
+            return _memory_response(
+                {"status": "failed", "error": "memory_operation_in_progress"},
+                status_code=409,
             )
         except ValueError:
             return _memory_response({"status": "failed", "error": "memory_invalid_input"}, status_code=400)
         except Exception:
             return _memory_response({"status": "failed", "error": "memory_store_unavailable"}, status_code=503)
+
+        # Confirmed identity change: candidate+marker are durable. Schedule the
+        # same rebuild path as Retry; never roll the confirmed config back.
+        if identity_changed and confirm_rebuild:
+            body, status_code = await asyncio.shield(_memory_rebuild_request_task())
+            runtime_payload = body if isinstance(body, dict) else {}
+            latest = await asyncio.to_thread(V2Config.load)
+            payload = _settings_ok_payload(latest.memory, runtime_payload)
+            if status_code != 200 or runtime_payload.get("ok") is not True:
+                error = _memory_closed_error(
+                    runtime_payload,
+                    fallback="memory_rebuild_failed",
+                )
+                payload["status"] = "failed"
+                payload["error"] = error
+                # Confirmed candidate stays; surface rebuild_required for Retry.
+                payload["rebuild_required"] = True
+                return _memory_response(payload, status_code=status_code if status_code >= 400 else 409)
+            return _memory_response(payload)
+
         response = await _memory_internal_response(internal_client.reconcile_memory)
         runtime_payload = _memory_response_body(response)
         if response.status_code != 200 or runtime_payload.get("ok") is not True:
-            # Persisted settings must not outrun the controller's closed
+            closed_error = _memory_closed_error(
+                runtime_payload,
+                fallback="memory_sidecar_unavailable",
+            )
+            # Pending-marker reconcile that only needs rebuild is not a rollback.
+            if closed_error == "memory_embedding_rebuild_required":
+                payload = _settings_ok_payload(saved.memory, runtime_payload)
+                payload["rebuild_required"] = True
+                return _memory_response(payload)
+            # Ordinary non-identity saves must not outrun the controller's closed
             # compatibility decision, including while memory is disabled.
             try:
                 rollback_payload = memory_config_to_payload(
@@ -298,6 +425,7 @@ async def _apply_memory_settings_patch(
                     api.save_memory_config,
                     rollback_payload,
                     embedding_change_pending=current.memory.embedding_change_pending,
+                    expected=saved.memory,
                 )
                 await _memory_internal_response(internal_client.reconcile_memory)
             except Exception:
@@ -305,16 +433,14 @@ async def _apply_memory_settings_patch(
             return _memory_response(
                 {
                     "status": "failed",
-                    "error": _memory_closed_error(runtime_payload, fallback="memory_sidecar_unavailable"),
+                    "error": closed_error,
                 },
                 status_code=409,
             )
         if response.status_code >= 500:
             return response
-        payload = _memory_settings_projection(saved.memory)
-        payload["runtime"] = runtime_payload
-        payload["status"] = "ok"
-        return _memory_response(payload)
+        latest = await asyncio.to_thread(V2Config.load)
+        return _memory_response(_settings_ok_payload(latest.memory, runtime_payload))
 
 
 def register_memory_routes(app) -> None:
@@ -507,6 +633,27 @@ def register_memory_routes(app) -> None:
             # The retained task shares only the internal transport result. Each
             # request needs its own Response so request-local after hooks cannot
             # mix remote-session cookies across concurrent callers.
+            return _memory_response(body, status_code=status_code)
+
+        return await app.dispatch_native_request(starlette_request, handler)
+
+    @app.post("/api/memory/runtime/rebuild", include_in_schema=False)
+    async def memory_runtime_rebuild_post(starlette_request: FastAPIRequest):
+        """Wait for one retained Memory rebuild; requires a pending marker."""
+
+        async def handler():
+            if _memory_ui_user_key() is None:
+                return _memory_forbidden_response()
+            try:
+                payload = await starlette_request.json()
+            except Exception:
+                payload = None
+            if payload != {"confirm": True}:
+                return _memory_response(
+                    {"status": "failed", "error": "memory_invalid_input"},
+                    status_code=400,
+                )
+            body, status_code = await asyncio.shield(_memory_rebuild_request_task())
             return _memory_response(body, status_code=status_code)
 
         return await app.dispatch_native_request(starlette_request, handler)

--- a/vibe/ui_memory_routes.py
+++ b/vibe/ui_memory_routes.py
@@ -340,9 +340,11 @@ async def _apply_memory_settings_patch(
                 status_code=409,
             )
 
-        # API-key (or other non-identity) updates under an existing marker update
-        # the candidate only. They do not reconcile, clear the fence, or roll back.
-        if pending_marker and not identity_changed:
+        # Credential-only updates under an existing marker update the candidate
+        # only. Operational fields (especially enabled) still reconcile so a
+        # disable cannot leave a live runtime admitting captures.
+        enabled_changed = bool(candidate.memory.enabled) != bool(current.memory.enabled)
+        if pending_marker and not identity_changed and not enabled_changed:
             try:
                 saved = await asyncio.to_thread(
                     api.save_memory_config,
@@ -397,8 +399,8 @@ async def _apply_memory_settings_patch(
                 )
                 payload["status"] = "failed"
                 payload["error"] = error
-                # Confirmed candidate stays; surface rebuild_required for Retry.
-                payload["rebuild_required"] = True
+                # Keep the durable marker projection from latest config. Do not
+                # re-arm Retry after settlement if only activation failed later.
                 return _memory_response(payload, status_code=status_code if status_code >= 400 else 409)
             return _memory_response(payload)
 

--- a/vibe/ui_memory_routes.py
+++ b/vibe/ui_memory_routes.py
@@ -418,6 +418,7 @@ async def _apply_memory_settings_patch(
                 return _memory_response(payload)
             # Ordinary non-identity saves must not outrun the controller's closed
             # compatibility decision, including while memory is disabled.
+            rollback_stale = False
             try:
                 rollback_payload = memory_config_to_payload(
                     current.memory,
@@ -430,8 +431,24 @@ async def _apply_memory_settings_patch(
                     expected=saved.memory,
                 )
                 await _memory_internal_response(internal_client.reconcile_memory)
+            except api.MemoryConfigStaleWrite:
+                # Concurrent settlement cleared the marker or advanced the
+                # candidate; the requested operational change may already be
+                # the durable unit.
+                rollback_stale = True
             except Exception:
                 pass
+            if rollback_stale or closed_error == "memory_operation_in_progress":
+                try:
+                    latest = await asyncio.to_thread(V2Config.load)
+                    if api.memory_operational_unit(latest.memory) == api.memory_operational_unit(
+                        saved.memory
+                    ):
+                        return _memory_response(
+                            _settings_ok_payload(latest.memory, runtime_payload)
+                        )
+                except Exception:
+                    pass
             return _memory_response(
                 {
                     "status": "failed",


### PR DESCRIPTION
Closes #1314

## Summary
- Confirmed embedding identity changes on PATCH /api/memory/settings (confirm_rebuild) persist candidate + embedding_change_pending before destructive work; unconfirmed identity changes return 409 memory_embedding_rebuild_required with nothing saved.
- Narrow cross-process Memory config transaction (memory_config_transaction file lock + compare-and-swap) so UI saves and Controller settlement cannot clobber each other.
- MemoryRuntime.rebuild() retained _rebuild_task (join-on-duplicate; HTTP waits for final result). Validate artifact/endpoint before stop, fence/quiesce, stop sidecar, empty fast path or cascade rebuild child, settle only on success, refresh restart snapshot, then cutover start.
- Stable public errors: memory_embedding_rebuild_required, memory_rebuild_failed, memory_rebuild_root_busy, memory_operation_in_progress. Never steers to factory reset.
- Minimal Settings UI: confirm dialog + draft replay, editable embedding identity, rebuild_required warning, Retry rebuild, Restart engine disabled while pending/running. en+zh i18n.

## Evidence layers
- Unit: MemoryRuntime rebuild validation / empty settlement / root_busy / snapshot refresh; pending-marker fence on reconcile/restart.
- Contract: UI memory routes for confirm required, confirmed save+rebuild wait, failed rebuild keeps candidate, API-key-under-marker, exact rebuild body, stale-save CAS interleaving, ordinary non-identity save serialization.
- Scenario: none (no catalog entry for this recovery path).
- Manual residual: end-to-end embedding change against a non-empty root in Incus regression after merge.

## Dependencies
- Requires #1307 and #1310 (already on dev).