### PR TITLE
fix(memory): allow clear after unknown provider add

### DIFF
--- a/core/memory/maintenance.py
+++ b/core/memory/maintenance.py
@@ -316,10 +316,9 @@ class MemoryMaintenance:
         if observation is None:
             observation = await self.observe(operator_ref=operator_ref)
         try:
-            meta, history, manual_required = await asyncio.gather(
+            meta, history = await asyncio.gather(
                 asyncio.to_thread(self._store.get_meta),
                 asyncio.to_thread(self._store.has_provider_data_history),
-                asyncio.to_thread(self._store.has_manual_required_fence),
             )
         except Exception:
             return MaintenanceResult(
@@ -340,11 +339,7 @@ class MemoryMaintenance:
         changed = latest != observation
         return MaintenanceResult(
             data_exists=bool(history or (meta is not None and meta.last_success_at)),
-            can_clear=(
-                not changed
-                and latest.can_clear
-                and not manual_required
-            ),
+            can_clear=not changed and latest.can_clear,
             clear_recovery=latest.clear_recovery,
             error=(
                 "memory_store_unavailable"
@@ -457,18 +452,11 @@ class MemoryMaintenance:
             try:
                 try:
                     await self._runtime.pause_claims()
-                    manual_required = await self._run_maintenance_io(
-                        self._store.has_manual_required_fence
-                    )
                 except BaseException as error:
                     self._runtime.leave_maintenance()
                     self._runtime.resume_claims()
                     if isinstance(error, asyncio.CancelledError):
                         raise
-                    return self._blocked(operator_ref=operator_ref)
-                if manual_required:
-                    self._runtime.leave_maintenance()
-                    self._runtime.resume_claims()
                     return self._blocked(operator_ref=operator_ref)
                 try:
                     meta = await self._run_maintenance_io(self._store.ensure_meta)

--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -106,6 +106,12 @@ the `memory` or `state/memory` roots themselves, original Avibe chats, copies
 already sent to providers, or data outside those surfaces (including logs,
 backups, and user-created snapshots); it is not a secure wipe.
 
+Clear Memory Data is also the explicit discard path for a timed-out or otherwise
+unknown provider add. It removes the retained `manual_required` queue evidence
+and pinned attachment bundle, clears that session's local fence, and never
+replays the ambiguous add. Because the provider outcome is unknown, Clear cannot
+remove a copy that may already have reached the provider.
+
 If Clear Memory Data is interrupted, Processing Record shows explicit **Resume Clear**
 and **Abort and restore** actions for that operation. **Resume Clear** continues
 the journaled deletion; **Abort and restore** restores every surface from the
@@ -163,7 +169,9 @@ generations, idle/max-age/message-count flush thresholds, exact fences, and
 immutable settlements. Natural extraction boundaries settle a generation
 without an extra flush. Unknown post-submission outcomes become
 `manual_required` and are never replayed automatically; unrelated sessions keep
-progressing.
+progressing. **Clear Memory Data** is the operator's terminal disposition for
+that retained local evidence; after Clear completes, later captures use the new
+epoch and can deliver normally.
 
 Workbench attachments are copied into a private durable bundle before capture
 is accepted. Queue payloads store only bundle-relative metadata. Confirmed

--- a/tests/scenarios/INDEX.yaml
+++ b/tests/scenarios/INDEX.yaml
@@ -8,6 +8,17 @@ navigation:
   - Read that capability's observations.yaml.
   - Read the listed scenario test files before changing production code.
 capabilities:
+  - id: memory_clear_recovery
+    name: Journaled Memory Clear recovery
+    status: active
+    catalog: tests/scenarios/memory_clear_recovery/catalog.yaml
+    observations: tests/scenarios/memory_clear_recovery/observations.yaml
+    scenario_tests:
+      - tests/test_memory_maintenance.py
+    unit_or_contract_tests:
+      - tests/test_memory_store.py
+      - tests/test_memory_clear_journal.py
+      - tests/test_memory_clear_snapshot_storage.py
   - id: memory_rebuild_recovery
     name: Confirmed Memory embedding rebuild recovery
     status: active

--- a/tests/scenarios/memory_clear_recovery/catalog.yaml
+++ b/tests/scenarios/memory_clear_recovery/catalog.yaml
@@ -1,0 +1,28 @@
+version: 1
+capability:
+  id: memory_clear_recovery
+  name: Journaled Memory Clear recovery
+  canonical_tests:
+    - tests/test_memory_maintenance.py
+status_legend:
+  covered: scenario coverage exists
+  partial: unit or contract coverage exists but the closed loop is incomplete
+  manual: currently validated only by human regression
+  gap: not covered yet
+scenarios:
+  - id: MEMORY-CLEAR-201
+    name: Clear discards an unknown add and restores session delivery
+    status: covered
+    kind: recovery
+    layer: scenario
+    test: tests/test_memory_maintenance.py::test_clear_discards_manual_required_fence_and_allows_new_delivery
+    actor: Memory Settings user
+    trigger: A provider add times out after submission and fences its session as manual_required
+    given: The queue retains the ambiguous payload and pinned attachment bundle without replaying it
+    when: The user confirms Clear Memory Data
+    then: The journaled Clear removes the retained evidence, advances the epoch, and a later capture in the same logical session delivers normally
+    expected_outputs:
+      - Maintenance advertises can_clear while the manual_required fence exists
+      - Clear completes through the existing snapshot and journal surfaces
+      - The ambiguous payload and attachment bundle are removed without another provider add
+      - The session is unfenced and a subsequent capture reaches the provider

--- a/tests/scenarios/memory_clear_recovery/observations.yaml
+++ b/tests/scenarios/memory_clear_recovery/observations.yaml
@@ -1,0 +1,15 @@
+version: 1
+capability: memory_clear_recovery
+observations:
+  - id: OBS-MEMORY-CLEAR-001
+    source: issue_1374_runtime_reproduction
+    related_scenarios:
+      - MEMORY-CLEAR-201
+    summary: An ordinary provider add timeout is conservatively retained as manual_required, but that local fence must not disable journaled Clear.
+    previous_assumption: Unknown provider outcomes had to block Clear to preserve their evidence.
+    observed_behavior: Clear already snapshots the queue and attachment tree before deletion, can restore them on Abort, and resets the queue at a new epoch on completion.
+    required_updates:
+      - keep automatic replay forbidden for unknown outcomes
+      - allow Clear to discard retained local evidence and release pinned attachments
+      - preserve the existing Resume Clear and Abort and restore recovery contract
+      - prove a later capture in the same logical session can deliver

--- a/tests/test_memory_maintenance.py
+++ b/tests/test_memory_maintenance.py
@@ -19,6 +19,7 @@ from config.v2_config import MemoryConfig
 from core.memory.artifact import FakeMemoryArtifactManager
 from core.memory.clear_journal import MemoryClearJournal
 from core.memory.clear_snapshot_storage import MemoryClearSnapshotStorage
+from core.memory.everos import FakeMemoryProvider
 from core.memory.process import SidecarOwnership
 from core.memory.maintenance import (
     ClearRecoveryResult,
@@ -29,7 +30,12 @@ from core.memory.maintenance import (
 from core.memory.runtime import MemoryRuntime
 from core.memory.snapshot import MemorySnapshotManager
 from core.memory.store import AmbiguousAdd, MemoryStore
-from core.memory.types import CaptureAccepted, CaptureRequest, CaptureSkipped
+from core.memory.types import (
+    CaptureAccepted,
+    CaptureAttachment,
+    CaptureRequest,
+    CaptureSkipped,
+)
 
 
 PRINCIPAL = "u-11111111111111111111111111111111"
@@ -550,159 +556,92 @@ async def test_clear_converges_for_provider_tree_deeper_than_recursion_limit(
     await memory_runtime_factory.close(runtime)
 
 
-async def test_clear_refuses_manual_required_fence_without_mutating_evidence(
+async def test_clear_discards_manual_required_fence_and_allows_new_delivery(
     monkeypatch,
     tmp_path: Path,
     memory_runtime_factory,
 ) -> None:
+    """MEMORY-CLEAR-201: Clear settles an unknown add without replaying it."""
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     runtime = memory_runtime_factory(MemoryConfig(enabled=True), effective_home=tmp_path)
-    worker = runtime.module._worker
+    provider_timeout = asyncio.Event()
 
-    class RetainedProcess:
-        running = True
+    async def time_out_add(_capture) -> None:
+        await provider_timeout.wait()
 
-        def __init__(self) -> None:
-            self.stop_calls = 0
-
-        async def stop(self) -> None:
-            self.stop_calls += 1
-
-    process = RetainedProcess()
-    runtime._process = process
-    _enqueue(runtime, "manual-clear-source")
-    claimed = runtime._store.claim_due(
-        lease_owner="manual-clear-worker",
-        now="2026-01-01T00:00:00.000Z",
+    provider = FakeMemoryProvider(add_hook=time_out_add)
+    runtime.module.replace_provider(provider)
+    runtime.module._worker.coordinator._add_timeout_seconds = 0.001
+    source_root = tmp_path / "attachments" / "avibe"
+    source_root.mkdir(parents=True, mode=0o700)
+    source_root.chmod(0o700)
+    attachment_path = source_root / "evidence.txt"
+    attachment_path.write_bytes(b"retained ambiguous attachment")
+    attachment_path.chmod(0o600)
+    first = CaptureRequest(
+        source_message_id="timed-out-add",
+        session_id="session",
+        principal_id=PRINCIPAL,
+        project_id=PROJECT,
+        provenance="user_input",
+        text="ambiguous payload",
+        occurred_at_ms=1,
+        attachments=(
+            CaptureAttachment(
+                kind="doc",
+                name=attachment_path.name,
+                uri=attachment_path.as_uri(),
+                ext="txt",
+            ),
+        ),
     )
-    assert claimed is not None
+    assert await runtime.module.capture(first) == CaptureAccepted()
+    assert await runtime.module.drain() == 1
+
+    ambiguous = runtime._store.list_queue_rows()
+    assert len(ambiguous) == 1
+    assert ambiguous[0].state == "manual_required"
+    assert ambiguous[0].payload_text == "ambiguous payload"
+    assert ambiguous[0].attachment_bundle_id is not None
+    attachment_bundle_id = ambiguous[0].attachment_bundle_id
+    assert runtime._store.has_manual_required_fence() is True
+    session = runtime._store.get_session_flush_state(ambiguous[0].provider_session_ref)
+    assert session is not None and session.state == "manual_required"
     assert (await runtime.maintenance_payload())["can_clear"] is True
 
-    surface_payloads = {
-        tmp_path / "memory/everos-root/sentinel.json": b'{"provider":"keep"}',
-        tmp_path / "memory/call-log/call-log.db": b"call-log-must-remain",
-        tmp_path / "memory/attachments/bundles/a/00.txt": b"attachment-must-remain",
-    }
-    for path, payload in surface_payloads.items():
-        path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_bytes(payload)
+    async def resume_without_sidecar() -> None:
+        runtime.module.resume_claims()
 
-    def settlement_evidence() -> list[tuple]:
-        with sqlite3.connect(runtime._store.path) as connection:
-            return connection.execute(
-                """
-                SELECT provider_session_ref, epoch, generation, operation_kind,
-                       operation_token, observation, request_id, error_code
-                FROM memory_flush_settlements
-                ORDER BY rowid
-                """
-            ).fetchall()
-
-    journal = _maintenance(runtime)._clear_journal
-    manager = _maintenance(runtime)._snapshot_manager
-    assert journal is not None
-    assert manager is not None
-    with sqlite3.connect(journal.database_path) as connection:
-        before_journal_operations = connection.execute(
-            "SELECT COUNT(*) FROM clear_operation"
-        ).fetchone()[0]
-
-    evidence: dict[str, object] = {}
-    events: list[str] = []
-
-    async def settle_while_quiescing(**_kwargs) -> bool:
-        worker.pause_claims()
-        events.append("quiesce")
-        settled = runtime._store.settle(
-            claimed,
-            AmbiguousAdd(add_request_id="manual-clear-request"),
-            lease_owner="manual-clear-worker",
-            now=datetime(2026, 1, 1, 0, 0, 1, tzinfo=UTC),
-        )
-        assert settled.state == "manual_required"
-        evidence["meta"] = runtime._store.ensure_meta()
-        evidence["queue"] = runtime._store.list_queue_rows()
-        evidence["session"] = runtime._store.get_session_flush_state(
-            claimed.provider_session_ref
-        )
-        evidence["settlements"] = settlement_evidence()
-        return True
-
-    original_has_manual_required_fence = runtime._store.has_manual_required_fence
-
-    def observed_manual_required_fence() -> bool:
-        events.append("manual-check")
-        return original_has_manual_required_fence()
-
-    resume_calls = 0
-    original_resume_claims = worker.resume_claims
-
-    def counted_resume_claims() -> None:
-        nonlocal resume_calls
-        resume_calls += 1
-        events.append("resume")
-        original_resume_claims()
-
-    stop_worker_calls = 0
-    original_stop_worker = runtime._stop_worker
-
-    async def observed_stop_worker() -> None:
-        nonlocal stop_worker_calls
-        stop_worker_calls += 1
-
-    start_calls: list[str] = []
-    original_start = journal.start
-
-    def observed_start(**kwargs):
-        start_calls.append("start")
-        return original_start(**kwargs)
-
-    monkeypatch.setattr(worker, "pause_and_wait", settle_while_quiescing)
-    monkeypatch.setattr(
-        runtime._store,
-        "has_manual_required_fence",
-        observed_manual_required_fence,
-    )
-    monkeypatch.setattr(worker, "resume_claims", counted_resume_claims)
-    monkeypatch.setattr(runtime, "_stop_worker", observed_stop_worker)
-    monkeypatch.setattr(journal, "start", observed_start)
-
+    _replace_runtime_port(runtime, resume=resume_without_sidecar)
     result = await _clear(runtime, operator_ref="user:owner")
 
-    assert result == {
-        "status": "failed",
-        "error": "memory_clear_failed",
-        "recovery": None,
-    }
-    assert events == ["quiesce", "manual-check", "resume"]
-    assert resume_calls == 1
-    assert stop_worker_calls == 0
-    assert runtime.module._worker is worker
-    assert worker._claims_paused is False
-    assert runtime._process is process
-    assert process.stop_calls == 0
-    assert start_calls == []
-    queue = evidence["queue"]
-    session = evidence["session"]
-    settlements = evidence["settlements"]
-    assert isinstance(queue, tuple) and queue[0].state == "manual_required"
-    assert session is not None and session.state == "manual_required"
-    assert isinstance(settlements, list) and settlements[0][5] == "manual_required"
-    assert runtime._store.ensure_meta() == evidence["meta"]
-    assert runtime._store.list_queue_rows() == queue
-    assert runtime._store.get_session_flush_state(claimed.provider_session_ref) == session
-    assert settlement_evidence() == settlements
-    with sqlite3.connect(journal.database_path) as connection:
-        after_journal_operations = connection.execute(
-            "SELECT COUNT(*) FROM clear_operation"
-        ).fetchone()[0]
-    assert after_journal_operations == before_journal_operations == 0
-    assert journal.get_open_operation() is None
-    assert not manager.snapshot_root.exists()
-    for path, payload in surface_payloads.items():
-        assert path.read_bytes() == payload
-    assert (await runtime.maintenance_payload())["can_clear"] is False
-    monkeypatch.setattr(runtime, "_stop_worker", original_stop_worker)
+    assert result["status"] == "completed"
+    assert runtime._store.list_queue_rows() == ()
+    assert runtime._store.has_manual_required_fence() is False
+    assert not (
+        tmp_path / "memory" / "attachments" / "bundles" / attachment_bundle_id
+    ).exists()
+    assert attachment_path.read_bytes() == b"retained ambiguous attachment"
+
+    provider.add_hook = None
+    second = CaptureRequest(
+        source_message_id="after-clear",
+        session_id="session",
+        principal_id=PRINCIPAL,
+        project_id=PROJECT,
+        provenance="user_input",
+        text="deliver after clear",
+        occurred_at_ms=2,
+    )
+    assert await runtime.module.capture(second) == CaptureAccepted()
+    assert await runtime.module.drain() == 1
+    delivered = runtime._store.list_queue_rows()
+    assert len(delivered) == 1 and delivered[0].state == "delivered"
+    assert delivered[0].provider_session_ref.epoch == result["epoch"]
+    assert [capture.text for capture in provider.captures] == [
+        "ambiguous payload",
+        "deliver after clear",
+    ]
     await memory_runtime_factory.close(runtime)
 
 


### PR DESCRIPTION
## Summary
- Part of #1374.
- Restore the `manual_required` Clear recovery capability after an unknown provider add outcome.
- Clear discards the retained ambiguous queue evidence and fence so later deliveries can proceed, while preserving the no-replay disposition: the unknown provider add is never replayed automatically.

## Scenario
- `MEMORY-CLEAR-201`: an ordinary provider add times out after submission, the session is fenced as `manual_required`, Clear settles that local recovery state without replaying the ambiguous add, and a new delivery can proceed.

## Evidence
- Unit: focused memory maintenance coverage for the timeout fence, Clear recovery, and subsequent delivery.
- Contract/status/API: maintenance capability/status assertions verify Clear remains advertised while `manual_required` exists and the API-compatible recovery path clears the fence.
- Scenario: added the `MEMORY-CLEAR-201` catalog and observation entries and registered the suite in the scenario index.
- Docs: documented operator-facing Clear recovery and the no-automatic-replay guarantee.
- Residual manual checks: integration verification through the packaged runtime/provider surface is deferred to the orchestrator integration pass; no provider-side replay should occur.