### PR TITLE
fix(ui): only report OpenCode OAuth sign-in for stored OAuth auth

### DIFF
--- a/ui/src/components/settings/providers/OpencodeProviderConfig.test.tsx
+++ b/ui/src/components/settings/providers/OpencodeProviderConfig.test.tsx
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import type { OpencodeProvider } from '@/context/ApiContext';
 
-import { providerOauthSignedIn } from './OpencodeProviderConfig';
+import { providerOauthSignedIn } from './opencodeProviderAuth';
 
 const baseProvider: OpencodeProvider = {
   id: 'openai',

--- a/ui/src/components/settings/providers/OpencodeProviderConfig.test.tsx
+++ b/ui/src/components/settings/providers/OpencodeProviderConfig.test.tsx
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+
+import type { OpencodeProvider } from '@/context/ApiContext';
+
+import { providerOauthSignedIn } from './OpencodeProviderConfig';
+
+const baseProvider: OpencodeProvider = {
+  id: 'openai',
+  name: 'OpenAI',
+  description: '',
+  configured: false,
+  oauth_available: true,
+  local: false,
+  models: [],
+  default_model: null,
+};
+
+describe('providerOauthSignedIn', () => {
+  // Regression: an API-key save marks the provider ``configured``, and the
+  // in-card OAuth panel used to render "OAuth credentials stored" off that
+  // flag alone. The panel must only report signed-in for a stored OAuth
+  // entry — property: signed-in follows the active auth type, never the
+  // configured badge.
+  it('is false for a provider configured with an API key', () => {
+    expect(
+      providerOauthSignedIn({
+        ...baseProvider,
+        configured: true,
+        has_auth: true,
+        active_auth_type: 'api',
+        api_key_masked: 'sk-9d68•••8819',
+      }),
+    ).toBe(false);
+  });
+
+  it('is true only while the active auth type is oauth', () => {
+    expect(
+      providerOauthSignedIn({
+        ...baseProvider,
+        configured: true,
+        has_auth: true,
+        active_auth_type: 'oauth',
+      }),
+    ).toBe(true);
+  });
+
+  it('is false when no auth type is reported (unconfigured, local, or custom)', () => {
+    expect(providerOauthSignedIn({ ...baseProvider })).toBe(false);
+    expect(
+      providerOauthSignedIn({
+        ...baseProvider,
+        configured: true,
+        local: true,
+        oauth_available: false,
+      }),
+    ).toBe(false);
+    expect(
+      providerOauthSignedIn({
+        ...baseProvider,
+        configured: true,
+        custom: true,
+        oauth_available: false,
+        active_auth_type: null,
+      }),
+    ).toBe(false);
+  });
+});

--- a/ui/src/components/settings/providers/OpencodeProviderConfig.tsx
+++ b/ui/src/components/settings/providers/OpencodeProviderConfig.tsx
@@ -152,6 +152,13 @@ const providerMatchesFilter = (provider: OpencodeProvider, mode: FilterMode): bo
 const providerHasAuth = (provider: OpencodeProvider): boolean =>
   provider.has_auth ?? Boolean(provider.api_key_masked || provider.active_auth_type);
 
+// The in-card OAuth panel must only report "signed in" when OpenCode's
+// auth store actually holds an OAuth entry for the provider. ``configured``
+// alone is true for API-key saves too, which used to render "OAuth
+// credentials stored" over a plain API-key setup.
+export const providerOauthSignedIn = (provider: OpencodeProvider): boolean =>
+  provider.active_auth_type === 'oauth';
+
 const providerMatchesSearch = (provider: OpencodeProvider, q: string): boolean => {
   if (!q) return true;
   const needle = q.toLowerCase();
@@ -1354,7 +1361,7 @@ export const OpencodeProviderConfig: React.FC<{
                                   <BackendOAuthPanel
                                     backend="opencode"
                                     opencodeProviderId={provider.id}
-                                    signedIn={provider.configured}
+                                    signedIn={providerOauthSignedIn(provider)}
                                     title={t('settings.backends.opencodeProviderOauthPanelTitle', {
                                       name: provider.name,
                                     })}

--- a/ui/src/components/settings/providers/OpencodeProviderConfig.tsx
+++ b/ui/src/components/settings/providers/OpencodeProviderConfig.tsx
@@ -37,6 +37,7 @@ import { useModelHubCapability } from '../models/useModelHubCapability';
 import { OpencodePermissionSetup } from '../shared/OpencodePermissionSetup';
 import { useBackendRuntime } from '../shared/useBackendRuntime';
 import { useOpencodePermission } from '../shared/useOpencodePermission';
+import { providerOauthSignedIn } from './opencodeProviderAuth';
 import { useApi } from '@/context/ApiContext';
 import type {
   OpencodeMutationResult,
@@ -151,13 +152,6 @@ const providerMatchesFilter = (provider: OpencodeProvider, mode: FilterMode): bo
 
 const providerHasAuth = (provider: OpencodeProvider): boolean =>
   provider.has_auth ?? Boolean(provider.api_key_masked || provider.active_auth_type);
-
-// The in-card OAuth panel must only report "signed in" when OpenCode's
-// auth store actually holds an OAuth entry for the provider. ``configured``
-// alone is true for API-key saves too, which used to render "OAuth
-// credentials stored" over a plain API-key setup.
-export const providerOauthSignedIn = (provider: OpencodeProvider): boolean =>
-  provider.active_auth_type === 'oauth';
 
 const providerMatchesSearch = (provider: OpencodeProvider, q: string): boolean => {
   if (!q) return true;

--- a/ui/src/components/settings/providers/opencodeProviderAuth.ts
+++ b/ui/src/components/settings/providers/opencodeProviderAuth.ts
@@ -1,0 +1,8 @@
+import type { OpencodeProvider } from '@/context/ApiContext';
+
+// The in-card OAuth panel must only report "signed in" when OpenCode's
+// auth store actually holds an OAuth entry for the provider. ``configured``
+// alone is true for API-key saves too, which used to render "OAuth
+// credentials stored" over a plain API-key setup.
+export const providerOauthSignedIn = (provider: OpencodeProvider): boolean =>
+  provider.active_auth_type === 'oauth';


### PR DESCRIPTION
## Changed capability

OpenCode provider Settings UI — the in-card OAuth panel's signed-in state.

The panel previously received `signedIn={provider.configured}`, so saving an
API key (which marks the provider configured) rendered "OAuth credentials
stored." even though no OAuth entry exists in OpenCode's `auth.json`. Users
who replaced a broken/expired OpenAI OAuth login with an API key + relay
base URL were told they were still "signed in via OAuth", masking the real
auth source and sending them debugging OAuth instead of their endpoint.

`signedIn` now derives from `active_auth_type === 'oauth'` — the same source
the list badge already uses — via a new exported pure helper
`providerOauthSignedIn`, with the property pinned by unit tests:
signed-in follows the active auth type, never the configured badge.

## Affected scenario IDs

None. `tests/scenarios/auth_setup/catalog.yaml` covers IM-side credential
installation flows (AUTH-SETUP-003/101/…), not this Settings UI panel; no
catalog entry maps to it.

## Evidence layers

- Unit: new
  `ui/src/components/settings/providers/OpencodeProviderConfig.test.tsx`
  (API-key-configured → not signed in; oauth → signed in; missing/null
  auth type → not signed in).
- Contract: unchanged — no API/field shape changes.
- Scenario: none affected (see above).
- Residual manual: visual confirmation in a packaged Settings UI build is
  deferred to the normal release pass; `npm run build` verified locally.

## Dependencies

None.
