### PR TITLE
fix(workbench): one session-row ⋯ trigger, paired with its menu

### DIFF
--- a/ui/src/components/workbench/WorkbenchSidebar.sessionRow.test.tsx
+++ b/ui/src/components/workbench/WorkbenchSidebar.sessionRow.test.tsx
@@ -1,0 +1,120 @@
+import { createInstance } from 'i18next';
+import type { ReactElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { I18nextProvider, initReactI18next } from 'react-i18next';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it, vi } from 'vitest';
+
+import en from '../../i18n/en.json';
+import type { WorkbenchSession } from '../../context/ApiContext';
+import { SessionRow } from './WorkbenchSidebar';
+import { SESSION_ROW_MENU_POSITION_CLASS, SESSION_ROW_PIN_POSITION_CLASS } from './sessionRowLayout';
+
+// The row reaches five providers (four of them through useSessionActions). Replacing
+// just those hooks — and keeping the rest of each module real — renders the row itself
+// without mounting the whole Workbench tree around it. Mocked rather than provider-
+// wrapped so the rendered markup is the ROW and nothing else: the real ToastProvider
+// contributes its own absolutely-positioned container, which the rail assertion below
+// would read as a third rail control.
+vi.mock('../../context/ApiContext', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../context/ApiContext')>()),
+  useApi: () => ({ setSessionVisibility: vi.fn() }),
+}));
+vi.mock('../../context/WorkbenchProjectsContext', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../context/WorkbenchProjectsContext')>()),
+  useWorkbenchProjectsTree: () => ({
+    renameSession: vi.fn(),
+    forkSession: vi.fn(),
+    setSessionPinned: vi.fn(),
+    archiveSession: vi.fn(),
+  }),
+}));
+vi.mock('../../context/ToastContext', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../context/ToastContext')>()),
+  useToast: () => ({ showToast: vi.fn() }),
+}));
+vi.mock('../../context/ComposerBridgeContext', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../context/ComposerBridgeContext')>()),
+  useComposerInsertTarget: () => null,
+}));
+vi.mock('../../context/useUnsavedChangesActionGuard', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../context/useUnsavedChangesActionGuard')>()),
+  useUnsavedChangesActionGuard: () => () => null,
+}));
+
+const i18n = createInstance();
+void i18n.use(initReactI18next).init({
+  lng: 'en',
+  fallbackLng: 'en',
+  resources: { en: { translation: en } },
+  interpolation: { escapeValue: false },
+});
+
+const render = (ui: ReactElement) =>
+  renderToStaticMarkup(
+    <I18nextProvider i18n={i18n}>
+      <MemoryRouter>{ui}</MemoryRouter>
+    </I18nextProvider>,
+  );
+
+const session = (over: Partial<WorkbenchSession> = {}): WorkbenchSession =>
+  ({
+    id: 'ses_01J8XK5M8T',
+    scope_id: 'scope-1',
+    project_id: 'proj-1',
+    title: 'Model Hub',
+    status: 'active',
+    pinned: false,
+    agent_status: 'idle',
+    native_session_id: 'native-1',
+    ...over,
+  }) as WorkbenchSession;
+
+const row = (over: { canManageMetadata: boolean; pinned?: boolean }) =>
+  render(
+    <SessionRow
+      projectId="proj-1"
+      session={session({ pinned: over.pinned ?? false })}
+      unread={0}
+      canChat
+      canManageMetadata={over.canManageMetadata}
+    />,
+  );
+
+const countTriggers = (markup: string) =>
+  markup.split(`aria-label="${en.workbench.sessionActions}"`).length - 1;
+
+// Every control on the row's right-hand rail is placed by a shared offset constant,
+// so the rendered offsets are the geometry contract: a control added at a literal
+// offset shows up here as an extra (or wrong) entry.
+const railOffsets = (markup: string) => (markup.match(/\bright-[^\s"]+/g) ?? []).sort();
+
+// ── The ⋯ trigger and the menu it opens are one control ──────────────────────
+// A merge resolution re-introduced the pre-#1194 trigger next to the refactored one,
+// so the row printed TWO ⋯ buttons: the reinstated copy sat at a literal `right-2`,
+// i.e. half-overlapping the pin's hit area. The surviving copy was also left OUTSIDE
+// the `canManageMetadata` gate while the Popover it triggers is gated on it, so a
+// read-only row rendered a button that could not open anything.
+//
+// The property, not the two symptoms: the row offers an actions trigger exactly when
+// its Popover can open — `render count === Number(canManageMetadata)` over the whole
+// domain of the flag, so neither a duplicate nor a dead trigger can return.
+describe('session row actions rail', () => {
+  it('renders one ⋯ trigger when the menu can open, and none when it cannot', () => {
+    for (const canManageMetadata of [true, false]) {
+      const markup = row({ canManageMetadata });
+
+      expect(markup).toContain('Model Hub'); // the row rendered at all
+      expect(countTriggers(markup)).toBe(canManageMetadata ? 1 : 0);
+    }
+  });
+
+  it('places the rail on the shared offsets, so the pin and menu cannot overlap', () => {
+    // Pin + menu, each on its own constant — no third control, no literal offset.
+    expect(railOffsets(row({ canManageMetadata: true }))).toEqual(
+      [SESSION_ROW_MENU_POSITION_CLASS, SESSION_ROW_PIN_POSITION_CLASS].sort(),
+    );
+    // A read-only row has no rail: no pin, no menu, nothing to reserve space for.
+    expect(railOffsets(row({ canManageMetadata: false }))).toEqual([]);
+  });
+});

--- a/ui/src/components/workbench/WorkbenchSidebar.tsx
+++ b/ui/src/components/workbench/WorkbenchSidebar.tsx
@@ -206,7 +206,9 @@ const STATUS_DOT_CLASS: Record<string, string> = {
 // see sessionActions.tsx, which owns the items and the writes for every surface.
 // Rename is inline here: the commit calls the provider, whose session.activity
 // 'updated' event patches the title in this list, so no manual local patch.
-const SessionRow: React.FC<{
+// Exported for the row-level test: the rail's controls only exist when the row's
+// Popover can actually open, and that pairing is what a test has to hold onto.
+export const SessionRow: React.FC<{
   projectId: string;
   session: WorkbenchSession;
   unread: number;
@@ -352,18 +354,13 @@ const SessionRow: React.FC<{
                   onToggle={pinAction.onSelect}
                 />
               )}
-              <span className="absolute inset-y-0 right-2 flex items-center">
+              <span className={clsx('absolute inset-y-0 flex items-center', SESSION_ROW_MENU_POSITION_CLASS)}>
                 <PopoverTrigger asChild>
                   <SessionActionsTrigger label={t('workbench.sessionActions')} open={menuOpen} />
                 </PopoverTrigger>
               </span>
             </>
           )}
-          <span className={clsx('absolute inset-y-0 flex items-center', SESSION_ROW_MENU_POSITION_CLASS)}>
-            <PopoverTrigger asChild>
-              <SessionActionsTrigger label={t('workbench.sessionActions')} open={menuOpen} />
-            </PopoverTrigger>
-          </span>
         </div>
       </PopoverAnchor>
       <SessionActionMenuContent


### PR DESCRIPTION
## Capability

Every Workbench sidebar session row offers **one** ⋯ actions trigger, and only
when that row's action menu can actually open.

Two symptoms, one defect:

1. **A manageable row printed two ⋯ buttons.** `6023483d2`
   (`fix(workbench): compact sidebar session actions (#1194)`) refactored the
   trigger onto the shared rail constant `SESSION_ROW_MENU_POSITION_CLASS`
   (`right-0`), next to the pin's `SESSION_ROW_PIN_POSITION_CLASS` (`right-5`).
   The merge commit `bc0fa9f6e` (`chore(merge): integrate latest master`) then
   reinstated the pre-#1194 copy alongside it, at a literal `right-2` — the
   controls are `size-5` (1.25rem), so `right-2` (0.5rem) overlapped the pin's
   1.25–2.5rem band by half a rem. Two triggers, one of them on top of the pin.
2. **A read-only row rendered a dead button.** The surviving copy sat *outside*
   the `canManageMetadata &&` fragment while the Popover it triggers is gated on
   that same flag (`open={canManageMetadata && menuOpen}`), so a viewer without
   metadata rights got a ⋯ button that could not open anything.

The fix treats them as one thing, because they are: a trigger and the menu it
opens are a single control. The surviving trigger moves inside the gate, which
makes the pairing structural rather than something two call sites have to agree
about — the same shape `ProjectsPage.tsx` already uses, where the whole Popover
is gated. Net effect on the manageable row is nil apart from removing the
duplicate; the read-only row loses a control that never worked.

No visual change to a correctly-rendered row, so `design.pen` is untouched:
the rail geometry it specifies is what `sessionRowLayout.ts` already encodes,
and this PR stops a second control from violating it.

## Evidence

- **unit** — new `ui/src/components/workbench/WorkbenchSidebar.sessionRow.test.tsx`
  renders the real row (`SessionRow` is exported for it; the five provider hooks
  it reaches are replaced, the rest of each module left real) and asserts two
  properties rather than the two symptoms:
  - trigger count `=== Number(canManageMetadata)`, evaluated over the **whole
    domain** of the flag — so neither a duplicate nor a dead trigger can return;
  - the multiset of `right-*` offsets in the rendered row equals exactly
    `{SESSION_ROW_MENU_POSITION_CLASS, SESSION_ROW_PIN_POSITION_CLASS}` when
    manageable and is empty when not — so a control re-added at a literal offset
    fails here even if the count stays right.

  Both **reverse-verified**: reintroducing the `right-2` duplicate fails with
  `expected 2 to be 1` and `['right-0','right-2','right-5']`; moving the trigger
  back outside the gate fails with `expected 1 to be +0` and `['right-0']`.
- **contract** — none: no cross-boundary payload or interface shape changes.
- **scenario** — no scenario ID applies. `tests/scenarios/` covers auth setup,
  harness, memory, message delivery, Model Hub, Telegram topic routing and
  tunnel quality; the Workbench sidebar row has no catalog entry, and this fix
  is not large enough to justify opening one.
- **gates** — `npm run validate:theme && npm run build && npm run lint &&
  npm test` all pass in `ui/` (199 test files, 2125 tests).
- **residual manual check** — hover a sidebar session row in a browser and
  confirm a single ⋯ sits flush outside the pin, and that a read-only instance
  shows neither control. The assertions above are on rendered markup, which
  cannot observe the hover-reveal transition itself.

## Dependencies

None. Branched from `origin/master` at `e72b8cf89`, touches only
`WorkbenchSidebar.tsx` and its new test, and does not overlap #1410's files.
