### PR TITLE
docs(show): design unified access and capability-gated HMR

### DIFF
--- a/docs/plans/public-show-live-update.md
+++ b/docs/plans/public-show-live-update.md
@@ -536,25 +536,40 @@ unclassified error is application-authored. This reduced compatibility surface i
 temporary because the capability ships with the bundled Runtime.
 
 Vite's native `/@fs/<absolute-path>` form cannot cross that shared boundary.
-When a shared transform references an allowed absolute file, Runtime opens it
-through a confinement-safe root descriptor: resolution cannot escape the selected
-allowed root or traverse a symlink prohibited by the existing policy, the final
-descriptor is verified against the allowed-root and sensitive-segment policy, and
-bounded bytes are copied into a namespace-owned immutable snapshot.
-Runtime compares descriptor metadata before and after the copy and rejects a file
-that changes during capture. It then allocates a stable opaque handle from a
-Runtime-process secret, the Session, the current share generation, the namespace,
-and the snapshot digest, not from a pathname.
+When a shared Vite resolve produces an allowed absolute request ID, Runtime retains
+its complete transform identity server-side: the resolved pathname, query-qualified
+loader mode such as `?raw` or `?worker`, importer identity, and representation type.
+It opens the file through a confinement-safe root descriptor: resolution cannot
+escape the selected allowed root or traverse a symlink prohibited by the existing
+policy, the final descriptor is verified against the allowed-root and
+sensitive-segment policy, and bounded bytes are copied into a namespace-owned
+immutable snapshot. Runtime compares descriptor metadata before and after the copy
+and rejects a file that changes during capture. It then binds the snapshot and
+transform identity to a namespace-local virtual module ID; neither that ID nor its
+browser handle is derived from or reveals the pathname.
+
+An opaque handle never means "serve the captured source bytes". Registry entries are
+typed as either an immutable asset response or an immutable virtual-module request.
+Assets may use their captured bytes and verified media type directly. Modules,
+stylesheets, and query-qualified loaders run through the same Vite
+resolve/load/transform semantics as their original request, but a context-scoped
+virtual-module plugin supplies the captured bytes and resolves every discovered
+dependency through the same confinement, snapshot, and opaque-handle pipeline. The
+query, importer conditions, transformed body, content type, safe response headers,
+provenance, and rewritten dependency handles are committed together. A transform
+that asks for an uncaptured mutable path, cannot resolve a nested dependency, or
+cannot produce a complete browser response fails closed; it cannot fall back to raw
+source delivery.
 
 The browser receives only
 `/p/<share>/__avibe_asset/<namespace>/<handle>`; Runtime's process-local registry
-serves the immutable snapshot inside the matching shared namespace and never
-reopens the source path for a handle read. Replacing the original file or any
-parent with a symlink therefore cannot retarget an existing handle. A later valid
-source edit creates a new snapshot in a new transformed graph; a newly unsafe path
-is rejected before allocation. A browser cannot submit a raw `/@fs/` path or mint a
-mapping, handles reveal no path bytes, and share rotation or Runtime replacement
-prevents new admission into the old namespace.
+serves the committed asset or transformed response inside the matching shared
+namespace and never reopens the source path for a handle read. Replacing the original
+file or any parent with a symlink therefore cannot retarget an existing handle. A
+later valid source edit creates a new snapshot and transformed response in a new
+graph; a newly unsafe path is rejected before allocation. A browser cannot submit a
+raw `/@fs/` path or mint a mapping, handles reveal no path bytes, and share rotation
+or Runtime replacement prevents new admission into the old namespace.
 
 Each transformed entry graph owns both a 30-minute idle namespace lease and a
 non-renewable two-hour absolute lifetime measured from admission. A successful
@@ -988,6 +1003,10 @@ limited route.
 - unprivileged documents reference only shared paths, opaque immutable-snapshot
   handles, and immutable shims; raw `/@fs/`, host paths, and Session paths are
   denied
+- absolute TSX, CSS, `?raw`, and `?worker` dependencies are captured into virtual
+  modules and retain their original Vite transform semantics; recursively emitted
+  imports receive handles from the same namespace, and no handle returns raw
+  non-browser source as a successful response
 - Runtime response provenance preserves authored application errors while every
   development diagnostic receives a fixed shared body; unsafe `SourceMap`,
   `X-SourceMap`, `Content-Location`, `Refresh`, `Location`, and `Link` values are
@@ -1004,7 +1023,8 @@ limited route.
   the private-editor reserve, and returns sanitized overload responses when nothing
   is reclaimable
 - after handle allocation, replace the source or any parent with an out-of-root or
-  sensitive symlink; the old handle serves only its captured immutable bytes, a new
+  sensitive symlink; an asset handle serves only its captured bytes, a module handle
+  serves only the response transformed from its captured virtual graph, a new
   allocation is denied, and no handle read reopens the pathname
 - `/p/<share>/__vite_hmr` rejects every connection
 - private document/module requests retain resource-reader ACL; private HMR repeats
@@ -1040,7 +1060,7 @@ limited route.
 | `SHOW-LIVE-013` | Shared content registers a share-scoped Service Worker, then the editor opens the link | No private bytes are served at `/p/`; any network-reached redirect lands outside the worker scope at `/show/`, and cached old bytes are recorded as a client-cache limitation |
 | `SHOW-LIVE-014` | Avibe runs against a Runtime without `show-context-key-v1` | Every `/p/` viewer stays on the compatibility no-HMR path; the existing single-context limitation is explicit and cannot be mistaken for negotiated isolation |
 | `SHOW-LIVE-015` | The first capability probe times out while the new Runtime app endpoint is ready | The request carries `shared` and succeeds, a later bounded retry detects support, and the next eligible navigation redirects without restart |
-| `SHOW-LIVE-016` | Shared transforms emit nested `/@fs/` imports, URL-bearing headers, and Vite errors | Only leased context-bound handles and safe rewritten headers reach the browser; every development error is fixed and path-free |
+| `SHOW-LIVE-016` | Shared transforms emit nested `/@fs/` TSX, CSS, `?raw`, and `?worker` imports, URL-bearing headers, and Vite errors | Each handle serves a complete browser response transformed from the immutable virtual graph with recursively rewritten same-namespace dependencies; raw source, paths, and development errors never reach the browser |
 | `SHOW-LIVE-017` | Startup reconciliation and `vibe show update` prewarm shared and private graphs | Each request carries its typed context; a missing/invalid context fails before creating or rebasing either graph |
 | `SHOW-LIVE-018` | Direct CLI changes an active page to offline with private HMR connected | The coalesced durable monitor closes every socket for the Session within five seconds without relying on an in-process event |
 | `SHOW-LIVE-019` | Public changes to limited and the cloud write fails | The target limited mode and original binding remain durable with the gate closed; neither anonymous nor stale listed viewers can read until reconciliation succeeds |
@@ -1129,9 +1149,12 @@ The design is implemented when all of the following are true:
   editor, and fails closed for unclassified errors or graphs that need raw absolute
   paths; missing provenance cannot expose a development diagnostic.
 - Shared file references use leased context-bound opaque handles backed by bounded
-  immutable snapshots captured through confinement-safe opens; handle reads never
-  reopen mutable pathnames. Raw absolute paths, unsafe URL-bearing response headers,
-  and Runtime development diagnostics never reach the browser.
+  immutable snapshots captured through confinement-safe opens. Asset handles serve
+  captured bytes, while module, stylesheet, and query-qualified handles serve
+  committed responses produced through context-scoped virtual-module transforms;
+  handle reads never reopen mutable pathnames or return raw module source. Raw
+  absolute paths, unsafe URL-bearing response headers, and Runtime development
+  diagnostics never reach the browser.
 - The access-schema migration is restartable, idempotent, revision-bound, and
   explicitly one-way. Avibe never starts an older executable against migrated state;
   no legacy audience projection or cross-version writer is part of the contract.

--- a/docs/plans/public-show-live-update.md
+++ b/docs/plans/public-show-live-update.md
@@ -409,20 +409,27 @@ is rejected before allocation. A browser cannot submit a raw `/@fs/` path or min
 mapping, handles reveal no path bytes, and share rotation or Runtime replacement
 prevents new admission into the old namespace.
 
-Each transformed entry graph owns one bounded 30-minute idle namespace lease.
-Every successful document, module, or lazy-asset read refreshes its lease. The
-current namespace is pinned; superseded namespaces are reclaimed only after 30 minutes
-with no request, and reclamation removes the whole namespace rather than
-individual handles. A document that remains idle beyond the lease may fail a
-later lazy import and must reload; it never receives a handle from another graph.
-The Runtime bounds namespaces and handles globally and per Session. When every
-slot is actively leased, new admission fails closed instead of evicting a live
-namespace. Snapshot bytes count against the same global and per-Session bounds and
-are reclaimed with their namespace. Thus loaded documents retain their complete
-referenced set during the lease, while successive edits and rotations cannot
-permanently consume capacity: expiry releases snapshot bytes without a process
-restart. The same chokepoint covers every emitted URL, including an absolute path
-nested inside another Vite URL.
+Each transformed entry graph owns both a 30-minute idle namespace lease and a
+non-renewable two-hour absolute lifetime measured from admission. A successful
+document, module, or lazy-asset read may refresh only the idle deadline; anonymous
+traffic cannot extend the absolute deadline. The current namespace is protected
+from idle reclamation, but not from its absolute deadline or process-wide resource
+pressure. Reclamation removes the whole namespace rather than individual handles.
+After either deadline a later module or lazy import receives a fixed stale-document
+response and the browser must reload; it never receives a handle from another graph.
+
+The Runtime admits namespaces, handles, and snapshot bytes through the same
+process-wide weighted budget used for shared Vite contexts, with additional
+per-Session limits. Before rejecting admission it reclaims expired namespaces and
+then the oldest shared bundle that has no request in flight, even if public reads
+kept that bundle recently active. In-flight work is pinned only until its response
+finishes. When no shared bundle is reclaimable, new shared admission fails closed
+with a sanitized retryable unavailable response; it cannot consume the capacity
+reserved for private editor contexts. Snapshot bytes count against the same bounds
+and are reclaimed with their namespace. Thus a loaded document normally retains
+its complete referenced set during the lease, while recorded old public URLs cannot
+pin capacity indefinitely. The same chokepoint covers every emitted URL, including
+an absolute path nested inside another Vite URL.
 
 Runtime also labels every loopback response as `application`, `asset`, or
 `development-diagnostic` in a stripped response metadata header. Avibe forwards
@@ -507,7 +514,7 @@ The model adds authorization routing, not a production publication pipeline:
 | Authorized editor opens `/p/` | Existing session/resource decision, one redirect, canonical Vite transforms, and one private HMR socket |
 | Limited exact-email viewer opens `/p/` | One current authorization decision plus shared transforms and shims; no socket or annotation bootstrap |
 | Public unprivileged viewer opens `/p/` | Existing shared transforms and shims from an isolated context when negotiated, or the explicit legacy compatibility path; no socket |
-| Both modes are active | Up to two Vite contexts for the Session; only the private context maintains HMR clients |
+| Both modes are active | Up to two Vite contexts for the Session; only the private context maintains HMR clients, and both count against the Runtime-wide budget |
 | Agent edit | Private context pushes HMR; shared context does no work until the next allowed `/p/` request or refresh |
 | Active private HMR sockets | One coalesced durable availability read per Session on a cadence no greater than five seconds |
 
@@ -521,11 +528,20 @@ After its one redirect, an authorized `/p/` load should have the same cold and
 warm profile as `/show/`.
 The negotiated isolated shared context can increase Runtime memory when authorized and
 share-link viewers are active simultaneously, but avoids production builds,
-artifact storage, SSE fanout, and anonymous sockets. Runtime must expose context
-count and memory so local Incus regression can set a per-Session idle eviction
-budget from measurements rather than an assumed universal threshold. Opaque shared
-path mappings are process-local, share-generation-bound, leased, and admission-bounded;
-capability probes are process-cached or backoff-limited rather than added to every
+artifact storage, SSE fanout, and anonymous sockets. Runtime owns one process-wide
+weighted admission controller over private/shared Vite contexts, opaque namespaces,
+handles, and snapshot bytes. It enforces hard context-count and memory-cost limits
+plus per-Session limits. Finite conservative defaults and a nonzero private-editor
+reserve ship with the feature; configuration can tune them only to another finite
+value, with increases justified by local Incus measurements. The reserved slice
+cannot be consumed by shared traffic; private admission may reclaim any shared
+bundle with no request in flight. Shared bundles are oldest-admitted reclaimable
+between requests and have the same non-renewable two-hour maximum lifetime as their
+namespaces, so a set of active anonymous Sessions cannot pin them forever. If all
+eligible capacity is in flight, shared requests receive a bounded sanitized
+overload response rather than growing the sidecar. Runtime exposes
+admitted/reclaimed/rejected counts and measured memory for release tuning.
+Capability probes are process-cached or backoff-limited rather than added to every
 request.
 
 ## Failure And Revocation Behavior
@@ -540,6 +556,8 @@ request.
 | Transient capability negotiation failure | Send the backward-compatible explicit `shared` context, keep the current allowed request shared, and retry after bounded backoff | Redacted probe state and retry metric |
 | Private Runtime unavailable after an editor redirect | Existing private sanitized recovery behavior; never fall through to a raw shared-route socket | Private Runtime log |
 | Shared context unavailable | Existing sanitized shared unavailable/static fallback | Shared Runtime log without source detail |
+| Shared Runtime admission is saturated | Reclaim the oldest non-in-flight shared bundle; if none is reclaimable, return a sanitized retryable unavailable response without consuming the private reserve | Global weighted-budget admission/reclamation metric |
+| A shared document outlives its absolute namespace/context lifetime | Return a fixed stale-document response for later module or lazy-asset reads and require reload | Namespace hard-expiry metric without source paths |
 | Runtime emits a development diagnostic or unsafe URL header | Preserve only a safe status class/body and filtered headers | Redacted operator-only diagnostic |
 | Limited-list replacement has an ambiguous result | Keep the durable page-email gate closed across retries and restarts until read-after-write reconciliation persists the exact mutation result | Mutation ID, target digest, and redacted reconciliation state |
 | Limited email removed | Reject the viewer's next network request and invalidate its stale revision; no HMR or annotation channel exists to close | Authorization-revision log |
@@ -643,9 +661,10 @@ feature, not a prerequisite for capability-gated editor HMR.
    requiring editor capability for HMR, annotation writes, and share-link
    redirect selection.
 9. Add leased opaque shared file namespaces backed by immutable bounded snapshots,
+   the process-wide weighted Runtime admission controller with a private reserve,
    Runtime response provenance, and URL-bearing header filtering so raw `/@fs/`
-   paths, mutable-path handles, and development diagnostics cannot cross the
-   shared boundary.
+   paths, mutable-path handles, anonymous resource pinning, and development
+   diagnostics cannot cross the shared boundary.
 10. Add the coalesced durable availability monitor for private HMR sockets.
 11. Add cache, Service Worker scope, network-revocation, mixed-version,
     negotiation retry, total context propagation, concurrency, rollback-write,
@@ -674,11 +693,17 @@ The schema migration separates availability from audience and is fail-closed:
 | `visibility=offline` | `offline` | `private` | Clear; the old model did not retain a trustworthy prior audience |
 
 Until the device can read the hosted grant set, an old private page stays
-private and records migration pending; it is never guessed to be limited. An old
-public page remains public, and any independently stored email set is cleared
-after the local public state is authoritative. Organization resource policies
-are not mapped into external audience modes; they remain canonical `/show/`
-collaborator policy.
+private and records migration pending with the source `audience_revision` and
+legacy-marker generation; it is never guessed to be limited. Reconciliation may
+commit only with a compare-and-swap proving that both values are still current.
+Every authoritative audience Apply and every reconciled legacy write increments
+`audience_revision` and deletes any pending migration in the same local transaction
+before remote work begins. A stale worker discards its hosted read and any provisional
+share allocation when that compare-and-swap fails; it cannot convert a newer public
+or private choice to `limited`. An old public page remains public, and any
+independently stored email set is cleared after the local public state is
+authoritative. Organization resource policies are not mapped into external audience
+modes; they remain canonical `/show/` collaborator policy.
 
 The compatibility read API projects old `visibility` fields for one rollback
 window, and new writes maintain a safe projection: public maps to old `public`,
@@ -704,6 +729,20 @@ and only then clears the marker. A rollback therefore treats `limited` as privat
 because older code cannot enforce its `/p/` authentication gate, while a later
 private/offline write by that old binary cannot be overwritten by stale
 `ShowAccess` on re-upgrade.
+
+Binary downgrade has a fail-closed preflight before the current executable or
+compatibility schema is replaced. The updater acquires the audience coordinator's
+exclusive write lock, holds it through service quiescence and executable/schema
+replacement, and under that lock requires the hosted resolver to be reachable, no
+audience transition or migration to be pending, every ambiguous mutation result to
+be reconciled, and every non-`limited` page to have an empty hosted email set with
+the resulting authorization revision persisted locally. A `limited` page is
+rollback-compatible only while its gate is open on that exact reconciled set. If
+cleanup or revocation is pending, downgrade is refused and the current binary and
+schema remain intact; retrying cleanup is the only recovery. This is the
+rollback-compatible barrier enforced by the old `/show/` serving path: it never
+starts in a state where a non-`limited` page still has a usable `show_page_email`
+claim, even though the old binary does not understand `page_email_gate`.
 
 ## Verification Plan
 
@@ -740,6 +779,12 @@ private/offline write by that old binary cannot be overwritten by stale
   and re-upgrade round trip; the legacy-write marker must preserve the last user
   action, including an unchanged-value private assignment, and ambiguous state must
   fail closed
+- leave an upgrade migration pending, perform a newer audience Apply, then restore
+  connectivity; the source-revision compare-and-swap discards the stale migration
+  and cannot allocate or reopen a limited audience
+- attempt downgrade while a limited-to-private/public cleanup or mutation result is
+  pending; preflight preserves the current binary and schema until hosted grants are
+  empty and the authorization revision is reconciled
 - interrupt every limited-list mutation before send, after backend commit, after a
   lost response, and before local revision persistence; the durable page-email gate
   stays closed across process restart until the exact mutation result reconciles
@@ -769,8 +814,12 @@ private/offline write by that old binary cannot be overwritten by stale
   `X-SourceMap`, `Content-Location`, `Refresh`, `Location`, and `Link` values are
   stripped or safely rewritten
 - old opaque namespaces survive lazy loads while leased, expire as a whole after
-  30 idle minutes, never cross graph/share boundaries, and do not make admission
-  capacity permanently consumable across successive edits
+  30 idle minutes or the non-renewable two-hour lifetime, never cross graph/share
+  boundaries, and cannot be kept admitted by anonymous reads
+- active public traffic across more Sessions than the process-wide context and
+  memory budget remains bounded, reclaims only non-in-flight shared bundles, preserves
+  the private-editor reserve, and returns sanitized overload responses when nothing
+  is reclaimable
 - after handle allocation, replace the source or any parent with an out-of-root or
   sensitive symlink; the old handle serves only its captured immutable bytes, a new
   allocation is denied, and no handle read reopens the pathname
@@ -817,6 +866,10 @@ private/offline write by that old binary cannot be overwritten by stale
 | `SHOW-LIVE-022` | Limited changes to private while hosted cleanup is unavailable | A stale page-email cookie is rejected on both `/p/` and `/show/`; independent resource collaborators retain their canonical access |
 | `SHOW-LIVE-023` | A public page upgrades, rolls back, is set private by the old binary, then re-upgrades | The legacy marker wins and the page stays private; stale `ShowAccess` cannot reopen anonymous access |
 | `SHOW-LIVE-024` | An allowed source is replaced by a sensitive symlink after an opaque handle is issued | The issued handle returns only immutable captured bytes, and the changed path cannot receive a new handle |
+| `SHOW-LIVE-025` | A disconnected private-page migration is pending, then the owner chooses public and later private before reconnecting | The newer revision cancels migration; reconnect cannot allocate a slug, commit limited, or restore the old email audience |
+| `SHOW-LIVE-026` | Limited changes to private while hosted cleanup is unavailable, then binary downgrade is requested | Downgrade is refused without replacing executable/schema; it succeeds only after grants are empty and the new revision is reconciled |
+| `SHOW-LIVE-027` | An anonymous client reads every superseded namespace just before each idle deadline | Each namespace still reaches its non-renewable hard expiry, releases all snapshot bytes, and requires stale documents to reload |
+| `SHOW-LIVE-028` | Anonymous clients keep shared pages active across more Sessions than the Runtime-wide budget | Context and memory stay under the hard limit, reclaimable shared bundles rotate, private HMR keeps its reserve, and excess shared admission is sanitized |
 
 Focused unit/contract tests, Ruff, repository CI, and local Incus browser
 regression are required. Green unit tests do not replace simultaneous editor,
@@ -869,6 +922,12 @@ The design is implemented when all of the following are true:
 - Compatibility rollback writes are durably marked and reconciled before serving,
   so a private/offline change made by an old binary cannot be overwritten by stale
   `ShowAccess` after re-upgrade.
+- Pending legacy migration is revision-bound and cancelled by every newer audience
+  mutation; downgrade cannot begin while stale hosted email authority could be
+  accepted by the old serving path.
+- Shared Vite contexts, opaque namespaces, handles, and snapshot bytes share one
+  Runtime-wide weighted budget with a private-editor reserve and non-renewable
+  lifetimes, so anonymous traffic cannot pin admission indefinitely.
 - Direct durable offline mutations close active private HMR within five seconds;
   share rotation alone does not revoke entitled canonical private access.
 - Authorization failure preserves fully public availability, fails limited access

--- a/docs/plans/public-show-live-update.md
+++ b/docs/plans/public-show-live-update.md
@@ -130,22 +130,41 @@ cannot read these settings APIs, mutate the audience, load the Workbench, or
 promote itself through a broader Instance endpoint.
 
 Audience changes use one Apply action and one durable fail-closed coordinator
-rather than three independent writes. Every Apply allocates a client mutation ID
-and first commits a local transition record containing the source revision, target
-mode/set, and phase. Any transition that can add, remove, or replace page-email
-authority also sets `page_email_gate=closed_pending` in that same transaction.
-While that durable barrier exists, neither `/p/` nor the page-email branch of the
-canonical `/show/` ACL accepts a page-email claim, including a claim minted before
-the transition. Owner and organization resource ACLs remain independent.
+rather than three independent writes. Every Apply allocates a client mutation ID.
+For a change that carries exact emails, the device first sends the normalized
+in-memory target and expected authorization revision to a backend `prepare`
+operation. Preparation stores the target only inside the existing hosted grant
+trust boundary, changes no grant authority, and returns an opaque operation ID plus
+target digest. A prepared operation has a non-renewable 24-hour lifetime. If this
+step fails or its response is lost, no local transition is accepted and the
+previous audience remains authoritative; an unreferenced preparation can only
+expire, never commit itself.
 
-The backend atomically replaces the exact-email set with the mutation ID and
-expected authorization revision. It retains an idempotent mutation result that the
-device can query after a lost response or process restart. The device reopens the
-page-email gate only after a read-after-write reconciliation proves that the
-backend's committed mutation ID, exact set, and returned authorization revision all
-match the local target and the revision has been persisted locally. An unavailable,
-ambiguous, conflicting, or unpersisted result leaves the durable gate closed; a
-periodic revision poll is recovery evidence, never the security boundary.
+After preparation succeeds, one local transaction persists only the opaque
+operation ID, source revision, target mode, target digest, and phase. It never
+persists the email addresses. Any transition that can add, remove, or replace
+page-email authority also sets `page_email_gate=closed_pending` in that same
+transaction. While that durable barrier exists, neither `/p/` nor the page-email
+branch of the canonical `/show/` ACL accepts a page-email claim, including a claim
+minted before the transition. Owner and organization resource ACLs remain
+independent.
+
+The device then asks the backend to `commit` the prepared operation. Commit
+atomically replaces the exact-email set under the expected authorization revision
+and retains an idempotent mutation result. After a lost response or process restart,
+the device resumes by opaque operation ID; a committed operation returns the exact
+current set/digest and authorization revision, while an uncommitted expired
+operation cannot mutate grants. The device reopens the page-email gate only after a
+read-after-write reconciliation proves that the backend's committed operation,
+exact current set/digest, and returned authorization revision match the local
+record and the revision has been persisted locally. The backend deletes the
+prepared target copy after device acknowledgement or the 24-hour hard limit; a
+terminal result retains only non-PII metadata and the digest. If the result copy has
+expired after commit, the authoritative current grant read supplies the same digest
+and revision proof. An unavailable, ambiguous, conflicting, expired-uncommitted, or
+unpersisted result leaves the durable gate closed. Email-list edits then require the
+owner to resubmit the target; empty-set cleanup can retry automatically. A periodic
+revision poll is recovery evidence, never the security boundary.
 
 The coordinator applies that invariant to every transition:
 
@@ -325,15 +344,24 @@ Content-Type: application/json
 {"protocol":1,"features":["show-context-key-v1"]}
 ```
 
-Avibe supplies the loopback-only `X-Avibe-Show-Context: private` or
-`X-Avibe-Show-Context: shared` header on every app-graph request, including
-requests made before capability negotiation finishes. A legacy Runtime ignores
-the unknown header; a new Runtime can therefore route shared traffic safely even
-when `GET /capabilities` is temporarily unavailable. With
-`show-context-key-v1`,
-Runtime keys Vite ownership by `(session_id, context)`. Avibe strips any
-browser-supplied copy of this header. Runtime health alone, an accepted app
-request, a package version, or support for `x-vibe-show-base` is not capability
+New Avibe supplies one loopback-only protocol envelope on every app-graph request,
+including requests made before capability negotiation finishes:
+
+```http
+X-Avibe-Show-Protocol: 1
+X-Avibe-Show-Context: private | shared
+```
+
+A legacy Runtime ignores both unknown headers. A new Runtime treats protocol `1`
+as an explicit client declaration and requires a valid context before resolving a
+Session or changing Vite ownership. A request with no protocol header is from a
+released/rolled-back Avibe client: Runtime ignores any context value, selects the
+legacy singleton base-switching path from the existing `x-vibe-show-base`, and does
+not claim keyed isolation. An unknown protocol value fails closed. This preserves
+old-Avibe/new-Runtime source and rollback pairings without letting a missing header
+from a declared new client silently downgrade its contract. Avibe strips any
+browser-supplied copy of both protocol headers. Runtime health alone, an accepted
+app request, a package version, or support for `x-vibe-show-base` is not capability
 evidence.
 
 Capability negotiation has three process-scoped outcomes:
@@ -350,13 +378,14 @@ capability. Stopping or replacing Runtime, or changing its base URL/process
 identity, clears every cached outcome and retry deadline.
 
 Context selection is a total Runtime request contract, not a proxy-only header.
-After Runtime advertises support, every operation that can create, read, prewarm,
-or connect to an app graph supplies an explicit context: entry and module HTTP
-requests, the SPA fallback retry, API handler requests, private HMR proxy setup,
-startup reconciliation, and `vibe show update` prewarm. Runtime rejects a missing
-or invalid context before resolving a Session or changing Vite ownership. Shared
+Every protocol-`1` operation that can create, read, prewarm, or connect to an app
+graph supplies an explicit context: entry and module HTTP requests, the SPA fallback
+retry, API handler requests, private HMR proxy setup, startup reconciliation, and
+`vibe show update` prewarm. Runtime rejects a missing or invalid context from a
+declared protocol-`1` client before resolving a Session or changing Vite ownership;
+only a headerless legacy client receives the singleton compatibility path. Shared
 prewarm uses `shared`; canonical `/show/` prewarm and HMR use `private`. The
-implementation keeps one typed context parameter through `ShowRuntimeManager`
+implementation keeps one typed protocol envelope through `ShowRuntimeManager`
 rather than allowing individual callers to assemble headers.
 
 The shared context is a read transform surface, not a publication guarantee. It
@@ -560,6 +589,7 @@ request.
 | A shared document outlives its absolute namespace/context lifetime | Return a fixed stale-document response for later module or lazy-asset reads and require reload | Namespace hard-expiry metric without source paths |
 | Runtime emits a development diagnostic or unsafe URL header | Preserve only a safe status class/body and filtered headers | Redacted operator-only diagnostic |
 | Limited-list replacement has an ambiguous result | Keep the durable page-email gate closed across retries and restarts until read-after-write reconciliation persists the exact mutation result | Mutation ID, target digest, and redacted reconciliation state |
+| Prepared email operation expires before commit | Keep the page-email gate closed when a local transition exists, discard the opaque operation reference, and require target resubmission; a preparation with no local transition expires without changing the audience | Operation expiry and non-PII target digest |
 | Limited email removed | Reject the viewer's next network request and invalidate its stale revision; no HMR or annotation channel exists to close | Authorization-revision log |
 | Limited page becomes private/public while hosted cleanup fails | Reject page-email claims on both `/p/` and `/show/` from the local mode commit; retry cleanup without reopening authority | Durable audience state and cleanup-pending record |
 | Editor role revoked but read ACL remains | Close private HMR; retain entitled private document/module reads; next `/p/` navigation stays shared only if its audience read rule succeeds | Existing authorization-revision/resource-revocation log |
@@ -639,20 +669,22 @@ feature, not a prerequisite for capability-gated editor HMR.
 2. Replace workspace audience plus public-link switch with the three-option
    select. Render exact emails only for `limited`, and link controls only for
    `limited | public`; keep availability separate.
-3. Implement the persistent page-email barrier, idempotent backend mutation-result
-   lookup, and fail-closed access coordinator. Retire the independent visibility
-   and email mutation paths after compatibility callers migrate.
+3. Implement backend prepare/commit email operations, the non-PII persistent
+   page-email barrier, idempotent mutation-result/current-grant lookup, and the
+   fail-closed access coordinator. Retire the independent visibility and email
+   mutation paths after compatibility callers migrate.
 4. Make `/p/<share>/` resolve both `limited` and `public`. Add the limited login,
    mode-scoped exact page-entitlement check on both `/p/` and `/show/`, generic
    denial, current-revision check, and private/no-store response policy.
 5. Factor annotation authorization into the shared, resource-aware
    `ShowEditorCapability`, explicitly excluding page-email entitlement, and use
    the same result for top-level editor navigation.
-6. Add the explicit Runtime capability state machine and one typed context
-   parameter; split canonical `private` and disposable `shared` context ownership
+6. Add the explicit Runtime capability state machine and one typed protocol
+   envelope; split canonical `private` and disposable `shared` context ownership
    without changing the private URL or bootstrap protocol. Migrate every HTTP,
-   WebSocket, fallback, and prewarm caller in the same contract change, and send
-   the backward-compatible context header before negotiation completes.
+   WebSocket, fallback, and prewarm caller in the same contract change, send the
+   protocol/context headers before negotiation completes, and retain the headerless
+   singleton path only for released clients.
 7. Redirect authorized top-level `/p/` navigations to the equivalent `/show/`
    route. Never route a `/p/` subresource to the private context. Keep every
    remaining `/p/` request on the shared transform/shim path and remove the
@@ -677,9 +709,11 @@ the redirect only after `GET /capabilities` returns protocol `1` and the exact
 `show-context-key-v1` feature. A definitive legacy Runtime keeps `/p/` on the
 existing no-HMR behavior and its existing single-context limitation; it is never
 described as isolated. A transient or malformed startup response fails the current
-request closed to shared mode, carries the explicit backward-compatible context,
-and remains retryable. An accepted legacy app request is not negotiation, and the
-old anonymous shared-route socket is never a compatibility fallback.
+request closed to shared mode, carries the explicit protocol/context envelope,
+and remains retryable. A new Runtime receiving no protocol header preserves the
+released Avibe singleton behavior; that headerless request is compatibility, not
+negotiation or keyed isolation. An accepted legacy app request is not negotiation,
+and the old anonymous shared-route socket is never a compatibility fallback.
 
 ### Data migration
 
@@ -694,8 +728,9 @@ The schema migration separates availability from audience and is fail-closed:
 
 Until the device can read the hosted grant set, an old private page stays
 private and records migration pending with the source `audience_revision` and
-legacy-marker generation; it is never guessed to be limited. Reconciliation may
-commit only with a compare-and-swap proving that both values are still current.
+legacy-audience journal generation; it is never guessed to be limited.
+Reconciliation may commit only with a compare-and-swap proving that both values are
+still current.
 Every authoritative audience Apply and every reconciled legacy write increments
 `audience_revision` and deletes any pending migration in the same local transaction
 before remote work begins. A stale worker discards its hosted read and any provisional
@@ -705,30 +740,38 @@ independently stored email set is cleared after the local public state is
 authoritative. Organization resource policies are not mapped into external audience
 modes; they remain canonical `/show/` collaborator policy.
 
-The compatibility read API projects old `visibility` fields for one rollback
-window, and new writes maintain a safe projection: public maps to old `public`,
-private and limited map to old `private`, and offline maps to old `offline`.
-The migration also installs a durable legacy-write marker triggered by every
-assignment to the legacy visibility column, including an assignment whose value is
-unchanged. A new writer updates `ShowAccess`, writes its legacy projection, and
-clears the marker only after both values are committed in the same transaction.
-An old binary cannot clear it, so any old-binary write remains distinguishable from
-a projection on the next upgrade. The compatibility column, marker, and trigger
-survive application rollback and schema downgrade for the entire supported
-rollback window; cleanup is a later migration after old binaries are no longer
-supported.
+The compatibility read API projects the complete legacy audience for one rollback
+window. New writes maintain a safe projection: public maps to old `public`; private
+and limited map to old `private`; offline maps to old `offline`; and the projected
+legacy `share_id` is the current binding only for a shareable mode.
 
-On startup or re-upgrade, a set marker makes the last legacy visibility assignment
-the user intent to reconcile before serving the page. Legacy `private` becomes
-active `private`, legacy `offline` becomes offline `private`, and an explicit legacy
-`public` becomes active `public`; a missing/corrupt marker state fails to private.
-The reconciled transaction invalidates the prior share binding where the target no
-longer uses it, makes page-email claims inapplicable unless the result is later
-opened as `limited` through the connected coordinator, writes the new projection,
-and only then clears the marker. A rollback therefore treats `limited` as private
-because older code cannot enforce its `/p/` authentication gate, while a later
-private/offline write by that old binary cannot be overwritten by stale
-`ShowAccess` on re-upgrade.
+The migration installs one durable legacy-audience journal rather than a
+visibility-only marker. Database triggers cover every assignment to any projected
+legacy audience column and record a monotonic generation plus the complete
+post-write legacy snapshot. The invariant is field-based: adding another projected
+audience column automatically requires it in the journal trigger and snapshot
+contract. It therefore captures visibility changes, generated rotations, custom
+slug writes, and unchanged assignments without depending on which released
+`ShowPageStore` method performed the write. A new writer updates `ShowAccess`, writes
+the complete legacy projection, and acknowledges the resulting journal generation
+after those writes but before their single transaction commits. An old binary cannot
+acknowledge it. The compatibility columns, journal, triggers, and acknowledgement
+survive application rollback and schema downgrade for the entire supported rollback
+window; cleanup is a later migration after old binaries are no longer supported.
+
+On startup or re-upgrade, the newest unacknowledged journal snapshot is the legacy
+user intent to reconcile before serving the page. Legacy `private` becomes active
+`private` and clears the binding; legacy `offline` becomes offline `private` and
+clears it; legacy `public` becomes active `public` with the exact journaled slug
+after an atomic uniqueness/ownership check. A missing/corrupt snapshot or a slug
+conflict fails to private with no share route and requires the owner to choose a new
+link; stale `ShowAccess` never wins the conflict. The reconciled transaction makes
+page-email claims inapplicable unless the result is later opened as `limited`
+through the connected coordinator, writes the complete new projection, advances
+`audience_revision`, and only then acknowledges the journal generation. A rollback
+therefore treats `limited` as private because older code cannot enforce its `/p/`
+authentication gate, while a visibility, rotation, or custom-slug write by that old
+binary cannot be overwritten by stale `ShowAccess` on re-upgrade.
 
 Binary downgrade has a fail-closed preflight before the current executable or
 compatibility schema is replaced. The updater acquires the audience coordinator's
@@ -775,19 +818,24 @@ claim, even though the old binary does not understand `page_email_gate`.
 - prove migration maps old public, private-with-grants, private-without-grants,
   and offline rows exactly as specified, with disconnected reconciliation staying
   private
-- perform a real new-write, binary rollback, legacy public/private/offline write,
-  and re-upgrade round trip; the legacy-write marker must preserve the last user
-  action, including an unchanged-value private assignment, and ambiguous state must
-  fail closed
+- perform a real new-write, binary rollback, every legacy audience-field mutation,
+  and re-upgrade round trip; the journal must preserve the complete latest snapshot,
+  including unchanged assignments, generated rotations, and custom slugs, while a
+  corrupt snapshot or uniqueness conflict fails closed
 - leave an upgrade migration pending, perform a newer audience Apply, then restore
   connectivity; the source-revision compare-and-swap discards the stale migration
   and cannot allocate or reopen a limited audience
 - attempt downgrade while a limited-to-private/public cleanup or mutation result is
   pending; preflight preserves the current binary and schema until hosted grants are
   empty and the authorization revision is reconciled
-- interrupt every limited-list mutation before send, after backend commit, after a
-  lost response, and before local revision persistence; the durable page-email gate
-  stays closed across process restart until the exact mutation result reconciles
+- interrupt every limited-list mutation before backend prepare, after prepare but
+  before the local transaction, after the local transaction but before commit, after
+  backend commit, after a lost response, and before local revision persistence; the
+  local record never contains an email, a preparation never changes authority by
+  itself, and the page-email gate stays closed until the exact result reconciles
+- expire prepared and committed-operation result copies, then recover from opaque
+  operation ID, target digest, and the authoritative current grant revision; failed
+  list edits require resubmission without persisting removed/failed email PII
 - prove a page-email cookie is rejected by both `/p/` and `/show/` immediately after
   the local mode leaves `limited`, even while backend cleanup is unavailable
 
@@ -796,13 +844,16 @@ claim, even though the old binary does not understand `page_email_gate`.
 - Runtime capability negotiation distinguishes supported, definitive legacy, and
   transient-unknown outcomes; transient failures retry and every outcome resets
   with the Runtime process
-- Avibe strips browser context headers; negotiated private and shared contexts
-  have independent keys and lifecycles
-- every app-graph call, including SPA fallback, WebSocket setup, startup
-  reconciliation, and shared/private prewarm, carries the selected typed context;
-  Runtime rejects missing or invalid selection before touching Vite ownership
-- a transient capability probe still sends `shared`, works with the new Runtime,
-  and remains accepted by a legacy Runtime that ignores the header
+- Avibe strips browser protocol/context headers; negotiated private and shared
+  contexts have independent keys and lifecycles
+- every new-client app-graph call, including SPA fallback, WebSocket setup, startup
+  reconciliation, and shared/private prewarm, carries the selected typed protocol
+  envelope; Runtime rejects missing/invalid context only when protocol `1` is
+  declared
+- a transient capability probe still sends protocol `1` plus `shared`, works with
+  the new Runtime, and remains accepted by a legacy Runtime that ignores the headers
+- a released Avibe client sends neither header to a new Runtime and retains the
+  singleton base-switching path; it is never rejected or reported as keyed isolation
 - shared requests never change, close, or rebuild the private context
 - authorized top-level `/p/` navigations redirect before document bytes to the
   equivalent canonical `/show/` route
@@ -864,12 +915,15 @@ claim, even though the old binary does not understand `page_email_gate`.
 | `SHOW-LIVE-020` | Old private/public/offline rows and exact-email grants upgrade | Each page matches the migration table; a disconnected private-with-grants page stays private and pending |
 | `SHOW-LIVE-021` | A live limited-list replacement commits remotely, its response is lost, and Avibe restarts | All page-email reads remain closed until the mutation result and revision reconcile; removed viewers never regain access |
 | `SHOW-LIVE-022` | Limited changes to private while hosted cleanup is unavailable | A stale page-email cookie is rejected on both `/p/` and `/show/`; independent resource collaborators retain their canonical access |
-| `SHOW-LIVE-023` | A public page upgrades, rolls back, is set private by the old binary, then re-upgrades | The legacy marker wins and the page stays private; stale `ShowAccess` cannot reopen anonymous access |
+| `SHOW-LIVE-023` | A public page upgrades, rolls back, is set private by the old binary, then re-upgrades | The newest complete journal snapshot wins and the page stays private; stale `ShowAccess` cannot reopen anonymous access |
 | `SHOW-LIVE-024` | An allowed source is replaced by a sensitive symlink after an opaque handle is issued | The issued handle returns only immutable captured bytes, and the changed path cannot receive a new handle |
 | `SHOW-LIVE-025` | A disconnected private-page migration is pending, then the owner chooses public and later private before reconnecting | The newer revision cancels migration; reconnect cannot allocate a slug, commit limited, or restore the old email audience |
 | `SHOW-LIVE-026` | Limited changes to private while hosted cleanup is unavailable, then binary downgrade is requested | Downgrade is refused without replacing executable/schema; it succeeds only after grants are empty and the new revision is reconciled |
 | `SHOW-LIVE-027` | An anonymous client reads every superseded namespace just before each idle deadline | Each namespace still reaches its non-renewable hard expiry, releases all snapshot bytes, and requires stale documents to reload |
 | `SHOW-LIVE-028` | Anonymous clients keep shared pages active across more Sessions than the Runtime-wide budget | Context and memory stay under the hard limit, reclaimable shared bundles rotate, private HMR keeps its reserve, and excess shared admission is sanitized |
+| `SHOW-LIVE-029` | A public page rolls back, then the old binary rotates and assigns a custom slug before re-upgrade | The newest complete journal snapshot wins; only the final slug resolves, and a conflict fails private without resurrecting stale `ShowAccess` |
+| `SHOW-LIVE-030` | A released Avibe client starts a new Runtime and sends only `x-vibe-show-base` | Entry, module, and prewarm requests retain the legacy singleton behavior; keyed isolation remains disabled until a protocol-`1` client supplies context |
+| `SHOW-LIVE-031` | A limited-list Apply crashes at every prepare/local/commit boundary and later exceeds operation retention | No local row contains an email, prepare alone never changes grants, committed state reconciles by digest/revision, and expired uncommitted edits remain closed until resubmitted |
 
 Focused unit/contract tests, Ruff, repository CI, and local Incus browser
 regression are required. Green unit tests do not replace simultaneous editor,
@@ -889,9 +943,10 @@ The design is implemented when all of the following are true:
   `ShowEditorCapability`, settings, Workbench, Agents annotations, HMR, or another
   Show Page. It authorizes page reads only while current mode is `limited`, the
   durable mutation gate is open, and its revision is current.
-- Every grant-set mutation closes a persistent local page-email gate before remote
-  work and reopens it only after idempotent read-after-write reconciliation; an
-  ambiguous response or restart cannot leave stale grants usable.
+- Every grant-set mutation is prepared without changing authority, then closes a
+  persistent non-PII local page-email gate before commit and reopens it only after
+  idempotent read-after-write reconciliation; an ambiguous response, restart, or
+  expired operation cannot leave stale grants usable or email targets on disk.
 - Authorized share-link editor navigations redirect to the corresponding private URL
   and get the same Vite HMR and React Fast Refresh behavior as private editors.
 - Annotation writes and the share-link editor redirect consume one validated,
@@ -910,18 +965,20 @@ The design is implemented when all of the following are true:
 - Ordinary private module reads preserve resource-viewer access while HMR remains
   editor-only.
 - Runtime support is accepted only through the explicit keyed-context capability
-  handshake; definitive mixed versions retain the existing compatibility
-  limitation, while transient negotiation failures carry the backward-compatible
-  shared context and retry without permanently disabling the feature.
-- Context selection is mandatory at every Runtime app-graph call site, including
-  prewarm and fallback paths, and missing selection fails before Vite ownership.
+  handshake and per-request protocol envelope; definitive mixed versions retain the
+  existing compatibility limitation, while transient negotiation failures carry
+  protocol `1` plus `shared` and retry without permanently disabling the feature.
+- Context selection is mandatory at every protocol-`1` Runtime app-graph call site,
+  including prewarm and fallback paths, and missing selection fails before Vite
+  ownership; a headerless released client retains only the singleton legacy path.
 - Shared file references use leased context-bound opaque handles backed by bounded
   immutable snapshots captured through confinement-safe opens; handle reads never
   reopen mutable pathnames. Raw absolute paths, unsafe URL-bearing response headers,
   and Runtime development diagnostics never reach the browser.
-- Compatibility rollback writes are durably marked and reconciled before serving,
-  so a private/offline change made by an old binary cannot be overwritten by stale
-  `ShowAccess` after re-upgrade.
+- Every compatibility audience-field write is captured as one complete durable
+  legacy snapshot and reconciled before serving, so visibility and share-link
+  changes made by an old binary cannot be overwritten by stale `ShowAccess` after
+  re-upgrade.
 - Pending legacy migration is revision-bound and cancelled by every newer audience
   mutation; downgrade cannot begin while stale hosted email authority could be
   accepted by the old serving path.

--- a/docs/plans/public-show-live-update.md
+++ b/docs/plans/public-show-live-update.md
@@ -1,31 +1,36 @@
-# Capability-Gated HMR for Public Show Links
+# Unified Show Access and Capability-Gated HMR
 
 Status: Proposed
 
 Date: 2026-08-16
 
-Scope: `avibe` public Show authorization/proxy and `vibe-show-runtime`
+Scope: `avibe` Show access UI, authorization/proxy, `avibe-backend` exact-email
+grants, and `vibe-show-runtime`
 
 ## Decision
 
-A public Show link selects its update behavior from the viewer's effective
-server-side capability:
+A Show Page has one audience setting and a separate development capability.
+Audience decides who may read. `ShowEditorCapability` decides who may use HMR
+and Agents annotations. The route and effective server-side capability select
+the resulting representation:
 
 | Surface and viewer | Runtime representation | Update behavior |
 | --- | --- | --- |
 | Private `/show/<session>/`, authorized editor | Canonical private Vite context | Vite HMR and React Fast Refresh |
-| Public `/p/<share>/`, authorized editor navigation | Redirect to canonical `/show/<session>/` | Vite HMR and React Fast Refresh after the redirect |
-| Public `/p/<share>/`, anonymous, read-only, expired, resource-forbidden, or unverifiable | Negotiated isolated public context; legacy compatibility context otherwise | No Hot Reload; refresh reads current content |
+| Limited or public `/p/<share>/`, authorized editor navigation | Redirect to canonical `/show/<session>/` | Vite HMR and React Fast Refresh after the redirect |
+| Limited `/p/<share>/`, signed-in exact-email viewer | Negotiated isolated shared context; legacy compatibility context otherwise | No Hot Reload or annotations; refresh reads current content |
+| Limited `/p/<share>/`, anonymous or unauthorized viewer | None | Login challenge or access denied; no page bytes |
+| Public `/p/<share>/`, anonymous, read-only, expired, resource-forbidden, or unverifiable | Negotiated isolated shared context; legacy compatibility context otherwise | No Hot Reload or annotations; refresh reads current content |
 | Offline | None | None |
 
-Public visibility is an anonymous read grant, not development authorization.
-Making a page public therefore does not downgrade its editor's experience, and
-being able to read a public link does not grant access to Vite's bidirectional
-development protocol.
+Limited and public access are read grants, not development authorization. Making
+a page shareable therefore does not downgrade its editor's experience, and being
+able to read a share link does not grant access to Vite's bidirectional
+development protocol or annotation dispatch.
 
-For a concrete example, Alice is an authorized editor and Bob is an anonymous
-viewer on the current bundled Runtime. They open the same `/p/brief/` URL while
-an Agent edits the page:
+For a concrete example, Alice is an authorized editor, Bob is on the exact-email
+list, and Carol is anonymous. They open the same limited `/p/brief/` URL while an
+Agent edits the page:
 
 1. Avibe resolves Alice's existing Workbench session and the same editor
    capability used to enable annotations.
@@ -33,11 +38,16 @@ an Agent edits the page:
    `/show/<session>/` path. That document, every module, and
    `/show/<session>/__vite_hmr` use one private representation; React Fast Refresh
    updates her page and preserves component state.
-3. Bob's document uses the isolated public transform context. It contains the
-   inert Vite/React Refresh shims and never opens an HMR socket.
-4. Bob's loaded page stays on the public representation even if identity state
-   changes while its subresources load. A later manual navigation or refresh reads
-   the current public content and may then take the editor redirect.
+3. Bob signs in, remains on `/p/brief/`, and receives the isolated shared
+   transform context. It contains inert Vite/React Refresh shims, exposes no
+   annotation capability, and never opens an HMR socket.
+4. Carol is asked to sign in and is denied after authentication because she has
+   neither the page-bound email grant nor editor capability.
+5. If Alice changes the audience to fully public, Carol can read the same shared
+   representation without login. Bob still receives no development capability.
+6. A loaded `/p/` document stays on the shared representation even if identity
+   state changes while its subresources load. A later network navigation may
+   take the editor redirect or re-evaluate limited access.
 
 This design intentionally does not add anonymous Live Reload. That requirement
 would need an independently published revision model with artifact retention,
@@ -47,13 +57,20 @@ HMR behavior.
 
 ## Why The Current Page Does Not Update
 
-The current public proxy rewrites `@vite/client` and `@react-refresh` to inert,
-immutable shims. This prevents an anonymous browser from opening the existing
-public Vite socket, but it applies the same behavior to an authenticated editor.
+The current shared proxy rewrites `@vite/client` and `@react-refresh` to inert,
+immutable shims. This prevents a share-link viewer from opening the existing
+Vite socket, but it applies the same behavior to an authenticated editor.
 The authorization information already used by the annotation surface is not
 used to select the Runtime representation.
 
-There is a second ownership problem. Runtime currently lets a Session's Vite
+There is also a product-model problem. The UI currently exposes workspace ACL,
+exact-email grants, and a separate public-link switch as independent controls.
+That permits states users cannot explain: a page can have an email list while no
+`/p/` route exists, and the public switch can anonymously bypass the list. These
+are not independent product concepts; they are three mutually exclusive audience
+modes.
+
+There is a third ownership problem. Runtime currently lets a Session's Vite
 context depend on the requested external base. Alternating `/show/<session>/`
 and `/p/<share>/` requests can therefore rebuild or replace one context as the
 base changes. Simply making the public socket conditional would still let an
@@ -64,45 +81,132 @@ ownership, not a weaker client-side HMR switch or two representations at one URL
 
 ## Product Contract
 
+### One audience setting
+
+The share control exposes one mutually exclusive select:
+
+| `access_mode` | UI label | Share route | Read rule | Conditional UI |
+| --- | --- | --- | --- | --- |
+| `private` | Private | Disabled | Existing canonical `/show/` resource access only | No email editor or share-link controls |
+| `limited` | Limited access | `/p/<share>/` | Current, page-bound exact-email grant, or `ShowEditorCapability` | Exact-email editor and share-link controls |
+| `public` | Fully public | `/p/<share>/` | Anyone; editors may redirect to `/show/` | Share-link controls only |
+
+The separate public-link switch is removed. The exact-email editor exists only
+while `limited` is selected, requires at least one valid address, and says
+explicitly that these users receive view-only access to this Show Page. The copy,
+custom-slug, and rotate-link controls appear for both `limited` and `public`.
+
+`offline` is not a fourth audience. Availability is an orthogonal lifecycle
+state (`active | offline`) controlled by archive/offline operations. An offline
+page serves no route and its audience control is read-only until reactivated.
+Separating availability from audience also stops an offline transition from
+silently destroying the page's intended audience.
+
+The persisted model is therefore:
+
+```text
+ShowAccess {
+  availability: active | offline
+  access_mode: private | limited | public
+  share_id: opaque slug | null
+  audience_revision: monotonic integer
+}
+```
+
+Exact emails remain normalized, unique page-bound grants in `avibe-backend`;
+they are not copied into local storage or encoded into the slug. `share_id` is a
+locator, never a bearer credential. It exists only for `limited` and `public`;
+rotating it invalidates the old route but does not change the page audience.
+
+Existing organization/resource ACLs continue to govern canonical `/show/`
+collaborator access and who can edit or manage the page. They are not a second
+share-audience control and cannot satisfy the exact-email gate for a limited
+`/p/` request. Only a resource-aware editor may bypass that viewer gate by taking
+the canonical redirect.
+
+Only the page owner or existing sharing-control authority may change
+`access_mode`, the email set, or the slug. A page-bound `show_page_email` viewer
+cannot read these settings APIs, mutate the audience, load the Workbench, or
+promote itself through a broader Instance endpoint.
+
+Audience changes use one Apply action and a fail-closed coordinator rather than
+three independent writes:
+
+1. Entering `limited` from `public` first closes the local share gate to
+   `private`, then atomically replaces the cloud email set, then commits
+   `limited` with the existing or newly allocated slug. Failure leaves the page
+   private, never anonymously readable.
+2. Entering `limited` from `private` writes the email set before opening the
+   route. At least one address is required.
+3. Editing a live limited list uses the backend's atomic replace and authorization
+   revision. Removed viewers fail subsequent requests immediately and their
+   existing session is rejected when its revision is revalidated.
+4. Leaving `limited` commits `private` or `public` locally first, which makes all
+   page-email claims inapplicable. The backend list is then cleared. Failed
+   cleanup is retried and surfaced as pending but cannot reopen the route.
+5. Switching `private` and `public` is one local transaction. Link allocation,
+   mode, revision, and old-route invalidation commit together.
+
+The UI does not optimistically display a new mode until the coordinator reaches
+its authoritative terminal state. A retry carries an idempotency key and expected
+`audience_revision`, so reconnects and double clicks cannot resurrect an older
+audience.
+
 ### One editor capability
 
 Avibe computes one `ShowEditorCapability` from server-owned facts:
 
 - a validated Workbench identity
 - an editor role
-- access to the Show Page resource
-- a current public share-to-Session binding when the request uses `/p/`
-- non-offline visibility
+- independent editor/resource access to the Show Page, evaluated without any
+  page-email entitlement
+- a current limited/public share-to-Session binding when the request uses `/p/`
+- active availability
 
-The public annotation decision and public-link HMR decision consume the same
-result. The implementation should factor the existing annotation inputs into
-one helper rather than make two similar authorization checks.
+The annotation decision and share-link HMR decision consume the same result. The
+implementation should factor the existing annotation inputs into one helper
+rather than make two similar authorization checks. Exact-email entitlement is
+intentionally excluded from this capability even though it can satisfy limited
+read access.
 
-A cookie's presence, a browser-provided flag, the public share ID, or a
+This exclusion is evidence-based, not only a role check. The hosted resolver may
+preserve a person's broader Instance role when the same identity also has an
+exact-email grant. `ShowEditorCapability` must therefore prove page access through
+the owner/organization resource policy while ignoring `show_page_id`; it cannot
+let the page-bound entitlement satisfy that proof. A real page editor still gets
+HMR even when their email also appears in the list, because their independent
+editor authority succeeds. A person whose only page authority is the list remains
+view-only regardless of the role text in another unrelated grant.
+
+A cookie's presence, a browser-provided flag, the share ID, or a
 share-scoped annotation write token is insufficient. The annotation token proves
 only one permitted public event write after capability selection; it is never
 accepted for module or HMR access.
 
 Missing, expired, read-only, resource-forbidden, ambiguous, or temporarily
-unverifiable authorization fails closed to the public no-HMR representation. A
-remote identity outage must not make an otherwise public page unavailable.
+unverifiable authorization never selects the private representation. A fully
+public page falls back to the shared no-HMR representation. A limited page fails
+closed to login/denial and returns no page bytes; an identity outage must never
+turn it public. A remote identity outage must not make an otherwise fully public
+page unavailable.
 
 ### URL-selected representation
 
 One browser document uses one representation for its complete lifetime:
 
-- `/p/<share>/...` always serves the public no-HMR representation.
+- `/p/<share>/...` always serves the shared no-HMR representation after the
+  current audience read gate succeeds.
 - `/show/<session>/...` always serves the canonical private representation.
 - Avibe never returns a private entry document, module, API response, or HMR
   client with a `/p/` document URL.
 
-For a `GET` top-level browser navigation to a current public share, Avibe first
+For a `GET` top-level browser navigation to a current limited/public share, Avibe first
 computes `ShowEditorCapability`. When it succeeds and Runtime has explicitly
 advertised keyed-context support, Avibe returns a private, no-store redirect to
 the equivalent `/show/<session>/<route>` URL, preserving the route suffix and
 query. `Sec-Fetch-Mode: navigate` and `Sec-Fetch-Dest: document` are the trusted
 navigation evidence. Missing or contradictory Fetch Metadata fails closed to the
-ordinary public document; it never upgrades a subresource, `fetch()`, worker, or
+ordinary shared document; it never upgrades a subresource, `fetch()`, worker, or
 API request.
 
 No update-mode discriminator replaces the existing `globalThis.__AVIBE_SHOW__`
@@ -112,46 +216,55 @@ payload. Public and private documents retain the shipped additive bootstrap keys
 scaffolds, history routing, annotations, and event streams keep their current
 bootstrap contract.
 
-Login or permission changes take effect on the next network navigation. A loaded
-public document and all relative `/p/` requests remain public even if identity
-resolution later recovers. Losing editor authorization closes an existing private
-HMR connection; ordinary private module reads then continue or fail according to
-the caller's current Show Page read ACL.
+Login or permission changes take effect on the next network request. A loaded
+shared document and all relative `/p/` requests remain on the shared Runtime
+representation even if identity resolution later recovers. Limited subresources
+still revalidate the page-bound read grant; revocation prevents future reads but
+never upgrades or mixes the document graph. Losing editor authorization closes
+an existing private HMR connection; ordinary private module reads then continue
+or fail according to the caller's current Show Page read ACL.
 
 ### User-visible requirements
 
 1. An authorized editor opening `/p/` is redirected to the equivalent `/show/`
    route and gets full Vite HMR and React Fast Refresh from the canonical
    development context.
-2. An anonymous or unauthorized `/p/` viewer never receives a Vite client,
+2. An anonymous, limited-email, or otherwise read-only `/p/` viewer never
+   receives a Vite client,
    React Refresh runtime, HMR socket, private module URL, Session identifier,
    source frame, or development diagnostic.
-3. The public link and page content remain readable without login.
-4. An unauthorized loaded page does not update automatically. Refreshing it
-   reads the current public workspace content.
-5. A failed or unavailable identity lookup selects the public representation
-   rather than delaying or failing the public page.
-6. With a negotiated keyed-context Runtime, private HMR traffic cannot be
-   restarted or rebased by an unauthorized public request.
-7. Existing public path confinement, sensitive-path denial, and symlink escape
-   protections remain in force for every public request.
+3. A limited link requires login and an exact current page-email grant. Its viewer
+   gets only page read access: no Workbench, Agents annotation, HMR, settings, or
+   unrelated Show Page access.
+4. A fully public link and page content remain readable without login.
+5. A shared loaded page does not update automatically. Refreshing it reads the
+   current content after re-evaluating audience access.
+6. A failed or unavailable identity lookup selects the shared representation for
+   a fully public page but denies a limited page.
+7. With a negotiated keyed-context Runtime, private HMR traffic cannot be
+   restarted or rebased by an unauthorized shared request.
+8. Existing shared-route path confinement, sensitive-path denial, and symlink
+   escape protections remain in force for every `/p/` request.
 
 An older Runtime does not gain isolation it cannot represent. Avibe does not
-enable the editor redirect for it, and its anonymous `/p/` traffic retains the
+enable the editor redirect for it, and its `/p/` traffic retains the
 existing single-context base-switching limitation until the bundled Runtime is
 upgraded. Compatibility mode is therefore availability-preserving, not evidence
-that requirement 6 has been met.
+that requirement 7 has been met.
 
 ## Architecture
 
 ```text
 GET /p/<share>/...
-  -> resolve current public share
+  -> resolve current limited/public share and availability
+  -> access_mode == limited?
+     -> yes: require current page-bound email grant or ShowEditorCapability
+     -> no: public read is allowed
   -> top-level navigation + Runtime keyed-context capability?
      -> yes: compute ShowEditorCapability
         -> authorized editor: redirect to /show/<session>/...
-        -> everyone else: public representation
-     -> no: public representation
+        -> every allowed viewer: shared representation
+     -> no: shared compatibility representation
 
 GET /show/<session>/...
   -> existing private Show read ACL
@@ -161,21 +274,21 @@ GET /show/<session>/...
 
 ### Runtime context ownership
 
-A negotiated Runtime owns at most two contexts for a public Session:
+A negotiated Runtime owns at most two contexts for a shareable Session:
 
 | Context key | Base | Consumers | Lifetime |
 | --- | --- | --- | --- |
 | `(session_id, private)` | `/show/<session>/` | Private `/show/` only | Existing private demand/lifecycle |
-| `(session_id, public)` | Current `/p/<share>/` | Every `/p/` document and subresource | Demand-created; disposable without affecting private HMR |
+| `(session_id, shared)` | Current `/p/<share>/` | Every allowed limited/public `/p/` document and subresource | Demand-created; disposable without affecting private HMR |
 
-The private context is canonical. An authorized public-link navigation redirects
+The private context is canonical. An authorized share-link navigation redirects
 before Runtime returns document bytes, so the resulting request is an ordinary
 `/show/` request. It does not send a share-specific `x-vibe-show-base`, rewrite
 private modules into the share path, or create a second private HMR protocol.
 
-The public transform context preserves today's no-HMR representation but no
+The shared transform context preserves today's no-HMR representation but no
 longer owns or replaces the private context. A share rotation may recreate only
-the disposable public context. Public context startup, failure, or traffic
+the disposable shared context. Shared context startup, failure, or traffic
 cannot close the private socket.
 
 Avibe negotiates that ownership once per Runtime process before enabling the
@@ -190,8 +303,12 @@ Content-Type: application/json
 {"protocol":1,"features":["show-context-key-v1"]}
 ```
 
-With `show-context-key-v1`, Avibe supplies the loopback-only
-`X-Avibe-Show-Context: private` or `X-Avibe-Show-Context: public` header and
+Avibe supplies the loopback-only `X-Avibe-Show-Context: private` or
+`X-Avibe-Show-Context: shared` header on every app-graph request, including
+requests made before capability negotiation finishes. A legacy Runtime ignores
+the unknown header; a new Runtime can therefore route shared traffic safely even
+when `GET /capabilities` is temporarily unavailable. With
+`show-context-key-v1`,
 Runtime keys Vite ownership by `(session_id, context)`. Avibe strips any
 browser-supplied copy of this header. Runtime health alone, an accepted app
 request, a package version, or support for `x-vibe-show-base` is not capability
@@ -203,7 +320,7 @@ Capability negotiation has three process-scoped outcomes:
 | --- | --- | --- |
 | `supported` | Well-formed protocol `1` response containing `show-context-key-v1` | Cache for this Runtime process; keyed routing and the editor redirect may run |
 | `unsupported` | A definitive legacy response such as `404`, or a well-formed response without the protocol/feature | Cache for this Runtime process; no redirect and `/p/` retains compatibility behavior |
-| `transient-unknown` | Connect/timeout failure, `408`, `429`, `5xx`, truncated JSON, or another malformed startup response | Current request stays public; retry on later requests with jittered exponential backoff capped at 5 seconds |
+| `transient-unknown` | Connect/timeout failure, `408`, `429`, `5xx`, truncated JSON, or another malformed startup response | Current request stays shared and carries the backward-compatible `shared` context; retry on later requests with jittered exponential backoff capped at 5 seconds |
 
 Only `supported` and definitive `unsupported` are permanent for one Runtime
 process. A transient failure records a next-probe time rather than a negative
@@ -215,12 +332,12 @@ After Runtime advertises support, every operation that can create, read, prewarm
 or connect to an app graph supplies an explicit context: entry and module HTTP
 requests, the SPA fallback retry, API handler requests, private HMR proxy setup,
 startup reconciliation, and `vibe show update` prewarm. Runtime rejects a missing
-or invalid context before resolving a Session or changing Vite ownership. Public
-prewarm uses `public`; canonical `/show/` prewarm and HMR use `private`. The
+or invalid context before resolving a Session or changing Vite ownership. Shared
+prewarm uses `shared`; canonical `/show/` prewarm and HMR use `private`. The
 implementation keeps one typed context parameter through `ShowRuntimeManager`
 rather than allowing individual callers to assemble headers.
 
-The public context is a read transform surface, not a publication guarantee. It
+The shared context is a read transform surface, not a publication guarantee. It
 may read the latest workspace state on navigation, so a fresh request during an
 invalid edit can receive the existing sanitized unavailable behavior. This
 change does not promise last-known-good artifacts or frontend/API revision
@@ -228,47 +345,67 @@ atomicity.
 
 ### HTTP routing
 
-For an authorized top-level public entry or SPA navigation, Avibe redirects the
-same route suffix and query to `/show/<session>/`. The private route then serves
+For an authorized top-level limited/public entry or SPA navigation, Avibe
+redirects the same route suffix and query to `/show/<session>/`. The private route then serves
 the existing private bootstrap and canonical private Runtime representation.
-There is no public document whose subresources can switch to private mode.
+There is no shared document whose subresources can switch to private mode.
 
-On a negotiated Runtime, every non-redirected `/p/` request uses only the public
-context and existing public-safe response transforms, regardless of current
-identity. A legacy Runtime uses the explicitly limited compatibility path instead.
+After the audience gate, every non-redirected `/p/` request uses only the shared
+context and existing shared-safe response transforms, regardless of the viewer's
+identity class. A legacy Runtime uses the explicitly limited compatibility path
+instead.
 Exact files and API handlers retain first refusal; route-shaped document misses
 retain the current SPA fallback. The implementation must preserve the existing
-path policy as an invariant over the whole public request surface:
+path policy as an invariant over the whole shared request surface:
 
 - no sensitive segment is readable
 - no symlink or `@fs` path escapes the allowed workspace/dependency roots
-- no private Session path survives a public response
-- no public request is forwarded to an arbitrary host file or plugin endpoint
+- no private Session path survives a shared response
+- no shared request is forwarded to an arbitrary host file or plugin endpoint
 
-The public context continues to use inert, versioned `@vite/client` and React
+The shared context continues to use inert, versioned `@vite/client` and React
 Refresh shims. It exposes neither Runtime diagnostics nor a message channel.
 
-Vite's native `/@fs/<absolute-path>` form cannot cross that public boundary.
-When a public transform references an allowed absolute file, Runtime first checks
+Vite's native `/@fs/<absolute-path>` form cannot cross that shared boundary.
+When a shared transform references an allowed absolute file, Runtime first checks
 the canonical path against the existing allowed-root, sensitive-segment, and
 symlink policy, then allocates a stable opaque handle from a Runtime-process secret,
 the Session, the current share generation, and the canonical path. The browser
-receives only `/p/<share>/__avibe_asset/<handle>`; Runtime's process-local registry
-resolves that handle only inside the matching public namespace. A browser cannot
-submit a raw `/@fs/` path or mint a mapping, handles reveal no path bytes, and share
-rotation or Runtime replacement invalidates them. Idle Vite-context disposal does
-not evict admitted handles, so an already-loaded page can still fetch a lazy module;
-new-handle admission fails closed instead of evicting a handle in use. The same
-chokepoint covers every emitted URL, including an absolute path nested inside
-another Vite URL.
+receives only `/p/<share>/__avibe_asset/<namespace>/<handle>`; Runtime's
+process-local registry resolves that handle only inside the matching shared
+namespace. A browser cannot submit a raw `/@fs/` path or mint a mapping, handles
+reveal no path bytes, and share rotation or Runtime replacement prevents new
+admission into the old namespace.
+
+Each transformed entry graph owns one bounded 30-minute idle namespace lease.
+Every successful document, module, or lazy-asset read refreshes its lease. The
+current namespace is pinned; superseded namespaces are reclaimed only after 30 minutes
+with no request, and reclamation removes the whole namespace rather than
+individual handles. A document that remains idle beyond the lease may fail a
+later lazy import and must reload; it never receives a handle from another graph.
+The Runtime bounds namespaces and handles globally and per Session. When every
+slot is actively leased, new admission fails closed instead of evicting a live
+namespace. Thus loaded documents retain their complete referenced set during the
+lease, while successive edits and rotations cannot consume capacity until
+process restart. The same chokepoint covers every emitted URL, including an
+absolute path nested inside another Vite URL.
 
 Runtime also labels every loopback response as `application`, `asset`, or
 `development-diagnostic` in a stripped response metadata header. Avibe forwards
 authored application/API bodies and successful assets, but replaces every
-`development-diagnostic` body with a fixed public error representation while
+`development-diagnostic` body with a fixed shared error representation while
 preserving only the safe status class. Source frames, plugin errors, stack traces,
 and local paths remain in a redacted operator log. HTTP error status alone is not
 trusted to distinguish an authored API error from a Vite transform failure.
+
+The shared proxy also treats response headers as URL output. It always removes
+`SourceMap`, `X-SourceMap`, `Content-Location`, and `Refresh`. It parses `Location`
+and `Link` only for Runtime-classified application responses, rewrites safe
+same-Show targets into the current `/p/` namespace, preserves explicitly external
+HTTP(S) application targets, and rejects local-file, private-Session, `@fs`, or
+malformed targets. No Runtime URL-bearing header is forwarded by a generic
+allowlist. Source-map comments in bodies pass through the same opaque-URL
+rewriter or are stripped.
 
 ### WebSocket routing
 
@@ -279,12 +416,12 @@ broker tasks close it when those facts stop holding. In-memory broker events are
 an optimization, not the durable visibility boundary: while any HMR socket is
 open, one coalesced monitor per Session rereads `ShowPageStore` on a cadence no
 greater than five seconds and closes every socket if the page becomes `offline`.
-A direct CLI mutation therefore takes effect without an IPC event. Making a public
-page private or rotating its share does not close the canonical private socket when
-editor and read access remain valid; the share binding is needed only for the
+A direct CLI mutation therefore takes effect without an IPC event. Changing a
+limited/public page to private or rotating its share does not close the canonical
+private socket when editor and read access remain valid; the share binding is needed only for the
 redirect that selected `/show/`.
 
-That editor requirement applies to HMR, annotation writes, and the public-link
+That editor requirement applies to HMR, annotation writes, and the share-link
 redirect, not to ordinary private document and module reads. `/show/` keeps the
 existing resource-reader ACL so a read-only user can load the complete private
 module graph without receiving an HMR channel. A downgrade from editor to viewer
@@ -297,20 +434,31 @@ live client.
 
 ### Cache boundary
 
-The redirect decision varies by capability, so redirect and public entry
-responses use `Cache-Control: private, no-store` and `Vary: Cookie`. Successful
+The redirect and limited-access decisions vary by capability, so redirects and
+all entry responses use `Cache-Control: private, no-store` and `Vary: Cookie`.
+Every limited response, including modules and API handlers, is private/no-store.
+Successful
 content-hashed vendor assets at capability-independent global URLs may retain
 immutable caching. Avibe never forwards browser cookies, authorization headers,
 CSRF headers, annotation tokens, or context-selection headers to Runtime.
 
 `/p/` never carries private document bytes, which also makes Service Worker
 interception representation-safe. A Show-owned worker under `/p/<share>/` may
-continue serving that public representation and can therefore delay the editor
+continue serving that shared representation and can therefore delay the editor
 redirect until a navigation reaches Avibe, but it cannot cache a private document
 at the shared URL or control the disjoint `/show/<session>/` scope. Avibe strips
-`Service-Worker-Allowed` from public Runtime responses so authored content cannot
-expand a public worker beyond the default `/p/<share>/` scope. Client-side mode
+`Service-Worker-Allowed` from shared Runtime responses so authored content cannot
+expand a worker beyond the default `/p/<share>/` scope. Client-side mode
 replacement is never a security boundary.
+
+A Service Worker or Cache Storage entry already installed in a browser is content
+that browser has downloaded; the server cannot erase it. Access-mode changes and
+share rotation therefore revoke every request that reaches Avibe immediately,
+but cannot promise that an old worker will stop rendering cached shared bytes in
+that browser. No private representation is ever cacheable at `/p/`, so this
+limitation cannot expose HMR, annotations, Session identifiers, or newer content.
+Verification distinguishes network-reached revocation from unavoidable local
+cache retention instead of claiming that `ShowPageStore` can control the latter.
 
 ## Performance Model
 
@@ -319,24 +467,26 @@ The model adds authorization routing, not a production publication pipeline:
 | Case | Cost |
 | --- | --- |
 | Authorized editor opens `/p/` | Existing session/resource decision, one redirect, canonical Vite transforms, and one private HMR socket |
-| Unprivileged viewer opens `/p/` | Existing public transforms and shims from an isolated context when negotiated, or the explicit legacy compatibility path; no socket |
+| Limited exact-email viewer opens `/p/` | One current authorization decision plus shared transforms and shims; no socket or annotation bootstrap |
+| Public unprivileged viewer opens `/p/` | Existing shared transforms and shims from an isolated context when negotiated, or the explicit legacy compatibility path; no socket |
 | Both modes are active | Up to two Vite contexts for the Session; only the private context maintains HMR clients |
-| Agent edit | Private context pushes HMR; public context does no work until the next public request or refresh |
-| Active private HMR sockets | One coalesced durable visibility read per Session on a cadence no greater than five seconds |
+| Agent edit | Private context pushes HMR; shared context does no work until the next allowed `/p/` request or refresh |
+| Active private HMR sockets | One coalesced durable availability read per Session on a cadence no greater than five seconds |
 
-The capability decision adds one redirect round trip for an authorized public-link
-navigation. A request without a Workbench cookie immediately stays public; a
-request with a cookie uses the existing bounded/cached identity resolution already
-needed by annotations.
+The capability decision adds one redirect round trip for an authorized share-link
+navigation. A public request without a Workbench cookie immediately stays shared.
+A limited request without a session enters the existing login flow; an authenticated
+request uses the current bounded/cached identity resolution and authorization
+revision already used by resource access.
 
 After its one redirect, an authorized `/p/` load should have the same cold and
 warm profile as `/show/`.
-The negotiated isolated public context can increase Runtime memory when authorized and
-anonymous viewers are active simultaneously, but avoids production builds,
+The negotiated isolated shared context can increase Runtime memory when authorized and
+share-link viewers are active simultaneously, but avoids production builds,
 artifact storage, SSE fanout, and anonymous sockets. Runtime must expose context
 count and memory so local Incus regression can set a per-Session idle eviction
-budget from measurements rather than an assumed universal threshold. Opaque public
-path mappings are process-local, share-generation-bound, and admission-bounded;
+budget from measurements rather than an assumed universal threshold. Opaque shared
+path mappings are process-local, share-generation-bound, leased, and admission-bounded;
 capability probes are process-cached or backoff-limited rather than added to every
 request.
 
@@ -344,16 +494,19 @@ request.
 
 | Failure | Browser behavior | Operator evidence |
 | --- | --- | --- |
-| Missing/expired/read-only identity | Serve the public no-HMR representation | Redacted authorization reason |
-| Identity service unavailable | Serve the public representation; public availability does not depend on identity recovery | Authorization availability metric/log |
+| Missing/expired/read-only identity on fully public page | Serve the shared no-HMR representation | Redacted authorization reason |
+| Missing/expired identity on limited page | Redirect to login for a top-level navigation; otherwise deny without page bytes | Redacted authorization reason |
+| Signed-in user lacks exact limited grant | Return one generic access-denied response; do not reveal whether the address or page exists | Redacted page-bound denial |
+| Identity service unavailable | Fully public stays readable; limited fails closed and remains retryable | Authorization availability metric/log |
 | Definitive keyed-context capability absence | Do not redirect; serve `/p/` through the legacy no-HMR path with its existing single-context limitation recorded | Runtime capability metric/log |
-| Transient capability negotiation failure | Keep the current request public and retry after bounded backoff; do not cache a permanent negative | Redacted probe state and retry metric |
-| Private Runtime unavailable after an editor redirect | Existing private sanitized recovery behavior; never fall through to a raw public socket | Private Runtime log |
-| Public context unavailable | Existing sanitized public unavailable/static fallback | Public Runtime log without source detail |
-| Runtime emits a development diagnostic | Preserve only a safe status class and fixed public body | Redacted operator-only diagnostic |
-| Editor role revoked but read ACL remains | Close private HMR; retain entitled private document/module reads; next `/p/` navigation stays public | Existing authorization-revision/resource-revocation log |
-| Show Page read access revoked | Close private HMR and reject later private document/module reads; next `/p/` navigation stays public if the share remains valid | Existing resource-revocation log |
-| Share rotates or becomes private | Old public reads fail immediately; an entitled canonical private socket remains independent | Durable Show Page state |
+| Transient capability negotiation failure | Send the backward-compatible explicit `shared` context, keep the current allowed request shared, and retry after bounded backoff | Redacted probe state and retry metric |
+| Private Runtime unavailable after an editor redirect | Existing private sanitized recovery behavior; never fall through to a raw shared-route socket | Private Runtime log |
+| Shared context unavailable | Existing sanitized shared unavailable/static fallback | Shared Runtime log without source detail |
+| Runtime emits a development diagnostic or unsafe URL header | Preserve only a safe status class/body and filtered headers | Redacted operator-only diagnostic |
+| Limited email removed | Reject the viewer's next network request and invalidate its stale revision; no HMR or annotation channel exists to close | Authorization-revision log |
+| Editor role revoked but read ACL remains | Close private HMR; retain entitled private document/module reads; next `/p/` navigation stays shared only if its audience read rule succeeds | Existing authorization-revision/resource-revocation log |
+| Show Page read access revoked | Close private HMR and reject later private document/module reads; `/p/` is re-evaluated independently | Existing resource-revocation log |
+| Share rotates or becomes private | Old network-reached `/p/` reads fail immediately; an entitled canonical private socket remains independent; previously cached bytes remain a client-cache limitation | Durable Show Page state |
 | Show Page becomes offline through any process | The coalesced durable-state monitor closes private HMR within five seconds and later reads return offline | Durable Show Page state |
 
 Revocation cannot erase module bytes already downloaded by a previously
@@ -363,9 +516,9 @@ unavoidable boundaries as the private `/show/` surface.
 
 ## Rejected Alternatives
 
-### Enable `/p/` HMR for every public viewer
+### Enable `/p/` HMR for every share-link viewer
 
-Public visibility grants content read access, not access to Vite custom messages,
+Limited/public audience grants content read access, not access to Vite custom messages,
 plugin listeners, local paths, source frames, or Runtime diagnostics. This would
 turn a share link into a development-server capability.
 
@@ -375,10 +528,10 @@ An anonymous viewer can remove a client-side condition or connect directly.
 Authorization must select the document representation and independently guard
 every private module and socket request on the server.
 
-### Serve the private representation at the public URL
+### Serve the private representation at the share URL
 
 This makes document and subresource capability checks race with one another and
-lets HTTP caches or a public-scope Service Worker retain private bytes at `/p/`.
+lets HTTP caches or a share-scoped Service Worker retain private bytes at `/p/`.
 Redirecting the editor to `/show/` makes representation identity part of the URL
 and lets the existing private route own the complete document graph.
 
@@ -396,8 +549,21 @@ the existing boundary and avoids protocol drift.
 ### Share one base-switching Vite context
 
 Alternating authorized and anonymous requests would continue to rebase or
-restart the editor's development context. Separate private/public ownership is
+restart the editor's development context. Separate private/shared ownership is
 the minimum isolation needed for reliable HMR.
+
+### Keep email grants beside a separate public switch
+
+This reproduces the current invalid combinations: grants can exist without a
+share route, and anonymous publication can bypass the list. Email grants and
+anonymous publication are mutually exclusive audience modes, not independent
+features.
+
+### Grant limited viewers ordinary Instance viewer access
+
+That would expose Workbench and every resource permitted to an Instance viewer.
+The existing `show_page_email` claim is deliberately frozen to one Show Page and
+must remain view-only even when the same person has other unrelated access.
 
 ### Add anonymous artifact Live Reload
 
@@ -409,82 +575,146 @@ feature, not a prerequisite for capability-gated editor HMR.
 
 ## Delivery Sequence
 
-1. Freeze `ShowEditorCapability`, top-level navigation detection, and the
-   capability-gated `/p/` to `/show/` redirect as contract fixtures; pin the
-   existing Show bootstrap payload as unchanged.
-2. Factor public annotation authorization into the shared, resource-aware editor
-   capability and use the same result for editor navigation.
-3. Add the explicit Runtime capability state machine and one typed context
-   parameter; split canonical private and disposable public context ownership
+1. Freeze `ShowAccess`, the unified access mutation payload, migration fixtures,
+   and the read/editor capability matrix as contract files shared by the UI,
+   local server, and hosted backend.
+2. Replace workspace audience plus public-link switch with the three-option
+   select. Render exact emails only for `limited`, and link controls only for
+   `limited | public`; keep availability separate.
+3. Implement the fail-closed access coordinator and idempotent revision contract.
+   Retire the independent visibility and email mutation paths after compatibility
+   callers migrate.
+4. Make `/p/<share>/` resolve both `limited` and `public`. Add the limited login,
+   exact page-entitlement check, generic denial, current-revision check, and
+   private/no-store response policy.
+5. Factor annotation authorization into the shared, resource-aware
+   `ShowEditorCapability`, explicitly excluding page-email entitlement, and use
+   the same result for top-level editor navigation.
+6. Add the explicit Runtime capability state machine and one typed context
+   parameter; split canonical `private` and disposable `shared` context ownership
    without changing the private URL or bootstrap protocol. Migrate every HTTP,
-   WebSocket, fallback, and prewarm caller in the same contract change.
-4. Redirect authorized top-level `/p/` navigations to the equivalent `/show/`
-   route. Never route a `/p/` subresource to the private context.
-5. Keep every non-redirected `/p/` request on the public transform/shim path and
-   remove the public HMR websocket.
-6. Preserve resource-viewer authorization for ordinary private modules while
-   requiring editor capability for HMR, annotation writes, and public-link
+   WebSocket, fallback, and prewarm caller in the same contract change, and send
+   the backward-compatible context header before negotiation completes.
+7. Redirect authorized top-level `/p/` navigations to the equivalent `/show/`
+   route. Never route a `/p/` subresource to the private context. Keep every
+   remaining `/p/` request on the shared transform/shim path and remove the
+   shared-route HMR websocket.
+8. Preserve resource-viewer authorization for ordinary private modules while
+   requiring editor capability for HMR, annotation writes, and share-link
    redirect selection.
-7. Add opaque public file handles plus Runtime response provenance so raw
-   `/@fs/` paths and development diagnostics cannot cross the public boundary.
-8. Add the coalesced durable visibility monitor for private HMR sockets.
-9. Add cache, Service Worker scope, revocation, mixed-version, negotiation retry,
-   total context propagation, concurrency, and path-confinement contract tests.
-10. Run local Incus regression with authorized, read-only, anonymous, and revoked
-    viewers open concurrently.
+9. Add leased opaque shared file namespaces, Runtime response provenance, and
+   URL-bearing header filtering so raw `/@fs/` paths, stale unbounded handles,
+   and development diagnostics cannot cross the shared boundary.
+10. Add the coalesced durable availability monitor for private HMR sockets.
+11. Add cache, Service Worker scope, network-revocation, mixed-version,
+    negotiation retry, total context propagation, concurrency, path-confinement,
+    and audience-transition contract tests.
+12. Run local Incus regression with editor, exact-email, anonymous, denied, and
+    revoked viewers open concurrently.
 
 The capability branch rolls out with the bundled Runtime change. Avibe enables
 the redirect only after `GET /capabilities` returns protocol `1` and the exact
 `show-context-key-v1` feature. A definitive legacy Runtime keeps `/p/` on the
 existing no-HMR behavior and its existing single-context limitation; it is never
 described as isolated. A transient or malformed startup response fails the current
-request closed to public mode but remains retryable. An accepted legacy app request
-is not negotiation, and the old anonymous public socket is never a compatibility
-fallback.
+request closed to shared mode, carries the explicit backward-compatible context,
+and remains retryable. An accepted legacy app request is not negotiation, and the
+old anonymous shared-route socket is never a compatibility fallback.
+
+### Data migration
+
+The schema migration separates availability from audience and is fail-closed:
+
+| Existing state | Migrated availability | Migrated access mode | Share ID |
+| --- | --- | --- | --- |
+| `visibility=public` | `active` | `public` | Preserve current ID |
+| `visibility=private` with no email grants | `active` | `private` | Clear any dormant ID |
+| `visibility=private` with a non-empty exact-email set | `active` after connected reconciliation | `limited` | Reuse a valid dormant ID or allocate one |
+| `visibility=offline` | `offline` | `private` | Clear; the old model did not retain a trustworthy prior audience |
+
+Until the device can read the hosted grant set, an old private page stays
+private and records migration pending; it is never guessed to be limited. An old
+public page remains public, and any independently stored email set is cleared
+after the local public state is authoritative. Organization resource policies
+are not mapped into external audience modes; they remain canonical `/show/`
+collaborator policy.
+
+The compatibility read API may project old `visibility` fields for one release,
+and new writes maintain a rollback-safe projection: public maps to old `public`,
+private and limited map to old `private`, and offline maps to old `offline`.
+Authoritative writes still go only through `ShowAccess`. A rollback therefore
+treats `limited` as private because older code cannot enforce its `/p/`
+authentication gate.
 
 ## Verification Plan
 
 ### Authorization and document contract tests
 
+- prove the settings API and UI expose exactly `private | limited | public`, the
+  old public switch is absent, emails render only for `limited`, and `/p/` link
+  controls render for `limited | public`
+- exercise every audience transition, coordinator failure point, stale revision,
+  retry, and double submission; no intermediate state may grant more read access
+  than the last committed or requested target
 - seed every supported identity/resource shape and assert that `canAnnotate` and
-  the public-link redirect are produced by the same editor capability
-- prove anonymous, read-only, expired, resource-forbidden, and unverifiable
-  top-level navigations receive only the public representation
+  the share-link redirect are produced by the same editor capability
+- prove page-email entitlement can satisfy only limited read, cannot satisfy the
+  editor's resource proof, and cannot access settings, Workbench, Agents,
+  annotations, HMR, or any other Show Page
+- prove a real independent page editor still redirects when the same email is
+  also listed
+- prove anonymous, expired, resource-forbidden, and unverifiable public
+  navigations receive only the shared representation, while equivalent limited
+  requests enter login or receive a generic denial with no page bytes
 - prove query parameters, headers outside the trusted identity boundary,
   annotation write tokens, subresource requests, and missing Fetch Metadata
   cannot trigger the redirect
 - prove the redirect preserves the route suffix and query while both redirect and
-  public entry responses are private/no-store and vary on cookies
-- prove public and private documents retain every existing Show bootstrap key and
-  that public configuration contains no Session identifier or private path
+  shared entry responses are private/no-store and vary on cookies
+- prove shared and private documents retain every existing Show bootstrap key,
+  shared configuration exposes `canAnnotate=false`, and it contains no Session
+  identifier or private path
+- prove migration maps old public, private-with-grants, private-without-grants,
+  and offline rows exactly as specified, with disconnected reconciliation staying
+  private
 
 ### Runtime and proxy tests
 
 - Runtime capability negotiation distinguishes supported, definitive legacy, and
   transient-unknown outcomes; transient failures retry and every outcome resets
   with the Runtime process
-- Avibe strips browser context headers; negotiated private and public contexts
+- Avibe strips browser context headers; negotiated private and shared contexts
   have independent keys and lifecycles
 - every app-graph call, including SPA fallback, WebSocket setup, startup
-  reconciliation, and public/private prewarm, carries the selected typed context;
+  reconciliation, and shared/private prewarm, carries the selected typed context;
   Runtime rejects missing or invalid selection before touching Vite ownership
-- public requests never change, close, or rebuild the private context
+- a transient capability probe still sends `shared`, works with the new Runtime,
+  and remains accepted by a legacy Runtime that ignores the header
+- shared requests never change, close, or rebuild the private context
 - authorized top-level `/p/` navigations redirect before document bytes to the
   equivalent canonical `/show/` route
-- unprivileged documents reference only public paths, opaque allowed-file handles,
+- unprivileged documents reference only shared paths, opaque allowed-file handles,
   and immutable shims; raw `/@fs/`, host paths, and Session paths are denied
 - Runtime response provenance preserves authored application errors while every
-  development diagnostic receives a fixed public body
+  development diagnostic receives a fixed shared body; unsafe `SourceMap`,
+  `X-SourceMap`, `Content-Location`, `Refresh`, `Location`, and `Link` values are
+  stripped or safely rewritten
+- old opaque namespaces survive lazy loads while leased, expire as a whole after
+  30 idle minutes, never cross graph/share boundaries, and do not make admission
+  capacity permanently consumable across successive edits
 - `/p/<share>/__vite_hmr` rejects every connection
 - private document/module requests retain resource-reader ACL; private HMR repeats
   editor/resource/origin checks, closes on authorization-revision or resource
-  revocation, and polls durable visibility once per active Session so direct CLI
+  revocation, and polls durable availability once per active Session so direct CLI
   offline changes close sockets within five seconds
-- public Runtime responses cannot expand a Service Worker beyond the public share
-  scope, and a public worker cannot control or cache the `/show/` representation
-- every existing public path-confinement fixture remains denied by the new
+- shared Runtime responses cannot expand a Service Worker beyond the share scope,
+  and a shared worker cannot control or cache the `/show/` representation
+- network-reached access-mode changes and rotations revoke the old route; a
+  separately asserted client-cache case documents that an already installed
+  worker may render only previously downloaded shared bytes
+- every existing shared-route path-confinement fixture remains denied by the new
   routing branch, including sensitive segments and workspace escapes
-- direct CLI share rotation or visibility mutation invalidates the old public
+- direct CLI share rotation or access mutation invalidates the old shared
   route without touching independently authorized private access
 
 ### Browser and regression scenarios
@@ -492,60 +722,74 @@ fallback.
 | ID | Scenario | Expected evidence |
 | --- | --- | --- |
 | `SHOW-LIVE-001` | Authorized editor opens `/p/<share>/` and the Agent edits a component | The navigation redirects to `/show/`; React Fast Refresh preserves component state |
-| `SHOW-LIVE-002` | Anonymous viewer opens the same link during the edit | No HMR socket exists and the loaded page stays unchanged until refresh |
-| `SHOW-LIVE-003` | Signed-in read-only or resource-forbidden viewer opens the link | Behavior and bytes match anonymous public mode; no private identifier appears |
-| `SHOW-LIVE-004` | Direct `/show/`, redirected editor `/show/`, and anonymous `/p/` are open together | Both private documents keep HMR while public traffic uses an independent context |
-| `SHOW-LIVE-005` | Identity resolution fails for a request carrying an unverifiable cookie | The public page remains readable with no HMR or diagnostic leak |
-| `SHOW-LIVE-006` | Editor role is revoked while redirected HMR is open but read ACL remains | The socket closes, private modules remain readable, and the next `/p/` navigation stays public |
-| `SHOW-LIVE-007` | Share rotates or direct CLI changes visibility | The old public URL stops serving; share rotation leaves entitled private HMR independent, while offline closes it within five seconds |
-| `SHOW-LIVE-008` | Public requests target every existing denied path shape | All remain denied before Runtime access; no sensitive or escaped file is returned |
+| `SHOW-LIVE-002` | Exact-email viewer opens a limited link and the Agent edits | The viewer stays on `/p/`, has no annotation UI or HMR socket, and sees new content only after refresh |
+| `SHOW-LIVE-003` | Anonymous viewer opens the limited link, signs in with an unlisted email, then retries | Login returns to the same `/p/` route, which gives a generic denial and no page bytes |
+| `SHOW-LIVE-004` | The same link changes from limited to fully public | Anonymous refresh becomes readable; listed viewers still receive no HMR or annotations |
+| `SHOW-LIVE-005` | Direct `/show/`, redirected editor `/show/`, exact-email `/p/`, and anonymous public `/p/` are open together | Both private documents keep HMR while all `/p/` traffic uses an independent shared context |
+| `SHOW-LIVE-006` | Identity resolution fails for public and limited requests | Public remains readable with no HMR; limited fails closed without leaking its audience |
+| `SHOW-LIVE-007` | Editor role is revoked while redirected HMR is open but read ACL remains | The socket closes, private modules remain readable, and `/p/` follows only the current audience read rule |
+| `SHOW-LIVE-008` | An email is removed while its limited page is open | The next network read is denied through authorization revision; no development channel ever existed |
 | `SHOW-LIVE-009` | A viewer connects directly to `/p/<share>/__vite_hmr` | The connection is rejected regardless of cookies or visibility |
-| `SHOW-LIVE-010` | Authorized and anonymous viewers remain open through repeated edits | Context count stays bounded, private HMR remains stable, and no public background build occurs |
-| `SHOW-LIVE-011` | A public document starts while identity is unavailable and identity recovers during module loading | Every module stays on `/p/`; no Vite client or mixed transform graph appears |
+| `SHOW-LIVE-010` | Editor and shared viewers remain open through repeated edits | Context and leased-namespace counts stay bounded, private HMR remains stable, and no shared background build occurs |
+| `SHOW-LIVE-011` | A shared document starts while identity is unavailable and identity recovers during module loading | Every module stays on `/p/`; no Vite client or mixed transform graph appears |
 | `SHOW-LIVE-012` | A read-only user opens `/show/<session>/` | The complete private module graph loads, while the HMR socket is denied |
-| `SHOW-LIVE-013` | Public content registers a share-scoped Service Worker, then the editor opens the link | No private bytes are served at `/p/`; any network-reached redirect lands outside the worker scope at `/show/` |
+| `SHOW-LIVE-013` | Shared content registers a share-scoped Service Worker, then the editor opens the link | No private bytes are served at `/p/`; any network-reached redirect lands outside the worker scope at `/show/`, and cached old bytes are recorded as a client-cache limitation |
 | `SHOW-LIVE-014` | Avibe runs against a Runtime without `show-context-key-v1` | Every `/p/` viewer stays on the compatibility no-HMR path; the existing single-context limitation is explicit and cannot be mistaken for negotiated isolation |
-| `SHOW-LIVE-015` | The first capability probe times out or returns truncated JSON while new Runtime starts | The request stays public, a later bounded retry detects support, and the next eligible navigation redirects without restarting Runtime |
-| `SHOW-LIVE-016` | Public transforms emit nested `/@fs/` imports and Vite transform errors | Only current context-bound opaque handles reach the browser and every development error body is fixed and path-free |
-| `SHOW-LIVE-017` | Startup reconciliation and `vibe show update` prewarm public and private graphs | Each request carries its typed context; a missing/invalid context fails before creating or rebasing either graph |
+| `SHOW-LIVE-015` | The first capability probe times out while the new Runtime app endpoint is ready | The request carries `shared` and succeeds, a later bounded retry detects support, and the next eligible navigation redirects without restart |
+| `SHOW-LIVE-016` | Shared transforms emit nested `/@fs/` imports, URL-bearing headers, and Vite errors | Only leased context-bound handles and safe rewritten headers reach the browser; every development error is fixed and path-free |
+| `SHOW-LIVE-017` | Startup reconciliation and `vibe show update` prewarm shared and private graphs | Each request carries its typed context; a missing/invalid context fails before creating or rebasing either graph |
 | `SHOW-LIVE-018` | Direct CLI changes an active page to offline with private HMR connected | The coalesced durable monitor closes every socket for the Session within five seconds without relying on an in-process event |
+| `SHOW-LIVE-019` | Public changes to limited and the cloud write fails | The local gate remains private; neither anonymous nor stale listed viewers can read until a complete retry succeeds |
+| `SHOW-LIVE-020` | Old private/public/offline rows and exact-email grants upgrade | Each page matches the migration table; a disconnected private-with-grants page stays private and pending |
 
 Focused unit/contract tests, Ruff, repository CI, and local Incus browser
-regression are required. Green unit tests do not replace simultaneous
-authorized/anonymous browser verification.
+regression are required. Green unit tests do not replace simultaneous editor,
+exact-email, denied, anonymous, and revoked browser verification.
 
 ## Acceptance Gate
 
 The design is implemented when all of the following are true:
 
-- Authorized public-link navigations redirect to the corresponding private URL
+- The settings surface has one three-option audience select, no public-link
+  switch, conditional email/link controls, and one authoritative Apply action.
+- `private`, `limited`, `public`, and orthogonal offline availability persist and
+  migrate according to one documented model.
+- Both limited and public sharing use `/p/<share>/`; limited requires a current
+  exact page grant and fully public remains anonymously readable.
+- Page-email authority is view-only and cannot contribute evidence to
+  `ShowEditorCapability`, settings, Workbench, Agents annotations, HMR, or another
+  Show Page.
+- Authorized share-link editor navigations redirect to the corresponding private URL
   and get the same Vite HMR and React Fast Refresh behavior as private editors.
-- Annotation writes and the public-link editor redirect consume one validated,
+- Annotation writes and the share-link editor redirect consume one validated,
   resource-aware editor capability.
-- Every other public viewer receives a readable no-HMR representation with no
-  private identifier, diagnostics, or bidirectional Runtime channel.
+- Every allowed non-editor `/p/` viewer receives the shared no-HMR representation
+  with no annotations, private identifier, diagnostics, or bidirectional channel;
+  disallowed limited viewers receive no page bytes.
 - `/show/<session>/__vite_hmr` is the only HMR endpoint and independently
   revalidates authorization; `/p/<share>/__vite_hmr` does not exist.
 - A loaded `/p/` document cannot switch representation as identity changes, and
-  on a negotiated Runtime anonymous traffic cannot restart, rebase, or close the
+  on a negotiated Runtime shared traffic cannot restart, rebase, or close the
   private Vite context.
 - Capability-varying responses cannot be shared across viewers by a cache.
-- Public Service Workers cannot cache private bytes at `/p/` or control `/show/`.
+- Shared Service Workers cannot cache private bytes at `/p/` or control `/show/`;
+  server-side revocation claims are limited to requests that reach Avibe.
 - Ordinary private module reads preserve resource-viewer access while HMR remains
   editor-only.
 - Runtime support is accepted only through the explicit keyed-context capability
   handshake; definitive mixed versions retain the existing compatibility
-  limitation, while transient negotiation failures retry without denying public
-  reads or permanently disabling the feature.
+  limitation, while transient negotiation failures carry the backward-compatible
+  shared context and retry without permanently disabling the feature.
 - Context selection is mandatory at every Runtime app-graph call site, including
   prewarm and fallback paths, and missing selection fails before Vite ownership.
-- Public file references use context-bound opaque handles after path validation;
-  raw absolute paths and Runtime development diagnostics never reach the browser.
+- Shared file references use leased context-bound opaque handles after path
+  validation; raw absolute paths, unsafe URL-bearing response headers, and Runtime
+  development diagnostics never reach the browser.
 - Direct durable offline mutations close active private HMR within five seconds;
   share rotation alone does not revoke entitled canonical private access.
-- Authorization failure preserves public availability and fails closed to
-  no-HMR mode.
-- Existing public source-confinement and sensitive-path protections hold for the
+- Authorization failure preserves fully public availability, fails limited access
+  closed, and never selects HMR.
+- Existing shared-route source-confinement and sensitive-path protections hold for the
   complete request surface.
 - Local Incus measurements show bounded context memory and no material page-load
-  regression beyond existing private/public transform costs.
+  regression beyond existing private/shared transform and limited-auth costs.

--- a/docs/plans/public-show-live-update.md
+++ b/docs/plans/public-show-live-update.md
@@ -17,7 +17,8 @@ the resulting representation:
 | Surface and viewer | Runtime representation | Update behavior |
 | --- | --- | --- |
 | Private `/show/<session>/`, authorized editor | Canonical private Vite context | Vite HMR and React Fast Refresh |
-| Limited or public `/p/<share>/`, authorized editor navigation | Redirect to canonical `/show/<session>/` | Vite HMR and React Fast Refresh after the redirect |
+| Limited or public `/p/<share>/`, authorized editor navigation with a negotiated Runtime | Redirect to canonical `/show/<session>/` | Vite HMR and React Fast Refresh after the redirect |
+| Limited or public `/p/<share>/`, authorized editor with a legacy Runtime | Existing shared compatibility context | Agents annotations remain available; no Hot Reload |
 | Limited `/p/<share>/`, signed-in exact-email viewer | Negotiated isolated shared context; legacy compatibility context otherwise | No Hot Reload or annotations; refresh reads current content |
 | Limited `/p/<share>/`, anonymous or unauthorized viewer | None | Login challenge or access denied; no page bytes |
 | Public `/p/<share>/`, anonymous, read-only, expired, resource-forbidden, or unverifiable | Negotiated isolated shared context; legacy compatibility context otherwise | No Hot Reload or annotations; refresh reads current content |
@@ -98,9 +99,12 @@ custom-slug, and rotate-link controls appear for both `limited` and `public`.
 
 `offline` is not a fourth audience. Availability is an orthogonal lifecycle
 state (`active | offline`) controlled by archive/offline operations. An offline
-page serves no route and its audience control is read-only until reactivated.
-Separating availability from audience also stops an offline transition from
-silently destroying the page's intended audience.
+page serves no route, but an authorized owner may still change its audience,
+replace or clear its limited grants, and rotate its future share binding without
+reactivating it. Apply and recovery use the same coordinator while route admission
+remains disabled. Separating availability from audience stops an offline transition
+from silently destroying the page's intended audience and does not force an owner to
+publish a page merely to clean up access.
 
 The persisted model is therefore:
 
@@ -140,11 +144,11 @@ promote itself through a broader Instance endpoint.
 Audience changes use one Apply action and one durable fail-closed coordinator
 rather than three independent writes. The coordinator is a cross-process write
 boundary, not an in-memory mutex. Every current-version entry point that can mutate
-`ShowAccess`, its legacy projection, or coordinator recovery state -- including the
-CLI, Web API, startup/migration reconciliation, and updater -- must acquire the same
+`ShowAccess` or coordinator recovery state -- including the CLI, Web API, and
+startup/migration reconciliation -- must acquire the same
 exclusive advisory lock at a stable file in Avibe's state directory before reading
-mutation preconditions. The lock file is never replaced or deleted during the
-compatibility window, so every process locks the same inode. Store mutation methods
+mutation preconditions. The lock file is never replaced or deleted, so every process
+locks the same inode. Store mutation methods
 require a held lock lease; callers cannot bypass the coordinator with a direct
 `ShowPageStore` write. The lock is acquired before any database transaction, and no
 code may wait for it while holding a database or hosted-operation lock.
@@ -153,14 +157,18 @@ Every Apply allocates a client mutation ID and holds the process-shared lease fr
 its first authoritative precondition read through either its terminal local commit
 or the durable recording of a fail-closed pending phase. A process crash releases
 the OS lock, but it can leave only a prepared non-authoritative hosted operation or
-a locally recorded pending phase that downgrade preflight rejects. For a change that
+a locally recorded pending phase that the next current-version process reconciles
+before admitting limited reads. For a change that
 carries exact emails, the device first sends the normalized in-memory target and
 expected page-scoped `grant_revision` to a backend `prepare` operation. Preparation
-stores the target only inside the existing hosted grant trust boundary, changes no
-grant authority, and returns an opaque operation ID plus an opaque target
-`grant_commitment`. The backend generates a fresh cryptographically random 256-bit
-commitment after canonicalizing the page-bound email set and binds it to that
-prepared operation; it is never derived from an email or a client-held key. A
+canonicalizes before comparing it with the authoritative current set. If they match,
+it returns a terminal `no_change` result containing the existing commitment and
+revision; the device creates no pending hosted operation and does not close an
+already-open gate. Otherwise preparation stores the target only inside the existing
+hosted grant trust boundary, changes no grant authority, and returns an opaque
+operation ID plus an opaque target `grant_commitment`. The backend generates a fresh
+cryptographically random 256-bit commitment and binds it to that prepared operation;
+it is never derived from an email or a client-held key. A
 prepared operation has a non-renewable 24-hour lifetime. If this step fails or its
 response is lost, no local transition is accepted and the previous audience remains
 authoritative; an unreferenced preparation can only expire, never commit itself.
@@ -168,11 +176,14 @@ authoritative; an unreferenced preparation can only expire, never commit itself.
 After preparation succeeds, one local transaction persists only the opaque
 operation ID, source audience revision, source page grant revision, target mode,
 target or preserved share binding, target commitment, and phase. It never persists
-the email addresses. Any transition that can add, remove, or replace page-email
-authority also sets `share_admission_gate=closed_pending` in that same transaction.
-This gate is orthogonal to `access_mode`: while it is closed, every `/p/` read and
-editor redirect is denied and the page-email branch of the canonical `/show/` ACL
-rejects claims, but the committed mode and `share_id` remain intact for recovery.
+the email addresses. Before a transition whose target mode is `limited` can add,
+remove, or replace page-email authority, it also sets
+`share_admission_gate=closed_pending` in that transaction. While a limited gate is
+closed, every `/p/` read and editor redirect is denied and the page-email branch of
+the canonical `/show/` ACL rejects claims. Entry into limited commits the conservative
+target mode and preserved `share_id` together with the closed gate; an edit to an
+already limited list leaves that mode and binding intact. Public reads do not depend
+on this limited-only gate.
 Owner and organization resource ACLs on canonical `/show/` remain independent.
 
 The device then asks the backend to `commit` the prepared operation. Commit
@@ -188,8 +199,10 @@ backend's committed operation, exact current set/commitment, and returned page g
 revision match the local record and that revision has been persisted locally. The
 backend deletes the prepared target copy after device acknowledgement or the
 24-hour hard limit; a terminal result retains only non-PII metadata and the opaque
-commitment. A same-set no-op returns the existing commitment and revision; a later
-change back to a previously used set receives a new random commitment. Consequently,
+commitment. A terminal same-set response is also the reconciliation proof for a
+local mode-only transition into `limited`: the device persists exactly the returned
+existing commitment/revision and opens the new limited audience atomically. A later
+real change back to a previously used set receives a new random commitment. Consequently,
 a copied SQLite database or backup exposes no deterministic verifier for guessed
 email addresses.
 If the result copy has expired after commit, the authoritative current page-grant
@@ -202,22 +215,23 @@ page-grant revision poll is recovery evidence, never the security boundary.
 
 The coordinator applies that invariant to every transition:
 
-1. Entering `limited` from `public` closes only `share_admission_gate`, preserving
-   the committed `public` mode and exact `share_id` while all `/p/` reads are denied.
-   It then replaces and reconciles the cloud email set and atomically commits
-   `limited` with that same binding while reopening the gate. A crash therefore
-   cannot expose anonymous access or silently rotate the URL.
-2. Entering `limited` from `private` follows the same closed-barrier protocol.
-   At least one address is required; any requested or allocated target binding is
-   non-sensitive coordinator state until the terminal local transaction.
+1. Entering `limited` from `public` atomically commits the conservative target mode,
+   closes `share_admission_gate`, and preserves the exact `share_id` before any hosted
+   commit. It then replaces and reconciles the cloud email set and reopens that same
+   limited binding. A crash therefore cannot preserve anonymous access or silently
+   rotate the URL.
+2. Entering `limited` from `private` follows the same closed-barrier protocol and
+   commits the requested or allocated binding with the closed target mode. At least
+   one address is required.
 3. Editing a live limited list closes the share admission gate before sending the
    replacement. Removed and retained viewers are both denied during ambiguity;
    the reconciled revision reopens the new set together.
-4. Leaving `limited` commits `private` or `public` locally first. Page-email
+4. Leaving `limited` commits `private` or `public` locally with
+   `share_admission_gate=open`. Page-email
    claims are accepted only when the current durable mode is exactly `limited`,
    so the local commit removes their authority from both `/p/` and `/show/`
    before best-effort backend cleanup. Failed cleanup is retried and surfaced as
-   pending but cannot restore authority.
+   pending but cannot restore authority or make a committed public page unavailable.
 5. Switching `private` and `public` is one local transaction. Link allocation,
    mode, revision, and old-route invalidation commit together.
 
@@ -345,9 +359,9 @@ that requirement 7 has been met.
 ```text
 GET /p/<share>/...
   -> resolve current limited/public share and availability
-  -> require share_admission_gate == open
   -> access_mode == limited?
-     -> yes: require current page-bound email grant at grant_revision or ShowEditorCapability
+     -> yes: require share_admission_gate == open, then require current page-bound
+             email grant at grant_revision or ShowEditorCapability
      -> no: public read is allowed
   -> top-level navigation + Runtime keyed-context capability?
      -> yes: compute ShowEditorCapability
@@ -403,11 +417,11 @@ X-Avibe-Show-Context: private | shared
 A legacy Runtime ignores both unknown headers. A new Runtime treats protocol `1`
 as an explicit client declaration and requires a valid context before resolving a
 Session or changing Vite ownership. A request with no protocol header is from a
-released/rolled-back Avibe client: Runtime ignores any context value, selects the
+released Avibe client: Runtime ignores any context value, selects the
 legacy singleton base-switching path from the existing `x-vibe-show-base`, and does
 not claim keyed isolation. An unknown protocol value fails closed. This preserves
-old-Avibe/new-Runtime source and rollback pairings without letting a missing header
-from a declared new client silently downgrade its contract. Avibe strips any
+old-Avibe/new-Runtime source compatibility without letting a missing header from a
+declared new client silently weaken its contract. Avibe strips any
 browser-supplied copy of both protocol headers. Runtime health alone, an accepted
 app request, a package version, or support for `x-vibe-show-base` is not capability
 evidence.
@@ -465,6 +479,24 @@ path policy as an invariant over the whole shared request surface:
 The shared context continues to use inert, versioned `@vite/client` and React
 Refresh shims. It exposes neither Runtime diagnostics nor a message channel.
 
+The legacy compatibility path is availability-preserving, not a second
+implementation of keyed isolation. It never enables HMR. A viewer with current
+`ShowEditorCapability` keeps the existing share-scoped annotation bootstrap and
+write token (`canAnnotate=true`); page-email, anonymous, and other read-only viewers
+receive `canAnnotate=false`. This capability choice changes only annotation UI and
+dispatch, never the Runtime context or module namespace.
+
+Legacy Runtime output is accepted only where the existing shared proxy can prove it
+safe without a new Runtime feature. Avibe-authored exact-file and API responses keep
+their existing behavior. A successful legacy Runtime response must complete the
+existing shared body, URL, and header transforms; if it contains a raw or nested
+`/@fs/` reference that requires the new immutable-snapshot registry, transformation
+fails closed with a fixed path-free unavailable response. For a Runtime error or
+failed transform without valid provenance metadata, Avibe replaces the body and
+URL-bearing headers with that same fixed response. It does not guess that an
+unclassified error is application-authored. This reduced compatibility surface is
+temporary because the capability ships with the bundled Runtime.
+
 Vite's native `/@fs/<absolute-path>` form cannot cross that shared boundary.
 When a shared transform references an allowed absolute file, Runtime opens it
 through a confinement-safe root descriptor: resolution cannot escape the selected
@@ -515,6 +547,8 @@ authored application/API bodies and successful assets, but replaces every
 preserving only the safe status class. Source frames, plugin errors, stack traces,
 and local paths remain in a redacted operator log. HTTP error status alone is not
 trusted to distinguish an authored API error from a Vite transform failure.
+Missing or invalid provenance follows the legacy fail-closed rule above; only an
+Avibe-authored response that did not traverse Runtime may bypass Runtime provenance.
 
 The shared proxy also treats response headers as URL output. It always removes
 `SourceMap`, `X-SourceMap`, `Content-Location`, and `Refresh`. It parses `Location`
@@ -630,19 +664,20 @@ request.
 | Missing/expired identity on limited page | Redirect to login for a top-level navigation; otherwise deny without page bytes | Redacted authorization reason |
 | Signed-in user lacks exact limited grant | Return one generic access-denied response; do not reveal whether the address or page exists | Redacted page-bound denial |
 | Identity service unavailable | Fully public stays readable; limited fails closed and remains retryable | Authorization availability metric/log |
-| Definitive keyed-context capability absence | Do not redirect; serve `/p/` through the legacy no-HMR path with its existing single-context limitation recorded | Runtime capability metric/log |
+| Definitive keyed-context capability absence | Do not redirect; serve `/p/` through the reduced legacy no-HMR path; preserve annotations only for a proven editor | Runtime capability metric/log |
 | Transient capability negotiation failure | Send the backward-compatible explicit `shared` context, keep the current allowed request shared, and retry after bounded backoff | Redacted probe state and retry metric |
 | Private Runtime unavailable after an editor redirect | Existing private sanitized recovery behavior; never fall through to a raw shared-route socket | Private Runtime log |
 | Shared context unavailable | Existing sanitized shared unavailable/static fallback | Shared Runtime log without source detail |
 | Shared Runtime admission is saturated | Reclaim the oldest non-in-flight shared bundle; if none is reclaimable, return a sanitized retryable unavailable response without consuming the private reserve | Global weighted-budget admission/reclamation metric |
 | A shared document outlives its absolute namespace/context lifetime | Return a fixed stale-document response for later module or lazy-asset reads and require reload | Namespace hard-expiry metric without source paths |
 | Runtime emits a development diagnostic or unsafe URL header | Preserve only a safe status class/body and filtered headers | Redacted operator-only diagnostic |
+| Legacy Runtime omits provenance or emits a graph requiring raw `@fs` paths | Preserve only a fully transformed safe success response; otherwise return a fixed path-free unavailable response | Redacted compatibility refusal reason |
 | Limited-list replacement has an ambiguous result | Keep the durable share admission gate closed across retries and restarts until read-after-write reconciliation persists the exact mutation result | Mutation ID, opaque target commitment, and redacted reconciliation state |
 | Prepared email operation expires before commit | Reopen the prior share audience only after authoritative commitment/revision proof that no commit occurred; otherwise remain closed and require target resubmission | Operation expiry and opaque target commitment |
 | Limited email removed | Reject the viewer's next network request by page grant revision; no HMR or annotation channel exists to close | Page-grant revision log |
 | Unrelated Instance authorization changes | Refresh generic session freshness without changing any page grant revision or denying an unchanged limited viewer | Instance and page revision metrics kept distinct |
-| Limited page becomes private/public while hosted cleanup fails | Reject page-email claims on both `/p/` and `/show/` from the local mode commit; retry cleanup without reopening authority | Durable audience state and cleanup-pending record |
-| Binary downgrade sees a limited/non-empty/pending page or cannot attest the backend fence | Refuse executable/schema replacement; while the fence is active, reject every released exact-email write | Fence epoch and redacted preflight reason |
+| Limited page becomes private/public while hosted cleanup fails | Reject page-email claims on both `/p/` and `/show/` from the local mode commit; keep public reads open and retry cleanup without reopening email authority | Durable audience state and cleanup-pending record |
+| Audience changes while the page is offline | Keep every route disabled; run the normal coordinator and persist the future audience without temporary publication | Durable audience state and coordinator evidence |
 | Editor role revoked but read ACL remains | Close private HMR; retain entitled private document/module reads; next `/p/` navigation stays shared only if its audience read rule succeeds | Existing authorization-revision/resource-revocation log |
 | Show Page read access revoked | Close private HMR and reject later private document/module reads; `/p/` is re-evaluated independently | Existing resource-revocation log |
 | Share rotates or becomes private | Old network-reached `/p/` reads fail immediately; an entitled canonical private socket remains independent; previously cached bytes remain a client-cache limitation | Durable Show Page state |
@@ -722,10 +757,9 @@ feature, not a prerequisite for capability-gated editor HMR.
    `limited | public`; keep availability separate.
 3. Implement backend prepare/commit email operations, page-scoped grant revisions,
    opaque grant commitments, the non-PII persistent share admission barrier, the
-   process-shared audience write lease, idempotent
-   mutation-result/current-grant lookup, the downgrade legacy-write fence, and the
-   fail-closed access coordinator. Retire the independent visibility and email
-   mutation paths after compatibility callers migrate.
+   process-shared audience write lease, idempotent no-op and
+   mutation-result/current-grant lookup, and the fail-closed access coordinator.
+   Retire the independent visibility and email mutation paths after callers migrate.
 4. Make `/p/<share>/` resolve both `limited` and `public`. Add the limited login,
    mode-scoped exact page-entitlement check on both `/p/` and `/show/`, generic
    denial, page-grant revision check, and private/no-store response policy.
@@ -752,7 +786,7 @@ feature, not a prerequisite for capability-gated editor HMR.
    diagnostics cannot cross the shared boundary.
 10. Add the coalesced durable availability monitor for private HMR sockets.
 11. Add cache, Service Worker scope, network-revocation, mixed-version,
-    negotiation retry, total context propagation, concurrency, rollback-write,
+    negotiation retry, total context propagation, concurrency, one-way migration,
     path-swap confinement, and audience-transition contract tests.
 12. Run local Incus regression with editor, exact-email, anonymous, denied, and
     revoked viewers open concurrently.
@@ -779,87 +813,33 @@ The schema migration separates availability from audience and is fail-closed:
 | `visibility=private` with a non-empty exact-email set | `active` after connected reconciliation | `limited` | Reuse a valid dormant ID or allocate one |
 | `visibility=offline` | `offline` | `private` | Clear; the old model did not retain a trustworthy prior audience |
 
-Until the device can read the hosted grant set, an old private page stays
-private and records migration pending with the source `audience_revision` and
-legacy-audience journal generation; it is never guessed to be limited. The hosted
-read returns the page-scoped grant revision and commitment, and reconciliation may
-commit only with a compare-and-swap proving that all three inputs are still current. The
-Instance-wide authorization revision is deliberately absent from this page-state
-comparison.
-Every authoritative audience Apply and every reconciled legacy write increments
-`audience_revision` and deletes any pending migration in the same local transaction
-before remote work begins. A stale worker discards its hosted read and any provisional
-share allocation when that compare-and-swap fails; it cannot convert a newer public
-or private choice to `limited`. An old public page remains public, and any
-independently stored email set is cleared after the local public state is
-authoritative. Organization resource policies are not mapped into external audience
-modes; they remain canonical `/show/` collaborator policy.
+Until the device can read the hosted grant set, an old private page stays private
+and records migration pending with its source `audience_revision`; it is never
+guessed to be limited. The hosted read returns the page-scoped grant revision and
+commitment, and reconciliation may commit only with a compare-and-swap proving that
+the source revision is still current. The Instance-wide authorization revision is
+deliberately absent from this page-state comparison.
 
-The compatibility read API projects the complete legacy audience for one rollback
-window. New writes maintain a safe projection: public maps to old `public`; private
-and limited map to old `private`; offline maps to old `offline`; and the projected
-legacy `share_id` is the current binding only for a shareable mode.
+Every authoritative audience Apply increments `audience_revision` and deletes any
+pending migration in the same local transaction before remote work begins. A stale
+worker discards its hosted read and any provisional share allocation when the
+compare-and-swap fails; it cannot convert a newer public or private choice to
+`limited`. An old public page remains public, and any independently stored email set
+is cleared after the local public state is authoritative. Organization resource
+policies are not mapped into external audience modes; they remain canonical
+`/show/` collaborator policy.
 
-The migration installs one durable legacy-audience journal rather than a
-visibility-only marker. Database triggers cover every assignment to any projected
-legacy audience column and record a monotonic generation plus the complete
-post-write legacy snapshot. The invariant is field-based: adding another projected
-audience column automatically requires it in the journal trigger and snapshot
-contract. It therefore captures visibility changes, generated rotations, custom
-slug writes, and unchanged assignments without depending on which released
-`ShowPageStore` method performed the write. A new writer updates `ShowAccess`, writes
-the complete legacy projection, and acknowledges the resulting journal generation
-after those writes but before their single transaction commits. An old binary cannot
-acknowledge it. The compatibility columns, journal, triggers, and acknowledgement
-survive application rollback and schema downgrade for the entire supported rollback
-window; cleanup is a later migration after old binaries are no longer supported.
-
-On startup or re-upgrade, the newest unacknowledged journal snapshot is the legacy
-user intent to reconcile before serving the page. Legacy `private` becomes active
-`private` and clears the binding; legacy `offline` becomes offline `private` and
-clears it; legacy `public` becomes active `public` with the exact journaled slug
-after an atomic uniqueness/ownership check. A missing/corrupt snapshot or a slug
-conflict fails to private with no share route and requires the owner to choose a new
-link; stale `ShowAccess` never wins the conflict. The reconciled transaction makes
-page-email claims inapplicable unless the result is later opened as `limited`
-through the connected coordinator, writes the complete new projection, advances
-`audience_revision`, and only then acknowledges the journal generation. A rollback
-projection represents `limited` as legacy private for schema compatibility, but the
-updater never starts an old binary while any limited page exists because that binary
-cannot enforce the new read-versus-development boundary. Visibility, rotation, or
-custom-slug writes made during an allowed rollback still cannot be overwritten by
-stale `ShowAccess` on re-upgrade.
-
-Binary downgrade has a fail-closed preflight before the current executable or
-compatibility schema is replaced. Before preflight, the updater acquires the same
-stable process-shared audience write lock used by CLI, Web, migration, and recovery
-writers. It waits for any writer that already owns the lease, prevents a new writer
-from starting after preflight, and holds the lease through service quiescence and
-executable/schema replacement. Under that lock it requires the hosted resolver to
-be reachable, no audience transition or migration to be pending, every share
-admission gate to be open, no page to be `limited`, and every hosted page-email set
-to be empty with its page grant revision/commitment reconciled locally and the
-resulting Instance-wide authorization watermark persisted for the released binary's
-session-freshness check. Owners must first move every limited page
-to private or public and complete the empty-set cleanup; an open limited gate is
-never rollback-compatible because the released `/show/` HMR handler accepts
-page-email viewers.
-
-After those checks, the backend atomically activates an Instance-scoped,
-mutation-ID-bound `legacy_page_email_write_fence` and returns a signed fence epoch.
-The fence applies to the paired Instance rather than trusting a client version
-header: every released exact-email replacement endpoint rejects writes while it is
-active. The updater persists the attested epoch before replacing the executable, so
-an old binary can continue serving private/public/offline pages but cannot create a
-new page-email viewer or restore that viewer's legacy HMR access. If fence activation,
-persistence, or any preflight check fails, downgrade is refused and the current
-binary/schema remain intact. A crash after activation but before replacement is
-recovered by the same idempotent mutation ID; an explicitly aborted updater may
-clear its epoch only after proving the new executable still owns the quiesced lock.
-Otherwise the fence remains closed. Re-upgrade keeps it active until the new binary
-has reconciled every empty grant revision and its prepare/commit API is ready, then
-clears exactly that epoch. This makes the rollback restriction reversible without
-asking an old HMR handler to enforce a capability it does not understand.
+This is an explicit one-way product migration. Avibe's supported updater advances
+to newer releases; it does not offer application or schema downgrade. Once the new
+access schema is committed, manually installing an older binary against that state
+is unsupported and the older binary must not be started. Backup restore remains a
+whole-state operation to a release that understands the restored schema, not a
+cross-version audience-write protocol. This boundary removes the need for legacy
+audience projections, write journals, hosted write fences, and re-upgrade conflict
+resolution, none of which correspond to a supported user workflow. The migration
+itself remains restartable and idempotent: an interrupted current-version process
+resumes from the pending record under the shared writer lease before admitting a
+limited route.
 
 ## Verification Plan
 
@@ -872,10 +852,10 @@ asking an old HMR handler to enforce a capability it does not understand.
   retry, and double submission; the share admission gate is the only transient
   route barrier, and no intermediate state may grant more read access than the last
   committed or requested target
-- enumerate every current-version CLI, Web, migration, recovery, and updater audience
+- enumerate every current-version CLI, Web, migration, and recovery audience
   mutation entry point and prove its store write requires the same process-shared
-  lease; race real CLI and Web writer processes against downgrade in both acquisition
-  orders, and prove no mutation can begin between preflight and executable replacement
+  lease; race real CLI and Web writer processes in both acquisition orders and prove
+  stale preconditions cannot commit
 - copy local state containing one-address and few-address limited sets and prove the
   opaque grant commitments cannot validate guessed emails offline; same-set retry
   keeps its revision/commitment while every real set change receives a fresh random
@@ -895,27 +875,29 @@ asking an old HMR handler to enforce a capability it does not understand.
   cannot trigger the redirect
 - prove the redirect preserves the route suffix and query while both redirect and
   shared entry responses are private/no-store and vary on cookies
-- prove shared and private documents retain every existing Show bootstrap key,
-  shared configuration exposes `canAnnotate=false`, and it contains no Session
-  identifier or private path
+- prove shared and private documents retain every existing Show bootstrap key;
+  page-email and public viewers receive `canAnnotate=false`, a compatibility-path
+  editor receives `canAnnotate=true` without HMR, and no shared bootstrap contains a
+  Session identifier or private path
 - prove migration maps old public, private-with-grants, private-without-grants,
   and offline rows exactly as specified, with disconnected reconciliation staying
   private
-- perform a real new-write, binary rollback, every legacy audience-field mutation,
-  and re-upgrade round trip; the journal must preserve the complete latest snapshot,
-  including unchanged assignments, generated rotations, and custom slugs, while a
-  corrupt snapshot or uniqueness conflict fails closed
+- interrupt and restart the one-way migration at every local and hosted boundary;
+  only the current schema serves afterward, the migration is idempotent, and an
+  older executable is never started against migrated state
 - leave an upgrade migration pending, perform a newer audience Apply, then restore
   connectivity; the source-revision compare-and-swap discards the stale migration
   and cannot allocate or reopen a limited audience
-- attempt downgrade while a limited-to-private/public cleanup or mutation result is
-  pending or while any limited page exists; preflight preserves the current binary
-  and schema until every page is non-limited and its hosted grant set is empty at the
-  reconciled page revision and the resulting global watermark invalidates old claims
-- interrupt downgrade before and after backend fence activation, attestation
-  persistence, executable replacement, and re-upgrade readiness; a released email
-  mutation is rejected for every active fence epoch, and abort clears only an epoch
-  whose new-binary lock ownership is proven
+- submit a canonical same-set grant target from every audience source mode; prepare
+  returns the current commitment/revision, creates no hosted operation, and either
+  leaves an open limited gate untouched or atomically completes a mode-only entry
+  into limited
+- leave limited for public while empty-set cleanup is unavailable; anonymous reads
+  remain available, stale page-email claims remain rejected, and cleanup later
+  converges without changing the public binding
+- change, clear, and rotate an offline page's future audience while hosted service is
+  available, unavailable, and recovering; no route becomes reachable until an
+  explicit activation
 - interrupt every limited-list mutation before backend prepare, after prepare but
   before the local transaction, after the local transaction but before commit, after
   backend commit, after a lost response, and before local revision persistence; the
@@ -959,6 +941,10 @@ asking an old HMR handler to enforce a capability it does not understand.
   development diagnostic receives a fixed shared body; unsafe `SourceMap`,
   `X-SourceMap`, `Content-Location`, `Refresh`, `Location`, and `Link` values are
   stripped or safely rewritten
+- a legacy Runtime with no provenance may return only a fully transformed successful
+  shared response; an error, failed transform, or raw/nested `@fs` graph receives a
+  fixed path-free unavailable response, while a proven editor still retains
+  annotations without HMR
 - old opaque namespaces survive lazy loads while leased, expire as a whole after
   30 idle minutes or the non-renewable two-hour lifetime, never cross graph/share
   boundaries, and cannot be kept admitted by anonymous reads
@@ -1006,23 +992,23 @@ asking an old HMR handler to enforce a capability it does not understand.
 | `SHOW-LIVE-016` | Shared transforms emit nested `/@fs/` imports, URL-bearing headers, and Vite errors | Only leased context-bound handles and safe rewritten headers reach the browser; every development error is fixed and path-free |
 | `SHOW-LIVE-017` | Startup reconciliation and `vibe show update` prewarm shared and private graphs | Each request carries its typed context; a missing/invalid context fails before creating or rebasing either graph |
 | `SHOW-LIVE-018` | Direct CLI changes an active page to offline with private HMR connected | The coalesced durable monitor closes every socket for the Session within five seconds without relying on an in-process event |
-| `SHOW-LIVE-019` | Public changes to limited and the cloud write fails | The share admission gate stays closed while the public mode and binding remain recoverable; neither anonymous nor stale listed viewers can read until reconciliation succeeds |
+| `SHOW-LIVE-019` | Public changes to limited and the cloud write fails | The target limited mode and original binding remain durable with the gate closed; neither anonymous nor stale listed viewers can read until reconciliation succeeds |
 | `SHOW-LIVE-020` | Old private/public/offline rows and exact-email grants upgrade | Each page matches the migration table; a disconnected private-with-grants page stays private and pending |
 | `SHOW-LIVE-021` | A live limited-list replacement commits remotely, its response is lost, and Avibe restarts | All page-email reads remain closed until the mutation result and revision reconcile; removed viewers never regain access |
 | `SHOW-LIVE-022` | Limited changes to private while hosted cleanup is unavailable | A stale page-email cookie is rejected on both `/p/` and `/show/`; independent resource collaborators retain their canonical access |
-| `SHOW-LIVE-023` | A public page upgrades, rolls back, is set private by the old binary, then re-upgrades | The newest complete journal snapshot wins and the page stays private; stale `ShowAccess` cannot reopen anonymous access |
+| `SHOW-LIVE-023` | A legacy Runtime returns an unclassified transform error and a nested raw `/@fs/` import | Both responses fail closed with fixed path-free output; no host path or diagnostic reaches the browser |
 | `SHOW-LIVE-024` | An allowed source is replaced by a sensitive symlink after an opaque handle is issued | The issued handle returns only immutable captured bytes, and the changed path cannot receive a new handle |
 | `SHOW-LIVE-025` | A disconnected private-page migration is pending, then the owner chooses public and later private before reconnecting | The newer revision cancels migration; reconnect cannot allocate a slug, commit limited, or restore the old email audience |
-| `SHOW-LIVE-026` | Limited changes to private while hosted cleanup is unavailable, then binary downgrade is requested | Downgrade is refused without replacing executable/schema; it can proceed only after no limited page exists and every grant set is empty at its reconciled page revision |
+| `SHOW-LIVE-026` | Applying a canonically identical limited email set | Backend returns the current commitment/revision, creates no pending operation, and the open gate never closes |
 | `SHOW-LIVE-027` | An anonymous client reads every superseded namespace just before each idle deadline | Each namespace still reaches its non-renewable hard expiry, releases all snapshot bytes, and requires stale documents to reload |
 | `SHOW-LIVE-028` | Anonymous clients keep shared pages active across more Sessions than the Runtime-wide budget | Context and memory stay under the hard limit, reclaimable shared bundles rotate, private HMR keeps its reserve, and excess shared admission is sanitized |
-| `SHOW-LIVE-029` | A public page rolls back, then the old binary rotates and assigns a custom slug before re-upgrade | The newest complete journal snapshot wins; only the final slug resolves, and a conflict fails private without resurrecting stale `ShowAccess` |
+| `SHOW-LIVE-029` | Limited changes to public while hosted empty-set cleanup remains unavailable | Anonymous reads start from the committed public binding, stale listed claims stay rejected, and cleanup retries do not close the public route |
 | `SHOW-LIVE-030` | A released Avibe client starts a new Runtime and sends only `x-vibe-show-base` | Entry, module, and prewarm requests retain the legacy singleton behavior; keyed isolation remains disabled until a protocol-`1` client supplies context |
 | `SHOW-LIVE-031` | A limited-list Apply crashes at every prepare/local/commit boundary and later exceeds operation retention | No local row contains an email, prepare alone never changes grants, committed state reconciles by page commitment/revision, and the prior audience reopens only after proof that an expired operation did not commit |
-| `SHOW-LIVE-032` | Downgrade is attempted with a limited page, then retried after conversion and empty cleanup | The first attempt is refused; the second invalidates old claims and activates an attested legacy-email-write fence, so the old binary cannot add listed viewers or expose its viewer-authorized HMR socket |
+| `SHOW-LIVE-032` | An offline page changes from limited to private, then prepares a future public custom slug | No route is admitted while offline; grant cleanup and the future audience converge without temporary activation |
 | `SHOW-LIVE-033` | An unrelated Instance ACL change advances the global authorization revision while a limited list is unchanged | Refreshed listed viewers remain readable at the same page grant revision; changing that page's list advances only its grant revision and rejects older claims |
 | `SHOW-LIVE-034` | A custom-slug public page crashes at every boundary while changing to limited | Every ambiguous `/p/` read is denied, and successful recovery preserves the exact slug without rotating or losing the route |
-| `SHOW-LIVE-035` | A direct CLI or Web audience mutation races binary downgrade from another process | Both entry points contend on one stable process-shared lease; a writer completes before preflight or remains blocked until replacement, so no limited or pending state can appear inside the downgrade window |
+| `SHOW-LIVE-035` | An authorized editor uses `/p/` with a definitive legacy Runtime | The editor remains on the shared compatibility representation with annotations enabled, no HMR socket, and no private module namespace |
 | `SHOW-LIVE-036` | An attacker obtains local state for a limited page with a small email set | The stored random commitment provides no offline email-guess verifier; only the hosted trust boundary can bind it to the canonical set |
 
 Focused unit/contract tests, Ruff, repository CI, and local Incus browser
@@ -1049,10 +1035,10 @@ The design is implemented when all of the following are true:
   after idempotent read-after-write reconciliation; an ambiguous response, restart,
   or expired operation cannot leave stale grants usable, email targets on disk, or
   a share binding lost.
-- Every current-version local audience writer and binary downgrade uses one stable
-  process-shared write lease from its authoritative precondition read through a
-  terminal or durably pending state; store writes cannot bypass the lease, and local
-  grant commitments are opaque random backend values rather than email-derived hashes.
+- Every current-version local audience writer uses one stable process-shared write
+  lease from its authoritative precondition read through a terminal or durably
+  pending state; store writes cannot bypass the lease, and local grant commitments
+  are opaque random backend values rather than email-derived hashes.
 - Authorized share-link editor navigations redirect to the corresponding private URL
   and get the same Vite HMR and React Fast Refresh behavior as private editors.
 - Annotation writes and the share-link editor redirect consume one validated,
@@ -1077,18 +1063,19 @@ The design is implemented when all of the following are true:
 - Context selection is mandatory at every protocol-`1` Runtime app-graph call site,
   including prewarm and fallback paths, and missing selection fails before Vite
   ownership; a headerless released client retains only the singleton legacy path.
+- The legacy Runtime path never enables HMR, preserves annotations only for a proven
+  editor, and fails closed for unclassified errors or graphs that need raw absolute
+  paths; missing provenance cannot expose a development diagnostic.
 - Shared file references use leased context-bound opaque handles backed by bounded
   immutable snapshots captured through confinement-safe opens; handle reads never
   reopen mutable pathnames. Raw absolute paths, unsafe URL-bearing response headers,
   and Runtime development diagnostics never reach the browser.
-- Every compatibility audience-field write is captured as one complete durable
-  legacy snapshot and reconciled before serving, so visibility and share-link
-  changes made by an old binary cannot be overwritten by stale `ShowAccess` after
-  re-upgrade.
-- Pending legacy migration is revision-bound and cancelled by every newer audience
-  mutation. Downgrade requires zero limited pages and empty reconciled grant sets,
-  then keeps a backend legacy-email-write fence active until the new binary is ready
-  again, so the old serving path can neither mint listed viewers nor grant them HMR.
+- The access-schema migration is restartable, idempotent, revision-bound, and
+  explicitly one-way. Avibe never starts an older executable against migrated state;
+  no legacy audience projection or cross-version writer is part of the contract.
+- A same-set grant prepare reuses the current commitment/revision without creating a
+  pending operation. Leaving limited for public keeps anonymous reads open during
+  best-effort grant cleanup, and offline audience changes never admit a route.
 - Shared Vite contexts, opaque namespaces, handles, and snapshot bytes share one
   Runtime-wide weighted budget with a private-editor reserve and non-renewable
   lifetimes, so anonymous traffic cannot pin admission indefinitely.

--- a/docs/plans/public-show-live-update.md
+++ b/docs/plans/public-show-live-update.md
@@ -112,7 +112,7 @@ ShowAccess {
   audience_revision: device-local monotonic integer
   share_admission_gate: open | closed_pending
   grant_revision: backend-issued page-scoped integer
-  grant_digest: non-PII hash
+  grant_commitment: backend-issued opaque random value
 }
 ```
 
@@ -138,20 +138,37 @@ cannot read these settings APIs, mutate the audience, load the Workbench, or
 promote itself through a broader Instance endpoint.
 
 Audience changes use one Apply action and one durable fail-closed coordinator
-rather than three independent writes. Every Apply allocates a client mutation ID.
-For a change that carries exact emails, the device first sends the normalized
-in-memory target and expected page-scoped `grant_revision` to a backend `prepare`
-operation. Preparation stores the target only inside the existing hosted grant
-trust boundary, changes no grant authority, and returns an opaque operation ID plus
-target digest. A prepared operation has a non-renewable 24-hour lifetime. If this
-step fails or its response is lost, no local transition is accepted and the
-previous audience remains authoritative; an unreferenced preparation can only
-expire, never commit itself.
+rather than three independent writes. The coordinator is a cross-process write
+boundary, not an in-memory mutex. Every current-version entry point that can mutate
+`ShowAccess`, its legacy projection, or coordinator recovery state -- including the
+CLI, Web API, startup/migration reconciliation, and updater -- must acquire the same
+exclusive advisory lock at a stable file in Avibe's state directory before reading
+mutation preconditions. The lock file is never replaced or deleted during the
+compatibility window, so every process locks the same inode. Store mutation methods
+require a held lock lease; callers cannot bypass the coordinator with a direct
+`ShowPageStore` write. The lock is acquired before any database transaction, and no
+code may wait for it while holding a database or hosted-operation lock.
+
+Every Apply allocates a client mutation ID and holds the process-shared lease from
+its first authoritative precondition read through either its terminal local commit
+or the durable recording of a fail-closed pending phase. A process crash releases
+the OS lock, but it can leave only a prepared non-authoritative hosted operation or
+a locally recorded pending phase that downgrade preflight rejects. For a change that
+carries exact emails, the device first sends the normalized in-memory target and
+expected page-scoped `grant_revision` to a backend `prepare` operation. Preparation
+stores the target only inside the existing hosted grant trust boundary, changes no
+grant authority, and returns an opaque operation ID plus an opaque target
+`grant_commitment`. The backend generates a fresh cryptographically random 256-bit
+commitment after canonicalizing the page-bound email set and binds it to that
+prepared operation; it is never derived from an email or a client-held key. A
+prepared operation has a non-renewable 24-hour lifetime. If this step fails or its
+response is lost, no local transition is accepted and the previous audience remains
+authoritative; an unreferenced preparation can only expire, never commit itself.
 
 After preparation succeeds, one local transaction persists only the opaque
 operation ID, source audience revision, source page grant revision, target mode,
-target or preserved share binding, target digest, and phase. It never persists the
-email addresses. Any transition that can add, remove, or replace page-email
+target or preserved share binding, target commitment, and phase. It never persists
+the email addresses. Any transition that can add, remove, or replace page-email
 authority also sets `share_admission_gate=closed_pending` in that same transaction.
 This gate is orthogonal to `access_mode`: while it is closed, every `/p/` read and
 editor redirect is denied and the page-email branch of the canonical `/show/` ACL
@@ -160,21 +177,26 @@ Owner and organization resource ACLs on canonical `/show/` remain independent.
 
 The device then asks the backend to `commit` the prepared operation. Commit
 atomically replaces the exact-email set under the expected page `grant_revision`,
-advances that revision once when the digest changes, and retains an idempotent
+advances that revision once when the canonical set changes, promotes the prepared
+commitment for a changed set, and retains an idempotent
 mutation result. After a lost response or process restart, the device resumes by
-opaque operation ID; a committed operation returns the exact current set/digest and
-page grant revision, while an uncommitted expired operation cannot mutate grants.
+opaque operation ID; a committed operation returns the exact current set/commitment
+and page grant revision, while an uncommitted expired operation cannot mutate grants.
 The device reopens the share admission gate only after a read-after-write
 reconciliation proves that the
-backend's committed operation, exact current set/digest, and returned page grant
+backend's committed operation, exact current set/commitment, and returned page grant
 revision match the local record and that revision has been persisted locally. The
 backend deletes the prepared target copy after device acknowledgement or the
-24-hour hard limit; a terminal result retains only non-PII metadata and the digest.
+24-hour hard limit; a terminal result retains only non-PII metadata and the opaque
+commitment. A same-set no-op returns the existing commitment and revision; a later
+change back to a previously used set receives a new random commitment. Consequently,
+a copied SQLite database or backup exposes no deterministic verifier for guessed
+email addresses.
 If the result copy has expired after commit, the authoritative current page-grant
-read supplies the same digest and revision proof. An unavailable, ambiguous,
+read supplies the same commitment and revision proof. An unavailable, ambiguous,
 conflicting, or unpersisted result leaves the durable gate closed. A proven expired
 and uncommitted preparation may restore the prior gate only when the authoritative
-page digest/revision still equal the recorded source; otherwise the owner must
+page commitment/revision still equal the recorded source; otherwise the owner must
 resubmit the target. Empty-set cleanup can retry automatically. A periodic
 page-grant revision poll is recovery evidence, never the security boundary.
 
@@ -615,8 +637,8 @@ request.
 | Shared Runtime admission is saturated | Reclaim the oldest non-in-flight shared bundle; if none is reclaimable, return a sanitized retryable unavailable response without consuming the private reserve | Global weighted-budget admission/reclamation metric |
 | A shared document outlives its absolute namespace/context lifetime | Return a fixed stale-document response for later module or lazy-asset reads and require reload | Namespace hard-expiry metric without source paths |
 | Runtime emits a development diagnostic or unsafe URL header | Preserve only a safe status class/body and filtered headers | Redacted operator-only diagnostic |
-| Limited-list replacement has an ambiguous result | Keep the durable share admission gate closed across retries and restarts until read-after-write reconciliation persists the exact mutation result | Mutation ID, target digest, and redacted reconciliation state |
-| Prepared email operation expires before commit | Reopen the prior share audience only after authoritative digest/revision proof that no commit occurred; otherwise remain closed and require target resubmission | Operation expiry and non-PII target digest |
+| Limited-list replacement has an ambiguous result | Keep the durable share admission gate closed across retries and restarts until read-after-write reconciliation persists the exact mutation result | Mutation ID, opaque target commitment, and redacted reconciliation state |
+| Prepared email operation expires before commit | Reopen the prior share audience only after authoritative commitment/revision proof that no commit occurred; otherwise remain closed and require target resubmission | Operation expiry and opaque target commitment |
 | Limited email removed | Reject the viewer's next network request by page grant revision; no HMR or annotation channel exists to close | Page-grant revision log |
 | Unrelated Instance authorization changes | Refresh generic session freshness without changing any page grant revision or denying an unchanged limited viewer | Instance and page revision metrics kept distinct |
 | Limited page becomes private/public while hosted cleanup fails | Reject page-email claims on both `/p/` and `/show/` from the local mode commit; retry cleanup without reopening authority | Durable audience state and cleanup-pending record |
@@ -699,7 +721,8 @@ feature, not a prerequisite for capability-gated editor HMR.
    select. Render exact emails only for `limited`, and link controls only for
    `limited | public`; keep availability separate.
 3. Implement backend prepare/commit email operations, page-scoped grant revisions,
-   the non-PII persistent share admission barrier, idempotent
+   opaque grant commitments, the non-PII persistent share admission barrier, the
+   process-shared audience write lease, idempotent
    mutation-result/current-grant lookup, the downgrade legacy-write fence, and the
    fail-closed access coordinator. Retire the independent visibility and email
    mutation paths after compatibility callers migrate.
@@ -759,8 +782,8 @@ The schema migration separates availability from audience and is fail-closed:
 Until the device can read the hosted grant set, an old private page stays
 private and records migration pending with the source `audience_revision` and
 legacy-audience journal generation; it is never guessed to be limited. The hosted
-read returns the page-scoped grant revision and digest, and reconciliation may commit
-only with a compare-and-swap proving that all three inputs are still current. The
+read returns the page-scoped grant revision and commitment, and reconciliation may
+commit only with a compare-and-swap proving that all three inputs are still current. The
 Instance-wide authorization revision is deliberately absent from this page-state
 comparison.
 Every authoritative audience Apply and every reconciled legacy write increments
@@ -808,14 +831,16 @@ custom-slug writes made during an allowed rollback still cannot be overwritten b
 stale `ShowAccess` on re-upgrade.
 
 Binary downgrade has a fail-closed preflight before the current executable or
-compatibility schema is replaced. The updater acquires the audience coordinator's
-exclusive write lock, holds it through service quiescence and executable/schema
-replacement, and under that lock requires the hosted resolver to be reachable, no
-audience transition or migration to be pending, every share admission gate to be
-open, no page to be `limited`, and every hosted page-email set to be empty with its
-page grant revision/digest reconciled locally and the resulting Instance-wide
-authorization watermark persisted for the released binary's session-freshness
-check. Owners must first move every limited page
+compatibility schema is replaced. Before preflight, the updater acquires the same
+stable process-shared audience write lock used by CLI, Web, migration, and recovery
+writers. It waits for any writer that already owns the lease, prevents a new writer
+from starting after preflight, and holds the lease through service quiescence and
+executable/schema replacement. Under that lock it requires the hosted resolver to
+be reachable, no audience transition or migration to be pending, every share
+admission gate to be open, no page to be `limited`, and every hosted page-email set
+to be empty with its page grant revision/commitment reconciled locally and the
+resulting Instance-wide authorization watermark persisted for the released binary's
+session-freshness check. Owners must first move every limited page
 to private or public and complete the empty-set cleanup; an open limited gate is
 never rollback-compatible because the released `/show/` HMR handler accepts
 page-email viewers.
@@ -847,6 +872,14 @@ asking an old HMR handler to enforce a capability it does not understand.
   retry, and double submission; the share admission gate is the only transient
   route barrier, and no intermediate state may grant more read access than the last
   committed or requested target
+- enumerate every current-version CLI, Web, migration, recovery, and updater audience
+  mutation entry point and prove its store write requires the same process-shared
+  lease; race real CLI and Web writer processes against downgrade in both acquisition
+  orders, and prove no mutation can begin between preflight and executable replacement
+- copy local state containing one-address and few-address limited sets and prove the
+  opaque grant commitments cannot validate guessed emails offline; same-set retry
+  keeps its revision/commitment while every real set change receives a fresh random
+  commitment
 - seed every supported identity/resource shape and assert that `canAnnotate` and
   the share-link redirect are produced by the same editor capability
 - prove page-email entitlement can satisfy only limited read, cannot satisfy the
@@ -889,7 +922,7 @@ asking an old HMR handler to enforce a capability it does not understand.
   local record never contains an email, a preparation never changes authority by
   itself, and the share admission gate stays closed until the exact result reconciles
 - expire prepared and committed-operation result copies, then recover from opaque
-  operation ID, target digest, and the authoritative page grant revision; reopen the
+  operation ID, target commitment, and the authoritative page grant revision; reopen the
   prior audience only after proof that an expired operation did not commit, and
   require resubmission without persisting removed/failed email PII otherwise
 - advance the Instance-wide authorization revision for every unrelated ACL shape and
@@ -985,10 +1018,12 @@ asking an old HMR handler to enforce a capability it does not understand.
 | `SHOW-LIVE-028` | Anonymous clients keep shared pages active across more Sessions than the Runtime-wide budget | Context and memory stay under the hard limit, reclaimable shared bundles rotate, private HMR keeps its reserve, and excess shared admission is sanitized |
 | `SHOW-LIVE-029` | A public page rolls back, then the old binary rotates and assigns a custom slug before re-upgrade | The newest complete journal snapshot wins; only the final slug resolves, and a conflict fails private without resurrecting stale `ShowAccess` |
 | `SHOW-LIVE-030` | A released Avibe client starts a new Runtime and sends only `x-vibe-show-base` | Entry, module, and prewarm requests retain the legacy singleton behavior; keyed isolation remains disabled until a protocol-`1` client supplies context |
-| `SHOW-LIVE-031` | A limited-list Apply crashes at every prepare/local/commit boundary and later exceeds operation retention | No local row contains an email, prepare alone never changes grants, committed state reconciles by page digest/revision, and the prior audience reopens only after proof that an expired operation did not commit |
+| `SHOW-LIVE-031` | A limited-list Apply crashes at every prepare/local/commit boundary and later exceeds operation retention | No local row contains an email, prepare alone never changes grants, committed state reconciles by page commitment/revision, and the prior audience reopens only after proof that an expired operation did not commit |
 | `SHOW-LIVE-032` | Downgrade is attempted with a limited page, then retried after conversion and empty cleanup | The first attempt is refused; the second invalidates old claims and activates an attested legacy-email-write fence, so the old binary cannot add listed viewers or expose its viewer-authorized HMR socket |
 | `SHOW-LIVE-033` | An unrelated Instance ACL change advances the global authorization revision while a limited list is unchanged | Refreshed listed viewers remain readable at the same page grant revision; changing that page's list advances only its grant revision and rejects older claims |
 | `SHOW-LIVE-034` | A custom-slug public page crashes at every boundary while changing to limited | Every ambiguous `/p/` read is denied, and successful recovery preserves the exact slug without rotating or losing the route |
+| `SHOW-LIVE-035` | A direct CLI or Web audience mutation races binary downgrade from another process | Both entry points contend on one stable process-shared lease; a writer completes before preflight or remains blocked until replacement, so no limited or pending state can appear inside the downgrade window |
+| `SHOW-LIVE-036` | An attacker obtains local state for a limited page with a small email set | The stored random commitment provides no offline email-guess verifier; only the hosted trust boundary can bind it to the canonical set |
 
 Focused unit/contract tests, Ruff, repository CI, and local Incus browser
 regression are required. Green unit tests do not replace simultaneous editor,
@@ -1014,6 +1049,10 @@ The design is implemented when all of the following are true:
   after idempotent read-after-write reconciliation; an ambiguous response, restart,
   or expired operation cannot leave stale grants usable, email targets on disk, or
   a share binding lost.
+- Every current-version local audience writer and binary downgrade uses one stable
+  process-shared write lease from its authoritative precondition read through a
+  terminal or durably pending state; store writes cannot bypass the lease, and local
+  grant commitments are opaque random backend values rather than email-derived hashes.
 - Authorized share-link editor navigations redirect to the corresponding private URL
   and get the same Vite HMR and React Fast Refresh behavior as private editors.
 - Annotation writes and the share-link editor redirect consume one validated,

--- a/docs/plans/public-show-live-update.md
+++ b/docs/plans/public-show-live-update.md
@@ -169,8 +169,11 @@ Public builds are demand-active rather than running for every private Session:
 - With no public demand, Runtime may stop building. The next public request
   catches up to the latest generation before returning the document.
 - If a previous artifact exists and a catch-up build fails, Runtime serves that
-  artifact. If no artifact has ever activated, Avibe returns the existing
-  sanitized generating/unavailable shell and retries on a later request; it
+  artifact. If no artifact has ever activated, Avibe returns a sanitized
+  recovery shell with `artifact: null`. The shell opens the same redacted
+  artifact stream, holds public demand, and reloads when the first artifact
+  activates. Its reconnect loop continues indefinitely with capped backoff, so
+  recovery does not depend on a later document request or manual refresh. It
   never falls back to development modules.
 
 This keeps private-only editing costs unchanged while ensuring a fresh public
@@ -189,8 +192,12 @@ sequence:
    maps, excludes development HMR/React Refresh clients, and emits content-hashed
    files with relative asset references.
 5. Runtime rejects the candidate if the build, link, or any required first-party
-   asset resolution fails. Output validation also rejects canonical private URL
-   references in emitted HTML, JavaScript, and CSS, including CSS `url(...)`.
+   asset resolution fails. It then validates the complete emitted byte set,
+   independent of file type, against the private-output deny set: the Session
+   identifier, canonical private route, sidecar route, current or previous share
+   identifier, and other private runtime identifiers. Any match rejects the
+   entire candidate before activation. A newly emitted URL-bearing format is
+   therefore covered without adding another MIME-specific validator.
 6. If another invalidation arrived during the build, Runtime discards the stale
    output and schedules the newest generation.
 7. Runtime moves the complete staging directory into immutable artifact storage,
@@ -198,18 +205,36 @@ sequence:
    current.
 8. Only pointer activation emits one artifact notification.
 
-The active artifact and its files are immutable. Runtime retains the active and
-immediately previous artifact; older inactive artifacts are cleaned up after no
-response or stream still references them. A process restart may rebuild the
-same source into a new opaque identifier, which causes at most one public reload.
-Artifacts are Runtime cache, not durable product history.
+The active artifact and its files are immutable. Each served document uses
+artifact-scoped file URLs. Serving the document starts a short connection grace;
+opening the stream with that document artifact promotes the grace to a document
+lease. Runtime pins the active artifact and every artifact referenced by an open
+document lease. A disconnected lease receives a bounded cleanup grace longer
+than the client's maximum reconnect delay; normal reconnection renews it. Lease
+count and retained bytes are bounded per Session at stream admission, so the
+number of simultaneously pinned inactive artifacts is also bounded. A refused
+stream does not evict an artifact serving an already admitted document. An
+inactive artifact is removed only after its last lease and grace expire. A
+process restart may rebuild the same source into a new opaque identifier, which
+causes at most one public reload. Artifacts are Runtime cache, not durable
+product history.
 
-Relative output is part of the contract. Avibe serves the same artifact beneath
-the current `/p/<share>/` path and injects a matching document `<base>` plus
-public configuration. HTML module references, JavaScript chunks, imported CSS,
-and CSS `url(...)` references therefore resolve through the gated share path and
-contain neither `/show/<session>/` nor a previous share ID. Rotating a share does
-not require rebuilding the artifact.
+Relative output is part of the contract. Avibe serves artifact files beneath
+`/p/<share>/__show/artifacts/<artifact-id>/` and injects separate public page and
+artifact base paths. Entry references are rewritten with a structured HTML
+transform to the artifact-scoped base; relative JavaScript chunks, imported CSS,
+and nested asset references remain inside that scope. The application route
+continues to use `/p/<share>/`, so asset addressing does not change SPA routing
+or relative public API requests. Neither the artifact nor its references contain
+`/show/<session>/` or a share ID. Rotating a share changes only the request-time
+gate and document configuration; it does not require rebuilding the artifact.
+
+Public navigation preserves the existing SPA fallback deliberately. Avibe first
+resolves exact artifact files and reserved `api/` and `__show/` routes. A `GET`
+or `HEAD` browser document navigation that matches none of them receives the
+active artifact's entry document, configured for the requested public route. A
+missing script, stylesheet, image, other asset, API route, or reserved Show route
+returns its real error and is never rewritten to the entry document.
 
 Public `api/` handlers remain permissioned live server code and are not bundled
 into the frontend artifact. Relative public API requests continue through the
@@ -222,13 +247,14 @@ The sidecar adds loopback-only endpoints:
 ```text
 GET /sessions/<session-id>/public-artifact?ensure=current
 GET /sessions/<session-id>/public-artifacts/<artifact-id>/<path>
-GET /sessions/<session-id>/public-artifacts?stream=1
+GET /sessions/<session-id>/public-artifacts?stream=1&document=<artifact-id>
 ```
 
 The public Avibe surface exposes:
 
 ```text
 GET /p/<share-id>/__show/artifacts
+GET /p/<share-id>/__show/artifacts/<artifact-id>/<path>
 ```
 
 The public endpoint is a terminating relay, not a byte-for-byte proxy. It parses
@@ -239,7 +265,11 @@ which its HTML was read:
 
 ```html
 <script>
-  globalThis.__AVIBE_SHOW__ = { basePath: "/p/brief/", artifact: "art_7f42" }
+  globalThis.__AVIBE_SHOW__ = {
+    basePath: "/p/brief/",
+    artifactBasePath: "/p/brief/__show/artifacts/art_7f42/",
+    artifact: "art_7f42"
+  }
 </script>
 ```
 
@@ -266,13 +296,20 @@ data: {"protocol":1,"artifact":"art_91ac"}
 Contract rules:
 
 - `protocol` is the schema version and is currently `1`.
-- `artifact` is an opaque identifier for one immutable activated build.
+- A non-null `artifact` is an opaque identifier for one immutable activated
+  build. Null is valid only in the recovery shell's `ready` event.
 - Equality is the only browser operation on `artifact`; ordering is unnecessary.
 - The payload contains no Session ID, share ID, module URL, filesystem path,
   source code, error, plugin name, or source frame.
 - Keepalives are SSE comment frames and carry no data.
 - A new subscriber receives exactly one `ready` event with the current active
-  artifact. Artifact history is not replayed.
+  artifact. The recovery shell may receive `artifact: null` until the first
+  activation. Artifact history is not replayed.
+- The browser opens the public stream with its document artifact, if any, as an
+  opaque `document` query value. Avibe validates that the artifact belongs to
+  the resolved Session before creating an internal lease; it never forwards the
+  query blindly. A null recovery-shell document holds build demand but no
+  artifact lease.
 - The document uses `Cache-Control: no-store`; hashed artifact files may use
   immutable caching while the share remains authorized.
 
@@ -291,8 +328,10 @@ The public document loads a small versioned live client. Public production
 artifacts contain no Vite HMR imports, so the client does not need to emulate
 the Vite protocol. It runs once per document:
 
-1. Read `basePath` and the document's `artifact` from the injected configuration.
-2. Open `<basePath>__show/artifacts` with `EventSource`.
+1. Read `basePath`, `artifactBasePath`, and the document's `artifact` from the
+   injected configuration.
+2. Open `<basePath>__show/artifacts`, adding the opaque document artifact as the
+   `document` query value when it is non-null.
 3. Compare both `ready` and later `artifact` events with the document artifact.
    Equal means current; different means a reload is pending.
 4. Keep only the newest pending identifier. A later event does not reset any
@@ -305,9 +344,12 @@ the Vite protocol. It runs once per document:
 7. Set an in-memory reload guard immediately before `location.reload()`. The new
    no-store document carries its own artifact and performs the same equality
    handshake, preventing a persistent reload loop.
-8. On stream failure, close the failed `EventSource` and reconnect with capped
-   exponential backoff. Stop after six consecutive failures and resume on
-   `online` or a later visibility transition.
+8. On stream failure, close the failed `EventSource` and reconnect indefinitely
+   with exponential backoff, jitter, and a maximum delay. A valid `ready` resets
+   the failure counter. `online` and visibility transitions may trigger an
+   immediate probe, but are not required for recovery. The recovery shell uses
+   the same loop, so a first-build failure heals after a later valid edit without
+   a manual refresh.
 
 The client displays no public error overlay. Build and connection diagnostics
 belong in private Runtime/Avibe logs.
@@ -363,7 +405,8 @@ Budgets and invariants:
 - one build per Session write burst, independent of viewer count
 - no public build while a private-only Session has no public demand
 - active hashed assets remain cacheable across document reloads
-- active plus previous artifact bounds steady-state artifact retention
+- active plus admitted document leases and their disconnect grace define
+  artifact retention; per-Session lease and byte budgets bound resource use
 - build work is cancellable by generation and never runs concurrently for the
   same Session
 
@@ -381,11 +424,11 @@ the final starter-page activation budget; the design does not claim a universal
 | Syntax, import/export, asset, or build-plugin failure | Keep active artifact; activate nothing | Vite build/Runtime diagnostic |
 | Arbitrary runtime exception after a successful build | Browser may fail; no stronger guarantee without a canary | Browser telemetry or manual regression |
 | New invalidation during a build | Discard stale candidate; build latest generation | Debug metric only |
-| Runtime unavailable | Keep loaded page; bounded reconnect | Runtime health/logs |
+| Runtime unavailable | Keep loaded page; indefinitely retry with capped delay | Runtime health/logs |
 | SSE interrupted | Compare reconnecting `ready` with the document artifact | Connection metric/log |
 | Share rotated/private/offline | Reject new reads; close stream immediately or within 5 seconds | Durable visibility state and relay log |
 | Runtime restarted | Reuse a valid cached artifact or rebuild; a new ID reloads once | Runtime lifecycle log |
-| Initial build fails with no active artifact | Sanitized unavailable/generating shell; no development fallback | Private build diagnostic |
+| Initial build fails with no active artifact | Sanitized recovery shell holds demand and reloads after the first valid activation; no development fallback | Private build diagnostic |
 
 ## Rejected Alternatives
 
@@ -460,7 +503,10 @@ guaranteed compatible.
 - atomically activate only complete immutable output
 - join concurrent initial requests to one build
 - hold demand while at least one public stream is subscribed
-- retain active plus previous artifact and clean only unreferenced older output
+- retain every artifact referenced by an admitted document lease and clean it
+  only after the last lease plus reconnect grace expires
+- keep artifact-scoped files available across two or more later activations
+- keep null-artifact recovery demand active after an initial build failure
 - replay only the current active artifact to a new subscriber
 
 ### Avibe unit and contract tests
@@ -473,8 +519,14 @@ guaranteed compatible.
   the 5-second bound without relying on an in-memory broker event
 - public relay drops unknown event types and extra fields
 - browser credentials are never forwarded to Runtime
-- emitted HTML, JavaScript, and CSS contain no canonical Session path or old
-  share ID; CSS `url(...)` assets resolve through the current gated share
+- every emitted file is checked for private runtime identifiers regardless of
+  format, and the complete candidate is rejected on any match
+- artifact-scoped resources remain available to their loaded document while a
+  newer artifact is active
+- browser-history document navigation receives the active entry document while
+  missing assets, API routes, and reserved Show routes keep their real errors
+- recovery-shell and ordinary clients continue reconnecting after more than six
+  consecutive failures and recover without manual interaction
 - public raw `__vite_hmr` is unavailable while private HMR remains unchanged
 - private and public traffic never changes or rebuilds the private Vite base
 
@@ -491,6 +543,11 @@ guaranteed compatible.
 | `SHOW-LIVE-007` | Revision arrives while both hidden and editing | No background deadline fires; after visibility, blur or 30 visible editable seconds causes exactly one reload |
 | `SHOW-LIVE-008` | Activation races the first SSE `ready` | Embedded and ready identifiers differ; the client reloads to the active artifact |
 | `SHOW-LIVE-009` | Page CSS references `url('./hero.png')`, then the share rotates | Asset loads on both share URLs and no canonical Session path is exposed |
+| `SHOW-LIVE-010` | Two artifacts activate while an older document defers reload during editing | The older document's lazy chunk, image, and font remain available until its lease and grace expire |
+| `SHOW-LIVE-011` | The artifact stream fails more than six times and later recovers | The client reconnects with capped delay and reloads without an online or visibility event |
+| `SHOW-LIVE-012` | The first public build fails and a later edit repairs it | The recovery shell holds demand and reloads automatically after the first valid activation |
+| `SHOW-LIVE-013` | A viewer opens a browser-history route such as `/p/<share>/reports/42` | The active entry document loads; a missing asset at the same depth returns 404 rather than HTML |
+| `SHOW-LIVE-014` | A generated SVG, manifest, or future artifact format contains a private route or identifier | Whole-output validation rejects the candidate before activation |
 
 The implementation adds these scenarios to the Show scenario catalog before its
 PR is complete. Focused unit/contract tests, Ruff, repository CI, and local Incus
@@ -508,8 +565,14 @@ The feature is complete when all of the following are true:
   on the next valid candidate.
 - The document artifact and SSE state use an exact equality handshake, including
   the activation-before-first-`ready` race.
-- Public HTML, JavaScript, CSS, and asset requests expose no canonical Session
-  path and continue to work after share rotation.
+- No emitted artifact byte contains a private runtime identifier, regardless of
+  format, and public requests continue to work after share rotation.
+- Loaded documents use artifact-scoped resources that remain available through
+  reload deferral, multiple later activations, and the reconnect grace.
+- Recovery shells and clients survive extended stream/build outages and recover
+  without manual refresh.
+- Browser-history navigations preserve SPA fallback without masking missing
+  assets, APIs, or reserved Show routes.
 - Direct cross-process visibility changes revoke reads and streams within the
   defined 5-second bound.
 - Hidden state dominates the editable-control deadline exactly as specified.

--- a/docs/plans/public-show-live-update.md
+++ b/docs/plans/public-show-live-update.md
@@ -1,582 +1,390 @@
-# Public Show Live Update
+# Capability-Gated HMR for Public Show Links
 
 Status: Proposed
 
 Date: 2026-08-16
 
-Scope: `avibe` public Show proxy and `vibe-show-runtime`
+Scope: `avibe` public Show authorization/proxy and `vibe-show-runtime`
 
 ## Decision
 
-Public Show Pages remain live. Making a page public must not turn it into a
-manually refreshed snapshot, but an anonymous browser must not become a client
-of the mutable Vite development server either.
+A public Show link selects its update behavior from the viewer's effective
+server-side capability:
 
-The two surfaces therefore use different publication models:
+| Surface and viewer | Runtime representation | Update behavior |
+| --- | --- | --- |
+| Private `/show/<session>/`, authorized editor | Canonical private Vite context | Vite HMR and React Fast Refresh |
+| Public `/p/<share>/`, authorized editor | The same canonical private Vite context | Vite HMR and React Fast Refresh |
+| Public `/p/<share>/`, anonymous, read-only, expired, resource-forbidden, or unverifiable | Isolated public transform context | No Hot Reload; refresh reads current content |
+| Offline | None | None |
 
-| Surface | Viewer trust | Content source | Update behavior |
-| --- | --- | --- | --- |
-| Private `/show/<session>/` | Authenticated and authorized | Canonical Vite development context | Vite HMR and React Fast Refresh |
-| Public `/p/<share>/` | Anonymous read access | Last atomically activated public artifact | Automatic full-page Live Reload |
-| Offline | No live page | None | None |
+Public visibility is an anonymous read grant, not development authorization.
+Making a page public therefore does not downgrade its editor's experience, and
+being able to read a public link does not grant access to Vite's bidirectional
+development protocol.
 
-For a concrete example, suppose the public page imports `renderChart` from
-`chart.ts`, and an Agent removes that named export while changing another file:
+For a concrete example, Alice is an authorized editor and Bob is an anonymous
+viewer. They open the same `/p/brief/` URL while an Agent edits the page:
 
-1. Private HMR may show the author the normal Vite diagnostic.
-2. Runtime builds the complete public entry graph into a staging directory.
-3. Rollup linking fails because the import no longer exists.
-4. Runtime discards the candidate and keeps serving the previous activated
-   artifact to every public viewer.
-5. After the Agent repairs the export, a complete build succeeds, Runtime
-   atomically activates it, and public viewers reload automatically.
+1. Avibe resolves Alice's existing Workbench session and the same editor
+   capability used to enable annotations.
+2. Alice's document uses the canonical private module graph and
+   `/show/<session>/__vite_hmr`; React Fast Refresh updates her page and preserves
+   component state.
+3. Bob's document uses the isolated public transform context. It contains the
+   inert Vite/React Refresh shims and never opens an HMR socket.
+4. Bob's loaded page stays unchanged. A later manual navigation or refresh reads
+   the current public content.
 
-The public browser receives neither raw Vite HMR nor mutable development
-modules. It receives an opaque active-artifact notification over a small,
-one-way Server-Sent Events (SSE) contract and reloads the public document when
-the artifact changes.
+This design intentionally does not add anonymous Live Reload. That requirement
+would need an independently published revision model with artifact retention,
+URL compatibility, API-version coherence, build sandboxing, and global build
+budgets. None of that is necessary to deliver the requested authorized-editor
+HMR behavior.
 
-This is deliberately called **Live Reload**, not HMR. A public reload does not
-preserve arbitrary component or application state. Private authors retain Fast
-Refresh and its state-preserving development experience.
+## Why The Current Page Does Not Update
 
-## Why This Is Needed
+The current public proxy rewrites `@vite/client` and `@react-refresh` to inert,
+immutable shims. This prevents an anonymous browser from opening the existing
+public Vite socket, but it applies the same behavior to an authenticated editor.
+The authorization information already used by the annotation surface is not
+used to select the Runtime representation.
 
-The current implementation contains two conflicting contracts:
+There is a second ownership problem. Runtime currently lets a Session's Vite
+context depend on the requested external base. Alternating `/show/<session>/`
+and `/p/<share>/` requests can therefore rebuild or replace one context as the
+base changes. Simply making the public socket conditional would still let an
+anonymous request disrupt an authorized editor's HMR connection.
 
-- `docs/plans/show-service-runtime.md` says private and public Show Pages both
-  receive live HMR.
-- The public proxy rewrites `@vite/client` and `@react-refresh` to inert,
-  immutable shims, so a public browser never opens the existing
-  `/p/<share>/__vite_hmr` socket.
-
-The shims were introduced by `8dc1319eb` (`fix(show): stabilize public runtime
-modules`). They prevented an anonymous Vite socket, but also disabled public
-live updates. That implementation detail accidentally became product behavior.
-
-There is also a deeper ownership problem. The sidecar currently keys an active
-Vite context by both `session_id` and an external base path. Alternating private
-and public requests can close and rebuild the same Session's Vite server as the
-base changes. More importantly, transforming individual modules in that mutable
-context cannot establish a stable public revision: static linking, stylesheet
-asset URLs, and the document-to-stream baseline can each disagree even when the
-individual transforms succeeded.
-
-The public publication boundary must therefore be a complete, immutable build,
-not a momentary observation of the development module graph.
+The fix is capability routing plus separate context ownership, not a weaker
+client-side HMR switch.
 
 ## Product Contract
 
-Visibility, publication, and update transport are distinct capabilities:
+### One editor capability
 
-- `public` controls who may read the activated public artifact.
-- authorization controls who may annotate, dispatch, or use private tools.
-- the public artifact controls which frontend version an anonymous viewer gets.
-- the surface trust boundary controls which update protocol is exposed.
+Avibe computes one `ShowEditorCapability` from server-owned facts:
 
-The last successfully activated artifact is the public page's last-known-good
-version. A candidate becomes visible only after its complete frontend build and
-static module linking succeed. Candidate files are never served in place.
+- a validated Workbench identity
+- an editor role
+- access to the Show Page resource
+- a current public share-to-Session binding when the request uses `/p/`
+- non-offline visibility
 
-This guarantee is intentionally precise. It prevents syntax, import/export
-linking, asset-graph, and build-plugin failures from replacing a working public
-page. A successful static build cannot prove that arbitrary application logic
-will not throw in a real browser. Browser canary execution would be required for
-that stronger guarantee and is not part of this change.
+The public annotation decision and public-link HMR decision consume the same
+result. The implementation should factor the existing annotation inputs into
+one helper rather than make two similar authorization checks.
+
+A cookie's presence, a browser-provided flag, the public share ID, or a
+share-scoped annotation write token is insufficient. The annotation token proves
+only one permitted public event write after capability selection; it is never
+accepted for module or HMR access.
+
+Missing, expired, read-only, resource-forbidden, ambiguous, or temporarily
+unverifiable authorization fails closed to `public-no-hmr`. A remote identity
+outage must not make an otherwise public page unavailable.
+
+### Server-selected document mode
+
+Before returning a public entry document or SPA fallback, Avibe selects exactly
+one discriminated configuration:
+
+```ts
+type PublicRouteDocumentConfig =
+  | {
+      protocol: 1
+      mode: "private-hmr"
+      pageBasePath: string
+      runtimeBasePath: string
+      editorAuthorized: true
+    }
+  | {
+      protocol: 1
+      mode: "public-no-hmr"
+      pageBasePath: string
+      editorAuthorized: false
+    }
+```
+
+For `private-hmr`, `pageBasePath` remains `/p/<share>/` while
+`runtimeBasePath` is `/show/<session>/`. For `public-no-hmr`, the configuration
+contains no Session identifier or private Runtime path. The existing structured
+configuration injector serializes this object; it is not assembled by replacing
+strings in HTML.
+
+The mode is request-scoped, not stored on the page and not sticky in the
+browser. Login or permission changes take effect on the next navigation. Losing
+authorization closes the existing private HMR connection and rejects subsequent
+private module reads; a later `/p/` navigation selects `public-no-hmr`.
 
 ### User-visible requirements
 
-1. An idle, visible public page reloads automatically after the latest valid
-   write burst has been built and activated.
-2. A failed public build does not replace an activated page with an error
-   overlay, partial graph, or blank document.
-3. Once the source builds again, the next activated artifact reloads the page
-   without manual action.
-4. A hidden tab records a pending artifact and waits without a deadline until it
-   becomes visible.
-5. Once visible, a pending reload waits while a text input, textarea, select, or
-   editable element is active, but for at most 30 seconds of visible editable
-   time. Visibility takes precedence over this deadline.
-6. Public Live Reload is best effort while Runtime or SSE is unavailable. The
-   activated page remains usable and the client reconnects with bounded backoff.
-7. The first public request after a cold Runtime or after public visibility is
-   enabled may wait for one initial build. Once an artifact is active, ordinary
-   page loads do not wait for a build.
+1. An authorized editor opening either `/show/` or `/p/` gets full Vite HMR and
+   React Fast Refresh from the same canonical development context.
+2. An anonymous or unauthorized `/p/` viewer never receives a Vite client,
+   React Refresh runtime, HMR socket, private module URL, Session identifier,
+   source frame, or development diagnostic.
+3. The public link and page content remain readable without login.
+4. An unauthorized loaded page does not update automatically. Refreshing it
+   reads the current public workspace content.
+5. A failed or unavailable identity lookup selects the public representation
+   rather than delaying or failing the public page.
+6. Private and authorized-public traffic cannot be restarted or rebased by an
+   unauthorized public request.
+7. Existing public path confinement, sensitive-path denial, and symlink escape
+   protections remain in force for every public request.
 
 ## Architecture
 
 ```text
-Agent file write
-  -> canonical private Vite development context (private HMR only)
-  -> demand-active public artifact builder
-  -> complete Vite production build in staging
-  -> generation check + atomic artifact activation
-  -> loopback active-artifact stream
-  -> Avibe public share/visibility gate and SSE relay
-  -> small public live client
-  -> location.reload()
-
-Public browser
-  -> /p/<share>/ document and relative artifact assets
-  -> never reads canonical /show/<session>/ development modules
+GET /p/<share>/...
+  -> resolve current public share
+  -> compute ShowEditorCapability
+     -> authorized editor
+        -> canonical private Vite context
+        -> canonical /show/<session>/ module URLs
+        -> existing private HMR socket and revocation
+     -> everyone else
+        -> isolated public transform context
+        -> public URL rewriting and immutable shims
+        -> no websocket and no automatic update
 ```
 
-### Private runtime ownership
+### Runtime context ownership
 
-Each Session has at most one Vite development context. It is keyed by
-`session_id` and uses the canonical private base:
+Runtime owns at most two contexts for a public Session:
 
-```text
-/show/<session-id>/
-```
+| Context key | Base | Consumers | Lifetime |
+| --- | --- | --- | --- |
+| `(session_id, private)` | `/show/<session>/` | Private `/show/` plus editor-authorized `/p/` | Existing private demand/lifecycle |
+| `(session_id, public)` | Current `/p/<share>/` | Unprivileged public requests only | Demand-created; disposable without affecting private HMR |
 
-Only the authenticated private surface reads that context and its HMR channel.
-Public requests no longer send a share-specific `x-vibe-show-base`, do not
-change the Vite base, and cannot restart the private development context.
+The private context is canonical. An authorized `/p/` request does not send a
+share-specific `x-vibe-show-base`, rewrite private modules into the share path,
+or create a second private HMR protocol. Its document is served at the public
+URL, but generated module, React Refresh, and HMR URLs point to the authenticated
+`/show/<session>/` routes.
 
-### Public artifact ownership
+The public transform context preserves today's no-HMR representation but no
+longer owns or replaces the private context. A share rotation may recreate only
+the disposable public context. Public context startup, failure, or traffic
+cannot close the private socket.
 
-`vibe-show-runtime` owns:
+The public context is a read transform surface, not a publication guarantee. It
+may read the latest workspace state on navigation, so a fresh request during an
+invalid edit can receive the existing sanitized unavailable behavior. This
+change does not promise last-known-good artifacts or frontend/API revision
+atomicity.
 
-- coalescing Vite-relevant workspace invalidations
-- complete public frontend builds
-- staging, validation, activation, retention, and cleanup of public artifacts
-- the opaque active-artifact identifier
-- the loopback-only artifact stream and artifact file endpoint
+### HTTP routing
 
-`avibe` owns:
+For an authorized public entry or SPA navigation, Avibe requests the canonical
+private Runtime representation while preserving the browser's public
+`pageBasePath`. Normal generated subresources then use `/show/<session>/` and
+pass through the existing private route. If authored code makes a relative
+request that still reaches `/p/`, Avibe recomputes the capability before routing
+that request to the private context.
 
-- public share resolution and durable visibility checks
-- public origin and host policy
-- injection of request-specific public document configuration
-- the gated public artifact proxy
-- the redacted public SSE contract and browser client
-- bounded revocation when a share rotates or leaves `public`
+For an unprivileged request, Avibe uses only the public context and existing
+public-safe response transforms. Exact files and API handlers retain first
+refusal; route-shaped document misses retain the current SPA fallback. The
+implementation must preserve the existing path policy as an invariant over the
+whole public request surface:
 
-The existing Show event stream remains separate. Show events are durable product
-events with replay and authorization semantics. Artifact activations are
-ephemeral render state. Combining them would make one stream own unrelated
-retention, redaction, and failure models.
+- no sensitive segment is readable
+- no symlink or `@fs` path escapes the allowed workspace/dependency roots
+- no private Session path survives a public response
+- no public request is forwarded to an arbitrary host file or plugin endpoint
 
-### Demand and cold start
+The public context continues to use inert, versioned `@vite/client` and React
+Refresh shims. It exposes neither Runtime diagnostics nor a message channel.
 
-Public builds are demand-active rather than running for every private Session:
+### WebSocket routing
 
-- A public document request asks Runtime to ensure an artifact for the current
-  workspace generation. Concurrent requests join the same build.
-- An open public SSE subscriber holds demand for its Session, so later edits are
-  built without waiting for another HTTP request.
-- With no public demand, Runtime may stop building. The next public request
-  catches up to the latest generation before returning the document.
-- If a previous artifact exists and a catch-up build fails, Runtime serves that
-  artifact. If no artifact has ever activated, Avibe returns a sanitized
-  recovery shell with `artifact: null`. The shell opens the same redacted
-  artifact stream, holds public demand, and reloads when the first artifact
-  activates. Its reconnect loop continues indefinitely with capped backoff, so
-  recovery does not depend on a later document request or manual refresh. It
-  never falls back to development modules.
+`/show/<session>/__vite_hmr` remains the only HMR endpoint. It requires the same
+effective editor capability, allowed origin, current remote authorization
+revision, and Show Page resource access. Existing authorization and resource
+broker tasks close it when those facts stop holding.
 
-This keeps private-only editing costs unchanged while ensuring a fresh public
-viewer cannot observe a partially edited source tree.
+`/p/<share>/__vite_hmr` is removed for every viewer. An authorized public
+document does not need it because its Vite client uses the canonical private
+socket; an unprivileged document contains no live client.
 
-## Atomic Artifact Model
+### Cache boundary
 
-Runtime maintains a candidate generation for each Session and follows this
-sequence:
+Every `/p/` response whose bytes can differ by capability uses
+`Cache-Control: private, no-store` and `Vary: Cookie`. Successful content-hashed
+vendor assets at capability-independent global URLs may retain immutable
+caching. Avibe never forwards browser cookies, authorization headers, CSRF
+headers, or annotation tokens to Runtime.
 
-1. A frontend-relevant invalidation increments the candidate generation.
-2. Runtime waits for a 250 ms quiet window and coalesces the write burst.
-3. Runtime allocates a new opaque artifact identifier and builds the complete
-   frontend entry graph into a staging directory outside the workspace.
-4. The build uses Vite's production build and Rollup linking, disables source
-   maps, excludes development HMR/React Refresh clients, and emits content-hashed
-   files with relative asset references.
-5. Runtime rejects the candidate if the build, link, or any required first-party
-   asset resolution fails. It then validates the complete emitted byte set,
-   independent of file type, against the private-output deny set: the Session
-   identifier, canonical private route, sidecar route, current or previous share
-   identifier, and other private runtime identifiers. Any match rejects the
-   entire candidate before activation. A newly emitted URL-bearing format is
-   therefore covered without adding another MIME-specific validator.
-6. If another invalidation arrived during the build, Runtime discards the stale
-   output and schedules the newest generation.
-7. Runtime moves the complete staging directory into immutable artifact storage,
-   then atomically replaces the active pointer only if the generation is still
-   current.
-8. Only pointer activation emits one artifact notification.
-
-The active artifact and its files are immutable. Each served document uses
-artifact-scoped file URLs. Serving the document starts a short connection grace;
-opening the stream with that document artifact promotes the grace to a document
-lease. Runtime pins the active artifact and every artifact referenced by an open
-document lease. A disconnected lease receives a bounded cleanup grace longer
-than the client's maximum reconnect delay; normal reconnection renews it. Lease
-count and retained bytes are bounded per Session at stream admission, so the
-number of simultaneously pinned inactive artifacts is also bounded. A refused
-stream does not evict an artifact serving an already admitted document. An
-inactive artifact is removed only after its last lease and grace expire. A
-process restart may rebuild the same source into a new opaque identifier, which
-causes at most one public reload. Artifacts are Runtime cache, not durable
-product history.
-
-Relative output is part of the contract. Avibe serves artifact files beneath
-`/p/<share>/__show/artifacts/<artifact-id>/` and injects separate public page and
-artifact base paths. Entry references are rewritten with a structured HTML
-transform to the artifact-scoped base; relative JavaScript chunks, imported CSS,
-and nested asset references remain inside that scope. The application route
-continues to use `/p/<share>/`, so asset addressing does not change SPA routing
-or relative public API requests. Neither the artifact nor its references contain
-`/show/<session>/` or a share ID. Rotating a share changes only the request-time
-gate and document configuration; it does not require rebuilding the artifact.
-
-Public navigation preserves the existing SPA fallback deliberately. Avibe first
-resolves exact artifact files and reserved `api/` and `__show/` routes. A `GET`
-or `HEAD` browser document navigation that matches none of them receives the
-active artifact's entry document, configured for the requested public route. A
-missing script, stylesheet, image, other asset, API route, or reserved Show route
-returns its real error and is never rewritten to the entry document.
-
-Public `api/` handlers remain permissioned live server code and are not bundled
-into the frontend artifact. Relative public API requests continue through the
-existing Avibe gate. A handler-only edit does not require a frontend reload.
-
-## Artifact Stream Contract
-
-The sidecar adds loopback-only endpoints:
-
-```text
-GET /sessions/<session-id>/public-artifact?ensure=current
-GET /sessions/<session-id>/public-artifacts/<artifact-id>/<path>
-GET /sessions/<session-id>/public-artifacts?stream=1&document=<artifact-id>
-```
-
-The public Avibe surface exposes:
-
-```text
-GET /p/<share-id>/__show/artifacts
-GET /p/<share-id>/__show/artifacts/<artifact-id>/<path>
-```
-
-The public endpoint is a terminating relay, not a byte-for-byte proxy. It parses
-the internal contract and serializes only the public allowlist.
-
-Every served public document contains the identifier of the exact artifact from
-which its HTML was read:
-
-```html
-<script>
-  globalThis.__AVIBE_SHOW__ = {
-    basePath: "/p/brief/",
-    artifactBasePath: "/p/brief/__show/artifacts/art_7f42/",
-    artifact: "art_7f42"
-  }
-</script>
-```
-
-The real value is serialized with the existing safe configuration-injection
-mechanism; the example is illustrative, not an inline-string implementation.
-
-Initial stream state:
-
-```text
-event: ready
-data: {"protocol":1,"artifact":"art_7f42"}
-
-```
-
-Activated update:
-
-```text
-id: art_91ac
-event: artifact
-data: {"protocol":1,"artifact":"art_91ac"}
-
-```
-
-Contract rules:
-
-- `protocol` is the schema version and is currently `1`.
-- A non-null `artifact` is an opaque identifier for one immutable activated
-  build. Null is valid only in the recovery shell's `ready` event.
-- Equality is the only browser operation on `artifact`; ordering is unnecessary.
-- The payload contains no Session ID, share ID, module URL, filesystem path,
-  source code, error, plugin name, or source frame.
-- Keepalives are SSE comment frames and carry no data.
-- A new subscriber receives exactly one `ready` event with the current active
-  artifact. The recovery shell may receive `artifact: null` until the first
-  activation. Artifact history is not replayed.
-- The browser opens the public stream with its document artifact, if any, as an
-  opaque `document` query value. Avibe validates that the artifact belongs to
-  the resolved Session before creating an internal lease; it never forwards the
-  query blindly. A null recovery-shell document holds build demand but no
-  artifact lease.
-- The document uses `Cache-Control: no-store`; hashed artifact files may use
-  immutable caching while the share remains authorized.
-
-Embedding the artifact in the document closes the initial-subscription race. If
-activation occurs after HTML is served but before the first `ready`, the two
-identifiers differ and the client reloads. The first `ready` is never accepted
-as an unverified baseline.
-
-Runtime health advertises artifact protocol v1 so Avibe can stage the Runtime
-release before enabling the client. An older Runtime yields a closed/no-content
-stream and never falls back to raw public HMR.
-
-## Public Client State Machine
-
-The public document loads a small versioned live client. Public production
-artifacts contain no Vite HMR imports, so the client does not need to emulate
-the Vite protocol. It runs once per document:
-
-1. Read `basePath`, `artifactBasePath`, and the document's `artifact` from the
-   injected configuration.
-2. Open `<basePath>__show/artifacts`, adding the opaque document artifact as the
-   `document` query value when it is non-null.
-3. Compare both `ready` and later `artifact` events with the document artifact.
-   Equal means current; different means a reload is pending.
-4. Keep only the newest pending identifier. A later event does not reset any
-   active editable-control deadline.
-5. If the document is hidden, wait without starting or advancing the 30-second
-   editable deadline.
-6. When visible, reload immediately unless an editable control is active. While
-   visible and editable, reload on blur or after 30 accumulated seconds. If the
-   document becomes hidden, pause the deadline; visibility remains dominant.
-7. Set an in-memory reload guard immediately before `location.reload()`. The new
-   no-store document carries its own artifact and performs the same equality
-   handshake, preventing a persistent reload loop.
-8. On stream failure, close the failed `EventSource` and reconnect indefinitely
-   with exponential backoff, jitter, and a maximum delay. A valid `ready` resets
-   the failure counter. `online` and visibility transitions may trigger an
-   immediate probe, but are not required for recovery. The recovery shell uses
-   the same loop, so a first-build failure heals after a later valid edit without
-   a manual refresh.
-
-The client displays no public error overlay. Build and connection diagnostics
-belong in private Runtime/Avibe logs.
-
-## Security and Revocation Boundary
-
-Raw Vite HMR is not acceptable on a public page because the current route is a
-bidirectional proxy into a development server. Client `custom` messages can
-reach installed plugin listeners, and development diagnostics can contain local
-paths, stack traces, source frames, and plugin code.
-
-Every public document, artifact-file, API, and SSE request therefore resolves
-the share against the durable `ShowPageStore` and requires that it currently
-maps to the Session with `public` visibility. The SSE relay additionally:
-
-- revalidates durable share state at connection time, before forwarding an
-  artifact event, and on every keepalive interval of at most 5 seconds
-- closes immediately on an in-process share/visibility broker event when one is
-  available
-- closes within 5 seconds even when `vibe show update` changed the store from a
-  different process and no in-memory broker event exists
-- requires an allowed public host and exact same-origin browser origin when an
-  `Origin` header is present
-- forwards no cookies, authorization headers, CSRF headers, or query credentials
-  to Runtime
-- accepts only protocol-v1 `ready` and `artifact` payloads
-- retains at most the latest pending artifact per subscriber
-- responds with `Cache-Control: no-store`, `Content-Type: text/event-stream`,
-  `X-Accel-Buffering: no`, and `Referrer-Policy: no-referrer`
-
-The anonymous `/p/<share>/__vite_hmr` route is removed. Private
-`/show/<session>/__vite_hmr` keeps its authentication, origin,
-authorization-revision, and resource-revocation checks.
-
-Revocation cannot erase bytes an anonymous browser already downloaded or cached;
-it prevents new authorized reads and bounds how long an existing live stream can
-remain attached. That is the same unavoidable limit as any public web response.
+This prevents an intermediary or browser cache from serving an editor's private
+document to an anonymous viewer. Mode selection must happen before any document
+or redirect bytes are returned; client-side replacement is not a security
+boundary.
 
 ## Performance Model
 
-The cost model has three distinct cases:
+The model adds authorization routing, not a production publication pipeline:
 
 | Case | Cost |
 | --- | --- |
-| Normal public page load with an active artifact | Static hashed files plus one small asynchronous SSE client; no build on the request path |
-| Valid edit while public demand exists | One coalesced production build per Session, one atomic activation, then one full reload per viewer |
-| First public request with no current artifact | One joined initial build before the document can be served |
+| Authorized editor opens `/p/` | Existing session/resource decision, canonical Vite transforms, and one private HMR socket; equivalent to `/show/` |
+| Unprivileged viewer opens `/p/` | Existing public transforms and shims from an isolated public context; no socket |
+| Both modes are active | Up to two Vite contexts for the Session; only the private context maintains HMR clients |
+| Agent edit | Private context pushes HMR; public context does no work until the next public request or refresh |
 
-Budgets and invariants:
+The authorization decision adds no browser round trip. A request without a
+Workbench cookie immediately selects public mode; a request with a cookie uses
+the existing bounded/cached identity resolution already needed by annotations.
 
-- public live client: at most 3 KB gzip
-- no Vite client, React Refresh runtime, source map, or public HMR socket
-- one build per Session write burst, independent of viewer count
-- no public build while a private-only Session has no public demand
-- active hashed assets remain cacheable across document reloads
-- active plus admitted document leases and their disconnect grace define
-  artifact retention; per-Session lease and byte budgets bound resource use
-- build work is cancellable by generation and never runs concurrently for the
-  same Session
+An authorized `/p/` load should have the same cold and warm profile as `/show/`.
+The isolated public context can increase Runtime memory when authorized and
+anonymous viewers are active simultaneously, but avoids production builds,
+artifact storage, SSE fanout, and anonymous sockets. Runtime must expose context
+count and memory so local Incus regression can set a per-Session idle eviction
+budget from measurements rather than an assumed universal threshold.
 
-An activated public page should not load slower because Live Reload is enabled:
-the SSE connection starts after the module script and does not block rendering.
-The model does add CPU and update latency compared with transform-only HMR, and a
-cold first public request can wait for a build. Local Incus measurements must set
-the final starter-page activation budget; the design does not claim a universal
-2-second bound before measuring representative pages.
+## Failure And Revocation Behavior
 
-## Failure Behavior
-
-| Failure | Public behavior | Private/operator evidence |
+| Failure | Browser behavior | Operator evidence |
 | --- | --- | --- |
-| Syntax, import/export, asset, or build-plugin failure | Keep active artifact; activate nothing | Vite build/Runtime diagnostic |
-| Arbitrary runtime exception after a successful build | Browser may fail; no stronger guarantee without a canary | Browser telemetry or manual regression |
-| New invalidation during a build | Discard stale candidate; build latest generation | Debug metric only |
-| Runtime unavailable | Keep loaded page; indefinitely retry with capped delay | Runtime health/logs |
-| SSE interrupted | Compare reconnecting `ready` with the document artifact | Connection metric/log |
-| Share rotated/private/offline | Reject new reads; close stream immediately or within 5 seconds | Durable visibility state and relay log |
-| Runtime restarted | Reuse a valid cached artifact or rebuild; a new ID reloads once | Runtime lifecycle log |
-| Initial build fails with no active artifact | Sanitized recovery shell holds demand and reloads after the first valid activation; no development fallback | Private build diagnostic |
+| Missing/expired/read-only identity | Serve `public-no-hmr` | Redacted authorization reason |
+| Identity service unavailable | Serve `public-no-hmr`; public availability does not depend on identity recovery | Authorization availability metric/log |
+| Private Runtime unavailable for an authorized editor | Existing private sanitized recovery behavior; never fall through to a raw public socket | Private Runtime log |
+| Public context unavailable | Existing sanitized public unavailable/static fallback | Public Runtime log without source detail |
+| Editor or resource access revoked | Close private HMR and reject later private reads; next `/p/` navigation uses public mode | Existing authorization-revision/resource-revocation log |
+| Share rotates or becomes private/offline | Old public reads fail immediately; private access remains governed independently | Durable Show Page state |
+
+Revocation cannot erase module bytes already downloaded by a previously
+authorized editor. It prevents future reads and terminates the bidirectional
+channel, which is the same unavoidable boundary as the private `/show/` surface.
 
 ## Rejected Alternatives
 
-### Expose private Vite HMR on `/p/`
+### Enable `/p/` HMR for every public viewer
 
-This is fastest and preserves React state, but exposes a bidirectional
-development protocol, diagnostics, version coupling, and one Vite socket per
-anonymous viewer. Filtering Vite deeply enough would create a second partial HMR
-implementation that remains coupled to Vite internals.
+Public visibility grants content read access, not access to Vite custom messages,
+plugin listeners, local paths, source frames, or Runtime diagnostics. This would
+turn a share link into a development-server capability.
 
-### Publish a transform-validated mutable graph
+### Gate HMR only in the browser
 
-Transforming affected modules is cheaper than a build, but cannot validate
-static linking across unchanged importers, cannot make the served document and
-first SSE baseline atomic, and still requires response rewriting for JavaScript,
-HTML, and stylesheet asset URLs. It has no stable unit to retain as
-last-known-good. These are properties of the model, not isolated proxy bugs.
+An anonymous viewer can remove a client-side condition or connect directly.
+Authorization must select the document representation and independently guard
+every private module and socket request on the server.
 
-### Poll the public document
+### Treat any login cookie as permission
 
-Polling creates traffic while nothing changes, adds update latency, and still
-needs an authoritative artifact identifier. SSE has a smaller idle cost and a
-clearer equality handshake.
+A cookie can be expired, read-only, resource-forbidden, or unrelated to the
+Show Page. The complete editor capability, not cookie presence, is the boundary.
 
-### Put artifacts on the durable Show event stream
+### Add an authenticated `/p/<share>/__vite_hmr` endpoint
 
-This reuses a connection but conflates ephemeral compilation state with durable
-human/assistant events and their replay, storage, redaction, and dispatch rules.
-The apparent transport reuse creates a larger conceptual system.
+This would duplicate private socket authorization/revocation and retain a
+share-specific Vite base. Using canonical `/show/` module and socket URLs reuses
+the existing boundary and avoids protocol drift.
 
-### Run a browser canary before every activation
+### Share one base-switching Vite context
 
-A canary can catch some runtime exceptions that a static build cannot, but adds
-a browser lifecycle, readiness protocol, timeout policy, side-effect isolation,
-and substantially higher edit latency. Static full-graph build validation is the
-smallest boundary that fixes the demonstrated blank-page class. A canary can be
-added later only if real failures justify the stronger publication guarantee.
+Alternating authorized and anonymous requests would continue to rebase or
+restart the editor's development context. Separate private/public ownership is
+the minimum isolation needed for reliable HMR.
+
+### Add anonymous artifact Live Reload
+
+An immutable artifact stream sounds safer than public HMR, but a complete model
+must also sandbox build inputs, retain every loaded document's files, preserve
+runtime-resolved asset URLs, coordinate live API handlers with frontend
+revisions, and bound builds across Sessions. It is a separate publication
+feature, not a prerequisite for capability-gated editor HMR.
 
 ## Delivery Sequence
 
-1. Freeze protocol-v1 artifact fixtures and the document configuration shape as
-   shared contract files consumed by Runtime and Avibe tests.
-2. In `vibe-show-runtime`, add the demand lease, generation-coalesced production
-   builder, immutable storage, atomic activation, loopback file endpoint, stream,
-   and capability advertisement.
-3. Release the Runtime artifact and update Avibe's managed Runtime manifest.
-4. In `avibe`, keep the private Vite context canonical, replace public
-   development-module proxying with the gated artifact proxy, inject the exact
-   document artifact/base, add the terminating SSE relay and durable-state
-   revalidation, and remove public raw HMR.
-5. Update `show-service-runtime.md` and the multipage scaffold plan so `HMR`
-   means the private protocol and `Live Reload` means activated public artifacts.
-6. Add scenario-catalog entries, then run local Incus regression with concurrent
-   private/public viewers and direct CLI visibility mutation.
+1. Freeze `ShowEditorCapability` inputs and the discriminated document
+   configuration as contract fixtures.
+2. Factor public annotation authorization into the shared, resource-aware editor
+   capability and use the same result for document mode selection.
+3. Split Runtime ownership into canonical private and disposable public contexts
+   without changing the private base or protocol.
+4. Route authorized `/p/` documents and relative requests to the private context;
+   keep their browser-visible page base public and their module/HMR base private.
+5. Keep unprivileged `/p/` on the public transform/shim path and remove the
+   public HMR websocket.
+6. Add cache, revocation, concurrency, and path-confinement contract tests.
+7. Run local Incus regression with authorized, read-only, anonymous, and revoked
+   viewers open concurrently.
 
-The rollout must not activate the public client before managed Runtime advertises
-protocol v1. During a mixed-version checkout, the feature remains disabled:
-public pages keep the current readable, non-live behavior and never expose raw
-HMR. The implementation PR must define the explicit compatibility cutover and
-remove the old public development-module path once the bundled Runtime is
-guaranteed compatible.
+The capability branch can roll out with the bundled Runtime change. Mixed
+versions fail closed: if Runtime cannot provide independently keyed contexts,
+`/p/` keeps the existing no-HMR behavior for every viewer. It never enables the
+old anonymous public socket as a compatibility fallback.
 
 ## Verification Plan
 
-### Runtime unit tests
+### Authorization and document contract tests
 
-- coalesce a file burst into one candidate build
-- statically link the full graph and reject a removed named export referenced by
-  an unchanged importer
-- leave the active pointer unchanged for syntax, link, plugin, and asset failure
-- discard a successful build superseded by a newer generation
-- atomically activate only complete immutable output
-- join concurrent initial requests to one build
-- hold demand while at least one public stream is subscribed
-- retain every artifact referenced by an admitted document lease and clean it
-  only after the last lease plus reconnect grace expires
-- keep artifact-scoped files available across two or more later activations
-- keep null-artifact recovery demand active after an initial build failure
-- replay only the current active artifact to a new subscriber
+- seed every supported identity/resource shape and assert that `canAnnotate`
+  and `private-hmr` are produced by the same editor capability
+- prove anonymous, read-only, expired, resource-forbidden, and unverifiable
+  requests receive only `public-no-hmr`
+- prove query parameters, headers outside the trusted identity boundary, and
+  annotation write tokens cannot upgrade document mode
+- prove both capability-varying entry responses are private/no-store and vary on
+  cookies
+- prove the public configuration contains no Session identifier or private path
 
-### Avibe unit and contract tests
+### Runtime and proxy tests
 
-- public documents embed the exact served artifact identifier
-- a `ready` value different from the embedded identifier reloads instead of
-  becoming an unchecked baseline
-- anonymous artifact and SSE requests succeed only for the current public share
-- direct `ShowPageStore` mutation from `vibe show update` closes a stream within
-  the 5-second bound without relying on an in-memory broker event
-- public relay drops unknown event types and extra fields
-- browser credentials are never forwarded to Runtime
-- every emitted file is checked for private runtime identifiers regardless of
-  format, and the complete candidate is rejected on any match
-- artifact-scoped resources remain available to their loaded document while a
-  newer artifact is active
-- browser-history document navigation receives the active entry document while
-  missing assets, API routes, and reserved Show routes keep their real errors
-- recovery-shell and ordinary clients continue reconnecting after more than six
-  consecutive failures and recover without manual interaction
-- public raw `__vite_hmr` is unavailable while private HMR remains unchanged
-- private and public traffic never changes or rebuilds the private Vite base
+- private and public contexts have independent keys and lifecycles
+- public requests never change, close, or rebuild the private context
+- authorized `/p/` documents reference canonical private modules, React Refresh,
+  and `/show/<session>/__vite_hmr`
+- unprivileged documents reference only public paths and immutable shims
+- `/p/<share>/__vite_hmr` rejects every connection
+- private module and HMR requests repeat editor/resource/origin checks and close
+  on authorization-revision or resource revocation
+- every existing public path-confinement fixture remains denied by the new
+  routing branch, including sensitive segments and workspace escapes
+- direct CLI share rotation or visibility mutation invalidates the old public
+  route without touching independently authorized private access
 
 ### Browser and regression scenarios
 
 | ID | Scenario | Expected evidence |
 | --- | --- | --- |
-| `SHOW-LIVE-001` | Agent edits a valid public page | One artifact activates and the visible public page reloads automatically |
-| `SHOW-LIVE-002` | Private author and public viewer are open together | Private Fast Refresh and public Live Reload both work; private Vite context stays stable |
-| `SHOW-LIVE-003` | Agent removes a named export still imported elsewhere, then repairs it | Public page retains the previous artifact with no diagnostic, then reloads after repair |
-| `SHOW-LIVE-004` | Public share rotates or direct CLI changes visibility to private/offline | Existing stream closes within 5 seconds and old share reads fail |
-| `SHOW-LIVE-005` | Many viewers watch one page | One candidate build per burst and no per-viewer Vite sockets or builds |
-| `SHOW-LIVE-006` | Public page cold-loads with a current artifact | No Vite/React Refresh client or source maps; live client stays within 3 KB gzip |
-| `SHOW-LIVE-007` | Revision arrives while both hidden and editing | No background deadline fires; after visibility, blur or 30 visible editable seconds causes exactly one reload |
-| `SHOW-LIVE-008` | Activation races the first SSE `ready` | Embedded and ready identifiers differ; the client reloads to the active artifact |
-| `SHOW-LIVE-009` | Page CSS references `url('./hero.png')`, then the share rotates | Asset loads on both share URLs and no canonical Session path is exposed |
-| `SHOW-LIVE-010` | Two artifacts activate while an older document defers reload during editing | The older document's lazy chunk, image, and font remain available until its lease and grace expire |
-| `SHOW-LIVE-011` | The artifact stream fails more than six times and later recovers | The client reconnects with capped delay and reloads without an online or visibility event |
-| `SHOW-LIVE-012` | The first public build fails and a later edit repairs it | The recovery shell holds demand and reloads automatically after the first valid activation |
-| `SHOW-LIVE-013` | A viewer opens a browser-history route such as `/p/<share>/reports/42` | The active entry document loads; a missing asset at the same depth returns 404 rather than HTML |
-| `SHOW-LIVE-014` | A generated SVG, manifest, or future artifact format contains a private route or identifier | Whole-output validation rejects the candidate before activation |
+| `SHOW-LIVE-001` | Authorized editor opens `/p/<share>/` and the Agent edits a component | React Fast Refresh applies through `/show/` and preserves component state |
+| `SHOW-LIVE-002` | Anonymous viewer opens the same link during the edit | No HMR socket exists and the loaded page stays unchanged until refresh |
+| `SHOW-LIVE-003` | Signed-in read-only or resource-forbidden viewer opens the link | Behavior and bytes match anonymous public mode; no private identifier appears |
+| `SHOW-LIVE-004` | Authorized `/show/`, authorized `/p/`, and anonymous `/p/` are open together | Both authorized views keep HMR while public traffic uses an independent context |
+| `SHOW-LIVE-005` | Identity resolution fails for a request carrying an unverifiable cookie | The public page remains readable with no HMR or diagnostic leak |
+| `SHOW-LIVE-006` | Editor or resource access is revoked while public-link HMR is open | The socket closes, private reads fail, and the next `/p/` navigation is no-HMR |
+| `SHOW-LIVE-007` | Share rotates or direct CLI changes visibility | The old public URL stops serving while authorized private routing remains independent |
+| `SHOW-LIVE-008` | Public requests target every existing denied path shape | All remain denied before Runtime access; no sensitive or escaped file is returned |
+| `SHOW-LIVE-009` | A viewer connects directly to `/p/<share>/__vite_hmr` | The connection is rejected regardless of cookies or visibility |
+| `SHOW-LIVE-010` | Authorized and anonymous viewers remain open through repeated edits | Context count stays bounded, private HMR remains stable, and no public background build occurs |
 
-The implementation adds these scenarios to the Show scenario catalog before its
-PR is complete. Focused unit/contract tests, Ruff, repository CI, and local Incus
-browser regression are required; green unit tests do not replace simultaneous
-private/public browser verification.
+Focused unit/contract tests, Ruff, repository CI, and local Incus browser
+regression are required. Green unit tests do not replace simultaneous
+authorized/anonymous browser verification.
 
 ## Acceptance Gate
 
-The feature is complete when all of the following are true:
+The design is implemented when all of the following are true:
 
-- Public Show updates automatically without exposing Vite HMR or diagnostics.
-- Every public response belongs to one immutable activated artifact; candidate
-  files are never served.
-- Complete build/link failures preserve the active public artifact and recover
-  on the next valid candidate.
-- The document artifact and SSE state use an exact equality handshake, including
-  the activation-before-first-`ready` race.
-- No emitted artifact byte contains a private runtime identifier, regardless of
-  format, and public requests continue to work after share rotation.
-- Loaded documents use artifact-scoped resources that remain available through
-  reload deferral, multiple later activations, and the reconnect grace.
-- Recovery shells and clients survive extended stream/build outages and recover
-  without manual refresh.
-- Browser-history navigations preserve SPA fallback without masking missing
-  assets, APIs, or reserved Show routes.
-- Direct cross-process visibility changes revoke reads and streams within the
-  defined 5-second bound.
-- Hidden state dominates the editable-control deadline exactly as specified.
-- Private HMR behavior and authorization remain unchanged, and public traffic
-  does not mutate the private Vite context.
-- Cold-build, normal-load, activation, client-size, build-fanout, and artifact
-  retention measurements satisfy the budgets established in local Incus.
+- Authorized public-link viewers get the same Vite HMR and React Fast Refresh
+  behavior as private editors.
+- Annotation and public-link HMR consume one validated, resource-aware editor
+  capability.
+- Every other public viewer receives a readable no-HMR representation with no
+  private identifier, diagnostics, or bidirectional Runtime channel.
+- `/show/<session>/__vite_hmr` is the only HMR endpoint and independently
+  revalidates authorization; `/p/<share>/__vite_hmr` does not exist.
+- Anonymous traffic cannot restart, rebase, or close the private Vite context.
+- Capability-varying responses cannot be shared across viewers by a cache.
+- Authorization failure preserves public availability and fails closed to
+  no-HMR mode.
+- Existing public source-confinement and sensitive-path protections hold for the
+  complete request surface.
+- Local Incus measurements show bounded context memory and no material page-load
+  regression beyond existing private/public transform costs.

--- a/docs/plans/public-show-live-update.md
+++ b/docs/plans/public-show-live-update.md
@@ -14,7 +14,7 @@ server-side capability:
 | Surface and viewer | Runtime representation | Update behavior |
 | --- | --- | --- |
 | Private `/show/<session>/`, authorized editor | Canonical private Vite context | Vite HMR and React Fast Refresh |
-| Public `/p/<share>/`, authorized editor | The same canonical private Vite context | Vite HMR and React Fast Refresh |
+| Public `/p/<share>/`, authorized editor navigation | Redirect to canonical `/show/<session>/` | Vite HMR and React Fast Refresh after the redirect |
 | Public `/p/<share>/`, anonymous, read-only, expired, resource-forbidden, or unverifiable | Isolated public transform context | No Hot Reload; refresh reads current content |
 | Offline | None | None |
 
@@ -28,13 +28,15 @@ viewer. They open the same `/p/brief/` URL while an Agent edits the page:
 
 1. Avibe resolves Alice's existing Workbench session and the same editor
    capability used to enable annotations.
-2. Alice's document uses the canonical private module graph and
-   `/show/<session>/__vite_hmr`; React Fast Refresh updates her page and preserves
-   component state.
+2. Avibe redirects Alice's top-level navigation to the corresponding canonical
+   `/show/<session>/` path. That document, every module, and
+   `/show/<session>/__vite_hmr` use one private representation; React Fast Refresh
+   updates her page and preserves component state.
 3. Bob's document uses the isolated public transform context. It contains the
    inert Vite/React Refresh shims and never opens an HMR socket.
-4. Bob's loaded page stays unchanged. A later manual navigation or refresh reads
-   the current public content.
+4. Bob's loaded page stays on the public representation even if identity state
+   changes while its subresources load. A later manual navigation or refresh reads
+   the current public content and may then take the editor redirect.
 
 This design intentionally does not add anonymous Live Reload. That requirement
 would need an independently published revision model with artifact retention,
@@ -56,8 +58,8 @@ and `/p/<share>/` requests can therefore rebuild or replace one context as the
 base changes. Simply making the public socket conditional would still let an
 anonymous request disrupt an authorized editor's HMR connection.
 
-The fix is capability routing plus separate context ownership, not a weaker
-client-side HMR switch.
+The fix is a capability-gated navigation redirect plus separate context
+ownership, not a weaker client-side HMR switch or two representations at one URL.
 
 ## Product Contract
 
@@ -81,46 +83,45 @@ only one permitted public event write after capability selection; it is never
 accepted for module or HMR access.
 
 Missing, expired, read-only, resource-forbidden, ambiguous, or temporarily
-unverifiable authorization fails closed to `public-no-hmr`. A remote identity
-outage must not make an otherwise public page unavailable.
+unverifiable authorization fails closed to the public no-HMR representation. A
+remote identity outage must not make an otherwise public page unavailable.
 
-### Server-selected document mode
+### URL-selected representation
 
-Before returning a public entry document or SPA fallback, Avibe selects exactly
-one discriminated configuration:
+One browser document uses one representation for its complete lifetime:
 
-```ts
-type PublicRouteDocumentConfig =
-  | {
-      protocol: 1
-      mode: "private-hmr"
-      pageBasePath: string
-      runtimeBasePath: string
-      editorAuthorized: true
-    }
-  | {
-      protocol: 1
-      mode: "public-no-hmr"
-      pageBasePath: string
-      editorAuthorized: false
-    }
-```
+- `/p/<share>/...` always serves the public no-HMR representation.
+- `/show/<session>/...` always serves the canonical private representation.
+- Avibe never returns a private entry document, module, API response, or HMR
+  client with a `/p/` document URL.
 
-For `private-hmr`, `pageBasePath` remains `/p/<share>/` while
-`runtimeBasePath` is `/show/<session>/`. For `public-no-hmr`, the configuration
-contains no Session identifier or private Runtime path. The existing structured
-configuration injector serializes this object; it is not assembled by replacing
-strings in HTML.
+For a `GET` top-level browser navigation to a current public share, Avibe first
+computes `ShowEditorCapability`. When it succeeds and Runtime has explicitly
+advertised keyed-context support, Avibe returns a private, no-store redirect to
+the equivalent `/show/<session>/<route>` URL, preserving the route suffix and
+query. `Sec-Fetch-Mode: navigate` and `Sec-Fetch-Dest: document` are the trusted
+navigation evidence. Missing or contradictory Fetch Metadata fails closed to the
+ordinary public document; it never upgrades a subresource, `fetch()`, worker, or
+API request.
 
-The mode is request-scoped, not stored on the page and not sticky in the
-browser. Login or permission changes take effect on the next navigation. Losing
-authorization closes the existing private HMR connection and rejects subsequent
-private module reads; a later `/p/` navigation selects `public-no-hmr`.
+No update-mode discriminator replaces the existing `globalThis.__AVIBE_SHOW__`
+payload. Public and private documents retain the shipped additive bootstrap keys:
+`sessionId`, `basePath`, `eventsPath`, `streamPath`, optional `writeToken`, and
+`annotation`. The URL and redirect are the representation boundary, so existing
+scaffolds, history routing, annotations, and event streams keep their current
+bootstrap contract.
+
+Login or permission changes take effect on the next network navigation. A loaded
+public document and all relative `/p/` requests remain public even if identity
+resolution later recovers. Losing editor authorization closes an existing private
+HMR connection; ordinary private module reads then continue or fail according to
+the caller's current Show Page read ACL.
 
 ### User-visible requirements
 
-1. An authorized editor opening either `/show/` or `/p/` gets full Vite HMR and
-   React Fast Refresh from the same canonical development context.
+1. An authorized editor opening `/p/` is redirected to the equivalent `/show/`
+   route and gets full Vite HMR and React Fast Refresh from the canonical
+   development context.
 2. An anonymous or unauthorized `/p/` viewer never receives a Vite client,
    React Refresh runtime, HMR socket, private module URL, Session identifier,
    source frame, or development diagnostic.
@@ -129,8 +130,8 @@ private module reads; a later `/p/` navigation selects `public-no-hmr`.
    reads the current public workspace content.
 5. A failed or unavailable identity lookup selects the public representation
    rather than delaying or failing the public page.
-6. Private and authorized-public traffic cannot be restarted or rebased by an
-   unauthorized public request.
+6. Private HMR traffic cannot be restarted or rebased by an unauthorized public
+   request.
 7. Existing public path confinement, sensitive-path denial, and symlink escape
    protections remain in force for every public request.
 
@@ -139,15 +140,16 @@ private module reads; a later `/p/` navigation selects `public-no-hmr`.
 ```text
 GET /p/<share>/...
   -> resolve current public share
-  -> compute ShowEditorCapability
-     -> authorized editor
-        -> canonical private Vite context
-        -> canonical /show/<session>/ module URLs
-        -> existing private HMR socket and revocation
-     -> everyone else
-        -> isolated public transform context
-        -> public URL rewriting and immutable shims
-        -> no websocket and no automatic update
+  -> top-level navigation + Runtime keyed-context capability?
+     -> yes: compute ShowEditorCapability
+        -> authorized editor: redirect to /show/<session>/...
+        -> everyone else: public representation
+     -> no: public representation
+
+GET /show/<session>/...
+  -> existing private Show read ACL
+  -> canonical private Vite context
+  -> editor-only HMR socket and revocation
 ```
 
 ### Runtime context ownership
@@ -156,19 +158,39 @@ Runtime owns at most two contexts for a public Session:
 
 | Context key | Base | Consumers | Lifetime |
 | --- | --- | --- | --- |
-| `(session_id, private)` | `/show/<session>/` | Private `/show/` plus editor-authorized `/p/` | Existing private demand/lifecycle |
-| `(session_id, public)` | Current `/p/<share>/` | Unprivileged public requests only | Demand-created; disposable without affecting private HMR |
+| `(session_id, private)` | `/show/<session>/` | Private `/show/` only | Existing private demand/lifecycle |
+| `(session_id, public)` | Current `/p/<share>/` | Every `/p/` document and subresource | Demand-created; disposable without affecting private HMR |
 
-The private context is canonical. An authorized `/p/` request does not send a
-share-specific `x-vibe-show-base`, rewrite private modules into the share path,
-or create a second private HMR protocol. Its document is served at the public
-URL, but generated module, React Refresh, and HMR URLs point to the authenticated
-`/show/<session>/` routes.
+The private context is canonical. An authorized public-link navigation redirects
+before Runtime returns document bytes, so the resulting request is an ordinary
+`/show/` request. It does not send a share-specific `x-vibe-show-base`, rewrite
+private modules into the share path, or create a second private HMR protocol.
 
 The public transform context preserves today's no-HMR representation but no
 longer owns or replaces the private context. A share rotation may recreate only
 the disposable public context. Public context startup, failure, or traffic
 cannot close the private socket.
+
+Avibe negotiates that ownership once per Runtime process before enabling the
+redirect:
+
+```http
+GET /capabilities
+
+200 OK
+Content-Type: application/json
+
+{"protocol":1,"features":["show-context-key-v1"]}
+```
+
+With `show-context-key-v1`, Avibe supplies the loopback-only
+`X-Avibe-Show-Context: private` or `X-Avibe-Show-Context: public` header and
+Runtime keys Vite ownership by `(session_id, context)`. Avibe strips any
+browser-supplied copy of this header. Runtime health alone, an accepted app
+request, a package version, or support for `x-vibe-show-base` is not capability
+evidence. If the endpoint, protocol, feature, or response is absent or invalid,
+Avibe does not enable the editor redirect and keeps every `/p/` request on the
+existing no-HMR compatibility path.
 
 The public context is a read transform surface, not a publication guarantee. It
 may read the latest workspace state on navigation, so a fresh request during an
@@ -178,18 +200,16 @@ atomicity.
 
 ### HTTP routing
 
-For an authorized public entry or SPA navigation, Avibe requests the canonical
-private Runtime representation while preserving the browser's public
-`pageBasePath`. Normal generated subresources then use `/show/<session>/` and
-pass through the existing private route. If authored code makes a relative
-request that still reaches `/p/`, Avibe recomputes the capability before routing
-that request to the private context.
+For an authorized top-level public entry or SPA navigation, Avibe redirects the
+same route suffix and query to `/show/<session>/`. The private route then serves
+the existing private bootstrap and canonical private Runtime representation.
+There is no public document whose subresources can switch to private mode.
 
-For an unprivileged request, Avibe uses only the public context and existing
-public-safe response transforms. Exact files and API handlers retain first
-refusal; route-shaped document misses retain the current SPA fallback. The
-implementation must preserve the existing path policy as an invariant over the
-whole public request surface:
+Every non-redirected `/p/` request uses only the public context and existing
+public-safe response transforms, regardless of current identity. Exact files and
+API handlers retain first refusal; route-shaped document misses retain the current
+SPA fallback. The implementation must preserve the existing path policy as an
+invariant over the whole public request surface:
 
 - no sensitive segment is readable
 - no symlink or `@fs` path escapes the allowed workspace/dependency roots
@@ -201,27 +221,38 @@ Refresh shims. It exposes neither Runtime diagnostics nor a message channel.
 
 ### WebSocket routing
 
-`/show/<session>/__vite_hmr` remains the only HMR endpoint. It requires the same
+`/show/<session>/__vite_hmr` remains the only HMR endpoint. It requires the
 effective editor capability, allowed origin, current remote authorization
 revision, and Show Page resource access. Existing authorization and resource
 broker tasks close it when those facts stop holding.
 
-`/p/<share>/__vite_hmr` is removed for every viewer. An authorized public
-document does not need it because its Vite client uses the canonical private
-socket; an unprivileged document contains no live client.
+That editor requirement applies to HMR, annotation writes, and the public-link
+redirect, not to ordinary private document and module reads. `/show/` keeps the
+existing resource-reader ACL so a read-only user can load the complete private
+module graph without receiving an HMR channel. A downgrade from editor to viewer
+closes HMR but does not manufacture a blank page by denying modules the viewer is
+still entitled to read.
+
+`/p/<share>/__vite_hmr` is removed for every viewer. A redirected editor uses the
+canonical private socket, while every document that remains at `/p/` contains no
+live client.
 
 ### Cache boundary
 
-Every `/p/` response whose bytes can differ by capability uses
-`Cache-Control: private, no-store` and `Vary: Cookie`. Successful content-hashed
-vendor assets at capability-independent global URLs may retain immutable
-caching. Avibe never forwards browser cookies, authorization headers, CSRF
-headers, or annotation tokens to Runtime.
+The redirect decision varies by capability, so redirect and public entry
+responses use `Cache-Control: private, no-store` and `Vary: Cookie`. Successful
+content-hashed vendor assets at capability-independent global URLs may retain
+immutable caching. Avibe never forwards browser cookies, authorization headers,
+CSRF headers, annotation tokens, or context-selection headers to Runtime.
 
-This prevents an intermediary or browser cache from serving an editor's private
-document to an anonymous viewer. Mode selection must happen before any document
-or redirect bytes are returned; client-side replacement is not a security
-boundary.
+`/p/` never carries private document bytes, which also makes Service Worker
+interception representation-safe. A Show-owned worker under `/p/<share>/` may
+continue serving that public representation and can therefore delay the editor
+redirect until a navigation reaches Avibe, but it cannot cache a private document
+at the shared URL or control the disjoint `/show/<session>/` scope. Avibe strips
+`Service-Worker-Allowed` from public Runtime responses so authored content cannot
+expand a public worker beyond the default `/p/<share>/` scope. Client-side mode
+replacement is never a security boundary.
 
 ## Performance Model
 
@@ -229,16 +260,18 @@ The model adds authorization routing, not a production publication pipeline:
 
 | Case | Cost |
 | --- | --- |
-| Authorized editor opens `/p/` | Existing session/resource decision, canonical Vite transforms, and one private HMR socket; equivalent to `/show/` |
+| Authorized editor opens `/p/` | Existing session/resource decision, one redirect, canonical Vite transforms, and one private HMR socket |
 | Unprivileged viewer opens `/p/` | Existing public transforms and shims from an isolated public context; no socket |
 | Both modes are active | Up to two Vite contexts for the Session; only the private context maintains HMR clients |
 | Agent edit | Private context pushes HMR; public context does no work until the next public request or refresh |
 
-The authorization decision adds no browser round trip. A request without a
-Workbench cookie immediately selects public mode; a request with a cookie uses
-the existing bounded/cached identity resolution already needed by annotations.
+The capability decision adds one redirect round trip for an authorized public-link
+navigation. A request without a Workbench cookie immediately stays public; a
+request with a cookie uses the existing bounded/cached identity resolution already
+needed by annotations.
 
-An authorized `/p/` load should have the same cold and warm profile as `/show/`.
+After its one redirect, an authorized `/p/` load should have the same cold and
+warm profile as `/show/`.
 The isolated public context can increase Runtime memory when authorized and
 anonymous viewers are active simultaneously, but avoids production builds,
 artifact storage, SSE fanout, and anonymous sockets. Runtime must expose context
@@ -249,16 +282,19 @@ budget from measurements rather than an assumed universal threshold.
 
 | Failure | Browser behavior | Operator evidence |
 | --- | --- | --- |
-| Missing/expired/read-only identity | Serve `public-no-hmr` | Redacted authorization reason |
-| Identity service unavailable | Serve `public-no-hmr`; public availability does not depend on identity recovery | Authorization availability metric/log |
-| Private Runtime unavailable for an authorized editor | Existing private sanitized recovery behavior; never fall through to a raw public socket | Private Runtime log |
+| Missing/expired/read-only identity | Serve the public no-HMR representation | Redacted authorization reason |
+| Identity service unavailable | Serve the public representation; public availability does not depend on identity recovery | Authorization availability metric/log |
+| Keyed-context capability absent | Serve every `/p/` request through the existing no-HMR compatibility path; do not redirect | Runtime capability metric/log |
+| Private Runtime unavailable after an editor redirect | Existing private sanitized recovery behavior; never fall through to a raw public socket | Private Runtime log |
 | Public context unavailable | Existing sanitized public unavailable/static fallback | Public Runtime log without source detail |
-| Editor or resource access revoked | Close private HMR and reject later private reads; next `/p/` navigation uses public mode | Existing authorization-revision/resource-revocation log |
+| Editor role revoked but read ACL remains | Close private HMR; retain entitled private document/module reads; next `/p/` navigation stays public | Existing authorization-revision/resource-revocation log |
+| Show Page read access revoked | Close private HMR and reject later private document/module reads; next `/p/` navigation stays public if the share remains valid | Existing resource-revocation log |
 | Share rotates or becomes private/offline | Old public reads fail immediately; private access remains governed independently | Durable Show Page state |
 
 Revocation cannot erase module bytes already downloaded by a previously
-authorized editor. It prevents future reads and terminates the bidirectional
-channel, which is the same unavoidable boundary as the private `/show/` surface.
+authorized editor. Editor-role revocation terminates the bidirectional channel;
+Show Page read revocation also prevents future reads. These are the same
+unavoidable boundaries as the private `/show/` surface.
 
 ## Rejected Alternatives
 
@@ -273,6 +309,13 @@ turn a share link into a development-server capability.
 An anonymous viewer can remove a client-side condition or connect directly.
 Authorization must select the document representation and independently guard
 every private module and socket request on the server.
+
+### Serve the private representation at the public URL
+
+This makes document and subresource capability checks race with one another and
+lets HTTP caches or a public-scope Service Worker retain private bytes at `/p/`.
+Redirecting the editor to `/show/` makes representation identity part of the URL
+and lets the existing private route own the complete document graph.
 
 ### Treat any login cookie as permission
 
@@ -301,49 +344,65 @@ feature, not a prerequisite for capability-gated editor HMR.
 
 ## Delivery Sequence
 
-1. Freeze `ShowEditorCapability` inputs and the discriminated document
-   configuration as contract fixtures.
+1. Freeze `ShowEditorCapability`, top-level navigation detection, and the
+   capability-gated `/p/` to `/show/` redirect as contract fixtures; pin the
+   existing Show bootstrap payload as unchanged.
 2. Factor public annotation authorization into the shared, resource-aware editor
-   capability and use the same result for document mode selection.
-3. Split Runtime ownership into canonical private and disposable public contexts
-   without changing the private base or protocol.
-4. Route authorized `/p/` documents and relative requests to the private context;
-   keep their browser-visible page base public and their module/HMR base private.
-5. Keep unprivileged `/p/` on the public transform/shim path and remove the
-   public HMR websocket.
-6. Add cache, revocation, concurrency, and path-confinement contract tests.
-7. Run local Incus regression with authorized, read-only, anonymous, and revoked
+   capability and use the same result for editor navigation.
+3. Add the explicit Runtime capability handshake and representation-key header;
+   split canonical private and disposable public context ownership without
+   changing the private URL or bootstrap protocol.
+4. Redirect authorized top-level `/p/` navigations to the equivalent `/show/`
+   route. Never route a `/p/` subresource to the private context.
+5. Keep every non-redirected `/p/` request on the public transform/shim path and
+   remove the public HMR websocket.
+6. Preserve resource-viewer authorization for ordinary private modules while
+   requiring editor capability for HMR, annotation writes, and public-link
+   redirect selection.
+7. Add cache, Service Worker scope, revocation, mixed-version, concurrency, and
+   path-confinement contract tests.
+8. Run local Incus regression with authorized, read-only, anonymous, and revoked
    viewers open concurrently.
 
-The capability branch can roll out with the bundled Runtime change. Mixed
-versions fail closed: if Runtime cannot provide independently keyed contexts,
-`/p/` keeps the existing no-HMR behavior for every viewer. It never enables the
-old anonymous public socket as a compatibility fallback.
+The capability branch can roll out with the bundled Runtime change. Avibe enables
+the redirect only after `GET /capabilities` returns protocol `1` and the exact
+`show-context-key-v1` feature. Mixed versions, malformed responses, and transient
+negotiation failures keep `/p/` on the existing no-HMR behavior for every viewer.
+An accepted legacy app request is not treated as negotiation, and the old
+anonymous public socket is never a compatibility fallback.
 
 ## Verification Plan
 
 ### Authorization and document contract tests
 
-- seed every supported identity/resource shape and assert that `canAnnotate`
-  and `private-hmr` are produced by the same editor capability
+- seed every supported identity/resource shape and assert that `canAnnotate` and
+  the public-link redirect are produced by the same editor capability
 - prove anonymous, read-only, expired, resource-forbidden, and unverifiable
-  requests receive only `public-no-hmr`
-- prove query parameters, headers outside the trusted identity boundary, and
-  annotation write tokens cannot upgrade document mode
-- prove both capability-varying entry responses are private/no-store and vary on
-  cookies
-- prove the public configuration contains no Session identifier or private path
+  top-level navigations receive only the public representation
+- prove query parameters, headers outside the trusted identity boundary,
+  annotation write tokens, subresource requests, and missing Fetch Metadata
+  cannot trigger the redirect
+- prove the redirect preserves the route suffix and query while both redirect and
+  public entry responses are private/no-store and vary on cookies
+- prove public and private documents retain every existing Show bootstrap key and
+  that public configuration contains no Session identifier or private path
 
 ### Runtime and proxy tests
 
-- private and public contexts have independent keys and lifecycles
+- Runtime capability negotiation is explicit, cached only for one Runtime
+  process, and rejects absent, malformed, or legacy responses
+- Avibe strips browser context headers; negotiated private and public contexts
+  have independent keys and lifecycles
 - public requests never change, close, or rebuild the private context
-- authorized `/p/` documents reference canonical private modules, React Refresh,
-  and `/show/<session>/__vite_hmr`
+- authorized top-level `/p/` navigations redirect before document bytes to the
+  equivalent canonical `/show/` route
 - unprivileged documents reference only public paths and immutable shims
 - `/p/<share>/__vite_hmr` rejects every connection
-- private module and HMR requests repeat editor/resource/origin checks and close
-  on authorization-revision or resource revocation
+- private document/module requests retain resource-reader ACL; private HMR repeats
+  editor/resource/origin checks and closes on authorization-revision or resource
+  revocation
+- public Runtime responses cannot expand a Service Worker beyond the public share
+  scope, and a public worker cannot control or cache the `/show/` representation
 - every existing public path-confinement fixture remains denied by the new
   routing branch, including sensitive segments and workspace escapes
 - direct CLI share rotation or visibility mutation invalidates the old public
@@ -353,16 +412,20 @@ old anonymous public socket as a compatibility fallback.
 
 | ID | Scenario | Expected evidence |
 | --- | --- | --- |
-| `SHOW-LIVE-001` | Authorized editor opens `/p/<share>/` and the Agent edits a component | React Fast Refresh applies through `/show/` and preserves component state |
+| `SHOW-LIVE-001` | Authorized editor opens `/p/<share>/` and the Agent edits a component | The navigation redirects to `/show/`; React Fast Refresh preserves component state |
 | `SHOW-LIVE-002` | Anonymous viewer opens the same link during the edit | No HMR socket exists and the loaded page stays unchanged until refresh |
 | `SHOW-LIVE-003` | Signed-in read-only or resource-forbidden viewer opens the link | Behavior and bytes match anonymous public mode; no private identifier appears |
-| `SHOW-LIVE-004` | Authorized `/show/`, authorized `/p/`, and anonymous `/p/` are open together | Both authorized views keep HMR while public traffic uses an independent context |
+| `SHOW-LIVE-004` | Direct `/show/`, redirected editor `/show/`, and anonymous `/p/` are open together | Both private documents keep HMR while public traffic uses an independent context |
 | `SHOW-LIVE-005` | Identity resolution fails for a request carrying an unverifiable cookie | The public page remains readable with no HMR or diagnostic leak |
-| `SHOW-LIVE-006` | Editor or resource access is revoked while public-link HMR is open | The socket closes, private reads fail, and the next `/p/` navigation is no-HMR |
+| `SHOW-LIVE-006` | Editor role is revoked while redirected HMR is open but read ACL remains | The socket closes, private modules remain readable, and the next `/p/` navigation stays public |
 | `SHOW-LIVE-007` | Share rotates or direct CLI changes visibility | The old public URL stops serving while authorized private routing remains independent |
 | `SHOW-LIVE-008` | Public requests target every existing denied path shape | All remain denied before Runtime access; no sensitive or escaped file is returned |
 | `SHOW-LIVE-009` | A viewer connects directly to `/p/<share>/__vite_hmr` | The connection is rejected regardless of cookies or visibility |
 | `SHOW-LIVE-010` | Authorized and anonymous viewers remain open through repeated edits | Context count stays bounded, private HMR remains stable, and no public background build occurs |
+| `SHOW-LIVE-011` | A public document starts while identity is unavailable and identity recovers during module loading | Every module stays on `/p/`; no Vite client or mixed transform graph appears |
+| `SHOW-LIVE-012` | A read-only user opens `/show/<session>/` | The complete private module graph loads, while the HMR socket is denied |
+| `SHOW-LIVE-013` | Public content registers a share-scoped Service Worker, then the editor opens the link | No private bytes are served at `/p/`; any network-reached redirect lands outside the worker scope at `/show/` |
+| `SHOW-LIVE-014` | Avibe runs against a Runtime without `show-context-key-v1` | Every `/p/` viewer stays on the compatibility no-HMR path and public traffic cannot be mistaken for negotiated isolation |
 
 Focused unit/contract tests, Ruff, repository CI, and local Incus browser
 regression are required. Green unit tests do not replace simultaneous
@@ -372,16 +435,22 @@ authorized/anonymous browser verification.
 
 The design is implemented when all of the following are true:
 
-- Authorized public-link viewers get the same Vite HMR and React Fast Refresh
-  behavior as private editors.
-- Annotation and public-link HMR consume one validated, resource-aware editor
-  capability.
+- Authorized public-link navigations redirect to the corresponding private URL
+  and get the same Vite HMR and React Fast Refresh behavior as private editors.
+- Annotation writes and the public-link editor redirect consume one validated,
+  resource-aware editor capability.
 - Every other public viewer receives a readable no-HMR representation with no
   private identifier, diagnostics, or bidirectional Runtime channel.
 - `/show/<session>/__vite_hmr` is the only HMR endpoint and independently
   revalidates authorization; `/p/<share>/__vite_hmr` does not exist.
-- Anonymous traffic cannot restart, rebase, or close the private Vite context.
+- A loaded `/p/` document cannot switch representation as identity changes, and
+  anonymous traffic cannot restart, rebase, or close the private Vite context.
 - Capability-varying responses cannot be shared across viewers by a cache.
+- Public Service Workers cannot cache private bytes at `/p/` or control `/show/`.
+- Ordinary private module reads preserve resource-viewer access while HMR remains
+  editor-only.
+- Runtime support is accepted only through the explicit keyed-context capability
+  handshake; mixed versions fail closed to public no-HMR behavior.
 - Authorization failure preserves public availability and fails closed to
   no-HMR mode.
 - Existing public source-confinement and sensitive-path protections hold for the

--- a/docs/plans/public-show-live-update.md
+++ b/docs/plans/public-show-live-update.md
@@ -1,0 +1,412 @@
+# Public Show Live Update
+
+Status: Proposed
+
+Date: 2026-08-16
+
+Scope: `avibe` public Show proxy and `vibe-show-runtime`
+
+## Decision
+
+Public Show Pages remain live. Making a page public must not turn it into a
+snapshot or require a viewer to refresh it manually.
+
+The two surfaces use different update protocols because they have different
+trust boundaries:
+
+| Surface | Viewer trust | Update behavior | Runtime protocol exposed to the browser |
+| --- | --- | --- | --- |
+| Private `/show/<session>/` | Authenticated and authorized | Vite HMR and React Fast Refresh | Full Vite HMR |
+| Public `/p/<share>/` | Anonymous read access | Automatic full-page Live Reload after a renderable revision | Avibe revision SSE only |
+| Offline | No live page | None | None |
+
+The public browser must never receive the raw Vite HMR protocol. It receives a
+small, one-way, path-free revision notification and reloads the document. This
+keeps the public page current without making Vite's development control channel
+part of Avibe's anonymous product API.
+
+This is deliberately called **Live Reload**, not HMR. Public viewers get the
+updated page automatically, but a reload does not preserve arbitrary component
+or application state. Private authors keep Fast Refresh and its state-preserving
+developer experience.
+
+## Why This Is Needed
+
+The current implementation contains two conflicting contracts:
+
+- `docs/plans/show-service-runtime.md` says private and public Show Pages both
+  receive live HMR.
+- The public proxy rewrites `@vite/client` and `@react-refresh` to inert,
+  immutable shims, so a public browser never opens the existing
+  `/p/<share>/__vite_hmr` socket.
+
+The shims were introduced by `8dc1319eb` (`fix(show): stabilize public runtime
+modules`). They solved a real stabilization problem and explicitly prevented an
+anonymous Vite socket, but they also disabled public live updates. That behavior
+became an accidental product policy while the design documents continued to
+promise a live public page.
+
+There is also a deeper runtime ownership problem. The sidecar currently keys an
+active Vite context by both `session_id` and the external base path. Alternating
+requests from `/show/<session>/` and `/p/<share>/` can therefore close and rebuild
+the same Session's Vite server as its base path changes. A private author and a
+public viewer should be able to use the page concurrently without restarting
+each other's runtime.
+
+## Product Contract
+
+Visibility and update transport are separate capabilities:
+
+- `public` controls who may read the rendered page.
+- authorization controls who may annotate, dispatch, or use private tools.
+- the surface trust boundary controls which update protocol is exposed.
+
+For a concrete example, an Agent edits `src/App.tsx` while an anonymous viewer
+has `/p/brief/` open:
+
+1. Vite invalidates the affected module graph.
+2. Show Runtime waits for the write burst to settle and validates the affected
+   graph.
+3. If validation succeeds and no newer write superseded it, Runtime commits the
+   next in-memory revision.
+4. Avibe relays only `{epoch, revision}` to the public browser.
+5. The browser reloads `/p/brief/` and renders the new source.
+
+If validation fails, the existing public document stays visible. The private
+author still receives normal Vite diagnostics. The public viewer receives no
+stack, source path, plugin name, source frame, or error text.
+
+### User-visible requirements
+
+1. An idle, visible public page reloads within 2 seconds in local regression
+   after the last edit of a renderable write burst.
+2. A failed transform does not replace an already-rendered public page with an
+   error overlay or a blank page.
+3. Once the source becomes renderable again, the next revision reloads the
+   public page without manual action.
+4. A hidden tab records a pending revision and reloads when it becomes visible.
+5. A revision received while a text input, textarea, select, or editable element
+   is active waits for blur, with a 30-second upper bound. This limits avoidable
+   loss of in-progress public interaction without allowing a stale page to wait
+   forever.
+6. Public Live Reload is best effort when the runtime or connection is
+   unavailable. The rendered page remains usable and the client reconnects with
+   bounded backoff.
+
+## Architecture
+
+```text
+Agent file write
+  -> one canonical Vite context for the Session
+  -> affected-graph validation + revision producer
+  -> internal revision SSE (loopback sidecar API)
+  -> Avibe public share/visibility gate and SSE relay
+  -> small public live client
+  -> location.reload()
+
+Private browser
+  -> authenticated /show/<session>/__vite_hmr
+  -> raw Vite HMR for the same canonical Vite context
+```
+
+### One canonical runtime base
+
+Each Session has one Vite context with a canonical base:
+
+```text
+/show/<session-id>/
+```
+
+The Vite context is keyed by `session_id`, not by an external share URL. Public
+HTTP responses continue to rewrite canonical `/show/<session>/...` URLs to
+`/p/<share>/...` at the Avibe boundary. Public requests no longer send the share
+base as `x-vibe-show-base`, and rotating a share link does not restart Vite.
+
+This invariant is required before Live Reload is enabled. Otherwise concurrent
+private and public traffic can repeatedly change the Vite epoch and make both
+update paths unreliable.
+
+### Ownership
+
+`vibe-show-runtime` owns:
+
+- Vite invalidation and transform state
+- the renderable-revision decision
+- the per-Session `{epoch, revision}` counter
+- the loopback-only revision stream
+
+`avibe` owns:
+
+- public share resolution and visibility checks
+- public origin and host policy
+- revocation when a share rotates or leaves `public`
+- the redacted public SSE contract
+- the small public browser client
+
+The existing Show event stream remains separate. Show events are durable product
+events with replay and authorization semantics. Runtime revisions are ephemeral
+render state. Combining them would make one stream own two unrelated retention
+and failure models.
+
+## Renderable Revision Model
+
+A revision is not emitted for every filesystem event. Runtime maintains a
+generation token and follows this sequence:
+
+1. A Vite-relevant invalidation increments the candidate generation and records
+   the affected module URLs.
+2. Runtime waits for a 250 ms quiet window and coalesces the burst.
+3. Runtime transforms the affected first-party module graph. A Vite full-reload
+   invalidation also validates the entry graph.
+4. If any required transform fails, Runtime records a private diagnostic and
+   emits no revision.
+5. If another invalidation arrived during validation, Runtime discards the stale
+   result and validates the newer generation.
+6. Only a successful, still-current validation increments `revision` and emits
+   one notification.
+
+The validator must fail closed for a required first-party module. Dependencies
+already resolved from the immutable shared vendor bundle do not need to be
+revalidated on every edit.
+
+This contract improves the experience for an already-open public page, but it is
+not an atomic publishing system. Source files remain mutable on disk, and there
+is no durable last-known-good artifact. A fresh viewer can still arrive while the
+workspace is temporarily broken. Guaranteeing atomic public releases would
+require a separate build-and-snapshot publishing model and is outside this
+change.
+
+## Revision Stream Contract
+
+The sidecar adds a loopback-only endpoint:
+
+```text
+GET /sessions/<session-id>/revisions?stream=1
+```
+
+The public Avibe surface exposes:
+
+```text
+GET /p/<share-id>/__show/revisions
+```
+
+The public endpoint is a terminating relay, not a byte-for-byte proxy. It parses
+the internal contract and serializes the public allowlist.
+
+Initial state:
+
+```text
+event: ready
+data: {"protocol":1,"epoch":"rte_7f42","revision":12}
+
+```
+
+Committed update:
+
+```text
+id: rte_7f42:13
+event: revision
+data: {"protocol":1,"epoch":"rte_7f42","revision":13}
+
+```
+
+Contract rules:
+
+- `protocol` is the schema version and is currently `1`.
+- `epoch` is an opaque random identifier for one active Vite context.
+- `revision` is a monotonically increasing integer inside the epoch.
+- The payload contains no Session ID, share ID, module URL, filesystem path,
+  source code, error, or plugin data.
+- Keepalives are SSE comment frames and carry no data.
+- A new subscriber receives exactly one `ready` event with the current state;
+  revision history is not persisted.
+
+The Runtime health/status payload advertises revision-stream capability so Avibe
+can stage the runtime release before activating the public client. An older
+runtime yields a closed/no-content public stream; it never falls back to raw
+public HMR.
+
+## Public Client State Machine
+
+The existing public `@vite/client` replacement becomes a small versioned live
+client while retaining no-op HMR exports required by transformed modules.
+`@react-refresh` remains inert on the public surface.
+
+The live client runs once per document:
+
+1. Read `globalThis.__AVIBE_SHOW__.basePath` and open
+   `<basePath>__show/revisions` with `EventSource`.
+2. Keep the current `{epoch, revision}` as an in-memory baseline for this
+   document.
+3. Treat the first `ready` as the baseline without an unnecessary reload.
+4. On a greater revision, or an epoch change after that baseline, update the
+   in-memory baseline before reloading. The new document also treats its first
+   `ready` as a baseline, so no persisted reload marker or reload loop exists.
+5. If the document is hidden or an editable control is active, mark the reload
+   pending and apply it on visibility/focus release, subject to the 30-second
+   bound.
+6. On stream failure, close the failed `EventSource` and reconnect with capped
+   exponential backoff. Stop after six consecutive failures; resume on `online`
+   or a later visibility transition.
+
+The client shows no public error overlay. Connection and validation diagnostics
+belong in private Runtime/Avibe logs.
+
+## Security Boundary
+
+Opening private HMR unchanged on a public page is not acceptable because the
+current route is a bidirectional proxy into Vite. Depending on installed Vite
+plugins, client `custom` messages can reach server listeners, and development
+error payloads can contain stack traces, source frames, plugin code, and local
+paths. The Vite wire protocol is also an implementation detail that can change
+with a Runtime release.
+
+The public revision endpoint therefore enforces all of the following:
+
+- the share exists, currently maps to the requested Session, and is `public`
+- the request uses an allowed public host and an exact same-origin browser
+  origin when an `Origin` header is present
+- no browser cookies, authorization headers, CSRF headers, or query credentials
+  are forwarded to the sidecar
+- the connection closes when the share rotates or visibility changes
+- only `ready` and `revision` payloads matching protocol v1 are relayed
+- subscriber queues retain at most the latest pending revision
+- responses use `Cache-Control: no-store`, `Content-Type: text/event-stream`,
+  `X-Accel-Buffering: no`, and `Referrer-Policy: no-referrer`
+
+The anonymous `/p/<share>/__vite_hmr` route is removed. Private
+`/show/<session>/__vite_hmr` keeps its existing authentication, origin,
+authorization-revision, and resource-revocation checks.
+
+## Performance Model
+
+The current public shim payload is about 1.3 KB decoded. Loading the real Vite
+client and React Refresh on the sampled regression page added about 60.9 KB
+compressed and about 291.8 KB decoded, both from no-cache development modules.
+Those figures are a measured reference, not a permanent protocol guarantee.
+
+The selected model has these budgets:
+
+- public live client: at most 3 KB gzip
+- no real Vite client or React Refresh runtime on `/p/`
+- SSE connection starts after the module script executes and does not block the
+  initial render
+- one validation per Session write burst, independent of public viewer count
+- no per-viewer Vite WebSocket or per-viewer module-graph validation
+- immutable shared vendor assets remain cached across a full reload
+
+Initial public page load should therefore not become materially slower. It adds
+one small client and one asynchronous SSE handshake. An update is heavier than
+private HMR because it reloads the document and first-party modules, but shared
+vendor modules remain cached. That is the intentional cost of keeping the public
+protocol small, stable, and read-only.
+
+## Failure Behavior
+
+| Failure | Public behavior | Private/operator evidence |
+| --- | --- | --- |
+| Transform or syntax error | Keep current rendered document; emit no revision | Normal Vite/Runtime diagnostic |
+| Runtime unavailable | Keep page; bounded reconnect | Runtime health/logs |
+| SSE interrupted | Compare `ready` against stored revision after reconnect | Connection metric/log |
+| Share rotated/private/offline | Close stream; old public URL cannot reconnect | Visibility/resource event |
+| New invalidation during validation | Discard stale result; validate latest generation | Debug metric only |
+| Runtime context restarted | New epoch; existing client reloads once | Runtime lifecycle log |
+
+## Rejected Alternatives
+
+### Expose private Vite HMR on `/p/`
+
+This gives the fastest update and preserves React state, but exposes a
+bidirectional development protocol, diagnostics, version coupling, and a Vite
+socket per anonymous viewer. Filtering enough of Vite to make that protocol safe
+would create a second partial HMR implementation that remains coupled to Vite.
+
+### Poll the public document
+
+Polling is simple but creates traffic while nothing changes, adds update latency,
+and still needs a revision/ETag source. A push stream has a smaller idle cost and
+a clearer state model.
+
+### Put revisions on the durable Show event stream
+
+This reuses a connection but conflates ephemeral compilation state with durable
+human/assistant events and their replay, storage, redaction, and dispatch rules.
+The apparent transport reuse creates a larger conceptual system.
+
+### Build and publish immutable snapshots after every write
+
+Snapshots could provide atomic publication and a durable last-known-good page,
+but they introduce build artifacts, retention, activation, rollback, and storage
+policy. That is a separate publishing capability, not the smallest complete fix
+for live public viewing.
+
+## Delivery Sequence
+
+1. Freeze protocol v1 as shared example fixtures consumed by Runtime and Avibe
+   contract tests.
+2. In `vibe-show-runtime`, add the generation validator, revision state, internal
+   SSE stream, capability advertisement, and focused tests.
+3. Release the Runtime artifact and update Avibe's managed Runtime manifest.
+4. In `avibe`, enforce the canonical Session base, add the terminating public SSE
+   relay, activate the versioned public live client, and remove the public raw HMR
+   route.
+5. Update `show-service-runtime.md` and the multipage scaffold plan so `HMR`
+   means the private protocol and `Live Reload` means the public behavior.
+6. Run local Incus regression with simultaneous private and public viewers before
+   enabling the feature by default.
+
+The rollout must not activate the public client before the managed Runtime
+advertises protocol v1. During a mixed-version development checkout, public pages
+remain readable but do not fall back to raw HMR.
+
+## Verification Plan
+
+### Runtime unit tests
+
+- coalesce a file burst into one committed revision
+- do not emit when an affected transform fails
+- discard a successful validation superseded by a newer generation
+- validate the entry graph for a full-reload invalidation
+- issue a new epoch after a Vite context restart
+- replay only the current `ready` state to a new subscriber
+
+### Avibe unit and contract tests
+
+- public live client uses revision SSE and retains no-op HMR exports
+- anonymous public revision stream succeeds only for the current public share
+- private/offline/rotated shares cannot open or retain the stream
+- public relay drops unknown event types and all extra fields
+- browser credentials are never forwarded to the sidecar
+- public raw `__vite_hmr` is unavailable while private HMR still works
+- private and public HTTP requests reuse one canonical Runtime context
+
+### Browser and regression scenarios
+
+| ID | Scenario | Expected evidence |
+| --- | --- | --- |
+| `SHOW-LIVE-001` | Agent edits a renderable public page | Open public page reloads within 2 seconds and shows the change |
+| `SHOW-LIVE-002` | Private author and public viewer are open together | Private Fast Refresh works; public Live Reload works; Runtime epoch stays stable |
+| `SHOW-LIVE-003` | Agent writes a syntax error, then fixes it | Public page keeps old render, exposes no diagnostic, then reloads after the fix |
+| `SHOW-LIVE-004` | Public share rotates or becomes private/offline | Existing stream closes and the old share cannot reconnect |
+| `SHOW-LIVE-005` | Many viewers watch one page | One revision validation and no per-viewer Vite sockets |
+| `SHOW-LIVE-006` | Public page cold load | No real Vite/React Refresh client; live client stays within the 3 KB gzip budget |
+| `SHOW-LIVE-007` | Viewer is typing or the tab is hidden | Revision waits according to the focus/visibility contract, then reloads once |
+
+The implementation adds these scenarios to the Show scenario catalog before its
+PR is considered complete. Focused unit/contract tests, Ruff, the repository CI
+suite, and local Incus browser regression are all required; green unit tests do
+not replace the simultaneous private/public browser check.
+
+## Acceptance Gate
+
+The feature is complete when all of the following are true:
+
+- Public Show is live by default and requires no manual viewer refresh.
+- Public browsers cannot reach a raw Vite HMR channel or receive Vite diagnostics.
+- Private HMR behavior and authorization remain unchanged.
+- Concurrent private/public use does not rebuild the Session Runtime because of
+  external base-path changes.
+- Failed edits preserve the already-rendered public document and recover on the
+  next valid revision.
+- Initial-load and update measurements satisfy the budgets above in local Incus
+  regression.

--- a/docs/plans/public-show-live-update.md
+++ b/docs/plans/public-show-live-update.md
@@ -15,7 +15,7 @@ server-side capability:
 | --- | --- | --- |
 | Private `/show/<session>/`, authorized editor | Canonical private Vite context | Vite HMR and React Fast Refresh |
 | Public `/p/<share>/`, authorized editor navigation | Redirect to canonical `/show/<session>/` | Vite HMR and React Fast Refresh after the redirect |
-| Public `/p/<share>/`, anonymous, read-only, expired, resource-forbidden, or unverifiable | Isolated public transform context | No Hot Reload; refresh reads current content |
+| Public `/p/<share>/`, anonymous, read-only, expired, resource-forbidden, or unverifiable | Negotiated isolated public context; legacy compatibility context otherwise | No Hot Reload; refresh reads current content |
 | Offline | None | None |
 
 Public visibility is an anonymous read grant, not development authorization.
@@ -24,7 +24,8 @@ being able to read a public link does not grant access to Vite's bidirectional
 development protocol.
 
 For a concrete example, Alice is an authorized editor and Bob is an anonymous
-viewer. They open the same `/p/brief/` URL while an Agent edits the page:
+viewer on the current bundled Runtime. They open the same `/p/brief/` URL while
+an Agent edits the page:
 
 1. Avibe resolves Alice's existing Workbench session and the same editor
    capability used to enable annotations.
@@ -130,10 +131,16 @@ the caller's current Show Page read ACL.
    reads the current public workspace content.
 5. A failed or unavailable identity lookup selects the public representation
    rather than delaying or failing the public page.
-6. Private HMR traffic cannot be restarted or rebased by an unauthorized public
-   request.
+6. With a negotiated keyed-context Runtime, private HMR traffic cannot be
+   restarted or rebased by an unauthorized public request.
 7. Existing public path confinement, sensitive-path denial, and symlink escape
    protections remain in force for every public request.
+
+An older Runtime does not gain isolation it cannot represent. Avibe does not
+enable the editor redirect for it, and its anonymous `/p/` traffic retains the
+existing single-context base-switching limitation until the bundled Runtime is
+upgraded. Compatibility mode is therefore availability-preserving, not evidence
+that requirement 6 has been met.
 
 ## Architecture
 
@@ -154,7 +161,7 @@ GET /show/<session>/...
 
 ### Runtime context ownership
 
-Runtime owns at most two contexts for a public Session:
+A negotiated Runtime owns at most two contexts for a public Session:
 
 | Context key | Base | Consumers | Lifetime |
 | --- | --- | --- | --- |
@@ -188,9 +195,30 @@ With `show-context-key-v1`, Avibe supplies the loopback-only
 Runtime keys Vite ownership by `(session_id, context)`. Avibe strips any
 browser-supplied copy of this header. Runtime health alone, an accepted app
 request, a package version, or support for `x-vibe-show-base` is not capability
-evidence. If the endpoint, protocol, feature, or response is absent or invalid,
-Avibe does not enable the editor redirect and keeps every `/p/` request on the
-existing no-HMR compatibility path.
+evidence.
+
+Capability negotiation has three process-scoped outcomes:
+
+| Outcome | Evidence | Cache and request behavior |
+| --- | --- | --- |
+| `supported` | Well-formed protocol `1` response containing `show-context-key-v1` | Cache for this Runtime process; keyed routing and the editor redirect may run |
+| `unsupported` | A definitive legacy response such as `404`, or a well-formed response without the protocol/feature | Cache for this Runtime process; no redirect and `/p/` retains compatibility behavior |
+| `transient-unknown` | Connect/timeout failure, `408`, `429`, `5xx`, truncated JSON, or another malformed startup response | Current request stays public; retry on later requests with jittered exponential backoff capped at 5 seconds |
+
+Only `supported` and definitive `unsupported` are permanent for one Runtime
+process. A transient failure records a next-probe time rather than a negative
+capability. Stopping or replacing Runtime, or changing its base URL/process
+identity, clears every cached outcome and retry deadline.
+
+Context selection is a total Runtime request contract, not a proxy-only header.
+After Runtime advertises support, every operation that can create, read, prewarm,
+or connect to an app graph supplies an explicit context: entry and module HTTP
+requests, the SPA fallback retry, API handler requests, private HMR proxy setup,
+startup reconciliation, and `vibe show update` prewarm. Runtime rejects a missing
+or invalid context before resolving a Session or changing Vite ownership. Public
+prewarm uses `public`; canonical `/show/` prewarm and HMR use `private`. The
+implementation keeps one typed context parameter through `ShowRuntimeManager`
+rather than allowing individual callers to assemble headers.
 
 The public context is a read transform surface, not a publication guarantee. It
 may read the latest workspace state on navigation, so a fresh request during an
@@ -205,11 +233,12 @@ same route suffix and query to `/show/<session>/`. The private route then serves
 the existing private bootstrap and canonical private Runtime representation.
 There is no public document whose subresources can switch to private mode.
 
-Every non-redirected `/p/` request uses only the public context and existing
-public-safe response transforms, regardless of current identity. Exact files and
-API handlers retain first refusal; route-shaped document misses retain the current
-SPA fallback. The implementation must preserve the existing path policy as an
-invariant over the whole public request surface:
+On a negotiated Runtime, every non-redirected `/p/` request uses only the public
+context and existing public-safe response transforms, regardless of current
+identity. A legacy Runtime uses the explicitly limited compatibility path instead.
+Exact files and API handlers retain first refusal; route-shaped document misses
+retain the current SPA fallback. The implementation must preserve the existing
+path policy as an invariant over the whole public request surface:
 
 - no sensitive segment is readable
 - no symlink or `@fs` path escapes the allowed workspace/dependency roots
@@ -219,12 +248,41 @@ invariant over the whole public request surface:
 The public context continues to use inert, versioned `@vite/client` and React
 Refresh shims. It exposes neither Runtime diagnostics nor a message channel.
 
+Vite's native `/@fs/<absolute-path>` form cannot cross that public boundary.
+When a public transform references an allowed absolute file, Runtime first checks
+the canonical path against the existing allowed-root, sensitive-segment, and
+symlink policy, then allocates a stable opaque handle from a Runtime-process secret,
+the Session, the current share generation, and the canonical path. The browser
+receives only `/p/<share>/__avibe_asset/<handle>`; Runtime's process-local registry
+resolves that handle only inside the matching public namespace. A browser cannot
+submit a raw `/@fs/` path or mint a mapping, handles reveal no path bytes, and share
+rotation or Runtime replacement invalidates them. Idle Vite-context disposal does
+not evict admitted handles, so an already-loaded page can still fetch a lazy module;
+new-handle admission fails closed instead of evicting a handle in use. The same
+chokepoint covers every emitted URL, including an absolute path nested inside
+another Vite URL.
+
+Runtime also labels every loopback response as `application`, `asset`, or
+`development-diagnostic` in a stripped response metadata header. Avibe forwards
+authored application/API bodies and successful assets, but replaces every
+`development-diagnostic` body with a fixed public error representation while
+preserving only the safe status class. Source frames, plugin errors, stack traces,
+and local paths remain in a redacted operator log. HTTP error status alone is not
+trusted to distinguish an authored API error from a Vite transform failure.
+
 ### WebSocket routing
 
 `/show/<session>/__vite_hmr` remains the only HMR endpoint. It requires the
 effective editor capability, allowed origin, current remote authorization
 revision, and Show Page resource access. Existing authorization and resource
-broker tasks close it when those facts stop holding.
+broker tasks close it when those facts stop holding. In-memory broker events are
+an optimization, not the durable visibility boundary: while any HMR socket is
+open, one coalesced monitor per Session rereads `ShowPageStore` on a cadence no
+greater than five seconds and closes every socket if the page becomes `offline`.
+A direct CLI mutation therefore takes effect without an IPC event. Making a public
+page private or rotating its share does not close the canonical private socket when
+editor and read access remain valid; the share binding is needed only for the
+redirect that selected `/show/`.
 
 That editor requirement applies to HMR, annotation writes, and the public-link
 redirect, not to ordinary private document and module reads. `/show/` keeps the
@@ -261,9 +319,10 @@ The model adds authorization routing, not a production publication pipeline:
 | Case | Cost |
 | --- | --- |
 | Authorized editor opens `/p/` | Existing session/resource decision, one redirect, canonical Vite transforms, and one private HMR socket |
-| Unprivileged viewer opens `/p/` | Existing public transforms and shims from an isolated public context; no socket |
+| Unprivileged viewer opens `/p/` | Existing public transforms and shims from an isolated context when negotiated, or the explicit legacy compatibility path; no socket |
 | Both modes are active | Up to two Vite contexts for the Session; only the private context maintains HMR clients |
 | Agent edit | Private context pushes HMR; public context does no work until the next public request or refresh |
+| Active private HMR sockets | One coalesced durable visibility read per Session on a cadence no greater than five seconds |
 
 The capability decision adds one redirect round trip for an authorized public-link
 navigation. A request without a Workbench cookie immediately stays public; a
@@ -272,11 +331,14 @@ needed by annotations.
 
 After its one redirect, an authorized `/p/` load should have the same cold and
 warm profile as `/show/`.
-The isolated public context can increase Runtime memory when authorized and
+The negotiated isolated public context can increase Runtime memory when authorized and
 anonymous viewers are active simultaneously, but avoids production builds,
 artifact storage, SSE fanout, and anonymous sockets. Runtime must expose context
 count and memory so local Incus regression can set a per-Session idle eviction
-budget from measurements rather than an assumed universal threshold.
+budget from measurements rather than an assumed universal threshold. Opaque public
+path mappings are process-local, share-generation-bound, and admission-bounded;
+capability probes are process-cached or backoff-limited rather than added to every
+request.
 
 ## Failure And Revocation Behavior
 
@@ -284,12 +346,15 @@ budget from measurements rather than an assumed universal threshold.
 | --- | --- | --- |
 | Missing/expired/read-only identity | Serve the public no-HMR representation | Redacted authorization reason |
 | Identity service unavailable | Serve the public representation; public availability does not depend on identity recovery | Authorization availability metric/log |
-| Keyed-context capability absent | Serve every `/p/` request through the existing no-HMR compatibility path; do not redirect | Runtime capability metric/log |
+| Definitive keyed-context capability absence | Do not redirect; serve `/p/` through the legacy no-HMR path with its existing single-context limitation recorded | Runtime capability metric/log |
+| Transient capability negotiation failure | Keep the current request public and retry after bounded backoff; do not cache a permanent negative | Redacted probe state and retry metric |
 | Private Runtime unavailable after an editor redirect | Existing private sanitized recovery behavior; never fall through to a raw public socket | Private Runtime log |
 | Public context unavailable | Existing sanitized public unavailable/static fallback | Public Runtime log without source detail |
+| Runtime emits a development diagnostic | Preserve only a safe status class and fixed public body | Redacted operator-only diagnostic |
 | Editor role revoked but read ACL remains | Close private HMR; retain entitled private document/module reads; next `/p/` navigation stays public | Existing authorization-revision/resource-revocation log |
 | Show Page read access revoked | Close private HMR and reject later private document/module reads; next `/p/` navigation stays public if the share remains valid | Existing resource-revocation log |
-| Share rotates or becomes private/offline | Old public reads fail immediately; private access remains governed independently | Durable Show Page state |
+| Share rotates or becomes private | Old public reads fail immediately; an entitled canonical private socket remains independent | Durable Show Page state |
+| Show Page becomes offline through any process | The coalesced durable-state monitor closes private HMR within five seconds and later reads return offline | Durable Show Page state |
 
 Revocation cannot erase module bytes already downloaded by a previously
 authorized editor. Editor-role revocation terminates the bidirectional channel;
@@ -349,9 +414,10 @@ feature, not a prerequisite for capability-gated editor HMR.
    existing Show bootstrap payload as unchanged.
 2. Factor public annotation authorization into the shared, resource-aware editor
    capability and use the same result for editor navigation.
-3. Add the explicit Runtime capability handshake and representation-key header;
-   split canonical private and disposable public context ownership without
-   changing the private URL or bootstrap protocol.
+3. Add the explicit Runtime capability state machine and one typed context
+   parameter; split canonical private and disposable public context ownership
+   without changing the private URL or bootstrap protocol. Migrate every HTTP,
+   WebSocket, fallback, and prewarm caller in the same contract change.
 4. Redirect authorized top-level `/p/` navigations to the equivalent `/show/`
    route. Never route a `/p/` subresource to the private context.
 5. Keep every non-redirected `/p/` request on the public transform/shim path and
@@ -359,17 +425,22 @@ feature, not a prerequisite for capability-gated editor HMR.
 6. Preserve resource-viewer authorization for ordinary private modules while
    requiring editor capability for HMR, annotation writes, and public-link
    redirect selection.
-7. Add cache, Service Worker scope, revocation, mixed-version, concurrency, and
-   path-confinement contract tests.
-8. Run local Incus regression with authorized, read-only, anonymous, and revoked
-   viewers open concurrently.
+7. Add opaque public file handles plus Runtime response provenance so raw
+   `/@fs/` paths and development diagnostics cannot cross the public boundary.
+8. Add the coalesced durable visibility monitor for private HMR sockets.
+9. Add cache, Service Worker scope, revocation, mixed-version, negotiation retry,
+   total context propagation, concurrency, and path-confinement contract tests.
+10. Run local Incus regression with authorized, read-only, anonymous, and revoked
+    viewers open concurrently.
 
-The capability branch can roll out with the bundled Runtime change. Avibe enables
+The capability branch rolls out with the bundled Runtime change. Avibe enables
 the redirect only after `GET /capabilities` returns protocol `1` and the exact
-`show-context-key-v1` feature. Mixed versions, malformed responses, and transient
-negotiation failures keep `/p/` on the existing no-HMR behavior for every viewer.
-An accepted legacy app request is not treated as negotiation, and the old
-anonymous public socket is never a compatibility fallback.
+`show-context-key-v1` feature. A definitive legacy Runtime keeps `/p/` on the
+existing no-HMR behavior and its existing single-context limitation; it is never
+described as isolated. A transient or malformed startup response fails the current
+request closed to public mode but remains retryable. An accepted legacy app request
+is not negotiation, and the old anonymous public socket is never a compatibility
+fallback.
 
 ## Verification Plan
 
@@ -389,18 +460,26 @@ anonymous public socket is never a compatibility fallback.
 
 ### Runtime and proxy tests
 
-- Runtime capability negotiation is explicit, cached only for one Runtime
-  process, and rejects absent, malformed, or legacy responses
+- Runtime capability negotiation distinguishes supported, definitive legacy, and
+  transient-unknown outcomes; transient failures retry and every outcome resets
+  with the Runtime process
 - Avibe strips browser context headers; negotiated private and public contexts
   have independent keys and lifecycles
+- every app-graph call, including SPA fallback, WebSocket setup, startup
+  reconciliation, and public/private prewarm, carries the selected typed context;
+  Runtime rejects missing or invalid selection before touching Vite ownership
 - public requests never change, close, or rebuild the private context
 - authorized top-level `/p/` navigations redirect before document bytes to the
   equivalent canonical `/show/` route
-- unprivileged documents reference only public paths and immutable shims
+- unprivileged documents reference only public paths, opaque allowed-file handles,
+  and immutable shims; raw `/@fs/`, host paths, and Session paths are denied
+- Runtime response provenance preserves authored application errors while every
+  development diagnostic receives a fixed public body
 - `/p/<share>/__vite_hmr` rejects every connection
 - private document/module requests retain resource-reader ACL; private HMR repeats
-  editor/resource/origin checks and closes on authorization-revision or resource
-  revocation
+  editor/resource/origin checks, closes on authorization-revision or resource
+  revocation, and polls durable visibility once per active Session so direct CLI
+  offline changes close sockets within five seconds
 - public Runtime responses cannot expand a Service Worker beyond the public share
   scope, and a public worker cannot control or cache the `/show/` representation
 - every existing public path-confinement fixture remains denied by the new
@@ -418,14 +497,18 @@ anonymous public socket is never a compatibility fallback.
 | `SHOW-LIVE-004` | Direct `/show/`, redirected editor `/show/`, and anonymous `/p/` are open together | Both private documents keep HMR while public traffic uses an independent context |
 | `SHOW-LIVE-005` | Identity resolution fails for a request carrying an unverifiable cookie | The public page remains readable with no HMR or diagnostic leak |
 | `SHOW-LIVE-006` | Editor role is revoked while redirected HMR is open but read ACL remains | The socket closes, private modules remain readable, and the next `/p/` navigation stays public |
-| `SHOW-LIVE-007` | Share rotates or direct CLI changes visibility | The old public URL stops serving while authorized private routing remains independent |
+| `SHOW-LIVE-007` | Share rotates or direct CLI changes visibility | The old public URL stops serving; share rotation leaves entitled private HMR independent, while offline closes it within five seconds |
 | `SHOW-LIVE-008` | Public requests target every existing denied path shape | All remain denied before Runtime access; no sensitive or escaped file is returned |
 | `SHOW-LIVE-009` | A viewer connects directly to `/p/<share>/__vite_hmr` | The connection is rejected regardless of cookies or visibility |
 | `SHOW-LIVE-010` | Authorized and anonymous viewers remain open through repeated edits | Context count stays bounded, private HMR remains stable, and no public background build occurs |
 | `SHOW-LIVE-011` | A public document starts while identity is unavailable and identity recovers during module loading | Every module stays on `/p/`; no Vite client or mixed transform graph appears |
 | `SHOW-LIVE-012` | A read-only user opens `/show/<session>/` | The complete private module graph loads, while the HMR socket is denied |
 | `SHOW-LIVE-013` | Public content registers a share-scoped Service Worker, then the editor opens the link | No private bytes are served at `/p/`; any network-reached redirect lands outside the worker scope at `/show/` |
-| `SHOW-LIVE-014` | Avibe runs against a Runtime without `show-context-key-v1` | Every `/p/` viewer stays on the compatibility no-HMR path and public traffic cannot be mistaken for negotiated isolation |
+| `SHOW-LIVE-014` | Avibe runs against a Runtime without `show-context-key-v1` | Every `/p/` viewer stays on the compatibility no-HMR path; the existing single-context limitation is explicit and cannot be mistaken for negotiated isolation |
+| `SHOW-LIVE-015` | The first capability probe times out or returns truncated JSON while new Runtime starts | The request stays public, a later bounded retry detects support, and the next eligible navigation redirects without restarting Runtime |
+| `SHOW-LIVE-016` | Public transforms emit nested `/@fs/` imports and Vite transform errors | Only current context-bound opaque handles reach the browser and every development error body is fixed and path-free |
+| `SHOW-LIVE-017` | Startup reconciliation and `vibe show update` prewarm public and private graphs | Each request carries its typed context; a missing/invalid context fails before creating or rebasing either graph |
+| `SHOW-LIVE-018` | Direct CLI changes an active page to offline with private HMR connected | The coalesced durable monitor closes every socket for the Session within five seconds without relying on an in-process event |
 
 Focused unit/contract tests, Ruff, repository CI, and local Incus browser
 regression are required. Green unit tests do not replace simultaneous
@@ -444,13 +527,22 @@ The design is implemented when all of the following are true:
 - `/show/<session>/__vite_hmr` is the only HMR endpoint and independently
   revalidates authorization; `/p/<share>/__vite_hmr` does not exist.
 - A loaded `/p/` document cannot switch representation as identity changes, and
-  anonymous traffic cannot restart, rebase, or close the private Vite context.
+  on a negotiated Runtime anonymous traffic cannot restart, rebase, or close the
+  private Vite context.
 - Capability-varying responses cannot be shared across viewers by a cache.
 - Public Service Workers cannot cache private bytes at `/p/` or control `/show/`.
 - Ordinary private module reads preserve resource-viewer access while HMR remains
   editor-only.
 - Runtime support is accepted only through the explicit keyed-context capability
-  handshake; mixed versions fail closed to public no-HMR behavior.
+  handshake; definitive mixed versions retain the existing compatibility
+  limitation, while transient negotiation failures retry without denying public
+  reads or permanently disabling the feature.
+- Context selection is mandatory at every Runtime app-graph call site, including
+  prewarm and fallback paths, and missing selection fails before Vite ownership.
+- Public file references use context-bound opaque handles after path validation;
+  raw absolute paths and Runtime development diagnostics never reach the browser.
+- Direct durable offline mutations close active private HMR within five seconds;
+  share rotation alone does not revoke entitled canonical private access.
 - Authorization failure preserves public availability and fails closed to
   no-HMR mode.
 - Existing public source-confinement and sensitive-path protections hold for the

--- a/docs/plans/public-show-live-update.md
+++ b/docs/plans/public-show-live-update.md
@@ -129,28 +129,50 @@ Only the page owner or existing sharing-control authority may change
 cannot read these settings APIs, mutate the audience, load the Workbench, or
 promote itself through a broader Instance endpoint.
 
-Audience changes use one Apply action and a fail-closed coordinator rather than
-three independent writes:
+Audience changes use one Apply action and one durable fail-closed coordinator
+rather than three independent writes. Every Apply allocates a client mutation ID
+and first commits a local transition record containing the source revision, target
+mode/set, and phase. Any transition that can add, remove, or replace page-email
+authority also sets `page_email_gate=closed_pending` in that same transaction.
+While that durable barrier exists, neither `/p/` nor the page-email branch of the
+canonical `/show/` ACL accepts a page-email claim, including a claim minted before
+the transition. Owner and organization resource ACLs remain independent.
+
+The backend atomically replaces the exact-email set with the mutation ID and
+expected authorization revision. It retains an idempotent mutation result that the
+device can query after a lost response or process restart. The device reopens the
+page-email gate only after a read-after-write reconciliation proves that the
+backend's committed mutation ID, exact set, and returned authorization revision all
+match the local target and the revision has been persisted locally. An unavailable,
+ambiguous, conflicting, or unpersisted result leaves the durable gate closed; a
+periodic revision poll is recovery evidence, never the security boundary.
+
+The coordinator applies that invariant to every transition:
 
 1. Entering `limited` from `public` first closes the local share gate to
-   `private`, then atomically replaces the cloud email set, then commits
-   `limited` with the existing or newly allocated slug. Failure leaves the page
-   private, never anonymously readable.
-2. Entering `limited` from `private` writes the email set before opening the
-   route. At least one address is required.
-3. Editing a live limited list uses the backend's atomic replace and authorization
-   revision. Removed viewers fail subsequent requests immediately and their
-   existing session is rejected when its revision is revalidated.
-4. Leaving `limited` commits `private` or `public` locally first, which makes all
-   page-email claims inapplicable. The backend list is then cleared. Failed
-   cleanup is retried and surfaced as pending but cannot reopen the route.
+   `private`, then replaces and reconciles the cloud email set, then commits
+   `limited` with the existing or newly allocated slug and opens the page-email
+   gate. Failure leaves the page private, never anonymously readable.
+2. Entering `limited` from `private` follows the same closed-barrier protocol.
+   At least one address is required.
+3. Editing a live limited list closes the page-email gate before sending the
+   replacement. Removed and retained viewers are both denied during ambiguity;
+   the reconciled revision reopens the new set together.
+4. Leaving `limited` commits `private` or `public` locally first. Page-email
+   claims are accepted only when the current durable mode is exactly `limited`,
+   so the local commit removes their authority from both `/p/` and `/show/`
+   before best-effort backend cleanup. Failed cleanup is retried and surfaced as
+   pending but cannot restore authority.
 5. Switching `private` and `public` is one local transaction. Link allocation,
    mode, revision, and old-route invalidation commit together.
 
-The UI does not optimistically display a new mode until the coordinator reaches
-its authoritative terminal state. A retry carries an idempotency key and expected
-`audience_revision`, so reconnects and double clicks cannot resurrect an older
-audience.
+Every request that considers page-email authority requires active availability,
+current mode `limited`, the current share binding where applicable,
+`page_email_gate=open`, and a claim revision equal to the reconciled local
+authorization revision. The UI does not optimistically display a new mode or set
+until the coordinator reaches its authoritative terminal state. Reconnects and
+double clicks reuse the mutation ID and expected audience revision, so they cannot
+resurrect an older audience.
 
 ### One editor capability
 
@@ -367,15 +389,25 @@ The shared context continues to use inert, versioned `@vite/client` and React
 Refresh shims. It exposes neither Runtime diagnostics nor a message channel.
 
 Vite's native `/@fs/<absolute-path>` form cannot cross that shared boundary.
-When a shared transform references an allowed absolute file, Runtime first checks
-the canonical path against the existing allowed-root, sensitive-segment, and
-symlink policy, then allocates a stable opaque handle from a Runtime-process secret,
-the Session, the current share generation, and the canonical path. The browser
-receives only `/p/<share>/__avibe_asset/<namespace>/<handle>`; Runtime's
-process-local registry resolves that handle only inside the matching shared
-namespace. A browser cannot submit a raw `/@fs/` path or mint a mapping, handles
-reveal no path bytes, and share rotation or Runtime replacement prevents new
-admission into the old namespace.
+When a shared transform references an allowed absolute file, Runtime opens it
+through a confinement-safe root descriptor: resolution cannot escape the selected
+allowed root or traverse a symlink prohibited by the existing policy, the final
+descriptor is verified against the allowed-root and sensitive-segment policy, and
+bounded bytes are copied into a namespace-owned immutable snapshot.
+Runtime compares descriptor metadata before and after the copy and rejects a file
+that changes during capture. It then allocates a stable opaque handle from a
+Runtime-process secret, the Session, the current share generation, the namespace,
+and the snapshot digest, not from a pathname.
+
+The browser receives only
+`/p/<share>/__avibe_asset/<namespace>/<handle>`; Runtime's process-local registry
+serves the immutable snapshot inside the matching shared namespace and never
+reopens the source path for a handle read. Replacing the original file or any
+parent with a symlink therefore cannot retarget an existing handle. A later valid
+source edit creates a new snapshot in a new transformed graph; a newly unsafe path
+is rejected before allocation. A browser cannot submit a raw `/@fs/` path or mint a
+mapping, handles reveal no path bytes, and share rotation or Runtime replacement
+prevents new admission into the old namespace.
 
 Each transformed entry graph owns one bounded 30-minute idle namespace lease.
 Every successful document, module, or lazy-asset read refreshes its lease. The
@@ -385,10 +417,12 @@ individual handles. A document that remains idle beyond the lease may fail a
 later lazy import and must reload; it never receives a handle from another graph.
 The Runtime bounds namespaces and handles globally and per Session. When every
 slot is actively leased, new admission fails closed instead of evicting a live
-namespace. Thus loaded documents retain their complete referenced set during the
-lease, while successive edits and rotations cannot consume capacity until
-process restart. The same chokepoint covers every emitted URL, including an
-absolute path nested inside another Vite URL.
+namespace. Snapshot bytes count against the same global and per-Session bounds and
+are reclaimed with their namespace. Thus loaded documents retain their complete
+referenced set during the lease, while successive edits and rotations cannot
+permanently consume capacity: expiry releases snapshot bytes without a process
+restart. The same chokepoint covers every emitted URL, including an absolute path
+nested inside another Vite URL.
 
 Runtime also labels every loopback response as `application`, `asset`, or
 `development-diagnostic` in a stripped response metadata header. Avibe forwards
@@ -423,10 +457,14 @@ redirect that selected `/show/`.
 
 That editor requirement applies to HMR, annotation writes, and the share-link
 redirect, not to ordinary private document and module reads. `/show/` keeps the
-existing resource-reader ACL so a read-only user can load the complete private
-module graph without receiving an HMR channel. A downgrade from editor to viewer
-closes HMR but does not manufacture a blank page by denying modules the viewer is
-still entitled to read.
+existing owner/organization resource-reader ACL so a read-only collaborator can
+load the complete private module graph without receiving an HMR channel. Its
+page-email branch is narrower: it can authorize a read only while the current local
+mode is `limited`, the page-email gate is open, and the claim revision is current.
+A transition to `private` or `public` therefore rejects stale page-email cookies on
+the canonical path even if hosted cleanup fails. A downgrade from editor to an
+independently entitled resource viewer closes HMR but does not manufacture a blank
+page by denying modules that viewer is still entitled to read.
 
 `/p/<share>/__vite_hmr` is removed for every viewer. A redirected editor uses the
 canonical private socket, while every document that remains at `/p/` contains no
@@ -503,7 +541,9 @@ request.
 | Private Runtime unavailable after an editor redirect | Existing private sanitized recovery behavior; never fall through to a raw shared-route socket | Private Runtime log |
 | Shared context unavailable | Existing sanitized shared unavailable/static fallback | Shared Runtime log without source detail |
 | Runtime emits a development diagnostic or unsafe URL header | Preserve only a safe status class/body and filtered headers | Redacted operator-only diagnostic |
+| Limited-list replacement has an ambiguous result | Keep the durable page-email gate closed across retries and restarts until read-after-write reconciliation persists the exact mutation result | Mutation ID, target digest, and redacted reconciliation state |
 | Limited email removed | Reject the viewer's next network request and invalidate its stale revision; no HMR or annotation channel exists to close | Authorization-revision log |
+| Limited page becomes private/public while hosted cleanup fails | Reject page-email claims on both `/p/` and `/show/` from the local mode commit; retry cleanup without reopening authority | Durable audience state and cleanup-pending record |
 | Editor role revoked but read ACL remains | Close private HMR; retain entitled private document/module reads; next `/p/` navigation stays shared only if its audience read rule succeeds | Existing authorization-revision/resource-revocation log |
 | Show Page read access revoked | Close private HMR and reject later private document/module reads; `/p/` is re-evaluated independently | Existing resource-revocation log |
 | Share rotates or becomes private | Old network-reached `/p/` reads fail immediately; an entitled canonical private socket remains independent; previously cached bytes remain a client-cache limitation | Durable Show Page state |
@@ -581,12 +621,12 @@ feature, not a prerequisite for capability-gated editor HMR.
 2. Replace workspace audience plus public-link switch with the three-option
    select. Render exact emails only for `limited`, and link controls only for
    `limited | public`; keep availability separate.
-3. Implement the fail-closed access coordinator and idempotent revision contract.
-   Retire the independent visibility and email mutation paths after compatibility
-   callers migrate.
+3. Implement the persistent page-email barrier, idempotent backend mutation-result
+   lookup, and fail-closed access coordinator. Retire the independent visibility
+   and email mutation paths after compatibility callers migrate.
 4. Make `/p/<share>/` resolve both `limited` and `public`. Add the limited login,
-   exact page-entitlement check, generic denial, current-revision check, and
-   private/no-store response policy.
+   mode-scoped exact page-entitlement check on both `/p/` and `/show/`, generic
+   denial, current-revision check, and private/no-store response policy.
 5. Factor annotation authorization into the shared, resource-aware
    `ShowEditorCapability`, explicitly excluding page-email entitlement, and use
    the same result for top-level editor navigation.
@@ -602,13 +642,14 @@ feature, not a prerequisite for capability-gated editor HMR.
 8. Preserve resource-viewer authorization for ordinary private modules while
    requiring editor capability for HMR, annotation writes, and share-link
    redirect selection.
-9. Add leased opaque shared file namespaces, Runtime response provenance, and
-   URL-bearing header filtering so raw `/@fs/` paths, stale unbounded handles,
-   and development diagnostics cannot cross the shared boundary.
+9. Add leased opaque shared file namespaces backed by immutable bounded snapshots,
+   Runtime response provenance, and URL-bearing header filtering so raw `/@fs/`
+   paths, mutable-path handles, and development diagnostics cannot cross the
+   shared boundary.
 10. Add the coalesced durable availability monitor for private HMR sockets.
 11. Add cache, Service Worker scope, network-revocation, mixed-version,
-    negotiation retry, total context propagation, concurrency, path-confinement,
-    and audience-transition contract tests.
+    negotiation retry, total context propagation, concurrency, rollback-write,
+    path-swap confinement, and audience-transition contract tests.
 12. Run local Incus regression with editor, exact-email, anonymous, denied, and
     revoked viewers open concurrently.
 
@@ -639,12 +680,30 @@ after the local public state is authoritative. Organization resource policies
 are not mapped into external audience modes; they remain canonical `/show/`
 collaborator policy.
 
-The compatibility read API may project old `visibility` fields for one release,
-and new writes maintain a rollback-safe projection: public maps to old `public`,
+The compatibility read API projects old `visibility` fields for one rollback
+window, and new writes maintain a safe projection: public maps to old `public`,
 private and limited map to old `private`, and offline maps to old `offline`.
-Authoritative writes still go only through `ShowAccess`. A rollback therefore
-treats `limited` as private because older code cannot enforce its `/p/`
-authentication gate.
+The migration also installs a durable legacy-write marker triggered by every
+assignment to the legacy visibility column, including an assignment whose value is
+unchanged. A new writer updates `ShowAccess`, writes its legacy projection, and
+clears the marker only after both values are committed in the same transaction.
+An old binary cannot clear it, so any old-binary write remains distinguishable from
+a projection on the next upgrade. The compatibility column, marker, and trigger
+survive application rollback and schema downgrade for the entire supported
+rollback window; cleanup is a later migration after old binaries are no longer
+supported.
+
+On startup or re-upgrade, a set marker makes the last legacy visibility assignment
+the user intent to reconcile before serving the page. Legacy `private` becomes
+active `private`, legacy `offline` becomes offline `private`, and an explicit legacy
+`public` becomes active `public`; a missing/corrupt marker state fails to private.
+The reconciled transaction invalidates the prior share binding where the target no
+longer uses it, makes page-email claims inapplicable unless the result is later
+opened as `limited` through the connected coordinator, writes the new projection,
+and only then clears the marker. A rollback therefore treats `limited` as private
+because older code cannot enforce its `/p/` authentication gate, while a later
+private/offline write by that old binary cannot be overwritten by stale
+`ShowAccess` on re-upgrade.
 
 ## Verification Plan
 
@@ -677,6 +736,15 @@ authentication gate.
 - prove migration maps old public, private-with-grants, private-without-grants,
   and offline rows exactly as specified, with disconnected reconciliation staying
   private
+- perform a real new-write, binary rollback, legacy public/private/offline write,
+  and re-upgrade round trip; the legacy-write marker must preserve the last user
+  action, including an unchanged-value private assignment, and ambiguous state must
+  fail closed
+- interrupt every limited-list mutation before send, after backend commit, after a
+  lost response, and before local revision persistence; the durable page-email gate
+  stays closed across process restart until the exact mutation result reconciles
+- prove a page-email cookie is rejected by both `/p/` and `/show/` immediately after
+  the local mode leaves `limited`, even while backend cleanup is unavailable
 
 ### Runtime and proxy tests
 
@@ -693,8 +761,9 @@ authentication gate.
 - shared requests never change, close, or rebuild the private context
 - authorized top-level `/p/` navigations redirect before document bytes to the
   equivalent canonical `/show/` route
-- unprivileged documents reference only shared paths, opaque allowed-file handles,
-  and immutable shims; raw `/@fs/`, host paths, and Session paths are denied
+- unprivileged documents reference only shared paths, opaque immutable-snapshot
+  handles, and immutable shims; raw `/@fs/`, host paths, and Session paths are
+  denied
 - Runtime response provenance preserves authored application errors while every
   development diagnostic receives a fixed shared body; unsafe `SourceMap`,
   `X-SourceMap`, `Content-Location`, `Refresh`, `Location`, and `Link` values are
@@ -702,6 +771,9 @@ authentication gate.
 - old opaque namespaces survive lazy loads while leased, expire as a whole after
   30 idle minutes, never cross graph/share boundaries, and do not make admission
   capacity permanently consumable across successive edits
+- after handle allocation, replace the source or any parent with an out-of-root or
+  sensitive symlink; the old handle serves only its captured immutable bytes, a new
+  allocation is denied, and no handle read reopens the pathname
 - `/p/<share>/__vite_hmr` rejects every connection
 - private document/module requests retain resource-reader ACL; private HMR repeats
   editor/resource/origin checks, closes on authorization-revision or resource
@@ -741,6 +813,10 @@ authentication gate.
 | `SHOW-LIVE-018` | Direct CLI changes an active page to offline with private HMR connected | The coalesced durable monitor closes every socket for the Session within five seconds without relying on an in-process event |
 | `SHOW-LIVE-019` | Public changes to limited and the cloud write fails | The local gate remains private; neither anonymous nor stale listed viewers can read until a complete retry succeeds |
 | `SHOW-LIVE-020` | Old private/public/offline rows and exact-email grants upgrade | Each page matches the migration table; a disconnected private-with-grants page stays private and pending |
+| `SHOW-LIVE-021` | A live limited-list replacement commits remotely, its response is lost, and Avibe restarts | All page-email reads remain closed until the mutation result and revision reconcile; removed viewers never regain access |
+| `SHOW-LIVE-022` | Limited changes to private while hosted cleanup is unavailable | A stale page-email cookie is rejected on both `/p/` and `/show/`; independent resource collaborators retain their canonical access |
+| `SHOW-LIVE-023` | A public page upgrades, rolls back, is set private by the old binary, then re-upgrades | The legacy marker wins and the page stays private; stale `ShowAccess` cannot reopen anonymous access |
+| `SHOW-LIVE-024` | An allowed source is replaced by a sensitive symlink after an opaque handle is issued | The issued handle returns only immutable captured bytes, and the changed path cannot receive a new handle |
 
 Focused unit/contract tests, Ruff, repository CI, and local Incus browser
 regression are required. Green unit tests do not replace simultaneous editor,
@@ -758,7 +834,11 @@ The design is implemented when all of the following are true:
   exact page grant and fully public remains anonymously readable.
 - Page-email authority is view-only and cannot contribute evidence to
   `ShowEditorCapability`, settings, Workbench, Agents annotations, HMR, or another
-  Show Page.
+  Show Page. It authorizes page reads only while current mode is `limited`, the
+  durable mutation gate is open, and its revision is current.
+- Every grant-set mutation closes a persistent local page-email gate before remote
+  work and reopens it only after idempotent read-after-write reconciliation; an
+  ambiguous response or restart cannot leave stale grants usable.
 - Authorized share-link editor navigations redirect to the corresponding private URL
   and get the same Vite HMR and React Fast Refresh behavior as private editors.
 - Annotation writes and the share-link editor redirect consume one validated,
@@ -782,9 +862,13 @@ The design is implemented when all of the following are true:
   shared context and retry without permanently disabling the feature.
 - Context selection is mandatory at every Runtime app-graph call site, including
   prewarm and fallback paths, and missing selection fails before Vite ownership.
-- Shared file references use leased context-bound opaque handles after path
-  validation; raw absolute paths, unsafe URL-bearing response headers, and Runtime
-  development diagnostics never reach the browser.
+- Shared file references use leased context-bound opaque handles backed by bounded
+  immutable snapshots captured through confinement-safe opens; handle reads never
+  reopen mutable pathnames. Raw absolute paths, unsafe URL-bearing response headers,
+  and Runtime development diagnostics never reach the browser.
+- Compatibility rollback writes are durably marked and reconciled before serving,
+  so a private/offline change made by an old binary cannot be overwritten by stale
+  `ShowAccess` after re-upgrade.
 - Direct durable offline mutations close active private HMR within five seconds;
   share rotation alone does not revoke entitled canonical private access.
 - Authorization failure preserves fully public availability, fails limited access

--- a/docs/plans/public-show-live-update.md
+++ b/docs/plans/public-show-live-update.md
@@ -109,14 +109,22 @@ ShowAccess {
   availability: active | offline
   access_mode: private | limited | public
   share_id: opaque slug | null
-  audience_revision: monotonic integer
+  audience_revision: device-local monotonic integer
+  share_admission_gate: open | closed_pending
+  grant_revision: backend-issued page-scoped integer
+  grant_digest: non-PII hash
 }
 ```
 
 Exact emails remain normalized, unique page-bound grants in `avibe-backend`;
 they are not copied into local storage or encoded into the slug. `share_id` is a
 locator, never a bearer credential. It exists only for `limited` and `public`;
-rotating it invalidates the old route but does not change the page audience.
+rotating it invalidates the old route but does not change the page audience. The
+backend owns one monotonic `grant_revision` per Show Page and advances it exactly
+once when a mutation ID changes that page's exact-email set, including a change to
+the empty set. A retry or same-set no-op returns the current revision. The existing
+Instance-wide authorization revision still invalidates generic sessions, but it is
+not the version of any individual page's grant set.
 
 Existing organization/resource ACLs continue to govern canonical `/show/`
 collaborator access and who can edit or manage the page. They are not a second
@@ -132,7 +140,7 @@ promote itself through a broader Instance endpoint.
 Audience changes use one Apply action and one durable fail-closed coordinator
 rather than three independent writes. Every Apply allocates a client mutation ID.
 For a change that carries exact emails, the device first sends the normalized
-in-memory target and expected authorization revision to a backend `prepare`
+in-memory target and expected page-scoped `grant_revision` to a backend `prepare`
 operation. Preparation stores the target only inside the existing hosted grant
 trust boundary, changes no grant authority, and returns an opaque operation ID plus
 target digest. A prepared operation has a non-renewable 24-hour lifetime. If this
@@ -141,40 +149,46 @@ previous audience remains authoritative; an unreferenced preparation can only
 expire, never commit itself.
 
 After preparation succeeds, one local transaction persists only the opaque
-operation ID, source revision, target mode, target digest, and phase. It never
-persists the email addresses. Any transition that can add, remove, or replace
-page-email authority also sets `page_email_gate=closed_pending` in that same
-transaction. While that durable barrier exists, neither `/p/` nor the page-email
-branch of the canonical `/show/` ACL accepts a page-email claim, including a claim
-minted before the transition. Owner and organization resource ACLs remain
-independent.
+operation ID, source audience revision, source page grant revision, target mode,
+target or preserved share binding, target digest, and phase. It never persists the
+email addresses. Any transition that can add, remove, or replace page-email
+authority also sets `share_admission_gate=closed_pending` in that same transaction.
+This gate is orthogonal to `access_mode`: while it is closed, every `/p/` read and
+editor redirect is denied and the page-email branch of the canonical `/show/` ACL
+rejects claims, but the committed mode and `share_id` remain intact for recovery.
+Owner and organization resource ACLs on canonical `/show/` remain independent.
 
 The device then asks the backend to `commit` the prepared operation. Commit
-atomically replaces the exact-email set under the expected authorization revision
-and retains an idempotent mutation result. After a lost response or process restart,
-the device resumes by opaque operation ID; a committed operation returns the exact
-current set/digest and authorization revision, while an uncommitted expired
-operation cannot mutate grants. The device reopens the page-email gate only after a
-read-after-write reconciliation proves that the backend's committed operation,
-exact current set/digest, and returned authorization revision match the local
-record and the revision has been persisted locally. The backend deletes the
-prepared target copy after device acknowledgement or the 24-hour hard limit; a
-terminal result retains only non-PII metadata and the digest. If the result copy has
-expired after commit, the authoritative current grant read supplies the same digest
-and revision proof. An unavailable, ambiguous, conflicting, expired-uncommitted, or
-unpersisted result leaves the durable gate closed. Email-list edits then require the
-owner to resubmit the target; empty-set cleanup can retry automatically. A periodic
-revision poll is recovery evidence, never the security boundary.
+atomically replaces the exact-email set under the expected page `grant_revision`,
+advances that revision once when the digest changes, and retains an idempotent
+mutation result. After a lost response or process restart, the device resumes by
+opaque operation ID; a committed operation returns the exact current set/digest and
+page grant revision, while an uncommitted expired operation cannot mutate grants.
+The device reopens the share admission gate only after a read-after-write
+reconciliation proves that the
+backend's committed operation, exact current set/digest, and returned page grant
+revision match the local record and that revision has been persisted locally. The
+backend deletes the prepared target copy after device acknowledgement or the
+24-hour hard limit; a terminal result retains only non-PII metadata and the digest.
+If the result copy has expired after commit, the authoritative current page-grant
+read supplies the same digest and revision proof. An unavailable, ambiguous,
+conflicting, or unpersisted result leaves the durable gate closed. A proven expired
+and uncommitted preparation may restore the prior gate only when the authoritative
+page digest/revision still equal the recorded source; otherwise the owner must
+resubmit the target. Empty-set cleanup can retry automatically. A periodic
+page-grant revision poll is recovery evidence, never the security boundary.
 
 The coordinator applies that invariant to every transition:
 
-1. Entering `limited` from `public` first closes the local share gate to
-   `private`, then replaces and reconciles the cloud email set, then commits
-   `limited` with the existing or newly allocated slug and opens the page-email
-   gate. Failure leaves the page private, never anonymously readable.
+1. Entering `limited` from `public` closes only `share_admission_gate`, preserving
+   the committed `public` mode and exact `share_id` while all `/p/` reads are denied.
+   It then replaces and reconciles the cloud email set and atomically commits
+   `limited` with that same binding while reopening the gate. A crash therefore
+   cannot expose anonymous access or silently rotate the URL.
 2. Entering `limited` from `private` follows the same closed-barrier protocol.
-   At least one address is required.
-3. Editing a live limited list closes the page-email gate before sending the
+   At least one address is required; any requested or allocated target binding is
+   non-sensitive coordinator state until the terminal local transaction.
+3. Editing a live limited list closes the share admission gate before sending the
    replacement. Removed and retained viewers are both denied during ambiguity;
    the reconciled revision reopens the new set together.
 4. Leaving `limited` commits `private` or `public` locally first. Page-email
@@ -187,11 +201,22 @@ The coordinator applies that invariant to every transition:
 
 Every request that considers page-email authority requires active availability,
 current mode `limited`, the current share binding where applicable,
-`page_email_gate=open`, and a claim revision equal to the reconciled local
-authorization revision. The UI does not optimistically display a new mode or set
-until the coordinator reaches its authoritative terminal state. Reconnects and
+`share_admission_gate=open`, and a signed claim `show_page_grant_revision` equal to
+the reconciled local page `grant_revision`. A change to an unrelated Instance ACL
+cannot invalidate an unchanged page grant, while a mutation of this page invalidates
+every older page-email claim. The UI does not optimistically display a new mode or
+set until the coordinator reaches its authoritative terminal state. Reconnects and
 double clicks reuse the mutation ID and expected audience revision, so they cannot
 resurrect an older audience.
+
+The hosted identity resolver produces `vibe_show_page_id`,
+`vibe_show_page_grant_revision`, and `vibe_instance_access_source=show_page_email`
+together inside the existing signed session payload; the signature covers all three
+fields. Avibe consumes the first two only for that exact page and obtains its local
+comparison value only from an authenticated current-grant or committed-operation
+response. Browser input cannot supply either revision. The generic Instance
+authorization watermark remains a separate signed freshness input and never
+substitutes for the page revision.
 
 ### One editor capability
 
@@ -298,8 +323,9 @@ that requirement 7 has been met.
 ```text
 GET /p/<share>/...
   -> resolve current limited/public share and availability
+  -> require share_admission_gate == open
   -> access_mode == limited?
-     -> yes: require current page-bound email grant or ShowEditorCapability
+     -> yes: require current page-bound email grant at grant_revision or ShowEditorCapability
      -> no: public read is allowed
   -> top-level navigation + Runtime keyed-context capability?
      -> yes: compute ShowEditorCapability
@@ -496,9 +522,10 @@ redirect, not to ordinary private document and module reads. `/show/` keeps the
 existing owner/organization resource-reader ACL so a read-only collaborator can
 load the complete private module graph without receiving an HMR channel. Its
 page-email branch is narrower: it can authorize a read only while the current local
-mode is `limited`, the page-email gate is open, and the claim revision is current.
-A transition to `private` or `public` therefore rejects stale page-email cookies on
-the canonical path even if hosted cleanup fails. A downgrade from editor to an
+mode is `limited`, the share admission gate is open, and the claim's page-scoped
+grant revision is current. A transition to `private` or `public` therefore rejects
+stale page-email cookies on the canonical path even if hosted cleanup fails. A
+downgrade from editor to an
 independently entitled resource viewer closes HMR but does not manufacture a blank
 page by denying modules that viewer is still entitled to read.
 
@@ -588,10 +615,12 @@ request.
 | Shared Runtime admission is saturated | Reclaim the oldest non-in-flight shared bundle; if none is reclaimable, return a sanitized retryable unavailable response without consuming the private reserve | Global weighted-budget admission/reclamation metric |
 | A shared document outlives its absolute namespace/context lifetime | Return a fixed stale-document response for later module or lazy-asset reads and require reload | Namespace hard-expiry metric without source paths |
 | Runtime emits a development diagnostic or unsafe URL header | Preserve only a safe status class/body and filtered headers | Redacted operator-only diagnostic |
-| Limited-list replacement has an ambiguous result | Keep the durable page-email gate closed across retries and restarts until read-after-write reconciliation persists the exact mutation result | Mutation ID, target digest, and redacted reconciliation state |
-| Prepared email operation expires before commit | Keep the page-email gate closed when a local transition exists, discard the opaque operation reference, and require target resubmission; a preparation with no local transition expires without changing the audience | Operation expiry and non-PII target digest |
-| Limited email removed | Reject the viewer's next network request and invalidate its stale revision; no HMR or annotation channel exists to close | Authorization-revision log |
+| Limited-list replacement has an ambiguous result | Keep the durable share admission gate closed across retries and restarts until read-after-write reconciliation persists the exact mutation result | Mutation ID, target digest, and redacted reconciliation state |
+| Prepared email operation expires before commit | Reopen the prior share audience only after authoritative digest/revision proof that no commit occurred; otherwise remain closed and require target resubmission | Operation expiry and non-PII target digest |
+| Limited email removed | Reject the viewer's next network request by page grant revision; no HMR or annotation channel exists to close | Page-grant revision log |
+| Unrelated Instance authorization changes | Refresh generic session freshness without changing any page grant revision or denying an unchanged limited viewer | Instance and page revision metrics kept distinct |
 | Limited page becomes private/public while hosted cleanup fails | Reject page-email claims on both `/p/` and `/show/` from the local mode commit; retry cleanup without reopening authority | Durable audience state and cleanup-pending record |
+| Binary downgrade sees a limited/non-empty/pending page or cannot attest the backend fence | Refuse executable/schema replacement; while the fence is active, reject every released exact-email write | Fence epoch and redacted preflight reason |
 | Editor role revoked but read ACL remains | Close private HMR; retain entitled private document/module reads; next `/p/` navigation stays shared only if its audience read rule succeeds | Existing authorization-revision/resource-revocation log |
 | Show Page read access revoked | Close private HMR and reject later private document/module reads; `/p/` is re-evaluated independently | Existing resource-revocation log |
 | Share rotates or becomes private | Old network-reached `/p/` reads fail immediately; an entitled canonical private socket remains independent; previously cached bytes remain a client-cache limitation | Durable Show Page state |
@@ -669,13 +698,14 @@ feature, not a prerequisite for capability-gated editor HMR.
 2. Replace workspace audience plus public-link switch with the three-option
    select. Render exact emails only for `limited`, and link controls only for
    `limited | public`; keep availability separate.
-3. Implement backend prepare/commit email operations, the non-PII persistent
-   page-email barrier, idempotent mutation-result/current-grant lookup, and the
+3. Implement backend prepare/commit email operations, page-scoped grant revisions,
+   the non-PII persistent share admission barrier, idempotent
+   mutation-result/current-grant lookup, the downgrade legacy-write fence, and the
    fail-closed access coordinator. Retire the independent visibility and email
    mutation paths after compatibility callers migrate.
 4. Make `/p/<share>/` resolve both `limited` and `public`. Add the limited login,
    mode-scoped exact page-entitlement check on both `/p/` and `/show/`, generic
-   denial, current-revision check, and private/no-store response policy.
+   denial, page-grant revision check, and private/no-store response policy.
 5. Factor annotation authorization into the shared, resource-aware
    `ShowEditorCapability`, explicitly excluding page-email entitlement, and use
    the same result for top-level editor navigation.
@@ -728,9 +758,11 @@ The schema migration separates availability from audience and is fail-closed:
 
 Until the device can read the hosted grant set, an old private page stays
 private and records migration pending with the source `audience_revision` and
-legacy-audience journal generation; it is never guessed to be limited.
-Reconciliation may commit only with a compare-and-swap proving that both values are
-still current.
+legacy-audience journal generation; it is never guessed to be limited. The hosted
+read returns the page-scoped grant revision and digest, and reconciliation may commit
+only with a compare-and-swap proving that all three inputs are still current. The
+Instance-wide authorization revision is deliberately absent from this page-state
+comparison.
 Every authoritative audience Apply and every reconciled legacy write increments
 `audience_revision` and deletes any pending migration in the same local transaction
 before remote work begins. A stale worker discards its hosted read and any provisional
@@ -769,23 +801,40 @@ link; stale `ShowAccess` never wins the conflict. The reconciled transaction mak
 page-email claims inapplicable unless the result is later opened as `limited`
 through the connected coordinator, writes the complete new projection, advances
 `audience_revision`, and only then acknowledges the journal generation. A rollback
-therefore treats `limited` as private because older code cannot enforce its `/p/`
-authentication gate, while a visibility, rotation, or custom-slug write by that old
-binary cannot be overwritten by stale `ShowAccess` on re-upgrade.
+projection represents `limited` as legacy private for schema compatibility, but the
+updater never starts an old binary while any limited page exists because that binary
+cannot enforce the new read-versus-development boundary. Visibility, rotation, or
+custom-slug writes made during an allowed rollback still cannot be overwritten by
+stale `ShowAccess` on re-upgrade.
 
 Binary downgrade has a fail-closed preflight before the current executable or
 compatibility schema is replaced. The updater acquires the audience coordinator's
 exclusive write lock, holds it through service quiescence and executable/schema
 replacement, and under that lock requires the hosted resolver to be reachable, no
-audience transition or migration to be pending, every ambiguous mutation result to
-be reconciled, and every non-`limited` page to have an empty hosted email set with
-the resulting authorization revision persisted locally. A `limited` page is
-rollback-compatible only while its gate is open on that exact reconciled set. If
-cleanup or revocation is pending, downgrade is refused and the current binary and
-schema remain intact; retrying cleanup is the only recovery. This is the
-rollback-compatible barrier enforced by the old `/show/` serving path: it never
-starts in a state where a non-`limited` page still has a usable `show_page_email`
-claim, even though the old binary does not understand `page_email_gate`.
+audience transition or migration to be pending, every share admission gate to be
+open, no page to be `limited`, and every hosted page-email set to be empty with its
+page grant revision/digest reconciled locally and the resulting Instance-wide
+authorization watermark persisted for the released binary's session-freshness
+check. Owners must first move every limited page
+to private or public and complete the empty-set cleanup; an open limited gate is
+never rollback-compatible because the released `/show/` HMR handler accepts
+page-email viewers.
+
+After those checks, the backend atomically activates an Instance-scoped,
+mutation-ID-bound `legacy_page_email_write_fence` and returns a signed fence epoch.
+The fence applies to the paired Instance rather than trusting a client version
+header: every released exact-email replacement endpoint rejects writes while it is
+active. The updater persists the attested epoch before replacing the executable, so
+an old binary can continue serving private/public/offline pages but cannot create a
+new page-email viewer or restore that viewer's legacy HMR access. If fence activation,
+persistence, or any preflight check fails, downgrade is refused and the current
+binary/schema remain intact. A crash after activation but before replacement is
+recovered by the same idempotent mutation ID; an explicitly aborted updater may
+clear its epoch only after proving the new executable still owns the quiesced lock.
+Otherwise the fence remains closed. Re-upgrade keeps it active until the new binary
+has reconciled every empty grant revision and its prepare/commit API is ready, then
+clears exactly that epoch. This makes the rollback restriction reversible without
+asking an old HMR handler to enforce a capability it does not understand.
 
 ## Verification Plan
 
@@ -795,8 +844,9 @@ claim, even though the old binary does not understand `page_email_gate`.
   old public switch is absent, emails render only for `limited`, and `/p/` link
   controls render for `limited | public`
 - exercise every audience transition, coordinator failure point, stale revision,
-  retry, and double submission; no intermediate state may grant more read access
-  than the last committed or requested target
+  retry, and double submission; the share admission gate is the only transient
+  route barrier, and no intermediate state may grant more read access than the last
+  committed or requested target
 - seed every supported identity/resource shape and assert that `canAnnotate` and
   the share-link redirect are produced by the same editor capability
 - prove page-email entitlement can satisfy only limited read, cannot satisfy the
@@ -826,16 +876,28 @@ claim, even though the old binary does not understand `page_email_gate`.
   connectivity; the source-revision compare-and-swap discards the stale migration
   and cannot allocate or reopen a limited audience
 - attempt downgrade while a limited-to-private/public cleanup or mutation result is
-  pending; preflight preserves the current binary and schema until hosted grants are
-  empty and the authorization revision is reconciled
+  pending or while any limited page exists; preflight preserves the current binary
+  and schema until every page is non-limited and its hosted grant set is empty at the
+  reconciled page revision and the resulting global watermark invalidates old claims
+- interrupt downgrade before and after backend fence activation, attestation
+  persistence, executable replacement, and re-upgrade readiness; a released email
+  mutation is rejected for every active fence epoch, and abort clears only an epoch
+  whose new-binary lock ownership is proven
 - interrupt every limited-list mutation before backend prepare, after prepare but
   before the local transaction, after the local transaction but before commit, after
   backend commit, after a lost response, and before local revision persistence; the
   local record never contains an email, a preparation never changes authority by
-  itself, and the page-email gate stays closed until the exact result reconciles
+  itself, and the share admission gate stays closed until the exact result reconciles
 - expire prepared and committed-operation result copies, then recover from opaque
-  operation ID, target digest, and the authoritative current grant revision; failed
-  list edits require resubmission without persisting removed/failed email PII
+  operation ID, target digest, and the authoritative page grant revision; reopen the
+  prior audience only after proof that an expired operation did not commit, and
+  require resubmission without persisting removed/failed email PII otherwise
+- advance the Instance-wide authorization revision for every unrelated ACL shape and
+  prove an unchanged limited page remains readable, then advance that page's grant
+  revision and prove every older page-email claim is rejected
+- crash a public-to-limited transition at every local and hosted boundary; `/p/`
+  remains closed during ambiguity and completion preserves the exact original custom
+  or generated `share_id`
 - prove a page-email cookie is rejected by both `/p/` and `/show/` immediately after
   the local mode leaves `limited`, even while backend cleanup is unavailable
 
@@ -900,7 +962,7 @@ claim, even though the old binary does not understand `page_email_gate`.
 | `SHOW-LIVE-005` | Direct `/show/`, redirected editor `/show/`, exact-email `/p/`, and anonymous public `/p/` are open together | Both private documents keep HMR while all `/p/` traffic uses an independent shared context |
 | `SHOW-LIVE-006` | Identity resolution fails for public and limited requests | Public remains readable with no HMR; limited fails closed without leaking its audience |
 | `SHOW-LIVE-007` | Editor role is revoked while redirected HMR is open but read ACL remains | The socket closes, private modules remain readable, and `/p/` follows only the current audience read rule |
-| `SHOW-LIVE-008` | An email is removed while its limited page is open | The next network read is denied through authorization revision; no development channel ever existed |
+| `SHOW-LIVE-008` | An email is removed while its limited page is open | The next network read is denied through the page grant revision; no development channel ever existed |
 | `SHOW-LIVE-009` | A viewer connects directly to `/p/<share>/__vite_hmr` | The connection is rejected regardless of cookies or visibility |
 | `SHOW-LIVE-010` | Editor and shared viewers remain open through repeated edits | Context and leased-namespace counts stay bounded, private HMR remains stable, and no shared background build occurs |
 | `SHOW-LIVE-011` | A shared document starts while identity is unavailable and identity recovers during module loading | Every module stays on `/p/`; no Vite client or mixed transform graph appears |
@@ -911,19 +973,22 @@ claim, even though the old binary does not understand `page_email_gate`.
 | `SHOW-LIVE-016` | Shared transforms emit nested `/@fs/` imports, URL-bearing headers, and Vite errors | Only leased context-bound handles and safe rewritten headers reach the browser; every development error is fixed and path-free |
 | `SHOW-LIVE-017` | Startup reconciliation and `vibe show update` prewarm shared and private graphs | Each request carries its typed context; a missing/invalid context fails before creating or rebasing either graph |
 | `SHOW-LIVE-018` | Direct CLI changes an active page to offline with private HMR connected | The coalesced durable monitor closes every socket for the Session within five seconds without relying on an in-process event |
-| `SHOW-LIVE-019` | Public changes to limited and the cloud write fails | The local gate remains private; neither anonymous nor stale listed viewers can read until a complete retry succeeds |
+| `SHOW-LIVE-019` | Public changes to limited and the cloud write fails | The share admission gate stays closed while the public mode and binding remain recoverable; neither anonymous nor stale listed viewers can read until reconciliation succeeds |
 | `SHOW-LIVE-020` | Old private/public/offline rows and exact-email grants upgrade | Each page matches the migration table; a disconnected private-with-grants page stays private and pending |
 | `SHOW-LIVE-021` | A live limited-list replacement commits remotely, its response is lost, and Avibe restarts | All page-email reads remain closed until the mutation result and revision reconcile; removed viewers never regain access |
 | `SHOW-LIVE-022` | Limited changes to private while hosted cleanup is unavailable | A stale page-email cookie is rejected on both `/p/` and `/show/`; independent resource collaborators retain their canonical access |
 | `SHOW-LIVE-023` | A public page upgrades, rolls back, is set private by the old binary, then re-upgrades | The newest complete journal snapshot wins and the page stays private; stale `ShowAccess` cannot reopen anonymous access |
 | `SHOW-LIVE-024` | An allowed source is replaced by a sensitive symlink after an opaque handle is issued | The issued handle returns only immutable captured bytes, and the changed path cannot receive a new handle |
 | `SHOW-LIVE-025` | A disconnected private-page migration is pending, then the owner chooses public and later private before reconnecting | The newer revision cancels migration; reconnect cannot allocate a slug, commit limited, or restore the old email audience |
-| `SHOW-LIVE-026` | Limited changes to private while hosted cleanup is unavailable, then binary downgrade is requested | Downgrade is refused without replacing executable/schema; it succeeds only after grants are empty and the new revision is reconciled |
+| `SHOW-LIVE-026` | Limited changes to private while hosted cleanup is unavailable, then binary downgrade is requested | Downgrade is refused without replacing executable/schema; it can proceed only after no limited page exists and every grant set is empty at its reconciled page revision |
 | `SHOW-LIVE-027` | An anonymous client reads every superseded namespace just before each idle deadline | Each namespace still reaches its non-renewable hard expiry, releases all snapshot bytes, and requires stale documents to reload |
 | `SHOW-LIVE-028` | Anonymous clients keep shared pages active across more Sessions than the Runtime-wide budget | Context and memory stay under the hard limit, reclaimable shared bundles rotate, private HMR keeps its reserve, and excess shared admission is sanitized |
 | `SHOW-LIVE-029` | A public page rolls back, then the old binary rotates and assigns a custom slug before re-upgrade | The newest complete journal snapshot wins; only the final slug resolves, and a conflict fails private without resurrecting stale `ShowAccess` |
 | `SHOW-LIVE-030` | A released Avibe client starts a new Runtime and sends only `x-vibe-show-base` | Entry, module, and prewarm requests retain the legacy singleton behavior; keyed isolation remains disabled until a protocol-`1` client supplies context |
-| `SHOW-LIVE-031` | A limited-list Apply crashes at every prepare/local/commit boundary and later exceeds operation retention | No local row contains an email, prepare alone never changes grants, committed state reconciles by digest/revision, and expired uncommitted edits remain closed until resubmitted |
+| `SHOW-LIVE-031` | A limited-list Apply crashes at every prepare/local/commit boundary and later exceeds operation retention | No local row contains an email, prepare alone never changes grants, committed state reconciles by page digest/revision, and the prior audience reopens only after proof that an expired operation did not commit |
+| `SHOW-LIVE-032` | Downgrade is attempted with a limited page, then retried after conversion and empty cleanup | The first attempt is refused; the second invalidates old claims and activates an attested legacy-email-write fence, so the old binary cannot add listed viewers or expose its viewer-authorized HMR socket |
+| `SHOW-LIVE-033` | An unrelated Instance ACL change advances the global authorization revision while a limited list is unchanged | Refreshed listed viewers remain readable at the same page grant revision; changing that page's list advances only its grant revision and rejects older claims |
+| `SHOW-LIVE-034` | A custom-slug public page crashes at every boundary while changing to limited | Every ambiguous `/p/` read is denied, and successful recovery preserves the exact slug without rotating or losing the route |
 
 Focused unit/contract tests, Ruff, repository CI, and local Incus browser
 regression are required. Green unit tests do not replace simultaneous editor,
@@ -942,11 +1007,13 @@ The design is implemented when all of the following are true:
 - Page-email authority is view-only and cannot contribute evidence to
   `ShowEditorCapability`, settings, Workbench, Agents annotations, HMR, or another
   Show Page. It authorizes page reads only while current mode is `limited`, the
-  durable mutation gate is open, and its revision is current.
+  durable share admission gate is open, and its signed page grant revision is
+  current; the Instance-wide revision is not used as that page-set version.
 - Every grant-set mutation is prepared without changing authority, then closes a
-  persistent non-PII local page-email gate before commit and reopens it only after
-  idempotent read-after-write reconciliation; an ambiguous response, restart, or
-  expired operation cannot leave stale grants usable or email targets on disk.
+  persistent non-PII local share admission gate before commit and reopens it only
+  after idempotent read-after-write reconciliation; an ambiguous response, restart,
+  or expired operation cannot leave stale grants usable, email targets on disk, or
+  a share binding lost.
 - Authorized share-link editor navigations redirect to the corresponding private URL
   and get the same Vite HMR and React Fast Refresh behavior as private editors.
 - Annotation writes and the share-link editor redirect consume one validated,
@@ -980,8 +1047,9 @@ The design is implemented when all of the following are true:
   changes made by an old binary cannot be overwritten by stale `ShowAccess` after
   re-upgrade.
 - Pending legacy migration is revision-bound and cancelled by every newer audience
-  mutation; downgrade cannot begin while stale hosted email authority could be
-  accepted by the old serving path.
+  mutation. Downgrade requires zero limited pages and empty reconciled grant sets,
+  then keeps a backend legacy-email-write fence active until the new binary is ready
+  again, so the old serving path can neither mint listed viewers nor grant them HMR.
 - Shared Vite contexts, opaque namespaces, handles, and snapshot bytes share one
   Runtime-wide weighted budget with a private-editor reserve and non-renewable
   lifetimes, so anonymous traffic cannot pin admission indefinitely.

--- a/docs/plans/public-show-live-update.md
+++ b/docs/plans/public-show-live-update.md
@@ -89,7 +89,7 @@ The share control exposes one mutually exclusive select:
 | `access_mode` | UI label | Share route | Read rule | Conditional UI |
 | --- | --- | --- | --- | --- |
 | `private` | Private | Disabled | Existing canonical `/show/` resource access only | No email editor or share-link controls |
-| `limited` | Limited access | `/p/<share>/` | Current, page-bound exact-email grant, or `ShowEditorCapability` | Exact-email editor and share-link controls |
+| `limited` | Limited access | `/p/<share>/` | Current, page-bound exact-email grant on this shared route, or `ShowEditorCapability` | Exact-email editor and share-link controls |
 | `public` | Fully public | `/p/<share>/` | Anyone; editors may redirect to `/show/` | Share-link controls only |
 
 The separate public-link switch is removed. The exact-email editor exists only
@@ -136,6 +136,15 @@ share-audience control and cannot satisfy the exact-email gate for a limited
 `/p/` request. Only a resource-aware editor may bypass that viewer gate by taking
 the canonical redirect.
 
+The reverse boundary is equally strict: page-email entitlement is an input only
+to the limited `/p/` shared-read gate. It is not general Show Page resource
+authority and must not make `can_use_show_page()` or any equivalent canonical
+resource check succeed. Every `/show/<session>/` document, module, API, and socket
+requires the existing owner/organization resource ACL independently of any
+`show_page_email` claim. A viewer whose only authority is the limited email list
+therefore remains on `/p/` and cannot obtain the private Vite graph by decoding
+their signed page ID and constructing a `/show/` URL.
+
 Only the page owner or existing sharing-control authority may change
 `access_mode`, the email set, or the slug. A page-bound `show_page_email` viewer
 cannot read these settings APIs, mutate the audience, load the Workbench, or
@@ -179,12 +188,12 @@ target or preserved share binding, target commitment, and phase. It never persis
 the email addresses. Before a transition whose target mode is `limited` can add,
 remove, or replace page-email authority, it also sets
 `share_admission_gate=closed_pending` in that transaction. While a limited gate is
-closed, every `/p/` read and editor redirect is denied and the page-email branch of
-the canonical `/show/` ACL rejects claims. Entry into limited commits the conservative
-target mode and preserved `share_id` together with the closed gate; an edit to an
-already limited list leaves that mode and binding intact. Public reads do not depend
-on this limited-only gate.
-Owner and organization resource ACLs on canonical `/show/` remain independent.
+closed, every `/p/` read and editor redirect is denied. Entry into limited commits
+the conservative target mode and preserved `share_id` together with the closed
+gate; an edit to an already limited list leaves that mode and binding intact.
+Public reads do not depend on this limited-only gate. Canonical `/show/` reads are
+always decided by the independent owner/organization resource ACL and never inspect
+page-email entitlement.
 
 The device then asks the backend to `commit` the prepared operation. Commit
 atomically replaces the exact-email set under the expected page `grant_revision`,
@@ -207,10 +216,14 @@ a copied SQLite database or backup exposes no deterministic verifier for guessed
 email addresses.
 If the result copy has expired after commit, the authoritative current page-grant
 read supplies the same commitment and revision proof. An unavailable, ambiguous,
-conflicting, or unpersisted result leaves the durable gate closed. A proven expired
-and uncommitted preparation may restore the prior gate only when the authoritative
-page commitment/revision still equal the recorded source; otherwise the owner must
-resubmit the target. Empty-set cleanup can retry automatically. A periodic
+conflicting, or unpersisted result leaves the durable gate closed. When an edit to
+an already limited audience is proven expired and uncommitted, the coordinator may
+reopen that unchanged limited binding only after the authoritative page
+commitment/revision equal the recorded source. An entry from `private` or `public`
+to `limited` never attempts to reconstruct its overwritten source mode or binding:
+an expired uncommitted entry remains limited with the gate closed and requires a
+new owner Apply. The owner may resubmit the limited target or explicitly choose a
+different audience. Empty-set cleanup can retry automatically. A periodic
 page-grant revision poll is recovery evidence, never the security boundary.
 
 The coordinator applies that invariant to every transition:
@@ -227,16 +240,16 @@ The coordinator applies that invariant to every transition:
    replacement. Removed and retained viewers are both denied during ambiguity;
    the reconciled revision reopens the new set together.
 4. Leaving `limited` commits `private` or `public` locally with
-   `share_admission_gate=open`. Page-email
-   claims are accepted only when the current durable mode is exactly `limited`,
-   so the local commit removes their authority from both `/p/` and `/show/`
-   before best-effort backend cleanup. Failed cleanup is retried and surfaced as
-   pending but cannot restore authority or make a committed public page unavailable.
+   `share_admission_gate=open`. Page-email claims are accepted only by `/p/` and
+   only when the current durable mode is exactly `limited`, so the local commit
+   removes their shared-route authority before best-effort backend cleanup.
+   `/show/` never accepted that authority. Failed cleanup is retried and surfaced
+   as pending but cannot restore authority or make a committed public page unavailable.
 5. Switching `private` and `public` is one local transaction. Link allocation,
    mode, revision, and old-route invalidation commit together.
 
-Every request that considers page-email authority requires active availability,
-current mode `limited`, the current share binding where applicable,
+Every `/p/` request that considers page-email authority requires active availability,
+current mode `limited`, the current share binding,
 `share_admission_gate=open`, and a signed claim `show_page_grant_revision` equal to
 the reconciled local page `grant_revision`. A change to an unrelated Instance ACL
 cannot invalidate an unchanged page grant, while a mutation of this page invalidates
@@ -253,6 +266,31 @@ comparison value only from an authenticated current-grant or committed-operation
 response. Browser input cannot supply either revision. The generic Instance
 authorization watermark remains a separate signed freshness input and never
 substitutes for the page revision.
+
+Limited-link authentication is initiated only after Avibe has resolved the current
+`/p/<share>/` binding to a Show Page. The share handler passes that server-owned
+page ID and binding to the existing login helper explicitly; the helper must not try
+to infer a page ID only from a `/show/` return path, and a browser-supplied `next`
+value can select only a safe return location. The signed OAuth state, the
+single-use server-side handshake record, and the browser-bound handshake cookie all
+carry the resolved page ID, current share binding, and safe `/p/` return target.
+The hosted authorization request receives the page ID from that bound handshake.
+
+A current generic login session does not short-circuit this flow when it lacks a
+current exact grant for the resolved limited page. Avibe performs one page-specific
+reauthorization so the hosted resolver can issue the page-scoped source, page ID,
+and grant revision together. On callback Avibe verifies the signed/state-bound page
+ID and share binding, requires any returned page-email claim to match that page,
+then re-resolves the return `/p/` route and requires it still to map to the same
+active limited page. The ordinary shared-read gate performs the final current mode,
+gate, email, and grant-revision check before returning bytes. A rotated, rebound,
+public, private, offline, unlisted, or stale result receives one generic denial and
+cannot install authority for another page. Completion without a matching page grant
+sets only a one-shot reauthorization-attempted marker that can suppress another
+redirect and produce the generic denial; the marker is never positive authority and
+is stripped from the safe return URL afterward. This is one closed-loop auth
+contract; it applies equally to the normal cookie path and the existing device-bound
+server-side handshake fallback.
 
 ### One editor capability
 
@@ -370,7 +408,7 @@ GET /p/<share>/...
      -> no: shared compatibility representation
 
 GET /show/<session>/...
-  -> existing private Show read ACL
+  -> existing private Show read ACL, evaluated without page-email entitlement
   -> canonical private Vite context
   -> editor-only HMR socket and revocation
 ```
@@ -576,14 +614,13 @@ redirect that selected `/show/`.
 That editor requirement applies to HMR, annotation writes, and the share-link
 redirect, not to ordinary private document and module reads. `/show/` keeps the
 existing owner/organization resource-reader ACL so a read-only collaborator can
-load the complete private module graph without receiving an HMR channel. Its
-page-email branch is narrower: it can authorize a read only while the current local
-mode is `limited`, the share admission gate is open, and the claim's page-scoped
-grant revision is current. A transition to `private` or `public` therefore rejects
-stale page-email cookies on the canonical path even if hosted cleanup fails. A
-downgrade from editor to an
-independently entitled resource viewer closes HMR but does not manufacture a blank
-page by denying modules that viewer is still entitled to read.
+load the complete private module graph without receiving an HMR channel. This ACL
+has no page-email branch: a `show_page_email` claim never authorizes `/show/`, even
+while the page is limited and its shared gate is open. A caller who independently
+holds resource-reader authority may use `/show/`; that decision must be recomputed
+without the page-email entitlement. A downgrade from editor to such an independently
+entitled resource viewer closes HMR but does not manufacture a blank page by denying
+modules that viewer is still entitled to read.
 
 `/p/<share>/__vite_hmr` is removed for every viewer. A redirected editor uses the
 canonical private socket, while every document that remains at `/p/` contains no
@@ -632,9 +669,10 @@ The model adds authorization routing, not a production publication pipeline:
 
 The capability decision adds one redirect round trip for an authorized share-link
 navigation. A public request without a Workbench cookie immediately stays shared.
-A limited request without a session enters the existing login flow; an authenticated
-request uses the current bounded/cached identity resolution and authorization
-revision already used by resource access.
+A limited request without a current page grant enters the page-bound login flow;
+this includes a caller with an otherwise current generic session. The flow reuses
+the existing bounded/cached identity resolution and authorization revision, but its
+signed handshake is explicitly bound to the server-resolved Show Page and share.
 
 After its one redirect, an authorized `/p/` load should have the same cold and
 warm profile as `/show/`.
@@ -673,10 +711,10 @@ request.
 | Runtime emits a development diagnostic or unsafe URL header | Preserve only a safe status class/body and filtered headers | Redacted operator-only diagnostic |
 | Legacy Runtime omits provenance or emits a graph requiring raw `@fs` paths | Preserve only a fully transformed safe success response; otherwise return a fixed path-free unavailable response | Redacted compatibility refusal reason |
 | Limited-list replacement has an ambiguous result | Keep the durable share admission gate closed across retries and restarts until read-after-write reconciliation persists the exact mutation result | Mutation ID, opaque target commitment, and redacted reconciliation state |
-| Prepared email operation expires before commit | Reopen the prior share audience only after authoritative commitment/revision proof that no commit occurred; otherwise remain closed and require target resubmission | Operation expiry and opaque target commitment |
+| Prepared email operation expires before commit | Reopen an already-limited unchanged audience only after authoritative proof that no commit occurred; an entry from private/public stays limited-and-closed and requires a new owner Apply | Operation expiry, source grant proof, and opaque target commitment |
 | Limited email removed | Reject the viewer's next network request by page grant revision; no HMR or annotation channel exists to close | Page-grant revision log |
 | Unrelated Instance authorization changes | Refresh generic session freshness without changing any page grant revision or denying an unchanged limited viewer | Instance and page revision metrics kept distinct |
-| Limited page becomes private/public while hosted cleanup fails | Reject page-email claims on both `/p/` and `/show/` from the local mode commit; keep public reads open and retry cleanup without reopening email authority | Durable audience state and cleanup-pending record |
+| Limited page becomes private/public while hosted cleanup fails | Reject page-email claims on `/p/` from the local mode commit; `/show/` remains governed only by its independent resource ACL; keep public reads open and retry cleanup without reopening email authority | Durable audience state and cleanup-pending record |
 | Audience changes while the page is offline | Keep every route disabled; run the normal coordinator and persist the future audience without temporary publication | Durable audience state and coordinator evidence |
 | Editor role revoked but read ACL remains | Close private HMR; retain entitled private document/module reads; next `/p/` navigation stays shared only if its audience read rule succeeds | Existing authorization-revision/resource-revocation log |
 | Show Page read access revoked | Close private HMR and reject later private document/module reads; `/p/` is re-evaluated independently | Existing resource-revocation log |
@@ -760,9 +798,12 @@ feature, not a prerequisite for capability-gated editor HMR.
    process-shared audience write lease, idempotent no-op and
    mutation-result/current-grant lookup, and the fail-closed access coordinator.
    Retire the independent visibility and email mutation paths after callers migrate.
-4. Make `/p/<share>/` resolve both `limited` and `public`. Add the limited login,
-   mode-scoped exact page-entitlement check on both `/p/` and `/show/`, generic
-   denial, page-grant revision check, and private/no-store response policy.
+4. Make `/p/<share>/` resolve both `limited` and `public`. Add the server-resolved,
+   page-bound limited-login handshake, page-specific reauthorization for a generic
+   session, mode-scoped exact page-entitlement check on `/p/`, generic denial,
+   page-grant revision check, and private/no-store response policy. Remove
+   page-email bypass from canonical Show resource authorization so `/show/` accepts
+   only its independent owner/organization ACL.
 5. Factor annotation authorization into the shared, resource-aware
    `ShowEditorCapability`, explicitly excluding page-email entitlement, and use
    the same result for top-level editor navigation.
@@ -862,14 +903,22 @@ limited route.
   commitment
 - seed every supported identity/resource shape and assert that `canAnnotate` and
   the share-link redirect are produced by the same editor capability
-- prove page-email entitlement can satisfy only limited read, cannot satisfy the
-  editor's resource proof, and cannot access settings, Workbench, Agents,
-  annotations, HMR, or any other Show Page
+- prove page-email entitlement can satisfy only a limited `/p/` shared read, cannot
+  satisfy canonical Show resource access or the editor's resource proof, and cannot
+  access `/show/`, settings, Workbench, Agents, annotations, HMR, or any other Show
+  Page; an independently authorized resource reader still retains `/show/` access
 - prove a real independent page editor still redirects when the same email is
   also listed
 - prove anonymous, expired, resource-forbidden, and unverifiable public
   navigations receive only the shared representation, while equivalent limited
   requests enter login or receive a generic denial with no page bytes
+- drive the real limited-link login from initial `/p/` resolution through OAuth
+  callback and the final shared read: signed state, cookie, and server-side fallback
+  bind the same server-resolved page/share; a listed viewer receives the current
+  page claim, an existing generic session is reauthorized, and rebound or unlisted
+  results receive only the generic denial; extend `AUTH-SETUP-401` in the auth/setup
+  catalog and its Show Page email harness to cover this closed loop rather than only
+  asserting a browser redirect
 - prove query parameters, headers outside the trusted identity boundary,
   annotation write tokens, subresource requests, and missing Fetch Metadata
   cannot trigger the redirect
@@ -904,17 +953,19 @@ limited route.
   local record never contains an email, a preparation never changes authority by
   itself, and the share admission gate stays closed until the exact result reconciles
 - expire prepared and committed-operation result copies, then recover from opaque
-  operation ID, target commitment, and the authoritative page grant revision; reopen the
-  prior audience only after proof that an expired operation did not commit, and
-  require resubmission without persisting removed/failed email PII otherwise
+  operation ID, target commitment, and the authoritative page grant revision;
+  reopen only an unchanged already-limited audience after proof that the operation
+  did not commit, while an entry from private/public remains limited-and-closed
+  until a new owner Apply, without persisting removed/failed email PII
 - advance the Instance-wide authorization revision for every unrelated ACL shape and
   prove an unchanged limited page remains readable, then advance that page's grant
   revision and prove every older page-email claim is rejected
 - crash a public-to-limited transition at every local and hosted boundary; `/p/`
   remains closed during ambiguity and completion preserves the exact original custom
   or generated `share_id`
-- prove a page-email cookie is rejected by both `/p/` and `/show/` immediately after
-  the local mode leaves `limited`, even while backend cleanup is unavailable
+- prove a page-email-only cookie is rejected by `/show/` in every audience mode and
+  by `/p/` immediately after the local mode leaves `limited`, even while backend
+  cleanup is unavailable
 
 ### Runtime and proxy tests
 
@@ -976,7 +1027,7 @@ limited route.
 | --- | --- | --- |
 | `SHOW-LIVE-001` | Authorized editor opens `/p/<share>/` and the Agent edits a component | The navigation redirects to `/show/`; React Fast Refresh preserves component state |
 | `SHOW-LIVE-002` | Exact-email viewer opens a limited link and the Agent edits | The viewer stays on `/p/`, has no annotation UI or HMR socket, and sees new content only after refresh |
-| `SHOW-LIVE-003` | Anonymous viewer opens the limited link, signs in with an unlisted email, then retries | Login returns to the same `/p/` route, which gives a generic denial and no page bytes |
+| `SHOW-LIVE-003` | Anonymous viewer opens the limited link, signs in with an unlisted email, then retries | The handshake stays bound to the server-resolved page and returns to the same `/p/` route, which gives one generic denial with no page bytes or login loop |
 | `SHOW-LIVE-004` | The same link changes from limited to fully public | Anonymous refresh becomes readable; listed viewers still receive no HMR or annotations |
 | `SHOW-LIVE-005` | Direct `/show/`, redirected editor `/show/`, exact-email `/p/`, and anonymous public `/p/` are open together | Both private documents keep HMR while all `/p/` traffic uses an independent shared context |
 | `SHOW-LIVE-006` | Identity resolution fails for public and limited requests | Public remains readable with no HMR; limited fails closed without leaking its audience |
@@ -985,7 +1036,7 @@ limited route.
 | `SHOW-LIVE-009` | A viewer connects directly to `/p/<share>/__vite_hmr` | The connection is rejected regardless of cookies or visibility |
 | `SHOW-LIVE-010` | Editor and shared viewers remain open through repeated edits | Context and leased-namespace counts stay bounded, private HMR remains stable, and no shared background build occurs |
 | `SHOW-LIVE-011` | A shared document starts while identity is unavailable and identity recovers during module loading | Every module stays on `/p/`; no Vite client or mixed transform graph appears |
-| `SHOW-LIVE-012` | A read-only user opens `/show/<session>/` | The complete private module graph loads, while the HMR socket is denied |
+| `SHOW-LIVE-012` | A read-only user with independent Show resource ACL opens `/show/<session>/` | The complete private module graph loads, while the HMR socket is denied |
 | `SHOW-LIVE-013` | Shared content registers a share-scoped Service Worker, then the editor opens the link | No private bytes are served at `/p/`; any network-reached redirect lands outside the worker scope at `/show/`, and cached old bytes are recorded as a client-cache limitation |
 | `SHOW-LIVE-014` | Avibe runs against a Runtime without `show-context-key-v1` | Every `/p/` viewer stays on the compatibility no-HMR path; the existing single-context limitation is explicit and cannot be mistaken for negotiated isolation |
 | `SHOW-LIVE-015` | The first capability probe times out while the new Runtime app endpoint is ready | The request carries `shared` and succeeds, a later bounded retry detects support, and the next eligible navigation redirects without restart |
@@ -995,7 +1046,7 @@ limited route.
 | `SHOW-LIVE-019` | Public changes to limited and the cloud write fails | The target limited mode and original binding remain durable with the gate closed; neither anonymous nor stale listed viewers can read until reconciliation succeeds |
 | `SHOW-LIVE-020` | Old private/public/offline rows and exact-email grants upgrade | Each page matches the migration table; a disconnected private-with-grants page stays private and pending |
 | `SHOW-LIVE-021` | A live limited-list replacement commits remotely, its response is lost, and Avibe restarts | All page-email reads remain closed until the mutation result and revision reconcile; removed viewers never regain access |
-| `SHOW-LIVE-022` | Limited changes to private while hosted cleanup is unavailable | A stale page-email cookie is rejected on both `/p/` and `/show/`; independent resource collaborators retain their canonical access |
+| `SHOW-LIVE-022` | Limited changes to private while hosted cleanup is unavailable | A stale page-email cookie is rejected on `/p/`; `/show/` continues to reject page-email-only authority while independent resource collaborators retain canonical access |
 | `SHOW-LIVE-023` | A legacy Runtime returns an unclassified transform error and a nested raw `/@fs/` import | Both responses fail closed with fixed path-free output; no host path or diagnostic reaches the browser |
 | `SHOW-LIVE-024` | An allowed source is replaced by a sensitive symlink after an opaque handle is issued | The issued handle returns only immutable captured bytes, and the changed path cannot receive a new handle |
 | `SHOW-LIVE-025` | A disconnected private-page migration is pending, then the owner chooses public and later private before reconnecting | The newer revision cancels migration; reconnect cannot allocate a slug, commit limited, or restore the old email audience |
@@ -1004,12 +1055,14 @@ limited route.
 | `SHOW-LIVE-028` | Anonymous clients keep shared pages active across more Sessions than the Runtime-wide budget | Context and memory stay under the hard limit, reclaimable shared bundles rotate, private HMR keeps its reserve, and excess shared admission is sanitized |
 | `SHOW-LIVE-029` | Limited changes to public while hosted empty-set cleanup remains unavailable | Anonymous reads start from the committed public binding, stale listed claims stay rejected, and cleanup retries do not close the public route |
 | `SHOW-LIVE-030` | A released Avibe client starts a new Runtime and sends only `x-vibe-show-base` | Entry, module, and prewarm requests retain the legacy singleton behavior; keyed isolation remains disabled until a protocol-`1` client supplies context |
-| `SHOW-LIVE-031` | A limited-list Apply crashes at every prepare/local/commit boundary and later exceeds operation retention | No local row contains an email, prepare alone never changes grants, committed state reconciles by page commitment/revision, and the prior audience reopens only after proof that an expired operation did not commit |
+| `SHOW-LIVE-031` | An already-limited list Apply crashes at every prepare/local/commit boundary and later exceeds operation retention | No local row contains an email, prepare alone never changes grants, committed state reconciles by page commitment/revision, and the unchanged limited audience reopens only after proof that an expired operation did not commit |
 | `SHOW-LIVE-032` | An offline page changes from limited to private, then prepares a future public custom slug | No route is admitted while offline; grant cleanup and the future audience converge without temporary activation |
 | `SHOW-LIVE-033` | An unrelated Instance ACL change advances the global authorization revision while a limited list is unchanged | Refreshed listed viewers remain readable at the same page grant revision; changing that page's list advances only its grant revision and rejects older claims |
-| `SHOW-LIVE-034` | A custom-slug public page crashes at every boundary while changing to limited | Every ambiguous `/p/` read is denied, and successful recovery preserves the exact slug without rotating or losing the route |
+| `SHOW-LIVE-034` | A custom-slug public page crashes at every boundary while changing to limited | Every ambiguous `/p/` read is denied, successful recovery preserves the exact slug, and a proven uncommitted expiry stays limited-and-closed until a new owner Apply |
 | `SHOW-LIVE-035` | An authorized editor uses `/p/` with a definitive legacy Runtime | The editor remains on the shared compatibility representation with annotations enabled, no HMR socket, and no private module namespace |
 | `SHOW-LIVE-036` | An attacker obtains local state for a limited page with a small email set | The stored random commitment provides no offline email-guess verifier; only the hosted trust boundary can bind it to the canonical set |
+| `SHOW-LIVE-037` | A listed viewer with only a generic session opens a limited `/p/` link and completes login | Avibe reauthorizes against the server-resolved page, validates the same page/share on callback, and serves only the shared representation with the current page grant |
+| `SHOW-LIVE-038` | A page-email-only viewer copies its signed page ID and requests `/show/<session>/` while the page remains limited | Canonical document, module, API, and HMR requests are denied; the claim remains usable only through the current limited `/p/` gate |
 
 Focused unit/contract tests, Ruff, repository CI, and local Incus browser
 regression are required. Green unit tests do not replace simultaneous editor,
@@ -1027,14 +1080,22 @@ The design is implemented when all of the following are true:
   exact page grant and fully public remains anonymously readable.
 - Page-email authority is view-only and cannot contribute evidence to
   `ShowEditorCapability`, settings, Workbench, Agents annotations, HMR, or another
-  Show Page. It authorizes page reads only while current mode is `limited`, the
-  durable share admission gate is open, and its signed page grant revision is
-  current; the Instance-wide revision is not used as that page-set version.
+  Show Page. It authorizes only `/p/` shared reads while current mode is `limited`,
+  the durable share admission gate is open, the share still resolves to that page,
+  and its signed page grant revision is current. It never contributes to canonical
+  `/show/` resource access; the Instance-wide revision is not used as the page-set
+  version.
+- A limited-link OAuth handshake is created from the server-resolved page/share,
+  carries that binding through signed state plus both handshake recovery paths,
+  reauthorizes an otherwise generic session, and validates the current binding again
+  on callback and before serving bytes.
 - Every grant-set mutation is prepared without changing authority, then closes a
   persistent non-PII local share admission gate before commit and reopens it only
   after idempotent read-after-write reconciliation; an ambiguous response, restart,
   or expired operation cannot leave stale grants usable, email targets on disk, or
-  a share binding lost.
+  a share binding lost. An expired uncommitted entry from private/public remains
+  limited-and-closed until a new owner Apply rather than guessing the overwritten
+  source audience.
 - Every current-version local audience writer uses one stable process-shared write
   lease from its authoritative precondition read through a terminal or durably
   pending state; store writes cannot bypass the lease, and local grant commitments
@@ -1054,8 +1115,9 @@ The design is implemented when all of the following are true:
 - Capability-varying responses cannot be shared across viewers by a cache.
 - Shared Service Workers cannot cache private bytes at `/p/` or control `/show/`;
   server-side revocation claims are limited to requests that reach Avibe.
-- Ordinary private module reads preserve resource-viewer access while HMR remains
-  editor-only.
+- Ordinary private module reads preserve independently authorized resource-viewer
+  access while HMR remains editor-only; page-email-only viewers are never private
+  resource viewers.
 - Runtime support is accepted only through the explicit keyed-context capability
   handshake and per-request protocol envelope; definitive mixed versions retain the
   existing compatibility limitation, while transient negotiation failures carry

--- a/docs/plans/public-show-live-update.md
+++ b/docs/plans/public-show-live-update.md
@@ -9,26 +9,36 @@ Scope: `avibe` public Show proxy and `vibe-show-runtime`
 ## Decision
 
 Public Show Pages remain live. Making a page public must not turn it into a
-snapshot or require a viewer to refresh it manually.
+manually refreshed snapshot, but an anonymous browser must not become a client
+of the mutable Vite development server either.
 
-The two surfaces use different update protocols because they have different
-trust boundaries:
+The two surfaces therefore use different publication models:
 
-| Surface | Viewer trust | Update behavior | Runtime protocol exposed to the browser |
+| Surface | Viewer trust | Content source | Update behavior |
 | --- | --- | --- | --- |
-| Private `/show/<session>/` | Authenticated and authorized | Vite HMR and React Fast Refresh | Full Vite HMR |
-| Public `/p/<share>/` | Anonymous read access | Automatic full-page Live Reload after a renderable revision | Avibe revision SSE only |
+| Private `/show/<session>/` | Authenticated and authorized | Canonical Vite development context | Vite HMR and React Fast Refresh |
+| Public `/p/<share>/` | Anonymous read access | Last atomically activated public artifact | Automatic full-page Live Reload |
 | Offline | No live page | None | None |
 
-The public browser must never receive the raw Vite HMR protocol. It receives a
-small, one-way, path-free revision notification and reloads the document. This
-keeps the public page current without making Vite's development control channel
-part of Avibe's anonymous product API.
+For a concrete example, suppose the public page imports `renderChart` from
+`chart.ts`, and an Agent removes that named export while changing another file:
 
-This is deliberately called **Live Reload**, not HMR. Public viewers get the
-updated page automatically, but a reload does not preserve arbitrary component
-or application state. Private authors keep Fast Refresh and its state-preserving
-developer experience.
+1. Private HMR may show the author the normal Vite diagnostic.
+2. Runtime builds the complete public entry graph into a staging directory.
+3. Rollup linking fails because the import no longer exists.
+4. Runtime discards the candidate and keeps serving the previous activated
+   artifact to every public viewer.
+5. After the Agent repairs the export, a complete build succeeds, Runtime
+   atomically activates it, and public viewers reload automatically.
+
+The public browser receives neither raw Vite HMR nor mutable development
+modules. It receives an opaque active-artifact notification over a small,
+one-way Server-Sent Events (SSE) contract and reloads the public document when
+the artifact changes.
+
+This is deliberately called **Live Reload**, not HMR. A public reload does not
+preserve arbitrary component or application state. Private authors retain Fast
+Refresh and its state-preserving development experience.
 
 ## Why This Is Needed
 
@@ -41,372 +51,469 @@ The current implementation contains two conflicting contracts:
   `/p/<share>/__vite_hmr` socket.
 
 The shims were introduced by `8dc1319eb` (`fix(show): stabilize public runtime
-modules`). They solved a real stabilization problem and explicitly prevented an
-anonymous Vite socket, but they also disabled public live updates. That behavior
-became an accidental product policy while the design documents continued to
-promise a live public page.
+modules`). They prevented an anonymous Vite socket, but also disabled public
+live updates. That implementation detail accidentally became product behavior.
 
-There is also a deeper runtime ownership problem. The sidecar currently keys an
-active Vite context by both `session_id` and the external base path. Alternating
-requests from `/show/<session>/` and `/p/<share>/` can therefore close and rebuild
-the same Session's Vite server as its base path changes. A private author and a
-public viewer should be able to use the page concurrently without restarting
-each other's runtime.
+There is also a deeper ownership problem. The sidecar currently keys an active
+Vite context by both `session_id` and an external base path. Alternating private
+and public requests can close and rebuild the same Session's Vite server as the
+base changes. More importantly, transforming individual modules in that mutable
+context cannot establish a stable public revision: static linking, stylesheet
+asset URLs, and the document-to-stream baseline can each disagree even when the
+individual transforms succeeded.
+
+The public publication boundary must therefore be a complete, immutable build,
+not a momentary observation of the development module graph.
 
 ## Product Contract
 
-Visibility and update transport are separate capabilities:
+Visibility, publication, and update transport are distinct capabilities:
 
-- `public` controls who may read the rendered page.
+- `public` controls who may read the activated public artifact.
 - authorization controls who may annotate, dispatch, or use private tools.
+- the public artifact controls which frontend version an anonymous viewer gets.
 - the surface trust boundary controls which update protocol is exposed.
 
-For a concrete example, an Agent edits `src/App.tsx` while an anonymous viewer
-has `/p/brief/` open:
+The last successfully activated artifact is the public page's last-known-good
+version. A candidate becomes visible only after its complete frontend build and
+static module linking succeed. Candidate files are never served in place.
 
-1. Vite invalidates the affected module graph.
-2. Show Runtime waits for the write burst to settle and validates the affected
-   graph.
-3. If validation succeeds and no newer write superseded it, Runtime commits the
-   next in-memory revision.
-4. Avibe relays only `{epoch, revision}` to the public browser.
-5. The browser reloads `/p/brief/` and renders the new source.
-
-If validation fails, the existing public document stays visible. The private
-author still receives normal Vite diagnostics. The public viewer receives no
-stack, source path, plugin name, source frame, or error text.
+This guarantee is intentionally precise. It prevents syntax, import/export
+linking, asset-graph, and build-plugin failures from replacing a working public
+page. A successful static build cannot prove that arbitrary application logic
+will not throw in a real browser. Browser canary execution would be required for
+that stronger guarantee and is not part of this change.
 
 ### User-visible requirements
 
-1. An idle, visible public page reloads within 2 seconds in local regression
-   after the last edit of a renderable write burst.
-2. A failed transform does not replace an already-rendered public page with an
-   error overlay or a blank page.
-3. Once the source becomes renderable again, the next revision reloads the
-   public page without manual action.
-4. A hidden tab records a pending revision and reloads when it becomes visible.
-5. A revision received while a text input, textarea, select, or editable element
-   is active waits for blur, with a 30-second upper bound. This limits avoidable
-   loss of in-progress public interaction without allowing a stale page to wait
-   forever.
-6. Public Live Reload is best effort when the runtime or connection is
-   unavailable. The rendered page remains usable and the client reconnects with
-   bounded backoff.
+1. An idle, visible public page reloads automatically after the latest valid
+   write burst has been built and activated.
+2. A failed public build does not replace an activated page with an error
+   overlay, partial graph, or blank document.
+3. Once the source builds again, the next activated artifact reloads the page
+   without manual action.
+4. A hidden tab records a pending artifact and waits without a deadline until it
+   becomes visible.
+5. Once visible, a pending reload waits while a text input, textarea, select, or
+   editable element is active, but for at most 30 seconds of visible editable
+   time. Visibility takes precedence over this deadline.
+6. Public Live Reload is best effort while Runtime or SSE is unavailable. The
+   activated page remains usable and the client reconnects with bounded backoff.
+7. The first public request after a cold Runtime or after public visibility is
+   enabled may wait for one initial build. Once an artifact is active, ordinary
+   page loads do not wait for a build.
 
 ## Architecture
 
 ```text
 Agent file write
-  -> one canonical Vite context for the Session
-  -> affected-graph validation + revision producer
-  -> internal revision SSE (loopback sidecar API)
+  -> canonical private Vite development context (private HMR only)
+  -> demand-active public artifact builder
+  -> complete Vite production build in staging
+  -> generation check + atomic artifact activation
+  -> loopback active-artifact stream
   -> Avibe public share/visibility gate and SSE relay
   -> small public live client
   -> location.reload()
 
-Private browser
-  -> authenticated /show/<session>/__vite_hmr
-  -> raw Vite HMR for the same canonical Vite context
+Public browser
+  -> /p/<share>/ document and relative artifact assets
+  -> never reads canonical /show/<session>/ development modules
 ```
 
-### One canonical runtime base
+### Private runtime ownership
 
-Each Session has one Vite context with a canonical base:
+Each Session has at most one Vite development context. It is keyed by
+`session_id` and uses the canonical private base:
 
 ```text
 /show/<session-id>/
 ```
 
-The Vite context is keyed by `session_id`, not by an external share URL. Public
-HTTP responses continue to rewrite canonical `/show/<session>/...` URLs to
-`/p/<share>/...` at the Avibe boundary. Public requests no longer send the share
-base as `x-vibe-show-base`, and rotating a share link does not restart Vite.
+Only the authenticated private surface reads that context and its HMR channel.
+Public requests no longer send a share-specific `x-vibe-show-base`, do not
+change the Vite base, and cannot restart the private development context.
 
-This invariant is required before Live Reload is enabled. Otherwise concurrent
-private and public traffic can repeatedly change the Vite epoch and make both
-update paths unreliable.
-
-### Ownership
+### Public artifact ownership
 
 `vibe-show-runtime` owns:
 
-- Vite invalidation and transform state
-- the renderable-revision decision
-- the per-Session `{epoch, revision}` counter
-- the loopback-only revision stream
+- coalescing Vite-relevant workspace invalidations
+- complete public frontend builds
+- staging, validation, activation, retention, and cleanup of public artifacts
+- the opaque active-artifact identifier
+- the loopback-only artifact stream and artifact file endpoint
 
 `avibe` owns:
 
-- public share resolution and visibility checks
+- public share resolution and durable visibility checks
 - public origin and host policy
-- revocation when a share rotates or leaves `public`
-- the redacted public SSE contract
-- the small public browser client
+- injection of request-specific public document configuration
+- the gated public artifact proxy
+- the redacted public SSE contract and browser client
+- bounded revocation when a share rotates or leaves `public`
 
 The existing Show event stream remains separate. Show events are durable product
-events with replay and authorization semantics. Runtime revisions are ephemeral
-render state. Combining them would make one stream own two unrelated retention
-and failure models.
+events with replay and authorization semantics. Artifact activations are
+ephemeral render state. Combining them would make one stream own unrelated
+retention, redaction, and failure models.
 
-## Renderable Revision Model
+### Demand and cold start
 
-A revision is not emitted for every filesystem event. Runtime maintains a
-generation token and follows this sequence:
+Public builds are demand-active rather than running for every private Session:
 
-1. A Vite-relevant invalidation increments the candidate generation and records
-   the affected module URLs.
-2. Runtime waits for a 250 ms quiet window and coalesces the burst.
-3. Runtime transforms the affected first-party module graph. A Vite full-reload
-   invalidation also validates the entry graph.
-4. If any required transform fails, Runtime records a private diagnostic and
-   emits no revision.
-5. If another invalidation arrived during validation, Runtime discards the stale
-   result and validates the newer generation.
-6. Only a successful, still-current validation increments `revision` and emits
-   one notification.
+- A public document request asks Runtime to ensure an artifact for the current
+  workspace generation. Concurrent requests join the same build.
+- An open public SSE subscriber holds demand for its Session, so later edits are
+  built without waiting for another HTTP request.
+- With no public demand, Runtime may stop building. The next public request
+  catches up to the latest generation before returning the document.
+- If a previous artifact exists and a catch-up build fails, Runtime serves that
+  artifact. If no artifact has ever activated, Avibe returns the existing
+  sanitized generating/unavailable shell and retries on a later request; it
+  never falls back to development modules.
 
-The validator must fail closed for a required first-party module. Dependencies
-already resolved from the immutable shared vendor bundle do not need to be
-revalidated on every edit.
+This keeps private-only editing costs unchanged while ensuring a fresh public
+viewer cannot observe a partially edited source tree.
 
-This contract improves the experience for an already-open public page, but it is
-not an atomic publishing system. Source files remain mutable on disk, and there
-is no durable last-known-good artifact. A fresh viewer can still arrive while the
-workspace is temporarily broken. Guaranteeing atomic public releases would
-require a separate build-and-snapshot publishing model and is outside this
-change.
+## Atomic Artifact Model
 
-## Revision Stream Contract
+Runtime maintains a candidate generation for each Session and follows this
+sequence:
 
-The sidecar adds a loopback-only endpoint:
+1. A frontend-relevant invalidation increments the candidate generation.
+2. Runtime waits for a 250 ms quiet window and coalesces the write burst.
+3. Runtime allocates a new opaque artifact identifier and builds the complete
+   frontend entry graph into a staging directory outside the workspace.
+4. The build uses Vite's production build and Rollup linking, disables source
+   maps, excludes development HMR/React Refresh clients, and emits content-hashed
+   files with relative asset references.
+5. Runtime rejects the candidate if the build, link, or any required first-party
+   asset resolution fails. Output validation also rejects canonical private URL
+   references in emitted HTML, JavaScript, and CSS, including CSS `url(...)`.
+6. If another invalidation arrived during the build, Runtime discards the stale
+   output and schedules the newest generation.
+7. Runtime moves the complete staging directory into immutable artifact storage,
+   then atomically replaces the active pointer only if the generation is still
+   current.
+8. Only pointer activation emits one artifact notification.
+
+The active artifact and its files are immutable. Runtime retains the active and
+immediately previous artifact; older inactive artifacts are cleaned up after no
+response or stream still references them. A process restart may rebuild the
+same source into a new opaque identifier, which causes at most one public reload.
+Artifacts are Runtime cache, not durable product history.
+
+Relative output is part of the contract. Avibe serves the same artifact beneath
+the current `/p/<share>/` path and injects a matching document `<base>` plus
+public configuration. HTML module references, JavaScript chunks, imported CSS,
+and CSS `url(...)` references therefore resolve through the gated share path and
+contain neither `/show/<session>/` nor a previous share ID. Rotating a share does
+not require rebuilding the artifact.
+
+Public `api/` handlers remain permissioned live server code and are not bundled
+into the frontend artifact. Relative public API requests continue through the
+existing Avibe gate. A handler-only edit does not require a frontend reload.
+
+## Artifact Stream Contract
+
+The sidecar adds loopback-only endpoints:
 
 ```text
-GET /sessions/<session-id>/revisions?stream=1
+GET /sessions/<session-id>/public-artifact?ensure=current
+GET /sessions/<session-id>/public-artifacts/<artifact-id>/<path>
+GET /sessions/<session-id>/public-artifacts?stream=1
 ```
 
 The public Avibe surface exposes:
 
 ```text
-GET /p/<share-id>/__show/revisions
+GET /p/<share-id>/__show/artifacts
 ```
 
 The public endpoint is a terminating relay, not a byte-for-byte proxy. It parses
-the internal contract and serializes the public allowlist.
+the internal contract and serializes only the public allowlist.
 
-Initial state:
+Every served public document contains the identifier of the exact artifact from
+which its HTML was read:
+
+```html
+<script>
+  globalThis.__AVIBE_SHOW__ = { basePath: "/p/brief/", artifact: "art_7f42" }
+</script>
+```
+
+The real value is serialized with the existing safe configuration-injection
+mechanism; the example is illustrative, not an inline-string implementation.
+
+Initial stream state:
 
 ```text
 event: ready
-data: {"protocol":1,"epoch":"rte_7f42","revision":12}
+data: {"protocol":1,"artifact":"art_7f42"}
 
 ```
 
-Committed update:
+Activated update:
 
 ```text
-id: rte_7f42:13
-event: revision
-data: {"protocol":1,"epoch":"rte_7f42","revision":13}
+id: art_91ac
+event: artifact
+data: {"protocol":1,"artifact":"art_91ac"}
 
 ```
 
 Contract rules:
 
 - `protocol` is the schema version and is currently `1`.
-- `epoch` is an opaque random identifier for one active Vite context.
-- `revision` is a monotonically increasing integer inside the epoch.
+- `artifact` is an opaque identifier for one immutable activated build.
+- Equality is the only browser operation on `artifact`; ordering is unnecessary.
 - The payload contains no Session ID, share ID, module URL, filesystem path,
-  source code, error, or plugin data.
+  source code, error, plugin name, or source frame.
 - Keepalives are SSE comment frames and carry no data.
-- A new subscriber receives exactly one `ready` event with the current state;
-  revision history is not persisted.
+- A new subscriber receives exactly one `ready` event with the current active
+  artifact. Artifact history is not replayed.
+- The document uses `Cache-Control: no-store`; hashed artifact files may use
+  immutable caching while the share remains authorized.
 
-The Runtime health/status payload advertises revision-stream capability so Avibe
-can stage the runtime release before activating the public client. An older
-runtime yields a closed/no-content public stream; it never falls back to raw
-public HMR.
+Embedding the artifact in the document closes the initial-subscription race. If
+activation occurs after HTML is served but before the first `ready`, the two
+identifiers differ and the client reloads. The first `ready` is never accepted
+as an unverified baseline.
+
+Runtime health advertises artifact protocol v1 so Avibe can stage the Runtime
+release before enabling the client. An older Runtime yields a closed/no-content
+stream and never falls back to raw public HMR.
 
 ## Public Client State Machine
 
-The existing public `@vite/client` replacement becomes a small versioned live
-client while retaining no-op HMR exports required by transformed modules.
-`@react-refresh` remains inert on the public surface.
+The public document loads a small versioned live client. Public production
+artifacts contain no Vite HMR imports, so the client does not need to emulate
+the Vite protocol. It runs once per document:
 
-The live client runs once per document:
+1. Read `basePath` and the document's `artifact` from the injected configuration.
+2. Open `<basePath>__show/artifacts` with `EventSource`.
+3. Compare both `ready` and later `artifact` events with the document artifact.
+   Equal means current; different means a reload is pending.
+4. Keep only the newest pending identifier. A later event does not reset any
+   active editable-control deadline.
+5. If the document is hidden, wait without starting or advancing the 30-second
+   editable deadline.
+6. When visible, reload immediately unless an editable control is active. While
+   visible and editable, reload on blur or after 30 accumulated seconds. If the
+   document becomes hidden, pause the deadline; visibility remains dominant.
+7. Set an in-memory reload guard immediately before `location.reload()`. The new
+   no-store document carries its own artifact and performs the same equality
+   handshake, preventing a persistent reload loop.
+8. On stream failure, close the failed `EventSource` and reconnect with capped
+   exponential backoff. Stop after six consecutive failures and resume on
+   `online` or a later visibility transition.
 
-1. Read `globalThis.__AVIBE_SHOW__.basePath` and open
-   `<basePath>__show/revisions` with `EventSource`.
-2. Keep the current `{epoch, revision}` as an in-memory baseline for this
-   document.
-3. Treat the first `ready` as the baseline without an unnecessary reload.
-4. On a greater revision, or an epoch change after that baseline, update the
-   in-memory baseline before reloading. The new document also treats its first
-   `ready` as a baseline, so no persisted reload marker or reload loop exists.
-5. If the document is hidden or an editable control is active, mark the reload
-   pending and apply it on visibility/focus release, subject to the 30-second
-   bound.
-6. On stream failure, close the failed `EventSource` and reconnect with capped
-   exponential backoff. Stop after six consecutive failures; resume on `online`
-   or a later visibility transition.
-
-The client shows no public error overlay. Connection and validation diagnostics
+The client displays no public error overlay. Build and connection diagnostics
 belong in private Runtime/Avibe logs.
 
-## Security Boundary
+## Security and Revocation Boundary
 
-Opening private HMR unchanged on a public page is not acceptable because the
-current route is a bidirectional proxy into Vite. Depending on installed Vite
-plugins, client `custom` messages can reach server listeners, and development
-error payloads can contain stack traces, source frames, plugin code, and local
-paths. The Vite wire protocol is also an implementation detail that can change
-with a Runtime release.
+Raw Vite HMR is not acceptable on a public page because the current route is a
+bidirectional proxy into a development server. Client `custom` messages can
+reach installed plugin listeners, and development diagnostics can contain local
+paths, stack traces, source frames, and plugin code.
 
-The public revision endpoint therefore enforces all of the following:
+Every public document, artifact-file, API, and SSE request therefore resolves
+the share against the durable `ShowPageStore` and requires that it currently
+maps to the Session with `public` visibility. The SSE relay additionally:
 
-- the share exists, currently maps to the requested Session, and is `public`
-- the request uses an allowed public host and an exact same-origin browser
-  origin when an `Origin` header is present
-- no browser cookies, authorization headers, CSRF headers, or query credentials
-  are forwarded to the sidecar
-- the connection closes when the share rotates or visibility changes
-- only `ready` and `revision` payloads matching protocol v1 are relayed
-- subscriber queues retain at most the latest pending revision
-- responses use `Cache-Control: no-store`, `Content-Type: text/event-stream`,
+- revalidates durable share state at connection time, before forwarding an
+  artifact event, and on every keepalive interval of at most 5 seconds
+- closes immediately on an in-process share/visibility broker event when one is
+  available
+- closes within 5 seconds even when `vibe show update` changed the store from a
+  different process and no in-memory broker event exists
+- requires an allowed public host and exact same-origin browser origin when an
+  `Origin` header is present
+- forwards no cookies, authorization headers, CSRF headers, or query credentials
+  to Runtime
+- accepts only protocol-v1 `ready` and `artifact` payloads
+- retains at most the latest pending artifact per subscriber
+- responds with `Cache-Control: no-store`, `Content-Type: text/event-stream`,
   `X-Accel-Buffering: no`, and `Referrer-Policy: no-referrer`
 
 The anonymous `/p/<share>/__vite_hmr` route is removed. Private
-`/show/<session>/__vite_hmr` keeps its existing authentication, origin,
+`/show/<session>/__vite_hmr` keeps its authentication, origin,
 authorization-revision, and resource-revocation checks.
+
+Revocation cannot erase bytes an anonymous browser already downloaded or cached;
+it prevents new authorized reads and bounds how long an existing live stream can
+remain attached. That is the same unavoidable limit as any public web response.
 
 ## Performance Model
 
-The current public shim payload is about 1.3 KB decoded. Loading the real Vite
-client and React Refresh on the sampled regression page added about 60.9 KB
-compressed and about 291.8 KB decoded, both from no-cache development modules.
-Those figures are a measured reference, not a permanent protocol guarantee.
+The cost model has three distinct cases:
 
-The selected model has these budgets:
+| Case | Cost |
+| --- | --- |
+| Normal public page load with an active artifact | Static hashed files plus one small asynchronous SSE client; no build on the request path |
+| Valid edit while public demand exists | One coalesced production build per Session, one atomic activation, then one full reload per viewer |
+| First public request with no current artifact | One joined initial build before the document can be served |
+
+Budgets and invariants:
 
 - public live client: at most 3 KB gzip
-- no real Vite client or React Refresh runtime on `/p/`
-- SSE connection starts after the module script executes and does not block the
-  initial render
-- one validation per Session write burst, independent of public viewer count
-- no per-viewer Vite WebSocket or per-viewer module-graph validation
-- immutable shared vendor assets remain cached across a full reload
+- no Vite client, React Refresh runtime, source map, or public HMR socket
+- one build per Session write burst, independent of viewer count
+- no public build while a private-only Session has no public demand
+- active hashed assets remain cacheable across document reloads
+- active plus previous artifact bounds steady-state artifact retention
+- build work is cancellable by generation and never runs concurrently for the
+  same Session
 
-Initial public page load should therefore not become materially slower. It adds
-one small client and one asynchronous SSE handshake. An update is heavier than
-private HMR because it reloads the document and first-party modules, but shared
-vendor modules remain cached. That is the intentional cost of keeping the public
-protocol small, stable, and read-only.
+An activated public page should not load slower because Live Reload is enabled:
+the SSE connection starts after the module script and does not block rendering.
+The model does add CPU and update latency compared with transform-only HMR, and a
+cold first public request can wait for a build. Local Incus measurements must set
+the final starter-page activation budget; the design does not claim a universal
+2-second bound before measuring representative pages.
 
 ## Failure Behavior
 
 | Failure | Public behavior | Private/operator evidence |
 | --- | --- | --- |
-| Transform or syntax error | Keep current rendered document; emit no revision | Normal Vite/Runtime diagnostic |
-| Runtime unavailable | Keep page; bounded reconnect | Runtime health/logs |
-| SSE interrupted | Compare `ready` against stored revision after reconnect | Connection metric/log |
-| Share rotated/private/offline | Close stream; old public URL cannot reconnect | Visibility/resource event |
-| New invalidation during validation | Discard stale result; validate latest generation | Debug metric only |
-| Runtime context restarted | New epoch; existing client reloads once | Runtime lifecycle log |
+| Syntax, import/export, asset, or build-plugin failure | Keep active artifact; activate nothing | Vite build/Runtime diagnostic |
+| Arbitrary runtime exception after a successful build | Browser may fail; no stronger guarantee without a canary | Browser telemetry or manual regression |
+| New invalidation during a build | Discard stale candidate; build latest generation | Debug metric only |
+| Runtime unavailable | Keep loaded page; bounded reconnect | Runtime health/logs |
+| SSE interrupted | Compare reconnecting `ready` with the document artifact | Connection metric/log |
+| Share rotated/private/offline | Reject new reads; close stream immediately or within 5 seconds | Durable visibility state and relay log |
+| Runtime restarted | Reuse a valid cached artifact or rebuild; a new ID reloads once | Runtime lifecycle log |
+| Initial build fails with no active artifact | Sanitized unavailable/generating shell; no development fallback | Private build diagnostic |
 
 ## Rejected Alternatives
 
 ### Expose private Vite HMR on `/p/`
 
-This gives the fastest update and preserves React state, but exposes a
-bidirectional development protocol, diagnostics, version coupling, and a Vite
-socket per anonymous viewer. Filtering enough of Vite to make that protocol safe
-would create a second partial HMR implementation that remains coupled to Vite.
+This is fastest and preserves React state, but exposes a bidirectional
+development protocol, diagnostics, version coupling, and one Vite socket per
+anonymous viewer. Filtering Vite deeply enough would create a second partial HMR
+implementation that remains coupled to Vite internals.
+
+### Publish a transform-validated mutable graph
+
+Transforming affected modules is cheaper than a build, but cannot validate
+static linking across unchanged importers, cannot make the served document and
+first SSE baseline atomic, and still requires response rewriting for JavaScript,
+HTML, and stylesheet asset URLs. It has no stable unit to retain as
+last-known-good. These are properties of the model, not isolated proxy bugs.
 
 ### Poll the public document
 
-Polling is simple but creates traffic while nothing changes, adds update latency,
-and still needs a revision/ETag source. A push stream has a smaller idle cost and
-a clearer state model.
+Polling creates traffic while nothing changes, adds update latency, and still
+needs an authoritative artifact identifier. SSE has a smaller idle cost and a
+clearer equality handshake.
 
-### Put revisions on the durable Show event stream
+### Put artifacts on the durable Show event stream
 
 This reuses a connection but conflates ephemeral compilation state with durable
 human/assistant events and their replay, storage, redaction, and dispatch rules.
 The apparent transport reuse creates a larger conceptual system.
 
-### Build and publish immutable snapshots after every write
+### Run a browser canary before every activation
 
-Snapshots could provide atomic publication and a durable last-known-good page,
-but they introduce build artifacts, retention, activation, rollback, and storage
-policy. That is a separate publishing capability, not the smallest complete fix
-for live public viewing.
+A canary can catch some runtime exceptions that a static build cannot, but adds
+a browser lifecycle, readiness protocol, timeout policy, side-effect isolation,
+and substantially higher edit latency. Static full-graph build validation is the
+smallest boundary that fixes the demonstrated blank-page class. A canary can be
+added later only if real failures justify the stronger publication guarantee.
 
 ## Delivery Sequence
 
-1. Freeze protocol v1 as shared example fixtures consumed by Runtime and Avibe
-   contract tests.
-2. In `vibe-show-runtime`, add the generation validator, revision state, internal
-   SSE stream, capability advertisement, and focused tests.
+1. Freeze protocol-v1 artifact fixtures and the document configuration shape as
+   shared contract files consumed by Runtime and Avibe tests.
+2. In `vibe-show-runtime`, add the demand lease, generation-coalesced production
+   builder, immutable storage, atomic activation, loopback file endpoint, stream,
+   and capability advertisement.
 3. Release the Runtime artifact and update Avibe's managed Runtime manifest.
-4. In `avibe`, enforce the canonical Session base, add the terminating public SSE
-   relay, activate the versioned public live client, and remove the public raw HMR
-   route.
+4. In `avibe`, keep the private Vite context canonical, replace public
+   development-module proxying with the gated artifact proxy, inject the exact
+   document artifact/base, add the terminating SSE relay and durable-state
+   revalidation, and remove public raw HMR.
 5. Update `show-service-runtime.md` and the multipage scaffold plan so `HMR`
-   means the private protocol and `Live Reload` means the public behavior.
-6. Run local Incus regression with simultaneous private and public viewers before
-   enabling the feature by default.
+   means the private protocol and `Live Reload` means activated public artifacts.
+6. Add scenario-catalog entries, then run local Incus regression with concurrent
+   private/public viewers and direct CLI visibility mutation.
 
-The rollout must not activate the public client before the managed Runtime
-advertises protocol v1. During a mixed-version development checkout, public pages
-remain readable but do not fall back to raw HMR.
+The rollout must not activate the public client before managed Runtime advertises
+protocol v1. During a mixed-version checkout, the feature remains disabled:
+public pages keep the current readable, non-live behavior and never expose raw
+HMR. The implementation PR must define the explicit compatibility cutover and
+remove the old public development-module path once the bundled Runtime is
+guaranteed compatible.
 
 ## Verification Plan
 
 ### Runtime unit tests
 
-- coalesce a file burst into one committed revision
-- do not emit when an affected transform fails
-- discard a successful validation superseded by a newer generation
-- validate the entry graph for a full-reload invalidation
-- issue a new epoch after a Vite context restart
-- replay only the current `ready` state to a new subscriber
+- coalesce a file burst into one candidate build
+- statically link the full graph and reject a removed named export referenced by
+  an unchanged importer
+- leave the active pointer unchanged for syntax, link, plugin, and asset failure
+- discard a successful build superseded by a newer generation
+- atomically activate only complete immutable output
+- join concurrent initial requests to one build
+- hold demand while at least one public stream is subscribed
+- retain active plus previous artifact and clean only unreferenced older output
+- replay only the current active artifact to a new subscriber
 
 ### Avibe unit and contract tests
 
-- public live client uses revision SSE and retains no-op HMR exports
-- anonymous public revision stream succeeds only for the current public share
-- private/offline/rotated shares cannot open or retain the stream
-- public relay drops unknown event types and all extra fields
-- browser credentials are never forwarded to the sidecar
-- public raw `__vite_hmr` is unavailable while private HMR still works
-- private and public HTTP requests reuse one canonical Runtime context
+- public documents embed the exact served artifact identifier
+- a `ready` value different from the embedded identifier reloads instead of
+  becoming an unchecked baseline
+- anonymous artifact and SSE requests succeed only for the current public share
+- direct `ShowPageStore` mutation from `vibe show update` closes a stream within
+  the 5-second bound without relying on an in-memory broker event
+- public relay drops unknown event types and extra fields
+- browser credentials are never forwarded to Runtime
+- emitted HTML, JavaScript, and CSS contain no canonical Session path or old
+  share ID; CSS `url(...)` assets resolve through the current gated share
+- public raw `__vite_hmr` is unavailable while private HMR remains unchanged
+- private and public traffic never changes or rebuilds the private Vite base
 
 ### Browser and regression scenarios
 
 | ID | Scenario | Expected evidence |
 | --- | --- | --- |
-| `SHOW-LIVE-001` | Agent edits a renderable public page | Open public page reloads within 2 seconds and shows the change |
-| `SHOW-LIVE-002` | Private author and public viewer are open together | Private Fast Refresh works; public Live Reload works; Runtime epoch stays stable |
-| `SHOW-LIVE-003` | Agent writes a syntax error, then fixes it | Public page keeps old render, exposes no diagnostic, then reloads after the fix |
-| `SHOW-LIVE-004` | Public share rotates or becomes private/offline | Existing stream closes and the old share cannot reconnect |
-| `SHOW-LIVE-005` | Many viewers watch one page | One revision validation and no per-viewer Vite sockets |
-| `SHOW-LIVE-006` | Public page cold load | No real Vite/React Refresh client; live client stays within the 3 KB gzip budget |
-| `SHOW-LIVE-007` | Viewer is typing or the tab is hidden | Revision waits according to the focus/visibility contract, then reloads once |
+| `SHOW-LIVE-001` | Agent edits a valid public page | One artifact activates and the visible public page reloads automatically |
+| `SHOW-LIVE-002` | Private author and public viewer are open together | Private Fast Refresh and public Live Reload both work; private Vite context stays stable |
+| `SHOW-LIVE-003` | Agent removes a named export still imported elsewhere, then repairs it | Public page retains the previous artifact with no diagnostic, then reloads after repair |
+| `SHOW-LIVE-004` | Public share rotates or direct CLI changes visibility to private/offline | Existing stream closes within 5 seconds and old share reads fail |
+| `SHOW-LIVE-005` | Many viewers watch one page | One candidate build per burst and no per-viewer Vite sockets or builds |
+| `SHOW-LIVE-006` | Public page cold-loads with a current artifact | No Vite/React Refresh client or source maps; live client stays within 3 KB gzip |
+| `SHOW-LIVE-007` | Revision arrives while both hidden and editing | No background deadline fires; after visibility, blur or 30 visible editable seconds causes exactly one reload |
+| `SHOW-LIVE-008` | Activation races the first SSE `ready` | Embedded and ready identifiers differ; the client reloads to the active artifact |
+| `SHOW-LIVE-009` | Page CSS references `url('./hero.png')`, then the share rotates | Asset loads on both share URLs and no canonical Session path is exposed |
 
 The implementation adds these scenarios to the Show scenario catalog before its
-PR is considered complete. Focused unit/contract tests, Ruff, the repository CI
-suite, and local Incus browser regression are all required; green unit tests do
-not replace the simultaneous private/public browser check.
+PR is complete. Focused unit/contract tests, Ruff, repository CI, and local Incus
+browser regression are required; green unit tests do not replace simultaneous
+private/public browser verification.
 
 ## Acceptance Gate
 
 The feature is complete when all of the following are true:
 
-- Public Show is live by default and requires no manual viewer refresh.
-- Public browsers cannot reach a raw Vite HMR channel or receive Vite diagnostics.
-- Private HMR behavior and authorization remain unchanged.
-- Concurrent private/public use does not rebuild the Session Runtime because of
-  external base-path changes.
-- Failed edits preserve the already-rendered public document and recover on the
-  next valid revision.
-- Initial-load and update measurements satisfy the budgets above in local Incus
-  regression.
+- Public Show updates automatically without exposing Vite HMR or diagnostics.
+- Every public response belongs to one immutable activated artifact; candidate
+  files are never served.
+- Complete build/link failures preserve the active public artifact and recover
+  on the next valid candidate.
+- The document artifact and SSE state use an exact equality handshake, including
+  the activation-before-first-`ready` race.
+- Public HTML, JavaScript, CSS, and asset requests expose no canonical Session
+  path and continue to work after share rotation.
+- Direct cross-process visibility changes revoke reads and streams within the
+  defined 5-second bound.
+- Hidden state dominates the editable-control deadline exactly as specified.
+- Private HMR behavior and authorization remain unchanged, and public traffic
+  does not mutate the private Vite context.
+- Cold-build, normal-load, activation, client-size, build-fanout, and artifact
+  retention measurements satisfy the budgets established in local Incus.


### PR DESCRIPTION
## Summary

- audience model: replace workspace audience, exact-email grants, and the separate public-link switch with one mutually exclusive `private | limited | public` Show access setting; keep offline availability orthogonal and editable without route admission
- route model: use `/p/<share>/` for both limited and fully public pages; limited requires a current page-bound exact-email grant, while public remains anonymously readable
- route authority: page-email entitlement authorizes only a limited `/p/` shared read and never canonical `/show/`; the private route accepts only independent owner/organization Show resource ACL
- capability model: exact-email authority is view-only and excluded from `ShowEditorCapability`; only independent resource-aware editor authority enables Agents annotations, the `/p/` to `/show/` redirect, Vite HMR, and React Fast Refresh
- limited login: resolve the Show Page before starting OAuth, bind page/share through signed state plus both handshake recovery paths, reauthorize generic sessions, and validate the current binding again on callback and before serving bytes
- transition model: stage changed exact-email targets in an authenticated backend prepare/commit operation, persist no email PII locally, use a page-scoped grant revision plus opaque random commitment, and serialize current-version audience writers with one process-shared lease
- transition recovery: canonical same-set requests reuse the current commitment/revision without a pending operation; entry into limited commits a conservative closed target and a proven uncommitted expiry remains closed until a new owner Apply; leaving limited for public keeps anonymous reads open while stale email authority is cleaned up
- representation isolation: `/p/` always serves the no-HMR shared graph after its audience gate, while `/show/<session>/` owns the complete private graph and the only HMR endpoint
- Runtime contract: negotiate `show-context-key-v1`; new clients send a typed protocol/context envelope on every app-graph call, while headerless released clients retain a reduced singleton compatibility path
- legacy boundary: compatibility never enables HMR, preserves annotations only for a proven editor, and fails closed for unclassified errors or graphs requiring raw absolute paths
- migration model: access-schema migration is restartable, revision-bound, and explicitly one-way; Avibe has no supported application/schema downgrade path and never starts an older executable against migrated state
- shared boundary: use leased opaque namespaces backed by immutable file snapshots, non-renewable lifetimes, a Runtime-wide weighted resource budget with a private-editor reserve, response provenance, URL-bearing header filtering, and qualified Service Worker revocation semantics
- scope decision: anonymous and limited viewers refresh for current content; this proposal intentionally does not add anonymous Live Reload or a production artifact publication system

## Scenario Coverage

- scenario IDs: defines `SHOW-LIVE-001` through `SHOW-LIVE-038`; extends the existing `AUTH-SETUP-401` closed-loop Show Page email login scenario
- unit coverage: no executable code changes in this design PR; required audience transition, no-op grant, exact-email route confinement, page-bound OAuth, editor capability, one-way migration, offline access editing, opaque commitment, redirect, ACL, Runtime context, immutable snapshot, path/header sanitization, cache, Service Worker, revocation, resource-admission, and mixed-version tests are specified
- contract coverage: freezes `ShowAccess`, `ShowEditorCapability`, the unified access mutation, backend-staged email operation, opaque page grant commitment, page-scoped grant revision, limited-only admission gate, process-shared audience lease, revision-bound migration, `/p/` limited/public gate, strict `/p/` versus `/show/` authority, page-bound OAuth handshake, `/p/` to `/show/` redirect, unchanged bootstrap fields, Runtime capability states, reduced legacy fallback, typed protocol envelope, globally budgeted immutable-snapshot namespaces, response provenance, and durable offline revocation
- scenario coverage: editor Fast Refresh, exact-email view-only behavior, limited login success/denial/no-loop, page/share callback rebinding rejection, direct canonical-route denial, public widening, public-to-limited binding retention and fail-closed expiry, page-versus-Instance revision independence, non-enumerable local grant metadata, concurrent representations, identity outage, ambiguous grant replacement, mode-scoped email revocation, stale-migration cancellation, one-way migration, legacy fail-closed output, compatibility-path annotations, path-swap confinement, hard namespace expiry, Runtime-wide public-load bounds, Service Worker cache limits, mixed-version Runtime behavior, staged-email crash recovery, direct socket denial, and context/resource bounds
- residual manual checks: follow-on implementation must run local Incus regression with editor, exact-email, denied, anonymous, revoked, Service Worker-controlled, legacy-Runtime, transient-startup, offline-audience-edit, stale-migration, resource-saturation, path-swap, migration, and direct-CLI-offline cases

## Validation

- `git diff --check`: passed
- Markdown parse with `markdown-it-py`: passed (954 tokens)
- Ruff: passed
- repository pre-commit Ruff hook: passed
- focused Python Show email/ACL tests: 8 passed
- closed-loop auth/setup scenario: 1 passed
- focused UI access tests: 9 passed across 2 files
- exact-head CI is monitored by the existing durable combined PR/Actions Watch

## Review-Loop Scope Decision

- `ce43f18beb`: 5 findings - publication validity, document/stream coherence, cross-process revocation, reload precedence, and public URL isolation
- `fc22b0dd0c`: 5 findings - document retention, recovery liveness, SPA compatibility, and repeated URL isolation
- `6270e60caf`: 6 findings - build-input confinement, share-validation ownership, repeated retention/addressing, frontend/API revision coherence, and Runtime-wide concurrency
- `1a1a3b9ee5`: 5 findings - per-document representation coherence, bootstrap compatibility, private reader ACL versus editor HMR, Service Worker isolation, and Runtime capability negotiation
- `cea579c2d6`: 6 findings - legacy context isolation, opaque path addressing, durable visibility revocation, transient negotiation recovery, diagnostic sanitization, and total prewarm context propagation
- `cca668f040`: 4 P2 findings - opaque namespace reclamation, Service Worker-controlled revocation semantics, transient pre-negotiation routing, and URL-bearing response-header sanitization
- `7825cf5481`: 4 findings (3 P1, 1 P2) - rollback-write authority, ambiguous grant-replacement revocation, mode-scoped page-email revocation, and mutable-path handle confinement
- `e506589e81`: 4 findings (2 P1, 2 P2) - stale migration ordering, rollback-compatible email revocation, renewable namespace exhaustion, and aggregate Runtime context exhaustion
- `95fd3d0d15`: 3 findings (1 P1, 2 P2) - legacy share-link write authority, headerless mixed-version routing, and durable no-PII email retry ownership
- `bbf6d318c2`: 4 P1 findings - downgrade-time legacy HMR authority, rollback-period hosted grant writes, page-versus-Instance revision ownership, and public-to-limited binding retention
- `5f173947f3`: 2 findings (1 P1, 1 P2) - cross-process audience-write exclusion during downgrade and non-enumerable local grant-set metadata
- `bcdfcfe503`: 8 findings (2 P1, 6 P2) - atomic downgrade-fence activation, late legacy writes after re-upgrade, grant no-op identity, public cleanup availability, missing legacy provenance, legacy raw-path safety, compatibility-path annotations, and offline grant cleanup
- `b90e59001c`: 3 P1 findings - page-email authority leaking into canonical private resource access, limited-link OAuth not bound to the resolved Show Page, and entry-transition recovery promising an unavailable source audience
- `59a7fbe854`: 3 findings (1 P1, 2 P2) - page-bound credential composability, offline-migration grant cleanup, and immutable-snapshot transform semantics
- repeated root-cause classes: rollback authority, durable grant-transition recovery, mixed-version negotiation, canonical/share representation and capability identity, page-bound authentication, shared-output confidentiality/source confinement, and Runtime lifecycle/admission crossed the circuit-breaker threshold over multiple heads
- prior orchestrator diagnosis: rollback findings modeled an unsupported old-binary workflow; the design therefore retained real old-client/new-Runtime protocol compatibility while making the access-schema migration one-way
- current orchestrator diagnosis: the remaining three findings came from retaining current implementation shortcuts inside the new audience model: the page-email claim still acted like canonical resource authority, OAuth inferred page scope only from a private return path, and entry recovery claimed it could restore state it never stored
- scope decision: enforce two non-overlapping access planes. Page-email grants participate only in the resolved limited `/p/` gate; `/show/` evaluates independent resource ACL with page-email ignored. Start limited OAuth from the resolved share and carry that binding end to end. Delete source-audience rollback for private/public entry transitions and remain closed until a new owner Apply.
- resolution in `59a7fbe85`: updates the route, OAuth, recovery, delivery, failure, verification, acceptance, and scenario contracts; `SHOW-LIVE-003`, `012`, `022`, `031`, `034`, `037`, `038`, and `AUTH-SETUP-401` cover the corrected boundaries
- latest orchestrator diagnosis: all three `59a7fbe854` findings repeat known classes; the blocking P1 comes from treating an immutable source snapshot as a browser-ready response instead of preserving the Vite transform contract
- latest scope decision: close only that complete blocking cause with typed asset versus virtual-module handles and recursive same-namespace transforms; retain the two nonblocking P2 items as explicit implementation follow-ups

## Known By Design / Follow-Ups

- follow-up (P2, `59a7fbe854`): make limited-page authorization composable across concurrent pages instead of replacing one host-wide scalar page claim
- follow-up (P2, `59a7fbe854`): migrate offline pages fail-closed while durably scheduling empty-set cleanup for any released exact-email grants

- exact-email and anonymous viewers do not update automatically; refresh performs a fresh audience check and reads current content
- a page-email-only viewer never receives canonical `/show/` access; a separately authorized resource viewer still does
- an independently authorized editor still gets HMR even when their email also appears in the list; the list itself never grants editor capability
- a definitive legacy Runtime retains its existing single-context limitation until the bundled Runtime upgrades; it has annotations only for a proven editor and no HMR
- access-schema migration is one-way; manually installing an older binary against migrated state is unsupported
- an already installed share-scoped Service Worker may render previously downloaded shared bytes after server-side revocation, but `/p/` never contains private bytes, HMR, annotations for read-only viewers, or Session identifiers
- an authorized share-link editor load adds one redirect round trip before matching the canonical `/show/` profile
- the shared transform context is not a last-known-good publication guarantee; a fresh request during an invalid edit receives sanitized current-state failure behavior
- finite global/per-Session Runtime budgets and the private reserve must be tuned from local Incus measurements, but configuration may never disable the hard bounds
- this PR is design-only; unified limited/public access and capability-gated HMR remain unimplemented until follow-on lanes land

