### PR TITLE
fix(regression): preserve Vault live updates from tenant shell

### DIFF
--- a/scripts/incus_regression.py
+++ b/scripts/incus_regression.py
@@ -51,6 +51,7 @@ METADATA_DIR = "/var/lib/avibe-regression"
 METADATA_PATH = f"{METADATA_DIR}/metadata.json"
 FINGERPRINT_PATH = f"{METADATA_DIR}/fingerprints.json"
 SERVICE_NAME = "avibe-regression.service"
+INTERNAL_DISPATCH_SOCKET = "/tmp/vibe_remote/dispatch.sock"
 DEFAULT_IMAGE = "avibe-regression-base-current"
 DEFAULT_BASE_SOURCE_IMAGE = "images:ubuntu/24.04/cloud"
 DEFAULT_NETWORK = "incusbr0"
@@ -508,7 +509,7 @@ def regression_service_unit() -> str:
         Environment=VIBE_DEPLOYMENT_ENV=regression
         Environment=VIBE_BUILD_METADATA_PATH={METADATA_PATH}
         Environment=AVIBE_ALLOW_DEV_STATE_MIGRATION=1
-        Environment=VIBE_INTERNAL_DISPATCH_SOCKET=/tmp/vibe_remote/dispatch.sock
+        Environment=VIBE_INTERNAL_DISPATCH_SOCKET={INTERNAL_DISPATCH_SOCKET}
         Environment=PYTHONUNBUFFERED=1
         Environment=PATH={VENV_DIR}/bin:{SERVICE_HOME}/.local/bin:/usr/local/bin:/usr/bin:/bin
         EnvironmentFile=-/etc/avibe-regression.env
@@ -669,6 +670,7 @@ def tenant_exec(target: RegressionTarget, command: str, *args: str, remote: str 
     bash_command = (
         "set -a; [ ! -f /etc/avibe-regression.env ] || . /etc/avibe-regression.env; "
         "VIBE_DEPLOYMENT_ENV=regression; AVIBE_ALLOW_DEV_STATE_MIGRATION=1; "
+        f"VIBE_INTERNAL_DISPATCH_SOCKET={shlex.quote(INTERNAL_DISPATCH_SOCKET)}; "
         f"set +a; cd {shlex.quote(SOURCE_DIR)} && {command}"
     )
     return incus(

--- a/tests/test_incus_regression.py
+++ b/tests/test_incus_regression.py
@@ -299,6 +299,7 @@ def test_tenant_exec_exports_regression_guard_override() -> None:
     assert "[ ! -f /etc/avibe-regression.env ] || . /etc/avibe-regression.env" in command
     assert "VIBE_DEPLOYMENT_ENV=regression" in command
     assert "AVIBE_ALLOW_DEV_STATE_MIGRATION=1" in command
+    assert "VIBE_INTERNAL_DISPATCH_SOCKET=/tmp/vibe_remote/dispatch.sock" in command
 
 
 def test_remote_ref_prefixes_resource_names_only() -> None:


### PR DESCRIPTION
## Summary

- export the regression Controller dispatch socket in every tenant shell/CLI command
- keep the service unit and tenant command on one shared socket constant
- cover the tenant environment contract in the regression runner tests

## User impact

Vault requests created from the local Incus regression shell now publish `vaults.updated` immediately, so an already-open Chat page refreshes without a browser reload. Terminal Vault outcomes can also wake the callback lane through the same event bridge.

The protected-denial path itself is unchanged: callback-enabled requests already emit the Vault outcome, while `--no-callback` intentionally suppresses Agent resume.

## Evidence

- Unit: focused Incus runner environment tests pass
- Contract: generated tenant command now carries the same dispatch socket as the systemd service
- Scenario: reproduced missing live event without the socket, then observed `vaults.updated` and the protected denial message when the shared socket was present
- Residual manual checks: update the worktree regression environment and repeat the open-Chat request/deny flow after review

## Scenario IDs

No existing catalog scenario covers regression-shell environment parity.
