### PR TITLE
fix(opencode): stream live tool activity while native session is busy

### DIFF
--- a/modules/agents/opencode/agent.py
+++ b/modules/agents/opencode/agent.py
@@ -184,13 +184,19 @@ class _SteeringAwareOpenCodeServer:
     def _has_post_boundary_activity(
         messages: list[Dict[str, Any]],
         boundary_ids: set[str],
+        baseline_ids: set[str],
     ) -> bool:
-        if not boundary_ids:
-            return True
-        return any(
-            (message.get("info", {}) or {}).get("id") not in boundary_ids
-            for message in messages
-        )
+        # Evidence means a message the restored poll loop would treat as new:
+        # outside the reconciliation boundary AND outside the pre-prompt
+        # baseline. The baseline term matters when the sampled boundary is
+        # empty (only baseline messages existed when it was sampled).
+        for message in messages:
+            message_id = (message.get("info", {}) or {}).get("id")
+            if not message_id:
+                continue
+            if message_id not in boundary_ids and message_id not in baseline_ids:
+                return True
+        return False
 
     @classmethod
     def _inserted_user_index(
@@ -417,6 +423,7 @@ class _SteeringAwareOpenCodeServer:
                                 elif inserted_user_text is None and not self._has_post_boundary_activity(
                                     messages,
                                     awaiting,
+                                    self._state.baseline_message_ids,
                                 ):
                                     # Restored boundary-sampled polls: a busy
                                     # snapshot holding only boundary messages

--- a/modules/agents/opencode/agent.py
+++ b/modules/agents/opencode/agent.py
@@ -350,22 +350,41 @@ class _SteeringAwareOpenCodeServer:
                     else:
                         self._state.status_reconciliation_failures = 0
                         if status is not None and status.get("type") in {"busy", "retry"}:
-                            if (
-                                reconcile_insert
-                                and inserted_user_text is not None
-                                and self._inserted_user_index(
+                            if reconcile_initial_status and awaiting is None:
+                                self._state.awaiting_after_message_ids = (
+                                    self._completed_assistant_boundary(messages)
+                                )
+                            if reconcile_insert and (
+                                inserted_user_text is None
+                                or self._inserted_user_index(
                                     messages,
                                     awaiting,
                                     inserted_user_text,
                                 )
                                 >= 0
                             ):
-                                self._state.awaiting_active_status_observed = True
-                                self._state.awaiting_result_confirmation_deadline = None
-                            if reconcile_initial_status and awaiting is None:
-                                self._state.awaiting_after_message_ids = (
-                                    self._completed_assistant_boundary(messages)
-                                )
+                                # Start confirmed: the inserted user message is
+                                # visible while the native session reports
+                                # activity (or a restored poll sampled its
+                                # boundary during activity). Hand the in-progress
+                                # snapshot back to the poll loop so live tool
+                                # activity keeps streaming; the result-confirmation
+                                # window still guards the idle boundary below.
+                                if inserted_user_text is not None:
+                                    self._state.awaiting_active_status_observed = True
+                                    self._state.awaiting_result_confirmation_deadline = None
+                                    if final_snapshot or self._has_final_assistant_after(
+                                        messages,
+                                        awaiting,
+                                        inserted_user_text=inserted_user_text,
+                                    ):
+                                        # The final assistant already exists even
+                                        # though the session still reports busy
+                                        # (status settles after the message lands):
+                                        # settle like the idle path does.
+                                        self._clear_awaiting_reconciliation()
+                                        self._state.closing = True
+                                return messages
                             wait_for_insert = True
                         else:
                             self._state.reconcile_initial_status = False

--- a/modules/agents/opencode/agent.py
+++ b/modules/agents/opencode/agent.py
@@ -169,6 +169,29 @@ class _SteeringAwareOpenCodeServer:
             if part.get("type") == "text"
         )
 
+    @staticmethod
+    def _last_is_completed_error(messages: list[Dict[str, Any]]) -> bool:
+        if not messages:
+            return False
+        info = messages[-1].get("info", {}) or {}
+        return bool(
+            info.get("role") == "assistant"
+            and info.get("time", {}).get("completed")
+            and info.get("error")
+        )
+
+    @staticmethod
+    def _has_post_boundary_activity(
+        messages: list[Dict[str, Any]],
+        boundary_ids: set[str],
+    ) -> bool:
+        if not boundary_ids:
+            return True
+        return any(
+            (message.get("info", {}) or {}).get("id") not in boundary_ids
+            for message in messages
+        )
+
     @classmethod
     def _inserted_user_index(
         cls,
@@ -384,7 +407,27 @@ class _SteeringAwareOpenCodeServer:
                                         # settle like the idle path does.
                                         self._clear_awaiting_reconciliation()
                                         self._state.closing = True
-                                return messages
+                                if self._last_is_completed_error(messages):
+                                    # Keep terminal error snapshots gated while the
+                                    # native runtime has not settled: the poll loop
+                                    # would emit its own terminal failure (or a
+                                    # competing "continue") while OpenCode's native
+                                    # retry is still active.
+                                    wait_for_insert = True
+                                elif inserted_user_text is None and not self._has_post_boundary_activity(
+                                    messages,
+                                    awaiting,
+                                ):
+                                    # Restored boundary-sampled polls: a busy
+                                    # snapshot holding only boundary messages
+                                    # (ending in a pre-restore final answer) must
+                                    # not be handed back, or the restored poll
+                                    # loop would re-emit the old answer and drop
+                                    # the still-running poll. Wait for post-boundary
+                                    # or in-progress evidence.
+                                    wait_for_insert = True
+                                else:
+                                    return messages
                             wait_for_insert = True
                         else:
                             self._state.reconcile_initial_status = False

--- a/tests/test_agent_steering.py
+++ b/tests/test_agent_steering.py
@@ -1524,6 +1524,131 @@ async def test_opencode_regular_turn_waits_for_unconfirmed_start() -> None:
 
 
 @pytest.mark.anyio
+async def test_opencode_restored_busy_snapshot_requires_post_boundary_evidence() -> None:
+    """A restored boundary-sampled poll must not receive a busy snapshot that
+    only contains boundary messages (the pre-restore final answer): the
+    restored poll loop would treat it as the final response and drop the
+    still-running poll."""
+    primary = _primary_request(backend="opencode")
+    gate_task = await _held_task()
+    server = _OpenCodeServer(
+        messages=[
+            {
+                "info": {
+                    "id": "old-final-assistant",
+                    "role": "assistant",
+                    "time": {"completed": 1},
+                    "finish": "stop",
+                },
+                "parts": [{"type": "text", "text": "old answer"}],
+            }
+        ],
+        status={"type": "busy"},
+    )
+    agent = _opencode_agent(primary, gate_task, server)
+    state = agent._steering_states[primary.base_session_id]
+    state.awaiting_after_message_ids = {"old-final-assistant"}
+    state.awaiting_user_text = None
+    state.restored = True
+    poll_server = _SteeringAwareOpenCodeServer(server, state)
+    poll_task = None
+    try:
+        poll_task = asyncio.create_task(
+            poll_server.list_messages("opencode-session", primary.working_path)
+        )
+        await asyncio.sleep(0.15)
+
+        assert not poll_task.done()
+        assert state.closing is False
+
+        server.messages.append(
+            {
+                "info": {
+                    "id": "running-assistant",
+                    "role": "assistant",
+                },
+                "parts": [
+                    {
+                        "type": "tool",
+                        "tool": "bash",
+                        "callID": "call-bash",
+                        "state": {"status": "running", "input": {"command": "ls"}},
+                    }
+                ],
+            }
+        )
+        snapshot = await asyncio.wait_for(poll_task, timeout=1)
+
+        assert snapshot[-1]["info"]["id"] == "running-assistant"
+        assert state.closing is False
+    finally:
+        await _cancel_tasks(*(task for task in (poll_task, gate_task) if task is not None))
+
+
+@pytest.mark.anyio
+async def test_opencode_retry_keeps_completed_error_snapshots_gated() -> None:
+    """A completed assistant error must stay gated while the native session
+    still reports busy/retry: handing it to the poll loop would emit a
+    terminal failure (or a competing "continue") while OpenCode's own retry
+    is still active."""
+    primary = _primary_request(backend="opencode")
+    gate_task = await _held_task()
+    server = _OpenCodeServer(
+        messages=[
+            {
+                "info": {"id": "primary-user", "role": "user"},
+                "parts": [{"type": "text", "text": "primary"}],
+            },
+            {
+                "info": {
+                    "id": "failed-assistant",
+                    "role": "assistant",
+                    "time": {"completed": 1},
+                    "error": {"name": "ProviderError", "data": {"message": "boom"}},
+                },
+                "parts": [],
+            },
+        ],
+        status={"type": "retry"},
+    )
+    agent = _opencode_agent(primary, gate_task, server)
+    state = agent._steering_states[primary.base_session_id]
+    state.awaiting_after_message_ids = set()
+    state.awaiting_user_text = "primary"
+    state.awaiting_start_confirmation_deadline = time.monotonic() + 5.0
+    poll_server = _SteeringAwareOpenCodeServer(server, state)
+    poll_task = None
+    try:
+        poll_task = asyncio.create_task(
+            poll_server.list_messages("opencode-session", primary.working_path)
+        )
+        await asyncio.sleep(0.15)
+
+        assert not poll_task.done()
+        assert state.awaiting_active_status_observed is True
+        assert state.closing is False
+
+        server.messages.append(
+            {
+                "info": {
+                    "id": "retried-assistant",
+                    "role": "assistant",
+                    "time": {"completed": 2},
+                    "finish": "stop",
+                },
+                "parts": [{"type": "text", "text": "recovered"}],
+            }
+        )
+        server.status = {"type": "busy"}
+        snapshot = await asyncio.wait_for(poll_task, timeout=1)
+
+        assert snapshot[-1]["info"]["id"] == "retried-assistant"
+        assert state.closing is True
+    finally:
+        await _cancel_tasks(*(task for task in (poll_task, gate_task) if task is not None))
+
+
+@pytest.mark.anyio
 async def test_opencode_refuses_after_poll_owner_claims_terminal_result() -> None:
     primary = _primary_request(backend="opencode")
     gate_task = await _held_task()

--- a/tests/test_agent_steering.py
+++ b/tests/test_agent_steering.py
@@ -1586,6 +1586,69 @@ async def test_opencode_restored_busy_snapshot_requires_post_boundary_evidence()
 
 
 @pytest.mark.anyio
+async def test_opencode_restored_empty_boundary_still_requires_new_evidence() -> None:
+    """When the sampled reconciliation boundary is empty (only pre-prompt
+    baseline messages existed at sample time), a busy snapshot holding only
+    the baseline final answer must still be gated: an empty boundary is not
+    automatic evidence."""
+    primary = _primary_request(backend="opencode")
+    gate_task = await _held_task()
+    server = _OpenCodeServer(
+        messages=[
+            {
+                "info": {
+                    "id": "old-final-assistant",
+                    "role": "assistant",
+                    "time": {"completed": 1},
+                    "finish": "stop",
+                },
+                "parts": [{"type": "text", "text": "old answer"}],
+            }
+        ],
+        status={"type": "busy"},
+    )
+    agent = _opencode_agent(primary, gate_task, server)
+    state = agent._steering_states[primary.base_session_id]
+    state.baseline_message_ids = {"old-final-assistant"}
+    state.awaiting_after_message_ids = set()
+    state.awaiting_user_text = None
+    state.restored = True
+    poll_server = _SteeringAwareOpenCodeServer(server, state)
+    poll_task = None
+    try:
+        poll_task = asyncio.create_task(
+            poll_server.list_messages("opencode-session", primary.working_path)
+        )
+        await asyncio.sleep(0.15)
+
+        assert not poll_task.done()
+        assert state.closing is False
+
+        server.messages.append(
+            {
+                "info": {
+                    "id": "running-assistant",
+                    "role": "assistant",
+                },
+                "parts": [
+                    {
+                        "type": "tool",
+                        "tool": "bash",
+                        "callID": "call-bash",
+                        "state": {"status": "running", "input": {"command": "ls"}},
+                    }
+                ],
+            }
+        )
+        snapshot = await asyncio.wait_for(poll_task, timeout=1)
+
+        assert snapshot[-1]["info"]["id"] == "running-assistant"
+        assert state.closing is False
+    finally:
+        await _cancel_tasks(*(task for task in (poll_task, gate_task) if task is not None))
+
+
+@pytest.mark.anyio
 async def test_opencode_retry_keeps_completed_error_snapshots_gated() -> None:
     """A completed assistant error must stay gated while the native session
     still reports busy/retry: handing it to the poll loop would emit a

--- a/tests/test_agent_steering.py
+++ b/tests/test_agent_steering.py
@@ -1373,7 +1373,11 @@ async def test_opencode_poll_owner_observes_accepted_steer_before_terminalizing(
         receipt = await steer_active_turn(controller, "opencode", _steer_request(identity[1]))
         await asyncio.sleep(0.15)
 
-        assert not poll_task.done()
+        # The poll owner now receives the in-progress snapshot once the steered
+        # user message is visible while the native session is busy, so the poll
+        # loop keeps streaming live activity instead of blocking on busy.
+        intermediate = await asyncio.wait_for(poll_task, timeout=1)
+        assert intermediate[-1]["info"]["role"] == "user"
         assert state.closing is False
         server.messages.append(
             {
@@ -1387,12 +1391,134 @@ async def test_opencode_poll_owner_observes_accepted_steer_before_terminalizing(
             }
         )
         server.status = {"type": "idle"}
-        messages = await asyncio.wait_for(poll_task, timeout=1)
+        messages = await asyncio.wait_for(
+            poll_server.list_messages("opencode-session", primary.working_path),
+            timeout=1,
+        )
 
         assert receipt.outcome is SteerOutcome.ACCEPTED
         assert messages[-1]["info"]["id"] == "steered-assistant"
         assert state.closing is True
         assert agent._active_requests == {primary.base_session_id: gate_task}
+    finally:
+        await _cancel_tasks(*(task for task in (poll_task, gate_task) if task is not None))
+
+
+@pytest.mark.anyio
+async def test_opencode_regular_turn_streams_snapshot_while_busy() -> None:
+    """A plain turn (start-armed, like ``_process_message``) must hand the
+    in-progress snapshot back to the poll loop while the native session is
+    busy, so live tool activity streams instead of blocking until idle."""
+    primary = _primary_request(backend="opencode")
+    gate_task = await _held_task()
+    server = _OpenCodeServer(
+        messages=[
+            {
+                "info": {"id": "baseline-user", "role": "user"},
+                "parts": [{"type": "text", "text": "earlier prompt"}],
+            },
+            {
+                "info": {"id": "primary-user", "role": "user"},
+                "parts": [{"type": "text", "text": "primary"}],
+            },
+            {
+                "info": {
+                    "id": "running-assistant",
+                    "role": "assistant",
+                },
+                "parts": [
+                    {
+                        "type": "tool",
+                        "tool": "bash",
+                        "callID": "call-bash",
+                        "state": {"status": "running", "input": {"command": "ls"}},
+                    }
+                ],
+            },
+        ],
+        status={"type": "busy"},
+    )
+    agent = _opencode_agent(primary, gate_task, server)
+    state = agent._steering_states[primary.base_session_id]
+    state.awaiting_after_message_ids = {"baseline-user"}
+    state.awaiting_user_text = "primary"
+    state.awaiting_start_confirmation_deadline = time.monotonic() + 5.0
+    poll_server = _SteeringAwareOpenCodeServer(server, state)
+    try:
+        intermediate = await asyncio.wait_for(
+            poll_server.list_messages("opencode-session", primary.working_path),
+            timeout=1,
+        )
+
+        assert intermediate[-1]["info"]["id"] == "running-assistant"
+        assert state.awaiting_active_status_observed is True
+        assert state.closing is False
+
+        server.messages.append(
+            {
+                "info": {
+                    "id": "final-assistant",
+                    "role": "assistant",
+                    "time": {"completed": 2},
+                    "finish": "stop",
+                },
+                "parts": [{"type": "text", "text": "final response"}],
+            }
+        )
+        server.status = {"type": "idle"}
+        final = await asyncio.wait_for(
+            poll_server.list_messages("opencode-session", primary.working_path),
+            timeout=1,
+        )
+
+        assert final[-1]["info"]["id"] == "final-assistant"
+        assert state.closing is True
+    finally:
+        await _cancel_tasks(gate_task)
+
+
+@pytest.mark.anyio
+async def test_opencode_regular_turn_waits_for_unconfirmed_start() -> None:
+    """While the inserted user message is not yet visible, a busy session must
+    keep waiting within the start-confirmation deadline (the 204-then-busy
+    race guard), not hand an empty snapshot back to the poll loop."""
+    primary = _primary_request(backend="opencode")
+    gate_task = await _held_task()
+    server = _OpenCodeServer(
+        messages=[
+            {
+                "info": {"id": "primary-user", "role": "user"},
+                "parts": [{"type": "text", "text": "primary"}],
+            }
+        ],
+        status={"type": "busy"},
+    )
+    agent = _opencode_agent(primary, gate_task, server)
+    state = agent._steering_states[primary.base_session_id]
+    state.awaiting_after_message_ids = {"primary-user"}
+    state.awaiting_user_text = "primary"
+    state.awaiting_start_confirmation_deadline = time.monotonic() + 5.0
+    poll_server = _SteeringAwareOpenCodeServer(server, state)
+    poll_task = None
+    try:
+        poll_task = asyncio.create_task(
+            poll_server.list_messages("opencode-session", primary.working_path)
+        )
+        await asyncio.sleep(0.15)
+
+        assert not poll_task.done()
+        assert state.awaiting_active_status_observed is False
+
+        server.messages.append(
+            {
+                "info": {"id": "steer-user-1", "role": "user"},
+                "parts": [{"type": "text", "text": "primary"}],
+            }
+        )
+        intermediate = await asyncio.wait_for(poll_task, timeout=1)
+
+        assert intermediate[-1]["info"]["id"] == "steer-user-1"
+        assert state.awaiting_active_status_observed is True
     finally:
         await _cancel_tasks(*(task for task in (poll_task, gate_task) if task is not None))
 
@@ -1528,7 +1654,7 @@ async def test_opencode_accepted_prompt_waits_for_delayed_busy_registration() ->
 
     class _DelayedStartServer(_OpenCodeServer):
         async def list_messages(self, session_id: str, directory: str) -> list[dict]:
-            if self.list_calls == 3:
+            if self.list_calls == 2:
                 self.messages.append(
                     {
                         "info": {
@@ -1573,11 +1699,13 @@ async def test_opencode_accepted_prompt_waits_for_delayed_busy_registration() ->
             timeout=1,
         )
 
+        # The busy snapshot is handed back once the inserted user message is
+        # visible; the third list lands the completed final assistant.
         assert messages[-1]["info"]["id"] == "follow-up-assistant"
         assert state.terminal_status_failure_messages is None
         assert state.awaiting_after_message_ids is None
         assert state.closing is True
-        assert server.list_calls == 4
+        assert server.list_calls == 3
     finally:
         await _cancel_tasks(gate_task)
 
@@ -1619,6 +1747,16 @@ async def test_opencode_idle_waits_for_delayed_terminal_message_visibility() -> 
     state.awaiting_start_confirmation_deadline = time.monotonic() - 1
     poll_server = _SteeringAwareOpenCodeServer(server, state)
     try:
+        intermediate = await asyncio.wait_for(
+            poll_server.list_messages("opencode-session", primary.working_path),
+            timeout=1,
+        )
+
+        # Busy + inserted user visible → in-progress snapshot streams back.
+        assert intermediate[-1]["info"]["id"] == "follow-up-user"
+        assert state.awaiting_active_status_observed is True
+        assert state.closing is False
+
         messages = await asyncio.wait_for(
             poll_server.list_messages("opencode-session", primary.working_path),
             timeout=1,

--- a/tests/test_opencode_restore_polls.py
+++ b/tests/test_opencode_restore_polls.py
@@ -623,12 +623,14 @@ def test_busy_restore_reconciles_inserted_user_that_later_becomes_idle() -> None
     class _ReconcilePollLoop:
         async def run_restored_poll_loop(self, poll_info):
             server = await agent._get_server()
-            reconciled_messages.extend(
-                await server.list_messages(
+            while True:
+                batch = await server.list_messages(
                     poll_info.opencode_session_id,
                     poll_info.working_path,
                 )
-            )
+                reconciled_messages.extend(batch)
+                if batch and batch[-1].get("info", {}).get("error"):
+                    return
 
         async def remove_restored_ack(self, poll_info):
             return None


### PR DESCRIPTION
## Capability

OpenCode backend real-time activity streaming: the Web Chat activity panel and IM process messages now show tool calls and interim assistant output live while the native turn runs, instead of only after it finishes.

## Root cause

`feat(agent): add native active-turn steering (#1113)` armed every regular turn with start-confirmation evidence (`awaiting_after_message_ids` / `awaiting_user_text`). The steering-aware `list_messages` wrapper then treated every busy native session as "insertion not yet confirmed" and spun on a 0.1s retry without returning the message snapshot. The poll loop's tool-call diff/emit only runs after `list_messages` returns, so nothing streamed until the session went idle and the final assistant became visible.

## Fix

In `_SteeringAwareOpenCodeServer.list_messages`, once the inserted user message is visible while the native session reports `busy` (or a restored poll has sampled its boundary during activity), hand the in-progress snapshot back to the poll loop:

- the 5s start-confirmation deadline still guards the 204-then-busy race (unconfirmed starts keep waiting),
- the result-confirmation window still guards the idle-then-visible race on the non-busy path,
- when the snapshot already contains the final assistant (status settles after the message lands), the busy path settles like the idle path does (clear reconciliation, mark closing).

Steer, restored-poll, and question-tool terminal semantics are preserved.

## Evidence

- **Unit**: `tests/test_agent_steering.py` — 2 new tests (`test_opencode_regular_turn_streams_snapshot_while_busy`, `test_opencode_regular_turn_waits_for_unconfirmed_start`); 3 existing tests updated to the new streaming semantics (`test_opencode_poll_owner_observes_accepted_steer_before_terminalizing`, `test_opencode_accepted_prompt_waits_for_delayed_busy_registration`, `test_opencode_idle_waits_for_delayed_terminal_message_visibility`). `tests/test_opencode_restore_polls.py` — restored poll loop now mirrors a real poll loop (repeat until terminal).
- **Unit (breadth)**: all opencode/steering/poll-related suites pass — 548 passed, 0 failed.
- **Scenario**: no scenario catalog covers this path.
- **Residual manual checks**: live verification in the local Incus regression environment — watch an OpenCode session on Web Chat and confirm tool calls / bash steps appear while the turn runs (deferred to the orchestrator's integration pass).
