### PR TITLE
fix(memory): restore published runtime guard coverage

### DIFF
--- a/.github/workflows/memory-runtime-release-guard.yml
+++ b/.github/workflows/memory-runtime-release-guard.yml
@@ -27,7 +27,10 @@ jobs:
     outputs:
       available: ${{ steps.manifests.outputs.available }}
       manifests: ${{ steps.manifests.outputs.manifests }}
+      excluded: ${{ steps.manifests.outputs.excluded }}
     steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09  # v5
+
       - name: Resolve every published Memory Runtime manifest
         id: manifests
         env:
@@ -37,16 +40,22 @@ jobs:
           set -euo pipefail
           candidate_dir="$RUNNER_TEMP/memory-runtime-candidate"
           records_file="$RUNNER_TEMP/memory-runtime-manifests.jsonl"
+          excluded_file="$RUNNER_TEMP/memory-runtime-excluded.jsonl"
           mkdir -p "$candidate_dir"
           : > "$records_file"
+          : > "$excluded_file"
           while IFS= read -r candidate_tag; do
             rm -rf "$candidate_dir"
             mkdir -p "$candidate_dir"
             if ! gh release download "$candidate_tag" --repo "$GITHUB_REPOSITORY" \
               --pattern 'avibe_os-*.whl' --dir "$candidate_dir" >/dev/null 2>&1; then
+              jq -nc --arg release_tag "$candidate_tag" \
+                --arg reason "published wheel could not be downloaded" \
+                '{release_tag: $release_tag, reason: $reason}' >> "$excluded_file"
               continue
             fi
-            if CANDIDATE_TAG="$candidate_tag" CANDIDATE_DIR="$candidate_dir" \
+            set +e
+            CANDIDATE_TAG="$candidate_tag" CANDIDATE_DIR="$candidate_dir" \
               python3 - <<'PY'
           import json
           import os
@@ -57,34 +66,92 @@ jobs:
           if len(wheels) != 1:
               raise SystemExit(1)
           with zipfile.ZipFile(wheels[0]) as wheel:
-              manifest = wheel.read("vibe/memory_runtime_manifest.json")
+              try:
+                  manifest = wheel.read("vibe/memory_runtime_manifest.json")
+              except KeyError:
+                  raise SystemExit(4) from None
           payload = json.loads(manifest)
           if payload.get("release_state") != "published" or payload.get("release_tag") != os.environ["CANDIDATE_TAG"]:
               raise SystemExit(1)
           (Path(os.environ["CANDIDATE_DIR"]) / "memory-runtime-manifest.json").write_bytes(manifest)
           PY
-            then
-              manifest_sha="$(sha256sum "$candidate_dir/memory-runtime-manifest.json" | cut -d' ' -f1)"
+            manifest_status=$?
+            set -e
+            # Wheels without a manifest predate Memory Runtime and are not scope exclusions.
+            if [ "$manifest_status" -eq 4 ]; then
+              continue
+            elif [ "$manifest_status" -ne 0 ]; then
+              jq -nc --arg release_tag "$candidate_tag" \
+                --arg reason "wheel does not contain a self-pinned published manifest" \
+                '{release_tag: $release_tag, reason: $reason}' >> "$excluded_file"
+              continue
+            fi
+            manifest="$candidate_dir/memory-runtime-manifest.json"
+            manifest_sha="$(sha256sum "$manifest" | cut -d' ' -f1)"
+            set +e
+            policy_output="$(
+              python3 scripts/memory_runtime_release_guard.py \
+                --manifest "$manifest" check-policy 2>&1
+            )"
+            policy_status=$?
+            set -e
+            if [ "$policy_status" -eq 0 ]; then
               jq -nc --arg release_tag "$candidate_tag" --arg sha256 "$manifest_sha" \
                 '{release_tag: $release_tag, sha256: $sha256}' >> "$records_file"
+            elif [ "$policy_status" -eq 2 ]; then
+              policy_reason="$(jq -r '.error // "manifest excluded by policy"' <<<"$policy_output")"
+              jq -nc --arg release_tag "$candidate_tag" --arg reason "$policy_reason" \
+                '{release_tag: $release_tag, reason: $reason}' >> "$excluded_file"
+            else
+              echo "$policy_output" >&2
+              exit "$policy_status"
             fi
           done < <(
             gh api --paginate "repos/$GITHUB_REPOSITORY/releases?per_page=100" \
               --jq '.[] | select(any(.assets[]?; (.name | startswith("avibe_os-")) and (.name | endswith(".whl")))) | .tag_name'
           )
-          RECORDS_FILE="$records_file" python3 - <<'PY'
+          RECORDS_FILE="$records_file" EXCLUDED_FILE="$excluded_file" python3 - <<'PY'
           import json
           import os
           from pathlib import Path
 
-          records = [
-              json.loads(line)
-              for line in Path(os.environ["RECORDS_FILE"]).read_text().splitlines()
-              if line.strip()
-          ]
+          def load_records(name: str) -> list[dict[str, str]]:
+              return [
+                  json.loads(line)
+                  for line in Path(os.environ[name]).read_text().splitlines()
+                  if line.strip()
+              ]
+
+          records = load_records("RECORDS_FILE")
+          excluded = load_records("EXCLUDED_FILE")
           with Path(os.environ["GITHUB_OUTPUT"]).open("a", encoding="utf-8") as output:
               output.write(f"available={'true' if records else 'false'}\n")
               output.write(f"manifests={json.dumps(records, separators=(',', ':'))}\n")
+              output.write(f"excluded={json.dumps(excluded, separators=(',', ':'))}\n")
+
+          guarded_tags = [record["release_tag"] for record in records]
+          print(f"Guarded Memory Runtime manifests ({len(records)}): {', '.join(guarded_tags) or 'none'}")
+          print(f"Excluded Memory Runtime manifests ({len(excluded)}):")
+          for record in excluded:
+              print(f"- {record['release_tag']}: {record['reason']}")
+          if not excluded:
+              print("- none")
+
+          summary = [
+              "## Memory Runtime release guard coverage",
+              "",
+              f"Guarded Memory Runtime manifests ({len(records)}): "
+              f"{', '.join(guarded_tags) or 'none'}",
+              "",
+              f"Excluded Memory Runtime manifests ({len(excluded)}):",
+          ]
+          summary.extend(
+              f"- `{record['release_tag']}`: {record['reason']}" for record in excluded
+          )
+          if not excluded:
+              summary.append("- none")
+          with Path(os.environ["GITHUB_STEP_SUMMARY"]).open("a", encoding="utf-8") as output:
+              output.write("\n".join(summary) + "\n")
           PY
 
   guard:
@@ -135,14 +202,35 @@ jobs:
 
       - name: Fetch and verify published assets
         id: probe
-        continue-on-error: true
+        env:
+          RELEASE_TAG: ${{ matrix.manifest.release_tag }}
+        shell: bash
         run: |
-          python3 scripts/memory_runtime_release_guard.py \
-            --manifest "$RUNNER_TEMP/memory-runtime-manifest/memory-runtime-manifest.json" \
-            fetch --output-dir "$RUNNER_TEMP/memory-runtime-release"
+          set -euo pipefail
+          set +e
+          probe_output="$(
+            python3 scripts/memory_runtime_release_guard.py \
+              --manifest "$RUNNER_TEMP/memory-runtime-manifest/memory-runtime-manifest.json" \
+              fetch --output-dir "$RUNNER_TEMP/memory-runtime-release" 2>&1
+          )"
+          probe_status=$?
+          set -e
+          echo "$probe_output"
+          failure_kind="$(jq -r '.failure_kind // empty' <<<"$probe_output" 2>/dev/null || true)"
+          if [ "$probe_status" -eq 0 ]; then
+            echo "result=verified" >> "$GITHUB_OUTPUT"
+          elif [ "$probe_status" -eq 1 ] && [ "$failure_kind" = "bytes" ]; then
+            echo "result=bytes_failure" >> "$GITHUB_OUTPUT"
+          elif [ "$probe_status" -eq 2 ] && [ "$failure_kind" = "policy" ]; then
+            echo "result=policy_excluded" >> "$GITHUB_OUTPUT"
+            echo "::notice title=Memory Runtime manifest excluded by policy::$RELEASE_TAG: $probe_output"
+            echo "- Guard-time exclusion for \`$RELEASE_TAG\`: $probe_output" >> "$GITHUB_STEP_SUMMARY"
+          else
+            exit "$probe_status"
+          fi
 
       - name: Recover missing assets from latest verified backup
-        if: steps.probe.outcome == 'failure'
+        if: steps.probe.outputs.result == 'bytes_failure'
         env:
           GH_TOKEN: ${{ github.token }}
           MANIFEST_SHA: ${{ matrix.manifest.sha256 }}
@@ -194,7 +282,7 @@ jobs:
           gh release upload "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" "${missing[@]}"
 
       - name: Verify recovered release
-        if: steps.probe.outcome == 'failure'
+        if: steps.probe.outputs.result == 'bytes_failure'
         run: |
           python3 scripts/memory_runtime_release_guard.py \
             --manifest "$RUNNER_TEMP/memory-runtime-manifest/memory-runtime-manifest.json" \
@@ -202,6 +290,9 @@ jobs:
 
       - name: Check whether this manifest already has a backup
         id: backup
+        if: >-
+          steps.probe.outputs.result == 'verified' ||
+          steps.probe.outputs.result == 'bytes_failure'
         env:
           GH_TOKEN: ${{ github.token }}
           MANIFEST_SHA: ${{ matrix.manifest.sha256 }}
@@ -227,10 +318,12 @@ jobs:
 
       - name: Preserve verified release backup
         if: >-
-          github.event_name != 'schedule' ||
-          github.event.schedule == '53 4 * * 0' ||
-          steps.probe.outcome == 'failure' ||
-          steps.backup.outputs.missing == 'true'
+          (steps.probe.outputs.result == 'verified' ||
+           steps.probe.outputs.result == 'bytes_failure') &&
+          (github.event_name != 'schedule' ||
+           github.event.schedule == '53 4 * * 0' ||
+           steps.probe.outputs.result == 'bytes_failure' ||
+           steps.backup.outputs.missing == 'true')
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6
         with:
           name: memory-runtime-release-backup-${{ matrix.manifest.sha256 }}

--- a/scripts/memory_runtime_release_guard.py
+++ b/scripts/memory_runtime_release_guard.py
@@ -25,10 +25,21 @@ EXPECTED_PLATFORMS = frozenset({"darwin-arm64", "linux-arm64", "linux-x64"})
 EXPECTED_SYNC_BOOTSTRAP_REVISION = 1
 EXPECTED_SYNC_ARGV = ["-I", "-m", "everos.entrypoints.cli.main", "cascade", "sync"]
 MAX_ARCHIVE_BYTES = 1024 * 1024 * 1024
+ASSET_FAILURE_EXIT = 1
+POLICY_EXCLUSION_EXIT = 2
+INTERNAL_GUARD_FAILURE_EXIT = 3
 
 
 class ReleaseGuardError(RuntimeError):
-    """Raised when published Memory Runtime bytes do not match their manifest."""
+    """Base error for Memory Runtime release guard failures."""
+
+
+class ManifestPolicyError(ReleaseGuardError):
+    """Raised when a manifest is outside the guard's verifiable policy scope."""
+
+
+class ReleaseAssetError(ReleaseGuardError):
+    """Raised when guarded release bytes are unavailable or fail verification."""
 
 
 @dataclass(frozen=True)
@@ -40,6 +51,11 @@ class RuntimeProvenance:
 
 # Existing published manifests remain verifiable after the current pin moves.
 PUBLISHED_RUNTIME_PROVENANCE = {
+    "1.1.3": RuntimeProvenance(
+        python_version=EXPECTED_PYTHON_VERSION,
+        lock_sha256="62b00f1a9ca04cc4ea4c5af51f389ba49acdea8786e5f7044d52823244502c57",
+        uv_version=EXPECTED_UV_VERSION,
+    ),
     "1.2.1": RuntimeProvenance(
         python_version=EXPECTED_PYTHON_VERSION,
         lock_sha256="e7b59ee874e5cb2bfcbcb87cbd1e9c2d6ca2df752cd8a1059ddd3badb8c0246f",
@@ -88,7 +104,7 @@ def _sha256(path: Path) -> str:
 def _required_string(payload: dict, key: str, context: str) -> str:
     value = payload.get(key)
     if not isinstance(value, str) or not value:
-        raise ReleaseGuardError(f"{context}.{key} must be a non-empty string")
+        raise ManifestPolicyError(f"{context}.{key} must be a non-empty string")
     return value
 
 
@@ -97,9 +113,9 @@ def load_release_spec(manifest_path: Path) -> ReleaseSpec:
         manifest_bytes = manifest_path.read_bytes()
         payload = json.loads(manifest_bytes)
     except (OSError, json.JSONDecodeError) as exc:
-        raise ReleaseGuardError(f"cannot read Memory Runtime manifest: {exc}") from exc
+        raise ManifestPolicyError(f"cannot read Memory Runtime manifest: {exc}") from exc
     if not isinstance(payload, dict) or payload.get("schema_version") != 1:
-        raise ReleaseGuardError("Memory Runtime manifest schema_version must be 1")
+        raise ManifestPolicyError("Memory Runtime manifest schema_version must be 1")
     everos_version = payload.get("everos_version")
     provenance = (
         PUBLISHED_RUNTIME_PROVENANCE.get(everos_version)
@@ -107,14 +123,14 @@ def load_release_spec(manifest_path: Path) -> ReleaseSpec:
         else None
     )
     if payload.get("release_state") != "published" or provenance is None:
-        raise ReleaseGuardError("Memory Runtime manifest must describe a published supported EverOS version")
+        raise ManifestPolicyError("Memory Runtime manifest must describe a published supported EverOS version")
     if (
         payload.get("python_version") != provenance.python_version
         or payload.get("lock_sha256") != provenance.lock_sha256
         or payload.get("lock_id") != f"uv-lock-sha256:{provenance.lock_sha256}"
         or payload.get("uv_version") != provenance.uv_version
     ):
-        raise ReleaseGuardError("Memory Runtime manifest provenance is invalid")
+        raise ManifestPolicyError("Memory Runtime manifest provenance is invalid")
     sync_revision = payload.get("sync_bootstrap_revision")
     sync_argv = payload.get("sync_argv")
     sync_digest = payload.get("sync_bootstrap_sha256")
@@ -135,17 +151,17 @@ def load_release_spec(manifest_path: Path) -> ReleaseSpec:
             or len(sync_scrubbers_digest) != 64
             or any(character not in "0123456789abcdef" for character in sync_scrubbers_digest)
         ):
-            raise ReleaseGuardError("Memory Runtime sync bootstrap contract is invalid")
+            raise ManifestPolicyError("Memory Runtime sync bootstrap contract is invalid")
 
     release_tag = _required_string(payload, "release_tag", "manifest")
     release_root = f"{RELEASE_DOWNLOAD_ROOT}/{release_tag}"
     raw_archives = payload.get("archives")
     if not isinstance(raw_archives, dict) or set(raw_archives) != EXPECTED_PLATFORMS:
-        raise ReleaseGuardError("Memory Runtime manifest platform set is invalid")
+        raise ManifestPolicyError("Memory Runtime manifest platform set is invalid")
     archives: list[ArchiveSpec] = []
     for platform, raw in sorted(raw_archives.items()):
         if not isinstance(raw, dict):
-            raise ReleaseGuardError(f"archives.{platform} must be an object")
+            raise ManifestPolicyError(f"archives.{platform} must be an object")
         context = f"archives.{platform}"
         name = _required_string(raw, "name", context)
         url = _required_string(raw, "url", context)
@@ -154,17 +170,17 @@ def load_release_spec(manifest_path: Path) -> ReleaseSpec:
         bin_path = _required_string(raw, "bin_path", context)
         size = raw.get("size")
         if Path(name).name != name or url != f"{release_root}/{name}":
-            raise ReleaseGuardError(f"{context} is outside the pinned release")
+            raise ManifestPolicyError(f"{context} is outside the pinned release")
         if (
             len(sha256) != 64
             or len(binary_sha256) != 64
             or any(character not in "0123456789abcdef" for character in sha256 + binary_sha256)
         ):
-            raise ReleaseGuardError(f"{context} has an invalid digest")
+            raise ManifestPolicyError(f"{context} has an invalid digest")
         if not isinstance(size, int) or isinstance(size, bool) or not 0 < size <= MAX_ARCHIVE_BYTES:
-            raise ReleaseGuardError(f"{context}.size is invalid")
+            raise ManifestPolicyError(f"{context}.size is invalid")
         if Path(bin_path).is_absolute() or ".." in Path(bin_path).parts:
-            raise ReleaseGuardError(f"{context}.bin_path is unsafe")
+            raise ManifestPolicyError(f"{context}.bin_path is unsafe")
         archives.append(ArchiveSpec(platform, name, url, sha256, binary_sha256, size, bin_path))
     return ReleaseSpec(
         manifest_bytes=manifest_bytes,
@@ -178,22 +194,22 @@ def load_release_spec(manifest_path: Path) -> ReleaseSpec:
 def verify_release_assets(manifest_path: Path, asset_dir: Path) -> ReleaseSpec:
     spec = load_release_spec(manifest_path)
     if not asset_dir.is_dir():
-        raise ReleaseGuardError("Memory Runtime asset directory is missing")
+        raise ReleaseAssetError("Memory Runtime asset directory is missing")
     entries = list(asset_dir.iterdir())
     if any(path.is_symlink() or not path.is_file() for path in entries):
-        raise ReleaseGuardError("Memory Runtime asset directory contains unsafe entries")
+        raise ReleaseAssetError("Memory Runtime asset directory contains unsafe entries")
     actual = {path.name for path in entries}
     if actual != spec.expected_asset_names:
-        raise ReleaseGuardError(
+        raise ReleaseAssetError(
             f"Memory Runtime asset set mismatch: missing={sorted(spec.expected_asset_names - actual)}, "
             f"unexpected={sorted(actual - spec.expected_asset_names)}"
         )
     if (asset_dir / "memory-runtime-manifest.json").read_bytes() != spec.manifest_bytes:
-        raise ReleaseGuardError("published Memory Runtime manifest differs from the pinned manifest")
+        raise ReleaseAssetError("published Memory Runtime manifest differs from the pinned manifest")
     for archive in spec.archives:
         path = asset_dir / archive.name
         if path.stat().st_size != archive.size or _sha256(path) != archive.sha256:
-            raise ReleaseGuardError(f"Memory Runtime archive integrity mismatch: {archive.name}")
+            raise ReleaseAssetError(f"Memory Runtime archive integrity mismatch: {archive.name}")
         try:
             with tarfile.open(path, "r:gz") as bundle:
                 member = bundle.getmember(archive.bin_path)
@@ -219,13 +235,13 @@ def verify_release_assets(manifest_path: Path, asset_dir: Path) -> ReleaseSpec:
                         or marker is None
                         or marker.read() != b"import avibe_memory_sync_bootstrap\n"
                     ):
-                        raise ReleaseGuardError(
+                        raise ReleaseAssetError(
                             f"Memory Runtime sync contract mismatch: {archive.name}"
                         )
         except (KeyError, OSError, tarfile.TarError) as exc:
-            raise ReleaseGuardError(f"invalid Memory Runtime archive: {archive.name}") from exc
+            raise ReleaseAssetError(f"invalid Memory Runtime archive: {archive.name}") from exc
         if digest != archive.binary_sha256:
-            raise ReleaseGuardError(f"Memory Runtime binary integrity mismatch: {archive.name}")
+            raise ReleaseAssetError(f"Memory Runtime binary integrity mismatch: {archive.name}")
     return spec
 
 
@@ -248,21 +264,21 @@ def _download(url: str, destination: Path, expected_size: int, attempts: int = 3
                 except (TypeError, ValueError):
                     declared_size = None
                 if declared_size is not None and declared_size > expected_size:
-                    raise ReleaseGuardError(f"release asset exceeds manifest size: {url}")
+                    raise ReleaseAssetError(f"release asset exceeds manifest size: {url}")
                 downloaded = 0
                 while chunk := response.read(1024 * 1024):
                     downloaded += len(chunk)
                     if downloaded > expected_size:
-                        raise ReleaseGuardError(f"release asset exceeds manifest size: {url}")
+                        raise ReleaseAssetError(f"release asset exceeds manifest size: {url}")
                     output.write(chunk)
             return
-        except ReleaseGuardError:
+        except ReleaseAssetError:
             destination.unlink(missing_ok=True)
             raise
         except (OSError, urllib.error.URLError) as exc:
             destination.unlink(missing_ok=True)
             if attempt == attempts:
-                raise ReleaseGuardError(f"release asset download failed: {url}: {exc}") from exc
+                raise ReleaseAssetError(f"release asset download failed: {url}: {exc}") from exc
             time.sleep(float(attempt))
 
 
@@ -292,7 +308,7 @@ def fetch_release_assets(manifest_path: Path, output_dir: Path) -> ReleaseSpec:
     return spec
 
 
-def main() -> int:
+def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--manifest", type=Path, required=True)
     subparsers = parser.add_subparsers(dest="command", required=True)
@@ -300,16 +316,33 @@ def main() -> int:
     fetch.add_argument("--output-dir", type=Path, required=True)
     verify = subparsers.add_parser("verify")
     verify.add_argument("--asset-dir", type=Path, required=True)
-    args = parser.parse_args()
+    subparsers.add_parser("check-policy")
+    args = parser.parse_args(argv)
     try:
-        spec = (
-            fetch_release_assets(args.manifest, args.output_dir)
-            if args.command == "fetch"
-            else verify_release_assets(args.manifest, args.asset_dir)
+        if args.command == "fetch":
+            spec = fetch_release_assets(args.manifest, args.output_dir)
+        elif args.command == "verify":
+            spec = verify_release_assets(args.manifest, args.asset_dir)
+        else:
+            spec = load_release_spec(args.manifest)
+    except ManifestPolicyError as exc:
+        print(
+            json.dumps({"ok": False, "failure_kind": "policy", "error": str(exc)}),
+            file=sys.stderr,
         )
+        return POLICY_EXCLUSION_EXIT
+    except ReleaseAssetError as exc:
+        print(
+            json.dumps({"ok": False, "failure_kind": "bytes", "error": str(exc)}),
+            file=sys.stderr,
+        )
+        return ASSET_FAILURE_EXIT
     except ReleaseGuardError as exc:
-        print(json.dumps({"ok": False, "error": str(exc)}), file=sys.stderr)
-        return 1
+        print(
+            json.dumps({"ok": False, "failure_kind": "internal", "error": str(exc)}),
+            file=sys.stderr,
+        )
+        return INTERNAL_GUARD_FAILURE_EXIT
     print(json.dumps({"ok": True, "release_tag": spec.release_tag, "asset_count": len(spec.expected_asset_names)}))
     return 0
 

--- a/tests/test_memory_runtime_release_guard.py
+++ b/tests/test_memory_runtime_release_guard.py
@@ -77,20 +77,64 @@ def _manifest(
     return manifest, remote
 
 
-def test_guard_accepts_previous_published_runtime_provenance(tmp_path: Path) -> None:
-    previous = guard.PUBLISHED_RUNTIME_PROVENANCE["1.2.1"]
-    manifest, _ = _manifest(tmp_path, everos_version="1.2.1", lock_sha256=previous.lock_sha256)
+@pytest.mark.parametrize("everos_version", sorted(guard.PUBLISHED_RUNTIME_PROVENANCE))
+def test_guard_accepts_every_published_runtime_provenance(
+    tmp_path: Path,
+    everos_version: str,
+) -> None:
+    provenance = guard.PUBLISHED_RUNTIME_PROVENANCE[everos_version]
+    manifest, _ = _manifest(
+        tmp_path,
+        everos_version=everos_version,
+        lock_sha256=provenance.lock_sha256,
+    )
 
     spec = guard.load_release_spec(manifest)
 
     assert spec.release_tag == "v3.1.0"
 
 
+def test_guard_keeps_gh_v3_0_9rc3_runtime_in_coverage() -> None:
+    assert guard.PUBLISHED_RUNTIME_PROVENANCE["1.1.3"] == guard.RuntimeProvenance(
+        python_version="3.12.12",
+        lock_sha256="62b00f1a9ca04cc4ea4c5af51f389ba49acdea8786e5f7044d52823244502c57",
+        uv_version="0.9.18",
+    )
+
+
 def test_guard_rejects_unknown_runtime_provenance(tmp_path: Path) -> None:
     manifest, _ = _manifest(tmp_path, everos_version="1.2.2")
 
-    with pytest.raises(guard.ReleaseGuardError, match="published supported EverOS version"):
+    with pytest.raises(guard.ManifestPolicyError, match="published supported EverOS version"):
         guard.load_release_spec(manifest)
+
+
+def test_guard_cli_distinguishes_policy_rejection_from_missing_bytes(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    unsupported, _ = _manifest(tmp_path, everos_version="1.2.2")
+
+    policy_status = guard.main(["--manifest", str(unsupported), "check-policy"])
+    policy_result = json.loads(capsys.readouterr().err)
+
+    assert policy_status == guard.POLICY_EXCLUSION_EXIT
+    assert policy_result["failure_kind"] == "policy"
+
+    supported, _ = _manifest(tmp_path)
+    bytes_status = guard.main(
+        [
+            "--manifest",
+            str(supported),
+            "verify",
+            "--asset-dir",
+            str(tmp_path / "missing-assets"),
+        ]
+    )
+    bytes_result = json.loads(capsys.readouterr().err)
+
+    assert bytes_status == guard.ASSET_FAILURE_EXIT
+    assert bytes_result["failure_kind"] == "bytes"
 
 
 def _fake_download(remote: dict[str, bytes]):
@@ -99,7 +143,7 @@ def _fake_download(remote: dict[str, bytes]):
         try:
             payload = remote[url]
         except KeyError as exc:
-            raise guard.ReleaseGuardError(f"missing test asset: {url}") from exc
+            raise guard.ReleaseAssetError(f"missing test asset: {url}") from exc
         assert len(payload) == expected_size
         destination.write_bytes(payload)
 
@@ -206,7 +250,8 @@ def test_guard_workflow_has_scheduled_backup_and_non_clobbering_recovery() -> No
     )
 
     assert "schedule:" in workflow
-    assert "continue-on-error: true" in workflow
+    assert "continue-on-error: true" not in workflow
+    assert "steps.probe.outputs.result == 'bytes_failure'" in workflow
     assert "gh run download" in workflow
     assert "memory-runtime-release-backup-${{ matrix.manifest.sha256 }}" in workflow
     assert "retention-days: 90" in workflow
@@ -214,7 +259,7 @@ def test_guard_workflow_has_scheduled_backup_and_non_clobbering_recovery() -> No
     assert "--clobber" not in workflow
 
 
-def test_guard_workflow_verifies_every_published_manifest() -> None:
+def test_guard_workflow_reports_and_verifies_supported_published_manifests() -> None:
     workflow = (Path(__file__).resolve().parents[1] / ".github/workflows/memory-runtime-release-guard.yml").read_text(
         encoding="utf-8"
     )
@@ -223,5 +268,8 @@ def test_guard_workflow_verifies_every_published_manifest() -> None:
     resolution = resolution.split("  guard:", 1)[0]
     assert "manifests=" in resolution
     assert "break" not in resolution
+    assert "check-policy" in resolution
+    assert "Guarded Memory Runtime manifests" in resolution
+    assert "Excluded Memory Runtime manifests" in resolution
     assert "fromJSON(needs.resolve_manifests.outputs.manifests)" in workflow
     assert "matrix.manifest.release_tag" in workflow


### PR DESCRIPTION
## Capability

Restore the scheduled Memory Runtime release availability guard so published manifests remain protected without routing manifest-policy decisions through byte recovery.

## What changed

- Keep `gh-v3.0.9rc3` / EverOS `1.1.3` in the published provenance set. Its still-published wheel embeds that manifest and existing installs continue to resolve the pinned runtime assets from it.
- Classify manifest policy exclusions separately from missing or mismatched release bytes. Only byte failures can enter the recovery path.
- Resolve policy scope before matrix fan-out and print the complete guarded and excluded sets in both logs and the workflow summary.
- Remove the `continue-on-error` outcome ambiguity and route recovery from the probe's typed result.

## Coverage decision

The guard coverage set does **not** shrink: all 15 currently published Memory Runtime manifests are guarded, including `gh-v3.0.9rc3`; the current excluded set is empty. Wheels that predate the embedded Memory Runtime manifest are not Memory Runtime release candidates and are not reported as policy exclusions.

## Known by design

- A published manifest excluded by policy is reported with its tag and reason in the log and Step Summary, but does not fail this availability guard and cannot enter byte recovery. This preserves the task contract that red means guarded bytes are unavailable or inconsistent; policy-scope decisions remain visible without masking integrity incidents behind a permanent red.

## Evidence

- Unit: 39 focused Memory Runtime release, guard, and sync-contract tests pass.
- Contract: all 15 manifests from the failing scheduled run pass the new policy check; the `gh-v3.0.9rc3` release manifest and all three pinned archives were downloaded and verified against manifest sizes, archive digests, and embedded Python digests.
- Scenario: N/A; no scenario catalog covers this release-maintenance workflow.
- GitHub-hosted workflow: [`workflow_dispatch` run 31923612782](https://github.com/avibe-bot/avibe/actions/runs/31923612782) passed on exact head `54e68107ba`; all 15 manifests were guarded, none were excluded, `gh-v3.0.9rc3` produced `result=verified`, and its manifest-keyed backup artifact was created.
- Residual manual: none for this workflow change; the first post-merge scheduled run remains the production cadence confirmation.

## Dependencies

None.
