### PR TITLE
fix(model-hub): honor agent chain guard plans

### DIFF
--- a/core/handlers/model_hub/service.py
+++ b/core/handlers/model_hub/service.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import time
 import uuid
@@ -253,6 +254,19 @@ AttemptObserver = Callable[
     ],
     None,
 ]
+
+
+def _same_json_value(left: object, right: object) -> bool:
+    try:
+        options = {
+            "allow_nan": False,
+            "ensure_ascii": False,
+            "separators": (",", ":"),
+            "sort_keys": True,
+        }
+        return json.dumps(left, **options) == json.dumps(right, **options)
+    except (TypeError, ValueError):
+        return False
 
 
 def _utc_now() -> datetime:
@@ -2659,7 +2673,8 @@ class ModelHubService:
             or not isinstance(model_id, str)
             or not model_id.strip()
             or not isinstance(payload, dict)
-            or set(payload) - {"hops", "force"}
+            or set(payload)
+            - {"hops", "force", "would_remove_hops", "would_interrupt"}
             or "hops" not in payload
             or ("force" in payload and not isinstance(payload["force"], bool))
         ):
@@ -2688,16 +2703,20 @@ class ModelHubService:
                     model.id == hop.model_id for model in source.models
                 ):
                     raise ModelHubError("mapping_target_unavailable", status=409)
+            new_pairs = {
+                (item.source_id, item.model_id)
+                for item in route.hops
+            }
             removed_hops = [
                 {
                     "backend": backend,
                     "menu_model": model_id,
                     "source_id": hop.source_id,
                     "model_id": hop.model_id,
+                    "position": position,
                 }
-                for hop in old_route.hops
-                if (hop.source_id, hop.model_id)
-                not in {(item.source_id, item.model_id) for item in route.hops}
+                for position, hop in enumerate(old_route.hops, start=1)
+                if (hop.source_id, hop.model_id) not in new_pairs
             ]
             agent.routes[model_id] = route
             interrupted = self._introduced_interruptions(
@@ -2709,7 +2728,18 @@ class ModelHubService:
                     else frozenset()
                 ),
             )
-            if interrupted and payload.get("force") is not True:
+            confirmed = (
+                payload.get("force") is True
+                and _same_json_value(
+                    payload.get("would_remove_hops"),
+                    removed_hops,
+                )
+                and _same_json_value(
+                    payload.get("would_interrupt"),
+                    interrupted,
+                )
+            )
+            if interrupted and not confirmed:
                 raise ModelHubError(
                     "source_last_supplier",
                     status=409,

--- a/tests/test_model_hub_api.py
+++ b/tests/test_model_hub_api.py
@@ -326,6 +326,33 @@ def _refresh_fixture_routes(config: ModelHubConfig) -> None:
                 route.hops = (*route.hops, ModelHubRouteHopConfig(source.id, model.id))
 
 
+def _set_claude_route_fixture(
+    store: MemoryStore,
+    source_ids: tuple[str, ...],
+    model_id: str,
+) -> tuple[ModelHubRouteHopConfig, ...]:
+    sources = [
+        ModelHubSourceConfig(
+            id=source_id,
+            kind="api_key",
+            vendor="anthropic",
+            display_name=source_id,
+            protocol="anthropic",
+            supply_channel="hub",
+            billing="metered",
+            state=ModelHubSourceStateConfig(status="standby"),
+            models=[ModelHubModelConfig(id=model_id, provenance="discovered")],
+            credential_ref=f"cred_{source_id}",
+        )
+        for source_id in source_ids
+    ]
+    hops = tuple(ModelHubRouteHopConfig(source.id, model_id) for source in sources)
+    store.config.sources = sources
+    store.config.agents["claude"].sources.order = list(source_ids)
+    store.config.agents["claude"].routes[model_id] = ModelHubRouteConfig(hops=hops)
+    return hops
+
+
 async def _create_source(service: ModelHubService, payload: dict) -> dict:
     return (await service.create_source(payload))["source"]
 
@@ -1069,6 +1096,147 @@ def test_chain_route_preserves_submitted_hops_against_opposite_source_order(
         (hop.source_id, hop.model_id)
         for hop in store.config.agents["claude"].routes[model_id].hops
     ] == [(hop["source_id"], hop["model_id"]) for hop in hops]
+
+
+def test_chain_route_guard_requires_and_replays_the_exact_current_plan(
+    monkeypatch, tmp_path
+):
+    service, store, _ = _service(tmp_path)
+    model_id = "claude-opus-4-6"
+    first_id, second_id = "src_chain0101", "src_chain0102"
+    old_hops = _set_claude_route_fixture(
+        store,
+        (first_id, second_id),
+        model_id,
+    )
+    monkeypatch.setattr(ui_server, "_model_hub_service", lambda: service)
+    client = app.test_client()
+    base_url = "http://127.0.0.1:15131"
+    headers = csrf_headers(client, base_url)
+    endpoint = f"/api/models/agents/claude/chain?model={model_id}"
+
+    refused = client.put(
+        endpoint,
+        json={"hops": []},
+        headers=headers,
+        base_url=base_url,
+    )
+
+    assert refused.status_code == 409
+    refusal = refused.get_json()
+    _assert_envelope(refusal, ok=False)
+    assert refusal["error"] == "source_last_supplier"
+    assert refusal["would_remove_hops"] == [
+        {
+            "backend": "claude",
+            "menu_model": model_id,
+            "source_id": first_id,
+            "model_id": model_id,
+            "position": 1,
+        },
+        {
+            "backend": "claude",
+            "menu_model": model_id,
+            "source_id": second_id,
+            "model_id": model_id,
+            "position": 2,
+        },
+    ]
+    assert refusal["would_interrupt"] == [
+        {"backend": "claude", "model_id": model_id, "agents": []}
+    ]
+
+    unconfirmed = client.put(
+        endpoint,
+        json={
+            "hops": [],
+            "force": True,
+            "would_remove_hops": [
+                {**refusal["would_remove_hops"][0], "position": True},
+                refusal["would_remove_hops"][1],
+            ],
+            "would_interrupt": refusal["would_interrupt"],
+        },
+        headers=headers,
+        base_url=base_url,
+    )
+
+    assert unconfirmed.status_code == 409
+    assert unconfirmed.get_json()["would_remove_hops"] == refusal["would_remove_hops"]
+    assert [
+        (hop.source_id, hop.model_id)
+        for hop in store.config.agents["claude"].routes[model_id].hops
+    ] == [(hop.source_id, hop.model_id) for hop in old_hops]
+
+    committed = client.put(
+        endpoint,
+        json={
+            "hops": [],
+            "force": True,
+            "would_remove_hops": refusal["would_remove_hops"],
+            "would_interrupt": refusal["would_interrupt"],
+        },
+        headers=headers,
+        base_url=base_url,
+    )
+
+    assert committed.status_code == 200
+    success = committed.get_json()
+    assert json.dumps(success["removed_hops"], separators=(",", ":")) == json.dumps(
+        refusal["would_remove_hops"], separators=(",", ":")
+    )
+    assert json.dumps(success["interrupted"], separators=(",", ":")) == json.dumps(
+        refusal["would_interrupt"], separators=(",", ":")
+    )
+    assert success["chain"]["chain"] == []
+    assert store.config.agents["claude"].routes[model_id].hops == ()
+
+
+def test_chain_route_noninterrupting_success_is_force_invariant(monkeypatch, tmp_path):
+    unforced_service, unforced_store, _ = _service(tmp_path / "unforced")
+    model_id = "claude-opus-4-6"
+    first_id, second_id = "src_chain0201", "src_chain0202"
+    _set_claude_route_fixture(
+        unforced_store,
+        (first_id, second_id),
+        model_id,
+    )
+    forced_service, forced_store, _ = _service(tmp_path / "forced")
+    forced_store.config = ModelHubConfig.from_payload(
+        unforced_store.config.to_payload()
+    )
+    client = app.test_client()
+    base_url = "http://127.0.0.1:15131"
+    headers = csrf_headers(client, base_url)
+    endpoint = f"/api/models/agents/claude/chain?model={model_id}"
+    hops = [{"source_id": first_id, "model_id": model_id}]
+
+    monkeypatch.setattr(ui_server, "_model_hub_service", lambda: unforced_service)
+    unforced = client.put(
+        endpoint,
+        json={"hops": hops},
+        headers=headers,
+        base_url=base_url,
+    )
+    monkeypatch.setattr(ui_server, "_model_hub_service", lambda: forced_service)
+    forced = client.put(
+        endpoint,
+        json={"hops": hops, "force": True},
+        headers=headers,
+        base_url=base_url,
+    )
+
+    assert unforced.status_code == forced.status_code == 200
+    assert unforced.content == forced.content
+    assert unforced.get_json()["removed_hops"] == [
+        {
+            "backend": "claude",
+            "menu_model": model_id,
+            "source_id": second_id,
+            "model_id": model_id,
+            "position": 2,
+        }
+    ]
 
 
 def test_delete_guard_reports_only_routes_emptied_by_this_mutation(tmp_path):

--- a/tests/test_model_hub_resolution.py
+++ b/tests/test_model_hub_resolution.py
@@ -1132,6 +1132,7 @@ def test_set_agent_chain_reports_complete_removed_hops_without_syncing(tmp_path)
             "menu_model": menu_model,
             "source_id": second.id,
             "model_id": menu_model,
+            "position": 2,
         }
     ]
     assert adapter.synced == []


### PR DESCRIPTION
## Summary

- accept and verify the frozen guard-plan echo on `set_agent_chain`
- reject forced destructive writes unless both recomputed plan arrays match exact JSON values
- report every removed hop with its one-based pre-mutation `position`
- preserve ordinary success for noninterrupting removals, with byte-identical forced and unforced responses

## Contract authority

- `docs/plans/model-hub-contracts/api.md` -> **Exact Route-chain configuration**
- `docs/plans/model-hub-contracts/api.md` -> **Supply guard**, including the `mutation.route_replace` decision matrix

Contract file is read-only in this PR.

## Review context

- [r3766941269](https://github.com/avibe-bot/avibe/pull/1371#discussion_r3766941269): confirmed requests were rejected because the live handler did not accept guard-plan fields
- [r3766941276](https://github.com/avibe-bot/avibe/pull/1371#discussion_r3766941276): `removed_hops` omitted the required pre-mutation position

## Evidence

- **Unit:** complete Model Hub resolution suite passed (71 tests), including existing guard behavior
- **Contract/API:** Model Hub resolution, API, and config suites passed together (329 tests); new public-route coverage verifies complete 409 plans, exact confirmation, one-based positions, and byte-identical forced/unforced noninterrupting success
- **Scenario:** no Model Hub scenario-catalog ID covers Route-chain mutation; no catalog entry is affected
- **Residual manual:** frame-02 UI integration remains in its owning lane; its end-to-end confirmation flow is deferred to the orchestrator integration pass

## Dependencies

None. PR #1312 currently changes other Model Hub service behavior and is not a functional dependency.
