### PR TITLE
test(watch): lock zero timeout CLI round-trip

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -436,6 +436,8 @@ for one-shot session creation. `vibe watch remove` hides the watch from manageme
 views while preserving existing run history in SQLite. Prefer `vibe watch`
 over ad-hoc `nohup` jobs when the
 user wants a managed background task with a guaranteed follow-up message.
+`--timeout` defaults to 21600 seconds; an explicit `--timeout 0` disables the
+per-cycle timeout, while any positive value is persisted unchanged.
 
 ### `vibe version`
 

--- a/docs/CLI_ZH.md
+++ b/docs/CLI_ZH.md
@@ -378,6 +378,8 @@ watch 与 `vibe task`、`vibe agent run` 共用 `--session-id`、`--create-sessi
 `--same-scope` 和 `--scope-id` 语义；`--create-session-per-run`
 只属于 `vibe task` 和 `vibe watch` 这类 stored definitions。需要可管理、可暂停、可查看的
 后台等待任务时，优先使用 `vibe watch`，不要随手起 `nohup`。
+`--timeout` 默认是 21600 秒；显式传入 `--timeout 0` 会关闭单次 cycle 的
+超时限制，任何正数值都会原样持久化。
 
 ### `vibe version`
 

--- a/tests/test_cli_watch_command.py
+++ b/tests/test_cli_watch_command.py
@@ -101,6 +101,7 @@ def test_watch_add_help_mentions_shell_and_lifetime_timeout(capsys) -> None:
 
     assert exc.value.code == 0
     captured = capsys.readouterr()
+    normalized_help = " ".join(captured.out.split())
     assert "Pass either --shell '<command>' or a command after '--'." in captured.out
     assert "--lifetime-timeout" in captured.out
     assert "vibe watch add --session-id sesk8m4q2p7x --message 'The export finished. Inspect it and continue.'" in captured.out
@@ -114,6 +115,7 @@ def test_watch_add_help_mentions_shell_and_lifetime_timeout(capsys) -> None:
     assert "a once Watch ends and a forever Watch re-arms" in captured.out
     assert "A once waiter that is still waiting must use a retry exit code" in captured.out
     assert "If this is your first time using this command, read this whole help entry before creating a watch." in captured.out
+    assert "Use 0 for no per-cycle timeout" in normalized_help
     assert "--same-scope" in captured.out
     assert "--scope-id" in captured.out
     assert "--post-to" not in captured.out
@@ -800,6 +802,59 @@ def test_watch_add_creates_exec_watch_with_retry_codes(tmp_path: Path, capsys) -
     assert payload["definition"]["mode"] == "forever"
     assert payload["definition"]["command"] == ["python3", "scripts/wait.py", "--build", "42"]
     assert payload["definition"]["retry_exit_codes"] == [1, 75]
+
+
+@pytest.mark.parametrize(
+    ("timeout_args", "expected_timeout"),
+    [
+        pytest.param([], 21600, id="omitted-default"),
+        pytest.param(["--timeout", "0"], 0, id="explicit-unlimited"),
+        pytest.param(["--timeout", "90.5"], 90.5, id="positive"),
+    ],
+)
+def test_watch_add_timeout_round_trips_through_persisted_read(
+    tmp_path: Path,
+    capsys,
+    timeout_args: list[str],
+    expected_timeout: float,
+) -> None:
+    store = ManagedWatchStore()
+    runtime_store = WatchRuntimeStateStore(tmp_path / "watch_runtime.json")
+    args = _parse_watch_add(
+        [
+            "--session-key",
+            "slack::channel::C123",
+            *timeout_args,
+            "--shell",
+            "exit 75",
+        ]
+    )
+
+    with (
+        patch("vibe.cli._ensure_config", return_value=_configured_v2({"slack"})),
+        patch("vibe.cli._watch_store", return_value=store),
+        patch("vibe.cli._watch_runtime_store", return_value=runtime_store),
+        patch(
+            "vibe.cli._wait_for_watch_startup",
+            side_effect=lambda *args, **kwargs: _startup_ok(
+                store, runtime_store, args[2]
+            ),
+        ),
+    ):
+        assert cli.cmd_watch_add(args) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    watch_id = payload["definition"]["id"]
+    reloaded_store = ManagedWatchStore()
+    try:
+        reloaded = reloaded_store.get_watch(watch_id)
+        assert reloaded is not None
+        assert reloaded.timeout_seconds == expected_timeout
+    finally:
+        if store.sqlite_backend is not None:
+            store.sqlite_backend.close()
+        if reloaded_store.sqlite_backend is not None:
+            reloaded_store.sqlite_backend.close()
 
 
 def test_watch_add_persists_absolute_cwd(tmp_path: Path, capsys, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary

- Add a parser-backed, hermetic contract test that exercises `vibe watch add` through the normal isolated SQLite persistence path and a fresh `ManagedWatchStore` read.
- Lock the three timeout cases: omitted uses `21600`, explicit `0` remains unlimited, and a positive value is preserved unchanged.
- Make the `0 = no per-cycle timeout` contract explicit in CLI help and the English and Chinese CLI documentation.

Closes #1480

## Root cause and scope

The reported behavior was version drift, not a remaining defect in current `master`:

- The installed `avibe-os 3.0.11rc4` reproduces the issue hermetically: the parser and raw test-owned SQLite row contain `0.0`, but a fresh store reload returns `21600.0` because that version reads with `float(row["timeout_seconds"] or 21600.0)`.
- Current `master` already uses a NULL-only fallback, fixed by `047f93f5e` / #1464 (`fix(watch): preserve zero timing values on read`). The same probe returns `0.0` after a fresh reload.
- Therefore this PR does not duplicate the product fix. Its net change is the missing regression boundary that allowed the bug to escape #1464 without a CLI-to-persistence contract test.

Had this test existed before #1464, the explicit-zero case would have failed at the fresh-store assertion: the persisted raw value was `0.0`, but the normal read path exposed `21600.0`.

The nearby `float(row["lifetime_timeout_seconds"] or 0.0)` is intentionally unchanged. Its fallback is also `0.0`, so an explicit zero and the fallback have the same observable value; it is not the same defect.

## Evidence layers

- **Unit:** the parser-backed help assertion locks the documented `Use 0 for no per-cycle timeout` contract.
- **Contract:** the parameterized test invokes the real CLI parser and `cmd_watch_add`, writes through a test-owned `ManagedWatchStore`, then opens a fresh store and verifies omitted, zero, and positive values.
- **Scenario:** the contract test is the hermetic CLI scenario for this persistence invariant. No catalog scenario ID currently covers watch CLI persistence, so no scenario ID is claimed.
- **Residual manual:** compared installed rc4 and the current checkout with the same temporary-`AVIBE_HOME` probe. No real watch database was opened and the running Avibe service was not restarted or modified.

## Validation

- `uv run --no-sync pytest -q tests/test_cli_watch_command.py tests/test_harness_definition_lifecycle.py tests/test_harness_skill_guidance.py` (`131 passed`)
- `uvx ruff check tests/test_cli_watch_command.py`
- `git diff --check`

## Risks and non-goals

- This PR changes no runtime reader, scheduler semantics, defaults, schema, migration, or existing watch definition. Existing watches, including the currently running `6cc6050bf93c`, are unaffected.
- The local installed runtime is still the affected rc4 build. Until a release containing #1464 is installed, a newly created `--timeout 0` watch will still reload as `21600`; updating that same watch in place to a large positive timeout remains the correct temporary workaround because recreating it would discard its seeded baseline.
- Upgrading or restarting the local Avibe service is outside this PR.
