### PR TITLE
docs(memory): add five-platform attachment acceptance

### DIFF
--- a/docs/regression/memory-im-attachment-five-platform-acceptance.md
+++ b/docs/regression/memory-im-attachment-five-platform-acceptance.md
@@ -19,7 +19,7 @@ observability issue, not in this checklist.
 
 ## Preconditions
 
-Do not start the 15-minute clock until all of these are true:
+Do not start the 20-minute clock until all of these are true:
 
 1. The authorized local Incus `master` target is healthy and still has its prior
    product state. This checklist requires a separately provisioned five-platform
@@ -69,21 +69,26 @@ production data.
 Use different markers for every platform. Keep a local table mapping each pair
 and marker to its platform; do not put that table in chat.
 
-## 15-minute acceptance flow
+## 20-minute acceptance flow
 
-Send the ten fixtures first, then wait once. Idle flush is tracked per session,
-so waiting after the final send covers every platform without mutating any
-session-owned state.
+Send the ten fixtures first, then wait once. The worker delivers the capture rows
+serially, and a session's idle-flush clock starts only after its add succeeds.
+The shared wait therefore budgets for both ingestion and the per-session idle
+window without mutating any session-owned state.
 
 1. In **Memory > Processing Record**, record the newest entry timestamp for each
    bound platform user. This is the per-user high-water mark for the run.
 2. Within about two minutes, send each platform's accepted PNG and rejected SVG
    as described in the table. The order within a platform does not affect the
    result; finish all ten sends before waiting.
-3. Do not send another message in any tested session for at least **5 minutes 30
-   seconds after the final fixture**. The wait derives from
-   `core/memory/coordinator.py`'s `IDLE_FLUSH_TIMEOUT = 5 minutes`, with 30 seconds
-   of scheduling margin. `MAX_UNFLUSHED_AGE = 30 minutes` and
+3. Do not send another message in any tested session for at least **10 minutes 30
+   seconds after the final fixture**. The first five minutes are the worst-case
+   ingestion budget for ten serial rows: `core/memory/worker.py` drains rows one
+   at a time and `core/memory/coordinator.py` bounds each provider add with
+   `ADD_TIMEOUT_SECONDS = 30`. Only after each successful add does
+   `MemoryStore.settle_add_ack()` set that session's idle deadline. The next five
+   minutes derive from `IDLE_FLUSH_TIMEOUT = 5 minutes`, followed by 30 seconds of
+   scheduling margin. `MAX_UNFLUSHED_AGE = 30 minutes` and
    `MAX_UNFLUSHED_MESSAGES = 100` are fallback bounds, not the expected trigger
    for this two-message-per-platform run.
 4. Refresh **Processing Record** and inspect all ten outcomes. Recheck that **Call
@@ -93,10 +98,10 @@ session-owned state.
 This flow deliberately does **not** use `/new`. That command tears down the Agent
 session and pauses session-bound tasks and watches
 (`core/handlers/command_handlers.py`), which conflicts with the long-lived
-`master` environment's state-preservation boundary. The shared idle window avoids
-those mutations and keeps the expected wall time near 15 minutes: roughly two
-minutes to send, 5.5 minutes idle, and the remaining time to inspect and record
-results.
+`master` environment's state-preservation boundary. The shared ingestion-plus-idle
+window avoids those mutations and keeps the expected wall time near 20 minutes:
+roughly two minutes to send, 10.5 minutes for serial ingestion plus idle, and the
+remaining time for the bounded flush, inspection, and result recording.
 
 The processing log is the primary evidence because it covers every user and
 project on the installation; **Memory > Search** is scoped to the current
@@ -145,7 +150,7 @@ post-baseline entry conditions in the table decide them.
 ## Fixture collection plan
 
 This is an optional, separately authorized engineering follow-up, not a phase of
-the 15-minute UI acceptance flow. The ten manual messages can inform which
+the 20-minute UI acceptance flow. The ten manual messages can inform which
 fixtures are most valuable, but they do not provide the Lark `media` or WeChat
 bot/self/system samples below. Do not block or complete the acceptance result on
 these fixture decisions unless the collector was separately authorized and run.

--- a/docs/regression/memory-im-attachment-five-platform-acceptance.md
+++ b/docs/regression/memory-im-attachment-five-platform-acceptance.md
@@ -22,7 +22,11 @@ observability issue, not in this checklist.
 Do not start the 15-minute clock until all of these are true:
 
 1. The authorized local Incus `master` target is healthy and still has its prior
-   product state.
+   product state. This checklist requires a separately provisioned five-platform
+   target: the standard regression seed covers Slack, Discord, Lark, and WeChat
+   but does not provision Telegram credentials. If Telegram is not already
+   configured and bound, record the run as `BLOCKED` and stop. Do not add or
+   change credentials as part of this checklist.
 2. Memory is enabled. In the Web UI, open **Memory > Processing Record** and verify
    **Engine status** is **Healthy**.
 3. In **Memory > Processing Record**, verify **Call log** is **Recording
@@ -107,7 +111,7 @@ For a rejected SVG, use only the post-baseline processing entries visible in the
 UI. A caption-bearing rejected turn must preserve its caption without showing the
 SVG filename as an attachment in the entry preview. The Lark and WeChat file-only
 rows must not produce an entry attributable to the rejected filename, marker,
-user, and send time. The hermetic `MEMORY-IM-ATTACH-004` scenario separately
+user, and send time. The hermetic `MEMORY-IM-ATTACH-010` scenario separately
 proves that a fully rejected attachment does not enter the multimodal provider
 path; the manual run does not try to reconstruct that engineering fact from an
 unobservable UI absence.
@@ -115,15 +119,15 @@ unobservable UI absence.
 | Platform | Scenario | Send | Pass condition in Memory > Processing Record |
 | --- | --- | --- | --- |
 | Slack | `MEMORY-IM-ATTACH-001` | In a bound human DM, send the Slack PNG with caption `<run-tag> slack accepted image`. | One post-baseline terminal entry exists for the Slack user. Its **Model calls** contain an attributed multimodal request with the image and a response that describes or reproduces the PNG-only marker. |
-| Slack | `MEMORY-IM-ATTACH-004` | In the same DM, send the Slack SVG with caption `<run-tag> slack rejected file`. | A post-baseline entry preserves the caption, and its preview does not show the Slack SVG filename as an attachment. |
+| Slack | `MEMORY-IM-ATTACH-010` | In the same DM, send the Slack SVG with caption `<run-tag> slack rejected file`. | A post-baseline entry preserves the caption, and its preview does not show the Slack SVG filename as an attachment. |
 | Discord | `MEMORY-IM-ATTACH-005` | In a bound human DM, upload the Discord PNG as an ordinary attachment with caption `<run-tag> discord accepted image`. Do not add a link embed, component, sticker, or forward. | One post-baseline terminal entry exists for the Discord user. Its attributed multimodal request contains the image and its response exposes the PNG-only marker. If the raw message has an automatic embed and no entry is created, fail this row and apply the Discord fixture decision below. |
-| Discord | `MEMORY-IM-ATTACH-004`, `MEMORY-IM-ATTACH-005` | Upload the Discord SVG with caption `<run-tag> discord rejected file`. | A post-baseline entry preserves the caption, and its preview does not show the Discord SVG filename as an attachment. |
+| Discord | `MEMORY-IM-ATTACH-010`, `MEMORY-IM-ATTACH-005` | Upload the Discord SVG with caption `<run-tag> discord rejected file`. | A post-baseline entry preserves the caption, and its preview does not show the Discord SVG filename as an attachment. |
 | Telegram | `MEMORY-IM-ATTACH-006` | In a bound private chat, send the Telegram PNG as one photo message with caption `<run-tag> telegram accepted image`. Do not use an album. | One post-baseline terminal entry exists for the Telegram user. Its attributed multimodal request contains the Telegram image input and its response exposes the PNG-only marker. The request may identify the normalized JPEG photo rather than the original PNG filename/MIME. |
-| Telegram | `MEMORY-IM-ATTACH-004`, `MEMORY-IM-ATTACH-006` | Send the Telegram SVG as one document with caption `<run-tag> telegram rejected file`. | A post-baseline entry preserves the caption, and its preview does not show the Telegram SVG filename as an attachment. |
+| Telegram | `MEMORY-IM-ATTACH-010`, `MEMORY-IM-ATTACH-006` | Send the Telegram SVG as one document with caption `<run-tag> telegram rejected file`. | A post-baseline entry preserves the caption, and its preview does not show the Telegram SVG filename as an attachment. |
 | Lark | `MEMORY-IM-ATTACH-007` | In a bound one-to-one chat, send the Lark PNG through the native **image** action as one image-only message. The pixel marker includes the run tag. | One post-baseline terminal entry appears for the Lark user. Its attributed multimodal request contains the image input and its response exposes the PNG-only marker. |
-| Lark | `MEMORY-IM-ATTACH-004`, `MEMORY-IM-ATTACH-007` | Send the Lark SVG through the native **file** action as one file-only message. The filename includes the run tag; its visible SVG marker is different from the filename. | No post-baseline entry is attributable to the rejected Lark filename, marker, user, and send time. |
+| Lark | `MEMORY-IM-ATTACH-010`, `MEMORY-IM-ATTACH-007` | Send the Lark SVG through the native **file** action as one file-only message. The filename includes the run tag; its visible SVG marker is different from the filename. | No post-baseline entry is attributable to the rejected Lark filename, marker, user, and send time. |
 | WeChat | `MEMORY-IM-ATTACH-008` | In a bound direct chat, send the WeChat PNG as one direct image item with no quoted/reference message. The pixel marker includes the run tag. | One post-baseline terminal entry appears for the WeChat user. Its attributed multimodal request contains the image input and its response exposes the PNG-only marker. |
-| WeChat | `MEMORY-IM-ATTACH-004`, `MEMORY-IM-ATTACH-008` | Send the WeChat SVG as one direct file item, with no quoted/reference message. The filename includes the run tag. | No post-baseline entry is attributable to the rejected WeChat filename, marker, user, and send time. |
+| WeChat | `MEMORY-IM-ATTACH-010`, `MEMORY-IM-ATTACH-008` | Send the WeChat SVG as one direct file item, with no quoted/reference message. The filename includes the run tag. | No post-baseline entry is attributable to the rejected WeChat filename, marker, user, and send time. |
 
 Record `PASS`, `FAIL`, or `INCONCLUSIVE` for every row. Where a caption is
 supported, a missing caption is a failure. For every platform, an accepted image
@@ -139,6 +143,12 @@ rows do not use absence of Model calls as evidence; only the visible
 post-baseline entry conditions in the table decide them.
 
 ## Fixture collection plan
+
+This is an optional, separately authorized engineering follow-up, not a phase of
+the 15-minute UI acceptance flow. The ten manual messages can inform which
+fixtures are most valuable, but they do not provide the Lark `media` or WeChat
+bot/self/system samples below. Do not block or complete the acceptance result on
+these fixture decisions unless the collector was separately authorized and run.
 
 Raw platform payloads may contain message IDs, user IDs, signed download URLs,
 tokens, filenames, captions, and other user content. Never commit a raw capture.
@@ -228,8 +238,10 @@ Decision:
   facts. WeChat source exclusion remains the explicit fixture decision above.
 - Resetting regression state, changing credentials, testing remote Incus, or
   validating Agent attachment behavior. This run covers Memory capture only.
+- Provisioning Telegram or any other platform credentials. A separately
+  provisioned five-platform target is a precondition, not an acceptance step.
 - Proving the absence of pre-memcell provider calls through the product UI. The
-  `MEMORY-IM-ATTACH-004` automated scenario owns the rejection-to-provider
+  `MEMORY-IM-ATTACH-010` automated scenario owns the rejection-to-provider
   boundary; issue #1483 tracks product visibility for calls without memcells.
 
 ## Follow-up tracking
@@ -246,7 +258,10 @@ Decision:
 
 ## Result record
 
-Record the run tag, source commit, service-health result, Call log baseline and
-final state, ten row outcomes (including any `INCONCLUSIVE` reason), and the three
-fixture decisions in the owning issue or acceptance report. Do not paste raw
-payloads, signed URLs, credentials, or unsanitized logs into that report.
+Record the run tag, source commit, five-platform provisioning check,
+service-health result, Call log baseline and final state, and ten row outcomes
+(including any `BLOCKED` or `INCONCLUSIVE` reason) in the owning issue or
+acceptance report. If a separately authorized fixture collection was also run,
+append only its scrubbed decisions; otherwise record fixture collection as **not
+run (optional follow-up)**. Do not paste raw payloads, signed URLs, credentials,
+or unsanitized logs into that report.

--- a/docs/regression/memory-im-attachment-five-platform-acceptance.md
+++ b/docs/regression/memory-im-attachment-five-platform-acceptance.md
@@ -8,28 +8,40 @@
 
 This runbook validates the first Memory attachment release across Slack, Discord,
 Telegram, Lark, and WeChat. It is deliberately short: prepare five fixture pairs,
-send ten direct messages in two flush-bounded phases, and inspect the ten
-outcomes. The Agent's reply is not evidence of Memory capture; Memory runs
+send ten direct messages, wait for one shared idle-flush window, and inspect the
+ten outcomes. The Agent's reply is not evidence of Memory capture; Memory runs
 independently of Agent delivery.
+
+This owner-facing checklist uses only evidence visible in the product UI. It does
+not require container access, database queries, or log inspection. A property
+that needs engineering tools belongs in an automated contract test or a product
+observability issue, not in this checklist.
 
 ## Preconditions
 
-Do not start the ten-minute clock until all of these are true:
+Do not start the 15-minute clock until all of these are true:
 
 1. The authorized local Incus `master` target is healthy and still has its prior
    product state.
 2. Memory is enabled. In the Web UI, open **Memory > Processing Record** and verify
    **Engine status** is **Healthy**.
-3. In **Memory > Settings**, the **IM attachment processing model (optional)** has
+3. In **Memory > Processing Record**, verify **Call log** is **Recording
+   normally**. Open at least one recent terminal entry and confirm that **Model
+   calls** expands to a Request/Response payload. If the UI says **Model calls
+   weren't logged or have expired**, stop and record the run as `INCONCLUSIVE`.
+   Call recording is runtime state rather than a permanent capability:
+   `core/memory/sidecar_lifecycle.py` may disable `records_calls`, and
+   `MemoryLogPanel.tsx` renders the unavailable/expired state.
+4. In **Memory > Settings**, the **IM attachment processing model (optional)** has
    a complete base URL, model, and API key. This is the explicit opt-in required by
    `MEMORY-IM-ATTACH-003`.
-4. The human test account on each platform is enabled and bound to this Avibe
+5. The human test account on each platform is enabled and bound to this Avibe
    installation. Use a one-to-one direct message only. Group, channel, unbound,
    forwarded, edited, quoted, webhook, and system traffic stays outside this
    human baseline and is closed where the platform exposes the required facts.
    WeChat bot/self/system source exclusion remains unverified and is collected
    below; this checklist does not claim those sources are currently excluded.
-5. Record a run tag such as `IMA-20260816-0508`. Put it in every supported
+6. Record a run tag such as `IMA-20260816-0508`. Put it in every supported
    caption and in every fixture's pixel/file marker. Lark and WeChat native
    image/file messages are verified by bound user plus send timestamp rather
    than by assuming those clients support attachment captions.
@@ -53,30 +65,34 @@ production data.
 Use different markers for every platform. Keep a local table mapping each pair
 and marker to its platform; do not put that table in chat.
 
-## Ten-minute acceptance flow
+## 15-minute acceptance flow
 
-Run the accepted and rejected rows as separate phases. This separation matters:
-ordinary Memory adds otherwise wait for the five-minute idle flush, and a late
-accepted result could contaminate a rejected-row baseline.
+Send the ten fixtures first, then wait once. Idle flush is tracked per session,
+so waiting after the final send covers every platform without mutating any
+session-owned state.
 
-1. Record the newest processing entry and provider-call timestamp for each bound
-   user, then send all five accepted-image messages.
-2. In each of the same five direct-message sessions, send `/new` after the image
-   turn has been accepted for processing. Wait for the new-session acknowledgement.
-   `/new` invokes the old session's final Memory flush; it is the documented phase
-   boundary and avoids treating the five-minute idle timeout as a failure.
-3. Open **Memory > Processing Record**, refresh the processing log, and finish all
-   five accepted-row checks before continuing. Start the 60-second terminal-state
-   allowance only after the corresponding `/new` acknowledgement. A lifecycle
-   busy/flush error, a missing acknowledgement, or a non-terminal expected row
-   after that allowance is a recorded failure; do not continue to the rejected
-   phase with an unsettled accepted row.
-4. Record fresh per-user processing-entry and provider-call baselines. Send all
-   five rejected SVG messages, then send `/new` in each corresponding direct
-   message and wait for its acknowledgement.
-5. Refresh **Processing Record** and evaluate all five rejected rows against the
-   fresh baselines. Apply the same post-`/new` 60-second allowance where a
-   text-only entry is expected.
+1. In **Memory > Processing Record**, record the newest entry timestamp for each
+   bound platform user. This is the per-user high-water mark for the run.
+2. Within about two minutes, send each platform's accepted PNG and rejected SVG
+   as described in the table. The order within a platform does not affect the
+   result; finish all ten sends before waiting.
+3. Do not send another message in any tested session for at least **5 minutes 30
+   seconds after the final fixture**. The wait derives from
+   `core/memory/coordinator.py`'s `IDLE_FLUSH_TIMEOUT = 5 minutes`, with 30 seconds
+   of scheduling margin. `MAX_UNFLUSHED_AGE = 30 minutes` and
+   `MAX_UNFLUSHED_MESSAGES = 100` are fallback bounds, not the expected trigger
+   for this two-message-per-platform run.
+4. Refresh **Processing Record** and inspect all ten outcomes. Recheck that **Call
+   log** is **Recording normally** before interpreting accepted-image Model calls.
+   Allow the remaining clock time for terminal entries to appear.
+
+This flow deliberately does **not** use `/new`. That command tears down the Agent
+session and pauses session-bound tasks and watches
+(`core/handlers/command_handlers.py`), which conflicts with the long-lived
+`master` environment's state-preservation boundary. The shared idle window avoids
+those mutations and keeps the expected wall time near 15 minutes: roughly two
+minutes to send, 5.5 minutes idle, and the remaining time to inspect and record
+results.
 
 The processing log is the primary evidence because it covers every user and
 project on the installation; **Memory > Search** is scoped to the current
@@ -87,31 +103,40 @@ request must contain the image input and the response must describe or reproduce
 the pixel-only marker. The timeline and Memory snippet preview do not expose
 attachment-derived model output and therefore are not positive evidence.
 
-For a rejected SVG, inspect calls after the phase baseline and verify that no
-multimodal call has an image/attachment request attributable to that turn. A
-caption-bearing rejected turn must still produce its expected text-only entry;
-the Lark and WeChat file-only rows must produce neither a new processing entry nor
-an attributable multimodal call. A row passes only when the falsifiable condition
-below is met.
+For a rejected SVG, use only the post-baseline processing entries visible in the
+UI. A caption-bearing rejected turn must preserve its caption without showing the
+SVG filename as an attachment in the entry preview. The Lark and WeChat file-only
+rows must not produce an entry attributable to the rejected filename, marker,
+user, and send time. The hermetic `MEMORY-IM-ATTACH-004` scenario separately
+proves that a fully rejected attachment does not enter the multimodal provider
+path; the manual run does not try to reconstruct that engineering fact from an
+unobservable UI absence.
 
 | Platform | Scenario | Send | Pass condition in Memory > Processing Record |
 | --- | --- | --- | --- |
-| Slack | `MEMORY-IM-ATTACH-001` | In a bound human DM, send the Slack PNG with caption `<run-tag> slack accepted image`. | After `/new`, one terminal entry exists for the Slack user. Its **Model calls** contain an attributed multimodal request with the PNG and a response that describes or reproduces the PNG-only marker. |
-| Slack | `MEMORY-IM-ATTACH-004` | In the same DM, send the Slack SVG with caption `<run-tag> slack rejected file`. | After `/new`, the caption appears in a terminal text-only entry. No call after the phase baseline sends the SVG to the multimodal model, and no provider response contains its marker. |
-| Discord | `MEMORY-IM-ATTACH-005` | In a bound human DM, upload the Discord PNG as an ordinary attachment with caption `<run-tag> discord accepted image`. Do not add a link embed, component, sticker, or forward. | After `/new`, one terminal entry exists for the Discord user. Its attributed multimodal request contains the PNG and its response exposes the PNG-only marker. If the raw message has an automatic embed and no entry is created, fail this row and apply the Discord fixture decision below. |
-| Discord | `MEMORY-IM-ATTACH-004`, `MEMORY-IM-ATTACH-005` | Upload the Discord SVG with caption `<run-tag> discord rejected file`. | After `/new`, the caption appears in a terminal text-only entry. No attributable multimodal request contains the SVG, and no provider response contains its marker. |
-| Telegram | `MEMORY-IM-ATTACH-006` | In a bound private chat, send the Telegram PNG as one photo message with caption `<run-tag> telegram accepted image`. Do not use an album. | After `/new`, one terminal entry exists for the Telegram user. Its attributed multimodal request contains the PNG and its response exposes the PNG-only marker. |
-| Telegram | `MEMORY-IM-ATTACH-004`, `MEMORY-IM-ATTACH-006` | Send the Telegram SVG as one document with caption `<run-tag> telegram rejected file`. | After `/new`, the caption appears in a terminal text-only entry. No attributable multimodal request contains the SVG, and no provider response contains its marker. |
-| Lark | `MEMORY-IM-ATTACH-007` | In a bound one-to-one chat, send the Lark PNG through the native **image** action as one image-only message. The pixel marker includes the run tag. | After `/new`, exactly one terminal entry appears for the Lark user. Its attributed multimodal request contains the PNG and its response exposes the PNG-only marker. |
-| Lark | `MEMORY-IM-ATTACH-004`, `MEMORY-IM-ATTACH-007` | Send the Lark SVG through the native **file** action as one file-only message. The filename includes the run tag; its visible SVG marker is different from the filename. | After `/new`, no processing entry or attributable multimodal call appears after the rejected-phase baseline, and no provider response contains the SVG-only marker. |
-| WeChat | `MEMORY-IM-ATTACH-008` | In a bound direct chat, send the WeChat PNG as one direct image item with no quoted/reference message. The pixel marker includes the run tag. | After `/new`, exactly one terminal entry appears for the WeChat user. Its attributed multimodal request contains the PNG and its response exposes the PNG-only marker. |
-| WeChat | `MEMORY-IM-ATTACH-004`, `MEMORY-IM-ATTACH-008` | Send the WeChat SVG as one direct file item, with no quoted/reference message. The filename includes the run tag. | After `/new`, no processing entry or attributable multimodal call appears after the rejected-phase baseline, and no provider response contains the SVG-only marker. |
+| Slack | `MEMORY-IM-ATTACH-001` | In a bound human DM, send the Slack PNG with caption `<run-tag> slack accepted image`. | One post-baseline terminal entry exists for the Slack user. Its **Model calls** contain an attributed multimodal request with the image and a response that describes or reproduces the PNG-only marker. |
+| Slack | `MEMORY-IM-ATTACH-004` | In the same DM, send the Slack SVG with caption `<run-tag> slack rejected file`. | A post-baseline entry preserves the caption, and its preview does not show the Slack SVG filename as an attachment. |
+| Discord | `MEMORY-IM-ATTACH-005` | In a bound human DM, upload the Discord PNG as an ordinary attachment with caption `<run-tag> discord accepted image`. Do not add a link embed, component, sticker, or forward. | One post-baseline terminal entry exists for the Discord user. Its attributed multimodal request contains the image and its response exposes the PNG-only marker. If the raw message has an automatic embed and no entry is created, fail this row and apply the Discord fixture decision below. |
+| Discord | `MEMORY-IM-ATTACH-004`, `MEMORY-IM-ATTACH-005` | Upload the Discord SVG with caption `<run-tag> discord rejected file`. | A post-baseline entry preserves the caption, and its preview does not show the Discord SVG filename as an attachment. |
+| Telegram | `MEMORY-IM-ATTACH-006` | In a bound private chat, send the Telegram PNG as one photo message with caption `<run-tag> telegram accepted image`. Do not use an album. | One post-baseline terminal entry exists for the Telegram user. Its attributed multimodal request contains the Telegram image input and its response exposes the PNG-only marker. The request may identify the normalized JPEG photo rather than the original PNG filename/MIME. |
+| Telegram | `MEMORY-IM-ATTACH-004`, `MEMORY-IM-ATTACH-006` | Send the Telegram SVG as one document with caption `<run-tag> telegram rejected file`. | A post-baseline entry preserves the caption, and its preview does not show the Telegram SVG filename as an attachment. |
+| Lark | `MEMORY-IM-ATTACH-007` | In a bound one-to-one chat, send the Lark PNG through the native **image** action as one image-only message. The pixel marker includes the run tag. | One post-baseline terminal entry appears for the Lark user. Its attributed multimodal request contains the image input and its response exposes the PNG-only marker. |
+| Lark | `MEMORY-IM-ATTACH-004`, `MEMORY-IM-ATTACH-007` | Send the Lark SVG through the native **file** action as one file-only message. The filename includes the run tag; its visible SVG marker is different from the filename. | No post-baseline entry is attributable to the rejected Lark filename, marker, user, and send time. |
+| WeChat | `MEMORY-IM-ATTACH-008` | In a bound direct chat, send the WeChat PNG as one direct image item with no quoted/reference message. The pixel marker includes the run tag. | One post-baseline terminal entry appears for the WeChat user. Its attributed multimodal request contains the image input and its response exposes the PNG-only marker. |
+| WeChat | `MEMORY-IM-ATTACH-004`, `MEMORY-IM-ATTACH-008` | Send the WeChat SVG as one direct file item, with no quoted/reference message. The filename includes the run tag. | No post-baseline entry is attributable to the rejected WeChat filename, marker, user, and send time. |
 
-Record `PASS` or `FAIL` for every row. Where a caption is supported, a missing
-caption is a failure. For every platform, an accepted image whose pixel-only
-marker is absent, a rejected SVG whose marker appears, an unexpected entry for a
-file-only rejected turn, or an entry attributed to the wrong platform user is a
-failure.
+Record `PASS`, `FAIL`, or `INCONCLUSIVE` for every row. Where a caption is
+supported, a missing caption is a failure. For every platform, an accepted image
+whose pixel-only marker is absent, a rejected SVG shown as an attachment, an
+unexpected entry attributable to a file-only rejected turn, or an entry
+attributed to the wrong platform user is a failure.
+
+An accepted row is `INCONCLUSIVE`, not `PASS` or `FAIL`, whenever **Call log** is
+not **Recording normally**, its Model calls are unavailable/expired, or the
+Request/Response evidence cannot be opened. Any row is `INCONCLUSIVE` when the
+Processing Record section needed by its pass condition is unavailable. Rejected
+rows do not use absence of Model calls as evidence; only the visible
+post-baseline entry conditions in the table decide them.
 
 ## Fixture collection plan
 
@@ -203,6 +228,9 @@ Decision:
   facts. WeChat source exclusion remains the explicit fixture decision above.
 - Resetting regression state, changing credentials, testing remote Incus, or
   validating Agent attachment behavior. This run covers Memory capture only.
+- Proving the absence of pre-memcell provider calls through the product UI. The
+  `MEMORY-IM-ATTACH-004` automated scenario owns the rejection-to-provider
+  boundary; issue #1483 tracks product visibility for calls without memcells.
 
 ## Follow-up tracking
 
@@ -212,10 +240,13 @@ Decision:
 - [#1480](https://github.com/avibe-bot/avibe/issues/1480) investigates why an
   explicit `vibe watch add --timeout 0` can read back as the default `21600`
   despite the repository reader preserving zero.
+- [#1483](https://github.com/avibe-bot/avibe/issues/1483) tracks the missing
+  Processing Record surface for provider calls and terminal turns that have no
+  memcell.
 
 ## Result record
 
-Record the run tag, source commit, service-health result, ten row outcomes, and
-the three fixture decisions in the owning issue or acceptance report. Do not
-paste raw payloads, signed URLs, credentials, or unsanitized logs into that
-report.
+Record the run tag, source commit, service-health result, Call log baseline and
+final state, ten row outcomes (including any `INCONCLUSIVE` reason), and the three
+fixture decisions in the owning issue or acceptance report. Do not paste raw
+payloads, signed URLs, credentials, or unsanitized logs into that report.

--- a/docs/regression/memory-im-attachment-five-platform-acceptance.md
+++ b/docs/regression/memory-im-attachment-five-platform-acceptance.md
@@ -40,10 +40,13 @@ Do not send the attachment fixtures until all of these are true:
    a complete base URL, model, and API key. This is the explicit opt-in required by
    `MEMORY-IM-ATTACH-003`.
 5. The human test account on each platform is enabled and bound to this Avibe
-   installation. Use a one-to-one direct message only. Group, channel, unbound,
-   forwarded, edited, quoted, webhook, and system traffic stays outside this
-   human baseline and is closed where the platform exposes the required facts.
-   WeChat bot/self/system source exclusion remains unverified and is collected
+   installation. Use an ordinary, unquoted one-to-one direct message only.
+   Group, channel, unbound, forwarded, edited, webhook, system, quoted, and
+   replied-to traffic stays outside this human baseline. Quoted/replied-to
+   exclusion is not verified across platforms: Slack accepts ordinary
+   `rich_text_quote` content, while Discord and Telegram expose reference facts
+   that their Memory attachment classifiers do not currently enforce. WeChat
+   bot/self/system source exclusion also remains unverified and is collected
    below; this checklist does not claim those sources are currently excluded.
 6. Record a run tag such as `IMA-20260816-0508`. Use it in baseline text and every
    supported caption, but never in an accepted image's pixel-only marker.
@@ -262,9 +265,10 @@ Decision:
 - Capturing SVG, Office/iWork/ODF/RTF documents, or other extensions excluded by
   the pinned modality policy. WeChat video may reach shared admission, but video
   processing is not enabled by this acceptance.
-- Group/channel, unbound, edited, forwarded, quoted/reference, or system-message
-  Memory capture, and bot-authored capture on platforms with verified source
-  facts. WeChat source exclusion remains the explicit fixture decision above.
+- Group/channel, unbound, edited, forwarded, webhook, or system-message Memory
+  capture, and bot-authored capture on platforms with verified source facts.
+  Quoted/replied-to traffic is unverified and out of scope rather than claimed
+  closed; WeChat source exclusion remains the explicit fixture decision above.
 - Resetting regression state, changing credentials, testing remote Incus, or
   validating Agent attachment behavior. This run covers Memory capture only.
 - Provisioning Telegram or any other platform credentials. A separately

--- a/docs/regression/memory-im-attachment-five-platform-acceptance.md
+++ b/docs/regression/memory-im-attachment-five-platform-acceptance.md
@@ -1,0 +1,190 @@
+# Memory IM attachment five-platform acceptance
+
+> **Safety boundary:** Run this checklist only in the local Incus regression
+> environment after the owner explicitly authorizes a regression update. Keep the
+> long-lived `master` target online and preserve its existing product state. Never
+> use `--remote`, `--reset-config`, or `--reset-all`. After any authorized source
+> update, verify service health before reporting an acceptance result.
+
+This runbook validates the first Memory attachment release across Slack, Discord,
+Telegram, Lark, and WeChat. It is deliberately short: prepare two fixtures, send
+ten direct messages, and then inspect the ten outcomes in one pass. The Agent's
+reply is not evidence of Memory capture; Memory runs independently of Agent
+delivery.
+
+## Preconditions
+
+Do not start the ten-minute clock until all of these are true:
+
+1. The authorized local Incus `master` target is healthy and still has its prior
+   product state.
+2. Memory is enabled. In the Web UI, open **Memory > Processing Record** and verify
+   **Engine status** is **Healthy**.
+3. In **Memory > Settings**, the **IM attachment processing model (optional)** has
+   a complete base URL, model, and API key. This is the explicit opt-in required by
+   `MEMORY-IM-ATTACH-003`.
+4. The human test account on each platform is enabled and bound to this Avibe
+   installation. Use a one-to-one direct message only; group, channel, unbound,
+   bot, forwarded, edited, quoted, webhook, and system traffic is denied by
+   `MEMORY-IM-ATTACH-002` and the platform contracts.
+5. Record a run tag such as `IMA-20260816-0508`. Put it in every supported
+   caption and in every fixture's pixel/file marker. Lark and WeChat native
+   image/file messages are verified by bound user plus send timestamp rather
+   than by assuming those clients support attachment captions.
+
+### Test fixtures
+
+Prepare two small files locally. Do not use personal or production data.
+
+- **Accepted image:** a 512 x 512 PNG under 1 MiB. Put a large, high-contrast
+  platform-specific marker in the pixels, for example `IMA-DISCORD-A7Q2`. The
+  caption must contain the run tag but must **not** contain the pixel marker. This
+  separates image understanding from text-only capture.
+- **Rejected file:** an SVG under 100 KiB with a different visible marker, for
+  example `IMA-DISCORD-REJECT-R9M4`. SVG is intentionally excluded from the
+  pinned Memory modality policy. Where the client supports a caption on that
+  attachment message, use a non-empty caption containing the run tag but not the
+  SVG marker. The table explicitly identifies the file-only cases.
+
+Use different markers for every platform. Keep a local table mapping each marker
+to its platform; do not put that table in chat.
+
+## Ten-minute acceptance flow
+
+Send the five accepted-image messages first, then the five rejected-file
+messages. After all ten sends, open **Memory > Processing Record**, refresh the
+processing log, and inspect the newest entries for the five bound IM users. The
+processing log is the primary evidence because it covers every user and project
+on the installation; **Memory > Search** is scoped to the current principal and
+is not a substitute for cross-platform verification.
+
+For each matching processing-log row, open its detail and inspect **Message
+tracking**, **Processing timeline**, and the **Memory snippet created** step. A
+row passes only when the falsifiable condition below is met. If an expected row
+has not reached a terminal state within 60 seconds, record a failure rather than
+waiting indefinitely.
+
+| Platform | Scenario | Send | Pass condition in Memory > Processing Record |
+| --- | --- | --- | --- |
+| Slack | `MEMORY-IM-ATTACH-001` | In a bound human DM, send the PNG with caption `<run-tag> slack accepted image`. | One new terminal processing entry exists for the Slack user. Its created Memory snippet contains the caption and describes or reproduces the PNG-only marker. |
+| Slack | `MEMORY-IM-ATTACH-004` | In the same DM, send the SVG with caption `<run-tag> slack rejected file`. | The caption is captured as text in a terminal Memory entry, but the SVG-only marker is absent. No attachment-derived snippet is created for that SVG. |
+| Discord | `MEMORY-IM-ATTACH-005` | In a bound human DM, upload the PNG as an ordinary attachment with caption `<run-tag> discord accepted image`. Do not add a link embed, component, sticker, or forward. | One new terminal processing entry exists for the Discord user and contains both the caption and evidence of the PNG-only marker. If the raw message has an automatic embed and no entry is created, fail this row and apply the Discord fixture decision below. |
+| Discord | `MEMORY-IM-ATTACH-004`, `MEMORY-IM-ATTACH-005` | Upload the SVG with caption `<run-tag> discord rejected file`. | The caption is captured as text; the SVG-only marker is absent from the created Memory snippet. |
+| Telegram | `MEMORY-IM-ATTACH-006` | In a bound private chat, send the PNG as one photo message with caption `<run-tag> telegram accepted image`. Do not use an album. | One new terminal processing entry exists for the Telegram user and contains the caption plus evidence of the PNG-only marker. |
+| Telegram | `MEMORY-IM-ATTACH-004`, `MEMORY-IM-ATTACH-006` | Send the SVG as one document with caption `<run-tag> telegram rejected file`. | The caption is captured as text; the SVG-only marker is absent from the created Memory snippet. |
+| Lark | `MEMORY-IM-ATTACH-007` | In a bound one-to-one chat, send the PNG through the native **image** action as one image-only message. The pixel marker includes the run tag. | Exactly one new terminal processing entry appears for the Lark user after the recorded send time, and its created Memory snippet describes or reproduces the PNG-only marker. |
+| Lark | `MEMORY-IM-ATTACH-004`, `MEMORY-IM-ATTACH-007` | Record the current newest Lark processing entry and send the SVG through the native **file** action as one file-only message. The filename includes the run tag; its visible SVG marker is different from the filename. | No new Memory processing entry is created for this Lark message, and the SVG-only marker is absent from every entry after the recorded send time. |
+| WeChat | `MEMORY-IM-ATTACH-008` | In a bound direct chat, send the PNG as one direct image item with no quoted/reference message. The pixel marker includes the run tag. | Exactly one new terminal processing entry appears for the WeChat user after the recorded send time and contains evidence of the PNG-only marker. |
+| WeChat | `MEMORY-IM-ATTACH-004`, `MEMORY-IM-ATTACH-008` | Record the current newest WeChat processing entry and send the SVG as one direct file item, with no quoted/reference message. The filename includes the run tag. | No new Memory processing entry is created for this WeChat message, and the SVG-only marker is absent from every entry after the recorded send time. |
+
+Record `PASS` or `FAIL` for every row. Where a caption is supported, a missing
+caption is a failure. For every platform, an accepted image whose pixel-only
+marker is absent, a rejected SVG whose marker appears, an unexpected entry for a
+file-only rejected turn, or an entry attributed to the wrong platform user is a
+failure.
+
+## Fixture collection plan
+
+Raw platform payloads may contain message IDs, user IDs, signed download URLs,
+tokens, filenames, captions, and other user content. Never commit a raw capture.
+Use an owner-approved, one-shot collector at the adapter-to-`message_facts`
+boundary, write only to test-owned local state, and reduce the capture to a
+minimal structural fixture before it enters the repository. Replace identifiers
+with stable placeholders, remove URL query strings and credentials, replace text
+and filenames with synthetic values, and retain only field presence, primitive
+types, enum values, and list cardinality needed by the classifier.
+
+### 1. Discord ordinary-upload embeds (highest priority)
+
+Capture the same human DM message used by the accepted Discord row before
+classification. Preserve this minimal shape:
+
+- `author.bot`, `webhook_id`, `edited_at`, and `message.is_system()`;
+- message flag `forwarded`;
+- the number and structural fields of `attachments` (`filename`, MIME family,
+  declared size; redact IDs and URLs);
+- the number and structural types of `embeds`, including whether an embed points
+  at the uploaded attachment; and
+- presence/cardinality only for components, stickers, sticker items, snapshots,
+  and forwards.
+
+Decision:
+
+- **No automatic embed:** the fixture confirms the current fail-closed predicate;
+  add the reduced fixture to the Discord contract tests and keep
+  `has_unverified_attachment_embeds` closed for authored embeds.
+- **Automatic attachment embed:** the current classifier disables ordinary
+  Discord capture at launch. Mark the Discord acceptance row failed, then change
+  the predicate only after the fixture distinguishes an automatic attachment
+  embed from authored/rich embeds. Do not broadly allow every embed.
+
+### 2. Lark human `media` message
+
+Capture one real human one-to-one `media` event and the adapter's parsed content.
+Preserve:
+
+- `sender.sender_type` and the redacted sender identifier shape;
+- `message.message_type`, plus presence of `edited` and `forwarded` facts;
+- the parsed content key names and which native resource key is populated;
+- the downloaded file's synthetic filename, MIME family, and declared size; and
+- whether `shared_text` or another non-caption payload is produced.
+
+Decision:
+
+- Enable `media` only if the reduced fixture proves a direct human source, a
+  stable non-empty native key, and the same bounded authenticated acquisition
+  semantics as `file`/`image`.
+- Otherwise retain the current fail-closed policy. The acceptance run does not
+  require `media` to pass.
+
+### 3. WeChat source identity
+
+Capture four structural `item_list` samples: an ordinary human direct image
+baseline, a bot-origin message, a message sent by the account itself, and a
+system message. Preserve:
+
+- top-level source/sender/system facts and their types;
+- each item `type`, `ref_msg` presence, and the selected media-item field;
+- presence only of nested `media.encrypt_query_param` (replace its value); and
+- list cardinality and any source facts currently discarded before
+  `is_ordinary_wechat_attachment` runs.
+
+Decision:
+
+- If bot, self, and system shapes expose stable negative source facts, thread
+  those facts into the classifier and add fixtures proving all three remain
+  closed while the human baseline stays open.
+- If they are structurally indistinguishable at the current boundary, do not
+  widen admission. Preserve fail-closed behavior and first retain the missing
+  source fact at the adapter boundary.
+
+## Explicit non-goals
+
+- Enabling Lark `media` before the real fixture supports that decision.
+- Broadly allowing Discord messages with embeds, components, stickers, webhooks,
+  forwards, or snapshots.
+- Inferring WeChat human origin when the raw shape does not provide a stable
+  discriminator.
+- Capturing SVG, Office/iWork/ODF/RTF documents, or other extensions excluded by
+  the pinned modality policy. WeChat video may reach shared admission, but video
+  processing is not enabled by this acceptance.
+- Group/channel, unbound, bot-authored, edited, forwarded, quoted/reference, or
+  system-message Memory capture.
+- Resetting regression state, changing credentials, testing remote Incus, or
+  validating Agent attachment behavior. This run covers Memory capture only.
+
+## Follow-up tracking
+
+- [#1477](https://github.com/avibe-bot/avibe/issues/1477) removes the dead
+  `feishu` Memory admission alias after confirming released compatibility does
+  not require it; runtime adapters use the canonical `lark` literal.
+- [#1480](https://github.com/avibe-bot/avibe/issues/1480) investigates why an
+  explicit `vibe watch add --timeout 0` can read back as the default `21600`
+  despite the repository reader preserving zero.
+
+## Result record
+
+Record the run tag, source commit, service-health result, ten row outcomes, and
+the three fixture decisions in the owning issue or acceptance report. Do not
+paste raw payloads, signed URLs, credentials, or unsanitized logs into that
+report.

--- a/docs/regression/memory-im-attachment-five-platform-acceptance.md
+++ b/docs/regression/memory-im-attachment-five-platform-acceptance.md
@@ -23,10 +23,10 @@ Do not send the attachment fixtures until all of these are true:
 
 1. The authorized local Incus `master` target is healthy and still has its prior
    product state. This checklist requires a separately provisioned five-platform
-   target: the standard regression seed covers Slack, Discord, Lark, and WeChat
-   but does not provision Telegram credentials. If Telegram is not already
-   configured and bound, record the run as `BLOCKED` and stop. Do not add or
-   change credentials as part of this checklist.
+   target: `.env.regression.example` and `scripts/prepare_regression.py` define
+   seed inputs for Slack, Discord, Lark, and WeChat but no Telegram credential
+   path. If Telegram is not already configured and bound, record the run as
+   `BLOCKED` and stop. Do not add or change credentials as part of this checklist.
 2. Memory is enabled. In the Web UI, open **Memory > Processing Record** and verify
    **Engine status** is **Healthy**.
 3. In **Memory > Processing Record**, verify **Call log** is **Recording
@@ -35,7 +35,8 @@ Do not send the attachment fixtures until all of these are true:
    weren't logged or have expired**, stop and record the run as `INCONCLUSIVE`.
    Call recording is runtime state rather than a permanent capability:
    `core/memory/sidecar_lifecycle.py` may disable `records_calls`, and
-   `MemoryLogPanel.tsx` renders the unavailable/expired state.
+   `ui/src/components/settings/memory/MemoryLogPanel.tsx` renders the
+   unavailable/expired state.
 4. In **Memory > Settings**, the **IM attachment processing model (optional)** has
    a complete base URL, model, and API key. This is the explicit opt-in required by
    `MEMORY-IM-ATTACH-003`.
@@ -43,11 +44,12 @@ Do not send the attachment fixtures until all of these are true:
    installation. Use an ordinary, unquoted one-to-one direct message only.
    Group, channel, unbound, forwarded, edited, webhook, system, quoted, and
    replied-to traffic stays outside this human baseline. Quoted/replied-to
-   exclusion is not verified across platforms: Slack accepts ordinary
-   `rich_text_quote` content, while Discord and Telegram expose reference facts
-   that their Memory attachment classifiers do not currently enforce. WeChat
-   bot/self/system source exclusion also remains unverified and is collected
-   below; this checklist does not claim those sources are currently excluded.
+   exclusion is not verified across platforms: `modules/im/message_facts.py`
+   accepts ordinary Slack `rich_text_quote` content, while Discord and Telegram
+   expose reference facts that the Memory attachment classifiers do not
+   currently enforce. WeChat bot/self/system source exclusion also remains
+   unverified and is collected below; this checklist does not claim those
+   sources are currently excluded.
 6. Record a run tag such as `IMA-20260816-0508`. Use it in baseline text and every
    supported caption, but never in an accepted image's pixel-only marker.
 7. From the exact human identity that will send each platform fixture, send one
@@ -57,7 +59,8 @@ Do not send the attachment fixtures until all of these are true:
    product-UI mapping from test identity to principal and the per-principal
    high-water mark. If any of the five identities cannot establish its tagged
    baseline, record the run as `BLOCKED` and stop; do not infer the mapping from
-   the HMAC-derived identifier or use an engineering lookup tool.
+   `core/memory/store.py::derive_principal_id`, which is HMAC-derived and
+   irreversible, or use an engineering lookup tool.
 
 ### Test fixtures
 
@@ -72,25 +75,28 @@ and do not use personal or production data.
   appear in the filename, caption, run tag, title, description, alt text, or any
   other message metadata.
 - **Rejected file:** an SVG under 100 KiB with a different visible marker, for
-  example `REJECT-R9M4`. SVG is intentionally excluded from the
-  pinned Memory modality policy. Where the client supports a caption on that
-  attachment message, use a non-empty caption containing the run tag but not the
-  SVG marker. Use a neutral filename such as `rejected-01.svg`.
+  example `REJECT-R9M4`. SVG is intentionally excluded by
+  `core/memory/modality.py::SUPPORTED_ATTACHMENT_EXTENSIONS`. Where the client
+  supports a caption on that attachment message, use a non-empty caption
+  containing the run tag but not the SVG marker. Use a neutral filename such as
+  `rejected-01.svg`.
 
 The isolation rule covers every text channel retained by the current path:
 
-- `EverOSPort.add()` sends capture text plus attachment `kind`, `name`, `uri`, and
-  `ext`; kind/extension are closed classifier values, while the pinned URI uses an
-  opaque bundle ID and indexed filename rather than the source name;
-- Slack may derive `attachment.name` from file `name` or `title`, so both stay
-  neutral;
-- Discord retains the attachment filename; leave descriptions/alt text absent or
-  neutral as well;
-- Telegram photo names normalize to `telegram-photo.jpg`, while its caption is
-  capture text;
-- Lark image resource keys become the attachment name; do not repeat the pixel
-  marker in surrounding message text; and
-- WeChat item filenames become attachment names, so they stay neutral.
+- `core/memory/everos.py::EverOSPort.add()` sends capture text plus attachment
+  `kind`, `name`, `uri`, and `ext`; kind/extension are closed classifier values,
+  while the pinned URI uses an opaque bundle ID and indexed filename rather than
+  the source name;
+- `modules/im/slack.py` may derive `attachment.name` from file `name` or `title`,
+  so both stay neutral;
+- `modules/im/discord.py` retains the attachment filename; leave descriptions/alt
+  text absent or neutral as well;
+- `modules/im/telegram.py` normalizes photo names to `telegram-photo.jpg`, while
+  its caption is capture text;
+- `modules/im/feishu.py` passes Lark image resource keys into attachment names; do
+  not repeat the pixel marker in surrounding message text; and
+- `modules/im/wechat.py` passes item filenames into attachment names, so they stay
+  neutral.
 
 Use a different complete pixel marker for every accepted platform image. Keep a
 local mapping from neutral fixture name and marker to platform; do not put that
@@ -99,8 +105,9 @@ mapping in any message or platform metadata.
 ## State-driven acceptance flow
 
 The completion condition is visible state, not elapsed wall time. The long-lived
-`master` target has a shared preserved queue and may receive concurrent traffic,
-so no finite delay proves that a missing fixture is a product failure.
+`master` target has a shared preserved queue ordered globally by
+`core/memory/store.py::claim_due` and may receive concurrent traffic, so no finite
+delay proves that a missing fixture is a product failure.
 
 1. Send the eight fixtures as described in the table. Use one fixed order for
    reproducibility, but no pass condition depends on that order.
@@ -110,10 +117,11 @@ so no finite delay proves that a missing fixture is a product failure.
    Discord, and Telegram rejected-caption outcomes. A flush may combine outcomes,
    so do not require eight distinct entries.
 3. Stop waiting 30 minutes after the final fixture. This is an operator stop
-   threshold, chosen at the same scale as `MAX_UNFLUSHED_AGE = 30 minutes`, not a
-   delivery upper bound. If any expected outcome is still absent, mark the whole
-   run `INCONCLUSIVE`, not `FAIL`: a shared preserved queue or concurrent traffic
-   can delay this run without proving a product defect. In an idle environment,
+   threshold, chosen at the same scale as `MAX_UNFLUSHED_AGE = 30 minutes` in
+   `core/memory/coordinator.py`, not a delivery upper bound. If any expected
+   outcome is still absent, mark the whole run `INCONCLUSIVE`, not `FAIL`: a
+   shared preserved queue or concurrent traffic can delay this run without
+   proving a product defect. In an idle environment, that module's
    `IDLE_FLUSH_TIMEOUT = 5 minutes` explains why results commonly appear sooner.
 4. Once all eight outcomes are present, recheck that **Call log** is **Recording
    normally**, then evaluate every row against its visible pass/fail condition.
@@ -124,14 +132,20 @@ session and pauses session-bound tasks and watches
 `master` environment's state-preservation boundary. State-driven completion avoids
 those mutations and returns as soon as the eight observable outcomes are ready.
 
-The processing log is the primary evidence because it covers every user and
-project on the installation; **Memory > Search** is scoped to the current
-principal and is not a substitute for cross-platform verification. For an
-accepted image, open the matching processing entry, expand **Model calls**, and
-inspect the attributed multimodal model call's **Request** and **Response**. The
+The processing log is the primary evidence because its admin reader spans users
+and projects (the
+`test_admin_log_spans_projects_and_principals_with_explicit_scope` case in
+`tests/test_memory_insight.py`); **Memory > Search** is principal-scoped
+(`tests/scenarios/memory_list/catalog.yaml`) and is not a substitute for
+cross-platform verification. For an accepted image, open the matching processing
+entry, expand **Model calls**, and inspect the attributed multimodal model call's
+**Request** and **Response**, which
+`ui/src/components/settings/memory/MemoryLogPanel.tsx` renders as JSON. The
 request must contain the image input and the response must describe or reproduce
-the pixel-only marker. The timeline and Memory snippet preview do not expose
-attachment-derived model output and therefore are not positive evidence.
+the pixel-only marker. The timeline and Memory snippet preview render only
+selected input text and attachment kind/name
+(`core/memory/everos_insight/reader.py::_memcell_preview`), not
+attachment-derived model output, and therefore are not positive evidence.
 
 For a rejected SVG, use only the post-baseline processing entries visible in the
 UI. A caption-bearing rejected turn must preserve its caption without showing the
@@ -263,8 +277,8 @@ Decision:
 - Claiming WeChat bot/self/system exclusion before the raw shapes prove a stable
   discriminator. This checklist exercises only the ordinary human baseline.
 - Capturing SVG, Office/iWork/ODF/RTF documents, or other extensions excluded by
-  the pinned modality policy. WeChat video may reach shared admission, but video
-  processing is not enabled by this acceptance.
+  `core/memory/modality.py::SUPPORTED_ATTACHMENT_EXTENSIONS`. WeChat video may
+  reach shared admission, but video processing is not enabled by this acceptance.
 - Group/channel, unbound, edited, forwarded, webhook, or system-message Memory
   capture, and bot-authored capture on platforms with verified source facts.
   Quoted/replied-to traffic is unverified and out of scope rather than claimed

--- a/docs/regression/memory-im-attachment-five-platform-acceptance.md
+++ b/docs/regression/memory-im-attachment-five-platform-acceptance.md
@@ -7,10 +7,10 @@
 > update, verify service health before reporting an acceptance result.
 
 This runbook validates the first Memory attachment release across Slack, Discord,
-Telegram, Lark, and WeChat. It is deliberately short: prepare five fixture pairs,
-send ten direct messages, wait for one shared idle-flush window, and inspect the
-ten outcomes. The Agent's reply is not evidence of Memory capture; Memory runs
-independently of Agent delivery.
+Telegram, Lark, and WeChat. Establish five UI-visible principal baselines, send
+five accepted images and three caption-bearing rejected files, then wait for the
+eight observable outcomes. The Agent's reply is not evidence of Memory capture;
+Memory runs independently of Agent delivery.
 
 This owner-facing checklist uses only evidence visible in the product UI. It does
 not require container access, database queries, or log inspection. A property
@@ -19,7 +19,7 @@ observability issue, not in this checklist.
 
 ## Preconditions
 
-Do not start the 20-minute clock until all of these are true:
+Do not send the attachment fixtures until all of these are true:
 
 1. The authorized local Incus `master` target is healthy and still has its prior
    product state. This checklist requires a separately provisioned five-platform
@@ -45,63 +45,81 @@ Do not start the 20-minute clock until all of these are true:
    human baseline and is closed where the platform exposes the required facts.
    WeChat bot/self/system source exclusion remains unverified and is collected
    below; this checklist does not claim those sources are currently excluded.
-6. Record a run tag such as `IMA-20260816-0508`. Put it in every supported
-   caption and in every fixture's pixel/file marker. Lark and WeChat native
-   image/file messages are verified by bound user plus send timestamp rather
-   than by assuming those clients support attachment captions.
+6. Record a run tag such as `IMA-20260816-0508`. Use it in baseline text and every
+   supported caption, but never in an accepted image's pixel-only marker.
+7. From the exact human identity that will send each platform fixture, send one
+   pure-text baseline with a unique value such as `<run-tag> principal slack`.
+   In **Memory > Processing Record**, wait for each tagged baseline, open it, and
+   record its opaque `principal_id` and timestamp. That entry is both the safe
+   product-UI mapping from test identity to principal and the per-principal
+   high-water mark. If any of the five identities cannot establish its tagged
+   baseline, record the run as `BLOCKED` and stop; do not infer the mapping from
+   the HMAC-derived identifier or use an engineering lookup tool.
 
 ### Test fixtures
 
-Prepare one small fixture pair per platform: five PNGs and five SVGs, ten files
-total. Do not reuse a file across platforms, and do not use personal or
-production data.
+Prepare five accepted PNGs (one per platform) and three rejected SVGs (Slack,
+Discord, and Telegram), eight files total. Do not reuse a file across platforms,
+and do not use personal or production data.
 
-- **Accepted image:** a 512 x 512 PNG under 1 MiB. Put a large, high-contrast
-  platform-specific marker in the pixels, for example `IMA-DISCORD-A7Q2`. The
-  caption must contain the run tag but must **not** contain the pixel marker. This
-  separates image understanding from text-only capture.
+- **Accepted image:** a 512 x 512 PNG under 1 MiB. Put a large, high-contrast,
+  platform-specific marker in the pixels, for example `PX-Q7M4-V2K9`. Match the
+  complete marker in the model response, never the run tag or a shared substring.
+  Use a neutral filename such as `accepted-01.png`; the complete marker must not
+  appear in the filename, caption, run tag, title, description, alt text, or any
+  other message metadata.
 - **Rejected file:** an SVG under 100 KiB with a different visible marker, for
-  example `IMA-DISCORD-REJECT-R9M4`. SVG is intentionally excluded from the
+  example `REJECT-R9M4`. SVG is intentionally excluded from the
   pinned Memory modality policy. Where the client supports a caption on that
   attachment message, use a non-empty caption containing the run tag but not the
-  SVG marker. The table explicitly identifies the file-only cases.
+  SVG marker. Use a neutral filename such as `rejected-01.svg`.
 
-Use different markers for every platform. Keep a local table mapping each pair
-and marker to its platform; do not put that table in chat.
+The isolation rule covers every text channel retained by the current path:
 
-## 20-minute acceptance flow
+- `EverOSPort.add()` sends capture text plus attachment `kind`, `name`, `uri`, and
+  `ext`; kind/extension are closed classifier values, while the pinned URI uses an
+  opaque bundle ID and indexed filename rather than the source name;
+- Slack may derive `attachment.name` from file `name` or `title`, so both stay
+  neutral;
+- Discord retains the attachment filename; leave descriptions/alt text absent or
+  neutral as well;
+- Telegram photo names normalize to `telegram-photo.jpg`, while its caption is
+  capture text;
+- Lark image resource keys become the attachment name; do not repeat the pixel
+  marker in surrounding message text; and
+- WeChat item filenames become attachment names, so they stay neutral.
 
-Send the ten fixtures first, then wait once. The worker delivers the capture rows
-serially, and a session's idle-flush clock starts only after its add succeeds.
-The shared wait therefore budgets for both ingestion and the per-session idle
-window without mutating any session-owned state.
+Use a different complete pixel marker for every accepted platform image. Keep a
+local mapping from neutral fixture name and marker to platform; do not put that
+mapping in any message or platform metadata.
 
-1. In **Memory > Processing Record**, record the newest entry timestamp for each
-   bound platform user. This is the per-user high-water mark for the run.
-2. Within about two minutes, send each platform's accepted PNG and rejected SVG
-   as described in the table. The order within a platform does not affect the
-   result; finish all ten sends before waiting.
-3. Do not send another message in any tested session for at least **10 minutes 30
-   seconds after the final fixture**. The first five minutes are the worst-case
-   ingestion budget for ten serial rows: `core/memory/worker.py` drains rows one
-   at a time and `core/memory/coordinator.py` bounds each provider add with
-   `ADD_TIMEOUT_SECONDS = 30`. Only after each successful add does
-   `MemoryStore.settle_add_ack()` set that session's idle deadline. The next five
-   minutes derive from `IDLE_FLUSH_TIMEOUT = 5 minutes`, followed by 30 seconds of
-   scheduling margin. `MAX_UNFLUSHED_AGE = 30 minutes` and
-   `MAX_UNFLUSHED_MESSAGES = 100` are fallback bounds, not the expected trigger
-   for this two-message-per-platform run.
-4. Refresh **Processing Record** and inspect all ten outcomes. Recheck that **Call
-   log** is **Recording normally** before interpreting accepted-image Model calls.
-   Allow the remaining clock time for terminal entries to appear.
+## State-driven acceptance flow
+
+The completion condition is visible state, not elapsed wall time. The long-lived
+`master` target has a shared preserved queue and may receive concurrent traffic,
+so no finite delay proves that a missing fixture is a product failure.
+
+1. Send the eight fixtures as described in the table. Use one fixed order for
+   reproducibility, but no pass condition depends on that order.
+2. Do not send another message in a tested session. Refresh **Memory > Processing
+   Record** until all eight post-baseline outcomes are identifiable under the five
+   recorded principals: five accepted-image terminal outcomes and the Slack,
+   Discord, and Telegram rejected-caption outcomes. A flush may combine outcomes,
+   so do not require eight distinct entries.
+3. Stop waiting 30 minutes after the final fixture. This is an operator stop
+   threshold, chosen at the same scale as `MAX_UNFLUSHED_AGE = 30 minutes`, not a
+   delivery upper bound. If any expected outcome is still absent, mark the whole
+   run `INCONCLUSIVE`, not `FAIL`: a shared preserved queue or concurrent traffic
+   can delay this run without proving a product defect. In an idle environment,
+   `IDLE_FLUSH_TIMEOUT = 5 minutes` explains why results commonly appear sooner.
+4. Once all eight outcomes are present, recheck that **Call log** is **Recording
+   normally**, then evaluate every row against its visible pass/fail condition.
 
 This flow deliberately does **not** use `/new`. That command tears down the Agent
 session and pauses session-bound tasks and watches
 (`core/handlers/command_handlers.py`), which conflicts with the long-lived
-`master` environment's state-preservation boundary. The shared ingestion-plus-idle
-window avoids those mutations and keeps the expected wall time near 20 minutes:
-roughly two minutes to send, 10.5 minutes for serial ingestion plus idle, and the
-remaining time for the bounded flush, inspection, and result recording.
+`master` environment's state-preservation boundary. State-driven completion avoids
+those mutations and returns as soon as the eight observable outcomes are ready.
 
 The processing log is the primary evidence because it covers every user and
 project on the installation; **Memory > Search** is scoped to the current
@@ -114,43 +132,49 @@ attachment-derived model output and therefore are not positive evidence.
 
 For a rejected SVG, use only the post-baseline processing entries visible in the
 UI. A caption-bearing rejected turn must preserve its caption without showing the
-SVG filename as an attachment in the entry preview. The Lark and WeChat file-only
-rows must not produce an entry attributable to the rejected filename, marker,
-user, and send time. The hermetic `MEMORY-IM-ATTACH-010` scenario separately
-proves that a fully rejected attachment does not enter the multimodal provider
-path; the manual run does not try to reconstruct that engineering fact from an
+SVG filename as an attachment in the entry preview. The hermetic
+`MEMORY-IM-ATTACH-010` scenario separately proves that a fully rejected
+caption-bearing attachment does not enter the multimodal provider path; the
+manual run does not try to reconstruct that engineering fact from an
 unobservable UI absence.
 
 | Platform | Scenario | Send | Pass condition in Memory > Processing Record |
 | --- | --- | --- | --- |
-| Slack | `MEMORY-IM-ATTACH-001` | In a bound human DM, send the Slack PNG with caption `<run-tag> slack accepted image`. | One post-baseline terminal entry exists for the Slack user. Its **Model calls** contain an attributed multimodal request with the image and a response that describes or reproduces the PNG-only marker. |
-| Slack | `MEMORY-IM-ATTACH-010` | In the same DM, send the Slack SVG with caption `<run-tag> slack rejected file`. | A post-baseline entry preserves the caption, and its preview does not show the Slack SVG filename as an attachment. |
-| Discord | `MEMORY-IM-ATTACH-005` | In a bound human DM, upload the Discord PNG as an ordinary attachment with caption `<run-tag> discord accepted image`. Do not add a link embed, component, sticker, or forward. | One post-baseline terminal entry exists for the Discord user. Its attributed multimodal request contains the image and its response exposes the PNG-only marker. If the raw message has an automatic embed and no entry is created, fail this row and apply the Discord fixture decision below. |
-| Discord | `MEMORY-IM-ATTACH-010`, `MEMORY-IM-ATTACH-005` | Upload the Discord SVG with caption `<run-tag> discord rejected file`. | A post-baseline entry preserves the caption, and its preview does not show the Discord SVG filename as an attachment. |
-| Telegram | `MEMORY-IM-ATTACH-006` | In a bound private chat, send the Telegram PNG as one photo message with caption `<run-tag> telegram accepted image`. Do not use an album. | One post-baseline terminal entry exists for the Telegram user. Its attributed multimodal request contains the Telegram image input and its response exposes the PNG-only marker. The request may identify the normalized JPEG photo rather than the original PNG filename/MIME. |
-| Telegram | `MEMORY-IM-ATTACH-010`, `MEMORY-IM-ATTACH-006` | Send the Telegram SVG as one document with caption `<run-tag> telegram rejected file`. | A post-baseline entry preserves the caption, and its preview does not show the Telegram SVG filename as an attachment. |
-| Lark | `MEMORY-IM-ATTACH-007` | In a bound one-to-one chat, send the Lark PNG through the native **image** action as one image-only message. The pixel marker includes the run tag. | One post-baseline terminal entry appears for the Lark user. Its attributed multimodal request contains the image input and its response exposes the PNG-only marker. |
-| Lark | `MEMORY-IM-ATTACH-010`, `MEMORY-IM-ATTACH-007` | Send the Lark SVG through the native **file** action as one file-only message. The filename includes the run tag; its visible SVG marker is different from the filename. | No post-baseline entry is attributable to the rejected Lark filename, marker, user, and send time. |
-| WeChat | `MEMORY-IM-ATTACH-008` | In a bound direct chat, send the WeChat PNG as one direct image item with no quoted/reference message. The pixel marker includes the run tag. | One post-baseline terminal entry appears for the WeChat user. Its attributed multimodal request contains the image input and its response exposes the PNG-only marker. |
-| WeChat | `MEMORY-IM-ATTACH-010`, `MEMORY-IM-ATTACH-008` | Send the WeChat SVG as one direct file item, with no quoted/reference message. The filename includes the run tag. | No post-baseline entry is attributable to the rejected WeChat filename, marker, user, and send time. |
+| Slack | `MEMORY-IM-ATTACH-001` | In the baseline Slack DM, send the neutral-named PNG with caption `<run-tag> slack accepted image`; keep the complete pixel marker out of the caption and file title. | One post-baseline terminal outcome exists under the recorded Slack principal. Its **Model calls** contain an attributed multimodal request with the image and a response that exposes the complete pixel-only marker. |
+| Slack | `MEMORY-IM-ATTACH-010` | In the same DM, send the neutral-named SVG with caption `<run-tag> slack rejected file`. | An outcome under the recorded Slack principal preserves the caption, and its preview does not show the neutral Slack SVG filename as an attachment. |
+| Discord | `MEMORY-IM-ATTACH-005` | In the baseline Discord DM, upload the neutral-named PNG as an ordinary attachment with caption `<run-tag> discord accepted image`. Keep the complete pixel marker out of the caption and attachment metadata. Do not add a link embed, component, sticker, or forward. | One post-baseline terminal outcome exists under the recorded Discord principal. Its attributed multimodal request contains the image and its response exposes the complete pixel-only marker. A missing outcome at the stop threshold is `INCONCLUSIVE`; the optional fixture decision below diagnoses automatic embeds. |
+| Discord | `MEMORY-IM-ATTACH-010`, `MEMORY-IM-ATTACH-005` | Upload the neutral-named SVG with caption `<run-tag> discord rejected file`. | An outcome under the recorded Discord principal preserves the caption, and its preview does not show the neutral Discord SVG filename as an attachment. |
+| Telegram | `MEMORY-IM-ATTACH-006` | In the baseline Telegram private chat, send the PNG as one photo with caption `<run-tag> telegram accepted image`. Keep the complete pixel marker out of the caption and do not use an album. | One post-baseline terminal outcome exists under the recorded Telegram principal. Its attributed multimodal request contains the Telegram image input and its response exposes the complete pixel-only marker. The request may identify the normalized JPEG photo rather than the original PNG filename/MIME. |
+| Telegram | `MEMORY-IM-ATTACH-010`, `MEMORY-IM-ATTACH-006` | Send the neutral-named SVG as one document with caption `<run-tag> telegram rejected file`. | An outcome under the recorded Telegram principal preserves the caption, and its preview does not show the neutral Telegram SVG filename as an attachment. |
+| Lark | `MEMORY-IM-ATTACH-007` | In a bound one-to-one chat, send the neutral-named Lark PNG through the native **image** action as one image-only message. Do not repeat its complete pixel marker in surrounding text. | One post-baseline terminal outcome appears under the recorded Lark principal. Its attributed multimodal request contains the image input and its response exposes the complete pixel-only marker. |
+| WeChat | `MEMORY-IM-ATTACH-008` | In a bound direct chat, send the neutral-named WeChat PNG as one direct image item with no quoted/reference message. Do not repeat its complete pixel marker in surrounding text or item metadata. | One post-baseline terminal outcome appears under the recorded WeChat principal. Its attributed multimodal request contains the image input and its response exposes the complete pixel-only marker. |
 
 Record `PASS`, `FAIL`, or `INCONCLUSIVE` for every row. Where a caption is
 supported, a missing caption is a failure. For every platform, an accepted image
-whose pixel-only marker is absent, a rejected SVG shown as an attachment, an
-unexpected entry attributable to a file-only rejected turn, or an entry
-attributed to the wrong platform user is a failure.
+whose complete pixel-only marker is absent from an available terminal response,
+a rejected SVG shown as an attachment, or an outcome under a principal different
+from the identity's tagged baseline is a failure.
 
 An accepted row is `INCONCLUSIVE`, not `PASS` or `FAIL`, whenever **Call log** is
 not **Recording normally**, its Model calls are unavailable/expired, or the
 Request/Response evidence cannot be opened. Any row is `INCONCLUSIVE` when the
 Processing Record section needed by its pass condition is unavailable. Rejected
 rows do not use absence of Model calls as evidence; only the visible
-post-baseline entry conditions in the table decide them.
+post-baseline entry conditions in the table decide them. A terminal outcome that
+is present but violates its row is `FAIL`; the 30-minute stop threshold applies
+only when required evidence never becomes observable.
+
+Before recording `PASS`, state the visible counterfactual: broken accepted-image
+processing yields an available terminal call whose response lacks the complete
+pixel-only marker; broken rejected-file filtering yields a visible attachment
+filename or loses its caption; broken attribution places the outcome under a
+principal other than the tagged baseline. If the UI never exposes the evidence
+needed to distinguish those states, record `INCONCLUSIVE` instead.
 
 ## Fixture collection plan
 
 This is an optional, separately authorized engineering follow-up, not a phase of
-the 20-minute UI acceptance flow. The ten manual messages can inform which
+the state-driven UI acceptance flow. The eight manual messages can inform which
 fixtures are most valuable, but they do not provide the Lark `media` or WeChat
 bot/self/system samples below. Do not block or complete the acceptance result on
 these fixture decisions unless the collector was separately authorized and run.
@@ -248,6 +272,14 @@ Decision:
 - Proving the absence of pre-memcell provider calls through the product UI. The
   `MEMORY-IM-ATTACH-010` automated scenario owns the rejection-to-provider
   boundary; issue #1483 tracks product visibility for calls without memcells.
+- Manually testing captionless, fully filtered Lark or WeChat file-only turns.
+  `CaptureAdmission.decide()` returns `CaptureSkipped(memory_invalid_input)` when
+  both text and selected attachments are empty (`core/memory/admission.py`),
+  before a `CaptureRequest`, queue row, provider call, or memcell can exist. The
+  unit test
+  `test_im_attachment_only_turn_with_every_upload_filtered_is_not_captured`
+  pins that structural boundary; this checklist does not treat an unobservable
+  absence as a manual PASS.
 
 ## Follow-up tracking
 
@@ -263,8 +295,9 @@ Decision:
 
 ## Result record
 
-Record the run tag, source commit, five-platform provisioning check,
-service-health result, Call log baseline and final state, and ten row outcomes
+Record the run tag, source commit, five-platform provisioning check, the five
+tagged principal baselines, service-health result, Call log baseline and final
+state, and eight row outcomes
 (including any `BLOCKED` or `INCONCLUSIVE` reason) in the owning issue or
 acceptance report. If a separately authorized fixture collection was also run,
 append only its scrubbed decisions; otherwise record fixture collection as **not

--- a/docs/regression/memory-im-attachment-five-platform-acceptance.md
+++ b/docs/regression/memory-im-attachment-five-platform-acceptance.md
@@ -7,10 +7,10 @@
 > update, verify service health before reporting an acceptance result.
 
 This runbook validates the first Memory attachment release across Slack, Discord,
-Telegram, Lark, and WeChat. It is deliberately short: prepare two fixtures, send
-ten direct messages, and then inspect the ten outcomes in one pass. The Agent's
-reply is not evidence of Memory capture; Memory runs independently of Agent
-delivery.
+Telegram, Lark, and WeChat. It is deliberately short: prepare five fixture pairs,
+send ten direct messages in two flush-bounded phases, and inspect the ten
+outcomes. The Agent's reply is not evidence of Memory capture; Memory runs
+independently of Agent delivery.
 
 ## Preconditions
 
@@ -24,9 +24,11 @@ Do not start the ten-minute clock until all of these are true:
    a complete base URL, model, and API key. This is the explicit opt-in required by
    `MEMORY-IM-ATTACH-003`.
 4. The human test account on each platform is enabled and bound to this Avibe
-   installation. Use a one-to-one direct message only; group, channel, unbound,
-   bot, forwarded, edited, quoted, webhook, and system traffic is denied by
-   `MEMORY-IM-ATTACH-002` and the platform contracts.
+   installation. Use a one-to-one direct message only. Group, channel, unbound,
+   forwarded, edited, quoted, webhook, and system traffic stays outside this
+   human baseline and is closed where the platform exposes the required facts.
+   WeChat bot/self/system source exclusion remains unverified and is collected
+   below; this checklist does not claim those sources are currently excluded.
 5. Record a run tag such as `IMA-20260816-0508`. Put it in every supported
    caption and in every fixture's pixel/file marker. Lark and WeChat native
    image/file messages are verified by bound user plus send timestamp rather
@@ -34,7 +36,9 @@ Do not start the ten-minute clock until all of these are true:
 
 ### Test fixtures
 
-Prepare two small files locally. Do not use personal or production data.
+Prepare one small fixture pair per platform: five PNGs and five SVGs, ten files
+total. Do not reuse a file across platforms, and do not use personal or
+production data.
 
 - **Accepted image:** a 512 x 512 PNG under 1 MiB. Put a large, high-contrast
   platform-specific marker in the pixels, for example `IMA-DISCORD-A7Q2`. The
@@ -46,36 +50,62 @@ Prepare two small files locally. Do not use personal or production data.
   attachment message, use a non-empty caption containing the run tag but not the
   SVG marker. The table explicitly identifies the file-only cases.
 
-Use different markers for every platform. Keep a local table mapping each marker
-to its platform; do not put that table in chat.
+Use different markers for every platform. Keep a local table mapping each pair
+and marker to its platform; do not put that table in chat.
 
 ## Ten-minute acceptance flow
 
-Send the five accepted-image messages first, then the five rejected-file
-messages. After all ten sends, open **Memory > Processing Record**, refresh the
-processing log, and inspect the newest entries for the five bound IM users. The
-processing log is the primary evidence because it covers every user and project
-on the installation; **Memory > Search** is scoped to the current principal and
-is not a substitute for cross-platform verification.
+Run the accepted and rejected rows as separate phases. This separation matters:
+ordinary Memory adds otherwise wait for the five-minute idle flush, and a late
+accepted result could contaminate a rejected-row baseline.
 
-For each matching processing-log row, open its detail and inspect **Message
-tracking**, **Processing timeline**, and the **Memory snippet created** step. A
-row passes only when the falsifiable condition below is met. If an expected row
-has not reached a terminal state within 60 seconds, record a failure rather than
-waiting indefinitely.
+1. Record the newest processing entry and provider-call timestamp for each bound
+   user, then send all five accepted-image messages.
+2. In each of the same five direct-message sessions, send `/new` after the image
+   turn has been accepted for processing. Wait for the new-session acknowledgement.
+   `/new` invokes the old session's final Memory flush; it is the documented phase
+   boundary and avoids treating the five-minute idle timeout as a failure.
+3. Open **Memory > Processing Record**, refresh the processing log, and finish all
+   five accepted-row checks before continuing. Start the 60-second terminal-state
+   allowance only after the corresponding `/new` acknowledgement. A lifecycle
+   busy/flush error, a missing acknowledgement, or a non-terminal expected row
+   after that allowance is a recorded failure; do not continue to the rejected
+   phase with an unsettled accepted row.
+4. Record fresh per-user processing-entry and provider-call baselines. Send all
+   five rejected SVG messages, then send `/new` in each corresponding direct
+   message and wait for its acknowledgement.
+5. Refresh **Processing Record** and evaluate all five rejected rows against the
+   fresh baselines. Apply the same post-`/new` 60-second allowance where a
+   text-only entry is expected.
+
+The processing log is the primary evidence because it covers every user and
+project on the installation; **Memory > Search** is scoped to the current
+principal and is not a substitute for cross-platform verification. For an
+accepted image, open the matching processing entry, expand **Model calls**, and
+inspect the attributed multimodal model call's **Request** and **Response**. The
+request must contain the image input and the response must describe or reproduce
+the pixel-only marker. The timeline and Memory snippet preview do not expose
+attachment-derived model output and therefore are not positive evidence.
+
+For a rejected SVG, inspect calls after the phase baseline and verify that no
+multimodal call has an image/attachment request attributable to that turn. A
+caption-bearing rejected turn must still produce its expected text-only entry;
+the Lark and WeChat file-only rows must produce neither a new processing entry nor
+an attributable multimodal call. A row passes only when the falsifiable condition
+below is met.
 
 | Platform | Scenario | Send | Pass condition in Memory > Processing Record |
 | --- | --- | --- | --- |
-| Slack | `MEMORY-IM-ATTACH-001` | In a bound human DM, send the PNG with caption `<run-tag> slack accepted image`. | One new terminal processing entry exists for the Slack user. Its created Memory snippet contains the caption and describes or reproduces the PNG-only marker. |
-| Slack | `MEMORY-IM-ATTACH-004` | In the same DM, send the SVG with caption `<run-tag> slack rejected file`. | The caption is captured as text in a terminal Memory entry, but the SVG-only marker is absent. No attachment-derived snippet is created for that SVG. |
-| Discord | `MEMORY-IM-ATTACH-005` | In a bound human DM, upload the PNG as an ordinary attachment with caption `<run-tag> discord accepted image`. Do not add a link embed, component, sticker, or forward. | One new terminal processing entry exists for the Discord user and contains both the caption and evidence of the PNG-only marker. If the raw message has an automatic embed and no entry is created, fail this row and apply the Discord fixture decision below. |
-| Discord | `MEMORY-IM-ATTACH-004`, `MEMORY-IM-ATTACH-005` | Upload the SVG with caption `<run-tag> discord rejected file`. | The caption is captured as text; the SVG-only marker is absent from the created Memory snippet. |
-| Telegram | `MEMORY-IM-ATTACH-006` | In a bound private chat, send the PNG as one photo message with caption `<run-tag> telegram accepted image`. Do not use an album. | One new terminal processing entry exists for the Telegram user and contains the caption plus evidence of the PNG-only marker. |
-| Telegram | `MEMORY-IM-ATTACH-004`, `MEMORY-IM-ATTACH-006` | Send the SVG as one document with caption `<run-tag> telegram rejected file`. | The caption is captured as text; the SVG-only marker is absent from the created Memory snippet. |
-| Lark | `MEMORY-IM-ATTACH-007` | In a bound one-to-one chat, send the PNG through the native **image** action as one image-only message. The pixel marker includes the run tag. | Exactly one new terminal processing entry appears for the Lark user after the recorded send time, and its created Memory snippet describes or reproduces the PNG-only marker. |
-| Lark | `MEMORY-IM-ATTACH-004`, `MEMORY-IM-ATTACH-007` | Record the current newest Lark processing entry and send the SVG through the native **file** action as one file-only message. The filename includes the run tag; its visible SVG marker is different from the filename. | No new Memory processing entry is created for this Lark message, and the SVG-only marker is absent from every entry after the recorded send time. |
-| WeChat | `MEMORY-IM-ATTACH-008` | In a bound direct chat, send the PNG as one direct image item with no quoted/reference message. The pixel marker includes the run tag. | Exactly one new terminal processing entry appears for the WeChat user after the recorded send time and contains evidence of the PNG-only marker. |
-| WeChat | `MEMORY-IM-ATTACH-004`, `MEMORY-IM-ATTACH-008` | Record the current newest WeChat processing entry and send the SVG as one direct file item, with no quoted/reference message. The filename includes the run tag. | No new Memory processing entry is created for this WeChat message, and the SVG-only marker is absent from every entry after the recorded send time. |
+| Slack | `MEMORY-IM-ATTACH-001` | In a bound human DM, send the Slack PNG with caption `<run-tag> slack accepted image`. | After `/new`, one terminal entry exists for the Slack user. Its **Model calls** contain an attributed multimodal request with the PNG and a response that describes or reproduces the PNG-only marker. |
+| Slack | `MEMORY-IM-ATTACH-004` | In the same DM, send the Slack SVG with caption `<run-tag> slack rejected file`. | After `/new`, the caption appears in a terminal text-only entry. No call after the phase baseline sends the SVG to the multimodal model, and no provider response contains its marker. |
+| Discord | `MEMORY-IM-ATTACH-005` | In a bound human DM, upload the Discord PNG as an ordinary attachment with caption `<run-tag> discord accepted image`. Do not add a link embed, component, sticker, or forward. | After `/new`, one terminal entry exists for the Discord user. Its attributed multimodal request contains the PNG and its response exposes the PNG-only marker. If the raw message has an automatic embed and no entry is created, fail this row and apply the Discord fixture decision below. |
+| Discord | `MEMORY-IM-ATTACH-004`, `MEMORY-IM-ATTACH-005` | Upload the Discord SVG with caption `<run-tag> discord rejected file`. | After `/new`, the caption appears in a terminal text-only entry. No attributable multimodal request contains the SVG, and no provider response contains its marker. |
+| Telegram | `MEMORY-IM-ATTACH-006` | In a bound private chat, send the Telegram PNG as one photo message with caption `<run-tag> telegram accepted image`. Do not use an album. | After `/new`, one terminal entry exists for the Telegram user. Its attributed multimodal request contains the PNG and its response exposes the PNG-only marker. |
+| Telegram | `MEMORY-IM-ATTACH-004`, `MEMORY-IM-ATTACH-006` | Send the Telegram SVG as one document with caption `<run-tag> telegram rejected file`. | After `/new`, the caption appears in a terminal text-only entry. No attributable multimodal request contains the SVG, and no provider response contains its marker. |
+| Lark | `MEMORY-IM-ATTACH-007` | In a bound one-to-one chat, send the Lark PNG through the native **image** action as one image-only message. The pixel marker includes the run tag. | After `/new`, exactly one terminal entry appears for the Lark user. Its attributed multimodal request contains the PNG and its response exposes the PNG-only marker. |
+| Lark | `MEMORY-IM-ATTACH-004`, `MEMORY-IM-ATTACH-007` | Send the Lark SVG through the native **file** action as one file-only message. The filename includes the run tag; its visible SVG marker is different from the filename. | After `/new`, no processing entry or attributable multimodal call appears after the rejected-phase baseline, and no provider response contains the SVG-only marker. |
+| WeChat | `MEMORY-IM-ATTACH-008` | In a bound direct chat, send the WeChat PNG as one direct image item with no quoted/reference message. The pixel marker includes the run tag. | After `/new`, exactly one terminal entry appears for the WeChat user. Its attributed multimodal request contains the PNG and its response exposes the PNG-only marker. |
+| WeChat | `MEMORY-IM-ATTACH-004`, `MEMORY-IM-ATTACH-008` | Send the WeChat SVG as one direct file item, with no quoted/reference message. The filename includes the run tag. | After `/new`, no processing entry or attributable multimodal call appears after the rejected-phase baseline, and no provider response contains the SVG-only marker. |
 
 Record `PASS` or `FAIL` for every row. Where a caption is supported, a missing
 caption is a failure. For every platform, an accepted image whose pixel-only
@@ -163,13 +193,14 @@ Decision:
 - Enabling Lark `media` before the real fixture supports that decision.
 - Broadly allowing Discord messages with embeds, components, stickers, webhooks,
   forwards, or snapshots.
-- Inferring WeChat human origin when the raw shape does not provide a stable
-  discriminator.
+- Claiming WeChat bot/self/system exclusion before the raw shapes prove a stable
+  discriminator. This checklist exercises only the ordinary human baseline.
 - Capturing SVG, Office/iWork/ODF/RTF documents, or other extensions excluded by
   the pinned modality policy. WeChat video may reach shared admission, but video
   processing is not enabled by this acceptance.
-- Group/channel, unbound, bot-authored, edited, forwarded, quoted/reference, or
-  system-message Memory capture.
+- Group/channel, unbound, edited, forwarded, quoted/reference, or system-message
+  Memory capture, and bot-authored capture on platforms with verified source
+  facts. WeChat source exclusion remains the explicit fixture decision above.
 - Resetting regression state, changing credentials, testing remote Incus, or
   validating Agent attachment behavior. This run covers Memory capture only.
 

--- a/tests/scenarios/memory_im_attachment_capture/catalog.yaml
+++ b/tests/scenarios/memory_im_attachment_capture/catalog.yaml
@@ -83,3 +83,10 @@ scenarios:
     layer: scenario
     delivery_slice: 6
     test: tests/scenarios/memory_im_attachment_capture/test_memory_im_attachment_capture_scenarios.py::test_claimed_attachment_preflight_failure_retries_caption_as_text_only
+  - id: MEMORY-IM-ATTACH-010
+    name: Fully rejected attachments preserve the caption without a multimodal provider call
+    status: covered
+    kind: boundary
+    layer: scenario
+    delivery_slice: 4
+    test: tests/scenarios/memory_im_attachment_capture/test_memory_im_attachment_capture_scenarios.py::test_rejected_attachment_preserves_caption_without_multimodal_provider_call

--- a/tests/scenarios/memory_im_attachment_capture/test_memory_im_attachment_capture_catalog.py
+++ b/tests/scenarios/memory_im_attachment_capture/test_memory_im_attachment_capture_catalog.py
@@ -66,6 +66,7 @@ def test_memory_im_attachment_catalog_is_indexed_and_locks_the_approved_contract
         ("MEMORY-IM-ATTACH-007", "platform_contract", 5),
         ("MEMORY-IM-ATTACH-008", "platform_contract", 5),
         ("MEMORY-IM-ATTACH-009", "degradation", 6),
+        ("MEMORY-IM-ATTACH-010", "boundary", 4),
     ],
 )
 def test_memory_im_attachment_covered_scenario_contract(
@@ -89,6 +90,7 @@ def test_memory_im_attachment_covered_scenario_contract(
         "MEMORY-IM-ATTACH-007",
         "MEMORY-IM-ATTACH-008",
         "MEMORY-IM-ATTACH-009",
+        "MEMORY-IM-ATTACH-010",
     }
     assert rows[scenario_id]["status"] == "covered"
     assert rows[scenario_id]["kind"] == kind

--- a/tests/scenarios/memory_im_attachment_capture/test_memory_im_attachment_capture_scenarios.py
+++ b/tests/scenarios/memory_im_attachment_capture/test_memory_im_attachment_capture_scenarios.py
@@ -215,6 +215,35 @@ def test_invalid_sibling_preserves_valid_attachment_and_leaves_no_memory_leak(
     assert not tuple(harness.home.rglob("*.part"))
 
 
+def test_rejected_attachment_preserves_caption_without_multimodal_provider_call(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    """Scenario: MEMORY-IM-ATTACH-004."""
+
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path / "avibe-home"))
+    harness = MemoryIMAttachmentScenarioHarness(tmp_path)
+    asyncio.run(
+        harness.capture(
+            text="Keep this caption without the rejected file",
+            payloads={
+                "excluded.svg": (
+                    "image/svg+xml",
+                    b'<svg xmlns="http://www.w3.org/2000/svg"></svg>',
+                )
+            },
+        )
+    )
+
+    assert len(harness.provider.captures) == 1
+    assert harness.provider.captures[0].text == (
+        "Keep this caption without the rejected file"
+    )
+    assert harness.provider.captures[0].attachments == ()
+    assert harness.provider.call_log == []
+    assert harness.memory_bundle_entries == ()
+
+
 class _ScenarioPrincipals:
     def principal_for_user_key(self, user_key: str) -> str:
         assert user_key.split(":", 1)[0] in {"discord", "telegram", "lark", "wechat"}

--- a/tests/scenarios/memory_im_attachment_capture/test_memory_im_attachment_capture_scenarios.py
+++ b/tests/scenarios/memory_im_attachment_capture/test_memory_im_attachment_capture_scenarios.py
@@ -219,7 +219,7 @@ def test_rejected_attachment_preserves_caption_without_multimodal_provider_call(
     tmp_path,
     monkeypatch,
 ) -> None:
-    """Scenario: MEMORY-IM-ATTACH-004."""
+    """Scenario: MEMORY-IM-ATTACH-010."""
 
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path / "avibe-home"))
     harness = MemoryIMAttachmentScenarioHarness(tmp_path)

--- a/tests/test_memory_admission.py
+++ b/tests/test_memory_admission.py
@@ -314,6 +314,25 @@ def test_missing_multimodal_skips_attachment_only_turn() -> None:
     ) == CaptureSkipped(reason="memory_invalid_input")
 
 
+def test_im_attachment_only_turn_with_every_upload_filtered_is_not_captured() -> None:
+    decision = _admission().decide(
+        _facts(
+            text="",
+            files=[object()],
+            is_ordinary_text=False,
+            is_ordinary_attachment=True,
+            attachment_capture_status="ready",
+            attachment_config_generation=1,
+            attachment_selection=SimpleNamespace(
+                attachments=(),
+                skipped=("unsupported_type",),
+            ),
+        )
+    )
+
+    assert decision == CaptureSkipped(reason="memory_invalid_input")
+
+
 @pytest.mark.parametrize(
     "overrides",
     [


### PR DESCRIPTION
## Capability

Adds an owner-executable acceptance runbook for Memory IM attachments across Slack, Discord, Telegram, Lark, and WeChat. It defines five accepted-image fixtures, three caption-bearing rejected-file fixtures, UI-established principal baselines, state-driven completion, an optional scrubbed fixture collection follow-up, and explicit non-goals.

Tracks audit and observability follow-ups in #1477, #1480, and #1483.

## Scenarios

- MEMORY-IM-ATTACH-001: Slack image closed loop
- MEMORY-IM-ATTACH-002: bound direct-message authorization prerequisite
- MEMORY-IM-ATTACH-003: explicit multimodal opt-in prerequisite
- MEMORY-IM-ATTACH-005: Discord ordinary-upload contract
- MEMORY-IM-ATTACH-006: Telegram native attachment contract
- MEMORY-IM-ATTACH-007: Lark file/image contract
- MEMORY-IM-ATTACH-008: WeChat direct-item contract
- MEMORY-IM-ATTACH-010: fully rejected attachments preserve caption without a multimodal provider call

## Evidence

- Unit/contract: added hermetic MEMORY-IM-ATTACH-010 coverage proving an all-rejected SVG preserves the caption, produces no captured attachment, and never creates a multimodal provider call. MEMORY-IM-ATTACH-004 remains the separate valid-sibling/no-leak contract.
- Unit/scenario/catalog: `pytest -q tests/test_memory_admission.py tests/scenarios/memory_im_attachment_capture/test_memory_im_attachment_capture_scenarios.py tests/scenarios/memory_im_attachment_capture/test_memory_im_attachment_capture_catalog.py` (97 passed).
- UI evidence surface: verified in `MemoryLogPanel.tsx` that an expanded Model call renders both `call.request` and `call.response`; accepted rows require that visible evidence. Rejected rows use only post-baseline Processing Record entries, while #1483 tracks calls without memcells.
- Recorder boundary: the checklist requires Call log = Recording normally before and after the run. Missing or expired accepted-row call evidence is INCONCLUSIVE, never PASS or FAIL.
- Completion boundary: the run waits for five accepted-image terminal outcomes plus three rejected-caption outcomes, not a fixed number of entries or a fixed delay. Thirty minutes is an operator stop threshold; missing evidence then makes the run INCONCLUSIVE because the preserved global queue has no per-run wall-clock bound. `/new` remains forbidden because it tears down sessions and pauses session-bound tasks/watches.
- Principal boundary: each exact test identity first sends a unique pure-text baseline; the UI-visible entry maps that identity to its opaque `principal_id` and establishes its high-water mark without engineering lookup tools.
- Marker boundary: verified `EverOSPort.add()` and all five adapters' normalized metadata paths. The complete accepted-image marker exists only in pixels; filenames, captions, run tags, Slack titles, Discord descriptions/alt text, and other platform metadata remain neutral.
- Evidence provenance: system-behavior claims in the runbook now cite the implementing code or contract test for regression provisioning, principal derivation, attachment metadata normalization, queue/flush timing, UI scope/preview behavior, and modality exclusions; unsupported source-shape claims remain explicit non-goals.
- File-only boundary: Lark/WeChat captionless fully filtered turns are explicit manual non-goals because admission skips empty text plus empty selected attachments before request/queue/provider state. A focused unit test pins that structural rule.
- Source-shape boundary: acceptance uses ordinary unquoted direct messages. Quoted/replied-to capture is explicitly unverified and out of scope because Slack accepts quote content and the Discord/Telegram Memory classifiers do not enforce their exposed reference facts.
- Provisioning boundary: the standard regression seed does not provide Telegram credentials. Acceptance requires a separately provisioned five-platform target and records BLOCKED when Telegram is absent; the checklist never changes credentials.
- Fixture boundary: raw fixture collection is a separately authorized engineering follow-up and does not block or complete the state-driven UI acceptance result.
- Telegram evidence: photo uploads may be normalized to JPEG, so the positive assertion follows the attributed image input rather than the original PNG filename or MIME.
- Residual manual: the checklist has not been executed. Local Incus `master` must only be updated after explicit owner authorization, preserving state and without reset or remote flags.

## Scope

Runbook plus focused admission/scenario contract tests and catalog registration. No product code changed. No Incus command was run and no regression environment or product state was changed.
