### PR TITLE
fix(opencode): unblock prewrite session turns

### DIFF
--- a/core/native_dispatch_phase.py
+++ b/core/native_dispatch_phase.py
@@ -9,14 +9,15 @@ DISPATCH_PHASE_KEY = "agent_dispatch_phase"
 DISPATCH_EVIDENCE_KEY = "agent_dispatch_evidence"
 DISPATCH_PHASE_PREWRITE = "prewrite"
 DISPATCH_PHASE_ATTEMPTING = "attempting"
+DISPATCH_PREWRITE_USER_STOP_KEY = "prewrite_user_stop"
 
 
 def set_dispatch_phase(
     context: Any,
     phase: str,
     *,
-    evidence: dict[str, str] | None = None,
-) -> dict[str, str]:
+    evidence: dict[str, Any] | None = None,
+) -> dict[str, Any]:
     payload = dict(getattr(context, "platform_specific", None) or {})
     current = payload.get(DISPATCH_EVIDENCE_KEY)
     if evidence is None:
@@ -41,6 +42,29 @@ def backend_dispatch_attempted(context: Any) -> Optional[bool]:
     if phase == DISPATCH_PHASE_ATTEMPTING:
         return True
     return None
+
+
+def mark_prewrite_user_stop(context: Any) -> None:
+    """Publish user-Stop intent to the adapter before canceling its task."""
+
+    payload = dict(getattr(context, "platform_specific", None) or {})
+    evidence = payload.get(DISPATCH_EVIDENCE_KEY)
+    if not isinstance(evidence, dict):
+        evidence = {}
+        payload[DISPATCH_EVIDENCE_KEY] = evidence
+    context.platform_specific = payload
+    evidence[DISPATCH_PREWRITE_USER_STOP_KEY] = True
+
+
+def prewrite_user_stop_requested(context: Any) -> bool:
+    """Return whether the shared Turn owner canceled this prewrite task for Stop."""
+
+    payload = getattr(context, "platform_specific", None) or {}
+    evidence = payload.get(DISPATCH_EVIDENCE_KEY)
+    return bool(
+        isinstance(evidence, dict)
+        and evidence.get(DISPATCH_PREWRITE_USER_STOP_KEY) is True
+    )
 
 
 def mark_backend_dispatch_attempted(context: Any) -> None:

--- a/core/session_turns.py
+++ b/core/session_turns.py
@@ -33,7 +33,11 @@ from core.message_context import (
     SCHEDULED_DISPATCH_METADATA_APPLIED_KEY,
     resolve_turn_sink_key,
 )
-from core.native_dispatch_phase import backend_dispatch_attempted
+from core.native_dispatch_phase import (
+    DISPATCH_PHASE_PREWRITE,
+    backend_dispatch_attempted,
+    set_dispatch_phase,
+)
 from core.run_settlement import (
     NON_COMPLETING_TURN_SETTLEMENTS,
     SETTLEMENTS_WITHOUT_RESULT,
@@ -3284,6 +3288,7 @@ class SessionTurnManager:
         successor_id: str | None = None
         interrupt_target_id: str | None = None
         should_interrupt = False
+        should_cancel_prewrite = False
         joined = False
         with self._runtime_start_owner(
             request.session_id,
@@ -3567,6 +3572,24 @@ class SessionTurnManager:
                     if claimed_control is None:
                         raise RuntimeError("P0 control-slot claim lost")
                     should_interrupt = current["state"] == "active"
+                    projected = self.in_flight.get(request.session_id)
+                    should_cancel_prewrite = bool(
+                        current["state"] == "starting"
+                        and projected is not None
+                        and projected.logical_turn_id == current_id
+                        and not projected.task.done()
+                        and backend_dispatch_attempted(projected.context) is False
+                    )
+                    if should_cancel_prewrite:
+                        claimed_control = delivery_store.cas_turn(
+                            conn,
+                            current_id,
+                            expected_version=int(claimed_control["version"]),
+                            expected_states=("starting",),
+                            values={"control_state": "interrupting"},
+                        )
+                        if claimed_control is None:
+                            raise RuntimeError("pre-write P0 control claim lost")
 
         if current is None and successor_id:
             await self._start_persisted_turn(successor_id, context=context)
@@ -3583,6 +3606,18 @@ class SessionTurnManager:
                 "queued" if delivery_id else "interrupt_waiting",
                 interrupt_target_id,
                 "joined_existing_interrupt",
+            )
+        if should_cancel_prewrite:
+            canceled = await self._cancel_prewrite_durable_turn(
+                request.session_id,
+                interrupt_target_id,
+            )
+            return DeliveryResult(
+                delivery_id,
+                None,
+                str(canceled.get("state") or "reconciling"),
+                interrupt_target_id,
+                canceled.get("reason"),
             )
         if not should_interrupt:
             return DeliveryResult(
@@ -3602,6 +3637,66 @@ class SessionTurnManager:
             interrupt_target_id,
             interrupted.get("reason"),
         )
+
+    async def _cancel_prewrite_durable_turn(
+        self,
+        session_id: str,
+        logical_turn_id: str | None,
+    ) -> dict[str, Any]:
+        """Cancel a live Turn that has definitive evidence of no native write."""
+
+        projected = self.in_flight.get(session_id)
+        if (
+            projected is None
+            or not logical_turn_id
+            or projected.logical_turn_id != logical_turn_id
+            or projected.task.done()
+            or backend_dispatch_attempted(projected.context) is not False
+        ):
+            return {"state": "reconciling", "reason": "prewrite_owner_changed"}
+
+        projected.cancel_settled_by = SETTLED_BY_STOPPED
+        projected.task.cancel()
+        await asyncio.gather(projected.task, return_exceptions=True)
+
+        with self._sqlite_engine().connect() as conn:
+            turn = delivery_store.get_turn(conn, logical_turn_id)
+            initial_delivery_ids = {
+                str(row["id"])
+                for row in delivery_store.initial_deliveries_for_turn(
+                    conn,
+                    logical_turn_id,
+                )
+                if row["state"] == "claimed"
+            }
+        if turn is None:
+            return {"state": "reconciling", "reason": "turn_missing"}
+        if turn["state"] == "terminal":
+            return {
+                "state": "settled",
+                "reason": (
+                    "prewrite_canceled"
+                    if turn.get("settled_by") == SETTLED_BY_STOPPED
+                    else "already_terminal"
+                ),
+            }
+
+        terminal = self._terminalize_durable_turn(
+            logical_turn_id,
+            "not_written",
+            settled_by=SETTLED_BY_STOPPED,
+            evidence_kind="user_stop_before_native_write",
+            evidence={"reason": "prewrite_canceled"},
+            retire_unwritten_delivery_ids=initial_delivery_ids,
+        )
+        if not terminal.get("changed"):
+            return {"state": "reconciling", "reason": "prewrite_terminal_cas_lost"}
+
+        successor_turn_id = str(terminal.get("successor_turn_id") or "")
+        if successor_turn_id:
+            await self._start_persisted_turn(successor_turn_id)
+            return {"state": "claimed", "reason": "prewrite_canceled"}
+        return {"state": "settled", "reason": "prewrite_canceled"}
 
     async def _interrupt_durable_turn(
         self,
@@ -4912,6 +5007,24 @@ class SessionTurnManager:
                     outcome=SETTLED_BY_REFUSED_CONCURRENT_TURN,
                 )
             if definitive_prewrite_exit:
+                if settled_by == SETTLED_BY_STOPPED:
+                    with self._sqlite_engine().connect() as conn:
+                        initial_delivery_ids = {
+                            str(row["id"])
+                            for row in delivery_store.initial_deliveries_for_turn(
+                                conn,
+                                turn_id,
+                            )
+                            if row["state"] == "claimed"
+                        }
+                    return self._terminalize_durable_turn(
+                        turn_id,
+                        "not_written",
+                        settled_by=SETTLED_BY_STOPPED,
+                        evidence_kind="user_stop_before_native_write",
+                        evidence={"reason": "prewrite_canceled"},
+                        retire_unwritten_delivery_ids=initial_delivery_ids,
+                    )
                 return self._settle_durable_prewrite_failure(
                     turn_id,
                     outcome=SETTLED_BY_NO_TERMINAL_RESULT,
@@ -7056,6 +7169,7 @@ class SessionTurnManager:
         else:
             logical_turn_id = logical_turn_id or context_turn_id or uuid.uuid4().hex
         context.platform_specific["turn_token"] = logical_turn_id
+        set_dispatch_phase(context, DISPATCH_PHASE_PREWRITE)
 
         async def _runner() -> None:
             cancelled = False
@@ -7099,6 +7213,19 @@ class SessionTurnManager:
                 )
                 settled_by = outcome.settled_by
                 definitive_prewrite_exit = outcome.backend_dispatch_attempted is False
+                current = self.in_flight.get(str(session_id or ""))
+                if (
+                    definitive_prewrite_exit
+                    and current is not None
+                    and current.task is asyncio.current_task()
+                    and current.logical_turn_id == logical_turn_id
+                    and current.cancel_settled_by == SETTLED_BY_STOPPED
+                ):
+                    # OpenCode intentionally absorbs the inner cancellation after
+                    # cleaning up its request. Preserve the Stop attribution at
+                    # this outer durable boundary so the input is retired instead
+                    # of becoming a queued retry.
+                    settled_by = SETTLED_BY_STOPPED
             except asyncio.CancelledError:
                 cancelled = True
                 # Do NOT decide the reason here: the canceller knows it, and it is

--- a/core/session_turns.py
+++ b/core/session_turns.py
@@ -33,11 +33,7 @@ from core.message_context import (
     SCHEDULED_DISPATCH_METADATA_APPLIED_KEY,
     resolve_turn_sink_key,
 )
-from core.native_dispatch_phase import (
-    DISPATCH_PHASE_PREWRITE,
-    backend_dispatch_attempted,
-    set_dispatch_phase,
-)
+from core.native_dispatch_phase import backend_dispatch_attempted
 from core.run_settlement import (
     NON_COMPLETING_TURN_SETTLEMENTS,
     SETTLEMENTS_WITHOUT_RESULT,
@@ -7169,7 +7165,6 @@ class SessionTurnManager:
         else:
             logical_turn_id = logical_turn_id or context_turn_id or uuid.uuid4().hex
         context.platform_specific["turn_token"] = logical_turn_id
-        set_dispatch_phase(context, DISPATCH_PHASE_PREWRITE)
 
         async def _runner() -> None:
             cancelled = False
@@ -7299,7 +7294,10 @@ class SessionTurnManager:
                     # persistence failure leaves the durable Turn unresolved for
                     # exact reconciliation; an empty fallback would overwrite that
                     # evidence with a fabricated terminal response.
-                    if definitive_prewrite_exit:
+                    if (
+                        definitive_prewrite_exit
+                        and settled_by != SETTLED_BY_STOPPED
+                    ):
                         try:
                             await self.controller.emit_agent_message(
                                 context,

--- a/core/session_turns.py
+++ b/core/session_turns.py
@@ -1768,6 +1768,7 @@ class SessionTurnManager:
         delivery_id: str,
         *,
         attempted_turn_id: str | None = None,
+        reason: str | None = None,
     ) -> DeliveryResult:
         """Return the exact post-transition Delivery instead of a cached claim."""
 
@@ -1787,6 +1788,7 @@ class SessionTurnManager:
             str(delivery.get("message_id") or "").strip() or None,
             state,
             turn_id or None,
+            reason,
             # Every caller reaches here right after dispatching a Turn this
             # Delivery participates in, so an owned state means this input
             # started the work rather than joining a Turn already running.
@@ -3608,6 +3610,12 @@ class SessionTurnManager:
                 request.session_id,
                 interrupt_target_id,
             )
+            if delivery_id is not None:
+                return self._committed_delivery_result(
+                    delivery_id,
+                    attempted_turn_id=successor_id,
+                    reason=canceled.get("reason"),
+                )
             return DeliveryResult(
                 delivery_id,
                 None,
@@ -3684,6 +3692,7 @@ class SessionTurnManager:
             evidence_kind="user_stop_before_native_write",
             evidence={"reason": "prewrite_canceled"},
             retire_unwritten_delivery_ids=initial_delivery_ids,
+            retire_unwritten_attempt_outcome="canceled",
         )
         if not terminal.get("changed"):
             return {"state": "reconciling", "reason": "prewrite_terminal_cas_lost"}
@@ -4382,6 +4391,7 @@ class SessionTurnManager:
         replay_unknown_start: bool = False,
         abandon_unaccepted_start: bool = False,
         retire_unwritten_delivery_ids: set[str] | None = None,
+        retire_unwritten_attempt_outcome: str = "invalid_input",
         resume_successors: bool = True,
     ) -> dict[str, Any]:
         if not self._durable_schema_available():
@@ -4569,7 +4579,11 @@ class SessionTurnManager:
                                 str(initial["id"]),
                                 expected_version=int(initial["version"]),
                                 expected_states=("claimed",),
-                                outcome=("invalid_input" if retire_unwritten else "not_written"),
+                                outcome=(
+                                    retire_unwritten_attempt_outcome
+                                    if retire_unwritten
+                                    else "not_written"
+                                ),
                                 next_state=next_state,
                                 next_priority="p3",
                                 receipt={"kind": evidence_kind, **(evidence or {})},
@@ -5020,6 +5034,7 @@ class SessionTurnManager:
                         evidence_kind="user_stop_before_native_write",
                         evidence={"reason": "prewrite_canceled"},
                         retire_unwritten_delivery_ids=initial_delivery_ids,
+                        retire_unwritten_attempt_outcome="canceled",
                     )
                 return self._settle_durable_prewrite_failure(
                     turn_id,

--- a/core/session_turns.py
+++ b/core/session_turns.py
@@ -33,7 +33,10 @@ from core.message_context import (
     SCHEDULED_DISPATCH_METADATA_APPLIED_KEY,
     resolve_turn_sink_key,
 )
-from core.native_dispatch_phase import backend_dispatch_attempted
+from core.native_dispatch_phase import (
+    backend_dispatch_attempted,
+    mark_prewrite_user_stop,
+)
 from core.run_settlement import (
     NON_COMPLETING_TURN_SETTLEMENTS,
     SETTLEMENTS_WITHOUT_RESULT,
@@ -3660,6 +3663,7 @@ class SessionTurnManager:
             return {"state": "reconciling", "reason": "prewrite_owner_changed"}
 
         projected.cancel_settled_by = SETTLED_BY_STOPPED
+        mark_prewrite_user_stop(projected.context)
         projected.task.cancel()
         await asyncio.gather(projected.task, return_exceptions=True)
 

--- a/modules/agents/opencode/agent.py
+++ b/modules/agents/opencode/agent.py
@@ -857,6 +857,8 @@ class OpenCodeAgent(OpenCodeMessageProcessorMixin, BaseAgent):
         poll_server: _SteeringAwareOpenCodeServer | None = None
         model_hub_overlay: OpenCodeOverlay | None = None
         model_hub_launch: ModelHubLaunch | None = None
+        model_hub_overlay_reservation: object | None = None
+        server = None
         # Bind early: get_or_create_session_id (below) can raise BEFORE assigning
         # session_id (a transient server error now that get_session raises on
         # non-404), and the error-cleanup paths reference session_id — keep it
@@ -880,10 +882,23 @@ class OpenCodeAgent(OpenCodeMessageProcessorMixin, BaseAgent):
             server = await self._get_server()
             configure_overlay = getattr(server, "configure_model_hub_overlay", None)
             if callable(configure_overlay):
-                await configure_overlay(model_hub_overlay)
+                model_hub_overlay_reservation = await configure_overlay(
+                    model_hub_overlay
+                )
             await server.ensure_running()
             activation_identity = self._attach_server_activation(server)
+        except asyncio.CancelledError:
+            await self._release_model_hub_overlay_reservation(
+                server,
+                model_hub_overlay_reservation,
+            )
+            raise
         except Exception as e:
+            await self._release_model_hub_overlay_reservation(
+                server,
+                model_hub_overlay_reservation,
+            )
+            model_hub_overlay_reservation = None
             logger.error(f"Failed to start OpenCode server: {e}", exc_info=True)
             await emit_backend_failure(
                 self.controller,
@@ -896,12 +911,31 @@ class OpenCodeAgent(OpenCodeMessageProcessorMixin, BaseAgent):
             await self._remove_ack_reaction(request)
             return
 
-        await self._delete_ack(request)
-        await self._session_manager.ensure_working_dir(request.working_path)
+        try:
+            await self._delete_ack(request)
+            await self._session_manager.ensure_working_dir(request.working_path)
+        except BaseException:
+            await self._release_model_hub_overlay_reservation(
+                server,
+                model_hub_overlay_reservation,
+            )
+            model_hub_overlay_reservation = None
+            raise
 
         try:
             session_id = await self._session_manager.get_or_create_session_id(request, server)
+        except asyncio.CancelledError:
+            await self._release_model_hub_overlay_reservation(
+                server,
+                model_hub_overlay_reservation,
+            )
+            raise
         except OpenCodeResumeUnavailableError as e:
+            await self._release_model_hub_overlay_reservation(
+                server,
+                model_hub_overlay_reservation,
+            )
+            model_hub_overlay_reservation = None
             # The previous session is gone server-side — surface it as a terminal
             # ERROR result (outbound chokepoint turns the dot red), don't silently
             # fork a fresh session and lose context.
@@ -916,6 +950,11 @@ class OpenCodeAgent(OpenCodeMessageProcessorMixin, BaseAgent):
             await self._remove_ack_reaction(request)
             return
         except Exception as e:
+            await self._release_model_hub_overlay_reservation(
+                server,
+                model_hub_overlay_reservation,
+            )
+            model_hub_overlay_reservation = None
             # A transient/transport/auth failure while acquiring the session
             # (get_session now raises on non-404, Codex P2): surface it as a
             # terminal error result instead of letting it propagate unhandled or be
@@ -934,6 +973,11 @@ class OpenCodeAgent(OpenCodeMessageProcessorMixin, BaseAgent):
             await self._remove_ack_reaction(request)
             return
         if not session_id:
+            await self._release_model_hub_overlay_reservation(
+                server,
+                model_hub_overlay_reservation,
+            )
+            model_hub_overlay_reservation = None
             await emit_backend_failure(
                 self.controller,
                 request.context,
@@ -945,18 +989,25 @@ class OpenCodeAgent(OpenCodeMessageProcessorMixin, BaseAgent):
             await self._remove_ack_reaction(request)
             return
 
-        self._session_manager.set_request_session(
-            request.base_session_id,
-            session_id,
-            request.working_path,
-            request.session_key,
-        )
-        self._session_manager.set_agent_session_id(
-            request.base_session_id,
-            _target_agent_session_id(request),
-        )
-
-        self._session_manager.mark_initialized(session_id)
+        try:
+            self._session_manager.set_request_session(
+                request.base_session_id,
+                session_id,
+                request.working_path,
+                request.session_key,
+            )
+            self._session_manager.set_agent_session_id(
+                request.base_session_id,
+                _target_agent_session_id(request),
+            )
+            self._session_manager.mark_initialized(session_id)
+        except BaseException:
+            await self._release_model_hub_overlay_reservation(
+                server,
+                model_hub_overlay_reservation,
+            )
+            model_hub_overlay_reservation = None
+            raise
 
         try:
             override_agent, override_model, override_reasoning = self.controller.get_opencode_overrides(request.context)
@@ -1098,7 +1149,14 @@ class OpenCodeAgent(OpenCodeMessageProcessorMixin, BaseAgent):
             if launch_identity is not None:
                 processing_indicator["model_hub_launch"] = launch_identity
 
-            await server.mark_run_active(session_id)
+            if model_hub_overlay_reservation is None:
+                await server.mark_run_active(session_id)
+            else:
+                await server.mark_run_active(
+                    session_id,
+                    overlay_reservation=model_hub_overlay_reservation,
+                )
+                model_hub_overlay_reservation = None
             run_registered = True
             # Persist the complete recovery address before the first native write.
             # A crash after OpenCode accepts the exact attempt part can now rebuild
@@ -1356,6 +1414,28 @@ class OpenCodeAgent(OpenCodeMessageProcessorMixin, BaseAgent):
                     self._steering_states.pop(request.base_session_id, None)
             if run_registered:
                 await server.mark_run_inactive(session_id)
+            await self._release_model_hub_overlay_reservation(
+                server,
+                model_hub_overlay_reservation,
+            )
+
+    @staticmethod
+    async def _release_model_hub_overlay_reservation(
+        server: Any,
+        reservation: object | None,
+    ) -> None:
+        if server is None or reservation is None:
+            return
+        release = getattr(server, "release_model_hub_overlay_reservation", None)
+        if not callable(release):
+            return
+        try:
+            await release(reservation)
+        except Exception:
+            logger.warning(
+                "Failed to release OpenCode Model Hub overlay reservation",
+                exc_info=True,
+            )
 
     def additional_steer_targets(self, session_id: str) -> list[ActiveSteerTarget]:
         """Expose restored poll owners that did not pass through AgentService."""

--- a/modules/agents/opencode/agent.py
+++ b/modules/agents/opencode/agent.py
@@ -21,7 +21,10 @@ from core.avibe_cloud import avibe_cloud_url_available
 from core.backend_failure import emit_backend_failure
 from core.message_output import stop_output_for, terminal_output_for
 from core.processing_indicator import STOPPED_REACTION_EMOJI
-from core.native_dispatch_phase import mark_backend_dispatch_attempted
+from core.native_dispatch_phase import (
+    mark_backend_dispatch_attempted,
+    prewrite_user_stop_requested,
+)
 from core.resource_governance import governor_from_controller
 from core.runtime_activation import RuntimeActivationIdentity
 from core.runtime_ownership import (
@@ -1326,7 +1329,7 @@ class OpenCodeAgent(OpenCodeMessageProcessorMixin, BaseAgent):
                 request,
                 terminal_emoji=(
                     STOPPED_REACTION_EMOJI
-                    if self.consume_user_stop_intent(request.base_session_id)
+                    if self._claim_user_stop_receipt(request)
                     else None
                 ),
             )
@@ -1464,10 +1467,17 @@ class OpenCodeAgent(OpenCodeMessageProcessorMixin, BaseAgent):
             request,
             terminal_emoji=(
                 STOPPED_REACTION_EMOJI
-                if self.consume_user_stop_intent(request.base_session_id)
+                if self._claim_user_stop_receipt(request)
                 else None
             ),
         )
+
+    def _claim_user_stop_receipt(self, request: AgentRequest) -> bool:
+        """Recognize adapter-local and shared prewrite Stop ownership."""
+
+        return self.consume_user_stop_intent(
+            request.base_session_id
+        ) or prewrite_user_stop_requested(request.context)
 
     def additional_steer_targets(self, session_id: str) -> list[ActiveSteerTarget]:
         """Expose restored poll owners that did not pass through AgentService."""

--- a/modules/agents/opencode/agent.py
+++ b/modules/agents/opencode/agent.py
@@ -888,7 +888,8 @@ class OpenCodeAgent(OpenCodeMessageProcessorMixin, BaseAgent):
             await server.ensure_running()
             activation_identity = self._attach_server_activation(server)
         except asyncio.CancelledError:
-            await self._release_model_hub_overlay_reservation(
+            await self._finish_prestart_cancellation(
+                request,
                 server,
                 model_hub_overlay_reservation,
             )
@@ -914,18 +915,26 @@ class OpenCodeAgent(OpenCodeMessageProcessorMixin, BaseAgent):
         try:
             await self._delete_ack(request)
             await self._session_manager.ensure_working_dir(request.working_path)
-        except BaseException:
-            await self._release_model_hub_overlay_reservation(
-                server,
-                model_hub_overlay_reservation,
-            )
+        except BaseException as error:
+            if isinstance(error, asyncio.CancelledError):
+                await self._finish_prestart_cancellation(
+                    request,
+                    server,
+                    model_hub_overlay_reservation,
+                )
+            else:
+                await self._release_model_hub_overlay_reservation(
+                    server,
+                    model_hub_overlay_reservation,
+                )
             model_hub_overlay_reservation = None
             raise
 
         try:
             session_id = await self._session_manager.get_or_create_session_id(request, server)
         except asyncio.CancelledError:
-            await self._release_model_hub_overlay_reservation(
+            await self._finish_prestart_cancellation(
+                request,
                 server,
                 model_hub_overlay_reservation,
             )
@@ -1001,11 +1010,18 @@ class OpenCodeAgent(OpenCodeMessageProcessorMixin, BaseAgent):
                 _target_agent_session_id(request),
             )
             self._session_manager.mark_initialized(session_id)
-        except BaseException:
-            await self._release_model_hub_overlay_reservation(
-                server,
-                model_hub_overlay_reservation,
-            )
+        except BaseException as error:
+            if isinstance(error, asyncio.CancelledError):
+                await self._finish_prestart_cancellation(
+                    request,
+                    server,
+                    model_hub_overlay_reservation,
+                )
+            else:
+                await self._release_model_hub_overlay_reservation(
+                    server,
+                    model_hub_overlay_reservation,
+                )
             model_hub_overlay_reservation = None
             raise
 
@@ -1436,6 +1452,22 @@ class OpenCodeAgent(OpenCodeMessageProcessorMixin, BaseAgent):
                 "Failed to release OpenCode Model Hub overlay reservation",
                 exc_info=True,
             )
+
+    async def _finish_prestart_cancellation(
+        self,
+        request: AgentRequest,
+        server: Any,
+        reservation: object | None,
+    ) -> None:
+        await self._release_model_hub_overlay_reservation(server, reservation)
+        await self._remove_ack_reaction(
+            request,
+            terminal_emoji=(
+                STOPPED_REACTION_EMOJI
+                if self.consume_user_stop_intent(request.base_session_id)
+                else None
+            ),
+        )
 
     def additional_steer_targets(self, session_id: str) -> list[ActiveSteerTarget]:
         """Expose restored poll owners that did not pass through AgentService."""

--- a/modules/agents/opencode/server.py
+++ b/modules/agents/opencode/server.py
@@ -131,6 +131,9 @@ class OpenCodeServerManager:
         self._model_hub_overlay_transition: tuple[
             Optional[str], Optional[str], object
         ] | None = None
+        self._model_hub_overlay_reservations: dict[
+            object, tuple[Optional[str], Optional[str]]
+        ] = {}
         self._model_hub_overlay_drain_timeout_seconds = MODEL_HUB_OVERLAY_DRAIN_TIMEOUT_SECONDS
         self._runtime_activation_retire: Callable[[bool], bool] | None = None
         self._runtime_generation_token: tuple[int, float | None] | None = None
@@ -454,8 +457,8 @@ class OpenCodeServerManager:
         active = info.get("active_run_sessions") if isinstance(info, dict) else None
         return isinstance(active, list) and bool(active)
 
-    async def configure_model_hub_overlay(self, overlay: Any | None) -> None:
-        """Apply a changed runtime-only overlay after active OpenCode work drains."""
+    async def configure_model_hub_overlay(self, overlay: Any | None) -> object:
+        """Select an overlay and reserve it until the caller registers its run."""
 
         desired_path = str(overlay.path) if overlay is not None else None
         desired_hash = str(overlay.content_hash) if overlay is not None else None
@@ -502,7 +505,11 @@ class OpenCodeServerManager:
                             self._model_hub_overlay_path = desired_path
                             self._model_hub_overlay_hash = desired_hash
                             self._model_hub_overlay_content = desired_content
-                            return
+                            self._model_hub_overlay_reservations[transition_owner] = (
+                                desired_path,
+                                desired_hash,
+                            )
+                            return transition_owner
 
                         if not owns_transition:
                             self._model_hub_overlay_transition = (
@@ -512,7 +519,11 @@ class OpenCodeServerManager:
                             )
                             owns_transition = True
 
-                        if self._active_requests > 0 or self._has_active_run_sessions():
+                        if (
+                            self._active_requests > 0
+                            or self._has_active_run_sessions()
+                            or self._model_hub_overlay_reservations
+                        ):
                             should_wait = True
                         else:
                             persisted_active = current_server and bool(
@@ -534,9 +545,12 @@ class OpenCodeServerManager:
                                         "Restarting OpenCode server after Model Hub overlay change"
                                     )
                                     await self._restart_for_auth_refresh_locked()
+                                self._model_hub_overlay_reservations[
+                                    transition_owner
+                                ] = (desired_path, desired_hash)
                                 self._model_hub_overlay_transition = None
                                 owns_transition = False
-                                return
+                                return transition_owner
                 if should_wait:
                     await asyncio.sleep(0.05)
         finally:
@@ -546,10 +560,44 @@ class OpenCodeServerManager:
                     if transition is not None and transition[2] is transition_owner:
                         self._model_hub_overlay_transition = None
 
-    async def mark_run_active(self, session_id: str) -> None:
+    async def release_model_hub_overlay_reservation(
+        self,
+        reservation: object,
+    ) -> None:
         async with self._get_lock():
+            self._model_hub_overlay_reservations.pop(reservation, None)
+
+    async def mark_run_active(
+        self,
+        session_id: str,
+        *,
+        overlay_reservation: object | None = None,
+    ) -> None:
+        async with self._get_lock():
+            reserved_overlay = None
+            if overlay_reservation is not None:
+                reserved_overlay = self._model_hub_overlay_reservations.get(
+                    overlay_reservation
+                )
+                if reserved_overlay is None:
+                    raise RuntimeError("OpenCode overlay reservation is no longer active")
+            run_was_active = session_id in self._active_run_sessions
             self._active_run_sessions.add(session_id)
-            self._write_active_run_sessions_to_pid_file()
+            if overlay_reservation is not None:
+                self._model_hub_overlay_reservations.pop(
+                    overlay_reservation,
+                    None,
+                )
+            try:
+                self._write_active_run_sessions_to_pid_file()
+            except Exception:
+                if not run_was_active:
+                    self._active_run_sessions.discard(session_id)
+                if overlay_reservation is not None and reserved_overlay is not None:
+                    self._model_hub_overlay_reservations[
+                        overlay_reservation
+                    ] = reserved_overlay
+                raise
 
     async def mark_run_inactive(self, session_id: str) -> None:
         async with self._get_lock():

--- a/modules/agents/opencode/server.py
+++ b/modules/agents/opencode/server.py
@@ -452,7 +452,7 @@ class OpenCodeServerManager:
         return isinstance(active, list) and bool(active)
 
     async def configure_model_hub_overlay(self, overlay: Any | None) -> None:
-        """Apply a runtime-only overlay after all active OpenCode work drains."""
+        """Apply a changed runtime-only overlay after active OpenCode work drains."""
 
         desired_path = str(overlay.path) if overlay is not None else None
         desired_hash = str(overlay.content_hash) if overlay is not None else None
@@ -467,11 +467,27 @@ class OpenCodeServerManager:
         while True:
             should_wait = False
             async with self._get_lock():
+                info = self._read_pid_file() or {}
+                current_server = self._pid_file_references_current_server(info)
+                effective_path = info.get("model_hub_overlay_path") if current_server else None
+                effective_hash = info.get("model_hub_overlay_hash") if current_server else None
+                if effective_path is None and effective_hash is None:
+                    effective_path = self._model_hub_overlay_path
+                    effective_hash = self._model_hub_overlay_hash
+
+                # Most turns reuse the running server's overlay. They must not
+                # wait behind unrelated active work because no runtime mutation
+                # is required. Cache the content so a later crash still restarts
+                # with the same OPENCODE_CONFIG.
+                if (effective_path, effective_hash) == (desired_path, desired_hash):
+                    self._model_hub_overlay_path = desired_path
+                    self._model_hub_overlay_hash = desired_hash
+                    self._model_hub_overlay_content = desired_content
+                    return
+
                 if self._active_requests > 0 or self._has_active_run_sessions():
                     should_wait = True
                 else:
-                    info = self._read_pid_file() or {}
-                    current_server = self._pid_file_references_current_server(info)
                     persisted_active = current_server and bool(info.get("active_run_sessions"))
                     if persisted_active and time.monotonic() < drain_deadline:
                         should_wait = True
@@ -481,20 +497,9 @@ class OpenCodeServerManager:
                                 "Ignoring stale OpenCode active-run metadata after %.1fs overlay drain timeout",
                                 self._model_hub_overlay_drain_timeout_seconds,
                             )
-                        effective_path = info.get("model_hub_overlay_path") if current_server else None
-                        effective_hash = info.get("model_hub_overlay_hash") if current_server else None
-                        if effective_path is None and effective_hash is None:
-                            effective_path = self._model_hub_overlay_path
-                            effective_hash = self._model_hub_overlay_hash
-
-                        # Cache the desired state even when adopted pid metadata
-                        # already matches. A later crash must restart with the
-                        # same OPENCODE_CONFIG without relying on the old pid file.
                         self._model_hub_overlay_path = desired_path
                         self._model_hub_overlay_hash = desired_hash
                         self._model_hub_overlay_content = desired_content
-                        if (effective_path, effective_hash) == (desired_path, desired_hash):
-                            return
                         if await self._is_healthy():
                             logger.info("Restarting OpenCode server after Model Hub overlay change")
                             await self._restart_for_auth_refresh_locked()

--- a/modules/agents/opencode/server.py
+++ b/modules/agents/opencode/server.py
@@ -128,6 +128,9 @@ class OpenCodeServerManager:
         self._model_hub_overlay_path: Optional[str] = None
         self._model_hub_overlay_hash: Optional[str] = None
         self._model_hub_overlay_content: Optional[str] = None
+        self._model_hub_overlay_transition: tuple[
+            Optional[str], Optional[str], object
+        ] | None = None
         self._model_hub_overlay_drain_timeout_seconds = MODEL_HUB_OVERLAY_DRAIN_TIMEOUT_SECONDS
         self._runtime_activation_retire: Callable[[bool], bool] | None = None
         self._runtime_generation_token: tuple[int, float | None] | None = None
@@ -464,48 +467,84 @@ class OpenCodeServerManager:
             elif isinstance(content, str):
                 desired_content = content
         drain_deadline = time.monotonic() + self._model_hub_overlay_drain_timeout_seconds
-        while True:
-            should_wait = False
-            async with self._get_lock():
-                info = self._read_pid_file() or {}
-                current_server = self._pid_file_references_current_server(info)
-                effective_path = info.get("model_hub_overlay_path") if current_server else None
-                effective_hash = info.get("model_hub_overlay_hash") if current_server else None
-                if effective_path is None and effective_hash is None:
-                    effective_path = self._model_hub_overlay_path
-                    effective_hash = self._model_hub_overlay_hash
-
-                # Most turns reuse the running server's overlay. They must not
-                # wait behind unrelated active work because no runtime mutation
-                # is required. Cache the content so a later crash still restarts
-                # with the same OPENCODE_CONFIG.
-                if (effective_path, effective_hash) == (desired_path, desired_hash):
-                    self._model_hub_overlay_path = desired_path
-                    self._model_hub_overlay_hash = desired_hash
-                    self._model_hub_overlay_content = desired_content
-                    return
-
-                if self._active_requests > 0 or self._has_active_run_sessions():
-                    should_wait = True
-                else:
-                    persisted_active = current_server and bool(info.get("active_run_sessions"))
-                    if persisted_active and time.monotonic() < drain_deadline:
+        transition_owner = object()
+        owns_transition = False
+        try:
+            while True:
+                should_wait = False
+                async with self._get_lock():
+                    transition = self._model_hub_overlay_transition
+                    if transition is not None and transition[2] is not transition_owner:
+                        # Once a real configuration change is queued, new turns on
+                        # the old overlay must wait. Otherwise they can continuously
+                        # replenish the active set and starve the transition.
                         should_wait = True
                     else:
-                        if persisted_active:
-                            logger.warning(
-                                "Ignoring stale OpenCode active-run metadata after %.1fs overlay drain timeout",
-                                self._model_hub_overlay_drain_timeout_seconds,
+                        info = self._read_pid_file() or {}
+                        current_server = self._pid_file_references_current_server(info)
+                        effective_path = (
+                            info.get("model_hub_overlay_path") if current_server else None
+                        )
+                        effective_hash = (
+                            info.get("model_hub_overlay_hash") if current_server else None
+                        )
+                        if effective_path is None and effective_hash is None:
+                            effective_path = self._model_hub_overlay_path
+                            effective_hash = self._model_hub_overlay_hash
+
+                        # Most turns reuse the running server's overlay. They must
+                        # not wait behind unrelated active work when no transition
+                        # has claimed the runtime.
+                        if (effective_path, effective_hash) == (
+                            desired_path,
+                            desired_hash,
+                        ):
+                            self._model_hub_overlay_path = desired_path
+                            self._model_hub_overlay_hash = desired_hash
+                            self._model_hub_overlay_content = desired_content
+                            return
+
+                        if not owns_transition:
+                            self._model_hub_overlay_transition = (
+                                desired_path,
+                                desired_hash,
+                                transition_owner,
                             )
-                        self._model_hub_overlay_path = desired_path
-                        self._model_hub_overlay_hash = desired_hash
-                        self._model_hub_overlay_content = desired_content
-                        if await self._is_healthy():
-                            logger.info("Restarting OpenCode server after Model Hub overlay change")
-                            await self._restart_for_auth_refresh_locked()
-                        return
-            if should_wait:
-                await asyncio.sleep(0.05)
+                            owns_transition = True
+
+                        if self._active_requests > 0 or self._has_active_run_sessions():
+                            should_wait = True
+                        else:
+                            persisted_active = current_server and bool(
+                                info.get("active_run_sessions")
+                            )
+                            if persisted_active and time.monotonic() < drain_deadline:
+                                should_wait = True
+                            else:
+                                if persisted_active:
+                                    logger.warning(
+                                        "Ignoring stale OpenCode active-run metadata after %.1fs overlay drain timeout",
+                                        self._model_hub_overlay_drain_timeout_seconds,
+                                    )
+                                self._model_hub_overlay_path = desired_path
+                                self._model_hub_overlay_hash = desired_hash
+                                self._model_hub_overlay_content = desired_content
+                                if await self._is_healthy():
+                                    logger.info(
+                                        "Restarting OpenCode server after Model Hub overlay change"
+                                    )
+                                    await self._restart_for_auth_refresh_locked()
+                                self._model_hub_overlay_transition = None
+                                owns_transition = False
+                                return
+                if should_wait:
+                    await asyncio.sleep(0.05)
+        finally:
+            if owns_transition:
+                async with self._get_lock():
+                    transition = self._model_hub_overlay_transition
+                    if transition is not None and transition[2] is transition_owner:
+                        self._model_hub_overlay_transition = None
 
     async def mark_run_active(self, session_id: str) -> None:
         async with self._get_lock():

--- a/tests/scenarios/INDEX.yaml
+++ b/tests/scenarios/INDEX.yaml
@@ -73,6 +73,7 @@ capabilities:
       - tests/test_model_hub_resolution.py
       - tests/test_model_hub_injection.py
       - tests/test_model_hub_runtime.py
+      - tests/test_opencode_server.py
   - id: harness_failure_recovery
     name: Harness per-Session failure recovery
     status: active

--- a/tests/scenarios/message_delivery/catalog.yaml
+++ b/tests/scenarios/message_delivery/catalog.yaml
@@ -140,6 +140,12 @@ scenarios:
     kind: recovery
     layer: contract
     test: tests/test_agent_steering.py::test_message_delivery_021_opencode_preserves_native_order_and_recovers_exact_part
+  - id: MESSAGE-DELIVERY-022
+    name: Stop retires a starting Turn that has not reached the native write boundary
+    status: covered
+    kind: lifecycle
+    layer: contract
+    test: tests/test_session_delivery_fsm.py::test_stop_cancels_a_starting_turn_before_native_write
   - id: MESSAGE-DELIVERY-101
     name: Unresolved fallback-capable delivery fences only later FIFO submissions
     status: covered

--- a/tests/scenarios/model_hub/catalog.yaml
+++ b/tests/scenarios/model_hub/catalog.yaml
@@ -8,6 +8,7 @@ capability:
     - tests/test_model_hub_resolution.py
     - tests/test_model_hub_injection.py
     - tests/test_model_hub_runtime.py
+    - tests/test_opencode_server.py
     - tests/scenarios/model_hub/test_model_hub_catalog.py
     - tests/scenarios/model_hub/test_model_hub_configured_route_scenarios.py
     - tests/scenarios/model_hub/test_model_hub_live_resolution_scenarios.py
@@ -98,6 +99,12 @@ scenarios:
     layer: unit
     missing_layer: scenario
     test: tests/test_model_hub_runtime.py::test_mh_runtime_001_service_restart_reports_installed_engine_as_not_started
+  - id: MH-RUNTIME-002
+    name: Matching OpenCode overlay never waits behind an unrelated active Turn
+    status: covered
+    kind: concurrency
+    layer: unit
+    test: tests/test_opencode_server.py::test_mh_runtime_002_matching_overlay_does_not_wait_for_an_unrelated_active_run
   - id: MH-RES-LIVE-001
     name: Live turn retries an eligible backup before streaming starts
     status: covered

--- a/tests/scenarios/model_hub/catalog.yaml
+++ b/tests/scenarios/model_hub/catalog.yaml
@@ -105,6 +105,12 @@ scenarios:
     kind: concurrency
     layer: unit
     test: tests/test_opencode_server.py::test_mh_runtime_002_matching_overlay_does_not_wait_for_an_unrelated_active_run
+  - id: MH-RUNTIME-003
+    name: A pending OpenCode overlay transition cannot be starved by new Turns on the old overlay
+    status: covered
+    kind: concurrency
+    layer: unit
+    test: tests/test_opencode_server.py::test_mh_runtime_003_pending_overlay_transition_blocks_new_turns_on_the_old_overlay
   - id: MH-RES-LIVE-001
     name: Live turn retries an eligible backup before streaming starts
     status: covered

--- a/tests/scenarios/model_hub/catalog.yaml
+++ b/tests/scenarios/model_hub/catalog.yaml
@@ -111,6 +111,12 @@ scenarios:
     kind: concurrency
     layer: unit
     test: tests/test_opencode_server.py::test_mh_runtime_003_pending_overlay_transition_blocks_new_turns_on_the_old_overlay
+  - id: MH-RUNTIME-004
+    name: An OpenCode overlay selection remains reserved until its initiating Turn becomes active
+    status: covered
+    kind: concurrency
+    layer: unit
+    test: tests/test_opencode_server.py::test_mh_runtime_004_overlay_reservation_promotes_atomically_to_active_run
   - id: MH-RES-LIVE-001
     name: Live turn retries an eligible backup before streaming starts
     status: covered

--- a/tests/test_multi_platform_runtime.py
+++ b/tests/test_multi_platform_runtime.py
@@ -690,8 +690,16 @@ def test_opencode_prompt_disables_question_tool_for_all_platforms():
     active_polls = []
     active_poll_updates = []
     recovery_order = []
+    overlay_reservation = object()
+    configured_overlays = []
+    active_registrations = []
+    released_reservations = []
 
     class _Server:
+        async def configure_model_hub_overlay(self, overlay):
+            configured_overlays.append(overlay)
+            return overlay_reservation
+
         async def ensure_running(self):
             return None
 
@@ -716,8 +724,11 @@ def test_opencode_prompt_disables_question_tool_for_all_platforms():
             recovery_order.append("prompt")
             calls.append(kwargs)
 
-        async def mark_run_active(self, session_id):
-            return None
+        async def mark_run_active(self, session_id, *, overlay_reservation=None):
+            active_registrations.append((session_id, overlay_reservation))
+
+        async def release_model_hub_overlay_reservation(self, reservation):
+            released_reservations.append(reservation)
 
         async def mark_run_inactive(self, session_id):
             return None
@@ -845,6 +856,9 @@ def test_opencode_prompt_disables_question_tool_for_all_platforms():
     assert calls[0]["attempt_id"] == ATTEMPT_ID
     assert "message_id" not in calls[0]
     assert recovery_order[:3] == ["poll", "prompt", "accepted"]
+    assert configured_overlays == [None]
+    assert active_registrations == [("oc-session", overlay_reservation)]
+    assert released_reservations == []
     assert active_poll_updates[0][0] == "oc-session"
     assert isinstance(active_poll_updates[0][1]["prompt_started_at"], float)
     steering_snapshot = active_polls[0]["processing_indicator"]["opencode_native_steering"]

--- a/tests/test_opencode_server.py
+++ b/tests/test_opencode_server.py
@@ -2344,5 +2344,62 @@ async def _async_none():
     return None
 
 
+def test_mh_runtime_002_matching_overlay_does_not_wait_for_an_unrelated_active_run():
+    """MH-RUNTIME-002: unchanged direct mode cannot head-of-line block another Session."""
+
+    manager = OpenCodeServerManager(binary="opencode", port=4096)
+    manager._active_run_sessions.add("sess-unrelated")
+    manager._read_pid_file = lambda: {  # type: ignore[method-assign]
+        "pid": 321,
+        "port": 4096,
+        "active_run_sessions": ["sess-unrelated"],
+    }
+    manager._pid_file_references_current_server = Mock(return_value=True)  # type: ignore[method-assign]
+    manager._is_healthy = AsyncMock(return_value=True)  # type: ignore[method-assign]
+    manager._restart_for_auth_refresh_locked = AsyncMock()  # type: ignore[method-assign]
+
+    asyncio.run(
+        asyncio.wait_for(
+            manager.configure_model_hub_overlay(None),
+            timeout=0.1,
+        )
+    )
+
+    assert manager._model_hub_overlay_path is None
+    assert manager._model_hub_overlay_hash is None
+    assert manager._model_hub_overlay_content is None
+    manager._is_healthy.assert_not_awaited()
+    manager._restart_for_auth_refresh_locked.assert_not_awaited()
+
+
+def test_changed_overlay_still_waits_for_active_run_before_restart():
+    manager = OpenCodeServerManager(binary="opencode", port=4096)
+    manager._model_hub_overlay_path = "/tmp/old-overlay.json"
+    manager._model_hub_overlay_hash = "old-hash"
+    manager._active_run_sessions.add("sess-active")
+    manager._read_pid_file = lambda: {}  # type: ignore[method-assign]
+    manager._pid_file_references_current_server = Mock(return_value=False)  # type: ignore[method-assign]
+    manager._is_healthy = AsyncMock(return_value=True)  # type: ignore[method-assign]
+    manager._restart_for_auth_refresh_locked = AsyncMock()  # type: ignore[method-assign]
+    overlay = types.SimpleNamespace(
+        path=Path("/tmp/new-overlay.json"),
+        content_hash="new-hash",
+        content='{"provider": {}}',
+    )
+
+    async def exercise():
+        configuring = asyncio.create_task(manager.configure_model_hub_overlay(overlay))
+        await asyncio.sleep(0.01)
+        assert not configuring.done()
+        manager._active_run_sessions.clear()
+        await asyncio.wait_for(configuring, timeout=0.2)
+
+    asyncio.run(exercise())
+
+    assert manager._model_hub_overlay_path == str(overlay.path)
+    assert manager._model_hub_overlay_hash == overlay.content_hash
+    manager._restart_for_auth_refresh_locked.assert_awaited_once()
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_opencode_server.py
+++ b/tests/test_opencode_server.py
@@ -2358,12 +2358,13 @@ def test_mh_runtime_002_matching_overlay_does_not_wait_for_an_unrelated_active_r
     manager._is_healthy = AsyncMock(return_value=True)  # type: ignore[method-assign]
     manager._restart_for_auth_refresh_locked = AsyncMock()  # type: ignore[method-assign]
 
-    asyncio.run(
+    reservation = asyncio.run(
         asyncio.wait_for(
             manager.configure_model_hub_overlay(None),
             timeout=0.1,
         )
     )
+    asyncio.run(manager.release_model_hub_overlay_reservation(reservation))
 
     assert manager._model_hub_overlay_path is None
     assert manager._model_hub_overlay_hash is None
@@ -2392,7 +2393,8 @@ def test_changed_overlay_still_waits_for_active_run_before_restart():
         await asyncio.sleep(0.01)
         assert not configuring.done()
         manager._active_run_sessions.clear()
-        await asyncio.wait_for(configuring, timeout=0.2)
+        reservation = await asyncio.wait_for(configuring, timeout=0.2)
+        await manager.release_model_hub_overlay_reservation(reservation)
 
     asyncio.run(exercise())
 
@@ -2436,7 +2438,8 @@ def test_mh_runtime_003_pending_overlay_transition_blocks_new_turns_on_the_old_o
         matching_old_turn.cancel()
         await asyncio.gather(matching_old_turn, return_exceptions=True)
         manager._active_run_sessions.clear()
-        await asyncio.wait_for(configuring, timeout=0.2)
+        reservation = await asyncio.wait_for(configuring, timeout=0.2)
+        await manager.release_model_hub_overlay_reservation(reservation)
 
     asyncio.run(exercise())
 
@@ -2444,6 +2447,55 @@ def test_mh_runtime_003_pending_overlay_transition_blocks_new_turns_on_the_old_o
     assert manager._model_hub_overlay_hash == new_overlay.content_hash
     assert manager._model_hub_overlay_transition is None
     manager._restart_for_auth_refresh_locked.assert_awaited_once()
+
+
+def test_mh_runtime_004_overlay_reservation_promotes_atomically_to_active_run():
+    """MH-RUNTIME-004: selection stays leased through active-run registration."""
+
+    manager = OpenCodeServerManager(binary="opencode", port=4096)
+    manager._model_hub_overlay_path = "/tmp/old-overlay.json"
+    manager._model_hub_overlay_hash = "old-hash"
+    manager._read_pid_file = lambda: {}  # type: ignore[method-assign]
+    manager._pid_file_references_current_server = Mock(return_value=False)  # type: ignore[method-assign]
+    manager._is_healthy = AsyncMock(return_value=True)  # type: ignore[method-assign]
+    manager._restart_for_auth_refresh_locked = AsyncMock()  # type: ignore[method-assign]
+    old_overlay = types.SimpleNamespace(
+        path=Path("/tmp/old-overlay.json"),
+        content_hash="old-hash",
+        content='{"provider": {}}',
+    )
+    new_overlay = types.SimpleNamespace(
+        path=Path("/tmp/new-overlay.json"),
+        content_hash="new-hash",
+        content='{"provider": {}}',
+    )
+
+    async def exercise():
+        reservation = await manager.configure_model_hub_overlay(new_overlay)
+        reverting = asyncio.create_task(
+            manager.configure_model_hub_overlay(old_overlay)
+        )
+        await asyncio.sleep(0.01)
+        assert not reverting.done()
+
+        await manager.mark_run_active(
+            "sess-new",
+            overlay_reservation=reservation,
+        )
+        await asyncio.sleep(0.01)
+        assert not reverting.done()
+
+        await manager.mark_run_inactive("sess-new")
+        old_reservation = await asyncio.wait_for(reverting, timeout=0.2)
+        await manager.release_model_hub_overlay_reservation(old_reservation)
+
+    asyncio.run(exercise())
+
+    assert manager._model_hub_overlay_path == str(old_overlay.path)
+    assert manager._model_hub_overlay_hash == old_overlay.content_hash
+    assert manager._model_hub_overlay_reservations == {}
+    assert manager._active_run_sessions == set()
+    assert manager._restart_for_auth_refresh_locked.await_count == 2
 
 
 if __name__ == "__main__":

--- a/tests/test_opencode_server.py
+++ b/tests/test_opencode_server.py
@@ -2401,5 +2401,50 @@ def test_changed_overlay_still_waits_for_active_run_before_restart():
     manager._restart_for_auth_refresh_locked.assert_awaited_once()
 
 
+def test_mh_runtime_003_pending_overlay_transition_blocks_new_turns_on_the_old_overlay():
+    """MH-RUNTIME-003: a queued change drains without old-overlay starvation."""
+
+    manager = OpenCodeServerManager(binary="opencode", port=4096)
+    manager._model_hub_overlay_path = "/tmp/old-overlay.json"
+    manager._model_hub_overlay_hash = "old-hash"
+    manager._active_run_sessions.add("sess-active")
+    manager._read_pid_file = lambda: {}  # type: ignore[method-assign]
+    manager._pid_file_references_current_server = Mock(return_value=False)  # type: ignore[method-assign]
+    manager._is_healthy = AsyncMock(return_value=True)  # type: ignore[method-assign]
+    manager._restart_for_auth_refresh_locked = AsyncMock()  # type: ignore[method-assign]
+    old_overlay = types.SimpleNamespace(
+        path=Path("/tmp/old-overlay.json"),
+        content_hash="old-hash",
+        content='{"provider": {}}',
+    )
+    new_overlay = types.SimpleNamespace(
+        path=Path("/tmp/new-overlay.json"),
+        content_hash="new-hash",
+        content='{"provider": {}}',
+    )
+
+    async def exercise():
+        configuring = asyncio.create_task(
+            manager.configure_model_hub_overlay(new_overlay)
+        )
+        await asyncio.sleep(0.01)
+        matching_old_turn = asyncio.create_task(
+            manager.configure_model_hub_overlay(old_overlay)
+        )
+        await asyncio.sleep(0.01)
+        assert not matching_old_turn.done()
+        matching_old_turn.cancel()
+        await asyncio.gather(matching_old_turn, return_exceptions=True)
+        manager._active_run_sessions.clear()
+        await asyncio.wait_for(configuring, timeout=0.2)
+
+    asyncio.run(exercise())
+
+    assert manager._model_hub_overlay_path == str(new_overlay.path)
+    assert manager._model_hub_overlay_hash == new_overlay.content_hash
+    assert manager._model_hub_overlay_transition is None
+    manager._restart_for_auth_refresh_locked.assert_awaited_once()
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_opencode_stop_receipt.py
+++ b/tests/test_opencode_stop_receipt.py
@@ -227,6 +227,31 @@ class OpenCodeStopIntentTests(unittest.IsolatedAsyncioTestCase):
         self.assertFalse(result)
         self.assertEqual(agent._user_stopped_sessions, set())
 
+    async def test_prestart_cancellation_releases_overlay_and_stamps_stop_receipt(self):
+        agent = _agent()
+        request = _request()
+        reservation = object()
+        server = SimpleNamespace(
+            release_model_hub_overlay_reservation=AsyncMock()
+        )
+        agent._remove_ack_reaction = AsyncMock()
+        agent._user_stopped_sessions.add(request.base_session_id)
+
+        await agent._finish_prestart_cancellation(
+            request,
+            server,
+            reservation,
+        )
+
+        server.release_model_hub_overlay_reservation.assert_awaited_once_with(
+            reservation
+        )
+        agent._remove_ack_reaction.assert_awaited_once_with(
+            request,
+            terminal_emoji=STOPPED_REACTION_EMOJI,
+        )
+        self.assertEqual(agent._user_stopped_sessions, set())
+
     async def test_restored_poll_cancellation_stamps_its_retained_request(self):
         entered = asyncio.Event()
         cleanups: list[tuple[object, object]] = []
@@ -305,12 +330,11 @@ class OpenCodeStopReceiptTests(unittest.TestCase):
 
     def test_cancellation_branch_reads_the_intent(self):
         source = inspect.getsource(OpenCodeAgent._process_message)
-        _, _, after = source.partition("except asyncio.CancelledError:")
-        branch = after.partition("raise")[0]
+        cleanup = inspect.getsource(OpenCodeAgent._finish_prestart_cancellation)
 
-        self.assertTrue(branch, "_process_message no longer handles cancellation")
-        self.assertIn("consume_user_stop_intent", branch)
-        self.assertIn("STOPPED_REACTION_EMOJI", branch)
+        self.assertIn("_finish_prestart_cancellation", source)
+        self.assertIn("consume_user_stop_intent", cleanup)
+        self.assertIn("STOPPED_REACTION_EMOJI", cleanup)
 
     def test_restored_cancellation_branch_reads_the_intent(self):
         source = inspect.getsource(OpenCodePollLoop.run_restored_poll_loop)

--- a/tests/test_opencode_stop_receipt.py
+++ b/tests/test_opencode_stop_receipt.py
@@ -23,6 +23,7 @@ import pytest
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from config.v2_sessions import ActivePollInfo
+from core.native_dispatch_phase import mark_prewrite_user_stop
 from core.processing_indicator import STOPPED_REACTION_EMOJI, ProcessingIndicatorService
 from modules.agents.opencode.agent import OpenCodeAgent
 from modules.agents.opencode.poll_loop import OpenCodePollLoop
@@ -235,7 +236,7 @@ class OpenCodeStopIntentTests(unittest.IsolatedAsyncioTestCase):
             release_model_hub_overlay_reservation=AsyncMock()
         )
         agent._remove_ack_reaction = AsyncMock()
-        agent._user_stopped_sessions.add(request.base_session_id)
+        mark_prewrite_user_stop(request.context)
 
         await agent._finish_prestart_cancellation(
             request,
@@ -331,9 +332,12 @@ class OpenCodeStopReceiptTests(unittest.TestCase):
     def test_cancellation_branch_reads_the_intent(self):
         source = inspect.getsource(OpenCodeAgent._process_message)
         cleanup = inspect.getsource(OpenCodeAgent._finish_prestart_cancellation)
+        claim = inspect.getsource(OpenCodeAgent._claim_user_stop_receipt)
 
         self.assertIn("_finish_prestart_cancellation", source)
-        self.assertIn("consume_user_stop_intent", cleanup)
+        self.assertIn("_claim_user_stop_receipt", cleanup)
+        self.assertIn("consume_user_stop_intent", claim)
+        self.assertIn("prewrite_user_stop_requested", claim)
         self.assertIn("STOPPED_REACTION_EMOJI", cleanup)
 
     def test_restored_cancellation_branch_reads_the_intent(self):

--- a/tests/test_session_delivery_fsm.py
+++ b/tests/test_session_delivery_fsm.py
@@ -16,6 +16,7 @@ from core.services.dispatch import TurnDispatchOutcome
 from core.native_dispatch_phase import (
     DISPATCH_PHASE_ATTEMPTING,
     DISPATCH_PHASE_PREWRITE,
+    prewrite_user_stop_requested,
     set_dispatch_phase,
 )
 from core.run_settlement import (
@@ -3291,13 +3292,20 @@ def test_stop_cancels_a_starting_turn_before_native_write(managers, monkeypatch)
         settle_agent_runs_without_result=settle_runs,
     )
     dispatch_entered = asyncio.Event()
+    stop_intent_seen: list[bool] = []
 
     async def blocked_prewrite_dispatch(_controller, dispatch_context, *_args, **_kwargs):
-        set_dispatch_phase(dispatch_context, DISPATCH_PHASE_PREWRITE)
+        dispatch_evidence = set_dispatch_phase(
+            dispatch_context,
+            DISPATCH_PHASE_PREWRITE,
+        )
         dispatch_entered.set()
         try:
             await asyncio.Event().wait()
         except asyncio.CancelledError:
+            stop_intent_seen.append(
+                prewrite_user_stop_requested(dispatch_context)
+            )
             # OpenCode absorbs cancellation after cleaning up its inner request
             # task, so lock that adapter behavior into the shared Stop contract.
             return TurnDispatchOutcome(
@@ -3340,6 +3348,7 @@ def test_stop_cancels_a_starting_turn_before_native_write(managers, monkeypatch)
     assert "ses_fsm" not in manager.in_flight
     manager.controller.command_handler.handle_stop.assert_not_awaited()
     manager.controller.emit_agent_message.assert_not_awaited()
+    assert stop_intent_seen == [True]
     assert settle_calls == [(["run-stop-prewrite"], SETTLED_BY_STOPPED)]
     with engine.connect() as conn:
         turn = delivery_store.get_turn(conn, turn_id)

--- a/tests/test_session_delivery_fsm.py
+++ b/tests/test_session_delivery_fsm.py
@@ -3280,9 +3280,19 @@ def test_stop_cancels_a_starting_turn_before_native_write(managers, monkeypatch)
 
     manager, _other, engine, _engine_b, _starts = managers
     manager._run = SessionTurnManager._run.__get__(manager, SessionTurnManager)
+    manager.controller.emit_agent_message = AsyncMock()
+    settle_calls: list[tuple[list[str], str]] = []
+
+    def settle_runs(run_ids, *, settled_by):
+        settle_calls.append((run_ids, settled_by))
+
+    manager.controller.scheduled_task_service = SimpleNamespace(
+        settle_agent_runs_without_result=settle_runs,
+    )
     dispatch_entered = asyncio.Event()
 
-    async def blocked_prewrite_dispatch(*_args, **_kwargs):
+    async def blocked_prewrite_dispatch(_controller, dispatch_context, *_args, **_kwargs):
+        set_dispatch_phase(dispatch_context, DISPATCH_PHASE_PREWRITE)
         dispatch_entered.set()
         try:
             await asyncio.Event().wait()
@@ -3301,16 +3311,20 @@ def test_stop_cancels_a_starting_turn_before_native_write(managers, monkeypatch)
     )
 
     async def run() -> tuple[dict, str, str]:
+        context = _context()
         admitted = await manager.deliver(
             DeliveryRequest(
                 session_id="ses_fsm",
                 priority="p3",
                 content="stop before native write",
             ),
-            context=_context(),
+            context=context,
         )
         assert admitted.turn_id and admitted.delivery_id
         await asyncio.wait_for(dispatch_entered.wait(), timeout=1.0)
+        manager.in_flight["ses_fsm"].context.platform_specific[
+            "task_execution_id"
+        ] = "run-stop-prewrite"
         stopped = await manager.cancel("ses_fsm")
         return stopped, str(admitted.turn_id), str(admitted.delivery_id)
 
@@ -3324,6 +3338,8 @@ def test_stop_cancels_a_starting_turn_before_native_write(managers, monkeypatch)
     }
     assert "ses_fsm" not in manager.in_flight
     manager.controller.command_handler.handle_stop.assert_not_awaited()
+    manager.controller.emit_agent_message.assert_not_awaited()
+    assert settle_calls == [(["run-stop-prewrite"], SETTLED_BY_STOPPED)]
     with engine.connect() as conn:
         turn = delivery_store.get_turn(conn, turn_id)
     assert turn is not None

--- a/tests/test_session_delivery_fsm.py
+++ b/tests/test_session_delivery_fsm.py
@@ -3275,6 +3275,64 @@ def test_empty_p0_uses_the_control_slot_without_creating_a_message_delivery(mana
     asyncio.run(run())
 
 
+def test_stop_cancels_a_starting_turn_before_native_write(managers, monkeypatch) -> None:
+    """MESSAGE-DELIVERY-022: Stop retires a definitively unwritten input."""
+
+    manager, _other, engine, _engine_b, _starts = managers
+    manager._run = SessionTurnManager._run.__get__(manager, SessionTurnManager)
+    dispatch_entered = asyncio.Event()
+
+    async def blocked_prewrite_dispatch(*_args, **_kwargs):
+        dispatch_entered.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            # OpenCode absorbs cancellation after cleaning up its inner request
+            # task, so lock that adapter behavior into the shared Stop contract.
+            return TurnDispatchOutcome(
+                error=None,
+                settled_by=None,
+                backend_dispatch_attempted=False,
+            )
+
+    monkeypatch.setattr(
+        "core.session_turns.dispatch_turn_with_outcome",
+        blocked_prewrite_dispatch,
+    )
+
+    async def run() -> tuple[dict, str, str]:
+        admitted = await manager.deliver(
+            DeliveryRequest(
+                session_id="ses_fsm",
+                priority="p3",
+                content="stop before native write",
+            ),
+            context=_context(),
+        )
+        assert admitted.turn_id and admitted.delivery_id
+        await asyncio.wait_for(dispatch_entered.wait(), timeout=1.0)
+        stopped = await manager.cancel("ses_fsm")
+        return stopped, str(admitted.turn_id), str(admitted.delivery_id)
+
+    stopped, turn_id, delivery_id = asyncio.run(run())
+
+    assert stopped == {
+        "ok": True,
+        "session_id": "ses_fsm",
+        "status": "stale_released",
+        "reason": "prewrite_canceled",
+    }
+    assert "ses_fsm" not in manager.in_flight
+    manager.controller.command_handler.handle_stop.assert_not_awaited()
+    with engine.connect() as conn:
+        turn = delivery_store.get_turn(conn, turn_id)
+    assert turn is not None
+    assert turn["state"] == "terminal"
+    assert turn["terminal_outcome"] == "not_written"
+    assert turn["settled_by"] == SETTLED_BY_STOPPED
+    assert _row(engine, delivery_id)["state"] == "retired"
+
+
 def test_empty_p0_terminal_race_still_resumes_the_queued_head(
     managers,
     monkeypatch,

--- a/tests/test_session_delivery_fsm.py
+++ b/tests/test_session_delivery_fsm.py
@@ -35,6 +35,7 @@ from core.session_turns import (
     SOURCE_SCHEDULED,
     TURN_LIFECYCLE_ADMISSION_KEY,
     DeliveryRequest,
+    DeliveryResult,
     SessionTurnManager,
     Turn,
     _scheduled_merge_key,
@@ -3346,7 +3347,71 @@ def test_stop_cancels_a_starting_turn_before_native_write(managers, monkeypatch)
     assert turn["state"] == "terminal"
     assert turn["terminal_outcome"] == "not_written"
     assert turn["settled_by"] == SETTLED_BY_STOPPED
-    assert _row(engine, delivery_id)["state"] == "retired"
+    retired = _row(engine, delivery_id)
+    assert retired["state"] == "retired"
+    history = json.loads(retired["delivery_history_json"])["events"]
+    assert history[-1]["outcome"] == "canceled"
+
+
+def test_prewrite_replacement_returns_the_successor_delivery_state(
+    managers,
+    monkeypatch,
+) -> None:
+    """A prewrite P0 replacement reports the state of its own successor."""
+
+    manager, _other, engine, _engine_b, _starts = managers
+    manager._run = SessionTurnManager._run.__get__(manager, SessionTurnManager)
+    manager.controller.emit_agent_message = AsyncMock()
+    dispatch_entered = asyncio.Event()
+
+    async def blocked_prewrite_dispatch(_controller, dispatch_context, *_args, **_kwargs):
+        set_dispatch_phase(dispatch_context, DISPATCH_PHASE_PREWRITE)
+        dispatch_entered.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            return TurnDispatchOutcome(
+                error=None,
+                settled_by=None,
+                backend_dispatch_attempted=False,
+            )
+
+    monkeypatch.setattr(
+        "core.session_turns.dispatch_turn_with_outcome",
+        blocked_prewrite_dispatch,
+    )
+
+    async def run() -> DeliveryResult:
+        admitted = await manager.deliver(
+            DeliveryRequest(
+                session_id="ses_fsm",
+                priority="p3",
+                content="replace before native write",
+            ),
+            context=_context(),
+        )
+        assert admitted.turn_id
+        await asyncio.wait_for(dispatch_entered.wait(), timeout=1.0)
+        manager._start_persisted_turn = AsyncMock(return_value=True)
+        return await manager.deliver(
+            DeliveryRequest(
+                session_id="ses_fsm",
+                priority="p0",
+                content="replacement",
+            ),
+            context=_context(),
+        )
+
+    replacement = asyncio.run(run())
+
+    assert replacement.delivery_id is not None
+    assert replacement.state == "claimed"
+    assert replacement.admission == "started"
+    with engine.connect() as conn:
+        row = delivery_store.get_delivery(conn, replacement.delivery_id)
+    assert row is not None
+    assert row["state"] == replacement.state
+    assert row["turn_id"] == replacement.turn_id
 
 
 def test_empty_p0_terminal_race_still_resumes_the_queued_head(


### PR DESCRIPTION
## Summary

- let OpenCode turns reuse an unchanged Model Hub overlay without waiting for unrelated active sessions
- serialize real overlay transitions and hold each selection through atomic active-run registration
- let Stop cancel a durable Turn while it is still definitively before the native write boundary
- report replacement delivery state accurately and record stopped attempts as cancellations

## Capability

- OpenCode session delivery and cancellation
- Model Hub OpenCode runtime overlay coordination

## Scenarios

- `MESSAGE-DELIVERY-022`
- `MH-RUNTIME-002`
- `MH-RUNTIME-003`
- `MH-RUNTIME-004`

## Evidence

- Unit and contract: delivery FSM, OpenCode server/agent, shared Stop intent propagation, restored polls, steering, OAuth, and internal API suites, 674 passed
- Scenario: complete Model Hub scenario directory, 71 passed
- Static: Ruff, Python compilation, and `git diff --check` passed
- Residual manual: the two reported live sessions were inspected but not mutated; deploying this code still requires the normal Avibe upgrade/restart path
