### PR TITLE
ci(diagnose): name unit-test files and kill 300s hangs [diagnostic]

### DIFF
--- a/scripts/ci_unit_tests.sh
+++ b/scripts/ci_unit_tests.sh
@@ -74,8 +74,12 @@ while IFS= read -r f; do
   discovered=$((discovered + 1))
   selected=$((selected + 1))
   started_at=$(date +%s)
-  "${PYTEST[@]}" "$f" -m "not integration" -p no:randomly -o addopts="" -q
+  echo "Starting $f"
+  timeout 300 "${PYTEST[@]}" "$f" -m "not integration" -p no:randomly -o addopts="" -q
   rc=$?
+  if [ "$rc" -eq 124 ]; then
+    echo "TIMEOUT(300s): $f hung and was killed."
+  fi
   finished_at=$(date +%s)
   elapsed=$((finished_at - started_at))
   echo "Finished $f in ${elapsed}s with exit code $rc."


### PR DESCRIPTION
Diagnostic draft. CI unit shards 3/6 and 4/6 hang silently on every run since ~23:22 (all PRs, fresh merge refs included). The shard script prints only 'Finished' lines, and the hanging pytest produces no output before dying, so the culprit file is unidentifiable from logs. This draft echoes each file before running and kills 300s hangs with a named TIMEOUT line. Not for merge as-is; will be closed or promoted after the culprit is identified.