### PR TITLE
fix(remote-access): stop local cloud-token requests from triggering the remote login redirect

### DIFF
--- a/tests/test_remote_access_vibe_cloud.py
+++ b/tests/test_remote_access_vibe_cloud.py
@@ -2798,6 +2798,80 @@ def test_cloud_token_for_request_requires_editor_role(monkeypatch) -> None:
     assert called is False
 
 
+def test_cloud_token_endpoint_local_origin_without_session_degrades_to_unavailable(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    """Issue #1491: a local-origin request has no avibe.bot session cookie by
+    design, so the endpoint must return the documented 503 ``cloud_unavailable``
+    fallback instead of the login-required signal that triggers the frontend's
+    full-page redirect to ``/auth/login`` (which the local host rejects)."""
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    config = _cloud_broker_config()
+    config.save()
+
+    response = ui_server.app.test_client().get(
+        "/api/cloud/token",
+        base_url="http://127.0.0.1:5123",
+    )
+
+    assert response.status_code == 503
+    assert response.get_json() == {"error": "cloud_unavailable"}
+
+
+def test_cloud_token_endpoint_remote_origin_without_session_requires_login(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    """On the genuine remote-access host, a missing session still means the
+    browser must log in, so the recovery signal is preserved there."""
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    config = _cloud_broker_config()
+    config.save()
+
+    response = ui_server.app.test_client().get(
+        "/api/cloud/token",
+        base_url="https://alex.avibe.bot",
+    )
+
+    assert response.status_code == 401
+    assert response.get_json() == {"ok": False, "error": "remote_access_login_required"}
+
+
+def test_cloud_token_endpoint_remote_origin_with_session_mints_token(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    """An authenticated remote request still reaches the mint path after the
+    local-origin degrade branch is added in front of it."""
+    monkeypatch.setenv("AVIBE_HOME", str(tmp_path))
+    config = _cloud_broker_config()
+    config.save()
+    monkeypatch.setattr(remote_access, "current_authorization_revision", lambda *a, **k: 1)
+    monkeypatch.setattr(
+        remote_access,
+        "_json_request",
+        lambda *a, **k: {"access_token": "ct_abc", "token_type": "Bearer", "expires_in": 43200},
+    )
+
+    client = ui_server.app.test_client()
+    client.set_cookie(
+        remote_access.SESSION_COOKIE_NAME,
+        _session_cookie(config),
+        domain="alex.avibe.bot",
+    )
+    response = client.get(
+        "/api/cloud/token",
+        base_url="https://alex.avibe.bot",
+    )
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["token"] == "ct_abc"
+    assert payload["scope"] == "asr"
+    assert response.headers["Cache-Control"] == "no-store, private"
+
+
 def test_ra_tq_029_connector_environment_applies_ip_and_interface_controls() -> None:
     config = _config()
     cloud = config.remote_access.vibe_cloud

--- a/vibe/ui_server.py
+++ b/vibe/ui_server.py
@@ -7386,6 +7386,15 @@ def api_cloud_token():
     cookie_value = request.cookies.get(remote_access.SESSION_COOKIE_NAME)
     identity = remote_access.parse_session_identity(config, cookie_value)
     if identity is None:
+        # Local-origin requests never carry the avibe.bot session cookie, so a
+        # missing identity is the expected state there, not an expired remote
+        # session. Emitting the login-required signal would trip the frontend's
+        # global auth-recovery redirect to ``/auth/login``, which the local
+        # host rejects with ``remote_access_not_enabled`` (issue #1491).
+        # Degrade to the documented ``cloud_unavailable`` fallback instead;
+        # only genuine remote-access requests get the login signal.
+        if not _is_remote_access_request(config):
+            return jsonify({"error": "cloud_unavailable"}), 503
         return jsonify({"ok": False, "error": "remote_access_login_required"}), 401
     resolution = remote_access.resolve_current_authorization(config, identity)
     if resolution.state == "revoked":


### PR DESCRIPTION
## Changed capability

Local Web UI no longer dead-ends on `{"error":"remote_access_not_enabled"}` when opening a conversation with Avibe Cloud paired and ASR available (fixes #1491).

`GET /api/cloud/token` previously returned `401 remote_access_login_required` for any request without an avibe.bot session cookie. Local-origin requests never carry that cookie by design, so the frontend's global auth-recovery hook (`ui/src/lib/apiFetch.ts`) performed a full-page redirect to `/auth/login`, which the local host rejects with `400 remote_access_not_enabled`.

The `identity is None` branch of `api_cloud_token` (`vibe/ui_server.py`) now gates the login-required signal on `_is_remote_access_request`:

- local-origin request, no session → `503 cloud_unavailable` (the docstring's documented fallback; the composer silently degrades to the local relay)
- remote-access request, no session → `401 remote_access_login_required` (unchanged; the browser genuinely needs to log in)
- remote-access request, valid session → token mint path (unchanged)

No frontend change needed: `apiFetch` treats 503 `cloud_unavailable` as a quiet fallback, not a recovery trigger.

## Scenario IDs

No existing scenario catalog covers the local-origin cloud-token fallback flow. Closest catalogs (`tunnel_quality`, `auth_setup`) target tunnel transport quality and IM-driven backend auth respectively; this fix is covered at the contract layer below.

## Evidence layers

- **Unit/contract**: three new endpoint tests in `tests/test_remote_access_vibe_cloud.py` covering the invariant across all three request shapes above (local no-session → 503, remote no-session → 401, remote authenticated → 200 mint)
- **Scenario**: n/a (no matching catalog; see above)
- **Residual manual checks**: on a locally-accessed instance with Avibe Cloud paired, open a conversation at `http://127.0.0.1:5123` and verify no redirect to `/auth/login`; verify the mic button and remote origin behavior are unchanged at `https://<slug>.avibe.bot`

## Validation

- `pytest tests/test_remote_access_vibe_cloud.py -k cloud_token`: 12 passed
- full `tests/test_remote_access_vibe_cloud.py`: 140 passed; the 2 failing `test_validated_backend_request_*` pinned-IP DNS tests also fail on master in this environment (pre-existing, unrelated)
- `ruff check` on changed files: clean

## Dependencies

None.
