### PR TITLE
docs(memory): specify IM attachment capture

### DIFF
--- a/docs/plans/memory-im-attachments-1425.md
+++ b/docs/plans/memory-im-attachments-1425.md
@@ -1,0 +1,194 @@
+# IM attachment capture via EverOS multimodal ingest
+
+Issue: [#1425](https://github.com/avibe-bot/avibe/issues/1425)
+
+## Goal
+
+Let an eligible attachment sent in a bound one-to-one IM conversation enter the
+existing durable Memory capture pipeline without changing ordinary Agent file
+delivery. Avibe acquires each native attachment once, pins only admitted content
+inside the existing private Memory bundle root, and sends the same closed
+`ContentItem` kinds that the Workbench path already uses to EverOS.
+
+This is a multi-platform, provider-neutral capability. Platform adapters expose
+bounded acquisition primitives; shared core owns admission, lifetime, limits,
+redaction, and capture behavior.
+
+## Locked product decisions
+
+- IM attachment capture requires an explicit, complete
+  `memory.processing.multimodal` endpoint. Workbench keeps the released implicit
+  main-LLM inheritance for one compatibility cycle; loading an old config must
+  not copy or persist that inherited API key.
+- A complete multimodal endpoint is the opt-in. There is no second attachment
+  toggle.
+- A mixed turn degrades per attachment. Eligible text and every valid attachment
+  survive independently; one unsupported, oversized, or failed download never
+  rejects the turn.
+- The first release keeps the existing Avibe allowlist in
+  `core/memory/modality.py`: bitmap images, PDF, supported audio, direct text,
+  CSV, VTT, HTML, and EML. Office/iWork/ODF/RTF, SVG, and video remain excluded
+  even where EverOS can parse them.
+- The Memory consumer alone applies the limit of 8 files, 25 MiB per file, and
+  100 MiB per bundle. Ordinary Agent attachment behavior is unchanged.
+- Multimodal preflight sends a tiny generated image containing no user or
+  conversation data.
+
+## Admission contract
+
+Adapters add a literal-true native fact for an ordinary human attachment turn,
+separate from `is_ordinary_text`. `core/memory/admission.py` remains the only
+authority. Memory may retain an IM file only after all of these properties hold:
+
+- Memory is enabled and explicit multimodal configuration is complete;
+- platform, stable native message id, and stable session id are recognized;
+- the event is a one-to-one DM from a human and is positively classified as an
+  ordinary attachment shape;
+- the user is bound and enabled; and
+- the principal and the default v3 Memory project resolve successfully.
+
+Missing or non-boolean facts fail closed. Groups, channels, edited, forwarded,
+shared, rich, system, bot, and self-authored events remain ineligible. Admission
+must complete before Memory retains a lease or performs Memory-only acquisition.
+The Agent path may still use the same materialized file under its existing rules.
+
+An attachment-only turn with no surviving attachment is skipped. A mixed turn
+with no surviving attachment may still capture eligible text. Admission and
+attachment failure never annotate or fail the chat turn.
+
+## Acquisition and lifetime contract
+
+`core/handlers/inbound_attachments.py` owns shared native-file materialization.
+It calls the platform's `BaseIMClient.download_file_to_path` implementation,
+uses sanitized names, removes partial files, and publishes only an opaque,
+reference-counted local lease. Consumers never receive a native URL, token,
+encryption material, or mutable `MessageContext` as their durable contract.
+
+The message handler materializes before scheduling Memory capture. Agent delivery
+and Memory retain independent lease references, so Agent cleanup, retry, or
+durable-delivery failure cannot race the Memory pin. Downloads are sequential or
+at most two concurrent and keep the existing 30-second per-file timeout.
+
+Slack, Discord, and Feishu/Lark use their existing authenticated streaming path
+downloads with declared, response-header, and streamed-byte limits. Telegram is
+changed to a bounded-to-disk Bot API download; it must not buffer the entire file
+before checking the limit. WeChat checks declared size before acquisition and
+bounds ciphertext/decrypted output while writing; a post-download-only check is
+not sufficient.
+
+`core/memory/im_attachments.py` accepts only shared-materializer leases. It checks
+declared size before retaining a Memory consumer and checks final size, MIME,
+extension, and magic after acquisition through the closed modality table. It
+produces immutable `CaptureAttachment` values for surviving files.
+
+`core/memory/attachments.py` accepts either the fixed Workbench upload root or a
+fixed leased-IM source handle. Both paths keep no-follow opens, owner and mode
+checks, copy-time size enforcement, hashing, atomic bundle publication, existing
+free-disk checks, and crash reconciliation. Source kind is not persisted; bundle
+manifest v1 and the store schema do not change.
+
+## Provider and degradation contract
+
+Prepared captures use the existing path:
+
+```text
+MemoryModule -> durable outbox -> coordinator -> EverOSPort.add(ContentItem[]) -> flush
+```
+
+The outbox and logs may contain only sanitized display name, closed content kind
+and extension, byte count, bundle-relative metadata, keyed source digests, and
+closed skip reasons. They must not contain native URLs, credentials, encryption
+material, raw attachment bytes, absolute source paths, filenames supplied for
+telemetry, or adapter exception text.
+
+Absent multimodal configuration or parser capability skips IM attachments before
+pinning, enqueueing, or calling `/add`. Each rejected item degrades independently.
+Avibe emits one scrub-safe `memory_attachment_capture_skipped` event per turn with
+platform, count, and one closed reason only.
+
+Configured adds retain the existing retry and ambiguity semantics. Deterministic
+EverOS `UNSUPPORTED_FORMAT` and `CAPABILITY_UNAVAILABLE` attachment outcomes are
+terminal, release their bundle, and cannot open an endless processing fault.
+Transient and ambiguous outcomes retain the bundle exactly as the current capture
+coordinator does.
+
+The sidecar gains no route. Its existing exact `POST /api/v2/memory/add` envelope
+remains unchanged; `_valid_workbench_attachment` becomes pinned-attachment
+validation without accepting platform URLs or widening the confined provider root.
+
+## Configuration, preflight, and status
+
+Add optional all-or-none values at:
+
+```text
+memory.processing.multimodal.base_url
+memory.processing.multimodal.model
+memory.processing.multimodal.api_key
+```
+
+The block follows the released rerank behavior: an absent old key loads and saves
+without shape churn, an empty block normalizes to absent, partial API input is
+rejected, and a malformed persisted optional block disables only multimodal with a
+warning so startup continues. API keys remain write-only.
+
+Only allowlisted child environment variables carry
+`EVEROS_MULTIMODAL__BASE_URL`, `EVEROS_MULTIMODAL__MODEL`, and
+`EVEROS_MULTIMODAL__API_KEY`. Generated TOML contains the confined attachment root
+and `file_uri_max_bytes = 26214400`, but no credential. Saving a changed endpoint
+runs bounded preflight and rolling sidecar reconciliation; it does not rebuild
+embeddings or restart Avibe.
+
+`MemoryPreflightDiagnostic.side` adds `multimodal`. Its real compatibility probe is
+a tiny generated image request with no user data. Missing optional configuration
+does not block Memory enablement. Insight-reader and preflight redaction include the
+independent multimodal URL and key; a configured parse may produce a bounded,
+redacted `multimodal_llm` record, while an unconfigured skip produces no provider
+add or call-log row.
+
+Settings exposes an optional Multimodal endpoint card with the same write-only-key
+and clear semantics as rerank. Status continues to project EverOS
+`multimodal_llm`, `parser`, and `disabled_features` and adds a concise attachment
+capture availability line. Configuration remains UI-only; no CLI config flags are
+added.
+
+## Scenario contract
+
+The canonical capability is `memory_im_attachment_capture` under
+`tests/scenarios/memory_im_attachment_capture/`:
+
+- `MEMORY-IM-ATTACH-001`: a bound Slack DM image/PDF is downloaded once, pinned,
+  added, flushed, extracted, and retrievable through `vibe memory search`;
+- `MEMORY-IM-ATTACH-002`: group and unbound denial performs no Memory acquisition;
+- `MEMORY-IM-ATTACH-003`: absent multimodal configuration captures eligible text
+  only and creates no attachment provider/call-log activity; and
+- `MEMORY-IM-ATTACH-004`: count, per-file, total-size, unsupported-type, and partial
+  download failures preserve valid siblings and leave no temp or bundle leak.
+
+The closed-loop harness uses a stub platform client, a real test-owned bundle path,
+and local fake OpenAI-compatible providers. It must not use live credentials,
+running Avibe services, real user paths, or production state.
+
+## Delivery slices
+
+1. Contract and scenario catalog, including the stale Workbench-copy and IM
+   non-goal corrections in `memory-plugin-system.md`.
+2. Optional multimodal config, child environment, preflight/redaction, UI, and
+   status. IM capture stays gated.
+3. Shared leased materializer, bounded Telegram/WeChat acquisition, and pin-source
+   generalization. IM capture stays gated.
+4. Attachment classification/admission and the Slack closed loop with call-log
+   proof.
+5. Discord, Telegram, Feishu/Lark, and WeChat enablement and contract tests, plus
+   final user documentation and manual verification matrix.
+
+Each PR is based on the latest merged `master`; there are no stacked PRs. Shared
+files with the #1424 lane receive only additive, narrowly scoped changes. If that
+lane lands first, this work rebases and re-runs the complete review loop before the
+next slice.
+
+## Residual manual checks
+
+Hermetic tests prove the product contracts without live platform credentials.
+After all five slices merge, the orchestrator's integration pass should verify one
+eligible image and one rejected file on every configured IM platform in the local
+Incus regression environment, preserving accumulated product state.

--- a/docs/plans/memory-plugin-system.md
+++ b/docs/plans/memory-plugin-system.md
@@ -81,9 +81,11 @@ Busy Workbench sessions preserve the same rule. Consecutive queued messages are
 merged only within one user segment, the flushed segment keeps that user's
 identity and final message id, and the segment is captured once.
 
-Workbench attachments are forwarded only when their existing local files are
-inside Avibe's controlled attachment root. Memory does not copy the files. IM
-attachments are excluded and no provider-side download pipeline is exposed.
+Workbench attachments are accepted only when their existing local files are
+inside Avibe's controlled attachment root. Memory validates and copies admitted
+files into a private pinned bundle before enqueueing; provider access remains
+confined to that bundle root. IM attachments are currently excluded pending the
+bounded acquisition and admission contract in #1425.
 
 ### User isolation
 
@@ -243,7 +245,7 @@ Important fixed guards are:
 | Guard | Limit |
 |---|---|
 | Automatic capture text | 32 KiB UTF-8 |
-| Workbench attachments | 8; 16 KiB total descriptor metadata |
+| Memory attachment bundle | 8 files; 25 MiB/file; 100 MiB total; 16 KiB descriptor metadata |
 | Nonterminal queue | 500 rows |
 | Minimum free disk for capture | 512 MiB |
 | Terminal idempotency tombstones | 90 days, newest 100,000 rows |
@@ -377,8 +379,8 @@ platform identities belong to the same human.
 
 ## Deliberate Non-goals
 
-The beta does not include automatic recall, assistant-message capture, IM
-attachments, group/workspace/shared memory, cross-platform identity linking,
+The beta does not include automatic recall, assistant-message capture,
+group/workspace/shared memory, cross-platform identity linking,
 registered backend-specific Memory tools, item-level edit/delete, export/import,
 provider migration, editable provider Markdown, exactly-once provider delivery,
 or agent-driven configuration and Clear all. Each requires a separate product

--- a/tests/scenarios/INDEX.yaml
+++ b/tests/scenarios/INDEX.yaml
@@ -67,6 +67,14 @@ capabilities:
       - tests/test_memory_cli.py
       - ui/src/components/settings/memory/MemorySearchPanel.test.tsx
       - ui/src/context/ApiContext.memoryList.test.tsx
+  - id: memory_im_attachment_capture
+    name: Bound-DM attachment capture through EverOS multimodal ingest
+    status: planned
+    catalog: tests/scenarios/memory_im_attachment_capture/catalog.yaml
+    observations: tests/scenarios/memory_im_attachment_capture/observations.yaml
+    scenario_tests: []
+    unit_or_contract_tests:
+      - tests/scenarios/memory_im_attachment_capture/test_memory_im_attachment_capture_catalog.py
   - id: memory_repair
     name: Live Memory index repair via admitted artifact sync
     status: active

--- a/tests/scenarios/memory_im_attachment_capture/catalog.yaml
+++ b/tests/scenarios/memory_im_attachment_capture/catalog.yaml
@@ -1,0 +1,41 @@
+version: 1
+capability:
+  id: memory_im_attachment_capture
+  name: Bound-DM attachment capture through EverOS multimodal ingest
+  canonical_tests:
+    - tests/scenarios/memory_im_attachment_capture/test_memory_im_attachment_capture_catalog.py
+contract:
+  admission: bound_enabled_one_to_one_dm_fail_closed
+  opt_in: explicit_complete_multimodal_endpoint
+  degradation: text_and_valid_attachments_survive_independently
+  formats: current_avibe_memory_allowlist
+  limits: memory_only_8_files_25_mib_each_100_mib_bundle
+  preflight: generated_image_without_user_data
+  workbench_compatibility: implicit_main_llm_for_one_cycle
+status_legend:
+  planned: scenario id and invariant reserved; behavior evidence lands in a later slice
+scenarios:
+  - id: MEMORY-IM-ATTACH-001
+    name: Bound Slack DM attachments traverse one download, pin, add, flush, and search path
+    status: planned
+    kind: happy_path
+    layer: scenario
+    delivery_slice: 4
+  - id: MEMORY-IM-ATTACH-002
+    name: Group and unbound events perform no Memory attachment acquisition
+    status: planned
+    kind: authorization
+    layer: scenario
+    delivery_slice: 4
+  - id: MEMORY-IM-ATTACH-003
+    name: Missing multimodal configuration preserves eligible text without attachment provider activity
+    status: planned
+    kind: degradation
+    layer: scenario
+    delivery_slice: 4
+  - id: MEMORY-IM-ATTACH-004
+    name: Invalid attachments preserve valid siblings and leave no temporary or bundle leak
+    status: planned
+    kind: boundary
+    layer: scenario
+    delivery_slice: 4

--- a/tests/scenarios/memory_im_attachment_capture/observations.yaml
+++ b/tests/scenarios/memory_im_attachment_capture/observations.yaml
@@ -1,0 +1,24 @@
+version: 1
+capability: memory_im_attachment_capture
+observations:
+  - id: MEMORY-IM-ATTACH-OBS-001
+    scenarios:
+      - MEMORY-IM-ATTACH-001
+      - MEMORY-IM-ATTACH-004
+    observation: Slack, Discord, and Feishu/Lark already expose bounded streaming path downloads; Telegram buffers before its limit and WeChat checks only after download and decrypt, so those two adapters require bounded writers.
+    evidence:
+      avibe_commit: c21bf9268417c9d857ea275fe9f7e95023809311
+  - id: MEMORY-IM-ATTACH-OBS-002
+    scenarios:
+      - MEMORY-IM-ATTACH-001
+      - MEMORY-IM-ATTACH-003
+    observation: EverOS parses non-text ContentItems before ordinary extraction, supports independent multimodal endpoint variables, and returns capability unavailable when that client or parser is absent.
+    evidence:
+      everos_commit: 560fb80b59fe5f033a911e38bebc87a3232a5234
+  - id: MEMORY-IM-ATTACH-OBS-003
+    scenarios:
+      - MEMORY-IM-ATTACH-001
+      - MEMORY-IM-ATTACH-002
+    observation: The existing Avibe sidecar already admits confined pinned file URIs for the exact memory add route, while current IM admission rejects file turns before Memory acquisition.
+    evidence:
+      avibe_commit: c21bf9268417c9d857ea275fe9f7e95023809311

--- a/tests/scenarios/memory_im_attachment_capture/test_memory_im_attachment_capture_catalog.py
+++ b/tests/scenarios/memory_im_attachment_capture/test_memory_im_attachment_capture_catalog.py
@@ -1,0 +1,84 @@
+"""Mechanical contract for the planned IM attachment capture scenarios."""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+SCENARIO_ROOT = Path("tests/scenarios/memory_im_attachment_capture")
+PROJECT_INDEX = Path("tests/scenarios/INDEX.yaml")
+
+LOCKED_CONTRACT = {
+    "admission": "bound_enabled_one_to_one_dm_fail_closed",
+    "opt_in": "explicit_complete_multimodal_endpoint",
+    "degradation": "text_and_valid_attachments_survive_independently",
+    "formats": "current_avibe_memory_allowlist",
+    "limits": "memory_only_8_files_25_mib_each_100_mib_bundle",
+    "preflight": "generated_image_without_user_data",
+    "workbench_compatibility": "implicit_main_llm_for_one_cycle",
+}
+
+
+def _load(path: Path) -> dict:
+    return yaml.safe_load(path.read_text())
+
+
+def test_memory_im_attachment_catalog_is_indexed_and_locks_the_approved_contract() -> None:
+    catalog = _load(SCENARIO_ROOT / "catalog.yaml")
+    observations = _load(SCENARIO_ROOT / "observations.yaml")
+    index = _load(PROJECT_INDEX)
+    entry = next(
+        item
+        for item in index["capabilities"]
+        if item["id"] == "memory_im_attachment_capture"
+    )
+
+    assert catalog["contract"] == LOCKED_CONTRACT
+    assert entry["status"] == "planned"
+    assert entry["catalog"] == (SCENARIO_ROOT / "catalog.yaml").as_posix()
+    assert entry["observations"] == (SCENARIO_ROOT / "observations.yaml").as_posix()
+    assert entry["unit_or_contract_tests"] == [
+        (SCENARIO_ROOT / "test_memory_im_attachment_capture_catalog.py").as_posix()
+    ]
+
+    scenario_ids = [row["id"] for row in catalog["scenarios"]]
+    assert len(scenario_ids) == len(set(scenario_ids))
+    assert all(
+        scenario_id in scenario_ids
+        for observation in observations["observations"]
+        for scenario_id in observation["scenarios"]
+    )
+
+
+@pytest.mark.parametrize(
+    ("scenario_id", "kind", "delivery_slice"),
+    [
+        ("MEMORY-IM-ATTACH-001", "happy_path", 4),
+        ("MEMORY-IM-ATTACH-002", "authorization", 4),
+        ("MEMORY-IM-ATTACH-003", "degradation", 4),
+        ("MEMORY-IM-ATTACH-004", "boundary", 4),
+    ],
+)
+def test_memory_im_attachment_planned_scenario_contract(
+    scenario_id: str,
+    kind: str,
+    delivery_slice: int,
+) -> None:
+    """The four MEMORY-IM-ATTACH scenario IDs stay stable until behavior evidence replaces this contract."""
+
+    catalog = _load(SCENARIO_ROOT / "catalog.yaml")
+    rows = {row["id"]: row for row in catalog["scenarios"]}
+
+    assert len(rows) == len(catalog["scenarios"])
+    assert set(rows) == {
+        "MEMORY-IM-ATTACH-001",
+        "MEMORY-IM-ATTACH-002",
+        "MEMORY-IM-ATTACH-003",
+        "MEMORY-IM-ATTACH-004",
+    }
+    assert rows[scenario_id]["status"] == "planned"
+    assert rows[scenario_id]["kind"] == kind
+    assert rows[scenario_id]["layer"] == "scenario"
+    assert rows[scenario_id]["delivery_slice"] == delivery_slice
+    assert "test" not in rows[scenario_id]


### PR DESCRIPTION
## Capability

Defines the approved contract for #1425 and registers the planned
`memory_im_attachment_capture` scenario capability. This first of five delivery
slices changes no runtime behavior: IM attachments remain excluded until the
later gated implementation slices land.

The contract fixes admission ownership, explicit multimodal opt-in, independent
mixed-message degradation, the current Avibe format allowlist, Memory-only size
limits, generated-image preflight, shared lease/pin lifetime, scrubbed telemetry,
and the one-cycle Workbench compatibility exception. It also corrects the stale
claim that Workbench Memory does not copy attachments into a private bundle.

## Scenario IDs

- `MEMORY-IM-ATTACH-001` - bound Slack DM attachment download/pin/add/flush/search
- `MEMORY-IM-ATTACH-002` - group and unbound denial before Memory acquisition
- `MEMORY-IM-ATTACH-003` - absent multimodal config preserves text without attachment provider activity
- `MEMORY-IM-ATTACH-004` - per-item limits/failures preserve valid siblings without leaks

## Evidence

- Unit: planned catalog rows are parameterized and mechanically checked for stable IDs, kinds, layers, and delivery slices
- Contract: executable assertions lock all seven owner decisions and index/catalog/observation traceability
- Scenario: IDs and invariants are reserved; closed-loop behavior evidence intentionally lands in PR4 (Slack) and PR5 (Discord, Telegram, Feishu/Lark, WeChat)
- Residual manual: none for this documentation-only slice; live-platform checks remain deferred to the post-PR5 local Incus integration pass

## Dependencies and delivery

- No prerequisite PR.
- PR2 must start from `master` after this PR merges; no stacked PRs.
- Subsequent slices are config/UI, shared download/pin, Slack closed loop, then the remaining four platforms.
- Shared files with the concurrent #1424 lane remain outside this PR.

## Known by design

- The capability is indexed as `planned`; this PR does not claim behavior coverage.
- Current IM attachment admission remains closed until the Slack slice.
- Office/iWork/ODF/RTF, SVG, and video remain excluded in the first release.
- The 8-file, 25 MiB/file, and 100 MiB/bundle limits apply only to Memory.

## Deviations

None.

Closes no issue; #1425 completes after all five slices merge.
