### PR TITLE
fix(watch): preserve completed cycle outcome pair

### DIFF
--- a/core/watches.py
+++ b/core/watches.py
@@ -809,8 +809,8 @@ class ManagedWatchStore:
             return False
         expect = self._read_state(watch)
         watch.last_started_at = _utc_now_iso()
-        if watch.retired_at is None:
-            watch.last_error = None
+        # The outcome pair describes the last completed cycle. Keep it stable while
+        # the next cycle is in flight; ``mark_cycle_result`` owns both fields.
         watch.updated_at = _utc_now_iso()
         # A runtime stamp: a lost write is reported by the return value, not by an
         # exception through the supervisor loop.

--- a/tests/test_harness_failure_visibility.py
+++ b/tests/test_harness_failure_visibility.py
@@ -12444,9 +12444,11 @@ def test_a_forever_watch_repeating_the_field_failure_notifies_once(
     assert second_claim is not None
     asyncio.run(executor._execute_claimed_request(second_claim))
 
-    def _ready() -> bool:
+    sentinel = "watch command exited with status 75"
+
+    def _last_completed_cycle_is_retry() -> bool:
         row = watch_store.get_watch(watch.id)
-        return row is not None and row.last_exit_code == 75
+        return row is not None and (row.last_exit_code, row.last_error) == (75, sentinel)
 
     service = ManagedWatchService(
         controller=SimpleNamespace(),
@@ -12454,7 +12456,14 @@ def test_a_forever_watch_repeating_the_field_failure_notifies_once(
         request_store=requests,
         runtime_store=runtime_store,
     )
-    asyncio.run(_drive_watch_service(service, watch.id, until=_ready, limit=800))
+    asyncio.run(
+        _drive_watch_service(
+            service,
+            watch.id,
+            until=_last_completed_cycle_is_retry,
+            limit=800,
+        )
+    )
 
     hooks = [first_hook, second_hook]
     assert len(hooks) == 2, f"two events must queue two follow-up deliveries: {hooks}"
@@ -12467,7 +12476,6 @@ def test_a_forever_watch_repeating_the_field_failure_notifies_once(
     assert saved.retired_at is None and saved.last_finished_at is None, (
         f"nor stamp a retirement on a watch that is still running: {saved}"
     )
-    sentinel = "watch command exited with status 75"
     assert saved.last_error == sentinel and saved.last_exit_code == 75, (
         f"the premise for the last assertion below — the last cycle was a retry: {saved}"
     )

--- a/tests/test_watches.py
+++ b/tests/test_watches.py
@@ -650,6 +650,41 @@ def test_hfr_479_late_cycle_cannot_replace_committed_watch_terminal_outcome(
     assert sqlite.get_run(late_run.id) is not None
 
 
+def test_cycle_start_preserves_last_completed_outcome_pair(tmp_path: Path) -> None:
+    """Starting a cycle must not tear the last completed cycle's outcome pair."""
+
+    store = ManagedWatchStore(tmp_path / "watches.json")
+    watch = store.add_watch(
+        name="retrying watch",
+        session_key="",
+        command=[],
+        shell_command="exit 75",
+        prefix=None,
+        cwd=None,
+        mode="forever",
+        timeout_seconds=0,
+        lifetime_timeout_seconds=0,
+        retry_exit_codes=[75],
+        retry_delay_seconds=0,
+        post_to=None,
+        deliver_key=None,
+    )
+
+    assert store.mark_cycle_result(
+        watch.id,
+        exit_code=75,
+        error="watch command exited with status 75",
+    )
+    assert store.mark_cycle_start(watch.id)
+
+    started = store.get_watch(watch.id)
+    assert started is not None and started.last_started_at is not None
+    assert (started.last_exit_code, started.last_error) == (
+        75,
+        "watch command exited with status 75",
+    )
+
+
 def test_sqlite_remove_watch_soft_deletes_watch_but_keeps_runtime(tmp_path: Path) -> None:
     sqlite = SQLiteBackgroundTaskStore(tmp_path / "state" / "vibe.sqlite")
     store = ManagedWatchStore(tmp_path / "watches.json")


### PR DESCRIPTION
## Changed capability

Watch definition health now keeps `last_error` and `last_exit_code` as one outcome pair for the last completed cycle, including while the next cycle is in flight.

PR #1464 is correct: preserving an explicit `retry_delay_seconds=0` exposed this pre-existing ownership defect rather than causing it. The bisect evidence was 6/6 passes at `61a639e42` (#1461) and 0/6 passes at `047f93f5e` (#1464); clean master reproduced the scenario failure about 11 times in 12. This PR closes the defect #1464 exposed without restoring a delay.

`mark_cycle_start` now stamps only cycle-start timing. `mark_cycle_result` remains the single writer of both outcome fields and retains its existing retirement guard, so health remains stable throughout an in-flight cycle.

The scheduled-task sibling was audited. Its reset path clears `last_error` and `last_exit_code` together, and no task cycle-start path clears either field alone, so no task-side refactor is included.

## Scenarios

- HFR-094

## Evidence layers

- Unit: direct invariant test proves a completed outcome pair survives the next cycle start; `tests/test_watches.py` passed 123/123.
- Contract: `tests/test_harness_health_projection.py` passed 5/5.
- Scenario: HFR-094's repeating forever-Watch test passed 20/20 in isolation; the full `tests/test_harness_failure_visibility.py` passed 221/221.
- Residual manual checks: none. The store, live supervisor scenario, and health projection cover the changed behavior without a service restart.

## Dependencies

None.

## Known by design

None.
