### PR TITLE
fix(ui): deepen light accent tokens to clear WCAG AA

### DIFF
--- a/ui/scripts/validate-theme.mjs
+++ b/ui/scripts/validate-theme.mjs
@@ -164,6 +164,76 @@ assertEqual('system dark background', systemDark.get('--background'), '#080812')
 assertEqual('system light color-scheme', systemLight.get('color-scheme'), 'light');
 assertEqual('system dark color-scheme', systemDark.get('color-scheme'), 'dark');
 
+// An accent doubles as small status text — text-mint / text-gold / text-cyan /
+// text-destructive are used app-wide — and every X / X-foreground pair is a fill
+// plus the label printed on it. Both have to clear WCAG AA for small text, in
+// both themes. Light is the fragile side: the dark palette's vivid accents read
+// at 2.5-4.2:1 on a light surface, which is what this guard exists to catch.
+const AA_SMALL_TEXT = 4.5;
+
+function parseColor(value) {
+  const match = /^#([\da-f]{3}|[\da-f]{6})$/i.exec(value ?? '');
+  if (!match) {
+    // Washes, hairlines and gradients are rgba or composed; they carry no
+    // small-text contract, so they are out of scope rather than a failure.
+    return null;
+  }
+
+  const hex = match[1].length === 3 ? [...match[1]].map((channel) => channel + channel).join('') : match[1];
+  return [0, 2, 4].map((offset) => Number.parseInt(hex.slice(offset, offset + 2), 16));
+}
+
+function relativeLuminance(rgb) {
+  const [r, g, b] = rgb.map((channel) => {
+    const ratio = channel / 255;
+    return ratio <= 0.03928 ? ratio / 12.92 : ((ratio + 0.055) / 1.055) ** 2.4;
+  });
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+}
+
+function contrastRatio(foreground, background) {
+  const [lighter, darker] = [relativeLuminance(foreground), relativeLuminance(background)]
+    .sort((a, b) => b - a);
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+function assertContrast(name, tokens, inkProp, surfaceProp) {
+  const ink = parseColor(tokens.get(inkProp));
+  const surface = parseColor(tokens.get(surfaceProp));
+  if (!ink || !surface) {
+    return;
+  }
+
+  const ratio = contrastRatio(ink, surface);
+  if (ratio < AA_SMALL_TEXT) {
+    throw new Error(
+      `${name}: ${inkProp} on ${surfaceProp} is ${ratio.toFixed(2)}:1, below WCAG AA ${AA_SMALL_TEXT}:1`,
+    );
+  }
+}
+
+const INK_TOKENS = ['--foreground', '--muted', '--mint', '--cyan', '--violet', '--gold', '--pink', '--destructive'];
+const INK_SURFACES = ['--card', '--background', '--surface-3'];
+
+for (const [theme, tokens] of [['light', systemLight], ['dark', systemDark]]) {
+  for (const ink of INK_TOKENS) {
+    assertEqual(`${theme} ${ink} is defined`, tokens.has(ink), true);
+    for (const surface of INK_SURFACES) {
+      assertContrast(`${theme} ink`, tokens, ink, surface);
+    }
+  }
+
+  // Every fill that declares its own foreground is checked against it, so a
+  // deepened or lightened fill can never silently strand its label.
+  const pairs = [...tokens.keys()]
+    .filter((prop) => prop.endsWith('-foreground') && tokens.has(prop.slice(0, -'-foreground'.length)))
+    .map((prop) => [prop, prop.slice(0, -'-foreground'.length)]);
+  assertEqual(`${theme} fill pairs exist`, pairs.length > 0, true);
+  for (const [foreground, fill] of pairs) {
+    assertContrast(`${theme} fill`, tokens, foreground, fill);
+  }
+}
+
 const modelHub = (options) => resolveThemeTokens({ ...options, source: modelHubCss });
 const modelHubSystemDark = modelHub({ prefersLight: false, themeAttr: null });
 const modelHubSystemLight = modelHub({ prefersLight: true, themeAttr: null });

--- a/ui/scripts/validate-theme.mjs
+++ b/ui/scripts/validate-theme.mjs
@@ -172,15 +172,31 @@ assertEqual('system dark color-scheme', systemDark.get('color-scheme'), 'dark');
 const AA_SMALL_TEXT = 4.5;
 
 function parseColor(value) {
-  const match = /^#([\da-f]{3}|[\da-f]{6})$/i.exec(value ?? '');
+  const match = /^#([\da-f]{3}|[\da-f]{6})$/i.exec((value ?? '').trim());
   if (!match) {
-    // Washes, hairlines and gradients are rgba or composed; they carry no
-    // small-text contract, so they are out of scope rather than a failure.
     return null;
   }
 
   const hex = match[1].length === 3 ? [...match[1]].map((channel) => channel + channel).join('') : match[1];
   return [0, 2, 4].map((offset) => Number.parseInt(hex.slice(offset, offset + 2), 16));
+}
+
+// A ratio only means something between two opaque colours. Anything else -- an
+// alpha channel, a var() indirection, a gradient, oklch() or color-mix() -- has
+// no single value to measure, so the guard must say so instead of skipping the
+// assertion it advertises.
+function requireMeasurableColor(name, prop, value) {
+  const rgb = parseColor(value);
+  if (!rgb) {
+    throw new Error(
+      `${name}: ${prop} is ${value ?? 'undefined'}, which carries no measurable contrast. `
+      + 'Guarded tokens must resolve to an opaque #rgb or #rrggbb value; a translucent or computed '
+      + 'colour depends on its backdrop, so AA cannot be asserted from the token alone. Give the '
+      + 'token an opaque value, or drop it from the guarded list and record why.',
+    );
+  }
+
+  return rgb;
 }
 
 function relativeLuminance(rgb) {
@@ -198,11 +214,8 @@ function contrastRatio(foreground, background) {
 }
 
 function assertContrast(name, tokens, inkProp, surfaceProp) {
-  const ink = parseColor(tokens.get(inkProp));
-  const surface = parseColor(tokens.get(surfaceProp));
-  if (!ink || !surface) {
-    return;
-  }
+  const ink = requireMeasurableColor(name, inkProp, tokens.get(inkProp));
+  const surface = requireMeasurableColor(name, surfaceProp, tokens.get(surfaceProp));
 
   const ratio = contrastRatio(ink, surface);
   if (ratio < AA_SMALL_TEXT) {

--- a/ui/src/components/AppShell.tsx
+++ b/ui/src/components/AppShell.tsx
@@ -153,7 +153,7 @@ const MobileNavLink: React.FC<{ item: ShellNavItem }> = ({ item }) => {
           <Icon className="size-4" />
         )}
         {item.badge ? (
-          <span className="absolute -right-2 -top-1.5 min-w-[14px] rounded-full bg-mint px-1 text-center font-mono text-[9px] font-bold leading-[14px] text-background">
+          <span className="absolute -right-2 -top-1.5 min-w-[14px] rounded-full bg-mint px-1 text-center font-mono text-[9px] font-bold leading-[14px] text-primary-foreground">
             {item.badge > 99 ? '99+' : item.badge}
           </span>
         ) : null}

--- a/ui/src/components/settings/SettingsPlatformsPage.tsx
+++ b/ui/src/components/settings/SettingsPlatformsPage.tsx
@@ -293,7 +293,7 @@ export const SettingsPlatformsPage: React.FC = () => {
                   )}
                 >
                   {active && (
-                    <span className="absolute right-1.5 top-1.5 inline-flex size-4 items-center justify-center rounded-full bg-mint text-background">
+                    <span className="absolute right-1.5 top-1.5 inline-flex size-4 items-center justify-center rounded-full bg-mint text-primary-foreground">
                       {busy ? <Loader2 size={10} className="animate-spin" /> : <Check size={11} strokeWidth={3} />}
                     </span>
                   )}

--- a/ui/src/components/steps/PlatformSelection.tsx
+++ b/ui/src/components/steps/PlatformSelection.tsx
@@ -418,7 +418,7 @@ export const PlatformSelection: React.FC<PlatformSelectionProps> = ({ data, onNe
                         className={clsx(
                           'flex size-4 shrink-0 items-center justify-center rounded-full border text-[9px] font-semibold',
                           index < 2 || currentValidationState === 'success'
-                            ? 'border-mint bg-mint text-background'
+                            ? 'border-mint bg-mint text-primary-foreground'
                             : 'border-border bg-background text-muted'
                         )}
                       >

--- a/ui/src/components/ui/checkbox.tsx
+++ b/ui/src/components/ui/checkbox.tsx
@@ -25,7 +25,7 @@ export interface CheckboxProps {
 export function Checkbox({ checked, onCheckedChange, disabled, label, className, presentational }: CheckboxProps) {
   const visual = clsx(
     'flex size-[18px] shrink-0 items-center justify-center rounded-[5px] border transition-colors',
-    checked ? 'border-transparent bg-mint text-[#06060e]' : 'border-border-strong bg-surface-3 text-transparent',
+    checked ? 'border-transparent bg-mint text-primary-foreground' : 'border-border-strong bg-surface-3 text-transparent',
     disabled && 'cursor-not-allowed opacity-50',
     className,
   );

--- a/ui/src/components/ui/directory-browser.tsx
+++ b/ui/src/components/ui/directory-browser.tsx
@@ -601,7 +601,7 @@ export const DirectoryBrowser: React.FC<DirectoryBrowserProps> = ({
                     className={clsx(
                       'rounded-md px-2.5 py-0.5 text-[11px] font-semibold transition',
                       newFolderName.trim()
-                        ? 'bg-mint text-[#080812] hover:brightness-110'
+                        ? 'bg-mint text-primary-foreground hover:brightness-110'
                         : 'bg-muted-soft text-muted',
                     )}
                   >
@@ -642,7 +642,7 @@ export const DirectoryBrowser: React.FC<DirectoryBrowserProps> = ({
             className={clsx(
               'flex items-center gap-1.5 rounded-md px-4 py-1.5 text-[12px] font-semibold transition',
               canConfirm
-                ? 'bg-mint text-[#080812] shadow-[0_0_14px_-4px_rgba(91,255,160,0.6)] hover:brightness-110'
+                ? 'bg-mint text-primary-foreground shadow-[0_0_14px_-4px_rgba(91,255,160,0.6)] hover:brightness-110'
                 : 'cursor-not-allowed bg-muted-soft text-muted',
             )}
           >

--- a/ui/src/components/ui/vault-protected-unlock.tsx
+++ b/ui/src/components/ui/vault-protected-unlock.tsx
@@ -128,7 +128,7 @@ export const VaultProtectedUnlock: React.FC<{ vault: Vault; secretName?: string;
 
         {canUsePasskey ? (
           <div className="flex flex-col items-center gap-2.5 rounded-xl border-[1.5px] border-mint bg-mint-soft p-4">
-            <Badge variant="success" className="border-transparent bg-mint uppercase tracking-wide text-background">
+            <Badge variant="success" className="border-transparent bg-mint uppercase tracking-wide text-primary-foreground">
               <Sparkles className="size-3" />
               {t('vaults.protectedUnlock.recommended')}
             </Badge>

--- a/ui/src/components/workbench/EditorApp.tsx
+++ b/ui/src/components/workbench/EditorApp.tsx
@@ -849,7 +849,7 @@ export const EditorApp: React.FC<{
           the left, but we have no real git/diagnostics data for an arbitrary folder — showing a
           hardcoded "master · 0 ⚠ 0" would be misleading, so those are omitted until wired. The
           right side (cursor / indentation / language) is real. */}
-      <div className="flex items-center gap-3.5 bg-cyan px-3.5 py-1 font-mono text-[10.5px] font-semibold text-[#06222B]">
+      <div className="flex items-center gap-3.5 bg-cyan px-3.5 py-1 font-mono text-[10.5px] font-semibold text-accent-foreground">
         {active && activeTab?.kind === 'preview' ? (
           <span className="ml-auto truncate">{t('preview.title')}</span>
         ) : active ? (

--- a/ui/src/components/workbench/InboxPage.tsx
+++ b/ui/src/components/workbench/InboxPage.tsx
@@ -287,7 +287,7 @@ export const InboxPage: React.FC = () => {
                     className="inline-flex items-center gap-1.5 rounded-md border border-mint/30 bg-mint/[0.06] px-3 py-1.5 text-[11px] font-semibold text-mint transition hover:bg-mint/[0.12]"
                   >
                     {unread > 0 && (
-                      <span className="inline-flex min-w-[1.1rem] items-center justify-center rounded-full bg-mint px-1.5 font-mono text-[9px] font-bold text-[#080812]">
+                      <span className="inline-flex min-w-[1.1rem] items-center justify-center rounded-full bg-mint px-1.5 font-mono text-[9px] font-bold text-primary-foreground">
                         {unread > 99 ? '99+' : unread}
                       </span>
                     )}

--- a/ui/src/components/workbench/NewAgentDialog.tsx
+++ b/ui/src/components/workbench/NewAgentDialog.tsx
@@ -341,7 +341,7 @@ export const NewAgentDialog: React.FC<NewAgentDialogProps> = ({ open, onClose, o
             className={clsx(
               'inline-flex items-center gap-1.5 rounded-md px-4 py-1.5 text-[12px] font-bold transition',
               canSubmit
-                ? 'bg-mint text-[#080812] shadow-[0_0_14px_-4px_rgba(91,255,160,0.6)] hover:brightness-110'
+                ? 'bg-mint text-primary-foreground shadow-[0_0_14px_-4px_rgba(91,255,160,0.6)] hover:brightness-110'
                 : 'cursor-not-allowed bg-muted-soft text-muted',
             )}
           >

--- a/ui/src/components/workbench/ProjectsPage.tsx
+++ b/ui/src/components/workbench/ProjectsPage.tsx
@@ -340,7 +340,7 @@ const MobileSessionRow: React.FC<{
         </span>
         <SessionPinIndicator pinned={session.pinned} label={t('workbench.sessionPinned')} />
         {unread > 0 ? (
-          <span className="shrink-0 rounded-full bg-mint px-1.5 py-0.5 font-mono text-[10px] font-bold text-background">
+          <span className="shrink-0 rounded-full bg-mint px-1.5 py-0.5 font-mono text-[10px] font-bold text-primary-foreground">
             {unread > 99 ? '99+' : unread}
           </span>
         ) : (

--- a/ui/src/components/workbench/WorkbenchSidebar.tsx
+++ b/ui/src/components/workbench/WorkbenchSidebar.tsx
@@ -336,7 +336,7 @@ const SessionRow: React.FC<{
               {displayName}
             </span>
             {unread > 0 && (
-              <span className="inline-flex min-w-[1.1rem] items-center justify-center rounded-full bg-mint px-1.5 font-mono text-[9px] font-bold text-[#080812]">
+              <span className="inline-flex min-w-[1.1rem] items-center justify-center rounded-full bg-mint px-1.5 font-mono text-[9px] font-bold text-primary-foreground">
                 {unread > 99 ? '99+' : unread}
               </span>
             )}
@@ -786,7 +786,7 @@ export const WorkbenchSidebar: React.FC<{ onOpenSearch?: () => void }> = ({ onOp
               <Inbox className={clsx('size-4', isActive ? 'text-cyan' : 'text-foreground')} />
               <span className="flex-1">{t('workbench.nav.inbox')}</span>
               {badge && (
-                <span className="inline-flex min-w-[1.25rem] items-center justify-center rounded-full bg-cyan px-1.5 py-0.5 font-mono text-[9px] font-bold text-[#080812] shadow-[0_0_10px_-2px_rgba(63,224,229,0.7)]">
+                <span className="inline-flex min-w-[1.25rem] items-center justify-center rounded-full bg-cyan px-1.5 py-0.5 font-mono text-[9px] font-bold text-accent-foreground shadow-[0_0_10px_-2px_rgba(63,224,229,0.7)]">
                   {badge}
                 </span>
               )}

--- a/ui/src/components/workbench/skills/AddSkillDialog.tsx
+++ b/ui/src/components/workbench/skills/AddSkillDialog.tsx
@@ -325,7 +325,7 @@ export function AddSkillDialog({ defaultScope, projectId, projectName, onClose, 
               type="button"
               onClick={install}
               disabled={!discovered || selected.size === 0 || backends.size === 0 || busy === 'install'}
-              className="flex items-center gap-1.5 rounded-lg bg-mint px-4 py-2 text-[12px] font-semibold text-[#080812] shadow-[0_4px_16px_-4px_rgba(91,255,160,0.5)] transition hover:brightness-110 disabled:opacity-50"
+              className="flex items-center gap-1.5 rounded-lg bg-mint px-4 py-2 text-[12px] font-semibold text-primary-foreground shadow-[0_4px_16px_-4px_rgba(91,255,160,0.5)] transition hover:brightness-110 disabled:opacity-50"
             >
               {busy === 'install' ? <Loader2 className="size-3.5 animate-spin" /> : <Download className="size-3.5" />}
               {busy === 'install' ? t('skills.addDialog.installing') : t('skills.addDialog.install', { count: selected.size })}

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -122,7 +122,9 @@
   --mint-soft: rgba(91, 255, 160, 0.16);
   --cyan: #3fe0e5;
   --cyan-soft: rgba(63, 224, 229, 0.16);
-  --violet: #7c5bff;
+  /* Lightened just past AA on --card: #7c5bff read at 4.28:1 there, the one dark
+     ink below the floor. Hue and saturation are unchanged. */
+  --violet: #8465ff;
   --violet-soft: rgba(124, 91, 255, 0.16);
   --gold: #ffc857;
   --gold-foreground: #080812;
@@ -176,31 +178,40 @@
     --popover: #ffffff;
     --popover-foreground: #0a0a14;
 
-    --primary: #10b981;
+    /* Light inks are deepened relative to dark. The dark palette's vivid accents
+       read at 2.5-4.2:1 as small text on a light surface, and text-mint /
+       text-gold / text-cyan / text-destructive are used app-wide, so every ink
+       here clears WCAG AA (4.5:1) against --surface-3, the darkest light
+       surface. Deepening the fills lifts white-on-fill for --primary /
+       --accent / --gold / --destructive by the same amount, since contrast is
+       symmetric. --primary / --accent / --ring carry --mint / --cyan by
+       definition. Guarded by ui/scripts/validate-theme.mjs. */
+    --primary: #067a55;
     --primary-foreground: #ffffff;
     --secondary: #eef1f7;
     --secondary-foreground: #0a0a14;
     --muted: #5c6079;
     --muted-soft: #eef1f7;
-    --accent: #0891b2;
+    --accent: #0e7490;
     --accent-foreground: #ffffff;
-    --destructive: #e11d48;
+    --destructive: #ca1a41;
     --destructive-foreground: #ffffff;
 
     --border: rgba(8, 8, 18, 0.08);
     --border-strong: rgba(8, 8, 18, 0.14);
     --input: rgba(8, 8, 18, 0.12);
-    --ring: rgba(16, 185, 129, 0.5);
+    --ring: rgba(6, 122, 85, 0.5);
 
-    --mint: #10b981;
+    /* Accents share the AA floor below - see the --primary group. */
+    --mint: #067a55;
     --mint-soft: rgba(16, 185, 129, 0.14);
-    --cyan: #0891b2;
+    --cyan: #0e7490;
     --cyan-soft: rgba(8, 145, 178, 0.14);
     --violet: #7c3aed;
     --violet-soft: rgba(124, 58, 237, 0.14);
-    --gold: #d97706;
+    --gold: #ae4f08;
     --gold-foreground: #ffffff;
-    --pink: #dc2659;
+    --pink: #c7204f;
     --pink-soft: rgba(220, 38, 89, 0.10);
 
     /* Light-theme page gradients (softer alphas over light base). */
@@ -253,31 +264,32 @@
   --popover: #ffffff;
   --popover-foreground: #0a0a14;
 
-  --primary: #10b981;
+  --primary: #067a55;
   --primary-foreground: #ffffff;
   --secondary: #eef1f7;
   --secondary-foreground: #0a0a14;
   --muted: #5c6079;
   --muted-soft: #eef1f7;
-  --accent: #0891b2;
+  --accent: #0e7490;
   --accent-foreground: #ffffff;
-  --destructive: #e11d48;
+  --destructive: #ca1a41;
   --destructive-foreground: #ffffff;
 
   --border: rgba(8, 8, 18, 0.08);
   --border-strong: rgba(8, 8, 18, 0.14);
   --input: rgba(8, 8, 18, 0.12);
-  --ring: rgba(16, 185, 129, 0.5);
+  --ring: rgba(6, 122, 85, 0.5);
 
-  --mint: #10b981;
+  /* Deepened inks, AA on --surface-3 - see the prefers-color-scheme block above. */
+  --mint: #067a55;
   --mint-soft: rgba(16, 185, 129, 0.14);
-  --cyan: #0891b2;
+  --cyan: #0e7490;
   --cyan-soft: rgba(8, 145, 178, 0.14);
   --violet: #7c3aed;
   --violet-soft: rgba(124, 58, 237, 0.14);
-  --gold: #d97706;
+  --gold: #ae4f08;
   --gold-foreground: #ffffff;
-  --pink: #dc2659;
+  --pink: #c7204f;
   --pink-soft: rgba(220, 38, 89, 0.10);
 
   /* Light-theme page gradients (softer alphas over light base). */


### PR DESCRIPTION
## Capability

Light-theme accent legibility, at the global token layer.

Follow-up to #1402. That PR fixed the Model Hub surface and deferred one measured
residual: the accent tokens themselves were unreadable as small text in light. The
owner's scope decision was to fix the global accents rather than add Model-Hub-local
role tokens, which is what this PR does.

## What was wrong

The light palette inherited the dark palette's vivid accents, so every accent used as
small status text sat below WCAG AA (4.5:1 for small text):

| token | before | on `--card` | on `--background` | on `--surface-3` |
| --- | --- | --- | --- | --- |
| `--mint` | `#10b981` | 2.54 | 2.35 | 2.25 |
| `--gold` | `#d97706` | 3.19 | 2.95 | 2.82 |
| `--cyan` | `#0891b2` | 3.68 | 3.40 | 3.26 |
| `--destructive` | `#e11d48` | 4.70 | 4.34 | 4.15 |
| `--pink` | `#dc2659` | 4.70 | 4.35 | 4.16 |

`text-mint` / `text-gold` / `text-cyan` / `text-destructive` appear in ~130 files
(558 usages), and the class does not distinguish a 10px label from a decorative
glyph, so a per-call-site migration would need human judgment at every site. The
defect is in the values, so the fix is in the values.

## What changed

Every light ink is deepened until it clears 4.5:1 against `--surface-3`, the darkest
light surface. Deepenings preserve hue and saturation (HSL lightness only):

| token | before | after | card / background / surface-3 |
| --- | --- | --- | --- |
| `--mint`, `--primary` | `#10b981` | `#067a55` | 5.35 / 4.95 / 4.73 |
| `--cyan`, `--accent` | `#0891b2` | `#0e7490` | 5.36 / 4.96 / 4.74 |
| `--gold` | `#d97706` | `#ae4f08` | 5.35 / 4.95 / 4.73 |
| `--destructive` | `#e11d48` | `#ca1a41` | 5.62 / 5.20 / 4.97 |
| `--pink` | `#dc2659` | `#c7204f` | 5.60 / 5.18 / 4.95 |
| `--ring` | `rgba(16,185,129,.5)` | `rgba(6,122,85,.5)` | follows `--mint` |

Applied identically to both light blocks (the `prefers-color-scheme` block and
`[data-theme="light"]`), which the existing cascade parity assertion enforces.

Dark needed exactly one value. `--violet #7c5bff` read 4.28:1 on `--card` — the only
dark ink below the floor — and is lightened to `#8465ff` (4.72 / 5.02 / 5.08).

### 14 accent-fill sites that were relying on the old shallow fills

Contrast is symmetric, so deepening a fill also lifts white-on-fill:
`--primary-foreground` on `--primary` 2.54 -> 5.35, `--accent-foreground` on
`--accent` 3.68 -> 5.36, `--gold-foreground` on `--gold` 3.19 -> 5.35.

That exposed 14 sites pairing a solid accent fill with hardcoded dark ink. Five
(`text-background` on `bg-mint`) were already broken in light at 2.35:1; the other
nine would have dropped from 7.76:1 to 3.68:1 under the deeper fills. All 14 now use
the paired foreground token instead of a literal, so they follow the theme by
definition: 12 `bg-mint` sites use `text-primary-foreground`, 2 `bg-cyan` sites use
`text-accent-foreground`.

AppShell, checkbox, directory-browser (x2), vault-protected-unlock,
SettingsPlatformsPage, PlatformSelection, InboxPage, EditorApp, ProjectsPage,
AddSkillDialog, NewAgentDialog, WorkbenchSidebar (x2).

Two dark-theme pixel deltas from that substitution, both deliberate and disclosed:
`checkbox.tsx` moves from `#06060e` to `#080812` (delta 2/255 per channel), and
`EditorApp.tsx:852` loses a hand-tuned teal tint (`#06222B` -> `#080812`). The tint
was a one-off literal with no token behind it; if it is wanted, it belongs in the
token layer as an `--accent-foreground` light/dark value, not inline.

## Evidence layers

- **Unit**: 198 files / 2121 tests pass. No unit test asserts colour values; vitest
  owns source hygiene here by design.
- **Contract**: `ui/scripts/validate-theme.mjs` (already CI-wired at
  `.github/workflows/lint.yml`) gains the durable half of this fix — a uniform
  invariant with no exemption list, asserted for **both themes**:
  1. every ink token (`--foreground`, `--muted`, `--mint`, `--cyan`, `--violet`,
     `--gold`, `--pink`, `--destructive`) clears AA against `--card`,
     `--background` and `--surface-3`;
  2. every `X` / `X-foreground` pair clears AA against each other.
  Both resolve through the existing postcss cascade resolver, so a rule cannot pass
  in one light block and be missed in the other. The guard was negative-tested — it
  fails with the exact number when light `--mint` is reverted (2.54:1), when dark
  `--violet` is reverted (4.28:1), and when `--primary-foreground` is flipped back to
  dark ink (3.72:1). It found the dark `--violet` defect on its first run; that value
  was not part of the reported bug.
- **Scenario**: none applicable. `tests/scenarios/INDEX.yaml` is a capability catalog
  with no theme or presentation capability, so there is no scenario ID to update. The
  theme validator is the durable evidence layer for this class of change.
- **Manual**: `npm run build` and `npm run lint` (baseline, no drift) pass. Visual
  verification of both themes in the local Incus regression environment is running;
  the result will be posted on this PR.

## Deliberately out of scope

- **The `-soft` washes and gradients keep their original rgba values**, so
  `design.pen` and the code stay in parity. See the residual below.
- **Measured residual — ink on its own translucent wash.** The `bg-mint-soft text-mint`
  / `bg-violet/15 text-violet` chip pattern composites the wash over the surface, so
  its real background is closer to the ink than any plain surface. Measured after this
  PR, in light: mint 4.69 / 4.37 / 4.20, cyan 4.54 / 4.23 / 4.06, violet 4.62 / 4.30 /
  4.12, pink 4.82 / 4.47 / 4.28 (card / background / surface-3); Tailwind `/15` alpha
  variants land 3.86–4.55. Dark `text-violet` on `bg-violet/15` over `--card` is 4.00.
  Chip labels are 10–11px, so AA small text does apply. Closing this needs either a
  further, much larger deepening of every accent or a lower wash alpha — both change
  the product's visual identity, and `design.pen` is the source of truth for that, so
  it is the owner's and the design file's call rather than a drive-by here. The guard
  intentionally asserts the plain-surface invariant only, so it does not silently
  bless the wash case.
- Four of the changed buttons carry hardcoded dark-mint/cyan glow shadows
  (`rgba(91,255,160,…)`, `rgba(63,224,229,0.7)`) that now sit under deeper light
  fills. They read as a halo, not as ink, and moving them to tokens is a separate
  cleanup.
- `lib/agentBackends.ts:42 text-[#e8a87c]` is a backend brand colour, not an accent
  fill, and is left alone.

## Paired design change

`design.pen` needs the same variable values so the design file and code do not drift.
The edit is applied and read back in the Pencil editor (`--mint`, `--cyan`, `--gold`,
`--primary`, `--accent`, `--destructive`, `--pink`, `--ring` in Light; `--violet` in
Dark; the `-soft` washes intentionally unchanged) and the Light landing frame renders
correctly, but the Pencil app has not flushed the document to disk yet and exposes no
save API, so the `avibe-docs` commit and its PR are pending that save.
