### PR TITLE
feat(memory): enable bounded agentic recall

### DIFF
--- a/core/memory/everos.py
+++ b/core/memory/everos.py
@@ -91,6 +91,14 @@ class ProviderHealthSnapshot:
         }
 
 
+@dataclass
+class AgenticRecallTelemetry:
+    """Scrub-safe state retained across one bounded agentic recall."""
+
+    round: Literal["round1", "round2", "unknown"] = "unknown"
+    timed_out: bool = False
+
+
 @dataclass(frozen=True)
 class ProviderCapture:
     session_ref: ProviderSessionRef
@@ -407,9 +415,9 @@ class EverOSPort:
         include_profile: bool = True,
         session_ref: ProviderSessionRef | None = None,
         timeout_seconds: float | None = None,
+        agentic_telemetry: AgenticRecallTelemetry | None = None,
     ) -> tuple[MemoryItem, ...]:
-        agentic_started = time.monotonic() if method == "agentic" else None
-        telemetry: dict[str, str] = {}
+        response_metadata: dict[str, str] = {}
         try:
             data = await self._search_data(
                 principal_id,
@@ -420,25 +428,14 @@ class EverOSPort:
                 include_profile=include_profile,
                 session_ref=session_ref,
                 timeout_seconds=timeout_seconds,
-                telemetry=telemetry,
+                telemetry=response_metadata,
             )
-            items = _map_search_items(data, principal_id=principal_id, limit=limit)
-        except MemoryProviderFailure as failure:
-            if agentic_started is not None:
-                logger.info(
-                    "Memory search telemetry mode=agentic round=%s duration_ms=%s success=false timeout=%s",
-                    telemetry.get("round", "unknown"),
-                    _elapsed_ms(agentic_started),
-                    str(failure.error == "memory_provider_timeout").lower(),
-                )
-            raise
-        if agentic_started is not None:
-            logger.info(
-                "Memory search telemetry mode=agentic round=%s duration_ms=%s success=true timeout=false",
-                telemetry.get("round", "unknown"),
-                _elapsed_ms(agentic_started),
-            )
-        return items
+            return _map_search_items(data, principal_id=principal_id, limit=limit)
+        finally:
+            if method == "agentic" and agentic_telemetry is not None:
+                round_value = response_metadata.get("round")
+                if round_value in {"round1", "round2"}:
+                    agentic_telemetry.round = round_value
 
     async def profile(self, principal_id: str, project_id: str) -> tuple[MemoryItem, ...]:
         del project_id
@@ -1446,6 +1443,7 @@ class MemoryProviderPort(Protocol):
         include_profile: bool = True,
         session_ref: ProviderSessionRef | None = None,
         timeout_seconds: float | None = None,
+        agentic_telemetry: AgenticRecallTelemetry | None = None,
     ) -> tuple[MemoryItem, ...]: ...
 
     async def profile(self, principal_id: str, project_id: str) -> tuple[MemoryItem, ...]: ...
@@ -1485,6 +1483,7 @@ class FakeMemoryProvider:
     profile_failure: BaseException | None = None
     health_failure: BaseException | None = None
     agentic_budget_enforced_flag: bool = False
+    agentic_round: Literal["round1", "round2", "unknown"] = "unknown"
     processing_health_failure: BaseException | None = None
     recorder_health_state: dict[str, str | None] = field(
         default_factory=lambda: {"state": "disabled", "reason": None}
@@ -1538,10 +1537,13 @@ class FakeMemoryProvider:
         include_profile: bool = True,
         session_ref: ProviderSessionRef | None = None,
         timeout_seconds: float | None = None,
+        agentic_telemetry: AgenticRecallTelemetry | None = None,
     ) -> tuple[MemoryItem, ...]:
         self.search_scopes.append((principal_id, project_id))
         self.search_policies.append((method, include_profile, session_ref))
         self.search_timeouts.append(timeout_seconds)
+        if method == "agentic" and agentic_telemetry is not None:
+            agentic_telemetry.round = self.agentic_round
         del query, limit
         if self.search_failure is not None:
             raise self.search_failure

--- a/core/memory/everos.py
+++ b/core/memory/everos.py
@@ -49,6 +49,8 @@ _MAX_ITEM_BYTES = 64 * 1024
 _MAX_RESPONSE_DEPTH = 8
 _MAX_RESPONSE_COLLECTION = 200
 _SIDECAR_TIMEOUT_SECONDS = 20.0
+_AGENTIC_TIMEOUT_HEADER = "X-Avibe-Memory-Agentic-Timeout-Seconds"
+_SIDECAR_TIMEOUT_RESPONSE_MARGIN_SECONDS = 0.05
 _ADD_TIMEOUT_SECONDS = 30.0
 _FLUSH_TIMEOUT_SECONDS = 300.0
 _PROCESSING_TIMEOUT_SECONDS = 8.0
@@ -405,17 +407,33 @@ class EverOSPort:
         session_ref: ProviderSessionRef | None = None,
         timeout_seconds: float | None = None,
     ) -> tuple[MemoryItem, ...]:
-        data = await self._search_data(
-            principal_id,
-            project_id,
-            query,
-            limit,
-            method=method,
-            include_profile=include_profile,
-            session_ref=session_ref,
-            timeout_seconds=timeout_seconds,
-        )
-        return _map_search_items(data, principal_id=principal_id, limit=limit)
+        agentic_started = time.monotonic() if method == "agentic" else None
+        try:
+            data = await self._search_data(
+                principal_id,
+                project_id,
+                query,
+                limit,
+                method=method,
+                include_profile=include_profile,
+                session_ref=session_ref,
+                timeout_seconds=timeout_seconds,
+            )
+            items = _map_search_items(data, principal_id=principal_id, limit=limit)
+        except MemoryProviderFailure as failure:
+            if agentic_started is not None:
+                logger.info(
+                    "Memory search telemetry mode=agentic duration_ms=%s success=false timeout=%s",
+                    _elapsed_ms(agentic_started),
+                    str(failure.error == "memory_provider_timeout").lower(),
+                )
+            raise
+        if agentic_started is not None:
+            logger.info(
+                "Memory search telemetry mode=agentic duration_ms=%s success=true timeout=false",
+                _elapsed_ms(agentic_started),
+            )
+        return items
 
     async def profile(self, principal_id: str, project_id: str) -> tuple[MemoryItem, ...]:
         del project_id
@@ -613,7 +631,6 @@ class EverOSPort:
         }
         if session_ref is not None:
             request["filters"] = {"session_id": session_ref.session_id}
-        agentic_started = time.monotonic() if method == "agentic" else None
         try:
             if method == "agentic":
                 request_timeout = min(
@@ -648,25 +665,7 @@ class EverOSPort:
             if not isinstance(data, dict) or not _is_bounded_json_value(data):
                 raise MemoryProviderFailure("memory_provider_response_invalid")
         except asyncio.TimeoutError as exc:
-            assert agentic_started is not None
-            logger.info(
-                "Memory search telemetry mode=agentic duration_ms=%s success=false timeout=true",
-                _elapsed_ms(agentic_started),
-            )
             raise MemoryProviderFailure("memory_provider_timeout") from exc
-        except MemoryProviderFailure as failure:
-            if agentic_started is not None:
-                logger.info(
-                    "Memory search telemetry mode=agentic duration_ms=%s success=false timeout=%s",
-                    _elapsed_ms(agentic_started),
-                    str(failure.error == "memory_provider_timeout").lower(),
-                )
-            raise
-        if agentic_started is not None:
-            logger.info(
-                "Memory search telemetry mode=agentic duration_ms=%s success=true timeout=false",
-                _elapsed_ms(agentic_started),
-            )
         return data
 
     async def _sidecar_request(
@@ -684,6 +683,13 @@ class EverOSPort:
             timeout_seconds,
             self._sidecar_timeout_seconds,
         )
+        headers = None
+        if timeout_seconds is not None:
+            sidecar_timeout = max(
+                0.001,
+                request_timeout - _SIDECAR_TIMEOUT_RESPONSE_MARGIN_SECONDS,
+            )
+            headers = {_AGENTIC_TIMEOUT_HEADER: str(sidecar_timeout)}
         transport = httpx.AsyncHTTPTransport(uds=str(self._socket_path))
         try:
             async with httpx.AsyncClient(
@@ -695,7 +701,12 @@ class EverOSPort:
                 ),
                 trust_env=False,
             ) as client:
-                async with client.stream(method, route, json=payload) as response:
+                async with client.stream(
+                    method,
+                    route,
+                    json=payload,
+                    headers=headers,
+                ) as response:
                     if not 200 <= response.status_code < 300:
                         logger.warning(
                             "EverOS sidecar request failed route=%s status=%s latency_ms=%s",
@@ -704,9 +715,13 @@ class EverOSPort:
                             _elapsed_ms(started),
                         )
                         raise MemoryProviderFailure(
-                            "memory_capability_unavailable"
-                            if capability_rejection and response.status_code == 422
-                            else "memory_processing_failed"
+                            "memory_provider_timeout"
+                            if timeout_seconds is not None and response.status_code == 504
+                            else (
+                                "memory_capability_unavailable"
+                                if capability_rejection and response.status_code == 422
+                                else "memory_processing_failed"
+                            )
                         )
                     if not require_json:
                         await _read_bounded_response(response)

--- a/core/memory/everos.py
+++ b/core/memory/everos.py
@@ -50,6 +50,7 @@ _MAX_RESPONSE_DEPTH = 8
 _MAX_RESPONSE_COLLECTION = 200
 _SIDECAR_TIMEOUT_SECONDS = 20.0
 _AGENTIC_TIMEOUT_HEADER = "X-Avibe-Memory-Agentic-Timeout-Seconds"
+_AGENTIC_ROUND_HEADER = "X-Avibe-Memory-Agentic-Round"
 _SIDECAR_TIMEOUT_RESPONSE_MARGIN_SECONDS = 0.05
 _ADD_TIMEOUT_SECONDS = 30.0
 _FLUSH_TIMEOUT_SECONDS = 300.0
@@ -408,6 +409,7 @@ class EverOSPort:
         timeout_seconds: float | None = None,
     ) -> tuple[MemoryItem, ...]:
         agentic_started = time.monotonic() if method == "agentic" else None
+        telemetry: dict[str, str] = {}
         try:
             data = await self._search_data(
                 principal_id,
@@ -418,19 +420,22 @@ class EverOSPort:
                 include_profile=include_profile,
                 session_ref=session_ref,
                 timeout_seconds=timeout_seconds,
+                telemetry=telemetry,
             )
             items = _map_search_items(data, principal_id=principal_id, limit=limit)
         except MemoryProviderFailure as failure:
             if agentic_started is not None:
                 logger.info(
-                    "Memory search telemetry mode=agentic duration_ms=%s success=false timeout=%s",
+                    "Memory search telemetry mode=agentic round=%s duration_ms=%s success=false timeout=%s",
+                    telemetry.get("round", "unknown"),
                     _elapsed_ms(agentic_started),
                     str(failure.error == "memory_provider_timeout").lower(),
                 )
             raise
         if agentic_started is not None:
             logger.info(
-                "Memory search telemetry mode=agentic duration_ms=%s success=true timeout=false",
+                "Memory search telemetry mode=agentic round=%s duration_ms=%s success=true timeout=false",
+                telemetry.get("round", "unknown"),
                 _elapsed_ms(agentic_started),
             )
         return items
@@ -611,6 +616,7 @@ class EverOSPort:
         include_profile: bool,
         session_ref: ProviderSessionRef | None,
         timeout_seconds: float | None,
+        telemetry: dict[str, str],
     ) -> dict[str, Any]:
         if method not in {"keyword", "vector", "hybrid", "agentic"}:
             raise MemoryProviderFailure("memory_invalid_input", retryable=False)
@@ -648,6 +654,7 @@ class EverOSPort:
                         require_json=True,
                         capability_rejection=True,
                         timeout_seconds=request_timeout,
+                        response_metadata=telemetry,
                     ),
                     timeout=request_timeout,
                 )
@@ -677,6 +684,7 @@ class EverOSPort:
         require_json: bool,
         capability_rejection: bool = False,
         timeout_seconds: float | None = None,
+        response_metadata: dict[str, str] | None = None,
     ) -> dict[str, Any] | None:
         started = time.monotonic()
         request_timeout = _positive_timeout(
@@ -707,6 +715,12 @@ class EverOSPort:
                     json=payload,
                     headers=headers,
                 ) as response:
+                    round_value = response.headers.get(_AGENTIC_ROUND_HEADER)
+                    if (
+                        response_metadata is not None
+                        and round_value in {"round1", "round2"}
+                    ):
+                        response_metadata["round"] = round_value
                     if not 200 <= response.status_code < 300:
                         logger.warning(
                             "EverOS sidecar request failed route=%s status=%s latency_ms=%s",

--- a/core/memory/everos.py
+++ b/core/memory/everos.py
@@ -27,6 +27,7 @@ from core.memory.types import (
     ProviderSessionRef,
     is_memory_error_code,
     MemoryPreflightDiagnostic,
+    MAX_AGENTIC_TIMEOUT_SECONDS,
 )
 from core.memory.observations import (
     AddAck,
@@ -207,9 +208,9 @@ class EverOSPort:
 
     @property
     def agentic_budget_enforced(self) -> bool:
-        """EverOS 1.2.3 exposes no model-call or token budget enforcement."""
+        """Whether this adapter enforces a bounded agentic wall-clock budget."""
 
-        return False
+        return True
 
     async def add(self, capture: ProviderCapture) -> AddResult:
         """Durably hand one capture to EverOS and return its acknowledgement."""
@@ -402,6 +403,7 @@ class EverOSPort:
         method: Literal["keyword", "vector", "hybrid", "agentic"] = "hybrid",
         include_profile: bool = True,
         session_ref: ProviderSessionRef | None = None,
+        timeout_seconds: float | None = None,
     ) -> tuple[MemoryItem, ...]:
         data = await self._search_data(
             principal_id,
@@ -411,6 +413,7 @@ class EverOSPort:
             method=method,
             include_profile=include_profile,
             session_ref=session_ref,
+            timeout_seconds=timeout_seconds,
         )
         return _map_search_items(data, principal_id=principal_id, limit=limit)
 
@@ -589,14 +592,10 @@ class EverOSPort:
         method: Literal["keyword", "vector", "hybrid", "agentic"],
         include_profile: bool,
         session_ref: ProviderSessionRef | None,
+        timeout_seconds: float | None,
     ) -> dict[str, Any]:
         if method not in {"keyword", "vector", "hybrid", "agentic"}:
             raise MemoryProviderFailure("memory_invalid_input", retryable=False)
-        if method == "agentic" and not self.agentic_budget_enforced:
-            raise MemoryProviderFailure(
-                "memory_capability_unavailable",
-                retryable=False,
-            )
         if session_ref is not None and (
             session_ref.principal_id != principal_id
             or session_ref.project_ref != project_id
@@ -614,18 +613,60 @@ class EverOSPort:
         }
         if session_ref is not None:
             request["filters"] = {"session_id": session_ref.session_id}
-        body = await self._sidecar_request(
-            "POST",
-            "/api/v2/memory/search",
-            request,
-            require_json=True,
-            capability_rejection=True,
-        )
-        if not isinstance(body, dict):
-            raise MemoryProviderFailure("memory_provider_response_invalid")
-        data = body.get("data")
-        if not isinstance(data, dict) or not _is_bounded_json_value(data):
-            raise MemoryProviderFailure("memory_provider_response_invalid")
+        agentic_started = time.monotonic() if method == "agentic" else None
+        try:
+            if method == "agentic":
+                request_timeout = min(
+                    _positive_timeout(
+                        timeout_seconds,
+                        MAX_AGENTIC_TIMEOUT_SECONDS,
+                    ),
+                    MAX_AGENTIC_TIMEOUT_SECONDS,
+                )
+                body = await asyncio.wait_for(
+                    self._sidecar_request(
+                        "POST",
+                        "/api/v2/memory/search",
+                        request,
+                        require_json=True,
+                        capability_rejection=True,
+                        timeout_seconds=request_timeout,
+                    ),
+                    timeout=request_timeout,
+                )
+            else:
+                body = await self._sidecar_request(
+                    "POST",
+                    "/api/v2/memory/search",
+                    request,
+                    require_json=True,
+                    capability_rejection=True,
+                )
+            if not isinstance(body, dict):
+                raise MemoryProviderFailure("memory_provider_response_invalid")
+            data = body.get("data")
+            if not isinstance(data, dict) or not _is_bounded_json_value(data):
+                raise MemoryProviderFailure("memory_provider_response_invalid")
+        except asyncio.TimeoutError as exc:
+            assert agentic_started is not None
+            logger.info(
+                "Memory search telemetry mode=agentic duration_ms=%s success=false timeout=true",
+                _elapsed_ms(agentic_started),
+            )
+            raise MemoryProviderFailure("memory_provider_timeout") from exc
+        except MemoryProviderFailure as failure:
+            if agentic_started is not None:
+                logger.info(
+                    "Memory search telemetry mode=agentic duration_ms=%s success=false timeout=%s",
+                    _elapsed_ms(agentic_started),
+                    str(failure.error == "memory_provider_timeout").lower(),
+                )
+            raise
+        if agentic_started is not None:
+            logger.info(
+                "Memory search telemetry mode=agentic duration_ms=%s success=true timeout=false",
+                _elapsed_ms(agentic_started),
+            )
         return data
 
     async def _sidecar_request(
@@ -636,14 +677,22 @@ class EverOSPort:
         *,
         require_json: bool,
         capability_rejection: bool = False,
+        timeout_seconds: float | None = None,
     ) -> dict[str, Any] | None:
         started = time.monotonic()
+        request_timeout = _positive_timeout(
+            timeout_seconds,
+            self._sidecar_timeout_seconds,
+        )
         transport = httpx.AsyncHTTPTransport(uds=str(self._socket_path))
         try:
             async with httpx.AsyncClient(
                 transport=transport,
                 base_url="http://memory-sidecar",
-                timeout=httpx.Timeout(self._sidecar_timeout_seconds, connect=3.0),
+                timeout=httpx.Timeout(
+                    request_timeout,
+                    connect=min(3.0, request_timeout),
+                ),
                 trust_env=False,
             ) as client:
                 async with client.stream(method, route, json=payload) as response:
@@ -1339,7 +1388,7 @@ def _normalized_endpoint_url(value: str | None) -> str | None:
     return normalized.rstrip("/") if normalized else None
 
 
-def _positive_timeout(value: float, fallback: float) -> float:
+def _positive_timeout(value: object, fallback: float) -> float:
     try:
         parsed = float(value)
     except (TypeError, ValueError):
@@ -1367,6 +1416,7 @@ class MemoryProviderPort(Protocol):
         method: Literal["keyword", "vector", "hybrid", "agentic"] = "hybrid",
         include_profile: bool = True,
         session_ref: ProviderSessionRef | None = None,
+        timeout_seconds: float | None = None,
     ) -> tuple[MemoryItem, ...]: ...
 
     async def profile(self, principal_id: str, project_id: str) -> tuple[MemoryItem, ...]: ...
@@ -1398,12 +1448,14 @@ class FakeMemoryProvider:
     search_policies: list[
         tuple[str, bool, ProviderSessionRef | None]
     ] = field(default_factory=list)
+    search_timeouts: list[float | None] = field(default_factory=list)
     ingest_failures: Deque[BaseException] = field(default_factory=deque)
     add_results: Deque[AddResult] = field(default_factory=deque)
     flush_results: Deque[FlushResult] = field(default_factory=deque)
     search_failure: BaseException | None = None
     profile_failure: BaseException | None = None
     health_failure: BaseException | None = None
+    agentic_budget_enforced_flag: bool = False
     processing_health_failure: BaseException | None = None
     recorder_health_state: dict[str, str | None] = field(
         default_factory=lambda: {"state": "disabled", "reason": None}
@@ -1456,9 +1508,11 @@ class FakeMemoryProvider:
         method: Literal["keyword", "vector", "hybrid", "agentic"] = "hybrid",
         include_profile: bool = True,
         session_ref: ProviderSessionRef | None = None,
+        timeout_seconds: float | None = None,
     ) -> tuple[MemoryItem, ...]:
         self.search_scopes.append((principal_id, project_id))
         self.search_policies.append((method, include_profile, session_ref))
+        self.search_timeouts.append(timeout_seconds)
         del query, limit
         if self.search_failure is not None:
             raise self.search_failure
@@ -1502,4 +1556,4 @@ class FakeMemoryProvider:
 
     @property
     def agentic_budget_enforced(self) -> bool:
-        return False
+        return self.agentic_budget_enforced_flag

--- a/core/memory/module.py
+++ b/core/memory/module.py
@@ -12,6 +12,7 @@ from collections.abc import Awaitable, Callable
 from contextlib import asynccontextmanager
 from datetime import date, datetime, timezone
 from pathlib import Path
+from time import monotonic
 from typing import Any, AsyncIterator, Literal, TypeVar
 
 from config import paths
@@ -633,6 +634,49 @@ class MemoryModule:
         if self._clear_active or self._is_maintenance_open():
             return OperationFailed(error="memory_clear_failed")
 
+        agentic_deadline = (
+            monotonic() + float(policy.timeout_seconds)
+            if policy.mode == "agentic" and policy.timeout_seconds is not None
+            else None
+        )
+        if agentic_deadline is None:
+            return await self._recall_validated(
+                normalized_query,
+                policy=policy,
+                principal_id=principal_id,
+                project_id=project_id,
+                current_session_id=current_session_id,
+                effective_mode=effective_mode,
+                agentic_deadline=None,
+            )
+        try:
+            remaining = _remaining_timeout(agentic_deadline)
+            return await asyncio.wait_for(
+                self._recall_validated(
+                    normalized_query,
+                    policy=policy,
+                    principal_id=principal_id,
+                    project_id=project_id,
+                    current_session_id=current_session_id,
+                    effective_mode=effective_mode,
+                    agentic_deadline=agentic_deadline,
+                ),
+                timeout=remaining,
+            )
+        except asyncio.TimeoutError:
+            return OperationFailed(error="memory_provider_timeout")
+
+    async def _recall_validated(
+        self,
+        normalized_query: str,
+        *,
+        policy: RecallPolicy,
+        principal_id: str,
+        project_id: str,
+        current_session_id: str | None,
+        effective_mode: Literal["keyword", "vector", "hybrid", "agentic"] | None,
+        agentic_deadline: float | None,
+    ) -> RecallResult:
         async with self._lifecycle_lock:
             if not self._is_enabled():
                 return OperationFailed(error="memory_disabled")
@@ -661,17 +705,27 @@ class MemoryModule:
             requested_mode = policy.mode
             mode_was_pre_resolved = effective_mode is not None
             if effective_mode is None:
-                effective_mode = await self.resolve_recall_mode(policy)
+                effective_mode = await self.resolve_recall_mode(
+                    policy,
+                    timeout_seconds=(
+                        _remaining_timeout(agentic_deadline)
+                        if agentic_deadline is not None
+                        else None
+                    ),
+                )
                 if isinstance(effective_mode, OperationFailed):
                     return effective_mode
             if effective_mode == "agentic":
-                if requested_mode != "agentic":
+                if requested_mode != "agentic" or agentic_deadline is None:
                     return OperationFailed(error="memory_capability_unavailable")
                 if mode_was_pre_resolved:
-                    resolved_mode = await self.resolve_recall_mode(policy)
+                    resolved_mode = await self.resolve_recall_mode(
+                        policy,
+                        timeout_seconds=_remaining_timeout(agentic_deadline),
+                    )
                     if resolved_mode != "agentic":
                         return OperationFailed(error="memory_capability_unavailable")
-                provider_timeout = float(policy.timeout_seconds or 0)
+                provider_timeout = _remaining_timeout(agentic_deadline)
             else:
                 provider_timeout = None
             result = await self._provider_read(
@@ -685,7 +739,7 @@ class MemoryModule:
                     session_ref=session_ref,
                     timeout_seconds=provider_timeout,
                 ),
-                timeout_seconds=(provider_timeout + 1.0 if provider_timeout else None),
+                timeout_seconds=provider_timeout,
             )
         if isinstance(result, OperationFailed):
             return result
@@ -702,6 +756,8 @@ class MemoryModule:
     async def resolve_recall_mode(
         self,
         policy: RecallPolicy,
+        *,
+        timeout_seconds: float | None = None,
     ) -> Literal["keyword", "vector", "hybrid", "agentic"] | OperationFailed:
         if policy.mode == "agentic":
             if not bool(getattr(self._provider, "agentic_budget_enforced", False)):
@@ -711,7 +767,11 @@ class MemoryModule:
         try:
             health = await asyncio.wait_for(
                 self._provider.health_snapshot(),
-                timeout=PROVIDER_READ_TIMEOUT_SECONDS,
+                timeout=(
+                    timeout_seconds
+                    if timeout_seconds is not None
+                    else PROVIDER_READ_TIMEOUT_SECONDS
+                ),
             )
             embed_available = health.capabilities.get("embed") is True
             agentic_available = (
@@ -1037,3 +1097,10 @@ def _positive_timeout(value: float) -> float:
         return max(float(value), 0.001)
     except (TypeError, ValueError):
         return 0.001
+
+
+def _remaining_timeout(deadline: float) -> float:
+    remaining = deadline - monotonic()
+    if remaining <= 0.001:
+        raise asyncio.TimeoutError
+    return remaining

--- a/core/memory/module.py
+++ b/core/memory/module.py
@@ -24,7 +24,11 @@ from core.memory.attachments import (
     encode_pinned_bundle,
 )
 from core.memory.provider_root import ProviderRoot
-from core.memory.everos import MemoryProviderFailure, MemoryProviderPort
+from core.memory.everos import (
+    AgenticRecallTelemetry,
+    MemoryProviderFailure,
+    MemoryProviderPort,
+)
 from core.memory.project_ids import (
     is_new_stored_memory_project_id,
     is_persisted_memory_project_id,
@@ -634,9 +638,14 @@ class MemoryModule:
         if self._clear_active or self._is_maintenance_open():
             return OperationFailed(error="memory_clear_failed")
 
-        agentic_deadline = (
-            monotonic() + float(policy.timeout_seconds)
+        agentic_started = (
+            monotonic()
             if policy.mode == "agentic" and policy.timeout_seconds is not None
+            else None
+        )
+        agentic_deadline = (
+            agentic_started + float(policy.timeout_seconds)
+            if agentic_started is not None
             else None
         )
         if agentic_deadline is None:
@@ -648,10 +657,12 @@ class MemoryModule:
                 current_session_id=current_session_id,
                 effective_mode=effective_mode,
                 agentic_deadline=None,
+                agentic_telemetry=None,
             )
+        agentic_telemetry = AgenticRecallTelemetry()
         try:
             remaining = _remaining_timeout(agentic_deadline)
-            return await asyncio.wait_for(
+            result = await asyncio.wait_for(
                 self._recall_validated(
                     normalized_query,
                     policy=policy,
@@ -660,11 +671,25 @@ class MemoryModule:
                     current_session_id=current_session_id,
                     effective_mode=effective_mode,
                     agentic_deadline=agentic_deadline,
+                    agentic_telemetry=agentic_telemetry,
                 ),
                 timeout=remaining,
             )
         except asyncio.TimeoutError:
-            return OperationFailed(error="memory_provider_timeout")
+            result = OperationFailed(error="memory_provider_timeout")
+        except BaseException:
+            _log_agentic_recall_telemetry(
+                started=agentic_started,
+                telemetry=agentic_telemetry,
+                result=None,
+            )
+            raise
+        _log_agentic_recall_telemetry(
+            started=agentic_started,
+            telemetry=agentic_telemetry,
+            result=result,
+        )
+        return result
 
     async def _recall_validated(
         self,
@@ -676,6 +701,7 @@ class MemoryModule:
         current_session_id: str | None,
         effective_mode: Literal["keyword", "vector", "hybrid", "agentic"] | None,
         agentic_deadline: float | None,
+        agentic_telemetry: AgenticRecallTelemetry | None,
     ) -> RecallResult:
         async with self._lifecycle_lock:
             if not self._is_enabled():
@@ -712,6 +738,7 @@ class MemoryModule:
                         if agentic_deadline is not None
                         else None
                     ),
+                    agentic_telemetry=agentic_telemetry,
                 )
                 if isinstance(effective_mode, OperationFailed):
                     return effective_mode
@@ -722,6 +749,7 @@ class MemoryModule:
                     resolved_mode = await self.resolve_recall_mode(
                         policy,
                         timeout_seconds=_remaining_timeout(agentic_deadline),
+                        agentic_telemetry=agentic_telemetry,
                     )
                     if resolved_mode != "agentic":
                         return OperationFailed(error="memory_capability_unavailable")
@@ -738,6 +766,7 @@ class MemoryModule:
                     include_profile=policy.include_profile,
                     session_ref=session_ref,
                     timeout_seconds=provider_timeout,
+                    agentic_telemetry=agentic_telemetry,
                 ),
                 timeout_seconds=provider_timeout,
             )
@@ -758,6 +787,7 @@ class MemoryModule:
         policy: RecallPolicy,
         *,
         timeout_seconds: float | None = None,
+        agentic_telemetry: AgenticRecallTelemetry | None = None,
     ) -> Literal["keyword", "vector", "hybrid", "agentic"] | OperationFailed:
         if policy.mode == "agentic":
             if not bool(getattr(self._provider, "agentic_budget_enforced", False)):
@@ -780,6 +810,11 @@ class MemoryModule:
                 and health.capabilities.get("rerank") is True
                 and "agentic_search" not in health.disabled_features
             )
+        except asyncio.TimeoutError:
+            if agentic_telemetry is not None:
+                agentic_telemetry.timed_out = True
+            embed_available = False
+            agentic_available = False
         except Exception:
             embed_available = False
             agentic_available = False
@@ -1104,3 +1139,22 @@ def _remaining_timeout(deadline: float) -> float:
     if remaining <= 0.001:
         raise asyncio.TimeoutError
     return remaining
+
+
+def _log_agentic_recall_telemetry(
+    *,
+    started: float,
+    telemetry: AgenticRecallTelemetry,
+    result: RecallResult | None,
+) -> None:
+    success = isinstance(result, RecallItems)
+    timeout = telemetry.timed_out or (
+        isinstance(result, OperationFailed) and result.error == "memory_provider_timeout"
+    )
+    logger.info(
+        "Memory recall telemetry mode=agentic round=%s duration_ms=%s success=%s timeout=%s",
+        telemetry.round,
+        max(0, int((monotonic() - started) * 1000)),
+        str(success).lower(),
+        str(timeout).lower(),
+    )

--- a/core/memory/module.py
+++ b/core/memory/module.py
@@ -810,8 +810,11 @@ class MemoryModule:
                 and health.capabilities.get("rerank") is True
                 and "agentic_search" not in health.disabled_features
             )
-        except asyncio.TimeoutError:
-            if agentic_telemetry is not None:
+        except (asyncio.TimeoutError, MemoryProviderFailure) as failure:
+            if agentic_telemetry is not None and (
+                isinstance(failure, asyncio.TimeoutError)
+                or failure.error == "memory_provider_timeout"
+            ):
                 agentic_telemetry.timed_out = True
             embed_available = False
             agentic_available = False

--- a/core/memory/module.py
+++ b/core/memory/module.py
@@ -659,15 +659,21 @@ class MemoryModule:
                     return OperationFailed(error="memory_store_unavailable")
 
             requested_mode = policy.mode
+            mode_was_pre_resolved = effective_mode is not None
             if effective_mode is None:
                 effective_mode = await self.resolve_recall_mode(policy)
                 if isinstance(effective_mode, OperationFailed):
                     return effective_mode
             if effective_mode == "agentic":
-                # EverOS 1.2.3 has no public model-call/token budget contract.
-                # A local timeout alone cannot make this policy enforceable.
-                if not bool(getattr(self._provider, "agentic_budget_enforced", False)):
+                if requested_mode != "agentic":
                     return OperationFailed(error="memory_capability_unavailable")
+                if mode_was_pre_resolved:
+                    resolved_mode = await self.resolve_recall_mode(policy)
+                    if resolved_mode != "agentic":
+                        return OperationFailed(error="memory_capability_unavailable")
+                provider_timeout = float(policy.timeout_seconds or 0)
+            else:
+                provider_timeout = None
             result = await self._provider_read(
                 lambda: self._provider.search(
                     principal_id,
@@ -677,7 +683,9 @@ class MemoryModule:
                     method=effective_mode,
                     include_profile=policy.include_profile,
                     session_ref=session_ref,
-                )
+                    timeout_seconds=provider_timeout,
+                ),
+                timeout_seconds=(provider_timeout + 1.0 if provider_timeout else None),
             )
         if isinstance(result, OperationFailed):
             return result
@@ -698,7 +706,6 @@ class MemoryModule:
         if policy.mode == "agentic":
             if not bool(getattr(self._provider, "agentic_budget_enforced", False)):
                 return OperationFailed(error="memory_capability_unavailable")
-            return "agentic"
         if policy.mode == "keyword":
             return "keyword"
         try:
@@ -707,8 +714,19 @@ class MemoryModule:
                 timeout=PROVIDER_READ_TIMEOUT_SECONDS,
             )
             embed_available = health.capabilities.get("embed") is True
+            agentic_available = (
+                embed_available
+                and health.capabilities.get("llm") is True
+                and health.capabilities.get("rerank") is True
+                and "agentic_search" not in health.disabled_features
+            )
         except Exception:
             embed_available = False
+            agentic_available = False
+        if policy.mode == "agentic":
+            if not agentic_available:
+                return OperationFailed(error="memory_capability_unavailable")
+            return "agentic"
         if policy.mode == "auto":
             return "hybrid" if embed_available else "keyword"
         if not embed_available:
@@ -763,9 +781,14 @@ class MemoryModule:
     async def _provider_read(
         self,
         operation: Callable[[], Awaitable[tuple[MemoryItem, ...]]],
+        *,
+        timeout_seconds: float | None = None,
     ) -> tuple[MemoryItem, ...] | OperationFailed:
         try:
-            return await asyncio.wait_for(operation(), timeout=PROVIDER_READ_TIMEOUT_SECONDS)
+            return await asyncio.wait_for(
+                operation(),
+                timeout=timeout_seconds or PROVIDER_READ_TIMEOUT_SECONDS,
+            )
         except asyncio.TimeoutError:
             return OperationFailed(error="memory_provider_timeout")
         except MemoryProviderFailure as failure:

--- a/core/memory/sidecar.py
+++ b/core/memory/sidecar.py
@@ -316,7 +316,7 @@ def _validate_search(payload: dict[str, Any]) -> str | None:
     if (
         not _valid_principal(payload.get("user_id"))
         or not isinstance(payload.get("query"), str)
-        or payload.get("method") not in {"keyword", "vector", "hybrid"}
+        or payload.get("method") not in {"keyword", "vector", "hybrid", "agentic"}
         or not isinstance(payload.get("top_k"), int)
         or isinstance(payload.get("top_k"), bool)
         or not 1 <= payload["top_k"] <= 20

--- a/core/memory/sidecar.py
+++ b/core/memory/sidecar.py
@@ -181,7 +181,12 @@ class _AgenticDeadlineProjection:
                 timeout=agentic_timeout,
             )
         except asyncio.TimeoutError:
-            await _send_json_error(send, status=504, detail="memory_request_timed_out")
+            await _send_json_error(
+                send,
+                status=504,
+                detail="memory_request_timed_out",
+                agentic_round=round_state.get("round"),
+            )
             return
         finally:
             _AGENTIC_ROUND_STATE.reset(token)
@@ -213,16 +218,30 @@ async def _buffer_request(receive: Any) -> tuple[list[dict[str, Any]], bytes]:
     return messages, b"".join(chunks)
 
 
-async def _send_json_error(send: Any, *, status: int, detail: str) -> None:
+async def _send_json_error(
+    send: Any,
+    *,
+    status: int,
+    detail: str,
+    agentic_round: str | None = None,
+) -> None:
     body = json.dumps({"detail": detail}, separators=(",", ":")).encode("utf-8")
+    headers = [
+        (b"content-type", b"application/json"),
+        (b"content-length", str(len(body)).encode("ascii")),
+    ]
+    if agentic_round in {"round1", "round2"}:
+        headers.append(
+            (
+                _AGENTIC_ROUND_HEADER.lower().encode("ascii"),
+                agentic_round.encode("ascii"),
+            )
+        )
     await send(
         {
             "type": "http.response.start",
             "status": status,
-            "headers": [
-                (b"content-type", b"application/json"),
-                (b"content-length", str(len(body)).encode("ascii")),
-            ],
+            "headers": headers,
         }
     )
     await send({"type": "http.response.body", "body": body})

--- a/core/memory/sidecar.py
+++ b/core/memory/sidecar.py
@@ -61,6 +61,8 @@ def serve(uds: Path) -> None:
     app = create_app()
     round_handler = _AgenticRoundHandler()
     round_logger = logging.getLogger("everos.memory.search.agentic")
+    original_round_logger_level = round_logger.level
+    round_logger.setLevel(logging.INFO)
     round_logger.addHandler(round_handler)
     if recorder is not None:
         original_lifespan = app.router.lifespan_context
@@ -114,6 +116,7 @@ def serve(uds: Path) -> None:
         uvicorn.Server(config).run()
     finally:
         round_logger.removeHandler(round_handler)
+        round_logger.setLevel(original_round_logger_level)
 
 
 class _AgenticRoundHandler(logging.Handler):

--- a/core/memory/sidecar.py
+++ b/core/memory/sidecar.py
@@ -7,13 +7,14 @@ import asyncio
 import importlib
 import json
 import logging
+import math
 import os
 import re
 import stat
 from contextlib import asynccontextmanager
 from importlib.metadata import version
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 from urllib.parse import unquote, urlparse
 
 from core.memory.artifact import EVEROS_VERSION
@@ -24,10 +25,12 @@ from core.memory.project_ids import (
 from core.memory.everos_insight import install_error_scrubbers, prepare_call_recorder
 from core.memory.everos_insight.patches import boundary_request
 from core.memory.modality import SUPPORTED_ATTACHMENT_EXTENSIONS
+from core.memory.types import MAX_AGENTIC_TIMEOUT_SECONDS
 
 
 _MAX_BODY_BYTES = 64 * 1024
 _APP_ID = "avibe"
+_AGENTIC_TIMEOUT_HEADER = "X-Avibe-Memory-Agentic-Timeout-Seconds"
 _PRINCIPAL_PATTERN = re.compile(r"u-[0-9a-f]{32}\Z")
 _SESSION_PATTERN = re.compile(r"src--[0-9a-f]{64}--e(?:0|[1-9][0-9]*)\Z")
 logger = logging.getLogger(__name__)
@@ -83,12 +86,30 @@ def serve(uds: Path) -> None:
         )
         if rejection is not None:
             return JSONResponse({"detail": "memory_request_rejected"}, status_code=403)
+        agentic_timeout = _agentic_request_timeout(
+            request.url.path,
+            body,
+            request.headers,
+        )
+        if agentic_timeout is False:
+            return JSONResponse({"detail": "memory_request_rejected"}, status_code=403)
         if recorder is not None and request.url.path in {
             "/api/v2/memory/add",
             "/api/v2/memory/flush",
         }:
             with boundary_request():
                 return await call_next(request)
+        if isinstance(agentic_timeout, float):
+            try:
+                return await asyncio.wait_for(
+                    call_next(request),
+                    timeout=agentic_timeout,
+                )
+            except asyncio.TimeoutError:
+                return JSONResponse(
+                    {"detail": "memory_request_timed_out"},
+                    status_code=504,
+                )
         return await call_next(request)
 
     config = uvicorn.Config(
@@ -202,6 +223,32 @@ def _request_rejection(
     if path == "/api/v2/memory/search":
         return _validate_search(payload)
     return _validate_get(payload)
+
+
+def _agentic_request_timeout(
+    path: str,
+    body: bytes,
+    headers: Any,
+) -> float | Literal[False] | None:
+    if path != "/api/v2/memory/search":
+        return None
+    try:
+        payload = json.loads(body)
+    except (TypeError, ValueError):
+        return False
+    if not isinstance(payload, dict) or payload.get("method") != "agentic":
+        return None
+    try:
+        timeout = float(headers.get(_AGENTIC_TIMEOUT_HEADER))
+    except (TypeError, ValueError):
+        return False
+    if (
+        not math.isfinite(timeout)
+        or timeout <= 0
+        or timeout > MAX_AGENTIC_TIMEOUT_SECONDS
+    ):
+        return False
+    return timeout
 
 
 def _valid_write_scope(payload: dict[str, Any]) -> bool:

--- a/core/memory/sidecar.py
+++ b/core/memory/sidecar.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import contextvars
 import importlib
 import json
 import logging
@@ -31,8 +32,12 @@ from core.memory.types import MAX_AGENTIC_TIMEOUT_SECONDS
 _MAX_BODY_BYTES = 64 * 1024
 _APP_ID = "avibe"
 _AGENTIC_TIMEOUT_HEADER = "X-Avibe-Memory-Agentic-Timeout-Seconds"
+_AGENTIC_ROUND_HEADER = "X-Avibe-Memory-Agentic-Round"
 _PRINCIPAL_PATTERN = re.compile(r"u-[0-9a-f]{32}\Z")
 _SESSION_PATTERN = re.compile(r"src--[0-9a-f]{64}--e(?:0|[1-9][0-9]*)\Z")
+_AGENTIC_ROUND_STATE: contextvars.ContextVar[dict[str, str] | None] = (
+    contextvars.ContextVar("avibe_memory_agentic_round", default=None)
+)
 logger = logging.getLogger(__name__)
 
 
@@ -54,6 +59,9 @@ def serve(uds: Path) -> None:
     factory_module = importlib.import_module("everos.entrypoints.api.app")
     create_app = getattr(factory_module, "create_app")
     app = create_app()
+    round_handler = _AgenticRoundHandler()
+    round_logger = logging.getLogger("everos.memory.search.agentic")
+    round_logger.addHandler(round_handler)
     if recorder is not None:
         original_lifespan = app.router.lifespan_context
 
@@ -86,41 +94,159 @@ def serve(uds: Path) -> None:
         )
         if rejection is not None:
             return JSONResponse({"detail": "memory_request_rejected"}, status_code=403)
-        agentic_timeout = _agentic_request_timeout(
-            request.url.path,
-            body,
-            request.headers,
-        )
-        if agentic_timeout is False:
-            return JSONResponse({"detail": "memory_request_rejected"}, status_code=403)
         if recorder is not None and request.url.path in {
             "/api/v2/memory/add",
             "/api/v2/memory/flush",
         }:
             with boundary_request():
                 return await call_next(request)
-        if isinstance(agentic_timeout, float):
-            try:
-                return await asyncio.wait_for(
-                    call_next(request),
-                    timeout=agentic_timeout,
-                )
-            except asyncio.TimeoutError:
-                return JSONResponse(
-                    {"detail": "memory_request_timed_out"},
-                    status_code=504,
-                )
         return await call_next(request)
 
     config = uvicorn.Config(
-        _RecorderHealthProjection(app, recorder),
+        _RecorderHealthProjection(_AgenticDeadlineProjection(app), recorder),
         uds=str(uds),
         access_log=False,
         log_level="warning",
         log_config=None,
         timeout_graceful_shutdown=1,
     )
-    uvicorn.Server(config).run()
+    try:
+        uvicorn.Server(config).run()
+    finally:
+        round_logger.removeHandler(round_handler)
+
+
+class _AgenticRoundHandler(logging.Handler):
+    """Capture only the bounded EverOS round token in the request context."""
+
+    def emit(self, record: logging.LogRecord) -> None:
+        state = _AGENTIC_ROUND_STATE.get()
+        if state is None or not isinstance(record.msg, dict):
+            return
+        if record.msg.get("event") != "agentic_search_decision":
+            return
+        round_value = record.msg.get("round")
+        if round_value in {"round1", "round2"}:
+            state["round"] = round_value
+
+
+class _AgenticDeadlineProjection:
+    """Own and cancel the downstream ASGI task for bounded agentic search."""
+
+    def __init__(self, app: Any) -> None:
+        self._app = app
+
+    async def __call__(self, scope: Any, receive: Any, send: Any) -> None:
+        if not (
+            scope.get("type") == "http"
+            and scope.get("method") == "POST"
+            and scope.get("path") == "/api/v2/memory/search"
+        ):
+            await self._app(scope, receive, send)
+            return
+
+        request_messages, body = await _buffer_request(receive)
+        message_index = 0
+
+        async def replay_receive() -> dict[str, Any]:
+            nonlocal message_index
+            if message_index < len(request_messages):
+                message = request_messages[message_index]
+                message_index += 1
+                return message
+            return await receive()
+
+        agentic_timeout = _agentic_request_timeout(
+            scope.get("path", ""),
+            body,
+            scope.get("headers", []),
+        )
+        if agentic_timeout is False:
+            await _send_json_error(send, status=403, detail="memory_request_rejected")
+            return
+        if agentic_timeout is None:
+            await self._app(scope, replay_receive, send)
+            return
+
+        response_messages: list[dict[str, Any]] = []
+
+        async def capture_send(message: dict[str, Any]) -> None:
+            response_messages.append(message)
+
+        round_state: dict[str, str] = {}
+        token = _AGENTIC_ROUND_STATE.set(round_state)
+        try:
+            await asyncio.wait_for(
+                self._app(scope, replay_receive, capture_send),
+                timeout=agentic_timeout,
+            )
+        except asyncio.TimeoutError:
+            await _send_json_error(send, status=504, detail="memory_request_timed_out")
+            return
+        finally:
+            _AGENTIC_ROUND_STATE.reset(token)
+
+        round_value = round_state.get("round")
+        if round_value in {"round1", "round2"}:
+            _append_response_header(
+                response_messages,
+                _AGENTIC_ROUND_HEADER,
+                round_value,
+            )
+        for message in response_messages:
+            await send(message)
+
+
+async def _buffer_request(receive: Any) -> tuple[list[dict[str, Any]], bytes]:
+    messages: list[dict[str, Any]] = []
+    chunks: list[bytes] = []
+    while True:
+        message = await receive()
+        messages.append(message)
+        if message.get("type") == "http.disconnect":
+            break
+        if message.get("type") != "http.request":
+            continue
+        chunks.append(message.get("body", b""))
+        if not message.get("more_body", False):
+            break
+    return messages, b"".join(chunks)
+
+
+async def _send_json_error(send: Any, *, status: int, detail: str) -> None:
+    body = json.dumps({"detail": detail}, separators=(",", ":")).encode("utf-8")
+    await send(
+        {
+            "type": "http.response.start",
+            "status": status,
+            "headers": [
+                (b"content-type", b"application/json"),
+                (b"content-length", str(len(body)).encode("ascii")),
+            ],
+        }
+    )
+    await send({"type": "http.response.body", "body": body})
+
+
+def _append_response_header(
+    messages: list[dict[str, Any]],
+    name: str,
+    value: str,
+) -> None:
+    encoded_name = name.lower().encode("ascii")
+    encoded_value = value.encode("ascii")
+    for index, message in enumerate(messages):
+        if message.get("type") != "http.response.start":
+            continue
+        projected = dict(message)
+        projected["headers"] = [
+            (header_name, header_value)
+            for header_name, header_value in message.get("headers", [])
+            if header_name.lower() != encoded_name
+        ]
+        projected["headers"].append((encoded_name, encoded_value))
+        messages[index] = projected
+        return
 
 
 class _RecorderHealthProjection:
@@ -239,7 +365,7 @@ def _agentic_request_timeout(
     if not isinstance(payload, dict) or payload.get("method") != "agentic":
         return None
     try:
-        timeout = float(headers.get(_AGENTIC_TIMEOUT_HEADER))
+        timeout = float(_header_value(headers, _AGENTIC_TIMEOUT_HEADER))
     except (TypeError, ValueError):
         return False
     if (
@@ -249,6 +375,22 @@ def _agentic_request_timeout(
     ):
         return False
     return timeout
+
+
+def _header_value(headers: Any, name: str) -> str | None:
+    if hasattr(headers, "get"):
+        value = headers.get(name)
+        if value is None:
+            value = headers.get(name.lower())
+        return value if isinstance(value, str) else None
+    encoded_name = name.lower().encode("ascii")
+    for header_name, header_value in headers:
+        if header_name.lower() == encoded_name:
+            try:
+                return header_value.decode("ascii")
+            except UnicodeDecodeError:
+                return None
+    return None
 
 
 def _valid_write_scope(payload: dict[str, Any]) -> bool:

--- a/core/memory/types.py
+++ b/core/memory/types.py
@@ -9,6 +9,7 @@ from typing import Any, Literal, TypeAlias
 
 MemoryKind = Literal["profile", "episode", "fact"]
 RecallMode = Literal["auto", "keyword", "vector", "hybrid", "agentic"]
+MAX_AGENTIC_TIMEOUT_SECONDS = 30.0
 MemoryContentKind = Literal["image", "audio", "doc", "pdf", "html", "email"]
 MemoryFailureKind = Literal[
     "boot_recovery",
@@ -393,7 +394,7 @@ class RecallPolicy:
                 or isinstance(self.timeout_seconds, bool)
                 or not isinstance(self.timeout_seconds, (int, float))
                 or not math.isfinite(float(self.timeout_seconds))
-                or not 0 < float(self.timeout_seconds) <= 30
+                or not 0 < float(self.timeout_seconds) <= MAX_AGENTIC_TIMEOUT_SECONDS
                 or isinstance(self.max_model_calls, bool)
                 or not isinstance(self.max_model_calls, int)
                 or not 1 <= self.max_model_calls <= 4

--- a/core/system_prompt_injection.py
+++ b/core/system_prompt_injection.py
@@ -435,6 +435,7 @@ Avibe Memory is enabled for this conversation. Read Memory through the scoped CL
 
 - `vibe memory search "<query>" --json` searches this user's default Memory project.
 - `vibe memory search "<query>" --project <slug> --json` searches one named project. Slugs are lowercase `^[a-z][a-z0-9_-]{0,62}$` and cannot be `all`, `personal`, mixed case, empty, or start with `p-` / `u-`. Never use `--project all`.
+- Agentic mode is for complex, multi-hop recall only: `vibe memory search "<query>" --mode agentic --json`.
 - `vibe memory profile --json` reads the current distilled profile.
 - `vibe memory status --json` is for diagnosing Memory availability and processing state.
 - `vibe memory remember "<text>" --json` queues one durable fact in `default`.

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -128,9 +128,20 @@ Read scoped local Memory or queue durable context to remember — facts the user
 ```bash
 vibe memory status [--json]
 vibe memory profile [--json]
-vibe memory search <query> [--project <slug>] [--limit 1..20] [--json]
+vibe memory search <query> [--project <slug>] [--mode {hybrid|keyword|vector|agentic}] [--limit 1..20] [--json]
 vibe memory remember <text> [--project <slug>] [--json]
 ```
+
+Search defaults to `--mode hybrid` with `--limit 8`. Use `keyword` for exact
+terms, `vector` for semantic matches, and reserve `agentic` for complex,
+multi-hop recall. Agentic searches are bounded to 30 seconds and require the
+configured LLM, embedding, and rerank capabilities. They fail closed when any
+required capability is unavailable, and `--project all --mode agentic` is not
+supported.
+
+EverOS returns an empty `atomic_facts` list for agentic episode results. When
+EverOS receives unlimited `top_k`, agent case and skill results are capped at
+10; the Avibe CLI always sends its explicit bounded `--limit` value.
 
 ### `vibe doctor`
 

--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -209,7 +209,11 @@ keyword. Explicit vector or hybrid requests fail closed when that capability is
 missing. A request performs at most one provider search and never retries in a
 different mode.
 
-EverOS 1.2.3 does not enforce model-call and token ceilings, so agentic recall is
-currently reported as unavailable even when its required budgets are supplied.
+Agentic recall is available only through the CLI when health explicitly reports
+embedding, LLM, and rerank capabilities and does not disable `agentic_search`.
+It uses one request with a sidecar-owned wall-clock deadline of at most 30
+seconds; unavailable capabilities fail closed. EverOS 1.2.3 does not enforce
+model-call and token ceilings, so those policy fields remain a declarative
+envelope rather than an independently enforced provider budget.
 Current-session overlay can only use the trusted caller session supplied by the
 runtime; callers cannot provide arbitrary provider filters or session IDs.

--- a/tests/scenarios/memory_search/catalog.yaml
+++ b/tests/scenarios/memory_search/catalog.yaml
@@ -6,6 +6,7 @@ capability:
     - tests/test_memory_admission.py
     - tests/test_memory_store.py
     - tests/test_internal_server.py
+    - tests/test_memory_cli.py
 status_legend:
   covered: executable evidence exists
   partial: contract coverage exists
@@ -46,3 +47,9 @@ scenarios:
     kind: lifecycle
     layer: contract
     test: tests/test_memory_store.py::test_session_scope_recovery_survives_store_reopen_and_separates_sessions
+  - id: MEMORY-SEARCH-007
+    name: Agentic CLI recall is explicit, bounded, and parser-backed
+    status: covered
+    kind: happy_path
+    layer: contract
+    test: tests/test_memory_cli.py::test_injected_agentic_memory_example_is_accepted_by_the_live_parser

--- a/tests/scenarios/memory_search/catalog.yaml
+++ b/tests/scenarios/memory_search/catalog.yaml
@@ -48,8 +48,8 @@ scenarios:
     layer: contract
     test: tests/test_memory_store.py::test_session_scope_recovery_survives_store_reopen_and_separates_sessions
   - id: MEMORY-SEARCH-007
-    name: Agentic CLI recall is explicit, bounded, and parser-backed
+    name: Agentic CLI recall builds the bounded internal policy envelope
     status: covered
     kind: happy_path
     layer: contract
-    test: tests/test_memory_cli.py::test_injected_agentic_memory_example_is_accepted_by_the_live_parser
+    test: tests/test_memory_cli.py::test_agentic_cli_builds_bounded_internal_recall_policy

--- a/tests/test_internal_client.py
+++ b/tests/test_internal_client.py
@@ -526,6 +526,12 @@ def test_memory_sync_read_helpers_use_verified_uds(socket_path):
             "status": "ok",
             "items": [],
         }
+        assert internal_client.memory_search_sync(
+            "connect the clues",
+            6,
+            mode="agentic",
+            socket_path=socket_path,
+        )["body"] == {"status": "ok", "items": []}
 
     assert captured == [
         ("/internal/memory/status", None),
@@ -539,6 +545,21 @@ def test_memory_sync_read_helpers_use_verified_uds(socket_path):
                     "max_results": 4,
                     "include_profile": True,
                     "include_current_session": False,
+                },
+            },
+        ),
+        (
+            "/internal/memory/search",
+            {
+                "query": "connect the clues",
+                "policy": {
+                    "mode": "agentic",
+                    "max_results": 6,
+                    "include_profile": True,
+                    "include_current_session": False,
+                    "timeout_seconds": 30.0,
+                    "max_model_calls": 2,
+                    "cost_budget_tokens": 32_000,
                 },
             },
         ),

--- a/tests/test_internal_client_timeouts.py
+++ b/tests/test_internal_client_timeouts.py
@@ -15,6 +15,7 @@ from pathlib import Path
 
 from core.memory.confined_filesystem import PRIVATE_SQLITE_BUSY_TIMEOUT_SECONDS
 from core.memory.module import PROVIDER_READ_TIMEOUT_SECONDS
+from core.memory.types import MAX_AGENTIC_TIMEOUT_SECONDS
 from core.memory.processing_record import (
     PROCESSING_RECORD_TRANSPORT_MARGIN_SECONDS,
     PROCESSING_RECORD_TRANSPORT_TIMEOUT_SECONDS,
@@ -125,7 +126,10 @@ def test_processing_record_client_covers_identity_journals_and_parallel_sources(
 
 
 def test_search_clients_outlast_capability_probe_and_provider_search() -> None:
-    assert MEMORY_SEARCH_TIMEOUT_SECONDS > 2 * PROVIDER_READ_TIMEOUT_SECONDS
+    assert (
+        MEMORY_SEARCH_TIMEOUT_SECONDS
+        > PROVIDER_READ_TIMEOUT_SECONDS + MAX_AGENTIC_TIMEOUT_SECONDS + 1.0
+    )
     for search in (memory_search, memory_search_sync):
         assert (
             inspect.signature(search).parameters["timeout"].default

--- a/tests/test_internal_server.py
+++ b/tests/test_internal_server.py
@@ -662,6 +662,68 @@ def test_memory_recovery_reads_resolve_only_signed_ui_operators() -> None:
     ]
 
 
+def test_memory_search_accepts_bounded_agentic_policy_from_cli_session() -> None:
+    from core.memory.http_headers import CALLER_SESSION_HEADER
+
+    captured: list[tuple] = []
+
+    class Runtime:
+        async def search_payload(
+            self,
+            query,
+            policy,
+            principal_id,
+            project_id,
+            *,
+            current_session_id=None,
+        ):
+            captured.append(
+                (query, policy, principal_id, project_id, current_session_id)
+            )
+            return {"status": "ok", "items": []}
+
+    controller = _build_controller_double()
+    controller.memory_scope_for_cli_session.return_value = (
+        "u-11111111111111111111111111111111",
+        "default",
+    )
+    controller.memory_runtime = Runtime()
+    app = internal_server.create_app(controller)
+
+    async def _exercise() -> httpx.Response:
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+            return await client.post(
+                "/internal/memory/search",
+                headers={CALLER_SESSION_HEADER: "ses-memory"},
+                json={
+                    "query": "connect the clues",
+                    "policy": {
+                        "mode": "agentic",
+                        "max_results": 8,
+                        "include_profile": True,
+                        "include_current_session": False,
+                        "timeout_seconds": 30,
+                        "max_model_calls": 2,
+                        "cost_budget_tokens": 32_000,
+                    },
+                },
+            )
+
+    response = asyncio.run(_exercise())
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok", "items": []}
+    assert len(captured) == 1
+    query, policy, principal_id, project_id, current_session_id = captured[0]
+    assert query == "connect the clues"
+    assert policy.mode == "agentic"
+    assert policy.timeout_seconds == 30
+    assert principal_id == "u-11111111111111111111111111111111"
+    assert project_id == "default"
+    assert current_session_id == "ses-memory"
+
+
 def test_memory_rebuild_requires_signed_ui_operator() -> None:
     from core.memory.http_headers import MEMORY_USER_KEY_HEADER
     from core.memory.ui_access import MEMORY_UI_PROOF_HEADER

--- a/tests/test_memory_cli.py
+++ b/tests/test_memory_cli.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 import json
+import shlex
 from pathlib import Path
 
 import pytest
 
 from core.caller_context import AVIBE_SESSION_ID_ENV
+from core.system_prompt_injection import _MEMORY_CLI_PROMPT
 from vibe import cli, internal_client
 
 
@@ -22,7 +24,12 @@ _MEMORY_HELP_BY_LANGUAGE = {
         ),
         "status": ("Print machine-readable output",),
         "profile": ("Print machine-readable output",),
-        "search": ("Search query", "Maximum results (1-20)", "Print machine-readable output"),
+        "search": (
+            "Search query",
+            "Maximum results (1-20)",
+            "Recall mode (default: hybrid)",
+            "Print machine-readable output",
+        ),
         "remember": ("Text to remember (maximum 4,000 characters)", "Print machine-readable output"),
     },
     "zh": {
@@ -30,7 +37,7 @@ _MEMORY_HELP_BY_LANGUAGE = {
         "memory": ("显示记忆状态", "显示记忆档案", "搜索本地记忆", "将长期个人信息加入队列"),
         "status": ("输出机器可读格式",),
         "profile": ("输出机器可读格式",),
-        "search": ("搜索内容", "最大结果数（1-20）", "输出机器可读格式"),
+        "search": ("搜索内容", "最大结果数（1-20）", "召回模式（默认：hybrid）", "输出机器可读格式"),
         "remember": ("要记住的文本（最多 4,000 个字符）", "输出机器可读格式"),
     },
 }
@@ -76,22 +83,36 @@ def test_memory_help_copy_is_not_hardcoded_in_cli_module() -> None:
 
 def test_memory_search_json_is_a_presentation_of_the_uds_response(monkeypatch, capsys) -> None:
     args = cli.build_parser().parse_args(["memory", "search", "find this", "--limit", "3", "--json"])
-    calls: list[tuple[str, int]] = []
+    calls: list[tuple[str, int, str]] = []
 
-    def search(query: str, limit: int, **_kwargs):
-        calls.append((query, limit))
+    def search(query: str, limit: int, **kwargs):
+        calls.append((query, limit, kwargs["mode"]))
         return {"status_code": 200, "body": {"status": "ok", "items": [{"kind": "fact", "text": "result"}]}}
 
     monkeypatch.setattr(internal_client, "memory_search_sync", search)
 
     assert cli.cmd_memory(args) == 0
-    assert calls == [("find this", 3)]
+    assert calls == [("find this", 3, "hybrid")]
     assert json.loads(capsys.readouterr().out) == {
         "schema_version": 1,
         "ok": True,
         "kind": "memory_search",
         "result": {"status": "ok", "items": [{"kind": "fact", "text": "result"}]},
     }
+
+
+def test_injected_agentic_memory_example_is_accepted_by_the_live_parser() -> None:
+    """Scenario: MEMORY-SEARCH-007."""
+
+    example = 'vibe memory search "<query>" --mode agentic --json'
+    assert f"`{example}`" in _MEMORY_CLI_PROMPT
+
+    args = cli.build_parser().parse_args(shlex.split(example)[1:])
+
+    assert args.memory_command == "search"
+    assert args.query == "<query>"
+    assert args.mode == "agentic"
+    assert args.limit == 8
 
 
 def test_memory_status_json_returns_a_closed_service_down_code(monkeypatch, capsys) -> None:

--- a/tests/test_memory_cli.py
+++ b/tests/test_memory_cli.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import pytest
 
 from core.caller_context import AVIBE_SESSION_ID_ENV
+from core.memory.types import MAX_AGENTIC_TIMEOUT_SECONDS, RecallPolicy
 from core.system_prompt_injection import _MEMORY_CLI_PROMPT
 from vibe import cli, internal_client
 
@@ -102,8 +103,6 @@ def test_memory_search_json_is_a_presentation_of_the_uds_response(monkeypatch, c
 
 
 def test_injected_agentic_memory_example_is_accepted_by_the_live_parser() -> None:
-    """Scenario: MEMORY-SEARCH-007."""
-
     example = 'vibe memory search "<query>" --mode agentic --json'
     assert f"`{example}`" in _MEMORY_CLI_PROMPT
 
@@ -113,6 +112,45 @@ def test_injected_agentic_memory_example_is_accepted_by_the_live_parser() -> Non
     assert args.query == "<query>"
     assert args.mode == "agentic"
     assert args.limit == 8
+
+
+def test_agentic_cli_builds_bounded_internal_recall_policy(
+    monkeypatch,
+    capsys,
+) -> None:
+    """Scenario: MEMORY-SEARCH-007."""
+
+    calls: list[tuple[str, str, dict[str, object]]] = []
+
+    def request_sync(method, path, *, payload, **_kwargs):
+        calls.append((method, path, payload))
+        return {
+            "status_code": 200,
+            "body": {"status": "ok", "items": [], "warnings": []},
+        }
+
+    monkeypatch.setattr(internal_client, "_memory_request_sync", request_sync)
+    args = cli.build_parser().parse_args(
+        ["memory", "search", "connect the clues", "--mode", "agentic", "--json"]
+    )
+
+    assert cli.cmd_memory(args) == 0
+    assert len(calls) == 1
+    method, path, payload = calls[0]
+    assert method == "POST"
+    assert path == "/internal/memory/search"
+    assert payload["query"] == "connect the clues"
+    policy = RecallPolicy.from_payload(payload["policy"])
+    assert policy == RecallPolicy(
+        mode="agentic",
+        max_results=8,
+        include_profile=True,
+        include_current_session=False,
+        timeout_seconds=MAX_AGENTIC_TIMEOUT_SECONDS,
+        max_model_calls=2,
+        cost_budget_tokens=32_000,
+    )
+    assert json.loads(capsys.readouterr().out)["ok"] is True
 
 
 def test_memory_status_json_returns_a_closed_service_down_code(monkeypatch, capsys) -> None:

--- a/tests/test_memory_everos.py
+++ b/tests/test_memory_everos.py
@@ -13,6 +13,7 @@ from core.memory.everos import (
     _AGENTIC_TIMEOUT_HEADER,
     AddAck,
     AddRejected,
+    AgenticRecallTelemetry,
     EverOSPort,
     FlushRejected,
     FlushRetryable,
@@ -653,11 +654,10 @@ def test_search_uses_public_search_only_and_maps_episode_and_nested_fact() -> No
     assert items[1].text == "Uses Python for automation."
 
 
-def test_agentic_search_uses_bounded_public_request_and_scrub_safe_telemetry(
-    caplog: pytest.LogCaptureFixture,
-) -> None:
+def test_agentic_search_retains_allowlisted_round_metadata() -> None:
     requests: list[dict] = []
     sidecar_timeouts: list[float] = []
+    telemetry = AgenticRecallTelemetry()
 
     def handler(request: httpx.Request) -> httpx.Response:
         requests.append(json.loads(request.content))
@@ -680,9 +680,9 @@ def test_agentic_search_uses_bounded_public_request_and_scrub_safe_telemetry(
             2,
             method="agentic",
             timeout_seconds=5,
+            agentic_telemetry=telemetry,
         )
 
-    caplog.set_level("INFO", logger="core.memory.everos")
     with _sidecar_transport(handler):
         assert asyncio.run(run()) == ()
 
@@ -699,22 +699,12 @@ def test_agentic_search_uses_bounded_public_request_and_scrub_safe_telemetry(
         }
     ]
     assert sidecar_timeouts == [pytest.approx(4.95)]
-    telemetry = [
-        record.getMessage()
-        for record in caplog.records
-        if "telemetry" in record.getMessage()
-    ]
-    assert len(telemetry) == 1
-    assert "mode=agentic" in telemetry[0]
-    assert "round=round2" in telemetry[0]
-    assert "success=true" in telemetry[0]
-    assert "timeout=false" in telemetry[0]
-    assert "private multi-hop query" not in telemetry[0]
+    assert telemetry.round == "round2"
 
 
-def test_agentic_search_logs_mapping_failure_as_unsuccessful(
-    caplog: pytest.LogCaptureFixture,
-) -> None:
+def test_agentic_search_retains_round_on_mapping_failure() -> None:
+    telemetry = AgenticRecallTelemetry()
+
     def handler(_request: httpx.Request) -> httpx.Response:
         return httpx.Response(
             200,
@@ -731,31 +721,22 @@ def test_agentic_search_logs_mapping_failure_as_unsuccessful(
                 2,
                 method="agentic",
                 timeout_seconds=5,
+                agentic_telemetry=telemetry,
             )
         return raised.value
 
-    caplog.set_level("INFO", logger="core.memory.everos")
     with _sidecar_transport(handler):
         failure = asyncio.run(run())
 
     assert failure.error == "memory_provider_response_invalid"
-    telemetry = [
-        record.getMessage()
-        for record in caplog.records
-        if "telemetry" in record.getMessage()
-    ]
-    assert len(telemetry) == 1
-    assert "round=round1" in telemetry[0]
-    assert "success=false" in telemetry[0]
-    assert "timeout=false" in telemetry[0]
-    assert "private multi-hop query" not in telemetry[0]
+    assert telemetry.round == "round1"
 
 
-def test_agentic_search_wall_clock_timeout_is_typed_and_logged(
+def test_agentic_search_wall_clock_timeout_is_typed(
     monkeypatch: pytest.MonkeyPatch,
-    caplog: pytest.LogCaptureFixture,
 ) -> None:
     provider = EverOSPort(Path("/tmp/everos.sock"))
+    telemetry = AgenticRecallTelemetry()
 
     async def slow_request(*_args, **_kwargs):
         await asyncio.sleep(1)
@@ -772,23 +753,14 @@ def test_agentic_search_wall_clock_timeout_is_typed_and_logged(
                 2,
                 method="agentic",
                 timeout_seconds=0.01,
+                agentic_telemetry=telemetry,
             )
         return raised.value
 
-    caplog.set_level("INFO", logger="core.memory.everos")
     failure = asyncio.run(run())
 
     assert failure.error == "memory_provider_timeout"
-    telemetry = [
-        record.getMessage()
-        for record in caplog.records
-        if "telemetry" in record.getMessage()
-    ]
-    assert len(telemetry) == 1
-    assert "round=unknown" in telemetry[0]
-    assert "success=false" in telemetry[0]
-    assert "timeout=true" in telemetry[0]
-    assert "private multi-hop query" not in telemetry[0]
+    assert telemetry.round == "unknown"
 
 
 def test_agentic_search_maps_provider_422_to_closed_capability_error() -> None:
@@ -817,9 +789,9 @@ def test_agentic_search_maps_provider_422_to_closed_capability_error() -> None:
     assert "422" not in str(failure)
 
 
-def test_agentic_search_maps_sidecar_deadline_with_round_telemetry(
-    caplog: pytest.LogCaptureFixture,
-) -> None:
+def test_agentic_search_retains_round_on_sidecar_deadline() -> None:
+    telemetry = AgenticRecallTelemetry()
+
     def handler(request: httpx.Request) -> httpx.Response:
         assert float(request.headers[_AGENTIC_TIMEOUT_HEADER]) <= 5
         return httpx.Response(
@@ -837,23 +809,15 @@ def test_agentic_search_maps_sidecar_deadline_with_round_telemetry(
                 2,
                 method="agentic",
                 timeout_seconds=5,
+                agentic_telemetry=telemetry,
             )
         return raised.value
 
-    caplog.set_level("INFO", logger="core.memory.everos")
     with _sidecar_transport(handler):
         failure = asyncio.run(run())
 
     assert failure.error == "memory_provider_timeout"
-    telemetry = [
-        record.getMessage()
-        for record in caplog.records
-        if "telemetry" in record.getMessage()
-    ]
-    assert len(telemetry) == 1
-    assert "round=round2" in telemetry[0]
-    assert "success=false" in telemetry[0]
-    assert "timeout=true" in telemetry[0]
+    assert telemetry.round == "round2"
 
 
 def test_profile_uses_get_and_reports_empty_profile_as_non_failure() -> None:

--- a/tests/test_memory_everos.py
+++ b/tests/test_memory_everos.py
@@ -9,6 +9,7 @@ import httpx
 import pytest
 
 from core.memory.everos import (
+    _AGENTIC_TIMEOUT_HEADER,
     AddAck,
     AddRejected,
     EverOSPort,
@@ -655,9 +656,13 @@ def test_agentic_search_uses_bounded_public_request_and_scrub_safe_telemetry(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     requests: list[dict] = []
+    sidecar_timeouts: list[float] = []
 
     def handler(request: httpx.Request) -> httpx.Response:
         requests.append(json.loads(request.content))
+        sidecar_timeouts.append(
+            float(request.headers[_AGENTIC_TIMEOUT_HEADER])
+        )
         return httpx.Response(200, json={"data": {"episodes": []}})
 
     async def run():
@@ -688,6 +693,7 @@ def test_agentic_search_uses_bounded_public_request_and_scrub_safe_telemetry(
             "enable_llm_rerank": False,
         }
     ]
+    assert sidecar_timeouts == [pytest.approx(4.95)]
     telemetry = [
         record.getMessage()
         for record in caplog.records
@@ -696,6 +702,40 @@ def test_agentic_search_uses_bounded_public_request_and_scrub_safe_telemetry(
     assert len(telemetry) == 1
     assert "mode=agentic" in telemetry[0]
     assert "success=true" in telemetry[0]
+    assert "timeout=false" in telemetry[0]
+    assert "private multi-hop query" not in telemetry[0]
+
+
+def test_agentic_search_logs_mapping_failure_as_unsuccessful(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"data": {"episodes": "invalid"}})
+
+    async def run() -> MemoryProviderFailure:
+        with pytest.raises(MemoryProviderFailure) as raised:
+            await EverOSPort(Path("/tmp/everos.sock")).search(
+                PRINCIPAL,
+                PROJECT,
+                "private multi-hop query",
+                2,
+                method="agentic",
+                timeout_seconds=5,
+            )
+        return raised.value
+
+    caplog.set_level("INFO", logger="core.memory.everos")
+    with _sidecar_transport(handler):
+        failure = asyncio.run(run())
+
+    assert failure.error == "memory_provider_response_invalid"
+    telemetry = [
+        record.getMessage()
+        for record in caplog.records
+        if "telemetry" in record.getMessage()
+    ]
+    assert len(telemetry) == 1
+    assert "success=false" in telemetry[0]
     assert "timeout=false" in telemetry[0]
     assert "private multi-hop query" not in telemetry[0]
 
@@ -763,6 +803,32 @@ def test_agentic_search_maps_provider_422_to_closed_capability_error() -> None:
 
     assert failure.error == "memory_capability_unavailable"
     assert "422" not in str(failure)
+
+
+def test_agentic_search_maps_sidecar_deadline_to_typed_timeout() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert float(request.headers[_AGENTIC_TIMEOUT_HEADER]) <= 5
+        return httpx.Response(
+            504,
+            json={"detail": "memory_request_timed_out"},
+        )
+
+    async def run() -> MemoryProviderFailure:
+        with pytest.raises(MemoryProviderFailure) as raised:
+            await EverOSPort(Path("/tmp/everos.sock")).search(
+                PRINCIPAL,
+                PROJECT,
+                "connect the clues",
+                2,
+                method="agentic",
+                timeout_seconds=5,
+            )
+        return raised.value
+
+    with _sidecar_transport(handler):
+        failure = asyncio.run(run())
+
+    assert failure.error == "memory_provider_timeout"
 
 
 def test_profile_uses_get_and_reports_empty_profile_as_non_failure() -> None:

--- a/tests/test_memory_everos.py
+++ b/tests/test_memory_everos.py
@@ -9,6 +9,7 @@ import httpx
 import pytest
 
 from core.memory.everos import (
+    _AGENTIC_ROUND_HEADER,
     _AGENTIC_TIMEOUT_HEADER,
     AddAck,
     AddRejected,
@@ -663,7 +664,11 @@ def test_agentic_search_uses_bounded_public_request_and_scrub_safe_telemetry(
         sidecar_timeouts.append(
             float(request.headers[_AGENTIC_TIMEOUT_HEADER])
         )
-        return httpx.Response(200, json={"data": {"episodes": []}})
+        return httpx.Response(
+            200,
+            headers={_AGENTIC_ROUND_HEADER: "round2"},
+            json={"data": {"episodes": []}},
+        )
 
     async def run():
         provider = EverOSPort(Path("/tmp/everos.sock"))
@@ -701,6 +706,7 @@ def test_agentic_search_uses_bounded_public_request_and_scrub_safe_telemetry(
     ]
     assert len(telemetry) == 1
     assert "mode=agentic" in telemetry[0]
+    assert "round=round2" in telemetry[0]
     assert "success=true" in telemetry[0]
     assert "timeout=false" in telemetry[0]
     assert "private multi-hop query" not in telemetry[0]
@@ -710,7 +716,11 @@ def test_agentic_search_logs_mapping_failure_as_unsuccessful(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     def handler(_request: httpx.Request) -> httpx.Response:
-        return httpx.Response(200, json={"data": {"episodes": "invalid"}})
+        return httpx.Response(
+            200,
+            headers={_AGENTIC_ROUND_HEADER: "round1"},
+            json={"data": {"episodes": "invalid"}},
+        )
 
     async def run() -> MemoryProviderFailure:
         with pytest.raises(MemoryProviderFailure) as raised:
@@ -735,6 +745,7 @@ def test_agentic_search_logs_mapping_failure_as_unsuccessful(
         if "telemetry" in record.getMessage()
     ]
     assert len(telemetry) == 1
+    assert "round=round1" in telemetry[0]
     assert "success=false" in telemetry[0]
     assert "timeout=false" in telemetry[0]
     assert "private multi-hop query" not in telemetry[0]
@@ -774,6 +785,7 @@ def test_agentic_search_wall_clock_timeout_is_typed_and_logged(
         if "telemetry" in record.getMessage()
     ]
     assert len(telemetry) == 1
+    assert "round=unknown" in telemetry[0]
     assert "success=false" in telemetry[0]
     assert "timeout=true" in telemetry[0]
     assert "private multi-hop query" not in telemetry[0]

--- a/tests/test_memory_everos.py
+++ b/tests/test_memory_everos.py
@@ -817,11 +817,14 @@ def test_agentic_search_maps_provider_422_to_closed_capability_error() -> None:
     assert "422" not in str(failure)
 
 
-def test_agentic_search_maps_sidecar_deadline_to_typed_timeout() -> None:
+def test_agentic_search_maps_sidecar_deadline_with_round_telemetry(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     def handler(request: httpx.Request) -> httpx.Response:
         assert float(request.headers[_AGENTIC_TIMEOUT_HEADER]) <= 5
         return httpx.Response(
             504,
+            headers={_AGENTIC_ROUND_HEADER: "round2"},
             json={"detail": "memory_request_timed_out"},
         )
 
@@ -837,10 +840,20 @@ def test_agentic_search_maps_sidecar_deadline_to_typed_timeout() -> None:
             )
         return raised.value
 
+    caplog.set_level("INFO", logger="core.memory.everos")
     with _sidecar_transport(handler):
         failure = asyncio.run(run())
 
     assert failure.error == "memory_provider_timeout"
+    telemetry = [
+        record.getMessage()
+        for record in caplog.records
+        if "telemetry" in record.getMessage()
+    ]
+    assert len(telemetry) == 1
+    assert "round=round2" in telemetry[0]
+    assert "success=false" in telemetry[0]
+    assert "timeout=true" in telemetry[0]
 
 
 def test_profile_uses_get_and_reports_empty_profile_as_non_failure() -> None:

--- a/tests/test_memory_everos.py
+++ b/tests/test_memory_everos.py
@@ -651,29 +651,118 @@ def test_search_uses_public_search_only_and_maps_episode_and_nested_fact() -> No
     assert items[1].text == "Uses Python for automation."
 
 
-def test_agentic_search_fails_before_any_sidecar_request(monkeypatch) -> None:
+def test_agentic_search_uses_bounded_public_request_and_scrub_safe_telemetry(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    requests: list[dict] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(json.loads(request.content))
+        return httpx.Response(200, json={"data": {"episodes": []}})
+
+    async def run():
+        provider = EverOSPort(Path("/tmp/everos.sock"))
+        assert provider.agentic_budget_enforced is True
+        return await provider.search(
+            PRINCIPAL,
+            PROJECT,
+            "private multi-hop query",
+            2,
+            method="agentic",
+            timeout_seconds=5,
+        )
+
+    caplog.set_level("INFO", logger="core.memory.everos")
+    with _sidecar_transport(handler):
+        assert asyncio.run(run()) == ()
+
+    assert requests == [
+        {
+            "user_id": PRINCIPAL,
+            "app_id": "avibe",
+            "project_id": PROJECT,
+            "query": "private multi-hop query",
+            "method": "agentic",
+            "top_k": 2,
+            "include_profile": True,
+            "enable_llm_rerank": False,
+        }
+    ]
+    telemetry = [
+        record.getMessage()
+        for record in caplog.records
+        if "telemetry" in record.getMessage()
+    ]
+    assert len(telemetry) == 1
+    assert "mode=agentic" in telemetry[0]
+    assert "success=true" in telemetry[0]
+    assert "timeout=false" in telemetry[0]
+    assert "private multi-hop query" not in telemetry[0]
+
+
+def test_agentic_search_wall_clock_timeout_is_typed_and_logged(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     provider = EverOSPort(Path("/tmp/everos.sock"))
 
-    async def unexpected_request(*_args, **_kwargs):
-        pytest.fail("agentic search must fail before an HTTP request")
+    async def slow_request(*_args, **_kwargs):
+        await asyncio.sleep(1)
+        return {"data": {"episodes": []}}
 
-    monkeypatch.setattr(provider, "_sidecar_request", unexpected_request)
+    monkeypatch.setattr(provider, "_sidecar_request", slow_request)
 
     async def run() -> MemoryProviderFailure:
         with pytest.raises(MemoryProviderFailure) as raised:
             await provider.search(
                 PRINCIPAL,
                 PROJECT,
-                "language",
+                "private multi-hop query",
                 2,
                 method="agentic",
+                timeout_seconds=0.01,
             )
         return raised.value
 
+    caplog.set_level("INFO", logger="core.memory.everos")
     failure = asyncio.run(run())
 
+    assert failure.error == "memory_provider_timeout"
+    telemetry = [
+        record.getMessage()
+        for record in caplog.records
+        if "telemetry" in record.getMessage()
+    ]
+    assert len(telemetry) == 1
+    assert "success=false" in telemetry[0]
+    assert "timeout=true" in telemetry[0]
+    assert "private multi-hop query" not in telemetry[0]
+
+
+def test_agentic_search_maps_provider_422_to_closed_capability_error() -> None:
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            422,
+            json={"error": {"code": "PROVIDER_NOT_CONFIGURED"}},
+        )
+
+    async def run() -> MemoryProviderFailure:
+        with pytest.raises(MemoryProviderFailure) as raised:
+            await EverOSPort(Path("/tmp/everos.sock")).search(
+                PRINCIPAL,
+                PROJECT,
+                "connect the clues",
+                2,
+                method="agentic",
+                timeout_seconds=5,
+            )
+        return raised.value
+
+    with _sidecar_transport(handler):
+        failure = asyncio.run(run())
+
     assert failure.error == "memory_capability_unavailable"
-    assert failure.retryable is False
+    assert "422" not in str(failure)
 
 
 def test_profile_uses_get_and_reports_empty_profile_as_non_failure() -> None:

--- a/tests/test_memory_module.py
+++ b/tests/test_memory_module.py
@@ -658,8 +658,19 @@ async def test_auto_recall_selects_only_keyword_or_hybrid(
     assert provider.search_policies == [(effective_mode, True, None)]
 
 
-async def test_agentic_recall_fails_closed_without_provider_search(tmp_path: Path) -> None:
-    provider = FakeMemoryProvider()
+@pytest.mark.parametrize("missing_capability", ["embed", "llm", "rerank"])
+async def test_agentic_recall_fails_closed_when_a_capability_is_missing(
+    tmp_path: Path,
+    missing_capability: str,
+) -> None:
+    provider = FakeMemoryProvider(agentic_budget_enforced_flag=True)
+    provider.health_snapshot_value = replace(
+        provider.health_snapshot_value,
+        capabilities={
+            **provider.health_snapshot_value.capabilities,
+            missing_capability: False,
+        },
+    )
     module, _store, _provider = _module(tmp_path, provider=provider)
     policy = RecallPolicy(
         mode="agentic",
@@ -679,6 +690,66 @@ async def test_agentic_recall_fails_closed_without_provider_search(tmp_path: Pat
     assert result == OperationFailed(error="memory_capability_unavailable")
     assert provider.search_scopes == []
     assert provider.search_policies == []
+
+
+async def test_agentic_recall_fails_closed_when_health_disables_agentic_search(
+    tmp_path: Path,
+) -> None:
+    provider = FakeMemoryProvider(agentic_budget_enforced_flag=True)
+    provider.health_snapshot_value = replace(
+        provider.health_snapshot_value,
+        disabled_features=("agentic_search",),
+    )
+    module, _store, _provider = _module(tmp_path, provider=provider)
+    policy = RecallPolicy(
+        mode="agentic",
+        max_results=4,
+        timeout_seconds=5,
+        max_model_calls=2,
+        cost_budget_tokens=32_000,
+    )
+
+    result = await module.recall(
+        "query",
+        policy=policy,
+        principal_id=PRINCIPAL,
+        project_id=PROJECT,
+    )
+
+    assert result == OperationFailed(error="memory_capability_unavailable")
+    assert provider.search_scopes == []
+
+
+async def test_agentic_recall_reaches_provider_with_policy_timeout(
+    tmp_path: Path,
+) -> None:
+    provider = FakeMemoryProvider(
+        agentic_budget_enforced_flag=True,
+        search_items=(MemoryItem(kind="fact", text="agentic result"),),
+    )
+    module, _store, _provider = _module(tmp_path, provider=provider)
+    policy = RecallPolicy(
+        mode="agentic",
+        max_results=4,
+        timeout_seconds=5,
+        max_model_calls=2,
+        cost_budget_tokens=32_000,
+    )
+
+    result = await module.recall(
+        "query",
+        policy=policy,
+        principal_id=PRINCIPAL,
+        project_id=PROJECT,
+    )
+
+    assert result == RecallItems(
+        items=provider.search_items,
+        requested_mode="agentic",
+        effective_mode="agentic",
+    )
+    assert provider.search_policies == [("agentic", True, None)]
+    assert provider.search_timeouts == [5.0]
 
 
 async def test_current_session_overlay_uses_the_trusted_canonical_reference(tmp_path: Path) -> None:

--- a/tests/test_memory_module.py
+++ b/tests/test_memory_module.py
@@ -662,6 +662,7 @@ async def test_auto_recall_selects_only_keyword_or_hybrid(
 async def test_agentic_recall_fails_closed_when_a_capability_is_missing(
     tmp_path: Path,
     missing_capability: str,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     provider = FakeMemoryProvider(agentic_budget_enforced_flag=True)
     provider.health_snapshot_value = replace(
@@ -680,6 +681,7 @@ async def test_agentic_recall_fails_closed_when_a_capability_is_missing(
         cost_budget_tokens=1_000,
     )
 
+    caplog.set_level("INFO", logger="core.memory.module")
     result = await module.recall(
         "query",
         policy=policy,
@@ -690,6 +692,17 @@ async def test_agentic_recall_fails_closed_when_a_capability_is_missing(
     assert result == OperationFailed(error="memory_capability_unavailable")
     assert provider.search_scopes == []
     assert provider.search_policies == []
+    telemetry = [
+        record.getMessage()
+        for record in caplog.records
+        if "telemetry" in record.getMessage()
+    ]
+    assert len(telemetry) == 1
+    assert "mode=agentic" in telemetry[0]
+    assert "round=unknown" in telemetry[0]
+    assert "success=false" in telemetry[0]
+    assert "timeout=false" in telemetry[0]
+    assert "query" not in telemetry[0]
 
 
 async def test_agentic_recall_fails_closed_when_health_disables_agentic_search(
@@ -745,12 +758,56 @@ async def test_agentic_mode_resolution_bounds_the_capability_probe(
     assert provider.search_scopes == []
 
 
+async def test_agentic_recall_logs_capability_probe_timeout(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    provider = FakeMemoryProvider(agentic_budget_enforced_flag=True)
+    module, _store, _provider = _module(tmp_path, provider=provider)
+
+    async def slow_health_snapshot():
+        await asyncio.sleep(1)
+        return provider.health_snapshot_value
+
+    provider.health_snapshot = slow_health_snapshot  # type: ignore[method-assign]
+    policy = RecallPolicy(
+        mode="agentic",
+        max_results=4,
+        timeout_seconds=0.01,
+        max_model_calls=2,
+        cost_budget_tokens=32_000,
+    )
+
+    caplog.set_level("INFO", logger="core.memory.module")
+    result = await module.recall(
+        "private query",
+        policy=policy,
+        principal_id=PRINCIPAL,
+        project_id=PROJECT,
+    )
+
+    assert result == OperationFailed(error="memory_provider_timeout")
+    assert provider.search_scopes == []
+    telemetry = [
+        record.getMessage()
+        for record in caplog.records
+        if "telemetry" in record.getMessage()
+    ]
+    assert len(telemetry) == 1
+    assert "mode=agentic" in telemetry[0]
+    assert "success=false" in telemetry[0]
+    assert "timeout=true" in telemetry[0]
+    assert "private query" not in telemetry[0]
+
+
 async def test_agentic_recall_reaches_provider_with_policy_timeout(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     provider = FakeMemoryProvider(
         agentic_budget_enforced_flag=True,
+        agentic_round="round2",
         search_items=(MemoryItem(kind="fact", text="agentic result"),),
     )
     module, _store, _provider = _module(tmp_path, provider=provider)
@@ -761,7 +818,7 @@ async def test_agentic_recall_reaches_provider_with_policy_timeout(
         max_model_calls=2,
         cost_budget_tokens=32_000,
     )
-    monotonic_values = iter((100.0, 100.0, 100.0, 102.0))
+    monotonic_values = iter((100.0, 100.0, 100.0, 102.0, 102.0))
     monkeypatch.setattr(
         "core.memory.module.monotonic",
         lambda: next(monotonic_values),
@@ -773,17 +830,20 @@ async def test_agentic_recall_reaches_provider_with_policy_timeout(
         tracked_policy: RecallPolicy,
         *,
         timeout_seconds: float | None = None,
+        agentic_telemetry=None,
     ):
         resolve_timeouts.append(timeout_seconds)
         return await resolve_recall_mode(
             tracked_policy,
             timeout_seconds=timeout_seconds,
+            agentic_telemetry=agentic_telemetry,
         )
 
     monkeypatch.setattr(module, "resolve_recall_mode", tracked_resolve_recall_mode)
 
+    caplog.set_level("INFO", logger="core.memory.module")
     result = await module.recall(
-        "query",
+        "private query",
         policy=policy,
         principal_id=PRINCIPAL,
         project_id=PROJECT,
@@ -797,6 +857,18 @@ async def test_agentic_recall_reaches_provider_with_policy_timeout(
     assert provider.search_policies == [("agentic", True, None)]
     assert resolve_timeouts == [5.0]
     assert provider.search_timeouts == [3.0]
+    telemetry = [
+        record.getMessage()
+        for record in caplog.records
+        if "telemetry" in record.getMessage()
+    ]
+    assert len(telemetry) == 1
+    assert "mode=agentic" in telemetry[0]
+    assert "round=round2" in telemetry[0]
+    assert "duration_ms=2000" in telemetry[0]
+    assert "success=true" in telemetry[0]
+    assert "timeout=false" in telemetry[0]
+    assert "private query" not in telemetry[0]
 
 
 async def test_current_session_overlay_uses_the_trusted_canonical_reference(tmp_path: Path) -> None:

--- a/tests/test_memory_module.py
+++ b/tests/test_memory_module.py
@@ -800,6 +800,45 @@ async def test_agentic_recall_logs_capability_probe_timeout(
     assert "private query" not in telemetry[0]
 
 
+async def test_agentic_recall_logs_typed_provider_health_timeout(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    provider = FakeMemoryProvider(
+        agentic_budget_enforced_flag=True,
+        health_failure=MemoryProviderFailure("memory_provider_timeout"),
+    )
+    module, _store, _provider = _module(tmp_path, provider=provider)
+    policy = RecallPolicy(
+        mode="agentic",
+        max_results=4,
+        timeout_seconds=30,
+        max_model_calls=2,
+        cost_budget_tokens=32_000,
+    )
+
+    caplog.set_level("INFO", logger="core.memory.module")
+    result = await module.recall(
+        "private query",
+        policy=policy,
+        principal_id=PRINCIPAL,
+        project_id=PROJECT,
+    )
+
+    assert result == OperationFailed(error="memory_capability_unavailable")
+    assert provider.search_scopes == []
+    telemetry = [
+        record.getMessage()
+        for record in caplog.records
+        if "telemetry" in record.getMessage()
+    ]
+    assert len(telemetry) == 1
+    assert "mode=agentic" in telemetry[0]
+    assert "success=false" in telemetry[0]
+    assert "timeout=true" in telemetry[0]
+    assert "private query" not in telemetry[0]
+
+
 async def test_agentic_recall_reaches_provider_with_policy_timeout(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_memory_module.py
+++ b/tests/test_memory_module.py
@@ -720,8 +720,34 @@ async def test_agentic_recall_fails_closed_when_health_disables_agentic_search(
     assert provider.search_scopes == []
 
 
+async def test_agentic_mode_resolution_bounds_the_capability_probe(
+    tmp_path: Path,
+) -> None:
+    provider = FakeMemoryProvider(agentic_budget_enforced_flag=True)
+    module, _store, _provider = _module(tmp_path, provider=provider)
+
+    async def slow_health_snapshot():
+        await asyncio.sleep(1)
+        return provider.health_snapshot_value
+
+    provider.health_snapshot = slow_health_snapshot  # type: ignore[method-assign]
+    policy = RecallPolicy(
+        mode="agentic",
+        max_results=4,
+        timeout_seconds=5,
+        max_model_calls=2,
+        cost_budget_tokens=32_000,
+    )
+
+    result = await module.resolve_recall_mode(policy, timeout_seconds=0.001)
+
+    assert result == OperationFailed(error="memory_capability_unavailable")
+    assert provider.search_scopes == []
+
+
 async def test_agentic_recall_reaches_provider_with_policy_timeout(
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     provider = FakeMemoryProvider(
         agentic_budget_enforced_flag=True,
@@ -735,6 +761,26 @@ async def test_agentic_recall_reaches_provider_with_policy_timeout(
         max_model_calls=2,
         cost_budget_tokens=32_000,
     )
+    monotonic_values = iter((100.0, 100.0, 100.0, 102.0))
+    monkeypatch.setattr(
+        "core.memory.module.monotonic",
+        lambda: next(monotonic_values),
+    )
+    resolve_timeouts: list[float | None] = []
+    resolve_recall_mode = module.resolve_recall_mode
+
+    async def tracked_resolve_recall_mode(
+        tracked_policy: RecallPolicy,
+        *,
+        timeout_seconds: float | None = None,
+    ):
+        resolve_timeouts.append(timeout_seconds)
+        return await resolve_recall_mode(
+            tracked_policy,
+            timeout_seconds=timeout_seconds,
+        )
+
+    monkeypatch.setattr(module, "resolve_recall_mode", tracked_resolve_recall_mode)
 
     result = await module.recall(
         "query",
@@ -749,7 +795,8 @@ async def test_agentic_recall_reaches_provider_with_policy_timeout(
         effective_mode="agentic",
     )
     assert provider.search_policies == [("agentic", True, None)]
-    assert provider.search_timeouts == [5.0]
+    assert resolve_timeouts == [5.0]
+    assert provider.search_timeouts == [3.0]
 
 
 async def test_current_session_overlay_uses_the_trusted_canonical_reference(tmp_path: Path) -> None:

--- a/tests/test_memory_runtime.py
+++ b/tests/test_memory_runtime.py
@@ -65,6 +65,8 @@ from core.memory.types import (
     MemoryItems,
     MemoryProfile,
     MemoryProfileExplicitInfo,
+    OperationFailed,
+    RecallPolicy,
     CaptureAttachment,
     CaptureRequest,
     ProviderSessionRef,
@@ -85,6 +87,25 @@ from config.v2_config import (
 
 PROJECT = "default"
 PRINCIPAL = "u-11111111111111111111111111111111"
+
+
+async def test_all_project_agentic_recall_is_rejected_before_project_access() -> None:
+    runtime = object.__new__(MemoryRuntime)
+    policy = RecallPolicy(
+        mode="agentic",
+        max_results=8,
+        timeout_seconds=30,
+        max_model_calls=2,
+        cost_budget_tokens=32_000,
+    )
+
+    result = await runtime._recall_all_projects(
+        "connect the clues",
+        policy=policy,
+        principal_id=PRINCIPAL,
+    )
+
+    assert result == OperationFailed(error="memory_invalid_input")
 
 
 def _maintenance(runtime: MemoryRuntime) -> MemoryMaintenance:

--- a/tests/test_memory_sidecar.py
+++ b/tests/test_memory_sidecar.py
@@ -189,9 +189,16 @@ def test_sidecar_prepares_recorder_before_import_and_wraps_existing_lifespan(
     ]
 
     class _Request:
-        def __init__(self, path: str, payload: dict[str, object]) -> None:
+        def __init__(
+            self,
+            path: str,
+            payload: dict[str, object],
+            *,
+            headers: dict[str, str] | None = None,
+        ) -> None:
             self.method = "POST"
             self.url = SimpleNamespace(path=path)
+            self.headers = headers or {}
             self._body = json.dumps(payload).encode()
 
         async def body(self) -> bytes:
@@ -218,8 +225,17 @@ def test_sidecar_prepares_recorder_before_import_and_wraps_existing_lifespan(
     }
 
     async def exercise_guard() -> None:
+        downstream_cancelled = asyncio.Event()
+
         async def call_next(request):
             return request.url.path
+
+        async def slow_agentic_call(_request):
+            try:
+                await asyncio.sleep(1)
+            except asyncio.CancelledError:
+                downstream_cancelled.set()
+                raise
 
         assert (
             await app.guard(
@@ -231,6 +247,16 @@ def test_sidecar_prepares_recorder_before_import_and_wraps_existing_lifespan(
             await app.guard(_Request("/api/v2/memory/get", get_payload), call_next)
             == "/api/v2/memory/get"
         )
+        timed_out = await app.guard(
+            _Request(
+                "/api/v2/memory/search",
+                {**search_payload, "method": "agentic"},
+                headers={sidecar._AGENTIC_TIMEOUT_HEADER: "0.001"},
+            ),
+            slow_agentic_call,
+        )
+        assert timed_out.status_code == 504
+        assert downstream_cancelled.is_set()
 
     asyncio.run(exercise_guard())
     assert "boundary-enter" not in events
@@ -369,14 +395,24 @@ def test_sidecar_guard_accepts_agentic_but_rejects_untrusted_search_scope() -> N
         "enable_llm_rerank": False,
     }
 
+    agentic_body = json.dumps({**search, "method": "agentic"}).encode()
+    assert _request_rejection("POST", "/api/v2/memory/search", agentic_body) is None
     assert (
-        _request_rejection(
-            "POST",
+        sidecar._agentic_request_timeout(
             "/api/v2/memory/search",
-            json.dumps({**search, "method": "agentic"}).encode(),
+            agentic_body,
+            {sidecar._AGENTIC_TIMEOUT_HEADER: "30"},
         )
-        is None
+        == 30.0
     )
+    assert sidecar._agentic_request_timeout(
+        "/api/v2/memory/search", agentic_body, {}
+    ) is False
+    assert sidecar._agentic_request_timeout(
+        "/api/v2/memory/search",
+        agentic_body,
+        {sidecar._AGENTIC_TIMEOUT_HEADER: "30.1"},
+    ) is False
 
     for invalid in (
         {**search, "filters": {"session_id": "raw-session"}},

--- a/tests/test_memory_sidecar.py
+++ b/tests/test_memory_sidecar.py
@@ -42,6 +42,9 @@ def test_sidecar_server_bounds_graceful_shutdown(monkeypatch, tmp_path: Path) ->
     import uvicorn
 
     captured: dict[str, object] = {}
+    round_logger = logging.getLogger("everos.memory.search.agentic")
+    original_round_logger_level = round_logger.level
+    round_logger.setLevel(logging.ERROR)
 
     class _App:
         def middleware(self, _kind: str):
@@ -62,6 +65,7 @@ def test_sidecar_server_bounds_graceful_shutdown(monkeypatch, tmp_path: Path) ->
             return None
 
         def run(self) -> None:
+            captured["round_logger_level"] = round_logger.level
             return None
 
     monkeypatch.setattr(sidecar, "version", lambda _package: "1.2.3")
@@ -72,9 +76,14 @@ def test_sidecar_server_bounds_graceful_shutdown(monkeypatch, tmp_path: Path) ->
     monkeypatch.setattr(uvicorn, "Server", _Server)
     monkeypatch.setenv("AVIBE_MEMORY_ATTACHMENTS_ROOT", str(tmp_path / "attachments"))
 
-    sidecar.serve(tmp_path / "everos.sock")
+    try:
+        sidecar.serve(tmp_path / "everos.sock")
+    finally:
+        round_logger.setLevel(original_round_logger_level)
 
     assert captured["timeout_graceful_shutdown"] == 1
+    assert captured["round_logger_level"] == logging.INFO
+    assert round_logger.level == original_round_logger_level
     assert isinstance(captured["app"], sidecar._RecorderHealthProjection)
     assert isinstance(captured["app"]._app, sidecar._AgenticDeadlineProjection)
 
@@ -141,6 +150,8 @@ def test_agentic_deadline_projection_returns_allowlisted_round_header() -> None:
     ]
     round_logger = logging.getLogger("everos.memory.search.agentic")
     round_handler = sidecar._AgenticRoundHandler()
+    original_round_logger_level = round_logger.level
+    round_logger.setLevel(logging.INFO)
     round_logger.addHandler(round_handler)
 
     async def receive():
@@ -153,20 +164,12 @@ def test_agentic_deadline_projection_returns_allowlisted_round_header() -> None:
 
     async def downstream(_scope, downstream_receive, send):
         assert (await downstream_receive())["body"] == _agentic_search_body()
-        round_logger.handle(
-            logging.LogRecord(
-                name="everos.memory.search.agentic",
-                level=logging.INFO,
-                pathname=__file__,
-                lineno=1,
-                msg={
-                    "event": "agentic_search_decision",
-                    "round": "round2",
-                    "query": "private query must not be projected",
-                },
-                args=(),
-                exc_info=None,
-            )
+        round_logger.info(
+            {
+                "event": "agentic_search_decision",
+                "round": "round2",
+                "query": "private query must not be projected",
+            }
         )
         await send(
             {
@@ -196,6 +199,7 @@ def test_agentic_deadline_projection_returns_allowlisted_round_header() -> None:
         )
     finally:
         round_logger.removeHandler(round_handler)
+        round_logger.setLevel(original_round_logger_level)
 
     headers = dict(sent[0]["headers"])
     assert headers[sidecar._AGENTIC_ROUND_HEADER.lower().encode()] == b"round2"

--- a/tests/test_memory_sidecar.py
+++ b/tests/test_memory_sidecar.py
@@ -357,7 +357,7 @@ def test_sidecar_guard_allows_derived_principals_and_memory_scope() -> None:
     assert _request_rejection("POST", "/unrelated", b"{}") == "route"
 
 
-def test_sidecar_guard_rejects_untrusted_search_scope_and_unbudgeted_agentic() -> None:
+def test_sidecar_guard_accepts_agentic_but_rejects_untrusted_search_scope() -> None:
     search = {
         "user_id": "u-11111111111111111111111111111111",
         "app_id": "avibe",
@@ -369,10 +369,19 @@ def test_sidecar_guard_rejects_untrusted_search_scope_and_unbudgeted_agentic() -
         "enable_llm_rerank": False,
     }
 
+    assert (
+        _request_rejection(
+            "POST",
+            "/api/v2/memory/search",
+            json.dumps({**search, "method": "agentic"}).encode(),
+        )
+        is None
+    )
+
     for invalid in (
-        {**search, "method": "agentic"},
         {**search, "filters": {"session_id": "raw-session"}},
         {**search, "filters": {"project_id": PROJECT}},
+        {**search, "enable_llm_rerank": True},
     ):
         assert (
             _request_rejection(

--- a/tests/test_memory_sidecar.py
+++ b/tests/test_memory_sidecar.py
@@ -79,7 +79,7 @@ def test_sidecar_server_bounds_graceful_shutdown(monkeypatch, tmp_path: Path) ->
     assert isinstance(captured["app"]._app, sidecar._AgenticDeadlineProjection)
 
 
-def test_agentic_deadline_projection_cancels_owned_downstream_asgi_task() -> None:
+def test_agentic_deadline_projection_cancels_downstream_and_preserves_round() -> None:
     downstream_cancelled = asyncio.Event()
     sent: list[dict] = []
     request_messages = [
@@ -100,6 +100,9 @@ def test_agentic_deadline_projection_cancels_owned_downstream_asgi_task() -> Non
 
     async def downstream(_scope, downstream_receive, _send):
         assert (await downstream_receive())["body"] == _agentic_search_body()
+        round_state = sidecar._AGENTIC_ROUND_STATE.get()
+        assert round_state is not None
+        round_state["round"] = "round2"
         try:
             await asyncio.sleep(1)
         except asyncio.CancelledError:
@@ -122,6 +125,8 @@ def test_agentic_deadline_projection_cancels_owned_downstream_asgi_task() -> Non
     assert downstream_cancelled.is_set()
     assert sent[0]["type"] == "http.response.start"
     assert sent[0]["status"] == 504
+    headers = dict(sent[0]["headers"])
+    assert headers[sidecar._AGENTIC_ROUND_HEADER.lower().encode()] == b"round2"
     assert json.loads(sent[1]["body"]) == {"detail": "memory_request_timed_out"}
 
 

--- a/tests/test_memory_sidecar.py
+++ b/tests/test_memory_sidecar.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 from contextlib import asynccontextmanager, contextmanager
 from pathlib import Path
 from types import SimpleNamespace
@@ -22,6 +23,21 @@ LEGACY_PROJECT = "p-22222222222222222222222222222222"
 SESSION_ID = f"src--{'1' * 64}--e1"
 
 
+def _agentic_search_body() -> bytes:
+    return json.dumps(
+        {
+            "user_id": "u-11111111111111111111111111111111",
+            "app_id": "avibe",
+            "project_id": PROJECT,
+            "query": "connect the clues",
+            "method": "agentic",
+            "top_k": 8,
+            "include_profile": True,
+            "enable_llm_rerank": False,
+        }
+    ).encode()
+
+
 def test_sidecar_server_bounds_graceful_shutdown(monkeypatch, tmp_path: Path) -> None:
     import uvicorn
 
@@ -37,7 +53,8 @@ def test_sidecar_server_bounds_graceful_shutdown(monkeypatch, tmp_path: Path) ->
             return _App()
 
     class _Config:
-        def __init__(self, _app, **kwargs):
+        def __init__(self, configured_app, **kwargs):
+            captured["app"] = configured_app
             captured.update(kwargs)
 
     class _Server:
@@ -58,6 +75,126 @@ def test_sidecar_server_bounds_graceful_shutdown(monkeypatch, tmp_path: Path) ->
     sidecar.serve(tmp_path / "everos.sock")
 
     assert captured["timeout_graceful_shutdown"] == 1
+    assert isinstance(captured["app"], sidecar._RecorderHealthProjection)
+    assert isinstance(captured["app"]._app, sidecar._AgenticDeadlineProjection)
+
+
+def test_agentic_deadline_projection_cancels_owned_downstream_asgi_task() -> None:
+    downstream_cancelled = asyncio.Event()
+    sent: list[dict] = []
+    request_messages = [
+        {
+            "type": "http.request",
+            "body": _agentic_search_body(),
+            "more_body": False,
+        }
+    ]
+
+    async def receive():
+        if request_messages:
+            return request_messages.pop(0)
+        return {"type": "http.disconnect"}
+
+    async def capture(message):
+        sent.append(message)
+
+    async def downstream(_scope, downstream_receive, _send):
+        assert (await downstream_receive())["body"] == _agentic_search_body()
+        try:
+            await asyncio.sleep(1)
+        except asyncio.CancelledError:
+            downstream_cancelled.set()
+            raise
+
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "path": "/api/v2/memory/search",
+        "headers": [
+            (sidecar._AGENTIC_TIMEOUT_HEADER.lower().encode(), b"0.001"),
+        ],
+    }
+
+    asyncio.run(
+        sidecar._AgenticDeadlineProjection(downstream)(scope, receive, capture)
+    )
+
+    assert downstream_cancelled.is_set()
+    assert sent[0]["type"] == "http.response.start"
+    assert sent[0]["status"] == 504
+    assert json.loads(sent[1]["body"]) == {"detail": "memory_request_timed_out"}
+
+
+def test_agentic_deadline_projection_returns_allowlisted_round_header() -> None:
+    sent: list[dict] = []
+    request_messages = [
+        {
+            "type": "http.request",
+            "body": _agentic_search_body(),
+            "more_body": False,
+        }
+    ]
+    round_logger = logging.getLogger("everos.memory.search.agentic")
+    round_handler = sidecar._AgenticRoundHandler()
+    round_logger.addHandler(round_handler)
+
+    async def receive():
+        if request_messages:
+            return request_messages.pop(0)
+        return {"type": "http.disconnect"}
+
+    async def capture(message):
+        sent.append(message)
+
+    async def downstream(_scope, downstream_receive, send):
+        assert (await downstream_receive())["body"] == _agentic_search_body()
+        round_logger.handle(
+            logging.LogRecord(
+                name="everos.memory.search.agentic",
+                level=logging.INFO,
+                pathname=__file__,
+                lineno=1,
+                msg={
+                    "event": "agentic_search_decision",
+                    "round": "round2",
+                    "query": "private query must not be projected",
+                },
+                args=(),
+                exc_info=None,
+            )
+        )
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 200,
+                "headers": [(b"content-type", b"application/json")],
+            }
+        )
+        await send({"type": "http.response.body", "body": b'{"data":{}}'})
+
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "path": "/api/v2/memory/search",
+        "headers": [
+            (sidecar._AGENTIC_TIMEOUT_HEADER.lower().encode(), b"1"),
+        ],
+    }
+
+    try:
+        asyncio.run(
+            sidecar._AgenticDeadlineProjection(downstream)(
+                scope,
+                receive,
+                capture,
+            )
+        )
+    finally:
+        round_logger.removeHandler(round_handler)
+
+    headers = dict(sent[0]["headers"])
+    assert headers[sidecar._AGENTIC_ROUND_HEADER.lower().encode()] == b"round2"
+    assert all(b"private query" not in value for value in headers.values())
 
 
 def test_sidecar_rejects_artifact_before_everos_can_persist_diagnostics(
@@ -189,16 +326,9 @@ def test_sidecar_prepares_recorder_before_import_and_wraps_existing_lifespan(
     ]
 
     class _Request:
-        def __init__(
-            self,
-            path: str,
-            payload: dict[str, object],
-            *,
-            headers: dict[str, str] | None = None,
-        ) -> None:
+        def __init__(self, path: str, payload: dict[str, object]) -> None:
             self.method = "POST"
             self.url = SimpleNamespace(path=path)
-            self.headers = headers or {}
             self._body = json.dumps(payload).encode()
 
         async def body(self) -> bytes:
@@ -225,17 +355,8 @@ def test_sidecar_prepares_recorder_before_import_and_wraps_existing_lifespan(
     }
 
     async def exercise_guard() -> None:
-        downstream_cancelled = asyncio.Event()
-
         async def call_next(request):
             return request.url.path
-
-        async def slow_agentic_call(_request):
-            try:
-                await asyncio.sleep(1)
-            except asyncio.CancelledError:
-                downstream_cancelled.set()
-                raise
 
         assert (
             await app.guard(
@@ -247,16 +368,6 @@ def test_sidecar_prepares_recorder_before_import_and_wraps_existing_lifespan(
             await app.guard(_Request("/api/v2/memory/get", get_payload), call_next)
             == "/api/v2/memory/get"
         )
-        timed_out = await app.guard(
-            _Request(
-                "/api/v2/memory/search",
-                {**search_payload, "method": "agentic"},
-                headers={sidecar._AGENTIC_TIMEOUT_HEADER: "0.001"},
-            ),
-            slow_agentic_call,
-        )
-        assert timed_out.status_code == 504
-        assert downstream_cancelled.is_set()
 
     asyncio.run(exercise_guard())
     assert "boundary-enter" not in events

--- a/tests/test_ui_memory_routes.py
+++ b/tests/test_ui_memory_routes.py
@@ -1093,6 +1093,47 @@ def test_memory_search_requires_csrf_and_only_forwards_query_policy_and_optional
     assert response.headers["cache-control"] == "no-store"
 
 
+def test_memory_search_rejects_agentic_policy_before_internal_transport(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    _save_config(tmp_path)
+
+    async def transport_must_not_run(*_args, **_kwargs):
+        raise AssertionError("agentic Web search reached internal transport")
+
+    monkeypatch.setattr(internal_client, "memory_search", transport_must_not_run)
+    client = app.test_client()
+    headers = csrf_headers(client, "http://127.0.0.1:15131")
+
+    response = client.post(
+        "/api/memory/search",
+        json={
+            "query": "connect the clues",
+            "policy": {
+                "mode": "agentic",
+                "max_results": 8,
+                "include_profile": True,
+                "include_current_session": False,
+                "timeout_seconds": 30,
+                "max_model_calls": 2,
+                "cost_budget_tokens": 32_000,
+            },
+        },
+        headers=headers,
+        base_url="http://127.0.0.1:15131",
+        environ_base={"REMOTE_ADDR": "127.0.0.1"},
+    )
+
+    assert response.status_code == 503
+    assert response.get_json() == {
+        "status": "failed",
+        "error": "memory_capability_unavailable",
+    }
+    assert response.headers["cache-control"] == "no-store"
+
+
 def test_memory_log_routes_forward_only_valid_query_and_are_no_store(monkeypatch, tmp_path) -> None:
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     _save_config(tmp_path)

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -557,6 +557,7 @@ def cmd_memory(args) -> int:
             response = internal_client.memory_search_sync(
                 query,
                 args.limit,
+                mode=args.mode,
                 project=getattr(args, "project", None),
                 **access,
             )
@@ -14250,6 +14251,12 @@ def build_parser():
         type=int,
         default=8,
         help=i18n_t("memory.cli.help.limit", memory_help_language),
+    )
+    memory_search_parser.add_argument(
+        "--mode",
+        choices=("hybrid", "keyword", "vector", "agentic"),
+        default="hybrid",
+        help=i18n_t("memory.cli.help.mode", memory_help_language),
     )
     memory_search_parser.add_argument(
         "--project",

--- a/vibe/i18n/en.json
+++ b/vibe/i18n/en.json
@@ -701,6 +701,7 @@
         "query": "Search query",
         "project": "Memory project: default or a named slug such as billing",
         "limit": "Maximum results (1-20)",
+        "mode": "Recall mode (default: hybrid)",
         "text": "Text to remember (maximum 4,000 characters)",
         "json": "Print machine-readable output"
       },

--- a/vibe/i18n/zh.json
+++ b/vibe/i18n/zh.json
@@ -701,6 +701,7 @@
         "query": "搜索内容",
         "project": "记忆项目：default，或 billing 这类小写 slug",
         "limit": "最大结果数（1-20）",
+        "mode": "召回模式（默认：hybrid）",
         "text": "要记住的文本（最多 4,000 个字符）",
         "json": "输出机器可读格式"
       },

--- a/vibe/internal_client.py
+++ b/vibe/internal_client.py
@@ -22,7 +22,7 @@ import logging
 import os
 import stat
 from pathlib import Path
-from typing import Any, AsyncIterator, Optional
+from typing import Any, AsyncIterator, Literal, Optional
 
 import httpx
 
@@ -30,6 +30,7 @@ from config import paths
 from core.memory.processing_record import (
     PROCESSING_RECORD_TRANSPORT_TIMEOUT_SECONDS,
 )
+from core.memory.types import MAX_AGENTIC_TIMEOUT_SECONDS
 
 logger = logging.getLogger(__name__)
 
@@ -47,10 +48,10 @@ _CHECK_POSIX_SOCKET_MODE = os.name != "nt"
 #
 # Most Memory reads wait on one provider operation bounded by
 # ``core.memory.module.PROVIDER_READ_TIMEOUT_SECONDS`` (20s). Search can first
-# probe capabilities and then issue the provider read, so it needs a separate
-# transport bound outside both sequential steps.
+# probe capabilities and then issue an agentic provider read bounded at 30s,
+# so it needs a separate transport bound outside both sequential steps.
 MEMORY_READ_TIMEOUT_SECONDS = 25.0
-MEMORY_SEARCH_TIMEOUT_SECONDS = 45.0
+MEMORY_SEARCH_TIMEOUT_SECONDS = 55.0
 MEMORY_STATUS_TIMEOUT_SECONDS = MEMORY_READ_TIMEOUT_SECONDS
 # Processing Record owns its complete identity/journal/provider/store work
 # budget; the transport imports that bound so the two processes cannot drift.
@@ -1010,19 +1011,29 @@ def memory_search_sync(
     query: str,
     limit: int,
     *,
+    mode: Literal["hybrid", "keyword", "vector", "agentic"] = "hybrid",
     caller_session_id: str | None = None,
     project: str | None = None,
     socket_path: Optional[Path] = None,
     timeout: float = MEMORY_SEARCH_TIMEOUT_SECONDS,
 ) -> dict[str, Any]:
+    policy: dict[str, object] = {
+        "mode": mode,
+        "max_results": limit,
+        "include_profile": True,
+        "include_current_session": False,
+    }
+    if mode == "agentic":
+        # RecallPolicy retains its complete legacy budget envelope. EverOSPort
+        # enforces the wall-clock field; EverOS 1.2.3 has no model/token gate.
+        policy.update(
+            timeout_seconds=MAX_AGENTIC_TIMEOUT_SECONDS,
+            max_model_calls=2,
+            cost_budget_tokens=32_000,
+        )
     payload: dict[str, object] = {
         "query": query,
-        "policy": {
-            "mode": "hybrid",
-            "max_results": limit,
-            "include_profile": True,
-            "include_current_session": False,
-        },
+        "policy": policy,
     }
     if project is not None:
         payload["project"] = project

--- a/vibe/ui_memory_routes.py
+++ b/vibe/ui_memory_routes.py
@@ -1125,6 +1125,14 @@ def register_memory_routes(app) -> None:
                 policy = RecallPolicy.from_payload(payload.get("policy"))
             except (TypeError, ValueError):
                 return _memory_response({"status": "failed", "error": "memory_invalid_input"}, status_code=400)
+            if policy.mode == "agentic":
+                return _memory_response(
+                    {
+                        "status": "failed",
+                        "error": "memory_capability_unavailable",
+                    },
+                    status_code=503,
+                )
             project = payload.get("project")
             if project is not None and not isinstance(project, str):
                 return _memory_response({"status": "failed", "error": "memory_invalid_input"}, status_code=400)


### PR DESCRIPTION
## Capability

Adds an opt-in CLI-only agentic memory recall mode with capability gating, a 30-second provider wall-clock bound, typed fail-closed errors, scrub-safe telemetry, and unchanged hybrid defaults. The Web UI remains hybrid-only.

This is PR2 of the approved plan in `docs/plans/memory-rerank-agentic-enablement.md` and builds on merged PR1 #1407.

## Evidence

- Unit: EverOS request/timeout/422/telemetry behavior, module capability gates, sidecar validation, and all-project rejection.
- Contract: CLI to internal client to internal server policy propagation; default hybrid body remains exact; injected prompt example is parser-backed.
- Scenario: `MEMORY-SEARCH-007` covers bounded agentic CLI recall.
- Manual: source-level call-path verification only; no local service restart or production-state access. UI build not required because no UI files changed.

## Behavioral contract

- Agentic mode requires healthy embed, LLM, and rerank capabilities and an enabled `agentic_search` feature.
- Agentic calls keep `enable_llm_rerank=false` and time out within 30 seconds.
- Agentic episodes return empty `atomic_facts`; unlimited `top_k` caps agent-kind results at 10.
- `--project all --mode agentic` remains rejected.

## Validation

- `uvx ruff check` on all changed Python files
- 495 focused memory/CLI/internal-server tests passed
- `git diff --check`