### PR TITLE
docs(model-hub): clarify source-order consumers

### DIFF
--- a/docs/plans/model-hub-contracts/api.md
+++ b/docs/plans/model-hub-contracts/api.md
@@ -36,7 +36,7 @@ Hub has not shipped, so there is no internal contract migration or compatibility
 | PATCH `/api/models/agents/<backend>/mode` | `{mode}` → `{agent: AgentSupply}` | Explicit `hub` / `direct` switch. A qualifying Direct → Gateway switch atomically adopts the recognized CLI login as the first native Source; other switches create nothing. |
 | PUT `/api/models/agents/opencode/menu` | `{menu}` → `{agent: AgentSupply}` | Open-menu configuration. |
 | GET `/api/models/agents/<backend>/chain?model=<id>` | → `{chain: AgentChain}` | Hub only. Direct returns the documented `direct_mode` error. |
-| PUT `/api/models/agents/<backend>/chain?model=<id>` | `{hops: RouteHop[], force?: boolean, would_remove_hops?: RouteHopRef[], would_interrupt?: SupplyGap[]}` → guarded `409` or `{chain, removed_hops, interrupted}` | Replaces the exact Source/model pairs in submitted order after validating new or changed pairs; it is the `mutation.route_replace` row of the authoritative mutation matrix. A visible noninterrupting hop removal is ordinary success; only a resulting protected-supply interruption enters the guard. |
+| PUT `/api/models/agents/<backend>/chain?model=<id>` | `{hops: RouteHop[], force?: boolean, would_remove_hops?: RouteHopRef[], would_interrupt?: SupplyGap[]}` → guarded `409` or `{chain, removed_hops, interrupted}` | Replaces the exact Source/model pairs in submitted order after validating new or changed pairs; the handler never reads `sources.order`, and the submitted `hops` carry no Source-order semantics. It is the `mutation.route_replace` row of the authoritative mutation matrix. A visible noninterrupting hop removal is ordinary success; only a resulting protected-supply interruption enters the guard. |
 | POST `/api/models/agents/<backend>/probe` | `{model?}` → `{probe: ProbeResult}` | Hub only. Direct returns the same `direct_mode` error. |
 | GET `/api/models/events?limit=<n>&before=<id>` | → `{events: ResolutionEvent[]}` | Bounded source-resolution feed. |
 | POST `/api/models/oauth/start` | `{vendor, channel, client_nonce?}` → `{flow: OAuthFlow}` | Starts creation of a new subscription source. Before provider work, the optional exact `(client_nonce, vendor, channel)` tuple is atomically claimed; concurrent retries coalesce to its one pending start and terminal result. |
@@ -355,9 +355,9 @@ It stores only `sources.order`, never reads or writes a Route chain, and therefo
 returns a guarded `409`. This is the G-9 tombstone: adding a guard branch would imply an
 order save is allowed to mutate supply, which violates S-1.
 
-`POST /api/models/agents/<backend>/chains/reorder` is the only operation that applies
-the stored Source order to existing Routes. For each Route, give every hop its original
-zero-based index `i` and sort by this total key:
+`POST /api/models/agents/<backend>/chains/reorder` is the only server-side post-creation
+operation that implicitly reads and applies the stored Source order to existing Routes.
+For each Route, give every hop its original zero-based index `i` and sort by this total key:
 
 ```text
 source_id in sources.order  -> (0, sources.order.index(source_id), i)
@@ -396,6 +396,9 @@ does not satisfy the recognition predicate.
 Every menu model stores one `hops` array. Each hop is an exact
 `{source_id, model_id}` pair; a differing upstream id is the mapping itself, not a
 separate mapping object. A write validates only newly introduced or changed pairs.
+The per-model PUT persists the explicit submitted order and never reads `sources.order`.
+An editor may sort its local draft from the Source-order projection already on the page,
+but the request still carries only explicit `hops`, with no stored-order instruction.
 The whole-array PUT uses `force` plus the optional echoed `would_remove_hops` and
 `would_interrupt` arrays in the JSON body only when the submitted edit would interrupt
 protected supply. A successful write returns `{chain, removed_hops, interrupted}`.
@@ -1067,6 +1070,7 @@ contract harness and API-boundary tests enforce:
 | authority registry and mirror relations are generated from live files in the same test run; every registered closed branch has a consumer and every registered consumer resolves to one authority | `mirror-registry.json` harness |
 | every non-null `then` constraint has matching `required` | contract harness |
 | every `sources.order` id exists, is unique, and is eligible | config loader + source-order route |
+| the per-model Route PUT accepts only explicit `hops` and its server path never reads or implicitly applies `sources.order`; only the all-chain reorder operation does so after creation | API route negative fixture |
 | eligibility contains one row per source and every ordered source is eligible | AgentSupply assembler |
 | every AgentSupply eligibility row carries `in_current_model_chain` and `process_availability_reason`; membership nullability follows `selected_model_id`, and only a native source may carry `native_cli_unavailable` | AgentSupply assembler |
 | `AgentChain.chain` re-echoes the stored exact hops in the same order, including missing, model-unsupported, and process-unavailable native CLI items; `AgentChain.current` is null or identifies one exact hop in that array | chain assembler |

--- a/docs/plans/model-hub.md
+++ b/docs/plans/model-hub.md
@@ -439,10 +439,15 @@ inventory result reorders existing configuration. `created_at` remains ordinary 
 metadata for audit/display; routing and placement never read or mutate it.
 
 The explicit `POST /api/models/agents/<backend>/chains/reorder` operation is the sole
-post-creation consumer of the current Source-order sequence. It reorders existing hops
-only, preserves every exact `(source_id, model_id)` member and mapping, and never reruns
-matching. Its complete stable order is defined in §4.6. Because it cannot remove supply,
-it has no guarded `409`, `force`, or interruption branch even when the first hop changes.
+server-side post-creation operation that implicitly applies the stored Source-order
+sequence to existing Routes. It reorders existing hops only, preserves every exact
+`(source_id, model_id)` member and mapping, and never reruns matching. Its complete stable
+order is defined in §4.6. A user-authored per-model `hops` PUT carries only the submitted
+explicit hop order, and its server handler never reads `sources.order`; an editor may use
+its page-held Source-order projection to help sort a local draft, but that draft becomes
+explicit `hops` with no Source-order semantics on the wire. Because the all-chain operation
+cannot remove supply, it has no guarded `409`, `force`, or interruption branch even when
+the first hop changes.
 
 On `PATCH /api/models/agents/<backend>/mode`, a `direct` → `hub` transition also owns
 one bounded adoption transaction. If the backend has a sanctioned, recognized CLI
@@ -1279,9 +1284,11 @@ current order and `(1, i, i)` otherwise, then sort lexicographically. Thus all l
 Sources come first in configured order, hops sharing a listed Source retain their
 relative order, and all unlisted-Source hops follow while retaining their mutual
 relative order. The operation is idempotent, never runs matching, and never adds,
-removes, remaps, guards, or reports interruption. It is the only existing-chain
-consumer of `sources.order`; storing a new Source order alone leaves every Route byte-
-identical.
+removes, remaps, guards, or reports interruption. It is the only server-side existing-
+chain operation that implicitly reads and applies `sources.order`; storing a new Source
+order alone leaves every Route byte-identical. A per-model Route PUT is instead an explicit
+user-authored `hops` replacement: its handler does not read `sources.order`, even when the
+client used its already-held Source-order projection as a local draft-sorting aid.
 
 `hops` may be empty and is always present. A newly introduced menu model starts with an
 empty route; catalog expansion and inventory refresh do not retroactively match it.

--- a/tests/test_model_hub_api.py
+++ b/tests/test_model_hub_api.py
@@ -1011,8 +1011,10 @@ def test_model_hub_oauth_blocks_recovery_before_external_auth(tmp_path):
     assert adapter.secret_lengths == []
 
 
-def test_chain_route_reorders_exact_persisted_hops(monkeypatch, tmp_path):
-    service, _, _ = _service(tmp_path)
+def test_chain_route_preserves_submitted_hops_against_opposite_source_order(
+    monkeypatch, tmp_path
+):
+    service, store, _ = _service(tmp_path)
     first = asyncio.run(
         _create_source(
             service,
@@ -1036,9 +1038,13 @@ def test_chain_route_reorders_exact_persisted_hops(monkeypatch, tmp_path):
         )
     )
     model_id = "claude-opus-4-6"
+    store.config.agents["claude"].sources.order = [first["id"], second["id"]]
     hops = [
         {"source_id": second["id"], "model_id": model_id},
         {"source_id": first["id"], "model_id": model_id},
+    ]
+    assert store.config.agents["claude"].sources.order == [
+        hop["source_id"] for hop in reversed(hops)
     ]
     monkeypatch.setattr(ui_server, "_model_hub_service", lambda: service)
     client = app.test_client()
@@ -1059,6 +1065,10 @@ def test_chain_route_reorders_exact_persisted_hops(monkeypatch, tmp_path):
         (hop["source_id"], hop["model_id"]) for hop in hops
     ]
     assert body["chain"]["current"] == {"source_id": second["id"], "model_id": model_id}
+    assert [
+        (hop.source_id, hop.model_id)
+        for hop in store.config.agents["claude"].routes[model_id].hops
+    ] == [(hop["source_id"], hop["model_id"]) for hop in hops]
 
 
 def test_delete_guard_reports_only_routes_emptied_by_this_mutation(tmp_path):

--- a/tests/test_model_hub_config.py
+++ b/tests/test_model_hub_config.py
@@ -528,6 +528,46 @@ def test_source_create_unavailable_inventory_consent_is_explicit_and_total():
         assert required in ac_54
 
 
+def test_per_model_route_put_does_not_consume_stored_source_order():
+    api_contract = (CONTRACTS / "api.md").read_text(encoding="utf-8")
+    model_hub_plan = (CONTRACTS.parent / "model-hub.md").read_text(encoding="utf-8")
+
+    route_row = next(
+        line
+        for line in api_contract.splitlines()
+        if line.startswith("| PUT `/api/models/agents/<backend>/chain?model=<id>`")
+    )
+    assert "handler never reads `sources.order`" in route_row
+    assert "submitted `hops` carry no Source-order semantics" in route_row
+
+    source_order_contract = api_contract.split("## Per-backend source order", 1)[1].split(
+        "### Direct-to-Gateway native adoption", 1
+    )[0]
+    assert "only server-side post-creation" in source_order_contract
+    assert "implicitly reads and applies the stored Source order" in source_order_contract
+
+    exact_route_contract = api_contract.split("### Exact Route-chain configuration", 1)[
+        1
+    ].split("## Source creation outcome", 1)[0]
+    assert "per-model PUT persists the explicit submitted order" in exact_route_contract
+    assert "never reads `sources.order`" in exact_route_contract
+    assert "request still carries only explicit `hops`" in exact_route_contract
+
+    section_42 = model_hub_plan.split("### 4.2 Gateway strategy", 1)[1].split(
+        "### 4.3 Runtime resolution", 1
+    )[0]
+    section_46 = model_hub_plan.split(
+        "### 4.6 Configured-chain storage and mutation", 1
+    )[1].split("### 4.7", 1)[0]
+    for authority in (section_42, section_46):
+        assert "server" in authority
+        assert "per-model" in authority
+        assert (
+            "does not read `sources.order`" in authority
+            or "never reads `sources.order`" in authority
+        )
+
+
 def test_guard_refusal_error_requires_its_corresponding_nonempty_plan_array():
     validator = Draft7Validator(_schema("guard-refusal.schema.json"))
     hop = {


### PR DESCRIPTION
## Capability

Clarify the Source-order consumer boundary that blocked PR #1350:

- `POST /api/models/agents/<backend>/chains/reorder` remains the sole server-side post-creation operation that implicitly reads stored `sources.order` and applies it to existing Routes
- the per-model Route PUT accepts only explicit `hops`; its server handler never reads `sources.order`, and the request carries no Source-order instruction
- the editor may use its already page-held Source-order projection as an explicit user-invoked local draft-sorting aid; Save still sends explicit `hops`

This is contract clarification only. It adds no field, route, behavior, or compatibility branch, and `contract_version` remains 5.

## Scope

- aligns the sole-consumer language in `model-hub.md` §4.2 and §4.6
- aligns the route row, Source-order section, exact-chain section, and mechanical-guard row in `api.md`
- adds a contract wording guard and a behavioral API fixture that stores Source order opposite to the submitted hops, then proves the response and persisted Route preserve the submitted order
- leaves `model-hub-ui-spec.md`, `turn-provenance.schema.json`, `resolution-event.schema.json`, and the §4.5 Turn-outcome segment untouched

Owner ruling: 2026-08-12 06:42 UTC+08. This PR unblocks the sole-consumer finding on #1350 without changing that lane's UI specification.

## Scenarios and evidence

- Affected scenario IDs: none; this is a wording/authority clarification
- Unit: none; no implementation changed
- Contract: `tests/test_model_hub_config.py` 120 passed, plus the focused API/contract behavior pair passed
- Static: Ruff and `git diff --check` passed
- Scenario: none
- Residual manual checks: none
