### PR TITLE
feat(show): add runtime context protocol foundation

### DIFF
--- a/core/show_runtime.py
+++ b/core/show_runtime.py
@@ -8,6 +8,7 @@ import json
 import logging
 import os
 import platform
+import random
 import re
 import shlex
 import shutil
@@ -15,12 +16,14 @@ import signal
 import subprocess
 import tarfile
 import tempfile
+import time
 import urllib.parse
 import urllib.request
 from dataclasses import dataclass
+from enum import Enum
 from pathlib import Path
 from sysconfig import get_platform
-from typing import Any
+from typing import Any, Mapping
 
 import httpx
 
@@ -48,6 +51,51 @@ _FALSE_VALUES = {"0", "false", "no", "off"}
 _PREWARM_IMPORT_RE = re.compile(r"""(?P<quote>["'])(?P<path>[^"']+)(?P=quote)""")
 _PREWARM_MAX_ASSETS = 64
 _PREWARM_MAX_DEPTH = 4
+SHOW_RUNTIME_PROTOCOL_VERSION = 1
+SHOW_RUNTIME_PROTOCOL_HEADER = "X-Avibe-Show-Protocol"
+SHOW_RUNTIME_CONTEXT_HEADER = "X-Avibe-Show-Context"
+SHOW_RUNTIME_CONTEXT_KEY_FEATURE = "show-context-key-v1"
+_CAPABILITY_RETRY_BASE_SECONDS = 0.25
+_CAPABILITY_RETRY_MAX_SECONDS = 5.0
+_CAPABILITY_RETRYABLE_STATUS_CODES = {408, 429}
+_MISSING = object()
+
+
+class ShowRuntimeContext(str, Enum):
+    PRIVATE = "private"
+    SHARED = "shared"
+
+
+class ShowRuntimeContextCapability(str, Enum):
+    SUPPORTED = "supported"
+    UNSUPPORTED = "unsupported"
+    TRANSIENT_UNKNOWN = "transient-unknown"
+
+
+@dataclass(frozen=True)
+class ShowRuntimeProtocolEnvelope:
+    context: ShowRuntimeContext
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.context, ShowRuntimeContext):
+            raise TypeError("Show Runtime protocol 1 requires an explicit private or shared context")
+
+    def headers(self, forwarded: Mapping[str, str] | None = None) -> dict[str, str]:
+        blocked = {SHOW_RUNTIME_PROTOCOL_HEADER.lower(), SHOW_RUNTIME_CONTEXT_HEADER.lower()}
+        headers = {
+            key: value
+            for key, value in (forwarded or {}).items()
+            if key.lower() not in blocked
+        }
+        headers[SHOW_RUNTIME_PROTOCOL_HEADER] = str(SHOW_RUNTIME_PROTOCOL_VERSION)
+        headers[SHOW_RUNTIME_CONTEXT_HEADER] = self.context.value
+        return headers
+
+
+@dataclass(frozen=True)
+class ShowRuntimeWebSocketTarget:
+    url: str
+    headers: dict[str, str]
 
 
 @dataclass(frozen=True)
@@ -139,6 +187,12 @@ class ShowRuntimeManager:
         self._process: subprocess.Popen[str] | None = None
         self._base_url: str | None = None
         self._lock = asyncio.Lock()
+        self._capability_lock = asyncio.Lock()
+        self._capability_identity: tuple[str, int | None] | None = None
+        self._context_key_capability: ShowRuntimeContextCapability | None = None
+        self._capability_retry_deadline = 0.0
+        self._capability_retry_attempt = 0
+        self._capability_generation = 0
 
     async def ensure(self) -> ShowRuntimeResult:
         if self._base_url and await self._healthy(self._base_url):
@@ -195,26 +249,62 @@ class ShowRuntimeManager:
         method: str,
         path: str,
         *,
+        envelope: ShowRuntimeProtocolEnvelope,
         headers: dict[str, str] | None = None,
         body: bytes | None = None,
     ) -> httpx.Response:
         ready = await self.ensure()
         if not ready.available or not ready.base_url:
             raise RuntimeError(ready.reason or "show runtime unavailable")
+        await self._negotiate_context_key_capability(ready.base_url)
         async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=5.0)) as client:
-            return await client.request(method, f"{ready.base_url}{path}", headers=headers, content=body)
+            return await client.request(
+                method,
+                f"{ready.base_url}{path}",
+                headers=envelope.headers(headers),
+                content=body,
+            )
 
-    async def prewarm_session(self, session_id: str, *, base_path: str | None = None) -> ShowRuntimeResult:
+    async def request_global(
+        self,
+        method: str,
+        path: str,
+        *,
+        headers: dict[str, str] | None = None,
+        body: bytes | None = None,
+    ) -> httpx.Response:
+        """Request a capability-independent Runtime resource without an app context."""
+        ready = await self.ensure()
+        if not ready.available or not ready.base_url:
+            raise RuntimeError(ready.reason or "show runtime unavailable")
+        blocked = {SHOW_RUNTIME_PROTOCOL_HEADER.lower(), SHOW_RUNTIME_CONTEXT_HEADER.lower()}
+        forwarded = {
+            key: value
+            for key, value in (headers or {}).items()
+            if key.lower() not in blocked
+        }
+        async with httpx.AsyncClient(timeout=httpx.Timeout(30.0, connect=5.0)) as client:
+            return await client.request(method, f"{ready.base_url}{path}", headers=forwarded, content=body)
+
+    async def prewarm_session(
+        self,
+        session_id: str,
+        *,
+        context: ShowRuntimeContext,
+        base_path: str | None = None,
+    ) -> ShowRuntimeResult:
         session_part = urllib.parse.quote(session_id, safe="")
         runtime_path = f"/sessions/{session_part}/app/"
         headers = {"x-vibe-show-base": base_path} if base_path else None
+        envelope = ShowRuntimeProtocolEnvelope(context)
         try:
-            response = await self.request("GET", runtime_path, headers=headers)
+            response = await self.request("GET", runtime_path, envelope=envelope, headers=headers)
             if response.status_code >= 500:
                 return ShowRuntimeResult(False, reason=f"session_prewarm_failed:{response.status_code}")
             result = await self._prewarm_session_module_graph(
                 session_id,
                 runtime_path=runtime_path,
+                envelope=envelope,
                 headers=headers,
                 seed_responses=[(runtime_path, response)],
                 base_path=base_path,
@@ -230,6 +320,7 @@ class ShowRuntimeManager:
         session_id: str,
         *,
         runtime_path: str,
+        envelope: ShowRuntimeProtocolEnvelope,
         headers: dict[str, str] | None,
         seed_responses: list[tuple[str, httpx.Response]],
         base_path: str | None,
@@ -252,7 +343,7 @@ class ShowRuntimeManager:
             if path in visited or depth > _PREWARM_MAX_DEPTH:
                 continue
             visited.add(path)
-            response = await self.request("GET", path, headers=headers)
+            response = await self.request("GET", path, envelope=envelope, headers=headers)
             if response.status_code >= 500:
                 return ShowRuntimeResult(False, reason=f"session_prewarm_module_failed:{response.status_code}:{path}")
             if response.status_code >= 400:
@@ -269,11 +360,107 @@ class ShowRuntimeManager:
                     pending.append((import_path, depth + 1))
         return ShowRuntimeResult(True, self._base_url)
 
-    async def websocket_url(self, path: str) -> str:
+    async def websocket_target(
+        self,
+        path: str,
+        *,
+        envelope: ShowRuntimeProtocolEnvelope,
+    ) -> ShowRuntimeWebSocketTarget:
         ready = await self.ensure()
         if not ready.available or not ready.base_url:
             raise RuntimeError(ready.reason or "show runtime unavailable")
-        return f"{ready.base_url.replace('http://', 'ws://', 1).replace('https://', 'wss://', 1)}{path}"
+        await self._negotiate_context_key_capability(ready.base_url)
+        url = f"{ready.base_url.replace('http://', 'ws://', 1).replace('https://', 'wss://', 1)}{path}"
+        return ShowRuntimeWebSocketTarget(url=url, headers=envelope.headers())
+
+    async def context_key_capability(self) -> ShowRuntimeContextCapability:
+        ready = await self.ensure()
+        if not ready.available or not ready.base_url:
+            return ShowRuntimeContextCapability.TRANSIENT_UNKNOWN
+        return await self._negotiate_context_key_capability(ready.base_url)
+
+    async def _negotiate_context_key_capability(
+        self,
+        base_url: str,
+    ) -> ShowRuntimeContextCapability:
+        async with self._capability_lock:
+            identity = self._runtime_identity(base_url)
+            if identity != self._capability_identity:
+                self._clear_capability_state(identity=identity)
+
+            if self._context_key_capability in {
+                ShowRuntimeContextCapability.SUPPORTED,
+                ShowRuntimeContextCapability.UNSUPPORTED,
+            }:
+                return self._context_key_capability
+
+            now = time.monotonic()
+            if (
+                self._context_key_capability is ShowRuntimeContextCapability.TRANSIENT_UNKNOWN
+                and now < self._capability_retry_deadline
+            ):
+                return ShowRuntimeContextCapability.TRANSIENT_UNKNOWN
+
+            generation = self._capability_generation
+            outcome = await self._probe_context_key_capability(base_url)
+            if generation != self._capability_generation or identity != self._runtime_identity(base_url):
+                return ShowRuntimeContextCapability.TRANSIENT_UNKNOWN
+
+            self._context_key_capability = outcome
+            if outcome is ShowRuntimeContextCapability.TRANSIENT_UNKNOWN:
+                self._capability_retry_attempt += 1
+                self._capability_retry_deadline = time.monotonic() + _show_runtime_capability_retry_delay(
+                    self._capability_retry_attempt
+                )
+            else:
+                self._capability_retry_attempt = 0
+                self._capability_retry_deadline = 0.0
+            return outcome
+
+    async def _probe_context_key_capability(self, base_url: str) -> ShowRuntimeContextCapability:
+        try:
+            async with httpx.AsyncClient(timeout=httpx.Timeout(2.0, connect=0.5)) as client:
+                response = await client.get(f"{base_url}/capabilities")
+        except (httpx.TimeoutException, httpx.TransportError):
+            return ShowRuntimeContextCapability.TRANSIENT_UNKNOWN
+
+        if response.status_code == 404:
+            return ShowRuntimeContextCapability.UNSUPPORTED
+        if response.status_code in _CAPABILITY_RETRYABLE_STATUS_CODES or response.status_code >= 500:
+            return ShowRuntimeContextCapability.TRANSIENT_UNKNOWN
+        if not 200 <= response.status_code < 300:
+            return ShowRuntimeContextCapability.TRANSIENT_UNKNOWN
+        try:
+            payload = response.json()
+        except (UnicodeDecodeError, ValueError):
+            return ShowRuntimeContextCapability.TRANSIENT_UNKNOWN
+        if not isinstance(payload, dict):
+            return ShowRuntimeContextCapability.TRANSIENT_UNKNOWN
+
+        protocol = payload.get("protocol", _MISSING)
+        features = payload.get("features", _MISSING)
+        if protocol is not _MISSING and (isinstance(protocol, bool) or not isinstance(protocol, int)):
+            return ShowRuntimeContextCapability.TRANSIENT_UNKNOWN
+        if features is not _MISSING and (
+            not isinstance(features, list) or any(not isinstance(feature, str) for feature in features)
+        ):
+            return ShowRuntimeContextCapability.TRANSIENT_UNKNOWN
+        if protocol == SHOW_RUNTIME_PROTOCOL_VERSION and SHOW_RUNTIME_CONTEXT_KEY_FEATURE in (
+            features if isinstance(features, list) else []
+        ):
+            return ShowRuntimeContextCapability.SUPPORTED
+        return ShowRuntimeContextCapability.UNSUPPORTED
+
+    def _runtime_identity(self, base_url: str) -> tuple[str, int | None]:
+        process = self._process
+        return base_url, getattr(process, "pid", None) if process is not None else None
+
+    def _clear_capability_state(self, *, identity: tuple[str, int | None] | None = None) -> None:
+        self._capability_identity = identity
+        self._context_key_capability = None
+        self._capability_retry_deadline = 0.0
+        self._capability_retry_attempt = 0
+        self._capability_generation += 1
 
     async def _healthy(self, base_url: str) -> bool:
         try:
@@ -303,6 +490,7 @@ class ShowRuntimeManager:
         process = self._process
         self._process = None
         self._base_url = None
+        self._clear_capability_state()
         if not process or process.poll() is not None:
             return
         signal_process_tree(process, signal.SIGTERM, logger, "show runtime")
@@ -1330,8 +1518,17 @@ async def prewarm_show_runtime() -> ShowRuntimeResult:
     return await get_show_runtime_manager().ensure()
 
 
-async def prewarm_show_page_session(session_id: str, *, base_path: str | None = None) -> ShowRuntimeResult:
-    return await get_show_runtime_manager().prewarm_session(session_id, base_path=base_path)
+async def prewarm_show_page_session(
+    session_id: str,
+    *,
+    context: ShowRuntimeContext,
+    base_path: str | None = None,
+) -> ShowRuntimeResult:
+    return await get_show_runtime_manager().prewarm_session(
+        session_id,
+        context=context,
+        base_path=base_path,
+    )
 
 
 def set_show_runtime_manager_for_tests(manager: ShowRuntimeManager | None) -> None:
@@ -1427,6 +1624,12 @@ def _join_show_runtime_prewarm_path(runtime_path: str, asset_path: str, separato
     if separator:
         path = f"{path}?{query}"
     return path
+
+
+def _show_runtime_capability_retry_delay(attempt: int) -> float:
+    exponent = max(0, min(attempt - 1, 16))
+    ceiling = min(_CAPABILITY_RETRY_MAX_SECONDS, _CAPABILITY_RETRY_BASE_SECONDS * (2**exponent))
+    return ceiling * (0.5 + random.random() * 0.5)
 
 
 def _auto_install_enabled() -> bool:

--- a/tests/test_local_deps.py
+++ b/tests/test_local_deps.py
@@ -1067,7 +1067,9 @@ def test_startup_show_page_prewarm_targets_recent_non_offline(monkeypatch, tmp_p
 
     assert out["limit"] == 2
     assert [page["session_id"] for page in out["pages"]] == ["ses-new", "ses-public"]
+    assert out["pages"][0]["context"] == "private"
     assert out["pages"][1]["visibility"] == "public"
+    assert out["pages"][1]["context"] == "shared"
     assert out["pages"][1]["base_path"].startswith("/p/")
 
 

--- a/tests/test_show_pages.py
+++ b/tests/test_show_pages.py
@@ -1773,7 +1773,7 @@ def test_show_path_cli_json_creates_page(monkeypatch, tmp_path, capsys):
     )
     assert (tmp_path / "show" / "ses123" / "index.html").exists()
     assert captured["url"] == "http://127.0.0.1:5123/api/show/sessions/ses123/prewarm"
-    assert captured["payload"] == {}
+    assert captured["payload"] == {"context": "private"}
     assert captured["timeout"] == 3
 
 
@@ -2084,7 +2084,7 @@ def test_show_update_cli_reports_transition_urls(monkeypatch, tmp_path, capsys):
     share_path = "/" + public_payload["public_url"].split("https://alex.avibe.bot/", 1)[1]
     assert prewarmed[-1] == (
         "http://127.0.0.1:5123/api/show/sessions/ses123/prewarm",
-        {"base_path": share_path},
+        {"context": "shared", "base_path": share_path},
     )
 
     args = parser.parse_args(["show", "update", "--session-id", "ses123", "--visibility", "private", "--json"])
@@ -2093,7 +2093,10 @@ def test_show_update_cli_reports_transition_urls(monkeypatch, tmp_path, capsys):
     assert private_payload["visibility"] == "private"
     assert private_payload["active_url"] == "https://alex.avibe.bot/show/ses123/"
     assert private_payload["previous_public_url"] == public_payload["public_url"]
-    assert prewarmed[-1] == ("http://127.0.0.1:5123/api/show/sessions/ses123/prewarm", {})
+    assert prewarmed[-1] == (
+        "http://127.0.0.1:5123/api/show/sessions/ses123/prewarm",
+        {"context": "private"},
+    )
 
 
 def test_show_status_and_update_default_to_caller_session(monkeypatch, tmp_path, capsys):

--- a/tests/test_show_runtime_protocol.py
+++ b/tests/test_show_runtime_protocol.py
@@ -1,0 +1,243 @@
+import asyncio
+from types import SimpleNamespace
+
+import httpx
+import pytest
+
+import core.show_runtime as show_runtime
+from core.show_runtime import (
+    SHOW_RUNTIME_CONTEXT_HEADER,
+    SHOW_RUNTIME_PROTOCOL_HEADER,
+    ShowRuntimeContext,
+    ShowRuntimeContextCapability,
+    ShowRuntimeManager,
+    ShowRuntimeProtocolEnvelope,
+    ShowRuntimeResult,
+)
+
+
+def _manager(tmp_path) -> ShowRuntimeManager:
+    return ShowRuntimeManager(
+        command="/bin/echo",
+        workspace_root=tmp_path / "show",
+        runtime_dir=tmp_path / "runtime",
+    )
+
+
+class _CapabilityClient:
+    def __init__(self, response=None, error=None):
+        self.response = response
+        self.error = error
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_args):
+        return None
+
+    async def get(self, _url):
+        if self.error is not None:
+            raise self.error
+        return self.response
+
+
+@pytest.mark.parametrize(
+    ("response", "expected"),
+    [
+        (httpx.Response(404), ShowRuntimeContextCapability.UNSUPPORTED),
+        (
+            httpx.Response(200, json={"protocol": 1, "features": []}),
+            ShowRuntimeContextCapability.UNSUPPORTED,
+        ),
+        (
+            httpx.Response(200, json={"protocol": 1, "features": ["show-context-key-v1"]}),
+            ShowRuntimeContextCapability.SUPPORTED,
+        ),
+        (httpx.Response(503), ShowRuntimeContextCapability.TRANSIENT_UNKNOWN),
+        (httpx.Response(200, content=b'{"protocol":1'), ShowRuntimeContextCapability.TRANSIENT_UNKNOWN),
+    ],
+)
+def test_show_live_014_capability_evidence_is_classified_without_guessing(
+    monkeypatch,
+    tmp_path,
+    response,
+    expected,
+):
+    manager = _manager(tmp_path)
+    monkeypatch.setattr(
+        show_runtime.httpx,
+        "AsyncClient",
+        lambda **_kwargs: _CapabilityClient(response=response),
+    )
+
+    outcome = asyncio.run(manager._probe_context_key_capability("http://127.0.0.1:4173"))
+
+    assert outcome is expected
+
+
+def test_show_live_015_transport_failure_is_transient(monkeypatch, tmp_path):
+    manager = _manager(tmp_path)
+    request = httpx.Request("GET", "http://127.0.0.1:4173/capabilities")
+    monkeypatch.setattr(
+        show_runtime.httpx,
+        "AsyncClient",
+        lambda **_kwargs: _CapabilityClient(error=httpx.ConnectTimeout("timed out", request=request)),
+    )
+
+    outcome = asyncio.run(manager._probe_context_key_capability("http://127.0.0.1:4173"))
+
+    assert outcome is ShowRuntimeContextCapability.TRANSIENT_UNKNOWN
+
+
+def test_show_live_015_transient_probe_keeps_shared_request_live_and_retries(
+    monkeypatch,
+    tmp_path,
+):
+    manager = _manager(tmp_path)
+    manager._base_url = "http://127.0.0.1:4173"
+    manager._process = SimpleNamespace(pid=101, poll=lambda: None)
+    clock = {"now": 100.0}
+    probes = []
+    requests = []
+    outcomes = iter(
+        [
+            ShowRuntimeContextCapability.TRANSIENT_UNKNOWN,
+            ShowRuntimeContextCapability.SUPPORTED,
+        ]
+    )
+
+    async def ensure():
+        return ShowRuntimeResult(True, manager._base_url)
+
+    async def probe(base_url):
+        probes.append(base_url)
+        return next(outcomes)
+
+    class _AppClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return None
+
+        async def request(self, method, url, *, headers, content):
+            requests.append((method, url, headers, content))
+            return httpx.Response(200, content=b"ready")
+
+    monkeypatch.setattr(manager, "ensure", ensure)
+    monkeypatch.setattr(manager, "_probe_context_key_capability", probe)
+    monkeypatch.setattr(show_runtime.time, "monotonic", lambda: clock["now"])
+    monkeypatch.setattr(show_runtime, "_show_runtime_capability_retry_delay", lambda _attempt: 1.0)
+    monkeypatch.setattr(show_runtime.httpx, "AsyncClient", lambda **_kwargs: _AppClient())
+    envelope = ShowRuntimeProtocolEnvelope(ShowRuntimeContext.SHARED)
+
+    async def exercise():
+        first = await manager.request("GET", "/sessions/ses/app/", envelope=envelope)
+        second = await manager.request("GET", "/sessions/ses/app/src/main.tsx", envelope=envelope)
+        clock["now"] = 101.0
+        third = await manager.request("GET", "/sessions/ses/app/src/App.tsx", envelope=envelope)
+        return first, second, third
+
+    responses = asyncio.run(exercise())
+
+    assert [response.status_code for response in responses] == [200, 200, 200]
+    assert probes == [manager._base_url, manager._base_url]
+    assert all(call[2][SHOW_RUNTIME_PROTOCOL_HEADER] == "1" for call in requests)
+    assert all(call[2][SHOW_RUNTIME_CONTEXT_HEADER] == "shared" for call in requests)
+
+
+def test_show_live_014_capability_cache_resets_with_process_base_and_manager_lifetime(
+    monkeypatch,
+    tmp_path,
+):
+    manager = _manager(tmp_path)
+    manager._base_url = "http://127.0.0.1:4173"
+    manager._process = SimpleNamespace(pid=101, poll=lambda: 0)
+    probes = []
+    outcomes = iter(
+        [
+            ShowRuntimeContextCapability.SUPPORTED,
+            ShowRuntimeContextCapability.UNSUPPORTED,
+            ShowRuntimeContextCapability.SUPPORTED,
+            ShowRuntimeContextCapability.TRANSIENT_UNKNOWN,
+            ShowRuntimeContextCapability.SUPPORTED,
+        ]
+    )
+
+    async def ensure():
+        return ShowRuntimeResult(True, manager._base_url)
+
+    async def probe(base_url):
+        probes.append((base_url, manager._process.pid))
+        return next(outcomes)
+
+    monkeypatch.setattr(manager, "ensure", ensure)
+    monkeypatch.setattr(manager, "_probe_context_key_capability", probe)
+    monkeypatch.setattr(show_runtime, "_show_runtime_capability_retry_delay", lambda _attempt: 5.0)
+
+    async def exercise():
+        assert await manager.context_key_capability() is ShowRuntimeContextCapability.SUPPORTED
+        assert await manager.context_key_capability() is ShowRuntimeContextCapability.SUPPORTED
+        manager._process = SimpleNamespace(pid=102, poll=lambda: 0)
+        assert await manager.context_key_capability() is ShowRuntimeContextCapability.UNSUPPORTED
+        manager._base_url = "http://127.0.0.1:4174"
+        assert await manager.context_key_capability() is ShowRuntimeContextCapability.SUPPORTED
+        manager._process = SimpleNamespace(pid=103, poll=lambda: 0)
+        assert await manager.context_key_capability() is ShowRuntimeContextCapability.TRANSIENT_UNKNOWN
+        manager.stop()
+        manager._base_url = "http://127.0.0.1:4174"
+        manager._process = SimpleNamespace(pid=104, poll=lambda: 0)
+        assert await manager.context_key_capability() is ShowRuntimeContextCapability.SUPPORTED
+
+    asyncio.run(exercise())
+
+    assert probes == [
+        ("http://127.0.0.1:4173", 101),
+        ("http://127.0.0.1:4173", 102),
+        ("http://127.0.0.1:4174", 102),
+        ("http://127.0.0.1:4174", 103),
+        ("http://127.0.0.1:4174", 104),
+    ]
+    assert manager._capability_retry_deadline == 0.0
+
+    replacement = _manager(tmp_path)
+    assert replacement._context_key_capability is None
+    assert replacement._capability_retry_deadline == 0.0
+
+
+def test_show_live_017_protocol_envelope_is_total_and_strips_untrusted_values():
+    private = ShowRuntimeProtocolEnvelope(ShowRuntimeContext.PRIVATE)
+    shared = ShowRuntimeProtocolEnvelope(ShowRuntimeContext.SHARED)
+
+    assert private.headers(
+        {
+            SHOW_RUNTIME_PROTOCOL_HEADER.lower(): "999",
+            SHOW_RUNTIME_CONTEXT_HEADER.lower(): "shared",
+            "accept": "text/html",
+        }
+    ) == {
+        "accept": "text/html",
+        SHOW_RUNTIME_PROTOCOL_HEADER: "1",
+        SHOW_RUNTIME_CONTEXT_HEADER: "private",
+    }
+    assert shared.headers() == {
+        SHOW_RUNTIME_PROTOCOL_HEADER: "1",
+        SHOW_RUNTIME_CONTEXT_HEADER: "shared",
+    }
+    with pytest.raises(TypeError):
+        ShowRuntimeProtocolEnvelope("private")  # type: ignore[arg-type]
+
+
+def test_show_live_017_app_graph_request_cannot_omit_protocol_context(tmp_path):
+    manager = _manager(tmp_path)
+
+    with pytest.raises(TypeError):
+        manager.request("GET", "/sessions/ses/app/")  # type: ignore[call-arg]
+
+
+def test_show_runtime_capability_backoff_is_jittered_exponential_and_bounded(monkeypatch):
+    monkeypatch.setattr(show_runtime.random, "random", lambda: 1.0)
+
+    delays = [show_runtime._show_runtime_capability_retry_delay(attempt) for attempt in range(1, 9)]
+
+    assert delays == [0.25, 0.5, 1.0, 2.0, 4.0, 5.0, 5.0, 5.0]

--- a/tests/test_ui_show_pages.py
+++ b/tests/test_ui_show_pages.py
@@ -10,6 +10,7 @@ import struct
 import tarfile
 import threading
 import urllib.error
+import urllib.parse
 import zlib
 from pathlib import Path
 from types import SimpleNamespace
@@ -28,7 +29,9 @@ from core.show_pages import (
     show_public_event_write_token,
 )
 from core.show_runtime import (
+    ShowRuntimeContext,
     ShowRuntimeManager,
+    ShowRuntimeWebSocketTarget,
     _runtime_download_error,
     _runtime_platform_tag,
     _safe_extract_tar,
@@ -96,12 +99,13 @@ class _FakeShowRuntimeManager:
         self.status_by_path = status_by_path or {}
         self.calls = []
         self.websocket_paths = []
+        self.websocket_headers = []
         self.stopped = False
 
-    async def request(self, method, path, *, headers=None, body=None):
+    async def request(self, method, path, *, envelope, headers=None, body=None):
         import httpx
 
-        self.calls.append((method, path, headers, body))
+        self.calls.append((method, path, envelope.headers(headers), body))
         if self.fail:
             raise RuntimeError("runtime unavailable")
         headers = {
@@ -115,9 +119,28 @@ class _FakeShowRuntimeManager:
             headers=headers,
         )
 
-    async def websocket_url(self, path):
+    async def request_global(self, method, path, *, headers=None, body=None):
+        import httpx
+
+        self.calls.append((method, path, headers or {}, body))
+        if self.fail:
+            raise RuntimeError("runtime unavailable")
+        response_headers = {
+            "content-type": "text/html; charset=utf-8",
+            "set-cookie": "__Host-vibe_remote_session=attacker",
+            "x-runtime-private-header": "secret",
+        } | self.extra_headers | self.headers_by_path.get(path, {})
+        return httpx.Response(
+            self.status_by_path.get(path, self.status_code),
+            content=self.bodies_by_path.get(path, self.body),
+            headers=response_headers,
+        )
+
+    async def websocket_target(self, path, *, envelope):
         self.websocket_paths.append(path)
-        return f"ws://127.0.0.1:1{path}"
+        headers = envelope.headers()
+        self.websocket_headers.append(headers)
+        return ShowRuntimeWebSocketTarget(url=f"ws://127.0.0.1:1{path}", headers=headers)
 
     def stop(self):
         self.stopped = True
@@ -490,10 +513,57 @@ def test_private_show_page_uses_runtime_when_available(monkeypatch, tmp_path):
     assert manager.calls[0][0] == "GET"
     assert manager.calls[0][1] == "/sessions/ses123/app/"
     assert manager.calls[0][2]["accept"] == "text/html"
+    assert manager.calls[0][2]["X-Avibe-Show-Protocol"] == "1"
+    assert manager.calls[0][2]["X-Avibe-Show-Context"] == "private"
     assert "accept-encoding" not in manager.calls[0][2]
     assert "authorization" not in manager.calls[0][2]
     assert "cookie" not in manager.calls[0][2]
     assert "x-vibe-csrf-token" not in manager.calls[0][2]
+
+
+@pytest.mark.parametrize("surface", ["private", "public"])
+def test_show_live_005_protocol_context_crosses_non_ascii_avibe_request_boundary(
+    monkeypatch,
+    tmp_path,
+    surface,
+):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    _save_config(tmp_path)
+    session_id = "ses-unicode-path"
+    asset_path = "路径/组件.tsx"
+    share_id = _create_show_page(session_id, surface)
+    encoded_session = urllib.parse.quote(session_id, safe="")
+    encoded_asset = urllib.parse.quote(asset_path, safe="/")
+    if surface == "private":
+        url = f"/show/{encoded_session}/{encoded_asset}"
+        request_kwargs = {"base_url": "http://127.0.0.1:5123"}
+        expected_context = "private"
+    else:
+        url = f"/p/{share_id}/{encoded_asset}"
+        request_kwargs = {
+            "base_url": "https://alex.avibe.bot",
+            "environ_base": _remote_peer(),
+        }
+        expected_context = "shared"
+    manager = _FakeShowRuntimeManager(body=b"export default true")
+    set_show_runtime_manager_for_tests(manager)
+    try:
+        response = app.test_client().get(
+            url,
+            headers={
+                "Accept": "text/javascript",
+                "X-Avibe-Show-Protocol": "999",
+                "X-Avibe-Show-Context": "shared" if surface == "private" else "private",
+            },
+            **request_kwargs,
+        )
+    finally:
+        set_show_runtime_manager_for_tests(None)
+
+    assert response.status_code == 200
+    assert manager.calls[0][1] == f"/sessions/{encoded_session}/app/{encoded_asset}"
+    assert manager.calls[0][2]["X-Avibe-Show-Protocol"] == "1"
+    assert manager.calls[0][2]["X-Avibe-Show-Context"] == expected_context
 
 
 @pytest.mark.parametrize("surface", ["private", "public"])
@@ -542,6 +612,9 @@ def test_show_page_history_route_retries_entry_after_runtime_404(monkeypatch, tm
     assert f'"basePath":"{expected_base}"' in body
     assert response.headers["cache-control"] == "no-store"
     assert [call[1] for call in manager.calls] == [route_runtime_path, entry_runtime_path]
+    expected_context = "private" if surface == "private" else "shared"
+    assert all(call[2]["X-Avibe-Show-Protocol"] == "1" for call in manager.calls)
+    assert all(call[2]["X-Avibe-Show-Context"] == expected_context for call in manager.calls)
     if surface == "public":
         assert all(call[2]["x-vibe-show-base"] == expected_base for call in manager.calls)
 
@@ -1187,7 +1260,11 @@ def test_private_show_page_injects_runtime_event_config(monkeypatch, tmp_path):
 
 
 @pytest.mark.parametrize("authenticated", [False, True])
-def test_public_show_page_injects_auth_aware_annotation_config(monkeypatch, tmp_path, authenticated):
+def test_show_live_035_public_show_page_injects_auth_aware_annotation_config(
+    monkeypatch,
+    tmp_path,
+    authenticated,
+):
     monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
     config = _save_config(tmp_path)
     share_id = _create_show_page("ses123", "public")
@@ -1212,6 +1289,8 @@ def test_public_show_page_injects_auth_aware_annotation_config(monkeypatch, tmp_
         set_show_runtime_manager_for_tests(None)
 
     assert response.status_code == 200
+    assert response.headers.get("location") is None
+    assert manager.calls[0][2]["X-Avibe-Show-Context"] == "shared"
     body = response.content.decode("utf-8")
     base_path = f"/p/{share_id}/"
     assert f'"sessionId":"{share_id}"' in body
@@ -2118,6 +2197,8 @@ def test_private_show_page_proxies_runtime_api_methods(monkeypatch, tmp_path):
     assert manager.calls[0][0] == "POST"
     assert manager.calls[0][1] == "/sessions/ses123/app/api/health"
     assert manager.calls[0][2]["content-type"] == "application/json"
+    assert manager.calls[0][2]["X-Avibe-Show-Protocol"] == "1"
+    assert manager.calls[0][2]["X-Avibe-Show-Context"] == "private"
     assert "cookie" not in manager.calls[0][2]
     assert manager.calls[0][3] == b'{"ping":true}'
 
@@ -3868,8 +3949,38 @@ def test_cli_show_prewarm_ingress_uses_ui_runtime_manager(monkeypatch, tmp_path)
     _save_config(tmp_path)
     calls = []
 
-    async def fake_prewarm(session_id, *, base_path=None):
-        calls.append((session_id, base_path))
+    async def fake_prewarm(session_id, *, context, base_path=None):
+        calls.append((session_id, context, base_path))
+        return SimpleNamespace(available=True, reason=None, base_url="http://127.0.0.1:49200")
+
+    monkeypatch.setattr("core.show_runtime.prewarm_show_page_session", fake_prewarm)
+
+    response = app.test_client().post(
+        "/api/show/sessions/ses123/prewarm",
+        base_url="http://127.0.0.1:5123",
+        headers={
+            "Content-Type": "application/json",
+            "X-Vibe-Show-Client": "cli",
+            "X-Vibe-Show-Cli-Token": show_cli_event_token(),
+        },
+        json={"context": "shared", "base_path": "/p/share123/"},
+    )
+
+    assert response.status_code == 200
+    assert response.get_json()["ok"] is True
+    assert calls == [("ses123", ShowRuntimeContext.SHARED, "/p/share123/")]
+
+
+def test_show_live_017_cli_show_prewarm_rejects_missing_context_before_runtime(
+    monkeypatch,
+    tmp_path,
+):
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    _save_config(tmp_path)
+    calls = []
+
+    async def fake_prewarm(*args, **kwargs):
+        calls.append((args, kwargs))
         return SimpleNamespace(available=True, reason=None, base_url="http://127.0.0.1:49200")
 
     monkeypatch.setattr("core.show_runtime.prewarm_show_page_session", fake_prewarm)
@@ -3885,9 +3996,9 @@ def test_cli_show_prewarm_ingress_uses_ui_runtime_manager(monkeypatch, tmp_path)
         json={"base_path": "/p/share123/"},
     )
 
-    assert response.status_code == 200
-    assert response.get_json()["ok"] is True
-    assert calls == [("ses123", "/p/share123/")]
+    assert response.status_code == 400
+    assert response.get_json()["code"] == "invalid_show_runtime_context"
+    assert calls == []
 
 
 def test_cli_show_prewarm_ingress_requires_cli_token(monkeypatch, tmp_path):
@@ -4679,10 +4790,10 @@ def test_show_runtime_manager_prewarm_loads_entry_module(monkeypatch, tmp_path):
     }
     calls = []
 
-    async def fake_request(self, method, path, *, headers=None, body=None):
+    async def fake_request(self, method, path, *, envelope, headers=None, body=None):
         import httpx
 
-        calls.append((method, path, headers, body))
+        calls.append((method, path, envelope.headers(headers), body))
         status, content, headers_out = responses[path]
         return httpx.Response(status, content=content, headers=headers_out)
 
@@ -4693,23 +4804,34 @@ def test_show_runtime_manager_prewarm_loads_entry_module(monkeypatch, tmp_path):
     )
     monkeypatch.setattr(ShowRuntimeManager, "request", fake_request)
 
-    result = asyncio.run(manager.prewarm_session("ses123", base_path="/show/ses123/"))
+    result = asyncio.run(
+        manager.prewarm_session(
+            "ses123",
+            context=ShowRuntimeContext.PRIVATE,
+            base_path="/show/ses123/",
+        )
+    )
 
     assert result.available is True
+    private_headers = {
+        "x-vibe-show-base": "/show/ses123/",
+        "X-Avibe-Show-Protocol": "1",
+        "X-Avibe-Show-Context": "private",
+    }
     assert calls == [
-        ("GET", "/sessions/ses123/app/", {"x-vibe-show-base": "/show/ses123/"}, None),
-        ("GET", "/sessions/ses123/app/src/main.tsx", {"x-vibe-show-base": "/show/ses123/"}, None),
-        ("GET", "/sessions/ses123/app/src/App.tsx", {"x-vibe-show-base": "/show/ses123/"}, None),
+        ("GET", "/sessions/ses123/app/", private_headers, None),
+        ("GET", "/sessions/ses123/app/src/main.tsx", private_headers, None),
+        ("GET", "/sessions/ses123/app/src/App.tsx", private_headers, None),
         (
             "GET",
             "/sessions/ses123/app/@fs/runtime/packages/ui/dist/button.js",
-            {"x-vibe-show-base": "/show/ses123/"},
+            private_headers,
             None,
         ),
         (
             "GET",
             "/sessions/ses123/app/@fs/runtime/vite-cache/deps/react_jsx-runtime.js?v=abc",
-            {"x-vibe-show-base": "/show/ses123/"},
+            private_headers,
             None,
         ),
     ]
@@ -4734,7 +4856,7 @@ def test_show_runtime_manager_prewarm_reports_nested_module_failures(monkeypatch
         ),
     }
 
-    async def fake_request(self, method, path, *, headers=None, body=None):
+    async def fake_request(self, method, path, *, envelope, headers=None, body=None):
         import httpx
 
         status, content, headers_out = responses[path]
@@ -4747,7 +4869,13 @@ def test_show_runtime_manager_prewarm_reports_nested_module_failures(monkeypatch
     )
     monkeypatch.setattr(ShowRuntimeManager, "request", fake_request)
 
-    result = asyncio.run(manager.prewarm_session("ses123", base_path="/p/share123/"))
+    result = asyncio.run(
+        manager.prewarm_session(
+            "ses123",
+            context=ShowRuntimeContext.SHARED,
+            base_path="/p/share123/",
+        )
+    )
 
     assert result.available is False
     assert result.reason == "session_prewarm_module_failed:504:/sessions/ses123/app/src/App.tsx"
@@ -5819,8 +5947,8 @@ def test_startup_dependency_reconcile_prewarms_runtime_after_prepare(monkeypatch
         called["runtime"] += 1
         return SimpleNamespace(available=True, reason=None)
 
-    async def fake_session_prewarm(session_id, *, base_path=None):
-        called["sessions"].append((session_id, base_path))
+    async def fake_session_prewarm(session_id, *, context, base_path=None):
+        called["sessions"].append((session_id, context, base_path))
         return SimpleNamespace(available=True, reason=None)
 
     monkeypatch.setattr("vibe.api.reconcile_startup_dependencies", fake_reconcile)
@@ -5830,8 +5958,8 @@ def test_startup_dependency_reconcile_prewarms_runtime_after_prepare(monkeypatch
             "ok": True,
             "limit": 2,
             "pages": [
-                {"session_id": "ses_private", "base_path": None},
-                {"session_id": "ses_public", "base_path": "/p/share123/"},
+                {"session_id": "ses_private", "context": "private", "base_path": None},
+                {"session_id": "ses_public", "context": "shared", "base_path": "/p/share123/"},
             ],
         },
     )
@@ -5843,7 +5971,10 @@ def test_startup_dependency_reconcile_prewarms_runtime_after_prepare(monkeypatch
     assert called == {
         "reconcile": 1,
         "runtime": 1,
-        "sessions": [("ses_private", None), ("ses_public", "/p/share123/")],
+        "sessions": [
+            ("ses_private", ShowRuntimeContext.PRIVATE, None),
+            ("ses_public", ShowRuntimeContext.SHARED, "/p/share123/"),
+        ],
     }
 
 
@@ -6163,6 +6294,14 @@ def test_private_show_page_hmr_websocket_accepts_setup_host_local_peer(monkeypat
     finally:
         set_show_runtime_manager_for_tests(None)
 
+    assert manager.websocket_paths == ["/show/ses123/__vite_hmr"]
+    assert manager.websocket_headers == [
+        {
+            "X-Avibe-Show-Protocol": "1",
+            "X-Avibe-Show-Context": "private",
+        }
+    ]
+
 
 def test_public_show_page_hmr_websocket_accepts_local_peer(monkeypatch, tmp_path):
     # Amendment §2.3: the HMR socket serves public pages too, so a public page's
@@ -6193,6 +6332,7 @@ def test_public_show_page_hmr_websocket_accepts_local_peer(monkeypatch, tmp_path
         set_show_runtime_manager_for_tests(None)
 
     assert manager.websocket_paths == ["/show/ses123/__vite_hmr"]
+    assert manager.websocket_headers[0]["X-Avibe-Show-Context"] == "private"
 
 
 def test_private_show_page_hmr_websocket_accepts_trusted_public_origin(monkeypatch, tmp_path):
@@ -6225,6 +6365,7 @@ def test_private_show_page_hmr_websocket_accepts_trusted_public_origin(monkeypat
         set_show_runtime_manager_for_tests(None)
 
     assert manager.websocket_paths == ["/show/ses123/__vite_hmr"]
+    assert manager.websocket_headers[0]["X-Avibe-Show-Context"] == "private"
 
 
 def test_private_show_page_hmr_websocket_rejects_trusted_public_origin_mismatch(monkeypatch, tmp_path):
@@ -6273,6 +6414,12 @@ def test_public_show_page_hmr_websocket_uses_share_path(monkeypatch, tmp_path):
         set_show_runtime_manager_for_tests(None)
 
     assert manager.websocket_paths == [f"/p/{share_id}/__vite_hmr?token=test-token"]
+    assert manager.websocket_headers == [
+        {
+            "X-Avibe-Show-Protocol": "1",
+            "X-Avibe-Show-Context": "shared",
+        }
+    ]
 
 
 def test_public_show_page_hmr_websocket_requires_public_page(monkeypatch, tmp_path):
@@ -6359,6 +6506,8 @@ def test_public_show_page_uses_runtime_when_available(monkeypatch, tmp_path):
     assert manager.calls[0][0] == "GET"
     assert manager.calls[0][1] == "/sessions/ses123/app/"
     assert manager.calls[0][2]["x-vibe-show-base"] == f"/p/{share_id}/"
+    assert manager.calls[0][2]["X-Avibe-Show-Protocol"] == "1"
+    assert manager.calls[0][2]["X-Avibe-Show-Context"] == "shared"
 
 
 def test_public_show_page_materializes_workspace_before_runtime_proxy(monkeypatch, tmp_path):
@@ -6435,6 +6584,8 @@ def test_public_show_page_proxies_runtime_api_methods(monkeypatch, tmp_path):
     assert manager.calls[0][1] == "/sessions/ses123/app/api/health"
     assert manager.calls[0][2]["content-type"] == "application/json"
     assert manager.calls[0][2]["x-vibe-show-base"] == f"/p/{share_id}/"
+    assert manager.calls[0][2]["X-Avibe-Show-Protocol"] == "1"
+    assert manager.calls[0][2]["X-Avibe-Show-Context"] == "shared"
     assert "cookie" not in manager.calls[0][2]
     assert manager.calls[0][3] == b'{"ping":true}'
 
@@ -6691,6 +6842,10 @@ def test_show_runtime_vendor_asset_proxy_is_immutable(monkeypatch, tmp_path):
         response = app.test_client().get(
             "/_show-runtime/vendor/abc123/react.js",
             base_url="http://127.0.0.1:5123",
+            headers={
+                "X-Avibe-Show-Protocol": "999",
+                "X-Avibe-Show-Context": "private",
+            },
         )
     finally:
         set_show_runtime_manager_for_tests(None)
@@ -6700,6 +6855,8 @@ def test_show_runtime_vendor_asset_proxy_is_immutable(monkeypatch, tmp_path):
     # The vendor prefix is forwarded verbatim, never under a per-session base path.
     assert manager.calls[-1][0] == "GET"
     assert manager.calls[-1][1] == "/_show-runtime/vendor/abc123/react.js"
+    assert "X-Avibe-Show-Protocol" not in manager.calls[-1][2]
+    assert "X-Avibe-Show-Context" not in manager.calls[-1][2]
     assert response.headers["cache-control"] == "public, max-age=31536000, immutable"
     assert response.headers["content-type"] == "text/javascript; charset=utf-8"
     assert "set-cookie" not in response.headers

--- a/vibe/api.py
+++ b/vibe/api.py
@@ -8541,6 +8541,7 @@ def startup_show_page_prewarm_targets(limit: int | None = None) -> dict:
         return {"ok": True, "limit": resolved_limit, "pages": []}
 
     from core.show_pages import ShowPageStore, VISIBILITY_PRIVATE, VISIBILITY_PUBLIC
+    from core.show_runtime import ShowRuntimeContext
     from storage.pagination import PageRequest
 
     store = ShowPageStore()
@@ -8556,12 +8557,14 @@ def startup_show_page_prewarm_targets(limit: int | None = None) -> dict:
     pages = []
     for page in candidates[:resolved_limit]:
         base_path = f"/p/{page.share_id}/" if page.visibility == VISIBILITY_PUBLIC and page.share_id else None
+        context = ShowRuntimeContext.SHARED if base_path else ShowRuntimeContext.PRIVATE
         pages.append(
             {
                 "session_id": page.session_id,
                 "visibility": page.visibility,
                 "updated_at": page.updated_at,
                 "base_path": base_path,
+                "context": context.value,
             }
         )
     return {"ok": True, "limit": resolved_limit, "pages": pages}

--- a/vibe/cli.py
+++ b/vibe/cli.py
@@ -12780,13 +12780,17 @@ def cmd_show_list(args):
 
 def cmd_show_path(args):
     from core.show_pages import ensure_show_page_dir
+    from core.show_runtime import ShowRuntimeContext
 
     store = _load_show_page_store()
     try:
         session_id, session_default_notice = _resolve_show_session_id(args, help_command="vibe show path --help")
         page = store.ensure(session_id)
         page_dir = ensure_show_page_dir(session_id)
-        _prewarm_show_page_session_best_effort(session_id)
+        _prewarm_show_page_session_best_effort(
+            session_id,
+            context=ShowRuntimeContext.PRIVATE.value,
+        )
         payload = _show_page_result(
             page,
             message=f"Show Page workspace is ready at {page_dir}.",
@@ -12805,8 +12809,13 @@ def cmd_show_path(args):
         store.close()
 
 
-def _prewarm_show_page_session_best_effort(session_id: str, *, base_path: str | None = None) -> None:
-    if _request_show_page_prewarm_best_effort(session_id, base_path=base_path) is None:
+def _prewarm_show_page_session_best_effort(
+    session_id: str,
+    *,
+    context: str,
+    base_path: str | None = None,
+) -> None:
+    if _request_show_page_prewarm_best_effort(session_id, context=context, base_path=base_path) is None:
         logger.debug("Show Page session prewarm skipped for %s", session_id)
 
 
@@ -12850,6 +12859,7 @@ def cmd_show_status(args):
 
 def cmd_show_update(args):
     from core.show_pages import public_url, show_page_payload
+    from core.show_runtime import ShowRuntimeContext
 
     store = _load_show_page_store()
     try:
@@ -12901,7 +12911,12 @@ def cmd_show_update(args):
 
         if updated.visibility != "offline":
             base_path = f"/p/{updated.share_id}/" if updated.visibility == "public" and updated.share_id else None
-            _prewarm_show_page_session_best_effort(updated.session_id, base_path=base_path)
+            context = ShowRuntimeContext.SHARED if base_path else ShowRuntimeContext.PRIVATE
+            _prewarm_show_page_session_best_effort(
+                updated.session_id,
+                context=context.value,
+                base_path=base_path,
+            )
         payload = _show_page_result(updated, message=message, extra=extra)
         if getattr(args, "json", False):
             _print_json(payload)
@@ -13020,13 +13035,20 @@ def _show_prewarm_target_matches_ui_pid(url: str, expected_ui_pid: int | None) -
     return actual_ui_pid == expected_ui_pid
 
 
-def _request_show_page_prewarm_best_effort(session_id: str, *, base_path: str | None = None) -> dict | None:
+def _request_show_page_prewarm_best_effort(
+    session_id: str,
+    *,
+    context: str,
+    base_path: str | None = None,
+) -> dict | None:
     from core.show_pages import SHOW_CLI_EVENT_TOKEN_HEADER, show_cli_event_token
 
     targets = _local_show_prewarm_targets(session_id)
     if not targets:
         return None
-    payload = {"base_path": base_path} if base_path else {}
+    payload = {"context": context}
+    if base_path:
+        payload["base_path"] = base_path
     body = json.dumps(payload).encode("utf-8")
     headers = {
         "Content-Type": "application/json",

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -111,6 +111,19 @@ _SHOW_RUNTIME_REQUEST_HEADER_ALLOWLIST = {
     "user-agent",
     SHOW_EVENT_WRITE_TOKEN_HEADER.lower(),
 }
+
+
+def _show_runtime_forwarded_headers(headers: Mapping[str, str]) -> dict[str, str]:
+    from core.show_runtime import SHOW_RUNTIME_CONTEXT_HEADER, SHOW_RUNTIME_PROTOCOL_HEADER
+
+    blocked = {SHOW_RUNTIME_PROTOCOL_HEADER.lower(), SHOW_RUNTIME_CONTEXT_HEADER.lower()}
+    return {
+        key: value
+        for key, value in headers.items()
+        if key.lower() in _SHOW_RUNTIME_REQUEST_HEADER_ALLOWLIST and key.lower() not in blocked
+    }
+
+
 _SHOW_RUNTIME_RESPONSE_HEADER_ALLOWLIST = {
     "accept-ranges",
     "cache-control",
@@ -4035,16 +4048,31 @@ async def _proxy_show_runtime_websocket(
     *,
     external_prefix: str | None = None,
 ) -> None:
-    from core.show_runtime import get_show_runtime_manager
+    from core.show_runtime import (
+        ShowRuntimeContext,
+        ShowRuntimeProtocolEnvelope,
+        get_show_runtime_manager,
+    )
 
     if external_prefix is None:
         external_prefix = f"/show/{quote(session_id, safe='')}"
+        context = ShowRuntimeContext.PRIVATE
+    else:
+        context = ShowRuntimeContext.SHARED
     runtime_path = f"{external_prefix.rstrip('/')}/__vite_hmr"
     if websocket.url.query:
         runtime_path = f"{runtime_path}?{websocket.url.query}"
-    upstream_url = await get_show_runtime_manager().websocket_url(runtime_path)
+    upstream = await get_show_runtime_manager().websocket_target(
+        runtime_path,
+        envelope=ShowRuntimeProtocolEnvelope(context),
+    )
     async with ClientSession() as session:
-        async with session.ws_connect(upstream_url, protocols=["vite-hmr"], autoping=True) as upstream:
+        async with session.ws_connect(
+            upstream.url,
+            headers=upstream.headers,
+            protocols=["vite-hmr"],
+            autoping=True,
+        ) as upstream:
             async def client_to_upstream():
                 try:
                     while True:
@@ -13989,9 +14017,14 @@ async def show_session_prewarm(session_id: str):
     base_path = payload.get("base_path")
     if base_path is not None and not isinstance(base_path, str):
         return jsonify({"ok": False, "code": "invalid_base_path"}), 400
-    from core.show_runtime import prewarm_show_page_session
+    from core.show_runtime import ShowRuntimeContext, prewarm_show_page_session
 
-    result = await prewarm_show_page_session(session_id, base_path=base_path)
+    try:
+        context = ShowRuntimeContext(payload.get("context"))
+    except (TypeError, ValueError):
+        return jsonify({"ok": False, "code": "invalid_show_runtime_context"}), 400
+
+    result = await prewarm_show_page_session(session_id, context=context, base_path=base_path)
     status_code = 200 if result.available else 202
     return jsonify({"ok": result.available, "reason": result.reason, "base_url": result.base_url}), status_code
 
@@ -14012,13 +14045,9 @@ async def show_runtime_vendor_asset(vendor_path: str):
         runtime_path = f"{runtime_path}?{request._request.url.query}"
     from core.show_runtime import get_show_runtime_manager
 
-    forwarded_headers = {
-        key: value
-        for key, value in request._request.headers.items()
-        if key.lower() in _SHOW_RUNTIME_REQUEST_HEADER_ALLOWLIST
-    }
+    forwarded_headers = _show_runtime_forwarded_headers(request._request.headers)
     try:
-        proxied = await get_show_runtime_manager().request(
+        proxied = await get_show_runtime_manager().request_global(
             request.method,
             runtime_path,
             headers=forwarded_headers,
@@ -14144,7 +14173,11 @@ async def _show_page_runtime_response(
     show_authenticated: bool = False,
     show_config_session_id: str | None = None,
 ):
-    from core.show_runtime import get_show_runtime_manager
+    from core.show_runtime import (
+        ShowRuntimeContext,
+        ShowRuntimeProtocolEnvelope,
+        get_show_runtime_manager,
+    )
 
     session_part = quote(session_id, safe="")
 
@@ -14158,19 +14191,18 @@ async def _show_page_runtime_response(
         return path
 
     runtime_path = runtime_app_path(asset_path)
-    forwarded_headers = {
-        key: value
-        for key, value in starlette_request.headers.items()
-        if key.lower() in _SHOW_RUNTIME_REQUEST_HEADER_ALLOWLIST
-    }
+    forwarded_headers = _show_runtime_forwarded_headers(starlette_request.headers)
     if external_prefix:
         forwarded_headers["x-vibe-show-base"] = f"{external_prefix.rstrip('/')}/"
+    context = ShowRuntimeContext.SHARED if external_prefix else ShowRuntimeContext.PRIVATE
+    envelope = ShowRuntimeProtocolEnvelope(context)
     body = await starlette_request.body()
     request_started = time.monotonic()
     manager = get_show_runtime_manager()
     proxied = await manager.request(
         starlette_request.method,
         runtime_path,
+        envelope=envelope,
         headers=forwarded_headers,
         body=body or None,
     )
@@ -14183,6 +14215,7 @@ async def _show_page_runtime_response(
         proxied = await manager.request(
             starlette_request.method,
             runtime_path,
+            envelope=envelope,
             headers=forwarded_headers,
             body=body or None,
         )
@@ -15098,7 +15131,11 @@ async def _reconcile_startup_dependencies_task() -> None:
         result = await asyncio.to_thread(api.reconcile_startup_dependencies)
         show_runtime = result.get("show_runtime") if isinstance(result.get("show_runtime"), dict) else {}
         if show_runtime.get("ok"):
-            from core.show_runtime import prewarm_show_page_session, prewarm_show_runtime
+            from core.show_runtime import (
+                ShowRuntimeContext,
+                prewarm_show_page_session,
+                prewarm_show_runtime,
+            )
 
             prewarm = await prewarm_show_runtime()
             show_runtime["prewarmed"] = prewarm.available
@@ -15112,8 +15149,20 @@ async def _reconcile_startup_dependencies_task() -> None:
                     session_id = str(page.get("session_id") or "")
                     if not session_id:
                         continue
+                    try:
+                        context = ShowRuntimeContext(page.get("context"))
+                    except (TypeError, ValueError):
+                        page_results.append(
+                            {
+                                "session_id": session_id,
+                                "ok": False,
+                                "reason": "invalid_show_runtime_context",
+                            }
+                        )
+                        continue
                     session_prewarm = await prewarm_show_page_session(
                         session_id,
+                        context=context,
                         base_path=page.get("base_path") if isinstance(page.get("base_path"), str) else None,
                     )
                     page_results.append(


### PR DESCRIPTION
## Capability

Adds the Avibe-side protocol 1 foundation for explicit private/shared Show Runtime contexts.

- centralizes protocol and context headers in one typed envelope
- negotiates `show-context-key-v1` once per Runtime identity with supported, definitive unsupported, and retryable transient-unknown outcomes
- clears capability and retry state when the Runtime process, base URL, or manager lifetime changes
- carries an explicit context through entry/module/API requests, SPA fallback, HMR setup, startup reconciliation, and CLI prewarm
- strips browser-supplied protocol/context headers at the Avibe proxy boundary

## Scenario Evidence

- `SHOW-LIVE-005`: private and shared Avibe request boundaries select distinct typed contexts, including a non-ASCII module path.
- `SHOW-LIVE-014`: legacy 404 and well-formed responses without the feature cache as unsupported; no keyed-isolation claim is made.
- `SHOW-LIVE-015`: transient capability failures keep shared requests live, respect bounded retry deadlines, and recover without restart.
- `SHOW-LIVE-017`: startup and CLI prewarm carry explicit contexts; missing context fails before Runtime access.
- `SHOW-LIVE-035`: public editor behavior remains on the existing shared representation in this foundation; redirect behavior is unchanged.
- `SHOW-LIVE-030`: the old-client/new-Runtime headerless contract remains owned by the external Runtime and is intentionally not claimed as Avibe-client evidence in this PR.

## Evidence Layers

- Unit: protocol envelope validation, capability classification/cache invalidation, retry behavior, and maximum backoff.
- Contract: 476 focused Show Runtime, Show Page, CLI, and startup dependency tests pass.
- Scenario: the applicable client-side invariants above are named in focused tests.
- Static: Ruff passes for every changed Python file; `git diff --check` passes.
- Residual manual/Incus: simultaneous private/shared graph isolation, legacy singleton behavior against a bundled Runtime, and browser HMR stability remain cross-repository regression checks after the Runtime implementation lands.

## Dependencies

No stacked Avibe PR dependency. Negotiated keyed isolation remains gated on the external Runtime advertising `show-context-key-v1`.

## Known By Design

- This PR does not change Show access settings, audience persistence, authorization, or redirect behavior.
- It does not add a public viewer HMR socket. Existing legacy routes remain unchanged until the later delivery steps.
- A definitive unsupported Runtime preserves the released singleton compatibility behavior; Avibe does not treat successful app traffic as keyed-isolation evidence.
- Capability-independent global vendor assets remain headerless and reject browser-supplied protocol/context headers.
