### PR TITLE
fix(opencode): repair wrapped message histories

### DIFF
--- a/config/v2_sessions.py
+++ b/config/v2_sessions.py
@@ -476,6 +476,23 @@ class SessionsStore:
             self.load()
         return bound_id
 
+    def replace_agent_session_native(
+        self,
+        agent_session_id: str,
+        *,
+        expected_native_session_id: Any,
+        replacement_native_session_id: Any,
+    ) -> Optional[str]:
+        self._ensure_service()
+        replaced_id = self._service.replace_agent_session_native(
+            session_id=agent_session_id,
+            expected_native_session_id=expected_native_session_id,
+            replacement_native_session_id=replacement_native_session_id,
+        )
+        if replaced_id:
+            self.load()
+        return replaced_id
+
     def remove_agent_session(self, user_id: str, agent_name: str, thread_id: str) -> bool:
         self._ensure_service()
         self._ensure_user_namespace(user_id)

--- a/modules/agents/opencode/agent.py
+++ b/modules/agents/opencode/agent.py
@@ -70,7 +70,11 @@ from .server import (
     OpenCodeServerManager,
     native_part_id_for_attempt,
 )
-from .session import OpenCodeResumeUnavailableError, OpenCodeSessionManager
+from .session import (
+    OpenCodeResumeUnavailableError,
+    OpenCodeSessionManager,
+    requires_message_order_repair,
+)
 from .utils import resolve_opencode_model_id, resolve_opencode_reasoning_effort
 
 logger = logging.getLogger(__name__)
@@ -1160,17 +1164,38 @@ class OpenCodeAgent(OpenCodeMessageProcessorMixin, BaseAgent):
                     logger.debug("Failed to resolve OpenCode model variant support: %s", err)
 
             baseline_message_ids: set[str] = set()
+            baseline_messages = None
             try:
                 baseline_messages = await server.list_messages(
                     session_id=session_id,
                     directory=request.working_path,
                 )
+            except Exception as err:
+                logger.debug(f"Failed to snapshot OpenCode messages before prompt: {err}")
+
+            if baseline_messages is not None:
+                if requires_message_order_repair(baseline_messages):
+                    session_id = await self._session_manager.repair_message_order(
+                        request,
+                        server,
+                        session_id,
+                        baseline_messages,
+                    )
+                    self._session_manager.set_request_session(
+                        request.base_session_id,
+                        session_id,
+                        request.working_path,
+                        request.session_key,
+                    )
+                    self._session_manager.mark_initialized(session_id)
+                    baseline_messages = await server.list_messages(
+                        session_id=session_id,
+                        directory=request.working_path,
+                    )
                 for message in baseline_messages:
                     message_id = message.get("info", {}).get("id")
                     if message_id:
                         baseline_message_ids.add(message_id)
-            except Exception as err:
-                logger.debug(f"Failed to snapshot OpenCode messages before prompt: {err}")
 
             # Prepare message with file attachment info if present
             prompt_text = self._prepare_message_with_files(request)

--- a/modules/agents/opencode/server.py
+++ b/modules/agents/opencode/server.py
@@ -1725,6 +1725,25 @@ class OpenCodeServerManager:
                     raise RuntimeError(f"Failed to list messages: {resp.status} {error_text}")
                 return await resp.json()
 
+    async def get_version(self) -> Optional[str]:
+        """Return the running OpenCode version advertised by its health endpoint."""
+
+        try:
+            async with self._request_scope():
+                session = await self._get_http_session()
+                async with session.get(
+                    f"{self.base_url}/global/health",
+                    timeout=aiohttp.ClientTimeout(total=5),
+                ) as resp:
+                    if resp.status != 200:
+                        return None
+                    data = await resp.json()
+                    version = data.get("version") if isinstance(data, dict) else None
+                    return str(version).strip() if version else None
+        except Exception as err:
+            logger.debug("Failed to read OpenCode runtime version: %s", err)
+            return None
+
     async def get_session_status(
         self,
         session_id: str,

--- a/modules/agents/opencode/session.py
+++ b/modules/agents/opencode/session.py
@@ -9,8 +9,9 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import re
 import time
-from typing import Dict, Optional, Tuple
+from typing import Any, Dict, Optional, Tuple
 
 from core.services.session_fork import fork_source_state, pending_native_fork
 from modules.agents.native_sessions.opencode import OpenCodeNativeSessionProvider
@@ -33,10 +34,86 @@ class OpenCodeResumeUnavailableError(RuntimeError):
             "Not creating a new one to avoid silently losing context — start a new session to continue."
         )
 
+
 logger = logging.getLogger(__name__)
 
 
+_OPENCODE_MESSAGE_ID_RE = re.compile(r"^msg_([0-9a-fA-F]{12})")
+_OPENCODE_ID_CLOCK_BITS = 48
+_OPENCODE_ID_COUNTER_BITS = 12
+_OPENCODE_ID_CLOCK_MODULUS = 1 << _OPENCODE_ID_CLOCK_BITS
+_OPENCODE_ID_WRAP_DISTANCE = _OPENCODE_ID_CLOCK_MODULUS // 2
+_OPENCODE_TIME_ORDERED_MESSAGES_VERSION = (1, 18, 15)
+
+
 RequestSessionTuple = Tuple[str, str, str]
+
+
+def _message_id_clock_value(message_id: object) -> Optional[int]:
+    match = _OPENCODE_MESSAGE_ID_RE.match(str(message_id or ""))
+    return int(match.group(1), 16) if match else None
+
+
+def _message_created_at(message: Dict[str, Any]) -> Optional[float]:
+    info = message.get("info") or {}
+    time_info = info.get("time") or {}
+    created = time_info.get("created")
+    if not isinstance(created, (int, float)):
+        return None
+    return float(created)
+
+
+def _uses_legacy_message_ordering(version: Optional[str]) -> bool:
+    match = re.match(r"^v?(\d+)\.(\d+)\.(\d+)", str(version or "").strip())
+    if not match:
+        return True
+    parsed = tuple(int(part) for part in match.groups())
+    return parsed < _OPENCODE_TIME_ORDERED_MESSAGES_VERSION
+
+
+def requires_message_order_repair(
+    messages: list[Dict[str, Any]],
+    *,
+    now_ms: Optional[int] = None,
+) -> bool:
+    """Detect histories that legacy OpenCode would order by the wrong message.
+
+    OpenCode <= 1.18.14 encoded a millisecond clock plus counter into only
+    48 bits, then selected the latest user/assistant message by lexicographic
+    ID. The clock wrapped in August 2026. A full native fork reassigns IDs in
+    creation order, preserving context while making those releases usable.
+    """
+
+    candidates: list[tuple[str, str, float, int]] = []
+    for message in messages:
+        info = message.get("info") or {}
+        role = str(info.get("role") or "")
+        if role not in {"user", "assistant"}:
+            continue
+        message_id = str(info.get("id") or "")
+        clock_value = _message_id_clock_value(message_id)
+        created_at = _message_created_at(message)
+        if clock_value is None or created_at is None:
+            continue
+        candidates.append((role, message_id, created_at, clock_value))
+
+    for role in ("user", "assistant"):
+        role_messages = [candidate for candidate in candidates if candidate[0] == role]
+        if len(role_messages) < 2:
+            continue
+        latest_by_time = max(role_messages, key=lambda candidate: (candidate[2], candidate[1]))
+        latest_by_id = max(role_messages, key=lambda candidate: candidate[1])
+        if latest_by_time[1] != latest_by_id[1]:
+            return True
+
+    if not candidates:
+        return False
+
+    current_ms = int(time.time() * 1000) if now_ms is None else int(now_ms)
+    current_clock = (current_ms << _OPENCODE_ID_COUNTER_BITS) % _OPENCODE_ID_CLOCK_MODULUS
+    newest_by_time = max(candidates, key=lambda candidate: (candidate[2], candidate[1]))
+    newest_clock = newest_by_time[3]
+    return newest_clock > current_clock and newest_clock - current_clock > _OPENCODE_ID_WRAP_DISTANCE
 
 
 class OpenCodeSessionManager:
@@ -245,6 +322,48 @@ class OpenCodeSessionManager:
             return False
         self._initialized_sessions.add(opencode_session_id)
         return True
+
+    async def repair_message_order(
+        self,
+        request: AgentRequest,
+        server: OpenCodeServerManager,
+        session_id: str,
+        messages: list[Dict[str, Any]],
+    ) -> str:
+        """Reindex a wrapped OpenCode history without dropping context."""
+
+        if not requires_message_order_repair(messages):
+            return session_id
+
+        runtime_version = await server.get_version()
+        if not _uses_legacy_message_ordering(runtime_version):
+            logger.info(
+                "OpenCode %s already uses time-ordered messages; leaving session %s unchanged",
+                runtime_version,
+                session_id,
+            )
+            return session_id
+
+        session_data = await server.fork_session(
+            session_id,
+            directory=request.working_path,
+            message_id=None,
+        )
+        repaired_session_id = str(session_data.get("id") or "").strip()
+        if not repaired_session_id:
+            raise RuntimeError(f"OpenCode returned no session ID while repairing wrapped history {session_id}")
+
+        self.bind_agent_session_id(
+            request,
+            request.base_session_id,
+            repaired_session_id,
+        )
+        logger.warning(
+            "Reindexed OpenCode session %s as %s after detecting non-monotonic message IDs",
+            session_id,
+            repaired_session_id,
+        )
+        return repaired_session_id
 
     def get_session_lock(self, base_session_id: str) -> asyncio.Lock:
         if base_session_id not in self._session_locks:

--- a/modules/agents/opencode/session.py
+++ b/modules/agents/opencode/session.py
@@ -42,7 +42,9 @@ _OPENCODE_MESSAGE_ID_RE = re.compile(r"^msg_([0-9a-fA-F]{12})")
 _OPENCODE_ID_CLOCK_BITS = 48
 _OPENCODE_ID_COUNTER_BITS = 12
 _OPENCODE_ID_CLOCK_MODULUS = 1 << _OPENCODE_ID_CLOCK_BITS
-_OPENCODE_ID_WRAP_DISTANCE = _OPENCODE_ID_CLOCK_MODULUS // 2
+_OPENCODE_ID_CLOCK_PERIOD_MS = 1 << (
+    _OPENCODE_ID_CLOCK_BITS - _OPENCODE_ID_COUNTER_BITS
+)
 _OPENCODE_TIME_ORDERED_MESSAGES_VERSION = (1, 18, 15)
 
 
@@ -111,9 +113,12 @@ def requires_message_order_repair(
 
     current_ms = int(time.time() * 1000) if now_ms is None else int(now_ms)
     current_clock = (current_ms << _OPENCODE_ID_COUNTER_BITS) % _OPENCODE_ID_CLOCK_MODULUS
-    newest_by_time = max(candidates, key=lambda candidate: (candidate[2], candidate[1]))
-    newest_clock = newest_by_time[3]
-    return newest_clock > current_clock and newest_clock - current_clock > _OPENCODE_ID_WRAP_DISTANCE
+    current_cycle = current_ms // _OPENCODE_ID_CLOCK_PERIOD_MS
+    return any(
+        int(created_at) // _OPENCODE_ID_CLOCK_PERIOD_MS < current_cycle
+        and clock_value > current_clock
+        for _role, _message_id, created_at, clock_value in candidates
+    )
 
 
 class OpenCodeSessionManager:
@@ -184,6 +189,16 @@ class OpenCodeSessionManager:
             return
         payload = dict(request.context.platform_specific or {})
         payload["agent_session_id"] = agent_session_id
+        request.context.platform_specific = payload
+
+    def _set_request_native_session_id(self, request: AgentRequest, native_session_id: str) -> None:
+        payload = dict(request.context.platform_specific or {})
+        target = payload.get("agent_session_target")
+        if isinstance(target, dict):
+            payload["agent_session_target"] = {
+                **target,
+                "native_session_id": native_session_id,
+            }
         request.context.platform_specific = payload
 
     def _reserved_agent_session_id(self, request: AgentRequest) -> Optional[str]:
@@ -353,15 +368,37 @@ class OpenCodeSessionManager:
         if not repaired_session_id:
             raise RuntimeError(f"OpenCode returned no session ID while repairing wrapped history {session_id}")
 
-        self.bind_agent_session_id(
-            request,
-            request.base_session_id,
-            repaired_session_id,
+        payload = request.context.platform_specific or {}
+        target = payload.get("agent_session_target") if isinstance(payload, dict) else None
+        agent_session_id = (
+            str(target.get("id") or "").strip()
+            if isinstance(target, dict)
+            else ""
+        ) or str(payload.get("agent_session_id") or "").strip()
+        sessions = getattr(self._settings_manager, "sessions", self._settings_manager)
+        replace_native = getattr(sessions, "replace_agent_session_native", None)
+        if not agent_session_id or not callable(replace_native):
+            raise RuntimeError(
+                f"Cannot persist repaired OpenCode session {repaired_session_id}: "
+                "the Avibe session replacement API is unavailable"
+            )
+        replaced_id = replace_native(
+            agent_session_id,
+            expected_native_session_id=session_id,
+            replacement_native_session_id=repaired_session_id,
         )
+        if not replaced_id:
+            raise RuntimeError(
+                f"Cannot persist repaired OpenCode session {repaired_session_id}: "
+                f"Avibe session {agent_session_id} no longer points to {session_id}"
+            )
+        self._set_request_agent_session_id(request, replaced_id)
+        self._set_request_native_session_id(request, repaired_session_id)
         logger.warning(
-            "Reindexed OpenCode session %s as %s after detecting non-monotonic message IDs",
+            "Reindexed OpenCode session %s as %s for Avibe session %s after detecting non-monotonic message IDs",
             session_id,
             repaired_session_id,
+            replaced_id,
         )
         return repaired_session_id
 

--- a/modules/sessions_facade.py
+++ b/modules/sessions_facade.py
@@ -166,6 +166,22 @@ class SessionsFacade:
             vibe_agent_backend=vibe_agent_backend,
         )
 
+    def replace_agent_session_native(
+        self,
+        agent_session_id: str,
+        *,
+        expected_native_session_id: Any,
+        replacement_native_session_id: Any,
+    ) -> Optional[str]:
+        replacer = getattr(self.sessions_store, "replace_agent_session_native", None)
+        if not callable(replacer):
+            return None
+        return replacer(
+            agent_session_id,
+            expected_native_session_id=expected_native_session_id,
+            replacement_native_session_id=replacement_native_session_id,
+        )
+
     def clear_agent_session_mapping(
         self,
         user_id: Union[int, str],

--- a/storage/sessions_service.py
+++ b/storage/sessions_service.py
@@ -1137,6 +1137,89 @@ class SQLiteSessionsService:
             )
             return str(session_id) if result.rowcount else None
 
+    def replace_agent_session_native(
+        self,
+        *,
+        session_id: str,
+        expected_native_session_id: Any,
+        replacement_native_session_id: Any,
+    ) -> str | None:
+        """Supersede one native binding while preserving the public Session id.
+
+        Native ids remain write-once on ordinary bind paths. A backend repair is
+        different: it first snapshots the old binding as an inert superseded row,
+        then atomically replaces the active row's binding. Keeping the active row
+        id preserves its transcript, deliveries, definitions, and Workbench URL.
+        """
+
+        expected = encode_session_value(expected_native_session_id)
+        replacement = encode_session_value(replacement_native_session_id)
+        if not expected or not replacement:
+            raise ValueError("expected and replacement native session ids are required")
+
+        now = _utc_now_iso()
+        with self.engine.begin() as conn:
+            reserve_write_lock(conn)
+            row = conn.execute(
+                select(agent_sessions).where(agent_sessions.c.id == str(session_id)).limit(1)
+            ).mappings().first()
+            if row is None or str(row["status"] or "") == "archived":
+                return None
+
+            current = str(row["native_session_id"] or "")
+            if current == replacement:
+                return str(session_id)
+            if current != expected:
+                return None
+
+            snapshot_id = new_session_id(conn)
+            anchor = str(row["session_anchor"] or "")
+            superseded_anchor = f"{anchor}{SUPERSEDED_ANCHOR_INFIX}{snapshot_id}"
+            metadata_value = _json_loads(row["metadata_json"], {})
+            snapshot_metadata = (
+                dict(metadata_value) if isinstance(metadata_value, dict) else {}
+            )
+            snapshot_metadata["superseded_native_binding"] = {
+                "active_session_id": str(session_id),
+                "replaced_at": now,
+            }
+            snapshot = dict(row)
+            snapshot.update(
+                {
+                    "id": snapshot_id,
+                    "session_anchor": superseded_anchor,
+                    "status": "archived",
+                    "visibility": "background",
+                    "pinned": 0,
+                    "agent_status": "idle",
+                    "composer_draft_text": None,
+                    "composer_draft_updated_at": None,
+                    "metadata_json": json.dumps(
+                        snapshot_metadata,
+                        separators=(",", ":"),
+                        ensure_ascii=False,
+                    ),
+                    "updated_at": now,
+                }
+            )
+            conn.execute(agent_sessions.insert().values(**snapshot))
+            replaced = conn.execute(
+                agent_sessions.update()
+                .where(agent_sessions.c.id == str(session_id))
+                .where(agent_sessions.c.status != "archived")
+                .where(func.coalesce(agent_sessions.c.native_session_id, "") == current)
+                .values(
+                    native_session_id=replacement,
+                    updated_at=now,
+                    last_active_at=now,
+                )
+            )
+            if not replaced.rowcount:
+                raise RuntimeError(
+                    f"lost native session replacement for Avibe session {session_id}"
+                )
+            return str(session_id)
+
     def find_session_for_anchor(self, *, scope_key: str, session_anchor: str) -> dict[str, Any] | None:
         """Latest ``agent_sessions`` row for ``(scope, anchor)``, any backend.
 

--- a/tests/test_opencode_server.py
+++ b/tests/test_opencode_server.py
@@ -451,6 +451,29 @@ class OpenCodeServerTests(unittest.IsolatedAsyncioTestCase):
             {"x-opencode-directory": "/tmp/%E5%B0%8F%E8%AF%B4"},
         )
 
+    async def test_get_version_uses_health_endpoint(self):
+        class _HealthSession(_FakeSession):
+            def get(self, url, headers=None, timeout=None):
+                self.gets.append({"url": url, "headers": headers, "timeout": timeout})
+                return _FakeResponse(
+                    status=200,
+                    json_data={"healthy": True, "version": "1.18.5"},
+                )
+
+        manager = OpenCodeServerManager(binary="opencode", port=4096)
+        fake_session = _HealthSession()
+
+        async def _fake_get_http_session():
+            return fake_session
+
+        manager._get_http_session = _fake_get_http_session  # type: ignore[method-assign]
+
+        with patch.object(SERVER_MODULE.aiohttp, "ClientTimeout", return_value=object()):
+            version = await manager.get_version()
+
+        self.assertEqual(version, "1.18.5")
+        self.assertEqual(fake_session.gets[0]["url"], "http://127.0.0.1:4096/global/health")
+
     async def test_prompt_async_includes_tools_when_provided(self):
         manager = OpenCodeServerManager(binary="opencode", port=4096)
         fake_session = _FakeSession()

--- a/tests/test_opencode_session_manager.py
+++ b/tests/test_opencode_session_manager.py
@@ -9,7 +9,11 @@ from unittest.mock import AsyncMock, Mock, patch
 import pytest
 
 from modules.agents.base import AgentRequest
-from modules.agents.opencode.session import OpenCodeResumeUnavailableError, OpenCodeSessionManager
+from modules.agents.opencode.session import (
+    OpenCodeResumeUnavailableError,
+    OpenCodeSessionManager,
+    requires_message_order_repair,
+)
 from modules.im import MessageContext
 from modules.sessions_facade import SessionsFacade
 
@@ -24,6 +28,100 @@ def _request() -> AgentRequest:
         composite_session_id="base-1:/repo",
         session_key="slack::channel::C1",
     )
+
+
+def _opencode_message(message_id: str, role: str, created: int) -> dict:
+    return {
+        "info": {
+            "id": message_id,
+            "role": role,
+            "time": {"created": created},
+        },
+        "parts": [],
+    }
+
+
+def test_opencode_message_order_repair_detects_completed_id_wrap() -> None:
+    messages = [
+        _opencode_message("msg_fff000000001AAAA", "user", 1),
+        _opencode_message("msg_fff000000002AAAA", "assistant", 2),
+        _opencode_message("msg_000100000001AAAA", "user", 3),
+        _opencode_message("msg_000100000002AAAA", "assistant", 4),
+    ]
+
+    assert requires_message_order_repair(messages, now_ms=0x10000) is True
+
+
+def test_opencode_message_order_repair_detects_wrap_before_first_new_message() -> None:
+    messages = [
+        _opencode_message("msg_fff000000001AAAA", "user", 1),
+        _opencode_message("msg_fff000000002AAAA", "assistant", 2),
+    ]
+
+    assert requires_message_order_repair(messages, now_ms=0x10000) is True
+
+
+def test_opencode_message_order_repair_ignores_monotonic_history() -> None:
+    messages = [
+        _opencode_message("msg_000000001001AAAA", "user", 1),
+        _opencode_message("msg_000000001002AAAA", "assistant", 2),
+        _opencode_message("msg_000000002001AAAA", "user", 3),
+        _opencode_message("msg_000000002002AAAA", "assistant", 4),
+    ]
+
+    assert requires_message_order_repair(messages, now_ms=0x10000) is False
+
+
+def test_opencode_message_order_repair_forks_and_rebinds_full_history() -> None:
+    sessions = SimpleNamespace(
+        bind_agent_session=Mock(return_value="sesk8m4q2p7x"),
+    )
+    manager = OpenCodeSessionManager(SimpleNamespace(sessions=sessions), "opencode")
+    server = SimpleNamespace(
+        get_version=AsyncMock(return_value="1.18.5"),
+        fork_session=AsyncMock(return_value={"id": "oc-reindexed"}),
+    )
+    request = _request()
+    messages = [
+        _opencode_message("msg_fff000000001AAAA", "user", 1),
+        _opencode_message("msg_000100000001AAAA", "user", 2),
+    ]
+
+    session_id = asyncio.run(manager.repair_message_order(request, server, "oc-wrapped", messages))
+
+    assert session_id == "oc-reindexed"
+    server.fork_session.assert_awaited_once_with(
+        "oc-wrapped",
+        directory="/repo",
+        message_id=None,
+    )
+    sessions.bind_agent_session.assert_called_once_with(
+        "slack::channel::C1",
+        "opencode",
+        "base-1",
+        "oc-reindexed",
+        workdir="/repo",
+    )
+
+
+def test_opencode_message_order_repair_skips_fixed_runtime() -> None:
+    sessions = SimpleNamespace(bind_agent_session=Mock())
+    manager = OpenCodeSessionManager(SimpleNamespace(sessions=sessions), "opencode")
+    server = SimpleNamespace(
+        get_version=AsyncMock(return_value="1.18.15"),
+        fork_session=AsyncMock(),
+    )
+    request = _request()
+    messages = [
+        _opencode_message("msg_fff000000001AAAA", "user", 1),
+        _opencode_message("msg_000100000001AAAA", "user", 2),
+    ]
+
+    session_id = asyncio.run(manager.repair_message_order(request, server, "oc-fixed", messages))
+
+    assert session_id == "oc-fixed"
+    server.fork_session.assert_not_awaited()
+    sessions.bind_agent_session.assert_not_called()
 
 
 def _seed_opencode_messages(tmp_path, native_session_id: str, roles: list[str]) -> None:

--- a/tests/test_opencode_session_manager.py
+++ b/tests/test_opencode_session_manager.py
@@ -41,6 +41,11 @@ def _opencode_message(message_id: str, role: str, created: int) -> dict:
     }
 
 
+def _legacy_opencode_message_id(created: int, counter: int = 1) -> str:
+    clock = ((created << 12) + counter) % (1 << 48)
+    return f"msg_{clock:012x}AAAA"
+
+
 def test_opencode_message_order_repair_detects_completed_id_wrap() -> None:
     messages = [
         _opencode_message("msg_fff000000001AAAA", "user", 1),
@@ -53,12 +58,30 @@ def test_opencode_message_order_repair_detects_completed_id_wrap() -> None:
 
 
 def test_opencode_message_order_repair_detects_wrap_before_first_new_message() -> None:
+    period_ms = 1 << 36
+    old_created = (2 * period_ms) - 0x10000
+    now_ms = (2 * period_ms) + 0x10000
     messages = [
-        _opencode_message("msg_fff000000001AAAA", "user", 1),
-        _opencode_message("msg_fff000000002AAAA", "assistant", 2),
+        _opencode_message(_legacy_opencode_message_id(old_created), "user", old_created),
+        _opencode_message(
+            _legacy_opencode_message_id(old_created + 1),
+            "assistant",
+            old_created + 1,
+        ),
     ]
 
-    assert requires_message_order_repair(messages, now_ms=0x10000) is True
+    assert requires_message_order_repair(messages, now_ms=now_ms) is True
+
+
+def test_opencode_message_order_repair_detects_prior_cycle_lower_half() -> None:
+    period_ms = 1 << 36
+    old_created = period_ms + 0x2000
+    now_ms = (2 * period_ms) + 0x1000
+    messages = [
+        _opencode_message(_legacy_opencode_message_id(old_created), "user", old_created),
+    ]
+
+    assert requires_message_order_repair(messages, now_ms=now_ms) is True
 
 
 def test_opencode_message_order_repair_ignores_monotonic_history() -> None:
@@ -74,7 +97,7 @@ def test_opencode_message_order_repair_ignores_monotonic_history() -> None:
 
 def test_opencode_message_order_repair_forks_and_rebinds_full_history() -> None:
     sessions = SimpleNamespace(
-        bind_agent_session=Mock(return_value="sesk8m4q2p7x"),
+        replace_agent_session_native=Mock(return_value="sesk8m4q2p7x"),
     )
     manager = OpenCodeSessionManager(SimpleNamespace(sessions=sessions), "opencode")
     server = SimpleNamespace(
@@ -82,6 +105,13 @@ def test_opencode_message_order_repair_forks_and_rebinds_full_history() -> None:
         fork_session=AsyncMock(return_value={"id": "oc-reindexed"}),
     )
     request = _request()
+    request.context.platform_specific = {
+        "agent_session_id": "sesk8m4q2p7x",
+        "agent_session_target": {
+            "id": "sesk8m4q2p7x",
+            "native_session_id": "oc-wrapped",
+        },
+    }
     messages = [
         _opencode_message("msg_fff000000001AAAA", "user", 1),
         _opencode_message("msg_000100000001AAAA", "user", 2),
@@ -95,17 +125,16 @@ def test_opencode_message_order_repair_forks_and_rebinds_full_history() -> None:
         directory="/repo",
         message_id=None,
     )
-    sessions.bind_agent_session.assert_called_once_with(
-        "slack::channel::C1",
-        "opencode",
-        "base-1",
-        "oc-reindexed",
-        workdir="/repo",
+    sessions.replace_agent_session_native.assert_called_once_with(
+        "sesk8m4q2p7x",
+        expected_native_session_id="oc-wrapped",
+        replacement_native_session_id="oc-reindexed",
     )
+    assert request.context.platform_specific["agent_session_target"]["native_session_id"] == "oc-reindexed"
 
 
 def test_opencode_message_order_repair_skips_fixed_runtime() -> None:
-    sessions = SimpleNamespace(bind_agent_session=Mock())
+    sessions = SimpleNamespace(replace_agent_session_native=Mock())
     manager = OpenCodeSessionManager(SimpleNamespace(sessions=sessions), "opencode")
     server = SimpleNamespace(
         get_version=AsyncMock(return_value="1.18.15"),
@@ -121,7 +150,7 @@ def test_opencode_message_order_repair_skips_fixed_runtime() -> None:
 
     assert session_id == "oc-fixed"
     server.fork_session.assert_not_awaited()
-    sessions.bind_agent_session.assert_not_called()
+    sessions.replace_agent_session_native.assert_not_called()
 
 
 def _seed_opencode_messages(tmp_path, native_session_id: str, roles: list[str]) -> None:

--- a/tests/test_sqlite_sessions_store.py
+++ b/tests/test_sqlite_sessions_store.py
@@ -2937,6 +2937,73 @@ def test_native_session_id_is_write_once_by_anchor(tmp_path: Path) -> None:
         service.close()
 
 
+def test_replace_agent_session_native_supersedes_binding_without_changing_public_session(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "vibe.sqlite"
+    service = SQLiteSessionsService(db_path)
+    try:
+        session_id = service.bind_agent_session(
+            scope_key="slack::channel::C123",
+            agent_name="opencode",
+            session_anchor="slack_C123",
+            native_session_id="native-wrapped",
+        )
+        assert session_id is not None
+
+        replaced = service.replace_agent_session_native(
+            session_id=session_id,
+            expected_native_session_id="native-wrapped",
+            replacement_native_session_id="native-repaired",
+        )
+
+        assert replaced == session_id
+        active = service.get_agent_session_by_id(session_id)
+        assert active is not None
+        assert active["session_anchor"] == "slack_C123"
+        assert active["native_session_id"] == "native-repaired"
+        assert service.find_session_for_anchor(
+            scope_key="slack::channel::C123",
+            session_anchor="slack_C123",
+        )["id"] == session_id
+        with service.engine.connect() as conn:
+            snapshots = conn.execute(
+                select(agent_sessions)
+                .where(agent_sessions.c.id != session_id)
+                .where(agent_sessions.c.session_anchor.like("slack_C123:superseded:%"))
+            ).mappings().all()
+        assert len(snapshots) == 1
+        assert snapshots[0]["native_session_id"] == "native-wrapped"
+        assert snapshots[0]["status"] == "archived"
+        assert snapshots[0]["visibility"] == "background"
+    finally:
+        service.close()
+
+
+def test_replace_agent_session_native_refuses_stale_expected_binding(tmp_path: Path) -> None:
+    db_path = tmp_path / "vibe.sqlite"
+    service = SQLiteSessionsService(db_path)
+    try:
+        session_id = service.bind_agent_session(
+            scope_key="slack::channel::C123",
+            agent_name="opencode",
+            session_anchor="slack_C123",
+            native_session_id="native-current",
+        )
+        assert session_id is not None
+
+        assert service.replace_agent_session_native(
+            session_id=session_id,
+            expected_native_session_id="native-stale",
+            replacement_native_session_id="native-repaired",
+        ) is None
+        assert service.get_agent_session_by_id(session_id)["native_session_id"] == "native-current"
+        with service.engine.connect() as conn:
+            assert conn.execute(select(agent_sessions.c.id)).all() == [(session_id,)]
+    finally:
+        service.close()
+
+
 def test_sqlite_sessions_service_delete_agent_sessions_escapes_anchor_prefix(tmp_path: Path) -> None:
     db_path = tmp_path / "vibe.sqlite"
     service = SQLiteSessionsService(db_path)
@@ -6739,6 +6806,12 @@ _MARKER_EXEMPT_ROUTE_WRITE_SITES = {
         "save_state": (
             "legacy import: the detected site is the INSERT path, and the upsert's "
             "set_ excludes both pinnable columns (see the note on its backend relabel)"
+        ),
+        # Native repair snapshot: the INSERT copies the old binding's complete
+        # route and metadata marker unchanged into an inert superseded row. The
+        # active-row UPDATE changes only native_session_id and timestamps.
+        "replace_agent_session_native": (
+            "native repair snapshot: route and marker are copied together unchanged"
         ),
     },
 }


### PR DESCRIPTION
## Summary

- detect legacy OpenCode message histories whose 48-bit ID clock has wrapped, including the first prompt that would cross the boundary
- transparently fork the full native history so OpenCode reassigns message IDs in creation order, then rebind the existing Avibe session to the repaired native session
- skip the compatibility repair on OpenCode 1.18.15+, where upstream already orders legacy messages by creation time

## Root cause

OpenCode through 1.18.14 encoded `Date.now() * 0x1000 + counter` into six bytes and selected the latest user message by lexicographically maximal ID. That clock wrapped on 2026-08-14. A post-wrap user message can therefore be persisted with the requested model while the new assistant is parented to an older pre-wrap user message and inherits that older model.

This is independent of Stop/model-switch timing: the old native turn can be fully aborted before the next prompt and the next prompt still selects the wrong historical user message.

Upstream references:

- https://github.com/anomalyco/opencode/issues/39624
- https://github.com/anomalyco/opencode/commit/db581e47a3a6f4900a6289ad7fddec60fec44e1c

## Affected scenarios

- `MESSAGE-DELIVERY-021`: durable OpenCode attempts preserve native order through exact part evidence

## Evidence

- Unit: rollover detection before and after the boundary, monotonic-history no-op, full-history fork/rebind, fixed-runtime no-op, health-version parsing
- Contract: 264 OpenCode session/server/Stop/restore/steering/runtime tests passed
- Scenario: the non-integration suite completed with 10,743 passed, 45 skipped, 17 deselected, and one expected failure; three unrelated environment failures were identified (injected caller env, occupied local Incus port, and absent worktree UI build)
- Manual: a real 169-message affected history was detected; an isolated temporary fork preserved all 169 messages and role order, cleared the rollover condition, and was deleted afterward
- Static: Ruff and `git diff --check` passed

## Residual checks

- CI should build the UI artifact and run in a clean caller/port environment, covering the three local environment-dependent failures above
- No live Avibe or OpenCode service was restarted, and no production session mapping was changed during validation
