### PR TITLE
fix(ui): paint unlabeled accent marks with the ink token, and guard it

### DIFF
--- a/ui/scripts/validate-theme.mjs
+++ b/ui/scripts/validate-theme.mjs
@@ -876,7 +876,17 @@ function classStrings(file, source) {
 // pinned-state Pin shipped a 14px `fill-cyan` glyph that this scan could not see.
 // A 14px filled glyph is read like small text rather than like a large non-text shape,
 // which is the bar its ink clears and its fill does not.
-const MARK_UTILITIES = ['bg', 'fill', 'stroke'];
+// A gradient stop is a fill too, spelled in three parts. `from-mint via-mint to-mint`
+// paints the same shape `bg-mint` does, so leaving them out would have been a hole with
+// a Tailwind name -- 0 sites today, which is why they cost nothing to close now instead
+// of in the round that finds them.
+//
+// `border-`, `ring-`, `outline-` and `divide-` are deliberately NOT here. They paint a
+// hairline, not a shape, and whether a 1px accent border needs the ink is the same open
+// design.pen question as the ten pinned control-chrome sites -- 46 live sites, measured
+// and recorded in the PR ledger rather than quietly recoloured to satisfy this file. That
+// is a decision, not an omission; do not read the gap as one and "fix" it here.
+const MARK_UTILITIES = ['bg', 'fill', 'stroke', 'from', 'via', 'to'];
 
 // `text-mint` is not a fill that might carry a label. It IS the label -- and through
 // `currentColor`, so is every icon under it that names no colour of its own, which is
@@ -890,7 +900,24 @@ const MARK_UTILITIES = ['bg', 'fill', 'stroke'];
 // 214 cyan, 138 destructive, 115 gold, 58 violet, 28 pink, 12 accent, 1 primary). That
 // is exactly why the rule belongs here: the codemod is what made it true, and nothing
 // was stopping the next `text-mint` from undoing it one site at a time.
-const INK_UTILITIES = ['text'];
+// `placeholder-`, `decoration-` and `caret-` print ink for the same reason: a placeholder
+// is text, an underline is read as part of the glyphs it sits under, and a caret you
+// cannot find is a text field you cannot use. 0 sites today.
+//
+// The flag is which of them prints *glyphs*, because "is ink" and "can carry a label" are
+// two different questions and collapsing them opens the hole this file just closed on
+// `border-`: a `caret-primary-foreground` is a 1px bar, so licensing `bg-mint` with it
+// excuses the fill on the strength of something nobody reads a word off. Glyphs sit on
+// the fill and are read off it; a caret and an underline sit near text without being it.
+const INK_UTILITIES = new Map([
+  ['text', true],
+  ['placeholder', true],
+  ['decoration', false],
+  ['caret', false],
+]);
+const LABEL_UTILITIES = [...INK_UTILITIES]
+  .filter(([, printsGlyphs]) => printsGlyphs)
+  .map(([utility]) => utility);
 
 // `bg-mint/100` is not a wash. It is `bg-mint` spelled with a modifier -- same token,
 // same opacity, same 2.35:1 -- and a `/` in the lookahead let it leave the scan
@@ -907,7 +934,39 @@ const INK_UTILITIES = ['text'];
 // a translucent mark is invisible in both themes, which whoever writes it sees
 // immediately, while an opaque one looks right in dark and goes illegible only in
 // light -- unseen, which is the whole reason this guard exists.
-const FULLY_OPAQUE_MODIFIER = /^\/(?:100|\[1\]|\[1\.0+\]|\[100%\])$/;
+// So the line is drawn on the alpha, which means reading it as a number. Tailwind
+// spells the same alpha four ways -- `/70`, `/[0.7]`, `/[70%]`, and no modifier at all
+// -- and matching the spellings that mean 1 exempted `bg-mint/[99%]`, which is the same
+// pixel as `bg-mint`. An enumeration of opaque spellings can only ever be as complete as
+// whoever wrote it; a parsed number is complete by construction.
+//
+// Unparseable fails closed and counts as a mark: the alternative is exempting the one
+// spelling nobody predicted, which is the bug this replaces.
+const markAlpha = (modifier) => {
+  if (!modifier) {
+    return 1;
+  }
+  const raw = modifier.slice(1).replace(/^\[|\]$/g, '');
+  const percent = raw.endsWith('%');
+  const value = Number.parseFloat(percent ? raw.slice(0, -1) : raw);
+  if (!Number.isFinite(value) || value < 0) {
+    return 1;
+  }
+  return percent || value > 1 ? value / 100 : value;
+};
+
+// Where a tint stops being a tint. The exemption above says a wash is not a mark -- it
+// is a colour cast on the surface, and what gets read is whatever sits on top of it. At
+// alpha 0.9 that defence is gone: the composite differs from the opaque fill by a tenth
+// of the surface, so it is the same shape, read the same way, and `/[99%]` was using the
+// wash exemption to smuggle it through.
+//
+// 0.5-0.89 is a real grey zone, and the tree has 35 of them (`/50`, `/55`, `/60`, `/70`).
+// Where a half-opacity accent stops being decorative is a design.pen question, not a
+// guard question, so they stay out and go in the ledger rather than being recoloured to
+// satisfy this file. The threshold is the honest instrument: one stated number, with the
+// parsed alpha reported in the error, instead of a list that silently grows a hole.
+const OPAQUE_ENOUGH = 0.9;
 
 // The Tailwind state the utility containing `index` is gated behind: `hover:`,
 // `md:hover:`, or '' for none. Scoped to the one utility rather than the class string,
@@ -953,7 +1012,7 @@ function sourceFiles(root) {
 
 function assertUnlabeledFillsTakeTheInk(root) {
   const bare = new RegExp(
-    `\\b(${[...MARK_UTILITIES, ...INK_UTILITIES].join('|')})-(${[...FILL_LABEL.keys(), 'pink'].join('|')})(?![\\w-])(/[\\w.%[\\]]+)?`,
+    `\\b(${[...MARK_UTILITIES, ...INK_UTILITIES.keys()].join('|')})-(${[...FILL_LABEL.keys(), 'pink'].join('|')})(?![\\w-])(/[\\w.%[\\]]+)?`,
     'g',
   );
   const found = new Map();
@@ -965,34 +1024,47 @@ function assertUnlabeledFillsTakeTheInk(root) {
         const utility = match[1];
         const accent = match[2];
         const modifier = match[3];
-        if (modifier && !FULLY_OPAQUE_MODIFIER.test(modifier)) {
+        const alpha = markAlpha(modifier);
+        if (alpha < OPAQUE_ENOUGH) {
           continue;
         }
+        // Reported alongside the site: a `/[99%]` mark was written believing it was a
+        // wash, so the number this guard read is the one fact that explains the failure.
+        const note = alpha < 1 ? ` (alpha ${alpha}, at or above ${OPAQUE_ENOUGH} reads as the fill)` : '';
         // Ink takes no label and no pin, so it never reaches the pairing logic below.
-        if (INK_UTILITIES.includes(utility)) {
-          inkMarks.push({ file, line, utility, accent, signature: markSignature(owner, text) });
+        if (INK_UTILITIES.has(utility)) {
+          inkMarks.push({ file, line, utility, accent, note, signature: markSignature(owner, text) });
           continue;
         }
+        // A label only labels if it is printed as ink. The lookup was for the token
+        // suffix anywhere in the string, so `bg-mint border-primary-foreground` cleared
+        // the mark on the strength of a 1px border nobody reads a word off -- the token
+        // was present, the label was not. The utilities that print ink are already
+        // named, so the label has to be carried by one of them.
         const label = FILL_LABEL.get(accent);
-        const fillPrefix = variantPrefix(text, match.index);
-        if (label && (labelCovers(text, `-${label}`, fillPrefix)
-          || labelCovers(scope, `-${label}`, fillPrefix))) {
+        const labelled = label !== undefined && LABEL_UTILITIES.some((ink) => {
+          const printed = `${ink}-${label}`;
+          const fillPrefix = variantPrefix(text, match.index);
+          return labelCovers(text, printed, fillPrefix) || labelCovers(scope, printed, fillPrefix);
+        });
+        if (labelled) {
           continue;
         }
 
         const key = `${file} --${accent}`;
-        found.set(key, [...found.get(key) ?? [], { signature: markSignature(owner, text), line }]);
+        found.set(key, [...found.get(key) ?? [], { signature: markSignature(owner, text), line, note }]);
       }
     }
   }
 
   if (inkMarks.length > 0) {
     throw new Error(
-      'These paint text (and, through currentColor, the icons inside it) with a bare accent, which '
-      + 'is the ink side of the split by definition -- no label can sit on top of text, so there is '
-      + 'nothing to pair it with. Use the -ink token:\n'
-      + inkMarks.map(({ file, line, utility, accent, signature }) => (
-        `  ${file}:${line} ${utility}-${accent} -> ${utility}-${accent}-ink\n    ${signature}`
+      'These paint a glyph, a placeholder, an underline or the caret with a bare accent -- text, '
+      + 'plus through currentColor every icon inside it. That is the ink side of the split by '
+      + 'definition: nothing can sit on top of text, so there is nothing to pair it with. Use the '
+      + '-ink token:\n'
+      + inkMarks.map(({ file, line, utility, accent, note, signature }) => (
+        `  ${file}:${line} ${utility}-${accent} -> ${utility}-${accent}-ink${note}\n    ${signature}`
       )).join('\n'),
     );
   }
@@ -1003,8 +1075,10 @@ function assertUnlabeledFillsTakeTheInk(root) {
       'These paint a bare accent with no paired *-foreground label in the same class string or in an '
       + 'unconditional sibling attribute/property, so they are marks read straight off the canvas and must use the '
       + '-ink token (bg-mint-ink, fill-cyan-ink, stroke-gold-ink, ...):\n'
-      + unpinned.map(([key, marks]) => marks.map(({ signature, line }) => `  ${key} at line ${line}\n    ${signature}`).join('\n')).join('\n')
-      + '\nIf the label is real but lives on a child element, move it into the same class string. '
+      + unpinned.map(([key, marks]) => marks.map(({ signature, line, note }) => `  ${key} at line ${line}${note}\n    ${signature}`).join('\n')).join('\n')
+      + `\nA label counts only when one of ${LABEL_UTILITIES.join('-, ')}- prints it as glyphs: the token on a `
+      + 'border, a ring, an underline or a caret is a hairline nobody reads a word off. '
+      + 'If the label is real but lives on a child element, move it into the same class string. '
       + 'If it is real but gated behind a state the fill is not, the resting element is still unlabeled '
       + '-- give the label the same variant prefix or drop the prefix, and for a JS condition '
       + '(`active ? ... : ...`, `active && ...`) merge the label into the fill\'s own string. '

--- a/ui/scripts/validate-theme.mjs
+++ b/ui/scripts/validate-theme.mjs
@@ -456,17 +456,51 @@ assertAccentAliasesKeepTheirTokenName(css);
 // accent has a LABEL printed on it. A fill or hairline may stay vivid because it is
 // read through the paired --X-foreground sitting on it; anything read directly
 // against the canvas -- text, an icon, a wire, an end node, a status dot -- carries
-// no label and so must take --X-ink. The two assertions below cover the two places
-// that distinction gets lost: a CSS rule painting a wire, and a Tailwind utility
-// painting a dot.
+// no label and so must take --X-ink. The assertions below cover the places that
+// distinction gets lost: a CSS rule painting a wire, a Tailwind utility painting a
+// dot, and a TypeScript string smuggling the token past both.
 //
-// Both are needed because neither the ink nor the fill assertion above can see this.
+// They are needed because neither the ink nor the fill assertion above can see this.
 // They check that each token is legible against the surface it claims; they cannot
 // know that .model-hub-wire--gateway chose the fill. That is how the supply graph
 // shipped 2px --mint strokes at 2.35:1 on the light canvas with every token guard
 // passing. Light is where it bites: --mint reads 2.35:1 on --background and --gold
 // 2.95:1, both under the 3:1 non-text floor, while their inks clear it. In dark each
 // accent's ink IS its fill, so none of this moves a dark pixel.
+//
+// What these assertions do NOT claim. Each decides fail-closed on what it reads -- an
+// unprovable pairing fails, a wash needs a written pin, a bare accent in a TS string is
+// rejected outright -- but two of them read an enumeration: Tailwind utility names in
+// src/*.tsx, and stroke/fill declarations in the Model Hub stylesheet. An accent can
+// reach a pixel by other routes, and five review rounds walked through them one at a
+// time. Each route was measured rather than argued about:
+//
+// Closed here, because closing them was cheap and total. Bare `text-<accent>`
+// (INK_UTILITIES) at 0 sites -- the #1406 codemod had already moved all 806 onto -ink,
+// which is exactly why the rule belongs here rather than nowhere. And every
+// `var(--<accent>)` written into a TypeScript string (assertNoBareAccentVarInSource),
+// which had 24 live sites: 1.6px spawn edges in the agent graph, two file-extension icon
+// maps, and the editor and terminal active-tab underlines. Those 24 are why the rule is
+// a carrier class and not one more utility name -- they reached pixels through a style
+// object, an arbitrary value and a lookup table, and no utility name catches any of them.
+//
+// Zero live sites, so what stays open is a hypothesis rather than a defect: a JSX paint
+// attribute (`fill="var(--mint)"`), `<svg color=>` / `stopColor`, an SVG `<animate to>`,
+// a runtime `setProperty`, a `:root` alias in a third stylesheet (src/ has exactly two),
+// and a conditional label paired with an unconditional fill.
+//
+// Deliberately out of scope, with the numbers attached: the
+// border/ring/outline/shadow/accent utilities. 1000 bare-accent references across 164
+// files, 844 of them opacity washes. bg/fill/stroke are already guarded above, which
+// leaves 488 on those five utilities -- and only 46 of the 488 are opaque (38 border,
+// 3 ring, 2 outline, 3 accent). The 443 washes are decoration whose legibility nobody
+// reads, which is not the defect this guard exists for. The 46 opaque ones are a visible
+// design change, and recolouring a border is design.pen's call -- the same reason the ten
+// ACCEPTED_BARE_FILLS pins are still bare. Both sets are named in the PR's
+// known-by-design ledger.
+//
+// Chasing that last group here would trade a guard people trust for one they route
+// around. So the scope is a decision with evidence under it, not an oversight.
 
 const ACCENT_NAMES = ACCENT_FILLS.map((fill) => fill.slice(2));
 const BARE_ACCENT_VAR = new RegExp(`var\\(\\s*--(${ACCENT_NAMES.join('|')})\\s*\\)`);
@@ -504,7 +538,8 @@ const ACCEPTED_ACCENT_WASHES = new Map([
 // mint while naming neither. modelHubSurface.css already routes ~20 accents through
 // --model-hub-* aliases, so this is one refactor away rather than hypothetical.
 //
-// Every definition of a name counts, not the last one. This file defines 11 properties
+// Every definition of a name counts, not the last one, and every stylesheet that ships
+// alongside is a place one can live -- hence the variadic sources. This file defines 11 properties
 // twice, once per theme -- `--model-hub-wash-channel` is `8 8 18` in dark and
 // `255 255 255` in light -- so a name-to-value map is not a simplification of this
 // file, it is a misreading of it. A last-write-wins resolver would read a light
@@ -523,15 +558,17 @@ const ACCEPTED_ACCENT_WASHES = new Map([
 // its input would spin. Cutting the cycle can under-report a cyclic definition, which
 // is correct rather than a hole -- a var() cycle is invalid at computed-value time, so
 // the browser paints nothing there either.
-function accentAliasIndex(source) {
+function accentAliasIndex(...sources) {
   const definitions = new Map();
-  postcss.parse(source).walkDecls((decl) => {
-    if (decl.prop.startsWith('--')) {
-      const values = definitions.get(decl.prop) ?? new Set();
-      values.add(normalizeCssValue(decl.value));
-      definitions.set(decl.prop, values);
-    }
-  });
+  for (const source of sources) {
+    postcss.parse(source).walkDecls((decl) => {
+      if (decl.prop.startsWith('--')) {
+        const values = definitions.get(decl.prop) ?? new Set();
+        values.add(normalizeCssValue(decl.value));
+        definitions.set(decl.prop, values);
+      }
+    });
+  }
 
   const reached = new Map();
 
@@ -567,8 +604,8 @@ function accentAliasIndex(source) {
   return accentsOfValue;
 }
 
-function assertMarksTakeTheInk(source, name) {
-  const accentsOfValue = accentAliasIndex(source);
+function assertMarksTakeTheInk(source, name, ...aliasSources) {
+  const accentsOfValue = accentAliasIndex(source, ...aliasSources);
   const seen = new Set();
 
   postcss.parse(source).walkDecls((decl) => {
@@ -606,7 +643,13 @@ function assertMarksTakeTheInk(source, name) {
   return seen;
 }
 
-const accentPaints = assertMarksTakeTheInk(modelHubCss, 'model hub');
+// index.css comes in as a definition source, not as a scan target. A custom property is
+// global once it is on :root, so `--wire-color: var(--mint)` in the app stylesheet is
+// visible to `stroke: var(--wire-color)` here -- the browser resolves it across files and
+// an index built from this file alone would see no definition and clear the wire. The
+// union is the answer for the same reason it is within one file: the question is whether
+// ANY definition can put a bare accent on this stroke.
+const accentPaints = assertMarksTakeTheInk(modelHubCss, 'model hub', css);
 
 // A pin that outlives what it excused is a silent exemption, so every entry has to
 // match a declaration that is really there.
@@ -761,11 +804,54 @@ function classStrings(file, source) {
     return '(module)';
   };
 
+  // The sibling class strings that apply whenever the marked one does -- which is not
+  // the same as every string in the opening element. A label reached only through a
+  // condition (`active ? 'text-mint-foreground' : ''`, `active && '...'`) leaves an
+  // unlabeled resting element behind, and that resting state is exactly what the guard
+  // is asked about. Raw source text cannot tell the two apart, so it cleared a mark on
+  // the strength of a branch that may never be taken -- the one direction a fail-closed
+  // guard must not fail.
+  //
+  // Both operands of a gate are excluded, not just the fallback. A label written into
+  // every branch does apply unconditionally, but proving that means evaluating the
+  // condition; the guard fails closed instead and the fix is to merge the label into the
+  // fill's own string, which is where it belonged anyway.
+  const unconditionalStrings = (scope) => {
+    const parts = [];
+    const walk = (node, gated) => {
+      if (!gated) {
+        if (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)) {
+          parts.push(node.text);
+        } else if (ts.isTemplateExpression(node)) {
+          parts.push(node.head.text, ...node.templateSpans.map((span) => span.literal.text));
+        }
+      }
+      if (ts.isConditionalExpression(node)) {
+        walk(node.condition, gated);
+        walk(node.whenTrue, true);
+        walk(node.whenFalse, true);
+        return;
+      }
+      if (ts.isBinaryExpression(node) && [
+        ts.SyntaxKind.AmpersandAmpersandToken,
+        ts.SyntaxKind.BarBarToken,
+        ts.SyntaxKind.QuestionQuestionToken,
+      ].includes(node.operatorToken.kind)) {
+        walk(node.left, true);
+        walk(node.right, true);
+        return;
+      }
+      ts.forEachChild(node, (child) => walk(child, gated));
+    };
+    walk(scope, false);
+    return parts.join(' ');
+  };
+
   const record = (node, text) => {
     strings.push({
       text,
       owner: ownerOf(node),
-      scope: scopeOf(node).getText(ast),
+      scope: unconditionalStrings(scopeOf(node)),
       line: ast.getLineAndCharacterOfPosition(node.getStart(ast)).line + 1,
     });
   };
@@ -791,6 +877,20 @@ function classStrings(file, source) {
 // A 14px filled glyph is read like small text rather than like a large non-text shape,
 // which is the bar its ink clears and its fill does not.
 const MARK_UTILITIES = ['bg', 'fill', 'stroke'];
+
+// `text-mint` is not a fill that might carry a label. It IS the label -- and through
+// `currentColor`, so is every icon under it that names no colour of its own, which is
+// how one class on a wrapper tints a whole glyph. So the pairing that licenses `bg-mint`
+// cannot license it: nothing is printed on top of text, and there is no second token to
+// look for. The answer is always the ink, which is the same value in dark and a legible
+// one in light -- so unlike a toggle track, this rule takes no exemption. A vivid accent
+// used as text has no reading under which it was intended.
+//
+// Zero sites violate this today; the #1406 codemod moved all 806 onto -ink (240 mint,
+// 214 cyan, 138 destructive, 115 gold, 58 violet, 28 pink, 12 accent, 1 primary). That
+// is exactly why the rule belongs here: the codemod is what made it true, and nothing
+// was stopping the next `text-mint` from undoing it one site at a time.
+const INK_UTILITIES = ['text'];
 
 // `bg-mint/100` is not a wash. It is `bg-mint` spelled with a modifier -- same token,
 // same opacity, same 2.35:1 -- and a `/` in the lookahead let it leave the scan
@@ -837,28 +937,40 @@ const labelCovers = (haystack, label, fillPrefix) => {
   return false;
 };
 
-function assertUnlabeledFillsTakeTheInk(root) {
-  const bare = new RegExp(
-    `\\b(?:${MARK_UTILITIES.join('|')})-(${[...FILL_LABEL.keys(), 'pink'].join('|')})(?![\\w-])(/[\\w.%[\\]]+)?`,
-    'g',
-  );
-  const found = new Map();
-
-  // readdirSync(recursive) yields platform separators, so on Windows an entry arrives
-  // as `components\ui\switch.tsx`. Normalise before it becomes a lookup key, or every
-  // pin below misses and validate:theme fails on an unchanged checkout.
-  const files = fs.readdirSync(root, { recursive: true })
+// Every TypeScript source under a root, in a stable order. Shared by the two scans
+// below so the normalisation cannot drift between them.
+//
+// readdirSync(recursive) yields platform separators, so on Windows an entry arrives
+// as `components\ui\switch.tsx`. Normalise before it becomes a lookup key, or every
+// pin below misses and validate:theme fails on an unchanged checkout.
+function sourceFiles(root) {
+  return fs.readdirSync(root, { recursive: true })
     .map((entry) => entry.split(path.sep).join('/'))
     .filter((entry) => /\.tsx?$/.test(entry))
     .map((entry) => `${root}/${entry}`)
     .sort();
+}
 
-  for (const file of files) {
+function assertUnlabeledFillsTakeTheInk(root) {
+  const bare = new RegExp(
+    `\\b(${[...MARK_UTILITIES, ...INK_UTILITIES].join('|')})-(${[...FILL_LABEL.keys(), 'pink'].join('|')})(?![\\w-])(/[\\w.%[\\]]+)?`,
+    'g',
+  );
+  const found = new Map();
+  const inkMarks = [];
+
+  for (const file of sourceFiles(root)) {
     for (const { text, owner, scope, line } of classStrings(file, fs.readFileSync(file, 'utf8'))) {
       for (const match of text.matchAll(bare)) {
-        const accent = match[1];
-        const modifier = match[2];
+        const utility = match[1];
+        const accent = match[2];
+        const modifier = match[3];
         if (modifier && !FULLY_OPAQUE_MODIFIER.test(modifier)) {
+          continue;
+        }
+        // Ink takes no label and no pin, so it never reaches the pairing logic below.
+        if (INK_UTILITIES.includes(utility)) {
+          inkMarks.push({ file, line, utility, accent, signature: markSignature(owner, text) });
           continue;
         }
         const label = FILL_LABEL.get(accent);
@@ -874,16 +986,28 @@ function assertUnlabeledFillsTakeTheInk(root) {
     }
   }
 
+  if (inkMarks.length > 0) {
+    throw new Error(
+      'These paint text (and, through currentColor, the icons inside it) with a bare accent, which '
+      + 'is the ink side of the split by definition -- no label can sit on top of text, so there is '
+      + 'nothing to pair it with. Use the -ink token:\n'
+      + inkMarks.map(({ file, line, utility, accent, signature }) => (
+        `  ${file}:${line} ${utility}-${accent} -> ${utility}-${accent}-ink\n    ${signature}`
+      )).join('\n'),
+    );
+  }
+
   const unpinned = [...found.entries()].filter(([key]) => !ACCEPTED_BARE_FILLS.has(key));
   if (unpinned.length > 0) {
     throw new Error(
-      'These paint a bare accent with no paired *-foreground label in the same class string or on '
-      + 'a sibling attribute/property, so they are marks read straight off the canvas and must use the '
+      'These paint a bare accent with no paired *-foreground label in the same class string or in an '
+      + 'unconditional sibling attribute/property, so they are marks read straight off the canvas and must use the '
       + '-ink token (bg-mint-ink, fill-cyan-ink, stroke-gold-ink, ...):\n'
       + unpinned.map(([key, marks]) => marks.map(({ signature, line }) => `  ${key} at line ${line}\n    ${signature}`).join('\n')).join('\n')
       + '\nIf the label is real but lives on a child element, move it into the same class string. '
       + 'If it is real but gated behind a state the fill is not, the resting element is still unlabeled '
-      + '-- give the label the same variant prefix or drop the prefix. '
+      + '-- give the label the same variant prefix or drop the prefix, and for a JS condition '
+      + '(`active ? ... : ...`, `active && ...`) merge the label into the fill\'s own string. '
       + 'If a mark is deliberately exempt, pin it in ACCEPTED_BARE_FILLS with its reason.',
     );
   }
@@ -904,7 +1028,54 @@ function assertUnlabeledFillsTakeTheInk(root) {
   }
 }
 
+// The scan above reads Tailwind utility NAMES, so it only sees an accent that arrives as
+// one. `var(--mint)` written into a TypeScript string does not: it reaches a pixel through
+// a `style={{ stroke }}` object, a `shadow-[inset_0_2px_0_0_var(--cyan)]` arbitrary value,
+// or a lookup table read two files away from the element it paints. All three shipped --
+// the agent graph drew 1.6px `var(--mint)` spawn edges, two file-extension icon maps
+// tinted their glyphs through `currentColor`, and the editor and terminal tab strips
+// underlined the active tab -- and the utility scan saw none of them.
+//
+// So this fence is the class of carrier rather than another utility name: no TypeScript
+// string literal may name a bare accent. One rule closes the style object, the JSX paint
+// attribute, the arbitrary value and the lookup table together, and it closes the carrier
+// nobody has invented yet, because what it constrains is the string and not the place the
+// string is used. `var(--mint-ink)` and `var(--mint-foreground)` are unaffected -- only
+// the bare token is a mark with no reading under which it was intended.
+//
+// No pin map, deliberately. The remedy is never an exemption: a mark takes the -ink
+// token, and a fill that genuinely carries a label belongs in a class string where the
+// pairing assertion above can read it -- an inline `style` is exactly where such a
+// pairing goes to hide. Zero sites need an exception after this change, so a pin map
+// would be speculative; add one when a real site earns it.
+function assertNoBareAccentVarInSource(root) {
+  const bareVar = new RegExp(BARE_ACCENT_VAR.source, 'g');
+  const marks = [];
+
+  for (const file of sourceFiles(root)) {
+    for (const { text, owner, line } of classStrings(file, fs.readFileSync(file, 'utf8'))) {
+      for (const [, accent] of text.matchAll(bareVar)) {
+        marks.push({ file, line, accent, signature: markSignature(owner, text) });
+      }
+    }
+  }
+
+  if (marks.length > 0) {
+    throw new Error(
+      'These name a bare accent inside a TypeScript string, so it reaches a pixel without ever '
+      + 'being a Tailwind utility -- through an inline style, an arbitrary value, or a lookup table '
+      + 'read somewhere else -- and the class scan cannot see it. Use the ink token:\n'
+      + marks.map(({ file, line, accent, signature }) => (
+        `  ${file}:${line} var(--${accent}) -> var(--${accent}-ink)\n    ${signature}`
+      )).join('\n')
+      + '\nIf it is genuinely a labelled fill, move the paint into a class string '
+      + '(bg-mint text-mint-foreground) where the pairing assertion can read the label.',
+    );
+  }
+}
+
 assertUnlabeledFillsTakeTheInk('src');
+assertNoBareAccentVarInSource('src');
 assertEveryAcceptedPairStillExists();
 
 const modelHub = (options) => resolveThemeTokens({ ...options, source: modelHubCss });

--- a/ui/scripts/validate-theme.mjs
+++ b/ui/scripts/validate-theme.mjs
@@ -468,64 +468,121 @@ assertAccentAliasesKeepTheirTokenName(css);
 // 2.95:1, both under the 3:1 non-text floor, while their inks clear it. In dark each
 // accent's ink IS its fill, so none of this moves a dark pixel.
 
-// A translucent value is a wash, not a mark -- it has no ratio of its own, exactly as
-// requireMeasurableColor says -- so only opaque declarations are held to the rule.
 const ACCENT_NAMES = ACCENT_FILLS.map((fill) => fill.slice(2));
 const BARE_ACCENT_VAR = new RegExp(`var\\(\\s*--(${ACCENT_NAMES.join('|')})\\s*\\)`);
 
-// Naming color-mix() is not proof of translucency, and that is the whole exemption.
-// `color-mix(in srgb, var(--mint) 100%, transparent)` mentions both `color-mix` and
-// `transparent` and still renders as bare mint at 2.35:1 on the light canvas -- exactly
-// the mark this assertion exists to reject. So resolve the accent's share and exempt
-// only what a wash actually is.
+// A wash is not exempt because of what its value looks like. It is exempt because
+// someone decided this hairline is decoration, and wrote that down here.
 //
-// A mix shape this pattern cannot read fails loudly rather than inheriting the old
-// free pass: an unmeasured mix is not a proven-translucent one. Extending the pattern
-// is the correct response to that failure. Only the accent's own share is resolved --
-// mixing an accent into an opaque colour keeps its ratio, so such a shape is a mark
-// and must say so here rather than be waved through.
-const ACCENT_SHARE_OF_MIX = /^color-mix\(\s*in\s+[\w-]+\s*,\s*[^,]+?\s+([\d.]+)%\s*,\s*transparent\s*\)$/i;
+// Three revisions tried to infer that decision from the value instead. Matching
+// `color-mix` passed an opaque `color-mix(in srgb, var(--mint) 100%, transparent)`.
+// Resolving the share and exempting anything under 100% passed a 99% one. Any
+// threshold that replaces it can be approached from below, and measuring the
+// composited result cannot work either: a real 20% mint wash lands near 1.2:1 on the
+// light canvas, so a contrast floor would reject the decorative rails this exemption
+// exists for. Whether a translucent stroke is decoration or an illegible mark is
+// intent, and intent is not in the CSS.
+//
+// So the guard stops guessing. Every accent reaching a stroke or fill is either the
+// ink, or listed here with a reason. There is no share left to tune and no bypass
+// left to find, and the cost is one line per genuine wash -- the same bargain
+// ACCEPTED_BARE_FILLS already makes for the control-chrome sites.
+//
+// Keyed by the resolved declaration, not by its address. An address-keyed pin excuses
+// whatever that selector paints next: edit this same stroke from 20% to 100% and an
+// opaque mint ships under a pin granted to a hairline. That is the identical defect a
+// per-file mark count had -- a pin has to name the construct it was granted for, and
+// for a declaration the construct is its value. Retinting a pinned wash now fails
+// twice over, as an unpinned mark and as a stale pin, and the error prints the key to
+// re-pin with. Resolved rather than authored, so an alias cannot smuggle an accent in
+// under an innocuous-looking key.
+const ACCEPTED_ACCENT_WASHES = new Map([
+  ['model hub .model-hub-rail-line stroke: color-mix(in srgb, var(--mint) 20%, transparent)', 'decorative rail behind the wires: a 20% tint, not a mark -- the wires it sits under carry the meaning'],
+]);
 
-function accentShare(name, decl, value) {
-  if (!value.includes('color-mix')) {
-    return 1;
-  }
+// What a declaration actually paints. A custom property is not a colour, it is a
+// name for one, and `--wire-color: var(--mint)` + `stroke: var(--wire-color)` paints
+// bare mint while naming neither. modelHubSurface.css already routes 20 accents
+// through --model-hub-* aliases, so this is one refactor away rather than
+// hypothetical. Aliases are resolved to their values before the check reads them.
+//
+// The depth cap is a cycle guard, not a limit on nesting anyone writes: CSS permits
+// `--a: var(--b); --b: var(--a)`, and a resolver that trusts its input would spin.
+const ALIAS_DEPTH = 10;
 
-  const mix = ACCENT_SHARE_OF_MIX.exec(value);
-  if (!mix) {
-    throw new Error(
-      `${name}: ${decl.selector ?? decl.parent?.selector} paints ${decl.prop} with ${value}, a `
-      + 'color-mix() this guard cannot resolve to an alpha. Only a mix proven translucent is exempt '
-      + 'from the mark rule, because an opaque mix renders as the bare fill -- teach '
-      + 'ACCENT_SHARE_OF_MIX this shape instead of letting an unmeasured mix through.',
-    );
-  }
+function resolveAliases(source) {
+  const aliases = new Map();
+  postcss.parse(source).walkDecls((decl) => {
+    if (decl.prop.startsWith('--')) {
+      aliases.set(decl.prop, normalizeCssValue(decl.value));
+    }
+  });
 
-  return Number.parseFloat(mix[1]) / 100;
+  return (value) => {
+    let resolved = value;
+    for (let depth = 0; depth < ALIAS_DEPTH; depth += 1) {
+      const next = resolved.replace(/var\(\s*(--[\w-]+)\s*\)/g, (whole, name) => (
+        // An accent token is the leaf this check is looking for -- resolving it to a
+        // hex would hide the very name the error message has to report.
+        ACCENT_NAMES.includes(name.slice(2)) ? whole : aliases.get(name) ?? whole
+      ));
+      if (next === resolved) {
+        return resolved;
+      }
+      resolved = next;
+    }
+    return resolved;
+  };
 }
 
 function assertMarksTakeTheInk(source, name) {
+  const resolve = resolveAliases(source);
+  const seen = new Set();
+
   postcss.parse(source).walkDecls((decl) => {
     if (decl.prop !== 'stroke' && decl.prop !== 'fill') {
       return;
     }
 
-    const value = normalizeCssValue(decl.value);
-    if (!BARE_ACCENT_VAR.test(value) || accentShare(name, decl, value) < 1) {
+    const value = resolve(normalizeCssValue(decl.value));
+    if (!BARE_ACCENT_VAR.test(value)) {
+      return;
+    }
+
+    const selector = decl.selector ?? decl.parent?.selector;
+    const key = `${name} ${selector} ${decl.prop}: ${value}`;
+    seen.add(key);
+    if (ACCEPTED_ACCENT_WASHES.has(key)) {
       return;
     }
 
     const accent = BARE_ACCENT_VAR.exec(value)[1];
     throw new Error(
-      `${name}: ${decl.selector ?? decl.parent?.selector} paints ${decl.prop} with var(--${accent}), the fill. `
+      `${name}: ${selector} paints ${decl.prop} with var(--${accent}), the fill${
+        value === normalizeCssValue(decl.value) ? '' : ` (via ${normalizeCssValue(decl.value)})`}. `
       + 'A stroke or an SVG fill is a mark on the bare canvas -- no label is printed on it, so the '
       + `pairing that licenses a vivid fill does not apply. Use var(--${accent}-ink), which is the same `
-      + 'value in dark and a legible one in light.',
+      + 'value in dark and a legible one in light. If this one is decoration rather than a mark, say so '
+      + `in ACCEPTED_ACCENT_WASHES under '${key}' -- a translucent value is not evidence on its own.`,
     );
   });
+
+  return seen;
 }
 
-assertMarksTakeTheInk(modelHubCss, 'model hub');
+const accentPaints = assertMarksTakeTheInk(modelHubCss, 'model hub');
+
+// A pin that outlives what it excused is a silent exemption, so every entry has to
+// match a declaration that is really there.
+for (const [key, reason] of ACCEPTED_ACCENT_WASHES) {
+  if (!accentPaints.has(key)) {
+    throw new Error(
+      `ACCEPTED_ACCENT_WASHES pins '${key}' (${reason}), but no stroke or fill paints that any more. `
+      + 'Drop the pin along with the declaration it was granted for -- or, if the declaration is still '
+      + 'there with a different value, re-pin the new one and re-read the reason against it.',
+    );
+  }
+}
 
 // The same rule in Tailwind: `bg-mint` on a 6px dot is a mark, `bg-mint` under a
 // `text-primary-foreground` label is a fill. Only the label tells them apart, so the
@@ -537,6 +594,11 @@ assertMarksTakeTheInk(modelHubCss, 'model hub');
 //   2. a sibling attribute or property of the same node -- an icon tile passes
 //      `iconTileClassName="bg-gold"` beside `iconClassName="text-gold-foreground"`,
 //      and agentBackends.ts pairs `tileCls`/`iconCls` in one object literal
+//
+// and the label must also apply whenever the fill does. A label restricted to a state
+// the fill is not -- `bg-mint hover:text-primary-foreground` -- leaves the resting
+// element unlabeled, so the variant prefix has to match or be absent. Absent is the
+// broader case and passes: an always-on label still labels a hover-only fill.
 //
 // Both scopes come from the TypeScript AST, so "belongs to" is a parent node rather
 // than a line count. Proximity is not evidence: an earlier draft looked in a +/-4 line
@@ -626,12 +688,21 @@ function classStrings(file, source) {
   }
   const strings = [];
 
+  // An object literal is a shared scope only when the class string is a property
+  // VALUE, which is what a config map looks like: `{ tileCls: 'bg-gold', iconCls:
+  // 'text-gold-foreground' }` describes one node, so the two pair. As a property KEY
+  // it is a clsx condition branch instead -- `clsx({ 'bg-mint': a, 'text-primary-
+  // foreground': b })` -- and branches that toggle independently are the opposite of
+  // evidence: the fill can render while the label's condition is false. Reading which
+  // side of the colon the string sits on separates them without an allowlist of
+  // helper names.
   const scopeOf = (node) => {
     const parent = node.parent;
     if (ts.isJsxAttribute(parent) || (ts.isJsxExpression(parent) && ts.isJsxAttribute(parent.parent))) {
       return ts.isJsxAttribute(parent) ? parent.parent : parent.parent.parent;
     }
-    if (ts.isPropertyAssignment(parent) && ts.isObjectLiteralExpression(parent.parent)) {
+    if (ts.isPropertyAssignment(parent) && parent.initializer === node
+      && ts.isObjectLiteralExpression(parent.parent)) {
       return parent.parent;
     }
     return node;
@@ -678,8 +749,46 @@ function classStrings(file, source) {
   return strings;
 }
 
+// Which utilities paint an accent onto a shape. `bg-` is the common one, but an icon
+// is a mark too, and Tailwind colours an SVG with `fill-`/`stroke-`: AppsLauncher's
+// pinned-state Pin shipped a 14px `fill-cyan` glyph that this scan could not see.
+// A 14px filled glyph is read like small text rather than like a large non-text shape,
+// which is the bar its ink clears and its fill does not.
+const MARK_UTILITIES = ['bg', 'fill', 'stroke'];
+
+// The Tailwind state the utility containing `index` is gated behind: `hover:`,
+// `md:hover:`, or '' for none. Scoped to the one utility rather than the class string,
+// so two utilities sharing a string can be compared. Any whitespace separates
+// utilities, because a multi-line class string wraps on newlines.
+const variantPrefix = (text, index) => {
+  let start = index;
+  while (start > 0 && !/\s/.test(text[start - 1])) {
+    start -= 1;
+  }
+  const colon = text.lastIndexOf(':', index - 1);
+  return colon >= start ? text.slice(start, colon + 1) : '';
+};
+
+// Does this label apply wherever the fill does? An unprefixed label always applies,
+// so it labels a `hover:`-only fill. Anything else has to match exactly. A broader but
+// unequal chain (label `hover:`, fill `md:hover:`) fails rather than being reasoned
+// about: no site writes one, and a guard should fail closed on a shape it cannot
+// prove -- the fix is to merge the two utilities into one string, or pin the mark.
+const labelCovers = (haystack, label, fillPrefix) => {
+  for (let at = haystack.indexOf(label); at !== -1; at = haystack.indexOf(label, at + 1)) {
+    const prefix = variantPrefix(haystack, at);
+    if (prefix === '' || prefix === fillPrefix) {
+      return true;
+    }
+  }
+  return false;
+};
+
 function assertUnlabeledFillsTakeTheInk(root) {
-  const bare = new RegExp(`\\bbg-(${[...FILL_LABEL.keys(), 'pink'].join('|')})(?![\\w-/])`, 'g');
+  const bare = new RegExp(
+    `\\b(?:${MARK_UTILITIES.join('|')})-(${[...FILL_LABEL.keys(), 'pink'].join('|')})(?![\\w-/])`,
+    'g',
+  );
   const found = new Map();
 
   // readdirSync(recursive) yields platform separators, so on Windows an entry arrives
@@ -696,7 +805,9 @@ function assertUnlabeledFillsTakeTheInk(root) {
       for (const match of text.matchAll(bare)) {
         const accent = match[1];
         const label = FILL_LABEL.get(accent);
-        if (label && (text.includes(`-${label}`) || scope.includes(`-${label}`))) {
+        const fillPrefix = variantPrefix(text, match.index);
+        if (label && (labelCovers(text, `-${label}`, fillPrefix)
+          || labelCovers(scope, `-${label}`, fillPrefix))) {
           continue;
         }
 
@@ -709,11 +820,13 @@ function assertUnlabeledFillsTakeTheInk(root) {
   const unpinned = [...found.entries()].filter(([key]) => !ACCEPTED_BARE_FILLS.has(key));
   if (unpinned.length > 0) {
     throw new Error(
-      'These paint a bare accent fill with no paired *-foreground label in the same class string or on '
+      'These paint a bare accent with no paired *-foreground label in the same class string or on '
       + 'a sibling attribute/property, so they are marks read straight off the canvas and must use the '
-      + '-ink token (bg-mint-ink, bg-gold-ink, ...):\n'
+      + '-ink token (bg-mint-ink, fill-cyan-ink, stroke-gold-ink, ...):\n'
       + unpinned.map(([key, marks]) => marks.map(({ signature, line }) => `  ${key} at line ${line}\n    ${signature}`).join('\n')).join('\n')
       + '\nIf the label is real but lives on a child element, move it into the same class string. '
+      + 'If it is real but gated behind a state the fill is not, the resting element is still unlabeled '
+      + '-- give the label the same variant prefix or drop the prefix. '
       + 'If a mark is deliberately exempt, pin it in ACCEPTED_BARE_FILLS with its reason.',
     );
   }

--- a/ui/scripts/validate-theme.mjs
+++ b/ui/scripts/validate-theme.mjs
@@ -515,7 +515,15 @@ const ACCENT_NAMES = ACCENT_FILLS.map((fill) => fill.slice(2));
 // what separates --mint from --mint-ink. Parsing the argument would have to survive nested
 // parens (`var(--mint, rgb(0 0 0))`) and a second comma level, and every version of that
 // is another CSS parser living inside a lookahead.
-const BARE_ACCENT_VAR = new RegExp(`var\\(\\s*--(${ACCENT_NAMES.join('|')})\\s*(?=[,)])`);
+//
+// One source for the boundary, parameterised by which names to capture, because round 8
+// found the same fallback hole a second time in the CSS alias resolver: that pattern was
+// written independently, required `)` immediately, and so read `--wire: var(--mint, #fff)`
+// as reaching no accent at all. Two predicates answering "does this reference name X" is
+// the defect; the alternation is the only thing that legitimately differs between them.
+const varReferenceSource = (names) => `var\\(\\s*--(${names})\\s*(?=[,)])`;
+const BARE_ACCENT_VAR = new RegExp(varReferenceSource(ACCENT_NAMES.join('|')));
+const anyVarReference = () => new RegExp(varReferenceSource('[\\w-]+'), 'g');
 
 // A wash is not exempt because of what its value looks like. It is exempt because
 // someone decided this hairline is decoration, and wrote that down here.
@@ -541,8 +549,27 @@ const BARE_ACCENT_VAR = new RegExp(`var\\(\\s*--(${ACCENT_NAMES.join('|')})\\s*(
 // for a declaration the construct is its value, together with the accents that value
 // can reach. Retinting a pinned wash now fails twice over, as an unpinned mark and as
 // a stale pin, and the error prints the key to re-pin with.
+// Round 8 widened the scanned properties from stroke/fill to the backgrounds as well, and
+// this map grew from 1 entry to 8. All seven new ones are 7.8-14.1% color-mix washes, so the
+// widening moved no pixels; what it closes is the next OPAQUE `background: var(--mint)`,
+// which until now was the one spelling of an unlabeled accent fill that no scan could see.
+//
+// Eight pins is still the bargain this map was built for, an order of magnitude under the
+// ~370 sites that made the Tailwind half use a threshold instead. Two shapes recur, and both
+// are undecidable here rather than wrong: a label declared on a DIFFERENT rule that happens
+// to match the same element (`class="strip strip--error"`), and a label on a child. The
+// stylesheet's own `--success` strip pairs `color: var(--mint-ink)` in-rule, which is what
+// makes the same-rule rule the idiom rather than an imposition -- and each pin below names
+// which of the two it is, so re-pinning is a decision and not a formality.
 const ACCEPTED_ACCENT_WASHES = new Map([
   ['model hub .model-hub-rail-line stroke: color-mix(in srgb, var(--mint) 20%, transparent) -> mint', 'decorative rail behind the wires: a 20% tint, not a mark -- the wires it sits under carry the meaning'],
+  ['model hub .model-hub-accent-tile--cyan background: var(--model-hub-cyan-1a) -> cyan', 'icon tile: a 10.2% wash behind a glyph the consuming element tints itself, so nothing is read off the tile'],
+  ['model hub .model-hub-accent-tile--mint background: var(--model-hub-mint-1a) -> mint', 'icon tile: a 10.2% wash behind a glyph the consuming element tints itself, so nothing is read off the tile'],
+  ['model hub .model-hub-accent-tile--gold background: var(--model-hub-gold-1a) -> gold', 'icon tile: a 10.2% wash behind a glyph the consuming element tints itself, so nothing is read off the tile'],
+  ['model hub .model-hub-accent-tile--violet background: var(--model-hub-violet-24) -> violet', 'icon tile: a 14.1% wash behind a glyph the consuming element tints itself, so nothing is read off the tile'],
+  ['model hub .model-hub-add-key-strip--error background: var(--model-hub-add-key-error-fill) -> destructive', 'advisory strip: a 7.8% wash whose text colour is declared on the base .model-hub-add-key-strip rule, which this file cannot prove co-occurs'],
+  ['model hub .model-hub-add-key-strip--advisory background: var(--model-hub-add-key-advisory-fill) -> gold', 'advisory strip: a 7.8% wash whose text colour is declared on the base .model-hub-add-key-strip rule, which this file cannot prove co-occurs'],
+  ['model hub .model-hub-adopt-failure background: var(--model-hub-danger-fill) -> destructive', 'failure banner: a 7.8% wash whose label lives on the child selectors (> svg, span span), which is not an accepted pairing scope'],
 ]);
 
 // What a declaration actually paints. A custom property is not a colour, it is a name
@@ -601,11 +628,11 @@ function accentAliasIndex(...sources) {
 
   function accentsOfValue(value) {
     const found = new Set();
-    for (const [, name] of value.matchAll(/var\(\s*(--[\w-]+)\s*\)/g)) {
-      if (ACCENT_NAMES.includes(name.slice(2))) {
-        found.add(name.slice(2));
+    for (const [, name] of value.matchAll(anyVarReference())) {
+      if (ACCENT_NAMES.includes(name)) {
+        found.add(name);
       } else {
-        for (const accent of accentsOfName(name)) {
+        for (const accent of accentsOfName(`--${name}`)) {
           found.add(accent);
         }
       }
@@ -616,12 +643,67 @@ function accentAliasIndex(...sources) {
   return accentsOfValue;
 }
 
+// What a CSS property paints, which is the CSS half of the same split MARK_UTILITIES and
+// INK_UTILITIES make on the Tailwind side. It was two property names compared inline --
+// `stroke` and `fill` -- and round 8 found the hole that shape guarantees: `background:
+// var(--mint)` in a stylesheet paints the identical pixels `bg-mint` does in a class
+// string, and the CSS half could not see it. An enumeration written at the comparison
+// site is only ever as complete as the round that wrote it; a table can be asserted.
+//
+//   canvas   -- a mark with nothing printed on it. A stroke or an SVG fill is read
+//               straight off the surface, so no pairing can license a vivid accent and
+//               the answer is always the ink (or a written pin).
+//   labelled -- an area a label can sit on. Same question as `bg-`: cleared by a legible
+//               label in the same rule, otherwise pinned.
+//   glyph    -- the label itself. Nothing sits on top of text, so like `text-mint` it
+//               takes the ink and takes no pairing.
+//
+// Hairlines (`border-color`, `outline-color`, `box-shadow`, `border`) are deliberately
+// absent for the same measured reason `border-` is absent from MARK_UTILITIES: whether a
+// 1px accent border needs the ink is design.pen's open question, recorded in the PR
+// ledger. Absence here means out of scope, and CSS_PAINT_SPELLINGS pins that meaning down
+// so a property cannot fall out of scope by never having been thought of.
+const CSS_PAINTED_SURFACE = new Map([
+  ['stroke', 'canvas'],
+  ['fill', 'canvas'],
+  ['background', 'labelled'],
+  ['background-color', 'labelled'],
+  ['background-image', 'labelled'],
+  ['color', 'glyph'],
+]);
+
+// The label side, in CSS. `color:` in the same rule paints the glyphs that sit on this
+// area, and both `--<accent>-ink` and `--<accent>-foreground` are tokens assertContrast
+// above already proves legible -- ink against the neutral surfaces, foreground against
+// the vivid fill. So a rule that paints an area with an accent and names one of them for
+// its text has stated the pairing, and the contrast of that token pair is a question this
+// file answers elsewhere rather than a second time here.
+//
+// Deliberately the same rule only, never a descendant selector. A label on a child is not
+// an accepted pairing scope on the Tailwind side either: proving `.tile p` covers `.tile`
+// means resolving the cascade and the DOM, and a guard that guesses at that clears marks
+// on the strength of a element it never saw.
+const cssLabelsTheArea = (rule, accent) => {
+  let labelled = false;
+  rule?.each?.((node) => {
+    if (node.type !== 'decl' || CSS_PAINTED_SURFACE.get(node.prop) !== 'glyph') {
+      return;
+    }
+    const value = normalizeCssValue(node.value);
+    if (new RegExp(varReferenceSource(`${accent}-(?:ink|foreground)`)).test(value)) {
+      labelled = true;
+    }
+  });
+  return labelled;
+};
+
 function assertMarksTakeTheInk(source, name, ...aliasSources) {
   const accentsOfValue = accentAliasIndex(source, ...aliasSources);
   const seen = new Set();
 
   postcss.parse(source).walkDecls((decl) => {
-    if (decl.prop !== 'stroke' && decl.prop !== 'fill') {
+    const paints = CSS_PAINTED_SURFACE.get(decl.prop);
+    if (paints === undefined) {
       return;
     }
 
@@ -631,7 +713,12 @@ function assertMarksTakeTheInk(source, name, ...aliasSources) {
       return;
     }
 
-    const selector = decl.selector ?? decl.parent?.selector;
+    const rule = decl.parent;
+    const selector = decl.selector ?? rule?.selector;
+    if (paints === 'labelled' && accents.every((accent) => cssLabelsTheArea(rule, accent))) {
+      return;
+    }
+
     // The pin names the declaration as written AND what it can reach. Value alone
     // would let `--wire: var(--mint-ink)` become `var(--mint)` under a pin granted to
     // the ink, since `stroke: var(--wire)` reads the same either way.
@@ -642,37 +729,25 @@ function assertMarksTakeTheInk(source, name, ...aliasSources) {
     }
 
     const direct = BARE_ACCENT_VAR.test(value);
+    const why = {
+      canvas: 'A stroke or an SVG fill is a mark on the bare canvas -- no label is printed on it, so the '
+        + 'pairing that licenses a vivid fill does not apply.',
+      labelled: 'Nothing in this rule prints a label on it: a paired label is a color declaration in this '
+        + 'same rule naming that accent\'s -ink or -foreground token. A label on a child element is not an accepted '
+        + 'scope -- proving it covers this area means resolving the cascade and the DOM.',
+      glyph: 'This IS the label -- and through currentColor so is every glyph under it -- so there is no '
+        + 'second token to pair it with.',
+    }[paints];
     throw new Error(
       `${name}: ${selector} paints ${decl.prop} with ${accents.map((accent) => `var(--${accent})`).join(' and ')}`
       + `, the fill${direct ? '' : ` -- reached through ${value}, in this file or a theme override of it`}. `
-      + 'A stroke or an SVG fill is a mark on the bare canvas -- no label is printed on it, so the '
-      + 'pairing that licenses a vivid fill does not apply. Use the -ink token, which is the same value '
+      + `${why} Use the -ink token, which is the same value `
       + 'in dark and a legible one in light. If this one is decoration rather than a mark, say so in '
       + `ACCEPTED_ACCENT_WASHES under '${key}' -- a translucent value is not evidence on its own.`,
     );
   });
 
   return seen;
-}
-
-// index.css comes in as a definition source, not as a scan target. A custom property is
-// global once it is on :root, so `--wire-color: var(--mint)` in the app stylesheet is
-// visible to `stroke: var(--wire-color)` here -- the browser resolves it across files and
-// an index built from this file alone would see no definition and clear the wire. The
-// union is the answer for the same reason it is within one file: the question is whether
-// ANY definition can put a bare accent on this stroke.
-const accentPaints = assertMarksTakeTheInk(modelHubCss, 'model hub', css);
-
-// A pin that outlives what it excused is a silent exemption, so every entry has to
-// match a declaration that is really there.
-for (const [key, reason] of ACCEPTED_ACCENT_WASHES) {
-  if (!accentPaints.has(key)) {
-    throw new Error(
-      `ACCEPTED_ACCENT_WASHES pins '${key}' (${reason}), but no stroke or fill paints that any more. `
-      + 'Drop the pin along with the declaration it was granted for -- or, if the declaration is still '
-      + 'there with a different value, re-pin the new one and re-read the reason against it.',
-    );
-  }
 }
 
 // The same rule in Tailwind: `bg-mint` on a 6px dot is a mark, `bg-mint` under a
@@ -682,9 +757,9 @@ for (const [key, reason] of ACCEPTED_ACCENT_WASHES) {
 //
 //   1. the same class string -- `bg-mint text-primary-foreground` (21 of the 23
 //      labelled fills in src/, including every cva variant in button-variants.ts)
-//   2. a sibling attribute or property of the same node -- an icon tile passes
+//   2. a sibling attribute of the same JSX element -- an icon tile passes
 //      `iconTileClassName="bg-gold"` beside `iconClassName="text-gold-foreground"`,
-//      and agentBackends.ts pairs `tileCls`/`iconCls` in one object literal
+//      and both land on one node
 //
 // and the label must also apply whenever the fill does. A label restricted to a state
 // the fill is not -- `bg-mint hover:text-primary-foreground` -- leaves the resting
@@ -703,6 +778,16 @@ for (const [key, reason] of ACCEPTED_ACCENT_WASHES) {
 // className="text-primary-foreground">`) is deliberately NOT a scope: no site needs it
 // today, and widening to a subtree would re-admit an unrelated nested label. Such a
 // site fails and is either merged into one class string or pinned below.
+//
+// An object literal used to be a third scope, and round 8 found it was the child scope
+// wearing different clothes. Two properties of one object are siblings in the source and
+// nothing more: `{ tileCls: 'bg-gold', iconCls: 'text-gold-foreground' }` is a PARENT and
+// its CHILD, since the consumer puts the tile class on the wrapper and the icon class on
+// the glyph inside it -- exactly the pairing the paragraph above refuses, admitted through
+// a syntactic side door. Worse, an object literal is also how mutually exclusive values are
+// written: a variant map's `success` and `danger` entries never render together, so one
+// entry's label could license another's fill. Both live shapes read as siblings, so the
+// scope is gone and the one site it carried is pinned below with what the consumer does.
 //
 // mint/cyan/pink declare no -foreground of their own; they print --primary-foreground
 // and --accent-foreground, the aliases SEMANTIC_FILL_ALIASES keeps equal. pink has no
@@ -743,6 +828,15 @@ const ACCEPTED_BARE_FILLS = new Map([
   ['src/components/steps/LarkConfig.tsx --mint', { reason: STEP_DOTS, marks: [`LarkConfig: ${STEP_DOT}`] }],
   ['src/components/steps/WeChatConfig.tsx --mint', { reason: STEP_DOTS, marks: [`WeChatConfig: ${STEP_DOT}`] }],
   ['src/components/visual/EmbeddedConfigShell.tsx --mint', { reason: STEP_DOTS, marks: [`EmbeddedConfigShell: ${STEP_DOT}`] }],
+  // Not control chrome. This is the one site the object-literal pairing scope was
+  // carrying, surfaced when round 8 closed that door: the Codex row pairs `tileCls:
+  // 'bg-gold'` with `iconCls: 'text-gold-foreground'`, which is a parent and its child,
+  // and the guard does not infer a child label at the element level either. The pairing
+  // is real -- the tile holds nothing but that icon -- so it is written here rather than
+  // derived from two neighbouring property names. Worth noting for design.pen: the other
+  // two backends give their tile a soft wash (bg-cyan-soft, bg-violet-soft) and only this
+  // one is a vivid fill, so the inconsistency is a design question, not a guard question.
+  ['src/lib/agentBackends.ts --gold', { reason: 'backend icon tile: the tile holds only the icon, which the neighbouring iconCls paints text-gold-foreground', marks: ['AGENT_BACKENDS: bg-gold'] }],
 ]);
 
 // What an exemption is bound to. Kept as one string so the pins above read as the
@@ -779,22 +873,24 @@ function classStrings(file, source) {
   }
   const strings = [];
 
-  // An object literal is a shared scope only when the class string is a property
-  // VALUE, which is what a config map looks like: `{ tileCls: 'bg-gold', iconCls:
-  // 'text-gold-foreground' }` describes one node, so the two pair. As a property KEY
-  // it is a clsx condition branch instead -- `clsx({ 'bg-mint': a, 'text-primary-
-  // foreground': b })` -- and branches that toggle independently are the opposite of
-  // evidence: the fill can render while the label's condition is false. Reading which
-  // side of the colon the string sits on separates them without an allowlist of
-  // helper names.
+  // One JSX element is a shared scope: its attributes are applied to the same node at the
+  // same time, which is what a pairing is a claim about.
+  //
+  // An object literal is not, and round 8 is where that came out. It was admitted for the
+  // config-map shape -- `{ tileCls: 'bg-gold', iconCls: 'text-gold-foreground' }` -- on the
+  // reading that such a map describes one node. Two things are wrong with it. A cva variant
+  // map is the identical syntax and means the opposite (`{ mint: 'bg-mint', ghost:
+  // 'text-foreground' }` are alternatives, never both), and telling the two apart means
+  // knowing what the consumer does with the object, which is not in the object. And even
+  // where the map really is a config map, `tileCls`/`iconCls` is a PARENT and its CHILD --
+  // so the rule was a side door into exactly the child-element pairing this guard refuses
+  // to infer at the element level. A property value now sees only itself; the one live site
+  // that relied on the door is pinned in ACCEPTED_BARE_FILLS, where the reasoning is
+  // written down instead of derived from a naming convention.
   const scopeOf = (node) => {
     const parent = node.parent;
     if (ts.isJsxAttribute(parent) || (ts.isJsxExpression(parent) && ts.isJsxAttribute(parent.parent))) {
       return ts.isJsxAttribute(parent) ? parent.parent : parent.parent.parent;
-    }
-    if (ts.isPropertyAssignment(parent) && parent.initializer === node
-      && ts.isObjectLiteralExpression(parent.parent)) {
-      return parent.parent;
     }
     return node;
   };
@@ -916,19 +1012,26 @@ const MARK_UTILITIES = ['bg', 'fill', 'stroke', 'from', 'via', 'to'];
 // is text, an underline is read as part of the glyphs it sits under, and a caret you
 // cannot find is a text field you cannot use. 0 sites today.
 //
-// The flag is which of them prints *glyphs*, because "is ink" and "can carry a label" are
+// The flag is which of them prints *the label*, because "is ink" and "can carry a label" are
 // two different questions and collapsing them opens the hole this file just closed on
 // `border-`: a `caret-primary-foreground` is a 1px bar, so licensing `bg-mint` with it
-// excuses the fill on the strength of something nobody reads a word off. Glyphs sit on
-// the fill and are read off it; a caret and an underline sit near text without being it.
+// excuses the fill on the strength of something nobody reads a word off. A label sits on
+// the fill and is read off it; a caret and an underline sit near text without being it.
+//
+// `placeholder-` prints real glyphs and still does not qualify, which is why the flag is
+// about the label rather than about glyphs. A placeholder is shown only while the field is
+// EMPTY, so it is precisely the text that is not there once there is text to read: pairing
+// it with a fill licenses that fill on the strength of something that disappears the moment
+// it would matter. The entered text takes its colour from `text-`, and that is the operand
+// this guard has to find.
 const INK_UTILITIES = new Map([
   ['text', true],
-  ['placeholder', true],
+  ['placeholder', false],
   ['decoration', false],
   ['caret', false],
 ]);
 const LABEL_UTILITIES = [...INK_UTILITIES]
-  .filter(([, printsGlyphs]) => printsGlyphs)
+  .filter(([, carriesTheLabel]) => carriesTheLabel)
   .map(([utility]) => utility);
 
 // `bg-mint/100` is not a wash. It is `bg-mint` spelled with a modifier -- same token,
@@ -958,17 +1061,26 @@ const LABEL_UTILITIES = [...INK_UTILITIES]
 // only half of one, because the same 1 that says "check this fill" also says "this label is
 // printed". That asymmetry is not hypothetical: reusing this number for the label is what
 // round 7 did, and it is exactly where the previous round's hole was.
+//
+// Which unit a modifier is in is decided by the brackets, not by the magnitude. Reading
+// `value > 1` as "this must be a percentage" was a guess that happens to be right for
+// every number Tailwind's own scale contains except one: `/1` is 1% on the opacity scale,
+// and the guess read it as fully opaque -- so `bg-mint/1`, an invisible tint, was checked
+// as the fill, and more to the point `text-primary-foreground/1` would have been ACCEPTED
+// as a printed label. Unbracketed is always the scale; only an arbitrary value can spell a
+// fraction, and there `/[0.5]` and `/[50%]` say which they are.
 const markAlpha = (modifier) => {
   if (!modifier) {
     return 1;
   }
+  const arbitrary = modifier.startsWith('/[');
   const raw = modifier.slice(1).replace(/^\[|\]$/g, '');
   const percent = raw.endsWith('%');
   const value = Number.parseFloat(percent ? raw.slice(0, -1) : raw);
   if (!Number.isFinite(value) || value < 0) {
     return null;
   }
-  return percent || value > 1 ? value / 100 : value;
+  return percent || !arbitrary ? value / 100 : value;
 };
 
 // Where a tint stops being a tint. The exemption above says a wash is not a mark -- it
@@ -1061,7 +1173,54 @@ const variantPrefix = (text, index) => {
 // translucent label carries a vivid fill is a design.pen question, and the answer is a pin
 // with a reason rather than a threshold quietly lowered to admit it. Nothing live is
 // affected: all 23 label sites in src/ are bare.
+// The unprefixed acceptance has a second condition, which round 8 found missing: an
+// unprefixed label is the label in EVERY state, including the ones a later variant
+// repaints. `bg-mint text-primary-foreground hover:text-muted` reads as paired, and on
+// hover the fill is still vivid mint while the glyphs on it are muted grey -- the exact
+// defect this file exists for, assembled out of two utilities that are each fine.
+//
+// Closed by refusing the shape rather than by modelling it. Deciding which states overlap
+// means an algebra over Tailwind's variants (`hover:` inside `md:`, `group-hover:` driven
+// by an ancestor, `aria-*` from runtime state), and a guard that reasons about that clears
+// marks on the strength of its own arithmetic. So any state-prefixed repaint of the label's
+// own utility voids the unprefixed acceptance, and the remedy is the one that was always
+// right: give that state its own label, or write the label into the state's own string.
+// Zero live sites -- the 7 that carry a state text override all paint soft or wash fills,
+// which never reach this predicate.
+// `text-` is two utilities wearing one prefix: it sets the colour, and it sets the font
+// size. `md:text-sm` repaints nothing, so the check has to know that much or it rejects a
+// responsive size sitting next to a perfectly good label.
+//
+// Sizes are exempted rather than colours enumerated, because the two directions cost
+// differently: a size this misses is a loud false positive on a paired fill, one the error
+// explains and a contributor can see is wrong, while a colour mistaken for a size is a
+// silent hole of the kind this whole round is about. The named scale is Tailwind's own and
+// closed; a unit-bearing arbitrary value is a length by construction, whatever the number.
+const FONT_SIZE_SCALE = /^(?:xs|sm|base|lg|\d?xl)(?:\/\S+)?$/;
+const FONT_SIZE_LENGTH = /^\[(?:length:)?[\d.]+(?:px|rem|em|ch|ex|vh|vw|vmin|vmax|pt|%)\]$/;
+const setsTheSizeNotTheColour = (token) => (
+  FONT_SIZE_SCALE.test(token) || FONT_SIZE_LENGTH.test(token)
+);
+
+const labelRepaintedInSomeState = (haystack, utility, label) => {
+  const prefixed = new RegExp(`(?:^|\\s)\\S+:${utility}-(\\S+)`, 'g');
+  const isTheLabel = new RegExp(`^\\S+:${utility}${accentTokenSource(label)}$`);
+  for (const [written, token] of haystack.matchAll(prefixed)) {
+    if (setsTheSizeNotTheColour(token)) {
+      continue;
+    }
+    const match = written.trimStart().match(isTheLabel);
+    if (!match || !printsTheLabel(markAlpha(match[2]))) {
+      return true;
+    }
+  }
+  return false;
+};
+
 const labelCovers = (haystack, utility, label, fillPrefix) => {
+  if (labelRepaintedInSomeState(haystack, utility, label)) {
+    return false;
+  }
   const printed = new RegExp(`\\b${utility}${accentTokenSource(label)}`, 'g');
   for (const match of haystack.matchAll(printed)) {
     if (!printsTheLabel(markAlpha(match[2]))) {
@@ -1089,10 +1248,10 @@ function sourceFiles(root) {
     .sort();
 }
 
-// The alphabet's own test, run before any file is read. If the pattern the scans are about
-// to use has stopped recognising a spelling, that is a hole in this guard, and it should
-// fail here -- next to the row that names the spelling -- instead of quietly passing a tree
-// that contains one. Adding a spelling means adding a row, which is the point of there being
+// The alphabet's own test, run before any scan reads a file. If the pattern the scans are
+// about to use has stopped recognising a spelling, that is a hole in this guard, and it
+// should fail here -- next to the row that names the spelling -- instead of quietly passing
+// a tree that contains one, or failing three screens away as a pin nothing reaches. Adding a spelling means adding a row, which is the point of there being
 // one alphabet at all.
 //
 // The negatives carry as much weight as the positives, and each was a real defect or a real
@@ -1112,6 +1271,11 @@ const ACCENT_SPELLINGS = [
   ['bg-mint/[0.95]', 'mint', 0.95, true],
   ['bg-mint/10', 'mint', 0.1, false],
   ['bg-mint/[oops]', 'mint', null, true],
+  // The unit is the brackets, not the magnitude: `/1` is 1% on Tailwind's scale, `/[1]` is
+  // the fraction 1. Reading the second meaning into the first is what round 8 found.
+  ['bg-mint/1', 'mint', 0.01, false],
+  ['bg-mint/[1]', 'mint', 1, true],
+  ['bg-mint/100', 'mint', 1, true],
   ['bg-(--mint)', 'mint', 1, true],
   ['bg-(--mint)/10', 'mint', 0.1, false],
   ['bg-(--mint)/[99%]', 'mint', 0.99, true],
@@ -1144,6 +1308,79 @@ const LABEL_SPELLINGS = [
   ['bg-mint text-primary-foregroundish', false],
   ['bg-mint text-primary-foreground/[oops]', false],
   ['bg-mint hover:text-primary-foreground', false],
+  // An unprefixed label claims every state, so a state that repaints it withdraws the
+  // claim -- the fill is still vivid there and the glyphs on it are not the label any more.
+  ['bg-mint text-primary-foreground hover:text-muted', false],
+  ['bg-mint text-primary-foreground hover:text-primary-foreground/50', false],
+  ['bg-mint text-primary-foreground hover:text-primary-foreground', true],
+  ['hover:bg-mint hover:text-primary-foreground focus:text-muted', false],
+  // ... and a size is not a repaint. `text-` is the one utility name that sets two
+  // different properties, so without this the rows above would reject ordinary responsive
+  // type sitting next to a perfectly good label.
+  ['bg-mint text-primary-foreground md:text-sm', true],
+  ['bg-mint text-primary-foreground sm:text-2xl lg:text-base', true],
+  ['bg-mint text-primary-foreground md:text-[13px]', true],
+  ['bg-mint text-primary-foreground md:text-sm/6', true],
+  ['bg-mint text-primary-foreground md:text-[#f00]', false],
+];
+
+// Which utilities can carry the label, written out rather than read off the flag they are
+// derived from, so flipping one entry of INK_UTILITIES fails here instead of silently
+// widening what licenses a fill. `placeholder-` is the round 8 correction: it prints real
+// glyphs, and they are gone exactly when there is text to read.
+const LABEL_UTILITY_SPELLINGS = [
+  ['text', true],
+  ['placeholder', false],
+  ['decoration', false],
+  ['caret', false],
+];
+
+// The CSS half of the accent alphabet, which had no rows here until round 8 -- and that is
+// precisely where round 8's first two findings were. `assertMarksTakeTheInk` resolves a
+// reference through the theme's own aliases, so its two enumerations are the reference
+// pattern and the property table, and both were written at their comparison sites where
+// nothing could test them. Rows, not review rounds.
+const CSS_ALIAS_FIXTURE = `:root {
+  --wire: var(--mint);
+  --deep: var(--wire, #fff);
+  --wash: color-mix(in srgb, var(--gold) 10%, transparent);
+  --loop: var(--loop);
+  --literal: rgba(91, 255, 160, 0.16);
+}`;
+const CSS_SPELLINGS = [
+  ['var(--mint)', ['mint']],
+  ['var(--mint, #10b981)', ['mint']],
+  ['var(--mint , rgb(0 0 0))', ['mint']],
+  ['var( --cyan )', ['cyan']],
+  // Reached through an alias, including one whose own definition carries a fallback: that
+  // second hop is the spelling the CSS resolver could not see.
+  ['var(--wire)', ['mint']],
+  ['var(--deep)', ['mint']],
+  ['var(--deep, #fff)', ['mint']],
+  ['var(--wash)', ['gold']],
+  ['1px solid var(--wire)', ['mint']],
+  // A cycle is invalid at computed-value time, so under-reporting it matches the browser.
+  ['var(--loop)', []],
+  ['var(--literal)', []],
+  ['var(--mint-ink)', []],
+  ['var(--mint-foreground)', []],
+  ['var(--undefined-name)', []],
+];
+
+// What each CSS property paints. Absence means out of scope, which is a decision here and
+// has to be asserted like one -- the hairlines are the measured design.pen question, and
+// `background` was absent because nobody had written it down, not because anybody decided.
+const CSS_PAINT_SPELLINGS = [
+  ['stroke', 'canvas'],
+  ['fill', 'canvas'],
+  ['background', 'labelled'],
+  ['background-color', 'labelled'],
+  ['background-image', 'labelled'],
+  ['color', 'glyph'],
+  ['border-color', undefined],
+  ['outline-color', undefined],
+  ['box-shadow', undefined],
+  ['border', undefined],
 ];
 
 // And the third operand. The var scan reads a CSS reference rather than a utility, so its
@@ -1185,6 +1422,43 @@ function assertAccentSpellingsAreCovered() {
         `The label alphabet reads "${text}" as ${!labelled}, expected ${labelled}.\n`
         + `A label counts only when it prints the token as glyphs at alpha ${OPAQUE_ENOUGH} or above, `
         + 'in a scope the fill also applies to.',
+      );
+    }
+  }
+
+  for (const [utility, carriesTheLabel] of LABEL_UTILITY_SPELLINGS) {
+    if (INK_UTILITIES.get(utility) !== carriesTheLabel
+      || LABEL_UTILITIES.includes(utility) !== carriesTheLabel) {
+      throw new Error(
+        `The ink utilities read "${utility}-" as ${carriesTheLabel ? 'not ' : ''}carrying the label, `
+        + `expected the opposite.\n`
+        + 'Every utility here prints ink and so takes the -ink token; the flag is the narrower '
+        + 'question of which one prints the label a vivid fill is read against. A placeholder, an '
+        + 'underline and a caret are all glyphs nobody reads a word off while the fill is there.',
+      );
+    }
+  }
+
+  const accentsOfFixtureValue = accentAliasIndex(CSS_ALIAS_FIXTURE);
+  for (const [value, accents] of CSS_SPELLINGS) {
+    const read = [...accentsOfFixtureValue(normalizeCssValue(value))].sort();
+    if (JSON.stringify(read) !== JSON.stringify([...accents].sort())) {
+      throw new Error(
+        `The CSS alphabet reads "${value}" as ${JSON.stringify(read)}, expected ${JSON.stringify(accents)}.\n`
+        + 'A stylesheet reference reaches an accent directly or through any number of alias hops, and '
+        + 'a fallback is part of the reference rather than the end of it.',
+      );
+    }
+  }
+
+  for (const [property, paints] of CSS_PAINT_SPELLINGS) {
+    if (CSS_PAINTED_SURFACE.get(property) !== paints) {
+      throw new Error(
+        `CSS_PAINTED_SURFACE reads "${property}" as ${JSON.stringify(CSS_PAINTED_SURFACE.get(property))}, `
+        + `expected ${JSON.stringify(paints)}.\n`
+        + 'What a property paints decides whether a label can license it, and undefined means out of '
+        + 'scope -- which is a recorded decision here, so a property cannot leave this guard by never '
+        + 'having been written down.',
       );
     }
   }
@@ -1342,10 +1616,35 @@ function assertNoBareAccentVarInSource(root) {
   }
 }
 
+// The alphabet first, then every scan that reads through it -- the CSS one included, which
+// is why it is called from here rather than beside its own helpers. A scan that fails while
+// its own alphabet is broken reports the site it happened to reach first, and the mutation
+// sweep for round 8 is where that showed: dropping `background` from CSS_PAINTED_SURFACE
+// surfaced as a stale pin three screens away instead of as the row that names the property.
 assertAccentSpellingsAreCovered();
 assertUnlabeledFillsTakeTheInk('src');
 assertNoBareAccentVarInSource('src');
 assertEveryAcceptedPairStillExists();
+
+// index.css comes in as a definition source, not as a scan target. A custom property is
+// global once it is on :root, so `--wire-color: var(--mint)` in the app stylesheet is
+// visible to `stroke: var(--wire-color)` here -- the browser resolves it across files and
+// an index built from this file alone would see no definition and clear the wire. The
+// union is the answer for the same reason it is within one file: the question is whether
+// ANY definition can put a bare accent on this stroke.
+const accentPaints = assertMarksTakeTheInk(modelHubCss, 'model hub', css);
+
+// A pin that outlives what it excused is a silent exemption, so every entry has to
+// match a declaration that is really there.
+for (const [key, reason] of ACCEPTED_ACCENT_WASHES) {
+  if (!accentPaints.has(key)) {
+    throw new Error(
+      `ACCEPTED_ACCENT_WASHES pins '${key}' (${reason}), but no accent paint reaches that any more. `
+      + 'Drop the pin along with the declaration it was granted for -- or, if the declaration is still '
+      + 'there with a different value, re-pin the new one and re-read the reason against it.',
+    );
+  }
+}
 
 const modelHub = (options) => resolveThemeTokens({ ...options, source: modelHubCss });
 const modelHubSystemDark = modelHub({ prefersLight: false, themeAttr: null });

--- a/ui/scripts/validate-theme.mjs
+++ b/ui/scripts/validate-theme.mjs
@@ -492,51 +492,83 @@ const BARE_ACCENT_VAR = new RegExp(`var\\(\\s*--(${ACCENT_NAMES.join('|')})\\s*\
 // whatever that selector paints next: edit this same stroke from 20% to 100% and an
 // opaque mint ships under a pin granted to a hairline. That is the identical defect a
 // per-file mark count had -- a pin has to name the construct it was granted for, and
-// for a declaration the construct is its value. Retinting a pinned wash now fails
-// twice over, as an unpinned mark and as a stale pin, and the error prints the key to
-// re-pin with. Resolved rather than authored, so an alias cannot smuggle an accent in
-// under an innocuous-looking key.
+// for a declaration the construct is its value, together with the accents that value
+// can reach. Retinting a pinned wash now fails twice over, as an unpinned mark and as
+// a stale pin, and the error prints the key to re-pin with.
 const ACCEPTED_ACCENT_WASHES = new Map([
-  ['model hub .model-hub-rail-line stroke: color-mix(in srgb, var(--mint) 20%, transparent)', 'decorative rail behind the wires: a 20% tint, not a mark -- the wires it sits under carry the meaning'],
+  ['model hub .model-hub-rail-line stroke: color-mix(in srgb, var(--mint) 20%, transparent) -> mint', 'decorative rail behind the wires: a 20% tint, not a mark -- the wires it sits under carry the meaning'],
 ]);
 
-// What a declaration actually paints. A custom property is not a colour, it is a
-// name for one, and `--wire-color: var(--mint)` + `stroke: var(--wire-color)` paints
-// bare mint while naming neither. modelHubSurface.css already routes 20 accents
-// through --model-hub-* aliases, so this is one refactor away rather than
-// hypothetical. Aliases are resolved to their values before the check reads them.
+// What a declaration actually paints. A custom property is not a colour, it is a name
+// for one, and `--wire-color: var(--mint)` + `stroke: var(--wire-color)` paints bare
+// mint while naming neither. modelHubSurface.css already routes ~20 accents through
+// --model-hub-* aliases, so this is one refactor away rather than hypothetical.
 //
-// The depth cap is a cycle guard, not a limit on nesting anyone writes: CSS permits
-// `--a: var(--b); --b: var(--a)`, and a resolver that trusts its input would spin.
-const ALIAS_DEPTH = 10;
-
-function resolveAliases(source) {
-  const aliases = new Map();
+// Every definition of a name counts, not the last one. This file defines 11 properties
+// twice, once per theme -- `--model-hub-wash-channel` is `8 8 18` in dark and
+// `255 255 255` in light -- so a name-to-value map is not a simplification of this
+// file, it is a misreading of it. A last-write-wins resolver would read a light
+// `stroke: var(--wire)` through a `.dark { --wire: ... }` override and clear it on the
+// strength of a value the browser never paints there.
+//
+// Resolving the cascade for real means specificity, at-rules and order: a CSS engine,
+// inside a guard, and one whose bugs would be silent clears. The guard does not need
+// one, because it is not asking what colour this paints. It is asking whether ANY
+// definition can put a bare accent here -- so the union over all of them is the
+// answer, ambiguity fails closed, and a theme-specific accent gets reported instead of
+// averaged away.
+//
+// Accents reachable from a name, memoised, with the in-progress entry doubling as the
+// cycle cut: CSS permits `--a: var(--b); --b: var(--a)`, and a resolver that trusts
+// its input would spin. Cutting the cycle can under-report a cyclic definition, which
+// is correct rather than a hole -- a var() cycle is invalid at computed-value time, so
+// the browser paints nothing there either.
+function accentAliasIndex(source) {
+  const definitions = new Map();
   postcss.parse(source).walkDecls((decl) => {
     if (decl.prop.startsWith('--')) {
-      aliases.set(decl.prop, normalizeCssValue(decl.value));
+      const values = definitions.get(decl.prop) ?? new Set();
+      values.add(normalizeCssValue(decl.value));
+      definitions.set(decl.prop, values);
     }
   });
 
-  return (value) => {
-    let resolved = value;
-    for (let depth = 0; depth < ALIAS_DEPTH; depth += 1) {
-      const next = resolved.replace(/var\(\s*(--[\w-]+)\s*\)/g, (whole, name) => (
-        // An accent token is the leaf this check is looking for -- resolving it to a
-        // hex would hide the very name the error message has to report.
-        ACCENT_NAMES.includes(name.slice(2)) ? whole : aliases.get(name) ?? whole
-      ));
-      if (next === resolved) {
-        return resolved;
-      }
-      resolved = next;
+  const reached = new Map();
+
+  const accentsOfName = (name) => {
+    if (reached.has(name)) {
+      return reached.get(name);
     }
-    return resolved;
+    reached.set(name, new Set());
+    const found = new Set();
+    for (const value of definitions.get(name) ?? []) {
+      for (const accent of accentsOfValue(value)) {
+        found.add(accent);
+      }
+    }
+    reached.set(name, found);
+    return found;
   };
+
+  function accentsOfValue(value) {
+    const found = new Set();
+    for (const [, name] of value.matchAll(/var\(\s*(--[\w-]+)\s*\)/g)) {
+      if (ACCENT_NAMES.includes(name.slice(2))) {
+        found.add(name.slice(2));
+      } else {
+        for (const accent of accentsOfName(name)) {
+          found.add(accent);
+        }
+      }
+    }
+    return found;
+  }
+
+  return accentsOfValue;
 }
 
 function assertMarksTakeTheInk(source, name) {
-  const resolve = resolveAliases(source);
+  const accentsOfValue = accentAliasIndex(source);
   const seen = new Set();
 
   postcss.parse(source).walkDecls((decl) => {
@@ -544,26 +576,30 @@ function assertMarksTakeTheInk(source, name) {
       return;
     }
 
-    const value = resolve(normalizeCssValue(decl.value));
-    if (!BARE_ACCENT_VAR.test(value)) {
+    const value = normalizeCssValue(decl.value);
+    const accents = [...accentsOfValue(value)].sort();
+    if (accents.length === 0) {
       return;
     }
 
     const selector = decl.selector ?? decl.parent?.selector;
-    const key = `${name} ${selector} ${decl.prop}: ${value}`;
+    // The pin names the declaration as written AND what it can reach. Value alone
+    // would let `--wire: var(--mint-ink)` become `var(--mint)` under a pin granted to
+    // the ink, since `stroke: var(--wire)` reads the same either way.
+    const key = `${name} ${selector} ${decl.prop}: ${value} -> ${accents.join(', ')}`;
     seen.add(key);
     if (ACCEPTED_ACCENT_WASHES.has(key)) {
       return;
     }
 
-    const accent = BARE_ACCENT_VAR.exec(value)[1];
+    const direct = BARE_ACCENT_VAR.test(value);
     throw new Error(
-      `${name}: ${selector} paints ${decl.prop} with var(--${accent}), the fill${
-        value === normalizeCssValue(decl.value) ? '' : ` (via ${normalizeCssValue(decl.value)})`}. `
+      `${name}: ${selector} paints ${decl.prop} with ${accents.map((accent) => `var(--${accent})`).join(' and ')}`
+      + `, the fill${direct ? '' : ` -- reached through ${value}, in this file or a theme override of it`}. `
       + 'A stroke or an SVG fill is a mark on the bare canvas -- no label is printed on it, so the '
-      + `pairing that licenses a vivid fill does not apply. Use var(--${accent}-ink), which is the same `
-      + 'value in dark and a legible one in light. If this one is decoration rather than a mark, say so '
-      + `in ACCEPTED_ACCENT_WASHES under '${key}' -- a translucent value is not evidence on its own.`,
+      + 'pairing that licenses a vivid fill does not apply. Use the -ink token, which is the same value '
+      + 'in dark and a legible one in light. If this one is decoration rather than a mark, say so in '
+      + `ACCEPTED_ACCENT_WASHES under '${key}' -- a translucent value is not evidence on its own.`,
     );
   });
 
@@ -756,6 +792,23 @@ function classStrings(file, source) {
 // which is the bar its ink clears and its fill does not.
 const MARK_UTILITIES = ['bg', 'fill', 'stroke'];
 
+// `bg-mint/100` is not a wash. It is `bg-mint` spelled with a modifier -- same token,
+// same opacity, same 2.35:1 -- and a `/` in the lookahead let it leave the scan
+// entirely. So the modifier is read rather than treated as an exit: fully opaque is
+// the fill, and a genuinely translucent one is a derived colour this guard does not
+// reason about, the same way it does not reason about `bg-mint-soft`.
+//
+// This is deliberately NOT the CSS half's rule, where a wash needs a written pin. The
+// asymmetry is in the inventory, not in the principle. modelHubSurface.css has one
+// translucent accent paint, so pinning it costs one line; `src/` has ~370
+// `bg-<accent>/10`-style washes sitting behind content. 370 pins would not make
+// anything legible, it would make this guard something people route around, and a
+// guard that is routed around checks nothing. The two cases also fail differently:
+// a translucent mark is invisible in both themes, which whoever writes it sees
+// immediately, while an opaque one looks right in dark and goes illegible only in
+// light -- unseen, which is the whole reason this guard exists.
+const FULLY_OPAQUE_MODIFIER = /^\/(?:100|\[1\]|\[1\.0+\]|\[100%\])$/;
+
 // The Tailwind state the utility containing `index` is gated behind: `hover:`,
 // `md:hover:`, or '' for none. Scoped to the one utility rather than the class string,
 // so two utilities sharing a string can be compared. Any whitespace separates
@@ -786,7 +839,7 @@ const labelCovers = (haystack, label, fillPrefix) => {
 
 function assertUnlabeledFillsTakeTheInk(root) {
   const bare = new RegExp(
-    `\\b(?:${MARK_UTILITIES.join('|')})-(${[...FILL_LABEL.keys(), 'pink'].join('|')})(?![\\w-/])`,
+    `\\b(?:${MARK_UTILITIES.join('|')})-(${[...FILL_LABEL.keys(), 'pink'].join('|')})(?![\\w-])(/[\\w.%[\\]]+)?`,
     'g',
   );
   const found = new Map();
@@ -804,6 +857,10 @@ function assertUnlabeledFillsTakeTheInk(root) {
     for (const { text, owner, scope, line } of classStrings(file, fs.readFileSync(file, 'utf8'))) {
       for (const match of text.matchAll(bare)) {
         const accent = match[1];
+        const modifier = match[2];
+        if (modifier && !FULLY_OPAQUE_MODIFIER.test(modifier)) {
+          continue;
+        }
         const label = FILL_LABEL.get(accent);
         const fillPrefix = variantPrefix(text, match.index);
         if (label && (labelCovers(text, `-${label}`, fillPrefix)

--- a/ui/scripts/validate-theme.mjs
+++ b/ui/scripts/validate-theme.mjs
@@ -1,6 +1,8 @@
 import fs from 'node:fs';
+import path from 'node:path';
 import vm from 'node:vm';
 import postcss from 'postcss';
+import ts from 'typescript';
 
 const html = fs.readFileSync('index.html', 'utf8');
 const css = fs.readFileSync('src/index.css', 'utf8');
@@ -495,11 +497,28 @@ function assertMarksTakeTheInk(source, name) {
 assertMarksTakeTheInk(modelHubCss, 'model hub');
 
 // The same rule in Tailwind: `bg-mint` on a 6px dot is a mark, `bg-mint` under a
-// `text-primary-foreground` label is a fill. Only the label tells them apart, and it
-// is regularly a prop or two away (an icon tile passes `iconTileClassName="bg-gold"`
-// and `iconClassName="text-gold-foreground"` on adjacent lines), so the label is
-// looked for in a window rather than on the same line. A per-line check produced
-// three false positives on exactly that shape.
+// `text-primary-foreground` label is a fill. Only the label tells them apart, so the
+// question is where a label counts as belonging to this fill. Two places do, and they
+// are the two the code actually uses:
+//
+//   1. the same class string -- `bg-mint text-primary-foreground` (21 of the 23
+//      labelled fills in src/, including every cva variant in button-variants.ts)
+//   2. a sibling attribute or property of the same node -- an icon tile passes
+//      `iconTileClassName="bg-gold"` beside `iconClassName="text-gold-foreground"`,
+//      and agentBackends.ts pairs `tileCls`/`iconCls` in one object literal
+//
+// Both scopes come from the TypeScript AST, so "belongs to" is a parent node rather
+// than a line count. Proximity is not evidence: an earlier draft looked in a +/-4 line
+// window and would accept a `text-primary-foreground` button standing next to an
+// unrelated `bg-mint` dot as proof the dot was labelled -- passing exactly the mark it
+// exists to catch. Reading literals off the AST also drops the need to blank comments
+// (a class name in JSDoc is comment trivia, never a string literal) and makes
+// multi-line class strings work without a hand-rolled quote scanner.
+//
+// A label on a child element (`<div className="bg-mint"><span
+// className="text-primary-foreground">`) is deliberately NOT a scope: no site needs it
+// today, and widening to a subtree would re-admit an unrelated nested label. Such a
+// site fails and is either merged into one class string or pinned below.
 //
 // mint/cyan/pink declare no -foreground of their own; they print --primary-foreground
 // and --accent-foreground, the aliases SEMANTIC_FILL_ALIASES keeps equal. pink has no
@@ -513,7 +532,6 @@ const FILL_LABEL = new Map([
   ['violet', 'violet-foreground'],
   ['gold', 'gold-foreground'],
 ]);
-const LABEL_WINDOW = 4;
 
 // Control chrome the owner has not ruled on: switch/toggle tracks and progress/step
 // bars, where the fill is a large shape whose state is already carried by knob
@@ -536,48 +554,86 @@ const ACCEPTED_BARE_FILLS = new Map([
   ['src/components/visual/EmbeddedConfigShell.tsx --mint', { marks: 1, reason: STEP_DOTS }],
 ]);
 
+// Every class string in a file, paired with the scope a sibling label may live in:
+// the JSX attribute list or the object literal the string sits in, else the string
+// itself. A template literal counts as one class string -- its static head and spans
+// are one `className`, and the interpolations are visited separately.
+function classStrings(file, source) {
+  const ast = ts.createSourceFile(file, source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
+  const strings = [];
+
+  const scopeOf = (node) => {
+    const parent = node.parent;
+    if (ts.isJsxAttribute(parent) || (ts.isJsxExpression(parent) && ts.isJsxAttribute(parent.parent))) {
+      return ts.isJsxAttribute(parent) ? parent.parent : parent.parent.parent;
+    }
+    if (ts.isPropertyAssignment(parent) && ts.isObjectLiteralExpression(parent.parent)) {
+      return parent.parent;
+    }
+    return node;
+  };
+
+  const record = (node, text) => {
+    strings.push({
+      text,
+      scope: scopeOf(node).getText(ast),
+      line: ast.getLineAndCharacterOfPosition(node.getStart(ast)).line + 1,
+    });
+  };
+
+  const visit = (node) => {
+    if (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)) {
+      record(node, node.text);
+    } else if (ts.isTemplateExpression(node)) {
+      record(node, [node.head.text, ...node.templateSpans.map((span) => span.literal.text)].join(' '));
+      node.templateSpans.forEach((span) => visit(span.expression));
+      return;
+    }
+    ts.forEachChild(node, visit);
+  };
+
+  visit(ast);
+  return strings;
+}
+
 function assertUnlabeledFillsTakeTheInk(root) {
   const bare = new RegExp(`\\bbg-(${[...FILL_LABEL.keys(), 'pink'].join('|')})(?![\\w-/])`, 'g');
   const found = new Map();
 
+  // readdirSync(recursive) yields platform separators, so on Windows an entry arrives
+  // as `components\ui\switch.tsx`. Normalise before it becomes a lookup key, or every
+  // pin below misses and validate:theme fails on an unchanged checkout.
   const files = fs.readdirSync(root, { recursive: true })
+    .map((entry) => entry.split(path.sep).join('/'))
     .filter((entry) => /\.tsx?$/.test(entry))
     .map((entry) => `${root}/${entry}`)
     .sort();
 
   for (const file of files) {
-    // A class name inside a comment paints nothing -- BackendRuntimeCard's JSDoc
-    // names ``"bg-gold"`` to document what callers pass -- so comment-only lines are
-    // blanked before the scan. Blanked for the label window too, and not merely
-    // skipped as marks: prose describing a pairing is not evidence that the pairing
-    // is rendered, and letting it stand in would excuse the next real mark beside it.
-    const lines = fs.readFileSync(file, 'utf8').split('\n')
-      .map((line) => (/^\s*(\*|\/\/|\/\*)/.test(line) ? '' : line));
-    lines.forEach((line, index) => {
-      for (const match of line.matchAll(bare)) {
+    for (const { text, scope, line } of classStrings(file, fs.readFileSync(file, 'utf8'))) {
+      for (const match of text.matchAll(bare)) {
         const accent = match[1];
         const label = FILL_LABEL.get(accent);
-        const window = lines
-          .slice(Math.max(0, index - LABEL_WINDOW), index + LABEL_WINDOW + 1)
-          .join('\n');
-        if (label && window.includes(`-${label}`)) {
+        if (label && (text.includes(`-${label}`) || scope.includes(`-${label}`))) {
           continue;
         }
 
         const key = `${file} --${accent}`;
         const entry = found.get(key) ?? { count: 0, lines: [] };
-        found.set(key, { count: entry.count + 1, lines: [...entry.lines, index + 1] });
+        found.set(key, { count: entry.count + 1, lines: [...entry.lines, line] });
       }
-    });
+    }
   }
 
   const unpinned = [...found.entries()].filter(([key]) => !ACCEPTED_BARE_FILLS.has(key));
   if (unpinned.length > 0) {
     throw new Error(
-      'These paint a bare accent fill with no paired *-foreground label anywhere near it, so they are '
-      + 'marks read straight off the canvas and must use the -ink token (bg-mint-ink, bg-gold-ink, ...):\n'
+      'These paint a bare accent fill with no paired *-foreground label in the same class string or on '
+      + 'a sibling attribute/property, so they are marks read straight off the canvas and must use the '
+      + '-ink token (bg-mint-ink, bg-gold-ink, ...):\n'
       + unpinned.map(([key, { lines }]) => `  ${key} at line ${lines.join(', ')}`).join('\n')
-      + '\nIf a mark is deliberately exempt, pin it in ACCEPTED_BARE_FILLS with its reason.',
+      + '\nIf the label is real but lives on a child element, move it into the same class string. '
+      + 'If a mark is deliberately exempt, pin it in ACCEPTED_BARE_FILLS with its reason.',
     );
   }
 

--- a/ui/scripts/validate-theme.mjs
+++ b/ui/scripts/validate-theme.mjs
@@ -473,6 +473,37 @@ assertAccentAliasesKeepTheirTokenName(css);
 const ACCENT_NAMES = ACCENT_FILLS.map((fill) => fill.slice(2));
 const BARE_ACCENT_VAR = new RegExp(`var\\(\\s*--(${ACCENT_NAMES.join('|')})\\s*\\)`);
 
+// Naming color-mix() is not proof of translucency, and that is the whole exemption.
+// `color-mix(in srgb, var(--mint) 100%, transparent)` mentions both `color-mix` and
+// `transparent` and still renders as bare mint at 2.35:1 on the light canvas -- exactly
+// the mark this assertion exists to reject. So resolve the accent's share and exempt
+// only what a wash actually is.
+//
+// A mix shape this pattern cannot read fails loudly rather than inheriting the old
+// free pass: an unmeasured mix is not a proven-translucent one. Extending the pattern
+// is the correct response to that failure. Only the accent's own share is resolved --
+// mixing an accent into an opaque colour keeps its ratio, so such a shape is a mark
+// and must say so here rather than be waved through.
+const ACCENT_SHARE_OF_MIX = /^color-mix\(\s*in\s+[\w-]+\s*,\s*[^,]+?\s+([\d.]+)%\s*,\s*transparent\s*\)$/i;
+
+function accentShare(name, decl, value) {
+  if (!value.includes('color-mix')) {
+    return 1;
+  }
+
+  const mix = ACCENT_SHARE_OF_MIX.exec(value);
+  if (!mix) {
+    throw new Error(
+      `${name}: ${decl.selector ?? decl.parent?.selector} paints ${decl.prop} with ${value}, a `
+      + 'color-mix() this guard cannot resolve to an alpha. Only a mix proven translucent is exempt '
+      + 'from the mark rule, because an opaque mix renders as the bare fill -- teach '
+      + 'ACCENT_SHARE_OF_MIX this shape instead of letting an unmeasured mix through.',
+    );
+  }
+
+  return Number.parseFloat(mix[1]) / 100;
+}
+
 function assertMarksTakeTheInk(source, name) {
   postcss.parse(source).walkDecls((decl) => {
     if (decl.prop !== 'stroke' && decl.prop !== 'fill') {
@@ -480,7 +511,7 @@ function assertMarksTakeTheInk(source, name) {
     }
 
     const value = normalizeCssValue(decl.value);
-    if (value.includes('color-mix') || value.includes('transparent') || !BARE_ACCENT_VAR.test(value)) {
+    if (!BARE_ACCENT_VAR.test(value) || accentShare(name, decl, value) < 1) {
       return;
     }
 
@@ -535,31 +566,64 @@ const FILL_LABEL = new Map([
 
 // Control chrome the owner has not ruled on: switch/toggle tracks and progress/step
 // bars, where the fill is a large shape whose state is already carried by knob
-// position or bar length rather than by the colour being legible on its own. They
-// are pinned rather than skipped, and pinned by count, so removing one goes stale
-// loudly and adding a sixth bare mark to a listed file still fails. Repainting them
-// is a design.pen decision, not a guard decision.
+// position or bar length rather than by the colour being legible on its own.
+// Repainting them is a design.pen decision, not a guard decision.
+//
+// Each is pinned to the construct it was granted for -- the owning component plus the
+// exact class string carrying the mark -- not to a per-file tally. A count treats every
+// same-accent mark in a file as interchangeable: delete the pinned track, add an
+// unrelated bare dot, and `1` still reads as `1`, so the exemption transfers in silence
+// to a mark nobody ruled on. A signature cannot transfer. It also survives edits above
+// it and reformatting, which a line number would not, and reads as documentation of
+// what is actually exempt.
 const TRACK = 'toggle track: state is carried by knob position, not by the fill reading on its own';
 const STEP_DOTS = 'wizard step dots: progress is carried by how many are filled, not by one dot reading on its own';
+const STEP_DOT = 'bg-mint shadow-[0_0_8px_rgba(91,255,160,0.6)]';
 const ACCEPTED_BARE_FILLS = new Map([
-  ['src/components/ui/switch.tsx --primary', { marks: 1, reason: TRACK }],
-  ['src/components/settings/SettingsPrimitives.tsx --mint', { marks: 1, reason: TRACK }],
-  ['src/components/steps/PlatformSelection.tsx --mint', { marks: 1, reason: TRACK }],
-  ['src/components/visual/ProgressBar.tsx --mint', { marks: 1, reason: 'progress bar: progress is carried by bar length' }],
-  ['src/components/steps/SlackConfig.tsx --mint', { marks: 1, reason: STEP_DOTS }],
-  ['src/components/steps/TelegramConfig.tsx --mint', { marks: 1, reason: STEP_DOTS }],
-  ['src/components/steps/DiscordConfig.tsx --mint', { marks: 1, reason: STEP_DOTS }],
-  ['src/components/steps/LarkConfig.tsx --mint', { marks: 1, reason: STEP_DOTS }],
-  ['src/components/steps/WeChatConfig.tsx --mint', { marks: 1, reason: STEP_DOTS }],
-  ['src/components/visual/EmbeddedConfigShell.tsx --mint', { marks: 1, reason: STEP_DOTS }],
+  ['src/components/ui/switch.tsx --primary', { reason: TRACK, marks: ['Switch: bg-primary'] }],
+  ['src/components/settings/SettingsPrimitives.tsx --mint', { reason: TRACK, marks: ['ToggleSwitch: border-mint/50 bg-mint shadow-[0_0_12px_-2px_rgba(91,255,160,0.6)]'] }],
+  ['src/components/steps/PlatformSelection.tsx --mint', { reason: TRACK, marks: ['CredentialToggle: bg-mint'] }],
+  ['src/components/visual/ProgressBar.tsx --mint', { reason: 'progress bar: progress is carried by bar length', marks: ['ProgressBar: bg-mint shadow-[0_0_12px_rgba(91,255,160,0.45)]'] }],
+  ['src/components/steps/SlackConfig.tsx --mint', { reason: STEP_DOTS, marks: [`SlackConfig: ${STEP_DOT}`] }],
+  ['src/components/steps/TelegramConfig.tsx --mint', { reason: STEP_DOTS, marks: [`TelegramConfig: ${STEP_DOT}`] }],
+  ['src/components/steps/DiscordConfig.tsx --mint', { reason: STEP_DOTS, marks: [`DiscordConfig: ${STEP_DOT}`] }],
+  ['src/components/steps/LarkConfig.tsx --mint', { reason: STEP_DOTS, marks: [`LarkConfig: ${STEP_DOT}`] }],
+  ['src/components/steps/WeChatConfig.tsx --mint', { reason: STEP_DOTS, marks: [`WeChatConfig: ${STEP_DOT}`] }],
+  ['src/components/visual/EmbeddedConfigShell.tsx --mint', { reason: STEP_DOTS, marks: [`EmbeddedConfigShell: ${STEP_DOT}`] }],
 ]);
+
+// What an exemption is bound to. Kept as one string so the pins above read as the
+// construct they excuse.
+const markSignature = (owner, text) => `${owner}: ${text}`;
 
 // Every class string in a file, paired with the scope a sibling label may live in:
 // the JSX attribute list or the object literal the string sits in, else the string
 // itself. A template literal counts as one class string -- its static head and spans
 // are one `className`, and the interpolations are visited separately.
+//
+// The dialect comes from the extension. A .ts file forced through the TSX parser reads a
+// generic arrow (`const f = <T>(x: T) => x`) as an unterminated JSX element: nine files in
+// src/ do that today, and asyncLifetime.ts surfaced 1 of its 53 string literals, so an
+// unlabeled bg-mint anywhere past the first generic would have passed unseen.
+//
+// Parse diagnostics are raised rather than ignored, because ignoring them is what made
+// that invisible: a file the parser cannot read yields no class strings, which is
+// indistinguishable from a clean file. The scan must not be able to go blind quietly.
 function classStrings(file, source) {
-  const ast = ts.createSourceFile(file, source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
+  const tsx = file.endsWith('.tsx');
+  const ast = ts.createSourceFile(
+    file, source, ts.ScriptTarget.Latest, true, tsx ? ts.ScriptKind.TSX : ts.ScriptKind.TS,
+  );
+  const [failure] = ast.parseDiagnostics;
+  if (failure) {
+    const { line } = ast.getLineAndCharacterOfPosition(failure.start);
+    throw new Error(
+      `${file}:${line + 1} does not parse as ${tsx ? 'TSX' : 'TypeScript'}: `
+      + `${ts.flattenDiagnosticMessageText(failure.messageText, ' ')}\n`
+      + 'A file the parser cannot read contributes no class strings, so every accent mark in it '
+      + 'would skip this check unseen. Fix the syntax, or give this scan the dialect it needs.',
+    );
+  }
   const strings = [];
 
   const scopeOf = (node) => {
@@ -573,9 +637,27 @@ function classStrings(file, source) {
     return node;
   };
 
+  // The nearest named declaration around a class string -- the component or helper the
+  // mark lives in. Anonymous arrows and JSX nodes in between are skipped, so a mark
+  // inside a `.map()` callback still reports the component. Half of what a pinned
+  // exemption is bound to; see markSignature.
+  const ownerOf = (node) => {
+    for (let current = node; current; current = current.parent) {
+      if (ts.isVariableDeclaration(current) && ts.isIdentifier(current.name)) {
+        return current.name.text;
+      }
+      if ((ts.isFunctionDeclaration(current) || ts.isClassDeclaration(current)
+        || ts.isMethodDeclaration(current)) && current.name) {
+        return current.name.getText(ast);
+      }
+    }
+    return '(module)';
+  };
+
   const record = (node, text) => {
     strings.push({
       text,
+      owner: ownerOf(node),
       scope: scopeOf(node).getText(ast),
       line: ast.getLineAndCharacterOfPosition(node.getStart(ast)).line + 1,
     });
@@ -610,7 +692,7 @@ function assertUnlabeledFillsTakeTheInk(root) {
     .sort();
 
   for (const file of files) {
-    for (const { text, scope, line } of classStrings(file, fs.readFileSync(file, 'utf8'))) {
+    for (const { text, owner, scope, line } of classStrings(file, fs.readFileSync(file, 'utf8'))) {
       for (const match of text.matchAll(bare)) {
         const accent = match[1];
         const label = FILL_LABEL.get(accent);
@@ -619,8 +701,7 @@ function assertUnlabeledFillsTakeTheInk(root) {
         }
 
         const key = `${file} --${accent}`;
-        const entry = found.get(key) ?? { count: 0, lines: [] };
-        found.set(key, { count: entry.count + 1, lines: [...entry.lines, line] });
+        found.set(key, [...found.get(key) ?? [], { signature: markSignature(owner, text), line }]);
       }
     }
   }
@@ -631,19 +712,23 @@ function assertUnlabeledFillsTakeTheInk(root) {
       'These paint a bare accent fill with no paired *-foreground label in the same class string or on '
       + 'a sibling attribute/property, so they are marks read straight off the canvas and must use the '
       + '-ink token (bg-mint-ink, bg-gold-ink, ...):\n'
-      + unpinned.map(([key, { lines }]) => `  ${key} at line ${lines.join(', ')}`).join('\n')
+      + unpinned.map(([key, marks]) => marks.map(({ signature, line }) => `  ${key} at line ${line}\n    ${signature}`).join('\n')).join('\n')
       + '\nIf the label is real but lives on a child element, move it into the same class string. '
       + 'If a mark is deliberately exempt, pin it in ACCEPTED_BARE_FILLS with its reason.',
     );
   }
 
   for (const [key, { reason, marks }] of ACCEPTED_BARE_FILLS) {
-    const actual = found.get(key)?.count ?? 0;
-    if (actual !== marks) {
+    const actual = (found.get(key) ?? []).map(({ signature }) => signature).sort();
+    const pinned = [...marks].sort();
+    if (actual.length !== pinned.length || pinned.some((signature, index) => signature !== actual[index])) {
       throw new Error(
-        `ACCEPTED_BARE_FILLS pins ${key} at ${marks} unlabeled mark(s) (${reason}) but found ${actual}. `
-        + 'An exemption covers the marks it was granted for, not whatever appears under the same key later '
-        + '-- re-count it here once the change is intended.',
+        `ACCEPTED_BARE_FILLS pins ${key} (${reason}) to:\n`
+        + pinned.map((signature) => `    ${signature}`).join('\n')
+        + '\n  but src/ now carries:\n'
+        + (actual.length > 0 ? actual.map((signature) => `    ${signature}`).join('\n') : '    (nothing)')
+        + '\n  An exemption covers the construct it was granted for, not whatever later appears under the '
+        + 'same file and accent -- re-pin it here once the change is intended.',
       );
     }
   }

--- a/ui/scripts/validate-theme.mjs
+++ b/ui/scripts/validate-theme.mjs
@@ -449,6 +449,151 @@ function assertAccentAliasesKeepTheirTokenName(source) {
 }
 
 assertAccentAliasesKeepTheirTokenName(css);
+
+// Which accent token a mark reaches for is not fill-versus-text. It is whether the
+// accent has a LABEL printed on it. A fill or hairline may stay vivid because it is
+// read through the paired --X-foreground sitting on it; anything read directly
+// against the canvas -- text, an icon, a wire, an end node, a status dot -- carries
+// no label and so must take --X-ink. The two assertions below cover the two places
+// that distinction gets lost: a CSS rule painting a wire, and a Tailwind utility
+// painting a dot.
+//
+// Both are needed because neither the ink nor the fill assertion above can see this.
+// They check that each token is legible against the surface it claims; they cannot
+// know that .model-hub-wire--gateway chose the fill. That is how the supply graph
+// shipped 2px --mint strokes at 2.35:1 on the light canvas with every token guard
+// passing. Light is where it bites: --mint reads 2.35:1 on --background and --gold
+// 2.95:1, both under the 3:1 non-text floor, while their inks clear it. In dark each
+// accent's ink IS its fill, so none of this moves a dark pixel.
+
+// A translucent value is a wash, not a mark -- it has no ratio of its own, exactly as
+// requireMeasurableColor says -- so only opaque declarations are held to the rule.
+const ACCENT_NAMES = ACCENT_FILLS.map((fill) => fill.slice(2));
+const BARE_ACCENT_VAR = new RegExp(`var\\(\\s*--(${ACCENT_NAMES.join('|')})\\s*\\)`);
+
+function assertMarksTakeTheInk(source, name) {
+  postcss.parse(source).walkDecls((decl) => {
+    if (decl.prop !== 'stroke' && decl.prop !== 'fill') {
+      return;
+    }
+
+    const value = normalizeCssValue(decl.value);
+    if (value.includes('color-mix') || value.includes('transparent') || !BARE_ACCENT_VAR.test(value)) {
+      return;
+    }
+
+    const accent = BARE_ACCENT_VAR.exec(value)[1];
+    throw new Error(
+      `${name}: ${decl.selector ?? decl.parent?.selector} paints ${decl.prop} with var(--${accent}), the fill. `
+      + 'A stroke or an SVG fill is a mark on the bare canvas -- no label is printed on it, so the '
+      + `pairing that licenses a vivid fill does not apply. Use var(--${accent}-ink), which is the same `
+      + 'value in dark and a legible one in light.',
+    );
+  });
+}
+
+assertMarksTakeTheInk(modelHubCss, 'model hub');
+
+// The same rule in Tailwind: `bg-mint` on a 6px dot is a mark, `bg-mint` under a
+// `text-primary-foreground` label is a fill. Only the label tells them apart, and it
+// is regularly a prop or two away (an icon tile passes `iconTileClassName="bg-gold"`
+// and `iconClassName="text-gold-foreground"` on adjacent lines), so the label is
+// looked for in a window rather than on the same line. A per-line check produced
+// three false positives on exactly that shape.
+//
+// mint/cyan/pink declare no -foreground of their own; they print --primary-foreground
+// and --accent-foreground, the aliases SEMANTIC_FILL_ALIASES keeps equal. pink has no
+// label token at all, so a bare bg-pink can only ever be an unlabeled mark.
+const FILL_LABEL = new Map([
+  ['primary', 'primary-foreground'],
+  ['mint', 'primary-foreground'],
+  ['accent', 'accent-foreground'],
+  ['cyan', 'accent-foreground'],
+  ['destructive', 'destructive-foreground'],
+  ['violet', 'violet-foreground'],
+  ['gold', 'gold-foreground'],
+]);
+const LABEL_WINDOW = 4;
+
+// Control chrome the owner has not ruled on: switch/toggle tracks and progress/step
+// bars, where the fill is a large shape whose state is already carried by knob
+// position or bar length rather than by the colour being legible on its own. They
+// are pinned rather than skipped, and pinned by count, so removing one goes stale
+// loudly and adding a sixth bare mark to a listed file still fails. Repainting them
+// is a design.pen decision, not a guard decision.
+const TRACK = 'toggle track: state is carried by knob position, not by the fill reading on its own';
+const STEP_DOTS = 'wizard step dots: progress is carried by how many are filled, not by one dot reading on its own';
+const ACCEPTED_BARE_FILLS = new Map([
+  ['src/components/ui/switch.tsx --primary', { marks: 1, reason: TRACK }],
+  ['src/components/settings/SettingsPrimitives.tsx --mint', { marks: 1, reason: TRACK }],
+  ['src/components/steps/PlatformSelection.tsx --mint', { marks: 1, reason: TRACK }],
+  ['src/components/visual/ProgressBar.tsx --mint', { marks: 1, reason: 'progress bar: progress is carried by bar length' }],
+  ['src/components/steps/SlackConfig.tsx --mint', { marks: 1, reason: STEP_DOTS }],
+  ['src/components/steps/TelegramConfig.tsx --mint', { marks: 1, reason: STEP_DOTS }],
+  ['src/components/steps/DiscordConfig.tsx --mint', { marks: 1, reason: STEP_DOTS }],
+  ['src/components/steps/LarkConfig.tsx --mint', { marks: 1, reason: STEP_DOTS }],
+  ['src/components/steps/WeChatConfig.tsx --mint', { marks: 1, reason: STEP_DOTS }],
+  ['src/components/visual/EmbeddedConfigShell.tsx --mint', { marks: 1, reason: STEP_DOTS }],
+]);
+
+function assertUnlabeledFillsTakeTheInk(root) {
+  const bare = new RegExp(`\\bbg-(${[...FILL_LABEL.keys(), 'pink'].join('|')})(?![\\w-/])`, 'g');
+  const found = new Map();
+
+  const files = fs.readdirSync(root, { recursive: true })
+    .filter((entry) => /\.tsx?$/.test(entry))
+    .map((entry) => `${root}/${entry}`)
+    .sort();
+
+  for (const file of files) {
+    // A class name inside a comment paints nothing -- BackendRuntimeCard's JSDoc
+    // names ``"bg-gold"`` to document what callers pass -- so comment-only lines are
+    // blanked before the scan. Blanked for the label window too, and not merely
+    // skipped as marks: prose describing a pairing is not evidence that the pairing
+    // is rendered, and letting it stand in would excuse the next real mark beside it.
+    const lines = fs.readFileSync(file, 'utf8').split('\n')
+      .map((line) => (/^\s*(\*|\/\/|\/\*)/.test(line) ? '' : line));
+    lines.forEach((line, index) => {
+      for (const match of line.matchAll(bare)) {
+        const accent = match[1];
+        const label = FILL_LABEL.get(accent);
+        const window = lines
+          .slice(Math.max(0, index - LABEL_WINDOW), index + LABEL_WINDOW + 1)
+          .join('\n');
+        if (label && window.includes(`-${label}`)) {
+          continue;
+        }
+
+        const key = `${file} --${accent}`;
+        const entry = found.get(key) ?? { count: 0, lines: [] };
+        found.set(key, { count: entry.count + 1, lines: [...entry.lines, index + 1] });
+      }
+    });
+  }
+
+  const unpinned = [...found.entries()].filter(([key]) => !ACCEPTED_BARE_FILLS.has(key));
+  if (unpinned.length > 0) {
+    throw new Error(
+      'These paint a bare accent fill with no paired *-foreground label anywhere near it, so they are '
+      + 'marks read straight off the canvas and must use the -ink token (bg-mint-ink, bg-gold-ink, ...):\n'
+      + unpinned.map(([key, { lines }]) => `  ${key} at line ${lines.join(', ')}`).join('\n')
+      + '\nIf a mark is deliberately exempt, pin it in ACCEPTED_BARE_FILLS with its reason.',
+    );
+  }
+
+  for (const [key, { reason, marks }] of ACCEPTED_BARE_FILLS) {
+    const actual = found.get(key)?.count ?? 0;
+    if (actual !== marks) {
+      throw new Error(
+        `ACCEPTED_BARE_FILLS pins ${key} at ${marks} unlabeled mark(s) (${reason}) but found ${actual}. `
+        + 'An exemption covers the marks it was granted for, not whatever appears under the same key later '
+        + '-- re-count it here once the change is intended.',
+      );
+    }
+  }
+}
+
+assertUnlabeledFillsTakeTheInk('src');
 assertEveryAcceptedPairStillExists();
 
 const modelHub = (options) => resolveThemeTokens({ ...options, source: modelHubCss });

--- a/ui/scripts/validate-theme.mjs
+++ b/ui/scripts/validate-theme.mjs
@@ -503,7 +503,19 @@ assertAccentAliasesKeepTheirTokenName(css);
 // around. So the scope is a decision with evidence under it, not an oversight.
 
 const ACCENT_NAMES = ACCENT_FILLS.map((fill) => fill.slice(2));
-const BARE_ACCENT_VAR = new RegExp(`var\\(\\s*--(${ACCENT_NAMES.join('|')})\\s*\\)`);
+
+// `var(--mint)` and `var(--mint, #10b981)` are the same paint. CSS reads the fallback only
+// when the name is undefined, and --mint ships in the theme, so the browser paints the
+// vivid accent either way and the fallback is decoration on the source. Requiring `)`
+// immediately after the name checked one spelling of the reference rather than the
+// reference.
+//
+// Closed with a boundary instead of by parsing the fallback. `(?=[,)])` asserts only that
+// the name ended here, which is the single thing this pattern has to get right -- it is
+// what separates --mint from --mint-ink. Parsing the argument would have to survive nested
+// parens (`var(--mint, rgb(0 0 0))`) and a second comma level, and every version of that
+// is another CSS parser living inside a lookahead.
+const BARE_ACCENT_VAR = new RegExp(`var\\(\\s*--(${ACCENT_NAMES.join('|')})\\s*(?=[,)])`);
 
 // A wash is not exempt because of what its value looks like. It is exempt because
 // someone decided this hairline is decoration, and wrote that down here.
@@ -940,8 +952,12 @@ const LABEL_UTILITIES = [...INK_UTILITIES]
 // pixel as `bg-mint`. An enumeration of opaque spellings can only ever be as complete as
 // whoever wrote it; a parsed number is complete by construction.
 //
-// Unparseable fails closed and counts as a mark: the alternative is exempting the one
-// spelling nobody predicted, which is the bug this replaces.
+// Unparseable returns null rather than a number, and the callers fail closed in opposite
+// directions: an unreadable mark must still be checked, an unreadable label must not license
+// one. Collapsing both onto 1 -- which is what "opaque" means -- reads as fail-closed and is
+// only half of one, because the same 1 that says "check this fill" also says "this label is
+// printed". That asymmetry is not hypothetical: reusing this number for the label is what
+// round 7 did, and it is exactly where the previous round's hole was.
 const markAlpha = (modifier) => {
   if (!modifier) {
     return 1;
@@ -950,7 +966,7 @@ const markAlpha = (modifier) => {
   const percent = raw.endsWith('%');
   const value = Number.parseFloat(percent ? raw.slice(0, -1) : raw);
   if (!Number.isFinite(value) || value < 0) {
-    return 1;
+    return null;
   }
   return percent || value > 1 ? value / 100 : value;
 };
@@ -967,6 +983,51 @@ const markAlpha = (modifier) => {
 // satisfy this file. The threshold is the honest instrument: one stated number, with the
 // parsed alpha reported in the error, instead of a list that silently grows a hole.
 const OPAQUE_ENOUGH = 0.9;
+
+// Does the alpha this guard read mean "check this as a fill"? Named and shared rather than
+// written inline at the scan, because a mutation sweep found the inline form untested: the
+// corpus below could see what the alphabet READ and not what the scan DECIDED, so flipping
+// this one condition to fail open passed everything. Same shape as the defect this round is
+// closing, one level down -- a rule with no single owner is a rule with no test.
+// The two differ in exactly one place -- what an unreadable alpha means -- and that is the
+// asymmetry worth having in one line where both can be seen at once: an alpha this guard
+// could not parse must still be checked as a fill, and must not be accepted as a label.
+const readsAsTheFill = (alpha) => alpha === null || alpha >= OPAQUE_ENOUGH;
+const printsTheLabel = (alpha) => alpha !== null && alpha >= OPAQUE_ENOUGH;
+
+// How a utility names an accent. Tailwind v4 admits four spellings that compile to the
+// same paint -- `bg-mint`, the custom-property shorthand `bg-(--mint)`, and the
+// arbitrary-value forms `bg-[var(--mint)]` and `bg-[--mint]` -- and this file was reading
+// the first one.
+//
+// One source, because the missing spellings were the symptom and this is the defect: "does
+// this text name accent X as paint, and how opaquely" was answered by three separate
+// patterns -- the mark scan, the var scan, and a substring search for the label -- so a
+// spelling only had to be missed by ONE of them to ship, and nothing made a new spelling
+// reach the other two. Three review rounds each found a different member of that set. A
+// shared alphabet is what turns the next spelling into one row instead of three edits, and
+// ACCENT_SPELLINGS below is what makes a broken row a failure instead of a silent hole.
+//
+// Deliberately loose about the wrapper. This alphabet decides only what gets CHECKED, so an
+// invented spelling costs a redundant check while a missing one ships an unlabeled fill --
+// the asymmetry says to over-match. The one place it must be exact is the end of the token:
+// `(?![\w-])` is why `bg-mint-ink` and `text-primary-foregroundish` are still different
+// words, and why matching the remedy this guard prints does not reject the fix.
+//
+// Contributes two groups, in order: the token, then the opacity modifier. The modifier is
+// read after the wrapper closes, because `bg-(--mint)/70` closes its bracket first.
+const accentTokenSource = (tokens) => (
+  `-(?:\\[var\\(\\s*|\\[|\\(\\s*)?(?:--)?(${tokens})(?![\\w-])(?:\\s*\\)|\\])*(/[\\w.%[\\]]+)?`
+);
+
+// Built per call, not shared: a `g` regex carries `lastIndex`, so one instance handed to
+// two scans would start the second one wherever the first stopped. The factory is what lets
+// the corpus test the pattern the scan actually uses rather than a copy of it.
+const accentMarkPattern = () => new RegExp(
+  `\\b(${[...MARK_UTILITIES, ...INK_UTILITIES.keys()].join('|')})`
+  + accentTokenSource([...FILL_LABEL.keys(), 'pink'].join('|')),
+  'g',
+);
 
 // The Tailwind state the utility containing `index` is gated behind: `hover:`,
 // `md:hover:`, or '' for none. Scoped to the one utility rather than the class string,
@@ -986,9 +1047,27 @@ const variantPrefix = (text, index) => {
 // unequal chain (label `hover:`, fill `md:hover:`) fails rather than being reasoned
 // about: no site writes one, and a guard should fail closed on a shape it cannot
 // prove -- the fix is to merge the two utilities into one string, or pin the mark.
-const labelCovers = (haystack, label, fillPrefix) => {
-  for (let at = haystack.indexOf(label); at !== -1; at = haystack.indexOf(label, at + 1)) {
-    const prefix = variantPrefix(haystack, at);
+// A label also has to BE a label, which a substring search cannot tell you.
+// `text-primary-foreground/0` is the right token, spelled completely, applying in the right
+// scope -- and invisible; `text-primary-foregroundish` is not the token at all. Both cleared
+// the mark. So the label is read through the same alphabet and the same alpha as the mark it
+// licenses: a pairing is a claim about contrast between two painted things, and something
+// unpainted cannot make it.
+//
+// One threshold serves both sides on purpose. A second number for labels would have to come
+// from somewhere -- white at 0.7 over vivid mint is still perfectly legible, so the honest
+// label threshold is not 0.9 -- and a number nobody can derive is how a tunable becomes a
+// hole to be argued down. At or above 0.9 a label is the label; below it, whether a
+// translucent label carries a vivid fill is a design.pen question, and the answer is a pin
+// with a reason rather than a threshold quietly lowered to admit it. Nothing live is
+// affected: all 23 label sites in src/ are bare.
+const labelCovers = (haystack, utility, label, fillPrefix) => {
+  const printed = new RegExp(`\\b${utility}${accentTokenSource(label)}`, 'g');
+  for (const match of haystack.matchAll(printed)) {
+    if (!printsTheLabel(markAlpha(match[2]))) {
+      continue;
+    }
+    const prefix = variantPrefix(haystack, match.index);
     if (prefix === '' || prefix === fillPrefix) {
       return true;
     }
@@ -1010,11 +1089,120 @@ function sourceFiles(root) {
     .sort();
 }
 
+// The alphabet's own test, run before any file is read. If the pattern the scans are about
+// to use has stopped recognising a spelling, that is a hole in this guard, and it should
+// fail here -- next to the row that names the spelling -- instead of quietly passing a tree
+// that contains one. Adding a spelling means adding a row, which is the point of there being
+// one alphabet at all.
+//
+// The negatives carry as much weight as the positives, and each was a real defect or a real
+// near-miss. `bg-mint-ink` is the remedy this guard prints, so matching it would reject the
+// fix. `bg-mint/10` is the wash exemption, and it is here as a number rather than as an
+// absence, because the bug it replaced was a `/` treated as an exit from the scan.
+// `text-primary-foreground` must not read as a bare `primary` mark -- that boundary broke
+// twice. `ring-mint` is the deliberate scope decision, not an oversight; the comment above
+// ACCENT_NAMES carries the count behind it.
+// Columns: the spelling, the accent it names (null for "not a mark"), the alpha this guard
+// reads, and whether that alpha reads as the fill. The last column is written out rather than
+// derived, so a flip in readsAsTheFill fails here instead of only in an out-of-tree probe.
+const ACCENT_SPELLINGS = [
+  ['bg-mint', 'mint', 1, true],
+  ['bg-mint/95', 'mint', 0.95, true],
+  ['bg-mint/[99%]', 'mint', 0.99, true],
+  ['bg-mint/[0.95]', 'mint', 0.95, true],
+  ['bg-mint/10', 'mint', 0.1, false],
+  ['bg-mint/[oops]', 'mint', null, true],
+  ['bg-(--mint)', 'mint', 1, true],
+  ['bg-(--mint)/10', 'mint', 0.1, false],
+  ['bg-(--mint)/[99%]', 'mint', 0.99, true],
+  ['bg-[var(--mint)]', 'mint', 1, true],
+  ['bg-[--mint]', 'mint', 1, true],
+  ['hover:bg-mint', 'mint', 1, true],
+  ['fill-cyan', 'cyan', 1, true],
+  ['stroke-gold', 'gold', 1, true],
+  ['text-violet', 'violet', 1, true],
+  ['caret-pink', 'pink', 1, true],
+  ['bg-mint-ink', null, null, null],
+  ['bg-mint-foreground', null, null, null],
+  ['text-primary-foreground', null, null, null],
+  ['bg-muted', null, null, null],
+  ['ring-mint', null, null, null],
+  ['auto-mint', null, null, null],
+];
+
+// The same list for the other operand. A label is only a label when it prints the token as
+// glyphs, opaquely, in a scope the fill also applies to -- so these rows are the three ways
+// that can be false, plus the spellings that make it true.
+const LABEL_SPELLINGS = [
+  ['bg-mint text-primary-foreground', true],
+  ['bg-mint text-primary-foreground/90', true],
+  ['bg-mint text-primary-foreground/[95%]', true],
+  ['bg-mint text-(--primary-foreground)', true],
+  ['bg-mint text-[var(--primary-foreground)]', true],
+  ['bg-mint text-primary-foreground/0', false],
+  ['bg-mint text-primary-foreground/50', false],
+  ['bg-mint text-primary-foregroundish', false],
+  ['bg-mint text-primary-foreground/[oops]', false],
+  ['bg-mint hover:text-primary-foreground', false],
+];
+
+// And the third operand. The var scan reads a CSS reference rather than a utility, so its
+// spellings are its own -- and it had no rows here until reverting its fix ran this corpus
+// green, which is the same defect one level up: a shared question with one operand left
+// outside the shared test. That is how round 6 shipped a measured mark next to an unmeasured
+// label, so the rule now is that every predicate answering "does this name an accent" owes
+// this file rows.
+const VAR_SPELLINGS = [
+  ['var(--mint)', 'mint'],
+  ['var(--mint, #10b981)', 'mint'],
+  ['var(--mint,#fff)', 'mint'],
+  ['var(--mint, rgb(0 0 0))', 'mint'],
+  ['var( --cyan )', 'cyan'],
+  ['var(--mint-ink)', null],
+  ['var(--mint-foreground)', null],
+  ['var(--mint-ink, #063)', null],
+];
+
+function assertAccentSpellingsAreCovered() {
+  for (const [text, accent, alpha, checked] of ACCENT_SPELLINGS) {
+    const read = [...text.matchAll(accentMarkPattern())].map((match) => {
+      const value = markAlpha(match[3]);
+      return [match[2], value, readsAsTheFill(value)];
+    });
+    const expected = accent === null ? [] : [[accent, alpha, checked]];
+    if (JSON.stringify(read) !== JSON.stringify(expected)) {
+      throw new Error(
+        `The accent alphabet reads "${text}" as ${JSON.stringify(read)}, expected ${JSON.stringify(expected)}.\n`
+        + 'ACCENT_SPELLINGS is the set of spellings this guard promises to see; a row that stops '
+        + 'holding is a hole in the scans below, not a stale expectation.',
+      );
+    }
+  }
+
+  for (const [text, labelled] of LABEL_SPELLINGS) {
+    if (labelCovers(text, 'text', 'primary-foreground', '') !== labelled) {
+      throw new Error(
+        `The label alphabet reads "${text}" as ${!labelled}, expected ${labelled}.\n`
+        + `A label counts only when it prints the token as glyphs at alpha ${OPAQUE_ENOUGH} or above, `
+        + 'in a scope the fill also applies to.',
+      );
+    }
+  }
+
+  for (const [text, accent] of VAR_SPELLINGS) {
+    const [, read = null] = text.match(BARE_ACCENT_VAR) ?? [];
+    if (read !== accent) {
+      throw new Error(
+        `The var alphabet reads "${text}" as ${JSON.stringify(read)}, expected ${JSON.stringify(accent)}.\n`
+        + 'A reference names the accent whatever follows the token, and names a different token when '
+        + 'the name continues -- --mint-ink is not --mint with a suffix.',
+      );
+    }
+  }
+}
+
 function assertUnlabeledFillsTakeTheInk(root) {
-  const bare = new RegExp(
-    `\\b(${[...MARK_UTILITIES, ...INK_UTILITIES.keys()].join('|')})-(${[...FILL_LABEL.keys(), 'pink'].join('|')})(?![\\w-])(/[\\w.%[\\]]+)?`,
-    'g',
-  );
+  const bare = accentMarkPattern();
   const found = new Map();
   const inkMarks = [];
 
@@ -1024,13 +1212,20 @@ function assertUnlabeledFillsTakeTheInk(root) {
         const utility = match[1];
         const accent = match[2];
         const modifier = match[3];
+        // Only a modifier this guard could READ exempts a wash. One it could not read is the
+        // spelling nobody predicted, so the mark stays in and the error says why.
         const alpha = markAlpha(modifier);
-        if (alpha < OPAQUE_ENOUGH) {
+        if (!readsAsTheFill(alpha)) {
           continue;
         }
         // Reported alongside the site: a `/[99%]` mark was written believing it was a
         // wash, so the number this guard read is the one fact that explains the failure.
-        const note = alpha < 1 ? ` (alpha ${alpha}, at or above ${OPAQUE_ENOUGH} reads as the fill)` : '';
+        let note = '';
+        if (alpha === null) {
+          note = ` (opacity modifier ${modifier} does not parse, so it is read as the fill)`;
+        } else if (alpha < 1) {
+          note = ` (alpha ${alpha}, at or above ${OPAQUE_ENOUGH} reads as the fill)`;
+        }
         // Ink takes no label and no pin, so it never reaches the pairing logic below.
         if (INK_UTILITIES.has(utility)) {
           inkMarks.push({ file, line, utility, accent, note, signature: markSignature(owner, text) });
@@ -1043,9 +1238,8 @@ function assertUnlabeledFillsTakeTheInk(root) {
         // named, so the label has to be carried by one of them.
         const label = FILL_LABEL.get(accent);
         const labelled = label !== undefined && LABEL_UTILITIES.some((ink) => {
-          const printed = `${ink}-${label}`;
           const fillPrefix = variantPrefix(text, match.index);
-          return labelCovers(text, printed, fillPrefix) || labelCovers(scope, printed, fillPrefix);
+          return labelCovers(text, ink, label, fillPrefix) || labelCovers(scope, ink, label, fillPrefix);
         });
         if (labelled) {
           continue;
@@ -1148,6 +1342,7 @@ function assertNoBareAccentVarInSource(root) {
   }
 }
 
+assertAccentSpellingsAreCovered();
 assertUnlabeledFillsTakeTheInk('src');
 assertNoBareAccentVarInSource('src');
 assertEveryAcceptedPairStillExists();

--- a/ui/src/components/AppShell.tsx
+++ b/ui/src/components/AppShell.tsx
@@ -685,7 +685,7 @@ export const AppShell: React.FC = () => {
                 <span
                   className={clsx(
                     'size-2 shrink-0 rounded-full',
-                    isRunning ? 'bg-mint shadow-[0_0_8px_rgba(91,255,160,0.9)]' : 'bg-muted'
+                    isRunning ? 'bg-mint-ink shadow-[0_0_8px_rgba(91,255,160,0.9)]' : 'bg-muted'
                   )}
                 />
                 {isRunning ? t('common.running') : t('common.stopped')}

--- a/ui/src/components/AppsLauncher.tsx
+++ b/ui/src/components/AppsLauncher.tsx
@@ -138,7 +138,7 @@ export const AppsLauncher: React.FC = () => {
         <LayoutGrid className="size-4 shrink-0 text-cyan-ink" />
         <span className="flex-1 whitespace-nowrap text-left">{t('apps.title')}</span>
         {pinned ? (
-          <Pin className="size-3.5 shrink-0 rotate-45 fill-cyan text-cyan-ink" />
+          <Pin className="size-3.5 shrink-0 rotate-45 fill-cyan-ink text-cyan-ink" />
         ) : (
           <ChevronUp className={clsx('size-3.5 shrink-0 text-muted transition-transform', !visible && 'rotate-180')} />
         )}

--- a/ui/src/components/Dashboard.tsx
+++ b/ui/src/components/Dashboard.tsx
@@ -318,7 +318,7 @@ export const Dashboard: React.FC = () => {
                 <span
                   className={clsx(
                     'size-1.5 rounded-full',
-                    isRunning ? 'bg-mint shadow-[0_0_8px_rgba(91,255,160,0.9)]' : 'bg-muted'
+                    isRunning ? 'bg-mint-ink shadow-[0_0_8px_rgba(91,255,160,0.9)]' : 'bg-muted'
                   )}
                 />
                 {isRunning ? t('dashboard.runningTitle') : t('dashboard.stoppedTitle')}

--- a/ui/src/components/InstallHint.tsx
+++ b/ui/src/components/InstallHint.tsx
@@ -64,7 +64,7 @@ export const InstallHint: React.FC = () => {
             aria-label={t('installHint.cta')}
             className="relative size-7 shrink-0 hover:bg-transparent"
           >
-            <span className="size-2.5 rounded-full bg-gold shadow-[0_0_8px_rgba(245,200,92,0.9)]" />
+            <span className="size-2.5 rounded-full bg-gold-ink shadow-[0_0_8px_rgba(245,200,92,0.9)]" />
             <span className="absolute inline-flex size-2.5 animate-ping rounded-full bg-gold/60" />
           </Button>
         </PopoverTrigger>

--- a/ui/src/components/ShowPagesPage.tsx
+++ b/ui/src/components/ShowPagesPage.tsx
@@ -44,8 +44,8 @@ const LABEL = 'font-mono text-[10px] font-bold uppercase tracking-[0.12em] text-
 // tile is now a letter avatar (hashed by session), so visibility reads from the
 // badge rather than a per-state icon.
 const STATUS: Record<Visibility, { badge: 'warning' | 'info' | 'secondary'; tone: SegmentedTone; dot: string }> = {
-  public: { badge: 'warning', tone: 'gold', dot: 'bg-gold' },
-  private: { badge: 'info', tone: 'cyan', dot: 'bg-cyan' },
+  public: { badge: 'warning', tone: 'gold', dot: 'bg-gold-ink' },
+  private: { badge: 'info', tone: 'cyan', dot: 'bg-cyan-ink' },
   offline: { badge: 'secondary', tone: 'muted', dot: 'bg-muted' },
 };
 

--- a/ui/src/components/VersionBadge.tsx
+++ b/ui/src/components/VersionBadge.tsx
@@ -134,7 +134,7 @@ export const VersionBadge: React.FC<{ openUpward?: boolean }> = ({ openUpward = 
         {isSourceBuild ? <GitCommitHorizontal size={12} /> : 'v'}
         {displayVersion}
         {hasUpdate && (
-          <span className="absolute -top-1 -right-1 size-2.5 rounded-full border-2 border-background bg-gold animate-pulse" />
+          <span className="absolute -top-1 -right-1 size-2.5 rounded-full border-2 border-background bg-gold-ink animate-pulse" />
         )}
       </button>
 

--- a/ui/src/components/settings/BackendLifecycleChip.tsx
+++ b/ui/src/components/settings/BackendLifecycleChip.tsx
@@ -43,10 +43,10 @@ const BADGE_VARIANT: Record<Visual, BadgeVariant> = {
 
 const DOT_STYLES: Record<Visual, string> = {
   disabled: 'bg-muted/60',
-  ready: 'bg-mint',
-  updating: 'bg-cyan animate-pulse',
-  update: 'bg-gold animate-pulse',
-  error: 'bg-destructive',
+  ready: 'bg-mint-ink',
+  updating: 'bg-cyan-ink animate-pulse',
+  update: 'bg-gold-ink animate-pulse',
+  error: 'bg-destructive-ink',
   loading: 'bg-muted/60',
 };
 

--- a/ui/src/components/settings/SettingsServicePage.tsx
+++ b/ui/src/components/settings/SettingsServicePage.tsx
@@ -191,7 +191,7 @@ export const SettingsServicePage: React.FC = () => {
             <span
               className={clsx(
                 'size-1.5 rounded-full',
-                isRunning ? 'bg-mint shadow-[0_0_8px_rgba(91,255,160,0.9)]' : 'bg-muted'
+                isRunning ? 'bg-mint-ink shadow-[0_0_8px_rgba(91,255,160,0.9)]' : 'bg-muted'
               )}
             />
             {isRunning ? t('common.running') : t('common.stopped')}

--- a/ui/src/components/settings/models/AgentCard.tsx
+++ b/ui/src/components/settings/models/AgentCard.tsx
@@ -122,11 +122,11 @@ const AgentModelCard: React.FC<{
       ? 'model-hub-ink-gold'
       : 'text-muted';
   const statusDot = switchFailed || health === 'interrupted'
-    ? 'bg-destructive'
+    ? 'bg-destructive-ink'
     : hasTakeover || health === 'degraded' || health === 'waiting'
-      ? 'bg-gold'
+      ? 'bg-gold-ink'
       : health === 'ok' && agent.mode === 'hub'
-        ? 'bg-mint'
+        ? 'bg-mint-ink'
         : 'bg-muted';
   return (
     <section className="overflow-hidden rounded-xl border border-border bg-background" data-agent-backend={agent.backend}>

--- a/ui/src/components/settings/models/BackendSupplyModeCard.tsx
+++ b/ui/src/components/settings/models/BackendSupplyModeCard.tsx
@@ -26,7 +26,7 @@ const RadioDot: React.FC<{ selected: boolean }> = ({ selected }) => (
       selected ? 'border-mint' : 'border-border-strong',
     )}
   >
-    {selected && <span className="size-2 rounded-full bg-mint" />}
+    {selected && <span className="size-2 rounded-full bg-mint-ink" />}
   </span>
 );
 

--- a/ui/src/components/settings/models/OAuthConnectDialog.tsx
+++ b/ui/src/components/settings/models/OAuthConnectDialog.tsx
@@ -695,7 +695,7 @@ export const OAuthConnectDialog: React.FC<{
                         )}
                         aria-hidden
                       >
-                        {selected && <span className="size-2 rounded-full bg-mint" />}
+                        {selected && <span className="size-2 rounded-full bg-mint-ink" />}
                       </span>
                     )}
                     <span className="model-hub-add-sub-option-copy min-w-0 flex flex-1 flex-col">
@@ -870,7 +870,7 @@ export const OAuthConnectDialog: React.FC<{
           <div className="flex items-center justify-between gap-3 border-t border-border pt-4">
             {active ? (
               <span className="flex items-center gap-2 text-[12px] text-muted">
-                <span className="size-2 shrink-0 rounded-full bg-gold" aria-hidden />
+                <span className="size-2 shrink-0 rounded-full bg-gold-ink" aria-hidden />
                 {state === 'verifying'
                   ? t('settings.models.oauth.status.verifying')
                   : isDevice

--- a/ui/src/components/settings/models/SupplyGraph.tsx
+++ b/ui/src/components/settings/models/SupplyGraph.tsx
@@ -93,11 +93,11 @@ export const SupplyLegend: React.FC<{ relations: SupplyRelation[] }> = ({ relati
         {LEGEND_ORDER.filter((kind) => visible.has(kind)).map((kind) => (
           <span key={kind} className="flex items-center gap-[7px] font-medium">
             <span className={cn(`model-hub-legend-swatch model-hub-legend-swatch--${kind}`, {
-              'bg-cyan': kind === 'native',
-              'bg-mint': kind === 'gateway',
+              'bg-cyan-ink': kind === 'native',
+              'bg-mint-ink': kind === 'gateway',
               'bg-foreground/15': kind === 'connected_unused',
-              'bg-violet': kind === 'takeover',
-              'bg-gold': kind === 'unavailable',
+              'bg-violet-ink': kind === 'takeover',
+              'bg-gold-ink': kind === 'unavailable',
             })} />
             {t(`settings.models.legend.${LEGEND_COPY[kind]}`)}
           </span>

--- a/ui/src/components/settings/models/modelHubSurface.css
+++ b/ui/src/components/settings/models/modelHubSurface.css
@@ -18,10 +18,15 @@
  * dimmed toward transparency reads as "quiet" over black and "washed out" over
  * white; light re-anchors those on the full ink.
  *
- * Which accent token a rule reaches for follows index.css: a fill, hairline or
- * wire takes --X, and anything that renders as text or an icon takes --X-ink.
- * They are different values in light, where a vivid brand fill and a legible
- * label pull in opposite directions.
+ * Which accent token a rule reaches for follows index.css, and the split is not
+ * fill-versus-text — it is whether the accent has a label printed on it. A fill
+ * or hairline takes --X because it is read through the paired --X-foreground
+ * sitting on it. Everything read directly against the canvas takes --X-ink: text
+ * and icons, and equally a wire, an end node or a status dot, none of which
+ * carry a label to be read through. This file previously grouped wires with
+ * fills, which is how the supply graph shipped 2px --mint strokes at 2.35:1 on
+ * the light canvas. They are different values in light, where a vivid brand fill
+ * and a legible mark pull in opposite directions.
  */
 :root {
   /* Neutral wash channel: white over the dark frame. */
@@ -1316,16 +1321,25 @@
   stroke-linejoin: round;
 }
 
+/* Wires and their end nodes take the ink, not the fill. A wire carries no label,
+ * so nothing is printed on it and the fill/label pairing that licenses a vivid
+ * --X never applies: the only thing it is read against is the canvas. On light
+ * that is the difference between visible and not — a 2px --mint stroke sits at
+ * 2.35:1 on --background and --gold at 2.95:1, both under the 3:1 WCAG floor for
+ * non-text, while --mint-ink clears it. Dark is untouched: every accent's ink is
+ * the same value as its fill there, which is the whole reason the split exists.
+ * The glow follows the stroke so a light wire is not haloed in the colour it
+ * stopped being. See assertMarksTakeTheInk in scripts/validate-theme.mjs. */
 .model-hub-wire--native {
-  stroke: var(--cyan);
+  stroke: var(--cyan-ink);
   stroke-width: var(--model-hub-wire-active-width);
-  filter: drop-shadow(0 0 4px color-mix(in srgb, var(--cyan) 40%, transparent));
+  filter: drop-shadow(0 0 4px color-mix(in srgb, var(--cyan-ink) 40%, transparent));
 }
 
 .model-hub-wire--gateway {
-  stroke: var(--mint);
+  stroke: var(--mint-ink);
   stroke-width: var(--model-hub-wire-active-width);
-  filter: drop-shadow(0 0 4px color-mix(in srgb, var(--mint) 40%, transparent));
+  filter: drop-shadow(0 0 4px color-mix(in srgb, var(--mint-ink) 40%, transparent));
 }
 
 .model-hub-wire--connected_unused {
@@ -1334,13 +1348,13 @@
 }
 
 .model-hub-wire--takeover {
-  stroke: var(--violet);
+  stroke: var(--violet-ink);
   stroke-width: var(--model-hub-wire-active-width);
-  filter: drop-shadow(0 0 4px color-mix(in srgb, var(--violet) 40%, transparent));
+  filter: drop-shadow(0 0 4px color-mix(in srgb, var(--violet-ink) 40%, transparent));
 }
 
 .model-hub-wire--unavailable {
-  stroke: var(--gold);
+  stroke: var(--gold-ink);
   stroke-width: var(--model-hub-wire-muted-width);
 }
 
@@ -1348,15 +1362,15 @@
   r: calc(var(--model-hub-wire-node) / 2);
 }
 
-.model-hub-wire-node--native { fill: var(--cyan); }
-.model-hub-wire-node--gateway { fill: var(--mint); }
+.model-hub-wire-node--native { fill: var(--cyan-ink); }
+.model-hub-wire-node--gateway { fill: var(--mint-ink); }
 .model-hub-wire-node--connected_unused {
   fill: var(--background);
   stroke: color-mix(in srgb, var(--foreground) 15%, transparent);
   stroke-width: 1.25px;
 }
-.model-hub-wire-node--takeover { fill: var(--violet); }
-.model-hub-wire-node--unavailable { fill: var(--gold); }
+.model-hub-wire-node--takeover { fill: var(--violet-ink); }
+.model-hub-wire-node--unavailable { fill: var(--gold-ink); }
 
 .model-hub-rail-line {
   stroke: color-mix(in srgb, var(--mint) 20%, transparent);

--- a/ui/src/components/settings/models/sourceStatePresentation.test.ts
+++ b/ui/src/components/settings/models/sourceStatePresentation.test.ts
@@ -29,13 +29,13 @@ describe('sourceStatePresentation', () => {
     })).toMatchObject({
       key: 'settings.models.upstream.state.supplying',
       values: { backends: 'Claude Code, Codex' },
-      dotClass: 'bg-mint',
+      dotClass: 'bg-mint-ink',
     });
     expect(sourceStatePresentation(state('active'), 'detail', 'en', 0, {
       known: true,
       backends: ['Claude Code'],
       native: true,
-    })).toMatchObject({ key: 'settings.models.sourceDetail.status.inUse', dotClass: 'bg-mint' });
+    })).toMatchObject({ key: 'settings.models.sourceDetail.status.inUse', dotClass: 'bg-mint-ink' });
   });
 
   it('renders a future cooldown as a localized duration', () => {

--- a/ui/src/components/settings/models/sourceStatePresentation.ts
+++ b/ui/src/components/settings/models/sourceStatePresentation.ts
@@ -36,7 +36,7 @@ const STATUS_RULES: Readonly<Record<SourceStatus, Rule>> = {
       return {
         key: 'settings.models.upstream.state.unavailableDue',
         textClass: 'model-hub-ink-gold',
-        dotClass: 'bg-gold',
+        dotClass: 'bg-gold-ink',
       };
     }
     return {
@@ -45,7 +45,7 @@ const STATUS_RULES: Readonly<Record<SourceStatus, Rule>> = {
         delay: new Intl.NumberFormat(locale, { style: 'unit', unit: 'minute', unitDisplay: 'long' }).format(remainingMinutes),
       },
       textClass: 'model-hub-ink-gold',
-      dotClass: 'bg-gold',
+      dotClass: 'bg-gold-ink',
     };
   },
   needs_action: (state) => ({
@@ -53,12 +53,12 @@ const STATUS_RULES: Readonly<Record<SourceStatus, Rule>> = {
       ? NEEDS_ACTION_KEY[state.detail_key as NeedsActionDetailKey] ?? state.detail_key
       : 'settings.models.state.needs_action',
     textClass: 'text-destructive-ink',
-    dotClass: 'bg-destructive',
+    dotClass: 'bg-destructive-ink',
   }),
   error: () => ({
     key: 'settings.models.sourceDetail.status.error',
     textClass: 'text-destructive-ink',
-    dotClass: 'bg-destructive',
+    dotClass: 'bg-destructive-ink',
   }),
 };
 
@@ -77,7 +77,7 @@ export const sourceStatePresentation = (
       return {
         key: 'settings.models.sourceDetail.status.inUse',
         textClass: 'model-hub-ink-mint',
-        dotClass: 'bg-mint',
+        dotClass: 'bg-mint-ink',
       };
     }
     return {
@@ -88,7 +88,7 @@ export const sourceStatePresentation = (
         ? { backend: adoption.backends[0] }
         : { backends: adoption.backends.join(locale.startsWith('zh') ? '、' : ', ') },
       textClass: adoption.native ? 'text-cyan-ink' : 'model-hub-ink-mint',
-      dotClass: adoption.native ? 'bg-cyan' : 'bg-mint',
+      dotClass: adoption.native ? 'bg-cyan-ink' : 'bg-mint-ink',
     };
   }
   return STATUS_RULES[state.status](state, surface, locale, now);

--- a/ui/src/components/settings/models/vendorMeta.ts
+++ b/ui/src/components/settings/models/vendorMeta.ts
@@ -28,10 +28,10 @@ export const ACCENT_ICON: Record<Accent, string> = {
 // Status dot fill (composite pill · recent-switch list). Gold reserved for the
 // "entered metered" billing marker.
 export const ACCENT_DOT: Record<Accent, string> = {
-  mint: 'bg-mint',
-  gold: 'bg-gold',
-  cyan: 'bg-cyan',
-  violet: 'bg-violet',
+  mint: 'bg-mint-ink',
+  gold: 'bg-gold-ink',
+  cyan: 'bg-cyan-ink',
+  violet: 'bg-violet-ink',
   muted: 'bg-muted',
 };
 

--- a/ui/src/components/shared/RoutingConfigPanel.tsx
+++ b/ui/src/components/shared/RoutingConfigPanel.tsx
@@ -284,7 +284,7 @@ export const RoutingConfigPanel: React.FC<RoutingConfigPanelProps> = ({
                 <span
                   className={clsx(
                     'size-1.5 rounded-full',
-                    checked ? 'bg-mint shadow-[0_0_6px_rgba(91,255,160,0.7)]' : 'bg-muted/50'
+                    checked ? 'bg-mint-ink shadow-[0_0_6px_rgba(91,255,160,0.7)]' : 'bg-muted/50'
                   )}
                 />
                 {label}

--- a/ui/src/components/steps/ChannelList.tsx
+++ b/ui/src/components/steps/ChannelList.tsx
@@ -1666,7 +1666,7 @@ export const ChannelList: React.FC<ChannelListProps> = ({ data = {}, onNext, onB
                         <span
                           className={clsx(
                             'size-1.5 rounded-full',
-                            channelEnabled ? 'bg-mint shadow-[0_0_6px_rgba(91,255,160,0.7)]' : 'bg-muted'
+                            channelEnabled ? 'bg-mint-ink shadow-[0_0_6px_rgba(91,255,160,0.7)]' : 'bg-muted'
                           )}
                         />
                         {channelEnabled ? t('common.enabled') : t('common.disabled')}

--- a/ui/src/components/ui/directory-browser.tsx
+++ b/ui/src/components/ui/directory-browser.tsx
@@ -23,6 +23,7 @@ import { useTranslation } from 'react-i18next';
 import clsx from 'clsx';
 
 import { useApi } from '../../context/ApiContext';
+import { Button } from './button';
 import { errorMessage } from '@/lib/errorMessage';
 
 interface DirectoryBrowserProps {
@@ -594,19 +595,16 @@ export const DirectoryBrowser: React.FC<DirectoryBrowserProps> = ({
                   >
                     {t('directoryBrowser.cancel')}
                   </button>
-                  <button
+                  <Button
                     type="button"
+                    variant="default"
+                    size={null}
                     onClick={submitNewFolder}
                     disabled={!newFolderName.trim()}
-                    className={clsx(
-                      'rounded-md px-2.5 py-0.5 text-[11px] font-semibold transition',
-                      newFolderName.trim()
-                        ? 'bg-mint text-primary-foreground hover:bg-mint-hover'
-                        : 'bg-muted-soft text-muted',
-                    )}
+                    className="rounded-md px-2.5 py-0.5 text-[11px] font-semibold"
                   >
                     {t('directoryBrowser.newFolder')}
-                  </button>
+                  </Button>
                 </div>
                 {createError && <div className="pl-6 text-[11px] text-destructive-ink">{createError}</div>}
               </div>
@@ -635,20 +633,17 @@ export const DirectoryBrowser: React.FC<DirectoryBrowserProps> = ({
           >
             {t('directoryBrowser.cancel')}
           </button>
-          <button
+          <Button
             type="button"
+            variant="brand"
+            size={null}
             onClick={() => canConfirm && onSelect(currentPath)}
             disabled={!canConfirm}
-            className={clsx(
-              'flex items-center gap-1.5 rounded-md px-4 py-1.5 text-[12px] font-semibold transition',
-              canConfirm
-                ? 'bg-mint text-primary-foreground shadow-[0_0_14px_-4px_rgba(91,255,160,0.6)] hover:bg-mint-hover'
-                : 'cursor-not-allowed bg-muted-soft text-muted',
-            )}
+            className="gap-1.5 rounded-md px-4 py-1.5 text-[12px] font-semibold"
           >
             <Check className="size-3.5" />
             {t('directoryBrowser.select')}
-          </button>
+          </Button>
         </div>
       </div>
     </div>

--- a/ui/src/components/ui/vault-secret-form.tsx
+++ b/ui/src/components/ui/vault-secret-form.tsx
@@ -980,7 +980,7 @@ export const VaultSecretForm: React.FC<{
         <SlidersHorizontal className="size-3.5 text-muted" />
         <span className="flex-1 text-xs font-semibold text-foreground">{t('vaults.dialog.advanced')}</span>
         {!advancedOpen && (allowHosts.length > 0 || fetchAuthMode !== 'bearer') && (
-          <span className="size-1.5 rounded-full bg-mint" aria-hidden />
+          <span className="size-1.5 rounded-full bg-mint-ink" aria-hidden />
         )}
       </button>
       {advancedOpen && (

--- a/ui/src/components/visual/StatusPill.tsx
+++ b/ui/src/components/visual/StatusPill.tsx
@@ -10,9 +10,9 @@ interface StatusPillProps extends React.HTMLAttributes<HTMLSpanElement> {
 }
 
 const TONE_CLASSES: Record<Tone, { wrapper: string; dot: string }> = {
-  running: { wrapper: 'border-mint/40 bg-mint/[0.12] text-foreground', dot: 'bg-mint shadow-[0_0_8px_rgba(91,255,160,0.6)]' },
+  running: { wrapper: 'border-mint/40 bg-mint/[0.12] text-foreground', dot: 'bg-mint-ink shadow-[0_0_8px_rgba(91,255,160,0.6)]' },
   stopped: { wrapper: 'border-border-strong bg-surface-2 text-muted', dot: 'bg-muted' },
-  warning: { wrapper: 'border-gold/40 bg-gold/[0.12] text-gold-ink', dot: 'bg-gold' },
+  warning: { wrapper: 'border-gold/40 bg-gold/[0.12] text-gold-ink', dot: 'bg-gold-ink' },
   idle: { wrapper: 'border-border bg-surface text-muted', dot: 'bg-muted' },
 };
 

--- a/ui/src/components/workbench/AgentGraphCanvas.tsx
+++ b/ui/src/components/workbench/AgentGraphCanvas.tsx
@@ -115,8 +115,8 @@ const NODE_TYPES = { session: SessionRFNode, trigger: TriggerRFNode };
 // panel's "REPORTS TO · callback status" is the only callback surface), so the
 // canvas renders spawn + trigger only.
 function edgeVars(kind: AgentGraphEdge['kind']): { color: string; dashed: boolean } {
-  if (kind === 'spawn') return { color: 'var(--mint)', dashed: false };
-  return { color: 'var(--violet)', dashed: true }; // trigger
+  if (kind === 'spawn') return { color: 'var(--mint-ink)', dashed: false };
+  return { color: 'var(--violet-ink)', dashed: true }; // trigger
 }
 
 // Build an undirected adjacency map so hovering a node can highlight its whole
@@ -420,10 +420,10 @@ const Legend: React.FC<{
 }> = ({ t, showDisabled, onToggleDisabled }) => (
   <div className="flex flex-wrap items-center gap-x-4 gap-y-1.5 rounded-xl border border-border-strong bg-surface/90 px-3 py-2 text-[11px] text-muted backdrop-blur">
     <LegendItem label={t('agents.graph.legend.spawn')}>
-      <span className="h-[2px] w-5" style={{ background: 'var(--mint)' }} />
+      <span className="h-[2px] w-5" style={{ background: 'var(--mint-ink)' }} />
     </LegendItem>
     <LegendItem label={t('agents.graph.legend.trigger')}>
-      <span className="h-0 w-5 border-t-2 border-dashed" style={{ borderColor: 'var(--violet)' }} />
+      <span className="h-0 w-5 border-t-2 border-dashed" style={{ borderColor: 'var(--violet-ink)' }} />
     </LegendItem>
     <LegendItem label={t('agents.graph.legend.background')}>
       <span className="text-muted">◎</span>

--- a/ui/src/components/workbench/AgentGraphOrphanStrip.tsx
+++ b/ui/src/components/workbench/AgentGraphOrphanStrip.tsx
@@ -23,7 +23,7 @@ const STATE_META: Record<
   LiveState,
   { dotClass: string; stateKey: string; endKey: string; Icon: typeof Square; needsConfirm: boolean }
 > = {
-  active: { dotClass: 'bg-mint', stateKey: 'agents.running.stateActive', endKey: 'agents.running.endActive', Icon: Square, needsConfirm: true },
+  active: { dotClass: 'bg-mint-ink', stateKey: 'agents.running.stateActive', endKey: 'agents.running.endActive', Icon: Square, needsConfirm: true },
   idle: { dotClass: 'bg-muted', stateKey: 'agents.running.stateIdle', endKey: 'agents.running.endIdle', Icon: Power, needsConfirm: false },
   orphan: { dotClass: 'bg-amber-500', stateKey: 'agents.running.stateOrphan', endKey: 'agents.running.endOrphan', Icon: Trash2, needsConfirm: true },
 };

--- a/ui/src/components/workbench/AgentGraphTab.tsx
+++ b/ui/src/components/workbench/AgentGraphTab.tsx
@@ -580,7 +580,7 @@ export const AgentGraphTab: React.FC = () => {
         <p className="min-w-0 flex-1 text-[12.5px] text-muted">{t('agents.graph.subtitle')}</p>
         {counts && (
           <span className="inline-flex shrink-0 items-center gap-1.5 rounded-full border border-mint/40 bg-mint-soft px-3 py-1 text-[12px] font-semibold text-mint-ink">
-            <span className="size-1.5 rounded-full bg-mint" />
+            <span className="size-1.5 rounded-full bg-mint-ink" />
             {t('agents.graph.livePill', { active: counts.active, queued: counts.queued })}
           </span>
         )}

--- a/ui/src/components/workbench/AgentGraphTriggerDetail.tsx
+++ b/ui/src/components/workbench/AgentGraphTriggerDetail.tsx
@@ -347,7 +347,7 @@ export const AgentGraphTriggerDetail: React.FC<AgentGraphTriggerDetailProps> = (
                 <span
                   className={clsx(
                     'size-1.5 rounded-full',
-                    watch?.runtime?.running ? 'bg-mint' : 'bg-muted',
+                    watch?.runtime?.running ? 'bg-mint-ink' : 'bg-muted',
                   )}
                 />
                 {defPending && !watch ? '…' : runtimeText}

--- a/ui/src/components/workbench/AgentsPage.tsx
+++ b/ui/src/components/workbench/AgentsPage.tsx
@@ -800,7 +800,7 @@ const AgentRow: React.FC<AgentRowProps> = ({ agent, isSelected, isDefault, onSel
         {description && <div className="text-[11px] text-muted">{description}</div>}
       </div>
       <Badge variant={agent.enabled ? 'success' : 'secondary'} className="font-mono uppercase">
-        <span className={clsx('size-1.5 rounded-full', agent.enabled ? 'bg-mint' : 'bg-muted')} />
+        <span className={clsx('size-1.5 rounded-full', agent.enabled ? 'bg-mint-ink' : 'bg-muted')} />
         {agent.enabled ? t('agents.statusEnabled') : t('agents.statusDisabled')}
       </Badge>
     </button>

--- a/ui/src/components/workbench/AppsFileBrowserPage.tsx
+++ b/ui/src/components/workbench/AppsFileBrowserPage.tsx
@@ -82,15 +82,15 @@ import { FilePicker } from './FilePicker';
 
 // A code-file extension → its accent + glyph (mirrors design nknn2's colored type icons).
 const EXT_ICON: Record<string, { Icon: LucideIcon; color: string }> = {
-  ts: { Icon: FileCode2, color: 'var(--cyan)' },
-  tsx: { Icon: FileCode2, color: 'var(--cyan)' },
-  js: { Icon: FileCode2, color: 'var(--gold)' },
-  jsx: { Icon: FileCode2, color: 'var(--gold)' },
-  json: { Icon: Braces, color: 'var(--gold)' },
-  css: { Icon: Hash, color: 'var(--violet)' },
-  scss: { Icon: Hash, color: 'var(--violet)' },
-  md: { Icon: FileText, color: 'var(--mint)' },
-  markdown: { Icon: FileText, color: 'var(--mint)' },
+  ts: { Icon: FileCode2, color: 'var(--cyan-ink)' },
+  tsx: { Icon: FileCode2, color: 'var(--cyan-ink)' },
+  js: { Icon: FileCode2, color: 'var(--gold-ink)' },
+  jsx: { Icon: FileCode2, color: 'var(--gold-ink)' },
+  json: { Icon: Braces, color: 'var(--gold-ink)' },
+  css: { Icon: Hash, color: 'var(--violet-ink)' },
+  scss: { Icon: Hash, color: 'var(--violet-ink)' },
+  md: { Icon: FileText, color: 'var(--mint-ink)' },
+  markdown: { Icon: FileText, color: 'var(--mint-ink)' },
   png: { Icon: ImageIcon, color: 'var(--muted)' },
   jpg: { Icon: ImageIcon, color: 'var(--muted)' },
   jpeg: { Icon: ImageIcon, color: 'var(--muted)' },
@@ -98,7 +98,7 @@ const EXT_ICON: Record<string, { Icon: LucideIcon; color: string }> = {
 };
 
 function entryIcon(e: FsEntry): { Icon: LucideIcon; color: string } {
-  if (e.kind === 'dir') return { Icon: Folder, color: 'var(--cyan)' };
+  if (e.kind === 'dir') return { Icon: Folder, color: 'var(--cyan-ink)' };
   return EXT_ICON[e.ext?.toLowerCase()] ?? { Icon: FileIcon, color: 'var(--muted)' };
 }
 

--- a/ui/src/components/workbench/ChatPage.tsx
+++ b/ui/src/components/workbench/ChatPage.tsx
@@ -3843,9 +3843,9 @@ export const ThinkingBubble: React.FC<{
         </div>
         <div className="w-fit rounded-2xl rounded-tl-md border border-mint/25 bg-mint/[0.09] px-3.5 py-2.5">
           <div className="flex items-center gap-1 py-0.5">
-            <span className="vr-typing-dot size-1.5 rounded-full bg-mint" />
-            <span className="vr-typing-dot size-1.5 rounded-full bg-mint [animation-delay:0.2s]" />
-            <span className="vr-typing-dot size-1.5 rounded-full bg-mint [animation-delay:0.4s]" />
+            <span className="vr-typing-dot size-1.5 rounded-full bg-mint-ink" />
+            <span className="vr-typing-dot size-1.5 rounded-full bg-mint-ink [animation-delay:0.2s]" />
+            <span className="vr-typing-dot size-1.5 rounded-full bg-mint-ink [animation-delay:0.4s]" />
           </div>
         </div>
       </div>

--- a/ui/src/components/workbench/EditorApp.tsx
+++ b/ui/src/components/workbench/EditorApp.tsx
@@ -774,7 +774,7 @@ export const EditorApp: React.FC<{
                       key={tab.id}
                       className={clsx(
                         'group/tab flex shrink-0 items-center gap-2 border-r border-border px-3 py-2 text-[12px] transition',
-                        active === tab.id ? 'bg-surface text-foreground shadow-[inset_0_2px_0_0_var(--cyan)]' : 'text-muted hover:bg-foreground/[0.04]',
+                        active === tab.id ? 'bg-surface text-foreground shadow-[inset_0_2px_0_0_var(--cyan-ink)]' : 'text-muted hover:bg-foreground/[0.04]',
                       )}
                     >
                       <button

--- a/ui/src/components/workbench/EditorApp.tsx
+++ b/ui/src/components/workbench/EditorApp.tsx
@@ -686,7 +686,7 @@ export const EditorApp: React.FC<{
                   view === key && !explorerCollapsed ? 'text-foreground' : 'text-muted hover:text-foreground',
                 )}
               >
-                {view === key && !explorerCollapsed && <span className="absolute left-0 top-0 h-full w-0.5 bg-cyan" />}
+                {view === key && !explorerCollapsed && <span className="absolute left-0 top-0 h-full w-0.5 bg-cyan-ink" />}
                 <Icon className="size-5" />
               </button>
             ))}
@@ -788,7 +788,7 @@ export const EditorApp: React.FC<{
                           <CodeXml className="size-3.5 text-cyan-ink" />
                         )}
                         {tab.name}
-                        {dirty[tab.id] && <span className="size-1.5 rounded-full bg-mint" />}
+                        {dirty[tab.id] && <span className="size-1.5 rounded-full bg-mint-ink" />}
                       </button>
                       <button
                         type="button"

--- a/ui/src/components/workbench/FileEditorPane.tsx
+++ b/ui/src/components/workbench/FileEditorPane.tsx
@@ -396,7 +396,7 @@ export const FileEditorPane: React.FC<{
             </Button>
           )}
           <span className="flex-1 truncate font-mono text-[12px] text-foreground">{filename}</span>
-          {dirty && <span className="size-1.5 shrink-0 rounded-full bg-mint" title={t('apps.fileBrowser.unsaved')} />}
+          {dirty && <span className="size-1.5 shrink-0 rounded-full bg-mint-ink" title={t('apps.fileBrowser.unsaved')} />}
           {onPopOut && (
             <Button
               type="button"

--- a/ui/src/components/workbench/FileTree.tsx
+++ b/ui/src/components/workbench/FileTree.tsx
@@ -35,14 +35,14 @@ import { InlineNameInput } from '../ui/inline-name-input';
 
 // Icon + accent per file extension (matches the explorer in design dnYPx).
 const EXT: Record<string, { Icon: typeof FileIcon; color: string }> = {
-  ts: { Icon: FileCode2, color: 'var(--cyan)' },
-  tsx: { Icon: FileCode2, color: 'var(--cyan)' },
-  js: { Icon: FileCode2, color: 'var(--gold)' },
-  jsx: { Icon: FileCode2, color: 'var(--gold)' },
-  json: { Icon: Braces, color: 'var(--gold)' },
-  css: { Icon: Hash, color: 'var(--violet)' },
-  scss: { Icon: Hash, color: 'var(--violet)' },
-  md: { Icon: FileText, color: 'var(--mint)' },
+  ts: { Icon: FileCode2, color: 'var(--cyan-ink)' },
+  tsx: { Icon: FileCode2, color: 'var(--cyan-ink)' },
+  js: { Icon: FileCode2, color: 'var(--gold-ink)' },
+  jsx: { Icon: FileCode2, color: 'var(--gold-ink)' },
+  json: { Icon: Braces, color: 'var(--gold-ink)' },
+  css: { Icon: Hash, color: 'var(--violet-ink)' },
+  scss: { Icon: Hash, color: 'var(--violet-ink)' },
+  md: { Icon: FileText, color: 'var(--mint-ink)' },
   png: { Icon: ImageIcon, color: 'var(--muted)' },
   jpg: { Icon: ImageIcon, color: 'var(--muted)' },
   svg: { Icon: ImageIcon, color: 'var(--muted)' },

--- a/ui/src/components/workbench/HarnessPage.tsx
+++ b/ui/src/components/workbench/HarnessPage.tsx
@@ -989,8 +989,8 @@ const TasksList: React.FC<TasksListProps> = ({
 // their second line *says*, never in how the row is built. ``definitionRowLine``
 // owns that difference so this component stays a single anatomy.
 const STATE_DOT_CLASS: Record<HarnessLifecycleState, string> = {
-  running: 'bg-mint shadow-[0_0_5px_rgba(52,211,153,0.7)]',
-  waiting: 'bg-cyan',
+  running: 'bg-mint-ink shadow-[0_0_5px_rgba(52,211,153,0.7)]',
+  waiting: 'bg-cyan-ink',
   paused: 'bg-muted/70',
   finished: 'bg-border-strong',
 };
@@ -2008,7 +2008,7 @@ const LifecyclePill: React.FC<{ row: HarnessTask | HarnessWatch }> = ({ row }) =
       className="shrink-0 font-mono text-[9px] uppercase"
     >
       {state === 'running' ? (
-        <span className="size-1.5 rounded-full bg-mint" />
+        <span className="size-1.5 rounded-full bg-mint-ink" />
       ) : state === 'paused' ? (
         <PauseCircle className="size-2.5" />
       ) : null}

--- a/ui/src/components/workbench/MorePage.tsx
+++ b/ui/src/components/workbench/MorePage.tsx
@@ -91,7 +91,7 @@ export const MoreConnectionSection: React.FC = () => {
         <span
           className={clsx(
             'size-2.5 shrink-0 rounded-full',
-            isRunning ? 'bg-mint shadow-[0_0_9px_rgba(91,255,160,0.9)]' : 'bg-muted',
+            isRunning ? 'bg-mint-ink shadow-[0_0_9px_rgba(91,255,160,0.9)]' : 'bg-muted',
           )}
         />
         <span className="flex-1 text-sm font-semibold">

--- a/ui/src/components/workbench/NewAgentDialog.tsx
+++ b/ui/src/components/workbench/NewAgentDialog.tsx
@@ -334,20 +334,17 @@ export const NewAgentDialog: React.FC<NewAgentDialogProps> = ({ open, onClose, o
           >
             {t('common.cancel')}
           </button>
-          <button
+          <Button
             type="button"
+            variant="brand"
+            size={null}
             onClick={handleSubmit}
             disabled={!canSubmit}
-            className={clsx(
-              'inline-flex items-center gap-1.5 rounded-md px-4 py-1.5 text-[12px] font-bold transition',
-              canSubmit
-                ? 'bg-mint text-primary-foreground shadow-[0_0_14px_-4px_rgba(91,255,160,0.6)] hover:bg-mint-hover'
-                : 'cursor-not-allowed bg-muted-soft text-muted',
-            )}
+            className="gap-1.5 rounded-md px-4 py-1.5 text-[12px]"
           >
             {t('agents.create.submit')}
             <ArrowRight className="size-3.5" />
-          </button>
+          </Button>
         </div>
       </div>
     </div>

--- a/ui/src/components/workbench/ProjectsPage.tsx
+++ b/ui/src/components/workbench/ProjectsPage.tsx
@@ -39,8 +39,8 @@ import { useSessionActions } from './useSessionActions';
 import { SessionPinIndicator } from './SessionPinIndicator';
 
 const DOT: Record<string, string> = {
-  running: 'bg-mint shadow-[0_0_7px_rgba(91,255,160,0.9)]',
-  failed: 'bg-destructive',
+  running: 'bg-mint-ink shadow-[0_0_7px_rgba(91,255,160,0.9)]',
+  failed: 'bg-destructive-ink',
   idle: 'bg-muted',
 };
 const MOBILE_SESSION_PAGE_SIZE = 8;

--- a/ui/src/components/workbench/ShowPageAnnotateControl.tsx
+++ b/ui/src/components/workbench/ShowPageAnnotateControl.tsx
@@ -149,16 +149,18 @@ export const ShowPageAnnotateControl: React.FC<ShowPageAnnotateControlProps> = (
         <div className="hidden items-center md:flex">
           {enabled ? (
             <div className="flex h-7 items-center gap-0.5 rounded-lg border border-mint/40 bg-mint/[0.06] p-0.5 shadow-[0_0_16px_-6px_rgba(91,255,160,0.5)]">
-              <button
+              <Button
                 type="button"
+                variant="default"
+                size={null}
                 onClick={onDisable}
                 aria-label={offLabel}
                 title={offLabel}
                 aria-pressed
-                className="grid size-6 shrink-0 place-items-center rounded-[5px] bg-mint text-primary-foreground transition hover:bg-mint-hover"
+                className="size-6 shrink-0 rounded-[5px]"
               >
                 <MessageSquarePlus className="size-3.5" />
-              </button>
+              </Button>
               <div
                 role="radiogroup"
                 aria-label={t('chat.showPage.annotate.modeTitle')}

--- a/ui/src/components/workbench/SkillsPage.tsx
+++ b/ui/src/components/workbench/SkillsPage.tsx
@@ -449,7 +449,7 @@ const BackendFilter: React.FC<BackendFilterProps> = ({ value, onChange }) => {
   const [open, setOpen] = useState(false);
   const label = value === 'all' ? t('skills.backendAll') : BACKEND_LABEL[value];
   const dot = (key: Backend | 'all') =>
-    key === 'all' ? 'bg-muted' : key === 'claude' ? 'bg-mint' : key === 'opencode' ? 'bg-cyan' : 'bg-violet';
+    key === 'all' ? 'bg-muted' : key === 'claude' ? 'bg-mint-ink' : key === 'opencode' ? 'bg-cyan-ink' : 'bg-violet-ink';
   return (
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>

--- a/ui/src/components/workbench/TerminalTabs.tsx
+++ b/ui/src/components/workbench/TerminalTabs.tsx
@@ -216,7 +216,7 @@ export const TerminalTabs: React.FC<{
               key={tab.key}
               className={clsx(
                 'group/tab flex shrink-0 items-center gap-1.5 rounded-md px-2.5 py-1 text-[12px] transition',
-                tab.key === active ? 'bg-surface text-foreground shadow-[inset_0_-2px_0_0_var(--mint)]' : 'text-muted hover:bg-foreground/[0.05]',
+                tab.key === active ? 'bg-surface text-foreground shadow-[inset_0_-2px_0_0_var(--mint-ink)]' : 'text-muted hover:bg-foreground/[0.05]',
               )}
             >
               {editing && editing.key === tab.key ? (

--- a/ui/src/components/workbench/TerminalTabs.tsx
+++ b/ui/src/components/workbench/TerminalTabs.tsx
@@ -274,11 +274,11 @@ export const TerminalTabs: React.FC<{
           const persistentReady = persistent && st === 'ready';
           const dotClass =
             st === 'ready'
-              ? 'bg-mint'
+              ? 'bg-mint-ink'
               : st === 'connecting'
                 ? 'bg-amber-400'
                 : st === 'closed' || st === 'error'
-                  ? 'bg-destructive'
+                  ? 'bg-destructive-ink'
                   : 'bg-muted';
           return (
             <span

--- a/ui/src/components/workbench/WorkbenchSidebar.tsx
+++ b/ui/src/components/workbench/WorkbenchSidebar.tsx
@@ -196,8 +196,8 @@ const InboxHoverPopover: React.FC<{
 // gray / green / red: idle → muted (gray), running → mint (green) + glow,
 // failed → destructive (red) + glow. Tokens resolve from src/index.css.
 const STATUS_DOT_CLASS: Record<string, string> = {
-  running: 'bg-mint shadow-[0_0_6px_0_rgba(91,255,160,0.65)]',
-  failed: 'bg-destructive shadow-[0_0_6px_0_rgba(255,107,107,0.6)]',
+  running: 'bg-mint-ink shadow-[0_0_6px_0_rgba(91,255,160,0.65)]',
+  failed: 'bg-destructive-ink shadow-[0_0_6px_0_rgba(255,107,107,0.6)]',
   idle: 'bg-muted',
 };
 

--- a/ui/src/components/workbench/skills/AddSkillDialog.tsx
+++ b/ui/src/components/workbench/skills/AddSkillDialog.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from 'react-i18next';
 import { useApi } from '../../../context/ApiContext';
 import type { SkillDiscovered, SkillScope } from '../../../context/ApiContext';
 import { useToast } from '../../../context/ToastContext';
+import { Button } from '../../ui/button';
 import { SegmentedRadio } from '../../ui/segmented';
 import { Checkbox } from '../../ui/checkbox';
 import { BACKEND_CHIP, BACKEND_LABEL, BACKEND_ORDER, type Backend } from '../../../lib/backendAccent';
@@ -321,15 +322,17 @@ export function AddSkillDialog({ defaultScope, projectId, projectName, onClose, 
             <button type="button" onClick={onClose} className="rounded-lg border border-border-strong px-3.5 py-2 text-[12px] font-medium text-foreground transition hover:bg-foreground/[0.04]">
               {t('skills.addDialog.cancel')}
             </button>
-            <button
+            <Button
               type="button"
+              variant="brand"
+              size={null}
               onClick={install}
               disabled={!discovered || selected.size === 0 || backends.size === 0 || busy === 'install'}
-              className="flex items-center gap-1.5 rounded-lg bg-mint px-4 py-2 text-[12px] font-semibold text-primary-foreground shadow-[0_4px_16px_-4px_rgba(91,255,160,0.5)] transition hover:bg-mint-hover disabled:opacity-50"
+              className="gap-1.5 px-4 py-2 text-[12px] font-semibold"
             >
               {busy === 'install' ? <Loader2 className="size-3.5 animate-spin" /> : <Download className="size-3.5" />}
               {busy === 'install' ? t('skills.addDialog.installing') : t('skills.addDialog.install', { count: selected.size })}
-            </button>
+            </Button>
           </div>
         </div>
       </div>

--- a/ui/src/features/organization/OrganizationShell.tsx
+++ b/ui/src/features/organization/OrganizationShell.tsx
@@ -170,7 +170,7 @@ function OrganizationNavbar() {
           <div className="hidden items-center gap-2 sm:flex">
             <div className="rounded-lg border border-mint/30 bg-mint/10 px-3 py-2">
               <div className="flex items-center gap-2 text-[12px] font-semibold">
-                <span className="size-2 rounded-full bg-mint shadow-[0_0_8px_rgba(91,255,160,0.8)]" />
+                <span className="size-2 rounded-full bg-mint-ink shadow-[0_0_8px_rgba(91,255,160,0.8)]" />
                 {t('organization.sidebar.cloudConnected')}
                 <span className="font-mono text-[10px] font-normal text-muted">
                   · {t('organization.sidebar.sessionRemaining', { minutes: Math.max(1, Math.ceil((session?.expires_in ?? 0) / 60)) })}

--- a/ui/src/lib/agentGraph.test.ts
+++ b/ui/src/lib/agentGraph.test.ts
@@ -100,7 +100,7 @@ describe('nodeDisplayTitle', () => {
 describe('statusMeta / isBackground', () => {
   it('maps status to tone + glyph', () => {
     expect(statusMeta('active').glyph).toBe('dot');
-    expect(statusMeta('active').dotClass).toBe('bg-mint');
+    expect(statusMeta('active').dotClass).toBe('bg-mint-ink');
     expect(statusMeta('idle')).toMatchObject({ tone: 'muted', dotClass: 'bg-muted', glyph: 'dot' });
     expect(statusMeta('succeeded').glyph).toBe('check');
     expect(statusMeta('failed').glyph).toBe('cross');

--- a/ui/src/lib/agentGraph.ts
+++ b/ui/src/lib/agentGraph.ts
@@ -189,12 +189,12 @@ export type StatusMeta = {
 };
 
 const STATUS_META: Record<AgentGraphStatus, StatusMeta> = {
-  active: { tone: 'mint', dotClass: 'bg-mint', labelKey: 'agents.graph.status.active', dim: false, glyph: 'dot' },
-  queued: { tone: 'gold', dotClass: 'bg-gold', labelKey: 'agents.graph.status.queued', dim: false, glyph: 'dot' },
+  active: { tone: 'mint', dotClass: 'bg-mint-ink', labelKey: 'agents.graph.status.active', dim: false, glyph: 'dot' },
+  queued: { tone: 'gold', dotClass: 'bg-gold-ink', labelKey: 'agents.graph.status.queued', dim: false, glyph: 'dot' },
   idle: { tone: 'muted', dotClass: 'bg-muted', labelKey: 'agents.graph.status.idle', dim: false, glyph: 'dot' },
   orphan: { tone: 'gold', dotClass: 'bg-amber-500', labelKey: 'agents.graph.status.orphan', dim: false, glyph: 'dot' },
   succeeded: { tone: 'muted', dotClass: 'bg-muted', labelKey: 'agents.graph.status.succeeded', dim: true, glyph: 'check' },
-  failed: { tone: 'destructive', dotClass: 'bg-destructive', labelKey: 'agents.graph.status.failed', dim: true, glyph: 'cross' },
+  failed: { tone: 'destructive', dotClass: 'bg-destructive-ink', labelKey: 'agents.graph.status.failed', dim: true, glyph: 'cross' },
   canceled: { tone: 'muted', dotClass: 'bg-muted', labelKey: 'agents.graph.status.canceled', dim: true, glyph: 'cross' },
 };
 

--- a/ui/src/lib/backendAccent.ts
+++ b/ui/src/lib/backendAccent.ts
@@ -22,9 +22,9 @@ export const BACKEND_TEXT: Record<Backend, string> = {
 
 // Solid dot fill — e.g. a status dot inside a chip.
 export const BACKEND_DOT: Record<Backend, string> = {
-  claude: 'bg-mint',
-  opencode: 'bg-cyan',
-  codex: 'bg-violet',
+  claude: 'bg-mint-ink',
+  opencode: 'bg-cyan-ink',
+  codex: 'bg-violet-ink',
 };
 
 // Full pill surface (soft bg + 40% border + accent text) for backend chips.


### PR DESCRIPTION
Clears both P2 follow-ups recorded when #1406 merged, at their shared root.

## Capability

Accent marks that are read directly against the page canvas now take the `-ink`
token, and two build-time assertions keep them there.

The taxonomy in `modelHubSurface.css`'s header was wrong, and that is the whole
defect: it framed the choice as **fill versus text**. It is not. It is whether
the accent has a **label printed on it**. A fill or hairline may stay vivid
because it is read *through* the paired `--X-foreground` sitting on it. Anything
read directly against the canvas — text, an icon, and equally a wire, an end
node, a status dot — carries no label, so it must take `--X-ink`.

Grouping wires with fills is how the supply graph shipped 2px `--mint` strokes
at **2.35:1** on the light canvas while every token guard passed. The ink and
fill assertions check that each *token* is legible against the surface it
claims; neither can see that a *rule* picked the wrong one. `--gold` is worse
at **2.95:1**. Both are under the 3:1 WCAG floor for non-text.

Light-theme measurements against `--background` `#f4f6fb`:

| accent | fill | ink |
| --- | --- | --- |
| mint | 2.35:1 ✗ | 6.02:1 ✓ |
| gold | 2.95:1 ✗ | 4.71:1 ✓ |
| cyan | 3.41:1 ✓ | 4.98:1 ✓ |
| violet | 5.27:1 ✓ | 5.27:1 ✓ |

In dark, each accent's ink **is** its fill (`mint-ink == mint`, `cyan-ink ==
cyan`, `gold-ink == gold`; violet differs imperceptibly), so none of this moves
a dark pixel.

## Changes

**Commit 1 — paint unlabeled marks with the ink token**

- rewrite the header rule in `modelHubSurface.css`, then move the four wire
  strokes, their glows and the four wire-node fills onto the ink tokens
- move 67 unlabeled marks across 33 files from `bg-X` to `bg-X-ink` — status
  dots, typing dots, backend accent dots, graph nodes — plus 3 expectations in
  `agentGraph.test.ts` and `sourceStatePresentation.test.ts`
- `assertMarksTakeTheInk`: an opaque `stroke`/`fill` in the Model Hub CSS may
  not name a bare accent fill. Translucent values are washes with no ratio of
  their own, so they stay out of scope — same reasoning as
  `requireMeasurableColor`.
- `assertUnlabeledFillsTakeTheInk`: a bare `bg-X` utility needs its paired
  `*-foreground` label. As first written the label was looked for in a ±4 line
  window; commit 3 replaced that with an AST scope after review — see below.

**Commit 2 — reuse `Button` for the five hand-rolled mint CTAs**

Five controls spelled out the primitive's own recipe (`bg-mint` +
`text-primary-foreground` + `hover:bg-mint-hover`) by hand. That is precisely
the pairing `SEMANTIC_FILL_ALIASES` and the hover assertion exist to hold
together, and a hand-rolled copy is the shape that drifts from it unnoticed.
Three also carried their own mint glow, at three different radii.

They pass `size={null}` and keep their own padding, radius and type, because
none matches a `Button` size — the new-folder submit is smaller than `xs`, the
annotate toggle is a 24px square. Geometry is unchanged; what moves to the
primitive is the accent pairing, the hover fill, the focus ring and the
disabled treatment. Verified by rendering each site's old class string against
what `Button` now produces: no padding, height, radius or type class differs.

## Deliberately held back

**Ten control-chrome sites keep the bare fill** — switch/toggle tracks
(`switch.tsx`, `SettingsPrimitives.tsx`, `PlatformSelection.tsx`) and
progress/step bars (`ProgressBar.tsx`, `EmbeddedConfigShell.tsx`, and the five
platform config step-dot rows). Their state is carried by knob position or bar
length, not by the colour reading on its own, and repainting a large light-theme
shape is a `design.pen` decision rather than a guard decision.

They are **pinned, not skipped** — by file, accent, reason and the signature of
the construct each exemption was granted for, following `ACCEPTED_BRAND_PAIRS`.
Removing one goes stale loudly; a different bare mark appearing under the same
file and accent still fails rather than inheriting the pin.

## Deliberate visual changes

- the three glow CTAs land on the `brand` variant's single declared glow
  (`0 0 24px -4px`) instead of their own 14px and 16px ones, removing two more
  hard-coded rgba mint literals from call sites
- three CTAs swapped to `bg-muted-soft`/`text-muted` when disabled; they now
  fade like every other disabled `Button`. A disabled control looking one way
  here and another way everywhere else is the inconsistency this removes.
- all five gain the `focus-visible` ring they never had

## Evidence

- **unit**: `npm test` — 198 files, 2123 tests pass. `agentGraph.test.ts` and
  `sourceStatePresentation.test.ts` expectations move with their sources.
- **contract**: `npm run validate:theme` passes. All four new assertions were
  **reverse-verified** by introducing the defect each one describes and
  confirming it fails: a wire painted `var(--mint)`; a new unlabeled `bg-mint`
  in an unpinned file; a pinned site removed (stale pin); a pinned file gaining
  a second bare mark. The AST rewrite in commit 3 was re-verified six ways on
  top of that — including the window's own false negative (injected, the old
  rule rescued it 23 → 24, the new rule fails) and *breaking* a sibling-prop
  pairing, which proves the new scope is load-bearing rather than vacuous.
  `path.sep` normalisation is verified as a transform in both directions, not
  by a Windows run.
- **build / lint**: `npm run build` clean; `npm run lint` reports no drift in
  any (file, rule) pair.
- **contract (rounds 3–4)**: the guard's contract changed from *enumerate the
  unsafe shapes* to *fail closed on anything unproven*, and round 4 carried that
  decision to the two places it had not reached. 31 reverse-verifications cover
  both directions of every assertion in commits 5 and 6, including two
  load-bearing checks that restore the old logic and confirm the case slips
  through. Detail under Commits 5 and 6.
- **contract (round 5)**: three findings were closed by widening what the guard
  reads — `text-` into the ink assertion, a bare-accent-in-any-TS-string rule over
  the whole route out of TypeScript, and an alias index unioned across every
  stylesheet that ships — and one by making the pairing scope condition-aware. The
  TS-string rule was a **true positive: 24 live defects**, not a hypothesis.
  Detail under Commit 7.
- **contract (round 6)**: both findings were one class — a predicate matching a
  spelling instead of the meaning — so the class was measured and closed whole
  rather than patched twice: the opacity modifier is parsed into a number against
  one stated threshold, and a label counts only when a glyph-printing utility
  carries it. **34 reverse-verifications**, including every deliberate exclusion
  and every wash below the threshold as negatives. Zero live sites in the closed
  class, so no pixel moves. Detail under Commit 8.
- **residual manual**: not done — the five conversions were verified at the
  class level rather than in a browser, and the light-theme wire recolour was
  verified numerically. The wires now use the same ink the owner already
  approved for the 772-site text codemod in #1406, so this is consistency with
  a settled decision rather than a new one.

**Commit 3 — scope the label check to the AST (review round 1, 2× P2)**

Proximity was standing in for ownership: the ±4 line window accepted any
`*-foreground` nearby as proof the fill beside it was labelled, so a `bg-mint`
dot two lines from an unrelated `text-primary-foreground` button passed the
guard that exists to catch it.

Measuring where labels actually live picked the replacement. Of the 23 labelled
fills in `src/`, **21** pair inside one class string (every cva variant in
`button-variants.ts` among them), **0** pair on the same line through a
different string, and **2** pair across sibling props of one node
(`iconTileClassName`/`iconClassName`, and `tileCls`/`iconCls` in one object
literal). So a label now counts only in the same class string or on a sibling
attribute/property, both read off the TypeScript AST — no new dependency,
`typescript` is already a devDependency. A label on a *child* element is
deliberately out of scope; such a site fails and the message says to merge the
classes or pin it.

Comment blanking and the multi-line-class-string problem disappear rather than
being fixed: a class name in JSDoc is comment trivia, never a string literal.

Also `readdirSync(recursive)` entries are now normalised through `path.sep`
before becoming lookup keys — on Windows they arrive as `components\ui\switch.tsx`
while every pin uses `/`, so all ten pins would miss and `validate:theme` would
fail on an unchanged checkout.

The pinned inventory is unchanged at ten entries and the guard got strictly
stricter.

**Commit 4 — measure what the guard exempts (review round 2, 3× P2)**

All three findings were one shape: an exemption granted on a *proxy* for the
thing it meant to check.

- *Naming `color-mix()` stood in for being translucent.*
  `color-mix(in srgb, var(--mint) 100%, transparent)` mentions both `color-mix`
  and `transparent` and renders as bare mint at 2.35:1 — the exact mark the
  assertion exists to reject, and both halves of the old condition waved it
  through. The accent's share is now resolved from the value; only `share < 1`
  is exempt, and a mix shape the pattern cannot read *fails* rather than
  inheriting the old free pass.
- *`ScriptKind.TSX` stood in for the file's dialect.* Nine `.ts` files in
  `src/` misparse as TSX because a generic arrow reads as an unterminated JSX
  element; `asyncLifetime.ts` surfaced **1** of its 53 string literals. The
  dialect now comes from the extension — but the deeper fault is that
  `parseDiagnostics` were ignored, since a file the parser cannot read yields no
  class strings, which is indistinguishable from a clean file. Diagnostics are
  now raised, so the scan cannot go blind quietly.
- *A per-file count stood in for a mark's identity.* `{ marks: 1 }` treats every
  same-accent mark in a file as interchangeable: delete the pinned track, add an
  unrelated bare dot, and `1` still reads as `1`. Each pin now names the
  construct it was granted for (`ProgressBar: bg-mint shadow-[…]`) — owning
  component plus exact class string, read off the AST. Chosen over a line
  number because it survives edits above it, and it reads as documentation of
  *what* is exempt rather than *how many*.

**No mark was actually being missed today.** I checked both holes against
`src/`: no `bg-<accent>` sits in any unparsed region, and the only accent
`color-mix` in a paint declaration is a genuine 20% wash. Both were latent
false-negative paths, and the guard's verdict on `src/` is unchanged — no
rendered pixel moves in this commit.

The ten pinned control-chrome sites are unchanged in substance and still await
the `design.pen` call. mint stays `#10b981` with its white label.

Reverse-verified nine ways, three per finding, each in both directions — the
defect fails *and* the legitimate case still passes: a 100% mix rejected, an
unresolvable mix shape rejected, an 8% wash still exempt; `ScriptKind.TSX`
forced back on now fails loudly, a mark planted past a generic arrow is now
caught, a plain syntax error fails instead of going blind; a swapped pinned
string rejected, a removed mark reported as `(nothing)`, and a construct moved
three lines down still passing.

**Commit 5 — fail closed instead of inferring exemptions (review round 3, 4× P2)**

Three rounds on one file, nine findings, one class: the guard asserts an
**open-world** property — *no illegible accent mark ships* — while implemented as
**closed-world** pattern matching over source text. Every round therefore
supplies the next shape it had not enumerated, and re-tuning the pattern is what
produced rounds 2 and 3. Both circuit-breaker thresholds in `ENGINEERING.md` were
met, so this round changes the contract rather than the patterns: an accent
reaching a mark is the ink, or it is pinned with a written reason, or it fails.

- *The alpha-share exemption is deleted, not re-tuned.* Exempting `share < 1`
  passes a 99% mix; any threshold replacing it can be approached from below. The
  reviewer's remedy — measure the composited stroke — cannot work either: a
  genuine 20% mint wash lands near **1.2:1** on the light canvas, *lower* than
  the bare fill, because thinning mint toward the canvas moves it toward the
  canvas. A contrast floor would reject the decorative rail the exemption exists
  for, hardest when it is most decorative. Whether a translucent stroke is
  decoration or an illegible mark is **intent**, and intent is not in the CSS.
  Washes are now listed in `ACCEPTED_ACCENT_WASHES` — one entry, the rail line.
- *Pins name the declaration, not its address.* Keyed by selector and property, a
  pin excuses whatever that selector paints next: retint the pinned stroke from
  20% to 100% and opaque mint ships under a pin granted to a hairline — round 2's
  `{ marks: 1 }` finding again. Keyed by resolved value, that fails twice, as an
  unpinned mark and as a stale pin. **My own reverse-verification caught this**,
  after the fix was written and passing; it is the case for running the harness
  in both directions rather than confirming the happy path.
- *CSS aliases are resolved at the point of paint.* `--wire-color: var(--mint)` +
  `stroke: var(--wire-color)` paints bare mint while naming neither. Latent —
  none of the ~20 `--model-hub-*` aliases is consumed by a paint declaration
  today — but one `stroke:` edit away. Accent tokens are the resolution leaf so
  the message can still name them; the depth cap is a cycle guard, since CSS
  permits `--a: var(--b); --b: var(--a)`.
- *`fill-`/`stroke-` are marks too.* **The one live defect in three rounds**:
  `AppsLauncher.tsx:141` painted the pinned-state Pin `fill-cyan`, and a 14px
  filled glyph is read like small text, not like a large non-text shape.
  Now `fill-cyan-ink`, **3.41:1 → 4.98:1**; it was the only `fill-`/`stroke-`
  accent utility in `src/`, and the icon beside it already used `text-cyan-ink`,
  so the two halves of one glyph now agree. Dark is unchanged.
- *A label must apply wherever its fill does.* `bg-mint
  hover:text-primary-foreground` leaves the resting element unlabeled. Coverage,
  not equality — an unprefixed label applies always, so it legitimately labels a
  `hover:`-only fill, and equality would reject correct code.
- *A `clsx` object key is its own scope; a property value still pairs.*
  `clsx({ 'bg-mint': a, 'text-primary-foreground': b })` are independent branches,
  so a sibling branch is the opposite of evidence: the fill can render while the
  label's condition is false. `{ tileCls: 'bg-gold', iconCls:
  'text-gold-foreground' }` is one node's config and pairs. Which side of the
  colon separates them — no allowlist of helper names, no condition analysis.

Inventory behind those last two: of 33 bare-accent matches in `src/`, 21 pair in
one class string, 2 across sibling props, 10 are the pinned control-chrome sites,
and **0** have a variant mismatch or a `clsx`-key pairing. Both were latent
false-negative paths; the only verdict this commit changes is the Pin glyph.

**Reverse-verified 17 ways**, both directions of every changed assertion:
unpinned 100% and 99% mixes rejected, a pinned wash retinted rejected, its
declaration removed reported as a stale pin, the pin deleted while the wash stays
rejected (so the exemption is load-bearing, not vacuous), the real 20% wash still
exempt; one-hop and two-hop aliases rejected reporting their `via` path, an alias
to `--mint-ink` passing, a cycle terminating; the real `fill-cyan` rejected and
`fill-cyan-ink` passing, a planted `stroke-gold` rejected; `bg-mint
hover:text-…` rejected while both `hover:bg-mint` spellings pass; the `clsx`-key
pairing rejected, a config-map pairing passing, and the old scope rule restored
lets the `clsx`-key case through — which proves the new scope is load-bearing.

The ten pinned control-chrome sites are untouched and still await the
`design.pen` call. mint stays `#10b981` with its white label.

**Commit 6 — finish applying commit 5's contract (review round 4, 2× P2)**

Both findings are on commit 5's own code, and both are that contract applied
**incompletely** rather than a new class — so this commit changes no rule, it
carries the existing one to the two places it had not reached.

- *The Tailwind opacity modifier was an exit, not a value.* A `/` in the negative
  lookahead meant `bg-mint/100` and `hover:bg-mint/[1]` matched **nothing at all**
  — invisible to the scan rather than judged by it — while painting exactly what
  `bg-mint` paints. Fully opaque is now the fill.

  **The asymmetry with the CSS half is deliberate**, and it is in the inventory,
  not the principle. `modelHubSurface.css` has one translucent accent paint, so
  "write a pin" costs one line. `src/` has **~370** opacity-modified accent
  utilities — 105 `bg-mint/`, 94 `bg-gold/`, 73 `bg-cyan/` — nearly all 10–20%
  washes behind content. 370 pins would not make anything legible; they would make
  the guard something people route around, which checks nothing. A threshold would
  avoid the pins and reintroduce exactly what commit 5 deleted (pick 90%, `/89`
  walks through). What actually separates the two cases is how they fail: a
  translucent mark is invisible in **both** themes and its author fixes it before
  pushing, while an opaque one looks right in dark and goes illegible only in
  light — unseen, which is why this guard exists. Residual: `/99` passes. Stated,
  not defended.
- *The alias resolver kept the last definition.* This file already defines **11**
  properties twice, once per theme — `--model-hub-wash-channel` is `8 8 18` in dark
  and `255 255 255` in light — so last-write-wins was not an approximation of the
  file but a misreading of it. Base `--wire: var(--mint)` with
  `.dark { --wire: var(--mint-ink) }` cleared a light `stroke: var(--wire)` on the
  strength of a value the browser never paints there.

  Resolving the cascade properly needs specificity, at-rules and order — a CSS
  engine inside a guard, whose bugs would be silent clears. Not needed: the
  question is not what colour this paints but whether **any** definition can put a
  bare accent here, so the transitive union over all definitions answers it and
  there is no resolution order left to get wrong. Pins now name the reachable
  accents as well as the authored value, or retargeting `--wire` from the ink to
  the fill would inherit a pin granted to the ink — round 2's
  address-versus-construct finding, one indirection up. Cycles under-report by
  design: a `var()` cycle is invalid at computed-value time, so the browser paints
  nothing there either.

**Reverse-verified 31 ways** — the round-3 suite re-run against the changed
pin-key format, plus `/100`, `/[1]`, `/[100%]` and `hover:bg-mint/100` rejected,
`fill-cyan/100` rejected, `/10` and `/[0.10]` still passing, an opaque mark with
its label still passing, `bg-mint-soft` still ignored, the theme-override case
caught in **both** definition orders, a real `--model-hub-mint-4d` consumer caught
and reported as reached-through, and a conflict-free alias to the ink still
passing. Both new behaviours are load-bearing, not vacuous: restoring
last-write-wins lets the theme-override case through, exactly as restoring the old
object-literal scope lets the `clsx`-key case through.

No pixel moves in this commit — every round-4 finding was a latent false-negative
path.

**Commit 7 — close the carrier gaps (review round 5, 4× P2)**

Round 5 found four ways a bare accent still reached a pixel unseen. Three were
closed by widening what the guard *reads* rather than by naming one more utility;
the fourth was failing **open**.

- **`text-<accent>` joins the ink assertion.** `INK_UTILITIES = ['text']` sits
  beside `MARK_UTILITIES = ['bg', 'fill', 'stroke']`, and the split is the point:
  a mark may be excused by a paired label or a pin, ink never can. `text-mint`
  also tints every child icon through `currentColor` — the Lucide case in the
  finding — so it takes `-ink` unconditionally. 0 live sites: #1406's codemod
  already moved all 806 references, and this turns that state into a rule.
- **No TypeScript string may contain `var(--<accent>)`.** One rule over the whole
  route out of TS, rather than a longer inspection list: an inline `style` object,
  a JSX paint attribute (`fill="var(--mint)"`), a `shadow-[…var(--cyan)]`
  arbitrary value and a lookup table read in a different file are four spellings
  of one fact, and the class scan misses all four for the same reason — it reads
  utility *names*. **24 live defects**, all fixed here: the 1.6px agent-graph
  spawn edges and their two legend swatches, two duplicated file-extension icon
  maps, and the editor and terminal active-tab underlines. `var(--mint-ink)` and
  `var(--mint-foreground)` are unaffected.
- **The alias index unions every stylesheet that ships together.** A custom
  property is global once it is on `:root`, so `--wire-color: var(--mint)` in
  `index.css` is visible to `stroke: var(--wire-color)` in Model Hub; an index
  built from that one file saw no definition and cleared the wire. Same reason it
  already unioned multiple definitions *within* a file. Zero fallout — no new pin.
- **A conditional label no longer licenses an unconditional fill.** `scope` held
  the raw source of the opening element, so a label reached only through
  ``${active ? 'text-primary-foreground' : ''}`` cleared a mark whose fill was
  unconditional — licensing the resting state on a branch that may never be
  taken. It now holds only unconditional strings: both branches of a conditional
  and both operands of `&&` / `||` / `??` are dropped. Both operands, not just the
  fallback: proving a label present in every branch means evaluating the
  condition, so the guard fails closed and the fix is to merge the label into the
  fill's own string. 0 live sites, so no coverage was lost and nothing needed a
  pin.

**Reverse-verified** — each rule against the defect it describes, and the pairing
negatives against regression. Rejected: a real `text-mint` className, a `style`
object, a `shadow-[…]` arbitrary value, a lookup table in a `.ts` file, a JSX
`fill="var(--mint)"` attribute, and the conditional-label shape from the finding.
Still passing: `var(--gold-ink)`, a template-static label, and an unconditional
sibling-attribute label. The two file scans now share one `sourceFiles()` helper
so the `path.sep` normalisation cannot drift between them.

24 pixels move in this commit — every one of them the defect class this PR is
about, reaching the canvas through a carrier the guard could not see.

**Commit 8 — decide by the measured property, not the spelling (review round 6, 2× P2)**

Both of round 6's findings were the same defect wearing two utility names: a
predicate matching a *spelling* where it meant to match a *meaning*. That class
had now appeared on a second reviewed head, so instead of patching the two
members the reviewer reached, the rest of the class was measured and closed in one
push — every remaining hole is 0 live sites, which is why they cost nothing to
close now instead of in the round that finds them.

- **The alpha is parsed, not enumerated.** `FULLY_OPAQUE_MODIFIER` listed the ways
  to write 1, so `bg-mint/[99%]` took the wash exemption while painting the same
  pixels as `bg-mint` — failing open. `markAlpha()` now reads all four Tailwind
  spellings (`/70`, `/[0.7]`, `/[70%]`, none) into a number and compares it to one
  stated threshold, `OPAQUE_ENOUGH = 0.9`; an unparseable modifier fails closed and
  counts as a mark. An enumeration of opaque spellings is only ever as complete as
  whoever wrote it; a parsed number is complete by construction. The error prints
  the alpha it read. **0 live sites in the 0.90–0.99 band.**
- **A label counts only when glyphs print it.** The lookup was for the
  `-foreground` token anywhere in the string, so `bg-mint border-primary-foreground`
  cleared the mark on the strength of a 1px hairline nobody reads a word off — the
  token was present, the label was not. A label now has to be carried by a utility
  that prints glyphs. **0 live sites** paired a fill with a non-glyph label.
- **"Is ink" and "can carry a label" are two predicates.** `INK_UTILITIES` grew to
  `text`, `placeholder`, `decoration`, `caret` — a placeholder is text, an underline
  is read with the glyphs above it, and a caret you cannot find is a text field you
  cannot use — and a flag marks the two that print glyphs. Collapsing the two sets
  is how the hole reappears: the first attempt here shared one list, which let
  `bg-mint caret-primary-foreground` license the fill, i.e. the reported defect in a
  different utility. Reverse-verification caught it. **0 live sites.**
- **Gradient stops are fills.** `from-mint via-mint to-mint` paints the shape
  `bg-mint` paints, so leaving them out was a hole with a Tailwind name. **0 live
  sites.**

`border-`, `ring-`, `outline-` and `divide-` stay out on purpose — ledger #2 — and
the source says so at the declaration, so the gap reads as the decision it is.

**Reverse-verified 34/34** on a throwaway probe, each rule against the defect it
describes plus the negatives it must not break. Rejected: `bg-mint/[99%]`,
`bg-mint/[0.95]`, `bg-mint/95`, `bg-mint/90` (the boundary), `bg-mint/huh`
(fail-closed), `text-mint/[99%]`, `bg-mint border-primary-foreground`,
`bg-mint ring-primary-foreground`, `bg-mint caret-primary-foreground`,
`bg-mint decoration-primary-foreground`, `fill-gold stroke-gold-foreground`,
`from-mint`, `via-cyan`, `to-gold`, `placeholder-mint`, `caret-cyan`,
`decoration-gold`. Still passing: every wash below the threshold (`/70`, `/[0.7]`,
`/[89%]`, `/10`, `text-mint/50`), `bg-mint text-primary-foreground`,
`bg-mint placeholder-primary-foreground`, `hover:bg-mint text-primary-foreground`,
`from-mint text-primary-foreground`, `border-mint`, `ring-cyan`, `outline-gold`,
`divide-violet`, `bg-mint-ink`, `bg-mint-soft`.

**Zero pixels move in this commit.** The whole class was measurable as empty
before it was closed, which is what made closing all of it cheaper than answering
it one member per round.

### Commit 9 — one spelling alphabet for the accent guard

Round 7 flagged three more predicates that matched a spelling rather than the
meaning: `var(--mint, #10b981)` (fallback), `bg-mint text-primary-foreground/0`
(transparent label accepted by a substring search), and `bg-(--mint)` (Tailwind v4
custom-property shorthand seen by neither the utility regex nor the `var(...)`
fallback). Round 6 was already that class, so **the circuit breaker tripped** and the
fix went one level up rather than to the three sites.

**The cause was structural, not local.** One question — *does this text name an accent
as paint, and how opaquely* — was answered by three independently written patterns: the
mark scan, the var scan, and a label substring search. A spelling only had to be missed
by **one** of them, and nothing forced a newly supported Tailwind spelling to reach the
other two. That is why the shorthand slipped past two assertions at once, and why
patching the three members would have bought exactly one more round.

Closed at the alphabet:

- **One spelling source.** `accentTokenSource(tokens)` builds the token pattern; the
  fill scan and `labelCovers` both consume it, so covering a spelling on one side
  covers it on the other by construction. That also closed the members this review had
  not reached: `bg-[var(--mint)]`, `bg-[--mint]`, `text-(--primary-foreground)`,
  `text-[var(--primary-foreground)]`, and `text-primary-foregroundish` as a
  non-match.
- **The boundary is asserted, not enumerated.** `(?![\w-])` after the utility token and
  `(?=[,)])` after the var token say *the name ended here*. `--mint-ink` is a different
  token, not `--mint` with a suffix, without listing what may follow. Parsing `var()`'s
  argument instead would need a CSS parser inside a lookahead to survive
  `var(--mint, rgb(0 0 0))`.
- **Alpha is measured on both operands** by one `markAlpha()`, so `/0` and `/50` no
  longer license a fill and `bg-mint/[0.95] text-primary-foreground/[0.2]` is rejected
  on the label.
- **The two fail-closed directions are named separately.** `markAlpha` returns `null`
  when a modifier does not parse. An unreadable alpha must still be *checked* as a fill
  but must not be *accepted* as a label, so `readsAsTheFill(null) === true` and
  `printsTheLabel(null) === false`. Sharing one constant is fail-open on the label side.
- **Three in-script corpora** — `ACCENT_SPELLINGS` (22 rows), `LABEL_SPELLINGS` (10),
  `VAR_SPELLINGS` (8) — run before any file is read. The next spelling is one row rather
  than three regex edits, and a hole fails the guard itself rather than an out-of-tree
  probe.

Over-matching is safe in this alphabet: it decides only what gets *checked*, so an
invented spelling costs a redundant check while a missing one ships an unlabeled fill.

**Reverse-verified by mutation sweep, and the sweep is why two of the points above
exist.** Eight mutations of the guard each fail the corpus: drop the shorthand wrapper,
drop the token boundary, stop measuring the label alpha, revert `var()` to the
one-argument spelling, read an unparseable alpha as opaque, flip either `null`
direction, lower the threshold. Two were **found by the sweep, not by review**:

1. Reverting `BARE_ACCENT_VAR` to the one-argument spelling **passed silently** — the
   var side had no corpus rows at all. That is the reported defect one level up: the fix
   was verified by hand instead of pinned. `VAR_SPELLINGS` exists because of that miss.
2. `markAlpha` first returned `1` for an unparseable modifier, which is fail-closed for
   a mark and fail-**open** for a label once the label scan reuses it —
   `bg-mint text-primary-foreground/[oops]` would have licensed the fill.

**40/40** out-of-tree probe cases hold besides.

**Zero pixels move.** Every newly covered spelling has **0 live sites**, and all 23 live
label sites are already bare, so nothing in the tree changes colour. `npm run
validate:theme` passes unchanged on the real tree.

### Commit 10 — one owner per accent primitive (review round 8, 7× P2)

Round 8 returned seven findings, and six of them are one class on its **third
consecutive head**, so the circuit breaker tripped again and the fix went structural
rather than to the six sites. The seventh (`PIVV`, "wire the guard into an enforced build
path") is **factually wrong** and was rebutted rather than fixed: `.github/workflows/lint.yml:48`
has run `npm run validate:theme` on every PR since `731f72784` (2026-05-13), and `lint` is
the only `pull_request`-triggered workflow in the repo.

**This round also corrects something commit 9 published.** Commit 9 claimed the accent
guard now had "one spelling source". That was overstated. The utility half did — but
`accentsOfValue`, the CSS resolver, was a **fourth** independently written `var(...)`
pattern, ending at `\)` where the shared one ends at `(?=[,)])`. So round 8's first
finding is commit 9's class one level below where commit 9 closed it.

Named properly, the class is: **one semantic question answered by several independently
written matchers, over surfaces enumerated at the comparison site where nothing could test
them.** The guard has two engines — a TS/TSX text+AST scan and a PostCSS scan — and each
re-derived the same four primitives. So each primitive now has one owner, and every
enumeration a finding reached became a table with rows:

| Primitive | Was | Now |
| --- | --- | --- |
| is this name an accent | 4 hand-written `var()` patterns | `varReferenceSource()`, called by both engines |
| how opaque is this paint | `/1` read as the fraction 1 | the brackets carry the unit, not the magnitude |
| does this property paint an area or a glyph | `stroke`/`fill` compared inline | `CSS_PAINTED_SURFACE`, `canvas` / `labelled` / `glyph` |
| what is the label's scope | class string, JSX attributes, **object literal** | class string, JSX attributes |

Two of those are fail-closed narrowings I made independently, because a narrowing can only
*reject more* — it cannot introduce a false negative, so the only risk is false positives on
live sites, and both were measured at zero before committing:

- **A state that repaints the label withdraws it.** `bg-mint text-primary-foreground
  hover:text-muted` read as paired; on hover the fill is still vivid mint under muted grey
  glyphs. Refused rather than modelled — reasoning about which Tailwind variants overlap
  means an algebra over `hover:` inside `md:`, `group-hover:`, and runtime `aria-*`, and a
  guard that clears marks on its own arithmetic is worse than one that fails closed. Font
  **sizes** are exempted rather than colours enumerated, since `text-` is two utilities under
  one prefix: a missed size is a loud false positive, a colour mistaken for a size is a silent
  hole.
- **An object literal is not a shared scope.** The reviewer's case was mutually exclusive
  variant values; the live shape was worse. The one site the scope carried is
  `agentBackends.ts`'s `{ tileCls: 'bg-gold', iconCls: 'text-gold-foreground' }` — the
  consumer puts one on the wrapper and the other on the glyph *inside* it, so it is the
  **parent/child pairing this guard explicitly refuses** (ledger #4), admitted through a
  syntactic side door. Two unsound readings, no site that needs it.

Plus two straightforward corrections: `placeholder-` prints ink but no longer counts as the
label (a placeholder is exactly the text that is gone once there is text to read), and
`background: var(--mint)` is now the accent mark it always was, cleared by an in-rule
`color:` naming that accent's `-ink` or `-foreground` — the same rule `bg-` follows, and the
one the stylesheet's own `--success` strip already writes.

**Four new corpora, and `CSS_SPELLINGS` is the point.** The CSS resolver had **no rows at
all**, which is exactly how its finding shipped — the same defect one level up from round 7's.
So the rule is now that every predicate answering "does this name an accent" owes this file
rows: `CSS_SPELLINGS` (15 rows, resolving through an alias, a fallback-bearing alias, a
`color-mix()` wrapper and a deliberate reference cycle), `CSS_PAINT_SPELLINGS` (10, including
the hairlines that are deliberately **out** of scope), `LABEL_UTILITY_SPELLINGS` (4), plus 3
new `ACCENT_SPELLINGS` and 13 new `LABEL_SPELLINGS` rows. The corpora now also run **before**
the CSS scan: dropping `background` from the table used to surface as a stale pin three
screens away instead of as the row naming the property.

**Reverse-verified: 14 mutations, all caught.** Each introduces the defect one new assertion
describes — revert the `var()` boundary, drop `background` from the table, delete a live pin,
read the label off the wrong property, accept only `-foreground`, flip `placeholder` back to a
label, three separate misreadings of the opacity unit (including the plausible "1 means fully
opaque"), disable the state-repaint check, disable the size exemption, widen it to any
bracketed value, restore the object-literal scope, delete the pin it cost. The 56-case
out-of-tree probe harness holds alongside.

**Zero pixels move.** The widened CSS scan costs 7 new `ACCEPTED_ACCENT_WASHES` pins, all
7.8–14.1% `color-mix` washes (ledger #9); the scope narrowing costs one `ACCEPTED_BARE_FILLS`
pin (ledger #10). `placeholder-` has 0 live sites in both directions, and 0 of the 15 sites
pairing an accent fill with a state `text-` override paints a vivid fill.

## Known-by-design ledger

Re-flags on any of these are answered by linking to this entry.

| # | Held back | Why |
| --- | --- | --- |
| 1 | Ten control-chrome sites keep the bare fill | Their state is carried by knob position or bar length, not by the colour reading on its own, and repainting a large light-theme shape is a `design.pen` decision rather than a guard decision. **Pinned, not skipped** — by file, accent, reason and construct signature, so removing one goes stale loudly and a different bare mark under the same key still fails. |
| 2 | 46 opaque `border-` / `ring-` / `outline-` / `accent-` accent utilities | The same open `design.pen` question as #1 — a 1px border is not read the way a filled shape is — across 38 border, 3 ring, 2 outline and 3 accent sites. `bg` / `fill` / `stroke` and the gradient stops are guarded; these are measured and recorded here rather than silently recoloured to satisfy a guard. `divide-` is out for the same reason. The exclusion is written at the `MARK_UTILITIES` declaration so it reads as a decision, not an omission — and a hairline still cannot *license* a fill (commit 8). |
| 3 | Accent opacity washes below alpha 0.9 (`bg-mint/10`, `bg-cyan/[0.10]`, …) | A wash has no contrast ratio of its own — the same reasoning as `requireMeasurableColor`. At or above 0.9 that defence is gone, so commit 8 guards that band; below it, 844 sites stay out, of which 35 sit in a real grey zone (`/50`, `/55`, `/60`, `/70`) where a half-opacity accent's status is a `design.pen` question, not a guard question. Independently a reuse-ladder problem: ~370 sit where an `--X-soft` token already exists. Large enough to be its own change. |
| 4 | A label on a **child** element is not an accepted pairing scope | The accepted scopes are the same class string and a sibling attribute of one JSX element. A subtree scope would let any descendant's label excuse a parent's fill — the false negative the AST rewrite in commit 3 removed. Commit 10 removed the **object literal** as a third scope for the same reason: `{ tileCls, iconCls }` is a parent and its child wearing sibling clothes, since the consumer puts one class on the wrapper and the other on the glyph inside it. Mutually exclusive variant values in one map read the same way. |
| 5 | Every assertion states a property, never an enumeration | "No bare accent mark without a label", "no `var(--accent)` in a TS string", "alpha at or above 0.9 is the fill" — not a list of forbidden spellings, so a carrier invented later fails a gate instead of costing a review round. Round 6 was this rule being paid for twice, and round 7 a third time: every finding in both rounds was an enumeration that had stayed behind. Commit 9 replaces the last of them with boundary assertions, so the property is now stated in the pattern rather than in a list. |
| 6 | No pin map for the TS-string rule | Zero sites need an exception. An empty pin map is speculative machinery; it gets added with the first real exception, keyed like the others. |
| 7 | `bg-[var(--mint)]` is rejected even when it is correctly paired | The TS-string rule (ledger #6) has no pin map, and a `className` literal is a TS string, so the arbitrary-value spelling trips it regardless of the label. This is not a false positive to suppress: the remedy is to write `bg-(--mint)` or `bg-mint`, both of which pair normally. Keeping one spelling unavailable is cheaper than giving that rule an exception surface. |
| 8 | The guard reads literals, not composed names | It is a static scan, so `` `bg-${accent}` `` is invisible to it. Every current accent call site is a literal; a composed one would need a lint rule or a runtime assertion, which is a different change. Declared here rather than left as an implied guarantee. |
| 9 | Seven CSS background washes are pinned rather than repainted | Commit 10 widened the CSS scan from `stroke`/`fill` to the backgrounds, and `ACCEPTED_ACCENT_WASHES` grew 1 → 8. All seven new entries are 7.8–14.1% `color-mix` washes, so **no pixels moved**; what the widening closes is the next *opaque* `background: var(--accent)`, the one spelling of an unlabeled fill no scan could see. Two shapes recur and both are undecidable here rather than wrong — a label declared on a *different* rule that matches the same element (`class="strip strip--error"`), and a label on a child (`.model-hub-adopt-failure > svg`) — so each pin names which it is. Keyed by the resolved declaration, not its address, so retinting a pinned wash fails twice over. |
| 10 | `src/lib/agentBackends.ts` keeps its bare `bg-gold` tile | The pin the object-literal narrowing cost (ledger #4). The tile holds only the icon, which the neighbouring `iconCls` paints `text-gold-foreground` — true of the rendered DOM, not provable from the source, so it is pinned with what the consumer does rather than inferred. Writing it surfaced a `design.pen` question recorded under follow-ups: codex is the **only** one of the three backends with a vivid tile. |

## Follow-ups (not in this PR)

- ~20 hard-coded glow shadows such as `shadow-[0_0_8px_rgba(91,255,160,0.9)]`
  and `rgba(245,200,92,0.9)` — the *dark* mint/gold literals, used in **both**
  themes. Same root cause, separable change.
- `src/lib/agentGraph.ts:195` uses `bg-amber-500`, a raw Tailwind palette colour
  rather than a theme token.
- the ten pinned control-chrome sites and the 46 opaque `border`/`ring`/`outline`/
  `accent` utilities, both pending the same `design.pen` call — ledger #1 and #2.
- the file-extension icon map is **duplicated** between `FileTree.tsx` and
  `AppsFileBrowserPage.tsx`. Both were fixed identically here; the third repeat
  should promote it to one module.
- the **codex** backend tile is the only vivid one of the three: `agentBackends.ts` gives
  claude `bg-cyan-soft` / `text-cyan-ink` and opencode `bg-violet-soft` / `text-violet-ink`,
  but codex `bg-gold` / `text-gold-foreground`. Consistent by accident or by intent is a
  `design.pen` call, so it is pinned (ledger #10) rather than recoloured here.
- `.model-hub-add-key-strip--success` declares `color: var(--mint-ink)` in-rule while its
  `--error` and `--advisory` siblings declare only the background, inheriting their text
  colour from the base `.model-hub-add-key-strip` rule. Both are pinned washes today; making
  the three strips symmetric would let two pins go.
- **~370 ad-hoc accent opacity washes** (`bg-mint/10`, `bg-gold/15`,
  `bg-cyan/[0.10]`, …) sitting where `--X-soft` tokens already exist. Surfaced by
  round 4: a reuse-ladder problem, not a contrast one, and large enough to be its
  own change.




