### PR TITLE
refactor(ui): reuse Button for the five hand-rolled mint CTAs

### DIFF
--- a/ui/src/components/ui/button-variants.ts
+++ b/ui/src/components/ui/button-variants.ts
@@ -26,18 +26,22 @@ export const buttonVariants = cva(
         // shadow no longer brightens with the fill; the fill swap carries the
         // affordance. See the --primary-hover note in index.css.
         //
-        // Glow blur is 16px on all four accents (owner decision 2026-08-14: 24px read
-        // too heavy). One radius, four accents — a per-accent radius would be the same
-        // drift this variant exists to remove. design.pen has no glow on any Button, so
-        // the value is ours to hold, not the design's; keep the four in lockstep.
+        // Glow blur comes from --brand-glow-blur: 16px dark, 20px light (owner decisions
+        // 2026-08-14 — 24px read too heavy, then 16px read as nothing in light, where the
+        // same neon spreads far less over a white card). It is one token, not four: a
+        // per-accent radius would be the same drift this variant exists to remove, and
+        // routing it through a variable is what makes it theme-dependent at all — this
+        // codebase has no `light:`/`dark:` Tailwind variant, so a per-theme value is
+        // always a CSS variable. design.pen has no glow on any Button, so the value is
+        // ours to hold, not the design's; keep the four in lockstep.
         brand:
-          'gap-2 bg-mint font-bold text-primary-foreground shadow-[0_0_16px_-4px_rgba(91,255,160,0.6)] hover:bg-mint-hover disabled:shadow-none',
+          'gap-2 bg-mint font-bold text-primary-foreground shadow-[0_0_var(--brand-glow-blur)_-4px_rgba(91,255,160,0.6)] hover:bg-mint-hover disabled:shadow-none',
         'brand-cyan':
-          'gap-2 bg-cyan font-bold text-accent-foreground shadow-[0_0_16px_-4px_rgba(63,224,229,0.6)] hover:bg-cyan-hover disabled:shadow-none',
+          'gap-2 bg-cyan font-bold text-accent-foreground shadow-[0_0_var(--brand-glow-blur)_-4px_rgba(63,224,229,0.6)] hover:bg-cyan-hover disabled:shadow-none',
         'brand-gold':
-          'gap-2 bg-gold font-bold text-gold-foreground shadow-[0_0_16px_-4px_rgba(255,200,87,0.55)] hover:bg-gold-hover disabled:shadow-none',
+          'gap-2 bg-gold font-bold text-gold-foreground shadow-[0_0_var(--brand-glow-blur)_-4px_rgba(255,200,87,0.55)] hover:bg-gold-hover disabled:shadow-none',
         'brand-violet':
-          'gap-2 bg-violet font-bold text-violet-foreground shadow-[0_0_16px_-4px_rgba(124,91,255,0.55)] hover:bg-violet-hover disabled:shadow-none',
+          'gap-2 bg-violet font-bold text-violet-foreground shadow-[0_0_var(--brand-glow-blur)_-4px_rgba(124,91,255,0.55)] hover:bg-violet-hover disabled:shadow-none',
         secondary: 'gap-1.5 border border-border bg-secondary text-secondary-foreground hover:border-border-strong',
         // Outline — bg matches page surface so it sits cleanly on glow gradients.
         outline:

--- a/ui/src/components/ui/button-variants.ts
+++ b/ui/src/components/ui/button-variants.ts
@@ -25,14 +25,19 @@ export const buttonVariants = cva(
         // inverted direction surfaces at build time rather than in review. The glow
         // shadow no longer brightens with the fill; the fill swap carries the
         // affordance. See the --primary-hover note in index.css.
+        //
+        // Glow blur is 16px on all four accents (owner decision 2026-08-14: 24px read
+        // too heavy). One radius, four accents — a per-accent radius would be the same
+        // drift this variant exists to remove. design.pen has no glow on any Button, so
+        // the value is ours to hold, not the design's; keep the four in lockstep.
         brand:
-          'gap-2 bg-mint font-bold text-primary-foreground shadow-[0_0_24px_-4px_rgba(91,255,160,0.6)] hover:bg-mint-hover disabled:shadow-none',
+          'gap-2 bg-mint font-bold text-primary-foreground shadow-[0_0_16px_-4px_rgba(91,255,160,0.6)] hover:bg-mint-hover disabled:shadow-none',
         'brand-cyan':
-          'gap-2 bg-cyan font-bold text-accent-foreground shadow-[0_0_24px_-4px_rgba(63,224,229,0.6)] hover:bg-cyan-hover disabled:shadow-none',
+          'gap-2 bg-cyan font-bold text-accent-foreground shadow-[0_0_16px_-4px_rgba(63,224,229,0.6)] hover:bg-cyan-hover disabled:shadow-none',
         'brand-gold':
-          'gap-2 bg-gold font-bold text-gold-foreground shadow-[0_0_24px_-4px_rgba(255,200,87,0.55)] hover:bg-gold-hover disabled:shadow-none',
+          'gap-2 bg-gold font-bold text-gold-foreground shadow-[0_0_16px_-4px_rgba(255,200,87,0.55)] hover:bg-gold-hover disabled:shadow-none',
         'brand-violet':
-          'gap-2 bg-violet font-bold text-violet-foreground shadow-[0_0_24px_-4px_rgba(124,91,255,0.55)] hover:bg-violet-hover disabled:shadow-none',
+          'gap-2 bg-violet font-bold text-violet-foreground shadow-[0_0_16px_-4px_rgba(124,91,255,0.55)] hover:bg-violet-hover disabled:shadow-none',
         secondary: 'gap-1.5 border border-border bg-secondary text-secondary-foreground hover:border-border-strong',
         // Outline — bg matches page surface so it sits cleanly on glow gradients.
         outline:

--- a/ui/src/components/ui/directory-browser.tsx
+++ b/ui/src/components/ui/directory-browser.tsx
@@ -23,6 +23,7 @@ import { useTranslation } from 'react-i18next';
 import clsx from 'clsx';
 
 import { useApi } from '../../context/ApiContext';
+import { Button } from './button';
 import { errorMessage } from '@/lib/errorMessage';
 
 interface DirectoryBrowserProps {
@@ -594,19 +595,16 @@ export const DirectoryBrowser: React.FC<DirectoryBrowserProps> = ({
                   >
                     {t('directoryBrowser.cancel')}
                   </button>
-                  <button
+                  <Button
                     type="button"
+                    variant="default"
+                    size={null}
                     onClick={submitNewFolder}
                     disabled={!newFolderName.trim()}
-                    className={clsx(
-                      'rounded-md px-2.5 py-0.5 text-[11px] font-semibold transition',
-                      newFolderName.trim()
-                        ? 'bg-mint text-primary-foreground hover:bg-mint-hover'
-                        : 'bg-muted-soft text-muted',
-                    )}
+                    className="rounded-md px-2.5 py-0.5 text-[11px] font-semibold"
                   >
                     {t('directoryBrowser.newFolder')}
-                  </button>
+                  </Button>
                 </div>
                 {createError && <div className="pl-6 text-[11px] text-destructive-ink">{createError}</div>}
               </div>
@@ -635,20 +633,17 @@ export const DirectoryBrowser: React.FC<DirectoryBrowserProps> = ({
           >
             {t('directoryBrowser.cancel')}
           </button>
-          <button
+          <Button
             type="button"
+            variant="brand"
+            size={null}
             onClick={() => canConfirm && onSelect(currentPath)}
             disabled={!canConfirm}
-            className={clsx(
-              'flex items-center gap-1.5 rounded-md px-4 py-1.5 text-[12px] font-semibold transition',
-              canConfirm
-                ? 'bg-mint text-primary-foreground shadow-[0_0_14px_-4px_rgba(91,255,160,0.6)] hover:bg-mint-hover'
-                : 'cursor-not-allowed bg-muted-soft text-muted',
-            )}
+            className="gap-1.5 rounded-md px-4 py-1.5 text-[12px] font-semibold"
           >
             <Check className="size-3.5" />
             {t('directoryBrowser.select')}
-          </button>
+          </Button>
         </div>
       </div>
     </div>

--- a/ui/src/components/workbench/NewAgentDialog.tsx
+++ b/ui/src/components/workbench/NewAgentDialog.tsx
@@ -334,20 +334,17 @@ export const NewAgentDialog: React.FC<NewAgentDialogProps> = ({ open, onClose, o
           >
             {t('common.cancel')}
           </button>
-          <button
+          <Button
             type="button"
+            variant="brand"
+            size={null}
             onClick={handleSubmit}
             disabled={!canSubmit}
-            className={clsx(
-              'inline-flex items-center gap-1.5 rounded-md px-4 py-1.5 text-[12px] font-bold transition',
-              canSubmit
-                ? 'bg-mint text-primary-foreground shadow-[0_0_14px_-4px_rgba(91,255,160,0.6)] hover:bg-mint-hover'
-                : 'cursor-not-allowed bg-muted-soft text-muted',
-            )}
+            className="gap-1.5 rounded-md px-4 py-1.5 text-[12px]"
           >
             {t('agents.create.submit')}
             <ArrowRight className="size-3.5" />
-          </button>
+          </Button>
         </div>
       </div>
     </div>

--- a/ui/src/components/workbench/ShowPageAnnotateControl.tsx
+++ b/ui/src/components/workbench/ShowPageAnnotateControl.tsx
@@ -149,16 +149,18 @@ export const ShowPageAnnotateControl: React.FC<ShowPageAnnotateControlProps> = (
         <div className="hidden items-center md:flex">
           {enabled ? (
             <div className="flex h-7 items-center gap-0.5 rounded-lg border border-mint/40 bg-mint/[0.06] p-0.5 shadow-[0_0_16px_-6px_rgba(91,255,160,0.5)]">
-              <button
+              <Button
                 type="button"
+                variant="default"
+                size={null}
                 onClick={onDisable}
                 aria-label={offLabel}
                 title={offLabel}
                 aria-pressed
-                className="grid size-6 shrink-0 place-items-center rounded-[5px] bg-mint text-primary-foreground transition hover:bg-mint-hover"
+                className="size-6 shrink-0 rounded-[5px]"
               >
                 <MessageSquarePlus className="size-3.5" />
-              </button>
+              </Button>
               <div
                 role="radiogroup"
                 aria-label={t('chat.showPage.annotate.modeTitle')}

--- a/ui/src/components/workbench/skills/AddSkillDialog.tsx
+++ b/ui/src/components/workbench/skills/AddSkillDialog.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from 'react-i18next';
 import { useApi } from '../../../context/ApiContext';
 import type { SkillDiscovered, SkillScope } from '../../../context/ApiContext';
 import { useToast } from '../../../context/ToastContext';
+import { Button } from '../../ui/button';
 import { SegmentedRadio } from '../../ui/segmented';
 import { Checkbox } from '../../ui/checkbox';
 import { BACKEND_CHIP, BACKEND_LABEL, BACKEND_ORDER, type Backend } from '../../../lib/backendAccent';
@@ -321,15 +322,17 @@ export function AddSkillDialog({ defaultScope, projectId, projectName, onClose, 
             <button type="button" onClick={onClose} className="rounded-lg border border-border-strong px-3.5 py-2 text-[12px] font-medium text-foreground transition hover:bg-foreground/[0.04]">
               {t('skills.addDialog.cancel')}
             </button>
-            <button
+            <Button
               type="button"
+              variant="brand"
+              size={null}
               onClick={install}
               disabled={!discovered || selected.size === 0 || backends.size === 0 || busy === 'install'}
-              className="flex items-center gap-1.5 rounded-lg bg-mint px-4 py-2 text-[12px] font-semibold text-primary-foreground shadow-[0_4px_16px_-4px_rgba(91,255,160,0.5)] transition hover:bg-mint-hover disabled:opacity-50"
+              className="gap-1.5 px-4 py-2 text-[12px] font-semibold"
             >
               {busy === 'install' ? <Loader2 className="size-3.5 animate-spin" /> : <Download className="size-3.5" />}
               {busy === 'install' ? t('skills.addDialog.installing') : t('skills.addDialog.install', { count: selected.size })}
-            </button>
+            </Button>
           </div>
         </div>
       </div>

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -187,6 +187,12 @@
   --pink-soft: rgba(255, 91, 138, 0.10);
   --pink-ink: #ff5b8a;
 
+  /* Blur radius of the brand CTA glow, shared by all four `brand*` Button variants
+     (see button-variants.ts). One radius, four accents — a per-accent value would be
+     the drift that variant exists to remove. It lives here rather than in the class
+     because it is the one part of that glow that differs per theme. */
+  --brand-glow-blur: 16px;
+
   /* Page-family gradients (mirror design.pen 1:1). Layers ordered top-most first. */
   --gradient-console:
     radial-gradient(50% 40% at 5% 5%, rgba(91, 255, 160, 0.20), rgba(91, 255, 160, 0) 100%),
@@ -335,6 +341,10 @@
     /* Light card glow — much softer than dark. */
     --shadow-mint-card: 0 12px 24px -16px rgba(16, 185, 129, 0.20);
     --shadow-mint-card-lg: 0 16px 32px -16px rgba(16, 185, 129, 0.22);
+
+    /* Wider CTA glow than dark: the same neon spreads far less over a white card,
+       so 16px read as almost nothing here (owner decision 2026-08-14). */
+    --brand-glow-blur: 20px;
   }
 }
 
@@ -435,6 +445,10 @@
   /* Light card glow — much softer than dark. */
   --shadow-mint-card: 0 12px 24px -16px rgba(16, 185, 129, 0.20);
   --shadow-mint-card-lg: 0 16px 32px -16px rgba(16, 185, 129, 0.22);
+
+  /* Wider CTA glow than dark: the same neon spreads far less over a white card,
+     so 16px read as almost nothing here (owner decision 2026-08-14). */
+  --brand-glow-blur: 20px;
 }
 
 html,


### PR DESCRIPTION
## What changes

Five controls hand-rolled the `Button` primitive's own recipe at the call site — `bg-mint` + `text-primary-foreground` + `hover:bg-mint-hover`, spelled out five times, three of them with their own mint glow at three different radii. This replaces those five with the shared primitive, and lightens that shared glow.

Salvaged from #1410, which was closed unmerged: this is the one commit in it that is independent of the accent palette. The rest of that PR (the accent-mark repaint and its guard) became a no-op once #1418 restored every accent to its design.pen value.

Sites: `ui/src/components/ui/directory-browser.tsx`, `ui/src/components/workbench/NewAgentDialog.tsx`, `ui/src/components/workbench/ShowPageAnnotateControl.tsx`, `ui/src/components/workbench/skills/AddSkillDialog.tsx`, plus `ui/src/components/ui/button-variants.ts` for the glow.

**Geometry is unchanged.** All five pass `size={null}` and keep their own padding, radius and type, because none matches a `Button` size — the new-folder submit is smaller than `xs`, and the annotate toggle is a 24px square. What moves to the primitive is the accent pairing, the hover fill, the focus ring and the disabled treatment.

Two of the five land on `variant="default"`, which is **flat** — they had no glow before and have none now. Only the three that already carried a hand-written glow land on `variant="brand"`.

## The glow: 24px, then 16px dark / 20px light

`brand` has carried `0 0 24px -4px` since a024cb330 (2026-05-11) consolidated the brand buttons onto the primitive. The 14px and 16px one-offs this PR removes were written *later*, at the call sites, so they were drift from that consolidation rather than an older intent.

At CTA size 24px reads heavy, so **the blur drops to 16px on all four brand accents at once** (mint, cyan, gold, violet). Per-accent radii would be the same drift the variant exists to remove. Owner decision, 2026-08-14.

That 16px then turned out to be a dark-theme value wearing a theme-neutral costume. The glow colour is the **dark** neon `rgba(91,255,160,.6)` in both themes (see the follow-up below), and that neon spreads far less over a white card, so in light the halo read as almost nothing. Second owner decision, same day: **light goes to 20px, dark stays 16px.**

The radius is now a token, `--brand-glow-blur`, not a literal repeated four times. Two reasons, and only the first is about tidiness: a per-theme value in this codebase is *always* a CSS variable — there is no `@custom-variant` and zero `light:` / `dark:` Tailwind-variant usage anywhere in `ui/src` — and one token keeps the four accents in lockstep by construction instead of by convention. Declared in the dark/default theme block, overridden in **both** light blocks, which `index.css` requires to stay value-identical.

Worth stating plainly: **design.pen has no glow on any `Button`.** `Button/Default` and `Button/Large/Default` are flat `#5bffa0`, radius 6, with no `effects` at all, and a full scan of the `vibe-remote-desktop` and `vibe-remote-mobile` design groups finds zero mint shadows. The glowing brand CTA is a code-only concept, so neither 14px nor 24px was ever "the design's value" — this variant is its only holder, which is why the value belongs here and nowhere else.

## Known by design

- **Disabled state is not a new look.** Two of these sites painted `bg-muted-soft` + `text-muted` when disabled; they now fade like every other disabled `Button`. `disabled:opacity-50` has been in the `Button` base since c3c93f957 (2026-04-30), so the fade *is* the app-wide standard and the grey chip was local drift. This is a restoration, not an invention — do not ask for the grey chip back at these two sites without changing the base for all 458 call sites.
- **All five gain the `focus-visible` ring** they never had — the thin ring at its restored value, per the owner's 2026-08-14 decision recorded in #1418's ledger. Not to be thickened, and no second higher-contrast outline.
- **No token value is touched by this PR.**

## Follow-ups, not this PR

- ~64 hand-written mint glow literals remain across `ui/src`, spelling one idea several ways: status dots at `0 0 6px` / `7px` / `8px` / `9px`, icon tiles at `0 0 16px -6px` / `18px -6px` / `20px -6px` / `24px -6px`, a mint-tinted elevation ladder at alpha 0.078, and hero glows at 32–48px. Collapsing those needs a declared set of glow tokens per role and a visual review of its own; the `Button` variant is the wrong home for card and dot glows.
- Every one of those literals, and the four in this variant, hardcode the **dark** theme's neon mint `rgba(91,255,160)` and reuse it in light, where the paired fill is `#10b981`. The 20px light blur widens that halo; it does not correct its hue, and a wider blur is the smaller half of the fix. The colour half belongs with the token work above, alongside the already-dead `--shadow-mint-card` / `--shadow-mint-card-lg` pair — declared and theme-overridden in `index.css`, consumed by nothing.

## Evidence

- **unit** — `npm test`: 201 files / 2158 tests pass.
- **contract** — `npm run validate:theme` passes (the pairing this change stops hand-rolling is exactly what `SEMANTIC_FILL_ALIASES` and the hover assertion hold together); `npm run build` and `npm run lint` pass. The built CSS was read back to confirm all four accents emit `0 0 var(--brand-glow-blur) -4px <accent>` and that the token resolves to `16px` once and `20px` in both light blocks. No guard or test pins either radius, so the values are asserted by nothing — see the token follow-up above.
- **scenario** — none; no scenario ID covers these controls.
- **residual manual** — the five converted controls need a browser pass in light and dark: resting, hover, disabled, and keyboard focus. The four `brand` accents were compared at 14 / 24 / 16px in both themes off the real built tokens before that value was chosen, and light was then compared at 16 vs 20px side by side on one card, against a colour-corrected control, off the rebuilt token.
