### PR TITLE
fix(memory): retry captions after provider attachment rejection

### DIFF
--- a/core/memory/coordinator.py
+++ b/core/memory/coordinator.py
@@ -30,6 +30,7 @@ from core.memory.everos import (
     MemoryProviderPort,
     MemoryProviderSystemFailure,
     ProviderCapture,
+    attachment_add_rejection_proves_no_write,
 )
 from core.memory.store import (
     AmbiguousAdd,
@@ -615,6 +616,14 @@ class SessionFlushCoordinator:
             return False
 
         if isinstance(ack, AddRejected):
+            if attachment_add_rejection_proves_no_write(
+                capture,
+                ack,
+            ) and await self._downgrade_attachment_capture_to_text(
+                row,
+                lease_owner=lease_owner,
+            ):
+                return False
             await self._settle_failure(
                 row,
                 lease_owner=lease_owner,
@@ -719,25 +728,41 @@ class SessionFlushCoordinator:
         failure: AttachmentPinError,
         retryable: bool,
     ) -> None:
-        bundle_id = None
-        if isinstance(failure, AttachmentBundleInvalidError):
-            bundle_id = await self._store_call(
-                self._store._downgrade_claimed_attachment_to_text,
-                row,
-                lease_owner=lease_owner,
-                now=self._current_time(),
-            )
-        if bundle_id is None:
-            await self._settle_failure(
-                row,
-                lease_owner=lease_owner,
-                outcome=MessageFailure(
-                    error=failure.error,
-                    retryable=retryable,
-                ),
-            )
+        if isinstance(
+            failure,
+            AttachmentBundleInvalidError,
+        ) and await self._downgrade_attachment_capture_to_text(
+            row,
+            lease_owner=lease_owner,
+        ):
             return
+        await self._settle_failure(
+            row,
+            lease_owner=lease_owner,
+            outcome=MessageFailure(
+                error=failure.error,
+                retryable=retryable,
+            ),
+        )
+
+    async def _downgrade_attachment_capture_to_text(
+        self,
+        row: QueueRow,
+        *,
+        lease_owner: str,
+    ) -> bool:
+        """Commit text-only retry and contain its durable bundle cleanup intent."""
+
+        bundle_id = await self._store_call(
+            self._store.downgrade_claimed_attachment_to_text,
+            row,
+            lease_owner=lease_owner,
+            now=self._current_time(),
+        )
+        if bundle_id is None:
+            return False
         await self._release_bundle(bundle_id)
+        return True
 
     async def _settle_failure(
         self,

--- a/core/memory/everos.py
+++ b/core/memory/everos.py
@@ -83,6 +83,13 @@ _RECORDER_HEALTH_REASONS = {
     "serialization_failed",
     "call_log_corrupt",
 }
+# The pinned EverOS 1.2.3 `/add` route emits these only while ingesting attachment
+# content, before boundary preparation or any durable provider write. Unknown
+# codes stay out: destructive text-only replay requires positive no-write proof.
+_ATTACHMENT_ADD_REJECTION_CODES_VALIDATED_EVEROS_VERSION = "1.2.3"
+_ATTACHMENT_ADD_REJECTION_CODES_WITHOUT_WRITE = frozenset(
+    {"UNSUPPORTED_FORMAT", "CAPABILITY_UNAVAILABLE"}
+)
 
 ProviderAttachment = CaptureAttachment
 
@@ -123,6 +130,19 @@ class ProviderCapture:
     text: str
     provider_timestamp_ms: int
     attachments: tuple[CaptureAttachment, ...] = ()
+
+
+def attachment_add_rejection_proves_no_write(
+    capture: ProviderCapture,
+    result: AddResult,
+) -> bool:
+    """Return whether EverOS proved an attachment add stopped before writing."""
+
+    return (
+        bool(capture.attachments)
+        and isinstance(result, AddRejected)
+        and result.error_code in _ATTACHMENT_ADD_REJECTION_CODES_WITHOUT_WRITE
+    )
 
 
 @dataclass(frozen=True)

--- a/core/memory/store.py
+++ b/core/memory/store.py
@@ -1602,7 +1602,7 @@ class MemoryStore:
             ).fetchone()
         return current is not None
 
-    def _downgrade_claimed_attachment_to_text(
+    def downgrade_claimed_attachment_to_text(
         self,
         row: QueueRow,
         *,

--- a/docs/plans/memory-im-attachment-followups-1470-1471.md
+++ b/docs/plans/memory-im-attachment-followups-1470-1471.md
@@ -142,12 +142,17 @@ claimed row or the committed downgraded row, never a caption-less intermediate.
 
 ## PR-C: deterministic provider rejection downgrade (#1471 item 3)
 
-**Selected model.** Reuse PR-B's row downgrade only when the provider returns the
-closed capability codes `UNSUPPORTED_FORMAT` or `CAPABILITY_UNAVAILABLE`. Those
-results prove no attachment write was accepted, so the row may safely retry as
-text-only. Timeouts, transport failures, unknown errors, and every other 4xx remain
-ambiguous and terminal/retry according to existing behavior; they are never
-replayed as text-only because the remote write may already exist.
+**Selected model.** Reuse PR-B's row downgrade only when pinned EverOS 1.2.3 returns one
+of the closed upstream `/add` envelope codes `UNSUPPORTED_FORMAT` or
+`CAPABILITY_UNAVAILABLE`. These are raw provider codes, not Avibe's closed
+`MemoryErrorCode` values. In the pinned provider they can arise only during
+attachment ingest/parser work, before boundary preparation or any durable provider
+write, so they prove no attachment write was accepted and the row may safely retry
+as text-only. Timeouts, transport failures, unknown errors,
+`PROVIDER_NOT_CONFIGURED`, and every other 4xx/5xx retain their existing
+terminal/retry semantics; they are never replayed as text-only because the remote
+write may already exist or the failure does not prove that dropping attachments
+would make the request acceptable.
 
 **Rejected models.** Treating every 4xx as deterministic guesses provider semantics.
 Routing all provider exceptions through one degradation path can duplicate memory
@@ -161,7 +166,8 @@ or migration.
 **Tests.** Parameterize the two allowed capability codes and the full rejected
 boundary. Allowed codes produce one attachment call followed by the durable
 text-only retry. Timeout, transport error, unknown error, and all other 4xx keep a
-single provider invocation and never enqueue or invoke a text-only replay.
+single provider invocation and never enqueue or invoke a text-only replay. The
+closed-loop provider-rejection degradation is `MEMORY-IM-ATTACH-011`.
 
 ## Delivery order and lane boundaries
 

--- a/tests/scenarios/memory_im_attachment_capture/catalog.yaml
+++ b/tests/scenarios/memory_im_attachment_capture/catalog.yaml
@@ -83,3 +83,10 @@ scenarios:
     layer: scenario
     delivery_slice: 6
     test: tests/scenarios/memory_im_attachment_capture/test_memory_im_attachment_capture_scenarios.py::test_claimed_attachment_preflight_failure_retries_caption_as_text_only
+  - id: MEMORY-IM-ATTACH-011
+    name: Provider attachment rejection retries its caption as text-only
+    status: covered
+    kind: degradation
+    layer: scenario
+    delivery_slice: 7
+    test: tests/scenarios/memory_im_attachment_capture/test_memory_im_attachment_capture_scenarios.py::test_provider_attachment_rejection_retries_caption_as_text_only

--- a/tests/scenarios/memory_im_attachment_capture/test_memory_im_attachment_capture_catalog.py
+++ b/tests/scenarios/memory_im_attachment_capture/test_memory_im_attachment_capture_catalog.py
@@ -66,6 +66,7 @@ def test_memory_im_attachment_catalog_is_indexed_and_locks_the_approved_contract
         ("MEMORY-IM-ATTACH-007", "platform_contract", 5),
         ("MEMORY-IM-ATTACH-008", "platform_contract", 5),
         ("MEMORY-IM-ATTACH-009", "degradation", 6),
+        ("MEMORY-IM-ATTACH-011", "degradation", 7),
     ],
 )
 def test_memory_im_attachment_covered_scenario_contract(
@@ -89,6 +90,7 @@ def test_memory_im_attachment_covered_scenario_contract(
         "MEMORY-IM-ATTACH-007",
         "MEMORY-IM-ATTACH-008",
         "MEMORY-IM-ATTACH-009",
+        "MEMORY-IM-ATTACH-011",
     }
     assert rows[scenario_id]["status"] == "covered"
     assert rows[scenario_id]["kind"] == kind

--- a/tests/scenarios/memory_im_attachment_capture/test_memory_im_attachment_capture_scenarios.py
+++ b/tests/scenarios/memory_im_attachment_capture/test_memory_im_attachment_capture_scenarios.py
@@ -11,6 +11,7 @@ import pytest
 
 from core.caller_context import AVIBE_SESSION_ID_ENV
 from core.memory.admission import CaptureAdmission, InboundTurnFacts
+from core.memory.observations import AddAck, AddRejected
 from core.memory.types import RecallItems, RecallPolicy, memory_item_payload
 from modules.im.base import FileAttachment
 from modules.im.message_facts import (
@@ -246,6 +247,41 @@ def test_claimed_attachment_preflight_failure_retries_caption_as_text_only(
     assert harness.provider.captures[0].attachments == ()
     assert harness.provider.observed_payloads == []
     assert harness.provider.call_log == []
+    assert harness.memory_bundle_entries == ()
+
+
+def test_provider_attachment_rejection_retries_caption_as_text_only(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    """Scenario: MEMORY-IM-ATTACH-011."""
+
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path / "avibe-home"))
+    harness = MemoryIMAttachmentScenarioHarness(tmp_path)
+    harness.provider.add_results.extend(
+        (
+            AddRejected(
+                request_id="unsupported-attachment",
+                error_code="UNSUPPORTED_FORMAT",
+                server_fault=False,
+            ),
+            AddAck(request_id="caption-accepted", status="accumulated"),
+        )
+    )
+
+    asyncio.run(
+        harness.capture(
+            text="Keep this caption when the provider rejects the image",
+            payloads={"unsupported.png": ("image/png", PNG_BYTES)},
+        )
+    )
+
+    assert len(harness.provider.captures) == 2
+    assert harness.provider.captures[0].attachments
+    assert harness.provider.captures[1].text == (
+        "Keep this caption when the provider rejects the image"
+    )
+    assert harness.provider.captures[1].attachments == ()
     assert harness.memory_bundle_entries == ()
 
 

--- a/tests/test_memory_everos.py
+++ b/tests/test_memory_everos.py
@@ -11,9 +11,11 @@ from unittest.mock import patch
 import httpx
 import pytest
 
+from core.memory import artifact as memory_artifact
 from core.memory.everos import (
     _AGENTIC_ROUND_HEADER,
     _AGENTIC_TIMEOUT_HEADER,
+    _ATTACHMENT_ADD_REJECTION_CODES_VALIDATED_EVEROS_VERSION,
     AddAck,
     AddRejected,
     AgenticRecallTelemetry,
@@ -26,6 +28,7 @@ from core.memory.everos import (
     MemoryProviderSystemFailure,
     ProviderAttachment,
     ProviderCapture,
+    attachment_add_rejection_proves_no_write,
 )
 from core.memory.store import _provider_session_ref
 from core.memory.types import (
@@ -47,6 +50,16 @@ SESSION_REF = ProviderSessionRef(
     session_id="src--one--e1",
 )
 WIRE_SESSION_ID = "src--one--e1"
+
+
+def test_attachment_rejection_no_write_proof_matches_pinned_everos_version() -> None:
+    assert (
+        _ATTACHMENT_ADD_REJECTION_CODES_VALIDATED_EVEROS_VERSION
+        == memory_artifact.EVEROS_VERSION
+    ), (
+        "Revalidate that UNSUPPORTED_FORMAT and CAPABILITY_UNAVAILABLE still occur "
+        "before every durable /add write in the newly pinned EverOS version"
+    )
 
 
 def _sidecar_transport(handler):
@@ -379,6 +392,65 @@ def test_add_treats_missing_provider_configuration_as_terminal_rejection() -> No
         request_id=None,
         error_code="PROVIDER_NOT_CONFIGURED",
         server_fault=False,
+    )
+
+
+@pytest.mark.parametrize(
+    ("status_code", "error_code", "expected"),
+    [
+        pytest.param(415, "UNSUPPORTED_FORMAT", True, id="unsupported-format"),
+        pytest.param(503, "CAPABILITY_UNAVAILABLE", True, id="capability-unavailable"),
+        pytest.param(400, "BAD_REQUEST", False, id="bad-request"),
+        pytest.param(404, "NOT_FOUND", False, id="not-found"),
+        pytest.param(409, "CONFLICT", False, id="conflict"),
+        pytest.param(422, "INVALID_INPUT", False, id="invalid-input"),
+        pytest.param(422, "EXTRACTION_EMPTY", False, id="extraction-empty"),
+        pytest.param(
+            422,
+            "PROVIDER_NOT_CONFIGURED",
+            False,
+            id="provider-not-configured",
+        ),
+        pytest.param(
+            503,
+            "EXTERNAL_SERVICE_UNAVAILABLE",
+            False,
+            id="external-service-unavailable",
+        ),
+        pytest.param(418, "FUTURE_REJECTION", False, id="unknown-code"),
+    ],
+)
+def test_attachment_add_rejection_requires_positive_no_write_proof(
+    status_code: int,
+    error_code: str,
+    expected: bool,
+) -> None:
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            status_code,
+            json={"error": {"code": error_code}},
+        )
+
+    capture = ProviderCapture(
+        SESSION_REF,
+        "remember this attachment",
+        1,
+        attachments=(
+            ProviderAttachment(
+                kind="doc",
+                name="evidence.txt",
+                uri="file:///owned/evidence.txt",
+                ext="txt",
+            ),
+        ),
+    )
+    with _sidecar_transport(handler):
+        result = asyncio.run(EverOSPort(Path("/tmp/everos.sock")).add(capture))
+
+    assert attachment_add_rejection_proves_no_write(capture, result) is expected
+    assert not attachment_add_rejection_proves_no_write(
+        ProviderCapture(SESSION_REF, "text only", 1),
+        result,
     )
 
 

--- a/tests/test_memory_flush_coordinator.py
+++ b/tests/test_memory_flush_coordinator.py
@@ -3358,7 +3358,7 @@ def test_claimed_attachment_downgrade_is_atomic_and_lease_fenced(
     assert stale is not None
 
     assert (
-        store._downgrade_claimed_attachment_to_text(
+        store.downgrade_claimed_attachment_to_text(
             stale,
             lease_owner="wrong-worker",
             now=datetime(2026, 1, 1, 0, 0, 1, tzinfo=UTC),
@@ -3373,7 +3373,7 @@ def test_claimed_attachment_downgrade_is_atomic_and_lease_fenced(
     assert current is not None
     assert current.lease_token == stale.lease_token + 1
     assert (
-        store._downgrade_claimed_attachment_to_text(
+        store.downgrade_claimed_attachment_to_text(
             stale,
             lease_owner="second-worker",
             now=datetime(2026, 1, 1, 0, 0, 3, tzinfo=UTC),
@@ -3382,7 +3382,7 @@ def test_claimed_attachment_downgrade_is_atomic_and_lease_fenced(
     )
 
     assert (
-        store._downgrade_claimed_attachment_to_text(
+        store.downgrade_claimed_attachment_to_text(
             current,
             lease_owner="second-worker",
             now=datetime(2026, 1, 1, 0, 0, 4, tzinfo=UTC),
@@ -3417,7 +3417,7 @@ def test_claimed_attachment_downgrade_is_atomic_and_lease_fenced(
         frozenset({bundle.bundle_id}),
     )
     assert (
-        store._downgrade_claimed_attachment_to_text(
+        store.downgrade_claimed_attachment_to_text(
             current,
             lease_owner="second-worker",
             now=datetime(2026, 1, 1, 0, 0, 5, tzinfo=UTC),
@@ -3450,7 +3450,7 @@ def test_claimed_attachment_downgrade_rolls_back_caption_and_bundle_together(
         )
 
     with pytest.raises(sqlite3.IntegrityError, match="forced release failure"):
-        store._downgrade_claimed_attachment_to_text(
+        store.downgrade_claimed_attachment_to_text(
             claimed,
             lease_owner="worker",
             now=datetime(2026, 1, 1, 0, 0, 1, tzinfo=UTC),
@@ -3560,6 +3560,217 @@ async def test_attachment_preflight_failure_retries_caption_as_text_only(
     assert provider.captures[0].text == "remember the attachment"
     assert provider.captures[0].attachments == ()
     assert releases == [bundle.bundle_id]
+
+
+@pytest.mark.parametrize(
+    "error_code",
+    ["UNSUPPORTED_FORMAT", "CAPABILITY_UNAVAILABLE"],
+)
+async def test_attachment_provider_rejection_retries_caption_as_text_only(
+    tmp_path: Path,
+    error_code: str,
+) -> None:
+    """Scenario: MEMORY-IM-ATTACH-011."""
+
+    store = _store(tmp_path)
+    attachment_store, bundle, pinned_path = _pin_attachment_bundle()
+    original = _enqueue_attachment_bundle(
+        store,
+        bundle,
+        source=f"provider-{error_code.lower()}-text-downgrade",
+    )
+    provider = FakeMemoryProvider()
+    provider.add_results.extend(
+        (
+            AddRejected(
+                request_id="attachment-rejected",
+                error_code=error_code,
+                server_fault=error_code == "CAPABILITY_UNAVAILABLE",
+            ),
+            AddAck(request_id="text-accepted", status="accumulated"),
+        )
+    )
+    releases: list[str] = []
+    coordinator = SessionFlushCoordinator(
+        store=store,
+        provider=provider,
+        enabled=lambda: True,
+        attachment_store=attachment_store,
+        release_attachment=releases.append,
+    )
+    claimed = store.claim_due(
+        lease_owner="worker",
+        now="2026-01-01T00:00:00.000Z",
+    )
+    assert claimed is not None
+
+    assert not await coordinator.deliver(claimed, lease_owner="worker")
+
+    downgraded = store.get_queue_row(original.source_message_digest)
+    assert downgraded is not None
+    assert (
+        downgraded.state,
+        downgraded.attempts,
+        downgraded.payload_text,
+        downgraded.payload_attachments,
+        downgraded.attachment_bundle_id,
+    ) == ("pending", 0, "remember the attachment", None, None)
+    assert releases == [bundle.bundle_id]
+    assert store.attachment_bundle_sets() == (frozenset(), frozenset())
+    assert not pinned_path.exists()
+    assert len(provider.captures) == 1
+    assert provider.captures[0].attachments
+
+    retry = store.claim_due(
+        lease_owner="retry-worker",
+        now="2026-01-01T00:00:01.000Z",
+    )
+    assert retry is not None
+    assert await coordinator.deliver(retry, lease_owner="retry-worker")
+    assert len(provider.captures) == 2
+    assert provider.captures[1].text == "remember the attachment"
+    assert provider.captures[1].attachments == ()
+    assert releases == [bundle.bundle_id]
+
+
+async def test_captionless_provider_rejection_falls_back_to_terminal_settlement(
+    tmp_path: Path,
+) -> None:
+    store = _store(tmp_path)
+    attachment_store, bundle, _pinned_path = _pin_attachment_bundle()
+    original = _enqueue_attachment_bundle(
+        store,
+        bundle,
+        source="captionless-provider-rejection",
+        payload_text="",
+    )
+    provider = FakeMemoryProvider()
+    provider.add_results.append(
+        AddRejected(
+            request_id="unsupported-attachment",
+            error_code="UNSUPPORTED_FORMAT",
+            server_fault=False,
+        )
+    )
+    coordinator = SessionFlushCoordinator(
+        store=store,
+        provider=provider,
+        enabled=lambda: True,
+        attachment_store=attachment_store,
+    )
+    claimed = store.claim_due(
+        lease_owner="worker",
+        now="2026-01-01T00:00:00.000Z",
+    )
+    assert claimed is not None
+
+    assert not await coordinator.deliver(claimed, lease_owner="worker")
+
+    settled = store.get_queue_row(original.source_message_digest)
+    assert settled is not None
+    assert (settled.state, settled.attempts) == ("dead", 1)
+    assert provider.captures[0].attachments
+    assert not any(capture.attachments == () for capture in provider.captures)
+
+
+@pytest.mark.parametrize(
+    ("outcome", "expected_state", "expected_attempts"),
+    [
+        pytest.param(asyncio.TimeoutError(), "manual_required", 0, id="timeout"),
+        pytest.param(
+            MemoryProviderSystemFailure(),
+            "pending",
+            0,
+            id="transport",
+        ),
+        pytest.param(
+            RuntimeError("unknown provider failure"),
+            "manual_required",
+            0,
+            id="unknown",
+        ),
+        *(
+            pytest.param(
+                AddRejected(
+                    request_id=f"rejected-{error_code.lower()}",
+                    error_code=error_code,
+                    server_fault=False,
+                ),
+                "dead",
+                1,
+                id=f"4xx-{error_code.lower()}",
+            )
+            for error_code in (
+                "BAD_REQUEST",
+                "NOT_FOUND",
+                "CONFLICT",
+                "INVALID_INPUT",
+                "EXTRACTION_EMPTY",
+                "PROVIDER_NOT_CONFIGURED",
+                "FUTURE_REJECTION",
+            )
+        ),
+    ],
+)
+async def test_unproven_provider_failure_never_replays_caption_without_attachment(
+    tmp_path: Path,
+    outcome: BaseException | AddRejected,
+    expected_state: str,
+    expected_attempts: int,
+) -> None:
+    store = _store(tmp_path)
+    attachment_store, bundle, pinned_path = _pin_attachment_bundle()
+    original = _enqueue_attachment_bundle(
+        store,
+        bundle,
+        source=f"provider-no-downgrade-{type(outcome).__name__}-{expected_state}",
+    )
+
+    class Provider(FakeMemoryProvider):
+        calls = 0
+
+        async def add(self, capture):
+            self.calls += 1
+            self.captures.append(capture)
+            if isinstance(outcome, BaseException):
+                raise outcome
+            return outcome
+
+    provider = Provider()
+    coordinator = SessionFlushCoordinator(
+        store=store,
+        provider=provider,
+        enabled=lambda: True,
+        attachment_store=attachment_store,
+    )
+    claimed = store.claim_due(
+        lease_owner="worker",
+        now="2026-01-01T00:00:00.000Z",
+    )
+    assert claimed is not None
+
+    assert not await coordinator.deliver(claimed, lease_owner="worker")
+
+    settled = store.get_queue_row(original.source_message_digest)
+    assert settled is not None
+    assert (settled.state, settled.attempts) == (expected_state, expected_attempts)
+    assert provider.calls == 1
+    assert len(provider.captures) == 1
+    assert provider.captures[0].attachments
+    assert not any(capture.attachments == () for capture in provider.captures)
+    if expected_state == "dead":
+        assert (settled.payload_text, settled.payload_attachments) == (None, None)
+        assert store.attachment_bundle_sets() == (frozenset(), frozenset())
+        assert not pinned_path.exists()
+    else:
+        assert settled.payload_text == "remember the attachment"
+        assert settled.payload_attachments == original.payload_attachments
+        assert settled.attachment_bundle_id == bundle.bundle_id
+        assert store.attachment_bundle_sets() == (
+            frozenset({bundle.bundle_id}),
+            frozenset(),
+        )
+        assert pinned_path.exists()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- capability: preserve a non-empty Memory caption when EverOS explicitly rejects its attachment payload before accepting any write
- user-visible change: a mixed caption + attachment capture now retries the same durable row as text-only after a proven attachment format/capability rejection
- motivation: complete #1471 item 3 without widening ambiguous provider failures into duplicate-memory risk

The downgrade allowlist is a positive-proof, closed set of raw EverOS `/add` envelope codes:

- `UNSUPPORTED_FORMAT`: EverOS v1.2.3 maps attachment ingest/parser format failures to this 415 response before boundary preparation or buffer/pipeline writes.
- `CAPABILITY_UNAVAILABLE`: EverOS v1.2.3 maps the missing multimodal parser/system capability to this 503 response from the same pre-boundary attachment ingest stage. Its HTTP class is not the proof; the exact machine code and tagged source location are.

Evidence: [v1.2.3 error mapping](https://github.com/EverMind-AI/EverMemOS/blob/v1.2.3/src/everos/entrypoints/api/exception_handlers.py), [attachment ingest ordering](https://github.com/EverMind-AI/EverMemOS/blob/v1.2.3/src/everos/service/memorize.py), and [parser failures](https://github.com/EverMind-AI/EverMemOS/tree/v1.2.3/src/everos/memory/extract/parser).

These are upstream provider codes, not Avibe's closed `MemoryErrorCode` values. The plan now records that distinction and the actual pinned EverOS 1.2.3 contract. A dedicated validated-version literal is mechanically checked against `artifact.EVEROS_VERSION`, so any future pin bump stops CI until both codes are revalidated against the new upstream write ordering. The coordinator reuses one confined entry for the PR-B transaction plus durable bundle release intent. Because that store operation now serves both preflight and provider-rejection paths across a module boundary, it is exposed as `downgrade_claimed_attachment_to_text` rather than a cross-module private call.

Closes #1471

## Scenario Coverage

- scenario IDs: `MEMORY-IM-ATTACH-011`
- unit / contract coverage: EverOS response mapping tests enumerate both allowed codes and every currently known non-allowed 4xx code, and bind the validated no-write proof to the pinned EverOS version; coordinator tests prove the two allowed codes persist and replay one text-only row, while timeout, transport, unknown, future, and other 4xx outcomes make exactly one provider call and never replay text-only. Existing PR-B transaction/lease/crash tests remain intact, including captionless progress.
- scenario coverage: the hermetic Slack-to-shared-Memory harness drives a provider `UNSUPPORTED_FORMAT` result, observes one attachment attempt followed by one text-only attempt, and verifies bundle cleanup.
- residual manual checks: no live sidecar or Incus mutation was needed. The allowed set and no-write ordering were verified against the pinned EverOS v1.2.3 tagged source; a future EverOS pin must revalidate this closed set.

The allowed-path contract and scenario failed before the implementation (`dead`, one provider call); the rejection-side matrix passed before implementation and remains the load-bearing guard against accidental widening.

## Validation

- commands run: focused red/green pytest; `pytest` over `test_memory_everos.py`, `test_memory_flush_coordinator.py`, `test_memory_store.py`, `test_memory_attachments.py`, and the attachment scenario catalog/suite; Ruff on every changed Python file; `git diff --check`
- result: 326 passed; Ruff clean; diff check clean

## Risks / Follow-ups

- risk: timeouts, transport failures, generic exceptions, `PROVIDER_NOT_CONFIGURED`, `EXTERNAL_SERVICE_UNAVAILABLE`, unknown/future codes, and every other 4xx/5xx intentionally retain their existing terminal/retry behavior. They do not prove both that no remote write exists and that dropping attachments makes the request acceptable, so text-only replay could duplicate memory or discard a recoverable bundle.
- follow-up: none in this PR. No schema, table, migration, provider retry policy, or adapter behavior changed.
