### PR TITLE
fix(show): dispatch authorized public annotations

### DIFF
--- a/tests/test_ui_show_pages.py
+++ b/tests/test_ui_show_pages.py
@@ -3357,23 +3357,30 @@ def test_public_show_page_events_require_login(monkeypatch, tmp_path):
     _save_config(tmp_path)
     _create_agent_session("ses123")
     share_id = _create_show_page("ses123", "public")
+    dispatches = []
 
-    response = app.test_client().post(
-        f"/p/{share_id}/__show/events",
-        base_url="https://alex.avibe.bot",
-        environ_base=_remote_peer(),
-        headers={
-            "Origin": "https://alex.avibe.bot",
-            "Content-Type": "application/json",
-        },
-        json={
-            "type": "human.annotation.created",
-            "annotation": {"comment": "Anonymous review."},
-        },
-    )
+    async def unexpected_dispatch(payload, **kwargs):
+        dispatches.append(payload)
+        return {"status_code": 202, "body": {"ok": True}}
+
+    with patch("vibe.internal_client.dispatch_async", unexpected_dispatch):
+        response = app.test_client().post(
+            f"/p/{share_id}/__show/events",
+            base_url="https://alex.avibe.bot",
+            environ_base=_remote_peer(),
+            headers={
+                "Origin": "https://alex.avibe.bot",
+                "Content-Type": "application/json",
+            },
+            json={
+                "type": "human.annotation.created",
+                "annotation": {"comment": "Anonymous review.", "dispatch": True},
+            },
+        )
 
     assert response.status_code == 403
     assert response.get_json()["code"] == "public_show_events_login_required"
+    assert dispatches == []
 
 
 def test_public_show_page_events_require_share_token(monkeypatch, tmp_path):
@@ -3782,12 +3789,13 @@ def test_public_show_page_intent_fallback_does_not_expose_author_email(monkeypat
     assert "member@example.com" not in listed.content.decode("utf-8")
 
 
-def test_public_show_page_events_ignore_client_event_id_and_dispatch(monkeypatch, tmp_path):
+def test_public_show_page_events_preserve_dispatch_for_authorized_user(monkeypatch, tmp_path):
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     config = _save_config(tmp_path)
     _create_agent_session("ses123")
     share_id = _create_show_page("ses123", "public")
     published = []
+    dispatches = []
     monkeypatch.setattr("vibe.ui_server._publish_show_session_event", published.append)
     client = app.test_client()
     client.set_cookie(
@@ -3796,24 +3804,33 @@ def test_public_show_page_events_ignore_client_event_id_and_dispatch(monkeypatch
         domain="alex.avibe.bot",
     )
 
-    response = client.post(
-        f"/p/{share_id}/__show/events",
-        base_url="https://alex.avibe.bot",
-        environ_base=_remote_peer(),
-        headers=_public_show_write_headers(share_id),
-        json={
-            "id": "forged\nid: injected",
-            "type": "human.annotation.created",
-            "annotation": {"comment": "Review this.", "dispatch": True},
-        },
-    )
+    async def fake_dispatch_async(payload, **kwargs):
+        dispatches.append(payload)
+        _accept_dispatch(payload)
+        return {"status_code": 202, "body": {"ok": True}}
+
+    with patch("vibe.internal_client.dispatch_async", fake_dispatch_async):
+        response = client.post(
+            f"/p/{share_id}/__show/events",
+            base_url="https://alex.avibe.bot",
+            environ_base=_remote_peer(),
+            headers=_public_show_write_headers(share_id),
+            json={
+                "id": "forged\nid: injected",
+                "type": "human.annotation.created",
+                "annotation": {"comment": "Review this.", "dispatch": True},
+            },
+        )
 
     assert response.status_code == 201
     event = response.get_json()["event"]
     assert event["id"] != "forged\nid: injected"
     assert "\n" not in event["id"]
-    assert "dispatch" not in event["payload"]
-    assert "dispatch" not in published[0]["payload"]
+    assert event["payload"]["dispatch"] is True
+    assert "delivery_id" not in event
+    assert published[0]["delivery_id"] == dispatches[0]["user_message_id"]
+    assert published[0]["payload"]["dispatch"] is True
+    assert dispatches[0]["session_id"] == "ses123"
 
 
 @pytest.mark.parametrize("event_type", ["assistant.mark.created", "system.annotation.control"])

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -53,6 +53,10 @@ from core.show_pages import (
     SHOW_EVENT_WRITE_TOKEN_COOKIE,
     SHOW_EVENT_WRITE_TOKEN_HEADER,
     SHOW_PAGE_ICON_MAX_UPLOAD_BYTES,
+    VISIBILITY_OFFLINE,
+    VISIBILITY_PRIVATE,
+    VISIBILITY_PUBLIC,
+    ShowPage,
     show_cli_event_token,
     show_event_write_token,
     show_public_event_write_token,
@@ -10012,7 +10016,7 @@ def _public_show_referer_matches(share_id: str) -> bool:
 
 def _sanitize_public_show_event_payload(payload: dict[str, Any]) -> dict[str, Any]:
     sanitized = dict(payload)
-    for key in ("id", "dispatch", "sessionId", "session_id"):
+    for key in ("id", "sessionId", "session_id"):
         sanitized.pop(key, None)
     for key in ("payload", "annotation", "mark"):
         nested = sanitized.get(key)
@@ -10020,9 +10024,30 @@ def _sanitize_public_show_event_payload(payload: dict[str, Any]) -> dict[str, An
             sanitized[key] = {
                 nested_key: value
                 for nested_key, value in nested.items()
-                if nested_key not in {"dispatch", "sessionId", "session_id"}
+                if nested_key not in {"sessionId", "session_id"}
             }
     return sanitized
+
+
+def _show_annotation_capability(
+    *,
+    author: dict[str, str] | None,
+    page: ShowPage,
+    public_share_id: str | None = None,
+) -> bool:
+    """Return whether this request may write and dispatch Show annotations.
+
+    The current device-side authorization boundary is the validated Workbench
+    session (or trusted local access), represented by ``author``. Page
+    visibility and the share/session binding remain independent structural
+    checks so a future ACL can extend the author decision without changing the
+    event pipeline.
+    """
+    if author is None or page.visibility == VISIBILITY_OFFLINE:
+        return False
+    if public_share_id is not None:
+        return page.visibility == VISIBILITY_PUBLIC and page.share_id == public_share_id
+    return page.visibility in {VISIBILITY_PRIVATE, VISIBILITY_PUBLIC}
 
 
 def _show_request_author(*, public: bool = False) -> dict[str, str] | None:
@@ -10047,10 +10072,16 @@ def _show_request_author(*, public: bool = False) -> dict[str, str] | None:
     return {"kind": "local"}
 
 
-def _show_me_response(author: dict[str, str] | None, *, write_token: str | None = None):
+def _show_me_response(
+    author: dict[str, str] | None,
+    *,
+    can_annotate: bool | None = None,
+    write_token: str | None = None,
+):
     authenticated = author is not None
-    payload = {"authenticated": authenticated, "canAnnotate": authenticated}
-    if authenticated and write_token:
+    capability = authenticated if can_annotate is None else bool(can_annotate)
+    payload = {"authenticated": authenticated, "canAnnotate": capability}
+    if capability and write_token:
         payload["writeToken"] = write_token
     response = jsonify(payload)
     response.headers["Cache-Control"] = "no-store, private"
@@ -11361,8 +11392,10 @@ async def serve_private_show_page(session_id, asset_path):
         if asset_path.strip("/") == "__show/me":
             if request.method not in {"GET", "HEAD"}:
                 return jsonify({"ok": False, "code": "method_not_allowed"}), 405
+            author = {"kind": "local"}
             return _show_me_response(
-                {"kind": "local"},
+                author,
+                can_annotate=_show_annotation_capability(author=author, page=page),
                 write_token=show_event_write_token(page.session_id),
             )
         if asset_path.strip("/") in {"__show/events", "__events"}:
@@ -11446,10 +11479,16 @@ async def serve_public_show_page(share_id, asset_path):
             if request.method not in {"GET", "HEAD"}:
                 return jsonify({"ok": False, "code": "method_not_allowed"}), 405
             author = _show_request_author(public=True)
+            can_annotate = _show_annotation_capability(
+                author=author,
+                page=page,
+                public_share_id=share_id,
+            )
             return _show_me_response(
                 author,
+                can_annotate=can_annotate,
                 write_token=(
-                    show_public_event_write_token(share_id, page.session_id) if author is not None else None
+                    show_public_event_write_token(share_id, page.session_id) if can_annotate else None
                 ),
             )
         if asset_path.strip("/").startswith("__show/media/"):
@@ -11475,6 +11514,13 @@ async def serve_public_show_page(share_id, asset_path):
             author = _show_request_author(public=True)
             if author is None:
                 return jsonify({"ok": False, "code": "public_show_events_login_required"}), 403
+            can_annotate = _show_annotation_capability(
+                author=author,
+                page=page,
+                public_share_id=share_id,
+            )
+            if not can_annotate:
+                return jsonify({"ok": False, "code": "public_show_events_forbidden"}), 403
             if not _public_show_referer_matches(share_id):
                 return jsonify({"ok": False, "code": "public_show_events_origin_mismatch"}), 403
             if not _public_show_event_write_authorized(share_id, page.session_id):
@@ -11498,7 +11544,7 @@ async def serve_public_show_page(share_id, asset_path):
                 author=author,
                 public=True,
                 public_share_id=share_id,
-                allow_dispatch=False,
+                allow_dispatch=can_annotate,
             )
         if request.method in {"GET", "HEAD"}:
             if shim_response := _show_runtime_public_client_shim_response(asset_path):


### PR DESCRIPTION
## Capability

Authorized Public Show Page annotations now enter the same delivery and Agent turn pipeline as private Show Page annotations. Public visibility remains an anonymous read policy; annotation dispatch is governed by the authenticated Show annotation capability.

## Changes

- reuse one server-side annotation capability for `__show/me`, public write-token issuance, and Public Show event dispatch
- preserve an authorized human event's `dispatch` intent while continuing to discard client-supplied event IDs and session identity fields
- keep anonymous writes fail-closed before storage or dispatch, even when the payload forges `dispatch: true`
- keep public event responses redacted from internal session, message, and delivery identifiers

## Evidence

- Unit: `tests/test_show_session_events.py` (84 passed)
- Contract: `tests/test_ui_show_pages.py` (227 passed), including authenticated Public dispatch and anonymous forged-dispatch rejection
- Scenario IDs: none; the Show Page flow has no matching scenario catalog entry
- Lint: Ruff passed on both changed files
- Build: UI production build passed during worktree bootstrap; no UI source changed
- Residual manual check: authenticated Avibe Cloud Public URL -> annotation -> live Agent response is deferred to the integration regression pass

## Risk

The current `master` data model has no device-side Workbench role ACL. A validated Workbench OAuth session (or trusted local access) remains the existing authorization boundary; the new capability isolates that decision so a future ACL can extend it without changing dispatch semantics.

## Known By Design

- Existing record-only Public events without `dispatch: true` remain record-only.
- Historical record-only annotations are not replayed automatically.
