### PR TITLE
fix(watch): preserve zero timing values on read

### DIFF
--- a/storage/background.py
+++ b/storage/background.py
@@ -8800,10 +8800,18 @@ class SQLiteBackgroundTaskStore:
             "message_payload": _json_loads(row["message_payload_json"], None),
             "cwd": row["cwd"],
             "mode": row["mode"] or "once",
-            "timeout_seconds": float(row["timeout_seconds"] or 21600.0),
+            "timeout_seconds": (
+                float(row["timeout_seconds"])
+                if row["timeout_seconds"] is not None
+                else 21600.0
+            ),
             "lifetime_timeout_seconds": float(row["lifetime_timeout_seconds"] or 0.0),
             "retry_exit_codes": [int(code) for code in _json_loads(row["retry_exit_codes_json"], [])],
-            "retry_delay_seconds": float(row["retry_delay_seconds"] or 30.0),
+            "retry_delay_seconds": (
+                float(row["retry_delay_seconds"])
+                if row["retry_delay_seconds"] is not None
+                else 30.0
+            ),
             "post_to": row["post_to"],
             "deliver_key": row["deliver_key"],
             "enabled": bool(row["enabled"]),

--- a/tests/test_harness_definition_lifecycle.py
+++ b/tests/test_harness_definition_lifecycle.py
@@ -133,6 +133,41 @@ def test_watch_row_serializer_covers_every_managed_watch_field(store) -> None:
     assert {field.name for field in fields(ManagedWatch)} <= set(row)
 
 
+def test_watch_numeric_defaults_preserve_zero_and_restore_nulls(store) -> None:
+    """Every numeric Watch setting preserves zero and restores its declared default."""
+    from dataclasses import MISSING, fields
+    from numbers import Real
+
+    from core.watches import ManagedWatch
+
+    numeric_defaults = {
+        field.name: field.default
+        for field in fields(ManagedWatch)
+        if field.default is not MISSING
+        and isinstance(field.default, Real)
+        and not isinstance(field.default, bool)
+    }
+    zero_values = dict.fromkeys(numeric_defaults, 0)
+
+    _watch(store, "zero-values", **zero_values)
+    zero_row = store.get_watch("zero-values")
+    assert {name: zero_row[name] for name in numeric_defaults} == zero_values
+
+    _watch(store, "absent-values")
+    absent_row = store.get_watch("absent-values")
+    assert {name: absent_row[name] for name in numeric_defaults} == numeric_defaults
+
+    _watch(store, "null-values")
+    with store.engine.begin() as connection:
+        connection.execute(
+            update(run_definitions)
+            .where(run_definitions.c.id == "null-values")
+            .values({name: None for name in numeric_defaults})
+        )
+    null_row = store.get_watch("null-values")
+    assert {name: null_row[name] for name in numeric_defaults} == numeric_defaults
+
+
 def test_watch_states_separate_the_switch_from_the_history(store) -> None:
     """The four states, one fixture per rule (plan §2)."""
     _watch(store, "armed")


### PR DESCRIPTION
## Changed capability

Watch definition reads now preserve explicitly stored zero values for per-cycle timeout and retry delay while continuing to map SQL NULL to the documented defaults.

## Why

The SQLite writer already distinguishes an absent key from an explicit zero. The reader used truthiness, which changed stored zero values to 21600 seconds and 30 seconds respectively.

The timing columns are nullable because tasks and watches share `run_definitions`; released SQLite Watch writers have always stored a numeric value for Watch rows, while scheduled-task rows intentionally use NULL in these columns.

## Evidence

- Unit: full `tests/test_harness_definition_lifecycle.py` suite passed (73 tests).
- Contract: a real SQLite store round-trip dynamically covers every numeric `ManagedWatch` field with a declared default, proving zero preservation and absent/NULL fallback.
- Scenario IDs: none; this storage invariant has no cataloged user-flow scenario.
- Scenario: existing Watch reload zero-value and CLI zero-timeout tests passed.
- Residual manual checks: none; downstream model parsing, waiter execution, retry sleep, and CLI display were inspected and do not reapply truthy defaults.

## Known by design

- The shared columns remain nullable; no schema migration is needed.
- `lifetime_timeout_seconds` keeps its existing `or 0.0` read because its documented default equals the falsy value.

## Dependencies

None.
