### PR TITLE
test(memory): move the deep-path snapshot test out of the unit shards

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -145,7 +145,7 @@ extend-ignore = ["E501"]
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 markers = [
-    "integration: platform integration tests requiring Docker + platform tokens",
+    "integration: tests excluded from the unit shards because they need external infrastructure (Docker + platform tokens) or minutes of real filesystem work",
     "uses_real_paths: opt out of the autouse home/config isolation so the test can exercise real path resolvers (must remain read-only)",
     "no_sqlite_template: opt out of the pre-migrated SQLite template for migration/bootstrap tests",
 ]

--- a/tests/test_memory_snapshot.py
+++ b/tests/test_memory_snapshot.py
@@ -821,6 +821,11 @@ def test_streaming_manifest_accepts_extended_unicode_path_record(tmp_path: Path)
         assert entries.entry(relative_path) is not None
 
 
+# The >256KB path record forces roughly 1046 directory levels, and snapshot
+# verification is currently quadratic in tree depth, so this one test costs about
+# 162 seconds of CPU and exceeds the unit shards' per-file cap. Issue #1380 owns
+# the verification speed-up that lets this move back into the unit shards.
+@pytest.mark.integration
 def test_snapshot_accepts_path_record_beyond_256k_and_clear_gc(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Capability

CI unit-test sharding for the **memory snapshot** capability. This is a **test
classification correction, not a coverage deletion** — the removed cost is tracked by
#1380, and reverting the isolation is a one-line change.

## Why

`tests/test_memory_snapshot.py::test_snapshot_accepts_path_record_beyond_256k_and_clear_gc`
costs about **162 seconds of CPU on an idle machine**. `scripts/ci_unit_tests.sh` caps each
file at 300 seconds, and on a runner executing six shards in parallel the test exceeds that
cap, so shard 5 of `unit-test-shards` was killed and failed — blocking every open PR from
merging.

Evidence:

- Diagnostic run `31632697691`, shard 5:
  `TIMEOUT(300s): tests/test_memory_snapshot.py hung and was killed.`
  `Finished tests/test_memory_snapshot.py in 300s with exit code 124.`
- Re-run alone under a 1200 s cap it **passes in `162.19s`** with CPU time tracking wall
  time 1:1 — it is pathological complexity, not a deadlock.
- With this one test excluded the whole file finishes in **13.23s**; the cost was entirely
  this test.
- The fixture depth cannot be reduced: the asserted >256 KB path record divided by the
  255-byte `PC_NAME_MAX` component limit forces roughly **1046 directory levels**. A
  shallower tree would no longer exercise the >256 KB record.
- Root cause (`cProfile`, filed in #1380): `core/memory/snapshot.py:1493` decides surface
  ownership with `surface_path in entry_path.parents`, a linear scan that materializes one
  `PurePosixPath` per ancestor — 11 M path objects, 84 s — and the 48-entry
  `_DirectoryDescriptorCache` re-walks the 1046-level chain for 146 k `openat` calls, 78 s.
  Together 81 % of the runtime.
- Introduced by `95e039b27` (#1357), not by any later change.

## What changed

- `tests/test_memory_snapshot.py`: one `@pytest.mark.integration` decorator plus a comment
  pointing at #1380.
- `pyproject.toml`: widened that marker's registered description. It previously read
  "platform integration tests requiring Docker + platform tokens", which would have made
  the new mark misleading — the marker's real job is "excluded from the unit shards", for
  external infrastructure **or** minutes of real filesystem work.

No production code is touched. Nothing in CI runs `-m integration` today (the e2e jobs
select files by path), so the test now runs nowhere in CI — that is the explicit tradeoff,
and #1380 owns restoring it.

## Scenario IDs

None. This changes no scenario; `tests/scenarios/memory_repair/` is unaffected.

## Evidence layers

- **Unit** — classification only, no assertions changed. Verified with the exact shard
  invocation `pytest tests/test_memory_snapshot.py -m "not integration" -p no:randomly
  -o addopts="" -q`: `2 failed, 36 passed, 1 deselected in 13.23s`, i.e. the intended test
  is deselected and the file is no longer capable of exceeding the cap.
- **Contract** — not applicable; no interface changes.
- **Scenario** — not applicable; no scenario touched.
- **Residual manual checks** — the two local failures above are pre-existing and
  macOS-only (`pathlib/_local.py:576: AttributeError` under Python 3.13). They reproduce
  identically on unmodified `master` (`2 failed, 36 passed, 1 deselected in 12.47s`) and
  pass on Linux CI, as the shard log's eleven progress dots before the timeout show.
- `ruff check` clean on both changed files.

## Related

- #1380 — snapshot verification is quadratic on deep trees (owns the real fix)
- #1357 — introduced the test
