### PR TITLE
test(watches): remove shared lifetime expiry timing window

### DIFF
--- a/tests/test_watches.py
+++ b/tests/test_watches.py
@@ -3807,12 +3807,12 @@ _HOOK_BRANCHES: dict[str, dict] = {
         "expect_hook": "exited with code 2",
         "expect_exit_code": 2,
     },
-    # the supervisor's own deadline. Cycle 1 retries (75 IS a retry code) and its
-    # ``retry_delay_seconds`` sleep pushes the loop past the lifetime, so iteration 2
-    # takes the lifetime branch BEFORE it ever reaches ``mark_cycle_start``. Writes in
-    # order: start #1, retry result #2, lifetime result #3.
+    # The supervisor's own deadline. The shared fixture arms the lifetime only after
+    # cycle 1's retry result has landed, then expires it after iteration 2 reloads the
+    # live mirror. The lifetime branch runs BEFORE ``mark_cycle_start``. Writes in order:
+    # start #1, retry result #2, lifetime result #3.
     "lifetime_expiry": {
-        "overrides": {"mode": "forever", "lifetime_timeout_seconds": 0.02, "retry_delay_seconds": 0.15},
+        "overrides": {"mode": "forever", "lifetime_timeout_seconds": 0},
         "cycles": [_CycleResult(exit_code=75, stdout="", stderr="not yet", timed_out=False)],
         "occurrence": 3,
         "expect_hook": "reached its lifetime timeout",
@@ -3907,6 +3907,32 @@ def _hook_branch_service(tmp_path: Path, branch: str, *, request_store=None) -> 
         return results[min(len(calls) - 1, len(results) - 1)]
 
     service._run_cycle = _spy_cycle  # type: ignore[method-assign]
+    if branch == "lifetime_expiry":
+        # Production reaches _sleep_before_retry only after the guarded retry-result
+        # stamp commits. Use that boundary as the condition; no wall-clock wait needed.
+        retry_result_landed = False
+        wait_for_follow_up_slot = service._wait_for_follow_up_slot
+
+        async def _mark_retry_result_landed(watch_arg, *, lifetime_started):  # noqa: ANN001
+            nonlocal retry_result_landed
+            assert calls == [watch_arg.id], "lifetime expiry must follow exactly one retry cycle"
+            retry_result_landed = True
+
+        async def _expire_after_next_reload(watch_id, *, lifetime_started):  # noqa: ANN001
+            slot = await wait_for_follow_up_slot(
+                watch_id,
+                lifetime_started=lifetime_started,
+            )
+            if retry_result_landed:
+                live_watch = store.get_watch(watch_id)
+                assert live_watch is not None
+                elapsed = asyncio.get_running_loop().time() - lifetime_started
+                assert elapsed > 0, "the retry result landed before the lifetime clock advanced"
+                live_watch.lifetime_timeout_seconds = elapsed
+            return slot
+
+        service._sleep_before_retry = _mark_retry_result_landed  # type: ignore[method-assign]
+        service._wait_for_follow_up_slot = _expire_after_next_reload  # type: ignore[method-assign]
     return store, service, watch, request_store, session_id, calls
 
 
@@ -3918,38 +3944,9 @@ def test_run_watch_enqueues_the_branch_hook_when_the_result_stamp_lands(tmp_path
     reached at all. Here the same wiring, minus the reclaim, must enqueue exactly one
     hook carrying that branch's own text.
     """
-    store, service, watch, request_store, _session_id, calls = _hook_branch_service(tmp_path, branch)
+    _store, service, watch, request_store, _session_id, calls = _hook_branch_service(tmp_path, branch)
 
-    async def _run() -> None:
-        if branch != "lifetime_expiry":
-            await service._run_watch(watch.id)
-            return
-
-        # The lifetime now begins when the Watch is created, so a tiny real-time
-        # deadline can expire during fixture setup on a busy CI runner. Hold a wide
-        # deadline until the retry result has landed, then expire it from the exact
-        # monotonic origin that _run_watch is using.
-        watch.lifetime_timeout_seconds = 60
-        store.upsert_watch(watch)
-        cycle_completed = asyncio.Event()
-        release_cycle = asyncio.Event()
-
-        async def _expire_after_completed_cycle(watch_arg, *, lifetime_started):  # noqa: ANN001
-            cycle_completed.set()
-            await release_cycle.wait()
-            watch_arg.lifetime_timeout_seconds = max(
-                asyncio.get_running_loop().time() - lifetime_started,
-                sys.float_info.min,
-            )
-            store.upsert_watch(watch_arg)
-
-        service._sleep_before_retry = _expire_after_completed_cycle  # type: ignore[method-assign]
-        task = asyncio.create_task(service._run_watch(watch.id))
-        await asyncio.wait_for(cycle_completed.wait(), timeout=2)
-        release_cycle.set()
-        await asyncio.wait_for(task, timeout=2)
-
-    asyncio.run(_run())
+    asyncio.run(service._run_watch(watch.id))
 
     _assert_branch_was_reached(branch, calls)
     pending = request_store.list_pending()


### PR DESCRIPTION
## Summary

- move lifetime-expiry control into the shared hook-branch fixture used by every consumer
- arm the synthetic lifetime only after the retry result stamp commits, then expire it after the next real store reload
- remove the per-test event workaround; production code and branch assertions are unchanged

## Root Cause

The shared `lifetime_expiry` fixture created a Watch with a 20 ms durable lifetime. SQLite schema reflection, secondary store construction, and race-listener setup all happened after creation and therefore consumed that lifetime. On a busy runner, `_run_watch` reached its first lifetime check after the deadline and committed lifetime expiry before `mark_cycle_start`, the fake cycle, or the retry-result stamp. That produced `calls == []` and only one guarded write instead of the expected three.

#1319 protected only `test_run_watch_enqueues_the_branch_hook_when_the_result_stamp_lands`; four other tests still consumed the same 20 ms fixture. PR #1326 exposed three of them in one shard, and PR #1312 exposed the HFR-269 positive control.

The fixture now begins with lifetime disabled. `_sleep_before_retry` is the deterministic condition that the retry-result stamp has committed, so the fixture marks that condition without sleeping. On the next iteration it lets the real reload and follow-up-slot check complete, then sets the live mirror's lifetime to the exact elapsed monotonic value. The immediately following production check sees `remaining == 0` and takes the lifetime branch before a second cycle. No real-time deadline, arbitrary sleep, extra definition write, or product change remains.

## Evidence

- pre-fix: 5 failures in 50 HFR-269 control invocations under P25 local contention
- post-fix: 0 failures in the same 50-invocation P25 run
- post-fix: 50/50 consecutive lifetime-expiry family runs passed (250 parameter instances)
- post-fix: `tests/test_watches.py` passed 120/120; Ruff passed
- independent CI reproduction: PR #1326 head `680429334` [unit-tests shard 4/6](https://github.com/avibe-bot/avibe/actions/runs/31503954130/job/93820690023) observed only one guarded write in total, so the configured reclaim at lifetime-result occurrence #3 never fired in HFR-267; this is the same pre-cycle expiry window covered by the shared fixture change
- unit: updated shared fixture is exercised by all five lifetime-expiry consumers
- contract: no production contract or code changed
- scenario: HFR-267 and HFR-269
- residual manual checks: none; test-only timing control

## Dependencies

None.

## Known By Design

None.
