### PR TITLE
docs(config): ratify the patch-write plan for config write safety

### DIFF
--- a/config/v2_config.py
+++ b/config/v2_config.py
@@ -3530,7 +3530,19 @@ class V2Config:
         return config
 
     def save(self, config_path: Optional[Path] = None) -> None:
-        """Persist non-Memory changes while preserving the durable Memory unit."""
+        """Persist non-Memory changes while preserving the durable Memory unit.
+
+        WARNING — cross-process lost updates: this writes the object's
+        FULL snapshot. If this ``V2Config`` was loaded earlier (another
+        request, minutes ago) while a different process (UI API server
+        vs controller, both write this file) committed changes since,
+        saving here silently reverts them. UI/controller writers must
+        instead declare their change through ``update_config_fields``
+        (see docs/plans/config-cross-process-write-serialization.md),
+        which loads fresh inside the cross-process file lock and only
+        applies the caller's fields. Direct load → mutate → ``save()``
+        cycles are only acceptable in single-writer contexts.
+        """
 
         if self.load_warnings:
             raise ValueError(

--- a/docs/plans/config-cross-process-write-serialization.md
+++ b/docs/plans/config-cross-process-write-serialization.md
@@ -62,6 +62,8 @@ Migrate every remaining direct writer to `update_config_fields`:
    controller write between load and save is overwritten); callers that
    pass a full snapshot rather than a partial payload are reclassified
    as snapshot overwrites and narrowed to the fields they own.
+   Read-decide-write callers (compare-then-assign) keep their decision
+   INSIDE the transaction mutator on the freshly loaded config.
 2. `core/handlers/model_hub/service.py` — model_hub section save.
 3. `vibe/api.py` codex auth save mirror + claude auth save mirror.
 4. `vibe/api.py` remove-key V2Config clear.
@@ -73,7 +75,18 @@ Migrate every remaining direct writer to `update_config_fields`:
    preserve both failure guarantees across an external-file write.
 6. `vibe/api.py:7047` agent install cli_path update,
    `vibe/api.py:7325` avault install cli_path update,
-   `vibe/api.py:11900` opencode default-provider clear.
+   `vibe/api.py:11900` opencode default-provider clear. The clear site
+   is read-decide-write (compare current default before clearing), so
+   its comparison AND assignment run on the freshly loaded config
+   inside the transaction mutator — not decisions outside, assignment
+   inside — otherwise a concurrent default switch to another provider
+   still gets cleared.
+7. First-run config creators: `vibe/runtime.py:149-151` and
+   `core/services/settings.py:83-87` both check-for-absence outside the
+   file lock then `default.save()`. Migrate to an atomic
+   create-if-absent transaction (load-or-default inside the lock, save
+   only when the file was absent) so a delayed first-run snapshot cannot
+   overwrite an initial settings save another process completed.
 
 Non-goals: no schema change, no file split, no new IPC, no guards.
 

--- a/docs/plans/config-cross-process-write-serialization.md
+++ b/docs/plans/config-cross-process-write-serialization.md
@@ -1,0 +1,73 @@
+# Plan: Config Write Safety — Patch Writes (#1458)
+
+Status: ratified (owner decision 2026-08-15)
+Tracker: GitHub issue #1458 (filed from PR #1455 review, discussion_r3788721089)
+Supersedes: the draft version of this document referenced by PR #1465
+(which existed only as an untracked file in the primary checkout — that
+dangling reference is repaired by landing this document).
+
+## Problem
+
+`config.json` has full-snapshot read-modify-write writers in two
+long-lived processes (UI API server, controller) plus potential
+short-lived CLI processes. `CONFIG_LOCK` is process-local, so:
+
+```
+t0  UI:  load  → snapshot_UI        (contains old codex.auth_mode)
+t1  CTL: load  → snapshot_CTL       (contains old slack token)
+t2  CTL: mutate + save              ✅
+t3  UI:  mutate + save              ← writes snapshot_UI: reverts CTL's t2 fields
+```
+
+Writes are already serialized (the Memory transaction flock covers each
+`save()`); the defect is **lost updates** — non-Memory fields are written
+from snapshots loaded outside the lock. Whole-file READ is fine (startup
+and decisions need a consistent view); **whole-file WRITE is the defect**.
+
+## Root-cause framing (owner decision)
+
+The fix is a dataflow-shape correction, not locking or discipline:
+
+> Writers must declare **patches** ("set these fields"), never
+> **snapshot overwrites** ("here is my new version of the world").
+
+A patch composes with concurrent changes (given one serialization of the
+read-merge-write cycle); a snapshot overwrite silently reverts them.
+
+## Options weighed
+
+| Option | Verdict |
+| --- | --- |
+| **Patch writes** — typed mutators (`update_config_fields`) / payload merges (`save_config`) | ✅ **Ratified.** The fix. |
+| Cross-process flock around whole RMW (generalize Memory transaction) | ✅ Landed as the serialization substrate (#1465); not sufficient alone — still needs patch-shaped writers. |
+| Single-writer via controller IPC (declarative patches over the dispatch socket) | ⏸️ Parked. Removes the need for cross-process discipline AND would simplify the controller-memory reconciliation dance, but patch semantics + flock already eliminate the race; revisit when reconciliation pain grows. |
+| Split `config.json` into per-section files | ❌ Rejected. Shipped-surface migration for a blast-radius reduction only — same-section races (codex auth vs marker, the confirmed conflict pair) remain. |
+| Dirty-tracking `save()` (auto-merge changed fields) | ❌ Rejected. Invasive across all config dataclasses; in-place mutations of dict/list fields bypass `__setattr__` — correctness holes. |
+| Move config into SQLite | ❌ Rejected. Disproportionate. |
+| CI grep guard + AGENTS.md convention ("direct load→save is a defect") | ❌ Dropped (owner). Detail belongs at the chokepoint: the `V2Config.save()` / `update_config_fields` docstrings already carry the warning where writers browse. No global doc, no guard. |
+
+## Landed
+
+- **#1465** (`config_write_transaction` / `update_config_fields` primitive
+  + 5 narrow field writers migrated: relay marker, language ×2, opencode
+  default_provider, rotate_session_secret; real two-process lock-contract
+  test).
+
+## Remaining — stage ③ (the close-out)
+
+Migrate the section writers to `update_config_fields`:
+
+1. `core/handlers/model_hub/service.py` — model_hub section save
+2. `vibe/api.py` codex auth save cluster (`save_codex_auth` mirror write)
+3. `vibe/api.py` claude auth save cluster
+4. `vibe/api.py` remove-key V2Config clear
+5. `core/agent_auth_service.py` auth-mode persist (3 sites; the marker
+   pre-persist folds into the transaction, removing the two-step dance)
+
+Non-goals: no schema change, no file split, no new IPC, no guards.
+
+## Close criteria for #1458
+
+Stage ③ merged → every cross-process `config.json` writer is
+patch-shaped under the transaction → issue closed with a pointer to the
+parked single-writer option.

--- a/docs/plans/config-cross-process-write-serialization.md
+++ b/docs/plans/config-cross-process-write-serialization.md
@@ -38,13 +38,13 @@ read-merge-write cycle); a snapshot overwrite silently reverts them.
 
 | Option | Verdict |
 | --- | --- |
-| **Patch writes** — typed mutators (`update_config_fields`) / payload merges (`save_config`) | ✅ **Ratified.** The fix. |
+| **Patch writes** — typed mutators (`update_config_fields`) | ✅ **Ratified.** The fix. `save_config` is NOT yet patch-shaped: its base snapshot loads outside the file lock and several callers pass full snapshots — its read-merge-write cycle moves to stage ③ below. |
 | Cross-process flock around whole RMW (generalize Memory transaction) | ✅ Landed as the serialization substrate (#1465); not sufficient alone — still needs patch-shaped writers. |
 | Single-writer via controller IPC (declarative patches over the dispatch socket) | ⏸️ Parked. Removes the need for cross-process discipline AND would simplify the controller-memory reconciliation dance, but patch semantics + flock already eliminate the race; revisit when reconciliation pain grows. |
 | Split `config.json` into per-section files | ❌ Rejected. Shipped-surface migration for a blast-radius reduction only — same-section races (codex auth vs marker, the confirmed conflict pair) remain. |
 | Dirty-tracking `save()` (auto-merge changed fields) | ❌ Rejected. Invasive across all config dataclasses; in-place mutations of dict/list fields bypass `__setattr__` — correctness holes. |
 | Move config into SQLite | ❌ Rejected. Disproportionate. |
-| CI grep guard + AGENTS.md convention ("direct load→save is a defect") | ❌ Dropped (owner). Detail belongs at the chokepoint: the `V2Config.save()` / `update_config_fields` docstrings already carry the warning where writers browse. No global doc, no guard. |
+| CI grep guard + AGENTS.md convention ("direct load→save is a defect") | ❌ Dropped (owner). Detail belongs at the chokepoint: the `V2Config.save()` and `update_config_fields` docstrings carry the warning where writers browse. No global doc, no guard. |
 
 ## Landed
 
@@ -55,14 +55,25 @@ read-merge-write cycle); a snapshot overwrite silently reverts them.
 
 ## Remaining — stage ③ (the close-out)
 
-Migrate the section writers to `update_config_fields`:
+Migrate every remaining direct writer to `update_config_fields`:
 
-1. `core/handlers/model_hub/service.py` — model_hub section save
-2. `vibe/api.py` codex auth save cluster (`save_codex_auth` mirror write)
-3. `vibe/api.py` claude auth save cluster
-4. `vibe/api.py` remove-key V2Config clear
-5. `core/agent_auth_service.py` auth-mode persist (3 sites; the marker
-   pre-persist folds into the transaction, removing the two-step dance)
+1. `vibe/api.py` `save_config` — serialize the WHOLE read-merge-write
+   cycle (base load currently happens outside the file lock, so a
+   controller write between load and save is overwritten); callers that
+   pass a full snapshot rather than a partial payload are reclassified
+   as snapshot overwrites and narrowed to the fields they own.
+2. `core/handlers/model_hub/service.py` — model_hub section save.
+3. `vibe/api.py` codex auth save mirror + claude auth save mirror.
+4. `vibe/api.py` remove-key V2Config clear.
+5. `core/agent_auth_service.py` auth-mode persist (3 sites). The
+   relay-marker pre-persist boundary is **retained as-is**: the marker
+   must be durable BEFORE `_clear_codex_api_key_for_oauth()` destroys
+   its only on-disk source, while the auth-mode mirror must only land
+   AFTER the external codex files updated — one transaction cannot
+   preserve both failure guarantees across an external-file write.
+6. `vibe/api.py:7047` agent install cli_path update,
+   `vibe/api.py:7325` avault install cli_path update,
+   `vibe/api.py:11900` opencode default-provider clear.
 
 Non-goals: no schema change, no file split, no new IPC, no guards.
 


### PR DESCRIPTION
## Changed capability

Config write safety design record (#1458).

## Why

PR #1465's description references `docs/plans/config-cross-process-write-serialization.md`, but that document existed only as an untracked file in the primary checkout — a dangling reference. This PR lands the ratified version and records the decision history.

## Decision summary

- **Ratified fix**: patch writes (typed mutators / payload merges) — a dataflow-shape correction, not locking or discipline. Whole-file read stays; whole-file write is the defect (lost updates).
- **Already landed**: #1465 (transaction substrate + 5 narrow writers).
- **Remaining**: stage ③ — migrate the 6 section-writer sites; closes #1458.
- **Rejected**: per-section file split (same-section races remain, shipped-surface migration), dirty-tracking save (in-place mutation holes), SQLite (disproportionate).
- **Dropped per owner**: CI grep guard + AGENTS.md convention — the warning lives in the `save()` / `update_config_fields` docstrings at the chokepoint, not global docs.
- **Parked**: single-writer via controller IPC — revisit when the reconciliation dance's pain grows.

## Evidence layers

- Unit/contract/scenario: none (documentation).
- Residual manual: none.

## Dependencies

None.
