### PR TITLE
fix(watch): publish cycle outcome atomically

### DIFF
--- a/core/watches.py
+++ b/core/watches.py
@@ -241,8 +241,17 @@ class ManagedWatch:
     last_exit_code: Optional[int] = None
     metadata: dict[str, Any] = field(default_factory=dict)
 
+    @property
+    def last_cycle_outcome(self) -> tuple[Optional[int], Optional[str]]:
+        """Return the last completed cycle's exit code and error as one snapshot."""
+
+        namespace = self.__dict__
+        return namespace["last_exit_code"], namespace["last_error"]
+
     def to_dict(self) -> dict[str, Any]:
-        return asdict(self)
+        payload = asdict(self)
+        payload["last_exit_code"], payload["last_error"] = self.last_cycle_outcome
+        return payload
 
     @classmethod
     def from_dict(cls, payload: dict[str, Any]) -> "ManagedWatch":
@@ -504,9 +513,10 @@ class ManagedWatchStore:
 
         EVERY way this write can fail to land reloads the mirror (HFR-271). Callers may
         pass either the cached object or a detached candidate; a landed detached write
-        replaces the cached object's complete namespace in one assignment. That keeps
-        existing references current without exposing a field-by-field transition. If
-        the write does not stick, its mutation must not either. Reloading on the
+        replaces the cached object's complete namespace in one assignment. Existing
+        references stay current, while readers capture the immutable
+        ``last_cycle_outcome`` from one published namespace. If the write does not
+        stick, its mutation must not either. Reloading on the
         ``False`` return alone was half the job -- a raised exception rolls the
         transaction back just as completely, and left the process serving edits the
         database never accepted. ``reconcile_watches`` chooses which watches keep
@@ -520,8 +530,8 @@ class ManagedWatchStore:
             if cached is None:
                 self._watches[watch.id] = watch
             elif cached is not watch:
-                # One namespace swap preserves object identity and makes every field
-                # in the persisted snapshot visible at the same publication point.
+                # Preserve mutation-result identity; outcome readers capture this
+                # namespace once rather than reading across its publication point.
                 cached.__dict__ = watch.__dict__
 
         try:

--- a/core/watches.py
+++ b/core/watches.py
@@ -503,16 +503,26 @@ class ManagedWatchStore:
         one to the file backend is a caller bug -- see ``sqlite_backend``.
 
         EVERY way this write can fail to land reloads the mirror (HFR-271). Callers may
-        pass either the cached object or a detached candidate; a landed write publishes
-        that whole object to the mirror in one dictionary assignment. If the write does
-        not stick, its mutation must not either. Reloading on the ``False`` return alone
-        was half the job -- a raised exception rolls the transaction back just as
-        completely, and left the process serving edits the database never accepted.
-        ``reconcile_watches`` chooses which watches keep running from this dict,
-        ``_read_state`` derives the NEXT compare-and-set's expectation from it, and
-        ``_watch_store_call`` swallows the exception, so nothing downstream would ever
-        have corrected it.
+        pass either the cached object or a detached candidate; a landed detached write
+        replaces the cached object's complete namespace in one assignment. That keeps
+        existing references current without exposing a field-by-field transition. If
+        the write does not stick, its mutation must not either. Reloading on the
+        ``False`` return alone was half the job -- a raised exception rolls the
+        transaction back just as completely, and left the process serving edits the
+        database never accepted. ``reconcile_watches`` chooses which watches keep
+        running from this dict, ``_read_state`` derives the NEXT compare-and-set's
+        expectation from it, and ``_watch_store_call`` swallows the exception, so
+        nothing downstream would ever have corrected it.
         """
+
+        def _publish_snapshot() -> None:
+            cached = self._watches.get(watch.id)
+            if cached is None:
+                self._watches[watch.id] = watch
+            elif cached is not watch:
+                # One namespace swap preserves object identity and makes every field
+                # in the persisted snapshot visible at the same publication point.
+                cached.__dict__ = watch.__dict__
 
         try:
             if self._sqlite is None:
@@ -521,7 +531,7 @@ class ManagedWatchStore:
                         "a file-backed watch store cannot commit a queued run with the watch row"
                     )
                 self._save(replacement=watch)
-                self._watches[watch.id] = watch
+                _publish_snapshot()
                 _publish_watch_definitions_updated()
                 return True
             if queued_run is None:
@@ -539,7 +549,7 @@ class ManagedWatchStore:
             self._reload_after_lost_write(watch.id)
             raise
         if landed:
-            self._watches[watch.id] = watch
+            _publish_snapshot()
             _publish_watch_definitions_updated()
             return True
         self.load()

--- a/core/watches.py
+++ b/core/watches.py
@@ -321,42 +321,49 @@ class ManagedWatchStore:
         self._sqlite = SQLiteBackgroundTaskStore() if path is None else None
         self._signature: Optional[tuple[int, int, int]] = None
         self._watches: dict[str, ManagedWatch] = {}
+        #: For this store, a durable write and the mirror publication reflecting it
+        #: are one atomic section for every observer of this mirror. No observer may
+        #: see an entry older than a row this store already committed. This must be
+        #: reentrant: ``_write_watch`` reloads through both its refused-write and
+        #: failed-write paths, so replacing the RLock with Lock would self-deadlock.
+        self._mirror_lock = threading.RLock()
         #: Set when a failed write left this mirror INCOMPLETE, cleared by the reload
         #: that repairs it. See ``maybe_reload`` and ``_reload_after_lost_write``.
         self._reload_required = False
         self.load()
 
     def load(self) -> None:
-        if self._sqlite is not None:
-            self._watches = {
-                item["id"]: ManagedWatch.from_dict(item)
-                for item in self._sqlite.list_watches()
-            }
-            self._reload_required = False
-            return
-        if not self.path.exists():
-            self._watches = {}
-            self._signature = None
-            self._reload_required = False
-            return
-        try:
-            payload = json.loads(self.path.read_text(encoding="utf-8"))
-        except Exception as exc:
-            logger.error("Failed to load managed watches: %s", exc)
-            self._watches = {}
-            self._signature = None
-            return
+        with self._mirror_lock:
+            if self._sqlite is not None:
+                self._watches = {
+                    item["id"]: ManagedWatch.from_dict(item)
+                    for item in self._sqlite.list_watches()
+                }
+                self._reload_required = False
+                return
+            if not self.path.exists():
+                self._watches = {}
+                self._signature = None
+                self._reload_required = False
+                return
+            try:
+                payload = json.loads(self.path.read_text(encoding="utf-8"))
+            except Exception as exc:
+                logger.error("Failed to load managed watches: %s", exc)
+                self._watches = {}
+                self._signature = None
+                return
 
-        raw_watches = payload.get("watches", []) if isinstance(payload, dict) else []
-        watches: dict[str, ManagedWatch] = {}
-        for item in raw_watches:
-            if not isinstance(item, dict):
-                continue
-            watch = ManagedWatch.from_dict(item)
-            watches[watch.id] = watch
-        self._watches = watches
-        self._signature = _path_signature(self.path)
-        self._reload_required = False
+            raw_watches = payload.get("watches", []) if isinstance(payload, dict) else []
+            watches: dict[str, ManagedWatch] = {}
+            for item in raw_watches:
+                if not isinstance(item, dict):
+                    continue
+                watch = ManagedWatch.from_dict(item)
+                watches[watch.id] = watch
+            self._watches = watches
+            self._signature = _path_signature(self.path)
+            self._reload_required = False
 
     def maybe_reload(self) -> bool:
         """Refresh the mirror when the database changed -- or when WE know it is stale.
@@ -376,59 +383,62 @@ class ManagedWatchStore:
         clears it, so a reload that fails again is retried on every later tick.
         """
 
-        if self._sqlite is not None:
-            changed = self._sqlite.maybe_reload()
-            if self._reload_required:
-                try:
+        with self._mirror_lock:
+            if self._sqlite is not None:
+                changed = self._sqlite.maybe_reload()
+                if self._reload_required:
+                    try:
+                        self.load()
+                    except Exception:
+                        # Still unreachable. Keep the flag and the incomplete mirror, and
+                        # report "nothing changed" -- the retry is the next tick's.
+                        logger.exception(
+                            "Could not reload managed watches after a lost write; the live "
+                            "store stays incomplete until a later attempt succeeds"
+                        )
+                        return False
+                    return True
+                if changed:
                     self.load()
-                except Exception:
-                    # Still unreachable. Keep the flag and the incomplete mirror, and
-                    # report "nothing changed" -- the retry is the next tick's.
-                    logger.exception(
-                        "Could not reload managed watches after a lost write; the live "
-                        "store stays incomplete until a later attempt succeeds"
-                    )
-                    return False
-                return True
-            if changed:
-                self.load()
-            return changed
-        signature = _path_signature(self.path)
-        if signature == self._signature and not self._reload_required:
-            return False
-        self.load()
-        return True
+                return changed
+            signature = _path_signature(self.path)
+            if signature == self._signature and not self._reload_required:
+                return False
+            self.load()
+            return True
 
     def _save(self, *, replacement: Optional[ManagedWatch] = None) -> None:
-        if self._sqlite is not None:
-            return
-        self.path.parent.mkdir(parents=True, exist_ok=True)
-        watches = dict(self._watches)
-        if replacement is not None:
-            watches[replacement.id] = replacement
-        payload = {
-            "watches": [
-                watch.to_dict()
-                for watch in sorted(
-                    watches.values(),
-                    key=lambda item: (item.created_at, item.id),
-                )
-            ]
-        }
-        with tempfile.NamedTemporaryFile(
-            mode="w",
-            dir=self.path.parent,
-            suffix=".tmp",
-            delete=False,
-            encoding="utf-8",
-        ) as handle:
-            json.dump(payload, handle, indent=2)
-            tmp_path = Path(handle.name)
-        tmp_path.replace(self.path)
-        self._signature = _path_signature(self.path)
+        with self._mirror_lock:
+            if self._sqlite is not None:
+                return
+            self.path.parent.mkdir(parents=True, exist_ok=True)
+            watches = dict(self._watches)
+            if replacement is not None:
+                watches[replacement.id] = replacement
+            payload = {
+                "watches": [
+                    watch.to_dict()
+                    for watch in sorted(
+                        watches.values(),
+                        key=lambda item: (item.created_at, item.id),
+                    )
+                ]
+            }
+            with tempfile.NamedTemporaryFile(
+                mode="w",
+                dir=self.path.parent,
+                suffix=".tmp",
+                delete=False,
+                encoding="utf-8",
+            ) as handle:
+                json.dump(payload, handle, indent=2)
+                tmp_path = Path(handle.name)
+            tmp_path.replace(self.path)
+            self._signature = _path_signature(self.path)
 
     def list_watches(self) -> list[ManagedWatch]:
-        return sorted(self._watches.values(), key=lambda item: (item.created_at, item.id))
+        with self._mirror_lock:
+            return sorted(self._watches.values(), key=lambda item: (item.created_at, item.id))
 
     def list_watches_for_recovery(self) -> list[ManagedWatch]:
         """Return a strict, current snapshot suitable for process recovery."""
@@ -466,7 +476,8 @@ class ManagedWatchStore:
         return sorted(watches, key=lambda item: (item.created_at, item.id))
 
     def get_watch(self, watch_id: str) -> Optional[ManagedWatch]:
-        return self._watches.get(watch_id)
+        with self._mirror_lock:
+            return self._watches.get(watch_id)
 
     @staticmethod
     def _read_state(watch: ManagedWatch) -> DefinitionWriteExpectation:
@@ -534,36 +545,37 @@ class ManagedWatchStore:
                 # namespace once rather than reading across its publication point.
                 cached.__dict__ = watch.__dict__
 
-        try:
-            if self._sqlite is None:
-                if queued_run is not None:
-                    raise ValueError(
-                        "a file-backed watch store cannot commit a queued run with the watch row"
+        with self._mirror_lock:
+            try:
+                if self._sqlite is None:
+                    if queued_run is not None:
+                        raise ValueError(
+                            "a file-backed watch store cannot commit a queued run with the watch row"
+                        )
+                    self._save(replacement=watch)
+                    landed = True
+                elif queued_run is None:
+                    landed = self._sqlite.upsert_watch(
+                        watch.to_dict(),
+                        expect=expect,
+                        expected_enabled_agent_id=expected_enabled_agent_id,
+                        expected_reference_agent_id=expected_reference_agent_id,
                     )
-                self._save(replacement=watch)
+                else:
+                    landed = self._sqlite.upsert_watch_with_queued_run(
+                        watch.to_dict(), expect=expect, run_payload=queued_run
+                    )
+            except Exception:
+                self._reload_after_lost_write(watch.id)
+                raise
+            if landed:
                 _publish_snapshot()
-                _publish_watch_definitions_updated()
-                return True
-            if queued_run is None:
-                landed = self._sqlite.upsert_watch(
-                    watch.to_dict(),
-                    expect=expect,
-                    expected_enabled_agent_id=expected_enabled_agent_id,
-                    expected_reference_agent_id=expected_reference_agent_id,
-                )
             else:
-                landed = self._sqlite.upsert_watch_with_queued_run(
-                    watch.to_dict(), expect=expect, run_payload=queued_run
-                )
-        except Exception:
-            self._reload_after_lost_write(watch.id)
-            raise
-        if landed:
-            _publish_snapshot()
-            _publish_watch_definitions_updated()
-            return True
-        self.load()
-        return False
+                self.load()
+        if not landed:
+            return False
+        _publish_watch_definitions_updated()
+        return True
 
     def _reload_after_lost_write(self, watch_id: str) -> None:
         """Drop a mirror entry the database did not accept, reloading if it can.
@@ -579,17 +591,18 @@ class ManagedWatchStore:
         forever.
         """
 
-        try:
-            self.load()
-        except Exception:
-            logger.exception(
-                "Could not reload managed watches after a failed write; dropping the "
-                "stale mirror entry for %s",
-                watch_id,
-            )
-            self._watches.pop(watch_id, None)
-            self._signature = None
-            self._reload_required = True
+        with self._mirror_lock:
+            try:
+                self.load()
+            except Exception:
+                logger.exception(
+                    "Could not reload managed watches after a failed write; dropping the "
+                    "stale mirror entry for %s",
+                    watch_id,
+                )
+                self._watches.pop(watch_id, None)
+                self._signature = None
+                self._reload_required = True
 
     def upsert_watch(
         self,
@@ -607,29 +620,31 @@ class ManagedWatchStore:
         with no durable row to stop it and nothing to reload it away.
         """
 
-        watch.updated_at = _utc_now_iso()
-        self._watches[watch.id] = watch
-        try:
-            if self._sqlite is not None:
-                # No ``expect``: the create/adopt entry point (``add_watch``), whose
-                # payload is not derived from a stored row.
-                self._sqlite.upsert_watch(
-                    watch.to_dict(),
-                    expected_enabled_agent_id=expected_enabled_agent_id,
-                    expected_reference_agent_id=expected_reference_agent_id,
-                )
-                if expected_reference_agent_id is not None:
-                    self.load()
-                    _publish_watch_definitions_updated()
-                    return self._watches[watch.id]
-                _publish_watch_definitions_updated()
-                return watch
-            self._save()
-        except Exception:
-            self._reload_after_lost_write(watch.id)
-            raise
+        with self._mirror_lock:
+            watch.updated_at = _utc_now_iso()
+            self._watches[watch.id] = watch
+            try:
+                if self._sqlite is not None:
+                    # No ``expect``: the create/adopt entry point (``add_watch``), whose
+                    # payload is not derived from a stored row.
+                    self._sqlite.upsert_watch(
+                        watch.to_dict(),
+                        expected_enabled_agent_id=expected_enabled_agent_id,
+                        expected_reference_agent_id=expected_reference_agent_id,
+                    )
+                    if expected_reference_agent_id is not None:
+                        self.load()
+                        result = self._watches[watch.id]
+                    else:
+                        result = watch
+                else:
+                    self._save()
+                    result = watch
+            except Exception:
+                self._reload_after_lost_write(watch.id)
+                raise
         _publish_watch_definitions_updated()
-        return watch
+        return result
 
     def add_watch(
         self,
@@ -701,43 +716,44 @@ class ManagedWatchStore:
         user was told could not be deleted just stops until the process restarts.
         """
 
-        if watch_id not in self._watches:
-            return False
-        del self._watches[watch_id]
-        try:
-            if self._sqlite is not None:
-                self._sqlite.remove_task(watch_id)
-                _publish_watch_definitions_updated()
-                return True
-            self._save()
-        except Exception:
-            self._reload_after_lost_write(watch_id)
-            raise
+        with self._mirror_lock:
+            if watch_id not in self._watches:
+                return False
+            del self._watches[watch_id]
+            try:
+                if self._sqlite is not None:
+                    self._sqlite.remove_task(watch_id)
+                else:
+                    self._save()
+            except Exception:
+                self._reload_after_lost_write(watch_id)
+                raise
         _publish_watch_definitions_updated()
         return True
 
     def set_enabled(self, watch_id: str, enabled: bool) -> ManagedWatch:
-        watch = self._watches[watch_id]
-        expect = self._read_state(watch)
-        if enabled and not watch.enabled:
-            # Same field split the storage layer applies to the Harness UI's
-            # toggle, so the two doorways cannot drift apart again.
-            self._clear_cycle_state(
-                watch,
-                definition_resume_clear_columns("watch", watch.mode),
-            )
-            watch.metadata = watch_metadata_after_resume(
-                watch.metadata,
-                resumed_at=_utc_now_iso(),
-            )
-        watch.enabled = enabled
-        watch.updated_at = _utc_now_iso()
-        if not self._write_watch(watch, expect):
-            # Same as the task side: this payload also restores ``last_error`` and the
-            # Session binding, so a pause/resume that lost to a teardown must fail
-            # loudly rather than quietly undo it.
-            raise DefinitionWriteConflict(watch_id, definition_type="watch")
-        return watch
+        with self._mirror_lock:
+            watch = self._watches[watch_id]
+            expect = self._read_state(watch)
+            if enabled and not watch.enabled:
+                # Same field split the storage layer applies to the Harness UI's
+                # toggle, so the two doorways cannot drift apart again.
+                self._clear_cycle_state(
+                    watch,
+                    definition_resume_clear_columns("watch", watch.mode),
+                )
+                watch.metadata = watch_metadata_after_resume(
+                    watch.metadata,
+                    resumed_at=_utc_now_iso(),
+                )
+            watch.enabled = enabled
+            watch.updated_at = _utc_now_iso()
+            if not self._write_watch(watch, expect):
+                # Same as the task side: this payload also restores ``last_error`` and the
+                # Session binding, so a pause/resume that lost to a teardown must fail
+                # loudly rather than quietly undo it.
+                raise DefinitionWriteConflict(watch_id, definition_type="watch")
+            return watch
 
     def update_watch(
         self,
@@ -773,61 +789,64 @@ class ManagedWatchStore:
 
         ensure_harness_definition_write(user_context)
         ensure_agent_name_access(agent_name, user_context=user_context)
-        watch = self._watches[watch_id]
-        # Captured before the first mutation: the state ``vibe watch update`` read and
-        # resolved its payload from.
-        expect = self._read_state(watch)
-        waiter_lifecycle_changed = (
-            mode != watch.mode
-            or command != watch.command
-            or shell_command != watch.shell_command
-            or cwd != watch.cwd
-        )
-        if mode != watch.mode:
-            # A mode change starts a new lifecycle. Completion and failure
-            # metadata from the old mode remains available in run history, but
-            # must not determine the definition state under the new mode.
-            self._clear_cycle_state(watch, DEFINITION_CYCLE_COLUMNS)
-        watch.name = name
-        watch.session_key = session_key
-        watch.session_id = session_id
-        watch.agent_name = agent_name
-        if session_policy is None:
-            session_policy = watch.session_policy or ("existing" if session_id or session_key else None)
-        watch.session_policy = session_policy
-        watch.command = command
-        watch.shell_command = shell_command
-        watch.prefix = prefix
-        watch.message = message or prefix
-        watch.cwd = cwd
-        watch.mode = mode
-        watch.timeout_seconds = timeout_seconds
-        watch.lifetime_timeout_seconds = lifetime_timeout_seconds
-        watch.retry_exit_codes = retry_exit_codes
-        watch.retry_delay_seconds = retry_delay_seconds
-        watch.post_to = post_to
-        watch.deliver_key = deliver_key
-        watch.metadata = metadata_with_resource_user_context(
-            metadata if metadata is not None else watch.metadata,
-            user_context,
-        )
-        if waiter_lifecycle_changed:
-            watch.metadata = dict(watch.metadata)
-            watch.metadata.pop(RECENT_EVENT_TIMESTAMPS_METADATA_KEY, None)
-        watch.updated_at = _utc_now_iso()
-        if not self._write_watch(
-            watch,
-            expect,
-            expected_enabled_agent_id=expected_enabled_agent_id,
-            expected_reference_agent_id=expected_reference_agent_id,
-        ):
-            # The edit did NOT land. ``cmd_watch_update`` turns this into a non-zero
-            # exit with an error payload instead of echoing an unwritten watch.
-            raise DefinitionWriteConflict(watch_id, definition_type="watch")
-        if expected_reference_agent_id is not None:
-            self.load()
-            return self._watches[watch_id]
-        return watch
+        with self._mirror_lock:
+            watch = self._watches[watch_id]
+            # Captured before the first mutation: the state ``vibe watch update`` read and
+            # resolved its payload from.
+            expect = self._read_state(watch)
+            waiter_lifecycle_changed = (
+                mode != watch.mode
+                or command != watch.command
+                or shell_command != watch.shell_command
+                or cwd != watch.cwd
+            )
+            if mode != watch.mode:
+                # A mode change starts a new lifecycle. Completion and failure
+                # metadata from the old mode remains available in run history, but
+                # must not determine the definition state under the new mode.
+                self._clear_cycle_state(watch, DEFINITION_CYCLE_COLUMNS)
+            watch.name = name
+            watch.session_key = session_key
+            watch.session_id = session_id
+            watch.agent_name = agent_name
+            if session_policy is None:
+                session_policy = watch.session_policy or (
+                    "existing" if session_id or session_key else None
+                )
+            watch.session_policy = session_policy
+            watch.command = command
+            watch.shell_command = shell_command
+            watch.prefix = prefix
+            watch.message = message or prefix
+            watch.cwd = cwd
+            watch.mode = mode
+            watch.timeout_seconds = timeout_seconds
+            watch.lifetime_timeout_seconds = lifetime_timeout_seconds
+            watch.retry_exit_codes = retry_exit_codes
+            watch.retry_delay_seconds = retry_delay_seconds
+            watch.post_to = post_to
+            watch.deliver_key = deliver_key
+            watch.metadata = metadata_with_resource_user_context(
+                metadata if metadata is not None else watch.metadata,
+                user_context,
+            )
+            if waiter_lifecycle_changed:
+                watch.metadata = dict(watch.metadata)
+                watch.metadata.pop(RECENT_EVENT_TIMESTAMPS_METADATA_KEY, None)
+            watch.updated_at = _utc_now_iso()
+            if not self._write_watch(
+                watch,
+                expect,
+                expected_enabled_agent_id=expected_enabled_agent_id,
+                expected_reference_agent_id=expected_reference_agent_id,
+            ):
+                # The edit did NOT land. ``cmd_watch_update`` turns this into a non-zero
+                # exit with an error payload instead of echoing an unwritten watch.
+                raise DefinitionWriteConflict(watch_id, definition_type="watch")
+            if expected_reference_agent_id is not None:
+                self.load()
+                return self._watches[watch_id]
+            return watch
 
     @staticmethod
     def _clear_cycle_state(watch: ManagedWatch, columns: tuple[str, ...]) -> None:
@@ -837,18 +856,19 @@ class ManagedWatchStore:
             setattr(watch, column, None)
 
     def mark_cycle_start(self, watch_id: str) -> bool:
-        self.maybe_reload()
-        watch = self._watches.get(watch_id)
-        if watch is None:
-            return False
-        expect = self._read_state(watch)
-        watch.last_started_at = _utc_now_iso()
-        # The outcome pair describes the last completed cycle. Keep it stable while
-        # the next cycle is in flight; ``mark_cycle_result`` owns both fields.
-        watch.updated_at = _utc_now_iso()
-        # A runtime stamp: a lost write is reported by the return value, not by an
-        # exception through the supervisor loop.
-        return self._write_watch(watch, expect)
+        with self._mirror_lock:
+            self.maybe_reload()
+            watch = self._watches.get(watch_id)
+            if watch is None:
+                return False
+            expect = self._read_state(watch)
+            watch.last_started_at = _utc_now_iso()
+            # The outcome pair describes the last completed cycle. Keep it stable while
+            # the next cycle is in flight; ``mark_cycle_result`` owns both fields.
+            watch.updated_at = _utc_now_iso()
+            # A runtime stamp: a lost write is reported by the return value, not by an
+            # exception through the supervisor loop.
+            return self._write_watch(watch, expect)
 
     def mark_cycle_result(
         self,
@@ -873,45 +893,48 @@ class ManagedWatchStore:
 
         if disable and pause:
             raise ValueError("a watch cycle cannot retire and pause at the same time")
-        self.maybe_reload()
-        watch = self._watches.get(watch_id)
-        if watch is None:
-            return False
-        expect = self._read_state(watch)
-        candidate = replace(watch)
-        now = _utc_now_iso()
-        # Retirement is state, not a conclusion drawn from cycle history.
-        # Only the cycle that changes enabled -> disabled may write it. A cycle
-        # landing after a manual pause must preserve that pause; a later result
-        # must likewise not erase a genuine earlier retirement.
-        was_enabled = candidate.enabled
-        if was_enabled:
-            candidate.last_finished_at = now if disable or pause else None
-            candidate.retired_at = now if disable else None
-        # Once retirement commits, these fields describe that terminal outcome.
-        # A late cycle still owns its individual Run row, but it cannot replace
-        # the definition outcome written by the cycle that retired the Watch.
-        if was_enabled or candidate.retired_at is None:
-            candidate.last_exit_code = exit_code
-            candidate.last_error = error
-        if event_detected:
-            candidate.last_event_at = now
-        if metadata_updates or (event_detected and acknowledge_event):
-            # A NEW dict: ``expect`` above was derived from the stored one and has to
-            # keep describing the row as it was read.
-            candidate.metadata = {
-                **candidate.metadata,
-                **(metadata_updates or {}),
-            }
-            if event_detected and acknowledge_event:
-                candidate.metadata[DELIVERY_ACK_METADATA_KEY] = _delivered_reports(candidate) + 1
-        if disable or pause:
-            candidate.enabled = False
-        candidate.updated_at = _utc_now_iso()
-        # Guarded for the reason ``mark_task_result`` is: a cycle result landing after a
-        # ``/new`` reclaim would otherwise re-enable the watch and restore the binding
-        # the teardown cleared.
-        return self._write_watch(candidate, expect, queued_run=queued_run)
+        with self._mirror_lock:
+            self.maybe_reload()
+            watch = self._watches.get(watch_id)
+            if watch is None:
+                return False
+            expect = self._read_state(watch)
+            candidate = replace(watch)
+            now = _utc_now_iso()
+            # Retirement is state, not a conclusion drawn from cycle history.
+            # Only the cycle that changes enabled -> disabled may write it. A cycle
+            # landing after a manual pause must preserve that pause; a later result
+            # must likewise not erase a genuine earlier retirement.
+            was_enabled = candidate.enabled
+            if was_enabled:
+                candidate.last_finished_at = now if disable or pause else None
+                candidate.retired_at = now if disable else None
+            # Once retirement commits, these fields describe that terminal outcome.
+            # A late cycle still owns its individual Run row, but it cannot replace
+            # the definition outcome written by the cycle that retired the Watch.
+            if was_enabled or candidate.retired_at is None:
+                candidate.last_exit_code = exit_code
+                candidate.last_error = error
+            if event_detected:
+                candidate.last_event_at = now
+            if metadata_updates or (event_detected and acknowledge_event):
+                # A NEW dict: ``expect`` above was derived from the stored one and has to
+                # keep describing the row as it was read.
+                candidate.metadata = {
+                    **candidate.metadata,
+                    **(metadata_updates or {}),
+                }
+                if event_detected and acknowledge_event:
+                    candidate.metadata[DELIVERY_ACK_METADATA_KEY] = (
+                        _delivered_reports(candidate) + 1
+                    )
+            if disable or pause:
+                candidate.enabled = False
+            candidate.updated_at = _utc_now_iso()
+            # Guarded for the reason ``mark_task_result`` is: a cycle result landing after a
+            # ``/new`` reclaim would otherwise re-enable the watch and restore the binding
+            # the teardown cleared.
+            return self._write_watch(candidate, expect, queued_run=queued_run)
 
 
 class WatchRuntimeStateStore:

--- a/core/watches.py
+++ b/core/watches.py
@@ -8,7 +8,7 @@ import logging
 import os
 import tempfile
 import threading
-from dataclasses import asdict, dataclass, field
+from dataclasses import asdict, dataclass, field, replace
 from datetime import datetime, timezone
 from functools import partial
 from pathlib import Path
@@ -390,11 +390,22 @@ class ManagedWatchStore:
         self.load()
         return True
 
-    def _save(self) -> None:
+    def _save(self, *, replacement: Optional[ManagedWatch] = None) -> None:
         if self._sqlite is not None:
             return
         self.path.parent.mkdir(parents=True, exist_ok=True)
-        payload = {"watches": [watch.to_dict() for watch in self.list_watches()]}
+        watches = dict(self._watches)
+        if replacement is not None:
+            watches[replacement.id] = replacement
+        payload = {
+            "watches": [
+                watch.to_dict()
+                for watch in sorted(
+                    watches.values(),
+                    key=lambda item: (item.created_at, item.id),
+                )
+            ]
+        }
         with tempfile.NamedTemporaryFile(
             mode="w",
             dir=self.path.parent,
@@ -491,15 +502,16 @@ class ManagedWatchStore:
         failure leaves neither behind. Only the SQLite backend can do that, and passing
         one to the file backend is a caller bug -- see ``sqlite_backend``.
 
-        EVERY way this write can fail to land reloads the mirror (HFR-271). This store is
-        a write-through cache: each caller mutates the cached ``ManagedWatch`` and hands
-        the whole row here, so if the write does not stick, the mutation must not either.
-        Reloading on the ``False`` return alone was half the job -- a raised exception
-        rolls the transaction back just as completely, and left the process serving edits
-        the database never accepted. ``reconcile_watches`` chooses which watches keep
-        running from this dict, ``_read_state`` derives the NEXT compare-and-set's
-        expectation from it, and ``_watch_store_call`` swallows the exception, so nothing
-        downstream would ever have corrected it.
+        EVERY way this write can fail to land reloads the mirror (HFR-271). Callers may
+        pass either the cached object or a detached candidate; a landed write publishes
+        that whole object to the mirror in one dictionary assignment. If the write does
+        not stick, its mutation must not either. Reloading on the ``False`` return alone
+        was half the job -- a raised exception rolls the transaction back just as
+        completely, and left the process serving edits the database never accepted.
+        ``reconcile_watches`` chooses which watches keep running from this dict,
+        ``_read_state`` derives the NEXT compare-and-set's expectation from it, and
+        ``_watch_store_call`` swallows the exception, so nothing downstream would ever
+        have corrected it.
         """
 
         try:
@@ -508,7 +520,8 @@ class ManagedWatchStore:
                     raise ValueError(
                         "a file-backed watch store cannot commit a queued run with the watch row"
                     )
-                self._save()
+                self._save(replacement=watch)
+                self._watches[watch.id] = watch
                 _publish_watch_definitions_updated()
                 return True
             if queued_run is None:
@@ -526,6 +539,7 @@ class ManagedWatchStore:
             self._reload_after_lost_write(watch.id)
             raise
         if landed:
+            self._watches[watch.id] = watch
             _publish_watch_definitions_updated()
             return True
         self.load()
@@ -844,39 +858,40 @@ class ManagedWatchStore:
         if watch is None:
             return False
         expect = self._read_state(watch)
+        candidate = replace(watch)
         now = _utc_now_iso()
         # Retirement is state, not a conclusion drawn from cycle history.
         # Only the cycle that changes enabled -> disabled may write it. A cycle
         # landing after a manual pause must preserve that pause; a later result
         # must likewise not erase a genuine earlier retirement.
-        was_enabled = watch.enabled
+        was_enabled = candidate.enabled
         if was_enabled:
-            watch.last_finished_at = now if disable or pause else None
-            watch.retired_at = now if disable else None
+            candidate.last_finished_at = now if disable or pause else None
+            candidate.retired_at = now if disable else None
         # Once retirement commits, these fields describe that terminal outcome.
         # A late cycle still owns its individual Run row, but it cannot replace
         # the definition outcome written by the cycle that retired the Watch.
-        if was_enabled or watch.retired_at is None:
-            watch.last_exit_code = exit_code
-            watch.last_error = error
+        if was_enabled or candidate.retired_at is None:
+            candidate.last_exit_code = exit_code
+            candidate.last_error = error
         if event_detected:
-            watch.last_event_at = now
+            candidate.last_event_at = now
         if metadata_updates or (event_detected and acknowledge_event):
             # A NEW dict: ``expect`` above was derived from the stored one and has to
             # keep describing the row as it was read.
-            watch.metadata = {
-                **watch.metadata,
+            candidate.metadata = {
+                **candidate.metadata,
                 **(metadata_updates or {}),
             }
             if event_detected and acknowledge_event:
-                watch.metadata[DELIVERY_ACK_METADATA_KEY] = _delivered_reports(watch) + 1
+                candidate.metadata[DELIVERY_ACK_METADATA_KEY] = _delivered_reports(candidate) + 1
         if disable or pause:
-            watch.enabled = False
-        watch.updated_at = _utc_now_iso()
+            candidate.enabled = False
+        candidate.updated_at = _utc_now_iso()
         # Guarded for the reason ``mark_task_result`` is: a cycle result landing after a
         # ``/new`` reclaim would otherwise re-enable the watch and restore the binding
         # the teardown cleared.
-        return self._write_watch(watch, expect, queued_run=queued_run)
+        return self._write_watch(candidate, expect, queued_run=queued_run)
 
 
 class WatchRuntimeStateStore:

--- a/tests/test_harness_failure_visibility.py
+++ b/tests/test_harness_failure_visibility.py
@@ -12416,6 +12416,7 @@ def test_watch_cycle_outcome_pair_is_published_atomically(
     assert not writer_errors
     visible_after = store.get_watch(watch.id)
     assert visible_after is not None
+    assert visible_after is visible_before
     assert (visible_after.last_exit_code, visible_after.last_error) == next_outcome
     persisted_after = ManagedWatchStore(tmp_path / "watches.json").get_watch(watch.id)
     assert persisted_after is not None

--- a/tests/test_harness_failure_visibility.py
+++ b/tests/test_harness_failure_visibility.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import asyncio
 import pytest
 import sys
+import threading
 from pathlib import Path
 from typing import Any
 
@@ -12321,6 +12322,104 @@ def test_a_watch_that_outlives_its_delivery_target_dies_visibly(
     assert replayed["interrupt_reason"] == "delivery_target_missing", (
         f"and the structured cause survives the replay: {replayed}"
     )
+
+
+def test_watch_cycle_outcome_pair_is_published_atomically(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """A reader sees one completed-cycle snapshot, never half of the next one."""
+
+    from core.watches import ManagedWatch, ManagedWatchStore
+
+    store = ManagedWatchStore(tmp_path / "watches.json")
+    watch = store.add_watch(
+        name="atomic outcome",
+        session_key="",
+        command=[],
+        shell_command="exit 75",
+        prefix=None,
+        cwd=None,
+        mode="forever",
+        timeout_seconds=0,
+        lifetime_timeout_seconds=0,
+        retry_exit_codes=[75],
+        retry_delay_seconds=0,
+        post_to=None,
+        deliver_key=None,
+    )
+    assert store.mark_cycle_result(watch.id, exit_code=0, error=None)
+    visible_before = store.get_watch(watch.id)
+    assert visible_before is not None
+    previous_outcome = (0, None)
+    next_outcome = (75, "watch command exited with status 75")
+
+    writer_reached_publish_boundary = threading.Event()
+    release_writer = threading.Event()
+    writer_errors: list[BaseException] = []
+    original_setattr = ManagedWatch.__setattr__
+    original_write = store._write_watch
+
+    def _block_legacy_field_write(self, name, value):
+        original_setattr(self, name, value)
+        if self is visible_before and (
+            (name == "last_exit_code" and value != previous_outcome[0])
+            or (name == "last_error" and value != previous_outcome[1])
+        ):
+            writer_reached_publish_boundary.set()
+            release_writer.wait(timeout=5)
+
+    def _block_snapshot_before_publish(candidate, expect, **kwargs):
+        if candidate is not visible_before:
+            writer_reached_publish_boundary.set()
+            release_writer.wait(timeout=5)
+        return original_write(candidate, expect, **kwargs)
+
+    monkeypatch.setattr(ManagedWatch, "__setattr__", _block_legacy_field_write)
+    monkeypatch.setattr(store, "_write_watch", _block_snapshot_before_publish)
+
+    def _write_result() -> None:
+        try:
+            assert store.mark_cycle_result(
+                watch.id,
+                exit_code=next_outcome[0],
+                error=next_outcome[1],
+            )
+        except BaseException as exc:
+            writer_errors.append(exc)
+
+    writer = threading.Thread(target=_write_result)
+    writer.start()
+    try:
+        assert writer_reached_publish_boundary.wait(timeout=5)
+        visible_during_write = store.get_watch(watch.id)
+        assert visible_during_write is not None
+        visible_outcome = (
+            visible_during_write.last_exit_code,
+            visible_during_write.last_error,
+        )
+        assert visible_outcome in {previous_outcome, next_outcome}
+        persisted_during_write = ManagedWatchStore(tmp_path / "watches.json").get_watch(
+            watch.id
+        )
+        assert persisted_during_write is not None
+        persisted_outcome = (
+            persisted_during_write.last_exit_code,
+            persisted_during_write.last_error,
+        )
+        assert persisted_outcome in {previous_outcome, next_outcome}
+    finally:
+        release_writer.set()
+        writer.join(timeout=5)
+
+    assert not writer.is_alive()
+    assert not writer_errors
+    visible_after = store.get_watch(watch.id)
+    assert visible_after is not None
+    assert (visible_after.last_exit_code, visible_after.last_error) == next_outcome
+    persisted_after = ManagedWatchStore(tmp_path / "watches.json").get_watch(watch.id)
+    assert persisted_after is not None
+    assert (persisted_after.last_exit_code, persisted_after.last_error) == next_outcome
 
 
 def test_a_forever_watch_repeating_the_field_failure_notifies_once(

--- a/tests/test_harness_failure_visibility.py
+++ b/tests/test_harness_failure_visibility.py
@@ -12413,6 +12413,111 @@ def test_watch_cycle_outcome_pair_is_published_atomically(
     assert persisted_after.last_cycle_outcome == next_outcome
 
 
+def test_watch_write_and_mirror_publication_exclude_same_store_reload(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """A newer durable edit cannot be replaced by an older pending publication."""
+
+    from core.watches import ManagedWatchStore
+
+    db_path = tmp_path / "state" / "vibe.sqlite"
+
+    def _sqlite_watch_store() -> ManagedWatchStore:
+        store = ManagedWatchStore(tmp_path / "unused-watches.json")
+        store._sqlite = SQLiteBackgroundTaskStore(db_path)
+        store.load()
+        return store
+
+    store = _sqlite_watch_store()
+    other = _sqlite_watch_store()
+    watch = store.add_watch(
+        name="atomic publication",
+        session_key="",
+        command=[],
+        shell_command="exit 75",
+        prefix=None,
+        cwd=None,
+        mode="forever",
+        timeout_seconds=0,
+        lifetime_timeout_seconds=0,
+        retry_exit_codes=[75],
+        retry_delay_seconds=0,
+        post_to=None,
+        deliver_key=None,
+    )
+    other.load()
+
+    candidate_committed = threading.Event()
+    allow_publication = threading.Event()
+    newer_edit_committed = threading.Event()
+    reload_started = threading.Event()
+    reload_finished = threading.Event()
+    writer_errors: list[BaseException] = []
+    reloader_errors: list[BaseException] = []
+    sqlite = store.sqlite_backend
+    assert sqlite is not None
+    original_upsert = sqlite.upsert_watch
+
+    def _pause_after_commit(*args, **kwargs):
+        landed = original_upsert(*args, **kwargs)
+        candidate_committed.set()
+        if not allow_publication.wait(timeout=5):
+            raise AssertionError("test did not release the pending mirror publication")
+        return landed
+
+    monkeypatch.setattr(sqlite, "upsert_watch", _pause_after_commit)
+
+    def _write_cycle_result() -> None:
+        try:
+            assert store.mark_cycle_result(
+                watch.id,
+                exit_code=75,
+                error="watch command exited with status 75",
+            )
+        except BaseException as exc:
+            writer_errors.append(exc)
+
+    def _write_newer_edit_and_reload() -> None:
+        try:
+            assert candidate_committed.wait(timeout=5)
+            other.set_enabled(watch.id, False)
+            newer_edit_committed.set()
+            reload_started.set()
+            store.load()
+        except BaseException as exc:
+            reloader_errors.append(exc)
+        finally:
+            reload_finished.set()
+
+    writer = threading.Thread(target=_write_cycle_result)
+    reloader = threading.Thread(target=_write_newer_edit_and_reload)
+    writer.start()
+    reloader.start()
+    assert candidate_committed.wait(timeout=5)
+    assert newer_edit_committed.wait(timeout=5)
+    assert reload_started.wait(timeout=5)
+    assert not reload_finished.wait(timeout=0.1), (
+        "same-store reload must wait for durable write plus mirror publication"
+    )
+    allow_publication.set()
+    writer.join(timeout=5)
+    reloader.join(timeout=5)
+
+    assert not writer.is_alive()
+    assert not reloader.is_alive()
+    assert not writer_errors
+    assert not reloader_errors
+    visible = store.get_watch(watch.id)
+    other_sqlite = other.sqlite_backend
+    assert other_sqlite is not None
+    persisted = other_sqlite.get_watch(watch.id)
+    assert visible is not None
+    assert visible.enabled is False
+    assert persisted is not None
+    assert persisted["enabled"] is False
+
+
 def test_a_forever_watch_repeating_the_field_failure_notifies_once(
     tmp_path: Path,
     monkeypatch,

--- a/tests/test_harness_failure_visibility.py
+++ b/tests/test_harness_failure_visibility.py
@@ -12326,11 +12326,10 @@ def test_a_watch_that_outlives_its_delivery_target_dies_visibly(
 
 def test_watch_cycle_outcome_pair_is_published_atomically(
     tmp_path: Path,
-    monkeypatch,
 ) -> None:
-    """A reader sees one completed-cycle snapshot, never half of the next one."""
+    """A held reader cannot straddle publication of the next cycle outcome."""
 
-    from core.watches import ManagedWatch, ManagedWatchStore
+    from core.watches import ManagedWatchStore
 
     store = ManagedWatchStore(tmp_path / "watches.json")
     watch = store.add_watch(
@@ -12349,34 +12348,35 @@ def test_watch_cycle_outcome_pair_is_published_atomically(
         deliver_key=None,
     )
     assert store.mark_cycle_result(watch.id, exit_code=0, error=None)
-    visible_before = store.get_watch(watch.id)
-    assert visible_before is not None
     previous_outcome = (0, None)
     next_outcome = (75, "watch command exited with status 75")
 
-    writer_reached_publish_boundary = threading.Event()
-    release_writer = threading.Event()
+    reader_has_old_exit_code = threading.Event()
+    writer_finished = threading.Event()
+    observed_outcomes: list[tuple[int | None, str | None]] = []
+    reader_errors: list[BaseException] = []
     writer_errors: list[BaseException] = []
-    original_setattr = ManagedWatch.__setattr__
-    original_write = store._write_watch
 
-    def _block_legacy_field_write(self, name, value):
-        original_setattr(self, name, value)
-        if self is visible_before and (
-            (name == "last_exit_code" and value != previous_outcome[0])
-            or (name == "last_error" and value != previous_outcome[1])
-        ):
-            writer_reached_publish_boundary.set()
-            release_writer.wait(timeout=5)
+    class _BlockingNamespace(dict):
+        def __getitem__(self, key):
+            value = super().__getitem__(key)
+            if key == "last_exit_code":
+                reader_has_old_exit_code.set()
+                if not writer_finished.wait(timeout=5):
+                    raise AssertionError("writer did not publish while the reader was paused")
+            return value
 
-    def _block_snapshot_before_publish(candidate, expect, **kwargs):
-        if candidate is not visible_before:
-            writer_reached_publish_boundary.set()
-            release_writer.wait(timeout=5)
-        return original_write(candidate, expect, **kwargs)
+    # ``watch`` is the mutation result retained by its caller and therefore the cached
+    # object whose namespace publication updates. Pause its outcome reader after the
+    # first old value has been fetched, then let the writer publish the complete next
+    # namespace before the reader fetches the second value.
+    watch.__dict__ = _BlockingNamespace(watch.__dict__)
 
-    monkeypatch.setattr(ManagedWatch, "__setattr__", _block_legacy_field_write)
-    monkeypatch.setattr(store, "_write_watch", _block_snapshot_before_publish)
+    def _read_result() -> None:
+        try:
+            observed_outcomes.append(watch.last_cycle_outcome)
+        except BaseException as exc:
+            reader_errors.append(exc)
 
     def _write_result() -> None:
         try:
@@ -12387,40 +12387,30 @@ def test_watch_cycle_outcome_pair_is_published_atomically(
             )
         except BaseException as exc:
             writer_errors.append(exc)
+        finally:
+            writer_finished.set()
 
+    reader = threading.Thread(target=_read_result)
+    reader.start()
+    assert reader_has_old_exit_code.wait(timeout=5)
     writer = threading.Thread(target=_write_result)
     writer.start()
-    try:
-        assert writer_reached_publish_boundary.wait(timeout=5)
-        visible_during_write = store.get_watch(watch.id)
-        assert visible_during_write is not None
-        visible_outcome = (
-            visible_during_write.last_exit_code,
-            visible_during_write.last_error,
-        )
-        assert visible_outcome in {previous_outcome, next_outcome}
-        persisted_during_write = ManagedWatchStore(tmp_path / "watches.json").get_watch(
-            watch.id
-        )
-        assert persisted_during_write is not None
-        persisted_outcome = (
-            persisted_during_write.last_exit_code,
-            persisted_during_write.last_error,
-        )
-        assert persisted_outcome in {previous_outcome, next_outcome}
-    finally:
-        release_writer.set()
-        writer.join(timeout=5)
+    writer.join(timeout=5)
+    reader.join(timeout=5)
 
     assert not writer.is_alive()
+    assert not reader.is_alive()
     assert not writer_errors
+    assert not reader_errors
+    assert observed_outcomes == [previous_outcome]
+
     visible_after = store.get_watch(watch.id)
     assert visible_after is not None
-    assert visible_after is visible_before
-    assert (visible_after.last_exit_code, visible_after.last_error) == next_outcome
+    assert visible_after is watch
+    assert visible_after.last_cycle_outcome == next_outcome
     persisted_after = ManagedWatchStore(tmp_path / "watches.json").get_watch(watch.id)
     assert persisted_after is not None
-    assert (persisted_after.last_exit_code, persisted_after.last_error) == next_outcome
+    assert persisted_after.last_cycle_outcome == next_outcome
 
 
 def test_a_forever_watch_repeating_the_field_failure_notifies_once(
@@ -12548,7 +12538,7 @@ def test_a_forever_watch_repeating_the_field_failure_notifies_once(
 
     def _last_completed_cycle_is_retry() -> bool:
         row = watch_store.get_watch(watch.id)
-        return row is not None and (row.last_exit_code, row.last_error) == (75, sentinel)
+        return row is not None and row.last_cycle_outcome == (75, sentinel)
 
     service = ManagedWatchService(
         controller=SimpleNamespace(),


### PR DESCRIPTION
## Capability

Make a managed watch cycle's `last_exit_code` and `last_error` visible as one completed-outcome snapshot, without allowing a same-store reload to regress the live mirror after the durable write.

## Root cause and fix

`mark_cycle_result` originally mutated the shared `ManagedWatch` cache field by field, so a reader could observe the new `last_exit_code` with an old or missing `last_error`. Publishing a detached candidate fixed that first gap, but publication was still last-writer-wins: a reload after the candidate committed and before `_publish_snapshot` could install a newer durable row, then be overwritten by the older candidate.

The store now enforces this invariant:

> For a given `WatchStore` instance, a durable write and the mirror publication that reflects it form one atomic section with respect to every observer of that same store's mirror. No observer can ever see a mirror entry older than a durable row this store has already committed.

A per-store `threading.RLock` is the mechanism. Reentrancy is required because `_write_watch` reaches `load()` through both `_reload_after_lost_write` and the refused-write branch; a plain `Lock` would self-deadlock. The lock covers only the SQLite/file persistence call, bounded mirror work, and publication. It is not held across subprocess execution, network I/O, agent dispatch, or waits on another component. Existing lock ordering is one-way: service paths take `_store_worker_lock` before the store lock, and no store path takes the worker lock.

Confinement audit: `load`, `maybe_reload`, `_reload_after_lost_write`, `_save`, `_write_watch` + `_publish_snapshot`, the direct insert in `upsert_watch`, and the direct delete in `remove_watch` all mutate the mirror under the lock. The mirror-derived mutation entry points `set_enabled`, `update_watch`, `mark_cycle_start`, and `mark_cycle_result`, plus the `list_watches` / `get_watch` observers, cooperate with the same lock. A grep audit finds zero `self._watches` replacement/insert/pop/delete or cached-entry `__dict__` assignment sites outside that confinement.

The narrower publication-time source/version guard was rejected: it would protect only one location, and a sound guard would require a real monotonic durable version. `updated_at` is clock-derived rather than a version; adding a version column would require a persisted-shape migration and released-shape fixtures, which is disproportionate here. The compare-and-set machinery and persisted shape are unchanged.

Cached-object identity remains preserved through `cached.__dict__ = watch.__dict__`. Readers of the outcome pair use `last_cycle_outcome`, which captures one published namespace and returns an immutable tuple; serialized payloads derive both fields from that tuple. The watch state machine, scheduling, retries, and notification behavior are unchanged.

## Evidence

- Closes #1473.
- Original CI failure: https://github.com/avibe-bot/avibe/actions/runs/31890890746/job/95026877612 (`last_exit_code=75`, `last_error=None`).
- Read-side exact interleaving: pauses a retained reader after fetching the old exit code, publishes the next namespace, and proves the reader receives the complete old tuple rather than a mixed pair. It fails before the read-side snapshot fix.
- Write-side exact interleaving: commits the candidate, performs a newer durable edit from another store, attempts a same-store reload before publication, and proves the reload waits and the mirror finishes on the newest durable row. It fails on the pre-lock implementation.
- Both concurrency tests are hermetic and deterministic; neither touches `~/.avibe` or a running service.

## Relation to #1037

This takes direction (a) from #1473: co-locate the pair in one persistence write and publish one cache snapshot. It intentionally does not implement #1037's broader user-visible failure-reason mapping/i18n work; #1037 remains the owner of deriving display copy from `exit_code` and demoting raw stderr.

## Validation

- Unit: `tests/test_watches.py`, `tests/test_harness_definition_lifecycle.py`, `tests/test_cli_watch_command.py`, the original failing test, and both exact concurrency regressions: 247 passed.
- Contract: complete outcome tuple, serialized pair consistency, retained cached-object identity, and durable-write/mirror-publication serialization.
- Scenario IDs: none; no scenario catalog behavior changed.
- Residual manual checks: none. The tests are hermetic and the local Avibe service was not restarted.
- Lint: `ruff check core/watches.py tests/test_harness_failure_visibility.py`.

## Dependencies / known by design

- Dependencies: none.
- Known by design: #1037 remains out of scope.
