### PR TITLE
fix(skills): remove harness path discovery

### DIFF
--- a/.agents/skills/pr-delivery-loop/SKILL.md
+++ b/.agents/skills/pr-delivery-loop/SKILL.md
@@ -206,11 +206,6 @@ turn ends because you armed a watch and are waiting, say exactly that.
   filtering, settling, retries, and delivery acknowledgement. Those mechanics
   belong to the reusable skill; this policy only constrains when and why the
   watch is armed.
-- Before arming any managed wait, use `background-watch-hook` to resolve the
-  active skill and verify the combined `wait_pr.py` capability flags. A failed
-  check is an environment blocker: repair the harness registration or symlink
-  before waiting. Never compensate for a stale copy by hand-rolling or patching
-  an old waiter.
 - Arm the fresh watch only AFTER your reply-then-resolve batch is pushed and
   settled: your own thread resolutions count as "review activity" to a watch
   armed earlier in the round, so it self-consumes on YOUR close-out actions and

--- a/skills/background-watch-hook/SKILL.md
+++ b/skills/background-watch-hook/SKILL.md
@@ -2,7 +2,7 @@
 name: background-watch-hook
 slug: background-watch-hook
 description: Use `vibe watch` to run a managed Harness waiter that returns to the same conversation later. Best for reviews, CI, files, logs, and other wait-now-continue-later workflows.
-version: 0.16.0
+version: 0.16.1
 ---
 
 # Background Watch Hook
@@ -203,80 +203,12 @@ opts into retrying that code. Exit code `64` with the
 `avibe-watch: no-event` marker means a cycle finished with nothing worth an Agent
 turn.
 
-The waiter is distributed with this skill, not with the caller's repository.
-Resolve the active skill directory before constructing a watch command:
+Run bundled waiters relative to the directory containing this loaded `SKILL.md`.
+The examples below use `BACKGROUND_WATCH_HOOK_DIR` for that directory:
 
 ```bash
-BACKGROUND_WATCH_HOOK_SKILL_FILE="${BACKGROUND_WATCH_HOOK_SKILL_FILE:-}"
-if [ -z "$BACKGROUND_WATCH_HOOK_SKILL_FILE" ]; then
-  REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
-  for SKILL_FILE in \
-    "$REPO_ROOT/skills/background-watch-hook/SKILL.md" \
-    "$REPO_ROOT/.agents/skills/background-watch-hook/SKILL.md"; do
-    if [ -f "$SKILL_FILE" ]; then
-      BACKGROUND_WATCH_HOOK_SKILL_FILE="$SKILL_FILE"
-      break
-    fi
-  done
-fi
-if [ -z "$BACKGROUND_WATCH_HOOK_SKILL_FILE" ]; then
-  for SKILL_FILE in \
-    "${CODEX_HOME:-$HOME/.codex}/skills/background-watch-hook/SKILL.md" \
-    "${AGENTS_HOME:-$HOME/.agents}/skills/background-watch-hook/SKILL.md" \
-    "${CLAUDE_CONFIG_DIR:-$HOME/.claude}/skills/background-watch-hook/SKILL.md" \
-    "${OPENCODE_HOME:-$HOME/.opencode}/skills/background-watch-hook/SKILL.md" \
-    "${XDG_CONFIG_HOME:-$HOME/.config}/opencode/skills/background-watch-hook/SKILL.md"; do
-    if [ -f "$SKILL_FILE" ]; then
-      BACKGROUND_WATCH_HOOK_SKILL_FILE="$SKILL_FILE"
-      break
-    fi
-  done
-fi
-test -f "$BACKGROUND_WATCH_HOOK_SKILL_FILE"
-BACKGROUND_WATCH_HOOK_DIR="$(dirname "$BACKGROUND_WATCH_HOOK_SKILL_FILE")"
+BACKGROUND_WATCH_HOOK_DIR="<directory containing the loaded SKILL.md>"
 ```
-
-## Active Waiter Preflight
-
-Skill distribution belongs to the agent environment, not to this skill. When
-multiple harnesses on one machine should use the same checkout, expose that
-canonical directory through harness-local symlinks instead of maintaining
-independent copies. This skill does not install, copy, or rewrite harness skill
-directories.
-
-Before arming a managed GitHub waiter, check the waiter in the active directory
-resolved above. The preflight is capability-based so it works for repository,
-symlinked, and harness-managed installations without a second resolver or a
-custom package manifest:
-
-```bash
-WAIT_PR="$BACKGROUND_WATCH_HOOK_DIR/scripts/wait_pr.py"
-test -f "$WAIT_PR"
-WAIT_PR_HELP="$(uv run --no-project "$WAIT_PR" --help 2>&1)" || {
-  printf '%s\n' "background-watch-hook waiter is not executable: $WAIT_PR" >&2
-  exit 1
-}
-for REQUIRED_FLAG in \
-  --sha \
-  --workflow \
-  --seed-state \
-  --actionable-only \
-  --ignore-author; do
-  case "$WAIT_PR_HELP" in
-    *"$REQUIRED_FLAG"*) ;;
-    *)
-      printf '%s\n' "background-watch-hook waiter is missing $REQUIRED_FLAG: $WAIT_PR" >&2
-      exit 1
-      ;;
-  esac
-done
-```
-
-The frontmatter version is a human-readable signal; the required command-line
-capabilities are the runtime contract. A failed preflight is an environment
-blocker. Repair the harness registration or symlink to the intended skill, then
-run the preflight again. Do not patch an older copy in place or hand-roll a
-substitute waiter.
 
 ## GitHub Example Waiter
 

--- a/tests/test_harness_skill_guidance.py
+++ b/tests/test_harness_skill_guidance.py
@@ -146,23 +146,22 @@ def test_background_watch_skill_defaults_to_current_session() -> None:
     assert "`--prefix`" not in body
 
 
-def test_background_watch_skill_resolves_local_waiters_and_persists_managed_pr_state() -> None:
+def test_background_watch_skill_uses_bundled_waiters_and_persists_managed_pr_state() -> None:
     body = _read("skills/background-watch-hook/SKILL.md")
 
-    assert 'REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"' in body
-    assert '"$REPO_ROOT/skills/background-watch-hook/SKILL.md"' in body
-    assert '"$REPO_ROOT/.agents/skills/background-watch-hook/SKILL.md"' in body
-    assert '"${OPENCODE_HOME:-$HOME/.opencode}/skills/background-watch-hook/SKILL.md"' in body
     assert (
-        '"${CLAUDE_CONFIG_DIR:-$HOME/.claude}/skills/background-watch-hook/SKILL.md"' in body
+        'BACKGROUND_WATCH_HOOK_DIR="<directory containing the loaded SKILL.md>"'
+        in body
     )
-    assert "CLAUDE_HOME" not in body
-    assert "find \"$SKILL_ROOT\"" not in body
-    assert 'WAIT_PR="$BACKGROUND_WATCH_HOOK_DIR/scripts/wait_pr.py"' in body
-    assert 'WAIT_PR_HELP="$(uv run --no-project "$WAIT_PR" --help 2>&1)"' in body
-    assert "--workflow" in body
-    assert "This skill does not install, copy, or rewrite harness skill" in body
-    assert "sync_skill.py" not in body
+    for environment_root in (
+        "CODEX_HOME",
+        "AGENTS_HOME",
+        "CLAUDE_CONFIG_DIR",
+        "OPENCODE_HOME",
+        "XDG_CONFIG_HOME",
+        "BACKGROUND_WATCH_HOOK_SKILL_FILE",
+    ):
+        assert environment_root not in body
     assert not (ROOT / "skills/background-watch-hook/scripts/sync_skill.py").exists()
     assert body.count('--state-file "$STATE_FILE"') >= 7
     assert body.count("--seed-state") >= 3


### PR DESCRIPTION
## Summary

- remove cross-harness path discovery and capability preflight from `background-watch-hook`
- keep bundled waiter usage relative to the already loaded skill source
- remove the matching environment-repair requirement from `pr-delivery-loop`

## Evidence

- unit: not applicable; no runtime implementation changed
- contract: `tests/test_harness_skill_guidance.py` now rejects harness-home discovery in the skill
- scenario: not applicable; no scenario catalog entry covers skill loading
- residual manual check: reviewed the rendered skill examples to confirm waiter commands still reference the bundled scripts

## Validation

- `askill validate skills/background-watch-hook/SKILL.md`
- `uv run pytest tests/test_harness_skill_guidance.py -q`
- `uv run ruff check tests/test_harness_skill_guidance.py`
- `npm run build` in `ui/`
