### PR TITLE
fix(ui): clarify harness failure details

### DIFF
--- a/core/scheduled_tasks.py
+++ b/core/scheduled_tasks.py
@@ -113,6 +113,7 @@ from storage.background import (
     SWEEP_REASON_ORPHANED,
     SWEEP_REASON_QUEUE_HOLD_EXPIRED,
     SWEEP_REASON_TRANSPORT_UNAVAILABLE,
+    TASK_LAST_RESULT_STATUS_METADATA_KEY,
     SweptRun,
     WATCH_HOOK_OUTCOME_CIRCUIT_REPAIR,
     WATCH_HOOK_OUTCOME_EVENT,
@@ -1841,6 +1842,7 @@ class ScheduledTaskStore:
         exit_code: Optional[int] = None,
         records_command_outcome: bool = False,
         timed_out: bool = False,
+        result_status: Optional[str] = None,
         queued_run: Optional[dict[str, Any]] = None,
         expected_uncanceled_run_id: Optional[str] = None,
     ) -> bool:
@@ -1855,6 +1857,10 @@ class ScheduledTaskStore:
         ``records_command_outcome`` marks the ONE stamp that is a command fire's own
         result, and it is what makes ``exit_code`` authoritative in both directions --
         see the write below.
+
+        ``result_status`` is the existing terminal Run verdict when this stamp is a
+        projection from that ledger. It is stored in definition metadata so read
+        surfaces never have to recover cancellation from localized ``error`` text.
 
         ``expected_uncanceled_run_id`` re-asserts, inside that same transaction, that
         the fire being stamped has not been stopped -- see
@@ -1875,6 +1881,18 @@ class ScheduledTaskStore:
         expect = self._read_state(task)
         task.last_run_at = _utc_now_iso()
         task.last_error = error
+        normalized_result_status = str(result_status or "").strip()
+        if normalized_result_status in TERMINAL_RUN_STATUSES:
+            task.metadata = {
+                **(task.metadata if isinstance(task.metadata, dict) else {}),
+                TASK_LAST_RESULT_STATUS_METADATA_KEY: normalized_result_status,
+            }
+        elif (
+            isinstance(task.metadata, dict)
+            and TASK_LAST_RESULT_STATUS_METADATA_KEY in task.metadata
+        ):
+            task.metadata = dict(task.metadata)
+            task.metadata.pop(TASK_LAST_RESULT_STATUS_METADATA_KEY, None)
         if records_command_outcome:
             # A COMMAND FIRE'S OWN STAMP OWNS THIS COLUMN, ``None`` included. A fire
             # that never reached a process -- a working directory that vanished, a
@@ -9125,6 +9143,7 @@ class ScheduledTaskService:
                 disable_one_shot=retire_one_shot,
                 exit_code=int(raw_exit_code) if raw_exit_code is not None else None,
                 records_command_outcome=records_command_outcome,
+                result_status=status,
                 expected_binding=(
                     task.session_id,
                     task.session_key,

--- a/storage/background.py
+++ b/storage/background.py
@@ -962,15 +962,14 @@ def definition_lifecycle_detail(
     one consumer — the row — and never a ``GROUP BY``: the filter groups by
     state, and the row alone says which of the three endings it was.
 
-    ``timed_out`` is THE ANSWER when the row has one, and the three states are
-    distinct on purpose. 124 is the code the runner synthesizes for a limit it
-    enforced itself, but it is also an exit status a command is free to return —
-    ``timeout 5 ...`` inside a ``--shell`` script returns exactly that — so reading
-    the code alone told a user their backup had been cut short by Avibe when it had
-    in fact cut itself short. ``False`` therefore SUPPRESSES the old inference rather
-    than merely not triggering it; ``None`` means the row never recorded the fact
-    (a watch, or a task stamped before this key existed) and keeps the inference,
-    which is still the best guess available for those rows.
+    ``timed_out`` is THE ANSWER for scheduled tasks when the row has one. 124 is
+    the code the runner synthesizes for a limit it enforced itself, but it is also
+    an exit status a command is free to return — ``timeout 5 ...`` inside a
+    ``--shell`` script returns exactly that. Inferring a Task timeout from the
+    code therefore mislabels rows written before the explicit fact existed. Watch
+    rows retain their legacy code inference because their waiter contract owns
+    that exit code; ``False`` suppresses it when the scheduler explicitly records
+    that its limit was not reached.
     """
 
     if lifecycle_state != "finished":
@@ -979,7 +978,7 @@ def definition_lifecycle_detail(
         return None
     if timed_out:
         return "timeout"
-    if timed_out is None and last_exit_code == _TIMEOUT_EXIT_CODE:
+    if definition_type != "scheduled" and timed_out is None and last_exit_code == _TIMEOUT_EXIT_CODE:
         return "timeout"
     # 64 is a completion, not a failure: the waiter finished its cycle and decided
     # it had nothing worth an Agent turn. Reading it as an ending that "went wrong"

--- a/storage/background.py
+++ b/storage/background.py
@@ -1249,6 +1249,12 @@ COMMAND_WORKER_REAP_ATTEMPTS_KEY = "reap_attempts"
 #: needs those three states apart.
 COMMAND_TIMED_OUT_METADATA_KEY = "last_command_timed_out"
 
+#: The terminal Run status most recently projected onto a scheduled definition.
+#: This reuses the Run ledger's existing status vocabulary; it lets read surfaces
+#: distinguish a user-canceled fire from an arbitrary ``last_error`` without parsing
+#: localized diagnostic text.
+TASK_LAST_RESULT_STATUS_METADATA_KEY = "last_result_status"
+
 
 def command_snapshot_from_definition_row(row: Any) -> Optional[dict[str, Any]]:
     """The ``{"shell", "argv"}`` record of what a scheduled definition row would run.

--- a/tests/scenarios/harness_command_task/catalog.yaml
+++ b/tests/scenarios/harness_command_task/catalog.yaml
@@ -680,3 +680,13 @@ scenarios:
     layer: contract
     backend: shared
     test: tests/test_background_work_banner.py::test_definition_banner_uses_creation_owner_before_execution_target
+  - id: SCT-061
+    name: Harness definition failures lead with translated stable facts and keep raw diagnostics collapsed
+    status: covered
+    kind: failure
+    layer: unit
+    backend: shared
+    test: ui/src/components/workbench/HarnessPage.test.tsx::TaskDetail command task shows a translated failure summary and keeps raw diagnostics collapsed
+    # The shared mapper cases in harnessLifecycle.test.ts cover timeout, nonzero,
+    # and unknown Task/Watch failures, including stderr that looks like another
+    # category. The Watch rendering case proves the same collapsed disclosure.

--- a/tests/test_harness_definition_lifecycle.py
+++ b/tests/test_harness_definition_lifecycle.py
@@ -797,6 +797,21 @@ def test_a_forever_watch_retired_by_its_lifetime_says_it_timed_out(store) -> Non
     ) == "timeout"
 
 
+def test_a_legacy_scheduled_task_exit_124_requires_the_explicit_timeout_fact() -> None:
+    """A command may return 124 itself; missing timeout metadata is generic."""
+    assert (
+        definition_lifecycle_detail(
+            lifecycle_state="finished",
+            definition_type="scheduled",
+            last_run_at=NOW,
+            last_exit_code=124,
+            last_error="command returned status 124",
+            timed_out=None,
+        )
+        == "error"
+    )
+
+
 def test_re_enabling_a_fired_one_shot_task_does_not_make_it_waiting_again(store) -> None:
     """``enabled`` is not a promise of a future fire.
 

--- a/tests/test_scheduled_tasks.py
+++ b/tests/test_scheduled_tasks.py
@@ -92,6 +92,7 @@ from storage.background import (
     COMMAND_TIMED_OUT_METADATA_KEY,
     DefinitionWriteConflict,
     SQLiteBackgroundTaskStore,
+    TASK_LAST_RESULT_STATUS_METADATA_KEY,
     definition_lifecycle_detail,
 )
 from storage.models import (
@@ -3057,8 +3058,12 @@ def test_task_definition_projection_follows_the_exact_terminal_cas_winner(
     assert task.id not in service.scheduler.jobs
     if settlement_winner == "natural_terminal":
         assert "interrupt_reason" not in settled["metadata"]
+        assert TASK_LAST_RESULT_STATUS_METADATA_KEY not in (projected.metadata or {})
     elif settlement_winner == "user_stop":
         assert settled["metadata"]["interrupt_reason"] == SETTLED_BY_STOPPED
+        assert projected.metadata[TASK_LAST_RESULT_STATUS_METADATA_KEY] == "canceled"
+    else:
+        assert projected.metadata[TASK_LAST_RESULT_STATUS_METADATA_KEY] == "failed"
 
 
 @pytest.mark.parametrize("shutdown_entrypoint", ["stop", "lease_loss"])

--- a/ui/src/components/workbench/HarnessPage.test.tsx
+++ b/ui/src/components/workbench/HarnessPage.test.tsx
@@ -914,7 +914,7 @@ describe('WatchDetail runtime', () => {
           watch={watch({
             enabled: true,
             retry_exit_codes: [75],
-            health: 'healthy',
+            health: 'failing',
             lifecycle_detail: 'error',
             last_exit_code,
           })}

--- a/ui/src/components/workbench/HarnessPage.test.tsx
+++ b/ui/src/components/workbench/HarnessPage.test.tsx
@@ -784,6 +784,16 @@ describe('TaskDetail command task', () => {
     expect(html.indexOf(en.harness.failure.generic)).toBeLessThan(html.indexOf(raw));
   });
 
+  it('uses the generic summary when only an opaque technical error is available', () => {
+    const raw = 'command not found: localized stderr';
+    const html = detail(task({ shell_command: 'missing-tool', last_error: raw }));
+
+    expect(html).toContain(en.harness.failure.generic);
+    expect(html).toContain(`>${en.harness.detail.technicalDetails}<`);
+    expect(html).toContain(raw);
+    expect(html).toMatch(/<details(?![^>]*\bopen\b)[^>]*>/);
+  });
+
   it('leaves a message task rendering exactly as it does today', () => {
     const html = detail(task({ name: 'Nightly digest', prompt: 'Summarize #ops', message: 'Summarize #ops' }));
 

--- a/ui/src/components/workbench/HarnessPage.test.tsx
+++ b/ui/src/components/workbench/HarnessPage.test.tsx
@@ -434,6 +434,18 @@ describe('HealthBadge', () => {
     expect(html).toContain(`>${i18n.t('harness.health.failing')} 4<`);
     expect(html).toContain('text-pink');
   });
+
+  it('never exposes raw stderr through the default badge tooltip', () => {
+    const raw = 'database password rejected';
+    const html = render(
+      <HealthBadge
+        row={watch({ health: 'failing', consecutive_failures: 1, recent_failures: 1, last_error: raw })}
+      />,
+    );
+
+    expect(html).toContain(`title="${en.harness.failure.generic}"`);
+    expect(html).not.toContain(raw);
+  });
 });
 
 describe('ProcessingHealthBadge', () => {
@@ -752,6 +764,26 @@ describe('TaskDetail command task', () => {
     );
   });
 
+  it('shows a translated failure summary and keeps raw diagnostics collapsed', () => {
+    const raw = 'pg_dump: connection refused';
+    const html = detail(
+      task({
+        shell_command: 'pg_dump app',
+        last_exit_code: 7,
+        last_error: raw,
+        lifecycle_detail: 'error',
+      }),
+    );
+
+    expect(html).toContain(en.harness.failure.generic);
+    expect(html).toContain(`>${en.harness.detail.lastExitCode}<`);
+    expect(html).toContain('>7<');
+    expect(html).toContain(`>${en.harness.detail.technicalDetails}<`);
+    expect(html).toContain(raw);
+    expect(html).toMatch(/<details(?![^>]*\bopen\b)[^>]*>/);
+    expect(html.indexOf(en.harness.failure.generic)).toBeLessThan(html.indexOf(raw));
+  });
+
   it('leaves a message task rendering exactly as it does today', () => {
     const html = detail(task({ name: 'Nightly digest', prompt: 'Summarize #ops', message: 'Summarize #ops' }));
 
@@ -837,6 +869,29 @@ describe('WatchDetail runtime', () => {
 
     expect(html).toContain(`>${i18n.t('harness.detail.eventProcessing')}<`);
     expect(html).toContain(`>${i18n.t('harness.processingHealth.unknown')}<`);
+  });
+
+  it('shows timeout as translated copy and keeps raw diagnostics collapsed', () => {
+    const raw = 'localized-looking stderr must stay technical';
+    const html = render(
+      <WatchDetail
+        watch={watch({
+          lifecycle_state: 'finished',
+          lifecycle_detail: 'timeout',
+          last_exit_code: 124,
+          last_error: raw,
+        })}
+        onToggleEnabled={() => undefined}
+        pending={false}
+      />,
+    );
+
+    expect(html).toContain(en.harness.failure.timeout);
+    expect(html).toContain(`>${en.harness.detail.lastExitCode}<`);
+    expect(html).toContain('>124<');
+    expect(html).toContain(`>${en.harness.detail.technicalDetails}<`);
+    expect(html).toContain(raw);
+    expect(html).toMatch(/<details(?![^>]*\bopen\b)[^>]*>/);
   });
 });
 

--- a/ui/src/components/workbench/HarnessPage.test.tsx
+++ b/ui/src/components/workbench/HarnessPage.test.tsx
@@ -102,6 +102,7 @@ const watch = (overrides: Partial<HarnessWatch>): HarnessWatch => ({
   last_event_at: null,
   last_error: null,
   last_exit_code: null,
+  metadata: {},
   lifecycle_state: 'paused',
   lifecycle_detail: null,
   next_run_at: null,
@@ -448,6 +449,25 @@ describe('HealthBadge', () => {
 
     expect(html).toContain(`title="${en.harness.failure.generic}"`);
     expect(html).not.toContain(raw);
+  });
+
+  it('does not turn a circuit-breaker pause into an ordinary failure tooltip', () => {
+    const html = render(
+      <HealthBadge
+        row={watch({
+          health: 'failing',
+          consecutive_failures: 1,
+          recent_failures: 1,
+          lifecycle_state: 'paused',
+          metadata: { watch_circuit_breaker: { status: 'tripped' } },
+          last_exit_code: 0,
+          last_error: 'localized circuit pause detail',
+        })}
+      />,
+    );
+
+    expect(html).not.toContain(`title="${en.harness.failure.generic}"`);
+    expect(html).not.toContain('localized circuit pause detail');
   });
 });
 
@@ -884,7 +904,7 @@ describe('WatchDetail runtime', () => {
     expect(html).toContain(`>${i18n.t('harness.processingHealth.unknown')}<`);
   });
 
-  it('shows timeout as translated copy and keeps raw diagnostics collapsed', () => {
+  it('keeps an insufficiently evidenced Watch timeout generic and technical details collapsed', () => {
     const raw = 'localized-looking stderr must stay technical';
     const html = render(
       <WatchDetail
@@ -899,7 +919,8 @@ describe('WatchDetail runtime', () => {
       />,
     );
 
-    expect(html).toContain(en.harness.failure.timeout);
+    expect(html).toContain(en.harness.failure.generic);
+    expect(html).not.toContain(en.harness.failure.timeout);
     expect(html).toContain(`>${en.harness.detail.lastExitCode}<`);
     expect(html).toContain('>124<');
     expect(html).toContain(`>${en.harness.detail.technicalDetails}<`);
@@ -914,8 +935,9 @@ describe('WatchDetail runtime', () => {
           watch={watch({
             enabled: true,
             retry_exit_codes: [75],
-            health: 'failing',
-            lifecycle_detail: 'error',
+            health: 'healthy',
+            lifecycle_state: 'waiting',
+            lifecycle_detail: null,
             last_exit_code,
           })}
           onToggleEnabled={() => undefined}
@@ -934,7 +956,8 @@ describe('WatchDetail runtime', () => {
           enabled: true,
           retry_exit_codes: [75],
           health: 'healthy',
-          lifecycle_detail: 'error',
+          lifecycle_state: 'waiting',
+          lifecycle_detail: null,
           last_exit_code: 75,
           last_error: raw,
         })}
@@ -946,6 +969,74 @@ describe('WatchDetail runtime', () => {
     expect(html).not.toContain(en.harness.failure.generic);
     expect(html).toContain(`<span class="font-mono text-[11px] text-muted">75</span>`);
     expect(html).toContain(`>${en.harness.detail.technicalDetails}<`);
+    expect(html).toContain(raw);
+    expect(html).toMatch(/<details(?![^>]*\bopen\b)[^>]*>/);
+  });
+
+  it('keeps a terminal missing-cwd retry exit as a failure', () => {
+    const raw = 'working directory is unavailable';
+    const html = render(
+      <WatchDetail
+        watch={watch({
+          enabled: false,
+          retry_exit_codes: [1],
+          health: 'failing',
+          lifecycle_state: 'finished',
+          lifecycle_detail: 'error',
+          last_exit_code: 1,
+          last_error: raw,
+        })}
+        onToggleEnabled={() => undefined}
+        pending={false}
+      />,
+    );
+
+    expect(html).toContain(en.harness.failure.generic);
+    expect(html).toContain('<span class="font-mono text-[11px] text-pink">1</span>');
+    expect(html).toContain(raw);
+    expect(html).toMatch(/<details(?![^>]*\bopen\b)[^>]*>/);
+  });
+
+  it('does not call a Watch lifetime expiry a run timeout', () => {
+    const html = render(
+      <WatchDetail
+        watch={watch({
+          enabled: false,
+          health: 'failing',
+          lifecycle_state: 'finished',
+          lifecycle_detail: 'timeout',
+          last_exit_code: 124,
+          last_error: 'watch lifetime expired before the next cycle',
+        })}
+        onToggleEnabled={() => undefined}
+        pending={false}
+      />,
+    );
+
+    expect(html).toContain(en.harness.failure.generic);
+    expect(html).not.toContain(en.harness.failure.timeout);
+  });
+
+  it('keeps a circuit-breaker pause explanation technical without a false run failure', () => {
+    const raw = 'Watch paused after rapid event burst';
+    const html = render(
+      <WatchDetail
+        watch={watch({
+          enabled: false,
+          health: 'failing',
+          lifecycle_state: 'paused',
+          lifecycle_detail: null,
+          last_exit_code: 0,
+          last_error: raw,
+          metadata: { watch_circuit_breaker: { status: 'tripped', exit_code: 0 } },
+        })}
+        onToggleEnabled={() => undefined}
+        pending={false}
+      />,
+    );
+
+    expect(html).not.toContain(en.harness.failure.generic);
+    expect(html).not.toContain(en.harness.failure.timeout);
     expect(html).toContain(raw);
     expect(html).toMatch(/<details(?![^>]*\bopen\b)[^>]*>/);
   });

--- a/ui/src/components/workbench/HarnessPage.test.tsx
+++ b/ui/src/components/workbench/HarnessPage.test.tsx
@@ -817,6 +817,25 @@ describe('TaskDetail command task', () => {
     expect(html).toMatch(/<details(?![^>]*\bopen\b)[^>]*>/);
   });
 
+  it('keeps a legacy Task timeout detail generic without the explicit timeout fact', () => {
+    const raw = 'command returned status 124';
+    const html = detail(
+      task({
+        shell_command: 'backup --self-timeout',
+        lifecycle_detail: 'timeout',
+        last_exit_code: 124,
+        last_error: raw,
+        metadata: {},
+      }),
+    );
+
+    expect(html).toContain(en.harness.failure.generic);
+    expect(html).not.toContain(en.harness.failure.timeout);
+    expect(html).toContain(`>${en.harness.detail.technicalDetails}<`);
+    expect(html).toContain(raw);
+    expect(html).toMatch(/<details(?![^>]*\bopen\b)[^>]*>/);
+  });
+
   it('keeps a canceled Task diagnostic collapsed without calling it a failure', () => {
     const raw = 'Run canceled by user';
     const html = detail(

--- a/ui/src/components/workbench/HarnessPage.test.tsx
+++ b/ui/src/components/workbench/HarnessPage.test.tsx
@@ -926,6 +926,30 @@ describe('WatchDetail runtime', () => {
     }
   });
 
+  it('keeps a healthy retry diagnostic without presenting it as a failure', () => {
+    const raw = 'avibe-watch: still waiting';
+    const html = render(
+      <WatchDetail
+        watch={watch({
+          enabled: true,
+          retry_exit_codes: [75],
+          health: 'healthy',
+          lifecycle_detail: 'error',
+          last_exit_code: 75,
+          last_error: raw,
+        })}
+        onToggleEnabled={() => undefined}
+        pending={false}
+      />,
+    );
+
+    expect(html).not.toContain(en.harness.failure.generic);
+    expect(html).toContain(`<span class="font-mono text-[11px] text-muted">75</span>`);
+    expect(html).toContain(`>${en.harness.detail.technicalDetails}<`);
+    expect(html).toContain(raw);
+    expect(html).toMatch(/<details(?![^>]*\bopen\b)[^>]*>/);
+  });
+
   it('resets technical details when selecting another definition', () => {
     const renderInteractive = (ui: ReactElement) =>
       renderDom(

--- a/ui/src/components/workbench/HarnessPage.test.tsx
+++ b/ui/src/components/workbench/HarnessPage.test.tsx
@@ -817,6 +817,24 @@ describe('TaskDetail command task', () => {
     expect(html).toMatch(/<details(?![^>]*\bopen\b)[^>]*>/);
   });
 
+  it('keeps a canceled Task diagnostic collapsed without calling it a failure', () => {
+    const raw = 'Run canceled by user';
+    const html = detail(
+      task({
+        shell_command: 'make release',
+        health: 'healthy',
+        last_error: raw,
+        metadata: { last_result_status: 'canceled' },
+      }),
+    );
+
+    expect(html).not.toContain(en.harness.failure.generic);
+    expect(html).not.toContain(en.harness.failure.timeout);
+    expect(html).toContain(`>${en.harness.detail.technicalDetails}<`);
+    expect(html).toContain(raw);
+    expect(html).toMatch(/<details(?![^>]*\bopen\b)[^>]*>/);
+  });
+
   it('leaves a message task rendering exactly as it does today', () => {
     const html = detail(task({ name: 'Nightly digest', prompt: 'Summarize #ops', message: 'Summarize #ops' }));
 
@@ -973,6 +991,31 @@ describe('WatchDetail runtime', () => {
     expect(html).toMatch(/<details(?![^>]*\bopen\b)[^>]*>/);
   });
 
+  it('keeps retry history neutral after the user manually pauses a Watch', () => {
+    const raw = 'avibe-watch: still waiting';
+    const html = render(
+      <WatchDetail
+        watch={watch({
+          enabled: false,
+          retry_exit_codes: [75],
+          health: 'failing',
+          lifecycle_state: 'paused',
+          lifecycle_detail: null,
+          retired_at: null,
+          last_exit_code: 75,
+          last_error: raw,
+        })}
+        onToggleEnabled={() => undefined}
+        pending={false}
+      />,
+    );
+
+    expect(html).not.toContain(en.harness.failure.generic);
+    expect(html).toContain('<span class="font-mono text-[11px] text-muted">75</span>');
+    expect(html).toContain(raw);
+    expect(html).toMatch(/<details(?![^>]*\bopen\b)[^>]*>/);
+  });
+
   it('keeps a terminal missing-cwd retry exit as a failure', () => {
     const raw = 'working directory is unavailable';
     const html = render(
@@ -983,6 +1026,7 @@ describe('WatchDetail runtime', () => {
           health: 'failing',
           lifecycle_state: 'finished',
           lifecycle_detail: 'error',
+          retired_at: '2026-08-12T00:00:00Z',
           last_exit_code: 1,
           last_error: raw,
         })}
@@ -1017,7 +1061,7 @@ describe('WatchDetail runtime', () => {
     expect(html).not.toContain(en.harness.failure.timeout);
   });
 
-  it('keeps a circuit-breaker pause explanation technical without a false run failure', () => {
+  it('shows a stable circuit-pause summary and keeps the reason technical', () => {
     const raw = 'Watch paused after rapid event burst';
     const html = render(
       <WatchDetail
@@ -1035,8 +1079,11 @@ describe('WatchDetail runtime', () => {
       />,
     );
 
+    expect(html).toContain(en.harness.failure.circuitPaused);
     expect(html).not.toContain(en.harness.failure.generic);
     expect(html).not.toContain(en.harness.failure.timeout);
+    expect(html).toContain('text-amber');
+    expect(html).toContain(`>${en.harness.detail.technicalDetails}<`);
     expect(html).toContain(raw);
     expect(html).toMatch(/<details(?![^>]*\bopen\b)[^>]*>/);
   });

--- a/ui/src/components/workbench/HarnessPage.test.tsx
+++ b/ui/src/components/workbench/HarnessPage.test.tsx
@@ -1,6 +1,9 @@
+/* @vitest-environment jsdom */
+
 import { createInstance } from 'i18next';
 import type { ReactElement } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
+import { fireEvent, render as renderDom } from '@testing-library/react';
 import { I18nextProvider, initReactI18next } from 'react-i18next';
 import { MemoryRouter } from 'react-router-dom';
 import { describe, expect, it } from 'vitest';
@@ -902,6 +905,59 @@ describe('WatchDetail runtime', () => {
     expect(html).toContain(`>${en.harness.detail.technicalDetails}<`);
     expect(html).toContain(raw);
     expect(html).toMatch(/<details(?![^>]*\bopen\b)[^>]*>/);
+  });
+
+  it('keeps configured retry and no-event exits neutral', () => {
+    for (const last_exit_code of [64, 75]) {
+      const html = render(
+        <WatchDetail
+          watch={watch({
+            enabled: true,
+            retry_exit_codes: [75],
+            health: 'healthy',
+            lifecycle_detail: 'error',
+            last_exit_code,
+          })}
+          onToggleEnabled={() => undefined}
+          pending={false}
+        />,
+      );
+      expect(html).toContain(`<span class="font-mono text-[11px] text-muted">${last_exit_code}</span>`);
+    }
+  });
+
+  it('resets technical details when selecting another definition', () => {
+    const renderInteractive = (ui: ReactElement) =>
+      renderDom(
+        <I18nextProvider i18n={i18n}>
+          <MemoryRouter>{ui}</MemoryRouter>
+        </I18nextProvider>,
+      );
+    const view = renderInteractive(
+      <TaskDetail
+        task={task({ id: 'task-a', shell_command: 'first', last_error: 'first technical error' })}
+        onToggleEnabled={() => undefined}
+        pending={false}
+      />,
+    );
+    const details = view.container.querySelector('details');
+    expect(details?.open).toBe(false);
+    fireEvent.click(details?.querySelector('summary') as HTMLElement);
+    expect(view.container.querySelector('details')?.open).toBe(true);
+
+    view.rerender(
+      <I18nextProvider i18n={i18n}>
+        <MemoryRouter>
+          <TaskDetail
+            task={task({ id: 'task-b', shell_command: 'second', last_error: 'second technical error' })}
+            onToggleEnabled={() => undefined}
+            pending={false}
+          />
+        </MemoryRouter>
+      </I18nextProvider>,
+    );
+    expect(view.container.querySelector('details')?.open).toBe(false);
+    view.unmount();
   });
 });
 

--- a/ui/src/components/workbench/HarnessPage.tsx
+++ b/ui/src/components/workbench/HarnessPage.tsx
@@ -65,7 +65,6 @@ import {
   definitionActiveCount,
   definitionChipLabel,
   definitionExitCodeTone,
-  definitionHasNeutralWatchExit,
   definitionHealth,
   definitionFailureSummaryKey,
   definitionProcessingHealth,
@@ -2163,9 +2162,7 @@ const FailureDetails: React.FC<{
   // The mapper uses structured facts only. A stored error without enough
   // structure still proves an unclassified failure, so keep the default copy
   // generic instead of letting raw stderr choose a category.
-  const summaryKey =
-    definitionFailureSummaryKey(row) ??
-    (row.last_error && !definitionHasNeutralWatchExit(row) ? 'harness.failure.generic' : null);
+  const summaryKey = definitionFailureSummaryKey(row, Boolean(row.last_error));
   const disclosureKey = `${'retry_exit_codes' in row ? 'watch' : 'task'}:${row.id}`;
   if (!summaryKey && !row.last_error) return null;
   return (

--- a/ui/src/components/workbench/HarnessPage.tsx
+++ b/ui/src/components/workbench/HarnessPage.tsx
@@ -4,6 +4,7 @@ import {
   ArrowLeft,
   Activity,
   Calendar,
+  ChevronRight,
   Eye,
   History,
   Plus,
@@ -64,6 +65,7 @@ import {
   definitionActiveCount,
   definitionChipLabel,
   definitionHealth,
+  definitionFailureSummaryKey,
   definitionProcessingHealth,
   definitionRowLine,
   definitionRowTitle,
@@ -1034,6 +1036,7 @@ export const HealthBadge: React.FC<{ row: HarnessTask | HarnessWatch }> = ({ row
   const { t } = useTranslation();
   const health = definitionHealth(row);
   if (health !== 'failing' && health !== 'degraded' && health !== 'unknown') return null;
+  const failureSummaryKey = definitionFailureSummaryKey(row);
   // No count on ``unknown``: both counters come from the same run history this
   // row could not read, so printing one would put a number on nothing.
   const count = health === 'unknown' ? 0 : health === 'failing' ? row.consecutive_failures : row.recent_failures;
@@ -1044,7 +1047,7 @@ export const HealthBadge: React.FC<{ row: HarnessTask | HarnessWatch }> = ({ row
         'shrink-0 font-mono text-[9px] uppercase',
         health === 'failing' ? 'text-pink' : health === 'degraded' ? 'text-amber' : 'text-muted',
       )}
-      title={row.last_error || undefined}
+      title={failureSummaryKey ? t(failureSummaryKey) : undefined}
     >
       {t(`harness.health.${health}`)}
       {count > 1 ? ` ${count}` : ''}
@@ -1454,6 +1457,7 @@ export const TaskDetail: React.FC<TaskDetailProps> = ({ task, agent, onToggleEna
           on the run row: a nightly command task's exit code is the one fact an
           operator wants without paging through the runs tab. Not gated on
           ``last_run_at`` — a stored exit code proves a run happened. */}
+      <FailureDetails row={task} />
       {task.last_exit_code != null && (
         <DetailField label={t('harness.detail.lastExitCode')}>
           <span
@@ -1461,17 +1465,6 @@ export const TaskDetail: React.FC<TaskDetailProps> = ({ task, agent, onToggleEna
           >
             {task.last_exit_code}
           </span>
-        </DetailField>
-      )}
-      {/* Its own field, and no longer nested inside ``last_run_at``: a task can
-          carry a ``last_error`` with no ``last_run_at`` (a fire that failed before
-          it ever ran), and that case rendered nothing at all. ``harness.detail.lastError``
-          already existed and was used only by the watch pane. */}
-      {task.last_error && (
-        <DetailField label={t('harness.detail.lastError')}>
-          <pre className="max-h-32 overflow-auto whitespace-pre-wrap rounded-md border border-destructive/40 bg-destructive/[0.06] p-2 font-mono text-[11px] text-destructive">
-            {task.last_error}
-          </pre>
         </DetailField>
       )}
       {task.resume_blocked?.code === 'task_owner_session_unavailable' && (
@@ -1629,11 +1622,14 @@ export const WatchDetail: React.FC<WatchDetailProps> = ({ watch, agent, onToggle
           )}
         </DetailField>
       )}
-      {watch.last_error && (
-        <DetailField label={t('harness.detail.lastError')}>
-          <div className="rounded-md border border-destructive/40 bg-destructive/[0.06] px-2 py-1 text-[11px] text-destructive">
-            {watch.last_error}
-          </div>
+      <FailureDetails row={watch} />
+      {watch.last_exit_code != null && (
+        <DetailField label={t('harness.detail.lastExitCode')}>
+          <span
+            className={clsx('font-mono text-[11px]', watch.last_exit_code === 0 ? 'text-muted' : 'text-pink')}
+          >
+            {watch.last_exit_code}
+          </span>
         </DetailField>
       )}
       {visibleProcessingHealth(watch) && (
@@ -2151,6 +2147,39 @@ const DetailGroup: React.FC<{ label: string; children: React.ReactNode }> = ({ l
     {children}
   </div>
 );
+
+const FailureDetails: React.FC<{
+  row: HarnessTask | HarnessWatch;
+}> = ({ row }) => {
+  const { t } = useTranslation();
+  const summaryKey = definitionFailureSummaryKey(row);
+  if (!summaryKey && !row.last_error) return null;
+  return (
+    <div className="flex flex-col gap-1.5">
+      {summaryKey && (
+        <>
+          <div className="font-mono text-[10px] font-bold uppercase tracking-[0.12em] text-muted">
+            {t('harness.detail.failureSummary')}
+          </div>
+          <div className="flex min-w-0 flex-wrap items-center gap-2 text-[12px] text-pink">
+            <span>{t(summaryKey)}</span>
+          </div>
+        </>
+      )}
+      {row.last_error && (
+        <details className="group min-w-0 rounded-md border border-border bg-surface-3 px-2 py-1.5">
+          <summary className="flex cursor-pointer list-none items-center gap-1.5 text-[10px] font-medium uppercase tracking-wide text-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-cyan/60">
+            <ChevronRight aria-hidden className="size-3 shrink-0 transition-transform group-open:rotate-90" />
+            {t('harness.detail.technicalDetails')}
+          </summary>
+          <pre className="mt-2 max-h-32 overflow-auto whitespace-pre-wrap break-words border-t border-border pt-2 font-mono text-[11px] text-muted">
+            {row.last_error}
+          </pre>
+        </details>
+      )}
+    </div>
+  );
+};
 
 const EmptyState: React.FC<{ i18nKey: string }> = ({ i18nKey }) => {
   const { t } = useTranslation();

--- a/ui/src/components/workbench/HarnessPage.tsx
+++ b/ui/src/components/workbench/HarnessPage.tsx
@@ -2163,6 +2163,7 @@ const FailureDetails: React.FC<{
   // structure still proves an unclassified failure, so keep the default copy
   // generic instead of letting raw stderr choose a category.
   const summaryKey = definitionFailureSummaryKey(row, Boolean(row.last_error));
+  const circuitPaused = summaryKey === 'harness.failure.circuitPaused';
   const disclosureKey = `${'retry_exit_codes' in row ? 'watch' : 'task'}:${row.id}`;
   if (!summaryKey && !row.last_error) return null;
   return (
@@ -2170,9 +2171,14 @@ const FailureDetails: React.FC<{
       {summaryKey && (
         <>
           <div className="font-mono text-[10px] font-bold uppercase tracking-[0.12em] text-muted">
-            {t('harness.detail.failureSummary')}
+            {t(circuitPaused ? 'harness.detail.pauseReason' : 'harness.detail.failureSummary')}
           </div>
-          <div className="flex min-w-0 flex-wrap items-center gap-2 text-[12px] text-pink">
+          <div
+            className={clsx(
+              'flex min-w-0 flex-wrap items-center gap-2 text-[12px]',
+              circuitPaused ? 'text-amber' : 'text-pink',
+            )}
+          >
             <span>{t(summaryKey)}</span>
           </div>
         </>

--- a/ui/src/components/workbench/HarnessPage.tsx
+++ b/ui/src/components/workbench/HarnessPage.tsx
@@ -2152,7 +2152,10 @@ const FailureDetails: React.FC<{
   row: HarnessTask | HarnessWatch;
 }> = ({ row }) => {
   const { t } = useTranslation();
-  const summaryKey = definitionFailureSummaryKey(row);
+  // The mapper uses structured facts only. A stored error without enough
+  // structure still proves an unclassified failure, so keep the default copy
+  // generic instead of letting raw stderr choose a category.
+  const summaryKey = definitionFailureSummaryKey(row) ?? (row.last_error ? 'harness.failure.generic' : null);
   if (!summaryKey && !row.last_error) return null;
   return (
     <div className="flex flex-col gap-1.5">

--- a/ui/src/components/workbench/HarnessPage.tsx
+++ b/ui/src/components/workbench/HarnessPage.tsx
@@ -65,6 +65,7 @@ import {
   definitionActiveCount,
   definitionChipLabel,
   definitionExitCodeTone,
+  definitionHasNeutralWatchExit,
   definitionHealth,
   definitionFailureSummaryKey,
   definitionProcessingHealth,
@@ -2162,7 +2163,9 @@ const FailureDetails: React.FC<{
   // The mapper uses structured facts only. A stored error without enough
   // structure still proves an unclassified failure, so keep the default copy
   // generic instead of letting raw stderr choose a category.
-  const summaryKey = definitionFailureSummaryKey(row) ?? (row.last_error ? 'harness.failure.generic' : null);
+  const summaryKey =
+    definitionFailureSummaryKey(row) ??
+    (row.last_error && !definitionHasNeutralWatchExit(row) ? 'harness.failure.generic' : null);
   const disclosureKey = `${'retry_exit_codes' in row ? 'watch' : 'task'}:${row.id}`;
   if (!summaryKey && !row.last_error) return null;
   return (

--- a/ui/src/components/workbench/HarnessPage.tsx
+++ b/ui/src/components/workbench/HarnessPage.tsx
@@ -64,6 +64,7 @@ import {
   DEFINITION_STATUS_FILTERS,
   definitionActiveCount,
   definitionChipLabel,
+  definitionExitCodeTone,
   definitionHealth,
   definitionFailureSummaryKey,
   definitionProcessingHealth,
@@ -1461,7 +1462,10 @@ export const TaskDetail: React.FC<TaskDetailProps> = ({ task, agent, onToggleEna
       {task.last_exit_code != null && (
         <DetailField label={t('harness.detail.lastExitCode')}>
           <span
-            className={clsx('font-mono text-[11px]', task.last_exit_code === 0 ? 'text-muted' : 'text-pink')}
+            className={clsx(
+              'font-mono text-[11px]',
+              definitionExitCodeTone(task) === 'failure' ? 'text-pink' : 'text-muted',
+            )}
           >
             {task.last_exit_code}
           </span>
@@ -1626,7 +1630,10 @@ export const WatchDetail: React.FC<WatchDetailProps> = ({ watch, agent, onToggle
       {watch.last_exit_code != null && (
         <DetailField label={t('harness.detail.lastExitCode')}>
           <span
-            className={clsx('font-mono text-[11px]', watch.last_exit_code === 0 ? 'text-muted' : 'text-pink')}
+            className={clsx(
+              'font-mono text-[11px]',
+              definitionExitCodeTone(watch) === 'failure' ? 'text-pink' : 'text-muted',
+            )}
           >
             {watch.last_exit_code}
           </span>
@@ -2156,6 +2163,7 @@ const FailureDetails: React.FC<{
   // structure still proves an unclassified failure, so keep the default copy
   // generic instead of letting raw stderr choose a category.
   const summaryKey = definitionFailureSummaryKey(row) ?? (row.last_error ? 'harness.failure.generic' : null);
+  const disclosureKey = `${'retry_exit_codes' in row ? 'watch' : 'task'}:${row.id}`;
   if (!summaryKey && !row.last_error) return null;
   return (
     <div className="flex flex-col gap-1.5">
@@ -2170,7 +2178,10 @@ const FailureDetails: React.FC<{
         </>
       )}
       {row.last_error && (
-        <details className="group min-w-0 rounded-md border border-border bg-surface-3 px-2 py-1.5">
+        <details
+          key={disclosureKey}
+          className="group min-w-0 rounded-md border border-border bg-surface-3 px-2 py-1.5"
+        >
           <summary className="flex cursor-pointer list-none items-center gap-1.5 text-[10px] font-medium uppercase tracking-wide text-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-cyan/60">
             <ChevronRight aria-hidden className="size-3 shrink-0 transition-transform group-open:rotate-90" />
             {t('harness.detail.technicalDetails')}

--- a/ui/src/components/workbench/harnessLifecycle.test.ts
+++ b/ui/src/components/workbench/harnessLifecycle.test.ts
@@ -131,8 +131,8 @@ describe('definitionFailureSummaryKey', () => {
     ],
     [
       'watch timeout',
-      { lifecycle_detail: 'timeout', last_exit_code: 124, last_error: 'permission denied' },
-      'harness.failure.timeout',
+      { lifecycle_state: 'finished', lifecycle_detail: 'timeout', retry_exit_codes: [], last_exit_code: 124, last_error: 'permission denied' },
+      'harness.failure.generic',
     ],
     [
       'task nonzero exit',
@@ -154,9 +154,13 @@ describe('definitionFailureSummaryKey', () => {
 
   it('does not let stderr wording change the category', () => {
     const facts = { last_exit_code: 9, lifecycle_detail: 'error' };
-    expect(definitionFailureSummaryKey({ ...facts, last_error: 'timed out' })).toBe(
-      definitionFailureSummaryKey({ ...facts, last_error: 'command not found' }),
-    );
+    const classify = (lastError: string) => definitionFailureSummaryKey({ ...facts }, Boolean(lastError));
+    expect(classify('timed out')).toBe(classify('command not found'));
+  });
+
+  it('uses only error presence for an otherwise unknown failure', () => {
+    expect(definitionFailureSummaryKey({ health: 'healthy' }, true)).toBe('harness.failure.generic');
+    expect(definitionFailureSummaryKey({ health: 'healthy' }, false)).toBeNull();
   });
 
   it('does not turn technical text into a failure when structured facts say healthy', () => {
@@ -191,10 +195,12 @@ describe('definitionFailureSummaryKey', () => {
 
 describe('definitionHasNeutralWatchExit', () => {
   it.each([
-    ['no-event completion', { last_exit_code: 64, retry_exit_codes: [] }, true],
-    ['default retry exit', { last_exit_code: 75, retry_exit_codes: [75] }, true],
-    ['custom retry exit', { last_exit_code: 90, retry_exit_codes: [75, 90] }, true],
-    ['unconfigured watch exit', { last_exit_code: 9, retry_exit_codes: [75] }, false],
+    ['no-event completion', { health: 'healthy', lifecycle_state: 'waiting', lifecycle_detail: null, last_exit_code: 64, retry_exit_codes: [] }, true],
+    ['default retry exit', { health: 'healthy', lifecycle_state: 'waiting', lifecycle_detail: null, last_exit_code: 75, retry_exit_codes: [75] }, true],
+    ['custom retry exit', { health: 'healthy', lifecycle_state: 'waiting', lifecycle_detail: null, last_exit_code: 90, retry_exit_codes: [75, 90] }, true],
+    ['terminal retry exit', { health: 'failing', lifecycle_state: 'finished', last_exit_code: 1, retry_exit_codes: [1] }, false],
+    ['unconfigured watch exit', { health: 'healthy', lifecycle_state: 'waiting', lifecycle_detail: null, last_exit_code: 9, retry_exit_codes: [75] }, false],
+    ['finished error with no-event code', { health: 'healthy', lifecycle_state: 'finished', lifecycle_detail: 'error', last_exit_code: 64, retry_exit_codes: [] }, false],
     ['task exit without watch evidence', { last_exit_code: 75 }, false],
   ] as const)('classifies %s from structured fields', (_name, row, expected) => {
     expect(definitionHasNeutralWatchExit(row)).toBe(expected);

--- a/ui/src/components/workbench/harnessLifecycle.test.ts
+++ b/ui/src/components/workbench/harnessLifecycle.test.ts
@@ -13,6 +13,7 @@ import {
   definitionStateSince,
   definitionStatusCount,
   definitionSurvivesToggle,
+  definitionFailureSummaryKey,
   formatWallTime,
   humanizeCron,
   humanizeGap,
@@ -112,6 +113,64 @@ describe('lifecycleLabel', () => {
       'error',
       'unknown',
     ]);
+  });
+});
+
+describe('definitionFailureSummaryKey', () => {
+  // SCT-061 final UI contract:
+  // timeout -> translated timeout summary + optional exit code;
+  // nonzero exit -> translated generic failure summary + exit code;
+  // unknown -> translated generic failure summary;
+  // raw technical details -> present but collapsed by default.
+  const cases = [
+    [
+      'task timeout',
+      { metadata: { last_command_timed_out: true }, last_exit_code: 124, last_error: 'permission denied' },
+      'harness.failure.timeout',
+    ],
+    [
+      'watch timeout',
+      { lifecycle_detail: 'timeout', last_exit_code: 124, last_error: 'permission denied' },
+      'harness.failure.timeout',
+    ],
+    [
+      'task nonzero exit',
+      { last_exit_code: 7, last_error: 'timed out while opening stderr' },
+      'harness.failure.generic',
+    ],
+    [
+      'watch nonzero exit',
+      { last_exit_code: 2, last_error: 'timed out while opening stderr' },
+      'harness.failure.generic',
+    ],
+    ['task unknown failure', { lifecycle_detail: 'error', last_error: null }, 'harness.failure.generic'],
+    ['watch unknown failure', { health: 'failing', last_error: null }, 'harness.failure.generic'],
+  ] as const;
+
+  it.each(cases)('maps %s without classifying stderr prose', (_name, row, expected) => {
+    expect(definitionFailureSummaryKey(row)).toBe(expected);
+  });
+
+  it('does not let stderr wording change the category', () => {
+    const facts = { last_exit_code: 9, lifecycle_detail: 'error' };
+    expect(definitionFailureSummaryKey({ ...facts, last_error: 'timed out' })).toBe(
+      definitionFailureSummaryKey({ ...facts, last_error: 'command not found' }),
+    );
+  });
+
+  it('does not turn technical text into a failure when structured facts say healthy', () => {
+    expect(definitionFailureSummaryKey({ health: 'healthy', last_exit_code: null })).toBeNull();
+  });
+
+  it('keeps the summary key set translated and in parity', () => {
+    expect(Object.keys(en.harness.failure).sort()).toEqual(['generic', 'timeout']);
+    expect(Object.keys(zh.harness.failure).sort()).toEqual(Object.keys(en.harness.failure).sort());
+    for (const detailKey of ['failureSummary', 'technicalDetails', 'lastExitCode'] as const) {
+      expect(typeof en.harness.detail[detailKey]).toBe('string');
+      expect(typeof zh.harness.detail[detailKey]).toBe('string');
+    }
+    expect(zh.harness.failure.timeout).toBe('最近一次运行已超时。');
+    expect(zh.harness.failure.generic).toBe('最近一次运行失败。');
   });
 });
 

--- a/ui/src/components/workbench/harnessLifecycle.test.ts
+++ b/ui/src/components/workbench/harnessLifecycle.test.ts
@@ -130,6 +130,11 @@ describe('definitionFailureSummaryKey', () => {
       'harness.failure.timeout',
     ],
     [
+      'legacy task timeout detail without explicit fact',
+      { lifecycle_detail: 'timeout', last_exit_code: 124, last_error: 'command returned status 124' },
+      'harness.failure.generic',
+    ],
+    [
       'watch timeout',
       { lifecycle_state: 'finished', lifecycle_detail: 'timeout', retry_exit_codes: [], last_exit_code: 124, last_error: 'permission denied' },
       'harness.failure.generic',

--- a/ui/src/components/workbench/harnessLifecycle.test.ts
+++ b/ui/src/components/workbench/harnessLifecycle.test.ts
@@ -162,6 +162,20 @@ describe('definitionFailureSummaryKey', () => {
     expect(definitionFailureSummaryKey({ health: 'healthy', last_exit_code: null })).toBeNull();
   });
 
+  it('keeps structured last-run failure visible after health history ages out', () => {
+    expect(
+      definitionFailureSummaryKey({ health: 'healthy', lifecycle_detail: 'error', last_exit_code: 7 }),
+    ).toBe('harness.failure.generic');
+    expect(
+      definitionFailureSummaryKey({
+        health: 'healthy',
+        lifecycle_detail: 'timeout',
+        metadata: { last_command_timed_out: true },
+        last_exit_code: 124,
+      }),
+    ).toBe('harness.failure.timeout');
+  });
+
   it('keeps the summary key set translated and in parity', () => {
     expect(Object.keys(en.harness.failure).sort()).toEqual(['generic', 'timeout']);
     expect(Object.keys(zh.harness.failure).sort()).toEqual(Object.keys(en.harness.failure).sort());

--- a/ui/src/components/workbench/harnessLifecycle.test.ts
+++ b/ui/src/components/workbench/harnessLifecycle.test.ts
@@ -14,6 +14,7 @@ import {
   definitionStatusCount,
   definitionSurvivesToggle,
   definitionFailureSummaryKey,
+  definitionHasNeutralWatchExit,
   formatWallTime,
   humanizeCron,
   humanizeGap,
@@ -185,6 +186,18 @@ describe('definitionFailureSummaryKey', () => {
     }
     expect(zh.harness.failure.timeout).toBe('最近一次运行已超时。');
     expect(zh.harness.failure.generic).toBe('最近一次运行失败。');
+  });
+});
+
+describe('definitionHasNeutralWatchExit', () => {
+  it.each([
+    ['no-event completion', { last_exit_code: 64, retry_exit_codes: [] }, true],
+    ['default retry exit', { last_exit_code: 75, retry_exit_codes: [75] }, true],
+    ['custom retry exit', { last_exit_code: 90, retry_exit_codes: [75, 90] }, true],
+    ['unconfigured watch exit', { last_exit_code: 9, retry_exit_codes: [75] }, false],
+    ['task exit without watch evidence', { last_exit_code: 75 }, false],
+  ] as const)('classifies %s from structured fields', (_name, row, expected) => {
+    expect(definitionHasNeutralWatchExit(row)).toBe(expected);
   });
 });
 

--- a/ui/src/components/workbench/harnessLifecycle.test.ts
+++ b/ui/src/components/workbench/harnessLifecycle.test.ts
@@ -182,7 +182,7 @@ describe('definitionFailureSummaryKey', () => {
   });
 
   it('keeps the summary key set translated and in parity', () => {
-    expect(Object.keys(en.harness.failure).sort()).toEqual(['generic', 'timeout']);
+    expect(Object.keys(en.harness.failure).sort()).toEqual(['circuitPaused', 'generic', 'timeout']);
     expect(Object.keys(zh.harness.failure).sort()).toEqual(Object.keys(en.harness.failure).sort());
     for (const detailKey of ['failureSummary', 'technicalDetails', 'lastExitCode'] as const) {
       expect(typeof en.harness.detail[detailKey]).toBe('string');
@@ -190,6 +190,26 @@ describe('definitionFailureSummaryKey', () => {
     }
     expect(zh.harness.failure.timeout).toBe('最近一次运行已超时。');
     expect(zh.harness.failure.generic).toBe('最近一次运行失败。');
+    expect(zh.harness.failure.circuitPaused).toBe('此 Watch 因短时间内重复事件而暂停。');
+  });
+
+  it('uses structured pause and cancellation facts without parsing diagnostics', () => {
+    expect(
+      definitionFailureSummaryKey(
+        {
+          lifecycle_state: 'paused',
+          retry_exit_codes: [75],
+          metadata: { watch_circuit_breaker: { status: 'tripped' } },
+        },
+        true,
+      ),
+    ).toBe('harness.failure.circuitPaused');
+    expect(
+      definitionFailureSummaryKey({ metadata: { last_result_status: 'canceled' } }, true),
+    ).toBeNull();
+    expect(
+      definitionFailureSummaryKey({ metadata: { last_result_status: 'failed' } }, true),
+    ).toBe('harness.failure.generic');
   });
 });
 
@@ -198,7 +218,9 @@ describe('definitionHasNeutralWatchExit', () => {
     ['no-event completion', { health: 'healthy', lifecycle_state: 'waiting', lifecycle_detail: null, last_exit_code: 64, retry_exit_codes: [] }, true],
     ['default retry exit', { health: 'healthy', lifecycle_state: 'waiting', lifecycle_detail: null, last_exit_code: 75, retry_exit_codes: [75] }, true],
     ['custom retry exit', { health: 'healthy', lifecycle_state: 'waiting', lifecycle_detail: null, last_exit_code: 90, retry_exit_codes: [75, 90] }, true],
-    ['terminal retry exit', { health: 'failing', lifecycle_state: 'finished', last_exit_code: 1, retry_exit_codes: [1] }, false],
+    ['manual pause preserves retry history', { health: 'failing', lifecycle_state: 'paused', lifecycle_detail: null, retired_at: null, last_exit_code: 75, retry_exit_codes: [75] }, true],
+    ['legacy pause without retirement evidence', { health: 'failing', lifecycle_state: 'paused', lifecycle_detail: null, last_exit_code: 75, retry_exit_codes: [75] }, false],
+    ['terminal retry exit', { health: 'failing', lifecycle_state: 'finished', retired_at: '2026-08-12T00:00:00Z', last_exit_code: 1, retry_exit_codes: [1] }, false],
     ['unconfigured watch exit', { health: 'healthy', lifecycle_state: 'waiting', lifecycle_detail: null, last_exit_code: 9, retry_exit_codes: [75] }, false],
     ['finished error with no-event code', { health: 'healthy', lifecycle_state: 'finished', lifecycle_detail: 'error', last_exit_code: 64, retry_exit_codes: [] }, false],
     ['task exit without watch evidence', { last_exit_code: 75 }, false],

--- a/ui/src/components/workbench/harnessLifecycle.ts
+++ b/ui/src/components/workbench/harnessLifecycle.ts
@@ -355,7 +355,7 @@ export type HarnessFailureSummaryKey = 'harness.failure.timeout' | 'harness.fail
 // failure facts collapse to one generic category; last_error is deliberately
 // absent from this mapper and remains technical disclosure content only.
 export function definitionFailureSummaryKey(
-  row: Pick<HarnessDefinitionFacts, 'health' | 'lifecycle_detail' | 'last_error' | 'last_exit_code' | 'metadata'>,
+  row: Pick<HarnessDefinitionFacts, 'health' | 'lifecycle_detail' | 'last_exit_code' | 'metadata'>,
 ): HarnessFailureSummaryKey | null {
   if (row.health === 'healthy') return null;
   const timedOut = row.metadata?.last_command_timed_out === true || row.lifecycle_detail === 'timeout';

--- a/ui/src/components/workbench/harnessLifecycle.ts
+++ b/ui/src/components/workbench/harnessLifecycle.ts
@@ -348,6 +348,26 @@ export type HarnessDefinitionFacts = {
   metadata?: Record<string, unknown> | null;
 };
 
+export type HarnessFailureSummaryKey = 'harness.failure.timeout' | 'harness.failure.generic';
+
+// The UI can only name a timeout when the scheduler's structured fact or the
+// already-projected lifecycle detail proves it. The remaining structured
+// failure facts collapse to one generic category; last_error is deliberately
+// absent from this mapper and remains technical disclosure content only.
+export function definitionFailureSummaryKey(
+  row: Pick<HarnessDefinitionFacts, 'health' | 'lifecycle_detail' | 'last_error' | 'last_exit_code' | 'metadata'>,
+): HarnessFailureSummaryKey | null {
+  if (row.health === 'healthy') return null;
+  const timedOut = row.metadata?.last_command_timed_out === true || row.lifecycle_detail === 'timeout';
+  const failed =
+    timedOut ||
+    row.health === 'failing' ||
+    (row.lifecycle_detail != null && row.lifecycle_detail !== 'normal') ||
+    (typeof row.last_exit_code === 'number' && row.last_exit_code !== 0);
+  if (!failed) return null;
+  return timedOut ? 'harness.failure.timeout' : 'harness.failure.generic';
+}
+
 // ``failing`` = the newest verdict failed; ``degraded`` = the newest succeeded but
 // a failure is still in the window; ``unknown`` = health could not be computed,
 // which is deliberately not the same as ``healthy``.

--- a/ui/src/components/workbench/harnessLifecycle.ts
+++ b/ui/src/components/workbench/harnessLifecycle.ts
@@ -322,6 +322,7 @@ export type HarnessDefinitionFacts = {
   last_run_at?: string | null;
   last_started_at?: string | null;
   last_finished_at?: string | null;
+  retired_at?: string | null;
   last_error?: string | null;
   updated_at?: string | null;
   // Derived server-side from the definition's own run history, because
@@ -349,17 +350,25 @@ export type HarnessDefinitionFacts = {
   retry_exit_codes?: number[] | null;
 };
 
-export type HarnessFailureSummaryKey = 'harness.failure.timeout' | 'harness.failure.generic';
+export type HarnessFailureSummaryKey =
+  | 'harness.failure.timeout'
+  | 'harness.failure.generic'
+  | 'harness.failure.circuitPaused';
 
 export function definitionHasNeutralWatchExit(
-  row: Pick<HarnessDefinitionFacts, 'health' | 'lifecycle_detail' | 'last_exit_code' | 'retry_exit_codes'>,
+  row: Pick<
+    HarnessDefinitionFacts,
+    'health' | 'lifecycle_detail' | 'lifecycle_state' | 'last_exit_code' | 'retired_at' | 'retry_exit_codes'
+  >,
 ): boolean {
   if (!Array.isArray(row.retry_exit_codes)) return false;
   // A terminal pre-cycle failure (for example a missing cwd) can reuse the
-  // configured code, but its projected health must remain visible. A healthy
-  // once-watch may be finished after a successful no-event cycle, so lifecycle
-  // state is intentionally not required here.
-  if (row.health !== 'healthy') return false;
+  // configured code, but its projected health must remain visible. A manually
+  // paused Watch preserves its most recent healthy cycle even though disabled
+  // rows project failing health; paused + explicitly unretired is the durable
+  // evidence that separates that history from supervisor retirement.
+  const preservedManualPause = row.lifecycle_state === 'paused' && row.retired_at === null;
+  if (row.health !== 'healthy' && !preservedManualPause) return false;
   if (row.lifecycle_detail != null && row.lifecycle_detail !== 'normal') return false;
   const exitCode = row.last_exit_code;
   return exitCode === 64 || (typeof exitCode === 'number' && row.retry_exit_codes.includes(exitCode));
@@ -376,6 +385,12 @@ function definitionIsCircuitPaused(
   );
 }
 
+function definitionLastResultWasCanceled(
+  row: Pick<HarnessDefinitionFacts, 'metadata' | 'retry_exit_codes'>,
+): boolean {
+  return !Array.isArray(row.retry_exit_codes) && row.metadata?.last_result_status === 'canceled';
+}
+
 // The UI can only name a timeout when the scheduler's structured fact or the
 // already-projected lifecycle detail proves it. The remaining structured
 // failure facts collapse to one generic category; last_error is deliberately
@@ -383,11 +398,18 @@ function definitionIsCircuitPaused(
 export function definitionFailureSummaryKey(
   row: Pick<
     HarnessDefinitionFacts,
-    'health' | 'lifecycle_detail' | 'lifecycle_state' | 'last_exit_code' | 'metadata' | 'retry_exit_codes'
+    | 'health'
+    | 'lifecycle_detail'
+    | 'lifecycle_state'
+    | 'last_exit_code'
+    | 'metadata'
+    | 'retired_at'
+    | 'retry_exit_codes'
   >,
   technicalErrorPresent = false,
 ): HarnessFailureSummaryKey | null {
-  if (definitionIsCircuitPaused(row)) return null;
+  if (definitionIsCircuitPaused(row)) return 'harness.failure.circuitPaused';
+  if (definitionLastResultWasCanceled(row)) return null;
   const isWatch = Array.isArray(row.retry_exit_codes);
   // A Watch lifecycle timeout can be its overall lifetime expiring before a
   // cycle starts. Only the scheduler's explicit command fact proves a run timed
@@ -410,7 +432,13 @@ export function definitionFailureSummaryKey(
 export function definitionExitCodeTone(
   row: Pick<
     HarnessDefinitionFacts,
-    'health' | 'lifecycle_detail' | 'lifecycle_state' | 'last_exit_code' | 'metadata' | 'retry_exit_codes'
+    | 'health'
+    | 'lifecycle_detail'
+    | 'lifecycle_state'
+    | 'last_exit_code'
+    | 'metadata'
+    | 'retired_at'
+    | 'retry_exit_codes'
   >,
 ): 'neutral' | 'failure' {
   if (definitionHasNeutralWatchExit(row)) return 'neutral';

--- a/ui/src/components/workbench/harnessLifecycle.ts
+++ b/ui/src/components/workbench/harnessLifecycle.ts
@@ -352,11 +352,28 @@ export type HarnessDefinitionFacts = {
 export type HarnessFailureSummaryKey = 'harness.failure.timeout' | 'harness.failure.generic';
 
 export function definitionHasNeutralWatchExit(
-  row: Pick<HarnessDefinitionFacts, 'last_exit_code' | 'retry_exit_codes'>,
+  row: Pick<HarnessDefinitionFacts, 'health' | 'lifecycle_detail' | 'last_exit_code' | 'retry_exit_codes'>,
 ): boolean {
   if (!Array.isArray(row.retry_exit_codes)) return false;
+  // A terminal pre-cycle failure (for example a missing cwd) can reuse the
+  // configured code, but its projected health must remain visible. A healthy
+  // once-watch may be finished after a successful no-event cycle, so lifecycle
+  // state is intentionally not required here.
+  if (row.health !== 'healthy') return false;
+  if (row.lifecycle_detail != null && row.lifecycle_detail !== 'normal') return false;
   const exitCode = row.last_exit_code;
   return exitCode === 64 || (typeof exitCode === 'number' && row.retry_exit_codes.includes(exitCode));
+}
+
+function definitionIsCircuitPaused(
+  row: Pick<HarnessDefinitionFacts, 'lifecycle_state' | 'metadata'>,
+): boolean {
+  return (
+    row.lifecycle_state === 'paused' &&
+    row.metadata?.watch_circuit_breaker != null &&
+    typeof row.metadata.watch_circuit_breaker === 'object' &&
+    (row.metadata.watch_circuit_breaker as { status?: unknown }).status === 'tripped'
+  );
 }
 
 // The UI can only name a timeout when the scheduler's structured fact or the
@@ -366,10 +383,16 @@ export function definitionHasNeutralWatchExit(
 export function definitionFailureSummaryKey(
   row: Pick<
     HarnessDefinitionFacts,
-    'health' | 'lifecycle_detail' | 'last_exit_code' | 'metadata' | 'retry_exit_codes'
+    'health' | 'lifecycle_detail' | 'lifecycle_state' | 'last_exit_code' | 'metadata' | 'retry_exit_codes'
   >,
+  technicalErrorPresent = false,
 ): HarnessFailureSummaryKey | null {
-  const timedOut = row.metadata?.last_command_timed_out === true || row.lifecycle_detail === 'timeout';
+  if (definitionIsCircuitPaused(row)) return null;
+  const isWatch = Array.isArray(row.retry_exit_codes);
+  // A Watch lifecycle timeout can be its overall lifetime expiring before a
+  // cycle starts. Only the scheduler's explicit command fact proves a run timed
+  // out; insufficiently evidenced Watch endings stay in the generic category.
+  const timedOut = row.metadata?.last_command_timed_out === true || (!isWatch && row.lifecycle_detail === 'timeout');
   const exitCode = row.last_exit_code;
   const successfulWatchExit = definitionHasNeutralWatchExit(row);
   const lifecycleFailure =
@@ -379,6 +402,7 @@ export function definitionFailureSummaryKey(
     (row.health === 'failing' && !successfulWatchExit) ||
     lifecycleFailure ||
     (typeof exitCode === 'number' && exitCode !== 0 && !successfulWatchExit);
+  if (!failed && technicalErrorPresent && !successfulWatchExit) return 'harness.failure.generic';
   if (!failed) return null;
   return timedOut ? 'harness.failure.timeout' : 'harness.failure.generic';
 }
@@ -386,7 +410,7 @@ export function definitionFailureSummaryKey(
 export function definitionExitCodeTone(
   row: Pick<
     HarnessDefinitionFacts,
-    'health' | 'lifecycle_detail' | 'last_exit_code' | 'metadata' | 'retry_exit_codes'
+    'health' | 'lifecycle_detail' | 'lifecycle_state' | 'last_exit_code' | 'metadata' | 'retry_exit_codes'
   >,
 ): 'neutral' | 'failure' {
   if (definitionHasNeutralWatchExit(row)) return 'neutral';

--- a/ui/src/components/workbench/harnessLifecycle.ts
+++ b/ui/src/components/workbench/harnessLifecycle.ts
@@ -370,7 +370,7 @@ export function definitionFailureSummaryKey(
     row.lifecycle_detail != null && row.lifecycle_detail !== 'normal' && !successfulWatchExit;
   const failed =
     timedOut ||
-    row.health === 'failing' ||
+    (row.health === 'failing' && !successfulWatchExit) ||
     lifecycleFailure ||
     (typeof exitCode === 'number' && exitCode !== 0 && !successfulWatchExit);
   if (!failed) return null;

--- a/ui/src/components/workbench/harnessLifecycle.ts
+++ b/ui/src/components/workbench/harnessLifecycle.ts
@@ -346,6 +346,7 @@ export type HarnessDefinitionFacts = {
   // Decoded server-side (key is ``metadata``, not ``metadata_json``). Holds the
   // command-task-only ``on_failure`` policy; see ``taskOnFailure``.
   metadata?: Record<string, unknown> | null;
+  retry_exit_codes?: number[] | null;
 };
 
 export type HarnessFailureSummaryKey = 'harness.failure.timeout' | 'harness.failure.generic';
@@ -355,17 +356,36 @@ export type HarnessFailureSummaryKey = 'harness.failure.timeout' | 'harness.fail
 // failure facts collapse to one generic category; last_error is deliberately
 // absent from this mapper and remains technical disclosure content only.
 export function definitionFailureSummaryKey(
-  row: Pick<HarnessDefinitionFacts, 'health' | 'lifecycle_detail' | 'last_exit_code' | 'metadata'>,
+  row: Pick<
+    HarnessDefinitionFacts,
+    'health' | 'lifecycle_detail' | 'last_exit_code' | 'metadata' | 'retry_exit_codes'
+  >,
 ): HarnessFailureSummaryKey | null {
-  if (row.health === 'healthy') return null;
   const timedOut = row.metadata?.last_command_timed_out === true || row.lifecycle_detail === 'timeout';
+  const exitCode = row.last_exit_code;
+  const successfulWatchExit =
+    Array.isArray(row.retry_exit_codes) &&
+    (exitCode === 64 || row.retry_exit_codes.includes(exitCode ?? Number.NaN));
+  const lifecycleFailure =
+    row.lifecycle_detail != null && row.lifecycle_detail !== 'normal' && !successfulWatchExit;
   const failed =
     timedOut ||
     row.health === 'failing' ||
-    (row.lifecycle_detail != null && row.lifecycle_detail !== 'normal') ||
-    (typeof row.last_exit_code === 'number' && row.last_exit_code !== 0);
+    lifecycleFailure ||
+    (typeof exitCode === 'number' && exitCode !== 0 && !successfulWatchExit);
   if (!failed) return null;
   return timedOut ? 'harness.failure.timeout' : 'harness.failure.generic';
+}
+
+export function definitionExitCodeTone(
+  row: Pick<
+    HarnessDefinitionFacts,
+    'health' | 'lifecycle_detail' | 'last_exit_code' | 'metadata' | 'retry_exit_codes'
+  >,
+): 'neutral' | 'failure' {
+  return row.last_exit_code != null && row.last_exit_code !== 0 && definitionFailureSummaryKey(row)
+    ? 'failure'
+    : 'neutral';
 }
 
 // ``failing`` = the newest verdict failed; ``degraded`` = the newest succeeded but

--- a/ui/src/components/workbench/harnessLifecycle.ts
+++ b/ui/src/components/workbench/harnessLifecycle.ts
@@ -351,6 +351,14 @@ export type HarnessDefinitionFacts = {
 
 export type HarnessFailureSummaryKey = 'harness.failure.timeout' | 'harness.failure.generic';
 
+export function definitionHasNeutralWatchExit(
+  row: Pick<HarnessDefinitionFacts, 'last_exit_code' | 'retry_exit_codes'>,
+): boolean {
+  if (!Array.isArray(row.retry_exit_codes)) return false;
+  const exitCode = row.last_exit_code;
+  return exitCode === 64 || (typeof exitCode === 'number' && row.retry_exit_codes.includes(exitCode));
+}
+
 // The UI can only name a timeout when the scheduler's structured fact or the
 // already-projected lifecycle detail proves it. The remaining structured
 // failure facts collapse to one generic category; last_error is deliberately
@@ -363,9 +371,7 @@ export function definitionFailureSummaryKey(
 ): HarnessFailureSummaryKey | null {
   const timedOut = row.metadata?.last_command_timed_out === true || row.lifecycle_detail === 'timeout';
   const exitCode = row.last_exit_code;
-  const successfulWatchExit =
-    Array.isArray(row.retry_exit_codes) &&
-    (exitCode === 64 || row.retry_exit_codes.includes(exitCode ?? Number.NaN));
+  const successfulWatchExit = definitionHasNeutralWatchExit(row);
   const lifecycleFailure =
     row.lifecycle_detail != null && row.lifecycle_detail !== 'normal' && !successfulWatchExit;
   const failed =
@@ -383,9 +389,8 @@ export function definitionExitCodeTone(
     'health' | 'lifecycle_detail' | 'last_exit_code' | 'metadata' | 'retry_exit_codes'
   >,
 ): 'neutral' | 'failure' {
-  return row.last_exit_code != null && row.last_exit_code !== 0 && definitionFailureSummaryKey(row)
-    ? 'failure'
-    : 'neutral';
+  if (definitionHasNeutralWatchExit(row)) return 'neutral';
+  return row.last_exit_code != null && row.last_exit_code !== 0 ? 'failure' : 'neutral';
 }
 
 // ``failing`` = the newest verdict failed; ``degraded`` = the newest succeeded but

--- a/ui/src/components/workbench/harnessLifecycle.ts
+++ b/ui/src/components/workbench/harnessLifecycle.ts
@@ -410,11 +410,10 @@ export function definitionFailureSummaryKey(
 ): HarnessFailureSummaryKey | null {
   if (definitionIsCircuitPaused(row)) return 'harness.failure.circuitPaused';
   if (definitionLastResultWasCanceled(row)) return null;
-  const isWatch = Array.isArray(row.retry_exit_codes);
-  // A Watch lifecycle timeout can be its overall lifetime expiring before a
-  // cycle starts. Only the scheduler's explicit command fact proves a run timed
-  // out; insufficiently evidenced Watch endings stay in the generic category.
-  const timedOut = row.metadata?.last_command_timed_out === true || (!isWatch && row.lifecycle_detail === 'timeout');
+  // A lifecycle timeout is insufficient for a Task because legacy rows can carry
+  // exit code 124 from the command itself. Only the scheduler's explicit fact
+  // proves a run timed out; Watch lifetime expiry also remains generic.
+  const timedOut = row.metadata?.last_command_timed_out === true;
   const exitCode = row.last_exit_code;
   const successfulWatchExit = definitionHasNeutralWatchExit(row);
   const lifecycleFailure =

--- a/ui/src/context/ApiContext.tsx
+++ b/ui/src/context/ApiContext.tsx
@@ -1459,6 +1459,10 @@ export type HarnessWatch = HarnessSessionSummary & HarnessDefinitionState & {
   last_event_at: string | null;
   last_error: string | null;
   last_exit_code: number | null;
+  // Decoded server-side metadata includes durable Watch admission facts such as
+  // the circuit-breaker incident; it is troubleshooting evidence, not a new UI
+  // lifecycle state.
+  metadata: Record<string, unknown> | null;
   runtime: HarnessWatchRuntime;
   // Whether the waiter process is alive. ``null`` means we have never seen a
   // heartbeat for it, which is not the same as having seen it exit — the row

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -3228,6 +3228,8 @@
       "timeoutNone": "No timeout",
       "timeoutDefault": "{{duration}} (default)",
       "lastExitCode": "Last exit code",
+      "failureSummary": "Failure",
+      "technicalDetails": "Technical details",
       "escalation": "On failure → escalation",
       "triagePrompt": "Triage prompt",
       "cwdFromSession": "Bound session, else runtime default or Avibe state dir",
@@ -3307,6 +3309,10 @@
       "timeout": "Timed out",
       "error": "Failed",
       "unknown": "Unknown"
+    },
+    "failure": {
+      "timeout": "The last run timed out.",
+      "generic": "The last run failed."
     },
     "kind": {
       "task": "Scheduled task",

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -3312,7 +3312,8 @@
     },
     "failure": {
       "timeout": "The last run timed out.",
-      "generic": "The last run failed."
+      "generic": "The last run failed.",
+      "circuitPaused": "This Watch was paused after repeated events."
     },
     "kind": {
       "task": "Scheduled task",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -3312,7 +3312,8 @@
     },
     "failure": {
       "timeout": "最近一次运行已超时。",
-      "generic": "最近一次运行失败。"
+      "generic": "最近一次运行失败。",
+      "circuitPaused": "此 Watch 因短时间内重复事件而暂停。"
     },
     "kind": {
       "task": "定时任务",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -3228,6 +3228,8 @@
       "timeoutNone": "不限时",
       "timeoutDefault": "{{duration}}（默认）",
       "lastExitCode": "最近退出码",
+      "failureSummary": "失败摘要",
+      "technicalDetails": "技术详情",
       "escalation": "失败后 → 交给 Agent",
       "triagePrompt": "排查提示词",
       "cwdFromSession": "跟随绑定会话，否则运行时默认目录或 Avibe 状态目录",
@@ -3307,6 +3309,10 @@
       "timeout": "已超时",
       "error": "出错结束",
       "unknown": "未知"
+    },
+    "failure": {
+      "timeout": "最近一次运行已超时。",
+      "generic": "最近一次运行失败。"
     },
     "kind": {
       "task": "定时任务",


### PR DESCRIPTION
## Capability

Closes the narrow user-facing Harness failure presentation slice from #1037. Watch and scheduled Task detail panels now lead with a translated summary derived only from structured timeout/lifecycle/exit-code facts, keep a useful exit code diagnostic, and place the existing raw `last_error`/stderr-derived text in an accessible technical-details disclosure collapsed by default.

## Final UI examples

- Timeout: `The last run timed out.` / `最近一次运行已超时。`, with the existing exit code shown when present.
- Nonzero exit: `The last run failed.` / `最近一次运行失败。`, with the existing exit code shown.
- Unknown or insufficient evidence: the same generic translated failure summary, never a guessed subprocess category.
- Technical details: raw `last_error` remains rendered inside a native `<details>` disclosure and is closed by default on desktop and mobile.

The mapper does not accept `last_error` as a classification input, so stderr saying `timed out` or `command not found` cannot change the summary. The boundary is deliberate: command-not-found versus generic nonzero exit is not proven by the current structured API without parsing arbitrary text, so this PR stays generic.

## Scope and non-goals

This PR changes only the UI presentation contract. Subprocess execution, retries and allowed exits, scheduler/watch persistence, lifecycle transitions, hook bodies, and `last_error` writes are unchanged. No backend error taxonomy or second lifecycle state machine is introduced.

## Evidence

- Scenario: `SCT-061` in `tests/scenarios/harness_command_task/catalog.yaml`.
- Unit: deterministic helper tests cover timeout, nonzero, unknown, stderr independence, healthy rows, and English/Chinese copy resolution; component tests cover both Task and Watch and prove technical details are collapsed by default while still rendered.
- Contract: both locale bundles carry the same `harness.failure` and detail keys; the shared API fields are consumed without changing the API shape.
- Scenario layer: existing execution scenarios were not weakened or rewritten; the new UI scenario is isolated to presentation.
- Residual manual: verify the expanded disclosure with a real failed Task and Watch in the local Incus regression Harness page at desktop and mobile widths.

Requires no other PR to merge first.
