### PR TITLE
fix(settings): restore Model Hub runtime detection

### DIFF
--- a/core/controller.py
+++ b/core/controller.py
@@ -382,7 +382,14 @@ class Controller:
                 if agent.backend == backend
             ]
 
+        cli_presence: dict[str, bool] = {}
+
         def cli_present(backend: str) -> bool:
+            # Payload assembly runs on the controller loop. Read only the last
+            # worker-produced snapshot here; a missing/erroring probe is false.
+            return cli_presence.get(backend, False)
+
+        def refresh_cli_presence() -> None:
             from config.v2_config import V2Config
             from vibe.api import resolve_cli_path
 
@@ -390,15 +397,21 @@ class Controller:
                 v2_config = V2Config.load()
             except FileNotFoundError:
                 v2_config = None
-            backend_config = getattr(getattr(v2_config, "agents", None), backend, None)
-            configured_path = getattr(backend_config, "cli_path", None) or backend
-            return resolve_cli_path(str(configured_path)) is not None
+            for backend in ("claude", "codex", "opencode"):
+                backend_config = getattr(getattr(v2_config, "agents", None), backend, None)
+                configured_path = getattr(backend_config, "cli_path", None) or backend
+                try:
+                    cli_presence[backend] = resolve_cli_path(str(configured_path)) is not None
+                except Exception:
+                    logger.warning("Model Hub CLI presence probe failed for %s", backend, exc_info=True)
+                    cli_presence[backend] = False
 
         self.model_hub_service = create_default_service(
             requested_model_override=default_vibe_agent_model,
             selected_agent_override=default_vibe_agent_name,
             named_agents_override=named_vibe_agents,
             cli_present_override=cli_present,
+            cli_presence_refresh=refresh_cli_presence,
         )
         self.model_hub_turn_gateway = ModelHubTurnGateway(
             self.model_hub_service,

--- a/core/controller.py
+++ b/core/controller.py
@@ -382,10 +382,23 @@ class Controller:
                 if agent.backend == backend
             ]
 
+        def cli_present(backend: str) -> bool:
+            from config.v2_config import V2Config
+            from vibe.api import resolve_cli_path
+
+            try:
+                v2_config = V2Config.load()
+            except FileNotFoundError:
+                v2_config = None
+            backend_config = getattr(getattr(v2_config, "agents", None), backend, None)
+            configured_path = getattr(backend_config, "cli_path", None) or backend
+            return resolve_cli_path(str(configured_path)) is not None
+
         self.model_hub_service = create_default_service(
             requested_model_override=default_vibe_agent_model,
             selected_agent_override=default_vibe_agent_name,
             named_agents_override=named_vibe_agents,
+            cli_present_override=cli_present,
         )
         self.model_hub_turn_gateway = ModelHubTurnGateway(
             self.model_hub_service,

--- a/core/handlers/model_hub/rpc.py
+++ b/core/handlers/model_hub/rpc.py
@@ -8,6 +8,12 @@ from typing import Any
 from .service import ModelHubError, ModelHubService
 
 
+async def _refresh_agent_presence(service: ModelHubService) -> None:
+    """Refresh host CLI facts without blocking the controller event loop."""
+
+    await asyncio.to_thread(service.refresh_cli_presence)
+
+
 async def dispatch_model_hub_rpc(
     service: ModelHubService,
     operation: str,
@@ -41,13 +47,16 @@ async def dispatch_model_hub_rpc(
     if operation == "list_agents":
         return await asyncio.to_thread(service.list_agents)
     if operation == "get_agent_sources":
+        await _refresh_agent_presence(service)
         return service.get_agent_sources(payload.get("backend"))
     if operation == "set_agent_sources":
+        await _refresh_agent_presence(service)
         return await service.set_agent_sources(
             payload.get("backend"),
             payload.get("sources"),
         )
     if operation == "set_agent_mode":
+        await _refresh_agent_presence(service)
         return await service.set_agent_mode(payload.get("backend"), payload.get("mode"))
     if operation == "set_agent_chain":
         return await service.set_agent_chain(
@@ -56,6 +65,7 @@ async def dispatch_model_hub_rpc(
             payload.get("chain"),
         )
     if operation == "set_opencode_menu":
+        await _refresh_agent_presence(service)
         return await service.set_opencode_menu(payload.get("menu"))
     if operation == "add_custom_model":
         return await service.add_custom_model(payload.get("source_id"), payload.get("model"))

--- a/core/handlers/model_hub/rpc.py
+++ b/core/handlers/model_hub/rpc.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from typing import Any
 
 from .service import ModelHubError, ModelHubService
@@ -38,7 +39,7 @@ async def dispatch_model_hub_rpc(
             force=payload.get("force") is True,
         )
     if operation == "list_agents":
-        return service.list_agents()
+        return await asyncio.to_thread(service.list_agents)
     if operation == "get_agent_sources":
         return service.get_agent_sources(payload.get("backend"))
     if operation == "set_agent_sources":

--- a/core/handlers/model_hub/service.py
+++ b/core/handlers/model_hub/service.py
@@ -3003,11 +3003,11 @@ class ModelHubService:
         }
 
     def list_agents(self) -> list[dict]:
-        self._refresh_cli_presence()
+        self.refresh_cli_presence()
         config = self.store.load()
         return [self._agent_payload(config, config.agents[backend]) for backend in ("claude", "codex", "opencode")]
 
-    def _refresh_cli_presence(self) -> None:
+    def refresh_cli_presence(self) -> None:
         if self.cli_presence_refresh is None:
             return
         try:

--- a/core/handlers/model_hub/service.py
+++ b/core/handlers/model_hub/service.py
@@ -544,6 +544,7 @@ class ModelHubService:
         named_agents_override: Optional[
             Callable[[BackendName], list[tuple[str, Optional[str]]]]
         ] = None,
+        cli_present_override: Optional[Callable[[BackendName], bool]] = None,
         now: Callable[[], datetime] = _utc_now,
     ):
         self.store = store
@@ -564,6 +565,7 @@ class ModelHubService:
         self.requested_model_override = requested_model_override
         self.selected_agent_override = selected_agent_override
         self.named_agents_override = named_agents_override
+        self.cli_present_override = cli_present_override
         self.now = now
         self.native_source_ready: Callable[[BackendName, ModelHubSourceConfig], bool] = (
             lambda _backend, _source: True
@@ -2983,6 +2985,13 @@ class ModelHubService:
             "selected_by_agent": selected_by_agent,
             "selected_model_id": selected_model_id,
             "selected_model_explicit": selected_model_explicit,
+            # The UI must distinguish an installed backend CLI from a configured
+            # Model Hub route. Keep this host fact at the controller boundary.
+            "cli_present": (
+                bool(self.cli_present_override(backend))
+                if self.cli_present_override is not None
+                else False
+            ),
             "sources": sources,
             "supply_status": (
                 resolution.supply_status
@@ -4787,6 +4796,7 @@ def create_default_service(
     named_agents_override: Optional[
         Callable[[BackendName], list[tuple[str, Optional[str]]]]
     ] = None,
+    cli_present_override: Optional[Callable[[BackendName], bool]] = None,
 ) -> ModelHubService:
     if adapter is None:
         from vibe.model_hub_runtime import get_model_hub_engine_adapter
@@ -4831,4 +4841,5 @@ def create_default_service(
         requested_model_override=requested_model_override,
         selected_agent_override=selected_agent_override,
         named_agents_override=named_agents_override,
+        cli_present_override=cli_present_override,
     )

--- a/core/handlers/model_hub/service.py
+++ b/core/handlers/model_hub/service.py
@@ -545,6 +545,7 @@ class ModelHubService:
             Callable[[BackendName], list[tuple[str, Optional[str]]]]
         ] = None,
         cli_present_override: Optional[Callable[[BackendName], bool]] = None,
+        cli_presence_refresh: Optional[Callable[[], None]] = None,
         now: Callable[[], datetime] = _utc_now,
     ):
         self.store = store
@@ -566,6 +567,7 @@ class ModelHubService:
         self.selected_agent_override = selected_agent_override
         self.named_agents_override = named_agents_override
         self.cli_present_override = cli_present_override
+        self.cli_presence_refresh = cli_presence_refresh
         self.now = now
         self.native_source_ready: Callable[[BackendName, ModelHubSourceConfig], bool] = (
             lambda _backend, _source: True
@@ -2987,11 +2989,7 @@ class ModelHubService:
             "selected_model_explicit": selected_model_explicit,
             # The UI must distinguish an installed backend CLI from a configured
             # Model Hub route. Keep this host fact at the controller boundary.
-            "cli_present": (
-                bool(self.cli_present_override(backend))
-                if self.cli_present_override is not None
-                else False
-            ),
+            "cli_present": self._cli_present(backend),
             "sources": sources,
             "supply_status": (
                 resolution.supply_status
@@ -3005,8 +3003,26 @@ class ModelHubService:
         }
 
     def list_agents(self) -> list[dict]:
+        self._refresh_cli_presence()
         config = self.store.load()
         return [self._agent_payload(config, config.agents[backend]) for backend in ("claude", "codex", "opencode")]
+
+    def _refresh_cli_presence(self) -> None:
+        if self.cli_presence_refresh is None:
+            return
+        try:
+            self.cli_presence_refresh()
+        except Exception:
+            logger.warning("Model Hub CLI presence refresh failed", exc_info=True)
+
+    def _cli_present(self, backend: BackendName) -> bool:
+        if self.cli_present_override is None:
+            return False
+        try:
+            return bool(self.cli_present_override(backend))
+        except Exception:
+            logger.warning("Model Hub CLI presence probe failed for %s", backend, exc_info=True)
+            return False
 
     async def set_agent_mode(self, backend: str, mode: object) -> dict:
         if mode not in {"hub", "direct"}:
@@ -4797,6 +4813,7 @@ def create_default_service(
         Callable[[BackendName], list[tuple[str, Optional[str]]]]
     ] = None,
     cli_present_override: Optional[Callable[[BackendName], bool]] = None,
+    cli_presence_refresh: Optional[Callable[[], None]] = None,
 ) -> ModelHubService:
     if adapter is None:
         from vibe.model_hub_runtime import get_model_hub_engine_adapter
@@ -4842,4 +4859,5 @@ def create_default_service(
         selected_agent_override=selected_agent_override,
         named_agents_override=named_agents_override,
         cli_present_override=cli_present_override,
+        cli_presence_refresh=cli_presence_refresh,
     )

--- a/tests/test_model_hub_api.py
+++ b/tests/test_model_hub_api.py
@@ -741,6 +741,18 @@ def test_agents_endpoint_projects_cli_presence_from_runtime(tmp_path):
     }
 
 
+def test_agents_endpoint_cli_presence_probe_errors_fail_closed(tmp_path):
+    service, _store, _adapter = _service(tmp_path)
+
+    def broken_probe(_backend):
+        raise OSError("probe failed")
+
+    service.cli_present_override = broken_probe
+    agents = {agent["backend"]: agent for agent in service.list_agents()}
+
+    assert all(agent["cli_present"] is False for agent in agents.values())
+
+
 def test_agents_endpoint_projects_each_enabled_named_agent_live(tmp_path):
     service, store, _adapter = _service(tmp_path)
     store.requested_model = lambda backend: {

--- a/tests/test_model_hub_api.py
+++ b/tests/test_model_hub_api.py
@@ -753,6 +753,26 @@ def test_agents_endpoint_cli_presence_probe_errors_fail_closed(tmp_path):
     assert all(agent["cli_present"] is False for agent in agents.values())
 
 
+def test_agent_supply_rpc_refreshes_cli_presence_before_first_response(tmp_path):
+    from core.handlers.model_hub.rpc import dispatch_model_hub_rpc
+
+    service, _store, _adapter = _service(tmp_path)
+    calls = []
+    service.cli_presence_refresh = lambda: calls.append("refresh")
+    service.cli_present_override = lambda backend: backend == "claude"
+
+    payload = asyncio.run(
+        dispatch_model_hub_rpc(
+            service,
+            "get_agent_sources",
+            {"backend": "claude"},
+        )
+    )
+
+    assert payload["cli_present"] is True
+    assert calls == ["refresh"]
+
+
 def test_agents_endpoint_projects_each_enabled_named_agent_live(tmp_path):
     service, store, _adapter = _service(tmp_path)
     store.requested_model = lambda backend: {

--- a/tests/test_model_hub_api.py
+++ b/tests/test_model_hub_api.py
@@ -728,6 +728,19 @@ def test_agents_endpoint_projects_builtin_models_and_standard_vendors(tmp_path):
     assert agents["opencode"]["standard_vendors"] == sorted(STANDARD_OPENCODE_VENDOR_IDS)
 
 
+def test_agents_endpoint_projects_cli_presence_from_runtime(tmp_path):
+    service, _store, _adapter = _service(tmp_path)
+    service.cli_present_override = lambda backend: backend in {"claude", "codex"}
+
+    agents = {agent["backend"]: agent for agent in service.list_agents()}
+
+    assert {backend: agent["cli_present"] for backend, agent in agents.items()} == {
+        "claude": True,
+        "codex": True,
+        "opencode": False,
+    }
+
+
 def test_agents_endpoint_projects_each_enabled_named_agent_live(tmp_path):
     service, store, _adapter = _service(tmp_path)
     store.requested_model = lambda backend: {


### PR DESCRIPTION
## Capability
Restore the Model Hub settings runtime projection and keep regression verification on the current frontend/backend baseline.

## Why
The current Model Hub UI filters Agent backends by the server-authoritative `cli_present` field, but the controller API omitted that field. The regression instance was therefore showing the empty-state copy even when all three CLIs were installed.

The reported Memory `undefined (reading 'syncing')` error was caused by serving an older UI bundle against the newer Memory processing-record contract. The latest UI no longer reads that legacy field; the regression rebuild below verifies that the same source revision supplies both sides.

## Implementation
- Refresh each configured Agent CLI path through `resolve_cli_path` in the internal RPC worker thread, keeping blocking npm resolution off the controller event loop.
- Include the cached, fail-closed `cli_present` host fact in every Model Hub AgentSupply payload.
- Keep probe and refresh failures observable in logs without turning a persisted settings mutation or agent listing into a 500 response.
- Add contract-level service coverage for mixed CLI presence and probe failures.

## Evidence
- Unit: `uv run pytest tests/test_model_hub_api.py -q` (147 passed)
- Contract/static: `uv run ruff check core/controller.py core/handlers/model_hub/service.py core/handlers/model_hub/rpc.py tests/test_model_hub_api.py` (passed)
- Scenario/UI: `npm run test -- --run src/components/settings/SettingsMemoryPage.test.tsx src/components/settings/memory/MemorySettingsPanel.test.tsx src/components/settings/memory/MemoryStatusPanel.test.tsx` (60 passed)
- Build: `npm run build` (passed)
- Regression: rebuild the local Incus `avibe-master` target from this exact PR head; `/api/models/agents` reported `cli_present: true` for Claude Code, Codex, and OpenCode, while Memory APIs returned the explicit `memory_disabled` contract response without a frontend crash.
- Residual manual check: review the latest PR head, exact-head CI, and unresolved findings after the next Codex review.

## Risk
The new field is read-only and fail-closed when no configured CLI can be resolved. No dependencies or persisted data are changed.
