### PR TITLE
fix(ui): restore the missing --gold-soft token

### DIFF
--- a/ui/src/components/workbench/search/Snippet.tsx
+++ b/ui/src/components/workbench/search/Snippet.tsx
@@ -7,8 +7,8 @@ type SnippetProps = {
 // A single, truncated line of message text with the matched term highlighted.
 // The server pre-splits the window into prefix / match / suffix, so this is
 // purely presentational. The <mark> uses the design's gold highlight
-// (bg-gold/10 + text-gold — the Badge "warning" tone; there is no gold-soft
-// token) with a small radius, no underline. When ``match`` is empty (leading
+// (bg-gold-soft + text-gold, matching the `hl` frames in the Editor Search
+// design) with a small radius, no underline. When ``match`` is empty (leading
 // context only) we render just the prefix.
 export const Snippet: React.FC<SnippetProps> = ({ snippet }) => {
   const { prefix, match, suffix } = snippet;
@@ -16,7 +16,7 @@ export const Snippet: React.FC<SnippetProps> = ({ snippet }) => {
     <span className="block truncate text-[12.5px] leading-relaxed text-foreground">
       {prefix}
       {match && (
-        <mark className="rounded-md bg-gold/10 px-1 font-medium text-gold no-underline">
+        <mark className="rounded-md bg-gold-soft px-1 font-medium text-gold no-underline">
           {match}
         </mark>
       )}

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -56,6 +56,7 @@
   --color-violet: var(--violet);
   --color-violet-soft: var(--violet-soft);
   --color-gold: var(--gold);
+  --color-gold-soft: var(--gold-soft);
   --color-gold-foreground: var(--gold-foreground);
   --color-pink: var(--pink);
   --color-pink-soft: var(--pink-soft);
@@ -127,6 +128,7 @@
   --violet: #8465ff;
   --violet-soft: rgba(124, 91, 255, 0.16);
   --gold: #ffc857;
+  --gold-soft: rgba(255, 200, 87, 0.16);
   --gold-foreground: #080812;
   --pink: #ff5b8a;
   --pink-soft: rgba(255, 91, 138, 0.10);
@@ -210,6 +212,7 @@
     --violet: #7c3aed;
     --violet-soft: rgba(124, 58, 237, 0.14);
     --gold: #ae4f08;
+    --gold-soft: rgba(217, 119, 6, 0.14);
     --gold-foreground: #ffffff;
     --pink: #c7204f;
     --pink-soft: rgba(220, 38, 89, 0.10);
@@ -288,6 +291,7 @@
   --violet: #7c3aed;
   --violet-soft: rgba(124, 58, 237, 0.14);
   --gold: #ae4f08;
+  --gold-soft: rgba(217, 119, 6, 0.14);
   --gold-foreground: #ffffff;
   --pink: #c7204f;
   --pink-soft: rgba(220, 38, 89, 0.10);


### PR DESCRIPTION
Restores a design token that `ui/src/index.css` was missing, so the
`bg-gold-soft` class stops resolving to nothing.

## The defect

`avibe-docs/design.pen` defines `--gold-soft` in both modes, but `index.css`
never carried it — gold was the one accent with an ink and a foreground but no
wash. Two consumers were affected:

- **`SettingsDependenciesPage.tsx:45`** — the avault tile asks for
  `bg-gold-soft`. With no such token and no such utility class, the tile
  rendered with no background at all, while its five siblings
  (`askill`, `show-runtime`, `memory-runtime`, `node`, `tmux`) all got theirs.
- **`Snippet.tsx:19`** — the search-result highlight worked around the gap with
  `bg-gold/10`, and the comment above it recorded the workaround as a fact about
  the design system ("there is no gold-soft token").

## The change

| Token | Light | Dark |
| --- | --- | --- |
| `--gold-soft` | `rgba(217, 119, 6, 0.14)` | `rgba(255, 200, 87, 0.16)` |

Added to all three cascade blocks — `:root, [data-theme="dark"]`, the
`prefers-color-scheme: light` block, and `[data-theme="light"]` — plus
`--color-gold-soft` in the `@theme` map. The two light blocks are written
identically, as the cascade-parity assertion in `validate-theme.mjs` requires.

The alphas are not new choices: 0.14 light / 0.16 dark is what `--mint-soft`,
`--cyan-soft` and `--violet-soft` already use. Like every other light wash, the
value keeps the *previous* accent hex (`#d97706`) rather than the deepened
`--gold` (`#ae4f08`); the washes were deliberately scoped out of the contrast
retune in #1403 and avibe-bot/avibe-docs#20, and this token stays consistent
with that decision.

`Snippet.tsx` now points at the token, which is also what the design does — the
eight `hl` frames in **Apps · Editor Search** are filled with `$--gold-soft`.

The avault tile needs no code change: adding the token is enough for
`bg-gold-soft` to resolve. Note that the **Settings · Dependencies** design
frame does not itself show an avault row with a gold tile, so the tile's colour
choice is justified by the tile map's own convention (`bg-X-soft` + `text-X` for
the other five entries) rather than by that frame.

## Evidence

**1:1 parity with the design, proven by the build.** The minifier collapses the
declarations to `--gold-soft:#d9770624` (light) and `--gold-soft:#ffc85729`
(dark) in `dist/assets/index-*.css`. Those are byte-identical to the values
`design.pen` holds for the same token, so the parity did not need a manual
comparison.

**The utility class now exists.** `dist/assets/index-*.css` contains
`.bg-gold-soft{background-color:var(--gold-soft)}`; before this change the class
was absent from the bundle entirely, which is why the tile had no background.

- `npm run validate:theme` — passes, including the cascade-parity assertion that
  the two light blocks are identical.
- `npm run build` — succeeds. The one warning is a pre-existing `@__PURE__`
  annotation notice from `node_modules/@hpke/common`, unrelated to this change.

## Evidence layers

- **Unit** — none added; the change is a token declaration, and the existing
  `validate-theme.mjs` guard already asserts cascade parity for every token in
  these blocks, including this one now.
- **Contract** — `validate:theme` (CI-wired at `.github/workflows/lint.yml`)
  covers the three-block contract.
- **Scenario** — no scenario catalog covers theme tokens.
- **Residual manual check** — the avault tile background on
  Settings › Dependencies, which only renders once avault is a known dependency.
