### PR TITLE
fix(ui): restore design.pen values for every accent ink and the light ring

### DIFF
--- a/ui/scripts/validate-theme.mjs
+++ b/ui/scripts/validate-theme.mjs
@@ -247,18 +247,18 @@ function contrastRatio(foreground, background) {
   return (lighter + 0.05) / (darker + 0.05);
 }
 
-// Brand fill/label pairs the owner has accepted against the AA floor. Avibe's
-// accents carry the product's personality — an AI-colleague product should read as
-// alive, not muted — so the light fills keep design.pen's saturation and the white
-// label the design drew, which is the pairing the palette shipped before it was
-// briefly deepened. Text on a neutral surface is a separate token (--X-ink) and
-// keeps the full floor; only the label printed on a brand fill is accepted here.
+// Measurements the owner has accepted below the WCAG floor. Avibe's accents carry
+// the product's personality — an AI-colleague product should read as alive, not
+// muted — so every accent keeps design.pen's value, and a brand value is never
+// moved to buy contrast. What that costs is recorded here rather than hidden:
+// the white label the design drew on a vivid light fill, and the mint focus ring
+// at 50% over the light surfaces. Owner decision 2026-08-14.
 //
-// These are pinned, not skipped. Each entry records the ratio the pair was accepted
-// at and the guard fails when the measured ratio moves off it, so an exemption still
-// catches drift: nudge either token and this list goes stale loudly, forcing a fresh
-// decision instead of quietly sliding further down. Owner decision 2026-08-14.
-const ACCEPTED_BRAND_PAIRS = new Map([
+// These are pinned, not skipped. Each entry records the ratio it was accepted at and
+// the guard fails when the measured ratio moves off it, so an exemption still catches
+// drift: nudge either token and this list goes stale loudly, forcing a fresh decision
+// instead of quietly sliding further down.
+const ACCEPTED_BRAND_RATIOS = new Map([
   ['light fill: --primary-foreground on --primary', 2.54],
   ['light fill: --accent-foreground on --accent', 3.68],
   ['light fill: --gold-foreground on --gold', 3.19],
@@ -267,43 +267,53 @@ const ACCEPTED_BRAND_PAIRS = new Map([
   // it and this guard could not see it. Naming --violet-foreground brings it under
   // the same pin as the rest instead of leaving it undeclared.
   ['dark fill: --violet-foreground on --violet', 4.38],
+  // The light ring is design.pen's mint at 50%, which composites to ~1.5:1 — a hint
+  // drawn beside a focused control, not the only cue for it. Dark needs no entry: the
+  // same token over the dark surfaces clears the non-text floor on its own.
+  ['light ring: --ring over --card', 1.61],
+  ['light ring: --ring over --background', 1.55],
+  ['light ring: --ring over --surface-3', 1.53],
 ]);
 const PIN_TOLERANCE = 0.01;
-const consultedBrandPairs = new Set();
+const consultedBrandRatios = new Set();
+
+// One ledger and one pin rule for every accepted measurement, whatever floor it was
+// measured against: text and non-text differ only in the floor passed in, so a second
+// exemption path can never drift away from this one.
+function assertRatio(name, measured, ratio, floor) {
+  const key = `${name}: ${measured}`;
+  const accepted = ACCEPTED_BRAND_RATIOS.get(key);
+  if (accepted !== undefined) {
+    consultedBrandRatios.add(key);
+    if (Math.abs(ratio - accepted) > PIN_TOLERANCE) {
+      throw new Error(
+        `${key} is ${ratio.toFixed(2)}:1, but ACCEPTED_BRAND_RATIOS pins it at ${accepted.toFixed(2)}:1. ` +
+          'This measurement is exempt from the WCAG floor by an owner decision taken at that exact ratio, ' +
+          'so moving either token needs a fresh decision — re-pin it here once the new value is intended.',
+      );
+    }
+    return;
+  }
+  if (ratio < floor) {
+    throw new Error(`${key} is ${ratio.toFixed(2)}:1, below WCAG AA ${floor}:1`);
+  }
+}
 
 function assertContrast(name, tokens, inkProp, surfaceProp) {
   const ink = requireMeasurableColor(name, inkProp, tokens.get(inkProp));
   const surface = requireMeasurableColor(name, surfaceProp, tokens.get(surfaceProp));
 
-  const ratio = contrastRatio(ink, surface);
-  const key = `${name}: ${inkProp} on ${surfaceProp}`;
-  const accepted = ACCEPTED_BRAND_PAIRS.get(key);
-  if (accepted !== undefined) {
-    consultedBrandPairs.add(key);
-    if (Math.abs(ratio - accepted) > PIN_TOLERANCE) {
-      throw new Error(
-        `${key} is ${ratio.toFixed(2)}:1, but ACCEPTED_BRAND_PAIRS pins it at ${accepted.toFixed(2)}:1. ` +
-          'This pair is exempt from the AA floor by an owner decision taken at that exact ratio, so moving ' +
-          'either token needs a fresh decision — re-pin it here once the new value is intended.',
-      );
-    }
-    return;
-  }
-  if (ratio < AA_SMALL_TEXT) {
-    throw new Error(
-      `${name}: ${inkProp} on ${surfaceProp} is ${ratio.toFixed(2)}:1, below WCAG AA ${AA_SMALL_TEXT}:1`,
-    );
-  }
+  assertRatio(name, `${inkProp} on ${surfaceProp}`, contrastRatio(ink, surface), AA_SMALL_TEXT);
 }
 
-// A pair that no longer exists must not keep its exemption: the tokens it excused
-// may have been renamed or dropped, and a stale entry would silently excuse whatever
-// takes that name next.
-function assertEveryAcceptedPairStillExists() {
-  const stale = [...ACCEPTED_BRAND_PAIRS.keys()].filter((key) => !consultedBrandPairs.has(key));
+// A measurement that no longer exists must not keep its exemption: the tokens it
+// excused may have been renamed or dropped, and a stale entry would silently excuse
+// whatever takes that name next.
+function assertEveryAcceptedRatioStillExists() {
+  const stale = [...ACCEPTED_BRAND_RATIOS.keys()].filter((key) => !consultedBrandRatios.has(key));
   if (stale.length > 0) {
     throw new Error(
-      `ACCEPTED_BRAND_PAIRS lists ${stale.join(', ')}, which no theme declares. Drop the entry.`,
+      `ACCEPTED_BRAND_RATIOS lists ${stale.join(', ')}, which no theme declares. Drop the entry.`,
     );
   }
 }
@@ -341,6 +351,19 @@ for (const [theme, tokens] of [['light', systemLight], ['dark', systemDark]]) {
   for (const fill of ACCENT_FILLS) {
     assertEqual(`${theme} ${fill} is defined`, tokens.has(fill), true);
     assertEqual(`${theme} ${fill} declares an ink`, tokens.has(`${fill}-ink`), true);
+    // --X-ink names the role an accent plays (a mark or small text rather than a
+    // fill); it is not a second, deepened palette. Both roles carry design.pen's
+    // value, so the ink equals the fill, and a light accent therefore reads
+    // 2.1-4.2:1 as text — under the AA floor by the owner decision above. This
+    // identity is what keeps that decision honest: re-deepening an ink to buy
+    // contrast fails here instead of shipping a palette nobody drew.
+    if (tokens.get(`${fill}-ink`) !== tokens.get(fill)) {
+      throw new Error(
+        `${theme} ${fill}-ink is ${tokens.get(`${fill}-ink`)} but ${fill} is ${tokens.get(fill)}. `
+          + 'An accent keeps its design value in both roles; move the design value if it should '
+          + 'change, and move both.',
+      );
+    }
   }
 
   for (const [semantic, palette] of SEMANTIC_FILL_ALIASES) {
@@ -377,8 +400,15 @@ for (const [theme, tokens] of [['light', systemLight], ['dark', systemDark]]) {
 
   // Inks are read as small text on a bare surface, so every one of them clears AA
   // against the darkest surface the theme owns. Derived from the token map rather
-  // than from ACCENT_FILLS so an ink added on its own is still covered.
-  const inks = [...NEUTRAL_INKS, ...[...tokens.keys()].filter((prop) => prop.endsWith('-ink'))];
+  // than from ACCENT_FILLS so an ink added on its own is still covered. Accent inks
+  // are the exception and are covered by the identity assertion above instead: they
+  // are brand values, and a floor here would just re-deepen the palette. Every ink
+  // therefore lands under exactly one of the two rules — none under neither.
+  const accentInks = new Set(ACCENT_FILLS.map((fill) => `${fill}-ink`));
+  const inks = [
+    ...NEUTRAL_INKS,
+    ...[...tokens.keys()].filter((prop) => prop.endsWith('-ink') && !accentInks.has(prop)),
+  ];
   for (const ink of inks) {
     assertEqual(`${theme} ${ink} is defined`, tokens.has(ink), true);
     for (const surface of INK_SURFACES) {
@@ -404,11 +434,7 @@ for (const [theme, tokens] of [['light', systemLight], ['dark', systemDark]]) {
   for (const surfaceProp of INK_SURFACES) {
     const surface = requireMeasurableColor(`${theme} ring`, surfaceProp, tokens.get(surfaceProp));
     const ratio = contrastRatio(compositeOver(ring, surface), surface);
-    if (ratio < AA_NON_TEXT) {
-      throw new Error(
-        `${theme} ring: --ring over ${surfaceProp} is ${ratio.toFixed(2)}:1, below WCAG AA ${AA_NON_TEXT}:1 for non-text`,
-      );
-    }
+    assertRatio(`${theme} ring`, `--ring over ${surfaceProp}`, ratio, AA_NON_TEXT);
   }
 }
 
@@ -449,7 +475,7 @@ function assertAccentAliasesKeepTheirTokenName(source) {
 }
 
 assertAccentAliasesKeepTheirTokenName(css);
-assertEveryAcceptedPairStillExists();
+assertEveryAcceptedRatioStillExists();
 
 const modelHub = (options) => resolveThemeTokens({ ...options, source: modelHubCss });
 const modelHubSystemDark = modelHub({ prefersLight: false, themeAttr: null });

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -166,9 +166,8 @@
   --cyan-soft: rgba(63, 224, 229, 0.16);
   --cyan-ink: #3fe0e5;
   --cyan-hover: #56e4e8;
-  /* The fill keeps design.pen's #7c5bff. Only the ink is lightened, because
-     #7c5bff read 4.28:1 as text on --card — the one dark accent below the
-     floor. Hue and saturation are unchanged.
+  /* Fill and ink both carry design.pen's #7c5bff. An accent is never moved off
+     its design value to buy contrast — see the light block for the decision.
      Violet is the only accent whose label is white in BOTH themes, which is why
      it needs its own --violet-foreground rather than borrowing a theme rule: the
      Button used a hard-coded text-white, so nothing declared the pair and the
@@ -177,7 +176,7 @@
   --violet: #7c5bff;
   --violet-soft: rgba(124, 91, 255, 0.16);
   --violet-foreground: #ffffff;
-  --violet-ink: #8465ff;
+  --violet-ink: #7c5bff;
   --violet-hover: #6d50e0;
   --gold: #ffc857;
   --gold-soft: rgba(255, 200, 87, 0.16);
@@ -245,11 +244,11 @@
        accepted at rather than skipping them — drift in either token changes
        the measured ratio and fails the guard until someone re-decides.
        --destructive needs no exemption: #e11d48 under white is 4.70:1.
-       Accent-as-text on a neutral surface is a separate token and keeps the
-       full AA floor; see the --mint-ink group. Owner decision 2026-08-14. */
+       Accent-as-text uses --X-ink, which carries the same brand value; see the
+       --mint-ink group. Owner decision 2026-08-14. */
     --primary: #10b981;
     --primary-foreground: #ffffff;
-    --primary-ink: #067a55;
+    --primary-ink: #10b981;
     /* Every brand fill darkens on hover here, because this theme's labels are white —
        see the dark block for why hover is a declared fill rather than a filter. */
     --primary-hover: #0ea372;
@@ -259,35 +258,34 @@
     --muted-soft: #eef1f7;
     --accent: #0891b2;
     --accent-foreground: #ffffff;
-    --accent-ink: #0e7490;
+    --accent-ink: #0891b2;
     --accent-hover: #07809d;
     --destructive: #e11d48;
     --destructive-foreground: #ffffff;
-    --destructive-ink: #ca1a41;
+    --destructive-ink: #e11d48;
     --destructive-hover: #c61a3f;
 
     --border: rgba(8, 8, 18, 0.08);
     --border-strong: rgba(8, 8, 18, 0.14);
     --input: rgba(8, 8, 18, 0.12);
-    /* The focus ring is an affordance drawn on a neutral surface, so it follows
-       the ink rather than the fill: the vivid fill at 50% composites to 1.5:1 on
-       every light surface, well under the 3:1 non-text floor. Mint ink at 85%
-       reads 3.7-4.0:1 while staying a ring rather than a hard stroke. */
-    --ring: rgba(6, 122, 85, 0.85);
+    /* design.pen's mint at 50%. It composites to ~1.5:1 on every light surface,
+       under the 3:1 non-text floor, and stays there by the same owner decision
+       as the fills above: the ring is a hint drawn beside a focused control,
+       and the brand value is not traded away to raise its ratio. */
+    --ring: rgba(16, 185, 129, 0.5);
 
-    /* Light is where fill and ink diverge. As small text on a light surface the
-       vivid fills read 2.2-4.2:1, so each --X-ink is deepened until it clears
-       WCAG AA (4.5:1) against --surface-3, the darkest light surface, keeping
-       the fill's hue and saturation. --violet already cleared the floor, so its
-       ink equals its fill. The washes below mix from the fill, which is why
-       they carry the fill's hex. */
+    /* Each --X-ink carries the same brand value as its fill: an accent is never
+       moved off its design value to buy contrast. As small text on a light
+       surface those values read 2.2-4.2:1, under WCAG AA (4.5:1), and stay
+       there by the owner decision of 2026-08-14 above. The washes below mix
+       from the fill, which is why they carry the fill's hex. */
     --mint: #10b981;
     --mint-soft: rgba(16, 185, 129, 0.14);
-    --mint-ink: #067a55;
+    --mint-ink: #10b981;
     --mint-hover: #0ea372;
     --cyan: #0891b2;
     --cyan-soft: rgba(8, 145, 178, 0.14);
-    --cyan-ink: #0e7490;
+    --cyan-ink: #0891b2;
     --cyan-hover: #07809d;
     --violet: #7c3aed;
     --violet-soft: rgba(124, 58, 237, 0.14);
@@ -297,11 +295,11 @@
     --gold: #d97706;
     --gold-soft: rgba(217, 119, 6, 0.14);
     --gold-foreground: #ffffff;
-    --gold-ink: #ae4f08;
+    --gold-ink: #d97706;
     --gold-hover: #bf6905;
     --pink: #dc2659;
     --pink-soft: rgba(220, 38, 89, 0.10);
-    --pink-ink: #c7204f;
+    --pink-ink: #dc2659;
 
     /* Light-theme page gradients (softer alphas over light base). */
     --gradient-console:
@@ -353,11 +351,12 @@
   --popover: #ffffff;
   --popover-foreground: #0a0a14;
 
-  /* Vivid fill + white label, deepened ink - see the prefers-color-scheme
-     block above. Both light blocks must stay value-identical. */
+  /* Vivid fill + white label, ink equal to the fill - see the
+     prefers-color-scheme block above. Both light blocks must stay
+     value-identical. */
   --primary: #10b981;
   --primary-foreground: #ffffff;
-  --primary-ink: #067a55;
+  --primary-ink: #10b981;
   /* Every brand fill darkens on hover here, because this theme's labels are white —
      see the dark block for why hover is a declared fill rather than a filter. */
   --primary-hover: #0ea372;
@@ -367,26 +366,26 @@
   --muted-soft: #eef1f7;
   --accent: #0891b2;
   --accent-foreground: #ffffff;
-  --accent-ink: #0e7490;
+  --accent-ink: #0891b2;
   --accent-hover: #07809d;
   --destructive: #e11d48;
   --destructive-foreground: #ffffff;
-  --destructive-ink: #ca1a41;
+  --destructive-ink: #e11d48;
   --destructive-hover: #c61a3f;
 
   --border: rgba(8, 8, 18, 0.08);
   --border-strong: rgba(8, 8, 18, 0.14);
   --input: rgba(8, 8, 18, 0.12);
   /* Mirrors the @media light block above; see the note there. */
-  --ring: rgba(6, 122, 85, 0.85);
+  --ring: rgba(16, 185, 129, 0.5);
 
   --mint: #10b981;
   --mint-soft: rgba(16, 185, 129, 0.14);
-  --mint-ink: #067a55;
+  --mint-ink: #10b981;
   --mint-hover: #0ea372;
   --cyan: #0891b2;
   --cyan-soft: rgba(8, 145, 178, 0.14);
-  --cyan-ink: #0e7490;
+  --cyan-ink: #0891b2;
   --cyan-hover: #07809d;
   --violet: #7c3aed;
   --violet-soft: rgba(124, 58, 237, 0.14);
@@ -396,11 +395,11 @@
   --gold: #d97706;
   --gold-soft: rgba(217, 119, 6, 0.14);
   --gold-foreground: #ffffff;
-  --gold-ink: #ae4f08;
+  --gold-ink: #d97706;
   --gold-hover: #bf6905;
   --pink: #dc2659;
   --pink-soft: rgba(220, 38, 89, 0.10);
-  --pink-ink: #c7204f;
+  --pink-ink: #dc2659;
 
   /* Light-theme page gradients (softer alphas over light base). */
   --gradient-console:


### PR DESCRIPTION
## Capability

Restores design.pen's accent values everywhere they are still deepened, and moves
the theme guard from *enforcing* a contrast floor the brand palette intentionally
misses to *recording* the owner decision that accepts it.

#1403 deepened the light accents. #1406 restored the vivid fills and moved the
deepened values into new `--X-ink` tokens — but its codemod also rewrote ~130 files
from `text-X` to `text-X-ink`, so every accent used as text or as a mark kept
rendering the deepened colour in light theme. The light `--ring` kept both a
deepened colour and a raised alpha (0.5 -> 0.85), and dark `--violet-ink` was still
lightened off its fill.

17 token values change:

| token | was | now |
| --- | --- | --- |
| light `--primary-ink`, `--mint-ink` (x2 blocks) | `#067a55` | `#10b981` |
| light `--accent-ink`, `--cyan-ink` (x2 blocks) | `#0e7490` | `#0891b2` |
| light `--destructive-ink` (x2 blocks) | `#ca1a41` | `#e11d48` |
| light `--gold-ink` (x2 blocks) | `#ae4f08` | `#d97706` |
| light `--pink-ink` (x2 blocks) | `#c7204f` | `#dc2659` |
| light `--ring` (x2 blocks) | `rgba(6, 122, 85, 0.85)` | `rgba(16, 185, 129, 0.5)` |
| dark `--violet-ink` | `#8465ff` | `#7c5bff` |

`--X-ink` stays as the name for the role an accent plays — a mark or small text
rather than a fill — so the codemodded call sites are untouched. It simply no longer
holds a second, deepened palette. `-soft` washes, `-hover` fills and every
`-foreground` pairing are unchanged: the white label on a vivid mint fill stays.

Verified token-by-token against the state before #1403 (`30a69bd49`): of every CSS
variable that existed then, **zero now differ in value**. The only additions relative
to that baseline are the `-ink` / `-hover` / `--gold-soft` / `--violet-foreground`
tokens introduced by #1406 and #1408, and each `-ink` now equals its fill.

## Guard

Restoring the values costs contrast, so the guard records the decision rather than
enforcing a floor the palette misses:

- **One ledger, one pin rule** for every accepted measurement, whatever floor it was
  measured against — text and non-text differ only in the floor passed in. The light
  ring joins the existing fill/label pins, so a second exemption path cannot drift
  away from the first. `ACCEPTED_BRAND_PAIRS` becomes `ACCEPTED_BRAND_RATIOS`.
- **Accent inks leave the AA loop** and are held by an identity assertion instead:
  `--X-ink` must equal `--X`, in both themes. That is the property, not an
  enumeration of accepted ratios — re-deepening any ink fails the guard rather than
  shipping a palette nobody drew.
- **Every other ink still clears AA** against every surface. The two rules partition
  the `-ink` tokens, so none lands under neither.

## Known by design

- Light accents read 2.1-4.2:1 as small text, under WCAG AA 4.5:1, and the light
  focus ring composites to ~1.5:1, under the 3:1 non-text floor. Both are owner
  decisions (2026-08-14): the brand palette is design.pen's, and a brand value is
  not moved to buy contrast. Pinned, not skipped — drift in either token fails the
  guard.
- `--X-ink` now always equals its fill, making it a semantic alias rather than a
  distinct value. Collapsing it back into the fill token would also mean reverting
  the ~130-file codemod; that is a separate decision, not part of a colour
  restoration.
- Codex review round 1 (head `ca9fdd815`) re-raised both entries above as P1 —
  [focus ring](https://github.com/avibe-bot/avibe/pull/1418#discussion_r3783404673)
  and [accent ink as small text](https://github.com/avibe-bot/avibe/pull/1418#discussion_r3783404682).
  Both ratios are measured correctly and both restore the values the product shipped
  before #1403; re-deepening either is the exact change the owner rejected. Answered in
  thread and resolved. The reviewer's non-brand-moving alternative — an additional
  focus-state cue on shared control chrome — is recorded as follow-up work for a
  design.pen decision, alongside the ten pinned control-chrome sites waiting on the
  same decision.
- Owner decision on the focus ring, taken against a rendered side-by-side of the
  live tokens (2026-08-14): the ring **stays thin at its restored value**. Not
  thickened, and no second higher-contrast outline added — a hairline ring is the
  intended look, and a heavier one is a visual regression. This closes the
  round-1 focus-ring finding as a deliberate product decision rather than an open
  follow-up. `ACCEPTED_BRAND_RATIOS` keeps the measurement pinned, so the value
  still cannot drift unnoticed.

## Evidence

- **unit** — `npm test`: 201 files / 2158 tests pass.
- **contract** — `npm run validate:theme` passes; `npm run build` and `npm run lint`
  pass. Every new or changed assertion was reverse-verified by introducing the defect
  it describes and confirming the intended assertion fires: deepened accent ink,
  accent ink deleted, ring moved off its pin, ring with its pin removed, stale ledger
  entry, neutral ink below AA.
- **scenario** — none; no scenario ID covers palette tokens.
- **residual manual** — light and dark theme in the browser, confirming the restored
  accents against design.pen.


