### PR TITLE
fix(skills): keep PR review watches continuous

### DIFF
--- a/.agents/skills/pr-delivery-loop/SKILL.md
+++ b/.agents/skills/pr-delivery-loop/SKILL.md
@@ -186,14 +186,14 @@ turn ends because you armed a watch and are waiting, say exactly that.
   the fact — look for a current-head verdict instead.
 - Liveness invariant: at every pause there is either a pending bot review of
   the current head, or one you just triggered. Never wait on nothing.
-- Use `background-watch-hook` to create one one-shot combined PR watch for each
-  review phase; never use `--forever` for a delivery loop. Prefer the bundled
-  `wait_pr.py` with the current `--sha` and each required `--workflow`, plus the
-  optional `--branch`, so one waiter observes PR activity and exact-head Actions
-  transitions with one state file and one follow-up Agent Run. Re-arm after every
-  round and update `--sha` when the PR head changes. Use `wait_pr.py` without CI
-  arguments for a PR-only loop, and reserve `wait_action.py` for Actions targets
-  that are not attached to a PR.
+- Use `background-watch-hook` to create one durable `--forever` combined PR watch
+  for the whole delivery loop. Prefer the bundled `wait_pr.py` with each required
+  `--workflow` and optional `--branch`, but omit `--sha`: every cycle resolves the
+  PR's current head and observes Actions at that exact SHA. A push is a head-change
+  event, not a reason to replace the Watch. Add `--sha` only for an intentionally
+  fixed-head one-shot wait. Use `wait_pr.py` without CI arguments for PR-only
+  monitoring, and reserve `wait_action.py` for Actions targets that are not attached
+  to a PR.
 - The one-watch invariant is scoped by owner and concern: one live lane/fix
   watch per PR, plus one independent orchestrator gate watch when work is
   delegated. Review activity and the PR's exact-head CI are one lane concern
@@ -206,21 +206,24 @@ turn ends because you armed a watch and are waiting, say exactly that.
   filtering, settling, retries, and delivery acknowledgement. Those mechanics
   belong to the reusable skill; this policy only constrains when and why the
   watch is armed.
-- Arm the fresh watch only AFTER your reply-then-resolve batch is pushed and
-  settled: your own thread resolutions count as "review activity" to a watch
-  armed earlier in the round, so it self-consumes on YOUR close-out actions and
-  the real next review lands with nobody watching. End every round by using the
-  `background-watch-hook` management commands to verify exactly one live watch
-  for this owner, concern, repository, and PR. Do not rely on a remembered watch
-  ID or one bookkeeping field as proof that its waiter is live.
-- Before a push or review trigger, use `background-watch-hook` to seed a complete
-  owner-specific state file. Arm the post-action watch with that same file so
-  activity that lands during the handoff is delivered. Use catch-up only when
-  deliberately processing historical activity; a first-poll baseline after the
-  action is not a valid review-loop handoff.
-- A watch you remove while handling its event is not a liveness break: the
-  running turn owns progress until the replacement is armed. Re-arm after the
-  push and close-out actions, then verify the invariant again.
+- Before the first push or review trigger, use `background-watch-hook` to seed one
+  complete owner-specific state file, then arm the forever Watch with that same
+  file. This is the only routine baseline creation in the loop. Never reseed,
+  rotate, or replace it between rounds: review or CI activity can land while the
+  current follow-up runs, and making the already-arrived event a fresh baseline
+  silently drops it. The durable delivery acknowledgement advances the state only
+  after a report was queued, so the next automatic cycle catches the whole handoff
+  window.
+- Keep the Watch alive while pushing, replying, and resolving threads. Those own
+  actions may produce one extra batched callback, but they cannot consume the Watch
+  or leave the real next review unobserved. End every round by using the
+  `background-watch-hook` management commands to verify exactly one live Watch for
+  this owner, concern, repository, and PR. Do not rely on a remembered Watch ID or
+  one bookkeeping field as proof that its waiter is live.
+- Use catch-up only when deliberately processing historical activity before the
+  durable loop starts. A first-poll baseline after a watched action is not a valid
+  handoff, and a replacement Watch is recovery from a real failure, not normal
+  per-round operation.
 - For whoever gates the PR: a lane run that ended `succeeded` proves nothing
   about the loop. A watch-triggered run can finish clean having pushed nothing
   and armed nothing, leaving the PR with new findings and no watcher on either
@@ -237,13 +240,12 @@ turn ends because you armed a watch and are waiting, say exactly that.
   workflow name at the exact SHA and branch. A workflow name is not a unique
   run identity; do not declare CI complete while a second matching run is
   pending or failed.
-- A `+1` reaction carries no commit sha by itself. Immediately before pushing a
-  new head, establish the current activity baseline through
-  `background-watch-hook`, and do not push another head while the new review is
-  pending. Accept the reaction only when that watch reports it as new for the
-  current review phase, the prior-head review was already terminal, and the PR
-  head is unchanged. If those facts cannot be established, require the
-  bot-authored exact-head pass comment instead.
+- A `+1` reaction carries no commit sha by itself. Do not push another head while
+  the current review is pending. Accept the reaction only when the durable Watch
+  reports it as new after the current head epoch began, the prior-head review was
+  already terminal, and the PR head is unchanged. Never reseed to manufacture that
+  boundary. If those facts cannot be established, require the bot-authored
+  exact-head pass comment instead.
 - Keep reaction meanings distinct: 👀 only says a trigger was picked up; the
   Codex bot's PR-body `+1` says the review completed without comments. Reactions
   from other authors or on other comments are not verdicts.
@@ -378,10 +380,11 @@ for dependent lanes, and your final-report draft.
 
 ## 7. Orchestrator counterpart (for dispatchers, not lanes)
 
-- Do not rely on lane terminal reports alone: arm your OWN one-shot gate watch
-  per PR through `background-watch-hook`, with the follow-up in your session and
-  merge-gate instructions in the message. Lanes go silent at exactly the moment
-  that matters (§5.5 failure mode); your gate watch is the insurance.
+- Do not rely on lane terminal reports alone: arm your OWN durable `--forever`
+  gate Watch per PR through `background-watch-hook`, with independent state, the
+  follow-up in your session, and merge-gate instructions in the message. Lanes go
+  silent at exactly the moment that matters (§5.5 failure mode); your gate Watch is
+  the insurance.
 - One waiter per concern still holds: the lane's watch drives its fix loop;
   your watch drives the merge gate. Two watches on one PR, two concerns — fine.
 - Every time a findings review lands, independently paginate the threads and

--- a/.agents/skills/pr-delivery-loop/SKILL.md
+++ b/.agents/skills/pr-delivery-loop/SKILL.md
@@ -194,6 +194,10 @@ turn ends because you armed a watch and are waiting, say exactly that.
   fixed-head one-shot wait. Use `wait_pr.py` without CI arguments for PR-only
   monitoring, and reserve `wait_action.py` for Actions targets that are not attached
   to a PR.
+- Set the durable PR Watch's per-cycle `--timeout 0`. The Harness default is
+  21600 seconds, so leaving it implicit turns six hours without PR activity into a
+  terminal timeout. The waiter's individual GitHub requests remain bounded; an idle
+  PR is expected state, not a failed cycle.
 - The one-watch invariant is scoped by owner and concern: one live lane/fix
   watch per PR, plus one independent orchestrator gate watch when work is
   delegated. Review activity and the PR's exact-head CI are one lane concern

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -204,6 +204,9 @@ Source-of-truth rule:
   review-fix loop running until the review passes; use that skill's bundled PR
   and Actions waiters rather than hand-rolling one, and create the watch
   immediately without waiting to be reminded
+- keep one durable `--forever` combined PR/CI Watch for the loop: seed its state
+  once before the first review trigger, let the waiter follow the PR's current
+  head for exact-SHA Actions, and never rebuild the baseline between rounds
 - PR descriptions must name the changed capability, list affected scenario IDs
   when a catalog exists, and state which evidence layers were updated: unit,
   contract, scenario, and residual manual checks

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -206,7 +206,8 @@ Source-of-truth rule:
   immediately without waiting to be reminded
 - keep one durable `--forever` combined PR/CI Watch for the loop: seed its state
   once before the first review trigger, let the waiter follow the PR's current
-  head for exact-SHA Actions, and never rebuild the baseline between rounds
+  head for exact-SHA Actions, disable the Watch's per-cycle timeout, and never
+  rebuild the baseline between rounds
 - PR descriptions must name the changed capability, list affected scenario IDs
   when a catalog exists, and state which evidence layers were updated: unit,
   contract, scenario, and residual manual checks

--- a/skills/background-watch-hook/SKILL.md
+++ b/skills/background-watch-hook/SKILL.md
@@ -2,7 +2,7 @@
 name: background-watch-hook
 slug: background-watch-hook
 description: Use `vibe watch` to run a managed Harness waiter that returns to the same conversation later. Best for reviews, CI, files, logs, and other wait-now-continue-later workflows.
-version: 0.17.0
+version: 0.17.1
 ---
 
 # Background Watch Hook
@@ -229,7 +229,9 @@ remain optional. Add `--sha` only when the caller intentionally wants a fixed-he
 one-shot wait. The waiter stays quiet while a requested run is missing or still
 running, then reports the complete exact-head result when every requested workflow
 has terminal runs. Every distinct matching run ID is included, so an earlier failed
-rerun remains visible to the follow-up turn.
+rerun remains visible to the follow-up turn. Set the forever Watch's `--timeout 0`:
+the default 21600-second per-cycle timeout treats six quiet hours as a terminal
+failure, which is not a meaningful end condition for a PR delivery loop.
 
 ```bash
 STATE_FILE="$HOME/.avibe/state/watch-cursors/pr-151-review.json"
@@ -245,6 +247,7 @@ uv run --no-project "$BACKGROUND_WATCH_HOOK_DIR/scripts/wait_pr.py" \
 vibe watch add \
   --name "Watch PR 151 review and CI" \
   --forever \
+  --timeout 0 \
   --message "PR #151 has new review activity, a head change, or current-head CI activity. Fetch the latest PR and Actions state, resolve actionable findings, and leave this durable combined Watch armed until close-out. Summarise the round here in one or two lines; do not post that summary as a PR comment." \
   -- \
   uv run --no-project "$BACKGROUND_WATCH_HOOK_DIR/scripts/wait_pr.py" \
@@ -284,6 +287,9 @@ vibe watch add \
 Before the first watched push or review trigger in the delivery loop, seed an
 owner-specific state file from the current complete PR snapshot. Arm the forever
 Watch with that exact file and confirm it is live before taking the watched action.
+Use `--timeout 0` so an ordinary quiet period cannot retire the Watch; GitHub request
+timeouts remain bounded inside the waiter itself. A nonzero per-cycle timeout is for
+a Watch whose lack of an event by that deadline is itself reportable.
 After the Watch starts, never reseed or replace its state between rounds: a later
 event may already exist, and turning it into the new baseline silently drops it.
 The forever Watch promotes each delivered batch and compares the next cycle against
@@ -342,8 +348,8 @@ uv run --no-project "$BACKGROUND_WATCH_HOOK_DIR/scripts/wait_pr.py" \
 vibe watch add \
   --name "Monitor PR 151 reviews" \
   --forever \
-  --timeout 21600 \
-  --lifetime-timeout 86400 \
+  --timeout 0 \
+  --lifetime-timeout 0 \
   --message "PR #151 has new review activity. Fetch the latest review state and resolve the actionable findings on the PR. Then summarise the round here in one or two lines -- which findings you resolved and what changed -- and do not post that summary as a PR comment. Save a longer message for the review passing, the loop being blocked, or a decision that needs the user." \
   -- \
   uv run --no-project "$BACKGROUND_WATCH_HOOK_DIR/scripts/wait_pr.py" \

--- a/skills/background-watch-hook/SKILL.md
+++ b/skills/background-watch-hook/SKILL.md
@@ -2,7 +2,7 @@
 name: background-watch-hook
 slug: background-watch-hook
 description: Use `vibe watch` to run a managed Harness waiter that returns to the same conversation later. Best for reviews, CI, files, logs, and other wait-now-continue-later workflows.
-version: 0.16.1
+version: 0.17.0
 ---
 
 # Background Watch Hook
@@ -183,9 +183,9 @@ This skill ships bundled GitHub waiters:
 
 - `scripts/wait_pr.py`
   Waits for GitHub PR review activity, including reviews, inline review comments, PR conversation comments, PR status transitions such as `draft -> open`, `open -> merged`, or `open -> closed`, and the special Codex `+1` reaction on the PR body. It can also wait for newly opened PRs in a repository.
-  When `--sha` and one or more `--workflow` values are provided for a specific PR,
-  the same waiter also waits for every matching Actions run at that exact SHA and
-  optional branch.
+  When one or more `--workflow` values are provided for a specific PR, the same
+  waiter also watches every matching Actions run at the PR's current head and
+  optional branch. Add `--sha` only to pin a one-shot wait to one exact head.
 - `scripts/wait_issue.py`
   Waits for GitHub issue activity, either newly opened issues in a repository or new comments on a single issue.
 - `scripts/wait_action.py`
@@ -212,50 +212,49 @@ BACKGROUND_WATCH_HOOK_DIR="<directory containing the loaded SKILL.md>"
 
 ## GitHub Example Waiter
 
-For a PR delivery loop, prefer one combined `wait_pr.py` watch. It observes PR review,
-comment, reaction, thread, lifecycle, and head-change events together with selected
-Actions workflows for one exact commit. This keeps one cursor/state file and one
-follow-up Agent Run for the whole PR concern. Use `wait_pr.py` without CI arguments
-for PR-only monitoring. Use `wait_action.py` only for an Actions wait that is not
-attached to a PR.
+For a PR delivery loop, prefer one durable combined `wait_pr.py` watch. It observes
+PR review, comment, reaction, thread, lifecycle, and head-change events together
+with selected Actions workflows for the PR's current head. Use `--forever` and one
+state file for the whole loop: when a push changes the head, the next cycle fetches
+Actions for the new exact SHA without replacing the Watch or rebuilding its PR
+baseline. Use `wait_pr.py` without CI arguments for PR-only monitoring. Use
+`wait_action.py` only for an Actions wait that is not attached to a PR.
 
 ### Preferred PR + CI watch
 
-The CI arguments are one group: `--sha` and at least one repeatable `--workflow` are
-required, while `--branch`, `--max-pages`, and `--success-conclusion` are optional.
-The waiter stays quiet while a requested run is missing or still running, then reports
-the complete exact-head result when every requested workflow has terminal runs. Every
-distinct matching run ID is included, so an earlier failed rerun remains visible to
-the follow-up turn. If the PR head changes, the waiter reports that event; fetch the
-new head and re-arm with a new `--sha` rather than continuing to gate the old commit.
+At least one repeatable `--workflow` enables combined CI monitoring. Omit `--sha`
+for the normal delivery loop: each cycle resolves the PR's current head and queries
+Actions for that exact SHA. `--branch`, `--max-pages`, and `--success-conclusion`
+remain optional. Add `--sha` only when the caller intentionally wants a fixed-head
+one-shot wait. The waiter stays quiet while a requested run is missing or still
+running, then reports the complete exact-head result when every requested workflow
+has terminal runs. Every distinct matching run ID is included, so an earlier failed
+rerun remains visible to the follow-up turn.
 
 ```bash
 STATE_FILE="$HOME/.avibe/state/watch-cursors/pr-151-review.json"
-HEAD_SHA="$(gh pr view 151 --repo avibe-bot/avibe --json headRefOid --jq .headRefOid)"
 BRANCH="$(gh pr view 151 --repo avibe-bot/avibe --json headRefName --jq .headRefName)"
 
 uv run --no-project "$BACKGROUND_WATCH_HOOK_DIR/scripts/wait_pr.py" \
   --repo avibe-bot/avibe --pr 151 \
-  --sha "$HEAD_SHA" --branch "$BRANCH" \
+  --branch "$BRANCH" \
   --workflow lint \
   --actionable-only \
   --state-file "$STATE_FILE" --seed-state
 
-# Push or post the review trigger only after the combined baseline is durable.
-# If the push changed the PR head after seeding, refresh both values before arming.
-# This is required even when the old SHA was used to create the baseline.
-HEAD_SHA="$(gh pr view 151 --repo avibe-bot/avibe --json headRefOid --jq .headRefOid)"
-BRANCH="$(gh pr view 151 --repo avibe-bot/avibe --json headRefName --jq .headRefName)"
-
 vibe watch add \
   --name "Watch PR 151 review and CI" \
-  --message "PR #151 has new review activity, a head change, or exact-head CI activity. Fetch the latest PR and Actions state, resolve actionable findings, and re-arm the combined waiter for any new head. Summarise the round here in one or two lines; do not post that summary as a PR comment." \
+  --forever \
+  --message "PR #151 has new review activity, a head change, or current-head CI activity. Fetch the latest PR and Actions state, resolve actionable findings, and leave this durable combined Watch armed until close-out. Summarise the round here in one or two lines; do not post that summary as a PR comment." \
   -- \
   uv run --no-project "$BACKGROUND_WATCH_HOOK_DIR/scripts/wait_pr.py" \
     --repo avibe-bot/avibe --pr 151 \
-    --sha "$HEAD_SHA" --branch "$BRANCH" \
+    --branch "$BRANCH" \
     --workflow lint \
     --actionable-only --settle 20 --state-file "$STATE_FILE" --interval 60
+
+# After the seeded Watch is confirmed live, push or post the review trigger.
+# Keep this same state file and Watch for every later head and review round.
 ```
 
 Do not combine `--new-prs` with CI arguments. A new PR has no stable exact-head
@@ -282,9 +281,14 @@ vibe watch add \
     --interval 60
 ```
 
-Before a push or review trigger, seed an owner-specific state file from the
-current complete PR snapshot. Arm the post-action watch with that exact file so
-activity that lands during the handoff remains visible.
+Before the first watched push or review trigger in the delivery loop, seed an
+owner-specific state file from the current complete PR snapshot. Arm the forever
+Watch with that exact file and confirm it is live before taking the watched action.
+After the Watch starts, never reseed or replace its state between rounds: a later
+event may already exist, and turning it into the new baseline silently drops it.
+The forever Watch promotes each delivered batch and compares the next cycle against
+that durable pre-event snapshot, including activity that landed while the Agent
+follow-up was running.
 
 Use `--catch-up` only when deliberately processing historical activity. It is
 not a substitute for the pre-action baseline in a review loop.

--- a/skills/background-watch-hook/SKILL.md
+++ b/skills/background-watch-hook/SKILL.md
@@ -2,7 +2,7 @@
 name: background-watch-hook
 slug: background-watch-hook
 description: Use `vibe watch` to run a managed Harness waiter that returns to the same conversation later. Best for reviews, CI, files, logs, and other wait-now-continue-later workflows.
-version: 0.17.1
+version: 0.17.2
 ---
 
 # Background Watch Hook
@@ -254,7 +254,8 @@ vibe watch add \
     --repo avibe-bot/avibe --pr 151 \
     --branch "$BRANCH" \
     --workflow lint \
-    --actionable-only --settle 20 --state-file "$STATE_FILE" --interval 60
+    --actionable-only --settle 20 --state-file "$STATE_FILE" --interval 60 \
+    --timeout 0
 
 # After the seeded Watch is confirmed live, push or post the review trigger.
 # Keep this same state file and Watch for every later head and review round.
@@ -287,9 +288,11 @@ vibe watch add \
 Before the first watched push or review trigger in the delivery loop, seed an
 owner-specific state file from the current complete PR snapshot. Arm the forever
 Watch with that exact file and confirm it is live before taking the watched action.
-Use `--timeout 0` so an ordinary quiet period cannot retire the Watch; GitHub request
-timeouts remain bounded inside the waiter itself. A nonzero per-cycle timeout is for
-a Watch whose lack of an event by that deadline is itself reportable.
+Set `--timeout 0` on both sides of the `--` command separator: the first disables
+the Watch supervisor's per-cycle deadline, while the second disables the bundled
+waiter's own default six-hour deadline. GitHub request timeouts remain bounded inside
+the waiter. A nonzero timeout at either layer is for a Watch whose lack of an event
+by that deadline is itself reportable.
 After the Watch starts, never reseed or replace its state between rounds: a later
 event may already exist, and turning it into the new baseline silently drops it.
 The forever Watch promotes each delivered batch and compares the next cycle against
@@ -358,7 +361,8 @@ vibe watch add \
     --actionable-only \
     --settle 20 \
     --state-file "$STATE_FILE" \
-    --interval 60
+    --interval 60 \
+    --timeout 0
 ```
 
 Always pass `--state-file` to a `--forever` watch. Each cycle is a fresh waiter

--- a/skills/background-watch-hook/scripts/wait_pr.py
+++ b/skills/background-watch-hook/scripts/wait_pr.py
@@ -603,12 +603,17 @@ def _fetch_state(
     review_threads, review_thread_requests = _fetch_review_threads(repo, pr_number, token)
     actions: list[dict[str, Any]] = []
     action_requests = 0
-    if ci_sha and ci_workflows:
+    selected_ci_sha = ci_sha or (_current_pr_head_sha(pull_request) if ci_workflows else None)
+    if ci_workflows and not selected_ci_sha:
+        raise RuntimeError(
+            "GitHub PR response has no head SHA for current-head CI monitoring"
+        )
+    if selected_ci_sha and ci_workflows:
         actions, action_requests = fetch_workflow_runs(
             repo,
             token,
             branch=ci_branch,
-            head_sha=ci_sha,
+            head_sha=selected_ci_sha,
             max_pages=ci_max_pages,
             cache=cache,
         )
@@ -619,9 +624,13 @@ def _fetch_state(
         requests_after_actions = 1
     else:
         requests_after_actions = 0
-    if ci_sha and ci_workflows and _current_pr_head_sha(pull_request).casefold() != ci_sha.casefold():
+    if (
+        selected_ci_sha
+        and ci_workflows
+        and _current_pr_head_sha(pull_request).casefold() != selected_ci_sha.casefold()
+    ):
         # The PR moved while this snapshot was assembled. The caller will report the
-        # head transition and re-arm with a new SHA; never render old-SHA Actions.
+        # head transition; never render Actions fetched for the previous head.
         actions = []
     return (
         {
@@ -1551,10 +1560,8 @@ def _validate_ci_args(args: argparse.Namespace) -> str | None:
         return None
     if args.pr is None:
         return "CI monitoring requires --pr; --new-prs cannot be combined with --sha or --workflow"
-    if not args.sha:
-        return "CI monitoring requires --sha"
     if not args.workflow:
-        return "CI monitoring requires at least one --workflow when --sha is provided"
+        return "CI monitoring requires at least one --workflow"
     if args.max_pages < 1:
         return "--max-pages must be at least 1"
     if len(set(args.workflow)) != len(args.workflow):
@@ -1779,8 +1786,8 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--sha",
         help=(
-            "Exact PR head SHA whose Actions runs should be monitored together with PR activity; "
-            "requires at least one --workflow"
+            "Optional exact PR head SHA whose Actions runs should be monitored together with PR "
+            "activity. Omit it to follow the PR's current head across watch cycles"
         ),
     )
     parser.add_argument(
@@ -1790,7 +1797,10 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--workflow",
         action="append",
-        help="Actions workflow name to monitor at --sha; repeatable and enables combined CI mode",
+        help=(
+            "Actions workflow name to monitor at --sha, or at the PR's current head when --sha is "
+            "omitted; repeatable and enables combined CI mode"
+        ),
     )
     parser.add_argument(
         "--max-pages",
@@ -1972,7 +1982,7 @@ def main() -> int:
         return 1
     selected_actions: dict[str, list[dict[str, Any]]] = {}
     state, requests_per_poll_count = initial_request.value
-    if args.pr is not None and ci_enabled:
+    if args.pr is not None and ci_enabled and args.sha:
         observed_head_sha = _current_pr_head_sha(state.get("pull_request"))
         if observed_head_sha.casefold() != args.sha.casefold():
             print(
@@ -1983,11 +1993,12 @@ def main() -> int:
             )
             return 2
     if ci_enabled:
+        selected_ci_sha = args.sha or _current_pr_head_sha(state.get("pull_request"))
         selected_actions = select_matching_runs(
             state.get("actions", []),
             workflows=args.workflow or [],
             branch=args.branch,
-            head_sha=args.sha,
+            head_sha=selected_ci_sha,
         )
 
     # The remote target is now proven valid. Only now may this run create or adopt
@@ -2139,6 +2150,9 @@ def main() -> int:
 
     if args.pr is not None:
 
+        def _active_ci_head_sha() -> str:
+            return args.sha or _current_pr_head_sha(state.get("pull_request"))
+
         def _initial_cursor(flag_value: int | None, saved_key: str, items_key: str) -> int:
             if flag_value is not None:
                 return flag_value
@@ -2216,7 +2230,7 @@ def main() -> int:
                 actions_output, _failed = render_actions_result(
                     repo=args.repo,
                     branch=args.branch,
-                    head_sha=args.sha,
+                    head_sha=_active_ci_head_sha(),
                     selected=selected_actions,
                     success_conclusions=success_conclusions,
                 )
@@ -2233,7 +2247,7 @@ def main() -> int:
                     state.get("actions", []),
                     workflows=args.workflow or [],
                     branch=args.branch,
-                    head_sha=args.sha,
+                    head_sha=_active_ci_head_sha(),
                 )
 
         def _actions_waiting_for_terminal_result() -> bool:
@@ -2245,7 +2259,7 @@ def main() -> int:
             actions_output, _failed = render_actions_result(
                 repo=args.repo,
                 branch=args.branch,
-                head_sha=args.sha,
+                head_sha=_active_ci_head_sha(),
                 selected=selected_actions,
                 success_conclusions=success_conclusions,
             )

--- a/tests/test_cli_watch_command.py
+++ b/tests/test_cli_watch_command.py
@@ -1324,6 +1324,39 @@ def test_watch_update_renames_and_retargets_watch(tmp_path: Path, capsys) -> Non
     assert payload["definition"]["shell_command"] == "python3 wait_deploy.py"
 
 
+def test_watch_update_accepts_zero_timeout(tmp_path: Path, capsys) -> None:
+    store = ManagedWatchStore(tmp_path / "watches.json")
+    runtime_store = WatchRuntimeStateStore(tmp_path / "watch_runtime.json")
+    watch = store.add_watch(
+        name="Watch PR",
+        session_key="slack::channel::C123",
+        command=["python3", "wait.py"],
+        shell_command=None,
+        prefix=None,
+        cwd=None,
+        mode="forever",
+        timeout_seconds=21600,
+        lifetime_timeout_seconds=0,
+        retry_exit_codes=[75],
+        retry_delay_seconds=30,
+        post_to=None,
+        deliver_key=None,
+    )
+    args = _parse_watch_update([watch.id, "--timeout", "0"])
+
+    with (
+        patch("vibe.cli._ensure_config", return_value=_configured_v2({"slack"})),
+        patch("vibe.cli._watch_store", return_value=store),
+        patch("vibe.cli._watch_runtime_store", return_value=runtime_store),
+    ):
+        result = cli.cmd_watch_update(args)
+
+    assert result == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["definition"]["timeout_seconds"] == 0
+    assert store.get_watch(watch.id).timeout_seconds == 0
+
+
 def test_watch_update_session_key_clears_previous_session_id(tmp_path: Path, capsys) -> None:
     store = ManagedWatchStore(tmp_path / "watches.json")
     runtime_store = WatchRuntimeStateStore(tmp_path / "watch_runtime.json")

--- a/tests/test_harness_skill_guidance.py
+++ b/tests/test_harness_skill_guidance.py
@@ -173,7 +173,20 @@ def test_background_watch_skill_uses_bundled_waiters_and_persists_managed_pr_sta
     assert "Omit `--sha`" in body
     assert "Use `--forever` and one" in body
     assert "never reseed or replace its state between rounds" in body
-    assert body.count("--timeout 0") >= 2
+    preferred_section = body.split("### Preferred PR + CI watch", 1)[1]
+    preferred_forever_command = preferred_section.split('vibe watch add \\\n', 1)[
+        1
+    ].split("```", 1)[0]
+    supervisor, waiter = preferred_forever_command.split("  -- \\\n", 1)
+    assert "--timeout 0" in supervisor
+    assert "--timeout 0" in waiter
+    generic_forever_command = body.split('  --name "Monitor PR 151 reviews"', 1)[1].split(
+        "```", 1
+    )[0]
+    supervisor, waiter = generic_forever_command.split("  -- \\\n", 1)
+    assert "--timeout 0" in supervisor
+    assert "--timeout 0" in waiter
+    assert "both sides of the `--` command separator" in body
     assert "six quiet hours" in body
     assert '--workflow lint' in body
 

--- a/tests/test_harness_skill_guidance.py
+++ b/tests/test_harness_skill_guidance.py
@@ -170,6 +170,10 @@ def test_background_watch_skill_uses_bundled_waiters_and_persists_managed_pr_sta
     assert "independent wake signal" in body
     assert "single wake/no-wake" in body
     assert "caught up or reseeded" in body
+    assert "Omit `--sha`" in body
+    assert "Use `--forever` and one" in body
+    assert "never reseed or replace its state between rounds" in body
+    assert '--workflow lint' in body
 
 
 def test_pr_delivery_loop_delegates_waiters_to_background_watch_skill() -> None:
@@ -185,5 +189,10 @@ def test_pr_delivery_loop_delegates_waiters_to_background_watch_skill() -> None:
 
     assert "the `pr-delivery-loop` skill for every implementation task" in agents
     assert "use the `background-watch-hook` skill" in agents
+    assert "one durable `--forever` combined PR/CI Watch" in agents
+    assert "one durable `--forever` combined PR watch" in body
+    assert "omit `--sha`" in body
+    assert "Never reseed" in body
+    assert "never use `--forever`" not in body
     assert (ROOT / "skills/background-watch-hook/scripts/wait_pr.py").is_file()
     assert (ROOT / "skills/background-watch-hook/scripts/wait_action.py").is_file()

--- a/tests/test_harness_skill_guidance.py
+++ b/tests/test_harness_skill_guidance.py
@@ -173,6 +173,8 @@ def test_background_watch_skill_uses_bundled_waiters_and_persists_managed_pr_sta
     assert "Omit `--sha`" in body
     assert "Use `--forever` and one" in body
     assert "never reseed or replace its state between rounds" in body
+    assert body.count("--timeout 0") >= 2
+    assert "six quiet hours" in body
     assert '--workflow lint' in body
 
 
@@ -192,6 +194,8 @@ def test_pr_delivery_loop_delegates_waiters_to_background_watch_skill() -> None:
     assert "one durable `--forever` combined PR/CI Watch" in agents
     assert "one durable `--forever` combined PR watch" in body
     assert "omit `--sha`" in body
+    assert "per-cycle `--timeout 0`" in body
+    assert "disable the Watch's per-cycle timeout" in agents
     assert "Never reseed" in body
     assert "never use `--forever`" not in body
     assert (ROOT / "skills/background-watch-hook/scripts/wait_pr.py").is_file()

--- a/tests/test_wait_for_github_pr_activity.py
+++ b/tests/test_wait_for_github_pr_activity.py
@@ -797,18 +797,23 @@ def test_main_detects_pr_status_change_during_polling() -> None:
     assert "pr_status #153 open -> merged" in stdout.getvalue()
 
 
-def test_combined_ci_mode_requires_exact_sha_and_workflow() -> None:
+def test_combined_ci_mode_supports_pinned_or_dynamic_current_head() -> None:
     module = _load_module()
 
-    valid = module._build_parser().parse_args(
+    pinned = module._build_parser().parse_args(
         ["--repo", "avibe-bot/avibe", "--pr", "153", "--sha", "abc123", "--workflow", "CI"]
     )
-    assert module._validate_ci_args(valid) is None
+    assert module._validate_ci_args(pinned) is None
 
-    missing_sha = module._build_parser().parse_args(
+    dynamic = module._build_parser().parse_args(
         ["--repo", "avibe-bot/avibe", "--pr", "153", "--workflow", "CI"]
     )
-    assert "--sha" in (module._validate_ci_args(missing_sha) or "")
+    assert module._validate_ci_args(dynamic) is None
+
+    missing_workflow = module._build_parser().parse_args(
+        ["--repo", "avibe-bot/avibe", "--pr", "153", "--branch", "feature"]
+    )
+    assert "--workflow" in (module._validate_ci_args(missing_workflow) or "")
 
     new_pr_mode = module._build_parser().parse_args(
         ["--repo", "avibe-bot/avibe", "--new-prs", "--sha", "abc123", "--workflow", "CI"]
@@ -1127,6 +1132,65 @@ def test_combined_pr_waiter_reports_ci_completion(tmp_path) -> None:
     assert fetch_calls == 2
     assert "GitHub Actions success for avibe-bot/avibe@abc123 on feature" in stdout.getvalue()
     assert "CI: status=completed conclusion=success" in stdout.getvalue()
+
+
+def test_dynamic_combined_waiter_follows_the_current_pr_head(tmp_path) -> None:
+    module = _load_module()
+    state_file = tmp_path / "pr-153-combined.json"
+    fetch_calls = 0
+
+    def _fake_fetch_state(repo, pr_number, token, **kwargs):
+        nonlocal fetch_calls
+        fetch_calls += 1
+        assert kwargs["ci_sha"] is None
+        assert kwargs["ci_workflows"] == ["CI"]
+        head_sha = "old-head" if fetch_calls == 1 else "new-head"
+        state = _pr_state()
+        state["pull_request"]["head"] = {"sha": head_sha}
+        state["actions"] = [
+            {
+                "id": fetch_calls,
+                "name": "CI",
+                "head_sha": head_sha,
+                "head_branch": "feature",
+                "status": "in_progress" if fetch_calls == 1 else "completed",
+                "conclusion": None if fetch_calls == 1 else "success",
+                "html_url": f"https://github.com/example/actions/runs/{fetch_calls}",
+            }
+        ]
+        return state, 2
+
+    stdout = io.StringIO()
+    with (
+        patch.object(module, "_fetch_state", side_effect=_fake_fetch_state),
+        patch.object(module, "get_token", return_value="token"),
+        patch.object(module, "get_authenticated_login", return_value="tester"),
+        patch.object(module.time, "sleep", return_value=None),
+        patch(
+            "sys.argv",
+            [
+                "wait_pr.py",
+                "--repo",
+                "avibe-bot/avibe",
+                "--pr",
+                "153",
+                "--workflow",
+                "CI",
+                "--state-file",
+                str(state_file),
+                "--interval",
+                "1",
+            ],
+        ),
+        redirect_stdout(stdout),
+    ):
+        rc = module.main()
+
+    output = stdout.getvalue()
+    assert rc == 0
+    assert fetch_calls == 2
+    assert "pr_head #153 old-head -> new-head" in output
+    assert "GitHub Actions success for avibe-bot/avibe@new-head" in output
 
 
 def test_combined_settle_does_not_report_a_stale_ci_success_after_a_rerun_starts() -> None:
@@ -2021,6 +2085,62 @@ def test_fetch_state_includes_combined_actions_and_request_count() -> None:
     assert state["actions"][0]["id"] == 7
     assert request_count == 2 + 5 + 2
     assert fetch_pr.call_count == 2
+
+
+def test_fetch_state_uses_the_observed_pr_head_for_dynamic_ci() -> None:
+    module = _load_module()
+    with (
+        patch.object(module, "list_paginated_with_count", return_value=([], 1)),
+        patch.object(
+            module,
+            "github_get",
+            side_effect=[
+                {"number": 153, "state": "open", "head": {"sha": "current-head"}},
+                {"number": 153, "state": "open", "head": {"sha": "current-head"}},
+            ],
+        ),
+        patch.object(module, "_fetch_review_threads", return_value=([], 1)),
+        patch.object(module, "fetch_workflow_runs", return_value=([], 1)) as fetch_actions,
+    ):
+        module._fetch_state(
+            "avibe-bot/avibe",
+            153,
+            "token",
+            ci_branch="feature",
+            ci_workflows=["CI"],
+        )
+
+    fetch_actions.assert_called_once_with(
+        "avibe-bot/avibe",
+        "token",
+        branch="feature",
+        head_sha="current-head",
+        max_pages=3,
+        cache=fetch_actions.call_args.kwargs["cache"],
+    )
+
+
+def test_fetch_state_rejects_dynamic_ci_when_pr_head_is_missing() -> None:
+    module = _load_module()
+    with (
+        patch.object(module, "list_paginated_with_count", return_value=([], 1)),
+        patch.object(module, "github_get", return_value={"number": 153, "state": "open"}),
+        patch.object(module, "_fetch_review_threads", return_value=([], 1)),
+        patch.object(module, "fetch_workflow_runs") as fetch_actions,
+        pytest.raises(
+            RuntimeError,
+            match="GitHub PR response has no head SHA for current-head CI monitoring",
+        ),
+    ):
+        module._fetch_state(
+            "avibe-bot/avibe",
+            153,
+            "token",
+            ci_branch="feature",
+            ci_workflows=["CI"],
+        )
+
+    fetch_actions.assert_not_called()
 
 
 def test_fetch_state_discards_actions_when_pr_moves_during_fetch() -> None:
@@ -3964,7 +4084,7 @@ def _managed_state(module, path, watch_id: str | None, **fields) -> None:
     )
 
 
-def _run_managed(module, state_file, fetch, *, delivery: str = ""):
+def _run_managed(module, state_file, fetch, *, delivery: str = "", extra_args=()):
     """One managed cycle over ``state_file``, told when this watch last delivered."""
 
     env = {module.WATCH_ID_ENV: "wat_9", module.LAST_DELIVERY_ENV: delivery}
@@ -3976,7 +4096,16 @@ def _run_managed(module, state_file, fetch, *, delivery: str = ""):
         patch.object(module, "get_authenticated_login", return_value="tester"),
         patch(
             "sys.argv",
-            ["wait_pr.py", "--repo", "avibe-bot/avibe", "--pr", "153", "--state-file", str(state_file)],
+            [
+                "wait_pr.py",
+                "--repo",
+                "avibe-bot/avibe",
+                "--pr",
+                "153",
+                "--state-file",
+                str(state_file),
+                *extra_args,
+            ],
         ),
         redirect_stdout(stdout),
         patch("sys.stderr", io.StringIO()),
@@ -4056,6 +4185,92 @@ def test_a_managed_run_promotes_the_staged_cursors_once_the_report_was_delivered
     payload = json.loads(state_file.read_text(encoding="utf-8"))
     assert payload["review_comment_cursor"] == 501
     assert module.STAGED_KEY not in payload
+
+
+def test_dynamic_combined_cycles_report_activity_that_lands_during_the_follow_up(tmp_path) -> None:
+    """A forever re-arm keeps one baseline across CI and the later review.
+
+    The first cycle exits after CI succeeds. The review lands while its Agent
+    follow-up is running, before the next cycle starts. Reusing the same durable
+    state must compare that review with the pre-review snapshot instead of
+    baselining it away.
+    """
+
+    module = _load_module()
+    state_file = tmp_path / "pr-153-combined.json"
+    baseline = _pr_state()
+    baseline["pull_request"]["head"] = {"sha": "head-1"}
+    in_progress = {
+        "id": 7,
+        "name": "CI",
+        "head_sha": "head-1",
+        "head_branch": "feature",
+        "status": "in_progress",
+        "conclusion": None,
+    }
+    _managed_state(
+        module,
+        state_file,
+        "wat_9",
+        **_complete_pr_baseline_fields(module, baseline),
+        actions=module.normalize_selected_runs({"CI": [in_progress]}),
+    )
+
+    succeeded = {
+        **in_progress,
+        "status": "completed",
+        "conclusion": "success",
+        "html_url": "https://github.com/example/actions/runs/7",
+    }
+
+    def _fetch_ci(repo, pr_number, token, **kwargs):
+        state = _pr_state()
+        state["pull_request"]["head"] = {"sha": "head-1"}
+        state["actions"] = [succeeded]
+        return state, 2
+
+    rc, first_output, first_payload = _run_managed(
+        module,
+        state_file,
+        _fetch_ci,
+        delivery="delivery-1",
+        extra_args=("--workflow", "CI"),
+    )
+    assert rc == 0
+    assert "GitHub Actions success" in first_output
+    assert module.STAGED_KEY in first_payload
+
+    def _fetch_review(repo, pr_number, token, **kwargs):
+        state = _pr_state(
+            issue_comments=[
+                {
+                    "id": 601,
+                    "body": (
+                        "Codex Review: Didn't find any major issues.\n\n"
+                        "**Reviewed commit:** `head-1`"
+                    ),
+                    "user": {"login": "chatgpt-codex-connector[bot]"},
+                    "html_url": "https://github.com/example/repo/pull/153#issuecomment-601",
+                }
+            ]
+        )
+        state["pull_request"]["head"] = {"sha": "head-1"}
+        state["actions"] = [succeeded]
+        return state, 2
+
+    rc, second_output, second_payload = _run_managed(
+        module,
+        state_file,
+        _fetch_review,
+        delivery="delivery-2",
+        extra_args=("--workflow", "CI"),
+    )
+
+    assert rc == 0
+    assert "issue_comment #601" in second_output
+    assert "Didn't find any major issues" in second_output
+    assert second_payload["issue_comment_cursor"] == 0
+    assert second_payload[module.STAGED_KEY]["cursors"]["issue_comment_cursor"] == 601
 
 
 def test_a_managed_run_reports_the_event_again_when_it_was_never_delivered(tmp_path) -> None:


### PR DESCRIPTION
## Capability

Keep one durable PR review Watch across every review and CI round. The combined waiter follows the PR's current head dynamically, queries Actions at that exact SHA, and preserves one delivery-aware cursor instead of rebuilding the baseline after each callback.

Durable PR Watches now explicitly disable both the Harness per-cycle timeout and the bundled waiter's own polling timeout, so an ordinary quiet period cannot retire either layer of the loop. Pinned `--sha` mode remains available for intentionally fixed-head one-shot waits.

## Scenarios

- No catalog scenario IDs apply to this Harness Skill change.
- Added a managed two-cycle regression for the observed handoff window: CI wakes the Watch, a Codex review lands during the Agent follow-up, and the next automatic cycle must report that review instead of absorbing it into a fresh baseline.
- Added a CLI contract regression that preserves zero as the valid "no per-cycle timeout" value when updating an existing Watch.
- Added a Skill contract regression that requires `--timeout 0` on both sides of the Watch command separator in every durable PR example.

## Evidence

- Unit: 333 focused waiter, CLI, Harness guidance, and Watch lifecycle tests pass.
- Contract: `ruff` passes; `background-watch-hook` validates at version 0.17.2; `pr-delivery-loop` remains valid with its existing frontmatter advisories.
- Scenario: dynamic current-head changes, exact-head Actions selection, mid-fetch head movement, missing-head protocol failure, callback-window delivery, zero-timeout updates, and dual-layer timeout guidance are covered.
- Residual manual: this branch's durable Watch reported the exact-head Codex pass and later CI success as separate events without reseeding. Six quiet hours exposed the supervisor deadline, and review of that fix exposed the independent waiter deadline; the same Watch ID and cursor were updated in place to disable both layers.

## Risk

The dynamic-head behavior applies only when workflows are requested without `--sha`. Existing pinned callers retain fixed-head validation and output semantics. A PR delivery Watch now remains idle until activity or explicit close-out; individual GitHub requests remain bounded inside the waiter.
