### PR TITLE
fix(ui): localize organization navigation

### DIFF
--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -116,6 +116,7 @@
   },
   "nav": {
     "dashboard": "Dashboard",
+    "organization": "Organization",
     "appLibrary": "App Library",
     "channels": "Groups",
     "users": "Direct Messages",

--- a/ui/src/i18n/navigation.test.ts
+++ b/ui/src/i18n/navigation.test.ts
@@ -1,0 +1,31 @@
+import { createInstance } from 'i18next';
+import { describe, expect, it } from 'vitest';
+
+import en from './en.json';
+import zh from './zh.json';
+
+const navigationLabels = {
+  en: en.nav,
+  zh: zh.nav,
+};
+
+describe('navigation translations', () => {
+  it.each(Object.entries(navigationLabels))(
+    'resolves every %s navigation key to visible copy',
+    (language, labels) => {
+      const i18n = createInstance();
+      void i18n.init({
+        lng: language,
+        resources: { [language]: { translation: { nav: labels } } },
+      });
+
+      for (const key of Object.keys(labels)) {
+        expect(i18n.t(`nav.${key}`)).not.toBe(`nav.${key}`);
+      }
+    },
+  );
+
+  it('keeps navigation keys available in both locales', () => {
+    expect(Object.keys(zh.nav).sort()).toEqual(Object.keys(en.nav).sort());
+  });
+});

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -116,6 +116,7 @@
   },
   "nav": {
     "dashboard": "控制台",
+    "organization": "组织",
     "appLibrary": "应用库",
     "channels": "群组",
     "users": "私聊",


### PR DESCRIPTION
## Capability

Localizes the Organization entry in the admin navigation so the UI renders human-readable copy instead of the raw `nav.organization` key. The same resource key covers desktop, mobile, and compact Organization navigation surfaces.

## Validation

- Unit: `npm test -- --run src/i18n/navigation.test.ts` (3 passed)
- Contract: navigation locale test requires English and Chinese `nav` key parity and rejects unresolved machine keys
- Scenario IDs: none; no matching scenario catalog entry for locale-only navigation copy
- UI build: `npm run lint`; `npm run build`
- Residual manual: verify Organization renders in English and Chinese after the packaged UI is deployed

## Dependencies

None.