### PR TITLE
fix(memory): keep IM attachment admission local

### DIFF
--- a/core/controller.py
+++ b/core/controller.py
@@ -1955,12 +1955,9 @@ class Controller:
             observed_generation = read_generation() if callable(read_generation) else None
         except Exception:
             observed_generation = None
-        if (
-            not isinstance(observed_generation, bool)
-            and isinstance(observed_generation, int)
-            and observed_generation >= 0
-        ):
-            generation = observed_generation
+        generation = memory_admission.normalize_attachment_config_generation(
+            observed_generation
+        )
         try:
             token = reserve(
                 principal_id=principal_id,
@@ -2511,12 +2508,12 @@ class Controller:
             attachment_selection = None
             if status not in {"ready", "not_configured", "unavailable"}:
                 status = "not_configured"
-                generation = facts.attachment_config_generation
                 if (
                     platform != WORKBENCH_PLATFORM
-                    and not isinstance(generation, bool)
-                    and isinstance(generation, int)
-                    and generation >= 0
+                    and memory_admission.normalize_attachment_config_generation(
+                        facts.attachment_config_generation
+                    )
+                    is not None
                 ):
                     status = "ready"
                 elif platform == WORKBENCH_PLATFORM:

--- a/core/controller.py
+++ b/core/controller.py
@@ -2511,10 +2511,15 @@ class Controller:
             attachment_selection = None
             if status not in {"ready", "not_configured", "unavailable"}:
                 status = "not_configured"
+                generation = facts.attachment_config_generation
                 if (
-                    platform == WORKBENCH_PLATFORM
-                    or facts.attachment_config_generation is not None
+                    platform != WORKBENCH_PLATFORM
+                    and not isinstance(generation, bool)
+                    and isinstance(generation, int)
+                    and generation >= 0
                 ):
+                    status = "ready"
+                elif platform == WORKBENCH_PLATFORM:
                     status = "unavailable"
                     read_status = getattr(
                         observed_runtime,

--- a/core/memory/admission.py
+++ b/core/memory/admission.py
@@ -192,7 +192,7 @@ class CaptureAdmission:
                 if not self.admits_attachment_turn(facts):
                     return CaptureSkipped(reason="memory_invalid_input")
                 status = facts.attachment_capture_status
-                config_generation = _attachment_config_generation(
+                config_generation = normalize_attachment_config_generation(
                     facts.attachment_config_generation
                 )
                 if status == "ready" and config_generation is not None:
@@ -248,7 +248,9 @@ def _asserted_true(value: object) -> bool:
     return value is True
 
 
-def _attachment_config_generation(value: object) -> int | None:
+def normalize_attachment_config_generation(value: object) -> int | None:
+    """Return one valid explicit multimodal configuration generation."""
+
     if isinstance(value, bool) or not isinstance(value, int) or value < 0:
         return None
     return value

--- a/docs/plans/memory-im-attachment-followups-1470-1471.md
+++ b/docs/plans/memory-im-attachment-followups-1470-1471.md
@@ -1,0 +1,160 @@
+# Memory IM attachment follow-ups (#1470 / #1471)
+
+## Fixed contracts
+
+Ingress attachment eligibility is the conjunction of:
+
+1. the platform belongs to `IM_ATTACHMENT_CAPTURE_PLATFORMS`;
+2. an explicit multimodal configuration is complete; and
+3. its configuration generation is a valid non-negative integer.
+
+Platform rollout changes only the first term. The #1470 ingress fix changes only
+the latter two terms by removing live provider health from eligibility. Workbench
+keeps its one-cycle live-read compatibility path.
+
+The call-site invariants remain:
+
+- **Bounded-wait invariant.** No deadline-bound provider or subprocess read may
+  occur in a span that blocks any bounded waiter.
+- **Text independence.** Eligible text remains independently best effort, and
+  that invariant holds at every attachment-path failure or early return.
+- Facts sampled before an indeterminate await are revalidated in the O(1),
+  no-`await` segment that consumes them; mismatch fails closed.
+
+## PR-D: local IM eligibility (#1470 item 1)
+
+**Selected model.** For IM ingress, a valid explicit configuration generation is
+the complete local eligibility proof. Project `ready` without calling
+`attachment_capture_status()`, then keep the existing replacement-gate generation
+comparison immediately before capture. Provider failure remains downstream and is
+absorbed by the existing fail-closed queue/provider outcomes.
+
+**Rejected models.** Moving the health read before or after ticket acquisition is
+a position rule: one placement blocks Agent dispatch and the other blocks `/new`.
+A cached health value is also rejected as an eligibility input because freshness
+cannot be proved without coupling admission correctness to refresh timing.
+
+**Blast radius.** `core/controller.py` and focused controller tests only. No
+persistent shape changes. This PR does not touch platform allowlists, Workbench
+readiness, Processing Record, or any `core/memory/` implementation.
+
+**Tests.** A permanently blocked health stub is never called and an eligible
+attachment reaches the request; `/new` completes inside its lifecycle budget while
+that stub remains blocked; a generation change after selection strips attachments
+but preserves caption text; and downstream unavailability does not change ingress
+eligibility. Scenarios: `MEMORY-IM-ATTACH-001`, `MEMORY-IM-ATTACH-003`.
+
+## PR-E: lock-free processing action execution (#1470 item 2)
+
+**Selected model.** Producers atomically persist the existing durable processing
+action and do nothing else. The existing `MemoryWorker` pass is the single driver:
+each active pass drains processing actions as an independent, unconditional step,
+before any session-due lookup or early return based on session work. Deliver,
+session flush, boot recovery, and future producers never call the runner. Failed
+actions retain the existing retry deadline; the worker's one-second tick bounds
+classification latency, which is not a prerequisite for user-path correctness.
+Generation and `occurred_at` compare-and-set checks continue to reject stale probe
+results.
+
+**Rejected models.** Having every producer call a shared drain entry is a
+coordination rule that a new producer can omit. Commit-triggered scheduling avoids
+that omission but introduces task/lifecycle wake-up machinery when the existing
+single periodic owner already supplies a one-second bound. Leaving the probe inside
+the exact-session delivery lock violates the bounded-wait invariant.
+
+**Blast radius.** `core/memory/worker.py`, `core/memory/coordinator.py`, and focused
+tests. It reuses the existing durable action representation and does not add a
+table, component, or migration.
+
+**Tests.** With zero due sessions and one durable processing action, one worker
+tick executes the action. A blocked probe never holds an exact-session delivery
+lock or delays `/new`; retry deadlines suppress only retry attempts, never the
+initial durable action; stale probe completion remains fail-closed.
+
+## PR-A: materializer-wide failure preserves caption (#1471 item 1)
+
+**Selected model.** After PR5 merges, keep the shared materializer's Agent-facing
+failure semantics unchanged. At the message-handler boundary, a batch-wide
+materializer exception schedules the already-authorized caption through the
+text-only Memory path, then preserves the original Agent-path error behavior. The
+text-only handoff uses the canonical session anchor and the existing best-effort
+capture ownership rules.
+
+**Rejected models.** Converting every materializer exception into per-file failures
+would hide infrastructure defects from ordinary Agent attachment handling. Moving
+all Memory capture ahead of materialization is a position rule and would duplicate
+capture when materialization later succeeds.
+
+**Blast radius.** `core/handlers/inbound_attachments.py`,
+`core/handlers/message_handler.py`, and focused tests. These files overlap PR5, so
+this work starts only after PR5 merges and rebases; it never runs in parallel with
+PR5. No persistent shape changes.
+
+**Tests.** Root initialization, lease initialization, and gather-level failures
+each preserve exactly one caption capture while the Agent path retains its existing
+error/result. Cancellation is not converted into degradation, and attachment-only
+turns do not create empty captures.
+
+## PR-B: atomic claimed-row text downgrade (#1471 item 2)
+
+**Selected model.** On deterministic bundle decode or revalidation failure before
+the provider is called, use one existing-store transaction to change the claimed
+row to text-only, clear its bundle reference, return the bundle release id, and make
+the same row retryable. The transaction is conditional on the current lease owner,
+a non-empty caption, and a still-present bundle. It does not increment attempts;
+after downgrade the missing bundle makes a second downgrade impossible. The
+coordinator releases the returned bundle outside the transaction.
+
+**Rejected models.** Settling the row and enqueuing a replacement creates a crash
+gap and can break ordering/deduplication. Creating a second row duplicates identity.
+Keeping text while terminally settling the original row never retries it.
+
+**Blast radius.** `core/memory/store.py`, `core/memory/coordinator.py`, attachment
+release handling, and focused transaction/coordinator tests. The default design
+changes no persisted schema. If an in-row downgrade cannot be expressed without a
+shape change, implementation stops for a persisted-shape decision and legacy-load
+fixtures before any code is pushed.
+
+**Tests.** Decode and descriptor revalidation failures atomically retain caption,
+release the bundle once, preserve row identity/order and attempt count, and deliver
+text on the next claim. Cancellation/crash boundaries leave either the original
+claimed row or the committed downgraded row, never a caption-less intermediate.
+
+## PR-C: deterministic provider rejection downgrade (#1471 item 3)
+
+**Selected model.** Reuse PR-B's row downgrade only when the provider returns the
+closed capability codes `UNSUPPORTED_FORMAT` or `CAPABILITY_UNAVAILABLE`. Those
+results prove no attachment write was accepted, so the row may safely retry as
+text-only. Timeouts, transport failures, unknown errors, and every other 4xx remain
+ambiguous and terminal/retry according to existing behavior; they are never
+replayed as text-only because the remote write may already exist.
+
+**Rejected models.** Treating every 4xx as deterministic guesses provider semantics.
+Routing all provider exceptions through one degradation path can duplicate memory
+after an ambiguous success. Adapter-side immediate text resubmission bypasses the
+durable row's ordering and idempotency.
+
+**Blast radius.** `core/memory/everos.py`, `core/memory/coordinator.py`, the PR-B
+store operation, and focused provider/coordinator tests. No new table, component,
+or migration.
+
+**Tests.** Parameterize the two allowed capability codes and the full rejected
+boundary. Allowed codes produce one attachment call followed by the durable
+text-only retry. Timeout, transport error, unknown error, and all other 4xx keep a
+single provider invocation and never enqueue or invoke a text-only replay.
+
+## Delivery order and lane boundaries
+
+1. PR-D ships first from `063aebd2`, in parallel with PR5.
+2. PR-E follows PR-D in this lane; it is not bundled with the cheapest fix or run
+   concurrently in this lane.
+3. PR-A starts immediately after PR5 merges and is the first #1471 implementation.
+4. PR-B lands alone because it owns the claimed-row transaction model.
+5. PR-C follows PR-B and reuses only its proven deterministic downgrade operation.
+
+PR5 exclusively owns the four remaining IM adapters plus
+`core/memory/attachments.py` and `core/memory/im_attachments.py`. PR-D exclusively
+owns `core/controller.py`. Any change to the frozen eligibility conjunction routes
+through the orchestrator rather than lane-to-lane coordination. Five-platform
+Incus acceptance remains incomplete until PR-A closes the multiplied caption-loss
+exposure after PR5.

--- a/docs/plans/memory-im-attachment-followups-1470-1471.md
+++ b/docs/plans/memory-im-attachment-followups-1470-1471.md
@@ -10,7 +10,7 @@ Ingress attachment eligibility is the conjunction of:
 
 Platform rollout changes only the first term. The #1470 ingress fix changes only
 the latter two terms by removing live provider health from eligibility. Workbench
-keeps its one-cycle live-read compatibility path.
+keeps its one-cycle implicit provider compatibility outside this IM call site.
 
 The call-site invariants remain:
 
@@ -34,9 +34,18 @@ a position rule: one placement blocks Agent dispatch and the other blocks `/new`
 A cached health value is also rejected as an eligibility input because freshness
 cannot be proved without coupling admission correctness to refresh timing.
 
-**Blast radius.** `core/controller.py` and focused controller tests only. No
-persistent shape changes. This PR does not touch platform allowlists, Workbench
-readiness, Processing Record, or any `core/memory/` implementation.
+**Blast radius.** `core/controller.py`, the authoritative generation normalizer in
+`core/memory/admission.py`, and focused controller tests only. No persistent shape
+changes. This PR does not touch platform allowlists, Workbench readiness, or
+Processing Record.
+
+Workbench does not enter the bounded span changed here. The outer
+`admits_attachment_turn()` check requires membership in the IM platform allowlist,
+while Workbench attachments are converted directly by `CaptureAdmission.decide()`.
+It therefore never awaits `attachment_capture_status()` while holding this IM
+exact-session ticket, and its `/new` lifecycle budget is not exposed to the probe
+removed by PR-D. The one-cycle implicit provider compatibility remains unchanged
+in the Workbench/provider path.
 
 **Tests.** A permanently blocked health stub is never called and an eligible
 attachment reaches the request; `/new` completes inside its lifecycle budget while
@@ -88,7 +97,10 @@ capture when materialization later succeeds.
 **Blast radius.** `core/handlers/inbound_attachments.py`,
 `core/handlers/message_handler.py`, and focused tests. These files overlap PR5, so
 this work starts only after PR5 merges and rebases; it never runs in parallel with
-PR5. No persistent shape changes.
+PR5. As part of that already-owned edit, PR-A replaces the existing inline
+non-negative-generation predicate in `message_handler.py` with
+`normalize_attachment_config_generation()`; PR-D deliberately does not widen into
+that file. No persistent shape changes.
 
 **Tests.** Root initialization, lease initialization, and gather-level failures
 each preserve exactly one caption capture while the Agent path retains its existing

--- a/tests/test_memory_slice3.py
+++ b/tests/test_memory_slice3.py
@@ -306,11 +306,14 @@ def test_slack_memory_lease_retention_is_local_and_ignores_runtime_health(
     assert reservation.config_generation == 1
 
 
-def test_slack_memory_reservation_survives_without_multimodal_opt_in() -> None:
+@pytest.mark.parametrize("generation", [None, True, -1, "1"])
+def test_slack_memory_reservation_normalizes_invalid_multimodal_generation(
+    generation: object,
+) -> None:
     """Scenario: MEMORY-IM-ATTACH-003."""
 
     controller = _controller()
-    controller.memory_runtime.attachment_generation = None
+    controller.memory_runtime.attachment_generation = generation
     context = _context("slack", ordinary=False)
     context.files = [
         FileAttachment(

--- a/tests/test_memory_slice3.py
+++ b/tests/test_memory_slice3.py
@@ -475,20 +475,32 @@ def test_slack_without_multimodal_opt_in_skips_live_health_read() -> None:
     asyncio.run(run())
 
 
-def test_attachment_capture_hands_off_before_runtime_health_read() -> None:
+def test_configured_attachment_capture_skips_live_health_read(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Scenario: MEMORY-IM-ATTACH-001."""
 
     async def run() -> None:
         controller = _controller()
-        health_started = asyncio.Event()
-        release_health = asyncio.Event()
+        health_reads = 0
 
         async def attachment_capture_status() -> str:
-            health_started.set()
-            await release_health.wait()
-            return "unavailable"
+            nonlocal health_reads
+            health_reads += 1
+            await asyncio.Event().wait()
+            return "ready"
 
         controller.memory_runtime.attachment_capture_status = attachment_capture_status
+        attachment = CaptureAttachment(
+            kind="pdf",
+            name="receipt.pdf",
+            uri="file:///leased/receipt.pdf",
+            ext="pdf",
+        )
+        monkeypatch.setattr(
+            "core.memory.admission.select_memory_attachments",
+            lambda _lease: SimpleNamespace(attachments=(attachment,), skipped=()),
+        )
         context = _context("slack", ordinary=False)
         context.files = [
             FileAttachment(
@@ -503,21 +515,93 @@ def test_attachment_capture_hands_off_before_runtime_health_read() -> None:
             "stable-session",
         )
         assert reservation is not None
+        assert reservation.config_generation == 1
 
-        capture = asyncio.create_task(
+        await asyncio.wait_for(
             controller.capture_user_memory(
                 context,
                 "remember this",
                 "stable-session",
                 attachment_lease=object(),
                 attachment_reservation=reservation,
+            ),
+            timeout=1.0,
+        )
+
+        assert health_reads == 0
+        assert len(controller.memory_module.accepted) == 1
+        assert controller.memory_module.accepted[0].attachments == (attachment,)
+
+    asyncio.run(run())
+
+
+def test_configured_attachment_capture_does_not_block_session_reset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Scenario: MEMORY-IM-ATTACH-003."""
+
+    async def run() -> None:
+        controller = _controller()
+        store = MemoryStore()
+        module = MemoryModule(store, FakeMemoryProvider(), enabled=True)
+        controller.memory_module = module
+        controller.memory_runtime = _Runtime(module)
+        health_reads = 0
+
+        async def attachment_capture_status() -> str:
+            nonlocal health_reads
+            health_reads += 1
+            await asyncio.Event().wait()
+            return "ready"
+
+        controller.memory_runtime.attachment_capture_status = attachment_capture_status
+        monkeypatch.setattr(
+            "core.memory.admission.select_memory_attachments",
+            lambda _lease: SimpleNamespace(attachments=(), skipped=()),
+        )
+        context = _context("slack", ordinary=False)
+        context.files = [
+            FileAttachment(
+                name="receipt.pdf",
+                mimetype="application/pdf",
+                url="https://files.slack.test/private",
+            )
+        ]
+        context.is_ordinary_attachment = True
+        reservation = controller.reserve_memory_attachment_capture(
+            context,
+            "stable-session",
+        )
+        assert reservation is not None
+        capture = asyncio.create_task(
+            controller.capture_user_memory(
+                context,
+                "keep the caption",
+                "stable-session",
+                attachment_lease=object(),
+                attachment_reservation=reservation,
             )
         )
-        await asyncio.wait_for(health_started.wait(), timeout=1.0)
-        assert not capture.done()
+        reset_ran = False
 
-        release_health.set()
+        async def reset() -> None:
+            nonlocal reset_ran
+            reset_ran = True
+
+        await asyncio.wait_for(
+            module.run_session_lifecycle(
+                principal_id="u-" + ("1" * 32),
+                project_id=PROJECT,
+                raw_session_id="stable-session",
+                operation=reset,
+                deadline_seconds=0.25,
+            ),
+            timeout=0.75,
+        )
         await asyncio.wait_for(capture, timeout=1.0)
+
+        assert reset_ran is True
+        assert health_reads == 0
 
     asyncio.run(run())
 
@@ -608,16 +692,14 @@ def test_attachment_capture_fails_closed_when_config_generation_changes(
             uri="file:///leased/receipt.pdf",
             ext="pdf",
         )
+        def select_attachments(_lease):
+            controller.memory_runtime.attachment_generation = 2
+            return SimpleNamespace(attachments=(attachment,), skipped=())
+
         monkeypatch.setattr(
             "core.memory.admission.select_memory_attachments",
-            lambda _lease: SimpleNamespace(attachments=(attachment,), skipped=()),
+            select_attachments,
         )
-
-        async def attachment_capture_status() -> str:
-            controller.memory_runtime.attachment_generation = 2
-            return "ready"
-
-        controller.memory_runtime.attachment_capture_status = attachment_capture_status
         context = _context("slack", ordinary=False)
         context.files = [
             FileAttachment(
@@ -655,6 +737,60 @@ def test_attachment_capture_fails_closed_when_config_generation_changes(
     ]
     assert len(records) == 1
     assert "platform=slack total=1 captured=0 dropped=1" in records[0].getMessage()
+
+
+def test_downstream_capture_unavailability_does_not_change_ingress_eligibility(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Scenario: MEMORY-IM-ATTACH-003."""
+
+    async def run() -> None:
+        controller = _controller()
+        attachment = CaptureAttachment(
+            kind="pdf",
+            name="receipt.pdf",
+            uri="file:///leased/receipt.pdf",
+            ext="pdf",
+        )
+        monkeypatch.setattr(
+            "core.memory.admission.select_memory_attachments",
+            lambda _lease: SimpleNamespace(attachments=(attachment,), skipped=()),
+        )
+        captured_requests: list[CaptureRequest] = []
+
+        async def unavailable_capture(request, **_options):
+            captured_requests.append(request)
+            return CaptureSkipped(reason="memory_operation_in_progress")
+
+        controller.memory_module.capture = unavailable_capture
+        controller.memory_runtime.attachment_status = "unavailable"
+        context = _context("slack", ordinary=False)
+        context.files = [
+            FileAttachment(
+                name="receipt.pdf",
+                mimetype="application/pdf",
+                url="https://files.slack.test/private",
+            )
+        ]
+        context.is_ordinary_attachment = True
+        reservation = controller.reserve_memory_attachment_capture(
+            context,
+            "stable-session",
+        )
+        assert reservation is not None
+
+        await controller.capture_user_memory(
+            context,
+            "keep the caption",
+            "stable-session",
+            attachment_lease=object(),
+            attachment_reservation=reservation,
+        )
+
+        assert len(captured_requests) == 1
+        assert captured_requests[0].attachments == (attachment,)
+
+    asyncio.run(run())
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Capability

Implements #1470 item 1 by making IM attachment eligibility a local, generation-bound decision. A complete explicit multimodal configuration now admits the attachment without a live provider health read; the existing replacement gate still strips attachments when the generation changes before capture. The generation boundary has one authoritative normalizer shared by reservation, controller projection, and admission.

The follow-up design for both #1470 and #1471 is recorded in `docs/plans/memory-im-attachment-followups-1470-1471.md`, including the approved single-driver model for #1470 item 2.

## Scenario IDs

- `MEMORY-IM-ATTACH-001`: configured attachments reach capture without a live health read.
- `MEMORY-IM-ATTACH-003`: `/new` stays within its lifecycle budget, invalid or replaced generations fail closed, and downstream unavailability does not change ingress eligibility.

## Evidence layers

- **Unit:** focused controller tests cover a permanently blocked health stub (`0` calls), attachment request formation, bounded `/new`, invalid and replaced generations, and downstream fail-closed behavior.
- **Contract:** the follow-up plan freezes eligibility as platform allowlist AND complete explicit config AND valid integer generation, and records selected/rejected models for all five follow-ups.
- **Scenario:** existing `memory_im_attachment_capture` IDs are visible in the focused tests; catalog shapes are unchanged.
- **Residual manual:** no live provider or real IM credential is required for this local admission invariant. Five-platform Incus acceptance remains deferred until PR5 and #1471 item 1 land.

## Lane boundaries

- PR5 exclusively owns `modules/im/{discord,telegram,feishu,wechat}.py`, `core/memory/attachments.py`, and `core/memory/im_attachments.py`; this PR has zero diff in those files.
- This PR owns the `core/controller.py` decision point, the authoritative normalizer in `core/memory/admission.py`, focused tests, and the approved plan document.
- The existing inline predicate in `core/handlers/message_handler.py` is deliberately not changed here; PR-A already owns that file after PR5 and the plan names its convergence explicitly.

## Known by design

- Provider online health is not an IM ingress eligibility condition. Provider failures remain downstream, where existing queue/provider outcomes absorb them fail closed.
- Workbench does not enter this bounded span: `admits_attachment_turn()` requires an IM allowlisted platform, while Workbench owned attachments are converted directly in `CaptureAdmission.decide()`. It therefore never awaits this `attachment_capture_status()` call while holding the IM exact-session ticket, so Workbench `/new` is not exposed to this probe. Its one-cycle implicit provider compatibility remains unchanged elsewhere.
- #1470 item 2 is intentionally separate as PR-E so the lock-free processing-action model is not coupled to this controller fix.

Refs #1470
Refs #1471
