### PR TITLE
fix(memory): admit artifacts during fenced recovery

### DIFF
--- a/config/v2_config.py
+++ b/config/v2_config.py
@@ -12,7 +12,7 @@ from copy import deepcopy
 from dataclasses import dataclass, field, fields
 from datetime import datetime
 from pathlib import Path
-from typing import Callable, ClassVar, Iterator, List, Literal, Mapping, Optional, Union
+from typing import Callable, ClassVar, Iterator, List, Literal, Mapping, Optional, Union, get_args
 from urllib.parse import parse_qsl, urlsplit, urlunsplit
 
 from config import paths
@@ -1423,6 +1423,10 @@ class MemoryDiagnosticsConfig:
         self.log_provider_calls = True
 
 
+MemoryRecoveryIntent = Literal["rebuild", "factory_reset"]
+MEMORY_RECOVERY_INTENTS = frozenset(get_args(MemoryRecoveryIntent))
+
+
 @dataclass
 class MemoryConfig:
     """Persisted local EverOS configuration; credentials are API-write-only."""
@@ -1430,14 +1434,14 @@ class MemoryConfig:
     enabled: bool = False
     processing: MemoryProcessingConfig = field(default_factory=MemoryProcessingConfig)
     diagnostics: MemoryDiagnosticsConfig = field(default_factory=MemoryDiagnosticsConfig)
-    recovery_intent: Literal["rebuild", "factory_reset"] | None = None
+    recovery_intent: MemoryRecoveryIntent | None = None
 
     def validate(self) -> None:
         if not isinstance(self.enabled, bool):
             raise ValueError("Config 'memory.enabled' must be a boolean")
         if self.recovery_intent is not None and (
             not isinstance(self.recovery_intent, str)
-            or self.recovery_intent not in {"rebuild", "factory_reset"}
+            or self.recovery_intent not in MEMORY_RECOVERY_INTENTS
         ):
             raise ValueError(
                 "Config 'memory.recovery_intent' must be 'rebuild', 'factory_reset', or null"
@@ -1591,7 +1595,7 @@ def memory_config_from_payload(payload: object) -> MemoryConfig:
         recovery_intent = payload.get("recovery_intent")
         if recovery_intent is not None and (
             not isinstance(recovery_intent, str)
-            or recovery_intent not in {"rebuild", "factory_reset"}
+            or recovery_intent not in MEMORY_RECOVERY_INTENTS
         ):
             raise ValueError(
                 "Config 'memory.recovery_intent' must be 'rebuild', 'factory_reset', or null"

--- a/core/memory/runtime.py
+++ b/core/memory/runtime.py
@@ -2389,6 +2389,34 @@ class MemoryRuntime:
                     "ok": True,
                     "result": "completed_empty",
                 }
+                # Empty rebuilds still own a provider-root format transition.
+                # Complete and verify it before clearing the durable retry fence.
+                try:
+                    async with self.module.provider_root_lifecycle():
+                        meta = await asyncio.to_thread(self._store.ensure_meta)
+                        active_metadata = self._active_provider_root_metadata()
+                        root_rollback = await run_blocking(
+                            self._provider_root_owner.activate_empty_format,
+                            meta,
+                            active_metadata,
+                        )
+                        try:
+                            await run_blocking(
+                                self._provider_root_owner.ensure,
+                                meta,
+                                active_metadata,
+                            )
+                        except Exception:
+                            if root_rollback is not None:
+                                await run_blocking(root_rollback.rollback)
+                            raise
+                except Exception:
+                    self._runtime_error = "memory_rebuild_failed"
+                    return {
+                        "ok": False,
+                        "error": self._runtime_error,
+                        "result": "failed",
+                    }
 
             settled = await run_blocking(
                 self._settle_rebuild_intent,

--- a/core/memory/runtime.py
+++ b/core/memory/runtime.py
@@ -446,18 +446,22 @@ class MemoryRuntime:
             for config in (self._config, self._restart_config)
         )
 
-    def _durable_recovery_pending(self) -> bool:
-        """Verify pointer-only repair authority from the persisted config."""
+    def _durable_recovery_intent(self) -> str | None:
+        """Return the persisted recovery intent matching this runtime fence."""
 
         try:
             durable_intent = V2Config.load().memory.recovery_intent
         except Exception:
             logger.exception("Memory artifact admission could not load durable recovery intent")
-            return False
-        return durable_intent in MEMORY_RECOVERY_INTENTS and any(
+            return None
+        if durable_intent not in MEMORY_RECOVERY_INTENTS:
+            return None
+        if not any(
             config.recovery_intent == durable_intent
             for config in (self._config, self._restart_config)
-        )
+        ):
+            return None
+        return durable_intent
 
     @property
     def factory_reset_pending(self) -> bool:
@@ -2628,15 +2632,23 @@ class MemoryRuntime:
     ) -> None:
         """Bridge the synchronous shared installer into the controller loop."""
 
-        # A durable recovery marker deliberately fences runtime activation.
-        # Repair still needs to publish an admitted pointer so explicit Retry
-        # can proceed, but it must not resurrect the pending runtime.
-        if self.recovery_pending and self._durable_recovery_pending():
+        # Factory reset deletes retained roots, so its durable fence may admit
+        # the pointer without inspecting them. Rebuild preserves retained data
+        # and therefore requires ProviderRoot.inspect() to have established
+        # compatibility before pointer-only admission.
+        durable_intent = (
+            self._durable_recovery_intent() if self.recovery_pending else None
+        )
+        if durable_intent == "factory_reset":
             commit()
             return
 
         if root_state is None:
             raise MemoryRuntimeActivationError("memory provider root could not be inspected")
+
+        if durable_intent == "rebuild":
+            commit()
+            return
 
         loop = self._activation_loop
         if loop is None or loop.is_closed():

--- a/core/memory/runtime.py
+++ b/core/memory/runtime.py
@@ -446,6 +446,19 @@ class MemoryRuntime:
             for config in (self._config, self._restart_config)
         )
 
+    def _durable_recovery_pending(self) -> bool:
+        """Verify pointer-only repair authority from the persisted config."""
+
+        try:
+            durable_intent = V2Config.load().memory.recovery_intent
+        except Exception:
+            logger.exception("Memory artifact admission could not load durable recovery intent")
+            return False
+        return durable_intent in MEMORY_RECOVERY_INTENTS and any(
+            config.recovery_intent == durable_intent
+            for config in (self._config, self._restart_config)
+        )
+
     @property
     def factory_reset_pending(self) -> bool:
         """Whether this aggregate is fenced by a durable factory-reset intent."""
@@ -2618,7 +2631,7 @@ class MemoryRuntime:
         # A durable recovery marker deliberately fences runtime activation.
         # Repair still needs to publish an admitted pointer so explicit Retry
         # can proceed, but it must not resurrect the pending runtime.
-        if self.recovery_pending:
+        if self.recovery_pending and self._durable_recovery_pending():
             commit()
             return
 

--- a/core/memory/runtime.py
+++ b/core/memory/runtime.py
@@ -18,7 +18,12 @@ from pathlib import Path
 from typing import Any, TypeVar
 
 from config import paths
-from config.v2_config import MemoryConfig, V2Config, atomic_update_memory
+from config.v2_config import (
+    MEMORY_RECOVERY_INTENTS,
+    MemoryConfig,
+    V2Config,
+    atomic_update_memory,
+)
 from core.memory.artifact import (
     EVEROS_VERSION,
     MemoryArtifactCandidate,
@@ -419,7 +424,7 @@ class MemoryRuntime:
         self._store = opened
         self._module = module
         self._require_maintenance().attach_store(opened)
-        if self._maintenance_open() or self.factory_reset_pending:
+        if self._maintenance_open() or self.recovery_pending:
             module.pause_claims()
         self._store_error = None
         self._configure_insight_reader(self._config)
@@ -431,6 +436,15 @@ class MemoryRuntime:
         """Whether the local store opened. False keeps every read closed."""
 
         return self._module is not None and not self._retired
+
+    @property
+    def recovery_pending(self) -> bool:
+        """Whether this aggregate is fenced by any durable recovery intent."""
+
+        return any(
+            getattr(config, "recovery_intent", None) in MEMORY_RECOVERY_INTENTS
+            for config in (self._config, self._restart_config)
+        )
 
     @property
     def factory_reset_pending(self) -> bool:
@@ -2089,7 +2103,7 @@ class MemoryRuntime:
         replay = deepcopy(self._restart_config)
         if not replay.enabled:
             return {"ok": False, "error": "memory_disabled"}
-        if replay.recovery_intent in {"rebuild", "factory_reset"}:
+        if replay.recovery_intent in MEMORY_RECOVERY_INTENTS:
             if replay.recovery_intent == "factory_reset":
                 return {"ok": False, "error": "memory_operation_in_progress"}
             return {"ok": False, "error": "memory_embedding_rebuild_required"}
@@ -2601,13 +2615,10 @@ class MemoryRuntime:
     ) -> None:
         """Bridge the synchronous shared installer into the controller loop."""
 
-        # A durable factory-reset marker deliberately fences runtime activation.
-        # Repair still needs to publish an admitted pointer so the next reset
-        # attempt can proceed, but it must not resurrect the pending runtime.
-        if (
-            getattr(self._config, "recovery_intent", None) == "factory_reset"
-            or getattr(self._restart_config, "recovery_intent", None) == "factory_reset"
-        ):
+        # A durable recovery marker deliberately fences runtime activation.
+        # Repair still needs to publish an admitted pointer so explicit Retry
+        # can proceed, but it must not resurrect the pending runtime.
+        if self.recovery_pending:
             commit()
             return
 

--- a/tests/scenarios/memory_rebuild_recovery/catalog.yaml
+++ b/tests/scenarios/memory_rebuild_recovery/catalog.yaml
@@ -53,3 +53,12 @@ scenarios:
     given: The user has confirmed a different embedding identity
     when: The rebuild reports that the provider root is busy
     then: The closed error is returned and the candidate plus rebuild intent remain durable for Retry
+  - id: MEMORY-REBUILD-202
+    name: Missing runtime artifact can be admitted while rebuild remains fenced
+    status: covered
+    kind: recovery
+    layer: scenario
+    test: tests/test_memory_runtime.py::test_pending_rebuild_install_publishes_artifact_for_explicit_retry
+    given: A rebuild intent is durable and no managed Memory runtime artifact is admitted
+    when: Dependencies installs a valid artifact and the user explicitly retries rebuild
+    then: Install publishes only the admitted pointer with claims and sidecar fenced, and Retry consumes the artifact and clears the intent on success

--- a/tests/test_memory_runtime.py
+++ b/tests/test_memory_runtime.py
@@ -49,6 +49,7 @@ from core.memory.process import (
     FakeEverOSProcessFactory,
     RebuildProcessResult,
 )
+from core.memory.provider_root import ProviderRootMetadata
 from core.memory.runtime import (
     MemoryRuntime,
     MemorySessionLifecycleBusyError,
@@ -5609,6 +5610,134 @@ async def test_runtime_rebuild_empty_root_settles_without_child(
     await memory_runtime_factory.close(runtime)
 
 
+async def test_runtime_rebuild_finalizes_incompatible_empty_root_before_settlement(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    memory_runtime_factory,
+) -> None:
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    candidate = MemoryConfig(
+        enabled=True,
+        processing=_processing_config(),
+        recovery_intent="rebuild",
+    )
+    V2Config(
+        mode="self_host",
+        version="v2",
+        slack=SlackConfig(bot_token=""),
+        runtime=RuntimeConfig(default_cwd="."),
+        agents=AgentsConfig(),
+        memory=candidate,
+    ).save()
+    artifact = _installed_artifact(
+        root_format="everos-2.0",
+        fingerprint="artifact-2.0",
+        compatible_formats=frozenset({"everos-2.0"}),
+    )
+    runtime = memory_runtime_factory(
+        candidate,
+        artifact_manager=artifact,
+        process_factory=FakeEverOSProcessFactory(),
+        effective_home=tmp_path,
+    )
+    meta = runtime._store.ensure_meta()
+    previous = ProviderRootMetadata(
+        provider_root_format="everos-1.0",
+        compatible_provider_root_formats=frozenset({"everos-1.0"}),
+        artifact_fingerprint="artifact-1.0",
+    )
+    runtime._provider_root_owner.ensure(meta, previous)
+    settlement_formats: list[str | None] = []
+    settle_rebuild_intent = runtime._settle_rebuild_intent
+
+    def settle_after_root_finalization(config: MemoryConfig):
+        root_state = runtime._provider_root_owner.inspect(
+            runtime._active_provider_root_metadata()
+        )
+        settlement_formats.append(root_state.provider_root_format)
+        return settle_rebuild_intent(config)
+
+    monkeypatch.setattr(
+        runtime,
+        "_settle_rebuild_intent",
+        settle_after_root_finalization,
+    )
+
+    assert await runtime.rebuild() == {
+        "ok": True,
+        "result": "completed_empty",
+        "state": "ready",
+    }
+    root_state = runtime._provider_root_owner.inspect(
+        runtime._active_provider_root_metadata()
+    )
+    assert root_state.provider_root_format == "everos-2.0"
+    assert root_state.empty is True
+    assert settlement_formats == ["everos-2.0"]
+    assert V2Config.load().memory.recovery_intent is None
+    await memory_runtime_factory.close(runtime)
+
+
+@pytest.mark.parametrize("failure_stage", ["activate", "ensure"])
+async def test_runtime_rebuild_empty_root_transition_failure_retains_marker(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    memory_runtime_factory,
+    failure_stage: str,
+) -> None:
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    candidate = MemoryConfig(
+        enabled=True,
+        processing=_processing_config(),
+        recovery_intent="rebuild",
+    )
+    V2Config(
+        mode="self_host",
+        version="v2",
+        slack=SlackConfig(bot_token=""),
+        runtime=RuntimeConfig(default_cwd="."),
+        agents=AgentsConfig(),
+        memory=candidate,
+    ).save()
+    runtime = memory_runtime_factory(
+        candidate,
+        artifact_manager=_installed_artifact(
+            root_format="everos-2.0",
+            fingerprint="artifact-2.0",
+            compatible_formats=frozenset({"everos-2.0"}),
+        ),
+        process_factory=FakeEverOSProcessFactory(),
+        effective_home=tmp_path,
+    )
+    meta = runtime._store.ensure_meta()
+    previous = ProviderRootMetadata(
+        provider_root_format="everos-1.0",
+        compatible_provider_root_formats=frozenset({"everos-1.0"}),
+        artifact_fingerprint="artifact-1.0",
+    )
+    runtime._provider_root_owner.ensure(meta, previous)
+
+    def fail_transition(*_args, **_kwargs):
+        raise RuntimeError(f"injected {failure_stage} failure")
+
+    monkeypatch.setattr(
+        runtime._provider_root_owner,
+        "activate_empty_format" if failure_stage == "activate" else "ensure",
+        fail_transition,
+    )
+
+    assert await runtime.rebuild() == {
+        "ok": False,
+        "error": "memory_rebuild_failed",
+        "result": "failed",
+    }
+    assert V2Config.load().memory.recovery_intent == "rebuild"
+    assert runtime._config.recovery_intent == "rebuild"
+    assert runtime._restart_config.recovery_intent == "rebuild"
+    assert runtime._provider_root_owner.inspect(previous).provider_root_format == "everos-1.0"
+    await memory_runtime_factory.close(runtime)
+
+
 async def test_runtime_rebuild_reads_key_correction_after_admission_gap(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -6007,7 +6136,7 @@ async def test_cancelled_rebuild_caller_still_refreshes_settled_config(
     await memory_runtime_factory.close(runtime)
 
 
-async def test_runtime_rebuild_keeps_completed_result_when_root_activation_fails(
+async def test_runtime_rebuild_retains_marker_when_root_identity_is_unavailable(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
     memory_runtime_factory,
@@ -6041,11 +6170,12 @@ async def test_runtime_rebuild_keeps_completed_result_when_root_activation_fails
 
     assert await runtime.rebuild() == {
         "ok": False,
-        "error": "memory_restart_failed",
-        "result": "completed_empty",
+        "error": "memory_rebuild_failed",
+        "result": "failed",
     }
-    assert V2Config.load().memory.recovery_intent is None
-    assert runtime._restart_config.recovery_intent is None
+    assert V2Config.load().memory.recovery_intent == "rebuild"
+    assert runtime._config.recovery_intent == "rebuild"
+    assert runtime._restart_config.recovery_intent == "rebuild"
     assert runtime.module._worker._claims_paused is True
     await memory_runtime_factory.close(runtime)
 

--- a/tests/test_memory_runtime.py
+++ b/tests/test_memory_runtime.py
@@ -2351,6 +2351,8 @@ async def test_runtime_repairs_artifact_without_activating_pending_recovery(
 ) -> None:
     """Repair admits only the pointer while every durable recovery fence remains set."""
 
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+
     class _RepairArtifact(FakeMemoryArtifactManager):
         def ensure(self, *, force: bool = False) -> dict:
             self.ensure_calls.append(force)
@@ -2377,8 +2379,17 @@ async def test_runtime_repairs_artifact_without_activating_pending_recovery(
         rolled_back.append(True)
 
     artifact = _RepairArtifact(python=Path(sys.executable))
+    pending = MemoryConfig(enabled=False, recovery_intent=recovery_intent)
+    V2Config(
+        mode="self_host",
+        version="v2",
+        slack=SlackConfig(bot_token=""),
+        runtime=RuntimeConfig(default_cwd="."),
+        agents=AgentsConfig(),
+        memory=pending,
+    ).save()
     runtime = memory_runtime_factory(
-        MemoryConfig(enabled=False, recovery_intent=recovery_intent),
+        pending,
         artifact_manager=artifact,
         effective_home=tmp_path,
     )
@@ -2397,6 +2408,7 @@ async def test_runtime_repairs_artifact_without_activating_pending_recovery(
     assert rolled_back == []
     assert runtime._config.recovery_intent == recovery_intent
     assert runtime._restart_config.recovery_intent == recovery_intent
+    assert V2Config.load().memory.recovery_intent == recovery_intent
     await memory_runtime_factory.close(runtime)
 
 
@@ -2603,6 +2615,109 @@ async def test_artifact_repair_rejects_uninspectable_root_without_pending_recove
             lambda: pytest.fail("ordinary repair must not commit"),
             lambda: pytest.fail("nothing was committed to roll back"),
         )
+
+    await memory_runtime_factory.close(runtime)
+
+
+async def test_synthetic_rebuild_fence_cannot_authorize_pointer_only_admission(
+    tmp_path: Path,
+    memory_runtime_factory,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failed durable-config read must not become artifact admission authority."""
+
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    persisted = MemoryConfig(enabled=True, processing=_processing_config())
+    V2Config(
+        mode="self_host",
+        version="v2",
+        slack=SlackConfig(bot_token=""),
+        runtime=RuntimeConfig(default_cwd="."),
+        agents=AgentsConfig(),
+        memory=persisted,
+    ).save()
+    runtime = memory_runtime_factory(
+        persisted,
+        artifact_manager=_installed_artifact(),
+        effective_home=tmp_path,
+    )
+
+    with monkeypatch.context() as config_failure:
+        config_failure.setattr(
+            V2Config,
+            "load",
+            classmethod(
+                lambda cls, config_path=None: (_ for _ in ()).throw(
+                    ValueError("durable config unavailable")
+                )
+            ),
+        )
+        assert await runtime.rebuild() == {
+            "ok": False,
+            "error": "memory_rebuild_failed",
+            "result": "failed",
+        }
+
+    assert runtime.rebuild_pending is True
+    assert V2Config.load().memory.recovery_intent is None
+    committed: list[bool] = []
+    with pytest.raises(
+        MemoryRuntimeActivationError,
+        match="provider root could not be inspected",
+    ):
+        runtime._coordinate_artifact_activation(
+            MemoryArtifactCandidate(
+                provider_root_format="everos-1.2.3",
+                compatible_provider_root_formats=frozenset({"everos-1.2.3"}),
+                artifact_fingerprint="candidate",
+            ),
+            None,
+            lambda: committed.append(True),
+            lambda: pytest.fail("nothing was committed to roll back"),
+        )
+    assert committed == []
+
+    await memory_runtime_factory.close(runtime)
+
+
+async def test_pointer_only_admission_requires_matching_durable_recovery_intent(
+    tmp_path: Path,
+    memory_runtime_factory,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A stale in-memory fence cannot borrow another durable recovery authority."""
+
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    V2Config(
+        mode="self_host",
+        version="v2",
+        slack=SlackConfig(bot_token=""),
+        runtime=RuntimeConfig(default_cwd="."),
+        agents=AgentsConfig(),
+        memory=MemoryConfig(enabled=False, recovery_intent="factory_reset"),
+    ).save()
+    runtime = memory_runtime_factory(
+        MemoryConfig(enabled=False, recovery_intent="rebuild"),
+        artifact_manager=_installed_artifact(),
+        effective_home=tmp_path,
+    )
+
+    committed: list[bool] = []
+    with pytest.raises(
+        MemoryRuntimeActivationError,
+        match="provider root could not be inspected",
+    ):
+        runtime._coordinate_artifact_activation(
+            MemoryArtifactCandidate(
+                provider_root_format="everos-1.2.3",
+                compatible_provider_root_formats=frozenset({"everos-1.2.3"}),
+                artifact_fingerprint="candidate",
+            ),
+            None,
+            lambda: committed.append(True),
+            lambda: pytest.fail("nothing was committed to roll back"),
+        )
+    assert committed == []
 
     await memory_runtime_factory.close(runtime)
 

--- a/tests/test_memory_runtime.py
+++ b/tests/test_memory_runtime.py
@@ -2619,6 +2619,62 @@ async def test_artifact_repair_rejects_uninspectable_root_without_pending_recove
     await memory_runtime_factory.close(runtime)
 
 
+@pytest.mark.parametrize(
+    ("recovery_intent", "commits"),
+    [("factory_reset", True), ("rebuild", False)],
+)
+async def test_uninspectable_recovery_root_admission_depends_on_operation_intent(
+    tmp_path: Path,
+    memory_runtime_factory,
+    monkeypatch: pytest.MonkeyPatch,
+    recovery_intent: str,
+    commits: bool,
+) -> None:
+    """Only reset may replace an artifact without proving retained-root compatibility."""
+
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    pending = MemoryConfig(enabled=False, recovery_intent=recovery_intent)
+    V2Config(
+        mode="self_host",
+        version="v2",
+        slack=SlackConfig(bot_token=""),
+        runtime=RuntimeConfig(default_cwd="."),
+        agents=AgentsConfig(),
+        memory=pending,
+    ).save()
+    runtime = memory_runtime_factory(
+        pending,
+        artifact_manager=_installed_artifact(),
+        effective_home=tmp_path,
+    )
+    committed: list[bool] = []
+
+    def coordinate() -> None:
+        runtime._coordinate_artifact_activation(
+            MemoryArtifactCandidate(
+                provider_root_format="everos-1.2.3",
+                compatible_provider_root_formats=frozenset({"everos-1.2.3"}),
+                artifact_fingerprint="candidate",
+            ),
+            None,
+            lambda: committed.append(True),
+            lambda: pytest.fail("nothing was committed to roll back"),
+        )
+
+    if commits:
+        coordinate()
+        assert committed == [True]
+    else:
+        with pytest.raises(
+            MemoryRuntimeActivationError,
+            match="provider root could not be inspected",
+        ):
+            coordinate()
+        assert committed == []
+
+    await memory_runtime_factory.close(runtime)
+
+
 async def test_synthetic_rebuild_fence_cannot_authorize_pointer_only_admission(
     tmp_path: Path,
     memory_runtime_factory,

--- a/tests/test_memory_runtime.py
+++ b/tests/test_memory_runtime.py
@@ -70,6 +70,7 @@ from core.memory.types import (
 )
 from config.v2_config import (
     AgentsConfig,
+    MEMORY_RECOVERY_INTENTS,
     MemoryConfig,
     MemoryDiagnosticsConfig,
     MemoryEndpointConfig,
@@ -2341,12 +2342,14 @@ async def test_runtime_install_artifact_uses_controller_owned_manager(
     await memory_runtime_factory.close(runtime)
 
 
-async def test_runtime_repairs_artifact_without_activating_pending_factory_reset(
+@pytest.mark.parametrize("recovery_intent", sorted(MEMORY_RECOVERY_INTENTS))
+async def test_runtime_repairs_artifact_without_activating_pending_recovery(
     tmp_path: Path,
     memory_runtime_factory,
     monkeypatch: pytest.MonkeyPatch,
+    recovery_intent: str,
 ) -> None:
-    """Repair may admit the pointer while the durable reset fence remains set."""
+    """Repair admits only the pointer while every durable recovery fence remains set."""
 
     class _RepairArtifact(FakeMemoryArtifactManager):
         def ensure(self, *, force: bool = False) -> dict:
@@ -2375,14 +2378,15 @@ async def test_runtime_repairs_artifact_without_activating_pending_factory_reset
 
     artifact = _RepairArtifact(python=Path(sys.executable))
     runtime = memory_runtime_factory(
-        MemoryConfig(enabled=False, recovery_intent="factory_reset"),
+        MemoryConfig(enabled=False, recovery_intent=recovery_intent),
         artifact_manager=artifact,
         effective_home=tmp_path,
     )
+    assert runtime.module._worker._claims_paused is True
     monkeypatch.setattr(
         runtime,
         "_activate_artifact_candidate",
-        lambda *_args: pytest.fail("pending reset repair must not activate Runtime"),
+        lambda *_args: pytest.fail("pending recovery repair must not activate Runtime"),
     )
 
     result = await runtime.install_artifact()
@@ -2391,7 +2395,8 @@ async def test_runtime_repairs_artifact_without_activating_pending_factory_reset
     assert artifact.ensure_calls == [True]
     assert committed == [True]
     assert rolled_back == []
-    assert runtime._config.recovery_intent == "factory_reset"
+    assert runtime._config.recovery_intent == recovery_intent
+    assert runtime._restart_config.recovery_intent == recovery_intent
     await memory_runtime_factory.close(runtime)
 
 
@@ -2422,11 +2427,16 @@ async def test_failed_fresh_runtime_stays_available_for_pending_reset_repair(
     await memory_runtime_factory.close(runtime)
 
 
-async def test_pending_factory_reset_repair_reports_pointer_commit_failure(
+@pytest.mark.parametrize("recovery_intent", sorted(MEMORY_RECOVERY_INTENTS))
+async def test_pending_recovery_repair_reports_pointer_commit_failure(
     tmp_path: Path,
     memory_runtime_factory,
+    monkeypatch: pytest.MonkeyPatch,
+    recovery_intent: str,
 ) -> None:
     """A failed admission commit remains a failed Repair with the fence intact."""
+
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
 
     class _RepairArtifact(FakeMemoryArtifactManager):
         def ensure(self, *, force: bool = False) -> dict:
@@ -2448,8 +2458,17 @@ async def test_pending_factory_reset_repair_reports_pointer_commit_failure(
         raise OSError("simulated pointer commit failure")
 
     artifact = _RepairArtifact(python=Path(sys.executable))
+    pending = MemoryConfig(enabled=False, recovery_intent=recovery_intent)
+    V2Config(
+        mode="self_host",
+        version="v2",
+        slack=SlackConfig(bot_token=""),
+        runtime=RuntimeConfig(default_cwd="."),
+        agents=AgentsConfig(),
+        memory=pending,
+    ).save()
     runtime = memory_runtime_factory(
-        MemoryConfig(enabled=False, recovery_intent="factory_reset"),
+        pending,
         artifact_manager=artifact,
         effective_home=tmp_path,
     )
@@ -2460,15 +2479,109 @@ async def test_pending_factory_reset_repair_reports_pointer_commit_failure(
         "download_error": None,
     }
     assert artifact.ensure_calls == [True]
-    assert runtime._config.recovery_intent == "factory_reset"
+    assert runtime._config.recovery_intent == recovery_intent
+    assert runtime._restart_config.recovery_intent == recovery_intent
+    assert V2Config.load().memory.recovery_intent == recovery_intent
     await memory_runtime_factory.close(runtime)
 
 
-async def test_artifact_repair_rejects_uninspectable_root_without_pending_reset(
+async def test_pending_rebuild_install_publishes_artifact_for_explicit_retry(
+    tmp_path: Path,
+    memory_runtime_factory,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Scenario: MEMORY-REBUILD-202"""
+
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+
+    manifest = _artifact_manifest("everos-1.2.3", compatible_formats=[])
+    binary_contents = b"#!/bin/sh\nexit 0\n"
+    archive = ManagedRuntimeArchive(
+        platform=memory_artifact.runtime_platform_tag(),
+        name="memory-runtime.tar.gz",
+        url="file:///memory-runtime.tar.gz",
+        sha256="d" * 64,
+        binary_sha256=hashlib.sha256(binary_contents).hexdigest(),
+        size=1,
+        bin_path="bin/python",
+    )
+
+    class _MissingArtifact(MemoryArtifactManager):
+        def ensure(self, *, force: bool = False) -> dict:
+            assert force is True
+            self._write_current_pointer(install_dir, manifest, archive)
+            return {"ok": True, "reason": None, "download_error": None}
+
+    pending = MemoryConfig(
+        enabled=True,
+        processing=_processing_config(),
+        recovery_intent="rebuild",
+    )
+    V2Config(
+        mode="self_host",
+        version="v2",
+        slack=SlackConfig(bot_token=""),
+        runtime=RuntimeConfig(default_cwd="."),
+        agents=AgentsConfig(),
+        memory=pending,
+    ).save()
+    artifact = _MissingArtifact(
+        runtime_dir=tmp_path / "runtime" / "memory-runtime",
+        provider_root=tmp_path / "memory" / "everos-root",
+        offline=True,
+    )
+    install_dir = artifact._manifest_install_dir(manifest, archive)
+    binary = install_dir / archive.bin_path
+    binary.parent.mkdir(parents=True)
+    binary.write_bytes(binary_contents)
+    binary.chmod(0o755)
+    artifact._write_manifest_install_metadata(
+        install_dir,
+        manifest,
+        archive,
+        binary_sha256=archive.binary_sha256,
+    )
+    factory = FakeEverOSProcessFactory()
+    runtime = memory_runtime_factory(
+        pending,
+        artifact_manager=artifact,
+        process_factory=factory,
+        effective_home=tmp_path,
+    )
+    assert runtime.module._worker._claims_paused is True
+
+    assert await runtime.install_artifact() == {
+        "ok": True,
+        "reason": None,
+        "download_error": None,
+    }
+    pointer = artifact._active_pointer()
+    assert pointer is not None
+    assert pointer["install_dir"] == str(install_dir)
+    assert pointer["admission_ok"] is True
+    assert artifact.resolve_python() == binary
+    assert factory.created == []
+    assert runtime.module._worker._claims_paused is True
+    assert V2Config.load().memory.recovery_intent == "rebuild"
+
+    monkeypatch.setattr(runtime, "_provider_data_exists_strict", lambda: False)
+    monkeypatch.setattr(runtime, "_probe_processing", lambda *_args: asyncio.sleep(0, result=True))
+    assert await runtime.rebuild() == {
+        "ok": True,
+        "result": "completed_empty",
+        "state": "ready",
+    }
+    assert V2Config.load().memory.recovery_intent is None
+    assert runtime._restart_config.recovery_intent is None
+    assert len(factory.supervised) == 1
+    await memory_runtime_factory.close(runtime)
+
+
+async def test_artifact_repair_rejects_uninspectable_root_without_pending_recovery(
     tmp_path: Path,
     memory_runtime_factory,
 ) -> None:
-    """Pointer-only admission is exclusive to the durable factory-reset fence."""
+    """Pointer-only admission is exclusive to a supported durable recovery fence."""
 
     runtime = memory_runtime_factory(
         MemoryConfig(enabled=False),


### PR DESCRIPTION
Part of #1374; do not close the shared issue.

## Capability
Marker-aware pointer-only managed memory-runtime recovery admission. During fenced recovery, explicit artifact repair admits only the validated managed-runtime pointer and keeps recovery claims and sidecar activation fenced; an explicit retry then consumes the admitted artifact and settles the rebuild intent.

## Scenario
- MEMORY-REBUILD-202: Missing runtime artifact can be admitted while rebuild remains fenced

## Evidence
- Unit updated: `tests/test_memory_runtime.py`
- Contract updated: `config/v2_config.py` recovery-intent contract
- Scenario updated: `tests/scenarios/memory_rebuild_recovery/catalog.yaml`
- Residual manual check: runtime environment regression remains required

## Exact tests
- `pytest -q tests/test_memory_runtime.py` (150 passed)
- `ruff check config/v2_config.py core/memory/runtime.py tests/test_memory_runtime.py`
- YAML parse/assertion for `tests/scenarios/memory_rebuild_recovery/catalog.yaml`

Requires no other PRs.