### PR TITLE
fix(model-hub): align subscription picker with Frame 13

### DIFF
--- a/ui/src/components/settings/models/SettingsModelsPage.render.test.tsx
+++ b/ui/src/components/settings/models/SettingsModelsPage.render.test.tsx
@@ -214,9 +214,13 @@ describe('SettingsModelsPage surface branches', () => {
 
     await screen.findByText('Retained source');
     await userEvent.click(screen.getByRole('button', { name: /Add subscription|添加订阅/i }));
-    expect(await screen.findByRole('dialog')).toBeTruthy();
-    await userEvent.click(screen.getByRole('button', { name: /Claude subscription|Claude 订阅/i }));
+    const picker = await screen.findByRole('menu');
+    expect(within(picker).getByText(/Native recommended|原生推荐/i)).toBeTruthy();
+    expect(within(picker).getByText(/Gateway recommended|网关推荐/i)).toBeTruthy();
+    expect(within(picker).queryByText(/Claude Pro \/ Max|ChatGPT Plus \/ Pro/i)).toBeNull();
+    await userEvent.click(within(picker).getByRole('menuitem', { name: /Claude subscription|Claude 订阅/i }));
 
+    expect(screen.queryByRole('menu')).toBeNull();
     expect((await screen.findByRole('dialog')).textContent).toMatch(/Add Claude subscription|添加 anthropic 订阅/i);
   });
 
@@ -227,9 +231,9 @@ describe('SettingsModelsPage surface branches', () => {
     await screen.findByText('Retained source');
     const trigger = screen.getByRole('button', { name: /Add subscription|添加订阅/i });
     await user.click(trigger);
-    const picker = await screen.findByRole('dialog');
-    const claude = within(picker).getByRole('button', { name: /Claude subscription|Claude 订阅/i });
-    const chatgpt = within(picker).getByRole('button', { name: /ChatGPT subscription|ChatGPT 订阅/i });
+    const picker = await screen.findByRole('menu');
+    const claude = within(picker).getByRole('menuitem', { name: /Claude subscription|Claude 订阅/i });
+    const chatgpt = within(picker).getByRole('menuitem', { name: /ChatGPT subscription|ChatGPT 订阅/i });
 
     await waitFor(() => expect(document.activeElement).toBe(claude));
     expect(claude.getAttribute('tabindex')).toBe('0');
@@ -251,9 +255,24 @@ describe('SettingsModelsPage surface branches', () => {
     await screen.findByText('Retained source');
     const trigger = screen.getByRole('button', { name: /Add subscription|添加订阅/i });
     await user.click(trigger);
-    await screen.findByRole('dialog');
+    await screen.findByRole('menu');
     await user.keyboard('{Escape}');
 
+    await waitFor(() => expect(screen.queryByRole('menu')).toBeNull());
+    await waitFor(() => expect(document.activeElement).toBe(trigger));
+  });
+
+  it('restores the Add subscription trigger when an outside press dismisses the vendor picker', async () => {
+    renderPage([retainedSource]);
+
+    const user = userEvent.setup();
+    await screen.findByText('Retained source');
+    const trigger = screen.getByRole('button', { name: /Add subscription|添加订阅/i });
+    await user.click(trigger);
+    await screen.findByRole('menu');
+    await user.click(document.body);
+
+    await waitFor(() => expect(screen.queryByRole('menu')).toBeNull());
     await waitFor(() => expect(document.activeElement).toBe(trigger));
   });
 
@@ -263,7 +282,7 @@ describe('SettingsModelsPage surface branches', () => {
     const user = userEvent.setup();
     await screen.findByText('Claude native login');
     await user.click(screen.getByRole('button', { name: /Add subscription|添加订阅/i }));
-    await user.click(await screen.findByRole('button', { name: /Claude subscription|Claude 订阅/i }));
+    await user.click(await screen.findByRole('menuitem', { name: /Claude subscription|Claude 订阅/i }));
 
     const native = await screen.findByRole('radio', { name: /Native|原生/i });
     const hub = screen.getByRole('radio', { name: /Gateway|网关/i });
@@ -278,7 +297,7 @@ describe('SettingsModelsPage surface branches', () => {
     await screen.findByText('Retained source');
     const trigger = screen.getByRole('button', { name: /Add subscription|添加订阅/i });
     await userEvent.click(trigger);
-    await userEvent.click(screen.getByRole('button', { name: /Claude subscription|Claude 订阅/i }));
+    await userEvent.click(screen.getByRole('menuitem', { name: /Claude subscription|Claude 订阅/i }));
     const cancelButtons = screen.getAllByRole('button', { name: /^Cancel$|^取消$/i });
     await userEvent.click(cancelButtons[cancelButtons.length - 1]);
 

--- a/ui/src/components/settings/models/SettingsModelsPage.tsx
+++ b/ui/src/components/settings/models/SettingsModelsPage.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react';
-import { ArrowLeft, Gauge, Info, LoaderCircle, Route, Sparkles } from 'lucide-react';
+import { ArrowLeft, Gauge, Info, LoaderCircle, Route } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
+import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Popover, PopoverAnchor, PopoverContent } from '@/components/ui/popover';
 import { useToast } from '@/context/ToastContext';
 import { cn } from '@/lib/utils';
 import { AddApiKeyDialog } from './AddApiKeyDialog';
@@ -56,6 +57,11 @@ import type { AgentBackend, AgentSupply, ResolutionEvent, RuntimeDependency, Sou
 
 const CHAIN_READ_CONCURRENCY = 6;
 const EVENT_PAGE = 20;
+const SUBSCRIPTION_PICKER_OPTIONS = [
+  { vendor: 'anthropic', recommendation: 'native' },
+  { vendor: 'openai', recommendation: 'gateway' },
+] as const;
+type SubscriptionPickerVendor = (typeof SUBSCRIPTION_PICKER_OPTIONS)[number]['vendor'];
 
 const readAgentChains = async (agent: AgentSupply): Promise<ModelChainIndex> => Object.fromEntries(
   await mapWithConcurrency(
@@ -300,7 +306,8 @@ export const SettingsModelsPage: React.FC = () => {
   // owns the success-landing timer and reconcile flag below.
   const [reauthSource, setReauthSource] = React.useState<Source | null>(null);
   const subscriptionTriggerRef = React.useRef<HTMLButtonElement>(null);
-  const subscriptionPickerRefs = React.useRef<Partial<Record<'anthropic' | 'openai', HTMLButtonElement | null>>>({});
+  const subscriptionAnchorRef = subscriptionTriggerRef as React.RefObject<HTMLButtonElement>;
+  const subscriptionPickerRefs = React.useRef<Partial<Record<SubscriptionPickerVendor, HTMLButtonElement | null>>>({});
   const subscriptionPickerHandoffRef = React.useRef(false);
   const subscriptionCloseTimer = React.useRef<number | null>(null);
   // A successful OAuth terminal reports the same moved rows twice: first with
@@ -913,9 +920,9 @@ export const SettingsModelsPage: React.FC = () => {
     setSubscriptionPickerOpen(false);
   }, []);
   const focusSubscriptionPickerOption = React.useCallback((index: number) => {
-    const bounded = Math.max(0, Math.min(index, 1));
+    const bounded = Math.max(0, Math.min(index, SUBSCRIPTION_PICKER_OPTIONS.length - 1));
     setSubscriptionPickerIndex(bounded);
-    const vendor = (['anthropic', 'openai'] as const)[bounded];
+    const { vendor } = SUBSCRIPTION_PICKER_OPTIONS[bounded];
     subscriptionPickerRefs.current[vendor]?.focus();
   }, []);
   const openSubscriptionPicker = React.useCallback(() => {
@@ -923,6 +930,10 @@ export const SettingsModelsPage: React.FC = () => {
     setSubscriptionPickerIndex(0);
     setSubscriptionPickerOpen(true);
   }, []);
+  const toggleSubscriptionPicker = React.useCallback(() => {
+    if (subscriptionPickerOpen) closeSubscriptionPicker();
+    else openSubscriptionPicker();
+  }, [closeSubscriptionPicker, openSubscriptionPicker, subscriptionPickerOpen]);
   React.useEffect(() => () => {
     if (subscriptionCloseTimer.current !== null) window.clearTimeout(subscriptionCloseTimer.current);
   }, []);
@@ -957,7 +968,91 @@ export const SettingsModelsPage: React.FC = () => {
                   {tab === 'sources' ? <div className="model-hub-overview">
                     <div className="model-hub-overview-body">
                       <div ref={overviewRef} className="model-hub-overview-grid relative flex flex-col gap-4">
-                        <SourcesCard read={sourcesRead} readFailureCopy={routeCommitStatus?.failed.has('sources') ? t('settings.models.routeDialog.impact.refreshFail') : undefined} onRetry={() => routeCommitStatus?.failed.has('sources') ? retryRouteCommit() : void retrySources()} onOpenSource={(source) => selectSource(source.id)} onAddApiKey={() => setApiKeyOpen(true)} onAddSubscription={openSubscriptionPicker} subscriptionTriggerRef={subscriptionTriggerRef} />
+                        <Popover
+                          open={subscriptionPickerOpen}
+                          onOpenChange={(open) => { if (!open) closeSubscriptionPicker(); }}
+                        >
+                          <PopoverAnchor virtualRef={subscriptionAnchorRef} />
+                          <SourcesCard read={sourcesRead} readFailureCopy={routeCommitStatus?.failed.has('sources') ? t('settings.models.routeDialog.impact.refreshFail') : undefined} onRetry={() => routeCommitStatus?.failed.has('sources') ? retryRouteCommit() : void retrySources()} onOpenSource={(source) => selectSource(source.id)} onAddApiKey={() => setApiKeyOpen(true)} onAddSubscription={toggleSubscriptionPicker} subscriptionPickerOpen={subscriptionPickerOpen} subscriptionTriggerRef={subscriptionTriggerRef} />
+                          <PopoverContent
+                            role="menu"
+                            aria-label={t('settings.models.upstream.addSubscription')}
+                            align="start"
+                            sideOffset={8}
+                            collisionPadding={12}
+                            className="flex w-[300px] max-w-[calc(100vw-24px)] flex-col gap-0.5 rounded-[10px] border-border-strong bg-surface p-1.5 text-foreground !shadow-[var(--model-hub-menu-shadow)]"
+                            onOpenAutoFocus={(event) => {
+                              event.preventDefault();
+                              window.requestAnimationFrame(() => {
+                                const { vendor } = SUBSCRIPTION_PICKER_OPTIONS[subscriptionPickerIndex];
+                                subscriptionPickerRefs.current[vendor]?.focus();
+                              });
+                            }}
+                            onCloseAutoFocus={(event) => {
+                              event.preventDefault();
+                              if (subscriptionPickerHandoffRef.current) {
+                                subscriptionPickerHandoffRef.current = false;
+                                return;
+                              }
+                              window.setTimeout(() => subscriptionTriggerRef.current?.focus(), 0);
+                            }}
+                            onInteractOutside={(event) => {
+                              if (subscriptionTriggerRef.current?.contains(event.target as Node)) event.preventDefault();
+                            }}
+                            onKeyDown={(event) => {
+                              if (event.key === 'ArrowDown' || event.key === 'ArrowRight') {
+                                event.preventDefault();
+                                focusSubscriptionPickerOption(subscriptionPickerIndex + 1);
+                              } else if (event.key === 'ArrowUp' || event.key === 'ArrowLeft') {
+                                event.preventDefault();
+                                focusSubscriptionPickerOption(subscriptionPickerIndex - 1);
+                              } else if (event.key === 'Home') {
+                                event.preventDefault();
+                                focusSubscriptionPickerOption(0);
+                              } else if (event.key === 'End') {
+                                event.preventDefault();
+                                focusSubscriptionPickerOption(SUBSCRIPTION_PICKER_OPTIONS.length - 1);
+                              }
+                            }}
+                          >
+                            {SUBSCRIPTION_PICKER_OPTIONS.map(({ vendor, recommendation }, index) => {
+                              const vendorLabel = t(`settings.models.subscriptionPicker.vendor.${vendor}`);
+                              const recommendationLabel = t(`settings.models.subscriptionPicker.recommendation.${recommendation}`);
+                              return (
+                                <Button
+                                  key={vendor}
+                                  ref={(node) => { subscriptionPickerRefs.current[vendor] = node; }}
+                                  type="button"
+                                  role="menuitem"
+                                  variant="ghost"
+                                  className={cn(
+                                    'model-hub-subscription-menu-row h-auto w-full min-w-0 justify-start gap-2 rounded-[7px] px-2.5 py-[9px] text-left focus-visible:ring-0 focus-visible:ring-offset-0',
+                                    subscriptionPickerIndex === index &&
+                                      'model-hub-subscription-menu-row--active',
+                                  )}
+                                  tabIndex={subscriptionPickerIndex === index ? 0 : -1}
+                                  onClick={() => {
+                                    subscriptionPickerHandoffRef.current = true;
+                                    setSubscriptionPickerOpen(false);
+                                    setSubscriptionVendor(vendor);
+                                  }}
+                                >
+                                  <span className="min-w-0 flex-1 truncate text-[12.5px] font-semibold" title={vendorLabel}>{vendorLabel}</span>
+                                  <Badge
+                                    variant="recommendation"
+                                    className={cn(
+                                      recommendation === 'native'
+                                        ? 'model-hub-accent-tile--mint model-hub-accent-ink--mint border-transparent'
+                                        : 'model-hub-accent-pill--neutral',
+                                    )}
+                                  >
+                                    {recommendationLabel}
+                                  </Badge>
+                                </Button>
+                              );
+                            })}
+                          </PopoverContent>
+                        </Popover>
                         <div className="hidden lg:block" aria-hidden="true" />
                         <GatewayModule supply={installedSupplyRead} readFailureCopy={routeCommitStatus?.failed.has('agents') ? t('settings.models.routeDialog.impact.refreshFail') : undefined} sources={sources} chains={chains} runtime={runtime} runtimeSnapshot={retainedRuntime} onRetry={() => routeCommitStatus?.failed.has('agents') ? retryRouteCommit() : void retrySupply()} pendingBackends={agentWrites} switchFailures={switchFailures} connectingBackend={adoptAgent?.backend ?? null} onConnectHub={setAdoptAgent} onSwitchDirect={switchToDirect} onOpenOrder={(agent) => setOrderBackend(agent.backend)} onOpenRoute={(agent, modelId, opener) => setRouteTarget({ agent, modelId, opener })} onProbeSettled={(agent) => void refreshAgentChains(agent)} />
                         <SupplyGraph containerRef={overviewRef} relations={supplyRelations} />
@@ -969,65 +1064,6 @@ export const SettingsModelsPage: React.FC = () => {
                   </div> : <section className="rounded-xl border border-border bg-surface px-5 py-8"><div className="flex items-start gap-3"><Info className="mt-0.5 size-4 text-muted" /><div><h2 className="text-[14px] font-semibold text-foreground">{t('settings.models.usageTab.title')}</h2><p className="mt-1 text-[12px] text-muted">{t('settings.models.usageTab.detail')}</p></div></div></section>}
                 </div>}
       <AddApiKeyDialog open={apiKeyOpen} sourceReads={sourceCollectionReads} onClose={() => setApiKeyOpen(false)} onAdded={(created) => void sourceAdded(created)} />
-      <Dialog open={subscriptionPickerOpen} onOpenChange={(open) => open ? setSubscriptionPickerOpen(true) : closeSubscriptionPicker()}>
-        <DialogContent
-          className="max-w-[420px]"
-          onOpenAutoFocus={(event) => {
-            event.preventDefault();
-            window.requestAnimationFrame(() => subscriptionPickerRefs.current[(['anthropic', 'openai'] as const)[subscriptionPickerIndex]]?.focus());
-          }}
-          onCloseAutoFocus={(event) => {
-            event.preventDefault();
-            if (subscriptionPickerHandoffRef.current) {
-              subscriptionPickerHandoffRef.current = false;
-              return;
-            }
-            window.setTimeout(() => subscriptionTriggerRef.current?.focus(), 0);
-          }}
-        >
-          <DialogHeader>
-            <DialogTitle>{t('settings.models.subscriptionPicker.title')}</DialogTitle>
-            <DialogDescription>{t('settings.models.subscriptionPicker.detail')}</DialogDescription>
-          </DialogHeader>
-          <div className="grid gap-2 sm:grid-cols-2" onKeyDown={(event) => {
-            if (event.key === 'ArrowDown' || event.key === 'ArrowRight') {
-              event.preventDefault();
-              focusSubscriptionPickerOption(subscriptionPickerIndex + 1);
-            } else if (event.key === 'ArrowUp' || event.key === 'ArrowLeft') {
-              event.preventDefault();
-              focusSubscriptionPickerOption(subscriptionPickerIndex - 1);
-            } else if (event.key === 'Home') {
-              event.preventDefault();
-              focusSubscriptionPickerOption(0);
-            } else if (event.key === 'End') {
-              event.preventDefault();
-              focusSubscriptionPickerOption(1);
-            }
-          }}>
-            {(['anthropic', 'openai'] as const).map((vendor, index) => (
-              <Button
-                key={vendor}
-                ref={(node) => { subscriptionPickerRefs.current[vendor] = node; }}
-                type="button"
-                variant="outline"
-                className="h-auto justify-start gap-3 px-3 py-3 text-left"
-                tabIndex={subscriptionPickerIndex === index ? 0 : -1}
-                onClick={() => {
-                  subscriptionPickerHandoffRef.current = true;
-                  setSubscriptionPickerOpen(false);
-                  setSubscriptionVendor(vendor);
-                }}
-              >
-                <span className="model-hub-accent-tile--mint grid size-8 shrink-0 place-items-center rounded-lg"><Sparkles className="model-hub-accent-ink--mint size-4" /></span>
-                <span className="flex flex-col items-start">
-                  <span className="font-semibold">{t(`settings.models.subscriptionPicker.${vendor}.title`)}</span>
-                  <span className="text-[11px] text-muted">{t(`settings.models.subscriptionPicker.${vendor}.detail`)}</span>
-                </span>
-              </Button>
-            ))}
-          </div>
-        </DialogContent>
-      </Dialog>
       {subscriptionVendor && (
         <OAuthConnectDialog
           open

--- a/ui/src/components/settings/models/SourcesCard.test.tsx
+++ b/ui/src/components/settings/models/SourcesCard.test.tsx
@@ -42,7 +42,7 @@ describe('SourcesCard footer', () => {
     await waitFor(() => expect(screen.queryByText(/dispatch layer|调度/i)).toBeNull());
   });
 
-  it('draws the two Frame 01 commands without restoring the retired vendor menu', async () => {
+  it('draws the two Frame 01 commands and dispatches each action', async () => {
     const onAddApiKey = vi.fn();
     const onAddSubscription = vi.fn();
     render(

--- a/ui/src/components/settings/models/SourcesCard.tsx
+++ b/ui/src/components/settings/models/SourcesCard.tsx
@@ -15,8 +15,9 @@ export const SourcesCard: React.FC<{
   onOpenSource: (source: Source) => void;
   onAddApiKey: () => void;
   onAddSubscription: () => void;
+  subscriptionPickerOpen?: boolean;
   subscriptionTriggerRef?: React.Ref<HTMLButtonElement>;
-}> = ({ read, onRetry, readFailureCopy, onOpenSource, onAddApiKey, onAddSubscription, subscriptionTriggerRef }) => {
+}> = ({ read, onRetry, readFailureCopy, onOpenSource, onAddApiKey, onAddSubscription, subscriptionPickerOpen, subscriptionTriggerRef }) => {
   const { t } = useTranslation();
   const sources = foldRegionRead<Source[], Source[] | undefined>(read, {
     loading: () => undefined,
@@ -58,6 +59,8 @@ export const SourcesCard: React.FC<{
           ref={subscriptionTriggerRef}
           variant="default"
           size="xs"
+          aria-haspopup="menu"
+          aria-expanded={subscriptionPickerOpen}
           className="model-hub-footer-action shadow-none disabled:opacity-100"
           onClick={onAddSubscription}
         >

--- a/ui/src/components/settings/models/modelHubSurface.css
+++ b/ui/src/components/settings/models/modelHubSurface.css
@@ -86,6 +86,7 @@
   /* Modal scrim and lifted-surface shadows, cast in the theme's own extreme:
    * dimming toward --background, shadowing in the darkest ink the theme owns. */
   --model-hub-scrim: color-mix(in srgb, var(--background) 87.8%, transparent);
+  --model-hub-menu-shadow: 0 10px 28px color-mix(in srgb, var(--background) 50%, transparent);
   --model-hub-dialog-shadow: 0 16px 40px 0 color-mix(in srgb, var(--background) 60%, transparent);
   --model-hub-drawer-shadow: -18px 0 48px color-mix(in srgb, var(--background) 65.1%, transparent);
 }
@@ -100,6 +101,7 @@
   --model-hub-gold-ink: var(--gold-ink);
   --model-hub-violet-ink: var(--violet-ink);
   --model-hub-mint-ink: var(--mint-ink);
+  --model-hub-menu-shadow: 0 10px 28px color-mix(in srgb, var(--foreground) 14%, transparent);
   --model-hub-dialog-shadow: 0 16px 40px 0 color-mix(in srgb, var(--foreground) 14%, transparent);
   --model-hub-drawer-shadow: -18px 0 48px color-mix(in srgb, var(--foreground) 16%, transparent);
 }
@@ -115,6 +117,7 @@
     --model-hub-gold-ink: var(--gold-ink);
     --model-hub-violet-ink: var(--violet-ink);
     --model-hub-mint-ink: var(--mint-ink);
+    --model-hub-menu-shadow: 0 10px 28px color-mix(in srgb, var(--foreground) 14%, transparent);
     --model-hub-dialog-shadow: 0 16px 40px 0 color-mix(in srgb, var(--foreground) 14%, transparent);
     --model-hub-drawer-shadow: -18px 0 48px color-mix(in srgb, var(--foreground) 16%, transparent);
   }
@@ -332,6 +335,12 @@
   padding-inline: 12px;
   border-radius: var(--model-hub-footer-action-radius);
   font-size: var(--model-hub-footer-action-font-size);
+}
+
+.model-hub-subscription-menu-row--active,
+.model-hub-subscription-menu-row:hover,
+.model-hub-subscription-menu-row:focus-visible {
+  background: var(--model-hub-wash-08);
 }
 
 .model-hub-add-sub-overlay { background: var(--model-hub-scrim); }

--- a/ui/src/components/ui/badge-variants.ts
+++ b/ui/src/components/ui/badge-variants.ts
@@ -15,6 +15,8 @@ export const badgeVariants = cva(
         warning: 'border border-gold/40 bg-gold/10 text-gold-ink',
         info: 'border border-cyan/40 bg-cyan-soft text-cyan-ink',
         destructive: 'border border-destructive/40 bg-destructive/10 text-destructive-ink',
+        recommendation:
+          'max-w-[140px] shrink-0 whitespace-normal rounded-full border px-[7px] py-0.5 text-center text-[10px] font-semibold leading-[1.2] tracking-normal',
         // Eyebrow — JetBrains Mono cyan w/ glow (design.pen Badge/Eyebrow mtcmf).
         eyebrow:
           'rounded-full border border-cyan/50 bg-cyan/[0.16] px-3 py-1.5 font-mono text-[11px] font-bold uppercase tracking-[0.14em] text-cyan-ink shadow-[0_0_24px_-4px_rgba(63,224,229,0.33)]',

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -865,10 +865,14 @@
         }
       },
       "subscriptionPicker": {
-        "title": "Choose a subscription to connect",
-        "detail": "Choose the account subscription you want to add to Model Hub.",
-        "anthropic": { "title": "Claude subscription", "detail": "Claude Pro / Max" },
-        "openai": { "title": "ChatGPT subscription", "detail": "ChatGPT Plus / Pro" }
+        "vendor": {
+          "anthropic": "Claude subscription",
+          "openai": "ChatGPT subscription"
+        },
+        "recommendation": {
+          "native": "Native recommended",
+          "gateway": "Gateway recommended"
+        }
       },
       "sources": {
         "title": "Sources",

--- a/ui/src/i18n/zh.json
+++ b/ui/src/i18n/zh.json
@@ -865,10 +865,14 @@
         }
       },
       "subscriptionPicker": {
-        "title": "选择要连接的订阅",
-        "detail": "选择要添加到 Model Hub 的账号订阅。",
-        "anthropic": { "title": "Claude 订阅", "detail": "Claude Pro / Max" },
-        "openai": { "title": "ChatGPT 订阅", "detail": "ChatGPT Plus / Pro" }
+        "vendor": {
+          "anthropic": "Claude 订阅",
+          "openai": "ChatGPT 订阅"
+        },
+        "recommendation": {
+          "native": "原生推荐",
+          "gateway": "网关推荐"
+        }
       },
       "sources": {
         "title": "来源",


### PR DESCRIPTION
## Changed capability

Align the Add Subscription vendor picker with Model Hub Frame 13 while preserving the existing vendor-selection flow.

## What changed

- Replace the centered vendor dialog with the existing controlled `Popover`, anchored to the still-mounted Add Subscription trigger at the Frame 13 300px menu width.
- Render both vendors as full-width menu rows with the existing `Badge` primitive and a reusable `recommendation` variant for Native recommended and Gateway recommended.
- Map the menu surface, active row, mint recommendation, neutral recommendation, border, and shadow to existing theme tokens, adding only the missing semantic menu-shadow token.
- Preserve the single existing picker implementation and its keyboard/focus contract: initial Claude focus, Arrow/Home/End navigation, close-before-vendor-dialog handoff, and trigger restoration after Escape or outside press.

## Namespace decision

The copy stays under `settings.models.subscriptionPicker.*`. This page already owns all of its copy under `settings.models`, and introducing `models.hub.addSubMenu.*` for one component would create a second namespace convention without another independent concept. Vendor keys continue to use the backend identifiers `anthropic` and `openai`; display copy remains Claude subscription and ChatGPT subscription.

## Scenario coverage

No scenario catalog entry covers this UI-only picker path, so there are no affected scenario IDs.

## Evidence

- Unit: 34 focused Vitest checks pass across the Model Hub page, its render contract, and Sources card; English/Chinese key parity passes.
- Contract: updated tests cover the anchored menu role, recommendation copy, focus on open, Arrow/Home/End navigation, close-before-dialog selection, handoff focus, Escape restoration, and outside-press restoration.
- Scenario: no cataloged scenario applies.
- Build: UI lint, production build, theme-token validation, and diff checks pass.
- Residual manual: compared the live rendered picker with Pencil Frame 13 node `Q9q5lF`, including the 300px anchored surface, 6px padding, row geometry, badges, border, radius, and shadow.

## Deliberate tradeoff

Secondary hover and collision permutations continue to follow the shared Popover and Button primitives. This PR does not add picker-specific branches for those lower-value edge states.

## Dependencies

None.
