### PR TITLE
fix(workbench): order session reads against session.activity

### DIFF
--- a/ui/src/context/WorkbenchInboxProvider.tsx
+++ b/ui/src/context/WorkbenchInboxProvider.tsx
@@ -87,13 +87,43 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
   // neither operation owns the full top-of-feed snapshot requested by refresh.
   const refreshRetryPendingRef = useRef(false);
   const reconcileRetryPendingRef = useRef(false);
+  const cursorReadsInFlightRef = useRef(0);
+  const refreshRetryRunnerRef = useRef<() => void>(() => {});
+  const reconcileRetryRunnerRef = useRef<() => void>(() => {});
+  const reconcileSessionRef = useRef<(sessionId: string) => void>(() => {});
   const refreshLoadingGenerationRef = useRef(0);
   const loadMoreLoadingGenerationRef = useRef(0);
   // Targeted foreground restores own one session independently from the
   // windowed feed. Keep their latest committed values so a later whole-feed
   // replacement cannot erase a restored card merely because the row sorts
-  // outside the page.
+  // outside the page; a later broad omission revalidates them by exact id.
   const targetedSnapshotsRef = useRef<Map<string, TargetedInboxSnapshot>>(new Map());
+
+  const flushBroadReadRetry = useCallback(() => {
+    if (cursorReadsInFlightRef.current > 0) return;
+    if (refreshRetryPendingRef.current) {
+      refreshRetryPendingRef.current = false;
+      // A replacement refresh owns the same top-of-feed recovery as a pending
+      // reconcile, so one authoritative read satisfies both intents.
+      reconcileRetryPendingRef.current = false;
+      refreshRetryRunnerRef.current();
+      return;
+    }
+    if (reconcileRetryPendingRef.current) {
+      reconcileRetryPendingRef.current = false;
+      reconcileRetryRunnerRef.current();
+    }
+  }, []);
+
+  const queueRefreshRetry = useCallback(() => {
+    refreshRetryPendingRef.current = true;
+    queueMicrotask(flushBroadReadRetry);
+  }, [flushBroadReadRetry]);
+
+  const queueReconcileRetry = useCallback(() => {
+    reconcileRetryPendingRef.current = true;
+    queueMicrotask(flushBroadReadRetry);
+  }, [flushBroadReadRetry]);
 
   const acceptSessionMutation = useCallback((sessionId: string) => {
     readOwnershipRef.current.acceptMutation([
@@ -138,6 +168,7 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
   }, []);
 
   const acceptFeedRows = useCallback((read: WorkbenchSessionReadStamp, rows: InboxSession[]) => {
+    const returnedIds = new Set(rows.map((row) => row.session_id));
     for (const row of rows) {
       const resource = `inbox-session:${row.session_id}`;
       readOwnershipRef.current.claimRead(read, resource);
@@ -145,9 +176,14 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
         targetedSnapshotsRef.current.delete(row.session_id);
       }
     }
+    return Array.from(targetedSnapshotsRef.current.entries())
+      .filter(([sessionId, snapshot]) => snapshot.row && !returnedIds.has(sessionId))
+      .map(([sessionId]) => sessionId);
   }, []);
 
   const refresh = useCallback(async function refresh() {
+    refreshRetryPendingRef.current = false;
+    reconcileRetryPendingRef.current = false;
     const read = readOwnershipRef.current.beginRead(['inbox-feed', 'inbox-unread', 'inbox-feed-refresh']);
     const loadingGeneration = ++refreshLoadingGenerationRef.current;
     const retryAfterInvalidation = () => {
@@ -166,11 +202,7 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
       ) {
         return false;
       }
-      refreshRetryPendingRef.current = true;
-      queueMicrotask(() => {
-        refreshRetryPendingRef.current = false;
-        void refresh();
-      });
+      queueRefreshRetry();
       return true;
     };
     setLoading(true);
@@ -180,9 +212,10 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
       if (!feedCurrent) {
         retryAfterInvalidation();
       } else {
-        acceptFeedRows(read, result.sessions);
+        const snapshotsToRevalidate = acceptFeedRows(read, result.sessions);
         setInboxSessions(() => mergeTargetedSnapshots(result.sessions));
         setNextCursor(result.next_cursor);
+        for (const sessionId of snapshotsToRevalidate) reconcileSessionRef.current(sessionId);
       }
       if (readOwnershipRef.current.isCurrent(read, 'inbox-unread')) {
         applyUnreadMap(result.unread_by_session ?? {});
@@ -192,12 +225,13 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
     } finally {
       if (refreshLoadingGenerationRef.current === loadingGeneration) setLoading(false);
     }
-  }, [acceptFeedRows, api, applyUnreadMap, mergeTargetedSnapshots]);
+  }, [acceptFeedRows, api, applyUnreadMap, mergeTargetedSnapshots, queueRefreshRetry]);
 
   const loadMore = useCallback(async function loadMore() {
     const cursor = cursorRef.current;
     if (!cursor) return;
     const read = readOwnershipRef.current.beginRead(['inbox-feed', 'inbox-feed-cursor']);
+    cursorReadsInFlightRef.current += 1;
     const loadingGeneration = ++loadMoreLoadingGenerationRef.current;
     let retryAfterInvalidation = false;
     setLoadingMore(true);
@@ -215,10 +249,12 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
         readOwnershipRef.current.isLatestRead(read);
       if (!retryAfterInvalidation) console.error('[inbox] load more failed', err);
     } finally {
+      cursorReadsInFlightRef.current -= 1;
       if (loadMoreLoadingGenerationRef.current === loadingGeneration) setLoadingMore(false);
       if (retryAfterInvalidation) queueMicrotask(() => void loadMore());
+      else flushBroadReadRetry();
     }
-  }, [api]);
+  }, [api, flushBroadReadRetry]);
 
   const markRead = useCallback(
     async (sessionId: string, untilMessageId?: string) => {
@@ -256,6 +292,7 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
   // that arrived during the gap surface at top. No loading flag — the user
   // already has content; this is a silent catch-up.
   const reconcile = useCallback(async () => {
+    reconcileRetryPendingRef.current = false;
     const read = readOwnershipRef.current.beginRead(['inbox-feed', 'inbox-unread', 'inbox-feed-reconcile']);
     const retryAfterInvalidation = () => {
       const invalidatedByMutation = !readOwnershipRef.current.isMutationCurrent(read, 'inbox-feed');
@@ -273,11 +310,7 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
       ) {
         return false;
       }
-      reconcileRetryPendingRef.current = true;
-      queueMicrotask(() => {
-        reconcileRetryPendingRef.current = false;
-        void reconcile();
-      });
+      queueReconcileRetry();
       return true;
     };
     // Snapshot loaded ids up front: sizes the re-read window, and lets us tell
@@ -299,7 +332,7 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
       if (!feedCurrent || supersededByCursorRead || supersededByReconcileRead) {
         retryAfterInvalidation();
       } else {
-        acceptFeedRows(read, result.sessions);
+        const snapshotsToRevalidate = acceptFeedRows(read, result.sessions);
         setInboxSessions((prev) => {
           const incoming = new Map(result.sessions.map((s) => [s.session_id, s]));
           const merged = prev.map((s) => incoming.get(s.session_id) ?? s);
@@ -308,6 +341,7 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
           merged.sort(byActivityDesc);
           return mergeTargetedSnapshots(merged);
         });
+        for (const sessionId of snapshotsToRevalidate) reconcileSessionRef.current(sessionId);
         // Cursor: the loaded feed is always a contiguous run from the top, and
         // this reads the newest `limit` rows. If the read shares ANY row with what
         // we had (overlap), the two runs are contiguous — no gap below the read —
@@ -326,7 +360,7 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
     } catch (err) {
       if (!retryAfterInvalidation()) console.error('[inbox] reconcile failed', err);
     }
-  }, [acceptFeedRows, api, applyUnreadMap, mergeTargetedSnapshots]);
+  }, [acceptFeedRows, api, applyUnreadMap, mergeTargetedSnapshots, queueReconcileRetry]);
 
   // Targeted reconcile for one session (contract A6 foreground restore): fetch
   // that exact session by id and upsert its card, so a restored session
@@ -375,6 +409,9 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
     },
     [api],
   );
+  refreshRetryRunnerRef.current = () => void refresh();
+  reconcileRetryRunnerRef.current = () => void reconcile();
+  reconcileSessionRef.current = (sessionId) => void reconcileSession(sessionId);
 
   useEffect(() => {
     // First mount loads page one; every later rerun reconciles the loaded window

--- a/ui/src/context/WorkbenchInboxProvider.tsx
+++ b/ui/src/context/WorkbenchInboxProvider.tsx
@@ -83,11 +83,12 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
   // Every Inbox read shares one ordering fence. This covers page-one refresh,
   // cursor reads, resume reconcile, and the targeted foreground-restore read.
   const readOwnershipRef = useRef(createWorkbenchSessionReadOwnership());
-  // Broad reads and cursor reads both own the feed. Preserve broad intents while
-  // a cursor request is active so either start order commits the requested page
-  // before the broad refresh/reconcile runs.
+  // Broad reads and cursor reads both own the feed. Run only one broad read at a
+  // time and preserve trailing intents while it or a cursor request is active,
+  // so a later failed duplicate cannot discard an earlier successful recovery.
   const refreshPendingRef = useRef(false);
   const reconcilePendingRef = useRef(false);
+  const broadReadInFlightRef = useRef(false);
   const cursorReadsInFlightRef = useRef(0);
   const refreshRunnerRef = useRef<() => void>(() => {});
   const reconcileRunnerRef = useRef<() => void>(() => {});
@@ -101,7 +102,7 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
   const targetedSnapshotsRef = useRef<Map<string, TargetedInboxSnapshot>>(new Map());
 
   const flushBroadReadIntent = useCallback(() => {
-    if (cursorReadsInFlightRef.current > 0) return;
+    if (broadReadInFlightRef.current || cursorReadsInFlightRef.current > 0) return;
     if (refreshPendingRef.current) {
       refreshPendingRef.current = false;
       // A replacement refresh owns the same top-of-feed recovery as a pending
@@ -183,10 +184,11 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
   }, []);
 
   const refresh = useCallback(async function refresh() {
-    if (cursorReadsInFlightRef.current > 0) {
+    if (broadReadInFlightRef.current || cursorReadsInFlightRef.current > 0) {
       queueRefreshIntent();
       return;
     }
+    broadReadInFlightRef.current = true;
     refreshPendingRef.current = false;
     reconcilePendingRef.current = false;
     const read = readOwnershipRef.current.beginRead(['inbox-feed', 'inbox-unread', 'inbox-feed-refresh']);
@@ -229,8 +231,10 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
       if (!retryAfterInvalidation()) console.error('[inbox] refresh failed', err);
     } finally {
       if (refreshLoadingGenerationRef.current === loadingGeneration) setLoading(false);
+      broadReadInFlightRef.current = false;
+      flushBroadReadIntent();
     }
-  }, [acceptFeedRows, api, applyUnreadMap, mergeTargetedSnapshots, queueRefreshIntent]);
+  }, [acceptFeedRows, api, applyUnreadMap, flushBroadReadIntent, mergeTargetedSnapshots, queueRefreshIntent]);
 
   const loadMore = useCallback(async function loadMore() {
     const cursor = cursorRef.current;
@@ -297,10 +301,11 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
   // that arrived during the gap surface at top. No loading flag — the user
   // already has content; this is a silent catch-up.
   const reconcile = useCallback(async () => {
-    if (cursorReadsInFlightRef.current > 0) {
+    if (broadReadInFlightRef.current || cursorReadsInFlightRef.current > 0) {
       queueReconcileIntent();
       return;
     }
+    broadReadInFlightRef.current = true;
     reconcilePendingRef.current = false;
     const read = readOwnershipRef.current.beginRead(['inbox-feed', 'inbox-unread', 'inbox-feed-reconcile']);
     const retryAfterInvalidation = () => {
@@ -368,8 +373,11 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
       }
     } catch (err) {
       if (!retryAfterInvalidation()) console.error('[inbox] reconcile failed', err);
+    } finally {
+      broadReadInFlightRef.current = false;
+      flushBroadReadIntent();
     }
-  }, [acceptFeedRows, api, applyUnreadMap, mergeTargetedSnapshots, queueReconcileIntent]);
+  }, [acceptFeedRows, api, applyUnreadMap, flushBroadReadIntent, mergeTargetedSnapshots, queueReconcileIntent]);
 
   // Targeted reconcile for one session (contract A6 foreground restore): fetch
   // that exact session by id and upsert its card, so a restored session

--- a/ui/src/context/WorkbenchInboxProvider.tsx
+++ b/ui/src/context/WorkbenchInboxProvider.tsx
@@ -83,13 +83,14 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
   // Every Inbox read shares one ordering fence. This covers page-one refresh,
   // cursor reads, resume reconcile, and the targeted foreground-restore read.
   const readOwnershipRef = useRef(createWorkbenchSessionReadOwnership());
-  // A stale refresh cannot be replaced by an event patch or cursor page alone:
-  // neither operation owns the full top-of-feed snapshot requested by refresh.
-  const refreshRetryPendingRef = useRef(false);
-  const reconcileRetryPendingRef = useRef(false);
+  // Broad reads and cursor reads both own the feed. Preserve broad intents while
+  // a cursor request is active so either start order commits the requested page
+  // before the broad refresh/reconcile runs.
+  const refreshPendingRef = useRef(false);
+  const reconcilePendingRef = useRef(false);
   const cursorReadsInFlightRef = useRef(0);
-  const refreshRetryRunnerRef = useRef<() => void>(() => {});
-  const reconcileRetryRunnerRef = useRef<() => void>(() => {});
+  const refreshRunnerRef = useRef<() => void>(() => {});
+  const reconcileRunnerRef = useRef<() => void>(() => {});
   const reconcileSessionRef = useRef<(sessionId: string) => void>(() => {});
   const refreshLoadingGenerationRef = useRef(0);
   const loadMoreLoadingGenerationRef = useRef(0);
@@ -99,31 +100,31 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
   // outside the page; a later broad omission revalidates them by exact id.
   const targetedSnapshotsRef = useRef<Map<string, TargetedInboxSnapshot>>(new Map());
 
-  const flushBroadReadRetry = useCallback(() => {
+  const flushBroadReadIntent = useCallback(() => {
     if (cursorReadsInFlightRef.current > 0) return;
-    if (refreshRetryPendingRef.current) {
-      refreshRetryPendingRef.current = false;
+    if (refreshPendingRef.current) {
+      refreshPendingRef.current = false;
       // A replacement refresh owns the same top-of-feed recovery as a pending
       // reconcile, so one authoritative read satisfies both intents.
-      reconcileRetryPendingRef.current = false;
-      refreshRetryRunnerRef.current();
+      reconcilePendingRef.current = false;
+      refreshRunnerRef.current();
       return;
     }
-    if (reconcileRetryPendingRef.current) {
-      reconcileRetryPendingRef.current = false;
-      reconcileRetryRunnerRef.current();
+    if (reconcilePendingRef.current) {
+      reconcilePendingRef.current = false;
+      reconcileRunnerRef.current();
     }
   }, []);
 
-  const queueRefreshRetry = useCallback(() => {
-    refreshRetryPendingRef.current = true;
-    queueMicrotask(flushBroadReadRetry);
-  }, [flushBroadReadRetry]);
+  const queueRefreshIntent = useCallback(() => {
+    refreshPendingRef.current = true;
+    queueMicrotask(flushBroadReadIntent);
+  }, [flushBroadReadIntent]);
 
-  const queueReconcileRetry = useCallback(() => {
-    reconcileRetryPendingRef.current = true;
-    queueMicrotask(flushBroadReadRetry);
-  }, [flushBroadReadRetry]);
+  const queueReconcileIntent = useCallback(() => {
+    reconcilePendingRef.current = true;
+    queueMicrotask(flushBroadReadIntent);
+  }, [flushBroadReadIntent]);
 
   const acceptSessionMutation = useCallback((sessionId: string) => {
     readOwnershipRef.current.acceptMutation([
@@ -182,8 +183,12 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
   }, []);
 
   const refresh = useCallback(async function refresh() {
-    refreshRetryPendingRef.current = false;
-    reconcileRetryPendingRef.current = false;
+    if (cursorReadsInFlightRef.current > 0) {
+      queueRefreshIntent();
+      return;
+    }
+    refreshPendingRef.current = false;
+    reconcilePendingRef.current = false;
     const read = readOwnershipRef.current.beginRead(['inbox-feed', 'inbox-unread', 'inbox-feed-refresh']);
     const loadingGeneration = ++refreshLoadingGenerationRef.current;
     const retryAfterInvalidation = () => {
@@ -198,11 +203,11 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
         (!invalidatedByMutation && !supersededByCursorRead) ||
         supersededByRefresh ||
         supersededByReconcile ||
-        refreshRetryPendingRef.current
+        refreshPendingRef.current
       ) {
         return false;
       }
-      queueRefreshRetry();
+      queueRefreshIntent();
       return true;
     };
     setLoading(true);
@@ -225,7 +230,7 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
     } finally {
       if (refreshLoadingGenerationRef.current === loadingGeneration) setLoading(false);
     }
-  }, [acceptFeedRows, api, applyUnreadMap, mergeTargetedSnapshots, queueRefreshRetry]);
+  }, [acceptFeedRows, api, applyUnreadMap, mergeTargetedSnapshots, queueRefreshIntent]);
 
   const loadMore = useCallback(async function loadMore() {
     const cursor = cursorRef.current;
@@ -252,9 +257,9 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
       cursorReadsInFlightRef.current -= 1;
       if (loadMoreLoadingGenerationRef.current === loadingGeneration) setLoadingMore(false);
       if (retryAfterInvalidation) queueMicrotask(() => void loadMore());
-      else flushBroadReadRetry();
+      else flushBroadReadIntent();
     }
-  }, [api, flushBroadReadRetry]);
+  }, [api, flushBroadReadIntent]);
 
   const markRead = useCallback(
     async (sessionId: string, untilMessageId?: string) => {
@@ -292,7 +297,11 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
   // that arrived during the gap surface at top. No loading flag — the user
   // already has content; this is a silent catch-up.
   const reconcile = useCallback(async () => {
-    reconcileRetryPendingRef.current = false;
+    if (cursorReadsInFlightRef.current > 0) {
+      queueReconcileIntent();
+      return;
+    }
+    reconcilePendingRef.current = false;
     const read = readOwnershipRef.current.beginRead(['inbox-feed', 'inbox-unread', 'inbox-feed-reconcile']);
     const retryAfterInvalidation = () => {
       const invalidatedByMutation = !readOwnershipRef.current.isMutationCurrent(read, 'inbox-feed');
@@ -306,11 +315,11 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
         (!invalidatedByMutation && !supersededByCursorRead) ||
         supersededByRefresh ||
         supersededByReconcileRead ||
-        reconcileRetryPendingRef.current
+        reconcilePendingRef.current
       ) {
         return false;
       }
-      queueReconcileRetry();
+      queueReconcileIntent();
       return true;
     };
     // Snapshot loaded ids up front: sizes the re-read window, and lets us tell
@@ -360,7 +369,7 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
     } catch (err) {
       if (!retryAfterInvalidation()) console.error('[inbox] reconcile failed', err);
     }
-  }, [acceptFeedRows, api, applyUnreadMap, mergeTargetedSnapshots, queueReconcileRetry]);
+  }, [acceptFeedRows, api, applyUnreadMap, mergeTargetedSnapshots, queueReconcileIntent]);
 
   // Targeted reconcile for one session (contract A6 foreground restore): fetch
   // that exact session by id and upsert its card, so a restored session
@@ -409,8 +418,8 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
     },
     [api],
   );
-  refreshRetryRunnerRef.current = () => void refresh();
-  reconcileRetryRunnerRef.current = () => void reconcile();
+  refreshRunnerRef.current = () => void refresh();
+  reconcileRunnerRef.current = () => void reconcile();
   reconcileSessionRef.current = (sessionId) => void reconcileSession(sessionId);
 
   useEffect(() => {

--- a/ui/src/context/WorkbenchInboxProvider.tsx
+++ b/ui/src/context/WorkbenchInboxProvider.tsx
@@ -6,7 +6,10 @@ import type { InboxSession } from './ApiContext';
 import { WorkbenchInboxContext, type InboxState } from './WorkbenchInboxContext';
 import { sessionActivityInboxAction } from '../lib/inboxActivity';
 import { syncFaviconBadge } from '../lib/faviconBadge';
-import { createWorkbenchSessionReadOwnership } from '../lib/workbenchSessionReadOwnership';
+import {
+  createWorkbenchSessionReadOwnership,
+  type WorkbenchSessionReadStamp,
+} from '../lib/workbenchSessionReadOwnership';
 
 const PAGE_SIZE = 30;
 
@@ -37,7 +40,6 @@ const appendPage = (prev: InboxSession[], page: InboxSession[]): InboxSession[] 
 
 type TargetedInboxSnapshot = {
   row: InboxSession | null;
-  unreadCount: number;
 };
 
 /** Provider that owns the Inbox state shared across WorkbenchSidebar + InboxPage.
@@ -91,12 +93,21 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
   const loadMoreLoadingGenerationRef = useRef(0);
   // Targeted foreground restores own one session independently from the
   // windowed feed. Keep their latest committed values so a later whole-feed
-  // replacement cannot erase a restored card or unread count merely because
-  // the row sorts outside the page.
+  // replacement cannot erase a restored card merely because the row sorts
+  // outside the page.
   const targetedSnapshotsRef = useRef<Map<string, TargetedInboxSnapshot>>(new Map());
 
-  const acceptSessionMutation = useCallback(() => {
-    readOwnershipRef.current.acceptMutation();
+  const acceptSessionMutation = useCallback((sessionId: string) => {
+    readOwnershipRef.current.acceptMutation([
+      'inbox-feed',
+      'inbox-unread',
+      `inbox-session:${sessionId}`,
+      `inbox-unread-session:${sessionId}`,
+    ]);
+  }, []);
+
+  const acceptUnreadMutation = useCallback(() => {
+    readOwnershipRef.current.acceptMutation(['inbox-unread', 'inbox-unread-all']);
   }, []);
 
   // One home for "an authoritative unread map arrived": set the map and flip
@@ -108,18 +119,6 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
     setUnreadLoaded(true);
   }, []);
 
-  const applyFeedUnreadMap = useCallback(
-    (map: Record<string, number>) => {
-      const next = { ...map };
-      for (const [sessionId, snapshot] of targetedSnapshotsRef.current) {
-        if (snapshot.unreadCount > 0) next[sessionId] = snapshot.unreadCount;
-        else delete next[sessionId];
-      }
-      applyUnreadMap(next);
-    },
-    [applyUnreadMap],
-  );
-
   const mergeTargetedSnapshots = useCallback((rows: InboxSession[]): InboxSession[] => {
     let next = rows;
     for (const [sessionId, snapshot] of targetedSnapshotsRef.current) {
@@ -130,13 +129,24 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
     return next;
   }, []);
 
+  const acceptFeedRows = useCallback((read: WorkbenchSessionReadStamp, rows: InboxSession[]) => {
+    for (const row of rows) {
+      const resource = `inbox-session:${row.session_id}`;
+      readOwnershipRef.current.claimRead(read, resource);
+      if (readOwnershipRef.current.isCurrent(read, resource)) {
+        targetedSnapshotsRef.current.delete(row.session_id);
+      }
+    }
+  }, []);
+
   const refresh = useCallback(async () => {
-    const read = readOwnershipRef.current.beginRead(['inbox-feed', 'inbox-feed-refresh']);
+    const read = readOwnershipRef.current.beginRead(['inbox-feed', 'inbox-unread', 'inbox-feed-refresh']);
     const loadingGeneration = ++refreshLoadingGenerationRef.current;
     setLoading(true);
     try {
       const result = await api.listInbox({ platform: 'avibe', limit: PAGE_SIZE });
-      if (!readOwnershipRef.current.isCurrent(read)) {
+      const feedCurrent = readOwnershipRef.current.isCurrent(read, 'inbox-feed');
+      if (!feedCurrent) {
         if (!authoritativeFeedLoadedRef.current && !coldRefreshRetryPendingRef.current) {
           coldRefreshRetryPendingRef.current = true;
           queueMicrotask(() => {
@@ -144,48 +154,59 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
             if (!authoritativeFeedLoadedRef.current) void refresh();
           });
         }
-        return;
+      } else {
+        acceptFeedRows(read, result.sessions);
+        setInboxSessions(() => mergeTargetedSnapshots(result.sessions));
+        setNextCursor(result.next_cursor);
+        authoritativeFeedLoadedRef.current = true;
       }
-      setInboxSessions(() => mergeTargetedSnapshots(result.sessions));
-      setNextCursor(result.next_cursor);
-      applyFeedUnreadMap(result.unread_by_session ?? {});
-      authoritativeFeedLoadedRef.current = true;
+      if (readOwnershipRef.current.isCurrent(read, 'inbox-unread')) {
+        applyUnreadMap(result.unread_by_session ?? {});
+      }
     } catch (err) {
       console.error('[inbox] refresh failed', err);
     } finally {
       if (refreshLoadingGenerationRef.current === loadingGeneration) setLoading(false);
     }
-  }, [api, applyFeedUnreadMap, mergeTargetedSnapshots]);
+  }, [acceptFeedRows, api, applyUnreadMap, mergeTargetedSnapshots]);
 
-  const loadMore = useCallback(async () => {
+  const loadMore = useCallback(async function loadMore() {
     const cursor = cursorRef.current;
     if (!cursor) return;
     const read = readOwnershipRef.current.beginRead(['inbox-feed', 'inbox-feed-cursor']);
     const loadingGeneration = ++loadMoreLoadingGenerationRef.current;
+    let retryAfterInvalidation = false;
     setLoadingMore(true);
     try {
       const result = await api.listInbox({ platform: 'avibe', limit: PAGE_SIZE, before: cursor });
-      if (!readOwnershipRef.current.isCurrent(read)) return;
+      if (!readOwnershipRef.current.isCurrent(read, 'inbox-feed')) {
+        retryAfterInvalidation = readOwnershipRef.current.isLatestRead(read);
+        return;
+      }
       setInboxSessions((prev) => appendPage(prev, result.sessions));
       setNextCursor(result.next_cursor);
     } catch (err) {
-      console.error('[inbox] load more failed', err);
+      retryAfterInvalidation =
+        !readOwnershipRef.current.isCurrent(read, 'inbox-feed') &&
+        readOwnershipRef.current.isLatestRead(read);
+      if (!retryAfterInvalidation) console.error('[inbox] load more failed', err);
     } finally {
       if (loadMoreLoadingGenerationRef.current === loadingGeneration) setLoadingMore(false);
+      if (retryAfterInvalidation) queueMicrotask(() => void loadMore());
     }
   }, [api]);
 
   const markRead = useCallback(
     async (sessionId: string, untilMessageId?: string) => {
+      const read = readOwnershipRef.current.beginRead('inbox-unread');
       const result = await api.markSessionRead(sessionId, untilMessageId);
-      targetedSnapshotsRef.current.delete(sessionId);
-      acceptSessionMutation();
+      if (!readOwnershipRef.current.isCurrent(read, 'inbox-unread')) return;
       // The unread map is authoritative for badges; the card's unread styling
       // derives from it, so clearing here clears the dot without touching the
       // feed order (a read doesn't change last activity).
       applyUnreadMap(result.unread_by_session ?? {});
     },
-    [acceptSessionMutation, api, applyUnreadMap],
+    [api, applyUnreadMap],
   );
 
   // Resume reconcile: re-read the feed WITHOUT collapsing pagination. A
@@ -196,7 +217,7 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
   // that arrived during the gap surface at top. No loading flag — the user
   // already has content; this is a silent catch-up.
   const reconcile = useCallback(async () => {
-    const read = readOwnershipRef.current.beginRead(['inbox-feed', 'inbox-feed-reconcile']);
+    const read = readOwnershipRef.current.beginRead(['inbox-feed', 'inbox-unread', 'inbox-feed-reconcile']);
     // Snapshot loaded ids up front: sizes the re-read window, and lets us tell
     // afterward whether the read overlapped what we already had (cursor note).
     const loadedIds = new Set(inboxSessionsRef.current.map((s) => s.session_id));
@@ -208,15 +229,15 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
         cache: false,
         handleError: false,
       });
-      const stale = !readOwnershipRef.current.isCurrent(read) || !readOwnershipRef.current.isLatestRead(read);
-      const invalidatedByMutation = readOwnershipRef.current.epoch() !== read.epoch;
+      const feedCurrent = readOwnershipRef.current.isCurrent(read, 'inbox-feed');
+      const invalidatedByMutation = !readOwnershipRef.current.isMutationCurrent(read, 'inbox-feed');
       const supersededByCursorRead =
         (readOwnershipRef.current.latestGeneration('inbox-feed-cursor') ?? 0) > read.generation;
       const supersededByReconcileRead =
         (readOwnershipRef.current.latestGeneration('inbox-feed-reconcile') ?? 0) > read.generation;
       const supersededByRefresh =
         (readOwnershipRef.current.latestGeneration('inbox-feed-refresh') ?? 0) > read.generation;
-      if (stale || supersededByCursorRead || supersededByReconcileRead) {
+      if (!feedCurrent || supersededByCursorRead || supersededByReconcileRead) {
         if (
           (invalidatedByMutation || supersededByCursorRead) &&
           !supersededByRefresh &&
@@ -229,43 +250,48 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
             void reconcile();
           });
         }
-        return;
+      } else {
+        acceptFeedRows(read, result.sessions);
+        setInboxSessions((prev) => {
+          const incoming = new Map(result.sessions.map((s) => [s.session_id, s]));
+          const merged = prev.map((s) => incoming.get(s.session_id) ?? s);
+          const have = new Set(prev.map((s) => s.session_id));
+          for (const s of result.sessions) if (!have.has(s.session_id)) merged.push(s);
+          merged.sort(byActivityDesc);
+          return mergeTargetedSnapshots(merged);
+        });
+        authoritativeFeedLoadedRef.current = true;
+        // Cursor: the loaded feed is always a contiguous run from the top, and
+        // this reads the newest `limit` rows. If the read shares ANY row with what
+        // we had (overlap), the two runs are contiguous — no gap below the read —
+        // so the existing cursor still marks the boundary; leave it untouched
+        // (this is what stops a >100-row exhausted feed from resurrecting a
+        // duplicate-page "Load more"). If the read is ENTIRELY new rows (no
+        // overlap), gap arrivals outnumbered the window and there are unseen rows
+        // between this read and the old feed — adopt result.next_cursor so "Load
+        // more" can page through them (loadMore dedupes the overlap).
+        const overlap = result.sessions.some((s) => loadedIds.has(s.session_id));
+        if (!overlap) setNextCursor(result.next_cursor);
       }
-      setInboxSessions((prev) => {
-        const incoming = new Map(result.sessions.map((s) => [s.session_id, s]));
-        const merged = prev.map((s) => incoming.get(s.session_id) ?? s);
-        const have = new Set(prev.map((s) => s.session_id));
-        for (const s of result.sessions) if (!have.has(s.session_id)) merged.push(s);
-        merged.sort(byActivityDesc);
-        return mergeTargetedSnapshots(merged);
-      });
-      // Whole-account unread map (not paginated) — always authoritative.
-      applyFeedUnreadMap(result.unread_by_session ?? {});
-      authoritativeFeedLoadedRef.current = true;
-      // Cursor: the loaded feed is always a contiguous run from the top, and
-      // this reads the newest `limit` rows. If the read shares ANY row with what
-      // we had (overlap), the two runs are contiguous — no gap below the read —
-      // so the existing cursor still marks the boundary; leave it untouched
-      // (this is what stops a >100-row exhausted feed from resurrecting a
-      // duplicate-page "Load more"). If the read is ENTIRELY new rows (no
-      // overlap), gap arrivals outnumbered the window and there are unseen rows
-      // between this read and the old feed — adopt result.next_cursor so "Load
-      // more" can page through them (loadMore dedupes the overlap).
-      const overlap = result.sessions.some((s) => loadedIds.has(s.session_id));
-      if (!overlap) setNextCursor(result.next_cursor);
+      if (readOwnershipRef.current.isCurrent(read, 'inbox-unread')) {
+        applyUnreadMap(result.unread_by_session ?? {});
+      }
     } catch (err) {
       console.error('[inbox] reconcile failed', err);
     }
-  }, [api, applyFeedUnreadMap, mergeTargetedSnapshots]);
+  }, [acceptFeedRows, api, applyUnreadMap, mergeTargetedSnapshots]);
 
   // Targeted reconcile for one session (contract A6 foreground restore): fetch
   // that exact session by id and upsert its card, so a restored session
   // reappears even when its activity sorts past the windowed reconcile()'s
   // newest-N rows. The response still carries the pagination-independent
-  // whole-account unread map, so refresh that too. Never touches the cursor.
+  // whole-account unread map, but this read owns only this session's count.
+  // Never touches the cursor or replaces unrelated unread state.
   const reconcileSession = useCallback(
     async (sessionId: string) => {
-      const read = readOwnershipRef.current.beginRead(`inbox-session:${sessionId}`);
+      const sessionResource = `inbox-session:${sessionId}`;
+      const unreadResource = `inbox-unread-session:${sessionId}`;
+      const read = readOwnershipRef.current.beginRead([sessionResource, unreadResource]);
       try {
         const result = await api.listInbox({
           platform: 'avibe',
@@ -275,20 +301,32 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
           handleError: false,
         });
         const row = result.sessions.find((s) => s.session_id === sessionId);
-        if (!readOwnershipRef.current.isCurrent(read)) return;
-        targetedSnapshotsRef.current.set(sessionId, {
-          row: row ?? null,
-          unreadCount: result.unread_by_session?.[sessionId] ?? 0,
-        });
-        setInboxSessions((prev) =>
-          row ? upsertSession(prev, row) : prev.filter((candidate) => candidate.session_id !== sessionId),
-        );
-        applyUnreadMap(result.unread_by_session ?? {});
+        if (readOwnershipRef.current.isCurrent(read, sessionResource)) {
+          targetedSnapshotsRef.current.set(sessionId, { row: row ?? null });
+          setInboxSessions((prev) =>
+            row ? upsertSession(prev, row) : prev.filter((candidate) => candidate.session_id !== sessionId),
+          );
+        }
+        const newerWholeUnreadRead =
+          (readOwnershipRef.current.latestGeneration('inbox-unread') ?? 0) > read.generation;
+        if (
+          readOwnershipRef.current.isCurrent(read, unreadResource) &&
+          readOwnershipRef.current.isMutationCurrent(read, 'inbox-unread-all') &&
+          !newerWholeUnreadRead
+        ) {
+          const unreadCount = result.unread_by_session?.[sessionId] ?? 0;
+          setUnreadBySession((prev) => {
+            const next = { ...prev };
+            if (unreadCount > 0) next[sessionId] = unreadCount;
+            else delete next[sessionId];
+            return next;
+          });
+        }
       } catch (err) {
         console.error('[inbox] reconcileSession failed', err);
       }
     },
-    [api, applyUnreadMap],
+    [api],
   );
 
   useEffect(() => {
@@ -307,7 +345,7 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
     const disconnect = api.connectWorkbenchEvents({
       onInboxSessionUpdated: (row) => {
         targetedSnapshotsRef.current.delete(row.session_id);
-        acceptSessionMutation();
+        acceptSessionMutation(row.session_id);
         setInboxSessions((prev) => upsertSession(prev, row));
         setUnreadBySession((prev) => {
           if ((prev[row.session_id] ?? 0) === row.unread_count) return prev;
@@ -318,8 +356,7 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
         });
       },
       onInboxUnreadChanged: (data) => {
-        targetedSnapshotsRef.current.clear();
-        acceptSessionMutation();
+        acceptUnreadMutation();
         if (data?.unread_by_session) {
           applyUnreadMap(data.unread_by_session);
         }
@@ -333,13 +370,13 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
         const action = sessionActivityInboxAction(data);
         if (action === 'reconcile') {
           targetedSnapshotsRef.current.delete(data.session_id);
-          acceptSessionMutation();
+          acceptSessionMutation(data.session_id);
           void reconcileSession(data.session_id);
           return;
         }
         if (action === 'ignore') return;
         targetedSnapshotsRef.current.delete(data.session_id);
-        acceptSessionMutation();
+        acceptSessionMutation(data.session_id);
         // action === 'drop': remove the card + its unread live, instead of
         // waiting for the next reconnect/refresh to filter it.
         setInboxSessions((prev) => prev.filter((s) => s.session_id !== data.session_id));
@@ -357,7 +394,7 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
       },
     });
     return disconnect;
-  }, [acceptSessionMutation, api, refresh, reconcile, reconcileSession, applyUnreadMap]);
+  }, [acceptSessionMutation, acceptUnreadMutation, api, refresh, reconcile, reconcileSession, applyUnreadMap]);
 
   // Recover after the OS suspended us. A backgrounded mobile PWA has its page
   // frozen and its SSE socket dropped, and the broker never replays the gap;

--- a/ui/src/context/WorkbenchInboxProvider.tsx
+++ b/ui/src/context/WorkbenchInboxProvider.tsx
@@ -32,8 +32,10 @@ const upsertSession = (list: InboxSession[], row: InboxSession): InboxSession[] 
 };
 
 const appendPage = (prev: InboxSession[], page: InboxSession[]): InboxSession[] => {
-  const seen = new Set(prev.map((s) => s.session_id));
-  const merged = prev.concat(page.filter((s) => !seen.has(s.session_id)));
+  const incoming = new Map(page.map((row) => [row.session_id, row]));
+  const merged = prev.map((row) => incoming.get(row.session_id) ?? row);
+  const seen = new Set(prev.map((row) => row.session_id));
+  for (const row of page) if (!seen.has(row.session_id)) merged.push(row);
   merged.sort(byActivityDesc);
   return merged;
 };
@@ -109,6 +111,9 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
   // replacement cannot erase a restored card merely because the row sorts
   // outside the page; a later broad omission revalidates them by exact id.
   const targetedSnapshotsRef = useRef<Map<string, TargetedInboxSnapshot>>(new Map());
+  const targetedReadInFlightRef = useRef<Set<string>>(new Set());
+  const targetedReadPendingRef = useRef<Set<string>>(new Set());
+  const committedWholeUnreadGenerationRef = useRef(0);
 
   const flushFeedReadIntent = useCallback(() => {
     if (broadReadInFlightRef.current || cursorReadsInFlightRef.current > 0) return;
@@ -168,6 +173,17 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
     setUnreadLoaded(true);
   }, []);
 
+  const applyWholeUnreadRead = useCallback((
+    read: WorkbenchSessionReadStamp,
+    map: Record<string, number>,
+  ) => {
+    committedWholeUnreadGenerationRef.current = Math.max(
+      committedWholeUnreadGenerationRef.current,
+      read.generation,
+    );
+    applyUnreadMap(map);
+  }, [applyUnreadMap]);
+
   const applySessionUnread = useCallback((sessionId: string, count: number) => {
     setUnreadBySession((prev) => {
       const next = { ...prev };
@@ -188,18 +204,30 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
     return next;
   }, []);
 
-  const acceptFeedRows = useCallback((read: WorkbenchSessionReadStamp, rows: InboxSession[]) => {
+  const acceptFeedRows = useCallback((
+    read: WorkbenchSessionReadStamp,
+    rows: InboxSession[],
+    revalidateOmissions = false,
+  ) => {
     const returnedIds = new Set(rows.map((row) => row.session_id));
     for (const row of rows) {
       const resource = `inbox-session:${row.session_id}`;
       readOwnershipRef.current.claimRead(read, resource);
       if (readOwnershipRef.current.isCurrent(read, resource)) {
         targetedSnapshotsRef.current.delete(row.session_id);
+        targetedReadPendingRef.current.delete(row.session_id);
       }
     }
-    return Array.from(targetedSnapshotsRef.current.entries())
-      .filter(([sessionId, snapshot]) => snapshot.row && !returnedIds.has(sessionId))
-      .map(([sessionId]) => sessionId);
+    if (!revalidateOmissions) return [];
+    const omitted = new Set(
+      Array.from(targetedSnapshotsRef.current.entries())
+        .filter(([sessionId, snapshot]) => snapshot.row && !returnedIds.has(sessionId))
+        .map(([sessionId]) => sessionId),
+    );
+    for (const sessionId of targetedReadInFlightRef.current) {
+      if (!returnedIds.has(sessionId)) omitted.add(sessionId);
+    }
+    return Array.from(omitted);
   }, []);
 
   const refresh = useCallback(async function refresh() {
@@ -238,13 +266,13 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
       if (!feedCurrent) {
         retryAfterInvalidation();
       } else {
-        const snapshotsToRevalidate = acceptFeedRows(read, result.sessions);
+        const snapshotsToRevalidate = acceptFeedRows(read, result.sessions, true);
         setInboxSessions(() => mergeTargetedSnapshots(result.sessions));
         applyNextCursor(result.next_cursor);
         for (const sessionId of snapshotsToRevalidate) reconcileSessionRef.current(sessionId);
       }
       if (readOwnershipRef.current.isCurrent(read, 'inbox-unread')) {
-        applyUnreadMap(result.unread_by_session ?? {});
+        applyWholeUnreadRead(read, result.unread_by_session ?? {});
       }
     } catch (err) {
       if (!retryAfterInvalidation()) console.error('[inbox] refresh failed', err);
@@ -253,7 +281,7 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
       broadReadInFlightRef.current = false;
       flushFeedReadIntent();
     }
-  }, [acceptFeedRows, api, applyNextCursor, applyUnreadMap, flushFeedReadIntent, mergeTargetedSnapshots, queueRefreshIntent]);
+  }, [acceptFeedRows, api, applyNextCursor, applyWholeUnreadRead, flushFeedReadIntent, mergeTargetedSnapshots, queueRefreshIntent]);
 
   const loadMore = useCallback(async function loadMore() {
     if (
@@ -281,7 +309,8 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
         retryAfterInvalidation = readOwnershipRef.current.isLatestRead(read);
         return;
       }
-      setInboxSessions((prev) => appendPage(prev, result.sessions));
+      acceptFeedRows(read, result.sessions);
+      setInboxSessions((prev) => mergeTargetedSnapshots(appendPage(prev, result.sessions)));
       applyNextCursor(result.next_cursor);
     } catch (err) {
       retryAfterInvalidation =
@@ -294,7 +323,7 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
       if (retryAfterInvalidation) queueLoadMoreIntent();
       else flushFeedReadIntent();
     }
-  }, [api, applyNextCursor, flushFeedReadIntent, queueLoadMoreIntent]);
+  }, [acceptFeedRows, api, applyNextCursor, flushFeedReadIntent, mergeTargetedSnapshots, queueLoadMoreIntent]);
 
   const markRead = useCallback(
     async (sessionId: string, untilMessageId?: string) => {
@@ -381,7 +410,7 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
       if (!feedCurrent || supersededByCursorRead || supersededByReconcileRead) {
         retryAfterInvalidation();
       } else {
-        const snapshotsToRevalidate = acceptFeedRows(read, result.sessions);
+        const snapshotsToRevalidate = acceptFeedRows(read, result.sessions, true);
         setInboxSessions((prev) => {
           const incoming = new Map(result.sessions.map((s) => [s.session_id, s]));
           const merged = prev.map((s) => incoming.get(s.session_id) ?? s);
@@ -404,7 +433,7 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
         if (!overlap) applyNextCursor(result.next_cursor);
       }
       if (readOwnershipRef.current.isCurrent(read, 'inbox-unread')) {
-        applyUnreadMap(result.unread_by_session ?? {});
+        applyWholeUnreadRead(read, result.unread_by_session ?? {});
       }
     } catch (err) {
       if (!retryAfterInvalidation()) console.error('[inbox] reconcile failed', err);
@@ -412,7 +441,7 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
       broadReadInFlightRef.current = false;
       flushFeedReadIntent();
     }
-  }, [acceptFeedRows, api, applyNextCursor, applyUnreadMap, flushFeedReadIntent, mergeTargetedSnapshots, queueReconcileIntent]);
+  }, [acceptFeedRows, api, applyNextCursor, applyWholeUnreadRead, flushFeedReadIntent, mergeTargetedSnapshots, queueReconcileIntent]);
 
   // Targeted reconcile for one session (contract A6 foreground restore): fetch
   // that exact session by id and upsert its card, so a restored session
@@ -422,44 +451,58 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
   // Never touches the cursor or replaces unrelated unread state.
   const reconcileSession = useCallback(
     async (sessionId: string) => {
-      const sessionResource = `inbox-session:${sessionId}`;
-      const unreadResource = `inbox-unread-session:${sessionId}`;
-      const read = readOwnershipRef.current.beginRead([sessionResource, unreadResource]);
+      if (targetedReadInFlightRef.current.has(sessionId)) {
+        targetedReadPendingRef.current.add(sessionId);
+        return;
+      }
+      targetedReadInFlightRef.current.add(sessionId);
       try {
-        const result = await api.listInbox({
-          platform: 'avibe',
-          onlySession: sessionId,
-          limit: 1,
-          cache: false,
-          handleError: false,
-        });
-        const row = result.sessions.find((s) => s.session_id === sessionId);
-        if (readOwnershipRef.current.isCurrent(read, sessionResource)) {
-          targetedSnapshotsRef.current.set(sessionId, { row: row ?? null });
-          setInboxSessions((prev) =>
-            row ? upsertSession(prev, row) : prev.filter((candidate) => candidate.session_id !== sessionId),
-          );
+        while (true) {
+          targetedReadPendingRef.current.delete(sessionId);
+          const sessionResource = `inbox-session:${sessionId}`;
+          const unreadResource = `inbox-unread-session:${sessionId}`;
+          const read = readOwnershipRef.current.beginRead([sessionResource, unreadResource]);
+          try {
+            const result = await api.listInbox({
+              platform: 'avibe',
+              onlySession: sessionId,
+              limit: 1,
+              cache: false,
+              handleError: false,
+            });
+            const supersededByPendingIntent = targetedReadPendingRef.current.has(sessionId);
+            const row = result.sessions.find((s) => s.session_id === sessionId);
+            if (
+              !supersededByPendingIntent &&
+              readOwnershipRef.current.isCurrent(read, sessionResource)
+            ) {
+              targetedSnapshotsRef.current.set(sessionId, { row: row ?? null });
+              setInboxSessions((prev) =>
+                row
+                  ? upsertSession(prev, row)
+                  : prev.filter((candidate) => candidate.session_id !== sessionId),
+              );
+            }
+            const newerCommittedWholeUnread =
+              committedWholeUnreadGenerationRef.current > read.generation;
+            if (
+              !supersededByPendingIntent &&
+              readOwnershipRef.current.isCurrent(read, unreadResource) &&
+              readOwnershipRef.current.isMutationCurrent(read, 'inbox-unread-all') &&
+              !newerCommittedWholeUnread
+            ) {
+              applySessionUnread(sessionId, result.unread_by_session?.[sessionId] ?? 0);
+            }
+          } catch (err) {
+            console.error('[inbox] reconcileSession failed', err);
+          }
+          if (!targetedReadPendingRef.current.has(sessionId)) return;
         }
-        const newerWholeUnreadRead =
-          (readOwnershipRef.current.latestGeneration('inbox-unread') ?? 0) > read.generation;
-        if (
-          readOwnershipRef.current.isCurrent(read, unreadResource) &&
-          readOwnershipRef.current.isMutationCurrent(read, 'inbox-unread-all') &&
-          !newerWholeUnreadRead
-        ) {
-          const unreadCount = result.unread_by_session?.[sessionId] ?? 0;
-          setUnreadBySession((prev) => {
-            const next = { ...prev };
-            if (unreadCount > 0) next[sessionId] = unreadCount;
-            else delete next[sessionId];
-            return next;
-          });
-        }
-      } catch (err) {
-        console.error('[inbox] reconcileSession failed', err);
+      } finally {
+        targetedReadInFlightRef.current.delete(sessionId);
       }
     },
-    [api],
+    [api, applySessionUnread],
   );
   refreshRunnerRef.current = () => void refresh();
   reconcileRunnerRef.current = () => void reconcile();

--- a/ui/src/context/WorkbenchInboxProvider.tsx
+++ b/ui/src/context/WorkbenchInboxProvider.tsx
@@ -71,6 +71,13 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
   // without re-creating its identity (and the context value) on every page.
   const cursorRef = useRef<string | null>(null);
   cursorRef.current = nextCursor;
+  const applyNextCursor = useCallback((cursor: string | null) => {
+    // A queued feed intent may start from the completing request's finally
+    // block, before React renders the state update. Commit both owners together
+    // so that intent always reads the logically latest cursor.
+    cursorRef.current = cursor;
+    setNextCursor(cursor);
+  }, []);
   // Mirror the loaded feed so ``reconcile`` can size its re-read to the current
   // window without depending on (and re-identifying with) ``inboxSessions``.
   const inboxSessionsRef = useRef<InboxSession[]>([]);
@@ -83,15 +90,17 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
   // Every Inbox read shares one ordering fence. This covers page-one refresh,
   // cursor reads, resume reconcile, and the targeted foreground-restore read.
   const readOwnershipRef = useRef(createWorkbenchSessionReadOwnership());
-  // Broad reads and cursor reads both own the feed. Run only one broad read at a
-  // time and preserve trailing intents while it or a cursor request is active,
-  // so a later failed duplicate cannot discard an earlier successful recovery.
+  // Broad reads and cursor reads both own the feed. Serialize every feed read
+  // and preserve trailing intents so response completion order cannot discard a
+  // recovery snapshot or a page the user asked to load.
   const refreshPendingRef = useRef(false);
   const reconcilePendingRef = useRef(false);
+  const loadMorePendingRef = useRef(false);
   const broadReadInFlightRef = useRef(false);
   const cursorReadsInFlightRef = useRef(0);
   const refreshRunnerRef = useRef<() => void>(() => {});
   const reconcileRunnerRef = useRef<() => void>(() => {});
+  const loadMoreRunnerRef = useRef<() => void>(() => {});
   const reconcileSessionRef = useRef<(sessionId: string) => void>(() => {});
   const refreshLoadingGenerationRef = useRef(0);
   const loadMoreLoadingGenerationRef = useRef(0);
@@ -101,7 +110,7 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
   // outside the page; a later broad omission revalidates them by exact id.
   const targetedSnapshotsRef = useRef<Map<string, TargetedInboxSnapshot>>(new Map());
 
-  const flushBroadReadIntent = useCallback(() => {
+  const flushFeedReadIntent = useCallback(() => {
     if (broadReadInFlightRef.current || cursorReadsInFlightRef.current > 0) return;
     if (refreshPendingRef.current) {
       refreshPendingRef.current = false;
@@ -114,18 +123,28 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
     if (reconcilePendingRef.current) {
       reconcilePendingRef.current = false;
       reconcileRunnerRef.current();
+      return;
+    }
+    if (loadMorePendingRef.current) {
+      loadMorePendingRef.current = false;
+      loadMoreRunnerRef.current();
     }
   }, []);
 
   const queueRefreshIntent = useCallback(() => {
     refreshPendingRef.current = true;
-    queueMicrotask(flushBroadReadIntent);
-  }, [flushBroadReadIntent]);
+    queueMicrotask(flushFeedReadIntent);
+  }, [flushFeedReadIntent]);
 
   const queueReconcileIntent = useCallback(() => {
     reconcilePendingRef.current = true;
-    queueMicrotask(flushBroadReadIntent);
-  }, [flushBroadReadIntent]);
+    queueMicrotask(flushFeedReadIntent);
+  }, [flushFeedReadIntent]);
+
+  const queueLoadMoreIntent = useCallback(() => {
+    loadMorePendingRef.current = true;
+    queueMicrotask(flushFeedReadIntent);
+  }, [flushFeedReadIntent]);
 
   const acceptSessionMutation = useCallback((sessionId: string) => {
     readOwnershipRef.current.acceptMutation([
@@ -221,7 +240,7 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
       } else {
         const snapshotsToRevalidate = acceptFeedRows(read, result.sessions);
         setInboxSessions(() => mergeTargetedSnapshots(result.sessions));
-        setNextCursor(result.next_cursor);
+        applyNextCursor(result.next_cursor);
         for (const sessionId of snapshotsToRevalidate) reconcileSessionRef.current(sessionId);
       }
       if (readOwnershipRef.current.isCurrent(read, 'inbox-unread')) {
@@ -232,11 +251,23 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
     } finally {
       if (refreshLoadingGenerationRef.current === loadingGeneration) setLoading(false);
       broadReadInFlightRef.current = false;
-      flushBroadReadIntent();
+      flushFeedReadIntent();
     }
-  }, [acceptFeedRows, api, applyUnreadMap, flushBroadReadIntent, mergeTargetedSnapshots, queueRefreshIntent]);
+  }, [acceptFeedRows, api, applyNextCursor, applyUnreadMap, flushFeedReadIntent, mergeTargetedSnapshots, queueRefreshIntent]);
 
   const loadMore = useCallback(async function loadMore() {
+    if (
+      broadReadInFlightRef.current ||
+      refreshPendingRef.current ||
+      reconcilePendingRef.current
+    ) {
+      queueLoadMoreIntent();
+      return;
+    }
+    // A duplicate click while the same cursor is already loading is not a new
+    // page intent. Mutation invalidation queues its retry explicitly below.
+    if (cursorReadsInFlightRef.current > 0) return;
+    loadMorePendingRef.current = false;
     const cursor = cursorRef.current;
     if (!cursor) return;
     const read = readOwnershipRef.current.beginRead(['inbox-feed', 'inbox-feed-cursor']);
@@ -251,7 +282,7 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
         return;
       }
       setInboxSessions((prev) => appendPage(prev, result.sessions));
-      setNextCursor(result.next_cursor);
+      applyNextCursor(result.next_cursor);
     } catch (err) {
       retryAfterInvalidation =
         !readOwnershipRef.current.isCurrent(read, 'inbox-feed') &&
@@ -260,10 +291,10 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
     } finally {
       cursorReadsInFlightRef.current -= 1;
       if (loadMoreLoadingGenerationRef.current === loadingGeneration) setLoadingMore(false);
-      if (retryAfterInvalidation) queueMicrotask(() => void loadMore());
-      else flushBroadReadIntent();
+      if (retryAfterInvalidation) queueLoadMoreIntent();
+      else flushFeedReadIntent();
     }
-  }, [api, flushBroadReadIntent]);
+  }, [api, applyNextCursor, flushFeedReadIntent, queueLoadMoreIntent]);
 
   const markRead = useCallback(
     async (sessionId: string, untilMessageId?: string) => {
@@ -301,7 +332,11 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
   // that arrived during the gap surface at top. No loading flag — the user
   // already has content; this is a silent catch-up.
   const reconcile = useCallback(async () => {
-    if (broadReadInFlightRef.current || cursorReadsInFlightRef.current > 0) {
+    if (
+      broadReadInFlightRef.current ||
+      cursorReadsInFlightRef.current > 0 ||
+      refreshPendingRef.current
+    ) {
       queueReconcileIntent();
       return;
     }
@@ -366,7 +401,7 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
         // between this read and the old feed — adopt result.next_cursor so "Load
         // more" can page through them (loadMore dedupes the overlap).
         const overlap = result.sessions.some((s) => loadedIds.has(s.session_id));
-        if (!overlap) setNextCursor(result.next_cursor);
+        if (!overlap) applyNextCursor(result.next_cursor);
       }
       if (readOwnershipRef.current.isCurrent(read, 'inbox-unread')) {
         applyUnreadMap(result.unread_by_session ?? {});
@@ -375,9 +410,9 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
       if (!retryAfterInvalidation()) console.error('[inbox] reconcile failed', err);
     } finally {
       broadReadInFlightRef.current = false;
-      flushBroadReadIntent();
+      flushFeedReadIntent();
     }
-  }, [acceptFeedRows, api, applyUnreadMap, flushBroadReadIntent, mergeTargetedSnapshots, queueReconcileIntent]);
+  }, [acceptFeedRows, api, applyNextCursor, applyUnreadMap, flushFeedReadIntent, mergeTargetedSnapshots, queueReconcileIntent]);
 
   // Targeted reconcile for one session (contract A6 foreground restore): fetch
   // that exact session by id and upsert its card, so a restored session
@@ -428,6 +463,7 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
   );
   refreshRunnerRef.current = () => void refresh();
   reconcileRunnerRef.current = () => void reconcile();
+  loadMoreRunnerRef.current = () => void loadMore();
   reconcileSessionRef.current = (sessionId) => void reconcileSession(sessionId);
 
   useEffect(() => {

--- a/ui/src/context/WorkbenchInboxProvider.tsx
+++ b/ui/src/context/WorkbenchInboxProvider.tsx
@@ -35,6 +35,11 @@ const appendPage = (prev: InboxSession[], page: InboxSession[]): InboxSession[] 
   return merged;
 };
 
+type TargetedInboxSnapshot = {
+  row: InboxSession | null;
+  unreadCount: number;
+};
+
 /** Provider that owns the Inbox state shared across WorkbenchSidebar + InboxPage.
  *
  *  Connects to ``/api/events`` and updates the per-session feed in place:
@@ -84,6 +89,11 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
   const reconcileRetryPendingRef = useRef(false);
   const refreshLoadingGenerationRef = useRef(0);
   const loadMoreLoadingGenerationRef = useRef(0);
+  // Targeted foreground restores own one session independently from the
+  // windowed feed. Keep their latest committed values so a later whole-feed
+  // replacement cannot erase a restored card or unread count merely because
+  // the row sorts outside the page.
+  const targetedSnapshotsRef = useRef<Map<string, TargetedInboxSnapshot>>(new Map());
 
   const acceptSessionMutation = useCallback(() => {
     readOwnershipRef.current.acceptMutation();
@@ -98,8 +108,30 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
     setUnreadLoaded(true);
   }, []);
 
+  const applyFeedUnreadMap = useCallback(
+    (map: Record<string, number>) => {
+      const next = { ...map };
+      for (const [sessionId, snapshot] of targetedSnapshotsRef.current) {
+        if (snapshot.unreadCount > 0) next[sessionId] = snapshot.unreadCount;
+        else delete next[sessionId];
+      }
+      applyUnreadMap(next);
+    },
+    [applyUnreadMap],
+  );
+
+  const mergeTargetedSnapshots = useCallback((rows: InboxSession[]): InboxSession[] => {
+    let next = rows;
+    for (const [sessionId, snapshot] of targetedSnapshotsRef.current) {
+      next = snapshot.row
+        ? upsertSession(next, snapshot.row)
+        : next.filter((row) => row.session_id !== sessionId);
+    }
+    return next;
+  }, []);
+
   const refresh = useCallback(async () => {
-    const read = readOwnershipRef.current.beginRead('inbox-feed');
+    const read = readOwnershipRef.current.beginRead(['inbox-feed', 'inbox-feed-refresh']);
     const loadingGeneration = ++refreshLoadingGenerationRef.current;
     setLoading(true);
     try {
@@ -114,21 +146,21 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
         }
         return;
       }
-      setInboxSessions(result.sessions);
+      setInboxSessions(() => mergeTargetedSnapshots(result.sessions));
       setNextCursor(result.next_cursor);
-      applyUnreadMap(result.unread_by_session ?? {});
+      applyFeedUnreadMap(result.unread_by_session ?? {});
       authoritativeFeedLoadedRef.current = true;
     } catch (err) {
       console.error('[inbox] refresh failed', err);
     } finally {
       if (refreshLoadingGenerationRef.current === loadingGeneration) setLoading(false);
     }
-  }, [api, applyUnreadMap]);
+  }, [api, applyFeedUnreadMap, mergeTargetedSnapshots]);
 
   const loadMore = useCallback(async () => {
     const cursor = cursorRef.current;
     if (!cursor) return;
-    const read = readOwnershipRef.current.beginRead('inbox-feed');
+    const read = readOwnershipRef.current.beginRead(['inbox-feed', 'inbox-feed-cursor']);
     const loadingGeneration = ++loadMoreLoadingGenerationRef.current;
     setLoadingMore(true);
     try {
@@ -146,6 +178,7 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
   const markRead = useCallback(
     async (sessionId: string, untilMessageId?: string) => {
       const result = await api.markSessionRead(sessionId, untilMessageId);
+      targetedSnapshotsRef.current.delete(sessionId);
       acceptSessionMutation();
       // The unread map is authoritative for badges; the card's unread styling
       // derives from it, so clearing here clears the dot without touching the
@@ -163,7 +196,7 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
   // that arrived during the gap surface at top. No loading flag — the user
   // already has content; this is a silent catch-up.
   const reconcile = useCallback(async () => {
-    const read = readOwnershipRef.current.beginRead('inbox-feed');
+    const read = readOwnershipRef.current.beginRead(['inbox-feed', 'inbox-feed-reconcile']);
     // Snapshot loaded ids up front: sizes the re-read window, and lets us tell
     // afterward whether the read overlapped what we already had (cursor note).
     const loadedIds = new Set(inboxSessionsRef.current.map((s) => s.session_id));
@@ -175,8 +208,21 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
         cache: false,
         handleError: false,
       });
-      if (!readOwnershipRef.current.isCurrent(read)) {
-        if (readOwnershipRef.current.epoch() !== read.epoch && !reconcileRetryPendingRef.current) {
+      const stale = !readOwnershipRef.current.isCurrent(read) || !readOwnershipRef.current.isLatestRead(read);
+      const invalidatedByMutation = readOwnershipRef.current.epoch() !== read.epoch;
+      const supersededByCursorRead =
+        (readOwnershipRef.current.latestGeneration('inbox-feed-cursor') ?? 0) > read.generation;
+      const supersededByReconcileRead =
+        (readOwnershipRef.current.latestGeneration('inbox-feed-reconcile') ?? 0) > read.generation;
+      const supersededByRefresh =
+        (readOwnershipRef.current.latestGeneration('inbox-feed-refresh') ?? 0) > read.generation;
+      if (stale || supersededByCursorRead || supersededByReconcileRead) {
+        if (
+          (invalidatedByMutation || supersededByCursorRead) &&
+          !supersededByRefresh &&
+          !supersededByReconcileRead &&
+          !reconcileRetryPendingRef.current
+        ) {
           reconcileRetryPendingRef.current = true;
           queueMicrotask(() => {
             reconcileRetryPendingRef.current = false;
@@ -191,10 +237,10 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
         const have = new Set(prev.map((s) => s.session_id));
         for (const s of result.sessions) if (!have.has(s.session_id)) merged.push(s);
         merged.sort(byActivityDesc);
-        return merged;
+        return mergeTargetedSnapshots(merged);
       });
       // Whole-account unread map (not paginated) — always authoritative.
-      applyUnreadMap(result.unread_by_session ?? {});
+      applyFeedUnreadMap(result.unread_by_session ?? {});
       authoritativeFeedLoadedRef.current = true;
       // Cursor: the loaded feed is always a contiguous run from the top, and
       // this reads the newest `limit` rows. If the read shares ANY row with what
@@ -210,7 +256,7 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
     } catch (err) {
       console.error('[inbox] reconcile failed', err);
     }
-  }, [api, applyUnreadMap]);
+  }, [api, applyFeedUnreadMap, mergeTargetedSnapshots]);
 
   // Targeted reconcile for one session (contract A6 foreground restore): fetch
   // that exact session by id and upsert its card, so a restored session
@@ -230,7 +276,13 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
         });
         const row = result.sessions.find((s) => s.session_id === sessionId);
         if (!readOwnershipRef.current.isCurrent(read)) return;
-        if (row) setInboxSessions((prev) => upsertSession(prev, row));
+        targetedSnapshotsRef.current.set(sessionId, {
+          row: row ?? null,
+          unreadCount: result.unread_by_session?.[sessionId] ?? 0,
+        });
+        setInboxSessions((prev) =>
+          row ? upsertSession(prev, row) : prev.filter((candidate) => candidate.session_id !== sessionId),
+        );
         applyUnreadMap(result.unread_by_session ?? {});
       } catch (err) {
         console.error('[inbox] reconcileSession failed', err);
@@ -254,6 +306,7 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
     }
     const disconnect = api.connectWorkbenchEvents({
       onInboxSessionUpdated: (row) => {
+        targetedSnapshotsRef.current.delete(row.session_id);
         acceptSessionMutation();
         setInboxSessions((prev) => upsertSession(prev, row));
         setUnreadBySession((prev) => {
@@ -265,6 +318,7 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
         });
       },
       onInboxUnreadChanged: (data) => {
+        targetedSnapshotsRef.current.clear();
         acceptSessionMutation();
         if (data?.unread_by_session) {
           applyUnreadMap(data.unread_by_session);
@@ -278,11 +332,13 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
         // See lib/inboxActivity.
         const action = sessionActivityInboxAction(data);
         if (action === 'reconcile') {
+          targetedSnapshotsRef.current.delete(data.session_id);
           acceptSessionMutation();
           void reconcileSession(data.session_id);
           return;
         }
         if (action === 'ignore') return;
+        targetedSnapshotsRef.current.delete(data.session_id);
         acceptSessionMutation();
         // action === 'drop': remove the card + its unread live, instead of
         // waiting for the next reconnect/refresh to filter it.

--- a/ui/src/context/WorkbenchInboxProvider.tsx
+++ b/ui/src/context/WorkbenchInboxProvider.tsx
@@ -83,11 +83,9 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
   // Every Inbox read shares one ordering fence. This covers page-one refresh,
   // cursor reads, resume reconcile, and the targeted foreground-restore read.
   const readOwnershipRef = useRef(createWorkbenchSessionReadOwnership());
-  // A stale cold-start snapshot cannot be replaced by an event patch alone: the
-  // event may have dropped a card that was never loaded in this provider. Retry
-  // one authoritative feed read after that response settles.
-  const authoritativeFeedLoadedRef = useRef(false);
-  const coldRefreshRetryPendingRef = useRef(false);
+  // A stale refresh cannot be replaced by an event patch or cursor page alone:
+  // neither operation owns the full top-of-feed snapshot requested by refresh.
+  const refreshRetryPendingRef = useRef(false);
   const reconcileRetryPendingRef = useRef(false);
   const refreshLoadingGenerationRef = useRef(0);
   const loadMoreLoadingGenerationRef = useRef(0);
@@ -119,6 +117,16 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
     setUnreadLoaded(true);
   }, []);
 
+  const applySessionUnread = useCallback((sessionId: string, count: number) => {
+    setUnreadBySession((prev) => {
+      const next = { ...prev };
+      if (count > 0) next[sessionId] = count;
+      else delete next[sessionId];
+      return next;
+    });
+    setUnreadLoaded(true);
+  }, []);
+
   const mergeTargetedSnapshots = useCallback((rows: InboxSession[]): InboxSession[] => {
     let next = rows;
     for (const [sessionId, snapshot] of targetedSnapshotsRef.current) {
@@ -139,32 +147,48 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
     }
   }, []);
 
-  const refresh = useCallback(async () => {
+  const refresh = useCallback(async function refresh() {
     const read = readOwnershipRef.current.beginRead(['inbox-feed', 'inbox-unread', 'inbox-feed-refresh']);
     const loadingGeneration = ++refreshLoadingGenerationRef.current;
+    const retryAfterInvalidation = () => {
+      const invalidatedByMutation = !readOwnershipRef.current.isMutationCurrent(read, 'inbox-feed');
+      const supersededByCursorRead =
+        (readOwnershipRef.current.latestGeneration('inbox-feed-cursor') ?? 0) > read.generation;
+      const supersededByRefresh =
+        (readOwnershipRef.current.latestGeneration('inbox-feed-refresh') ?? 0) > read.generation;
+      const supersededByReconcile =
+        (readOwnershipRef.current.latestGeneration('inbox-feed-reconcile') ?? 0) > read.generation;
+      if (
+        (!invalidatedByMutation && !supersededByCursorRead) ||
+        supersededByRefresh ||
+        supersededByReconcile ||
+        refreshRetryPendingRef.current
+      ) {
+        return false;
+      }
+      refreshRetryPendingRef.current = true;
+      queueMicrotask(() => {
+        refreshRetryPendingRef.current = false;
+        void refresh();
+      });
+      return true;
+    };
     setLoading(true);
     try {
       const result = await api.listInbox({ platform: 'avibe', limit: PAGE_SIZE });
       const feedCurrent = readOwnershipRef.current.isCurrent(read, 'inbox-feed');
       if (!feedCurrent) {
-        if (!authoritativeFeedLoadedRef.current && !coldRefreshRetryPendingRef.current) {
-          coldRefreshRetryPendingRef.current = true;
-          queueMicrotask(() => {
-            coldRefreshRetryPendingRef.current = false;
-            if (!authoritativeFeedLoadedRef.current) void refresh();
-          });
-        }
+        retryAfterInvalidation();
       } else {
         acceptFeedRows(read, result.sessions);
         setInboxSessions(() => mergeTargetedSnapshots(result.sessions));
         setNextCursor(result.next_cursor);
-        authoritativeFeedLoadedRef.current = true;
       }
       if (readOwnershipRef.current.isCurrent(read, 'inbox-unread')) {
         applyUnreadMap(result.unread_by_session ?? {});
       }
     } catch (err) {
-      console.error('[inbox] refresh failed', err);
+      if (!retryAfterInvalidation()) console.error('[inbox] refresh failed', err);
     } finally {
       if (refreshLoadingGenerationRef.current === loadingGeneration) setLoading(false);
     }
@@ -198,15 +222,30 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
 
   const markRead = useCallback(
     async (sessionId: string, untilMessageId?: string) => {
-      const read = readOwnershipRef.current.beginRead('inbox-unread');
+      const operation = readOwnershipRef.current.beginRead(`inbox-mark-read:${sessionId}`);
       const result = await api.markSessionRead(sessionId, untilMessageId);
-      if (!readOwnershipRef.current.isCurrent(read, 'inbox-unread')) return;
+      if (
+        !readOwnershipRef.current.isMutationCurrent(operation, [
+          `inbox-session:${sessionId}`,
+          'inbox-unread-all',
+        ])
+      ) {
+        return;
+      }
+      // A successful write commits after every read that was already in flight,
+      // even when one of those reads started later and returns last. The endpoint
+      // mutates only this session, so merge only that count; concurrent mark-read
+      // writes for other sessions remain independent.
+      readOwnershipRef.current.acceptMutation([
+        'inbox-unread',
+        `inbox-unread-session:${sessionId}`,
+      ]);
       // The unread map is authoritative for badges; the card's unread styling
       // derives from it, so clearing here clears the dot without touching the
       // feed order (a read doesn't change last activity).
-      applyUnreadMap(result.unread_by_session ?? {});
+      applySessionUnread(sessionId, result.unread_by_session?.[sessionId] ?? 0);
     },
-    [api, applyUnreadMap],
+    [api, applySessionUnread],
   );
 
   // Resume reconcile: re-read the feed WITHOUT collapsing pagination. A
@@ -218,6 +257,29 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
   // already has content; this is a silent catch-up.
   const reconcile = useCallback(async () => {
     const read = readOwnershipRef.current.beginRead(['inbox-feed', 'inbox-unread', 'inbox-feed-reconcile']);
+    const retryAfterInvalidation = () => {
+      const invalidatedByMutation = !readOwnershipRef.current.isMutationCurrent(read, 'inbox-feed');
+      const supersededByCursorRead =
+        (readOwnershipRef.current.latestGeneration('inbox-feed-cursor') ?? 0) > read.generation;
+      const supersededByReconcileRead =
+        (readOwnershipRef.current.latestGeneration('inbox-feed-reconcile') ?? 0) > read.generation;
+      const supersededByRefresh =
+        (readOwnershipRef.current.latestGeneration('inbox-feed-refresh') ?? 0) > read.generation;
+      if (
+        (!invalidatedByMutation && !supersededByCursorRead) ||
+        supersededByRefresh ||
+        supersededByReconcileRead ||
+        reconcileRetryPendingRef.current
+      ) {
+        return false;
+      }
+      reconcileRetryPendingRef.current = true;
+      queueMicrotask(() => {
+        reconcileRetryPendingRef.current = false;
+        void reconcile();
+      });
+      return true;
+    };
     // Snapshot loaded ids up front: sizes the re-read window, and lets us tell
     // afterward whether the read overlapped what we already had (cursor note).
     const loadedIds = new Set(inboxSessionsRef.current.map((s) => s.session_id));
@@ -230,26 +292,12 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
         handleError: false,
       });
       const feedCurrent = readOwnershipRef.current.isCurrent(read, 'inbox-feed');
-      const invalidatedByMutation = !readOwnershipRef.current.isMutationCurrent(read, 'inbox-feed');
       const supersededByCursorRead =
         (readOwnershipRef.current.latestGeneration('inbox-feed-cursor') ?? 0) > read.generation;
       const supersededByReconcileRead =
         (readOwnershipRef.current.latestGeneration('inbox-feed-reconcile') ?? 0) > read.generation;
-      const supersededByRefresh =
-        (readOwnershipRef.current.latestGeneration('inbox-feed-refresh') ?? 0) > read.generation;
       if (!feedCurrent || supersededByCursorRead || supersededByReconcileRead) {
-        if (
-          (invalidatedByMutation || supersededByCursorRead) &&
-          !supersededByRefresh &&
-          !supersededByReconcileRead &&
-          !reconcileRetryPendingRef.current
-        ) {
-          reconcileRetryPendingRef.current = true;
-          queueMicrotask(() => {
-            reconcileRetryPendingRef.current = false;
-            void reconcile();
-          });
-        }
+        retryAfterInvalidation();
       } else {
         acceptFeedRows(read, result.sessions);
         setInboxSessions((prev) => {
@@ -260,7 +308,6 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
           merged.sort(byActivityDesc);
           return mergeTargetedSnapshots(merged);
         });
-        authoritativeFeedLoadedRef.current = true;
         // Cursor: the loaded feed is always a contiguous run from the top, and
         // this reads the newest `limit` rows. If the read shares ANY row with what
         // we had (overlap), the two runs are contiguous — no gap below the read —
@@ -277,7 +324,7 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
         applyUnreadMap(result.unread_by_session ?? {});
       }
     } catch (err) {
-      console.error('[inbox] reconcile failed', err);
+      if (!retryAfterInvalidation()) console.error('[inbox] reconcile failed', err);
     }
   }, [acceptFeedRows, api, applyUnreadMap, mergeTargetedSnapshots]);
 

--- a/ui/src/context/WorkbenchInboxProvider.tsx
+++ b/ui/src/context/WorkbenchInboxProvider.tsx
@@ -81,6 +81,9 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
   // one authoritative feed read after that response settles.
   const authoritativeFeedLoadedRef = useRef(false);
   const coldRefreshRetryPendingRef = useRef(false);
+  const reconcileRetryPendingRef = useRef(false);
+  const refreshLoadingGenerationRef = useRef(0);
+  const loadMoreLoadingGenerationRef = useRef(0);
 
   const acceptSessionMutation = useCallback(() => {
     readOwnershipRef.current.acceptMutation();
@@ -97,6 +100,7 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
 
   const refresh = useCallback(async () => {
     const read = readOwnershipRef.current.beginRead('inbox-feed');
+    const loadingGeneration = ++refreshLoadingGenerationRef.current;
     setLoading(true);
     try {
       const result = await api.listInbox({ platform: 'avibe', limit: PAGE_SIZE });
@@ -117,7 +121,7 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
     } catch (err) {
       console.error('[inbox] refresh failed', err);
     } finally {
-      if (readOwnershipRef.current.isLatestRead(read)) setLoading(false);
+      if (refreshLoadingGenerationRef.current === loadingGeneration) setLoading(false);
     }
   }, [api, applyUnreadMap]);
 
@@ -125,6 +129,7 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
     const cursor = cursorRef.current;
     if (!cursor) return;
     const read = readOwnershipRef.current.beginRead('inbox-feed');
+    const loadingGeneration = ++loadMoreLoadingGenerationRef.current;
     setLoadingMore(true);
     try {
       const result = await api.listInbox({ platform: 'avibe', limit: PAGE_SIZE, before: cursor });
@@ -134,7 +139,7 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
     } catch (err) {
       console.error('[inbox] load more failed', err);
     } finally {
-      if (readOwnershipRef.current.isLatestRead(read)) setLoadingMore(false);
+      if (loadMoreLoadingGenerationRef.current === loadingGeneration) setLoadingMore(false);
     }
   }, [api]);
 
@@ -170,7 +175,16 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
         cache: false,
         handleError: false,
       });
-      if (!readOwnershipRef.current.isCurrent(read)) return;
+      if (!readOwnershipRef.current.isCurrent(read)) {
+        if (readOwnershipRef.current.epoch() !== read.epoch && !reconcileRetryPendingRef.current) {
+          reconcileRetryPendingRef.current = true;
+          queueMicrotask(() => {
+            reconcileRetryPendingRef.current = false;
+            void reconcile();
+          });
+        }
+        return;
+      }
       setInboxSessions((prev) => {
         const incoming = new Map(result.sessions.map((s) => [s.session_id, s]));
         const merged = prev.map((s) => incoming.get(s.session_id) ?? s);
@@ -215,7 +229,7 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
           handleError: false,
         });
         const row = result.sessions.find((s) => s.session_id === sessionId);
-        if (!readOwnershipRef.current.isCurrent(read, ['inbox-feed', `inbox-session:${sessionId}`])) return;
+        if (!readOwnershipRef.current.isCurrent(read)) return;
         if (row) setInboxSessions((prev) => upsertSession(prev, row));
         applyUnreadMap(result.unread_by_session ?? {});
       } catch (err) {

--- a/ui/src/context/WorkbenchInboxProvider.tsx
+++ b/ui/src/context/WorkbenchInboxProvider.tsx
@@ -76,6 +76,11 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
   // Every Inbox read shares one ordering fence. This covers page-one refresh,
   // cursor reads, resume reconcile, and the targeted foreground-restore read.
   const readOwnershipRef = useRef(createWorkbenchSessionReadOwnership());
+  // A stale cold-start snapshot cannot be replaced by an event patch alone: the
+  // event may have dropped a card that was never loaded in this provider. Retry
+  // one authoritative feed read after that response settles.
+  const authoritativeFeedLoadedRef = useRef(false);
+  const coldRefreshRetryPendingRef = useRef(false);
 
   const acceptSessionMutation = useCallback(() => {
     readOwnershipRef.current.acceptMutation();
@@ -91,14 +96,24 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
   }, []);
 
   const refresh = useCallback(async () => {
-    const read = readOwnershipRef.current.beginRead();
+    const read = readOwnershipRef.current.beginRead('inbox-feed');
     setLoading(true);
     try {
       const result = await api.listInbox({ platform: 'avibe', limit: PAGE_SIZE });
-      if (!readOwnershipRef.current.isCurrent(read)) return;
+      if (!readOwnershipRef.current.isCurrent(read)) {
+        if (!authoritativeFeedLoadedRef.current && !coldRefreshRetryPendingRef.current) {
+          coldRefreshRetryPendingRef.current = true;
+          queueMicrotask(() => {
+            coldRefreshRetryPendingRef.current = false;
+            if (!authoritativeFeedLoadedRef.current) void refresh();
+          });
+        }
+        return;
+      }
       setInboxSessions(result.sessions);
       setNextCursor(result.next_cursor);
       applyUnreadMap(result.unread_by_session ?? {});
+      authoritativeFeedLoadedRef.current = true;
     } catch (err) {
       console.error('[inbox] refresh failed', err);
     } finally {
@@ -109,7 +124,7 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
   const loadMore = useCallback(async () => {
     const cursor = cursorRef.current;
     if (!cursor) return;
-    const read = readOwnershipRef.current.beginRead();
+    const read = readOwnershipRef.current.beginRead('inbox-feed');
     setLoadingMore(true);
     try {
       const result = await api.listInbox({ platform: 'avibe', limit: PAGE_SIZE, before: cursor });
@@ -143,7 +158,7 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
   // that arrived during the gap surface at top. No loading flag — the user
   // already has content; this is a silent catch-up.
   const reconcile = useCallback(async () => {
-    const read = readOwnershipRef.current.beginRead();
+    const read = readOwnershipRef.current.beginRead('inbox-feed');
     // Snapshot loaded ids up front: sizes the re-read window, and lets us tell
     // afterward whether the read overlapped what we already had (cursor note).
     const loadedIds = new Set(inboxSessionsRef.current.map((s) => s.session_id));
@@ -166,6 +181,7 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
       });
       // Whole-account unread map (not paginated) — always authoritative.
       applyUnreadMap(result.unread_by_session ?? {});
+      authoritativeFeedLoadedRef.current = true;
       // Cursor: the loaded feed is always a contiguous run from the top, and
       // this reads the newest `limit` rows. If the read shares ANY row with what
       // we had (overlap), the two runs are contiguous — no gap below the read —
@@ -189,7 +205,7 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
   // whole-account unread map, so refresh that too. Never touches the cursor.
   const reconcileSession = useCallback(
     async (sessionId: string) => {
-      const read = readOwnershipRef.current.beginRead();
+      const read = readOwnershipRef.current.beginRead(`inbox-session:${sessionId}`);
       try {
         const result = await api.listInbox({
           platform: 'avibe',
@@ -199,7 +215,7 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
           handleError: false,
         });
         const row = result.sessions.find((s) => s.session_id === sessionId);
-        if (!readOwnershipRef.current.isCurrent(read)) return;
+        if (!readOwnershipRef.current.isCurrent(read, ['inbox-feed', `inbox-session:${sessionId}`])) return;
         if (row) setInboxSessions((prev) => upsertSession(prev, row));
         applyUnreadMap(result.unread_by_session ?? {});
       } catch (err) {
@@ -241,7 +257,6 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
         }
       },
       onSessionActivity: (data) => {
-        acceptSessionMutation();
         // Contract A6: react to visibility/scope changes carried on the event.
         // background ⇒ drop the card (like an archive); foreground ⇒ fetch that
         // exact session and upsert its card so it reappears even if it sorts past
@@ -249,10 +264,12 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
         // See lib/inboxActivity.
         const action = sessionActivityInboxAction(data);
         if (action === 'reconcile') {
+          acceptSessionMutation();
           void reconcileSession(data.session_id);
           return;
         }
         if (action === 'ignore') return;
+        acceptSessionMutation();
         // action === 'drop': remove the card + its unread live, instead of
         // waiting for the next reconnect/refresh to filter it.
         setInboxSessions((prev) => prev.filter((s) => s.session_id !== data.session_id));

--- a/ui/src/context/WorkbenchInboxProvider.tsx
+++ b/ui/src/context/WorkbenchInboxProvider.tsx
@@ -166,7 +166,8 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
 
   // One home for "an authoritative unread map arrived": set the map and flip
   // ``unreadLoaded`` together so the two can never drift apart. Every whole-account
-  // write (refresh / reconcile / markRead / unread.changed) goes through here;
+  // write (refresh / reconcile / unread.changed) goes through here; targeted
+  // reads and mark-read responses merge one session without claiming completeness.
   // stable identity, so it never churns the memoized context value.
   const applyUnreadMap = useCallback((map: Record<string, number>) => {
     setUnreadBySession(map);
@@ -191,7 +192,6 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
       else delete next[sessionId];
       return next;
     });
-    setUnreadLoaded(true);
   }, []);
 
   const mergeTargetedSnapshots = useCallback((rows: InboxSession[]): InboxSession[] => {
@@ -330,10 +330,7 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
       const operation = readOwnershipRef.current.beginRead(`inbox-mark-read:${sessionId}`);
       const result = await api.markSessionRead(sessionId, untilMessageId);
       if (
-        !readOwnershipRef.current.isMutationCurrent(operation, [
-          `inbox-session:${sessionId}`,
-          'inbox-unread-all',
-        ])
+        !readOwnershipRef.current.isMutationCurrent(operation, `inbox-session:${sessionId}`)
       ) {
         return;
       }

--- a/ui/src/context/WorkbenchInboxProvider.tsx
+++ b/ui/src/context/WorkbenchInboxProvider.tsx
@@ -6,6 +6,7 @@ import type { InboxSession } from './ApiContext';
 import { WorkbenchInboxContext, type InboxState } from './WorkbenchInboxContext';
 import { sessionActivityInboxAction } from '../lib/inboxActivity';
 import { syncFaviconBadge } from '../lib/faviconBadge';
+import { createWorkbenchSessionReadOwnership } from '../lib/workbenchSessionReadOwnership';
 
 const PAGE_SIZE = 30;
 
@@ -72,6 +73,13 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
   // — reconciles the loaded window instead, so a non-resume
   // rerun never collapses a multi-page feed back to page one.
   const initialFetched = useRef(false);
+  // Every Inbox read shares one ordering fence. This covers page-one refresh,
+  // cursor reads, resume reconcile, and the targeted foreground-restore read.
+  const readOwnershipRef = useRef(createWorkbenchSessionReadOwnership());
+
+  const acceptSessionMutation = useCallback(() => {
+    readOwnershipRef.current.acceptMutation();
+  }, []);
 
   // One home for "an authoritative unread map arrived": set the map and flip
   // ``unreadLoaded`` together so the two can never drift apart. Every whole-account
@@ -83,43 +91,48 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
   }, []);
 
   const refresh = useCallback(async () => {
+    const read = readOwnershipRef.current.beginRead();
     setLoading(true);
     try {
       const result = await api.listInbox({ platform: 'avibe', limit: PAGE_SIZE });
+      if (!readOwnershipRef.current.isCurrent(read)) return;
       setInboxSessions(result.sessions);
       setNextCursor(result.next_cursor);
       applyUnreadMap(result.unread_by_session ?? {});
     } catch (err) {
       console.error('[inbox] refresh failed', err);
     } finally {
-      setLoading(false);
+      if (readOwnershipRef.current.isLatestRead(read)) setLoading(false);
     }
   }, [api, applyUnreadMap]);
 
   const loadMore = useCallback(async () => {
     const cursor = cursorRef.current;
     if (!cursor) return;
+    const read = readOwnershipRef.current.beginRead();
     setLoadingMore(true);
     try {
       const result = await api.listInbox({ platform: 'avibe', limit: PAGE_SIZE, before: cursor });
+      if (!readOwnershipRef.current.isCurrent(read)) return;
       setInboxSessions((prev) => appendPage(prev, result.sessions));
       setNextCursor(result.next_cursor);
     } catch (err) {
       console.error('[inbox] load more failed', err);
     } finally {
-      setLoadingMore(false);
+      if (readOwnershipRef.current.isLatestRead(read)) setLoadingMore(false);
     }
   }, [api]);
 
   const markRead = useCallback(
     async (sessionId: string, untilMessageId?: string) => {
       const result = await api.markSessionRead(sessionId, untilMessageId);
+      acceptSessionMutation();
       // The unread map is authoritative for badges; the card's unread styling
       // derives from it, so clearing here clears the dot without touching the
       // feed order (a read doesn't change last activity).
       applyUnreadMap(result.unread_by_session ?? {});
     },
-    [api, applyUnreadMap],
+    [acceptSessionMutation, api, applyUnreadMap],
   );
 
   // Resume reconcile: re-read the feed WITHOUT collapsing pagination. A
@@ -130,6 +143,7 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
   // that arrived during the gap surface at top. No loading flag — the user
   // already has content; this is a silent catch-up.
   const reconcile = useCallback(async () => {
+    const read = readOwnershipRef.current.beginRead();
     // Snapshot loaded ids up front: sizes the re-read window, and lets us tell
     // afterward whether the read overlapped what we already had (cursor note).
     const loadedIds = new Set(inboxSessionsRef.current.map((s) => s.session_id));
@@ -141,6 +155,7 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
         cache: false,
         handleError: false,
       });
+      if (!readOwnershipRef.current.isCurrent(read)) return;
       setInboxSessions((prev) => {
         const incoming = new Map(result.sessions.map((s) => [s.session_id, s]));
         const merged = prev.map((s) => incoming.get(s.session_id) ?? s);
@@ -174,6 +189,7 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
   // whole-account unread map, so refresh that too. Never touches the cursor.
   const reconcileSession = useCallback(
     async (sessionId: string) => {
+      const read = readOwnershipRef.current.beginRead();
       try {
         const result = await api.listInbox({
           platform: 'avibe',
@@ -183,6 +199,7 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
           handleError: false,
         });
         const row = result.sessions.find((s) => s.session_id === sessionId);
+        if (!readOwnershipRef.current.isCurrent(read)) return;
         if (row) setInboxSessions((prev) => upsertSession(prev, row));
         applyUnreadMap(result.unread_by_session ?? {});
       } catch (err) {
@@ -207,6 +224,7 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
     }
     const disconnect = api.connectWorkbenchEvents({
       onInboxSessionUpdated: (row) => {
+        acceptSessionMutation();
         setInboxSessions((prev) => upsertSession(prev, row));
         setUnreadBySession((prev) => {
           if ((prev[row.session_id] ?? 0) === row.unread_count) return prev;
@@ -217,11 +235,13 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
         });
       },
       onInboxUnreadChanged: (data) => {
+        acceptSessionMutation();
         if (data?.unread_by_session) {
           applyUnreadMap(data.unread_by_session);
         }
       },
       onSessionActivity: (data) => {
+        acceptSessionMutation();
         // Contract A6: react to visibility/scope changes carried on the event.
         // background ⇒ drop the card (like an archive); foreground ⇒ fetch that
         // exact session and upsert its card so it reappears even if it sorts past
@@ -250,7 +270,7 @@ export const WorkbenchInboxProvider = ({ children }: { children: ReactNode }) =>
       },
     });
     return disconnect;
-  }, [api, refresh, reconcile, reconcileSession, applyUnreadMap]);
+  }, [acceptSessionMutation, api, refresh, reconcile, reconcileSession, applyUnreadMap]);
 
   // Recover after the OS suspended us. A backgrounded mobile PWA has its page
   // frozen and its SSE socket dropped, and the broker never replays the gap;

--- a/ui/src/context/WorkbenchProjectsProvider.tsx
+++ b/ui/src/context/WorkbenchProjectsProvider.tsx
@@ -123,6 +123,8 @@ export const WorkbenchProjectsProvider: React.FC<{ children: ReactNode }> = ({ c
   // paginated read, or targeted row read that started before a newer mutation
   // must not commit its snapshot after that mutation is accepted.
   const readOwnershipRef = useRef(createWorkbenchSessionReadOwnership());
+  const authoritativeProjectsLoadedRef = useRef(false);
+  const bootstrapRetryPendingRef = useRef(false);
 
   const acceptSessionMutation = useCallback(() => {
     readOwnershipRef.current.acceptMutation();
@@ -161,9 +163,26 @@ export const WorkbenchProjectsProvider: React.FC<{ children: ReactNode }> = ({ c
 
   const fetchProjects = useCallback(async (options?: { cache?: boolean }) => {
     const read = readOwnershipRef.current.beginRead(['projects', 'projects-bootstrap']);
+    const retryAfterMutation = () => {
+      if (
+        authoritativeProjectsLoadedRef.current ||
+        readOwnershipRef.current.epoch() === read.epoch ||
+        bootstrapRetryPendingRef.current
+      ) {
+        return;
+      }
+      bootstrapRetryPendingRef.current = true;
+      queueMicrotask(() => {
+        bootstrapRetryPendingRef.current = false;
+        if (!authoritativeProjectsLoadedRef.current) void fetchProjects({ cache: false });
+      });
+    };
     try {
       const result = await api.getWorkbenchProjectsBootstrap({ cache: options?.cache });
-      if (!readOwnershipRef.current.isCurrent(read, 'projects')) return;
+      if (!readOwnershipRef.current.isCurrent(read, 'projects')) {
+        retryAfterMutation();
+        return;
+      }
       setProjects(result.projects);
       const pages = Object.fromEntries(
         Object.entries(result.sessions ?? {}).filter(([projectId]) =>
@@ -172,11 +191,14 @@ export const WorkbenchProjectsProvider: React.FC<{ children: ReactNode }> = ({ c
       );
       applyBootstrapSessions(pages);
       setProjectsError(null);
+      authoritativeProjectsLoadedRef.current = true;
     } catch (err) {
       // Don't strand consumers on an empty-state for a transient failure — keep
       // any list we had and surface the error (mobile shows a retry).
       if (readOwnershipRef.current.isCurrent(read, 'projects')) {
         setProjectsError(errorMessage(err) ?? String(err));
+      } else {
+        retryAfterMutation();
       }
     }
   }, [api, applyBootstrapSessions]);
@@ -246,6 +268,19 @@ export const WorkbenchProjectsProvider: React.FC<{ children: ReactNode }> = ({ c
       }
     },
     [api, queueReconcile, takePendingReconcile],
+  );
+
+  const queueReconcileForSession = useCallback(
+    (sessionId: string) => {
+      const entry = Object.entries(sessionsRef.current).find(([, state]) =>
+        state.sessions?.some((session) => session.id === sessionId),
+      );
+      if (!entry) return;
+      const [projectId, state] = entry;
+      if (!inFlightRef.current.has(projectId)) return;
+      queueReconcile(projectId, state.sessions?.length ?? 0);
+    },
+    [queueReconcile],
   );
 
   const reconcileProjectTree = useCallback(async () => {
@@ -467,6 +502,7 @@ export const WorkbenchProjectsProvider: React.FC<{ children: ReactNode }> = ({ c
       },
       onSessionStatus: ({ session_id, agent_status }) => {
         acceptSessionMutation();
+        queueReconcileForSession(session_id);
         setSessions((prev) =>
           patchSessionRow(prev, session_id, (s) => (s.agent_status === agent_status ? s : { ...s, agent_status })),
         );
@@ -474,6 +510,7 @@ export const WorkbenchProjectsProvider: React.FC<{ children: ReactNode }> = ({ c
       },
       onTurnEnd: ({ session_id }) => {
         acceptSessionMutation();
+        queueReconcileForSession(session_id);
         // The first turn can bind the native_session_id server-side, but the
         // status event only carries the dot state. Refresh the cached row so
         // actions gated on native binding, such as Fork session, unlock without
@@ -482,7 +519,14 @@ export const WorkbenchProjectsProvider: React.FC<{ children: ReactNode }> = ({ c
       },
     });
     return disconnect;
-  }, [acceptSessionMutation, api, reconcileProjectTree, reconcileSessions, refreshCachedSessionRow]);
+  }, [
+    acceptSessionMutation,
+    api,
+    queueReconcileForSession,
+    reconcileProjectTree,
+    reconcileSessions,
+    refreshCachedSessionRow,
+  ]);
 
   const toggleExpanded = useCallback(
     (projectId: string) => {

--- a/ui/src/context/WorkbenchProjectsProvider.tsx
+++ b/ui/src/context/WorkbenchProjectsProvider.tsx
@@ -353,7 +353,7 @@ export const WorkbenchProjectsProvider: React.FC<{ children: ReactNode }> = ({ c
     }
     bootstrapReadInFlightRef.current = true;
     const retryAfterInvalidation = (read: WorkbenchSessionReadStamp) => {
-      if (readOwnershipRef.current.isCurrent(read, 'projects-bootstrap')) return;
+      if (readOwnershipRef.current.isCurrent(read, ['projects', 'projects-bootstrap'])) return;
       queueProjectTreeIntent();
     };
     const bootstrapGroups = new Map<number, string[]>();
@@ -417,7 +417,7 @@ export const WorkbenchProjectsProvider: React.FC<{ children: ReactNode }> = ({ c
         );
         applyBootstrapSessions(read, currentPages);
       }
-      if (!readOwnershipRef.current.isCurrent(read, 'projects-bootstrap')) {
+      if (!readOwnershipRef.current.isCurrent(read, ['projects', 'projects-bootstrap'])) {
         retryAfterInvalidation(read);
         return;
       }
@@ -426,7 +426,7 @@ export const WorkbenchProjectsProvider: React.FC<{ children: ReactNode }> = ({ c
         void reconcileSessions(projectId);
       }
     } catch (err) {
-      if (!readOwnershipRef.current.isCurrent(read, 'projects-bootstrap')) {
+      if (!readOwnershipRef.current.isCurrent(read, ['projects', 'projects-bootstrap'])) {
         retryAfterInvalidation(read);
         return;
       }

--- a/ui/src/context/WorkbenchProjectsProvider.tsx
+++ b/ui/src/context/WorkbenchProjectsProvider.tsx
@@ -123,6 +123,8 @@ export const WorkbenchProjectsProvider: React.FC<{ children: ReactNode }> = ({ c
   const inFlightRef = useRef<Set<string>>(new Set());
   const pendingReconcileRef = useRef<Map<string, number>>(new Map());
   const sessionProjectRef = useRef<Map<string, string>>(new Map());
+  const cachedRowRefreshInFlightRef = useRef<Set<string>>(new Set());
+  const pendingCachedRowRefreshRef = useRef<Set<string>>(new Set());
   // All reads owned by this provider share one ordering fence. A bootstrap,
   // paginated read, or targeted row read that started before a newer mutation
   // must not commit its snapshot after that mutation is accepted.
@@ -407,28 +409,41 @@ export const WorkbenchProjectsProvider: React.FC<{ children: ReactNode }> = ({ c
   }, [api, applyBootstrapSessions, queueReconcile, reconcileSessions]);
 
   const refreshCachedSessionRow = useCallback(async function refreshCachedSessionRow(sessionId: string) {
-    const projectId = Object.entries(sessionsRef.current).find(([, state]) =>
-      state.sessions?.some((session) => session.id === sessionId && !session.native_session_id),
-    )?.[0];
-    if (!projectId) return;
-    const resource = `project-session:${sessionId}`;
-    const read = readOwnershipRef.current.beginRead(resource);
+    if (cachedRowRefreshInFlightRef.current.has(sessionId)) {
+      pendingCachedRowRefreshRef.current.add(sessionId);
+      return;
+    }
+    cachedRowRefreshInFlightRef.current.add(sessionId);
     try {
-      const updated = await api.getSession(sessionId, { cache: false });
-      if (readOwnershipRef.current.isCurrent(read, resource)) {
-        sessionProjectRef.current.set(updated.id, projectId);
-        setSessions((prev) => patchSessionRow(prev, sessionId, () => updated));
-      } else if (readOwnershipRef.current.isLatestRead(read)) {
+      while (true) {
+        pendingCachedRowRefreshRef.current.delete(sessionId);
+        const projectId = Object.entries(sessionsRef.current).find(([, state]) =>
+          state.sessions?.some((session) => session.id === sessionId && !session.native_session_id),
+        )?.[0];
+        if (!projectId) return;
+        const resource = `project-session:${sessionId}`;
+        const read = readOwnershipRef.current.beginRead(resource);
+        let stale = false;
+        try {
+          const updated = await api.getSession(sessionId, { cache: false });
+          stale = !readOwnershipRef.current.isCurrent(read, resource);
+          if (!stale) {
+            sessionProjectRef.current.set(updated.id, projectId);
+            setSessions((prev) => patchSessionRow(prev, sessionId, () => updated));
+            return;
+          }
+        } catch {
+          stale = !readOwnershipRef.current.isCurrent(read, resource);
+          if (!stale && !pendingCachedRowRefreshRef.current.has(sessionId)) return;
+          /* current best-effort failures are recovered by reconnect reconcile */
+        }
+        if (!stale && !pendingCachedRowRefreshRef.current.has(sessionId)) return;
+      }
+    } finally {
+      cachedRowRefreshInFlightRef.current.delete(sessionId);
+      if (pendingCachedRowRefreshRef.current.delete(sessionId)) {
         queueMicrotask(() => void refreshCachedSessionRow(sessionId));
       }
-    } catch {
-      if (
-        !readOwnershipRef.current.isCurrent(read, resource) &&
-        readOwnershipRef.current.isLatestRead(read)
-      ) {
-        queueMicrotask(() => void refreshCachedSessionRow(sessionId));
-      }
-      /* best-effort current failures are recovered by reconnect reconcile */
     }
   }, [api]);
 

--- a/ui/src/context/WorkbenchProjectsProvider.tsx
+++ b/ui/src/context/WorkbenchProjectsProvider.tsx
@@ -11,7 +11,10 @@ import {
 import { createdReconcileMinCount } from '../lib/sessionVisibilityEvents';
 import { orderProjectSessions } from '../lib/sessionPinning';
 import { errorMessage } from '@/lib/errorMessage';
-import { createWorkbenchSessionReadOwnership } from '../lib/workbenchSessionReadOwnership';
+import {
+  createWorkbenchSessionReadOwnership,
+  type WorkbenchSessionReadStamp,
+} from '../lib/workbenchSessionReadOwnership';
 
 // How many sessions to load per page under a project. The server clamps the
 // /api/sessions limit (to 200) and returns a cursor (next_before_id); both the
@@ -125,6 +128,7 @@ export const WorkbenchProjectsProvider: React.FC<{ children: ReactNode }> = ({ c
   const readOwnershipRef = useRef(createWorkbenchSessionReadOwnership());
   const authoritativeProjectsLoadedRef = useRef(false);
   const bootstrapRetryPendingRef = useRef(false);
+  const projectTreeRetryPendingRef = useRef(false);
 
   const acceptSessionMutation = useCallback(() => {
     readOwnershipRef.current.acceptMutation();
@@ -283,7 +287,21 @@ export const WorkbenchProjectsProvider: React.FC<{ children: ReactNode }> = ({ c
     [queueReconcile],
   );
 
-  const reconcileProjectTree = useCallback(async () => {
+  const reconcileProjectTree = useCallback(async function reconcileProjectTree() {
+    const retryAfterInvalidation = (read: WorkbenchSessionReadStamp) => {
+      if (
+        readOwnershipRef.current.isCurrent(read, 'projects-bootstrap') ||
+        !readOwnershipRef.current.isLatestRead(read) ||
+        projectTreeRetryPendingRef.current
+      ) {
+        return;
+      }
+      projectTreeRetryPendingRef.current = true;
+      queueMicrotask(() => {
+        projectTreeRetryPendingRef.current = false;
+        void reconcileProjectTree();
+      });
+    };
     const bootstrapGroups = new Map<number, string[]>();
     const largeProjectIds: string[] = [];
     for (const [projectId, state] of Object.entries(sessionsRef.current)) {
@@ -318,7 +336,10 @@ export const WorkbenchProjectsProvider: React.FC<{ children: ReactNode }> = ({ c
             limit,
             cache: false,
           });
-          if (!readOwnershipRef.current.isCurrent(read, 'projects-bootstrap')) return;
+          if (!readOwnershipRef.current.isCurrent(read, 'projects-bootstrap')) {
+            retryAfterInvalidation(read);
+            return;
+          }
           nextProjects = result.projects;
           for (const [projectId, page] of Object.entries(result.sessions ?? {})) {
             const currentCount = sessionsRef.current[projectId]?.sessions?.length ?? 0;
@@ -342,13 +363,19 @@ export const WorkbenchProjectsProvider: React.FC<{ children: ReactNode }> = ({ c
         );
         applyBootstrapSessions(currentPages);
       }
-      if (!readOwnershipRef.current.isCurrent(read, 'projects-bootstrap')) return;
+      if (!readOwnershipRef.current.isCurrent(read, 'projects-bootstrap')) {
+        retryAfterInvalidation(read);
+        return;
+      }
       if (readOwnershipRef.current.isCurrent(read, 'projects')) setProjectsError(null);
       for (const projectId of largeProjectIds) {
         void reconcileSessions(projectId);
       }
     } catch (err) {
-      if (!readOwnershipRef.current.isCurrent(read, 'projects-bootstrap')) return;
+      if (!readOwnershipRef.current.isCurrent(read, 'projects-bootstrap')) {
+        retryAfterInvalidation(read);
+        return;
+      }
       if (readOwnershipRef.current.isCurrent(read, 'projects')) setProjectsError(errorMessage(err) ?? String(err));
       const projectIds = [...bootstrapGroups.values()].flat();
       for (const projectId of [...projectIds, ...largeProjectIds]) {
@@ -376,7 +403,7 @@ export const WorkbenchProjectsProvider: React.FC<{ children: ReactNode }> = ({ c
   // Load the first page (append=false) or the next page (append=true) of a
   // project's sessions, with dedupe + per-project serialisation.
   const fetchSessions = useCallback(
-    async (projectId: string, opts?: { append?: boolean }) => {
+    async function fetchSessions(projectId: string, opts?: { append?: boolean }) {
       const append = opts?.append ?? false;
       if (append && !sessionsRef.current[projectId]?.cursor) return; // nothing more to load
       if (inFlightRef.current.has(projectId)) return; // serialise per project
@@ -390,11 +417,14 @@ export const WorkbenchProjectsProvider: React.FC<{ children: ReactNode }> = ({ c
       });
       const beforeId = append ? sessionsRef.current[projectId]?.cursor ?? undefined : undefined;
       const read = readOwnershipRef.current.beginRead(`project:${projectId}`);
+      let retryFirstPage = false;
       try {
         const res = await api.listSessions({ projectId, status: 'active', limit: SESSIONS_PAGE_SIZE, beforeId });
+        const currentRead = readOwnershipRef.current.isCurrent(read, ['projects-bootstrap', `project:${projectId}`]);
+        retryFirstPage = !currentRead && !append && sessionsRef.current[projectId]?.sessions === null;
         setSessions((prev) => {
           const cur = prev[projectId] ?? EMPTY_SESSIONS;
-          if (!readOwnershipRef.current.isCurrent(read, ['projects-bootstrap', `project:${projectId}`])) {
+          if (!currentRead) {
             return {
               ...prev,
               [projectId]: append ? { ...cur, loadingMore: false } : { ...cur, loading: false },
@@ -412,10 +442,12 @@ export const WorkbenchProjectsProvider: React.FC<{ children: ReactNode }> = ({ c
           };
         });
       } catch {
+        const currentRead = readOwnershipRef.current.isCurrent(read, ['projects-bootstrap', `project:${projectId}`]);
+        retryFirstPage = !currentRead && !append && sessionsRef.current[projectId]?.sessions === null;
         setSessions((prev) => {
           const cur = prev[projectId] ?? EMPTY_SESSIONS;
           if (!readOwnershipRef.current.isLatestRead(read)) return prev;
-          if (!readOwnershipRef.current.isCurrent(read, ['projects-bootstrap', `project:${projectId}`])) {
+          if (!currentRead) {
             return append
               ? { ...prev, [projectId]: { ...cur, loadingMore: false } }
               : { ...prev, [projectId]: { ...cur, loading: false } };
@@ -429,6 +461,14 @@ export const WorkbenchProjectsProvider: React.FC<{ children: ReactNode }> = ({ c
         });
       } finally {
         inFlightRef.current.delete(projectId);
+        if (retryFirstPage) {
+          queueMicrotask(() => {
+            const current = sessionsRef.current[projectId];
+            if (current?.sessions === null && !inFlightRef.current.has(projectId)) {
+              void fetchSessions(projectId);
+            }
+          });
+        }
         const pendingMinCount = takePendingReconcile(projectId);
         if (pendingMinCount !== null) {
           void reconcileSessions(projectId, { minCount: pendingMinCount });

--- a/ui/src/context/WorkbenchProjectsProvider.tsx
+++ b/ui/src/context/WorkbenchProjectsProvider.tsx
@@ -122,6 +122,7 @@ export const WorkbenchProjectsProvider: React.FC<{ children: ReactNode }> = ({ c
   // reconcile per project so they can't race or truncate an append.
   const inFlightRef = useRef<Set<string>>(new Set());
   const pendingReconcileRef = useRef<Map<string, number>>(new Map());
+  const sessionProjectRef = useRef<Map<string, string>>(new Map());
   // All reads owned by this provider share one ordering fence. A bootstrap,
   // paginated read, or targeted row read that started before a newer mutation
   // must not commit its snapshot after that mutation is accepted.
@@ -130,8 +131,23 @@ export const WorkbenchProjectsProvider: React.FC<{ children: ReactNode }> = ({ c
   const bootstrapRetryPendingRef = useRef(false);
   const projectTreeRetryPendingRef = useRef(false);
 
-  const acceptSessionMutation = useCallback(() => {
-    readOwnershipRef.current.acceptMutation();
+  const acceptSessionMutation = useCallback((projectId?: string | null, sessionId?: string) => {
+    const resources = ['projects-bootstrap'];
+    if (projectId) resources.push(`project:${projectId}`);
+    if (sessionId) resources.push(`project-session:${sessionId}`);
+    readOwnershipRef.current.acceptMutation(resources);
+  }, []);
+
+  const acceptProjectsMutation = useCallback(() => {
+    readOwnershipRef.current.acceptMutation('projects');
+  }, []);
+
+  const projectIdForSession = useCallback((sessionId: string): string | null => {
+    const known = sessionProjectRef.current.get(sessionId);
+    if (known) return known;
+    return Object.entries(sessionsRef.current).find(([, state]) =>
+      state.sessions?.some((session) => session.id === sessionId),
+    )?.[0] ?? null;
   }, []);
 
   const queueReconcile = useCallback((projectId: string, minCount = 0) => {
@@ -146,7 +162,23 @@ export const WorkbenchProjectsProvider: React.FC<{ children: ReactNode }> = ({ c
     return pending;
   }, []);
 
-  const applyBootstrapSessions = useCallback((pages: Record<string, { sessions: WorkbenchSession[]; next_before_id: string | null } | undefined>) => {
+  const acceptProjectRows = useCallback(
+    (read: WorkbenchSessionReadStamp, projectId: string, rows: WorkbenchSession[]) => {
+      for (const session of rows) {
+        readOwnershipRef.current.claimRead(read, `project-session:${session.id}`);
+        sessionProjectRef.current.set(session.id, projectId);
+      }
+    },
+    [],
+  );
+
+  const applyBootstrapSessions = useCallback((
+    read: WorkbenchSessionReadStamp,
+    pages: Record<string, { sessions: WorkbenchSession[]; next_before_id: string | null } | undefined>,
+  ) => {
+    for (const [projectId, page] of Object.entries(pages)) {
+      if (page) acceptProjectRows(read, projectId, page.sessions);
+    }
     setSessions((prev) => {
       let changed = false;
       const next = { ...prev };
@@ -163,14 +195,15 @@ export const WorkbenchProjectsProvider: React.FC<{ children: ReactNode }> = ({ c
       }
       return changed ? next : prev;
     });
-  }, []);
+  }, [acceptProjectRows]);
 
   const fetchProjects = useCallback(async (options?: { cache?: boolean }) => {
     const read = readOwnershipRef.current.beginRead(['projects', 'projects-bootstrap']);
     const retryAfterMutation = () => {
       if (
         authoritativeProjectsLoadedRef.current ||
-        readOwnershipRef.current.epoch() === read.epoch ||
+        readOwnershipRef.current.isCurrent(read, 'projects-bootstrap') ||
+        !readOwnershipRef.current.isLatestRead(read) ||
         bootstrapRetryPendingRef.current
       ) {
         return;
@@ -183,23 +216,23 @@ export const WorkbenchProjectsProvider: React.FC<{ children: ReactNode }> = ({ c
     };
     try {
       const result = await api.getWorkbenchProjectsBootstrap({ cache: options?.cache });
-      if (!readOwnershipRef.current.isCurrent(read, 'projects')) {
+      if (readOwnershipRef.current.isCurrent(read, 'projects')) setProjects(result.projects);
+      if (!readOwnershipRef.current.isCurrent(read, 'projects-bootstrap')) {
         retryAfterMutation();
         return;
       }
-      setProjects(result.projects);
       const pages = Object.fromEntries(
         Object.entries(result.sessions ?? {}).filter(([projectId]) =>
-          readOwnershipRef.current.isCurrent(read, `project:${projectId}`),
+          readOwnershipRef.current.isCurrent(read, ['projects-bootstrap', `project:${projectId}`]),
         ),
       );
-      applyBootstrapSessions(pages);
-      setProjectsError(null);
+      applyBootstrapSessions(read, pages);
+      if (readOwnershipRef.current.isCurrent(read, 'projects')) setProjectsError(null);
       authoritativeProjectsLoadedRef.current = true;
     } catch (err) {
       // Don't strand consumers on an empty-state for a transient failure — keep
       // any list we had and surface the error (mobile shows a retry).
-      if (readOwnershipRef.current.isCurrent(read, 'projects')) {
+      if (readOwnershipRef.current.isCurrent(read, ['projects', 'projects-bootstrap'])) {
         setProjectsError(errorMessage(err) ?? String(err));
       } else {
         retryAfterMutation();
@@ -242,7 +275,7 @@ export const WorkbenchProjectsProvider: React.FC<{ children: ReactNode }> = ({ c
               beforeId: before,
               cache: false,
             });
-            if (!readOwnershipRef.current.isCurrent(read, ['projects-bootstrap', `project:${projectId}`])) {
+            if (!readOwnershipRef.current.isCurrent(read, `project:${projectId}`)) {
               stale = true;
               break;
             }
@@ -255,36 +288,25 @@ export const WorkbenchProjectsProvider: React.FC<{ children: ReactNode }> = ({ c
             nextBeforeId = res.next_before_id;
             before = res.next_before_id ?? undefined;
           } while (before && acc.length < targetCount);
-          if (!stale && readOwnershipRef.current.isCurrent(read, ['projects-bootstrap', `project:${projectId}`])) {
+          if (!stale && readOwnershipRef.current.isCurrent(read, `project:${projectId}`)) {
+            acceptProjectRows(read, projectId, acc);
             setSessions((prev) => ({
               ...prev,
               [projectId]: { sessions: acc, cursor: nextBeforeId, loading: false, loadingMore: false, error: false },
             }));
           }
         } catch {
-          /* keep the current window on a failed reconcile */
+          stale = !readOwnershipRef.current.isCurrent(read, `project:${projectId}`);
+          /* keep the current window on a current failed reconcile */
         } finally {
           inFlightRef.current.delete(projectId);
         }
         const pendingMinCount = takePendingReconcile(projectId);
-        if (pendingMinCount === null) return;
-        minCount = pendingMinCount;
+        if (!stale && pendingMinCount === null) return;
+        minCount = Math.max(targetCount, pendingMinCount ?? 0);
       }
     },
-    [api, queueReconcile, takePendingReconcile],
-  );
-
-  const queueReconcileForSession = useCallback(
-    (sessionId: string) => {
-      const entry = Object.entries(sessionsRef.current).find(([, state]) =>
-        state.sessions?.some((session) => session.id === sessionId),
-      );
-      if (!entry) return;
-      const [projectId, state] = entry;
-      if (!inFlightRef.current.has(projectId)) return;
-      queueReconcile(projectId, state.sessions?.length ?? 0);
-    },
-    [queueReconcile],
+    [acceptProjectRows, api, queueReconcile, takePendingReconcile],
   );
 
   const reconcileProjectTree = useCallback(async function reconcileProjectTree() {
@@ -361,7 +383,7 @@ export const WorkbenchProjectsProvider: React.FC<{ children: ReactNode }> = ({ c
             readOwnershipRef.current.isCurrent(read, ['projects-bootstrap', `project:${projectId}`]),
           ),
         );
-        applyBootstrapSessions(currentPages);
+        applyBootstrapSessions(read, currentPages);
       }
       if (!readOwnershipRef.current.isCurrent(read, 'projects-bootstrap')) {
         retryAfterInvalidation(read);
@@ -384,19 +406,29 @@ export const WorkbenchProjectsProvider: React.FC<{ children: ReactNode }> = ({ c
     }
   }, [api, applyBootstrapSessions, queueReconcile, reconcileSessions]);
 
-  const refreshCachedSessionRow = useCallback(async (sessionId: string) => {
+  const refreshCachedSessionRow = useCallback(async function refreshCachedSessionRow(sessionId: string) {
     const projectId = Object.entries(sessionsRef.current).find(([, state]) =>
       state.sessions?.some((session) => session.id === sessionId && !session.native_session_id),
     )?.[0];
     if (!projectId) return;
-    const read = readOwnershipRef.current.beginRead(`project:${projectId}`);
+    const resource = `project-session:${sessionId}`;
+    const read = readOwnershipRef.current.beginRead(resource);
     try {
       const updated = await api.getSession(sessionId, { cache: false });
-      if (readOwnershipRef.current.isCurrent(read, ['projects-bootstrap', `project:${projectId}`])) {
+      if (readOwnershipRef.current.isCurrent(read, resource)) {
+        sessionProjectRef.current.set(updated.id, projectId);
         setSessions((prev) => patchSessionRow(prev, sessionId, () => updated));
+      } else if (readOwnershipRef.current.isLatestRead(read)) {
+        queueMicrotask(() => void refreshCachedSessionRow(sessionId));
       }
     } catch {
-      /* best-effort: reconnect reconcile will refresh the row later */
+      if (
+        !readOwnershipRef.current.isCurrent(read, resource) &&
+        readOwnershipRef.current.isLatestRead(read)
+      ) {
+        queueMicrotask(() => void refreshCachedSessionRow(sessionId));
+      }
+      /* best-effort current failures are recovered by reconnect reconcile */
     }
   }, [api]);
 
@@ -417,11 +449,12 @@ export const WorkbenchProjectsProvider: React.FC<{ children: ReactNode }> = ({ c
       });
       const beforeId = append ? sessionsRef.current[projectId]?.cursor ?? undefined : undefined;
       const read = readOwnershipRef.current.beginRead(`project:${projectId}`);
-      let retryFirstPage = false;
+      let retryAfterInvalidation = false;
       try {
         const res = await api.listSessions({ projectId, status: 'active', limit: SESSIONS_PAGE_SIZE, beforeId });
-        const currentRead = readOwnershipRef.current.isCurrent(read, ['projects-bootstrap', `project:${projectId}`]);
-        retryFirstPage = !currentRead && !append && sessionsRef.current[projectId]?.sessions === null;
+        const currentRead = readOwnershipRef.current.isCurrent(read, `project:${projectId}`);
+        retryAfterInvalidation = !currentRead && readOwnershipRef.current.isLatestRead(read);
+        if (currentRead) acceptProjectRows(read, projectId, res.sessions);
         setSessions((prev) => {
           const cur = prev[projectId] ?? EMPTY_SESSIONS;
           if (!currentRead) {
@@ -442,8 +475,8 @@ export const WorkbenchProjectsProvider: React.FC<{ children: ReactNode }> = ({ c
           };
         });
       } catch {
-        const currentRead = readOwnershipRef.current.isCurrent(read, ['projects-bootstrap', `project:${projectId}`]);
-        retryFirstPage = !currentRead && !append && sessionsRef.current[projectId]?.sessions === null;
+        const currentRead = readOwnershipRef.current.isCurrent(read, `project:${projectId}`);
+        retryAfterInvalidation = !currentRead && readOwnershipRef.current.isLatestRead(read);
         setSessions((prev) => {
           const cur = prev[projectId] ?? EMPTY_SESSIONS;
           if (!readOwnershipRef.current.isLatestRead(read)) return prev;
@@ -461,21 +494,18 @@ export const WorkbenchProjectsProvider: React.FC<{ children: ReactNode }> = ({ c
         });
       } finally {
         inFlightRef.current.delete(projectId);
-        if (retryFirstPage) {
-          queueMicrotask(() => {
-            const current = sessionsRef.current[projectId];
-            if (current?.sessions === null && !inFlightRef.current.has(projectId)) {
-              void fetchSessions(projectId);
-            }
-          });
-        }
         const pendingMinCount = takePendingReconcile(projectId);
-        if (pendingMinCount !== null) {
+        if (retryAfterInvalidation) {
+          if (pendingMinCount !== null) queueReconcile(projectId, pendingMinCount);
+          queueMicrotask(() => {
+            if (!inFlightRef.current.has(projectId)) void fetchSessions(projectId, opts);
+          });
+        } else if (pendingMinCount !== null) {
           void reconcileSessions(projectId, { minCount: pendingMinCount });
         }
       }
     },
-    [api, reconcileSessions, takePendingReconcile],
+    [acceptProjectRows, api, queueReconcile, reconcileSessions, takePendingReconcile],
   );
 
   // Keep the tree live: patch a row's status dot / title from SSE, and refetch
@@ -488,8 +518,13 @@ export const WorkbenchProjectsProvider: React.FC<{ children: ReactNode }> = ({ c
         void reconcileProjectTree();
       },
       onSessionActivity: (data) => {
-        acceptSessionMutation();
+        const projectId =
+          projectsRef.current?.find((project) => project.scope_id === data.scope_id)?.id ??
+          projectIdForSession(data.session_id);
+        if (projectId) sessionProjectRef.current.set(data.session_id, projectId);
+        acceptSessionMutation(projectId, data.session_id);
         if (data.event === 'archived') {
+          sessionProjectRef.current.delete(data.session_id);
           // Terminal archive (here or in another tab) — drop the row live.
           setSessions((prev) => removeSessionRow(prev, data.session_id));
           return;
@@ -517,7 +552,6 @@ export const WorkbenchProjectsProvider: React.FC<{ children: ReactNode }> = ({ c
             ),
           );
           if (hasPinned) {
-            const projectId = projectsRef.current?.find((project) => project.scope_id === data.scope_id)?.id;
             if (projectId) {
               const loaded = sessionsRef.current[projectId]?.sessions?.length ?? 0;
               void reconcileSessions(projectId, { minCount: loaded });
@@ -526,7 +560,6 @@ export const WorkbenchProjectsProvider: React.FC<{ children: ReactNode }> = ({ c
           return;
         }
         if (!REORDER_ACTIVITY_EVENTS.has(data.event)) return;
-        const projectId = projectsRef.current?.find((project) => project.scope_id === data.scope_id)?.id;
         if (!projectId) return;
         // Grow the window ONLY for a synthesized foreground-restore (`data.restored`,
         // set by visibilityActivityEvents on Undo): reconcile one past the loaded
@@ -541,16 +574,14 @@ export const WorkbenchProjectsProvider: React.FC<{ children: ReactNode }> = ({ c
         void reconcileSessions(projectId, { minCount });
       },
       onSessionStatus: ({ session_id, agent_status }) => {
-        acceptSessionMutation();
-        queueReconcileForSession(session_id);
+        acceptSessionMutation(projectIdForSession(session_id), session_id);
         setSessions((prev) =>
           patchSessionRow(prev, session_id, (s) => (s.agent_status === agent_status ? s : { ...s, agent_status })),
         );
         if (agent_status !== 'running') void refreshCachedSessionRow(session_id);
       },
       onTurnEnd: ({ session_id }) => {
-        acceptSessionMutation();
-        queueReconcileForSession(session_id);
+        acceptSessionMutation(projectIdForSession(session_id), session_id);
         // The first turn can bind the native_session_id server-side, but the
         // status event only carries the dot state. Refresh the cached row so
         // actions gated on native binding, such as Fork session, unlock without
@@ -562,7 +593,7 @@ export const WorkbenchProjectsProvider: React.FC<{ children: ReactNode }> = ({ c
   }, [
     acceptSessionMutation,
     api,
-    queueReconcileForSession,
+    projectIdForSession,
     reconcileProjectTree,
     reconcileSessions,
     refreshCachedSessionRow,
@@ -597,7 +628,8 @@ export const WorkbenchProjectsProvider: React.FC<{ children: ReactNode }> = ({ c
       try {
         // No overrides → omit agent fields so the server defers to the default Agent.
         const session = await api.createSession({ project_id: projectId, ...overrides });
-        acceptSessionMutation();
+        sessionProjectRef.current.set(session.id, projectId);
+        acceptSessionMutation(projectId, session.id);
         if (alreadyLoaded) {
           setSessions((prev) => {
             const cur = prev[projectId] ?? EMPTY_SESSIONS;
@@ -637,13 +669,13 @@ export const WorkbenchProjectsProvider: React.FC<{ children: ReactNode }> = ({ c
     async (projectId: string, name: string) => {
       try {
         const updated = await api.updateProject(projectId, { display_name: name });
-        acceptSessionMutation();
+        acceptProjectsMutation();
         setProjects((prev) => (prev ? prev.map((p) => (p.id === projectId ? updated : p)) : prev));
       } catch (err) {
         console.error('[workbench] rename project failed', err);
       }
     },
-    [acceptSessionMutation, api],
+    [acceptProjectsMutation, api],
   );
 
   const forkSession = useCallback(
@@ -655,7 +687,8 @@ export const WorkbenchProjectsProvider: React.FC<{ children: ReactNode }> = ({ c
       const alreadyLoaded = projectId != null && sessionsRef.current[projectId]?.sessions != null;
       try {
         const session = await api.forkSession(sessionId);
-        acceptSessionMutation();
+        if (projectId) sessionProjectRef.current.set(session.id, projectId);
+        acceptSessionMutation(projectId, session.id);
         if (projectId == null) return session;
         if (alreadyLoaded) {
           setSessions((prev) => {
@@ -699,16 +732,18 @@ export const WorkbenchProjectsProvider: React.FC<{ children: ReactNode }> = ({ c
         model: route.model,
         reasoning_effort: route.reasoning_effort,
       });
+      acceptProjectsMutation();
       setProjects((prev) => (prev ? prev.map((p) => (p.id === projectId ? updated : p)) : prev));
     },
-    [api],
+    [acceptProjectsMutation, api],
   );
 
   const archiveProject = useCallback(
     async (projectId: string) => {
       try {
         await api.archiveProject(projectId);
-        acceptSessionMutation();
+        acceptProjectsMutation();
+        acceptSessionMutation(projectId);
         setProjects((prev) => (prev ? prev.filter((p) => p.id !== projectId) : prev));
         setExpanded((prev) => {
           if (!prev.has(projectId)) return prev;
@@ -720,7 +755,7 @@ export const WorkbenchProjectsProvider: React.FC<{ children: ReactNode }> = ({ c
         console.error('[workbench] archive project failed', err);
       }
     },
-    [acceptSessionMutation, api],
+    [acceptProjectsMutation, acceptSessionMutation, api],
   );
 
   const renameSession = useCallback(
@@ -730,7 +765,7 @@ export const WorkbenchProjectsProvider: React.FC<{ children: ReactNode }> = ({ c
       // broadcast then reconciles the same value. Throws on failure (caller's
       // inline editor catches it) so a failed rename leaves the old title.
       const updated = await api.updateSession(sessionId, { title });
-      acceptSessionMutation();
+      acceptSessionMutation(projectId, sessionId);
       setSessions((prev) => {
         const state = prev[projectId];
         if (!state?.sessions) return prev;
@@ -749,7 +784,7 @@ export const WorkbenchProjectsProvider: React.FC<{ children: ReactNode }> = ({ c
   const setSessionPinned = useCallback(
     async (projectId: string | null, sessionId: string, pinned: boolean) => {
       const updated = await api.updateSession(sessionId, { pinned });
-      acceptSessionMutation();
+      acceptSessionMutation(projectId, sessionId);
       // Session-keyed: patches whatever project holds the row (none, for a
       // standalone session). Only the pinned-first re-order needs a project.
       setSessions((prev) => patchSessionRow(prev, sessionId, () => updated, true));
@@ -765,7 +800,8 @@ export const WorkbenchProjectsProvider: React.FC<{ children: ReactNode }> = ({ c
       // Archive is terminal — the API reclaims bound tasks/watches/runs server-side.
       // Drop the row from the tree on success; throw so the caller's dialog can react.
       await api.archiveSession(sessionId);
-      acceptSessionMutation();
+      acceptSessionMutation(projectId, sessionId);
+      sessionProjectRef.current.delete(sessionId);
       if (projectId == null) return; // standalone session: no tree row to drop
       setSessions((prev) => {
         const state = prev[projectId];
@@ -781,6 +817,7 @@ export const WorkbenchProjectsProvider: React.FC<{ children: ReactNode }> = ({ c
 
   const upsertProjectToTop = useCallback(
     (project: WorkbenchProject) => {
+      acceptProjectsMutation();
       // create_project is find-or-create by path: opening a tracked folder returns
       // the existing project, refreshed. Drop any stale copy, hoist to top, expand.
       setProjects((prev) => (prev ? [project, ...prev.filter((p) => p.id !== project.id)] : [project]));
@@ -794,7 +831,7 @@ export const WorkbenchProjectsProvider: React.FC<{ children: ReactNode }> = ({ c
       const state = sessionsRef.current[project.id];
       if (!state || state.sessions === null || state.error) void fetchSessions(project.id);
     },
-    [fetchSessions],
+    [acceptProjectsMutation, fetchSessions],
   );
 
   const sessionsOf = useCallback((projectId: string) => sessions[projectId] ?? EMPTY_SESSIONS, [sessions]);

--- a/ui/src/context/WorkbenchProjectsProvider.tsx
+++ b/ui/src/context/WorkbenchProjectsProvider.tsx
@@ -129,8 +129,42 @@ export const WorkbenchProjectsProvider: React.FC<{ children: ReactNode }> = ({ c
   // paginated read, or targeted row read that started before a newer mutation
   // must not commit its snapshot after that mutation is accepted.
   const readOwnershipRef = useRef(createWorkbenchSessionReadOwnership());
-  const bootstrapRetryPendingRef = useRef(false);
-  const projectTreeRetryPendingRef = useRef(false);
+  // Initial/manual project fetches and reconnect bootstraps claim the same
+  // global resources. Serialize them and retain trailing intents so a later
+  // failed recovery cannot invalidate an earlier successful snapshot.
+  const bootstrapReadInFlightRef = useRef(false);
+  const fetchProjectsPendingRef = useRef<{ cache?: boolean } | null>(null);
+  const projectTreePendingRef = useRef(false);
+  const fetchProjectsRunnerRef = useRef<(options?: { cache?: boolean }) => void>(() => {});
+  const projectTreeRunnerRef = useRef<() => void>(() => {});
+
+  const flushBootstrapReadIntent = useCallback(() => {
+    if (bootstrapReadInFlightRef.current) return;
+    const pendingFetch = fetchProjectsPendingRef.current;
+    if (pendingFetch) {
+      fetchProjectsPendingRef.current = null;
+      fetchProjectsRunnerRef.current(pendingFetch);
+      return;
+    }
+    if (projectTreePendingRef.current) {
+      projectTreePendingRef.current = false;
+      projectTreeRunnerRef.current();
+    }
+  }, []);
+
+  const queueFetchProjectsIntent = useCallback((options?: { cache?: boolean }) => {
+    const pending = fetchProjectsPendingRef.current;
+    fetchProjectsPendingRef.current =
+      options?.cache === false || pending?.cache === false
+        ? { cache: false }
+        : pending ?? options ?? {};
+    queueMicrotask(flushBootstrapReadIntent);
+  }, [flushBootstrapReadIntent]);
+
+  const queueProjectTreeIntent = useCallback(() => {
+    projectTreePendingRef.current = true;
+    queueMicrotask(flushBootstrapReadIntent);
+  }, [flushBootstrapReadIntent]);
 
   const acceptSessionMutation = useCallback((projectId?: string | null, sessionId?: string) => {
     const resources = ['projects-bootstrap'];
@@ -199,20 +233,16 @@ export const WorkbenchProjectsProvider: React.FC<{ children: ReactNode }> = ({ c
   }, [acceptProjectRows]);
 
   const fetchProjects = useCallback(async (options?: { cache?: boolean }) => {
+    if (bootstrapReadInFlightRef.current) {
+      queueFetchProjectsIntent(options);
+      return;
+    }
+    bootstrapReadInFlightRef.current = true;
     const read = readOwnershipRef.current.beginRead(['projects', 'projects-bootstrap']);
     const retryAfterMutation = () => {
-      if (
-        readOwnershipRef.current.isCurrent(read, ['projects', 'projects-bootstrap']) ||
-        !readOwnershipRef.current.isLatestRead(read) ||
-        bootstrapRetryPendingRef.current
-      ) {
-        return;
-      }
-      bootstrapRetryPendingRef.current = true;
-      queueMicrotask(() => {
-        bootstrapRetryPendingRef.current = false;
-        void fetchProjects({ cache: false });
-      });
+      if (readOwnershipRef.current.isCurrent(read, ['projects', 'projects-bootstrap'])) return;
+      // Upgrade any already-pending cached fetch to the authoritative retry.
+      queueFetchProjectsIntent({ cache: false });
     };
     try {
       const result = await api.getWorkbenchProjectsBootstrap({ cache: options?.cache });
@@ -241,8 +271,11 @@ export const WorkbenchProjectsProvider: React.FC<{ children: ReactNode }> = ({ c
       } else {
         retryAfterMutation();
       }
+    } finally {
+      bootstrapReadInFlightRef.current = false;
+      flushBootstrapReadIntent();
     }
-  }, [api, applyBootstrapSessions]);
+  }, [api, applyBootstrapSessions, flushBootstrapReadIntent, queueFetchProjectsIntent]);
 
   useEffect(() => {
     void fetchProjects();
@@ -314,19 +347,14 @@ export const WorkbenchProjectsProvider: React.FC<{ children: ReactNode }> = ({ c
   );
 
   const reconcileProjectTree = useCallback(async function reconcileProjectTree() {
+    if (bootstrapReadInFlightRef.current) {
+      queueProjectTreeIntent();
+      return;
+    }
+    bootstrapReadInFlightRef.current = true;
     const retryAfterInvalidation = (read: WorkbenchSessionReadStamp) => {
-      if (
-        readOwnershipRef.current.isCurrent(read, 'projects-bootstrap') ||
-        !readOwnershipRef.current.isLatestRead(read) ||
-        projectTreeRetryPendingRef.current
-      ) {
-        return;
-      }
-      projectTreeRetryPendingRef.current = true;
-      queueMicrotask(() => {
-        projectTreeRetryPendingRef.current = false;
-        void reconcileProjectTree();
-      });
+      if (readOwnershipRef.current.isCurrent(read, 'projects-bootstrap')) return;
+      queueProjectTreeIntent();
     };
     const bootstrapGroups = new Map<number, string[]>();
     const largeProjectIds: string[] = [];
@@ -407,8 +435,14 @@ export const WorkbenchProjectsProvider: React.FC<{ children: ReactNode }> = ({ c
       for (const projectId of [...projectIds, ...largeProjectIds]) {
         void reconcileSessions(projectId);
       }
+    } finally {
+      bootstrapReadInFlightRef.current = false;
+      flushBootstrapReadIntent();
     }
-  }, [api, applyBootstrapSessions, queueReconcile, reconcileSessions]);
+  }, [api, applyBootstrapSessions, flushBootstrapReadIntent, queueProjectTreeIntent, queueReconcile, reconcileSessions]);
+
+  fetchProjectsRunnerRef.current = (options) => void fetchProjects(options);
+  projectTreeRunnerRef.current = () => void reconcileProjectTree();
 
   const refreshCachedSessionRow = useCallback(async function refreshCachedSessionRow(sessionId: string) {
     if (cachedRowRefreshInFlightRef.current.has(sessionId)) {

--- a/ui/src/context/WorkbenchProjectsProvider.tsx
+++ b/ui/src/context/WorkbenchProjectsProvider.tsx
@@ -11,6 +11,7 @@ import {
 import { createdReconcileMinCount } from '../lib/sessionVisibilityEvents';
 import { orderProjectSessions } from '../lib/sessionPinning';
 import { errorMessage } from '@/lib/errorMessage';
+import { createWorkbenchSessionReadOwnership } from '../lib/workbenchSessionReadOwnership';
 
 // How many sessions to load per page under a project. The server clamps the
 // /api/sessions limit (to 200) and returns a cursor (next_before_id); both the
@@ -118,6 +119,14 @@ export const WorkbenchProjectsProvider: React.FC<{ children: ReactNode }> = ({ c
   // reconcile per project so they can't race or truncate an append.
   const inFlightRef = useRef<Set<string>>(new Set());
   const pendingReconcileRef = useRef<Map<string, number>>(new Map());
+  // All reads owned by this provider share one ordering fence. A bootstrap,
+  // paginated read, or targeted row read that started before a newer mutation
+  // must not commit its snapshot after that mutation is accepted.
+  const readOwnershipRef = useRef(createWorkbenchSessionReadOwnership());
+
+  const acceptSessionMutation = useCallback(() => {
+    readOwnershipRef.current.acceptMutation();
+  }, []);
 
   const queueReconcile = useCallback((projectId: string, minCount = 0) => {
     const pending = pendingReconcileRef.current.get(projectId) ?? 0;
@@ -151,15 +160,19 @@ export const WorkbenchProjectsProvider: React.FC<{ children: ReactNode }> = ({ c
   }, []);
 
   const fetchProjects = useCallback(async (options?: { cache?: boolean }) => {
+    const read = readOwnershipRef.current.beginRead();
     try {
       const result = await api.getWorkbenchProjectsBootstrap({ cache: options?.cache });
+      if (!readOwnershipRef.current.isCurrent(read)) return;
       setProjects(result.projects);
       applyBootstrapSessions(result.sessions ?? {});
       setProjectsError(null);
     } catch (err) {
       // Don't strand consumers on an empty-state for a transient failure — keep
       // any list we had and surface the error (mobile shows a retry).
-      setProjectsError(errorMessage(err) ?? String(err));
+      if (readOwnershipRef.current.isCurrent(read)) {
+        setProjectsError(errorMessage(err) ?? String(err));
+      }
     }
   }, [api, applyBootstrapSessions]);
 
@@ -183,6 +196,8 @@ export const WorkbenchProjectsProvider: React.FC<{ children: ReactNode }> = ({ c
         const targetCount = Math.max(sessionsRef.current[projectId]?.sessions?.length ?? 0, minCount);
         if (targetCount === 0) return; // nothing loaded to reconcile
         inFlightRef.current.add(projectId);
+        const read = readOwnershipRef.current.beginRead();
+        let stale = false;
         try {
           const acc: WorkbenchSession[] = [];
           const seen = new Set<string>();
@@ -196,6 +211,10 @@ export const WorkbenchProjectsProvider: React.FC<{ children: ReactNode }> = ({ c
               beforeId: before,
               cache: false,
             });
+            if (!readOwnershipRef.current.isCurrent(read)) {
+              stale = true;
+              break;
+            }
             for (const s of res.sessions) {
               if (!seen.has(s.id)) {
                 seen.add(s.id);
@@ -205,10 +224,12 @@ export const WorkbenchProjectsProvider: React.FC<{ children: ReactNode }> = ({ c
             nextBeforeId = res.next_before_id;
             before = res.next_before_id ?? undefined;
           } while (before && acc.length < targetCount);
-          setSessions((prev) => ({
-            ...prev,
-            [projectId]: { sessions: acc, cursor: nextBeforeId, loading: false, loadingMore: false, error: false },
-          }));
+          if (!stale && readOwnershipRef.current.isCurrent(read)) {
+            setSessions((prev) => ({
+              ...prev,
+              [projectId]: { sessions: acc, cursor: nextBeforeId, loading: false, loadingMore: false, error: false },
+            }));
+          }
         } catch {
           /* keep the current window on a failed reconcile */
         } finally {
@@ -223,6 +244,7 @@ export const WorkbenchProjectsProvider: React.FC<{ children: ReactNode }> = ({ c
   );
 
   const reconcileProjectTree = useCallback(async () => {
+    const read = readOwnershipRef.current.beginRead();
     const bootstrapGroups = new Map<number, string[]>();
     const largeProjectIds: string[] = [];
     for (const [projectId, state] of Object.entries(sessionsRef.current)) {
@@ -245,6 +267,7 @@ export const WorkbenchProjectsProvider: React.FC<{ children: ReactNode }> = ({ c
       const groups = Array.from(bootstrapGroups.entries());
       if (groups.length === 0) {
         const result = await api.getWorkbenchProjectsBootstrap({ cache: false });
+        if (!readOwnershipRef.current.isCurrent(read)) return;
         setProjects(result.projects);
       } else {
         let nextProjects: WorkbenchProject[] | null = null;
@@ -256,6 +279,7 @@ export const WorkbenchProjectsProvider: React.FC<{ children: ReactNode }> = ({ c
             limit,
             cache: false,
           });
+          if (!readOwnershipRef.current.isCurrent(read)) return;
           nextProjects = result.projects;
           for (const [projectId, page] of Object.entries(result.sessions ?? {})) {
             const currentCount = sessionsRef.current[projectId]?.sessions?.length ?? 0;
@@ -266,14 +290,17 @@ export const WorkbenchProjectsProvider: React.FC<{ children: ReactNode }> = ({ c
             }
           }
         }
+        if (!readOwnershipRef.current.isCurrent(read)) return;
         if (nextProjects) setProjects(nextProjects);
         applyBootstrapSessions(pages);
       }
+      if (!readOwnershipRef.current.isCurrent(read)) return;
       setProjectsError(null);
       for (const projectId of largeProjectIds) {
         void reconcileSessions(projectId);
       }
     } catch (err) {
+      if (!readOwnershipRef.current.isCurrent(read)) return;
       setProjectsError(errorMessage(err) ?? String(err));
       const projectIds = [...bootstrapGroups.values()].flat();
       for (const projectId of [...projectIds, ...largeProjectIds]) {
@@ -287,9 +314,12 @@ export const WorkbenchProjectsProvider: React.FC<{ children: ReactNode }> = ({ c
       state.sessions?.some((session) => session.id === sessionId && !session.native_session_id),
     );
     if (!needsRefresh) return;
+    const read = readOwnershipRef.current.beginRead();
     try {
       const updated = await api.getSession(sessionId, { cache: false });
-      setSessions((prev) => patchSessionRow(prev, sessionId, () => updated));
+      if (readOwnershipRef.current.isCurrent(read)) {
+        setSessions((prev) => patchSessionRow(prev, sessionId, () => updated));
+      }
     } catch {
       /* best-effort: reconnect reconcile will refresh the row later */
     }
@@ -310,11 +340,18 @@ export const WorkbenchProjectsProvider: React.FC<{ children: ReactNode }> = ({ c
           [projectId]: append ? { ...cur, loadingMore: true } : { ...cur, loading: true, error: false },
         };
       });
+      const beforeId = append ? sessionsRef.current[projectId]?.cursor ?? undefined : undefined;
+      const read = readOwnershipRef.current.beginRead();
       try {
-        const beforeId = append ? sessionsRef.current[projectId]?.cursor ?? undefined : undefined;
         const res = await api.listSessions({ projectId, status: 'active', limit: SESSIONS_PAGE_SIZE, beforeId });
         setSessions((prev) => {
           const cur = prev[projectId] ?? EMPTY_SESSIONS;
+          if (!readOwnershipRef.current.isCurrent(read)) {
+            return {
+              ...prev,
+              [projectId]: append ? { ...cur, loadingMore: false } : { ...cur, loading: false },
+            };
+          }
           const existing = append ? cur.sessions ?? [] : [];
           // Cursor pages can overlap if a row's last_active_at shifts between
           // fetches (the cursor is just a row id resolved against current
@@ -329,6 +366,12 @@ export const WorkbenchProjectsProvider: React.FC<{ children: ReactNode }> = ({ c
       } catch {
         setSessions((prev) => {
           const cur = prev[projectId] ?? EMPTY_SESSIONS;
+          if (!readOwnershipRef.current.isLatestRead(read)) return prev;
+          if (!readOwnershipRef.current.isCurrent(read)) {
+            return append
+              ? { ...prev, [projectId]: { ...cur, loadingMore: false } }
+              : { ...prev, [projectId]: { ...cur, loading: false } };
+          }
           // Load-more failure: keep the list + cursor so the button stays usable.
           // First-page failure: flag error (mobile retry; re-expand refetches) and
           // keep `sessions` non-null so the desktop still renders its empty state.
@@ -357,6 +400,7 @@ export const WorkbenchProjectsProvider: React.FC<{ children: ReactNode }> = ({ c
         void reconcileProjectTree();
       },
       onSessionActivity: (data) => {
+        acceptSessionMutation();
         if (data.event === 'archived') {
           // Terminal archive (here or in another tab) — drop the row live.
           setSessions((prev) => removeSessionRow(prev, data.session_id));
@@ -409,12 +453,14 @@ export const WorkbenchProjectsProvider: React.FC<{ children: ReactNode }> = ({ c
         void reconcileSessions(projectId, { minCount });
       },
       onSessionStatus: ({ session_id, agent_status }) => {
+        acceptSessionMutation();
         setSessions((prev) =>
           patchSessionRow(prev, session_id, (s) => (s.agent_status === agent_status ? s : { ...s, agent_status })),
         );
         if (agent_status !== 'running') void refreshCachedSessionRow(session_id);
       },
       onTurnEnd: ({ session_id }) => {
+        acceptSessionMutation();
         // The first turn can bind the native_session_id server-side, but the
         // status event only carries the dot state. Refresh the cached row so
         // actions gated on native binding, such as Fork session, unlock without
@@ -423,7 +469,7 @@ export const WorkbenchProjectsProvider: React.FC<{ children: ReactNode }> = ({ c
       },
     });
     return disconnect;
-  }, [api, reconcileProjectTree, reconcileSessions, refreshCachedSessionRow]);
+  }, [acceptSessionMutation, api, reconcileProjectTree, reconcileSessions, refreshCachedSessionRow]);
 
   const toggleExpanded = useCallback(
     (projectId: string) => {
@@ -454,6 +500,7 @@ export const WorkbenchProjectsProvider: React.FC<{ children: ReactNode }> = ({ c
       try {
         // No overrides → omit agent fields so the server defers to the default Agent.
         const session = await api.createSession({ project_id: projectId, ...overrides });
+        acceptSessionMutation();
         if (alreadyLoaded) {
           setSessions((prev) => {
             const cur = prev[projectId] ?? EMPTY_SESSIONS;
@@ -486,19 +533,20 @@ export const WorkbenchProjectsProvider: React.FC<{ children: ReactNode }> = ({ c
         });
       }
     },
-    [api, fetchSessions],
+    [acceptSessionMutation, api, fetchSessions],
   );
 
   const renameProject = useCallback(
     async (projectId: string, name: string) => {
       try {
         const updated = await api.updateProject(projectId, { display_name: name });
+        acceptSessionMutation();
         setProjects((prev) => (prev ? prev.map((p) => (p.id === projectId ? updated : p)) : prev));
       } catch (err) {
         console.error('[workbench] rename project failed', err);
       }
     },
-    [api],
+    [acceptSessionMutation, api],
   );
 
   const forkSession = useCallback(
@@ -510,6 +558,7 @@ export const WorkbenchProjectsProvider: React.FC<{ children: ReactNode }> = ({ c
       const alreadyLoaded = projectId != null && sessionsRef.current[projectId]?.sessions != null;
       try {
         const session = await api.forkSession(sessionId);
+        acceptSessionMutation();
         if (projectId == null) return session;
         if (alreadyLoaded) {
           setSessions((prev) => {
@@ -537,7 +586,7 @@ export const WorkbenchProjectsProvider: React.FC<{ children: ReactNode }> = ({ c
         return null;
       }
     },
-    [api, fetchSessions],
+    [acceptSessionMutation, api, fetchSessions],
   );
 
   const setProjectDefaultAgent = useCallback(
@@ -562,6 +611,7 @@ export const WorkbenchProjectsProvider: React.FC<{ children: ReactNode }> = ({ c
     async (projectId: string) => {
       try {
         await api.archiveProject(projectId);
+        acceptSessionMutation();
         setProjects((prev) => (prev ? prev.filter((p) => p.id !== projectId) : prev));
         setExpanded((prev) => {
           if (!prev.has(projectId)) return prev;
@@ -573,7 +623,7 @@ export const WorkbenchProjectsProvider: React.FC<{ children: ReactNode }> = ({ c
         console.error('[workbench] archive project failed', err);
       }
     },
-    [api],
+    [acceptSessionMutation, api],
   );
 
   const renameSession = useCallback(
@@ -583,6 +633,7 @@ export const WorkbenchProjectsProvider: React.FC<{ children: ReactNode }> = ({ c
       // broadcast then reconciles the same value. Throws on failure (caller's
       // inline editor catches it) so a failed rename leaves the old title.
       const updated = await api.updateSession(sessionId, { title });
+      acceptSessionMutation();
       setSessions((prev) => {
         const state = prev[projectId];
         if (!state?.sessions) return prev;
@@ -595,12 +646,13 @@ export const WorkbenchProjectsProvider: React.FC<{ children: ReactNode }> = ({ c
         };
       });
     },
-    [api],
+    [acceptSessionMutation, api],
   );
 
   const setSessionPinned = useCallback(
     async (projectId: string | null, sessionId: string, pinned: boolean) => {
       const updated = await api.updateSession(sessionId, { pinned });
+      acceptSessionMutation();
       // Session-keyed: patches whatever project holds the row (none, for a
       // standalone session). Only the pinned-first re-order needs a project.
       setSessions((prev) => patchSessionRow(prev, sessionId, () => updated, true));
@@ -608,7 +660,7 @@ export const WorkbenchProjectsProvider: React.FC<{ children: ReactNode }> = ({ c
       const loaded = sessionsRef.current[projectId]?.sessions?.length ?? 0;
       void reconcileSessions(projectId, { minCount: loaded });
     },
-    [api, reconcileSessions],
+    [acceptSessionMutation, api, reconcileSessions],
   );
 
   const archiveSession = useCallback(
@@ -616,6 +668,7 @@ export const WorkbenchProjectsProvider: React.FC<{ children: ReactNode }> = ({ c
       // Archive is terminal — the API reclaims bound tasks/watches/runs server-side.
       // Drop the row from the tree on success; throw so the caller's dialog can react.
       await api.archiveSession(sessionId);
+      acceptSessionMutation();
       if (projectId == null) return; // standalone session: no tree row to drop
       setSessions((prev) => {
         const state = prev[projectId];
@@ -626,7 +679,7 @@ export const WorkbenchProjectsProvider: React.FC<{ children: ReactNode }> = ({ c
         };
       });
     },
-    [api],
+    [acceptSessionMutation, api],
   );
 
   const upsertProjectToTop = useCallback(

--- a/ui/src/context/WorkbenchProjectsProvider.tsx
+++ b/ui/src/context/WorkbenchProjectsProvider.tsx
@@ -129,7 +129,6 @@ export const WorkbenchProjectsProvider: React.FC<{ children: ReactNode }> = ({ c
   // paginated read, or targeted row read that started before a newer mutation
   // must not commit its snapshot after that mutation is accepted.
   const readOwnershipRef = useRef(createWorkbenchSessionReadOwnership());
-  const authoritativeProjectsLoadedRef = useRef(false);
   const bootstrapRetryPendingRef = useRef(false);
   const projectTreeRetryPendingRef = useRef(false);
 
@@ -203,8 +202,7 @@ export const WorkbenchProjectsProvider: React.FC<{ children: ReactNode }> = ({ c
     const read = readOwnershipRef.current.beginRead(['projects', 'projects-bootstrap']);
     const retryAfterMutation = () => {
       if (
-        authoritativeProjectsLoadedRef.current ||
-        readOwnershipRef.current.isCurrent(read, 'projects-bootstrap') ||
+        readOwnershipRef.current.isCurrent(read, ['projects', 'projects-bootstrap']) ||
         !readOwnershipRef.current.isLatestRead(read) ||
         bootstrapRetryPendingRef.current
       ) {
@@ -213,12 +211,13 @@ export const WorkbenchProjectsProvider: React.FC<{ children: ReactNode }> = ({ c
       bootstrapRetryPendingRef.current = true;
       queueMicrotask(() => {
         bootstrapRetryPendingRef.current = false;
-        if (!authoritativeProjectsLoadedRef.current) void fetchProjects({ cache: false });
+        void fetchProjects({ cache: false });
       });
     };
     try {
       const result = await api.getWorkbenchProjectsBootstrap({ cache: options?.cache });
-      if (readOwnershipRef.current.isCurrent(read, 'projects')) setProjects(result.projects);
+      const projectsCurrent = readOwnershipRef.current.isCurrent(read, 'projects');
+      if (projectsCurrent) setProjects(result.projects);
       if (!readOwnershipRef.current.isCurrent(read, 'projects-bootstrap')) {
         retryAfterMutation();
         return;
@@ -229,8 +228,11 @@ export const WorkbenchProjectsProvider: React.FC<{ children: ReactNode }> = ({ c
         ),
       );
       applyBootstrapSessions(read, pages);
-      if (readOwnershipRef.current.isCurrent(read, 'projects')) setProjectsError(null);
-      authoritativeProjectsLoadedRef.current = true;
+      if (!projectsCurrent) {
+        retryAfterMutation();
+        return;
+      }
+      setProjectsError(null);
     } catch (err) {
       // Don't strand consumers on an empty-state for a transient failure — keep
       // any list we had and surface the error (mobile shows a retry).

--- a/ui/src/context/WorkbenchProjectsProvider.tsx
+++ b/ui/src/context/WorkbenchProjectsProvider.tsx
@@ -160,17 +160,22 @@ export const WorkbenchProjectsProvider: React.FC<{ children: ReactNode }> = ({ c
   }, []);
 
   const fetchProjects = useCallback(async (options?: { cache?: boolean }) => {
-    const read = readOwnershipRef.current.beginRead();
+    const read = readOwnershipRef.current.beginRead(['projects', 'projects-bootstrap']);
     try {
       const result = await api.getWorkbenchProjectsBootstrap({ cache: options?.cache });
-      if (!readOwnershipRef.current.isCurrent(read)) return;
+      if (!readOwnershipRef.current.isCurrent(read, 'projects')) return;
       setProjects(result.projects);
-      applyBootstrapSessions(result.sessions ?? {});
+      const pages = Object.fromEntries(
+        Object.entries(result.sessions ?? {}).filter(([projectId]) =>
+          readOwnershipRef.current.isCurrent(read, `project:${projectId}`),
+        ),
+      );
+      applyBootstrapSessions(pages);
       setProjectsError(null);
     } catch (err) {
       // Don't strand consumers on an empty-state for a transient failure — keep
       // any list we had and surface the error (mobile shows a retry).
-      if (readOwnershipRef.current.isCurrent(read)) {
+      if (readOwnershipRef.current.isCurrent(read, 'projects')) {
         setProjectsError(errorMessage(err) ?? String(err));
       }
     }
@@ -196,7 +201,7 @@ export const WorkbenchProjectsProvider: React.FC<{ children: ReactNode }> = ({ c
         const targetCount = Math.max(sessionsRef.current[projectId]?.sessions?.length ?? 0, minCount);
         if (targetCount === 0) return; // nothing loaded to reconcile
         inFlightRef.current.add(projectId);
-        const read = readOwnershipRef.current.beginRead();
+        const read = readOwnershipRef.current.beginRead(`project:${projectId}`);
         let stale = false;
         try {
           const acc: WorkbenchSession[] = [];
@@ -211,7 +216,7 @@ export const WorkbenchProjectsProvider: React.FC<{ children: ReactNode }> = ({ c
               beforeId: before,
               cache: false,
             });
-            if (!readOwnershipRef.current.isCurrent(read)) {
+            if (!readOwnershipRef.current.isCurrent(read, ['projects-bootstrap', `project:${projectId}`])) {
               stale = true;
               break;
             }
@@ -224,7 +229,7 @@ export const WorkbenchProjectsProvider: React.FC<{ children: ReactNode }> = ({ c
             nextBeforeId = res.next_before_id;
             before = res.next_before_id ?? undefined;
           } while (before && acc.length < targetCount);
-          if (!stale && readOwnershipRef.current.isCurrent(read)) {
+          if (!stale && readOwnershipRef.current.isCurrent(read, ['projects-bootstrap', `project:${projectId}`])) {
             setSessions((prev) => ({
               ...prev,
               [projectId]: { sessions: acc, cursor: nextBeforeId, loading: false, loadingMore: false, error: false },
@@ -244,7 +249,6 @@ export const WorkbenchProjectsProvider: React.FC<{ children: ReactNode }> = ({ c
   );
 
   const reconcileProjectTree = useCallback(async () => {
-    const read = readOwnershipRef.current.beginRead();
     const bootstrapGroups = new Map<number, string[]>();
     const largeProjectIds: string[] = [];
     for (const [projectId, state] of Object.entries(sessionsRef.current)) {
@@ -263,12 +267,12 @@ export const WorkbenchProjectsProvider: React.FC<{ children: ReactNode }> = ({ c
       group.push(projectId);
       bootstrapGroups.set(limit, group);
     }
+    const read = readOwnershipRef.current.beginRead(['projects', 'projects-bootstrap']);
     try {
       const groups = Array.from(bootstrapGroups.entries());
       if (groups.length === 0) {
         const result = await api.getWorkbenchProjectsBootstrap({ cache: false });
-        if (!readOwnershipRef.current.isCurrent(read)) return;
-        setProjects(result.projects);
+        if (readOwnershipRef.current.isCurrent(read, 'projects')) setProjects(result.projects);
       } else {
         let nextProjects: WorkbenchProject[] | null = null;
         const pages: Record<string, { sessions: WorkbenchSession[]; next_before_id: string | null }> = {};
@@ -279,29 +283,38 @@ export const WorkbenchProjectsProvider: React.FC<{ children: ReactNode }> = ({ c
             limit,
             cache: false,
           });
-          if (!readOwnershipRef.current.isCurrent(read)) return;
+          if (!readOwnershipRef.current.isCurrent(read, 'projects-bootstrap')) return;
           nextProjects = result.projects;
           for (const [projectId, page] of Object.entries(result.sessions ?? {})) {
             const currentCount = sessionsRef.current[projectId]?.sessions?.length ?? 0;
-            if (page && !inFlightRef.current.has(projectId) && currentCount <= limit) {
+            if (
+              page &&
+              !inFlightRef.current.has(projectId) &&
+              currentCount <= limit &&
+              readOwnershipRef.current.isCurrent(read, ['projects-bootstrap', `project:${projectId}`])
+            ) {
               pages[projectId] = page;
             } else {
               queueReconcile(projectId, currentCount);
             }
           }
         }
-        if (!readOwnershipRef.current.isCurrent(read)) return;
-        if (nextProjects) setProjects(nextProjects);
-        applyBootstrapSessions(pages);
+        if (readOwnershipRef.current.isCurrent(read, 'projects') && nextProjects) setProjects(nextProjects);
+        const currentPages = Object.fromEntries(
+          Object.entries(pages).filter(([projectId]) =>
+            readOwnershipRef.current.isCurrent(read, ['projects-bootstrap', `project:${projectId}`]),
+          ),
+        );
+        applyBootstrapSessions(currentPages);
       }
-      if (!readOwnershipRef.current.isCurrent(read)) return;
-      setProjectsError(null);
+      if (!readOwnershipRef.current.isCurrent(read, 'projects-bootstrap')) return;
+      if (readOwnershipRef.current.isCurrent(read, 'projects')) setProjectsError(null);
       for (const projectId of largeProjectIds) {
         void reconcileSessions(projectId);
       }
     } catch (err) {
-      if (!readOwnershipRef.current.isCurrent(read)) return;
-      setProjectsError(errorMessage(err) ?? String(err));
+      if (!readOwnershipRef.current.isCurrent(read, 'projects-bootstrap')) return;
+      if (readOwnershipRef.current.isCurrent(read, 'projects')) setProjectsError(errorMessage(err) ?? String(err));
       const projectIds = [...bootstrapGroups.values()].flat();
       for (const projectId of [...projectIds, ...largeProjectIds]) {
         void reconcileSessions(projectId);
@@ -310,14 +323,14 @@ export const WorkbenchProjectsProvider: React.FC<{ children: ReactNode }> = ({ c
   }, [api, applyBootstrapSessions, queueReconcile, reconcileSessions]);
 
   const refreshCachedSessionRow = useCallback(async (sessionId: string) => {
-    const needsRefresh = Object.values(sessionsRef.current).some((state) =>
+    const projectId = Object.entries(sessionsRef.current).find(([, state]) =>
       state.sessions?.some((session) => session.id === sessionId && !session.native_session_id),
-    );
-    if (!needsRefresh) return;
-    const read = readOwnershipRef.current.beginRead();
+    )?.[0];
+    if (!projectId) return;
+    const read = readOwnershipRef.current.beginRead(`project:${projectId}`);
     try {
       const updated = await api.getSession(sessionId, { cache: false });
-      if (readOwnershipRef.current.isCurrent(read)) {
+      if (readOwnershipRef.current.isCurrent(read, ['projects-bootstrap', `project:${projectId}`])) {
         setSessions((prev) => patchSessionRow(prev, sessionId, () => updated));
       }
     } catch {
@@ -341,12 +354,12 @@ export const WorkbenchProjectsProvider: React.FC<{ children: ReactNode }> = ({ c
         };
       });
       const beforeId = append ? sessionsRef.current[projectId]?.cursor ?? undefined : undefined;
-      const read = readOwnershipRef.current.beginRead();
+      const read = readOwnershipRef.current.beginRead(`project:${projectId}`);
       try {
         const res = await api.listSessions({ projectId, status: 'active', limit: SESSIONS_PAGE_SIZE, beforeId });
         setSessions((prev) => {
           const cur = prev[projectId] ?? EMPTY_SESSIONS;
-          if (!readOwnershipRef.current.isCurrent(read)) {
+          if (!readOwnershipRef.current.isCurrent(read, ['projects-bootstrap', `project:${projectId}`])) {
             return {
               ...prev,
               [projectId]: append ? { ...cur, loadingMore: false } : { ...cur, loading: false },
@@ -367,7 +380,7 @@ export const WorkbenchProjectsProvider: React.FC<{ children: ReactNode }> = ({ c
         setSessions((prev) => {
           const cur = prev[projectId] ?? EMPTY_SESSIONS;
           if (!readOwnershipRef.current.isLatestRead(read)) return prev;
-          if (!readOwnershipRef.current.isCurrent(read)) {
+          if (!readOwnershipRef.current.isCurrent(read, ['projects-bootstrap', `project:${projectId}`])) {
             return append
               ? { ...prev, [projectId]: { ...cur, loadingMore: false } }
               : { ...prev, [projectId]: { ...cur, loading: false } };

--- a/ui/src/context/WorkbenchSessionReadOrdering.test.tsx
+++ b/ui/src/context/WorkbenchSessionReadOrdering.test.tsx
@@ -886,6 +886,129 @@ describe('Workbench session read ownership', () => {
     expect(inbox?.unreadBySession).toEqual({});
   });
 
+  it('does not treat targeted unread data as a complete account snapshot', async () => {
+    const staleInitialRead = deferred({
+      sessions: [],
+      next_cursor: null,
+      unread_by_session: { [sessionB.id]: 5 },
+    });
+    const replacementFailure = new Error('replacement refresh failed');
+    const listInbox = vi.fn()
+      .mockReturnValueOnce(staleInitialRead.promise)
+      .mockResolvedValueOnce({
+        sessions: [inboxRow],
+        next_cursor: null,
+        unread_by_session: { [session.id]: 3 },
+      })
+      .mockRejectedValueOnce(replacementFailure);
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    let handlers: WorkbenchEventHandlers | null = null;
+    apiRef.current = {
+      listInbox,
+      connectWorkbenchEvents: vi.fn((next) => {
+        handlers = next;
+        return vi.fn();
+      }),
+    };
+    const favicon = document.createElement('link');
+    favicon.rel = 'icon';
+    favicon.href = '/logo.png';
+    document.head.appendChild(favicon);
+    let inbox: ReturnType<typeof useWorkbenchInbox> | null = null;
+    const Probe = () => {
+      const value = useWorkbenchInbox();
+      useEffect(() => {
+        inbox = value;
+      }, [value]);
+      return null;
+    };
+
+    render(
+      <WorkbenchInboxProvider>
+        <Probe />
+      </WorkbenchInboxProvider>,
+    );
+    await settle();
+    act(() => {
+      handlers?.onSessionActivity?.({
+        session_id: session.id,
+        scope_id: session.scope_id,
+        event: 'updated',
+        visibility: 'foreground',
+      });
+    });
+    await settle();
+    expect(inbox?.unreadBySession).toEqual({ [session.id]: 3 });
+    await act(async () => {
+      staleInitialRead.resolve({
+        sessions: [],
+        next_cursor: null,
+        unread_by_session: { [sessionB.id]: 5 },
+      });
+      await staleInitialRead.promise;
+    });
+    await settle();
+
+    expect(listInbox).toHaveBeenCalledTimes(3);
+    expect(inbox?.unreadBySession).toEqual({ [session.id]: 3 });
+    expect(favicon.getAttribute('href')).toBe('/logo.png');
+    expect(consoleError).toHaveBeenCalledWith('[inbox] refresh failed', replacementFailure);
+    favicon.remove();
+    consoleError.mockRestore();
+  });
+
+  it('keeps a mark-read result across an unrelated unread event', async () => {
+    const markReadResult = deferred({ unread_by_session: { [sessionB.id]: 4 } });
+    let handlers: WorkbenchEventHandlers | null = null;
+    apiRef.current = {
+      listInbox: vi.fn().mockResolvedValue({
+        sessions: [inboxRow],
+        next_cursor: null,
+        unread_by_session: { [session.id]: 3, [sessionB.id]: 5 },
+      }),
+      markSessionRead: vi.fn().mockReturnValue(markReadResult.promise),
+      connectWorkbenchEvents: vi.fn((next) => {
+        handlers = next;
+        return vi.fn();
+      }),
+    };
+    let inbox: ReturnType<typeof useWorkbenchInbox> | null = null;
+    const Probe = () => {
+      const value = useWorkbenchInbox();
+      useEffect(() => {
+        inbox = value;
+      }, [value]);
+      return null;
+    };
+
+    render(
+      <WorkbenchInboxProvider>
+        <Probe />
+      </WorkbenchInboxProvider>,
+    );
+    await settle();
+    act(() => {
+      void inbox?.markRead(session.id);
+    });
+    await settle();
+    act(() => {
+      handlers?.onInboxUnreadChanged?.({
+        session_id: sessionB.id,
+        scope_id: sessionB.scope_id,
+        delta: -1,
+        unread_counts: { agent: 7 },
+        unread_by_session: { [session.id]: 3, [sessionB.id]: 4 },
+      });
+    });
+    await act(async () => {
+      markReadResult.resolve({ unread_by_session: { [sessionB.id]: 4 } });
+      await markReadResult.promise;
+    });
+    await settle();
+
+    expect(inbox?.unreadBySession).toEqual({ [sessionB.id]: 4 });
+  });
+
   it('keeps a successful mark-read result when an older unread snapshot finishes last', async () => {
     const markReadResult = deferred({ unread_by_session: { [sessionB.id]: 5 } });
     const staleRefresh = deferred({

--- a/ui/src/context/WorkbenchSessionReadOrdering.test.tsx
+++ b/ui/src/context/WorkbenchSessionReadOrdering.test.tsx
@@ -56,6 +56,22 @@ const project = {
   archived: false,
 };
 
+const projectB = {
+  ...project,
+  id: 'proj_b',
+  scope_id: 'scope_b',
+  display_name: 'Project B',
+  folder_path: '/tmp/project-b',
+};
+
+const sessionB = {
+  ...session,
+  id: 'ses_b',
+  scope_id: projectB.scope_id,
+  project_id: projectB.id,
+  title: 'Project B session',
+};
+
 const inboxRow = {
   session_id: session.id,
   scope_id: session.scope_id,
@@ -69,6 +85,7 @@ const inboxRow = {
 
 type FakeApi = {
   getWorkbenchProjectsBootstrap?: () => Promise<unknown>;
+  listSessions?: (args: { projectId: string }) => Promise<unknown>;
   listInbox?: () => Promise<unknown>;
   connectWorkbenchEvents: (handlers: WorkbenchEventHandlers) => () => void;
 };
@@ -145,6 +162,53 @@ describe('Workbench session read ownership', () => {
     expect(tree?.sessionsOf('proj_a').sessions).toEqual([]);
   });
 
+  it('commits concurrent reads for independent project resources', async () => {
+    const projectARead = deferred({ sessions: [session], next_before_id: null });
+    const projectBRead = deferred({ sessions: [sessionB], next_before_id: null });
+    apiRef.current = {
+      getWorkbenchProjectsBootstrap: vi.fn().mockResolvedValue({
+        projects: [project, projectB],
+        sessions: {},
+      }),
+      listSessions: vi.fn(({ projectId }) => (
+        projectId === project.id ? projectARead.promise : projectBRead.promise
+      )),
+      connectWorkbenchEvents: vi.fn(() => vi.fn()),
+    };
+    let tree: ReturnType<typeof useWorkbenchProjectsTree> | null = null;
+    const Probe = () => {
+      const value = useWorkbenchProjectsTree();
+      useEffect(() => {
+        tree = value;
+      }, [value]);
+      return null;
+    };
+
+    render(
+      <WorkbenchProjectsProvider>
+        <Probe />
+      </WorkbenchProjectsProvider>,
+    );
+    await settle();
+
+    act(() => {
+      tree?.toggleExpanded(project.id);
+      tree?.toggleExpanded(projectB.id);
+    });
+    await settle();
+    await act(async () => {
+      projectBRead.resolve({ sessions: [sessionB], next_before_id: null });
+      await projectBRead.promise;
+    });
+    await act(async () => {
+      projectARead.resolve({ sessions: [session], next_before_id: null });
+      await projectARead.promise;
+    });
+
+    expect(tree?.sessionsOf(project.id).sessions).toEqual([session]);
+    expect(tree?.sessionsOf(projectB.id).sessions).toEqual([sessionB]);
+  });
+
   it('does not let an Inbox refresh issued before hide restore the card or unread count', async () => {
     const staleRefresh = deferred({ sessions: [inboxRow], next_cursor: 'cursor_a', unread_by_session: { [session.id]: 3 } });
     let handlers: WorkbenchEventHandlers | null = null;
@@ -196,6 +260,55 @@ describe('Workbench session read ownership', () => {
     expect(inbox?.nextCursor).toBe('cursor_a');
   });
 
+  it('retries a cold Inbox refresh invalidated by activity', async () => {
+    const staleRefresh = deferred({ sessions: [inboxRow], next_cursor: 'stale_cursor', unread_by_session: { [session.id]: 3 } });
+    const listInbox = vi.fn()
+      .mockReturnValueOnce(staleRefresh.promise)
+      .mockResolvedValueOnce({ sessions: [], next_cursor: null, unread_by_session: {} });
+    let handlers: WorkbenchEventHandlers | null = null;
+    apiRef.current = {
+      listInbox,
+      connectWorkbenchEvents: vi.fn((next) => {
+        handlers = next;
+        return vi.fn();
+      }),
+    };
+    let inbox: ReturnType<typeof useWorkbenchInbox> | null = null;
+    const Probe = () => {
+      const value = useWorkbenchInbox();
+      useEffect(() => {
+        inbox = value;
+      }, [value]);
+      return null;
+    };
+
+    render(
+      <WorkbenchInboxProvider>
+        <Probe />
+      </WorkbenchInboxProvider>,
+    );
+    await settle();
+
+    act(() => {
+      handlers?.onSessionActivity?.({
+        session_id: session.id,
+        scope_id: session.scope_id,
+        event: 'updated',
+        visibility: 'background',
+      });
+    });
+    await act(async () => {
+      staleRefresh.resolve({ sessions: [inboxRow], next_cursor: 'stale_cursor', unread_by_session: { [session.id]: 3 } });
+      await staleRefresh.promise;
+    });
+    await settle();
+
+    expect(listInbox).toHaveBeenCalledTimes(2);
+    expect(inbox?.inboxSessions).toEqual([]);
+    expect(inbox?.unreadBySession).toEqual({});
+    expect(inbox?.nextCursor).toBeNull();
+  });
+
   it('keeps the targeted foreground-restore upsert and its cursor untouched', async () => {
     const listInbox = vi.fn()
       .mockResolvedValueOnce({ sessions: [], next_cursor: 'cursor_before_restore', unread_by_session: {} })
@@ -230,6 +343,12 @@ describe('Workbench session read ownership', () => {
         scope_id: session.scope_id,
         event: 'updated',
         visibility: 'foreground',
+      });
+      handlers?.onSessionActivity?.({
+        session_id: session.id,
+        scope_id: session.scope_id,
+        event: 'created',
+        restored: true,
       });
     });
     await settle();

--- a/ui/src/context/WorkbenchSessionReadOrdering.test.tsx
+++ b/ui/src/context/WorkbenchSessionReadOrdering.test.tsx
@@ -207,6 +207,52 @@ describe('Workbench session read ownership', () => {
     expect(tree?.sessionsOf(project.id).sessions).toEqual([session]);
   });
 
+  it('retries an expanded project first-page read invalidated by activity', async () => {
+    const staleFirstPage = deferred({ sessions: [session], next_before_id: null });
+    const listSessions = vi.fn()
+      .mockReturnValueOnce(staleFirstPage.promise)
+      .mockResolvedValueOnce({ sessions: [session], next_before_id: null });
+    let handlers: WorkbenchEventHandlers | null = null;
+    apiRef.current = {
+      getWorkbenchProjectsBootstrap: vi.fn().mockResolvedValue({ projects: [project], sessions: {} }),
+      listSessions,
+      connectWorkbenchEvents: vi.fn((next) => {
+        handlers = next;
+        return vi.fn();
+      }),
+    };
+    let tree: ReturnType<typeof useWorkbenchProjectsTree> | null = null;
+    const Probe = () => {
+      const value = useWorkbenchProjectsTree();
+      useEffect(() => {
+        tree = value;
+      }, [value]);
+      return null;
+    };
+
+    render(
+      <WorkbenchProjectsProvider>
+        <Probe />
+      </WorkbenchProjectsProvider>,
+    );
+    await settle();
+    act(() => {
+      tree?.toggleExpanded(project.id);
+    });
+    await settle();
+    act(() => {
+      handlers?.onSessionStatus?.({ session_id: session.id, agent_status: 'idle' });
+    });
+    await act(async () => {
+      staleFirstPage.resolve({ sessions: [session], next_before_id: null });
+      await staleFirstPage.promise;
+    });
+    await settle();
+
+    expect(listSessions).toHaveBeenCalledTimes(2);
+    expect(tree?.sessionsOf(project.id).sessions).toEqual([session]);
+  });
+
   it('commits concurrent reads for independent project resources', async () => {
     const projectARead = deferred({ sessions: [session], next_before_id: null });
     const projectBRead = deferred({ sessions: [sessionB], next_before_id: null });
@@ -304,6 +350,58 @@ describe('Workbench session read ownership', () => {
 
     expect(listSessions).toHaveBeenCalledTimes(2);
     expect(tree?.sessionsOf(project.id).sessions).toEqual([{ ...trackedSession, agent_status: 'idle' }]);
+  });
+
+  it('retries a reconnect project tree read invalidated by a live event', async () => {
+    const staleTree = deferred({ projects: [project], sessions: { [project.id]: { sessions: [session], next_before_id: null } } });
+    const refreshedSession = { ...session, title: 'Fresh after reconnect' };
+    const getWorkbenchProjectsBootstrap = vi.fn()
+      .mockResolvedValueOnce({ projects: [project], sessions: { [project.id]: { sessions: [session], next_before_id: null } } })
+      .mockReturnValueOnce(staleTree.promise)
+      .mockResolvedValueOnce({ projects: [project], sessions: { [project.id]: { sessions: [refreshedSession], next_before_id: null } } });
+    let handlers: WorkbenchEventHandlers | null = null;
+    apiRef.current = {
+      getWorkbenchProjectsBootstrap,
+      connectWorkbenchEvents: vi.fn((next) => {
+        handlers = next;
+        return vi.fn();
+      }),
+    };
+    let tree: ReturnType<typeof useWorkbenchProjectsTree> | null = null;
+    const Probe = () => {
+      const value = useWorkbenchProjectsTree();
+      useEffect(() => {
+        tree = value;
+      }, [value]);
+      return null;
+    };
+
+    render(
+      <WorkbenchProjectsProvider>
+        <Probe />
+      </WorkbenchProjectsProvider>,
+    );
+    await settle();
+    act(() => {
+      handlers?.onConnected?.({ sub_id: 3, source: 'browser' });
+    });
+    await settle();
+    act(() => {
+      handlers?.onSessionActivity?.({
+        session_id: session.id,
+        scope_id: session.scope_id,
+        event: 'updated',
+        title: 'Fresh after reconnect',
+      });
+    });
+    await act(async () => {
+      staleTree.resolve({ projects: [project], sessions: { [project.id]: { sessions: [session], next_before_id: null } } });
+      await staleTree.promise;
+    });
+    await settle();
+
+    expect(getWorkbenchProjectsBootstrap).toHaveBeenCalledTimes(3);
+    expect(tree?.sessionsOf(project.id).sessions).toEqual([refreshedSession]);
   });
 
   it('does not let an Inbox refresh issued before hide restore the card or unread count', async () => {
@@ -458,6 +556,62 @@ describe('Workbench session read ownership', () => {
     expect(inbox?.nextCursor).toBeNull();
   });
 
+  it('retries a resume reconcile superseded by load-more', async () => {
+    const staleReconcile = deferred({ sessions: [inboxRow], next_cursor: 'stale_cursor', unread_by_session: { [session.id]: 3 } });
+    const loadMoreRead = deferred({ sessions: [], next_cursor: 'cursor_after_load_more', unread_by_session: { [session.id]: 3 } });
+    const retryReconcile = deferred({ sessions: [inboxRow], next_cursor: 'cursor_after_reconcile', unread_by_session: { [session.id]: 3 } });
+    const listInbox = vi.fn()
+      .mockResolvedValueOnce({ sessions: [inboxRow], next_cursor: 'cursor_a', unread_by_session: { [session.id]: 3 } })
+      .mockReturnValueOnce(staleReconcile.promise)
+      .mockReturnValueOnce(loadMoreRead.promise)
+      .mockReturnValueOnce(retryReconcile.promise);
+    let inbox: ReturnType<typeof useWorkbenchInbox> | null = null;
+    const Probe = () => {
+      const value = useWorkbenchInbox();
+      useEffect(() => {
+        inbox = value;
+      }, [value]);
+      return null;
+    };
+
+    apiRef.current = {
+      listInbox,
+      connectWorkbenchEvents: vi.fn(() => vi.fn()),
+    };
+    render(
+      <WorkbenchInboxProvider>
+        <Probe />
+      </WorkbenchInboxProvider>,
+    );
+    await settle();
+    act(() => {
+      window.dispatchEvent(new Event('focus'));
+    });
+    await settle();
+    act(() => {
+      void inbox?.loadMore();
+    });
+    await settle();
+    await act(async () => {
+      loadMoreRead.resolve({ sessions: [], next_cursor: 'cursor_after_load_more', unread_by_session: { [session.id]: 3 } });
+      await loadMoreRead.promise;
+    });
+    await act(async () => {
+      staleReconcile.resolve({ sessions: [inboxRow], next_cursor: 'stale_cursor', unread_by_session: { [session.id]: 3 } });
+      await staleReconcile.promise;
+    });
+    await settle();
+    expect(listInbox).toHaveBeenCalledTimes(4);
+    await act(async () => {
+      retryReconcile.resolve({ sessions: [inboxRow], next_cursor: 'cursor_after_reconcile', unread_by_session: { [session.id]: 3 } });
+      await retryReconcile.promise;
+    });
+    await settle();
+
+    expect(inbox?.inboxSessions).toEqual([inboxRow]);
+    expect(inbox?.nextCursor).toBe('cursor_after_load_more');
+  });
+
   it('clears independent Inbox loading flags when reads overlap', async () => {
     const refreshRead = deferred({ sessions: [inboxRow], next_cursor: 'cursor_refresh', unread_by_session: { [session.id]: 3 } });
     const loadMoreRead = deferred({ sessions: [], next_cursor: null, unread_by_session: { [session.id]: 3 } });
@@ -608,6 +762,62 @@ describe('Workbench session read ownership', () => {
     await settle();
 
     expect(inbox?.inboxSessions.map((row) => row.session_id)).toEqual([session.id]);
+    expect(inbox?.nextCursor).toBe('cursor_after_refresh');
+  });
+
+  it('keeps a targeted restore when the broad refresh completes last', async () => {
+    const targetedRead = deferred({ sessions: [inboxRow], next_cursor: null, unread_by_session: { [session.id]: 3 } });
+    const broadRead = deferred({ sessions: [], next_cursor: 'cursor_after_refresh', unread_by_session: {} });
+    const listInbox = vi.fn()
+      .mockResolvedValueOnce({ sessions: [], next_cursor: 'cursor_before_restore', unread_by_session: {} })
+      .mockReturnValueOnce(targetedRead.promise)
+      .mockReturnValueOnce(broadRead.promise);
+    let handlers: WorkbenchEventHandlers | null = null;
+    apiRef.current = {
+      listInbox,
+      connectWorkbenchEvents: vi.fn((next) => {
+        handlers = next;
+        return vi.fn();
+      }),
+    };
+    let inbox: ReturnType<typeof useWorkbenchInbox> | null = null;
+    const Probe = () => {
+      const value = useWorkbenchInbox();
+      useEffect(() => {
+        inbox = value;
+      }, [value]);
+      return null;
+    };
+
+    render(
+      <WorkbenchInboxProvider>
+        <Probe />
+      </WorkbenchInboxProvider>,
+    );
+    await settle();
+    act(() => {
+      handlers?.onSessionActivity?.({
+        session_id: session.id,
+        scope_id: session.scope_id,
+        event: 'updated',
+        visibility: 'foreground',
+      });
+      void inbox?.refresh();
+    });
+    await settle();
+    await act(async () => {
+      targetedRead.resolve({ sessions: [inboxRow], next_cursor: null, unread_by_session: { [session.id]: 3 } });
+      await targetedRead.promise;
+    });
+    await settle();
+    await act(async () => {
+      broadRead.resolve({ sessions: [], next_cursor: 'cursor_after_refresh', unread_by_session: {} });
+      await broadRead.promise;
+    });
+    await settle();
+
+    expect(inbox?.inboxSessions.map((row) => row.session_id)).toEqual([session.id]);
+    expect(inbox?.unreadBySession).toEqual({ [session.id]: 3 });
     expect(inbox?.nextCursor).toBe('cursor_after_refresh');
   });
 });

--- a/ui/src/context/WorkbenchSessionReadOrdering.test.tsx
+++ b/ui/src/context/WorkbenchSessionReadOrdering.test.tsx
@@ -208,6 +208,54 @@ describe('Workbench session read ownership', () => {
     expect(tree?.sessionsOf(project.id).sessions).toEqual([session]);
   });
 
+  it('retries a cold project list invalidated by a local project upsert', async () => {
+    const staleBootstrap = deferred({
+      projects: [project, projectB],
+      sessions: { [project.id]: { sessions: [session], next_before_id: null } },
+    });
+    const getWorkbenchProjectsBootstrap = vi.fn()
+      .mockReturnValueOnce(staleBootstrap.promise)
+      .mockResolvedValueOnce({
+        projects: [project, projectB],
+        sessions: { [project.id]: { sessions: [session], next_before_id: null } },
+      });
+    apiRef.current = {
+      getWorkbenchProjectsBootstrap,
+      listSessions: vi.fn().mockResolvedValue({ sessions: [session], next_before_id: null }),
+      connectWorkbenchEvents: vi.fn(() => vi.fn()),
+    };
+    let tree: ReturnType<typeof useWorkbenchProjectsTree> | null = null;
+    const Probe = () => {
+      const value = useWorkbenchProjectsTree();
+      useEffect(() => {
+        tree = value;
+      }, [value]);
+      return null;
+    };
+
+    render(
+      <WorkbenchProjectsProvider>
+        <Probe />
+      </WorkbenchProjectsProvider>,
+    );
+    await settle();
+    act(() => {
+      tree?.upsertProjectToTop(project);
+    });
+    await settle();
+    await act(async () => {
+      staleBootstrap.resolve({
+        projects: [project, projectB],
+        sessions: { [project.id]: { sessions: [session], next_before_id: null } },
+      });
+      await staleBootstrap.promise;
+    });
+    await settle();
+
+    expect(getWorkbenchProjectsBootstrap).toHaveBeenCalledTimes(2);
+    expect(tree?.projects).toEqual([project, projectB]);
+  });
+
   it('retries an expanded project first-page read invalidated by activity', async () => {
     const staleFirstPage = deferred({ sessions: [session], next_before_id: null });
     const listSessions = vi.fn()
@@ -962,6 +1010,103 @@ describe('Workbench session read ownership', () => {
     expect(inbox?.nextCursor).toBe('cursor_after_load_more');
   });
 
+  it('defers a resume retry until a later load-more completes', async () => {
+    const pageRow = {
+      ...inboxRow,
+      session_id: sessionB.id,
+      scope_id: sessionB.scope_id,
+      title: sessionB.title,
+      preview_message_id: 'msg_b',
+      last_activity_at: '2026-08-10T23:00:00Z',
+    };
+    const staleReconcile = deferred({
+      sessions: [inboxRow],
+      next_cursor: 'stale_cursor',
+      unread_by_session: { [session.id]: 3 },
+    });
+    const loadMoreRead = deferred({
+      sessions: [pageRow],
+      next_cursor: 'cursor_after_load_more',
+      unread_by_session: { [session.id]: 3 },
+    });
+    const retryReconcile = deferred({
+      sessions: [inboxRow],
+      next_cursor: 'cursor_after_reconcile',
+      unread_by_session: { [session.id]: 3 },
+    });
+    const listInbox = vi.fn()
+      .mockResolvedValueOnce({
+        sessions: [inboxRow],
+        next_cursor: 'cursor_a',
+        unread_by_session: { [session.id]: 3 },
+      })
+      .mockReturnValueOnce(staleReconcile.promise)
+      .mockReturnValueOnce(loadMoreRead.promise)
+      .mockReturnValueOnce(retryReconcile.promise);
+    apiRef.current = {
+      listInbox,
+      connectWorkbenchEvents: vi.fn(() => vi.fn()),
+    };
+    let inbox: ReturnType<typeof useWorkbenchInbox> | null = null;
+    const Probe = () => {
+      const value = useWorkbenchInbox();
+      useEffect(() => {
+        inbox = value;
+      }, [value]);
+      return null;
+    };
+
+    render(
+      <WorkbenchInboxProvider>
+        <Probe />
+      </WorkbenchInboxProvider>,
+    );
+    await settle();
+    act(() => {
+      window.dispatchEvent(new Event('focus'));
+    });
+    await settle();
+    act(() => {
+      void inbox?.loadMore();
+    });
+    await settle();
+    await act(async () => {
+      staleReconcile.resolve({
+        sessions: [inboxRow],
+        next_cursor: 'stale_cursor',
+        unread_by_session: { [session.id]: 3 },
+      });
+      await staleReconcile.promise;
+    });
+    await settle();
+    expect(listInbox).toHaveBeenCalledTimes(3);
+    await act(async () => {
+      loadMoreRead.resolve({
+        sessions: [pageRow],
+        next_cursor: 'cursor_after_load_more',
+        unread_by_session: { [session.id]: 3 },
+      });
+      await loadMoreRead.promise;
+    });
+    await settle();
+    expect(listInbox).toHaveBeenCalledTimes(4);
+    await act(async () => {
+      retryReconcile.resolve({
+        sessions: [inboxRow],
+        next_cursor: 'cursor_after_reconcile',
+        unread_by_session: { [session.id]: 3 },
+      });
+      await retryReconcile.promise;
+    });
+    await settle();
+
+    expect(inbox?.inboxSessions.map((row) => row.session_id).sort()).toEqual([
+      session.id,
+      sessionB.id,
+    ]);
+    expect(inbox?.nextCursor).toBe('cursor_after_load_more');
+  });
+
   it('clears independent Inbox loading flags when reads overlap', async () => {
     const refreshRead = deferred({ sessions: [inboxRow], next_cursor: 'cursor_refresh', unread_by_session: { [session.id]: 3 } });
     const loadMoreRead = deferred({ sessions: [], next_cursor: null, unread_by_session: { [session.id]: 3 } });
@@ -1060,6 +1205,60 @@ describe('Workbench session read ownership', () => {
     expect(inbox?.inboxSessions.map((row) => row.session_id)).toEqual([session.id]);
     expect(inbox?.unreadBySession).toEqual({ [session.id]: 3 });
     expect(inbox?.nextCursor).toBe('cursor_before_restore');
+  });
+
+  it('revalidates a targeted snapshot omitted after a missed removal event', async () => {
+    const listInbox = vi.fn()
+      .mockResolvedValueOnce({ sessions: [], next_cursor: 'cursor_a', unread_by_session: {} })
+      .mockResolvedValueOnce({
+        sessions: [inboxRow],
+        next_cursor: null,
+        unread_by_session: { [session.id]: 3 },
+      })
+      .mockResolvedValueOnce({ sessions: [], next_cursor: 'cursor_after_refresh', unread_by_session: {} })
+      .mockResolvedValueOnce({ sessions: [], next_cursor: null, unread_by_session: {} });
+    let handlers: WorkbenchEventHandlers | null = null;
+    apiRef.current = {
+      listInbox,
+      connectWorkbenchEvents: vi.fn((next) => {
+        handlers = next;
+        return vi.fn();
+      }),
+    };
+    let inbox: ReturnType<typeof useWorkbenchInbox> | null = null;
+    const Probe = () => {
+      const value = useWorkbenchInbox();
+      useEffect(() => {
+        inbox = value;
+      }, [value]);
+      return null;
+    };
+
+    render(
+      <WorkbenchInboxProvider>
+        <Probe />
+      </WorkbenchInboxProvider>,
+    );
+    await settle();
+    act(() => {
+      handlers?.onSessionActivity?.({
+        session_id: session.id,
+        scope_id: session.scope_id,
+        event: 'updated',
+        visibility: 'foreground',
+      });
+    });
+    await settle();
+    expect(inbox?.inboxSessions).toEqual([inboxRow]);
+    act(() => {
+      void inbox?.refresh();
+    });
+    await settle();
+
+    expect(listInbox).toHaveBeenCalledTimes(4);
+    expect(inbox?.inboxSessions).toEqual([]);
+    expect(inbox?.unreadBySession).toEqual({});
+    expect(inbox?.nextCursor).toBe('cursor_after_refresh');
   });
 
   it('keeps a targeted restore without replacing a newer broad unread map', async () => {
@@ -1243,7 +1442,8 @@ describe('Workbench session read ownership', () => {
     const listInbox = vi.fn()
       .mockResolvedValueOnce({ sessions: [], next_cursor: 'cursor_before_restore', unread_by_session: {} })
       .mockReturnValueOnce(targetedRead.promise)
-      .mockReturnValueOnce(broadRead.promise);
+      .mockReturnValueOnce(broadRead.promise)
+      .mockResolvedValueOnce({ sessions: [inboxRow], next_cursor: null, unread_by_session: {} });
     let handlers: WorkbenchEventHandlers | null = null;
     apiRef.current = {
       listInbox,
@@ -1288,6 +1488,7 @@ describe('Workbench session read ownership', () => {
     });
     await settle();
 
+    expect(listInbox).toHaveBeenCalledTimes(4);
     expect(inbox?.inboxSessions.map((row) => row.session_id)).toEqual([session.id]);
     expect(inbox?.unreadBySession).toEqual({});
     expect(inbox?.nextCursor).toBe('cursor_after_refresh');

--- a/ui/src/context/WorkbenchSessionReadOrdering.test.tsx
+++ b/ui/src/context/WorkbenchSessionReadOrdering.test.tsx
@@ -208,6 +208,56 @@ describe('Workbench session read ownership', () => {
     expect(tree?.sessionsOf(project.id).sessions).toEqual([session]);
   });
 
+  it('serializes the initial project bootstrap with reconnect recovery', async () => {
+    const initialBootstrap = deferred({
+      projects: [project],
+      sessions: { [project.id]: { sessions: [session], next_before_id: null } },
+    });
+    const getWorkbenchProjectsBootstrap = vi.fn()
+      .mockReturnValueOnce(initialBootstrap.promise)
+      .mockRejectedValueOnce(new Error('later reconnect failed'));
+    let handlers: WorkbenchEventHandlers | null = null;
+    apiRef.current = {
+      getWorkbenchProjectsBootstrap,
+      connectWorkbenchEvents: vi.fn((next) => {
+        handlers = next;
+        return vi.fn();
+      }),
+    };
+    let tree: ReturnType<typeof useWorkbenchProjectsTree> | null = null;
+    const Probe = () => {
+      const value = useWorkbenchProjectsTree();
+      useEffect(() => {
+        tree = value;
+      }, [value]);
+      return null;
+    };
+
+    render(
+      <WorkbenchProjectsProvider>
+        <Probe />
+      </WorkbenchProjectsProvider>,
+    );
+    await settle();
+    act(() => {
+      handlers?.onConnected?.({ sub_id: 2, source: 'browser' });
+    });
+    await settle();
+    expect(getWorkbenchProjectsBootstrap).toHaveBeenCalledTimes(1);
+    await act(async () => {
+      initialBootstrap.resolve({
+        projects: [project],
+        sessions: { [project.id]: { sessions: [session], next_before_id: null } },
+      });
+      await initialBootstrap.promise;
+    });
+    await settle();
+
+    expect(getWorkbenchProjectsBootstrap).toHaveBeenCalledTimes(2);
+    expect(tree?.projects).toEqual([project]);
+    expect(tree?.sessionsOf(project.id).sessions).toEqual([session]);
+  });
+
   it('retries a cold project list invalidated by a local project upsert', async () => {
     const staleBootstrap = deferred({
       projects: [project, projectB],
@@ -1261,6 +1311,125 @@ describe('Workbench session read ownership', () => {
       sessionB.id,
     ]);
     expect(inbox?.nextCursor).toBe('cursor_after_load_more');
+  });
+
+  it('serializes duplicate resume reconciles so a later failure cannot discard an earlier success', async () => {
+    const reconciledRow = { ...inboxRow, title: 'Recovered from the first reconcile' };
+    const firstReconcile = deferred({
+      sessions: [reconciledRow],
+      next_cursor: 'cursor_after_reconcile',
+      unread_by_session: { [session.id]: 3 },
+    });
+    const laterFailure = new Error('later reconcile failed');
+    const listInbox = vi.fn()
+      .mockResolvedValueOnce({
+        sessions: [inboxRow],
+        next_cursor: 'cursor_a',
+        unread_by_session: { [session.id]: 3 },
+      })
+      .mockReturnValueOnce(firstReconcile.promise)
+      .mockRejectedValueOnce(laterFailure);
+    apiRef.current = {
+      listInbox,
+      connectWorkbenchEvents: vi.fn(() => vi.fn()),
+    };
+    let inbox: ReturnType<typeof useWorkbenchInbox> | null = null;
+    const Probe = () => {
+      const value = useWorkbenchInbox();
+      useEffect(() => {
+        inbox = value;
+      }, [value]);
+      return null;
+    };
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    render(
+      <WorkbenchInboxProvider>
+        <Probe />
+      </WorkbenchInboxProvider>,
+    );
+    await settle();
+    act(() => {
+      document.dispatchEvent(new Event('visibilitychange'));
+      window.dispatchEvent(new Event('focus'));
+    });
+    await settle();
+    expect(listInbox).toHaveBeenCalledTimes(2);
+    await act(async () => {
+      firstReconcile.resolve({
+        sessions: [reconciledRow],
+        next_cursor: 'cursor_after_reconcile',
+        unread_by_session: { [session.id]: 3 },
+      });
+      await firstReconcile.promise;
+    });
+    await settle();
+
+    expect(listInbox).toHaveBeenCalledTimes(3);
+    expect(inbox?.inboxSessions).toEqual([reconciledRow]);
+    expect(inbox?.nextCursor).toBe('cursor_a');
+    expect(consoleError).toHaveBeenCalledWith('[inbox] reconcile failed', laterFailure);
+    consoleError.mockRestore();
+  });
+
+  it('serializes duplicate refreshes so a later failure cannot discard an earlier success', async () => {
+    const refreshedRow = { ...inboxRow, title: 'Recovered from the first refresh' };
+    const firstRefresh = deferred({
+      sessions: [refreshedRow],
+      next_cursor: 'cursor_after_refresh',
+      unread_by_session: { [session.id]: 3 },
+    });
+    const laterFailure = new Error('later refresh failed');
+    const listInbox = vi.fn()
+      .mockResolvedValueOnce({
+        sessions: [inboxRow],
+        next_cursor: 'cursor_a',
+        unread_by_session: { [session.id]: 3 },
+      })
+      .mockReturnValueOnce(firstRefresh.promise)
+      .mockRejectedValueOnce(laterFailure);
+    apiRef.current = {
+      listInbox,
+      connectWorkbenchEvents: vi.fn(() => vi.fn()),
+    };
+    let inbox: ReturnType<typeof useWorkbenchInbox> | null = null;
+    const Probe = () => {
+      const value = useWorkbenchInbox();
+      useEffect(() => {
+        inbox = value;
+      }, [value]);
+      return null;
+    };
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    render(
+      <WorkbenchInboxProvider>
+        <Probe />
+      </WorkbenchInboxProvider>,
+    );
+    await settle();
+    act(() => {
+      void inbox?.refresh();
+      void inbox?.refresh();
+    });
+    await settle();
+    expect(listInbox).toHaveBeenCalledTimes(2);
+    await act(async () => {
+      firstRefresh.resolve({
+        sessions: [refreshedRow],
+        next_cursor: 'cursor_after_refresh',
+        unread_by_session: { [session.id]: 3 },
+      });
+      await firstRefresh.promise;
+    });
+    await settle();
+
+    expect(listInbox).toHaveBeenCalledTimes(3);
+    expect(inbox?.inboxSessions).toEqual([refreshedRow]);
+    expect(inbox?.nextCursor).toBe('cursor_after_refresh');
+    expect(inbox?.loading).toBe(false);
+    expect(consoleError).toHaveBeenCalledWith('[inbox] refresh failed', laterFailure);
+    consoleError.mockRestore();
   });
 
   it('clears independent Inbox loading flags when reads overlap', async () => {

--- a/ui/src/context/WorkbenchSessionReadOrdering.test.tsx
+++ b/ui/src/context/WorkbenchSessionReadOrdering.test.tsx
@@ -88,6 +88,7 @@ type FakeApi = {
   listSessions?: (args: { projectId: string }) => Promise<unknown>;
   getSession?: () => Promise<unknown>;
   listInbox?: () => Promise<unknown>;
+  markSessionRead?: () => Promise<unknown>;
   connectWorkbenchEvents: (handlers: WorkbenchEventHandlers) => () => void;
 };
 
@@ -241,7 +242,12 @@ describe('Workbench session read ownership', () => {
     });
     await settle();
     act(() => {
-      handlers?.onSessionStatus?.({ session_id: session.id, agent_status: 'idle' });
+      handlers?.onSessionActivity?.({
+        session_id: session.id,
+        scope_id: session.scope_id,
+        event: 'updated',
+        title: 'Fresh title',
+      });
     });
     await act(async () => {
       staleFirstPage.resolve({ sessions: [session], next_before_id: null });
@@ -350,6 +356,115 @@ describe('Workbench session read ownership', () => {
 
     expect(listSessions).toHaveBeenCalledTimes(2);
     expect(tree?.sessionsOf(project.id).sessions).toEqual([{ ...trackedSession, agent_status: 'idle' }]);
+  });
+
+  it('retries a created-session reconcile invalidated before the row is cached', async () => {
+    const staleRead = deferred({ sessions: [], next_before_id: null });
+    const listSessions = vi.fn()
+      .mockReturnValueOnce(staleRead.promise)
+      .mockResolvedValueOnce({ sessions: [session], next_before_id: null });
+    let handlers: WorkbenchEventHandlers | null = null;
+    apiRef.current = {
+      getWorkbenchProjectsBootstrap: vi.fn().mockResolvedValue({
+        projects: [project],
+        sessions: { [project.id]: { sessions: [], next_before_id: null } },
+      }),
+      listSessions,
+      connectWorkbenchEvents: vi.fn((next) => {
+        handlers = next;
+        return vi.fn();
+      }),
+    };
+    let tree: ReturnType<typeof useWorkbenchProjectsTree> | null = null;
+    const Probe = () => {
+      const value = useWorkbenchProjectsTree();
+      useEffect(() => {
+        tree = value;
+      }, [value]);
+      return null;
+    };
+
+    render(
+      <WorkbenchProjectsProvider>
+        <Probe />
+      </WorkbenchProjectsProvider>,
+    );
+    await settle();
+    act(() => {
+      handlers?.onSessionActivity?.({
+        session_id: session.id,
+        scope_id: session.scope_id,
+        event: 'created',
+      });
+    });
+    await settle();
+    act(() => {
+      handlers?.onSessionStatus?.({ session_id: session.id, agent_status: 'idle' });
+    });
+    await act(async () => {
+      staleRead.resolve({ sessions: [], next_before_id: null });
+      await staleRead.promise;
+    });
+    await settle();
+
+    expect(listSessions).toHaveBeenCalledTimes(2);
+    expect(tree?.sessionsOf(project.id).sessions).toEqual([session]);
+  });
+
+  it('retries an invalidated project pagination read', async () => {
+    const pageSession = { ...sessionB, scope_id: project.scope_id, project_id: project.id };
+    const stalePage = deferred({ sessions: [pageSession], next_before_id: null });
+    const listSessions = vi.fn()
+      .mockReturnValueOnce(stalePage.promise)
+      .mockResolvedValueOnce({ sessions: [pageSession], next_before_id: null });
+    let handlers: WorkbenchEventHandlers | null = null;
+    apiRef.current = {
+      getWorkbenchProjectsBootstrap: vi.fn().mockResolvedValue({
+        projects: [project],
+        sessions: { [project.id]: { sessions: [session], next_before_id: 'cursor_a' } },
+      }),
+      listSessions,
+      connectWorkbenchEvents: vi.fn((next) => {
+        handlers = next;
+        return vi.fn();
+      }),
+    };
+    let tree: ReturnType<typeof useWorkbenchProjectsTree> | null = null;
+    const Probe = () => {
+      const value = useWorkbenchProjectsTree();
+      useEffect(() => {
+        tree = value;
+      }, [value]);
+      return null;
+    };
+
+    render(
+      <WorkbenchProjectsProvider>
+        <Probe />
+      </WorkbenchProjectsProvider>,
+    );
+    await settle();
+    act(() => {
+      tree?.loadMore(project.id);
+    });
+    await settle();
+    act(() => {
+      handlers?.onSessionActivity?.({
+        session_id: session.id,
+        scope_id: session.scope_id,
+        event: 'updated',
+        title: 'Fresh title',
+      });
+    });
+    await act(async () => {
+      stalePage.resolve({ sessions: [pageSession], next_before_id: null });
+      await stalePage.promise;
+    });
+    await settle();
+
+    expect(listSessions).toHaveBeenCalledTimes(2);
+    expect(tree?.sessionsOf(project.id).sessions?.map((row) => row.id)).toEqual([session.id, pageSession.id]);
+    expect(tree?.sessionsOf(project.id).cursor).toBeNull();
   });
 
   it('retries a reconnect project tree read invalidated by a live event', async () => {
@@ -502,6 +617,58 @@ describe('Workbench session read ownership', () => {
     expect(inbox?.inboxSessions).toEqual([]);
     expect(inbox?.unreadBySession).toEqual({});
     expect(inbox?.nextCursor).toBeNull();
+  });
+
+  it('does not let an older mark-read response restore unread after hide', async () => {
+    const staleMarkRead = deferred({ unread_by_session: { [session.id]: 2 } });
+    let handlers: WorkbenchEventHandlers | null = null;
+    apiRef.current = {
+      listInbox: vi.fn().mockResolvedValue({
+        sessions: [inboxRow],
+        next_cursor: null,
+        unread_by_session: { [session.id]: 3 },
+      }),
+      markSessionRead: vi.fn().mockReturnValue(staleMarkRead.promise),
+      connectWorkbenchEvents: vi.fn((next) => {
+        handlers = next;
+        return vi.fn();
+      }),
+    };
+    let inbox: ReturnType<typeof useWorkbenchInbox> | null = null;
+    const Probe = () => {
+      const value = useWorkbenchInbox();
+      useEffect(() => {
+        inbox = value;
+      }, [value]);
+      return null;
+    };
+
+    render(
+      <WorkbenchInboxProvider>
+        <Probe />
+      </WorkbenchInboxProvider>,
+    );
+    await settle();
+    act(() => {
+      void inbox?.markRead(session.id);
+    });
+    await settle();
+    act(() => {
+      handlers?.onSessionActivity?.({
+        session_id: session.id,
+        scope_id: session.scope_id,
+        event: 'updated',
+        visibility: 'background',
+      });
+    });
+    await act(async () => {
+      staleMarkRead.resolve({ unread_by_session: { [session.id]: 2 } });
+      await staleMarkRead.promise;
+    });
+    await settle();
+
+    expect(inbox?.inboxSessions).toEqual([]);
+    expect(inbox?.unreadBySession).toEqual({});
   });
 
   it('retries a resume reconcile invalidated by activity', async () => {
@@ -711,9 +878,9 @@ describe('Workbench session read ownership', () => {
     expect(inbox?.nextCursor).toBe('cursor_before_restore');
   });
 
-  it('keeps a targeted restore when a newer broad feed read completes first', async () => {
+  it('keeps a targeted restore without replacing a newer broad unread map', async () => {
     const targetedRead = deferred({ sessions: [inboxRow], next_cursor: null, unread_by_session: { [session.id]: 3 } });
-    const broadRead = deferred({ sessions: [], next_cursor: 'cursor_after_refresh', unread_by_session: {} });
+    const broadRead = deferred({ sessions: [], next_cursor: 'cursor_after_refresh', unread_by_session: { [sessionB.id]: 5 } });
     const listInbox = vi.fn()
       .mockResolvedValueOnce({ sessions: [], next_cursor: 'cursor_before_restore', unread_by_session: {} })
       .mockReturnValueOnce(targetedRead.promise)
@@ -752,7 +919,7 @@ describe('Workbench session read ownership', () => {
     });
     await settle();
     await act(async () => {
-      broadRead.resolve({ sessions: [], next_cursor: 'cursor_after_refresh', unread_by_session: {} });
+      broadRead.resolve({ sessions: [], next_cursor: 'cursor_after_refresh', unread_by_session: { [sessionB.id]: 5 } });
       await broadRead.promise;
     });
     await act(async () => {
@@ -762,6 +929,127 @@ describe('Workbench session read ownership', () => {
     await settle();
 
     expect(inbox?.inboxSessions.map((row) => row.session_id)).toEqual([session.id]);
+    expect(inbox?.unreadBySession).toEqual({ [sessionB.id]: 5 });
+    expect(inbox?.nextCursor).toBe('cursor_after_refresh');
+  });
+
+  it('does not let an older targeted row replace a newer broad row that completed first', async () => {
+    const refreshedRow = {
+      ...inboxRow,
+      title: 'Fresh from broad feed',
+      last_activity_at: '2026-08-11T01:00:00Z',
+    };
+    const targetedRead = deferred({ sessions: [inboxRow], next_cursor: null, unread_by_session: { [session.id]: 3 } });
+    const broadRead = deferred({
+      sessions: [refreshedRow],
+      next_cursor: 'cursor_after_refresh',
+      unread_by_session: { [session.id]: 4 },
+    });
+    const listInbox = vi.fn()
+      .mockResolvedValueOnce({ sessions: [], next_cursor: 'cursor_before_restore', unread_by_session: {} })
+      .mockReturnValueOnce(targetedRead.promise)
+      .mockReturnValueOnce(broadRead.promise);
+    let handlers: WorkbenchEventHandlers | null = null;
+    apiRef.current = {
+      listInbox,
+      connectWorkbenchEvents: vi.fn((next) => {
+        handlers = next;
+        return vi.fn();
+      }),
+    };
+    let inbox: ReturnType<typeof useWorkbenchInbox> | null = null;
+    const Probe = () => {
+      const value = useWorkbenchInbox();
+      useEffect(() => {
+        inbox = value;
+      }, [value]);
+      return null;
+    };
+
+    render(
+      <WorkbenchInboxProvider>
+        <Probe />
+      </WorkbenchInboxProvider>,
+    );
+    await settle();
+    act(() => {
+      handlers?.onSessionActivity?.({
+        session_id: session.id,
+        scope_id: session.scope_id,
+        event: 'updated',
+        visibility: 'foreground',
+      });
+      void inbox?.refresh();
+    });
+    await settle();
+    await act(async () => {
+      broadRead.resolve({
+        sessions: [refreshedRow],
+        next_cursor: 'cursor_after_refresh',
+        unread_by_session: { [session.id]: 4 },
+      });
+      await broadRead.promise;
+    });
+    await act(async () => {
+      targetedRead.resolve({ sessions: [inboxRow], next_cursor: null, unread_by_session: { [session.id]: 3 } });
+      await targetedRead.promise;
+    });
+    await settle();
+
+    expect(inbox?.inboxSessions).toEqual([refreshedRow]);
+    expect(inbox?.unreadBySession).toEqual({ [session.id]: 4 });
+    expect(inbox?.nextCursor).toBe('cursor_after_refresh');
+  });
+
+  it('lets a later broad feed replace a targeted session snapshot', async () => {
+    const refreshedRow = {
+      ...inboxRow,
+      title: 'Fresh from broad feed',
+      last_activity_at: '2026-08-11T01:00:00Z',
+    };
+    const listInbox = vi.fn()
+      .mockResolvedValueOnce({ sessions: [], next_cursor: 'cursor_before_restore', unread_by_session: {} })
+      .mockResolvedValueOnce({ sessions: [inboxRow], next_cursor: null, unread_by_session: { [session.id]: 3 } })
+      .mockResolvedValueOnce({ sessions: [refreshedRow], next_cursor: 'cursor_after_refresh', unread_by_session: { [session.id]: 4 } });
+    let handlers: WorkbenchEventHandlers | null = null;
+    apiRef.current = {
+      listInbox,
+      connectWorkbenchEvents: vi.fn((next) => {
+        handlers = next;
+        return vi.fn();
+      }),
+    };
+    let inbox: ReturnType<typeof useWorkbenchInbox> | null = null;
+    const Probe = () => {
+      const value = useWorkbenchInbox();
+      useEffect(() => {
+        inbox = value;
+      }, [value]);
+      return null;
+    };
+
+    render(
+      <WorkbenchInboxProvider>
+        <Probe />
+      </WorkbenchInboxProvider>,
+    );
+    await settle();
+    act(() => {
+      handlers?.onSessionActivity?.({
+        session_id: session.id,
+        scope_id: session.scope_id,
+        event: 'updated',
+        visibility: 'foreground',
+      });
+    });
+    await settle();
+    act(() => {
+      void inbox?.refresh();
+    });
+    await settle();
+
+    expect(inbox?.inboxSessions).toEqual([refreshedRow]);
+    expect(inbox?.unreadBySession).toEqual({ [session.id]: 4 });
     expect(inbox?.nextCursor).toBe('cursor_after_refresh');
   });
 
@@ -817,7 +1105,7 @@ describe('Workbench session read ownership', () => {
     await settle();
 
     expect(inbox?.inboxSessions.map((row) => row.session_id)).toEqual([session.id]);
-    expect(inbox?.unreadBySession).toEqual({ [session.id]: 3 });
+    expect(inbox?.unreadBySession).toEqual({});
     expect(inbox?.nextCursor).toBe('cursor_after_refresh');
   });
 });

--- a/ui/src/context/WorkbenchSessionReadOrdering.test.tsx
+++ b/ui/src/context/WorkbenchSessionReadOrdering.test.tsx
@@ -902,6 +902,83 @@ describe('Workbench session read ownership', () => {
     expect(inbox?.nextCursor).toBe('cursor_after_refresh');
   });
 
+  it('defers a later Inbox refresh until an in-flight load-more completes', async () => {
+    const pageRow = {
+      ...inboxRow,
+      session_id: sessionB.id,
+      scope_id: sessionB.scope_id,
+      title: sessionB.title,
+      preview_message_id: 'msg_b',
+      last_activity_at: '2026-08-10T23:00:00Z',
+    };
+    const loadMoreRead = deferred({
+      sessions: [pageRow],
+      next_cursor: 'cursor_after_load_more',
+      unread_by_session: { [session.id]: 3 },
+    });
+    const refreshedRow = { ...inboxRow, title: 'Fresh after deferred refresh' };
+    const refreshRead = deferred({
+      sessions: [refreshedRow],
+      next_cursor: 'cursor_after_refresh',
+      unread_by_session: { [session.id]: 3 },
+    });
+    const listInbox = vi.fn()
+      .mockResolvedValueOnce({
+        sessions: [inboxRow],
+        next_cursor: 'cursor_a',
+        unread_by_session: { [session.id]: 3 },
+      })
+      .mockReturnValueOnce(loadMoreRead.promise)
+      .mockReturnValueOnce(refreshRead.promise);
+    apiRef.current = {
+      listInbox,
+      connectWorkbenchEvents: vi.fn(() => vi.fn()),
+    };
+    let inbox: ReturnType<typeof useWorkbenchInbox> | null = null;
+    const Probe = () => {
+      const value = useWorkbenchInbox();
+      useEffect(() => {
+        inbox = value;
+      }, [value]);
+      return null;
+    };
+
+    render(
+      <WorkbenchInboxProvider>
+        <Probe />
+      </WorkbenchInboxProvider>,
+    );
+    await settle();
+    act(() => {
+      void inbox?.loadMore();
+      void inbox?.refresh();
+    });
+    await settle();
+    expect(listInbox).toHaveBeenCalledTimes(2);
+    await act(async () => {
+      loadMoreRead.resolve({
+        sessions: [pageRow],
+        next_cursor: 'cursor_after_load_more',
+        unread_by_session: { [session.id]: 3 },
+      });
+      await loadMoreRead.promise;
+    });
+    await settle();
+    expect(listInbox).toHaveBeenCalledTimes(3);
+    await act(async () => {
+      refreshRead.resolve({
+        sessions: [refreshedRow],
+        next_cursor: 'cursor_after_refresh',
+        unread_by_session: { [session.id]: 3 },
+      });
+      await refreshRead.promise;
+    });
+    await settle();
+
+    expect(inbox?.inboxSessions).toEqual([refreshedRow]);
+    expect(inbox?.nextCursor).toBe('cursor_after_refresh');
+  });
+
   it('retries a resume reconcile invalidated by activity', async () => {
     const staleReconcile = deferred({ sessions: [inboxRow], next_cursor: 'stale_cursor', unread_by_session: { [session.id]: 3 } });
     const listInbox = vi.fn()
@@ -1097,6 +1174,85 @@ describe('Workbench session read ownership', () => {
         unread_by_session: { [session.id]: 3 },
       });
       await retryReconcile.promise;
+    });
+    await settle();
+
+    expect(inbox?.inboxSessions.map((row) => row.session_id).sort()).toEqual([
+      session.id,
+      sessionB.id,
+    ]);
+    expect(inbox?.nextCursor).toBe('cursor_after_load_more');
+  });
+
+  it('defers a later resume reconcile until an in-flight load-more completes', async () => {
+    const pageRow = {
+      ...inboxRow,
+      session_id: sessionB.id,
+      scope_id: sessionB.scope_id,
+      title: sessionB.title,
+      preview_message_id: 'msg_b',
+      last_activity_at: '2026-08-10T23:00:00Z',
+    };
+    const loadMoreRead = deferred({
+      sessions: [pageRow],
+      next_cursor: 'cursor_after_load_more',
+      unread_by_session: { [session.id]: 3 },
+    });
+    const reconcileRead = deferred({
+      sessions: [inboxRow],
+      next_cursor: 'cursor_after_reconcile',
+      unread_by_session: { [session.id]: 3 },
+    });
+    const listInbox = vi.fn()
+      .mockResolvedValueOnce({
+        sessions: [inboxRow],
+        next_cursor: 'cursor_a',
+        unread_by_session: { [session.id]: 3 },
+      })
+      .mockReturnValueOnce(loadMoreRead.promise)
+      .mockReturnValueOnce(reconcileRead.promise);
+    apiRef.current = {
+      listInbox,
+      connectWorkbenchEvents: vi.fn(() => vi.fn()),
+    };
+    let inbox: ReturnType<typeof useWorkbenchInbox> | null = null;
+    const Probe = () => {
+      const value = useWorkbenchInbox();
+      useEffect(() => {
+        inbox = value;
+      }, [value]);
+      return null;
+    };
+
+    render(
+      <WorkbenchInboxProvider>
+        <Probe />
+      </WorkbenchInboxProvider>,
+    );
+    await settle();
+    act(() => {
+      void inbox?.loadMore();
+      window.dispatchEvent(new Event('focus'));
+    });
+    await settle();
+    expect(listInbox).toHaveBeenCalledTimes(2);
+    await act(async () => {
+      loadMoreRead.resolve({
+        sessions: [pageRow],
+        next_cursor: 'cursor_after_load_more',
+        unread_by_session: { [session.id]: 3 },
+      });
+      await loadMoreRead.promise;
+    });
+    await settle();
+    expect(listInbox).toHaveBeenCalledTimes(3);
+    await act(async () => {
+      reconcileRead.resolve({
+        sessions: [inboxRow],
+        next_cursor: 'cursor_after_reconcile',
+        unread_by_session: { [session.id]: 3 },
+      });
+      await reconcileRead.promise;
     });
     await settle();
 

--- a/ui/src/context/WorkbenchSessionReadOrdering.test.tsx
+++ b/ui/src/context/WorkbenchSessionReadOrdering.test.tsx
@@ -306,6 +306,68 @@ describe('Workbench session read ownership', () => {
     expect(tree?.projects).toEqual([project, projectB]);
   });
 
+  it('retries reconnect project recovery invalidated by a local project upsert', async () => {
+    const recoveredProject = { ...project, display_name: 'Project A from recovery' };
+    const localProject = { ...project, display_name: 'Project A opened locally' };
+    const staleReconnect = deferred({
+      projects: [recoveredProject, projectB],
+      sessions: { [project.id]: { sessions: [session], next_before_id: null } },
+    });
+    const getWorkbenchProjectsBootstrap = vi.fn()
+      .mockResolvedValueOnce({
+        projects: [project],
+        sessions: { [project.id]: { sessions: [session], next_before_id: null } },
+      })
+      .mockReturnValueOnce(staleReconnect.promise)
+      .mockResolvedValueOnce({
+        projects: [localProject, projectB],
+        sessions: { [project.id]: { sessions: [session], next_before_id: null } },
+      });
+    let handlers: WorkbenchEventHandlers | null = null;
+    apiRef.current = {
+      getWorkbenchProjectsBootstrap,
+      connectWorkbenchEvents: vi.fn((next) => {
+        handlers = next;
+        return vi.fn();
+      }),
+    };
+    let tree: ReturnType<typeof useWorkbenchProjectsTree> | null = null;
+    const Probe = () => {
+      const value = useWorkbenchProjectsTree();
+      useEffect(() => {
+        tree = value;
+      }, [value]);
+      return null;
+    };
+
+    render(
+      <WorkbenchProjectsProvider>
+        <Probe />
+      </WorkbenchProjectsProvider>,
+    );
+    await settle();
+    act(() => {
+      handlers?.onConnected?.({ sub_id: 3, source: 'browser' });
+    });
+    await settle();
+    expect(getWorkbenchProjectsBootstrap).toHaveBeenCalledTimes(2);
+    act(() => {
+      tree?.upsertProjectToTop(localProject);
+    });
+    await act(async () => {
+      staleReconnect.resolve({
+        projects: [recoveredProject, projectB],
+        sessions: { [project.id]: { sessions: [session], next_before_id: null } },
+      });
+      await staleReconnect.promise;
+    });
+    await settle();
+
+    expect(getWorkbenchProjectsBootstrap).toHaveBeenCalledTimes(3);
+    expect(tree?.projects).toEqual([localProject, projectB]);
+    expect(tree?.sessionsOf(project.id).sessions).toEqual([session]);
+  });
+
   it('retries an expanded project first-page read invalidated by activity', async () => {
     const staleFirstPage = deferred({ sessions: [session], next_before_id: null });
     const listSessions = vi.fn()
@@ -1631,7 +1693,8 @@ describe('Workbench session read ownership', () => {
     const listInbox = vi.fn()
       .mockResolvedValueOnce({ sessions: [], next_cursor: 'cursor_before_restore', unread_by_session: {} })
       .mockReturnValueOnce(targetedRead.promise)
-      .mockReturnValueOnce(broadRead.promise);
+      .mockReturnValueOnce(broadRead.promise)
+      .mockResolvedValueOnce({ sessions: [inboxRow], next_cursor: null, unread_by_session: { [session.id]: 3 } });
     let handlers: WorkbenchEventHandlers | null = null;
     apiRef.current = {
       listInbox,
@@ -1675,9 +1738,184 @@ describe('Workbench session read ownership', () => {
     });
     await settle();
 
+    expect(listInbox).toHaveBeenCalledTimes(4);
     expect(inbox?.inboxSessions.map((row) => row.session_id)).toEqual([session.id]);
-    expect(inbox?.unreadBySession).toEqual({ [sessionB.id]: 5 });
+    expect(inbox?.unreadBySession).toEqual({ [sessionB.id]: 5, [session.id]: 3 });
     expect(inbox?.nextCursor).toBe('cursor_after_refresh');
+  });
+
+  it('revalidates an in-flight targeted read omitted by a newer broad refresh', async () => {
+    const targetedRead = deferred({ sessions: [inboxRow], next_cursor: null, unread_by_session: { [session.id]: 3 } });
+    const broadRead = deferred({ sessions: [], next_cursor: 'cursor_after_refresh', unread_by_session: {} });
+    const exactRevalidation = deferred({ sessions: [], next_cursor: null, unread_by_session: {} });
+    const listInbox = vi.fn()
+      .mockResolvedValueOnce({ sessions: [], next_cursor: 'cursor_before_restore', unread_by_session: {} })
+      .mockReturnValueOnce(targetedRead.promise)
+      .mockReturnValueOnce(broadRead.promise)
+      .mockReturnValueOnce(exactRevalidation.promise);
+    let handlers: WorkbenchEventHandlers | null = null;
+    apiRef.current = {
+      listInbox,
+      connectWorkbenchEvents: vi.fn((next) => {
+        handlers = next;
+        return vi.fn();
+      }),
+    };
+    let inbox: ReturnType<typeof useWorkbenchInbox> | null = null;
+    const Probe = () => {
+      const value = useWorkbenchInbox();
+      useEffect(() => {
+        inbox = value;
+      }, [value]);
+      return null;
+    };
+
+    render(
+      <WorkbenchInboxProvider>
+        <Probe />
+      </WorkbenchInboxProvider>,
+    );
+    await settle();
+    act(() => {
+      handlers?.onSessionActivity?.({
+        session_id: session.id,
+        scope_id: session.scope_id,
+        event: 'updated',
+        visibility: 'foreground',
+      });
+      void inbox?.refresh();
+    });
+    await settle();
+    await act(async () => {
+      broadRead.resolve({ sessions: [], next_cursor: 'cursor_after_refresh', unread_by_session: {} });
+      await broadRead.promise;
+    });
+    await act(async () => {
+      targetedRead.resolve({ sessions: [inboxRow], next_cursor: null, unread_by_session: { [session.id]: 3 } });
+      await targetedRead.promise;
+    });
+    await settle();
+
+    expect(listInbox).toHaveBeenCalledTimes(4);
+    expect(inbox?.inboxSessions).toEqual([]);
+    expect(inbox?.unreadBySession).toEqual({});
+    await act(async () => {
+      exactRevalidation.resolve({ sessions: [], next_cursor: null, unread_by_session: {} });
+      await exactRevalidation.promise;
+    });
+    await settle();
+
+    expect(inbox?.inboxSessions).toEqual([]);
+    expect(inbox?.unreadBySession).toEqual({});
+    expect(inbox?.nextCursor).toBe('cursor_after_refresh');
+  });
+
+  it('keeps targeted unread data when a newer broad refresh fails', async () => {
+    const targetedRead = deferred({ sessions: [inboxRow], next_cursor: null, unread_by_session: { [session.id]: 3 } });
+    const refreshFailure = new Error('refresh failed');
+    const listInbox = vi.fn()
+      .mockResolvedValueOnce({ sessions: [], next_cursor: 'cursor_before_restore', unread_by_session: {} })
+      .mockReturnValueOnce(targetedRead.promise)
+      .mockRejectedValueOnce(refreshFailure);
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    let handlers: WorkbenchEventHandlers | null = null;
+    apiRef.current = {
+      listInbox,
+      connectWorkbenchEvents: vi.fn((next) => {
+        handlers = next;
+        return vi.fn();
+      }),
+    };
+    let inbox: ReturnType<typeof useWorkbenchInbox> | null = null;
+    const Probe = () => {
+      const value = useWorkbenchInbox();
+      useEffect(() => {
+        inbox = value;
+      }, [value]);
+      return null;
+    };
+
+    render(
+      <WorkbenchInboxProvider>
+        <Probe />
+      </WorkbenchInboxProvider>,
+    );
+    await settle();
+    act(() => {
+      handlers?.onSessionActivity?.({
+        session_id: session.id,
+        scope_id: session.scope_id,
+        event: 'updated',
+        visibility: 'foreground',
+      });
+      void inbox?.refresh();
+    });
+    await settle();
+    await act(async () => {
+      targetedRead.resolve({ sessions: [inboxRow], next_cursor: null, unread_by_session: { [session.id]: 3 } });
+      await targetedRead.promise;
+    });
+    await settle();
+
+    expect(inbox?.inboxSessions).toEqual([inboxRow]);
+    expect(inbox?.unreadBySession).toEqual({ [session.id]: 3 });
+    expect(inbox?.nextCursor).toBe('cursor_before_restore');
+    expect(consoleError).toHaveBeenCalledWith('[inbox] refresh failed', refreshFailure);
+    consoleError.mockRestore();
+  });
+
+  it('lets a newer cursor page replace a targeted session snapshot', async () => {
+    const pagedRow = {
+      ...inboxRow,
+      title: 'Fresh from cursor page',
+      last_activity_at: '2026-08-11T02:00:00Z',
+    };
+    const listInbox = vi.fn()
+      .mockResolvedValueOnce({ sessions: [], next_cursor: 'cursor_a', unread_by_session: {} })
+      .mockResolvedValueOnce({ sessions: [inboxRow], next_cursor: null, unread_by_session: { [session.id]: 3 } })
+      .mockResolvedValueOnce({ sessions: [pagedRow], next_cursor: null, unread_by_session: {} });
+    let handlers: WorkbenchEventHandlers | null = null;
+    apiRef.current = {
+      listInbox,
+      connectWorkbenchEvents: vi.fn((next) => {
+        handlers = next;
+        return vi.fn();
+      }),
+    };
+    let inbox: ReturnType<typeof useWorkbenchInbox> | null = null;
+    const Probe = () => {
+      const value = useWorkbenchInbox();
+      useEffect(() => {
+        inbox = value;
+      }, [value]);
+      return null;
+    };
+
+    render(
+      <WorkbenchInboxProvider>
+        <Probe />
+      </WorkbenchInboxProvider>,
+    );
+    await settle();
+    act(() => {
+      handlers?.onSessionActivity?.({
+        session_id: session.id,
+        scope_id: session.scope_id,
+        event: 'updated',
+        visibility: 'foreground',
+      });
+    });
+    await settle();
+    act(() => {
+      void inbox?.loadMore();
+    });
+    await settle();
+
+    expect(listInbox).toHaveBeenCalledTimes(3);
+    expect(listInbox.mock.calls[2]?.[0]).toMatchObject({ before: 'cursor_a' });
+    expect(inbox?.inboxSessions).toEqual([pagedRow]);
+    expect(inbox?.unreadBySession).toEqual({ [session.id]: 3 });
+    expect(inbox?.nextCursor).toBeNull();
   });
 
   it('does not let an older targeted row replace a newer broad row that completed first', async () => {

--- a/ui/src/context/WorkbenchSessionReadOrdering.test.tsx
+++ b/ui/src/context/WorkbenchSessionReadOrdering.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { act, render } from '@testing-library/react';
+import { act, cleanup, render } from '@testing-library/react';
 import { useEffect } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -86,6 +86,7 @@ const inboxRow = {
 type FakeApi = {
   getWorkbenchProjectsBootstrap?: () => Promise<unknown>;
   listSessions?: (args: { projectId: string }) => Promise<unknown>;
+  getSession?: () => Promise<unknown>;
   listInbox?: () => Promise<unknown>;
   connectWorkbenchEvents: (handlers: WorkbenchEventHandlers) => () => void;
 };
@@ -110,6 +111,7 @@ describe('Workbench session read ownership', () => {
   });
 
   afterEach(() => {
+    cleanup();
     apiRef.current = null;
   });
 
@@ -162,6 +164,49 @@ describe('Workbench session read ownership', () => {
     expect(tree?.sessionsOf('proj_a').sessions).toEqual([]);
   });
 
+  it('retries a cold project bootstrap invalidated by activity', async () => {
+    const staleBootstrap = deferred({ projects: [project], sessions: { proj_a: { sessions: [session], next_before_id: null } } });
+    const getWorkbenchProjectsBootstrap = vi.fn()
+      .mockReturnValueOnce(staleBootstrap.promise)
+      .mockResolvedValueOnce({ projects: [project], sessions: { proj_a: { sessions: [session], next_before_id: null } } });
+    let handlers: WorkbenchEventHandlers | null = null;
+    apiRef.current = {
+      getWorkbenchProjectsBootstrap,
+      connectWorkbenchEvents: vi.fn((next) => {
+        handlers = next;
+        return vi.fn();
+      }),
+    };
+    let tree: ReturnType<typeof useWorkbenchProjectsTree> | null = null;
+    const Probe = () => {
+      const value = useWorkbenchProjectsTree();
+      useEffect(() => {
+        tree = value;
+      }, [value]);
+      return null;
+    };
+
+    render(
+      <WorkbenchProjectsProvider>
+        <Probe />
+      </WorkbenchProjectsProvider>,
+    );
+    await settle();
+
+    act(() => {
+      handlers?.onSessionStatus?.({ session_id: session.id, agent_status: 'idle' });
+    });
+    await act(async () => {
+      staleBootstrap.resolve({ projects: [project], sessions: { proj_a: { sessions: [session], next_before_id: null } } });
+      await staleBootstrap.promise;
+    });
+    await settle();
+
+    expect(getWorkbenchProjectsBootstrap).toHaveBeenCalledTimes(2);
+    expect(tree?.projects).toEqual([project]);
+    expect(tree?.sessionsOf(project.id).sessions).toEqual([session]);
+  });
+
   it('commits concurrent reads for independent project resources', async () => {
     const projectARead = deferred({ sessions: [session], next_before_id: null });
     const projectBRead = deferred({ sessions: [sessionB], next_before_id: null });
@@ -207,6 +252,58 @@ describe('Workbench session read ownership', () => {
 
     expect(tree?.sessionsOf(project.id).sessions).toEqual([session]);
     expect(tree?.sessionsOf(projectB.id).sessions).toEqual([sessionB]);
+  });
+
+  it('requeues a project reconcile invalidated by a lifecycle event', async () => {
+    const loadedSessions = Array.from({ length: 201 }, (_, index) => ({ ...session, id: `ses_${index}` }));
+    const trackedSession = loadedSessions[0];
+    const staleRead = deferred({ sessions: [trackedSession], next_before_id: null });
+    const listSessions = vi.fn()
+      .mockReturnValueOnce(staleRead.promise)
+      .mockResolvedValueOnce({ sessions: [{ ...trackedSession, agent_status: 'idle' }], next_before_id: null });
+    apiRef.current = {
+      getWorkbenchProjectsBootstrap: vi.fn().mockResolvedValue({
+        projects: [project],
+        sessions: { [project.id]: { sessions: loadedSessions, next_before_id: null } },
+      }),
+      listSessions,
+      getSession: vi.fn().mockResolvedValue(trackedSession),
+      connectWorkbenchEvents: vi.fn((next) => {
+        handlers = next;
+        return vi.fn();
+      }),
+    };
+    let handlers: WorkbenchEventHandlers | null = null;
+    let tree: ReturnType<typeof useWorkbenchProjectsTree> | null = null;
+    const Probe = () => {
+      const value = useWorkbenchProjectsTree();
+      useEffect(() => {
+        tree = value;
+      }, [value]);
+      return null;
+    };
+
+    render(
+      <WorkbenchProjectsProvider>
+        <Probe />
+      </WorkbenchProjectsProvider>,
+    );
+    await settle();
+    act(() => {
+      handlers?.onConnected?.({ sub_id: 2, source: 'browser' });
+    });
+    await settle();
+    act(() => {
+      handlers?.onSessionStatus?.({ session_id: trackedSession.id, agent_status: 'idle' });
+    });
+    await act(async () => {
+      staleRead.resolve({ sessions: [trackedSession], next_before_id: null });
+      await staleRead.promise;
+    });
+    await settle();
+
+    expect(listSessions).toHaveBeenCalledTimes(2);
+    expect(tree?.sessionsOf(project.id).sessions).toEqual([{ ...trackedSession, agent_status: 'idle' }]);
   });
 
   it('does not let an Inbox refresh issued before hide restore the card or unread count', async () => {
@@ -309,6 +406,107 @@ describe('Workbench session read ownership', () => {
     expect(inbox?.nextCursor).toBeNull();
   });
 
+  it('retries a resume reconcile invalidated by activity', async () => {
+    const staleReconcile = deferred({ sessions: [inboxRow], next_cursor: 'stale_cursor', unread_by_session: { [session.id]: 3 } });
+    const listInbox = vi.fn()
+      .mockResolvedValueOnce({ sessions: [inboxRow], next_cursor: 'cursor_a', unread_by_session: { [session.id]: 3 } })
+      .mockReturnValueOnce(staleReconcile.promise)
+      .mockResolvedValue({ sessions: [], next_cursor: null, unread_by_session: {} });
+    let handlers: WorkbenchEventHandlers | null = null;
+    apiRef.current = {
+      listInbox,
+      connectWorkbenchEvents: vi.fn((next) => {
+        handlers = next;
+        return vi.fn();
+      }),
+    };
+    let inbox: ReturnType<typeof useWorkbenchInbox> | null = null;
+    const Probe = () => {
+      const value = useWorkbenchInbox();
+      useEffect(() => {
+        inbox = value;
+      }, [value]);
+      return null;
+    };
+
+    render(
+      <WorkbenchInboxProvider>
+        <Probe />
+      </WorkbenchInboxProvider>,
+    );
+    await settle();
+    act(() => {
+      window.dispatchEvent(new Event('focus'));
+    });
+    await settle();
+    act(() => {
+      handlers?.onSessionActivity?.({
+        session_id: session.id,
+        scope_id: session.scope_id,
+        event: 'updated',
+        visibility: 'background',
+      });
+    });
+    await act(async () => {
+      staleReconcile.resolve({ sessions: [inboxRow], next_cursor: 'stale_cursor', unread_by_session: { [session.id]: 3 } });
+      await staleReconcile.promise;
+    });
+    await settle();
+
+    expect(listInbox).toHaveBeenCalledTimes(3);
+    expect(inbox?.inboxSessions).toEqual([]);
+    expect(inbox?.nextCursor).toBeNull();
+  });
+
+  it('clears independent Inbox loading flags when reads overlap', async () => {
+    const refreshRead = deferred({ sessions: [inboxRow], next_cursor: 'cursor_refresh', unread_by_session: { [session.id]: 3 } });
+    const loadMoreRead = deferred({ sessions: [], next_cursor: null, unread_by_session: { [session.id]: 3 } });
+    const listInbox = vi.fn()
+      .mockResolvedValueOnce({ sessions: [inboxRow], next_cursor: 'cursor_a', unread_by_session: { [session.id]: 3 } })
+      .mockReturnValueOnce(refreshRead.promise)
+      .mockReturnValueOnce(loadMoreRead.promise);
+    apiRef.current = {
+      listInbox,
+      connectWorkbenchEvents: vi.fn(() => vi.fn()),
+    };
+    let inbox: ReturnType<typeof useWorkbenchInbox> | null = null;
+    const Probe = () => {
+      const value = useWorkbenchInbox();
+      useEffect(() => {
+        inbox = value;
+      }, [value]);
+      return null;
+    };
+
+    render(
+      <WorkbenchInboxProvider>
+        <Probe />
+      </WorkbenchInboxProvider>,
+    );
+    await settle();
+    act(() => {
+      void inbox?.refresh();
+      void inbox?.loadMore();
+    });
+    await settle();
+    expect(inbox?.loading).toBe(true);
+    expect(inbox?.loadingMore).toBe(true);
+    await act(async () => {
+      refreshRead.resolve({ sessions: [inboxRow], next_cursor: 'cursor_refresh', unread_by_session: { [session.id]: 3 } });
+      await refreshRead.promise;
+    });
+    await settle();
+    expect(inbox?.loading).toBe(false);
+    expect(inbox?.loadingMore).toBe(true);
+    await act(async () => {
+      loadMoreRead.resolve({ sessions: [], next_cursor: null, unread_by_session: { [session.id]: 3 } });
+      await loadMoreRead.promise;
+    });
+    await settle();
+    expect(inbox?.loading).toBe(false);
+    expect(inbox?.loadingMore).toBe(false);
+  });
+
   it('keeps the targeted foreground-restore upsert and its cursor untouched', async () => {
     const listInbox = vi.fn()
       .mockResolvedValueOnce({ sessions: [], next_cursor: 'cursor_before_restore', unread_by_session: {} })
@@ -357,5 +555,59 @@ describe('Workbench session read ownership', () => {
     expect(inbox?.inboxSessions.map((row) => row.session_id)).toEqual([session.id]);
     expect(inbox?.unreadBySession).toEqual({ [session.id]: 3 });
     expect(inbox?.nextCursor).toBe('cursor_before_restore');
+  });
+
+  it('keeps a targeted restore when a newer broad feed read completes first', async () => {
+    const targetedRead = deferred({ sessions: [inboxRow], next_cursor: null, unread_by_session: { [session.id]: 3 } });
+    const broadRead = deferred({ sessions: [], next_cursor: 'cursor_after_refresh', unread_by_session: {} });
+    const listInbox = vi.fn()
+      .mockResolvedValueOnce({ sessions: [], next_cursor: 'cursor_before_restore', unread_by_session: {} })
+      .mockReturnValueOnce(targetedRead.promise)
+      .mockReturnValueOnce(broadRead.promise);
+    let handlers: WorkbenchEventHandlers | null = null;
+    apiRef.current = {
+      listInbox,
+      connectWorkbenchEvents: vi.fn((next) => {
+        handlers = next;
+        return vi.fn();
+      }),
+    };
+    let inbox: ReturnType<typeof useWorkbenchInbox> | null = null;
+    const Probe = () => {
+      const value = useWorkbenchInbox();
+      useEffect(() => {
+        inbox = value;
+      }, [value]);
+      return null;
+    };
+
+    render(
+      <WorkbenchInboxProvider>
+        <Probe />
+      </WorkbenchInboxProvider>,
+    );
+    await settle();
+    act(() => {
+      handlers?.onSessionActivity?.({
+        session_id: session.id,
+        scope_id: session.scope_id,
+        event: 'updated',
+        visibility: 'foreground',
+      });
+      void inbox?.refresh();
+    });
+    await settle();
+    await act(async () => {
+      broadRead.resolve({ sessions: [], next_cursor: 'cursor_after_refresh', unread_by_session: {} });
+      await broadRead.promise;
+    });
+    await act(async () => {
+      targetedRead.resolve({ sessions: [inboxRow], next_cursor: null, unread_by_session: { [session.id]: 3 } });
+      await targetedRead.promise;
+    });
+    await settle();
+
+    expect(inbox?.inboxSessions.map((row) => row.session_id)).toEqual([session.id]);
+    expect(inbox?.nextCursor).toBe('cursor_after_refresh');
   });
 });

--- a/ui/src/context/WorkbenchSessionReadOrdering.test.tsx
+++ b/ui/src/context/WorkbenchSessionReadOrdering.test.tsx
@@ -411,6 +411,59 @@ describe('Workbench session read ownership', () => {
     expect(tree?.sessionsOf(project.id).sessions).toEqual([session]);
   });
 
+  it('coalesces cached-row refreshes and retries after a newer lifecycle mutation', async () => {
+    const staleRowRead = deferred({ ...session, native_session_id: 'native_stale' });
+    const boundSession = { ...session, native_session_id: 'native_fresh' };
+    const getSession = vi.fn()
+      .mockReturnValueOnce(staleRowRead.promise)
+      .mockResolvedValueOnce(boundSession);
+    let handlers: WorkbenchEventHandlers | null = null;
+    apiRef.current = {
+      getWorkbenchProjectsBootstrap: vi.fn().mockResolvedValue({
+        projects: [project],
+        sessions: { [project.id]: { sessions: [session], next_before_id: null } },
+      }),
+      getSession,
+      connectWorkbenchEvents: vi.fn((next) => {
+        handlers = next;
+        return vi.fn();
+      }),
+    };
+    let tree: ReturnType<typeof useWorkbenchProjectsTree> | null = null;
+    const Probe = () => {
+      const value = useWorkbenchProjectsTree();
+      useEffect(() => {
+        tree = value;
+      }, [value]);
+      return null;
+    };
+
+    render(
+      <WorkbenchProjectsProvider>
+        <Probe />
+      </WorkbenchProjectsProvider>,
+    );
+    await settle();
+    act(() => {
+      handlers?.onSessionStatus?.({ session_id: session.id, agent_status: 'idle' });
+    });
+    await settle();
+    act(() => {
+      handlers?.onTurnEnd?.({ session_id: session.id });
+    });
+    await settle();
+
+    expect(getSession).toHaveBeenCalledTimes(1);
+    await act(async () => {
+      staleRowRead.resolve({ ...session, native_session_id: 'native_stale' });
+      await staleRowRead.promise;
+    });
+    await settle();
+
+    expect(getSession).toHaveBeenCalledTimes(2);
+    expect(tree?.sessionsOf(project.id).sessions).toEqual([boundSession]);
+  });
+
   it('retries an invalidated project pagination read', async () => {
     const pageSession = { ...sessionB, scope_id: project.scope_id, project_id: project.id };
     const stalePage = deferred({ sessions: [pageSession], next_before_id: null });
@@ -525,7 +578,8 @@ describe('Workbench session read ownership', () => {
     apiRef.current = {
       listInbox: vi.fn()
         .mockResolvedValueOnce({ sessions: [inboxRow], next_cursor: 'cursor_a', unread_by_session: { [session.id]: 3 } })
-        .mockReturnValueOnce(staleRefresh.promise),
+        .mockReturnValueOnce(staleRefresh.promise)
+        .mockResolvedValueOnce({ sessions: [], next_cursor: 'cursor_a', unread_by_session: {} }),
       connectWorkbenchEvents: vi.fn((next) => {
         handlers = next;
         return vi.fn();
@@ -565,6 +619,7 @@ describe('Workbench session read ownership', () => {
     });
     await settle();
 
+    expect(apiRef.current?.listInbox).toHaveBeenCalledTimes(3);
     expect(inbox?.inboxSessions).toEqual([]);
     expect(inbox?.unreadBySession).toEqual({});
     expect(inbox?.nextCursor).toBe('cursor_a');
@@ -669,6 +724,134 @@ describe('Workbench session read ownership', () => {
 
     expect(inbox?.inboxSessions).toEqual([]);
     expect(inbox?.unreadBySession).toEqual({});
+  });
+
+  it('keeps a successful mark-read result when an older unread snapshot finishes last', async () => {
+    const markReadResult = deferred({ unread_by_session: { [sessionB.id]: 5 } });
+    const staleRefresh = deferred({
+      sessions: [inboxRow],
+      next_cursor: 'stale_cursor',
+      unread_by_session: { [session.id]: 3, [sessionB.id]: 5 },
+    });
+    const listInbox = vi.fn()
+      .mockResolvedValueOnce({
+        sessions: [inboxRow],
+        next_cursor: 'cursor_a',
+        unread_by_session: { [session.id]: 3, [sessionB.id]: 5 },
+      })
+      .mockReturnValueOnce(staleRefresh.promise);
+    apiRef.current = {
+      listInbox,
+      markSessionRead: vi.fn().mockReturnValue(markReadResult.promise),
+      connectWorkbenchEvents: vi.fn(() => vi.fn()),
+    };
+    let inbox: ReturnType<typeof useWorkbenchInbox> | null = null;
+    const Probe = () => {
+      const value = useWorkbenchInbox();
+      useEffect(() => {
+        inbox = value;
+      }, [value]);
+      return null;
+    };
+
+    render(
+      <WorkbenchInboxProvider>
+        <Probe />
+      </WorkbenchInboxProvider>,
+    );
+    await settle();
+    act(() => {
+      void inbox?.markRead(session.id);
+      void inbox?.refresh();
+    });
+    await settle();
+    await act(async () => {
+      markReadResult.resolve({ unread_by_session: { [sessionB.id]: 5 } });
+      await markReadResult.promise;
+    });
+    await act(async () => {
+      staleRefresh.resolve({
+        sessions: [inboxRow],
+        next_cursor: 'stale_cursor',
+        unread_by_session: { [session.id]: 3, [sessionB.id]: 5 },
+      });
+      await staleRefresh.promise;
+    });
+    await settle();
+
+    expect(inbox?.unreadBySession).toEqual({ [sessionB.id]: 5 });
+  });
+
+  it('retries a loaded Inbox refresh superseded by load-more', async () => {
+    const staleRefresh = deferred({
+      sessions: [inboxRow],
+      next_cursor: 'stale_cursor',
+      unread_by_session: { [session.id]: 3 },
+    });
+    const loadMoreRead = deferred({
+      sessions: [],
+      next_cursor: 'cursor_after_load_more',
+      unread_by_session: { [session.id]: 3 },
+    });
+    const refreshedRow = { ...inboxRow, title: 'Fresh after explicit refresh' };
+    const listInbox = vi.fn()
+      .mockResolvedValueOnce({
+        sessions: [inboxRow],
+        next_cursor: 'cursor_a',
+        unread_by_session: { [session.id]: 3 },
+      })
+      .mockReturnValueOnce(staleRefresh.promise)
+      .mockReturnValueOnce(loadMoreRead.promise)
+      .mockResolvedValueOnce({
+        sessions: [refreshedRow],
+        next_cursor: 'cursor_after_refresh',
+        unread_by_session: { [session.id]: 3 },
+      });
+    apiRef.current = {
+      listInbox,
+      connectWorkbenchEvents: vi.fn(() => vi.fn()),
+    };
+    let inbox: ReturnType<typeof useWorkbenchInbox> | null = null;
+    const Probe = () => {
+      const value = useWorkbenchInbox();
+      useEffect(() => {
+        inbox = value;
+      }, [value]);
+      return null;
+    };
+
+    render(
+      <WorkbenchInboxProvider>
+        <Probe />
+      </WorkbenchInboxProvider>,
+    );
+    await settle();
+    act(() => {
+      void inbox?.refresh();
+      void inbox?.loadMore();
+    });
+    await settle();
+    await act(async () => {
+      loadMoreRead.resolve({
+        sessions: [],
+        next_cursor: 'cursor_after_load_more',
+        unread_by_session: { [session.id]: 3 },
+      });
+      await loadMoreRead.promise;
+    });
+    await act(async () => {
+      staleRefresh.resolve({
+        sessions: [inboxRow],
+        next_cursor: 'stale_cursor',
+        unread_by_session: { [session.id]: 3 },
+      });
+      await staleRefresh.promise;
+    });
+    await settle();
+
+    expect(listInbox).toHaveBeenCalledTimes(4);
+    expect(inbox?.inboxSessions).toEqual([refreshedRow]);
+    expect(inbox?.nextCursor).toBe('cursor_after_refresh');
   });
 
   it('retries a resume reconcile invalidated by activity', async () => {
@@ -785,7 +968,8 @@ describe('Workbench session read ownership', () => {
     const listInbox = vi.fn()
       .mockResolvedValueOnce({ sessions: [inboxRow], next_cursor: 'cursor_a', unread_by_session: { [session.id]: 3 } })
       .mockReturnValueOnce(refreshRead.promise)
-      .mockReturnValueOnce(loadMoreRead.promise);
+      .mockReturnValueOnce(loadMoreRead.promise)
+      .mockResolvedValueOnce({ sessions: [inboxRow], next_cursor: 'cursor_refresh', unread_by_session: { [session.id]: 3 } });
     apiRef.current = {
       listInbox,
       connectWorkbenchEvents: vi.fn(() => vi.fn()),

--- a/ui/src/context/WorkbenchSessionReadOrdering.test.tsx
+++ b/ui/src/context/WorkbenchSessionReadOrdering.test.tsx
@@ -880,31 +880,34 @@ describe('Workbench session read ownership', () => {
     expect(inbox?.unreadBySession).toEqual({ [sessionB.id]: 5 });
   });
 
-  it('retries a loaded Inbox refresh superseded by load-more', async () => {
-    const staleRefresh = deferred({
-      sessions: [inboxRow],
-      next_cursor: 'stale_cursor',
+  it('defers a later load-more until an in-flight Inbox refresh completes', async () => {
+    const pageRow = {
+      ...inboxRow,
+      session_id: sessionB.id,
+      scope_id: sessionB.scope_id,
+      title: sessionB.title,
+      preview_message_id: 'msg_b',
+      last_activity_at: '2026-08-10T23:00:00Z',
+    };
+    const refreshedRow = { ...inboxRow, title: 'Fresh before deferred load-more' };
+    const refreshRead = deferred({
+      sessions: [refreshedRow],
+      next_cursor: 'cursor_after_refresh',
       unread_by_session: { [session.id]: 3 },
     });
     const loadMoreRead = deferred({
-      sessions: [],
+      sessions: [pageRow],
       next_cursor: 'cursor_after_load_more',
       unread_by_session: { [session.id]: 3 },
     });
-    const refreshedRow = { ...inboxRow, title: 'Fresh after explicit refresh' };
     const listInbox = vi.fn()
       .mockResolvedValueOnce({
         sessions: [inboxRow],
         next_cursor: 'cursor_a',
         unread_by_session: { [session.id]: 3 },
       })
-      .mockReturnValueOnce(staleRefresh.promise)
-      .mockReturnValueOnce(loadMoreRead.promise)
-      .mockResolvedValueOnce({
-        sessions: [refreshedRow],
-        next_cursor: 'cursor_after_refresh',
-        unread_by_session: { [session.id]: 3 },
-      });
+      .mockReturnValueOnce(refreshRead.promise)
+      .mockReturnValueOnce(loadMoreRead.promise);
     apiRef.current = {
       listInbox,
       connectWorkbenchEvents: vi.fn(() => vi.fn()),
@@ -926,30 +929,36 @@ describe('Workbench session read ownership', () => {
     await settle();
     act(() => {
       void inbox?.refresh();
+    });
+    await settle();
+    act(() => {
       void inbox?.loadMore();
     });
     await settle();
+    expect(listInbox).toHaveBeenCalledTimes(2);
+    await act(async () => {
+      refreshRead.resolve({
+        sessions: [refreshedRow],
+        next_cursor: 'cursor_after_refresh',
+        unread_by_session: { [session.id]: 3 },
+      });
+      await refreshRead.promise;
+    });
+    await settle();
+    expect(listInbox).toHaveBeenCalledTimes(3);
+    expect(listInbox.mock.calls[2]?.[0]).toMatchObject({ before: 'cursor_after_refresh' });
     await act(async () => {
       loadMoreRead.resolve({
-        sessions: [],
+        sessions: [pageRow],
         next_cursor: 'cursor_after_load_more',
         unread_by_session: { [session.id]: 3 },
       });
       await loadMoreRead.promise;
     });
-    await act(async () => {
-      staleRefresh.resolve({
-        sessions: [inboxRow],
-        next_cursor: 'stale_cursor',
-        unread_by_session: { [session.id]: 3 },
-      });
-      await staleRefresh.promise;
-    });
     await settle();
 
-    expect(listInbox).toHaveBeenCalledTimes(4);
-    expect(inbox?.inboxSessions).toEqual([refreshedRow]);
-    expect(inbox?.nextCursor).toBe('cursor_after_refresh');
+    expect(inbox?.inboxSessions).toEqual([refreshedRow, pageRow]);
+    expect(inbox?.nextCursor).toBe('cursor_after_load_more');
   });
 
   it('defers a later Inbox refresh until an in-flight load-more completes', async () => {
@@ -1081,15 +1090,30 @@ describe('Workbench session read ownership', () => {
     expect(inbox?.nextCursor).toBeNull();
   });
 
-  it('retries a resume reconcile superseded by load-more', async () => {
-    const staleReconcile = deferred({ sessions: [inboxRow], next_cursor: 'stale_cursor', unread_by_session: { [session.id]: 3 } });
-    const loadMoreRead = deferred({ sessions: [], next_cursor: 'cursor_after_load_more', unread_by_session: { [session.id]: 3 } });
-    const retryReconcile = deferred({ sessions: [inboxRow], next_cursor: 'cursor_after_reconcile', unread_by_session: { [session.id]: 3 } });
+  it('defers a later load-more until an in-flight resume reconcile completes', async () => {
+    const pageRow = {
+      ...inboxRow,
+      session_id: sessionB.id,
+      scope_id: sessionB.scope_id,
+      title: sessionB.title,
+      preview_message_id: 'msg_b',
+      last_activity_at: '2026-08-10T23:00:00Z',
+    };
+    const reconciledRow = { ...inboxRow, title: 'Fresh before deferred load-more' };
+    const reconcileRead = deferred({
+      sessions: [reconciledRow],
+      next_cursor: 'cursor_after_reconcile',
+      unread_by_session: { [session.id]: 3 },
+    });
+    const loadMoreRead = deferred({
+      sessions: [pageRow],
+      next_cursor: 'cursor_after_load_more',
+      unread_by_session: { [session.id]: 3 },
+    });
     const listInbox = vi.fn()
       .mockResolvedValueOnce({ sessions: [inboxRow], next_cursor: 'cursor_a', unread_by_session: { [session.id]: 3 } })
-      .mockReturnValueOnce(staleReconcile.promise)
-      .mockReturnValueOnce(loadMoreRead.promise)
-      .mockReturnValueOnce(retryReconcile.promise);
+      .mockReturnValueOnce(reconcileRead.promise)
+      .mockReturnValueOnce(loadMoreRead.promise);
     let inbox: ReturnType<typeof useWorkbenchInbox> | null = null;
     const Probe = () => {
       const value = useWorkbenchInbox();
@@ -1117,27 +1141,33 @@ describe('Workbench session read ownership', () => {
       void inbox?.loadMore();
     });
     await settle();
+    expect(listInbox).toHaveBeenCalledTimes(2);
     await act(async () => {
-      loadMoreRead.resolve({ sessions: [], next_cursor: 'cursor_after_load_more', unread_by_session: { [session.id]: 3 } });
-      await loadMoreRead.promise;
-    });
-    await act(async () => {
-      staleReconcile.resolve({ sessions: [inboxRow], next_cursor: 'stale_cursor', unread_by_session: { [session.id]: 3 } });
-      await staleReconcile.promise;
+      reconcileRead.resolve({
+        sessions: [reconciledRow],
+        next_cursor: 'cursor_after_reconcile',
+        unread_by_session: { [session.id]: 3 },
+      });
+      await reconcileRead.promise;
     });
     await settle();
-    expect(listInbox).toHaveBeenCalledTimes(4);
+    expect(listInbox).toHaveBeenCalledTimes(3);
+    expect(listInbox.mock.calls[2]?.[0]).toMatchObject({ before: 'cursor_a' });
     await act(async () => {
-      retryReconcile.resolve({ sessions: [inboxRow], next_cursor: 'cursor_after_reconcile', unread_by_session: { [session.id]: 3 } });
-      await retryReconcile.promise;
+      loadMoreRead.resolve({
+        sessions: [pageRow],
+        next_cursor: 'cursor_after_load_more',
+        unread_by_session: { [session.id]: 3 },
+      });
+      await loadMoreRead.promise;
     });
     await settle();
 
-    expect(inbox?.inboxSessions).toEqual([inboxRow]);
+    expect(inbox?.inboxSessions).toEqual([reconciledRow, pageRow]);
     expect(inbox?.nextCursor).toBe('cursor_after_load_more');
   });
 
-  it('defers a resume retry until a later load-more completes', async () => {
+  it('runs a queued resume retry before a later load-more', async () => {
     const pageRow = {
       ...inboxRow,
       session_id: sessionB.id,
@@ -1154,12 +1184,12 @@ describe('Workbench session read ownership', () => {
     const loadMoreRead = deferred({
       sessions: [pageRow],
       next_cursor: 'cursor_after_load_more',
-      unread_by_session: { [session.id]: 3 },
+      unread_by_session: {},
     });
     const retryReconcile = deferred({
-      sessions: [inboxRow],
+      sessions: [],
       next_cursor: 'cursor_after_reconcile',
-      unread_by_session: { [session.id]: 3 },
+      unread_by_session: {},
     });
     const listInbox = vi.fn()
       .mockResolvedValueOnce({
@@ -1168,11 +1198,15 @@ describe('Workbench session read ownership', () => {
         unread_by_session: { [session.id]: 3 },
       })
       .mockReturnValueOnce(staleReconcile.promise)
-      .mockReturnValueOnce(loadMoreRead.promise)
-      .mockReturnValueOnce(retryReconcile.promise);
+      .mockReturnValueOnce(retryReconcile.promise)
+      .mockReturnValueOnce(loadMoreRead.promise);
+    let handlers: WorkbenchEventHandlers | null = null;
     apiRef.current = {
       listInbox,
-      connectWorkbenchEvents: vi.fn(() => vi.fn()),
+      connectWorkbenchEvents: vi.fn((next) => {
+        handlers = next;
+        return vi.fn();
+      }),
     };
     let inbox: ReturnType<typeof useWorkbenchInbox> | null = null;
     const Probe = () => {
@@ -1194,6 +1228,12 @@ describe('Workbench session read ownership', () => {
     });
     await settle();
     act(() => {
+      handlers?.onSessionActivity?.({
+        session_id: session.id,
+        scope_id: session.scope_id,
+        event: 'updated',
+        visibility: 'background',
+      });
       void inbox?.loadMore();
     });
     await settle();
@@ -1208,29 +1248,27 @@ describe('Workbench session read ownership', () => {
     await settle();
     expect(listInbox).toHaveBeenCalledTimes(3);
     await act(async () => {
-      loadMoreRead.resolve({
-        sessions: [pageRow],
-        next_cursor: 'cursor_after_load_more',
-        unread_by_session: { [session.id]: 3 },
-      });
-      await loadMoreRead.promise;
-    });
-    await settle();
-    expect(listInbox).toHaveBeenCalledTimes(4);
-    await act(async () => {
       retryReconcile.resolve({
-        sessions: [inboxRow],
+        sessions: [],
         next_cursor: 'cursor_after_reconcile',
-        unread_by_session: { [session.id]: 3 },
+        unread_by_session: {},
       });
       await retryReconcile.promise;
     });
     await settle();
+    expect(listInbox).toHaveBeenCalledTimes(4);
+    expect(listInbox.mock.calls[3]?.[0]).toMatchObject({ before: 'cursor_after_reconcile' });
+    await act(async () => {
+      loadMoreRead.resolve({
+        sessions: [pageRow],
+        next_cursor: 'cursor_after_load_more',
+        unread_by_session: {},
+      });
+      await loadMoreRead.promise;
+    });
+    await settle();
 
-    expect(inbox?.inboxSessions.map((row) => row.session_id).sort()).toEqual([
-      session.id,
-      sessionB.id,
-    ]);
+    expect(inbox?.inboxSessions.map((row) => row.session_id)).toEqual([sessionB.id]);
     expect(inbox?.nextCursor).toBe('cursor_after_load_more');
   });
 
@@ -1432,14 +1470,13 @@ describe('Workbench session read ownership', () => {
     consoleError.mockRestore();
   });
 
-  it('clears independent Inbox loading flags when reads overlap', async () => {
+  it('starts the load-more indicator only after a blocking refresh settles', async () => {
     const refreshRead = deferred({ sessions: [inboxRow], next_cursor: 'cursor_refresh', unread_by_session: { [session.id]: 3 } });
     const loadMoreRead = deferred({ sessions: [], next_cursor: null, unread_by_session: { [session.id]: 3 } });
     const listInbox = vi.fn()
       .mockResolvedValueOnce({ sessions: [inboxRow], next_cursor: 'cursor_a', unread_by_session: { [session.id]: 3 } })
       .mockReturnValueOnce(refreshRead.promise)
-      .mockReturnValueOnce(loadMoreRead.promise)
-      .mockResolvedValueOnce({ sessions: [inboxRow], next_cursor: 'cursor_refresh', unread_by_session: { [session.id]: 3 } });
+      .mockReturnValueOnce(loadMoreRead.promise);
     apiRef.current = {
       listInbox,
       connectWorkbenchEvents: vi.fn(() => vi.fn()),
@@ -1465,7 +1502,8 @@ describe('Workbench session read ownership', () => {
     });
     await settle();
     expect(inbox?.loading).toBe(true);
-    expect(inbox?.loadingMore).toBe(true);
+    expect(inbox?.loadingMore).toBe(false);
+    expect(listInbox).toHaveBeenCalledTimes(2);
     await act(async () => {
       refreshRead.resolve({ sessions: [inboxRow], next_cursor: 'cursor_refresh', unread_by_session: { [session.id]: 3 } });
       await refreshRead.promise;
@@ -1473,6 +1511,7 @@ describe('Workbench session read ownership', () => {
     await settle();
     expect(inbox?.loading).toBe(false);
     expect(inbox?.loadingMore).toBe(true);
+    expect(listInbox).toHaveBeenCalledTimes(3);
     await act(async () => {
       loadMoreRead.resolve({ sessions: [], next_cursor: null, unread_by_session: { [session.id]: 3 } });
       await loadMoreRead.promise;

--- a/ui/src/context/WorkbenchSessionReadOrdering.test.tsx
+++ b/ui/src/context/WorkbenchSessionReadOrdering.test.tsx
@@ -1,0 +1,242 @@
+// @vitest-environment jsdom
+
+import { act, render } from '@testing-library/react';
+import { useEffect } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { WorkbenchInboxProvider } from './WorkbenchInboxProvider';
+import { useWorkbenchInbox } from './WorkbenchInboxContext';
+import { WorkbenchProjectsProvider } from './WorkbenchProjectsProvider';
+import { useWorkbenchProjectsTree } from './WorkbenchProjectsContext';
+import type { WorkbenchEventHandlers } from './ApiContext';
+
+type Deferred<T> = {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+};
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((next) => {
+    resolve = next;
+  });
+  return { promise, resolve };
+}
+
+const session = {
+  id: 'ses_a',
+  scope_id: 'scope_a',
+  project_id: 'proj_a',
+  title: 'Visible before hide',
+  agent_id: null,
+  agent_name: null,
+  agent_backend: 'codex',
+  agent_variant: null,
+  model: null,
+  reasoning_effort: null,
+  status: 'active',
+  visibility: 'foreground' as const,
+  pinned: false,
+  agent_status: 'idle' as const,
+  workdir: null,
+  native_session_id: null,
+  created_at: '2026-08-11T00:00:00Z',
+  updated_at: '2026-08-11T00:00:00Z',
+  last_active_at: '2026-08-11T00:00:00Z',
+  metadata: {},
+};
+
+const project = {
+  id: 'proj_a',
+  scope_id: 'scope_a',
+  display_name: 'Project A',
+  folder_path: '/tmp/project-a',
+  created_at: '2026-08-11T00:00:00Z',
+  last_active_at: null,
+  archived: false,
+};
+
+const inboxRow = {
+  session_id: session.id,
+  scope_id: session.scope_id,
+  title: session.title,
+  preview: 'A stale inbox snapshot',
+  preview_message_id: 'msg_a',
+  last_activity_at: session.last_active_at,
+  unread_count: 3,
+  visibility: 'foreground' as const,
+};
+
+type FakeApi = {
+  getWorkbenchProjectsBootstrap?: () => Promise<unknown>;
+  listInbox?: () => Promise<unknown>;
+  connectWorkbenchEvents: (handlers: WorkbenchEventHandlers) => () => void;
+};
+
+const apiRef = { current: null as FakeApi | null };
+
+vi.mock('./ApiContext', async () => {
+  const actual = await vi.importActual<typeof import('./ApiContext')>('./ApiContext');
+  return { ...actual, useApi: () => apiRef.current };
+});
+
+function settle() {
+  return act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+describe('Workbench session read ownership', () => {
+  beforeEach(() => {
+    apiRef.current = null;
+  });
+
+  afterEach(() => {
+    apiRef.current = null;
+  });
+
+  it('does not let a bootstrap issued before hide repopulate the projects tree', async () => {
+    const staleBootstrap = deferred({ projects: [project], sessions: { proj_a: { sessions: [session], next_before_id: null } } });
+    let handlers: WorkbenchEventHandlers | null = null;
+    apiRef.current = {
+      getWorkbenchProjectsBootstrap: vi.fn()
+        .mockResolvedValueOnce({ projects: [project], sessions: { proj_a: { sessions: [session], next_before_id: null } } })
+        .mockReturnValueOnce(staleBootstrap.promise),
+      connectWorkbenchEvents: vi.fn((next) => {
+        handlers = next;
+        return vi.fn();
+      }),
+    };
+    let tree: ReturnType<typeof useWorkbenchProjectsTree> | null = null;
+    const Probe = () => {
+      const value = useWorkbenchProjectsTree();
+      useEffect(() => {
+        tree = value;
+      }, [value]);
+      return null;
+    };
+
+    render(
+      <WorkbenchProjectsProvider>
+        <Probe />
+      </WorkbenchProjectsProvider>,
+    );
+    await settle();
+
+    act(() => {
+      handlers?.onConnected?.({ sub_id: 1, source: 'browser' });
+    });
+    await settle();
+    act(() => {
+      handlers?.onSessionActivity?.({
+        session_id: session.id,
+        scope_id: session.scope_id,
+        event: 'archived',
+      });
+    });
+    await act(async () => {
+      staleBootstrap.resolve({ projects: [project], sessions: { proj_a: { sessions: [session], next_before_id: null } } });
+      await staleBootstrap.promise;
+    });
+    await settle();
+
+    expect(tree?.projects).toEqual([project]);
+    expect(tree?.sessionsOf('proj_a').sessions).toEqual([]);
+  });
+
+  it('does not let an Inbox refresh issued before hide restore the card or unread count', async () => {
+    const staleRefresh = deferred({ sessions: [inboxRow], next_cursor: 'cursor_a', unread_by_session: { [session.id]: 3 } });
+    let handlers: WorkbenchEventHandlers | null = null;
+    apiRef.current = {
+      listInbox: vi.fn()
+        .mockResolvedValueOnce({ sessions: [inboxRow], next_cursor: 'cursor_a', unread_by_session: { [session.id]: 3 } })
+        .mockReturnValueOnce(staleRefresh.promise),
+      connectWorkbenchEvents: vi.fn((next) => {
+        handlers = next;
+        return vi.fn();
+      }),
+    };
+    let inbox: ReturnType<typeof useWorkbenchInbox> | null = null;
+    const Probe = () => {
+      const value = useWorkbenchInbox();
+      useEffect(() => {
+        inbox = value;
+      }, [value]);
+      return null;
+    };
+
+    render(
+      <WorkbenchInboxProvider>
+        <Probe />
+      </WorkbenchInboxProvider>,
+    );
+    await settle();
+
+    act(() => {
+      void inbox?.refresh();
+    });
+    await settle();
+    act(() => {
+      handlers?.onSessionActivity?.({
+        session_id: session.id,
+        scope_id: session.scope_id,
+        event: 'updated',
+        visibility: 'background',
+      });
+    });
+    await act(async () => {
+      staleRefresh.resolve({ sessions: [inboxRow], next_cursor: 'cursor_a', unread_by_session: { [session.id]: 3 } });
+      await staleRefresh.promise;
+    });
+    await settle();
+
+    expect(inbox?.inboxSessions).toEqual([]);
+    expect(inbox?.unreadBySession).toEqual({});
+    expect(inbox?.nextCursor).toBe('cursor_a');
+  });
+
+  it('keeps the targeted foreground-restore upsert and its cursor untouched', async () => {
+    const listInbox = vi.fn()
+      .mockResolvedValueOnce({ sessions: [], next_cursor: 'cursor_before_restore', unread_by_session: {} })
+      .mockResolvedValueOnce({ sessions: [inboxRow], next_cursor: null, unread_by_session: { [session.id]: 3 } });
+    let handlers: WorkbenchEventHandlers | null = null;
+    apiRef.current = {
+      listInbox,
+      connectWorkbenchEvents: vi.fn((next) => {
+        handlers = next;
+        return vi.fn();
+      }),
+    };
+    let inbox: ReturnType<typeof useWorkbenchInbox> | null = null;
+    const Probe = () => {
+      const value = useWorkbenchInbox();
+      useEffect(() => {
+        inbox = value;
+      }, [value]);
+      return null;
+    };
+
+    render(
+      <WorkbenchInboxProvider>
+        <Probe />
+      </WorkbenchInboxProvider>,
+    );
+    await settle();
+
+    act(() => {
+      handlers?.onSessionActivity?.({
+        session_id: session.id,
+        scope_id: session.scope_id,
+        event: 'updated',
+        visibility: 'foreground',
+      });
+    });
+    await settle();
+
+    expect(listInbox).toHaveBeenCalledTimes(2);
+    expect(inbox?.inboxSessions.map((row) => row.session_id)).toEqual([session.id]);
+    expect(inbox?.unreadBySession).toEqual({ [session.id]: 3 });
+    expect(inbox?.nextCursor).toBe('cursor_before_restore');
+  });
+});

--- a/ui/src/lib/workbenchSessionReadOwnership.test.ts
+++ b/ui/src/lib/workbenchSessionReadOwnership.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+
+import { createWorkbenchSessionReadOwnership } from './workbenchSessionReadOwnership';
+
+describe('Workbench session read ownership', () => {
+  it('accepts only the newest read in the current mutation epoch', () => {
+    const ownership = createWorkbenchSessionReadOwnership();
+    const older = ownership.beginRead();
+    const newer = ownership.beginRead();
+
+    expect(ownership.isCurrent(older)).toBe(false);
+    expect(ownership.isCurrent(newer)).toBe(true);
+  });
+
+  it('invalidates reads issued before an accepted session mutation', () => {
+    const ownership = createWorkbenchSessionReadOwnership();
+    const read = ownership.beginRead();
+
+    expect(ownership.epoch()).toBe(0);
+    expect(ownership.acceptMutation()).toBe(1);
+    expect(ownership.isCurrent(read)).toBe(false);
+    expect(ownership.isLatestRead(read)).toBe(true);
+  });
+});

--- a/ui/src/lib/workbenchSessionReadOwnership.test.ts
+++ b/ui/src/lib/workbenchSessionReadOwnership.test.ts
@@ -16,7 +16,6 @@ describe('Workbench session read ownership', () => {
     const ownership = createWorkbenchSessionReadOwnership();
     const read = ownership.beginRead();
 
-    expect(ownership.epoch()).toBe(0);
     expect(ownership.acceptMutation()).toBe(1);
     expect(ownership.isCurrent(read)).toBe(false);
     expect(ownership.isLatestRead(read)).toBe(true);
@@ -34,6 +33,39 @@ describe('Workbench session read ownership', () => {
     expect(ownership.isCurrent(projectA)).toBe(false);
     expect(ownership.isCurrent(newerProjectA)).toBe(true);
     expect(ownership.isCurrent(projectB)).toBe(true);
+  });
+
+  it('tracks mutation versions independently for independent resources', () => {
+    const ownership = createWorkbenchSessionReadOwnership();
+    const projectA = ownership.beginRead('project:a');
+    const projectB = ownership.beginRead('project:b');
+
+    ownership.acceptMutation('project:a');
+
+    expect(ownership.isCurrent(projectA)).toBe(false);
+    expect(ownership.isCurrent(projectB)).toBe(true);
+  });
+
+  it('lets a later broad read claim a dynamic row resource', () => {
+    const ownership = createWorkbenchSessionReadOwnership();
+    const targeted = ownership.beginRead('session:a');
+    const broad = ownership.beginRead('feed');
+
+    ownership.claimRead(broad, 'session:a');
+
+    expect(ownership.isCurrent(targeted, 'session:a')).toBe(false);
+    expect(ownership.isCurrent(broad, 'session:a')).toBe(true);
+  });
+
+  it('does not let an older broad read claim over a later targeted read', () => {
+    const ownership = createWorkbenchSessionReadOwnership();
+    const broad = ownership.beginRead('feed');
+    const targeted = ownership.beginRead('session:a');
+
+    ownership.claimRead(broad, 'session:a');
+
+    expect(ownership.isCurrent(broad, 'session:a')).toBe(false);
+    expect(ownership.isCurrent(targeted, 'session:a')).toBe(true);
   });
 
   it('lets a broad read and a resource read order their overlapping payload', () => {

--- a/ui/src/lib/workbenchSessionReadOwnership.test.ts
+++ b/ui/src/lib/workbenchSessionReadOwnership.test.ts
@@ -21,4 +21,27 @@ describe('Workbench session read ownership', () => {
     expect(ownership.isCurrent(read)).toBe(false);
     expect(ownership.isLatestRead(read)).toBe(true);
   });
+
+  it('tracks read generations independently for independent resources', () => {
+    const ownership = createWorkbenchSessionReadOwnership();
+    const projectA = ownership.beginRead('project:a');
+    const projectB = ownership.beginRead('project:b');
+
+    expect(ownership.isCurrent(projectA)).toBe(true);
+    expect(ownership.isCurrent(projectB)).toBe(true);
+
+    const newerProjectA = ownership.beginRead('project:a');
+    expect(ownership.isCurrent(projectA)).toBe(false);
+    expect(ownership.isCurrent(newerProjectA)).toBe(true);
+    expect(ownership.isCurrent(projectB)).toBe(true);
+  });
+
+  it('lets a broad read and a resource read order their overlapping payload', () => {
+    const ownership = createWorkbenchSessionReadOwnership();
+    const bootstrap = ownership.beginRead('projects-bootstrap');
+    const project = ownership.beginRead('project:a');
+
+    expect(ownership.isCurrent(bootstrap, ['projects-bootstrap', 'project:a'])).toBe(false);
+    expect(ownership.isCurrent(project, ['projects-bootstrap', 'project:a'])).toBe(true);
+  });
 });

--- a/ui/src/lib/workbenchSessionReadOwnership.test.ts
+++ b/ui/src/lib/workbenchSessionReadOwnership.test.ts
@@ -44,4 +44,13 @@ describe('Workbench session read ownership', () => {
     expect(ownership.isCurrent(bootstrap, ['projects-bootstrap', 'project:a'])).toBe(false);
     expect(ownership.isCurrent(project, ['projects-bootstrap', 'project:a'])).toBe(true);
   });
+
+  it('exposes the latest generation for operation-specific retry decisions', () => {
+    const ownership = createWorkbenchSessionReadOwnership();
+    const reconcile = ownership.beginRead(['inbox-feed', 'inbox-feed-reconcile']);
+    const cursor = ownership.beginRead(['inbox-feed', 'inbox-feed-cursor']);
+
+    expect(ownership.latestGeneration('inbox-feed-cursor')).toBe(cursor.generation);
+    expect(ownership.latestGeneration('inbox-feed-reconcile')).toBe(reconcile.generation);
+  });
 });

--- a/ui/src/lib/workbenchSessionReadOwnership.ts
+++ b/ui/src/lib/workbenchSessionReadOwnership.ts
@@ -1,20 +1,24 @@
 /**
  * Orders asynchronous Workbench reads against accepted session mutations.
  *
- * A response is only allowed to commit when it belongs to the current
- * mutation epoch and is the newest read issued by this data owner. This keeps
- * HTTP completion order from deciding whether a stale snapshot wins over a
- * realtime event or a newer read.
+ * A response is only allowed to commit when it belongs to the current mutation
+ * epoch and has not been superseded for any resource it owns. The shared epoch
+ * orders realtime mutations, while resource generations keep independent reads
+ * from invalidating one another merely because they completed in another order.
  */
 export type WorkbenchSessionReadStamp = {
   epoch: number;
   generation: number;
+  resources: string[];
 };
 
 export type WorkbenchSessionReadOwnership = {
-  beginRead: () => WorkbenchSessionReadStamp;
+  beginRead: (resources?: string | readonly string[]) => WorkbenchSessionReadStamp;
   acceptMutation: () => number;
-  isCurrent: (stamp: WorkbenchSessionReadStamp) => boolean;
+  isCurrent: (
+    stamp: WorkbenchSessionReadStamp,
+    resources?: string | readonly string[],
+  ) => boolean;
   isLatestRead: (stamp: WorkbenchSessionReadStamp) => boolean;
   epoch: () => number;
 };
@@ -22,19 +26,32 @@ export type WorkbenchSessionReadOwnership = {
 export function createWorkbenchSessionReadOwnership(): WorkbenchSessionReadOwnership {
   let mutationEpoch = 0;
   let latestGeneration = 0;
+  const latestByResource = new Map<string, number>();
 
   return {
-    beginRead: () => {
+    beginRead: (resources = 'default') => {
+      const resourceList = typeof resources === 'string' ? [resources] : [...resources];
+      if (resourceList.length === 0) throw new Error('A session read must own at least one resource');
       latestGeneration += 1;
-      return { epoch: mutationEpoch, generation: latestGeneration };
+      for (const resource of resourceList) latestByResource.set(resource, latestGeneration);
+      return { epoch: mutationEpoch, generation: latestGeneration, resources: resourceList };
     },
     acceptMutation: () => {
       mutationEpoch += 1;
       return mutationEpoch;
     },
-    isCurrent: (stamp) =>
-      stamp.epoch === mutationEpoch && stamp.generation === latestGeneration,
-    isLatestRead: (stamp) => stamp.generation === latestGeneration,
+    isCurrent: (stamp, resources = stamp.resources) => {
+      const resourceList = typeof resources === 'string' ? [resources] : resources;
+      return (
+        stamp.epoch === mutationEpoch &&
+        resourceList.every((resource) => {
+          const latest = latestByResource.get(resource);
+          return latest === undefined || latest <= stamp.generation;
+        })
+      );
+    },
+    isLatestRead: (stamp) =>
+      stamp.resources.every((resource) => latestByResource.get(resource) === stamp.generation),
     epoch: () => mutationEpoch,
   };
 }

--- a/ui/src/lib/workbenchSessionReadOwnership.ts
+++ b/ui/src/lib/workbenchSessionReadOwnership.ts
@@ -2,9 +2,9 @@
  * Orders asynchronous Workbench reads against accepted session mutations.
  *
  * A response is only allowed to commit when it belongs to the current mutation
- * epoch and has not been superseded for any resource it owns. The shared epoch
- * orders realtime mutations, while resource generations keep independent reads
- * from invalidating one another merely because they completed in another order.
+ * version and has not been superseded for any resource it owns.
+ * Resource-scoped mutation versions and read generations keep independent
+ * projects and data slices from invalidating one another.
  */
 export type WorkbenchSessionReadStamp = {
   epoch: number;
@@ -14,20 +14,28 @@ export type WorkbenchSessionReadStamp = {
 
 export type WorkbenchSessionReadOwnership = {
   beginRead: (resources?: string | readonly string[]) => WorkbenchSessionReadStamp;
-  acceptMutation: () => number;
+  claimRead: (
+    stamp: WorkbenchSessionReadStamp,
+    resources: string | readonly string[],
+  ) => void;
+  acceptMutation: (resources?: string | readonly string[]) => number;
+  isMutationCurrent: (
+    stamp: WorkbenchSessionReadStamp,
+    resources?: string | readonly string[],
+  ) => boolean;
   isCurrent: (
     stamp: WorkbenchSessionReadStamp,
     resources?: string | readonly string[],
   ) => boolean;
   isLatestRead: (stamp: WorkbenchSessionReadStamp) => boolean;
   latestGeneration: (resource: string) => number | undefined;
-  epoch: () => number;
 };
 
 export function createWorkbenchSessionReadOwnership(): WorkbenchSessionReadOwnership {
   let mutationEpoch = 0;
   let latestGeneration = 0;
   const latestByResource = new Map<string, number>();
+  const mutationByResource = new Map<string, number>();
 
   return {
     beginRead: (resources = 'default') => {
@@ -35,16 +43,39 @@ export function createWorkbenchSessionReadOwnership(): WorkbenchSessionReadOwner
       if (resourceList.length === 0) throw new Error('A session read must own at least one resource');
       latestGeneration += 1;
       for (const resource of resourceList) latestByResource.set(resource, latestGeneration);
-      return { epoch: mutationEpoch, generation: latestGeneration, resources: resourceList };
+      return {
+        epoch: mutationEpoch,
+        generation: latestGeneration,
+        resources: resourceList,
+      };
     },
-    acceptMutation: () => {
+    claimRead: (stamp, resources) => {
+      const resourceList = typeof resources === 'string' ? [resources] : resources;
+      if (resourceList.length === 0) throw new Error('A session read must claim at least one resource');
+      for (const resource of resourceList) {
+        const latest = latestByResource.get(resource) ?? 0;
+        if (stamp.generation > latest) latestByResource.set(resource, stamp.generation);
+      }
+    },
+    acceptMutation: (resources = 'default') => {
+      const resourceList = typeof resources === 'string' ? [resources] : resources;
+      if (resourceList.length === 0) throw new Error('A session mutation must own at least one resource');
       mutationEpoch += 1;
+      for (const resource of resourceList) mutationByResource.set(resource, mutationEpoch);
       return mutationEpoch;
+    },
+    isMutationCurrent: (stamp, resources = stamp.resources) => {
+      const resourceList = typeof resources === 'string' ? [resources] : resources;
+      return resourceList.every(
+        (resource) => (mutationByResource.get(resource) ?? 0) <= stamp.epoch,
+      );
     },
     isCurrent: (stamp, resources = stamp.resources) => {
       const resourceList = typeof resources === 'string' ? [resources] : resources;
       return (
-        stamp.epoch === mutationEpoch &&
+        resourceList.every(
+          (resource) => (mutationByResource.get(resource) ?? 0) <= stamp.epoch,
+        ) &&
         resourceList.every((resource) => {
           const latest = latestByResource.get(resource);
           return latest === undefined || latest <= stamp.generation;
@@ -54,6 +85,5 @@ export function createWorkbenchSessionReadOwnership(): WorkbenchSessionReadOwner
     isLatestRead: (stamp) =>
       stamp.resources.every((resource) => latestByResource.get(resource) === stamp.generation),
     latestGeneration: (resource) => latestByResource.get(resource),
-    epoch: () => mutationEpoch,
   };
 }

--- a/ui/src/lib/workbenchSessionReadOwnership.ts
+++ b/ui/src/lib/workbenchSessionReadOwnership.ts
@@ -20,6 +20,7 @@ export type WorkbenchSessionReadOwnership = {
     resources?: string | readonly string[],
   ) => boolean;
   isLatestRead: (stamp: WorkbenchSessionReadStamp) => boolean;
+  latestGeneration: (resource: string) => number | undefined;
   epoch: () => number;
 };
 
@@ -52,6 +53,7 @@ export function createWorkbenchSessionReadOwnership(): WorkbenchSessionReadOwner
     },
     isLatestRead: (stamp) =>
       stamp.resources.every((resource) => latestByResource.get(resource) === stamp.generation),
+    latestGeneration: (resource) => latestByResource.get(resource),
     epoch: () => mutationEpoch,
   };
 }

--- a/ui/src/lib/workbenchSessionReadOwnership.ts
+++ b/ui/src/lib/workbenchSessionReadOwnership.ts
@@ -1,0 +1,40 @@
+/**
+ * Orders asynchronous Workbench reads against accepted session mutations.
+ *
+ * A response is only allowed to commit when it belongs to the current
+ * mutation epoch and is the newest read issued by this data owner. This keeps
+ * HTTP completion order from deciding whether a stale snapshot wins over a
+ * realtime event or a newer read.
+ */
+export type WorkbenchSessionReadStamp = {
+  epoch: number;
+  generation: number;
+};
+
+export type WorkbenchSessionReadOwnership = {
+  beginRead: () => WorkbenchSessionReadStamp;
+  acceptMutation: () => number;
+  isCurrent: (stamp: WorkbenchSessionReadStamp) => boolean;
+  isLatestRead: (stamp: WorkbenchSessionReadStamp) => boolean;
+  epoch: () => number;
+};
+
+export function createWorkbenchSessionReadOwnership(): WorkbenchSessionReadOwnership {
+  let mutationEpoch = 0;
+  let latestGeneration = 0;
+
+  return {
+    beginRead: () => {
+      latestGeneration += 1;
+      return { epoch: mutationEpoch, generation: latestGeneration };
+    },
+    acceptMutation: () => {
+      mutationEpoch += 1;
+      return mutationEpoch;
+    },
+    isCurrent: (stamp) =>
+      stamp.epoch === mutationEpoch && stamp.generation === latestGeneration,
+    isLatestRead: (stamp) => stamp.generation === latestGeneration,
+    epoch: () => mutationEpoch,
+  };
+}


### PR DESCRIPTION
Fixes #971

## Changed capability

The shared Workbench project-tree and Inbox data owners now determine the final state by logical freshness rather than response completion order. One ownership helper tracks resource-scoped mutation epochs and read generations for project lists, per-project windows, Inbox feed rows, whole-account unread snapshots, and targeted session rows/counts. Broad responses claim only the dynamic rows they actually contain, so a newer broad row supersedes an older targeted snapshot while a window that omits the restored Session preserves the targeted foreground-restore upsert.

Invalidated startup, reconnect, first-page, pagination, and resume operations retry their original ownership operation after the existing serialization lock releases. Independent projects and Inbox data slices do not invalidate one another. Project pagination, Inbox cursor behavior, local create/fork placement, loading flags, and the existing targeted foreground-restore upsert remain intact.

Covered read/write siblings include project bootstrap, reconnect reconcile, first-page and cursor session reads, cached session-row reads, Inbox refresh, load-more, resume reconcile, mark-read, targeted restore, realtime session/unread events, and successful local session/project mutations.

## Evidence

- Unit: workbenchSessionReadOwnership.test.ts covers per-resource mutation/read independence, overlapping broad/targeted ownership, dynamic row claims, and operation-specific generations.
- Contract: WorkbenchSessionReadOrdering.test.tsx deterministically controls response completion order for stale project bootstrap after archive, created-session reconcile after status, first-page and pagination invalidation, reconnect retry, stale Inbox refresh/reconcile/mark-read after hide, targeted/broad feed rows in both completion orders, unread-map independence, cursor preservation, and paired foreground restore.
- Scenario: no repository scenario catalog entry applies to this UI client race; the focused provider contract suite exercises the issue #971 acceptance flows.
- Residual manual checks: cross-platform end-to-end verification of hide/archive/restore over a live SSE connection remains for the integration/regression pass.

## Dependencies

- Requires no other PR to merge first.
