### PR TITLE
fix(remote-access): restore technical details across the tunnel

### DIFF
--- a/tests/scenarios/tunnel_quality/catalog.yaml
+++ b/tests/scenarios/tunnel_quality/catalog.yaml
@@ -200,3 +200,9 @@ scenarios:
     kind: user_experience
     layer: browser
     test: null
+  - id: RA-TQ-032
+    name: Remote status keeps the Remote Access page fields while dropping host internals
+    status: covered
+    kind: network_policy
+    layer: contract
+    test: tests/test_remote_access_vibe_cloud.py::test_ra_tq_032_remote_status_keeps_page_fields_and_drops_host_internals

--- a/tests/test_remote_access_vibe_cloud.py
+++ b/tests/test_remote_access_vibe_cloud.py
@@ -152,6 +152,68 @@ def test_ra_tq_026_remote_status_ignores_spoofed_cf_ray(monkeypatch, tmp_path):
     assert config.remote_access.vibe_cloud.public_url == "https://alex.avibe.bot"
 
 
+def test_ra_tq_032_remote_status_keeps_page_fields_and_drops_host_internals(monkeypatch, tmp_path):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    config = _config()
+    config.save()
+    full_payload = {
+        "ok": True,
+        "provider": "vibe_cloud",
+        "enabled": True,
+        "public_url": "https://alex.avibe.bot",
+        "paired": True,
+        "running": True,
+        "pid": 4711,
+        "pid_state": "cloudflared",
+        "binary_found": True,
+        "binary_path": "/usr/local/bin/cloudflared",
+        "binary_version": "2024.1.0",
+        "transport_protocol": "http2",
+        "settings": {
+            "transport_protocol": "http2",
+            "auto_recovery": True,
+            "optimization_profile": "balanced",
+            "edge_ip_version": "4",
+            "edge_bind_address": "192.168.1.5",
+        },
+        "tunnel_quality": {"sampled_at": "2026-08-10T10:00:00Z", "grade": "good"},
+        "network_path": {
+            "schema_version": 1,
+            "provider": "Cloudflare",
+            "asn": 13335,
+            "client_access": "remote",
+        },
+    }
+    monkeypatch.setattr(remote_access, "status", lambda *a, **k: dict(full_payload))
+
+    client = ui_server.app.test_client()
+    client.set_cookie(
+        remote_access.SESSION_COOKIE_NAME,
+        _session_cookie(config),
+        domain="alex.avibe.bot",
+    )
+    remote_response = client.get(
+        "/api/remote-access/status",
+        base_url="https://alex.avibe.bot",
+    )
+    local_response = client.get(
+        "/api/remote-access/status",
+        base_url="http://127.0.0.1:5123",
+    )
+
+    assert remote_response.status_code == 200
+    remote_body = remote_response.get_json()
+    assert set(remote_body) == set(ui_server._REMOTE_ACCESS_STATUS_PUBLIC_FIELDS)
+    for sensitive in ("pid", "binary_found", "binary_path", "binary_version"):
+        assert sensitive not in remote_body
+    assert remote_body["network_path"] == full_payload["network_path"]
+    assert remote_body["settings"] == full_payload["settings"]
+    assert remote_body["pid_state"] == "cloudflared"
+
+    assert local_response.status_code == 200
+    assert local_response.get_json() == full_payload
+
+
 def test_session_cookie_roundtrip() -> None:
     config = _config()
 

--- a/ui/src/components/RemoteAccess.test.tsx
+++ b/ui/src/components/RemoteAccess.test.tsx
@@ -1,0 +1,106 @@
+/* @vitest-environment jsdom */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+
+import { RemoteAccess } from './RemoteAccess';
+import type { RemoteAccessStatus } from '../context/ApiContext';
+
+const api = vi.hoisted(() => ({
+  connectWorkbenchEvents: vi.fn(() => () => undefined),
+  diagnoseRemoteAccess: vi.fn(),
+  getRemoteAccessNetworkInterfaces: vi.fn(),
+  optimizeRemoteAccessRoute: vi.fn(),
+  pairVibeCloudRemoteAccess: vi.fn(),
+  remoteAccessStatus: vi.fn(),
+  saveRemoteAccessSettings: vi.fn(),
+  startRemoteAccess: vi.fn(),
+  stopRemoteAccess: vi.fn(),
+}));
+const showToast = vi.hoisted(() => vi.fn());
+
+vi.mock('../context/ApiContext', async (loadOriginal) => {
+  const original = await loadOriginal<typeof import('../context/ApiContext')>();
+  return { ...original, useApi: () => api };
+});
+
+vi.mock('../context/ToastContext', () => ({
+  useToast: () => ({ showToast }),
+}));
+
+vi.mock('react-i18next', () => ({
+  Trans: ({ i18nKey }: { i18nKey: string }) => <span>{i18nKey}</span>,
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+const runningStatus = (overrides: Partial<RemoteAccessStatus> = {}): RemoteAccessStatus => ({
+  ok: true,
+  enabled: true,
+  paired: true,
+  running: true,
+  public_url: 'https://alex.avibe.bot',
+  pid_state: 'cloudflared',
+  transport_protocol: 'http2',
+  settings: {
+    transport_protocol: 'http2',
+    auto_recovery: true,
+    optimization_profile: 'balanced',
+    edge_ip_version: '4',
+    edge_bind_address: '',
+  },
+  network_path: {
+    schema_version: 1,
+    provider: 'Cloudflare',
+    asn: 13335,
+    sampled_at: '2026-08-14T08:00:00Z',
+    locations_pending: false,
+    client_access: 'remote',
+    client_ingress: { colo: 'SIN', location: 'Singapore' },
+    connector: {
+      locations: [{ id: 'sin09', colo: 'SIN', location: 'Singapore' }],
+      edge_ips: ['198.41.192.47'],
+    },
+    route: { assessment: 'same_metro' },
+  },
+  ...overrides,
+});
+
+function renderPage() {
+  return render(<RemoteAccess />);
+}
+
+describe('RemoteAccess', () => {
+  beforeEach(() => {
+    api.connectWorkbenchEvents.mockReturnValue(() => undefined);
+    api.getRemoteAccessNetworkInterfaces.mockResolvedValue({ ok: true, interfaces: [] });
+    api.remoteAccessStatus.mockResolvedValue(runningStatus());
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it('RA-TQ-032 shows technical details when the remote status includes a network path', async () => {
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText('remoteAccess.networkTechnicalDetails')).toBeTruthy();
+    });
+    expect(screen.getByText('remoteAccess.networkPath')).toBeTruthy();
+    expect(screen.getByText('remoteAccess.controls')).toBeTruthy();
+  });
+
+  it('hides technical details when the remote projection omits the network path', async () => {
+    api.remoteAccessStatus.mockResolvedValue(runningStatus({ network_path: undefined }));
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText('remoteAccess.controls')).toBeTruthy();
+    });
+    expect(screen.queryByText('remoteAccess.networkTechnicalDetails')).toBeNull();
+    expect(screen.queryByText('remoteAccess.networkPath')).toBeNull();
+  });
+});

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -1349,6 +1349,21 @@ def _is_remote_access_request(config: V2Config) -> bool:
     return _remote_access_host_allowed(config, _effective_normalized_host())
 
 
+_REMOTE_ACCESS_STATUS_PUBLIC_FIELDS = (
+    "ok",
+    "provider",
+    "enabled",
+    "public_url",
+    "paired",
+    "running",
+    "pid_state",
+    "transport_protocol",
+    "settings",
+    "tunnel_quality",
+    "network_path",
+)
+
+
 def _remote_access_allowed_hosts(config: V2Config) -> frozenset[str]:
     public_host = _remote_access_public_host(config)
     if not public_host:
@@ -5967,26 +5982,14 @@ def remote_access_status():
         include_network_path=True,
     )
     if remote_request:
-        # The raw status exposes host internals — cloudflared PID, absolute
-        # binary path/version, the edge bind-address settings, and network-path
-        # diagnostics — none of which a remote caller needs and several of which
-        # fingerprint the host. The remote-visible UI (the Dashboard connector
-        # card) consumes only the public URL, the paired/running connector
-        # state, and the tunnel quality, so project exactly that and drop the
-        # rest at the boundary rather than relying on every future field staying
-        # inert across the tunnel.
+        # Keep host internals (cloudflared PID, absolute binary path/version)
+        # local-only. The Remote Access page itself is used across the tunnel,
+        # so the projection must still carry the fields that page renders:
+        # connector health, saved tunnel controls, quality, and the network
+        # path that owns the "Technical details" disclosure.
         status_payload = {
             key: status_payload[key]
-            for key in (
-                "ok",
-                "provider",
-                "enabled",
-                "public_url",
-                "paired",
-                "running",
-                "transport_protocol",
-                "tunnel_quality",
-            )
+            for key in _REMOTE_ACCESS_STATUS_PUBLIC_FIELDS
             if key in status_payload
         }
     return jsonify(status_payload)


### PR DESCRIPTION
## Capability

Restore the Remote Access page's Technical details disclosure when the UI is opened through the tunnel.

`3d7d98a57` projected `/api/remote-access/status` down to a Dashboard-sized subset for remote callers. That dropped `network_path`, `settings`, and `pid_state`. The page only renders Technical details when `running && network_path`, so the whole network-path block vanished and the remaining sections sat flush against each other.

## Change

- Keep host internals (`pid`, `binary_*`) local-only.
- Let the remote projection keep the fields the page actually renders: `pid_state`, `settings`, `network_path`, plus the existing connector/quality fields.
- Shared allowlist: `_REMOTE_ACCESS_STATUS_PUBLIC_FIELDS`.

## Scenarios

- RA-TQ-032: Remote status keeps the Remote Access page fields while dropping host internals

## Evidence

- unit: `ui/src/components/RemoteAccess.test.tsx` — Technical details renders when `network_path` is present and stays hidden when the projection omits it
- contract: `test_ra_tq_032_remote_status_keeps_page_fields_and_drops_host_internals`
- scenario: catalog RA-TQ-032
- residual manual: reopen `/admin/remote-access` through the paired public URL and confirm Technical details plus the gap under Tunnel controls

## Known-by-design

None.
