### PR TITLE
fix(runtime): clarify local build metadata outputs

### DIFF
--- a/scripts/build_memory_runtime.py
+++ b/scripts/build_memory_runtime.py
@@ -424,6 +424,16 @@ def build_runtime(
     return archive, metadata
 
 
+def build_output(*, archive: Path, metadata: dict[str, object]) -> dict[str, object]:
+    """Return transport status with reusable manifest metadata kept explicit."""
+
+    return {
+        "ok": True,
+        "archive": str(archive),
+        "metadata": metadata,
+    }
+
+
 def main() -> int:
     repository = Path(__file__).resolve().parents[1]
     parser = argparse.ArgumentParser(description="Build an Avibe-managed EverOS Memory Runtime archive.")
@@ -436,7 +446,11 @@ def main() -> int:
     parser.add_argument("--uv", default="uv")
     parser.add_argument("--python-version", default=PYTHON_VERSION)
     parser.add_argument("--platform", choices=sorted(EXPECTED_PLATFORMS))
-    parser.add_argument("--metadata-output", type=Path)
+    parser.add_argument(
+        "--metadata-output",
+        type=Path,
+        help="Write generator-compatible Memory Runtime metadata JSON to this path.",
+    )
     args = parser.parse_args()
     archive, metadata = build_runtime(
         output_dir=args.output_dir,
@@ -448,7 +462,7 @@ def main() -> int:
     if args.metadata_output is not None:
         args.metadata_output.parent.mkdir(parents=True, exist_ok=True)
         args.metadata_output.write_text(json.dumps(metadata, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-    print(json.dumps({"ok": True, "archive": str(archive), **metadata}, indent=2, sort_keys=True))
+    print(json.dumps(build_output(archive=archive, metadata=metadata), indent=2, sort_keys=True))
     return 0
 
 

--- a/scripts/prepare_local_show_runtime_manifest.py
+++ b/scripts/prepare_local_show_runtime_manifest.py
@@ -8,6 +8,10 @@ from pathlib import Path
 from show_runtime_manifest_asset import prepare_manifest
 
 
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_OUTPUT = REPOSITORY_ROOT / "vibe" / "show_runtime_manifest.json"
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(
         description="Prepare a verified Show Runtime manifest for a local Avibe wheel build."
@@ -19,7 +23,7 @@ def main() -> int:
     parser.add_argument(
         "--output",
         type=Path,
-        default=Path("vibe/show_runtime_manifest.json"),
+        default=DEFAULT_OUTPUT,
         help="Manifest destination used by the Avibe wheel build.",
     )
     args = parser.parse_args()

--- a/tests/test_memory_runtime_release.py
+++ b/tests/test_memory_runtime_release.py
@@ -4,6 +4,7 @@ import hashlib
 import io
 import json
 import os
+import subprocess
 import sys
 import tarfile
 import tempfile
@@ -185,13 +186,41 @@ def test_build_outputs_metadata_accepted_by_manifest_generator(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    for platform in PLATFORMS:
-        archive, _ = _write_archive(tmp_path, platform)
-        metadata_path = archive.with_suffix("").with_suffix(".json")
-        metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
-        metadata_path.unlink()
+    def fake_run(
+        command: list[str],
+        *,
+        cwd: Path,
+        capture_output: bool = False,
+    ) -> subprocess.CompletedProcess[str]:
+        if command == ["uv", "--version"]:
+            stdout = f"uv {UV_VERSION}\n"
+        elif command[:3] == ["uv", "python", "install"]:
+            binary = cwd / "managed" / "bin" / "python"
+            binary.parent.mkdir(parents=True)
+            binary.write_bytes(b"embedded-python")
+            binary.chmod(0o755)
+            stdout = ""
+        elif command[:3] == ["uv", "python", "find"]:
+            stdout = f"{cwd / 'managed' / 'bin' / 'python'}\n"
+        elif command[:2] == ["uv", "export"]:
+            output = Path(command[command.index("--output-file") + 1])
+            output.write_text("", encoding="utf-8")
+            stdout = ""
+        elif command[:3] == ["uv", "pip", "sync"]:
+            stdout = ""
+        elif command[1:4] == ["-I", "-B", "-c"]:
+            stdout = f"{EVEROS_VERSION}\n{PYTHON_VERSION}\n"
+        elif command[1:] == ["-c", "import platform; print(platform.python_version())"]:
+            stdout = f"{PYTHON_VERSION}\n"
+        else:
+            raise AssertionError(f"Unexpected Memory Runtime subprocess: {command}")
+        return subprocess.CompletedProcess(command, 0, stdout=stdout, stderr="")
 
-        monkeypatch.setattr(runtime_builder, "build_runtime", lambda **kwargs: (archive, metadata))
+    monkeypatch.setattr(runtime_builder, "_run", fake_run)
+    monkeypatch.setattr(runtime_builder, "_sidecar_health_smoke", lambda *args, **kwargs: None)
+
+    for platform in PLATFORMS:
+        metadata_path = tmp_path / f"memory-runtime-{EVEROS_VERSION}-{platform}.json"
         monkeypatch.setattr(
             sys,
             "argv",
@@ -210,7 +239,6 @@ def test_build_outputs_metadata_accepted_by_manifest_generator(
         output = json.loads(capsys.readouterr().out)
 
         assert set(output) == {"ok", "archive", "metadata"}
-        assert output["metadata"] == metadata
         assert json.loads(metadata_path.read_text(encoding="utf-8")) == output["metadata"]
 
     manifest = manifest_generator.build_manifest(

--- a/tests/test_memory_runtime_release.py
+++ b/tests/test_memory_runtime_release.py
@@ -4,12 +4,14 @@ import hashlib
 import io
 import json
 import os
+import sys
 import tarfile
 import tempfile
 from pathlib import Path
 
 import pytest
 
+from scripts import build_memory_runtime as runtime_builder
 from scripts import generate_memory_runtime_manifest as manifest_generator
 from scripts.build_memory_runtime import (
     EVEROS_VERSION,
@@ -176,6 +178,49 @@ def test_generate_memory_runtime_manifest_records_verified_platform_archives(tmp
             "size": archive.stat().st_size,
             "bin_path": "bin/python",
         }
+
+
+def test_build_outputs_metadata_accepted_by_manifest_generator(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    for platform in PLATFORMS:
+        archive, _ = _write_archive(tmp_path, platform)
+        metadata_path = archive.with_suffix("").with_suffix(".json")
+        metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+        metadata_path.unlink()
+
+        monkeypatch.setattr(runtime_builder, "build_runtime", lambda **kwargs: (archive, metadata))
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            [
+                "build_memory_runtime.py",
+                "--output-dir",
+                str(tmp_path),
+                "--platform",
+                platform,
+                "--metadata-output",
+                str(metadata_path),
+            ],
+        )
+
+        assert runtime_builder.main() == 0
+        output = json.loads(capsys.readouterr().out)
+
+        assert set(output) == {"ok", "archive", "metadata"}
+        assert output["metadata"] == metadata
+        assert json.loads(metadata_path.read_text(encoding="utf-8")) == output["metadata"]
+
+    manifest = manifest_generator.build_manifest(
+        archive_dir=tmp_path,
+        tag="v3.1.0",
+        repo="avibe-bot/avibe",
+        output=tmp_path / "manifest.json",
+    )
+
+    assert set(manifest["archives"]) == set(PLATFORMS)
 
 
 def test_generate_memory_runtime_manifest_fails_when_platform_archive_missing(tmp_path: Path) -> None:

--- a/tests/test_show_runtime_manifest_packaging.py
+++ b/tests/test_show_runtime_manifest_packaging.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import hashlib
+import importlib.util
 import json
+import sys
 from pathlib import Path
 
 import pytest
@@ -30,6 +32,17 @@ class _Response:
 
     def read(self) -> bytes:
         return self.content
+
+
+def _load_prepare_script(monkeypatch: pytest.MonkeyPatch):
+    repository = Path(__file__).resolve().parents[1]
+    script = repository / "scripts" / "prepare_local_show_runtime_manifest.py"
+    monkeypatch.syspath_prepend(str(script.parent))
+    spec = importlib.util.spec_from_file_location("prepare_local_show_runtime_manifest", script)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
 
 
 def _manifest() -> dict:
@@ -103,6 +116,29 @@ def test_prepare_manifest_verifies_release_asset_digest_and_writes_output(tmp_pa
 
     assert result["runtime_version"] == RUNTIME_VERSION
     assert output.read_bytes() == manifest_content
+
+
+@pytest.mark.parametrize("invocation_directory", ["repository", "scripts"])
+def test_prepare_local_manifest_default_output_is_repository_relative(
+    invocation_directory: str,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    repository = Path(__file__).resolve().parents[1]
+    module = _load_prepare_script(monkeypatch)
+    captured_output: list[Path] = []
+
+    def fake_prepare_manifest(output: Path, *, release_tag: str | None = None):
+        captured_output.append(output)
+        return {"runtime_version": RUNTIME_VERSION, "archives": {"linux-x64": {}}}
+
+    monkeypatch.setattr(module, "prepare_manifest", fake_prepare_manifest)
+    monkeypatch.setattr(sys, "argv", ["prepare_local_show_runtime_manifest.py"])
+    monkeypatch.chdir(repository if invocation_directory == "repository" else repository / "scripts")
+
+    assert module.main() == 0
+    assert captured_output == [repository / "vibe" / "show_runtime_manifest.json"]
+    assert json.loads(capsys.readouterr().out)["output"] == str(captured_output[0])
 
 
 def test_prepare_manifest_rejects_a_release_asset_digest_mismatch(tmp_path: Path) -> None:


### PR DESCRIPTION
Part of #1374

## Summary

- Anchor the local Show Runtime manifest default at the repository-root `vibe/show_runtime_manifest.json`, independent of the invocation directory.
- Make the Memory Runtime builder producer-consumer contract explicit: stdout wraps reusable generator-compatible manifest metadata under `metadata`, while `--metadata-output` writes that same metadata payload for `generate_memory_runtime_manifest.py`.

## Scenarios

- Scenario IDs: none

## Evidence layers

- Unit: updated
- Contract: updated
- Scenario: not applicable
- Residual manual checks: none

## Exact tests

- `uv run --no-project pytest tests/test_memory_runtime_release.py tests/test_show_runtime_manifest_packaging.py` (27 passed)
- `uv run --no-project ruff check scripts/build_memory_runtime.py scripts/prepare_local_show_runtime_manifest.py tests/test_memory_runtime_release.py tests/test_show_runtime_manifest_packaging.py`
- `git diff --check origin/master...HEAD`