### PR TITLE
fix(memory): preserve captions on materializer failure

### DIFF
--- a/core/handlers/message_handler.py
+++ b/core/handlers/message_handler.py
@@ -116,6 +116,45 @@ class MessageHandler(BaseHandler):
             return None
         return await acquire(session_id)
 
+    async def _schedule_text_only_memory_capture(
+        self,
+        context: MessageContext,
+        text: str,
+        session_id: str,
+        lifecycle_admission: Any,
+    ) -> Any:
+        capture_memory = getattr(self.controller, "capture_user_memory", None)
+        if not callable(capture_memory) or not text.strip():
+            return lifecycle_admission
+
+        admission_was_owned_by_turn = lifecycle_admission is not None
+        lifecycle_admission = await self._acquire_memory_capture_admission(
+            session_id,
+            lifecycle_admission,
+        )
+        if not self._memory_capture_registration_open:
+            release = getattr(lifecycle_admission, "release", None)
+            if callable(release):
+                release()
+            return None
+
+        try:
+            capture_task = asyncio.create_task(
+                capture_memory(context, text, session_id),
+                name="memory-capture",
+            )
+            self._track_memory_capture_task(
+                capture_task,
+                lifecycle_admission=lifecycle_admission,
+            )
+        except BaseException:
+            if not admission_was_owned_by_turn:
+                release = getattr(lifecycle_admission, "release", None)
+                if callable(release):
+                    release()
+            raise
+        return None
+
     def _memory_session_lifecycle_epoch(self, session_id: str) -> int:
         manager = getattr(self.controller, "session_turns", None)
         read_epoch = getattr(manager, "session_lifecycle_epoch", None)
@@ -355,25 +394,14 @@ class MessageHandler(BaseHandler):
             # turns defer only until the shared materializer has produced a
             # descriptor-backed lease.
             if is_human and not context.files:
-                capture_memory = getattr(self.controller, "capture_user_memory", None)
-                if callable(capture_memory):
-                    turn_lifecycle_admission = await self._acquire_memory_capture_admission(
+                turn_lifecycle_admission = (
+                    await self._schedule_text_only_memory_capture(
+                        context,
+                        control_message,
                         memory_session_id,
                         turn_lifecycle_admission,
                     )
-                    if self._memory_capture_registration_open:
-                        capture_task = asyncio.create_task(
-                            capture_memory(context, control_message, memory_session_id),
-                            name="memory-capture",
-                        )
-                        self._track_memory_capture_task(
-                            capture_task,
-                            lifecycle_admission=turn_lifecycle_admission,
-                        )
-                        turn_lifecycle_admission = None
-                    elif turn_lifecycle_admission is not None:
-                        turn_lifecycle_admission.release()
-                        turn_lifecycle_admission = None
+                )
 
             reply_anchor_base_session_id = payload.get("reply_anchor_base_session_id")
             if reply_anchor_base_session_id and reply_anchor_base_session_id != base_session_id:
@@ -755,10 +783,29 @@ class MessageHandler(BaseHandler):
                     if isinstance(attachment, FileAttachment)
                     and attachment.local_path
                 }
-                attachment_batch = await self._materialize_file_attachments(
-                    context,
-                    working_path,
-                )
+                try:
+                    attachment_batch = await self._materialize_file_attachments(
+                        context,
+                        working_path,
+                    )
+                except Exception:
+                    if is_human:
+                        try:
+                            turn_lifecycle_admission = (
+                                await self._schedule_text_only_memory_capture(
+                                    context,
+                                    control_message,
+                                    memory_session_id,
+                                    turn_lifecycle_admission,
+                                )
+                            )
+                        except Exception:
+                            logger.warning(
+                                "Memory caption capture could not be scheduled "
+                                "after attachment materialization failed",
+                                exc_info=True,
+                            )
+                    raise
                 attachment_lease = attachment_batch.lease
                 processed_files = list(attachment_batch.attachments) or None
                 attachment_errors = list(attachment_batch.display_errors)
@@ -810,15 +857,19 @@ class MessageHandler(BaseHandler):
                             and not stale_attachment_capture
                             else None
                         )
-                        attachment_config_generation = getattr(
-                            memory_capture_reservation,
-                            "config_generation",
-                            None,
+                        from core.memory import admission as memory_admission
+
+                        attachment_config_generation = (
+                            memory_admission.normalize_attachment_config_generation(
+                                getattr(
+                                    memory_capture_reservation,
+                                    "config_generation",
+                                    None,
+                                )
+                            )
                         )
                         if (
-                            not isinstance(attachment_config_generation, bool)
-                            and isinstance(attachment_config_generation, int)
-                            and attachment_config_generation >= 0
+                            attachment_config_generation is not None
                             and attachment_lease is not None
                         ):
                             try:

--- a/tests/test_message_handler_typing.py
+++ b/tests/test_message_handler_typing.py
@@ -632,6 +632,261 @@ class MessageHandlerTypingTests(unittest.IsolatedAsyncioTestCase):
         lease.adopt.assert_called_once_with()
         lease.release.assert_called_once_with()
 
+    async def test_materializer_global_failures_capture_caption_once(self):
+        """Scenario: MEMORY-IM-ATTACH-004."""
+
+        from modules.im.base import FileAttachment
+
+        cases = (
+            ("slack", OSError("attachment root initialization failed")),
+            ("discord", RuntimeError("attachment lease initialization failed")),
+            ("telegram", RuntimeError("attachment gather failed")),
+        )
+        for platform, materialization_error in cases:
+            with self.subTest(platform=platform):
+                controller = _StubController(
+                    platform=platform,
+                    ack_mode="reaction",
+                    typing_result=True,
+                )
+                controller.session_turns = types.SimpleNamespace(deliver=AsyncMock())
+                controller.capture_user_memory = AsyncMock()
+                controller.reserve_memory_attachment_capture = Mock()
+                handler = MessageHandler(controller)
+                handler.set_session_handler(_StubSessionHandler())
+                handler._is_duplicate_human_delivery = Mock(return_value=False)
+                handler._prepend_message_metadata = AsyncMock(
+                    return_value="remember this caption"
+                )
+                handler._materialize_file_attachments = AsyncMock(
+                    side_effect=materialization_error
+                )
+                handler._emit_agent_dispatch_failure = AsyncMock()
+                context = MessageContext(
+                    user_id="U1",
+                    channel_id="D1",
+                    message_id=f"m-materializer-{platform}",
+                    platform=platform,
+                    platform_specific={"is_dm": True},
+                    files=[
+                        FileAttachment(
+                            "report.pdf",
+                            "application/pdf",
+                            url="private",
+                        )
+                    ],
+                    is_ordinary_attachment=True,
+                )
+
+                result = await handler._handle_turn(
+                    context,
+                    "remember this caption",
+                    source=handler.TURN_SOURCE_HUMAN,
+                )
+                await handler.drain_memory_capture_tasks()
+
+                self.assertEqual(result, str(materialization_error))
+                controller.capture_user_memory.assert_awaited_once_with(
+                    context,
+                    "remember this caption",
+                    "base-session",
+                )
+                controller.reserve_memory_attachment_capture.assert_not_called()
+                handler._emit_agent_dispatch_failure.assert_awaited_once()
+                self.assertIs(
+                    handler._emit_agent_dispatch_failure.await_args.args[2],
+                    materialization_error,
+                )
+                self.assertEqual(controller.agent_service.requests, [])
+
+    async def test_materializer_failure_with_empty_caption_does_not_capture(self):
+        """Scenario: MEMORY-IM-ATTACH-004."""
+
+        from modules.im.base import FileAttachment
+
+        controller = _StubController(
+            platform="discord",
+            ack_mode="reaction",
+            typing_result=True,
+        )
+        controller.session_turns = types.SimpleNamespace(deliver=AsyncMock())
+        controller.capture_user_memory = AsyncMock()
+        handler = MessageHandler(controller)
+        handler.set_session_handler(_StubSessionHandler())
+        handler._is_duplicate_human_delivery = Mock(return_value=False)
+        handler._prepend_message_metadata = AsyncMock(return_value="")
+        handler._materialize_file_attachments = AsyncMock(
+            side_effect=RuntimeError("materialization failed")
+        )
+        handler._emit_agent_dispatch_failure = AsyncMock()
+        context = MessageContext(
+            user_id="U1",
+            channel_id="D1",
+            message_id="m-empty-caption-materializer",
+            platform="discord",
+            platform_specific={"is_dm": True},
+            files=[FileAttachment("report.pdf", "application/pdf", url="private")],
+            is_ordinary_attachment=True,
+        )
+
+        await handler._handle_turn(
+            context,
+            "   ",
+            source=handler.TURN_SOURCE_HUMAN,
+        )
+
+        controller.capture_user_memory.assert_not_called()
+
+    async def test_materializer_cancellation_does_not_capture_caption(self):
+        """Scenario: MEMORY-IM-ATTACH-004."""
+
+        from modules.im.base import FileAttachment
+
+        controller = _StubController(
+            platform="telegram",
+            ack_mode="reaction",
+            typing_result=True,
+        )
+        controller.session_turns = types.SimpleNamespace(deliver=AsyncMock())
+        controller.capture_user_memory = AsyncMock()
+        handler = MessageHandler(controller)
+        handler.set_session_handler(_StubSessionHandler())
+        handler._is_duplicate_human_delivery = Mock(return_value=False)
+        handler._prepend_message_metadata = AsyncMock(return_value="remember this")
+        handler._materialize_file_attachments = AsyncMock(
+            side_effect=asyncio.CancelledError
+        )
+        handler._emit_agent_dispatch_failure = AsyncMock()
+        context = MessageContext(
+            user_id="U1",
+            channel_id="D1",
+            message_id="m-cancelled-materializer",
+            platform="telegram",
+            platform_specific={"is_dm": True},
+            files=[FileAttachment("report.pdf", "application/pdf", url="private")],
+            is_ordinary_attachment=True,
+        )
+
+        with self.assertRaises(asyncio.CancelledError):
+            await handler._handle_turn(
+                context,
+                "remember this",
+                source=handler.TURN_SOURCE_HUMAN,
+            )
+
+        controller.capture_user_memory.assert_not_called()
+        handler._emit_agent_dispatch_failure.assert_not_awaited()
+
+    async def test_caption_fallback_scheduling_failure_preserves_materializer_error(self):
+        """Scenario: MEMORY-IM-ATTACH-004."""
+
+        from modules.im.base import FileAttachment
+
+        materialization_error = RuntimeError("materialization failed")
+        controller = _StubController(
+            platform="slack",
+            ack_mode="reaction",
+            typing_result=True,
+        )
+        controller.session_turns = types.SimpleNamespace(
+            deliver=AsyncMock(),
+            acquire_lifecycle_admission=AsyncMock(
+                side_effect=RuntimeError("capture scheduling failed")
+            ),
+        )
+        controller.capture_user_memory = AsyncMock()
+        handler = MessageHandler(controller)
+        handler.set_session_handler(_StubSessionHandler())
+        handler._is_duplicate_human_delivery = Mock(return_value=False)
+        handler._prepend_message_metadata = AsyncMock(return_value="remember this")
+        handler._materialize_file_attachments = AsyncMock(
+            side_effect=materialization_error
+        )
+        handler._emit_agent_dispatch_failure = AsyncMock()
+        context = MessageContext(
+            user_id="U1",
+            channel_id="D1",
+            message_id="m-failed-caption-fallback",
+            platform="slack",
+            platform_specific={"is_dm": True},
+            files=[FileAttachment("report.pdf", "application/pdf", url="private")],
+            is_ordinary_attachment=True,
+        )
+
+        result = await handler._handle_turn(
+            context,
+            "remember this",
+            source=handler.TURN_SOURCE_HUMAN,
+        )
+
+        self.assertEqual(result, "materialization failed")
+        controller.capture_user_memory.assert_not_called()
+        self.assertIs(
+            handler._emit_agent_dispatch_failure.await_args.args[2],
+            materialization_error,
+        )
+
+    async def test_invalid_attachment_generation_is_normalized_before_capture(self):
+        """Scenario: MEMORY-IM-ATTACH-003."""
+
+        from modules.im.base import FileAttachment
+
+        controller = _StubController(
+            platform="slack",
+            ack_mode="reaction",
+            typing_result=True,
+        )
+        controller.session_turns = types.SimpleNamespace(deliver=AsyncMock())
+        reservation = _capture_reservation(generation=True)
+        controller.reserve_memory_attachment_capture = Mock(
+            return_value=reservation
+        )
+        controller.capture_user_memory = AsyncMock()
+        lease = Mock()
+        attachment = FileAttachment(
+            name="report.pdf",
+            mimetype="application/pdf",
+            local_path="/tmp/leased-report.pdf",
+            size=10,
+        )
+        handler = MessageHandler(controller)
+        handler.set_session_handler(_StubSessionHandler())
+        handler._is_duplicate_human_delivery = Mock(return_value=False)
+        handler._prepend_message_metadata = AsyncMock(return_value="remember this")
+        handler._materialize_file_attachments = AsyncMock(
+            return_value=types.SimpleNamespace(
+                attachments=(attachment,),
+                display_errors=(),
+                lease=lease,
+            )
+        )
+
+        async def admit(**_kwargs):
+            lease.adopt()
+            lease.release()
+            return True
+
+        handler._admit_human_delivery = AsyncMock(side_effect=admit)
+        context = MessageContext(
+            user_id="U1",
+            channel_id="D1",
+            message_id="m-invalid-generation",
+            platform="slack",
+            platform_specific={"is_dm": True},
+            files=[FileAttachment("report.pdf", "application/pdf", url="private")],
+            is_ordinary_attachment=True,
+        )
+
+        await handler.handle_user_message(context, "remember this")
+        await handler.drain_memory_capture_tasks()
+
+        capture_call = controller.capture_user_memory.await_args
+        self.assertIsNone(
+            capture_call.kwargs["attachment_config_generation"]
+        )
+        self.assertNotIn("attachment_lease", capture_call.kwargs)
+        lease.retain.assert_not_called()
+
     async def test_denied_attachment_turn_does_not_retain_a_memory_lease(self):
         """Scenario: MEMORY-IM-ATTACH-002."""
 


### PR DESCRIPTION
## Capability

Preserve an eligible human caption in Memory when shared IM attachment materialization fails for the whole batch, without changing the Agent-facing attachment failure.

Part of #1471 (item 1 only).

## Change

- Reuse one handler-owned text-only capture scheduler for ordinary text turns and the materializer failure fallback.
- Catch only non-cancellation materializer exceptions, schedule one caption-only capture against the canonical Memory session anchor saved before download, then re-raise the original exception unchanged.
- Keep fallback scheduling best effort; an admission or task-scheduling failure cannot replace the original materializer error.
- Pass no attachment reservation or lease on the fallback path, and skip scheduling for an empty caption.
- Replace the handler's copied generation predicate with the authoritative `normalize_attachment_config_generation()` result. The import stays at the consumption point to avoid the existing `admission -> im_attachments -> handlers` initialization cycle.

No materializer, persistence, state-machine, adapter, or per-reason attachment accounting changes are included.

## Evidence

- **Unit:** `tests/test_message_handler_typing.py` covers root initialization, lease initialization, and gather-level exceptions; each case failed before this change because no caption capture was scheduled. It also covers empty captions, `CancelledError`, fallback scheduling failure, and invalid boolean generations.
- **Contract:** the invalid-generation regression proves the handler consumes the shared generation normalizer and never retains an attachment lease for an invalid generation.
- **Scenario:** `MEMORY-IM-ATTACH-004` now covers batch-wide failure text independence across Slack, Discord, and Telegram, in addition to existing per-item degradation coverage.
- **Residual manual:** none required for this handler-only failure boundary. Platform payload and real download verification remain in the existing Incus attachment matrix.

## Validation

- `pytest -q tests/test_message_handler_typing.py tests/test_memory_admission.py tests/scenarios/memory_im_attachment_capture/test_memory_im_attachment_capture_catalog.py tests/scenarios/memory_im_attachment_capture/test_memory_im_attachment_capture_scenarios.py` (`157 passed`)
- `ruff check core/handlers/message_handler.py tests/test_message_handler_typing.py`
