### PR TITLE
fix(ui): restore the design's white label on light brand fills

### DIFF
--- a/ui/scripts/validate-theme.mjs
+++ b/ui/scripts/validate-theme.mjs
@@ -247,14 +247,58 @@ function contrastRatio(foreground, background) {
   return (lighter + 0.05) / (darker + 0.05);
 }
 
+// Brand fill/label pairs the owner has accepted against the AA floor. Avibe's
+// accents carry the product's personality — an AI-colleague product should read as
+// alive, not muted — so the light fills keep design.pen's saturation and the white
+// label the design drew, which is the pairing the palette shipped before it was
+// briefly deepened. Text on a neutral surface is a separate token (--X-ink) and
+// keeps the full floor; only the label printed on a brand fill is accepted here.
+//
+// These are pinned, not skipped. Each entry records the ratio the pair was accepted
+// at and the guard fails when the measured ratio moves off it, so an exemption still
+// catches drift: nudge either token and this list goes stale loudly, forcing a fresh
+// decision instead of quietly sliding further down. Owner decision 2026-08-14.
+const ACCEPTED_BRAND_PAIRS = new Map([
+  ['light fill: --primary-foreground on --primary', 2.54],
+  ['light fill: --accent-foreground on --accent', 3.68],
+  ['light fill: --gold-foreground on --gold', 3.19],
+]);
+const PIN_TOLERANCE = 0.01;
+const consultedBrandPairs = new Set();
+
 function assertContrast(name, tokens, inkProp, surfaceProp) {
   const ink = requireMeasurableColor(name, inkProp, tokens.get(inkProp));
   const surface = requireMeasurableColor(name, surfaceProp, tokens.get(surfaceProp));
 
   const ratio = contrastRatio(ink, surface);
+  const key = `${name}: ${inkProp} on ${surfaceProp}`;
+  const accepted = ACCEPTED_BRAND_PAIRS.get(key);
+  if (accepted !== undefined) {
+    consultedBrandPairs.add(key);
+    if (Math.abs(ratio - accepted) > PIN_TOLERANCE) {
+      throw new Error(
+        `${key} is ${ratio.toFixed(2)}:1, but ACCEPTED_BRAND_PAIRS pins it at ${accepted.toFixed(2)}:1. ` +
+          'This pair is exempt from the AA floor by an owner decision taken at that exact ratio, so moving ' +
+          'either token needs a fresh decision — re-pin it here once the new value is intended.',
+      );
+    }
+    return;
+  }
   if (ratio < AA_SMALL_TEXT) {
     throw new Error(
       `${name}: ${inkProp} on ${surfaceProp} is ${ratio.toFixed(2)}:1, below WCAG AA ${AA_SMALL_TEXT}:1`,
+    );
+  }
+}
+
+// A pair that no longer exists must not keep its exemption: the tokens it excused
+// may have been renamed or dropped, and a stale entry would silently excuse whatever
+// takes that name next.
+function assertEveryAcceptedPairStillExists() {
+  const stale = [...ACCEPTED_BRAND_PAIRS.keys()].filter((key) => !consultedBrandPairs.has(key));
+  if (stale.length > 0) {
+    throw new Error(
+      `ACCEPTED_BRAND_PAIRS lists ${stale.join(', ')}, which no theme declares. Drop the entry.`,
     );
   }
 }
@@ -346,6 +390,7 @@ function assertAccentAliasesKeepTheirTokenName(source) {
 }
 
 assertAccentAliasesKeepTheirTokenName(css);
+assertEveryAcceptedPairStillExists();
 
 const modelHub = (options) => resolveThemeTokens({ ...options, source: modelHubCss });
 const modelHubSystemDark = modelHub({ prefersLight: false, themeAttr: null });

--- a/ui/scripts/validate-theme.mjs
+++ b/ui/scripts/validate-theme.mjs
@@ -311,10 +311,27 @@ const ACCENT_FILLS = ['--primary', '--accent', '--destructive', '--mint', '--cya
 const NEUTRAL_INKS = ['--foreground', '--muted'];
 const INK_SURFACES = ['--card', '--background', '--surface-3'];
 
+// A semantic fill and the palette token behind it must hold the same value, because
+// the pair measured here is not always the pair rendered: Button's `brand` prints
+// --primary-foreground on bg-mint and `brand-cyan` prints --accent-foreground on
+// bg-cyan. They match today by convention only, so without this the pinned ratio on
+// --primary would keep passing while the CTA it claims to describe drifted away.
+const SEMANTIC_FILL_ALIASES = [['--primary', '--mint'], ['--accent', '--cyan']];
+
 for (const [theme, tokens] of [['light', systemLight], ['dark', systemDark]]) {
   for (const fill of ACCENT_FILLS) {
     assertEqual(`${theme} ${fill} is defined`, tokens.has(fill), true);
     assertEqual(`${theme} ${fill} declares an ink`, tokens.has(`${fill}-ink`), true);
+  }
+
+  for (const [semantic, palette] of SEMANTIC_FILL_ALIASES) {
+    if (tokens.get(semantic) !== tokens.get(palette)) {
+      throw new Error(
+        `${theme} ${semantic} is ${tokens.get(semantic)} but ${palette} is ${tokens.get(palette)}. `
+          + `Button prints ${semantic}-foreground on ${palette}, so the contrast measured on ${semantic} `
+          + 'is only the contrast users see while the two stay equal. Move both or neither.',
+      );
+    }
   }
 
   // Inks are read as small text on a bare surface, so every one of them clears AA

--- a/ui/scripts/validate-theme.mjs
+++ b/ui/scripts/validate-theme.mjs
@@ -262,6 +262,11 @@ const ACCEPTED_BRAND_PAIRS = new Map([
   ['light fill: --primary-foreground on --primary', 2.54],
   ['light fill: --accent-foreground on --accent', 3.68],
   ['light fill: --gold-foreground on --gold', 3.19],
+  // Dark violet is not a new exemption: the Button already printed a hard-coded
+  // text-white on this fill, so the pair shipped at 4.38:1 while no token declared
+  // it and this guard could not see it. Naming --violet-foreground brings it under
+  // the same pin as the rest instead of leaving it undeclared.
+  ['dark fill: --violet-foreground on --violet', 4.38],
 ]);
 const PIN_TOLERANCE = 0.01;
 const consultedBrandPairs = new Set();
@@ -318,6 +323,20 @@ const INK_SURFACES = ['--card', '--background', '--surface-3'];
 // --primary would keep passing while the CTA it claims to describe drifted away.
 const SEMANTIC_FILL_ALIASES = [['--primary', '--mint'], ['--accent', '--cyan']];
 
+// Pointing at a control must never cost contrast. Every interactive brand fill
+// therefore declares the value it hovers to, and the hovered fill is measured against
+// the same label as the resting one. Naming the hovered value is the point: a filter
+// scales the label along with the background, so it cannot be aimed — brightness(1.1)
+// on light --primary read 2.09:1 against the 2.54:1 it started from, and no brightness
+// value fixes it, because a white label is already clamped at the top.
+//
+// The direction follows the LABEL, not the theme. Mint, cyan and gold carry a dark
+// label in dark and a white one in light, so they lighten there and darken here;
+// --violet's label is white in both, so it darkens in both. That inversion is exactly
+// what a single shared mix token got wrong, and what this assertion catches.
+// --mint / --cyan ride along through SEMANTIC_FILL_ALIASES above.
+const HOVER_FILLS = ['--primary', '--accent', '--gold', '--violet', '--destructive'];
+
 for (const [theme, tokens] of [['light', systemLight], ['dark', systemDark]]) {
   for (const fill of ACCENT_FILLS) {
     assertEqual(`${theme} ${fill} is defined`, tokens.has(fill), true);
@@ -325,11 +344,33 @@ for (const [theme, tokens] of [['light', systemLight], ['dark', systemDark]]) {
   }
 
   for (const [semantic, palette] of SEMANTIC_FILL_ALIASES) {
-    if (tokens.get(semantic) !== tokens.get(palette)) {
+    // The hover pair is aliased for the same reason as the resting one: `brand` pairs
+    // bg-mint with --primary-foreground, so a --mint-hover that drifted from
+    // --primary-hover would render a pairing no assertion below ever measures.
+    for (const suffix of ['', '-hover']) {
+      const [a, b] = [`${semantic}${suffix}`, `${palette}${suffix}`];
+      if (tokens.get(a) !== tokens.get(b)) {
+        throw new Error(
+          `${theme} ${a} is ${tokens.get(a)} but ${b} is ${tokens.get(b)}. `
+            + `Button prints ${semantic}-foreground on ${palette}, so the contrast measured on ${a} `
+            + 'is only the contrast users see while the two stay equal. Move both or neither.',
+        );
+      }
+    }
+  }
+
+  for (const fill of HOVER_FILLS) {
+    assertEqual(`${theme} ${fill} declares a hover fill`, tokens.has(`${fill}-hover`), true);
+    const name = `${theme} hover`;
+    const label = requireMeasurableColor(name, `${fill}-foreground`, tokens.get(`${fill}-foreground`));
+    const resting = contrastRatio(label, requireMeasurableColor(name, fill, tokens.get(fill)));
+    const hovered = contrastRatio(label, requireMeasurableColor(name, `${fill}-hover`, tokens.get(`${fill}-hover`)));
+    if (hovered < resting) {
       throw new Error(
-        `${theme} ${semantic} is ${tokens.get(semantic)} but ${palette} is ${tokens.get(palette)}. `
-          + `Button prints ${semantic}-foreground on ${palette}, so the contrast measured on ${semantic} `
-          + 'is only the contrast users see while the two stay equal. Move both or neither.',
+        `${theme} ${fill}-hover reads ${hovered.toFixed(2)}:1 against ${fill}-foreground, worse than `
+          + `${fill}'s own ${resting.toFixed(2)}:1. Hovering a control must not cost contrast, so the `
+          + `hovered fill has to move AWAY from its label — darker under a light label, lighter under a `
+          + 'dark one. Check which way this theme\'s label points before picking the value.',
       );
     }
   }
@@ -385,6 +426,7 @@ function assertAccentAliasesKeepTheirTokenName(source) {
     `${fill}-ink`,
     `${fill}-soft`,
     `${fill}-foreground`,
+    `${fill}-hover`,
   ]));
 
   postcss.parse(source).walkAtRules('theme', (atRule) => {

--- a/ui/src/components/settings/models/modelHubSurface.css
+++ b/ui/src/components/settings/models/modelHubSurface.css
@@ -74,9 +74,13 @@
   --model-hub-danger-border: color-mix(in srgb, var(--destructive) 25%, transparent);
   --model-hub-success-fill: color-mix(in srgb, var(--mint) 7.8%, transparent);
   --model-hub-success-border: color-mix(in srgb, var(--mint) 25%, transparent);
-  /* A brand button held at low emphasis: the fill fades toward the surface while
-   * the label stays --primary-foreground, which is dark in both themes. Needs no
-   * light branch — the same fade lands on white and keeps the label legible. */
+  /* A brand button held at low emphasis: the fill fades toward the surface. Once
+   * it fades it is a wash, not a fill, so the label follows the wash rule and
+   * takes --mint-ink rather than the fill's paired --primary-foreground. That
+   * matters in light, where --primary-foreground is white: white on a 34.9%
+   * mint wash over a light dialog is ~1.4:1, i.e. the same invisible-label bug
+   * this palette work started from. --mint-ink is asserted against every
+   * neutral surface in both themes, so one value serves both. */
   --model-hub-dim-brand-fill: color-mix(in srgb, var(--mint) 34.9%, transparent);
 
   /* Modal scrim and lifted-surface shadows, cast in the theme's own extreme:
@@ -593,11 +597,16 @@
   padding: var(--model-hub-add-key-foot-padding-y) var(--model-hub-add-key-foot-padding-x);
   background: var(--model-hub-add-key-footer-fill);
 }
+/* The fill is a wash here, so the label leaves the brand pair and takes the ink
+ * token — see --model-hub-dim-brand-fill. The hover rule repeats the pair to
+ * hold the button steady: a dimmed action is deliberately not interactive-looking. */
 .model-hub-add-key-action--dim {
   background: var(--model-hub-add-key-dim-primary);
+  color: var(--mint-ink);
 }
 .model-hub-add-key-action--dim:hover {
   background: var(--model-hub-add-key-dim-primary);
+  color: var(--mint-ink);
 }
 
 .model-hub-route-overlay { background: var(--model-hub-scrim); }

--- a/ui/src/components/ui/button-variants.ts
+++ b/ui/src/components/ui/button-variants.ts
@@ -11,9 +11,10 @@ export const buttonVariants = cva(
         // Mint primary — flat, no glow shadow (design.pen Button/Default).
         default: 'gap-1.5 bg-primary text-primary-foreground hover:brightness-110',
         // Brand CTA — bright bg + brand-color glow shadow + bold text + brighten on hover.
-        // The fill is the accent itself and the label its paired *-foreground, which
-        // is the dark ink in both themes: a brand fill stays vivid under light, so it
-        // takes the same dark label there that it takes on the dark frame.
+        // The fill is the accent itself and the label its paired *-foreground: a dark
+        // ink on the dark theme's neon accents, white on light's vivid ones. Both are
+        // the design's own pairing; see the ACCEPTED_BRAND_PAIRS note in
+        // ui/scripts/validate-theme.mjs for why light's white label is deliberate.
         brand:
           'gap-2 bg-mint font-bold text-primary-foreground shadow-[0_0_24px_-4px_rgba(91,255,160,0.6)] hover:brightness-105 disabled:shadow-none',
         'brand-cyan':

--- a/ui/src/components/ui/button-variants.ts
+++ b/ui/src/components/ui/button-variants.ts
@@ -9,28 +9,30 @@ export const buttonVariants = cva(
     variants: {
       variant: {
         // Mint primary — flat, no glow shadow (design.pen Button/Default).
-        default:
-          'gap-1.5 bg-primary text-primary-foreground hover:bg-[color-mix(in_srgb,var(--primary)_88%,var(--brand-hover-mix))]',
+        default: 'gap-1.5 bg-primary text-primary-foreground hover:bg-primary-hover',
         // Brand CTA — bright bg + brand-color glow shadow + bold text.
         // The fill is the accent itself and the label its paired *-foreground: a dark
-        // ink on the dark theme's neon accents, white on light's vivid ones. Both are
-        // the design's own pairing; see the ACCEPTED_BRAND_PAIRS note in
+        // ink on the dark theme's neon accents, white on light's vivid ones (and white
+        // in both for violet, the one accent whose label does not follow the theme).
+        // All are the design's own pairing; see the ACCEPTED_BRAND_PAIRS note in
         // ui/scripts/validate-theme.mjs for why light's white label is deliberate.
         //
-        // Hover shifts the *fill* toward --brand-hover-mix rather than filtering the
-        // button, because brightness() scales the label along with the background: on
-        // light's white labels that made hover strictly worse than the pairing the
-        // owner accepted. Mixing the background instead moves the fill away from its
-        // label in either theme. The glow shadow no longer brightens with the fill —
-        // the fill shift carries the affordance. See --brand-hover-mix in index.css.
+        // Hover paints a declared --X-hover fill rather than filtering the button,
+        // because brightness() scales the label along with the background: on light's
+        // white labels that made hover strictly worse than the pairing the owner
+        // accepted. A named fill also lets validate-theme.mjs measure the hovered pair
+        // and assert it never reads worse than the resting one — which is how violet's
+        // inverted direction surfaces at build time rather than in review. The glow
+        // shadow no longer brightens with the fill; the fill swap carries the
+        // affordance. See the --primary-hover note in index.css.
         brand:
-          'gap-2 bg-mint font-bold text-primary-foreground shadow-[0_0_24px_-4px_rgba(91,255,160,0.6)] hover:bg-[color-mix(in_srgb,var(--mint)_92%,var(--brand-hover-mix))] disabled:shadow-none',
+          'gap-2 bg-mint font-bold text-primary-foreground shadow-[0_0_24px_-4px_rgba(91,255,160,0.6)] hover:bg-mint-hover disabled:shadow-none',
         'brand-cyan':
-          'gap-2 bg-cyan font-bold text-accent-foreground shadow-[0_0_24px_-4px_rgba(63,224,229,0.6)] hover:bg-[color-mix(in_srgb,var(--cyan)_92%,var(--brand-hover-mix))] disabled:shadow-none',
+          'gap-2 bg-cyan font-bold text-accent-foreground shadow-[0_0_24px_-4px_rgba(63,224,229,0.6)] hover:bg-cyan-hover disabled:shadow-none',
         'brand-gold':
-          'gap-2 bg-gold font-bold text-gold-foreground shadow-[0_0_24px_-4px_rgba(255,200,87,0.55)] hover:bg-[color-mix(in_srgb,var(--gold)_92%,var(--brand-hover-mix))] disabled:shadow-none',
+          'gap-2 bg-gold font-bold text-gold-foreground shadow-[0_0_24px_-4px_rgba(255,200,87,0.55)] hover:bg-gold-hover disabled:shadow-none',
         'brand-violet':
-          'gap-2 bg-violet font-bold text-white shadow-[0_0_24px_-4px_rgba(124,91,255,0.55)] hover:bg-[color-mix(in_srgb,var(--violet)_92%,var(--brand-hover-mix))] disabled:shadow-none',
+          'gap-2 bg-violet font-bold text-violet-foreground shadow-[0_0_24px_-4px_rgba(124,91,255,0.55)] hover:bg-violet-hover disabled:shadow-none',
         secondary: 'gap-1.5 border border-border bg-secondary text-secondary-foreground hover:border-border-strong',
         // Outline — bg matches page surface so it sits cleanly on glow gradients.
         outline:
@@ -39,11 +41,12 @@ export const buttonVariants = cva(
         'outline-cyan':
           'gap-1.5 border border-cyan/40 bg-cyan/[0.06] text-cyan-ink hover:bg-cyan/[0.10]',
         ghost: 'gap-1.5 text-foreground hover:bg-surface-2',
-        // Hover darkens the fill rather than fading it: opacity blends the fill
-        // toward the page surface, which pulls the white label *down* toward AA
-        // (4.70:1 -> ~4.25:1 in light). brightness-95 deepens it instead, so the
-        // label gains contrast on hover, and it matches the other fill variants.
-        destructive: 'gap-1.5 bg-destructive text-destructive-foreground hover:brightness-95',
+        // Hover swaps the fill rather than fading it: opacity blends the fill toward
+        // the page surface, which pulls the white label *down* toward AA (4.70:1 ->
+        // ~4.25:1 in light). A fixed brightness-95 was no better — it only deepened,
+        // which helps light's white label but drags dark's #080812 label the wrong
+        // way. --destructive-hover is declared per theme like every other brand fill.
+        destructive: 'gap-1.5 bg-destructive text-destructive-foreground hover:bg-destructive-hover',
         // Pink-soft destructive — design.pen T09T8Z. Pink fill + pink border
         // + pink text/icon, used for in-panel delete CTAs where a full
         // destructive shouts too loud. Drives the --pink / --pink-soft tokens

--- a/ui/src/components/ui/button-variants.ts
+++ b/ui/src/components/ui/button-variants.ts
@@ -9,20 +9,28 @@ export const buttonVariants = cva(
     variants: {
       variant: {
         // Mint primary — flat, no glow shadow (design.pen Button/Default).
-        default: 'gap-1.5 bg-primary text-primary-foreground hover:brightness-110',
-        // Brand CTA — bright bg + brand-color glow shadow + bold text + brighten on hover.
+        default:
+          'gap-1.5 bg-primary text-primary-foreground hover:bg-[color-mix(in_srgb,var(--primary)_88%,var(--brand-hover-mix))]',
+        // Brand CTA — bright bg + brand-color glow shadow + bold text.
         // The fill is the accent itself and the label its paired *-foreground: a dark
         // ink on the dark theme's neon accents, white on light's vivid ones. Both are
         // the design's own pairing; see the ACCEPTED_BRAND_PAIRS note in
         // ui/scripts/validate-theme.mjs for why light's white label is deliberate.
+        //
+        // Hover shifts the *fill* toward --brand-hover-mix rather than filtering the
+        // button, because brightness() scales the label along with the background: on
+        // light's white labels that made hover strictly worse than the pairing the
+        // owner accepted. Mixing the background instead moves the fill away from its
+        // label in either theme. The glow shadow no longer brightens with the fill —
+        // the fill shift carries the affordance. See --brand-hover-mix in index.css.
         brand:
-          'gap-2 bg-mint font-bold text-primary-foreground shadow-[0_0_24px_-4px_rgba(91,255,160,0.6)] hover:brightness-105 disabled:shadow-none',
+          'gap-2 bg-mint font-bold text-primary-foreground shadow-[0_0_24px_-4px_rgba(91,255,160,0.6)] hover:bg-[color-mix(in_srgb,var(--mint)_92%,var(--brand-hover-mix))] disabled:shadow-none',
         'brand-cyan':
-          'gap-2 bg-cyan font-bold text-accent-foreground shadow-[0_0_24px_-4px_rgba(63,224,229,0.6)] hover:brightness-105 disabled:shadow-none',
+          'gap-2 bg-cyan font-bold text-accent-foreground shadow-[0_0_24px_-4px_rgba(63,224,229,0.6)] hover:bg-[color-mix(in_srgb,var(--cyan)_92%,var(--brand-hover-mix))] disabled:shadow-none',
         'brand-gold':
-          'gap-2 bg-gold font-bold text-gold-foreground shadow-[0_0_24px_-4px_rgba(255,200,87,0.55)] hover:brightness-105 disabled:shadow-none',
+          'gap-2 bg-gold font-bold text-gold-foreground shadow-[0_0_24px_-4px_rgba(255,200,87,0.55)] hover:bg-[color-mix(in_srgb,var(--gold)_92%,var(--brand-hover-mix))] disabled:shadow-none',
         'brand-violet':
-          'gap-2 bg-violet font-bold text-white shadow-[0_0_24px_-4px_rgba(124,91,255,0.55)] hover:brightness-105 disabled:shadow-none',
+          'gap-2 bg-violet font-bold text-white shadow-[0_0_24px_-4px_rgba(124,91,255,0.55)] hover:bg-[color-mix(in_srgb,var(--violet)_92%,var(--brand-hover-mix))] disabled:shadow-none',
         secondary: 'gap-1.5 border border-border bg-secondary text-secondary-foreground hover:border-border-strong',
         // Outline — bg matches page surface so it sits cleanly on glow gradients.
         outline:

--- a/ui/src/components/ui/checkbox.tsx
+++ b/ui/src/components/ui/checkbox.tsx
@@ -19,8 +19,12 @@ export interface CheckboxProps {
 /**
  * Lightweight controlled checkbox (no Radix dependency — the repo only pulls
  * in `@radix-ui/react-dialog`, and a checkbox this simple doesn't warrant a
- * new one). Mint fill + dark check when checked; bordered surface when not.
- * Visual contract mirrors design.pen's multi-select rows.
+ * new one). Mint fill + the fill's paired label colour for the check when
+ * checked (dark on the dark theme's neon mint, white on light's vivid one);
+ * bordered surface when not. Visual contract mirrors design.pen's multi-select
+ * rows. The checked state is carried by the fill swap, not by the glyph alone —
+ * bg-mint against bg-surface-3 plus aria-checked — so the glyph inherits the
+ * brand pairing rather than needing a contrasting icon token of its own.
  */
 export function Checkbox({ checked, onCheckedChange, disabled, label, className, presentational }: CheckboxProps) {
   const visual = clsx(

--- a/ui/src/components/ui/directory-browser.tsx
+++ b/ui/src/components/ui/directory-browser.tsx
@@ -601,7 +601,7 @@ export const DirectoryBrowser: React.FC<DirectoryBrowserProps> = ({
                     className={clsx(
                       'rounded-md px-2.5 py-0.5 text-[11px] font-semibold transition',
                       newFolderName.trim()
-                        ? 'bg-mint text-primary-foreground hover:brightness-110'
+                        ? 'bg-mint text-primary-foreground hover:bg-mint-hover'
                         : 'bg-muted-soft text-muted',
                     )}
                   >
@@ -642,7 +642,7 @@ export const DirectoryBrowser: React.FC<DirectoryBrowserProps> = ({
             className={clsx(
               'flex items-center gap-1.5 rounded-md px-4 py-1.5 text-[12px] font-semibold transition',
               canConfirm
-                ? 'bg-mint text-primary-foreground shadow-[0_0_14px_-4px_rgba(91,255,160,0.6)] hover:brightness-110'
+                ? 'bg-mint text-primary-foreground shadow-[0_0_14px_-4px_rgba(91,255,160,0.6)] hover:bg-mint-hover'
                 : 'cursor-not-allowed bg-muted-soft text-muted',
             )}
           >

--- a/ui/src/components/workbench/NewAgentDialog.tsx
+++ b/ui/src/components/workbench/NewAgentDialog.tsx
@@ -341,7 +341,7 @@ export const NewAgentDialog: React.FC<NewAgentDialogProps> = ({ open, onClose, o
             className={clsx(
               'inline-flex items-center gap-1.5 rounded-md px-4 py-1.5 text-[12px] font-bold transition',
               canSubmit
-                ? 'bg-mint text-primary-foreground shadow-[0_0_14px_-4px_rgba(91,255,160,0.6)] hover:brightness-110'
+                ? 'bg-mint text-primary-foreground shadow-[0_0_14px_-4px_rgba(91,255,160,0.6)] hover:bg-mint-hover'
                 : 'cursor-not-allowed bg-muted-soft text-muted',
             )}
           >

--- a/ui/src/components/workbench/ShowPageAnnotateControl.tsx
+++ b/ui/src/components/workbench/ShowPageAnnotateControl.tsx
@@ -155,7 +155,7 @@ export const ShowPageAnnotateControl: React.FC<ShowPageAnnotateControlProps> = (
                 aria-label={offLabel}
                 title={offLabel}
                 aria-pressed
-                className="grid size-6 shrink-0 place-items-center rounded-[5px] bg-mint text-primary-foreground transition hover:brightness-110"
+                className="grid size-6 shrink-0 place-items-center rounded-[5px] bg-mint text-primary-foreground transition hover:bg-mint-hover"
               >
                 <MessageSquarePlus className="size-3.5" />
               </button>

--- a/ui/src/components/workbench/skills/AddSkillDialog.tsx
+++ b/ui/src/components/workbench/skills/AddSkillDialog.tsx
@@ -325,7 +325,7 @@ export function AddSkillDialog({ defaultScope, projectId, projectName, onClose, 
               type="button"
               onClick={install}
               disabled={!discovered || selected.size === 0 || backends.size === 0 || busy === 'install'}
-              className="flex items-center gap-1.5 rounded-lg bg-mint px-4 py-2 text-[12px] font-semibold text-primary-foreground shadow-[0_4px_16px_-4px_rgba(91,255,160,0.5)] transition hover:brightness-110 disabled:opacity-50"
+              className="flex items-center gap-1.5 rounded-lg bg-mint px-4 py-2 text-[12px] font-semibold text-primary-foreground shadow-[0_4px_16px_-4px_rgba(91,255,160,0.5)] transition hover:bg-mint-hover disabled:opacity-50"
             >
               {busy === 'install' ? <Loader2 className="size-3.5 animate-spin" /> : <Download className="size-3.5" />}
               {busy === 'install' ? t('skills.addDialog.installing') : t('skills.addDialog.install', { count: selected.size })}

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -120,6 +120,15 @@
   --primary: #5bffa0;
   --primary-foreground: #080812;
   --primary-ink: #5bffa0;
+  /* Hover on a brand fill moves the fill AWAY from its label, so the pairing
+     improves under the cursor instead of degrading. This theme's labels are dark
+     ink, so the fill mixes toward white; light's labels are white, so it mixes
+     toward black. A brightness() filter cannot express this: it scales the label
+     with the fill, and a white label is already clamped at the top, so
+     brightness(1.1) only lowered light --primary from 2.54:1 to 2.09:1 while
+     brightness(0.95) bought nothing back (2.50:1). Mixing the background alone
+     leaves the label at full luminance and lifts hover to 3.23:1. */
+  --brand-hover-mix: #ffffff;
   --secondary: #11111c;
   --secondary-foreground: #f5f1e8;
   --muted: #9ba3b8;
@@ -218,6 +227,9 @@
     --primary: #10b981;
     --primary-foreground: #ffffff;
     --primary-ink: #067a55;
+    /* Mixes toward black because this theme's brand labels are white — see the
+       dark block for why hover shifts the fill rather than filtering the button. */
+    --brand-hover-mix: #000000;
     --secondary: #eef1f7;
     --secondary-foreground: #0a0a14;
     --muted: #5c6079;
@@ -316,6 +328,9 @@
   --primary: #10b981;
   --primary-foreground: #ffffff;
   --primary-ink: #067a55;
+  /* Mixes toward black because this theme's brand labels are white — see the
+     dark block for why hover shifts the fill rather than filtering the button. */
+  --brand-hover-mix: #000000;
   --secondary: #eef1f7;
   --secondary-foreground: #0a0a14;
   --muted: #5c6079;

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -38,6 +38,7 @@
   --color-primary: var(--primary);
   --color-primary-foreground: var(--primary-foreground);
   --color-primary-ink: var(--primary-ink);
+  --color-primary-hover: var(--primary-hover);
   --color-secondary: var(--secondary);
   --color-secondary-foreground: var(--secondary-foreground);
   --color-muted: var(--muted);
@@ -45,9 +46,11 @@
   --color-accent: var(--accent);
   --color-accent-foreground: var(--accent-foreground);
   --color-accent-ink: var(--accent-ink);
+  --color-accent-hover: var(--accent-hover);
   --color-destructive: var(--destructive);
   --color-destructive-foreground: var(--destructive-foreground);
   --color-destructive-ink: var(--destructive-ink);
+  --color-destructive-hover: var(--destructive-hover);
   --color-border: var(--border);
   --color-border-strong: var(--border-strong);
   --color-input: var(--input);
@@ -62,16 +65,21 @@
   --color-mint: var(--mint);
   --color-mint-soft: var(--mint-soft);
   --color-mint-ink: var(--mint-ink);
+  --color-mint-hover: var(--mint-hover);
   --color-cyan: var(--cyan);
   --color-cyan-soft: var(--cyan-soft);
   --color-cyan-ink: var(--cyan-ink);
+  --color-cyan-hover: var(--cyan-hover);
   --color-violet: var(--violet);
   --color-violet-soft: var(--violet-soft);
+  --color-violet-foreground: var(--violet-foreground);
   --color-violet-ink: var(--violet-ink);
+  --color-violet-hover: var(--violet-hover);
   --color-gold: var(--gold);
   --color-gold-soft: var(--gold-soft);
   --color-gold-foreground: var(--gold-foreground);
   --color-gold-ink: var(--gold-ink);
+  --color-gold-hover: var(--gold-hover);
   --color-pink: var(--pink);
   --color-pink-soft: var(--pink-soft);
   --color-pink-ink: var(--pink-ink);
@@ -120,15 +128,18 @@
   --primary: #5bffa0;
   --primary-foreground: #080812;
   --primary-ink: #5bffa0;
-  /* Hover on a brand fill moves the fill AWAY from its label, so the pairing
-     improves under the cursor instead of degrading. This theme's labels are dark
-     ink, so the fill mixes toward white; light's labels are white, so it mixes
-     toward black. A brightness() filter cannot express this: it scales the label
-     with the fill, and a white label is already clamped at the top, so
-     brightness(1.1) only lowered light --primary from 2.54:1 to 2.09:1 while
-     brightness(0.95) bought nothing back (2.50:1). Mixing the background alone
-     leaves the label at full luminance and lifts hover to 3.23:1. */
-  --brand-hover-mix: #ffffff;
+  /* Every interactive brand fill declares the value it hovers to, instead of deriving
+     one with a filter. A filter scales the label along with the background, so it
+     cannot move a pairing in a chosen direction: light's labels are white, already
+     clamped at the top, and brightness(1.1) there dropped --primary from 2.54:1 to
+     2.09:1 while brightness(0.95) bought nothing back (2.50:1). A declared fill leaves
+     the label at full luminance and lifts that same hover to 3.23:1.
+     Which way a fill moves follows its LABEL, not its theme — the distinction a single
+     shared mix token could not express. These accents carry a dark label, so they
+     lighten; --violet's label is white in both themes, so it darkens in both. Each
+     value is the fill mixed 88% toward its label's opposite, and validate-theme.mjs
+     asserts hovering never costs contrast, so no brand fill can ship without one. */
+  --primary-hover: #6fffab;
   --secondary: #11111c;
   --secondary-foreground: #f5f1e8;
   --muted: #9ba3b8;
@@ -136,9 +147,11 @@
   --accent: #3fe0e5;
   --accent-foreground: #080812;
   --accent-ink: #3fe0e5;
+  --accent-hover: #56e4e8;
   --destructive: #ff6b6b;
   --destructive-foreground: #080812;
   --destructive-ink: #ff6b6b;
+  --destructive-hover: #ff7d7d;
 
   --border: rgba(255, 255, 255, 0.08);
   --border-strong: rgba(255, 255, 255, 0.14);
@@ -148,19 +161,29 @@
   --mint: #5bffa0;
   --mint-soft: rgba(91, 255, 160, 0.16);
   --mint-ink: #5bffa0;
+  --mint-hover: #6fffab;
   --cyan: #3fe0e5;
   --cyan-soft: rgba(63, 224, 229, 0.16);
   --cyan-ink: #3fe0e5;
+  --cyan-hover: #56e4e8;
   /* The fill keeps design.pen's #7c5bff. Only the ink is lightened, because
      #7c5bff read 4.28:1 as text on --card — the one dark accent below the
-     floor. Hue and saturation are unchanged. */
+     floor. Hue and saturation are unchanged.
+     Violet is the only accent whose label is white in BOTH themes, which is why
+     it needs its own --violet-foreground rather than borrowing a theme rule: the
+     Button used a hard-coded text-white, so nothing declared the pair and the
+     guard could not see it. Naming it also fixes the hover direction — violet
+     darkens on hover in dark too, where every other accent lightens. */
   --violet: #7c5bff;
   --violet-soft: rgba(124, 91, 255, 0.16);
+  --violet-foreground: #ffffff;
   --violet-ink: #8465ff;
+  --violet-hover: #6d50e0;
   --gold: #ffc857;
   --gold-soft: rgba(255, 200, 87, 0.16);
   --gold-foreground: #080812;
   --gold-ink: #ffc857;
+  --gold-hover: #ffcf6b;
   --pink: #ff5b8a;
   --pink-soft: rgba(255, 91, 138, 0.10);
   --pink-ink: #ff5b8a;
@@ -227,9 +250,9 @@
     --primary: #10b981;
     --primary-foreground: #ffffff;
     --primary-ink: #067a55;
-    /* Mixes toward black because this theme's brand labels are white — see the
-       dark block for why hover shifts the fill rather than filtering the button. */
-    --brand-hover-mix: #000000;
+    /* Every brand fill darkens on hover here, because this theme's labels are white —
+       see the dark block for why hover is a declared fill rather than a filter. */
+    --primary-hover: #0ea372;
     --secondary: #eef1f7;
     --secondary-foreground: #0a0a14;
     --muted: #5c6079;
@@ -237,9 +260,11 @@
     --accent: #0891b2;
     --accent-foreground: #ffffff;
     --accent-ink: #0e7490;
+    --accent-hover: #07809d;
     --destructive: #e11d48;
     --destructive-foreground: #ffffff;
     --destructive-ink: #ca1a41;
+    --destructive-hover: #c61a3f;
 
     --border: rgba(8, 8, 18, 0.08);
     --border-strong: rgba(8, 8, 18, 0.14);
@@ -259,16 +284,21 @@
     --mint: #10b981;
     --mint-soft: rgba(16, 185, 129, 0.14);
     --mint-ink: #067a55;
+    --mint-hover: #0ea372;
     --cyan: #0891b2;
     --cyan-soft: rgba(8, 145, 178, 0.14);
     --cyan-ink: #0e7490;
+    --cyan-hover: #07809d;
     --violet: #7c3aed;
     --violet-soft: rgba(124, 58, 237, 0.14);
+    --violet-foreground: #ffffff;
     --violet-ink: #7c3aed;
+    --violet-hover: #6d33d1;
     --gold: #d97706;
     --gold-soft: rgba(217, 119, 6, 0.14);
     --gold-foreground: #ffffff;
     --gold-ink: #ae4f08;
+    --gold-hover: #bf6905;
     --pink: #dc2659;
     --pink-soft: rgba(220, 38, 89, 0.10);
     --pink-ink: #c7204f;
@@ -328,9 +358,9 @@
   --primary: #10b981;
   --primary-foreground: #ffffff;
   --primary-ink: #067a55;
-  /* Mixes toward black because this theme's brand labels are white — see the
-     dark block for why hover shifts the fill rather than filtering the button. */
-  --brand-hover-mix: #000000;
+  /* Every brand fill darkens on hover here, because this theme's labels are white —
+     see the dark block for why hover is a declared fill rather than a filter. */
+  --primary-hover: #0ea372;
   --secondary: #eef1f7;
   --secondary-foreground: #0a0a14;
   --muted: #5c6079;
@@ -338,9 +368,11 @@
   --accent: #0891b2;
   --accent-foreground: #ffffff;
   --accent-ink: #0e7490;
+  --accent-hover: #07809d;
   --destructive: #e11d48;
   --destructive-foreground: #ffffff;
   --destructive-ink: #ca1a41;
+  --destructive-hover: #c61a3f;
 
   --border: rgba(8, 8, 18, 0.08);
   --border-strong: rgba(8, 8, 18, 0.14);
@@ -351,16 +383,21 @@
   --mint: #10b981;
   --mint-soft: rgba(16, 185, 129, 0.14);
   --mint-ink: #067a55;
+  --mint-hover: #0ea372;
   --cyan: #0891b2;
   --cyan-soft: rgba(8, 145, 178, 0.14);
   --cyan-ink: #0e7490;
+  --cyan-hover: #07809d;
   --violet: #7c3aed;
   --violet-soft: rgba(124, 58, 237, 0.14);
+  --violet-foreground: #ffffff;
   --violet-ink: #7c3aed;
+  --violet-hover: #6d33d1;
   --gold: #d97706;
   --gold-soft: rgba(217, 119, 6, 0.14);
   --gold-foreground: #ffffff;
   --gold-ink: #ae4f08;
+  --gold-hover: #bf6905;
   --pink: #dc2659;
   --pink-soft: rgba(220, 38, 89, 0.10);
   --pink-ink: #c7204f;

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -203,21 +203,27 @@
     --popover: #ffffff;
     --popover-foreground: #0a0a14;
 
-    /* Fills keep design.pen's vivid light accents, and take a dark label the
-       way the dark theme already does — #10b981 reads 2.54:1 under white but
-       7.86:1 under #080812, so the fill never had to move. --destructive is
-       the exception: #e11d48 is 4.70:1 under white and only 4.24:1 under the
-       dark ink, so its label stays white. Inks are a separate token; see the
-       --mint-ink group. Guarded by ui/scripts/validate-theme.mjs. */
+    /* Fills keep design.pen's vivid light accents *and* its white label — the
+       pairing the product shipped before it was briefly deepened. The brand
+       pair is a product decision, not an oversight: an AI-colleague product
+       should read as alive rather than muted, so the accent stays at full
+       saturation and the label stays white the way the design drew it. That
+       costs AA on the label (white on #10b981 is 2.54:1), so
+       validate-theme.mjs exempts these pairs by *pinning* the ratio each was
+       accepted at rather than skipping them — drift in either token changes
+       the measured ratio and fails the guard until someone re-decides.
+       --destructive needs no exemption: #e11d48 under white is 4.70:1.
+       Accent-as-text on a neutral surface is a separate token and keeps the
+       full AA floor; see the --mint-ink group. Owner decision 2026-08-14. */
     --primary: #10b981;
-    --primary-foreground: #080812;
+    --primary-foreground: #ffffff;
     --primary-ink: #067a55;
     --secondary: #eef1f7;
     --secondary-foreground: #0a0a14;
     --muted: #5c6079;
     --muted-soft: #eef1f7;
     --accent: #0891b2;
-    --accent-foreground: #080812;
+    --accent-foreground: #ffffff;
     --accent-ink: #0e7490;
     --destructive: #e11d48;
     --destructive-foreground: #ffffff;
@@ -249,7 +255,7 @@
     --violet-ink: #7c3aed;
     --gold: #d97706;
     --gold-soft: rgba(217, 119, 6, 0.14);
-    --gold-foreground: #080812;
+    --gold-foreground: #ffffff;
     --gold-ink: #ae4f08;
     --pink: #dc2659;
     --pink-soft: rgba(220, 38, 89, 0.10);
@@ -305,17 +311,17 @@
   --popover: #ffffff;
   --popover-foreground: #0a0a14;
 
-  /* Vivid fill + dark label, deepened ink - see the prefers-color-scheme block
-     above. Both light blocks must stay value-identical. */
+  /* Vivid fill + white label, deepened ink - see the prefers-color-scheme
+     block above. Both light blocks must stay value-identical. */
   --primary: #10b981;
-  --primary-foreground: #080812;
+  --primary-foreground: #ffffff;
   --primary-ink: #067a55;
   --secondary: #eef1f7;
   --secondary-foreground: #0a0a14;
   --muted: #5c6079;
   --muted-soft: #eef1f7;
   --accent: #0891b2;
-  --accent-foreground: #080812;
+  --accent-foreground: #ffffff;
   --accent-ink: #0e7490;
   --destructive: #e11d48;
   --destructive-foreground: #ffffff;
@@ -338,7 +344,7 @@
   --violet-ink: #7c3aed;
   --gold: #d97706;
   --gold-soft: rgba(217, 119, 6, 0.14);
-  --gold-foreground: #080812;
+  --gold-foreground: #ffffff;
   --gold-ink: #ae4f08;
   --pink: #dc2659;
   --pink-soft: rgba(220, 38, 89, 0.10);


### PR DESCRIPTION
## Capability

Restores the light theme's original brand pairing: design.pen's vivid accent fill
with the **white** label it shipped with.

`#1403` deepened the light fills (reverted in `#1406`). `#1406` restored the fills
but also swapped the label to dark ink to clear WCAG AA — a change the design never
asked for, and the one the owner pushed back on. This completes the restoration.

| token | before (#1406) | after | note |
| --- | --- | --- | --- |
| light `--primary-foreground` | `#080812` | `#ffffff` | on `--primary` `#10b981` |
| light `--accent-foreground` | `#080812` | `#ffffff` | on `--accent` `#0891b2` |
| light `--gold-foreground` | `#080812` | `#ffffff` | on `--gold` `#d97706` |

Fills, inks, washes, and the dark theme are all untouched. Both light blocks stay
value-identical, as `assertTokenMapsEqual` requires.

## The AA tradeoff, made explicit rather than silent

White on `#10b981` is 2.54:1, below the 4.5:1 floor. That is a deliberate product
decision: the brand accent carries the product's personality, and an AI-colleague
product should read as alive rather than muted.

Rather than delete the fill assertion and lose the protection everywhere, the guard
gains `ACCEPTED_BRAND_PAIRS`, which **pins** instead of skipping. Each entry records
the exact ratio the pair was accepted at:

- moving either token changes the measured ratio and **fails the guard**, forcing a
  fresh decision instead of a quiet slide further down
- an entry naming a pair no theme declares also fails, so a rename cannot leave a
  stale exemption excusing whatever takes that name next

Scope is narrow by construction: only the label printed on a brand fill is accepted.
Accent-as-text on a neutral surface is a separate token (`--X-ink`) and keeps the full
4.5:1 floor. `--destructive` needs no exemption — white on `#e11d48` is 4.70:1.

## Evidence

- **unit / contract** — `npm run validate:theme` passes. Both new behaviours were
  negative-tested by deliberately breaking them, and both fired with the intended
  message: drifting light `--primary` to `#059669` reported `3.77:1 ... pins it at
  2.54:1`, and a bogus entry reported `which no theme declares. Drop the entry.`
- **build / lint** — `npm run build` and `npm run lint` pass.
- **scenario** — no scenario catalog covers theme tokens; none updated.
- **residual manual** — visual check of light-mode brand CTAs.

## Companion change

`avibe-docs/design.pen` carries the same three Light-mode values. The `#1406` sync had
pushed the dark ink into the design file — the wrong direction, since the design leads
the code. That is corrected in the Pencil session and ships with the pending
`design.pen` commit on the docs side.

## Follow-up, not in scope

The `#1406` P2 stands: a bare accent mark on a neutral surface (the Model Hub gateway
wire, one unlabelled `bg-mint` dot) is guarded by neither assertion, and light `--mint`
is 2.54:1 against white there. Tracked separately; the fix is to point those at
`--mint-ink`, which is the rule the focus ring already follows.
