### PR TITLE
docs(memory): specify EverOS agent track

### DIFF
--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -38,9 +38,13 @@ user-id attribution lines. Enabling Agent Memory discloses that those content
 bytes are retained locally and sent to the configured processing endpoints;
 they never become structural Memory ownership, scope, or provider paths.
 
-Each enable, disable, Clear, and Reinitialize atomically records its completed-
-Turn high water and capture intent in the primary state transaction that orders
-Turn settlement. The Memory scan state projects that exact cutover. Turns
+Each enable or disable first atomically records a prepared completed-Turn high
+water and capture intent in the primary state transaction that orders Turn
+settlement, then replaces V2 config. Recovery commits that exact boundary only
+when config has the desired digest, or cancels it when the prior digest remains;
+it never advances the boundary to restart time. Clear and Reinitialize record
+the same cutover before destructive work. The Memory scan state projects that
+exact cutover. Turns
 completed before first enable, during a later disabled interval, or before a
 destructive reset are not backfilled. The owner's workdir/project bindings
 remain in Memory settings across Clear and Reinitialize; the reset runtime
@@ -55,18 +59,18 @@ starts after worker quiescence. Crash recovery reuses the exact intent and
 resumes that drain; drained rows remain pending without provider I/O until a
 later enable, which also skips the completed opt-out interval.
 
-Adding, changing, or removing a workdir binding has its own committed terminal
-high-water cutover taken after the desired V2 config is persisted. The setting
-becomes sequence-effective when that high water and a recovery intent commit in
-one primary-state transaction; the Agent scanner pauses until the corresponding
-epoch is published, and the save succeeds only after publication. Backlogged
+Adding, changing, or removing a workdir binding first records a prepared
+terminal high-water cutover and prior/desired config digests in primary state,
+then replaces V2 config. The Agent scanner pauses until the corresponding epoch
+is published, and the save succeeds only after publication. A failed config
+write cancels the prepared cutover; recovery commits its original high water
+only when the desired digest persisted. Backlogged
 Turns use the project binding that was effective when they settled; a new project
 never captures pre-cutover work, and removal keeps its closed binding epoch until
 the scanner durably drains through the cutover. That already-settled backlog
 remains eligible for delivery under the old project; later-settling Turns do not.
-Crash recovery uses a later conservative high water only when config committed
-before any intent; otherwise it reuses the exact recorded cutover. Turn
-settlement never waits for Memory projection work.
+Crash recovery never creates a later cutover. Turn settlement never waits for
+Memory projection work.
 
 The existing Personal Memory root remains pinned to chat mode. Agent Memory has
 its own provider root, socket, lifecycle/health slot, scanner, and queue. An
@@ -74,16 +78,24 @@ ordinary agent-track scanning, processing, retrieval, or reconcile failure
 cannot alter user capture or Personal Memory processing. Explicit Clear,
 Reinitialize, and embedding-identity rebuild operations intentionally share a
 maintenance fence and can pause both roles until the operation converges.
+The roles also share remote processing credentials: Agent load can consume the
+endpoint account's concurrency, rate, or quota and throttle Personal requests.
+This external resource coupling cannot corrupt or merge the two local tracks;
+Agent requests remain bounded and back off when throttled.
 The Agent queue independently caps nonterminal work at 500 rows and requires at
 least 512 MiB free before admission; guarded turns are counted without retaining
 their text. Scrubbed terminal tombstones retain at most 90 days and the newest
 100,000 rows.
 
 Agent cases and skills are available only through explicit, scoped Agent Memory
-search/list operations in the CLI or owner Settings UI. Returned skill content
-is untrusted text: Avibe does not install or execute it and never injects it into
-an Agent prompt. Each displayed skill includes its last-updated timestamp and
-maturity score. Memory status reports a non-blocking per-Agent skill-count hint:
+search/list operations in the CLI or owner Settings UI. CLI ownership comes from
+the trusted current Turn's immutable executing-Agent snapshot, not mutable
+Session routing. A read-only per-Agent project catalog keeps already-enqueued or
+later-delivered data and existing provider data retrievable after its last
+workdir binding is removed. Returned skill content is untrusted text: Avibe does
+not install or execute it and never injects it into an Agent prompt. Each
+displayed skill includes its last-updated timestamp and maturity score. Memory
+status reports a non-blocking per-Agent skill-count hint:
 8-10 is approaching the upstream prompt limit and more than 10 is the risk zone.
 A global incremental sampler limits one refresh to 32 Agent/project count reads
 with concurrency two; incomplete observations are shown as unknown or stale.

--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -14,6 +14,37 @@ Avibe Memory distills eligible Workbench and private-IM messages into a
 per-user profile, episodes, and facts. Open **Settings > Memory** to inspect its
 Processing Record, current profile, search results, and settings.
 
+## Planned Agent Memory beta
+
+This track remains unavailable until the #1424 implementation slices land. The
+contract below records the behavior those slices must deliver.
+
+Agent Memory is a separate, off-by-default track for completed Agent Turns. When
+the owner explicitly enables it and binds a source workdir to `default` or a
+named Memory project, Avibe asynchronously sends the exact Agent dispatch text
+and successful final result to a dedicated EverOS agent-mode root. Interactive
+and Harness turns use the same admission rule. Failed, canceled, silent,
+legacy-Agent, oversized, malformed, callback, maintenance, and unbound turns are
+skipped without delaying or changing the Turn result.
+
+The existing Personal Memory root remains pinned to chat mode. Agent Memory has
+its own provider root, socket, lifecycle/health slot, scanner, and queue. An
+agent-track failure cannot alter user capture or Personal Memory processing.
+
+Agent cases and skills are available only through explicit, scoped Agent Memory
+search/list operations in the CLI or owner Settings UI. Returned skill content
+is untrusted text: Avibe does not install or execute it and never injects it into
+an Agent prompt. A successful add/flush means the trajectory was processed, not
+that EverOS necessarily produced a case or skill.
+
+EverOS 1.2.3 may produce zero output through quality gates. Skill retirement is
+not implemented; sanitized skill-name collisions can overwrite a prior file;
+and clusters above ten indexed skills retain an upstream stale-index clobber
+risk. The track is isolated so these accepted limitations cannot corrupt
+Personal Memory. See
+[`memory-agent-track-1424.md`](plans/memory-agent-track-1424.md) for the complete
+contract.
+
 ## Processed episode listing
 
 `vibe memory list` reads only valid, active processed episodes for the current
@@ -128,8 +159,9 @@ finish before starting another one.
 
 Before Reinitialize Memory, use **Clear Memory Data** when retained Memory data or the
 call-log database is corrupt. Clear Memory Data records a durable intent marker, then
-removes only the queue, provider data, call log, and pinned attachments through their
-idempotent deletion primitives. Clear is irreversible; it does not delete
+removes the Personal and Agent Memory queues, both owned provider roots, role-owned call
+logs, and pinned attachments through their idempotent deletion primitives. Clear is
+irreversible; it does not delete
 the `memory` or `state/memory` roots themselves, original Avibe chats, copies
 already sent to providers, or data outside those surfaces (including logs or
 user-created snapshots); it is not a secure wipe.
@@ -182,7 +214,7 @@ Retired backup and snapshot residue is also cleaned best effort and never blocks
 
 ### Reinitialize Memory
 
-When Memory state is corrupt beyond rebuild, use **Reinitialize Memory** beside Repair on the Memory Runtime card in Settings > Dependencies. The action remains visible but unavailable until the pinned `memory-runtime` artifact is installed and ready; repair that artifact first when it is invalid. The confirmation pauses for five seconds and explains that it will delete local Memory data and related operational state before attempting to start a brand-new Memory engine. It also warns that startup can fail after deletion and the old data will not be restored. The mixed-purpose storage locations are labeled **Primary Memory storage** and **Memory state storage**; their technical paths, `<effective_home>/memory` and `<effective_home>/state/memory`, remain available as secondary details.
+When Memory state is corrupt beyond rebuild, use **Reinitialize Memory** beside Repair on the Memory Runtime card in Settings > Dependencies. The action remains visible but unavailable until the pinned `memory-runtime` artifact is installed and ready; repair that artifact first when it is invalid. The confirmation pauses for five seconds and explains that it will delete local Memory data and related operational state, including both Personal and Agent Memory roots, before attempting to start brand-new enabled Memory engines. It also warns that startup can fail after deletion and the old data will not be restored. The mixed-purpose storage locations are labeled **Primary Memory storage** and **Memory state storage**; their technical paths, `<effective_home>/memory` and `<effective_home>/state/memory`, remain available as secondary details.
 
 Reinitialize Memory keeps Memory settings, credentials, and the installed artifact. The request waits for its final result and reports the two storage locations independently, so a partial deletion is shown as partial rather than claimed as a clean success. A durable internal `factory_reset` recovery intent makes retry idempotent after a crash; while that intent is pending, other Memory controls remain disabled and the action is labeled **Retry initialization**. Reinitialize Memory is not a secure wipe and does not remove original chats or copies already sent to remote endpoints.
 

--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -57,7 +57,11 @@ never advances the boundary to restart time. Clear and Reinitialize record their
 capture high water after destructive deletion completes and before scan-state
 recreation. In that same primary transaction they scrub both terminal and
 in-flight dispatch snapshots, release their budget, and mark them reset-crossing
-before reporting success. The Memory scan state projects that exact cutover. Turns
+before reporting success. Primary state also persists the current capture
+epoch/enabled/config-revision projection; enable, disable, and reset replace it
+only when their intent is cleared, so native-start admission survives controller
+restart without reading `memory.sqlite` or inventing an epoch. The Memory scan
+state projects that exact cutover. Turns
 completed before first enable, during a later disabled interval, or before a
 destructive reset are not backfilled. The owner's workdir/project bindings
 remain in Memory settings across Clear and Reinitialize; the reset runtime
@@ -80,9 +84,13 @@ later enable, which also skips the completed opt-out interval.
 
 Adding, changing, or removing a workdir binding first records a prepared
 terminal high-water cutover and prior/desired config revision/digest pairs in
-primary state,
-then replaces V2 config. The Agent scanner pauses until the corresponding epoch
-is published, and the save succeeds only after publication. A failed config
+primary state, then replaces V2 config. Each add or reassignment receives a new
+monotonic opaque binding generation. After config commit, the promotion
+transaction scrubs an old generation from every Turn still active or settled
+after the cutover while preserving terminal backlog through the high water; a
+remove/re-add therefore cannot revive an earlier snapshot. The Agent scanner
+pauses until the corresponding epoch is published, and the save succeeds only
+after publication. A failed config
 write cancels the prepared cutover; recovery commits its original high water
 only when the desired revision/digest pair persisted. Backlogged
 Turns use the project binding that was effective when they settled; a new project
@@ -115,10 +123,11 @@ their text. Scrubbed terminal tombstones retain at most 90 days and the newest
 Final-dispatch snapshots are admitted only while a committed capture epoch is
 enabled and the source workdir has one committed explicit project binding, at
 most 256 KiB per Turn and 128 MiB total in primary state. The Turn persists only
-that binding's opaque key. The start gate checks it against a revision-matched
-controller projection while binding cutovers are fenced; it never reads the
-Memory store or stores a workdir/project. The Turn must settle in the same
-capture epoch, and its project is resolved from the epoch effective at
+that binding's opaque key and monotonic generation. The start gate checks both
+against a revision-matched controller projection while binding cutovers are
+fenced; it never reads the Memory store or stores a workdir/project. The Turn
+must settle in the same capture epoch and continuous binding generation, and its
+project is resolved from the epoch effective at
 settlement. A Turn started unbound is never admitted retroactively. The final
 native backend request must be text-only;
 any Turn with a separate image, attachment, audio, file, or other out-of-band
@@ -130,9 +139,14 @@ enqueue/skip, disabled settlement, abandonment, Clear, or Reinitialize;
 destructive operations include snapshots of Turns still in flight.
 
 Agent cases and skills are available only through explicit, scoped Agent Memory
-search/list operations in the CLI or owner Settings UI. CLI ownership comes from
-the trusted current Turn's immutable executing-Agent snapshot, not mutable
-Session routing. A read-only per-Agent project catalog keeps already-enqueued or
+search/list operations in the CLI or owner Settings UI. The CLI carries only its
+session-stable locator. Immediately before each recognized command, the backend
+tool callback resolves exactly one native-started nonterminal Turn and injects a
+30-second, one-use controller capability bound to that Turn, its immutable
+executing Agent, and the normalized request. Cached Claude clients use per-call
+`updated_input`, not spawn-time environment. Missing, stale, reused, or ambiguous
+context fails closed with no static-Session fallback. Mutable Session routing is
+never identity. A read-only per-Agent project catalog keeps already-enqueued or
 later-delivered data and existing provider data retrievable after its last
 workdir binding is removed. If the Agent is hard-deleted, owner Settings retains
 an opaque read-only `Deleted Agent` selector; CLI retrieval remains bound to the

--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -21,13 +21,16 @@ contract below records the behavior those slices must deliver.
 
 Agent Memory is a separate, off-by-default track for completed Agent Turns. When
 the owner explicitly enables it and binds a source workdir to `default` or a
-named Memory project, Avibe asynchronously sends the exact Agent dispatch text
-and successful final result to a dedicated EverOS agent-mode root. Interactive
-and Harness turns use the same admission rule and snapshot the final executing
-`agents.id` when the Turn starts; later Session routing cannot change its Memory
-partition. Accepted-live-steer, failed, canceled, silent, missing-agent-snapshot,
-oversized, malformed, callback, maintenance, and unbound turns are skipped
-without delaying or changing the Turn result.
+named Memory project, Avibe asynchronously sends the exact post-transformation
+backend dispatch text and successful final result to a dedicated EverOS
+agent-mode root. The Turn durably records that final text before native start.
+Interactive and Harness turns use the same admission rule and
+snapshot the final executing `agents.id` when the Turn starts; later Session
+routing or Agent hard deletion cannot change its Memory partition. Delivery
+batching keeps ordinary Harness work separate from callbacks. Accepted-live-
+steer, failed, canceled, silent, missing-snapshot, oversized, malformed,
+callback, maintenance, and unbound turns are skipped without delaying or
+changing the Turn result.
 
 Because the input is the exact backend dispatch, it can contain identifiers in
 user/Agent-authored text and Avibe-injected time, source-Session, username, or
@@ -35,20 +38,22 @@ user-id attribution lines. Enabling Agent Memory discloses that those content
 bytes are retained locally and sent to the configured processing endpoints;
 they never become structural Memory ownership, scope, or provider paths.
 
-Each enable, Clear, and Reinitialize begins at the current completed-Turn high
-water. Turns completed before first enable, during a later disabled interval, or
-before a destructive reset are not backfilled. The owner's workdir/project
-bindings remain in Memory settings across Clear and Reinitialize; the reset
-runtime derives fresh opaque internal keys from them.
+Each enable, disable, Clear, and Reinitialize atomically records its completed-
+Turn high water and capture intent in the primary state transaction that orders
+Turn settlement. The Memory scan state projects that exact cutover. Turns
+completed before first enable, during a later disabled interval, or before a
+destructive reset are not backfilled. The owner's workdir/project bindings
+remain in Memory settings across Clear and Reinitialize; the reset runtime
+derives fresh opaque internal keys from them.
 
-Disable atomically snapshots the current terminal high water, closes the enable
-epoch, and closes new Agent provider claims. It then waits for any current
-bounded provider request to settle, stops the sidecar, and keeps only the local
-scanner in `disabling` state until every enabled-period Turn through the saved
-target is enqueued or durably skipped. No new provider write starts after worker
-quiescence. Crash recovery resumes that drain; drained rows remain pending
-without provider I/O until a later enable, which also skips the completed
-opt-out interval.
+Disable closes new Agent provider claims, then commits its primary capture
+cutover and projects that exact high water as the old epoch's drain target. It
+waits for any current bounded provider request to settle, stops the sidecar, and
+keeps only the local scanner in `disabling` state until every enabled-period Turn
+through the saved target is enqueued or durably skipped. No new provider write
+starts after worker quiescence. Crash recovery reuses the exact intent and
+resumes that drain; drained rows remain pending without provider I/O until a
+later enable, which also skips the completed opt-out interval.
 
 Adding, changing, or removing a workdir binding has its own committed terminal
 high-water cutover taken after the desired V2 config is persisted. The setting

--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -27,9 +27,17 @@ and Harness turns use the same admission rule. Failed, canceled, silent,
 legacy-Agent, oversized, malformed, callback, maintenance, and unbound turns are
 skipped without delaying or changing the Turn result.
 
+Each enable begins at the current completed-Turn high water. Turns completed
+before first enable or during a later disabled interval are not backfilled. The
+owner's workdir/project bindings remain in Memory settings across Clear and
+Reinitialize; the reset runtime derives fresh opaque internal keys from them.
+
 The existing Personal Memory root remains pinned to chat mode. Agent Memory has
 its own provider root, socket, lifecycle/health slot, scanner, and queue. An
 agent-track failure cannot alter user capture or Personal Memory processing.
+The Agent queue independently caps nonterminal work at 500 rows and requires at
+least 512 MiB free before admission; guarded turns are counted without retaining
+their text.
 
 Agent cases and skills are available only through explicit, scoped Agent Memory
 search/list operations in the CLI or owner Settings UI. Returned skill content
@@ -159,9 +167,10 @@ finish before starting another one.
 
 Before Reinitialize Memory, use **Clear Memory Data** when retained Memory data or the
 call-log database is corrupt. Clear Memory Data records a durable intent marker, then
-removes the Personal and Agent Memory queues, both owned provider roots, role-owned call
-logs, and pinned attachments through their idempotent deletion primitives. Clear is
-irreversible; it does not delete
+removes the Personal and Agent Memory queues, the owned Personal root and any
+existing owned Agent root, role-owned call logs, and pinned attachments through
+their idempotent deletion primitives. A never-created Agent root is a safe no-op.
+Clear is irreversible; it does not delete
 the `memory` or `state/memory` roots themselves, original Avibe chats, copies
 already sent to providers, or data outside those surfaces (including logs or
 user-created snapshots); it is not a secure wipe.

--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -23,9 +23,11 @@ Agent Memory is a separate, off-by-default track for completed Agent Turns. When
 the owner explicitly enables it and binds a source workdir to `default` or a
 named Memory project, Avibe asynchronously sends the exact Agent dispatch text
 and successful final result to a dedicated EverOS agent-mode root. Interactive
-and Harness turns use the same admission rule. Accepted-live-steer, failed,
-canceled, silent, legacy-Agent, oversized, malformed, callback, maintenance, and
-unbound turns are skipped without delaying or changing the Turn result.
+and Harness turns use the same admission rule and snapshot the final executing
+`agents.id` when the Turn starts; later Session routing cannot change its Memory
+partition. Accepted-live-steer, failed, canceled, silent, missing-agent-snapshot,
+oversized, malformed, callback, maintenance, and unbound turns are skipped
+without delaying or changing the Turn result.
 
 Because the input is the exact backend dispatch, it can contain identifiers in
 user/Agent-authored text and Avibe-injected time, source-Session, username, or
@@ -49,11 +51,17 @@ without provider I/O until a later enable, which also skips the completed
 opt-out interval.
 
 Adding, changing, or removing a workdir binding has its own committed terminal
-high-water cutover. Backlogged Turns use the project binding that was effective
-when they settled; a new project never captures pre-cutover work, and removal
-keeps its closed binding epoch until the scanner durably drains through the
-cutover. That already-settled backlog remains eligible for delivery under the
-old project; later-settling Turns do not.
+high-water cutover taken after the desired V2 config is persisted. The setting
+becomes sequence-effective when that high water and a recovery intent commit in
+one primary-state transaction; the Agent scanner pauses until the corresponding
+epoch is published, and the save succeeds only after publication. Backlogged
+Turns use the project binding that was effective when they settled; a new project
+never captures pre-cutover work, and removal keeps its closed binding epoch until
+the scanner durably drains through the cutover. That already-settled backlog
+remains eligible for delivery under the old project; later-settling Turns do not.
+Crash recovery uses a later conservative high water only when config committed
+before any intent; otherwise it reuses the exact recorded cutover. Turn
+settlement never waits for Memory projection work.
 
 The existing Personal Memory root remains pinned to chat mode. Agent Memory has
 its own provider root, socket, lifecycle/health slot, scanner, and queue. An

--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -56,6 +56,12 @@ destructive reset are not backfilled. The owner's workdir/project bindings
 remain in Memory settings across Clear and Reinitialize; the reset runtime
 derives fresh opaque internal keys from them.
 
+If the Agent role fails to start after enable commits, the desired enabled
+setting and exact recovery intent remain in degraded state, while dispatch
+snapshot admission and scanner/provider claims stay closed. **Retry/Restart**
+reuses that intent; explicit Disable may replace it through the same controller
+cutover. The Personal Memory failed-enable rollback behavior is unchanged.
+
 Disable closes new Agent provider claims, then commits its primary capture
 cutover and projects that exact high water as the old epoch's drain target. It
 waits for any current bounded provider request to settle, stops the sidecar, and
@@ -113,8 +119,11 @@ status reports a non-blocking per-Agent skill-count hint:
 8-10 is approaching the upstream prompt limit and more than 10 is the risk zone.
 A global incremental sampler limits one refresh to 32 Agent/project count reads
 with concurrency two; incomplete observations are shown as unknown or stale.
-A successful add/flush means the trajectory was processed, not that EverOS
-necessarily produced a case or skill.
+A terminal add that requires no flush, or a successful required flush, means the
+trajectory was processed, not that EverOS necessarily produced a case or skill.
+After Agent `/add` is confirmed, Avibe durably stores only its receipt and flush
+scope and immediately scrubs both trajectory texts before any required
+`/flush`; an unavailable flush therefore cannot retain the source payload.
 
 EverOS 1.2.3 may produce zero output through quality gates. Skill retirement is
 not implemented; sanitized skill-name collisions can overwrite a prior file;
@@ -223,7 +232,11 @@ finish before starting another one.
 3. **Rebuild index**: Use it after changing the Embedding endpoint or model,
    or to recover a pending rebuild. Confirming **Save and rebuild** saves the
    new settings before rebuilding the local vector index and preserves Markdown
-   memory. If rebuilding fails before settlement, the confirmed change remains
+   memory. When Agent Memory owns a nonempty second root, the same operation
+   fences and quiesces both roles and rebuilds each nonempty root without Clear;
+   neither role activates on the new vector identity until both converge. A
+   partial failure leaves both fenced for **Retry rebuild**. If rebuilding fails
+   before settlement, the confirmed change remains
    saved, the recovery intent and rebuild warning remain, and **Restart engine**
    stays unavailable. An Embedding endpoint or model correction changes the
    vector-space identity, so edit it and reconfirm **Save and rebuild**; do not

--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -23,14 +23,17 @@ Agent Memory is a separate, off-by-default track for completed Agent Turns. When
 the owner explicitly enables it and binds a source workdir to `default` or a
 named Memory project, Avibe asynchronously sends the exact post-transformation
 backend dispatch text and successful final result to a dedicated EverOS
-agent-mode root. The Turn durably records that final text before native start.
-Interactive and Harness turns use the same admission rule and
-snapshot the final executing `agents.id` when the Turn starts; later Session
-routing or Agent hard deletion cannot change its Memory partition. Delivery
-batching keeps ordinary Harness work separate from callbacks. Accepted-live-
-steer, failed, canceled, silent, missing-snapshot, oversized, malformed,
-callback, maintenance, and unbound turns are skipped without delaying or
-changing the Turn result.
+agent-mode root. A candidate Turn that passes the enabled-epoch and storage
+guards durably records that final text before native start.
+The shared durable Turn owner covers Workbench, Slack, Discord, Telegram,
+Feishu/Lark, WeChat, and Harness executions under the same admission rule and
+snapshots the final executing `agents.id` when the Turn starts; later Session
+routing or Agent hard deletion cannot change its Memory partition. Platform
+transcript mirrors are not capture sources. Delivery batching keeps ordinary
+Harness work separate from callbacks. Accepted-live-steer, failed, canceled,
+silent, missing/guarded-snapshot, epoch-crossing, oversized, malformed, callback,
+maintenance, and unbound turns are skipped without delaying or changing the
+Turn result.
 
 Because the input is the exact backend dispatch, it can contain identifiers in
 user/Agent-authored text and Avibe-injected time, source-Session, username, or
@@ -38,13 +41,16 @@ user-id attribution lines. Enabling Agent Memory discloses that those content
 bytes are retained locally and sent to the configured processing endpoints;
 they never become structural Memory ownership, scope, or provider paths.
 
-Each enable or disable first atomically records a prepared completed-Turn high
-water and capture intent in the primary state transaction that orders Turn
-settlement, then replaces V2 config. Recovery commits that exact boundary only
-when config has the desired digest, or cancels it when the prior digest remains;
-it never advances the boundary to restart time. Clear and Reinitialize record
-the same cutover before destructive work. The Memory scan state projects that
-exact cutover. Turns
+The Settings UI sends Agent-track changes to one controller IPC operation; it
+does not save that config block itself. Under the same controller lifecycle lock
+used by scanner, Clear, and reset, each enable or disable first atomically records
+a prepared completed-Turn high water and capture intent in the primary state
+transaction that orders Turn settlement, then replaces V2 config. Recovery
+commits that exact boundary only when config has the desired digest, or cancels
+it when the prior digest remains; it never advances the boundary to restart
+time. Clear and Reinitialize record their capture high water after destructive
+deletion completes and before scan-state recreation. The Memory scan state
+projects that exact cutover. Turns
 completed before first enable, during a later disabled interval, or before a
 destructive reset are not backfilled. The owner's workdir/project bindings
 remain in Memory settings across Clear and Reinitialize; the reset runtime
@@ -86,13 +92,21 @@ The Agent queue independently caps nonterminal work at 500 rows and requires at
 least 512 MiB free before admission; guarded turns are counted without retaining
 their text. Scrubbed terminal tombstones retain at most 90 days and the newest
 100,000 rows.
+Final-dispatch snapshots are admitted only while a committed capture epoch is
+enabled, at most 256 KiB per Turn and 128 MiB total in primary state. A Turn must
+settle in that same epoch. Disabled/transitioning, oversized, and over-budget
+dispatches retain only an omission reason and still execute normally. Admitted
+primary snapshots are scrubbed after durable enqueue/skip, disabled settlement,
+abandonment, Clear, or Reinitialize.
 
 Agent cases and skills are available only through explicit, scoped Agent Memory
 search/list operations in the CLI or owner Settings UI. CLI ownership comes from
 the trusted current Turn's immutable executing-Agent snapshot, not mutable
 Session routing. A read-only per-Agent project catalog keeps already-enqueued or
 later-delivered data and existing provider data retrievable after its last
-workdir binding is removed. Returned skill content is untrusted text: Avibe does
+workdir binding is removed. If the Agent is hard-deleted, owner Settings retains
+an opaque read-only `Deleted Agent` selector; CLI retrieval remains bound to the
+current executing Turn. Returned skill content is untrusted text: Avibe does
 not install or execute it and never injects it into an Agent prompt. Each
 displayed skill includes its last-updated timestamp and maturity score. Memory
 status reports a non-blocking per-Agent skill-count hint:

--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -49,14 +49,15 @@ visible when either role is enabled or recovery is pending, and shared
 credentials can be cleared only when both roles will be disabled and no recovery
 intent needs them. Under the same cross-process controller lifecycle/config lock
 used by scanner, Clear, and reset, each Agent enable or disable first atomically
-records
-a prepared completed-Turn high water and capture intent in the primary state
+records a prepared completed-Turn high water and capture intent in primary state
 transaction that orders Turn settlement, then replaces V2 config. Recovery
-commits that exact boundary only when config has the desired digest, or cancels
-it when the prior digest remains; it never advances the boundary to restart
-time. Clear and Reinitialize record their capture high water after destructive
-deletion completes and before scan-state recreation. The Memory scan state
-projects that exact cutover. Turns
+requires the intent's exact desired revision/digest pair to commit that boundary,
+or its prior pair to cancel it; a third or ABA state degrades closed, and recovery
+never advances the boundary to restart time. Clear and Reinitialize record their
+capture high water after destructive deletion completes and before scan-state
+recreation. In that same primary transaction they scrub both terminal and
+in-flight dispatch snapshots, release their budget, and mark them reset-crossing
+before reporting success. The Memory scan state projects that exact cutover. Turns
 completed before first enable, during a later disabled interval, or before a
 destructive reset are not backfilled. The owner's workdir/project bindings
 remain in Memory settings across Clear and Reinitialize; the reset runtime
@@ -78,11 +79,12 @@ resumes that drain; drained rows remain pending without provider I/O until a
 later enable, which also skips the completed opt-out interval.
 
 Adding, changing, or removing a workdir binding first records a prepared
-terminal high-water cutover and prior/desired config digests in primary state,
+terminal high-water cutover and prior/desired config revision/digest pairs in
+primary state,
 then replaces V2 config. The Agent scanner pauses until the corresponding epoch
 is published, and the save succeeds only after publication. A failed config
 write cancels the prepared cutover; recovery commits its original high water
-only when the desired digest persisted. Backlogged
+only when the desired revision/digest pair persisted. Backlogged
 Turns use the project binding that was effective when they settled; a new project
 never captures pre-cutover work, and removal keeps its closed binding epoch until
 the scanner durably drains through the cutover. That already-settled backlog
@@ -111,14 +113,21 @@ least 512 MiB free before admission; guarded turns are counted without retaining
 their text. Scrubbed terminal tombstones retain at most 90 days and the newest
 100,000 rows.
 Final-dispatch snapshots are admitted only while a committed capture epoch is
-enabled, at most 256 KiB per Turn and 128 MiB total in primary state. A Turn must
-settle in that same epoch. The final native backend request must be text-only;
+enabled and the source workdir has one committed explicit project binding, at
+most 256 KiB per Turn and 128 MiB total in primary state. The Turn persists only
+that binding's opaque key. The start gate checks it against a revision-matched
+controller projection while binding cutovers are fenced; it never reads the
+Memory store or stores a workdir/project. The Turn must settle in the same
+capture epoch, and its project is resolved from the epoch effective at
+settlement. A Turn started unbound is never admitted retroactively. The final
+native backend request must be text-only;
 any Turn with a separate image, attachment, audio, file, or other out-of-band
 input is excluded without copying its path, metadata, or bytes. Disabled,
-transitioning, attachment-bearing, oversized, and over-budget dispatches retain
-only a closed shape/omission reason and still execute normally. Admitted primary
-snapshots are scrubbed after durable enqueue/skip, disabled settlement,
-abandonment, Clear, or Reinitialize.
+transitioning, unbound, attachment-bearing, oversized, and over-budget dispatches
+retain only a closed shape/omission reason, consume no snapshot budget, and still
+execute normally. Admitted primary snapshots are scrubbed after durable
+enqueue/skip, disabled settlement, abandonment, Clear, or Reinitialize;
+destructive operations include snapshots of Turns still in flight.
 
 Agent cases and skills are available only through explicit, scoped Agent Memory
 search/list operations in the CLI or owner Settings UI. CLI ownership comes from
@@ -277,8 +286,9 @@ already sent to providers, or data outside those surfaces (including logs or
 user-created snapshots); it is not a secure wipe.
 
 Clear Memory Data is also the explicit discard path for a timed-out or otherwise
-unknown provider add. It removes the retained `manual_required` queue evidence
-and pinned attachment bundle, clears that session's local fence, and never
+unknown Personal Memory provider add. It removes the retained `manual_required`
+queue evidence and pinned attachment bundle, clears that session's local fence,
+and never
 replays the ambiguous add. Because the provider outcome is unknown, Clear cannot
 remove a copy that may already have reached the provider.
 

--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -31,9 +31,9 @@ snapshots the final executing `agents.id` when the Turn starts; later Session
 routing or Agent hard deletion cannot change its Memory partition. Platform
 transcript mirrors are not capture sources. Delivery batching keeps ordinary
 Harness work separate from callbacks. Accepted-live-steer, failed, canceled,
-silent, missing/guarded-snapshot, epoch-crossing, oversized, malformed, callback,
-maintenance, and unbound turns are skipped without delaying or changing the
-Turn result.
+silent, missing/guarded-snapshot, epoch-crossing, out-of-band attachment,
+oversized, malformed, callback, maintenance, and unbound turns are skipped
+without delaying or changing the Turn result.
 
 Because the input is the exact backend dispatch, it can contain identifiers in
 user/Agent-authored text and Avibe-injected time, source-Session, username, or
@@ -41,9 +41,15 @@ user-id attribution lines. Enabling Agent Memory discloses that those content
 bytes are retained locally and sent to the configured processing endpoints;
 they never become structural Memory ownership, scope, or provider paths.
 
-The Settings UI sends Agent-track changes to one controller IPC operation; it
-does not save that config block itself. Under the same controller lifecycle lock
-used by scanner, Clear, and reset, each enable or disable first atomically records
+Every writer of Personal, Agent, endpoint, credential, or repair/rebuild Memory
+config submits a field-scoped revision-checked patch through one controller IPC
+transaction; UI, compatibility, and maintenance processes do not persist any
+Memory config block directly. The Memory navigation and recovery controls remain
+visible when either role is enabled or recovery is pending, and shared
+credentials can be cleared only when both roles will be disabled and no recovery
+intent needs them. Under the same cross-process controller lifecycle/config lock
+used by scanner, Clear, and reset, each Agent enable or disable first atomically
+records
 a prepared completed-Turn high water and capture intent in the primary state
 transaction that orders Turn settlement, then replaces V2 config. Recovery
 commits that exact boundary only when config has the desired digest, or cancels
@@ -94,15 +100,24 @@ The roles also share remote processing credentials: Agent load can consume the
 endpoint account's concurrency, rate, or quota and throttle Personal requests.
 This external resource coupling cannot corrupt or merge the two local tracks;
 Agent requests remain bounded and back off when throttled.
+Both roots and `memory.sqlite` share the effective-home volume. Agent-root or
+index growth after provider acceptance can therefore exhaust local capacity and
+make later Personal or Agent writes fail even though their paths and state are
+disjoint. Status reports free space and per-role provider use, and new Agent
+claims pause below the reserve; this is backpressure and observability, not a
+local-disk quota or capacity-isolation guarantee.
 The Agent queue independently caps nonterminal work at 500 rows and requires at
 least 512 MiB free before admission; guarded turns are counted without retaining
 their text. Scrubbed terminal tombstones retain at most 90 days and the newest
 100,000 rows.
 Final-dispatch snapshots are admitted only while a committed capture epoch is
 enabled, at most 256 KiB per Turn and 128 MiB total in primary state. A Turn must
-settle in that same epoch. Disabled/transitioning, oversized, and over-budget
-dispatches retain only an omission reason and still execute normally. Admitted
-primary snapshots are scrubbed after durable enqueue/skip, disabled settlement,
+settle in that same epoch. The final native backend request must be text-only;
+any Turn with a separate image, attachment, audio, file, or other out-of-band
+input is excluded without copying its path, metadata, or bytes. Disabled,
+transitioning, attachment-bearing, oversized, and over-budget dispatches retain
+only a closed shape/omission reason and still execute normally. Admitted primary
+snapshots are scrubbed after durable enqueue/skip, disabled settlement,
 abandonment, Clear, or Reinitialize.
 
 Agent cases and skills are available only through explicit, scoped Agent Memory

--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -64,8 +64,11 @@ restart without reading `memory.sqlite` or inventing an epoch. The Memory scan
 state projects that exact cutover. Turns
 completed before first enable, during a later disabled interval, or before a
 destructive reset are not backfilled. The owner's workdir/project bindings
-remain in Memory settings across Clear and Reinitialize; the reset runtime
-derives fresh opaque internal keys from them.
+remain in Memory settings across Clear and Reinitialize. Clear reconstructs open
+project epochs for the preserved current opaque binding keys/generations after
+its high water and before reopening admission. Reinitialize derives fresh opaque
+keys/generations from the new scope key and likewise publishes their epochs
+before an enabled scanner starts.
 
 If the Agent role fails to start after enable commits, the desired enabled
 setting and exact recovery intent remain in degraded state, while dispatch
@@ -134,7 +137,10 @@ any Turn with a separate image, attachment, audio, file, or other out-of-band
 input is excluded without copying its path, metadata, or bytes. Disabled,
 transitioning, unbound, attachment-bearing, oversized, and over-budget dispatches
 retain only a closed shape/omission reason, consume no snapshot budget, and still
-execute normally. Admitted primary snapshots are scrubbed after durable
+execute normally. A snapshot transaction failure rolls back the optional Memory
+payload and reservation, records only a best-effort sanitized diagnostic, and
+still dispatches the finalized in-memory request; that Turn is not a Memory
+candidate. Admitted primary snapshots are scrubbed after durable
 enqueue/skip, disabled settlement, abandonment, Clear, or Reinitialize;
 destructive operations include snapshots of Turns still in flight.
 
@@ -143,7 +149,10 @@ search/list operations in the CLI or owner Settings UI. The CLI carries only its
 session-stable locator. Immediately before each recognized command, the backend
 tool callback resolves exactly one native-started nonterminal Turn and injects a
 30-second, one-use controller capability bound to that Turn, its immutable
-executing Agent, and the normalized request. Cached Claude clients use per-call
+executing Agent, its immutable owner-Workbench authorization, and the normalized
+request. Only trusted local or authenticated remote owner Workbench ingress can
+receive that authorization; IM, shared-scope, Harness, ambiguous, and
+pre-migration Turns fail closed. Cached Claude clients use per-call
 `updated_input`, not spawn-time environment. Missing, stale, reused, or ambiguous
 context fails closed with no static-Session fallback. Mutable Session routing is
 never identity. A read-only per-Agent project catalog keeps already-enqueued or
@@ -294,6 +303,9 @@ call-log database is corrupt. Clear Memory Data records a durable intent marker,
 removes the Personal and Agent Memory queues, each existing owned role root,
 role-owned call logs, and pinned attachments through their idempotent deletion
 primitives. A never-created, fully absent Personal or Agent root is a safe no-op.
+Before Agent snapshot admission reopens, Clear reconstructs every binding
+preserved in V2 config as an open project epoch effective after the fixed Clear
+high water; it cannot leave the primary admission set without matching epochs.
 Clear is irreversible; it does not delete
 the `memory` or `state/memory` roots themselves, original Avibe chats, copies
 already sent to providers, or data outside those surfaces (including logs or

--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -27,14 +27,18 @@ and Harness turns use the same admission rule. Failed, canceled, silent,
 legacy-Agent, oversized, malformed, callback, maintenance, and unbound turns are
 skipped without delaying or changing the Turn result.
 
-Each enable begins at the current completed-Turn high water. Turns completed
-before first enable or during a later disabled interval are not backfilled. The
-owner's workdir/project bindings remain in Memory settings across Clear and
-Reinitialize; the reset runtime derives fresh opaque internal keys from them.
+Each enable, Clear, and Reinitialize begins at the current completed-Turn high
+water. Turns completed before first enable, during a later disabled interval, or
+before a destructive reset are not backfilled. The owner's workdir/project
+bindings remain in Memory settings across Clear and Reinitialize; the reset
+runtime derives fresh opaque internal keys from them.
 
 The existing Personal Memory root remains pinned to chat mode. Agent Memory has
 its own provider root, socket, lifecycle/health slot, scanner, and queue. An
-agent-track failure cannot alter user capture or Personal Memory processing.
+ordinary agent-track scanning, processing, retrieval, or reconcile failure
+cannot alter user capture or Personal Memory processing. Explicit Clear,
+Reinitialize, and embedding-identity rebuild operations intentionally share a
+maintenance fence and can pause both roles until the operation converges.
 The Agent queue independently caps nonterminal work at 500 rows and requires at
 least 512 MiB free before admission; guarded turns are counted without retaining
 their text.
@@ -254,9 +258,12 @@ is accepted. Queue payloads store only bundle-relative metadata. Confirmed
 delivery or deterministic rejection releases the bundle; pending and
 `manual_required` captures retain it for recovery.
 
-This implementation initializes a clean Avibe-owned schema; migration or
-preservation of earlier Memory databases is intentionally unsupported while the
-feature remains unused.
+The Agent track raises the Avibe-owned Memory store from released schema v3 to
+schema v4 through one transactional migration. Existing v3 rows, tables,
+indexes, values, and project-catalog entries remain unchanged, and fixtures
+cover that shipped shape. A malformed optional Agent-track section degrades by
+disabling that track with a sanitized warning; it never makes startup fail or
+resets Personal Memory state.
 
 An incomplete, malformed, overlong-receipt, timed-out, or response-disconnected
 provider add is terminal for automatic delivery: the row is retained and its

--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -39,13 +39,21 @@ before a destructive reset are not backfilled. The owner's workdir/project
 bindings remain in Memory settings across Clear and Reinitialize; the reset
 runtime derives fresh opaque internal keys from them.
 
-Disable closes new Agent provider claims, waits for any current bounded provider
-request to settle, stops the sidecar, snapshots the current terminal high water,
-and keeps only the local scanner in `disabling` state until every enabled-period
-Turn through that target is enqueued or durably skipped. No new provider write
-starts after worker quiescence. Crash recovery resumes that drain; drained rows
-remain pending without provider I/O until a later enable, which also skips the
-completed opt-out interval.
+Disable atomically snapshots the current terminal high water, closes the enable
+epoch, and closes new Agent provider claims. It then waits for any current
+bounded provider request to settle, stops the sidecar, and keeps only the local
+scanner in `disabling` state until every enabled-period Turn through the saved
+target is enqueued or durably skipped. No new provider write starts after worker
+quiescence. Crash recovery resumes that drain; drained rows remain pending
+without provider I/O until a later enable, which also skips the completed
+opt-out interval.
+
+Adding, changing, or removing a workdir binding has its own committed terminal
+high-water cutover. Backlogged Turns use the project binding that was effective
+when they settled; a new project never captures pre-cutover work, and removal
+keeps its closed binding epoch until the scanner durably drains through the
+cutover. That already-settled backlog remains eligible for delivery under the
+old project; later-settling Turns do not.
 
 The existing Personal Memory root remains pinned to chat mode. Agent Memory has
 its own provider root, socket, lifecycle/health slot, scanner, and queue. An
@@ -193,9 +201,9 @@ finish before starting another one.
 
 Before Reinitialize Memory, use **Clear Memory Data** when retained Memory data or the
 call-log database is corrupt. Clear Memory Data records a durable intent marker, then
-removes the Personal and Agent Memory queues, the owned Personal root and any
-existing owned Agent root, role-owned call logs, and pinned attachments through
-their idempotent deletion primitives. A never-created Agent root is a safe no-op.
+removes the Personal and Agent Memory queues, each existing owned role root,
+role-owned call logs, and pinned attachments through their idempotent deletion
+primitives. A never-created, fully absent Personal or Agent root is a safe no-op.
 Clear is irreversible; it does not delete
 the `memory` or `state/memory` roots themselves, original Avibe chats, copies
 already sent to providers, or data outside those surfaces (including logs or

--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -42,14 +42,19 @@ their text.
 Agent cases and skills are available only through explicit, scoped Agent Memory
 search/list operations in the CLI or owner Settings UI. Returned skill content
 is untrusted text: Avibe does not install or execute it and never injects it into
-an Agent prompt. A successful add/flush means the trajectory was processed, not
-that EverOS necessarily produced a case or skill.
+an Agent prompt. Each displayed skill includes its last-updated timestamp and
+maturity score. Memory status reports a non-blocking per-Agent skill-count hint:
+8-10 is approaching the upstream prompt limit and more than 10 is the risk zone.
+A successful add/flush means the trajectory was processed, not that EverOS
+necessarily produced a case or skill.
 
 EverOS 1.2.3 may produce zero output through quality gates. Skill retirement is
 not implemented; sanitized skill-name collisions can overwrite a prior file;
 and clusters above ten indexed skills retain an upstream stale-index clobber
 risk. The track is isolated so these accepted limitations cannot corrupt
-Personal Memory. See
+Personal Memory. Freshness/maturity metadata and the count hint help the owner
+judge possible staleness but do not repair, rename, retire, or rewrite skills.
+See
 [`memory-agent-track-1424.md`](plans/memory-agent-track-1424.md) for the complete
 contract.
 

--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -23,15 +23,29 @@ Agent Memory is a separate, off-by-default track for completed Agent Turns. When
 the owner explicitly enables it and binds a source workdir to `default` or a
 named Memory project, Avibe asynchronously sends the exact Agent dispatch text
 and successful final result to a dedicated EverOS agent-mode root. Interactive
-and Harness turns use the same admission rule. Failed, canceled, silent,
-legacy-Agent, oversized, malformed, callback, maintenance, and unbound turns are
-skipped without delaying or changing the Turn result.
+and Harness turns use the same admission rule. Accepted-live-steer, failed,
+canceled, silent, legacy-Agent, oversized, malformed, callback, maintenance, and
+unbound turns are skipped without delaying or changing the Turn result.
+
+Because the input is the exact backend dispatch, it can contain identifiers in
+user/Agent-authored text and Avibe-injected time, source-Session, username, or
+user-id attribution lines. Enabling Agent Memory discloses that those content
+bytes are retained locally and sent to the configured processing endpoints;
+they never become structural Memory ownership, scope, or provider paths.
 
 Each enable, Clear, and Reinitialize begins at the current completed-Turn high
 water. Turns completed before first enable, during a later disabled interval, or
 before a destructive reset are not backfilled. The owner's workdir/project
 bindings remain in Memory settings across Clear and Reinitialize; the reset
 runtime derives fresh opaque internal keys from them.
+
+Disable closes new Agent provider claims, waits for any current bounded provider
+request to settle, stops the sidecar, snapshots the current terminal high water,
+and keeps only the local scanner in `disabling` state until every enabled-period
+Turn through that target is enqueued or durably skipped. No new provider write
+starts after worker quiescence. Crash recovery resumes that drain; drained rows
+remain pending without provider I/O until a later enable, which also skips the
+completed opt-out interval.
 
 The existing Personal Memory root remains pinned to chat mode. Agent Memory has
 its own provider root, socket, lifecycle/health slot, scanner, and queue. An
@@ -41,7 +55,8 @@ Reinitialize, and embedding-identity rebuild operations intentionally share a
 maintenance fence and can pause both roles until the operation converges.
 The Agent queue independently caps nonterminal work at 500 rows and requires at
 least 512 MiB free before admission; guarded turns are counted without retaining
-their text.
+their text. Scrubbed terminal tombstones retain at most 90 days and the newest
+100,000 rows.
 
 Agent cases and skills are available only through explicit, scoped Agent Memory
 search/list operations in the CLI or owner Settings UI. Returned skill content
@@ -49,6 +64,8 @@ is untrusted text: Avibe does not install or execute it and never injects it int
 an Agent prompt. Each displayed skill includes its last-updated timestamp and
 maturity score. Memory status reports a non-blocking per-Agent skill-count hint:
 8-10 is approaching the upstream prompt limit and more than 10 is the risk zone.
+A global incremental sampler limits one refresh to 32 Agent/project count reads
+with concurrency two; incomplete observations are shown as unknown or stale.
 A successful add/flush means the trajectory was processed, not that EverOS
 necessarily produced a case or skill.
 

--- a/docs/plans/memory-agent-track-1424.md
+++ b/docs/plans/memory-agent-track-1424.md
@@ -52,11 +52,12 @@ Personal Memory admission, prompt, provider root, queue, or retrieval semantics.
    reports them but does not patch EverOS or file an upstream issue. Retrieval
    exposes skill freshness/maturity metadata, and status adds a conservative
    per-Agent skill-count hint; neither mitigation mutates provider state.
-9. Every settings capture/binding cutover first records its terminal-settlement
+9. Every Memory config capture/binding cutover first records its terminal-settlement
    high water and prepared recovery intent atomically in the primary state
    writer transaction, before the V2 config replacement. Recovery commits that
    exact boundary only when the persisted config has the intent's desired
-   digest, or cancels it when the prior digest remains. Clear and factory reset
+   revision/digest pair, or cancels it when the prior pair remains. Clear and
+   factory reset
    retain their documented primary-state destructive-recovery cutover. The
    Memory scan state is an idempotent projection of those records. There is no
    historical, disabled-period, or post-reset replay in v1; only turns admitted
@@ -204,8 +205,8 @@ these invariants hold:
   rename/disable/archive/hard-delete does not rewrite the snapshot;
 - `source_class` is exactly `interactive` or `harness_request`, never `callback`,
   `maintenance`, `agent_callback`, or missing; and
-- the session workdir resolves through an explicit opaque binding to exactly one
-  new-style Memory project.
+- the immutable start-snapshot `binding_key` resolves at the Turn's terminal
+  sequence through exactly one opaque epoch to one new-style Memory project.
 
 Every Delivery snapshots one admission-relevant source class from durable
 provenance. FIFO/scheduled compatibility keys include that class, and Turn claim
@@ -218,18 +219,28 @@ After scheduled attribution, transcription, attachment/file formatting, and all
 other input transformations finish, the shared start boundary classifies the
 final native request as the closed `text_only | out_of_band_attachment`
 `backend_input_shape` and checks the controller-projected primary capture epoch
-without opening the Memory store. Only `text_only` requests are candidates. If
-that epoch is committed enabled, the exact UTF-8 text is at most 256 KiB, and the
-global primary snapshot budget remains below 128 MiB, one primary transaction
-reserves its byte count and persists `backend_dispatch_text`, digest, shape, and
-capture epoch before invoking the native adapter. The adapter must send exactly
-that stored text with no additional native input; an automatic start retry
-reuses the snapshot instead of re-running a text-changing transform.
+without opening the Memory store. The same primary transaction derives the
+source workdir's opaque `binding_key` and requires it in the controller-projected
+primary admission set at the current committed Memory-config revision, with no
+binding cutover intent. That set contains only opaque keys, never workdirs or
+projects; the controller replaces it while the intent fence is closed and opens
+snapshot admission only after V2 config and the projection converge. Only bound
+`text_only` requests are candidates. If that epoch is committed enabled, the
+exact UTF-8 text is at most 256 KiB, and the global primary snapshot budget
+remains below 128 MiB, the transaction reserves its byte count and persists
+`backend_dispatch_text`, digest, shape, opaque binding key, and capture epoch
+before invoking the native adapter. The adapter must send exactly that stored
+text with no additional native input; an automatic start retry reuses the
+snapshot instead of re-running a text-changing transform. The scanner later
+resolves that immutable key against the project epoch effective at terminal
+settlement; a reassignment/removal may therefore change or remove eligibility,
+but a Turn started before its first binding is never admitted retroactively.
 
-Disabled/transitioning epochs, out-of-band attachment input, oversized text, or
-an exhausted snapshot budget record only a closed omission reason, input-shape
-marker, and small counter; they never retain text, attachment paths/bytes, or
-block native dispatch. A successful config transition cannot retroactively
+Disabled/transitioning epochs, missing/transitioning bindings, out-of-band
+attachment input, oversized text, or an exhausted snapshot budget record only a
+closed omission reason, input-shape marker, and small counter; they never retain
+text, attachment paths/bytes, or consume the snapshot budget or block native
+dispatch. A successful config transition cannot retroactively
 admit an in-flight Turn that omitted its snapshot. Persistence failure for a
 snapshot that was admitted still fails closed before native start, because the
 candidate could otherwise diverge from the adapter input. Backend-native
@@ -460,12 +471,15 @@ primary Avibe state schema:
 - `backend_input_shape TEXT`, constrained on new writes to `text_only` or
   `out_of_band_attachment` and derived from the final native request rather
   than transport transcript metadata;
+- `backend_dispatch_binding_key TEXT`, the opaque start-snapshot key for the
+  committed explicit source-workdir binding; it is present only with an admitted
+  dispatch and contains neither workdir nor project id;
 - `backend_dispatch_text TEXT` and `backend_dispatch_sha256 TEXT`, the exact
   bounded final backend-facing input and digest;
 - `backend_dispatch_capture_epoch INTEGER` and
   `backend_dispatch_omission_reason TEXT`, the admitted epoch or a closed
-  `disabled | transition | out_of_band_attachment | oversized | budget` reason,
-  never both; and
+  `disabled | transition | unbound | out_of_band_attachment | oversized |
+  budget | destructive_reset` reason, never both; and
 - `terminal_sequence INTEGER`, with a unique partial index.
 
 The shared `MessageHandler`/dispatch boundary creates the same durable Delivery
@@ -497,15 +511,16 @@ fail-closed for Agent Memory but do not block ordinary execution.
 The primary schema also keeps a singleton snapshot-byte reservation capped at
 128 MiB. Immediately before the first native start call, after every
 shared/backend input transformation, a primary state transaction classifies the
-complete native input shape, checks the committed capture epoch and per-row 256
-KiB bound, reserves bytes, and compares-and-sets the admitted
-text/digest/shape/epoch. The adapter receives that exact stored text without
-additional native input. A retry must reuse it and a conflicting second value
-fails closed; Memory never derives candidate input from the earlier raw
+complete native input shape, checks the committed capture epoch, resolves one
+committed explicit opaque binding key, enforces the per-row 256 KiB bound,
+reserves bytes, and compares-and-sets the admitted
+text/digest/shape/binding-key/epoch. The adapter receives that exact stored text
+without additional native input. A retry must reuse it and a conflicting second
+value fails closed; Memory never derives candidate input from the earlier raw
 `dispatch_text`. When no snapshot is admitted, the same transaction writes only
 the closed shape/omission reason and the adapter proceeds with its in-memory
-native input. Out-of-band attachment metadata and bytes are never copied into
-the Memory source schema.
+native input. Unbound content and out-of-band attachment metadata/bytes are
+never copied into the Memory source schema or charged to its byte reservation.
 Startup and periodic primary-state maintenance recompute the reservation from
 the UTF-8 byte lengths of actual nonempty snapshots before admitting more, so a
 crash cannot leak budget.
@@ -525,17 +540,41 @@ For an eligible terminal Turn, the scanner clears the primary snapshot and
 releases the reservation after its enqueue, duplicate, guarded decline, or
 closed skip is durable. A crash between the Memory-store decision and that
 cleanup is repaired idempotently by comparing terminal sequence with the durable
-scanner cursor. Abandoned-Turn recovery uses the same cleanup. Clear and factory
-reset bulk-scrub every terminal snapshot through their post-deletion high water
-before scan state is recreated. Thus the primary duplicate is bounded while
-live and does not survive final disposition or destructive reset.
+scanner cursor. Abandoned-Turn recovery uses the same cleanup. Clear and
+Reinitialize/factory reset first close new dispatch snapshot admission. After
+destructive deletion, the same serialized primary transaction that records the
+new epoch and terminal high water bulk-scrubs every admitted snapshot, including
+nonterminal/in-flight Turns without a `terminal_sequence`, releases their byte
+reservations, and replaces their admitted epoch/key with the closed
+`destructive_reset` omission reason. Turn settlement cannot interleave with that
+transaction; a later settlement is therefore epoch-crossing and ineligible.
+The destructive operation cannot report success or recreate scan state before
+this scrub commits. Thus the primary duplicate is bounded while live and does
+not survive final disposition or destructive reset, even when native execution
+remains in flight.
 
 The primary state schema also adds bounded singleton
 `memory_agent_capture_cutover` and `memory_agent_binding_cutover` recovery
-records used below. Each contains only its kind, prior/desired config digests,
-epoch, terminal high water, closed `prepared | committed` phase, state, and
-timestamps; normalized workdirs and project ids remain in V2 config, while
-opaque epochs remain in the Memory store.
+records used below. Each contains its kind, prior/desired Agent-block config
+digests, `prior_memory_config_revision`, `desired_memory_config_revision`,
+terminal high water, closed `prepared | committed` phase, and timestamps. The
+capture record also stores its epoch and desired state. The binding record stores
+no normalized workdir/project payload; those remain in V2 config, while opaque
+epochs remain in the Memory store. V2 config persists one monotonic
+`memory.revision` incremented exactly once by each successful controller Memory
+mutation. Recovery requires both revision and digest to match the durable prior
+or desired pair, so an ABA edit cannot masquerade as either state. A released
+config without the internal revision loads as revision `0`; migration preserves
+all other values, and the first successful controller mutation writes `1`.
+
+The primary schema also adds
+`memory_agent_admission_bindings(binding_key, memory_config_revision)` as the
+content-free current binding set used only by the dispatch gate. A binding
+cutover intent fences reads as ineligible, then the controller atomically
+replaces this opaque set and promotes the intent after V2 config persistence.
+Recovery rebuilds it only from an exact desired revision/digest pair. It stores
+neither project ids nor normalized workdirs and is never the scanner's historical
+project authority.
 
 ### Agent trajectory outbox
 
@@ -631,8 +670,8 @@ terminal high water `H` and insert a prepared singleton
 digests, whole-config revisions, and `H`. Terminal settlement cannot interleave
 between that read and intent commit. The scanner is then fenced, V2 config is
 atomically replaced, and the intent is promoted to committed; terminal
-settlement performs no Memory/config
-I/O and never waits for projection work. The UI does not write these bindings
+settlement performs no Memory/config I/O and never waits for projection work.
+The UI does not write these bindings
 before contacting the controller.
 
 When one Settings save changes both `enabled` and bindings, that same primary
@@ -649,18 +688,19 @@ Settings save reports success only after projection converges. A Turn at or
 below `H` uses the old mapping; a later Turn uses the new mapping after a
 successful save, or the old mapping after a failed save cancels the intent.
 
-If config persistence fails, the prior digest cancels the prepared intent and
-leaves the projection unchanged. After a crash, the prior digest cancels it, the
-desired digest promotes it and reuses the exact original `H`, and any third
-digest leaves only Agent Memory fenced and degraded. If projection already
-committed, matching digests make intent cleanup idempotent. Recovery never
-creates a cutover at restart time. A crash therefore cannot backdate the new
-binding, extend a disabled epoch, or block the Agent hot path.
+If config persistence fails, the prior revision/digest pair cancels the prepared
+intent and leaves the projection unchanged. After a crash, the prior pair
+cancels it, the desired pair promotes it and reuses the exact original `H`, and
+any third or ABA state leaves only Agent Memory fenced and degraded. If
+projection already committed, matching revisions and digests make intent cleanup
+idempotent. Recovery never creates a cutover at restart time. A crash therefore
+cannot backdate the new binding, extend a disabled epoch, or block the Agent hot
+path.
 
 An added mapping is effective only for `terminal_sequence > H`. Reassignment
 closes the old epoch through `H` and opens the new project after `H`; removal
-only closes the old epoch through `H`. The scanner resolves each source against
-the unique epoch satisfying
+only closes the old epoch through `H`. The scanner resolves each source's
+immutable start-snapshot binding key against the unique epoch satisfying
 `effective_after_sequence < terminal_sequence <= effective_through_sequence`,
 with a `NULL` through-sequence meaning open. It therefore drains backlog through
 the old project without admitting opt-in or reassignment history to the new
@@ -786,17 +826,17 @@ stable ids:
 
 | ID | Invariant |
 |---|---|
-| `MEMORY-AGENT-001` | The absent/default config leaves the second root, scanner, and worker off; every Personal/Agent/endpoint Memory config writer uses one controller transaction with revision conflict detection through cutover cleanup; Agent-only enablement keeps navigation/recovery visible and forbids shared-credential clearing; a failed Agent-role start retains a fenced retryable intent without snapshot admission; post-deletion reset high waters do not drift on recovery; and Clear accepts either never-created role as absent. |
+| `MEMORY-AGENT-001` | The absent/default config leaves the second root, scanner, and worker off; every Personal/Agent/endpoint Memory config writer uses one controller transaction with monotonic revision/digest conflict detection through cutover cleanup; Agent-only enablement keeps navigation/recovery visible and forbids shared-credential clearing; a failed Agent-role start retains a fenced retryable intent without snapshot admission; destructive reset atomically scrubs terminal and in-flight snapshots at its fixed high water; and Clear accepts either never-created role as absent. |
 | `MEMORY-AGENT-002` | Every semantically eligible non-steered completed Workbench, Slack, Discord, Telegram, Feishu/Lark, WeChat, or Harness Turn not durably declined by a specified snapshot/queue/disk guard is represented once by its exact post-transformation backend-dispatch/result pair. |
-| `MEMORY-AGENT-003` | Admission excludes every terminal shape that does not satisfy the completed-result invariant; source-class batching separates callbacks, accepted live steers are excluded, and any final native request with an out-of-band attachment fails closed without retaining attachment metadata or bytes. |
-| `MEMORY-AGENT-004` | Commit ordering and crash/replay cannot lose or enqueue one source Turn more than once. |
+| `MEMORY-AGENT-003` | Admission excludes every terminal shape that does not satisfy the completed-result invariant; source-class batching separates callbacks; accepted live steers are excluded; the revision-matched opaque primary admission set makes an unbound or binding-transition Turn retain no dispatch text or budget; and any final native request with an out-of-band attachment fails closed without retaining attachment metadata or bytes. |
+| `MEMORY-AGENT-004` | Commit ordering and crash/replay cannot lose or enqueue one source Turn more than once; persisted prior/desired config revisions plus digests detect third-state and ABA edits during capture or binding recovery. |
 | `MEMORY-AGENT-005` | Agent and project partitions cannot read or write each other's output; capture and trusted-Turn CLI retrieval use the immutable executing Agent without blocking hard deletion, deleted owners remain UI-retrievable, and crash-safe prepared binding cutovers keep backlog in the project effective at settlement. |
 | `MEMORY-AGENT-006` | Malformed config, missing/pre-migration identity/source/final-dispatch snapshots, and missing project binding fail closed. |
 | `MEMORY-AGENT-007` | Agent-sidecar/local pipeline outage leaves chat and Personal Memory healthy; dual-root embedding rebuild preserves and fences both roots through partial failure; shared remote endpoint throttling and effective-home capacity exhaustion are reported as explicit resource couplings without cross-role state mixing. |
 | `MEMORY-AGENT-008` | Both role sidecars reject every payload outside their exact owner/shape contract. |
 | `MEMORY-AGENT-009` | CLI/UI retrieval is explicit, bounded, inert, and absent from Agent prompts/install paths; a read-only per-Agent project catalog keeps removed-binding output reachable. |
 | `MEMORY-AGENT-010` | Accepted processing with zero cases or skills is a truthful valid outcome. |
-| `MEMORY-AGENT-011` | Per-row/global primary snapshot guards plus queue/disk exhaustion skip durably; primary copies are scrubbed after disposition/reset, queue payloads are scrubbed immediately after a durable add receipt and before flush, and 90-day/100,000-row tombstone compaction bounds closed-row storage without degrading Personal Memory. |
+| `MEMORY-AGENT-011` | Per-row/global primary snapshot guards plus queue/disk exhaustion skip durably; primary copies, including active nonterminal snapshots, are scrubbed after disposition/reset; queue payloads are scrubbed immediately after a durable add receipt and before flush; ambiguous post-submission Agent adds dead-letter without replay; and 90-day/100,000-row tombstone compaction bounds closed-row storage without degrading Personal Memory. |
 | `MEMORY-AGENT-012` | Skill retrieval exposes exact freshness/maturity metadata, while the request-budgeted status sampler reports non-blocking per-Agent count hints at 8 and 11 skills. |
 | `MEMORY-AGENT-013` | Opt-in disclosure models raw attribution bytes in exact trajectory content without allowing them to become Memory identity or scope. |
 

--- a/docs/plans/memory-agent-track-1424.md
+++ b/docs/plans/memory-agent-track-1424.md
@@ -45,10 +45,11 @@ Personal Memory admission, prompt, provider root, queue, or retrieval semantics.
    reports them but does not patch EverOS or file an upstream issue. Retrieval
    exposes skill freshness/maturity metadata, and status adds a conservative
    per-Agent skill-count hint; neither mitigation mutates provider state.
-9. Every disabled-to-enabled transition initializes the scan cursor to the
-   current terminal-settlement sequence high water mark. There is no historical
-   or disabled-period backfill in v1; only turns settling after that explicit
-   enable cutover are candidates.
+9. Every disabled-to-enabled transition, Clear, and factory reset initializes
+   the scan cursor to the current terminal-settlement sequence high water mark
+   before scanner admission opens. There is no historical, disabled-period, or
+   post-reset replay in v1; only turns settling after that explicit cutover are
+   candidates.
 
 ## Product Contract
 
@@ -322,11 +323,15 @@ ambiguous agent write cannot fence user capture.
 `memory_agent_scan_state` is a singleton containing the last committed terminal
 sequence, enable epoch, durable missed counters, and scan/update timestamps. On
 every enable cutover the cursor advances to the primary store's current maximum
-before admission opens. The scanner then queries strictly after that sequence in
-bounded pages. It advances through admitted, duplicate, guarded, and closed-skip
-rows only after the corresponding decision is durable. A crash before commit
-re-reads the same row; the digest keeps enqueue idempotent. Adding a binding
-later does not backfill turns already skipped at an earlier cursor.
+before admission opens. Clear and factory-reset recovery apply the same cutover
+after deleting or recreating the Memory store: while the shared maintenance
+fence is held, they create the new scan state at the current committed maximum,
+then rebuild bindings, and only then may an enabled scanner start. The scanner
+queries strictly after that sequence in bounded pages. It advances through
+admitted, duplicate, guarded, and closed-skip rows only after the corresponding
+decision is durable. A crash before commit re-reads the same row; the digest
+keeps enqueue idempotent. Adding a binding later does not backfill turns already
+skipped at an earlier cursor.
 
 `memory_agent_project_bindings` is a replaceable projection of the V2 config. It
 maps only opaque `binding_key` to exact new-style `project_id`, with
@@ -383,6 +388,10 @@ responses, or credentials. Agent recorder failure degrades only the agent role.
   cannot block later rows or the Personal Memory worker.
 - The chat root stays available when the agent root is down, and user capture
   remains governed exclusively by the existing human-input admission.
+- These isolation guarantees cover ordinary scanning, processing, retrieval,
+  and role-reconcile failures. Explicit Clear, factory reset, and
+  embedding-identity rebuild intentionally use the shared maintenance fence and
+  can pause both roles until their idempotent operation converges.
 - Retrieval failure returns a closed Agent Memory error and never falls back to
   Personal Memory or a different Agent/project.
 - Empty case/skill results after successful processing are valid. UI and CLI say
@@ -436,7 +445,7 @@ stable ids:
 
 | ID | Invariant |
 |---|---|
-| `MEMORY-AGENT-001` | The absent/default config leaves the second root, scanner, and worker off; every enable starts at the current high water. |
+| `MEMORY-AGENT-001` | The absent/default config leaves the second root, scanner, and worker off; every enable or destructive reset starts at the current high water. |
 | `MEMORY-AGENT-002` | Every eligible completed interactive or Harness Turn is represented once by its exact dispatch/result pair. |
 | `MEMORY-AGENT-003` | Admission excludes every terminal shape that does not satisfy the completed-result invariant. |
 | `MEMORY-AGENT-004` | Commit ordering and crash/replay cannot lose or enqueue one source Turn more than once. |

--- a/docs/plans/memory-agent-track-1424.md
+++ b/docs/plans/memory-agent-track-1424.md
@@ -42,7 +42,9 @@ Personal Memory admission, prompt, provider root, queue, or retrieval semantics.
    source workdir to either the exact `default` project or an existing/new-style
    named Memory project. Missing bindings fail closed.
 8. EverOS 1.2.3 limitations listed below are accepted. Avibe isolates and
-   reports them but does not patch EverOS or file an upstream issue.
+   reports them but does not patch EverOS or file an upstream issue. Retrieval
+   exposes skill freshness/maturity metadata, and status adds a conservative
+   per-Agent skill-count hint; neither mitigation mutates provider state.
 9. Every disabled-to-enabled transition initializes the scan cursor to the
    current terminal-settlement sequence high water mark. There is no historical
    or disabled-period backfill in v1; only turns settling after that explicit
@@ -179,12 +181,30 @@ must equal it. The owner Settings UI may select an installed Agent and one exact
 bound project. It may search and list `agent_case` and `agent_skill` with the
 same per-kind and response-size bounds.
 
-Results are provider-neutral records labelled `case` or `skill`. Returned skill
-content is untrusted inert text. Avibe does not copy a returned `SKILL.md`, load
-its references or scripts, register it with an Agent backend, execute it, or add
-it to any system/user prompt. The existing Personal Memory prompt and
-`vibe memory search/list` contracts remain byte-for-byte unchanged by the new
-CLI examples and parser registration.
+Results are provider-neutral records labelled `case` or `skill`. Every skill in
+human-readable, JSON, and UI search/list output includes its `updated_at` as a
+UTC RFC 3339 timestamp and its numeric `maturity_score` in the closed `[0, 1]`
+range. EverOS 1.2.3 omits `updated_at` from its public Agent retrieval shapes, so
+the Avibe-owned agent sidecar enriches the validated response through a
+read-only, sentinel-confined lookup of the exact `agent_skill` row in that role's
+provider root. Missing, malformed, or mismatched metadata invalidates the
+response rather than displaying a guessed timestamp or a partial result.
+
+Returned skill content is untrusted inert text. Avibe does not copy a returned
+`SKILL.md`, load its references or scripts, register it with an Agent backend,
+execute it, or add it to any system/user prompt. The existing Personal Memory
+prompt and `vibe memory search/list` contracts remain byte-for-byte unchanged by
+the new CLI examples and parser registration.
+
+Memory status also reports a content-free skill-count observation for each
+installed Agent across that Agent's explicitly bound projects. The monitor uses
+bounded `total_count` metadata, not skill bodies, and reports `normal` for 0-7,
+`approaching` for 8-10, and `risk` above 10. The hint says explicitly that this
+total is a conservative proxy: EverOS does not expose cluster membership, name
+sanitization collisions can occur at any count, and the stale-index risk applies
+when one upstream cluster exceeds 10. An unavailable count is `unknown` and
+degrades only Agent Memory status. Counts and hints never block capture,
+retrieval, or provider writes.
 
 ## Isolation Architecture
 
@@ -337,7 +357,9 @@ The agent sidecar accepts only:
   bounded query/top-k. EverOS returns both Agent arrays; the adapter validates
   both completely before applying Avibe's requested case/skill projection; and
 - get: `agent_id` only, `memory_type=agent_case|agent_skill`, 1-based bounded
-  paging, and fixed allowlisted ordering.
+  paging, and fixed allowlisted ordering. Skill responses are joined read-only
+  to the exact root-confined `agent_skill` metadata for `updated_at`; list
+  `total_count` also feeds the content-free status monitor.
 
 Both `user_id` plus `agent_id`, raw Avibe ids, `u-...` owners, mismatched message
 owners, legacy/reserved projects, unknown keys, attachments, tool payloads,
@@ -368,7 +390,7 @@ responses, or credentials. Agent recorder failure degrades only the agent role.
 
 ## Accepted EverOS 1.2.3 Limitations
 
-These are known by design and are not Avibe bugs to work around in this issue:
+These are known by design and are not fixed in this issue:
 
 - agent-skill retire is unimplemented, so retired output may remain searchable;
 - skill names are sanitized for filesystem paths and collisions can overwrite an
@@ -384,7 +406,10 @@ These are known by design and are not Avibe bugs to work around in this issue:
 
 The dedicated agent root ensures these limitations cannot corrupt Personal
 Memory state. Bounded validation and retrieval ensure malformed or oversized
-Agent output degrades closed instead of crossing into the user track.
+Agent output degrades closed instead of crossing into the user track. The
+freshness/maturity fields and count hint above are observability mitigations
+only: they help an owner judge possible staleness but do not retire, rename,
+repair, or rewrite any skill.
 
 ## Delivery Slices
 
@@ -396,8 +421,8 @@ Agent output degrades closed instead of crossing into the user track.
 3. **Capture:** durable scanner/read port, admission, enqueue, worker/delivery,
    lifecycle composition, and degradation tests.
 4. **Retrieval:** scoped CLI/internal API, owner Settings enablement/binding,
-   independent status and Agent Memory search/list UI, i18n, and prompt-inert
-   parser contracts.
+   independent status with per-Agent skill-count hints, freshness/maturity
+   enriched Agent Memory search/list UI, i18n, and prompt-inert parser contracts.
 5. **Scenario closed loop:** catalog, reusable harness, packaged-runtime
    regression, final docs/observations, and issue close-out evidence.
 
@@ -422,6 +447,7 @@ stable ids:
 | `MEMORY-AGENT-009` | CLI/UI retrieval is explicit, bounded, inert, and absent from Agent prompts/install paths. |
 | `MEMORY-AGENT-010` | Accepted processing with zero cases or skills is a truthful valid outcome. |
 | `MEMORY-AGENT-011` | Queue/disk exhaustion skips durably without retaining text or degrading Personal Memory. |
+| `MEMORY-AGENT-012` | Skill retrieval exposes exact freshness/maturity metadata, and status reports non-blocking per-Agent count hints at 8 and 11 skills. |
 
 Evidence layers are unit tests for config/identity/admission/store/worker/runtime,
 contract tests for provider/sidecar/internal API/CLI/UI, executable catalog

--- a/docs/plans/memory-agent-track-1424.md
+++ b/docs/plans/memory-agent-track-1424.md
@@ -1,0 +1,380 @@
+# EverOS Agent Memory Track
+
+> Status: approved implementation contract
+>
+> Issue: [#1424](https://github.com/avibe-bot/avibe/issues/1424)
+>
+> Provider reference: EverOS 1.2.3
+
+## Goal
+
+Add an opt-in Agent Memory beta that turns eligible, successfully completed
+Avibe Agent Turns into EverOS `agent_case` records and lets EverOS cluster those
+cases into `agent_skill` records. The track is isolated from Personal Memory,
+never delays Agent Turn settlement, and is recalled only through explicit,
+bounded CLI or owner Settings operations.
+
+This contract supersedes the earlier Agent-capture non-goal in
+[`memory-plugin-system.md`](./memory-plugin-system.md). It does not change the
+Personal Memory admission, prompt, provider root, queue, or retrieval semantics.
+
+## Locked Decisions
+
+1. The existing Personal Memory provider root is permanently a chat-mode root.
+   Agent Memory uses a second root, UDS, generated-config directory, process
+   ownership record, lifecycle supervisor, health projection, and retention
+   slot. No reconcile or maintenance operation may mode-flip an existing root.
+2. The durable source is `session_turns`, joined to `agent_sessions`, not
+   Harness-specific `agent_runs`. Both interactive and Harness turns are
+   eligible under the same rules.
+3. A controller-owned background scanner copies eligible terminal turns into a
+   separate schema-v4 queue. Terminal settlement and backend adapters do no
+   Memory I/O and await no Memory work.
+4. EverOS `agent_id` is derived from immutable `agents.id` with the install-local
+   Memory scope key. Mutable Agent names and user principals are never agent
+   owners.
+5. Agent/project retrieval is explicit, lazy, inert, and bounded. Agent Memory
+   is never injected into a prompt, installed as a Codex/Claude skill, or
+   executed.
+6. The first version contains only the exact backend dispatch text and terminal
+   result. It does not parse formatted event streams into synthetic tool calls.
+7. Enabling the track does not create a project binding. The owner must bind a
+   source workdir to either the exact `default` project or an existing/new-style
+   named Memory project. Missing bindings fail closed.
+8. EverOS 1.2.3 limitations listed below are accepted. Avibe isolates and
+   reports them but does not patch EverOS or file an upstream issue.
+9. First enable initializes the scan cursor to the current terminal-turn high
+   water mark. There is no historical backfill in v1; only turns completing
+   after explicit enablement are candidates.
+
+## Product Contract
+
+### Enablement and disclosure
+
+`memory.agent_track.enabled` is a persisted boolean and defaults to `false`.
+Absence is equivalent to disabled. A malformed optional `agent_track` block is
+discarded with a sanitized warning; it must not prevent Avibe startup or alter
+the independently parsed Personal Memory configuration.
+
+The owner Settings surface explains that eligible Agent inputs and results may
+be sent to the configured Memory processing endpoints, that accepted processing
+may produce no case or skill, and that the feature inherits the documented
+EverOS 1.2.3 limitations. The source set is fixed to eligible completed Agent
+Turns, including interactive and Harness turns; v1 has no source-type selector.
+
+Enabling requires the installed Memory runtime, complete processing endpoints,
+and at least one explicit project binding. On first enable the owner-visible
+operation snapshots the current terminal-turn high water mark before the
+scanner starts. It starts only the agent sidecar and scanner/worker slots needed
+by the track. A failed start rolls the agent-track projection back to
+unavailable without disabling Personal Memory or restarting the Avibe service.
+
+### Admission
+
+One durable `session_turns` row is one candidate trajectory. The scanner reads
+in stable `(terminal_at, id)` order and joins the owning `agent_sessions` row
+and its referenced `agents` row. Admission is provider-neutral and accepts a
+row only when all of these invariants hold:
+
+- the turn is terminal with `terminal_outcome="completed"`;
+- `terminal_evidence_kind="terminal_result"` and the versioned evidence contains
+  one non-empty final `result_text`;
+- immutable `dispatch_text` and the final result are valid, nonempty UTF-8 text
+  of at most 256 KiB each;
+- the session's `agent_id` resolves to a real `agents.id`; legacy name-only
+  sessions fail closed, while later Agent disable/archive does not rewrite an
+  already completed Turn's identity;
+- the source is an ordinary interactive or Harness-request turn, not a callback,
+  system maintenance action, or Agent-to-Agent completion callback; and
+- the session workdir resolves through an explicit opaque binding to exactly one
+  new-style Memory project.
+
+The property is deliberately positive. Every terminal shape not satisfying the
+complete invariant is skipped, including failed, canceled, stopped/restarted,
+silent, missing-result, malformed-evidence, oversized, and unbound turns.
+Admission logs only a closed reason and opaque source digest.
+
+The v1 trajectory has exactly two ordered messages:
+
+```json
+[
+  {
+    "sender_id": "i-<32 lowercase hex>",
+    "role": "user",
+    "timestamp": 0,
+    "content": "<exact dispatch_text>"
+  },
+  {
+    "sender_id": "a-<32 lowercase hex>",
+    "role": "assistant",
+    "timestamp": 1,
+    "content": "<exact terminal result_text>"
+  }
+]
+```
+
+The actual timestamps are stable millisecond values derived from the durable
+turn times, with the assistant timestamp strictly later than the input. The
+synthetic input actor is local to this isolated provider track and is never
+treated as an Avibe user principal. There are no attachments, `tool_calls`, tool
+results, reasoning traces, or sender names in v1.
+
+### Identity and project isolation
+
+The Memory store's install-local `scope_key` derives both opaque identities:
+
+```text
+agent_id    = "a-" + HMAC_SHA256(scope_key, "agent:" + agents.id).hex()[:32]
+binding_key = "b-" + HMAC_SHA256(scope_key, "agent-project:" + normalized_workdir).hex()[:32]
+```
+
+The raw Agent id, Agent name, workdir, Session id, Turn id, Run id, platform
+identity, and user principal are not written into the Memory database or
+provider paths. The source Turn id is reduced to a keyed digest for idempotency.
+The synthetic input actor is `i-` plus the first 32 hex characters of a separate
+HMAC domain over that source digest; it can never collide with `u-` or `a-`
+owners.
+
+One binding maps one `binding_key` to one project id. Project ids use the schema
+v3 write contract exactly: literal `default`, or a 1-63 byte lower-case named
+slug accepted by `is_new_stored_memory_project_id`; reserved values and legacy
+`p-...` workdir hashes are never new writes. `agent_id` partitions Agents and
+`project_id` partitions one Agent's learning. Search/list responses must match
+both before they cross the provider boundary.
+
+### Explicit retrieval
+
+The CLI adds explicit Agent Memory operations under `vibe memory agent`:
+
+```text
+vibe memory agent search <query> [--project <slug>] [--kind case|skill|all] [--limit 1..20] [--json]
+vibe memory agent list [--project <slug>] [--kind case|skill] [--page N] [--limit 1..20] [--json]
+```
+
+The CLI accepts an Avibe-injected Session id through the existing trusted
+context, resolves that Session's immutable Agent and explicit project binding,
+and accepts no raw `agent_id`, Agent selector, workdir, provider filter, or
+cross-project `all`. Omitting `--project` uses that binding; an explicit value
+must equal it. The owner Settings UI may select an installed Agent and one exact
+bound project. It may search and list `agent_case` and `agent_skill` with the
+same per-kind and response-size bounds.
+
+Results are provider-neutral records labelled `case` or `skill`. Returned skill
+content is untrusted inert text. Avibe does not copy a returned `SKILL.md`, load
+its references or scripts, register it with an Agent backend, execute it, or add
+it to any system/user prompt. The existing Personal Memory prompt and
+`vibe memory search/list` contracts remain byte-for-byte unchanged by the new
+CLI examples and parser registration.
+
+## Isolation Architecture
+
+### Owned state
+
+The two provider roles use disjoint paths under the effective `AVIBE_HOME`:
+
+| Role | Provider root | Private UDS | Generated config |
+|---|---|---|---|
+| Personal Memory | `memory/everos-root/` | `memory/.rt/everos.sock` | `memory/generated/chat/` after role migration |
+| Agent Memory | `memory/everos-agent-root/` | `memory/.rt/everos-agent.sock` | `memory/generated/agent/` |
+
+The existing generated files may be migrated into the `chat/` role directory
+only through a compatibility-preserving write; the sentinel-owned provider root
+and socket identity do not change. Every generated configuration pins
+`memorize.mode` explicitly: `chat` for the existing root and `agent` for the new
+root. Validation accepts only the role's expected value. EverOS's upstream
+default of `agent` is never relied upon.
+
+The roles share the immutable installed EverOS artifact and environment-only
+endpoint credentials. They do not share provider roots, sockets, process
+records, root sentinels, provider-root locks, supervisors, health snapshots,
+call-log ownership slots, or worker queues. All ownership records include the
+role plus exact root/socket pair so a stale chat record can never identify an
+agent child, or vice versa.
+
+The agent sidecar reuses EverOS's public `GET /health` and POST
+`/api/v2/memory/{add,flush,search,get}` paths. Role-specific validators, not new
+provider paths, define the wire contract. The chat sidecar retains its exact
+current profiles and continues rejecting every agent shape.
+
+### Lifecycle and maintenance
+
+Reconcile owns the roles independently:
+
+- Personal Memory enablement continues to own the chat root and user worker.
+- Agent-track enablement owns the agent root, scanner, trajectory worker, and
+  agent sidecar. Turning it off preserves its queue and provider data.
+- A crash, failed health check, recorder degradation, or processing error in one
+  role changes only that role's projection and retry loop.
+- Agent `/add` failures cannot merge into or alter a chat-root `/add` result.
+- Shutdown closes both owned child trees independently under the normal
+  controller lifecycle; no routine verification restarts Avibe.
+
+Restart engine, Repair index, Clear Memory Data, rebuild, and factory reset must
+enumerate role-owned resources rather than assuming one global slot. Clear and
+factory reset cover both roots, both role call-log/health records, and both
+queues under one existing durable maintenance fence. A partial failure reports
+each role truthfully and keeps Memory fenced until idempotent retry converges.
+Embedding-identity rebuild validates once, quiesces both sidecars, rebuilds each
+nonempty owned root independently, and does not activate either root against a
+different vector-space identity. Restart/repair may target a degraded role
+without mode-flipping or deleting the healthy role.
+
+## Schema-v4 Contract
+
+Raise `MEMORY_STORE_SCHEMA_VERSION` from 3 to 4 with a transactional v3-to-v4
+migration. A released schema-v3 fixture must upgrade with every existing row,
+table, index, value, and project-catalog entry unchanged. The new tables are
+separate from `memory_capture_queue` and its user principal/session-generation
+invariants.
+
+### Agent trajectory outbox
+
+`memory_agent_trajectory_queue` stores one row per admitted source Turn:
+
+- `source_turn_digest` primary key: keyed digest of the durable Turn id;
+- stable provider `session_id`, opaque `agent_id`, and exact `project_id`;
+- bounded input/result payloads and stable input/result timestamps;
+- closed `pending | processing | delivered | dead` state;
+- lease token/owner/time, attempts, next retry, closed error, provider request
+  ids/status, and created/completed timestamps.
+
+Idempotent enqueue and cursor advancement are one transaction. A duplicate
+source digest returns duplicate without changing the existing row. Successful
+delivery scrubs both source texts. A deterministic rejection or exhausted
+bounded retry dead-letters and scrubs the row; infrastructure unavailability
+pauses claims without consuming a content retry. Agent rows never enter
+`manual_required` or the Personal Memory session-flush coordinator.
+
+Each row uses its own deterministic provider session. The worker performs one
+two-message add and, when needed, one matching flush. Acknowledgement means only
+that EverOS accepted/processed the trajectory boundary; it does not prove a case
+or skill exists. Unknown post-submission outcomes are never replayed
+automatically; they settle to a closed agent-only dead-letter reason so an
+ambiguous agent write cannot fence user capture.
+
+### Scanner cursor and project bindings
+
+`memory_agent_scan_state` is a singleton containing the last committed
+`(terminal_at, turn_id)` cursor, whether the first-enable high water was
+initialized, and scan/update timestamps. The scanner queries strictly after
+that tuple in bounded pages. It advances through admitted, duplicate, and
+closed-skip rows only after the corresponding enqueue/skip decision is durable.
+A crash before commit re-reads the same row; the digest keeps enqueue
+idempotent. Adding a binding later does not backfill turns already skipped at an
+earlier cursor.
+
+`memory_agent_project_bindings` maps only opaque `binding_key` to exact
+new-style `project_id`, with created/updated timestamps. Settings writes the
+binding after resolving and normalizing a local workdir; reads expose a friendly
+local project/workdir label from the primary Avibe store, never by reversing the
+opaque Memory key. Deleting a binding stops new admission and does not rewrite
+queued or provider data already bound to that project.
+
+## Provider and Sidecar Contracts
+
+The provider-neutral port adds four operations:
+
+- `add_agent_trajectory(trajectory)`;
+- `flush_agent_trajectory(ref)`;
+- `search_agent_memory(agent_id, project_id, query, kind, limit)`; and
+- `list_agent_memory(agent_id, project_id, kind, page, page_size)`.
+
+The agent sidecar accepts only:
+
+- add: exact scope plus exactly two text-only messages, first synthetic user
+  actor and second assistant owner `a-[0-9a-f]{32}`;
+- flush: the exact session/app/project scope from an admitted trajectory;
+- search: `agent_id` only, `include_profile=false`, no arbitrary filters, and
+  bounded query/top-k. EverOS returns both Agent arrays; the adapter validates
+  both completely before applying Avibe's requested case/skill projection; and
+- get: `agent_id` only, `memory_type=agent_case|agent_skill`, 1-based bounded
+  paging, and fixed allowlisted ordering.
+
+Both `user_id` plus `agent_id`, raw Avibe ids, `u-...` owners, mismatched message
+owners, legacy/reserved projects, unknown keys, attachments, tool payloads,
+filters, and cross-role requests are rejected before forwarding. Responses are
+fully validated for envelope, owner, app/project, item kind, pagination/counts,
+closed numeric ranges, and bounded canonical text. A malformed or cross-scope
+response becomes `memory_provider_response_invalid` with no partial projection.
+
+Agent add/flush remain inside the mandatory redacted recorder boundary. Insight
+patches, recorder, and reader recognize agent-pipeline events but never expose
+trajectory text, raw Agent/Turn/Session ids, provider paths, prompts, model
+responses, or credentials. Agent recorder failure degrades only the agent role.
+
+## Failure and Degradation
+
+- Scanning, enqueue, add, flush, and retrieval are outside Agent hot paths.
+- A malformed agent config, missing binding, missing immutable Agent id,
+  unavailable sidecar, provider error, or queue problem produces one sanitized
+  agent-track status/skip/failure and leaves the completed Turn unchanged.
+- Queue work uses bounded backoff and agent-only dead letters. A poisoned row
+  cannot block later rows or the Personal Memory worker.
+- The chat root stays available when the agent root is down, and user capture
+  remains governed exclusively by the existing human-input admission.
+- Retrieval failure returns a closed Agent Memory error and never falls back to
+  Personal Memory or a different Agent/project.
+- Empty case/skill results after successful processing are valid. UI and CLI say
+  `processed`/`no results`, never `learned`, until retrieval observes output.
+
+## Accepted EverOS 1.2.3 Limitations
+
+These are known by design and are not Avibe bugs to work around in this issue:
+
+- agent-skill retire is unimplemented, so retired output may remain searchable;
+- skill names are sanitized for filesystem paths and collisions can overwrite an
+  earlier `SKILL.md`, including case-only collisions on insensitive filesystems;
+- clustering above `MAX_SKILLS_IN_PROMPT=10` can use a stale partial index and
+  clobber a concurrent/newer skill view;
+- provider quality gates can legitimately emit a case but no skill, or no
+  durable Agent output for an accepted trajectory;
+- 1.2.3 is the first release with the relevant cascade-race fix; earlier
+  behavior is not supported by this feature; and
+- the markdown shape supports `references/` and `scripts/`, but the 1.2.3
+  extraction path populates only `SKILL.md`.
+
+The dedicated agent root ensures these limitations cannot corrupt Personal
+Memory state. Bounded validation and retrieval ensure malformed or oversized
+Agent output degrades closed instead of crossing into the user track.
+
+## Delivery Slices
+
+1. **Spec:** this contract plus the canonical product/recovery documentation.
+   No runtime behavior changes.
+2. **Infrastructure:** schema v4, config/identity/project-binding primitives,
+   dual-root lifecycle, provider port, role-specific sidecar/recorder contracts,
+   and focused migrations/fixtures. Capture remains inactive.
+3. **Capture:** durable scanner/read port, admission, enqueue, worker/delivery,
+   lifecycle composition, and degradation tests.
+4. **Retrieval:** scoped CLI/internal API, owner Settings enablement/binding,
+   independent status and Agent Memory search/list UI, i18n, and prompt-inert
+   parser contracts.
+5. **Scenario closed loop:** catalog, reusable harness, packaged-runtime
+   regression, final docs/observations, and issue close-out evidence.
+
+No PR is stacked. Each slice branches from the latest `master` after the prior
+slice is approved and merged.
+
+## Scenario Contract
+
+The final catalog is `tests/scenarios/memory_agent_track/` and registers these
+stable ids:
+
+| ID | Invariant |
+|---|---|
+| `MEMORY-AGENT-001` | The absent/default config leaves the second root, scanner, and worker off; first enable starts at the current high water. |
+| `MEMORY-AGENT-002` | Every eligible completed interactive or Harness Turn is represented once by its exact dispatch/result pair. |
+| `MEMORY-AGENT-003` | Admission excludes every terminal shape that does not satisfy the completed-result invariant. |
+| `MEMORY-AGENT-004` | Crash/replay cannot enqueue one source Turn more than once. |
+| `MEMORY-AGENT-005` | Agent and project partitions cannot read or write each other's output. |
+| `MEMORY-AGENT-006` | Malformed config, legacy Agent identity, and missing project binding fail closed. |
+| `MEMORY-AGENT-007` | Agent-sidecar outage leaves chat and Personal Memory healthy. |
+| `MEMORY-AGENT-008` | Both role sidecars reject every payload outside their exact owner/shape contract. |
+| `MEMORY-AGENT-009` | CLI/UI retrieval is explicit, bounded, inert, and absent from Agent prompts/install paths. |
+| `MEMORY-AGENT-010` | Accepted processing with zero cases or skills is a truthful valid outcome. |
+
+Evidence layers are unit tests for config/identity/admission/store/worker/runtime,
+contract tests for provider/sidecar/internal API/CLI/UI, executable catalog
+scenarios for the closed loop, and one hermetic packaged EverOS regression. No
+test may read or write real `~/.avibe`, restart the local `vibe` service, or use
+external provider credentials.

--- a/docs/plans/memory-agent-track-1424.md
+++ b/docs/plans/memory-agent-track-1424.md
@@ -49,12 +49,15 @@ Personal Memory admission, prompt, provider root, queue, or retrieval semantics.
    reports them but does not patch EverOS or file an upstream issue. Retrieval
    exposes skill freshness/maturity metadata, and status adds a conservative
    per-Agent skill-count hint; neither mitigation mutates provider state.
-9. Every enable, disable, Clear, and factory-reset capture cutover records its
-   terminal-settlement high water and recovery intent atomically in the primary
-   state writer transaction. The Memory scan state is an idempotent projection
-   of that cutover. There is no historical, disabled-period, or post-reset
-   replay in v1; only turns settling inside a committed enabled epoch are
-   candidates.
+9. Every settings capture/binding cutover first records its terminal-settlement
+   high water and prepared recovery intent atomically in the primary state
+   writer transaction, before the V2 config replacement. Recovery commits that
+   exact boundary only when the persisted config has the intent's desired
+   digest, or cancels it when the prior digest remains. Clear and factory reset
+   retain their documented primary-state destructive-recovery cutover. The
+   Memory scan state is an idempotent projection of those records. There is no
+   historical, disabled-period, or post-reset replay in v1; only turns settling
+   inside a committed enabled epoch are candidates.
 
 ## Product Contract
 
@@ -95,15 +98,21 @@ for later-settling Turns, while already-settled backlog through its committed
 cutover remains eligible under the old project.
 
 Enabling requires the installed Memory runtime, complete processing endpoints,
-and at least one explicit project binding. Enable/disable Settings writes first
-persist the desired V2 config. Under the agent-capture lifecycle lock, one
-serialized primary state transaction then reads terminal high water `H` and
-inserts a singleton `memory_agent_capture_cutover` intent with a new capture
-epoch, desired enabled state, config digest, and `H`. Terminal settlement cannot
-interleave between that read and intent commit.
+and at least one explicit project binding. Under the agent-capture lifecycle
+lock, an enable/disable Settings write first uses one serialized primary state
+transaction to read terminal high water `H` and insert a singleton prepared
+`memory_agent_capture_cutover` intent with a new capture epoch, prior and desired
+config digests, desired enabled state, and `H`. Terminal settlement cannot
+interleave between that read and intent commit. The scanner is fenced, then the
+desired V2 config is atomically replaced and the prepared intent is promoted to
+committed. The cutover is conditionally sequence-effective at the prepared
+intent's `H`: Turns above `H` use the desired state if the config replacement
+succeeds, or the prior state if it fails.
 
-Normal Agent scanner admission is fenced while a capture intent exists; only
-idempotent cutover projection and the bounded disable drain may run. Enable
+Normal Agent scanner admission is fenced while a capture intent exists. A
+prepared intent permits no projection or drain; after config persistence,
+committed intent handling permits only idempotent cutover projection and the
+bounded disable drain. Enable
 projects an open epoch and cursor `H`, rebuilds opaque bindings, starts the role
 runtime, and only then clears the intent and opens scanner admission. Disable
 first closes new provider claims in the controller, commits its disabled intent,
@@ -114,16 +123,21 @@ worker quiescence no provider write may start. The scanner runs local-only in
 then stops and clears the intent. Rows enqueued by the drain remain pending
 without provider I/O and become claimable only after a later enable.
 
-If Avibe stops after config commit but before an intent, recovery creates the
-intent with a conservative recovery-time `H`. Once an intent exists, recovery
-always reuses its exact epoch and `H`; Memory projection/drain and intent cleanup
-are idempotent. Re-enable requires an earlier disable drain to converge, then
-its own enabled cutover skips the completed opt-out interval. Clear/factory
-reset record the same primary-state intent immediately before recreating scan
-state, after destructive deletion is complete. Turn settlement performs no
-Memory/config I/O and never waits for projection or drain work. A failed start
-leaves only Agent Memory unavailable without disabling Personal Memory or
-restarting Avibe.
+If V2 config persistence fails, the still-prior digest authorizes cancellation
+of the prepared intent, any claims closed for a proposed disable reopen, and
+scanner work resumes under the prior epoch, including Turns above `H`. After a
+crash, recovery compares the persisted digest: the
+prior digest cancels the intent, the exact desired digest promotes and projects
+the intent's original epoch and `H`, and any third digest fences Agent Memory as
+degraded for explicit repair. Recovery never invents a later high water. Thus a
+disable that reached config commit cannot extend its old enabled epoch to
+restart time. Memory projection/drain and intent cleanup are idempotent.
+Re-enable requires an earlier disable drain to converge, then its own enabled
+cutover skips the completed opt-out interval. Clear/factory reset record the
+same primary-state intent immediately before recreating scan state, after
+destructive deletion is complete. Turn settlement performs no Memory/config I/O
+and never waits for projection or drain work. A failed start leaves only Agent
+Memory unavailable without disabling Personal Memory or restarting Avibe.
 
 ### Admission
 
@@ -237,13 +251,18 @@ vibe memory agent search <query> [--project <slug>] [--kind case|skill|all] [--l
 vibe memory agent list [--project <slug>] [--kind case|skill] [--page N] [--limit 1..20] [--json]
 ```
 
-The CLI accepts an Avibe-injected Session id through the existing trusted
-context, resolves that Session's immutable Agent and explicit project binding,
-and accepts no raw `agent_id`, Agent selector, workdir, provider filter, or
-cross-project `all`. Omitting `--project` uses that binding; an explicit value
-must equal it. The owner Settings UI may select an installed Agent and one exact
-bound project. It may search and list `agent_case` and `agent_skill` with the
-same per-kind and response-size bounds.
+The CLI requires an Avibe-injected current Session id and current Turn id through
+the existing trusted context. It validates that the Turn belongs to that Session
+and derives the owner only from the Turn's immutable `executing_agent_id`
+snapshot, including explicit Harness/CLI Agent overrides; mutable Session routing
+is never retrieval identity. It accepts no caller-supplied Turn id, raw
+`agent_id`, Agent selector, workdir, provider filter, or cross-project `all`.
+Omitting `--project` uses the Session workdir's current explicit binding. An
+explicit value must be either that binding or an exact project retained in this
+executing Agent's read-only project catalog; without either, access fails closed.
+The owner Settings UI may select an installed Agent and one exact current or
+cataloged historical project. It may search and list `agent_case` and
+`agent_skill` with the same per-kind and response-size bounds.
 
 Results are provider-neutral records labelled `case` or `skill`. Every skill in
 human-readable, JSON, and UI search/list output includes its `updated_at` as a
@@ -261,14 +280,17 @@ prompt and `vibe memory search/list` contracts remain byte-for-byte unchanged by
 the new CLI examples and parser registration.
 
 Memory status also reports a content-free skill-count observation for each
-installed Agent across that Agent's explicitly bound projects. An explicit
+installed Agent across that Agent's current and cataloged historical projects.
+An explicit
 status refresh may advance one durable, stable-order sampling cursor at most
 once per 60 seconds. One sampler batch issues at most 32 scoped `total_count`
 requests with concurrency at most two, caches only count/observed-at metadata,
 and resumes at the next Agent/project pair; status rendering never fans out its
 own provider reads. An Agent count is complete only after all of its current
-bound projects have been observed in the same sampling generation; otherwise it
-is `unknown` or explicitly stale. Removed Agents/bindings invalidate their cache.
+retrievable projects have been observed in the same sampling generation;
+otherwise it is `unknown` or explicitly stale. Removed Agents invalidate their
+cache; binding removal keeps observations through the retained project catalog
+entry.
 
 A complete count reports `normal` for 0-7, `approaching` for 8-10, and `risk`
 above 10. The hint says explicitly that this total is a conservative proxy:
@@ -296,7 +318,10 @@ root. Validation accepts only the role's expected value. EverOS's upstream
 default of `agent` is never relied upon.
 
 The roles share the immutable installed EverOS artifact and environment-only
-endpoint credentials. They do not share provider roots, sockets, process
+endpoint credentials. Consequently the remote LLM/embedding service's account
+quota, concurrency allowance, and rate limits are an explicit external resource
+coupling: Agent traffic can throttle Personal traffic even though failures and
+state remain role-local. They do not share provider roots, sockets, process
 records, root sentinels, provider-root locks, supervisors, health snapshots,
 call-log ownership slots, or worker queues. All ownership records include the
 role plus exact root/socket pair so a stale chat record can never identify an
@@ -390,9 +415,10 @@ for every new field and are not backfilled.
 
 The primary state schema also adds bounded singleton
 `memory_agent_capture_cutover` and `memory_agent_binding_cutover` recovery
-records used below. Each contains only its kind/digest/epoch, terminal high
-water, state, and timestamps; normalized workdirs and project ids remain in V2
-config, while opaque epochs remain in the Memory store.
+records used below. Each contains only its kind, prior/desired config digests,
+epoch, terminal high water, closed `prepared | committed` phase, state, and
+timestamps; normalized workdirs and project ids remain in V2 config, while
+opaque epochs remain in the Memory store.
 
 ### Agent trajectory outbox
 
@@ -456,13 +482,24 @@ remains the authoritative desired owner setting. The projection also stores its
 `applied_config_digest`; historical epochs exist only to finish committed
 scanner work.
 
+`memory_agent_project_catalog` is a conservative read-only retrieval directory
+keyed by opaque `agent_id` plus exact `project_id`. The enqueue transaction
+creates or refreshes an entry before provider data can exist. Binding removal and
+closed-epoch compaction never delete it, so later-delivered queued output and
+existing provider cases/skills remain discoverable after the last binding is
+removed or reassigned. Entries contain no workdir or raw Agent id and disappear
+only with the Agent root's Clear/factory reset, or a future explicit
+provider-data deletion contract. A catalog entry does not claim that EverOS
+produced output.
+
 Under the agent-capture lifecycle lock, every add, reassignment, or removal first
-persists the desired V2 config atomically. It then uses one serialized primary
-state transaction to read the current committed terminal high water `H` and
-insert a singleton `memory_agent_binding_cutover` intent containing the desired
-config digest and `H`. Terminal settlement cannot interleave between that read
-and intent commit, but it performs no Memory/config I/O and never waits for
-projection work.
+uses one serialized primary state transaction to read the current committed
+terminal high water `H` and insert a prepared singleton
+`memory_agent_binding_cutover` intent containing the prior/desired config digests
+and `H`. Terminal settlement cannot interleave between that read and intent
+commit. The scanner is then fenced, V2 config is atomically replaced, and the
+intent is promoted to committed; terminal settlement performs no Memory/config
+I/O and never waits for projection work.
 
 When one Settings save changes both `enabled` and bindings, that same primary
 writer transaction records the capture and binding intents at one shared `H`.
@@ -473,18 +510,18 @@ While an intent exists, Agent scanner admission is fenced. One idempotent Memory
 transaction appends/closes the opaque epochs at the intent's exact `H` and
 advances `applied_config_digest`; only then may recovery clear the primary-state
 intent and reopen the scanner. The binding becomes sequence-effective at the
-intent commit, and the Settings save reports success only after projection
-converges. A Turn settled before that commit is at or below `H` and uses the old
-mapping; a later Turn is above `H` and uses the new mapping when scanning resumes.
+prepared intent's `H` only if the desired config commit succeeds, and the
+Settings save reports success only after projection converges. A Turn at or
+below `H` uses the old mapping; a later Turn uses the new mapping after a
+successful save, or the old mapping after a failed save cancels the intent.
 
-If Avibe stops after config commit but before the cutover intent, startup sees
-the digest mismatch and creates the intent with a new recovery-time high water.
-If it stops after the intent, recovery reuses that exact `H`; if projection
-already committed, matching digests make intent cleanup idempotent. Until
-convergence status reports binding reconcile as degraded and only the Agent
-scanner is fenced. If config persistence fails, no intent is created and the
-projection is unchanged. A crash therefore cannot backdate the new binding or
-block the Agent hot path.
+If config persistence fails, the prior digest cancels the prepared intent and
+leaves the projection unchanged. After a crash, the prior digest cancels it, the
+desired digest promotes it and reuses the exact original `H`, and any third
+digest leaves only Agent Memory fenced and degraded. If projection already
+committed, matching digests make intent cleanup idempotent. Recovery never
+creates a cutover at restart time. A crash therefore cannot backdate the new
+binding, extend a disabled epoch, or block the Agent hot path.
 
 An added mapping is effective only for `terminal_sequence > H`. Reassignment
 closes the old epoch through `H` and opens the new project after `H`; removal
@@ -495,7 +532,7 @@ with a `NULL` through-sequence meaning open. It therefore drains backlog through
 the old project without admitting opt-in or reassignment history to the new
 project. Closed epochs remain until the committed scanner cursor reaches their
 cutover, then compact; immutable queued/provider rows keep their original
-project.
+project and the read-only catalog keeps that project retrievable.
 
 Settings writes friendly normalized workdir/project pairs only to V2 config;
 reconcile derives opaque keys with the current Memory scope key. Reads expose
@@ -549,7 +586,11 @@ responses, or credentials. Agent recorder failure degrades only the agent role.
 - The chat root stays available when the agent root is down, and user capture
   remains governed exclusively by the existing human-input admission.
 - These isolation guarantees cover ordinary scanning, processing, retrieval,
-  and role-reconcile failures. Explicit Clear, factory reset, and
+  and role-reconcile failures in Avibe-owned state and processes. The shared
+  remote processing credentials do not provide quota isolation: Agent load can
+  consume account concurrency/rate/quota and throttle Personal requests. Agent
+  work remains bounded and backs off on throttling, but Avibe cannot partition
+  an endpoint provider's account budget. Explicit Clear, factory reset, and
   embedding-identity rebuild intentionally use the shared maintenance fence and
   can pause both roles until their idempotent operation converges.
 - Retrieval failure returns a closed Agent Memory error and never falls back to
@@ -605,15 +646,15 @@ stable ids:
 
 | ID | Invariant |
 |---|---|
-| `MEMORY-AGENT-001` | The absent/default config leaves the second root, scanner, and worker off; primary-state capture intents make enable/disable/reset cutovers crash-atomic with Turn settlement, and Clear accepts either never-created role as absent. |
+| `MEMORY-AGENT-001` | The absent/default config leaves the second root, scanner, and worker off; pre-config primary-state capture intents make enable/disable/reset cutovers crash-atomic with Turn settlement without recovery-time boundary drift, and Clear accepts either never-created role as absent. |
 | `MEMORY-AGENT-002` | Every semantically eligible non-steered completed interactive or Harness Turn not durably declined by a specified resource guard is represented once by its exact post-transformation backend-dispatch/result pair. |
 | `MEMORY-AGENT-003` | Admission excludes every terminal shape that does not satisfy the completed-result invariant; source-class batching separates callbacks and accepted live steers are excluded. |
 | `MEMORY-AGENT-004` | Commit ordering and crash/replay cannot lose or enqueue one source Turn more than once. |
-| `MEMORY-AGENT-005` | Agent and project partitions cannot read or write each other's output; the Turn snapshots its executing Agent without blocking hard deletion, and crash-safe post-config binding cutovers keep backlog in the project effective at settlement. |
+| `MEMORY-AGENT-005` | Agent and project partitions cannot read or write each other's output; capture and trusted-Turn CLI retrieval use the immutable executing Agent without blocking hard deletion, and crash-safe prepared binding cutovers keep backlog in the project effective at settlement. |
 | `MEMORY-AGENT-006` | Malformed config, missing/pre-migration identity/source/final-dispatch snapshots, and missing project binding fail closed. |
-| `MEMORY-AGENT-007` | Agent-sidecar outage leaves chat and Personal Memory healthy. |
+| `MEMORY-AGENT-007` | Agent-sidecar/local pipeline outage leaves chat and Personal Memory healthy; shared remote endpoint throttling is reported as an external quota coupling without cross-role state corruption. |
 | `MEMORY-AGENT-008` | Both role sidecars reject every payload outside their exact owner/shape contract. |
-| `MEMORY-AGENT-009` | CLI/UI retrieval is explicit, bounded, inert, and absent from Agent prompts/install paths. |
+| `MEMORY-AGENT-009` | CLI/UI retrieval is explicit, bounded, inert, and absent from Agent prompts/install paths; a read-only per-Agent project catalog keeps removed-binding output reachable. |
 | `MEMORY-AGENT-010` | Accepted processing with zero cases or skills is a truthful valid outcome. |
 | `MEMORY-AGENT-011` | Queue/disk exhaustion skips durably, and 90-day/100,000-row tombstone compaction bounds closed-row storage without degrading Personal Memory. |
 | `MEMORY-AGENT-012` | Skill retrieval exposes exact freshness/maturity metadata, while the request-budgeted status sampler reports non-blocking per-Agent count hints at 8 and 11 skills. |

--- a/docs/plans/memory-agent-track-1424.md
+++ b/docs/plans/memory-agent-track-1424.md
@@ -39,11 +39,13 @@ Personal Memory admission, prompt, provider root, queue, or retrieval semantics.
    Agent names, and user principals are never agent owners.
 5. Agent/project retrieval is explicit, lazy, inert, and bounded. Agent Memory
    is never injected into a prompt, installed as a Codex/Claude skill, or
-   executed.
-6. The first version contains only the exact final backend dispatch text,
+   executed. CLI retrieval additionally requires an owner-authorized Workbench
+   Turn; an IM/shared-scope Turn is never sufficient retrieval authority.
+6. An admitted candidate contains only the exact final backend dispatch text,
    durably snapshotted after all transformations and before native dispatch,
-   plus the terminal result. It does not parse formatted event streams into
-   synthetic tool calls.
+   plus the terminal result. Snapshot failure omits only the Memory candidate
+   and never blocks the native request. V1 does not parse formatted event streams
+   into synthetic tool calls.
 7. Enabling the track does not create a project binding. The owner must bind a
    source workdir to either the exact `default` project or an existing/new-style
    named Memory project. Missing bindings fail closed. Binding additions,
@@ -245,13 +247,18 @@ before its first binding is never admitted retroactively.
 Disabled/transitioning epochs, missing/transitioning bindings, out-of-band
 attachment input, oversized text, or an exhausted snapshot budget record only a
 closed omission reason, input-shape marker, and small counter; they never retain
-text, attachment paths/bytes, or consume the snapshot budget or block native
-dispatch. A successful config transition cannot retroactively
-admit an in-flight Turn that omitted its snapshot. Persistence failure for a
-snapshot that was admitted still fails closed before native start, because the
-candidate could otherwise diverge from the adapter input. Backend-native
-acceptance can therefore never precede the durable exact input used by an
-Agent-Memory candidate.
+text, attachment paths/bytes, consume the snapshot budget, or block native
+dispatch. A successful config transition cannot retroactively admit an in-flight
+Turn that omitted its snapshot. If the optional snapshot transaction fails, it
+rolls back its reservation and payload atomically and native dispatch proceeds
+with the already-finalized in-memory input. A separate best-effort content-free
+write may record `snapshot_persist_failed`; failure of that diagnostic write is
+observable only through a sanitized health counter. Such a Turn is not an
+Agent-Memory candidate, and an automatic native retry follows the ordinary Agent
+retry contract rather than attempting to reconstruct Memory input. Thus
+backend-native acceptance can precede snapshot persistence only for an omitted
+Turn; every admitted Agent-Memory candidate still has durable exact input before
+native acceptance.
 
 The property is deliberately positive. Every terminal shape not satisfying the
 complete invariant is skipped, including failed, canceled, stopped/restarted,
@@ -337,11 +344,22 @@ vibe memory agent list [--project <slug>] [--kind case|skill] [--page N] [--limi
 ```
 
 The CLI's session-stable environment provides only an Avibe Session locator; it
-is never sufficient authorization and carries no Turn id. Immediately before a
-recognized `vibe memory agent` tool invocation, an Avibe-owned backend callback
-asks the controller to resolve exactly one native-started, nonterminal active
-Turn for that Session and mint a random one-use capability bound to the Session,
-logical/native Turn, executing Agent snapshot, closed search/list command class,
+is never sufficient authorization and carries no Turn id. At initial Delivery
+claim, trusted ingress snapshots the closed
+`agent_memory_retrieval_authority = owner_workbench | none` value on the Turn.
+Only a local owner Workbench request or an authenticated remote owner Workbench
+request receives `owner_workbench`; every IM transport, shared scope, Harness
+trigger, unauthenticated request, pre-migration row, or ambiguous provenance
+receives `none`. This authorization snapshot contains no raw user identity and
+cannot be upgraded by later routing, prompt text, Agent tool arguments, or
+Session mutation.
+
+Immediately before a recognized `vibe memory agent` tool invocation, an
+Avibe-owned backend callback asks the controller to resolve exactly one
+native-started, nonterminal active Turn for that Session. It mints a random
+one-use capability only when that immutable Turn has `owner_workbench`, binding
+the token to the Session, logical/native Turn, executing Agent snapshot,
+retrieval-authority snapshot, closed search/list command class,
 parser-normalized argv/request digest, and a 30-second expiry. The callback
 injects it only into that child invocation. The recognizer uses a shell parser
 and accepts one standalone simple command with allowlisted CLI flags; shell
@@ -357,11 +375,13 @@ session-bound closure and uses the SDK's `updated_input` result to inject a fres
 capability for each matching Bash call. It does not rely on or refresh the
 client's spawn-time environment. Codex and OpenCode use the equivalent
 per-invocation adapter hook. If a backend cannot provide the hook, the token is
-missing/expired/reused, or active Turn resolution is zero/ambiguous/terminal,
+missing/expired/reused, active Turn resolution is zero/ambiguous/terminal, or
+the Turn lacks owner-Workbench authority,
 the command returns `memory_turn_context_unavailable`; there is no fallback to a
 static Session lookup, caller-supplied Turn id, prompt text, or mutable Session
 routing. Explicit Harness/CLI Agent overrides are already reflected in the
-capability's immutable executing-Agent snapshot. The command also accepts no raw
+capability's immutable executing-Agent snapshot but do not confer retrieval
+authority. The command also accepts no raw
 `agent_id`, Agent selector, workdir, provider filter, or cross-project `all`.
 Omitting `--project` uses the Session workdir's current explicit binding. An
 explicit value must be either that binding or an exact project retained in this
@@ -495,6 +515,8 @@ primary Avibe state schema:
   selected by the final execution route, deliberately without a foreign key;
 - `source_class TEXT`, constrained on new writes to `interactive`,
   `harness_request`, `callback`, `maintenance`, or `agent_callback`;
+- `agent_memory_retrieval_authority TEXT`, constrained on new writes to the
+  content-free `owner_workbench` or `none` ingress authorization snapshot;
 - `backend_input_shape TEXT`, constrained on new writes to `text_only` or
   `out_of_band_attachment` and derived from the final native request rather
   than transport transcript metadata;
@@ -509,7 +531,8 @@ primary Avibe state schema:
 - `backend_dispatch_capture_epoch INTEGER` and
   `backend_dispatch_omission_reason TEXT`, the admitted epoch or a closed
   `disabled | transition | unbound | out_of_band_attachment | oversized |
-  budget | binding_cutover | destructive_reset` reason, never both; and
+  budget | binding_cutover | snapshot_persist_failed | destructive_reset`
+  reason, never both; and
 - `terminal_sequence INTEGER`, with a unique partial index.
 
 The shared `MessageHandler`/dispatch boundary creates the same durable Delivery
@@ -523,7 +546,9 @@ existing durable path.
 The initial Delivery claim/Turn creation transaction snapshots
 `executing_agent_id` from the resolved execution route, including an explicit
 Harness/task override, after validating that id against the live Agent catalog.
-It also snapshots the homogeneous Delivery `source_class`. These fields are
+It also snapshots the homogeneous Delivery `source_class` and the closed
+content-free `agent_memory_retrieval_authority` derived from trusted ingress.
+These fields are
 observational for Memory: inability to resolve a stable Agent id/source class
 does not block the Turn, but leaves the field `NULL` and makes that Turn
 ineligible for Agent Memory. The Agent snapshot is not referentially constrained,
@@ -546,7 +571,11 @@ committed explicit opaque binding key, enforces the per-row 256 KiB bound,
 reserves bytes, and compares-and-sets the admitted
 text/digest/shape/binding-key/binding-epoch/capture-epoch. The adapter receives
 that exact stored text without additional native input. A retry must reuse it and
-a conflicting second value fails closed; Memory never derives candidate input
+a conflicting second value makes only Memory fail closed; native execution still
+uses its already-finalized in-memory input. If this optional persistence
+transaction fails, it rolls back the reservation and payload together, attempts
+a separate content-free `snapshot_persist_failed` diagnostic, and proceeds with
+native dispatch without a Memory candidate. Memory never derives candidate input
 from the earlier raw `dispatch_text`. When no snapshot is admitted, the same
 transaction writes only the closed shape/omission reason and the adapter
 proceeds with its in-memory native input. Unbound content and out-of-band
@@ -782,10 +811,15 @@ project and the read-only catalog keeps that project retrievable.
 
 Settings writes friendly normalized workdir/project pairs only to V2 config;
 reconcile derives opaque keys with the current Memory scope key. Reads expose
-the current config labels, never by reversing an opaque key. Clear may remove
-all epochs; factory reset creates a new Memory scope key and rebuilds current
-bindings with an effective-after cutover at the new high water before an enabled
-scanner starts.
+the current config labels, never by reversing an opaque key. Clear deletes the
+old Agent-root epochs and catalog, then reconstructs one open epoch for every
+binding preserved in V2 config using its current primary admission key and
+generation, effective only after the Clear high water. The rebuild and scanner
+cursor commit before the Clear intent is removed or snapshot admission reopens.
+Factory reset instead creates a new Memory scope key, derives fresh opaque keys
+and generations, and rebuilds current bindings with an effective-after cutover
+at its new high water before an enabled scanner starts. Neither operation can
+leave the preserved primary admission set without matching project epochs.
 
 ## Provider and Sidecar Contracts
 
@@ -823,7 +857,8 @@ responses, or credentials. Agent recorder failure degrades only the agent role.
 
 ## Failure and Degradation
 
-- Scanning, enqueue, add, flush, and retrieval are outside Agent hot paths.
+- Scanning, enqueue, add, flush, retrieval, and dispatch-snapshot persistence
+  are optional to the Agent hot path; failure cannot suppress native dispatch.
 - A malformed agent config, missing binding, missing immutable Agent id,
   unavailable sidecar, provider error, or queue problem produces one sanitized
   agent-track status/skip/failure and leaves the completed Turn unchanged.
@@ -898,15 +933,15 @@ stable ids:
 
 | ID | Invariant |
 |---|---|
-| `MEMORY-AGENT-001` | The absent/default config leaves the second root, scanner, and worker off; every Personal/Agent/endpoint Memory config writer uses one controller transaction with monotonic revision/digest conflict detection through cutover cleanup; the durable current-capture projection preserves exact enabled epoch admission across controller restart; Agent-only enablement keeps navigation/recovery visible and forbids shared-credential clearing; a failed Agent-role start retains a fenced retryable intent without snapshot admission; destructive reset atomically scrubs terminal and in-flight snapshots at its fixed high water; and Clear accepts either never-created role as absent. |
-| `MEMORY-AGENT-002` | Every semantically eligible non-steered completed Workbench, Slack, Discord, Telegram, Feishu/Lark, WeChat, or Harness Turn not durably declined by a specified snapshot/queue/disk guard is represented once by its exact post-transformation backend-dispatch/result pair. |
-| `MEMORY-AGENT-003` | Admission excludes every terminal shape that does not satisfy the completed-result invariant; source-class batching separates callbacks; accepted live steers are excluded; the revision-matched opaque primary admission set makes an unbound or binding-transition Turn retain no dispatch text or budget; a remove/reassign scrubs old-generation Turns settling after its high water so re-add cannot revive them; and any final native request with an out-of-band attachment fails closed without retaining attachment metadata or bytes. |
+| `MEMORY-AGENT-001` | The absent/default config leaves the second root, scanner, and worker off; every Personal/Agent/endpoint Memory config writer uses one controller transaction with monotonic revision/digest conflict detection through cutover cleanup; the durable current-capture projection preserves exact enabled epoch admission across controller restart; Agent-only enablement keeps navigation/recovery visible and forbids shared-credential clearing; a failed Agent-role start retains a fenced retryable intent without snapshot admission; destructive reset atomically scrubs terminal and in-flight snapshots at its fixed high water; Clear accepts either never-created role as absent and rebuilds every preserved binding epoch before reopening admission. |
+| `MEMORY-AGENT-002` | Every semantically eligible non-steered completed Workbench, Slack, Discord, Telegram, Feishu/Lark, WeChat, or Harness Turn whose dispatch snapshot committed and was not durably declined by a later queue/disk guard is represented once by its exact post-transformation backend-dispatch/result pair. |
+| `MEMORY-AGENT-003` | Admission excludes every terminal shape that does not satisfy the completed-result invariant; source-class batching separates callbacks; accepted live steers are excluded; the revision-matched opaque primary admission set makes an unbound or binding-transition Turn retain no dispatch text or budget; snapshot persistence failure rolls back only the Memory candidate and never blocks native dispatch; a remove/reassign scrubs old-generation Turns settling after its high water so re-add cannot revive them; and any final native request with an out-of-band attachment fails closed without retaining attachment metadata or bytes. |
 | `MEMORY-AGENT-004` | Commit ordering and crash/replay cannot lose or enqueue one source Turn more than once; persisted prior/desired config revisions plus digests detect third-state and ABA edits during capture or binding recovery. |
-| `MEMORY-AGENT-005` | Agent and project partitions cannot read or write each other's output; capture and controller-resolved active-Turn CLI retrieval use the immutable executing Agent without blocking hard deletion; deleted owners remain UI-retrievable; and crash-safe generation-bearing binding cutovers preserve settled backlog while invalidating in-flight old generations. |
+| `MEMORY-AGENT-005` | Agent and project partitions cannot read or write each other's output; capture and controller-resolved active-Turn CLI retrieval use the immutable executing Agent without blocking hard deletion; CLI capability minting additionally requires immutable owner-Workbench authority so a second IM/shared-scope user cannot retrieve the first user's Agent Memory; deleted owners remain UI-retrievable; and crash-safe generation-bearing binding cutovers preserve settled backlog while invalidating in-flight old generations. |
 | `MEMORY-AGENT-006` | Malformed config, missing/pre-migration identity/source/final-dispatch snapshots, and missing project binding fail closed. |
 | `MEMORY-AGENT-007` | Agent-sidecar/local pipeline outage leaves chat and Personal Memory healthy; dual-root embedding rebuild preserves and fences both roots through partial failure; shared remote endpoint throttling and effective-home capacity exhaustion are reported as explicit resource couplings without cross-role state mixing. |
 | `MEMORY-AGENT-008` | Both role sidecars reject every payload outside their exact owner/shape contract. |
-| `MEMORY-AGENT-009` | CLI/UI retrieval is explicit, bounded, inert, and absent from Agent prompts/install paths; each adapter injects a request-bound one-use active-Turn capability, cached Claude sessions refresh it through per-call `updated_input` without an environment Turn id, and missing/reused/expired/ambiguous/terminal context fails closed; a read-only per-Agent project catalog keeps removed-binding output reachable. |
+| `MEMORY-AGENT-009` | CLI/UI retrieval is explicit, bounded, inert, and absent from Agent prompts/install paths; each adapter injects a request-bound one-use active-Turn capability only for trusted owner-Workbench ingress, cached Claude sessions refresh it through per-call `updated_input` without an environment Turn id, and IM/shared/Harness plus missing/reused/expired/ambiguous/terminal context fails closed; a read-only per-Agent project catalog keeps removed-binding output reachable. |
 | `MEMORY-AGENT-010` | Accepted processing with zero cases or skills is a truthful valid outcome. |
 | `MEMORY-AGENT-011` | Per-row/global primary snapshot guards plus queue/disk exhaustion skip durably; primary copies, including active nonterminal snapshots, are scrubbed after disposition/reset; queue payloads are scrubbed immediately after a durable add receipt and before flush; ambiguous post-submission Agent adds dead-letter without replay; and 90-day/100,000-row tombstone compaction bounds closed-row storage without degrading Personal Memory. |
 | `MEMORY-AGENT-012` | Skill retrieval exposes exact freshness/maturity metadata, while the request-budgeted status sampler reports non-blocking per-Agent count hints at 8 and 11 skills. |

--- a/docs/plans/memory-agent-track-1424.md
+++ b/docs/plans/memory-agent-track-1424.md
@@ -103,19 +103,26 @@ for later-settling Turns, while already-settled backlog through its committed
 cutover remains eligible under the old project.
 
 Enabling requires the installed Memory runtime, complete processing endpoints,
-and at least one explicit project binding. The UI validates the candidate but
-does not persist `agent_track` settings itself. It sends the candidate plus its
-expected prior config digest to one authenticated controller IPC operation,
-`apply_agent_memory_settings`. The controller owns the complete
-capture/binding/config/claim transition under the same lifecycle lock used by
-scanner, Clear, and reset orchestration; a process-local UI lock is not a
-correctness boundary. If the controller is unavailable, the request fails before
-any mutation.
+and at least one explicit project binding. Every writer that mutates any Memory
+V2 config field, including Personal enablement, endpoint/API-key edits, Agent
+enablement and bindings, and repair/rebuild settings, submits a field-scoped
+patch plus its expected Memory-config revision to one authenticated controller
+IPC transaction, `apply_memory_settings`. `apply_agent_memory_settings` is its
+Agent-role logical operation, not an independent writer. No UI, compatibility,
+or maintenance process directly persists any part of the Memory config. The
+controller compares the expected revision, applies the patch to the latest
+config, owns any capture/binding/config/claim transition, atomically replaces
+V2 config, reconciles the affected roles, and retains the same cross-process
+lifecycle/config transaction through intent cleanup. A stale revision returns a
+conflict for reload instead of overwriting another writer; a process-local UI
+lock is only a debounce and never a correctness boundary. If the controller is
+unavailable, the request fails before any mutation.
 
-The controller first uses one serialized primary state transaction to read
-terminal high water `H` and insert a singleton prepared
+For an Agent-role patch, the controller first uses one serialized primary state
+transaction to read terminal high water `H` and insert a singleton prepared
 `memory_agent_capture_cutover` intent with a new capture epoch, prior and desired
-config digests, desired enabled state, and `H`. Terminal settlement cannot
+Agent-block digests, the whole Memory-config revision, desired enabled state,
+and `H`. Terminal settlement cannot
 interleave between that read and intent commit. The scanner is fenced, then the
 desired V2 config is atomically replaced and the prepared intent is promoted to
 committed. The cutover is conditionally sequence-effective at the prepared
@@ -136,13 +143,18 @@ worker quiescence no provider write may start. The scanner runs local-only in
 then stops and clears the intent. Rows enqueued by the drain remain pending
 without provider I/O and become claimable only after a later enable.
 
-If V2 config persistence fails, the still-prior digest authorizes cancellation
+All Memory writers remain serialized behind that controller transaction until
+the intent is cleared, so a Personal or endpoint save cannot create a third
+digest during Agent recovery. If V2 config persistence fails, the still-prior
+Agent-block digest and config revision authorize cancellation
 of the prepared intent, any claims closed for a proposed disable reopen, and
 scanner work resumes under the prior epoch, including Turns above `H`. After a
-crash, recovery compares the persisted digest: the
-prior digest cancels the intent, the exact desired digest promotes and projects
-the intent's original epoch and `H`, and any third digest fences Agent Memory as
-degraded for explicit repair. Recovery never invents a later high water. Thus a
+crash, recovery compares the persisted revision and Agent-block digest: the
+prior state cancels the intent, the exact desired state promotes and projects
+the intent's original epoch and `H`, and any unrecognized state fences Agent
+Memory as degraded for explicit repair. The same controller transaction must
+repair or retire that intent before accepting another Memory write. Recovery
+never invents a later high water. Thus a
 disable that reached config commit cannot extend its old enabled epoch to
 restart time. Memory projection/drain and intent cleanup are idempotent.
 Re-enable requires an earlier disable drain to converge, then its own enabled
@@ -177,6 +189,9 @@ these invariants hold:
   one non-empty final `result_text`;
 - immutable `backend_dispatch_text` and the final result are valid, nonempty
   UTF-8 text of at most 256 KiB each;
+- `backend_input_shape="text_only"`; any Turn whose native backend request also
+  contains an out-of-band image, attachment, audio, file, or other non-text
+  input is excluded even when its dispatch string is nonempty;
 - the dispatch snapshot was admitted while one committed capture epoch was
   enabled, and the Turn settled inside that same epoch; a Turn crossing enable,
   disable, Clear, or reset is excluded;
@@ -200,18 +215,21 @@ Harness request therefore cannot coalesce with a callback even when both use the
 same trigger/backend/Session.
 
 After scheduled attribution, transcription, attachment/file formatting, and all
-other input transformations finish, the shared start boundary checks the
-controller-projected primary capture epoch without opening the Memory store. If
+other input transformations finish, the shared start boundary classifies the
+final native request as the closed `text_only | out_of_band_attachment`
+`backend_input_shape` and checks the controller-projected primary capture epoch
+without opening the Memory store. Only `text_only` requests are candidates. If
 that epoch is committed enabled, the exact UTF-8 text is at most 256 KiB, and the
 global primary snapshot budget remains below 128 MiB, one primary transaction
-reserves its byte count and persists `backend_dispatch_text`, digest, and capture
-epoch before invoking the native adapter. The adapter must send exactly that
-stored text; an automatic start retry reuses it instead of re-running a
-text-changing transform.
+reserves its byte count and persists `backend_dispatch_text`, digest, shape, and
+capture epoch before invoking the native adapter. The adapter must send exactly
+that stored text with no additional native input; an automatic start retry
+reuses the snapshot instead of re-running a text-changing transform.
 
-Disabled/transitioning epochs, oversized text, or an exhausted snapshot budget
-record only a closed omission reason and small counter; they never retain the
-text or block native dispatch. A successful config transition cannot retroactively
+Disabled/transitioning epochs, out-of-band attachment input, oversized text, or
+an exhausted snapshot budget record only a closed omission reason, input-shape
+marker, and small counter; they never retain text, attachment paths/bytes, or
+block native dispatch. A successful config transition cannot retroactively
 admit an in-flight Turn that omitted its snapshot. Persistence failure for a
 snapshot that was admitted still fails closed before native start, because the
 candidate could otherwise diverge from the adapter input. Backend-native
@@ -221,7 +239,8 @@ Agent-Memory candidate.
 The property is deliberately positive. Every terminal shape not satisfying the
 complete invariant is skipped, including failed, canceled, stopped/restarted,
 silent, missing-result, missing/guarded final-dispatch, epoch-crossing,
-malformed-evidence, oversized, accepted-steer, callback-class, and unbound turns.
+malformed-evidence, out-of-band attachment, oversized, accepted-steer,
+callback-class, and unbound turns.
 Admission logs only a closed
 reason and opaque source digest.
 
@@ -281,6 +300,15 @@ slug accepted by `is_new_stored_memory_project_id`; reserved values and legacy
 `p-...` workdir hashes are never new writes. `agent_id` partitions Agents and
 `project_id` partitions one Agent's learning. Search/list responses must match
 both before they cross the provider boundary.
+
+The owner UI derives one aggregate navigation/credential guard,
+`memory_roles_enabled = memory.enabled || memory.agent_track.enabled`. The
+Memory page remains visible and its recovery controls remain reachable whenever
+either role is enabled or a Memory recovery intent is pending, including the
+valid Agent-only state where Personal Memory is disabled. An explicit shared
+endpoint credential clear is accepted only when both roles will be disabled and
+no pending recovery requires that credential. Personal-only checks must never
+hide Agent status or authorize credential removal from an active Agent role.
 
 ### Explicit retrieval
 
@@ -366,7 +394,15 @@ The roles share the immutable installed EverOS artifact and environment-only
 endpoint credentials. Consequently the remote LLM/embedding service's account
 quota, concurrency allowance, and rate limits are an explicit external resource
 coupling: Agent traffic can throttle Personal traffic even though failures and
-state remain role-local. They do not share provider roots, sockets, process
+state remain role-local. Both roots and `memory.sqlite` also share the effective
+home volume, so local capacity is an explicit resource coupling: growth of the
+Agent EverOS root or index can consume the reserve and make later Agent or
+Personal writes fail even though paths are disjoint. The pre-claim free-space
+guard limits new Agent work but cannot quota or preempt growth caused by work
+already accepted inside EverOS. Status therefore reports free space and
+role-specific provider-root use, warns at the Agent reserve, and pauses new
+Agent claims while below it; this is observability and backpressure, not local
+capacity isolation. The roles do not share provider roots, sockets, process
 records, root sentinels, provider-root locks, supervisors, health snapshots,
 call-log ownership slots, or worker queues. All ownership records include the
 role plus exact root/socket pair so a stale chat record can never identify an
@@ -421,11 +457,15 @@ primary Avibe state schema:
   selected by the final execution route, deliberately without a foreign key;
 - `source_class TEXT`, constrained on new writes to `interactive`,
   `harness_request`, `callback`, `maintenance`, or `agent_callback`;
+- `backend_input_shape TEXT`, constrained on new writes to `text_only` or
+  `out_of_band_attachment` and derived from the final native request rather
+  than transport transcript metadata;
 - `backend_dispatch_text TEXT` and `backend_dispatch_sha256 TEXT`, the exact
   bounded final backend-facing input and digest;
 - `backend_dispatch_capture_epoch INTEGER` and
   `backend_dispatch_omission_reason TEXT`, the admitted epoch or a closed
-  `disabled | transition | oversized | budget` reason, never both; and
+  `disabled | transition | out_of_band_attachment | oversized | budget` reason,
+  never both; and
 - `terminal_sequence INTEGER`, with a unique partial index.
 
 The shared `MessageHandler`/dispatch boundary creates the same durable Delivery
@@ -456,13 +496,16 @@ fail-closed for Agent Memory but do not block ordinary execution.
 
 The primary schema also keeps a singleton snapshot-byte reservation capped at
 128 MiB. Immediately before the first native start call, after every
-shared/backend input transformation, a primary state transaction checks the
-committed capture epoch and per-row 256 KiB bound, reserves bytes, and
-compares-and-sets the admitted text/digest/epoch. The adapter receives that exact
-stored value. A retry must reuse it and a conflicting second value fails closed;
-Memory never derives candidate input from the earlier raw `dispatch_text`.
-When no snapshot is admitted, the same transaction writes only the closed
-omission reason and the adapter proceeds with its in-memory final text.
+shared/backend input transformation, a primary state transaction classifies the
+complete native input shape, checks the committed capture epoch and per-row 256
+KiB bound, reserves bytes, and compares-and-sets the admitted
+text/digest/shape/epoch. The adapter receives that exact stored text without
+additional native input. A retry must reuse it and a conflicting second value
+fails closed; Memory never derives candidate input from the earlier raw
+`dispatch_text`. When no snapshot is admitted, the same transaction writes only
+the closed shape/omission reason and the adapter proceeds with its in-memory
+native input. Out-of-band attachment metadata and bytes are never copied into
+the Memory source schema.
 Startup and periodic primary-state maintenance recompute the reservation from
 the UTF-8 byte lengths of actual nonempty snapshots before admitting more, so a
 crash cannot leak budget.
@@ -579,14 +622,16 @@ opaque selection token for that exact catalog owner; requests never accept a raw
 `agent_id`. Hard deletion therefore remains unconstrained and does not delete
 or orphan queued/provider data.
 
-The same controller `apply_agent_memory_settings` IPC owns every binding add,
-reassignment, and removal under the shared lifecycle lock. It first uses one
+The shared controller `apply_memory_settings` transaction owns every binding
+add, reassignment, and removal under the cross-process lifecycle/config lock;
+its Agent-role operation is `apply_agent_memory_settings`. It first uses one
 serialized primary state transaction to read the current committed
 terminal high water `H` and insert a prepared singleton
-`memory_agent_binding_cutover` intent containing the prior/desired config digests
-and `H`. Terminal settlement cannot interleave between that read and intent
-commit. The scanner is then fenced, V2 config is atomically replaced, and the
-intent is promoted to committed; terminal settlement performs no Memory/config
+`memory_agent_binding_cutover` intent containing the prior/desired Agent-block
+digests, whole-config revisions, and `H`. Terminal settlement cannot interleave
+between that read and intent commit. The scanner is then fenced, V2 config is
+atomically replaced, and the intent is promoted to committed; terminal
+settlement performs no Memory/config
 I/O and never waits for projection work. The UI does not write these bindings
 before contacting the controller.
 
@@ -679,7 +724,12 @@ responses, or credentials. Agent recorder failure degrades only the agent role.
   remote processing credentials do not provide quota isolation: Agent load can
   consume account concurrency/rate/quota and throttle Personal requests. Agent
   work remains bounded and backs off on throttling, but Avibe cannot partition
-  an endpoint provider's account budget. Explicit Clear, factory reset, and
+  an endpoint provider's account budget. The shared effective-home volume also
+  does not provide capacity isolation: post-admission EverOS Agent-root/index
+  growth can cross the free-space reserve and make later Personal or Agent local
+  writes fail. Role-specific paths still prevent state mixing or logical
+  corruption, but status must report this capacity coupling and new Agent claims
+  pause below the reserve. Explicit Clear, factory reset, and
   embedding-identity rebuild intentionally use the shared maintenance fence and
   can pause both roles until their idempotent operation converges.
 - Retrieval failure returns a closed Agent Memory error and never falls back to
@@ -736,13 +786,13 @@ stable ids:
 
 | ID | Invariant |
 |---|---|
-| `MEMORY-AGENT-001` | The absent/default config leaves the second root, scanner, and worker off; one controller IPC owns prepared settings cutovers, a failed Agent-role start retains a fenced retryable intent without snapshot admission, post-deletion reset high waters do not drift on recovery, and Clear accepts either never-created role as absent. |
+| `MEMORY-AGENT-001` | The absent/default config leaves the second root, scanner, and worker off; every Personal/Agent/endpoint Memory config writer uses one controller transaction with revision conflict detection through cutover cleanup; Agent-only enablement keeps navigation/recovery visible and forbids shared-credential clearing; a failed Agent-role start retains a fenced retryable intent without snapshot admission; post-deletion reset high waters do not drift on recovery; and Clear accepts either never-created role as absent. |
 | `MEMORY-AGENT-002` | Every semantically eligible non-steered completed Workbench, Slack, Discord, Telegram, Feishu/Lark, WeChat, or Harness Turn not durably declined by a specified snapshot/queue/disk guard is represented once by its exact post-transformation backend-dispatch/result pair. |
-| `MEMORY-AGENT-003` | Admission excludes every terminal shape that does not satisfy the completed-result invariant; source-class batching separates callbacks and accepted live steers are excluded. |
+| `MEMORY-AGENT-003` | Admission excludes every terminal shape that does not satisfy the completed-result invariant; source-class batching separates callbacks, accepted live steers are excluded, and any final native request with an out-of-band attachment fails closed without retaining attachment metadata or bytes. |
 | `MEMORY-AGENT-004` | Commit ordering and crash/replay cannot lose or enqueue one source Turn more than once. |
 | `MEMORY-AGENT-005` | Agent and project partitions cannot read or write each other's output; capture and trusted-Turn CLI retrieval use the immutable executing Agent without blocking hard deletion, deleted owners remain UI-retrievable, and crash-safe prepared binding cutovers keep backlog in the project effective at settlement. |
 | `MEMORY-AGENT-006` | Malformed config, missing/pre-migration identity/source/final-dispatch snapshots, and missing project binding fail closed. |
-| `MEMORY-AGENT-007` | Agent-sidecar/local pipeline outage leaves chat and Personal Memory healthy; dual-root embedding rebuild preserves and fences both roots through partial failure, while shared remote endpoint throttling is reported as an external quota coupling without cross-role state corruption. |
+| `MEMORY-AGENT-007` | Agent-sidecar/local pipeline outage leaves chat and Personal Memory healthy; dual-root embedding rebuild preserves and fences both roots through partial failure; shared remote endpoint throttling and effective-home capacity exhaustion are reported as explicit resource couplings without cross-role state mixing. |
 | `MEMORY-AGENT-008` | Both role sidecars reject every payload outside their exact owner/shape contract. |
 | `MEMORY-AGENT-009` | CLI/UI retrieval is explicit, bounded, inert, and absent from Agent prompts/install paths; a read-only per-Agent project catalog keeps removed-binding output reachable. |
 | `MEMORY-AGENT-010` | Accepted processing with zero cases or skills is a truthful valid outcome. |

--- a/docs/plans/memory-agent-track-1424.md
+++ b/docs/plans/memory-agent-track-1424.md
@@ -40,7 +40,8 @@ Personal Memory admission, prompt, provider root, queue, or retrieval semantics.
    result. It does not parse formatted event streams into synthetic tool calls.
 7. Enabling the track does not create a project binding. The owner must bind a
    source workdir to either the exact `default` project or an existing/new-style
-   named Memory project. Missing bindings fail closed.
+   named Memory project. Missing bindings fail closed. Binding additions,
+   reassignments, and removals use commit-ordered high-water epochs.
 8. EverOS 1.2.3 limitations listed below are accepted. Avibe isolates and
    reports them but does not patch EverOS or file an upstream issue. Retrieval
    exposes skill freshness/maturity metadata, and status adds a conservative
@@ -86,6 +87,9 @@ trajectory content: user/Agent-authored identifiers and Avibe-injected time,
 source-Session, username, or user-id attribution lines present in those texts
 are retained locally and forwarded to the processing endpoints. They are never
 used as structural Memory owners, project selectors, or provider paths.
+The binding control also discloses that removal or reassignment stops eligibility
+for later-settling Turns, while already-settled backlog through its committed
+cutover remains eligible under the old project.
 
 Enabling requires the installed Memory runtime, complete processing endpoints,
 and at least one explicit project binding. Under the agent-capture lifecycle
@@ -279,9 +283,9 @@ Reconcile owns the roles independently:
   controller lifecycle; no routine verification restarts Avibe.
 
 Restart engine, Repair index, Clear Memory Data, rebuild, and factory reset must
-enumerate role-owned resources rather than assuming one global slot. A
-never-enabled Agent role whose root, sentinel, process record, and socket are all
-absent is a successful `absent` no-op. A present Agent path without its expected
+enumerate role-owned resources rather than assuming one global slot. Either
+never-enabled role whose root, sentinel, process record, and socket are all
+absent is a successful `absent` no-op. A present role path without its expected
 sentinel remains unsafe and fails closed. Clear and factory reset cover every
 existing owned root, both role call-log/health records, and both queues under one
 existing durable maintenance fence while preserving the V2 config binding
@@ -326,7 +330,8 @@ cursor. Pre-migration terminal rows retain `NULL` and are not backfilled.
 
 Before enqueue, the store enforces an independent maximum of 500 nonterminal
 Agent rows and at least 512 MiB free on the volume containing `memory.sqlite`.
-At either guard, the scanner records a durable aggregate
+At either guard, the scanner durably declines the otherwise semantically
+eligible source: it records an aggregate
 `missed_queue_full`/`missed_low_disk_space` count and advances past that source
 sequence in the same transaction; it never retains the rejected trajectory
 text. These guards are independent of, and do not consume, Personal Memory's
@@ -356,29 +361,51 @@ ambiguous agent write cannot fence user capture.
 ### Scanner cursor and project bindings
 
 `memory_agent_scan_state` is a singleton containing the last committed terminal
-sequence, enable epoch, optional drain-through sequence/state, durable missed
-counters, and scan/update timestamps. On
-every enable cutover the cursor advances to the primary store's current maximum
-before admission opens. Clear and factory-reset recovery apply the same cutover
+sequence, enable epoch, optional disable/binding drain-through sequence/state,
+durable missed counters, and scan/update timestamps. On every enable cutover
+the cursor advances to the primary store's current maximum before admission
+opens. Clear and factory-reset recovery apply the same cutover
 after deleting or recreating the Memory store: while the shared maintenance
 fence is held, they create the new scan state at the current committed maximum,
 then rebuild bindings, and only then may an enabled scanner start. The scanner
 queries strictly after that sequence in bounded pages. It advances through
 admitted, duplicate, guarded, and closed-skip rows only after the corresponding
 decision is durable. A crash before commit re-reads the same row; the digest
-keeps enqueue idempotent. Adding a binding later does not backfill turns already
-skipped at an earlier cursor.
+keeps enqueue idempotent.
 
-`memory_agent_project_bindings` is a replaceable projection of the V2 config. It
-maps only opaque `binding_key` to exact new-style `project_id`, with
-created/updated timestamps. Settings writes the normalized workdir/project pair
-to V2 config; reconcile derives the opaque key with the current Memory scope key
-and transactionally replaces the projection. Reads expose the config's friendly
-local workdir label, never by reversing the opaque Memory key. Clear may remove
-the projection; factory reset creates a new Memory scope key and rebuilds every
-opaque key from the preserved config before an enabled scanner starts. Deleting
-a config binding stops new admission after reconcile and does not rewrite queued
-or provider data already bound to that project.
+`memory_agent_project_bindings` is an opaque, sequence-versioned projection of
+the V2 config. Each epoch stores `binding_key`, exact new-style `project_id`, an
+exclusive `effective_after_sequence`, an optional inclusive
+`effective_through_sequence`, and created/closed timestamps. The V2 config
+remains the authoritative current owner setting; historical epochs exist only
+to finish committed scanner work.
+
+Under the agent-capture lifecycle lock, every add, reassignment, or removal reads
+the current committed terminal high water `H`. Before the V2 config commit, a
+singleton `memory_agent_binding_reconcile` intent durably records `H`, the
+current and desired config digests, and only the opaque epoch changes. After the
+config commit, reconcile applies those epochs and clears the intent. Startup
+compares the authoritative config digest and either completes the desired
+cutover or discards an intent whose config commit never occurred; a crash cannot
+invent a later cutover.
+
+An added mapping is effective only for `terminal_sequence > H`. Reassignment
+closes the old epoch through `H` and opens the new project after `H`; removal
+only closes the old epoch through `H`. The scanner resolves each source against
+the unique epoch satisfying
+`effective_after_sequence < terminal_sequence <= effective_through_sequence`,
+with a `NULL` through-sequence meaning open. It therefore drains backlog through
+the old project without admitting opt-in or reassignment history to the new
+project. Closed epochs remain until the committed scanner cursor reaches their
+cutover, then compact; immutable queued/provider rows keep their original
+project.
+
+Settings writes friendly normalized workdir/project pairs only to V2 config;
+reconcile derives opaque keys with the current Memory scope key. Reads expose
+the current config labels, never by reversing an opaque key. Clear may remove
+all epochs; factory reset creates a new Memory scope key and rebuilds current
+bindings with an effective-after cutover at the new high water before an enabled
+scanner starts.
 
 ## Provider and Sidecar Contracts
 
@@ -481,11 +508,11 @@ stable ids:
 
 | ID | Invariant |
 |---|---|
-| `MEMORY-AGENT-001` | The absent/default config leaves the second root, scanner, and worker off; disable drains its enabled interval, and every enable or destructive reset starts at the correct high water. |
-| `MEMORY-AGENT-002` | Every eligible non-steered completed interactive or Harness Turn is represented once by its exact dispatch/result pair. |
+| `MEMORY-AGENT-001` | The absent/default config leaves the second root, scanner, and worker off; disable snapshots then drains its enabled interval, every enable/reset starts at the correct high water, and Clear accepts either never-created role as absent. |
+| `MEMORY-AGENT-002` | Every semantically eligible non-steered completed interactive or Harness Turn not durably declined by a specified resource guard is represented once by its exact dispatch/result pair. |
 | `MEMORY-AGENT-003` | Admission excludes every terminal shape that does not satisfy the completed-result invariant, including accepted live steers. |
 | `MEMORY-AGENT-004` | Commit ordering and crash/replay cannot lose or enqueue one source Turn more than once. |
-| `MEMORY-AGENT-005` | Agent and project partitions cannot read or write each other's output. |
+| `MEMORY-AGENT-005` | Agent and project partitions cannot read or write each other's output; crash-safe sequence-versioned binding cutovers keep backlog in the project effective at settlement. |
 | `MEMORY-AGENT-006` | Malformed config, legacy Agent identity, and missing project binding fail closed. |
 | `MEMORY-AGENT-007` | Agent-sidecar outage leaves chat and Personal Memory healthy. |
 | `MEMORY-AGENT-008` | Both role sidecars reject every payload outside their exact owner/shape contract. |

--- a/docs/plans/memory-agent-track-1424.md
+++ b/docs/plans/memory-agent-track-1424.md
@@ -25,9 +25,12 @@ Personal Memory admission, prompt, provider root, queue, or retrieval semantics.
    ownership record, lifecycle supervisor, health projection, and retention
    slot. No reconcile or maintenance operation may mode-flip an existing root.
 2. The durable source is `session_turns`, joined to `agent_sessions`, not
-   Harness-specific `agent_runs`. Both interactive and Harness turns are
-   eligible under the same rules. Each new Turn snapshots the exact executing
-   `agents.id`; mutable Session routing is not execution identity.
+   Harness-specific `agent_runs`. The shared execution owner is extended to
+   create these rows for Workbench and every supported IM transport as well as
+   Harness dispatch; platform transcript mirroring is not a trajectory source.
+   All interactive and Harness turns use the same eligibility rules. Each new
+   Turn snapshots the exact executing `agents.id`; mutable Session routing is
+   not execution identity.
 3. A controller-owned background scanner copies eligible terminal turns into a
    separate schema-v4 queue. Terminal settlement and backend adapters do no
    Memory I/O and await no Memory work.
@@ -56,8 +59,9 @@ Personal Memory admission, prompt, provider root, queue, or retrieval semantics.
    digest, or cancels it when the prior digest remains. Clear and factory reset
    retain their documented primary-state destructive-recovery cutover. The
    Memory scan state is an idempotent projection of those records. There is no
-   historical, disabled-period, or post-reset replay in v1; only turns settling
-   inside a committed enabled epoch are candidates.
+   historical, disabled-period, or post-reset replay in v1; only turns admitted
+   at dispatch and settling inside the same committed enabled epoch are
+   candidates.
 
 ## Product Contract
 
@@ -87,7 +91,8 @@ The owner Settings surface explains that eligible Agent inputs and results may
 be sent to the configured Memory processing endpoints, that accepted processing
 may produce no case or skill, and that the feature inherits the documented
 EverOS 1.2.3 limitations. The source set is fixed to eligible completed Agent
-Turns, including interactive and Harness turns; v1 has no source-type selector.
+Turns from Workbench, Slack, Discord, Telegram, Feishu/Lark, WeChat, and Harness;
+v1 has no source-type or platform selector.
 The disclosure also states that the exact backend dispatch and final result are
 trajectory content: user/Agent-authored identifiers and Avibe-injected time,
 source-Session, username, or user-id attribution lines present in those texts
@@ -98,9 +103,17 @@ for later-settling Turns, while already-settled backlog through its committed
 cutover remains eligible under the old project.
 
 Enabling requires the installed Memory runtime, complete processing endpoints,
-and at least one explicit project binding. Under the agent-capture lifecycle
-lock, an enable/disable Settings write first uses one serialized primary state
-transaction to read terminal high water `H` and insert a singleton prepared
+and at least one explicit project binding. The UI validates the candidate but
+does not persist `agent_track` settings itself. It sends the candidate plus its
+expected prior config digest to one authenticated controller IPC operation,
+`apply_agent_memory_settings`. The controller owns the complete
+capture/binding/config/claim transition under the same lifecycle lock used by
+scanner, Clear, and reset orchestration; a process-local UI lock is not a
+correctness boundary. If the controller is unavailable, the request fails before
+any mutation.
+
+The controller first uses one serialized primary state transaction to read
+terminal high water `H` and insert a singleton prepared
 `memory_agent_capture_cutover` intent with a new capture epoch, prior and desired
 config digests, desired enabled state, and `H`. Terminal settlement cannot
 interleave between that read and intent commit. The scanner is fenced, then the
@@ -152,6 +165,9 @@ these invariants hold:
   one non-empty final `result_text`;
 - immutable `backend_dispatch_text` and the final result are valid, nonempty
   UTF-8 text of at most 256 KiB each;
+- the dispatch snapshot was admitted while one committed capture epoch was
+  enabled, and the Turn settled inside that same epoch; a Turn crossing enable,
+  disable, Clear, or reset is excluded;
 - no accepted live-steer Delivery is linked to the Turn; v1 excludes steered
   Turns because their accepted instruction text is not durably available after
   materialization and cannot satisfy the exact two-message contract;
@@ -172,17 +188,29 @@ Harness request therefore cannot coalesce with a callback even when both use the
 same trigger/backend/Session.
 
 After scheduled attribution, transcription, attachment/file formatting, and all
-other input transformations finish, the shared start boundary persists
-`backend_dispatch_text` plus its digest before invoking the native adapter. The
-adapter must send exactly that stored text. A failed persistence makes no native
-call; an automatic start retry reuses the snapshot instead of re-running a
-text-changing transform. Backend-native acceptance can therefore never precede
-the durable exact input used by Agent Memory.
+other input transformations finish, the shared start boundary checks the
+controller-projected primary capture epoch without opening the Memory store. If
+that epoch is committed enabled, the exact UTF-8 text is at most 256 KiB, and the
+global primary snapshot budget remains below 128 MiB, one primary transaction
+reserves its byte count and persists `backend_dispatch_text`, digest, and capture
+epoch before invoking the native adapter. The adapter must send exactly that
+stored text; an automatic start retry reuses it instead of re-running a
+text-changing transform.
+
+Disabled/transitioning epochs, oversized text, or an exhausted snapshot budget
+record only a closed omission reason and small counter; they never retain the
+text or block native dispatch. A successful config transition cannot retroactively
+admit an in-flight Turn that omitted its snapshot. Persistence failure for a
+snapshot that was admitted still fails closed before native start, because the
+candidate could otherwise diverge from the adapter input. Backend-native
+acceptance can therefore never precede the durable exact input used by an
+Agent-Memory candidate.
 
 The property is deliberately positive. Every terminal shape not satisfying the
 complete invariant is skipped, including failed, canceled, stopped/restarted,
-silent, missing-result, missing-final-dispatch, malformed-evidence, oversized,
-accepted-steer, callback-class, and unbound turns. Admission logs only a closed
+silent, missing-result, missing/guarded final-dispatch, epoch-crossing,
+malformed-evidence, oversized, accepted-steer, callback-class, and unbound turns.
+Admission logs only a closed
 reason and opaque source digest.
 
 The v1 trajectory has exactly two ordered messages:
@@ -260,9 +288,14 @@ is never retrieval identity. It accepts no caller-supplied Turn id, raw
 Omitting `--project` uses the Session workdir's current explicit binding. An
 explicit value must be either that binding or an exact project retained in this
 executing Agent's read-only project catalog; without either, access fails closed.
-The owner Settings UI may select an installed Agent and one exact current or
-cataloged historical project. It may search and list `agent_case` and
-`agent_skill` with the same per-kind and response-size bounds.
+The owner Settings UI may select an installed Agent or a read-only deleted-Agent
+tombstone and one exact current or cataloged historical project. A deleted
+selector is synthesized from the opaque project catalog and labelled `Deleted
+Agent <opaque-suffix>`; it exposes neither the former raw Agent id nor a
+caller-controlled provider filter. The CLI remains bound to its executing Turn,
+so deleted-Agent retrieval is an owner-UI-only operation. Both surfaces search
+and list `agent_case` and `agent_skill` with the same per-kind and response-size
+bounds.
 
 Results are provider-neutral records labelled `case` or `skill`. Every skill in
 human-readable, JSON, and UI search/list output includes its `updated_at` as a
@@ -280,17 +313,17 @@ prompt and `vibe memory search/list` contracts remain byte-for-byte unchanged by
 the new CLI examples and parser registration.
 
 Memory status also reports a content-free skill-count observation for each
-installed Agent across that Agent's current and cataloged historical projects.
-An explicit
-status refresh may advance one durable, stable-order sampling cursor at most
+installed or cataloged deleted Agent across that Agent's current and cataloged
+historical projects. An explicit status refresh may advance one durable,
+stable-order sampling cursor at most
 once per 60 seconds. One sampler batch issues at most 32 scoped `total_count`
 requests with concurrency at most two, caches only count/observed-at metadata,
 and resumes at the next Agent/project pair; status rendering never fans out its
 own provider reads. An Agent count is complete only after all of its current
 retrievable projects have been observed in the same sampling generation;
-otherwise it is `unknown` or explicitly stale. Removed Agents invalidate their
-cache; binding removal keeps observations through the retained project catalog
-entry.
+otherwise it is `unknown` or explicitly stale. Hard deletion relabels but does
+not invalidate a cataloged Agent's cache; binding removal likewise retains
+observations through the project catalog entry.
 
 A complete count reports `normal` for 0-7, `approaching` for 8-10, and `risk`
 above 10. The hint says explicitly that this total is a conservative proxy:
@@ -377,8 +410,19 @@ primary Avibe state schema:
 - `source_class TEXT`, constrained on new writes to `interactive`,
   `harness_request`, `callback`, `maintenance`, or `agent_callback`;
 - `backend_dispatch_text TEXT` and `backend_dispatch_sha256 TEXT`, the exact
-  final backend-facing input and digest; and
+  bounded final backend-facing input and digest;
+- `backend_dispatch_capture_epoch INTEGER` and
+  `backend_dispatch_omission_reason TEXT`, the admitted epoch or a closed
+  `disabled | transition | oversized | budget` reason, never both; and
 - `terminal_sequence INTEGER`, with a unique partial index.
+
+The shared `MessageHandler`/dispatch boundary creates the same durable Delivery
+and Turn owner for Workbench and every supported IM execution before native
+dispatch. IM adapters continue to provide transport context and transcript
+mirroring, but no adapter-specific mirror row is a Memory source.
+`persist_silent_terminal` remains activity evidence rather than a trajectory;
+the shared owner now also settles the corresponding IM Turn. Harness uses its
+existing durable path.
 
 The initial Delivery claim/Turn creation transaction snapshots
 `executing_agent_id` from the resolved execution route, including an explicit
@@ -398,11 +442,18 @@ Delivery can queue; batching compatibility and Turn claim use the column rather
 than reparsing later mutable metadata. Pre-migration/missing classes remain
 fail-closed for Agent Memory but do not block ordinary execution.
 
-Immediately before the first native start call, after every shared/backend input
-transformation, a primary state transaction compares-and-sets
-`backend_dispatch_text` and its SHA-256 digest. The adapter receives that exact
+The primary schema also keeps a singleton snapshot-byte reservation capped at
+128 MiB. Immediately before the first native start call, after every
+shared/backend input transformation, a primary state transaction checks the
+committed capture epoch and per-row 256 KiB bound, reserves bytes, and
+compares-and-sets the admitted text/digest/epoch. The adapter receives that exact
 stored value. A retry must reuse it and a conflicting second value fails closed;
-Memory never derives input from the earlier raw `dispatch_text`.
+Memory never derives candidate input from the earlier raw `dispatch_text`.
+When no snapshot is admitted, the same transaction writes only the closed
+omission reason and the adapter proceeds with its in-memory final text.
+Startup and periodic primary-state maintenance recompute the reservation from
+the UTF-8 byte lengths of actual nonempty snapshots before admitting more, so a
+crash cannot leak budget.
 
 The transaction that first settles a Turn terminal assigns one greater than the
 maximum non-NULL `terminal_sequence` (or `1` when none exists) while holding
@@ -412,6 +463,17 @@ Consequently sequence order is settlement commit order even when wall time
 moves backward or UUIDs sort in another order. `terminal_at` remains display
 metadata and is never a scanner cursor. Pre-migration Turn rows retain `NULL`
 for every new field and are not backfilled.
+
+Terminal settlement in a disabled or different capture epoch clears any
+snapshot and releases its byte reservation in the same primary transaction.
+For an eligible terminal Turn, the scanner clears the primary snapshot and
+releases the reservation after its enqueue, duplicate, guarded decline, or
+closed skip is durable. A crash between the Memory-store decision and that
+cleanup is repaired idempotently by comparing terminal sequence with the durable
+scanner cursor. Abandoned-Turn recovery uses the same cleanup. Clear and factory
+reset bulk-scrub every terminal snapshot through their post-deletion high water
+before scan state is recreated. Thus the primary duplicate is bounded while
+live and does not survive final disposition or destructive reset.
 
 The primary state schema also adds bounded singleton
 `memory_agent_capture_cutover` and `memory_agent_binding_cutover` recovery
@@ -492,14 +554,23 @@ only with the Agent root's Clear/factory reset, or a future explicit
 provider-data deletion contract. A catalog entry does not claim that EverOS
 produced output.
 
-Under the agent-capture lifecycle lock, every add, reassignment, or removal first
-uses one serialized primary state transaction to read the current committed
+Installed Agents are joined to catalog owners by recomputing their opaque
+`agent_id`. A catalog owner with no live join remains a read-only deleted-Agent
+tombstone instead of becoming unreachable. Owner Settings issues a bounded
+opaque selection token for that exact catalog owner; requests never accept a raw
+`agent_id`. Hard deletion therefore remains unconstrained and does not delete
+or orphan queued/provider data.
+
+The same controller `apply_agent_memory_settings` IPC owns every binding add,
+reassignment, and removal under the shared lifecycle lock. It first uses one
+serialized primary state transaction to read the current committed
 terminal high water `H` and insert a prepared singleton
 `memory_agent_binding_cutover` intent containing the prior/desired config digests
 and `H`. Terminal settlement cannot interleave between that read and intent
 commit. The scanner is then fenced, V2 config is atomically replaced, and the
 intent is promoted to committed; terminal settlement performs no Memory/config
-I/O and never waits for projection work.
+I/O and never waits for projection work. The UI does not write these bindings
+before contacting the controller.
 
 When one Settings save changes both `enabled` and bindings, that same primary
 writer transaction records the capture and binding intents at one shared `H`.
@@ -626,8 +697,9 @@ repair, or rewrite any skill.
 1. **Spec:** this contract plus the canonical product/recovery documentation.
    No runtime behavior changes.
 2. **Infrastructure:** schema v4, config/identity/project-binding primitives,
-   dual-root lifecycle, provider port, role-specific sidecar/recorder contracts,
-   and focused migrations/fixtures. Capture remains inactive.
+   platform-neutral Workbench/IM/Harness Turn ownership, dual-root lifecycle,
+   provider port, role-specific sidecar/recorder contracts, and focused
+   migrations/fixtures. Capture remains inactive.
 3. **Capture:** durable scanner/read port, admission, enqueue, worker/delivery,
    lifecycle composition, and degradation tests.
 4. **Retrieval:** scoped CLI/internal API, owner Settings enablement/binding,
@@ -646,17 +718,17 @@ stable ids:
 
 | ID | Invariant |
 |---|---|
-| `MEMORY-AGENT-001` | The absent/default config leaves the second root, scanner, and worker off; pre-config primary-state capture intents make enable/disable/reset cutovers crash-atomic with Turn settlement without recovery-time boundary drift, and Clear accepts either never-created role as absent. |
-| `MEMORY-AGENT-002` | Every semantically eligible non-steered completed interactive or Harness Turn not durably declined by a specified resource guard is represented once by its exact post-transformation backend-dispatch/result pair. |
+| `MEMORY-AGENT-001` | The absent/default config leaves the second root, scanner, and worker off; one controller IPC owns prepared settings cutovers, post-deletion reset high waters do not drift on recovery, and Clear accepts either never-created role as absent. |
+| `MEMORY-AGENT-002` | Every semantically eligible non-steered completed Workbench, Slack, Discord, Telegram, Feishu/Lark, WeChat, or Harness Turn not durably declined by a specified snapshot/queue/disk guard is represented once by its exact post-transformation backend-dispatch/result pair. |
 | `MEMORY-AGENT-003` | Admission excludes every terminal shape that does not satisfy the completed-result invariant; source-class batching separates callbacks and accepted live steers are excluded. |
 | `MEMORY-AGENT-004` | Commit ordering and crash/replay cannot lose or enqueue one source Turn more than once. |
-| `MEMORY-AGENT-005` | Agent and project partitions cannot read or write each other's output; capture and trusted-Turn CLI retrieval use the immutable executing Agent without blocking hard deletion, and crash-safe prepared binding cutovers keep backlog in the project effective at settlement. |
+| `MEMORY-AGENT-005` | Agent and project partitions cannot read or write each other's output; capture and trusted-Turn CLI retrieval use the immutable executing Agent without blocking hard deletion, deleted owners remain UI-retrievable, and crash-safe prepared binding cutovers keep backlog in the project effective at settlement. |
 | `MEMORY-AGENT-006` | Malformed config, missing/pre-migration identity/source/final-dispatch snapshots, and missing project binding fail closed. |
 | `MEMORY-AGENT-007` | Agent-sidecar/local pipeline outage leaves chat and Personal Memory healthy; shared remote endpoint throttling is reported as an external quota coupling without cross-role state corruption. |
 | `MEMORY-AGENT-008` | Both role sidecars reject every payload outside their exact owner/shape contract. |
 | `MEMORY-AGENT-009` | CLI/UI retrieval is explicit, bounded, inert, and absent from Agent prompts/install paths; a read-only per-Agent project catalog keeps removed-binding output reachable. |
 | `MEMORY-AGENT-010` | Accepted processing with zero cases or skills is a truthful valid outcome. |
-| `MEMORY-AGENT-011` | Queue/disk exhaustion skips durably, and 90-day/100,000-row tombstone compaction bounds closed-row storage without degrading Personal Memory. |
+| `MEMORY-AGENT-011` | Per-row/global primary snapshot guards plus queue/disk exhaustion skip durably; primary copies are scrubbed after disposition/reset, and 90-day/100,000-row tombstone compaction bounds closed-row storage without degrading Personal Memory. |
 | `MEMORY-AGENT-012` | Skill retrieval exposes exact freshness/maturity metadata, while the request-budgeted status sampler reports non-blocking per-Agent count hints at 8 and 11 skills. |
 | `MEMORY-AGENT-013` | Opt-in disclosure models raw attribution bytes in exact trajectory content without allowing them to become Memory identity or scope. |
 

--- a/docs/plans/memory-agent-track-1424.md
+++ b/docs/plans/memory-agent-track-1424.md
@@ -26,13 +26,14 @@ Personal Memory admission, prompt, provider root, queue, or retrieval semantics.
    slot. No reconcile or maintenance operation may mode-flip an existing root.
 2. The durable source is `session_turns`, joined to `agent_sessions`, not
    Harness-specific `agent_runs`. Both interactive and Harness turns are
-   eligible under the same rules.
+   eligible under the same rules. Each new Turn snapshots the exact executing
+   `agents.id`; mutable Session routing is not execution identity.
 3. A controller-owned background scanner copies eligible terminal turns into a
    separate schema-v4 queue. Terminal settlement and backend adapters do no
    Memory I/O and await no Memory work.
-4. EverOS `agent_id` is derived from immutable `agents.id` with the install-local
-   Memory scope key. Mutable Agent names and user principals are never agent
-   owners.
+4. EverOS `agent_id` is derived from the Turn's immutable executing `agents.id`
+   snapshot with the install-local Memory scope key. Mutable Session routing,
+   Agent names, and user principals are never agent owners.
 5. Agent/project retrieval is explicit, lazy, inert, and bounded. Agent Memory
    is never injected into a prompt, installed as a Codex/Claude skill, or
    executed.
@@ -113,9 +114,10 @@ restarting the Avibe service.
 ### Admission
 
 One durable `session_turns` row is one candidate trajectory. The scanner reads
-in stable `terminal_sequence` order and joins the owning `agent_sessions` row
-and its referenced `agents` row. Admission is provider-neutral and accepts a
-row only when all of these invariants hold:
+in stable `terminal_sequence` order, joins the owning `agent_sessions` row for
+source workdir/provenance classification, and joins
+`session_turns.executing_agent_id` to the referenced `agents` row. Admission is
+provider-neutral and accepts a row only when all of these invariants hold:
 
 - the turn is terminal with `terminal_outcome="completed"`;
 - `terminal_evidence_kind="terminal_result"` and the versioned evidence contains
@@ -125,9 +127,10 @@ row only when all of these invariants hold:
 - no accepted live-steer Delivery is linked to the Turn; v1 excludes steered
   Turns because their accepted instruction text is not durably available after
   materialization and cannot satisfy the exact two-message contract;
-- the session's `agent_id` resolves to a real `agents.id`; legacy name-only
-  sessions fail closed, while later Agent disable/archive does not rewrite an
-  already completed Turn's identity;
+- the Turn's immutable `executing_agent_id` resolves to a real `agents.id`;
+  legacy/pre-migration or backend-only Turns without that snapshot fail closed,
+  while later Session rerouting or Agent rename/disable/archive does not rewrite
+  an already admitted Turn's identity;
 - the source is an ordinary interactive or Harness-request turn, not a callback,
   system maintenance action, or Agent-to-Agent completion callback; and
 - the session workdir resolves through an explicit opaque binding to exactly one
@@ -171,6 +174,9 @@ The Memory store's install-local `scope_key` derives both opaque identities:
 agent_id    = "a-" + HMAC_SHA256(scope_key, "agent:" + agents.id).hex()[:32]
 binding_key = "b-" + HMAC_SHA256(scope_key, "agent-project:" + normalized_workdir).hex()[:32]
 ```
+
+Here `agents.id` is the Turn's immutable `executing_agent_id` snapshot, never a
+later read of the Session's current route.
 
 The raw Agent id, Agent name, workdir, Session id, Turn id, Run id, platform
 identity, and user principal are never structural Memory columns, owner/filter
@@ -306,16 +312,35 @@ invariants.
 
 ### Commit-ordered terminal source
 
-The infrastructure slice also adds nullable
-`session_turns.terminal_sequence INTEGER` plus a unique partial index in the
-primary Avibe state schema. The transaction that first settles a Turn terminal
-assigns one greater than the maximum non-NULL `terminal_sequence` (or `1` when
-none exists) while holding SQLite's serialized writer lock. The assignment,
-terminal outcome/evidence, and terminal state commit
-together; retries cannot allocate a second value. Consequently sequence order
-is settlement commit order even when wall time moves backward or UUIDs sort in
-another order. `terminal_at` remains display metadata and is never a scanner
-cursor. Pre-migration terminal rows retain `NULL` and are not backfilled.
+The infrastructure slice adds two nullable columns to `session_turns` in the
+primary Avibe state schema:
+
+- `executing_agent_id TEXT NULL REFERENCES agents(id) ON DELETE NO ACTION`, an
+  indexed reference to the stable Agent selected by the final execution route;
+  and
+- `terminal_sequence INTEGER`, with a unique partial index.
+
+The initial Delivery claim/Turn creation transaction snapshots
+`executing_agent_id` from the resolved execution route, including an explicit
+Harness/task override. This is observational for Memory: inability to resolve a
+stable Agent id does not block the Turn, but leaves the field `NULL` and makes
+that Turn ineligible for Agent Memory. Retries preserve the first snapshot, and
+no later Session route update may rewrite it.
+
+The transaction that first settles a Turn terminal assigns one greater than the
+maximum non-NULL `terminal_sequence` (or `1` when none exists) while holding
+SQLite's serialized writer lock. The assignment, terminal outcome/evidence,
+and terminal state commit together; retries cannot allocate a second value.
+Consequently sequence order is settlement commit order even when wall time
+moves backward or UUIDs sort in another order. `terminal_at` remains display
+metadata and is never a scanner cursor. Pre-migration terminal rows retain
+`NULL` for both new fields and are not backfilled.
+
+The primary state schema also adds the singleton
+`memory_agent_binding_cutover` recovery record used below. It contains only a
+desired config digest, terminal high water, state, and timestamps; normalized
+workdirs and project ids remain in V2 config, while opaque epochs remain in the
+Memory store.
 
 ### Agent trajectory outbox
 
@@ -377,17 +402,34 @@ keeps enqueue idempotent.
 the V2 config. Each epoch stores `binding_key`, exact new-style `project_id`, an
 exclusive `effective_after_sequence`, an optional inclusive
 `effective_through_sequence`, and created/closed timestamps. The V2 config
-remains the authoritative current owner setting; historical epochs exist only
-to finish committed scanner work.
+remains the authoritative desired owner setting. The projection also stores its
+`applied_config_digest`; historical epochs exist only to finish committed
+scanner work.
 
-Under the agent-capture lifecycle lock, every add, reassignment, or removal reads
-the current committed terminal high water `H`. Before the V2 config commit, a
-singleton `memory_agent_binding_reconcile` intent durably records `H`, the
-current and desired config digests, and only the opaque epoch changes. After the
-config commit, reconcile applies those epochs and clears the intent. Startup
-compares the authoritative config digest and either completes the desired
-cutover or discards an intent whose config commit never occurred; a crash cannot
-invent a later cutover.
+Under the agent-capture lifecycle lock, every add, reassignment, or removal first
+persists the desired V2 config atomically. It then uses one serialized primary
+state transaction to read the current committed terminal high water `H` and
+insert a singleton `memory_agent_binding_cutover` intent containing the desired
+config digest and `H`. Terminal settlement cannot interleave between that read
+and intent commit, but it performs no Memory/config I/O and never waits for
+projection work.
+
+While an intent exists, Agent scanner admission is fenced. One idempotent Memory
+transaction appends/closes the opaque epochs at the intent's exact `H` and
+advances `applied_config_digest`; only then may recovery clear the primary-state
+intent and reopen the scanner. The binding becomes sequence-effective at the
+intent commit, and the Settings save reports success only after projection
+converges. A Turn settled before that commit is at or below `H` and uses the old
+mapping; a later Turn is above `H` and uses the new mapping when scanning resumes.
+
+If Avibe stops after config commit but before the cutover intent, startup sees
+the digest mismatch and creates the intent with a new recovery-time high water.
+If it stops after the intent, recovery reuses that exact `H`; if projection
+already committed, matching digests make intent cleanup idempotent. Until
+convergence status reports binding reconcile as degraded and only the Agent
+scanner is fenced. If config persistence fails, no intent is created and the
+projection is unchanged. A crash therefore cannot backdate the new binding or
+block the Agent hot path.
 
 An added mapping is effective only for `terminal_sequence > H`. Reassignment
 closes the old epoch through `H` and opens the new project after `H`; removal
@@ -512,8 +554,8 @@ stable ids:
 | `MEMORY-AGENT-002` | Every semantically eligible non-steered completed interactive or Harness Turn not durably declined by a specified resource guard is represented once by its exact dispatch/result pair. |
 | `MEMORY-AGENT-003` | Admission excludes every terminal shape that does not satisfy the completed-result invariant, including accepted live steers. |
 | `MEMORY-AGENT-004` | Commit ordering and crash/replay cannot lose or enqueue one source Turn more than once. |
-| `MEMORY-AGENT-005` | Agent and project partitions cannot read or write each other's output; crash-safe sequence-versioned binding cutovers keep backlog in the project effective at settlement. |
-| `MEMORY-AGENT-006` | Malformed config, legacy Agent identity, and missing project binding fail closed. |
+| `MEMORY-AGENT-005` | Agent and project partitions cannot read or write each other's output; the Turn snapshots its executing Agent, and crash-safe post-config binding cutovers keep backlog in the project effective at settlement. |
+| `MEMORY-AGENT-006` | Malformed config, a missing/pre-migration executing-Agent snapshot, and missing project binding fail closed. |
 | `MEMORY-AGENT-007` | Agent-sidecar outage leaves chat and Personal Memory healthy. |
 | `MEMORY-AGENT-008` | Both role sidecars reject every payload outside their exact owner/shape contract. |
 | `MEMORY-AGENT-009` | CLI/UI retrieval is explicit, bounded, inert, and absent from Agent prompts/install paths. |

--- a/docs/plans/memory-agent-track-1424.md
+++ b/docs/plans/memory-agent-track-1424.md
@@ -45,10 +45,11 @@ Personal Memory admission, prompt, provider root, queue, or retrieval semantics.
    reports them but does not patch EverOS or file an upstream issue. Retrieval
    exposes skill freshness/maturity metadata, and status adds a conservative
    per-Agent skill-count hint; neither mitigation mutates provider state.
-9. Every disabled-to-enabled transition, Clear, and factory reset initializes
-   the scan cursor to the current terminal-settlement sequence high water mark
+9. Every disable snapshots and drains through its current terminal-settlement
+   sequence high water. Every disabled-to-enabled transition, Clear, and
+   factory reset initializes the scan cursor to the then-current high water
    before scanner admission opens. There is no historical, disabled-period, or
-   post-reset replay in v1; only turns settling after that explicit cutover are
+   post-reset replay in v1; only turns settling inside an enabled epoch are
    candidates.
 
 ## Product Contract
@@ -80,15 +81,28 @@ be sent to the configured Memory processing endpoints, that accepted processing
 may produce no case or skill, and that the feature inherits the documented
 EverOS 1.2.3 limitations. The source set is fixed to eligible completed Agent
 Turns, including interactive and Harness turns; v1 has no source-type selector.
+The disclosure also states that the exact backend dispatch and final result are
+trajectory content: user/Agent-authored identifiers and Avibe-injected time,
+source-Session, username, or user-id attribution lines present in those texts
+are retained locally and forwarded to the processing endpoints. They are never
+used as structural Memory owners, project selectors, or provider paths.
 
 Enabling requires the installed Memory runtime, complete processing endpoints,
 and at least one explicit project binding. Under the agent-capture lifecycle
 lock, every disabled-to-enabled operation snapshots the current committed
 terminal-sequence high water, persists it as the new scan cursor, rebuilds the
 opaque binding projection, and only then opens scanner admission. A disable
-closes scanner admission and waits for the current bounded scan transaction
-before it reports success. It preserves rows admitted before that cutover but
-never later imports turns settled while disabled. A failed start leaves the
+atomically records the current terminal high water as a durable drain target and
+closes the enable epoch and new Agent provider claims. Disable waits for any
+current bounded provider request to settle before stopping the worker and
+sidecar; after that worker-quiescence point, no provider write may start. The
+scanner meanwhile enters local-only
+`disabling` mode and durably enqueues/skips every source through the drain
+target. Only then does the scanner stop and status become `disabled`. Crash
+recovery resumes an unfinished drain. Rows enqueued during the drain remain
+pending without provider I/O and become claimable only after a later enable.
+Re-enable first requires that drain to converge, then advances the cursor past
+the disabled interval before opening a new epoch. A failed start leaves the
 agent-track projection unavailable without disabling Personal Memory or
 restarting the Avibe service.
 
@@ -104,6 +118,9 @@ row only when all of these invariants hold:
   one non-empty final `result_text`;
 - immutable `dispatch_text` and the final result are valid, nonempty UTF-8 text
   of at most 256 KiB each;
+- no accepted live-steer Delivery is linked to the Turn; v1 excludes steered
+  Turns because their accepted instruction text is not durably available after
+  materialization and cannot satisfy the exact two-message contract;
 - the session's `agent_id` resolves to a real `agents.id`; legacy name-only
   sessions fail closed, while later Agent disable/archive does not rewrite an
   already completed Turn's identity;
@@ -114,8 +131,8 @@ row only when all of these invariants hold:
 
 The property is deliberately positive. Every terminal shape not satisfying the
 complete invariant is skipped, including failed, canceled, stopped/restarted,
-silent, missing-result, malformed-evidence, oversized, and unbound turns.
-Admission logs only a closed reason and opaque source digest.
+silent, missing-result, malformed-evidence, oversized, accepted-steer, and
+unbound turns. Admission logs only a closed reason and opaque source digest.
 
 The v1 trajectory has exactly two ordered messages:
 
@@ -152,11 +169,15 @@ binding_key = "b-" + HMAC_SHA256(scope_key, "agent-project:" + normalized_workdi
 ```
 
 The raw Agent id, Agent name, workdir, Session id, Turn id, Run id, platform
-identity, and user principal are not written into the Memory database or
-provider paths. The source Turn id is reduced to a keyed digest for idempotency.
-The synthetic input actor is `i-` plus the first 32 hex characters of a separate
-HMAC domain over that source digest; it can never collide with `u-` or `a-`
-owners.
+identity, and user principal are never structural Memory columns, owner/filter
+values, or provider path components. The source Turn id is reduced to a keyed
+digest for idempotency. Because v1 deliberately preserves exact backend texts,
+those bytes may still contain user/Agent-authored identifiers or the disclosed
+Avibe-injected attribution lines. They remain bounded untrusted content and are
+scrubbed with the payload; no content parsing may promote them into identity or
+scope. The synthetic input actor is `i-` plus the first 32 hex characters of a
+separate HMAC domain over that source digest; it can never collide with `u-` or
+`a-` owners.
 
 One binding maps one `binding_key` to one project id. Project ids use the schema
 v3 write contract exactly: literal `default`, or a 1-63 byte lower-case named
@@ -198,14 +219,21 @@ prompt and `vibe memory search/list` contracts remain byte-for-byte unchanged by
 the new CLI examples and parser registration.
 
 Memory status also reports a content-free skill-count observation for each
-installed Agent across that Agent's explicitly bound projects. The monitor uses
-bounded `total_count` metadata, not skill bodies, and reports `normal` for 0-7,
-`approaching` for 8-10, and `risk` above 10. The hint says explicitly that this
-total is a conservative proxy: EverOS does not expose cluster membership, name
-sanitization collisions can occur at any count, and the stale-index risk applies
-when one upstream cluster exceeds 10. An unavailable count is `unknown` and
-degrades only Agent Memory status. Counts and hints never block capture,
-retrieval, or provider writes.
+installed Agent across that Agent's explicitly bound projects. An explicit
+status refresh may advance one durable, stable-order sampling cursor at most
+once per 60 seconds. One sampler batch issues at most 32 scoped `total_count`
+requests with concurrency at most two, caches only count/observed-at metadata,
+and resumes at the next Agent/project pair; status rendering never fans out its
+own provider reads. An Agent count is complete only after all of its current
+bound projects have been observed in the same sampling generation; otherwise it
+is `unknown` or explicitly stale. Removed Agents/bindings invalidate their cache.
+
+A complete count reports `normal` for 0-7, `approaching` for 8-10, and `risk`
+above 10. The hint says explicitly that this total is a conservative proxy:
+EverOS does not expose cluster membership, name sanitization collisions can
+occur at any count, and the stale-index risk applies when one upstream cluster
+exceeds 10. An unavailable count degrades only Agent Memory status. Counts and
+hints never block capture, retrieval, or provider writes.
 
 ## Isolation Architecture
 
@@ -311,6 +339,13 @@ bounded retry dead-letters and scrubs the row; infrastructure unavailability
 pauses claims without consuming a content retry. Agent rows never enter
 `manual_required` or the Personal Memory session-flush coordinator.
 
+Scrubbed `delivered` and `dead` rows are idempotency tombstones with the same
+bounded retention as Personal Memory: retain at most 90 days and, within that
+window, only the newest 100,000 closed Agent rows. Transactional compaction runs
+after settlement and from periodic store maintenance, deletes oldest excess
+tombstones, and never changes the scan cursor, enable/drain state, or aggregate
+missed counters.
+
 Each row uses its own deterministic provider session. The worker performs one
 two-message add and, when needed, one matching flush. Acknowledgement means only
 that EverOS accepted/processed the trajectory boundary; it does not prove a case
@@ -321,7 +356,8 @@ ambiguous agent write cannot fence user capture.
 ### Scanner cursor and project bindings
 
 `memory_agent_scan_state` is a singleton containing the last committed terminal
-sequence, enable epoch, durable missed counters, and scan/update timestamps. On
+sequence, enable epoch, optional drain-through sequence/state, durable missed
+counters, and scan/update timestamps. On
 every enable cutover the cursor advances to the primary store's current maximum
 before admission opens. Clear and factory-reset recovery apply the same cutover
 after deleting or recreating the Memory store: while the shared maintenance
@@ -445,9 +481,9 @@ stable ids:
 
 | ID | Invariant |
 |---|---|
-| `MEMORY-AGENT-001` | The absent/default config leaves the second root, scanner, and worker off; every enable or destructive reset starts at the current high water. |
-| `MEMORY-AGENT-002` | Every eligible completed interactive or Harness Turn is represented once by its exact dispatch/result pair. |
-| `MEMORY-AGENT-003` | Admission excludes every terminal shape that does not satisfy the completed-result invariant. |
+| `MEMORY-AGENT-001` | The absent/default config leaves the second root, scanner, and worker off; disable drains its enabled interval, and every enable or destructive reset starts at the correct high water. |
+| `MEMORY-AGENT-002` | Every eligible non-steered completed interactive or Harness Turn is represented once by its exact dispatch/result pair. |
+| `MEMORY-AGENT-003` | Admission excludes every terminal shape that does not satisfy the completed-result invariant, including accepted live steers. |
 | `MEMORY-AGENT-004` | Commit ordering and crash/replay cannot lose or enqueue one source Turn more than once. |
 | `MEMORY-AGENT-005` | Agent and project partitions cannot read or write each other's output. |
 | `MEMORY-AGENT-006` | Malformed config, legacy Agent identity, and missing project binding fail closed. |
@@ -455,8 +491,9 @@ stable ids:
 | `MEMORY-AGENT-008` | Both role sidecars reject every payload outside their exact owner/shape contract. |
 | `MEMORY-AGENT-009` | CLI/UI retrieval is explicit, bounded, inert, and absent from Agent prompts/install paths. |
 | `MEMORY-AGENT-010` | Accepted processing with zero cases or skills is a truthful valid outcome. |
-| `MEMORY-AGENT-011` | Queue/disk exhaustion skips durably without retaining text or degrading Personal Memory. |
-| `MEMORY-AGENT-012` | Skill retrieval exposes exact freshness/maturity metadata, and status reports non-blocking per-Agent count hints at 8 and 11 skills. |
+| `MEMORY-AGENT-011` | Queue/disk exhaustion skips durably, and 90-day/100,000-row tombstone compaction bounds closed-row storage without degrading Personal Memory. |
+| `MEMORY-AGENT-012` | Skill retrieval exposes exact freshness/maturity metadata, while the request-budgeted status sampler reports non-blocking per-Agent count hints at 8 and 11 skills. |
+| `MEMORY-AGENT-013` | Opt-in disclosure models raw attribution bytes in exact trajectory content without allowing them to become Memory identity or scope. |
 
 Evidence layers are unit tests for config/identity/admission/store/worker/runtime,
 contract tests for provider/sidecar/internal API/CLI/UI, executable catalog

--- a/docs/plans/memory-agent-track-1424.md
+++ b/docs/plans/memory-agent-track-1424.md
@@ -149,8 +149,20 @@ Re-enable requires an earlier disable drain to converge, then its own enabled
 cutover skips the completed opt-out interval. Clear/factory reset record the
 same primary-state intent immediately before recreating scan state, after
 destructive deletion is complete. Turn settlement performs no Memory/config I/O
-and never waits for projection or drain work. A failed start leaves only Agent
-Memory unavailable without disabling Personal Memory or restarting Avibe.
+and never waits for projection or drain work.
+
+If Agent runtime/sidecar start fails after the desired enabled config and intent
+commit, Agent Memory remains `enabled=true` but `degraded` with that exact
+committed intent retained; it does not apply Personal Memory's failed-enable
+rollback rule. The dispatch snapshot gate and scanner/provider claims remain
+closed while any enable intent exists, so no trajectory text accumulates. The
+controller's Agent-role Retry/Restart reuses the intent idempotently and clears
+it only after the role is healthy. An explicit Disable may instead supersede the
+failed enable through the normal controller cutover. Personal Memory and normal
+Agent execution remain unchanged. The controller IPC returns a closed
+`memory_agent_start_failed` degradation with `persisted_enabled=true` and
+`recovery_pending=true`; Settings must not report either disabled rollback or
+ready state.
 
 ### Admission
 
@@ -489,9 +501,10 @@ opaque epochs remain in the Memory store.
 - `source_turn_digest` primary key: keyed digest of the durable Turn id;
 - stable provider `session_id`, opaque `agent_id`, and exact `project_id`;
 - bounded input/result payloads and stable input/result timestamps;
-- closed `pending | processing | delivered | dead` state;
+- closed `pending | processing | awaiting_flush | delivered | dead` state;
 - lease token/owner/time, attempts, next retry, closed error, provider request
-  ids/status, and created/completed timestamps.
+  ids/status, durable add receipt/flush requirement, and created/completed
+  timestamps.
 
 Before enqueue, the store enforces an independent maximum of 500 nonterminal
 Agent rows and at least 512 MiB free on the volume containing `memory.sqlite`.
@@ -503,11 +516,15 @@ text. These guards are independent of, and do not consume, Personal Memory's
 500-row allowance. Status reports the counters without source content.
 
 Idempotent enqueue and cursor advancement are one transaction. A duplicate
-source digest returns duplicate without changing the existing row. Successful
-delivery scrubs both source texts. A deterministic rejection or exhausted
-bounded retry dead-letters and scrubs the row; infrastructure unavailability
-pauses claims without consuming a content retry. Agent rows never enter
-`manual_required` or the Personal Memory session-flush coordinator.
+source digest returns duplicate without changing the existing row. Immediately
+after a confirmed add, one queue transaction persists the sanitized add receipt
+and exact session/app/project flush scope, scrubs both source texts, and moves
+the row directly to `delivered` when no flush is required or to
+`awaiting_flush` before any flush attempt. Flush and every flush retry use only
+that scope; provider/infrastructure unavailability can therefore never retain
+trajectory text. A deterministic add rejection, exhausted bounded add retry, or
+unknown post-submission add outcome dead-letters and scrubs the row. Agent rows
+never enter `manual_required` or the Personal Memory session-flush coordinator.
 
 Scrubbed `delivered` and `dead` rows are idempotency tombstones with the same
 bounded retention as Personal Memory: retain at most 90 days and, within that
@@ -517,11 +534,12 @@ tombstones, and never changes the scan cursor, enable/drain state, or aggregate
 missed counters.
 
 Each row uses its own deterministic provider session. The worker performs one
-two-message add and, when needed, one matching flush. Acknowledgement means only
-that EverOS accepted/processed the trajectory boundary; it does not prove a case
-or skill exists. Unknown post-submission outcomes are never replayed
-automatically; they settle to a closed agent-only dead-letter reason so an
-ambiguous agent write cannot fence user capture.
+two-message add and, when needed, one matching flush. A confirmed add receipt
+means only that EverOS accepted the trajectory boundary and authorizes immediate
+payload scrubbing; a successful flush/terminal acknowledgement still does not
+prove a case or skill exists. Unknown post-submission add outcomes are never
+replayed automatically; they settle to a scrubbed agent-only dead-letter reason
+so an ambiguous agent write cannot fence user capture.
 
 ### Scanner cursor and project bindings
 
@@ -718,17 +736,17 @@ stable ids:
 
 | ID | Invariant |
 |---|---|
-| `MEMORY-AGENT-001` | The absent/default config leaves the second root, scanner, and worker off; one controller IPC owns prepared settings cutovers, post-deletion reset high waters do not drift on recovery, and Clear accepts either never-created role as absent. |
+| `MEMORY-AGENT-001` | The absent/default config leaves the second root, scanner, and worker off; one controller IPC owns prepared settings cutovers, a failed Agent-role start retains a fenced retryable intent without snapshot admission, post-deletion reset high waters do not drift on recovery, and Clear accepts either never-created role as absent. |
 | `MEMORY-AGENT-002` | Every semantically eligible non-steered completed Workbench, Slack, Discord, Telegram, Feishu/Lark, WeChat, or Harness Turn not durably declined by a specified snapshot/queue/disk guard is represented once by its exact post-transformation backend-dispatch/result pair. |
 | `MEMORY-AGENT-003` | Admission excludes every terminal shape that does not satisfy the completed-result invariant; source-class batching separates callbacks and accepted live steers are excluded. |
 | `MEMORY-AGENT-004` | Commit ordering and crash/replay cannot lose or enqueue one source Turn more than once. |
 | `MEMORY-AGENT-005` | Agent and project partitions cannot read or write each other's output; capture and trusted-Turn CLI retrieval use the immutable executing Agent without blocking hard deletion, deleted owners remain UI-retrievable, and crash-safe prepared binding cutovers keep backlog in the project effective at settlement. |
 | `MEMORY-AGENT-006` | Malformed config, missing/pre-migration identity/source/final-dispatch snapshots, and missing project binding fail closed. |
-| `MEMORY-AGENT-007` | Agent-sidecar/local pipeline outage leaves chat and Personal Memory healthy; shared remote endpoint throttling is reported as an external quota coupling without cross-role state corruption. |
+| `MEMORY-AGENT-007` | Agent-sidecar/local pipeline outage leaves chat and Personal Memory healthy; dual-root embedding rebuild preserves and fences both roots through partial failure, while shared remote endpoint throttling is reported as an external quota coupling without cross-role state corruption. |
 | `MEMORY-AGENT-008` | Both role sidecars reject every payload outside their exact owner/shape contract. |
 | `MEMORY-AGENT-009` | CLI/UI retrieval is explicit, bounded, inert, and absent from Agent prompts/install paths; a read-only per-Agent project catalog keeps removed-binding output reachable. |
 | `MEMORY-AGENT-010` | Accepted processing with zero cases or skills is a truthful valid outcome. |
-| `MEMORY-AGENT-011` | Per-row/global primary snapshot guards plus queue/disk exhaustion skip durably; primary copies are scrubbed after disposition/reset, and 90-day/100,000-row tombstone compaction bounds closed-row storage without degrading Personal Memory. |
+| `MEMORY-AGENT-011` | Per-row/global primary snapshot guards plus queue/disk exhaustion skip durably; primary copies are scrubbed after disposition/reset, queue payloads are scrubbed immediately after a durable add receipt and before flush, and 90-day/100,000-row tombstone compaction bounds closed-row storage without degrading Personal Memory. |
 | `MEMORY-AGENT-012` | Skill retrieval exposes exact freshness/maturity metadata, while the request-budgeted status sampler reports non-blocking per-Agent count hints at 8 and 11 skills. |
 | `MEMORY-AGENT-013` | Opt-in disclosure models raw attribution bytes in exact trajectory content without allowing them to become Memory identity or scope. |
 

--- a/docs/plans/memory-agent-track-1424.md
+++ b/docs/plans/memory-agent-track-1424.md
@@ -135,14 +135,17 @@ prepared intent permits no projection or drain; after config persistence,
 committed intent handling permits only idempotent cutover projection and the
 bounded disable drain. Enable
 projects an open epoch and cursor `H`, rebuilds opaque bindings, starts the role
-runtime, and only then clears the intent and opens scanner admission. Disable
+runtime, and only then atomically persists the enabled current-capture
+projection while clearing the intent and opening scanner/snapshot admission.
+Disable
 first closes new provider claims in the controller, commits its disabled intent,
 then projects the old epoch's inclusive drain target `H`. It waits for any current
 bounded provider request to settle before stopping the worker and sidecar; after
 worker quiescence no provider write may start. The scanner runs local-only in
 `disabling` mode until every source through `H` is enqueued or durably skipped,
-then stops and clears the intent. Rows enqueued by the drain remain pending
-without provider I/O and become claimable only after a later enable.
+then stops and atomically persists the disabled current-capture projection while
+clearing the intent. Rows enqueued by the drain remain pending without provider
+I/O and become claimable only after a later enable.
 
 All Memory writers remain serialized behind that controller transaction until
 the intent is cleared, so a Personal or endpoint save cannot create a third
@@ -161,8 +164,9 @@ restart time. Memory projection/drain and intent cleanup are idempotent.
 Re-enable requires an earlier disable drain to converge, then its own enabled
 cutover skips the completed opt-out interval. Clear/factory reset record the
 same primary-state intent immediately before recreating scan state, after
-destructive deletion is complete. Turn settlement performs no Memory/config I/O
-and never waits for projection or drain work.
+destructive deletion is complete, and replace the current-capture projection at
+the same fresh epoch before clearing that intent. Turn settlement performs no
+Memory/config I/O and never waits for projection or drain work.
 
 If Agent runtime/sidecar start fails after the desired enabled config and intent
 commit, Agent Memory remains `enabled=true` but `degraded` with that exact
@@ -205,8 +209,9 @@ these invariants hold:
   rename/disable/archive/hard-delete does not rewrite the snapshot;
 - `source_class` is exactly `interactive` or `harness_request`, never `callback`,
   `maintenance`, `agent_callback`, or missing; and
-- the immutable start-snapshot `binding_key` resolves at the Turn's terminal
-  sequence through exactly one opaque epoch to one new-style Memory project.
+- the immutable start-snapshot `binding_key` plus `binding_epoch` resolves at the
+  Turn's terminal sequence through that same continuous opaque epoch to one
+  new-style Memory project.
 
 Every Delivery snapshots one admission-relevant source class from durable
 provenance. FIFO/scheduled compatibility keys include that class, and Turn claim
@@ -223,18 +228,19 @@ without opening the Memory store. The same primary transaction derives the
 source workdir's opaque `binding_key` and requires it in the controller-projected
 primary admission set at the current committed Memory-config revision, with no
 binding cutover intent. That set contains only opaque keys, never workdirs or
-projects; the controller replaces it while the intent fence is closed and opens
-snapshot admission only after V2 config and the projection converge. Only bound
-`text_only` requests are candidates. If that epoch is committed enabled, the
+projects, and returns the current monotonic `binding_epoch`; the controller
+replaces it while the intent fence is closed and opens snapshot admission only
+after V2 config and the projection converge. Only bound `text_only` requests are
+candidates. If the capture epoch is committed enabled, the
 exact UTF-8 text is at most 256 KiB, and the global primary snapshot budget
 remains below 128 MiB, the transaction reserves its byte count and persists
-`backend_dispatch_text`, digest, shape, opaque binding key, and capture epoch
-before invoking the native adapter. The adapter must send exactly that stored
-text with no additional native input; an automatic start retry reuses the
+`backend_dispatch_text`, digest, shape, opaque binding key/epoch, and capture
+epoch before invoking the native adapter. The adapter must send exactly that
+stored text with no additional native input; an automatic start retry reuses the
 snapshot instead of re-running a text-changing transform. The scanner later
-resolves that immutable key against the project epoch effective at terminal
-settlement; a reassignment/removal may therefore change or remove eligibility,
-but a Turn started before its first binding is never admitted retroactively.
+requires that exact binding generation at terminal settlement. A
+reassignment/removal invalidates an in-flight generation, while a Turn started
+before its first binding is never admitted retroactively.
 
 Disabled/transitioning epochs, missing/transitioning bindings, out-of-band
 attachment input, oversized text, or an exhausted snapshot budget record only a
@@ -330,11 +336,32 @@ vibe memory agent search <query> [--project <slug>] [--kind case|skill|all] [--l
 vibe memory agent list [--project <slug>] [--kind case|skill] [--page N] [--limit 1..20] [--json]
 ```
 
-The CLI requires an Avibe-injected current Session id and current Turn id through
-the existing trusted context. It validates that the Turn belongs to that Session
-and derives the owner only from the Turn's immutable `executing_agent_id`
-snapshot, including explicit Harness/CLI Agent overrides; mutable Session routing
-is never retrieval identity. It accepts no caller-supplied Turn id, raw
+The CLI's session-stable environment provides only an Avibe Session locator; it
+is never sufficient authorization and carries no Turn id. Immediately before a
+recognized `vibe memory agent` tool invocation, an Avibe-owned backend callback
+asks the controller to resolve exactly one native-started, nonterminal active
+Turn for that Session and mint a random one-use capability bound to the Session,
+logical/native Turn, executing Agent snapshot, closed search/list command class,
+parser-normalized argv/request digest, and a 30-second expiry. The callback
+injects it only into that child invocation. The recognizer uses a shell parser
+and accepts one standalone simple command with allowlisted CLI flags; shell
+operators, pipelines, substitutions, redirections, environment wrappers, and
+extra commands receive no capability. The CLI sends the token over the
+authenticated controller UDS, where it is atomically
+consumed before the controller performs the bounded retrieval. Tokens are kept
+only as hashes in controller memory, expose no raw ids, and are invalidated by
+controller restart.
+
+For a cached Claude SDK client, the per-tool permission/hook callback is a
+session-bound closure and uses the SDK's `updated_input` result to inject a fresh
+capability for each matching Bash call. It does not rely on or refresh the
+client's spawn-time environment. Codex and OpenCode use the equivalent
+per-invocation adapter hook. If a backend cannot provide the hook, the token is
+missing/expired/reused, or active Turn resolution is zero/ambiguous/terminal,
+the command returns `memory_turn_context_unavailable`; there is no fallback to a
+static Session lookup, caller-supplied Turn id, prompt text, or mutable Session
+routing. Explicit Harness/CLI Agent overrides are already reflected in the
+capability's immutable executing-Agent snapshot. The command also accepts no raw
 `agent_id`, Agent selector, workdir, provider filter, or cross-project `all`.
 Omitting `--project` uses the Session workdir's current explicit binding. An
 explicit value must be either that binding or an exact project retained in this
@@ -474,12 +501,15 @@ primary Avibe state schema:
 - `backend_dispatch_binding_key TEXT`, the opaque start-snapshot key for the
   committed explicit source-workdir binding; it is present only with an admitted
   dispatch and contains neither workdir nor project id;
+- `backend_dispatch_binding_epoch INTEGER`, the immutable monotonic generation
+  returned with that key; the pair must resolve through one continuous project
+  epoch at terminal settlement;
 - `backend_dispatch_text TEXT` and `backend_dispatch_sha256 TEXT`, the exact
   bounded final backend-facing input and digest;
 - `backend_dispatch_capture_epoch INTEGER` and
   `backend_dispatch_omission_reason TEXT`, the admitted epoch or a closed
   `disabled | transition | unbound | out_of_band_attachment | oversized |
-  budget | destructive_reset` reason, never both; and
+  budget | binding_cutover | destructive_reset` reason, never both; and
 - `terminal_sequence INTEGER`, with a unique partial index.
 
 The shared `MessageHandler`/dispatch boundary creates the same durable Delivery
@@ -514,12 +544,13 @@ shared/backend input transformation, a primary state transaction classifies the
 complete native input shape, checks the committed capture epoch, resolves one
 committed explicit opaque binding key, enforces the per-row 256 KiB bound,
 reserves bytes, and compares-and-sets the admitted
-text/digest/shape/binding-key/epoch. The adapter receives that exact stored text
-without additional native input. A retry must reuse it and a conflicting second
-value fails closed; Memory never derives candidate input from the earlier raw
-`dispatch_text`. When no snapshot is admitted, the same transaction writes only
-the closed shape/omission reason and the adapter proceeds with its in-memory
-native input. Unbound content and out-of-band attachment metadata/bytes are
+text/digest/shape/binding-key/binding-epoch/capture-epoch. The adapter receives
+that exact stored text without additional native input. A retry must reuse it and
+a conflicting second value fails closed; Memory never derives candidate input
+from the earlier raw `dispatch_text`. When no snapshot is admitted, the same
+transaction writes only the closed shape/omission reason and the adapter
+proceeds with its in-memory native input. Unbound content and out-of-band
+attachment metadata/bytes are
 never copied into the Memory source schema or charged to its byte reservation.
 Startup and periodic primary-state maintenance recompute the reservation from
 the UTF-8 byte lengths of actual nonempty snapshots before admitting more, so a
@@ -545,9 +576,10 @@ Reinitialize/factory reset first close new dispatch snapshot admission. After
 destructive deletion, the same serialized primary transaction that records the
 new epoch and terminal high water bulk-scrubs every admitted snapshot, including
 nonterminal/in-flight Turns without a `terminal_sequence`, releases their byte
-reservations, and replaces their admitted epoch/key with the closed
-`destructive_reset` omission reason. Turn settlement cannot interleave with that
-transaction; a later settlement is therefore epoch-crossing and ineligible.
+reservations, and replaces their admitted capture/binding epochs and key with
+the closed `destructive_reset` omission reason. Turn settlement cannot
+interleave with that transaction; a later settlement is therefore epoch-crossing
+and ineligible.
 The destructive operation cannot report success or recreate scan state before
 this scrub commits. Thus the primary duplicate is bounded while live and does
 not survive final disposition or destructive reset, even when native execution
@@ -559,8 +591,9 @@ records used below. Each contains its kind, prior/desired Agent-block config
 digests, `prior_memory_config_revision`, `desired_memory_config_revision`,
 terminal high water, closed `prepared | committed` phase, and timestamps. The
 capture record also stores its epoch and desired state. The binding record stores
-no normalized workdir/project payload; those remain in V2 config, while opaque
-epochs remain in the Memory store. V2 config persists one monotonic
+its bounded desired opaque key/generation set but no normalized workdir/project
+payload; those remain in V2 config, while opaque project epochs remain in the
+Memory store. V2 config persists one monotonic
 `memory.revision` incremented exactly once by each successful controller Memory
 mutation. Recovery requires both revision and digest to match the durable prior
 or desired pair, so an ABA edit cannot masquerade as either state. A released
@@ -568,13 +601,39 @@ config without the internal revision loads as revision `0`; migration preserves
 all other values, and the first successful controller mutation writes `1`.
 
 The primary schema also adds
-`memory_agent_admission_bindings(binding_key, memory_config_revision)` as the
-content-free current binding set used only by the dispatch gate. A binding
-cutover intent fences reads as ineligible, then the controller atomically
-replaces this opaque set and promotes the intent after V2 config persistence.
-Recovery rebuilds it only from an exact desired revision/digest pair. It stores
-neither project ids nor normalized workdirs and is never the scanner's historical
+`memory_agent_capture_projection(capture_epoch, enabled,
+memory_config_revision, applied_agent_config_digest, updated_at)` as the durable
+singleton read by native start. The transaction admits a snapshot only when this
+projection is enabled, its revision matches the binding projection, and no
+capture/binding/maintenance intent exists. Enable, disable, and destructive
+reset replace it in the same primary transaction that clears the corresponding
+intent, after the role-specific work has converged. Startup validates it against
+V2 config and an exact pending intent; missing or mismatched state fences
+admission as `transition` and never derives a fresh epoch from wall time or the
+Memory store. Every successful Memory config transaction, including a
+Personal-only patch, stamps both current Agent projections with the new config
+revision before releasing the controller lock; when Agent semantics are
+unchanged it preserves their epoch/generations. Thus equal projection revisions
+cannot both lag the persisted config after a completed writer.
+Controller startup keeps native snapshot admission globally fenced until this
+validation and Agent-role runtime reconciliation complete; a failed role restart
+retains enabled config but enters the existing retryable recovery state instead
+of trusting the old projection alone.
+
+The primary schema also adds `memory_agent_admission_bindings(binding_key,
+binding_epoch, memory_config_revision)` as the content-free current binding set
+used only by the dispatch gate. A binding cutover intent fences reads as
+ineligible, then the controller atomically replaces this opaque set and promotes
+the intent after V2 config persistence. Every addition or reassignment allocates
+a new monotonic `binding_epoch`; re-adding the same workdir never reuses a closed
+generation. Recovery rebuilds the set only from an exact desired
+revision/digest pair and the intent's allocated generations. It stores neither
+project ids nor normalized workdirs and is never the scanner's historical
 project authority.
+`memory_agent_binding_epoch_counter` is a primary singleton incremented in the
+prepared-intent transaction for every added or reassigned key. Aborted cutovers
+may leave gaps but never reuse a generation, even after closed historical epochs
+are compacted.
 
 ### Agent trajectory outbox
 
@@ -637,8 +696,9 @@ and closed-skip rows only after the corresponding decision is durable. A crash
 before commit re-reads the same row; the digest keeps enqueue idempotent.
 
 `memory_agent_project_bindings` is an opaque, sequence-versioned projection of
-the V2 config. Each epoch stores `binding_key`, exact new-style `project_id`, an
-exclusive `effective_after_sequence`, an optional inclusive
+the V2 config. Each epoch stores `binding_key`, its monotonic `binding_epoch`,
+exact new-style `project_id`, an exclusive `effective_after_sequence`, an
+optional inclusive
 `effective_through_sequence`, and created/closed timestamps. The V2 config
 remains the authoritative desired owner setting. The projection also stores its
 `applied_config_digest`; historical epochs exist only to finish committed
@@ -667,12 +727,21 @@ its Agent-role operation is `apply_agent_memory_settings`. It first uses one
 serialized primary state transaction to read the current committed
 terminal high water `H` and insert a prepared singleton
 `memory_agent_binding_cutover` intent containing the prior/desired Agent-block
-digests, whole-config revisions, and `H`. Terminal settlement cannot interleave
+digests, whole-config revisions, bounded desired opaque key/generation set, and
+`H`; additions/reassignments allocate that set from the durable generation
+counter in this transaction. Terminal settlement cannot interleave
 between that read and intent commit. The scanner is then fenced, V2 config is
-atomically replaced, and the intent is promoted to committed; terminal
-settlement performs no Memory/config I/O and never waits for projection work.
-The UI does not write these bindings
-before contacting the controller.
+atomically replaced. On the exact desired revision/digest, one primary
+transaction promotes the intent, replaces the current admission set, and scrubs
+every old-generation snapshot whose Turn is still nonterminal or settled after
+`H`, releasing its reservation and recording `binding_cutover`. A terminal Turn
+at or below `H` is already old-epoch backlog and is not scrubbed. Terminal
+settlement cannot interleave with this promotion/scrub transaction. Thus removal
+or reassignment invalidates every in-flight old generation before a re-add can
+open a new one, while a failed config write cancels without destroying a valid
+snapshot. Then the historical project projection converges; terminal settlement
+performs no Memory/config I/O and never waits for projection work. The UI does
+not write these bindings before contacting the controller.
 
 When one Settings save changes both `enabled` and bindings, that same primary
 writer transaction records the capture and binding intents at one shared `H`.
@@ -680,9 +749,10 @@ Binding epochs project before an enabled scanner may open; a disabled drain uses
 the old binding epochs through `H`.
 
 While an intent exists, Agent scanner admission is fenced. One idempotent Memory
-transaction appends/closes the opaque epochs at the intent's exact `H` and
-advances `applied_config_digest`; only then may recovery clear the primary-state
-intent and reopen the scanner. The binding becomes sequence-effective at the
+transaction appends/closes the exact opaque key/generation epochs at the
+intent's `H` and advances `applied_config_digest`; only then may recovery clear
+the primary-state intent and reopen the scanner. The binding becomes
+sequence-effective at the
 prepared intent's `H` only if the desired config commit succeeds, and the
 Settings save reports success only after projection converges. A Turn at or
 below `H` uses the old mapping; a later Turn uses the new mapping after a
@@ -700,7 +770,9 @@ path.
 An added mapping is effective only for `terminal_sequence > H`. Reassignment
 closes the old epoch through `H` and opens the new project after `H`; removal
 only closes the old epoch through `H`. The scanner resolves each source's
-immutable start-snapshot binding key against the unique epoch satisfying
+immutable start-snapshot binding key/generation against the unique row satisfying
+`row.binding_key = snapshot.binding_key`,
+`row.binding_epoch = snapshot.binding_epoch`, and
 `effective_after_sequence < terminal_sequence <= effective_through_sequence`,
 with a `NULL` through-sequence meaning open. It therefore drains backlog through
 the old project without admitting opt-in or reassignment history to the new
@@ -826,15 +898,15 @@ stable ids:
 
 | ID | Invariant |
 |---|---|
-| `MEMORY-AGENT-001` | The absent/default config leaves the second root, scanner, and worker off; every Personal/Agent/endpoint Memory config writer uses one controller transaction with monotonic revision/digest conflict detection through cutover cleanup; Agent-only enablement keeps navigation/recovery visible and forbids shared-credential clearing; a failed Agent-role start retains a fenced retryable intent without snapshot admission; destructive reset atomically scrubs terminal and in-flight snapshots at its fixed high water; and Clear accepts either never-created role as absent. |
+| `MEMORY-AGENT-001` | The absent/default config leaves the second root, scanner, and worker off; every Personal/Agent/endpoint Memory config writer uses one controller transaction with monotonic revision/digest conflict detection through cutover cleanup; the durable current-capture projection preserves exact enabled epoch admission across controller restart; Agent-only enablement keeps navigation/recovery visible and forbids shared-credential clearing; a failed Agent-role start retains a fenced retryable intent without snapshot admission; destructive reset atomically scrubs terminal and in-flight snapshots at its fixed high water; and Clear accepts either never-created role as absent. |
 | `MEMORY-AGENT-002` | Every semantically eligible non-steered completed Workbench, Slack, Discord, Telegram, Feishu/Lark, WeChat, or Harness Turn not durably declined by a specified snapshot/queue/disk guard is represented once by its exact post-transformation backend-dispatch/result pair. |
-| `MEMORY-AGENT-003` | Admission excludes every terminal shape that does not satisfy the completed-result invariant; source-class batching separates callbacks; accepted live steers are excluded; the revision-matched opaque primary admission set makes an unbound or binding-transition Turn retain no dispatch text or budget; and any final native request with an out-of-band attachment fails closed without retaining attachment metadata or bytes. |
+| `MEMORY-AGENT-003` | Admission excludes every terminal shape that does not satisfy the completed-result invariant; source-class batching separates callbacks; accepted live steers are excluded; the revision-matched opaque primary admission set makes an unbound or binding-transition Turn retain no dispatch text or budget; a remove/reassign scrubs old-generation Turns settling after its high water so re-add cannot revive them; and any final native request with an out-of-band attachment fails closed without retaining attachment metadata or bytes. |
 | `MEMORY-AGENT-004` | Commit ordering and crash/replay cannot lose or enqueue one source Turn more than once; persisted prior/desired config revisions plus digests detect third-state and ABA edits during capture or binding recovery. |
-| `MEMORY-AGENT-005` | Agent and project partitions cannot read or write each other's output; capture and trusted-Turn CLI retrieval use the immutable executing Agent without blocking hard deletion, deleted owners remain UI-retrievable, and crash-safe prepared binding cutovers keep backlog in the project effective at settlement. |
+| `MEMORY-AGENT-005` | Agent and project partitions cannot read or write each other's output; capture and controller-resolved active-Turn CLI retrieval use the immutable executing Agent without blocking hard deletion; deleted owners remain UI-retrievable; and crash-safe generation-bearing binding cutovers preserve settled backlog while invalidating in-flight old generations. |
 | `MEMORY-AGENT-006` | Malformed config, missing/pre-migration identity/source/final-dispatch snapshots, and missing project binding fail closed. |
 | `MEMORY-AGENT-007` | Agent-sidecar/local pipeline outage leaves chat and Personal Memory healthy; dual-root embedding rebuild preserves and fences both roots through partial failure; shared remote endpoint throttling and effective-home capacity exhaustion are reported as explicit resource couplings without cross-role state mixing. |
 | `MEMORY-AGENT-008` | Both role sidecars reject every payload outside their exact owner/shape contract. |
-| `MEMORY-AGENT-009` | CLI/UI retrieval is explicit, bounded, inert, and absent from Agent prompts/install paths; a read-only per-Agent project catalog keeps removed-binding output reachable. |
+| `MEMORY-AGENT-009` | CLI/UI retrieval is explicit, bounded, inert, and absent from Agent prompts/install paths; each adapter injects a request-bound one-use active-Turn capability, cached Claude sessions refresh it through per-call `updated_input` without an environment Turn id, and missing/reused/expired/ambiguous/terminal context fails closed; a read-only per-Agent project catalog keeps removed-binding output reachable. |
 | `MEMORY-AGENT-010` | Accepted processing with zero cases or skills is a truthful valid outcome. |
 | `MEMORY-AGENT-011` | Per-row/global primary snapshot guards plus queue/disk exhaustion skip durably; primary copies, including active nonterminal snapshots, are scrubbed after disposition/reset; queue payloads are scrubbed immediately after a durable add receipt and before flush; ambiguous post-submission Agent adds dead-letter without replay; and 90-day/100,000-row tombstone compaction bounds closed-row storage without degrading Personal Memory. |
 | `MEMORY-AGENT-012` | Skill retrieval exposes exact freshness/maturity metadata, while the request-budgeted status sampler reports non-blocking per-Agent count hints at 8 and 11 skills. |

--- a/docs/plans/memory-agent-track-1424.md
+++ b/docs/plans/memory-agent-track-1424.md
@@ -43,18 +43,34 @@ Personal Memory admission, prompt, provider root, queue, or retrieval semantics.
    named Memory project. Missing bindings fail closed.
 8. EverOS 1.2.3 limitations listed below are accepted. Avibe isolates and
    reports them but does not patch EverOS or file an upstream issue.
-9. First enable initializes the scan cursor to the current terminal-turn high
-   water mark. There is no historical backfill in v1; only turns completing
-   after explicit enablement are candidates.
+9. Every disabled-to-enabled transition initializes the scan cursor to the
+   current terminal-settlement sequence high water mark. There is no historical
+   or disabled-period backfill in v1; only turns settling after that explicit
+   enable cutover are candidates.
 
 ## Product Contract
 
 ### Enablement and disclosure
 
-`memory.agent_track.enabled` is a persisted boolean and defaults to `false`.
-Absence is equivalent to disabled. A malformed optional `agent_track` block is
-discarded with a sanitized warning; it must not prevent Avibe startup or alter
-the independently parsed Personal Memory configuration.
+`memory.agent_track` is an optional persisted block with this exact shape:
+
+```yaml
+memory:
+  agent_track:
+    enabled: false
+    project_bindings:
+      - workdir: /normalized/absolute/path
+        project_id: default
+```
+
+`enabled` is a boolean and defaults to `false`; `project_bindings` permits at
+most 128 entries with unique normalized absolute workdirs paired with exact
+new-style Memory project ids. Each UTF-8 workdir and project id is at most 4,096
+bytes. Absence is equivalent to disabled with no bindings. The V2 config block
+is the authoritative owner setting and survives Clear/factory reset. A malformed
+optional `agent_track` block is discarded as a whole with a sanitized warning;
+it must not prevent Avibe startup or alter the independently parsed Personal
+Memory configuration.
 
 The owner Settings surface explains that eligible Agent inputs and results may
 be sent to the configured Memory processing endpoints, that accepted processing
@@ -63,16 +79,20 @@ EverOS 1.2.3 limitations. The source set is fixed to eligible completed Agent
 Turns, including interactive and Harness turns; v1 has no source-type selector.
 
 Enabling requires the installed Memory runtime, complete processing endpoints,
-and at least one explicit project binding. On first enable the owner-visible
-operation snapshots the current terminal-turn high water mark before the
-scanner starts. It starts only the agent sidecar and scanner/worker slots needed
-by the track. A failed start rolls the agent-track projection back to
-unavailable without disabling Personal Memory or restarting the Avibe service.
+and at least one explicit project binding. Under the agent-capture lifecycle
+lock, every disabled-to-enabled operation snapshots the current committed
+terminal-sequence high water, persists it as the new scan cursor, rebuilds the
+opaque binding projection, and only then opens scanner admission. A disable
+closes scanner admission and waits for the current bounded scan transaction
+before it reports success. It preserves rows admitted before that cutover but
+never later imports turns settled while disabled. A failed start leaves the
+agent-track projection unavailable without disabling Personal Memory or
+restarting the Avibe service.
 
 ### Admission
 
 One durable `session_turns` row is one candidate trajectory. The scanner reads
-in stable `(terminal_at, id)` order and joins the owning `agent_sessions` row
+in stable `terminal_sequence` order and joins the owning `agent_sessions` row
 and its referenced `agents` row. Admission is provider-neutral and accepts a
 row only when all of these invariants hold:
 
@@ -210,10 +230,14 @@ Reconcile owns the roles independently:
   controller lifecycle; no routine verification restarts Avibe.
 
 Restart engine, Repair index, Clear Memory Data, rebuild, and factory reset must
-enumerate role-owned resources rather than assuming one global slot. Clear and
-factory reset cover both roots, both role call-log/health records, and both
-queues under one existing durable maintenance fence. A partial failure reports
-each role truthfully and keeps Memory fenced until idempotent retry converges.
+enumerate role-owned resources rather than assuming one global slot. A
+never-enabled Agent role whose root, sentinel, process record, and socket are all
+absent is a successful `absent` no-op. A present Agent path without its expected
+sentinel remains unsafe and fails closed. Clear and factory reset cover every
+existing owned root, both role call-log/health records, and both queues under one
+existing durable maintenance fence while preserving the V2 config binding
+source. A partial failure reports each role truthfully and keeps Memory fenced
+until idempotent retry converges.
 Embedding-identity rebuild validates once, quiesces both sidecars, rebuilds each
 nonempty owned root independently, and does not activate either root against a
 different vector-space identity. Restart/repair may target a degraded role
@@ -227,6 +251,19 @@ table, index, value, and project-catalog entry unchanged. The new tables are
 separate from `memory_capture_queue` and its user principal/session-generation
 invariants.
 
+### Commit-ordered terminal source
+
+The infrastructure slice also adds nullable
+`session_turns.terminal_sequence INTEGER` plus a unique partial index in the
+primary Avibe state schema. The transaction that first settles a Turn terminal
+assigns one greater than the maximum non-NULL `terminal_sequence` (or `1` when
+none exists) while holding SQLite's serialized writer lock. The assignment,
+terminal outcome/evidence, and terminal state commit
+together; retries cannot allocate a second value. Consequently sequence order
+is settlement commit order even when wall time moves backward or UUIDs sort in
+another order. `terminal_at` remains display metadata and is never a scanner
+cursor. Pre-migration terminal rows retain `NULL` and are not backfilled.
+
 ### Agent trajectory outbox
 
 `memory_agent_trajectory_queue` stores one row per admitted source Turn:
@@ -237,6 +274,14 @@ invariants.
 - closed `pending | processing | delivered | dead` state;
 - lease token/owner/time, attempts, next retry, closed error, provider request
   ids/status, and created/completed timestamps.
+
+Before enqueue, the store enforces an independent maximum of 500 nonterminal
+Agent rows and at least 512 MiB free on the volume containing `memory.sqlite`.
+At either guard, the scanner records a durable aggregate
+`missed_queue_full`/`missed_low_disk_space` count and advances past that source
+sequence in the same transaction; it never retains the rejected trajectory
+text. These guards are independent of, and do not consume, Personal Memory's
+500-row allowance. Status reports the counters without source content.
 
 Idempotent enqueue and cursor advancement are one transaction. A duplicate
 source digest returns duplicate without changing the existing row. Successful
@@ -254,21 +299,25 @@ ambiguous agent write cannot fence user capture.
 
 ### Scanner cursor and project bindings
 
-`memory_agent_scan_state` is a singleton containing the last committed
-`(terminal_at, turn_id)` cursor, whether the first-enable high water was
-initialized, and scan/update timestamps. The scanner queries strictly after
-that tuple in bounded pages. It advances through admitted, duplicate, and
-closed-skip rows only after the corresponding enqueue/skip decision is durable.
-A crash before commit re-reads the same row; the digest keeps enqueue
-idempotent. Adding a binding later does not backfill turns already skipped at an
-earlier cursor.
+`memory_agent_scan_state` is a singleton containing the last committed terminal
+sequence, enable epoch, durable missed counters, and scan/update timestamps. On
+every enable cutover the cursor advances to the primary store's current maximum
+before admission opens. The scanner then queries strictly after that sequence in
+bounded pages. It advances through admitted, duplicate, guarded, and closed-skip
+rows only after the corresponding decision is durable. A crash before commit
+re-reads the same row; the digest keeps enqueue idempotent. Adding a binding
+later does not backfill turns already skipped at an earlier cursor.
 
-`memory_agent_project_bindings` maps only opaque `binding_key` to exact
-new-style `project_id`, with created/updated timestamps. Settings writes the
-binding after resolving and normalizing a local workdir; reads expose a friendly
-local project/workdir label from the primary Avibe store, never by reversing the
-opaque Memory key. Deleting a binding stops new admission and does not rewrite
-queued or provider data already bound to that project.
+`memory_agent_project_bindings` is a replaceable projection of the V2 config. It
+maps only opaque `binding_key` to exact new-style `project_id`, with
+created/updated timestamps. Settings writes the normalized workdir/project pair
+to V2 config; reconcile derives the opaque key with the current Memory scope key
+and transactionally replaces the projection. Reads expose the config's friendly
+local workdir label, never by reversing the opaque Memory key. Clear may remove
+the projection; factory reset creates a new Memory scope key and rebuilds every
+opaque key from the preserved config before an enabled scanner starts. Deleting
+a config binding stops new admission after reconcile and does not rewrite queued
+or provider data already bound to that project.
 
 ## Provider and Sidecar Contracts
 
@@ -362,16 +411,17 @@ stable ids:
 
 | ID | Invariant |
 |---|---|
-| `MEMORY-AGENT-001` | The absent/default config leaves the second root, scanner, and worker off; first enable starts at the current high water. |
+| `MEMORY-AGENT-001` | The absent/default config leaves the second root, scanner, and worker off; every enable starts at the current high water. |
 | `MEMORY-AGENT-002` | Every eligible completed interactive or Harness Turn is represented once by its exact dispatch/result pair. |
 | `MEMORY-AGENT-003` | Admission excludes every terminal shape that does not satisfy the completed-result invariant. |
-| `MEMORY-AGENT-004` | Crash/replay cannot enqueue one source Turn more than once. |
+| `MEMORY-AGENT-004` | Commit ordering and crash/replay cannot lose or enqueue one source Turn more than once. |
 | `MEMORY-AGENT-005` | Agent and project partitions cannot read or write each other's output. |
 | `MEMORY-AGENT-006` | Malformed config, legacy Agent identity, and missing project binding fail closed. |
 | `MEMORY-AGENT-007` | Agent-sidecar outage leaves chat and Personal Memory healthy. |
 | `MEMORY-AGENT-008` | Both role sidecars reject every payload outside their exact owner/shape contract. |
 | `MEMORY-AGENT-009` | CLI/UI retrieval is explicit, bounded, inert, and absent from Agent prompts/install paths. |
 | `MEMORY-AGENT-010` | Accepted processing with zero cases or skills is a truthful valid outcome. |
+| `MEMORY-AGENT-011` | Queue/disk exhaustion skips durably without retaining text or degrading Personal Memory. |
 
 Evidence layers are unit tests for config/identity/admission/store/worker/runtime,
 contract tests for provider/sidecar/internal API/CLI/UI, executable catalog

--- a/docs/plans/memory-agent-track-1424.md
+++ b/docs/plans/memory-agent-track-1424.md
@@ -37,8 +37,10 @@ Personal Memory admission, prompt, provider root, queue, or retrieval semantics.
 5. Agent/project retrieval is explicit, lazy, inert, and bounded. Agent Memory
    is never injected into a prompt, installed as a Codex/Claude skill, or
    executed.
-6. The first version contains only the exact backend dispatch text and terminal
-   result. It does not parse formatted event streams into synthetic tool calls.
+6. The first version contains only the exact final backend dispatch text,
+   durably snapshotted after all transformations and before native dispatch,
+   plus the terminal result. It does not parse formatted event streams into
+   synthetic tool calls.
 7. Enabling the track does not create a project binding. The owner must bind a
    source workdir to either the exact `default` project or an existing/new-style
    named Memory project. Missing bindings fail closed. Binding additions,
@@ -47,11 +49,11 @@ Personal Memory admission, prompt, provider root, queue, or retrieval semantics.
    reports them but does not patch EverOS or file an upstream issue. Retrieval
    exposes skill freshness/maturity metadata, and status adds a conservative
    per-Agent skill-count hint; neither mitigation mutates provider state.
-9. Every disable snapshots and drains through its current terminal-settlement
-   sequence high water. Every disabled-to-enabled transition, Clear, and
-   factory reset initializes the scan cursor to the then-current high water
-   before scanner admission opens. There is no historical, disabled-period, or
-   post-reset replay in v1; only turns settling inside an enabled epoch are
+9. Every enable, disable, Clear, and factory-reset capture cutover records its
+   terminal-settlement high water and recovery intent atomically in the primary
+   state writer transaction. The Memory scan state is an idempotent projection
+   of that cutover. There is no historical, disabled-period, or post-reset
+   replay in v1; only turns settling inside a committed enabled epoch are
    candidates.
 
 ## Product Contract
@@ -93,53 +95,81 @@ for later-settling Turns, while already-settled backlog through its committed
 cutover remains eligible under the old project.
 
 Enabling requires the installed Memory runtime, complete processing endpoints,
-and at least one explicit project binding. Under the agent-capture lifecycle
-lock, every disabled-to-enabled operation snapshots the current committed
-terminal-sequence high water, persists it as the new scan cursor, rebuilds the
-opaque binding projection, and only then opens scanner admission. A disable
-atomically records the current terminal high water as a durable drain target and
-closes the enable epoch and new Agent provider claims. Disable waits for any
-current bounded provider request to settle before stopping the worker and
-sidecar; after that worker-quiescence point, no provider write may start. The
-scanner meanwhile enters local-only
-`disabling` mode and durably enqueues/skips every source through the drain
-target. Only then does the scanner stop and status become `disabled`. Crash
-recovery resumes an unfinished drain. Rows enqueued during the drain remain
-pending without provider I/O and become claimable only after a later enable.
-Re-enable first requires that drain to converge, then advances the cursor past
-the disabled interval before opening a new epoch. A failed start leaves the
-agent-track projection unavailable without disabling Personal Memory or
-restarting the Avibe service.
+and at least one explicit project binding. Enable/disable Settings writes first
+persist the desired V2 config. Under the agent-capture lifecycle lock, one
+serialized primary state transaction then reads terminal high water `H` and
+inserts a singleton `memory_agent_capture_cutover` intent with a new capture
+epoch, desired enabled state, config digest, and `H`. Terminal settlement cannot
+interleave between that read and intent commit.
+
+Normal Agent scanner admission is fenced while a capture intent exists; only
+idempotent cutover projection and the bounded disable drain may run. Enable
+projects an open epoch and cursor `H`, rebuilds opaque bindings, starts the role
+runtime, and only then clears the intent and opens scanner admission. Disable
+first closes new provider claims in the controller, commits its disabled intent,
+then projects the old epoch's inclusive drain target `H`. It waits for any current
+bounded provider request to settle before stopping the worker and sidecar; after
+worker quiescence no provider write may start. The scanner runs local-only in
+`disabling` mode until every source through `H` is enqueued or durably skipped,
+then stops and clears the intent. Rows enqueued by the drain remain pending
+without provider I/O and become claimable only after a later enable.
+
+If Avibe stops after config commit but before an intent, recovery creates the
+intent with a conservative recovery-time `H`. Once an intent exists, recovery
+always reuses its exact epoch and `H`; Memory projection/drain and intent cleanup
+are idempotent. Re-enable requires an earlier disable drain to converge, then
+its own enabled cutover skips the completed opt-out interval. Clear/factory
+reset record the same primary-state intent immediately before recreating scan
+state, after destructive deletion is complete. Turn settlement performs no
+Memory/config I/O and never waits for projection or drain work. A failed start
+leaves only Agent Memory unavailable without disabling Personal Memory or
+restarting Avibe.
 
 ### Admission
 
 One durable `session_turns` row is one candidate trajectory. The scanner reads
 in stable `terminal_sequence` order, joins the owning `agent_sessions` row for
-source workdir/provenance classification, and joins
-`session_turns.executing_agent_id` to the referenced `agents` row. Admission is
-provider-neutral and accepts a row only when all of these invariants hold:
+source workdir, and uses immutable identity/source/text snapshots carried by the
+Turn itself. Admission is provider-neutral and accepts a row only when all of
+these invariants hold:
 
 - the turn is terminal with `terminal_outcome="completed"`;
 - `terminal_evidence_kind="terminal_result"` and the versioned evidence contains
   one non-empty final `result_text`;
-- immutable `dispatch_text` and the final result are valid, nonempty UTF-8 text
-  of at most 256 KiB each;
+- immutable `backend_dispatch_text` and the final result are valid, nonempty
+  UTF-8 text of at most 256 KiB each;
 - no accepted live-steer Delivery is linked to the Turn; v1 excludes steered
   Turns because their accepted instruction text is not durably available after
   materialization and cannot satisfy the exact two-message contract;
-- the Turn's immutable `executing_agent_id` resolves to a real `agents.id`;
-  legacy/pre-migration or backend-only Turns without that snapshot fail closed,
-  while later Session rerouting or Agent rename/disable/archive does not rewrite
-  an already admitted Turn's identity;
-- the source is an ordinary interactive or Harness-request turn, not a callback,
-  system maintenance action, or Agent-to-Agent completion callback; and
+- the Turn carries a nonempty `executing_agent_id` that was validated against a
+  real `agents.id` at start claim; legacy/pre-migration or backend-only Turns
+  without that snapshot fail closed, while later Session rerouting or Agent
+  rename/disable/archive/hard-delete does not rewrite the snapshot;
+- `source_class` is exactly `interactive` or `harness_request`, never `callback`,
+  `maintenance`, `agent_callback`, or missing; and
 - the session workdir resolves through an explicit opaque binding to exactly one
   new-style Memory project.
 
+Every Delivery snapshots one admission-relevant source class from durable
+provenance. FIFO/scheduled compatibility keys include that class, and Turn claim
+asserts that every constituent Delivery matches before writing the Turn's
+`source_class`; an incompatible row remains queued for a later Turn. An ordinary
+Harness request therefore cannot coalesce with a callback even when both use the
+same trigger/backend/Session.
+
+After scheduled attribution, transcription, attachment/file formatting, and all
+other input transformations finish, the shared start boundary persists
+`backend_dispatch_text` plus its digest before invoking the native adapter. The
+adapter must send exactly that stored text. A failed persistence makes no native
+call; an automatic start retry reuses the snapshot instead of re-running a
+text-changing transform. Backend-native acceptance can therefore never precede
+the durable exact input used by Agent Memory.
+
 The property is deliberately positive. Every terminal shape not satisfying the
 complete invariant is skipped, including failed, canceled, stopped/restarted,
-silent, missing-result, malformed-evidence, oversized, accepted-steer, and
-unbound turns. Admission logs only a closed reason and opaque source digest.
+silent, missing-result, missing-final-dispatch, malformed-evidence, oversized,
+accepted-steer, callback-class, and unbound turns. Admission logs only a closed
+reason and opaque source digest.
 
 The v1 trajectory has exactly two ordered messages:
 
@@ -149,7 +179,7 @@ The v1 trajectory has exactly two ordered messages:
     "sender_id": "i-<32 lowercase hex>",
     "role": "user",
     "timestamp": 0,
-    "content": "<exact dispatch_text>"
+    "content": "<exact backend_dispatch_text>"
   },
   {
     "sender_id": "a-<32 lowercase hex>",
@@ -175,8 +205,10 @@ agent_id    = "a-" + HMAC_SHA256(scope_key, "agent:" + agents.id).hex()[:32]
 binding_key = "b-" + HMAC_SHA256(scope_key, "agent-project:" + normalized_workdir).hex()[:32]
 ```
 
-Here `agents.id` is the Turn's immutable `executing_agent_id` snapshot, never a
-later read of the Session's current route.
+Here `agents.id` is the Turn's claim-time-validated immutable
+`executing_agent_id` snapshot, never a later read of the Session route or Agent
+catalog. It deliberately survives hard deletion without constraining the Agent
+row.
 
 The raw Agent id, Agent name, workdir, Session id, Turn id, Run id, platform
 identity, and user principal are never structural Memory columns, owner/filter
@@ -312,20 +344,40 @@ invariants.
 
 ### Commit-ordered terminal source
 
-The infrastructure slice adds two nullable columns to `session_turns` in the
+The infrastructure slice adds these nullable columns to `session_turns` in the
 primary Avibe state schema:
 
-- `executing_agent_id TEXT NULL REFERENCES agents(id) ON DELETE NO ACTION`, an
-  indexed reference to the stable Agent selected by the final execution route;
-  and
+- `executing_agent_id TEXT`, an indexed immutable copy of the stable Agent id
+  selected by the final execution route, deliberately without a foreign key;
+- `source_class TEXT`, constrained on new writes to `interactive`,
+  `harness_request`, `callback`, `maintenance`, or `agent_callback`;
+- `backend_dispatch_text TEXT` and `backend_dispatch_sha256 TEXT`, the exact
+  final backend-facing input and digest; and
 - `terminal_sequence INTEGER`, with a unique partial index.
 
 The initial Delivery claim/Turn creation transaction snapshots
 `executing_agent_id` from the resolved execution route, including an explicit
-Harness/task override. This is observational for Memory: inability to resolve a
-stable Agent id does not block the Turn, but leaves the field `NULL` and makes
-that Turn ineligible for Agent Memory. Retries preserve the first snapshot, and
-no later Session route update may rewrite it.
+Harness/task override, after validating that id against the live Agent catalog.
+It also snapshots the homogeneous Delivery `source_class`. These fields are
+observational for Memory: inability to resolve a stable Agent id/source class
+does not block the Turn, but leaves the field `NULL` and makes that Turn
+ineligible for Agent Memory. The Agent snapshot is not referentially constrained,
+so existing `VibeAgentStore.remove()` hard deletion remains valid; the already
+validated id string survives only as immutable execution history and HMAC input.
+Retries preserve the first snapshots, and no later Session/catalog update may
+rewrite them.
+
+The same primary migration adds nullable `message_deliveries.source_class` with
+the same closed values. Reservation derives it from durable provenance before a
+Delivery can queue; batching compatibility and Turn claim use the column rather
+than reparsing later mutable metadata. Pre-migration/missing classes remain
+fail-closed for Agent Memory but do not block ordinary execution.
+
+Immediately before the first native start call, after every shared/backend input
+transformation, a primary state transaction compares-and-sets
+`backend_dispatch_text` and its SHA-256 digest. The adapter receives that exact
+stored value. A retry must reuse it and a conflicting second value fails closed;
+Memory never derives input from the earlier raw `dispatch_text`.
 
 The transaction that first settles a Turn terminal assigns one greater than the
 maximum non-NULL `terminal_sequence` (or `1` when none exists) while holding
@@ -333,14 +385,14 @@ SQLite's serialized writer lock. The assignment, terminal outcome/evidence,
 and terminal state commit together; retries cannot allocate a second value.
 Consequently sequence order is settlement commit order even when wall time
 moves backward or UUIDs sort in another order. `terminal_at` remains display
-metadata and is never a scanner cursor. Pre-migration terminal rows retain
-`NULL` for both new fields and are not backfilled.
+metadata and is never a scanner cursor. Pre-migration Turn rows retain `NULL`
+for every new field and are not backfilled.
 
-The primary state schema also adds the singleton
-`memory_agent_binding_cutover` recovery record used below. It contains only a
-desired config digest, terminal high water, state, and timestamps; normalized
-workdirs and project ids remain in V2 config, while opaque epochs remain in the
-Memory store.
+The primary state schema also adds bounded singleton
+`memory_agent_capture_cutover` and `memory_agent_binding_cutover` recovery
+records used below. Each contains only its kind/digest/epoch, terminal high
+water, state, and timestamps; normalized workdirs and project ids remain in V2
+config, while opaque epochs remain in the Memory store.
 
 ### Agent trajectory outbox
 
@@ -386,17 +438,15 @@ ambiguous agent write cannot fence user capture.
 ### Scanner cursor and project bindings
 
 `memory_agent_scan_state` is a singleton containing the last committed terminal
-sequence, enable epoch, optional disable/binding drain-through sequence/state,
-durable missed counters, and scan/update timestamps. On every enable cutover
-the cursor advances to the primary store's current maximum before admission
-opens. Clear and factory-reset recovery apply the same cutover
-after deleting or recreating the Memory store: while the shared maintenance
-fence is held, they create the new scan state at the current committed maximum,
-then rebuild bindings, and only then may an enabled scanner start. The scanner
-queries strictly after that sequence in bounded pages. It advances through
-admitted, duplicate, guarded, and closed-skip rows only after the corresponding
-decision is durable. A crash before commit re-reads the same row; the digest
-keeps enqueue idempotent.
+sequence, applied capture epoch/state, optional disable drain-through sequence,
+durable missed counters, and scan/update timestamps. Enable and destructive
+reset projection initialize the cursor from the exact primary capture intent
+high water, never from a fresh cross-database read. Disable projects that same
+intent high water as its inclusive drain target. The scanner queries strictly
+after its cursor in bounded pages and may cross an epoch boundary only according
+to the primary cutover record. It advances through admitted, duplicate, guarded,
+and closed-skip rows only after the corresponding decision is durable. A crash
+before commit re-reads the same row; the digest keeps enqueue idempotent.
 
 `memory_agent_project_bindings` is an opaque, sequence-versioned projection of
 the V2 config. Each epoch stores `binding_key`, exact new-style `project_id`, an
@@ -413,6 +463,11 @@ insert a singleton `memory_agent_binding_cutover` intent containing the desired
 config digest and `H`. Terminal settlement cannot interleave between that read
 and intent commit, but it performs no Memory/config I/O and never waits for
 projection work.
+
+When one Settings save changes both `enabled` and bindings, that same primary
+writer transaction records the capture and binding intents at one shared `H`.
+Binding epochs project before an enabled scanner may open; a disabled drain uses
+the old binding epochs through `H`.
 
 While an intent exists, Agent scanner admission is fenced. One idempotent Memory
 transaction appends/closes the opaque epochs at the intent's exact `H` and
@@ -550,12 +605,12 @@ stable ids:
 
 | ID | Invariant |
 |---|---|
-| `MEMORY-AGENT-001` | The absent/default config leaves the second root, scanner, and worker off; disable snapshots then drains its enabled interval, every enable/reset starts at the correct high water, and Clear accepts either never-created role as absent. |
-| `MEMORY-AGENT-002` | Every semantically eligible non-steered completed interactive or Harness Turn not durably declined by a specified resource guard is represented once by its exact dispatch/result pair. |
-| `MEMORY-AGENT-003` | Admission excludes every terminal shape that does not satisfy the completed-result invariant, including accepted live steers. |
+| `MEMORY-AGENT-001` | The absent/default config leaves the second root, scanner, and worker off; primary-state capture intents make enable/disable/reset cutovers crash-atomic with Turn settlement, and Clear accepts either never-created role as absent. |
+| `MEMORY-AGENT-002` | Every semantically eligible non-steered completed interactive or Harness Turn not durably declined by a specified resource guard is represented once by its exact post-transformation backend-dispatch/result pair. |
+| `MEMORY-AGENT-003` | Admission excludes every terminal shape that does not satisfy the completed-result invariant; source-class batching separates callbacks and accepted live steers are excluded. |
 | `MEMORY-AGENT-004` | Commit ordering and crash/replay cannot lose or enqueue one source Turn more than once. |
-| `MEMORY-AGENT-005` | Agent and project partitions cannot read or write each other's output; the Turn snapshots its executing Agent, and crash-safe post-config binding cutovers keep backlog in the project effective at settlement. |
-| `MEMORY-AGENT-006` | Malformed config, a missing/pre-migration executing-Agent snapshot, and missing project binding fail closed. |
+| `MEMORY-AGENT-005` | Agent and project partitions cannot read or write each other's output; the Turn snapshots its executing Agent without blocking hard deletion, and crash-safe post-config binding cutovers keep backlog in the project effective at settlement. |
+| `MEMORY-AGENT-006` | Malformed config, missing/pre-migration identity/source/final-dispatch snapshots, and missing project binding fail closed. |
 | `MEMORY-AGENT-007` | Agent-sidecar outage leaves chat and Personal Memory healthy. |
 | `MEMORY-AGENT-008` | Both role sidecars reject every payload outside their exact owner/shape contract. |
 | `MEMORY-AGENT-009` | CLI/UI retrieval is explicit, bounded, inert, and absent from Agent prompts/install paths. |

--- a/docs/plans/memory-plugin-system.md
+++ b/docs/plans/memory-plugin-system.md
@@ -117,8 +117,9 @@ There is no shared install-wide pool, workspace memory, or group memory.
 This principal model and the capture table above govern Personal Memory only.
 Opt-in Agent Memory reads completed `session_turns` after settlement, admits
 interactive and Harness turns under a separate positive contract, and partitions
-output by an opaque HMAC-derived Agent id plus an explicit new-style Memory
-project binding. It does not create or read a Personal Memory principal.
+output by an opaque HMAC derived from the Turn's immutable executing `agents.id`
+snapshot plus an explicit new-style Memory project binding. It does not infer
+identity from mutable Session routing or create/read a Personal Memory principal.
 
 The local Settings page always reads `avibe:local`. Authenticated remote
 Workbench users and IM users access only their own principal through an eligible
@@ -223,8 +224,10 @@ runtime/memory/                  # downloaded immutable runtimes and active poin
 
 Schema v3 introduced the durable Personal Memory project catalog. Schema v4
 adds separate Agent trajectory, scan-cursor, and sequence-versioned opaque
-project-binding tables; it does not overload `memory_capture_queue` or rewrite
-schema-v3 user rows.
+project-binding tables; the primary state schema also adds nullable immutable
+executing-Agent and commit-order snapshots to `session_turns` plus a bounded
+binding-cutover recovery record. It does not overload `memory_capture_queue` or
+rewrite schema-v3 user rows.
 
 The root sentinel binds a random `provider_root_id`, provider id, root format,
 and artifact fingerprint. Clear treats a fully absent, never-created role as a

--- a/docs/plans/memory-plugin-system.md
+++ b/docs/plans/memory-plugin-system.md
@@ -296,8 +296,10 @@ never logged or serialized as errors.
 ### Disable and re-enable
 
 Disabling Personal Memory closes user capture/content reads and stops its worker
-and chat sidecar. Disabling Agent Memory independently stops its scanner, worker,
-and agent sidecar. Both preserve their queues and provider data. Neither toggle
+and chat sidecar. Disabling Agent Memory independently closes scanner admission,
+stops its worker and agent sidecar, and preserves already admitted rows/provider
+data. Every later enable advances the scanner to the current terminal-settlement
+high water, so work completed during opt-out is never imported. Neither toggle
 mode-flips or deletes the other root.
 
 Changing only an API key is allowed without replacing the vector space.
@@ -312,9 +314,13 @@ idempotent. Under the shared lifecycle lock it:
 
 1. records `clear_in_progress` and advances the epoch;
 2. pauses both role workers/scanner and stops each owned sidecar;
-3. validates and removes children of both exact sentinel-owned provider roots
-   without following links;
-4. removes every user/agent queue row and recreates empty owned roots; and
+3. validates and removes children of the exact sentinel-owned chat root and any
+   existing sentinel-owned Agent root without following links (a never-created,
+   fully absent Agent root is a successful no-op; unexpected unowned paths fail
+   closed);
+4. removes every user/agent queue row, recreates the chat root, and recreates the
+   Agent root only when it existed before Clear or Agent Memory remains enabled;
+   and
 5. clears the recovery marker and restarts Memory only if it remains enabled.
 
 Startup resumes an interrupted clear before opening Memory. A restart failure

--- a/docs/plans/memory-plugin-system.md
+++ b/docs/plans/memory-plugin-system.md
@@ -1,6 +1,6 @@
 # Memory Plugin System
 
-> Status: implemented beta
+> Status: Personal Memory implemented beta; Agent Memory approved for implementation
 >
 > This is the canonical product and architecture contract for the complete
 > Memory plugin system, including the final behavior from
@@ -8,16 +8,22 @@
 > technical, POC, and follow-up documents are retained in Git history only.
 
 Memory is an optional built-in Avibe capability backed by an independently
-packaged EverOS runtime. It captures eligible human input into a local queue,
-processes that queue outside the chat response path, and exposes user-scoped
-profile, search, status, and explicit Agent writes.
+packaged EverOS runtime. Personal Memory captures eligible human input into a
+local queue and exposes user-scoped profile, search, status, and explicit Agent
+writes. The separately enabled Agent Memory track copies eligible completed
+Agent Turns into an isolated provider root for explicit case/skill retrieval.
+Both tracks process work outside the chat and Agent response paths.
 
 The core product invariants are:
 
 - normal chat never waits for Memory processing and continues when Memory fails;
 - installing the runtime never enables Memory, and startup never downloads it;
-- every captured or recalled item is scoped to one derived user principal;
-- automatic capture accepts human input only, never assistant or tool output;
+- every Personal Memory item is scoped to one derived user principal, and every
+  Agent Memory item to one opaque Agent id plus exact project;
+- Personal Memory automatic capture accepts human input only, never assistant
+  or tool output;
+- Agent Memory is off by default and accepts only completed durable Turn
+  trajectories through its separate queue and agent-mode provider root;
 - Agents recall only through an explicit, capability-gated CLI call; there is no
   automatic prompt injection;
 - configuration and destructive operations remain in the local Settings UI;
@@ -25,6 +31,9 @@ The core product invariants are:
   instructions; and
 - runtime code, Avibe queue state, and provider data have separate ownership and
   deletion boundaries.
+
+The Agent Memory implementation contract, including its accepted EverOS 1.2.3
+limitations, is [`memory-agent-track-1424.md`](./memory-agent-track-1424.md).
 
 ## Product Surface
 
@@ -104,6 +113,12 @@ and provider session references include the principal and current clear epoch.
 This is isolation, not identity linking. The same person on two platforms has
 two principals unless a future product explicitly introduces account linking.
 There is no shared install-wide pool, workspace memory, or group memory.
+
+This principal model and the capture table above govern Personal Memory only.
+Opt-in Agent Memory reads completed `session_turns` after settlement, admits
+interactive and Harness turns under a separate positive contract, and partitions
+output by an opaque HMAC-derived Agent id plus an explicit new-style Memory
+project binding. It does not create or read a Personal Memory principal.
 
 The local Settings page always reads `avibe:local`. Authenticated remote
 Workbench users and IM users access only their own principal through an eligible
@@ -200,14 +215,15 @@ State is split under the effective `AVIBE_HOME` (normally `~/.avibe`):
 state/memory/memory.sqlite       # Avibe queue and operational metadata
 memory/everos-root/              # sentinel-owned provider data
 memory/.rt/everos.sock           # private sidecar socket
-memory/generated/                # generated non-secret provider config
+memory/everos-agent-root/        # optional isolated Agent Memory provider data
+memory/.rt/everos-agent.sock     # optional private Agent Memory sidecar socket
+memory/generated/{chat,agent}/   # role-pinned non-secret provider configs
 runtime/memory/                  # downloaded immutable runtimes and active pointer
 ```
 
-The SQLite store has only `memory_meta` and `memory_capture_queue`. The initial
-schema is edited in place because Memory has not shipped; old development state
-from an earlier branch revision must be reset explicitly rather than through a
-silent startup migration.
+Schema v3 introduced the durable Personal Memory project catalog. Schema v4
+adds separate Agent trajectory, scan-cursor, and opaque project-binding tables;
+it does not overload `memory_capture_queue` or rewrite schema-v3 user rows.
 
 The root sentinel binds a random `provider_root_id`, provider id, root format,
 and artifact fingerprint. Clear and runtime activation refuse missing,
@@ -279,10 +295,10 @@ never logged or serialized as errors.
 
 ### Disable and re-enable
 
-Disable closes capture and content reads, pauses the worker, and stops the
-sidecar. It preserves queued rows, tombstones, provider data, and stored endpoint
-credentials. Status and Clear all remain available. Re-enable starts the same
-verified runtime and resumes pending work.
+Disabling Personal Memory closes user capture/content reads and stops its worker
+and chat sidecar. Disabling Agent Memory independently stops its scanner, worker,
+and agent sidecar. Both preserve their queues and provider data. Neither toggle
+mode-flips or deletes the other root.
 
 Changing only an API key is allowed without replacing the vector space.
 Changing the embedding endpoint or model while provider data exists is rejected.
@@ -295,10 +311,10 @@ Clear all is local-Settings-only, CSRF-protected, explicitly confirmed, and
 idempotent. Under the shared lifecycle lock it:
 
 1. records `clear_in_progress` and advances the epoch;
-2. pauses claims and stops the owned sidecar;
-3. validates and removes children of the exact sentinel-owned provider root
+2. pauses both role workers/scanner and stops each owned sidecar;
+3. validates and removes children of both exact sentinel-owned provider roots
    without following links;
-4. removes every queue row and recreates an empty owned root; and
+4. removes every user/agent queue row and recreates empty owned roots; and
 5. clears the recovery marker and restarts Memory only if it remains enabled.
 
 Startup resumes an interrupted clear before opening Memory. A restart failure
@@ -312,10 +328,10 @@ not remove the installed `memory-runtime`.
 
 ## Managed Runtime and Release
 
-The production provider is official EverOS 1.1.3 behind the internal adapter.
+The production provider is official EverOS 1.2.3 behind the internal adapter.
 The independently built `memory-runtime` pins:
 
-- EverOS 1.1.3;
+- EverOS 1.2.3;
 - Python 3.12.12;
 - uv 0.9.18; and
 - the reviewed `scripts/memory_runtime/uv.lock` digest.
@@ -359,12 +375,13 @@ with different content.
   as that account's remote Workbench messages. The install-wide settings,
   diagnostics, runtime restart, and Clear all controls remain owner operations
   protected by the signed Cloud session and same-origin/CSRF checks.
-- The controller socket and EverOS socket are owner-only Unix-domain sockets in
-  mode `0600`; the sidecar has no TCP listener and is not exposed through remote
-  access.
-- The sidecar accepts only health plus the exact add, flush, search, and get
-  shapes used by Avibe. Principals must match `u-[0-9a-f]{32}`, and file URIs
-  must stay inside the Workbench attachment root.
+- The controller socket and both role-specific EverOS sockets are owner-only
+  Unix-domain sockets in mode `0600`; neither sidecar has a TCP listener or is
+  exposed through remote access.
+- Each sidecar accepts only health plus its exact add, flush, search, and get
+  shapes. Chat principals match `u-[0-9a-f]{32}`; Agent owners match
+  `a-[0-9a-f]{32}`. File URIs are chat-only and must stay inside the Workbench
+  attachment root.
 - Child environment variables are allowlisted. Outside Avibe's owner-only
   config, API keys reach the provider only through the sidecar environment;
   generated files contain no secrets, and proxy/TLS override variables are not
@@ -379,11 +396,14 @@ platform identities belong to the same human.
 
 ## Deliberate Non-goals
 
-The beta does not include automatic recall, assistant-message capture,
+The beta does not include automatic recall, Personal Memory assistant-message
+capture, tool-rich Agent trajectories,
 group/workspace/shared memory, cross-platform identity linking,
 registered backend-specific Memory tools, item-level edit/delete, export/import,
 provider migration, editable provider Markdown, exactly-once provider delivery,
-or agent-driven configuration and Clear all. Each requires a separate product
+or agent-driven configuration and Clear all. Extracted Agent skills are never
+installed, executed, or prompt-injected. Each omitted capability requires a
+separate product
 and migration contract rather than placeholder interfaces in this system.
 
 ## Verification Contract

--- a/docs/plans/memory-plugin-system.md
+++ b/docs/plans/memory-plugin-system.md
@@ -52,10 +52,14 @@ The setup flow is deliberately staged:
    reached from Dependencies.
 
 Enablement requires complete endpoint blocks, bounded authenticated probes, a
-verified runtime, an owned provider root, and a healthy sidecar. A failed enable
-rolls the persisted setting back to disabled. API keys are write-only: responses
-expose only `has_api_key`, omission preserves an existing key, and explicit key
-clearing is allowed only while the resulting configuration is disabled.
+verified runtime, an owned provider root, and a healthy sidecar. A failed
+Personal Memory enable rolls its persisted setting back to disabled. Agent
+Memory follows its separate cutover contract: a post-commit role-start failure
+retains the desired enabled setting and recovery intent in degraded state, keeps
+capture/claims closed, and retries only through the controller role-recovery
+path. API keys are write-only: responses expose only `has_api_key`, omission
+preserves an existing key, and explicit key clearing is allowed only while the
+resulting configuration is disabled.
 
 The Settings page provides:
 
@@ -317,9 +321,18 @@ pending Agent rows claimable. Neither toggle mode-flips or deletes the other
 root.
 
 Changing only an API key is allowed without replacing the vector space.
-Changing the embedding endpoint or model while provider data exists is rejected.
-The supported replacement flow is: disable Memory, Clear all, change the
-embedding configuration, then re-enable.
+Changing the embedding endpoint or model while either sentinel-owned role root
+contains data requires explicit **Save and rebuild** confirmation; Disable,
+Clear, and re-enable is not the replacement flow. The controller persists the
+candidate plus durable rebuild intent, performs one bounded preflight, fences
+both roles, quiesces both sidecars, and rebuilds each nonempty chat/Agent root
+independently while preserving its Markdown/provider data. Neither role may
+activate against the new vector-space identity until every nonempty owned root
+has converged. A partial failure retains the candidate and intent, keeps both
+roles fenced, and resumes idempotently through **Retry rebuild**. If rebuild
+settled but later role activation fails, the repaired roots remain intact and
+the degraded role uses **Restart engine**; Clear remains only the explicit
+destructive recovery action.
 
 ### Clear all
 

--- a/docs/plans/memory-plugin-system.md
+++ b/docs/plans/memory-plugin-system.md
@@ -118,8 +118,10 @@ This principal model and the capture table above govern Personal Memory only.
 Opt-in Agent Memory reads completed `session_turns` after settlement, admits
 interactive and Harness turns under a separate positive contract, and partitions
 output by an opaque HMAC derived from the Turn's immutable executing `agents.id`
-snapshot plus an explicit new-style Memory project binding. It does not infer
-identity from mutable Session routing or create/read a Personal Memory principal.
+snapshot plus an explicit new-style Memory project binding. Turn creation also
+freezes a homogeneous source class, and native start durably records the exact
+post-transformation backend text before dispatch. It does not infer identity
+from mutable Session routing or create/read a Personal Memory principal.
 
 The local Settings page always reads `avibe:local`. Authenticated remote
 Workbench users and IM users access only their own principal through an eligible
@@ -225,9 +227,10 @@ runtime/memory/                  # downloaded immutable runtimes and active poin
 Schema v3 introduced the durable Personal Memory project catalog. Schema v4
 adds separate Agent trajectory, scan-cursor, and sequence-versioned opaque
 project-binding tables; the primary state schema also adds nullable immutable
-executing-Agent and commit-order snapshots to `session_turns` plus a bounded
-binding-cutover recovery record. It does not overload `memory_capture_queue` or
-rewrite schema-v3 user rows.
+executing-Agent/source-class/final-dispatch and commit-order snapshots to
+`session_turns`, a matching immutable source class on `message_deliveries`, plus
+bounded capture/binding cutover recovery records. It does not overload
+`memory_capture_queue` or rewrite schema-v3 user rows.
 
 The root sentinel binds a random `provider_root_id`, provider id, root format,
 and artifact fingerprint. Clear treats a fully absent, never-created role as a
@@ -301,15 +304,17 @@ never logged or serialized as errors.
 ### Disable and re-enable
 
 Disabling Personal Memory closes user capture/content reads and stops its worker
-and chat sidecar. Disabling Agent Memory independently snapshots a durable
-terminal high-water drain target, closes new provider claims, waits for any
-current bounded request to settle, and then stops its provider worker/sidecar.
-It leaves only the local scanner running until every enabled-period source
-through that target is enqueued or durably skipped, then stops the scanner.
-Drained rows remain pending without provider I/O. Every later enable first
-requires that drain to converge, advances past work completed during opt-out,
-and only then makes pending Agent rows claimable. Neither toggle mode-flips or
-deletes the other root.
+and chat sidecar. Disabling Agent Memory independently closes new provider
+claims, then atomically records its capture epoch/high water in the same primary
+state writer transaction that orders terminal Turns. The Agent scan state
+projects that exact drain target. Disable waits for any current bounded request
+to settle, stops its provider worker/sidecar, and leaves only the local scanner
+running until every enabled-period source through the target is enqueued or
+durably skipped. Drained rows remain pending without provider I/O. Every later
+enable uses the same primary-state cutover protocol, first requires that drain
+to converge, advances past work completed during opt-out, and only then makes
+pending Agent rows claimable. Neither toggle mode-flips or deletes the other
+root.
 
 Changing only an API key is allowed without replacing the vector space.
 Changing the embedding endpoint or model while provider data exists is rejected.

--- a/docs/plans/memory-plugin-system.md
+++ b/docs/plans/memory-plugin-system.md
@@ -264,7 +264,7 @@ Important fixed guards are:
 | Memory attachment bundle | 8 files; 25 MiB/file; 100 MiB total; 16 KiB descriptor metadata |
 | Nonterminal queue | 500 rows |
 | Minimum free disk for capture | 512 MiB |
-| Terminal idempotency tombstones | 90 days, newest 100,000 rows |
+| Personal and Agent terminal idempotency tombstones | 90 days, newest 100,000 rows per queue |
 | Search query/results | 8 KiB query; 1-20 items; 64 KiB/item; 256 KiB total; 20 s |
 
 At a queue or disk guard, capture is skipped and an aggregate missed counter is
@@ -272,10 +272,10 @@ updated; normal chat still proceeds.
 
 ### Status and failure behavior
 
-Status uses the closed states `disabled`, `starting`, `ready`, `syncing`,
-`degraded`, `down`, `clearing`, and `error`. It includes pending, processing,
-awaiting-receipt, succeeded, unknown, distillation-failed, dead, and missed
-counters plus the latest sanitized processing observation.
+Status uses the closed states `disabled`, `disabling`, `starting`, `ready`,
+`syncing`, `degraded`, `down`, `clearing`, and `error`. It includes pending,
+processing, awaiting-receipt, succeeded, unknown, distillation-failed, dead, and
+missed counters plus the latest sanitized processing observation.
 
 Sidecar or endpoint outages pause new claims and trigger bounded
 supervision/backoff. Work not yet added remains pending; an ambiguous flush is
@@ -296,11 +296,15 @@ never logged or serialized as errors.
 ### Disable and re-enable
 
 Disabling Personal Memory closes user capture/content reads and stops its worker
-and chat sidecar. Disabling Agent Memory independently closes scanner admission,
-stops its worker and agent sidecar, and preserves already admitted rows/provider
-data. Every later enable advances the scanner to the current terminal-settlement
-high water, so work completed during opt-out is never imported. Neither toggle
-mode-flips or deletes the other root.
+and chat sidecar. Disabling Agent Memory independently snapshots a durable
+terminal high-water drain target, closes new provider claims, waits for any
+current bounded request to settle, and then stops its provider worker/sidecar.
+It leaves only the local scanner running until every enabled-period source
+through that target is enqueued or durably skipped, then stops the scanner.
+Drained rows remain pending without provider I/O. Every later enable first
+requires that drain to converge, advances past work completed during opt-out,
+and only then makes pending Agent rows claimable. Neither toggle mode-flips or
+deletes the other root.
 
 Changing only an API key is allowed without replacing the vector space.
 Changing the embedding endpoint or model while provider data exists is rejected.

--- a/docs/plans/memory-plugin-system.md
+++ b/docs/plans/memory-plugin-system.md
@@ -47,9 +47,10 @@ The setup flow is deliberately staged:
    `/admin/settings/memory` (`/settings/memory` redirects there).
 3. The owner configures separate OpenAI-compatible LLM and embedding endpoints,
    reviews the data disclosure, and explicitly enables Memory.
-4. After the runtime is installed and Memory is enabled, **Memory - Beta** is
-   visible in Settings navigation. Before then, the route still exists but is
-   reached from Dependencies.
+4. After the runtime is installed and either Personal Memory or Agent Memory is
+   enabled, **Memory - Beta** is visible in Settings navigation. It also remains
+   visible while either role has a pending recovery intent. Before then, the
+   route still exists but is reached from Dependencies.
 
 Enablement requires complete endpoint blocks, bounded authenticated probes, a
 verified runtime, an owned provider root, and a healthy sidecar. A failed
@@ -57,9 +58,14 @@ Personal Memory enable rolls its persisted setting back to disabled. Agent
 Memory follows its separate cutover contract: a post-commit role-start failure
 retains the desired enabled setting and recovery intent in degraded state, keeps
 capture/claims closed, and retries only through the controller role-recovery
-path. API keys are write-only: responses expose only `has_api_key`, omission
-preserves an existing key, and explicit key clearing is allowed only while the
-resulting configuration is disabled.
+path. Every writer of Personal, Agent, endpoint, credential, or repair/rebuild
+Memory config submits a field-scoped revision-checked patch through the
+controller's single cross-process lifecycle/config transaction; UI,
+compatibility, and maintenance processes do not persist Memory config directly.
+API keys are write-only: responses
+expose only `has_api_key`, omission preserves an existing key, and explicit key
+clearing is allowed only when the resulting configuration disables both roles
+and no pending recovery intent requires the credential.
 
 The Settings page provides:
 
@@ -420,7 +426,14 @@ with different content.
   inherited.
 - Captured text, attachment content, and search queries may be sent to the
   configured Memory endpoints and retained under those providers' policies.
-  Disable retains local data; only Clear all removes Avibe-owned Memory data.
+  Disable retains local data. **Clear Memory Data** removes both roles'
+  Avibe-owned provider data, queues, and call-log/health state while preserving
+  installed runtime artifacts, settings, credentials, and bindings.
+  **Reinitialize** also deletes the mixed-purpose `memory/` and `state/memory/`
+  trees, including both provider roots and operational state, then recreates
+  them from preserved settings/credentials/bindings and the installed artifact.
+  Neither operation is a secure wipe or deletes copies retained by remote
+  processing providers.
 
 These controls enforce the supported product surfaces. They are not a sandbox
 against arbitrary code running as the same OS account and do not prove that two

--- a/docs/plans/memory-plugin-system.md
+++ b/docs/plans/memory-plugin-system.md
@@ -267,12 +267,21 @@ distinguishes queued work, delivered-but-awaiting receipt, successful
 distillation, rejected distillation, and an unknown result without inspecting
 EverOS private files.
 
-Delivery is at least once. A crash or timeout can produce duplicate derived
-memory. Infrastructure outages pause claims without consuming a row's retry
-budget; a failure isolated to one message retries at fixed backoff and becomes
-dead after three failed attempts. Terminal rows contain no source payload. A
-sanitized failure history reports abandoned delivery, rejected distillation,
-and unknown results without provider bodies or user text.
+Personal Memory delivery is at least once. A crash or timeout can produce
+duplicate derived Personal memory. Personal infrastructure outages pause claims
+without consuming a row's retry budget; a failure isolated to one message
+retries at fixed backoff and becomes dead after three failed attempts.
+
+Agent Memory uses its separate schema-v4 queue contract. A failure proven to be
+before submission may retry with its deterministic request, but an `/add`
+timeout or other unknown post-submission outcome immediately becomes a scrubbed
+Agent-only dead letter and is never replayed automatically. A confirmed add
+receipt authorizes payload scrubbing and any required flush retry uses only the
+durable session/app/project scope. This avoids duplicate derived Agent cases or
+skills while preserving Personal Memory's at-least-once behavior. Terminal rows
+in both queues contain no source payload. A sanitized failure history reports
+abandoned delivery, rejected distillation, and unknown results without provider
+bodies or user text.
 
 Important fixed guards are:
 

--- a/docs/plans/memory-plugin-system.md
+++ b/docs/plans/memory-plugin-system.md
@@ -222,12 +222,14 @@ runtime/memory/                  # downloaded immutable runtimes and active poin
 ```
 
 Schema v3 introduced the durable Personal Memory project catalog. Schema v4
-adds separate Agent trajectory, scan-cursor, and opaque project-binding tables;
-it does not overload `memory_capture_queue` or rewrite schema-v3 user rows.
+adds separate Agent trajectory, scan-cursor, and sequence-versioned opaque
+project-binding tables; it does not overload `memory_capture_queue` or rewrite
+schema-v3 user rows.
 
 The root sentinel binds a random `provider_root_id`, provider id, root format,
-and artifact fingerprint. Clear and runtime activation refuse missing,
-mismatched, symlinked, or unowned roots.
+and artifact fingerprint. Clear treats a fully absent, never-created role as a
+no-op; a present role path with a missing, mismatched, symlinked, or unowned
+sentinel fails closed, as does runtime activation.
 
 ### Queue and delivery semantics
 
@@ -318,13 +320,12 @@ idempotent. Under the shared lifecycle lock it:
 
 1. records `clear_in_progress` and advances the epoch;
 2. pauses both role workers/scanner and stops each owned sidecar;
-3. validates and removes children of the exact sentinel-owned chat root and any
-   existing sentinel-owned Agent root without following links (a never-created,
-   fully absent Agent root is a successful no-op; unexpected unowned paths fail
+3. validates and removes children of each existing exact sentinel-owned role
+   root without following links (a never-created, fully absent chat or Agent
+   root is independently a successful no-op; unexpected unowned paths fail
    closed);
-4. removes every user/agent queue row, recreates the chat root, and recreates the
-   Agent root only when it existed before Clear or Agent Memory remains enabled;
-   and
+4. removes every user/agent queue row and recreates each role root only when it
+   existed before Clear or that role remains enabled; and
 5. clears the recovery marker and restarts Memory only if it remains enabled.
 
 Startup resumes an interrupted clear before opening Memory. A restart failure


### PR DESCRIPTION
Part of #1424.

## Capability

Freezes the implementation contract for the opt-in EverOS Agent Memory track before code: separate chat/agent provider roots and lifecycle slots, completed `session_turns` admission, a commit-ordered terminal source, schema-v4 agent queue/cursor/bindings, HMAC Agent identity, exact sidecar payloads, inert explicit retrieval, failure isolation, and accepted EverOS 1.2.3 limitations with owner-approved freshness/maturity and skill-count observability mitigations. It also updates the canonical Memory architecture and recovery documentation without enabling runtime behavior.

## Scenario IDs

- `MEMORY-AGENT-001` - primary-state capture cutovers, disable drain, reset high water, and symmetric absent-root Clear
- `MEMORY-AGENT-002` - exact post-transformation backend trajectory except durable resource-guard skips
- `MEMORY-AGENT-003` - homogeneous source-class batching and steer/callback exclusion
- `MEMORY-AGENT-004` - commit ordering and crash/replay idempotency
- `MEMORY-AGENT-005` - deletion-safe immutable executing-Agent identity and crash-safe binding cutovers
- `MEMORY-AGENT-006` - malformed config/missing identity-source-final snapshots/missing binding
- `MEMORY-AGENT-007` - agent-sidecar outage isolation
- `MEMORY-AGENT-008` - exact role-specific sidecar rejection
- `MEMORY-AGENT-009` - explicit bounded inert retrieval
- `MEMORY-AGENT-010` - zero-output processing is valid
- `MEMORY-AGENT-011` - queue/disk exhaustion and closed-row retention
- `MEMORY-AGENT-012` - skill freshness/maturity and budgeted count-risk sampling
- `MEMORY-AGENT-013` - exact trajectory attribution disclosure and identity isolation

The executable catalog and closed-loop scenario harness land in PR5.

## Evidence layers

- Unit: deferred to infrastructure/capture/retrieval slices; PR1 changes no runtime code
- Contract: `docs/plans/memory-agent-track-1424.md` freezes identities, paths, payloads, state/migration boundaries, admission, degradation, and five-PR slicing
- Scenario: stable IDs and invariants defined now; executable catalog deferred to PR5
- Residual manual: no live EverOS or local Avibe service probe; all runtime verification is deferred to hermetic implementation tests and the packaged-runtime regression in PR5

## Dependencies and deviations

- Dependencies: none; rebased onto latest `master`
- Deviations from the approved #1424 plan: none
- Cross-lane scope: documentation only; no #1425-owned or shared implementation file changed

## Known by design

- Enable/disable/reset commit high water plus capture intent atomically with terminal sequencing in primary state; disable then drains the enabled epoch locally, so v1 never backfills historical or opt-out-period Turns.
- V1 persists the exact final backend dispatch after all transformations and before native start, then captures it with the final result, each bounded to 256 KiB. Source-class batching prevents callback coalescing; accepted live steers are excluded and tool calls are not synthesized. Exact content can retain disclosed attribution bytes, but they never become structural Memory identity or scope.
- Project binding is explicit and fail-closed in V2 config; no implicit `default` binding is created. V1 accepts at most 128 bindings with 4,096-byte workdir/project-id fields.
- Each Turn snapshots its final executing `agents.id` during durable start claim without a catalog foreign key; Session rerouting, Harness/task overrides, and later Agent hard deletion cannot move or invalidate a completed trajectory.
- Binding add/reassignment/removal persists desired config, then atomically records committed terminal high water plus a primary-state cutover intent; the scanner fences until sequence-versioned opaque epochs publish, while Turn settlement never waits for Memory projection work.
- Agent queue admission independently caps nonterminal work at 500 rows and requires 512 MiB free, with aggregate missed-work accounting and no rejected text retention; scrubbed terminal tombstones retain at most 90 days and the newest 100,000 rows.
- A fully absent, never-created Personal or Agent root is independently a successful Clear no-op; present unowned paths still fail closed.
- Agent Memory is never prompt-injected, installed, or executed.
- EverOS 1.2.3 skill-retire, sanitized-name collision, above-ten-skill index-lag, zero-output, and progressive-disclosure limitations are accepted and isolated from Personal Memory. Skill output exposes exact `updated_at`/maturity metadata, while an incremental 32-request/concurrency-two sampler reports non-blocking per-Agent count hints at 8 and 11 skills; neither mitigation changes provider data or files an upstream issue.

Closes no issue; four implementation/evidence PRs follow after this PR is approved and merged.
