### PR TITLE
fix(reply): parse angle-wrapped file links

### DIFF
--- a/core/reply_enhancer.py
+++ b/core/reply_enhancer.py
@@ -478,6 +478,151 @@ def _normalize_file_destination(value: str) -> str:
     return unescapeAll(_protect_file_uri_delimiters(value))
 
 
+def _mask_legacy_bare_file_link_spaces(source: str) -> str:
+    """Make only legacy bare ``file://`` path spaces parseable by CommonMark.
+
+    The returned source is the same length as the input. MarkdownIt still owns
+    link/image syntax and nesting; replacing the spaces only lets it evaluate
+    the one historical extension that CommonMark rejects lexically.
+    """
+    marker = "](file://"
+    if marker not in source or " " not in source:
+        return source
+
+    masked: List[str] | None = None
+    search_start = 0
+    while True:
+        marker_start = source.find(marker, search_start)
+        if marker_start < 0:
+            break
+        destination_start = marker_start + 2
+        cursor = destination_start + len("file://")
+        depth = 0
+        slash_count = 0
+        space_offsets: List[int] = []
+        destination_end = -1
+        while cursor < len(source):
+            char = source[cursor]
+            if char in "\t\r\n":
+                break
+            if char == "\\":
+                slash_count += 1
+                cursor += 1
+                continue
+
+            escaped = slash_count % 2 == 1
+            slash_count = 0
+            if char == " " and depth >= 0:
+                space_offsets.append(cursor)
+            elif char == "(" and not escaped:
+                depth += 1
+            elif char == ")" and not escaped:
+                if depth == 0:
+                    destination_end = cursor
+                    break
+                depth -= 1
+            cursor += 1
+
+        if destination_end >= 0 and space_offsets:
+            title_separator = _legacy_bare_title_separator(
+                source,
+                destination_start,
+                destination_end,
+            )
+            if title_separator is not None:
+                space_offsets = [
+                    offset for offset in space_offsets if offset < title_separator
+                ]
+            if not space_offsets:
+                search_start = destination_end + 1
+                continue
+            if masked is None:
+                masked = list(source)
+            for offset in space_offsets:
+                masked[offset] = "_"
+            search_start = destination_end + 1
+        elif cursor >= len(source):
+            break
+        else:
+            search_start = cursor + 1
+
+    return "".join(masked) if masked is not None else source
+
+
+def _legacy_bare_title_separator(
+    source: str,
+    destination_start: int,
+    destination_end: int,
+) -> int | None:
+    """Return the ASCII-space separator before a standard trailing title."""
+    if destination_end <= destination_start + 2:
+        return None
+    closer = source[destination_end - 1]
+    opener = "(" if closer == ")" else closer
+    if opener not in "\"'(":
+        return None
+
+    cursor = destination_end - 2
+    title_start = -1
+    while cursor >= destination_start:
+        if source[cursor] != opener:
+            cursor -= 1
+            continue
+        slash_start = cursor
+        while slash_start > destination_start and source[slash_start - 1] == "\\":
+            slash_start -= 1
+        if (cursor - slash_start) % 2 == 0:
+            title_start = cursor
+            break
+        cursor = slash_start - 1
+    if title_start <= destination_start or source[title_start - 1] != " ":
+        return None
+
+    title = _FILE_LINK_MARKDOWN.helpers.parseLinkTitle(
+        source,
+        title_start,
+        destination_end,
+    )
+    if not title.ok or title.pos != destination_end:
+        return None
+    separator = title_start - 1
+    while separator > destination_start and source[separator - 1] == " ":
+        separator -= 1
+    return separator
+
+
+def _inline_file_link_captures(
+    content: str,
+) -> list[tuple[int, int, bool, int, int, int, int]]:
+    """Capture CommonMark links plus the bounded legacy bare-space extension."""
+    env: dict = {_FILE_LINK_CAPTURES_KEY: []}
+    _FILE_LINK_MARKDOWN.inline.parse(content, _FILE_LINK_MARKDOWN, env, [])
+    captures = list(env[_FILE_LINK_CAPTURES_KEY])
+
+    compatibility_source = _mask_legacy_bare_file_link_spaces(content)
+    if compatibility_source == content:
+        return captures
+
+    compatibility_env: dict = {_FILE_LINK_CAPTURES_KEY: []}
+    _FILE_LINK_MARKDOWN.inline.parse(
+        compatibility_source,
+        _FILE_LINK_MARKDOWN,
+        compatibility_env,
+        [],
+    )
+    claimed_spans = {(capture[0], capture[1]) for capture in captures}
+    for capture in compatibility_env[_FILE_LINK_CAPTURES_KEY]:
+        destination = content[capture[5] : capture[6]]
+        if (
+            (capture[0], capture[1]) not in claimed_spans
+            and content[capture[5] - 1 : capture[5]] != "<"
+            and destination.startswith("file://")
+            and " " in destination
+        ):
+            captures.append(capture)
+    return captures
+
+
 def _strip_file_links(text: str) -> str:
     """Replace file links outside Markdown code with their labels."""
     return _strip_file_links_with_mask(text, _mask_markdown_code(text))[0]
@@ -581,20 +726,16 @@ def _file_link_matches(
     code_ranges, inline_ranges, _ = _markdown_block_ranges(text)
     captures: list[tuple[int, int, bool, int, int, int, int]] = []
     for source_start, source_end, content in inline_ranges:
-        env: dict = {_FILE_LINK_CAPTURES_KEY: []}
-        _FILE_LINK_MARKDOWN.inline.parse(
-            content,
-            _FILE_LINK_MARKDOWN,
-            env,
-            [],
-        )
+        inline_captures = _inline_file_link_captures(content)
+        if not inline_captures:
+            continue
         offsets = _inline_source_offsets(
             text,
             source_start,
             source_end,
             content,
         )
-        for capture in env[_FILE_LINK_CAPTURES_KEY]:
+        for capture in inline_captures:
             mapped = _map_file_link_capture(capture, offsets)
             if mapped is not None:
                 captures.append(mapped)
@@ -603,14 +744,9 @@ def _file_link_matches(
         for source_start, source_end in code_ranges:
             if "[" not in markdown_mask[source_start:source_end]:
                 continue
-            fallback_env: dict = {_FILE_LINK_CAPTURES_KEY: []}
-            _FILE_LINK_MARKDOWN.inline.parse(
-                text[source_start:source_end],
-                _FILE_LINK_MARKDOWN,
-                fallback_env,
-                [],
-            )
-            for capture in fallback_env[_FILE_LINK_CAPTURES_KEY]:
+            for capture in _inline_file_link_captures(
+                text[source_start:source_end]
+            ):
                 captures.append(
                     (
                         source_start + capture[0],
@@ -645,7 +781,10 @@ def _file_link_matches(
         ):
             continue
         normalized_url = _normalize_file_destination(text[url_start:url_end])
-        parsed = _parse_file_uri(normalized_url)
+        try:
+            parsed = _parse_file_uri(normalized_url)
+        except ValueError:
+            continue
         path = _file_uri_to_local_path(parsed)
         if parsed.scheme.casefold() != "file" or not os.path.isabs(path):
             continue

--- a/core/reply_enhancer.py
+++ b/core/reply_enhancer.py
@@ -147,7 +147,10 @@ class EnhancedReply:
 # The lookahead validates the complete destination form before the shared URL
 # capture consumes it, keeping malformed or half-paired brackets unmatched.
 _BARE_FILE_URI = r"file://(?:[^()]+|\([^)]*\))+"
-_ANGLE_FILE_URI = r"file://(?:\\[<>]|[^()<>\\\r\n]+|\([^)]*\))+"
+# Pointy destinations may contain spaces and unbalanced parentheses. Each
+# repetition begins with either a non-backslash or a backslash, keeping
+# malformed input linear while allowing escaped angle brackets.
+_ANGLE_FILE_URI = r"file://(?:[^\\<>\r\n]|\\[^\r\n])+"
 _FILE_LINK_RE = re.compile(
     rf"(!?)\[([^\]]*)\]\("
     rf"(?=(?:<{_ANGLE_FILE_URI}>|{_BARE_FILE_URI})\))"
@@ -313,7 +316,7 @@ def _file_uri_to_local_path(parsed) -> str:
     """Convert a parsed file URI into a local path for the current OS."""
     # CommonMark pointy destinations permit backslash-escaped angle brackets;
     # those escapes are Markdown syntax, not part of the local filename.
-    path = re.sub(r"\\([<>])", r"\1", unquote(parsed.path))
+    path = unquote(re.sub(r"\\([<>])", r"\1", parsed.path))
     if os.name != "nt":
         return path
 
@@ -377,8 +380,19 @@ def _file_link_matches(
             masked_match.start(),
             masked_match.end(),
         )
-        if original_match is not None:
-            matches.append(original_match)
+        if original_match is None:
+            continue
+        bracket_start = original_match.start() + (
+            1 if original_match.group(1) else 0
+        )
+        backslash_count = 0
+        cursor = bracket_start - 1
+        while cursor >= 0 and text[cursor] == "\\":
+            backslash_count += 1
+            cursor -= 1
+        if backslash_count % 2:
+            continue
+        matches.append(original_match)
     return matches
 
 

--- a/core/reply_enhancer.py
+++ b/core/reply_enhancer.py
@@ -138,10 +138,21 @@ class EnhancedReply:
 # Regex patterns
 # ---------------------------------------------------------------------------
 
-# Matches markdown links with file:// URLs, including image links:
+# Matches markdown links with file:// URLs, including image links. CommonMark
+# permits angle brackets around destinations so paths containing spaces do not
+# need escaping:
 #   [label](file:///path)
-#   ![alt](file:///path)
-_FILE_LINK_RE = re.compile(r"(!?)\[([^\]]*)\]\((file://(?:[^()]+|\([^)]*\))+)\)")
+#   [label](<file:///path with spaces>)
+#   ![alt](<file:///path/(v1).png>)
+# The lookahead validates the complete destination form before the shared URL
+# capture consumes it, keeping malformed or half-paired brackets unmatched.
+_BARE_FILE_URI = r"file://(?:[^()]+|\([^)]*\))+"
+_ANGLE_FILE_URI = r"file://[^<>\r\n]+"
+_FILE_LINK_RE = re.compile(
+    rf"(!?)\[([^\]]*)\]\("
+    rf"(?=(?:<{_ANGLE_FILE_URI}>|{_BARE_FILE_URI})\))"
+    rf"(?:<)?((?<=<){_ANGLE_FILE_URI}|{_BARE_FILE_URI})(?:>)?\)"
+)
 
 # Matches the quick-reply button block at the end of the text.
 # A horizontal rule (``---``) on its own line, followed by bracket buttons.

--- a/core/reply_enhancer.py
+++ b/core/reply_enhancer.py
@@ -21,6 +21,7 @@ import os
 import re
 from bisect import bisect_left
 from dataclasses import dataclass, field
+from html import unescape as html_unescape
 from typing import List, Tuple
 from urllib.parse import unquote, urlparse
 
@@ -195,7 +196,7 @@ _BARE_FILE_URI = r"file://(?:[^()]+|\([^)]*\))+"
 _BARE_FILE_LINK_RE = re.compile(
     rf"(!?)\[([^\]]*)\]\(({_BARE_FILE_URI})\)"
 )
-_FILE_LINK_LABEL_RE = re.compile(r"(!?)\[([^\]]*)\]\(")
+_FILE_LINK_OPENER_RE = re.compile(r"(!?)\[")
 _COMMONMARK_ASCII_PUNCTUATION = frozenset(
     r'''!"#$%&'()*+,-./:;<=>?@[\]^_`{|}~'''
 )
@@ -345,7 +346,7 @@ def _extract_file_links(
     for match in _file_link_matches(text, markdown_mask):
         bang, label, url = match.groups()
         parsed = _parse_file_uri(url)
-        if parsed.scheme != "file":
+        if parsed.scheme.casefold() != "file":
             continue
         path = _file_uri_to_local_path(parsed)
         if not os.path.isabs(path):
@@ -359,7 +360,7 @@ def _file_uri_to_local_path(parsed) -> str:
     """Convert a parsed file URI into a local path for the current OS."""
     # CommonMark pointy destinations permit backslash-escaped angle brackets;
     # those escapes are Markdown syntax, not part of the local filename.
-    path = unquote(_unescape_commonmark_destination_characters(parsed.path))
+    path = unquote(parsed.path)
     if os.name != "nt":
         return path
 
@@ -390,17 +391,34 @@ def _unescape_commonmark_destination_characters(value: str) -> str:
 
 def _protect_file_uri_delimiters(value: str) -> str:
     """Keep escaped URI delimiters in the local path during URL parsing."""
-    return re.sub(
-        r"\\([?#])",
-        lambda match: f"%{ord(match.group(1)):02X}",
-        value,
-    )
+    chars: List[str] = []
+    cursor = 0
+    while cursor < len(value):
+        if value[cursor] == "\\":
+            slash_start = cursor
+            while cursor < len(value) and value[cursor] == "\\":
+                cursor += 1
+            slash_count = cursor - slash_start
+            if cursor < len(value) and value[cursor] in "?#":
+                chars.append("\\" * (slash_count - slash_count % 2))
+                if slash_count % 2:
+                    chars.append(f"%{ord(value[cursor]):02X}")
+                else:
+                    chars.append(value[cursor])
+                cursor += 1
+                continue
+            chars.append("\\" * slash_count)
+            continue
+        chars.append(value[cursor])
+        cursor += 1
+    return "".join(chars)
 
 
 def _parse_file_uri(value: str):
     """Parse a source-level CommonMark destination without losing path punctuation."""
     protected = _protect_file_uri_delimiters(value)
-    return urlparse(_unescape_commonmark_destination_characters(protected))
+    normalized = _unescape_commonmark_destination_characters(protected)
+    return urlparse(html_unescape(normalized))
 
 
 def _scan_angle_file_link(
@@ -432,17 +450,19 @@ def _scan_angle_file_link(
         uri_chars.append(text[cursor])
         cursor += 1
     raw_uri = "".join(uri_chars)
-    if cursor >= len(text) or not _unescape_commonmark_destination_characters(
-        raw_uri
-    ).startswith("file://"):
+    normalized_uri = _unescape_commonmark_destination_characters(raw_uri)
+    if cursor >= len(text) or not normalized_uri[:7].casefold() == "file://":
         return None
 
     cursor += 1
+    title_start = cursor
     while cursor < len(text) and text[cursor].isspace():
         cursor += 1
     if cursor >= len(text):
         return None
     if text[cursor] != ")":
+        if cursor == title_start:
+            return None
         marker = text[cursor]
         if marker not in "\"'(":
             return None
@@ -526,8 +546,11 @@ def _file_link_matches(
 ) -> List[_FileLinkMatch | re.Match]:
     """Find eligible link ranges using a mask, then recover original groups."""
     matches: List[_FileLinkMatch | re.Match] = []
-    mask = markdown_mask if markdown_mask is not None else _mask_markdown_code(text)
-    for candidate in _FILE_LINK_LABEL_RE.finditer(mask):
+    mask = _mask_file_link_candidates(
+        text,
+        markdown_mask if markdown_mask is not None else _mask_markdown_code(text),
+    )
+    for candidate in _FILE_LINK_OPENER_RE.finditer(mask):
         opener_start = candidate.start()
         bang = candidate.group(1) == "!"
         bracket_start = opener_start + (1 if bang else 0)
@@ -536,11 +559,17 @@ def _file_link_matches(
         while prefix_cursor >= 0 and text[prefix_cursor] == "\\":
             backslash_count += 1
             prefix_cursor -= 1
+        if not bang and opener_start > 0 and text[opener_start - 1] == "!":
+            # The bracket half of an image opener is discovered separately by
+            # the linear opener scan; let the ``![`` candidate own the link.
+            continue
         if backslash_count % 2:
             if not bang:
                 continue
             opener_start = bracket_start
-        label_end = candidate.end() - 2
+        label_end = _scan_file_link_label_end(mask, bracket_start)
+        if label_end is None:
+            continue
         if mask[label_end + 2 : label_end + 3] == "<":
             angle_match = _scan_angle_file_link(text, mask, opener_start, label_end)
             if angle_match is not None:
@@ -555,6 +584,38 @@ def _file_link_matches(
                 matches.append(original_match)
                 continue
     return matches
+
+
+def _scan_file_link_label_end(mask: str, bracket_start: int) -> int | None:
+    """Find an unescaped ``](`` label boundary in one linear pass."""
+    cursor = bracket_start + 1
+    while cursor < len(mask):
+        if mask[cursor] == "\\" and cursor + 1 < len(mask):
+            if mask[cursor + 1] in _COMMONMARK_ASCII_PUNCTUATION:
+                cursor += 2
+                continue
+        if mask[cursor] != "]":
+            cursor += 1
+            continue
+        if mask[cursor + 1 : cursor + 2] == "(":
+            return cursor
+        cursor += 1
+    return None
+
+
+def _mask_file_link_candidates(text: str, mask: str) -> str:
+    """Also hide raw-HTML inline tokens from file-link candidate discovery."""
+    ranges: List[Tuple[int, int]] = []
+    terminators = {
+        "-->": _substring_positions(text, "-->"),
+        "?>": _substring_positions(text, "?>"),
+        "]]>": _substring_positions(text, "]]>") ,
+        ">": _substring_positions(text, ">"),
+    }
+    for start, end in _inline_angle_token_ranges(text):
+        if _raw_html_end(text, start, terminators) == end:
+            ranges.append((start, end))
+    return _mask_ranges(mask, ranges) if ranges else mask
 
 
 def _extract_secret_requests(

--- a/core/reply_enhancer.py
+++ b/core/reply_enhancer.py
@@ -21,14 +21,17 @@ import os
 import re
 from bisect import bisect_left
 from dataclasses import dataclass, field
-from html import unescape as html_unescape
 from typing import List, Tuple
 from urllib.parse import unquote, urlparse
 
 from markdown_it import MarkdownIt
+from markdown_it.common.normalize_url import validateLink as _validate_markdown_link
+from markdown_it.common.utils import isStrSpace, unescapeAll
 from markdown_it.common.html_re import HTML_TAG_RE
 from markdown_it.rules_inline.autolink import AUTOLINK_RE, EMAIL_RE
 from markdown_it.rules_inline.backticks import backtick as _commonmark_backtick
+from markdown_it.rules_inline.image import image as _commonmark_image
+from markdown_it.rules_inline.link import link as _commonmark_link
 from markdown_it.rules_inline.state_inline import StateInline
 
 logger = logging.getLogger(__name__)
@@ -37,6 +40,7 @@ _INLINE_MARKDOWN = MarkdownIt("commonmark")
 _INLINE_CODE_RANGES_KEY = "avibe_inline_code_ranges"
 _INLINE_ANGLE_RANGES_KEY = "avibe_inline_angle_ranges"
 _INLINE_SILENT_RANGES_KEY = "avibe_inline_silent_ranges"
+_FILE_LINK_CAPTURES_KEY = "avibe_file_link_captures"
 
 
 def _track_inline_code(state: StateInline, silent: bool) -> bool:
@@ -77,6 +81,76 @@ def _skip_silent_control(state: StateInline, silent: bool) -> bool:
     return True
 
 
+def _validate_file_link_locally(url: str) -> bool:
+    """Allow file links only in the reply parser's isolated MarkdownIt."""
+    return url.strip().casefold().startswith("file:") or _validate_markdown_link(url)
+
+
+def _capture_file_link_rule(rule, *, is_image: bool):
+    """Wrap a CommonMark rule and record its accepted source ownership."""
+
+    def capture(state: StateInline, silent: bool) -> bool:
+        start = state.pos
+        token_start = len(state.tokens)
+        matched = rule(state, silent)
+        if not matched or silent:
+            return matched
+
+        href = None
+        for token in state.tokens[token_start:]:
+            if is_image and token.type == "image":
+                href = token.attrGet("src")
+                break
+            if not is_image and token.type == "link_open":
+                href = token.attrGet("href")
+                break
+        if not isinstance(href, str) or not href.casefold().startswith("file:"):
+            return matched
+
+        bracket_start = start + (1 if is_image else 0)
+        label_start = bracket_start + 1
+        label_end = state.md.helpers.parseLinkLabel(
+            state,
+            bracket_start,
+            not is_image,
+        )
+        pos = label_end + 1
+        if label_end < 0 or pos >= state.posMax or state.src[pos] != "(":
+            return matched
+        pos += 1
+        while pos < state.posMax:
+            char = state.src[pos]
+            if not isStrSpace(char) and char != "\n":
+                break
+            pos += 1
+        destination_start = pos
+        destination = state.md.helpers.parseLinkDestination(
+            state.src,
+            destination_start,
+            state.posMax,
+        )
+        if not destination.ok:
+            return matched
+        destination_end = destination.pos
+        if state.src[destination_start : destination_start + 1] == "<":
+            destination_start += 1
+            destination_end -= 1
+        state.env.setdefault(_FILE_LINK_CAPTURES_KEY, []).append(
+            (
+                start,
+                state.pos,
+                is_image,
+                label_start,
+                label_end,
+                destination_start,
+                destination_end,
+            )
+        )
+        return matched
+
+    return capture
+
+
 _INLINE_MARKDOWN.inline.ruler.disable(["autolink", "html_inline"])
 _INLINE_MARKDOWN.inline.ruler.before(
     "backticks",
@@ -89,6 +163,17 @@ _INLINE_MARKDOWN.inline.ruler.before(
     _skip_silent_control,
 )
 _INLINE_MARKDOWN.inline.ruler.at("backticks", _track_inline_code)
+
+_FILE_LINK_MARKDOWN = MarkdownIt("commonmark")
+_FILE_LINK_MARKDOWN.validateLink = _validate_file_link_locally
+_FILE_LINK_MARKDOWN.inline.ruler.at(
+    "link",
+    _capture_file_link_rule(_commonmark_link, is_image=False),
+)
+_FILE_LINK_MARKDOWN.inline.ruler.at(
+    "image",
+    _capture_file_link_rule(_commonmark_image, is_image=True),
+)
 
 # ---------------------------------------------------------------------------
 # Data classes
@@ -145,6 +230,10 @@ class _FileLinkMatch:
     bang: str
     label: str
     url: str
+    label_start_offset: int
+    label_end_offset: int
+    url_start_offset: int
+    url_end_offset: int
 
     def start(self, group: int | None = None) -> int:
         if group in (None, 0):
@@ -152,10 +241,9 @@ class _FileLinkMatch:
         if group == 1:
             return self.start_offset
         if group == 2:
-            return self.start_offset + len(self.bang) + 1
+            return self.label_start_offset
         if group == 3:
-            label_end = self.start_offset + len(self.bang) + 1 + len(self.label)
-            return label_end + 2
+            return self.url_start_offset
         raise IndexError(group)
 
     def end(self, group: int | None = None) -> int:
@@ -164,9 +252,9 @@ class _FileLinkMatch:
         if group == 1:
             return self.start_offset + len(self.bang)
         if group == 2:
-            return self.start_offset + len(self.bang) + 1 + len(self.label)
+            return self.label_end_offset
         if group == 3:
-            return self.start(3) + len(self.url)
+            return self.url_end_offset
         raise IndexError(group)
 
     def group(self, *groups: int) -> str | tuple[str, ...]:
@@ -183,23 +271,6 @@ class _FileLinkMatch:
 # ---------------------------------------------------------------------------
 # Regex patterns
 # ---------------------------------------------------------------------------
-
-# Matches markdown links with file:// URLs, including image links. CommonMark
-# permits angle brackets around destinations so paths containing spaces do not
-# need escaping:
-#   [label](file:///path)
-#   [label](<file:///path with spaces>)
-#   ![alt](<file:///path/(v1).png>)
-# The lookahead validates the complete destination form before the shared URL
-# capture consumes it, keeping malformed or half-paired brackets unmatched.
-_BARE_FILE_URI = r"file://(?:[^()]+|\([^)]*\))+"
-_BARE_FILE_LINK_RE = re.compile(
-    rf"(!?)\[([^\]]*)\]\(({_BARE_FILE_URI})\)"
-)
-_FILE_LINK_OPENER_RE = re.compile(r"(!?)\[")
-_COMMONMARK_ASCII_PUNCTUATION = frozenset(
-    r'''!"#$%&'()*+,-./:;<=>?@[\]^_`{|}~'''
-)
 
 # Matches the quick-reply button block at the end of the text.
 # A horizontal rule (``---``) on its own line, followed by bracket buttons.
@@ -371,133 +442,40 @@ def _file_uri_to_local_path(parsed) -> str:
     return ntpath.normpath(path)
 
 
-def _unescape_commonmark_destination_characters(value: str) -> str:
-    """Remove CommonMark backslash escapes from ASCII punctuation only."""
-    chars: List[str] = []
-    cursor = 0
-    while cursor < len(value):
-        if (
-            value[cursor] == "\\"
-            and cursor + 1 < len(value)
-            and value[cursor + 1] in _COMMONMARK_ASCII_PUNCTUATION
-        ):
-            chars.append(value[cursor + 1])
-            cursor += 2
-            continue
-        chars.append(value[cursor])
-        cursor += 1
-    return "".join(chars)
+def _parse_file_uri(value: str):
+    """Parse a CommonMark-normalized file destination."""
+    return urlparse(value)
 
 
 def _protect_file_uri_delimiters(value: str) -> str:
-    """Keep escaped URI delimiters in the local path during URL parsing."""
+    """Keep escaped URI delimiters in the path before CommonMark unescaping."""
     chars: List[str] = []
     cursor = 0
     while cursor < len(value):
-        if value[cursor] == "\\":
-            slash_start = cursor
-            while cursor < len(value) and value[cursor] == "\\":
-                cursor += 1
-            slash_count = cursor - slash_start
-            if cursor < len(value) and value[cursor] in "?#":
-                chars.append("\\" * (slash_count - slash_count % 2))
-                if slash_count % 2:
-                    chars.append(f"%{ord(value[cursor]):02X}")
-                else:
-                    chars.append(value[cursor])
-                cursor += 1
-                continue
-            chars.append("\\" * slash_count)
+        if value[cursor] != "\\":
+            chars.append(value[cursor])
+            cursor += 1
             continue
-        chars.append(value[cursor])
-        cursor += 1
+        slash_start = cursor
+        while cursor < len(value) and value[cursor] == "\\":
+            cursor += 1
+        slash_count = cursor - slash_start
+        if cursor < len(value) and value[cursor] in "?#":
+            chars.append("\\" * (slash_count - slash_count % 2))
+            chars.append(
+                f"%{ord(value[cursor]):02X}"
+                if slash_count % 2
+                else value[cursor]
+            )
+            cursor += 1
+            continue
+        chars.append("\\" * slash_count)
     return "".join(chars)
 
 
-def _parse_file_uri(value: str):
-    """Parse a source-level CommonMark destination without losing path punctuation."""
-    protected = _protect_file_uri_delimiters(value)
-    normalized = _unescape_commonmark_destination_characters(protected)
-    return urlparse(html_unescape(normalized))
-
-
-def _scan_angle_file_link(
-    text: str,
-    mask: str,
-    start: int,
-    label_end: int,
-) -> _FileLinkMatch | None:
-    """Scan one angle destination and its optional CommonMark title."""
-    destination_start = label_end + 2
-    if mask[destination_start : destination_start + 1] != "<":
-        return None
-    cursor = destination_start + 1
-    uri_chars: List[str] = []
-    while cursor < len(text):
-        char = text[cursor]
-        if char in "\r\n":
-            return None
-        if char == ">":
-            break
-        if char == "<":
-            return None
-        if char == "\\" and cursor + 1 < len(text):
-            next_char = text[cursor + 1]
-            if next_char in _COMMONMARK_ASCII_PUNCTUATION:
-                uri_chars.append(text[cursor : cursor + 2])
-                cursor += 2
-                continue
-        uri_chars.append(text[cursor])
-        cursor += 1
-    raw_uri = "".join(uri_chars)
-    normalized_uri = _unescape_commonmark_destination_characters(raw_uri)
-    if cursor >= len(text) or not normalized_uri[:7].casefold() == "file://":
-        return None
-
-    cursor += 1
-    title_start = cursor
-    while cursor < len(text) and text[cursor].isspace():
-        cursor += 1
-    if cursor >= len(text):
-        return None
-    if text[cursor] != ")":
-        if cursor == title_start:
-            return None
-        marker = text[cursor]
-        if marker not in "\"'(":
-            return None
-        closing = ")" if marker == "(" else marker
-        cursor += 1
-        while cursor < len(text):
-            char = text[cursor]
-            if char == "\\" and cursor + 1 < len(text):
-                cursor += 2
-                continue
-            if char == "\r" or char == "\n":
-                return None
-            if char == "(" and closing == ")":
-                return None
-            if char == closing:
-                cursor += 1
-                break
-            cursor += 1
-        else:
-            return None
-        while cursor < len(text) and text[cursor].isspace():
-            cursor += 1
-    if cursor >= len(text) or text[cursor] != ")":
-        return None
-
-    bang = text[start : start + 1] if text[start : start + 1] == "!" else ""
-    label_start = start + len(bang) + 1
-    return _FileLinkMatch(
-        source=text[start : cursor + 1],
-        start_offset=start,
-        end_offset=cursor + 1,
-        bang=bang,
-        label=text[label_start:label_end],
-        url=raw_uri,
-    )
+def _normalize_file_destination(value: str) -> str:
+    """Apply markdown-it's strict entity and backslash normalization once."""
+    return unescapeAll(_protect_file_uri_delimiters(value))
 
 
 def _strip_file_links(text: str) -> str:
@@ -526,96 +504,173 @@ def _strip_file_links_with_mask(text: str, markdown_mask: str) -> Tuple[str, str
 
 
 def _replace_file_links(text: str, replacement) -> str:
-    """Replace eligible file links while preserving Markdown code regions."""
+    """Replace eligible file-link destinations while preserving Markdown syntax."""
     matches = _file_link_matches(text)
     if not matches:
         return text
     parts: List[str] = []
     cursor = 0
     for match in matches:
-        parts.append(text[cursor : match.start()])
+        parts.append(text[cursor : match.start(3)])
         parts.append(replacement(match))
-        cursor = match.end()
+        cursor = match.end(3)
     parts.append(text[cursor:])
     return "".join(parts)
+
+
+def _inline_source_offsets(
+    text: str,
+    start: int,
+    end: int,
+    content: str,
+) -> dict[int, int]:
+    """Map container-stripped inline content offsets to source offsets."""
+    source_lines: List[Tuple[int, str]] = []
+    line_start = start
+    for match in re.finditer(r"\r\n|\r|\n", text[start:end]):
+        line_end = start + match.start()
+        source_lines.append((line_start, text[line_start:line_end]))
+        line_start = start + match.end()
+    source_lines.append((line_start, text[line_start:end]))
+
+    offsets: dict[int, int] = {}
+    source_index = 0
+    content_offset = 0
+    for content_line in content.split("\n"):
+        for candidate_index in range(source_index, len(source_lines)):
+            absolute_start, source_line = source_lines[candidate_index]
+            normalized_source_line = source_line.replace("\x00", "\ufffd")
+            relative_start = normalized_source_line.find(content_line)
+            if relative_start < 0:
+                continue
+            for relative_offset in range(len(content_line) + 1):
+                offsets[content_offset + relative_offset] = (
+                    absolute_start + relative_start + relative_offset
+                )
+            source_index = candidate_index + 1
+            break
+        content_offset += len(content_line) + 1
+    return offsets
+
+
+def _map_file_link_capture(
+    capture: tuple[int, int, bool, int, int, int, int],
+    offsets: dict[int, int],
+) -> tuple[int, int, bool, int, int, int, int] | None:
+    """Translate one inline-token capture back to the original source."""
+    start, end, is_image, label_start, label_end, url_start, url_end = capture
+    boundaries = (start, end - 1, label_start, label_end, url_start, url_end)
+    if any(boundary not in offsets for boundary in boundaries):
+        return None
+    return (
+        offsets[start],
+        offsets[end - 1] + 1,
+        is_image,
+        offsets[label_start],
+        offsets[label_end],
+        offsets[url_start],
+        offsets[url_end],
+    )
 
 
 def _file_link_matches(
     text: str,
     markdown_mask: str | None = None,
-) -> List[_FileLinkMatch | re.Match]:
-    """Find eligible link ranges using a mask, then recover original groups."""
-    matches: List[_FileLinkMatch | re.Match] = []
-    mask = _mask_file_link_candidates(
-        text,
-        markdown_mask if markdown_mask is not None else _mask_markdown_code(text),
-    )
-    for candidate in _FILE_LINK_OPENER_RE.finditer(mask):
-        opener_start = candidate.start()
-        bang = candidate.group(1) == "!"
-        bracket_start = opener_start + (1 if bang else 0)
-        backslash_count = 0
-        prefix_cursor = opener_start - 1
-        while prefix_cursor >= 0 and text[prefix_cursor] == "\\":
-            backslash_count += 1
-            prefix_cursor -= 1
-        if not bang and opener_start > 0 and text[opener_start - 1] == "!":
-            # The bracket half of an image opener is discovered separately by
-            # the linear opener scan; let the ``![`` candidate own the link.
-            continue
-        if backslash_count % 2:
-            if not bang:
+) -> List[_FileLinkMatch]:
+    """Return file links accepted by CommonMark and the local-path policy."""
+    code_ranges, inline_ranges, _ = _markdown_block_ranges(text)
+    captures: list[tuple[int, int, bool, int, int, int, int]] = []
+    for source_start, source_end, content in inline_ranges:
+        env: dict = {_FILE_LINK_CAPTURES_KEY: []}
+        _FILE_LINK_MARKDOWN.inline.parse(
+            content,
+            _FILE_LINK_MARKDOWN,
+            env,
+            [],
+        )
+        offsets = _inline_source_offsets(
+            text,
+            source_start,
+            source_end,
+            content,
+        )
+        for capture in env[_FILE_LINK_CAPTURES_KEY]:
+            mapped = _map_file_link_capture(capture, offsets)
+            if mapped is not None:
+                captures.append(mapped)
+
+    if markdown_mask is not None:
+        for source_start, source_end in code_ranges:
+            if "[" not in markdown_mask[source_start:source_end]:
                 continue
-            opener_start = bracket_start
-        label_end = _scan_file_link_label_end(mask, bracket_start)
-        if label_end is None:
-            continue
-        if mask[label_end + 2 : label_end + 3] == "<":
-            angle_match = _scan_angle_file_link(text, mask, opener_start, label_end)
-            if angle_match is not None:
-                matches.append(angle_match)
-                continue
-        bare_match = _BARE_FILE_LINK_RE.match(mask, opener_start)
-        if bare_match is not None:
-            original_match = _BARE_FILE_LINK_RE.fullmatch(
-                text, opener_start, bare_match.end()
+            fallback_env: dict = {_FILE_LINK_CAPTURES_KEY: []}
+            _FILE_LINK_MARKDOWN.inline.parse(
+                text[source_start:source_end],
+                _FILE_LINK_MARKDOWN,
+                fallback_env,
+                [],
             )
-            if original_match is not None:
-                matches.append(original_match)
-                continue
-    return matches
+            for capture in fallback_env[_FILE_LINK_CAPTURES_KEY]:
+                captures.append(
+                    (
+                        source_start + capture[0],
+                        source_start + capture[1],
+                        capture[2],
+                        source_start + capture[3],
+                        source_start + capture[4],
+                        source_start + capture[5],
+                        source_start + capture[6],
+                    )
+                )
 
-
-def _scan_file_link_label_end(mask: str, bracket_start: int) -> int | None:
-    """Find an unescaped ``](`` label boundary in one linear pass."""
-    cursor = bracket_start + 1
-    while cursor < len(mask):
-        if mask[cursor] == "\\" and cursor + 1 < len(mask):
-            if mask[cursor + 1] in _COMMONMARK_ASCII_PUNCTUATION:
-                cursor += 2
-                continue
-        if mask[cursor] != "]":
-            cursor += 1
+    candidates: List[_FileLinkMatch] = []
+    captures = sorted(
+        captures,
+        key=lambda capture: (capture[0], -capture[1]),
+    )
+    for capture in captures:
+        (
+            start,
+            end,
+            is_image,
+            label_start,
+            label_end,
+            url_start,
+            url_end,
+        ) = capture
+        opener_end = start + (2 if is_image else 1)
+        if (
+            markdown_mask is not None
+            and markdown_mask[start:opener_end] != text[start:opener_end]
+        ):
             continue
-        if mask[cursor + 1 : cursor + 2] == "(":
-            return cursor
-        cursor += 1
-    return None
-
-
-def _mask_file_link_candidates(text: str, mask: str) -> str:
-    """Also hide raw-HTML inline tokens from file-link candidate discovery."""
-    ranges: List[Tuple[int, int]] = []
-    terminators = {
-        "-->": _substring_positions(text, "-->"),
-        "?>": _substring_positions(text, "?>"),
-        "]]>": _substring_positions(text, "]]>") ,
-        ">": _substring_positions(text, ">"),
-    }
-    for start, end in _inline_angle_token_ranges(text):
-        if _raw_html_end(text, start, terminators) == end:
-            ranges.append((start, end))
-    return _mask_ranges(mask, ranges) if ranges else mask
+        normalized_url = _normalize_file_destination(text[url_start:url_end])
+        parsed = _parse_file_uri(normalized_url)
+        path = _file_uri_to_local_path(parsed)
+        if parsed.scheme.casefold() != "file" or not os.path.isabs(path):
+            continue
+        candidates.append(
+            _FileLinkMatch(
+                source=text[start:end],
+                start_offset=start,
+                end_offset=end,
+                bang="!" if is_image else "",
+                label=text[label_start:label_end],
+                url=normalized_url,
+                label_start_offset=label_start,
+                label_end_offset=label_end,
+                url_start_offset=url_start,
+                url_end_offset=url_end,
+            )
+        )
+    matches: List[_FileLinkMatch] = []
+    covered_until = 0
+    for candidate in candidates:
+        if candidate.start() < covered_until:
+            continue
+        matches.append(candidate)
+        covered_until = candidate.end()
+    return matches
 
 
 def _extract_secret_requests(

--- a/core/reply_enhancer.py
+++ b/core/reply_enhancer.py
@@ -501,7 +501,11 @@ def _mask_legacy_bare_file_link_spaces(source: str) -> str:
         slash_count = 0
         space_offsets: List[int] = []
         destination_end = -1
+        later_marker_start = -1
         while cursor < len(source):
+            if source.startswith(marker, cursor):
+                later_marker_start = cursor
+                break
             char = source[cursor]
             if char in "\t\r\n":
                 break
@@ -523,6 +527,9 @@ def _mask_legacy_bare_file_link_spaces(source: str) -> str:
                 depth -= 1
             cursor += 1
 
+        if later_marker_start >= 0:
+            search_start = later_marker_start
+            continue
         if destination_end >= 0 and space_offsets:
             title_separator = _legacy_bare_title_separator(
                 source,

--- a/core/reply_enhancer.py
+++ b/core/reply_enhancer.py
@@ -134,6 +134,51 @@ class EnhancedReply:
     secret_requests: List[SecretRequest] = field(default_factory=list)
 
 
+@dataclass(frozen=True)
+class _FileLinkMatch:
+    """Small match-compatible value shared by the regex and angle scanner."""
+
+    source: str
+    start_offset: int
+    end_offset: int
+    bang: str
+    label: str
+    url: str
+
+    def start(self, group: int | None = None) -> int:
+        if group in (None, 0):
+            return self.start_offset
+        if group == 1:
+            return self.start_offset
+        if group == 2:
+            return self.start_offset + len(self.bang) + 1
+        if group == 3:
+            label_end = self.start_offset + len(self.bang) + 1 + len(self.label)
+            return label_end + 2
+        raise IndexError(group)
+
+    def end(self, group: int | None = None) -> int:
+        if group in (None, 0):
+            return self.end_offset
+        if group == 1:
+            return self.start_offset + len(self.bang)
+        if group == 2:
+            return self.start_offset + len(self.bang) + 1 + len(self.label)
+        if group == 3:
+            return self.start(3) + len(self.url)
+        raise IndexError(group)
+
+    def group(self, *groups: int) -> str | tuple[str, ...]:
+        values = (self.source, self.bang, self.label, self.url)
+        if not groups:
+            return self.source
+        selected = tuple(values[group] for group in groups)
+        return selected[0] if len(selected) == 1 else selected
+
+    def groups(self) -> tuple[str, str, str]:
+        return self.bang, self.label, self.url
+
+
 # ---------------------------------------------------------------------------
 # Regex patterns
 # ---------------------------------------------------------------------------
@@ -147,14 +192,12 @@ class EnhancedReply:
 # The lookahead validates the complete destination form before the shared URL
 # capture consumes it, keeping malformed or half-paired brackets unmatched.
 _BARE_FILE_URI = r"file://(?:[^()]+|\([^)]*\))+"
-# Pointy destinations may contain spaces and unbalanced parentheses. Each
-# repetition begins with either a non-backslash or a backslash, keeping
-# malformed input linear while allowing escaped angle brackets.
-_ANGLE_FILE_URI = r"file://(?:[^\\<>\r\n]|\\[^\r\n])+"
-_FILE_LINK_RE = re.compile(
-    rf"(!?)\[([^\]]*)\]\("
-    rf"(?=(?:<{_ANGLE_FILE_URI}>|{_BARE_FILE_URI})\))"
-    rf"(?:<)?((?<=<){_ANGLE_FILE_URI}|{_BARE_FILE_URI})(?:>)?\)"
+_BARE_FILE_LINK_RE = re.compile(
+    rf"(!?)\[([^\]]*)\]\(({_BARE_FILE_URI})\)"
+)
+_FILE_LINK_LABEL_RE = re.compile(r"(!?)\[([^\]]*)\]\(")
+_COMMONMARK_ASCII_PUNCTUATION = frozenset(
+    r'''!"#$%&'()*+,-./:;<=>?@[\]^_`{|}~'''
 )
 
 # Matches the quick-reply button block at the end of the text.
@@ -301,7 +344,7 @@ def _extract_file_links(
     results: List[FileLink] = []
     for match in _file_link_matches(text, markdown_mask):
         bang, label, url = match.groups()
-        parsed = urlparse(url)
+        parsed = _parse_file_uri(url)
         if parsed.scheme != "file":
             continue
         path = _file_uri_to_local_path(parsed)
@@ -316,7 +359,7 @@ def _file_uri_to_local_path(parsed) -> str:
     """Convert a parsed file URI into a local path for the current OS."""
     # CommonMark pointy destinations permit backslash-escaped angle brackets;
     # those escapes are Markdown syntax, not part of the local filename.
-    path = unquote(re.sub(r"\\([<>])", r"\1", parsed.path))
+    path = unquote(_unescape_commonmark_destination_characters(parsed.path))
     if os.name != "nt":
         return path
 
@@ -325,6 +368,116 @@ def _file_uri_to_local_path(parsed) -> str:
     if re.match(r"^/[A-Za-z]:/", path):
         path = path[1:]
     return ntpath.normpath(path)
+
+
+def _unescape_commonmark_destination_characters(value: str) -> str:
+    """Remove CommonMark backslash escapes from ASCII punctuation only."""
+    chars: List[str] = []
+    cursor = 0
+    while cursor < len(value):
+        if (
+            value[cursor] == "\\"
+            and cursor + 1 < len(value)
+            and value[cursor + 1] in _COMMONMARK_ASCII_PUNCTUATION
+        ):
+            chars.append(value[cursor + 1])
+            cursor += 2
+            continue
+        chars.append(value[cursor])
+        cursor += 1
+    return "".join(chars)
+
+
+def _protect_file_uri_delimiters(value: str) -> str:
+    """Keep escaped URI delimiters in the local path during URL parsing."""
+    return re.sub(
+        r"\\([?#])",
+        lambda match: f"%{ord(match.group(1)):02X}",
+        value,
+    )
+
+
+def _parse_file_uri(value: str):
+    """Parse a source-level CommonMark destination without losing path punctuation."""
+    protected = _protect_file_uri_delimiters(value)
+    return urlparse(_unescape_commonmark_destination_characters(protected))
+
+
+def _scan_angle_file_link(
+    text: str,
+    mask: str,
+    start: int,
+    label_end: int,
+) -> _FileLinkMatch | None:
+    """Scan one angle destination and its optional CommonMark title."""
+    destination_start = label_end + 2
+    if mask[destination_start : destination_start + 1] != "<":
+        return None
+    cursor = destination_start + 1
+    uri_chars: List[str] = []
+    while cursor < len(text):
+        char = text[cursor]
+        if char in "\r\n":
+            return None
+        if char == ">":
+            break
+        if char == "<":
+            return None
+        if char == "\\" and cursor + 1 < len(text):
+            next_char = text[cursor + 1]
+            if next_char in _COMMONMARK_ASCII_PUNCTUATION:
+                uri_chars.append(text[cursor : cursor + 2])
+                cursor += 2
+                continue
+        uri_chars.append(text[cursor])
+        cursor += 1
+    raw_uri = "".join(uri_chars)
+    if cursor >= len(text) or not _unescape_commonmark_destination_characters(
+        raw_uri
+    ).startswith("file://"):
+        return None
+
+    cursor += 1
+    while cursor < len(text) and text[cursor].isspace():
+        cursor += 1
+    if cursor >= len(text):
+        return None
+    if text[cursor] != ")":
+        marker = text[cursor]
+        if marker not in "\"'(":
+            return None
+        closing = ")" if marker == "(" else marker
+        cursor += 1
+        while cursor < len(text):
+            char = text[cursor]
+            if char == "\\" and cursor + 1 < len(text):
+                cursor += 2
+                continue
+            if char == "\r" or char == "\n":
+                return None
+            if char == "(" and closing == ")":
+                return None
+            if char == closing:
+                cursor += 1
+                break
+            cursor += 1
+        else:
+            return None
+        while cursor < len(text) and text[cursor].isspace():
+            cursor += 1
+    if cursor >= len(text) or text[cursor] != ")":
+        return None
+
+    bang = text[start : start + 1] if text[start : start + 1] == "!" else ""
+    label_start = start + len(bang) + 1
+    return _FileLinkMatch(
+        source=text[start : cursor + 1],
+        start_offset=start,
+        end_offset=cursor + 1,
+        bang=bang,
+        label=text[label_start:label_end],
+        url=raw_uri,
+    )
 
 
 def _strip_file_links(text: str) -> str:
@@ -370,29 +523,37 @@ def _replace_file_links(text: str, replacement) -> str:
 def _file_link_matches(
     text: str,
     markdown_mask: str | None = None,
-) -> List[re.Match]:
+) -> List[_FileLinkMatch | re.Match]:
     """Find eligible link ranges using a mask, then recover original groups."""
-    matches: List[re.Match] = []
+    matches: List[_FileLinkMatch | re.Match] = []
     mask = markdown_mask if markdown_mask is not None else _mask_markdown_code(text)
-    for masked_match in _FILE_LINK_RE.finditer(mask):
-        original_match = _FILE_LINK_RE.fullmatch(
-            text,
-            masked_match.start(),
-            masked_match.end(),
-        )
-        if original_match is None:
-            continue
-        bracket_start = original_match.start() + (
-            1 if original_match.group(1) else 0
-        )
+    for candidate in _FILE_LINK_LABEL_RE.finditer(mask):
+        opener_start = candidate.start()
+        bang = candidate.group(1) == "!"
+        bracket_start = opener_start + (1 if bang else 0)
         backslash_count = 0
-        cursor = bracket_start - 1
-        while cursor >= 0 and text[cursor] == "\\":
+        prefix_cursor = opener_start - 1
+        while prefix_cursor >= 0 and text[prefix_cursor] == "\\":
             backslash_count += 1
-            cursor -= 1
+            prefix_cursor -= 1
         if backslash_count % 2:
-            continue
-        matches.append(original_match)
+            if not bang:
+                continue
+            opener_start = bracket_start
+        label_end = candidate.end() - 2
+        if mask[label_end + 2 : label_end + 3] == "<":
+            angle_match = _scan_angle_file_link(text, mask, opener_start, label_end)
+            if angle_match is not None:
+                matches.append(angle_match)
+                continue
+        bare_match = _BARE_FILE_LINK_RE.match(mask, opener_start)
+        if bare_match is not None:
+            original_match = _BARE_FILE_LINK_RE.fullmatch(
+                text, opener_start, bare_match.end()
+            )
+            if original_match is not None:
+                matches.append(original_match)
+                continue
     return matches
 
 

--- a/core/reply_enhancer.py
+++ b/core/reply_enhancer.py
@@ -147,7 +147,7 @@ class EnhancedReply:
 # The lookahead validates the complete destination form before the shared URL
 # capture consumes it, keeping malformed or half-paired brackets unmatched.
 _BARE_FILE_URI = r"file://(?:[^()]+|\([^)]*\))+"
-_ANGLE_FILE_URI = r"file://[^<>\r\n]+"
+_ANGLE_FILE_URI = r"file://(?:\\[<>]|[^()<>\\\r\n]+|\([^)]*\))+"
 _FILE_LINK_RE = re.compile(
     rf"(!?)\[([^\]]*)\]\("
     rf"(?=(?:<{_ANGLE_FILE_URI}>|{_BARE_FILE_URI})\))"
@@ -311,7 +311,9 @@ def _extract_file_links(
 
 def _file_uri_to_local_path(parsed) -> str:
     """Convert a parsed file URI into a local path for the current OS."""
-    path = unquote(parsed.path)
+    # CommonMark pointy destinations permit backslash-escaped angle brackets;
+    # those escapes are Markdown syntax, not part of the local filename.
+    path = re.sub(r"\\([<>])", r"\1", unquote(parsed.path))
     if os.name != "nt":
         return path
 
@@ -345,6 +347,21 @@ def _strip_file_links_with_mask(text: str, markdown_mask: str) -> Tuple[str, str
     text_parts.append(text[cursor:])
     mask_parts.append(markdown_mask[cursor:])
     return "".join(text_parts), "".join(mask_parts)
+
+
+def _replace_file_links(text: str, replacement) -> str:
+    """Replace eligible file links while preserving Markdown code regions."""
+    matches = _file_link_matches(text)
+    if not matches:
+        return text
+    parts: List[str] = []
+    cursor = 0
+    for match in matches:
+        parts.append(text[cursor : match.start()])
+        parts.append(replacement(match))
+        cursor = match.end()
+    parts.append(text[cursor:])
+    return "".join(parts)
 
 
 def _file_link_matches(

--- a/core/workbench_media.py
+++ b/core/workbench_media.py
@@ -371,13 +371,13 @@ def rewrite_agent_media(conn: Connection, *, scope_id: str | None, session_id: s
     and non-absolute paths are left untouched. Best-effort: a registration
     failure leaves that one link as written rather than dropping the reply.
     """
-    if not text or "file://" not in text:
+    if not text or "file://" not in text.casefold():
         return text
 
     def _replace(match) -> str:
         bang, label, url = match.group(1), match.group(2), match.group(3)
         parsed = _parse_file_uri(url)
-        if parsed.scheme != "file":
+        if parsed.scheme.casefold() != "file":
             return match.group(0)
         path = _file_uri_to_local_path(parsed)
         if not os.path.isabs(path):

--- a/core/workbench_media.py
+++ b/core/workbench_media.py
@@ -371,23 +371,24 @@ def rewrite_agent_media(conn: Connection, *, scope_id: str | None, session_id: s
     and non-absolute paths are left untouched. Best-effort: a registration
     failure leaves that one link as written rather than dropping the reply.
     """
-    if not text or "file://" not in text.casefold():
+    if not text:
         return text
 
     def _replace(match) -> str:
         bang, label, url = match.group(1), match.group(2), match.group(3)
+        source_url = text[match.start(3) : match.end(3)]
         parsed = _parse_file_uri(url)
         if parsed.scheme.casefold() != "file":
-            return match.group(0)
+            return source_url
         path = _file_uri_to_local_path(parsed)
         if not os.path.isabs(path):
             logger.warning("workbench_media: skipping non-absolute file link: %s", url)
-            return match.group(0)
+            return source_url
         try:
             safe_path = str(Path(path).resolve())
         except Exception:
             logger.warning("workbench_media: could not resolve file link: %s", url)
-            return match.group(0)
+            return source_url
         try:
             token = register_agent_reply_media(
                 conn,
@@ -399,7 +400,7 @@ def rewrite_agent_media(conn: Connection, *, scope_id: str | None, session_id: s
             )
         except Exception:
             logger.exception("workbench_media: failed to register media for %s", safe_path)
-            return match.group(0)
+            return source_url
         url = f"/api/media/{token}"
         # For an image, carry its pixel dimensions on the URL (``?w=&h=``) so the
         # browser reserves the box before it loads — the transcript never shifts on
@@ -412,7 +413,7 @@ def rewrite_agent_media(conn: Connection, *, scope_id: str | None, session_id: s
                     url = f"{url}?w={w}&h={h}"
             except Exception:
                 logger.debug("workbench_media: no dimensions for %s", safe_path, exc_info=True)
-        return f"{bang}[{label}]({url})"
+        return url
 
     return _replace_file_links(text, _replace)
 

--- a/core/workbench_media.py
+++ b/core/workbench_media.py
@@ -28,12 +28,11 @@ from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
 from typing import BinaryIO
-from urllib.parse import urlparse
 
 from sqlalchemy.engine import Connection
 
 from config import paths
-from core.reply_enhancer import _file_uri_to_local_path, _replace_file_links
+from core.reply_enhancer import _file_uri_to_local_path, _parse_file_uri, _replace_file_links
 from storage import media_service
 
 logger = logging.getLogger(__name__)
@@ -377,7 +376,7 @@ def rewrite_agent_media(conn: Connection, *, scope_id: str | None, session_id: s
 
     def _replace(match) -> str:
         bang, label, url = match.group(1), match.group(2), match.group(3)
-        parsed = urlparse(url)
+        parsed = _parse_file_uri(url)
         if parsed.scheme != "file":
             return match.group(0)
         path = _file_uri_to_local_path(parsed)

--- a/core/workbench_media.py
+++ b/core/workbench_media.py
@@ -33,7 +33,7 @@ from urllib.parse import urlparse
 from sqlalchemy.engine import Connection
 
 from config import paths
-from core.reply_enhancer import _FILE_LINK_RE, _file_uri_to_local_path
+from core.reply_enhancer import _file_uri_to_local_path, _replace_file_links
 from storage import media_service
 
 logger = logging.getLogger(__name__)
@@ -415,7 +415,7 @@ def rewrite_agent_media(conn: Connection, *, scope_id: str | None, session_id: s
                 logger.debug("workbench_media: no dimensions for %s", safe_path, exc_info=True)
         return f"{bang}[{label}]({url})"
 
-    return _FILE_LINK_RE.sub(_replace, text)
+    return _replace_file_links(text, _replace)
 
 
 def resolve_attachment_specs(conn: Connection, *, session_id: str, attachments) -> list[dict]:

--- a/tests/test_message_dispatcher_file_uploads.py
+++ b/tests/test_message_dispatcher_file_uploads.py
@@ -94,7 +94,7 @@ class MessageDispatcherFileUploadTests(unittest.IsolatedAsyncioTestCase):
             file_path.write_bytes(b"png")
             escaped_path = str(file_path).replace("(", r"\(").replace(")", r"\)")
             enhanced = process_reply(
-                f'![preview](<file://{escaped_path}> "download")'
+                f'![preview](<FILE://{escaped_path}> "download")'
             )
 
             self.assertEqual(enhanced.text, "preview")

--- a/tests/test_message_dispatcher_file_uploads.py
+++ b/tests/test_message_dispatcher_file_uploads.py
@@ -84,6 +84,27 @@ class MessageDispatcherFileUploadTests(unittest.IsolatedAsyncioTestCase):
         )
         self.assertEqual(im_client.image_uploads, [])
 
+    async def test_angle_image_link_with_title_is_uploaded_as_image(self):
+        dispatcher = ConsolidatedMessageDispatcher(_StubController())
+        im_client = _StubIMClient()
+        context = MessageContext(user_id="U1", channel_id="C1")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            file_path = Path(tmpdir) / "preview (final).png"
+            file_path.write_bytes(b"png")
+            escaped_path = str(file_path).replace("(", r"\(").replace(")", r"\)")
+            enhanced = process_reply(
+                f'![preview](<file://{escaped_path}> "download")'
+            )
+
+            self.assertEqual(enhanced.text, "preview")
+            await dispatcher._upload_file_links(im_client, context, enhanced.files)
+
+        self.assertEqual(
+            im_client.image_uploads,
+            [("C1", str(file_path.resolve()), "preview.png")],
+        )
+
     async def test_upload_file_link_allows_path_outside_cwd(self):
         dispatcher = ConsolidatedMessageDispatcher(_StubController())
         im_client = _StubIMClient()

--- a/tests/test_message_dispatcher_file_uploads.py
+++ b/tests/test_message_dispatcher_file_uploads.py
@@ -139,6 +139,33 @@ class MessageDispatcherFileUploadTests(unittest.IsolatedAsyncioTestCase):
         )
         self.assertEqual(im_client.file_uploads, [])
 
+    async def test_legacy_bare_space_image_after_malformed_prefix_is_uploaded(self):
+        dispatcher = ConsolidatedMessageDispatcher(_StubController())
+        im_client = _StubIMClient()
+        context = MessageContext(user_id="U1", channel_id="C1")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            file_path = Path(tmpdir) / "preview image.png"
+            file_path.write_bytes(b"png")
+            prefix = "[bad](file:///tmp/My Report "
+            enhanced = process_reply(
+                f"{prefix}![preview](file://{file_path})"
+            )
+
+            self.assertEqual(enhanced.text, f"{prefix}preview")
+            self.assertEqual(len(enhanced.files), 1)
+            await dispatcher._upload_file_links(
+                im_client,
+                context,
+                enhanced.files,
+            )
+
+        self.assertEqual(
+            im_client.image_uploads,
+            [("C1", str(file_path.resolve()), "preview.png")],
+        )
+        self.assertEqual(im_client.file_uploads, [])
+
     async def test_upload_file_link_allows_path_outside_cwd(self):
         dispatcher = ConsolidatedMessageDispatcher(_StubController())
         im_client = _StubIMClient()

--- a/tests/test_message_dispatcher_file_uploads.py
+++ b/tests/test_message_dispatcher_file_uploads.py
@@ -90,14 +90,21 @@ class MessageDispatcherFileUploadTests(unittest.IsolatedAsyncioTestCase):
         context = MessageContext(user_id="U1", channel_id="C1")
 
         with tempfile.TemporaryDirectory() as tmpdir:
-            file_path = Path(tmpdir) / "preview (final).png"
+            file_path = Path(tmpdir) / "preview & (final).png"
             file_path.write_bytes(b"png")
-            escaped_path = str(file_path).replace("(", r"\(").replace(")", r"\)")
+            escaped_path = (
+                str(file_path)
+                .replace("&", "&amp;")
+                .replace("(", r"\(")
+                .replace(")", r"\)")
+            )
             enhanced = process_reply(
-                f'![preview](<FILE://{escaped_path}> "download")'
+                f'![preview](<f&#105;le://{escaped_path}> "download") '
+                "and [draft](<file:relative.png>)"
             )
 
-            self.assertEqual(enhanced.text, "preview")
+            self.assertEqual(enhanced.text, "preview and [draft](<file:relative.png>)")
+            self.assertEqual(len(enhanced.files), 1)
             await dispatcher._upload_file_links(im_client, context, enhanced.files)
 
         self.assertEqual(

--- a/tests/test_message_dispatcher_file_uploads.py
+++ b/tests/test_message_dispatcher_file_uploads.py
@@ -112,6 +112,33 @@ class MessageDispatcherFileUploadTests(unittest.IsolatedAsyncioTestCase):
             [("C1", str(file_path.resolve()), "preview.png")],
         )
 
+    async def test_legacy_bare_space_image_ignores_malformed_authority(self):
+        dispatcher = ConsolidatedMessageDispatcher(_StubController())
+        im_client = _StubIMClient()
+        context = MessageContext(user_id="U1", channel_id="C1")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            file_path = Path(tmpdir) / "preview image.png"
+            file_path.write_bytes(b"png")
+            malformed = "[bad](<file://[bad/path>)"
+            enhanced = process_reply(
+                f"![preview](file://{file_path}) and {malformed}"
+            )
+
+            self.assertEqual(enhanced.text, f"preview and {malformed}")
+            self.assertEqual(len(enhanced.files), 1)
+            await dispatcher._upload_file_links(
+                im_client,
+                context,
+                enhanced.files,
+            )
+
+        self.assertEqual(
+            im_client.image_uploads,
+            [("C1", str(file_path.resolve()), "preview.png")],
+        )
+        self.assertEqual(im_client.file_uploads, [])
+
     async def test_upload_file_link_allows_path_outside_cwd(self):
         dispatcher = ConsolidatedMessageDispatcher(_StubController())
         im_client = _StubIMClient()

--- a/tests/test_message_dispatcher_file_uploads.py
+++ b/tests/test_message_dispatcher_file_uploads.py
@@ -7,7 +7,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from core.message_dispatcher import ConsolidatedMessageDispatcher
-from core.reply_enhancer import FileLink
+from core.reply_enhancer import FileLink, process_reply
 from modules.im import MessageContext
 from storage.db import create_sqlite_engine
 from storage.importer import ensure_sqlite_state
@@ -65,6 +65,25 @@ class _SuccessfulWechatIMClient(_FailingWechatIMClient):
 
 
 class MessageDispatcherFileUploadTests(unittest.IsolatedAsyncioTestCase):
+    async def test_angle_wrapped_file_link_is_extracted_and_uploaded(self):
+        dispatcher = ConsolidatedMessageDispatcher(_StubController())
+        im_client = _StubIMClient()
+        context = MessageContext(user_id="U1", channel_id="C1")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            file_path = Path(tmpdir) / "报告 (最终).md"
+            file_path.write_text("report", encoding="utf-8")
+            enhanced = process_reply(f"[下载报告](<file://{file_path}>)")
+
+            self.assertEqual(enhanced.text, "下载报告")
+            await dispatcher._upload_file_links(im_client, context, enhanced.files)
+
+        self.assertEqual(
+            im_client.file_uploads,
+            [("C1", str(file_path.resolve()), "下载报告.md")],
+        )
+        self.assertEqual(im_client.image_uploads, [])
+
     async def test_upload_file_link_allows_path_outside_cwd(self):
         dispatcher = ConsolidatedMessageDispatcher(_StubController())
         im_client = _StubIMClient()

--- a/tests/test_reply_enhancer_platform.py
+++ b/tests/test_reply_enhancer_platform.py
@@ -1962,6 +1962,33 @@ class ReplyEnhancerPlatformTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(enhanced.text, "literal")
         self.assertEqual([file.path for file in enhanced.files], [r"/tmp/a\>b.txt"])
 
+    def test_angle_wrapped_file_links_unescape_all_commonmark_punctuation(self):
+        enhanced = process_reply(r"[report](<file:///tmp/a\(b\)\[c\]\#d.md> 'download')")
+
+        self.assertEqual(enhanced.text, "report")
+        self.assertEqual([file.path for file in enhanced.files], ["/tmp/a(b)[c]#d.md"])
+
+    def test_angle_wrapped_file_links_support_titles_and_reject_bad_titles(self):
+        valid = [
+            '[double](<file:///tmp/report.md> "download")',
+            r"[single](<file:///tmp/report.md> 'download')",
+            r"[paren](<file:///tmp/report.md> (download))",
+        ]
+        for text in valid:
+            with self.subTest(text=text):
+                self.assertEqual(len(process_reply(text).files), 1)
+
+        invalid = [
+            '[unclosed](<file:///tmp/report.md> "download)',
+            r"[nested](<file:///tmp/report.md> (download (copy)))",
+            '[marker](<file:///tmp/report.md> `download`)',
+        ]
+        for text in invalid:
+            with self.subTest(text=text):
+                enhanced = process_reply(text)
+                self.assertEqual(enhanced.text, text)
+                self.assertEqual(enhanced.files, [])
+
     def test_angle_wrapped_file_links_ignore_escaped_openers(self):
         escaped = process_reply(r"\[example](<file:///tmp/report.txt>)")
         even_escaped = process_reply(r"\\[example](<file:///tmp/report.txt>)")
@@ -1970,6 +1997,13 @@ class ReplyEnhancerPlatformTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(escaped.files, [])
         self.assertEqual(even_escaped.text, r"\\example")
         self.assertEqual([file.path for file in even_escaped.files], ["/tmp/report.txt"])
+
+        escaped_image = process_reply(r"\![preview](<file:///tmp/preview.png>)")
+        even_escaped_image = process_reply(r"\\![preview](<file:///tmp/preview.png>)")
+        self.assertEqual(escaped_image.text, r"\!preview")
+        self.assertEqual([file.is_image for file in escaped_image.files], [False])
+        self.assertEqual(even_escaped_image.text, r"\\preview")
+        self.assertEqual([file.is_image for file in even_escaped_image.files], [True])
 
     def test_angle_wrapped_file_links_reject_malformed_markdown_and_code(self):
         specimens = [

--- a/tests/test_reply_enhancer_platform.py
+++ b/tests/test_reply_enhancer_platform.py
@@ -1968,6 +1968,27 @@ class ReplyEnhancerPlatformTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(enhanced.text, "report")
         self.assertEqual([file.path for file in enhanced.files], ["/tmp/a(b)[c]#d.md"])
 
+    def test_angle_wrapped_file_links_commonmark_source_matrix(self):
+        cases = {
+            r"[a\]b](<file:///tmp/report.md>)": "/tmp/report.md",
+            r"[double](<file:///tmp/a\\(b.txt>)": r"/tmp/a\(b.txt",
+            "[refs](<file:///tmp/a&amp;b.txt>)": "/tmp/a&b.txt",
+            "[upper](<FILE:///tmp/upper.txt>)": "/tmp/upper.txt",
+        }
+        for text, expected_path in cases.items():
+            with self.subTest(text=text):
+                enhanced = process_reply(text)
+                self.assertEqual(len(enhanced.files), 1)
+                self.assertEqual(enhanced.files[0].path, expected_path)
+
+    def test_angle_wrapped_file_links_require_whitespace_before_title(self):
+        text = '[report](<file:///tmp/report.md>"download")'
+
+        enhanced = process_reply(text)
+
+        self.assertEqual(enhanced.text, text)
+        self.assertEqual(enhanced.files, [])
+
     def test_angle_wrapped_file_links_support_titles_and_reject_bad_titles(self):
         valid = [
             '[double](<file:///tmp/report.md> "download")',
@@ -1982,6 +2003,7 @@ class ReplyEnhancerPlatformTests(unittest.IsolatedAsyncioTestCase):
             '[unclosed](<file:///tmp/report.md> "download)',
             r"[nested](<file:///tmp/report.md> (download (copy)))",
             '[marker](<file:///tmp/report.md> `download`)',
+            '[no-space](<file:///tmp/report.md>"download")',
         ]
         for text in invalid:
             with self.subTest(text=text):
@@ -2004,6 +2026,14 @@ class ReplyEnhancerPlatformTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual([file.is_image for file in escaped_image.files], [False])
         self.assertEqual(even_escaped_image.text, r"\\preview")
         self.assertEqual([file.is_image for file in even_escaped_image.files], [True])
+
+    def test_angle_wrapped_file_links_ignore_raw_html_attributes(self):
+        text = '<span title="[hidden](<file:///tmp/hidden.txt>)">visible</span>'
+
+        enhanced = process_reply(text)
+
+        self.assertEqual(enhanced.text, text)
+        self.assertEqual(enhanced.files, [])
 
     def test_angle_wrapped_file_links_reject_malformed_markdown_and_code(self):
         specimens = [

--- a/tests/test_reply_enhancer_platform.py
+++ b/tests/test_reply_enhancer_platform.py
@@ -1978,6 +1978,43 @@ class ReplyEnhancerPlatformTests(unittest.IsolatedAsyncioTestCase):
                 self.assertEqual(enhanced.text, text)
                 self.assertEqual(enhanced.files, [])
 
+    def test_legacy_bare_file_link_recovers_after_malformed_prefix(self):
+        text = (
+            "[bad](file:///tmp/My Report "
+            "[ok](file:///tmp/Good Report.md)"
+        )
+
+        enhanced = process_reply(text)
+
+        self.assertEqual(enhanced.text, "[bad](file:///tmp/My Report ok")
+        self.assertEqual(
+            [(file.label, file.path) for file in enhanced.files],
+            [("ok", "/tmp/Good Report.md")],
+        )
+
+    def test_legacy_bare_file_link_recovers_after_multiple_malformed_prefixes(self):
+        text = (
+            "[bad1](file:///tmp/One Report "
+            "[bad2](file:///tmp/Two Report "
+            "[ok](file:///tmp/Good Report.md)"
+        )
+
+        enhanced = process_reply(text)
+
+        self.assertEqual(
+            enhanced.text,
+            "[bad1](file:///tmp/One Report [bad2](file:///tmp/Two Report ok",
+        )
+        self.assertEqual([file.path for file in enhanced.files], ["/tmp/Good Report.md"])
+
+    def test_legacy_bare_file_link_keeps_malformed_source_without_valid_tail(self):
+        text = "[bad](file:///tmp/My Report"
+
+        enhanced = process_reply(text)
+
+        self.assertEqual(enhanced.text, text)
+        self.assertEqual(enhanced.files, [])
+
     def test_angle_wrapped_file_links_unescape_angle_brackets_in_paths(self):
         enhanced = process_reply(r"[report](<file:///tmp/a\>b.md>)")
 
@@ -2190,6 +2227,19 @@ class ReplyEnhancerPlatformTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(enhanced.text, text)
         self.assertEqual(enhanced.files, [])
+        self.assertLess(elapsed, 10.0)
+
+    def test_legacy_bare_file_link_scans_many_malformed_candidates_linearly(self):
+        text = (
+            "[bad](file:///tmp/My Report " * 4000
+            + "[ok](file:///tmp/Good Report.md)"
+        )
+
+        started = time.perf_counter()
+        enhanced = process_reply(text)
+        elapsed = time.perf_counter() - started
+
+        self.assertEqual([file.path for file in enhanced.files], ["/tmp/Good Report.md"])
         self.assertLess(elapsed, 10.0)
 
     def test_unwrapped_file_link_parser_keeps_existing_destination_behavior(self):

--- a/tests/test_reply_enhancer_platform.py
+++ b/tests/test_reply_enhancer_platform.py
@@ -1945,6 +1945,39 @@ class ReplyEnhancerPlatformTests(unittest.IsolatedAsyncioTestCase):
             ],
         )
 
+    def test_legacy_bare_file_links_accept_ascii_spaces(self):
+        enhanced = process_reply(
+            "[download](file:///tmp/My Report.md) and "
+            '![image](file:///tmp/图片 文件.png "preview")'
+        )
+
+        self.assertEqual(enhanced.text, "download and image")
+        self.assertEqual(
+            [(file.path, file.is_image) for file in enhanced.files],
+            [
+                ("/tmp/My Report.md", False),
+                ("/tmp/图片 文件.png", True),
+            ],
+        )
+
+    def test_legacy_bare_file_link_extension_rejects_near_neighbors(self):
+        specimens = [
+            "[newline](file:///tmp/My\nReport.md)",
+            "[tab](file:///tmp/My\tReport.md)",
+            "[unclosed](file:///tmp/My Report.md",
+            "[upper](FILE:///tmp/My Report.md)",
+            "`[code](file:///tmp/My Report.md)`",
+            '<span title="[html](file:///tmp/My Report.md)">visible</span>',
+            '[outer](https://example.com "[inner](file:///tmp/My Report.md)")',
+            r"\[escaped](file:///tmp/My Report.md)",
+        ]
+
+        for text in specimens:
+            with self.subTest(text=text):
+                enhanced = process_reply(text)
+                self.assertEqual(enhanced.text, text)
+                self.assertEqual(enhanced.files, [])
+
     def test_angle_wrapped_file_links_unescape_angle_brackets_in_paths(self):
         enhanced = process_reply(r"[report](<file:///tmp/a\>b.md>)")
 
@@ -2034,6 +2067,37 @@ class ReplyEnhancerPlatformTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(enhanced.text, text)
         self.assertEqual(enhanced.files, [])
 
+    def test_file_link_parser_keeps_malformed_authority_verbatim(self):
+        text = "[bad](<file://[bad/path>)"
+
+        enhanced = process_reply(text)
+
+        self.assertEqual(enhanced.text, text)
+        self.assertEqual(enhanced.files, [])
+
+    def test_file_link_parser_skips_offset_maps_without_captures(self):
+        with patch.object(
+            reply_enhancer,
+            "_inline_source_offsets",
+            wraps=reply_enhancer._inline_source_offsets,
+        ) as source_offsets:
+            enhanced = process_reply("ordinary reply " + "x" * 100000)
+
+        self.assertEqual(enhanced.files, [])
+        source_offsets.assert_not_called()
+
+    def test_file_link_parser_maps_captured_inline_source(self):
+        with patch.object(
+            reply_enhancer,
+            "_inline_source_offsets",
+            wraps=reply_enhancer._inline_source_offsets,
+        ) as source_offsets:
+            enhanced = process_reply("> [report](<file:///tmp/report.md>)")
+
+        self.assertEqual(enhanced.text, "> report")
+        self.assertEqual([file.path for file in enhanced.files], ["/tmp/report.md"])
+        self.assertGreaterEqual(source_offsets.call_count, 1)
+
     def test_angle_wrapped_file_links_require_whitespace_before_title(self):
         text = '[report](<file:///tmp/report.md>"download")'
 
@@ -2115,6 +2179,17 @@ class ReplyEnhancerPlatformTests(unittest.IsolatedAsyncioTestCase):
         elapsed = time.perf_counter() - started
 
         self.assertEqual([file.path for file in enhanced.files], ["/tmp/report.md"])
+        self.assertLess(elapsed, 10.0)
+
+    def test_legacy_bare_file_link_scans_malformed_destination_in_bounded_time(self):
+        text = "[missing](file:///tmp/" + "a " * 50000 + "tail"
+
+        started = time.perf_counter()
+        enhanced = process_reply(text)
+        elapsed = time.perf_counter() - started
+
+        self.assertEqual(enhanced.text, text)
+        self.assertEqual(enhanced.files, [])
         self.assertLess(elapsed, 10.0)
 
     def test_unwrapped_file_link_parser_keeps_existing_destination_behavior(self):

--- a/tests/test_reply_enhancer_platform.py
+++ b/tests/test_reply_enhancer_platform.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import time
 import unittest
 from pathlib import Path
 from types import SimpleNamespace
@@ -1981,6 +1982,58 @@ class ReplyEnhancerPlatformTests(unittest.IsolatedAsyncioTestCase):
                 self.assertEqual(len(enhanced.files), 1)
                 self.assertEqual(enhanced.files[0].path, expected_path)
 
+    def test_file_link_parser_uses_commonmark_link_ownership(self):
+        nested = process_reply("[outer [inner](<file:///tmp/inner.txt>)]")
+        titled = process_reply(
+            '[outer](<file:///tmp/outer.txt> "fake [inner](<file:///tmp/inner.txt>)")'
+        )
+        image_label = process_reply(
+            "[outer ![inner](<file:///tmp/inner.png>)](<file:///tmp/outer.txt>)"
+        )
+
+        self.assertEqual(nested.text, "[outer inner]")
+        self.assertEqual([file.path for file in nested.files], ["/tmp/inner.txt"])
+        self.assertEqual(titled.text, "outer")
+        self.assertEqual([file.path for file in titled.files], ["/tmp/outer.txt"])
+        self.assertEqual(
+            image_label.text,
+            "outer ![inner](<file:///tmp/inner.png>)",
+        )
+        self.assertEqual(
+            [file.path for file in image_label.files],
+            ["/tmp/outer.txt"],
+        )
+
+    def test_file_link_parser_respects_commonmark_html_block_ownership(self):
+        html_block = "<script>\n[hidden](<file:///tmp/hidden.txt>)\n</script>"
+        escaped_tag = r"\<span>[visible](<file:///tmp/visible.txt>)</span>"
+
+        blocked = process_reply(html_block)
+        visible = process_reply(escaped_tag)
+
+        self.assertEqual(blocked.text, html_block)
+        self.assertEqual(blocked.files, [])
+        self.assertEqual(visible.text, r"\<span>visible</span>")
+        self.assertEqual([file.path for file in visible.files], ["/tmp/visible.txt"])
+
+    def test_file_link_parser_normalizes_strict_entities_before_acceptance(self):
+        valid = process_reply("[report](<f&#105;le:///tmp/a&amp;b.txt>)")
+        semicolonless = process_reply("[literal](<file:///tmp/a&amp.txt>)")
+
+        self.assertEqual([file.path for file in valid.files], ["/tmp/a&b.txt"])
+        self.assertEqual(
+            [file.path for file in semicolonless.files],
+            ["/tmp/a&amp.txt"],
+        )
+
+    def test_file_link_parser_keeps_rejected_relative_links_verbatim(self):
+        text = "[draft](<file:relative/report.md>)"
+
+        enhanced = process_reply(text)
+
+        self.assertEqual(enhanced.text, text)
+        self.assertEqual(enhanced.files, [])
+
     def test_angle_wrapped_file_links_require_whitespace_before_title(self):
         text = '[report](<file:///tmp/report.md>"download")'
 
@@ -1994,6 +2047,7 @@ class ReplyEnhancerPlatformTests(unittest.IsolatedAsyncioTestCase):
             '[double](<file:///tmp/report.md> "download")',
             r"[single](<file:///tmp/report.md> 'download')",
             r"[paren](<file:///tmp/report.md> (download))",
+            '[line](<file:///tmp/report.md>\n "download")',
         ]
         for text in valid:
             with self.subTest(text=text):
@@ -2004,6 +2058,7 @@ class ReplyEnhancerPlatformTests(unittest.IsolatedAsyncioTestCase):
             r"[nested](<file:///tmp/report.md> (download (copy)))",
             '[marker](<file:///tmp/report.md> `download`)',
             '[no-space](<file:///tmp/report.md>"download")',
+            '[blank](<file:///tmp/report.md>\n\n"download")',
         ]
         for text in invalid:
             with self.subTest(text=text):
@@ -2041,7 +2096,7 @@ class ReplyEnhancerPlatformTests(unittest.IsolatedAsyncioTestCase):
             "[extra angle](<file:///tmp/report>copy.md>)",
             "[extra open](<<file:///tmp/report.md>>)",
             "[missing label close(<file:///tmp/report.md>)",
-            "[missing close](<file://" + "a" * 10000,
+            "[missing close](<file://" + "a" * 100000,
             "`[inline](<file:///tmp/report.md>)`",
             "```markdown\n[fenced](<file:///tmp/report.md>)\n```",
         ]
@@ -2051,6 +2106,16 @@ class ReplyEnhancerPlatformTests(unittest.IsolatedAsyncioTestCase):
                 enhanced = process_reply(text)
                 self.assertEqual(enhanced.text, text)
                 self.assertEqual(enhanced.files, [])
+
+    def test_file_link_parser_handles_many_openers_in_bounded_time(self):
+        text = "[" * 100000 + "[report](<file:///tmp/report.md>)"
+
+        started = time.perf_counter()
+        enhanced = process_reply(text)
+        elapsed = time.perf_counter() - started
+
+        self.assertEqual([file.path for file in enhanced.files], ["/tmp/report.md"])
+        self.assertLess(elapsed, 10.0)
 
     def test_unwrapped_file_link_parser_keeps_existing_destination_behavior(self):
         enhanced = process_reply("[report](file:///tmp/report>draft.md)")

--- a/tests/test_reply_enhancer_platform.py
+++ b/tests/test_reply_enhancer_platform.py
@@ -1944,6 +1944,12 @@ class ReplyEnhancerPlatformTests(unittest.IsolatedAsyncioTestCase):
             ],
         )
 
+    def test_angle_wrapped_file_links_unescape_angle_brackets_in_paths(self):
+        enhanced = process_reply(r"[report](<file:///tmp/a\>b.md>)")
+
+        self.assertEqual(enhanced.text, "report")
+        self.assertEqual([file.path for file in enhanced.files], ["/tmp/a>b.md"])
+
     def test_angle_wrapped_file_links_reject_malformed_markdown_and_code(self):
         specimens = [
             "[missing close](<file:///tmp/report.md)",

--- a/tests/test_reply_enhancer_platform.py
+++ b/tests/test_reply_enhancer_platform.py
@@ -1950,12 +1950,34 @@ class ReplyEnhancerPlatformTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(enhanced.text, "report")
         self.assertEqual([file.path for file in enhanced.files], ["/tmp/a>b.md"])
 
+    def test_angle_wrapped_file_links_allow_unbalanced_parentheses(self):
+        enhanced = process_reply(r"[draft](<file:///tmp/draft (v1.txt>)")
+
+        self.assertEqual(enhanced.text, "draft")
+        self.assertEqual([file.path for file in enhanced.files], ["/tmp/draft (v1.txt"])
+
+    def test_angle_wrapped_file_links_unescape_before_percent_decoding(self):
+        enhanced = process_reply(r"[literal](<file:///tmp/a%5C%3Eb.txt>)")
+
+        self.assertEqual(enhanced.text, "literal")
+        self.assertEqual([file.path for file in enhanced.files], [r"/tmp/a\>b.txt"])
+
+    def test_angle_wrapped_file_links_ignore_escaped_openers(self):
+        escaped = process_reply(r"\[example](<file:///tmp/report.txt>)")
+        even_escaped = process_reply(r"\\[example](<file:///tmp/report.txt>)")
+
+        self.assertEqual(escaped.text, r"\[example](<file:///tmp/report.txt>)")
+        self.assertEqual(escaped.files, [])
+        self.assertEqual(even_escaped.text, r"\\example")
+        self.assertEqual([file.path for file in even_escaped.files], ["/tmp/report.txt"])
+
     def test_angle_wrapped_file_links_reject_malformed_markdown_and_code(self):
         specimens = [
             "[missing close](<file:///tmp/report.md)",
             "[extra angle](<file:///tmp/report>copy.md>)",
             "[extra open](<<file:///tmp/report.md>>)",
             "[missing label close(<file:///tmp/report.md>)",
+            "[missing close](<file://" + "a" * 10000,
             "`[inline](<file:///tmp/report.md>)`",
             "```markdown\n[fenced](<file:///tmp/report.md>)\n```",
         ]

--- a/tests/test_reply_enhancer_platform.py
+++ b/tests/test_reply_enhancer_platform.py
@@ -1929,6 +1929,46 @@ class ReplyEnhancerPlatformTests(unittest.IsolatedAsyncioTestCase):
             "/Users/test/SaveTwitter.Net_GABV3XNWYAARAZz(gif).mp4",
         )
 
+    def test_angle_wrapped_file_links_accept_commonmark_destinations(self):
+        enhanced = process_reply(
+            "[下载报告](<file:///tmp/My Report (最终).md>) and "
+            "![图片](<file:///tmp/图片 文件.png>)"
+        )
+
+        self.assertEqual(enhanced.text, "下载报告 and 图片")
+        self.assertEqual(
+            [(file.label, file.path, file.is_image) for file in enhanced.files],
+            [
+                ("下载报告", "/tmp/My Report (最终).md", False),
+                ("图片", "/tmp/图片 文件.png", True),
+            ],
+        )
+
+    def test_angle_wrapped_file_links_reject_malformed_markdown_and_code(self):
+        specimens = [
+            "[missing close](<file:///tmp/report.md)",
+            "[extra angle](<file:///tmp/report>copy.md>)",
+            "[extra open](<<file:///tmp/report.md>>)",
+            "[missing label close(<file:///tmp/report.md>)",
+            "`[inline](<file:///tmp/report.md>)`",
+            "```markdown\n[fenced](<file:///tmp/report.md>)\n```",
+        ]
+
+        for text in specimens:
+            with self.subTest(text=text):
+                enhanced = process_reply(text)
+                self.assertEqual(enhanced.text, text)
+                self.assertEqual(enhanced.files, [])
+
+    def test_unwrapped_file_link_parser_keeps_existing_destination_behavior(self):
+        enhanced = process_reply("[report](file:///tmp/report>draft.md)")
+
+        self.assertEqual(enhanced.text, "report")
+        self.assertEqual(
+            [file.path for file in enhanced.files],
+            ["/tmp/report>draft.md"],
+        )
+
     def test_windows_file_uri_is_normalized_before_absolute_check(self):
         with patch("core.reply_enhancer.os.name", "nt"), patch("core.reply_enhancer.os.path.isabs") as isabs:
             isabs.side_effect = lambda value: value == r"C:\Users\test\generated image.png"

--- a/tests/test_workbench_media.py
+++ b/tests/test_workbench_media.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import struct
 import zlib
 from datetime import datetime, timezone
+from unittest.mock import patch
 
 from sqlalchemy import select
 
@@ -155,8 +156,8 @@ def test_rewrite_angle_wrapped_file_links(tmp_path):
         out = rewrite_agent_media(conn, scope_id=scope_id, session_id="sess_x", text=text)
 
     assert "file://" not in out
-    assert out.startswith("![图片](/api/media/")
-    assert "and [下载报告](/api/media/" in out
+    assert out.startswith("![图片](</api/media/")
+    assert "and [下载报告](</api/media/" in out
     with engine.connect() as conn:
         rows = conn.execute(select(media_objects)).mappings().all()
     assert {row["local_path"] for row in rows} == {
@@ -412,5 +413,55 @@ def test_rewrite_angle_file_link_unescapes_path_and_ignores_title(tmp_path):
         scope_id = _seed_scope_and_session(conn)
         out = rewrite_agent_media(conn, scope_id=scope_id, session_id="sess_x", text=text)
 
-    assert out.startswith("[report](/api/media/")
-    assert out.endswith(")")
+    assert out.startswith("[report](</api/media/")
+    assert out.endswith('> "download")')
+
+
+def test_rewrite_commonmark_owned_destination_preserves_source_syntax(tmp_path):
+    db = tmp_path / "vibe.sqlite"
+    run_migrations(db)
+    engine = create_sqlite_engine(db)
+    report = tmp_path / "report & (final).md"
+    report.write_text("report", encoding="utf-8")
+    escaped_report = (
+        str(report)
+        .replace("&", "&amp;")
+        .replace("(", r"\(")
+        .replace(")", r"\)")
+    )
+    text = (
+        f'[outer [report](<f&#105;le://{escaped_report}>\n "download")]'
+        " and [draft](<file:relative.md>)"
+    )
+
+    with engine.begin() as conn:
+        scope_id = _seed_scope_and_session(conn)
+        out = rewrite_agent_media(conn, scope_id=scope_id, session_id="sess_x", text=text)
+
+    assert out.startswith("[outer [report](</api/media/")
+    assert out.endswith('>\n "download")] and [draft](<file:relative.md>)')
+    with engine.connect() as conn:
+        rows = conn.execute(select(media_objects)).mappings().all()
+    assert [row["local_path"] for row in rows] == [str(report.resolve())]
+
+
+def test_rewrite_failure_preserves_original_destination_source(tmp_path):
+    db = tmp_path / "vibe.sqlite"
+    run_migrations(db)
+    engine = create_sqlite_engine(db)
+    text = '[report](<f&#105;le:///tmp/a&amp;b.md> "download")'
+
+    with engine.begin() as conn:
+        scope_id = _seed_scope_and_session(conn)
+        with patch(
+            "core.workbench_media.register_agent_reply_media",
+            side_effect=RuntimeError("registration failed"),
+        ):
+            out = rewrite_agent_media(
+                conn,
+                scope_id=scope_id,
+                session_id="sess_x",
+                text=text,
+            )
+
+    assert out == text

--- a/tests/test_workbench_media.py
+++ b/tests/test_workbench_media.py
@@ -166,6 +166,23 @@ def test_rewrite_angle_wrapped_file_links(tmp_path):
     assert sorted(row["kind"] for row in rows) == ["file", "image"]
 
 
+def test_rewrite_does_not_materialize_file_links_inside_code(tmp_path):
+    db = tmp_path / "vibe.sqlite"
+    run_migrations(db)
+    engine = create_sqlite_engine(db)
+    image = tmp_path / "code.png"
+    image.write_bytes(b"image")
+    text = f"Example `![code](<file://{image}>)` and:\n\n```md\n![fenced](<file://{image}>)\n```"
+
+    with engine.begin() as conn:
+        scope_id = _seed_scope_and_session(conn)
+        out = rewrite_agent_media(conn, scope_id=scope_id, session_id="sess_x", text=text)
+
+    assert out == text
+    with engine.connect() as conn:
+        assert conn.execute(select(media_objects)).first() is None
+
+
 def test_resolve_attachment_specs(tmp_path):
     db = tmp_path / "vibe.sqlite"
     run_migrations(db)

--- a/tests/test_workbench_media.py
+++ b/tests/test_workbench_media.py
@@ -406,7 +406,7 @@ def test_rewrite_angle_file_link_unescapes_path_and_ignores_title(tmp_path):
     report = tmp_path / "report (final).md"
     report.write_text("report", encoding="utf-8")
     escaped_report = str(report).replace("(", "\\(").replace(")", "\\)")
-    text = f'[report](<file://{escaped_report}> "download")'
+    text = f'[report](<FILE://{escaped_report}> "download")'
 
     with engine.begin() as conn:
         scope_id = _seed_scope_and_session(conn)

--- a/tests/test_workbench_media.py
+++ b/tests/test_workbench_media.py
@@ -192,6 +192,30 @@ def test_rewrite_legacy_bare_space_link_and_reject_malformed_authority(tmp_path)
     assert [row["local_path"] for row in rows] == [str(report.resolve())]
 
 
+def test_rewrite_legacy_bare_space_link_after_malformed_prefix(tmp_path):
+    db = tmp_path / "vibe.sqlite"
+    run_migrations(db)
+    engine = create_sqlite_engine(db)
+    report = tmp_path / "Good Report.md"
+    report.write_text("report", encoding="utf-8")
+    prefix = "[bad](file:///tmp/My Report "
+    text = f"{prefix}[report](file://{report})"
+
+    with engine.begin() as conn:
+        scope_id = _seed_scope_and_session(conn)
+        out = rewrite_agent_media(
+            conn,
+            scope_id=scope_id,
+            session_id="sess_x",
+            text=text,
+        )
+
+    assert out.startswith(f"{prefix}[report](/api/media/")
+    with engine.connect() as conn:
+        rows = conn.execute(select(media_objects)).mappings().all()
+    assert [row["local_path"] for row in rows] == [str(report.resolve())]
+
+
 def test_rewrite_does_not_materialize_file_links_inside_code(tmp_path):
     db = tmp_path / "vibe.sqlite"
     run_migrations(db)

--- a/tests/test_workbench_media.py
+++ b/tests/test_workbench_media.py
@@ -167,6 +167,31 @@ def test_rewrite_angle_wrapped_file_links(tmp_path):
     assert sorted(row["kind"] for row in rows) == ["file", "image"]
 
 
+def test_rewrite_legacy_bare_space_link_and_reject_malformed_authority(tmp_path):
+    db = tmp_path / "vibe.sqlite"
+    run_migrations(db)
+    engine = create_sqlite_engine(db)
+    report = tmp_path / "My Report.md"
+    report.write_text("report", encoding="utf-8")
+    malformed = "[bad](<file://[bad/path>)"
+    text = f'[report](file://{report} "download") and {malformed}'
+
+    with engine.begin() as conn:
+        scope_id = _seed_scope_and_session(conn)
+        out = rewrite_agent_media(
+            conn,
+            scope_id=scope_id,
+            session_id="sess_x",
+            text=text,
+        )
+
+    assert out.startswith("[report](/api/media/")
+    assert out.endswith(f' "download") and {malformed}')
+    with engine.connect() as conn:
+        rows = conn.execute(select(media_objects)).mappings().all()
+    assert [row["local_path"] for row in rows] == [str(report.resolve())]
+
+
 def test_rewrite_does_not_materialize_file_links_inside_code(tmp_path):
     db = tmp_path / "vibe.sqlite"
     run_migrations(db)

--- a/tests/test_workbench_media.py
+++ b/tests/test_workbench_media.py
@@ -139,6 +139,33 @@ def test_rewrite_in_place_image_file_and_external(tmp_path):
     assert all(r["source"] == "agent_reply" for r in rows)
 
 
+def test_rewrite_angle_wrapped_file_links(tmp_path):
+    db = tmp_path / "vibe.sqlite"
+    run_migrations(db)
+    engine = create_sqlite_engine(db)
+
+    image = tmp_path / "图片 文件.png"
+    image.write_bytes(b"image")
+    report = tmp_path / "My Report (最终).md"
+    report.write_text("report", encoding="utf-8")
+    text = f"![图片](<file://{image}>) and [下载报告](<file://{report}>)"
+
+    with engine.begin() as conn:
+        scope_id = _seed_scope_and_session(conn)
+        out = rewrite_agent_media(conn, scope_id=scope_id, session_id="sess_x", text=text)
+
+    assert "file://" not in out
+    assert out.startswith("![图片](/api/media/")
+    assert "and [下载报告](/api/media/" in out
+    with engine.connect() as conn:
+        rows = conn.execute(select(media_objects)).mappings().all()
+    assert {row["local_path"] for row in rows} == {
+        str(image.resolve()),
+        str(report.resolve()),
+    }
+    assert sorted(row["kind"] for row in rows) == ["file", "image"]
+
+
 def test_resolve_attachment_specs(tmp_path):
     db = tmp_path / "vibe.sqlite"
     run_migrations(db)

--- a/tests/test_workbench_media.py
+++ b/tests/test_workbench_media.py
@@ -397,3 +397,20 @@ def test_rewrite_appends_image_dimensions(tmp_path):
     # …and a non-image link gets no dimension query.
     assert "/api/media/" in out.split(" and ")[1]
     assert "?w=" not in out.split(" and ")[1]
+
+
+def test_rewrite_angle_file_link_unescapes_path_and_ignores_title(tmp_path):
+    db = tmp_path / "vibe.sqlite"
+    run_migrations(db)
+    engine = create_sqlite_engine(db)
+    report = tmp_path / "report (final).md"
+    report.write_text("report", encoding="utf-8")
+    escaped_report = str(report).replace("(", "\\(").replace(")", "\\)")
+    text = f'[report](<file://{escaped_report}> "download")'
+
+    with engine.begin() as conn:
+        scope_id = _seed_scope_and_session(conn)
+        out = rewrite_agent_media(conn, scope_id=scope_id, session_id="sess_x", text=text)
+
+    assert out.startswith("[report](/api/media/")
+    assert out.endswith(")")


### PR DESCRIPTION
## Summary

- Delegate shared inline `file:` link/image syntax ownership to the repository's existing markdown-it-py CommonMark parser, with a parser-local `file:` validation policy.
- Capture accepted whole-link and destination source spans so IM strips only accepted absolute local file links and Workbench rewrites only the destination.
- Preserve the bounded legacy lowercase bare `file://` space extension while supporting pointy destinations, CommonMark escapes/entities/titles, nested ownership, HTML/code exclusions, and adversarial input.

Fixes #1103.

## Scope

- Changed capability: shared agent-reply `file://` Markdown parsing and its source-span contract.
- Workbench consumer: `rewrite_agent_media` registers accepted absolute local links and replaces only the destination, preserving labels, angle wrappers, whitespace, and titles.
- IM consumer: extraction/upload and text stripping consume the same accepted match set; rejected or malformed links remain verbatim.
- Non-goals preserved: no UI local-path parsing changes, no rework of #1114, no new dependency, no generic renderer/security-policy change, and no non-`file:` Markdown behavior change.

## Scenarios

- `FILE-LINK-PARSER-ANGLE-DESTINATION`: wrapped file/image destinations with spaces, Chinese text, parentheses, escaped punctuation, percent escapes, and strict character references.
- `FILE-LINK-PARSER-BARE-COMPATIBILITY`: lowercase bare absolute `file://` paths retain legacy ASCII-space support, including titles; tabs, newlines, malformed delimiters, uppercase compatibility extensions, code, raw HTML, escaped openers, and nested title content remain ineligible.
- `FILE-LINK-PARSER-RECOVERY`: malformed legacy prefixes remain verbatim while the monotonic compatibility scan continues to later valid links/images without rescanning consumed input.
- `FILE-LINK-PARSER-OWNERSHIP`: nested brackets/images, outer titles containing link-like text, opener escapes, raw HTML, code spans/fences, and complete HTML blocks follow CommonMark ownership without overlapping matches.
- `FILE-LINK-PARSER-ACCEPTANCE`: case-folded/entity-decoded `file:` schemes are accepted only for absolute local paths; relative links and malformed authorities remain unchanged without aborting enhancement.
- `FILE-LINK-PARSER-BOUNDED`: 100k malformed destinations and 100k preceding openers complete within the regression guard; ordinary inline blocks with no capture skip source-offset construction.
- `FILE-LINK-WORKBENCH-MATERIALIZATION`: only the accepted destination span is rewritten to `/api/media/<token>` while wrappers, titles, whitespace, and rejected links are preserved.
- `FILE-LINK-IM-ATTACHMENT-UPLOAD`: accepted wrapped and legacy bare image/file links are extracted and uploaded once; rejected links stay in message text.
- Existing coverage retained: valid CommonMark bare destinations and bare paths containing parentheses.

## Evidence

- Unit: CommonMark destination matrix, strict entities, scheme normalization, legacy bare-space compatibility and invalid neighbors, malformed-prefix recovery, nested ownership/non-overlap, escaped openers/raw tags, HTML/code blocks, optional titles, malformed syntax/authority, absolute-path acceptance, offset-map gating, and 100k bounded-input guards.
- Contract: Workbench destination-only rewrite, exact malformed-prefix preservation with a valid tail, media registration, and bare/angle/title/entity combinations.
- Scenario: IM extraction and upload use the same accepted match set across bare-space images, malformed-prefix recovery, entity-encoded schemes, escaped paths, image titles, and rejected malformed/relative links.
- Residual manual: no live IM or browser regression was run; the shared parser and both consuming boundaries are covered hermetically, with live platform delivery left to the integration regression pass.

## Validation

- `pytest -q tests/test_reply_enhancer_platform.py tests/test_reply_enhancer_secret_requests.py tests/test_workbench_media.py tests/test_message_dispatcher_file_uploads.py` (176 passed, 35 subtests passed)
- `ruff check core/reply_enhancer.py core/workbench_media.py tests/test_reply_enhancer_platform.py tests/test_reply_enhancer_secret_requests.py tests/test_workbench_media.py tests/test_message_dispatcher_file_uploads.py`
