### PR TITLE
fix(ui): preserve session drafts across navigation

### DIFF
--- a/storage/message_deliveries.py
+++ b/storage/message_deliveries.py
@@ -1969,29 +1969,39 @@ def retire_for_archive(conn: Connection, session_id: str) -> dict[str, Any]:
 
 
 def set_draft(conn: Connection, session_id: str, text: str | None) -> bool:
-    now = utc_now_iso()
+    # A clear is a real draft revision too: retaining its timestamp prevents an
+    # offline client based on the previous revision from recreating text that a
+    # successful send already cleared. Microseconds keep rapid edits distinct.
+    now = turn_now_iso()
     result = conn.execute(
         update(agent_sessions)
         .where(agent_sessions.c.id == session_id)
         .values(
             composer_draft_text=text if text and text.strip() else None,
-            composer_draft_updated_at=now if text and text.strip() else None,
+            composer_draft_updated_at=now,
             updated_at=now,
         )
     )
     return result.rowcount == 1
 
 
-def get_draft(conn: Connection, session_id: str) -> dict[str, Any] | None:
+def get_draft_state(conn: Connection, session_id: str) -> dict[str, Any] | None:
     row = conn.execute(
         select(
             agent_sessions.c.composer_draft_text,
             agent_sessions.c.composer_draft_updated_at,
         ).where(agent_sessions.c.id == session_id)
     ).first()
-    if row is None or not row[0]:
+    if row is None:
         return None
-    return {"text": str(row[0]), "updated_at": row[1]}
+    return {"text": str(row[0] or ""), "updated_at": row[1]}
+
+
+def get_draft(conn: Connection, session_id: str) -> dict[str, Any] | None:
+    state = get_draft_state(conn, session_id)
+    if state is None or not state["text"]:
+        return None
+    return state
 
 
 def pending_control_for_turn(conn: Connection, turn_id: str) -> dict[str, Any] | None:

--- a/tests/test_messages_service.py
+++ b/tests/test_messages_service.py
@@ -1968,6 +1968,9 @@ def test_draft_upsert_get_and_clear(isolated_state):
         assert message_deliveries.set_draft(conn, "ses_d", "   ") is True
     with engine.connect() as conn:
         assert message_deliveries.get_draft(conn, "ses_d") is None
+        cleared = message_deliveries.get_draft_state(conn, "ses_d")
+    assert cleared["text"] == ""
+    assert cleared["updated_at"] is not None
 
     # clear_draft is idempotent.
     with engine.begin() as conn:
@@ -1976,6 +1979,7 @@ def test_draft_upsert_get_and_clear(isolated_state):
         message_deliveries.set_draft(conn, "ses_d", None)
     with engine.connect() as conn:
         assert message_deliveries.get_draft(conn, "ses_d") is None
+        assert message_deliveries.get_draft_state(conn, "ses_d")["updated_at"] is not None
 
 
 def test_inbox_ignores_draft_and_queued_delivery_activity(isolated_state):

--- a/tests/test_ui_session_stream.py
+++ b/tests/test_ui_session_stream.py
@@ -1248,6 +1248,39 @@ def test_session_draft_compare_and_set_protects_newer_writes_and_clears(
     assert resurrect.get_json()["draft"] == cleared_draft
 
 
+def test_session_draft_reserves_writer_before_cas_reads(isolated_state, tmp_path):
+    from core.services import sessions as sessions_service
+    from storage.agent_session_rows import reserve_write_lock as real_reserve_write_lock
+    from vibe.ui_server import app
+
+    real_get_session = sessions_service.get_session
+    _, session_id = _make_session(tmp_path)
+    client = app.test_client()
+    headers = csrf_headers(client)
+    calls = []
+
+    def reserve_write_lock(conn):
+        calls.append("write_lock")
+        return real_reserve_write_lock(conn)
+
+    def get_session(conn, target_session_id):
+        calls.append("session_read")
+        return real_get_session(conn, target_session_id)
+
+    with (
+        patch("storage.agent_session_rows.reserve_write_lock", reserve_write_lock),
+        patch("core.services.sessions.get_session", get_session),
+    ):
+        response = client.put(
+            f"/api/sessions/{session_id}/draft",
+            json={"text": "serialized", "expected_updated_at": None},
+            headers=headers,
+        )
+
+    assert response.status_code == 200
+    assert calls[:2] == ["write_lock", "session_read"]
+
+
 def test_queue_row_send_now_passes_the_exact_delivery_id(isolated_state, tmp_path):
     from vibe.ui_server import app
 

--- a/tests/test_ui_session_stream.py
+++ b/tests/test_ui_session_stream.py
@@ -1172,11 +1172,80 @@ def test_chat_bootstrap_returns_first_screen_payload(isolated_state, tmp_path):
     assert [message["type"] for message in body["messages"]] == ["user", "result"]
     assert body["queued"][0]["text"] == "follow-up"
     assert body["draft"]["text"] == "draft text"
+    assert body["draft"]["updated_at"] is not None
     assert body["turn_state"]["in_flight"] is True
     assert body["turn_state"]["foreground"] == "running"
     assert body["turn_state"]["pending_input_count"] == 1
     assert body["turn_state"]["background_activities"][0]["id"] == "task-1"
     assert body["turn_state"]["connection"] == "connected"
+
+
+def test_session_draft_compare_and_set_protects_newer_writes_and_clears(
+    isolated_state,
+    tmp_path,
+):
+    from vibe.ui_server import app
+
+    _, session_id = _make_session(tmp_path)
+    client = app.test_client()
+    headers = csrf_headers(client)
+    path = f"/api/sessions/{session_id}/draft"
+
+    created = client.put(
+        path,
+        json={"text": "first", "expected_updated_at": None},
+        headers=headers,
+    )
+    assert created.status_code == 200
+    created_draft = created.get_json()["draft"]
+    assert created_draft["text"] == "first"
+    first_revision = created_draft["updated_at"]
+    assert first_revision is not None
+
+    fetched = client.get(path)
+    assert fetched.status_code == 200
+    assert fetched.get_json() == created_draft
+
+    stale = client.put(
+        path,
+        json={"text": "stale", "expected_updated_at": None},
+        headers=headers,
+    )
+    assert stale.status_code == 409
+    assert stale.get_json() == {
+        "ok": False,
+        "code": "draft_conflict",
+        "draft": created_draft,
+    }
+
+    updated = client.put(
+        path,
+        json={"text": "second", "expected_updated_at": first_revision},
+        headers=headers,
+    )
+    assert updated.status_code == 200
+    updated_draft = updated.get_json()["draft"]
+    assert updated_draft["text"] == "second"
+    second_revision = updated_draft["updated_at"]
+    assert second_revision not in (None, first_revision)
+
+    cleared = client.put(
+        path,
+        json={"text": "", "expected_updated_at": second_revision},
+        headers=headers,
+    )
+    assert cleared.status_code == 200
+    cleared_draft = cleared.get_json()["draft"]
+    assert cleared_draft["text"] == ""
+    assert cleared_draft["updated_at"] not in (None, second_revision)
+
+    resurrect = client.put(
+        path,
+        json={"text": "resurrected", "expected_updated_at": second_revision},
+        headers=headers,
+    )
+    assert resurrect.status_code == 409
+    assert resurrect.get_json()["draft"] == cleared_draft
 
 
 def test_queue_row_send_now_passes_the_exact_delivery_id(isolated_state, tmp_path):

--- a/tests/test_ui_session_stream.py
+++ b/tests/test_ui_session_stream.py
@@ -219,6 +219,11 @@ def test_route_fire_and_forgets_dispatch(isolated_state, tmp_path):
     ):
         client = app.test_client()
         headers = csrf_headers(client)
+        saved_draft = client.put(
+            f"/api/sessions/{session_id}/draft",
+            json={"text": "draft before send", "expected_updated_at": None},
+            headers=headers,
+        ).get_json()["draft"]
         response = client.post(
             f"/api/sessions/{session_id}/messages",
             json={"text": "no stream", "author_id": "remote:spoofed"},
@@ -231,6 +236,9 @@ def test_route_fire_and_forgets_dispatch(isolated_state, tmp_path):
     assert payload["metadata"]["_web_push_user_key"] == "remote:user-a"
     assert payload["metadata"]["_memory_cli_admitted"] is False
     assert payload["text"] == "no stream"
+    assert payload["draft_advanced"] is True
+    assert payload["draft"]["text"] == ""
+    assert payload["draft"]["updated_at"] not in (None, saved_draft["updated_at"])
     # The turn was kicked off fire-and-forget with the session + text.
     dispatch_mock.assert_awaited_once()
     sent = dispatch_mock.await_args.args[0]
@@ -266,6 +274,9 @@ def test_workbench_side_actions_are_not_marked_as_ordinary_memory_input(
 
     assert response.status_code == 201
     assert dispatch.await_args.args[0]["is_ordinary_text"] is False
+    assert response.get_json()["draft_advanced"] is (
+        "quick_reply_for" not in payload.get("metadata", {})
+    )
 
 
 
@@ -1213,6 +1224,18 @@ def test_session_draft_compare_and_set_protects_newer_writes_and_clears(
     )
     assert stale.status_code == 409
     assert stale.get_json() == {
+        "ok": False,
+        "code": "draft_conflict",
+        "draft": created_draft,
+    }
+
+    revisionless = client.put(
+        path,
+        json={"text": "legacy overwrite"},
+        headers=headers,
+    )
+    assert revisionless.status_code == 409
+    assert revisionless.get_json() == {
         "ok": False,
         "code": "draft_conflict",
         "draft": created_draft,

--- a/ui/src/components/workbench/ChatPage.tsx
+++ b/ui/src/components/workbench/ChatPage.tsx
@@ -1098,7 +1098,8 @@ export const ChatPage: React.FC = () => {
   // subscription, including the ones issued by components this page owns rather
   // than by the page itself. ``sendMessage`` is the exception by construction: it
   // uses a raw ``apiFetch`` so it can read ``queued``/``already_answered`` off a
-  // non-2xx-aware response, so it calls the same converger directly.
+  // non-2xx-aware response, so it reports the terminal state back through the
+  // ApiContext converger explicitly.
   useEffect(() => api.onSessionArchived(convergeSessionArchived), [api, convergeSessionArchived]);
 
   useEffect(() => {
@@ -1766,6 +1767,45 @@ export const ChatPage: React.FC = () => {
           body: JSON.stringify(requestBody),
         });
         const body = await response.json().catch(() => null);
+        if (isSessionArchivedConflict(response.status, body)) {
+          // Archive is terminal. Clear the original session's draft even when
+          // this response settles after navigation, and do not return false:
+          // false tells Composer to restore a retryable submission.
+          api.convergeSessionArchived(sessionId);
+          if (sessionId === sessionIdRef.current) {
+            setWorking(false);
+            setError(t('chat.archived.sendBlocked'));
+          }
+          return;
+        }
+        if (!response.ok) {
+          // A reserved ordinary message may already have cleared the server
+          // draft. Start recovery for its original session before any page
+          // staleness decision; the old Composer will then persist its restore
+          // even if navigation unmounted it. Quick replies never advance drafts.
+          if (!metadata?.quick_reply_for && body?.draft_advanced !== false) {
+            void api.recoverSessionDraftAfterRejectedSend(sessionId);
+          }
+          if (sessionId === sessionIdRef.current) {
+            void syncTurnStateRef.current?.();
+            setWorking(false);
+            // Routes answer either the flat ``{"error": "<sentence>"}`` or the shared
+            // CODED shape (``{"error": {code, message}, code, message}``) — the
+            // runtime-owned session's ``403 reserved_session`` is the latter, and
+            // ``String(body.error)`` renders that object as literal "[object Object]".
+            const parsed = body ? selectApiErrorFields(body, `HTTP ${response.status}`) : null;
+            setError(
+              parsed
+                ? parsed.code
+                  ? t(`errors.${parsed.code}`, { defaultValue: parsed.fallback })
+                  : parsed.fallback
+                : body?.detail
+                  ? String(body.detail)
+                  : `HTTP ${response.status}`,
+            );
+          }
+          return false;
+        }
         // Reserving an accepted message advances the server draft to a blank
         // revision. Apply that exact causal revision before handling this chat's
         // UI response, so text typed while the POST was in flight is rebased and
@@ -1783,37 +1823,6 @@ export const ChatPage: React.FC = () => {
         // error on the chat they moved to (Codex P2). The turn still ran for the
         // original session; its rows live there.
         if (sessionId !== sessionIdRef.current) return;
-        if (isSessionArchivedConflict(response.status, body)) {
-          // Archive is terminal, so this is not a retryable failure — it is state
-          // this tab missed. Raw ``apiFetch`` never reaches ``handleApiError``, so
-          // the shared subscription can't see this one: call the same converger
-          // directly. Only the turn state and the message are send-specific.
-          setWorking(false);
-          setError(t('chat.archived.sendBlocked'));
-          convergeSessionArchived(sessionId);
-          return false;
-        }
-        if (!response.ok) {
-          setWorking(false);
-          // Routes answer either the flat ``{"error": "<sentence>"}`` or the shared
-          // CODED shape (``{"error": {code, message}, code, message}``) — the
-          // runtime-owned session's ``403 reserved_session`` is the latter, and
-          // ``String(body.error)`` renders that object as literal "[object Object]".
-          // This is a raw ``apiFetch``, so ``handleApiError`` never runs; reuse its own
-          // selector instead of re-deriving the precedence, and localize by code the
-          // same way, so a coded refusal reads as a sentence here too. ``detail`` is
-          // only FastAPI's own validation shape.
-          const parsed = body ? selectApiErrorFields(body, `HTTP ${response.status}`) : null;
-          throw new Error(
-            parsed
-              ? parsed.code
-                ? t(`errors.${parsed.code}`, { defaultValue: parsed.fallback })
-                : parsed.fallback
-              : body?.detail
-                ? String(body.detail)
-                : `HTTP ${response.status}`,
-          );
-        }
         if (body?.already_answered) {
           // A duplicate quick-reply the backend already had (stale tab / missed
           // event): no turn started HERE. Reconcile authoritatively rather than
@@ -1847,20 +1856,23 @@ export const ChatPage: React.FC = () => {
           }
         }
       } catch (err) {
+        if (!metadata?.quick_reply_for) {
+          void api.recoverSessionDraftAfterRejectedSend(sessionId);
+        }
         if (sessionId === sessionIdRef.current) {
           // The request may have raced a turn owned by another tab or source.
           // Reconcile rather than clearing that turn's Stop state optimistically.
           void syncTurnStateRef.current?.();
           setWorking(false);
           setError(errorMessage(err) ?? String(err));
-          void api.recoverSessionDraftAfterRejectedSend(sessionId);
-          // Signal the composer the send didn't start so it restores the text +
-          // uploaded chips — the user can retry without re-uploading (Codex r5).
-          return false;
         }
+        // Recovery belongs to the original session, while UI mutation is gated
+        // above. Returning false also lets an unmounted old Composer persist its
+        // submitted text after navigation.
+        return false;
       }
     },
-    [sessionId, api, appendMessage, refreshQueue, markWorking, reloadLatestMessages, convergeSessionArchived, t],
+    [sessionId, api, appendMessage, refreshQueue, markWorking, reloadLatestMessages, t],
   );
 
   // @ mention source: all enabled Agents, filtered client-side (the set is small

--- a/ui/src/components/workbench/ChatPage.tsx
+++ b/ui/src/components/workbench/ChatPage.tsx
@@ -1841,13 +1841,14 @@ export const ChatPage: React.FC = () => {
           void syncTurnStateRef.current?.();
           setWorking(false);
           setError(errorMessage(err) ?? String(err));
+          void api.recoverSessionDraftAfterRejectedSend(sessionId);
           // Signal the composer the send didn't start so it restores the text +
           // uploaded chips — the user can retry without re-uploading (Codex r5).
           return false;
         }
       }
     },
-    [sessionId, appendMessage, refreshQueue, markWorking, reloadLatestMessages, convergeSessionArchived, t],
+    [sessionId, api, appendMessage, refreshQueue, markWorking, reloadLatestMessages, convergeSessionArchived, t],
   );
 
   // @ mention source: all enabled Agents, filtered client-side (the set is small

--- a/ui/src/components/workbench/ChatPage.tsx
+++ b/ui/src/components/workbench/ChatPage.tsx
@@ -1766,6 +1766,18 @@ export const ChatPage: React.FC = () => {
           body: JSON.stringify(requestBody),
         });
         const body = await response.json().catch(() => null);
+        // Reserving an accepted message advances the server draft to a blank
+        // revision. Apply that exact causal revision before handling this chat's
+        // UI response, so text typed while the POST was in flight is rebased and
+        // synced even if the user has already navigated to another session.
+        if (
+          response.ok
+          && body?.draft_advanced === true
+          && body?.draft
+          && typeof body.draft === 'object'
+        ) {
+          void api.reconcileSessionDraftAfterSend(sessionId, body.draft);
+        }
         // If the user switched chats while this POST was in flight, the response
         // belongs to the previous session — don't append it / mutate working /
         // error on the chat they moved to (Codex P2). The turn still ran for the

--- a/ui/src/components/workbench/ChatPage.tsx
+++ b/ui/src/components/workbench/ChatPage.tsx
@@ -1271,12 +1271,12 @@ export const ChatPage: React.FC = () => {
     }
   }, [api, sessionId, scheduleActivityRefresh]);
 
-  // Persist the composer's unsent text server-side (debounced) so it survives a
-  // reload / device switch. The send path clears it server-side; this only
-  // saves while typing.
+  // Cache every edit synchronously so navigation, a tab close, or a disconnected
+  // network cannot lose it. Cloud persistence remains debounced and serialized.
   const onDraftChange = useCallback(
     (text: string) => {
       if (!sessionId) return;
+      api.cacheSessionDraft(sessionId, text);
       // Tag the pending save with THIS session so the timer (and the
       // session-change flush) save to the right session even if the user has
       // since navigated away.
@@ -1306,6 +1306,13 @@ export const ChatPage: React.FC = () => {
       if (pending) void api.setSessionDraft(pending.sessionId, pending.text);
     };
   }, [sessionId, api]);
+
+  useEffect(() => {
+    if (!sessionId) return undefined;
+    const syncLocalDraft = () => void api.syncSessionDraft(sessionId);
+    window.addEventListener('online', syncLocalDraft);
+    return () => window.removeEventListener('online', syncLocalDraft);
+  }, [api, sessionId]);
 
   // The fire-and-forget turn survives browser disconnects, so a freshly loaded /
   // reconnected page asks the controller whether a turn is still in flight and
@@ -1487,7 +1494,7 @@ export const ChatPage: React.FC = () => {
     setWorking(false);
     setRuntimeState(emptyRuntimeState());
     setQueue([]);
-    setInitialDraft(null);
+    setInitialDraft(sessionId ? api.getCachedSessionDraft(sessionId) : null);
     // Clear all Agent Activity state so the previous session's groups / live buffer
     // never leak into the new chat (refresh re-reads the toggle + summary).
     setActivityGroups([]);
@@ -1508,7 +1515,7 @@ export const ChatPage: React.FC = () => {
       window.clearTimeout(graceResyncRef.current);
       graceResyncRef.current = null;
     }
-  }, [sessionId]);
+  }, [api, sessionId]);
 
   // Persistent per-session subscription: append every transcript-visible
   // ``message.new`` for THIS session for as long as the page is open. An agent

--- a/ui/src/components/workbench/ChatPage.tsx
+++ b/ui/src/components/workbench/ChatPage.tsx
@@ -1307,13 +1307,6 @@ export const ChatPage: React.FC = () => {
     };
   }, [sessionId, api]);
 
-  useEffect(() => {
-    if (!sessionId) return undefined;
-    const syncLocalDraft = () => void api.syncSessionDraft(sessionId);
-    window.addEventListener('online', syncLocalDraft);
-    return () => window.removeEventListener('online', syncLocalDraft);
-  }, [api, sessionId]);
-
   // The fire-and-forget turn survives browser disconnects, so a freshly loaded /
   // reconnected page asks the controller whether a turn is still in flight and
   // restores the working/Stop state to match (Codex P2). Authoritative in BOTH

--- a/ui/src/components/workbench/Composer.attachmentRetry.test.tsx
+++ b/ui/src/components/workbench/Composer.attachmentRetry.test.tsx
@@ -107,3 +107,26 @@ describe('Composer attachment retry', () => {
     expect(uploadWorkbenchAttachment).toHaveBeenCalledTimes(1);
   });
 });
+
+describe('Composer draft retry', () => {
+  it('re-caches optimistically cleared text when a send cannot start', async () => {
+    const onDraftChange = vi.fn();
+    render(providers(
+      <Composer
+        onSend={async () => false}
+        onDraftChange={onDraftChange}
+      />,
+    ));
+
+    const textbox = screen.getByRole('textbox') as HTMLTextAreaElement;
+    fireEvent.change(textbox, { target: { value: 'keep this' } });
+    fireEvent.click(screen.getByLabelText(en.chat.compose.send));
+
+    await waitFor(() => expect(textbox.value).toBe('keep this'));
+    expect(onDraftChange.mock.calls.map(([text]) => text)).toEqual([
+      'keep this',
+      '',
+      'keep this',
+    ]);
+  });
+});

--- a/ui/src/components/workbench/Composer.attachmentRetry.test.tsx
+++ b/ui/src/components/workbench/Composer.attachmentRetry.test.tsx
@@ -129,4 +129,30 @@ describe('Composer draft retry', () => {
       'keep this',
     ]);
   });
+
+  it('persists rejected text after navigation unmounts the old composer', async () => {
+    let rejectSend!: () => void;
+    const onDraftChange = vi.fn();
+    const view = render(providers(
+      <Composer
+        onSend={() => new Promise<boolean>((resolve) => {
+          rejectSend = () => resolve(false);
+        })}
+        onDraftChange={onDraftChange}
+      />,
+    ));
+
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'survive navigation' } });
+    fireEvent.click(screen.getByLabelText(en.chat.compose.send));
+    await waitFor(() => expect(onDraftChange).toHaveBeenLastCalledWith(''));
+
+    view.unmount();
+    await act(async () => rejectSend());
+
+    expect(onDraftChange.mock.calls.map(([text]) => text)).toEqual([
+      'survive navigation',
+      '',
+      'survive navigation',
+    ]);
+  });
 });

--- a/ui/src/components/workbench/Composer.tsx
+++ b/ui/src/components/workbench/Composer.tsx
@@ -1227,18 +1227,25 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
       // restore the prompt + attachments for retry — unless the user typed anew.
       const started = await onSend(submitted, sent, useMentions ? sentRefs : undefined);
       if (started === false) {
-        setAttachments((cur) => (cur.length ? cur : sent));
+        if (!unmountedRef.current) {
+          setAttachments((cur) => (cur.length ? cur : sent));
+        }
         if (!valueRef.current.trim()) {
           // Only restore when the user hasn't started a new draft during the
           // in-flight send. Persist the restored text as a draft too: the
-          // optimistic blank was already cached before onSend rejected it.
+          // optimistic blank was already cached before onSend rejected it. The
+          // callback still runs after navigation unmounts this Composer, because
+          // the original session's local draft must survive even though its UI
+          // state no longer exists.
           valueRef.current = submitted;
-          setValue(submitted);
-          setHasText(Boolean(submitted));
-          if (useMentions) {
-            // Chips re-resolve when re-picked; the content is never lost.
-            referencesRef.current = sentRefs;
-            mentionRef.current?.setText(submitted);
+          if (!unmountedRef.current) {
+            setValue(submitted);
+            setHasText(Boolean(submitted));
+            if (useMentions) {
+              // Chips re-resolve when re-picked; the content is never lost.
+              referencesRef.current = sentRefs;
+              mentionRef.current?.setText(submitted);
+            }
           }
           onDraftChange?.(submitted);
         }

--- a/ui/src/components/workbench/Composer.tsx
+++ b/ui/src/components/workbench/Composer.tsx
@@ -1200,6 +1200,7 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
   const voiceDiscardAvailable = recording || voiceRetainedSession !== null;
 
   const update = (next: string) => {
+    valueRef.current = next;
     setValue(next);
     onDraftChange?.(next);
   };
@@ -1213,6 +1214,7 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
     pendingRef.current = true;
     // Clear optimistically so the box can't be re-submitted and a slow send can't
     // wipe text typed in the meantime.
+    valueRef.current = '';
     setValue('');
     setHasText(false);
     onDraftChange?.('');
@@ -1225,14 +1227,20 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
       // restore the prompt + attachments for retry — unless the user typed anew.
       const started = await onSend(submitted, sent, useMentions ? sentRefs : undefined);
       if (started === false) {
-        setValue((cur) => (cur ? cur : submitted));
         setAttachments((cur) => (cur.length ? cur : sent));
-        if (useMentions && !valueRef.current.trim()) {
+        if (!valueRef.current.trim()) {
           // Only restore when the user hasn't started a new draft during the
-          // in-flight send (mirrors the textarea path's keep-new-typing guard).
-          // Chips re-resolve when re-picked; the content is never lost.
-          referencesRef.current = sentRefs;
-          mentionRef.current?.setText(submitted);
+          // in-flight send. Persist the restored text as a draft too: the
+          // optimistic blank was already cached before onSend rejected it.
+          valueRef.current = submitted;
+          setValue(submitted);
+          setHasText(Boolean(submitted));
+          if (useMentions) {
+            // Chips re-resolve when re-picked; the content is never lost.
+            referencesRef.current = sentRefs;
+            mentionRef.current?.setText(submitted);
+          }
+          onDraftChange?.(submitted);
         }
       }
     } finally {

--- a/ui/src/context/ApiContext.sessionDraftRetry.test.tsx
+++ b/ui/src/context/ApiContext.sessionDraftRetry.test.tsx
@@ -1,0 +1,78 @@
+/* @vitest-environment jsdom */
+
+import { act, cleanup, render, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const apiFetch = vi.hoisted(() => vi.fn());
+const showToast = vi.hoisted(() => vi.fn());
+
+vi.mock('../lib/apiFetch', () => ({ apiFetch }));
+vi.mock('./ToastContext', () => ({ useToast: () => ({ showToast }) }));
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+import { SessionDraftLocalCache } from '../lib/sessionDraftLocalCache';
+import { ApiProvider } from './ApiContext';
+
+beforeEach(() => {
+  window.localStorage.clear();
+  apiFetch.mockReset();
+  showToast.mockReset();
+  Object.defineProperty(document, 'visibilityState', {
+    configurable: true,
+    value: 'visible',
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  window.localStorage.clear();
+});
+
+describe('ApiProvider session draft reconnect', () => {
+  it('syncs dirty drafts for every session when the browser comes online', async () => {
+    const cache = new SessionDraftLocalCache(window.localStorage);
+    cache.writeDirty('session-a', 'offline A', 'rev-a');
+    cache.writeDirty('session-b', 'offline B', 'rev-b');
+    cache.writeClean('session-c', 'already synced', 'rev-c');
+    apiFetch.mockImplementation(async (_path: string, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body)) as {
+        text: string;
+        expected_updated_at: string | null;
+      };
+      return new Response(JSON.stringify({
+        ok: true,
+        draft: {
+          text: body.text,
+          updated_at: `synced-${body.expected_updated_at}`,
+        },
+      }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    });
+
+    render(<ApiProvider><div /></ApiProvider>);
+    act(() => window.dispatchEvent(new Event('online')));
+
+    await waitFor(() => expect(apiFetch).toHaveBeenCalledTimes(2));
+    const writes = apiFetch.mock.calls.map(([path, init]) => ({
+      path,
+      body: JSON.parse(String(init?.body)),
+    }));
+    expect(writes).toEqual(expect.arrayContaining([
+      {
+        path: '/api/sessions/session-a/draft',
+        body: { text: 'offline A', expected_updated_at: 'rev-a' },
+      },
+      {
+        path: '/api/sessions/session-b/draft',
+        body: { text: 'offline B', expected_updated_at: 'rev-b' },
+      },
+    ]));
+    expect(cache.read('session-a')?.dirty).toBe(false);
+    expect(cache.read('session-b')?.dirty).toBe(false);
+    expect(cache.read('session-c')).toMatchObject({ text: 'already synced', dirty: false });
+  });
+});

--- a/ui/src/context/ApiContext.sessionDraftRetry.test.tsx
+++ b/ui/src/context/ApiContext.sessionDraftRetry.test.tsx
@@ -31,6 +31,27 @@ afterEach(() => {
 });
 
 describe('ApiProvider session draft reconnect', () => {
+  it('syncs restored dirty drafts when a visible provider mounts', async () => {
+    const cache = new SessionDraftLocalCache(window.localStorage);
+    cache.writeDirty('session-a', 'restored A', 'rev-a');
+    apiFetch.mockImplementation(async (_path: string, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body)) as { text: string };
+      return new Response(JSON.stringify({
+        ok: true,
+        draft: { text: body.text, updated_at: 'synced-a' },
+      }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    });
+
+    render(<ApiProvider><div /></ApiProvider>);
+
+    await waitFor(() => expect(apiFetch).toHaveBeenCalledTimes(1));
+    expect(apiFetch.mock.calls[0]?.[0]).toBe('/api/sessions/session-a/draft');
+    expect(cache.read('session-a')?.dirty).toBe(false);
+  });
+
   it('syncs dirty drafts for every session when the browser comes online', async () => {
     const cache = new SessionDraftLocalCache(window.localStorage);
     cache.writeDirty('session-a', 'offline A', 'rev-a');

--- a/ui/src/context/ApiContext.sessionDraftRetry.test.tsx
+++ b/ui/src/context/ApiContext.sessionDraftRetry.test.tsx
@@ -188,4 +188,53 @@ describe('ApiProvider session draft reconnect', () => {
       expected_updated_at: 'clear-revision',
     });
   });
+
+  it('rebases text typed while an accepted send advances the draft revision', async () => {
+    let resolveStaleWrite!: (response: Response) => void;
+    const staleWrite = new Promise<Response>((resolve) => { resolveStaleWrite = resolve; });
+    let putCount = 0;
+    apiFetch.mockImplementation(async (_path: string, init?: RequestInit) => {
+      if (++putCount === 1) return staleWrite;
+      const body = JSON.parse(String(init?.body)) as { text: string };
+      return new Response(JSON.stringify({
+        ok: true,
+        draft: { text: body.text, updated_at: 'next-revision' },
+      }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    });
+
+    render(<ApiProvider><CaptureApi /></ApiProvider>);
+    capturedApi!.cacheSessionDraft('session-a', 'submitted');
+    capturedApi!.cacheSessionDraft('session-a', '');
+    capturedApi!.cacheSessionDraft('session-a', 'next prompt');
+    const stale = capturedApi!.setSessionDraft('session-a', 'next prompt');
+    await Promise.resolve();
+
+    await capturedApi!.reconcileSessionDraftAfterSend('session-a', {
+      text: '',
+      updated_at: 'clear-revision',
+    });
+    resolveStaleWrite(new Response(JSON.stringify({
+      ok: true,
+      draft: { text: 'next prompt', updated_at: 'stale-write-revision' },
+    }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    }));
+    await stale;
+
+    const writes = apiFetch.mock.calls.map(([, init]) => JSON.parse(String(init?.body)));
+    expect(writes).toEqual([
+      { text: 'next prompt', expected_updated_at: null },
+      { text: 'next prompt', expected_updated_at: 'clear-revision' },
+    ]);
+    const cache = new SessionDraftLocalCache(window.localStorage);
+    expect(cache.read('session-a')).toMatchObject({
+      text: 'next prompt',
+      serverUpdatedAt: 'next-revision',
+      dirty: false,
+    });
+  });
 });

--- a/ui/src/context/ApiContext.sessionDraftRetry.test.tsx
+++ b/ui/src/context/ApiContext.sessionDraftRetry.test.tsx
@@ -156,6 +156,60 @@ describe('ApiProvider session draft reconnect', () => {
     ]);
   });
 
+  it('rebases a successor when its timed-out predecessor commits after reconciliation', async () => {
+    vi.useFakeTimers();
+    const writes: Array<{ text: string; expected_updated_at: string | null }> = [];
+    apiFetch.mockImplementation(async (_path: string, init?: RequestInit) => {
+      if (!init?.method) {
+        return Response.json({ text: '', updated_at: null });
+      }
+      const body = JSON.parse(String(init.body)) as {
+        text: string;
+        expected_updated_at: string | null;
+      };
+      writes.push(body);
+      if (writes.length === 1) {
+        return new Promise<Response>((_resolve, reject) => {
+          init.signal?.addEventListener('abort', () => {
+            reject(new DOMException('aborted', 'AbortError'));
+          }, { once: true });
+        });
+      }
+      if (writes.length === 2) {
+        return Response.json({
+          ok: false,
+          code: 'draft_conflict',
+          draft: { text: 'first', updated_at: 'late-first-revision' },
+        }, { status: 409 });
+      }
+      return Response.json({
+        ok: true,
+        draft: { text: body.text, updated_at: 'second-revision' },
+      });
+    });
+
+    render(<ApiProvider><CaptureApi /></ApiProvider>);
+    capturedApi!.cacheSessionDraft('session-a', 'first');
+    const first = capturedApi!.setSessionDraft('session-a', 'first');
+    await Promise.resolve();
+    capturedApi!.cacheSessionDraft('session-a', 'second');
+    const second = capturedApi!.setSessionDraft('session-a', 'second');
+
+    await vi.advanceTimersByTimeAsync(12_000);
+    await expect(first).resolves.toMatchObject({ ok: false });
+    await expect(second).resolves.toMatchObject({ ok: true });
+    expect(writes).toEqual([
+      { text: 'first', expected_updated_at: null },
+      { text: 'second', expected_updated_at: null },
+      { text: 'second', expected_updated_at: 'late-first-revision' },
+    ]);
+    expect(new SessionDraftLocalCache(window.localStorage).read('session-a')).toMatchObject({
+      text: 'second',
+      serverUpdatedAt: 'second-revision',
+      dirty: false,
+    });
+  });
+
   it('rebases and retries text restored after a rejected send', async () => {
     let resolveDraft!: (response: Response) => void;
     const draft = new Promise<Response>((resolve) => { resolveDraft = resolve; });
@@ -236,5 +290,18 @@ describe('ApiProvider session draft reconnect', () => {
       serverUpdatedAt: 'next-revision',
       dirty: false,
     });
+  });
+
+  it('clears and announces an archived session reported by a raw request path', () => {
+    render(<ApiProvider><CaptureApi /></ApiProvider>);
+    capturedApi!.cacheSessionDraft('session-a', 'must be reclaimed');
+    const archived = vi.fn();
+    capturedApi!.onSessionArchived(archived);
+
+    act(() => capturedApi!.convergeSessionArchived('session-a'));
+
+    expect(archived).toHaveBeenCalledWith('session-a');
+    expect(new SessionDraftLocalCache(window.localStorage).read('session-a')).toBeNull();
+    expect(capturedApi!.getCachedSessionDraft('session-a')).toBeNull();
   });
 });

--- a/ui/src/context/ApiContext.sessionDraftRetry.test.tsx
+++ b/ui/src/context/ApiContext.sessionDraftRetry.test.tsx
@@ -1,6 +1,7 @@
 /* @vitest-environment jsdom */
 
 import { act, cleanup, render, waitFor } from '@testing-library/react';
+import { useEffect } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const apiFetch = vi.hoisted(() => vi.fn());
@@ -13,12 +14,23 @@ vi.mock('react-i18next', () => ({
 }));
 
 import { SessionDraftLocalCache } from '../lib/sessionDraftLocalCache';
-import { ApiProvider } from './ApiContext';
+import { ApiProvider, useApi } from './ApiContext';
+
+let capturedApi: ReturnType<typeof useApi> | null = null;
+
+const CaptureApi = () => {
+  const api = useApi();
+  useEffect(() => {
+    capturedApi = api;
+  }, [api]);
+  return null;
+};
 
 beforeEach(() => {
   window.localStorage.clear();
   apiFetch.mockReset();
   showToast.mockReset();
+  capturedApi = null;
   Object.defineProperty(document, 'visibilityState', {
     configurable: true,
     value: 'visible',
@@ -27,6 +39,7 @@ beforeEach(() => {
 
 afterEach(() => {
   cleanup();
+  vi.useRealTimers();
   window.localStorage.clear();
 });
 
@@ -95,5 +108,84 @@ describe('ApiProvider session draft reconnect', () => {
     expect(cache.read('session-a')?.dirty).toBe(false);
     expect(cache.read('session-b')?.dirty).toBe(false);
     expect(cache.read('session-c')).toMatchObject({ text: 'already synced', dirty: false });
+  });
+
+  it('bounds a stalled write and releases its reconciled successor', async () => {
+    vi.useFakeTimers();
+    let putCount = 0;
+    apiFetch.mockImplementation(async (path: string, init?: RequestInit) => {
+      if (init?.method === 'PUT' && ++putCount === 1) {
+        return new Promise<Response>((_resolve, reject) => {
+          init.signal?.addEventListener('abort', () => {
+            reject(new DOMException('aborted', 'AbortError'));
+          }, { once: true });
+        });
+      }
+      if (!init?.method) {
+        return new Response(JSON.stringify({ text: '', updated_at: null }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      const body = JSON.parse(String(init.body)) as { text: string };
+      return new Response(JSON.stringify({
+        ok: true,
+        draft: { text: body.text, updated_at: 'second-revision' },
+      }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    });
+
+    render(<ApiProvider><CaptureApi /></ApiProvider>);
+    capturedApi!.cacheSessionDraft('session-a', 'first');
+    const first = capturedApi!.setSessionDraft('session-a', 'first');
+    await Promise.resolve();
+    capturedApi!.cacheSessionDraft('session-a', 'second');
+    const second = capturedApi!.setSessionDraft('session-a', 'second');
+
+    await vi.advanceTimersByTimeAsync(12_000);
+    await expect(first).resolves.toMatchObject({ ok: false });
+    await expect(second).resolves.toMatchObject({ ok: true });
+    const writes = apiFetch.mock.calls
+      .filter(([, init]) => init?.method === 'PUT')
+      .map(([, init]) => JSON.parse(String(init?.body)));
+    expect(writes).toEqual([
+      { text: 'first', expected_updated_at: null },
+      { text: 'second', expected_updated_at: null },
+    ]);
+  });
+
+  it('rebases and retries text restored after a rejected send', async () => {
+    let resolveDraft!: (response: Response) => void;
+    const draft = new Promise<Response>((resolve) => { resolveDraft = resolve; });
+    apiFetch.mockImplementation(async (_path: string, init?: RequestInit) => {
+      if (!init?.method) return draft;
+      const body = JSON.parse(String(init.body)) as { text: string };
+      return new Response(JSON.stringify({
+        ok: true,
+        draft: { text: body.text, updated_at: 'restored-revision' },
+      }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    });
+
+    render(<ApiProvider><CaptureApi /></ApiProvider>);
+    capturedApi!.cacheSessionDraft('session-a', 'submitted');
+    capturedApi!.cacheSessionDraft('session-a', '');
+    const recovery = capturedApi!.recoverSessionDraftAfterRejectedSend('session-a');
+    capturedApi!.cacheSessionDraft('session-a', 'submitted');
+    resolveDraft(new Response(JSON.stringify({ text: '', updated_at: 'clear-revision' }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    }));
+    await recovery;
+
+    const write = apiFetch.mock.calls.find(([, init]) => init?.method === 'PUT');
+    expect(JSON.parse(String(write?.[1]?.body))).toEqual({
+      text: 'submitted',
+      expected_updated_at: 'clear-revision',
+    });
   });
 });

--- a/ui/src/context/ApiContext.tsx
+++ b/ui/src/context/ApiContext.tsx
@@ -2362,6 +2362,7 @@ export const ApiProvider: React.FC<{ children: React.ReactNode }> = ({ children 
     // must never change whether/what this handler throws.
     const archivedSessionId = archivedConflictSessionId(errorCode, path);
     if (archivedSessionId) {
+      sessionDraftPersistence.clearSession(archivedSessionId);
       for (const handler of Array.from(sessionArchivedHandlersRef.current)) {
         try {
           handler(archivedSessionId);
@@ -2554,6 +2555,9 @@ export const ApiProvider: React.FC<{ children: React.ReactNode }> = ({ children 
       if (!envelope) return;
       if (envelope.data.session_id) {
         clearSessionReadCache(envelope.data.session_id);
+        if (envelope.data.event === 'archived') {
+          sessionDraftPersistence.clearSession(envelope.data.session_id);
+        }
       } else {
         clearReadCacheMatching((path) => path.startsWith('/api/inbox') || path.startsWith('/api/sessions'));
       }
@@ -3127,12 +3131,20 @@ export const ApiProvider: React.FC<{ children: React.ReactNode }> = ({ children 
       };
     },
     getSessionBootstrap: async (sessionId) => {
-      await sessionDraftPersistence.waitForWrites(sessionId);
-      const readRevision = sessionDraftPersistence.revision(sessionId);
-      const payload = await getJson(`/api/sessions/${encodeURIComponent(sessionId)}/bootstrap`);
-      const serverText = payload?.draft?.text ?? '';
-      const text = sessionDraftPersistence.reconcileRead(sessionId, readRevision, serverText);
-      return text === serverText ? payload : { ...payload, draft: { ...(payload.draft ?? {}), text } };
+      const read = sessionDraftPersistence.beginRead(sessionId);
+      try {
+        const payload = await getJson(`/api/sessions/${encodeURIComponent(sessionId)}/bootstrap`);
+        if (payload?.session?.status === 'archived') {
+          sessionDraftPersistence.clearSession(sessionId);
+          return payload;
+        }
+        const serverText = payload?.draft?.text ?? '';
+        const text = sessionDraftPersistence.reconcileRead(sessionId, read, serverText);
+        return text === serverText ? payload : { ...payload, draft: { ...(payload.draft ?? {}), text } };
+      } catch (error) {
+        sessionDraftPersistence.releaseRead(sessionId, read);
+        throw error;
+      }
     },
     updateSession: async (sessionId, payload) => {
       const { payloadJson } = await requestJson(`/api/sessions/${encodeURIComponent(sessionId)}`, {
@@ -3142,7 +3154,11 @@ export const ApiProvider: React.FC<{ children: React.ReactNode }> = ({ children 
       }, `PATCH /api/sessions/${sessionId}`);
       return payloadJson;
     },
-    archiveSession: (sessionId) => deleteJson(`/api/sessions/${encodeURIComponent(sessionId)}`),
+    archiveSession: async (sessionId) => {
+      const payload = await deleteJson(`/api/sessions/${encodeURIComponent(sessionId)}`);
+      sessionDraftPersistence.clearSession(sessionId);
+      return payload;
+    },
     onSessionArchived,
     getArchivePreview: (sessionId) =>
       getJson(`/api/sessions/${encodeURIComponent(sessionId)}/archive-preview`),
@@ -3232,12 +3248,16 @@ export const ApiProvider: React.FC<{ children: React.ReactNode }> = ({ children 
       return res.json();
     },
     getSessionDraft: async (sessionId) => {
-      await sessionDraftPersistence.waitForWrites(sessionId);
-      const readRevision = sessionDraftPersistence.revision(sessionId);
-      const payload = await getCachedJson(`/api/sessions/${encodeURIComponent(sessionId)}/draft`);
-      const serverText = payload?.text ?? '';
-      const text = sessionDraftPersistence.reconcileRead(sessionId, readRevision, serverText);
-      return { text };
+      const read = sessionDraftPersistence.beginRead(sessionId);
+      try {
+        const payload = await getCachedJson(`/api/sessions/${encodeURIComponent(sessionId)}/draft`);
+        const serverText = payload?.text ?? '';
+        const text = sessionDraftPersistence.reconcileRead(sessionId, read, serverText);
+        return { text };
+      } catch (error) {
+        sessionDraftPersistence.releaseRead(sessionId, read);
+        throw error;
+      }
     },
     setSessionDraft: (sessionId, text) => sessionDraftPersistence.save(sessionId, text, async () => {
       const { res } = await requestJson(`/api/sessions/${encodeURIComponent(sessionId)}/draft`, {

--- a/ui/src/context/ApiContext.tsx
+++ b/ui/src/context/ApiContext.tsx
@@ -725,6 +725,10 @@ export type ApiContextType = {
   cacheSessionDraft: (sessionId: string, text: string) => void;
   getSessionDraft: (sessionId: string) => Promise<{ text: string }>;
   setSessionDraft: (sessionId: string, text: string) => Promise<{ ok: boolean }>;
+  reconcileSessionDraftAfterSend: (
+    sessionId: string,
+    draft: { text: string; updated_at: string | null },
+  ) => Promise<void>;
   recoverSessionDraftAfterRejectedSend: (sessionId: string) => Promise<void>;
   listInbox: (params?: { platform?: string; unreadOnly?: boolean; limit?: number; before?: string; onlySession?: string; cache?: boolean; handleError?: boolean }) => Promise<InboxFeedResult>;
   connectWorkbenchEvents: (handlers: WorkbenchEventHandlers) => () => void;
@@ -2831,6 +2835,16 @@ export const ApiProvider: React.FC<{ children: React.ReactNode }> = ({ children 
       window.clearTimeout(timeout);
     }
   };
+  const rebaseAndRetrySessionDraft = async (
+    sessionId: string,
+    server: SessionDraftServerState,
+  ): Promise<void> => {
+    sessionDraftPersistence.rebase(sessionId, server);
+    await sessionDraftPersistence.retry(
+      sessionId,
+      (draft) => writeSessionDraft(sessionId, draft),
+    );
+  };
   syncSessionDraftsRef.current = () => {
     void sessionDraftPersistence.retryAll(writeSessionDraft);
   };
@@ -3373,6 +3387,9 @@ export const ApiProvider: React.FC<{ children: React.ReactNode }> = ({ children 
       text,
       (draft) => writeSessionDraft(sessionId, draft),
     ),
+    reconcileSessionDraftAfterSend: (sessionId, draft) => (
+      rebaseAndRetrySessionDraft(sessionId, sessionDraftServerState(draft))
+    ),
     recoverSessionDraftAfterRejectedSend: async (sessionId) => {
       // The message reservation clears the cloud draft before dispatch. A
       // rejected/unknown dispatch therefore needs an authoritative revision
@@ -3380,11 +3397,7 @@ export const ApiProvider: React.FC<{ children: React.ReactNode }> = ({ children 
       sessionDraftPersistence.markRejectedSend(sessionId);
       const server = await readSessionDraftServer(sessionId);
       if (!server) return;
-      sessionDraftPersistence.rebase(sessionId, server);
-      await sessionDraftPersistence.retry(
-        sessionId,
-        (draft) => writeSessionDraft(sessionId, draft),
-      );
+      await rebaseAndRetrySessionDraft(sessionId, server);
     },
     listInbox: (params) => {
       const search = new URLSearchParams();

--- a/ui/src/context/ApiContext.tsx
+++ b/ui/src/context/ApiContext.tsx
@@ -678,6 +678,9 @@ export type ApiContextType = {
   getSessionBootstrap: (sessionId: string) => Promise<WorkbenchSessionBootstrap>;
   updateSession: (sessionId: string, payload: Partial<WorkbenchSessionUpdate>) => Promise<WorkbenchSession>;
   archiveSession: (sessionId: string) => Promise<WorkbenchSession>;
+  /** Apply the terminal archived state for raw request paths that intentionally
+   *  bypass the shared JSON error handler. */
+  convergeSessionArchived: (sessionId: string) => void;
   /** Subscribe to "the server just refused a write because that session is
    *  archived". Fires for EVERY request whose error body carries
    *  ``session_archived``, whatever the verb — the messages POST, the sessions
@@ -2350,6 +2353,17 @@ export const ApiProvider: React.FC<{ children: React.ReactNode }> = ({ children 
   const sessionArchivedHandlersRef = useRef(new Set<(sessionId: string) => void>());
   const sessionDraftPersistence = useMemo(() => new SessionDraftPersistence(), []);
 
+  const convergeSessionArchived = (sessionId: string) => {
+    sessionDraftPersistence.clearSession(sessionId);
+    for (const handler of Array.from(sessionArchivedHandlersRef.current)) {
+      try {
+        handler(sessionId);
+      } catch (err) {
+        console.error('[API] session-archived subscriber failed', err);
+      }
+    }
+  };
+
   const handleApiError = async (res: Response, path: string) => {
     let errorMessage = `Request failed: ${path} (${res.status})`;
     let errorCode: string | null = null;
@@ -2388,14 +2402,7 @@ export const ApiProvider: React.FC<{ children: React.ReactNode }> = ({ children 
     // must never change whether/what this handler throws.
     const archivedSessionId = archivedConflictSessionId(errorCode, path);
     if (archivedSessionId) {
-      sessionDraftPersistence.clearSession(archivedSessionId);
-      for (const handler of Array.from(sessionArchivedHandlersRef.current)) {
-        try {
-          handler(archivedSessionId);
-        } catch (err) {
-          console.error('[API] session-archived subscriber failed', err);
-        }
-      }
+      convergeSessionArchived(archivedSessionId);
     }
 
     throw new ApiError(errorMessage, res.status, errorCode);
@@ -2830,7 +2837,14 @@ export const ApiProvider: React.FC<{ children: React.ReactNode }> = ({ children 
       if (server.text === draft.text) return { ok: true, server };
       return server.updatedAt !== draft.expectedUpdatedAt
         ? { ok: false, conflict: true, server }
-        : { ok: false, server };
+        : {
+            ok: false,
+            server,
+            // The abort only stops waiting for the response; the synchronous
+            // server transaction may still commit. If the queued successor
+            // conflicts specifically with this text, rebase and retry once.
+            retryConflictIfServerText: draft.text,
+          };
     } finally {
       window.clearTimeout(timeout);
     }
@@ -3276,6 +3290,7 @@ export const ApiProvider: React.FC<{ children: React.ReactNode }> = ({ children 
       sessionDraftPersistence.clearSession(sessionId);
       return payload;
     },
+    convergeSessionArchived,
     onSessionArchived,
     getArchivePreview: (sessionId) =>
       getJson(`/api/sessions/${encodeURIComponent(sessionId)}/archive-preview`),

--- a/ui/src/context/ApiContext.tsx
+++ b/ui/src/context/ApiContext.tsx
@@ -12,7 +12,12 @@ import {
 } from '../lib/workbenchEventConnection';
 import type { DockDoc } from './dockDoc';
 import { archivedConflictSessionId, selectApiErrorFields } from './apiErrorParse';
-import { SessionDraftPersistence } from '../lib/sessionDraftPersistence';
+import {
+  SessionDraftPersistence,
+  type SessionDraftSaveResult,
+  type SessionDraftServerState,
+  type SessionDraftWrite,
+} from '../lib/sessionDraftPersistence';
 
 // The workbench Dock API response shape ({ ok, dock }); the Dock document type
 // itself lives with the DockProvider that owns reconciliation.
@@ -716,6 +721,9 @@ export type ApiContextType = {
   removeQueuedMessage: (sessionId: string, messageId: string) => Promise<{ removed: boolean }>;
   sendQueuedNow: (sessionId: string, messageId: string) => Promise<{ ok: boolean; status?: string; code?: string; detail?: string }>;
   getTurnState: (sessionId: string, options?: { handleError?: boolean }) => Promise<SessionRuntimeState>;
+  getCachedSessionDraft: (sessionId: string) => string | null;
+  cacheSessionDraft: (sessionId: string, text: string) => void;
+  syncSessionDraft: (sessionId: string) => Promise<{ ok: boolean }>;
   getSessionDraft: (sessionId: string) => Promise<{ text: string }>;
   setSessionDraft: (sessionId: string, text: string) => Promise<{ ok: boolean }>;
   listInbox: (params?: { platform?: string; unreadOnly?: boolean; limit?: number; before?: string; onlySession?: string; cache?: boolean; handleError?: boolean }) => Promise<InboxFeedResult>;
@@ -1248,9 +1256,19 @@ export type WorkbenchSessionBootstrap = {
   next_after_id: string | null;
   next_before_id?: string | null;
   queued: WorkbenchMessage[];
-  draft: { text: string };
+  draft: { text: string; updated_at: string | null };
   turn_state: SessionRuntimeState;
 };
+
+function sessionDraftServerState(payload: unknown): SessionDraftServerState {
+  const draft = payload && typeof payload === 'object'
+    ? payload as { text?: unknown; updated_at?: unknown }
+    : {};
+  return {
+    text: typeof draft.text === 'string' ? draft.text : '',
+    updatedAt: typeof draft.updated_at === 'string' ? draft.updated_at : null,
+  };
+}
 
 // One row of the per-session ("Slack-like") inbox feed from ``GET /api/inbox``.
 // Aggregated per session at query time: ``preview_text`` is the session's latest
@@ -2738,6 +2756,33 @@ export const ApiProvider: React.FC<{ children: React.ReactNode }> = ({ children 
     return { res, payloadJson };
   };
 
+  const writeSessionDraft = async (
+    sessionId: string,
+    draft: SessionDraftWrite,
+  ): Promise<SessionDraftSaveResult> => {
+    const { res, payloadJson } = await requestJson(
+      `/api/sessions/${encodeURIComponent(sessionId)}/draft`,
+      {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          text: draft.text,
+          expected_updated_at: draft.expectedUpdatedAt,
+        }),
+      },
+      `/api/sessions/${sessionId}/draft`,
+      { handleError: false },
+    );
+    const hasServerDraft = payloadJson?.draft && typeof payloadJson.draft === 'object';
+    const server = sessionDraftServerState(payloadJson?.draft);
+    if (res.status === 409 && payloadJson?.code === 'draft_conflict') {
+      return { ok: false, conflict: true, server };
+    }
+    return res.ok
+      ? { ok: true, ...(hasServerDraft ? { server } : {}) }
+      : { ok: false };
+  };
+
   const postJson = async (path: string, payload: any, opts?: { handleError?: boolean }) => {
     const { payloadJson } = await requestJson(
       path,
@@ -3138,9 +3183,15 @@ export const ApiProvider: React.FC<{ children: React.ReactNode }> = ({ children 
           sessionDraftPersistence.clearSession(sessionId);
           return payload;
         }
-        const serverText = payload?.draft?.text ?? '';
-        const text = sessionDraftPersistence.reconcileRead(sessionId, read, serverText);
-        return text === serverText ? payload : { ...payload, draft: { ...(payload.draft ?? {}), text } };
+        const server = sessionDraftServerState(payload?.draft);
+        const text = sessionDraftPersistence.reconcileRead(sessionId, read, server);
+        void sessionDraftPersistence.retry(
+          sessionId,
+          (draft) => writeSessionDraft(sessionId, draft),
+        );
+        return text === server.text
+          ? payload
+          : { ...payload, draft: { ...(payload.draft ?? {}), text } };
       } catch (error) {
         sessionDraftPersistence.releaseRead(sessionId, read);
         throw error;
@@ -3247,26 +3298,33 @@ export const ApiProvider: React.FC<{ children: React.ReactNode }> = ({ children 
       }
       return res.json();
     },
+    getCachedSessionDraft: (sessionId) => sessionDraftPersistence.peek(sessionId),
+    cacheSessionDraft: (sessionId, text) => sessionDraftPersistence.cache(sessionId, text),
+    syncSessionDraft: (sessionId) => sessionDraftPersistence.retry(
+      sessionId,
+      (draft) => writeSessionDraft(sessionId, draft),
+    ),
     getSessionDraft: async (sessionId) => {
       const read = sessionDraftPersistence.beginRead(sessionId);
       try {
-        const payload = await getCachedJson(`/api/sessions/${encodeURIComponent(sessionId)}/draft`);
-        const serverText = payload?.text ?? '';
-        const text = sessionDraftPersistence.reconcileRead(sessionId, read, serverText);
+        const payload = await getJson(`/api/sessions/${encodeURIComponent(sessionId)}/draft`);
+        const server = sessionDraftServerState(payload);
+        const text = sessionDraftPersistence.reconcileRead(sessionId, read, server);
+        void sessionDraftPersistence.retry(
+          sessionId,
+          (draft) => writeSessionDraft(sessionId, draft),
+        );
         return { text };
       } catch (error) {
         sessionDraftPersistence.releaseRead(sessionId, read);
         throw error;
       }
     },
-    setSessionDraft: (sessionId, text) => sessionDraftPersistence.save(sessionId, text, async () => {
-      const { res } = await requestJson(`/api/sessions/${encodeURIComponent(sessionId)}/draft`, {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ text }),
-      }, `/api/sessions/${sessionId}/draft`, { handleError: false });
-      return res.ok ? { ok: true } : { ok: false };
-    }),
+    setSessionDraft: (sessionId, text) => sessionDraftPersistence.save(
+      sessionId,
+      text,
+      (draft) => writeSessionDraft(sessionId, draft),
+    ),
     listInbox: (params) => {
       const search = new URLSearchParams();
       if (params?.platform) search.set('platform', params.platform);

--- a/ui/src/context/ApiContext.tsx
+++ b/ui/src/context/ApiContext.tsx
@@ -723,7 +723,6 @@ export type ApiContextType = {
   getTurnState: (sessionId: string, options?: { handleError?: boolean }) => Promise<SessionRuntimeState>;
   getCachedSessionDraft: (sessionId: string) => string | null;
   cacheSessionDraft: (sessionId: string, text: string) => void;
-  syncSessionDraft: (sessionId: string) => Promise<{ ok: boolean }>;
   getSessionDraft: (sessionId: string) => Promise<{ text: string }>;
   setSessionDraft: (sessionId: string, text: string) => Promise<{ ok: boolean }>;
   listInbox: (params?: { platform?: string; unreadOnly?: boolean; limit?: number; before?: string; onlySession?: string; cache?: boolean; handleError?: boolean }) => Promise<InboxFeedResult>;
@@ -2338,6 +2337,7 @@ export const ApiProvider: React.FC<{ children: React.ReactNode }> = ({ children 
   const eventConnectionStateRef = useRef<WorkbenchEventConnectionState>('reconnecting');
   const eventReconnectLoopRef = useRef<WorkbenchEventReconnectLoop | null>(null);
   const wakeWorkbenchEventsRef = useRef<() => void>(() => {});
+  const syncSessionDraftsRef = useRef<() => void>(() => {});
   const stopWorkbenchEventsRef = useRef<() => void>(() => {});
   const sessionArchivedHandlersRef = useRef(new Set<(sessionId: string) => void>());
   const sessionDraftPersistence = useMemo(() => new SessionDraftPersistence(), []);
@@ -2726,7 +2726,9 @@ export const ApiProvider: React.FC<{ children: React.ReactNode }> = ({ children 
 
   useEffect(() => {
     const wakeIfVisible = () => {
-      if (document.visibilityState === 'visible') wakeWorkbenchEventsRef.current();
+      if (document.visibilityState !== 'visible') return;
+      wakeWorkbenchEventsRef.current();
+      syncSessionDraftsRef.current();
     };
     document.addEventListener('visibilitychange', wakeIfVisible);
     window.addEventListener('online', wakeIfVisible);
@@ -2781,6 +2783,9 @@ export const ApiProvider: React.FC<{ children: React.ReactNode }> = ({ children 
     return res.ok
       ? { ok: true, ...(hasServerDraft ? { server } : {}) }
       : { ok: false };
+  };
+  syncSessionDraftsRef.current = () => {
+    void sessionDraftPersistence.retryAll(writeSessionDraft);
   };
 
   const postJson = async (path: string, payload: any, opts?: { handleError?: boolean }) => {
@@ -3300,10 +3305,6 @@ export const ApiProvider: React.FC<{ children: React.ReactNode }> = ({ children 
     },
     getCachedSessionDraft: (sessionId) => sessionDraftPersistence.peek(sessionId),
     cacheSessionDraft: (sessionId, text) => sessionDraftPersistence.cache(sessionId, text),
-    syncSessionDraft: (sessionId) => sessionDraftPersistence.retry(
-      sessionId,
-      (draft) => writeSessionDraft(sessionId, draft),
-    ),
     getSessionDraft: async (sessionId) => {
       const read = sessionDraftPersistence.beginRead(sessionId);
       try {

--- a/ui/src/context/ApiContext.tsx
+++ b/ui/src/context/ApiContext.tsx
@@ -725,6 +725,7 @@ export type ApiContextType = {
   cacheSessionDraft: (sessionId: string, text: string) => void;
   getSessionDraft: (sessionId: string) => Promise<{ text: string }>;
   setSessionDraft: (sessionId: string, text: string) => Promise<{ ok: boolean }>;
+  recoverSessionDraftAfterRejectedSend: (sessionId: string) => Promise<void>;
   listInbox: (params?: { platform?: string; unreadOnly?: boolean; limit?: number; before?: string; onlySession?: string; cache?: boolean; handleError?: boolean }) => Promise<InboxFeedResult>;
   connectWorkbenchEvents: (handlers: WorkbenchEventHandlers) => () => void;
   listVibeAgents: (params?: {
@@ -1268,6 +1269,9 @@ function sessionDraftServerState(payload: unknown): SessionDraftServerState {
     updatedAt: typeof draft.updated_at === 'string' ? draft.updated_at : null,
   };
 }
+
+const SESSION_DRAFT_WRITE_TIMEOUT_MS = 12_000;
+const SESSION_DRAFT_RECONCILE_TIMEOUT_MS = 5_000;
 
 // One row of the per-session ("Slack-like") inbox feed from ``GET /api/inbox``.
 // Aggregated per session at query time: ``preview_text`` is the session's latest
@@ -2759,31 +2763,73 @@ export const ApiProvider: React.FC<{ children: React.ReactNode }> = ({ children 
     return { res, payloadJson };
   };
 
+  const readSessionDraftServer = async (
+    sessionId: string,
+    timeoutMs = SESSION_DRAFT_RECONCILE_TIMEOUT_MS,
+  ): Promise<SessionDraftServerState | null> => {
+    const controller = new AbortController();
+    const timeout = window.setTimeout(() => controller.abort(), timeoutMs);
+    try {
+      const res = await apiFetch(
+        `/api/sessions/${encodeURIComponent(sessionId)}/draft`,
+        { signal: controller.signal },
+      );
+      if (!res.ok) return null;
+      return sessionDraftServerState(await res.json().catch(() => null));
+    } catch {
+      return null;
+    } finally {
+      window.clearTimeout(timeout);
+    }
+  };
+
   const writeSessionDraft = async (
     sessionId: string,
     draft: SessionDraftWrite,
   ): Promise<SessionDraftSaveResult> => {
-    const { res, payloadJson } = await requestJson(
-      `/api/sessions/${encodeURIComponent(sessionId)}/draft`,
-      {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          text: draft.text,
-          expected_updated_at: draft.expectedUpdatedAt,
-        }),
-      },
-      `/api/sessions/${sessionId}/draft`,
-      { handleError: false },
-    );
-    const hasServerDraft = payloadJson?.draft && typeof payloadJson.draft === 'object';
-    const server = sessionDraftServerState(payloadJson?.draft);
-    if (res.status === 409 && payloadJson?.code === 'draft_conflict') {
-      return { ok: false, conflict: true, server };
+    const controller = new AbortController();
+    let timedOut = false;
+    const timeout = window.setTimeout(() => {
+      timedOut = true;
+      controller.abort();
+    }, SESSION_DRAFT_WRITE_TIMEOUT_MS);
+    try {
+      const { res, payloadJson } = await requestJson(
+        `/api/sessions/${encodeURIComponent(sessionId)}/draft`,
+        {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            text: draft.text,
+            expected_updated_at: draft.expectedUpdatedAt,
+          }),
+          signal: controller.signal,
+        },
+        `/api/sessions/${sessionId}/draft`,
+        { handleError: false },
+      );
+      const hasServerDraft = payloadJson?.draft && typeof payloadJson.draft === 'object';
+      const server = sessionDraftServerState(payloadJson?.draft);
+      if (res.status === 409 && payloadJson?.code === 'draft_conflict') {
+        return { ok: false, conflict: true, server };
+      }
+      return res.ok
+        ? { ok: true, ...(hasServerDraft ? { server } : {}) }
+        : { ok: false };
+    } catch (error) {
+      if (!timedOut) throw error;
+      // The request may have committed before its response stalled. Reconcile
+      // once before releasing queued successors so they inherit the actual
+      // cloud revision instead of manufacturing a conflict from uncertainty.
+      const server = await readSessionDraftServer(sessionId);
+      if (!server) return { ok: false };
+      if (server.text === draft.text) return { ok: true, server };
+      return server.updatedAt !== draft.expectedUpdatedAt
+        ? { ok: false, conflict: true, server }
+        : { ok: false, server };
+    } finally {
+      window.clearTimeout(timeout);
     }
-    return res.ok
-      ? { ok: true, ...(hasServerDraft ? { server } : {}) }
-      : { ok: false };
   };
   syncSessionDraftsRef.current = () => {
     void sessionDraftPersistence.retryAll(writeSessionDraft);
@@ -3327,6 +3373,19 @@ export const ApiProvider: React.FC<{ children: React.ReactNode }> = ({ children 
       text,
       (draft) => writeSessionDraft(sessionId, draft),
     ),
+    recoverSessionDraftAfterRejectedSend: async (sessionId) => {
+      // The message reservation clears the cloud draft before dispatch. A
+      // rejected/unknown dispatch therefore needs an authoritative revision
+      // before the composer's optimistic text restoration is replayed.
+      sessionDraftPersistence.markRejectedSend(sessionId);
+      const server = await readSessionDraftServer(sessionId);
+      if (!server) return;
+      sessionDraftPersistence.rebase(sessionId, server);
+      await sessionDraftPersistence.retry(
+        sessionId,
+        (draft) => writeSessionDraft(sessionId, draft),
+      );
+    },
     listInbox: (params) => {
       const search = new URLSearchParams();
       if (params?.platform) search.set('platform', params.platform);

--- a/ui/src/context/ApiContext.tsx
+++ b/ui/src/context/ApiContext.tsx
@@ -2733,6 +2733,7 @@ export const ApiProvider: React.FC<{ children: React.ReactNode }> = ({ children 
     document.addEventListener('visibilitychange', wakeIfVisible);
     window.addEventListener('online', wakeIfVisible);
     window.addEventListener('focus', wakeIfVisible);
+    if (document.visibilityState === 'visible') syncSessionDraftsRef.current();
     return () => {
       document.removeEventListener('visibilitychange', wakeIfVisible);
       window.removeEventListener('online', wakeIfVisible);

--- a/ui/src/context/ApiContext.tsx
+++ b/ui/src/context/ApiContext.tsx
@@ -12,6 +12,7 @@ import {
 } from '../lib/workbenchEventConnection';
 import type { DockDoc } from './dockDoc';
 import { archivedConflictSessionId, selectApiErrorFields } from './apiErrorParse';
+import { SessionDraftPersistence } from '../lib/sessionDraftPersistence';
 
 // The workbench Dock API response shape ({ ok, dock }); the Dock document type
 // itself lives with the DockProvider that owns reconciliation.
@@ -2321,6 +2322,7 @@ export const ApiProvider: React.FC<{ children: React.ReactNode }> = ({ children 
   const wakeWorkbenchEventsRef = useRef<() => void>(() => {});
   const stopWorkbenchEventsRef = useRef<() => void>(() => {});
   const sessionArchivedHandlersRef = useRef(new Set<(sessionId: string) => void>());
+  const sessionDraftPersistence = useMemo(() => new SessionDraftPersistence(), []);
 
   const handleApiError = async (res: Response, path: string) => {
     let errorMessage = `Request failed: ${path} (${res.status})`;
@@ -3124,8 +3126,14 @@ export const ApiProvider: React.FC<{ children: React.ReactNode }> = ({ children 
         session: res.ok && payload && typeof payload.id === 'string' ? payload : null,
       };
     },
-    getSessionBootstrap: (sessionId) =>
-      getJson(`/api/sessions/${encodeURIComponent(sessionId)}/bootstrap`),
+    getSessionBootstrap: async (sessionId) => {
+      await sessionDraftPersistence.waitForWrites(sessionId);
+      const readRevision = sessionDraftPersistence.revision(sessionId);
+      const payload = await getJson(`/api/sessions/${encodeURIComponent(sessionId)}/bootstrap`);
+      const serverText = payload?.draft?.text ?? '';
+      const text = sessionDraftPersistence.reconcileRead(sessionId, readRevision, serverText);
+      return text === serverText ? payload : { ...payload, draft: { ...(payload.draft ?? {}), text } };
+    },
     updateSession: async (sessionId, payload) => {
       const { payloadJson } = await requestJson(`/api/sessions/${encodeURIComponent(sessionId)}`, {
         method: 'PATCH',
@@ -3223,15 +3231,22 @@ export const ApiProvider: React.FC<{ children: React.ReactNode }> = ({ children 
       }
       return res.json();
     },
-    getSessionDraft: (sessionId) => getCachedJson(`/api/sessions/${encodeURIComponent(sessionId)}/draft`),
-    setSessionDraft: async (sessionId, text) => {
-      const { res, payloadJson } = await requestJson(`/api/sessions/${encodeURIComponent(sessionId)}/draft`, {
+    getSessionDraft: async (sessionId) => {
+      await sessionDraftPersistence.waitForWrites(sessionId);
+      const readRevision = sessionDraftPersistence.revision(sessionId);
+      const payload = await getCachedJson(`/api/sessions/${encodeURIComponent(sessionId)}/draft`);
+      const serverText = payload?.text ?? '';
+      const text = sessionDraftPersistence.reconcileRead(sessionId, readRevision, serverText);
+      return { text };
+    },
+    setSessionDraft: (sessionId, text) => sessionDraftPersistence.save(sessionId, text, async () => {
+      const { res } = await requestJson(`/api/sessions/${encodeURIComponent(sessionId)}/draft`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ text }),
       }, `/api/sessions/${sessionId}/draft`, { handleError: false });
-      return res.ok ? payloadJson : { ok: false };
-    },
+      return res.ok ? { ok: true } : { ok: false };
+    }),
     listInbox: (params) => {
       const search = new URLSearchParams();
       if (params?.platform) search.set('platform', params.platform);
@@ -3523,7 +3538,7 @@ export const ApiProvider: React.FC<{ children: React.ReactNode }> = ({ children 
     getAuthSession: () => getJson('/api/session'),
     signOut: () => postJson('/auth/logout', {}),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }), [showToast, t]);
+  }), [sessionDraftPersistence, showToast, t]);
 
   return <ApiContext.Provider value={value}>{children}</ApiContext.Provider>;
 };

--- a/ui/src/lib/sessionDraftLocalCache.test.ts
+++ b/ui/src/lib/sessionDraftLocalCache.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  SESSION_DRAFT_INVALIDATION_PREFIX,
   SESSION_DRAFT_STORAGE_PREFIX,
   SessionDraftLocalCache,
 } from './sessionDraftLocalCache';
@@ -95,6 +96,19 @@ describe('SessionDraftLocalCache', () => {
     expect(storage.getItem(`${SESSION_DRAFT_STORAGE_PREFIX}broken`)).toBeNull();
   });
 
+  it('persists archive invalidation across cache instances', () => {
+    const storage = new MemoryStorage();
+    const first = new SessionDraftLocalCache(storage, () => 'archive-1', () => 1);
+    const second = new SessionDraftLocalCache(storage, () => 'unused', () => 2);
+
+    expect(first.readInvalidation('session/a')).toBeNull();
+    expect(first.invalidate('session/a')).toBe('archive-1');
+    expect(second.readInvalidation('session/a')).toBe('archive-1');
+    expect(storage.getItem(
+      `${SESSION_DRAFT_INVALIDATION_PREFIX}session%2Fa`,
+    )).toBe('archive-1');
+  });
+
   it('discards malformed data and tolerates blocked storage', () => {
     const storage = new MemoryStorage();
     storage.setItem(`${SESSION_DRAFT_STORAGE_PREFIX}broken`, '{not-json');
@@ -112,5 +126,7 @@ describe('SessionDraftLocalCache', () => {
     expect(() => fallback.writeDirty('session-a', 'text', null)).not.toThrow();
     expect(fallback.read('session-a')).toBeNull();
     expect(() => fallback.clear('session-a')).not.toThrow();
+    expect(fallback.invalidate('session-a')).toBe('id');
+    expect(fallback.readInvalidation('session-a')).toBe('id');
   });
 });

--- a/ui/src/lib/sessionDraftLocalCache.test.ts
+++ b/ui/src/lib/sessionDraftLocalCache.test.ts
@@ -131,6 +131,32 @@ describe('SessionDraftLocalCache', () => {
     });
   });
 
+  it('retires mutations older than the acknowledged reload winner', () => {
+    const storage = new MemoryStorage();
+    let sequence = 0;
+    const writer = new SessionDraftLocalCache(
+      storage,
+      () => `mutation-${++sequence}`,
+      () => sequence,
+    );
+    const older = writer.writeDirty('session-a', 'older text', 'rev-0');
+    const winner = writer.writeDirty('session-a', 'selected text', 'rev-0');
+    const restored = new SessionDraftLocalCache(storage, () => 'unused', () => 10);
+
+    expect(restored.read('session-a')?.mutationId).toBe(winner.mutationId);
+    restored.acknowledge('session-a', winner.mutationId, winner.text, 'rev-1');
+
+    expect(storage.getItem(
+      `${SESSION_DRAFT_MUTATION_PREFIX}session-a:${older.mutationId}`,
+    )).toBeNull();
+    expect(restored.dirtySessionIds()).toEqual([]);
+    expect(restored.read('session-a')).toMatchObject({
+      text: 'selected text',
+      serverUpdatedAt: 'rev-1',
+      dirty: false,
+    });
+  });
+
   it('persists archive invalidation across cache instances', () => {
     const storage = new MemoryStorage();
     const first = new SessionDraftLocalCache(storage, () => 'archive-1', () => 1);

--- a/ui/src/lib/sessionDraftLocalCache.test.ts
+++ b/ui/src/lib/sessionDraftLocalCache.test.ts
@@ -7,6 +7,14 @@ import {
 class MemoryStorage {
   readonly values = new Map<string, string>();
 
+  get length(): number {
+    return this.values.size;
+  }
+
+  key(index: number): string | null {
+    return [...this.values.keys()][index] ?? null;
+  }
+
   getItem(key: string): string | null {
     return this.values.get(key) ?? null;
   }
@@ -62,8 +70,29 @@ describe('SessionDraftLocalCache', () => {
     cache.acknowledge('session-a', 'stale', 'old text', 'server-1');
     expect(cache.read('session-a')).toMatchObject({ text: 'text', dirty: true });
 
+    cache.acknowledge('session-a', 'current', 'text', 'server-1');
+    expect(cache.read('session-a')).toMatchObject({
+      text: 'text',
+      dirty: false,
+      mutationId: 'current',
+      serverUpdatedAt: 'server-1',
+    });
+
     cache.writeClean('session-a', '', 'server-2');
     expect(cache.read('session-a')).toBeNull();
+  });
+
+  it('enumerates only dirty session records for reconnect replay', () => {
+    const storage = new MemoryStorage();
+    let sequence = 0;
+    const cache = new SessionDraftLocalCache(storage, () => `id-${++sequence}`, () => sequence);
+    cache.writeDirty('session/a', 'offline A', 'server-1');
+    storage.setItem(`${SESSION_DRAFT_STORAGE_PREFIX}broken`, '{not-json');
+    cache.writeClean('session-b', 'synced B', 'server-2');
+    cache.writeDirty('session-c', 'offline C', null);
+
+    expect(cache.dirtySessionIds()).toEqual(['session/a', 'session-c']);
+    expect(storage.getItem(`${SESSION_DRAFT_STORAGE_PREFIX}broken`)).toBeNull();
   });
 
   it('discards malformed data and tolerates blocked storage', () => {

--- a/ui/src/lib/sessionDraftLocalCache.test.ts
+++ b/ui/src/lib/sessionDraftLocalCache.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   SESSION_DRAFT_INVALIDATION_PREFIX,
+  SESSION_DRAFT_MUTATION_PREFIX,
   SESSION_DRAFT_STORAGE_PREFIX,
   SessionDraftLocalCache,
 } from './sessionDraftLocalCache';
@@ -39,7 +40,7 @@ describe('SessionDraftLocalCache', () => {
       () => 100 + sequence,
     );
 
-    cache.writeDirty('session/a', 'typing', 'server-1');
+    const dirty = cache.writeDirty('session/a', 'typing', 'server-1');
     expect(cache.read('session/a')).toEqual({
       version: 1,
       text: 'typing',
@@ -48,13 +49,16 @@ describe('SessionDraftLocalCache', () => {
       mutationId: 'id-1',
       savedAt: 101,
     });
+    expect([...storage.values.keys()]).toEqual([
+      `${SESSION_DRAFT_MUTATION_PREFIX}session%2Fa:id-1`,
+    ]);
 
-    cache.writeClean('session/a', 'typing', 'server-2');
+    cache.acknowledge('session/a', dirty.mutationId, 'typing', 'server-2');
     expect(cache.read('session/a')).toMatchObject({
       text: 'typing',
       serverUpdatedAt: 'server-2',
       dirty: false,
-      mutationId: 'id-2',
+      mutationId: 'id-1',
     });
     expect([...storage.values.keys()]).toEqual([
       `${SESSION_DRAFT_STORAGE_PREFIX}session%2Fa`,
@@ -94,6 +98,37 @@ describe('SessionDraftLocalCache', () => {
 
     expect(cache.dirtySessionIds()).toEqual(['session/a', 'session-c']);
     expect(storage.getItem(`${SESSION_DRAFT_STORAGE_PREFIX}broken`)).toBeNull();
+  });
+
+  it('acknowledges one tab without replacing another tab mutation', () => {
+    const storage = new MemoryStorage();
+    const first = new SessionDraftLocalCache(storage, () => 'tab-a', () => 1);
+    const second = new SessionDraftLocalCache(storage, () => 'tab-b', () => 2);
+
+    first.writeDirty('session-a', 'from tab A', null);
+    const removeItem = storage.removeItem.bind(storage);
+    storage.removeItem = (key) => {
+      if (key === `${SESSION_DRAFT_MUTATION_PREFIX}session-a:tab-a`) {
+        second.writeDirty('session-a', 'from tab B', null);
+      }
+      removeItem(key);
+    };
+    first.acknowledge('session-a', 'tab-a', 'from tab A', 'rev-a');
+
+    expect(second.read('session-a')).toMatchObject({
+      text: 'from tab B',
+      dirty: true,
+      mutationId: 'tab-b',
+    });
+    expect(storage.getItem(
+      `${SESSION_DRAFT_MUTATION_PREFIX}session-a:tab-b`,
+    )).not.toBeNull();
+    first.writeClean('session-a', '', 'clear-revision');
+    expect(second.read('session-a')).toMatchObject({
+      text: 'from tab B',
+      dirty: true,
+      mutationId: 'tab-b',
+    });
   });
 
   it('persists archive invalidation across cache instances', () => {

--- a/ui/src/lib/sessionDraftLocalCache.test.ts
+++ b/ui/src/lib/sessionDraftLocalCache.test.ts
@@ -109,6 +109,30 @@ describe('SessionDraftLocalCache', () => {
     )).toBe('archive-1');
   });
 
+  it('keeps a newer in-memory invalidation when storage retains an older token', () => {
+    const storage = new MemoryStorage();
+    let sequence = 0;
+    let blockWrites = false;
+    const setItem = storage.setItem.bind(storage);
+    storage.setItem = (key, value) => {
+      if (blockWrites) throw new Error('read only');
+      setItem(key, value);
+    };
+    const cache = new SessionDraftLocalCache(
+      storage,
+      () => `archive-${++sequence}`,
+      () => sequence,
+    );
+
+    expect(cache.invalidate('session-a')).toBe('archive-1');
+    blockWrites = true;
+    expect(cache.invalidate('session-a')).toBe('archive-2');
+    expect(storage.getItem(
+      `${SESSION_DRAFT_INVALIDATION_PREFIX}session-a`,
+    )).toBe('archive-1');
+    expect(cache.readInvalidation('session-a')).toBe('archive-2');
+  });
+
   it('discards malformed data and tolerates blocked storage', () => {
     const storage = new MemoryStorage();
     storage.setItem(`${SESSION_DRAFT_STORAGE_PREFIX}broken`, '{not-json');

--- a/ui/src/lib/sessionDraftLocalCache.test.ts
+++ b/ui/src/lib/sessionDraftLocalCache.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+import {
+  SESSION_DRAFT_STORAGE_PREFIX,
+  SessionDraftLocalCache,
+} from './sessionDraftLocalCache';
+
+class MemoryStorage {
+  readonly values = new Map<string, string>();
+
+  getItem(key: string): string | null {
+    return this.values.get(key) ?? null;
+  }
+
+  setItem(key: string, value: string): void {
+    this.values.set(key, value);
+  }
+
+  removeItem(key: string): void {
+    this.values.delete(key);
+  }
+}
+
+describe('SessionDraftLocalCache', () => {
+  it('stores dirty and clean versioned records per session', () => {
+    const storage = new MemoryStorage();
+    let sequence = 0;
+    const cache = new SessionDraftLocalCache(
+      storage,
+      () => `id-${++sequence}`,
+      () => 100 + sequence,
+    );
+
+    cache.writeDirty('session/a', 'typing', 'server-1');
+    expect(cache.read('session/a')).toEqual({
+      version: 1,
+      text: 'typing',
+      serverUpdatedAt: 'server-1',
+      dirty: true,
+      mutationId: 'id-1',
+      savedAt: 101,
+    });
+
+    cache.writeClean('session/a', 'typing', 'server-2');
+    expect(cache.read('session/a')).toMatchObject({
+      text: 'typing',
+      serverUpdatedAt: 'server-2',
+      dirty: false,
+      mutationId: 'id-2',
+    });
+    expect([...storage.values.keys()]).toEqual([
+      `${SESSION_DRAFT_STORAGE_PREFIX}session%2Fa`,
+    ]);
+  });
+
+  it('removes an empty clean draft and ignores stale acknowledgements or rebases', () => {
+    const storage = new MemoryStorage();
+    const cache = new SessionDraftLocalCache(storage, () => 'current', () => 1);
+    cache.writeDirty('session-a', 'text', null);
+
+    cache.rebaseDirty('session-a', 'stale', 'server-1');
+    expect(cache.read('session-a')?.serverUpdatedAt).toBeNull();
+    cache.acknowledge('session-a', 'stale', 'old text', 'server-1');
+    expect(cache.read('session-a')).toMatchObject({ text: 'text', dirty: true });
+
+    cache.writeClean('session-a', '', 'server-2');
+    expect(cache.read('session-a')).toBeNull();
+  });
+
+  it('discards malformed data and tolerates blocked storage', () => {
+    const storage = new MemoryStorage();
+    storage.setItem(`${SESSION_DRAFT_STORAGE_PREFIX}broken`, '{not-json');
+    const cache = new SessionDraftLocalCache(storage);
+
+    expect(cache.read('broken')).toBeNull();
+    expect(storage.values.size).toBe(0);
+
+    const blocked = {
+      getItem: () => { throw new Error('blocked'); },
+      setItem: () => { throw new Error('full'); },
+      removeItem: () => { throw new Error('blocked'); },
+    };
+    const fallback = new SessionDraftLocalCache(blocked, () => 'id', () => 1);
+    expect(() => fallback.writeDirty('session-a', 'text', null)).not.toThrow();
+    expect(fallback.read('session-a')).toBeNull();
+    expect(() => fallback.clear('session-a')).not.toThrow();
+  });
+});

--- a/ui/src/lib/sessionDraftLocalCache.ts
+++ b/ui/src/lib/sessionDraftLocalCache.ts
@@ -54,7 +54,7 @@ export class SessionDraftLocalCache {
   private readonly storage?: DraftStorage;
   private readonly createId: CreateId;
   private readonly now: Now;
-  private readonly memoryInvalidations = new Map<string, string>();
+  private readonly memoryInvalidations = new Map<string, { token: string; persisted: boolean }>();
 
   constructor(
     storage?: DraftStorage,
@@ -81,25 +81,31 @@ export class SessionDraftLocalCache {
   }
 
   readInvalidation(sessionId: string): string | null {
-    const memory = this.memoryInvalidations.get(sessionId) ?? null;
+    const memory = this.memoryInvalidations.get(sessionId);
+    // A failed write leaves an older token readable in storage. The newer
+    // process-local token must win until it can be persisted.
+    if (memory && !memory.persisted) return memory.token;
     const target = browserStorage(this.storage);
-    if (!target) return memory;
+    if (!target) return memory?.token ?? null;
     try {
       const stored = target.getItem(this.invalidationKey(sessionId));
-      return stored || memory;
+      return stored || memory?.token || null;
     } catch {
-      return memory;
+      return memory?.token ?? null;
     }
   }
 
   invalidate(sessionId: string): string {
     const token = this.createId();
-    this.memoryInvalidations.set(sessionId, token);
+    let persisted = false;
     try {
-      browserStorage(this.storage)?.setItem(this.invalidationKey(sessionId), token);
+      const target = browserStorage(this.storage);
+      target?.setItem(this.invalidationKey(sessionId), token);
+      persisted = Boolean(target);
     } catch {
-      // The in-memory token still invalidates reads in this tab.
+      // Recorded below so this token remains newer than stale stored state.
     }
+    this.memoryInvalidations.set(sessionId, { token, persisted });
     return token;
   }
 

--- a/ui/src/lib/sessionDraftLocalCache.ts
+++ b/ui/src/lib/sessionDraftLocalCache.ts
@@ -5,6 +5,7 @@ export type SessionDraftCacheRecord = {
   dirty: boolean;
   mutationId: string;
   savedAt: number;
+  rebaseOnConflict?: boolean;
 };
 
 type DraftStorage = Pick<Storage, 'getItem' | 'setItem' | 'removeItem'>
@@ -13,6 +14,7 @@ type CreateId = () => string;
 type Now = () => number;
 
 export const SESSION_DRAFT_STORAGE_PREFIX = 'avibe.session-draft.v1.';
+export const SESSION_DRAFT_MUTATION_PREFIX = 'avibe.session-draft-mutation.v1.';
 export const SESSION_DRAFT_INVALIDATION_PREFIX = 'avibe.session-draft-invalidation.v1.';
 
 function browserStorage(storage?: DraftStorage): DraftStorage | undefined {
@@ -41,6 +43,7 @@ function parseRecord(raw: string | null): SessionDraftCacheRecord | null {
       || !value.mutationId
       || typeof value.savedAt !== 'number'
       || !Number.isFinite(value.savedAt)
+      || (value.rebaseOnConflict !== undefined && typeof value.rebaseOnConflict !== 'boolean')
     ) {
       return null;
     }
@@ -69,12 +72,19 @@ export class SessionDraftLocalCache {
   read(sessionId: string): SessionDraftCacheRecord | null {
     const target = browserStorage(this.storage);
     if (!target) return null;
-    const key = this.key(sessionId);
     try {
-      const raw = target.getItem(key);
-      const record = parseRecord(raw);
-      if (raw && !record) target.removeItem(key);
-      return record;
+      const dirty = this.readDirtyMutations(target, sessionId);
+      const stored = this.readRecord(target, this.key(sessionId));
+      if (stored?.dirty) dirty.push(stored); // Legacy single-record cache.
+      if (dirty.length) {
+        return dirty.reduce((latest, record) => (
+          record.savedAt > latest.savedAt
+          || (record.savedAt === latest.savedAt && record.mutationId > latest.mutationId)
+            ? record
+            : latest
+        ));
+      }
+      return stored;
     } catch {
       return null;
     }
@@ -114,18 +124,25 @@ export class SessionDraftLocalCache {
     if (!target || typeof target.length !== 'number' || typeof target.key !== 'function') return [];
     const sessionIds = new Set<string>();
     try {
-      const keys = Array.from(
-        { length: target.length },
-        (_, index) => target.key!(index),
-      );
+      const keys = this.keys(target);
       for (const key of keys) {
-        if (!key?.startsWith(SESSION_DRAFT_STORAGE_PREFIX)) continue;
-        const raw = target.getItem(key);
-        const record = parseRecord(raw);
-        if (raw && !record) {
-          target.removeItem(key);
+        if (key.startsWith(SESSION_DRAFT_MUTATION_PREFIX)) {
+          const separator = key.indexOf(':', SESSION_DRAFT_MUTATION_PREFIX.length);
+          if (separator < 0) continue;
+          const record = this.readRecord(target, key);
+          if (!record?.dirty) continue;
+          try {
+            sessionIds.add(decodeURIComponent(key.slice(
+              SESSION_DRAFT_MUTATION_PREFIX.length,
+              separator,
+            )));
+          } catch {
+            // Ignore malformed keys that were not written by this cache.
+          }
           continue;
         }
+        if (!key.startsWith(SESSION_DRAFT_STORAGE_PREFIX)) continue;
+        const record = this.readRecord(target, key);
         if (!record?.dirty) continue;
         try {
           sessionIds.add(decodeURIComponent(key.slice(SESSION_DRAFT_STORAGE_PREFIX.length)));
@@ -139,20 +156,41 @@ export class SessionDraftLocalCache {
     return [...sessionIds];
   }
 
-  writeDirty(sessionId: string, text: string, serverUpdatedAt: string | null): SessionDraftCacheRecord {
-    return this.write(sessionId, {
+  writeDirty(
+    sessionId: string,
+    text: string,
+    serverUpdatedAt: string | null,
+    previousMutationId?: string,
+    rebaseOnConflict = false,
+  ): SessionDraftCacheRecord {
+    const record: SessionDraftCacheRecord = {
       version: 1,
       text,
       serverUpdatedAt,
       dirty: true,
       mutationId: this.createId(),
       savedAt: this.now(),
-    });
+      ...(rebaseOnConflict ? { rebaseOnConflict: true } : {}),
+    };
+    try {
+      const target = browserStorage(this.storage);
+      target?.setItem(this.mutationKey(sessionId, record.mutationId), JSON.stringify(record));
+      if (target && previousMutationId) {
+        target.removeItem(this.mutationKey(sessionId, previousMutationId));
+      }
+    } catch {
+      // The in-memory persistence layer still protects this tab when storage is unavailable.
+    }
+    return record;
   }
 
   writeClean(sessionId: string, text: string, serverUpdatedAt: string | null): SessionDraftCacheRecord | null {
     if (!text) {
-      this.clear(sessionId);
+      try {
+        browserStorage(this.storage)?.removeItem(this.key(sessionId));
+      } catch {
+        // Concurrent dirty mutations use separate keys and remain recoverable.
+      }
       return null;
     }
     return this.write(sessionId, {
@@ -165,10 +203,55 @@ export class SessionDraftLocalCache {
     });
   }
 
-  rebaseDirty(sessionId: string, mutationId: string, serverUpdatedAt: string | null): void {
-    const current = this.read(sessionId);
-    if (!current || current.mutationId !== mutationId || !current.dirty) return;
-    this.write(sessionId, { ...current, serverUpdatedAt });
+  rebaseDirty(
+    sessionId: string,
+    mutationId: string,
+    serverUpdatedAt: string | null,
+    rebaseOnConflict = false,
+  ): void {
+    const target = browserStorage(this.storage);
+    if (!target) return;
+    try {
+      const mutationKey = this.mutationKey(sessionId, mutationId);
+      const mutation = this.readRecord(target, mutationKey);
+      if (mutation?.dirty && mutation.mutationId === mutationId) {
+        target.setItem(mutationKey, JSON.stringify({
+          ...mutation,
+          serverUpdatedAt,
+          rebaseOnConflict: rebaseOnConflict || undefined,
+        }));
+        return;
+      }
+      // Compatibility with dirty records created before mutations used
+      // independent keys.
+      const legacy = this.readRecord(target, this.key(sessionId));
+      if (!legacy?.dirty || legacy.mutationId !== mutationId) return;
+      target.setItem(this.key(sessionId), JSON.stringify({
+        ...legacy,
+        serverUpdatedAt,
+        rebaseOnConflict: rebaseOnConflict || undefined,
+      }));
+    } catch {
+      // Best-effort cache metadata; the live in-memory entry remains authoritative.
+    }
+  }
+
+  markRebaseOnConflict(sessionId: string, mutationId: string): void {
+    const target = browserStorage(this.storage);
+    if (!target) return;
+    try {
+      const mutationKey = this.mutationKey(sessionId, mutationId);
+      const mutation = this.readRecord(target, mutationKey);
+      if (mutation?.dirty && mutation.mutationId === mutationId) {
+        target.setItem(mutationKey, JSON.stringify({ ...mutation, rebaseOnConflict: true }));
+        return;
+      }
+      const legacy = this.readRecord(target, this.key(sessionId));
+      if (!legacy?.dirty || legacy.mutationId !== mutationId) return;
+      target.setItem(this.key(sessionId), JSON.stringify({ ...legacy, rebaseOnConflict: true }));
+    } catch {
+      // The live entry still carries the recovery marker in this tab.
+    }
   }
 
   acknowledge(
@@ -177,24 +260,59 @@ export class SessionDraftLocalCache {
     text: string,
     serverUpdatedAt: string | null,
   ): void {
-    const current = this.read(sessionId);
-    if (!current || current.mutationId !== mutationId) return;
-    if (!text) {
-      this.clear(sessionId);
-      return;
+    const target = browserStorage(this.storage);
+    if (!target) return;
+    try {
+      const mutationKey = this.mutationKey(sessionId, mutationId);
+      const mutation = this.readRecord(target, mutationKey);
+      if (mutation?.dirty && mutation.mutationId === mutationId) {
+        // Dirty mutations use independent keys, so acknowledging this tab can
+        // never replace another tab's concurrently-written text.
+        target.removeItem(mutationKey);
+        if (!text) {
+          target.removeItem(this.key(sessionId));
+          return;
+        }
+        this.write(sessionId, {
+          ...mutation,
+          text,
+          serverUpdatedAt,
+          dirty: false,
+          savedAt: this.now(),
+          rebaseOnConflict: undefined,
+        });
+        return;
+      }
+
+      // Compatibility with the former single-record cache. New mutations never
+      // use this path, so current tabs retain atomic cross-tab ownership.
+      const legacy = this.readRecord(target, this.key(sessionId));
+      if (!legacy || legacy.mutationId !== mutationId) return;
+      if (!text) {
+        target.removeItem(this.key(sessionId));
+        return;
+      }
+      this.write(sessionId, {
+        ...legacy,
+        text,
+        serverUpdatedAt,
+        dirty: false,
+        savedAt: this.now(),
+        rebaseOnConflict: undefined,
+      });
+    } catch {
+      // The cloud acknowledgement succeeded; a blocked cache is non-fatal.
     }
-    this.write(sessionId, {
-      ...current,
-      text,
-      serverUpdatedAt,
-      dirty: false,
-      savedAt: this.now(),
-    });
   }
 
   clear(sessionId: string): void {
     try {
-      browserStorage(this.storage)?.removeItem(this.key(sessionId));
+      const target = browserStorage(this.storage);
+      if (!target) return;
+      target.removeItem(this.key(sessionId));
+      for (const key of this.keys(target)) {
+        if (key.startsWith(this.mutationPrefix(sessionId))) target.removeItem(key);
+      }
     } catch {
       // Draft caching is best-effort when storage is blocked or full.
     }
@@ -213,7 +331,39 @@ export class SessionDraftLocalCache {
     return `${SESSION_DRAFT_STORAGE_PREFIX}${encodeURIComponent(sessionId)}`;
   }
 
+  private mutationPrefix(sessionId: string): string {
+    return `${SESSION_DRAFT_MUTATION_PREFIX}${encodeURIComponent(sessionId)}:`;
+  }
+
+  private mutationKey(sessionId: string, mutationId: string): string {
+    return `${this.mutationPrefix(sessionId)}${encodeURIComponent(mutationId)}`;
+  }
+
   private invalidationKey(sessionId: string): string {
     return `${SESSION_DRAFT_INVALIDATION_PREFIX}${encodeURIComponent(sessionId)}`;
+  }
+
+  private keys(target: DraftStorage): string[] {
+    if (typeof target.length !== 'number' || typeof target.key !== 'function') return [];
+    return Array.from({ length: target.length }, (_, index) => target.key!(index))
+      .filter((key): key is string => Boolean(key));
+  }
+
+  private readRecord(target: DraftStorage, key: string): SessionDraftCacheRecord | null {
+    const raw = target.getItem(key);
+    const record = parseRecord(raw);
+    if (raw && !record) target.removeItem(key);
+    return record;
+  }
+
+  private readDirtyMutations(
+    target: DraftStorage,
+    sessionId: string,
+  ): SessionDraftCacheRecord[] {
+    const prefix = this.mutationPrefix(sessionId);
+    return this.keys(target)
+      .filter((key) => key.startsWith(prefix))
+      .map((key) => this.readRecord(target, key))
+      .filter((record): record is SessionDraftCacheRecord => Boolean(record?.dirty));
   }
 }

--- a/ui/src/lib/sessionDraftLocalCache.ts
+++ b/ui/src/lib/sessionDraftLocalCache.ts
@@ -13,6 +13,7 @@ type CreateId = () => string;
 type Now = () => number;
 
 export const SESSION_DRAFT_STORAGE_PREFIX = 'avibe.session-draft.v1.';
+export const SESSION_DRAFT_INVALIDATION_PREFIX = 'avibe.session-draft-invalidation.v1.';
 
 function browserStorage(storage?: DraftStorage): DraftStorage | undefined {
   try {
@@ -53,6 +54,7 @@ export class SessionDraftLocalCache {
   private readonly storage?: DraftStorage;
   private readonly createId: CreateId;
   private readonly now: Now;
+  private readonly memoryInvalidations = new Map<string, string>();
 
   constructor(
     storage?: DraftStorage,
@@ -76,6 +78,29 @@ export class SessionDraftLocalCache {
     } catch {
       return null;
     }
+  }
+
+  readInvalidation(sessionId: string): string | null {
+    const memory = this.memoryInvalidations.get(sessionId) ?? null;
+    const target = browserStorage(this.storage);
+    if (!target) return memory;
+    try {
+      const stored = target.getItem(this.invalidationKey(sessionId));
+      return stored || memory;
+    } catch {
+      return memory;
+    }
+  }
+
+  invalidate(sessionId: string): string {
+    const token = this.createId();
+    this.memoryInvalidations.set(sessionId, token);
+    try {
+      browserStorage(this.storage)?.setItem(this.invalidationKey(sessionId), token);
+    } catch {
+      // The in-memory token still invalidates reads in this tab.
+    }
+    return token;
   }
 
   dirtySessionIds(): string[] {
@@ -180,5 +205,9 @@ export class SessionDraftLocalCache {
 
   private key(sessionId: string): string {
     return `${SESSION_DRAFT_STORAGE_PREFIX}${encodeURIComponent(sessionId)}`;
+  }
+
+  private invalidationKey(sessionId: string): string {
+    return `${SESSION_DRAFT_INVALIDATION_PREFIX}${encodeURIComponent(sessionId)}`;
   }
 }

--- a/ui/src/lib/sessionDraftLocalCache.ts
+++ b/ui/src/lib/sessionDraftLocalCache.ts
@@ -1,0 +1,143 @@
+export type SessionDraftCacheRecord = {
+  version: 1;
+  text: string;
+  serverUpdatedAt: string | null;
+  dirty: boolean;
+  mutationId: string;
+  savedAt: number;
+};
+
+type DraftStorage = Pick<Storage, 'getItem' | 'setItem' | 'removeItem'>;
+type CreateId = () => string;
+type Now = () => number;
+
+export const SESSION_DRAFT_STORAGE_PREFIX = 'avibe.session-draft.v1.';
+
+function browserStorage(storage?: DraftStorage): DraftStorage | undefined {
+  try {
+    return storage ?? (typeof window !== 'undefined' ? window.localStorage : undefined);
+  } catch {
+    return undefined;
+  }
+}
+
+function defaultId(): string {
+  return globalThis.crypto?.randomUUID?.()
+    ?? `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+}
+
+function parseRecord(raw: string | null): SessionDraftCacheRecord | null {
+  if (!raw) return null;
+  try {
+    const value = JSON.parse(raw) as Partial<SessionDraftCacheRecord>;
+    if (
+      value.version !== 1
+      || typeof value.text !== 'string'
+      || (value.serverUpdatedAt !== null && typeof value.serverUpdatedAt !== 'string')
+      || typeof value.dirty !== 'boolean'
+      || typeof value.mutationId !== 'string'
+      || !value.mutationId
+      || typeof value.savedAt !== 'number'
+      || !Number.isFinite(value.savedAt)
+    ) {
+      return null;
+    }
+    return value as SessionDraftCacheRecord;
+  } catch {
+    return null;
+  }
+}
+
+export class SessionDraftLocalCache {
+  private readonly storage?: DraftStorage;
+  private readonly createId: CreateId;
+  private readonly now: Now;
+
+  constructor(
+    storage?: DraftStorage,
+    createId: CreateId = defaultId,
+    now: Now = Date.now,
+  ) {
+    this.storage = storage;
+    this.createId = createId;
+    this.now = now;
+  }
+
+  read(sessionId: string): SessionDraftCacheRecord | null {
+    const target = browserStorage(this.storage);
+    if (!target) return null;
+    const key = this.key(sessionId);
+    try {
+      const raw = target.getItem(key);
+      const record = parseRecord(raw);
+      if (raw && !record) target.removeItem(key);
+      return record;
+    } catch {
+      return null;
+    }
+  }
+
+  writeDirty(sessionId: string, text: string, serverUpdatedAt: string | null): SessionDraftCacheRecord {
+    return this.write(sessionId, {
+      version: 1,
+      text,
+      serverUpdatedAt,
+      dirty: true,
+      mutationId: this.createId(),
+      savedAt: this.now(),
+    });
+  }
+
+  writeClean(sessionId: string, text: string, serverUpdatedAt: string | null): SessionDraftCacheRecord | null {
+    if (!text) {
+      this.clear(sessionId);
+      return null;
+    }
+    return this.write(sessionId, {
+      version: 1,
+      text,
+      serverUpdatedAt,
+      dirty: false,
+      mutationId: this.createId(),
+      savedAt: this.now(),
+    });
+  }
+
+  rebaseDirty(sessionId: string, mutationId: string, serverUpdatedAt: string | null): void {
+    const current = this.read(sessionId);
+    if (!current || current.mutationId !== mutationId || !current.dirty) return;
+    this.write(sessionId, { ...current, serverUpdatedAt });
+  }
+
+  acknowledge(
+    sessionId: string,
+    mutationId: string,
+    text: string,
+    serverUpdatedAt: string | null,
+  ): void {
+    const current = this.read(sessionId);
+    if (!current || current.mutationId !== mutationId) return;
+    this.writeClean(sessionId, text, serverUpdatedAt);
+  }
+
+  clear(sessionId: string): void {
+    try {
+      browserStorage(this.storage)?.removeItem(this.key(sessionId));
+    } catch {
+      // Draft caching is best-effort when storage is blocked or full.
+    }
+  }
+
+  private write(sessionId: string, record: SessionDraftCacheRecord): SessionDraftCacheRecord {
+    try {
+      browserStorage(this.storage)?.setItem(this.key(sessionId), JSON.stringify(record));
+    } catch {
+      // The in-memory persistence layer still protects this tab when storage is unavailable.
+    }
+    return record;
+  }
+
+  private key(sessionId: string): string {
+    return `${SESSION_DRAFT_STORAGE_PREFIX}${encodeURIComponent(sessionId)}`;
+  }
+}

--- a/ui/src/lib/sessionDraftLocalCache.ts
+++ b/ui/src/lib/sessionDraftLocalCache.ts
@@ -7,7 +7,8 @@ export type SessionDraftCacheRecord = {
   savedAt: number;
 };
 
-type DraftStorage = Pick<Storage, 'getItem' | 'setItem' | 'removeItem'>;
+type DraftStorage = Pick<Storage, 'getItem' | 'setItem' | 'removeItem'>
+  & Partial<Pick<Storage, 'key' | 'length'>>;
 type CreateId = () => string;
 type Now = () => number;
 
@@ -77,6 +78,36 @@ export class SessionDraftLocalCache {
     }
   }
 
+  dirtySessionIds(): string[] {
+    const target = browserStorage(this.storage);
+    if (!target || typeof target.length !== 'number' || typeof target.key !== 'function') return [];
+    const sessionIds = new Set<string>();
+    try {
+      const keys = Array.from(
+        { length: target.length },
+        (_, index) => target.key!(index),
+      );
+      for (const key of keys) {
+        if (!key?.startsWith(SESSION_DRAFT_STORAGE_PREFIX)) continue;
+        const raw = target.getItem(key);
+        const record = parseRecord(raw);
+        if (raw && !record) {
+          target.removeItem(key);
+          continue;
+        }
+        if (!record?.dirty) continue;
+        try {
+          sessionIds.add(decodeURIComponent(key.slice(SESSION_DRAFT_STORAGE_PREFIX.length)));
+        } catch {
+          // Ignore malformed keys that were not written by this cache.
+        }
+      }
+    } catch {
+      return [];
+    }
+    return [...sessionIds];
+  }
+
   writeDirty(sessionId: string, text: string, serverUpdatedAt: string | null): SessionDraftCacheRecord {
     return this.write(sessionId, {
       version: 1,
@@ -117,7 +148,17 @@ export class SessionDraftLocalCache {
   ): void {
     const current = this.read(sessionId);
     if (!current || current.mutationId !== mutationId) return;
-    this.writeClean(sessionId, text, serverUpdatedAt);
+    if (!text) {
+      this.clear(sessionId);
+      return;
+    }
+    this.write(sessionId, {
+      ...current,
+      text,
+      serverUpdatedAt,
+      dirty: false,
+      savedAt: this.now(),
+    });
   }
 
   clear(sessionId: string): void {

--- a/ui/src/lib/sessionDraftLocalCache.ts
+++ b/ui/src/lib/sessionDraftLocalCache.ts
@@ -78,8 +78,7 @@ export class SessionDraftLocalCache {
       if (stored?.dirty) dirty.push(stored); // Legacy single-record cache.
       if (dirty.length) {
         return dirty.reduce((latest, record) => (
-          record.savedAt > latest.savedAt
-          || (record.savedAt === latest.savedAt && record.mutationId > latest.mutationId)
+          this.compareMutationOrder(record, latest) > 0
             ? record
             : latest
         ));
@@ -268,6 +267,12 @@ export class SessionDraftLocalCache {
       if (mutation?.dirty && mutation.mutationId === mutationId) {
         // Dirty mutations use independent keys, so acknowledging this tab can
         // never replace another tab's concurrently-written text.
+        // A reload replays the newest stored mutation. Once that winner reaches
+        // the cloud, every mutation at or before its ordering frontier is stale;
+        // otherwise the next reload would reveal and replay an older hidden key.
+        // Retire older keys first so a partial storage failure leaves the winner
+        // available for an idempotent retry instead of exposing an older draft.
+        this.retireMutationsBefore(target, sessionId, mutation);
         target.removeItem(mutationKey);
         if (!text) {
           target.removeItem(this.key(sessionId));
@@ -365,5 +370,32 @@ export class SessionDraftLocalCache {
       .filter((key) => key.startsWith(prefix))
       .map((key) => this.readRecord(target, key))
       .filter((record): record is SessionDraftCacheRecord => Boolean(record?.dirty));
+  }
+
+  private compareMutationOrder(
+    left: SessionDraftCacheRecord,
+    right: SessionDraftCacheRecord,
+  ): number {
+    if (left.savedAt !== right.savedAt) return left.savedAt - right.savedAt;
+    if (left.mutationId === right.mutationId) return 0;
+    return left.mutationId > right.mutationId ? 1 : -1;
+  }
+
+  private retireMutationsBefore(
+    target: DraftStorage,
+    sessionId: string,
+    acknowledged: SessionDraftCacheRecord,
+  ): void {
+    const prefix = this.mutationPrefix(sessionId);
+    for (const key of this.keys(target)) {
+      if (!key.startsWith(prefix)) continue;
+      const record = this.readRecord(target, key);
+      if (
+        record?.dirty
+        && this.compareMutationOrder(record, acknowledged) < 0
+      ) {
+        target.removeItem(key);
+      }
+    }
   }
 }

--- a/ui/src/lib/sessionDraftLocalCache.ts
+++ b/ui/src/lib/sessionDraftLocalCache.ts
@@ -6,6 +6,7 @@ export type SessionDraftCacheRecord = {
   mutationId: string;
   savedAt: number;
   rebaseOnConflict?: boolean;
+  rebaseOnConflictServerText?: string;
 };
 
 type DraftStorage = Pick<Storage, 'getItem' | 'setItem' | 'removeItem'>
@@ -44,6 +45,13 @@ function parseRecord(raw: string | null): SessionDraftCacheRecord | null {
       || typeof value.savedAt !== 'number'
       || !Number.isFinite(value.savedAt)
       || (value.rebaseOnConflict !== undefined && typeof value.rebaseOnConflict !== 'boolean')
+      || (
+        value.rebaseOnConflictServerText !== undefined
+        && (
+          typeof value.rebaseOnConflictServerText !== 'string'
+          || value.rebaseOnConflict !== true
+        )
+      )
     ) {
       return null;
     }
@@ -161,6 +169,7 @@ export class SessionDraftLocalCache {
     serverUpdatedAt: string | null,
     previousMutationId?: string,
     rebaseOnConflict = false,
+    rebaseOnConflictServerText?: string,
   ): SessionDraftCacheRecord {
     const record: SessionDraftCacheRecord = {
       version: 1,
@@ -170,6 +179,9 @@ export class SessionDraftLocalCache {
       mutationId: this.createId(),
       savedAt: this.now(),
       ...(rebaseOnConflict ? { rebaseOnConflict: true } : {}),
+      ...(rebaseOnConflict && rebaseOnConflictServerText !== undefined
+        ? { rebaseOnConflictServerText }
+        : {}),
     };
     try {
       const target = browserStorage(this.storage);
@@ -207,6 +219,7 @@ export class SessionDraftLocalCache {
     mutationId: string,
     serverUpdatedAt: string | null,
     rebaseOnConflict = false,
+    rebaseOnConflictServerText?: string,
   ): void {
     const target = browserStorage(this.storage);
     if (!target) return;
@@ -218,6 +231,9 @@ export class SessionDraftLocalCache {
           ...mutation,
           serverUpdatedAt,
           rebaseOnConflict: rebaseOnConflict || undefined,
+          rebaseOnConflictServerText: rebaseOnConflict
+            ? rebaseOnConflictServerText
+            : undefined,
         }));
         return;
       }
@@ -229,25 +245,40 @@ export class SessionDraftLocalCache {
         ...legacy,
         serverUpdatedAt,
         rebaseOnConflict: rebaseOnConflict || undefined,
+        rebaseOnConflictServerText: rebaseOnConflict
+          ? rebaseOnConflictServerText
+          : undefined,
       }));
     } catch {
       // Best-effort cache metadata; the live in-memory entry remains authoritative.
     }
   }
 
-  markRebaseOnConflict(sessionId: string, mutationId: string): void {
+  markRebaseOnConflict(
+    sessionId: string,
+    mutationId: string,
+    serverText?: string,
+  ): void {
     const target = browserStorage(this.storage);
     if (!target) return;
     try {
       const mutationKey = this.mutationKey(sessionId, mutationId);
       const mutation = this.readRecord(target, mutationKey);
       if (mutation?.dirty && mutation.mutationId === mutationId) {
-        target.setItem(mutationKey, JSON.stringify({ ...mutation, rebaseOnConflict: true }));
+        target.setItem(mutationKey, JSON.stringify({
+          ...mutation,
+          rebaseOnConflict: true,
+          rebaseOnConflictServerText: serverText,
+        }));
         return;
       }
       const legacy = this.readRecord(target, this.key(sessionId));
       if (!legacy?.dirty || legacy.mutationId !== mutationId) return;
-      target.setItem(this.key(sessionId), JSON.stringify({ ...legacy, rebaseOnConflict: true }));
+      target.setItem(this.key(sessionId), JSON.stringify({
+        ...legacy,
+        rebaseOnConflict: true,
+        rebaseOnConflictServerText: serverText,
+      }));
     } catch {
       // The live entry still carries the recovery marker in this tab.
     }
@@ -285,6 +316,7 @@ export class SessionDraftLocalCache {
           dirty: false,
           savedAt: this.now(),
           rebaseOnConflict: undefined,
+          rebaseOnConflictServerText: undefined,
         });
         return;
       }
@@ -304,6 +336,7 @@ export class SessionDraftLocalCache {
         dirty: false,
         savedAt: this.now(),
         rebaseOnConflict: undefined,
+        rebaseOnConflictServerText: undefined,
       });
     } catch {
       // The cloud acknowledgement succeeded; a blocked cache is non-fatal.

--- a/ui/src/lib/sessionDraftPersistence.test.ts
+++ b/ui/src/lib/sessionDraftPersistence.test.ts
@@ -167,6 +167,29 @@ describe('SessionDraftPersistence', () => {
     expect(persistence.revision('session-a')).toBe(0);
   });
 
+  it('keeps the saved revision when a newer read settles before an older read', async () => {
+    const persistence = new SessionDraftPersistence(localCache());
+    const olderRead = persistence.beginRead('session-a');
+    await persistence.save('session-a', 'newer', async () => ({
+      ok: true,
+      server: { text: 'newer', updatedAt: 'rev-2' },
+    }));
+    const newerRead = persistence.beginRead('session-a');
+
+    expect(persistence.reconcileRead(
+      'session-a',
+      newerRead,
+      { text: 'newer', updatedAt: 'rev-2' },
+    )).toBe('newer');
+    expect(persistence.revision('session-a')).toBe(1);
+    expect(persistence.reconcileRead(
+      'session-a',
+      olderRead,
+      { text: 'old', updatedAt: 'rev-1' },
+    )).toBe('newer');
+    expect(persistence.revision('session-a')).toBe(0);
+  });
+
   it('recovers a failed write from local storage in a new persistence instance', async () => {
     const storage = new MemoryStorage();
     const first = new SessionDraftPersistence(localCache(storage));
@@ -297,6 +320,32 @@ describe('SessionDraftPersistence', () => {
     expect(resolved).toHaveBeenCalledWith({
       text: 'local edit resolved',
       expectedUpdatedAt: 'rev-2',
+    });
+  });
+
+  it('rebases a newer edit made before the previous write conflict returns', async () => {
+    const persistence = new SessionDraftPersistence(localCache());
+    const first = deferred<SessionDraftSaveResult>();
+    const firstSave = persistence.save('session-a', 'before send', async () => first.promise);
+    await Promise.resolve();
+
+    persistence.cache('session-a', 'typed after send');
+    const successor = vi.fn(async (draft: SessionDraftWrite): Promise<SessionDraftSaveResult> => ({
+      ok: true,
+      server: { text: draft.text, updatedAt: 'rev-3' },
+    }));
+    const secondSave = persistence.save('session-a', 'typed after send', successor);
+    first.resolve({
+      ok: false,
+      conflict: true,
+      server: { text: '', updatedAt: 'clear-revision' },
+    });
+
+    await expect(firstSave).resolves.toMatchObject({ ok: false, conflict: true });
+    await expect(secondSave).resolves.toMatchObject({ ok: true });
+    expect(successor).toHaveBeenCalledWith({
+      text: 'typed after send',
+      expectedUpdatedAt: 'clear-revision',
     });
   });
 

--- a/ui/src/lib/sessionDraftPersistence.test.ts
+++ b/ui/src/lib/sessionDraftPersistence.test.ts
@@ -17,6 +17,14 @@ const deferred = <T,>() => {
 class MemoryStorage {
   readonly values = new Map<string, string>();
 
+  get length(): number {
+    return this.values.size;
+  }
+
+  key(index: number): string | null {
+    return [...this.values.keys()][index] ?? null;
+  }
+
   getItem(key: string): string | null {
     return this.values.get(key) ?? null;
   }
@@ -110,6 +118,28 @@ describe('SessionDraftPersistence', () => {
     });
   });
 
+  it('retries the newest local mutation instead of a stale in-memory tab copy', async () => {
+    const storage = new MemoryStorage();
+    const firstCache = new SessionDraftLocalCache(storage, () => 'tab-a', () => 1);
+    const secondCache = new SessionDraftLocalCache(storage, () => 'tab-b', () => 2);
+    const first = new SessionDraftPersistence(firstCache);
+    await first.save('session-a', 'from tab A', async () => ({ ok: false }));
+    secondCache.writeDirty('session-a', 'from tab B', null);
+    const writes: SessionDraftWrite[] = [];
+
+    await first.retryAll(async (_sessionId, draft) => {
+      writes.push(draft);
+      return { ok: true, server: { text: draft.text, updatedAt: 'rev-1' } };
+    });
+
+    expect(writes).toEqual([{ text: 'from tab B', expectedUpdatedAt: null }]);
+    expect(secondCache.read('session-a')).toMatchObject({
+      text: 'from tab B',
+      dirty: false,
+      mutationId: 'tab-b',
+    });
+  });
+
   it('keeps local text when a read starts during a pending write', async () => {
     const persistence = new SessionDraftPersistence(localCache());
     const first = deferred<SessionDraftSaveResult>();
@@ -159,6 +189,38 @@ describe('SessionDraftPersistence', () => {
       text: 'offline text',
       expectedUpdatedAt: null,
     });
+  });
+
+  it('retries every dirty session discovered after a reload', async () => {
+    const storage = new MemoryStorage();
+    const cache = localCache(storage);
+    cache.writeDirty('session-a', 'offline A', 'rev-a');
+    cache.writeDirty('session-b', 'offline B', 'rev-b');
+    cache.writeClean('session-c', 'synced C', 'rev-c');
+    const persistence = new SessionDraftPersistence(cache);
+    const calls: Array<{ sessionId: string; draft: SessionDraftWrite }> = [];
+
+    await persistence.retryAll(async (sessionId, draft) => {
+      calls.push({ sessionId, draft });
+      return {
+        ok: true,
+        server: { text: draft.text, updatedAt: `synced-${sessionId}` },
+      };
+    });
+
+    expect(calls).toEqual([
+      {
+        sessionId: 'session-a',
+        draft: { text: 'offline A', expectedUpdatedAt: 'rev-a' },
+      },
+      {
+        sessionId: 'session-b',
+        draft: { text: 'offline B', expectedUpdatedAt: 'rev-b' },
+      },
+    ]);
+    expect(cache.read('session-a')?.dirty).toBe(false);
+    expect(cache.read('session-b')?.dirty).toBe(false);
+    expect(cache.read('session-c')).toMatchObject({ text: 'synced C', dirty: false });
   });
 
   it('lets an authoritative newer cloud revision replace a clean local copy', async () => {
@@ -227,5 +289,19 @@ describe('SessionDraftPersistence', () => {
     expect(cache.read('session-a')).toBeNull();
     expect(persistence.revision('session-a')).toBe(0);
     expect(persistence.beginRead('session-a').pending).toBe(false);
+  });
+
+  it('discards a read response captured before the session was archived', () => {
+    const cache = localCache();
+    const persistence = new SessionDraftPersistence(cache);
+    const read = persistence.beginRead('session-a');
+
+    persistence.clearSession('session-a');
+    expect(persistence.reconcileRead(
+      'session-a',
+      read,
+      { text: 'stale pre-archive draft', updatedAt: 'old-revision' },
+    )).toBe('');
+    expect(cache.read('session-a')).toBeNull();
   });
 });

--- a/ui/src/lib/sessionDraftPersistence.test.ts
+++ b/ui/src/lib/sessionDraftPersistence.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it, vi } from 'vitest';
-import { SessionDraftLocalCache } from './sessionDraftLocalCache';
+import {
+  SESSION_DRAFT_MUTATION_PREFIX,
+  SessionDraftLocalCache,
+} from './sessionDraftLocalCache';
 import {
   SessionDraftPersistence,
   type SessionDraftSaveResult,
@@ -138,6 +141,24 @@ describe('SessionDraftPersistence', () => {
       dirty: true,
       mutationId: 'tab-b',
     });
+  });
+
+  it('does not delete an adopted mutation when this tab starts editing', () => {
+    const storage = new MemoryStorage();
+    const firstCache = new SessionDraftLocalCache(storage, () => 'tab-a', () => 1);
+    const secondCache = new SessionDraftLocalCache(storage, () => 'tab-b', () => 2);
+    secondCache.writeDirty('session-a', 'from tab B', null);
+    const first = new SessionDraftPersistence(firstCache);
+
+    first.beginRead('session-a');
+    first.cache('session-a', 'from tab A');
+
+    expect(storage.getItem(
+      `${SESSION_DRAFT_MUTATION_PREFIX}session-a:tab-b`,
+    )).not.toBeNull();
+    expect(storage.getItem(
+      `${SESSION_DRAFT_MUTATION_PREFIX}session-a:tab-a`,
+    )).not.toBeNull();
   });
 
   it('keeps local text when a read starts during a pending write', async () => {
@@ -347,6 +368,80 @@ describe('SessionDraftPersistence', () => {
       text: 'typed after send',
       expectedUpdatedAt: 'clear-revision',
     });
+  });
+
+  it('rebases a successor from the authoritative state after an uncertain write', async () => {
+    const persistence = new SessionDraftPersistence(localCache());
+    const first = deferred<SessionDraftSaveResult>();
+    const firstSave = persistence.save('session-a', 'first', async () => first.promise);
+    await Promise.resolve();
+
+    persistence.cache('session-a', 'second');
+    const successor = vi.fn(async (draft: SessionDraftWrite): Promise<SessionDraftSaveResult> => ({
+      ok: true,
+      server: { text: draft.text, updatedAt: 'rev-2' },
+    }));
+    const secondSave = persistence.save('session-a', 'second', successor);
+    first.resolve({
+      ok: false,
+      server: { text: '', updatedAt: 'reconciled-revision' },
+    });
+
+    await expect(firstSave).resolves.toMatchObject({ ok: false });
+    await expect(secondSave).resolves.toMatchObject({ ok: true });
+    expect(successor).toHaveBeenCalledWith({
+      text: 'second',
+      expectedUpdatedAt: 'reconciled-revision',
+    });
+  });
+
+  it('rebases and retries a rejected-send restoration without another edit', async () => {
+    const persistence = new SessionDraftPersistence(localCache());
+    persistence.cache('session-a', 'submitted');
+    persistence.cache('session-a', '');
+    persistence.cache('session-a', 'submitted');
+
+    persistence.rebase('session-a', { text: '', updatedAt: 'clear-revision' });
+    const write = vi.fn(async (draft: SessionDraftWrite): Promise<SessionDraftSaveResult> => ({
+      ok: true,
+      server: { text: draft.text, updatedAt: 'restored-revision' },
+    }));
+    await persistence.retry('session-a', write);
+
+    expect(write).toHaveBeenCalledWith({
+      text: 'submitted',
+      expectedUpdatedAt: 'clear-revision',
+    });
+  });
+
+  it('persists rejected-send recovery and retries its first conflict after reload', async () => {
+    const storage = new MemoryStorage();
+    const first = new SessionDraftPersistence(localCache(storage));
+    first.cache('session-a', 'submitted');
+    first.markRejectedSend('session-a');
+
+    const restored = new SessionDraftPersistence(localCache(storage));
+    const writes: SessionDraftWrite[] = [];
+    const result = await restored.retry('session-a', async (draft) => {
+      writes.push(draft);
+      if (writes.length === 1) {
+        return {
+          ok: false,
+          conflict: true,
+          server: { text: '', updatedAt: 'clear-revision' },
+        };
+      }
+      return {
+        ok: true,
+        server: { text: draft.text, updatedAt: 'restored-revision' },
+      };
+    });
+
+    expect(result).toMatchObject({ ok: true });
+    expect(writes).toEqual([
+      { text: 'submitted', expectedUpdatedAt: null },
+      { text: 'submitted', expectedUpdatedAt: 'clear-revision' },
+    ]);
   });
 
   it('treats a same-text conflict as convergence and cleans the local record', async () => {

--- a/ui/src/lib/sessionDraftPersistence.test.ts
+++ b/ui/src/lib/sessionDraftPersistence.test.ts
@@ -395,6 +395,97 @@ describe('SessionDraftPersistence', () => {
     });
   });
 
+  it('does not overwrite an unrelated conflict after an uncertain write', async () => {
+    const persistence = new SessionDraftPersistence(localCache());
+    const first = deferred<SessionDraftSaveResult>();
+    const firstSave = persistence.save('session-a', 'first', async () => first.promise);
+    await Promise.resolve();
+
+    persistence.cache('session-a', 'second');
+    const successor = vi.fn(async (): Promise<SessionDraftSaveResult> => ({
+      ok: false,
+      conflict: true,
+      server: { text: 'other device', updatedAt: 'other-revision' },
+    }));
+    const secondSave = persistence.save('session-a', 'second', successor);
+    first.resolve({
+      ok: false,
+      server: { text: '', updatedAt: 'reconciled-revision' },
+      retryConflictIfServerText: 'first',
+    });
+
+    await expect(firstSave).resolves.toMatchObject({ ok: false });
+    await expect(secondSave).resolves.toMatchObject({ ok: false, conflict: true });
+    expect(successor).toHaveBeenCalledTimes(1);
+    expect(persistence.peek('session-a')).toBe('second');
+  });
+
+  it('carries timeout uncertainty into an edit made after reconciliation', async () => {
+    const persistence = new SessionDraftPersistence(localCache());
+    await persistence.save('session-a', 'first', async () => ({
+      ok: false,
+      server: { text: '', updatedAt: 'reconciled-revision' },
+      retryConflictIfServerText: 'first',
+    }));
+
+    persistence.cache('session-a', 'second');
+    const writes: SessionDraftWrite[] = [];
+    const result = await persistence.save('session-a', 'second', async (draft) => {
+      writes.push(draft);
+      if (writes.length === 1) {
+        return {
+          ok: false,
+          conflict: true,
+          server: { text: 'first', updatedAt: 'late-first-revision' },
+        };
+      }
+      return {
+        ok: true,
+        server: { text: draft.text, updatedAt: 'second-revision' },
+      };
+    });
+
+    expect(result).toMatchObject({ ok: true });
+    expect(writes).toEqual([
+      { text: 'second', expectedUpdatedAt: 'reconciled-revision' },
+      { text: 'second', expectedUpdatedAt: 'late-first-revision' },
+    ]);
+  });
+
+  it('restores the bounded timeout recovery marker after reload', async () => {
+    const storage = new MemoryStorage();
+    const cache = localCache(storage);
+    cache.writeDirty('session-a', 'second', 'reconciled-revision', undefined, true, 'first');
+    const restored = new SessionDraftPersistence(localCache(storage));
+    const writes: SessionDraftWrite[] = [];
+
+    const result = await restored.retry('session-a', async (draft) => {
+      writes.push(draft);
+      if (writes.length === 1) {
+        return {
+          ok: false,
+          conflict: true,
+          server: { text: 'first', updatedAt: 'late-first-revision' },
+        };
+      }
+      return {
+        ok: true,
+        server: { text: draft.text, updatedAt: 'second-revision' },
+      };
+    });
+
+    expect(result).toMatchObject({ ok: true });
+    expect(writes).toEqual([
+      { text: 'second', expectedUpdatedAt: 'reconciled-revision' },
+      { text: 'second', expectedUpdatedAt: 'late-first-revision' },
+    ]);
+    expect(cache.read('session-a')).toMatchObject({
+      text: 'second',
+      serverUpdatedAt: 'second-revision',
+      dirty: false,
+    });
+  });
+
   it('rebases and retries a rejected-send restoration without another edit', async () => {
     const persistence = new SessionDraftPersistence(localCache());
     persistence.cache('session-a', 'submitted');

--- a/ui/src/lib/sessionDraftPersistence.test.ts
+++ b/ui/src/lib/sessionDraftPersistence.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+import { SessionDraftPersistence } from './sessionDraftPersistence';
+
+const deferred = <T,>() => {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((next) => {
+    resolve = next;
+  });
+  return { promise, resolve };
+};
+
+describe('SessionDraftPersistence', () => {
+  it('serializes writes for one session and keeps the latest text', async () => {
+    const persistence = new SessionDraftPersistence();
+    const first = deferred<{ ok: boolean }>();
+    const calls: string[] = [];
+
+    persistence.save('session-a', 'first', async () => {
+      calls.push('first');
+      return first.promise;
+    });
+    await Promise.resolve();
+    const second = persistence.save('session-a', 'second', async () => {
+      calls.push('second');
+      return { ok: true };
+    });
+
+    expect(calls).toEqual(['first']);
+    first.resolve({ ok: true });
+    await second;
+    expect(calls).toEqual(['first', 'second']);
+    expect(persistence.revision('session-a')).toBe(0);
+  });
+
+  it('does not block writes for different sessions', async () => {
+    const persistence = new SessionDraftPersistence();
+    const first = deferred<{ ok: boolean }>();
+    const calls: string[] = [];
+
+    persistence.save('session-a', 'first', async () => {
+      calls.push('a');
+      return first.promise;
+    });
+    await persistence.save('session-b', 'other', async () => {
+      calls.push('b');
+      return { ok: true };
+    });
+
+    expect(calls).toEqual(['a', 'b']);
+    first.resolve({ ok: true });
+  });
+
+  it('waits for a write before a bootstrap read', async () => {
+    const persistence = new SessionDraftPersistence();
+    const first = deferred<{ ok: boolean }>();
+    let readStarted = false;
+    persistence.save('session-a', 'draft', async () => first.promise);
+
+    const read = (async () => {
+      await persistence.waitForWrites('session-a');
+      readStarted = true;
+    })();
+    await Promise.resolve();
+    expect(readStarted).toBe(false);
+    first.resolve({ ok: true });
+    await read;
+    expect(readStarted).toBe(true);
+  });
+
+  it('returns the local text when a read races a newer or failed write', async () => {
+    const persistence = new SessionDraftPersistence();
+    const failed = persistence.save('session-a', 'local', async () => ({ ok: false }));
+    await failed;
+    expect(persistence.reconcileRead('session-a', 1, '')).toBe('local');
+
+    const pending = deferred<{ ok: boolean }>();
+    persistence.save('session-a', 'newer', async () => pending.promise);
+    expect(persistence.reconcileRead('session-a', 1, 'old')).toBe('newer');
+    pending.resolve({ ok: true });
+  });
+});

--- a/ui/src/lib/sessionDraftPersistence.test.ts
+++ b/ui/src/lib/sessionDraftPersistence.test.ts
@@ -118,7 +118,7 @@ describe('SessionDraftPersistence', () => {
     });
   });
 
-  it('retries the newest local mutation instead of a stale in-memory tab copy', async () => {
+  it('keeps each live tab dirty mutation authoritative until it is acknowledged', async () => {
     const storage = new MemoryStorage();
     const firstCache = new SessionDraftLocalCache(storage, () => 'tab-a', () => 1);
     const secondCache = new SessionDraftLocalCache(storage, () => 'tab-b', () => 2);
@@ -132,10 +132,10 @@ describe('SessionDraftPersistence', () => {
       return { ok: true, server: { text: draft.text, updatedAt: 'rev-1' } };
     });
 
-    expect(writes).toEqual([{ text: 'from tab B', expectedUpdatedAt: null }]);
+    expect(writes).toEqual([{ text: 'from tab A', expectedUpdatedAt: null }]);
     expect(secondCache.read('session-a')).toMatchObject({
       text: 'from tab B',
-      dirty: false,
+      dirty: true,
       mutationId: 'tab-b',
     });
   });
@@ -242,7 +242,7 @@ describe('SessionDraftPersistence', () => {
     expect(restored.peek('session-a')).toBe('other device');
   });
 
-  it('preserves a dirty local draft and stops automatic writes on a version conflict', async () => {
+  it('preserves a conflicted draft and resumes syncing after the user edits it', async () => {
     const persistence = new SessionDraftPersistence(localCache());
     const firstRead = persistence.beginRead('session-a');
     persistence.reconcileRead('session-a', firstRead, { text: 'cloud', updatedAt: 'rev-1' });
@@ -262,6 +262,42 @@ describe('SessionDraftPersistence', () => {
     });
     expect(write).not.toHaveBeenCalled();
     expect(persistence.peek('session-a')).toBe('local edit');
+
+    persistence.cache('session-a', 'local edit resolved');
+    await expect(persistence.save('session-a', 'local edit resolved', write)).resolves.toMatchObject({
+      ok: true,
+    });
+    expect(write).toHaveBeenCalledWith({
+      text: 'local edit resolved',
+      expectedUpdatedAt: 'rev-2',
+    });
+  });
+
+  it('rebases the next edit onto the server revision returned by a write conflict', async () => {
+    const persistence = new SessionDraftPersistence(localCache());
+    const conflict = vi.fn(async (): Promise<SessionDraftSaveResult> => ({
+      ok: false,
+      conflict: true,
+      server: { text: 'other device', updatedAt: 'rev-2' },
+    }));
+
+    await expect(persistence.save('session-a', 'local edit', conflict)).resolves.toMatchObject({
+      ok: false,
+      conflict: true,
+    });
+    await persistence.save('session-a', 'local edit', conflict);
+    expect(conflict).toHaveBeenCalledTimes(1);
+
+    const resolved = vi.fn(async (draft: SessionDraftWrite): Promise<SessionDraftSaveResult> => ({
+      ok: true,
+      server: { text: draft.text, updatedAt: 'rev-3' },
+    }));
+    persistence.cache('session-a', 'local edit resolved');
+    await persistence.save('session-a', 'local edit resolved', resolved);
+    expect(resolved).toHaveBeenCalledWith({
+      text: 'local edit resolved',
+      expectedUpdatedAt: 'rev-2',
+    });
   });
 
   it('treats a same-text conflict as convergence and cleans the local record', async () => {
@@ -303,5 +339,28 @@ describe('SessionDraftPersistence', () => {
       { text: 'stale pre-archive draft', updatedAt: 'old-revision' },
     )).toBe('');
     expect(cache.read('session-a')).toBeNull();
+  });
+
+  it('discards a pre-archive read when another tab invalidates the session', () => {
+    const storage = new MemoryStorage();
+    const first = new SessionDraftPersistence(new SessionDraftLocalCache(
+      storage,
+      () => 'tab-a',
+      () => 1,
+    ));
+    const second = new SessionDraftPersistence(new SessionDraftLocalCache(
+      storage,
+      () => 'tab-b-archive',
+      () => 2,
+    ));
+    const read = first.beginRead('session-a');
+
+    second.clearSession('session-a');
+    expect(first.reconcileRead(
+      'session-a',
+      read,
+      { text: 'stale pre-archive draft', updatedAt: 'old-revision' },
+    )).toBe('');
+    expect(first.peek('session-a')).toBeNull();
   });
 });

--- a/ui/src/lib/sessionDraftPersistence.test.ts
+++ b/ui/src/lib/sessionDraftPersistence.test.ts
@@ -50,32 +50,48 @@ describe('SessionDraftPersistence', () => {
     first.resolve({ ok: true });
   });
 
-  it('waits for a write before a bootstrap read', async () => {
+  it('keeps the local text when a read starts during a pending write', async () => {
     const persistence = new SessionDraftPersistence();
     const first = deferred<{ ok: boolean }>();
-    let readStarted = false;
     persistence.save('session-a', 'draft', async () => first.promise);
 
-    const read = (async () => {
-      await persistence.waitForWrites('session-a');
-      readStarted = true;
-    })();
-    await Promise.resolve();
-    expect(readStarted).toBe(false);
+    const read = persistence.beginRead('session-a');
+    expect(persistence.reconcileRead('session-a', read, '')).toBe('draft');
     first.resolve({ ok: true });
-    await read;
-    expect(readStarted).toBe(true);
+    await Promise.resolve();
   });
 
-  it('returns the local text when a read races a newer or failed write', async () => {
+  it('retains a successful revision until an older read reconciles', async () => {
+    const persistence = new SessionDraftPersistence();
+    const read = persistence.beginRead('session-a');
+    await persistence.save('session-a', 'newer', async () => ({ ok: true }));
+
+    expect(persistence.reconcileRead('session-a', read, 'old')).toBe('newer');
+    expect(persistence.revision('session-a')).toBe(0);
+  });
+
+  it('returns the local text when a read races a failed write', async () => {
     const persistence = new SessionDraftPersistence();
     const failed = persistence.save('session-a', 'local', async () => ({ ok: false }));
     await failed;
-    expect(persistence.reconcileRead('session-a', 1, '')).toBe('local');
+    const failedRead = persistence.beginRead('session-a');
+    expect(persistence.reconcileRead('session-a', failedRead, '')).toBe('local');
 
     const pending = deferred<{ ok: boolean }>();
+    const newerRead = persistence.beginRead('session-a');
     persistence.save('session-a', 'newer', async () => pending.promise);
-    expect(persistence.reconcileRead('session-a', 1, 'old')).toBe('newer');
+    expect(persistence.reconcileRead('session-a', newerRead, 'old')).toBe('newer');
     pending.resolve({ ok: true });
+    await Promise.resolve();
+  });
+
+  it('clears pending and failed state when a session is archived', async () => {
+    const persistence = new SessionDraftPersistence();
+    persistence.save('session-a', 'draft', async () => ({ ok: false }));
+    await Promise.resolve();
+    persistence.clearSession('session-a');
+
+    expect(persistence.revision('session-a')).toBe(0);
+    expect(persistence.beginRead('session-a').pending).toBe(false);
   });
 });

--- a/ui/src/lib/sessionDraftPersistence.test.ts
+++ b/ui/src/lib/sessionDraftPersistence.test.ts
@@ -1,5 +1,10 @@
-import { describe, expect, it } from 'vitest';
-import { SessionDraftPersistence } from './sessionDraftPersistence';
+import { describe, expect, it, vi } from 'vitest';
+import { SessionDraftLocalCache } from './sessionDraftLocalCache';
+import {
+  SessionDraftPersistence,
+  type SessionDraftSaveResult,
+  type SessionDraftWrite,
+} from './sessionDraftPersistence';
 
 const deferred = <T,>() => {
   let resolve!: (value: T) => void;
@@ -9,32 +14,68 @@ const deferred = <T,>() => {
   return { promise, resolve };
 };
 
-describe('SessionDraftPersistence', () => {
-  it('serializes writes for one session and keeps the latest text', async () => {
-    const persistence = new SessionDraftPersistence();
-    const first = deferred<{ ok: boolean }>();
-    const calls: string[] = [];
+class MemoryStorage {
+  readonly values = new Map<string, string>();
 
-    persistence.save('session-a', 'first', async () => {
-      calls.push('first');
+  getItem(key: string): string | null {
+    return this.values.get(key) ?? null;
+  }
+
+  setItem(key: string, value: string): void {
+    this.values.set(key, value);
+  }
+
+  removeItem(key: string): void {
+    this.values.delete(key);
+  }
+}
+
+const localCache = (storage = new MemoryStorage()) => {
+  let sequence = 0;
+  return new SessionDraftLocalCache(
+    storage,
+    () => `mutation-${++sequence}`,
+    () => sequence,
+  );
+};
+
+describe('SessionDraftPersistence', () => {
+  it('serializes one session and rebases a newer edit onto the successful cloud revision', async () => {
+    const cache = localCache();
+    const persistence = new SessionDraftPersistence(cache);
+    const first = deferred<SessionDraftSaveResult>();
+    const calls: SessionDraftWrite[] = [];
+
+    persistence.save('session-a', 'first', async (draft) => {
+      calls.push(draft);
       return first.promise;
     });
     await Promise.resolve();
-    const second = persistence.save('session-a', 'second', async () => {
-      calls.push('second');
-      return { ok: true };
+    persistence.cache('session-a', 'second');
+    const second = persistence.save('session-a', 'second', async (draft) => {
+      calls.push(draft);
+      return { ok: true, server: { text: draft.text, updatedAt: 'rev-2' } };
     });
 
-    expect(calls).toEqual(['first']);
-    first.resolve({ ok: true });
+    expect(calls).toEqual([{ text: 'first', expectedUpdatedAt: null }]);
+    first.resolve({ ok: true, server: { text: 'first', updatedAt: 'rev-1' } });
     await second;
-    expect(calls).toEqual(['first', 'second']);
+
+    expect(calls).toEqual([
+      { text: 'first', expectedUpdatedAt: null },
+      { text: 'second', expectedUpdatedAt: 'rev-1' },
+    ]);
+    expect(cache.read('session-a')).toMatchObject({
+      text: 'second',
+      serverUpdatedAt: 'rev-2',
+      dirty: false,
+    });
     expect(persistence.revision('session-a')).toBe(0);
   });
 
   it('does not block writes for different sessions', async () => {
-    const persistence = new SessionDraftPersistence();
-    const first = deferred<{ ok: boolean }>();
+    const persistence = new SessionDraftPersistence(localCache());
+    const first = deferred<SessionDraftSaveResult>();
     const calls: string[] = [];
 
     persistence.save('session-a', 'first', async () => {
@@ -43,54 +84,147 @@ describe('SessionDraftPersistence', () => {
     });
     await persistence.save('session-b', 'other', async () => {
       calls.push('b');
-      return { ok: true };
+      return { ok: true, server: { text: 'other', updatedAt: 'rev-b' } };
     });
 
     expect(calls).toEqual(['a', 'b']);
-    first.resolve({ ok: true });
+    first.resolve({ ok: true, server: { text: 'first', updatedAt: 'rev-a' } });
   });
 
-  it('keeps the local text when a read starts during a pending write', async () => {
-    const persistence = new SessionDraftPersistence();
-    const first = deferred<{ ok: boolean }>();
+  it('does not let a slow acknowledgement overwrite another tab local mutation', async () => {
+    const storage = new MemoryStorage();
+    const firstCache = new SessionDraftLocalCache(storage, () => 'tab-a', () => 1);
+    const secondCache = new SessionDraftLocalCache(storage, () => 'tab-b', () => 2);
+    const first = new SessionDraftPersistence(firstCache);
+    const slow = deferred<SessionDraftSaveResult>();
+
+    const save = first.save('session-a', 'from tab A', async () => slow.promise);
+    secondCache.writeDirty('session-a', 'from tab B', null);
+    slow.resolve({ ok: true, server: { text: 'from tab A', updatedAt: 'rev-1' } });
+    await save;
+
+    expect(secondCache.read('session-a')).toMatchObject({
+      text: 'from tab B',
+      dirty: true,
+      mutationId: 'tab-b',
+    });
+  });
+
+  it('keeps local text when a read starts during a pending write', async () => {
+    const persistence = new SessionDraftPersistence(localCache());
+    const first = deferred<SessionDraftSaveResult>();
     persistence.save('session-a', 'draft', async () => first.promise);
 
     const read = persistence.beginRead('session-a');
-    expect(persistence.reconcileRead('session-a', read, '')).toBe('draft');
-    first.resolve({ ok: true });
+    expect(persistence.reconcileRead('session-a', read, { text: '', updatedAt: null })).toBe('draft');
+    first.resolve({ ok: true, server: { text: 'draft', updatedAt: 'rev-1' } });
     await Promise.resolve();
   });
 
   it('retains a successful revision until an older read reconciles', async () => {
-    const persistence = new SessionDraftPersistence();
+    const persistence = new SessionDraftPersistence(localCache());
     const read = persistence.beginRead('session-a');
-    await persistence.save('session-a', 'newer', async () => ({ ok: true }));
+    await persistence.save('session-a', 'newer', async () => ({
+      ok: true,
+      server: { text: 'newer', updatedAt: 'rev-2' },
+    }));
 
-    expect(persistence.reconcileRead('session-a', read, 'old')).toBe('newer');
+    expect(persistence.reconcileRead(
+      'session-a',
+      read,
+      { text: 'old', updatedAt: 'rev-1' },
+    )).toBe('newer');
     expect(persistence.revision('session-a')).toBe(0);
   });
 
-  it('returns the local text when a read races a failed write', async () => {
-    const persistence = new SessionDraftPersistence();
-    const failed = persistence.save('session-a', 'local', async () => ({ ok: false }));
-    await failed;
-    const failedRead = persistence.beginRead('session-a');
-    expect(persistence.reconcileRead('session-a', failedRead, '')).toBe('local');
+  it('recovers a failed write from local storage in a new persistence instance', async () => {
+    const storage = new MemoryStorage();
+    const first = new SessionDraftPersistence(localCache(storage));
+    await first.save('session-a', 'offline text', async () => ({ ok: false }));
 
-    const pending = deferred<{ ok: boolean }>();
-    const newerRead = persistence.beginRead('session-a');
-    persistence.save('session-a', 'newer', async () => pending.promise);
-    expect(persistence.reconcileRead('session-a', newerRead, 'old')).toBe('newer');
-    pending.resolve({ ok: true });
-    await Promise.resolve();
+    const restored = new SessionDraftPersistence(localCache(storage));
+    expect(restored.peek('session-a')).toBe('offline text');
+    const read = restored.beginRead('session-a');
+    expect(restored.reconcileRead(
+      'session-a',
+      read,
+      { text: '', updatedAt: null },
+    )).toBe('offline text');
+    const write = vi.fn(async (draft: SessionDraftWrite) => ({
+      ok: true,
+      server: { text: draft.text, updatedAt: 'rev-1' },
+    }));
+    await restored.retry('session-a', write);
+    expect(write).toHaveBeenCalledWith({
+      text: 'offline text',
+      expectedUpdatedAt: null,
+    });
   });
 
-  it('clears pending and failed state when a session is archived', async () => {
-    const persistence = new SessionDraftPersistence();
-    persistence.save('session-a', 'draft', async () => ({ ok: false }));
-    await Promise.resolve();
+  it('lets an authoritative newer cloud revision replace a clean local copy', async () => {
+    const storage = new MemoryStorage();
+    const first = new SessionDraftPersistence(localCache(storage));
+    await first.save('session-a', 'synced', async () => ({
+      ok: true,
+      server: { text: 'synced', updatedAt: 'rev-1' },
+    }));
+
+    const restored = new SessionDraftPersistence(localCache(storage));
+    expect(restored.peek('session-a')).toBe('synced');
+    const read = restored.beginRead('session-a');
+    expect(restored.reconcileRead(
+      'session-a',
+      read,
+      { text: 'other device', updatedAt: 'rev-2' },
+    )).toBe('other device');
+    expect(restored.peek('session-a')).toBe('other device');
+  });
+
+  it('preserves a dirty local draft and stops automatic writes on a version conflict', async () => {
+    const persistence = new SessionDraftPersistence(localCache());
+    const firstRead = persistence.beginRead('session-a');
+    persistence.reconcileRead('session-a', firstRead, { text: 'cloud', updatedAt: 'rev-1' });
+    persistence.cache('session-a', 'local edit');
+
+    const racingRead = persistence.beginRead('session-a');
+    expect(persistence.reconcileRead(
+      'session-a',
+      racingRead,
+      { text: 'other device', updatedAt: 'rev-2' },
+    )).toBe('local edit');
+
+    const write = vi.fn(async () => ({ ok: true }));
+    await expect(persistence.retry('session-a', write)).resolves.toMatchObject({
+      ok: false,
+      conflict: true,
+    });
+    expect(write).not.toHaveBeenCalled();
+    expect(persistence.peek('session-a')).toBe('local edit');
+  });
+
+  it('treats a same-text conflict as convergence and cleans the local record', async () => {
+    const cache = localCache();
+    const persistence = new SessionDraftPersistence(cache);
+
+    const result = await persistence.save('session-a', '', async () => ({
+      ok: false,
+      conflict: true,
+      server: { text: '', updatedAt: 'clear-revision' },
+    }));
+
+    expect(result).toMatchObject({ ok: true });
+    expect(cache.read('session-a')).toBeNull();
+    expect(persistence.revision('session-a')).toBe(0);
+  });
+
+  it('removes persistent and in-memory state when a session is archived', async () => {
+    const cache = localCache();
+    const persistence = new SessionDraftPersistence(cache);
+    await persistence.save('session-a', 'draft', async () => ({ ok: false }));
+
     persistence.clearSession('session-a');
 
+    expect(cache.read('session-a')).toBeNull();
     expect(persistence.revision('session-a')).toBe(0);
     expect(persistence.beginRead('session-a').pending).toBe(false);
   });

--- a/ui/src/lib/sessionDraftPersistence.ts
+++ b/ui/src/lib/sessionDraftPersistence.ts
@@ -177,6 +177,23 @@ export class SessionDraftPersistence {
       return dirty.text;
     }
 
+    if (current && this.hasOlderRead(sessionId, current.revision)) {
+      // A read that began after this successful write may settle before a read
+      // from the older revision. Keep one retained value as a read barrier so
+      // every older response returns the newest value instead of deleting the
+      // only stale-response guard.
+      this.localCache.acknowledge(
+        sessionId,
+        current.localId,
+        server.text,
+        server.updatedAt,
+      );
+      current.text = server.text;
+      current.baseUpdatedAt = server.updatedAt;
+      this.serverVersions.set(sessionId, server.updatedAt);
+      return current.text;
+    }
+
     this.acceptServer(sessionId, server);
     this.cleanupSuccessfulEntry(sessionId);
     return server.text;
@@ -208,11 +225,27 @@ export class SessionDraftPersistence {
       );
       const beforeWrite = this.entries.get(sessionId);
       if (!beforeWrite || beforeWrite.revision !== revision) return { ok: true };
-      if (beforeWrite.conflict || predecessorResult?.conflict) {
+      if (predecessorResult?.conflict) {
+        if (predecessorResult.server) {
+          beforeWrite.baseUpdatedAt = predecessorResult.server.updatedAt;
+          beforeWrite.conflict = false;
+          this.localCache.rebaseDirty(
+            sessionId,
+            beforeWrite.localId,
+            predecessorResult.server.updatedAt,
+          );
+        } else {
+          beforeWrite.pending = null;
+          beforeWrite.pendingRevision = null;
+          beforeWrite.conflict = true;
+          return { ok: false, conflict: true };
+        }
+      }
+      if (beforeWrite.conflict) {
         beforeWrite.pending = null;
         beforeWrite.pendingRevision = null;
         beforeWrite.conflict = true;
-        return { ok: false, conflict: true, server: predecessorResult?.server };
+        return { ok: false, conflict: true };
       }
 
       let result: SessionDraftSaveResult;
@@ -278,8 +311,14 @@ export class SessionDraftPersistence {
       current.pendingRevision = null;
     }
     if (result.conflict) {
-      current.conflict = true;
       if (result.server) this.serverVersions.set(sessionId, result.server.updatedAt);
+      if (current.revision !== revision && result.server) {
+        current.baseUpdatedAt = result.server.updatedAt;
+        current.conflict = false;
+        this.localCache.rebaseDirty(sessionId, current.localId, result.server.updatedAt);
+      } else {
+        current.conflict = true;
+      }
     }
   }
 
@@ -348,5 +387,10 @@ export class SessionDraftPersistence {
     if (current && !current.pending && !current.dirty && !this.activeReads.has(sessionId)) {
       this.entries.delete(sessionId);
     }
+  }
+
+  private hasOlderRead(sessionId: string, revision: number): boolean {
+    const reads = this.activeReads.get(sessionId);
+    return Boolean(reads && [...reads].some((read) => read.revision < revision));
   }
 }

--- a/ui/src/lib/sessionDraftPersistence.ts
+++ b/ui/src/lib/sessionDraftPersistence.ts
@@ -1,0 +1,84 @@
+export type SessionDraftSaveResult = { ok: boolean };
+
+type DraftEntry = {
+  revision: number;
+  text: string;
+  pending: Promise<SessionDraftSaveResult> | null;
+  dirty: boolean;
+};
+
+type DraftSave = () => Promise<SessionDraftSaveResult>;
+
+/**
+ * Serializes per-session draft writes and closes the read-after-write gap that
+ * appears when navigation remounts ChatPage before its fire-and-forget PUT
+ * finishes. The latest text stays available for a read that raced a write.
+ */
+export class SessionDraftPersistence {
+  private readonly entries = new Map<string, DraftEntry>();
+
+  save(sessionId: string, text: string, write: DraftSave): Promise<SessionDraftSaveResult> {
+    const previous = this.entries.get(sessionId);
+    const revision = (previous?.revision ?? 0) + 1;
+    const entry: DraftEntry = {
+      revision,
+      text,
+      pending: null,
+      dirty: true,
+    };
+    const predecessor = previous?.pending;
+    const pending = (async (): Promise<SessionDraftSaveResult> => {
+      await predecessor?.catch(() => undefined);
+      // A newer edit superseded this write while it was waiting. Its successor
+      // carries this promise as the predecessor and will write the latest text.
+      if (this.entries.get(sessionId)?.revision !== revision) return { ok: true };
+
+      let result: SessionDraftSaveResult;
+      try {
+        result = await write();
+      } catch {
+        result = { ok: false };
+      }
+      const current = this.entries.get(sessionId);
+      if (current?.revision === revision) {
+        if (result.ok) {
+          this.entries.delete(sessionId);
+        } else {
+          current.pending = null;
+          current.dirty = true;
+        }
+      }
+      return result;
+    })();
+    entry.pending = pending;
+    this.entries.set(sessionId, entry);
+    return pending;
+  }
+
+  async waitForWrites(sessionId: string): Promise<void> {
+    while (true) {
+      const pending = this.entries.get(sessionId)?.pending;
+      if (!pending) return;
+      await pending;
+      if (this.entries.get(sessionId)?.pending !== pending) continue;
+      return;
+    }
+  }
+
+  revision(sessionId: string): number {
+    return this.entries.get(sessionId)?.revision ?? 0;
+  }
+
+  /**
+   * Prefer local text when a write failed or changed while the read was in
+   * flight. Once a clean write is known to predate the read, the server is the
+   * source of truth and the temporary entry can be retired.
+   */
+  reconcileRead(sessionId: string, readRevision: number, serverText: string): string {
+    const current = this.entries.get(sessionId);
+    if (!current) return serverText;
+    if (current.revision > readRevision || current.pending || current.dirty) return current.text;
+    this.entries.delete(sessionId);
+    return serverText;
+  }
+}

--- a/ui/src/lib/sessionDraftPersistence.ts
+++ b/ui/src/lib/sessionDraftPersistence.ts
@@ -33,6 +33,7 @@ type DraftEntry = {
   conflict: boolean;
   localOwned: boolean;
   rebaseOnConflict: boolean;
+  serverEpoch: number;
 };
 
 type DraftSave = (draft: SessionDraftWrite) => Promise<SessionDraftSaveResult>;
@@ -89,6 +90,7 @@ export class SessionDraftPersistence {
       conflict: resolvesConflict ? false : current?.conflict ?? false,
       localOwned: true,
       rebaseOnConflict: current?.rebaseOnConflict ?? false,
+      serverEpoch: current?.serverEpoch ?? 0,
     });
   }
 
@@ -225,6 +227,12 @@ export class SessionDraftPersistence {
     current.baseUpdatedAt = server.updatedAt;
     current.conflict = false;
     current.rebaseOnConflict = false;
+    current.serverEpoch += 1;
+    // The external revision is causally newer than every write already in
+    // flight. Detach that promise chain; its eventual result is ignored by the
+    // epoch guard below, while retry() starts from this exact server revision.
+    current.pending = null;
+    current.pendingRevision = null;
     this.localCache.rebaseDirty(sessionId, current.localId, server.updatedAt, false);
   }
 
@@ -245,6 +253,7 @@ export class SessionDraftPersistence {
 
     const predecessor = entry.pending;
     const revision = entry.revision;
+    const serverEpoch = entry.serverEpoch;
     const text = entry.text;
     const pending = (async (): Promise<SessionDraftSaveResult> => {
       const predecessorResult: SessionDraftSaveResult | undefined = await predecessor?.catch(
@@ -252,6 +261,7 @@ export class SessionDraftPersistence {
       );
       const beforeWrite = this.entries.get(sessionId);
       if (!beforeWrite || beforeWrite.revision !== revision) return { ok: true };
+      if (beforeWrite.serverEpoch !== serverEpoch) return { ok: false };
       if (predecessorResult?.server) {
         beforeWrite.baseUpdatedAt = predecessorResult.server.updatedAt;
         beforeWrite.conflict = false;
@@ -292,9 +302,10 @@ export class SessionDraftPersistence {
         result.conflict
         && result.server
         && beforeWrite.revision === revision
+        && beforeWrite.serverEpoch === serverEpoch
         && beforeWrite.rebaseOnConflict,
       );
-      this.applyWriteResult(sessionId, revision, result);
+      this.applyWriteResult(sessionId, revision, serverEpoch, result);
       if (shouldRetryRecoveredConflict) {
         const retry = this.entries.get(sessionId);
         if (retry?.dirty && !retry.conflict && !retry.pending) {
@@ -312,10 +323,11 @@ export class SessionDraftPersistence {
   private applyWriteResult(
     sessionId: string,
     revision: number,
+    serverEpoch: number,
     result: SessionDraftSaveResult,
   ): void {
     const current = this.entries.get(sessionId);
-    if (!current) return;
+    if (!current || current.serverEpoch !== serverEpoch) return;
 
     if (result.ok) {
       const server = result.server ?? {
@@ -394,6 +406,7 @@ export class SessionDraftPersistence {
       conflict: false,
       localOwned: false,
       rebaseOnConflict: cached.rebaseOnConflict ?? false,
+      serverEpoch: current?.serverEpoch ?? 0,
     };
     this.entries.set(sessionId, hydrated);
     return hydrated;

--- a/ui/src/lib/sessionDraftPersistence.ts
+++ b/ui/src/lib/sessionDraftPersistence.ts
@@ -31,6 +31,8 @@ type DraftEntry = {
   pendingRevision: number | null;
   dirty: boolean;
   conflict: boolean;
+  localOwned: boolean;
+  rebaseOnConflict: boolean;
 };
 
 type DraftSave = (draft: SessionDraftWrite) => Promise<SessionDraftSaveResult>;
@@ -67,7 +69,13 @@ export class SessionDraftPersistence {
         ?? cached?.serverUpdatedAt
         ?? this.serverVersions.get(sessionId)
         ?? null;
-    const local = this.localCache.writeDirty(sessionId, text, baseUpdatedAt);
+    const local = this.localCache.writeDirty(
+      sessionId,
+      text,
+      baseUpdatedAt,
+      current?.localOwned ? current.localId : undefined,
+      current?.rebaseOnConflict ?? false,
+    );
     this.entries.set(sessionId, {
       revision: (current?.revision ?? 0) + 1,
       text,
@@ -79,6 +87,8 @@ export class SessionDraftPersistence {
       // A new keystroke after a conflict is explicit user intent. Rebase that
       // edit onto the revision returned by the conflict and resume CAS writes.
       conflict: resolvesConflict ? false : current?.conflict ?? false,
+      localOwned: true,
+      rebaseOnConflict: current?.rebaseOnConflict ?? false,
     });
   }
 
@@ -166,7 +176,7 @@ export class SessionDraftPersistence {
     const dirty = current?.dirty ? current : cached?.dirty ? this.hydrateDirty(sessionId) : null;
     if (dirty) {
       if (dirty.text === server.text) {
-        this.acceptServer(sessionId, server);
+        this.acceptServer(sessionId, server, dirty.localId);
         return server.text;
       }
 
@@ -208,6 +218,23 @@ export class SessionDraftPersistence {
     this.localCache.clear(sessionId);
   }
 
+  rebase(sessionId: string, server: SessionDraftServerState): void {
+    this.serverVersions.set(sessionId, server.updatedAt);
+    const current = this.hydrateDirty(sessionId);
+    if (!current) return;
+    current.baseUpdatedAt = server.updatedAt;
+    current.conflict = false;
+    current.rebaseOnConflict = false;
+    this.localCache.rebaseDirty(sessionId, current.localId, server.updatedAt, false);
+  }
+
+  markRejectedSend(sessionId: string): void {
+    const current = this.hydrateDirty(sessionId);
+    if (!current) return;
+    current.rebaseOnConflict = true;
+    this.localCache.markRebaseOnConflict(sessionId, current.localId);
+  }
+
   private startSync(
     sessionId: string,
     entry: DraftEntry,
@@ -225,21 +252,21 @@ export class SessionDraftPersistence {
       );
       const beforeWrite = this.entries.get(sessionId);
       if (!beforeWrite || beforeWrite.revision !== revision) return { ok: true };
-      if (predecessorResult?.conflict) {
-        if (predecessorResult.server) {
-          beforeWrite.baseUpdatedAt = predecessorResult.server.updatedAt;
-          beforeWrite.conflict = false;
-          this.localCache.rebaseDirty(
-            sessionId,
-            beforeWrite.localId,
-            predecessorResult.server.updatedAt,
-          );
-        } else {
-          beforeWrite.pending = null;
-          beforeWrite.pendingRevision = null;
-          beforeWrite.conflict = true;
-          return { ok: false, conflict: true };
-        }
+      if (predecessorResult?.server) {
+        beforeWrite.baseUpdatedAt = predecessorResult.server.updatedAt;
+        beforeWrite.conflict = false;
+        beforeWrite.rebaseOnConflict = false;
+        this.localCache.rebaseDirty(
+          sessionId,
+          beforeWrite.localId,
+          predecessorResult.server.updatedAt,
+        );
+      }
+      if (predecessorResult?.conflict && !predecessorResult.server) {
+        beforeWrite.pending = null;
+        beforeWrite.pendingRevision = null;
+        beforeWrite.conflict = true;
+        return { ok: false, conflict: true };
       }
       if (beforeWrite.conflict) {
         beforeWrite.pending = null;
@@ -261,7 +288,19 @@ export class SessionDraftPersistence {
       if (result.conflict && result.server?.text === text) {
         result = { ok: true, server: result.server };
       }
+      const shouldRetryRecoveredConflict = Boolean(
+        result.conflict
+        && result.server
+        && beforeWrite.revision === revision
+        && beforeWrite.rebaseOnConflict,
+      );
       this.applyWriteResult(sessionId, revision, result);
+      if (shouldRetryRecoveredConflict) {
+        const retry = this.entries.get(sessionId);
+        if (retry?.dirty && !retry.conflict && !retry.pending) {
+          return this.startSync(sessionId, retry, write);
+        }
+      }
       return result;
     })();
 
@@ -289,6 +328,7 @@ export class SessionDraftPersistence {
         current.pendingRevision = null;
         current.dirty = false;
         current.conflict = false;
+        current.rebaseOnConflict = false;
         current.baseUpdatedAt = server.updatedAt;
         this.localCache.acknowledge(
           sessionId,
@@ -315,7 +355,13 @@ export class SessionDraftPersistence {
       if (current.revision !== revision && result.server) {
         current.baseUpdatedAt = result.server.updatedAt;
         current.conflict = false;
-        this.localCache.rebaseDirty(sessionId, current.localId, result.server.updatedAt);
+        current.rebaseOnConflict = false;
+        this.localCache.rebaseDirty(sessionId, current.localId, result.server.updatedAt, false);
+      } else if (current.rebaseOnConflict && result.server) {
+        current.baseUpdatedAt = result.server.updatedAt;
+        current.conflict = false;
+        current.rebaseOnConflict = false;
+        this.localCache.rebaseDirty(sessionId, current.localId, result.server.updatedAt, false);
       } else {
         current.conflict = true;
       }
@@ -346,15 +392,25 @@ export class SessionDraftPersistence {
       pendingRevision: current?.pendingRevision ?? null,
       dirty: true,
       conflict: false,
+      localOwned: false,
+      rebaseOnConflict: cached.rebaseOnConflict ?? false,
     };
     this.entries.set(sessionId, hydrated);
     return hydrated;
   }
 
-  private acceptServer(sessionId: string, server: SessionDraftServerState): void {
+  private acceptServer(
+    sessionId: string,
+    server: SessionDraftServerState,
+    mutationId?: string,
+  ): void {
     this.serverVersions.set(sessionId, server.updatedAt);
     this.entries.delete(sessionId);
-    this.localCache.writeClean(sessionId, server.text, server.updatedAt);
+    if (mutationId) {
+      this.localCache.acknowledge(sessionId, mutationId, server.text, server.updatedAt);
+    } else {
+      this.localCache.writeClean(sessionId, server.text, server.updatedAt);
+    }
   }
 
   private observeInvalidation(sessionId: string): void {

--- a/ui/src/lib/sessionDraftPersistence.ts
+++ b/ui/src/lib/sessionDraftPersistence.ts
@@ -1,4 +1,8 @@
 export type SessionDraftSaveResult = { ok: boolean };
+export type SessionDraftRead = {
+  revision: number;
+  pending: boolean;
+};
 
 type DraftEntry = {
   revision: number;
@@ -16,6 +20,7 @@ type DraftSave = () => Promise<SessionDraftSaveResult>;
  */
 export class SessionDraftPersistence {
   private readonly entries = new Map<string, DraftEntry>();
+  private readonly activeReads = new Map<string, Set<SessionDraftRead>>();
 
   save(sessionId: string, text: string, write: DraftSave): Promise<SessionDraftSaveResult> {
     const previous = this.entries.get(sessionId);
@@ -42,7 +47,9 @@ export class SessionDraftPersistence {
       const current = this.entries.get(sessionId);
       if (current?.revision === revision) {
         if (result.ok) {
-          this.entries.delete(sessionId);
+          current.pending = null;
+          current.dirty = false;
+          if (!this.activeReads.has(sessionId)) this.entries.delete(sessionId);
         } else {
           current.pending = null;
           current.dirty = true;
@@ -55,30 +62,53 @@ export class SessionDraftPersistence {
     return pending;
   }
 
-  async waitForWrites(sessionId: string): Promise<void> {
-    while (true) {
-      const pending = this.entries.get(sessionId)?.pending;
-      if (!pending) return;
-      await pending;
-      if (this.entries.get(sessionId)?.pending !== pending) continue;
-      return;
-    }
+  beginRead(sessionId: string): SessionDraftRead {
+    const current = this.entries.get(sessionId);
+    const read: SessionDraftRead = {
+      revision: current?.revision ?? 0,
+      pending: Boolean(current?.pending),
+    };
+    const reads = this.activeReads.get(sessionId) ?? new Set<SessionDraftRead>();
+    reads.add(read);
+    this.activeReads.set(sessionId, reads);
+    return read;
+  }
+
+  releaseRead(sessionId: string, read: SessionDraftRead): void {
+    this.finishRead(sessionId, read);
+    this.cleanupSuccessfulEntry(sessionId);
   }
 
   revision(sessionId: string): number {
     return this.entries.get(sessionId)?.revision ?? 0;
   }
 
-  /**
-   * Prefer local text when a write failed or changed while the read was in
-   * flight. Once a clean write is known to predate the read, the server is the
-   * source of truth and the temporary entry can be retired.
-   */
-  reconcileRead(sessionId: string, readRevision: number, serverText: string): string {
+  reconcileRead(sessionId: string, read: SessionDraftRead, serverText: string): string {
     const current = this.entries.get(sessionId);
+    this.finishRead(sessionId, read);
     if (!current) return serverText;
-    if (current.revision > readRevision || current.pending || current.dirty) return current.text;
+    const localWins = read.pending || current.revision > read.revision || current.pending || current.dirty;
+    const text = localWins ? current.text : serverText;
+    this.cleanupSuccessfulEntry(sessionId);
+    return text;
+  }
+
+  clearSession(sessionId: string): void {
     this.entries.delete(sessionId);
-    return serverText;
+    this.activeReads.delete(sessionId);
+  }
+
+  private finishRead(sessionId: string, read: SessionDraftRead): void {
+    const reads = this.activeReads.get(sessionId);
+    if (!reads) return;
+    reads.delete(read);
+    if (!reads.size) this.activeReads.delete(sessionId);
+  }
+
+  private cleanupSuccessfulEntry(sessionId: string): void {
+    const current = this.entries.get(sessionId);
+    if (current && !current.pending && !current.dirty && !this.activeReads.has(sessionId)) {
+      this.entries.delete(sessionId);
+    }
   }
 }

--- a/ui/src/lib/sessionDraftPersistence.ts
+++ b/ui/src/lib/sessionDraftPersistence.ts
@@ -19,6 +19,7 @@ export type SessionDraftSaveResult = {
 export type SessionDraftRead = {
   revision: number;
   pending: boolean;
+  generation: number;
 };
 
 type DraftEntry = {
@@ -33,6 +34,10 @@ type DraftEntry = {
 };
 
 type DraftSave = (draft: SessionDraftWrite) => Promise<SessionDraftSaveResult>;
+type SessionDraftSave = (
+  sessionId: string,
+  draft: SessionDraftWrite,
+) => Promise<SessionDraftSaveResult>;
 
 /**
  * Keeps the latest draft available synchronously, serializes cloud writes per
@@ -44,6 +49,7 @@ export class SessionDraftPersistence {
   private readonly entries = new Map<string, DraftEntry>();
   private readonly activeReads = new Map<string, Set<SessionDraftRead>>();
   private readonly serverVersions = new Map<string, string | null>();
+  private readonly generations = new Map<string, number>();
   private readonly localCache: SessionDraftLocalCache;
 
   constructor(localCache = new SessionDraftLocalCache()) {
@@ -91,11 +97,25 @@ export class SessionDraftPersistence {
     return this.startSync(sessionId, current, write);
   }
 
+  retryAll(write: SessionDraftSave): Promise<SessionDraftSaveResult[]> {
+    const sessionIds = new Set(this.localCache.dirtySessionIds());
+    for (const [sessionId, entry] of this.entries) {
+      if (entry.dirty) sessionIds.add(sessionId);
+    }
+    return Promise.all(
+      [...sessionIds].map((sessionId) => this.retry(
+        sessionId,
+        (draft) => write(sessionId, draft),
+      )),
+    );
+  }
+
   beginRead(sessionId: string): SessionDraftRead {
     const current = this.hydrateDirty(sessionId);
     const read: SessionDraftRead = {
       revision: current?.revision ?? 0,
       pending: Boolean(current?.pending),
+      generation: this.generations.get(sessionId) ?? 0,
     };
     const reads = this.activeReads.get(sessionId) ?? new Set<SessionDraftRead>();
     reads.add(read);
@@ -119,6 +139,9 @@ export class SessionDraftPersistence {
   ): string {
     const current = this.entries.get(sessionId);
     this.finishRead(sessionId, read);
+    if (read.generation !== (this.generations.get(sessionId) ?? 0)) {
+      return '';
+    }
 
     // A write that finished after this read started is newer than the read's
     // response even though both have server revisions. Preserve that result
@@ -149,6 +172,7 @@ export class SessionDraftPersistence {
   }
 
   clearSession(sessionId: string): void {
+    this.generations.set(sessionId, (this.generations.get(sessionId) ?? 0) + 1);
     this.entries.delete(sessionId);
     this.activeReads.delete(sessionId);
     this.serverVersions.delete(sessionId);
@@ -249,16 +273,21 @@ export class SessionDraftPersistence {
 
   private hydrateDirty(sessionId: string): DraftEntry | null {
     const current = this.entries.get(sessionId);
-    if (current) return current;
     const cached = this.localCache.read(sessionId);
+    if (current && (!cached || cached.mutationId === current.localId)) return current;
+    if (current && cached && !cached.dirty) {
+      if (current.pending) return current;
+      this.entries.delete(sessionId);
+      return null;
+    }
     if (!cached?.dirty) return null;
     const hydrated: DraftEntry = {
-      revision: 1,
+      revision: (current?.revision ?? 0) + 1,
       text: cached.text,
       localId: cached.mutationId,
       baseUpdatedAt: cached.serverUpdatedAt,
-      pending: null,
-      pendingRevision: null,
+      pending: current?.pending ?? null,
+      pendingRevision: current?.pendingRevision ?? null,
       dirty: true,
       conflict: false,
     };

--- a/ui/src/lib/sessionDraftPersistence.ts
+++ b/ui/src/lib/sessionDraftPersistence.ts
@@ -14,6 +14,9 @@ export type SessionDraftSaveResult = {
   ok: boolean;
   conflict?: boolean;
   server?: SessionDraftServerState;
+  /** Retry one successor conflict only when the server contains this timed-out
+   *  predecessor, never when an unrelated device wrote instead. */
+  retryConflictIfServerText?: string;
 };
 
 export type SessionDraftRead = {
@@ -33,6 +36,7 @@ type DraftEntry = {
   conflict: boolean;
   localOwned: boolean;
   rebaseOnConflict: boolean;
+  rebaseOnConflictServerText?: string;
   serverEpoch: number;
 };
 
@@ -76,6 +80,7 @@ export class SessionDraftPersistence {
       baseUpdatedAt,
       current?.localOwned ? current.localId : undefined,
       current?.rebaseOnConflict ?? false,
+      current?.rebaseOnConflictServerText,
     );
     this.entries.set(sessionId, {
       revision: (current?.revision ?? 0) + 1,
@@ -90,6 +95,7 @@ export class SessionDraftPersistence {
       conflict: resolvesConflict ? false : current?.conflict ?? false,
       localOwned: true,
       rebaseOnConflict: current?.rebaseOnConflict ?? false,
+      rebaseOnConflictServerText: current?.rebaseOnConflictServerText,
       serverEpoch: current?.serverEpoch ?? 0,
     });
   }
@@ -227,6 +233,7 @@ export class SessionDraftPersistence {
     current.baseUpdatedAt = server.updatedAt;
     current.conflict = false;
     current.rebaseOnConflict = false;
+    current.rebaseOnConflictServerText = undefined;
     current.serverEpoch += 1;
     // The external revision is causally newer than every write already in
     // flight. Detach that promise chain; its eventual result is ignored by the
@@ -240,6 +247,7 @@ export class SessionDraftPersistence {
     const current = this.hydrateDirty(sessionId);
     if (!current) return;
     current.rebaseOnConflict = true;
+    current.rebaseOnConflictServerText = undefined;
     this.localCache.markRebaseOnConflict(sessionId, current.localId);
   }
 
@@ -265,11 +273,18 @@ export class SessionDraftPersistence {
       if (predecessorResult?.server) {
         beforeWrite.baseUpdatedAt = predecessorResult.server.updatedAt;
         beforeWrite.conflict = false;
-        beforeWrite.rebaseOnConflict = false;
+        beforeWrite.rebaseOnConflict = (
+          predecessorResult.retryConflictIfServerText !== undefined
+        );
+        beforeWrite.rebaseOnConflictServerText = (
+          predecessorResult.retryConflictIfServerText
+        );
         this.localCache.rebaseDirty(
           sessionId,
           beforeWrite.localId,
           predecessorResult.server.updatedAt,
+          beforeWrite.rebaseOnConflict,
+          beforeWrite.rebaseOnConflictServerText,
         );
       }
       if (predecessorResult?.conflict && !predecessorResult.server) {
@@ -303,7 +318,7 @@ export class SessionDraftPersistence {
         && result.server
         && beforeWrite.revision === revision
         && beforeWrite.serverEpoch === serverEpoch
-        && beforeWrite.rebaseOnConflict,
+        && this.matchesConflictRecovery(beforeWrite, result)
       );
       this.applyWriteResult(sessionId, revision, serverEpoch, result);
       if (shouldRetryRecoveredConflict) {
@@ -341,6 +356,7 @@ export class SessionDraftPersistence {
         current.dirty = false;
         current.conflict = false;
         current.rebaseOnConflict = false;
+        current.rebaseOnConflictServerText = undefined;
         current.baseUpdatedAt = server.updatedAt;
         this.localCache.acknowledge(
           sessionId,
@@ -362,22 +378,64 @@ export class SessionDraftPersistence {
       current.pending = null;
       current.pendingRevision = null;
     }
+    if (result.retryConflictIfServerText !== undefined && result.server) {
+      // No successor has to exist yet. Preserve this uncertainty on the current
+      // mutation so a later edit or a reload can recognize the timed-out write
+      // if it eventually commits and becomes the next conflict response.
+      current.baseUpdatedAt = result.server.updatedAt;
+      current.rebaseOnConflict = true;
+      current.rebaseOnConflictServerText = result.retryConflictIfServerText;
+      this.localCache.rebaseDirty(
+        sessionId,
+        current.localId,
+        result.server.updatedAt,
+        true,
+        result.retryConflictIfServerText,
+      );
+    }
     if (result.conflict) {
       if (result.server) this.serverVersions.set(sessionId, result.server.updatedAt);
       if (current.revision !== revision && result.server) {
         current.baseUpdatedAt = result.server.updatedAt;
         current.conflict = false;
         current.rebaseOnConflict = false;
+        current.rebaseOnConflictServerText = undefined;
         this.localCache.rebaseDirty(sessionId, current.localId, result.server.updatedAt, false);
-      } else if (current.rebaseOnConflict && result.server) {
+      } else if (
+        this.matchesConflictRecovery(current, result)
+        && result.server
+      ) {
         current.baseUpdatedAt = result.server.updatedAt;
         current.conflict = false;
         current.rebaseOnConflict = false;
+        current.rebaseOnConflictServerText = undefined;
         this.localCache.rebaseDirty(sessionId, current.localId, result.server.updatedAt, false);
       } else {
         current.conflict = true;
+        current.rebaseOnConflict = false;
+        current.rebaseOnConflictServerText = undefined;
+        this.localCache.rebaseDirty(
+          sessionId,
+          current.localId,
+          current.baseUpdatedAt,
+          false,
+        );
       }
     }
+  }
+
+  private matchesConflictRecovery(
+    entry: DraftEntry,
+    result: SessionDraftSaveResult,
+  ): boolean {
+    return Boolean(
+      entry.rebaseOnConflict
+      && result.server
+      && (
+        entry.rebaseOnConflictServerText === undefined
+        || result.server.text === entry.rebaseOnConflictServerText
+      )
+    );
   }
 
   private hydrateDirty(sessionId: string): DraftEntry | null {
@@ -406,6 +464,7 @@ export class SessionDraftPersistence {
       conflict: false,
       localOwned: false,
       rebaseOnConflict: cached.rebaseOnConflict ?? false,
+      rebaseOnConflictServerText: cached.rebaseOnConflictServerText,
       serverEpoch: current?.serverEpoch ?? 0,
     };
     this.entries.set(sessionId, hydrated);

--- a/ui/src/lib/sessionDraftPersistence.ts
+++ b/ui/src/lib/sessionDraftPersistence.ts
@@ -19,7 +19,7 @@ export type SessionDraftSaveResult = {
 export type SessionDraftRead = {
   revision: number;
   pending: boolean;
-  generation: number;
+  generation: string | null;
 };
 
 type DraftEntry = {
@@ -49,7 +49,7 @@ export class SessionDraftPersistence {
   private readonly entries = new Map<string, DraftEntry>();
   private readonly activeReads = new Map<string, Set<SessionDraftRead>>();
   private readonly serverVersions = new Map<string, string | null>();
-  private readonly generations = new Map<string, number>();
+  private readonly invalidations = new Map<string, string | null>();
   private readonly localCache: SessionDraftLocalCache;
 
   constructor(localCache = new SessionDraftLocalCache()) {
@@ -57,12 +57,16 @@ export class SessionDraftPersistence {
   }
 
   cache(sessionId: string, text: string): void {
+    this.observeInvalidation(sessionId);
     const current = this.entries.get(sessionId);
     const cached = this.localCache.read(sessionId);
-    const baseUpdatedAt = current?.baseUpdatedAt
-      ?? cached?.serverUpdatedAt
-      ?? this.serverVersions.get(sessionId)
-      ?? null;
+    const resolvesConflict = Boolean(current?.conflict && current.text !== text);
+    const baseUpdatedAt = resolvesConflict && this.serverVersions.has(sessionId)
+      ? this.serverVersions.get(sessionId)!
+      : current?.baseUpdatedAt
+        ?? cached?.serverUpdatedAt
+        ?? this.serverVersions.get(sessionId)
+        ?? null;
     const local = this.localCache.writeDirty(sessionId, text, baseUpdatedAt);
     this.entries.set(sessionId, {
       revision: (current?.revision ?? 0) + 1,
@@ -72,17 +76,21 @@ export class SessionDraftPersistence {
       pending: current?.pending ?? null,
       pendingRevision: current?.pendingRevision ?? null,
       dirty: true,
-      // Editing cannot resolve an already-observed version fork. Keep the
-      // automatic cloud writer stopped until an authoritative read converges.
-      conflict: current?.conflict ?? false,
+      // A new keystroke after a conflict is explicit user intent. Rebase that
+      // edit onto the revision returned by the conflict and resume CAS writes.
+      conflict: resolvesConflict ? false : current?.conflict ?? false,
     });
   }
 
   peek(sessionId: string): string | null {
+    this.observeInvalidation(sessionId);
+    const current = this.entries.get(sessionId);
+    if (current?.dirty) return current.text;
     return this.localCache.read(sessionId)?.text ?? null;
   }
 
   save(sessionId: string, text: string, write: DraftSave): Promise<SessionDraftSaveResult> {
+    this.observeInvalidation(sessionId);
     let current = this.entries.get(sessionId);
     if (!current || current.text !== text || !current.dirty) {
       this.cache(sessionId, text);
@@ -115,7 +123,7 @@ export class SessionDraftPersistence {
     const read: SessionDraftRead = {
       revision: current?.revision ?? 0,
       pending: Boolean(current?.pending),
-      generation: this.generations.get(sessionId) ?? 0,
+      generation: this.localCache.readInvalidation(sessionId),
     };
     const reads = this.activeReads.get(sessionId) ?? new Set<SessionDraftRead>();
     reads.add(read);
@@ -137,11 +145,14 @@ export class SessionDraftPersistence {
     read: SessionDraftRead,
     server: SessionDraftServerState,
   ): string {
-    const current = this.entries.get(sessionId);
     this.finishRead(sessionId, read);
-    if (read.generation !== (this.generations.get(sessionId) ?? 0)) {
+    const invalidation = this.localCache.readInvalidation(sessionId);
+    if (read.generation !== invalidation) {
+      this.discardInvalidatedSession(sessionId, invalidation);
       return '';
     }
+    this.invalidations.set(sessionId, invalidation);
+    const current = this.entries.get(sessionId);
 
     // A write that finished after this read started is newer than the read's
     // response even though both have server revisions. Preserve that result
@@ -172,7 +183,8 @@ export class SessionDraftPersistence {
   }
 
   clearSession(sessionId: string): void {
-    this.generations.set(sessionId, (this.generations.get(sessionId) ?? 0) + 1);
+    const invalidation = this.localCache.invalidate(sessionId);
+    this.invalidations.set(sessionId, invalidation);
     this.entries.delete(sessionId);
     this.activeReads.delete(sessionId);
     this.serverVersions.delete(sessionId);
@@ -272,8 +284,13 @@ export class SessionDraftPersistence {
   }
 
   private hydrateDirty(sessionId: string): DraftEntry | null {
+    this.observeInvalidation(sessionId);
     const current = this.entries.get(sessionId);
     const cached = this.localCache.read(sessionId);
+    // A live tab owns its unsynced mutation. Shared localStorage is recovery
+    // state for reloads and inactive tabs, not permission for one tab to replace
+    // another tab's composer while navigating.
+    if (current?.dirty) return current;
     if (current && (!cached || cached.mutationId === current.localId)) return current;
     if (current && cached && !cached.dirty) {
       if (current.pending) return current;
@@ -299,6 +316,24 @@ export class SessionDraftPersistence {
     this.serverVersions.set(sessionId, server.updatedAt);
     this.entries.delete(sessionId);
     this.localCache.writeClean(sessionId, server.text, server.updatedAt);
+  }
+
+  private observeInvalidation(sessionId: string): void {
+    const invalidation = this.localCache.readInvalidation(sessionId);
+    if (!this.invalidations.has(sessionId)) {
+      this.invalidations.set(sessionId, invalidation);
+      return;
+    }
+    if (this.invalidations.get(sessionId) === invalidation) return;
+    this.discardInvalidatedSession(sessionId, invalidation);
+  }
+
+  private discardInvalidatedSession(sessionId: string, invalidation: string | null): void {
+    this.invalidations.set(sessionId, invalidation);
+    this.entries.delete(sessionId);
+    this.activeReads.delete(sessionId);
+    this.serverVersions.delete(sessionId);
+    this.localCache.clear(sessionId);
   }
 
   private finishRead(sessionId: string, read: SessionDraftRead): void {

--- a/ui/src/lib/sessionDraftPersistence.ts
+++ b/ui/src/lib/sessionDraftPersistence.ts
@@ -1,4 +1,21 @@
-export type SessionDraftSaveResult = { ok: boolean };
+import { SessionDraftLocalCache } from './sessionDraftLocalCache';
+
+export type SessionDraftServerState = {
+  text: string;
+  updatedAt: string | null;
+};
+
+export type SessionDraftWrite = {
+  text: string;
+  expectedUpdatedAt: string | null;
+};
+
+export type SessionDraftSaveResult = {
+  ok: boolean;
+  conflict?: boolean;
+  server?: SessionDraftServerState;
+};
+
 export type SessionDraftRead = {
   revision: number;
   pending: boolean;
@@ -7,63 +24,75 @@ export type SessionDraftRead = {
 type DraftEntry = {
   revision: number;
   text: string;
+  localId: string;
+  baseUpdatedAt: string | null;
   pending: Promise<SessionDraftSaveResult> | null;
+  pendingRevision: number | null;
   dirty: boolean;
+  conflict: boolean;
 };
 
-type DraftSave = () => Promise<SessionDraftSaveResult>;
+type DraftSave = (draft: SessionDraftWrite) => Promise<SessionDraftSaveResult>;
 
 /**
- * Serializes per-session draft writes and closes the read-after-write gap that
- * appears when navigation remounts ChatPage before its fire-and-forget PUT
- * finishes. The latest text stays available for a read that raced a write.
+ * Keeps the latest draft available synchronously, serializes cloud writes per
+ * session, and reconciles reads against the server revision each local edit was
+ * based on. A real version conflict preserves the local text without silently
+ * overwriting the other device's newer cloud draft.
  */
 export class SessionDraftPersistence {
   private readonly entries = new Map<string, DraftEntry>();
   private readonly activeReads = new Map<string, Set<SessionDraftRead>>();
+  private readonly serverVersions = new Map<string, string | null>();
+  private readonly localCache: SessionDraftLocalCache;
+
+  constructor(localCache = new SessionDraftLocalCache()) {
+    this.localCache = localCache;
+  }
+
+  cache(sessionId: string, text: string): void {
+    const current = this.entries.get(sessionId);
+    const cached = this.localCache.read(sessionId);
+    const baseUpdatedAt = current?.baseUpdatedAt
+      ?? cached?.serverUpdatedAt
+      ?? this.serverVersions.get(sessionId)
+      ?? null;
+    const local = this.localCache.writeDirty(sessionId, text, baseUpdatedAt);
+    this.entries.set(sessionId, {
+      revision: (current?.revision ?? 0) + 1,
+      text,
+      localId: local.mutationId,
+      baseUpdatedAt,
+      pending: current?.pending ?? null,
+      pendingRevision: current?.pendingRevision ?? null,
+      dirty: true,
+      // Editing cannot resolve an already-observed version fork. Keep the
+      // automatic cloud writer stopped until an authoritative read converges.
+      conflict: current?.conflict ?? false,
+    });
+  }
+
+  peek(sessionId: string): string | null {
+    return this.localCache.read(sessionId)?.text ?? null;
+  }
 
   save(sessionId: string, text: string, write: DraftSave): Promise<SessionDraftSaveResult> {
-    const previous = this.entries.get(sessionId);
-    const revision = (previous?.revision ?? 0) + 1;
-    const entry: DraftEntry = {
-      revision,
-      text,
-      pending: null,
-      dirty: true,
-    };
-    const predecessor = previous?.pending;
-    const pending = (async (): Promise<SessionDraftSaveResult> => {
-      await predecessor?.catch(() => undefined);
-      // A newer edit superseded this write while it was waiting. Its successor
-      // carries this promise as the predecessor and will write the latest text.
-      if (this.entries.get(sessionId)?.revision !== revision) return { ok: true };
+    let current = this.entries.get(sessionId);
+    if (!current || current.text !== text || !current.dirty) {
+      this.cache(sessionId, text);
+      current = this.entries.get(sessionId)!;
+    }
+    return this.startSync(sessionId, current, write);
+  }
 
-      let result: SessionDraftSaveResult;
-      try {
-        result = await write();
-      } catch {
-        result = { ok: false };
-      }
-      const current = this.entries.get(sessionId);
-      if (current?.revision === revision) {
-        if (result.ok) {
-          current.pending = null;
-          current.dirty = false;
-          if (!this.activeReads.has(sessionId)) this.entries.delete(sessionId);
-        } else {
-          current.pending = null;
-          current.dirty = true;
-        }
-      }
-      return result;
-    })();
-    entry.pending = pending;
-    this.entries.set(sessionId, entry);
-    return pending;
+  retry(sessionId: string, write: DraftSave): Promise<SessionDraftSaveResult> {
+    const current = this.hydrateDirty(sessionId);
+    if (!current) return Promise.resolve({ ok: true });
+    return this.startSync(sessionId, current, write);
   }
 
   beginRead(sessionId: string): SessionDraftRead {
-    const current = this.entries.get(sessionId);
+    const current = this.hydrateDirty(sessionId);
     const read: SessionDraftRead = {
       revision: current?.revision ?? 0,
       pending: Boolean(current?.pending),
@@ -83,19 +112,164 @@ export class SessionDraftPersistence {
     return this.entries.get(sessionId)?.revision ?? 0;
   }
 
-  reconcileRead(sessionId: string, read: SessionDraftRead, serverText: string): string {
+  reconcileRead(
+    sessionId: string,
+    read: SessionDraftRead,
+    server: SessionDraftServerState,
+  ): string {
     const current = this.entries.get(sessionId);
     this.finishRead(sessionId, read);
-    if (!current) return serverText;
-    const localWins = read.pending || current.revision > read.revision || current.pending || current.dirty;
-    const text = localWins ? current.text : serverText;
+
+    // A write that finished after this read started is newer than the read's
+    // response even though both have server revisions. Preserve that result
+    // until every racing read has reconciled.
+    if (current && (read.pending || current.revision > read.revision || current.pending)) {
+      this.cleanupSuccessfulEntry(sessionId);
+      return current.text;
+    }
+
+    const cached = this.localCache.read(sessionId);
+    const dirty = current?.dirty ? current : cached?.dirty ? this.hydrateDirty(sessionId) : null;
+    if (dirty) {
+      if (dirty.text === server.text) {
+        this.acceptServer(sessionId, server);
+        return server.text;
+      }
+
+      this.serverVersions.set(sessionId, server.updatedAt);
+      if (dirty.baseUpdatedAt !== server.updatedAt) {
+        dirty.conflict = true;
+      }
+      return dirty.text;
+    }
+
+    this.acceptServer(sessionId, server);
     this.cleanupSuccessfulEntry(sessionId);
-    return text;
+    return server.text;
   }
 
   clearSession(sessionId: string): void {
     this.entries.delete(sessionId);
     this.activeReads.delete(sessionId);
+    this.serverVersions.delete(sessionId);
+    this.localCache.clear(sessionId);
+  }
+
+  private startSync(
+    sessionId: string,
+    entry: DraftEntry,
+    write: DraftSave,
+  ): Promise<SessionDraftSaveResult> {
+    if (entry.conflict) return Promise.resolve({ ok: false, conflict: true });
+    if (entry.pending && entry.pendingRevision === entry.revision) return entry.pending;
+
+    const predecessor = entry.pending;
+    const revision = entry.revision;
+    const text = entry.text;
+    const pending = (async (): Promise<SessionDraftSaveResult> => {
+      const predecessorResult: SessionDraftSaveResult | undefined = await predecessor?.catch(
+        (): SessionDraftSaveResult => ({ ok: false }),
+      );
+      const beforeWrite = this.entries.get(sessionId);
+      if (!beforeWrite || beforeWrite.revision !== revision) return { ok: true };
+      if (beforeWrite.conflict || predecessorResult?.conflict) {
+        beforeWrite.pending = null;
+        beforeWrite.pendingRevision = null;
+        beforeWrite.conflict = true;
+        return { ok: false, conflict: true, server: predecessorResult?.server };
+      }
+
+      let result: SessionDraftSaveResult;
+      try {
+        result = await write({ text, expectedUpdatedAt: beforeWrite.baseUpdatedAt });
+      } catch {
+        result = { ok: false };
+      }
+
+      // The cloud may already contain this exact text because another write
+      // (notably the send transaction clearing a draft) won the race. That is
+      // convergence, not a user-visible conflict.
+      if (result.conflict && result.server?.text === text) {
+        result = { ok: true, server: result.server };
+      }
+      this.applyWriteResult(sessionId, revision, result);
+      return result;
+    })();
+
+    entry.pending = pending;
+    entry.pendingRevision = revision;
+    return pending;
+  }
+
+  private applyWriteResult(
+    sessionId: string,
+    revision: number,
+    result: SessionDraftSaveResult,
+  ): void {
+    const current = this.entries.get(sessionId);
+    if (!current) return;
+
+    if (result.ok) {
+      const server = result.server ?? {
+        text: current.text,
+        updatedAt: current.baseUpdatedAt,
+      };
+      this.serverVersions.set(sessionId, server.updatedAt);
+      if (current.revision === revision) {
+        current.pending = null;
+        current.pendingRevision = null;
+        current.dirty = false;
+        current.conflict = false;
+        current.baseUpdatedAt = server.updatedAt;
+        this.localCache.acknowledge(
+          sessionId,
+          current.localId,
+          server.text,
+          server.updatedAt,
+        );
+        this.cleanupSuccessfulEntry(sessionId);
+      } else if (current.dirty && !current.conflict) {
+        // A newer edit was made while this request was in flight. Advance only
+        // that exact local mutation's cloud base before its serialized write.
+        current.baseUpdatedAt = server.updatedAt;
+        this.localCache.rebaseDirty(sessionId, current.localId, server.updatedAt);
+      }
+      return;
+    }
+
+    if (current.revision === revision) {
+      current.pending = null;
+      current.pendingRevision = null;
+    }
+    if (result.conflict) {
+      current.conflict = true;
+      if (result.server) this.serverVersions.set(sessionId, result.server.updatedAt);
+    }
+  }
+
+  private hydrateDirty(sessionId: string): DraftEntry | null {
+    const current = this.entries.get(sessionId);
+    if (current) return current;
+    const cached = this.localCache.read(sessionId);
+    if (!cached?.dirty) return null;
+    const hydrated: DraftEntry = {
+      revision: 1,
+      text: cached.text,
+      localId: cached.mutationId,
+      baseUpdatedAt: cached.serverUpdatedAt,
+      pending: null,
+      pendingRevision: null,
+      dirty: true,
+      conflict: false,
+    };
+    this.entries.set(sessionId, hydrated);
+    return hydrated;
+  }
+
+  private acceptServer(sessionId: string, server: SessionDraftServerState): void {
+    this.serverVersions.set(sessionId, server.updatedAt);
+    this.entries.delete(sessionId);
+    this.localCache.writeClean(sessionId, server.text, server.updatedAt);
   }
 
   private finishRead(sessionId: string, read: SessionDraftRead): void {

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -8922,6 +8922,7 @@ def sessions_draft_set(session_id: str):
     """Upsert the session's draft (debounced from the composer). Blank clears it."""
     from core.services import sessions as workbench_sessions_service
     from storage import message_deliveries
+    from storage.agent_session_rows import reserve_write_lock
 
     payload = request.json or {}
     text = payload.get("text")
@@ -8932,6 +8933,10 @@ def sessions_draft_set(session_id: str):
     engine = _projects_engine()
     try:
         with engine.begin() as conn:
+            # The version read and its update are one CAS decision. Reserving
+            # SQLite's writer slot before either read prevents a concurrent
+            # commit from turning this transaction's snapshot into BUSY_SNAPSHOT.
+            reserve_write_lock(conn)
             session = workbench_sessions_service.get_session(conn, session_id)
             # Archive is terminal: drop a late/debounced draft save (e.g. the
             # composer flushing as it unmounts right after archive) so it can't

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -6785,7 +6785,7 @@ async def sessions_bootstrap(session_id: str):
         from storage import message_deliveries
 
         queued = message_deliveries.list_queued(conn, session_id)
-        draft = message_deliveries.get_draft(conn, session_id)
+        draft = message_deliveries.get_draft_state(conn, session_id)
 
     try:
         agents_payload = vibe_api.get_vibe_agents(include_disabled=False, include_archived=True)
@@ -6829,7 +6829,7 @@ async def sessions_bootstrap(session_id: str):
             "next_after_id": messages_result.get("next_after_id"),
             "next_before_id": messages_result.get("next_before_id"),
             "queued": queued,
-            "draft": {"text": (draft or {}).get("text") or ""},
+            "draft": _session_draft_payload(draft),
             "turn_state": turn_state,
         }
     )
@@ -8899,6 +8899,13 @@ async def sessions_queue_send_now(session_id: str, message_id: str):
     return jsonify(body), status
 
 
+def _session_draft_payload(draft: dict | None) -> dict:
+    return {
+        "text": (draft or {}).get("text") or "",
+        "updated_at": (draft or {}).get("updated_at"),
+    }
+
+
 @app.route("/api/sessions/<session_id>/draft", methods=["GET"])
 def sessions_draft_get(session_id: str):
     """The session's saved unsent compose text (restored on open / device switch)."""
@@ -8906,8 +8913,8 @@ def sessions_draft_get(session_id: str):
 
     engine = _projects_engine()
     with engine.connect() as conn:
-        draft = message_deliveries.get_draft(conn, session_id)
-    return jsonify({"text": (draft or {}).get("text") or ""})
+        draft = message_deliveries.get_draft_state(conn, session_id)
+    return jsonify(_session_draft_payload(draft))
 
 
 @app.route("/api/sessions/<session_id>/draft", methods=["PUT"])
@@ -8918,6 +8925,10 @@ def sessions_draft_set(session_id: str):
 
     payload = request.json or {}
     text = payload.get("text")
+    expected_supplied = "expected_updated_at" in payload
+    expected_updated_at = payload.get("expected_updated_at")
+    if expected_supplied and expected_updated_at is not None and not isinstance(expected_updated_at, str):
+        return jsonify({"ok": False, "code": "invalid_expected_updated_at"}), 400
     engine = _projects_engine()
     try:
         with engine.begin() as conn:
@@ -8926,15 +8937,26 @@ def sessions_draft_set(session_id: str):
             # composer flushing as it unmounts right after archive) so it can't
             # recreate a draft on a session whose drafts were just reclaimed.
             if session.get("status") == "archived":
-                return jsonify({"ok": True})
+                current = message_deliveries.get_draft_state(conn, session_id)
+                return jsonify({"ok": True, "draft": _session_draft_payload(current)})
+            current = message_deliveries.get_draft_state(conn, session_id)
+            if expected_supplied and (current or {}).get("updated_at") != expected_updated_at:
+                return jsonify(
+                    {
+                        "ok": False,
+                        "code": "draft_conflict",
+                        "draft": _session_draft_payload(current),
+                    }
+                ), 409
             message_deliveries.set_draft(
                 conn,
                 session_id,
                 text if isinstance(text, str) else None,
             )
+            saved = message_deliveries.get_draft_state(conn, session_id)
     except LookupError as err:
         return jsonify({"error": str(err)}), 404
-    return jsonify({"ok": True})
+    return jsonify({"ok": True, "draft": _session_draft_payload(saved)})
 
 
 @app.route("/api/events", methods=["GET"])

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -8613,8 +8613,12 @@ async def sessions_messages_create(session_id: str):
             )
             if not quick_reply_for:
                 message_deliveries.set_draft(conn, session_id, None)
+            draft = message_deliveries.get_draft_state(conn, session_id)
             workbench_sessions_service.touch_session(conn, session_id)
-        return message_deliveries.delivery_payload(row)
+        result = message_deliveries.delivery_payload(row)
+        result["draft"] = _session_draft_payload(draft)
+        result["draft_advanced"] = not bool(quick_reply_for)
+        return result
 
     # Reserve the row FIRST (pending), then decide by the dispatch outcome.
     message = _persist_user_row()
@@ -8662,6 +8666,8 @@ async def sessions_messages_create(session_id: str):
         if current is None:
             return dict(message)
         payload = message_deliveries.delivery_payload(current)
+        payload["draft"] = message["draft"]
+        payload["draft_advanced"] = message["draft_advanced"]
         if current["state"] == "queued":
             payload["type"] = "queued"
             payload["queued"] = True
@@ -8744,7 +8750,14 @@ async def sessions_messages_create(session_id: str):
                         "dispatch_error": "dispatch_pending",
                     }
                 ), 502
-            return jsonify({**accepted, **body}), 201
+            return jsonify(
+                {
+                    **accepted,
+                    **body,
+                    "draft": message["draft"],
+                    "draft_advanced": message["draft_advanced"],
+                }
+            ), 201
         return jsonify({**current, **body}), 202
     current = _retire_unclaimed_delivery(f"internal_dispatch_rejected_{status}")
     return jsonify(
@@ -8945,7 +8958,11 @@ def sessions_draft_set(session_id: str):
                 current = message_deliveries.get_draft_state(conn, session_id)
                 return jsonify({"ok": True, "draft": _session_draft_payload(current)})
             current = message_deliveries.get_draft_state(conn, session_id)
-            if expected_supplied and (current or {}).get("updated_at") != expected_updated_at:
+            current_updated_at = (current or {}).get("updated_at")
+            if (
+                (not expected_supplied and current_updated_at is not None)
+                or (expected_supplied and current_updated_at != expected_updated_at)
+            ):
                 return jsonify(
                     {
                         "ok": False,


### PR DESCRIPTION
## Capability

Preserve unsent chat drafts across navigation, reloads, slow requests, and temporary network loss without letting stale local or cloud state silently overwrite newer work.

## Root cause

ChatPage only scheduled a debounced server write. Navigation could race that fire-and-forget PUT, offline writes had no durable browser fallback, and unconditional cloud writes could complete out of order or recreate text after another device had cleared the draft.

## Concurrency model

- The server draft revision is the single causal clock for cross-device synchronization.
- A server revision returned by an accepted send supersedes every older in-flight client write; delayed results from the previous client epoch are ignored.
- Each local mutation is independently durable. Synchronizing the selected winner acknowledges an ordering frontier and retires only mutations at or before that frontier, while preserving newer concurrent writes.
- A timed-out write records a one-shot expected server-text marker. A successor rebases only if the conflicting server text is that exact predecessor; unrelated device writes remain conflicts.
- A server draft with an established revision rejects revisionless writes. Missing `expected_updated_at` remains compatible only while the server state is still revisionless.

## Change

- Write every composer edit synchronously to a versioned, per-session localStorage record; keep cloud writes debounced.
- Serialize cloud writes per session, bound each cloud write, reconcile the authoritative server revision after a timeout, and retain the newest successful revision as a read barrier until every older response settles.
- Return the exact post-reservation draft revision with accepted message responses. Rebase text typed while the send was in flight onto that revision before any navigation guard, and ignore delayed writes from the superseded epoch.
- Recover a rejected send for its original session before applying page-staleness guards. Treat archive rejection as terminal through the shared API convergence path, so it clears that session without restoring retryable text.
- Expose the server draft revision and use compare-and-set writes so stale or revisionless clients receive a conflict instead of overwriting newer cloud text or clears; reserve SQLite's writer slot before the CAS read and update.
- Store each tab's dirty mutation under an independent key, acknowledge the selected mutation frontier, and keep clean server snapshots separate so one tab cannot overwrite another tab's concurrent local text.
- Retry every dirty session both on visible provider mount and when connectivity returns; preserve live tab ownership when another tab has a newer recovery record.
- Preserve true conflicts without overwriting the cloud draft. A subsequent edit resolves a normal conflict, while rejected-send and bounded timeout recovery markers rebase and retry once without another keystroke, including after reload.
- Persist per-session archive invalidation tokens across tabs, prefer the newer process-local token if persistence fails, and clear local state on archive without letting stale reads recreate reclaimed text.

Scenario catalog: this repository has no draft-specific scenario IDs.

## Evidence

- Unit: added local cache enumeration, offline recovery, initial and reconnect replay, bounded stalled writes, authoritative timeout reconciliation, ordered and out-of-order read/write races, cloud conflict recovery, accepted-send and rejected-send rebasing, navigation-time send recovery, terminal archive convergence, reload recovery, CAS lock ordering, live-tab mutation ownership, mutation-frontier acknowledgement, archive invalidation, storage-write failure, and corrupted storage coverage.
- Contract: draft GET/bootstrap return `updated_at`; draft PUT uses `expected_updated_at` for compare-and-set and returns `409 draft_conflict` with the current server draft for stale writes or revisionless writes against versioned state. Message reservation responses identify whether they advanced the draft and include the exact resulting draft revision.
- Scenario: full UI suite passed (143 files, 1715 tests); the affected backend route suite passed (62 tests).
- Residual manual check: type while offline in multiple sessions, switch chats, reconnect, and confirm every draft remains and syncs. Repeat with a second browser/device changing or clearing the same draft while the first client is offline.

## Validation

- UI tests, production build, TypeScript project build, and lint baseline passed.
- Affected Python suite and ruff passed on the last backend-changing head; this review round changes UI draft convergence only.

No new dependencies.
