### PR TITLE
fix(release): canonicalize memory runtime temp roots

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -137,6 +137,8 @@ jobs:
           python-version: "3.12"
 
       - name: Build Memory Runtime bundle
+        env:
+          TMPDIR: ${{ runner.temp }}
         run: |
           python scripts/build_memory_runtime.py \
             --output-dir runtime-artifacts \

--- a/.github/workflows/release_ai.yml
+++ b/.github/workflows/release_ai.yml
@@ -116,6 +116,8 @@ jobs:
           python-version: "3.12"
 
       - name: Build Memory Runtime bundle
+        env:
+          TMPDIR: ${{ runner.temp }}
         run: |
           python scripts/build_memory_runtime.py \
             --output-dir runtime-artifacts \

--- a/scripts/build_memory_runtime.py
+++ b/scripts/build_memory_runtime.py
@@ -14,6 +14,8 @@ import sys
 import sysconfig
 import tarfile
 import tempfile
+from collections.abc import Iterator
+from contextlib import contextmanager
 from pathlib import Path, PurePosixPath, PureWindowsPath
 
 
@@ -53,6 +55,15 @@ def _sha256(path: Path) -> str:
         for chunk in iter(lambda: file.read(1024 * 1024), b""):
             digest.update(chunk)
     return digest.hexdigest()
+
+
+@contextmanager
+def _temporary_directory(prefix: str) -> Iterator[Path]:
+    """Create scratch space beneath the canonical system temp directory."""
+
+    temp_root = Path(tempfile.gettempdir()).resolve(strict=True)
+    with tempfile.TemporaryDirectory(prefix=prefix, dir=temp_root) as temporary:
+        yield Path(temporary)
 
 
 def _platform_tag() -> str:
@@ -142,8 +153,8 @@ def create_archive(*, runtime_root: Path, output: Path, platform: str) -> dict[s
 def verify_archive(archive_path: Path, *, binary_sha256: str) -> None:
     """Extract and smoke the final bytes in a new directory."""
 
-    with tempfile.TemporaryDirectory(prefix="avibe-memory-runtime-verify-") as temporary_value:
-        destination = Path(temporary_value) / "runtime"
+    with _temporary_directory("avibe-memory-runtime-verify-") as temporary:
+        destination = temporary / "runtime"
         destination.mkdir()
         destination_resolved = destination.resolve()
         with tarfile.open(archive_path, "r:gz") as archive:
@@ -171,8 +182,8 @@ def verify_archive(archive_path: Path, *, binary_sha256: str) -> None:
         if _sha256(binary) != binary_sha256:
             raise SystemExit("Memory Runtime extracted Python checksum mismatch")
         _smoke(binary, cwd=destination.parent)
-        with tempfile.TemporaryDirectory(prefix="mrv-health-", dir="/tmp") as health_home:
-            _sidecar_health_smoke(binary, effective_home=Path(health_home))
+        with _temporary_directory("mrv-health-") as health_home:
+            _sidecar_health_smoke(binary, effective_home=health_home)
 
 
 def prune_runtime(runtime_root: Path) -> None:
@@ -329,8 +340,7 @@ def build_runtime(
     if uv_identity.split()[:2] != ["uv", UV_VERSION]:
         raise SystemExit(f"Memory Runtime builder requires uv {UV_VERSION}")
 
-    with tempfile.TemporaryDirectory(prefix="avibe-memory-runtime-") as temporary_value:
-        temporary = Path(temporary_value)
+    with _temporary_directory("avibe-memory-runtime-") as temporary:
         _run([uv_command, "python", "install", python_version], cwd=temporary)
         found = _run(
             [uv_command, "python", "find", "--no-project", "--managed-python", python_version],

--- a/scripts/build_memory_runtime.py
+++ b/scripts/build_memory_runtime.py
@@ -66,6 +66,15 @@ def _temporary_directory(prefix: str) -> Iterator[Path]:
         yield Path(temporary)
 
 
+@contextmanager
+def _short_socket_directory(prefix: str) -> Iterator[Path]:
+    """Create canonical scratch space short enough for Unix-domain sockets."""
+
+    temp_root = Path("/tmp").resolve(strict=True)
+    with tempfile.TemporaryDirectory(prefix=prefix, dir=temp_root) as temporary:
+        yield Path(temporary)
+
+
 def _platform_tag() -> str:
     raw = sysconfig.get_platform().lower()
     machine = raw.rsplit("-", 1)[-1]
@@ -182,7 +191,7 @@ def verify_archive(archive_path: Path, *, binary_sha256: str) -> None:
         if _sha256(binary) != binary_sha256:
             raise SystemExit("Memory Runtime extracted Python checksum mismatch")
         _smoke(binary, cwd=destination.parent)
-        with _temporary_directory("mrv-health-") as health_home:
+        with _short_socket_directory("mrv-") as health_home:
             _sidecar_health_smoke(binary, effective_home=health_home)
 
 

--- a/tests/test_memory_runtime_release.py
+++ b/tests/test_memory_runtime_release.py
@@ -17,6 +17,7 @@ from scripts.build_memory_runtime import (
     LOCK_SHA256,
     PYTHON_VERSION,
     UV_VERSION,
+    _short_socket_directory,
     _temporary_directory,
     create_archive,
     prune_runtime,
@@ -66,6 +67,21 @@ def test_memory_runtime_scratch_paths_resolve_the_system_temp_root(
     with _temporary_directory("memory-runtime-test-") as scratch:
         assert scratch.parent == real_temp.resolve(strict=True)
         assert scratch == scratch.resolve(strict=True)
+
+
+def test_memory_runtime_health_home_uses_a_short_canonical_root(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    long_temp = tmp_path / ("long-temp-" * 12)
+    long_temp.mkdir()
+    monkeypatch.setattr(tempfile, "tempdir", str(long_temp))
+
+    with _short_socket_directory("mrv-") as health_home:
+        socket_path = health_home / "memory" / ".rt" / "everos.sock"
+        assert health_home.parent == Path("/tmp").resolve(strict=True)
+        assert health_home == health_home.resolve(strict=True)
+        assert len(os.fsencode(socket_path)) < 104
 
 
 def test_github_only_release_runs_memory_runtime_guard_before_uploading_assets() -> None:

--- a/tests/test_memory_runtime_release.py
+++ b/tests/test_memory_runtime_release.py
@@ -5,6 +5,7 @@ import io
 import json
 import os
 import tarfile
+import tempfile
 from pathlib import Path
 
 import pytest
@@ -16,6 +17,7 @@ from scripts.build_memory_runtime import (
     LOCK_SHA256,
     PYTHON_VERSION,
     UV_VERSION,
+    _temporary_directory,
     create_archive,
     prune_runtime,
 )
@@ -39,6 +41,31 @@ def test_release_workflows_emit_metadata_for_the_current_runtime_version() -> No
         workflow = (workflows / name).read_text(encoding="utf-8")
         assert expected in workflow
         assert "memory-runtime-1.2.1-${{ matrix.artifact }}.json" not in workflow
+
+
+def test_release_workflows_build_memory_runtime_under_runner_temp() -> None:
+    workflows = Path(__file__).resolve().parents[1] / ".github/workflows"
+
+    for name in ("release_ai.yml", "publish.yml"):
+        workflow = (workflows / name).read_text(encoding="utf-8")
+        build_step = workflow.split("- name: Build Memory Runtime bundle", 1)[1]
+        build_step = build_step.split("- name: Upload Memory Runtime bundle", 1)[0]
+        assert "TMPDIR: ${{ runner.temp }}" in build_step
+
+
+def test_memory_runtime_scratch_paths_resolve_the_system_temp_root(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    real_temp = tmp_path / "real-temp"
+    real_temp.mkdir()
+    linked_temp = tmp_path / "linked-temp"
+    linked_temp.symlink_to(real_temp, target_is_directory=True)
+    monkeypatch.setattr(tempfile, "tempdir", str(linked_temp))
+
+    with _temporary_directory("memory-runtime-test-") as scratch:
+        assert scratch.parent == real_temp.resolve(strict=True)
+        assert scratch == scratch.resolve(strict=True)
 
 
 def test_github_only_release_runs_memory_runtime_guard_before_uploading_assets() -> None:


### PR DESCRIPTION
## Summary

- canonicalize Memory Runtime scratch directories before build and archive verification
- keep the health-check Unix socket under a short canonical root
- force both release workflows to use the GitHub runner's canonical temporary directory
- prevent macOS `/var -> /private/var` aliases from failing provider-root symlink admission

## Release impact

This unblocks a new `gh-v3.0.11rc3` prerelease from a post-merge commit. The failed `v3.0.11` tag remains immutable and will not be rerun or published; no Release assets or PyPI distributions exist for it.

## Evidence

- Unit: `tests/test_memory_runtime_release.py` (14 passed)
- Contract: both release workflows assert `TMPDIR: ${{ runner.temp }}` for Memory Runtime builds
- Scenario: simulated a symlinked system temp root and a long `TMPDIR`; scratch roots remain canonical and the health socket path stays below the macOS limit
- Manual: built the complete `darwin-arm64` Memory Runtime with pinned `uv 0.9.18`; archive verification, sidecar startup, and UDS health all passed
- Residual: exact GitHub macOS ARM workflow execution after merge
