### PR TITLE
fix(ui): align remote pairing controls

### DIFF
--- a/ui/src/components/RemoteAccess.tsx
+++ b/ui/src/components/RemoteAccess.tsx
@@ -727,43 +727,46 @@ export const RemoteAccess: React.FC = () => {
       )}
 
       {showPairingForm ? (
-        <div className="grid gap-3 px-5 py-4 md:grid-cols-[1fr_auto] md:items-end">
-          <label className="space-y-1.5">
-            <span className="text-[12px] font-medium text-foreground">{t('remoteAccess.pairingKey')}</span>
+        <div className="space-y-1.5 px-5 py-4">
+          <label htmlFor="remote-access-pairing-key" className="block text-[12px] font-medium text-foreground">
+            {t('remoteAccess.pairingKey')}
+          </label>
+          <div className="flex flex-col gap-2 md:flex-row md:items-center">
             <CompactField
-              className="w-full font-mono"
+              id="remote-access-pairing-key"
+              className="min-w-0 flex-1 font-mono"
               value={pairingKey}
               onChange={(event) => setPairingKey(event.target.value)}
               placeholder="vrp_xxxxxxxxxxxxxxxxx"
             />
-            <span className="block text-[10px] text-muted">{t('remoteAccess.pairingKeyHelp')}</span>
-          </label>
-          <div className="flex flex-wrap gap-2">
-            <Button
-              type="button"
-              variant="default"
-              size="xs"
-              className="font-semibold"
-              disabled={pairing || !pairingKey.trim()}
-              onClick={pair}
-            >
-              <Link2 className="size-3.5" />
-              {pairing ? t('remoteAccess.pairing') : t('remoteAccess.pair')}
-            </Button>
-            {paired && (
+            <div className="flex shrink-0 flex-wrap gap-2">
               <Button
                 type="button"
-                variant="secondary"
+                variant="default"
                 size="xs"
-                onClick={() => {
-                  setReconfiguring(false);
-                  setPairingKey('');
-                }}
+                className="font-semibold"
+                disabled={pairing || !pairingKey.trim()}
+                onClick={pair}
               >
-                {t('common.cancel')}
+                <Link2 className="size-3.5" />
+                {pairing ? t('remoteAccess.pairing') : t('remoteAccess.pair')}
               </Button>
-            )}
+              {paired && (
+                <Button
+                  type="button"
+                  variant="secondary"
+                  size="xs"
+                  onClick={() => {
+                    setReconfiguring(false);
+                    setPairingKey('');
+                  }}
+                >
+                  {t('common.cancel')}
+                </Button>
+              )}
+            </div>
           </div>
+          <span className="block text-[10px] text-muted">{t('remoteAccess.pairingKeyHelp')}</span>
         </div>
       ) : (
         <div className="flex flex-col gap-3 px-5 py-4 md:flex-row md:items-center md:justify-between">


### PR DESCRIPTION
## Changed capability
Align the Remote Access re-pairing controls so the pairing key input, Pair and start, and Cancel controls share one responsive row on medium and larger screens. The help text remains on its own line, and narrow layouts stack without overflow. Also associates the visible pairing-key label with its input.

## Scenarios
- No dedicated UI scenario catalog entry exists for this layout-only adjustment.

## Evidence
- Unit: not applicable; no business logic changed.
- Contract: not applicable; API and persisted shapes are unchanged.
- Scenario: not applicable; existing Remote Access pairing flow is unchanged.
- Residual manual check: local Vite preview starts, but the page could not render past the shell because the configured backend returned 502 for `/api/session`, `/api/config`, and related bootstrap requests. Verify the rendered pairing state against the supplied screenshot in the integration environment.
- `npm run build` (passes)
- `npm run lint` (passes)
- `git diff --check` (passes)

## Dependencies
None.
